### PR TITLE
Relay Global Object Identification support.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
   "presets": ["es2015"],
+  "plugins": ["transform-object-rest-spread"],
   "env": {
     "test": {
       "plugins": ["rewire"]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,7 @@
     "es6": true
   },
   "extends": "airbnb",
+  "parser": "babel-eslint",
   "rules": {
     "camelcase": 0
   }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -39,6 +39,11 @@
       "from": "acorn-globals@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz"
     },
+    "acorn-to-esprima": {
+      "version": "2.0.8",
+      "from": "acorn-to-esprima@>=2.0.4 <3.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-to-esprima/-/acorn-to-esprima-2.0.8.tgz"
+    },
     "agent-base": {
       "version": "1.0.2",
       "from": "agent-base@>=1.0.1 <1.1.0",
@@ -92,7 +97,19 @@
     "are-we-there-yet": {
       "version": "1.1.2",
       "from": "are-we-there-yet@~1.1.2",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        },
+        "readable-stream": {
+          "version": "2.1.4",
+          "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+        }
+      }
     },
     "argparse": {
       "version": "1.0.3",
@@ -320,6 +337,11 @@
         }
       }
     },
+    "babel-eslint": {
+      "version": "5.0.4",
+      "from": "babel-eslint@>=5.0.4 <6.0.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-5.0.4.tgz"
+    },
     "babel-generator": {
       "version": "6.3.15",
       "from": "babel-generator@>=6.3.15 <7.0.0",
@@ -506,21 +528,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.3.13.tgz"
     },
     "babel-plugin-transform-es2015-spread": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-spread@latest",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
-      "dependencies": {
-        "babel-runtime": {
-          "version": "6.9.2",
-          "from": "babel-runtime@>=6.0.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz"
-        },
-        "core-js": {
-          "version": "2.4.0",
-          "from": "core-js@>=2.4.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz"
-        }
-      }
+      "version": "6.3.14",
+      "from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.3.14.tgz"
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.3.13",
@@ -544,7 +554,7 @@
     },
     "babel-plugin-transform-object-rest-spread": {
       "version": "6.8.0",
-      "from": "babel-plugin-transform-object-rest-spread@latest",
+      "from": "babel-plugin-transform-object-rest-spread@>=6.8.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.8.0.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -732,6 +742,11 @@
       "version": "1.8.2",
       "from": "braces@>=1.8.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.2.tgz"
+    },
+    "buffer-shims": {
+      "version": "1.0.0",
+      "from": "buffer-shims@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -1430,6 +1445,11 @@
       "from": "fs-readdir-recursive@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
     },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "from": "fs.realpath@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+    },
     "fsevents": {
       "version": "1.0.12",
       "from": "fsevents@1.0.12",
@@ -1445,7 +1465,14 @@
     "fstream": {
       "version": "1.0.8",
       "from": "fstream@^1.0.2",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.4",
+          "from": "graceful-fs@>=4.1.2 <5.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
+        }
+      }
     },
     "fstream-ignore": {
       "version": "1.0.3",
@@ -2184,6 +2211,11 @@
       "version": "4.2.0",
       "from": "lodash.padstart@^4.1.0",
       "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.2.0.tgz"
+    },
+    "lodash.pick": {
+      "version": "3.1.0",
+      "from": "lodash.pick@>=3.1.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-3.1.0.tgz"
     },
     "lodash.repeat": {
       "version": "4.0.0",
@@ -3198,7 +3230,34 @@
     "tar-pack": {
       "version": "3.1.3",
       "from": "tar-pack@~3.1.0",
-      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.3.tgz"
+      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.3.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "7.0.5",
+          "from": "glob@>=7.0.5 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@~1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        },
+        "minimatch": {
+          "version": "3.0.2",
+          "from": "minimatch@>=3.0.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz"
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "from": "readable-stream@>=2.0.4 <2.1.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+        },
+        "rimraf": {
+          "version": "2.5.3",
+          "from": "rimraf@>=2.5.1 <2.6.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.3.tgz"
+        }
+      }
     },
     "text-table": {
       "version": "0.2.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -416,6 +416,23 @@
       "from": "babel-plugin-syntax-async-functions@>=6.3.13 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.3.13.tgz"
     },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.8.0",
+      "from": "babel-plugin-syntax-object-rest-spread@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.8.0.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.9.2",
+          "from": "babel-runtime@^6.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz"
+        },
+        "core-js": {
+          "version": "2.4.0",
+          "from": "core-js@>=2.4.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz"
+        }
+      }
+    },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.3.13",
       "from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
@@ -489,9 +506,21 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.3.13.tgz"
     },
     "babel-plugin-transform-es2015-spread": {
-      "version": "6.3.14",
-      "from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.3.14.tgz"
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-spread@latest",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.9.2",
+          "from": "babel-runtime@>=6.0.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz"
+        },
+        "core-js": {
+          "version": "2.4.0",
+          "from": "core-js@>=2.4.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz"
+        }
+      }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.3.13",
@@ -512,6 +541,23 @@
       "version": "6.3.13",
       "from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.3.13.tgz"
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-object-rest-spread@latest",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.8.0.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.9.2",
+          "from": "babel-runtime@>=6.0.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz"
+        },
+        "core-js": {
+          "version": "2.4.0",
+          "from": "core-js@^2.4.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz"
+        }
+      }
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.3.13",
@@ -2788,6 +2834,11 @@
       "version": "1.2.1",
       "from": "regenerate@>=1.2.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+    },
+    "regenerator-runtime": {
+      "version": "0.9.5",
+      "from": "regenerator-runtime@>=0.9.5 <0.10.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz"
     },
     "regex-cache": {
       "version": "0.4.2",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -39,6 +39,11 @@
       "from": "acorn-globals@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz"
     },
+    "agent-base": {
+      "version": "1.0.2",
+      "from": "agent-base@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-1.0.2.tgz"
+    },
     "align-text": {
       "version": "0.1.3",
       "from": "align-text@>=0.1.0 <0.2.0",
@@ -48,6 +53,11 @@
       "version": "1.0.0",
       "from": "amdefine@>=0.0.4",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+    },
+    "ansi": {
+      "version": "0.3.1",
+      "from": "ansi@~0.3.1",
+      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
     },
     "ansi-escapes": {
       "version": "1.1.1",
@@ -78,6 +88,11 @@
       "version": "1.3.0",
       "from": "anymatch@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz"
+    },
+    "are-we-there-yet": {
+      "version": "1.1.2",
+      "from": "are-we-there-yet@~1.1.2",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
     },
     "argparse": {
       "version": "1.0.3",
@@ -647,6 +662,11 @@
         }
       }
     },
