### PR TITLE
@broskoski => Dont auth on OPTIONS requests

### DIFF
--- a/lib/auth/middleware.js
+++ b/lib/auth/middleware.js
@@ -6,8 +6,9 @@ export function isUserAdmin(user) {
   return user.type === 'Admin' || user.roles.indexOf('admin') !== -1;
 }
 
+// short-circuit auth check for OPTIONS requests
 export function isAuthable(req) {
-  return req.accepts(['json', 'html']) === 'html';
+  return req.method !== 'OPTIONS' && req.accepts(['json', 'html']) === 'html';
 }
 
 export function authenticateWithUser(req) {

--- a/test/lib/auth/middleware.js
+++ b/test/lib/auth/middleware.js
@@ -55,4 +55,17 @@ describe('auth middleware', () => {
       expect(next.called).toBeTruthy();
     });
   });
+
+  describe('options request', () => {
+    let next;
+
+    beforeEach(() => {
+      next = sinon.stub();
+    });
+
+    it('nexts', () => {
+      middleware.authenticateOrLogin({ method: 'OPTIONS' }, null, next);
+      expect(next.called).toBeTruthy();
+    });
+  });
 });


### PR DESCRIPTION
cc @joeyAghion 

Kind of a weird one, it seems like the combination of POSTs + auth on Metaphysics was breaking Firefox client-side metaphysics requests.

It seems like the OPTIONS pre-flight request had some custom list of stuff in the `Accept` header, and not what was specified for the POST itself:

<img width="436" alt="screen shot 2017-03-14 at 12 45 29 pm" src="https://cloud.githubusercontent.com/assets/1457859/23913219/a072f804-08b8-11e7-956f-520906f98fec.png">

Specified headers for the POST: https://github.com/artsy/force/blob/72cb7b5096b66d1b216d24dac998610886f2e3a5/lib/metaphysics.coffee#L11

So, the auth middleware was treating the preflight requests from Firefox as though they were coming from the GraphiQL browser, and trying to auth those requests. That check is here: https://github.com/artsy/metaphysics/blob/626e6191b6075bc59f2fef78f40f543ddfbe4146/lib/auth/middleware.js#L9-L11

This can be repro'ed locally, this seems to fix it.