### PR TITLE
@mzikherman => filter sale artworks endpoint

### DIFF
--- a/schema/aggregations/aggregation_count.js
+++ b/schema/aggregations/aggregation_count.js
@@ -19,10 +19,13 @@ export const AggregationCountType = new GraphQLObjectType({
     name: {
       type: GraphQLString,
     },
+    sortable_id: {
+      type: GraphQLString,
+    },
   },
 });
 
 export default ({
   type: AggregationCountType,
-  resolve: ({ name, count }, id) => ({ id, name, count }),
+  resolve: ({ name, count, sortable_id }, id) => ({ id, sortable_id, name, count }),
 }: GraphQLFieldConfig<AggregationCountType, any>);

--- a/schema/aggregations/filter_sale_artworks_aggregation.js
+++ b/schema/aggregations/filter_sale_artworks_aggregation.js
@@ -1,0 +1,51 @@
+// @flow
+
+import { map, orderBy } from 'lodash';
+import AggregationCount from './aggregation_count';
+import {
+  GraphQLObjectType,
+  GraphQLEnumType,
+  GraphQLList,
+} from 'graphql';
+
+export const SaleArtworksAggregation = new GraphQLEnumType({
+  name: 'SaleArtworkAggregation',
+  values: {
+    ARTIST: {
+      value: 'artist',
+    },
+    FOLLOWED_ARTISTS: {
+      value: 'followed_artists',
+    },
+    MEDIUM: {
+      value: 'medium',
+    },
+    TOTAL: {
+      value: 'total',
+    },
+  },
+});
+
+const sorts = {
+  default: (counts) => orderBy(counts, ['count'], ['desc']),
+  artist: (counts) => orderBy(counts, ['sortable_id', 'count'], ['asc', 'desc']),
+};
+
+export const SaleArtworksAggregationResultsType = new GraphQLObjectType({
+  name: 'SaleArtworksAggregationResults',
+  description: 'The results for one of the requested aggregations',
+  fields: () => ({
+    counts: {
+      type: new GraphQLList(AggregationCount.type),
+      resolve: ({ counts, slice }) => {
+        const mapped = map(counts, AggregationCount.resolve);
+        let sort = sorts[slice];
+        if (!sort) sort = sorts.default;
+        return sort ? sort(mapped) : mapped;
+      },
+    },
+    slice: {
+      type: SaleArtworksAggregation,
+    },
+  }),
+});

--- a/schema/filter_sale_artworks.js
+++ b/schema/filter_sale_artworks.js
@@ -1,0 +1,85 @@
+import gravity from '../lib/loaders/gravity';
+import { map, omit } from 'lodash';
+import SaleArtwork from './sale_artwork';
+import numeral from './fields/numeral';
+import {
+  SaleArtworksAggregationResultsType,
+  SaleArtworksAggregation,
+} from './aggregations/filter_sale_artworks_aggregation';
+import {
+  GraphQLList,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLBoolean,
+  GraphQLInt,
+  GraphQLID,
+} from 'graphql';
+
+export const FilterSaleArtworksType = new GraphQLObjectType({
+  name: 'FilterSaleArtworks',
+  fields: () => ({
+    aggregations: {
+      description: 'Returns aggregation counts for the given filter query.',
+      type: new GraphQLList(SaleArtworksAggregationResultsType),
+      resolve: ({ aggregations }) => {
+        const whitelistedAggregations = omit(aggregations, ['total', 'followed_artists']);
+        return map(whitelistedAggregations, (counts, slice) => ({ slice, counts }));
+      },
+    },
+    counts: {
+      type: new GraphQLObjectType({
+        name: 'FilterSaleArtworksCounts',
+        fields: {
+          total: numeral(({ aggregations }) => aggregations.total.value),
+          followed_artists: numeral(({ aggregations }) => aggregations.followed_artists.value),
+        },
+      }),
+      resolve: (artist) => artist,
+    },
+    hits: {
+      description: 'Sale Artwork results.',
+      type: new GraphQLList(SaleArtwork.type),
+    },
+  }),
+});
+
+export const filterSaleArtworksArgs = {
+  aggregations: {
+    type: new GraphQLList(SaleArtworksAggregation),
+  },
+  artist_ids: {
+    type: new GraphQLList(GraphQLString),
+  },
+  include_artworks_by_followed_artists: {
+    type: GraphQLBoolean,
+  },
+  gene_ids: {
+    type: new GraphQLList(GraphQLString),
+  },
+  estimate_range: {
+    type: GraphQLString,
+  },
+  page: {
+    type: GraphQLInt,
+  },
+  sale_id: {
+    type: GraphQLID,
+  },
+  size: {
+    type: GraphQLInt,
+  },
+  sort: {
+    type: GraphQLString,
+  },
+};
+
+const FilterSaleArtworks = {
+  type: FilterSaleArtworksType,
+  description: 'Sale Artworks Elastic Search results',
+  args: filterSaleArtworksArgs,
+  resolve: (root, options, request, { rootValue: { accessToken } }) => {
+    return gravity.with(accessToken)('filter/sale_artworks', options);
+  },
+};
+
+export default FilterSaleArtworks;

