### PR TITLE
Pass thru gene family pagination params to Gravity

### DIFF
--- a/schema/gene.js
+++ b/schema/gene.js
@@ -11,7 +11,7 @@ import Image from "./image"
 import filterArtworks, { filterArtworksArgs } from "./filter_artworks"
 import { queriedForFieldsOtherThanBlacklisted, parseRelayOptions } from "lib/helpers"
 import { GravityIDFields, NodeInterface } from "./object_identification"
-import { GraphQLObjectType, GraphQLString, GraphQLNonNull, GraphQLList, GraphQLInt } from "graphql"
+import { GraphQLObjectType, GraphQLString, GraphQLNonNull, GraphQLList, GraphQLInt, GraphQLBoolean } from "graphql"
 
 const SUBJECT_MATTER_MATCHES = [
   "content",
@@ -81,12 +81,19 @@ const GeneType = new GraphQLObjectType({
     description: {
       type: GraphQLString,
     },
+    display_name: {
+      type: GraphQLString,
+    },
     filtered_artworks: filterArtworks("gene_id"),
     href: {
       type: GraphQLString,
       resolve: ({ id }) => `gene/${id}`,
     },
     image: Image,
+    is_published: {
+      type: GraphQLBoolean,
+      resolve: ({ published }) => published,
+    },
     mode: {
       type: GraphQLString,
       resolve: ({ type }) => {

--- a/schema/gene_families.js
+++ b/schema/gene_families.js
@@ -1,11 +1,20 @@
 import GeneFamily from "./gene_family"
-import { GraphQLList } from "graphql"
+import { GraphQLList, GraphQLInt } from "graphql"
 
 const GeneFamilies = {
   type: new GraphQLList(GeneFamily.type),
   description: "A list of Gene Families",
-  resolve: (_source, _args, _request, { rootValue }) => {
-    return rootValue.geneFamiliesLoader()
+  args: {
+    page: {
+      type: GraphQLInt,
+    },
+    size: {
+      type: GraphQLInt,
+    },
+  },
+  resolve: (_source, options, _request, { rootValue }) => {
+    const gravityOptions = Object.assign({}, options, { sort: "position" })
+    return rootValue.geneFamiliesLoader(gravityOptions)
   },
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/artsy/gravity/pull/11304

This adds pagination and sorting to the `GeneFamily` schema and exposes a few additional `Gene` attributes
