### PR TITLE
@alloy => Add an Impulse loader and fetch user conversations

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -9,6 +9,7 @@ METAPHYSICS_STAGING_ENDPOINT=https://metaphysics-staging.artsy.net
 METAPHYSICS_PRODUCTION_ENDPOINT=https://metaphysics-production.artsy.net
 HMAC_SECRET=https://www.youtube.com/watch?v=F5bAa6gFvLs
 GALAXY_API_BASE=https://galaxy-staging-herokuapp.com
+IMPULSE_API_BASE=https://converations-staging.artsy.net/api
 PORT=5001
 
 NODE_ENV=test

--- a/lib/apis/fetch.js
+++ b/lib/apis/fetch.js
@@ -9,7 +9,8 @@ export default (url, options = {}) => {
       timeout: config.REQUEST_TIMEOUT_MS,
     });
     request(url, opts, (err, response) => {
-      if (!!err || (response.statusCode !== 200 && response.statusCode !== 201)) {
+      // If there is an error or non-200 status code, reject.
+      if (!!err || !(response.statusCode.toString().match(/^2/))) {
         if (err) return reject(err);
 
         const message = compact([

--- a/lib/apis/fetch.js
+++ b/lib/apis/fetch.js
@@ -8,9 +8,8 @@ export default (url, options = {}) => {
       method: 'GET',
       timeout: config.REQUEST_TIMEOUT_MS,
     });
-
     request(url, opts, (err, response) => {
-      if (!!err || response.statusCode !== 200) {
+      if (!!err || (response.statusCode !== 200 && response.statusCode !== 201)) {
         if (err) return reject(err);
 
         const message = compact([

--- a/lib/apis/gravity.js
+++ b/lib/apis/gravity.js
@@ -4,8 +4,8 @@ import config from '../../config';
 
 const { GRAVITY_API_BASE } = process.env;
 
-export default (path, accessToken) => {
+export default (path, accessToken, fetchOptions = {}) => {
   const headers = { 'X-XAPP-TOKEN': config.GRAVITY_XAPP_TOKEN };
   if (accessToken) assign(headers, { 'X-ACCESS-TOKEN': accessToken });
-  return fetch(`${GRAVITY_API_BASE}/${path}`, { headers });
+  return fetch(`${GRAVITY_API_BASE}/${path}`, assign({}, fetchOptions, { headers }));
 };

--- a/lib/apis/impulse.js
+++ b/lib/apis/impulse.js
@@ -1,0 +1,11 @@
+import { assign } from 'lodash';
+import fetch from './fetch';
+import config from '../../config';
+
+const { IMPULSE_API_BASE } = process.env;
+
+export default (path, accessToken) => {
+  const headers = {};
+  if (accessToken) assign(headers, { 'Authorization': `Bearer ${accessToken}` });
+  return fetch(`${IMPULSE_API_BASE}/${path}`, { headers });
+};

--- a/lib/apis/impulse.js
+++ b/lib/apis/impulse.js
@@ -1,11 +1,10 @@
 import { assign } from 'lodash';
 import fetch from './fetch';
-import config from '../../config';
 
 const { IMPULSE_API_BASE } = process.env;
 
 export default (path, accessToken) => {
   const headers = {};
-  if (accessToken) assign(headers, { 'Authorization': `Bearer ${accessToken}` });
+  if (accessToken) assign(headers, { Authorization: `Bearer ${accessToken}` });
   return fetch(`${IMPULSE_API_BASE}/${path}`, { headers });
 };

--- a/lib/loaders/authenticated_http.js
+++ b/lib/loaders/authenticated_http.js
@@ -2,13 +2,13 @@ import timer from '../timer';
 import { verbose, error } from '../loggers';
 import { pick } from 'lodash';
 
-export default (api, headers, loaderOptions) => {
+export default (api, headers, loaderOptions = {}) => {
   return path => {
     const clock = timer(path);
     clock.start();
     return new Promise((resolve, reject) => {
       verbose(`Requested: ${path}`);
-      api(path, headers)
+      api(path, headers, loaderOptions)
         .then((response) => {
           if (loaderOptions.headers) {
             resolve(pick(response, ['body', 'headers']));

--- a/lib/loaders/gravity.js
+++ b/lib/loaders/gravity.js
@@ -1,4 +1,5 @@
 import { toKey } from '../helpers';
+import { defaults } from 'lodash';
 import gravity from '../apis/gravity';
 import httpLoader from './http';
 import authenticatedHttpLoader from './authenticated_http';
@@ -21,6 +22,17 @@ load.with = (accessToken, loaderOptions = {}) => {
     return gravityLoader.load(key);
   };
 };
+
+load.authenticatedPost = (accessToken, loaderOptions = {}) => {
+  const opts = defaults(loaderOptions, {
+    method: 'POST',
+  });
+  const authenticatedGravityLoader = authenticatedHttpLoader(gravity, accessToken, opts);
+  return (path, options = {}) => {
+    const key = toKey(path, options);
+    return authenticatedGravityLoader(key, accessToken);
+  };
+}
 
 load.all = all;
 

--- a/lib/loaders/gravity.js
+++ b/lib/loaders/gravity.js
@@ -32,7 +32,7 @@ load.authenticatedPost = (accessToken, loaderOptions = {}) => {
     const key = toKey(path, options);
     return authenticatedGravityLoader(key, accessToken);
   };
-}
+};
 
 load.all = all;
 

--- a/lib/loaders/impulse.js
+++ b/lib/loaders/impulse.js
@@ -1,0 +1,15 @@
+import { toKey } from '../helpers';
+import impulse from '../apis/impulse';
+import authenticatedHttpLoader from './authenticated_http';
+
+const load = {};
+
+load.with = (accessToken, loaderOptions = {}) => {
+  const authenticatedImpulseLoader = authenticatedHttpLoader(impulse, accessToken, loaderOptions);
+  return (path, options = {}) => {
+    const key = toKey(path, options);
+    return authenticatedImpulseLoader(key, accessToken);
+  };
+};
+
+export default load;

--- a/lib/loaders/per_type.js
+++ b/lib/loaders/per_type.js
@@ -1,5 +1,6 @@
 import gravity from '../apis/gravity';
 import positron from '../apis/positron';
+import impulse from '../apis/impulse';
 import { toKey } from '../helpers';
 import httpLoader from './http';
 

--- a/lib/loaders/per_type.js
+++ b/lib/loaders/per_type.js
@@ -1,6 +1,5 @@
 import gravity from '../apis/gravity';
 import positron from '../apis/positron';
-import impulse from '../apis/impulse';
 import { toKey } from '../helpers';
 import httpLoader from './http';
 

--- a/schema/me/conversations.js
+++ b/schema/me/conversations.js
@@ -1,0 +1,68 @@
+import date from '../fields/date';
+import impulse from '../../lib/loaders/impulse';
+import gravity from '../../lib/loaders/gravity';
+import {
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLList,
+  GraphQLInt,
+} from 'graphql';
+const { IMPULSE_APPLICATION_ID } = process.env;
+
+const ConversationType = new GraphQLObjectType({
+  name: 'ConversationType',
+  description: 'A conversation.',
+  fields: {
+    id: {
+      description: 'Impulse id.',
+      type: GraphQLString,
+    },
+    inquiry_id: {
+      description: 'Gravity inquiry id.',
+      type: GraphQLString,
+    },
+    from_id: {
+      type: GraphQLString,
+    },
+    from_type: {
+      type: GraphQLString,
+    },
+    from_email: {
+      type: GraphQLString,
+    },
+    to_id: {
+      type: GraphQLString,
+    },
+    to_type: {
+      type: GraphQLString,
+    },
+    buyer_outcome: {
+      type: GraphQLString,
+    },
+    buyer_outcome_at: date,
+    initial_message: {
+      type: GraphQLString,
+    },
+  },
+});
+
+export default {
+  type: new GraphQLList(ConversationType),
+  decription: 'Converations for the user. First a token from gravity is requested.',
+  args: {
+    page: {
+      type: GraphQLInt,
+    },
+    size: {
+      type: GraphQLInt,
+    },
+  },
+  resolve: (root, option, request, { rootValue: { accessToken, userID } }) => {
+    if (!accessToken) return null;
+    return gravity.authenticatedPost(accessToken)('me/token', { client_application_id: IMPULSE_APPLICATION_ID }).then(data => {
+      return impulse.with(data.token)('conversations', { from_id: userID, from_type: 'User' }).then(impulseData => {
+        return impulseData.conversations;
+      });
+    });
+  }
+}

--- a/schema/me/conversations.js
+++ b/schema/me/conversations.js
@@ -6,6 +6,8 @@ import {
   GraphQLString,
   GraphQLList,
   GraphQLInt,
+  GraphQLBoolean,
+  GraphQLNonNull,
 } from 'graphql';
 const { IMPULSE_APPLICATION_ID } = process.env;
 
@@ -22,33 +24,44 @@ const ConversationType = new GraphQLObjectType({
       type: GraphQLString,
     },
     from_id: {
-      type: GraphQLString,
+      type: new GraphQLNonNull(GraphQLString),
     },
     from_type: {
-      type: GraphQLString,
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    from_name: {
+      type: new GraphQLNonNull(GraphQLString),
     },
     from_email: {
-      type: GraphQLString,
+      type: new GraphQLNonNull(GraphQLString),
     },
     to_id: {
-      type: GraphQLString,
+      type: new GraphQLNonNull(GraphQLString),
     },
     to_type: {
-      type: GraphQLString,
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    to_name: {
+      type: new GraphQLNonNull(GraphQLString),
     },
     buyer_outcome: {
       type: GraphQLString,
     },
     buyer_outcome_at: date,
+    created_at: date,
+
     initial_message: {
       type: GraphQLString,
+    },
+    purchase_request: {
+      type: GraphQLBoolean,
     },
   },
 });
 
 export default {
   type: new GraphQLList(ConversationType),
-  decription: 'Converations for the user. First a token from gravity is requested.',
+  decription: 'Conversations, usually between a user and partner.',
   args: {
     page: {
       type: GraphQLInt,

--- a/schema/me/conversations.js
+++ b/schema/me/conversations.js
@@ -59,10 +59,15 @@ export default {
   },
   resolve: (root, option, request, { rootValue: { accessToken, userID } }) => {
     if (!accessToken) return null;
-    return gravity.authenticatedPost(accessToken)('me/token', { client_application_id: IMPULSE_APPLICATION_ID }).then(data => {
-      return impulse.with(data.token)('conversations', { from_id: userID, from_type: 'User' }).then(impulseData => {
+    return gravity.authenticatedPost(accessToken)('me/token', {
+      client_application_id: IMPULSE_APPLICATION_ID,
+    }).then(data => {
+      return impulse.with(data.token)('conversations', {
+        from_id: userID,
+        from_type: 'User',
+      }).then(impulseData => {
         return impulseData.conversations;
       });
     });
-  }
-}
+  },
+};

--- a/schema/me/index.js
+++ b/schema/me/index.js
@@ -9,6 +9,7 @@ import SaleRegistrations from './sale_registrations';
 import SuggestedArtists from './suggested_artists';
 import FollowArtists from './follow_artists';
 import Notifications from './notifications';
+import Conversations from './conversations';
 import ArtworkInquiries from './artwork_inquiries';
 import { IDFields } from '../object_identification';
 import {
@@ -24,6 +25,7 @@ const Me = new GraphQLObjectType({
     bidders: Bidders,
     bidder_status: BidderStatus,
     bidder_positions: BidderPositions,
+    conversations: Conversations,
     created_at: date,
     email: {
       type: GraphQLString,

--- a/test/lib/loaders/gravity.js
+++ b/test/lib/loaders/gravity.js
@@ -4,7 +4,7 @@ describe('gravity', () => {
   afterEach(() => gravity.__ResetDependency__('gravity'));
 
   describe('with authentication', () => {
-    it('loads the path and passes in the token', () => {
+    it('loads the path and passes in the token and options', () => {
       const api = sinon.stub().returns(Promise.resolve({ body: { ok: true } }));
       gravity.__Rewire__('gravity', api);
 
@@ -15,9 +15,9 @@ describe('gravity', () => {
       ])
         .then(responses => {
           expect(api.args).toEqual([
-            ['foo/bar?ids%5B%5D=baz', 'xxx'],
-            ['foo/bar?ids%5B%5D=baz', 'yyy'],
-            ['foo/bar?ids%5B%5D=baz', 'zzz'],
+            ['foo/bar?ids%5B%5D=baz', 'xxx', {}],
+            ['foo/bar?ids%5B%5D=baz', 'yyy', {}],
+            ['foo/bar?ids%5B%5D=baz', 'zzz', {}],
           ]);
           expect(responses).toEqual([
             { ok: true },

--- a/test/schema/me/conversations.js
+++ b/test/schema/me/conversations.js
@@ -1,0 +1,81 @@
+describe('Me', () => {
+  describe('Conversations', () => {
+    const gravity = sinon.stub();
+    const impulse = sinon.stub();
+    const Me = schema.__get__('Me');
+    const Conversations = Me.__get__('Conversations');
+
+    beforeEach(() => {
+      gravity.with = sinon.stub().returns(gravity);
+      gravity.authenticatedPost = sinon.stub().returns(gravity);
+      impulse.with = sinon.stub().returns(impulse);
+
+      Me.__Rewire__('gravity', gravity);
+      Conversations.__Rewire__('gravity', gravity);
+      Conversations.__Rewire__('impulse', impulse);
+
+      gravity
+        // Me fetch
+        .onCall(0)
+        .returns(Promise.resolve({}));
+    });
+
+    afterEach(() => {
+      Me.__ResetDependency__('gravity');
+      Conversations.__ResetDependency__('gravity');
+      Conversations.__ResetDependency__('impulse');
+    });
+
+    it('returns conversations', () => {
+      const query = `
+        {
+          me {
+            conversations {
+              id
+              initial_message
+              from_email
+            }
+          }
+        }
+      `;
+
+      const conversation1 = {
+        id: '2',
+        initial_message: 'omg im sooo interested',
+        from_email: 'percy@cat.com',
+      };
+      const conversation2 = {
+        id: '3',
+        initial_message: 'im only a little interested',
+        from_email: 'percy@cat.com',
+      };
+
+      const expectedConversationData = [
+        {
+          id: '2',
+          initial_message: 'omg im sooo interested',
+          from_email: 'percy@cat.com',
+        },
+        {
+          id: '3',
+          initial_message: 'im only a little interested',
+          from_email: 'percy@cat.com',
+        },
+      ];
+
+      gravity
+        // Token request
+        .onCall(1)
+        .returns(Promise.resolve({ token: 'token' }));
+
+      impulse
+        .onCall(0)
+        .returns(Promise.resolve({ conversations: [conversation1, conversation2] }));
+
+      return runAuthenticatedQuery(query)
+      .then(({ me: { conversations } }) => {
+        expect(conversations).toEqual(expectedConversationData);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This isn't really a requirement (yet), but I figured it sort of made sense before the mutation. Basically, this adds the `Impulse` stuff and lets a user start to fetch their own conversations.

The mutation will wind up returning a Conversation type so figured this makes sense first. Also, even though we are just fetching inquiries, if we ever want to fetch conversations we'll have thi.

Additionally, I added a pattern of _first_ getting your credentials from Gravity for the request. This is what we'll use in the mutation.

Still to do: some tests!