### PR TITLE
[PartnerShow] Don’t return an error when there’s no cover image.

### DIFF
--- a/schema/partner_show.js
+++ b/schema/partner_show.js
@@ -229,8 +229,8 @@ const PartnerShowType = new GraphQLObjectType({
           published: true,
         })
           .then(artworks => {
-            const { images } = artworks[0];
-            return Image.resolve(getDefault(images));
+            const artwork = artworks[0];
+            return artwork && Image.resolve(getDefault(artwork.images));
           });
       },
     },

--- a/test/schema/partner_show.js
+++ b/test/schema/partner_show.js
@@ -2,14 +2,16 @@ import sinon from 'sinon';
 import moment from 'moment';
 import { graphql } from 'graphql';
 import schema from '../../schema';
+import { runQuery } from '../helper';
 
 describe('PartnerShow type', () => {
   const PartnerShow = schema.__get__('PartnerShow');
   let total = null;
+  let gravity = null;
   let showData = null;
 
   beforeEach(() => {
-    const gravity = sinon.stub();
+    gravity = sinon.stub();
     total = sinon.stub();
 
     showData = {
@@ -196,6 +198,29 @@ describe('PartnerShow type', () => {
               artworks: 2,
             },
           },
+        });
+      });
+  });
+
+  it('does not return errors when there is no cover image', () => {
+    gravity
+      .onCall(1)
+      .returns(Promise.resolve([]));
+
+    const query = `
+      {
+        partner_show(id: "new-museum-1-2015-triennial-surround-audience") {
+          cover_image {
+            id
+          }
+        }
+      }
+    `;
+
+    return runQuery(query)
+      .then(({ partner_show }) => {
+        partner_show.should.eql({
+          cover_image: null,
         });
       });
   });


### PR DESCRIPTION
This was returning an error, which Relay, being a ‘type safety’ pedantic lib, interprets as not being reliable data.

```json
{
  "data": { … },
  "errors": [
    {
      "message": "Cannot read property 'images' of undefined",
      "locations": [
        {
          "line": 5,
          "column": 7
        }
      ]
    }
  ]
}
```