### PR TITLE
@dblock => Intercepts errors from Gravity

### DIFF
--- a/schema/collection.js
+++ b/schema/collection.js
@@ -46,9 +46,11 @@ export const CollectionType = new GraphQLObjectType({
               sliceStart: gravityOptions.offset,
             })
           })
-          .catch(() => {
+          .catch(e => {
+            console.log("Bypassing Gravity error: ", e)
             // For some users with no favourites, Gravity produces an error of "Collection Not Found".
             // This can cause a crash on Eigen 3.2.4, so we will intercept the error and return an empty list.
+            // FIXME: This can be removed once use of 3.2.4 drops to zero.
             return connectionFromArray([], options, {
               arrayLength: 0,
               sliceStart: 0,

--- a/test/schema/__snapshots__/collection.js.snap
+++ b/test/schema/__snapshots__/collection.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Collections Handles getting collection metadata ignores errors from gravity. 1`] = `
+Object {
+  "collection": Object {
+    "artworks_connection": Object {
+      "edges": Array [],
+    },
+  },
+}
+`;
+
 exports[`Collections Handles getting collection metadata returns artworks for a collection 1`] = `
 Object {
   "collection": Object {

--- a/test/schema/collection.js
+++ b/test/schema/collection.js
@@ -76,5 +76,35 @@ describe("Collections", () => {
         expect(data).toMatchSnapshot()
       })
     })
+
+    it("ignores errors from gravity.", () => {
+      gravity
+        .withArgs("collection/saved-artwork/artworks", {
+          size: 10,
+          offset: 0,
+          private: false,
+          total_count: true,
+          user_id: "user-42",
+        })
+        .returns(Promise.reject(new Error("Collection Not Found")))
+
+      const query = `
+                {
+                  collection(id: "saved-artwork") {
+                    artworks_connection(first:10) {
+                      edges {
+                        node {
+                          id
+                          title
+                        }
+                      }
+                    }
+                  }
+                }
+              `
+      return runAuthenticatedQuery(query).then(data => {
+        expect(data).toMatchSnapshot()
+      })
+    })
   })
 })


### PR DESCRIPTION
Eigen 3.2.4 doesn't handle GraphQL errors properly (retrospective forthcoming). To provide an immediate fix, I've modified metaphysics.

The problem is, for some users (and all newly created users) requesting their favourites returns an error from Gravity. This PR catches the error and returns an empty list of results instead. Note this catches *all* errors from that specific endpoint, but I don't believe any services beside eigen rely on this specific part of metaphysics. I can submit a more nuanced error-catching PR later, after the bug has been fixed.