### PR TITLE
[Artist] add suggested artist field from /me/suggested/artists for onboarding

### DIFF
--- a/lib/loaders/loaders_with_authentication/index.js
+++ b/lib/loaders/loaders_with_authentication/index.js
@@ -31,6 +31,7 @@ export default (accessToken, userID, requestID) => {
       "artworks",
       "is_saved"
     ),
+    suggestedArtistsLoader: gravityLoader("me/suggested/artists"),
     lotStandingLoader: gravityLoader("me/lot_standings"),
     authenticatedPopularArtistsLoader: gravityLoader("artists/popular"),
     ...convectionLoaders(accessToken, requestID),

--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -89,7 +89,8 @@ const ShowField = {
       defaults(options, {
         artist_id: id,
         sort: "-end_at",
-      })).then(shows => showsWithBLacklistedPartnersRemoved(shows))
+      })
+    ).then(shows => showsWithBLacklistedPartnersRemoved(shows))
   },
 }
 
@@ -136,6 +137,37 @@ export const ArtistType = new GraphQLObjectType({
           relatedMainArtistsLoader(
             defaults(options, {
               artist: [id],
+            })
+          ),
+      },
+      suggested_artists: {
+        // '/me/suggested/artists'
+        type: new GraphQLList(Artist.type), // eslint-disable-line no-use-before-define
+        args: {
+          size: {
+            type: GraphQLInt,
+            description: "The number of Artists to return",
+          },
+          exclude_artists_without_artworks: {
+            type: GraphQLBoolean,
+            defaultValue: false,
+          },
+          exclude_artists_without_forsale_artworks: {
+            type: GraphQLBoolean,
+            defaultValue: false,
+          },
+          exclude_followed_artists: {
+            type: GraphQLBoolean,
+            defaultValue: true,
+          },
+          exclude_artist_ids: {
+            type: new GraphQLList(GraphQLString),
+          },
+        },
+        resolve: ({ id }, options, request, { rootValue: { suggestedArtistsLoader } }) =>
+          suggestedArtistsLoader(
+            defaults(options, {
+              artist_id: id,
             })
           ),
       },


### PR DESCRIPTION
The spec for onboarding requires recommended artists to show after a user follows an artist [link to spec](https://github.com/artsy/collector-experience/issues/505). Whilst the Artist endpoint already has a field `artists` that contains related artists, we should be using the suggested endpoint to show user recommended artists. This is also used in Eigen's onboarding, previous discussion [here](https://github.com/artsy/eigen/issues/1449).

Made with @mennenia ^_^

![screen shot 2017-10-24 at 6 25 10 pm](https://user-images.githubusercontent.com/5201004/31971200-bf243246-b8e8-11e7-940b-13c434041f7f.png)
