### PR TITLE
[Tests] Removes the global functions for schema and runQuery

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,8 +27,6 @@
   ],
   "globals": {
     "expect": false,
-    "runQuery": false,
-    "runAuthenticatedQuery": false,
     "schema": false,
     "sinon": false,
     "expectPromiseRejectionToMatch": false

--- a/package.json
+++ b/package.json
@@ -94,14 +94,14 @@
     "testPathIgnorePatterns": [
       "/node_modules/",
       "/test/helper.js",
+      "/test/utils.js",
       "/test/__mocks__"
     ]
   },
   "lint-staged": {
     "*.js": [
       "prettier --write --trailing-comma es5 --print-width 120 --no-semi",
-      "git add",
-      "jest --bail --findRelatedTests"
+      "git add"
     ]
   }
 }

--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -346,7 +346,7 @@ const ArtistType = new GraphQLObjectType({
       },
       formatted_nationality_and_birthday: {
         type: GraphQLString,
-        description: "A string of the form \"Nationality, Birthday (or Birthday-Deathday)\"",
+        description: `A string of the form "Nationality, Birthday (or Birthday-Deathday)"`,
         resolve: ({ birthday, nationality, deathday }) => {
           let formatted_bday = !isNaN(birthday) && birthday ? "b. " + birthday : birthday
           formatted_bday = formatted_bday && formatted_bday.replace(/born/i, "b.")

--- a/schema/sale_artwork.js
+++ b/schema/sale_artwork.js
@@ -73,7 +73,7 @@ const SaleArtworkType = new GraphQLObjectType({
       },
       currency: {
         type: GraphQLString,
-        description: "Currency abbreviation (e.g. \"USD\")",
+        description: `Currency abbreviation (e.g. "USD")`,
       },
       current_bid: money({
         name: "SaleArtworkCurrentBid",
@@ -231,7 +231,7 @@ const SaleArtworkType = new GraphQLObjectType({
       },
       symbol: {
         type: GraphQLString,
-        description: "Currency symbol (e.g. \"$\")",
+        description: `Currency symbol (e.g. "$")`,
       },
     }
   },

--- a/test/helper.js
+++ b/test/helper.js
@@ -2,58 +2,24 @@
 import dotenv from "dotenv"
 dotenv.config({ path: ".env.test" })
 
-import schema from "../schema"
-import sinon from "sinon"
-
-import { graphql } from "graphql"
 // Set up our globals
-global.schema = schema
+import sinon from "sinon"
 global.sinon = sinon
-
-/**
- * Performs a GraphQL query against our schema.
- *
- * On success, the promise resolves with the `data` part of the resonse.
- *
- * On error, the promise will reject with the original error that was thrown.
- *
- * @param {String} query      The GraphQL query to run.
- * @param {Object} rootValue  The request params, which currently are `accessToken` and `userID`.
- * @returns {Promise}
- *
- * @todo This assumes there will always be just 1 error, not sure how to handle this differently.
- */
-global.runQuery = (query, rootValue = { accessToken: null, userID: null }) => {
-  return graphql(schema, query, rootValue, {}).then(result => {
-    if (result.errors) {
-      const error = result.errors[0]
-      throw error.originalError || error
-    } else {
-      return Promise.resolve(result.data)
-    }
-  })
-}
-
-/**
- * Same as `runQuery` except it provides a `rootValue` that’s required for authenticated queries.
- *
- * @see runQuery
- */
-global.runAuthenticatedQuery = query => {
-  return runQuery(query, { accessToken: "secret", userID: "user-42" })
-}
 
 /**
  * Ensuring that promises fail is actually a little bit tricky,
  * see https://github.com/facebook/jest/issues/2129
  *
- * So until this is built into Jest, then this will do for now 👍
- */
-global.expectPromiseRejectionToMatch = (promise, failureMessage) => {
+ * So until this is built into Jest, then this will do for now 👍 */ global.expectPromiseRejectionToMatch = (
+  promise,
+  failureMessage
+) => {
   return new Promise((resolve, reject) => {
     promise
       .then(() => {
-        const object = { message: "Expected this promise to fail" }
+        const object = {
+          message: "Expected this promise to fail",
+        }
         reject(object)
       })
       .catch(e => {
@@ -61,8 +27,5 @@ global.expectPromiseRejectionToMatch = (promise, failureMessage) => {
         resolve({})
       })
   })
-}
-
-// // We want to silence the console output from node-uuid, so we use a mocked module
-// // at __mocks__/node-uuid.js which has it's console muted
+} // We want to silence the console output from node-uuid, so we use a mocked module // // at __mocks__/node-uuid.js which has it's console muted
 jest.mock("node-uuid")

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,4 +1,5 @@
 // Do not require the use of node-foreman during testing
+
 import dotenv from "dotenv"
 dotenv.config({ path: ".env.test" })
 
@@ -6,14 +7,16 @@ dotenv.config({ path: ".env.test" })
 import sinon from "sinon"
 global.sinon = sinon
 
+// prettier-ignore
+
 /**
  * Ensuring that promises fail is actually a little bit tricky,
  * see https://github.com/facebook/jest/issues/2129
  *
- * So until this is built into Jest, then this will do for now 👍 */ global.expectPromiseRejectionToMatch = (
-  promise,
-  failureMessage
-) => {
+ * So until this is built into Jest, then this will do for now
+*/
+
+const expectPromiseRejectionToMatch = (promise, failureMessage) => {
   return new Promise((resolve, reject) => {
     promise
       .then(() => {
@@ -27,5 +30,12 @@ global.sinon = sinon
         resolve({})
       })
   })
-} // We want to silence the console output from node-uuid, so we use a mocked module // // at __mocks__/node-uuid.js which has it's console muted
+}
+
+global.expectPromiseRejectionToMatch = expectPromiseRejectionToMatch
+
+/**
+ * We want to silence the console output from node-uuid, so we use a mocked module
+ *  at __mocks__/node-uuid.js which has it's console muted
+ * */
 jest.mock("node-uuid")

--- a/test/schema/article.js
+++ b/test/schema/article.js
@@ -1,3 +1,6 @@
+import schema from "../../schema"
+import { runQuery } from "../utils"
+
 describe("Article type", () => {
   const Article = schema.__get__("Article")
   let positron = null
@@ -48,7 +51,7 @@ describe("Article type", () => {
   })
 
   it("returns an array of contributing authors", () => {
-    return runQuery("{ article(id: \"foo-bar\") { id, title, contributing_authors{ id, name } } }").then(data => {
+    return runQuery(`{ article(id: "foo-bar") { id, title, contributing_authors{ id, name } } }`).then(data => {
       expect(data.article.id).toBe("foo-bar")
       expect(data.article.title).toBe("My Awesome Article")
       expect(data.article.contributing_authors).toEqual([

--- a/test/schema/artist/carousel.js
+++ b/test/schema/artist/carousel.js
@@ -1,3 +1,5 @@
+import { runQuery } from "../../utils"
+
 describe("ArtistCarousel type", () => {
   let artist = null
   let rootValue = null

--- a/test/schema/artist/index.js
+++ b/test/schema/artist/index.js
@@ -1,3 +1,6 @@
+import schema from "../../../schema"
+import { runQuery } from "../../utils"
+
 describe("Artist type", () => {
   const Artist = schema.__get__("Artist")
   let artist = null

--- a/test/schema/artist/statuses.js
+++ b/test/schema/artist/statuses.js
@@ -1,3 +1,5 @@
+import { runQuery } from "../../utils"
+
 describe("Artist Statuses", () => {
   let artist = null
   let rootValue = null

--- a/test/schema/artwork/index.js
+++ b/test/schema/artwork/index.js
@@ -1,6 +1,9 @@
 import { assign } from "lodash"
 import moment from "moment"
 
+import schema from "../../../schema"
+import { runQuery } from "../../utils"
+
 describe("Artwork type", () => {
   let gravity
   const Artwork = schema.__get__("Artwork")
@@ -458,7 +461,6 @@ describe("Artwork type", () => {
         })
       })
     })
-
     it("is false if the artwork is not acquireable", () => {
       artwork.acquireable = false
       rootValue.salesLoader = sinon.stub().returns(
@@ -477,7 +479,6 @@ describe("Artwork type", () => {
         })
       })
     })
-
     it("is false if the artwork is acquireable but not in any open sales", () => {
       artwork.acquireable = false
       rootValue.salesLoader = sinon.stub().returns(Promise.resolve([]))

--- a/test/schema/causality_jwt.js
+++ b/test/schema/causality_jwt.js
@@ -1,6 +1,9 @@
 import jwt from "jwt-simple"
 import { omit } from "lodash"
 
+import schema from "../../schema"
+import { runQuery, runAuthenticatedQuery } from "../utils"
+
 const { HMAC_SECRET } = process.env
 
 describe("CausalityJWT", () => {

--- a/test/schema/collection.js
+++ b/test/schema/collection.js
@@ -1,6 +1,9 @@
 import { resolve } from "path"
 import { readFileSync } from "fs"
 
+import schema from "../../schema"
+import { runQuery } from "../utils"
+
 const gravityData = {
   id: "saved-artwork",
   name: "Saved Artwork",

--- a/test/schema/fair.js
+++ b/test/schema/fair.js
@@ -1,3 +1,6 @@
+import schema from "../../schema"
+import { runQuery } from "../utils"
+
 describe("Fair type", () => {
   const Fair = schema.__get__("Fair")
   let gravity = null

--- a/test/schema/filter_artworks.js
+++ b/test/schema/filter_artworks.js
@@ -1,3 +1,6 @@
+import schema from "../../schema"
+import { runQuery } from "../utils"
+
 describe("Filter Artworks", () => {
   describe(`Does not pass along the medium param if it is "*"`, () => {
     const Gene = schema.__get__("Gene")

--- a/test/schema/filter_sale_artworks.js
+++ b/test/schema/filter_sale_artworks.js
@@ -1,3 +1,6 @@
+import schema from "../../schema"
+import { runQuery } from "../utils"
+
 describe("Filter Sale Artworks", () => {
   const FilterSaleArtworks = schema.__get__("FilterSaleArtworks")
 

--- a/test/schema/gene/gene.js
+++ b/test/schema/gene/gene.js
@@ -1,3 +1,6 @@
+import schema from "../../../schema"
+import { runQuery } from "../../utils"
+
 describe("Gene", () => {
   describe("For just querying the gene artworks", () => {
     const Gene = schema.__get__("Gene")

--- a/test/schema/home/home_page_artist_module.js
+++ b/test/schema/home/home_page_artist_module.js
@@ -1,5 +1,8 @@
 import { graphql } from "graphql"
 
+import schema from "../../../schema"
+import { runQuery, runAuthenticatedQuery } from "../../utils"
+
 describe("HomePageArtistModule", () => {
   const HomePage = schema.__get__("HomePage")
   const HomePageArtistModule = HomePage.__get__("HomePageArtistModule")

--- a/test/schema/home/home_page_artist_modules.js
+++ b/test/schema/home/home_page_artist_modules.js
@@ -1,5 +1,8 @@
 import { map } from "lodash"
 
+import schema from "../../../schema"
+import { runQuery, runAuthenticatedQuery } from "../../utils"
+
 describe("HomePageArtistModules", () => {
   describe("concerning display", () => {
     const query = `

--- a/test/schema/home/home_page_artwork_module.js
+++ b/test/schema/home/home_page_artwork_module.js
@@ -1,3 +1,6 @@
+import schema from "../../../schema"
+import { runQuery } from "../../utils"
+
 describe("HomePageArtworkModule", () => {
   const HomePage = schema.__get__("HomePage")
   const HomePageArtworkModule = HomePage.__get__("HomePageArtworkModule")

--- a/test/schema/home/home_page_artwork_modules.js
+++ b/test/schema/home/home_page_artwork_modules.js
@@ -1,5 +1,8 @@
 import { map, find } from "lodash"
 
+import schema from "../../../schema"
+import { runAuthenticatedQuery } from "../../utils"
+
 describe("HomePageArtworkModules", () => {
   describe("when signed in", () => {
     const HomePage = schema.__get__("HomePage")
@@ -171,7 +174,6 @@ describe("HomePageArtworkModules", () => {
       })
     })
   })
-
   describe("when signed-out", () => {
     // nothing for now
   })

--- a/test/schema/home/home_page_hero_units.js
+++ b/test/schema/home/home_page_hero_units.js
@@ -1,3 +1,6 @@
+import schema from "../../../schema"
+import { runQuery } from "../../utils"
+
 describe("HomePageHeroUnits", () => {
   const HomePage = schema.__get__("HomePage")
   const HomePageHeroUnits = HomePage.__get__("HomePageHeroUnits")

--- a/test/schema/image/index.js
+++ b/test/schema/image/index.js
@@ -1,6 +1,8 @@
 import { assign } from "lodash"
 import { getDefault } from "../../../schema/image"
 
+import { runQuery } from "../../utils"
+
 describe("getDefault", () => {
   it("returns the default image", () => {
     expect(

--- a/test/schema/me/artwork_inquiries.js
+++ b/test/schema/me/artwork_inquiries.js
@@ -1,3 +1,6 @@
+import schema from "../../../schema"
+import { runAuthenticatedQuery } from "../../utils"
+
 describe("Me", () => {
   describe("ArtworkInquiries", () => {
     const gravity = sinon.stub()

--- a/test/schema/me/bidder_positions.js
+++ b/test/schema/me/bidder_positions.js
@@ -1,5 +1,8 @@
 import { map, times } from "lodash"
 
+import schema from "../../../schema"
+import { runAuthenticatedQuery } from "../../utils"
+
 describe("Me type", () => {
   const Me = schema.__get__("Me")
   const BidderPositions = Me.__get__("BidderPositions")

--- a/test/schema/me/bidder_status.js
+++ b/test/schema/me/bidder_status.js
@@ -1,3 +1,6 @@
+import schema from "../../../schema"
+import { runAuthenticatedQuery } from "../../utils"
+
 describe("BidderStatus type", () => {
   const Me = schema.__get__("Me")
   const BidderStatus = Me.__get__("BidderStatus")

--- a/test/schema/me/bidders.js
+++ b/test/schema/me/bidders.js
@@ -1,3 +1,6 @@
+import schema from "../../../schema"
+import { runAuthenticatedQuery } from "../../utils"
+
 describe("Me", () => {
   describe("Bidders", () => {
     let gravity

--- a/test/schema/me/collector_profile.js
+++ b/test/schema/me/collector_profile.js
@@ -1,3 +1,6 @@
+import schema from "../../../schema"
+import { runAuthenticatedQuery } from "../../utils"
+
 describe("Me", () => {
   describe("CollectorProfile", () => {
     const gravity = sinon.stub()

--- a/test/schema/me/conversations.js
+++ b/test/schema/me/conversations.js
@@ -1,3 +1,6 @@
+import schema from "../../../schema"
+import { runAuthenticatedQuery } from "../../utils"
+
 describe("Me", () => {
   describe("Conversations", () => {
     const gravity = sinon.stub()

--- a/test/schema/me/lot_standing.js
+++ b/test/schema/me/lot_standing.js
@@ -1,3 +1,6 @@
+import schema from "../../../schema"
+import { runAuthenticatedQuery } from "../../utils"
+
 describe("LotStanding type", () => {
   const Me = schema.__get__("Me")
   const LotStanding = Me.__get__("LotStanding")

--- a/test/schema/me/notifications.js
+++ b/test/schema/me/notifications.js
@@ -1,5 +1,8 @@
 import { assign } from "lodash"
 
+import schema from "../../../schema"
+import { runAuthenticatedQuery } from "../../utils"
+
 describe("Me", () => {
   describe("Notifications", () => {
     const gravity = sinon.stub()

--- a/test/schema/me/sale_registrations.js
+++ b/test/schema/me/sale_registrations.js
@@ -1,3 +1,6 @@
+import schema from "../../../schema"
+import { runAuthenticatedQuery } from "../../utils"
+
 describe("Me", () => {
   describe("SaleRegistrations", () => {
     const gravity = sinon.stub()

--- a/test/schema/me/save_artwork.js
+++ b/test/schema/me/save_artwork.js
@@ -1,3 +1,6 @@
+import schema from "../../../schema"
+import { runAuthenticatedQuery } from "../../utils"
+
 describe("SaveArtwork", () => {
   const gravity = sinon.stub()
   const SaveArtwork = schema.__get__("SaveArtwork")

--- a/test/schema/me/update_collector_profile.js
+++ b/test/schema/me/update_collector_profile.js
@@ -1,3 +1,6 @@
+import schema from "../../../schema"
+import { runAuthenticatedQuery } from "../../utils"
+
 describe("UpdateCollectorProfile", () => {
   const gravity = sinon.stub()
   const UpdateCollectorProfile = schema.__get__("UpdateCollectorProfile")

--- a/test/schema/me/update_conversation.js
+++ b/test/schema/me/update_conversation.js
@@ -1,3 +1,6 @@
+import schema from "../../../schema"
+import { runAuthenticatedQuery } from "../../utils"
+
 describe("UpdateConversation", () => {
   const gravity = sinon.stub()
   const impulse = sinon.stub()

--- a/test/schema/object_identification.js
+++ b/test/schema/object_identification.js
@@ -1,6 +1,9 @@
 import _ from "lodash"
 import { toGlobalId } from "graphql-relay"
 
+import schema from "../../schema"
+import { runQuery, runAuthenticatedQuery } from "../utils"
+
 describe("Object Identification", () => {
   // TODO As we add more loaders, remove the old tests at the bottom of this file and add them here.
   const loaderTests = {
@@ -85,27 +88,25 @@ describe("Object Identification", () => {
     PartnerShow: {
       gravity: {
         displayable: true, // this is only so that the show doesn’t get rejected
-        partner: { id: "for-baz" },
+        partner: {
+          id: "for-baz",
+        },
         display_on_partner_profile: true,
       },
     },
   }
-
   _.keys(tests).forEach(typeName => {
     describe(`for a ${typeName}`, () => {
       const fieldName = _.snakeCase(typeName)
       const type = schema.__get__(typeName)
       const api = _.keys(tests[typeName])[0]
       const payload = tests[typeName][api]
-
       beforeEach(() => {
         type.__Rewire__(api, sinon.stub().returns(Promise.resolve(_.assign({ id: "foo-bar" }, payload))))
       })
-
       afterEach(() => {
         type.__ResetDependency__(api)
       })
-
       it("generates a Global ID", () => {
         const query = `
           {
@@ -114,14 +115,14 @@ describe("Object Identification", () => {
             }
           }
         `
-
         return runQuery(query).then(data => {
           const expectedData = {}
-          expectedData[fieldName] = { __id: toGlobalId(typeName, "foo-bar") }
+          expectedData[fieldName] = {
+            __id: toGlobalId(typeName, "foo-bar"),
+          }
           expect(data).toEqual(expectedData)
         })
       })
-
       it("resolves a node", () => {
         const query = `
           {
@@ -133,7 +134,6 @@ describe("Object Identification", () => {
             }
           }
         `
-
         return runQuery(query).then(data => {
           expect(data).toEqual({
             node: {
@@ -145,10 +145,8 @@ describe("Object Identification", () => {
       })
     })
   })
-
   describe("for the Me field", () => {
     const globalId = toGlobalId("Me", "user-42")
-
     it("generates a Global ID", () => {
       const query = `
         {
@@ -157,7 +155,6 @@ describe("Object Identification", () => {
           }
         }
       `
-
       return runAuthenticatedQuery(query).then(data => {
         expect(data).toEqual({
           me: {
@@ -166,7 +163,6 @@ describe("Object Identification", () => {
         })
       })
     })
-
     it("resolves a node", () => {
       const query = `
         {
@@ -178,7 +174,6 @@ describe("Object Identification", () => {
           }
         }
       `
-
       return runAuthenticatedQuery(query).then(data => {
         expect(data).toEqual({
           node: {
@@ -189,11 +184,9 @@ describe("Object Identification", () => {
       })
     })
   })
-
   describe("for a HomePageArtworkModule", () => {
     describe("with a specific module", () => {
       const globalId = toGlobalId("HomePageArtworkModule", JSON.stringify({ key: "popular_artists" }))
-
       it("generates a Global ID", () => {
         const query = `
           {
@@ -204,7 +197,6 @@ describe("Object Identification", () => {
             }
           }
         `
-
         return runQuery(query).then(data => {
           expect(data).toEqual({
             home_page: {
@@ -215,7 +207,6 @@ describe("Object Identification", () => {
           })
         })
       })
-
       it("resolves a node", () => {
         const query = `
           {
@@ -227,7 +218,6 @@ describe("Object Identification", () => {
             }
           }
         `
-
         return runQuery(query).then(data => {
           expect(data).toEqual({
             node: {
@@ -238,10 +228,8 @@ describe("Object Identification", () => {
         })
       })
     })
-
     describe("with a generic gene", () => {
       const globalId = toGlobalId("HomePageArtworkModule", JSON.stringify({ id: "abstract-art", key: "generic_gene" }))
-
       it("generates a Global ID", () => {
         const query = `
           {
@@ -252,7 +240,6 @@ describe("Object Identification", () => {
             }
           }
         `
-
         return runQuery(query).then(data => {
           expect(data).toEqual({
             home_page: {
@@ -263,7 +250,6 @@ describe("Object Identification", () => {
           })
         })
       })
-
       it("resolves a node", () => {
         const query = `
           {
@@ -278,7 +264,6 @@ describe("Object Identification", () => {
             }
           }
         `
-
         return runQuery(query).then(data => {
           expect(data).toEqual({
             node: {
@@ -292,7 +277,6 @@ describe("Object Identification", () => {
         })
       })
     })
-
     describe("with a related artist", () => {
       const globalId = toGlobalId(
         "HomePageArtworkModule",
@@ -302,7 +286,6 @@ describe("Object Identification", () => {
           key: "related_artists",
         })
       )
-
       it("generates a Global ID", () => {
         const query = `
           {
@@ -315,7 +298,6 @@ describe("Object Identification", () => {
             }
           }
         `
-
         return runQuery(query).then(data => {
           expect(data).toEqual({
             home_page: {
@@ -326,7 +308,6 @@ describe("Object Identification", () => {
           })
         })
       })
-
       it("resolves a node", () => {
         const query = `
           {
@@ -342,7 +323,6 @@ describe("Object Identification", () => {
             }
           }
         `
-
         return runQuery(query).then(data => {
           expect(data).toEqual({
             node: {
@@ -358,10 +338,8 @@ describe("Object Identification", () => {
       })
     })
   })
-
   describe("for a HomePageArtistModule", () => {
     const globalId = toGlobalId("HomePageArtistModule", JSON.stringify({ key: "TRENDING" }))
-
     it("generates a Global ID", () => {
       const query = `
         {
@@ -372,7 +350,6 @@ describe("Object Identification", () => {
           }
         }
       `
-
       return runQuery(query).then(data => {
         expect(data).toEqual({
           home_page: {
@@ -383,7 +360,6 @@ describe("Object Identification", () => {
         })
       })
     })
-
     it("resolves a node", () => {
       const query = `
         {
@@ -395,7 +371,6 @@ describe("Object Identification", () => {
           }
         }
       `
-
       return runQuery(query).then(data => {
         expect(data).toEqual({
           node: {
@@ -405,14 +380,9 @@ describe("Object Identification", () => {
         })
       })
     })
-  })
-
-  // These test that the proper AST is passed on by testing that the `Me` type doesn’t make any
-  // gravity calls (as the `Me` type’s `resolve` function is optimised to not make a request when
-  // only the `id` field is requested).
+  }) // These test that the proper AST is passed on by testing that the `Me` type doesn’t make any // gravity calls (as the `Me` type’s `resolve` function is optimised to not make a request when // only the `id` field is requested).
   describe("concerning passing the proper AST to resolvers", () => {
     const globalId = toGlobalId("Me", "user-42")
-
     it("should pass the proper inline fragment AST", () => {
       const query = `
         {
@@ -423,7 +393,6 @@ describe("Object Identification", () => {
           }
         }
       `
-
       return runAuthenticatedQuery(query).then(data => {
         expect(data).toEqual({
           node: {
@@ -432,7 +401,6 @@ describe("Object Identification", () => {
         })
       })
     })
-
     it("should pass the proper spread fragment AST", () => {
       const query = `
         {
@@ -444,7 +412,6 @@ describe("Object Identification", () => {
           id
         }
       `
-
       return runAuthenticatedQuery(query).then(data => {
         expect(data).toEqual({
           node: {

--- a/test/schema/object_identification.js
+++ b/test/schema/object_identification.js
@@ -380,7 +380,12 @@ describe("Object Identification", () => {
         })
       })
     })
-  }) // These test that the proper AST is passed on by testing that the `Me` type doesn’t make any // gravity calls (as the `Me` type’s `resolve` function is optimised to not make a request when // only the `id` field is requested).
+  }) /*
+  * These test that the proper AST is passed on by testing that the `Me` type
+  * doesn’t make any gravity calls (as the `Me` type’s `resolve` function is
+  * optimised to not make a request when
+  * only the `id` field is requested).
+  */
   describe("concerning passing the proper AST to resolvers", () => {
     const globalId = toGlobalId("Me", "user-42")
     it("should pass the proper inline fragment AST", () => {

--- a/test/schema/ordered_sets.js
+++ b/test/schema/ordered_sets.js
@@ -1,3 +1,6 @@
+import schema from "../../schema"
+import { runQuery } from "../utils"
+
 describe("OrderedSets type", () => {
   const OrderedSets = schema.__get__("OrderedSets")
 

--- a/test/schema/partner_show.js
+++ b/test/schema/partner_show.js
@@ -1,5 +1,8 @@
 import moment from "moment"
 
+import schema from "../../schema"
+import { runQuery } from "../utils"
+
 describe("PartnerShow type", () => {
   const PartnerShow = schema.__get__("PartnerShow")
   let total = null
@@ -74,10 +77,8 @@ describe("PartnerShow type", () => {
       })
     })
   })
-
   it("includes an update on upcoming status changes", () => {
     showData.end_at = moment().add(1, "d")
-
     const query = `
       {
         partner_show(id: "new-museum-1-2015-triennial-surround-audience") {
@@ -85,7 +86,6 @@ describe("PartnerShow type", () => {
         }
       }
     `
-
     return runQuery(query).then(data => {
       expect(data).toEqual({
         partner_show: {
@@ -94,7 +94,6 @@ describe("PartnerShow type", () => {
       })
     })
   })
-
   it("includes the html version of markdown", () => {
     const query = `
       {
@@ -103,10 +102,8 @@ describe("PartnerShow type", () => {
         }
       }
     `
-
     return runQuery(query).then(data => {
       expect(PartnerShow.__get__("gravity").args[0][0]).toBe("show/new-museum-1-2015-triennial-surround-audience")
-
       expect(data).toEqual({
         partner_show: {
           press_release: "<p><strong>foo</strong> <em>bar</em></p>\n",
@@ -114,10 +111,8 @@ describe("PartnerShow type", () => {
       })
     })
   })
-
   it("includes the total number of artworks", () => {
     total.onCall(0).returns(Promise.resolve(42))
-
     const query = `
       {
         partner_show(id: "new-museum-1-2015-triennial-surround-audience") {
@@ -127,7 +122,6 @@ describe("PartnerShow type", () => {
         }
       }
     `
-
     return runQuery(query).then(data => {
       expect(data).toEqual({
         partner_show: {
@@ -138,7 +132,6 @@ describe("PartnerShow type", () => {
       })
     })
   })
-
   it("includes the total number of eligible artworks", () => {
     const query = `
       {
@@ -149,7 +142,6 @@ describe("PartnerShow type", () => {
         }
       }
     `
-
     return runQuery(query).then(data => {
       expect(data).toEqual({
         partner_show: {
@@ -160,10 +152,8 @@ describe("PartnerShow type", () => {
       })
     })
   })
-
   it("includes the number of artworks by a specific artist", () => {
     total.onCall(0).returns(Promise.resolve(2))
-
     const query = `
       {
         partner_show(id: "new-museum-1-2015-triennial-surround-audience") {
@@ -173,7 +163,6 @@ describe("PartnerShow type", () => {
         }
       }
     `
-
     return runQuery(query).then(data => {
       expect(data).toEqual({
         partner_show: {
@@ -184,10 +173,8 @@ describe("PartnerShow type", () => {
       })
     })
   })
-
   it("does not return errors when there is no cover image", () => {
     gravity.onCall(1).returns(Promise.resolve([]))
-
     const query = `
       {
         partner_show(id: "new-museum-1-2015-triennial-surround-audience") {
@@ -197,7 +184,6 @@ describe("PartnerShow type", () => {
         }
       }
     `
-
     return runQuery(query).then(({ partner_show }) => {
       expect(partner_show).toEqual({
         cover_image: null,

--- a/test/schema/partner_shows.js
+++ b/test/schema/partner_shows.js
@@ -1,3 +1,6 @@
+import schema from "../../schema"
+import { runQuery } from "../utils"
+
 describe("PartnerShows type", () => {
   const PartnerShows = schema.__get__("PartnerShows")
   const PartnerShow = PartnerShows.__get__("PartnerShow")

--- a/test/schema/profile.js
+++ b/test/schema/profile.js
@@ -1,3 +1,6 @@
+import schema from "../../schema"
+import { runQuery } from "../utils"
+
 describe("Profile type", () => {
   const Profile = schema.__get__("Profile")
   let gravity = null

--- a/test/schema/sale/index.js
+++ b/test/schema/sale/index.js
@@ -1,5 +1,8 @@
 import moment from "moment"
 
+import schema from "../../../schema"
+import { runQuery } from "../../utils"
+
 describe("Sale type", () => {
   const Sale = schema.__get__("Sale")
 

--- a/test/schema/sale_artwork.js
+++ b/test/schema/sale_artwork.js
@@ -1,3 +1,6 @@
+import schema from "../../schema"
+import { runQuery } from "../utils"
+
 describe("SaleArtwork type", () => {
   let gravity
   const SaleArtwork = schema.__get__("SaleArtwork")
@@ -30,14 +33,11 @@ describe("SaleArtwork type", () => {
         symbol: "€",
       })
     )
-
     SaleArtwork.__Rewire__("gravity", gravity)
   })
-
   afterEach(() => {
     SaleArtwork.__ResetDependency__("gravity")
   })
-
   it("formats money correctly", () => {
     const query = `
       {
@@ -65,7 +65,6 @@ describe("SaleArtwork type", () => {
         }
       }
     `
-
     return runQuery(query).then(data => {
       expect(SaleArtwork.__get__("gravity").args[0][0]).toBe("sale_artwork/54c7ed2a7261692bfa910200")
       expect(data).toEqual({
@@ -94,7 +93,6 @@ describe("SaleArtwork type", () => {
       })
     })
   })
-
   it("can return the bid increment", () => {
     gravity
       .onCall(1)
@@ -108,7 +106,18 @@ describe("SaleArtwork type", () => {
         Promise.resolve([
           {
             key: "default",
-            increments: [{ from: 0, to: 399999, amount: 5000 }, { from: 400000, to: 1000000, amount: 10000 }],
+            increments: [
+              {
+                from: 0,
+                to: 399999,
+                amount: 5000,
+              },
+              {
+                from: 400000,
+                to: 1000000,
+                amount: 10000,
+              },
+            ],
           },
         ])
       )
@@ -144,16 +153,13 @@ describe("SaleArtwork type", () => {
       ])
     })
   })
-
   describe("with a max amount set", () => {
     beforeEach(() => {
       SaleArtwork.__Rewire__("BIDDER_POSITION_MAX_BID_AMOUNT_CENTS_LIMIT", "400000")
     })
-
     afterEach(() => {
       SaleArtwork.__ResetDependency__("BIDDER_POSITION_MAX_BID_AMOUNT_CENTS_LIMIT")
     })
-
     it("does not return increments above the max allowed", () => {
       gravity
         .onCall(1)
@@ -167,7 +173,18 @@ describe("SaleArtwork type", () => {
           Promise.resolve([
             {
               key: "default",
-              increments: [{ from: 0, to: 399999, amount: 5000 }, { from: 400000, to: 1000000, amount: 10000 }],
+              increments: [
+                {
+                  from: 0,
+                  to: 399999,
+                  amount: 5000,
+                },
+                {
+                  from: 400000,
+                  to: 1000000,
+                  amount: 10000,
+                },
+              ],
             },
           ])
         )

--- a/test/schema/show.js
+++ b/test/schema/show.js
@@ -1,5 +1,8 @@
 import moment from "moment"
 
+import schema from "../../schema"
+import { runQuery } from "../utils"
+
 describe("Show type", () => {
   const Show = schema.__get__("Show")
   const ExternalPartner = schema.__get__("ExternalPartner")
@@ -360,10 +363,8 @@ describe("Show type", () => {
       })
     })
   })
-
   it("includes an update on upcoming status changes", () => {
     showData.end_at = moment().add(1, "d")
-
     const query = `
       {
         show(id: "new-museum-1-2015-triennial-surround-audience") {
@@ -371,7 +372,6 @@ describe("Show type", () => {
         }
       }
     `
-
     return runQuery(query).then(data => {
       expect(data).toEqual({
         show: {
@@ -380,7 +380,6 @@ describe("Show type", () => {
       })
     })
   })
-
   it("includes the html version of markdown", () => {
     const query = `
       {
@@ -389,10 +388,8 @@ describe("Show type", () => {
         }
       }
     `
-
     return runQuery(query).then(data => {
       expect(Show.__get__("gravity").args[0][0]).toBe("show/new-museum-1-2015-triennial-surround-audience")
-
       expect(data).toEqual({
         show: {
           press_release: "<p><strong>foo</strong> <em>bar</em></p>\n",
@@ -400,10 +397,8 @@ describe("Show type", () => {
       })
     })
   })
-
   it("includes the total number of artworks", () => {
     total.onCall(0).returns(Promise.resolve(42))
-
     const query = `
       {
         show(id: "new-museum-1-2015-triennial-surround-audience") {
@@ -413,7 +408,6 @@ describe("Show type", () => {
         }
       }
     `
-
     return runQuery(query).then(data => {
       expect(data).toEqual({
         show: {
@@ -424,7 +418,6 @@ describe("Show type", () => {
       })
     })
   })
-
   it("includes the total number of eligible artworks", () => {
     const query = `
       {
@@ -435,7 +428,6 @@ describe("Show type", () => {
         }
       }
     `
-
     return runQuery(query).then(data => {
       expect(data).toEqual({
         show: {
@@ -446,10 +438,8 @@ describe("Show type", () => {
       })
     })
   })
-
   it("includes the number of artworks by a specific artist", () => {
     total.onCall(0).returns(Promise.resolve(2))
-
     const query = `
       {
         show(id: "new-museum-1-2015-triennial-surround-audience") {
@@ -459,7 +449,6 @@ describe("Show type", () => {
         }
       }
     `
-
     return runQuery(query).then(data => {
       expect(data).toEqual({
         show: {
@@ -470,10 +459,8 @@ describe("Show type", () => {
       })
     })
   })
-
   it("does not return errors when there is no cover image", () => {
     gravity.onCall(1).returns(Promise.resolve([]))
-
     const query = `
       {
         show(id: "new-museum-1-2015-triennial-surround-audience") {
@@ -483,7 +470,6 @@ describe("Show type", () => {
         }
       }
     `
-
     return runQuery(query).then(({ show }) => {
       expect(show).toEqual({
         cover_image: null,

--- a/test/utils.js
+++ b/test/utils.js
@@ -29,9 +29,8 @@ export const runQuery = (query: string, rootValue: ?any = { accessToken: null, u
  * Same as `runQuery` except it provides a `rootValue` that’s required for authenticated queries.
  *
  * @see runQuery
- */ export const runAuthenticatedQuery = (
-  query: string
-) => {
+ */
+export const runAuthenticatedQuery = (query: string) => {
   return runQuery(query, {
     accessToken: "secret",
     userID: "user-42",

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,39 @@
+import schema from "../schema"
+import { graphql } from "graphql"
+
+/**
+ * Performs a GraphQL query against our schema.
+ *
+ * On success, the promise resolves with the `data` part of the resonse.
+ *
+ * On error, the promise will reject with the original error that was thrown.
+ *
+ * @param {String} query      The GraphQL query to run.
+ * @param {Object} rootValue  The request params, which currently are `accessToken` and `userID`.
+ * @returns {Promise}
+ *
+ * @todo This assumes there will always be just 1 error, not sure how to handle this differently.
+ */
+export const runQuery = (query: string, rootValue: ?any = { accessToken: null, userID: null }) => {
+  return graphql(schema, query, rootValue, {}).then(result => {
+    if (result.errors) {
+      const error = result.errors[0]
+      throw error.originalError || error
+    } else {
+      return Promise.resolve(result.data)
+    }
+  })
+}
+
+/**
+ * Same as `runQuery` except it provides a `rootValue` that’s required for authenticated queries.
+ *
+ * @see runQuery
+ */ export const runAuthenticatedQuery = (
+  query: string
+) => {
+  return runQuery(query, {
+    accessToken: "secret",
+    userID: "user-42",
+  })
+}


### PR DESCRIPTION
I was on a long bus, so I took a look at TypeScript support- first by running some regexes and setting it up. Looks pretty feasible. What isn't trivial is getting the tests to work - because they all use babel-rewire, for which there's no TS equivalent. 

So this _starts_ the movement towards removing babel-rewire, by first removing some of the globals inside our tests.