### PR TITLE
Optimized conversations existence

### DIFF
--- a/lib/loaders/api/loader_with_authentication_factory.js
+++ b/lib/loaders/api/loader_with_authentication_factory.js
@@ -19,11 +19,12 @@ import { verbose, error } from "lib/loggers"
  */
 export const apiLoaderWithAuthenticationFactory = api => {
   return accessTokenLoader => {
-    return (path, globalParams = {}, apiOptions = {}) => {
+    return (path, globalParams = {}, apiOptions = {}, optimizeRequests = null) => {
       const loader = new DataLoader(
-        keys => {
-          return accessTokenLoader().then(accessToken =>
-            Promise.all(
+        allKeys => {
+          const { keys, postProcess } = optimizeRequests ? optimizeRequests(allKeys) : { keys: allKeys }
+          return accessTokenLoader().then(accessToken => {
+            const responsesPromise = Promise.all(
               keys.map(key => {
                 const clock = timer(key)
                 clock.start()
@@ -45,7 +46,8 @@ export const apiLoaderWithAuthenticationFactory = api => {
                 })
               })
             )
-          )
+            return postProcess ? responsesPromise.then(responses => postProcess(responses)) : responsesPromise
+          })
         },
         {
           batch: true,

--- a/lib/loaders/api/loader_without_authentication_factory.js
+++ b/lib/loaders/api/loader_without_authentication_factory.js
@@ -22,10 +22,11 @@ import { verbose, error } from "lib/loggers"
  * @param {apiSignature} api a function that performs an API request
  */
 export const apiLoaderWithoutAuthenticationFactory = api => {
-  return (path, globalParams = {}, apiOptions = {}) => {
+  return (path, globalParams = {}, apiOptions = {}, optimizeRequests = null) => {
     const loader = new DataLoader(
-      keys =>
-        Promise.all(
+      allKeys => {
+        const { keys, postProcess } = optimizeRequests ? optimizeRequests(allKeys) : { keys: allKeys }
+        const responsesPromise = Promise.all(
           keys.map(key => {
             const clock = timer(key)
             clock.start()
@@ -71,9 +72,11 @@ export const apiLoaderWithoutAuthenticationFactory = api => {
               )
             })
           })
-        ),
+        )
+        return postProcess ? responsesPromise.then(responses => postProcess(responses)) : responsesPromise
+      },
       {
-        batch: false,
+        batch: !!optimizeRequests, // FIXME Does this ever need to be false? I guess requests will immediately resolve.
         cache: true,
       }
     )

--- a/lib/loaders/loaders_with_authentication/impulse.js
+++ b/lib/loaders/loaders_with_authentication/impulse.js
@@ -4,6 +4,44 @@ import { gravityLoaderWithAuthenticationFactory, impulseLoaderWithAuthentication
 
 const { IMPULSE_APPLICATION_ID } = process.env
 
+/**
+ * This optimizes conversations requests by removing requests that are only interested in the `total_count` and instead
+ * rely on another request to provide that data.
+ */
+function optimize(keys) {
+  if (keys.length === 1) {
+    /**
+     * If there’s only 1 request, then it doesn’t matter if it’s a counter or not, we can’t optimize it onto any
+     * other request anyways, so just resolve the original key.
+     *
+     * TODO It could well be that all optimizations will perform this same check, if so just move this into the
+     *      loader factory.
+     */
+    return { keys }
+  }
+  /**
+   * NOTE We only ever query convos of 1 user (the authenticated one) for the duration of 1 query execution, if we
+   *      weren’t we’d have to match the counterKeys to the right remainderKeys by user ID and also assume that
+   *      multiple counter keys could exist.
+   *
+   * FIXME We really shouldn’t have to reflect on the key in such a poor way. Maybe we shouldn’t convert the path
+   *       and params to a string until the last moment, meaning we could reflect on the query params object here.
+   */
+  const counterKeyIndex = keys.findIndex(key => key.includes("size=0"))
+  const counterKey = keys[counterKeyIndex]
+  const remainderKeys = keys.slice(0)
+  if (counterKey) remainderKeys.splice(counterKeyIndex, 1)
+  return {
+    keys: remainderKeys,
+    postProcess: responses => {
+      const result = responses.slice(0)
+      // Now just return any other response at the index where the counter response would have been.
+      result.splice(counterKeyIndex, 0, responses[0])
+      return result
+    },
+  }
+}
+
 export default (accessToken, userID) => {
   let impulseTokenLoader
   const gravityAccessTokenLoader = () => Promise.resolve(accessToken)
@@ -15,11 +53,9 @@ export default (accessToken, userID) => {
   // This generates a token with a lifetime of 1 minute, which should be plenty of time to fulfill a full query.
   impulseTokenLoader = gravityLoader("me/token", { client_application_id: IMPULSE_APPLICATION_ID }, { method: "POST" })
 
-  return {
-    conversationsLoader: impulseLoader("conversations", {
-      from_id: userID,
-      from_type: "User",
-    }),
+  const loaders = {
+    conversationsLoader: impulseLoader("conversations", { from_id: userID, from_type: "User" }, {}, optimize),
+    conversationsCountLoader: () => loaders.conversationsLoader({ size: 0 }).then(({ total_count }) => total_count),
     conversationLoader: impulseLoader(id => `conversations/${id}`),
     conversationUpdateLoader: impulseLoader(id => `conversations/${id}`, {}, { method: "PUT" }),
     conversationMessagesLoader: impulseLoader("message_details"),
@@ -41,4 +77,6 @@ export default (accessToken, userID) => {
       { method: "POST" }
     ),
   }
+
+  return loaders
 }

--- a/schema/me/conversations.js
+++ b/schema/me/conversations.js
@@ -7,7 +7,7 @@ import { ConversationType } from "./conversation"
 const connectionFields = {
   totalCount: {
     type: GraphQLInt,
-    resolve: ({ pageInfo }) => pageInfo.totalCount,
+    resolve: (root, options, request, { rootValue: { conversationsCountLoader } }) => conversationsCountLoader(),
   },
 }
 
@@ -19,12 +19,10 @@ export default {
     if (!conversationsLoader) return null
     const { page, size, offset } = parseRelayOptions(options)
     return conversationsLoader({ page, size }).then(({ total_count, conversations }) => {
-      const arrayConn = connectionFromArraySlice(conversations, options, {
+      return connectionFromArraySlice(conversations, options, {
         arrayLength: total_count,
         sliceStart: offset,
       })
-      arrayConn.pageInfo.totalCount = total_count
-      return arrayConn
     })
   },
 }

--- a/schema/me/index.js
+++ b/schema/me/index.js
@@ -18,7 +18,7 @@ import ArtworkInquiries from "./artwork_inquiries"
 import SavedArtworks from "./saved_artworks"
 import { IDFields, NodeInterface } from "schema/object_identification"
 import { queriedForFieldsOtherThanBlacklisted } from "lib/helpers"
-import { GraphQLString, GraphQLObjectType } from "graphql"
+import { GraphQLString, GraphQLObjectType, GraphQLBoolean } from "graphql"
 import { has } from "lodash"
 
 const Me = new GraphQLObjectType({
@@ -56,6 +56,12 @@ const Me = new GraphQLObjectType({
     type: {
       type: GraphQLString,
     },
+    has_conversations: {
+      type: GraphQLBoolean,
+      resolve: (root, options, request, { rootValue: { conversationsCountLoader } }) => {
+        return conversationsCountLoader().then(count => count > 0)
+      },
+    },
   },
 })
 
@@ -78,6 +84,7 @@ export default {
       "sale_registrations",
       "conversation",
       "conversations",
+      "has_conversations",
       "collector_profile",
       "artwork_inquiries_connection",
       "notifications_connection",


### PR DESCRIPTION
With these changes a ‘count’ request will be merged with other data requests, if they exist, but only ever 1 request will be made to fulfil both these queries.

## Just count (in form of boolean)

```graphql
{
  me {
    has_conversations
  }
}
```

```
Elapsed: 0s 576.05448ms - conversations?from_id=[SNIP]&from_type=User&size=0
```

## With conversation data

```graphql
{
  me {
    has_conversations
    conversations(first: 10) {
      totalCount
      edges {
        node {
          initial_message
        }
      }
    }
  }
}
```

```
Elapsed: 0s 983.291054ms - conversations?from_id=[SNIP]&from_type=User&page=1&size=10
```