### PR TITLE
@kanaabe => adds a few more fields to the article schema

### DIFF
--- a/schema/article.js
+++ b/schema/article.js
@@ -6,6 +6,8 @@ import Image from './image';
 import date from './fields/date';
 import { IDFields, NodeInterface } from './object_identification';
 import {
+  GraphQLInt,
+  GraphQLList,
   GraphQLString,
   GraphQLObjectType,
   GraphQLNonNull,
@@ -21,6 +23,13 @@ const ArticleType = new GraphQLObjectType({
     author: {
       type: AuthorType,
       resolve: ({ author }) => author,
+    },
+    channel_id: {
+      type: GraphQLString,
+    },
+    contributing_authors: {
+      type: new GraphQLList(AuthorType),
+      resolve: ({ contributing_authors }) => contributing_authors,
     },
     href: {
       type: GraphQLString,
@@ -39,6 +48,9 @@ const ArticleType = new GraphQLObjectType({
     thumbnail_image: {
       type: Image.type,
       resolve: ({ thumbnail_image }) => Image.resolve(thumbnail_image),
+    },
+    tier: {
+      type: GraphQLInt,
     },
     title: {
       type: GraphQLString,

--- a/test/schema/article.js
+++ b/test/schema/article.js
@@ -1,0 +1,62 @@
+describe('Article type', () => {
+  const Article = schema.__get__('Article');
+  let positron = null;
+
+  beforeEach(() => {
+    positron = sinon.stub();
+
+    positron.returns(Promise.resolve({
+      id: 'foo-bar',
+      slug: 'foo-bar',
+      title: 'My Awesome Article',
+      thumbnail_title: 'Tiny Thumbnail',
+      thumbnail_image: {
+        url: 'tiny_thumbnail.jpg',
+      },
+      published_at: '2017-01-26T00:26:57.928Z',
+      channel_id: 'abc123',
+      author: {
+        id: 'author1',
+        name: 'First Author',
+      },
+      contributing_authors: [
+        {
+          id: 'contrib-1',
+          name: 'Contributing Author 1',
+        },
+        {
+          id: 'contrib-2',
+          name: 'Contributing Author 2',
+        },
+      ],
+    }));
+
+    Article.__Rewire__('positron', positron);
+  });
+
+  afterEach(() => {
+    Article.__ResetDependency__('positron');
+  });
+
+  it('fetches an article by ID', () => {
+    return runQuery('{ article(id: "foo-bar") { id, title } }')
+      .then(data => {
+        expect(data.article.id).toBe('foo-bar');
+        expect(data.article.title).toBe('My Awesome Article');
+      });
+  });
+
+  it('returns an array of contributing authors', () => {
+    return runQuery('{ article(id: "foo-bar") { id, title, contributing_authors{ id, name } } }')
+      .then(data => {
+        expect(data.article.id).toBe('foo-bar');
+        expect(data.article.title).toBe('My Awesome Article');
+        expect(data.article.contributing_authors).toEqual(
+          [
+            { id: 'contrib-1', name: 'Contributing Author 1' },
+            { id: 'contrib-2', name: 'Contributing Author 2' },
+          ]
+        );
+      });
+  });
+});


### PR DESCRIPTION
Eventual goal is to render this widget in force (the `/article-figure` mixin) using data from metaphysics. I think this should do it!

![image](https://cloud.githubusercontent.com/assets/2081340/24558532/76b3c4a4-1609-11e7-98d2-485b973ab986.png)
