### PR TITLE
@damassi - Adds viewer type back to metaphysics 

### DIFF
--- a/schema/index.js
+++ b/schema/index.js
@@ -28,6 +28,7 @@ import Show from './show';
 import TrendingArtists from './trending';
 import Me from './me';
 import CausalityJWT from './causality_jwt';
+import Viewer from './viewer';
 import ObjectIdentification from './object_identification';
 import {
   GraphQLSchema,
@@ -69,6 +70,7 @@ const schema = new GraphQLSchema({
       trending_artists: TrendingArtists,
       me: Me,
       causality_jwt: CausalityJWT,
+      viewer: Viewer,
     },
   }),
 });

--- a/schema/viewer.js
+++ b/schema/viewer.js
@@ -1,0 +1,25 @@
+/**
+ * A "Viewer" is effectively a wildcard type to get around limitations in
+ * Relay, e.g., its inability to support root nodes that contain more than one
+ * argument, and lists. See https://github.com/facebook/relay/issues/112 for
+ * more info
+ */
+
+import filterArtworks from './filter_artworks';
+import { GraphQLObjectType } from 'graphql';
+
+const ViewerType = new GraphQLObjectType({
+  name: 'Viewer',
+  description: 'A wildcard used to support complex root queries in Relay',
+  fields: () => ({
+    filter_artworks: filterArtworks(),
+  }),
+});
+
+const Viewer = {
+  type: ViewerType,
+  description: 'A wildcard used to support complex root queries in Relay',
+  resolve: x => x,
+};
+
+export default Viewer;


### PR DESCRIPTION
As discussed offline, `filter_artworks` is one of those weirdly shaped schema's that is going to need a `viewer` type to work properly....and so adding your `viewer` type back!