### PR TITLE
@dzucconi => Allow images to just be url

### DIFF
--- a/schema/article.js
+++ b/schema/article.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import positron from '../lib/loaders/positron';
 import cached from './fields/cached';
 import AuthorType from './author';
+import Image from './image'
 import {
   GraphQLString,
   GraphQLObjectType,
@@ -24,6 +25,10 @@ let ArticleType = new GraphQLObjectType({
     author: {
       type: AuthorType,
       resolve: ({ author }) => author
+    },
+    thumbnail_image: {
+      type: Image.type,
+      resolve: ({ thumbnail_image }) => thumbnail_image
     }
   })
 });

--- a/schema/image/cropped.js
+++ b/schema/image/cropped.js
@@ -14,9 +14,16 @@ export let CroppedImageUrl = (image, options) => {
   });
 
   let { width, height } = options;
-  let src = image.image_url.replace(':version', options.version);
-  let url = proxy(src, 'crop', width, height);
+  let src = null;
 
+  if (image.image_url) {
+    src = image.image_url.replace(':version', options.version);
+  }
+  else {
+    src = image;
+  }
+
+  let url = proxy(src, 'crop', width, height);
   return {
     width,
     height,

--- a/test/schema/image/cropped.js
+++ b/test/schema/image/cropped.js
@@ -15,5 +15,14 @@ describe('Image', () => {
           url: 'https://i.embed.ly.test/1/display/crop?url=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg&width=500&height=500&key=xxx_embedly_key_xxx&quality=95'
         });
     });
+    it('works with just a url and resizes it to crop', () => {
+      image = 'https://xxx.cloudfront.net/xxx/cat.jpg'
+      CroppedImageUrl(image, { width: 500, height: 500 })
+        .should.eql({
+          width: 500,
+          height: 500,
+          url: 'https://i.embed.ly.test/1/display/crop?url=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Fcat.jpg&width=500&height=500&key=xxx_embedly_key_xxx&quality=95'
+        });
+    });
   });
 });


### PR DESCRIPTION
I feel eh about this.

Basically, positron thumbnail images are just a url to the original:

![screen shot 2015-12-03 at 3 46 09 pm](https://cloud.githubusercontent.com/assets/1457859/11573574/03f46c86-99d5-11e5-913c-f68b3faecbf3.png)

I still want to use the crop code which returns the proxied URL for this.
