### PR TITLE
@mzikherman => [Notifications] fix for image url bug

### DIFF
--- a/schema/me/notifications.js
+++ b/schema/me/notifications.js
@@ -49,7 +49,7 @@ const NotificationsFeedItemType = new GraphQLObjectType({
     },
     image: {
       type: Image.type,
-      resolve: ({ object }) => object.artists.count > 0 && Image.resolve(object.artists[0]),
+      resolve: ({ object }) => object.artists.length > 0 && Image.resolve(object.artists[0]),
     },
   }),
 });

--- a/test/schema/me/notifications.js
+++ b/test/schema/me/notifications.js
@@ -38,6 +38,9 @@ describe('Me', () => {
                   artworks {
                     title
                   }
+                  image {
+                    url
+                  }
                 }
               }
             }
@@ -57,6 +60,9 @@ describe('Me', () => {
         edges: [{
           node: {
             status: 'READ',
+            image: {
+              url: 'cloudfront.url',
+            },
             date: '2017',
             artworks: [{ title: 'Artwork1' }, { title: 'Artwork2' }],
           },
@@ -71,6 +77,7 @@ describe('Me', () => {
           feed: [
             {
               status: 'read',
+              object: { artists: [{ image_url: 'cloudfront.url' }] },
               object_ids: ['artwork1', 'artwork2'],
               date: '2017-02-17T17:19:44.000Z',
             },


### PR DESCRIPTION
I think I lost the OG branch that produced that screenshot in my last pr and hastily re-wrote the line with `count` instead of `length`... oops. This definitely DEFINITELY uses `length` and adds the url the notifications spec ✅ .