### PR TITLE
Bug fix for HomePageModuleContext

### DIFF
--- a/schema/home/context.js
+++ b/schema/home/context.js
@@ -58,16 +58,16 @@ export const moduleContext = {
       return assign({}, trending, { context_type: 'Trending' });
     });
   },
-  active_bids: () => false,
+  active_bids: () => null,
   followed_artists: ({ accessToken }) => {
     return gravity.with(accessToken)('me/follow/artists', { size: 9, page: 1 })
       .then((artists) => {
         return assign({}, { artists }, { context_type: 'FollowArtists' });
       });
   },
-  followed_galleries: () => false,
-  saved_works: () => false,
-  recommended_works: () => false,
+  followed_galleries: () => null,
+  saved_works: () => null,
+  recommended_works: () => null,
   live_auctions: () => {
     return featuredAuction().then((sale) => {
       return assign({}, sale, { context_type: 'Sale' });


### PR DESCRIPTION
Previously, modules without `context`'s could resolve to `false` without problems. The new Graphql version is a bit stricter and metaphysics started throwing this error any time a `context`-less module was fetched:
`1. Abstract type HomePageModuleContext must resolve to an Object type at runtime for field HomePageArtworkModule.context with value "false", received "undefined".`

To remedy this, we updated the `Context` field to return `null` instead of `false`, since `false` is a boolean and a `HomePageModuleContext` must resolve to either one of [these](https://github.com/artsy/metaphysics/blob/master/schema/home/context.js#L105) or nothing.