### PR TITLE
@dzucconi -> add more params to partners, nest them in categories

### DIFF
--- a/schema/input_fields/partner_categorytype.js
+++ b/schema/input_fields/partner_categorytype.js
@@ -1,0 +1,15 @@
+import { GraphQLEnumType } from 'graphql';
+
+export default {
+  type: new GraphQLEnumType({
+    name: 'PartnerCategorytype',
+    values: {
+      gallery: {
+        value: 'Gallery',
+      },
+      institution: {
+        value: 'institution',
+      },
+    },
+  }),
+};

--- a/schema/partner_categories.js
+++ b/schema/partner_categories.js
@@ -1,6 +1,7 @@
 import gravity from '../lib/loaders/gravity';
 import PartnerCategory from './partner_category';
 import {
+  GraphQLString,
   GraphQLList,
   GraphQLInt,
 } from 'graphql';
@@ -11,6 +12,9 @@ const PartnerCategories = {
   args: {
     size: {
       type: GraphQLInt,
+    },
+    category_type: {
+      type: GraphQLString,
     },
   },
   resolve: (root, options) => gravity('partner_categories', options),

--- a/schema/partner_category.js
+++ b/schema/partner_category.js
@@ -2,12 +2,11 @@ import _ from 'lodash';
 import gravity from '../lib/loaders/gravity';
 import cached from './fields/cached';
 import Partners from './partners';
+import PartnerCategorytype from './input_fields/partner_categorytype';
 import {
   GraphQLString,
   GraphQLObjectType,
   GraphQLNonNull,
-  GraphQLList,
-  GraphQLInt,
 } from 'graphql';
 
 const PartnerCategoryType = new GraphQLObjectType({
@@ -20,9 +19,7 @@ const PartnerCategoryType = new GraphQLObjectType({
     name: {
       type: GraphQLString,
     },
-    category_type: {
-      type: GraphQLString,
-    },
+    category_type: PartnerCategorytype,
     partners: {
       type: Partners.type,
       args: Partners.args,

--- a/schema/partner_category.js
+++ b/schema/partner_category.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import gravity from '../lib/loaders/gravity';
 import cached from './fields/cached';
-import Partner from './partner';
+import Partners from './partners';
 import {
   GraphQLString,
   GraphQLObjectType,
@@ -24,12 +24,8 @@ const PartnerCategoryType = new GraphQLObjectType({
       type: GraphQLString,
     },
     partners: {
-      type: new GraphQLList(Partner.type),
-      args: {
-        size: {
-          type: GraphQLInt,
-        },
-      },
+      type: Partners.type,
+      args: Partners.args,
       resolve: ({ id }, options) => gravity('partners', _.defaults(options, {
         partner_categories: [id],
       })),

--- a/schema/partners.js
+++ b/schema/partners.js
@@ -3,6 +3,7 @@ import Partner from './partner';
 import {
   GraphQLString,
   GraphQLList,
+  GraphQLBoolean,
 } from 'graphql';
 
 const Partners = {
@@ -12,6 +13,20 @@ const Partners = {
     near: {
       type: GraphQLString,
       description: 'Coordinates to find partners closest to',
+    },
+    eligible_for_primary_bucket: {
+      type: GraphQLBoolean,
+      description: 'Indicates tier 1/2 for gallery, 1 for institution',
+    },
+    eligible_for_secondary_bucket: {
+      type: GraphQLBoolean,
+      description: 'Indicates tierl 3/4 for gallery, 2 for institution',
+    },
+    has_full_profile: {
+      type: GraphQLBoolean,
+    },
+    default_profile_public: {
+      type: GraphQLBoolean,
     },
     partner_categories: {
       type: new GraphQLList(GraphQLString),

--- a/schema/partners.js
+++ b/schema/partners.js
@@ -20,7 +20,7 @@ const Partners = {
     },
     eligible_for_secondary_bucket: {
       type: GraphQLBoolean,
-      description: 'Indicates tierl 3/4 for gallery, 2 for institution',
+      description: 'Indicates tier 3/4 for gallery, 2 for institution',
     },
     has_full_profile: {
       type: GraphQLBoolean,


### PR DESCRIPTION
I'm putting the query I made here so that I don't forget it
```
{
  partner_categories(category_type:"Gallery"){
    id
    name
		primary: partners(eligible_for_primary_bucket: true, has_full_profile:true, default_profile_public:true) {
			... partner
    } 
    secondary: partners(eligible_for_secondary_bucket:true, has_full_profile:true, default_profile_public:true){
      ... partner
    }
  }
}

fragment partner on Partner  {
  id
  initials
  locations {
    city
  }
  profile {
    image {
      url(version:"featured")
    }
  }
}
```

Partners can take buckets and a bunch of other stuff. Also made it so that Partners nested in a Category can be filtered the same way.