### PR TITLE
[Home] Add Relay Node support.

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,2 @@
-web: node_modules/.bin/nodemon index.js
+web: node_modules/.bin/nodemon --debug index.js
 memcached: memcached -p 11211

--- a/schema/home/home_page_module.js
+++ b/schema/home/home_page_module.js
@@ -14,8 +14,8 @@ import {
   GraphQLNonNull,
 } from 'graphql';
 
-export const HomePageModuleType = new GraphQLObjectType({
-  name: 'HomePageModule',
+export const HomePageModulesType = new GraphQLObjectType({
+  name: 'HomePageModules',
   interfaces: [NodeInterface],
   fields: () => ({
     __id: {
@@ -27,7 +27,7 @@ export const HomePageModuleType = new GraphQLObjectType({
         if (obj.params) {
           payload.id = obj.params.id;
         }
-        return toGlobalId('HomePageModule', JSON.stringify(payload));
+        return toGlobalId('HomePageModules', JSON.stringify(payload));
       },
     },
     key: {
@@ -49,7 +49,7 @@ export const HomePageModuleType = new GraphQLObjectType({
 });
 
 const HomePageModule = {
-  type: HomePageModuleType,
+  type: HomePageModulesType,
   description: 'Single module to show on the home screen',
   args: {
     key: {

--- a/schema/home/home_page_module.js
+++ b/schema/home/home_page_module.js
@@ -13,8 +13,8 @@ import {
   GraphQLNonNull,
 } from 'graphql';
 
-export const HomePageModulesType = new GraphQLObjectType({
-  name: 'HomePageModules',
+export const HomePageModuleType = new GraphQLObjectType({
+  name: 'HomePageModule',
   fields: () => ({
     __id: {
       type: new GraphQLNonNull(GraphQLID),
@@ -40,7 +40,7 @@ export const HomePageModulesType = new GraphQLObjectType({
 });
 
 const HomePageModule = {
-  type: HomePageModulesType,
+  type: HomePageModuleType,
   description: 'Single module to show on the home screen',
   args: {
     key: {

--- a/schema/home/home_page_module.js
+++ b/schema/home/home_page_module.js
@@ -14,8 +14,8 @@ import {
   GraphQLNonNull,
 } from 'graphql';
 
-export const HomePageModulesType = new GraphQLObjectType({
-  name: 'HomePageModules',
+export const HomePageModuleType = new GraphQLObjectType({
+  name: 'HomePageModule',
   interfaces: [NodeInterface],
   fields: () => ({
     __id: {
@@ -27,7 +27,7 @@ export const HomePageModulesType = new GraphQLObjectType({
         if (obj.params) {
           payload.id = obj.params.id;
         }
-        return toGlobalId('HomePageModules', JSON.stringify(payload));
+        return toGlobalId('HomePageModule', JSON.stringify(payload));
       },
     },
     key: {
@@ -49,7 +49,7 @@ export const HomePageModulesType = new GraphQLObjectType({
 });
 
 const HomePageModule = {
-  type: HomePageModulesType,
+  type: HomePageModuleType,
   description: 'Single module to show on the home screen',
   args: {
     key: {

--- a/schema/home/home_page_module.js
+++ b/schema/home/home_page_module.js
@@ -4,15 +4,23 @@ import Results from './results';
 import Title from './title';
 import Context from './context';
 import Params from './params';
+import { toGlobalId } from 'graphql-relay';
 import {
   GraphQLObjectType,
   GraphQLString,
   GraphQLBoolean,
+  GraphQLID,
+  GraphQLNonNull,
 } from 'graphql';
 
 export const HomePageModulesType = new GraphQLObjectType({
   name: 'HomePageModules',
   fields: () => ({
+    __id: {
+      type: new GraphQLNonNull(GraphQLID),
+      description: 'A globally unique ID.',
+      resolve: (obj) => toGlobalId('HomePageModules', JSON.stringify(obj)),
+    },
     key: {
       type: GraphQLString,
     },

--- a/schema/home/home_page_module.js
+++ b/schema/home/home_page_module.js
@@ -4,6 +4,7 @@ import Results from './results';
 import Title from './title';
 import Context from './context';
 import Params from './params';
+import { NodeInterface } from '../object_identification';
 import { toGlobalId } from 'graphql-relay';
 import {
   GraphQLObjectType,
@@ -15,11 +16,19 @@ import {
 
 export const HomePageModuleType = new GraphQLObjectType({
   name: 'HomePageModule',
+  interfaces: [NodeInterface],
   fields: () => ({
     __id: {
       type: new GraphQLNonNull(GraphQLID),
       description: 'A globally unique ID.',
-      resolve: (obj) => toGlobalId('HomePageModules', JSON.stringify(obj)),
+      resolve: (obj) => {
+        // Compose this ID from params that `resolve` uses to identify a rail later on.
+        const payload = { key: obj.key };
+        if (obj.params) {
+          payload.id = obj.params.id;
+        }
+        return toGlobalId('HomePageModule', JSON.stringify(payload));
+      },
     },
     key: {
       type: GraphQLString,
@@ -60,6 +69,8 @@ const HomePageModule = {
     }
     return { key, display: true };
   },
+  // ObjectIdentification
+  isType: (obj) => obj.hasOwnProperty('key') && obj.hasOwnProperty('display'),
 };
 
 export default HomePageModule;

--- a/schema/home/home_page_modules.js
+++ b/schema/home/home_page_modules.js
@@ -9,7 +9,7 @@ import {
   GraphQLList,
   GraphQLInt,
 } from 'graphql';
-import { HomePageModuleType } from './home_page_module';
+import { HomePageModulesType } from './home_page_module';
 import loggedOutModules from './logged_out_modules';
 import addGenericGenes from './add_generic_genes';
 import { featuredFair, featuredAuction } from './fetch';
@@ -21,7 +21,7 @@ const filteredModules = (modules, max_rails) => {
 };
 
 const HomePageModules = {
-  type: new GraphQLList(HomePageModuleType),
+  type: new GraphQLList(HomePageModulesType),
   description: 'Modules to show on the home screen',
   args: {
     max_rails: {

--- a/schema/home/home_page_modules.js
+++ b/schema/home/home_page_modules.js
@@ -9,7 +9,7 @@ import {
   GraphQLList,
   GraphQLInt,
 } from 'graphql';
-import { HomePageModulesType } from './home_page_module';
+import { HomePageModuleType } from './home_page_module';
 import loggedOutModules from './logged_out_modules';
 import addGenericGenes from './add_generic_genes';
 import { featuredFair, featuredAuction } from './fetch';
@@ -21,7 +21,7 @@ const filteredModules = (modules, max_rails) => {
 };
 
 const HomePageModules = {
-  type: new GraphQLList(HomePageModulesType),
+  type: new GraphQLList(HomePageModuleType),
   description: 'Modules to show on the home screen',
   args: {
     max_rails: {

--- a/schema/object_identification.js
+++ b/schema/object_identification.js
@@ -55,7 +55,7 @@ SupportedTypes.typeMap = SupportedTypes.files.reduce((typeMap, file) => {
   const type = _.upperFirst(_.camelCase(basename(file)));
   // TODO Fix incorrect plural naming of type: https://github.com/artsy/metaphysics/issues/353
   if (type === 'HomePageModule') {
-    typeMap['HomePageModules'] = file;
+    typeMap.HomePageModules = file;
   } else {
     typeMap[type] = file;
   }

--- a/schema/object_identification.js
+++ b/schema/object_identification.js
@@ -53,7 +53,12 @@ const SupportedTypes = {
 
 SupportedTypes.typeMap = SupportedTypes.files.reduce((typeMap, file) => {
   const type = _.upperFirst(_.camelCase(basename(file)));
-  typeMap[type] = file;
+  // TODO Fix incorrect plural naming of type: https://github.com/artsy/metaphysics/issues/353
+  if (type === 'HomePageModule') {
+    typeMap['HomePageModules'] = file;
+  } else {
+    typeMap[type] = file;
+  }
   return typeMap;
 }, {});
 
@@ -104,7 +109,7 @@ const NodeField = {
   resolve: (root, { __id }) => {
     const { type, id } = fromGlobalId(__id);
     if (_.includes(SupportedTypes.types, type)) {
-      const payload = type === 'HomePageModule' ? JSON.parse(id) : { id };
+      const payload = type === 'HomePageModules' ? JSON.parse(id) : { id };
       // Re-uses (slightly abuses) the existing GraphQL `resolve` function.
       return SupportedTypes.typeModules[type].resolve(null, payload);
     }

--- a/schema/object_identification.js
+++ b/schema/object_identification.js
@@ -53,12 +53,7 @@ const SupportedTypes = {
 
 SupportedTypes.typeMap = SupportedTypes.files.reduce((typeMap, file) => {
   const type = _.upperFirst(_.camelCase(basename(file)));
-  // TODO Fix incorrect plural naming of type: https://github.com/artsy/metaphysics/issues/353
-  if (type === 'HomePageModule') {
-    typeMap.HomePageModules = file;
-  } else {
-    typeMap[type] = file;
-  }
+  typeMap[type] = file;
   return typeMap;
 }, {});
 
@@ -109,7 +104,7 @@ const NodeField = {
   resolve: (root, { __id }) => {
     const { type, id } = fromGlobalId(__id);
     if (_.includes(SupportedTypes.types, type)) {
-      const payload = type === 'HomePageModules' ? JSON.parse(id) : { id };
+      const payload = type === 'HomePageModule' ? JSON.parse(id) : { id };
       // Re-uses (slightly abuses) the existing GraphQL `resolve` function.
       return SupportedTypes.typeModules[type].resolve(null, payload);
     }

--- a/schema/object_identification.js
+++ b/schema/object_identification.js
@@ -48,31 +48,26 @@ const SupportedTypes = {
     './home/home_page_module',
     './partner',
     './partner_show',
-  ],
-  get typeMap() {
-    delete this.typeMap;
-    this.typeMap = this.files.reduce((typeMap, file) => {
-      const type = _.upperFirst(_.camelCase(basename(file)));
-      typeMap[type] = file;
-      return typeMap;
-    }, {});
-    return this.typeMap;
-  },
-  get types() {
-    delete this.types;
-    this.types = _.keys(this.typeMap);
-    return this.types;
-  },
-  // To prevent circular dependencies, when this file is loaded, the modules are lazily loaded.
-  get typeModules() {
-    delete this.typeModules;
-    this.typeModules = this.types.reduce((modules, type) => {
-      modules[type] = require(this.typeMap[type]).default;
+  ]
+};
+
+SupportedTypes.typeMap = SupportedTypes.files.reduce((typeMap, file) => {
+  const type = _.upperFirst(_.camelCase(basename(file)));
+  typeMap[type] = file;
+  return typeMap;
+}, {});
+
+SupportedTypes.types = _.keys(SupportedTypes.typeMap);
+
+Object.defineProperty(SupportedTypes, 'typeModules', { get: () => {
+  if (SupportedTypes._typeModules === undefined) {
+    SupportedTypes._typeModules = SupportedTypes.types.reduce((modules, type) => {
+      modules[type] = require(SupportedTypes.typeMap[type]).default;
       return modules;
     }, {});
-    return this.typeModules;
-  },
-};
+  }
+  return SupportedTypes._typeModules;
+}});
 /* eslint-enable no-param-reassign */
 
 // Because we use a custom Node ID, we duplicate and slightly adjust the code from:

--- a/schema/object_identification.js
+++ b/schema/object_identification.js
@@ -48,7 +48,7 @@ const SupportedTypes = {
     './home/home_page_module',
     './partner',
     './partner_show',
-  ]
+  ],
 };
 
 SupportedTypes.typeMap = SupportedTypes.files.reduce((typeMap, file) => {
@@ -67,7 +67,7 @@ Object.defineProperty(SupportedTypes, 'typeModules', { get: () => {
     }, {});
   }
   return SupportedTypes._typeModules;
-}});
+} });
 /* eslint-enable no-param-reassign */
 
 // Because we use a custom Node ID, we duplicate and slightly adjust the code from:

--- a/test/schema/object_identification.js
+++ b/test/schema/object_identification.js
@@ -113,7 +113,7 @@ describe('Object Identification', () => {
           data.should.eql({
             home_page_module: {
               __id: globalId,
-            }
+            },
           });
         });
       });
@@ -142,7 +142,10 @@ describe('Object Identification', () => {
     });
 
     describe('with a generic gene', () => {
-      const globalId = toGlobalId('HomePageModules', JSON.stringify({ key: 'generic_gene', id: 'abstract-art' }));
+      const globalId = toGlobalId(
+        'HomePageModules',
+        JSON.stringify({ key: 'generic_gene', id: 'abstract-art' })
+      );
 
       it('generates a Global ID', () => {
         const query = `
@@ -157,7 +160,7 @@ describe('Object Identification', () => {
           data.should.eql({
             home_page_module: {
               __id: globalId,
-            }
+            },
           });
         });
       });

--- a/test/schema/object_identification.js
+++ b/test/schema/object_identification.js
@@ -95,4 +95,100 @@ describe('Object Identification', () => {
       });
     });
   });
+
+  describe('for a HomePageModule', () => {
+    describe('with a specific module', () => {
+      const globalId = toGlobalId('HomePageModule', JSON.stringify({ key: 'iconic_artists' }));
+
+      it('generates a Global ID', () => {
+        const query = `
+          {
+            home_page_module(key: "iconic_artists") {
+              __id
+            }
+          }
+        `;
+
+        return graphql(schema, query).then(({ data }) => {
+          data.should.eql({
+            home_page_module: {
+              __id: globalId,
+            }
+          });
+        });
+      });
+
+      it('resolves a node', () => {
+        const query = `
+          {
+            node(__id: "${globalId}") {
+              __typename
+              ... on HomePageModule {
+                key
+              }
+            }
+          }
+        `;
+
+        return graphql(schema, query).then(({ data }) => {
+          data.should.eql({
+            node: {
+              __typename: 'HomePageModule',
+              key: 'iconic_artists',
+            },
+          });
+        });
+      });
+    });
+
+    describe('with a generic gene', () => {
+      const globalId = toGlobalId('HomePageModule', JSON.stringify({ key: 'generic_gene', id: 'abstract-art' }));
+
+      it('generates a Global ID', () => {
+        const query = `
+          {
+            home_page_module(key: "generic_gene", id: "abstract-art") {
+              __id
+            }
+          }
+        `;
+
+        return graphql(schema, query).then(({ data }) => {
+          data.should.eql({
+            home_page_module: {
+              __id: globalId,
+            }
+          });
+        });
+      });
+
+      it('resolves a node', () => {
+        const query = `
+          {
+            node(__id: "${globalId}") {
+              __typename
+              ... on HomePageModule {
+                key
+                params {
+                  id
+                }
+              }
+            }
+          }
+        `;
+
+        return graphql(schema, query).then(({ data }) => {
+          data.should.eql({
+            node: {
+              __typename: 'HomePageModule',
+              key: 'generic_gene',
+              params: {
+                id: 'abstract-art',
+              },
+            },
+          });
+        });
+      });
+    });
+  });
 });

--- a/test/schema/object_identification.js
+++ b/test/schema/object_identification.js
@@ -98,7 +98,7 @@ describe('Object Identification', () => {
 
   describe('for a HomePageModule', () => {
     describe('with a specific module', () => {
-      const globalId = toGlobalId('HomePageModule', JSON.stringify({ key: 'iconic_artists' }));
+      const globalId = toGlobalId('HomePageModules', JSON.stringify({ key: 'iconic_artists' }));
 
       it('generates a Global ID', () => {
         const query = `
@@ -123,7 +123,7 @@ describe('Object Identification', () => {
           {
             node(__id: "${globalId}") {
               __typename
-              ... on HomePageModule {
+              ... on HomePageModules {
                 key
               }
             }
@@ -133,7 +133,7 @@ describe('Object Identification', () => {
         return graphql(schema, query).then(({ data }) => {
           data.should.eql({
             node: {
-              __typename: 'HomePageModule',
+              __typename: 'HomePageModules',
               key: 'iconic_artists',
             },
           });
@@ -142,7 +142,7 @@ describe('Object Identification', () => {
     });
 
     describe('with a generic gene', () => {
-      const globalId = toGlobalId('HomePageModule', JSON.stringify({ key: 'generic_gene', id: 'abstract-art' }));
+      const globalId = toGlobalId('HomePageModules', JSON.stringify({ key: 'generic_gene', id: 'abstract-art' }));
 
       it('generates a Global ID', () => {
         const query = `
@@ -167,7 +167,7 @@ describe('Object Identification', () => {
           {
             node(__id: "${globalId}") {
               __typename
-              ... on HomePageModule {
+              ... on HomePageModules {
                 key
                 params {
                   id
@@ -180,7 +180,7 @@ describe('Object Identification', () => {
         return graphql(schema, query).then(({ data }) => {
           data.should.eql({
             node: {
-              __typename: 'HomePageModule',
+              __typename: 'HomePageModules',
               key: 'generic_gene',
               params: {
                 id: 'abstract-art',

--- a/test/schema/object_identification.js
+++ b/test/schema/object_identification.js
@@ -98,7 +98,7 @@ describe('Object Identification', () => {
 
   describe('for a HomePageModule', () => {
     describe('with a specific module', () => {
-      const globalId = toGlobalId('HomePageModules', JSON.stringify({ key: 'iconic_artists' }));
+      const globalId = toGlobalId('HomePageModule', JSON.stringify({ key: 'iconic_artists' }));
 
       it('generates a Global ID', () => {
         const query = `
@@ -123,7 +123,7 @@ describe('Object Identification', () => {
           {
             node(__id: "${globalId}") {
               __typename
-              ... on HomePageModules {
+              ... on HomePageModule {
                 key
               }
             }
@@ -133,7 +133,7 @@ describe('Object Identification', () => {
         return graphql(schema, query).then(({ data }) => {
           data.should.eql({
             node: {
-              __typename: 'HomePageModules',
+              __typename: 'HomePageModule',
               key: 'iconic_artists',
             },
           });
@@ -143,7 +143,7 @@ describe('Object Identification', () => {
 
     describe('with a generic gene', () => {
       const globalId = toGlobalId(
-        'HomePageModules',
+        'HomePageModule',
         JSON.stringify({ key: 'generic_gene', id: 'abstract-art' })
       );
 
@@ -170,7 +170,7 @@ describe('Object Identification', () => {
           {
             node(__id: "${globalId}") {
               __typename
-              ... on HomePageModules {
+              ... on HomePageModule {
                 key
                 params {
                   id
@@ -183,7 +183,7 @@ describe('Object Identification', () => {
         return graphql(schema, query).then(({ data }) => {
           data.should.eql({
             node: {
-              __typename: 'HomePageModules',
+              __typename: 'HomePageModule',
               key: 'generic_gene',
               params: {
                 id: 'abstract-art',


### PR DESCRIPTION

This generates a globally unique ID for each rail based on `key` and `params.id`. It _could_ also do this based on `params.gene_id` and `params.medium`, which means that `params.id` could be removed entirely, but that assumes you would use the `__id` key to identify rails in Force as well. Not impossible, just something to keep in mind.

### Node ID

```graphql
{
  home_page {
    module(key: "generic_gene", id: "abstract-art") {
      __id
    }
  }
}
```

```json
{
  "data": {
    "home_page": {
      "module": {
        "__id": "SG9tZVBhZ2VNb2R1bGU6eyJrZXkiOiJnZW5lcmljX2dlbmUiLCJpZCI6ImFic3RyYWN0LWFydCJ9"
      }
    }
  }
}
```

### Node query

```graphql
{
  node(__id: "SG9tZVBhZ2VNb2R1bGU6eyJrZXkiOiJnZW5lcmljX2dlbmUiLCJpZCI6ImFic3RyYWN0LWFydCJ9") {
    __typename
    ... on HomePageModules {
      key
      title
      params {
        id
      }
    }
  }
}
```

```json
{
  "data": {
    "node": {
      "__typename": "HomePageModules",
      "key": "generic_gene",
      "title": "Abstract Painting",
      "params": {
        "id": "abstract-art"
      }
    }
  }
}
```