### PR TITLE
@alloy => Switch to Show over PartnerShow for exhibition highlights of an artist #dontmerge

### DIFF
--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -17,7 +17,6 @@ import Article from '../article';
 import Artwork from '../artwork';
 import PartnerArtist from '../partner_artist';
 import Meta from './meta';
-import PartnerShow from '../partner_show';
 import Show from '../show';
 import Sale from '../sale/index';
 import ArtworkSorts from '../sorts/artwork_sorts';
@@ -412,7 +411,7 @@ const ArtistType = new GraphQLObjectType({
       },
 
       partner_shows: {
-        type: new GraphQLList(PartnerShow.type),
+        type: new GraphQLList(Show.type),
         args: {
           at_a_fair: {
             type: GraphQLBoolean,

--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -18,6 +18,7 @@ import Artwork from '../artwork';
 import PartnerArtist from '../partner_artist';
 import Meta from './meta';
 import PartnerShow from '../partner_show';
+import Show from '../show';
 import Sale from '../sale/index';
 import ArtworkSorts from '../sorts/artwork_sorts';
 import ArticleSorts from '../sorts/article_sorts';
@@ -310,11 +311,11 @@ const ArtistType = new GraphQLObjectType({
         args: {
           size: {
             type: GraphQLInt,
-            description: 'The number of Artists to return',
+            description: 'The number of Shows to return',
             defaultValue: 5,
           },
         },
-        type: new GraphQLList(PartnerShow.type),
+        type: new GraphQLList(Show.type),
         resolve: ({ id }, options) => {
           return Promise.all([
             // Highest tier solo institutional shows

--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -17,6 +17,7 @@ import Article from '../article';
 import Artwork from '../artwork';
 import PartnerArtist from '../partner_artist';
 import Meta from './meta';
+import PartnerShow from '../partner_show';
 import Show from '../show';
 import Sale from '../sale/index';
 import ArtworkSorts from '../sorts/artwork_sorts';
@@ -411,7 +412,8 @@ const ArtistType = new GraphQLObjectType({
       },
 
       partner_shows: {
-        type: new GraphQLList(Show.type),
+        type: new GraphQLList(PartnerShow.type),
+        deprecationReason: 'Prefer to use shows attribute',
         args: {
           at_a_fair: {
             type: GraphQLBoolean,
@@ -425,6 +427,38 @@ const ArtistType = new GraphQLObjectType({
           size: {
             type: GraphQLInt,
             description: 'The number of PartnerShows to return',
+          },
+          solo_show: {
+            type: GraphQLBoolean,
+          },
+          top_tier: {
+            type: GraphQLBoolean,
+          },
+          sort: PartnerShowSorts,
+        },
+        resolve: ({ id }, options) => {
+          return gravity('related/shows', defaults(options, {
+            artist_id: id,
+            sort: '-end_at',
+          }));
+        },
+      },
+
+      shows: {
+        type: new GraphQLList(Show.type),
+        args: {
+          at_a_fair: {
+            type: GraphQLBoolean,
+          },
+          active: {
+            type: GraphQLBoolean,
+          },
+          status: {
+            type: GraphQLString,
+          },
+          size: {
+            type: GraphQLInt,
+            description: 'The number of Shows to return',
           },
           solo_show: {
             type: GraphQLBoolean,

--- a/schema/external_partner.js
+++ b/schema/external_partner.js
@@ -16,6 +16,10 @@ const ExternalPartnerType = new GraphQLObjectType({
         type: GraphQLString,
         resolve: ({ name }) => name.trim(),
       },
+      city: {
+        type: GraphQLString,
+        resolve: ({ city }) => city,
+      },
     };
   },
 });

--- a/schema/show.js
+++ b/schema/show.js
@@ -42,7 +42,7 @@ const kind = ({ artists, fair }) => {
 const ShowType = new GraphQLObjectType({
   name: 'Show',
   interfaces: [NodeInterface],
-  isTypeOf: (obj) => has(obj, 'partner') && has(obj, 'display_on_partner_profile'),
+  isTypeOf: (obj) => has(obj, 'is_reference') && has(obj, 'display_on_partner_profile'),
   fields: () => ({
     ...GravityIDFields,
     cached,

--- a/test/schema/show.js
+++ b/test/schema/show.js
@@ -25,6 +25,7 @@ describe('Show type', () => {
       },
       display_on_partner_profile: true,
       eligible_artworks_count: 8,
+      is_reference: true,
     };
     gravity.returns(Promise.resolve(showData));
 


### PR DESCRIPTION
## Don't Merge

This is a breaking change to the `exhibition_highlights` field in the `Artist` schema. I don't think we have a choice here (and I'd rather not duplicate the artist schema) as this field is the one I'd like to take advantage of the new `Show` schema.

I can get the updates ready in Force/MG, where the way you query `partner` attributes from `exhibition_highlights` will change to the `... on ExternalPartner` and `... on Partner` style. I'll update here when those PR's are ready. 

I think we can just make sure to merge/deploy the clients, I'll make sure to deploy Metaphysics (which is fast) as soon as the clients are deployed. I think that'll minimize downtime.

Big question- is this being used in iOS land?