### PR TITLE
Adds sale information to LotStanding

### DIFF
--- a/lib/loaders/loaders_with_authentication/index.js
+++ b/lib/loaders/loaders_with_authentication/index.js
@@ -4,7 +4,7 @@ import trackedEntityLoaderFactory from "lib/loaders/loaders_with_authentication/
 import convectionLoaders from "./convection"
 import impulseLoaders from "./impulse"
 
-export default (accessToken, userID) => {
+export default (accessToken, userID, options) => {
   const gravityAccessTokenLoader = () => Promise.resolve(accessToken)
   const gravityLoader = gravityLoaderWithAuthenticationFactory(gravityAccessTokenLoader)
 
@@ -30,6 +30,7 @@ export default (accessToken, userID) => {
       "artworks",
       "is_saved"
     ),
+    lotStandingLoader: gravityLoader("me/lot_standings", options),
     ...convectionLoaders(accessToken),
     ...impulseLoaders(accessToken, userID),
   }

--- a/schema/me/lot_standings.js
+++ b/schema/me/lot_standings.js
@@ -1,4 +1,3 @@
-import gravity from "lib/loaders/legacy/gravity"
 import LotStanding from "./lot_standing"
 import { GraphQLList, GraphQLBoolean, GraphQLString } from "graphql"
 
@@ -23,13 +22,9 @@ export default {
       description: "Only the lot standings for a specific auction",
     },
   },
-  resolve: (root, { active_positions, artwork_id, live, sale_id }, request, { rootValue: { accessToken } }) => {
-    return gravity.with(accessToken)("me/lot_standings", {
-      active_positions,
-      artwork_id,
-      live,
-      sale_id,
-    }).then(lotStandings => {
+  resolve: (root, { active_positions, artwork_id, live, sale_id }, request, { rootValue: { lotStandingLoader } }) => {
+    if (!lotStandingLoader) return null
+    return lotStandingLoader({ active_positions, artwork_id, live, sale_id }).then(lotStandings => {
       return lotStandings
     })
   },

--- a/test/schema/me/lot_standing.js
+++ b/test/schema/me/lot_standing.js
@@ -179,4 +179,112 @@ describe("LotStanding type", () => {
       })
     })
   })
+
+  it("correctly determines if a lot is part of a live auction", () => {
+    gravity
+      .onCall(0)
+      .returns(
+        Promise.resolve([
+          {
+            bidder: {
+              sale: {
+                id: "a-live-auction",
+              },
+            },
+            sale_artwork: {
+              id: "untitled",
+              reserve_status: "reserve_not_met",
+            },
+            max_position: {
+              id: 0,
+              max_bid_amount_cents: 90000,
+              sale_artwork_id: "untitled",
+            },
+            leading_position: {
+              id: 0,
+              max_bid_amount_cents: 90000,
+              sale_artwork_id: "untitled",
+            },
+          },
+        ])
+      )
+      .onCall(1)
+      .returns(
+        Promise.resolve({
+          live_start_at: "2017-09-23T14:00:00+00:00",
+        })
+      )
+
+    const query = `
+      {
+        me {
+          lot_standing(artwork_id: "untitled", sale_id: "active-auction") {
+            is_in_live_auction
+          }
+        }
+      }
+    `
+
+    return runAuthenticatedQuery(query).then(({ me }) => {
+      expect(me).toEqual({
+        lot_standing: {
+          is_in_live_auction: true,
+        },
+      })
+    })
+  })
+
+  it("correctly determines if a lot is not part of a live auction", () => {
+    gravity
+      .onCall(0)
+      .returns(
+        Promise.resolve([
+          {
+            bidder: {
+              sale: {
+                id: "a-timed-auction",
+              },
+            },
+            sale_artwork: {
+              id: "untitled",
+              reserve_status: "reserve_not_met",
+            },
+            max_position: {
+              id: 0,
+              max_bid_amount_cents: 90000,
+              sale_artwork_id: "untitled",
+            },
+            leading_position: {
+              id: 0,
+              max_bid_amount_cents: 90000,
+              sale_artwork_id: "untitled",
+            },
+          },
+        ])
+      )
+      .onCall(1)
+      .returns(
+        Promise.resolve({
+          live_start_at: null,
+        })
+      )
+
+    const query = `
+      {
+        me {
+          lot_standing(artwork_id: "untitled", sale_id: "active-auction") {
+            is_in_live_auction
+          }
+        }
+      }
+    `
+
+    return runAuthenticatedQuery(query).then(({ me }) => {
+      expect(me).toEqual({
+        lot_standing: {
+          is_in_live_auction: false,
+        },
+      })
+    })
+  })
 })

--- a/test/schema/me/lot_standing.js
+++ b/test/schema/me/lot_standing.js
@@ -1,59 +1,42 @@
-import schema from "schema"
 import { runAuthenticatedQuery } from "test/utils"
