### PR TITLE
@alloy => If there is no featured bio, return the Artsy one

### DIFF
--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -192,6 +192,7 @@ const ArtistType = new GraphQLObjectType({
                 partner_id: partner.id,
               };
             }
+            return { text: formatMarkdownValue(blurb, format) };
           });
         },
       },

--- a/test/schema/artist/index.js
+++ b/test/schema/artist/index.js
@@ -332,32 +332,34 @@ describe('Artist type', () => {
           artist.blurb = 'artsy blurb';
         });
       });
-      it('returns the artsy blurb if there is no featured partner bio', () => {
-        artist.blurb = 'artsy blurb';
-        const query = `
-          {
-            artist(id: "foo-bar") {
-              biography_blurb {
-                text
-                credit
-                partner_id
+      describe('without a featured partner bio', () => {
+        it('returns the artsy blurb if there is no featured partner bio', () => {
+          artist.blurb = 'artsy blurb';
+          const query = `
+            {
+              artist(id: "foo-bar") {
+                biography_blurb(partner_bio: true) {
+                  text
+                  credit
+                  partner_id
+                }
               }
             }
-          }
-        `;
+          `;
 
-        return runQuery(query)
-          .then(data => {
-            expect(data).to.eql({
-              artist: {
-                biography_blurb: {
-                  text: 'artsy blurb',
-                  credit: null,
-                  partner_id: null,
+          return runQuery(query)
+            .then(data => {
+              expect(data).to.eql({
+                artist: {
+                  biography_blurb: {
+                    text: 'artsy blurb',
+                    credit: null,
+                    partner_id: null,
+                  },
                 },
-              },
+              });
             });
-          });
+        });
       });
     });
     it('returns the blurb if present', () => {


### PR DESCRIPTION
Minor bug- even when we prefer to return the featured partner bio, we should always return the Artsy one if there is no featured bio.