### PR TITLE
@sarahscott => [Artist] Use correct field when determining `has_metadata`.

### DIFF
--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -84,9 +84,7 @@ const ArtistType = new GraphQLObjectType({
       },
       has_metadata: {
         type: GraphQLBoolean,
-        resolve: ({ bio, blurb }) => {
-          return !!(bio || blurb);
-        },
+        resolve: ({ biography, blurb }) => !!(biography || blurb),
       },
       hometown: {
         type: GraphQLString,


### PR DESCRIPTION
This adds some tests for the permutations of `bio` + `blurb`, which I added in order to trace down [this issue](https://github.com/artsy/metaphysics/pull/298#issuecomment-223575770), however it doesn’t reveal the cause.

----

Hmm, this is weird. For [an artist that only has a bio](http://metaphysics-staging.artsy.net/?query=%7B%0A%09artist(id%3A%20%22jack-smith%22)%20%7B%0A%20%20%20%20bio%0A%20%20%20%20blurb%0A%20%20%20%20has_metadata%0A%20%20%7D%0A%7D) I’m getting unexpected results:

```json
{
  "data": {
    "artist": {
      "bio": "British, 1928-2011, Sheffield, United Kingdom",
      "blurb": null,
      "has_metadata": false
    }
  }
}
```