### PR TITLE
Improve util function to accept rootValue

### DIFF
--- a/test/schema/me/conversation/index.js
+++ b/test/schema/me/conversation/index.js
@@ -84,7 +84,7 @@ describe("Me", () => {
             metadata: {
               lewitt_invoice_id: "420i",
             },
-            from: "\"Percy Z\" <percy@cat.com>",
+            from: '"Percy Z" <percy@cat.com>',
             body: "I'm a cat",
           },
           {
@@ -94,7 +94,7 @@ describe("Me", () => {
             from_id: null,
             attachments: [],
             metadata: {},
-            from: "\"Bitty Z\" <Bitty@cat.com>",
+            from: '"Bitty Z" <Bitty@cat.com>',
             body: "",
           },
           {
@@ -104,7 +104,7 @@ describe("Me", () => {
             from_id: "user-42",
             attachments: [],
             metadata: {},
-            from: "\"Matt Z\" <matt@cat.com>",
+            from: '"Matt Z" <matt@cat.com>',
             body: null,
           },
           {
@@ -115,9 +115,11 @@ describe("Me", () => {
             attachments: [],
             metadata: {},
             from: "<email@email.com>",
-            deliveries: [{
-              opened_at: "2020-12-31T12:00:00+00:00",
-            }],
+            deliveries: [
+              {
+                opened_at: "2020-12-31T12:00:00+00:00",
+              },
+            ],
           },
         ],
       }
@@ -182,9 +184,11 @@ describe("Me", () => {
                     email: "postman+wunderlich@posteo.de",
                   },
                   body: null,
-                  deliveries: [{
-                    opened_at: "2020-12-31T12:00:00+00:00",
-                  }],
+                  deliveries: [
+                    {
+                      opened_at: "2020-12-31T12:00:00+00:00",
+                    },
+                  ],
                 },
               },
             ],
@@ -197,7 +201,7 @@ describe("Me", () => {
       gravity.onCall(1).returns(Promise.resolve({ token: "token" }))
       impulse.onCall(1).returns(Promise.resolve(conversation1Messages))
 
-      return runAuthenticatedQuery(query, "user-42").then(({ me: conversation }) => {
+      return runAuthenticatedQuery(query).then(({ me: conversation }) => {
         expect(conversation).toEqual(expectedConversationData)
       })
     })

--- a/test/schema/me/conversation/index.js
+++ b/test/schema/me/conversation/index.js
@@ -84,7 +84,7 @@ describe("Me", () => {
             metadata: {
               lewitt_invoice_id: "420i",
             },
-            from: '"Percy Z" <percy@cat.com>',
+            from: `"Percy Z" <percy@cat.com>`,
             body: "I'm a cat",
           },
           {
@@ -94,7 +94,7 @@ describe("Me", () => {
             from_id: null,
             attachments: [],
             metadata: {},
-            from: '"Bitty Z" <Bitty@cat.com>',
+            from: `"Bitty Z" <Bitty@cat.com>`,
             body: "",
           },
           {
@@ -104,7 +104,7 @@ describe("Me", () => {
             from_id: "user-42",
             attachments: [],
             metadata: {},
-            from: '"Matt Z" <matt@cat.com>',
+            from: `"Matt Z" <matt@cat.com>`,
             body: null,
           },
           {

--- a/test/utils.js
+++ b/test/utils.js
@@ -4,7 +4,7 @@ import { graphql } from "graphql"
 /**
  * Performs a GraphQL query against our schema.
  *
- * On success, the promise resolves with the `data` part of the resonse.
+ * On success, the promise resolves with the `data` part of the response.
  *
  * On error, the promise will reject with the original error that was thrown.
  *
@@ -30,9 +30,10 @@ export const runQuery = (query: string, rootValue: ?any = { accessToken: null, u
  *
  * @see runQuery
  */
-export const runAuthenticatedQuery = (query: string, userID: string = "user-42") => {
-  return runQuery(query, {
-    accessToken: "secret",
-    userID,
-  })
+export const runAuthenticatedQuery = (query: string, rootValue: ?any = {}) => {
+  const authenticatedRootValue = rootValue
+  authenticatedRootValue.accessToken = "secret"
+  authenticatedRootValue.userID = "user-42"
+
+  return runQuery(query, authenticatedRootValue)
 }


### PR DESCRIPTION
Prior to this commit it was not possible to use `runAuthenticatedQuery` with a `rootValue`, instead you'd use `runQuery` and provide the authenticated values. Whaa, whaa.

Before considering this change I audited the usage of `runAuthenticatedQuery` and found that in only one place were we not taking the default value for `userID`, and even in that one place we actually WERE using the default value! So, I floated the idea on Slack and it sounded ok to @alloy.

From there I simply copied the signature of `runQuery` and scooped out the defaults to override them in the body of the function. Since you can't mutate a function param without being yelled at, I copied the `rootValue` into a local const and set the appropriate values.

Technically, there is a regression here where you cannot use an incorrect `userID`, but since that "feature" wasn't being used, I think it's ok - open to other thoughts on this though!!

There is also some prettier noise in the diff. I actually didn't even know this was here until I was writing this PR description. That means this happened in the commit hook that runs prettier and this is why I'm not a fan, but yolo!! 😆 