### PR TITLE
@alloy => Add best_city to accomodate the ref show cities

### DIFF
--- a/schema/show.js
+++ b/schema/show.js
@@ -49,7 +49,10 @@ const ShowType = new GraphQLObjectType({
     cached,
     href: {
       type: GraphQLString,
-      resolve: ({ id }) => `/show/${id}`,
+      resolve: ({ id, is_reference }) => {
+        if (is_reference) return null;
+        return `/show/${id}`;
+      },
     },
     kind: {
       type: GraphQLString,

--- a/schema/show.js
+++ b/schema/show.js
@@ -2,6 +2,7 @@ import moment from 'moment';
 import {
   isExisty,
   exclude,
+  existyValue,
 } from '../lib/helpers';
 import {
   find,
@@ -130,6 +131,15 @@ const ShowType = new GraphQLObjectType({
     location: {
       type: Location.type,
       resolve: ({ location, fair_location }) => location || fair_location,
+    },
+    best_city: {
+      type: GraphQLString,
+      resolve: ({ location, partner_city }) => {
+        if (location && isExisty(location.city)) {
+          return existyValue(location.city);
+        }
+        return existyValue(partner_city);
+      },
     },
     status: {
       type: GraphQLString,

--- a/schema/show.js
+++ b/schema/show.js
@@ -135,7 +135,7 @@ const ShowType = new GraphQLObjectType({
       type: Location.type,
       resolve: ({ location, fair_location }) => location || fair_location,
     },
-    best_city: {
+    city: {
       type: GraphQLString,
       resolve: ({ location, partner_city }) => {
         if (location && isExisty(location.city)) {

--- a/test/schema/show.js
+++ b/test/schema/show.js
@@ -88,6 +88,44 @@ describe('Show type', () => {
     });
   });
 
+  describe('href', () => {
+    it('returns the href for a regular show', () => {
+      showData.is_reference = false;
+      const query = `
+        {
+          show(id: "new-museum-1-2015-triennial-surround-audience") {
+            href
+          }
+        }
+      `;
+      return runQuery(query)
+        .then(data => {
+          expect(data).to.eql({
+            show: {
+              href: '/show/new-museum-1-2015-triennial-surround-audience',
+            },
+          });
+        });
+    });
+    it('returns null for a reference show', () => {
+      const query = `
+        {
+          show(id: "new-museum-1-2015-triennial-surround-audience") {
+            href
+          }
+        }
+      `;
+      return runQuery(query)
+        .then(data => {
+          expect(data).to.eql({
+            show: {
+              href: null,
+            },
+          });
+        });
+    });
+  });
+
   it('includes the galaxy partner information when galaxy_partner_id is present', () => {
     showData.galaxy_partner_id = 'galaxy-partner';
     showData.partner = null;

--- a/test/schema/show.js
+++ b/test/schema/show.js
@@ -47,14 +47,14 @@ describe('Show type', () => {
     Show.__ResetDependency__('total');
   });
 
-  describe('best_city', () => {
+  describe('city', () => {
     it('returns the location city if one is set', () => {
       showData.location = { city: 'Quonochontaug' };
       showData.partner_city = 'Something Else';
       const query = `
         {
           show(id: "new-museum-1-2015-triennial-surround-audience") {
-            best_city
+            city
           }
         }
       `;
@@ -62,7 +62,7 @@ describe('Show type', () => {
         .then(data => {
           expect(data).to.eql({
             show: {
-              best_city: 'Quonochontaug',
+              city: 'Quonochontaug',
             },
           });
         });
@@ -73,7 +73,7 @@ describe('Show type', () => {
       const query = `
         {
           show(id: "new-museum-1-2015-triennial-surround-audience") {
-            best_city
+            city
           }
         }
       `;
@@ -81,7 +81,7 @@ describe('Show type', () => {
         .then(data => {
           expect(data).to.eql({
             show: {
-              best_city: 'Quonochontaug',
+              city: 'Quonochontaug',
             },
           });
         });

--- a/test/schema/show.js
+++ b/test/schema/show.js
@@ -47,6 +47,47 @@ describe('Show type', () => {
     Show.__ResetDependency__('total');
   });
 
+  describe('best_city', () => {
+    it('returns the location city if one is set', () => {
+      showData.location = { city: 'Quonochontaug' };
+      showData.partner_city = 'Something Else';
+      const query = `
+        {
+          show(id: "new-museum-1-2015-triennial-surround-audience") {
+            best_city
+          }
+        }
+      `;
+      return runQuery(query)
+        .then(data => {
+          expect(data).to.eql({
+            show: {
+              best_city: 'Quonochontaug',
+            },
+          });
+        });
+    });
+    it('returns the partner_city if one is set', () => {
+      showData.partner_city = 'Quonochontaug';
+      showData.location = null;
+      const query = `
+        {
+          show(id: "new-museum-1-2015-triennial-surround-audience") {
+            best_city
+          }
+        }
+      `;
+      return runQuery(query)
+        .then(data => {
+          expect(data).to.eql({
+            show: {
+              best_city: 'Quonochontaug',
+            },
+          });
+        });
+    });
+  });
+
   it('includes the galaxy partner information when galaxy_partner_id is present', () => {
     showData.galaxy_partner_id = 'galaxy-partner';
     showData.partner = null;


### PR DESCRIPTION
The last piece of the puzzle for 
<img width="395" alt="screen shot 2016-10-07 at 2 15 31 pm" src="https://cloud.githubusercontent.com/assets/1457859/19200724/884ad572-8c98-11e6-9f05-6262a32bdbe4.png">

(rendering the Partner-submitted Admin-moderated reference shows!) is the city name. In Gravity, a show can have two kinds of city fields.

[One](https://github.com/artsy/gravity/blob/c0114584039fd424021a7ca3f6c5c6fd49a50f37/app/models/domain/partner_show.rb#L38) is a rich `Location` object with other attributes.

[The other](https://github.com/artsy/gravity/blob/c0114584039fd424021a7ca3f6c5c6fd49a50f37/app/models/domain/partner_show.rb#L32) is a simple string field, however all UI's that feed into it are powered by Google Maps location search, so the data should be well structured.

I'm not crazy about this `best_city` name, what do you think?
