### PR TITLE
@mzikherman => dont include bucket increments above set limit

### DIFF
--- a/schema/sale_artwork.js
+++ b/schema/sale_artwork.js
@@ -23,6 +23,8 @@ import {
   GraphQLList,
 } from 'graphql';
 
+const { BIDDER_POSITION_MAX_BID_AMOUNT_CENTS_LIMIT } = process.env;
+
 export const isBiddable = (sale, { artwork: { sold } }) => {
   return (
     !sold &&
@@ -234,6 +236,7 @@ const SaleArtworkType = new GraphQLObjectType({
                   bid >= inc.from && bid <= inc.to
                 ) || last(incr);
                 const nextBid = bid + bucket.amount;
+                if (nextBid > BIDDER_POSITION_MAX_BID_AMOUNT_CENTS_LIMIT) return increments;
                 if (!bucket.to) return increments.push(nextBid);
                 const nextBidBucket = find(incr, (inc) =>
                   nextBid >= inc.from && nextBid <= inc.to


### PR DESCRIPTION
Metaphysics orchestrates figuring out the bucket of values that a bidder can bid on. Right now, we use the `minimum_next_bid_amount_cents` and generate 100 increments above that value as possible bid values.

This can get hairy if the starting bids are very high because:
- Gravity only allows you to bid up to its `BIDDER_POSITION_MAX_BID_AMOUNT_CENTS_LIMIT` anyways
- At a certain point, the numbers become > 32-bit integers and metaphysics explodes.

To solve this, we add a `BIDDER_POSITION_MAX_BID_AMOUNT_CENTS_LIMIT` to metaphysics and don't give you increments above that amount.

Note that when we're dealing with actual bids that are above 32-bit integers we'll have to update this and also throw some kind of lavish party.