### PR TITLE
add is_leading_bidder property to LotStanding type

### DIFF
--- a/schema/me/lot_standing.js
+++ b/schema/me/lot_standing.js
@@ -10,8 +10,12 @@ import {
   GraphQLBoolean,
 } from 'graphql';
 
+
+// is leading human bidder
+export const isLeadingBidder = (lotStanding) => isExisty(lotStanding.leading_position);
+
 export const isHighestBidder = (lotStanding) =>
-  isExisty(lotStanding.leading_position)
+  isLeadingBidder(lotStanding)
     && lotStanding.sale_artwork.reserve_status !== 'reserve_not_met';
 
 export const LotStandingType = new GraphQLObjectType({
@@ -25,7 +29,13 @@ export const LotStandingType = new GraphQLObjectType({
     },
     is_highest_bidder: {
       type: GraphQLBoolean,
+      description: 'You are winning and reserve is met',
       resolve: isHighestBidder,
+    },
+    is_leading_bidder: {
+      type: GraphQLBoolean,
+      description: 'You are the leading bidder without regard to reserve',
+      resolve: isLeadingBidder,
     },
     active_bid: {
       type: BidderPosition.type,

--- a/test/schema/me/lot_standing.js
+++ b/test/schema/me/lot_standing.js
@@ -17,7 +17,7 @@ describe('LotStanding type', () => {
     LotStanding.__ResetDependency__('gravity');
   });
 
-  it('returns the correct state when you are the high bidder on a work', () => {
+  it('returns the correct state when you are the high bidder and reserve is met', () => {
     gravity
       // Me fetch
       .onCall(0)
@@ -90,7 +90,62 @@ describe('LotStanding type', () => {
       });
   });
 
-  it('returns the correct state when you are outbid on a work', () => {
+  it('returns the correct state when you are outbid on a work & reserve is met', () => {
+    gravity
+      // Me fetch
+      .onCall(0)
+      .returns(Promise.resolve({
+        id: 'damon',
+        name: 'damon',
+      }))
+      // LotStanding fetch
+      .onCall(1)
+      .returns(Promise.resolve([
+        {
+          sale_artwork: {
+            id: 'untitled',
+            reserve_status: 'reserve_met',
+          },
+          max_position: {
+            id: 0,
+            max_bid_amount_cents: 90000,
+            sale_artwork_id: 'untitled',
+          },
+          leading_position: null,
+        },
+      ]));
+
+    const query = `
+      {
+        me {
+          lot_standing(artwork_id: "untitled", sale_id: "active-auction") {
+            is_highest_bidder
+            is_leading_bidder
+            most_recent_bid {
+              id
+            }
+            active_bid {
+              id
+            }
+          }
+        }
+      }
+    `;
+
+    return runAuthenticatedQuery(query)
+      .then(({ me }) => {
+        expect(me).to.eql({
+          lot_standing: {
+            is_highest_bidder: false,
+            is_leading_bidder: false,
+            most_recent_bid: { id: '0' },
+            active_bid: null,
+          },
+        });
+      });
+  });
+
+  it('returns the correct state when you are the top bid but reserve is not met', () => {
     gravity
       // Me fetch
       .onCall(0)
@@ -124,6 +179,7 @@ describe('LotStanding type', () => {
         me {
           lot_standing(artwork_id: "untitled", sale_id: "active-auction") {
             is_highest_bidder
+            is_leading_bidder
             most_recent_bid {
               id
             }
@@ -140,6 +196,7 @@ describe('LotStanding type', () => {
         expect(me).to.eql({
           lot_standing: {
             is_highest_bidder: false,
+            is_leading_bidder: true,
             most_recent_bid: { id: '0' },
             active_bid: null,
           },


### PR DESCRIPTION
@sweir27 @acjay - actually hold on unless you think this is worthwhile, see below
linked to https://github.com/artsy/auctions/issues/140
Adding this after talking with sarah- we needed a check for the reserve message ticket to see whether the person was winning on human bids alone. `is_highest_bidder` included reserve, so i added `is_leading_bidder`. 

maybe hold off on this? I looks like the same information is available as the presence on the active_bid object. i'll return