### PR TITLE
Removes FIXMEs

### DIFF
--- a/schema/collection.js
+++ b/schema/collection.js
@@ -42,24 +42,16 @@ export const CollectionType = new GraphQLObjectType({
         delete gravityOptions.page // this can't also be used with the offset in gravity
         return gravity.with(accessToken, { headers: true })(`collection/${id}/artworks`, gravityOptions)
           .then(({ body, headers }) => {
-            const connection = connectionFromArraySlice(body, options, {
+            return connectionFromArraySlice(body, options, {
               arrayLength: headers["x-total-count"],
               sliceStart: gravityOptions.offset,
             })
-            // Gravity has a bug (see PR https://github.com/artsy/gravity/pull/11240) where the counts
-            // returned in the X-Total-Count header includes unpublished artworks, even though only
-            // published artworks are returned. This can lead to a situation where hasNextPage is true
-            // but endCursor is null, violating Relay norms and causing serious problems for Eigen.
-            // FIXME: Remove the following line once Gravity PR 11240 has been deployed to production.
-            connection.pageInfo.hasNextPage =
-              connection.pageInfo.endCursor === null ? false : connection.pageInfo.hasNextPage
-            return connection
           })
           .catch(e => {
             error("Bypassing Gravity error: ", e)
             // For some users with no favourites, Gravity produces an error of "Collection Not Found".
-            // This can cause a crash on Eigen 3.2.4, so we will intercept the error and return an empty list.
-            // FIXME: This can be removed once use of 3.2.4 drops to zero.
+            // This can cause the Gravity endpoint to produce a 404, so we will intercept the error
+            // and return an empty list instead.
             return connectionFromArray([], options, {
               arrayLength: 0,
               sliceStart: 0,

--- a/test/schema/__snapshots__/collection.js.snap
+++ b/test/schema/__snapshots__/collection.js.snap
@@ -10,19 +10,6 @@ Object {
 }
 `;
 
-exports[`Collections Handles getting collection metadata ignores incorrect counts from gravity 1`] = `
-Object {
-  "collection": Object {
-    "artworks_connection": Object {
-      "pageInfo": Object {
-        "endCursor": null,
-        "hasNextPage": false,
-      },
-    },
-  },
-}
-`;
-
 exports[`Collections Handles getting collection metadata returns artworks for a collection 1`] = `
 Object {
   "collection": Object {

--- a/test/schema/collection.js
+++ b/test/schema/collection.js
@@ -106,32 +106,5 @@ describe("Collections", () => {
         expect(data).toMatchSnapshot()
       })
     })
-
-    it("ignores incorrect counts from gravity", () => {
-      gravity
-        .withArgs("collection/saved-artwork/artworks", {
-          size: 10,
-          offset: 0,
-          private: false,
-          total_count: true,
-          user_id: "user-42",
-        })
-        .returns(Promise.resolve({ body: [], headers: { "x-total-count": 10 } }))
-      const query = `
-                {
-                  collection(id: "saved-artwork") {
-                    artworks_connection(first:10) {
-                      pageInfo {
-                        hasNextPage
-                        endCursor
-                      }
-                    }
-                  }
-                }
-              `
-      return runAuthenticatedQuery(query).then(data => {
-        expect(data).toMatchSnapshot()
-      })
-    })
   })
 })


### PR DESCRIPTION
This removes two FIXMEs from metaphysics as a part of [Eigen's retrospective](https://github.com/artsy/post_mortems/issues/20). In detail:

- [The first fix](https://github.com/artsy/metaphysics/pull/738) was to overcome a bug in Gravity that's been [fixed](https://github.com/artsy/gravity/pull/11240) and deployed. I've tested locally by favouriting three artworks on staging, unpublishing one, and paging through using GraphiQL. I only get two.
- [The second fix](https://github.com/artsy/metaphysics/pull/737) was kept in, and the FIXME removed to avoid propagating errors from Gravity (that are a part of using this API) to the metaphysics consumer. This makes metaphysics more of an idiomatic GraphQL provider.

Not sure about the lock file changes – any suggestions?