### PR TITLE
Add timing/cache metadata to the dev extensions

### DIFF
--- a/lib/loaders/api/loader_with_authentication_factory.js
+++ b/lib/loaders/api/loader_with_authentication_factory.js
@@ -34,7 +34,6 @@ export const apiLoaderWithAuthenticationFactory = (api, apiName, globalAPIOption
                 clock.start()
                 return new Promise((resolve, reject) => {
                   verbose(`Requested: ${key}`)
-                  logger(globalAPIOptions.requestID, apiName, key)
                   api(key, accessToken, apiOptions)
                     .then(response => {
                       if (apiOptions.headers) {
@@ -42,7 +41,8 @@ export const apiLoaderWithAuthenticationFactory = (api, apiName, globalAPIOption
                       } else {
                         resolve(response.body)
                       }
-                      clock.end()
+                      const time = clock.end()
+                      logger(globalAPIOptions.requestID, apiName, key, { time, cache: false })
                     })
                     .catch(err => {
                       error(path, err)

--- a/lib/loaders/api/loader_without_authentication_factory.js
+++ b/lib/loaders/api/loader_without_authentication_factory.js
@@ -43,7 +43,9 @@ export const apiLoaderWithoutAuthenticationFactory = (api, apiName, globalAPIOpt
                   // Return cached data first
                   resolve(data)
                   verbose(`Cached: ${key}`)
-                  clock.end()
+
+                  const time = clock.end()
+                  logger(globalAPIOptions.requestID, apiName, key, { time, cache: true })
 
                   // Then refresh cache
                   throttled(key, () => {
@@ -62,12 +64,12 @@ export const apiLoaderWithoutAuthenticationFactory = (api, apiName, globalAPIOpt
                 },
                 // Cache miss
                 () => {
-                  logger(globalAPIOptions.requestID, apiName, key)
                   api(key, null, apiOptions)
                     .then(({ body }) => {
                       resolve(body)
                       verbose(`Requested (Uncached): ${key}`)
-                      clock.end()
+                      const time = clock.end()
+                      logger(globalAPIOptions.requestID, apiName, key, { time, cache: false })
                       cache.set(key, body)
                     })
                     .catch(err => {

--- a/lib/loaders/api/logger.js
+++ b/lib/loaders/api/logger.js
@@ -13,21 +13,22 @@ const requests = {}
  * @param requestID {string} the ID for the request
  * @param host {string} the type of server
  * @param key {string} basically query string for the call
+ * @param metadata {any} any additional details to go along
  */
-const logger = (requestID, host, key) => {
+const logger = (requestID, host, key, metadata) => {
   if (requests[requestID]) {
     const cache = requests[requestID]
 
     if (!cache[host]) {
       cache[host] = {
-        requests: [],
+        requests: {},
         count: 0,
       }
     }
 
     // Remove empty trailing `?`s
     const safeKey = key.replace(/(\?$)/, "")
-    cache[host].requests.push(safeKey)
+    cache[host].requests[safeKey] = metadata
     cache[host].count = cache[host].requests.length
   }
 }

--- a/lib/timer.js
+++ b/lib/timer.js
@@ -1,4 +1,5 @@
 import { info } from "./loggers"
+import { round } from "lodash"
 
 export default key => {
   const start = process.hrtime()
@@ -11,8 +12,9 @@ export default key => {
 
     end: () => {
       const end = process.hrtime(start)
-      info(`Elapsed: ${end[0]}s ${end[1] / 1000000}ms - ${key}`)
-      return end
+      const interval = `${end[0]}s ${round(end[1] / 1000000, 3)}ms`
+      info(`Elapsed: ${interval} - ${key}`)
+      return interval
     },
   }
 }


### PR DESCRIPTION
Increases the metadata coming from staging/dev mode metaphysics:

```graphql
{
  me {
    name # Not a dataloader
    followed_artists_connection(first:5) {
      edges {
        node {
          artist {
            name
          }
        }
      }
    }
  }
  popular_artists {
    artists{
      name
    }
  }
  artist(id:"banksy") {
    name
  }
  
  gene(id:"the-fantastic"){ # Not a dataloader
    name
    display_name
  }
}
```

to 

```json
{
  "data": {
    "me": {
      "name": "Orta Therox",
      "followed_artists_connection": {
        "edges": []
      }
    },
    "popular_artists": {
      "artists": [
        {
          "name": "Pablo Picasso"
        },
        [...]
      ]
    },
    "artist": {
      "name": "Banksy"
    },
    "gene": {
      "name": "The Fantastic",
      "display_name": null
    }
  },
  "extensions": {
    "requests": {
      "gravity": {
        "requests": {
          "artist/banksy": {
            "time": "0s 128.459ms",
            "cache": true
          },
          "artists/popular": {
            "time": "0s 340.384ms",
            "cache": false
          },
          "me/follow/artists?offset=0&size=5&total_count=true": {
            "time": "0s 178.794ms",
            "cache": false
          }
        }
      }
    },
    "requestID": "41686fd0-ce6d-11e7-ad3a-e5e3b0979c5d"
  }
}
```