### PR TITLE
Add `total_sale_artworks` field to Sale

### DIFF
--- a/schema/sale/index.js
+++ b/schema/sale/index.js
@@ -1,15 +1,16 @@
-import { map } from 'lodash';
-import { exclude } from '../../lib/helpers';
-import moment from 'moment';
-import gravity from '../../lib/loaders/gravity';
+import Artwork from '../artwork';
+import Image from '../image/index';
+import Profile from '../profile';
+import SaleArtwork from '../sale_artwork';
 import cached from '../fields/cached';
 import date from '../fields/date';
-import Artwork from '../artwork';
-import SaleArtwork from '../sale_artwork';
-import Profile from '../profile';
-import Image from '../image/index';
-import { amount } from '../fields/money';
+import gravity from '../../lib/loaders/gravity';
+import moment from 'moment';
 import { GravityIDFields } from '../object_identification';
+import { amount } from '../fields/money';
+import { exclude } from '../../lib/helpers';
+import { map } from 'lodash';
+
 import {
   GraphQLString,
   GraphQLObjectType,
@@ -124,6 +125,9 @@ const SaleType = new GraphQLObjectType({
       },
       description: {
         type: GraphQLString,
+      },
+      eligible_sale_artworks_count: {
+        type: GraphQLInt,
       },
       end_at: date,
       event_start_at: date,


### PR DESCRIPTION
This PR adds a new `total_sale_artworks` field to the `Sale` type, in support for an [Artwork lot page update](https://github.com/artsy/auctions/issues/317):

<img width="610" alt="screen shot 2017-03-09 at 1 30 26 pm" src="https://cloud.githubusercontent.com/assets/236943/23771647/a82670d4-04cc-11e7-8019-83d2e3949d31.png">
