### PR TITLE
[Artist] Guard against empty ID string.

### DIFF
--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -476,6 +476,9 @@ const Artist: GraphQLFieldConfig<ArtistType, *> = {
     },
   },
   resolve: (root, { id }, request, resolver) => {
+    if (id.length === 0) {
+      return null
+    }
     const { artistLoader } = (resolver.rootValue: any)
     return artistLoader(id)
   },

--- a/test/schema/artist/index.js
+++ b/test/schema/artist/index.js
@@ -40,6 +40,12 @@ describe("Artist type", () => {
     Artist.__ResetDependency__("positron")
   })
 
+  it("returns null for an empty ID string", () => {
+    return runQuery(`{ artist(id: "") { id } }`, rootValue).then(data => {
+      expect(data.artist).toBe(null)
+    })
+  })
+
   it("fetches an artist by ID", () => {
     return runQuery(`{ artist(id: "foo-bar") { id, name } }`, rootValue).then(data => {
       expect(data.artist.id).toBe("foo-bar")


### PR DESCRIPTION
This specific guard is needed because from Emission we conditionally
fetch a ‘selected artist’ for the Works for You view, but using an extra
boolean for this proved problematic because it meant that the ID
variable would be unused and GraphQL would complain about that. Instead
we always send the‘selected artist’ request, but with an empty string
when we don’t actually want it.