### PR TITLE
@alloy => Fix some issues in calling certain loaders

### DIFF
--- a/schema/artist/carousel.js
+++ b/schema/artist/carousel.js
@@ -22,7 +22,7 @@ const ArtistCarousel: GraphQLFieldConfig<ArtistCarouselType, *> = {
     const { artistArtworksLoader, partnerShowImagesLoader, relatedShowsLoader } = (resolver.rootValue: any)
 
     return Promise.all([
-      relatedShowsLoader(id, {
+      relatedShowsLoader({
         artist_id: id,
         sort: "-end_at",
         displayable: true,

--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -72,7 +72,6 @@ const ShowField = {
   },
   resolve: ({ id }, options, request, { rootValue: { relatedShowsLoader } }) => {
     return relatedShowsLoader(
-      id,
       defaults(options, {
         artist_id: id,
         sort: "-end_at",
@@ -102,7 +101,6 @@ export const ArtistType = new GraphQLObjectType({
         type: new GraphQLList(Article.type),
         resolve: ({ _id }, options, request, { rootValue: { articlesLoader } }) =>
           articlesLoader(
-            _id,
             defaults(options, {
               artist_id: _id,
               published: true,
@@ -123,7 +121,6 @@ export const ArtistType = new GraphQLObjectType({
         },
         resolve: ({ id }, options, request, { rootValue: { relatedMainArtistsLoader } }) =>
           relatedMainArtistsLoader(
-            id,
             defaults(options, {
               artist: [id],
             })
@@ -190,7 +187,7 @@ export const ArtistType = new GraphQLObjectType({
         type: Article.type,
         description: "The Artist biography article written by Artsy",
         resolve: ({ _id }, options, request, { rootValue: { articlesLoader } }) =>
-          articlesLoader(_id, {
+          articlesLoader({
             published: true,
             biography_for_artist_id: _id,
             limit: 1,
@@ -272,7 +269,6 @@ export const ArtistType = new GraphQLObjectType({
         },
         resolve: ({ id }, options, request, { rootValue: { relatedContemporaryArtistsLoader } }) =>
           relatedContemporaryArtistsLoader(
-            id,
             defaults(options, {
               artist: [id],
             })
@@ -321,7 +317,7 @@ export const ArtistType = new GraphQLObjectType({
         type: new GraphQLList(Show.type),
         description: "Custom-sorted list of shows for an artist, in order of significance.",
         resolve: ({ id }, options, request, { rootValue: { relatedShowsLoader } }) => {
-          return relatedShowsLoader(id, {
+          return relatedShowsLoader({
             artist_id: id,
             sort: "-relevance,-start_at",
             is_reference: true,
@@ -449,7 +445,6 @@ export const ArtistType = new GraphQLObjectType({
         },
         resolve: ({ id }, options, request, { rootValue: { relatedSalesLoader } }) =>
           relatedSalesLoader(
-            id,
             defaults(options, {
               artist_id: id,
               sort: "timely_at,name",

--- a/schema/artist/statuses.js
+++ b/schema/artist/statuses.js
@@ -17,7 +17,7 @@ const ArtistStatusesType = new GraphQLObjectType({
     articles: {
       type: GraphQLBoolean,
       resolve: ({ _id }, options, request, { rootValue: { articlesLoader } }) =>
-        articlesLoader(_id, {
+        articlesLoader({
           artist_id: _id,
           published: true,
           limit: 0,
@@ -37,7 +37,7 @@ const ArtistStatusesType = new GraphQLObjectType({
     biography: {
       type: GraphQLBoolean,
       resolve: ({ _id }, options, request, { rootValue: { articlesLoader } }) =>
-        articlesLoader(_id, {
+        articlesLoader({
           published: true,
           biography_for_artist_id: _id,
           limit: 0,

--- a/schema/artwork/context.js
+++ b/schema/artwork/context.js
@@ -42,18 +42,18 @@ export default {
   ) => {
     let sale_promise = Promise.resolve(null)
     if (sale_ids && sale_ids.length > 0) {
-      sale_promise = salesLoader(id, { id: sale_ids }).then(first).then(sale => {
+      sale_promise = salesLoader({ id: sale_ids }).then(first).then(sale => {
         if (!sale) return null
         return assign({ context_type: sale.is_auction ? "Auction" : "Sale" }, sale)
       })
     }
 
-    const fair_promise = relatedFairsLoader(id, { artwork: [id], size: 1 }).then(first).then(fair => {
+    const fair_promise = relatedFairsLoader({ artwork: [id], size: 1 }).then(first).then(fair => {
       if (!fair || (fair && !fair.has_full_feature)) return null
       return assign({ context_type: "Fair" }, fair)
     })
 
-    const show_promise = relatedShowsLoader(id, {
+    const show_promise = relatedShowsLoader({
       artwork: [id],
       size: 1,
       active: false,

--- a/schema/artwork/index.js
+++ b/schema/artwork/index.js
@@ -173,7 +173,7 @@ export const artworkFields = () => {
     fair: {
       type: Fair.type,
       resolve: ({ id }, options, request, { rootValue: { relatedFairsLoader } }) => {
-        return relatedFairsLoader(id, { artwork: [id], size: 1 }).then(_.first)
+        return relatedFairsLoader({ artwork: [id], size: 1 }).then(_.first)
       },
     },
     highlights: {
@@ -181,8 +181,8 @@ export const artworkFields = () => {
       description: "Returns the highlighted shows and articles",
       resolve: ({ id, _id }, options, request, { rootValue: { relatedShowsLoader, articlesLoader } }) =>
         Promise.all([
-          relatedShowsLoader(id, { artwork: [id], size: 1, at_a_fair: false }),
-          articlesLoader(_id, {
+          relatedShowsLoader({ artwork: [id], size: 1, at_a_fair: false }),
+          articlesLoader({
             artwork_id: _id,
             published: true,
             limit: 1,
@@ -252,7 +252,7 @@ export const artworkFields = () => {
       description: "When in an auction, can the work be bought immediately",
       resolve: ({ id, acquireable, sale_ids }, options, request, { rootValue: { salesLoader } }) => {
         if (sale_ids && sale_ids.length > 0 && acquireable) {
-          return salesLoader(id, {
+          return salesLoader({
             id: sale_ids,
             is_auction: true,
             live: true,


### PR DESCRIPTION
Some of the uses of loaders where the API path didn't need to be dynamically generated (only params passed thru), were being used as if it were the other style (dynamically generated from id's).