### PR TITLE
@anandaroop => Dont return exhibition highlights for an artist from private partners

### DIFF
--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -328,7 +328,7 @@ export const ArtistType = new GraphQLObjectType({
             visible_to_public: false,
             size: options.size,
           }).then(shows => {
-            return shows
+            return reject(shows, show => includes(blacklistedPartnerTypes, show.partner.type))
           })
         },
       },

--- a/test/schema/artist/index.js
+++ b/test/schema/artist/index.js
@@ -541,7 +541,7 @@ describe("Artist type", () => {
     })
   })
   describe("concerning related shows", () => {
-    it("excludes shows from private partners", () => {
+    beforeEach(() => {
       const privateShow = {
         id: "oops",
         partner: {
@@ -566,6 +566,8 @@ describe("Artist type", () => {
         .stub()
         .withArgs(artist.id)
         .returns(Promise.resolve([privateShow, publicShow]))
+    })
+    it("excludes shows from private partners for related shows", () => {
       const query = `
         {
           artist(id: "foo-bar") {
@@ -579,6 +581,28 @@ describe("Artist type", () => {
         expect(data).toEqual({
           artist: {
             shows: [
+              {
+                id: "ok",
+              },
+            ],
+          },
+        })
+      })
+    })
+    it("excludes shows from private partners for exhibition highlights", () => {
+      const query = `
+        {
+          artist(id: "foo-bar") {
+            exhibition_highlights {
+              id
+            }
+          }
+        }
+      `
+      return runQuery(query, rootValue).then(data => {
+        expect(data).toEqual({
+          artist: {
+            exhibition_highlights: [
               {
                 id: "ok",
               },


### PR DESCRIPTION
This is the same fix, but for `exhibition_highlights`.

Note the issue with receiving less data than available is more apparent, the exhibition highlights for Dan Colen will appear slightly anemic for now.

That can be fixed by setting a super low [relevance](https://github.com/artsy/gravity/blob/7fbedb2462c77887155caa096b0323b59533b562/app/models/domain/partner_show.rb#L561-L592) for those partner types, but in the meantime, this is the fix.