### PR TITLE
@mzikherman - Add artworks_connection to filter_artworks

### DIFF
--- a/schema/filter_artworks.js
+++ b/schema/filter_artworks.js
@@ -32,7 +32,7 @@ export const FilterArtworksType = new GraphQLObjectType({
       type: artworkConnection,
       args: pageable(),
       resolve: ({ hits, aggregations }, options) => {
-        if ((!aggregations && !aggregations.total)) {
+        if (!aggregations || !aggregations.total) {
           throw new Error('This query must contain the total aggregation');
         }
         const relayOptions = parseRelayOptions(options);


### PR DESCRIPTION
Mostly PR-ing this as-is for discussion ( cc @alloy )

The one issue here is that we need the `total` count for results to make relay happy. However in the case of `filter_artworks`, this won't be present unless the query contains the `total` aggregation.

