### PR TITLE
[Onboarding] add match_gene

### DIFF
--- a/lib/loaders/loaders_without_authentication/gravity.js
+++ b/lib/loaders/loaders_without_authentication/gravity.js
@@ -23,5 +23,6 @@ export default requestID => {
     relatedShowsLoader: gravityLoader("related/shows"),
     saleLoader: gravityLoader(id => `sale/${id}`),
     salesLoader: gravityLoader("sales"),
+    matchGeneLoader: gravityLoader("match/genes"),
   }
 }

--- a/schema/index.js
+++ b/schema/index.js
@@ -38,6 +38,7 @@ import Show from "./show"
 import Tag from "./tag"
 import TrendingArtists from "./artists/trending"
 import MatchArtist from "./match/artist"
+import MatchGene from "./match/gene"
 import Me from "./me"
 
 import UpdateConversationMutation from "./me/conversation/update_mutation"
@@ -76,6 +77,7 @@ const rootFields = {
   gene_family: GeneFamily,
   home_page: HomePage,
   match_artist: MatchArtist,
+  match_gene: MatchGene,
   me: Me,
   node: ObjectIdentification.NodeField,
   ordered_set: OrderedSet,

--- a/schema/match/gene.js
+++ b/schema/match/gene.js
@@ -1,12 +1,9 @@
 // @ts-check
-import type { GraphQLFieldConfig } from "graphql"
 
 import { GraphQLString, GraphQLList, GraphQLNonNull, GraphQLInt } from "graphql"
 import Gene from "schema/gene"
 
-import gravity from "lib/loaders/legacy/gravity"
-
-const GeneMatch: GraphQLFieldConfig<typeof Gene, *> = {
+const GeneMatch = {
   type: new GraphQLList(Gene.type),
   description: "A Search for Genes",
   args: {
@@ -27,7 +24,7 @@ const GeneMatch: GraphQLFieldConfig<typeof Gene, *> = {
       description: "Exclude these MongoDB ids from results",
     },
   },
-  resolve: (root: any, options: any) => gravity("match/genes", options),
+  resolve: (_root, options, _request, { rootValue: { matchGeneLoader } }) => matchGeneLoader(options),
 }
 
 export default GeneMatch

--- a/schema/match/gene.js
+++ b/schema/match/gene.js
@@ -1,0 +1,33 @@
+// @ts-check
+import type { GraphQLFieldConfig } from "graphql"
+
+import { GraphQLString, GraphQLList, GraphQLNonNull, GraphQLInt } from "graphql"
+import Gene from "schema/gene"
+
+import gravity from "lib/loaders/legacy/gravity"
+
+const GeneMatch: GraphQLFieldConfig<typeof Gene, *> = {
+  type: new GraphQLList(Gene.type),
+  description: "A Search for Genes",
+  args: {
+    term: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "Your search term",
+    },
+    size: {
+      type: GraphQLInt,
+      description: "Maximum number of items to retrieve. Default: 5.",
+    },
+    page: {
+      type: GraphQLInt,
+      description: "Page to retrieve. Default: 1.",
+    },
+    exclude_ids: {
+      type: new GraphQLList(GraphQLString),
+      description: "Exclude these MongoDB ids from results",
+    },
+  },
+  resolve: (root: any, options: any) => gravity("match/genes", options),
+}
+
+export default GeneMatch

--- a/test/schema/match/gene.js
+++ b/test/schema/match/gene.js
@@ -1,20 +1,6 @@
-import schema from "schema"
 import { runQuery } from "test/utils"
 
 describe("MatchGene", () => {
-  let gravity
-
-  const MatchGene = schema.__get__("MatchGene")
-
-  beforeEach(() => {
-    gravity = sinon.stub()
-    MatchGene.__Rewire__("gravity", gravity)
-  })
-
-  afterEach(() => {
-    MatchGene.__ResetDependency__("gravity")
-  })
-
   it("queries match/genes for the term 'pop'", () => {
     const query = `
       {
@@ -25,7 +11,6 @@ describe("MatchGene", () => {
         }
       }
     `
-
     const response = [
       {
         family: {
@@ -46,9 +31,9 @@ describe("MatchGene", () => {
       },
     ]
 
-    gravity.withArgs("match/genes", { term: "pop" }).returns(Promise.resolve(response))
+    const matchGeneLoader = () => Promise.resolve(response)
 
-    return runQuery(query).then(data => {
+    return runQuery(query, { matchGeneLoader }).then(data => {
       expect(data).toEqual({
         match_gene: [{ id: "pop-art", name: "Pop Art", _id: "123456" }],
       })

--- a/test/schema/match/gene.js
+++ b/test/schema/match/gene.js
@@ -1,0 +1,57 @@
+import schema from "schema"
+import { runQuery } from "test/utils"
+
+describe("MatchGene", () => {
+  let gravity
+
+  const MatchGene = schema.__get__("MatchGene")
+
+  beforeEach(() => {
+    gravity = sinon.stub()
+    MatchGene.__Rewire__("gravity", gravity)
+  })
+
+  afterEach(() => {
+    MatchGene.__ResetDependency__("gravity")
+  })
+
+  it("queries match/genes for the term 'pop'", () => {
+    const query = `
+      {
+        match_gene(term: "pop") {
+          id
+          name
+          _id
+        }
+      }
+    `
+
+    const response = [
+      {
+        family: {
+          _id: "575ac46debad644c13000005",
+          id: "styles-and-movements",
+          name: "Styles and Movements",
+        },
+        _id: "123456",
+        id: "pop-art",
+        name: "Pop Art",
+        image_urls: {
+          big_and_tall: "https://d32dm0rphc51dk.cloudfront.net/zwMP_9kbs2XcSP\n >  TaGLJ6qw/big_and_tall.jpg",
+          square500: "https://d32dm0rphc51dk.cloudfront.net/zwMP_9kbs2XcSPTaG\n >  LJ6qw/square500.jpg",
+          tall: "https://d32dm0rphc51dk.cloudfront.net/zwMP_9kbs2XcSPTaGLJ6qw\n >  /tall.jpg",
+          thumb: "https://d32dm0rphc51dk.cloudfront.net/zwMP_9kbs2XcSPTaGLJ6q\n >  w/thumb.jpg",
+        },
+        browseable: true,
+      },
+    ]
+
+    gravity.withArgs("match/genes", { term: "pop" }).returns(Promise.resolve(response))
+
+    return runQuery(query).then(data => {
+      expect(data).toEqual({
+        match_gene: [{ id: "pop-art", name: "Pop Art", _id: "123456" }],
+      })
+    })
+  })
+})


### PR DESCRIPTION
This adds a scheme for the `match_gene` in order to search for genes in the [gene follow onboarding component](https://github.com/artsy/collector-experience/issues/506#issuecomment-340519191).  

![screen shot 2017-11-07 at 1 04 02 pm](https://user-images.githubusercontent.com/5201004/32509716-2b2a127a-c3bc-11e7-87c3-8b8d6aa0dc13.png)
