### PR TITLE
[package] Update memjs to 0.10.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "jwt-simple": "^0.5.0",
     "lodash": "^4.3.0",
     "marked": "^0.3.4",
-    "memjs": "^0.9.0",
+    "memjs": "^0.10.0",
     "moment": "^2.14.1",
     "moment-timezone": "^0.5.5",
     "morgan": "^1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2904,9 +2904,9 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
 
-memjs@^0.9.0:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/memjs/-/memjs-0.9.1.tgz#2c2abcc18231e1eb310d13b0f9a265d374ef4903"
+memjs@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/memjs/-/memjs-0.10.0.tgz#5dd549c8c8561aaca7a13e8339f4a7cd88c65efd"
 
 merge-descriptors@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
The version we were using had an issue where too many timeout handlers
were being defined: https://github.com/alevy/memjs/pull/86.

This lead to many warnings like the following in the production logs:

    (node:9852) Warning: Possible EventEmitter memory leak detected.
    11 timeout listeners added. Use emitter.setMaxListeners() to
    increase limit

The logs also show many `ECONNRESET` and similar errors, which may be
related to this: https://github.com/alevy/memjs/issues/89. According to
that thread, however, it seems like version 0.10.0 could also be
suffering from issues, although others report it working for them.