### PR TITLE
Adds ID fields to Buyers Premium

### DIFF
--- a/schema/sale/index.js
+++ b/schema/sale/index.js
@@ -39,6 +39,7 @@ const BidIncrement = new GraphQLObjectType({
 const BuyersPremium = new GraphQLObjectType({
   name: 'BuyersPremium',
   fields: {
+    ...GravityIDFields,
     amount: amount(({ cents }) => cents),
     cents: {
       type: GraphQLInt,


### PR DESCRIPTION
It's a bit weird, but eigen needs the ID field for parsing our model objects from JSON. Made this change in the browser editor because metaphysics isn't set up locally on this machine, 🤞 for CI. 