### PR TITLE
@dzucconi => Term Search support for Partners

### DIFF
--- a/schema/partners.js
+++ b/schema/partners.js
@@ -79,6 +79,10 @@ const Partners = {
     type: {
       type: new GraphQLList(PartnerTypeType),
     },
+    term: {
+      type: GraphQLString,
+      description: 'term used for searching Partners',
+    },
   },
   resolve: (root, options) => gravity('partners', options),
 };


### PR DESCRIPTION
# Problem
Need to match latest gravity changes so we can support term search along with filtering.
https://github.com/artsy/gravity/pull/9965
This is needed in order to support https://trello.com/c/xrTp0Skr/422-galleries-institutions-partner-search-that-differentiates-between-galleries-and-institutions
# Change
Modified our `partners` GraphQL schema to match latest Gravity changes and include `term`

cc: @starsirius 
