### PR TITLE
[Messaging] adds last_message_at field

### DIFF
--- a/schema/me/conversations.js
+++ b/schema/me/conversations.js
@@ -74,17 +74,16 @@ export const ConversationFields = {
   purchase_request: {
     type: GraphQLBoolean,
   },
-
   initial_message: {
     type: GraphQLString,
   },
-
   last_message: {
     type: GraphQLString,
     resolve: conversation => {
       return get(conversation, "_embedded.last_message.snippet")
     },
   },
+  last_message_at: date,
 
   artworks: {
     type: new GraphQLList(ArtworkType),


### PR DESCRIPTION
Closes: #647 
Turns out the property was already being returned by Impulse and the list is already being sorted by last_message_at desc. It just had to be exposed 😅
