### PR TITLE
@sweir27 (cc @acjay): Update Causality JWT logic

### DIFF
--- a/schema/causality_jwt.js
+++ b/schema/causality_jwt.js
@@ -53,23 +53,23 @@ export default {
 
           // ...registered users, use bidder role...
           ? jwt.encode({
-              aud: 'auctions',
-              role: 'bidder',
-              userId: me._id,
-              saleId: sale._id,
-              bidderId: me.paddle_number,
-              iat: new Date().getTime(),
-            }, HMAC_SECRET)
+            aud: 'auctions',
+            role: 'bidder',
+            userId: me._id,
+            saleId: sale._id,
+            bidderId: me.paddle_number,
+            iat: new Date().getTime(),
+          }, HMAC_SECRET)
 
           // ...otherwise use observer role
           : jwt.encode({
-              aud: 'auctions',
-              role: 'observer',
-              userId: me._id,
-              saleId: sale._id,
-              bidderId: null,
-              iat: new Date().getTime(),
-            }, HMAC_SECRET)
+            aud: 'auctions',
+            role: 'observer',
+            userId: me._id,
+            saleId: sale._id,
+            bidderId: null,
+            iat: new Date().getTime(),
+          }, HMAC_SECRET)
       );
 
     // Operator role if logged in as an admin


### PR DESCRIPTION
This updates the JWT logic to split the path down it's 4 separate ways...

1. Any logged out users default to "observer" role
2. A logged in user specifying PARTICIPANT gets a "bidder" role if registered
3. A logged in user specifying PARTICIPANT gets a "observer" role if *not* registered
4. An admin specifying OPERATOR gets "operator" role or "unauthorized" if not admin