### PR TITLE
Extends collection artwork_connection with private+sort args

### DIFF
--- a/schema/collection.js
+++ b/schema/collection.js
@@ -5,7 +5,7 @@ import { connectionFromArraySlice } from "graphql-relay"
 import _ from "lodash"
 import gravity from "lib/loaders/gravity"
 import cached from "./fields/cached"
-import ArtworkSorts from "./sorts/artwork_sorts"
+import CollectionSorts from "./sorts/collection_sorts"
 import { artworkConnection } from "./artwork"
 import { queriedForFieldsOtherThanBlacklisted, parseRelayOptions } from "lib/helpers"
 import { GravityIDFields, NodeInterface } from "./object_identification"
@@ -30,7 +30,7 @@ export const CollectionType = new GraphQLObjectType({
           type: GraphQLBoolean,
           defaultValue: false,
         },
-        sort: ArtworkSorts,
+        sort: CollectionSorts,
       },
       resolve: ({ id }, options, request, { rootValue: { accessToken, userID } }) => {
         const gravityOptions = parseRelayOptions(options)

--- a/schema/sorts/artwork_sorts.js
+++ b/schema/sorts/artwork_sorts.js
@@ -76,6 +76,12 @@ export default {
       PARTNER_UPDATED_AT_DESC: {
         value: "-partner_updated_at",
       },
+      POSITION_ASC: {
+        value: "position",
+      },
+      POSITION_DESC: {
+        value: "-position",
+      },
       PUBLISHED_AT_ASC: {
         value: "published_at",
       },

--- a/schema/sorts/artwork_sorts.js
+++ b/schema/sorts/artwork_sorts.js
@@ -76,12 +76,6 @@ export default {
       PARTNER_UPDATED_AT_DESC: {
         value: "-partner_updated_at",
       },
-      POSITION_ASC: {
-        value: "position",
-      },
-      POSITION_DESC: {
-        value: "-position",
-      },
       PUBLISHED_AT_ASC: {
         value: "published_at",
       },

--- a/schema/sorts/collection_sorts.js
+++ b/schema/sorts/collection_sorts.js
@@ -1,0 +1,15 @@
+import { GraphQLEnumType } from "graphql"
+
+export default {
+  type: new GraphQLEnumType({
+    name: "CollectionSorts",
+    values: {
+      POSITION_ASC: {
+        value: "position",
+      },
+      POSITION_DESC: {
+        value: "-position",
+      },
+    },
+  }),
+}

--- a/test/schema/collection.js
+++ b/test/schema/collection.js
@@ -49,7 +49,13 @@ describe("Collections", () => {
       const artworksPath = resolve("test", "fixtures", "gravity", "artworks_array.json")
       const artworks = JSON.parse(readFileSync(artworksPath, "utf8"))
       gravity
-        .withArgs("collection/saved-artwork/artworks", { size: 10, offset: 0, total_count: true, user_id: "user-42" })
+        .withArgs("collection/saved-artwork/artworks", {
+          size: 10,
+          offset: 0,
+          private: false,
+          total_count: true,
+          user_id: "user-42",
+        })
         .returns(Promise.resolve({ body: artworks, headers: { "x-total-count": 10 } }))
 
       const query = `


### PR DESCRIPTION
Eigen is changing its Favourites view to use Metaphysics ( https://github.com/artsy/eigen/pull/2402 ) and we need the ability to specify artwork sort order and `private` options, added in this PR. 