### PR TITLE
@dzucconi: Fix logic that was causing dupes for bids in the same auction

### DIFF
--- a/schema/me.js
+++ b/schema/me.js
@@ -61,13 +61,14 @@ const Me = new GraphQLObjectType({
               return Promise.all(_.map(saleArtworks, (saleArtwork) =>
                 gravity(`sale/${saleArtwork.sale_id}`)
               )).then((sales) => {
-                return _(sales).chain()
-                  .filter((sale) => sale.auction_state === 'open')
-                  .map((sale) => _.find(saleArtworks, { sale_id: sale.id }))
-                  .map((sa) =>
-                    _.find(latestPositions, { sale_artwork_id: sa._id })
-                  )
-                  .value();
+                const bids = _.filter(latestPositions, (position) => {
+                  const saleArtwork = _.find(saleArtworks, {
+                    _id: position.sale_artwork_id,
+                  });
+                  const sale = _.find(sales, { id: saleArtwork.sale_id });
+                  return sale.auction_state === 'open';
+                });
+                return bids;
               });
             });
           });

--- a/schema/me.js
+++ b/schema/me.js
@@ -61,14 +61,13 @@ const Me = new GraphQLObjectType({
               return Promise.all(_.map(saleArtworks, (saleArtwork) =>
                 gravity(`sale/${saleArtwork.sale_id}`)
               )).then((sales) => {
-                const bids = _.filter(latestPositions, (position) => {
+                return _.filter(latestPositions, (position) => {
                   const saleArtwork = _.find(saleArtworks, {
                     _id: position.sale_artwork_id,
                   });
                   const sale = _.find(sales, { id: saleArtwork.sale_id });
                   return sale.auction_state === 'open';
                 });
-                return bids;
               });
             });
           });

--- a/test/schema/me.js
+++ b/test/schema/me.js
@@ -67,14 +67,14 @@ describe('Me type', () => {
         id,
         _id: id,
         artwork: { title: 'Andy Warhol Skull' },
-        sale_id: i,
+        sale_id: i === 1 ? 'bar-auction' : 'else-auction',
       }));
     });
     // Sale fetches
     times(3, (i) => {
       gravity.onCall(i + 5)
       .returns(Promise.resolve({
-        id: i,
+        id: i === 1 ? 'bar-auction' : 'else-auction',
         auction_state: i === 1 ? 'closed' : 'open',
       }));
     });


### PR DESCRIPTION
My `filter/map/map/find/filter/map/find/map/filter/filter/find` logic was going about finding bidder positions in "open" auctions in the wrong direction which caused a subtle bug where it would return dupe bidder positions.

This is because I was approaching it from the auciton->sale_artwork->bidder_position direction—where as now I just filter down the bidder positions according to their related `sale_artwork.sale`.