### PR TITLE
@dzucconi moar filter partners

### DIFF
--- a/schema/aggregations/filter_partners_aggregation.js
+++ b/schema/aggregations/filter_partners_aggregation.js
@@ -1,10 +1,11 @@
-import { map } from 'lodash';
+import { map, omit } from 'lodash';
 import Partner from '../partner';
 import AggregationCount from './aggregation_count';
 import {
   GraphQLObjectType,
   GraphQLEnumType,
   GraphQLList,
+  GraphQLInt,
 } from 'graphql';
 
 export const PartnersAggregation = new GraphQLEnumType({
@@ -15,6 +16,9 @@ export const PartnersAggregation = new GraphQLEnumType({
     },
     CATEGORY: {
       value: 'partner_category',
+    },
+    TOTAL: {
+      value: 'total',
     },
   },
 });
@@ -39,10 +43,14 @@ export const FilterPartnersType = new GraphQLObjectType({
     hits: {
       type: new GraphQLList(Partner.type),
     },
+    total: {
+      type: GraphQLInt,
+      resolve: ({ aggregations }) => aggregations.total.value,
+    },
     aggregations: {
       type: new GraphQLList(PartnersAggregationResultsType),
       resolve: ({ aggregations }) =>
-        map(aggregations, (counts, slice) => ({ slice, counts })),
+        map(omit(aggregations, ['total']), (counts, slice) => ({ slice, counts })),
     },
   }),
 });

--- a/schema/filter_partners.js
+++ b/schema/filter_partners.js
@@ -13,7 +13,7 @@ import {
 const FilterPartners = {
   type: FilterPartnersType,
   description: 'Partners Elastic Search results',
-  args: _.extend(Partners.args, {
+  args: _.assign({}, Partners.args, {
     aggregations: {
       type: new GraphQLNonNull(new GraphQLList(PartnersAggregation)),
     },

--- a/schema/filter_partners.js
+++ b/schema/filter_partners.js
@@ -13,7 +13,7 @@ import {
 const FilterPartners = {
   type: FilterPartnersType,
   description: 'Partners Elastic Search results',
-  args: _.create(Partners.args, {
+  args: _.extend(Partners.args, {
     aggregations: {
       type: new GraphQLNonNull(new GraphQLList(PartnersAggregation)),
     },


### PR DESCRIPTION
the `total` aggregation looks different and should be treated different
![screen shot 2016-01-22 at 6 01 37 pm](https://cloud.githubusercontent.com/assets/3171662/12525452/5ddc62ba-c132-11e5-9528-6ad201003c59.png)

for my a set of coordinates and selected category, i can get the search results and the total number of results for my given parameters, and the counts of all other categories with results that match my coordinates:

![screen shot 2016-01-22 at 5 57 43 pm](https://cloud.githubusercontent.com/assets/3171662/12525460/6b6a5996-c132-11e5-842b-f5c7907b32ed.png)

![screen shot 2016-01-22 at 5 57 58 pm](https://cloud.githubusercontent.com/assets/3171662/12525471/78de35e8-c132-11e5-94ae-6a293f8ef31c.png)

![screen shot 2016-01-22 at 5 58 25 pm](https://cloud.githubusercontent.com/assets/3171662/12525473/7d4cd5da-c132-11e5-8a85-48bdb5c70020.png)
