### PR TITLE
[sendMessageMutation] Add missing data to optimistic response.

### DIFF
--- a/schema/me/conversation/send_message_mutation.js
+++ b/schema/me/conversation/send_message_mutation.js
@@ -58,6 +58,7 @@ export default mutationWithClientMutationId({
             from_email_address: from,
             from_id: userID,
             raw_text: body_text,
+            body: body_text,
             created_at: new Date().toISOString(),
             attachments: [],
             // This addition is only for MP so it can determine if the message was from the current user.

--- a/test/schema/me/conversation/__snapshots__/message.js.snap
+++ b/test/schema/me/conversation/__snapshots__/message.js.snap
@@ -26,6 +26,10 @@ Object {
         Object {
           "node": Object {
             "body": "I'm a cat",
+            "from": Object {
+              "email": "fancy_german_person@posteo.de",
+              "name": "Percy Z",
+            },
             "id": "222",
           },
         },

--- a/test/schema/me/conversation/__snapshots__/send_message_mutation.js.snap
+++ b/test/schema/me/conversation/__snapshots__/send_message_mutation.js.snap
@@ -8,6 +8,11 @@ Object {
   "messageEdge": Object {
     "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
     "node": Object {
+      "body": "Sehr schön!",
+      "from": Object {
+        "email": "pio-dog@example.com",
+        "name": null,
+      },
       "id": "222",
     },
   },

--- a/test/schema/me/conversation/message.js
+++ b/test/schema/me/conversation/message.js
@@ -65,6 +65,10 @@ describe("Me", () => {
                     node {
                       body
                       id
+                      from {
+                        email
+                        name
+                      }
                     }
                   }
                 }

--- a/test/schema/me/conversation/send_message_mutation.js
+++ b/test/schema/me/conversation/send_message_mutation.js
@@ -7,7 +7,7 @@ describe("SendConversationMessageMutation", () => {
         sendConversationMessage(
           input: {
             id: "623",
-            from:"pio@dog.com",
+            from: "pio-dog@example.com",
             body_text: "Sehr schön!"
             reply_to_message_id: "221"
           }
@@ -19,6 +19,11 @@ describe("SendConversationMessageMutation", () => {
               cursor
               node {
                 id
+                body
+                from {
+                  email
+                  name
+                }
               }
             }
           }


### PR DESCRIPTION
We use the `body` field nowadays in Emission, not `raw_text` anymore, so added that and faffed a bit with test coverage.