### PR TITLE
@sweir27: Query my active bids by sale_id

### DIFF
--- a/schema/me/bidder_positions.js
+++ b/schema/me/bidder_positions.js
@@ -19,11 +19,16 @@ export default {
       type: GraphQLString,
       description: 'Only the bidder positions on a specific artwork',
     },
+    sale_id: {
+      type: GraphQLString,
+      description: 'Only the bidder positions for a specific auction',
+    },
   },
-  resolve: (root, { current, artwork_id }, { rootValue: { accessToken } }) => {
+  resolve: (root, { current, artwork_id, sale_id }, { rootValue: { accessToken } }) => {
     return gravity
       .with(accessToken)('me/bidder_positions', {
         artwork_id,
+        sale_id,
         sort: '-created_at',
       })
       .then((positions) => {


### PR DESCRIPTION
Right now the my active bids on the sale page is showing across-auctions. I forget when this regression was introduced, but before we were filtering on the client-side, when ideally we actually filter this down via MP + Gravity. So this allows that.