### PR TITLE
@broskoski => Custom text for on hold works as well

### DIFF
--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -220,10 +220,12 @@ const ArtworkType = new GraphQLObjectType({
               'Could you please let me know if you have anything available?',
             ].join(' ');
           }
-          return [
-            'Hi, I’m interested in purchasing this work.',
-            'Could you please provide more information about the piece?',
-          ].join(' ');
+          if (availability !== 'not for sale') {
+            return [
+              'Hi, I’m interested in purchasing this work.',
+              'Could you please provide more information about the piece?',
+            ].join(' ');
+          }
         },
       },
       is_in_auction: {

--- a/test/schema/artwork/index.js
+++ b/test/schema/artwork/index.js
@@ -476,7 +476,8 @@ describe('Artwork type', () => {
         });
     });
 
-    it('returns custom text for all other works', () => {
+    it('returns custom text for an on hold work', () => {
+      artwork.availability = 'on hold'
       gravity
         // Artwork
         .onCall(0)
@@ -488,6 +489,24 @@ describe('Artwork type', () => {
             artwork: {
               id: 'richard-prince-untitled-portrait',
               contact_message: 'Hi, I’m interested in purchasing this work. Could you please provide more information about the piece?', // eslint-disable-line max-len
+            },
+          });
+        });
+    });
+
+    it('returns nothing for a not for sale work', () => {
+      artwork.availability = 'not for sale'
+      gravity
+        // Artwork
+        .onCall(0)
+        .returns(Promise.resolve(artwork));
+
+      return runQuery(query)
+        .then(data => {
+          expect(data).toEqual({
+            artwork: {
+              id: 'richard-prince-untitled-portrait',
+              contact_message: null,
             },
           });
         });


### PR DESCRIPTION
Oops forgot this, we want to blank the text for 'not for sale' works, and include the standard one for 'on hold'.

So:

sold: custom text
on hold/for sale: custom text (diff from sold)
not for sale: no text