### PR TITLE
@craigspaeth - checks if current user has the winning bid

### DIFF
--- a/schema/sale_artwork.js
+++ b/schema/sale_artwork.js
@@ -75,14 +75,17 @@ const SaleArtworkType = new GraphQLObjectType({
       current_user_has_winning_bid: {
         type: GraphQLBoolean,
         resolve: (sale_artwork, $, { rootValue: { accessToken } }) => {
-          if(!sale_artwork.highest_bid) return false;
+          if (!sale_artwork.highest_bid) return false;
           return gravity.with(accessToken)('me/bidder_positions')
             .then((positions) => {
               return _.some(_(positions).find((position) => {
-                return position.highest_bid && position.highest_bid.id == sale_artwork.highest_bid.id;
+                return (
+                  position.highest_bid &&
+                  position.highest_bid.id === sale_artwork.highest_bid.id
+                );
               }));
             }).catch(() => false);
-        }
+        },
       },
       artwork: {
         type: Artwork.type,


### PR DESCRIPTION
cc @dzucconi 
cc @xtina-starr 

I know this deviates from the `/me` convention but the alternative to this is making two requests on the client-side (and not in parallel i.e. artwork -> sale_artwork, then me -> bidder_positions(sale_artwork: id)...etc). Down for whatever but this makes things easiest on the client-side.