### PR TITLE
@broskoski Add eligible_artworks_count to partner show schema.

### DIFF
--- a/schema/partner_show.js
+++ b/schema/partner_show.js
@@ -9,6 +9,7 @@ import {
 } from 'lodash';
 import gravity from '../lib/loaders/gravity';
 import total from '../lib/loaders/total';
+import numeral from './fields/numeral';
 import { exhibitionPeriod, exhibitionStatus } from '../lib/date';
 import cached from './fields/cached';
 import date from './fields/date';
@@ -151,6 +152,8 @@ const PartnerShowType = new GraphQLObjectType({
               return total(`partner/${partner.id}/show/${id}/artworks`, options);
             },
           },
+          eligible_artworks: numeral(({ eligible_artworks_count }) =>
+            eligible_artworks_count),
         },
       }),
       resolve: (partner_show) => partner_show,

--- a/test/schema/partner_show.js
+++ b/test/schema/partner_show.js
@@ -22,6 +22,7 @@ describe('PartnerShow type', () => {
         id: 'new-museum',
       },
       display_on_partner_profile: true,
+      eligible_artworks_count: 8,
     };
     gravity.returns(Promise.resolve(showData));
 
@@ -143,6 +144,29 @@ describe('PartnerShow type', () => {
           partner_show: {
             counts: {
               artworks: 42,
+            },
+          },
+        });
+      });
+  });
+
+  it('includes the total number of eligible artworks', () => {
+    const query = `
+      {
+        partner_show(id: "new-museum-1-2015-triennial-surround-audience") {
+          counts {
+            eligible_artworks
+          }
+        }
+      }
+    `;
+
+    return graphql(schema, query)
+      .then(({ data }) => {
+        data.should.eql({
+          partner_show: {
+            counts: {
+              eligible_artworks: 8,
             },
           },
         });


### PR DESCRIPTION
Re: https://github.com/artsy/force/issues/124

We want to include the eligible artworks (published artworks) count of a show in the Sailthru meta tags. It's currently not in the schema but returned in the Gravity [json response](https://github.com/artsy/gravity/blob/3a4a342b738fd3fcffb96aec5c8d09b260241753/app/models/domain/partner_show.rb#L123). This adds it to the schema.

Is there anything I need to do besides the test?