### PR TITLE
Don’t return the same Node ID for multiple objects.

### DIFF
--- a/schema/image/index.js
+++ b/schema/image/index.js
@@ -8,7 +8,6 @@ import CroppedUrl from './cropped';
 import ResizedUrl from './resized';
 import DeepZoom, { isZoomable } from './deep_zoom';
 import normalize from './normalize';
-import { GlobalIDField } from '../object_identification';
 import {
   GraphQLObjectType,
   GraphQLString,
@@ -29,7 +28,6 @@ export const getDefault = images => {
 const ImageType = new GraphQLObjectType({
   name: 'Image',
   fields: () => ({
-    __id: GlobalIDField,
     id: {
       description: 'A type-specific ID.',
       type: GraphQLString,

--- a/schema/object_identification.js
+++ b/schema/object_identification.js
@@ -115,7 +115,9 @@ export const GlobalIDField = {
   name: '__id',
   description: 'A globally unique ID.',
   type: new GraphQLNonNull(GraphQLID),
-  resolve: (obj, args, info) => toGlobalId(info.parentType.name, obj.id),
+  // Ensure we never encode a null `id`, as it would silently work. Instead return `null`, so that
+  // e.g. Relay will complain about the result not matching the type specified in the schema.
+  resolve: (obj, args, info) => obj.id && toGlobalId(info.parentType.name, obj.id),
 };
 
 export const IDFields = {


### PR DESCRIPTION
This fixes https://github.com/artsy/emission/issues/205 (just need to update the schema there).

The problem was that the `Image` object for an `Article` is not actually its own object and its `id` was thus `null`. Because we encoded that `null` regardless, we ended up with the same `__id` value for each image and Relay would thus treat all those `Image` objects as if they were the same.

Now an `Image` no longer acts as if it has a `__id` and we also won’t encode `null` IDs any longer.