### PR TITLE
Add fix for Relay/Gravity count discrepencies.

### DIFF
--- a/schema/collection.js
+++ b/schema/collection.js
@@ -50,6 +50,7 @@ export const CollectionType = new GraphQLObjectType({
             // returned in the X-Total-Count header includes unpublished artworks, even though only
             // published artworks are returned. This can lead to a situation where hasNextPage is true
             // but endCursor is null, violating Relay norms and causing serious problems for Eigen.
+            // FIXME: Remove the following line once Gravity PR 11240 has been deployed to production.
             connection.pageInfo.hasNextPage =
               connection.pageInfo.endCursor === null ? false : connection.pageInfo.hasNextPage
             return connection

--- a/test/schema/__snapshots__/collection.js.snap
+++ b/test/schema/__snapshots__/collection.js.snap
@@ -10,6 +10,19 @@ Object {
 }
 `;
 
+exports[`Collections Handles getting collection metadata ignores incorrect counts from gravity 1`] = `
+Object {
+  "collection": Object {
+    "artworks_connection": Object {
+      "pageInfo": Object {
+        "endCursor": null,
+        "hasNextPage": false,
+      },
+    },
+  },
+}
+`;
+
 exports[`Collections Handles getting collection metadata returns artworks for a collection 1`] = `
 Object {
   "collection": Object {

--- a/test/schema/collection.js
+++ b/test/schema/collection.js
@@ -106,5 +106,32 @@ describe("Collections", () => {
         expect(data).toMatchSnapshot()
       })
     })
+
+    it("ignores incorrect counts from gravity", () => {
+      gravity
+        .withArgs("collection/saved-artwork/artworks", {
+          size: 10,
+          offset: 0,
+          private: false,
+          total_count: true,
+          user_id: "user-42",
+        })
+        .returns(Promise.resolve({ body: [], headers: { "x-total-count": 10 } }))
+      const query = `
+                {
+                  collection(id: "saved-artwork") {
+                    artworks_connection(first:10) {
+                      pageInfo {
+                        hasNextPage
+                        endCursor
+                      }
+                    }
+                  }
+                }
+              `
+      return runAuthenticatedQuery(query).then(data => {
+        expect(data).toMatchSnapshot()
+      })
+    })
   })
 })


### PR DESCRIPTION
Gravity has a bug (see [this PR](https://github.com/artsy/gravity/pull/11240)) where total counts being returned for user favourites include unpublished artworks. This count discrepancy causes Relay to return `hasNextPage` as `true` while `endCursor` is `null`, which causes serious problems for users on Eigen (see [this Sentry report](https://sentry.io/artsynet/eigen/issues/347342766/events/7196937891/)). 

This pull requests overrides the `pageInfo.hasNextPage` value returned from Relay to set it to false if the end cursor is missing. I've tested locally on Eigen to verify the fix works, and have added test coverage.

Serious props to @orta for his help reproducing this bug. 

Also removes `console.log` statements I accidentally'd last night.