### PR TITLE
@acjay: Finds increments based on sale's strategy

### DIFF
--- a/schema/sale_artwork.js
+++ b/schema/sale_artwork.js
@@ -223,7 +223,7 @@ const SaleArtworkType = new GraphQLObjectType({
         resolve: ({ minimum_next_bid_cents, sale_id }) => {
           return gravity(`sale/${sale_id}`).then((sale) => {
             return gravity('increments', {
-              key: sale.increment_strategy
+              key: sale.increment_strategy,
             }).then((incrs) => {
               const incr = incrs[0].increments;
               const increments = [minimum_next_bid_cents];

--- a/test/schema/sale_artwork.js
+++ b/test/schema/sale_artwork.js
@@ -100,7 +100,9 @@ describe('SaleArtwork type', () => {
   });
 
   it('can return the bid increment', () => {
-    gravity.onCall(1).returns(Promise.resolve([
+    gravity.onCall(1).returns(Promise.resolve({
+      increment_strategy: 'default',
+    })).onCall(2).returns(Promise.resolve([
       {
         key: 'default',
         increments: [


### PR DESCRIPTION
Adds an extra fetch for the related sale to get the increment_strategy instead of just using default.

![image](https://cloud.githubusercontent.com/assets/555859/16097398/ae0678ec-331b-11e6-87fb-e55fb2de1ec8.png)
