### PR TITLE
Fix is_buy_nowable logic

### DIFF
--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -268,7 +268,7 @@ export const artworkFields = () => {
             .then(([sale, saleArtwork]) => {
               if (!sale) return false
 
-              return saleArtwork.bidder_positions_count < 1
+              return !saleArtwork.sold
             })
         }
         return false


### PR DESCRIPTION
Fixes https://github.com/artsy/auctions/issues/405. 

This PR fixes our `is_buy_nowable` logic by enabling until the artwork reserve is met. 