--- a/schema/index.js
+++ b/schema/index.js
@@ -16,6 +16,7 @@ import Partner from './partner';
 import Partners from './partners';
 import FilterPartners from './filter_partners';
 import filterArtworks from './filter_artworks';
+import FilterSaleArtworks from './filter_sale_artworks';
 import PartnerCategory from './partner_category';
 import PartnerCategories from './partner_categories';
 import PartnerShow from './partner_show';
@@ -51,6 +52,7 @@ const schema = new GraphQLSchema({
       fairs: Fairs,
       filter_partners: FilterPartners,
       filter_artworks: filterArtworks(),
+      filter_sale_artworks: FilterSaleArtworks,
       gene: Gene,
       home_page: HomePage,
       me: Me,

--- a/test/schema/filter_sale_artworks.js
+++ b/test/schema/filter_sale_artworks.js
@@ -1,0 +1,92 @@
+describe('Filter Sale Artworks', () => {
+  const FilterSaleArtworks = schema.__get__('FilterSaleArtworks');
+
+  beforeEach(() => {
+    const gravity = sinon.stub();
+    gravity.with = sinon.stub().returns(gravity);
+    gravity.withArgs(
+      'filter/sale_artworks', {
+        aggregations: ['total', 'medium', 'followed_artists', 'artist'],
+      }).returns(Promise.resolve({
+        aggregations: {
+          followed_artists: {
+            value: 2,
+          },
+          total: {
+            value: 400,
+          },
+          medium: {
+            prints: {
+              name: 'Prints',
+              count: 123,
+            },
+            painting: {
+              name: 'Painting',
+              count: 24,
+            },
+          },
+          artist: {
+            'andy-warhol': {
+              name: 'Andy Warhol',
+              sortable_id: 'warhol-andy',
+            },
+            'donald-judd': {
+              name: 'Donald Judd',
+              sortable_id: 'judd-donald',
+            },
+            'kara-walker': {
+              name: 'Kara Walker',
+              sortable_id: 'walker-kara',
+            },
+          },
+        },
+      }));
+
+    FilterSaleArtworks.__Rewire__('gravity', gravity);
+  });
+
+  afterEach(() => {
+    FilterSaleArtworks.__ResetDependency__('gravity');
+  });
+
+  it('formats the counts and aggregations, and sorts the artists correctly', () => {
+    const query = `
+      {
+        filter_sale_artworks(
+          aggregations:[TOTAL, MEDIUM, FOLLOWED_ARTISTS, ARTIST]
+        ) {
+          aggregations {
+            slice
+            counts {
+              id
+              name
+              sortable_id
+            }
+          }
+          counts {
+            total
+            followed_artists
+          }
+        }
+      }
+    `;
+
+    return runQuery(query).then(({ filter_sale_artworks: { aggregations, counts } }) => {
+      expect(counts).toEqual({ followed_artists: 2, total: 400 });
+      expect(aggregations).toEqual([{
+        counts: [
+          { id: 'prints', name: 'Prints', sortable_id: null },
+          { id: 'painting', name: 'Painting', sortable_id: null },
+        ],
+        slice: 'MEDIUM',
+      }, {
+        counts: [
+          { id: 'donald-judd', name: 'Donald Judd', sortable_id: 'judd-donald' },
+          { id: 'kara-walker', name: 'Kara Walker', sortable_id: 'walker-kara' },
+          { id: 'andy-warhol', name: 'Andy Warhol', sortable_id: 'warhol-andy' },
+        ],
+        slice: 'ARTIST',
+      }]);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a `filter_sale_artworks` endpoint, which is mostly modeled after the `filter_artworks`. We'll use this on the `/auction2` page instead of the `filter_artworks` endpoint!