### PR TITLE
@ashfurrow: Add bid increments as root query

### DIFF
--- a/schema/bid_increments.js
+++ b/schema/bid_increments.js
@@ -1,0 +1,39 @@
+import {
+  GraphQLString,
+  GraphQLObjectType,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+} from 'graphql';
+import { find } from 'lodash';
+import gravity from '../lib/loaders/gravity';
+
+const BidIncrementsType = new GraphQLObjectType({
+  name: 'BidIncrements',
+  fields: {
+    from: {
+      type: GraphQLInt,
+    },
+    to: {
+      type: GraphQLInt,
+    },
+    amount: {
+      type: GraphQLInt,
+    },
+  },
+});
+
+const BidIncrements = {
+  type: new GraphQLList(BidIncrementsType),
+  description: 'A bid increment policy that explains minimum bids in ranges.',
+  args: {
+    key: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: 'The name denoting the type of bid increment policy',
+    },
+  },
+  resolve: (root, { key }) =>
+    gravity(`increments`).then((incs) => find(incs, { key }).increments),
+};
+
+export default BidIncrements;

--- a/schema/bid_increments.js
+++ b/schema/bid_increments.js
@@ -5,7 +5,6 @@ import {
   GraphQLList,
   GraphQLNonNull,
 } from 'graphql';
-import { find } from 'lodash';
 import gravity from '../lib/loaders/gravity';
 
 const BidIncrementsType = new GraphQLObjectType({
@@ -33,7 +32,7 @@ const BidIncrements = {
     },
   },
   resolve: (root, { key }) =>
-    gravity(`increments`).then((incs) => find(incs, { key }).increments),
+    gravity(`increments`, { key }).then((incs) => incs[0].increments),
 };
 
 export default BidIncrements;

--- a/schema/index.js
+++ b/schema/index.js
@@ -26,6 +26,7 @@ import Search from './search';
 import TrendingArtists from './trending';
 import Me from './me';
 import CausalityJWT from './causality_jwt';
+import BidIncrements from './bid_increments';
 import {
   GraphQLSchema,
   GraphQLObjectType,
@@ -63,6 +64,7 @@ const schema = new GraphQLSchema({
       trending_artists: TrendingArtists,
       me: Me,
       causality_jwt: CausalityJWT,
+      bid_increments: BidIncrements,
     },
   }),
 });


### PR DESCRIPTION
Adds the global bid increment policy as something that can be queried at the root.

![image](https://cloud.githubusercontent.com/assets/555859/16092815/5569ae52-3307-11e6-8ec8-c1da5ee89915.png)
