### PR TITLE
Add the image field to SuggestedGene type

### DIFF
--- a/schema/__tests__/suggested_genes.test.js
+++ b/schema/__tests__/suggested_genes.test.js
@@ -34,16 +34,18 @@ describe("SuggestedGenes type", () => {
       {
         suggested_genes {
           id
-          name
-          image_url
           _id
+          name
+          image {
+            url
+          }
         }
       }
     `
 
     return runQuery(query, {}).then(data => {
       expect(data.suggested_genes[0]._id).toBe("123456")
-      expect(data.suggested_genes[0].image_url).toBe("photography.jpg")
+      expect(data.suggested_genes[0].image.url).toBe("photography.jpg")
     })
   })
 })

--- a/schema/suggested_genes.js
+++ b/schema/suggested_genes.js
@@ -1,22 +1,22 @@
 import fetch from "../lib/apis/fetch"
-import { GraphQLObjectType, GraphQLList, GraphQLString } from "graphql"
+import { GraphQLList } from "graphql"
+import { GeneType } from "./gene"
 
-const SuggestedGeneType = new GraphQLObjectType({
-  name: "SuggestedGene",
-  fields: {
-    id: { type: GraphQLString },
-    image_url: { type: GraphQLString },
-    _id: { type: GraphQLString },
-    name: { type: GraphQLString },
-  },
+// Takes our dummy data and makes sure that it conforms to the
+// Gene's Node interface check (e.g. pass `isTypeOf` in `GeneType`.)
+
+const suggestedGeneToGene = (suggestedGene) => ({
+  ...suggestedGene,
+  browseable: true,
+  published: true,
 })
 
 const SUGGESTED_GENES_JSON = "https://s3.amazonaws.com/eigen-production/json/eigen_categories.json"
 
 const SuggestedGenes = {
-  type: new GraphQLList(SuggestedGeneType),
+  type: new GraphQLList(GeneType),
   description: "List of curated genes with custom images",
-  resolve: () => fetch(SUGGESTED_GENES_JSON).then(({ body }) => body),
+  resolve: () => fetch(SUGGESTED_GENES_JSON).then(({ body }) => body.map(suggestedGeneToGene)),
 }
 
 export default SuggestedGenes


### PR DESCRIPTION
Right now the `SuggestedGene` type is a different type from the `Gene` type. The Follow Gene step in the onboarding flow needs to deal with both the types and adding the same fields will allow Relay to respect required fields like `name` and `image`.

Alternatively, we could just use the `Gene` type anywhere rather than maintaining two similar types. Let us know if this is something we should be doing.

