### PR TITLE
@sweir27: Add bid_increment to sale artwork schema

### DIFF
--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -97,10 +97,10 @@ const ArtworkType = new GraphQLObjectType({
             description: 'Use whatever is in the original response instead of making a request',
           },
         },
-        resolve: ({ partner }, { shallow }) => {
-          if (shallow) return partner;
-          return gravity(`partner/${partner.id}`)
-            .catch(() => null);
+        resolve: (artwork, { shallow }) => {
+          if (shallow) return artwork.partner;
+          console.log(artwork.partner);
+          return gravity(`partner/${artwork.partner._id}`);
         },
       },
       embed: {

--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -97,10 +97,10 @@ const ArtworkType = new GraphQLObjectType({
             description: 'Use whatever is in the original response instead of making a request',
           },
         },
-        resolve: (artwork, { shallow }) => {
-          if (shallow) return artwork.partner;
-          console.log(artwork.partner);
-          return gravity(`partner/${artwork.partner._id}`);
+        resolve: ({ partner }, { shallow }) => {
+          if (shallow) return partner;
+          return gravity(`partner/${partner.id}`)
+            .catch(() => null);
         },
       },
       embed: {

--- a/schema/sale_artwork.js
+++ b/schema/sale_artwork.js
@@ -1,6 +1,7 @@
 import {
   assign,
   compact,
+  find,
 } from 'lodash';
 import cached from './fields/cached';
 import date from './fields/date';
@@ -214,6 +215,19 @@ const SaleArtworkType = new GraphQLObjectType({
         type: GraphQLInt,
         deprecationReason: 'Favor `counts.bidder_positions`',
       },
+      bid_increment: {
+        type: GraphQLInt,
+        resolve: ({ minimum_next_bid_cents }) => {
+          return gravity('/increments').then((res) => {
+            const deflt = find(res, { key: 'default' });
+            const bucket = find(deflt.increments, (inc) =>
+              minimum_next_bid_cents >= inc.from &&
+              minimum_next_bid_cents <= inc.to
+            )
+            return bucket.amount;
+          });
+        }
+      }
     };
   },
 });

--- a/schema/sale_artwork.js
+++ b/schema/sale_artwork.js
@@ -223,11 +223,11 @@ const SaleArtworkType = new GraphQLObjectType({
             const bucket = find(deflt.increments, (inc) =>
               minimum_next_bid_cents >= inc.from &&
               minimum_next_bid_cents <= inc.to
-            )
+            );
             return bucket.amount;
           });
-        }
-      }
+        },
+      },
     };
   },
 });

--- a/test/schema/sale_artwork.js
+++ b/test/schema/sale_artwork.js
@@ -106,8 +106,8 @@ describe('SaleArtwork type', () => {
         increments: [
           { from: 0, to: 249999, amount: 1 },
           { from: 350000, to: 500000, amount: 2 },
-        ]
-      }
+        ],
+      },
     ]));
     const query = `
       {

--- a/test/schema/sale_artwork.js
+++ b/test/schema/sale_artwork.js
@@ -3,10 +3,11 @@ import { graphql } from 'graphql';
 import schema from '../../schema';
 
 describe('SaleArtwork type', () => {
+  let gravity;
   const SaleArtwork = schema.__get__('SaleArtwork');
 
   beforeEach(() => {
-    const gravity = sinon.stub();
+    gravity = sinon.stub();
 
     gravity.returns(Promise.resolve({
       id: 'ed-ruscha-pearl-dust-combination-from-insects-portfolio',
@@ -71,7 +72,6 @@ describe('SaleArtwork type', () => {
       .then(({ data }) => {
         SaleArtwork.__get__('gravity').args[0][0]
           .should.equal('sale_artwork/54c7ed2a7261692bfa910200');
-
         data.should.eql({
           sale_artwork: {
             high_estimate: {
@@ -97,5 +97,26 @@ describe('SaleArtwork type', () => {
           },
         });
       });
+  });
+
+  it('can return the bid increment', () => {
+    gravity.onCall(1).returns(Promise.resolve([
+      {
+        key: 'default',
+        increments: [
+          { from: 0, to: 249999, amount: 1 },
+          { from: 350000, to: 500000, amount: 2 },
+        ]
+      }
+    ]));
+    const query = `
+      {
+        sale_artwork(id: "54c7ed2a7261692bfa910200") {
+          bid_increment
+        }
+      }
+    `;
+    return graphql(schema, query)
+      .then(({ data }) => data.sale_artwork.bid_increment.should.equal(2));
   });
 });


### PR DESCRIPTION
This leverages https://github.com/artsy/gravity/pull/10091 to expose a `bid_increment` field from metaphysics. Which should make it easy to populate the max bid selects.

Down the line we might replace the Gravity call with a Causality call.

![image](https://cloud.githubusercontent.com/assets/555859/15902803/d02b6ac6-2d77-11e6-8559-1dbdb3ef6c43.png)
