### PR TITLE
Add from_id to append message mutation, fix typos

### DIFF
--- a/schema/me/conversation/send_message_mutation.js
+++ b/schema/me/conversation/send_message_mutation.js
@@ -47,7 +47,11 @@ export default mutationWithClientMutationId({
       },
     },
   },
-  mutateAndGetPayload: ({ id, from, to, body_text, reply_to_message_id }, request, { rootValue: { accessToken } }) => {
+  mutateAndGetPayload: (
+    { id, from, to, body_text, reply_to_message_id },
+    request,
+    { rootValue: { accessToken, userID } }
+  ) => {
     if (!accessToken) return null
     let impulseToken
     return getImpulseToken(accessToken)
@@ -69,6 +73,7 @@ export default mutationWithClientMutationId({
             newMessagePayload: {
               id: newMessageID,
               from_email_address: from,
+              from_id: userID,
               raw_text: body_text,
               created_at: new Date().toISOString(),
               attachments: [],

--- a/schema/me/conversation/send_message_mutation.js
+++ b/schema/me/conversation/send_message_mutation.js
@@ -48,7 +48,7 @@ export default mutationWithClientMutationId({
     },
   },
   mutateAndGetPayload: (
-    { id, from, to, body_text, reply_to_message_id },
+    { id, from, from_id, to, body_text, reply_to_message_id },
     request,
     { rootValue: { accessToken, userID } }
   ) => {
@@ -61,6 +61,7 @@ export default mutationWithClientMutationId({
           reply_all: true,
           reply_to_message_id,
           from,
+          from_id: userID,
           body_text,
         })
       })

--- a/schema/me/conversation/update_mutation.js
+++ b/schema/me/conversation/update_mutation.js
@@ -7,7 +7,7 @@ import { mutationWithClientMutationId } from "graphql-relay"
 
 export default mutationWithClientMutationId({
   name: "UpdateConversationMutation",
-  decription: "Updating buyer outcome of a conversation.",
+  description: "Updating buyer outcome of a conversation.",
   inputFields: {
     buyer_outcome: {
       type: new GraphQLNonNull(BuyerOutcomeTypes),

--- a/schema/me/conversations.js
+++ b/schema/me/conversations.js
@@ -9,7 +9,7 @@ import { ConversationType } from "./conversation"
 
 export default {
   type: connectionDefinitions({ nodeType: ConversationType }).connectionType,
-  decription: "Conversations, usually between a user and partner.",
+  description: "Conversations, usually between a user and partner.",
   args: pageable(),
   resolve: (root, options, request, { rootValue: { accessToken, userID } }) => {
     if (!accessToken) return null


### PR DESCRIPTION
In https://github.com/artsy/impulse/pull/282 we added `from_id` to `Message` model and we can now pass optional `from_id` to append message request.

This PR updates Metaphysics to pass `from_id` when replying to a message.

cc: @mzikherman @joeyAghion 