### PR TITLE
@alloy=>Added has_metadata flag and counts for related artists and articles

### DIFF
--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -83,6 +83,12 @@ const ArtistType = new GraphQLObjectType({
       display_auction_link: {
         type: GraphQLBoolean,
       },
+      has_metadata: {
+        type: GraphQLBoolean,
+        resolve: ({ bio, blurb }) => {
+          return !!(bio || blurb);
+        },
+      },
       hometown: {
         type: GraphQLString,
       },
@@ -132,6 +138,8 @@ const ArtistType = new GraphQLObjectType({
               forsale_artworks_count),
             partner_shows: numeral(({ id }) =>
               total(`related/shows`, { artist_id: id })),
+            related_artists: numeral(({ id }) =>
+              total(`related/layer/main/artists`, { artist: id })),
           },
         }),
         resolve: (artist) => artist,

--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -140,6 +140,12 @@ const ArtistType = new GraphQLObjectType({
               total(`related/shows`, { artist_id: id })),
             related_artists: numeral(({ id }) =>
               total(`related/layer/main/artists`, { artist: id })),
+            articles: numeral(({ _id }) =>
+              positron('articles', {
+                artist_id: _id,
+                published: true,
+                limit: 1,
+              }).then(({ count }) => count)),
           },
         }),
         resolve: (artist) => artist,

--- a/test/schema/artist/index.js
+++ b/test/schema/artist/index.js
@@ -10,6 +10,13 @@ describe('Artist type', () => {
       Promise.resolve({
         id: 'foo-bar',
         name: 'Foo Bar',
+        bio: null,
+        blurb: null,
+      })
+    ));
+    Artist.__Rewire__('positron', sinon.stub().returns(
+      Promise.resolve({
+        count: 22,
       })
     ));
 
@@ -18,24 +25,12 @@ describe('Artist type', () => {
       .onCall(0)
       .returns(Promise.resolve(42));
     Artist.__Rewire__('total', total);
-
-    const bio = sinon.stub();
-    bio
-      .onCall(0)
-      .returns(Promise.resolve(null));
-    Artist.__Rewire__('bio', bio);
-
-    const blurb = sinon.stub();
-    blurb
-      .onCall(0)
-      .returns(Promise.resolve(null));
-    Artist.__Rewire__('blurb', blurb);
   });
 
   afterEach(() => {
     Artist.__ResetDependency__('gravity');
     Artist.__ResetDependency__('total');
-    Artist.__ResetDependency__('bio');
+    Artist.__ResetDependency__('positron');
   });
 
   it('fetches an artist by ID', () => {
@@ -87,6 +82,29 @@ describe('Artist type', () => {
           artist: {
             counts: {
               related_artists: 42,
+            },
+          },
+        });
+      });
+  });
+
+  it('returns the total number of related articles for an artist', () => {
+    const query = `
+      {
+        artist(id: "foo-bar") {
+          counts {
+            articles
+          }
+        }
+      }
+    `;
+
+    return graphql(schema, query)
+      .then(({ data }) => {
+        data.should.eql({
+          artist: {
+            counts: {
+              articles: 22,
             },
           },
         });

--- a/test/schema/artist/index.js
+++ b/test/schema/artist/index.js
@@ -18,11 +18,24 @@ describe('Artist type', () => {
       .onCall(0)
       .returns(Promise.resolve(42));
     Artist.__Rewire__('total', total);
+
+    const bio = sinon.stub();
+    bio
+      .onCall(0)
+      .returns(Promise.resolve(null));
+    Artist.__Rewire__('bio', bio);
+
+    const blurb = sinon.stub();
+    blurb
+      .onCall(0)
+      .returns(Promise.resolve(null));
+    Artist.__Rewire__('blurb', blurb);
   });
 
   afterEach(() => {
     Artist.__ResetDependency__('gravity');
     Artist.__ResetDependency__('total');
+    Artist.__ResetDependency__('bio');
   });
 
   it('fetches an artist by ID', () => {
@@ -52,6 +65,48 @@ describe('Artist type', () => {
             counts: {
               partner_shows: 42,
             },
+          },
+        });
+      });
+  });
+
+  it('returns the total number of related artists for an artist', () => {
+    const query = `
+      {
+        artist(id: "foo-bar") {
+          counts {
+            related_artists
+          }
+        }
+      }
+    `;
+
+    return graphql(schema, query)
+      .then(({ data }) => {
+        data.should.eql({
+          artist: {
+            counts: {
+              related_artists: 42,
+            },
+          },
+        });
+      });
+  });
+
+  it('returns false if artist has no metadata', () => {
+    const query = `
+      {
+        artist(id: "foo-bar") {
+          has_metadata
+        }
+      }
+    `;
+
+    return graphql(schema, query)
+      .then(({ data }) => {
+        data.should.eql({
+          artist: {
+            has_metadata: false,
           },
         });
       });


### PR DESCRIPTION
- [x] Related Artists in `counts`
- [x] `has_metadata` field
- [x] Articles
- [x] Improve tests, possibly by using `gravity` stub instead of `bio` and `blurb`