### PR TITLE
Filters closed sales from is_in_auction field.

### DIFF
--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -183,14 +183,20 @@ export const artworkFields = () => {
       description: "Returns the highlighted shows and articles",
       resolve: ({ id, _id }, options, request, { rootValue: { relatedShowsLoader, articlesLoader } }) =>
         Promise.all([
-          relatedShowsLoader(id, { artwork: [id], size: 1, at_a_fair: false }),
+          relatedShowsLoader(id, {
+            artwork: [id],
+            size: 1,
+            at_a_fair: false,
+          }),
           articlesLoader(_id, {
             artwork_id: _id,
             published: true,
             limit: 1,
           }).then(({ results }) => results),
         ]).then(([shows, articles]) => {
-          const highlightedShows = enhance(shows, { highlight_type: "Show" })
+          const highlightedShows = enhance(shows, {
+            highlight_type: "Show",
+          })
           const highlightedArticles = enhance(articles, {
             highlight_type: "Article",
           })
@@ -334,7 +340,7 @@ export const artworkFields = () => {
             id: sale_ids,
             is_auction: true,
           }).then(sales => {
-            return sales.length > 0
+            return sales.filter(sale => sale.is_open).length > 0
           })
         }
         return false
@@ -440,14 +446,16 @@ export const artworkFields = () => {
         },
       },
       resolve: ({ _id }, { size }, request, { rootValue: { relatedArtworksLoader } }) =>
-        relatedArtworksLoader(null, { artwork_id: _id, size }),
+        relatedArtworksLoader(null, {
+          artwork_id: _id,
+          size,
+        }),
     },
     sale: {
       type: Sale.type,
       resolve: ({ sale_ids }, options, request, { rootValue: { saleLoader } }) => {
         if (sale_ids && sale_ids.length > 0) {
-          const sale_id = _.first(sale_ids)
-          // don't error if the sale is unpublished
+          const sale_id = _.first(sale_ids) // don't error if the sale is unpublished
           return saleLoader(sale_id).catch(() => null)
         }
         return null
@@ -457,8 +465,7 @@ export const artworkFields = () => {
       type: SaleArtwork.type,
       resolve: ({ id, sale_ids }) => {
         if (sale_ids && sale_ids.length > 0) {
-          const sale_id = _.first(sale_ids)
-          // don't error if the sale/artwork is unpublished
+          const sale_id = _.first(sale_ids) // don't error if the sale/artwork is unpublished
           return gravity(`sale/${sale_id}/sale_artwork/${id}`).catch(() => null)
         }
         return null
@@ -550,7 +557,6 @@ export const artworkFields = () => {
     },
   }
 }
-
 export const ArtworkType = new GraphQLObjectType({
   name: "Artwork",
   interfaces: [NodeInterface],
@@ -562,7 +568,6 @@ export const ArtworkType = new GraphQLObjectType({
     }
   },
 })
-
 Artwork = {
   type: ArtworkType,
   description: "An Artwork",
@@ -574,9 +579,7 @@ Artwork = {
   },
   resolve: (root, { id }, request, { rootValue: { artworkLoader } }) => artworkLoader(id),
 }
-
 export default Artwork
-
 export const artworkConnection = connectionDefinitions({
   nodeType: Artwork.type,
 }).connectionType

--- a/test/schema/artwork/index.js
+++ b/test/schema/artwork/index.js
@@ -236,7 +236,7 @@ describe("Artwork type", () => {
     `
 
     it("is true if the artwork has any sales that are auctions", () => {
-      const sales = [assign({}, sale, { is_auction: false }), assign({}, sale, { is_auction: true })]
+      const sales = [assign({}, sale, { is_auction: false }), assign({}, sale, { is_auction: true, is_open: true })]
       rootValue.salesLoader = sinon.stub().returns(Promise.resolve(sales))
 
       return runQuery(query, rootValue).then(data => {
@@ -251,6 +251,20 @@ describe("Artwork type", () => {
 
     it("is false if the artwork is not in any sales that are auctions", () => {
       rootValue.salesLoader = sinon.stub().returns(Promise.resolve([]))
+
+      return runQuery(query, rootValue).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            id: "richard-prince-untitled-portrait",
+            is_in_auction: false,
+          },
+        })
+      })
+    })
+
+    it("is false if the only sales the artwork is in are all closed", () => {
+      const sales = [assign({}, sale, { is_auction: false }), assign({}, sale, { is_open: false })]
+      rootValue.salesLoader = sinon.stub().returns(Promise.resolve(sales))
 
       return runQuery(query, rootValue).then(data => {
         expect(data).toEqual({


### PR DESCRIPTION
The `is_in_auction` field of an `Artwork` wasn't excluding closed sales. As [discussed in Slack](https://artsy.slack.com/archives/C02BAQ5K7/p1499704577290637) I want to make sure this won't inadvertently break anything else, but I feel like changing `is_in_auction` to behave more like an `is_in_open_auction` makes a lot of sense.

There are some inadvertent changes ESLint made – I kept them in but can remove them if they're not appropriate. The relevant line of the Artwork file is 343.