### PR TITLE
Removes logging for Query depths.

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,9 +86,7 @@ app.use(
         ...createLoaders(accessToken, userID, requestID),
       },
       formatError: graphqlErrorHandler(request.body),
-      validationRules: [
-        depthLimit(queryLimit, { ignore: [] }, depths => console.log("Depths: ", depths)), // eslint-disable-line
-      ],
+      validationRules: [depthLimit(queryLimit)],
     }
   })
 )


### PR DESCRIPTION
Pretty straightforward PR. Since we now know the maximum depths of queries run in production, we no longer need to log them.