### PR TITLE
WIP: Adds `time` to schema & refactors Gemini loaders

### DIFF
--- a/lib/loaders/api/index.js
+++ b/lib/loaders/api/index.js
@@ -4,9 +4,11 @@ import gravity from "lib/apis/gravity"
 import impulse from "lib/apis/impulse"
 import positron from "lib/apis/positron"
 import convection from "lib/apis/convection"
+import gemini from "lib/apis/gemini"
 
 import { apiLoaderWithAuthenticationFactory } from "lib/loaders/api/loader_with_authentication_factory"
 import { apiLoaderWithoutAuthenticationFactory } from "lib/loaders/api/loader_without_authentication_factory"
+import { loaderOneOffFactory } from "lib/loaders/api/loader_one_off_factory"
 
 export default requestID => ({
   /**
@@ -46,4 +48,16 @@ export default requestID => ({
    * Use this for authenticated requests.
    */
   convectionLoaderWithAuthenticationFactory: apiLoaderWithAuthenticationFactory(convection),
+
+  /**
+   * The Gravity loaders produced by this factory _will not_ cache any responses to memcache.
+   *
+   * You may use it for authenticated requests.
+   */
+  gravityLoaderWithoutAuthenticationWithoutCachingFactory: loaderOneOffFactory(gravity),
+
+  /**
+   * The Gemini loaders produced by this factory _will not_ cache any responses to memcache.
+   */
+  geminiLoader: loaderOneOffFactory(gemini),
 })

--- a/lib/loaders/api/loader_one_off_factory.js
+++ b/lib/loaders/api/loader_one_off_factory.js
@@ -7,12 +7,19 @@ import { loaderInterface } from "./loader_interface"
  * This factory provides a short-cut system for our data loader system, it provides
  * and uncached result that is close to the equivilent to calling the fetch request directly.
  *
- * @param {(string, any) => Promise<any>} api a function that performs an API request
- * @param {string} path the path for the API call
- * @param {any} options values which should be passed into the fetch request
+ * @param {(path: string, token: string | null, apiOptions: any) => Promise<any>} api an API request function
+ * @param {any} globalAPIOptions options that need to be passed to any API loader created with this factory
  */
 
