### PR TITLE
@joeyAghion => Make sure we fetch each artist individually for an artwork

### DIFF
--- a/lib/loaders/per_type.js
+++ b/lib/loaders/per_type.js
@@ -19,7 +19,6 @@ export default () => {
   return {
     articlesLoader: positronLoader('articles'),
     artistLoader: gravityLoader(id => `artist/${id}`),
-    artistsLoader: gravityLoader('artists'),
     artworkLoader: gravityLoader(id => `artwork/${id}`),
     artistArtworksLoader: gravityLoader(id => `artist/${id}/artworks`),
     relatedArtworksLoader: gravityLoader('related/artworks'),

--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -87,10 +87,11 @@ const ArtworkType = new GraphQLObjectType({
             description: 'Use whatever is in the original response instead of making a request',
           },
         },
-        resolve: ({ artists }, { shallow }, request, { rootValue: { artistsLoader } }) => {
+        resolve: ({ artists }, { shallow }, request, { rootValue: { artistLoader } }) => {
           if (shallow) return artists;
-          const ids = artists.map(artist => artist._id);
-          return artistsLoader(null, { ids }).catch(() => []);
+          return Promise.all(
+            artists.map(artist => artistLoader(artist.id))
+          ).catch(() => []);
         },
       },
       artist_names: {


### PR DESCRIPTION
In my aggressive schema/loader updates, I switched this away from fetching each artist individually (but in parallel), to just one fetch (via `ids`).

Only problem is that just returns _short_ JSON, yet we need _public_ JSON (which we were of course getting by fetching each individually).