### PR TITLE
@mzikherman => Allow these to fail silently on account of related shows endpoint

### DIFF
--- a/schema/show.js
+++ b/schema/show.js
@@ -315,7 +315,7 @@ const Show = {
       .then(show => {
         if (!show.displayable && !show.is_reference) return new Error('Show Not Found');
         return show;
-      });
+      }).catch(() => null);
   },
 };
 


### PR DESCRIPTION
..which sometimes returns documents that really don't exist (that endpoint is cached purely based on time).