### PR TITLE
@alloy => Add is_purchasable to artworks to support inquireable artworks w/ exact pricing

### DIFF
--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -39,6 +39,10 @@ import {
   GraphQLInt,
 } from 'graphql';
 
+const is_inquireable = ({ inquireable, acquireable }) => {
+  return (inquireable && !acquireable);
+};
+
 let Artwork;
 
 const ArtworkType = new GraphQLObjectType({
@@ -145,10 +149,18 @@ const ArtworkType = new GraphQLObjectType({
           );
         },
       },
+      is_purchasable: {
+        type: GraphQLBoolean,
+        description: 'True for inquireable artworks that have an exact price.',
+        resolve: (artwork) => {
+          const hasRange = new RegExp(/\-/).exec(artwork.price);
+          return (is_inquireable(artwork) && !hasRange);
+        },
+      },
       is_inquireable: {
         type: GraphQLBoolean,
         description: 'Do we want to encourage inquiries on this work?',
-        resolve: ({ inquireable, acquireable }) => inquireable && !acquireable,
+        resolve: (artwork) => is_inquireable(artwork),
       },
       is_contactable: {
         type: GraphQLBoolean,

--- a/test/schema/artwork/index.js
+++ b/test/schema/artwork/index.js
@@ -113,6 +113,74 @@ describe('Artwork type', () => {
     });
   });
 
+  describe('#is_purchasable', () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          id
+          is_purchasable
+        }
+      }
+    `;
+
+    it('is purchasable if it is inquireable with an exact price', () => {
+      artwork.inquireable = true;
+      artwork.price = '$420';
+      gravity
+        // Artwork
+        .onCall(0)
+        .returns(Promise.resolve(assign({}, artwork)));
+
+      return runQuery(query)
+        .then(data => {
+          expect(data).toEqual({
+            artwork: {
+              id: 'richard-prince-untitled-portrait',
+              is_purchasable: true,
+            },
+          });
+        });
+    });
+
+    it('is not purchasable if it is inquireable without an exact price', () => {
+      artwork.inquireable = true;
+      artwork.price = '$420 - $500';
+      gravity
+        // Artwork
+        .onCall(0)
+        .returns(Promise.resolve(assign({}, artwork)));
+
+      return runQuery(query)
+        .then(data => {
+          expect(data).toEqual({
+            artwork: {
+              id: 'richard-prince-untitled-portrait',
+              is_purchasable: false,
+            },
+          });
+        });
+    });
+
+    it('is not purchasable if it is not inquireable with an exact price', () => {
+      artwork.inquireable = false;
+      artwork.price = '$420';
+      gravity
+        // Artwork
+        .onCall(0)
+        .returns(Promise.resolve(assign({}, artwork)));
+
+      return runQuery(query)
+        .then(data => {
+          expect(data).toEqual({
+            artwork: {
+              id: 'richard-prince-untitled-portrait',
+              is_purchasable: false,
+            },
+          });
+        });
+    });
+  });
+
   describe('#images', () => {
     const query = `
       {


### PR DESCRIPTION
Since this is just for a Force test (for now), decided to go this route rather than something more 'official' in Gravity.

If the test succeeds and we want to roll it out to other clients, it probably makes sense to then offer full-fledged first class support in Gravity, which would probably include other changes besides these booleans (better pricing information overall, etc.)

I believe the logic for this field is correct: an artwork should be inquireable and have an exact price. An artwork being sold (and having an exact price), would not be inquireable, and artworks with hidden prices would not have the exact price, so this would be `false` for those cases.