### PR TITLE
Add schema for gene families endpoint

### DIFF
--- a/lib/loaders/per_type.js
+++ b/lib/loaders/per_type.js
@@ -21,6 +21,7 @@ export default () => {
     artistLoader: gravityLoader(id => `artist/${id}`),
     artworkLoader: gravityLoader(id => `artwork/${id}`),
     artistArtworksLoader: gravityLoader(id => `artist/${id}/artworks`),
+    geneFamiliesLoader: gravityLoader("gene_families"),
     relatedArtworksLoader: gravityLoader("related/artworks"),
     relatedFairsLoader: gravityLoader("related/fairs"),
     relatedSalesLoader: gravityLoader("related/sales"),

--- a/schema/gene_families.js
+++ b/schema/gene_families.js
@@ -1,11 +1,12 @@
-import gravity from "../lib/loaders/gravity"
 import GeneFamily from "./gene_family"
 import { GraphQLList } from "graphql"
 
 const GeneFamilies = {
   type: new GraphQLList(GeneFamily.type),
   description: "A list of Gene Families",
-  resolve: () => gravity("gene_families"),
+  resolve: (_source, _args, _request, { rootValue }) => {
+    return rootValue.geneFamiliesLoader()
+  },
 }
 
 export default GeneFamilies

--- a/schema/gene_families.js
+++ b/schema/gene_families.js
@@ -1,0 +1,11 @@
+import gravity from "../lib/loaders/gravity"
+import GeneFamily from "./gene_family"
+import { GraphQLList } from "graphql"
+
+const GeneFamilies = {
+  type: new GraphQLList(GeneFamily.type),
+  description: "A list of Gene Families",
+  resolve: () => gravity("gene_families"),
+}
+
+export default GeneFamilies

--- a/schema/gene_family.js
+++ b/schema/gene_family.js
@@ -1,15 +1,14 @@
-import type { GraphQLFieldConfig } from "graphql"
-import { GraphQLObjectType, GraphQLString, GraphQLList } from "graphql"
+import { GraphQLFieldConfig, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString } from "graphql"
 import Gene from "./gene"
 
 const GeneFamilyType = new GraphQLObjectType({
   name: "GeneFamily",
   fields: {
     id: {
-      type: GraphQLString,
+      type: new GraphQLNonNull(GraphQLString),
     },
     name: {
-      type: GraphQLString,
+      type: new GraphQLNonNull(GraphQLString),
     },
     genes: {
       type: new GraphQLList(Gene.type),
@@ -19,9 +18,6 @@ const GeneFamilyType = new GraphQLObjectType({
 
 const GeneFamily: GraphQLFieldConfig<GeneFamilyType, *> = {
   type: GeneFamilyType,
-  resolve: () => {
-    return root => root
-  },
 }
 
 export default GeneFamily

--- a/schema/gene_family.js
+++ b/schema/gene_family.js
@@ -1,0 +1,27 @@
+import type { GraphQLFieldConfig } from "graphql"
+import { GraphQLObjectType, GraphQLString, GraphQLList } from "graphql"
+import Gene from "./gene"
+
+const GeneFamilyType = new GraphQLObjectType({
+  name: "GeneFamily",
+  fields: {
+    id: {
+      type: GraphQLString,
+    },
+    name: {
+      type: GraphQLString,
+    },
+    genes: {
+      type: new GraphQLList(Gene.type),
+    },
+  },
+})
+
+const GeneFamily: GraphQLFieldConfig<GeneFamilyType, *> = {
+  type: GeneFamilyType,
+  resolve: () => {
+    return root => root
+  },
+}
+
+export default GeneFamily

--- a/schema/index.js
+++ b/schema/index.js
@@ -10,6 +10,8 @@ import ExternalPartner from "./external_partner"
 import Fair from "./fair"
 import Fairs from "./fairs"
 import Gene from "./gene"
+import GeneFamilies from "./gene_families"
+import GeneFamily from "./gene_family"
 import HomePage from "./home"
 import OrderedSet from "./ordered_set"
 import OrderedSets from "./ordered_sets"
@@ -56,6 +58,8 @@ const rootFields = {
   filter_artworks: filterArtworks(),
   filter_sale_artworks: FilterSaleArtworks,
   gene: Gene,
+  gene_families: GeneFamilies,
+  gene_family: GeneFamily,
   home_page: HomePage,
   match_artist: MatchArtist,
   me: Me,

--- a/test/schema/gene/gene_families.js
+++ b/test/schema/gene/gene_families.js
@@ -36,18 +36,7 @@ describe("GeneFamilies", () => {
     `
 
     return runQuery(query).then(data => {
-      expect(data).toEqual({
-        gene_families: [
-          {
-            id: "design-concepts-and-techniques",
-            name: "Design Concepts and Techniques",
-          },
-          {
-            id: "furniture-and-lighting",
-            name: "Furniture & Lighting",
-          },
-        ],
-      })
+      expect(data).toEqual({ gene_families: api_data })
     })
   })
 })

--- a/test/schema/gene/gene_families.js
+++ b/test/schema/gene/gene_families.js
@@ -1,0 +1,53 @@
+import schema from "../../../schema"
+import { runQuery } from "../../utils"
+
+describe("GeneFamilies", () => {
+  const GeneFamilies = schema.__get__("GeneFamilies")
+  let gravity = null
+  const api_data = [
+    {
+      id: "design-concepts-and-techniques",
+      name: "Design Concepts and Techniques",
+    },
+    {
+      id: "furniture-and-lighting",
+      name: "Furniture & Lighting",
+    },
+  ]
+
+  beforeEach(() => {
+    gravity = sinon.stub()
+    gravity.returns(Promise.resolve(api_data))
+    GeneFamilies.__Rewire__("gravity", gravity)
+  })
+
+  afterEach(() => {
+    GeneFamilies.__ResetDependency__("gravity")
+  })
+
+  it("returns a list of gene families", () => {
+    const query = `
+      {
+        gene_families {
+          id
+          name
+        }
+      }
+    `
+
+    return runQuery(query).then(data => {
+      expect(data).toEqual({
+        gene_families: [
+          {
+            id: "design-concepts-and-techniques",
+            name: "Design Concepts and Techniques",
+          },
+          {
+            id: "furniture-and-lighting",
+            name: "Furniture & Lighting",
+          },
+        ],
+      })
+    })
+  })
+})

--- a/test/schema/gene/gene_families.js
+++ b/test/schema/gene/gene_families.js
@@ -1,9 +1,6 @@
-import schema from "../../../schema"
 import { runQuery } from "../../utils"
 
 describe("GeneFamilies", () => {
-  const GeneFamilies = schema.__get__("GeneFamilies")
-  let gravity = null
   const api_data = [
     {
       id: "design-concepts-and-techniques",
@@ -15,17 +12,8 @@ describe("GeneFamilies", () => {
     },
   ]
 
-  beforeEach(() => {
-    gravity = sinon.stub()
-    gravity.returns(Promise.resolve(api_data))
-    GeneFamilies.__Rewire__("gravity", gravity)
-  })
-
-  afterEach(() => {
-    GeneFamilies.__ResetDependency__("gravity")
-  })
-
   it("returns a list of gene families", () => {
+    const geneFamiliesLoader = () => Promise.resolve(api_data)
     const query = `
       {
         gene_families {
@@ -35,7 +23,7 @@ describe("GeneFamilies", () => {
       }
     `
 
-    return runQuery(query).then(data => {
+    return runQuery(query, { geneFamiliesLoader }).then(data => {
       expect(data).toEqual({ gene_families: api_data })
     })
   })


### PR DESCRIPTION
As part of the new [Categories page](https://www.artsy.net/categories), we'd like to fetch gene families from the new endpoint. This PR adds a new schema to that end. 

As this is my first non-trivial PR for Metaphysics/GraphQL, there may be some learning opportunities here. So please point out ways in which this  PR could be improved if you see them. 

CC @oxaudo @anandaroop 