### PR TITLE
@orta => Bump Node v.8.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "repository": "https://github.com/artsy/metaphysics",
   "engines": {
-    "node": ">=5.1.1",
-    "npm": "3.8.x",
-    "yarn": "0.27.x"
+    "node": "8.4.x",
+    "npm": "5.4.x",
+    "yarn": "1.0.x"
   },
   "scripts": {
     "start": "yarn run dev",


### PR DESCRIPTION
Bumps:
- `node` 8.4.x
- `npm` 5.4.x 
- `yarn` 1.0.x

This matches the Node version in Force and Reaction. 