### PR TITLE
@alloy: Skip related artist rail if Gravity returns an empty array for related artists

### DIFF
--- a/schema/home/home_page_artwork_modules.js
+++ b/schema/home/home_page_artwork_modules.js
@@ -131,7 +131,7 @@ const HomePageArtworkModules = {
               // relatedArtist now returns 2 random artist pairs
               // we will use one for the related_artist rail and one for
               // the followed_artist rail
-              if (artistPairs) {
+              if (artistPairs && artistPairs.length) {
                 const { artist, sim_artist } = artistPairs[0]
 
                 const relatedArtistModuleParams = {

--- a/test/schema/home/home_page_artwork_modules.js
+++ b/test/schema/home/home_page_artwork_modules.js
@@ -142,6 +142,37 @@ describe("HomePageArtworkModules", () => {
       })
     })
 
+    it("skips the followed_artist module if the pairs are empty", () => {
+      relatedArtists.onCall(0).returns(Promise.resolve([]))
+
+      const query = `
+        {
+          home_page {
+            artwork_modules {
+              key
+              params {
+                related_artist_id
+                followed_artist_id
+              }
+            }
+          }
+        }
+      `
+
+      return runAuthenticatedQuery(query).then(({ home_page }) => {
+        const keys = map(home_page.artwork_modules, "key")
+        expect(keys).toEqual([
+          "followed_galleries",
+          "saved_works",
+          "recommended_works",
+          "current_fairs",
+          "generic_gene",
+          "generic_gene",
+          "generic_gene",
+        ])
+      })
+    })
+
     it("takes a preferred order of modules", () => {
       const query = `
         {


### PR DESCRIPTION
See [this Slack thread](https://artsy.slack.com/archives/C02CAB1KW/p1493786263193179) for details. Basically Eigen's homepage is stuck because MP choked on an empty array returned from /api/v1/user/:id/suggested/similar/artists

This fixes that, but maybe I'm not seeing the forest from the trees and this should be fixed further down in Gravity or up in Emission.