### PR TITLE
@alloy => Update kind of show to support reference shows, where artists lack artworks

### DIFF
--- a/test/schema/show.js
+++ b/test/schema/show.js
@@ -88,6 +88,103 @@ describe('Show type', () => {
     });
   });
 
+  describe('kind', () => {
+    it('returns fair when a fair booth', () => {
+      showData.fair = { id: 'foo' };
+      const query = `
+        {
+          show(id: "new-museum-1-2015-triennial-surround-audience") {
+            kind
+          }
+        }
+      `;
+      return runQuery(query)
+        .then(data => {
+          expect(data).to.eql({
+            show: {
+              kind: 'fair',
+            },
+          });
+        });
+    });
+    it('returns solo when only one artist in a ref show', () => {
+      showData.artists = [];
+      showData.artists_without_artworks = [{ id: 'foo' }];
+      const query = `
+        {
+          show(id: "new-museum-1-2015-triennial-surround-audience") {
+            kind
+          }
+        }
+      `;
+      return runQuery(query)
+        .then(data => {
+          expect(data).to.eql({
+            show: {
+              kind: 'solo',
+            },
+          });
+        });
+    });
+    it('returns group when more than one artist in a ref show', () => {
+      showData.artists = [];
+      showData.artists_without_artworks = [{ id: 'foo' }, { id: 'bar' }];
+      const query = `
+        {
+          show(id: "new-museum-1-2015-triennial-surround-audience") {
+            kind
+          }
+        }
+      `;
+      return runQuery(query)
+        .then(data => {
+          expect(data).to.eql({
+            show: {
+              kind: 'group',
+            },
+          });
+        });
+    });
+    it('returns solo when only one artist', () => {
+      showData.artists = [{ id: 'foo' }];
+      showData.artists_without_artworks = null;
+      const query = `
+        {
+          show(id: "new-museum-1-2015-triennial-surround-audience") {
+            kind
+          }
+        }
+      `;
+      return runQuery(query)
+        .then(data => {
+          expect(data).to.eql({
+            show: {
+              kind: 'solo',
+            },
+          });
+        });
+    });
+    it('returns group when more than one artist in a regular show show', () => {
+      showData.artists = [{ id: 'foo' }, { id: 'bar' }];
+      showData.artists_without_artworks = null;
+      const query = `
+        {
+          show(id: "new-museum-1-2015-triennial-surround-audience") {
+            kind
+          }
+        }
+      `;
+      return runQuery(query)
+        .then(data => {
+          expect(data).to.eql({
+            show: {
+              kind: 'group',
+            },
+          });
+        });
+    });
+  });
+
   describe('href', () => {
     it('returns the href for a regular show', () => {
       showData.is_reference = false;


### PR DESCRIPTION
In order to classify shows as 'group', or 'solo', (or a fair booth), the `artists` node was examined. For reference shows, we associate artists directly to a show w/o artworks. Because this is pretty different than the usual association of artists only through artworks, I exposed that as `artists_without_artworks` in the show JSON.

This updates that definition. After the recent Metaphysics PR's, the grand update to the Force artwork page was:
https://github.com/artsy/force/pull/251 (updates artist and artwork page for new partner type)
https://github.com/artsy/force/pull/254 (updates artwork page for new show city)

<img width="628" alt="screen shot 2016-10-07 at 2 27 00 pm" src="https://cloud.githubusercontent.com/assets/1457859/19202766/eba639c8-8ca1-11e6-8902-689bb73c0b32.png">

<img width="675" alt="screen shot 2016-10-07 at 3 23 01 pm" src="https://cloud.githubusercontent.com/assets/1457859/19202778/f6b5ed22-8ca1-11e6-9aa5-a2a3c67966c8.png">
