### PR TITLE
@joeyAghion => revert options for filter artworks endpoint

### DIFF
--- a/schema/aggregations/filter_artworks_aggregation.js
+++ b/schema/aggregations/filter_artworks_aggregation.js
@@ -11,9 +11,6 @@ import {
 export const ArtworksAggregation = new GraphQLEnumType({
   name: 'ArtworkAggregation',
   values: {
-    ARTIST: {
-      value: 'artist',
-    },
     COLOR: {
       value: 'color',
     },

--- a/schema/filter_artworks.js
+++ b/schema/filter_artworks.js
@@ -147,9 +147,6 @@ export const filterArtworksArgs = {
   price_range: {
     type: GraphQLString,
   },
-  estimate_range: {
-    type: GraphQLString,
-  },
   page: {
     type: GraphQLInt,
   },


### PR DESCRIPTION
Related to your work here: https://github.com/artsy/gravity/pull/10886
(also a direct revert of https://github.com/artsy/metaphysics/pull/527, haha :sob:)

This PR removes the `estimate_range` parameter and `ARTIST` aggregation options from the `filter_artworks` endpoint here, as they are no longer supported from our API.