### PR TITLE
@bhoggard - Omit page and size from options passed

### DIFF
--- a/lib/loaders/total.js
+++ b/lib/loaders/total.js
@@ -1,4 +1,4 @@
-import { assign } from 'lodash';
+import { assign, omit } from 'lodash';
 import { toKey } from '../helpers';
 import qs from 'qs';
 import url from 'url';
@@ -24,7 +24,7 @@ export const total = (path, accessToken, options = {}) => {
 export const totalLoader = httpLoader(total);
 
 const load = (path, options = {}) => {
-  const key = toKey(path, assign({}, options));
+  const key = toKey(path, assign({}, omit(options, 'page', 'size')));
 
   return totalLoader.load(key)
     .then(response => response.total);


### PR DESCRIPTION
Here's a complicated explanation, get ready...... 

1. https://github.com/artsy/metaphysics/blob/master/schema/sale/index.js#L136 has default arguments and they were being passed down to the `gravity.all` loader (which is a little unnecessary, but ok).
2. We recently changed the way `total` gets called (which passes options down here https://github.com/artsy/metaphysics/blob/master/lib/all.js#L10 , in this case `page` and `size` where in the options (because they were default values). 
3. Because our cache uses args + path as the cache key, `total` was overwriting the first response's cache (which was identical to the `all` loader requesting the first page).

 