### PR TITLE
@sarahscott => Add notifications schema

### DIFF
--- a/schema/me/index.js
+++ b/schema/me/index.js
@@ -8,6 +8,7 @@ import LotStandings from './lot_standings';
 import SaleRegistrations from './sale_registrations';
 import SuggestedArtists from './suggested_artists';
 import FollowArtists from './follow_artists';
+import Notifications from './notifications';
 import { IDFields } from '../object_identification';
 import {
   GraphQLString,
@@ -39,6 +40,7 @@ const Me = new GraphQLObjectType({
     sale_registrations: SaleRegistrations,
     follow_artists: FollowArtists,
     suggested_artists: SuggestedArtists,
+    notifications: Notifications,
   },
 });
 

--- a/schema/me/notifications.js
+++ b/schema/me/notifications.js
@@ -1,0 +1,64 @@
+import gravity from '../../lib/loaders/gravity';
+import date from '../fields/date';
+import Artwork from '../artwork';
+import {
+  GraphQLEnumType,
+  GraphQLList,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLInt,
+} from 'graphql';
+
+const NotificationsFeedItemType = new GraphQLObjectType({
+  name: 'NotificationsFeedItem',
+  fields: () => ({
+    status: {
+      type: new GraphQLEnumType({
+        name: 'NotificationsFeedItemStatus',
+        values: {
+          READ: {
+            value: 'read',
+          },
+          UNREAD: {
+            value: 'unread',
+          },
+        },
+      }),
+    },
+    artists: {
+      type: GraphQLString,
+      resolve: ({ actors }) => actors,
+    },
+    message: {
+      type: GraphQLString,
+    },
+    date,
+    artworks: {
+      type: new GraphQLList(Artwork.type),
+      description: 'List of artworks in this notification bundle',
+      resolve: ({ object_ids }) => {
+        return gravity('artworks', { ids: object_ids });
+      },
+    },
+  }),
+});
+
+const Notifications = {
+  type: new GraphQLList(NotificationsFeedItemType),
+  description: 'A list of feed items, indicating published artworks (grouped by date and artists).',
+  args: {
+    size: {
+      type: GraphQLInt,
+      description: 'Number of feed items to return',
+    },
+    page: {
+      type: GraphQLInt,
+    },
+  },
+  resolve: (root, options, request, { rootValue: { accessToken } }) => {
+    if (!accessToken) return null;
+    return gravity.with(accessToken)('me/notifications/feed', options).then(({ feed }) => feed);
+  },
+};
+
+export default Notifications;

--- a/test/schema/me/notifications.js
+++ b/test/schema/me/notifications.js
@@ -1,0 +1,75 @@
+import { assign } from 'lodash';
+
+describe('Me', () => {
+  describe('Notifications', () => {
+    const gravity = sinon.stub();
+    const Me = schema.__get__('Me');
+    const Notifications = Me.__get__('Notifications');
+
+    beforeEach(() => {
+      gravity.with = sinon.stub().returns(gravity);
+
+      Me.__Rewire__('gravity', gravity);
+      Notifications.__Rewire__('gravity', gravity);
+
+      gravity
+        // Me fetch
+        .onCall(0)
+        .returns(Promise.resolve({}));
+    });
+
+    afterEach(() => {
+      Me.__ResetDependency__('gravity');
+      Notifications.__ResetDependency__('gravity');
+    });
+
+    it('returns notification feed items', () => {
+      const query = `
+        {
+          me {
+            notifications {
+              status
+              date(format: "YYYY")
+              artworks {
+                title
+              }
+            }
+          }
+        }
+      `;
+
+      const artworkStub = { artists: [] };
+
+      const artwork1 = assign({}, artworkStub, { title: 'Artwork1' });
+      const artwork2 = assign({}, artworkStub, { title: 'Artwork2' });
+
+      gravity
+        // Feed fetch
+        .onCall(1)
+        .returns(Promise.resolve({
+          feed: [
+            {
+              status: 'read',
+              object_ids: ['artwork1', 'artwork2'],
+              date: '2017-02-17T17:19:44.000Z',
+            },
+          ],
+        }))
+
+        // Artwork fetches
+        .onCall(2)
+        .returns(Promise.resolve([artwork1, artwork2]));
+
+      return runAuthenticatedQuery(query)
+      .then(({ me: { notifications } }) => {
+        expect(notifications).toEqual([
+          {
+            status: 'READ',
+            date: '2017',
+            artworks: [{ title: 'Artwork1' }, { title: 'Artwork2' }],
+          },
+        ]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Queried like:

<img width="904" alt="screen shot 2017-02-17 at 1 50 30 pm" src="https://cloud.githubusercontent.com/assets/1457859/23078763/0a60aeaa-f518-11e6-9ad7-fb015c39bf70.png">

Gravity has been deployed but it'll take a few days for enough data to start being saved to notifications for this to be returning data, so by next week it should be good to go.

Up next: I'm going to look into how to make this possible for Relay. For now this is just queryable via the usual means.