### PR TITLE
@mzikherman: Make displaying partner types less awkward

### DIFF
--- a/schema/partner.js
+++ b/schema/partner.js
@@ -39,6 +39,15 @@ const PartnerType = new GraphQLObjectType({
       },
       type: {
         type: GraphQLString,
+        resolve: ({ name, type }) => {
+          const exceptions = {
+            Auction: 'Auction House',
+            Brand: name,
+            'Institutional Seller': 'Institution',
+          };
+
+          return exceptions[type] || type;
+        },
       },
       href: {
         type: GraphQLString,


### PR DESCRIPTION
For places where we want to display the 'kind' of partner but the actual type is awkward.

![](http://static.damonzucconi.com/_capture/1dBAlRUoE1.png)
![](http://static.damonzucconi.com/_capture/DwF23trBMD.png)

We could also alias this as a new field, but I don't really see a downside to this approach.