### PR TITLE
@alloy => Cleanup access token handling

### DIFF
--- a/lib/loaders/gravity.js
+++ b/lib/loaders/gravity.js
@@ -15,7 +15,10 @@ load.with = (accessToken) => {
   const authenticatedGravityLoader = authenticatedHttpLoader(gravity, accessToken);
   return (path, options = {}) => {
     const key = toKey(path, options);
-    return authenticatedGravityLoader(key, accessToken);
+    if (accessToken) {
+      return authenticatedGravityLoader(key, accessToken);
+    }
+    return gravityLoader.load(key);
   };
 };
 

--- a/schema/filter_artworks.js
+++ b/schema/filter_artworks.js
@@ -145,11 +145,7 @@ function filterArtworks(primaryKey) {
         delete gravityOptions.medium;
       }
 
-      if (accessToken) {
-        return gravity.with(accessToken)('filter/artworks', gravityOptions);
-      }
-
-      return gravity('filter/artworks', gravityOptions);
+      return gravity.with(accessToken)('filter/artworks', gravityOptions);
     },
   };
 }

--- a/test/schema/filter_artworks.js
+++ b/test/schema/filter_artworks.js
@@ -5,6 +5,7 @@ describe('Filter Artworks', () => {
 
     beforeEach(() => {
       const gravity = sinon.stub();
+      gravity.with = sinon.stub().returns(gravity);
       // This is the key to the test
       // the 2nd parameter _should not_ include the mediums option, even though it's included below
       gravity.withArgs('filter/artworks', { gene_id: '500-1000-ce', aggregations: ['total'] })

--- a/test/schema/gene/gene.js
+++ b/test/schema/gene/gene.js
@@ -5,6 +5,7 @@ describe('Gene', () => {
 
     beforeEach(() => {
       const gravity = sinon.stub();
+      gravity.with = sinon.stub().returns(gravity);
       gravity.withArgs('filter/artworks', { gene_id: '500-1000-ce', aggregations: ['total'] })
         .returns(Promise.resolve({
           hits: [
@@ -48,6 +49,7 @@ describe('Gene', () => {
 
     beforeEach(() => {
       const gravity = sinon.stub();
+      gravity.with = sinon.stub().returns(gravity);
       gravity.withArgs('filter/artworks', { gene_id: '500-1000-ce', aggregations: ['total'] })
         .returns(Promise.resolve({
           hits: [


### PR DESCRIPTION
You can now do `gravity.with(accessToken)(...)` anytime you need to pass that along.