### PR TITLE
[Home/Fair Artworks] Hotfix to work around Gravity bug.

### DIFF
--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -39,6 +39,8 @@ import {
   GraphQLInt,
 } from 'graphql';
 
+let Artwork;
+
 const ArtworkType = new GraphQLObjectType({
   name: 'Artwork',
   interfaces: [NodeInterface],
@@ -447,7 +449,7 @@ const ArtworkType = new GraphQLObjectType({
           },
         },
         resolve: ({ _id }, { size }) =>
-          gravity('related/artworks', { artwork_id: _id, size: size })
+          gravity('related/artworks', { artwork_id: _id, size }),
       },
       layer: {
         type: ArtworkLayer.type,
@@ -470,7 +472,7 @@ const ArtworkType = new GraphQLObjectType({
   },
 });
 
-const Artwork = {
+Artwork = {
   type: ArtworkType,
   description: 'An Artwork',
   args: {

--- a/schema/home/fetch.js
+++ b/schema/home/fetch.js
@@ -4,7 +4,9 @@ import { sortBy, first, forEach, clone, sample } from 'lodash';
 import blacklist from '../../lib/artist_blacklist';
 
 export const featuredFair = () => {
-  return gravity('fairs', { size: 5, active: true, has_homepage_section: true }).then((fairs) => {
+  // FIXME: Until this Gravity bug is fixed https://github.com/artsy/gravity/issues/10347,
+  //        the order of the query parameters is hardcoded to ensure results.
+  return gravity('fairs?has_homepage_section=true&active=true&size=5').then((fairs) => {
     if (fairs.length) {
       return first(sortBy(fairs, ({ banner_size }) =>
         ['x-large', 'large', 'medium', 'small', 'x-small'].indexOf(banner_size)


### PR DESCRIPTION
Fixes https://github.com/artsy/emission/issues/276

See https://github.com/artsy/gravity/issues/10347.

This issue would in some cases cause no fairs to be returned from Gravity. (I guess JS object -> query params encoding has undefined order?)