### PR TITLE
@sarahscott = Add new type under me to group published artworks by followed artists

### DIFF
--- a/lib/loaders/loaders_with_authentication/gravity.js
+++ b/lib/loaders/loaders_with_authentication/gravity.js
@@ -17,6 +17,7 @@ export default (accessToken, userID, requestIDs) => {
       "artist"
     ),
     followedArtistsLoader: gravityLoader("me/follow/artists", {}, { headers: true }),
+    followedArtistsArtworksLoader: gravityLoader("me/follow/artists/artworks", {}, { headers: true }),
     followedGenesLoader: gravityLoader("me/follow/genes", {}, { headers: true }),
     followedProfileLoader: trackedEntityLoaderFactory(
       gravityLoader("me/follow/profiles"),

--- a/schema/me/__tests__/followed_artists_artwork_groups.test.js
+++ b/schema/me/__tests__/followed_artists_artwork_groups.test.js
@@ -7,14 +7,16 @@ describe("Me", () => {
       const query = `
         {
           me {
-            followed_artists_artwork_groups(first: 10) {
-              pageInfo {
-                hasNextPage
-              }
-              edges {
-                node {
-                  summary
-                  artists
+            followsAndSaves {
+              bundledArtworksByArtist(first: 10) {
+                pageInfo {
+                  hasNextPage
+                }
+                edges {
+                  node {
+                    summary
+                    artists
+                  }
                 }
               }
             }
@@ -48,8 +50,8 @@ describe("Me", () => {
 
       return runAuthenticatedQuery(query, {
         followedArtistsArtworksLoader: () => Promise.resolve(artworkResponse),
-      }).then(({ me: { followed_artists_artwork_groups } }) => {
-        expect(followed_artists_artwork_groups).toEqual(expectedConnectionData)
+      }).then(({ me: { followsAndSaves: { bundledArtworksByArtist } } }) => {
+        expect(bundledArtworksByArtist).toEqual(expectedConnectionData)
       })
     })
   })

--- a/schema/me/__tests__/followed_artists_artwork_groups.test.js
+++ b/schema/me/__tests__/followed_artists_artwork_groups.test.js
@@ -1,0 +1,56 @@
+import { assign } from "lodash"
+import { runAuthenticatedQuery } from "test/utils"
+
+describe("Me", () => {
+  describe("Followed Artists Artwork Groups", () => {
+    it("returns artworks grouped by artist", () => {
+      const query = `
+        {
+          me {
+            followed_artists_artwork_groups(first: 10) {
+              pageInfo {
+                hasNextPage
+              }
+              edges {
+                node {
+                  summary
+                  artists
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const artworkStub = { artist: { id: "percy-z", name: "Percy Z" } }
+
+      const artwork1 = assign({}, artworkStub, { title: "Artwork1" })
+      const artwork2 = assign({}, artworkStub, { title: "Artwork2" })
+
+      const expectedConnectionData = {
+        pageInfo: {
+          hasNextPage: true,
+        },
+        edges: [
+          {
+            node: {
+              summary: "2 Works Added",
+              artists: "Percy Z",
+            },
+          },
+        ],
+      }
+
+      const artworkResponse = {
+        headers: { "x-total-count": 11 },
+        body: [artwork1, artwork2],
+      }
+
+      return runAuthenticatedQuery(query, {
+        followedArtistsArtworksLoader: () => Promise.resolve(artworkResponse),
+      }).then(({ me: { followed_artists_artwork_groups } }) => {
+        expect(followed_artists_artwork_groups).toEqual(expectedConnectionData)
+      })
+    })
+  })
+})

--- a/schema/me/followed_artists_artworks_group.js
+++ b/schema/me/followed_artists_artworks_group.js
@@ -1,0 +1,84 @@
+import { pageable } from "relay-cursor-paging"
+import { connectionDefinitions, connectionFromArraySlice } from "graphql-relay"
+import Artwork from "schema/artwork"
+import ArtworkSorts from "schema/sorts/artwork_sorts"
+import Image from "schema/image"
+import { GraphQLList, GraphQLObjectType, GraphQLString } from "graphql"
+import { omit, groupBy, map } from "lodash"
+import { parseRelayOptions } from "lib/helpers"
+import { GlobalIDField, NodeInterface } from "schema/object_identification"
+
+const FollowedArtistsArtworksGroupType = new GraphQLObjectType({
+  name: "FollowedArtistsArtworksGroup",
+  interfaces: [NodeInterface],
+  isTypeOf: obj => obj._type === "FollowedArtistsArtworksGroup",
+  fields: () => ({
+    __id: GlobalIDField,
+    artworks: {
+      type: new GraphQLList(Artwork.type),
+      description: "List of artworks in this group.",
+    },
+    artists: {
+      type: GraphQLString,
+    },
+    summary: {
+      type: GraphQLString,
+    },
+    image: {
+      type: Image.type,
+      resolve: ({ artworks }) => {
+        return artworks.length > 0 && artworks[0].artists.length > 0 && Image.resolve(artworks[0].artists[0])
+      },
+    },
+  }),
+})
+
+const FollowedArtistsArtworksGroup = {
+  type: connectionDefinitions({ nodeType: FollowedArtistsArtworksGroupType }).connectionType,
+  description: "A list of published artworks by followed artists (grouped by date and artists).",
+  args: pageable({
+    sort: ArtworkSorts,
+  }),
+  resolve: (root, options, request, { rootValue: { followedArtistsArtworksLoader } }) => {
+    if (!followedArtistsArtworksLoader) return null
+
+    // Convert Relay-style pagination to the supported page/size style for the backend.
+    const gravityOptions = parseRelayOptions(options)
+    gravityOptions.total_count = true
+
+    return followedArtistsArtworksLoader(omit(gravityOptions, "offset")).then(({ body, headers }) => {
+      const connection = connectionFromArraySlice(body, options, {
+        arrayLength: headers["x-total-count"],
+        sliceStart: gravityOptions.offset,
+      })
+
+      const groupedByArtist = groupBy(connection.edges, item => {
+        return item.node.artist.id
+      })
+
+      let newEdges = []
+      let newEdge
+      Object.keys(groupedByArtist).forEach(artist => {
+        const groupedNodes = groupedByArtist[artist]
+        newEdge = {
+          node: {
+            summary: `${groupedNodes.length} Work${groupedNodes.length === 1 ? "" : "s"} Added`,
+            artworks: map(groupedNodes, groupped => {
+              return groupped.node
+            }),
+            id: groupedNodes[0].node._id,
+            artists: groupedNodes[0].node.artist.name,
+            _type: "FollowedArtistsArtworksGroup",
+          },
+          cursor: groupedNodes[0].cursor,
+        }
+        newEdges = newEdges.concat(newEdge)
+      })
+
+      connection.edges = newEdges
+      return connection
+    })
+  },
+}
+
+export default FollowedArtistsArtworksGroup

--- a/schema/me/index.js
+++ b/schema/me/index.js
@@ -17,6 +17,7 @@ import CollectorProfile from "./collector_profile"
 import Conversation from "./conversation"
 import Conversations from "./conversations"
 import FollowArtists from "./follow_artists"
+import FollowedArtistsArtworkGroups from "./followed_artists_artworks_group"
 import FollowedArtists from "./followed_artists"
 import FollowedGenes from "./followed_genes"
 import Invoice from "./conversation/invoice"
@@ -31,11 +32,7 @@ import Submissions from "./consignments/submissions"
 const { ENABLE_SCHEMA_STITCHING } = process.env
 const enableSchemaStitching = ENABLE_SCHEMA_STITCHING === "true"
 
-const mySubmissions = enableSchemaStitching
-  ? {}
-  : {
-    consignment_submissions: Submissions,
-  }
+const mySubmissions = enableSchemaStitching ? {} : { consignment_submissions: Submissions }
 
 const Me = new GraphQLObjectType({
   name: "Me",
@@ -57,6 +54,7 @@ const Me = new GraphQLObjectType({
     },
     follow_artists: FollowArtists,
     followed_artists_connection: FollowedArtists,
+    followed_artists_artwork_groups: FollowedArtistsArtworkGroups,
     followed_genes: FollowedGenes,
     invoice: Invoice,
     lot_standing: LotStanding,
@@ -102,6 +100,7 @@ export default {
       "artwork_inquiries_connection",
       "notifications_connection",
       "consignment_submissions",
+      "followed_artists_artwork_groups",
     ]
     if (queriedForFieldsOtherThanBlacklisted(fieldNodes, blacklistedFields)) {
       return gravity

--- a/schema/me/index.js
+++ b/schema/me/index.js
@@ -54,8 +54,16 @@ const Me = new GraphQLObjectType({
     },
     follow_artists: FollowArtists,
     followed_artists_connection: FollowedArtists,
-    followed_artists_artwork_groups: FollowedArtistsArtworkGroups,
     followed_genes: FollowedGenes,
+    followsAndSaves: {
+      type: new GraphQLObjectType({
+        name: "FollowsAndSaves",
+        fields: {
+          bundledArtworksByArtist: FollowedArtistsArtworkGroups,
+        },
+      }),
+      resolve: () => ({}),
+    },
     invoice: Invoice,
     lot_standing: LotStanding,
     lot_standings: LotStandings,
@@ -80,7 +88,6 @@ export default {
   type: Me,
   resolve: (root, options, request, { rootValue: { accessToken, userID }, fieldNodes }) => {
     if (!accessToken) return null
-
     const blacklistedFields = [
       "id",
       "__id",
@@ -100,7 +107,7 @@ export default {
       "artwork_inquiries_connection",
       "notifications_connection",
       "consignment_submissions",
-      "followed_artists_artwork_groups",
+      "followsAndSaves",
     ]
     if (queriedForFieldsOtherThanBlacklisted(fieldNodes, blacklistedFields)) {
       return gravity

--- a/schema/me/notifications.js
+++ b/schema/me/notifications.js
@@ -54,15 +54,18 @@ const Notifications = {
   type: connectionDefinitions({ nodeType: NotificationsFeedItemType }).connectionType,
   description: "A list of feed items, indicating published artworks (grouped by date and artists).",
   args: pageable({}),
+  deprecationReason: "Prefer to use followed_artists_artwork_groups.",
   resolve: (root, options, request, { rootValue: { accessToken } }) => {
     if (!accessToken) return null
     const gravityOptions = parseRelayOptions(options)
-    return gravity.with(accessToken)("me/notifications/feed", omit(gravityOptions, "offset")).then(({ feed, total }) =>
-      connectionFromArraySlice(feed, options, {
-        arrayLength: total,
-        sliceStart: gravityOptions.offset,
-      })
-    )
+    return gravity
+      .with(accessToken)("me/notifications/feed", omit(gravityOptions, "offset"))
+      .then(({ feed, total }) =>
+        connectionFromArraySlice(feed, options, {
+          arrayLength: total,
+          sliceStart: gravityOptions.offset,
+        })
+      )
   },
 }
 


### PR DESCRIPTION
Still have to add some specs, but this is working with some minor updates in Emission!

This basically does what's described in https://github.com/artsy/collector-experience/issues/728#issuecomment-349737737

There's a new schema under `me`, that returns something like:

<img width="566" alt="screen shot 2017-12-07 at 11 56 48 am" src="https://user-images.githubusercontent.com/1457859/33738431-3697ca90-db67-11e7-8f74-e5016fb49869.png">
