### PR TITLE
@dzucconi : move biography status to metaphysics

### DIFF
--- a/schema/artist/statuses.js
+++ b/schema/artist/statuses.js
@@ -54,6 +54,15 @@ const ArtistStatusesType = new GraphQLObjectType({
         }).then(articles => !!articles.count);
       },
     },
+    biography: {
+      type: GraphQLBoolean,
+      resolve: ({ _id }) => {
+        return positron('articles', {
+          published: true,
+          biography_for_artist_id: _id,
+        }).then(articles => !!articles.count);
+      },
+    },
   },
 });
 


### PR DESCRIPTION
@briansw pointed out a bug where the biography tab went missing from artist pages after i started fetching statuses from metaphysics rather than compiling them on the client based on a series of netsed fetches and logic. This fixes that.