### PR TITLE
Adds ability to sort conversation messages

### DIFF
--- a/schema/me/conversation/index.js
+++ b/schema/me/conversation/index.js
@@ -272,7 +272,17 @@ export const ConversationFields = {
   messages: {
     type: MessageConnection,
     description: "A connection for all messages in a single conversation",
-    args: pageable(),
+    args: pageable({
+      sort: {
+        type: new GraphQLEnumType({
+          name: "sort",
+          values: {
+            DESC: { value: "desc" },
+            ASC: { value: "asc" },
+          },
+        }),
+      },
+    }),
     resolve: ({ id, from_email }, options, req, { rootValue: { conversationMessagesLoader } }) => {
       const { page, size, offset } = parseRelayOptions(options)
       return conversationMessagesLoader({
@@ -280,6 +290,7 @@ export const ConversationFields = {
         size,
         conversation_id: id,
         "expand[]": "deliveries",
+        sort: options.sort || "asc",
       }).then(({ total_count, message_details }) => {
         // Inject the convesation initiator's email into each message payload
         // so we can tell if the user sent a particular message.

--- a/test/schema/me/conversation/index.js
+++ b/test/schema/me/conversation/index.js
@@ -42,58 +42,65 @@ describe("Me", () => {
           ],
         })
       },
-      conversationMessagesLoader: () =>
-        Promise.resolve({
-          total_count: 4,
-          message_details: [
-            {
-              id: "240",
-              raw_text: "this is a good message",
-              from_email_address: "fancy_german_person@posteo.de",
-              from_id: null,
-              attachments: [],
-              metadata: {
-                lewitt_invoice_id: "420i",
+      conversationMessagesLoader: ({ sort } = { sort: "asc" }) => {
+        let messages = [
+          {
+            id: "240",
+            raw_text: "this is a good message",
+            from_email_address: "fancy_german_person@posteo.de",
+            from_id: null,
+            attachments: [],
+            metadata: {
+              lewitt_invoice_id: "420i",
+            },
+            from: `"Percy Z" <percy@cat.com>`,
+            body: "I'm a cat",
+          },
+          {
+            id: "241",
+            raw_text: "this is a good message",
+            from_email_address: "postman@posteo.de",
+            from_id: null,
+            attachments: [],
+            metadata: {},
+            from: `"Bitty Z" <Bitty@cat.com>`,
+            body: "",
+          },
+          {
+            id: "242",
+            raw_text: "this is a good message",
+            from_email_address: "fancy_german_person+wunderbar@posteo.de",
+            from_id: "user-42",
+            attachments: [],
+            metadata: {},
+            from: `"Matt Z" <matt@cat.com>`,
+            body: null,
+          },
+          {
+            id: "243",
+            raw_text: "this is a good message",
+            from_email_address: "postman+wunderlich@posteo.de",
+            from_id: "user-21",
+            attachments: [],
+            metadata: {},
+            from: "<email@email.com>",
+            deliveries: [
+              {
+                opened_at: "2020-12-31T12:00:00+00:00",
               },
-              from: `"Percy Z" <percy@cat.com>`,
-              body: "I'm a cat",
-            },
-            {
-              id: "241",
-              raw_text: "this is a good message",
-              from_email_address: "postman@posteo.de",
-              from_id: null,
-              attachments: [],
-              metadata: {},
-              from: `"Bitty Z" <Bitty@cat.com>`,
-              body: "",
-            },
-            {
-              id: "242",
-              raw_text: "this is a good message",
-              from_email_address: "fancy_german_person+wunderbar@posteo.de",
-              from_id: "user-42",
-              attachments: [],
-              metadata: {},
-              from: `"Matt Z" <matt@cat.com>`,
-              body: null,
-            },
-            {
-              id: "243",
-              raw_text: "this is a good message",
-              from_email_address: "postman+wunderlich@posteo.de",
-              from_id: "user-21",
-              attachments: [],
-              metadata: {},
-              from: "<email@email.com>",
-              deliveries: [
-                {
-                  opened_at: "2020-12-31T12:00:00+00:00",
-                },
-              ],
-            },
-          ],
-        }),
+            ],
+          },
+        ]
+
+        if (sort === "desc") {
+          messages = messages.reverse()
+        }
+
+        return Promise.resolve({
+          total_count: 4,
+          message_details: messages,
+        })
+      },
       conversationInvoiceLoader: () =>
         Promise.resolve({
           payment_url: "https://www.adopt-cats.org/adopt-all-the-cats",
@@ -220,6 +227,44 @@ describe("Me", () => {
         return runAuthenticatedQuery(query, customRootValue).then(({ me: { conversation: { items } } }) => {
           expect(items.length).toEqual(1)
           expect(items).toMatchSnapshot()
+        })
+      })
+    })
+
+    describe("messages", () => {
+      const getQuery = (sort = "ASC") => {
+        return `
+          {
+            me {
+              conversation(id: "420") {
+                messages(first: 10, sort: ${sort}) {
+                  edges {
+                    node {
+                      id
+                    }
+                  }
+                }
+              }
+            }
+          }
+        `
+      }
+
+      it("returns messages in ascending order", () => {
+        const query = getQuery()
+
+        return runAuthenticatedQuery(query, rootValue).then(({ me: { conversation: { messages } } }) => {
+          expect(messages.edges.length).toEqual(4)
+          expect(messages.edges[0].node.id).toEqual("240")
+        })
+      })
+
+      it("returns messages in descending order", () => {
+        const query = getQuery("DESC")
+
+        return runAuthenticatedQuery(query, rootValue).then(({ me: { conversation: { messages } } }) => {
+          expect(messages.edges.length).toEqual(4)
+          expect(messages.edges[0].node.id).toEqual("243")
         })
       })
     })


### PR DESCRIPTION
Added the ability to sort messages in ascending or descending order to support the following feature (https://github.com/artsy/collector-experience/issues/486). Namely, returning messages in a conversation thread starting from the most recent and paginate backwards.