### PR TITLE
[Artist] Add `is_reference` back to `shows`.

### DIFF
--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -62,6 +62,9 @@ const ShowField = {
     top_tier: {
       type: GraphQLBoolean,
     },
+    is_reference: {
+      type: GraphQLBoolean,
+    },
     sort: PartnerShowSorts,
   },
   resolve: ({ id }, options) => {


### PR DESCRIPTION
I had removed this field when I refactored the deprecated `partner_shows` and `shows` fields https://github.com/artsy/metaphysics/commit/2363552ecc02328b335548221d9fa47ea8b9d9d1. This is now causing a failure in Force.