### PR TITLE
@broskoski: Adds sale_id to bidder query for server-side filtering

### DIFF
--- a/schema/me/bidders.js
+++ b/schema/me/bidders.js
@@ -2,11 +2,21 @@ import gravity from '../../lib/loaders/gravity';
 import Bidder from '../bidder';
 import {
   GraphQLList,
+  GraphQLString,
 } from 'graphql';
 
 export default {
   type: new GraphQLList(Bidder.type),
   description: 'A list of the current user’s bidder registrations',
-  resolve: (root, options, { rootValue: { accessToken } }) =>
-    gravity.with(accessToken)('me/bidders'),
+  args: {
+    sale_id: {
+      type: GraphQLString,
+      description: 'The slug or ID of a Sale',
+    },
+  },
+  resolve: (root, options, { rootValue: { accessToken } }) => {
+    const url = options.sale_id === undefined ? 'me/bidders' : 'bidders';
+    if (!accessToken) return null;
+    return gravity.with(accessToken)(url, options);
+  },
 };

--- a/test/schema/me/bidders.js
+++ b/test/schema/me/bidders.js
@@ -1,0 +1,85 @@
+import sinon from 'sinon';
+import { graphql } from 'graphql';
+import schema from '../../../schema';
+
+describe('Me', () => {
+  describe('Bidders', () => {
+    let gravity;
+
+    const Me = schema.__get__('Me');
+    const Bidders = Me.__get__('Bidders');
+
+    beforeEach(() => {
+      gravity = sinon.stub();
+      gravity.with = sinon.stub().returns(gravity);
+
+      Me.__Rewire__('gravity', gravity);
+      Bidders.__Rewire__('gravity', gravity);
+
+      gravity
+        // Me fetch
+        .onCall(0)
+        .returns(Promise.resolve({}));
+    });
+
+    afterEach(() => {
+      Me.__ResetDependency__('gravity');
+      Bidders.__ResetDependency__('gravity');
+    });
+
+    it('returns bidder ids that the user is registered in sales for', () => {
+      const query = `
+        {
+          me {
+            bidders {
+              id
+            }
+          }
+        }
+      `;
+
+      gravity
+        .withArgs('me/bidders', {})
+        .returns(Promise.resolve([
+          { id: 'Foo ID' },
+          { id: 'Bar ID' },
+        ]));
+
+      return graphql(schema, query, { accessToken: 'foo' })
+        .then(({ data: { me: { bidders } } }) => {
+          bidders.should.eql([
+            { id: 'Foo ID' },
+            { id: 'Bar ID' },
+          ]);
+        });
+    });
+
+
+    it('returns bidder ids for the requested sale', () => {
+      const query = `
+        {
+          me {
+            bidders(sale_id: "the-fun-sale") {
+              id
+            }
+          }
+        }
+      `;
+
+      gravity
+        .withArgs('bidders', { sale_id: 'the-fun-sale' })
+        .returns(Promise.resolve([
+          { id: 'Foo ID' },
+          { id: 'Bar ID' },
+        ]));
+
+      return graphql(schema, query, { accessToken: 'foo' })
+        .then(({ data: { me: { bidders } } }) => {
+          bidders.should.eql([
+            { id: 'Foo ID' },
+            { id: 'Bar ID' },
+          ]);
+        });
+    });
+  });
+});


### PR DESCRIPTION
Gravity has two endpoints for retrieving `me`'s sale registration status: `bidders` and `me/bidders` depending one if you specify a `sale_id` or not. This PR adds an optional `sale_id` argument to the `me { bidders }` query.

![screen shot 2016-05-11 at 3 03 57 pm](https://cloud.githubusercontent.com/assets/498212/15192946/9cb2530c-1789-11e6-9aab-e9496e758285.png)

Paired with @orta on this one. 