### PR TITLE
Convert GeneFamiles pagination to connection

### DIFF
--- a/schema/gene_families.js
+++ b/schema/gene_families.js
@@ -1,20 +1,17 @@
 import GeneFamily from "./gene_family"
-import { GraphQLList, GraphQLInt } from "graphql"
+import { pageable } from "relay-cursor-paging"
+import { connectionDefinitions, connectionFromPromisedArray } from "graphql-relay"
+import { parseRelayOptions } from "lib/helpers"
+
+const { connectionType: GeneFamilyConnection } = connectionDefinitions({ nodeType: GeneFamily.type })
 
 const GeneFamilies = {
-  type: new GraphQLList(GeneFamily.type),
+  type: GeneFamilyConnection,
   description: "A list of Gene Families",
-  args: {
-    page: {
-      type: GraphQLInt,
-    },
-    size: {
-      type: GraphQLInt,
-    },
-  },
-  resolve: (_source, options, _request, { rootValue }) => {
-    const gravityOptions = Object.assign({}, options, { sort: "position" })
-    return rootValue.geneFamiliesLoader(gravityOptions)
+  args: pageable(),
+  resolve: (_root, options, _request, { rootValue }) => {
+    const gravityOptions = Object.assign({}, parseRelayOptions(options), { sort: "position" })
+    return connectionFromPromisedArray(rootValue.geneFamiliesLoader(gravityOptions), gravityOptions)
   },
 }
 

--- a/test/schema/gene/__snapshots__/gene_families.js.snap
+++ b/test/schema/gene/__snapshots__/gene_families.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GeneFamilies returns a list of gene families 1`] = `
+Object {
+  "gene_families": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "id": "design-concepts-and-techniques",
+          "name": "Design Concepts and Techniques",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "furniture-and-lighting",
+          "name": "Furniture & Lighting",
+        },
+      },
+    ],
+  },
+}
+`;

--- a/test/schema/gene/gene_families.js
+++ b/test/schema/gene/gene_families.js
@@ -17,14 +17,18 @@ describe("GeneFamilies", () => {
     const query = `
       {
         gene_families {
-          id
-          name
+          edges {
+            node {
+              id
+              name
+            }
+          }
         }
       }
     `
 
-    return runQuery(query, { geneFamiliesLoader }).then(data => {
-      expect(data).toEqual({ gene_families: api_data })
+    return runQuery(query, { geneFamiliesLoader }).then(geneFamilies => {
+      expect(geneFamilies).toMatchSnapshot()
     })
   })
 })


### PR DESCRIPTION
@alloy [pointed out](https://artsy.slack.com/archives/C1HH3KNJG/p1508149028000096) that going forward we should prefer [**connections**](https://facebook.github.io/relay/graphql/connections.htm) for list types in our schemas.

Accordingly, this updates the recently added `GeneFamilies` schema to use a connection. 

#### Before

![before](https://user-images.githubusercontent.com/140521/31623666-310ec2ee-b26e-11e7-8134-65f15511ad9e.png)

#### After 

![after](https://user-images.githubusercontent.com/140521/31623668-3288e2b2-b26e-11e7-9a93-2280fa0b9d02.png)