### PR TITLE
@alloy => Fall back to featured bio in biography_blurb field on Artist

### DIFF
--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -159,13 +159,12 @@ const ArtistType = new GraphQLObjectType({
           },
         }),
         resolve: ({ blurb, id }, { format }) => {
-          if (blurb.length) {
+          if (blurb && blurb.length) {
             return { text: formatMarkdownValue(blurb, format) };
           }
           return gravity(`artist/${id}/partner_artists`, {
             size: 1,
-            sort: '-published_artworks_count',
-            has_biography: true,
+            featured: true,
           }).then((partner_artists) => {
             if (partner_artists && partner_artists.length) {
               const { biography, partner } = first(partner_artists);


### PR DESCRIPTION
Now that bios come from CMS to the Partner Moderation Admin app, and all the platform work for featuring a bio is done, we want the front-end to display the featured bio, as well as an attribution line.

There was already this field set up to be able to provide a fallback if Artsy hasn't provided a bio. However, the referenced code (in Force) only ever displays Artsy bios, so it should be perfectly safe to modify.

With this update, I can switch Force/Microgravity to support displaying a featured bio if one exists, plus the 'credit' line.