### PR TITLE
@dzucconi - home page modules (rails)

### DIFF
--- a/schema/me/home_page_modules.js
+++ b/schema/me/home_page_modules.js
@@ -1,5 +1,11 @@
 import gravity from '../../lib/loaders/gravity';
-import { keys, map, sortBy, first, filter } from 'lodash';
+import {
+  keys,
+  map,
+  sortBy,
+  first,
+  filter
+} from 'lodash';
 import Artwork from '../artwork/index';
 import {
   GraphQLList,
@@ -111,12 +117,25 @@ export const HomePageModulesType = new GraphQLObjectType({
 const HomePageModules = {
   type: new GraphQLList(HomePageModulesType),
   description: 'Modules to show on the home screen',
-  resolve: (root, options, { rootValue: { accessToken } }) => {
+  args: {
+    include_keys: {
+      type: new GraphQLList(GraphQLString),
+      description: 'A list of modules to return (by key)',
+      defaultValue: false,
+    },
+  },
+  resolve: (root, { include_keys }, { rootValue: { accessToken } }) => {
     return gravity.with(accessToken)('me/modules').then((response) => {
       const modules = map(keys(response), (key) => {
         return { key: key, display: response[key] };
       });
-      return filter(modules, [ 'display', true ]);
+      if(include_keys){
+        return filter(modules, (module) => {
+          return include_keys.indexOf(module.key) > -1;
+        });
+      }else{
+        return filter(modules, [ 'display', true ]);
+      }
     })
   },
 };

--- a/schema/me/home_page_modules.js
+++ b/schema/me/home_page_modules.js
@@ -1,0 +1,70 @@
+import gravity from '../../lib/loaders/gravity';
+import { keys, map, sortBy } from 'lodash';
+import {
+  GraphQLList,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLBoolean,
+  GraphQLInt,
+} from 'graphql';
+
+const featuredFair = () => {
+  return gravity('fairs', { size: 5, status: 'running' }).then((fairs) => {
+    return sortBy(fairs, ({ banner_size }) =>
+      ['x-large', 'large', 'medium', 'small', 'x-small'].indexOf(banner_size)
+    )[0];
+  });
+}
+
+const moduleTitle = {
+  active_bids: () => "Your Active Bids",
+  followed_artists: () => "Works by Artists you Follow",
+  followed_galleries: () => "Works from Galleries you Follow",
+  saved_works: () => "Recently Saved Works",
+  recommended_works: () => "Recommended Works for You",
+  live_auctions: () => "At Auction: ",
+  current_fairs: () =>  {
+    return featuredFair().then(({name}) => {
+      return `Art Fair: ${name}`
+    })
+  },
+  related_artists: () => "Works by Related Artists",
+  genes: () => "Works from Gene you Follow",
+}
+
+
+export const HomePageModulesType = new GraphQLObjectType({
+  name: 'HomePageModules',
+  fields: () => ({
+    key: {
+      type: GraphQLString,
+    },
+    should_display: {
+      type: GraphQLString,
+    },
+    title: {
+      type: GraphQLString,
+      resolve: ({ key, should_display }) => {
+        if(should_display){
+          return moduleTitle[key]();
+        } else {
+          return "";
+        }
+      },
+    }
+  }),
+});
+
+const HomePageModules = {
+  type: new GraphQLList(HomePageModulesType),
+  description: 'Modules to show on the home screen',
+  resolve: (root, options, { rootValue: { accessToken } }) => {
+    return gravity.with(accessToken)('me/modules').then((response) => {
+      return map(keys(response), (key) => {
+        return { key: key, should_display: response[key] };
+      });
+    })
+  },
+};
+
+export default HomePageModules;

--- a/schema/me/index.js
+++ b/schema/me/index.js
@@ -3,6 +3,7 @@ import gravity from '../../lib/loaders/gravity';
 import Bidders from './bidders';
 import BidderPositions from './bidder_positions';
 import SaleRegistrations from './sale_registrations';
+import HomePageModules from './home_page_modules';
 import {
   GraphQLString,
   GraphQLObjectType,
@@ -21,6 +22,7 @@ const Me = new GraphQLObjectType({
     bidders: Bidders,
     bidder_positions: BidderPositions,
     sale_registrations: SaleRegistrations,
+    home_page_modules: HomePageModules,
   },
 });
 


### PR DESCRIPTION
cc @alloy @mzikherman 

Still working on this but want to keep some feedback before I get too deep in. 

My current thinking is:

### 1. On initial load

```
query {
  me{
    id
    home_page_modules{
      key
      display
      title
    }
  }
}
```
(would return something like):

```
{
  "data": {
    "me": {
      "id": "547e891d7261691220dc0000",
      "home_page_modules": [
        {
          "key": "followed_artists",
          "display": "true",
          "title": "Works by Artists you Follow"
        },
        {
          "key": "followed_galleries",
          "display": "true",
          "title": "Works from Galleries you Follow"
        },
        {
          "key": "saved_works",
          "display": "true",
          "title": "Recently Saved Works"
        },
        {
          "key": "recommended_works",
          "display": "true",
          "title": "Recommended Works for You"
        },
        {
          "key": "live_auctions",
          "display": "true",
          "title": "At auction: Art in General: Benefit Auction 2016"
        },
        {
          "key": "current_fairs",
          "display": "true",
          "title": "Art Fair: SP-Arte 2016"
        },
        {
          "key": "related_artists",
          "display": "true",
          "title": "Works by Related Artists"
        }
      ]
    }
  }
}
```

### 2. Then client side, for each key returned: 

```
query {
  me{
    id
    home_page_modules(include_keys: ["recommended_works"]){
      results{
        id
      }
    }
  }
}
```

This way, each rail has all the information it needs to render itself.

There's some weird things about this implementation (most obviously, passing the `accessToken` around), so feel free to let me know where things are non-optimal.

