### PR TITLE
Revert even more loader work

### DIFF
--- a/schema/home/context.js
+++ b/schema/home/context.js
@@ -82,8 +82,8 @@ export const moduleContext = {
       return assign({}, fair, { context_type: "Fair" })
     })
   },
-  followed_artist: ({ params }, options, request, { rootValue: { artistLoader } }) => {
-    return artistLoader(params.followed_artist_id).then(artist => {
+  followed_artist: ({ params }) => {
+    return gravity(`artist/${params.followed_artist_id}`).then(artist => {
       return assign(
         {},
         {
@@ -93,10 +93,10 @@ export const moduleContext = {
       )
     })
   },
-  related_artists: ({ params }, options, request, { rootValue: { artistLoader } }) => {
+  related_artists: ({ params }) => {
     return Promise.all([
-      artistLoader(params.related_artist_id),
-      artistLoader(params.followed_artist_id),
+      gravity(`artist/${params.related_artist_id}`),
+      gravity(`artist/${params.followed_artist_id}`),
     ]).then(([related_artist, follow_artist]) => {
       return assign(
         {},

--- a/schema/home/title.js
+++ b/schema/home/title.js
@@ -1,4 +1,5 @@
 import { featuredAuction, featuredFair, featuredGene } from "./fetch"
+import gravity from "lib/loaders/legacy/gravity"
 import { GraphQLString } from "graphql"
 
 const moduleTitle = {
@@ -10,8 +11,8 @@ const moduleTitle = {
       }
     })
   },
-  followed_artist: ({ params }, options, request, { rootValue: { artistLoader } }) => {
-    return artistLoader(params.followed_artist_id).then(artist => {
+  followed_artist: ({ params }) => {
+    return gravity(`artist/${params.followed_artist_id}`).then(artist => {
       return `Works by ${artist.name}`
     })
   },
@@ -40,8 +41,8 @@ const moduleTitle = {
   },
   popular_artists: () => "Works by Popular Artists",
   recommended_works: () => "Recommended Works for You",
-  related_artists: ({ params }, options, request, { rootValue: { artistLoader } }) => {
-    return artistLoader(params.related_artist_id).then(artist => {
+  related_artists: ({ params }) => {
+    return gravity(`artist/${params.related_artist_id}`).then(artist => {
       return `Works by ${artist.name}`
     })
   },


### PR DESCRIPTION
During team swap, I did some incorrect work in #707 that I thought was safely reverted in #714, but I was wrong. There were still other places where we had broken functions and this was only caught after deployment to production.

This commit should revert the rest of the broken changes from #707 and fix the bugs seen in production.