### PR TITLE
@xtina-starr => Be able to retrieve a users collector profile

### DIFF
--- a/schema/me/collector_profile.js
+++ b/schema/me/collector_profile.js
@@ -1,0 +1,40 @@
+import date from '../fields/date';
+import gravity from '../../lib/loaders/gravity';
+import { IDFields } from '../object_identification';
+import {
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLInt,
+} from 'graphql';
+
+export const CollectorProfileType = new GraphQLObjectType({
+  name: 'CollectorProfileType',
+  fields: {
+    ...IDFields,
+    email: {
+      type: GraphQLString,
+    },
+    name: {
+      type: GraphQLString,
+    },
+    confirmed_buyer_at: date,
+    collector_level: {
+      type: GraphQLInt,
+    },
+    self_reported_purchases: {
+      type: GraphQLString,
+    },
+    loyalty_applicant_at: date,
+    professional_buyer_at: date,
+    professional_buyer_applied_at: date,
+  },
+});
+
+export default {
+  type: CollectorProfileType,
+  decription: 'A collector profile.',
+  resolve: (root, option, request, { rootValue: { accessToken } }) => {
+    if (!accessToken) return null;
+    return gravity.with(accessToken)('me/collector_profile');
+  },
+};

--- a/schema/me/index.js
+++ b/schema/me/index.js
@@ -10,6 +10,7 @@ import SuggestedArtists from './suggested_artists';
 import FollowArtists from './follow_artists';
 import Notifications from './notifications';
 import Conversations from './conversations';
+import CollectorProfile from './collector_profile';
 import ArtworkInquiries from './artwork_inquiries';
 import { IDFields } from '../object_identification';
 import {
@@ -25,6 +26,7 @@ const Me = new GraphQLObjectType({
     bidders: Bidders,
     bidder_status: BidderStatus,
     bidder_positions: BidderPositions,
+    collector_profile: CollectorProfile,
     conversations: Conversations,
     created_at: date,
     email: {

--- a/test/schema/me/collector_profile.js
+++ b/test/schema/me/collector_profile.js
@@ -1,0 +1,62 @@
+describe('Me', () => {
+  describe('CollectorProfile', () => {
+    const gravity = sinon.stub();
+    const Me = schema.__get__('Me');
+    const CollectorProfile = Me.__get__('CollectorProfile');
+
+    beforeEach(() => {
+      gravity.with = sinon.stub().returns(gravity);
+
+      Me.__Rewire__('gravity', gravity);
+      CollectorProfile.__Rewire__('gravity', gravity);
+
+      gravity
+        // Me fetch
+        .onCall(0)
+        .returns(Promise.resolve({}));
+    });
+
+    afterEach(() => {
+      Me.__ResetDependency__('gravity');
+      CollectorProfile.__ResetDependency__('gravity');
+    });
+
+    it('returns the collector profile', () => {
+      const query = `
+        {
+          me {
+            collector_profile {
+              id
+              name
+              email
+              self_reported_purchases
+            }
+          }
+        }
+      `;
+
+      const collectorProfile = {
+        id: '3',
+        name: 'Percy',
+        email: 'percy@cat.com',
+        self_reported_purchases: 'treats',
+      };
+
+      const expectedProfileData = {
+        id: '3',
+        name: 'Percy',
+        email: 'percy@cat.com',
+        self_reported_purchases: 'treats',
+      };
+
+      gravity
+        .onCall(1)
+        .returns(Promise.resolve(collectorProfile));
+
+      return runAuthenticatedQuery(query)
+      .then(({ me: { collector_profile } }) => {
+        expect(collector_profile).toEqual(expectedProfileData);
+      });
+    });
+  });
+});


### PR DESCRIPTION
We'll be storing some information on `CollectorProfile`, namely, when the user has applied for the loyalty program.

So we need a way to retrieve it (and can redirect to the appropriate page in the loyalty app on a subsequent visit).

We'll also need a way to mark that they applied (when they hit the 'Submit' button), which we can do with a mutation (forthcoming PR).