### PR TITLE
@broskoski => adds additional fields to the artists endpoint

### DIFF
--- a/schema/artists.js
+++ b/schema/artists.js
@@ -4,6 +4,7 @@ import ArtistSorts from './sorts/artist_sorts';
 import {
   GraphQLList,
   GraphQLInt,
+  GraphQLID,
 } from 'graphql';
 
 const Artists = {
@@ -13,7 +14,14 @@ const Artists = {
     size: {
       type: GraphQLInt,
     },
+    sale_id: {
+      type: GraphQLID,
+    },
     sort: ArtistSorts,
+    page: {
+      type: GraphQLInt,
+      defaultValue: 1,
+    },
   },
   resolve: (root, options) => gravity('artists', options),
 };


### PR DESCRIPTION
After this PR https://github.com/artsy/gravity/pull/10794, the `/artists` endpoint can be filtered further by `sale_id`. Enabling this here so we can use it on the auction2 page!