### PR TITLE
@dzucconi: Bidder positions schema

### DIFF
--- a/lib/apis/gravity.js
+++ b/lib/apis/gravity.js
@@ -6,6 +6,6 @@ const { GRAVITY_API_BASE } = process.env;
 
 export default (path, accessToken) => {
   const headers = { 'X-XAPP-TOKEN': config.GRAVITY_XAPP_TOKEN };
-  if (accessToken) assign(headers, { 'X-AUTHENTICATION-TOKEN': accessToken });
+  if (accessToken) assign(headers, { 'X-ACCESS-TOKEN': accessToken });
   return fetch(`${GRAVITY_API_BASE}/${path}`, { headers });
 };

--- a/lib/loaders/authenticated_http.js
+++ b/lib/loaders/authenticated_http.js
@@ -6,7 +6,7 @@ export default (api, headers) => {
     const clock = timer(path);
     clock.start();
     return new Promise((resolve, reject) => {
-      verbose(`Requested: ${path}`);
+      verbose(`Requested: ${path} with ${JSON.stringify(headers)}`);
       api(path, headers)
         .then(response => {
           resolve(response);

--- a/lib/loaders/authenticated_http.js
+++ b/lib/loaders/authenticated_http.js
@@ -6,7 +6,7 @@ export default (api, headers) => {
     const clock = timer(path);
     clock.start();
     return new Promise((resolve, reject) => {
-      verbose(`Requested: ${path} with ${JSON.stringify(headers)}`);
+      verbose(`Requested: ${path}`);
       api(path, headers)
         .then(response => {
           resolve(response);

--- a/schema/bidder_position.js
+++ b/schema/bidder_position.js
@@ -1,4 +1,6 @@
+import gravity from '../lib/loaders/gravity';
 import date from './fields/date';
+import SaleArtwork from './sale_artwork';
 import {
   GraphQLInt,
   GraphQLBoolean,
@@ -38,6 +40,12 @@ const BidderPositionType = new GraphQLObjectType({
     },
     suggested_next_bid_cents: {
       type: GraphQLInt,
+    },
+    sale_artwork: {
+      type: SaleArtwork.type,
+      resolve: (position) => {
+        return gravity(`sale_artwork/${position.sale_artwork_id}`);
+      },
     },
     highest_bid: {
       type: new GraphQLObjectType({

--- a/schema/bidder_position.js
+++ b/schema/bidder_position.js
@@ -43,9 +43,7 @@ const BidderPositionType = new GraphQLObjectType({
     },
     sale_artwork: {
       type: SaleArtwork.type,
-      resolve: (position) => {
-        return gravity(`sale_artwork/${position.sale_artwork_id}`);
-      },
+      resolve: position => gravity(`sale_artwork/${position.sale_artwork_id}`),
     },
     highest_bid: {
       type: new GraphQLObjectType({

--- a/schema/bidder_positions.js
+++ b/schema/bidder_positions.js
@@ -2,17 +2,11 @@ import gravity from '../lib/loaders/gravity';
 import BidderPosition from './bidder_position';
 import {
   GraphQLList,
-  GraphQLBoolean,
 } from 'graphql';
 
 const BidderPositions = {
   type: new GraphQLList(BidderPosition.type),
   description: 'A list of bidder positions',
-  args: {
-    me: {
-      type: GraphQLBoolean,
-    },
-  },
   resolve: (root, options, { rootValue: { accessToken } }) => {
     return gravity.with(accessToken)('me/bidder_positions');
   },

--- a/schema/bidder_positions.js
+++ b/schema/bidder_positions.js
@@ -1,0 +1,21 @@
+import gravity from '../lib/loaders/gravity';
+import BidderPosition from './bidder_position';
+import {
+  GraphQLList,
+  GraphQLBoolean,
+} from 'graphql';
+
+const BidderPositions = {
+  type: new GraphQLList(BidderPosition.type),
+  description: 'A list of bidder positions',
+  args: {
+    me: {
+      type: GraphQLBoolean,
+    },
+  },
+  resolve: (root, options, { rootValue: { accessToken } }) => {
+    return gravity.with(accessToken)('me/bidder_positions');
+  },
+};
+
+export default BidderPositions;

--- a/schema/index.js
+++ b/schema/index.js
@@ -20,6 +20,7 @@ import Sale from './sale';
 import SaleArtwork from './sale_artwork';
 import Search from './search';
 import Me from './me';
+import BidderPositions from './bidder_positions';
 import {
   GraphQLSchema,
   GraphQLObjectType,
@@ -51,6 +52,7 @@ const schema = new GraphQLSchema({
       sale_artwork: SaleArtwork,
       search: Search,
       me: Me,
+      bidder_positions: BidderPositions,
     },
   }),
 });


### PR DESCRIPTION
This allows a single query for "My Active Bids" w00t w00t <3 <3 <3 Metaphysics. Not sure if this makes sense but the query uses `bidder_positions(me: true)` to indicate "find by access token". I noticed we have a `me` schema—maybe it belongs there instead? It seems odd to bloat that schema up with all "me" things though. Open to all ideas.