### PR TITLE
@ashkan18 => Use original_text if available for the body

### DIFF
--- a/schema/me/conversation/message.js
+++ b/schema/me/conversation/message.js
@@ -77,10 +77,13 @@ export const MessageType = new GraphQLObjectType({
     },
 
     body: {
-      description: "Text which has been parsed/sanitized of quoted replies (among other things).",
+      description: "Unaltered text if possible, otherwise `body`: a parsed/sanitized version from Sendgrid.",
       type: GraphQLString,
-      resolve: ({ body }) => {
-        return body && body.split("\n\nAbout this collector")[0]
+      resolve: ({ body, original_text }) => {
+        if (original_text) {
+          return original_text
+        }
+        return body
       },
     },
 

--- a/test/schema/me/conversation/__snapshots__/message.js.snap
+++ b/test/schema/me/conversation/__snapshots__/message.js.snap
@@ -25,7 +25,7 @@ Object {
       "edges": Array [
         Object {
           "node": Object {
-            "body": "I'm a cat",
+            "body": "I'm a cat oh yea!",
             "from": Object {
               "email": "fancy_german_person@posteo.de",
               "name": "Percy Z",

--- a/test/schema/me/conversation/message.js
+++ b/test/schema/me/conversation/message.js
@@ -16,17 +16,7 @@ describe("Me", () => {
             message_details: [
               {
                 id: "222",
-                raw_text:
-                  "I'm a cat\n\nAbout this collector:\n\nSarah Scott is based in NY, NY and has been an Artsy member" +
-                  "since February 2015.\n\nVIEW FULL INQUIRY ( https://cms-staging.artsy.net/conversations/70 )\n\n" +
-                  "( https://staging.artsy.net/artwork/rafael-rozendaal-shadow-object-16-07-03?utm_campaign=20170822" +
-                  "&utm_medium=email&utm_source=inquiry-request )\n\nRafaël Rozendaal " +
-                  "( https://staging.artsy.net/artist/rafael-rozendaal?utm_campaign=20170822&utm_medium=email&utm_sou" +
-                  "rce=inquiry-request )\n\nShadow Object 16 07 03 ( https://staging.artsy.net/artwork/rafael-rozend" +
-                  "al-shadow-object-16-07-03?utm_campaign=20170822&utm_medium=email&utm_source=inquiry-request ), " +
-                  "2016\n\nSteel\n\n19 7/10 × 19 7/10 in\n\n50 × 50 cm\n\nContact For Price\n\nUnique\n\nThis is an " +
-                  "inquiry sent through Artsy regarding interest in the work “Shadow Object 16 07 03” (2016) by Rafaë" +
-                  "l Rozendaal. Please respond to this inquiry by replying directly to this email.",
+                raw_text: "I'm a cat",
                 from_email_address: "fancy_german_person@posteo.de",
                 from_id: null,
                 attachments: [],
@@ -34,17 +24,8 @@ describe("Me", () => {
                   lewitt_invoice_id: "420i",
                 },
                 from: `"Percy Z" <percy@cat.com>`,
-                body:
-                  "I'm a cat\n\nAbout this collector:\n\nSarah Scott is based in NY, NY and has been an Artsy member" +
-                  "since February 2015.\n\nVIEW FULL INQUIRY ( https://cms-staging.artsy.net/conversations/70 )\n\n" +
-                  "( https://staging.artsy.net/artwork/rafael-rozendaal-shadow-object-16-07-03?utm_campaign=20170822" +
-                  "&utm_medium=email&utm_source=inquiry-request )\n\nRafaël Rozendaal " +
-                  "( https://staging.artsy.net/artist/rafael-rozendaal?utm_campaign=20170822&utm_medium=email&utm_sou" +
-                  "rce=inquiry-request )\n\nShadow Object 16 07 03 ( https://staging.artsy.net/artwork/rafael-rozend" +
-                  "al-shadow-object-16-07-03?utm_campaign=20170822&utm_medium=email&utm_source=inquiry-request ), " +
-                  "2016\n\nSteel\n\n19 7/10 × 19 7/10 in\n\n50 × 50 cm\n\nContact For Price\n\nUnique\n\nThis is an " +
-                  "inquiry sent through Artsy regarding interest in the work “Shadow Object 16 07 03” (2016) by Rafaë" +
-                  "l Rozendaal. Please respond to this inquiry by replying directly to this email.",
+                original_text: "I'm a cat oh yea!",
+                body: "I'm a cat",
               },
             ],
           }),


### PR DESCRIPTION
Once https://github.com/artsy/impulse/pull/348 is deployed, certain messages will have this available, and so we can return it, instead of relying on the `body` fallback.