### PR TITLE
[Onboarding] add intents field to collector profile mutation

### DIFF
--- a/lib/loaders/loaders_with_authentication/gravity.js
+++ b/lib/loaders/loaders_with_authentication/gravity.js
@@ -36,5 +36,6 @@ export default (accessToken, userID, requestID) => {
     lotStandingLoader: gravityLoader("me/lot_standings"),
     authenticatedPopularArtistsLoader: gravityLoader("artists/popular"),
     updateMeLoader: gravityLoader("me", {}, { method: "PUT" }),
+    updateCollectorProfileLoader: gravityLoader("me/collector_profile", {}, { method: "PUT" }),
   }
 }

--- a/schema/me/update_collector_profile.js
+++ b/schema/me/update_collector_profile.js
@@ -1,4 +1,3 @@
-import gravity from "lib/loaders/legacy/gravity"
 import { CollectorProfileFields } from "./collector_profile"
 import { GraphQLBoolean, GraphQLString, GraphQLList } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
@@ -9,34 +8,22 @@ export default mutationWithClientMutationId({
   inputFields: {
     loyalty_applicant: {
       type: GraphQLBoolean,
-      defaultValue: false,
     },
     professional_buyer: {
       type: GraphQLBoolean,
-      defaultValue: false,
     },
     self_reported_purchases: {
       type: GraphQLString,
-      defaultValue: null,
     },
     intents: {
       type: new GraphQLList(GraphQLString),
     },
   },
   outputFields: CollectorProfileFields,
-  mutateAndGetPayload: (
-    { loyalty_applicant, professional_buyer, self_reported_purchases, intents },
-    request,
-    { rootValue: { accessToken } }
-  ) => {
-    if (!accessToken) return null
-    return gravity.with(accessToken, {
-      method: "PUT",
-    })("me/collector_profile", {
-      loyalty_applicant,
-      professional_buyer,
-      self_reported_purchases,
-      intents,
-    })
+  mutateAndGetPayload: (options, request, { rootValue: { updateCollectorProfileLoader } }) => {
+    if (!updateCollectorProfileLoader) {
+      throw new Error("Missing Update Collector Profile Loader. Check your access token.")
+    }
+    return updateCollectorProfileLoader(options)
   },
 })

--- a/schema/me/update_collector_profile.js
+++ b/schema/me/update_collector_profile.js
@@ -1,6 +1,6 @@
 import gravity from "lib/loaders/legacy/gravity"
 import { CollectorProfileFields } from "./collector_profile"
-import { GraphQLBoolean, GraphQLString } from "graphql"
+import { GraphQLBoolean, GraphQLString, GraphQLList } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 
 export default mutationWithClientMutationId({
@@ -9,17 +9,23 @@ export default mutationWithClientMutationId({
   inputFields: {
     loyalty_applicant: {
       type: GraphQLBoolean,
+      defaultValue: false,
     },
     professional_buyer: {
       type: GraphQLBoolean,
+      defaultValue: false,
     },
     self_reported_purchases: {
       type: GraphQLString,
+      defaultValue: null,
+    },
+    intents: {
+      type: new GraphQLList(GraphQLString),
     },
   },
   outputFields: CollectorProfileFields,
   mutateAndGetPayload: (
-    { loyalty_applicant, professional_buyer, self_reported_purchases },
+    { loyalty_applicant, professional_buyer, self_reported_purchases, intents },
     request,
     { rootValue: { accessToken } }
   ) => {
@@ -30,6 +36,7 @@ export default mutationWithClientMutationId({
       loyalty_applicant,
       professional_buyer,
       self_reported_purchases,
+      intents,
     })
   },
 })


### PR DESCRIPTION
This updates the `updateCollectorProfile` mutation in order to implement the data submission for the [Collector Intent](https://github.com/artsy/collector-experience/issues/504) question of onboarding. In this PR, I added the intents field, switched the data loader for a custom one, and added some better error handling for when the data loader is missing.

![screen shot 2017-11-17 at 2 13 29 pm](https://user-images.githubusercontent.com/5201004/32964589-b8d485b4-cba1-11e7-92ca-7a66e3aa5ce3.png)
