### PR TITLE
@craigspaeth - Fetch random related artist

### DIFF
--- a/schema/home/context.js
+++ b/schema/home/context.js
@@ -80,13 +80,16 @@ export const moduleContext = {
       return assign({}, fair, { context_type: 'Fair' });
     });
   },
-  related_artists: ({ accessToken }) => {
-    return followedArtist(accessToken).then((follow) => {
-      return relatedArtist(accessToken).then((artist) => ({
+  related_artists: ({ params }) => {
+    return Promise.all([
+      gravity(`artist/${params.related_artist_id}`),
+      gravity(`artist/${params.followed_artist_id}`),
+    ]).then(([related_artist, follow_artist]) => {
+      return assign({}, {
         context_type: 'Artist',
-        based_on: follow,
-        artist,
-      }));
+        based_on: follow_artist,
+        artist: related_artist,
+      });
     });
   },
   genes: ({ accessToken }) => {

--- a/schema/home/fetch.js
+++ b/schema/home/fetch.js
@@ -37,21 +37,12 @@ export const followedArtist = (accessToken) => {
   });
 };
 
-export const relatedArtist = (accessToken) => {
-  return followedArtist(accessToken).then((followed_artist) => {
-    return gravity
-      .with(accessToken)('me/suggested/artists', {
-        exclude_followed_artists: true,
-        exclude_artists_without_forsale_artworks: true,
-        artist_id: followed_artist._id,
-      })
-      .then((related_artists) => {
-        return {
-          followed_artist,
-          related_artist: first(related_artists),
-        };
-      });
-  });
+export const relatedArtist = (accessToken, userID) => {
+  return gravity.with(accessToken)(`user/${userID}/suggested/similar/artists`,{
+    exclude_artists_without_forsale_artworks: true,
+    exclude_artists_without_artworks: true,
+
+  })
 };
 
 export const iconicArtists = () => {

--- a/schema/home/fetch.js
+++ b/schema/home/fetch.js
@@ -33,7 +33,7 @@ export const relatedArtist = (accessToken, userID) => {
   return gravity.with(accessToken)(`user/${userID}/suggested/similar/artists`, {
     exclude_artists_without_forsale_artworks: true,
     exclude_followed_artists: true,
-  }).then( sample );
+  }).then(sample);
 };
 
 export const iconicArtists = () => {

--- a/schema/home/fetch.js
+++ b/schema/home/fetch.js
@@ -1,6 +1,6 @@
 import gravity from '../../lib/loaders/gravity';
 import delta from '../../lib/loaders/delta';
-import { sortBy, first, forEach, clone } from 'lodash';
+import { sortBy, first, forEach, clone, sample } from 'lodash';
 import blacklist from '../../lib/artist_blacklist';
 
 export const featuredFair = () => {
@@ -30,9 +30,9 @@ export const featuredGene = (accessToken) => {
 };
 
 export const followedArtist = (accessToken) => {
-  return gravity.with(accessToken)('me/follow/artists', { size: 1 }).then((follows) => {
+  return gravity.with(accessToken)('me/follow/artists', { size: 15 }).then((follows) => {
     if (follows.length) {
-      return first(follows).artist;
+      return sample(follows).artist;
     }
   });
 };
@@ -45,7 +45,12 @@ export const relatedArtist = (accessToken) => {
         exclude_artists_without_forsale_artworks: true,
         artist_id: followed_artist._id,
       })
-      .then(first);
+      .then((related_artists) => {
+        return {
+          followed_artist,
+          related_artist: first(related_artists),
+        };
+      });
   });
 };
 

--- a/schema/home/home_page_artwork_module.js
+++ b/schema/home/home_page_artwork_module.js
@@ -17,7 +17,7 @@ import {
   GraphQLNonNull,
 } from 'graphql';
 
-const HomePageArtworkModuleType = new GraphQLObjectType({
+export const HomePageArtworkModuleType = new GraphQLObjectType({
   name: 'HomePageArtworkModule',
   interfaces: [NodeInterface],
   isTypeOf: (obj) => has(obj, 'key') && has(obj, 'display'),

--- a/schema/home/home_page_artwork_module.js
+++ b/schema/home/home_page_artwork_module.js
@@ -64,12 +64,30 @@ export function createHomePageArtworkModule(moduleTypeName) {
       id: {
         type: GraphQLString,
         description: 'ID of generic gene rail to target',
+        deprecationReason: 'Favor more specific `generic_gene_id`',
+      },
+      generic_gene_id: {
+        type: GraphQLString,
+        description: 'ID of generic gene rail to target',
+        deprecationReason: 'Favor more specific `generic_gene_id`',
+      },
+      followed_artist_id: {
+        type: GraphQLString,
+        description: 'ID of followed artist to target for related artist rails',
+      },
+      related_artist_id: {
+        type: GraphQLString,
+        description: 'ID of related artist to target for related artist rails',
       },
     },
-    resolve: (root, { key, id }) => {
+    resolve: (root, { key, id, followed_artist_id, related_artist_id }) => {
       // is id a generic gene?
-      const params = find(genericGenes, ['id', id]);
+      let params = find(genericGenes, ['id', id]);
       if (params) {
+        return { key, params, display: true };
+      }
+      if (followed_artist_id && related_artist_id) {
+        params = { followed_artist_id, related_artist_id };
         return { key, params, display: true };
       }
       return { key, display: true };

--- a/schema/home/home_page_artwork_modules.js
+++ b/schema/home/home_page_artwork_modules.js
@@ -51,8 +51,6 @@ const HomePageArtworkModules = {
         if (relatedArtistIndex > -1) {
           return Promise.resolve(relatedArtist(accessToken, userID))
           .then(({ artist, sim_artist }) => {
-            console.log('artist', artist, 'sim_artist', sim_artist);
-
             const relatedArtistModuleParams = {
               followed_artist_id: sim_artist.id,
               related_artist_id: artist.id,

--- a/schema/home/home_page_artwork_modules.js
+++ b/schema/home/home_page_artwork_modules.js
@@ -11,7 +11,7 @@ import {
   GraphQLList,
   GraphQLInt,
 } from 'graphql';
-import HomePageArtworkModule from './home_page_artwork_module';
+import { HomePageArtworkModuleType } from './home_page_artwork_module';
 import loggedOutModules from './logged_out_modules';
 import addGenericGenes from './add_generic_genes';
 import { featuredFair, featuredAuction, relatedArtist } from './fetch';
@@ -22,61 +22,61 @@ const filterModules = (modules, max_rails) => {
   0, max_rails);
 };
 
-export function createHomePageArtworkModules(singularModule) {
-  return {
-    type: new GraphQLList(singularModule.type),
-    description: 'Artwork modules to show on the home screen',
-    args: {
-      max_rails: {
-        type: GraphQLInt,
-        description: 'Maximum number of modules to return',
-        defaultValue: 8,
-      },
+const HomePageArtworkModules = {
+  type: new GraphQLList(HomePageArtworkModuleType),
+  description: 'Artwork modules to show on the home screen',
+  args: {
+    max_rails: {
+      type: GraphQLInt,
+      description: 'Maximum number of modules to return',
+      defaultValue: 8,
     },
-    resolve: (root, { max_rails }, { rootValue: { accessToken, userID } }) => {
-      // If user is logged in, get their specific modules
-      if (accessToken) {
-        return gravity.with(accessToken)('me/modules').then((response) => {
-          const modules = map(keys(response), (key) => {
-            // We always want to show the followed_artists rail no matter what
-            const display = key === 'followed_artists' ? true : response[key];
-            return { key, display };
-          });
-          const filteredModules = filterModules(modules, max_rails);
-
-          // For the related artists rail, we need to fetch a random
-          // set of followed artist + related artist initially
-          // and pass it along so that any placeholder titles are consistent
-          const relatedArtistIndex = findIndex(filteredModules, ['key', 'related_artists']);
-          if (relatedArtistIndex) {
-            return Promise.resolve(relatedArtist(accessToken, userID))
-            .then(({ artist, sim_artist }) => {
-              const relatedArtistModuleParams = {
-                followed_artist_id: sim_artist.id,
-                related_artist_id: artist.id,
-              };
-              return set(
-                filteredModules,
-                `[${relatedArtistIndex}].params`,
-                relatedArtistModuleParams
-              );
-            });
-          }
-          return filteredModules;
+  },
+  resolve: (root, { max_rails }, { rootValue: { accessToken, userID } }) => {
+    // If user is logged in, get their specific modules
+    if (accessToken) {
+      return gravity.with(accessToken)('me/modules').then((response) => {
+        const modules = map(keys(response), (key) => {
+          // We always want to show the followed_artists rail no matter what
+          const display = key === 'followed_artists' ? true : response[key];
+          return { key, display };
         });
-      }
+        const filteredModules = filterModules(modules, max_rails);
 
-      // Otherwise, get the generic set of modules
-      return Promise.all([
-        featuredAuction(),
-        featuredFair(),
-      ]).then(([auction, fair]) => {
-        const modules = loggedOutModules(auction, fair);
-        return filterModules(modules, max_rails);
+        // For the related artists rail, we need to fetch a random
+        // set of followed artist + related artist initially
+        // and pass it along so that any placeholder titles are consistent
+        const relatedArtistIndex = findIndex(filteredModules, { key: 'related_artists' });
+
+        if (relatedArtistIndex > -1) {
+          return Promise.resolve(relatedArtist(accessToken, userID))
+          .then(({ artist, sim_artist }) => {
+            console.log('artist', artist, 'sim_artist', sim_artist);
+
+            const relatedArtistModuleParams = {
+              followed_artist_id: sim_artist.id,
+              related_artist_id: artist.id,
+            };
+            return set(
+              filteredModules,
+              `[${relatedArtistIndex}].params`,
+              relatedArtistModuleParams
+            );
+          });
+        }
+        return filteredModules;
       });
-    },
-  };
-}
+    }
 
-const HomePageArtworkModules = createHomePageArtworkModules(HomePageArtworkModule);
+    // Otherwise, get the generic set of modules
+    return Promise.all([
+      featuredAuction(),
+      featuredFair(),
+    ]).then(([auction, fair]) => {
+      const modules = loggedOutModules(auction, fair);
+      return filterModules(modules, max_rails);
+    });
+  },
+};
+
 export default HomePageArtworkModules;

--- a/schema/home/params.js
+++ b/schema/home/params.js
@@ -19,6 +19,12 @@ const HomePageModuleParams = new GraphQLObjectType({
     id: {
       type: GraphQLID,
     },
+    followed_artist_id: {
+      type: GraphQLID,
+    },
+    related_artist_id: {
+      type: GraphQLID,
+    },
   },
 });
 

--- a/schema/home/results.js
+++ b/schema/home/results.js
@@ -78,16 +78,12 @@ const moduleResults = {
       }
     });
   },
-  related_artists: ({ accessToken }) => {
-    return relatedArtist(accessToken).then((related_artist) => {
-      if (related_artist) {
-        return gravity('filter/artworks', {
-          artist_id: related_artist._id,
-          for_sale: true,
-          size: RESULTS_SIZE,
-        }).then(({ hits }) => hits);
-      }
-    });
+  related_artists: ({ params }) => {
+    return gravity('filter/artworks', {
+      artist_id: params.related_artist_id,
+      for_sale: true,
+      size: RESULTS_SIZE,
+    }).then(({ hits }) => hits);
   },
   genes: ({ accessToken }) => {
     return featuredGene(accessToken).then((gene) => {

--- a/schema/home/results.js
+++ b/schema/home/results.js
@@ -5,7 +5,6 @@ import {
   featuredFair,
   featuredGene,
   iconicArtists,
-  relatedArtist,
 } from './fetch';
 import { map, assign, keys, without, shuffle, slice } from 'lodash';
 import { toQueryString } from '../../lib/helpers';

--- a/schema/home/title.js
+++ b/schema/home/title.js
@@ -2,8 +2,8 @@ import {
   featuredAuction,
   featuredFair,
   featuredGene,
-  relatedArtist,
 } from './fetch';
+import gravity from '../../lib/loaders/gravity';
 import { GraphQLString } from 'graphql';
 
 const moduleTitle = {
@@ -27,11 +27,9 @@ const moduleTitle = {
       }
     });
   },
-  related_artists: ({ accessToken }) => {
-    return relatedArtist(accessToken).then((related_artist) => {
-      if (related_artist) {
-        return `Works by ${related_artist.name}`;
-      }
+  related_artists: ({ params }) => {
+    return gravity(`artist/${params.related_artist_id}`).then((artist) => {
+      return `Works by ${artist.name}`;
     });
   },
   genes: ({ accessToken }) => {

--- a/test/schema/home/home_page_artwork_module.js
+++ b/test/schema/home/home_page_artwork_module.js
@@ -32,15 +32,10 @@ describe('HomePageArtworkModule', () => {
     HomePageArtworkModule.__ResetDependency__('gravity');
   });
 
-  describe('when signed-out', () => {
+  describe('when signed out', () => {
     it('returns the proper title for iconic_artists', () => {
       return runQuery(query('iconic_artists')).then(({ home_page }) => {
         home_page.artwork_module.title.should.eql('Works by Iconic Artists');
-      });
-    });
-    it('returns the proper title for current_fairs', () => {
-      return runQuery(query('current_fairs')).then(({ home_page }) => {
-        home_page.artwork_module.title.should.eql("Current Fair: Cabbie's Fair, Y'all");
       });
     });
   });

--- a/test/schema/home/home_page_artwork_modules.js
+++ b/test/schema/home/home_page_artwork_modules.js
@@ -1,0 +1,95 @@
+import { map, find } from 'lodash';
+import sinon from 'sinon';
+import schema from '../../../schema';
+import { runAuthenticatedQuery } from '../../helper';
+
+describe('HomePageArtworkModules', () => {
+  const query = `
+    {
+      home_page {
+        artwork_modules {
+          key
+          params {
+            related_artist_id
+            followed_artist_id
+          }
+        }
+      }
+    }
+  `;
+  describe('when signed in', () => {
+    const HomePage = schema.__get__('HomePage');
+    const HomePageArtworkModules = HomePage.__get__('HomePageArtworkModules');
+
+    let gravity;
+    let modules;
+    let relatedArtistsResponse;
+    let relatedArtist;
+
+    beforeEach(() => {
+      modules = {
+        active_bids: false,
+        followed_artists: false,
+        followed_galleries: true,
+        saved_works: true,
+        recommended_works: true,
+        live_auctions: false,
+        current_fairs: true,
+        related_artists: true,
+        genes: false,
+      };
+
+      relatedArtistsResponse = {
+        sim_artist: { id: 'pablo-picasso' },
+        artist: { id: 'charles-broskoski' },
+      };
+
+      gravity = sinon.stub();
+      gravity.with = sinon.stub().returns(gravity);
+      relatedArtist = sinon.stub();
+
+      HomePageArtworkModules.__Rewire__('gravity', gravity);
+      HomePageArtworkModules.__Rewire__('relatedArtist', relatedArtist);
+
+      gravity
+        // Modules fetch
+        .onCall(0)
+        .returns(Promise.resolve(modules));
+      relatedArtist
+        .onCall(0)
+        .returns(Promise.resolve(relatedArtistsResponse));
+    });
+
+    afterEach(() => {
+      HomePageArtworkModules.__ResetDependency__('gravity');
+    });
+
+    it('shows all modules that should be returned', () => {
+      return runAuthenticatedQuery(query).then(({ home_page }) => {
+        const keys = map(home_page.artwork_modules, 'key');
+
+        // followed artists should always return true
+        // the default module response is 8 keys
+        keys.should.eql([
+          'followed_artists',
+          'followed_galleries',
+          'saved_works',
+          'recommended_works',
+          'current_fairs',
+          'related_artists',
+          'generic_gene',
+          'generic_gene',
+        ]);
+
+        const relatedArtistsModule = find(home_page.artwork_modules, { key: 'related_artists' });
+        relatedArtistsModule.params.should.eql({
+          related_artist_id: 'charles-broskoski',
+          followed_artist_id: 'pablo-picasso',
+        });
+      });
+    });
+  });
+  describe('when signed-out', () => {
+    // nothing for now
+  });
+});


### PR DESCRIPTION
Sorry for the sloppy history, picking up something I've been tinkering with for a while.

Right now on the homepage, we fetch the last artist the user followed and get an related suggestion based on that. That works fine, but what would be better is if we fetched a different random artist / related pair every time. The tricky part here is that two requests have to match up:

1. On page load we get a response of all the modules that _should_ be displayed. The client should be able to render parts of these modules initially as placeholders (like the title).
2. Then on the client side we fetch each module again individually with all the results, depending on what keys and parameters are returned in the initial fetch. This means that the random artist / related pair needs to match up between the first fetch and the secondary fetch. So.....

The approach now is, if the `me/modules` returns for a user that we _should_ show a related artists rail (i.e. the user follows any artist), we hit the `user/${userID}/suggested/similar/artists`, get some results, pick out a random pair, and then drop it into the `params` object for the subsequent to use.

With me??????

cc @mzikherman @alloy 

p.s. Hi @alloy, I'm back again.