### PR TITLE
Add missing pagination params for OrderedSets

### DIFF
--- a/schema/ordered_sets.js
+++ b/schema/ordered_sets.js
@@ -16,9 +16,11 @@ const OrderedSets = {
     },
     page: {
       type: GraphQLInt,
+      defaultValue: 1,
     },
     size: {
       type: GraphQLInt,
+      defaultValue: 10,
     },
   },
   resolve: (root, options) => gravity("sets", options),

--- a/schema/ordered_sets.js
+++ b/schema/ordered_sets.js
@@ -1,6 +1,6 @@
 import gravity from "lib/loaders/legacy/gravity"
 import OrderedSet from "./ordered_set"
-import { GraphQLString, GraphQLNonNull, GraphQLList, GraphQLBoolean } from "graphql"
+import { GraphQLString, GraphQLNonNull, GraphQLList, GraphQLBoolean, GraphQLInt } from "graphql"
 
 const OrderedSets = {
   type: new GraphQLList(OrderedSet.type),
@@ -13,6 +13,12 @@ const OrderedSets = {
     public: {
       type: GraphQLBoolean,
       defaultValue: true,
+    },
+    page: {
+      type: GraphQLInt,
+    },
+    size: {
+      type: GraphQLInt,
     },
   },
   resolve: (root, options) => gravity("sets", options),

--- a/test/schema/ordered_sets.js
+++ b/test/schema/ordered_sets.js
@@ -4,6 +4,20 @@ import { runQuery } from "test/utils"
 describe("OrderedSets type", () => {
   const OrderedSets = schema.__get__("OrderedSets")
   const OrderedSet = OrderedSets.__get__("OrderedSet")
+  const query = `
+  {
+    ordered_sets(key: "artists:featured-genes", page: 1, size: 5) {
+      id
+      name
+      description
+      genes: items {
+        ... on GeneItem {
+          name
+        }
+      }
+    }
+  }
+`
 
   beforeEach(() => {
     const gravity = sinon.stub()
@@ -42,23 +56,9 @@ describe("OrderedSets type", () => {
   })
 
   it("fetches sets by key", () => {
-    const query = `
-      {
-        ordered_sets(key: "artists:featured-genes") {
-          id
-          name
-          description
-          genes: items {
-            ... on GeneItem {
-              name
-            }
-          }
-        }
-      }
-    `
-
     return runQuery(query).then(data => {
-      expect(OrderedSets.__get__("gravity").args[0]).toEqual(["sets", { key: "artists:featured-genes", public: true }])
+      expect(OrderedSets.__get__("gravity").args[0][0]).toEqual("sets")
+      expect(OrderedSets.__get__("gravity").args[0][1]).toMatchObject({ key: "artists:featured-genes", public: true })
       expect(OrderedSets.__get__("gravity").args[1]).toEqual(["set/52dd3c2e4b8480091700027f/items"])
 
       expect(data).toEqual({
@@ -75,6 +75,12 @@ describe("OrderedSets type", () => {
           },
         ],
       })
+    })
+  })
+
+  it("includes pagination params", () => {
+    return runQuery(query).then(() => {
+      expect(OrderedSets.__get__("gravity").args[0][1]).toMatchObject({ page: 1, size: 5 })
     })
   })
 })


### PR DESCRIPTION
Looks like the schema definition for `OrderedSets` never accepted / forwarded the `size` and `page` parameters to Gravity, presumably because most OrderedSets use cases don't require >10 sets for any given `key`

But the new /categories page in Force in fact does expect ~15 gene families, so in order to be able fetch them all, we simply add the missing pagination params here.
