### PR TITLE
Update the VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,10 @@
     "search.exclude": {
         "flow-typed": true
     },
+    "files.exclude": {
+        "**/.git": true,
+        "**/build": true
+    },
     "editor.formatOnSave": true,
     "prettier.singleQuote": false,
     "prettier.trailingComma": "es5",


### PR DESCRIPTION
Removes `build` from the sidebar.