### PR TITLE
@broskoski: image_url null

### DIFF
--- a/schema/image/resized.js
+++ b/schema/image/resized.js
@@ -8,6 +8,8 @@ import {
 } from 'graphql';
 
 export const resizedImageUrl = (image, options) => {
+  if (!image.image_url) return null;
+
   const opts = _.defaults(options, {
     version: 'large',
   });


### PR DESCRIPTION
So... sometimes Gravity gives us a response with an existy image object that's empty. (which makes  zero sense).

On a related note: `cropped` is completely broken because of this https://github.com/artsy/metaphysics/commit/f0f7ab481eb4769139355e1b0e59b1aeb81e6fa0 which wasn't a great idea.

(Mints URLs that look like: `https://i.embed.ly/1/display/crop?url%5Bid%5D=5633b4b772616964060000a2&url%5Bposition%5D=1&url%5Bcaption%5D=&url%5Bdefault%5D=false&url%5Baspect_ratio%5D=&url%5Boriginal_height%5D=&url%5Boriginal_width%5D=&url%5Bimage_url%5D=&url%5Bgemini_token%5D=WagRqg8ovVO3eaBvGBklWw&url%5Bcached%5D=1452802281684&width=300&height=300&key=a1f82558d8134f6cbebceb9e67d04980&quality=95`)

Can you help me resolve this all when you get back @mzikherman?

In the meantime this stops the bleeding on the front-end and lets the page actually render.