### PR TITLE
@alloy => Dont crash when we dont have an inquireable snapshot

### DIFF
--- a/schema/me/conversation/index.js
+++ b/schema/me/conversation/index.js
@@ -1,3 +1,4 @@
+import { isExisty } from "lib/helpers"
 import impulse from "lib/loaders/impulse"
 import gravity from "lib/loaders/gravity"
 import date from "schema/fields/date"
@@ -192,7 +193,7 @@ export const ConversationFields = {
     resolve: conversation => {
       const results = []
       for (const item of conversation.items) {
-        if (item.item_type === "Artwork" || item.item_type === "PartnerShow") {
+        if (isExisty(item.properties) && (item.item_type === "Artwork" || item.item_type === "PartnerShow")) {
           results.push(item)
         }
       }

--- a/test/schema/me/conversation/index.js
+++ b/test/schema/me/conversation/index.js
@@ -147,8 +147,7 @@ describe("Me", () => {
         expect(conversation).toEqual(expectedConversationData)
       })
     })
-
-    it("returns the conversation items", () => {
+    describe("concerning items", () => {
       const conversation = {
         initial_message: "Loved some of the works at your fair booth!",
         from_email: "collector@example.com",
@@ -178,10 +177,6 @@ describe("Me", () => {
           },
         ],
       }
-
-      gravity.onCall(0).returns(Promise.resolve({ token: "token" }))
-      impulse.onCall(0).returns(Promise.resolve(conversation))
-
       const query = `
         {
           me {
@@ -202,26 +197,49 @@ describe("Me", () => {
           }
         }
       `
-
-      const expectedItems = [
-        {
-          title: "Pwetty Cats",
-          item: {
-            __typename: "Artwork",
-            is_acquireable: true,
+      beforeEach(() => {
+        gravity.onCall(0).returns(Promise.resolve({ token: "token" }))
+      })
+      it("returns the conversation items", () => {
+        impulse.onCall(0).returns(Promise.resolve(conversation))
+        const expectedItems = [
+          {
+            title: "Pwetty Cats",
+            item: {
+              __typename: "Artwork",
+              is_acquireable: true,
+            },
           },
-        },
-        {
-          title: "Catty Show",
-          item: {
-            __typename: "Show",
-            is_reference: true,
+          {
+            title: "Catty Show",
+            item: {
+              __typename: "Show",
+              is_reference: true,
+            },
           },
-        },
-      ]
+        ]
 
-      return runAuthenticatedQuery(query).then(({ me: { conversation: { items } } }) => {
-        expect(items).toEqual(expectedItems)
+        return runAuthenticatedQuery(query).then(({ me: { conversation: { items } } }) => {
+          expect(items).toEqual(expectedItems)
+        })
+      })
+
+      it("doesnt return invalid items", () => {
+        conversation.items[0].properties = {}
+        impulse.onCall(0).returns(Promise.resolve(conversation))
+        const expectedItems = [
+          {
+            title: "Catty Show",
+            item: {
+              __typename: "Show",
+              is_reference: true,
+            },
+          },
+        ]
+
+        return runAuthenticatedQuery(query).then(({ me: { conversation: { items } } }) => {
+          expect(items).toEqual(expectedItems)
+        })
       })
     })
   })


### PR DESCRIPTION
So now that we have the full snapshot (and going forward) for inquiries, for the handful where we weren't able to backfill (actually deleted from the database), we can just silently skip them and avoid a crash.

Clients can choose to then do what they'd like with the requested data, which for other conversation purposes _is_ complete....in Emission, we don't render these in the Inbox. That's because of https://github.com/artsy/emission/pull/695/files#diff-d44670c88b75d348586c602c7216e036R139