### PR TITLE
@1aurabrown => is_purchasable to return false for blank prices

### DIFF
--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -8,6 +8,7 @@ import {
 import {
   enhance,
   existyValue,
+  isExisty,
 } from '../../lib/helpers';
 import cached from '../fields/cached';
 import { markdown } from '../fields/markdown';
@@ -161,7 +162,13 @@ const ArtworkType = new GraphQLObjectType({
       is_purchasable: {
         type: GraphQLBoolean,
         description: 'True for inquireable artworks that have an exact price.',
-        resolve: (artwork) => (is_inquireable(artwork) && !has_price_range(artwork.price)),
+        resolve: (artwork) => {
+          return (
+            is_inquireable(artwork) &&
+            isExisty(artwork.price) &&
+            !has_price_range(artwork.price)
+          );
+        },
       },
       is_inquireable: {
         type: GraphQLBoolean,

--- a/test/schema/artwork/index.js
+++ b/test/schema/artwork/index.js
@@ -179,6 +179,25 @@ describe('Artwork type', () => {
           });
         });
     });
+
+    it('is not purchasable if it is inquireable with a blank price', () => {
+      artwork.inquireable = true;
+      artwork.price = '';
+      gravity
+        // Artwork
+        .onCall(0)
+        .returns(Promise.resolve(assign({}, artwork)));
+
+      return runQuery(query)
+        .then(data => {
+          expect(data).toEqual({
+            artwork: {
+              id: 'richard-prince-untitled-portrait',
+              is_purchasable: false,
+            },
+          });
+        });
+    });
   });
 
   describe('#images', () => {


### PR DESCRIPTION
Inquireable works with a blank price were technically 'passing the regex' and so were considered to have an exact price (since it wasn't a range).

Since a blank price is valid (partner chose to hide the price or not input it), let's check for the existence of a price as well.