### PR TITLE
@xtina-starr artwork page

### DIFF
--- a/schema/artwork/layer.js
+++ b/schema/artwork/layer.js
@@ -5,6 +5,7 @@ import {
   GraphQLObjectType,
   GraphQLString,
   GraphQLList,
+  GraphQLInt,
 } from 'graphql';
 
 const ArtworkLayerType = new GraphQLObjectType({
@@ -25,9 +26,14 @@ const ArtworkLayerType = new GraphQLObjectType({
       type: GraphQLString,
     },
     artworks: {
+      args: {
+        size: {
+          type: GraphQLInt,
+        },
+      },
       type: new GraphQLList(Artwork.type),
-      resolve: ({ id, type, artwork_id }) => {
-        return gravity(`related/layer/${type}/${id}/artworks`, { artwork: [artwork_id] });
+      resolve: ({ id, type, artwork_id }, { size }) => {
+        return gravity(`related/layer/${type}/${id}/artworks`, { artwork: [artwork_id], size });
       },
     },
   }),

--- a/schema/filter_artworks.js
+++ b/schema/filter_artworks.js
@@ -11,6 +11,7 @@ import {
   GraphQLString,
   GraphQLBoolean,
   GraphQLInt,
+  GraphQLID,
 } from 'graphql';
 
 export const FilterArtworksType = new GraphQLObjectType({
@@ -92,7 +93,7 @@ const FilterArtworks = {
       type: new GraphQLList(GraphQLString),
     },
     partner_id: {
-      type: GraphQLString,
+      type: GraphQLID,
     },
     partner_cities: {
       type: new GraphQLList(GraphQLString),

--- a/schema/filter_artworks.js
+++ b/schema/filter_artworks.js
@@ -91,6 +91,9 @@ const FilterArtworks = {
     major_periods: {
       type: new GraphQLList(GraphQLString),
     },
+    partner_id: {
+      type: GraphQLString,
+    },
     partner_cities: {
       type: new GraphQLList(GraphQLString),
     },

--- a/schema/partner.js
+++ b/schema/partner.js
@@ -103,10 +103,9 @@ const PartnerType = new GraphQLObjectType({
           },
         },
         resolve: ({ id }, options) => {
-          return gravity(`filter/artworks`, assign({}, options, {
-            partner_id: id,
+          return gravity(`partner/${id}/artworks`, assign({}, options, {
             published: true,
-          })).then((data) => data.hits).then(exclude(options.exclude, 'id'));
+          })).then(exclude(options.exclude, 'id'));
         },
       },
       locations: {

--- a/schema/partner.js
+++ b/schema/partner.js
@@ -2,12 +2,17 @@ import {
   assign,
   omit,
 } from 'lodash';
+import { exclude } from '../lib/helpers';
 import gravity from '../lib/loaders/gravity';
 import cached from './fields/cached';
 import initials from './fields/initials';
 import Profile from './profile';
 import Location from './location';
 import { GravityIDFields, NodeInterface } from './object_identification';
+import Artwork from './artwork';
+import numeral from './fields/numeral';
+import ArtworkSorts from './sorts/artwork_sorts';
+
 import {
   GraphQLString,
   GraphQLObjectType,
@@ -86,6 +91,24 @@ const PartnerType = new GraphQLObjectType({
           }));
         },
       },
+      artworks: {
+        type: new GraphQLList(Artwork.type),
+        args: {
+          size: {
+            type: GraphQLInt,
+          },
+          sort: ArtworkSorts,
+          exclude: {
+            type: new GraphQLList(GraphQLString),
+          },
+        },
+        resolve: ({ id }, options) => {
+          return gravity(`filter/artworks`, assign({}, options, {
+            partner_id: id,
+            published: true,
+          })).then((data) => data.hits).then(exclude(options.exclude, 'id'));
+        },
+      },
       locations: {
         type: new GraphQLList(Location.type),
         args: {
@@ -110,6 +133,36 @@ const PartnerType = new GraphQLObjectType({
             'Could you please provide more information about the piece?',
           ].join(' ');
         },
+      },
+      counts: {
+        type: new GraphQLObjectType({
+          name: 'PartnerCounts',
+          fields: {
+            artworks: numeral(({ artworks_count }) =>
+              artworks_count),
+            artists: numeral(({ artists_count }) =>
+              artists_count),
+            partner_artists: numeral(({ partner_artists_count }) =>
+              partner_artists_count),
+            eligible_artworks: numeral(({ eligible_artworks_count }) =>
+              eligible_artworks_count),
+            published_for_sale_artworks: numeral(({ published_for_sale_artworks_count }) =>
+              published_for_sale_artworks_count),
+            published_not_for_sale_artworks: numeral(({ published_not_for_sale_artworks_count }) =>
+              published_not_for_sale_artworks_count),
+            shows: numeral(({ shows_count }) =>
+              shows_count),
+            displayable_shows: numeral(({ displayable_shows_count }) =>
+              displayable_shows_count),
+            current_displayable_shows: numeral(({ current_displayable_shows_count }) =>
+              current_displayable_shows_count),
+            artist_documents: numeral(({ artist_documents_count }) =>
+              artist_documents_count),
+            partner_show_documents: numeral(({ partner_show_documents_count }) =>
+              partner_show_documents_count),
+          },
+        }),
+        resolve: (artist) => artist,
       },
     };
   },


### PR DESCRIPTION
@xtina-starr here are some metphysics changes for the artwork page's related artwork sections. adds a partner's artworks, you can use the `exclude` parmeter to exclude the id of the artwork whose page is currently being displayed. also adds size parameter to related artworks.

using the filter artworks endpoint with the partner_id param, instead of /partner/artworks because the latter doesn't support sorting, apparently