### PR TITLE
[schema] Rename root types to conventional ones.

### DIFF
--- a/schema/index.js
+++ b/schema/index.js
@@ -98,7 +98,7 @@ const Viewer = {
 
 const schema = new GraphQLSchema({
   mutation: new GraphQLObjectType({
-    name: "RootMutationType",
+    name: "Mutation",
     fields: {
       followArtist: FollowArtist,
       updateCollectorProfile: UpdateCollectorProfile,
@@ -108,7 +108,7 @@ const schema = new GraphQLSchema({
     },
   }),
   query: new GraphQLObjectType({
-    name: "RootQueryType",
+    name: "Query",
     fields: {
       ...rootFields,
       viewer: Viewer,


### PR DESCRIPTION
These conventional ones are alas hardcoded in Relay. Rather than trying
ot make Relay adapt to different schemas than FB’s, I chose to just
rename instead. Nobody is really using the names of these types anyways.