### PR TITLE
@craigspaeth => send bidderId instead of paddle number

### DIFF
--- a/schema/causality_jwt.js
+++ b/schema/causality_jwt.js
@@ -48,29 +48,27 @@ export default {
         gravity(`sale/${options.sale_id}`),
         gravity.with(accessToken)('me'),
         gravity.with(accessToken)('me/bidders'),
-      ]).then(([sale, me, bidders]) =>
-        find(bidders, (b) => b.sale._id === sale._id)
-
-          // ...registered users, use bidder role...
-          ? jwt.encode({
+      ]).then(([sale, me, bidders]) => {
+        const bidder = find(bidders, (b) => b.sale._id === sale._id);
+        if (bidder) {
+          return jwt.encode({
             aud: 'auctions',
             role: 'bidder',
             userId: me._id,
             saleId: sale._id,
-            bidderId: me.paddle_number,
+            bidderId: bidder.id,
             iat: new Date().getTime(),
-          }, HMAC_SECRET)
-
-          // ...otherwise use observer role
-          : jwt.encode({
-            aud: 'auctions',
-            role: 'observer',
-            userId: me._id,
-            saleId: sale._id,
-            bidderId: null,
-            iat: new Date().getTime(),
-          }, HMAC_SECRET)
-      );
+          }, HMAC_SECRET);
+        }
+        return jwt.encode({
+          aud: 'auctions',
+          role: 'observer',
+          userId: me._id,
+          saleId: sale._id,
+          bidderId: null,
+          iat: new Date().getTime(),
+        }, HMAC_SECRET);
+      });
 
     // Operator role if logged in as an admin
     } else if (options.role === 'OPERATOR' && accessToken) {

--- a/test/schema/causality_jwt.js
+++ b/test/schema/causality_jwt.js
@@ -24,7 +24,7 @@ describe('CausalityJWT', () => {
         type: 'User',
       }))
       .onCall(2)
-      .returns(Promise.resolve([{ sale: { _id: 'foo', id: 'slug' } }]));
+      .returns(Promise.resolve([{ id: 'bidder1', sale: { _id: 'foo', id: 'slug' } }]));
     CausalityJWT.__Rewire__('gravity', gravity);
   });
 
@@ -44,7 +44,7 @@ describe('CausalityJWT', () => {
             role: 'bidder',
             userId: 'craig',
             saleId: 'foo',
-            bidderId: '123',
+            bidderId: 'bidder1',
           });
       });
   });
@@ -61,7 +61,7 @@ describe('CausalityJWT', () => {
             role: 'bidder',
             userId: 'craig',
             saleId: 'foo',
-            bidderId: '123',
+            bidderId: 'bidder1',
           });
       });
   });


### PR DESCRIPTION
With the breaking causality changes, we have to send `bidderId` instead of `paddleNumber` in the jwt so they can be matched with the user's `bidderId` in subsequent requests.