### PR TITLE
Changes collection sort order default.

### DIFF
--- a/schema/sorts/collection_sorts.js
+++ b/schema/sorts/collection_sorts.js
@@ -12,4 +12,5 @@ export default {
       },
     },
   }),
+  defaultValue: "-position",
 }

--- a/test/schema/collection.js
+++ b/test/schema/collection.js
@@ -55,6 +55,7 @@ describe("Collections", () => {
           private: false,
           total_count: true,
           user_id: "user-42",
+          sort: "-position",
         })
         .returns(Promise.resolve({ body: artworks, headers: { "x-total-count": 10 } }))
 
@@ -85,6 +86,7 @@ describe("Collections", () => {
           private: false,
           total_count: true,
           user_id: "user-42",
+          sort: "-position",
         })
         .returns(Promise.reject(new Error("Collection Not Found")))
 
@@ -115,6 +117,7 @@ describe("Collections", () => {
           private: false,
           total_count: true,
           user_id: "user-42",
+          sort: "-position",
         })
         .returns(Promise.resolve({ body: [], headers: { "x-total-count": 10 } }))
       const query = `


### PR DESCRIPTION
As [discussed in Slack](https://artsy.slack.com/archives/C1HH3KNJG/p1506357396000388), the only use of collections is for saved artworks. Gravity defaults to sorting this in the order you added them in, but a more sensible default which metaphysics can expose is to sort them in most recently saved first. Since this is a change to the schema itself, I didn't add any tests but rather had to update the existing tests. Let me know.