### PR TITLE
Exposes gravity's raw estimate_cents field

### DIFF
--- a/schema/sale_artwork.js
+++ b/schema/sale_artwork.js
@@ -201,6 +201,10 @@ const SaleArtworkType = new GraphQLObjectType({
           },
         }),
       },
+      estimate_cents: {
+        type: GraphQLInt,
+        description: 'Singular estimate field, if specified',
+      },
       low_estimate_cents: {
         type: GraphQLInt,
         deprecationReason: 'Favor `low_estimate`',


### PR DESCRIPTION
I need to access sale artworks' `estimate_cents` field [in causality](https://github.com/artsy/causality/pull/346) but it's not exposed through metaphysics yet; this PR adds it. Ideally this would have been specified in the schema as `estimate` but that field name is already taken as a formatted string value. At least eigen uses this, so renaming it isn't really an option, so I use `estimate_cents`, the same field name as the `SaleArtwork` model in gravity.