### PR TITLE
@broskoski => Annotate related artist on homepage with followed artist

### DIFF
--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -44,6 +44,9 @@ const ArtistType = new GraphQLObjectType({
       id: {
         type: GraphQLString,
       },
+      follow_annotation: {
+        type: GraphQLString,
+      },
       href: {
         type: GraphQLString,
         resolve: (artist) => `/artist/${artist.id}`,

--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -44,9 +44,6 @@ const ArtistType = new GraphQLObjectType({
       id: {
         type: GraphQLString,
       },
-      follow_annotation: {
-        type: GraphQLString,
-      },
       href: {
         type: GraphQLString,
         resolve: (artist) => `/artist/${artist.id}`,

--- a/schema/home/context.js
+++ b/schema/home/context.js
@@ -14,7 +14,7 @@ import Gene from '../gene';
 import Artist from '../artist/index';
 import FollowArtists from '../me/follow_artists';
 import Trending from '../trending';
-import { GraphQLUnionType } from 'graphql';
+import { GraphQLUnionType, GraphQLObjectType } from 'graphql';
 
 export const HomePageModuleContextFairType = create(Fair.type, {
   name: 'HomePageModuleContextFair',
@@ -41,8 +41,16 @@ export const HomePageModuleContextFollowArtistsType = create(FollowArtists.type,
   isTypeOf: ({ context_type }) => context_type === 'FollowArtists',
 });
 
-export const HomePageModuleContextRelatedArtistsType = create(Artist.type, {
-  name: 'HomePageModuleContextRelatedArtists',
+export const HomePageModuleContextRelatedArtistType = new GraphQLObjectType({
+  name: 'HomePageModuleContextRelatedArtist',
+  fields: () => ({
+    artist: {
+      type: Artist.type,
+    },
+    based_on: {
+      type: Artist.type,
+    },
+  }),
   isTypeOf: ({ context_type }) => context_type === 'Artist',
 });
 
@@ -74,10 +82,11 @@ export const moduleContext = {
   },
   related_artists: ({ accessToken }) => {
     return followedArtist(accessToken).then((follow) => {
-      return relatedArtist(accessToken).then((artist) => {
-        const message = `Based on ${follow.name}`;
-        return assign({}, artist, { context_type: 'Artist', follow_annotation: message });
-      });
+      return relatedArtist(accessToken).then((artist) => ({
+        context_type: 'Artist',
+        based_on: follow,
+        artist,
+      }));
     });
   },
   genes: ({ accessToken }) => {
@@ -101,7 +110,7 @@ export default {
       HomePageModuleContextGeneType,
       HomePageModuleContextTrendingType,
       HomePageModuleContextFollowArtistsType,
-      HomePageModuleContextRelatedArtistsType,
+      HomePageModuleContextRelatedArtistType,
     ],
   }),
   resolve: ({ key, display, params }, options, { rootValue: { accessToken } }) => {

--- a/schema/home/context.js
+++ b/schema/home/context.js
@@ -6,6 +6,7 @@ import {
   featuredGene,
   iconicArtists,
   relatedArtist,
+  followedArtist,
 } from './fetch';
 import Fair from '../fair';
 import Sale from '../sale/index';
@@ -72,8 +73,11 @@ export const moduleContext = {
     });
   },
   related_artists: ({ accessToken }) => {
-    return relatedArtist(accessToken).then((artist) => {
-      return assign({}, artist, { context_type: 'Artist' });
+    return followedArtist(accessToken).then((follow) => {
+      return relatedArtist(accessToken).then((artist) => {
+        const message = `Based on ${follow.name}`;
+        return assign({}, artist, { context_type: 'Artist', follow_annotation: message });
+      });
     });
   },
   genes: ({ accessToken }) => {

--- a/schema/home/fetch.js
+++ b/schema/home/fetch.js
@@ -1,6 +1,6 @@
 import gravity from '../../lib/loaders/gravity';
 import delta from '../../lib/loaders/delta';
-import { sortBy, first, forEach, clone, get } from 'lodash';
+import { sortBy, first, forEach, clone } from 'lodash';
 import blacklist from '../../lib/artist_blacklist';
 
 export const featuredFair = () => {
@@ -29,17 +29,23 @@ export const featuredGene = (accessToken) => {
   });
 };
 
-export const relatedArtist = (accessToken) => {
-  return gravity.with(accessToken)('me/follow/artists', { size: 10 }).then((follows) => {
+export const followedArtist = (accessToken) => {
+  return gravity.with(accessToken)('me/follow/artists', { size: 1 }).then((follows) => {
     if (follows.length) {
-      return gravity
-        .with(accessToken)('me/suggested/artists', {
-          exclude_followed_artists: true,
-          exclude_artists_without_artworks: true,
-          artist_id: get(first(follows), 'artist._id'),
-        })
-        .then(first);
+      return first(follows).artist;
     }
+  });
+};
+
+export const relatedArtist = (accessToken) => {
+  return followedArtist(accessToken).then((followed_artist) => {
+    return gravity
+      .with(accessToken)('me/suggested/artists', {
+        exclude_followed_artists: true,
+        exclude_artists_without_artworks: true,
+        artist_id: followed_artist._id,
+      })
+      .then(first);
   });
 };
 

--- a/schema/home/title.js
+++ b/schema/home/title.js
@@ -30,7 +30,7 @@ const moduleTitle = {
   related_artists: ({ accessToken }) => {
     return relatedArtist(accessToken).then((related_artist) => {
       if (related_artist) {
-        return related_artist.name;
+        return `Works by ${related_artist.name}`;
       }
     });
   },


### PR DESCRIPTION
This is pretty ghetto.

Basically, the context object shouldn't be an `Artist`, but something custom, a struct of the artist and another object that represents the follow it is based on, or maybe we could get away with something as simple as a struct of `{href, follow_annotation}`. 

My JS-fu wasn't good enough to get that tho, so just went with this for now :(

```
{
  "data": {
    "home_page_module": {
      "title": "Works by Jasper Johns",
      "key": "related_artists",
      "context": {
        "href": "/artist/jasper-johns",
        "id": "jasper-johns",
        "follow_annotation": "Based on Andy Warhol"
      }
    }
  }
}
```