-export const loaderOneOffFactory = (api, path, options) => {
-  const loader = new DataLoader(() => Promise.resolve([api(path, options).then(r => r.body)]), { cache: false })
-  return loaderInterface(loader, path, options)(options)
+export const loaderOneOffFactory = (api, globalAPIOptions = {}) => {
+  return (path, globalParams = {}, pathAPIOptions = {}) => {
+    const apiOptions = Object.assign({}, globalAPIOptions, pathAPIOptions)
+    const loader = new DataLoader(
+      keys => Promise.all(keys.map(key => Promise.resolve(api(key, null, apiOptions).then(r => r.body)))),
+      {
+        cache: false,
+      }
+    )
+    return loaderInterface(loader, path, globalParams)
+  }
 }

--- a/lib/loaders/loaders_without_authentication/gemini.js
+++ b/lib/loaders/loaders_without_authentication/gemini.js
@@ -1,36 +1,32 @@
 // @ts-check
 
-import gemini from "../../apis/gemini"
+import factories from "../api"
 import { unescape } from "querystring"
-
-import { loaderOneOffFactory } from "../api/loader_one_off_factory"
 
 const toBase64 = string => new Buffer(unescape(encodeURIComponent(string)), "binary").toString("base64")
 
-export default () => ({
-  // The outer function is so that we can pass params from the schema,
-  // into the gemini api.
-  createNewGeminiAssetLoader: ({ name, acl }) =>
-    loaderOneOffFactory(gemini, `uploads/new.json?acl=${acl}`, {
-      acl,
-      headers: {
-        Authorization: "Basic " + toBase64(name + ":"),
-      },
-    }),
-
-  createNewGeminiEntryAssetLoader: ({ template_key, source_key, source_bucket, metadata }) =>
-    loaderOneOffFactory(gemini, `entries.json`, {
-      method: "POST",
-      form: {
-        entry: {
-          template_key,
-          source_key,
-          source_bucket,
-          metadata,
+export default () => {
+  const { geminiLoader } = factories()
+  return {
+    createNewGeminiAssetLoader: (name, acl) =>
+      geminiLoader(`uploads/new.json?acl=${acl}`, {
+        acl,
+        headers: { Authorization: "Basic " + toBase64(name + ":") },
+      }),
+    createNewGeminiEntryAssetLoader: (template_key, source_key, source_bucket, metadata) =>
+      geminiLoader("entries.json", {
+        method: "POST",
+        form: {
+          entry: {
+            template_key,
+            source_key,
+            source_bucket,
+            metadata,
+          },
         },
-      },
-      headers: {
-        Authorization: "Basic " + toBase64(template_key + ":"),
-      },
-    }),
-})
+        headers: {
+          Authorization: "Basic " + toBase64(template_key + ":"),
+        },
+      }),
+  }
+}

--- a/lib/loaders/loaders_without_authentication/gravity.js
+++ b/lib/loaders/loaders_without_authentication/gravity.js
@@ -1,10 +1,13 @@
 // @ts-check
+import gravity from "../../apis/gravity"
 import factories from "../api"
+
+import { loaderOneOffFactory } from "../api/loader_one_off_factory"
 
 export default requestID => {
   const { gravityLoaderWithoutAuthenticationFactory } = factories(requestID)
   const gravityLoader = gravityLoaderWithoutAuthenticationFactory
-
+  const oneOffLoader = path => options => loaderOneOffFactory(gravity, path, options)
   return {
     artistArtworksLoader: gravityLoader(id => `artist/${id}/artworks`),
     popularArtistsLoader: gravityLoader(`artists/popular`),
@@ -24,6 +27,6 @@ export default requestID => {
     saleLoader: gravityLoader(id => `sale/${id}`),
     salesLoader: gravityLoader("sales"),
     matchGeneLoader: gravityLoader("match/genes"),
-    timeLoader: gravityLoader("system/time"),
+    timeLoader: oneOffLoader("system/time"),
   }
 }

--- a/lib/loaders/loaders_without_authentication/gravity.js
+++ b/lib/loaders/loaders_without_authentication/gravity.js
@@ -7,7 +7,7 @@ import { loaderOneOffFactory } from "../api/loader_one_off_factory"
 export default requestID => {
   const { gravityLoaderWithoutAuthenticationFactory } = factories(requestID)
   const gravityLoader = gravityLoaderWithoutAuthenticationFactory
-  const oneOffLoader = path => options => loaderOneOffFactory(gravity, path, options)
+  const oneOffLoader = pathFactory => (path, options) => loaderOneOffFactory(gravity, pathFactory(path), options)
   return {
     artistArtworksLoader: gravityLoader(id => `artist/${id}/artworks`),
     popularArtistsLoader: gravityLoader(`artists/popular`),
@@ -27,6 +27,6 @@ export default requestID => {
     saleLoader: gravityLoader(id => `sale/${id}`),
     salesLoader: gravityLoader("sales"),
     matchGeneLoader: gravityLoader("match/genes"),
-    timeLoader: oneOffLoader("system/time"),
+    systemLoader: oneOffLoader(path => `system/${path}`),
   }
 }

--- a/lib/loaders/loaders_without_authentication/gravity.js
+++ b/lib/loaders/loaders_without_authentication/gravity.js
@@ -24,5 +24,6 @@ export default requestID => {
     saleLoader: gravityLoader(id => `sale/${id}`),
     salesLoader: gravityLoader("sales"),
     matchGeneLoader: gravityLoader("match/genes"),
+    timeLoader: gravityLoader("system/time"),
   }
 }

--- a/lib/loaders/loaders_without_authentication/gravity.js
+++ b/lib/loaders/loaders_without_authentication/gravity.js
@@ -1,13 +1,11 @@
 // @ts-check
-import gravity from "../../apis/gravity"
 import factories from "../api"
 
-import { loaderOneOffFactory } from "../api/loader_one_off_factory"
-
 export default requestID => {
-  const { gravityLoaderWithoutAuthenticationFactory } = factories(requestID)
-  const gravityLoader = gravityLoaderWithoutAuthenticationFactory
-  const oneOffLoader = pathFactory => (path, options) => loaderOneOffFactory(gravity, pathFactory(path), options)
+  const {
+    gravityLoaderWithoutAuthenticationFactory: gravityLoader,
+    gravityLoaderWithoutAuthenticationWithoutCachingFactory: oneOffGravityLoader,
+  } = factories(requestID)
   return {
     artistArtworksLoader: gravityLoader(id => `artist/${id}/artworks`),
     popularArtistsLoader: gravityLoader(`artists/popular`),
@@ -27,6 +25,6 @@ export default requestID => {
     saleLoader: gravityLoader(id => `sale/${id}`),
     salesLoader: gravityLoader("sales"),
     matchGeneLoader: gravityLoader("match/genes"),
-    systemLoader: oneOffLoader(path => `system/${path}`),
+    systemLoader: oneOffGravityLoader(endpoint => `system/${endpoint}`),
   }
 }

--- a/schema/asset_uploads/create_asset_request_mutation.js
+++ b/schema/asset_uploads/create_asset_request_mutation.js
@@ -93,6 +93,6 @@ export default mutationWithClientMutationId({
   },
   mutateAndGetPayload: ({ name, acl }, request, { rootValue: { createNewGeminiAssetLoader } }) => {
     if (!createNewGeminiAssetLoader) return null
-    return createNewGeminiAssetLoader({ name, acl })
+    return createNewGeminiAssetLoader(name, acl)
   },
 })

--- a/schema/asset_uploads/finalize_asset_mutation.js
+++ b/schema/asset_uploads/finalize_asset_mutation.js
@@ -50,6 +50,6 @@ export default mutationWithClientMutationId({
     { rootValue: { createNewGeminiEntryAssetLoader } }
   ) => {
     if (!createNewGeminiEntryAssetLoader) return null
-    return createNewGeminiEntryAssetLoader({ name, template_key, source_key, source_bucket, metadata })
+    return createNewGeminiEntryAssetLoader(template_key, source_key, source_bucket, metadata)
   },
 })

--- a/schema/index.js
+++ b/schema/index.js
@@ -36,6 +36,7 @@ import SaleArtwork from "./sale_artwork"
 import Search from "./search"
 import Show from "./show"
 import Tag from "./tag"
+import Time from "./time"
 import TrendingArtists from "./artists/trending"
 import MatchArtist from "./match/artist"
 import MatchGene from "./match/gene"
@@ -97,6 +98,7 @@ const rootFields = {
   show: Show,
   status: Status,
   tag: Tag,
+  time: Time,
   trending_artists: TrendingArtists,
   popular_artists: PopularArtists,
 }

--- a/schema/time/index.js
+++ b/schema/time/index.js
@@ -27,7 +27,7 @@ export const TimeType = new GraphQLObjectType({
 const Time = {
   type: TimeType,
   description: "Artsy system time, never cached",
-  resolve: (root, params, request, { rootValue: { timeLoader } }) => timeLoader(),
+  resolve: (root, params, request, { rootValue: { systemLoader } }) => systemLoader("time"),
 }
 
 export default Time

--- a/schema/time/index.js
+++ b/schema/time/index.js
@@ -26,7 +26,7 @@ export const TimeType = new GraphQLObjectType({
 
 const Time = {
   type: TimeType,
-  description: "Artsy system time",
+  description: "Artsy system time, never cached",
   resolve: (root, params, request, { rootValue: { timeLoader } }) => timeLoader(),
 }
 

--- a/schema/time/index.js
+++ b/schema/time/index.js
@@ -1,0 +1,33 @@
+import { GraphQLString, GraphQLBoolean, GraphQLInt, GraphQLObjectType } from "graphql"
+
+export const timeFields = () => {
+  return {
+    day: { type: GraphQLInt },
+    wday: { type: GraphQLInt },
+    month: { type: GraphQLInt },
+    year: { type: GraphQLInt },
+    hour: { type: GraphQLInt },
+    min: { type: GraphQLInt },
+    sec: { type: GraphQLInt },
+    dst: { type: GraphQLBoolean },
+    unix: { type: GraphQLInt },
+    utc_offset: { type: GraphQLInt },
+    zone: { type: GraphQLString },
+    iso8601: { type: GraphQLString },
+  }
+}
+
+export const TimeType = new GraphQLObjectType({
+  name: "Time",
+  fields: () => ({
+    ...timeFields(),
+  }),
+})
+
+const Time = {
+  type: TimeType,
+  description: "Artsy system time",
+  resolve: (root, params, request, { rootValue: { timeLoader } }) => timeLoader(),
+}
+
+export default Time

--- a/test/schema/time/__snapshots__/index.js.snap
+++ b/test/schema/time/__snapshots__/index.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Time type returns the system time 1`] = `
+Object {
+  "time": Object {
+    "day": 15,
+    "dst": false,
+    "hour": 19,
+    "iso8601": "2017-11-15T19:45:03Z",
+    "min": 45,
+    "month": 11,
+    "sec": 3,
+    "unix": 1510775103,
+    "utc_offset": 0,
+    "wday": 3,
+    "year": 2017,
+    "zone": "UTC",
+  },
+}
+`;

--- a/test/schema/time/index.js
+++ b/test/schema/time/index.js
@@ -1,0 +1,46 @@
+import { runQuery } from "test/utils"
+
+describe("Time type", () => {
+  it("returns the system time", () => {
+    const fullQuery = `
+    {
+      time {
+        day
+        wday
+        month
+        year
+        hour
+        min
+        sec
+        dst
+        unix
+        utc_offset
+        zone
+        iso8601
+      }
+    }
+    `
+    const rootValue = {
+      timeLoader: () =>
+        Promise.resolve({
+          day: 15,
+          wday: 3,
+          month: 11,
+          year: 2017,
+          hour: 19,
+          min: 45,
+          sec: 3,
+          dst: false,
+          unix: 1510775103,
+          utc_offset: 0,
+          zone: "UTC",
+          iso8601: "2017-11-15T19:45:03Z",
+        }),
+    }
+
+    expect.assertions(1)
+    return runQuery(fullQuery, rootValue).then(response => {
+      expect(response).toMatchSnapshot()
+    })
+  })
+})

--- a/test/schema/time/index.js
+++ b/test/schema/time/index.js
@@ -21,7 +21,7 @@ describe("Time type", () => {
     }
     `
     const rootValue = {
-      timeLoader: () =>
+      systemLoader: () =>
         Promise.resolve({
           day: 15,
           wday: 3,


### PR DESCRIPTION
Follow [a discussion on Slack](https://artsy.slack.com/archives/C0C4AJ1PF/p1510775689000184), this PR started as solely the addition of `time` to the GraphQL schema. However, after exploring the idioms a bit, I thought it might make sense to refactor the Gemini loaders to make the `loaderOneOffFactory` have the same shape as the other loader factories. If that's not something we want to pursue, we can just drop https://github.com/artsy/metaphysics/commit/3fa755d611711a21957dce4321ad8ed05e08ebe2 from the PR.

![screen shot 2017-11-15 at 9 47 38 pm](https://user-images.githubusercontent.com/498212/32871366-9c35a464-ca4e-11e7-878d-f3e8ee113660.png)

WIP because I still need to test that the Gemini loaders actually work 🙊 