### PR TITLE
@mzikherman - Add mode and artists connection to Gene schema

### DIFF
--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -1,7 +1,7 @@
 // @flow
 import type { GraphQLFieldConfig } from "graphql"
 import { pageable, getPagingParameters } from "relay-cursor-paging"
-import { connectionFromArraySlice } from "graphql-relay"
+import { connectionFromArraySlice, connectionDefinitions } from "graphql-relay"
 import { assign, compact, defaults, first, has } from "lodash"
 import { exclude } from "../../lib/helpers"
 import cached from "../fields/cached"
@@ -479,3 +479,7 @@ const Artist: GraphQLFieldConfig<ArtistType, *> = {
   },
 }
 export default Artist
+
+export const artistConnection = connectionDefinitions({
+  nodeType: Artist.type,
+}).connectionType

--- a/schema/gene.js
+++ b/schema/gene.js
@@ -6,7 +6,7 @@ import _ from "lodash"
 import gravity from "../lib/loaders/gravity"
 import cached from "./fields/cached"
 import { artworkConnection } from "./artwork"
-import Artist from "./artist"
+import Artist, { artistConnection } from "./artist"
 import Image from "./image"
 import filterArtworks, { filterArtworksArgs } from "./filter_artworks"
 import { queriedForFieldsOtherThanBlacklisted, parseRelayOptions } from "../lib/helpers"
@@ -32,6 +32,23 @@ const GeneType = new GraphQLObjectType({
       resolve: ({ id }) => {
         return gravity(`gene/${id}/artists`, {
           exclude_artists_without_artworks: true,
+        })
+      },
+    },
+    artists_connection: {
+      type: artistConnection,
+      args: pageable(),
+      resolve: ({ id, counts }, options) => {
+        const parsedOptions = _.omit(parseRelayOptions(options), "page")
+        const gravityOptions = _.extend(parsedOptions, {
+          exclude_artists_without_artworks: true,
+        })
+        return gravity(`gene/${id}/artists`, gravityOptions)
+        .then(response => {
+          return connectionFromArraySlice(response, options, {
+            arrayLength: counts.artists,
+            sliceStart: gravityOptions.offset,
+          })
         })
       },
     },

--- a/schema/gene.js
+++ b/schema/gene.js
@@ -66,15 +66,15 @@ const GeneType = new GraphQLObjectType({
       resolve: ({ id }) => `gene/${id}`,
     },
     image: Image,
-    name: {
-      type: GraphQLString,
-    },
     mode: {
       type: GraphQLString,
       resolve: ({ type }) => {
         const isSubjectMatter = type && type.name && type.name.match(SUBJECT_MATTER_REGEX)
         return isSubjectMatter ? "artworks" : "artist"
       },
+    },
+    name: {
+      type: GraphQLString,
     },
     trending_artists: {
       type: new GraphQLList(Artist.type),

--- a/schema/gene.js
+++ b/schema/gene.js
@@ -13,6 +13,13 @@ import { queriedForFieldsOtherThanBlacklisted, parseRelayOptions } from "../lib/
 import { GravityIDFields, NodeInterface } from "./object_identification"
 import { GraphQLObjectType, GraphQLString, GraphQLNonNull, GraphQLList, GraphQLInt } from "graphql"
 
+const SUBJECT_MATTER_MATCHES = [
+  "content", "medium", "concrete contemporary",
+  "abstract contemporary", "concept", "technique", "appearance genes",
+]
+
+const SUBJECT_MATTER_REGEX = new RegExp(SUBJECT_MATTER_MATCHES.join("|"), "i")
+
 const GeneType = new GraphQLObjectType({
   name: "Gene",
   interfaces: [NodeInterface],
@@ -61,6 +68,13 @@ const GeneType = new GraphQLObjectType({
     image: Image,
     name: {
       type: GraphQLString,
+    },
+    mode: {
+      type: GraphQLString,
+      resolve: ({ type }) => {
+        const isSubjectMatter = type && type.name && type.name.match(SUBJECT_MATTER_REGEX)
+        return isSubjectMatter ? "artworks" : "artist"
+      },
     },
     trending_artists: {
       type: new GraphQLList(Artist.type),

--- a/test/schema/gene/gene.js
+++ b/test/schema/gene/gene.js
@@ -135,6 +135,83 @@ describe("Gene", () => {
     })
   })
 
+  describe("arist_connection", () => {
+    const Gene = schema.__get__("Gene")
+
+    beforeEach(() => {
+      Gene.__ResetDependency__("gravity")
+      const gravity = sinon.stub()
+      gravity.with = sinon.stub().returns(gravity)
+      const gene = {
+        id: "500-1000-ce",
+        browseable: true,
+        family: "",
+        counts: { artists: 20 },
+      }
+      gravity
+        // Gene
+        .onCall(0)
+        .returns(Promise.resolve(Object.assign({}, gene)))
+        // 20 artworks
+        .onCall(1)
+        .returns(
+          Promise.resolve(Array(20))
+        )
+
+      Gene.__Rewire__("gravity", gravity)
+    })
+    it("does not have a next page when the requested amount exceeds the count", () => {
+      const query = `
+        {
+          gene(id: "500-1000-ce") {
+            artists_connection(first: 40) {
+              pageInfo {
+                hasNextPage
+              }
+            }
+          }
+        }
+      `
+
+      return runQuery(query).then(data => {
+        expect(data).toEqual({
+          gene: {
+            artists_connection: {
+              pageInfo: {
+                hasNextPage: false,
+              },
+            },
+          },
+        })
+      })
+    })
+    it("has a next page when the amount requested is less than the count", () => {
+      const query = `
+        {
+          gene(id: "500-1000-ce") {
+            artists_connection(first: 10) {
+              pageInfo {
+                hasNextPage
+              }
+            }
+          }
+        }
+      `
+
+      return runQuery(query).then(data => {
+        expect(data).toEqual({
+          gene: {
+            artists_connection: {
+              pageInfo: {
+                hasNextPage: true,
+              },
+            },
+          },
+        })
+      })
+    })
+  })
+
   // The key distinction here is that because the query contains
   // metadata about the gene, then gravity will have to be called,
   // and in the test mocked out. Whereas above, it does not need


### PR DESCRIPTION
`mode` corresponds to the type of Gene page we should default to, `artists_connection` lets us fetch gene artists via relay.


![screenshot 2017-05-17 18 03 27](https://cloud.githubusercontent.com/assets/821469/26178229/24ec3290-3b2b-11e7-9935-c93f5ec9e5f5.png)