+import moment from "moment"
 
 describe("LotStanding type", () => {
-  const Me = schema.__get__("Me")
-  const LotStanding = Me.__get__("LotStanding")
-
-  let gravity
-
-  beforeEach(() => {
-    gravity = sinon.stub()
-    gravity.with = sinon.stub().returns(gravity)
-    LotStanding.__Rewire__("gravity", gravity)
-  })
-
-  afterEach(() => {
-    LotStanding.__ResetDependency__("gravity")
-  })
-
   it("returns the correct state when you are the high bidder and reserve is met", () => {
-    gravity.returns(
-      Promise.resolve([
-        {
-          sale_artwork: {
-            id: "untitled",
-            reserve_status: "reserve_met",
-          },
-          max_position: {
-            id: 0,
-            max_bid_amount_cents: 90000,
-            sale_artwork_id: "untitled",
-          },
-          leading_position: {
-            id: 0,
-            max_bid_amount_cents: 90000,
-            sale_artwork_id: "untitled",
-          },
+    const lotStandings = [
+      {
+        sale_artwork: {
+          id: "untitled",
+          reserve_status: "reserve_met",
         },
-        {
-          sale_artwork: {
-            id: "untitled-2",
-            reserve_status: "reserve_met",
-          },
-          max_position: {
-            id: 1,
-            max_bid_amount_cents: 100000,
-            sale_artwork_id: "untitled-2",
-          },
-          leading_position: {
-            id: 2,
-            max_bid_amount_cents: 100000,
-            sale_artwork_id: "untitled-2",
-          },
+        max_position: {
+          id: 0,
+          max_bid_amount_cents: 90000,
+          sale_artwork_id: "untitled",
         },
-      ])
-    )
+        leading_position: {
+          id: 0,
+          max_bid_amount_cents: 90000,
+          sale_artwork_id: "untitled",
+        },
+      },
+      {
+        sale_artwork: {
+          id: "untitled-2",
+          reserve_status: "reserve_met",
+        },
+        max_position: {
+          id: 1,
+          max_bid_amount_cents: 100000,
+          sale_artwork_id: "untitled-2",
+        },
+        leading_position: {
+          id: 2,
+          max_bid_amount_cents: 100000,
+          sale_artwork_id: "untitled-2",
+        },
+      },
+    ]
 
     const query = `
       {
@@ -71,7 +54,9 @@ describe("LotStanding type", () => {
       }
     `
 
-    return runAuthenticatedQuery(query).then(({ me }) => {
+    return runAuthenticatedQuery(query, {
+      lotStandingLoader: () => Promise.resolve(lotStandings),
+    }).then(({ me }) => {
       expect(me).toEqual({
         lot_standing: {
           is_highest_bidder: true,
@@ -83,22 +68,20 @@ describe("LotStanding type", () => {
   })
 
   it("returns the correct state when you are outbid on a work & reserve is met", () => {
-    gravity.returns(
-      Promise.resolve([
-        {
-          sale_artwork: {
-            id: "untitled",
-            reserve_status: "reserve_met",
-          },
-          max_position: {
-            id: 0,
-            max_bid_amount_cents: 90000,
-            sale_artwork_id: "untitled",
-          },
-          leading_position: null,
+    const lotStanding = [
+      {
+        sale_artwork: {
+          id: "untitled",
+          reserve_status: "reserve_met",
         },
-      ])
-    )
+        max_position: {
+          id: 0,
+          max_bid_amount_cents: 90000,
+          sale_artwork_id: "untitled",
+        },
+        leading_position: null,
+      },
+    ]
 
     const query = `
       {
@@ -117,7 +100,9 @@ describe("LotStanding type", () => {
       }
     `
 
-    return runAuthenticatedQuery(query).then(({ me }) => {
+    return runAuthenticatedQuery(query, {
+      lotStandingLoader: () => Promise.resolve(lotStanding),
+    }).then(({ me }) => {
       expect(me).toEqual({
         lot_standing: {
           is_highest_bidder: false,
@@ -130,26 +115,24 @@ describe("LotStanding type", () => {
   })
 
   it("returns the correct state when you are the top bid but reserve is not met", () => {
-    gravity.returns(
-      Promise.resolve([
-        {
-          sale_artwork: {
-            id: "untitled",
-            reserve_status: "reserve_not_met",
-          },
-          max_position: {
-            id: 0,
-            max_bid_amount_cents: 90000,
-            sale_artwork_id: "untitled",
-          },
-          leading_position: {
-            id: 0,
-            max_bid_amount_cents: 90000,
-            sale_artwork_id: "untitled",
-          },
+    const lotStanding = [
+      {
+        sale_artwork: {
+          id: "untitled",
+          reserve_status: "reserve_not_met",
         },
-      ])
-    )
+        max_position: {
+          id: 0,
+          max_bid_amount_cents: 90000,
+          sale_artwork_id: "untitled",
+        },
+        leading_position: {
+          id: 0,
+          max_bid_amount_cents: 90000,
+          sale_artwork_id: "untitled",
+        },
+      },
+    ]
 
     const query = `
       {
@@ -168,7 +151,9 @@ describe("LotStanding type", () => {
       }
     `
 
-    return runAuthenticatedQuery(query).then(({ me }) => {
+    return runAuthenticatedQuery(query, {
+      lotStandingLoader: () => Promise.resolve(lotStanding),
+    }).then(({ me }) => {
       expect(me).toEqual({
         lot_standing: {
           is_highest_bidder: false,
@@ -180,109 +165,89 @@ describe("LotStanding type", () => {
     })
   })
 
-  it("correctly determines if a lot is part of a live auction", () => {
-    gravity
-      .onCall(0)
-      .returns(
-        Promise.resolve([
-          {
-            bidder: {
-              sale: {
-                id: "a-live-auction",
-              },
-            },
-            sale_artwork: {
-              id: "untitled",
-              reserve_status: "reserve_not_met",
-            },
-            max_position: {
-              id: 0,
-              max_bid_amount_cents: 90000,
-              sale_artwork_id: "untitled",
-            },
-            leading_position: {
-              id: 0,
-              max_bid_amount_cents: 90000,
-              sale_artwork_id: "untitled",
-            },
-          },
-        ])
-      )
-      .onCall(1)
-      .returns(
-        Promise.resolve({
-          live_start_at: "2017-09-23T14:00:00+00:00",
-        })
-      )
-
+  it("correctly determines if a lot is part of a live and open auction", () => {
     const query = `
       {
         me {
           lot_standing(artwork_id: "untitled", sale_id: "active-auction") {
-            is_in_live_auction
+            sale {
+              is_live_open
+            }
           }
         }
       }
     `
 
-    return runAuthenticatedQuery(query).then(({ me }) => {
+    const lotStanding = [
+      {
+        bidder: {
+          sale: {
+            id: "a-live-auction",
+          },
+        },
+        sale_artwork: {
+          id: "untitled",
+          reserve_status: "reserve_not_met",
+        },
+      },
+    ]
+
+    const liveOpenSale = {
+      auction_state: "open",
+      live_start_at: moment().subtract(2, "days"),
+    }
+
+    return runAuthenticatedQuery(query, {
+      lotStandingLoader: () => Promise.resolve(lotStanding),
+      saleLoader: () => Promise.resolve(liveOpenSale),
+    }).then(({ me }) => {
       expect(me).toEqual({
         lot_standing: {
-          is_in_live_auction: true,
+          sale: { is_live_open: true },
         },
       })
     })
   })
 
-  it("correctly determines if a lot is not part of a live auction", () => {
-    gravity
-      .onCall(0)
-      .returns(
-        Promise.resolve([
-          {
-            bidder: {
-              sale: {
-                id: "a-timed-auction",
-              },
-            },
-            sale_artwork: {
-              id: "untitled",
-              reserve_status: "reserve_not_met",
-            },
-            max_position: {
-              id: 0,
-              max_bid_amount_cents: 90000,
-              sale_artwork_id: "untitled",
-            },
-            leading_position: {
-              id: 0,
-              max_bid_amount_cents: 90000,
-              sale_artwork_id: "untitled",
-            },
-          },
-        ])
-      )
-      .onCall(1)
-      .returns(
-        Promise.resolve({
-          live_start_at: null,
-        })
-      )
-
+  it("correctly determines if a lot is not part of a live and open auction", () => {
     const query = `
       {
         me {
           lot_standing(artwork_id: "untitled", sale_id: "active-auction") {
-            is_in_live_auction
+            sale {
+              is_live_open
+            }
           }
         }
       }
     `
 
-    return runAuthenticatedQuery(query).then(({ me }) => {
+    const lotStanding = [
+      {
+        bidder: {
+          sale: {
+            id: "a-live-auction",
+          },
+        },
+        sale_artwork: {
+          id: "untitled",
+          reserve_status: "reserve_not_met",
+        },
+      },
+    ]
+
+    const notALiveOpenSale = {
+      auction_state: "open",
+      live_start_at: moment().add(2, "days"),
+    }
+
+    return runAuthenticatedQuery(query, {
+      lotStandingLoader: () => Promise.resolve(lotStanding),
+      saleLoader: () => Promise.resolve(notALiveOpenSale),
+    }).then(({ me }) => {
       expect(me).toEqual({
         lot_standing: {
-          is_in_live_auction: false,
+          sale: { is_live_open: false },
         },
       })
     })


### PR DESCRIPTION
This will make it possible to quickly tell if an auction is live or not and also access its `sale` information (i.e. `href`, `title`, etc).

Fixes #750 

cc @sweir27 

<img width="714" alt="screen shot 2017-09-21 at 12 29 08 pm" src="https://user-images.githubusercontent.com/2712962/30691583-7d317aa4-9ec8-11e7-8e7c-57e49e709b64.png">
