### PR TITLE
Add is_invoice to message response

### DIFF
--- a/schema/me/conversation/message.js
+++ b/schema/me/conversation/message.js
@@ -40,6 +40,15 @@ export const MessageType = new GraphQLObjectType({
     attachments: {
       type: new GraphQLList(AttachmentType),
     },
+    is_invoice: {
+      description: "True if message is an invoice message",
+      type: GraphQLBoolean,
+      resolve: ({ metadata }) => {
+        if (!metadata) return false
+        console.log(metadata)
+        return !!metadata.lewitt_invoice_id
+      },
+    },
     created_at: date,
   },
 })

--- a/schema/me/conversation/message.js
+++ b/schema/me/conversation/message.js
@@ -3,6 +3,7 @@ import { has } from "lodash"
 import { GraphQLBoolean, GraphQLList, GraphQLObjectType, GraphQLString, GraphQLNonNull } from "graphql"
 import { GlobalIDField, NodeInterface } from "schema/object_identification"
 import { AttachmentType } from "./attachment"
+import { isExisty } from "lib/helpers"
 
 export const MessageType = new GraphQLObjectType({
   name: "Message",
@@ -43,11 +44,7 @@ export const MessageType = new GraphQLObjectType({
     is_invoice: {
       description: "True if message is an invoice message",
       type: GraphQLBoolean,
-      resolve: ({ metadata }) => {
-        if (!metadata) return false
-        console.log(metadata)
-        return !!metadata.lewitt_invoice_id
-      },
+      resolve: ({ metadata: { lewitt_invoice_id } }) => isExisty(lewitt_invoice_id),
     },
     created_at: date,
   },

--- a/test/schema/me/conversation/index.js
+++ b/test/schema/me/conversation/index.js
@@ -34,6 +34,15 @@ describe("Me", () => {
               from {
                 email
               }
+              messages(first: 10) {
+                edges {
+                  node {
+                    id
+                    is_invoice
+                    is_from_user
+                  }
+                }
+              }
             }
           }
         }
@@ -45,6 +54,21 @@ describe("Me", () => {
         from_email: "fancy_german_person@posteo.de",
       }
 
+      const conversation1Messages = {
+        total_count: 1,
+        message_details: [
+          {
+            id: "240",
+            raw_text: "this is a good message",
+            from_email_address: "fancy_german_person@posteo.de",
+            attachments: [],
+            metadata: {
+              lewitt_invoice_id: "420i",
+            },
+          },
+        ],
+      }
+
       const expectedConversationData = {
         conversation: {
           id: "420",
@@ -52,11 +76,24 @@ describe("Me", () => {
           from: {
             email: "fancy_german_person@posteo.de",
           },
+          messages: {
+            edges: [
+              {
+                node: {
+                  id: "240",
+                  is_invoice: true,
+                  is_from_user: true,
+                },
+              },
+            ],
+          },
         },
       }
 
       gravity.onCall(0).returns(Promise.resolve({ token: "token" }))
       impulse.onCall(0).returns(Promise.resolve(conversation1))
+      gravity.onCall(1).returns(Promise.resolve({ token: "token" }))
+      impulse.onCall(1).returns(Promise.resolve(conversation1Messages))
 
       return runAuthenticatedQuery(query).then(({ me: conversation }) => {
         expect(conversation).toEqual(expectedConversationData)


### PR DESCRIPTION
# Feature
We currently show Invoice messages `raw_text` which is not readable and useful, I can imagine we may want to detect these invoice messages and show them differently. 

# Solution
Add a new `is_invoice` attribute to `MessageType` which basically looks for `metadata` of Radiation's message and checks if there is `lewitt_invoice_id` present or not, having `lewitt_invoice_id` in `metadata` means it was an invoice related message.