### PR TITLE
[Home] Move `module` and `modules` into `home_page` field.

### DIFF
--- a/schema/home/index.js
+++ b/schema/home/index.js
@@ -1,0 +1,25 @@
+import HomePageModules from './home_page_modules';
+import HomePageModule from './home_page_module';
+
+import {
+  GraphQLObjectType,
+} from 'graphql';
+
+const HomePageType = new GraphQLObjectType({
+  name: 'HomePage',
+  fields: {
+    modules: HomePageModules,
+    module: HomePageModule,
+  },
+});
+
+const HomePage = {
+  type: HomePageType,
+  description: 'Home screen content',
+  resolve: () => {
+    // dummy response object, otherwise the nested fields won’t work
+    return {};
+  },
+};
+
+export default HomePage;

--- a/schema/index.js
+++ b/schema/index.js
@@ -8,6 +8,7 @@ import Artists from './artists';
 import Fair from './fair';
 import Fairs from './fairs';
 import Gene from './gene';
+import HomePage from './home';
 import HomePageModules from './home/home_page_modules';
 import HomePageModule from './home/home_page_module';
 import OrderedSets from './ordered_sets';
@@ -46,6 +47,7 @@ const schema = new GraphQLSchema({
       fair: Fair,
       fairs: Fairs,
       gene: Gene,
+      home_page: HomePage,
       home_page_modules: HomePageModules,
       home_page_module: HomePageModule,
       profile: Profile,


### PR DESCRIPTION
Relay requires root fields to be singular, no lists.

I tried adding `deprecationReason` fields to the root `home_page_module` and `home_page_modules` fields, but for some reason these deprecation warnings did not show up when introspecting the schema, so I ended up not adding those. In addition it’s probably easier for force to just switch over and we can remove these fields. /cc @broskoski 

----

```graphql
{
  home_page {
    module(key: "live_auctions") {
      title
    },
    modules(max_rails: 3) {
      title
    }
  }
}
```

```json
{
  "data": {
    "home_page": {
      "module": {
        "title": "Current Auction: Heather James Fine Art: Benefit Auction 2016"
      },
      "modules": [
        {
          "title": "Works by Iconic Artists"
        },
        {
          "title": "Current Auction: Heather James Fine Art: Benefit Auction 2016"
        },
        {
          "title": "Current Fair: Art Southampton 2016"
        }
      ]
    }
  }
}
```
