### PR TITLE
Add a services section to metaphysics

### DIFF
--- a/schema/index.js
+++ b/schema/index.js
@@ -30,6 +30,7 @@ import Sale from "./sale/index"
 import Sales from "./sales"
 import SaleArtwork from "./sale_artwork"
 import Search from "./search"
+import Services from "./services"
 import Show from "./show"
 import Tag from "./tag"
 import TrendingArtists from "./trending"
@@ -82,6 +83,7 @@ const rootFields = {
   sale_artwork: SaleArtwork,
   sales: Sales,
   search: Search,
+  services: Services,
   show: Show,
   status: Status,
   tag: Tag,

--- a/schema/services/convection.js
+++ b/schema/services/convection.js
@@ -1,0 +1,30 @@
+// @ts-check
+import { GraphQLString, GraphQLObjectType } from "graphql"
+
+const ConvectionSchema = new GraphQLObjectType({
+  name: "Convection",
+  fields: () => ({
+    api_base: {
+      type: GraphQLString,
+    },
+    app_id: {
+      type: GraphQLString,
+    },
+    gemini_app_id: {
+      type: GraphQLString,
+    },
+  }),
+})
+
+const Convection = {
+  type: ConvectionSchema,
+  description: "The schema for microservice settings",
+  args: {},
+  resolve: () => ({
+    api_base: process.env.CONVECTION_API_BASE,
+    app_id: process.env.CONVECTION_APP_ID,
+    gemini_app_id: process.env.CONVECTION_GEMINI_APP,
+  }),
+}
+
+export default Convection

--- a/schema/services/gemini.js
+++ b/schema/services/gemini.js
@@ -1,0 +1,26 @@
+// @ts-check
+import { GraphQLString, GraphQLObjectType } from "graphql"
+
+const GeminiSchema = new GraphQLObjectType({
+  name: "Gemini",
+  fields: () => ({
+    api_base: {
+      type: GraphQLString,
+    },
+    cloudfront_url: {
+      type: GraphQLString,
+    },
+  }),
+})
+
+const Gemini = {
+  type: GeminiSchema,
+  description: "The schema for microservice settings",
+  args: {},
+  resolve: () => ({
+    api_base: process.env.GEMINI_APP,
+    cloudfront_url: process.env.GEMINI_CLOUDFRONT_URL,
+  }),
+}
+
+export default Gemini

--- a/schema/services/index.js
+++ b/schema/services/index.js
@@ -1,0 +1,29 @@
+// @ts-check
+import { GraphQLString, GraphQLObjectType } from "graphql"
+
+import Gemini from "./gemini"
+import Convection from "./convection"
+
+const ServicesSchema = new GraphQLObjectType({
+  name: "Services",
+  fields: () => ({
+    gemini: {
+      type: Gemini.type,
+    },
+    convection: {
+      type: Convection.type,
+    },
+  }),
+})
+
+const Services = {
+  type: ServicesSchema,
+  description: "The schema for difference microservice settings",
+  args: {},
+  resolve: () => ({
+    gemini: Gemini.resolve(),
+    convection: Convection.resolve(),
+  }),
+}
+
+export default Services


### PR DESCRIPTION
I was thinking something like this ( the code can definitely be refactored ( the value will always be a string, so can probably generate the schema obj, resolver and type from one object) and it has no code, but it's enough to show what I mean

![screen shot 2017-09-18 at 11 05 31 am](https://user-images.githubusercontent.com/49038/30548870-4f5e10ba-9c61-11e7-95e8-372b1e58d0eb.png)
