### PR TITLE
[logging] Symbolicate stack traces.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -261,7 +261,19 @@
         "babel-register": {
           "version": "6.8.0",
           "from": "babel-register@>=6.8.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.8.0.tgz"
+          "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.8.0.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.32",
+              "from": "source-map@0.1.32",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz"
+            },
+            "source-map-support": {
+              "version": "0.2.10",
+              "from": "source-map-support@>=0.2.10 <0.3.0",
+              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz"
+            }
+          }
         },
         "babel-runtime": {
           "version": "6.6.1",
@@ -615,6 +627,16 @@
           "version": "3.10.1",
           "from": "lodash@>=3.10.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+        },
+        "source-map": {
+          "version": "0.1.32",
+          "from": "source-map@0.1.32",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz"
+        },
+        "source-map-support": {
+          "version": "0.2.10",
+          "from": "source-map-support@>=0.2.10 <0.3.0",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz"
         }
       }
     },
@@ -3139,14 +3161,14 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
     },
     "source-map-support": {
-      "version": "0.2.10",
-      "from": "source-map-support@>=0.2.10 <0.3.0",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+      "version": "0.4.3",
+      "from": "source-map-support@latest",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.3.tgz",
       "dependencies": {
         "source-map": {
-          "version": "0.1.32",
-          "from": "source-map@0.1.32",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz"
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.3 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "numeral": "^1.5.3",
     "qs": "^5.2.0",
     "react": "^0.14.3",
-    "request": "^2.67.0"
+    "request": "^2.67.0",
+    "source-map-support": "^0.4.3"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",

--- a/server.js
+++ b/server.js
@@ -13,6 +13,8 @@ import { info, error } from './lib/loggers';
 import auth from './lib/auth';
 import graphqlErrorHandler from './lib/graphql-error-handler';
 
+import 'source-map-support/register';
+
 const {
   PORT,
   NODE_ENV,


### PR DESCRIPTION
This is required to go from a stack trace in a compiled file:

```
TypeError: Cannot read property 'id' of null
    at resolve (index.js:102:44)
    at resolveOrError (/app/node_modules/graphql/execution/execute.js:426:12)
```

To the real source:

```
TypeError: Cannot read property 'id' of null
    at resolve (/Users/eloy/Code/Artsy/metaphysics/schema/artwork/index.js:173:61)
    at resolveOrError (/Users/eloy/Code/Artsy/metaphysics/node_modules/graphql/execution/execute.js:426:12)
```