### PR TITLE
@mzikherman: deprecate lowercase enums

### DIFF
--- a/schema/input_fields/event_status.js
+++ b/schema/input_fields/event_status.js
@@ -6,14 +6,30 @@ export default {
     values: {
       current: {
         value: 'current',
+        deprecationReason: 'use capital enums',
       },
       running: {
         value: 'running',
+        deprecationReason: 'use capital enums',
       },
       closed: {
         value: 'closed',
+        deprecationReason: 'use capital enums',
       },
       upcoming: {
+        value: 'upcoming',
+        deprecationReason: 'use capital enums',
+      },
+      CURRENT: {
+        value: 'current',
+      },
+      RUNNING: {
+        value: 'running',
+      },
+      CLOSED: {
+        value: 'closed',
+      },
+      UPCOMING: {
         value: 'upcoming',
       },
     },

--- a/schema/input_fields/format.js
+++ b/schema/input_fields/format.js
@@ -12,6 +12,7 @@ export default {
       },
       markdown: { // Deprecated
         value: 'markdown',
+        deprecationReason: 'deprecated',
       },
     },
   }),

--- a/schema/sorts/artist_sorts.js
+++ b/schema/sorts/artist_sorts.js
@@ -5,12 +5,24 @@ export default {
     name: 'ArtistSorts',
     values: {
       sortable_id_asc: {
+        deprecationReason: 'use capital enums',
         value: 'sortable_id',
       },
       sortable_id_desc: {
+        deprecationReason: 'use capital enums',
         value: '-sortable_id',
       },
       trending_desc: {
+        deprecationReason: 'use capital enums',
+        value: '-trending',
+      },
+      SORTABLE_ID_ASC: {
+        value: 'sortable_id',
+      },
+      SORTABLE_ID_DESC: {
+        value: '-sortable_id',
+      },
+      TRENDING_DESC: {
         value: '-trending',
       },
     },

--- a/schema/sorts/artwork_sorts.js
+++ b/schema/sorts/artwork_sorts.js
@@ -5,39 +5,87 @@ export default {
     name: 'ArtworkSorts',
     values: {
       title_asc: {
+        deprecationReason: 'use capital enums',
         value: 'title',
       },
       title_desc: {
+        deprecationReason: 'use capital enums',
         value: '-title',
       },
       created_at_asc: {
+        deprecationReason: 'use capital enums',
         value: 'created_at',
       },
       created_at_desc: {
+        deprecationReason: 'use capital enums',
         value: '-created_at',
       },
       deleted_at_asc: {
+        deprecationReason: 'use capital enums',
         value: 'deleted_at',
       },
       deleted_at_desc: {
+        deprecationReason: 'use capital enums',
         value: '-deleted_at',
       },
       iconicity_desc: {
+        deprecationReason: 'use capital enums',
         value: '-iconicity',
       },
       merchandisability_desc: {
+        deprecationReason: 'use capital enums',
         value: '-merchandisability',
       },
       published_at_asc: {
+        deprecationReason: 'use capital enums',
         value: 'published_at',
       },
       published_at_desc: {
+        deprecationReason: 'use capital enums',
         value: '-published_at',
       },
       partner_updated_at_desc: {
+        deprecationReason: 'use capital enums',
         value: '-partner_updated_at',
       },
       availability_desc: {
+        deprecationReason: 'use capital enums',
+        value: '-availability',
+      },
+      TITLE_ASC: {
+        value: 'title',
+      },
+      TITLE_DESC: {
+        value: '-title',
+      },
+      CREATED_AT_ASC: {
+        value: 'created_at',
+      },
+      CREATED_AT_DESC: {
+        value: '-created_at',
+      },
+      DELETED_AT_ASC: {
+        value: 'deleted_at',
+      },
+      DELETED_AT_DESC: {
+        value: '-deleted_at',
+      },
+      ICONICITY_DESC: {
+        value: '-iconicity',
+      },
+      MERCHANDISABILITY_DESC: {
+        value: '-merchandisability',
+      },
+      PUBLISHED_AT_ASC: {
+        value: 'published_at',
+      },
+      PUBLISHED_AT_DESC: {
+        value: '-published_at',
+      },
+      PARTNER_UPDATED_AT_DESC: {
+        value: '-partner_updated_at',
+      },
+      AVAILABILITY_DESC: {
         value: '-availability',
       },
     },

--- a/schema/sorts/partner_show_sorts.js
+++ b/schema/sorts/partner_show_sorts.js
@@ -5,33 +5,73 @@ export default {
     name: 'PartnerShowSorts',
     values: {
       created_at_asc: {
+        deprecationReason: 'use capital enums',
         value: 'created_at',
       },
       created_at_desc: {
+        deprecationReason: 'use capital enums',
         value: '-created_at',
       },
       end_at_asc: {
+        deprecationReason: 'use capital enums',
         value: 'end_at',
       },
       end_at_desc: {
+        deprecationReason: 'use capital enums',
         value: '-end_at',
       },
       start_at_asc: {
+        deprecationReason: 'use capital enums',
         value: 'start_at',
       },
       start_at_desc: {
+        deprecationReason: 'use capital enums',
         value: '-start_at',
       },
       name_asc: {
+        deprecationReason: 'use capital enums',
         value: 'name',
       },
       name_desc: {
+        deprecationReason: 'use capital enums',
         value: '-name',
       },
       publish_at_asc: {
+        deprecationReason: 'use capital enums',
         value: 'publish_at',
       },
       publish_at_desc: {
+        deprecationReason: 'use capital enums',
+        value: '-publish_at',
+      },
+      CREATED_AT_ASC: {
+        value: 'created_at',
+      },
+      CREATED_AT_DESC: {
+        value: '-created_at',
+      },
+      END_AT_ASC: {
+        value: 'end_at',
+      },
+      END_AT_DESC: {
+        value: '-end_at',
+      },
+      START_AT_ASC: {
+        value: 'start_at',
+      },
+      START_AT_DESC: {
+        value: '-start_at',
+      },
+      NAME_ASC: {
+        value: 'name',
+      },
+      NAME_DESC: {
+        value: '-name',
+      },
+      PUBLISH_AT_ASC: {
+        value: 'publish_at',
+      },
+      PUBLISH_AT_DESC: {
         value: '-publish_at',
       },
     },


### PR DESCRIPTION
fixes https://github.com/artsy/metaphysics/issues/83

The thing is, you have no way of knowing that these enum values are deprecated unless you intropsect on them somehow. and ideally we'd update all clients, even though the deprecated enum values continue to function.

The graphql ui doesn't seem to alert you, although after looking at their code base it seems like they attempted to add some messaging in the Docs panel if a deprecated enum or field is queried. However, it seems not to be working correctly, or else it doesn't affect enums used as an _argument_. I'm going to make an issue on their repo.

![screen shot 2017-01-12 at 12 20 09 pm](https://cloud.githubusercontent.com/assets/3171662/21887925/529ffba2-d8c2-11e6-8360-eaf0454defe9.png)
![screen shot 2017-01-12 at 12 20 02 pm](https://cloud.githubusercontent.com/assets/3171662/21887926/52b72ff2-d8c2-11e6-8f81-0b6c4b63bca6.png)
