### PR TITLE
@alloy: Check to if fair organizer profile is published

### DIFF
--- a/schema/fair.js
+++ b/schema/fair.js
@@ -20,6 +20,9 @@ const FairOrganizerType = new GraphQLObjectType({
     profile_id: {
       type: GraphQLID,
     },
+    profile: {
+      type: Profile.type,
+    },
   },
 });
 
@@ -94,14 +97,6 @@ const FairType = new GraphQLObjectType({
     end_at: date,
     organizer: {
       type: FairOrganizerType,
-    },
-    has_published_organizer_profile: {
-      type: new GraphQLNonNull(GraphQLBoolean),
-      resolve: ({ organizer }) => {
-        const id = organizer && organizer.profile_id;
-        if (id === null) return false;
-        return gravity(`profile/${id}`).then(profile => profile && profile.published && !profile.private);
-      },
     },
     published: {
       type: GraphQLBoolean,

--- a/schema/fair.js
+++ b/schema/fair.js
@@ -22,6 +22,9 @@ const FairOrganizerType = new GraphQLObjectType({
     },
     profile: {
       type: Profile.type,
+      resolve: ({ profile_id }) => {
+        return gravity(`profile/${profile_id}`).catch(() => null);
+      },
     },
   },
 });

--- a/schema/fair.js
+++ b/schema/fair.js
@@ -96,14 +96,11 @@ const FairType = new GraphQLObjectType({
       type: FairOrganizerType,
     },
     has_published_organizer_profile: {
-      type: GraphQLBoolean,
+      type: new GraphQLNonNull(GraphQLBoolean),
       resolve: ({ organizer }) => {
         const id = organizer && organizer.profile_id;
         if (id === null) return false;
-        return gravity(`profile/${id}`)
-        .then(profile => {
-          return profile && profile.published;
-        });
+        return gravity(`profile/${id}`).then(profile => profile && profile.published && !profile.private);
       },
     },
     published: {

--- a/schema/fair.js
+++ b/schema/fair.js
@@ -95,6 +95,17 @@ const FairType = new GraphQLObjectType({
     organizer: {
       type: FairOrganizerType,
     },
+    has_published_organizer_profile: {
+      type: GraphQLBoolean,
+      resolve: ({ organizer }) => {
+        const id = organizer && organizer.profile_id;
+        if (id === null) return false;
+        return gravity(`profile/${id}`)
+        .then(profile => {
+          return profile && profile.published;
+        });
+      },
+    },
     published: {
       type: GraphQLBoolean,
       deprecationReason: 'Prefix Boolean returning fields with `is_`',

--- a/schema/profile.js
+++ b/schema/profile.js
@@ -49,6 +49,10 @@ const ProfileType = new GraphQLObjectType({
       type: GraphQLString,
       resolve: ({ owner }) => owner.name,
     },
+    is_publically_visible: {
+      type: GraphQLBoolean,
+      resolve: (profile) => profile && profile.published && !profile.private,
+    },
   }),
 });
 

--- a/test/schema/fair.js
+++ b/test/schema/fair.js
@@ -1,0 +1,120 @@
+
+describe('Fair type', () => {
+  const Fair = schema.__get__('Fair');
+  let gravity = null;
+  let fairData = null;
+
+  beforeEach(() => {
+    gravity = sinon.stub();
+
+    fairData = {
+      id: 'the-armory-show-2017',
+      name: 'The Armory Show 2017',
+      organizer: {
+        profile_id: 'the-armory-show',
+      },
+    };
+
+    gravity.returns(Promise.resolve(fairData));
+
+    Fair.__Rewire__('gravity', gravity);
+  });
+
+  afterEach(() => {
+    Fair.__ResetDependency__('gravity');
+  });
+
+  const query = `
+    {
+      fair(id: "the-armory-show-2017") {
+        id
+        name
+        organizer {
+          profile_id
+        }
+        has_published_organizer_profile
+      }
+    }
+  `;
+
+  it('has_published_fair_organize returns true when profile is published', () => {
+    const profileData = {
+      id: 'the-armory-show',
+      published: true,
+      private: false,
+    };
+
+    gravity
+      .onCall(1)
+      .returns(Promise.resolve(profileData));
+
+    return runQuery(query)
+      .then(data => {
+        expect(Fair.__get__('gravity').args[1][0])
+          .toBe('profile/the-armory-show');
+
+        expect(data).toEqual({
+          fair: {
+            id: 'the-armory-show-2017',
+            name: 'The Armory Show 2017',
+            organizer: { profile_id: 'the-armory-show' },
+            has_published_organizer_profile: true,
+          },
+        });
+      });
+  });
+
+  it('has_published_fair_organize returns false when profile is not published', () => {
+    const profileData = {
+      id: 'the-armory-show',
+      published: false,
+      private: false,
+    };
+
+    gravity
+      .onCall(1)
+      .returns(Promise.resolve(profileData));
+
+    return runQuery(query)
+      .then(data => {
+        expect(Fair.__get__('gravity').args[1][0])
+          .toBe('profile/the-armory-show');
+
+        expect(data).toEqual({
+          fair: {
+            id: 'the-armory-show-2017',
+            name: 'The Armory Show 2017',
+            organizer: { profile_id: 'the-armory-show' },
+            has_published_organizer_profile: false,
+          },
+        });
+      });
+  });
+
+  it('has_published_fair_organize returns false when profile is private', () => {
+    const profileData = {
+      id: 'the-armory-show',
+      published: true,
+      private: true,
+    };
+
+    gravity
+      .onCall(1)
+      .returns(Promise.resolve(profileData));
+
+    return runQuery(query)
+      .then(data => {
+        expect(Fair.__get__('gravity').args[1][0])
+          .toBe('profile/the-armory-show');
+
+        expect(data).toEqual({
+          fair: {
+            id: 'the-armory-show-2017',
+            name: 'The Armory Show 2017',
+            organizer: { profile_id: 'the-armory-show' },
+            has_published_organizer_profile: false,
+          },
+        });
+      });
+  });
+});

--- a/test/schema/fair.js
+++ b/test/schema/fair.js
@@ -11,10 +11,6 @@ describe('Fair type', () => {
       name: 'The Armory Show 2017',
       organizer: {
         profile_id: 'the-armory-show',
-        profile: {
-          published: true,
-          private: false,
-        },
       },
     };
 
@@ -43,6 +39,16 @@ describe('Fair type', () => {
   `;
 
   it('is_publically_visible returns true when profile is published', () => {
+    const profileData = {
+      id: 'the-armory-show',
+      published: true,
+      private: false,
+    };
+
+    gravity
+      .onCall(1)
+      .returns(Promise.resolve(profileData));
+
     return runQuery(query)
       .then(data => {
         expect(data).toEqual({
@@ -59,53 +65,18 @@ describe('Fair type', () => {
         });
       });
   });
-});
-
-describe('Fair unpublished organizer profile', () => {
-  const Fair = schema.__get__('Fair');
-  let gravity = null;
-  let fairData = null;
-
-  beforeEach(() => {
-    gravity = sinon.stub();
-
-    fairData = {
-      id: 'the-armory-show-2017',
-      name: 'The Armory Show 2017',
-      organizer: {
-        profile_id: 'the-armory-show',
-        profile: {
-          published: false,
-          private: false,
-        },
-      },
-    };
-
-    gravity.returns(Promise.resolve(fairData));
-
-    Fair.__Rewire__('gravity', gravity);
-  });
-
-  afterEach(() => {
-    Fair.__ResetDependency__('gravity');
-  });
-
-  const query = `
-    {
-      fair(id: "the-armory-show-2017") {
-        id
-        name
-        organizer {
-          profile_id
-          profile {
-            is_publically_visible
-          }
-        }
-      }
-    }
-  `;
 
   it('is_publically_visible returns false when profile is not published', () => {
+    const unpublishedProfileData = {
+      id: 'context',
+      published: false,
+      private: false,
+    };
+
+    gravity
+      .onCall(1)
+      .returns(Promise.resolve(unpublishedProfileData));
+
     return runQuery(query)
       .then(data => {
         expect(data).toEqual({
@@ -122,53 +93,18 @@ describe('Fair unpublished organizer profile', () => {
         });
       });
   });
-});
 
-describe('Fair private organizer profile', () => {
-  const Fair = schema.__get__('Fair');
-  let gravity = null;
-  let fairData = null;
-
-  beforeEach(() => {
-    gravity = sinon.stub();
-
-    fairData = {
-      id: 'the-armory-show-2017',
-      name: 'The Armory Show 2017',
-      organizer: {
-        profile_id: 'the-armory-show',
-        profile: {
-          published: true,
-          private: true,
-        },
-      },
+  it('is_publically_visible returns false when profile is not published', () => {
+    const privateProfileData = {
+      id: 'context',
+      published: false,
+      private: false,
     };
 
-    gravity.returns(Promise.resolve(fairData));
+    gravity
+      .onCall(1)
+      .returns(Promise.resolve(privateProfileData));
 
-    Fair.__Rewire__('gravity', gravity);
-  });
-
-  afterEach(() => {
-    Fair.__ResetDependency__('gravity');
-  });
-
-  const query = `
-    {
-      fair(id: "the-armory-show-2017") {
-        id
-        name
-        organizer {
-          profile_id
-          profile {
-            is_publically_visible
-          }
-        }
-      }
-    }
-  `;
-
-  it('is_publically_visible returns false when profile is private', () => {
     return runQuery(query)
       .then(data => {
         expect(data).toEqual({

--- a/test/schema/fair.js
+++ b/test/schema/fair.js
@@ -1,4 +1,3 @@
-
 describe('Fair type', () => {
   const Fair = schema.__get__('Fair');
   let gravity = null;
@@ -12,6 +11,10 @@ describe('Fair type', () => {
       name: 'The Armory Show 2017',
       organizer: {
         profile_id: 'the-armory-show',
+        profile: {
+          published: true,
+          private: false,
+        },
       },
     };
 
@@ -31,88 +34,153 @@ describe('Fair type', () => {
         name
         organizer {
           profile_id
+          profile {
+            is_publically_visible
+          }
         }
-        has_published_organizer_profile
       }
     }
   `;
 
-  it('has_published_fair_organize returns true when profile is published', () => {
-    const profileData = {
-      id: 'the-armory-show',
-      published: true,
-      private: false,
-    };
-
-    gravity
-      .onCall(1)
-      .returns(Promise.resolve(profileData));
-
+  it('is_publically_visible returns true when profile is published', () => {
     return runQuery(query)
       .then(data => {
-        expect(Fair.__get__('gravity').args[1][0])
-          .toBe('profile/the-armory-show');
-
         expect(data).toEqual({
           fair: {
             id: 'the-armory-show-2017',
             name: 'The Armory Show 2017',
-            organizer: { profile_id: 'the-armory-show' },
-            has_published_organizer_profile: true,
+            organizer: {
+              profile_id: 'the-armory-show',
+              profile: {
+                is_publically_visible: true,
+              },
+            },
           },
         });
       });
   });
+});
 
-  it('has_published_fair_organize returns false when profile is not published', () => {
-    const profileData = {
-      id: 'the-armory-show',
-      published: false,
-      private: false,
+describe('Fair unpublished organizer profile', () => {
+  const Fair = schema.__get__('Fair');
+  let gravity = null;
+  let fairData = null;
+
+  beforeEach(() => {
+    gravity = sinon.stub();
+
+    fairData = {
+      id: 'the-armory-show-2017',
+      name: 'The Armory Show 2017',
+      organizer: {
+        profile_id: 'the-armory-show',
+        profile: {
+          published: false,
+          private: false,
+        },
+      },
     };
 
-    gravity
-      .onCall(1)
-      .returns(Promise.resolve(profileData));
+    gravity.returns(Promise.resolve(fairData));
 
+    Fair.__Rewire__('gravity', gravity);
+  });
+
+  afterEach(() => {
+    Fair.__ResetDependency__('gravity');
+  });
+
+  const query = `
+    {
+      fair(id: "the-armory-show-2017") {
+        id
+        name
+        organizer {
+          profile_id
+          profile {
+            is_publically_visible
+          }
+        }
+      }
+    }
+  `;
+
+  it('is_publically_visible returns false when profile is not published', () => {
     return runQuery(query)
       .then(data => {
-        expect(Fair.__get__('gravity').args[1][0])
-          .toBe('profile/the-armory-show');
-
         expect(data).toEqual({
           fair: {
             id: 'the-armory-show-2017',
             name: 'The Armory Show 2017',
-            organizer: { profile_id: 'the-armory-show' },
-            has_published_organizer_profile: false,
+            organizer: {
+              profile_id: 'the-armory-show',
+              profile: {
+                is_publically_visible: false,
+              },
+            },
           },
         });
       });
   });
+});
 
-  it('has_published_fair_organize returns false when profile is private', () => {
-    const profileData = {
-      id: 'the-armory-show',
-      published: true,
-      private: true,
+describe('Fair private organizer profile', () => {
+  const Fair = schema.__get__('Fair');
+  let gravity = null;
+  let fairData = null;
+
+  beforeEach(() => {
+    gravity = sinon.stub();
+
+    fairData = {
+      id: 'the-armory-show-2017',
+      name: 'The Armory Show 2017',
+      organizer: {
+        profile_id: 'the-armory-show',
+        profile: {
+          published: true,
+          private: true,
+        },
+      },
     };
 
-    gravity
-      .onCall(1)
-      .returns(Promise.resolve(profileData));
+    gravity.returns(Promise.resolve(fairData));
 
+    Fair.__Rewire__('gravity', gravity);
+  });
+
+  afterEach(() => {
+    Fair.__ResetDependency__('gravity');
+  });
+
+  const query = `
+    {
+      fair(id: "the-armory-show-2017") {
+        id
+        name
+        organizer {
+          profile_id
+          profile {
+            is_publically_visible
+          }
+        }
+      }
+    }
+  `;
+
+  it('is_publically_visible returns false when profile is private', () => {
     return runQuery(query)
       .then(data => {
-        expect(Fair.__get__('gravity').args[1][0])
-          .toBe('profile/the-armory-show');
-
         expect(data).toEqual({
           fair: {
             id: 'the-armory-show-2017',
             name: 'The Armory Show 2017',
-            organizer: { profile_id: 'the-armory-show' },
-            has_published_organizer_profile: false,
+            organizer: {
+              profile_id: 'the-armory-show',
+              profile: {
+                is_publically_visible: false,
+              },
+            },
           },
         });
       });

--- a/test/schema/profile.js
+++ b/test/schema/profile.js
@@ -1,0 +1,89 @@
+describe('Profile type', () => {
+  const Profile = schema.__get__('Profile');
+  let gravity = null;
+  let profileData = null;
+
+  beforeEach(() => {
+    gravity = sinon.stub();
+
+    profileData = {
+      id: 'the-armory-show',
+      published: true,
+      private: false,
+    };
+
+    gravity.returns(Promise.resolve(profileData));
+
+    Profile.__Rewire__('gravity', gravity);
+  });
+
+  afterEach(() => {
+    Profile.__ResetDependency__('gravity');
+  });
+
+  const query = `
+    {
+      profile(id: "the-armory-show") {
+        id
+        is_publically_visible
+      }
+    }
+  `;
+
+  it('is_publically_visible returns true when profile is published', () => {
+    return runQuery(query)
+      .then(data => {
+        expect(data).toEqual({
+          profile: {
+            id: 'the-armory-show',
+            is_publically_visible: true,
+          },
+        });
+      });
+  });
+});
+
+describe('Profile type', () => {
+  const Profile = schema.__get__('Profile');
+  let gravity = null;
+  let profileData = null;
+
+  beforeEach(() => {
+    gravity = sinon.stub();
+
+    profileData = {
+      id: 'the-armory-show',
+      published: true,
+      private: true,
+    };
+
+    gravity.returns(Promise.resolve(profileData));
+
+    Profile.__Rewire__('gravity', gravity);
+  });
+
+  afterEach(() => {
+    Profile.__ResetDependency__('gravity');
+  });
+
+  const query = `
+    {
+      profile(id: "the-armory-show") {
+        id
+        is_publically_visible
+      }
+    }
+  `;
+
+  it('is_publically_visible returns false when profile is private', () => {
+    return runQuery(query)
+      .then(data => {
+        expect(data).toEqual({
+          profile: {
+            id: 'the-armory-show',
+            is_publically_visible: false,
+          },
+        });
+      });
+  });
+});


### PR DESCRIPTION
Related to https://github.com/artsy/collector-experience/issues/132 where year-round links on the `/fairs` page are 404ing. This is because the [check in force](https://github.com/artsy/force/blob/master/desktop/apps/fairs/templates/fair_upcoming.jade#L2-L3) that creates the link needs an additional check to determine if the fair organizer profile is published. This PR adds a `has_published_organizer_profile` flag to the fair object. 