### PR TITLE
@broskoski => Only include for sale artworks for purchasable test

### DIFF
--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -177,7 +177,8 @@ const ArtworkType = new GraphQLObjectType({
             !has_multiple_editions(artwork.edition_sets) &&
             is_inquireable(artwork) &&
             isExisty(artwork.price) &&
-            !has_price_range(artwork.price)
+            !has_price_range(artwork.price) &&
+            artwork.forsale
           );
         },
       },

--- a/test/schema/artwork/index.js
+++ b/test/schema/artwork/index.js
@@ -219,6 +219,26 @@ describe('Artwork type', () => {
           });
         });
     });
+
+    it('is not purchasable if it is inquireable w/ an exact price but not for sale', () => {
+      artwork.inquireable = true;
+      artwork.price = '$420';
+      artwork.forsale = false;
+      gravity
+        // Artwork
+        .onCall(0)
+        .returns(Promise.resolve(assign({}, artwork)));
+
+      return runQuery(query)
+        .then(data => {
+          expect(data).toEqual({
+            artwork: {
+              id: 'richard-prince-untitled-portrait',
+              is_purchasable: false,
+            },
+          });
+        });
+    });
   });
 
   describe('#images', () => {


### PR DESCRIPTION
We were previously using a definition for determining purchasable eligibility that was: `Is the artwork inquireable, w/ an exact price?` (ignoring edition sets).

Now, we've modified the artwork inquireable state to include a larger set of 'unavailable' works. Since the pricing information is more canonical and independent of business logic, it's perfectly possible to have a not-for-sale/sold/on-hold work w/ an exact price (and which is now inquireable).

We'd like to exclude that set of works from being eligible for the purchase test, so we adjust the definition to now require the work be for sale.