### PR TITLE
@dzucconi: Move to the correct catch

### DIFF
--- a/lib/loaders/http.js
+++ b/lib/loaders/http.js
@@ -23,6 +23,11 @@ export default api => {
               .then(({ body }) => {
                 verbose(`Refreshing: ${key}`);
                 cache.set(key, body);
+              })
+              .catch(err => {
+                if (err.statusCode === 404) { // Unpublished
+                  cache.delete(key);
+                }
               });
           });
         }, () => {
@@ -37,12 +42,6 @@ export default api => {
             .catch(err => {
               reject(err);
               error(key, err);
-
-              // If the error is a 404 then the object
-              // may exist in cache and may have been unpublished
-              if (err.statusCode === 404) {
-                cache.delete(key);
-              }
             });
         });
     });


### PR DESCRIPTION
Should be in the request that gets fired off after the cache `get`