+    "block-stream": {
+      "version": "0.0.8",
+      "from": "block-stream@*",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+    },
     "bluebird": {
       "version": "3.3.4",
       "from": "bluebird@latest",
@@ -931,6 +951,11 @@
       "version": "0.0.5",
       "from": "delayed-stream@0.0.5",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "from": "delegates@^1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
     },
     "depd": {
       "version": "1.0.1",
@@ -1360,572 +1385,57 @@
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
     },
     "fsevents": {
-      "version": "1.0.5",
-      "from": "fsevents@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.5.tgz",
+      "version": "1.0.12",
+      "from": "fsevents@1.0.12",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.12.tgz",
       "dependencies": {
-        "abbrev": {
-          "version": "1.0.7",
-          "from": "abbrev@1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-        },
-        "ansi": {
-          "version": "0.3.0",
-          "from": "ansi@~0.3.0",
-          "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
-        },
-        "ansi-regex": {
-          "version": "2.0.0",
-          "from": "ansi-regex@^2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-        },
-        "ansi-styles": {
-          "version": "2.1.0",
-          "from": "ansi-styles@^2.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-        },
-        "are-we-there-yet": {
-          "version": "1.0.4",
-          "from": "are-we-there-yet@~1.0.0",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz"
-        },
-        "asn1": {
-          "version": "0.1.11",
-          "from": "asn1@0.1.11",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-        },
-        "assert-plus": {
-          "version": "0.1.5",
-          "from": "assert-plus@^0.1.5",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-        },
-        "async": {
-          "version": "1.5.0",
-          "from": "async@^1.4.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "from": "aws-sign2@~0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-        },
-        "balanced-match": {
-          "version": "0.2.1",
-          "from": "balanced-match@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
-        },
-        "bl": {
-          "version": "1.0.0",
-          "from": "bl@~1.0.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.4",
-              "from": "readable-stream@~2.0.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.3",
-                  "from": "process-nextick-args@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "util-deprecate@~1.0.1",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            }
-          }
-        },
-        "block-stream": {
-          "version": "0.0.8",
-          "from": "block-stream@*",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
-        },
-        "boom": {
-          "version": "2.10.1",
-          "from": "boom@^2.8.x",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-        },
-        "brace-expansion": {
-          "version": "1.1.1",
-          "from": "brace-expansion@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz"
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "from": "caseless@~0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-        },
-        "chalk": {
-          "version": "1.1.1",
-          "from": "chalk@^1.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "from": "combined-stream@~1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
-        },
-        "commander": {
-          "version": "2.9.0",
-          "from": "commander@^2.8.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "from": "concat-map@0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-        },
-        "core-util-is": {
-          "version": "1.0.1",
-          "from": "core-util-is@~1.0.0",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "from": "cryptiles@2.x.x",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-        },
-        "ctype": {
-          "version": "0.5.3",
-          "from": "ctype@0.5.3",
-          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-        },
-        "debug": {
-          "version": "0.7.4",
-          "from": "debug@~0.7.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-        },
-        "deep-extend": {
-          "version": "0.2.11",
-          "from": "deep-extend@~0.2.5",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "from": "delayed-stream@~1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-        },
-        "delegates": {
-          "version": "0.1.0",
-          "from": "delegates@^0.1.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
-        },
-        "escape-string-regexp": {
-          "version": "1.0.3",
-          "from": "escape-string-regexp@^1.0.2",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-        },
-        "extend": {
-          "version": "3.0.0",
-          "from": "extend@~3.0.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "from": "forever-agent@~0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-        },
-        "form-data": {
-          "version": "1.0.0-rc3",
-          "from": "form-data@~1.0.0-rc3",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
-        },
-        "fstream": {
-          "version": "1.0.8",
-          "from": "fstream@^1.0.2",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
-        },
-        "fstream-ignore": {
-          "version": "1.0.3",
-          "from": "fstream-ignore@~1.0.3",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
-          "dependencies": {
-            "minimatch": {
-              "version": "3.0.0",
-              "from": "minimatch@>=3.0.0 <4.0.0"
-            }
-          }
-        },
-        "gauge": {
-          "version": "1.2.2",
-          "from": "gauge@~1.2.0",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz"
-        },
-        "generate-function": {
-          "version": "2.0.0",
-          "from": "generate-function@^2.0.0",
-          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-        },
-        "generate-object-property": {
-          "version": "1.2.0",
-          "from": "generate-object-property@^1.1.0",
-          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
-        },
-        "graceful-fs": {
-          "version": "4.1.2",
-          "from": "graceful-fs@4.1",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-        },
-        "graceful-readlink": {
-          "version": "1.0.1",
-          "from": "graceful-readlink@>= 1.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-        },
-        "har-validator": {
-          "version": "2.0.2",
-          "from": "har-validator@~2.0.2",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.2.tgz"
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "from": "has-ansi@^2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-        },
-        "has-unicode": {
-          "version": "1.0.1",
-          "from": "has-unicode@^1.0.0",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
-        },
-        "hawk": {
-          "version": "3.1.0",
-          "from": "hawk@~3.1.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz"
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "from": "hoek@2.x.x",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-        },
-        "http-signature": {
-          "version": "0.11.0",
-          "from": "http-signature@~0.11.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz"
-        },
-        "inflight": {
-          "version": "1.0.4",
-          "from": "inflight@>=1.0.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-          "dependencies": {
-            "once": {
-              "version": "1.3.2",
-              "from": "once@>=1.3.0 <2.0.0"
-            }
-          }
-        },
-        "inherits": {
-          "version": "2.0.1",
-          "from": "inherits@*",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-        },
-        "ini": {
-          "version": "1.3.4",
-          "from": "ini@~1.3.0",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-        },
-        "is-my-json-valid": {
-          "version": "2.12.2",
-          "from": "is-my-json-valid@^2.12.2",
-          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz"
-        },
-        "is-property": {
-          "version": "1.0.2",
-          "from": "is-property@^1.0.0",
-          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "from": "isstream@~0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "from": "json-stringify-safe@~5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-        },
-        "jsonpointer": {
-          "version": "2.0.0",
-          "from": "jsonpointer@2.0.0",
-          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
-        },
-        "lodash._basetostring": {
-          "version": "3.0.1",
-          "from": "lodash._basetostring@^3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
-        },
-        "lodash._createpadding": {
-          "version": "3.6.1",
-          "from": "lodash._createpadding@^3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
-        },
-        "lodash.pad": {
-          "version": "3.1.1",
-          "from": "lodash.pad@^3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
-        },
-        "lodash.padleft": {
-          "version": "3.1.1",
-          "from": "lodash.padleft@^3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
-        },
-        "lodash.padright": {
-          "version": "3.1.1",
-          "from": "lodash.padright@^3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
-        },
-        "lodash.repeat": {
-          "version": "3.0.1",
-          "from": "lodash.repeat@^3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
-        },
-        "mime-db": {
-          "version": "1.19.0",
-          "from": "mime-db@~1.19.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
-        },
-        "mime-types": {
-          "version": "2.1.7",
-          "from": "mime-types@~2.1.7",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz"
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "from": "minimist@0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-        },
-        "node-pre-gyp": {
-          "version": "0.6.15",
-          "from": "node-pre-gyp@latest",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.15.tgz",
-          "dependencies": {
-            "nopt": {
-              "version": "3.0.4",
-              "from": "nopt@>=3.0.1 <3.1.0",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz"
-            }
-          }
-        },
-        "node-uuid": {
-          "version": "1.4.3",
-          "from": "node-uuid@~1.4.3",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
-        },
-        "npmlog": {
-          "version": "1.2.1",
-          "from": "npmlog@~1.2.0",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz"
-        },
-        "oauth-sign": {
-          "version": "0.8.0",
-          "from": "oauth-sign@~0.8.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
-        },
-        "once": {
-          "version": "1.1.1",
-          "from": "once@~1.1.1",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
-        },
-        "path-is-absolute": {
-          "version": "1.0.0",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-        },
-        "pinkie": {
-          "version": "1.0.0",
-          "from": "pinkie@^1.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
-        },
-        "pinkie-promise": {
-          "version": "1.0.0",
-          "from": "pinkie-promise@^1.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz"
-        },
-        "qs": {
-          "version": "5.2.0",
-          "from": "qs@~5.2.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
-        },
-        "rc": {
-          "version": "1.1.2",
-          "from": "rc@~1.1.0",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.2.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "from": "minimist@^1.1.2",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "1.1.13",
-          "from": "readable-stream@^1.1.13",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
-        },
-        "request": {
-          "version": "2.65.0",
-          "from": "request@2.x",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz"
-        },
-        "rimraf": {
-          "version": "2.4.3",
-          "from": "rimraf@~2.4.0",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "5.0.15",
-              "from": "glob@>=5.0.14 <6.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
-            },
-            "minimatch": {
-              "version": "3.0.0",
-              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
-            },
-            "once": {
-              "version": "1.3.2",
-              "from": "once@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz"
-            }
-          }
-        },
-        "semver": {
-          "version": "5.0.3",
-          "from": "semver@~5.0.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "from": "sntp@1.x.x",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "from": "string_decoder@~0.10.x",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "from": "stringstream@~0.0.4",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-        },
-        "strip-ansi": {
-          "version": "3.0.0",
-          "from": "strip-ansi@^3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
-        },
-        "strip-json-comments": {
-          "version": "0.1.3",
-          "from": "strip-json-comments@0.1.x",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "from": "supports-color@^2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-        },
-        "tar": {
-          "version": "2.2.1",
-          "from": "tar@~2.2.0",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
-        },
-        "tar-pack": {
-          "version": "3.1.0",
-          "from": "tar-pack@~3.1.0",
-          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.0.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "readable-stream@~1.0.2",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                }
-              }
-            },
-            "rimraf": {
-              "version": "2.2.8",
-              "from": "rimraf@~2.2.0",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-            }
-          }
-        },
-        "tough-cookie": {
-          "version": "2.2.0",
-          "from": "tough-cookie@~2.2.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
-        },
-        "tunnel-agent": {
-          "version": "0.4.1",
-          "from": "tunnel-agent@~0.4.1",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-        },
-        "uid-number": {
-          "version": "0.0.3",
-          "from": "uid-number@0.0.3",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
-        },
-        "wrappy": {
-          "version": "1.0.1",
-          "from": "wrappy@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@^4.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+        "nan": {
+          "version": "2.3.5",
+          "from": "nan@>=2.3.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz"
         }
       }
+    },
+    "fstream": {
+      "version": "1.0.8",
+      "from": "fstream@^1.0.2",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
+    },
+    "fstream-ignore": {
+      "version": "1.0.3",
+      "from": "fstream-ignore@~1.0.3",
+      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.0",
+          "from": "minimatch@^3.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.3",
+              "from": "brace-expansion@^1.0.0",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.3.0",
+                  "from": "balanced-match@^0.3.0",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gauge": {
+      "version": "1.2.7",
+      "from": "gauge@~1.2.5",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz"
     },
     "generate-function": {
       "version": "2.0.0",
@@ -2057,6 +1567,11 @@
       "from": "has-ansi@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
     },
+    "has-unicode": {
+      "version": "2.0.0",
+      "from": "has-unicode@^2.0.0",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
+    },
     "hawk": {
       "version": "3.1.2",
       "from": "hawk@>=3.1.0 <3.2.0",
@@ -2091,6 +1606,18 @@
       "version": "1.1.0",
       "from": "http-signature@>=1.1.0 <1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz"
+    },
+    "https-proxy-agent": {
+      "version": "0.3.6",
+      "from": "https-proxy-agent@>=0.3.5 <0.4.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-0.3.6.tgz",
+      "dependencies": {
+        "extend": {
+          "version": "3.0.0",
+          "from": "extend@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+        }
+      }
     },
     "i": {
       "version": "0.3.5",
@@ -2597,6 +2124,26 @@
       "from": "lodash.omit@>=3.1.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz"
     },
+    "lodash.pad": {
+      "version": "4.1.0",
+      "from": "lodash.pad@^4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.1.0.tgz"
+    },
+    "lodash.padend": {
+      "version": "4.2.0",
+      "from": "lodash.padend@^4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.2.0.tgz"
+    },
+    "lodash.padstart": {
+      "version": "4.2.0",
+      "from": "lodash.padstart@^4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.2.0.tgz"
+    },
+    "lodash.repeat": {
+      "version": "4.0.0",
+      "from": "lodash.repeat@^4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz"
+    },
     "lodash.restparam": {
       "version": "3.6.1",
       "from": "lodash.restparam@>=3.0.0 <4.0.0",
@@ -2606,6 +2153,11 @@
       "version": "3.0.0",
       "from": "lodash.toplainobject@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz"
+    },
+    "lodash.tostring": {
+      "version": "4.1.2",
+      "from": "lodash.tostring@^4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz"
     },
     "log-symbols": {
       "version": "1.0.2",
@@ -2679,7 +2231,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.1.3 <2.0.0"
+          "from": "minimist@1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         }
       }
     },
@@ -2804,11 +2357,6 @@
       "from": "mute-stream@0.0.5",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
     },
-    "nan": {
-      "version": "2.1.0",
-      "from": "nan@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
-    },
     "negotiator": {
       "version": "0.5.3",
       "from": "negotiator@0.5.3",
@@ -2824,89 +2372,6 @@
       "from": "newrelic@>=1.22.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-1.24.0.tgz",
       "dependencies": {
-        "concat-stream": {
-          "version": "1.5.1",
-          "from": "concat-stream@>=1.5.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "readable-stream": {
-              "version": "2.0.4",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.3",
-                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            },
-            "typedarray": {
-              "version": "0.0.6",
-              "from": "typedarray@>=0.0.5 <0.1.0",
-              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-            }
-          }
-        },
-        "https-proxy-agent": {
-          "version": "0.3.6",
-          "from": "https-proxy-agent@>=0.3.5 <0.4.0",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-0.3.6.tgz",
-          "dependencies": {
-            "agent-base": {
-              "version": "1.0.2",
-              "from": "agent-base@>=1.0.1 <1.1.0",
-              "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-1.0.2.tgz"
-            },
-            "debug": {
-              "version": "2.2.0",
-              "from": "debug@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.1",
-                  "from": "ms@0.7.1",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                }
-              }
-            },
-            "extend": {
-              "version": "3.0.0",
-              "from": "extend@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-            }
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "from": "json-stringify-safe@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-        },
         "readable-stream": {
           "version": "1.1.13",
           "from": "readable-stream@>=1.1.13 <2.0.0",
@@ -2938,11 +2403,25 @@
           "version": "4.3.6",
           "from": "semver@>=4.2.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
-        },
-        "yakaa": {
-          "version": "1.0.1",
-          "from": "yakaa@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/yakaa/-/yakaa-1.0.1.tgz"
+        }
+      }
+    },
+    "node-pre-gyp": {
+      "version": "0.6.25",
+      "from": "node-pre-gyp@0.6.25",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.25.tgz",
+      "dependencies": {
+        "nopt": {
+          "version": "3.0.6",
+          "from": "nopt@~3.0.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.7",
+              "from": "abbrev@1",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+            }
+          }
         }
       }
     },
