### PR TITLE
@acjay => use graphQLFloat type for increments #migration

### DIFF
--- a/schema/sale_artwork.js
+++ b/schema/sale_artwork.js
@@ -8,6 +8,7 @@ import Artwork from "./artwork"
 import Sale from "./sale"
 import { GravityIDFields } from "./object_identification"
 import {
+  GraphQLFloat,
   GraphQLObjectType,
   GraphQLID,
   GraphQLString,
@@ -38,7 +39,7 @@ const SaleArtworkType = new GraphQLObjectType({
         deprecationReason: "Favor `counts.bidder_positions`",
       },
       bid_increments: {
-        type: new GraphQLList(GraphQLInt),
+        type: new GraphQLList(GraphQLFloat),
         resolve: ({ minimum_next_bid_cents, sale_id }) => {
           return gravity(`sale/${sale_id}`).then(sale => {
             return gravity("increments", {


### PR DESCRIPTION
This PR changes the list of `bid_increments` to be of the `GraphQLFloat` type instead of `GraphQLInt`. We have sales running now (in HKD) with amounts over $24,000,000 which leads to this error `TypeError: Int cannot represent non 32-bit signed integer value: 2400000000` when trying to load increments.

The migration is to _also_ update the value of `BIDDER_POSITION_MAX_BID_AMOUNT_CENTS_LIMIT` in gravity and metaphysics. The current limit is actually below the starting price of this lot. (This has already been completed.)