### PR TITLE
Run prettier against the entire codebase

### DIFF
--- a/schema/artist/maps/artist_meta_descriptions.js
+++ b/schema/artist/maps/artist_meta_descriptions.js
@@ -1,37 +1,69 @@
 // @flow
 /* eslint-disable */
 export default {
-  "ai-weiwei": "Find the best of Ai Weiwei art, including his sculptures, installations & more. Read about Ai Weiwei & browse his latest shows & exclusive articles on Artsy.",
-  "alec-monopoly": "Find the best Alec Monopoly art for sale, and explore his current shows, events & biography. Street artist Alec Monopoly takes ...",
-  "alex-katz": "Browse the best of Alex Katz, including his paintings, prints for sale, exclusive articles, upcoming shows & more. New York School painter Alex Katz developed his highly stylized aesthetic in reaction to...",
-  "alexander-calder": "American artist Alexander Calder changed the course of modern art by developing a method of bending and twisting wire to create three-dimensional “drawings in space.” ",
-  "andy-warhol": "Browse the best of Andy Warhol art, including paintings and artwork for sale (with prices), upcoming shows, and exclusive Andy Warhol articles on Artsy.",
-  banksy: "Find the best of Banksy, including his biography, art for sale, current shows, and exclusive Banksy articles on Artsy. Banksy creates street art with an irreverent wit ...",
-  "barbara-kruger": "Best known for laying aggressively directive slogans over black-and-white photographs that she finds in magazines, Barbara Kruger developed a visual language that was strongly influenced by her early work as...",
-  "blek-le-rat": "Browse the best of Blek le Rat, including his works & prints for sale, exclusive articles, and related artists. Blek Le Rat counts the infamous Banksy among his many admirers.",
-  "chuck-close": "Find the best of Chuck Close including his biography, paintings & prints for sale, shows and articles on Artsy. Chuck Close reinvented painting with his monumental portraits...",
-  "cindy-sherman": "Browse the best of Cindy Sherman, including artwork for sale, her latest shows & events, biography, and exclusive Cindy Sherman articles.",
-  "damien-hirst": "Browse the best of Damien Hirst, including his works & prints for sale, shows, collections, exclusive articles, and related artists on Artsy. Damien Hirst first came to public attention in London...",
-  "david-lachapelle": "Find the best of David LaChapelle, including photographs, prints for sale, his biography, current shows, and articles on Artsy. Discovered by Andy Warhol at the age of 17...",
-  "fernando-botero": "Find the best of Fernando Botero, including paintings, sculptures & prints for sale, his biography & more on Artsy. Drawing inspiration from a diverse array of influences, from ...",
-  "jean-michel-basquiat": "A poet, musician, and graffiti prodigy in late-1970s New York, Jean-Michel Basquiat had honed his signature painting style of obsessive scribbling, elusive symbols...",
-  "jeff-koons": "Welcome to the official Jeff Koons page on Artsy. Jeff Koons plays with ideas of taste, pleasure, celebrity, and commerce. “I believe in advertisement and media completely” ...",
-  "jenny-saville": "Browse Jenny Saville paintings, drawings, biographical information, and upcoming shows. Jenny Saville paints female nudes in extreme states of grotesque exaggeration...",
-  "jim-dine": "Find the best of Jim Dine - his artworks (including Hearts & Robes) & prints for sale, current shows & more. Emerging as a pioneer of New York’s Happenings of the 1960s, Jim Dine...",
-  "john-currin": "Browse the best of John Currin, including paintings & other artworks for sale, his biography, the latest shows & events, and exclusive John Currin articles.",
-  "kiki-kogelnik": "Browse the best of Kiki Kogelnik (Austrian, 1935-1997), including her artworks, current shows, biography, and exclusive Kiki Kogelnik articles.",
-  "kiki-smith": "Find the best of Kiki Smith art, including sculptures & prints for sale. Explore her biography, current shows, and articles on Artsy. Kiki Smith’s collections are meditations on life and spirituality...",
-  "lucien-smith": "Browse the best of Lucien Smith, including his Rain paintings series, upcoming shows, biography & exclusive Lucien Smith articles. Lucien Smith creates work that traverses a spectrum of styles...",
-  "paul-strand": "Paul Strand was one of the defining masters of early American modernist photography. In the early 20th century Strand began taking the photographs for which...",
-  retna: "Explore the bio, art, and shows of street, graffiti, and studio artist Retna, a.k.a. Marquis Lewis. Browse works for sale (including prints) and more.",
-  "richard-serra": "Browse the best of Richard Serra, including his artwork & prints for sale, upcoming shows, his biography, and exclusive Richard Serra articles,. The monumental sculptures of Richard Serra...",
-  "riusuke-fukahori": "Browse the best of Riusuke Fukahori, including artwork for sale, his latest shows & events, biography, and exclusive Riusuke Fukahori articles on Artsy.",
-  "sister-mary-corita-kent": "Browse the best of Sister Mary Corita Kent, including her biography, artwork for sale, exclusive Corita Kent articles & more. A contemporary of Andy Warhol and Ed Ruscha...",
-  "sol-lewitt": "Browse the best of Sol Lewitt, including his artwork & prints for sale, upcoming shows, biography & exclusive Sol Lewitt articles on Artsy. One of the leading exponents of Conceptual art, Sol LeWitt...",
-  "takashi-murakami": "Find the best of Takashi Murakami, including prints, paintings & sculptures. Read his biography & browse his latest shows & exclusive articles on Artsy.",
-  "tauba-auerbach": "Browse the best of Tauba Auerbach, including her artwork & prints for sale, upcoming shows, biography & exclusive Tauba Auerbach articles. Tauba Auerbach is best known for her Op art-inflected paintings that play with perceptions of space.",
-  "vik-muniz": "Browse the best of Vik Minuz, including his biography, artwork & prints for sale, upcoming shows, and exclusive Vik Muniz articles. Photographer and mixed-media artist Vik Muniz is best known for ...",
-  "william-eggleston": "Browse the best of William Eggleston photography, including artwork & prints for sale, upcoming shows, his biography, and exclusive William Eggleston articles.",
-  "zaria-forman": "Find the best collection of Zaria Forman art, including paintings & prints for sale. Explore her biography, current shows, and articles. Zaria Forman’s pristine, photorealist paintings...",
+  "ai-weiwei":
+    "Find the best of Ai Weiwei art, including his sculptures, installations & more. Read about Ai Weiwei & browse his latest shows & exclusive articles on Artsy.",
+  "alec-monopoly":
+    "Find the best Alec Monopoly art for sale, and explore his current shows, events & biography. Street artist Alec Monopoly takes ...",
+  "alex-katz":
+    "Browse the best of Alex Katz, including his paintings, prints for sale, exclusive articles, upcoming shows & more. New York School painter Alex Katz developed his highly stylized aesthetic in reaction to...",
+  "alexander-calder":
+    "American artist Alexander Calder changed the course of modern art by developing a method of bending and twisting wire to create three-dimensional “drawings in space.” ",
+  "andy-warhol":
+    "Browse the best of Andy Warhol art, including paintings and artwork for sale (with prices), upcoming shows, and exclusive Andy Warhol articles on Artsy.",
+  banksy:
+    "Find the best of Banksy, including his biography, art for sale, current shows, and exclusive Banksy articles on Artsy. Banksy creates street art with an irreverent wit ...",
+  "barbara-kruger":
+    "Best known for laying aggressively directive slogans over black-and-white photographs that she finds in magazines, Barbara Kruger developed a visual language that was strongly influenced by her early work as...",
+  "blek-le-rat":
+    "Browse the best of Blek le Rat, including his works & prints for sale, exclusive articles, and related artists. Blek Le Rat counts the infamous Banksy among his many admirers.",
+  "chuck-close":
+    "Find the best of Chuck Close including his biography, paintings & prints for sale, shows and articles on Artsy. Chuck Close reinvented painting with his monumental portraits...",
+  "cindy-sherman":
+    "Browse the best of Cindy Sherman, including artwork for sale, her latest shows & events, biography, and exclusive Cindy Sherman articles.",
+  "damien-hirst":
+    "Browse the best of Damien Hirst, including his works & prints for sale, shows, collections, exclusive articles, and related artists on Artsy. Damien Hirst first came to public attention in London...",
+  "david-lachapelle":
+    "Find the best of David LaChapelle, including photographs, prints for sale, his biography, current shows, and articles on Artsy. Discovered by Andy Warhol at the age of 17...",
+  "fernando-botero":
+    "Find the best of Fernando Botero, including paintings, sculptures & prints for sale, his biography & more on Artsy. Drawing inspiration from a diverse array of influences, from ...",
+  "jean-michel-basquiat":
+    "A poet, musician, and graffiti prodigy in late-1970s New York, Jean-Michel Basquiat had honed his signature painting style of obsessive scribbling, elusive symbols...",
+  "jeff-koons":
+    "Welcome to the official Jeff Koons page on Artsy. Jeff Koons plays with ideas of taste, pleasure, celebrity, and commerce. “I believe in advertisement and media completely” ...",
+  "jenny-saville":
+    "Browse Jenny Saville paintings, drawings, biographical information, and upcoming shows. Jenny Saville paints female nudes in extreme states of grotesque exaggeration...",
+  "jim-dine":
+    "Find the best of Jim Dine - his artworks (including Hearts & Robes) & prints for sale, current shows & more. Emerging as a pioneer of New York’s Happenings of the 1960s, Jim Dine...",
+  "john-currin":
+    "Browse the best of John Currin, including paintings & other artworks for sale, his biography, the latest shows & events, and exclusive John Currin articles.",
+  "kiki-kogelnik":
+    "Browse the best of Kiki Kogelnik (Austrian, 1935-1997), including her artworks, current shows, biography, and exclusive Kiki Kogelnik articles.",
+  "kiki-smith":
+    "Find the best of Kiki Smith art, including sculptures & prints for sale. Explore her biography, current shows, and articles on Artsy. Kiki Smith’s collections are meditations on life and spirituality...",
+  "lucien-smith":
+    "Browse the best of Lucien Smith, including his Rain paintings series, upcoming shows, biography & exclusive Lucien Smith articles. Lucien Smith creates work that traverses a spectrum of styles...",
+  "paul-strand":
+    "Paul Strand was one of the defining masters of early American modernist photography. In the early 20th century Strand began taking the photographs for which...",
+  retna:
+    "Explore the bio, art, and shows of street, graffiti, and studio artist Retna, a.k.a. Marquis Lewis. Browse works for sale (including prints) and more.",
+  "richard-serra":
+    "Browse the best of Richard Serra, including his artwork & prints for sale, upcoming shows, his biography, and exclusive Richard Serra articles,. The monumental sculptures of Richard Serra...",
+  "riusuke-fukahori":
+    "Browse the best of Riusuke Fukahori, including artwork for sale, his latest shows & events, biography, and exclusive Riusuke Fukahori articles on Artsy.",
+  "sister-mary-corita-kent":
+    "Browse the best of Sister Mary Corita Kent, including her biography, artwork for sale, exclusive Corita Kent articles & more. A contemporary of Andy Warhol and Ed Ruscha...",
+  "sol-lewitt":
+    "Browse the best of Sol Lewitt, including his artwork & prints for sale, upcoming shows, biography & exclusive Sol Lewitt articles on Artsy. One of the leading exponents of Conceptual art, Sol LeWitt...",
+  "takashi-murakami":
+    "Find the best of Takashi Murakami, including prints, paintings & sculptures. Read his biography & browse his latest shows & exclusive articles on Artsy.",
+  "tauba-auerbach":
+    "Browse the best of Tauba Auerbach, including her artwork & prints for sale, upcoming shows, biography & exclusive Tauba Auerbach articles. Tauba Auerbach is best known for her Op art-inflected paintings that play with perceptions of space.",
+  "vik-muniz":
+    "Browse the best of Vik Minuz, including his biography, artwork & prints for sale, upcoming shows, and exclusive Vik Muniz articles. Photographer and mixed-media artist Vik Muniz is best known for ...",
+  "william-eggleston":
+    "Browse the best of William Eggleston photography, including artwork & prints for sale, upcoming shows, his biography, and exclusive William Eggleston articles.",
+  "zaria-forman":
+    "Find the best collection of Zaria Forman art, including paintings & prints for sale. Explore her biography, current shows, and articles. Zaria Forman’s pristine, photorealist paintings...",
 }
 /* eslint-enable */

