### PR TITLE
@joeyAghion => Mutate collector profile

### DIFF
--- a/schema/index.js
+++ b/schema/index.js
@@ -29,6 +29,7 @@ import Show from './show';
 import TrendingArtists from './trending';
 import Me from './me';
 import UpdateConversation from './me/update_conversation';
+import UpdateCollectorProfile from './me/update_collector_profile';
 import CausalityJWT from './causality_jwt';
 import Viewer from './viewer';
 import ObjectIdentification from './object_identification';
@@ -41,6 +42,7 @@ const schema = new GraphQLSchema({
   mutation: new GraphQLObjectType({
     name: 'RootMutationType',
     fields: {
+      updateCollectorProfile: UpdateCollectorProfile,
       updateConversation: UpdateConversation,
     },
   }),

--- a/schema/me/update_collector_profile.js
+++ b/schema/me/update_collector_profile.js
@@ -1,0 +1,27 @@
+import gravity from '../../lib/loaders/gravity';
+import { CollectorProfileType } from './collector_profile';
+import {
+  GraphQLBoolean,
+} from 'graphql';
+
+export default {
+  type: CollectorProfileType,
+  decription: 'Updating a collector profile (loyalty applicant status).',
+  args: {
+    loyalty_applicant: {
+      type: GraphQLBoolean,
+    },
+    professional_buyer: {
+      type: GraphQLBoolean,
+    },
+  },
+  resolve: (root, {
+    loyalty_applicant,
+    professional_buyer,
+  }, request, { rootValue: { accessToken } }) => {
+    if (!accessToken) return null;
+    return gravity.with(accessToken, {
+      method: 'POST',
+    })('me/collector_profile', { loyalty_applicant, professional_buyer });
+  },
+};

--- a/schema/me/update_collector_profile.js
+++ b/schema/me/update_collector_profile.js
@@ -21,7 +21,7 @@ export default {
   }, request, { rootValue: { accessToken } }) => {
     if (!accessToken) return null;
     return gravity.with(accessToken, {
-      method: 'POST',
+      method: 'PUT',
     })('me/collector_profile', { loyalty_applicant, professional_buyer });
   },
 };

--- a/test/schema/me/update_collector_profile.js
+++ b/test/schema/me/update_collector_profile.js
@@ -1,0 +1,50 @@
+describe('UpdateCollectorProfile', () => {
+  const gravity = sinon.stub();
+  const UpdateCollectorProfile = schema.__get__('UpdateCollectorProfile');
+
+  beforeEach(() => {
+    gravity.with = sinon.stub().returns(gravity);
+
+    UpdateCollectorProfile.__Rewire__('gravity', gravity);
+  });
+
+  afterEach(() => {
+    UpdateCollectorProfile.__ResetDependency__('gravity');
+  });
+
+  it('updates and returns a collector profile', () => {
+    const mutation = `
+      mutation {
+        updateCollectorProfile(professional_buyer: true, loyalty_applicant: true) {
+          id
+          name
+          email
+          self_reported_purchases
+        }
+      }
+    `;
+
+    const collectorProfile = {
+      id: '3',
+      name: 'Percy',
+      email: 'percy@cat.com',
+      self_reported_purchases: 'treats',
+    };
+
+    const expectedProfileData = {
+      id: '3',
+      name: 'Percy',
+      email: 'percy@cat.com',
+      self_reported_purchases: 'treats',
+    };
+
+    gravity
+      .onCall(0)
+      .returns(Promise.resolve(collectorProfile));
+
+    return runAuthenticatedQuery(mutation)
+    .then(({ updateCollectorProfile }) => {
+      expect(updateCollectorProfile).toEqual(expectedProfileData);
+    });
+  });
+});


### PR DESCRIPTION
Builds upon https://github.com/artsy/metaphysics/pull/586

This lets you set the `loyalty_applicant` setting (and I threw in the `professional_buyer` as an example).

<img width="961" alt="screen shot 2017-03-30 at 4 41 27 pm" src="https://cloud.githubusercontent.com/assets/1457859/24525459/5c9b7d06-1568-11e7-9c80-afc237d10ed1.png">
