### PR TITLE
[HomePage] Pass `fairsLoader` into fetch function.

### DIFF
--- a/schema/home/fetch.js
+++ b/schema/home/fetch.js
@@ -3,7 +3,7 @@ import delta from "lib/loaders/delta"
 import { clone, first, forEach, map, sampleSize, shuffle, slice, filter, sortBy } from "lodash"
 import blacklist from "lib/artist_blacklist"
 
-export const featuredFair = (root, options, request, { rootValue: { fairsLoader } }) => {
+export const featuredFair = fairsLoader => {
   return fairsLoader({
     size: 5,
     active: true,

--- a/schema/home/home_page_artwork_modules.js
+++ b/schema/home/home_page_artwork_modules.js
@@ -105,7 +105,12 @@ const HomePageArtworkModules = {
       description: "The preferred order of modules, defaults to order returned by Gravity",
     },
   },
-  resolve: (root, { max_rails, max_followed_gene_rails, order }, request, { rootValue: { accessToken, userID } }) => {
+  resolve: (
+    root,
+    { max_rails, max_followed_gene_rails, order },
+    request,
+    { rootValue: { accessToken, userID, fairsLoader } }
+  ) => {
     // If user is logged in, get their specific modules
     if (accessToken) {
       return gravity.with(accessToken)("me/modules").then(response => {
@@ -163,7 +168,7 @@ const HomePageArtworkModules = {
     }
 
     // Otherwise, get the generic set of modules
-    return Promise.all([featuredAuction(), featuredFair()]).then(([auction, fair]) => {
+    return Promise.all([featuredAuction(), featuredFair(fairsLoader)]).then(([auction, fair]) => {
       const modules = loggedOutModules(auction, fair)
       return filterModules(modules, max_rails)
     })


### PR DESCRIPTION
The functions in the `fetch` module are not GraphQL resolvers and thus
won’t get the same arguments passed in by default, especially not seeing
as these functions are invoked by our own code, e.g. `featuredFair()`.

/cc @jonallured My bad for missing this during review 🙈 