### PR TITLE
@broskoski => Add fields to fair schema and fairs endpoint

### DIFF
--- a/schema/fair.js
+++ b/schema/fair.js
@@ -43,6 +43,15 @@ const FairType = new GraphQLObjectType({
     has_full_feature: {
       type: GraphQLBoolean,
     },
+    has_homepage_section: {
+      type: GraphQLBoolean,
+    },
+    has_listing: {
+      type: GraphQLBoolean,
+    },
+    has_large_banner: {
+      type: GraphQLBoolean,
+    },
     href: {
       type: GraphQLString,
       resolve: ({ default_profile_id, organizer }) => {

--- a/schema/fairs.js
+++ b/schema/fairs.js
@@ -32,6 +32,12 @@ const Fairs = {
     has_full_feature: {
       type: GraphQLBoolean,
     },
+    has_homepage_section: {
+      type: GraphQLBoolean,
+    },
+    has_listing: {
+      type: GraphQLBoolean,
+    },
   },
   resolve: (root, options) => {
     if (options.near) {


### PR DESCRIPTION
Once https://github.com/artsy/gravity/pull/10283/files is deployed and data migrated, we can start switching to the new fields!

Only update needed is to Force/MicroG for listings, the large banner is a #no-op and https://github.com/artsy/metaphysics/pull/382/files took care of the homepage.