### PR TITLE
@sweir27: Expose buyer's premium

### DIFF
--- a/schema/sale/index.js
+++ b/schema/sale/index.js
@@ -8,6 +8,7 @@ import Artwork from '../artwork';
 import SaleArtwork from '../sale_artwork';
 import Profile from '../profile';
 import Image from '../image/index';
+import { amount } from '../fields/money';
 import {
   GraphQLString,
   GraphQLObjectType,
@@ -205,8 +206,10 @@ const SaleType = new GraphQLObjectType({
         type: new GraphQLList(new GraphQLObjectType({
           name: 'BuyersPremium',
           fields: {
-            min_amount_cents: {
+            amount: amount(({ min_amount_cents }) => min_amount_cents),
+            cents: {
               type: GraphQLInt,
+              resolve: ({ min_amount_cents }) => min_amount_cents,
             },
             percent: {
               type: GraphQLFloat,

--- a/schema/sale/index.js
+++ b/schema/sale/index.js
@@ -206,10 +206,10 @@ const SaleType = new GraphQLObjectType({
         type: new GraphQLList(new GraphQLObjectType({
           name: 'BuyersPremium',
           fields: {
-            amount: amount(({ min_amount_cents }) => min_amount_cents),
+            amount: amount(({ cents }) => cents),
             cents: {
               type: GraphQLInt,
-              resolve: ({ min_amount_cents }) => min_amount_cents,
+              resolve: ({ cents }) => cents,
             },
             percent: {
               type: GraphQLFloat,
@@ -217,7 +217,11 @@ const SaleType = new GraphQLObjectType({
           },
         })),
         description: "Auction's buyer's premium policy.",
-        resolve: (sale) => sale.buyers_premium.schedule,
+        resolve: (sale) => map(sale.buyers_premium.schedule, (item) => ({
+          cents: item.min_amount_cents,
+          symbol: sale.currency,
+          percent: item.percent,
+        })),
       },
     };
   },

--- a/schema/sale/index.js
+++ b/schema/sale/index.js
@@ -15,6 +15,7 @@ import {
   GraphQLList,
   GraphQLBoolean,
   GraphQLInt,
+  GraphQLFloat,
 } from 'graphql';
 
 export function auctionState({ start_at, end_at, live_start_at }) {
@@ -199,6 +200,21 @@ const SaleType = new GraphQLObjectType({
         resolve: (sale) =>
           gravity(`increments`, { key: sale.increment_strategy })
             .then((incs) => incs[0].increments),
+      },
+      buyers_premium: {
+        type: new GraphQLList(new GraphQLObjectType({
+          name: 'BuyersPremium',
+          fields: {
+            min_amount_cents: {
+              type: GraphQLInt,
+            },
+            percent: {
+              type: GraphQLFloat,
+            },
+          },
+        })),
+        description: "Auction's buyer's premium policy.",
+        resolve: (sale) => sale.buyers_premium.schedule,
       },
     };
   },


### PR DESCRIPTION
This exposes a sale's buyer's premium in MP...

![image](https://cloud.githubusercontent.com/assets/555859/16210855/2cce2686-370c-11e6-93dd-4bd7e050467d.png)

In Gravity there's all this other data other than `schedule` that we don't use, but I wanted to check with you that I'm not overlooking something useful in here... e.g. Why would we ever need to know the `name` or `currency` aren't those always the same as the auction itself?

![image](https://cloud.githubusercontent.com/assets/555859/16210612/01320016-370b-11e6-95cf-2fa7b1e2af03.png)

We need this data to render UI's like this that explain the buyer's premium policy...

![image](https://cloud.githubusercontent.com/assets/555859/16210662/3d03e640-370b-11e6-8233-2d0361099323.png)
