### PR TITLE
@orta => Dont crash when just deathday is provided

### DIFF
--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -158,7 +158,7 @@ const ArtistType = new GraphQLObjectType({
           let formatted_bday = (!isNaN(birthday) && birthday) ? 'b. ' + birthday : birthday;
           formatted_bday = formatted_bday && formatted_bday.replace(/born/i, 'b.');
 
-          if ((!isNaN(deathday) && deathday)) {
+          if ((!isNaN(deathday) && deathday && formatted_bday)) {
             formatted_bday = `${formatted_bday.replace('b. ', '')}–${deathday.match(/\d+/)}`;
           }
 

--- a/test/schema/artist/index.js
+++ b/test/schema/artist/index.js
@@ -263,7 +263,28 @@ describe('Artist type', () => {
         });
     });
 
-    it('returns null if neither are provided', () => {
+    it('returns null if neither birthday, deathday, nor nationality are provided', () => {
+      const query = `
+        {
+          artist(id: "foo-bar") {
+            formatted_nationality_and_birthday
+          }
+        }
+      `;
+
+      return runQuery(query)
+        .then(data => {
+          expect(data).toEqual({
+            artist: {
+              formatted_nationality_and_birthday: null,
+            },
+          });
+        });
+    });
+
+    it('returns null if neither birthday nor nationality are provided', () => {
+      artist.deathday = '2016';
+
       const query = `
         {
           artist(id: "foo-bar") {


### PR DESCRIPTION
We were being defensive about missing nationalities, birthdays and deathdays- except it would still crash if _just_ the deathday was provided :(

Fixes errors like: https://rpm.newrelic.com/accounts/1147389/applications/10782493/traced_errors/a83a7f90-c78b-11e6-972d-f8bc124256a0_0_7913