### PR TITLE
[logging] In case of an underlying network error, only report 5xx.

### DIFF
--- a/lib/graphql-error-handler.js
+++ b/lib/graphql-error-handler.js
@@ -2,7 +2,9 @@ export default function graphqlErrorHandler(query) {
   if (process.env.NEW_RELIC_LICENSE_KEY) {
     const newrelic = require('newrelic');
     return error => {
-      newrelic.noticeError(error, query);
+      if (error.statusCode === undefined || error.statusCode >= 500) {
+        newrelic.noticeError(error, query);
+      }
       return { message: error.message };
     };
   }


### PR DESCRIPTION
The `fetch` function [assigns the `statusCode` field](https://github.com/artsy/metaphysics/blob/511fd8322b7277fc411655957f6e8143e4f2a7f5/lib/apis/fetch.js#L20-L22). If that field exists we now only report it in case of a 5xx error.