### PR TITLE
@joeyAghion => Expose collections to artist schema

### DIFF
--- a/schema/artist/__tests__/index.test.js
+++ b/schema/artist/__tests__/index.test.js
@@ -15,6 +15,7 @@ describe("Artist type", () => {
       birthday: null,
       artworks_count: 42,
       partner_shows_count: 42,
+      collections: "Catty Art Collections\nMatt's Personal Art Collection",
     }
 
     rootValue = {
@@ -135,6 +136,24 @@ describe("Artist type", () => {
       expect(data).toEqual({
         artist: {
           has_metadata: false,
+        },
+      })
+    })
+  })
+
+  it("rincludes collections data", () => {
+    const query = `
+      {
+        artist(id: "foo-bar") {
+          collections
+        }
+      }
+    `
+
+    return runQuery(query, rootValue).then(data => {
+      expect(data).toEqual({
+        artist: {
+          collections: ["Catty Art Collections", "Matt's Personal Art Collection"],
         },
       })
     })

--- a/schema/artist/index.js
+++ b/schema/artist/index.js
@@ -296,6 +296,15 @@ export const ArtistType = new GraphQLObjectType({
         },
       },
       carousel: ArtistCarousel,
+      collections: {
+        type: new GraphQLList(GraphQLString),
+        resolve: ({ collections }) => {
+          if (!collections) {
+            return null
+          }
+          return collections.split("\n")
+        },
+      },
       contemporary: {
         type: new GraphQLList(Artist.type), // eslint-disable-line no-use-before-define
         args: {


### PR DESCRIPTION
It seems like its a string field in Mongo, but we're storing lists delimited by a newline.

Looks like:

![screen shot 2017-12-05 at 3 28 25 pm](https://user-images.githubusercontent.com/1457859/33629199-3710afce-d9d1-11e7-80c2-41dcea295c4d.png)
