### PR TITLE
Add Viewer Type

### DIFF
--- a/schema/index.js
+++ b/schema/index.js
@@ -26,6 +26,7 @@ import SaleArtwork from './sale_artwork';
 import Search from './search';
 import Show from './show';
 import TrendingArtists from './trending';
+import Viewer from './viewer';
 import Me from './me';
 import CausalityJWT from './causality_jwt';
 import ObjectIdentification from './object_identification';
@@ -67,6 +68,7 @@ const schema = new GraphQLSchema({
       search: Search,
       show: Show,
       trending_artists: TrendingArtists,
+      viewer: Viewer,
       me: Me,
       causality_jwt: CausalityJWT,
     },

--- a/schema/object_identification.js
+++ b/schema/object_identification.js
@@ -1,28 +1,31 @@
-// To support a type, it should:
-// * specify that it implements the Node interface
-// * add the Node `__id` fields
-// * implement a `isTypeOf` function that from a payload determines if the payload is of that type
-// * add to the below `SupportedTypes` list.
-//
-// Example:
-//
-//   import { has } from 'lodash';
-//   import {
-//     GlobalIDField,
-//     NodeInterface,
-//   } from './object_identification';
-//
-//   const ArtworkType = new GraphQLObjectType({
-//     ...
-//     interfaces: [NodeInterface],
-//     isTypeOf: (obj) => has(obj, 'title') && has(obj, 'artists'),
-//     fields: () => {
-//       return {
-//         __id: GlobalIDField,
-//         ...
-//       };
-//     },
-//   });
+/**
+ * To support a type, it should:
+ *
+ * - specify that it implements the Node interface
+ * - add the Node `__id` fields
+ * - implement a `isTypeOf` function that from a payload determines if the
+ *   payload is of that type
+ * - add to the below `SupportedTypes` list.
+ *
+ * @example
+ *
+ * import { has } from 'lodash';
+ *
+ * import {
+ *   GlobalIDField,
+ *   NodeInterface,
+ * } from './object_identification';
+ *
+ * const ArtworkType = new GraphQLObjectType({
+ *   ...
+ *   interfaces: [NodeInterface],
+ *   isTypeOf: (obj) => has(obj, 'title') && has(obj, 'artists'),
+ *   fields: () => ({
+ *     __id: GlobalIDField,
+ *     ...
+ *   }),
+ * });
+ */
 
 import { basename } from 'path';
 import _ from 'lodash';

--- a/schema/viewer.js
+++ b/schema/viewer.js
@@ -1,0 +1,48 @@
+/**
+ * A "Viewer" is effectively a wildcard type to get around limitations in
+ * Relay, e.g., its inability to support root nodes that contain more than one
+ * argument, and lists. See https://github.com/facebook/relay/issues/112 for
+ * more info, but in sum:
+ *
+ * @example
+ *
+ * This is an invalid Relay query (root has multiple arguments and is a list):
+ *
+ * query {
+ *   sales(is_auction: true, sort: CREATED_AT_ASC) {
+ *     ...
+ *   }
+ * }
+ *
+ * While this is valid as the root is a simple container:
+ *
+ * query {
+ *   viewer {
+ *     sales(is_auction: true, sort: CREATED_AT_ASC) {
+ *       ...
+ *     }
+ *   }
+ * }
+ *
+ * If you need to support the above conditions in your Relay program, add in
+ * additional fields below.
+ */
+
+import Sales from './sales';
+import { GraphQLObjectType } from 'graphql';
+
+const ViewerType = new GraphQLObjectType({
+  name: 'Viewer',
+  description: 'A Viewer',
+  fields: () => ({
+    sales: Sales,
+  }),
+});
+
+const Viewer = {
+  type: ViewerType,
+  description: 'A "Viewer" wildcard used to support complex root queries in Relay',
+  resolve: x => x,
+};
+
+export default Viewer;


### PR DESCRIPTION
While experimenting with Relay yesterday I stumbled upon a few hard constraints around supporting root queries with multiple parameters, as well as lists. After talking with @alloy about [this issue](https://github.com/facebook/relay/issues/112) we determined that adding a wildcard "Viewer" type is an OK workaround, at least until Relay 2 is released. 

**Explanation:**

In Relay, this query doesn't work for two reasons; a) it contains two arguments, and b) it returns a list:
```
query {
  sales(is_auction: true, sort: CREATED_AT_ASC) {
    ...
  }
}
```

Following https://github.com/facebook/relay/issues/112, if the query is wrapped in a simple "view" container, you can get around this limitation:

```
query {
  viewer {
    sales(is_auction: true, sort: CREATED_AT_ASC) {
      ...
    }
  } 
}
```