### PR TITLE
@mzikherman => fix how we check for auction state in is_biddable

### DIFF
--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -196,7 +196,7 @@ const ArtworkType = new GraphQLObjectType({
         description: 'Is this artwork part of an auction that is currently running?',
         resolve: ({ sale_ids }) => {
           if (sale_ids && sale_ids.length > 0) {
-            return gravity('sales', { id: sale_ids, is_auction: true, auction_state: 'open' })
+            return gravity('sales', { id: sale_ids, is_auction: true, live: true })
               .then(sales => {
                 return sales.length > 0;
               });


### PR DESCRIPTION
The sales API doesn't filter based on `auction_state`, so this was returning the auction even if it had closed (related issue: https://github.com/artsy/force/issues/450)

This fixes `is_biddable` to instead query the API based on the `live` param, which is handled: https://github.com/artsy/gravity/blob/master/app/api/v1/sales_endpoint.rb#L23. As we set sales to have `live: true` when open and `live: false` when closed, this should achieve the same thing.