### PR TITLE
@joeyAghion => Add nested categories to a partner

### DIFF
--- a/schema/__tests__/object_identification.test.js
+++ b/schema/__tests__/object_identification.test.js
@@ -27,6 +27,13 @@ describe("Object Identification", () => {
         artists: null,
       },
     },
+    Partner: {
+      partnerLoader: {
+        id: "foo-bar",
+        has_full_profile: true,
+        profile_banner_display: false,
+      },
+    },
   }
 
   _.keys(loaderTests).forEach(typeName => {
@@ -82,12 +89,6 @@ describe("Object Identification", () => {
   })
 
   const tests = {
-    Partner: {
-      gravity: {
-        has_full_profile: true,
-        profile_banner_display: false,
-      },
-    },
     PartnerShow: {
       gravity: {
         displayable: true, // this is only so that the show doesn’t get rejected

--- a/schema/__tests__/partner.test.js
+++ b/schema/__tests__/partner.test.js
@@ -1,0 +1,56 @@
+import { runQuery } from "test/utils"
+
+describe("Partner type", () => {
+  let partner = null
+  let rootValue = null
+
+  beforeEach(() => {
+    partner = {
+      id: "catty-partner",
+      name: "Catty Partner",
+      has_full_profile: true,
+      profile_banner_display: true,
+      partner_categories: [
+        {
+          id: "blue-chip",
+          name: "Blue Chip",
+        },
+      ],
+    }
+
+    rootValue = {
+      partnerLoader: sinon
+        .stub()
+        .withArgs(partner.id)
+        .returns(Promise.resolve(partner)),
+    }
+  })
+
+  it("returns a partner and categories", () => {
+    const query = `
+      {
+        partner(id: "catty-partner") {
+          name
+          categories {
+            id
+            name
+          }
+        }
+      }
+    `
+
+    return runQuery(query, rootValue).then(data => {
+      expect(data).toEqual({
+        partner: {
+          name: "Catty Partner",
+          categories: [
+            {
+              id: "blue-chip",
+              name: "Blue Chip",
+            },
+          ],
+        },
+      })
+    })
+  })
+})

--- a/schema/partner.js
+++ b/schema/partner.js
@@ -12,6 +12,25 @@ import ArtworkSorts from "./sorts/artwork_sorts"
 
 import { GraphQLString, GraphQLObjectType, GraphQLNonNull, GraphQLInt, GraphQLList, GraphQLBoolean } from "graphql"
 
+const PartnerCategoryType = new GraphQLObjectType({
+  name: "Category",
+  desciption: "Fields of partner category (currently from Gravity).",
+  fields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    category_type: {
+      type: GraphQLString,
+    },
+    internal: {
+      type: GraphQLBoolean,
+    },
+    name: {
+      type: GraphQLString,
+    },
+  },
+})
+
 const PartnerType = new GraphQLObjectType({
   name: "Partner",
   interfaces: [NodeInterface],
@@ -45,6 +64,10 @@ const PartnerType = new GraphQLObjectType({
             })
           ).then(exclude(options.exclude, "id"))
         },
+      },
+      categories: {
+        type: new GraphQLList(PartnerCategoryType),
+        resolve: ({ partner_categories }) => partner_categories,
       },
       collecting_institution: {
         type: GraphQLString,
@@ -170,7 +193,7 @@ const Partner = {
       description: "The slug or ID of the Partner",
     },
   },
-  resolve: (root, { id }) => gravity(`partner/${id}`),
+  resolve: (root, { id }, _request, { rootValue: { partnerLoader } }) => partnerLoader(id),
 }
 
 export default Partner


### PR DESCRIPTION
So we can determine what category of partner represent a partner (where category is 'Blue Chip', 'Top Emerging', etc. - based on being included in that category).