### PR TITLE
Fix null `is_invoice` issue

### DIFF
--- a/schema/me/conversation/message.js
+++ b/schema/me/conversation/message.js
@@ -44,7 +44,10 @@ export const MessageType = new GraphQLObjectType({
     is_invoice: {
       description: "True if message is an invoice message",
       type: GraphQLBoolean,
-      resolve: ({ metadata: { lewitt_invoice_id } }) => isExisty(lewitt_invoice_id),
+      resolve: ({ metadata }) => {
+        if (!metadata) return false
+        return isExisty(metadata.lewitt_invoice_id)
+      },
     },
     created_at: date,
   },

--- a/schema/me/conversation/message.js
+++ b/schema/me/conversation/message.js
@@ -45,8 +45,7 @@ export const MessageType = new GraphQLObjectType({
       description: "True if message is an invoice message",
       type: GraphQLBoolean,
       resolve: ({ metadata }) => {
-        if (!metadata) return false
-        return isExisty(metadata.lewitt_invoice_id)
+        return !!metadata && isExisty(metadata.lewitt_invoice_id)
       },
     },
     created_at: date,

--- a/test/schema/me/conversation/index.js
+++ b/test/schema/me/conversation/index.js
@@ -55,7 +55,7 @@ describe("Me", () => {
       }
 
       const conversation1Messages = {
-        total_count: 1,
+        total_count: 2,
         message_details: [
           {
             id: "240",
@@ -65,6 +65,13 @@ describe("Me", () => {
             metadata: {
               lewitt_invoice_id: "420i",
             },
+          },
+          {
+            id: "241",
+            raw_text: "this is a good message",
+            from_email_address: "postman@posteo.de",
+            attachments: [],
+            metadata: {},
           },
         ],
       }
@@ -83,6 +90,13 @@ describe("Me", () => {
                   id: "240",
                   is_invoice: true,
                   is_from_user: true,
+                },
+              },
+              {
+                node: {
+                  id: "241",
+                  is_invoice: false,
+                  is_from_user: false,
                 },
               },
             ],


### PR DESCRIPTION
# Problem
On https://github.com/artsy/metaphysics/pull/686 we added `is_invoice` to messages response, using destructing to check if `metadata` has `lewitt_invoice_id` caused returning `null` when messages don't have `lewitt_invoice_id`, we want to return `false` for `is_invoice` for these cases,


# Solution
First check if we don't have metadata return `false` and if we do then check for `isExisty`.