### PR TITLE
@broskoski: Delete keys with requests that 404

### DIFF
--- a/lib/apis/fetch.js
+++ b/lib/apis/fetch.js
@@ -1,4 +1,4 @@
-import { defaults } from 'lodash';
+import { get, defaults, compact } from 'lodash';
 import request from 'request';
 import config from '../../config';
 
@@ -11,7 +11,15 @@ export default (url, options = {}) => {
 
     request(url, opts, (err, response) => {
       if (!!err || response.statusCode !== 200) {
-        return reject(err || new Error(response.body));
+        if (err) return reject(err);
+
+        const message = compact([
+          get(response, 'request.uri.href'),
+          response.body,
+        ]).join(' - ');
+        const error = new Error(message);
+        error.statusCode = response.statusCode;
+        return reject(error);
       }
 
       try {

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -53,4 +53,12 @@ export default {
       if (err) error(err);
     });
   },
+
+  delete: (key) =>
+    new Promise((resolve, reject) =>
+      client.delete(key, (err, response) => {
+        if (err) return reject(err);
+        resolve(response);
+      })
+    ),
 };

--- a/lib/loaders/http.js
+++ b/lib/loaders/http.js
@@ -37,6 +37,12 @@ export default api => {
             .catch(err => {
               reject(err);
               error(key, err);
+
+              // If the error is a 404 then the object
+              // may exist in cache and may have been unpublished
+              if (err.statusCode === 404) {
+                cache.delete(key);
+              }
             });
         });
     });


### PR DESCRIPTION
Slightly more useful error handling as well for API errors (by including the failed URL):
![](http://static.damonzucconi.com/_capture/ZBSEm9d1G7.png)