### PR TITLE
@broskoski: Orchestrate Google CSE results

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -8,3 +8,6 @@ GEMINI_ENDPOINT=https://gemini.cloudfront.test
 REDIS_URL=redis://127.0.0.1:6379
 EMBEDLY_ENDPOINT=https://i.embed.ly.test/1/display
 EMBEDLY_KEY=xxx_embedly_key_xxx
+GOOGLE_CSE_API_BASE=https://www.googleapis.test/customsearch/v1
+GOOGLE_CSE_CX=xxx_google_cse_cx_xxx
+GOOGLE_CSE_KEY=xxx_google_cse_key_xxx

--- a/lib/apis/google_cse.js
+++ b/lib/apis/google_cse.js
@@ -1,0 +1,4 @@
+import fetch from './fetch';
+const { GOOGLE_CSE_API_BASE } = process.env;
+
+export default (path) => fetch(`${GOOGLE_CSE_API_BASE}/${path}`);

--- a/lib/loaders/google_cse.js
+++ b/lib/loaders/google_cse.js
@@ -1,0 +1,19 @@
+import _ from 'lodash';
+import qs from 'qs';
+import googleCSE from '../apis/google_cse';
+import httpLoader from './http';
+const {
+  GOOGLE_CSE_KEY,
+  GOOGLE_CSE_CX
+} = process.env;
+
+export let googleCSELoader = httpLoader(googleCSE);
+
+export default (options = {}) => {
+  let queryString = qs.stringify(_.assign(options, {
+    key: GOOGLE_CSE_KEY,
+    cx: GOOGLE_CSE_CX
+  }));
+
+  return googleCSELoader.load(`?${queryString}`);
+};

--- a/lib/loaders/index.js
+++ b/lib/loaders/index.js
@@ -1,14 +1,17 @@
 import { gravityLoader } from './gravity';
 import { positronLoader } from './positron';
+import { googleCSELoader } from './google_cse';
 
 export default {
   loaders: {
     gravity: gravityLoader,
-    positron: positronLoader
+    positron: positronLoader,
+    googleCSELoader: googleCSELoader
   },
 
   clearAll: () => {
     gravityLoader.clearAll();
     positronLoader.clearAll();
+    googleCSELoader.clearAll();
   }
 };

--- a/lib/routing.js
+++ b/lib/routing.js
@@ -1,0 +1,24 @@
+import _ from 'lodash';
+
+export default (type, id) => {
+  switch (type) {
+    case 'PartnerShow':
+      return {
+        api: `show/${id}`,
+        href: `/show/${id}`
+      };
+
+    case 'Profile':
+      return {
+        api: `profile/${id}`,
+        href: `/${id}`
+      };
+
+    default:
+      let namespace = _.snakeCase(type);
+      return {
+        api: `${namespace}/${id}`,
+        href: `/${namespace}/${id}`
+      }
+  };
+};

--- a/schema/day_schedule.js
+++ b/schema/day_schedule.js
@@ -1,4 +1,4 @@
-import { 
+import {
   GraphQLInt,
   GraphQLString,
   GraphQLObjectType

--- a/schema/index.js
+++ b/schema/index.js
@@ -12,6 +12,7 @@ import PartnerCategories from './partner_categories';
 import PartnerShow from './partner_show';
 import PartnerShows from './partner_shows';
 import Sale from './sale';
+import Search from './search';
 import {
   GraphQLSchema,
   GraphQLObjectType
@@ -34,7 +35,8 @@ let schema = new GraphQLSchema({
       partner_categories: PartnerCategories,
       partner_show: PartnerShow,
       partner_shows: PartnerShows,
-      sale: Sale
+      sale: Sale,
+      search: Search
     }
   })
 });

--- a/schema/search/index.js
+++ b/schema/search/index.js
@@ -1,0 +1,39 @@
+import googleCSE from '../../lib/loaders/google_cse';
+import cached from '../fields/cached';
+import SearchResult from './search_result';
+import {
+  GraphQLString,
+  GraphQLObjectType,
+  GraphQLNonNull,
+  GraphQLList,
+  GraphQLInt
+} from 'graphql';
+
+let SearchType = new GraphQLObjectType({
+  name: 'Search',
+  fields: () => ({
+    cached: cached,
+    total: {
+      type: GraphQLInt,
+      resolve: (response) => response.searchInformation.totalResults
+    },
+    results: {
+      type: new GraphQLList(SearchResult.type),
+      resolve: ({ items }) => items
+    }
+  })
+});
+
+let Search = {
+  type: SearchType,
+  description: 'A Search',
+  args: {
+    term: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: 'Your search term'
+    }
+  },
+  resolve: (root, { term }) => googleCSE({ q: term })
+};
+
+export default Search;

