### PR TITLE
@broskoski => Contact message

### DIFF
--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -204,6 +204,28 @@ const ArtworkType = new GraphQLObjectType({
             }).catch(() => false);
         },
       },
+      contact_message: {
+        type: GraphQLString,
+        description: 'Pre-filled inquiry text',
+        resolve: ({ partner, availability }) => {
+          if (partner && partner.type === 'Auction') {
+            return [
+              'Hello, I am interested in placing a bid on this work.',
+              'Please send me more information.',
+            ].join(' ');
+          }
+          if (availability === 'sold') {
+            return [
+              'Hi, I’m interested in similar works by this artist.',
+              'Could you please let me know if you have anything available?',
+            ].join(' ');
+          }
+          return [
+            'Hi, I’m interested in purchasing this work.',
+            'Could you please provide more information about the piece?',
+          ].join(' ');
+        },
+      },
       is_in_auction: {
         type: GraphQLBoolean,
         description: 'Is this artwork part of an auction?',

--- a/schema/partner.js
+++ b/schema/partner.js
@@ -126,6 +126,7 @@ const PartnerType = new GraphQLObjectType({
       },
       contact_message: {
         type: GraphQLString,
+        deprecationReason: 'Prefer artwork contact_message to handle availability-based prompts.',
         resolve: ({ type }) => {
           if (type === 'Auction') {
             return [

--- a/test/schema/artwork/index.js
+++ b/test/schema/artwork/index.js
@@ -452,7 +452,7 @@ describe('Artwork type', () => {
           expect(data).toEqual({
             artwork: {
               id: 'richard-prince-untitled-portrait',
-              contact_message: 'Hello, I am interested in placing a bid on this work. Please send me more information.',
+              contact_message: 'Hello, I am interested in placing a bid on this work. Please send me more information.', // eslint-disable-line max-len
             },
           });
         });
@@ -470,7 +470,7 @@ describe('Artwork type', () => {
           expect(data).toEqual({
             artwork: {
               id: 'richard-prince-untitled-portrait',
-              contact_message: 'Hi, I’m interested in similar works by this artist. Could you please let me know if you have anything available?',
+              contact_message: 'Hi, I’m interested in similar works by this artist. Could you please let me know if you have anything available?', // eslint-disable-line max-len
             },
           });
         });
@@ -487,7 +487,7 @@ describe('Artwork type', () => {
           expect(data).toEqual({
             artwork: {
               id: 'richard-prince-untitled-portrait',
-              contact_message: 'Hi, I’m interested in purchasing this work. Could you please provide more information about the piece?',
+              contact_message: 'Hi, I’m interested in purchasing this work. Could you please provide more information about the piece?', // eslint-disable-line max-len
             },
           });
         });

--- a/test/schema/artwork/index.js
+++ b/test/schema/artwork/index.js
@@ -430,6 +430,70 @@ describe('Artwork type', () => {
     });
   });
 
+  describe('#contact_message', () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          id
+          contact_message
+        }
+      }
+    `;
+
+    it('returns custom text for an auction partner type', () => {
+      artwork.partner = { type: 'Auction' };
+      gravity
+        // Artwork
+        .onCall(0)
+        .returns(Promise.resolve(artwork));
+
+      return runQuery(query)
+        .then(data => {
+          expect(data).toEqual({
+            artwork: {
+              id: 'richard-prince-untitled-portrait',
+              contact_message: 'Hello, I am interested in placing a bid on this work. Please send me more information.',
+            },
+          });
+        });
+    });
+
+    it('returns custom text for a sold work', () => {
+      artwork.availability = 'sold';
+      gravity
+        // Artwork
+        .onCall(0)
+        .returns(Promise.resolve(artwork));
+
+      return runQuery(query)
+        .then(data => {
+          expect(data).toEqual({
+            artwork: {
+              id: 'richard-prince-untitled-portrait',
+              contact_message: 'Hi, I’m interested in similar works by this artist. Could you please let me know if you have anything available?',
+            },
+          });
+        });
+    });
+
+    it('returns custom text for all other works', () => {
+      gravity
+        // Artwork
+        .onCall(0)
+        .returns(Promise.resolve(artwork));
+
+      return runQuery(query)
+        .then(data => {
+          expect(data).toEqual({
+            artwork: {
+              id: 'richard-prince-untitled-portrait',
+              contact_message: 'Hi, I’m interested in purchasing this work. Could you please provide more information about the piece?',
+            },
+          });
+        });
+    });
+  });
+
   describe('#is_biddable', () => {
     const query = `
       {


### PR DESCRIPTION
Adds a `contact_message` field on the `Artwork` schema to handle various inquiry prompts based on availability.

Deprecated the one on `Partner` since that can't handle a per-artwork one.

I'll update Force to use this new field when possible, and then we can _probably_ remove the `Partner` one. Microgravity proxies Force, and I think Eigen doesn't use it at all.