### PR TITLE
@mzikherman - Add show to supported node types

### DIFF
--- a/schema/object_identification.js
+++ b/schema/object_identification.js
@@ -44,6 +44,7 @@ const SupportedTypes = {
     "./me",
     "./partner",
     "./partner_show",
+    "./show",
   ],
 }
 

--- a/schema/show.js
+++ b/schema/show.js
@@ -253,9 +253,11 @@ const ShowType = new GraphQLObjectType({
       type: Image.type,
       resolve: ({ id, partner, image_versions, image_url }) => {
         if (image_versions && image_versions.length && image_url) {
-          return Image.resolve({ image_versions, image_url })
+          return Image.resolve({
+            image_versions,
+            image_url,
+          })
         }
-
         return gravity(`partner/${partner.id}/show/${id}/artworks`, {
           published: true,
         }).then(artworks => {
@@ -310,7 +312,6 @@ const ShowType = new GraphQLObjectType({
     },
   }),
 })
-
 const Show = {
   type: ShowType,
   description: "A Show",
@@ -329,9 +330,7 @@ const Show = {
       .catch(() => null)
   },
 }
-
 export default Show
-
 export const showConnection = connectionDefinitions({
   nodeType: Show.type,
 }).connectionType


### PR DESCRIPTION
In reaction-force we need to be able to refetch `Show`'s by their node ids. This allows us to do that :)