### PR TITLE
fix bad increments of sale_artwork within sale

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 8
+    version: 8.4
   pre:
     - mkdir ~/.yarn-cache
 deployment:

--- a/schema/sale_artwork.js
+++ b/schema/sale_artwork.js
@@ -45,7 +45,8 @@ const SaleArtworkType = new GraphQLObjectType({
               key: sale.increment_strategy,
             }).then(incrs => {
               // We already have the asking price for the lot. Produce a list
-              // of increments beyond that amount.
+              // of increments beyond that amount. Make a local copy of the
+              // tiers to avoid mutating the cached value.
               const tiers = incrs[0].increments.slice(0)
               const increments = [minimum_next_bid_cents]
               const limit = BIDDER_POSITION_MAX_BID_AMOUNT_CENTS_LIMIT || Number.MAX_SAFE_INTEGER

--- a/schema/sale_artwork.js
+++ b/schema/sale_artwork.js
@@ -46,7 +46,7 @@ const SaleArtworkType = new GraphQLObjectType({
             }).then(incrs => {
               // We already have the asking price for the lot. Produce a list
               // of increments beyond that amount.
-              const tiers = incrs[0].increments
+              const tiers = incrs[0].increments.slice(0)
               const increments = [minimum_next_bid_cents]
               const limit = BIDDER_POSITION_MAX_BID_AMOUNT_CENTS_LIMIT || Number.MAX_SAFE_INTEGER
               let current = 0 // Always start from zero, so that all prices are on-increment

--- a/schema/sale_artwork.js
+++ b/schema/sale_artwork.js
@@ -47,7 +47,7 @@ const SaleArtworkType = new GraphQLObjectType({
               // We already have the asking price for the lot. Produce a list
               // of increments beyond that amount. Make a local copy of the
               // tiers to avoid mutating the cached value.
-              const tiers = incrs[0].increments.slice(0)
+              const tiers = incrs[0].increments.slice()
               const increments = [minimum_next_bid_cents]
               const limit = BIDDER_POSITION_MAX_BID_AMOUNT_CENTS_LIMIT || Number.MAX_SAFE_INTEGER
               let current = 0 // Always start from zero, so that all prices are on-increment


### PR DESCRIPTION
Without using `slice`, I was mutating the cached promise returned by the call to `/increments`. For future lots with a lower starting price, this resulted potentially in some of the increment policy tiers having been excluded for subsequent calls to the `bid_increments` resolver.