### PR TITLE
@alloy => allow sale to have null buyers premium

### DIFF
--- a/schema/sale/index.js
+++ b/schema/sale/index.js
@@ -220,7 +220,7 @@ const SaleType = new GraphQLObjectType({
         type: new GraphQLList(BuyersPremium),
         description: "Auction's buyer's premium policy.",
         resolve: sale => {
-          if (!sale.buyers_premium || !sale.buyers_premium.schedule) return null;
+          if (!sale.buyers_premium) return null;
 
           return map(sale.buyers_premium.schedule, item => ({
             cents: item.min_amount_cents,

--- a/schema/sale/index.js
+++ b/schema/sale/index.js
@@ -220,7 +220,7 @@ const SaleType = new GraphQLObjectType({
         type: new GraphQLList(BuyersPremium),
         description: "Auction's buyer's premium policy.",
         resolve: sale => {
-          if (!sale.buyers_premium.schedule) return null;
+          if (!sale.buyers_premium || !sale.buyers_premium.schedule) return null;
 
           return map(sale.buyers_premium.schedule, item => ({
             cents: item.min_amount_cents,

--- a/test/schema/sale/index.js
+++ b/test/schema/sale/index.js
@@ -74,31 +74,5 @@ describe('Sale type', () => {
           });
         });
     });
-
-    it('returns a valid object if the buyers premium is missing a schedule', () => {
-      sale.buyers_premium = {};
-
-      const query = `
-        {
-          sale(id: "foo-foo") {
-            _id
-            buyers_premium {
-              amount
-              cents
-            }
-          }
-        }
-      `;
-
-      return runQuery(query)
-        .then(data => {
-          expect(data).to.eql({
-            sale: {
-              _id: '123',
-              buyers_premium: null,
-            },
-          });
-        });
-    });
   });
 });

--- a/test/schema/sale/index.js
+++ b/test/schema/sale/index.js
@@ -1,0 +1,104 @@
+describe('Sale type', () => {
+  const Sale = schema.__get__('Sale');
+
+  const sale = {
+    id: 'foo-foo',
+    _id: '123',
+  };
+
+  beforeEach(() => {
+    Sale.__Rewire__('gravity', sinon.stub().returns(Promise.resolve(sale)));
+  });
+
+  afterEach(() => {
+    Sale.__ResetDependency__('gravity');
+  });
+
+  describe('buyers premium', () => {
+    it('returns a valid object even if the sale has no buyers premium', () => {
+      const query = `
+        {
+          sale(id: "foo-foo") {
+            _id
+            buyers_premium {
+              amount
+              cents
+            }
+          }
+        }
+      `;
+
+      return runQuery(query)
+        .then(data => {
+          expect(data).to.eql({
+            sale: {
+              _id: '123',
+              buyers_premium: null,
+            },
+          });
+        });
+    });
+
+    it('returns a valid object if there is a complete buyers premium', () => {
+      sale.buyers_premium = {
+        schedule: [
+          {
+            min_amount_cents: 10000,
+            currency: 'USD',
+          },
+        ],
+      };
+
+      const query = `
+        {
+          sale(id: "foo-foo") {
+            _id
+            buyers_premium {
+              amount
+              cents
+            }
+          }
+        }
+      `;
+
+      return runQuery(query)
+        .then(data => {
+          expect(data).to.eql({
+            sale: {
+              _id: '123',
+              buyers_premium: [{
+                amount: '$100',
+                cents: 10000,
+              }],
+            },
+          });
+        });
+    });
+
+    it('returns a valid object if the buyers premium is missing a schedule', () => {
+      sale.buyers_premium = {};
+
+      const query = `
+        {
+          sale(id: "foo-foo") {
+            _id
+            buyers_premium {
+              amount
+              cents
+            }
+          }
+        }
+      `;
+
+      return runQuery(query)
+        .then(data => {
+          expect(data).to.eql({
+            sale: {
+              _id: '123',
+              buyers_premium: null,
+            },
+          });
+        });
+    });
+  });
+});


### PR DESCRIPTION
Previously, metaphysics would through a `TypeError: Cannot read property 'schedule' of undefined` if a sale had no buyers premium. This updates the logic to check for both the presence of `buyers_premium` and `buyers_premium.schedule` when generating the response for a `sale`.

This will allow us to run live auction integration sales when the sale has no buyers premium.