### PR TITLE
@dzucconi: Support a prioritized list of image versions for `version` arg

### DIFF
--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -106,6 +106,9 @@ const ArtworkType = new GraphQLObjectType({
           return (partner.type === 'Gallery') ? 'Gallery' : 'Seller';
         },
       },
+      cultural_maker: {
+        type: GraphQLString,
+      },
       artists: {
         type: new GraphQLList(Artist.type),
         resolve: ({ artists }) => {

--- a/schema/image/cropped.js
+++ b/schema/image/cropped.js
@@ -6,11 +6,12 @@ import {
   GraphQLInt,
   GraphQLString,
   GraphQLNonNull,
+  GraphQLList,
 } from 'graphql';
 
 export const croppedImageUrl = (image, options) => {
   const opts = _.defaults(options, {
-    version: 'large',
+    version: ['large'],
   });
 
   const { width, height } = opts;
@@ -48,7 +49,7 @@ export default {
       type: new GraphQLNonNull(GraphQLInt),
     },
     version: {
-      type: GraphQLString,
+      type: new GraphQLList(GraphQLString),
     },
   },
   type: CroppedImageUrlType,

--- a/schema/image/normalize.js
+++ b/schema/image/normalize.js
@@ -9,20 +9,20 @@ import {
   last,
   isArray,
   isString,
-  has,
+  find,
+  curry,
 } from 'lodash';
 
 export const grab = flow(pick, values, first);
 
-export const setVersion = (image, version) => {
-  if (has(image, ['image_urls', version])) return image.image_urls[version];
-  if (!includes(image.image_url, ':version')) return image.image_url;
-
-  let size = version;
-  if (!includes(image.image_versions, version)) {
-    size = last(image.image_versions);
-  }
-  return image.image_url.replace(':version', size);
+export const setVersion = ({ image_url, image_urls, image_versions }, versions) => {
+  const version = (
+    find(versions, curry(includes)(image_versions)) ||
+    last(image_versions)
+  );
+  if (image_urls && version) return image_urls[version];
+  if (includes(image_url, ':version') && version) return image_url.replace(':version', version);
+  return image_url;
 };
 
 const normalizeImageUrl = (image) => {
@@ -40,9 +40,7 @@ const normalizeImageVersions = (image) => {
 };
 
 const normalizeBareUrls = (image) => {
-  if (isString(image)) {
-    return { image_url: image };
-  }
+  if (isString(image)) return { image_url: image };
   return image;
 };
 

--- a/schema/image/resized.js
+++ b/schema/image/resized.js
@@ -6,11 +6,12 @@ import {
   GraphQLFloat,
   GraphQLInt,
   GraphQLString,
+  GraphQLList,
 } from 'graphql';
 
 export const resizedImageUrl = (image, options) => {
   const opts = _.defaults(options, {
-    version: 'larger',
+    version: ['large'],
   });
 
   const desired = _.pick(opts, 'width', 'height');
@@ -64,7 +65,7 @@ export default {
       type: GraphQLInt,
     },
     version: {
-      type: GraphQLString,
+      type: new GraphQLList(GraphQLString),
     },
   },
   type: ResizedImageUrlType,

--- a/schema/image/versioned.js
+++ b/schema/image/versioned.js
@@ -1,5 +1,8 @@
 import { setVersion } from './normalize';
-import { GraphQLString } from 'graphql';
+import {
+  GraphQLList,
+  GraphQLString,
+} from 'graphql';
 
 export const versionedImageUrl = (image, { version }) => {
   return setVersion(image, version);
@@ -8,7 +11,7 @@ export const versionedImageUrl = (image, { version }) => {
 export default {
   args: {
     version: {
-      type: GraphQLString,
+      type: new GraphQLList(GraphQLString),
     },
   },
   type: GraphQLString,

--- a/test/schema/image/normalize.js
+++ b/test/schema/image/normalize.js
@@ -33,13 +33,23 @@ describe('setVersion', () => {
   };
 
   it('works with JPGs', () => {
-    setVersion(image, 'large')
+    setVersion(image, ['large'])
       .should.equal('https://xxx.cloudfront.net/xxx/large.jpg');
   });
 
   it('works with PNGs', () => {
-    setVersion(image, 'icon')
+    setVersion(image, ['icon'])
       .should.equal('https://xxx.cloudfront.net/xxx/icon.png');
+  });
+
+  it('supports a prioritized list of versions', () => {
+    setVersion(image, ['version_that_will_fall_thru_because_it_doesnt_exist', 'icon'])
+      .should.equal('https://xxx.cloudfront.net/xxx/icon.png');
+  });
+
+  it('falls back to any existy version', () => {
+    setVersion(image, ['garbage'])
+      .should.equal('https://xxx.cloudfront.net/xxx/large.jpg');
   });
 });
 


### PR DESCRIPTION
Artworks *very* often will not have a `larger` version but usually have a `large` (UGH).

This lets us query for an image like:

```
{
  artwork(id: "some-id") {
    resized(width: 500, version: ["larger", "large"]) {
      url
    }
  }
}
```

In the case of a missing `larger`, we'll get a URL for the `large`.

GraphQL will coerce a list type so queries that use the non array form of `version: "larger"` will work fine.