### PR TITLE
Removes New Relic browser monitoring.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import Bluebird from "bluebird"
-import newrelic from "artsy-newrelic"
+import "artsy-newrelic"
 import xapp from "artsy-xapp"
 import cors from "cors"
 import depthLimit from "graphql-depth-limit"
@@ -24,8 +24,6 @@ const { PORT, NODE_ENV, GRAVITY_API_URL, GRAVITY_ID, GRAVITY_SECRET } = process.
 
 const app = express()
 const port = PORT || 3000
-
-app.use(newrelic)
 
 if (NODE_ENV === "production") {
   app.set("forceSSLOptions", { trustXFPHeader: true }).use(forceSSL)


### PR DESCRIPTION
Signed-off-by: Ash Furrow <ash@ashfurrow.com>

By importing the module, we are loading New Relic. By using it's middleware, we _were_ adding browser monitoring, which was causing a lot of logs like this:

> {"v":0,"level":40,"name":"newrelic","hostname":"XXX","pid":15,"time":"2017-10-10T20:19:29.239Z","msg":"NREUM: browser_monitoring requires valid application_id","component":"api"}

