### PR TITLE
@dzucconi Add the "internal" arg to the partner_categories schema.

### DIFF
--- a/schema/partner_categories.js
+++ b/schema/partner_categories.js
@@ -5,7 +5,7 @@ import CategoryType from './input_fields/category_type';
 import {
   GraphQLList,
   GraphQLInt,
-  GraphQLBoolean
+  GraphQLBoolean,
 } from 'graphql';
 
 const PartnerCategories = {
@@ -18,8 +18,9 @@ const PartnerCategories = {
     category_type: CategoryType,
     internal: {
       type: GraphQLBoolean,
-      description: 'Filter by whether category is internal'
-    }
+      defaultValue: false,
+      description: 'Filter by whether category is internal',
+    },
   },
   resolve: (root, options) => gravity('partner_categories', options),
 };

--- a/schema/partner_categories.js
+++ b/schema/partner_categories.js
@@ -5,6 +5,7 @@ import CategoryType from './input_fields/category_type';
 import {
   GraphQLList,
   GraphQLInt,
+  GraphQLBoolean
 } from 'graphql';
 
 const PartnerCategories = {
@@ -15,6 +16,10 @@ const PartnerCategories = {
       type: GraphQLInt,
     },
     category_type: CategoryType,
+    internal: {
+      type: GraphQLBoolean,
+      description: 'Filter by whether category is internal'
+    }
   },
   resolve: (root, options) => gravity('partner_categories', options),
 };


### PR DESCRIPTION
cc @1aurabrown 

On the /institutions page, we don't want to display internal categories. This adds the [param](https://github.com/artsy/gravity/blob/a96a1dd570994ae9d2f5290b7f0e715d8b7c9a82/app/api/v1/partner_categories_endpoint.rb#L11) to the partner_categories schema, and so we can filter them out.