### PR TITLE
@broskoski => adds ordered set interface + artwork item type

### DIFF
--- a/schema/index.js
+++ b/schema/index.js
@@ -11,6 +11,7 @@ import Fair from "./fair"
 import Fairs from "./fairs"
 import Gene from "./gene"
 import HomePage from "./home"
+import OrderedSet from "./ordered_set"
 import OrderedSets from "./ordered_sets"
 import Profile from "./profile"
 import Partner from "./partner"
@@ -59,6 +60,7 @@ const rootFields = {
   match_artist: MatchArtist,
   me: Me,
   node: ObjectIdentification.NodeField,
+  ordered_set: OrderedSet,
   ordered_sets: OrderedSets,
   partner: Partner,
   partner_categories: PartnerCategories,

--- a/schema/item.js
+++ b/schema/item.js
@@ -1,5 +1,6 @@
 import _ from "lodash"
 import Artist from "./artist"
+import Artwork from "./artwork/index"
 import FeaturedLink from "./featured_link"
 import Gene from "./gene"
 import { GraphQLUnionType } from "graphql"
@@ -14,6 +15,11 @@ export const ArtistItemType = _.create(Artist.type, {
   isTypeOf: ({ item_type }) => item_type === "Artist",
 })
 
+export const ArtworkItemType = _.create(Artwork.type, {
+  name: "ArtworkItem",
+  isTypeOf: ({ item_type }) => item_type === "Artwork",
+})
+
 export const GeneItemType = _.create(Gene.type, {
   name: "GeneItem",
   isTypeOf: ({ item_type }) => item_type === "Gene",
@@ -21,7 +27,7 @@ export const GeneItemType = _.create(Gene.type, {
 
 export const ItemType = new GraphQLUnionType({
   name: "Item",
-  types: [ArtistItemType, FeaturedLinkItemType, GeneItemType],
+  types: [ArtistItemType, ArtworkItemType, FeaturedLinkItemType, GeneItemType],
 })
 
 export default ItemType

--- a/schema/ordered_set.js
+++ b/schema/ordered_set.js
@@ -1,0 +1,50 @@
+import gravity from "../lib/loaders/gravity"
+import cached from "./fields/cached"
+import ItemType from "./item"
+import { IDFields } from "./object_identification"
+import { GraphQLString, GraphQLObjectType, GraphQLNonNull, GraphQLList } from "graphql"
+
+const OrderedSetType = new GraphQLObjectType({
+  name: "OrderedSet",
+  fields: () => ({
+    ...IDFields,
+    cached,
+    description: {
+      type: GraphQLString,
+    },
+    key: {
+      type: GraphQLString,
+    },
+    item_type: {
+      type: GraphQLString,
+    },
+    items: {
+      type: new GraphQLList(ItemType),
+      resolve: ({ id, item_type }) => {
+        return gravity(`set/${id}/items`).then(items => {
+          return items.map(item => {
+            item.item_type = item_type // eslint-disable-line no-param-reassign
+            return item
+          })
+        })
+      },
+    },
+    name: {
+      type: GraphQLString,
+    },
+  }),
+})
+
+const OrderedSet = {
+  type: OrderedSetType,
+  description: "An OrderedSet",
+  args: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the OrderedSet",
+    },
+  },
+  resolve: (root, { id }) => gravity(`set/${id}`),
+}
+
+export default OrderedSet

--- a/schema/ordered_sets.js
+++ b/schema/ordered_sets.js
@@ -1,42 +1,9 @@
 import gravity from "../lib/loaders/gravity"
-import cached from "./fields/cached"
-import ItemType from "./item"
-import { IDFields } from "./object_identification"
-import { GraphQLString, GraphQLObjectType, GraphQLNonNull, GraphQLList, GraphQLBoolean } from "graphql"
-
-const OrderedSetType = new GraphQLObjectType({
-  name: "OrderedSet",
-  fields: () => ({
-    ...IDFields,
-    cached,
-    description: {
-      type: GraphQLString,
-    },
-    key: {
-      type: GraphQLString,
-    },
-    item_type: {
-      type: GraphQLString,
-    },
-    items: {
-      type: new GraphQLList(ItemType),
-      resolve: ({ id, item_type }) => {
-        return gravity(`set/${id}/items`).then(items => {
-          return items.map(item => {
-            item.item_type = item_type // eslint-disable-line no-param-reassign
-            return item
-          })
-        })
-      },
-    },
-    name: {
-      type: GraphQLString,
-    },
-  }),
-})
+import OrderedSet from "./ordered_set"
+import { GraphQLString, GraphQLNonNull, GraphQLList, GraphQLBoolean } from "graphql"
 
 const OrderedSets = {
-  type: new GraphQLList(OrderedSetType),
+  type: new GraphQLList(OrderedSet.type),
   description: "A collection of OrderedSets",
   args: {
     key: {

--- a/test/schema/ordered_set.js
+++ b/test/schema/ordered_set.js
@@ -1,0 +1,81 @@
+import schema from "../../schema"
+import { runQuery } from "../utils"
+
+describe("OrderedSet type", () => {
+  const OrderedSet = schema.__get__("OrderedSet")
+
+  beforeEach(() => {
+    const gravity = sinon.stub()
+
+    gravity
+      // OrderedSet
+      .onCall(0)
+      .returns(
+        Promise.resolve({
+          description: "",
+          id: "52dd3c2e4b8480091700027f",
+          item_type: "Artwork",
+          key: "artworks:featured-artworks",
+          name: "Featured Artworks",
+        })
+      )
+      // ArtworkItems
+      .onCall(1)
+      .returns(
+        Promise.resolve([
+          {
+            title: "My Artwork",
+          },
+          {
+            title: "Another Artwork",
+          },
+        ])
+      )
+
+    OrderedSet.__Rewire__("gravity", gravity)
+  })
+
+  afterEach(() => {
+    OrderedSet.__ResetDependency__("gravity")
+  })
+
+  it("fetches set by id", () => {
+    const query = `
+      {
+        ordered_set(id: "52dd3c2e4b8480091700027f") {
+          id
+          name
+          key
+          description
+          artworks: items {
+            ... on ArtworkItem {
+              title
+            }
+          }
+        }
+      }
+    `
+
+    return runQuery(query).then(data => {
+      expect(OrderedSet.__get__("gravity").args[0]).toEqual(["set/52dd3c2e4b8480091700027f"])
+      expect(OrderedSet.__get__("gravity").args[1]).toEqual(["set/52dd3c2e4b8480091700027f/items"])
+
+      expect(data).toEqual({
+        ordered_set: {
+          id: "52dd3c2e4b8480091700027f",
+          name: "Featured Artworks",
+          description: "",
+          key: "artworks:featured-artworks",
+          artworks: [
+            {
+              title: "My Artwork",
+            },
+            {
+              title: "Another Artwork",
+            },
+          ],
+        },
+      })
+    })
+  })
+})

--- a/test/schema/ordered_sets.js
+++ b/test/schema/ordered_sets.js
@@ -3,6 +3,7 @@ import { runQuery } from "../utils"
 
 describe("OrderedSets type", () => {
   const OrderedSets = schema.__get__("OrderedSets")
+  const OrderedSet = OrderedSets.__get__("OrderedSet")
 
   beforeEach(() => {
     const gravity = sinon.stub()
@@ -32,10 +33,12 @@ describe("OrderedSets type", () => {
       )
 
     OrderedSets.__Rewire__("gravity", gravity)
+    OrderedSet.__Rewire__("gravity", gravity)
   })
 
   afterEach(() => {
     OrderedSets.__ResetDependency__("gravity")
+    OrderedSet.__ResetDependency__("gravity")
   })
 
   it("fetches sets by key", () => {
@@ -56,7 +59,6 @@ describe("OrderedSets type", () => {
 
     return runQuery(query).then(data => {
       expect(OrderedSets.__get__("gravity").args[0]).toEqual(["sets", { key: "artists:featured-genes", public: true }])
-
       expect(OrderedSets.__get__("gravity").args[1]).toEqual(["set/52dd3c2e4b8480091700027f/items"])
 
       expect(data).toEqual({


### PR DESCRIPTION
Pretty small actual change here-- just adds an `ordered_set` interface that accepts an `id`, and the ability to return `Artwork`-type ordered sets. This will be used to power the `RECENTLY_SOLD` section of the consignments landing page.