### PR TITLE
@orta => Rename to drop redundant Connection

### DIFF
--- a/schema/partner_artist.js
+++ b/schema/partner_artist.js
@@ -75,7 +75,7 @@ export default PartnerArtist
 // The below can be used as the connection from an artist to its partners.
 // The edge is the PartnerArtist relationship, with the node being the partner.
 export const PartnerArtistConnection = connectionDefinitions({
-  name: "PartnerArtistConnection",
+  name: "PartnerArtist",
   edgeType: PartnerArtistType,
   nodeType: Partner.type,
   edgeFields: fields,


### PR DESCRIPTION
The library appends `Connection` to the name, so no need for this.

<img width="338" alt="screen shot 2017-12-11 at 12 28 57 pm" src="https://user-images.githubusercontent.com/1457859/33844647-e17ce27e-de6e-11e7-9b77-73636d14462b.png">
