### PR TITLE
@mzikherman => catch unpublished sales without erroring

### DIFF
--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -448,7 +448,8 @@ const ArtworkType = new GraphQLObjectType({
         resolve: ({ id, sale_ids }) => {
           if (sale_ids && sale_ids.length > 0) {
             const sale_id = _.first(sale_ids);
-            return gravity(`sale/${sale_id}/sale_artwork/${id}`);
+            // don't error if the sale/artwork is unpublished
+            return gravity(`sale/${sale_id}/sale_artwork/${id}`).catch(() => null);
           }
           return null;
         },
@@ -458,7 +459,8 @@ const ArtworkType = new GraphQLObjectType({
         resolve: ({ sale_ids }) => {
           if (sale_ids && sale_ids.length > 0) {
             const sale_id = _.first(sale_ids);
-            return gravity(`sale/${sale_id}`);
+            // don't error if the sale is unpublished
+            return gravity(`sale/${sale_id}`).catch(() => null);
           }
           return null;
         },


### PR DESCRIPTION
Artworks can have `sale_ids` that point to unpublished sales. This PR updates the artwork schema to fail silently when this is the case (for `sale` and `sale_artwork`).