### PR TITLE
Add created_at to partner_show schema

### DIFF
--- a/schema/partner_show.js
+++ b/schema/partner_show.js
@@ -92,6 +92,7 @@ const PartnerShowType = new GraphQLObjectType({
     press_release: markdown(),
     start_at: date,
     end_at: date,
+    created_at: date,
     exhibition_period: {
       type: GraphQLString,
       description: 'A formatted description of the start to end dates',


### PR DESCRIPTION
# Problem
We need `created_at` in Force's show page to use it for `sailthru.date` metadata field.

# Solution
Well... add it :)