### PR TITLE
@alloy - Adds _artworks field as Relay connection interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "qs": "^5.2.0",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
+    "relay-cursor-paging": "^0.2.0",
     "request": "^2.67.0",
     "source-map-support": "^0.4.3"
   },

--- a/schema/artist/artwork_filters.js
+++ b/schema/artist/artwork_filters.js
@@ -1,0 +1,15 @@
+import { GraphQLEnumType } from 'graphql';
+
+const ArtistArtworksFilters = new GraphQLEnumType({
+  name: 'ArtistArtworksFilters',
+  values: {
+    IS_FOR_SALE: {
+      value: 'for_sale',
+    },
+    IS_NOT_FOR_SALE: {
+      value: 'not_for_sale',
+    },
+  },
+});
+
+export default ArtistArtworksFilters;

--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -1,5 +1,5 @@
 // @flow
-import type { GraphQLFieldConfig } from 'graphql'; 
+import type { GraphQLFieldConfig } from 'graphql';
 import { pageable, getPagingParameters } from 'relay-cursor-paging';
 import {
   connectionDefinitions,

--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -283,7 +283,7 @@ const ArtistType = new GraphQLObjectType({
         }),
         resolve: (artist) => artist,
       },
-      _artworks: {
+      artworks_connection: {
         type: connectionDefinitions({ nodeType: Artwork.type }).connectionType,
         args: pageable(),
         resolve: ({ id, published_artworks_count }, options) => {

--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -44,8 +44,6 @@ import {
   GraphQLEnumType,
 } from 'graphql';
 
-import info from '../../lib/loggers';
-
 // TODO Get rid of this when we remove the deprecated PartnerShow in favour of Show.
 const ShowField = {
   args: {

--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -331,7 +331,7 @@ const ArtistType = new GraphQLObjectType({
         },
         resolve: ({ id }, options) =>
           gravity(`artist/${id}/artworks`, options)
-            .then(exclude(options.exclude, 'id'))
+            .then(exclude(options.exclude, 'id')),
       },
       formatted_artworks_count: {
         type: GraphQLString,

--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -1,7 +1,7 @@
 // @flow
-import type { GraphQLFieldConfig } from 'graphql';
+import type { GraphQLFieldConfig } from 'graphql'; 
 import { pageable, getPagingParameters } from 'relay-cursor-paging';
-import { 
+import {
   connectionDefinitions,
   connectionFromArraySlice,
 } from 'graphql-relay';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,16 @@
 # yarn lockfile v1
 
 
+"@types/graphql-relay@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@types/graphql-relay/-/graphql-relay-0.4.0.tgz#9a033958f2ef0b03a79d82c3da2a91df02a632ee"
+  dependencies:
+    "@types/graphql" "*"
+
+"@types/graphql@*":
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.8.6.tgz#b34fb880493ba835b0c067024ee70130d6f9bb68"
+
 abab@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
@@ -3572,6 +3582,12 @@ regjsparser@^0.1.4:
   resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.1.5.tgz#7ee8f84dc6fa792d3fd0ae228d24bd949ead205c"
   dependencies:
     jsesc "~0.5.0"
+
+relay-cursor-paging@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/relay-cursor-paging/-/relay-cursor-paging-0.2.0.tgz#e005e393dee4145ca123fc910b16017bac64b06b"
+  dependencies:
+    "@types/graphql-relay" "^0.4.0"
 
 repeat-element@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Closes #543 
This implements an `_artworks` (open to alternate name suggestions) field to the `Artist` schema.

`relay-cursor-paging` automatically handles the conversion from `after`, `first`, etc to params that gravity can understand (`size`, `offset`, etc)

![screenshot 2017-02-07 16 40 45](https://cloud.githubusercontent.com/assets/821469/22712839/3eb09e02-ed54-11e6-809b-7121f3f0dec5.png)

TODO:
- Handle `sort` and `filter` args
