### PR TITLE
@broskoski: Sort by -created_at

### DIFF
--- a/schema/me/bidder_positions.js
+++ b/schema/me/bidder_positions.js
@@ -21,7 +21,11 @@ export default {
     },
   },
   resolve: (root, { current, artwork_id }, { rootValue: { accessToken } }) => {
-    return gravity.with(accessToken)('me/bidder_positions', { artwork_id })
+    return gravity
+      .with(accessToken)('me/bidder_positions', {
+        artwork_id,
+        sort: '-created_at',
+      })
       .then((positions) => {
         if (!current || artwork_id) return positions;
         // When asking for "my current bids" we need to...


### PR DESCRIPTION
I noticed when testing my active bids stuff that if someone places a ton of bids, they can reach beyond the first pages and not show up. Simple fix—just sort by most recently placed, or `-created_at`