### PR TITLE
@broskoski => Support differing sale message for clients detail and list views

### DIFF
--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -319,24 +319,18 @@ const ArtworkType = new GraphQLObjectType({
       },
       sale_message: {
         type: GraphQLString,
-        args: {
-          format: {
-            type: GraphQLBoolean,
-            default: false,
-            description: 'Show a formatted response instead of the one that comes from gravity',
-          },
-        },
-        resolve: (artwork, { format }) => {
-          const sale_message = artwork.sale_message;
-          if (!format) { return sale_message; }
-          if (artwork.availability === 'on hold') {
-            if (artwork.price) {
-              return `${artwork.price}, on hold`;
+        resolve: ({ sale_message, availability, price }) => {
+          if (availability === 'on hold') {
+            if (price) {
+              return `${price}, on hold`;
             }
             return 'On hold';
           }
-          if (sale_message && (sale_message === 'Not for sale' || sale_message.indexOf('Sold') > -1)) { // eslint-disable-line max-len
+          if (availability === 'not for sale') {
             return '';
+          }
+          if (sale_message && sale_message.indexOf('Sold') > -1) {
+            return 'Sold';
           }
           return sale_message;
         },

--- a/test/schema/artwork/index.js
+++ b/test/schema/artwork/index.js
@@ -324,17 +324,17 @@ describe('Artwork type', () => {
     });
   });
 
-  describe('#sale_message (formatted)', () => {
+  describe('#sale_message', () => {
     const query = `
       {
         artwork(id: "richard-prince-untitled-portrait") {
           id
-          sale_message(format: true)
+          sale_message
         }
       }
     `;
 
-    it('returns an "On hold" if work is on hold with no price', () => {
+    it('returns "On hold" if work is on hold with no price', () => {
       artwork.sale_message = 'Not for sale';
       artwork.price = null;
       artwork.availability = 'on hold';
@@ -354,7 +354,7 @@ describe('Artwork type', () => {
         });
     });
 
-    it('returns an "[Price], on hold" if work is on hold with a price', () => {
+    it('returns "[Price], on hold" if work is on hold with a price', () => {
       artwork.sale_message = 'Not for sale';
       artwork.price = '$420,000';
       artwork.availability = 'on hold';
@@ -374,8 +374,26 @@ describe('Artwork type', () => {
         });
     });
 
-    it('returns an empty string if work is sold', () => {
+    it('returns "Sold" if work is sold', () => {
       artwork.sale_message = '$420,000 - Sold';
+      gravity
+        // Artwork
+        .onCall(0)
+        .returns(Promise.resolve(artwork));
+
+      return runQuery(query)
+        .then(data => {
+          expect(data).toEqual({
+            artwork: {
+              id: 'richard-prince-untitled-portrait',
+              sale_message: 'Sold',
+            },
+          });
+        });
+    });
+
+    it('returns an empty string if work is not for sale', () => {
+      artwork.availability = 'not for sale';
       gravity
         // Artwork
         .onCall(0)
@@ -392,8 +410,9 @@ describe('Artwork type', () => {
         });
     });
 
-    it('returns an empty string if work is not for sale', () => {
-      artwork.sale_message = 'Not for sale';
+    it('returns the gravity sale_message if for sale', () => {
+      artwork.availability = 'for sale';
+      artwork.sale_message = 'something from gravity';
       gravity
         // Artwork
         .onCall(0)
@@ -404,7 +423,7 @@ describe('Artwork type', () => {
           expect(data).toEqual({
             artwork: {
               id: 'richard-prince-untitled-portrait',
-              sale_message: '',
+              sale_message: 'something from gravity',
             },
           });
         });


### PR DESCRIPTION
cc @xtina-starr 

As discussed, this supports the new sale message texts across Force/Micro-g/Eigen, for both the artwork detail and list views.

Those can be specified with `view: LIST` and `view: DETAIL`. Calls without any `view` arg just pass through the original sale message from gravity (unformatted).

So, we can just start rendering these simply in clients with no other conditionals, and can be easily updated in the future in just one place.