### PR TITLE
@alloy cc @broskoski: Expand on hero unit schema

### DIFF
--- a/schema/home/home_page_hero_units.js
+++ b/schema/home/home_page_hero_units.js
@@ -7,6 +7,7 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
+  GraphQLBoolean,
 } from 'graphql';
 import { shuffle } from 'lodash';
 
@@ -15,6 +16,34 @@ const HomePageHeroUnitType = new GraphQLObjectType({
   fields: {
     ...GravityIDFields,
     cached,
+    mode: {
+      type: new GraphQLEnumType({
+        name: 'HomePageHeroUnitMode',
+        values: {
+          LEFT_DARK: {
+            value: 'left white',
+          },
+          LEFT_LIGHT: {
+            value: 'left black',
+          },
+          CENTERED_DARK: {
+            value: 'center white',
+          },
+          CENTERED_LIGHT: {
+            value: 'center black',
+          },
+          RIGHT_DARK: {
+            value: 'right white',
+          },
+          RIGHT_LIGHT: {
+            value: 'right black',
+          },
+        },
+      }),
+      resolve: ({ type, menu_color_class }) => {
+        return type.toLowerCase() + ' ' + menu_color_class.toLowerCase();
+      },
+    },
     heading: {
       type: GraphQLString,
     },
@@ -22,27 +51,28 @@ const HomePageHeroUnitType = new GraphQLObjectType({
       type: GraphQLString,
       resolve: ({ link }) => link,
     },
-    description: {
-      type: GraphQLString
-    },
     title: {
       type: GraphQLString,
-      resolve: ({ mobile_title }) => mobile_title,
+      resolve: ({ mobile_title, name, platform }) => {
+        return platform === 'desktop' ? name : mobile_title;
+      },
     },
     title_image_url: {
+      args: {
+        retina: {
+          type: GraphQLBoolean,
+        },
+      },
       type: GraphQLString,
+      resolve: ({ title_image_url, title_image_retina_url, retina }) => {
+        return retina ? title_image_retina_url : title_image_url;
+      },
     },
-    type: {
+    subtitle: {
       type: GraphQLString,
-    },
-    name: {
-      type: GraphQLString,
-    },
-    menu_color_class: {
-      type: GraphQLString,
-    },
-    link_color_hover_hex: {
-      type: GraphQLString,
+      resolve: ({ mobile_description, description, platform }) => {
+        return platform === 'desktop' ? description : mobile_description;
+      },
     },
     link_text: {
       type: GraphQLString,

--- a/schema/home/home_page_hero_units.js
+++ b/schema/home/home_page_hero_units.js
@@ -22,14 +22,23 @@ const HomePageHeroUnitType = new GraphQLObjectType({
       type: GraphQLString,
       resolve: ({ link }) => link,
     },
+    description: {
+      type: GraphQLString
+    },
     title: {
       type: GraphQLString,
       resolve: ({ mobile_title }) => mobile_title,
+    },
+    title_image_url: {
+      type: GraphQLString,
     },
     type: {
       type: GraphQLString,
     },
     name: {
+      type: GraphQLString,
+    },
+    menu_color_class: {
       type: GraphQLString,
     },
     link_color_hover_hex: {

--- a/schema/home/home_page_hero_units.js
+++ b/schema/home/home_page_hero_units.js
@@ -8,6 +8,7 @@ import {
   GraphQLObjectType,
   GraphQLString,
 } from 'graphql';
+import { shuffle } from 'lodash';
 
 const HomePageHeroUnitType = new GraphQLObjectType({
   name: 'HomePageHeroUnit',
@@ -24,6 +25,21 @@ const HomePageHeroUnitType = new GraphQLObjectType({
     title: {
       type: GraphQLString,
       resolve: ({ mobile_title }) => mobile_title,
+    },
+    type: {
+      type: GraphQLString,
+    },
+    name: {
+      type: GraphQLString,
+    },
+    link_color_hover_hex: {
+      type: GraphQLString,
+    },
+    link_text: {
+      type: GraphQLString,
+    },
+    credit_line: {
+      type: GraphQLString,
     },
     background_image_url: {
       type: GraphQLString,
@@ -78,7 +94,7 @@ const HomePageHeroUnits = {
     const params = { enabled: true };
     params[platform] = true;
     return gravity('site_hero_units', params).then(units => {
-      return units.map(unit => Object.assign({ platform }, unit));
+      return shuffle(units.map(unit => Object.assign({ platform }, unit)));
     });
   },
 };

--- a/test/schema/home/home_page_hero_units.js
+++ b/test/schema/home/home_page_hero_units.js
@@ -7,9 +7,12 @@ describe('HomePageHeroUnits', () => {
     id: 'artrio-2016-number-3',
     link: '/artrio-2016',
     heading: 'Featured Fair',
+    name: 'ArtRio 2016',
     mobile_title: 'ArtRio 2016',
     background_image_url: 'wide.jpg',
     background_image_mobile_url: 'narrow.jpg',
+    description: 'Discover works on your laptop',
+    mobile_description: 'Discover works on your phone',
   }];
 
   beforeEach(() => {
@@ -21,7 +24,31 @@ describe('HomePageHeroUnits', () => {
     HomePageHeroUnits.__ResetDependency__('gravity');
   });
 
-  ['mobile', 'desktop', 'martsy'].forEach(platform => {
+  ['mobile', 'desktop'].forEach(platform => {
+    it(`picks subtitle for ${platform}`, () => {
+      const params = { enabled: true };
+      params[platform] = true;
+      gravity.withArgs('site_hero_units', params).returns(Promise.resolve(payload));
+
+      const query = `
+        {
+          home_page {
+            hero_units(platform: ${platform.toUpperCase()}) {
+              subtitle
+            }
+          }
+        }
+      `;
+
+      return runQuery(query).then(({ home_page: { hero_units } }) => {
+        if (platform === 'desktop') {
+          expect(hero_units[0].subtitle).toEqual('Discover works on your laptop');
+        } else {
+          expect(hero_units[0].subtitle).toEqual('Discover works on your phone');
+        }
+      });
+    });
+
     it(`returns enabled hero units for ${platform} only`, () => {
       const params = { enabled: true };
       params[platform] = true;


### PR DESCRIPTION
Related: https://github.com/artsy/force/issues/744

Talked with Robert about a request to make the order of homepage banners random to free up our GP + other members from the overhead of managing this (e.g. it becomes complicated when balancing events with things like pricing for promoted content).

I figured `shuffle`ing at the MP level would allow us to easily surface this in Eigen and web simultaneously. This simply adds that shuffling plus other fields necessary to render on web from MP. I'll comment some minor thoughts inline.