### PR TITLE
@alloy => Un-deprecate blurb on Artist

### DIFF
--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -141,11 +141,23 @@ const ArtistType = new GraphQLObjectType({
         type: new GraphQLList(GraphQLString),
       },
       meta: Meta,
-      blurb: assign({
-        deprecationReason: 'Use biography_blurb which includes a gallery-submitted fallback.',
-      }, markdown()),
-      biography_blurb: {
+      blurb: {
         args: markdown().args,
+        type: GraphQLString,
+        resolve: ({ blurb }, { format }) => {
+          if (blurb.length) {
+            return formatMarkdownValue(blurb, format);
+          }
+        },
+      },
+      biography_blurb: {
+        args: assign({
+          partner_bio: {
+            type: GraphQLBoolean,
+            description: 'If true, will return featured bio over Artsy one.',
+            defaultValue: false,
+          },
+        }, markdown().args),
         type: new GraphQLObjectType({
           name: 'ArtistBlurb',
           fields: {
@@ -157,10 +169,15 @@ const ArtistType = new GraphQLObjectType({
               type: GraphQLString,
               resolve: ({ credit }) => credit,
             },
+            partner_id: {
+              type: GraphQLString,
+              resolve: ({ partner_id }) => partner_id,
+              description: 'The partner id of the partner who submitted the featured bio.',
+            },
           },
         }),
-        resolve: ({ blurb, id }, { format }) => {
-          if (blurb && blurb.length) {
+        resolve: ({ blurb, id }, { format, partner_bio }) => {
+          if (!partner_bio && blurb && blurb.length) {
             return { text: formatMarkdownValue(blurb, format) };
           }
           return gravity(`artist/${id}/partner_artists`, {
@@ -172,6 +189,7 @@ const ArtistType = new GraphQLObjectType({
               return {
                 text: biography,
                 credit: `Submitted by ${partner.name}`,
+                partner_id: partner.id,
               };
             }
           });


### PR DESCRIPTION
So, basically I think we need to have two fields in the schema. One has to be the Artsy blurb, and one should be the featured partner blurb. To do nuanced fallbacks on clients...it's really messy with just one field. Also because in some cases you want to switch behavior on the client based on data that isn't known at the time of the query (such as the partner).

Since one of the fields is exactly that and was deprecated, I just un-deprecated it (and added a spec). Additionally, the other field was set up to do a fallback if there wasn't an Artsy bio, so I just added a param to essentially always return the fallback. In that way, we accomplish our goal of two fields: one for the Artsy blurb and one for the partner, while the latter retains its current behavior: providing an Artsy blurb or fallback.

Re-organized the specs a bit better as well.