### PR TITLE
Adds back the JS Convection API

### DIFF
--- a/lib/loaders/loaders_with_authentication/convection.js
+++ b/lib/loaders/loaders_with_authentication/convection.js
@@ -19,6 +19,7 @@ export default (accessToken, requestIDs) => {
 
   return {
     convectionTokenLoader,
+    submissionsLoader: convectionLoader(`submissions`),
     assetCreateLoader: convectionLoader(`assets`, {}, { method: "POST" }),
     submissionCreateLoader: convectionLoader(`submissions`, {}, { method: "POST" }),
     submissionUpdateLoader: convectionLoader(id => `submissions/${id}`, {}, { method: "PUT" }),

--- a/schema/aggregations/aggregation_count.js
+++ b/schema/aggregations/aggregation_count.js
@@ -1,5 +1,4 @@
 // @ts-check
-import type { GraphQLFieldConfig } from "graphql"
 
 import { IDFields } from "schema/object_identification"
 import { GraphQLObjectType, GraphQLString, GraphQLInt } from "graphql"
@@ -21,7 +20,7 @@ export const AggregationCountType = new GraphQLObjectType({
   },
 })
 
-export default ({
+export default {
   type: AggregationCountType,
   resolve: ({ name, count, sortable_id }, id) => ({
     id,
@@ -29,4 +28,4 @@ export default ({
     name,
     count,
   }),
-}: GraphQLFieldConfig<AggregationCountType, any>)
+}

--- a/schema/aggregations/aggregation_count.js
+++ b/schema/aggregations/aggregation_count.js
@@ -1,4 +1,5 @@
 // @ts-check
+import type { GraphQLFieldConfig } from "graphql"
 
 import { IDFields } from "schema/object_identification"
 import { GraphQLObjectType, GraphQLString, GraphQLInt } from "graphql"
@@ -20,7 +21,7 @@ export const AggregationCountType = new GraphQLObjectType({
   },
 })
 
-export default {
+export default ({
   type: AggregationCountType,
   resolve: ({ name, count, sortable_id }, id) => ({
     id,
@@ -28,4 +29,4 @@ export default {
     name,
     count,
   }),
-}
+}: GraphQLFieldConfig<AggregationCountType, any>)

--- a/schema/gene.js
+++ b/schema/gene.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import { pageable } from "relay-cursor-paging"
 import { connectionDefinitions, connectionFromArraySlice } from "graphql-relay"
 import _ from "lodash"
@@ -83,15 +81,17 @@ const GeneType = new GraphQLObjectType({
          *        compose authenticated and unauthenticated loaders based on the request?
          *        Here’s an example of such a setup https://gist.github.com/alloy/69bb274039ecd552de76c3f1739c519e
          */
-        return gravity.with(accessToken)("filter/artworks", gravityOptions).then(({ aggregations, hits }) => {
-          return Object.assign(
-            { aggregations }, // Add data to connection so the `aggregations` connection field can resolve it
-            connectionFromArraySlice(hits, options, {
-              arrayLength: aggregations.total.value,
-              sliceStart: gravityOptions.offset,
-            })
-          )
-        })
+        return gravity
+          .with(accessToken)("filter/artworks", gravityOptions)
+          .then(({ aggregations, hits }) => {
+            return Object.assign(
+              { aggregations }, // Add data to connection so the `aggregations` connection field can resolve it
+              connectionFromArraySlice(hits, options, {
+                arrayLength: aggregations.total.value,
+                sliceStart: gravityOptions.offset,
+              })
+            )
+          })
       },
     },
     description: {

--- a/schema/index.js
+++ b/schema/index.js
@@ -58,6 +58,9 @@ import CausalityJWT from "./causality_jwt"
 import ObjectIdentification from "./object_identification"
 import { GraphQLSchema, GraphQLObjectType } from "graphql"
 
+const { ENABLE_SCHEMA_STITCHING } = process.env
+const enableSchemaStitching = ENABLE_SCHEMA_STITCHING === "true"
+
 const rootFields = {
   article: Article,
   articles: Articles,
@@ -115,6 +118,14 @@ const Viewer = {
   resolve: x => x,
 }
 
+const convectionMutations = enableSchemaStitching
+  ? {}
+  : {
+    createConsignmentSubmission: CreateSubmissionMutation,
+    updateConsignmentSubmission: UpdateSubmissionMutation,
+    addAssetToConsignmentSubmission: AddAssetToConsignmentSubmission,
+  }
+
 const schema = new GraphQLSchema({
   mutation: new GraphQLObjectType({
     name: "Mutation",
@@ -126,11 +137,9 @@ const schema = new GraphQLSchema({
       sendConversationMessage: SendConversationMessageMutation,
       markReadMessage: MarkReadMessageMutation,
       saveArtwork: SaveArtworkMutation,
-      createConsignmentSubmission: CreateSubmissionMutation,
-      updateConsignmentSubmission: UpdateSubmissionMutation,
-      addAssetToConsignmentSubmission: AddAssetToConsignmentSubmission,
       requestCredentialsForAssetUpload: CreateAssetRequestLoader,
       createGeminiEntryForAsset: CreateGeminiEntryForAsset,
+      ...convectionMutations,
     },
   }),
   query: new GraphQLObjectType({

--- a/schema/index.js
+++ b/schema/index.js
@@ -46,6 +46,9 @@ import UpdateConversationMutation from "./me/conversation/update_mutation"
 import SendConversationMessageMutation from "./me/conversation/send_message_mutation"
 import MarkReadMessageMutation from "./me/conversation/mark_read_message_mutation"
 import UpdateCollectorProfile from "./me/update_collector_profile"
+import CreateSubmissionMutation from "./me/consignments/create_submission_mutation"
+import UpdateSubmissionMutation from "./me/consignments/update_submission_mutation"
+import AddAssetToConsignmentSubmission from "./me/consignments/add_asset_to_submission_mutation"
 import SaveArtworkMutation from "./me/save_artwork_mutation"
 import CreateAssetRequestLoader from "./asset_uploads/create_asset_request_mutation"
 import CreateGeminiEntryForAsset from "./asset_uploads/finalize_asset_mutation"
@@ -123,6 +126,9 @@ const schema = new GraphQLSchema({
       sendConversationMessage: SendConversationMessageMutation,
       markReadMessage: MarkReadMessageMutation,
       saveArtwork: SaveArtworkMutation,
+      createConsignmentSubmission: CreateSubmissionMutation,
+      updateConsignmentSubmission: UpdateSubmissionMutation,
+      addAssetToConsignmentSubmission: AddAssetToConsignmentSubmission,
       requestCredentialsForAssetUpload: CreateAssetRequestLoader,
       createGeminiEntryForAsset: CreateGeminiEntryForAsset,
     },

--- a/schema/me/__tests__/consignments/__snapshots__/add_asset_to_submission_mutation.test.js.snap
+++ b/schema/me/__tests__/consignments/__snapshots__/add_asset_to_submission_mutation.test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`addAssetToConsignmentSubmission creates a submission and returns its new data payload 1`] = `
+Object {
+  "addAssetToConsignmentSubmission": Object {
+    "asset": Object {
+      "gemini_token": "12345",
+      "submission_id": "123",
+    },
+  },
+}
+`;

--- a/schema/me/__tests__/consignments/__snapshots__/create_submission_mutation.test.js.snap
+++ b/schema/me/__tests__/consignments/__snapshots__/create_submission_mutation.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UpdateSubmissionMutation updates a submission and returns its new data payload 1`] = `
+Object {
+  "createConsignmentSubmission": Object {
+    "clientMutationId": "2",
+    "submission": Object {
+      "artist_id": "andy-warhol",
+      "authenticity_certificate": null,
+      "dimensions_metric": null,
+      "id": "106",
+    },
+  },
+}
+`;

--- a/schema/me/__tests__/consignments/__snapshots__/create_submission_mutation.test.js.snap
+++ b/schema/me/__tests__/consignments/__snapshots__/create_submission_mutation.test.js.snap
@@ -4,10 +4,10 @@ exports[`UpdateSubmissionMutation updates a submission and returns its new data 
 Object {
   "createConsignmentSubmission": Object {
     "clientMutationId": "2",
-    "submission": Object {
+    "consignment_submission": Object {
       "artist_id": "andy-warhol",
-      "authenticity_certificate": null,
-      "dimensions_metric": null,
+      "authenticity_certificate": true,
+      "dimensions_metric": "CM",
       "id": "106",
     },
   },

--- a/schema/me/__tests__/consignments/__snapshots__/submissions.test.js.snap
+++ b/schema/me/__tests__/consignments/__snapshots__/submissions.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`submissions asks for a user's submissions 1`] = `
+Object {
+  "me": Object {
+    "consignment_submissions": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "artist": Object {
+              "name": "Larissa Croft",
+            },
+            "artist_id": "123",
+            "authenticity_certificate": true,
+            "id": "106",
+            "title": "The best photo yet",
+          },
+        },
+      ],
+    },
+  },
+}
+`;

--- a/schema/me/__tests__/consignments/__snapshots__/update_submission_mutation.test.js.snap
+++ b/schema/me/__tests__/consignments/__snapshots__/update_submission_mutation.test.js.snap
@@ -4,8 +4,8 @@ exports[`UpdateSubmissionMutation updates a submission and returns its new data 
 Object {
   "updateConsignmentSubmission": Object {
     "clientMutationId": "123123",
-    "submission": Object {
-      "depth": null,
+    "consignment_submission": Object {
+      "depth": "1000",
     },
   },
 }

--- a/schema/me/__tests__/consignments/__snapshots__/update_submission_mutation.test.js.snap
+++ b/schema/me/__tests__/consignments/__snapshots__/update_submission_mutation.test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UpdateSubmissionMutation updates a submission and returns its new data payload 1`] = `
+Object {
+  "updateConsignmentSubmission": Object {
+    "clientMutationId": "123123",
+    "submission": Object {
+      "depth": null,
+    },
+  },
+}
+`;

--- a/schema/me/__tests__/consignments/add_asset_to_submission_mutation.test.js
+++ b/schema/me/__tests__/consignments/add_asset_to_submission_mutation.test.js
@@ -1,0 +1,33 @@
+import { runAuthenticatedQuery } from "test/utils"
+import gql from "test/gql"
+
+describe("addAssetToConsignmentSubmission", () => {
+  it("creates a submission and returns its new data payload", () => {
+    const mutation = gql`
+      mutation {
+        addAssetToConsignmentSubmission(
+          input: { asset_type: "image", gemini_token: "12345", submission_id: "123", clientMutationId: "123" }
+        ) {
+          asset {
+            submission_id
+            gemini_token
+          }
+        }
+      }
+    `
+
+    const rootValue = {
+      assetCreateLoader: () =>
+        Promise.resolve({
+          id: "106",
+          gemini_token: "12345",
+          submission_id: "123",
+        }),
+    }
+
+    expect.assertions(1)
+    return runAuthenticatedQuery(mutation, rootValue).then(data => {
+      expect(data).toMatchSnapshot()
+    })
+  })
+})

--- a/schema/me/__tests__/consignments/create_submission_mutation.test.js
+++ b/schema/me/__tests__/consignments/create_submission_mutation.test.js
@@ -26,7 +26,7 @@ describe("UpdateSubmissionMutation", () => {
           }
         ) {
           clientMutationId
-          submission {
+          consignment_submission {
             artist_id
             authenticity_certificate
             id
@@ -40,6 +40,8 @@ describe("UpdateSubmissionMutation", () => {
         Promise.resolve({
           id: "106",
           artist_id: "andy-warhol",
+          authenticity_certificate: true,
+          dimensions_metric: "cm",
         }),
     }
 

--- a/schema/me/__tests__/consignments/create_submission_mutation.test.js
+++ b/schema/me/__tests__/consignments/create_submission_mutation.test.js
@@ -1,0 +1,51 @@
+import { runAuthenticatedQuery } from "test/utils"
+import { config as createSubmissionMutation } from "schema/me/consignments/create_submission_mutation.js"
+
+import gql from "test/gql"
+
+describe("UpdateSubmissionMutation", () => {
+  it("does not include the id param", () => {
+    const mutation = createSubmissionMutation
+    expect(Object.keys(mutation.inputFields)).not.toContain("id")
+  })
+
+  it("includes the state param", () => {
+    const mutation = createSubmissionMutation
+    expect(Object.keys(mutation.inputFields)).toContain("state")
+  })
+
+  it("updates a submission and returns its new data payload", () => {
+    const mutation = gql`
+      mutation {
+        createConsignmentSubmission(
+          input: {
+            artist_id: "andy-warhol"
+            clientMutationId: "2"
+            authenticity_certificate: true
+            dimensions_metric: CM
+          }
+        ) {
+          clientMutationId
+          submission {
+            artist_id
+            authenticity_certificate
+            id
+            dimensions_metric
+          }
+        }
+      }
+    `
+    const rootValue = {
+      submissionCreateLoader: () =>
+        Promise.resolve({
+          id: "106",
+          artist_id: "andy-warhol",
+        }),
+    }
+
+    expect.assertions(1)
+    return runAuthenticatedQuery(mutation, rootValue).then(data => {
+      expect(data).toMatchSnapshot()
+    })
+  })
+})

--- a/schema/me/__tests__/consignments/submissions.test.js
+++ b/schema/me/__tests__/consignments/submissions.test.js
@@ -1,0 +1,49 @@
+import { runAuthenticatedQuery } from "test/utils"
+import gql from "test/gql"
+
+describe("submissions", () => {
+  it("asks for a user's submissions", () => {
+    const mutation = gql`
+      {
+        me {
+          consignment_submissions(first: 5, completed: true) {
+            edges {
+              node {
+                id
+                authenticity_certificate
+                title
+                artist_id
+                artist {
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const rootValue = {
+      submissionsLoader: () =>
+        Promise.resolve([
+          {
+            id: "106",
+            authenticity_certificate: true,
+            artist_id: "123",
+            title: "The best photo yet",
+          },
+        ]),
+      artistLoader: () =>
+        Promise.resolve({
+          name: "Larissa Croft",
+          birthday: "April 2011",
+          artworks_count: 1,
+        }),
+    }
+
+    expect.assertions(1)
+    return runAuthenticatedQuery(mutation, rootValue).then(data => {
+      expect(data).toMatchSnapshot()
+    })
+  })
+})

--- a/schema/me/__tests__/consignments/update_submission_mutation.test.js
+++ b/schema/me/__tests__/consignments/update_submission_mutation.test.js
@@ -1,0 +1,43 @@
+import { runAuthenticatedQuery } from "test/utils"
+import { config as updateSubmissionMutation } from "schema/me/consignments/update_submission_mutation.js"
+import gql from "test/gql"
+
+describe("UpdateSubmissionMutation", () => {
+  it("includes the id param", () => {
+    const mutation = updateSubmissionMutation
+    expect(Object.keys(mutation.inputFields)).toContain("id")
+  })
+
+  it("includes the state param", () => {
+    const mutation = updateSubmissionMutation
+    expect(Object.keys(mutation.inputFields)).toContain("state")
+  })
+
+  it("updates a submission and returns its new data payload", () => {
+    const mutation = gql`
+      mutation {
+        updateConsignmentSubmission(
+          input: { id: "108", artist_id: "andy-warhol", depth: "123", clientMutationId: "123123" }
+        ) {
+          clientMutationId
+          submission {
+            depth
+          }
+        }
+      }
+    `
+
+    const rootValue = {
+      submissionUpdateLoader: () =>
+        Promise.resolve({
+          id: "106",
+          artist_id: "andy-warhol",
+        }),
+    }
+
+    expect.assertions(1)
+    return runAuthenticatedQuery(mutation, rootValue).then(data => {
+      expect(data).toMatchSnapshot()
+    })
+  })
+})

--- a/schema/me/__tests__/consignments/update_submission_mutation.test.js
+++ b/schema/me/__tests__/consignments/update_submission_mutation.test.js
@@ -20,7 +20,7 @@ describe("UpdateSubmissionMutation", () => {
           input: { id: "108", artist_id: "andy-warhol", depth: "123", clientMutationId: "123123" }
         ) {
           clientMutationId
-          submission {
+          consignment_submission {
             depth
           }
         }
@@ -32,6 +32,8 @@ describe("UpdateSubmissionMutation", () => {
         Promise.resolve({
           id: "106",
           artist_id: "andy-warhol",
+          authenticity_certificate: true,
+          depth: "1000",
         }),
     }
 

--- a/schema/me/consignments/add_asset_to_submission_mutation.js
+++ b/schema/me/consignments/add_asset_to_submission_mutation.js
@@ -1,0 +1,34 @@
+// @ts-check
+
+import { GraphQLString, GraphQLNonNull } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { AssetType } from "./asset"
+
+export default mutationWithClientMutationId({
+  name: "AddAssetToConsignmentSubmission",
+  description: "Attach an gemini asset to a consignment submission",
+  inputFields: {
+    asset_type: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The type of the asset",
+    },
+    gemini_token: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The token provided by Gemini for your asset",
+    },
+    submission_id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The id of the submission you want to attach an asset to",
+    },
+  },
+  outputFields: {
+    asset: {
+      type: AssetType,
+      resolve: asset => asset,
+    },
+  },
+  mutateAndGetPayload: (assets, _request, { rootValue: { assetCreateLoader } }) => {
+    if (!assetCreateLoader) return null
+    return assetCreateLoader(assets)
+  },
+})

--- a/schema/me/consignments/asset.js
+++ b/schema/me/consignments/asset.js
@@ -1,0 +1,30 @@
+// @ts-check
+
+import { GraphQLObjectType, GraphQLString, GraphQLNonNull } from "graphql"
+
+export const AssetType = new GraphQLObjectType({
+  name: "Asset",
+  description: "An asset which is assigned to a consignment submission",
+  fields: {
+    id: {
+      description: "Convection asset ID.",
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    submission_id: {
+      description: "The convection submission ID",
+      type: GraphQLString,
+    },
+    gemini_token: {
+      description: "The gemini token for the asset",
+      type: GraphQLString,
+    },
+    asset_type: {
+      description: "The type of the asset",
+      type: GraphQLString,
+    },
+  },
+})
+
+// There is no need to support reading yet,
+// and so this file has no default export
+// to handle resolving.

--- a/schema/me/consignments/create_submission_mutation.js
+++ b/schema/me/consignments/create_submission_mutation.js
@@ -8,10 +8,10 @@ export const config = {
   name: "CreateSubmissionMutation",
   description: "Create a new consignment submission using Convection",
   inputFields: {
-    ...omit(SubmissionType.getFields(), ["id"]),
+    ...omit(SubmissionType.getFields(), ["id", "_id", "__id", "artist"]),
   },
   outputFields: {
-    submission: {
+    consignment_submission: {
       type: SubmissionType,
       resolve: response => response,
     },

--- a/schema/me/consignments/create_submission_mutation.js
+++ b/schema/me/consignments/create_submission_mutation.js
@@ -1,0 +1,24 @@
+// @ts-check
+
+import { mutationWithClientMutationId } from "graphql-relay"
+import { SubmissionType } from "./submission"
+import { omit } from "lodash"
+
+export const config = {
+  name: "CreateSubmissionMutation",
+  description: "Create a new consignment submission using Convection",
+  inputFields: {
+    ...omit(SubmissionType.getFields(), ["id"]),
+  },
+  outputFields: {
+    submission: {
+      type: SubmissionType,
+      resolve: response => response,
+    },
+  },
+  mutateAndGetPayload: (request, _response, { rootValue: { submissionCreateLoader } }) => {
+    if (!submissionCreateLoader) return null
+    return submissionCreateLoader(request)
+  },
+}
+export default mutationWithClientMutationId(config)

--- a/schema/me/consignments/submission.js
+++ b/schema/me/consignments/submission.js
@@ -1,0 +1,169 @@
+// @ts-check
+
+import { GraphQLObjectType, GraphQLString, GraphQLNonNull, GraphQLBoolean, GraphQLEnumType, GraphQLInt } from "graphql"
+
+export const SubmissionDimensionAggregation = new GraphQLEnumType({
+  name: "SubmissionDimensionAggregation",
+  values: {
+    CM: {
+      value: "cm",
+    },
+    IN: {
+      value: "in",
+    },
+  },
+})
+
+export const SubmissionCategoryAggregation = new GraphQLEnumType({
+  name: "SubmissionCategoryAggregation",
+  values: {
+    PAINTING: {
+      value: "Painting",
+    },
+    SCULPTURE: {
+      value: "Sculpture",
+    },
+    PHOTOGRAPHY: {
+      value: "Photography",
+    },
+    PRINT: {
+      value: "Print",
+    },
+    DRAWING_COLLAGE_OR_OTHER_WORK_ON_PAPER: {
+      value: "Drawing, Collage or other Work on Paper",
+    },
+    MIXED_MEDIA: {
+      value: "Mixed Media",
+    },
+    PERFORMANCE_ART: {
+      value: "Performance Art",
+    },
+    INSTALLATION: {
+      value: "Installation",
+    },
+    VIDEO_FILM_ANIMATION: {
+      value: "Video/Film/Animation",
+    },
+    ARCHITECTURE: {
+      value: "Architecture",
+    },
+    FASHION_DESIGN_AND_WEARABLE_ART: {
+      value: "Fashion Design and Wearable Art",
+    },
+    JEWELRY: {
+      value: "Jewelry",
+    },
+    DESIGN_DECORATIVE_ART: {
+      value: "Design/Decorative Art",
+    },
+    TEXTILE_ARTS: {
+      value: "Textile Arts",
+    },
+    OTHER: {
+      value: "Other",
+    },
+  },
+})
+
+export const SubmissionStateAggregation = new GraphQLEnumType({
+  name: "SubmissionStateAggregation",
+  values: {
+    DRAFT: {
+      value: "draft",
+    },
+    SUBMITTED: {
+      value: "submitted",
+    },
+  },
+})
+
+export const SubmissionType = new GraphQLObjectType({
+  name: "Submission",
+  description: "A work to be consigned to the user",
+  fields: {
+    id: {
+      description: "Convection id.",
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    artist_id: {
+      decription: "The gravity ID for an Artist",
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    authenticity_certificate: {
+      description: "Does the artwork come with an certificate of authenticity?",
+      type: GraphQLBoolean,
+    },
+    category: {
+      description: "The set in which to put the work",
+      type: SubmissionCategoryAggregation,
+    },
+    depth: {
+      description: "The depth of the work",
+      type: GraphQLString,
+    },
+    dimensions_metric: {
+      description: "A string, either CM or IN",
+      type: SubmissionDimensionAggregation,
+    },
+    edition: {
+      description: "Is the work a part of an edition",
+      type: GraphQLBoolean,
+    },
+    edition_number: {
+      description: "The number of the individual work if in a set",
+      type: GraphQLString,
+    },
+    edition_size: {
+      description: "The whole size of the set of works",
+      type: GraphQLInt,
+    },
+    height: {
+      description: "The height of the work",
+      type: GraphQLString,
+    },
+    location_city: {
+      description: "The city where the work currently resides",
+      type: GraphQLString,
+    },
+    location_country: {
+      description: "The country where the work currently resides",
+      type: GraphQLString,
+    },
+    location_state: {
+      description: "The state where the work currently resides",
+      type: GraphQLString,
+    },
+    medium: {
+      description: "The materials in which the work is created",
+      type: GraphQLString,
+    },
+    provenance: {
+      description: "The history of an work",
+      type: GraphQLString,
+    },
+    signature: {
+      description: "Is this work signed?",
+      type: GraphQLBoolean,
+    },
+    title: {
+      description: "The name of the work",
+      type: GraphQLString,
+    },
+    state: {
+      description: "The internal state of the work, e.g. draft/submitted",
+      type: SubmissionStateAggregation,
+    },
+    width: {
+      description: "The width of the work",
+      type: GraphQLString,
+    },
+    year: {
+      description: "The year the work was created",
+      type: GraphQLString,
+    },
+  },
+})
+
+// There is no need to support reading yet,
+// and so this file has no default export
+// to handle resolving.

--- a/schema/me/consignments/submissions.js
+++ b/schema/me/consignments/submissions.js
@@ -1,0 +1,31 @@
+import { SubmissionType } from "./submission"
+import { GraphQLBoolean } from "graphql/type/scalars"
+
+import { pageable } from "relay-cursor-paging"
+import { connectionDefinitions, connectionFromArraySlice } from "graphql-relay"
+
+export default {
+  type: connectionDefinitions({ nodeType: SubmissionType }).connectionType,
+  args: {
+    ...pageable({}),
+
+    completed: {
+      type: GraphQLBoolean,
+      default: true,
+    },
+  },
+  description: "A list of the current user’s consignment submissions",
+  resolve: (root, options, _request, { rootValue: { submissionsLoader } }) => {
+    // TODO: This should get replaced in stitching,
+    //       it _does not_ handle pagination at API level, so you'll need a
+    //       list size that's a little higher than average while there
+    //       are still small amounts of data.
+    if (!submissionsLoader) return null
+    return submissionsLoader(options).then(body => {
+      return connectionFromArraySlice(body, options, {
+        arrayLength: body.length,
+        sliceStart: 0,
+      })
+    })
+  },
+}

--- a/schema/me/consignments/update_submission_mutation.js
+++ b/schema/me/consignments/update_submission_mutation.js
@@ -1,19 +1,21 @@
+// @ts-check
 import { mutationWithClientMutationId } from "graphql-relay"
 import { SubmissionType } from "./submission"
+import { omit } from "lodash"
 
 export const config = {
   name: "UpdateSubmissionMutation",
   description: "Update a consigment using Convection",
   inputFields: {
-    ...SubmissionType.getFields(),
+    ...omit(SubmissionType.getFields(), ["__id", "_id", "artist"]),
   },
   outputFields: {
-    submission: {
+    consignment_submission: {
       type: SubmissionType,
       resolve: submission => submission,
     },
   },
-  mutateAndGetPayload: (submission, request, { rootValue: { submissionUpdateLoader } }) => {
+  mutateAndGetPayload: (submission, _request, { rootValue: { submissionUpdateLoader } }) => {
     if (!submissionUpdateLoader) return null
     return submissionUpdateLoader(submission.id, submission)
   },

--- a/schema/me/consignments/update_submission_mutation.js
+++ b/schema/me/consignments/update_submission_mutation.js
@@ -1,0 +1,21 @@
+import { mutationWithClientMutationId } from "graphql-relay"
+import { SubmissionType } from "./submission"
+
+export const config = {
+  name: "UpdateSubmissionMutation",
+  description: "Update a consigment using Convection",
+  inputFields: {
+    ...SubmissionType.getFields(),
+  },
+  outputFields: {
+    submission: {
+      type: SubmissionType,
+      resolve: submission => submission,
+    },
+  },
+  mutateAndGetPayload: (submission, request, { rootValue: { submissionUpdateLoader } }) => {
+    if (!submissionUpdateLoader) return null
+    return submissionUpdateLoader(submission.id, submission)
+  },
+}
+export default mutationWithClientMutationId(config)

--- a/schema/me/index.js
+++ b/schema/me/index.js
@@ -1,5 +1,3 @@
-// TODO: @ts-check
-
 import { GraphQLString, GraphQLObjectType } from "graphql"
 import { has } from "lodash"
 
@@ -71,7 +69,7 @@ const Me = new GraphQLObjectType({
 
 export default {
   type: Me,
-  resolve: (_root, _options, _request, { rootValue: { accessToken, userID }, fieldNodes }) => {
+  resolve: (root, options, request, { rootValue: { accessToken, userID }, fieldNodes }) => {
     if (!accessToken) return null
 
     const blacklistedFields = [

--- a/schema/me/index.js
+++ b/schema/me/index.js
@@ -26,6 +26,16 @@ import Notifications from "./notifications"
 import SaleRegistrations from "./sale_registrations"
 import SavedArtworks from "./saved_artworks"
 import SuggestedArtists from "./suggested_artists"
+import Submissions from "./consignments/submissions"
+
+const { ENABLE_SCHEMA_STITCHING } = process.env
+const enableSchemaStitching = ENABLE_SCHEMA_STITCHING === "true"
+
+const mySubmissions = enableSchemaStitching
+  ? {}
+  : {
+    consignment_submissions: Submissions,
+  }
 
 const Me = new GraphQLObjectType({
   name: "Me",
@@ -33,6 +43,7 @@ const Me = new GraphQLObjectType({
   isTypeOf: obj => has(obj, "email") && has(obj, "is_collector"),
   fields: {
     ...IDFields,
+    ...mySubmissions,
     artwork_inquiries_connection: ArtworkInquiries,
     bidders: Bidders,
     bidder_status: BidderStatus,
@@ -90,9 +101,12 @@ export default {
       "collector_profile",
       "artwork_inquiries_connection",
       "notifications_connection",
+      "consignment_submissions",
     ]
     if (queriedForFieldsOtherThanBlacklisted(fieldNodes, blacklistedFields)) {
-      return gravity.with(accessToken)("me").catch(() => null)
+      return gravity
+        .with(accessToken)("me")
+        .catch(() => null)
     }
 
     // The email and is_collector are here so that the type system's `isTypeOf`


### PR DESCRIPTION
Paired with @sweir27 on bringing back the JS API for Convection, we've built it with the expectation of this being the API that we'll use when stitching. Now the ENV var switches between a working JS implementation, and a stitched implementation. They're not 100% fit _today_, but it's built with *client side* future proofing in mind.

Opted to having a `submission` always be called `consignment_submission` inside metaphysics. So, things that would need to be done in stitching:

* Rename mutations to something like `createConsignmentSubmission`
* Mutations in Convection change their return types to be `consignment_submission: [data]`
* `Submission` -> `ConsignmentSubmission`