### PR TITLE
@dzucconi: Move bidder positions under "me"

### DIFF
--- a/schema/index.js
+++ b/schema/index.js
@@ -20,7 +20,6 @@ import Sale from './sale';
 import SaleArtwork from './sale_artwork';
 import Search from './search';
 import Me from './me';
-import BidderPositions from './bidder_positions';
 import {
   GraphQLSchema,
   GraphQLObjectType,
@@ -52,7 +51,6 @@ const schema = new GraphQLSchema({
       sale_artwork: SaleArtwork,
       search: Search,
       me: Me,
-      bidder_positions: BidderPositions,
     },
   }),
 });

--- a/schema/me.js
+++ b/schema/me.js
@@ -1,6 +1,7 @@
 import date from './fields/date';
 import gravity from '../lib/loaders/gravity';
 import Profile from './profile';
+import BidderPositions from './bidder_positions';
 import {
   GraphQLString,
   GraphQLObjectType,
@@ -21,6 +22,7 @@ const Me = new GraphQLObjectType({
       resolve: ({ default_profile_id }) =>
         gravity(`profile/${default_profile_id}`),
     },
+    bidder_positions: BidderPositions,
   },
 });
 


### PR DESCRIPTION
Sorry to be fickle about this, but I just want to decide on a flexible convention for querying "me" resources. My initial thought was something close to the "restful" approach—which would be using a param to modify a root resource e.g. something like `/api/v1/bidder_positions?user_id=me`, so `bidder_positions(me: true)` made sense to me at first. However, I couldn't find any best practices example of this for GraphQL—since we already have a me->profile in place, I think expanding inside `me` makes sense.

It's a small thing, but I think this'll make it more obvious when deciding how to query something, e.g. if down the line we want to query that admin-only "all bidder positions" my first thought would be:

```
bidder_positions {
  id
  ...
}
```

Which would trip me up when it returns only my bidder positions.