--- a/schema/artwork/utilities.js
+++ b/schema/artwork/utilities.js
@@ -27,10 +27,14 @@ export const embed = (website, { width, height, autoplay }) => {
   switch (host) {
     case "youtu.be":
     case "youtube.com":
-      return `<iframe width='${width}' height='${height}' src='https://www.youtube.com/embed/${id}?rel=0&amp;showinfo=0&amp;autoplay=${autoplay ? 1 : 0}' frameborder='0' allowfullscreen></iframe>` // eslint-disable-line max-len
+      return `<iframe width='${width}' height='${height}' src='https://www.youtube.com/embed/${id}?rel=0&amp;showinfo=0&amp;autoplay=${autoplay // eslint-disable-line max-len
+        ? 1
+        : 0}' frameborder='0' allowfullscreen></iframe>`
 
     case "vimeo.com":
-      return `<iframe width='${width}' height='${height}' src='//player.vimeo.com/video/${id}?color=ffffff&amp;autoplay=${autoplay ? 1 : 0}' frameborder='0' allowfullscreen></iframe>` // eslint-disable-line max-len
+      return `<iframe width='${width}' height='${height}' src='//player.vimeo.com/video/${id}?color=ffffff&amp;autoplay=${autoplay // eslint-disable-line max-len
+        ? 1
+        : 0}' frameborder='0' allowfullscreen></iframe>`
 
     default:
       return null

--- a/schema/filter_artworks.js
+++ b/schema/filter_artworks.js
@@ -214,9 +214,9 @@ function filterArtworks(primaryKey) {
         delete gravityOptions.medium
       }
 
-      return gravity
-        .with(accessToken)("filter/artworks", gravityOptions)
-        .then(response => assign({}, response, { options: gravityOptions }))
+      return gravity.with(accessToken)("filter/artworks", gravityOptions).then(response =>
+        assign({}, response, { options: gravityOptions })
+      )
     },
   }
 }

