### PR TITLE
Adds artworks to the gene via the filter_artworks API

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,16 +1,19 @@
 import { stringify } from 'qs';
 import { formatMarkdownValue } from '../schema/fields/markdown';
 import {
-  flow,
   assign,
   camelCase,
+  compact,
+  difference,
+  flow,
+  flatMap,
+  includes,
   isEmpty,
   isObject,
   isString,
-  compact,
   trim,
   reject,
-  includes,
+  map,
 } from 'lodash';
 
 export function enhance(xs = [], source = {}) {
@@ -50,6 +53,7 @@ export const toQueryString = (options = {}) =>
   stringify(options, {
     arrayFormat: 'brackets',
     sort: (a, b) =>
+
       a.localeCompare(b),
   });
 
@@ -66,4 +70,9 @@ export const stripTags = (str) => {
 
 export const markdownToText = (str) => {
   return stripTags(formatMarkdownValue(str));
+};
+
+export const queriedForFieldsOtherThanBlacklisted = (fieldASTs, blacklistedFields) => {
+  const queriedFields = map(flatMap(fieldASTs, 'selectionSet.selections'), 'name.value');
+  return difference(queriedFields, blacklistedFields).length > 0;
 };

--- a/schema/filter_artworks.js
+++ b/schema/filter_artworks.js
@@ -52,83 +52,95 @@ export const FilterArtworksType = new GraphQLObjectType({
   }),
 });
 
-const FilterArtworks = {
-  type: FilterArtworksType,
-  description: 'Artworks Elastic Search results',
-  args: {
-    aggregation_partner_cities: {
-      type: new GraphQLList(GraphQLString),
-    },
-    aggregations: {
-      type: new GraphQLList(ArtworksAggregation),
-    },
-    artist_id: {
-      type: GraphQLString,
-    },
-    color: {
-      type: GraphQLString,
-    },
-    dimension_range: {
-      type: GraphQLString,
-    },
-    extra_aggregation_gene_ids: {
-      type: new GraphQLList(GraphQLString),
-    },
-    include_artworks_by_followed_artists: {
-      type: GraphQLBoolean,
-    },
-    for_sale: {
-      type: GraphQLBoolean,
-    },
-    gene_id: {
-      type: GraphQLString,
-    },
-    gene_ids: {
-      type: new GraphQLList(GraphQLString),
-    },
-    height: {
-      type: GraphQLString,
-    },
-    width: {
-      type: GraphQLString,
-    },
-    medium: {
-      type: GraphQLString,
-    },
-    period: {
-      type: GraphQLString,
-    },
-    periods: {
-      type: new GraphQLList(GraphQLString),
-    },
-    major_periods: {
-      type: new GraphQLList(GraphQLString),
-    },
-    partner_id: {
-      type: GraphQLID,
-    },
-    partner_cities: {
-      type: new GraphQLList(GraphQLString),
-    },
-    price_range: {
-      type: GraphQLString,
-    },
-    page: {
-      type: GraphQLInt,
-    },
-    size: {
-      type: GraphQLInt,
-    },
-    sort: {
-      type: GraphQLString,
-    },
-  },
-  resolve: (root, options, request, { rootValue: { accessToken } }) => {
-    if (accessToken) {
-      return gravity.with(accessToken)('filter/artworks', options);
-    }
-    return gravity('filter/artworks', options);
-  },
-};
+// Support passing in your own primary key
+// so that you can nest this function into another.
 
-export default FilterArtworks;
+// When given a primary key, this function take the
+// value out of the parent payload and moves it into
+// the query itself
+
+function filterArtworks(primaryKey) {
+  return {
+    type: FilterArtworksType,
+    description: 'Artworks Elastic Search results',
+    args: {
+      aggregation_partner_cities: {
+        type: new GraphQLList(GraphQLString),
+      },
+      aggregations: {
+        type: new GraphQLList(ArtworksAggregation),
+      },
+      artist_id: {
+        type: GraphQLString,
+      },
+      color: {
+        type: GraphQLString,
+      },
+      dimension_range: {
+        type: GraphQLString,
+      },
+      extra_aggregation_gene_ids: {
+        type: new GraphQLList(GraphQLString),
+      },
+      include_artworks_by_followed_artists: {
+        type: GraphQLBoolean,
+      },
+      for_sale: {
+        type: GraphQLBoolean,
+      },
+      gene_id: {
+        type: GraphQLString,
+      },
+      gene_ids: {
+        type: new GraphQLList(GraphQLString),
+      },
+      height: {
+        type: GraphQLString,
+      },
+      width: {
+        type: GraphQLString,
+      },
+      medium: {
+        type: GraphQLString,
+      },
+      period: {
+        type: GraphQLString,
+      },
+      periods: {
+        type: new GraphQLList(GraphQLString),
+      },
+      major_periods: {
+        type: new GraphQLList(GraphQLString),
+      },
+      partner_id: {
+        type: GraphQLID,
+      },
+      partner_cities: {
+        type: new GraphQLList(GraphQLString),
+      },
+      price_range: {
+        type: GraphQLString,
+      },
+      page: {
+        type: GraphQLInt,
+      },
+      size: {
+        type: GraphQLInt,
+      },
+      sort: {
+        type: GraphQLString,
+      },
+    },
+    resolve: (root, options, request, { rootValue: { accessToken } }) => {
+      if (primaryKey) {
+        options[primaryKey] = root.id; // eslint-disable-line no-param-reassign
+      }
+      if (accessToken) {
+        return gravity.with(accessToken)('filter/artworks', options);
+      }
+      return gravity('filter/artworks', options);
+    },
+  };
+}
+
+export default filterArtworks;

