### PR TITLE
@alloy => Use new counts to determine artist tab statuses for shows and CV

### DIFF
--- a/schema/artist/statuses.js
+++ b/schema/artist/statuses.js
@@ -14,23 +14,11 @@ const ArtistStatusesType = new GraphQLObjectType({
     },
     shows: {
       type: GraphQLBoolean,
-      resolve: ({ id }) => {
-        return total(`related/shows`, {
-          artist_id: id,
-          displayable: true,
-          size: 0,
-        }).then(count => count > 0);
-      },
+      resolve: ({ partner_shows_count }) => partner_shows_count > 0,
     },
     cv: {
       type: GraphQLBoolean,
-      resolve: ({ id }) => {
-        return total(`related/shows`, {
-          artist_id: id,
-          displayable: true,
-          size: 0,
-        }).then(count => count > 15);
-      },
+      resolve: ({ partner_shows_count }) => partner_shows_count > 15,
     },
     artists: {
       type: GraphQLBoolean,

--- a/test/schema/artist/statuses.js
+++ b/test/schema/artist/statuses.js
@@ -1,0 +1,48 @@
+describe('Artist Statuses', () => {
+  const Artist = schema.__get__('Artist');
+  let artist = null;
+
+  beforeEach(() => {
+    artist = {
+      id: 'foo-bar',
+      name: 'Foo Bar',
+      birthday: null,
+      artworks_count: 42,
+      partner_shows_count: 42,
+      published_artworks_count: 42,
+    };
+
+    Artist.__Rewire__('gravity', sinon.stub().returns(Promise.resolve(artist)));
+  });
+
+  afterEach(() => {
+    Artist.__ResetDependency__('gravity');
+  });
+
+  it('returns statuses for artworks, shows and cv', () => {
+    const query = `
+      {
+        artist(id: "foo-bar") {
+          statuses {
+            artworks
+            shows
+            cv
+          }
+        }
+      }
+    `;
+
+    return runQuery(query)
+      .then(data => {
+        expect(data).to.eql({
+          artist: {
+            statuses: {
+              artworks: true,
+              shows: true,
+              cv: true,
+            },
+          },
+        });
+      });
+  });
+});


### PR DESCRIPTION
Now that counts are denormalized onto the artist model (and deployed to prod. with data migrated) we can use them (instead of this expensive ES call) to determine whether to show certain tabs on the artist page.

cc @briansw this should make the 'CV' tab start to show up when the count of total shows for an artist (including ref shows) goes above 15.