### PR TITLE
@mzikherman => add associated sale to sale index schema

### DIFF
--- a/schema/sale/index.js
+++ b/schema/sale/index.js
@@ -90,6 +90,12 @@ const SaleType = new GraphQLObjectType({
             .then(exclude(options.exclude, 'id'));
         },
       },
+      associated_sale: {
+        type: SaleType,
+        resolve: ({ associated_sale }) => {
+          return gravity(`sale/${associated_sale.id}`);
+        },
+      },
       auction_state: {
         type: GraphQLString,
         resolve: ({ auction_state }) => auction_state,


### PR DESCRIPTION
Working on implementing the "Related Sale" component on the new auction page, and realized that we weren't returning the `associated_sale` from metaphysics.

This PR adds that. Unfortunately, since the `associated_sale` returns `reference_properties: :short` from gravity, we need to make an extra request so we can get all of the params we need (like `start_at`, `end_at`, etc.).