--- a/schema/gene.js
+++ b/schema/gene.js
@@ -3,6 +3,9 @@ import gravity from '../lib/loaders/gravity';
 import cached from './fields/cached';
 import Artist from './artist';
 import Image from './image';
+import filterArtworks from './filter_artworks';
+import { queriedForFieldsOtherThanBlacklisted } from '../lib/helpers';
+
 import { GravityIDFields } from './object_identification';
 import {
   GraphQLObjectType,
@@ -17,6 +20,7 @@ const GeneType = new GraphQLObjectType({
   fields: {
     ...GravityIDFields,
     cached,
+    artworks: filterArtworks('gene_id'),
     href: {
       type: GraphQLString,
       resolve: ({ id }) => `gene/${id}`,
@@ -63,7 +67,15 @@ const Gene = {
       type: new GraphQLNonNull(GraphQLString),
     },
   },
-  resolve: (root, { id }) => gravity(`gene/${id}`),
+  resolve: (root, { id }, request, { fieldASTs }) => {
+    // If you are just making an artworks call ( e.g. if paginating )
+    // do not make a Gravity call for the gene data.
+    const blacklistedFields = ['artworks', 'id'];
+    if (queriedForFieldsOtherThanBlacklisted(fieldASTs, blacklistedFields)) {
+      return gravity(`gene/${id}`);
+    }
+    return { id };
+  },
 };
 
 export default Gene;

--- a/schema/gene.js
+++ b/schema/gene.js
@@ -20,7 +20,7 @@ const GeneType = new GraphQLObjectType({
   fields: {
     ...GravityIDFields,
     cached,
-    artworks: filterArtworks('gene_id'),
+    filtered_artworks: filterArtworks('gene_id'),
     href: {
       type: GraphQLString,
       resolve: ({ id }) => `gene/${id}`,
@@ -70,7 +70,7 @@ const Gene = {
   resolve: (root, { id }, request, { fieldASTs }) => {
     // If you are just making an artworks call ( e.g. if paginating )
     // do not make a Gravity call for the gene data.
-    const blacklistedFields = ['artworks', 'id'];
+    const blacklistedFields = ['filtered_artworks', 'id'];
     if (queriedForFieldsOtherThanBlacklisted(fieldASTs, blacklistedFields)) {
       return gravity(`gene/${id}`);
     }

--- a/schema/index.js
+++ b/schema/index.js
@@ -15,7 +15,7 @@ import Profile from './profile';
 import Partner from './partner';
 import Partners from './partners';
 import FilterPartners from './filter_partners';
-import FilterArtworks from './filter_artworks';
+import filterArtworks from './filter_artworks';
 import PartnerCategory from './partner_category';
 import PartnerCategories from './partner_categories';
 import PartnerShow from './partner_show';
@@ -56,7 +56,7 @@ const schema = new GraphQLSchema({
       partner: Partner,
       partners: Partners,
       filter_partners: FilterPartners,
-      filter_artworks: FilterArtworks,
+      filter_artworks: filterArtworks(),
       partner_category: PartnerCategory,
       partner_categories: PartnerCategories,
       partner_show: PartnerShow,

--- a/test/schema/gene/gene.js
+++ b/test/schema/gene/gene.js
@@ -1,0 +1,86 @@
+describe('Gene', () => {
+  describe('For just querying the gene artworks', () => {
+    const Gene = schema.__get__('Gene');
+    const filterArtworks = Gene.__get__('filterArtworks');
+
+    beforeEach(() => {
+      const gravity = sinon.stub();
+      gravity.withArgs('filter/artworks', { gene_id: '500-1000-ce', aggregations: ['total'] })
+        .returns(Promise.resolve({
+          hits: [
+            { id: 'oseberg-norway-queens-ship', title: "Queen's Ship", artists: [] },
+          ],
+        }));
+      filterArtworks.__Rewire__('gravity', gravity);
+    });
+
+    afterEach(() => {
+      filterArtworks.__ResetDependency__('gravity');
+    });
+
+    it('returns filtered artworks', () => {
+      const query = `
+        {
+          gene(id: "500-1000-ce") {
+            artworks(aggregations:[TOTAL]){
+              hits {
+                id
+              }
+            }
+          }
+        }
+      `;
+
+      return runQuery(query).then(({ gene: { artworks: { hits } } }) => {
+        expect(hits).to.eql([{ id: 'oseberg-norway-queens-ship' }]);
+      });
+    });
+  });
+
+  // The key distinction here is that because the query contains
+  // metadata about the gene, then gravity will have to be called,
+  // and in the test mocked out. Whereas above, it does not need
+  // to happen.
+
+  describe('For querying the gene artworks + gene metadata', () => {
+    const Gene = schema.__get__('Gene');
+    const filterArtworks = Gene.__get__('filterArtworks');
+
+    beforeEach(() => {
+      const gravity = sinon.stub();
+      gravity.withArgs('filter/artworks', { gene_id: '500-1000-ce', aggregations: ['total'] })
+        .returns(Promise.resolve({
+          hits: [
+            { id: 'oseberg-norway-queens-ship', title: "Queen's Ship", artists: [] },
+          ],
+        }));
+
+      Gene.__Rewire__('gravity', sinon.stub().returns(Promise.resolve({ id: '500-1000-ce' })));
+      filterArtworks.__Rewire__('gravity', gravity);
+    });
+
+    afterEach(() => {
+      filterArtworks.__ResetDependency__('gravity');
+      Gene.__ResetDependency__('gravity');
+    });
+
+    it('returns filtered artworks, and makes a gravity call', () => {
+      const query = `
+        {
+          gene(id: "500-1000-ce") {
+            name
+            artworks(aggregations:[TOTAL]){
+              hits {
+                id
+              }
+            }
+          }
+        }
+      `;
+
+      return runQuery(query).then(({ gene: { artworks: { hits } } }) => {
+        expect(hits).to.eql([{ id: 'oseberg-norway-queens-ship' }]);
+      });
+    });
+  });
+});

--- a/test/schema/gene/gene.js
+++ b/test/schema/gene/gene.js
@@ -22,7 +22,7 @@ describe('Gene', () => {
       const query = `
         {
           gene(id: "500-1000-ce") {
-            artworks(aggregations:[TOTAL]){
+            filtered_artworks(aggregations:[TOTAL]){
               hits {
                 id
               }
@@ -31,7 +31,7 @@ describe('Gene', () => {
         }
       `;
 
-      return runQuery(query).then(({ gene: { artworks: { hits } } }) => {
+      return runQuery(query).then(({ gene: { filtered_artworks: { hits } } }) => {
         expect(hits).to.eql([{ id: 'oseberg-norway-queens-ship' }]);
       });
     });
@@ -69,7 +69,7 @@ describe('Gene', () => {
         {
           gene(id: "500-1000-ce") {
             name
-            artworks(aggregations:[TOTAL]){
+            filtered_artworks(aggregations:[TOTAL]){
               hits {
                 id
               }
@@ -78,7 +78,7 @@ describe('Gene', () => {
         }
       `;
 
-      return runQuery(query).then(({ gene: { artworks: { hits } } }) => {
+      return runQuery(query).then(({ gene: { filtered_artworks: { hits } } }) => {
         expect(hits).to.eql([{ id: 'oseberg-norway-queens-ship' }]);
       });
     });


### PR DESCRIPTION
Currently to pull in artworks for a Gene, with refine options, you will need to do a query like:

```graphql
{
  gene(id:"500-1000-ce") {
    id
  }
  filter_artworks(gene_id: "500-1000-ce", aggregations:[MEDIUM, PRICE_RANGE, TOTAL], sort:"prices", for_sale:false, page:1){
    hits {
      title
    }
  }
}
```

Which is not ideal, as that's not a graph 👯 

This PR allows you to do this:

```graphql
  {
    gene(id:"500-1000-ce") {
      id
      filter_artworks(aggregations:[MEDIUM, PRICE_RANGE, TOTAL], sort:"prices", for_sale:false, page:1){
        hits {
          title
        }
      }
    }
  }
```

Which is a graph 🎉 

---

This PR also takes into account how you would normally paginate, e.g.

```graphql
  {
    gene(id:"500-1000-ce") {
      filter_artworks(aggregations:[MEDIUM, PRICE_RANGE, TOTAL], sort:"prices", for_sale:false, page:2){
        hits {
          title
        }
      }
    }
  }
```

and won't make a query to Gravity for the Gene unless there is a need for that metadata.