### PR TITLE
@alloy => Bulk update conversations w/ buyer outcome

### DIFF
--- a/test/schema/me/update_conversation.js
+++ b/test/schema/me/update_conversation.js
@@ -19,10 +19,12 @@ describe('UpdateConversation', () => {
   it('updates and returns a conversation', () => {
     const mutation = `
       mutation {
-        updateConversation(input: { id: "3", buyer_outcome: HIGH_PRICE }) {
-          id
-          initial_message
-          from_email
+        updateConversation(input: { ids: ["3"], buyer_outcome: HIGH_PRICE }) {
+          conversations {
+            id
+            initial_message
+            from_email
+          }
         }
       }
     `;
@@ -34,9 +36,11 @@ describe('UpdateConversation', () => {
     };
 
     const expectedConversationData = {
-      id: '3',
-      initial_message: 'omg im sooo interested',
-      from_email: 'percy@cat.com',
+      conversations: [{
+        id: '3',
+        initial_message: 'omg im sooo interested',
+        from_email: 'percy@cat.com',
+      }],
     };
 
     gravity


### PR DESCRIPTION
We're adjusting our mutation to instead take an array of id's, and set the buyer outcome on those.

This means that we now return an array of conversations, rather than just a single conversation.

~~I've tried various combinations of that in `outputFields`, all to no avail.~~

Since the Relay spec requires an object to be returned, we return a single `conversations` object which is a list of all the modified conversations.