### PR TITLE
@dzucconi => Deprecate is_contactable, and introduce is_inquireable

### DIFF
--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -103,9 +103,15 @@ const ArtworkType = new GraphQLObjectType({
           );
         },
       },
+      is_inquireable: {
+        type: GraphQLBoolean,
+        description: 'Do we want to encourage inquiries on this work?',
+        resolve: ({ inquireable, acquireable }) => inquireable && !acquireable,
+      },
       is_contactable: {
         type: GraphQLBoolean,
         description: 'Are we able to display a contact form on artwork pages?',
+        deprecationReason: 'Prefer to use is_inquireable',
         resolve: (artwork) => {
           return gravity('related/sales', { size: 1, active: true, artwork: [artwork.id] })
             .then(sales => {


### PR DESCRIPTION
**NOT FOR MERGE YET**

Waiting on https://github.com/artsy/gravity/pull/9939 to be deployed, cache updated and migration ran, etc.

The next step once this is deployed is to switch some existing uses of `is_contactable` to this new one and carefully examine...