### PR TITLE
Revert "[FilterArtworks] Default `page` to 1."

### DIFF
--- a/schema/filter_artworks.js
+++ b/schema/filter_artworks.js
@@ -176,7 +176,6 @@ export const filterArtworksArgs = {
   },
   page: {
     type: GraphQLInt,
-    defaultValue: 1,
   },
   sale_id: {
     type: GraphQLID,

--- a/test/schema/filter_artworks.js
+++ b/test/schema/filter_artworks.js
@@ -15,7 +15,6 @@ describe("Filter Artworks", () => {
         .withArgs("filter/artworks", {
           gene_id: "500-1000-ce",
           aggregations: ["total"],
-          page: 1,
         })
         .returns(
           Promise.resolve({

--- a/test/schema/gene/gene.js
+++ b/test/schema/gene/gene.js
@@ -18,7 +18,6 @@ describe("Gene", () => {
         .withArgs("filter/artworks", {
           gene_id: "500-1000-ce",
           aggregations: ["total"],
-          page: 1,
         })
         .returns(
           Promise.resolve({
@@ -42,7 +41,7 @@ describe("Gene", () => {
       const query = `
         {
           gene(id: "500-1000-ce") {
-            filtered_artworks(aggregations: [TOTAL]) {
+            filtered_artworks(aggregations:[TOTAL]){
               hits {
                 id
               }
@@ -216,6 +215,7 @@ describe("Gene", () => {
 
       Gene.__Rewire__("gravity", gravity)
     })
+
     it("does not have a next page when the requested amount exceeds the count", () => {
       const query = `
         {
@@ -241,6 +241,7 @@ describe("Gene", () => {
         })
       })
     })
+
     it("has a next page when the amount requested is less than the count", () => {
       const query = `
         {
@@ -284,7 +285,6 @@ describe("Gene", () => {
         .withArgs("filter/artworks", {
           gene_id: "500-1000-ce",
           aggregations: ["total"],
-          page: 1,
         })
         .returns(
           Promise.resolve({


### PR DESCRIPTION
This reverts commit 574d4309fdd152f47ac82764342ab326190418ca.

It lead to `options` containing `page: 1` [here](https://github.com/artsy/metaphysics/blob/0839e1e3f1a521c698dc41fe873f0b29af968458/schema/gene.js#L70), which subsequently lead to `page: 1` overriding the calculated `page` [here](https://github.com/artsy/metaphysics/blob/0839e1e3f1a521c698dc41fe873f0b29af968458/lib/helpers.js#L84).

I actually think the `Object.assign(…)` is done in the wrong order, `gravityArgs` should come first, but it felt kinda weird to override a `page` param when it exists, so opted for restoring the previous behaviour instead.