### PR TITLE
[Gene] Add aggregation metadata to artworks connection.

### DIFF
--- a/schema/filter_artworks.js
+++ b/schema/filter_artworks.js
@@ -171,6 +171,7 @@ export const filterArtworksArgs = {
   },
   page: {
     type: GraphQLInt,
+    defaultValue: 1,
   },
   sale_id: {
     type: GraphQLID,

--- a/schema/gene.js
+++ b/schema/gene.js
@@ -1,14 +1,14 @@
 // @ts-check
 import type { GraphQLFieldConfig } from "graphql"
 import { pageable } from "relay-cursor-paging"
-import { connectionFromArraySlice } from "graphql-relay"
+import { connectionDefinitions, connectionFromArraySlice } from "graphql-relay"
 import _ from "lodash"
 import gravity from "lib/loaders/legacy/gravity"
 import cached from "./fields/cached"
-import { artworkConnection } from "./artwork"
+import Artwork from "./artwork"
 import Artist, { artistConnection } from "./artist"
 import Image from "./image"
-import filterArtworks, { filterArtworksArgs } from "./filter_artworks"
+import filterArtworks, { ArtworkFilterAggregations, filterArtworksArgs, FilterArtworksCounts } from "./filter_artworks"
 import { queriedForFieldsOtherThanBlacklisted, parseRelayOptions } from "lib/helpers"
 import { GravityIDFields, NodeInterface } from "./object_identification"
 import { GraphQLObjectType, GraphQLString, GraphQLNonNull, GraphQLList, GraphQLInt, GraphQLBoolean } from "graphql"
@@ -57,7 +57,14 @@ const GeneType = new GraphQLObjectType({
       },
     },
     artworks_connection: {
-      type: artworkConnection,
+      type: connectionDefinitions({
+        name: "GeneArtworks",
+        nodeType: Artwork.type,
+        connectionFields: {
+          aggregations: ArtworkFilterAggregations,
+          counts: FilterArtworksCounts,
+        },
+      }).connectionType,
       args: pageable(filterArtworksArgs),
       resolve: ({ id }, options, request, { rootValue: { accessToken } }) => {
         const gravityOptions = parseRelayOptions(options)
@@ -70,11 +77,20 @@ const GeneType = new GraphQLObjectType({
         }
         // Manually set the gene_id to the current id
         gravityOptions.gene_id = id
-        return gravity.with(accessToken)("filter/artworks", gravityOptions).then(response => {
-          return connectionFromArraySlice(response.hits, options, {
-            arrayLength: response.aggregations.total.value,
-            sliceStart: gravityOptions.offset,
-          })
+        /**
+         * FIXME: There’s no need for this loader to be authenticated (and not cache data), unless the
+         *        `include_artworks_by_followed_artists` argument is given. Perhaps we can have specialized loaders that
+         *        compose authenticated and unauthenticated loaders based on the request?
+         *        Here’s an example of such a setup https://gist.github.com/alloy/69bb274039ecd552de76c3f1739c519e
+         */
+        return gravity.with(accessToken)("filter/artworks", gravityOptions).then(({ aggregations, hits }) => {
+          return Object.assign(
+            { aggregations }, // Add data to connection so the `aggregations` connection field can resolve it
+            connectionFromArraySlice(hits, options, {
+              arrayLength: aggregations.total.value,
+              sliceStart: gravityOptions.offset,
+            })
+          )
         })
       },
     },

--- a/test/schema/filter_artworks.js
+++ b/test/schema/filter_artworks.js
@@ -15,6 +15,7 @@ describe("Filter Artworks", () => {
         .withArgs("filter/artworks", {
           gene_id: "500-1000-ce",
           aggregations: ["total"],
+          page: 1,
         })
         .returns(
           Promise.resolve({

--- a/test/schema/gene/gene.js
+++ b/test/schema/gene/gene.js
@@ -141,11 +141,14 @@ describe("Gene", () => {
       })
     })
 
-    it("exposes aggregation information", () => {
+    it("exposes aggregation metadata", () => {
       const query = `
         {
           gene(id: "500-1000-ce") {
             artworks_connection(aggregations: [MEDIUM], first: 10) {
+              counts {
+                total
+              }
               aggregations {
                 slice
                 counts {
@@ -163,6 +166,9 @@ describe("Gene", () => {
         expect(data).toEqual({
           gene: {
             artworks_connection: {
+              counts: {
+                total: 20,
+              },
               aggregations: [
                 {
                   slice: "MEDIUM",


### PR DESCRIPTION
Part of the fix for https://github.com/artsy/force/issues/1822

The `filter_artworks.artworks_connection` field is problematic, because it requires both `filter_artworks` and `artworks_connection` fields to receive pagination information, which is unintuitive.

Seeing as the `artworks_connection` field on the `Gene` type already is backed by the filter endpoint, I took this opportunity to see what it would look like to integrate the aggregation results more fully inside the connection itself.