### PR TITLE
@joeyAghion => Add body for use instead of raw_text

### DIFF
--- a/schema/me/conversation/message.js
+++ b/schema/me/conversation/message.js
@@ -67,7 +67,14 @@ export const MessageType = new GraphQLObjectType({
     raw_text: {
       description: "Full unsanitized text.",
       type: new GraphQLNonNull(GraphQLString),
+      deprecationReason: "Prefer to use the parsed/cleaned-up `body`.",
     },
+
+    body: {
+      description: "Text which has been parsed/sanitized of quoted replies (among other things).",
+      type: GraphQLString,
+    },
+
     attachments: {
       type: new GraphQLList(AttachmentType),
     },

--- a/test/schema/me/conversation/index.js
+++ b/test/schema/me/conversation/index.js
@@ -46,6 +46,7 @@ describe("Me", () => {
                       name
                       email
                     }
+                    body
                   }
                 }
               }
@@ -73,6 +74,7 @@ describe("Me", () => {
               lewitt_invoice_id: "420i",
             },
             from: "\"Percy Z\" <percy@cat.com>",
+            body: "I'm a cat",
           },
           {
             id: "241",
@@ -82,6 +84,7 @@ describe("Me", () => {
             attachments: [],
             metadata: {},
             from: "\"Bitty Z\" <Bitty@cat.com>",
+            body: "",
           },
           {
             id: "242",
@@ -91,6 +94,7 @@ describe("Me", () => {
             attachments: [],
             metadata: {},
             from: "\"Matt Z\" <matt@cat.com>",
+            body: null,
           },
           {
             id: "243",
@@ -122,6 +126,7 @@ describe("Me", () => {
                     name: "Percy Z",
                     email: "fancy_german_person@posteo.de",
                   },
+                  body: "I'm a cat",
                 },
               },
               {
@@ -133,6 +138,7 @@ describe("Me", () => {
                     name: "Bitty Z",
                     email: "postman@posteo.de",
                   },
+                  body: "",
                 },
               },
               {
@@ -144,6 +150,7 @@ describe("Me", () => {
                     name: "Matt Z",
                     email: "fancy_german_person+wunderbar@posteo.de",
                   },
+                  body: null,
                 },
               },
               {
@@ -155,6 +162,7 @@ describe("Me", () => {
                     name: null,
                     email: "postman+wunderlich@posteo.de",
                   },
+                  body: null,
                 },
               },
             ],


### PR DESCRIPTION
cc @l2succes 

We were using `raw_text`, which included quoted replies, forwarded content, email signatures, etc.

Apparently `body` is the text, but already parsed/cleaned-up (or attempted to), by [Griddler](https://github.com/thoughtbot/griddler), so we should just switch to using it! Then, we can see how our test cases look. This may seriously alter our plans for sanitization/parsing (or the 'REPLY ABOVE THS LINE' thing). I'll switch Emission to use this.

Thanks for the tip @joeyAghion !

If we want to explore other things, there is https://github.com/github/email_reply_parser, which is what GitHub uses to create comments out of email replies.