### PR TITLE
@mzikherman => adds a few additional params for the auction2 page

### DIFF
--- a/schema/aggregations/filter_artworks_aggregation.js
+++ b/schema/aggregations/filter_artworks_aggregation.js
@@ -41,6 +41,9 @@ export const ArtworksAggregation = new GraphQLEnumType({
     TOTAL: {
       value: 'total',
     },
+    ARTIST: {
+      value: 'artist',
+    },
     FOLLOWED_ARTISTS: {
       value: 'followed_artists',
     },

--- a/schema/filter_artworks.js
+++ b/schema/filter_artworks.js
@@ -137,6 +137,9 @@ function filterArtworks(primaryKey) {
       price_range: {
         type: GraphQLString,
       },
+      estimate_range: {
+        type: GraphQLString,
+      },
       page: {
         type: GraphQLInt,
       },


### PR DESCRIPTION
Follow-up to: https://github.com/artsy/gravity/pull/10732

Looks like we don't define the acceptable sort params anywhere, but I tested `lot_number` and `searchable_estimate` sorts locally and they look 👌 .