### PR TITLE
@l2succes => Save self_reported_purchaes as well as loyalty applicant status

### DIFF
--- a/schema/me/update_collector_profile.js
+++ b/schema/me/update_collector_profile.js
@@ -2,6 +2,7 @@ import gravity from '../../lib/loaders/gravity';
 import { CollectorProfileType } from './collector_profile';
 import {
   GraphQLBoolean,
+  GraphQLString,
 } from 'graphql';
 
 export default {
@@ -14,14 +15,18 @@ export default {
     professional_buyer: {
       type: GraphQLBoolean,
     },
+    self_reported_purchases: {
+      type: GraphQLString,
+    },
   },
   resolve: (root, {
     loyalty_applicant,
     professional_buyer,
+    self_reported_purchases,
   }, request, { rootValue: { accessToken } }) => {
     if (!accessToken) return null;
     return gravity.with(accessToken, {
       method: 'PUT',
-    })('me/collector_profile', { loyalty_applicant, professional_buyer });
+    })('me/collector_profile', { loyalty_applicant, professional_buyer, self_reported_purchases });
   },
 };

--- a/test/schema/me/update_collector_profile.js
+++ b/test/schema/me/update_collector_profile.js
@@ -13,9 +13,10 @@ describe('UpdateCollectorProfile', () => {
   });
 
   it('updates and returns a collector profile', () => {
+    /* eslint-disable max-len */
     const mutation = `
       mutation {
-        updateCollectorProfile(professional_buyer: true, loyalty_applicant: true) {
+        updateCollectorProfile(professional_buyer: true, loyalty_applicant: true, self_reported_purchases: "trust me i buy art") {
           id
           name
           email
@@ -23,6 +24,7 @@ describe('UpdateCollectorProfile', () => {
         }
       }
     `;
+    /* eslint-enable max-len */
 
     const collectorProfile = {
       id: '3',


### PR DESCRIPTION
![screen shot 2017-04-03 at 2 27 23 pm](https://cloud.githubusercontent.com/assets/1457859/24624403/c2533152-1879-11e7-8139-421d0898f5f7.png)

This allows the mutation to not only mark their loyalty applicant status, but also passes thru their `self_reported_purchases`

