### PR TITLE
@broskoski => Pass access token along for artwork request

### DIFF
--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -469,7 +469,12 @@ const Artwork = {
       description: 'The slug or ID of the Artwork',
     },
   },
-  resolve: (root, { id }) => gravity(`artwork/${id}`),
+  resolve: (root, { id }, { rootValue: { accessToken } }) => {
+    if(accessToken) {
+      return gravity.with(accessToken)(`artwork/${id}`);
+    }
+    return gravity(`artwork/${id}`);
+  },
 };
 
 export default Artwork;


### PR DESCRIPTION
For the record, all that was needed to get unpublished artworks to 'work', passing along the user token.

Similar updates would happen to get that to work on other contexts/pages.