### PR TITLE
[Auctions] Add is_registration_closed to Sale schema

### DIFF
--- a/schema/sale/index.js
+++ b/schema/sale/index.js
@@ -168,6 +168,10 @@ const SaleType = new GraphQLObjectType({
         type: GraphQLBoolean,
         resolve: ({ auction_state }) => auction_state === "preview",
       },
+      is_registration_closed: {
+        type: GraphQLBoolean,
+        resolve: ({ registration_ends_at }) => moment().isAfter(registration_ends_at),
+      },
       is_with_buyers_premium: {
         type: GraphQLBoolean,
         resolve: ({ buyers_premium }) => buyers_premium,

--- a/test/schema/sale/index.js
+++ b/test/schema/sale/index.js
@@ -28,6 +28,7 @@ describe("Sale type", () => {
           is_open
           is_live_open
           is_closed
+          is_registration_closed
           auction_state
           status
         }
@@ -44,6 +45,7 @@ describe("Sale type", () => {
             is_open: false,
             is_live_open: false,
             is_closed: true,
+            is_registration_closed: false,
             auction_state: "closed",
             status: "closed",
           },
@@ -61,6 +63,7 @@ describe("Sale type", () => {
             is_open: false,
             is_live_open: false,
             is_closed: false,
+            is_registration_closed: false,
             auction_state: "preview",
             status: "preview",
           },
@@ -79,6 +82,7 @@ describe("Sale type", () => {
             is_open: true,
             is_live_open: false,
             is_closed: false,
+            is_registration_closed: false,
             auction_state: "open",
             status: "open",
           },
@@ -97,6 +101,26 @@ describe("Sale type", () => {
             is_open: true,
             is_live_open: true,
             is_closed: false,
+            is_registration_closed: false,
+            auction_state: "open",
+            status: "open",
+          },
+        })
+      })
+    })
+
+    it("returns the correct values when sale registration is closed", () => {
+      sale.auction_state = "open"
+      sale.registration_ends_at = moment().subtract(2, "days")
+      return runQuery(query).then(data => {
+        expect(data).toEqual({
+          sale: {
+            _id: "123",
+            is_preview: false,
+            is_open: true,
+            is_live_open: true,
+            is_closed: false,
+            is_registration_closed: true,
             auction_state: "open",
             status: "open",
           },


### PR DESCRIPTION
This PR adds `is_registration_closed` to the `Sale` schema. (Following up to logic stored in https://github.com/artsy/force/pull/1469.) 