### PR TITLE
@craigspaeth: Deduplicate similar requests

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,3 +1,4 @@
+import { stringify } from 'qs';
 import {
   flow,
   assign,
@@ -40,3 +41,13 @@ export const truncate = (string, length, append = '…') => {
   const limit = ~~length;
   return x.length > limit ? (x.slice(0, limit) + append) : x;
 };
+
+export const toQueryString = (options = {}) =>
+  stringify(options, {
+    arrayFormat: 'brackets',
+    sort: (a, b) =>
+      a.localeCompare(b),
+  });
+
+export const toKey = (path, options = {}) =>
+  `${path}?${toQueryString(options)}`;

--- a/lib/loaders/delta.js
+++ b/lib/loaders/delta.js
@@ -1,10 +1,8 @@
-import qs from 'qs';
+import { toKey } from '../helpers';
 import delta from '../apis/delta';
 import httpLoader from './http';
 
 export const deltaLoader = httpLoader(delta);
 
-export default (path, options = {}) => {
-  const queryString = qs.stringify(options, { arrayFormat: 'brackets' });
-  return deltaLoader.load(`${path}?${queryString}`);
-};
+export default (path, options = {}) =>
+  deltaLoader.load(toKey(path, options));

--- a/lib/loaders/google_cse.js
+++ b/lib/loaders/google_cse.js
@@ -1,5 +1,5 @@
-import _ from 'lodash';
-import qs from 'qs';
+import { assign } from 'lodash';
+import { toQueryString } from '../helpers';
 import googleCSE from '../apis/google_cse';
 import httpLoader from './http';
 const {
@@ -10,7 +10,7 @@ const {
 export const googleCSELoader = httpLoader(googleCSE);
 
 export default (options = {}) => {
-  const queryString = qs.stringify(_.assign(options, {
+  const queryString = toQueryString(assign(options, {
     key: GOOGLE_CSE_KEY,
     cx: GOOGLE_CSE_CX,
   }));

--- a/lib/loaders/gravity.js
+++ b/lib/loaders/gravity.js
@@ -1,24 +1,19 @@
-import qs from 'qs';
+import { toKey } from '../helpers';
 import gravity from '../apis/gravity';
 import httpLoader from './http';
 import authenticatedHttpLoader from './authenticated_http';
 
 export const gravityLoader = httpLoader(gravity);
 
-const keyify = (path, options = {}) => {
-  const queryString = qs.stringify(options, { arrayFormat: 'brackets' });
-  return `${path}?${queryString}`;
-};
-
 const load = (path, options = {}) => {
-  const key = keyify(path, options);
+  const key = toKey(path, options);
   return gravityLoader.load(key);
 };
 
 load.with = (accessToken) => {
   const authenticatedGravityLoader = authenticatedHttpLoader(gravity, accessToken);
   return (path, options = {}) => {
-    const key = keyify(path, options);
+    const key = toKey(path, options);
     return authenticatedGravityLoader(key, accessToken);
   };
 };

--- a/lib/loaders/positron.js
+++ b/lib/loaders/positron.js
@@ -1,10 +1,8 @@
-import qs from 'qs';
+import { toKey } from '../helpers';
 import positron from '../apis/positron';
 import httpLoader from './http';
 
 export const positronLoader = httpLoader(positron);
 
-export default (path, options = {}) => {
-  const queryString = qs.stringify(options, { arrayFormat: 'brackets' });
-  return positronLoader.load(`${path}?${queryString}`);
-};
+export default (path, options = {}) =>
+  positronLoader.load(toKey(path, options));

--- a/test/lib/helpers.js
+++ b/test/lib/helpers.js
@@ -1,4 +1,39 @@
-import { isExisty } from '../../lib/helpers';
+import {
+  toKey,
+  isExisty,
+} from '../../lib/helpers';
+
+describe('toKey', () => {
+  it('returns a stringified key given a path', () => {
+    toKey('foo/bar')
+      .should.equal('foo/bar?');
+  });
+
+  it('returns a stringified key given a path and an option', () => {
+    toKey('foo/bar', { sort: 'asc' })
+      .should.equal('foo/bar?sort=asc');
+  });
+
+  it('returns a stringified key given a path and multiple options', () => {
+    toKey('foo/bar', {
+      sort: 'asc',
+      sleep: false,
+      size: 10,
+    })
+      .should.equal('foo/bar?size=10&sleep=false&sort=asc');
+  });
+
+  it('sorts the option keys in alphabetical order', () => {
+    toKey('foo/bar', {
+      a: 3,
+      z: 'whatever',
+      b: 99,
+      d: false,
+      c: 0,
+    })
+      .should.equal('foo/bar?a=3&b=99&c=0&d=false&z=whatever');
+  });
+});
 
 describe('isExisty', () => {
   describe('existy things', () => {


### PR DESCRIPTION
I noticed this in practice on the `artwork_2` page: While although Objects aren't technically sorted, in practice when `qs.stringify` was run it would create keys in the order that one declared the options.

As part of that `artwork_2` query these two keys would get loaded:
```
related/sales?artwork%5B%5D=andy-warhol-electric-chair-18&active=true&size=1
related/sales?size=1&active=true&artwork%5B%5D=andy-warhol-electric-chair-18
``` 

Those now become:
```
related/sales?active=true&artwork%5B%5D=andy-warhol-electric-chair-18&size=1
```

Which of course is neither of those.

So once this gets deployed we should see the cache hit rate drop while these get rebuilt. But we should see reduced cache usage & marginally increased performance later on.