### PR TITLE
@alloy => Make a connection for partner artists (+ cache headers for unauth'ed requests)

### DIFF
--- a/lib/loaders/api/loader_without_authentication_factory.js
+++ b/lib/loaders/api/loader_without_authentication_factory.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import DataLoader from "dataloader"
+import { pick } from "lodash"
 
 import { loaderInterface } from "./loader_interface"
 import cache from "lib/cache"
@@ -41,7 +42,11 @@ export const apiLoaderWithoutAuthenticationFactory = (api, apiName, globalAPIOpt
                 // Cache hit
                 data => {
                   // Return cached data first
-                  resolve(data)
+                  if (apiOptions.headers) {
+                    resolve(pick(data, ["body", "headers"]))
+                  } else {
+                    resolve(data)
+                  }
                   verbose(`Cached: ${key}`)
 
                   const time = clock.end()
@@ -50,9 +55,13 @@ export const apiLoaderWithoutAuthenticationFactory = (api, apiName, globalAPIOpt
                   // Then refresh cache
                   throttled(key, () => {
                     api(key, null, apiOptions)
-                      .then(({ body }) => {
+                      .then(({ body, headers }) => {
+                        if (apiOptions.headers) {
+                          cache.set(key, { body, headers })
+                        } else {
+                          cache.set(key, body)
+                        }
                         verbose(`Refreshing: ${key}`)
-                        cache.set(key, body)
                       })
                       .catch(err => {
                         if (err.statusCode === 404) {
@@ -65,12 +74,20 @@ export const apiLoaderWithoutAuthenticationFactory = (api, apiName, globalAPIOpt
                 // Cache miss
                 () => {
                   api(key, null, apiOptions)
-                    .then(({ body }) => {
-                      resolve(body)
+                    .then(({ body, headers }) => {
+                      if (apiOptions.headers) {
+                        resolve({ body, headers })
+                      } else {
+                        resolve(body)
+                      }
                       verbose(`Requested (Uncached): ${key}`)
                       const time = clock.end()
                       logger(globalAPIOptions.requestIDs.requestID, apiName, key, { time, cache: false })
-                      cache.set(key, body)
+                      if (apiOptions.headers) {
+                        cache.set(key, { body, headers })
+                      } else {
+                        cache.set(key, body)
+                      }
                     })
                     .catch(err => {
                       reject(err)

--- a/lib/loaders/loaders_without_authentication/gravity.js
+++ b/lib/loaders/loaders_without_authentication/gravity.js
@@ -14,7 +14,7 @@ export default requestIDs => {
     geneFamiliesLoader: gravityLoader("gene_families"),
     matchGeneLoader: gravityLoader("match/genes"),
     partnerArtistsForArtistLoader: gravityLoader(id => `artist/${id}/partner_artists`),
-    partnerArtistsLoader: gravityLoader("partner_artists"),
+    partnerArtistsLoader: gravityLoader("partner_artists", {}, { headers: true }),
     partnerLoader: gravityLoader(id => `partner/${id}`),
     partnerShowImagesLoader: gravityLoader(id => `partner_show/${id}/images`),
     partnersLoader: gravityLoader("partners"),

--- a/schema/artist/__tests__/highlights.test.js
+++ b/schema/artist/__tests__/highlights.test.js
@@ -10,7 +10,9 @@ describe("Artist Statuses", () => {
 
   beforeEach(() => {
     rootValue = {
-      partnerArtistsLoader: sinon.stub().returns(Promise.resolve([{ artist }])),
+      partnerArtistsLoader: sinon
+        .stub()
+        .returns(Promise.resolve({ headers: { "x-total-count": 1 }, body: [{ artist }] })),
       artistLoader: sinon.stub().returns(Promise.resolve(artist)),
     }
   })
@@ -20,9 +22,13 @@ describe("Artist Statuses", () => {
       {
         artist(id: "foo-bar") {
           highlights {
-            partner_artists {
-              artist {
-                id
+            partner_artists(first: 1) {
+              edges {
+                node {
+                  artist {
+                    id
+                  }
+                }
               }
             }
           }
@@ -33,13 +39,17 @@ describe("Artist Statuses", () => {
     const expectedHighlightData = {
       artist: {
         highlights: {
-          partner_artists: [
-            {
-              artist: {
-                id: "percy-z",
+          partner_artists: {
+            edges: [
+              {
+                node: {
+                  artist: {
+                    id: "percy-z",
+                  },
+                },
               },
-            },
-          ],
+            ],
+          },
         },
       },
     }

--- a/schema/artist/__tests__/highlights.test.js
+++ b/schema/artist/__tests__/highlights.test.js
@@ -8,11 +8,24 @@ describe("Artist Statuses", () => {
     artworks_count: 420,
   }
 
+  const partnerArtistResp = [
+    {
+      artist,
+      partner: {
+        id: "catty-gallery",
+        name: "Catty Gallery",
+        has_full_profile: true,
+        profile_banner_display: true,
+      },
+      represented_by: true,
+    },
+  ]
+
   beforeEach(() => {
     rootValue = {
       partnerArtistsLoader: sinon
         .stub()
-        .returns(Promise.resolve({ headers: { "x-total-count": 1 }, body: [{ artist }] })),
+        .returns(Promise.resolve({ headers: { "x-total-count": 1 }, body: partnerArtistResp })),
       artistLoader: sinon.stub().returns(Promise.resolve(artist)),
     }
   })
@@ -22,12 +35,12 @@ describe("Artist Statuses", () => {
       {
         artist(id: "foo-bar") {
           highlights {
-            partner_artists(first: 1) {
+            partners(first: 1) {
               edges {
+                is_represented_by
                 node {
-                  artist {
-                    id
-                  }
+                  id
+                  name
                 }
               }
             }
@@ -39,13 +52,13 @@ describe("Artist Statuses", () => {
     const expectedHighlightData = {
       artist: {
         highlights: {
-          partner_artists: {
+          partners: {
             edges: [
               {
+                is_represented_by: true,
                 node: {
-                  artist: {
-                    id: "percy-z",
-                  },
+                  id: "catty-gallery",
+                  name: "Catty Gallery",
                 },
               },
             ],

--- a/schema/artist/highlights.js
+++ b/schema/artist/highlights.js
@@ -1,23 +1,36 @@
 import { GraphQLBoolean, GraphQLObjectType, GraphQLList, GraphQLString } from "graphql"
-import { assign } from "lodash"
-import { PartnerArtistType } from "../partner_artist"
+import { partnerArtistConnection } from "../partner_artist"
+import { pageable, getPagingParameters } from "relay-cursor-paging"
+import { connectionFromArraySlice } from "graphql-relay"
 
 const ArtistHighlightsType = new GraphQLObjectType({
   name: "ArtistHighlights",
   fields: {
     partner_artists: {
-      type: new GraphQLList(PartnerArtistType),
-      args: {
+      type: partnerArtistConnection,
+      args: pageable({
         represented_by: {
           type: GraphQLBoolean,
         },
         partner_category: {
           type: new GraphQLList(GraphQLString),
         },
-      },
-      resolve: ({ id }, options, _request, { rootValue: { partnerArtistsLoader } }) => {
-        const partnerArtistOptions = assign({ artist_id: id }, options, {})
-        return partnerArtistsLoader(partnerArtistOptions)
+      }),
+      resolve: ({ id: artist_id }, options, _request, { rootValue: { partnerArtistsLoader } }) => {
+        // Convert `after` cursors to page params
+        const { limit: size, offset } = getPagingParameters(options)
+        // Construct an object of all the params gravity will listen to
+        const { represented_by, partner_category } = options
+        const gravityArgs = { total_count: true, size, offset, artist_id, represented_by, partner_category }
+
+        return partnerArtistsLoader(gravityArgs).then(({ body, headers }) => {
+          console.log(body)
+          console.log(headers)
+          return connectionFromArraySlice(body, options, {
+            arrayLength: headers["x-total-count"],
+            sliceStart: offset,
+          })
+        })
       },
     },
   },

--- a/schema/artist/highlights.js
+++ b/schema/artist/highlights.js
@@ -2,11 +2,12 @@ import { GraphQLBoolean, GraphQLObjectType, GraphQLList, GraphQLString } from "g
 import { PartnerArtistConnection } from "../partner_artist"
 import { pageable, getPagingParameters } from "relay-cursor-paging"
 import { connectionFromArraySlice } from "graphql-relay"
+import { assign } from "lodash"
 
 const ArtistHighlightsType = new GraphQLObjectType({
   name: "ArtistHighlights",
   fields: {
-    partner_artists: {
+    partners: {
       type: PartnerArtistConnection,
       args: pageable({
         represented_by: {
@@ -28,7 +29,21 @@ const ArtistHighlightsType = new GraphQLObjectType({
             arrayLength: headers["x-total-count"],
             sliceStart: offset,
           })
-          debugger
+          // Inject the partner artist data into edges, and set the partner as the node.
+          let newEdges = []
+          connection.edges.forEach(edge => {
+            const newEdge = assign(
+              {
+                ...edge.node,
+              },
+              {},
+              edge
+            )
+            newEdge.node = edge.node.partner
+            newEdges = newEdges.concat(newEdge)
+          })
+          connection.edges = newEdges
+
           return connection
         })
       },

--- a/schema/artist/highlights.js
+++ b/schema/artist/highlights.js
@@ -1,5 +1,5 @@
 import { GraphQLBoolean, GraphQLObjectType, GraphQLList, GraphQLString } from "graphql"
-import { partnerArtistConnection } from "../partner_artist"
+import { PartnerArtistConnection } from "../partner_artist"
 import { pageable, getPagingParameters } from "relay-cursor-paging"
 import { connectionFromArraySlice } from "graphql-relay"
 
@@ -7,7 +7,7 @@ const ArtistHighlightsType = new GraphQLObjectType({
   name: "ArtistHighlights",
   fields: {
     partner_artists: {
-      type: partnerArtistConnection,
+      type: PartnerArtistConnection,
       args: pageable({
         represented_by: {
           type: GraphQLBoolean,
@@ -24,10 +24,12 @@ const ArtistHighlightsType = new GraphQLObjectType({
         const gravityArgs = { total_count: true, size, offset, artist_id, represented_by, partner_category }
 
         return partnerArtistsLoader(gravityArgs).then(({ body, headers }) => {
-          return connectionFromArraySlice(body, options, {
+          const connection = connectionFromArraySlice(body, options, {
             arrayLength: headers["x-total-count"],
             sliceStart: offset,
           })
+          debugger
+          return connection
         })
       },
     },

--- a/schema/artist/highlights.js
+++ b/schema/artist/highlights.js
@@ -24,8 +24,6 @@ const ArtistHighlightsType = new GraphQLObjectType({
         const gravityArgs = { total_count: true, size, offset, artist_id, represented_by, partner_category }
 
         return partnerArtistsLoader(gravityArgs).then(({ body, headers }) => {
-          console.log(body)
-          console.log(headers)
           return connectionFromArraySlice(body, options, {
             arrayLength: headers["x-total-count"],
             sliceStart: offset,

--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -451,20 +451,19 @@ export const ArtistType = new GraphQLObjectType({
               sliceStart: offset,
             })
 
-            // Inject the partner artist data into edges
+            // Inject the partner artist data into edges, and set the partner as the node.
             let newEdges = []
             connection.edges.forEach(edge => {
-              edge = assign(
+              const newEdge = assign(
                 {
                   ...edge.node,
                 },
                 {},
                 edge
               )
-              edge.node = edge.partner
-              newEdges = newEdges.concat(edge)
+              newEdge.node = edge.node.partner
+              newEdges = newEdges.concat(newEdge)
             })
-            debugger
             connection.edges = newEdges
 
             return connection

--- a/schema/partner_artist.js
+++ b/schema/partner_artist.js
@@ -6,9 +6,19 @@ import { IDFields } from "./object_identification"
 import { GraphQLString, GraphQLObjectType, GraphQLNonNull, GraphQLBoolean } from "graphql"
 import { connectionDefinitions } from "graphql-relay"
 
-export const PartnerArtistType = new GraphQLObjectType({
-  name: "PartnerArtist",
-  fields: () => ({
+const counts = {
+  type: new GraphQLObjectType({
+    name: "PartnerArtistCounts",
+    fields: {
+      artworks: numeral(({ published_artworks_count }) => published_artworks_count),
+      for_sale_artworks: numeral(({ published_for_sale_artworks_count }) => published_for_sale_artworks_count),
+    },
+  }),
+  resolve: partner_artist => partner_artist,
+}
+
+const fields = () => {
+  return {
     ...IDFields,
     artist: {
       type: Artist.type,
@@ -16,16 +26,7 @@ export const PartnerArtistType = new GraphQLObjectType({
     biography: {
       type: GraphQLString,
     },
-    counts: {
-      type: new GraphQLObjectType({
-        name: "PartnerArtistCounts",
-        fields: {
-          artworks: numeral(({ published_artworks_count }) => published_artworks_count),
-          for_sale_artworks: numeral(({ published_for_sale_artworks_count }) => published_for_sale_artworks_count),
-        },
-      }),
-      resolve: partner_artist => partner_artist,
-    },
+    counts,
     is_display_on_partner_profile: {
       type: GraphQLBoolean,
       resolve: ({ display_on_partner_profile }) => display_on_partner_profile,
@@ -42,7 +43,12 @@ export const PartnerArtistType = new GraphQLObjectType({
     sortable_id: {
       type: GraphQLString,
     },
-  }),
+  }
+}
+
+export const PartnerArtistType = new GraphQLObjectType({
+  name: "PartnerArtist",
+  fields,
 })
 
 const PartnerArtist = {
@@ -63,6 +69,16 @@ const PartnerArtist = {
 
 export default PartnerArtist
 
-export const partnerArtistConnection = connectionDefinitions({
+// export const partnerArtistConnection = connectionDefinitions({
+//   nodeType: PartnerArtistType,
+// }).connectionType
+
+// export const { edgeType: PartnerArtistEdge } = connectionDefinitions({
+//   nodeType: PartnerArtistType,
+// }).connectionType
+
+export const PartnerArtistConnection = connectionDefinitions({
+  name: "PartnerArtistConnection",
   nodeType: PartnerArtistType,
+  edgeFields: fields,
 }).connectionType

--- a/schema/partner_artist.js
+++ b/schema/partner_artist.js
@@ -33,6 +33,7 @@ const fields = () => {
     },
     is_represented_by: {
       type: GraphQLBoolean,
+      resolve: ({ represented_by }) => represented_by,
     },
     is_use_default_biography: {
       type: GraphQLBoolean,
@@ -69,16 +70,11 @@ const PartnerArtist = {
 
 export default PartnerArtist
 
-// export const partnerArtistConnection = connectionDefinitions({
-//   nodeType: PartnerArtistType,
-// }).connectionType
-
-// export const { edgeType: PartnerArtistEdge } = connectionDefinitions({
-//   nodeType: PartnerArtistType,
-// }).connectionType
-
+// The below can be used as the connection from an artist to its partners.
+// The edge is the PartnerArtist relationship, with the node being the partner.
 export const PartnerArtistConnection = connectionDefinitions({
   name: "PartnerArtistConnection",
-  nodeType: PartnerArtistType,
+  edgeType: PartnerArtistType,
+  nodeType: Partner.type,
   edgeFields: fields,
 }).connectionType

--- a/schema/partner_artist.js
+++ b/schema/partner_artist.js
@@ -4,6 +4,7 @@ import Artist from "./artist/index"
 import numeral from "./fields/numeral"
 import { IDFields } from "./object_identification"
 import { GraphQLString, GraphQLObjectType, GraphQLNonNull, GraphQLBoolean } from "graphql"
+import { connectionDefinitions } from "graphql-relay"
 
 export const PartnerArtistType = new GraphQLObjectType({
   name: "PartnerArtist",
@@ -61,3 +62,7 @@ const PartnerArtist = {
 }
 
 export default PartnerArtist
+
+export const partnerArtistConnection = connectionDefinitions({
+  nodeType: PartnerArtistType,
+}).connectionType


### PR DESCRIPTION
~~This doesn't actually work (yet), but uses the loaders in the way you might expect (ie- unauthenticated loaders can still cache and resolve with body/headers).~~

This PR does all the things now- it can cache/resolve body/headers for unauthenticated loaders, and also exposes an edge from artist to partners, decorated with `PartnerArtist` info.