### PR TITLE
@craigspaeth => deprecate custom auction state

### DIFF
--- a/schema/sale_artwork.js
+++ b/schema/sale_artwork.js
@@ -11,7 +11,7 @@ import money, { amount } from './fields/money';
 import numeral from './fields/numeral';
 import gravity from '../lib/loaders/gravity';
 import Artwork from './artwork';
-import Sale, { auctionState } from './sale';
+import Sale from './sale';
 import { GravityIDFields } from './object_identification';
 import {
   GraphQLObjectType,
@@ -29,7 +29,7 @@ export const isBiddable = (sale, { artwork: { sold } }) => {
   return (
     !sold &&
     sale.is_auction &&
-    auctionState(sale) === 'open'
+    sale.auction_state === 'open'
   );
 };
 

--- a/test/schema/sale/index.js
+++ b/test/schema/sale/index.js
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 describe('Sale type', () => {
   const Sale = schema.__get__('Sale');
 
@@ -12,6 +14,96 @@ describe('Sale type', () => {
 
   afterEach(() => {
     Sale.__ResetDependency__('gravity');
+  });
+
+  describe('auction state', () => {
+    const query = `
+      {
+        sale(id: "foo-foo") {
+          _id
+          is_preview
+          is_open
+          is_live_open
+          is_closed
+          auction_state
+          status
+        }
+      }
+    `;
+
+    it('returns the correct values when the sale is closed', () => {
+      sale.auction_state = 'closed';
+      return runQuery(query)
+        .then(data => {
+          expect(data).toEqual({
+            sale: {
+              _id: '123',
+              is_preview: false,
+              is_open: false,
+              is_live_open: false,
+              is_closed: true,
+              auction_state: 'closed',
+              status: 'closed',
+            },
+          });
+        });
+    });
+
+    it('returns the correct values when the sale is in preview mode', () => {
+      sale.auction_state = 'preview';
+      return runQuery(query)
+        .then(data => {
+          expect(data).toEqual({
+            sale: {
+              _id: '123',
+              is_preview: true,
+              is_open: false,
+              is_live_open: false,
+              is_closed: false,
+              auction_state: 'preview',
+              status: 'preview',
+            },
+          });
+        });
+    });
+
+    it('returns the correct values when the sale is open', () => {
+      sale.auction_state = 'open';
+      sale.live_start_at = moment().add(2, 'days');
+      return runQuery(query)
+        .then(data => {
+          expect(data).toEqual({
+            sale: {
+              _id: '123',
+              is_preview: false,
+              is_open: true,
+              is_live_open: false,
+              is_closed: false,
+              auction_state: 'open',
+              status: 'open',
+            },
+          });
+        });
+    });
+
+    it('returns the correct values when the sale is in live mode', () => {
+      sale.auction_state = 'open';
+      sale.live_start_at = moment().subtract(2, 'days');
+      return runQuery(query)
+        .then(data => {
+          expect(data).toEqual({
+            sale: {
+              _id: '123',
+              is_preview: false,
+              is_open: true,
+              is_live_open: true,
+              is_closed: false,
+              auction_state: 'open',
+              status: 'open',
+            },
+          });
+        });
+    });
   });
 
   describe('buyers premium', () => {


### PR DESCRIPTION
This PR deprecates the custom `auction_state` implementation, to be more consistent and reduce some unneeded business logic. The API doesn't return `'live'` as a possible state, but from looking at microgravity, force, and eigen, it doesn't look like this is ever used directly (clients either calculate the live status directly based on `live_start_at`, or use `is_live_open`.

Also, to circle back to https://github.com/artsy/metaphysics/pull/131, it seems that the issues we were seeing in staging were due to the fact that staging's cache does not get rewritten when data is copied from production. Doing a quick test in production showed that all of the auction states match what is returned from the API for all published auctions.

If we do end up seeing errors, we should update or remove caching on those endpoints, but I think better to use the API's state here than re-calculating it in a bunch of places. 😄 

For reference:
```ruby
user = User.find_by_email('sarah@artsymail.com')
sale_ids = Sale.auction.published.pluck(:id).map(&:to_s)
sale_ids.each do |id|
  resp = HTTParty.get("https://api.artsy.net/api/v1/sale/#{id}", headers: {"X-Authentication-Token" => "#{user.authentication_token}"})
  endpoint_state = resp.parsed_response['auction_state']
  db_state = Sale.find(id).auction_state
  puts "#{endpoint_state} -- #{db_state}"
end
```

Will definitely monitor/test this in staging to make sure nothing looks off.