### PR TITLE
[Onboarding] refactor intents type to be an enum

### DIFF
--- a/schema/me/update_collector_profile.js
+++ b/schema/me/update_collector_profile.js
@@ -1,6 +1,30 @@
 import { CollectorProfileFields } from "./collector_profile"
-import { GraphQLBoolean, GraphQLString, GraphQLList } from "graphql"
+import { GraphQLBoolean, GraphQLString, GraphQLList, GraphQLEnumType } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
+
+export const IntentsType = new GraphQLEnumType({
+  name: "Intents",
+  values: {
+    BUY_ART_AND_DESIGN: {
+      value: "buy art & design",
+    },
+    SELL_ART_AND_DESIGN: {
+      value: "sell art & design",
+    },
+    RESEARCH_ART_PRICES: {
+      value: "research art prices",
+    },
+    LEARN_ABOUT_ART: {
+      value: "learn about art",
+    },
+    FIND_ART_EXHIBITS: {
+      value: "find out about new exhibitions",
+    },
+    READ_ART_MARKET_NEWS: {
+      value: "read art market news",
+    },
+  },
+})
 
 export default mutationWithClientMutationId({
   name: "UpdateCollectorProfile",
@@ -16,7 +40,7 @@ export default mutationWithClientMutationId({
       type: GraphQLString,
     },
     intents: {
-      type: new GraphQLList(GraphQLString),
+      type: new GraphQLList(IntentsType),
     },
   },
   outputFields: CollectorProfileFields,

--- a/test/schema/me/update_collector_profile.js
+++ b/test/schema/me/update_collector_profile.js
@@ -5,7 +5,7 @@ describe("UpdateCollectorProfile", () => {
     /* eslint-disable max-len */
     const mutation = `
       mutation {
-        updateCollectorProfile(input: { professional_buyer: true, loyalty_applicant: true, self_reported_purchases: "trust me i buy art" }) {
+        updateCollectorProfile(input: { professional_buyer: true, loyalty_applicant: true, self_reported_purchases: "trust me i buy art", intents: [BUY_ART_AND_DESIGN] }) {
           id
           name
           email


### PR DESCRIPTION
Switch the `intents` input field in the `updateCollectorProfile` mutation to be an enum.