### PR TITLE
@alloy add artwork inquiry requets field on me

### DIFF
--- a/lib/loaders/authenticated_http.js
+++ b/lib/loaders/authenticated_http.js
@@ -1,15 +1,19 @@
 import timer from '../timer';
 import { verbose, error } from '../loggers';
 
-export default (api, headers) => {
+export default (api, headers, loaderOptions) => {
   return path => {
     const clock = timer(path);
     clock.start();
     return new Promise((resolve, reject) => {
       verbose(`Requested: ${path}`);
       api(path, headers)
-        .then(({ body }) => {
-          resolve(body);
+        .then(({ body, headers }) => {
+          if(loaderOptions.headers) {
+            resolve({ body, headers});
+          } else {
+            resolve(body);
+          }
           clock.end();
         })
         .catch((err) => {

--- a/lib/loaders/authenticated_http.js
+++ b/lib/loaders/authenticated_http.js
@@ -1,5 +1,6 @@
 import timer from '../timer';
 import { verbose, error } from '../loggers';
+import { pick } from 'lodash';
 
 export default (api, headers, loaderOptions) => {
   return path => {
@@ -8,11 +9,11 @@ export default (api, headers, loaderOptions) => {
     return new Promise((resolve, reject) => {
       verbose(`Requested: ${path}`);
       api(path, headers)
-        .then(({ body, headers }) => {
-          if(loaderOptions.headers) {
-            resolve({ body, headers});
+        .then((response) => {
+          if (loaderOptions.headers) {
+            resolve(pick(response, ['body', 'headers']));
           } else {
-            resolve(body);
+            resolve(response.body);
           }
           clock.end();
         })

--- a/lib/loaders/gravity.js
+++ b/lib/loaders/gravity.js
@@ -11,8 +11,8 @@ const load = (path, options = {}) => {
   return gravityLoader.load(key);
 };
 
-load.with = (accessToken) => {
-  const authenticatedGravityLoader = authenticatedHttpLoader(gravity, accessToken);
+load.with = (accessToken, loaderOptions = {}) => {
+  const authenticatedGravityLoader = authenticatedHttpLoader(gravity, accessToken, loaderOptions);
   return (path, options = {}) => {
     const key = toKey(path, options);
     if (accessToken) {

--- a/schema/me/artwork_inquiries.js
+++ b/schema/me/artwork_inquiries.js
@@ -8,7 +8,7 @@ import {
 import {
   GraphQLObjectType,
   GraphQLID,
-  GraphQLNonNull
+  GraphQLNonNull,
 } from 'graphql';
 
 export const ArtworkInquiryType = new GraphQLObjectType({
@@ -32,12 +32,12 @@ export default {
     if (!accessToken) return null;
     const { limit: size, offset } = getPagingParameters(options);
     const gravityArgs = { size, offset, inquireable_type: 'artwork', total_count: true };
-    return gravity.with(accessToken, { headers: true })('me/inquiry_requests', gravityArgs )
-      .then (({ body, headers }) => {
+    return gravity.with(accessToken, { headers: true })('me/inquiry_requests', gravityArgs)
+      .then(({ body, headers }) => {
         return connectionFromArraySlice(body, options, {
           arrayLength: headers['x-total-count'],
           sliceStart: offset,
         });
       });
-  }
+  },
 };

--- a/schema/me/artwork_inquiries.js
+++ b/schema/me/artwork_inquiries.js
@@ -11,8 +11,8 @@ import {
   GraphQLNonNull
 } from 'graphql';
 
-export const ArtworkInquiryRequestType = new GraphQLObjectType({
-  name: 'ArtworkInquiryRequest',
+export const ArtworkInquiryType = new GraphQLObjectType({
+  name: 'ArtworkInquiry',
   fields: () => ({
     id: {
       type: GraphQLID,
@@ -25,7 +25,7 @@ export const ArtworkInquiryRequestType = new GraphQLObjectType({
 });
 
 export default {
-  type: connectionDefinitions({ nodeType: ArtworkInquiryRequestType }).connectionType,
+  type: connectionDefinitions({ nodeType: ArtworkInquiryType }).connectionType,
   args: pageable({}),
   description: 'A list of the current user’s inquiry requests',
   resolve: (root, options, request, { rootValue: { accessToken } }) => {

--- a/schema/me/artwork_inquiry_requests.js
+++ b/schema/me/artwork_inquiry_requests.js
@@ -1,0 +1,87 @@
+import gravity from '../../lib/loaders/gravity';
+import date from '../fields/date'
+import Artwork from '../artwork/index';
+import { pageable, getPagingParameters } from 'relay-cursor-paging';
+import {
+  connectionDefinitions,
+  connectionFromArraySlice,
+} from 'graphql-relay';
+import {
+  GraphQLList,
+  GraphQLInt,
+  GraphQLBoolean,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLID,
+  GraphQLEnumType
+} from 'graphql';
+
+export const ArtworkInquiryRequestType = new GraphQLObjectType({
+  name: 'ArtworkInquiryRequest',
+  fields: () => ({
+    id: {
+      type: GraphQLID,
+    },
+    inquirer: {
+      type: new GraphQLObjectType({
+        name: 'ArtworkInquiryRequestInquirer',
+        fields: () => ({
+          id: { type: GraphQLID },
+          name: { type: GraphQLString, }
+        }),
+      })
+    },
+    artwork: {
+      type: Artwork.type,
+      resolve: ({ inquireable }) => inquireable,
+    },
+    statuses: {
+      type: new GraphQLList(
+        new GraphQLObjectType({
+          name: 'ArtworkInquiryRequestStatus',
+          fields: () => ({
+            id: { type: GraphQLID },
+            title: { type: GraphQLString },
+            note: { type: GraphQLString },
+            created_at: date
+          }),
+        })
+      ),
+    },
+    status: {
+      type: GraphQLInt,
+    },
+    user_reported_outcome: {
+      type: new GraphQLEnumType({
+        name: 'UserReportedOutcome',
+        values: {
+          PURCHASED: { value: 'purchased' },
+          STILL_CONSIDERING: { value: 'still_considering' },
+          HIGH_PRICE: { value: 'high_price' },
+          LOST_INTEREST: { value: 'lost_interest' },
+          WORK_UNAVAILABLE: { value: 'work_unavailable' },
+          OTHER: { value: 'other' },
+        },
+      }),
+    },
+    created_at: date,
+  }),
+});
+
+export default {
+  type: connectionDefinitions({ nodeType: ArtworkInquiryRequestType }).connectionType,
+  args: pageable({}),
+  description: 'A list of the current user’s inquiry requests',
+  resolve: (root, options, request, { rootValue: { accessToken } }) => {
+    if (!accessToken) return null;
+    const { limit: size, offset } = getPagingParameters(options);
+    const gravityArgs = { size, offset, inquireable_type: 'artwork', total_count: true }
+    return gravity.with(accessToken, { headers: true })('me/inquiry_requests', gravityArgs )
+      .then (({ body, headers }) => {
+        return connectionFromArraySlice(body, options, {
+          arrayLength: headers['x-total-count'],
+          sliceStart: offset,
+        })
+      });
+  }
+};

--- a/schema/me/artwork_inquiry_requests.js
+++ b/schema/me/artwork_inquiry_requests.js
@@ -22,49 +22,10 @@ export const ArtworkInquiryRequestType = new GraphQLObjectType({
     id: {
       type: GraphQLID,
     },
-    inquirer: {
-      type: new GraphQLObjectType({
-        name: 'ArtworkInquiryRequestInquirer',
-        fields: () => ({
-          id: { type: GraphQLID },
-          name: { type: GraphQLString, }
-        }),
-      })
-    },
     artwork: {
       type: Artwork.type,
       resolve: ({ inquireable }) => inquireable,
     },
-    statuses: {
-      type: new GraphQLList(
-        new GraphQLObjectType({
-          name: 'ArtworkInquiryRequestStatus',
-          fields: () => ({
-            id: { type: GraphQLID },
-            title: { type: GraphQLString },
-            note: { type: GraphQLString },
-            created_at: date
-          }),
-        })
-      ),
-    },
-    status: {
-      type: GraphQLInt,
-    },
-    user_reported_outcome: {
-      type: new GraphQLEnumType({
-        name: 'UserReportedOutcome',
-        values: {
-          PURCHASED: { value: 'purchased' },
-          STILL_CONSIDERING: { value: 'still_considering' },
-          HIGH_PRICE: { value: 'high_price' },
-          LOST_INTEREST: { value: 'lost_interest' },
-          WORK_UNAVAILABLE: { value: 'work_unavailable' },
-          OTHER: { value: 'other' },
-        },
-      }),
-    },
-    created_at: date,
   }),
 });
 

--- a/schema/me/artwork_inquiry_requests.js
+++ b/schema/me/artwork_inquiry_requests.js
@@ -1,5 +1,4 @@
 import gravity from '../../lib/loaders/gravity';
-import date from '../fields/date'
 import Artwork from '../artwork/index';
 import { pageable, getPagingParameters } from 'relay-cursor-paging';
 import {
@@ -7,13 +6,9 @@ import {
   connectionFromArraySlice,
 } from 'graphql-relay';
 import {
-  GraphQLList,
-  GraphQLInt,
-  GraphQLBoolean,
   GraphQLObjectType,
-  GraphQLString,
   GraphQLID,
-  GraphQLEnumType
+  GraphQLNonNull
 } from 'graphql';
 
 export const ArtworkInquiryRequestType = new GraphQLObjectType({
@@ -23,7 +18,7 @@ export const ArtworkInquiryRequestType = new GraphQLObjectType({
       type: GraphQLID,
     },
     artwork: {
-      type: Artwork.type,
+      type: new GraphQLNonNull(Artwork.type),
       resolve: ({ inquireable }) => inquireable,
     },
   }),
@@ -36,13 +31,13 @@ export default {
   resolve: (root, options, request, { rootValue: { accessToken } }) => {
     if (!accessToken) return null;
     const { limit: size, offset } = getPagingParameters(options);
-    const gravityArgs = { size, offset, inquireable_type: 'artwork', total_count: true }
+    const gravityArgs = { size, offset, inquireable_type: 'artwork', total_count: true };
     return gravity.with(accessToken, { headers: true })('me/inquiry_requests', gravityArgs )
       .then (({ body, headers }) => {
         return connectionFromArraySlice(body, options, {
           arrayLength: headers['x-total-count'],
           sliceStart: offset,
-        })
+        });
       });
   }
 };

--- a/schema/me/index.js
+++ b/schema/me/index.js
@@ -9,6 +9,7 @@ import SaleRegistrations from './sale_registrations';
 import SuggestedArtists from './suggested_artists';
 import FollowArtists from './follow_artists';
 import Notifications from './notifications';
+import ArtworkInquiries from './artwork_inquiries';
 import { IDFields } from '../object_identification';
 import {
   GraphQLString,
@@ -41,6 +42,7 @@ const Me = new GraphQLObjectType({
     follow_artists: FollowArtists,
     suggested_artists: SuggestedArtists,
     notifications_connection: Notifications,
+    artwork_inquiries: ArtworkInquiries
   },
 });
 

--- a/schema/me/index.js
+++ b/schema/me/index.js
@@ -42,7 +42,7 @@ const Me = new GraphQLObjectType({
     follow_artists: FollowArtists,
     suggested_artists: SuggestedArtists,
     notifications_connection: Notifications,
-    artwork_inquiries: ArtworkInquiries
+    artwork_inquiries: ArtworkInquiries,
   },
 });
 

--- a/schema/me/index.js
+++ b/schema/me/index.js
@@ -42,7 +42,7 @@ const Me = new GraphQLObjectType({
     follow_artists: FollowArtists,
     suggested_artists: SuggestedArtists,
     notifications_connection: Notifications,
-    artwork_inquiries: ArtworkInquiries,
+    artwork_inquiries_connection: ArtworkInquiries,
   },
 });
 

--- a/test/schema/me/artwork_inquiries.js
+++ b/test/schema/me/artwork_inquiries.js
@@ -1,0 +1,71 @@
+describe('Me', () => {
+  describe('ArtworkInquiries', () => {
+    const gravity = sinon.stub();
+    const Me = schema.__get__('Me');
+    const ArtworkInquiries = Me.__get__('ArtworkInquiries');
+
+    beforeEach(() => {
+      gravity.with = sinon.stub().returns(gravity);
+
+      Me.__Rewire__('gravity', gravity);
+      ArtworkInquiries.__Rewire__('gravity', gravity);
+
+      gravity
+        // Me fetch
+        .onCall(0)
+        .returns(Promise.resolve({}));
+    });
+
+    afterEach(() => {
+      Me.__ResetDependency__('gravity');
+      ArtworkInquiries.__ResetDependency__('gravity');
+    });
+
+    it('returns notification feed items w/ Relay pagination', () => {
+      const query = `
+        {
+          me {
+            artwork_inquiries_connection(first: 2) {
+              pageInfo {
+                hasNextPage
+              }
+              edges {
+                node {
+                  artwork {
+                    title
+                  }
+                }
+              }
+            }
+          }
+        }
+      `;
+
+      const artwork1 = { id: 'artwork1', title: 'Artwork 1', artists: [] };
+      const artwork2 = { id: 'artwork2', title: 'Artwork 2', artists: [] };
+
+      const expectedConnectionData = {
+        pageInfo: {
+          hasNextPage: true,
+        },
+        edges: [
+          { node: { artwork: { title: 'Artwork 1' } } },
+          { node: { artwork: { title: 'Artwork 2' } } },
+        ],
+      };
+
+      gravity
+        // Feed fetch
+        .onCall(1)
+        .returns(Promise.resolve({
+          headers: { 'x-total-count': 3 },
+          body: [{ inquireable: artwork1 }, { inquireable: artwork2 }],
+        }));
+
+      return runAuthenticatedQuery(query)
+      .then(({ me: { artwork_inquiries_connection } }) => {
+        expect(artwork_inquiries_connection).toEqual(expectedConnectionData);
+      });
+    });
+  });
+});


### PR DESCRIPTION
I am including `user_reported_outcome`, `status` and `statuses`, and the client can do whatever it wants with them to determine how to treat artworks in the grid view of the collector loyalty page.