### PR TITLE
@ashkan18 => Use enums to update buyer outcome

### DIFF
--- a/schema/me/conversations.js
+++ b/schema/me/conversations.js
@@ -8,8 +8,36 @@ import {
   GraphQLInt,
   GraphQLBoolean,
   GraphQLNonNull,
+  GraphQLEnumType,
 } from 'graphql';
 const { IMPULSE_APPLICATION_ID } = process.env;
+
+export const BuyerOutcomeTypes = new GraphQLEnumType({
+  name: 'BuyerOutcomeTypes',
+  values: {
+    PURCHASED: {
+      value: 'purchased',
+    },
+    STILL_CONSIDERING: {
+      value: 'still_considering',
+    },
+    HIGH_PRICE: {
+      value: 'high_price',
+    },
+    LOST_INTEREST: {
+      value: 'lost_interest',
+    },
+    WORK_UNAVAILABLE: {
+      value: 'work_unavailable',
+    },
+    OTHER: {
+      value: 'other',
+    },
+    BLANK: {
+      value: '',
+    },
+  },
+});
 
 export const ConversationType = new GraphQLObjectType({
   name: 'ConversationType',

--- a/schema/me/update_conversation.js
+++ b/schema/me/update_conversation.js
@@ -1,6 +1,6 @@
 import impulse from '../../lib/loaders/impulse';
 import gravity from '../../lib/loaders/gravity';
-import { ConversationType } from './conversations';
+import { ConversationType, BuyerOutcomeTypes } from './conversations';
 import {
   GraphQLString,
   GraphQLNonNull,
@@ -12,7 +12,7 @@ export default {
   decription: 'Updating buyer outcome of a conversation.',
   args: {
     buyer_outcome: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNull(BuyerOutcomeTypes),
     },
     id: {
       type: new GraphQLNonNull(GraphQLString),

--- a/test/schema/me/update_conversation.js
+++ b/test/schema/me/update_conversation.js
@@ -19,7 +19,7 @@ describe('UpdateConversation', () => {
   it('updates and returns a conversation', () => {
     const mutation = `
       mutation {
-        updateConversation(id: "3", buyer_outcome: "too expensive") {
+        updateConversation(id: "3", buyer_outcome: HIGH_PRICE) {
           id
           initial_message
           from_email


### PR DESCRIPTION
went with `BLANK` for the 'unsetting' mode

![bp](https://cloud.githubusercontent.com/assets/1457859/24627696/d128cd0e-1883-11e7-9f9e-d412041b5448.gif)

(We typically use enums in GraphQL for this kind of field/update).