### PR TITLE
@cab => Bring collector profile mutation up to Relay spec

### DIFF
--- a/schema/me/collector_profile.js
+++ b/schema/me/collector_profile.js
@@ -7,27 +7,29 @@ import {
   GraphQLInt,
 } from 'graphql';
 
+export const CollectorProfileFields = {
+  ...IDFields,
+  email: {
+    type: GraphQLString,
+  },
+  name: {
+    type: GraphQLString,
+  },
+  confirmed_buyer_at: date,
+  collector_level: {
+    type: GraphQLInt,
+  },
+  self_reported_purchases: {
+    type: GraphQLString,
+  },
+  loyalty_applicant_at: date,
+  professional_buyer_at: date,
+  professional_buyer_applied_at: date,
+};
+
 export const CollectorProfileType = new GraphQLObjectType({
   name: 'CollectorProfileType',
-  fields: {
-    ...IDFields,
-    email: {
-      type: GraphQLString,
-    },
-    name: {
-      type: GraphQLString,
-    },
-    confirmed_buyer_at: date,
-    collector_level: {
-      type: GraphQLInt,
-    },
-    self_reported_purchases: {
-      type: GraphQLString,
-    },
-    loyalty_applicant_at: date,
-    professional_buyer_at: date,
-    professional_buyer_applied_at: date,
-  },
+  fields: CollectorProfileFields,
 });
 
 export default {

--- a/schema/me/update_collector_profile.js
+++ b/schema/me/update_collector_profile.js
@@ -6,9 +6,7 @@ import {
 } from 'graphql';
 import { mutationWithClientMutationId } from 'graphql-relay';
 
-let UpdateCollectorProfile;
-
-UpdateCollectorProfile = mutationWithClientMutationId({
+export default mutationWithClientMutationId({
   name: 'UpdateCollectorProfile',
   decription: 'Updating a collector profile (loyalty applicant status).',
   inputFields: {
@@ -34,5 +32,3 @@ UpdateCollectorProfile = mutationWithClientMutationId({
     })('me/collector_profile', { loyalty_applicant, professional_buyer, self_reported_purchases });
   },
 });
-
-export default UpdateCollectorProfile;

--- a/schema/me/update_collector_profile.js
+++ b/schema/me/update_collector_profile.js
@@ -1,14 +1,17 @@
 import gravity from '../../lib/loaders/gravity';
-import { CollectorProfileType } from './collector_profile';
+import { CollectorProfileFields } from './collector_profile';
 import {
   GraphQLBoolean,
   GraphQLString,
 } from 'graphql';
+import { mutationWithClientMutationId } from 'graphql-relay';
 
-export default {
-  type: CollectorProfileType,
+let UpdateCollectorProfile;
+
+UpdateCollectorProfile = mutationWithClientMutationId({
+  name: 'UpdateCollectorProfile',
   decription: 'Updating a collector profile (loyalty applicant status).',
-  args: {
+  inputFields: {
     loyalty_applicant: {
       type: GraphQLBoolean,
     },
@@ -19,7 +22,8 @@ export default {
       type: GraphQLString,
     },
   },
-  resolve: (root, {
+  outputFields: CollectorProfileFields,
+  mutateAndGetPayload: ({
     loyalty_applicant,
     professional_buyer,
     self_reported_purchases,
@@ -29,4 +33,6 @@ export default {
       method: 'PUT',
     })('me/collector_profile', { loyalty_applicant, professional_buyer, self_reported_purchases });
   },
-};
+});
+
+export default UpdateCollectorProfile;

--- a/test/schema/me/update_collector_profile.js
+++ b/test/schema/me/update_collector_profile.js
@@ -16,7 +16,7 @@ describe('UpdateCollectorProfile', () => {
     /* eslint-disable max-len */
     const mutation = `
       mutation {
-        updateCollectorProfile(professional_buyer: true, loyalty_applicant: true, self_reported_purchases: "trust me i buy art") {
+        updateCollectorProfile(input: { professional_buyer: true, loyalty_applicant: true, self_reported_purchases: "trust me i buy art" }) {
           id
           name
           email


### PR DESCRIPTION
So I goofed and didn't realize there was a precise Relay spec for mutations.

I just added sort of arbitrary mutations for conversations and collector profiles, expecting to be able to use them. But after having some difficulty with Relay yesterday I realized I didn't have the proper single `input` parameter format (and potentially other things).

Hoping this is closer/matches the Relay spec.

<img width="963" alt="screen shot 2017-04-06 at 1 07 36 pm" src="https://cloud.githubusercontent.com/assets/1457859/24766732/6513b374-1aca-11e7-8807-981e7e8c765a.png">
