### PR TITLE
@alloy => New Show schema, and includes ExternalPartner

### DIFF
--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -321,7 +321,6 @@ const ArtistType = new GraphQLObjectType({
             gravity('related/shows', {
               artist_id: id,
               sort: '-end_at',
-              displayable: true,
               is_institution: true,
               highest_tier: true,
               solo_show: true,
@@ -332,7 +331,6 @@ const ArtistType = new GraphQLObjectType({
             gravity('related/shows', {
               artist_id: id,
               sort: '-end_at',
-              displayable: true,
               is_institution: false,
               highest_tier: true,
               solo_show: true,
@@ -343,7 +341,6 @@ const ArtistType = new GraphQLObjectType({
             gravity('related/shows', {
               artist_id: id,
               sort: '-end_at',
-              displayable: true,
               is_institution: true,
               highest_tier: true,
               solo_show: false,
@@ -354,7 +351,6 @@ const ArtistType = new GraphQLObjectType({
             gravity('related/shows', {
               artist_id: id,
               sort: '-end_at',
-              displayable: true,
               is_institution: false,
               highest_tier: true,
               solo_show: false,
@@ -365,7 +361,6 @@ const ArtistType = new GraphQLObjectType({
             gravity('related/shows', {
               artist_id: id,
               sort: '-end_at',
-              displayable: true,
               is_institution: true,
               highest_tier: false,
               solo_show: true,
@@ -376,8 +371,8 @@ const ArtistType = new GraphQLObjectType({
             gravity('related/shows', {
               artist_id: id,
               sort: '-end_at',
-              displayable: true,
               is_institution: false,
+              is_reference: true,
               highest_tier: false,
               solo_show: true,
               at_a_fair: false,
@@ -387,7 +382,6 @@ const ArtistType = new GraphQLObjectType({
             gravity('related/shows', {
               artist_id: id,
               sort: '-end_at',
-              displayable: true,
               is_institution: true,
               highest_tier: false,
               solo_show: false,
@@ -398,9 +392,9 @@ const ArtistType = new GraphQLObjectType({
             gravity('related/shows', {
               artist_id: id,
               sort: '-end_at',
-              displayable: true,
               is_institution: false,
               highest_tier: false,
+              is_reference: true,
               solo_show: false,
               at_a_fair: false,
               size: options.size,
@@ -409,7 +403,6 @@ const ArtistType = new GraphQLObjectType({
             gravity('related/shows', {
               artist_id: id,
               sort: '-end_at',
-              displayable: true,
               at_a_fair: true,
               size: options.size,
             }),
@@ -444,7 +437,6 @@ const ArtistType = new GraphQLObjectType({
         resolve: ({ id }, options) => {
           return gravity('related/shows', defaults(options, {
             artist_id: id,
-            displayable: true,
             sort: '-end_at',
           }));
         },

--- a/schema/external_partner.js
+++ b/schema/external_partner.js
@@ -7,8 +7,8 @@ import {
   GraphQLNonNull,
 } from 'graphql';
 
-const GalaxyPartnerType = new GraphQLObjectType({
-  name: 'GalaxyPartner',
+const ExternalPartnerType = new GraphQLObjectType({
+  name: 'ExternalPartner',
   fields: () => {
     return {
       ...IDFields,
@@ -20,9 +20,9 @@ const GalaxyPartnerType = new GraphQLObjectType({
   },
 });
 
-const GalaxyPartner = {
-  type: GalaxyPartnerType,
-  description: 'A Galaxy Partner',
+const ExternalPartner = {
+  type: ExternalPartnerType,
+  description: 'An External Partner not on the platform',
   args: {
     id: {
       type: new GraphQLNonNull(GraphQLString),
@@ -32,4 +32,4 @@ const GalaxyPartner = {
   resolve: (id) => galaxy(`galleries/${id}`),
 };
 
-export default GalaxyPartner;
+export default ExternalPartner;

--- a/schema/galaxy_partner.js
+++ b/schema/galaxy_partner.js
@@ -1,0 +1,35 @@
+import galaxy from '../lib/loaders/galaxy';
+import { IDFields } from './object_identification';
+
+import {
+  GraphQLString,
+  GraphQLObjectType,
+  GraphQLNonNull,
+} from 'graphql';
+
+const GalaxyPartnerType = new GraphQLObjectType({
+  name: 'GalaxyPartner',
+  fields: () => {
+    return {
+      ...IDFields,
+      name: {
+        type: GraphQLString,
+        resolve: ({ name }) => name.trim(),
+      },
+    };
+  },
+});
+
+const GalaxyPartner = {
+  type: GalaxyPartnerType,
+  description: 'A Galaxy Partner',
+  args: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: 'The ID of the Partner',
+    },
+  },
+  resolve: (id) => galaxy(`galleries/${id}`),
+};
+
+export default GalaxyPartner;

--- a/schema/index.js
+++ b/schema/index.js
@@ -5,9 +5,9 @@ import Artwork from './artwork';
 import Artworks from './artworks';
 import Artist from './artist';
 import Artists from './artists';
+import ExternalPartner from './external_partner';
 import Fair from './fair';
 import Fairs from './fairs';
-import GalaxyPartner from './galaxy_partner';
 import Gene from './gene';
 import HomePage from './home';
 import OrderedSets from './ordered_sets';
@@ -46,9 +46,9 @@ const schema = new GraphQLSchema({
       artworks: Artworks,
       artist: Artist,
       artists: Artists,
+      external_partner: ExternalPartner,
       fair: Fair,
       fairs: Fairs,
-      galaxy_partner: GalaxyPartner,
       gene: Gene,
       home_page: HomePage,
       profile: Profile,

--- a/schema/index.js
+++ b/schema/index.js
@@ -23,6 +23,7 @@ import Sale from './sale/index';
 import Sales from './sales';
 import SaleArtwork from './sale_artwork';
 import Search from './search';
+import Show from './show';
 import TrendingArtists from './trending';
 import Me from './me';
 import CausalityJWT from './causality_jwt';
@@ -62,6 +63,7 @@ const schema = new GraphQLSchema({
       sales: Sales,
       sale_artwork: SaleArtwork,
       search: Search,
+      show: Show,
       trending_artists: TrendingArtists,
       me: Me,
       causality_jwt: CausalityJWT,

--- a/schema/index.js
+++ b/schema/index.js
@@ -7,6 +7,7 @@ import Artist from './artist';
 import Artists from './artists';
 import Fair from './fair';
 import Fairs from './fairs';
+import GalaxyPartner from './galaxy_partner';
 import Gene from './gene';
 import HomePage from './home';
 import OrderedSets from './ordered_sets';
@@ -47,6 +48,7 @@ const schema = new GraphQLSchema({
       artists: Artists,
       fair: Fair,
       fairs: Fairs,
+      galaxy_partner: GalaxyPartner,
       gene: Gene,
       home_page: HomePage,
       profile: Profile,

--- a/schema/partner_show.js
+++ b/schema/partner_show.js
@@ -30,7 +30,6 @@ import {
   GraphQLList,
   GraphQLInt,
   GraphQLBoolean,
-  GraphQLUnionType,
 } from 'graphql';
 
 const kind = ({ artists, fair }) => {
@@ -102,26 +101,17 @@ const PartnerShowType = new GraphQLObjectType({
       type: new GraphQLList(Artist.type),
       resolve: ({ artists }) => artists,
     },
-    partner: {
-      type: new GraphQLUnionType({
-        name: 'PartnerTypes',
-        types: [
-          Partner.type,
-          GalaxyPartner.type,
-        ],
-        resolveType: (value) => {
-          if (value._links) {
-            return GalaxyPartner.type;
-          }
-          return Partner.type;
-        },
-      }),
-      resolve: ({ partner, galaxy_partner_id }) => {
-        if (partner) {
-          return partner;
+    galaxy_partner: {
+      type: GalaxyPartner.type,
+      resolve: ({ galaxy_partner_id }) => {
+        if (galaxy_partner_id) {
+          return GalaxyPartner.resolve(galaxy_partner_id);
         }
-        return GalaxyPartner.resolve(galaxy_partner_id);
       },
+    },
+    partner: {
+      type: Partner.type,
+      resolve: ({ partner }) => partner,
     },
     fair: {
       type: Fair.type,

--- a/schema/partner_show.js
+++ b/schema/partner_show.js
@@ -16,7 +16,6 @@ import date from './fields/date';
 import { markdown } from './fields/markdown';
 import Artist from './artist';
 import Partner from './partner';
-import GalaxyPartner from './galaxy_partner';
 import Fair from './fair';
 import Artwork from './artwork';
 import Location from './location';
@@ -40,7 +39,7 @@ const kind = ({ artists, fair }) => {
 
 const PartnerShowType = new GraphQLObjectType({
   name: 'PartnerShow',
-  description: 'Deprecated in favor of Show',
+  deprecationReason: 'Prefer to use Show schema',
   interfaces: [NodeInterface],
   isTypeOf: (obj) => has(obj, 'partner') && has(obj, 'display_on_partner_profile'),
   fields: () => ({
@@ -101,14 +100,6 @@ const PartnerShowType = new GraphQLObjectType({
     artists: {
       type: new GraphQLList(Artist.type),
       resolve: ({ artists }) => artists,
-    },
-    galaxy_partner: {
-      type: GalaxyPartner.type,
-      resolve: ({ galaxy_partner_id }) => {
-        if (galaxy_partner_id) {
-          return GalaxyPartner.resolve(galaxy_partner_id);
-        }
-      },
     },
     partner: {
       type: Partner.type,

--- a/schema/show.js
+++ b/schema/show.js
@@ -16,7 +16,7 @@ import date from './fields/date';
 import { markdown } from './fields/markdown';
 import Artist from './artist';
 import Partner from './partner';
-import GalaxyPartner from './galaxy_partner';
+import ExternalPartner from './external_partner';
 import Fair from './fair';
 import Artwork from './artwork';
 import Location from './location';
@@ -107,11 +107,11 @@ const ShowType = new GraphQLObjectType({
         name: 'PartnerTypes',
         types: [
           Partner.type,
-          GalaxyPartner.type,
+          ExternalPartner.type,
         ],
         resolveType: (value) => {
           if (value._links) {
-            return GalaxyPartner.type;
+            return ExternalPartner.type;
           }
           return Partner.type;
         },
@@ -120,7 +120,7 @@ const ShowType = new GraphQLObjectType({
         if (partner) {
           return partner;
         }
-        return GalaxyPartner.resolve(galaxy_partner_id);
+        return ExternalPartner.resolve(galaxy_partner_id);
       },
     },
     fair: {

--- a/schema/show.js
+++ b/schema/show.js
@@ -30,6 +30,7 @@ import {
   GraphQLList,
   GraphQLInt,
   GraphQLBoolean,
+  GraphQLUnionType,
 } from 'graphql';
 
 const kind = ({ artists, fair }) => {
@@ -38,9 +39,8 @@ const kind = ({ artists, fair }) => {
   if (artists.length === 1) return 'solo';
 };
 
-const PartnerShowType = new GraphQLObjectType({
-  name: 'PartnerShow',
-  description: 'Deprecated in favor of Show',
+const ShowType = new GraphQLObjectType({
+  name: 'Show',
   interfaces: [NodeInterface],
   isTypeOf: (obj) => has(obj, 'partner') && has(obj, 'display_on_partner_profile'),
   fields: () => ({
@@ -102,17 +102,26 @@ const PartnerShowType = new GraphQLObjectType({
       type: new GraphQLList(Artist.type),
       resolve: ({ artists }) => artists,
     },
-    galaxy_partner: {
-      type: GalaxyPartner.type,
-      resolve: ({ galaxy_partner_id }) => {
-        if (galaxy_partner_id) {
-          return GalaxyPartner.resolve(galaxy_partner_id);
-        }
-      },
-    },
     partner: {
-      type: Partner.type,
-      resolve: ({ partner }) => partner,
+      type: new GraphQLUnionType({
+        name: 'PartnerTypes',
+        types: [
+          Partner.type,
+          GalaxyPartner.type,
+        ],
+        resolveType: (value) => {
+          if (value._links) {
+            return GalaxyPartner.type;
+          }
+          return Partner.type;
+        },
+      }),
+      resolve: ({ partner, galaxy_partner_id }) => {
+        if (partner) {
+          return partner;
+        }
+        return GalaxyPartner.resolve(galaxy_partner_id);
+      },
     },
     fair: {
       type: Fair.type,
@@ -148,7 +157,7 @@ const PartnerShowType = new GraphQLObjectType({
     },
     counts: {
       type: new GraphQLObjectType({
-        name: 'PartnerShowCounts',
+        name: 'ShowCounts',
         fields: {
           artworks: {
             type: GraphQLInt,
@@ -267,22 +276,22 @@ const PartnerShowType = new GraphQLObjectType({
   }),
 });
 
-const PartnerShow = {
-  type: PartnerShowType,
-  description: 'A Partner Show',
+const Show = {
+  type: ShowType,
+  description: 'A Show',
   args: {
     id: {
       type: new GraphQLNonNull(GraphQLString),
-      description: 'The slug or ID of the PartnerShow',
+      description: 'The slug or ID of the Show',
     },
   },
   resolve: (root, { id }) => {
     return gravity(`show/${id}`)
       .then(show => {
-        if (!show.displayable) return new Error('Show Not Found');
+        if (!show.displayable && !show.is_reference) return new Error('Show Not Found');
         return show;
       });
   },
 };
 
-export default PartnerShow;
+export default Show;

--- a/test/schema/show.js
+++ b/test/schema/show.js
@@ -1,0 +1,223 @@
+import moment from 'moment';
+
+describe('Show type', () => {
+  const Show = schema.__get__('Show');
+  let total = null;
+  let gravity = null;
+  let showData = null;
+
+  beforeEach(() => {
+    gravity = sinon.stub();
+    total = sinon.stub();
+
+    showData = {
+      id: 'new-museum-1-2015-triennial-surround-audience',
+      start_at: '2015-02-25T12:00:00+00:00',
+      end_at: '2015-05-24T12:00:00+00:00',
+      press_release: '**foo** *bar*',
+      displayable: true,
+      partner: {
+        id: 'new-museum',
+      },
+      display_on_partner_profile: true,
+      eligible_artworks_count: 8,
+    };
+    gravity.returns(Promise.resolve(showData));
+
+    Show.__Rewire__('gravity', gravity);
+    Show.__Rewire__('total', total);
+  });
+
+  afterEach(() => {
+    Show.__ResetDependency__('gravity');
+    Show.__ResetDependency__('total');
+  });
+
+  it('includes a formattable start and end date', () => {
+    const query = `
+      {
+        show(id: "new-museum-1-2015-triennial-surround-audience") {
+          id
+          start_at(format: "dddd, MMMM Do YYYY, h:mm:ss a")
+          end_at(format: "YYYY")
+        }
+      }
+    `;
+
+    return runQuery(query)
+      .then(data => {
+        expect(Show.__get__('gravity').args[0][0])
+          .to.equal('show/new-museum-1-2015-triennial-surround-audience');
+
+        expect(data).to.eql({
+          show: {
+            id: 'new-museum-1-2015-triennial-surround-audience',
+            start_at: 'Wednesday, February 25th 2015, 12:00:00 pm',
+            end_at: '2015',
+          },
+        });
+      });
+  });
+
+  it('includes a formatted exhibition period', () => {
+    const query = `
+      {
+        show(id: "new-museum-1-2015-triennial-surround-audience") {
+          exhibition_period
+        }
+      }
+    `;
+
+    return runQuery(query)
+      .then(data => {
+        expect(data).to.eql({
+          show: {
+            exhibition_period: 'Feb 25 – May 24, 2015',
+          },
+        });
+      });
+  });
+
+  it('includes an update on upcoming status changes', () => {
+    showData.end_at = moment().add(1, 'd');
+
+    const query = `
+      {
+        show(id: "new-museum-1-2015-triennial-surround-audience") {
+          status_update
+        }
+      }
+    `;
+
+    return runQuery(query)
+      .then(data => {
+        expect(data).to.eql({
+          show: {
+            status_update: 'Closing tomorrow',
+          },
+        });
+      });
+  });
+
+  it('includes the html version of markdown', () => {
+    const query = `
+      {
+        show(id: "new-museum-1-2015-triennial-surround-audience") {
+          press_release(format: markdown)
+        }
+      }
+    `;
+
+    return runQuery(query)
+      .then(data => {
+        expect(Show.__get__('gravity').args[0][0])
+          .to.equal('show/new-museum-1-2015-triennial-surround-audience');
+
+        expect(data).to.eql({
+          show: {
+            press_release: '<p><strong>foo</strong> <em>bar</em></p>\n',
+          },
+        });
+      });
+  });
+
+  it('includes the total number of artworks', () => {
+    total
+      .onCall(0)
+      .returns(Promise.resolve(42));
+
+    const query = `
+      {
+        show(id: "new-museum-1-2015-triennial-surround-audience") {
+          counts {
+            artworks
+          }
+        }
+      }
+    `;
+
+    return runQuery(query)
+      .then(data => {
+        expect(data).to.eql({
+          show: {
+            counts: {
+              artworks: 42,
+            },
+          },
+        });
+      });
+  });
+
+  it('includes the total number of eligible artworks', () => {
+    const query = `
+      {
+        show(id: "new-museum-1-2015-triennial-surround-audience") {
+          counts {
+            eligible_artworks
+          }
+        }
+      }
+    `;
+
+    return runQuery(query)
+      .then(data => {
+        expect(data).to.eql({
+          show: {
+            counts: {
+              eligible_artworks: 8,
+            },
+          },
+        });
+      });
+  });
+
+  it('includes the number of artworks by a specific artist', () => {
+    total
+      .onCall(0)
+      .returns(Promise.resolve(2));
+
+    const query = `
+      {
+        show(id: "new-museum-1-2015-triennial-surround-audience") {
+          counts {
+            artworks(artist_id: "juliana-huxtable")
+          }
+        }
+      }
+    `;
+
+    return runQuery(query)
+      .then(data => {
+        expect(data).to.eql({
+          show: {
+            counts: {
+              artworks: 2,
+            },
+          },
+        });
+      });
+  });
+
+  it('does not return errors when there is no cover image', () => {
+    gravity
+      .onCall(1)
+      .returns(Promise.resolve([]));
+
+    const query = `
+      {
+        show(id: "new-museum-1-2015-triennial-surround-audience") {
+          cover_image {
+            id
+          }
+        }
+      }
+    `;
+
+    return runQuery(query)
+      .then(({ show }) => {
+        expect(show).to.eql({
+          cover_image: null,
+        });
+      });
+  });
+});

--- a/test/schema/show.js
+++ b/test/schema/show.js
@@ -2,7 +2,7 @@ import moment from 'moment';
 
 describe('Show type', () => {
   const Show = schema.__get__('Show');
-  const GalaxyPartner = schema.__get__('GalaxyPartner');
+  const ExternalPartner = schema.__get__('ExternalPartner');
   let total = null;
   let gravity = null;
   let galaxy = null;
@@ -36,13 +36,13 @@ describe('Show type', () => {
     galaxy.returns(Promise.resolve(galaxyData));
 
     Show.__Rewire__('gravity', gravity);
-    GalaxyPartner.__Rewire__('galaxy', galaxy);
+    ExternalPartner.__Rewire__('galaxy', galaxy);
     Show.__Rewire__('total', total);
   });
 
   afterEach(() => {
     Show.__ResetDependency__('gravity');
-    GalaxyPartner.__ResetDependency__('galaxy');
+    ExternalPartner.__ResetDependency__('galaxy');
     Show.__ResetDependency__('total');
   });
 
@@ -53,7 +53,7 @@ describe('Show type', () => {
       {
         show(id: "new-museum-1-2015-triennial-surround-audience") {
           partner {
-            ... on GalaxyPartner {
+            ... on ExternalPartner {
               name
             }
           }


### PR DESCRIPTION
This includes the Galaxy commits from https://github.com/artsy/metaphysics/pull/422

Idk if this is the right approach, but we can now get the partner name from a show like this (which works for Artsy or Galaxy partners):

<img width="823" alt="screen shot 2016-10-05 at 10 28 13 pm" src="https://cloud.githubusercontent.com/assets/1457859/19138532/087435a8-8b4b-11e6-9002-d32bd233d174.png">

However, this breaks the regular approach:

<img width="960" alt="screen shot 2016-10-05 at 10 28 52 pm" src="https://cloud.githubusercontent.com/assets/1457859/19138544/20eb7394-8b4b-11e6-9f52-cd5d83deff7d.png">

I don't mind updating Force (and other clients), but there might be lots of places that query partner attributes (from a show) in the original style. Is this the right approach? Or something more graceful?
