### PR TITLE
Support passing a medium through as a '*' have it not sent to gravity

### DIFF
--- a/schema/filter_artworks.js
+++ b/schema/filter_artworks.js
@@ -102,6 +102,7 @@ function filterArtworks(primaryKey) {
       },
       medium: {
         type: GraphQLString,
+        description: 'A string from the list of allocations, or * to denote all mediums',
       },
       period: {
         type: GraphQLString,
@@ -131,14 +132,20 @@ function filterArtworks(primaryKey) {
         type: GraphQLString,
       },
     },
-    resolve: (root, options, request, { rootValue: { accessToken } }) => {
+    resolve: (root, options) => {
+      const gravityOptions = Object.assign({}, options);
       if (primaryKey) {
-        options[primaryKey] = root.id; // eslint-disable-line no-param-reassign
+        gravityOptions[primaryKey] = root.id;
       }
-      if (accessToken) {
-        return gravity.with(accessToken)('filter/artworks', options);
+
+      // Support queries that show all mediums using the medium param.
+      // If you specify "*" it results in metaphysics removing the query option
+      // making the graphQL queries between all and a subset of mediums the same shape.
+      if (options.medium === '*') {
+        delete gravityOptions.medium;
       }
-      return gravity('filter/artworks', options);
+
+      return gravity('filter/artworks', gravityOptions);
     },
   };
 }

--- a/test/schema/filter_artworks.js
+++ b/test/schema/filter_artworks.js
@@ -1,0 +1,45 @@
+describe('Filter Artworks', () => {
+  describe('Does not pass along the medium param if it is "*"', () => {
+    const Gene = schema.__get__('Gene');
+    const filterArtworks = Gene.__get__('filterArtworks');
+
+    beforeEach(() => {
+      const gravity = sinon.stub();
+      // This is the key to the test
+      // the 2nd parameter _should not_ include the mediums option, even though it's included below
+      gravity.withArgs('filter/artworks', { gene_id: '500-1000-ce', aggregations: ['total'] })
+        .returns(Promise.resolve({
+          hits: [
+            { id: 'oseberg-norway-queens-ship', title: "Queen's Ship", artists: [] },
+          ],
+        }));
+
+      Gene.__Rewire__('gravity', sinon.stub().returns(Promise.resolve({ id: '500-1000-ce' })));
+      filterArtworks.__Rewire__('gravity', gravity);
+    });
+
+    afterEach(() => {
+      filterArtworks.__ResetDependency__('gravity');
+      Gene.__ResetDependency__('gravity');
+    });
+
+    it('returns filtered artworks, and makes a gravity call', () => {
+      const query = `
+        {
+          gene(id: "500-1000-ce") {
+            name
+            filtered_artworks(aggregations:[TOTAL], medium: "*"){
+              hits {
+                id
+              }
+            }
+          }
+        }
+      `;
+
+      return runQuery(query).then(({ gene: { filtered_artworks: { hits } } }) => {
+        expect(hits).to.eql([{ id: 'oseberg-norway-queens-ship' }]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
With a relay fragment like:

```js
export default Relay.createContainer(Gene, {
  initialVariables: {
    medium: null,
    price_range: '*-*'
  },
  fragments: {
    gene: () => Relay.QL`
      fragment on Gene {
        _id
        id
        ${Header.getFragment('gene')}
        ${About.getFragment('gene')}
        filtered_artworks(medium: $medium, price_range:$price_range, aggregations:[MEDIUM, PRICE_RANGE, TOTAL], page:1){
          total
          aggregations {
            slice
            counts {
              id
              name
            }
          }
        }
      }
    `,
  }
```

There is no way to make the medium _not_ get sent along to metaphysics, without a bunch of hacky hack hacks. So we've opted to allow something like the price-range of all - to a known (and documented in the schema) constant of "*". 