### PR TITLE
[Onboarding] add intents property to collector profile schema

### DIFF
--- a/schema/me/collector_profile.js
+++ b/schema/me/collector_profile.js
@@ -1,7 +1,7 @@
 import date from "schema/fields/date"
 import gravity from "lib/loaders/legacy/gravity"
 import { IDFields } from "schema/object_identification"
-import { GraphQLObjectType, GraphQLString, GraphQLInt } from "graphql"
+import { GraphQLObjectType, GraphQLString, GraphQLInt, GraphQLList } from "graphql"
 
 export const CollectorProfileFields = {
   ...IDFields,
@@ -21,6 +21,9 @@ export const CollectorProfileFields = {
   loyalty_applicant_at: date,
   professional_buyer_at: date,
   professional_buyer_applied_at: date,
+  intents: {
+    type: new GraphQLList(GraphQLString),
+  },
 }
 
 export const CollectorProfileType = new GraphQLObjectType({

--- a/test/schema/me/collector_profile.js
+++ b/test/schema/me/collector_profile.js
@@ -25,6 +25,7 @@ describe("Me", () => {
               name
               email
               self_reported_purchases
+              intents
             }
           }
         }
@@ -35,6 +36,7 @@ describe("Me", () => {
         name: "Percy",
         email: "percy@cat.com",
         self_reported_purchases: "treats",
+        intents: ["buy art & design"],
       }
 
       const expectedProfileData = {
@@ -42,6 +44,7 @@ describe("Me", () => {
         name: "Percy",
         email: "percy@cat.com",
         self_reported_purchases: "treats",
+        intents: ["buy art & design"],
       }
 
       gravity.returns(Promise.resolve(collectorProfile))


### PR DESCRIPTION
This adds the `intents` property to the `collector_profile` object on the me schema in order to implement the [collector intent question](https://github.com/artsy/collector-experience/issues/504) with a [graphQL mutation](https://github.com/artsy/collector-experience/issues/564#issuecomment-336897545).