### PR TITLE
@broskoski: Adds reserve_cents to sale artwork; removes amount_cents

### DIFF
--- a/schema/sale_artwork.js
+++ b/schema/sale_artwork.js
@@ -38,7 +38,7 @@ const SaleArtworkType = new GraphQLObjectType({
       reserve_status: {
         type: GraphQLInt,
       },
-      amount_cents: {
+      reserve_cents: {
         type: GraphQLInt,
       },
       low_estimate_cents: {


### PR DESCRIPTION
I didn't see any `amount_cents` [fields on the sale artwork Gravity](https://github.com/artsy/gravity/blob/master/app/models/domain/sale_artwork.rb#L47)... doesn't seem like we use that anywhere (it does a appear under `highest_bid` so maybe copypasta fluke `¯\_(ツ)_/¯`). We do however have `reserve_cents` which is something that may be useful for Live (at-least for now it'll help me sync data to Causality for dev purpose).