### PR TITLE
Put popular_artists module first for logged-out users

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -17,7 +17,7 @@ printf "[1/${STEPS}]  checking dependencies"
 actual_node_version=$(node --version)
 expected_node_version=$(cat .nvmrc)
 
-if ! command -v nvm > /dev/null; then
+if [ -d "~/.nvm" ]; then
   printf "${CLEAR_LINE}${RED}  You must install nvm before setup can continue${NO_COLOR}\n"
   printf "    You should read this:\n"
   printf "      https://github.com/creationix/nvm#installation\n"

--- a/schema/home/logged_out_modules.js
+++ b/schema/home/logged_out_modules.js
@@ -1,16 +1,16 @@
 export default (auction, fair) => {
   const modules = [
     {
+      key: "popular_artists",
+      display: true,
+    },
+    {
       key: "current_fairs",
       display: fair ? true : false,
     },
     {
       key: "live_auctions",
       display: auction ? true : false,
-    },
-    {
-      key: "popular_artists",
-      display: true,
     },
   ]
   return modules


### PR DESCRIPTION
I also added a fix for the setup script's `nvm` check.

Related issue: https://github.com/artsy/collector-experience/issues/362