### PR TITLE
@broskoski => add sale_id to filter results

### DIFF
--- a/schema/filter_artworks.js
+++ b/schema/filter_artworks.js
@@ -146,6 +146,9 @@ function filterArtworks(primaryKey) {
       sort: {
         type: GraphQLString,
       },
+      sale_id: {
+        type: GraphQLID,
+      },
     },
     resolve: (root, options, request, { rootValue: { accessToken } }) => {
       const gravityOptions = Object.assign({}, options);


### PR DESCRIPTION
After https://github.com/artsy/gravity/pull/10728, we are now able to filter artworks by `sale_id` in ES. We'll need this for the new collect-like interface on the `/auction` page!