### PR TITLE
@alloy => Move SaleArtworks connection down a level

### DIFF
--- a/schema/__tests__/sale_artworks.test.js
+++ b/schema/__tests__/sale_artworks.test.js
@@ -24,18 +24,20 @@ describe("Sale Artworks", () => {
     const query = gql`
       {
         sale_artworks {
-          counts {
-            total
-          }
-          edges {
-            node {
-              id
+          connection {
+            counts {
+              total
+            }
+            edges {
+              node {
+                id
+              }
             }
           }
         }
       }
     `
-    const { sale_artworks: { counts: { total }, edges } } = await execute(gravityResponse, query)
+    const { sale_artworks: { connection: { counts: { total }, edges } } } = await execute(gravityResponse, query)
     expect(total).toEqual(totalCount)
     expect(edges.length).toEqual(hits.length)
   })
@@ -53,16 +55,18 @@ describe("Sale Artworks", () => {
     }
     const query = gql`
       {
-        sale_artworks(size: 1) {
-          edges {
-            node {
-              id
+        sale_artworks {
+          connection(size: 1) {
+            edges {
+              node {
+                id
+              }
             }
           }
         }
       }
     `
-    const { sale_artworks: { edges } } = await execute(gravityResponse, query)
+    const { sale_artworks: { connection: { edges } } } = await execute(gravityResponse, query)
     expect(edges.length).toEqual(size)
   })
 
@@ -78,25 +82,26 @@ describe("Sale Artworks", () => {
     }
     const query = gql`
       {
-        sale_artworks(first: 5) {
-          pageInfo {
-            startCursor
-            endCursor
-            hasNextPage
-          }
-          edges {
-            cursor
-            node {
-              id
+        sale_artworks {
+          connection(first: 5) {
+            pageInfo {
+              startCursor
+              endCursor
+              hasNextPage
+            }
+            edges {
+              cursor
+              node {
+                id
+              }
             }
           }
         }
       }
     `
-    const { sale_artworks: { edges, pageInfo: { startCursor, endCursor, hasNextPage } } } = await execute(
-      gravityResponse,
-      query
-    )
+    const {
+      sale_artworks: { connection: { edges, pageInfo: { startCursor, endCursor, hasNextPage } } },
+    } = await execute(gravityResponse, query)
     const [first, last] = [_.first(edges), _.last(edges)]
     expect(first.cursor).toEqual(startCursor)
     expect(last.cursor).toEqual(endCursor)
@@ -104,14 +109,16 @@ describe("Sale Artworks", () => {
 
     const query2 = gql`
       {
-        sale_artworks(after: "${last.cursor}") {
-          pageInfo {
-            hasNextPage
+        sale_artworks {
+          connection(after: "${last.cursor}") {
+            pageInfo {
+              hasNextPage
+            }
           }
         }
       }
     `
-    const { sale_artworks: { pageInfo } } = await execute(gravityResponse, query2)
+    const { sale_artworks: { connection: { pageInfo } } } = await execute(gravityResponse, query2)
     expect(pageInfo.hasNextPage).toEqual(false)
   })
 
@@ -128,13 +135,15 @@ describe("Sale Artworks", () => {
     const query = gql`
       {
         sale_artworks {
-          counts {
-            total
+          connection {
+            counts {
+              total
+            }
           }
         }
       }
     `
-    const { sale_artworks: { counts: { total } } } = await execute(gravityResponse, query)
+    const { sale_artworks: { connection: { counts: { total } } } } = await execute(gravityResponse, query)
     expect(total).toEqual(hits.length)
   })
 
@@ -178,16 +187,18 @@ describe("Sale Artworks", () => {
 
     const query = gql`
       {
-        sale_artworks(aggregations: [TOTAL, MEDIUM, FOLLOWED_ARTISTS]) {
-          aggregations {
-            counts {
-              id
+        sale_artworks {
+          connection(aggregations: [TOTAL, MEDIUM, FOLLOWED_ARTISTS]) {
+            aggregations {
+              counts {
+                id
+              }
             }
           }
         }
       }
     `
-    const { sale_artworks: { aggregations } } = await execute(gravityResponse, query)
+    const { sale_artworks: { connection: { aggregations } } } = await execute(gravityResponse, query)
 
     expect(aggregations.length).toBeGreaterThan(0)
     aggregations.forEach(aggregation => {


### PR DESCRIPTION
In order to support Relay Modern's `@connection` format, it appears as though GraphQL `connection`s can't be set at the root. If so, then a warning is returned by Relay saying that the `@connection` cannot be found. See this [Slack convo](https://artsy.slack.com/archives/C1HH3KNJG/p1511938519000162) for more details, an example from [PaginationContainer](https://github.com/facebook/relay/blob/master/packages/react-relay/modern/ReactRelayPaginationContainer.js#L156) and [this comment](https://github.com/facebook/relay/issues/1705#issuecomment-298040893). 

<img width="552" alt="screen shot 2017-11-28 at 11 42 21 pm" src="https://user-images.githubusercontent.com/236943/33363585-d8b19686-d495-11e7-90b7-7124bc313d8e.png">

```
{
  sale_artworks {
    connection(first:2) {
      edges {
        node {
          id
        }
      }
    }
  }
}
```