### PR TITLE
@mzikherman => Dont send Artwork Not Found to NewRelic

### DIFF
--- a/lib/graphql-error-handler.js
+++ b/lib/graphql-error-handler.js
@@ -2,7 +2,8 @@ export default function graphqlErrorHandler(query) {
   if (process.env.NEW_RELIC_LICENSE_KEY) {
     const newrelic = require('newrelic');
     return error => {
-      if (error.statusCode === undefined || error.statusCode >= 500) {
+      const artworkNotFound = /Artwork Not Found/.test(error.message);
+      if (!artworkNotFound && (error.statusCode === undefined || error.statusCode >= 500)) {
         newrelic.noticeError(error, query);
       }
       return { message: error.message };


### PR DESCRIPTION
There's still something up with the way we pass around errors.

Logging out the `error` object at this state shows that it's been already transformed from [here](https://github.com/artsy/metaphysics/blob/3df9403b57ac9e3c5638123e2117c64a23220a71/lib/apis/fetch.js#L20-L22). 