### PR TITLE
[Image] May have a nil ID, so reflect in schema.

### DIFF
--- a/schema/image/index.js
+++ b/schema/image/index.js
@@ -8,7 +8,7 @@ import CroppedUrl from './cropped';
 import ResizedUrl from './resized';
 import DeepZoom, { isZoomable } from './deep_zoom';
 import normalize from './normalize';
-import { IDFields } from '../object_identification';
+import { GlobalIDField } from '../object_identification';
 import {
   GraphQLObjectType,
   GraphQLString,
@@ -29,7 +29,11 @@ export const getDefault = images => {
 const ImageType = new GraphQLObjectType({
   name: 'Image',
   fields: () => ({
-    ...IDFields,
+    __id: GlobalIDField,
+    id: {
+      description: 'A type-specific ID.',
+      type: GraphQLString,
+    },
     href: {
       type: GraphQLString,
     },

--- a/schema/object_identification.js
+++ b/schema/object_identification.js
@@ -84,7 +84,7 @@ const NodeField = {
   },
 };
 
-const GlobalIDField = {
+export const GlobalIDField = {
   name: '__id',
   description: 'A globally unique ID.',
   type: new GraphQLNonNull(GraphQLID),


### PR DESCRIPTION
I can’t say I really understand why some image objects wouldn’t have an ID, but MP is complaining about it happening, so for now getting rid of that error.