### PR TITLE
@joeyAghion => Fixes is_buy_nowable logic

### DIFF
--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -251,25 +251,16 @@ export const artworkFields = () => {
     },
     is_buy_nowable: {
       type: GraphQLBoolean,
-      description: "When in an auction, can the work be bought before any bids are placed",
+      description: "When in an auction, can the work be bought immediately",
       resolve: ({ id, acquireable, sale_ids }, options, request, { rootValue: { salesLoader } }) => {
         if (sale_ids && sale_ids.length > 0 && acquireable) {
           return salesLoader(id, {
             id: sale_ids,
             is_auction: true,
-            auction_state: "open",
+            live: true,
+          }).then(sales => {
+            return sales.length > 0
           })
-            .then(_.first)
-            .then(sale => {
-              if (!sale) return [false]
-
-              return gravity(`sale/${sale.id}/sale_artwork/${id}`).then(saleArtwork => [sale, saleArtwork])
-            })
-            .then(([sale, saleArtwork]) => {
-              if (!sale) return false
-
-              return saleArtwork.bidder_positions_count < 1
-            })
         }
         return false
       },

--- a/test/schema/artwork/index.js
+++ b/test/schema/artwork/index.js
@@ -440,7 +440,7 @@ describe("Artwork type", () => {
         }
       }
     `
-    it("is true if the artwork is acquireable and in an open auction with no bids", () => {
+    it("is true if the artwork is acquireable and in an open auction", () => {
       artwork.acquireable = true
       rootValue.salesLoader = sinon.stub().returns(
         Promise.resolve([
@@ -449,18 +449,45 @@ describe("Artwork type", () => {
           },
         ])
       )
-      gravity // Sale Artwork
-        .onCall(0)
-        .returns(
-          Promise.resolve({
-            bidder_positions_count: 0,
-          })
-        )
       return runQuery(query, rootValue).then(data => {
         expect(data).toEqual({
           artwork: {
             id: "richard-prince-untitled-portrait",
             is_buy_nowable: true,
+          },
+        })
+      })
+    })
+
+    it("is false if the artwork is not acquireable", () => {
+      artwork.acquireable = false
+      rootValue.salesLoader = sinon.stub().returns(
+        Promise.resolve([
+          {
+            id: "sale-id",
+          },
+        ])
+      )
+      return runQuery(query, rootValue).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            id: "richard-prince-untitled-portrait",
+            is_buy_nowable: false,
+          },
+        })
+      })
+    })
+
+    it("is false if the artwork is acquireable but not in any open sales", () => {
+      artwork.acquireable = false
+      rootValue.salesLoader = sinon.stub().returns(
+        Promise.resolve([])
+      )
+      return runQuery(query, rootValue).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            id: "richard-prince-untitled-portrait",
+            is_buy_nowable: false,
           },
         })
       })


### PR DESCRIPTION
This PR updates the logic for `is_buy_nowable` (which was wrong for various reasons explained below). 

The updated logic is that an artwork is `is_buy_nowable` if: it is in an auction that is `live` (meaning "open"), and if the artwork is `acquireable`.