### PR TITLE
@craigspaeth => use float so we get 64 bits

### DIFF
--- a/schema/fields/money.js
+++ b/schema/fields/money.js
@@ -4,6 +4,7 @@ import {
   GraphQLString,
   GraphQLInt,
   GraphQLObjectType,
+  GraphQLFloat,
 } from 'graphql';
 
 export const amount = resolve => ({
@@ -47,7 +48,7 @@ const money = ({ name, resolve }) => ({
     name,
     fields: {
       cents: {
-        type: GraphQLInt,
+        type: GraphQLFloat,
         description: 'An amount of money expressed in cents.',
         resolve: (obj) => {
           const { cents } = resolve(obj);


### PR DESCRIPTION
High estimates for auctions are running above 25M HKD, which is larger than 32 bits and thus borking GraphQL.