### PR TITLE
@alloy => More nuanced behavior around returning featured partner bios for an artist

### DIFF
--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -199,6 +199,21 @@ const ArtistType = new GraphQLObjectType({
           }
         },
       },
+      featured_partner_id: {
+        type: GraphQLString,
+        description: 'If there is a featured partner bio for this artist, returns the partner id.',
+        resolve: ({ id }) => {
+          return gravity(`artist/${id}/partner_artists`, {
+            size: 1,
+            featured: true,
+          }).then((partner_artists) => {
+            if (partner_artists && partner_artists.length) {
+              const { partner } = first(partner_artists);
+              return partner.id;
+            }
+          });
+        },
+      },
       is_shareable: {
         type: GraphQLBoolean,
         resolve: (artist) => artist.published_artworks_count > 0,

--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -145,7 +145,17 @@ const ArtistType = new GraphQLObjectType({
         deprecationReason: 'Use biography_blurb which includes a gallery-submitted fallback.',
       }, markdown()),
       biography_blurb: {
-        args: markdown().args,
+        args: assign({
+          partner_id: {
+            type: GraphQLString,
+            description: 'If passed in, will return this partners featured bio, if one exists.',
+          },
+          partner_bio: {
+            type: GraphQLBoolean,
+            description: 'If true, will return any partners featured bio, if one exists.',
+            defaultValue: false,
+          },
+        }, markdown().args),
         type: new GraphQLObjectType({
           name: 'ArtistBlurb',
           fields: {
@@ -159,22 +169,34 @@ const ArtistType = new GraphQLObjectType({
             },
           },
         }),
-        resolve: ({ blurb, id }, { format }) => {
+        resolve: ({ blurb, id }, { format, partner_id, partner_bio }) => {
+          let bio = null;
+          if (partner_id || partner_bio) {
+            return gravity(`artist/${id}/partner_artists`, {
+              size: 1,
+              featured: true,
+            }).then((partner_artists) => {
+              if (partner_artists && partner_artists.length) {
+                const { biography, partner } = first(partner_artists);
+                bio = {
+                  text: biography,
+                  credit: `Submitted by ${partner.name}`,
+                };
+                if (partner.id === partner_id) {
+                  return bio;
+                }
+                if (blurb && blurb.length) {
+                  return { text: formatMarkdownValue(blurb, format) };
+                }
+                if (partner_bio) {
+                  return bio;
+                }
+              }
+            });
+          }
           if (blurb && blurb.length) {
             return { text: formatMarkdownValue(blurb, format) };
           }
-          return gravity(`artist/${id}/partner_artists`, {
-            size: 1,
-            featured: true,
-          }).then((partner_artists) => {
-            if (partner_artists && partner_artists.length) {
-              const { biography, partner } = first(partner_artists);
-              return {
-                text: biography,
-                credit: `Submitted by ${partner.name}`,
-              };
-            }
-          });
         },
       },
       is_shareable: {

--- a/test/schema/artist/index.js
+++ b/test/schema/artist/index.js
@@ -258,6 +258,71 @@ describe('Artist type', () => {
     });
   });
 
+  describe('featured_partner_id', () => {
+    it('returns the featured partner id if there is a featured bio', () => {
+      Artist.__ResetDependency__('gravity');
+      const gravity = sinon.stub();
+      Artist.__Rewire__('gravity', gravity);
+      gravity
+        // Artist
+        .onCall(0)
+        .returns(Promise.resolve(assign({}, artist)))
+        // PartnerArtist
+        .onCall(1)
+        .returns(Promise.resolve([assign({}, {
+          biography: 'new catty bio',
+          partner: { name: 'Catty Partner', id: 'catty-partner' },
+        })]));
+
+      const query = `
+        {
+          artist(id: "foo-bar") {
+            featured_partner_id
+          }
+        }
+      `;
+
+      return runQuery(query)
+        .then(data => {
+          expect(data).to.eql({
+            artist: {
+              featured_partner_id: 'catty-partner',
+            },
+          });
+        });
+    });
+
+    it('returns null if there is no featured bio', () => {
+      Artist.__ResetDependency__('gravity');
+      const gravity = sinon.stub();
+      Artist.__Rewire__('gravity', gravity);
+      gravity
+        // Artist
+        .onCall(0)
+        .returns(Promise.resolve(assign({}, artist)))
+        // PartnerArtist
+        .onCall(1)
+        .returns(Promise.resolve([]));
+
+      const query = `
+        {
+          artist(id: "foo-bar") {
+            featured_partner_id
+          }
+        }
+      `;
+
+      return runQuery(query)
+        .then(data => {
+          expect(data).to.eql({
+            artist: {
+              featured_partner_id: null,
+            },
+          });
+        });
+    });
+  });
+
   describe('biography_blurb', () => {
     it('returns the blurb if present', () => {
       artist.blurb = 'catty blurb';

--- a/test/schema/artist/index.js
+++ b/test/schema/artist/index.js
@@ -285,7 +285,7 @@ describe('Artist type', () => {
         });
     });
 
-    it('returns the featured bio if there is no Artsy one', () => {
+    it('returns any featured bio if there is no Artsy one', () => {
       Artist.__ResetDependency__('gravity');
       const gravity = sinon.stub();
       Artist.__Rewire__('gravity', gravity);
@@ -303,7 +303,7 @@ describe('Artist type', () => {
       const query = `
         {
           artist(id: "foo-bar") {
-            biography_blurb {
+            biography_blurb(partner_bio: true) {
               text
               credit
             }
@@ -318,6 +318,86 @@ describe('Artist type', () => {
               biography_blurb: {
                 text: 'new catty bio',
                 credit: 'Submitted by Catty Partner',
+              },
+            },
+          });
+        });
+    });
+
+    it('returns the featured bio if it is for the requested partner', () => {
+      Artist.__ResetDependency__('gravity');
+      const gravity = sinon.stub();
+      Artist.__Rewire__('gravity', gravity);
+      artist.blurb = 'catty blurb';
+      gravity
+        // Artist
+        .onCall(0)
+        .returns(Promise.resolve(assign({}, artist)))
+        // PartnerArtist
+        .onCall(1)
+        .returns(Promise.resolve([assign({}, {
+          biography: 'new catty bio',
+          partner: { name: 'Catty Partner', id: 'catty-partner' },
+        })]));
+
+      const query = `
+        {
+          artist(id: "foo-bar") {
+            biography_blurb(partner_id: "catty-partner") {
+              text
+              credit
+            }
+          }
+        }
+      `;
+
+      return runQuery(query)
+        .then(data => {
+          expect(data).to.eql({
+            artist: {
+              biography_blurb: {
+                text: 'new catty bio',
+                credit: 'Submitted by Catty Partner',
+              },
+            },
+          });
+        });
+    });
+
+    it('returns the fallback if the featured bio is not for the requested partner', () => {
+      Artist.__ResetDependency__('gravity');
+      const gravity = sinon.stub();
+      Artist.__Rewire__('gravity', gravity);
+      artist.blurb = 'catty blurb';
+      gravity
+        // Artist
+        .onCall(0)
+        .returns(Promise.resolve(assign({}, artist)))
+        // PartnerArtist
+        .onCall(1)
+        .returns(Promise.resolve([assign({}, {
+          biography: 'new catty bio',
+          partner: { name: 'Catty Partner' },
+        })]));
+
+      const query = `
+        {
+          artist(id: "foo-bar") {
+            biography_blurb(partner_id: "nonexistent") {
+              text
+              credit
+            }
+          }
+        }
+      `;
+
+      return runQuery(query)
+        .then(data => {
+          expect(data).to.eql({
+            artist: {
+              biography_blurb: {
+                text: 'catty blurb',
+                credit: null,
               },
             },
           });


### PR DESCRIPTION
I misinterpreted how we want to use these on artist and artwork pages, so this modifies it a bit.

For an artist page: 
- if the Artsy bio is present- we want to show it.
- if not, we want to show _any_ featured partner bio.

For an artwork page:
- if there exists a featured partner bio and it matches the artwork's partner, we want to show it.
- if there is no featured partner bio, or the featured bio is a different partner's, we want to show Artsy's.

That's a bit more nuanced than a simple fallback.

I decided to use the same `biography_blurb` field to accommodate this behavior. This PR adds two input args to that, so it remains fully backwards compatible with any existing uses, as existing behavior is unchanged.

I also added specs for the above cases.

Also added `featured_partner_id` as well.