### PR TITLE
Trace optimzations

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ import { forIn, has, assign } from "lodash"
 import uuid from "uuid/v1"
 import { fetchLoggerSetup, fetchLoggerRequestDone } from "lib/loaders/api/logger"
 import { timestamp } from "./lib/helpers"
+import { getNamedType, GraphQLObjectType } from "graphql"
 
 global.Promise = Bluebird
 
@@ -77,6 +78,7 @@ function pushFinishedSpan(finishedSpans, span) {
 }
 
 function processFinishedSpans(finishedSpans) {
+  console.log(finishedSpans.length)
   let i = 0
   const iter = () => {
     const entry = finishedSpans[i]
@@ -163,7 +165,7 @@ forIn(schema._typeMap, function (value, key) {
   const typeName = key
   if (has(value, "_fields")) {
     forIn(value._fields, function (field, fieldName) {
-      if (field.resolve instanceof Function) {
+      if (field.resolve instanceof Function && getNamedType(field.type) instanceof GraphQLObjectType) {
         field.resolve = wrapResolve(typeName, fieldName, field.resolve) // eslint-disable-line no-param-reassign
       }
     })


### PR DESCRIPTION
As [discussed in Slack](https://artsy.slack.com/archives/C1HH3KNJG/p1511366042000596) here are a few optimisations that:

* Ensure processing is done _after_ the response is sent to the client
* Other code gets a chance to enqueue work
* Only instrument resolvers of object types (we may be missing out on resolvers for scalar fields that _do_ perform IO work, though)
* Do not instrument resolvers of the introspection query

Better detection of interesting resolvers can be done by making them use async/await: https://github.com/artsy/metaphysics/issues/829