### PR TITLE
@broskoski => Sort /sales and /related/sales by timely_at

### DIFF
--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -426,7 +426,7 @@ const ArtistType = new GraphQLObjectType({
         resolve: ({ id }, options) => {
           return gravity('related/sales', defaults(options, {
             artist_id: id,
-            sort: '-end_at',
+            sort: 'timely_at,name',
           }));
         },
       },

--- a/schema/home/fetch.js
+++ b/schema/home/fetch.js
@@ -22,7 +22,7 @@ export const featuredFair = () => {
 };
 
 export const featuredAuction = () => {
-  return gravity('sales', { live: true, size: 1, sort: 'end_at' }).then((sales) => {
+  return gravity('sales', { live: true, size: 1, sort: 'timely_at,name' }).then((sales) => {
     if (sales.length) {
       return first(sales);
     }

--- a/schema/sale/sorts.js
+++ b/schema/sale/sorts.js
@@ -40,6 +40,12 @@ export default {
       ELIGIBLE_SALE_ARTWORKS_COUNT_DESC: {
         value: '-eligible_sale_artworks_count',
       },
+      TIMELY_AT_NAME_ASC: {
+        value: 'timely_at,name',
+      },
+      TIMELY_AT_NAME_DESC: {
+        value: '-timely_at,name',
+      },
     },
   }),
 };


### PR DESCRIPTION
This is related to all of the changes I've been PRing to you...

Live sales may not have an `end_at`, so we should be grabbing sales sorted by `timely_at` for the featured auction on the homepage and the widgets on the artist page.