### PR TITLE
[Onboarding] add price_range_min and price_range_max to UpdateMyProfile mutation

### DIFF
--- a/schema/me/__tests__/__snapshots__/update_me_mutation.test.js.snap
+++ b/schema/me/__tests__/__snapshots__/update_me_mutation.test.js.snap
@@ -10,6 +10,7 @@ Object {
       },
       "name": "andy-warhol",
       "phone": "1234890",
+      "price_range": "-1:50000",
     },
   },
 }

--- a/schema/me/__tests__/update_me_mutation.test.js
+++ b/schema/me/__tests__/update_me_mutation.test.js
@@ -11,6 +11,8 @@ describe("UpdateMeMutation", () => {
             clientMutationId: "1232"
             phone: "1234890"
             location: { address: "123 my street" }
+            price_range_min: -1
+            price_range_max: 50000
           }
         ) {
           user {
@@ -20,6 +22,7 @@ describe("UpdateMeMutation", () => {
               city
               address
             }
+            price_range
           }
         }
       }
@@ -34,6 +37,7 @@ describe("UpdateMeMutation", () => {
           location: {
             address: "123 my street",
           },
+          price_range: "-1:50000",
         }),
     }
 

--- a/schema/me/update_me_mutation.js
+++ b/schema/me/update_me_mutation.js
@@ -65,6 +65,14 @@ export default mutationWithClientMutationId({
       description: "The collector level for the user",
       type: GraphQLInt,
     },
+    price_range_min: {
+      description: "The minimum price collector has selected",
+      type: GraphQLInt,
+    },
+    price_range_max: {
+      description: "The maximum price collector has selected",
+      type: GraphQLInt,
+    },
   },
   outputFields: {
     user: {

--- a/schema/user.js
+++ b/schema/user.js
@@ -24,6 +24,10 @@ const UserType = new GraphQLObjectType({
       description: "The given location of the user as structured data",
       type: LocationType,
     },
+    price_range: {
+      description: "The price range the collector has selected",
+      type: GraphQLString,
+    },
   },
 })
 


### PR DESCRIPTION
Signed-off-by: Yuki Nishijima <yuki@artsymail.com>

We added the `price_range_min` and `price_range_max` fields to the `UpdateMyProfile` mutation. Initially we had added `price_range` but discovered that`/me` does not support `price_range`. For more context see [slack conversation](https://artsy.slack.com/archives/C0GNAB0US/p1511284180000014). This work is in support of the data submission for the [onboarding budget question](https://github.com/artsy/collector-experience/issues/507).

![screen shot 2017-11-21 at 2 28 07 pm](https://user-images.githubusercontent.com/5201004/33092482-400344b6-cec8-11e7-8683-d37876f00e51.png)