@@ -2977,6 +2456,11 @@
       "version": "2.0.1",
       "from": "normalize-path@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
+    },
+    "npmlog": {
+      "version": "2.0.3",
+      "from": "npmlog@~2.0.0",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.3.tgz"
     },
     "number-is-nan": {
       "version": "1.0.0",
@@ -3655,6 +3139,16 @@
       "from": "supports-color@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
     },
+    "tar": {
+      "version": "2.2.1",
+      "from": "tar@~2.2.0",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+    },
+    "tar-pack": {
+      "version": "3.1.3",
+      "from": "tar-pack@~3.1.0",
+      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.3.tgz"
+    },
     "text-table": {
       "version": "0.2.0",
       "from": "text-table@>=0.2.0 <0.3.0",
@@ -3786,6 +3280,11 @@
       "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
     },
+    "uid-number": {
+      "version": "0.0.6",
+      "from": "uid-number@~0.0.6",
+      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
+    },
     "undefsafe": {
       "version": "0.0.3",
       "from": "undefsafe@0.0.3",
@@ -3914,6 +3413,11 @@
       "version": "4.0.1",
       "from": "xtend@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+    },
+    "yakaa": {
+      "version": "1.0.1",
+      "from": "yakaa@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/yakaa/-/yakaa-1.0.1.tgz"
     },
     "yargs": {
       "version": "3.10.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -515,11 +515,13 @@
       "dependencies": {
         "babel-runtime": {
           "version": "6.6.1",
-          "from": "babel-runtime@>=6.0.0 <7.0.0"
+          "from": "babel-runtime@6.6.1",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.6.1.tgz"
         },
         "core-js": {
           "version": "2.4.0",
-          "from": "core-js@>=2.1.0 <3.0.0"
+          "from": "core-js@2.4.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz"
         }
       }
     },
@@ -2011,6 +2013,11 @@
       "from": "graphql@>=0.4.13 <0.5.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.4.14.tgz"
     },
