### PR TITLE
@broskoski => Merchandisable artists aggregation results

### DIFF
--- a/schema/aggregations/filter_artworks_aggregation.js
+++ b/schema/aggregations/filter_artworks_aggregation.js
@@ -42,6 +42,9 @@ export const ArtworksAggregation = new GraphQLEnumType({
     FOLLOWED_ARTISTS: {
       value: 'followed_artists',
     },
+    MERCHANDISABLE_ARTISTS: {
+      value: 'merchandisable_artists',
+    },
   },
 });
 

--- a/schema/filter_artworks.js
+++ b/schema/filter_artworks.js
@@ -1,6 +1,8 @@
 import gravity from '../lib/loaders/gravity';
-import { map, omit } from 'lodash';
+import { map, omit, keys } from 'lodash';
+import { isExisty } from '../lib/helpers';
 import Artwork from './artwork';
+import Artist from './artist';
 import {
   ArtworksAggregationResultsType,
   ArtworksAggregation,
@@ -27,6 +29,16 @@ export const FilterArtworksType = new GraphQLObjectType({
     followed_artists_total: {
       type: GraphQLInt,
       resolve: ({ aggregations }) => aggregations.followed_artists.value,
+    },
+    merchandisable_artists: {
+      type: new GraphQLList(Artist.type),
+      description: 'Returns a list of merchandisable artists sorted by merch score.',
+      resolve: ({ aggregations }) => {
+        if (!isExisty(aggregations.merchandisable_artists)) {
+          return null;
+        }
+        return gravity(`artists`, { ids: keys(aggregations.merchandisable_artists) });
+      },
     },
     aggregations: {
       description: 'Returns aggregation counts for the given filter query.',


### PR DESCRIPTION
<img width="1180" alt="screen shot 2016-07-14 at 4 04 39 pm" src="https://cloud.githubusercontent.com/assets/1457859/16853960/d7b7f832-49dc-11e6-977b-493ac9b9302e.png">

For use in: 
<img width="478" alt="screen shot 2016-07-14 at 11 41 37 am" src="https://cloud.githubusercontent.com/assets/1457859/16853969/e66c867c-49dc-11e6-8b26-9c58ea115b89.png">

This will just be an aggregation, where we also receive the actual artists in order of max merch score.