--- a/schema/home/fetch.js
+++ b/schema/home/fetch.js
@@ -18,10 +18,9 @@ export const featuredFair = () => {
 }
 
 export const activeSaleArtworks = accessToken => {
-  return gravity
-    .with(accessToken)("me/lot_standings", {
-      live: true,
-    })
+  return gravity.with(accessToken)("me/lot_standings", {
+    live: true,
+  })
     .then(results => {
       return results.map(result => result.sale_artwork)
     })
@@ -63,18 +62,16 @@ export const geneArtworks = (id, size) => {
 }
 
 export const relatedArtists = (accessToken, userID) => {
-  return gravity
-    .with(accessToken)(`user/${userID}/suggested/similar/artists`, {
-      exclude_artists_without_forsale_artworks: true,
-      exclude_followed_artists: true,
-      size: 20,
+  return gravity.with(accessToken)(`user/${userID}/suggested/similar/artists`, {
+    exclude_artists_without_forsale_artworks: true,
+    exclude_followed_artists: true,
+    size: 20,
+  }).then(results => {
+    const filteredResults = filter(results, result => {
+      return result.sim_artist.forsale_artworks_count > 0
     })
-    .then(results => {
-      const filteredResults = filter(results, result => {
-        return result.sim_artist.forsale_artworks_count > 0
-      })
-      return sampleSize(filteredResults, 2)
-    })
+    return sampleSize(filteredResults, 2)
+  })
 }
 
 export const popularArtists = () => {

--- a/schema/home/home_page_artist_module.js
+++ b/schema/home/home_page_artist_module.js
@@ -31,12 +31,10 @@ export const HomePageArtistModuleTypes = {
       if (!accessToken || !userID) {
         throw new Error("Both the X-USER-ID and X-ACCESS-TOKEN headers are required.")
       }
-      return gravity
-        .with(accessToken)(`user/${userID}/suggested/similar/artists`, {
-          exclude_followed_artists: true,
-          exclude_artists_without_forsale_artworks: true,
-        })
-        .then(results => map(results, "artist"))
+      return gravity.with(accessToken)(`user/${userID}/suggested/similar/artists`, {
+        exclude_followed_artists: true,
+        exclude_artists_without_forsale_artworks: true,
+      }).then(results => map(results, "artist"))
     },
   },
   TRENDING: {

--- a/schema/home/results.js
+++ b/schema/home/results.js
@@ -37,14 +37,12 @@ const moduleResults = {
     })
   },
   followed_galleries: ({ accessToken }) => {
-    return gravity
-      .with(accessToken)("me/follow/profiles/artworks", {
-        for_sale: true,
-        size: 60,
-      })
-      .then(artworks => {
-        return slice(shuffle(artworks), 0, RESULTS_SIZE)
-      })
+    return gravity.with(accessToken)("me/follow/profiles/artworks", {
+      for_sale: true,
+      size: 60,
+    }).then(artworks => {
+      return slice(shuffle(artworks), 0, RESULTS_SIZE)
+    })
   },
   genes: ({ accessToken, params: { id } }) => {
     if (id) {

--- a/schema/me/artwork_inquiries.js
+++ b/schema/me/artwork_inquiries.js
@@ -33,13 +33,14 @@ export default {
       inquireable_type: "artwork",
       total_count: true,
     }
-    return gravity
-      .with(accessToken, { headers: true })("me/inquiry_requests", gravityArgs)
-      .then(({ body, headers }) => {
-        return connectionFromArraySlice(body, options, {
-          arrayLength: headers["x-total-count"],
-          sliceStart: offset,
-        })
+    return gravity.with(accessToken, { headers: true })(
+      "me/inquiry_requests",
+      gravityArgs
+    ).then(({ body, headers }) => {
+      return connectionFromArraySlice(body, options, {
+        arrayLength: headers["x-total-count"],
+        sliceStart: offset,
       })
+    })
   },
 }

--- a/schema/me/bidder_positions.js
+++ b/schema/me/bidder_positions.js
@@ -21,48 +21,46 @@ export default {
     },
   },
   resolve: (root, { current, artwork_id, sale_id }, request, { rootValue: { accessToken } }) => {
-    return gravity
-      .with(accessToken)("me/bidder_positions", {
-        artwork_id,
-        sale_id,
-        sort: "-created_at",
-      })
-      .then(positions => {
-        if (!current || artwork_id) return positions
-        // When asking for "my current bids" we need to...
-        //
-        // 1. Find only positions that are "last placed" and
-        // "competing to win" for that user, which means finding the most
-        // recently created bidder positions per sale artwork where
-        // `position.highest_bid != null`.
-        //
-        const latestPositions = _(positions).chain().reject({ highest_bid: null }).uniqBy("sale_artwork_id").value()
-        //
-        // 2. Find only bidder positions in "open" auctions. This requires
-        // fetching all of that related data to be able to do:
-        // `bidder_position.sale_artwork.sale.auction_state != open`
-        //
+    return gravity.with(accessToken)("me/bidder_positions", {
+      artwork_id,
+      sale_id,
+      sort: "-created_at",
+    }).then(positions => {
+      if (!current || artwork_id) return positions
+      // When asking for "my current bids" we need to...
+      //
+      // 1. Find only positions that are "last placed" and
+      // "competing to win" for that user, which means finding the most
+      // recently created bidder positions per sale artwork where
+      // `position.highest_bid != null`.
+      //
+      const latestPositions = _(positions).chain().reject({ highest_bid: null }).uniqBy("sale_artwork_id").value()
+      //
+      // 2. Find only bidder positions in "open" auctions. This requires
+      // fetching all of that related data to be able to do:
+      // `bidder_position.sale_artwork.sale.auction_state != open`
+      //
+      return Promise.all(
+        _.map(latestPositions, position =>
+          gravity(`sale_artwork/${position.sale_artwork_id}`)
+            // For unpublished artworks
+            .catch(() => null)
+        )
+      ).then(saleArtworks => {
         return Promise.all(
-          _.map(latestPositions, position =>
-            gravity(`sale_artwork/${position.sale_artwork_id}`)
-              // For unpublished artworks
-              .catch(() => null)
-          )
-        ).then(saleArtworks => {
-          return Promise.all(
-            _.map(_.compact(saleArtworks), saleArtwork => gravity(`sale/${saleArtwork.sale_id}`))
-          ).then(sales => {
-            return _.filter(latestPositions, position => {
-              const saleArtwork = _.find(saleArtworks, {
-                _id: position.sale_artwork_id,
-              })
-              if (!saleArtwork) return false
-              const sale = _.find(sales, { id: saleArtwork.sale_id })
-              if (!sale) return false
-              return sale.auction_state === "open"
+          _.map(_.compact(saleArtworks), saleArtwork => gravity(`sale/${saleArtwork.sale_id}`))
+        ).then(sales => {
+          return _.filter(latestPositions, position => {
+            const saleArtwork = _.find(saleArtworks, {
+              _id: position.sale_artwork_id,
             })
+            if (!saleArtwork) return false
+            const sale = _.find(sales, { id: saleArtwork.sale_id })
+            if (!sale) return false
+            return sale.auction_state === "open"
           })
         })
       })
+    })
   },
 }

--- a/schema/me/conversation/index.js
+++ b/schema/me/conversation/index.js
@@ -190,7 +190,7 @@ export const ConversationFields = {
   last_message_open: {
     type: GraphQLString,
     description: "Timestamp if the user opened the last message, null in all other cases",
-    resolve: (conversation) => null, // eslint-disable-line no-unused-vars
+    resolve: conversation => null, // eslint-disable-line no-unused-vars
   },
 
   artworks: {

--- a/schema/me/conversation/update_mutation.js
+++ b/schema/me/conversation/update_mutation.js
@@ -24,20 +24,18 @@ export default mutationWithClientMutationId({
   },
   mutateAndGetPayload: ({ buyer_outcome, ids }, request, { rootValue: { accessToken } }) => {
     if (!accessToken) return null
-    return gravity
-      .with(accessToken, { method: "POST" })("me/token", {
-        client_application_id: IMPULSE_APPLICATION_ID,
+    return gravity.with(accessToken, { method: "POST" })("me/token", {
+      client_application_id: IMPULSE_APPLICATION_ID,
+    }).then(data => {
+      return Promise.all(
+        ids.map(id =>
+          impulse.with(data.token, { method: "PUT" })(`conversations/${id}`, {
+            buyer_outcome,
+          })
+        )
+      ).then(conversations => {
+        return conversations
       })
-      .then(data => {
-        return Promise.all(
-          ids.map(id =>
-            impulse.with(data.token, { method: "PUT" })(`conversations/${id}`, {
-              buyer_outcome,
-            })
-          )
-        ).then(conversations => {
-          return conversations
-        })
-      })
+    })
   },
 })

--- a/schema/me/conversations.js
+++ b/schema/me/conversations.js
@@ -16,23 +16,19 @@ export default {
 
     const impulseOptions = parseRelayOptions(options)
 
-    return gravity
-      .with(accessToken, { method: "POST" })("me/token", {
-        client_application_id: IMPULSE_APPLICATION_ID,
+    return gravity.with(accessToken, { method: "POST" })("me/token", {
+      client_application_id: IMPULSE_APPLICATION_ID,
+    }).then(data => {
+      return impulse.with(data.token)("conversations", {
+        ...impulseOptions,
+        from_id: userID,
+        from_type: "User",
+      }).then(({ conversations }) => {
+        return connectionFromArraySlice(conversations, options, {
+          arrayLength: conversations.length,
+          sliceStart: impulseOptions.offset,
+        })
       })
-      .then(data => {
-        return impulse
-          .with(data.token)("conversations", {
-            ...impulseOptions,
-            from_id: userID,
-            from_type: "User",
-          })
-          .then(({ conversations }) => {
-            return connectionFromArraySlice(conversations, options, {
-              arrayLength: conversations.length,
-              sliceStart: impulseOptions.offset,
-            })
-          })
-      })
+    })
   },
 }

--- a/schema/me/follow_artist.js
+++ b/schema/me/follow_artist.js
@@ -30,10 +30,8 @@ export default mutationWithClientMutationId({
     const saveMethod = unfollow ? "DELETE" : "POST"
     const options = unfollow ? {} : { artist_id }
     const followPath = unfollow ? `/${artist_id}` : ""
-    return gravity
-      .with(accessToken, {
-        method: saveMethod,
-      })(`/me/follow/artist${followPath}`, options)
-      .then(() => ({ artist_id }))
+    return gravity.with(accessToken, {
+      method: saveMethod,
+    })(`/me/follow/artist${followPath}`, options).then(() => ({ artist_id }))
   },
 })

--- a/schema/me/lot_standings.js
+++ b/schema/me/lot_standings.js
@@ -24,15 +24,13 @@ export default {
     },
   },
   resolve: (root, { active_positions, artwork_id, live, sale_id }, request, { rootValue: { accessToken } }) => {
-    return gravity
-      .with(accessToken)("me/lot_standings", {
-        active_positions,
-        artwork_id,
-        live,
-        sale_id,
-      })
-      .then(lotStandings => {
-        return lotStandings
-      })
+    return gravity.with(accessToken)("me/lot_standings", {
+      active_positions,
+      artwork_id,
+      live,
+      sale_id,
+    }).then(lotStandings => {
+      return lotStandings
+    })
   },
 }

--- a/schema/me/save_artwork.js
+++ b/schema/me/save_artwork.js
@@ -23,12 +23,10 @@ export default mutationWithClientMutationId({
   mutateAndGetPayload: ({ artwork_id, remove }, request, { rootValue: { accessToken, userID } }) => {
     if (!accessToken) return new Error("You need to be signed in to perform this action")
     const saveMethod = remove ? "DELETE" : "POST"
-    return gravity
-      .with(accessToken, {
-        method: saveMethod,
-      })(`/collection/saved-artwork/artwork/${artwork_id}`, {
-        user_id: userID,
-      })
-      .then(() => ({ artwork_id }))
+    return gravity.with(accessToken, {
+      method: saveMethod,
+    })(`/collection/saved-artwork/artwork/${artwork_id}`, {
+      user_id: userID,
+    }).then(() => ({ artwork_id }))
   },
 })

--- a/schema/partner.js
+++ b/schema/partner.js
@@ -99,7 +99,7 @@ const PartnerType = new GraphQLObjectType({
       href: {
         type: GraphQLString,
         resolve: ({ type, default_profile_id }) =>
-          (type === "Auction" ? `/auction/${default_profile_id}` : `/${default_profile_id}`),
+          type === "Auction" ? `/auction/${default_profile_id}` : `/${default_profile_id}`,
       },
       initials: initials("name"),
       is_default_profile_public: {

--- a/schema/types/formatted_number.js
+++ b/schema/types/formatted_number.js
@@ -4,7 +4,8 @@ import { Kind } from "graphql/language"
 
 const FormattedNumber = new GraphQLScalarType({
   name: "FormattedNumber",
-  description: "The `FormattedNumber` type represents a number that can optionally be returned" +
+  description:
+    "The `FormattedNumber` type represents a number that can optionally be returned" +
     "as a formatted String. It does not try to coerce the type.",
   serialize: x => x,
   parseValue: x => x,

--- a/test/schema/artist/carousel.js
+++ b/test/schema/artist/carousel.js
@@ -79,7 +79,8 @@ describe("ArtistCarousel type", () => {
               resized: {
                 height: 199,
                 width: 300,
-                url: "https://gemini.cloudfront.test/?resize_to=fit&width=300&height=199&quality=95&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg", // eslint-disable-line
+                url:
+                  "https://gemini.cloudfront.test/?resize_to=fit&width=300&height=199&quality=95&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg", // eslint-disable-line
               },
             },
           ],

--- a/test/schema/artwork/index.js
+++ b/test/schema/artwork/index.js
@@ -374,7 +374,8 @@ describe("Artwork type", () => {
         expect(data).toEqual({
           artwork: {
             id: "richard-prince-untitled-portrait",
-            contact_message: "Hi, I’m interested in similar works by this artist. Could you please let me know if you have anything available?", // eslint-disable-line max-len
+            contact_message:
+              "Hi, I’m interested in similar works by this artist. Could you please let me know if you have anything available?", // eslint-disable-line max-len
           },
         })
       })
@@ -385,7 +386,8 @@ describe("Artwork type", () => {
         expect(data).toEqual({
           artwork: {
             id: "richard-prince-untitled-portrait",
-            contact_message: "Hi, I’m interested in purchasing this work. Could you please provide more information about the piece?", // eslint-disable-line max-len
+            contact_message:
+              "Hi, I’m interested in purchasing this work. Could you please provide more information about the piece?", // eslint-disable-line max-len
           },
         })
       })

--- a/test/schema/image/cropped.js
+++ b/test/schema/image/cropped.js
@@ -12,7 +12,8 @@ describe("Image", () => {
       expect(croppedImageUrl(image, { width: 500, height: 500 })).toEqual({
         width: 500,
         height: 500,
-        url: "https://gemini.cloudfront.test/?resize_to=fill&width=500&height=500&quality=95&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg", // eslint-disable-line
+        url:
+          "https://gemini.cloudfront.test/?resize_to=fill&width=500&height=500&quality=95&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg", // eslint-disable-line
       })
     })
 
@@ -21,7 +22,8 @@ describe("Image", () => {
       expect(croppedImageUrl(bareImageUrl, { width: 500, height: 500 })).toEqual({
         width: 500,
         height: 500,
-        url: "https://gemini.cloudfront.test/?resize_to=fill&width=500&height=500&quality=95&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Fcat.jpg", // eslint-disable-line
+        url:
+          "https://gemini.cloudfront.test/?resize_to=fill&width=500&height=500&quality=95&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Fcat.jpg", // eslint-disable-line
       })
     })
   })

--- a/test/schema/image/resized.js
+++ b/test/schema/image/resized.js
@@ -14,7 +14,8 @@ describe("Image", () => {
         factor: 0.14285714285714285,
         height: 333,
         width: 500,
-        url: "https://gemini.cloudfront.test/?resize_to=fit&width=500&height=333&quality=95&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg", // eslint-disable-line
+        url:
+          "https://gemini.cloudfront.test/?resize_to=fit&width=500&height=333&quality=95&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg", // eslint-disable-line
       })
     })
 
@@ -23,7 +24,8 @@ describe("Image", () => {
         factor: 0.14285714285714285,
         height: 333,
         width: 500,
-        url: "https://gemini.cloudfront.test/?resize_to=fit&width=500&height=333&quality=95&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg", // eslint-disable-line
+        url:
+          "https://gemini.cloudfront.test/?resize_to=fit&width=500&height=333&quality=95&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg", // eslint-disable-line
       })
     })
 
@@ -43,7 +45,8 @@ describe("Image", () => {
         factor: Infinity,
         width: null,
         height: null,
-        url: "https://gemini.cloudfront.test/?resize_to=fit&width=500&height=500&quality=95&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg", // eslint-disable-line
+        url:
+          "https://gemini.cloudfront.test/?resize_to=fit&width=500&height=500&quality=95&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg", // eslint-disable-line
       })
     })
   })


### PR DESCRIPTION
I thought this was going to be a bloody mess, but instead it just worked! Here was the command I ran:

```
yarn prettier -- --write --trailing-comma es5 --print-width 120 --no-semi lib/**/*.js schema/**/*.js test/**/*.js
```

Then there was a little issue with how prettier dealt with some goofy lines in `schema/artwork/utilities.js`, but that was easy to fix - I just moved the eslint disables back to where they belonged.

Other than that linter is happy, prettier is happy and tests are green! 🤗 