### PR TITLE
@mzikherman => [Home/Artist] Exclude followed artists from trending/popular.

### DIFF
--- a/schema/home/home_page_artist_module.js
+++ b/schema/home/home_page_artist_module.js
@@ -16,6 +16,13 @@ import {
   GraphQLString,
 } from 'graphql';
 
+function fetchArtists(path) {
+  return (accessToken) => {
+    const loader = accessToken ? gravity.with(accessToken) : gravity;
+    return loader(path, accessToken && { exclude_followed_artists: true });
+  };
+}
+
 // This object is used for both the `key` argument enum and to do fetching.
 export const HomePageArtistModuleTypes = {
   SUGGESTED: {
@@ -40,12 +47,12 @@ export const HomePageArtistModuleTypes = {
   TRENDING: {
     description: 'The trending artists.',
     display: () => Promise.resolve(true),
-    resolve: () => gravity('artists/trending'),
+    resolve: fetchArtists('artists/trending'),
   },
   POPULAR: {
     description: 'The most searched for artists.',
     display: () => Promise.resolve(true),
-    resolve: () => gravity('artists/popular'),
+    resolve: fetchArtists('artists/popular'),
   },
 };
 


### PR DESCRIPTION
When signed it in the `exclude_followed_artists` parameter is included.

For whatever reason `exclude_followed_artists` didn’t seem to work properly yet on staging (cache no invalidated) but it does on production, or maybe I was just doing something wrong. Anyways, keep that in mind when trying it out.