### PR TITLE
[DataLoader] Switch to new typed loaders for artwork schema

### DIFF
--- a/lib/loaders/per_type.js
+++ b/lib/loaders/per_type.js
@@ -19,12 +19,19 @@ export default () => {
   return {
     articlesLoader: positronLoader('articles'),
     artistLoader: gravityLoader(id => `artist/${id}`),
+    artistsLoader: gravityLoader('artists'),
+    artworkLoader: gravityLoader(id => `artwork/${id}`),
     artistArtworksLoader: gravityLoader(id => `artist/${id}/artworks`),
+    relatedArtworksLoader: gravityLoader('related/artworks'),
+    relatedFairsLoader: gravityLoader('related/fairs'),
     relatedSalesLoader: gravityLoader('related/sales'),
     relatedShowsLoader: gravityLoader('related/shows'),
     relatedMainArtistsLoader: gravityLoader('related/layer/main/artists'),
     relatedContemporaryArtistsLoader: gravityLoader('related/layer/contemporary/artists'),
+    partnerLoader: gravityLoader(id => `partner/${id}`),
     partnerArtistsLoader: gravityLoader(id => `artist/${id}/partner_artists`),
     partnerShowImagesLoader: gravityLoader(id => `partner_show/${id}/images`),
+    saleLoader: gravityLoader(id => `sale/${id}`),
+    salesLoader: gravityLoader('sales'),
   };
 };

--- a/test/schema/image/index.js
+++ b/test/schema/image/index.js
@@ -22,7 +22,6 @@ describe('getDefault', () => {
 });
 
 describe('Image type', () => {
-  const Artwork = schema.__get__('Artwork');
   const image = {
     image_url: 'https://xxx.cloudfront.net/xxx/:version.jpg',
     image_versions: [
@@ -35,24 +34,19 @@ describe('Image type', () => {
     },
   };
 
+  let artwork = null;
+  let rootValue = null;
+
   beforeEach(() => {
-    const gravity = sinon.stub();
-
-    gravity
-      // Artwork
-      .onCall(0)
-      .returns(Promise.resolve({
-        id: 'richard-prince-untitled-portrait',
-        title: 'untitled-portrait',
-        artists: [],
-        images: [image],
-      }));
-
-    Artwork.__Rewire__('gravity', gravity);
-  });
-
-  afterEach(() => {
-    Artwork.__ResetDependency__('gravity');
+    artwork = {
+      id: 'richard-prince-untitled-portrait',
+      title: 'untitled-portrait',
+      artists: [],
+      images: [image],
+    };
+    rootValue = {
+      artworkLoader: sinon.stub().withArgs(artwork.id).returns(Promise.resolve(artwork)),
+    };
   });
 
   describe('#orientation', () => {
@@ -67,7 +61,7 @@ describe('Image type', () => {
     it('is square by default (when there is no image geometry)', () => {
       assign(image, { original_width: null, original_height: null });
 
-      return runQuery(query)
+      return runQuery(query, rootValue)
         .then(data => {
           expect(data.artwork.image.orientation).toBe('square');
         });
@@ -76,7 +70,7 @@ describe('Image type', () => {
     it('detects portrait', () => {
       assign(image, { original_width: 1000, original_height: 1500 });
 
-      return runQuery(query)
+      return runQuery(query, rootValue)
         .then(data => {
           expect(data.artwork.image.orientation).toBe('portrait');
         });
@@ -85,7 +79,7 @@ describe('Image type', () => {
     it('detects landscape', () => {
       assign(image, { original_width: 2000, original_height: 1500 });
 
-      return runQuery(query)
+      return runQuery(query, rootValue)
         .then(data => {
           expect(data.artwork.image.orientation).toBe('landscape');
         });
@@ -94,7 +88,7 @@ describe('Image type', () => {
     it('detects square', () => {
       assign(image, { original_width: 2000, original_height: 2000 });
 
-      return runQuery(query)
+      return runQuery(query, rootValue)
         .then(data => {
           expect(data.artwork.image.orientation).toBe('square');
         });

--- a/test/schema/object_identification.js
+++ b/test/schema/object_identification.js
@@ -11,6 +11,13 @@ describe('Object Identification', () => {
         artworks_count: 42,
       },
     },
+    Artwork: {
+      artworkLoader: {
+        id: 'foo-bar',
+        title: 'Foo Bar',
+        artists: null,
+      },
+    },
   };
 
   _.keys(loaderTests).forEach(typeName => {
@@ -67,12 +74,6 @@ describe('Object Identification', () => {
       positron: {
         title: 'Nightlife at the Foo Bar',
         author: 'Artsy Editorial',
-      },
-    },
-    Artwork: {
-      gravity: {
-        title: 'For baz',
-        artists: null,
       },
     },
     Partner: {


### PR DESCRIPTION
This updates a bunch of artwork ones.

Still to do: we have some that are nested API routes where the route is built up out of more than just the `id` (https://github.com/artsy/metaphysics/blob/af58764d25fec83433e4535286f0693f8b1e0f3e/schema/artwork/index.js#L289)

+ tests