--- a/schema/search/search_entity.js
+++ b/schema/search/search_entity.js
@@ -1,0 +1,42 @@
+import _ from 'lodash';
+import Artist from '../artist';
+import Artwork from '../artwork';
+import Profile from '../profile';
+import PartnerShow from '../partner_show';
+import {
+  GraphQLObjectType,
+  GraphQLUnionType
+} from 'graphql';
+
+export let ArtistSearchEntityType = _.create(Artist.type, {
+  name: 'ArtistSearchEntity',
+  isTypeOf: ({ type }) => type === 'Artist',
+});
+
+export let ArtworkSearchEntityType = _.create(Artwork.type, {
+  name: 'ArtworkSearchEntity',
+  isTypeOf: ({ type }) => type === 'Artwork',
+});
+
+
+export let ProfileSearchEntityType = _.create(Profile.type, {
+  name: 'ProfileSearchEntity',
+  isTypeOf: ({ type }) => type === 'Profile'
+});
+
+export let PartnerShowSearchEntityType = _.create(PartnerShow.type, {
+  name: 'PartnerShowSearchEntity',
+  isTypeOf: ({ type }) => type === 'PartnerShow'
+});
+
+export let SearchEntityType = new GraphQLUnionType({
+  name: 'SearchEntity',
+  types: [
+    ArtistSearchEntityType,
+    ArtworkSearchEntityType,
+    ProfileSearchEntityType,
+    PartnerShowSearchEntityType
+  ]
+});
+
+export default SearchEntityType;

--- a/schema/search/search_result.js
+++ b/schema/search/search_result.js
@@ -1,0 +1,88 @@
+import _ from 'lodash';
+import url from 'url';
+import routing from '../../lib/routing';
+import gravity from '../../lib/loaders/gravity';
+import Image from '../image';
+import SearchEntityType from './search_entity';
+import {
+  GraphQLString,
+  GraphQLObjectType,
+} from 'graphql';
+
+let classify = _.flow(_.camelCase, _.capitalize);
+
+export let parseOgType = ({ pagemap }) => {
+  let ogType = _.get(pagemap, ['metatags', '0', 'og:type'], '');
+  let cleanType = ogType.split(':')[1] || ogType;
+  if (cleanType === 'exhibition') {
+    return 'PartnerShow';
+  } else {
+    return classify(cleanType);
+  }
+};
+
+export let parseId = ({ link }) => {
+  let urlComponents = _.rest(url.parse(link).path.split('/'));
+  let supportedRouteTypes = ['artist', 'artwork', 'show'];
+
+  let first = _.first(urlComponents);
+  let last = _.last(urlComponents);
+
+  return _.some(supportedRouteTypes.map(type => first === type)) ? last : first;
+}
+
+let SearchResultType = new GraphQLObjectType({
+  name: 'SearchResult',
+  fields: () => ({
+    id: {
+      type: GraphQLString,
+      resolve: parseId
+    },
+    title: {
+      type: GraphQLString
+    },
+    href: {
+      type: GraphQLString,
+      resolve: ({ link }) => url.parse(link).path
+    },
+    snippet: {
+      type: GraphQLString
+    },
+    image: {
+      type: Image.type,
+      resolve: ({ pagemap }) => {
+        // Should attempt to get the entity's image rather than
+        // using Google's, as it is often inaccurate.
+        let image = _.first(_.get(pagemap, 'cse_image'));
+        return {
+          image_url: image.src,
+          original_height: image.height,
+          original_width: image.width
+        };
+      }
+    },
+    type: {
+      type: GraphQLString,
+      resolve: parseOgType
+    },
+    entity: {
+      type: SearchEntityType,
+      resolve: (searchResult) => {
+        let id = parseId(searchResult);
+        let type = parseOgType(searchResult);
+        return gravity(routing(type, id).api)
+          .then(response => {
+            response.type = type;
+            return response;
+          });
+      }
+    }
+  })
+});
+
+let SearchResult = {
+  type: SearchResultType,
+  description: 'A Search Result'
+};
+
+export default SearchResult;


### PR DESCRIPTION
Re: https://github.com/artsy/metaphysics/issues/13

Trying this made me like Google CSE even less.

Part of the main problem here is that there's not a fantastic way to get a canonical entity ID and type given a URL. So there's a lot of guess work involving parsing the URL and parsing whatever poorly specified meta tags/open graph tags we have around. It's very, very gross.

A query might look like:

```graphql
query search($term: String!) {
  search(term: $term) {
    results {
      id
      type
      title
      href
      entity {
        ... on ArtistSearchEntity {
          image {
            ...CroppedThumbnail
          }
          artworks(size: 5) {
            images(size: 1) {
              ...CroppedThumbnail
            }
          }
        }
        ... on ArtworkSearchEntity {
          images(size: 1) {
            ...CroppedThumbnail
          }
        }
        ... on ProfileSearchEntity {
          image {
            ...CroppedThumbnail
          }
        }
        ... on PartnerShowSearchEntity {
          cover_image {
            ...CroppedThumbnail
          }
        }
      }
    }
  }
}

fragment CroppedThumbnail on Image {
  thumb: cropped(width: 200, height: 200) {
    url
  }
}
```

Operating under the assumption that you have a few different typed templates depending on the entities you want to support.

I'm dropping this for the time being, but may pick it back up or delete this entirely, depending.