### PR TITLE
[Consignments] Adds support for a saved artists connection

### DIFF
--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -346,7 +346,7 @@ const ArtistType = new GraphQLObjectType({
       },
       formatted_nationality_and_birthday: {
         type: GraphQLString,
-        description: "A string of the form \"Nationality, Birthday (or Birthday-Deathday)\"",
+        description: 'A string of the form "Nationality, Birthday (or Birthday-Deathday)"',
         resolve: ({ birthday, nationality, deathday }) => {
           let formatted_bday = !isNaN(birthday) && birthday ? "b. " + birthday : birthday
           formatted_bday = formatted_bday && formatted_bday.replace(/born/i, "b.")

--- a/schema/me/follow_artists.js
+++ b/schema/me/follow_artists.js
@@ -4,7 +4,7 @@ import { total as getTotal } from "../../lib/loaders/total"
 import Artist from "../artist"
 import { GraphQLInt, GraphQLList, GraphQLObjectType } from "graphql"
 
-const FollowArtists = new GraphQLObjectType({
+const FollowArtistsType = new GraphQLObjectType({
   name: "FollowArtists",
   fields: {
     artists: {
@@ -34,7 +34,7 @@ const FollowArtists = new GraphQLObjectType({
 })
 
 export default {
-  type: FollowArtists,
+  type: FollowArtistsType,
   description: "A list of the current user’s artist follows",
   args: {
     page: {

--- a/schema/me/followed_artists.js
+++ b/schema/me/followed_artists.js
@@ -1,0 +1,44 @@
+import _ from "lodash"
+
+import gravity from "../../lib/loaders/gravity"
+import Artist from "../artist"
+import { IDFields } from "../object_identification"
+
+import { pageable, getPagingParameters } from "relay-cursor-paging"
+import { connectionDefinitions, connectionFromArraySlice } from "graphql-relay"
+import { GraphQLObjectType, GraphQLBoolean } from "graphql"
+
+export const FollowArtistType = new GraphQLObjectType({
+  name: "FollowArtist",
+  fields: {
+    artist: {
+      type: Artist.type,
+    },
+    auto: {
+      type: GraphQLBoolean,
+    },
+    ...IDFields,
+  },
+  isTypeOf: obj => _.has(obj, "artist") && _.has(obj, "auto"),
+})
+
+export default {
+  type: connectionDefinitions({ nodeType: FollowArtistType }).connectionType,
+  args: pageable({}),
+  description: "A list of the current user’s inquiry requests",
+  resolve: (root, options, request, { rootValue: { accessToken } }) => {
+    if (!accessToken) return null
+    const { limit: size, offset } = getPagingParameters(options)
+    const gravityArgs = {
+      size,
+      offset,
+      total_count: true,
+    }
+    return gravity.with(accessToken, { headers: true })("me/follow/artists", gravityArgs).then(({ body, headers }) => {
+      return connectionFromArraySlice(body, options, {
+        arrayLength: headers["x-total-count"],
+        sliceStart: offset,
+      })
+    })
+  },
+}

--- a/schema/me/index.js
+++ b/schema/me/index.js
@@ -62,6 +62,7 @@ export default {
       "id",
       "__id",
       "follow_artists",
+      "followed_artists_connection",
       "suggested_artists",
       "bidders",
       "bidder_positions",

--- a/schema/me/index.js
+++ b/schema/me/index.js
@@ -8,6 +8,7 @@ import LotStandings from "./lot_standings"
 import SaleRegistrations from "./sale_registrations"
 import SuggestedArtists from "./suggested_artists"
 import FollowArtists from "./follow_artists"
+import FollowedArtists from "./followed_artists"
 import Notifications from "./notifications"
 import Conversations from "./conversations"
 import CollectorProfile from "./collector_profile"
@@ -34,6 +35,7 @@ const Me = new GraphQLObjectType({
       type: GraphQLString,
     },
     follow_artists: FollowArtists,
+    followed_artists_connection: FollowedArtists,
     lot_standing: LotStanding,
     lot_standings: LotStandings,
     name: {

--- a/test/fixtures/gravity/follow_artists.json
+++ b/test/fixtures/gravity/follow_artists.json
@@ -1,0 +1,37 @@
+[
+  {
+    "artist": {
+      "_id": "555271f87261694916290200",
+      "id": "bradley-theodore",
+      "sortable_id": "theodore-bradley",
+      "name": "Bradley Theodore",
+      "years": "",
+      "public": true,
+      "birthday": "",
+      "consignable": false,
+      "deathday": "",
+      "nationality": "",
+      "published_artworks_count": 160,
+      "forsale_artworks_count": 86,
+      "artworks_count": 212,
+      "original_width": null,
+      "original_height": null,
+      "image_url": "https://d32dm0rphc51dk.cloudfront.net/OcYkonYKNoEIvg__2jnZCA/:version.jpg",
+      "image_versions": [
+        "four_thirds",
+        "large",
+        "square",
+        "tall"
+      ],
+      "image_urls": {
+        "four_thirds": "https://d32dm0rphc51dk.cloudfront.net/OcYkonYKNoEIvg__2jnZCA/four_thirds.jpg",
+        "large": "https://d32dm0rphc51dk.cloudfront.net/OcYkonYKNoEIvg__2jnZCA/large.jpg",
+        "square": "https://d32dm0rphc51dk.cloudfront.net/OcYkonYKNoEIvg__2jnZCA/square.jpg",
+        "tall": "https://d32dm0rphc51dk.cloudfront.net/OcYkonYKNoEIvg__2jnZCA/tall.jpg"
+      }
+    },
+    "id": "59109d358b3b8114c26e453a",
+    "created_at": "2017-05-08T16:30:45+00:00",
+    "auto": null
+  }
+]

--- a/test/schema/me/__snapshots__/followed_artists.js.snap
+++ b/test/schema/me/__snapshots__/followed_artists.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Collections Handles getting collection metadata returns artworks for a collection 1`] = `
+Object {
+  "me": Object {
+    "followed_artists_connection": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "artist": Object {
+              "id": "bradley-theodore",
+              "name": "Bradley Theodore",
+            },
+          },
+        },
+      ],
+    },
+  },
+}
+`;

--- a/test/schema/me/followed_artists.js
+++ b/test/schema/me/followed_artists.js
@@ -1,0 +1,53 @@
+import { resolve } from "path"
+import { readFileSync } from "fs"
+
+import schema from "../../../schema"
+import { runAuthenticatedQuery } from "../../utils"
+
+describe("Collections", () => {
+  describe("Handles getting collection metadata", () => {
+    const Me = schema.__get__("Me")
+    const FollowedArtists = Me.__get__("FollowedArtists")
+
+    let gravity = null
+    beforeEach(() => {
+      gravity = sinon.stub()
+      gravity.with = sinon.stub().returns(gravity)
+
+      FollowedArtists.__Rewire__("gravity", gravity)
+    })
+
+    afterEach(() => {
+      FollowedArtists.__ResetDependency__("gravity")
+    })
+
+    it("returns artworks for a collection", () => {
+      const artworksPath = resolve("test", "fixtures", "gravity", "follow_artists.json")
+      const artworks = JSON.parse(readFileSync(artworksPath, "utf8"))
+
+      gravity
+        .withArgs("me/follow/artists", { size: 10, offset: 0, total_count: true })
+        .returns(Promise.resolve({ body: artworks, headers: { "x-total-count": 10 } }))
+
+      const query = `
+        {
+          me {
+            followed_artists_connection(first: 10) {
+              edges {
+                node {
+                  artist {
+                    name,
+                    id
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+      return runAuthenticatedQuery(query).then(data => {
+        expect(data).toMatchSnapshot()
+      })
+    })
+  })
+})


### PR DESCRIPTION
![screen shot 2017-05-08 at 17 50 02](https://cloud.githubusercontent.com/assets/49038/25815418/332ca48a-3418-11e7-9e01-fdf471393863.png)

Surprisingly, the data wasn't actually an artist (screenshot below), but a FollowArtist, so I'm not _really_ sure on the naming. My options were:

* `followed_artists_connection`
* `follow_artist_connection`

I felt that the former had a better feel if I was reading the query.

![screen shot 2017-05-08 at 17 45 57](https://cloud.githubusercontent.com/assets/49038/25815447/526eef06-3418-11e7-87ce-ed4a1a6aef73.png)

* WIP cause tests