### PR TITLE
@1aurabrown => Make notifications a Relay connection interface

### DIFF
--- a/schema/me/index.js
+++ b/schema/me/index.js
@@ -40,7 +40,7 @@ const Me = new GraphQLObjectType({
     sale_registrations: SaleRegistrations,
     follow_artists: FollowArtists,
     suggested_artists: SuggestedArtists,
-    notifications: Notifications,
+    notifications_connection: Notifications,
   },
 });
 

--- a/schema/me/notifications.js
+++ b/schema/me/notifications.js
@@ -1,4 +1,9 @@
 import gravity from '../../lib/loaders/gravity';
+import { pageable } from 'relay-cursor-paging';
+import {
+  connectionDefinitions,
+  connectionFromArraySlice,
+} from 'graphql-relay';
 import date from '../fields/date';
 import Artwork from '../artwork';
 import {
@@ -6,8 +11,9 @@ import {
   GraphQLList,
   GraphQLObjectType,
   GraphQLString,
-  GraphQLInt,
 } from 'graphql';
+import { omit } from 'lodash';
+import { parseRelayOptions } from '../../lib/helpers';
 
 const NotificationsFeedItemType = new GraphQLObjectType({
   name: 'NotificationsFeedItem',
@@ -44,20 +50,17 @@ const NotificationsFeedItemType = new GraphQLObjectType({
 });
 
 const Notifications = {
-  type: new GraphQLList(NotificationsFeedItemType),
+  type: connectionDefinitions({ nodeType: NotificationsFeedItemType }).connectionType,
   description: 'A list of feed items, indicating published artworks (grouped by date and artists).',
-  args: {
-    size: {
-      type: GraphQLInt,
-      description: 'Number of feed items to return',
-    },
-    page: {
-      type: GraphQLInt,
-    },
-  },
+  args: pageable({}),
   resolve: (root, options, request, { rootValue: { accessToken } }) => {
     if (!accessToken) return null;
-    return gravity.with(accessToken)('me/notifications/feed', options).then(({ feed }) => feed);
+    const gravityOptions = parseRelayOptions(options);
+    return gravity.with(accessToken)('me/notifications/feed', omit(gravityOptions, 'offset'))
+      .then(({ feed, total_unread }) => connectionFromArraySlice(feed, options, {
+        arrayLength: total_unread,
+        sliceStart: gravityOptions.offset,
+      }));
   },
 };
 

--- a/schema/me/notifications.js
+++ b/schema/me/notifications.js
@@ -57,8 +57,8 @@ const Notifications = {
     if (!accessToken) return null;
     const gravityOptions = parseRelayOptions(options);
     return gravity.with(accessToken)('me/notifications/feed', omit(gravityOptions, 'offset'))
-      .then(({ feed, total_unread }) => connectionFromArraySlice(feed, options, {
-        arrayLength: total_unread,
+      .then(({ feed, total }) => connectionFromArraySlice(feed, options, {
+        arrayLength: total,
         sliceStart: gravityOptions.offset,
       }));
   },

--- a/test/schema/me/notifications.js
+++ b/test/schema/me/notifications.js
@@ -27,11 +27,15 @@ describe('Me', () => {
       const query = `
         {
           me {
-            notifications {
-              status
-              date(format: "YYYY")
-              artworks {
-                title
+            notifications_connection(first: 1) {
+              edges {
+                node {
+                  status
+                  date(format: "YYYY")
+                  artworks {
+                    title
+                  }
+                }
               }
             }
           }
@@ -43,10 +47,19 @@ describe('Me', () => {
       const artwork1 = assign({}, artworkStub, { title: 'Artwork1' });
       const artwork2 = assign({}, artworkStub, { title: 'Artwork2' });
 
+      const expectedData = {
+        node: {
+          status: 'READ',
+          date: '2017',
+          artworks: [{ title: 'Artwork1' }, { title: 'Artwork2' }],
+        },
+      };
+
       gravity
         // Feed fetch
         .onCall(1)
         .returns(Promise.resolve({
+          total_unread: 2,
           feed: [
             {
               status: 'read',
@@ -61,14 +74,8 @@ describe('Me', () => {
         .returns(Promise.resolve([artwork1, artwork2]));
 
       return runAuthenticatedQuery(query)
-      .then(({ me: { notifications } }) => {
-        expect(notifications).toEqual([
-          {
-            status: 'READ',
-            date: '2017',
-            artworks: [{ title: 'Artwork1' }, { title: 'Artwork2' }],
-          },
-        ]);
+      .then(({ me: { notifications_connection: { edges } } }) => {
+        expect(edges).toEqual([expectedData]);
       });
     });
   });


### PR DESCRIPTION
cc @sarahscott 

I suspect that when you actually go to use this you may find an issue that this endpoint/connection only returns unread feed items.

I think what you want is to be able to return (and thus page thru) all of your feed items (we keep 30 days worth around before evicting them), and be able to know which ones are read/unread.

Currently, you just get the unread ones, and so their status is UNREAD for all of them.

Is it correct that you need that modification (in order to page thru your whole feed)? If so, I'll modify Gravity (and subsequently Metaphysics) with that argument.

