### PR TITLE
Adds a popular Artists schema

### DIFF
--- a/lib/loaders/loaders_with_authentication/index.js
+++ b/lib/loaders/loaders_with_authentication/index.js
@@ -31,6 +31,7 @@ export default (accessToken, userID, options) => {
       "is_saved"
     ),
     lotStandingLoader: gravityLoader("me/lot_standings", options),
+    authenticatedPopularArtistsLoader: gravityLoader("artists/popular"),
     ...convectionLoaders(accessToken),
     ...impulseLoaders(accessToken, userID),
   }

--- a/lib/loaders/loaders_without_authentication/gravity.js
+++ b/lib/loaders/loaders_without_authentication/gravity.js
@@ -2,6 +2,7 @@ import { gravityLoaderWithoutAuthenticationFactory as gravityLoader } from "../a
 
 export default {
   artistArtworksLoader: gravityLoader(id => `artist/${id}/artworks`),
+  popularArtistsLoader: gravityLoader(`artists/popular`),
   artistLoader: gravityLoader(id => `artist/${id}`),
   artworkLoader: gravityLoader(id => `artwork/${id}`),
   fairsLoader: gravityLoader("fairs"),

--- a/schema/artists/popular.js
+++ b/schema/artists/popular.js
@@ -1,0 +1,33 @@
+import Artist from "../artist"
+import { GraphQLObjectType, GraphQLList, GraphQLInt, GraphQLBoolean } from "graphql"
+
+const PopularArtistsType = new GraphQLObjectType({
+  name: "PopularArtists",
+  fields: () => ({
+    artists: {
+      type: new GraphQLList(Artist.type),
+      resolve: results => results,
+    },
+  }),
+})
+
+const PopularArtists = {
+  type: PopularArtistsType,
+  description: "Popular artists",
+  args: {
+    exclude_followed_artists: {
+      type: GraphQLBoolean,
+      description: "If true, will exclude followed artists for the user",
+    },
+    size: {
+      type: GraphQLInt,
+      description: "Number of results to return",
+    },
+  },
+  resolve: ({ userID, popularArtistsLoader, authenticatedPopularArtistsLoader }, options) => {
+    const loader = userID ? authenticatedPopularArtistsLoader : popularArtistsLoader
+    return loader(options)
+  },
+}
+
+export default PopularArtists

--- a/schema/artists/trending.js
+++ b/schema/artists/trending.js
@@ -1,7 +1,7 @@
 import delta from "lib/loaders/legacy/delta"
 import gravity from "lib/loaders/legacy/gravity"
 import { keys, without } from "lodash"
-import Artist from "./artist"
+import Artist from "../artist"
 import {
   GraphQLString,
   GraphQLObjectType,

--- a/schema/home/context.js
+++ b/schema/home/context.js
@@ -6,7 +6,7 @@ import Sale from "schema/sale/index"
 import Gene from "schema/gene"
 import Artist from "schema/artist/index"
 import FollowArtists from "schema/me/follow_artists"
-import Trending from "schema/trending"
+import Trending from "schema/artists/trending"
 import { GraphQLUnionType, GraphQLObjectType } from "graphql"
 
 export const HomePageModuleContextFairType = create(Fair.type, {

--- a/schema/index.js
+++ b/schema/index.js
@@ -28,13 +28,14 @@ import PartnerCategory from "./partner_category"
 import PartnerCategories from "./partner_categories"
 import PartnerShow from "./partner_show"
 import PartnerShows from "./partner_shows"
+import PopularArtists from "./artists/popular"
 import Sale from "./sale/index"
 import Sales from "./sales"
 import SaleArtwork from "./sale_artwork"
 import Search from "./search"
 import Show from "./show"
 import Tag from "./tag"
-import TrendingArtists from "./trending"
+import TrendingArtists from "./artists/trending"
 import MatchArtist from "./match/artist"
 import Me from "./me"
 
@@ -92,6 +93,7 @@ const rootFields = {
   status: Status,
   tag: Tag,
   trending_artists: TrendingArtists,
+  popular_artists: PopularArtists,
 }
 
 const ViewerType = new GraphQLObjectType({

--- a/test/schema/artists/__snapshots__/popular.js.snap
+++ b/test/schema/artists/__snapshots__/popular.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`when an anonymous user makes a call for popular artists to the popularArtistsLoader 1`] = `
+Object {
+  "popular_artists": Object {
+    "artists": Array [
+      Object {
+        "id": "ortina",
+      },
+      Object {
+        "id": "xtina",
+      },
+    ],
+  },
+}
+`;
+
+exports[`when logged in makes a call for popular artists to the auth'd popularArtistsLoader 1`] = `
+Object {
+  "popular_artists": Object {
+    "artists": Array [
+      Object {
+        "id": "ortina",
+      },
+      Object {
+        "id": "xtina",
+      },
+    ],
+  },
+}
+`;

--- a/test/schema/artists/popular.js
+++ b/test/schema/artists/popular.js
@@ -1,0 +1,56 @@
+import { runAuthenticatedQuery, runQuery } from "test/utils"
+import gql from "test/gql"
+
+describe("when logged in", () => {
+  it("makes a call for popular artists to the auth'd popularArtistsLoader", () => {
+    const query = gql`
+      {
+        popular_artists {
+          artists {
+            id
+          }
+        }
+      }
+    `
+
+    const rootValue = {
+      authenticatedPopularArtistsLoader: () =>
+        Promise.resolve([
+          { birthday: "1900", artworks_count: 100, id: "ortina" },
+          { birthday: "1900", artworks_count: 100, id: "xtina" },
+        ]),
+    }
+
+    expect.assertions(1)
+    return runAuthenticatedQuery(query, rootValue).then(data => {
+      expect(data).toMatchSnapshot()
+    })
+  })
+})
+
+describe("when an anonymous user", () => {
+  it("makes a call for popular artists to the popularArtistsLoader", () => {
+    const query = gql`
+      {
+        popular_artists {
+          artists {
+            id
+          }
+        }
+      }
+    `
+
+    const rootValue = {
+      popularArtistsLoader: () =>
+        Promise.resolve([
+          { birthday: "1900", artworks_count: 100, id: "ortina" },
+          { birthday: "1900", artworks_count: 100, id: "xtina" },
+        ]),
+    }
+
+    expect.assertions(1)
+    return runQuery(query, rootValue).then(data => {
+      expect(data).toMatchSnapshot()
+    })
+  })
+})

--- a/test/utils.js
+++ b/test/utils.js
@@ -14,7 +14,7 @@ import { graphql } from "graphql"
  *
  * @todo This assumes there will always be just 1 error, not sure how to handle this differently.
  */
-export const runQuery = (query: string, rootValue: ?any = { accessToken: null, userID: null }) => {
+export const runQuery = (query, rootValue = { accessToken: null, userID: null }) => {
   return graphql(schema, query, rootValue, {}).then(result => {
     if (result.errors) {
       const error = result.errors[0]
@@ -28,8 +28,10 @@ export const runQuery = (query: string, rootValue: ?any = { accessToken: null, u
 /**
  * Same as `runQuery` except it provides a `rootValue` that’s required for authenticated queries.
  *
+ * @param {String} query      The GraphQL query to run.
+ * @param {Object} rootValue  The request params, which currently are `accessToken` and `userID`.
  * @see runQuery
  */
-export const runAuthenticatedQuery = (query: string, rootValue: ?any = {}) => {
+export const runAuthenticatedQuery = (query, rootValue = {}) => {
   return runQuery(query, Object.assign({ accessToken: "secret", userID: "user-42" }, rootValue))
 }


### PR DESCRIPTION
Covers the gravity route `artists/popular`, copying the pattern set by `trending_artists`. 

![screen shot 2017-10-04 at 3 13 27 pm](https://user-images.githubusercontent.com/49038/31194961-b82446fc-a916-11e7-8059-e67cc9a71b08.png)

*Interesting sidenote*: this route works for both auth'd and unauth'd users. It's because there [is a param](https://github.com/artsy/gravity/blob/cb728d02a59ca232df2eb0cac19d17d016f629fa/app/api/v1/artists_endpoint.rb#L189) `exclude_followed_artists` which is only accessible if you're logged in. So we switch between auth/unauth'd loaders depending on whether you're a logged in user. 

TBH though, and this is probably something we should do in another PR, or have a quick chat about is that should these kind of things should get scoped somewhere? E.g.

```graphql
{
  artist_things {
   popular {

   }  
  trending {
 
   }
  }
}
```