### PR TITLE
@alloy=>Fixed has_metadata check

### DIFF
--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -84,8 +84,8 @@ const ArtistType = new GraphQLObjectType({
       },
       has_metadata: {
         type: GraphQLBoolean,
-        resolve: ({ bio, blurb }) => {
-          return !!(bio || blurb);
+        resolve: ({ blurb, nationality, years, hometown, location }) => {
+          return !!(blurb || nationality || years || hometown || location);
         },
       },
       hometown: {


### PR DESCRIPTION
```json
{
  "data": {
    "artist": {
      "has_metadata": true,
      "bio": "British, 1928-2011, Sheffield, United Kingdom",
      "blurb": null
    }
  }
}
```

Fixes `bio` problem in #301 