### PR TITLE
@alloy => Add an API loader for Galaxy to retrieve non-Artsy partners

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -8,6 +8,7 @@ GOOGLE_CSE_API_BASE=https://www.googleapis.test/customsearch/v1
 METAPHYSICS_STAGING_ENDPOINT=https://metaphysics-staging.artsy.net
 METAPHYSICS_PRODUCTION_ENDPOINT=https://metaphysics-production.artsy.net
 HMAC_SECRET=https://www.youtube.com/watch?v=F5bAa6gFvLs
+GALAXY_API_BASE=https://galaxy-production-herokuapp.com
 
 NODE_ENV=test
 GRAVITY_ID=xxx_artsy_id_xxx
@@ -18,3 +19,4 @@ GOOGLE_CSE_KEY=xxx_google_cse_key_xxx
 BASIC_AUTH_USERNAME=foo
 BASIC_AUTH_PASSWORD=bar
 RESIZING_SERVICE=gemini
+GALAXY_TOKEN=galaxy_token

--- a/.env.test
+++ b/.env.test
@@ -8,7 +8,7 @@ GOOGLE_CSE_API_BASE=https://www.googleapis.test/customsearch/v1
 METAPHYSICS_STAGING_ENDPOINT=https://metaphysics-staging.artsy.net
 METAPHYSICS_PRODUCTION_ENDPOINT=https://metaphysics-production.artsy.net
 HMAC_SECRET=https://www.youtube.com/watch?v=F5bAa6gFvLs
-GALAXY_API_BASE=https://galaxy-production-herokuapp.com
+GALAXY_API_BASE=https://galaxy-staging-herokuapp.com
 
 NODE_ENV=test
 GRAVITY_ID=xxx_artsy_id_xxx

--- a/lib/apis/galaxy.js
+++ b/lib/apis/galaxy.js
@@ -1,0 +1,12 @@
+import fetch from './fetch';
+
+const { GALAXY_API_BASE, GALAXY_TOKEN } = process.env;
+
+export default (path) => {
+  const headers = {
+    Accept: 'application/vnd.galaxy-admin+json',
+    'Content-Type': 'application/hal+json',
+    'Http-Authorization': GALAXY_TOKEN,
+  };
+  return fetch(`${GALAXY_API_BASE}/${path}`, { headers });
+};

--- a/lib/apis/galaxy.js
+++ b/lib/apis/galaxy.js
@@ -4,7 +4,7 @@ const { GALAXY_API_BASE, GALAXY_TOKEN } = process.env;
 
 export default (path) => {
   const headers = {
-    Accept: 'application/vnd.galaxy-admin+json',
+    Accept: 'application/vnd.galaxy-public+json',
     'Content-Type': 'application/hal+json',
     'Http-Authorization': GALAXY_TOKEN,
   };

--- a/lib/loaders/galaxy.js
+++ b/lib/loaders/galaxy.js
@@ -1,0 +1,8 @@
+import { toKey } from '../helpers';
+import galaxy from '../apis/galaxy';
+import httpLoader from './http';
+
+export const galaxyLoader = httpLoader(galaxy);
+
+export default (path, options = {}) =>
+  galaxyLoader.load(toKey(path, options));

--- a/test/lib/apis/galaxy.js
+++ b/test/lib/apis/galaxy.js
@@ -1,0 +1,71 @@
+import galaxy from '../../../lib/apis/galaxy';
+
+describe('APIs', () => {
+  describe('galaxy', () => {
+    const fetch = galaxy.__get__('fetch');
+
+    afterEach(() => {
+      fetch.__ResetDependency__('request');
+    });
+
+    it('makes a correct request to galaxy', () => {
+      const request = sinon.stub().yields(null, { statusCode: 200, body: {} });
+      fetch.__Rewire__('request', request);
+
+      return galaxy('foo/bar').then(() => {
+        expect(request.args[0][0]).to.equal('https://galaxy-production-herokuapp.com/foo/bar');
+        expect(request.args[0][1]).to.eql({
+          headers: {
+            Accept: 'application/vnd.galaxy-admin+json',
+            'Content-Type': 'application/hal+json',
+            'Http-Authorization': 'galaxy_token',
+          },
+          method: 'GET',
+          timeout: 5000,
+        });
+      });
+    });
+
+    it('resolves when there is a successful JSON response', () => {
+      const request = sinon.stub().yields(null, { statusCode: 200, body: { foo: 'bar' } });
+      fetch.__Rewire__('request', request);
+
+      return galaxy('foo/bar').then(({ body: { foo } }) => {
+        expect(foo).to.equal('bar');
+      });
+    });
+
+    it('tries to parse the response when there is a String and resolves with it', () => {
+      const request = sinon.stub().yields(null, {
+        statusCode: 200,
+        body: JSON.stringify({ foo: 'bar' }),
+      });
+      fetch.__Rewire__('request', request);
+
+      return galaxy('foo/bar').then(({ body: { foo } }) => {
+        expect(foo).to.equal('bar');
+      });
+    });
+
+    it('rejects request errors', () => {
+      const request = sinon.stub().yields(new Error('bad'));
+      fetch.__Rewire__('request', request);
+
+      return expect(galaxy('foo/bar')).to.be.rejectedWith('bad');
+    });
+
+    it('rejects API errors', () => {
+      const request = sinon.stub().yields(null, { statusCode: 401, body: 'Unauthorized' });
+      fetch.__Rewire__('request', request);
+
+      return expect(galaxy('foo/bar')).to.be.rejectedWith('Unauthorized');
+    });
+
+    it('rejects parse errors', () => {
+      const request = sinon.stub().yields(null, { statusCode: 200, body: 'not json' });
+      fetch.__Rewire__('request', request);
+
+      return expect(galaxy('foo/bar')).to.be.rejectedWith(/Unexpected token o/);
+    });
+  });
+});

--- a/test/lib/apis/galaxy.js
+++ b/test/lib/apis/galaxy.js
@@ -16,7 +16,7 @@ describe('APIs', () => {
         expect(request.args[0][0]).to.equal('https://galaxy-production-herokuapp.com/foo/bar');
         expect(request.args[0][1]).to.eql({
           headers: {
-            Accept: 'application/vnd.galaxy-admin+json',
+            Accept: 'application/vnd.galaxy-public+json',
             'Content-Type': 'application/hal+json',
             'Http-Authorization': 'galaxy_token',
           },

--- a/test/lib/apis/galaxy.js
+++ b/test/lib/apis/galaxy.js
@@ -13,7 +13,7 @@ describe('APIs', () => {
       fetch.__Rewire__('request', request);
 
       return galaxy('foo/bar').then(() => {
-        expect(request.args[0][0]).to.equal('https://galaxy-production-herokuapp.com/foo/bar');
+        expect(request.args[0][0]).to.equal('https://galaxy-staging-herokuapp.com/foo/bar');
         expect(request.args[0][1]).to.eql({
           headers: {
             Accept: 'application/vnd.galaxy-public+json',


### PR DESCRIPTION
I'm going to need to be able to query [Galaxy](https://github.com/artsy/galaxy-api) for non-Artsy partners. Some partner shows can include a `galaxy_partner_id`, which is a reference to the corresponding entry in Galaxy.

This just adds in the boilerplate, similar to the positron and gravity loaders.

Up next: I need to figure out how to make the `partner` node resolve to a potentially different type, a 'Galaxy partner', which I'm still struggling with doing the 'GraphQL way' (ie- how can a node resolve to one of two types?). That will actually use this, but in the meantime...