+    "graphql-relay": {
+      "version": "0.3.6",
+      "from": "graphql-relay@>=0.3.6 <0.4.0",
+      "resolved": "https://registry.npmjs.org/graphql-relay/-/graphql-relay-0.3.6.tgz"
+    },
     "growl": {
       "version": "1.8.1",
       "from": "growl@1.8.1",
@@ -3093,7 +3100,8 @@
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.4",
-          "from": "graceful-fs@>=4.1.2 <5.0.0"
+          "from": "graceful-fs@4.1.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "artsy-xapp": "^1.0.4",
     "babel": "6.3.13",
     "babel-core": "^6.2.4",
+    "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-preset-es2015": "^6.1.18",
     "basic-auth": "^1.0.3",
     "bluebird": "^3.3.4",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "express-graphql": "^0.4.4",
     "graphiql": "^0.3.1",
     "graphql": "^0.4.13",
+    "graphql-relay": "^0.3.6",
     "i": "^0.3.5",
     "jwt-simple": "^0.5.0",
     "lodash": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",
+    "babel-eslint": "^5.0.4",
     "babel-plugin-rewire": "1.0.0-beta-2",
     "deep-equal": "^1.0.1",
     "eslint": "^1.10.3",

--- a/schema/aggregations/aggregation_count.js
+++ b/schema/aggregations/aggregation_count.js
@@ -1,3 +1,4 @@
+import { IDFields } from '../object_identification';
 import {
   GraphQLObjectType,
   GraphQLString,
@@ -8,9 +9,7 @@ export const AggregationCountType = new GraphQLObjectType({
   name: 'AggregationCount',
   description: 'One item in an aggregation',
   fields: {
-    id: {
-      type: GraphQLString,
-    },
+    ...IDFields,
     name: {
       type: GraphQLString,
     },

--- a/schema/article.js
+++ b/schema/article.js
@@ -3,8 +3,9 @@ import cached from './fields/cached';
 import AuthorType from './author';
 import Image from './image';
 import date from './fields/date';
-import ObjectIdentification from './object_identification';
+import { IDFields, NodeInterface } from './object_identification';
 import {
+  GraphQLID,
   GraphQLString,
   GraphQLObjectType,
   GraphQLNonNull,
@@ -12,13 +13,10 @@ import {
 
 const ArticleType = new GraphQLObjectType({
   name: 'Article',
-  interfaces: [ObjectIdentification.NodeInterface],
+  interfaces: [NodeInterface],
   fields: () => ({
+    ...IDFields,
     cached,
-    __id: ObjectIdentification.GlobalIDField,
-    id: {
-      type: GraphQLString,
-    },
     title: {
       type: GraphQLString,
     },
@@ -53,7 +51,7 @@ const Article = {
   description: 'An Article',
   args: {
     id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNull(GraphQLID),
       description: 'The ID of the Article',
     },
   },

--- a/schema/article.js
+++ b/schema/article.js
@@ -58,6 +58,8 @@ const Article = {
     },
   },
   resolve: (root, { id }) => positron(`articles/${id}`),
+  // ObjectIdentification
+  isType: (obj) => obj.title !== undefined && obj.author !== undefined,
 };
 
 export default Article;

--- a/schema/article.js
+++ b/schema/article.js
@@ -3,6 +3,7 @@ import cached from './fields/cached';
 import AuthorType from './author';
 import Image from './image';
 import date from './fields/date';
+import ObjectIdentification from './object_identification';
 import {
   GraphQLString,
   GraphQLObjectType,
@@ -11,8 +12,10 @@ import {
 
 const ArticleType = new GraphQLObjectType({
   name: 'Article',
+  interfaces: [ObjectIdentification.NodeInterface],
   fields: () => ({
     cached,
+    __id: ObjectIdentification.GlobalIDField,
     id: {
       type: GraphQLString,
     },

--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -27,6 +27,7 @@ import ArtistStatuses from './statuses';
 import gravity from '../../lib/loaders/gravity';
 import positron from '../../lib/loaders/positron';
 import total from '../../lib/loaders/total';
+import ObjectIdentification from '../object_identification';
 import {
   GraphQLObjectType,
   GraphQLBoolean,
@@ -39,9 +40,11 @@ import {
 
 const ArtistType = new GraphQLObjectType({
   name: 'Artist',
+  interfaces: [ObjectIdentification.NodeInterface],
   fields: () => {
     return {
       cached,
+      __id: ObjectIdentification.GlobalIDField,
       _id: {
         type: GraphQLString,
       },

--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -491,6 +491,8 @@ const Artist = {
     },
   },
   resolve: (root, { id }) => gravity(`artist/${id}`),
+  // ObjectIdentification
+  isType: (obj) => obj.birthday !== undefined && obj.artworks_count !== undefined,
 };
 
 export default Artist;

--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -27,10 +27,11 @@ import ArtistStatuses from './statuses';
 import gravity from '../../lib/loaders/gravity';
 import positron from '../../lib/loaders/positron';
 import total from '../../lib/loaders/total';
-import ObjectIdentification from '../object_identification';
+import { GravityIDFields, NodeInterface } from '../object_identification';
 import {
   GraphQLObjectType,
   GraphQLBoolean,
+  GraphQLID,
   GraphQLString,
   GraphQLNonNull,
   GraphQLList,
@@ -40,17 +41,11 @@ import {
 
 const ArtistType = new GraphQLObjectType({
   name: 'Artist',
-  interfaces: [ObjectIdentification.NodeInterface],
+  interfaces: [NodeInterface],
   fields: () => {
     return {
+      ...GravityIDFields,
       cached,
-      __id: ObjectIdentification.GlobalIDField,
-      _id: {
-        type: GraphQLString,
-      },
-      id: {
-        type: GraphQLString,
-      },
       href: {
         type: GraphQLString,
         resolve: (artist) => `/artist/${artist.id}`,
@@ -487,7 +482,7 @@ const Artist = {
   args: {
     id: {
       description: 'The slug or ID of the Artist',
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNull(GraphQLID),
     },
   },
   resolve: (root, { id }) => gravity(`artist/${id}`),

--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -29,6 +29,7 @@ import ArtworkLayer from './layer';
 import ArtworkLayers, { artworkLayers } from './layers';
 import gravity from '../../lib/loaders/gravity';
 import positron from '../../lib/loaders/positron';
+import ObjectIdentification from '../object_identification';
 import {
   GraphQLObjectType,
   GraphQLBoolean,
@@ -40,9 +41,11 @@ import {
 
 const ArtworkType = new GraphQLObjectType({
   name: 'Artwork',
+  interfaces: [ObjectIdentification.NodeInterface],
   fields: () => {
     return {
       cached,
+      __id: ObjectIdentification.GlobalIDField,
       id: {
         type: GraphQLString,
       },

--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -29,10 +29,11 @@ import ArtworkLayer from './layer';
 import ArtworkLayers, { artworkLayers } from './layers';
 import gravity from '../../lib/loaders/gravity';
 import positron from '../../lib/loaders/positron';
-import ObjectIdentification from '../object_identification';
+import { GravityIDFields, NodeInterface } from '../object_identification';
 import {
   GraphQLObjectType,
   GraphQLBoolean,
+  GraphQLID,
   GraphQLString,
   GraphQLNonNull,
   GraphQLList,
@@ -41,17 +42,11 @@ import {
 
 const ArtworkType = new GraphQLObjectType({
   name: 'Artwork',
-  interfaces: [ObjectIdentification.NodeInterface],
+  interfaces: [NodeInterface],
   fields: () => {
     return {
+      ...GravityIDFields,
       cached,
-      __id: ObjectIdentification.GlobalIDField,
-      id: {
-        type: GraphQLString,
-      },
-      _id: {
-        type: GraphQLString,
-      },
       to_s: {
         type: GraphQLString,
         resolve: ({ artist, title, date, partner }) => {
@@ -435,7 +430,7 @@ const ArtworkType = new GraphQLObjectType({
         type: ArtworkLayer.type,
         args: {
           id: {
-            type: GraphQLString,
+            type: GraphQLID,
           },
         },
         resolve: (artwork, { id }) =>
@@ -457,7 +452,7 @@ const Artwork = {
   description: 'An Artwork',
   args: {
     id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNull(GraphQLID),
       description: 'The slug or ID of the Artwork',
     },
   },

--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -462,6 +462,8 @@ const Artwork = {
     },
   },
   resolve: (root, { id }) => gravity(`artwork/${id}`),
+  // ObjectIdentification
+  isType: (obj) => obj.title !== undefined && obj.artists !== undefined,
 };
 
 export default Artwork;

--- a/schema/artwork/layer.js
+++ b/schema/artwork/layer.js
@@ -1,5 +1,6 @@
 import Artwork from './index';
 import gravity from '../../lib/loaders/gravity';
+import { IDFields } from '../object_identification';
 import {
   GraphQLObjectType,
   GraphQLString,
@@ -9,9 +10,7 @@ import {
 const ArtworkLayerType = new GraphQLObjectType({
   name: 'ArtworkLayer',
   fields: () => ({
-    id: {
-      type: GraphQLString,
-    },
+    ...IDFields,
     type: {
       type: GraphQLString,
     },

--- a/schema/author.js
+++ b/schema/author.js
@@ -1,3 +1,4 @@
+import { IDFields } from './object_identification';
 import {
   GraphQLString,
   GraphQLObjectType,
@@ -6,9 +7,7 @@ import {
 const AuthorType = new GraphQLObjectType({
   name: 'Author',
   fields: {
-    id: {
-      type: GraphQLString,
-    },
+    ...IDFields,
     name: {
       type: GraphQLString,
     },

--- a/schema/author.js
+++ b/schema/author.js
@@ -18,7 +18,7 @@ const AuthorType = new GraphQLObjectType({
     href: {
       type: GraphQLString,
       resolve: ({ profile_handle }) => `/${profile_handle}`,
-      deprecationReason: "Profiles and thus artist hrefs don't exist anymore",
+      deprecationReason: "Profiles have been removed and thus author hrefs don't exist anymore.",
     },
   },
 });

--- a/schema/bidder.js
+++ b/schema/bidder.js
@@ -1,5 +1,6 @@
 import date from './fields/date';
 import Sale from './sale/index';
+import { IDFields } from './object_identification';
 import {
   GraphQLString,
   GraphQLObjectType,
@@ -9,9 +10,7 @@ import {
 const BidderType = new GraphQLObjectType({
   name: 'Bidder',
   fields: () => ({
-    id: {
-      type: GraphQLString,
-    },
+    ...IDFields,
     created_at: date,
     pin: {
       type: GraphQLString,

--- a/schema/bidder_position.js
+++ b/schema/bidder_position.js
@@ -3,6 +3,7 @@ import gravity from '../lib/loaders/gravity';
 import date from './fields/date';
 import money, { amount } from './fields/money';
 import SaleArtwork from './sale_artwork';
+import { IDFields } from './object_identification';
 import {
   GraphQLInt,
   GraphQLBoolean,
@@ -13,9 +14,7 @@ import {
 const BidderPositionType = new GraphQLObjectType({
   name: 'BidderPosition',
   fields: () => ({
-    id: {
-      type: GraphQLString,
-    },
+    ...IDFields,
     created_at: date,
     updated_at: date,
     processed_at: date,
@@ -61,9 +60,7 @@ const BidderPositionType = new GraphQLObjectType({
       type: new GraphQLObjectType({
         name: 'HighestBid',
         fields: {
-          id: {
-            type: GraphQLString,
-          },
+          ...IDFields,
           created_at: date,
           number: {
             type: GraphQLInt,

--- a/schema/edition_set.js
+++ b/schema/edition_set.js
@@ -1,17 +1,16 @@
 import { isEmpty } from 'lodash';
+import { IDFields } from './object_identification';
+import Dimensions from './dimensions';
 import {
   GraphQLString,
   GraphQLBoolean,
   GraphQLObjectType,
 } from 'graphql';
-import Dimensions from './dimensions';
 
 const EditionSetType = new GraphQLObjectType({
   name: 'EditionSet',
   fields: {
-    id: {
-      type: GraphQLString,
-    },
+    ...IDFields,
     dimensions: Dimensions,
     edition_of: {
       type: GraphQLString,

--- a/schema/fair.js
+++ b/schema/fair.js
@@ -11,6 +11,15 @@ import {
   GraphQLNonNull,
 } from 'graphql';
 
+const OrganizerType = new GraphQLObjectType({
+  name: 'organizer',
+  fields: {
+    profile_id: {
+      type: GraphQLString,
+    },
+  },
+});
+
 const FairType = new GraphQLObjectType({
   name: 'Fair',
   fields: () => ({
@@ -75,14 +84,7 @@ const FairType = new GraphQLObjectType({
       resolve: ({ published }) => published,
     },
     organizer: {
-      type: new GraphQLObjectType({
-        name: 'organizer',
-        fields: {
-          profile_id: {
-            type: GraphQLString,
-          },
-        },
-      }),
+      type: OrganizerType,
     },
   }),
 });

--- a/schema/fair.js
+++ b/schema/fair.js
@@ -13,7 +13,7 @@ import {
   GraphQLNonNull,
 } from 'graphql';
 
-const OrganizerType = new GraphQLObjectType({
+const FairOrganizerType = new GraphQLObjectType({
   name: 'organizer',
   fields: {
     profile_id: {
@@ -81,7 +81,7 @@ const FairType = new GraphQLObjectType({
       resolve: ({ published }) => published,
     },
     organizer: {
-      type: OrganizerType,
+      type: FairOrganizerType,
     },
   }),
 });

--- a/schema/fair.js
+++ b/schema/fair.js
@@ -4,8 +4,10 @@ import date from './fields/date';
 import Profile from './profile';
 import Image from './image';
 import Location from './location';
+import { GravityIDFields } from './object_identification';
 import {
   GraphQLObjectType,
+  GraphQLID,
   GraphQLString,
   GraphQLBoolean,
   GraphQLNonNull,
@@ -15,7 +17,7 @@ const OrganizerType = new GraphQLObjectType({
   name: 'organizer',
   fields: {
     profile_id: {
-      type: GraphQLString,
+      type: GraphQLID,
     },
   },
 });
@@ -23,13 +25,8 @@ const OrganizerType = new GraphQLObjectType({
 const FairType = new GraphQLObjectType({
   name: 'Fair',
   fields: () => ({
+    ...GravityIDFields,
     cached,
-    _id: {
-      type: GraphQLString,
-    },
-    id: {
-      type: GraphQLString,
-    },
     banner_size: {
       type: GraphQLString,
     },
@@ -94,7 +91,7 @@ const Fair = {
   description: 'A Fair',
   args: {
     id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNull(GraphQLID),
       description: 'The slug or ID of the Fair',
     },
   },

--- a/schema/gene.js
+++ b/schema/gene.js
@@ -3,8 +3,10 @@ import gravity from '../lib/loaders/gravity';
 import cached from './fields/cached';
 import Artist from './artist';
 import Image from './image';
+import { GravityIDFields } from './object_identification';
 import {
   GraphQLObjectType,
+  GraphQLID,
   GraphQLString,
   GraphQLNonNull,
   GraphQLList,
@@ -14,10 +16,8 @@ import {
 const GeneType = new GraphQLObjectType({
   name: 'Gene',
   fields: {
+    ...GravityIDFields,
     cached,
-    id: {
-      type: GraphQLString,
-    },
     href: {
       type: GraphQLString,
       resolve: ({ id }) => `gene/${id}`,
@@ -58,7 +58,7 @@ const Gene = {
   args: {
     id: {
       description: 'The slug or ID of the Gene',
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNull(GraphQLID),
     },
   },
   resolve: (root, { id }) => gravity(`gene/${id}`),

--- a/schema/home/home_page_module.js
+++ b/schema/home/home_page_module.js
@@ -6,6 +6,7 @@ import Context from './context';
 import Params from './params';
 import {
   GraphQLObjectType,
+  GraphQLID,
   GraphQLString,
   GraphQLBoolean,
 } from 'graphql';
@@ -40,7 +41,7 @@ const HomePageModule = {
       description: 'Module key',
     },
     id: {
-      type: GraphQLString,
+      type: GraphQLID,
       description: 'ID of generic gene rail to target',
     },
   },

--- a/schema/home/params.js
+++ b/schema/home/params.js
@@ -1,5 +1,6 @@
 import {
   GraphQLObjectType,
+  GraphQLID,
   GraphQLString,
 } from 'graphql';
 
@@ -16,7 +17,7 @@ const HomePageModuleParams = new GraphQLObjectType({
       type: GraphQLString,
     },
     id: {
-      type: GraphQLString,
+      type: GraphQLID,
     },
   },
 });

--- a/schema/image/index.js
+++ b/schema/image/index.js
@@ -8,6 +8,7 @@ import CroppedUrl from './cropped';
 import ResizedUrl from './resized';
 import DeepZoom, { isZoomable } from './deep_zoom';
 import normalize from './normalize';
+import { IDFields } from '../object_identification';
 import {
   GraphQLObjectType,
   GraphQLString,
@@ -28,9 +29,7 @@ export const getDefault = images => {
 const ImageType = new GraphQLObjectType({
   name: 'Image',
   fields: () => ({
-    id: {
-      type: GraphQLString,
-    },
+    ...IDFields,
     href: {
       type: GraphQLString,
     },

--- a/schema/index.js
+++ b/schema/index.js
@@ -27,6 +27,7 @@ import Search from './search';
 import TrendingArtists from './trending';
 import Me from './me';
 import CausalityJWT from './causality_jwt';
+import ObjectIdentification from './object_identification';
 import {
   GraphQLSchema,
   GraphQLObjectType,
@@ -36,6 +37,7 @@ const schema = new GraphQLSchema({
   query: new GraphQLObjectType({
     name: 'RootQueryType',
     fields: {
+      node: ObjectIdentification.NodeField,
       status: Status,
       article: Article,
       articles: Articles,

--- a/schema/location.js
+++ b/schema/location.js
@@ -1,6 +1,7 @@
 import { existyValue } from '../lib/helpers';
 import cached from './fields/cached';
 import DayScheduleType from './day_schedule';
+import { IDFields } from './object_identification';
 import {
   GraphQLString,
   GraphQLObjectType,
@@ -11,10 +12,8 @@ import {
 const LocationType = new GraphQLObjectType({
   name: 'Location',
   fields: () => ({
+    ...IDFields,
     cached,
-    id: {
-      type: GraphQLString,
-    },
     city: {
       type: GraphQLString,
       resolve: ({ city }) => existyValue(city),

--- a/schema/me/index.js
+++ b/schema/me/index.js
@@ -5,6 +5,7 @@ import BidderStatus from './bidder_status';
 import BidderPositions from './bidder_positions';
 import SaleRegistrations from './sale_registrations';
 import FollowArtists from './follow_artists';
+import { IDFields } from '../object_identification';
 import {
   GraphQLString,
   GraphQLObjectType,
@@ -13,9 +14,7 @@ import {
 const Me = new GraphQLObjectType({
   name: 'Me',
   fields: {
-    id: {
-      type: GraphQLString,
-    },
+    ...IDFields,
     type: {
       type: GraphQLString,
     },

--- a/schema/object_identification.js
+++ b/schema/object_identification.js
@@ -1,0 +1,71 @@
+import {
+  fromGlobalId,
+  toGlobalId,
+} from 'graphql-relay';
+import {
+  GraphQLNonNull,
+  GraphQLID,
+  GraphQLInterfaceType,
+} from 'graphql';
+
+import gravity from '../lib/loaders/gravity';
+import Artist from './artist';
+import Artwork from './artwork';
+
+// Because we use a custom Node ID, we duplicate and slightly adjust the code from:
+// https://github.com/graphql/graphql-relay-js/blob/master/src/node/node.js
+
+const NodeInterface = new GraphQLInterfaceType({
+  name: 'Node',
+  description: 'An object with a Globally Unique ID',
+  fields: () => ({
+    __id: {
+      type: new GraphQLNonNull(GraphQLID),
+      description: 'The ID of the object.',
+    },
+  }),
+  resolveType: (obj) => {
+    if (obj.birthday !== undefined && obj.artworks_count !== undefined) {
+      return Artist.type;
+    } else if (obj.title !== undefined && obj.artists !== undefined) {
+      return Artwork.type;
+    }
+    return null;
+  },
+});
+
+const NodeField = {
+  name: 'node',
+  description: 'Fetches an object given its Globally Unique ID',
+  type: NodeInterface,
+  args: {
+    __id: {
+      type: new GraphQLNonNull(GraphQLID),
+      description: 'The ID of the object',
+    },
+  },
+  resolve: (_, { __id }) => {
+    const { type, id } = fromGlobalId(__id);
+    switch (type) {
+      case 'Artist':
+        return gravity(`artist/${id}`);
+      case 'Artwork':
+        return gravity(`artwork/${id}`);
+      default:
+        return null;
+    }
+  },
+};
+
+const GlobalIDField = {
+  name: '__id',
+  description: 'A Globally Unique ID',
+  type: new GraphQLNonNull(GraphQLID),
+  resolve: (obj, args, info) => toGlobalId(info.parentType.name, obj.id),
+};
+
+export default {
+  GlobalIDField,
+  NodeField,
+  NodeInterface,
+};

--- a/schema/object_identification.js
+++ b/schema/object_identification.js
@@ -10,7 +10,7 @@ import {
 } from 'graphql';
 
 const SupportedTypes = {
-  types: ['Article', 'Artist', 'Artwork', 'PartnerShow'],
+  types: ['Article', 'Artist', 'Artwork', 'Partner', 'PartnerShow'],
   // To prevent circular dependencies, when this file is loaded, the modules are lazily loaded.
   typeModule: _.memoize(type => require(`./${_.snakeCase(type)}`).default),
 };

--- a/schema/object_identification.js
+++ b/schema/object_identification.js
@@ -46,7 +46,7 @@ const SupportedTypes = {
 // Because we use a custom Node ID, we duplicate and slightly adjust the code from:
 // https://github.com/graphql/graphql-relay-js/blob/master/src/node/node.js
 
-const NodeInterface = new GraphQLInterfaceType({
+export const NodeInterface = new GraphQLInterfaceType({
   name: 'Node',
   description: 'An object with a Globally Unique ID',
   fields: () => ({
@@ -85,13 +85,31 @@ const NodeField = {
 
 const GlobalIDField = {
   name: '__id',
-  description: 'A Globally Unique ID',
+  description: 'A globally unique ID.',
   type: new GraphQLNonNull(GraphQLID),
   resolve: (obj, args, info) => toGlobalId(info.parentType.name, obj.id),
 };
 
+export const IDFields = {
+  __id: GlobalIDField,
+  id: {
+    description: 'A type-specific ID.',
+    type: new GraphQLNonNull(GraphQLID),
+  },
+};
+
+export const GravityIDFields = {
+  ...IDFields,
+  _id: {
+    description: 'A type-specific Gravity Mongo Document ID.',
+    type: new GraphQLNonNull(GraphQLID),
+  },
+};
+
 export default {
   GlobalIDField,
-  NodeField,
+  GravityIDFields,
+  IDFields,
   NodeInterface,
+  NodeField,
 };

--- a/schema/object_identification.js
+++ b/schema/object_identification.js
@@ -30,6 +30,8 @@ const NodeInterface = new GraphQLInterfaceType({
       return require('./artwork').default.type;
     } else if (obj.title !== undefined && obj.author !== undefined) {
       return require('./article').default.type;
+    } else if (obj.partner !== undefined && obj.display_on_partner_profile !== undefined) {
+      return require('./partner_show').default.type;
     }
     return null;
   },
@@ -54,6 +56,8 @@ const NodeField = {
         return gravity(`artwork/${id}`);
       case 'Article':
         return positron(`articles/${id}`);
+      case 'PartnerShow':
+        return gravity(`show/${id}`);
       default:
         return null;
     }

--- a/schema/object_identification.js
+++ b/schema/object_identification.js
@@ -1,3 +1,31 @@
+// To support a type, it should:
+// * specify that it implements the Node interface
+// * add the Node `__id` fields
+// * implement a `isType` function that from a payload determines if the payload is of that type
+// * add to the below `SupportedTypes` list.
+//
+// Example:
+//
+//   import ObjectIdentification from './object_identification';
+//
+//   const ArtworkType = new GraphQLObjectType({
+//     ...
+//     interfaces: [ObjectIdentification.NodeInterface],
+//     fields: () => {
+//       return {
+//         __id: ObjectIdentification.GlobalIDField,
+//         ...
+//       };
+//     },
+//   });
+//
+//   const Artwork = {
+//     type: ArtworkType,
+//     resolve: (root, { id }) => gravity(`artwork/${id}`),
+//     isType: (obj) => obj.title !== undefined && obj.artists !== undefined,
+//     ...
+//   };
+
 import _ from 'lodash';
 import {
   fromGlobalId,

--- a/schema/object_identification.js
+++ b/schema/object_identification.js
@@ -1,3 +1,6 @@
+import gravity from '../lib/loaders/gravity';
+import positron from '../lib/loaders/positron';
+
 import {
   fromGlobalId,
   toGlobalId,
@@ -7,10 +10,6 @@ import {
   GraphQLID,
   GraphQLInterfaceType,
 } from 'graphql';
-
-import gravity from '../lib/loaders/gravity';
-import Artist from './artist';
-import Artwork from './artwork';
 
 // Because we use a custom Node ID, we duplicate and slightly adjust the code from:
 // https://github.com/graphql/graphql-relay-js/blob/master/src/node/node.js
@@ -26,9 +25,11 @@ const NodeInterface = new GraphQLInterfaceType({
   }),
   resolveType: (obj) => {
     if (obj.birthday !== undefined && obj.artworks_count !== undefined) {
-      return Artist.type;
+      return require('./artist').default.type;
     } else if (obj.title !== undefined && obj.artists !== undefined) {
-      return Artwork.type;
+      return require('./artwork').default.type;
+    } else if (obj.title !== undefined && obj.author !== undefined) {
+      return require('./article').default.type;
     }
     return null;
   },
@@ -51,6 +52,8 @@ const NodeField = {
         return gravity(`artist/${id}`);
       case 'Artwork':
         return gravity(`artwork/${id}`);
+      case 'Article':
+        return positron(`articles/${id}`);
       default:
         return null;
     }

--- a/schema/ordered_sets.js
+++ b/schema/ordered_sets.js
@@ -1,6 +1,7 @@
 import gravity from '../lib/loaders/gravity';
 import cached from './fields/cached';
 import ItemType from './item';
+import { IDFields } from './object_identification';
 import {
   GraphQLString,
   GraphQLObjectType,
@@ -12,10 +13,8 @@ import {
 const OrderedSetType = new GraphQLObjectType({
   name: 'OrderedSet',
   fields: () => ({
+    ...IDFields,
     cached,
-    id: {
-      type: GraphQLString,
-    },
     key: {
       type: GraphQLString,
     },

--- a/schema/partner.js
+++ b/schema/partner.js
@@ -7,8 +7,9 @@ import cached from './fields/cached';
 import initials from './fields/initials';
 import Profile from './profile';
 import Location from './location';
-import ObjectIdentification from './object_identification';
+import { GravityIDFields, NodeInterface } from './object_identification';
 import {
+  GraphQLID,
   GraphQLString,
   GraphQLObjectType,
   GraphQLNonNull,
@@ -19,20 +20,14 @@ import {
 
 const PartnerType = new GraphQLObjectType({
   name: 'Partner',
-  interfaces: [ObjectIdentification.NodeInterface],
+  interfaces: [NodeInterface],
   fields: () => {
     // Prevent circular dependency
     const PartnerShows = require('./partner_shows').default;
 
     return {
+      ...GravityIDFields,
       cached,
-      __id: ObjectIdentification.GlobalIDField,
-      _id: {
-        type: GraphQLString,
-      },
-      id: {
-        type: GraphQLString,
-      },
       name: {
         type: GraphQLString,
         resolve: ({ name }) => name.trim(),
@@ -126,7 +121,7 @@ const Partner = {
   description: 'A Partner',
   args: {
     id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNull(GraphQLID),
       description: 'The slug or ID of the Partner',
     },
   },

--- a/schema/partner.js
+++ b/schema/partner.js
@@ -7,6 +7,7 @@ import cached from './fields/cached';
 import initials from './fields/initials';
 import Profile from './profile';
 import Location from './location';
+import ObjectIdentification from './object_identification';
 import {
   GraphQLString,
   GraphQLObjectType,
@@ -18,12 +19,14 @@ import {
 
 const PartnerType = new GraphQLObjectType({
   name: 'Partner',
+  interfaces: [ObjectIdentification.NodeInterface],
   fields: () => {
     // Prevent circular dependency
     const PartnerShows = require('./partner_shows').default;
 
     return {
       cached,
+      __id: ObjectIdentification.GlobalIDField,
       _id: {
         type: GraphQLString,
       },
@@ -128,6 +131,8 @@ const Partner = {
     },
   },
   resolve: (root, { id }) => gravity(`partner/${id}`),
+  // ObjectIdentification
+  isType: (obj) => obj.has_full_profile !== undefined && obj.shows_count !== undefined,
 };
 
 export default Partner;

--- a/schema/partner_artist.js
+++ b/schema/partner_artist.js
@@ -2,6 +2,7 @@ import gravity from '../lib/loaders/gravity';
 import Partner from './partner';
 import Artist from './artist/index';
 import numeral from './fields/numeral';
+import { IDFields } from './object_identification';
 import {
   GraphQLString,
   GraphQLObjectType,
@@ -12,7 +13,7 @@ import {
 const PartnerArtistType = new GraphQLObjectType({
   name: 'PartnerArtist',
   fields: () => ({
-
+    ...IDFields,
     counts: {
       type: new GraphQLObjectType({
         name: 'PartnerArtistCounts',
@@ -24,9 +25,6 @@ const PartnerArtistType = new GraphQLObjectType({
         },
       }),
       resolve: (partner_artist) => partner_artist,
-    },
-    id: {
-      type: GraphQLString,
     },
     is_display_on_partner_profile: {
       type: GraphQLBoolean,

--- a/schema/partner_category.js
+++ b/schema/partner_category.js
@@ -3,8 +3,10 @@ import gravity from '../lib/loaders/gravity';
 import cached from './fields/cached';
 import Partners from './partners';
 import CategoryType from './input_fields/category_type';
+import { IDFields } from './object_identification';
 import {
   GraphQLString,
+  GraphQLID,
   GraphQLObjectType,
   GraphQLNonNull,
 } from 'graphql';
@@ -12,10 +14,8 @@ import {
 const PartnerCategoryType = new GraphQLObjectType({
   name: 'PartnerCategory',
   fields: () => ({
+    ...IDFields,
     cached,
-    id: {
-      type: GraphQLString,
-    },
     name: {
       type: GraphQLString,
     },
@@ -35,7 +35,7 @@ const PartnerCategory = {
   description: 'A PartnerCategory',
   args: {
     id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNull(GraphQLID),
       description: 'The slug or ID of the PartnerCategory',
     },
   },

--- a/schema/partner_show.js
+++ b/schema/partner_show.js
@@ -17,6 +17,7 @@ import Artwork from './artwork';
 import Location from './location';
 import Image, { getDefault } from './image';
 import PartnerShowEventType from './partner_show_event';
+import ObjectIdentification from './object_identification';
 import {
   GraphQLObjectType,
   GraphQLString,
@@ -34,8 +35,10 @@ const kind = ({ artists, fair }) => {
 
 const PartnerShowType = new GraphQLObjectType({
   name: 'PartnerShow',
+  interfaces: [ObjectIdentification.NodeInterface],
   fields: () => ({
     cached,
+    __id: ObjectIdentification.GlobalIDField,
     _id: {
       type: GraphQLString,
     },

--- a/schema/partner_show.js
+++ b/schema/partner_show.js
@@ -17,9 +17,10 @@ import Artwork from './artwork';
 import Location from './location';
 import Image, { getDefault } from './image';
 import PartnerShowEventType from './partner_show_event';
-import ObjectIdentification from './object_identification';
+import { GravityIDFields, NodeInterface } from './object_identification';
 import {
   GraphQLObjectType,
+  GraphQLID,
   GraphQLString,
   GraphQLNonNull,
   GraphQLList,
@@ -35,16 +36,10 @@ const kind = ({ artists, fair }) => {
 
 const PartnerShowType = new GraphQLObjectType({
   name: 'PartnerShow',
-  interfaces: [ObjectIdentification.NodeInterface],
+  interfaces: [NodeInterface],
   fields: () => ({
+    ...GravityIDFields,
     cached,
-    __id: ObjectIdentification.GlobalIDField,
-    _id: {
-      type: GraphQLString,
-    },
-    id: {
-      type: GraphQLString,
-    },
     href: {
       type: GraphQLString,
       resolve: ({ id }) => `/show/${id}`,
@@ -257,7 +252,7 @@ const PartnerShow = {
   description: 'A Partner Show',
   args: {
     id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNull(GraphQLID),
       description: 'The slug or ID of the PartnerShow',
     },
   },

--- a/schema/partner_show.js
+++ b/schema/partner_show.js
@@ -268,6 +268,8 @@ const PartnerShow = {
         return show;
       });
   },
+  // ObjectIdentification
+  isType: (obj) => obj.partner !== undefined && obj.display_on_partner_profile !== undefined,
 };
 
 export default PartnerShow;

--- a/schema/profile.js
+++ b/schema/profile.js
@@ -3,7 +3,9 @@ import cached from './fields/cached';
 import initials from './fields/initials';
 import numeral from './fields/numeral';
 import Image from './image';
+import { GravityIDFields } from './object_identification';
 import {
+  GraphQLID,
   GraphQLString,
   GraphQLObjectType,
   GraphQLNonNull,
@@ -13,13 +15,8 @@ import {
 const ProfileType = new GraphQLObjectType({
   name: 'Profile',
   fields: () => ({
+    ...GravityIDFields,
     cached,
-    _id: {
-      type: GraphQLString,
-    },
-    id: {
-      type: GraphQLString,
-    },
     name: {
       type: GraphQLString,
       resolve: ({ owner }) => owner.name,
@@ -61,7 +58,7 @@ const Profile = {
   description: 'A Profile',
   args: {
     id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNull(GraphQLID),
       description: 'The slug or ID of the Profile',
     },
   },

--- a/schema/sale/index.js
+++ b/schema/sale/index.js
@@ -34,6 +34,35 @@ export function auctionState({ start_at, end_at, live_start_at }) {
   }
 }
 
+const BidIncrement = new GraphQLObjectType({
+  name: 'BidIncrements',
+  fields: {
+    from: {
+      type: GraphQLInt,
+    },
+    to: {
+      type: GraphQLInt,
+    },
+    amount: {
+      type: GraphQLInt,
+    },
+  },
+});
+
+const BuyersPremium = new GraphQLObjectType({
+  name: 'BuyersPremium',
+  fields: {
+    amount: amount(({ cents }) => cents),
+    cents: {
+      type: GraphQLInt,
+      resolve: ({ cents }) => cents,
+    },
+    percent: {
+      type: GraphQLFloat,
+    },
+  },
+});
+
 const SaleType = new GraphQLObjectType({
   name: 'Sale',
   fields: () => {
@@ -183,39 +212,14 @@ const SaleType = new GraphQLObjectType({
         resolve: ({ profile }) => profile,
       },
       bid_increments: {
-        type: new GraphQLList(new GraphQLObjectType({
-          name: 'BidIncrements',
-          fields: {
-            from: {
-              type: GraphQLInt,
-            },
-            to: {
-              type: GraphQLInt,
-            },
-            amount: {
-              type: GraphQLInt,
-            },
-          },
-        })),
+        type: new GraphQLList(BidIncrement),
         description: 'A bid increment policy that explains minimum bids in ranges.',
         resolve: (sale) =>
           gravity(`increments`, { key: sale.increment_strategy })
             .then((incs) => incs[0].increments),
       },
       buyers_premium: {
-        type: new GraphQLList(new GraphQLObjectType({
-          name: 'BuyersPremium',
-          fields: {
-            amount: amount(({ cents }) => cents),
-            cents: {
-              type: GraphQLInt,
-              resolve: ({ cents }) => cents,
-            },
-            percent: {
-              type: GraphQLFloat,
-            },
-          },
-        })),
+        type: new GraphQLList(BuyersPremium),
         description: "Auction's buyer's premium policy.",
         resolve: (sale) => map(sale.buyers_premium.schedule, (item) => ({
           cents: item.min_amount_cents,

--- a/schema/sale/index.js
+++ b/schema/sale/index.js
@@ -37,7 +37,7 @@ export function auctionState({ start_at, end_at, live_start_at }) {
 }
 
 const BidIncrement = new GraphQLObjectType({
-  name: 'BidIncrements',
+  name: 'BidIncrement',
   fields: {
     from: {
       type: GraphQLInt,

--- a/schema/sale/index.js
+++ b/schema/sale/index.js
@@ -9,7 +9,9 @@ import SaleArtwork from '../sale_artwork';
 import Profile from '../profile';
 import Image from '../image/index';
 import { amount } from '../fields/money';
+import { GravityIDFields } from '../object_identification';
 import {
+  GraphQLID,
   GraphQLString,
   GraphQLObjectType,
   GraphQLNonNull,
@@ -67,13 +69,8 @@ const SaleType = new GraphQLObjectType({
   name: 'Sale',
   fields: () => {
     return {
+      ...GravityIDFields,
       cached,
-      id: {
-        type: GraphQLString,
-      },
-      _id: {
-        type: GraphQLString,
-      },
       name: {
         type: GraphQLString,
       },
@@ -201,7 +198,7 @@ const SaleType = new GraphQLObjectType({
         type: SaleArtwork.type,
         args: {
           id: {
-            type: new GraphQLNonNull(GraphQLString),
+            type: new GraphQLNonNull(GraphQLID),
           },
         },
         resolve: (sale, { id }) =>
@@ -236,7 +233,7 @@ const Sale = {
   description: 'A Sale',
   args: {
     id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNull(GraphQLID),
       description: 'The slug or ID of the Sale',
     },
   },

--- a/schema/sale_artwork.js
+++ b/schema/sale_artwork.js
@@ -12,8 +12,10 @@ import numeral from './fields/numeral';
 import gravity from '../lib/loaders/gravity';
 import Artwork from './artwork';
 import Sale, { auctionState } from './sale';
+import { GravityIDFields } from './object_identification';
 import {
   GraphQLObjectType,
+  GraphQLID,
   GraphQLString,
   GraphQLNonNull,
   GraphQLInt,
@@ -31,13 +33,8 @@ const SaleArtworkType = new GraphQLObjectType({
   name: 'SaleArtwork',
   fields: () => {
     return {
+      ...GravityIDFields,
       cached,
-      _id: {
-        type: GraphQLString,
-      },
-      id: {
-        type: GraphQLString,
-      },
       sale_id: {
         type: GraphQLString,
       },
@@ -148,7 +145,7 @@ const SaleArtworkType = new GraphQLObjectType({
           name: 'SaleArtworkHighestBid',
           fields: {
             id: {
-              type: GraphQLString,
+              type: GraphQLID,
             },
             created_at: date,
             is_cancelled: {
@@ -257,7 +254,7 @@ const SaleArtwork = {
   description: 'A Sale Artwork',
   args: {
     id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNull(GraphQLID),
       description: 'The slug or ID of the SaleArtwork',
     },
   },

--- a/schema/search/search_result.js
+++ b/schema/search/search_result.js
@@ -6,6 +6,7 @@ import gravity from '../../lib/loaders/gravity';
 import Image from '../image';
 import SearchEntityType from './search_entity';
 import {
+  GraphQLID,
   GraphQLString,
   GraphQLObjectType,
 } from 'graphql';
@@ -31,7 +32,7 @@ const SearchResultType = new GraphQLObjectType({
   name: 'SearchResult',
   fields: () => ({
     id: {
-      type: GraphQLString,
+      type: GraphQLID,
       resolve: parseId,
     },
     title: {

--- a/test/lib/apis/gravity.js
+++ b/test/lib/apis/gravity.js
@@ -66,7 +66,7 @@ describe('APIs', () => {
       const request = sinon.stub().yields(null, { statusCode: 200, body: 'not json' });
       fetch.__Rewire__('request', request);
 
-      return gravity('foo/bar').should.be.rejectedWith('Unexpected token o');
+      return gravity('foo/bar').should.be.rejectedWith(/Unexpected token o/);
     });
   });
 });

--- a/test/schema/object_identification.js
+++ b/test/schema/object_identification.js
@@ -1,0 +1,128 @@
+import sinon from 'sinon';
+import { graphql } from 'graphql';
+import { toGlobalId } from 'graphql-relay';
+import schema from '../../schema';
+
+describe('Global Identification', () => {
+  const Artist = schema.__get__('Artist');
+  const Artwork = schema.__get__('Artwork');
+  const ObjectIdentification = schema.__get__('ObjectIdentification');
+
+  afterEach(() => {
+    Artist.__ResetDependency__('gravity');
+    Artwork.__ResetDependency__('gravity');
+    ObjectIdentification.__ResetDependency__('gravity');
+  });
+
+  describe('for an Artist', () => {
+    beforeEach(() => {
+      [Artist, ObjectIdentification].forEach((mod) => {
+        mod.__Rewire__('gravity', sinon.stub().returns(
+          Promise.resolve({
+            id: 'foo-bar',
+            birthday: null,
+            artworks_count: 42,
+          })
+        ));
+      });
+    });
+
+    it('generates a Global ID', () => {
+      const query = `
+        {
+          artist(id: "foo-bar") {
+            __id
+          }
+        }
+      `;
+
+      return graphql(schema, query)
+        .then(({ data }) => {
+          data.should.eql({
+            artist: {
+              __id: toGlobalId('Artist', 'foo-bar'),
+            },
+          });
+        });
+    });
+
+    it('resolves a node', () => {
+      const query = `
+        {
+          node(__id: "${toGlobalId('Artist', 'foo-bar')}") {
+            __typename
+            ... on Artist {
+              id
+            }
+          }
+        }
+      `;
+
+      return graphql(schema, query)
+        .then(({ data }) => {
+          data.should.eql({
+            node: {
+              __typename: 'Artist',
+              id: 'foo-bar',
+            },
+          });
+        });
+    });
+  });
+
+  describe('for an Artwork', () => {
+    beforeEach(() => {
+      [Artwork, ObjectIdentification].forEach((mod) => {
+        mod.__Rewire__('gravity', sinon.stub().returns(
+          Promise.resolve({
+            id: 'foo-bar',
+            title: 'For baz',
+            artists: null,
+          })
+        ));
+      });
+    });
+
+    it('generates a Global ID', () => {
+      const query = `
+        {
+          artwork(id: "foo-bar") {
+            __id
+          }
+        }
+      `;
+
+      return graphql(schema, query)
+        .then(({ data }) => {
+          data.should.eql({
+            artwork: {
+              __id: toGlobalId('Artwork', 'foo-bar'),
+            },
+          });
+        });
+    });
+
+    it('resolves a node', () => {
+      const query = `
+        {
+          node(__id: "${toGlobalId('Artwork', 'foo-bar')}") {
+            __typename
+            ... on Artwork {
+              id
+            }
+          }
+        }
+      `;
+
+      return graphql(schema, query)
+        .then(({ data }) => {
+          data.should.eql({
+            node: {
+              __typename: 'Artwork',
+              id: 'foo-bar',
+            },
+          });
+        });
+    });
+  });
+});

--- a/test/schema/object_identification.js
+++ b/test/schema/object_identification.js
@@ -4,14 +4,74 @@ import { toGlobalId } from 'graphql-relay';
 import schema from '../../schema';
 
 describe('Global Identification', () => {
+  const Article = schema.__get__('Article');
   const Artist = schema.__get__('Artist');
   const Artwork = schema.__get__('Artwork');
+  const PartnerShow = schema.__get__('PartnerShow');
   const ObjectIdentification = schema.__get__('ObjectIdentification');
 
   afterEach(() => {
+    Article.__ResetDependency__('positron');
     Artist.__ResetDependency__('gravity');
     Artwork.__ResetDependency__('gravity');
+    PartnerShow.__ResetDependency__('gravity');
     ObjectIdentification.__ResetDependency__('gravity');
+  });
+
+  describe('for an Article', () => {
+    beforeEach(() => {
+      [Article, ObjectIdentification].forEach((mod) => {
+        mod.__Rewire__('positron', sinon.stub().returns(
+          Promise.resolve({
+            id: 'foo-bar',
+            title: 'Nightlife at the Foo Bar',
+            author: 'Artsy Editorial',
+          })
+        ));
+      });
+    });
+
+    it('generates a Global ID', () => {
+      const query = `
+        {
+          article(id: "foo-bar") {
+            __id
+          }
+        }
+      `;
+
+      return graphql(schema, query)
+        .then(({ data }) => {
+          data.should.eql({
+            article: {
+              __id: toGlobalId('Article', 'foo-bar'),
+            },
+          });
+        });
+    });
+
+    it('resolves a node', () => {
+      const query = `
+        {
+          node(__id: "${toGlobalId('Article', 'foo-bar')}") {
+            __typename
+            ... on Article {
+              id
+            }
+          }
+        }
+      `;
+
+      return graphql(schema, query)
+        .then(({ data }) => {
+          data.should.eql({
+            node: {
+              __typename: 'Article',
+              id: 'foo-bar',
+            },
+          });
+        });
+    });
   });
 
   describe('for an Artist', () => {

--- a/test/schema/object_identification.js
+++ b/test/schema/object_identification.js
@@ -185,4 +185,61 @@ describe('Global Identification', () => {
         });
     });
   });
+
+  describe('for a PartnerShow', () => {
+    beforeEach(() => {
+      [PartnerShow, ObjectIdentification].forEach((mod) => {
+        mod.__Rewire__('gravity', sinon.stub().returns(
+          Promise.resolve({
+            id: 'foo-bar',
+            displayable: true,
+            partner: { id: 'for-baz' },
+            display_on_partner_profile: true,
+          })
+        ));
+      });
+    });
+
+    it('generates a Global ID', () => {
+      const query = `
+        {
+          partner_show(id: "foo-bar") {
+            __id
+          }
+        }
+      `;
+
+      return graphql(schema, query)
+        .then(({ data }) => {
+          data.should.eql({
+            partner_show: {
+              __id: toGlobalId('PartnerShow', 'foo-bar'),
+            },
+          });
+        });
+    });
+
+    it('resolves a node', () => {
+      const query = `
+        {
+          node(__id: "${toGlobalId('PartnerShow', 'foo-bar')}") {
+            __typename
+            ... on PartnerShow {
+              id
+            }
+          }
+        }
+      `;
+
+      return graphql(schema, query)
+        .then(({ data }) => {
+          data.should.eql({
+            node: {
+              __typename: 'PartnerShow',
+              id: 'foo-bar',
+            },
+          });
+        });
+    });
+  });
 });

--- a/test/schema/object_identification.js
+++ b/test/schema/object_identification.js
@@ -8,27 +8,23 @@ describe('Global Identification', () => {
   const Artist = schema.__get__('Artist');
   const Artwork = schema.__get__('Artwork');
   const PartnerShow = schema.__get__('PartnerShow');
-  const ObjectIdentification = schema.__get__('ObjectIdentification');
 
   afterEach(() => {
     Article.__ResetDependency__('positron');
     Artist.__ResetDependency__('gravity');
     Artwork.__ResetDependency__('gravity');
     PartnerShow.__ResetDependency__('gravity');
-    ObjectIdentification.__ResetDependency__('gravity');
   });
 
   describe('for an Article', () => {
     beforeEach(() => {
-      [Article, ObjectIdentification].forEach((mod) => {
-        mod.__Rewire__('positron', sinon.stub().returns(
-          Promise.resolve({
-            id: 'foo-bar',
-            title: 'Nightlife at the Foo Bar',
-            author: 'Artsy Editorial',
-          })
-        ));
-      });
+      Article.__Rewire__('positron', sinon.stub().returns(
+        Promise.resolve({
+          id: 'foo-bar',
+          title: 'Nightlife at the Foo Bar',
+          author: 'Artsy Editorial',
+        })
+      ));
     });
 
     it('generates a Global ID', () => {
@@ -76,15 +72,13 @@ describe('Global Identification', () => {
 
   describe('for an Artist', () => {
     beforeEach(() => {
-      [Artist, ObjectIdentification].forEach((mod) => {
-        mod.__Rewire__('gravity', sinon.stub().returns(
-          Promise.resolve({
-            id: 'foo-bar',
-            birthday: null,
-            artworks_count: 42,
-          })
-        ));
-      });
+      Artist.__Rewire__('gravity', sinon.stub().returns(
+        Promise.resolve({
+          id: 'foo-bar',
+          birthday: null,
+          artworks_count: 42,
+        })
+      ));
     });
 
     it('generates a Global ID', () => {
@@ -132,15 +126,13 @@ describe('Global Identification', () => {
 
   describe('for an Artwork', () => {
     beforeEach(() => {
-      [Artwork, ObjectIdentification].forEach((mod) => {
-        mod.__Rewire__('gravity', sinon.stub().returns(
-          Promise.resolve({
-            id: 'foo-bar',
-            title: 'For baz',
-            artists: null,
-          })
-        ));
-      });
+      Artwork.__Rewire__('gravity', sinon.stub().returns(
+        Promise.resolve({
+          id: 'foo-bar',
+          title: 'For baz',
+          artists: null,
+        })
+      ));
     });
 
     it('generates a Global ID', () => {
@@ -188,16 +180,14 @@ describe('Global Identification', () => {
 
   describe('for a PartnerShow', () => {
     beforeEach(() => {
-      [PartnerShow, ObjectIdentification].forEach((mod) => {
-        mod.__Rewire__('gravity', sinon.stub().returns(
-          Promise.resolve({
-            id: 'foo-bar',
-            displayable: true,
-            partner: { id: 'for-baz' },
-            display_on_partner_profile: true,
-          })
-        ));
-      });
+      PartnerShow.__Rewire__('gravity', sinon.stub().returns(
+        Promise.resolve({
+          id: 'foo-bar',
+          displayable: true,
+          partner: { id: 'for-baz' },
+          display_on_partner_profile: true,
+        })
+      ));
     });
 
     it('generates a Global ID', () => {

--- a/test/schema/object_identification.js
+++ b/test/schema/object_identification.js
@@ -24,6 +24,12 @@ describe('Object Identification', () => {
         artists: null,
       },
     },
+    Partner: {
+      gravity: {
+        has_full_profile: true,
+        shows_count: 42,
+      }
+    },
     PartnerShow: {
       gravity: {
         displayable: true, // this is only so that the show doesn’t get rejected

--- a/test/schema/object_identification.js
+++ b/test/schema/object_identification.js
@@ -28,7 +28,7 @@ describe('Object Identification', () => {
       gravity: {
         has_full_profile: true,
         shows_count: 42,
-      }
+      },
     },
     PartnerShow: {
       gravity: {
@@ -68,7 +68,7 @@ describe('Object Identification', () => {
         return graphql(schema, query).then(({ data }) => {
           const expectedData = {};
           expectedData[fieldName] = { __id: toGlobalId(typeName, 'foo-bar') };
-          data.should.eql(expectedData)
+          data.should.eql(expectedData);
         });
       });
 


### PR DESCRIPTION
This adds the [Relay Node ID](https://facebook.github.io/relay/graphql/objectidentification.htm) support that we need to make full use of Relay’s capabilities.

* It adds a `Node` interface, which identifies an object with the `__id` field. From the `__id` value it is able to deduce the actual type and its type-specific ID.
* Article, Artist, Artwork, Partner, and PartnerShow have gained the `Node` interface. Any other types that will be used with Relay in the future will need to get support added.
* All types that have a `id` field now also have a `__id` field, because even though you can’t look all of those up through the `Node` interface yet, the globally unique IDs does mean that Relay can already cache them efficiently.
* I started using `GraphQLID` for all `id` fields instead of `GraphQLString`. I did not yet add the non-null type to all of those, but I have a feeling that there are lots of places where a value (such as an ID) cannot be null.