### PR TITLE
Always create un-auth'd loaders

### DIFF
--- a/lib/loaders/index.js
+++ b/lib/loaders/index.js
@@ -9,7 +9,7 @@ import loadersWithoutAuthentication from "./loaders_without_authentication"
  * it would be wise to check if the loader is not in fact `undefined`.
  */
 export default (accessToken, userID) => {
-  const loaders = loadersWithoutAuthentication
+  const loaders = loadersWithoutAuthentication()
 
   if (accessToken) {
     return Object.assign({}, loaders, loadersWithAuthentication(accessToken, userID))

--- a/lib/loaders/loaders_without_authentication/index.js
+++ b/lib/loaders/loaders_without_authentication/index.js
@@ -2,8 +2,8 @@ import gravityLoaders from "./gravity"
 import positronLoaders from "./positron"
 import geminiLoaders from "./gemini"
 
-export default {
+export default () => ({
   ...gravityLoaders,
   ...positronLoaders,
   ...geminiLoaders,
-}
+})


### PR DESCRIPTION
Converted into an object in https://github.com/artsy/metaphysics/pull/759 but needs to be a function to ensure they're re-created.

I tried making a test for this, but struggled:

```js
describe("all loaders", () => {
  it("recreates all loaders each time", () => {
    const firstTimeLoaders = loaders()
    const secondTimeLoaders = loaders()
    for (const key in firstTimeLoaders) {
      if (firstTimeLoaders.hasOwnProperty(key)) {
        expect(firstTimeLoaders[key]).not.toEqual(secondTimeLoaders[key])
      }
    }
  })
})
```

```js
describe("all loaders", () => {
  it("recreates all loaders each time", () => {
    const firstTimeLoaders = loaders()
    const secondTimeLoaders = loaders()
    expect(firstTimeLoaders).not.toEqual(secondTimeLoaders)
  })
})
```

both are equal, there's not really a way I can think of to check memory addresses etc.