### PR TITLE
@mzikherman mimmick computed value from backbone model

### DIFF
--- a/schema/fair.js
+++ b/schema/fair.js
@@ -88,6 +88,10 @@ const FairType = new GraphQLObjectType({
     name: {
       type: GraphQLString,
     },
+    name_without_year: {
+      type: GraphQLString,
+      resolve: ({ name }) => name.replace(/\s([0-9])+$/, ''),
+    },
     tagline: {
       type: GraphQLString,
     },


### PR DESCRIPTION
There's a function in the backbone fair model that does this, but in the case of the purchase page we're just working with metaphysics json objects. I have a suspicion that this is reversing some logic that takes place on gravity and perhaps gravity could just return an un-appended fair name but this also seems fine.