### PR TITLE
Convert BIDDERs to OBSERVERs automatically if they are not registered for a sale

### DIFF
--- a/schema/causality_jwt.js
+++ b/schema/causality_jwt.js
@@ -51,15 +51,14 @@ export default {
       const registered = find(bidders, (b) => {
         return (b.sale._id === options.sale_id || b.sale.id === options.sale_id);
       });
-      if (options.role === 'BIDDER' && !registered) {
-        throw new Error('Not registered to bid in this auction');
-      }
+      const loggedInAndNotRegistered = (options.role === 'BIDDER' && !registered);
+      const role = loggedInAndNotRegistered ? 'OBSERVER' : options.role;
       const data = {
         aud: 'auctions',
-        role: options.role.toLowerCase(),
+        role: role.toLowerCase(),
         userId: me.id,
         saleId: registered ? registered.sale._id : options.sale_id,
-        bidderId: me.paddle_number,
+        bidderId: registered ? me.paddle_number : null,
         iat: new Date().getTime(),
       };
       return jwt.encode(data, HMAC_SECRET);

--- a/test/schema/causality_jwt.js
+++ b/test/schema/causality_jwt.js
@@ -84,13 +84,20 @@ describe('CausalityJWT', () => {
       });
   });
 
-  it('denies a bidder not registered to the sale', () => {
+  it('converts a BIDDER to an OBSERVER if not registered to the sale', () => {
     const query = `{
       causality_jwt(role: BIDDER, sale_id: "bar")
     }`;
     return graphql(schema, query, { accessToken: 'foo' })
       .then((data) => {
-        data.errors[0].message.should.containEql('Not registered');
+        omit(jwt.decode(data.data.causality_jwt, HMAC_SECRET), 'iat')
+          .should.eql({
+            aud: 'auctions',
+            role: 'observer',
+            userId: 'craig',
+            saleId: 'bar',
+            bidderId: null,
+          });
       });
   });
 


### PR DESCRIPTION
Currently for logged in users, the clients need to have enough stored gravity data to know whether a user is registered to bid. The current implementation on both sides for logged in users to it make the request, see if it fails, then try again with the other one. 

This is a bit of a waste, considering metaphysics already knows this data, and is passing it onwards. It means extra time waiting for a second request to get any data on a client when logged in and not registered.

Instead now you will be downgraded from a BIDDER to an OBSERVER, and that is encoded into the response.