### PR TITLE
@joeyAghion - Fixes active/live discrepancy for artworks in Auctions

### DIFF
--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -168,7 +168,7 @@ const ArtworkType = new GraphQLObjectType({
         type: GraphQLBoolean,
         description: 'Is this artwork part of an auction?',
         resolve: ({ id }) => {
-          return gravity(`related/sales`, { size: 1, active: true, artwork: [id] })
+          return gravity(`related/sales`, { size: 1, live: true, artwork: [id] })
             .then(sales => _.some(sales, 'is_auction')).catch(() => false);
         },
       },

--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -168,7 +168,7 @@ const ArtworkType = new GraphQLObjectType({
         type: GraphQLBoolean,
         description: 'Is this artwork part of an auction?',
         resolve: ({ id }) => {
-          return gravity(`related/sales`, { size: 1, live: true, artwork: [id] })
+          return gravity(`related/sales`, { size: 1, artwork: [id] })
             .then(sales => _.some(sales, 'is_auction')).catch(() => false);
         },
       },
@@ -182,6 +182,14 @@ const ArtworkType = new GraphQLObjectType({
       is_for_sale: {
         type: GraphQLBoolean,
         resolve: ({ forsale }) => forsale,
+      },
+      is_biddable: {
+        type: GraphQLBoolean,
+        description: 'Is this artwork part of an auction that is currently running?',
+        resolve: ({ id }) => {
+          return gravity(`related/sales`, { size: 1, live: true, artwork: [id] })
+            .then(sales => _.some(sales, 'is_auction')).catch(() => false);
+        },
       },
       is_unique: {
         type: GraphQLBoolean,


### PR DESCRIPTION
Turns out we were interpreting this in different ways in different places. On the artwork page, `is_in_auction` is meant to ask if the artwork was ever part of an auction and on artwork thumbnails, `is_in_auction` is assumed to mean "is this artwork available to bid on?". This keeps `is_in_auction` the same and adds support for `is_biddable`.