### PR TITLE
@mzikherman => Add default_profile_public to Partner schema

### DIFF
--- a/schema/partner.js
+++ b/schema/partner.js
@@ -37,6 +37,9 @@ const PartnerType = new GraphQLObjectType({
       collecting_institution: {
         type: GraphQLString,
       },
+      default_profile_public: {
+        type: GraphQLBoolean,
+      },
       type: {
         type: GraphQLString,
         resolve: ({ name, type }) => {


### PR DESCRIPTION
Needed for backwards compatibility when coercing results into Backbone models.