### PR TITLE
@orta => Implement NodeInterface for filtered artworks

### DIFF
--- a/schema/__tests__/gene.test.js
+++ b/schema/__tests__/gene.test.js
@@ -28,6 +28,7 @@ describe("Gene", () => {
                 artists: [],
               },
             ],
+            aggregations: [],
           })
         )
       filterArtworks.__Rewire__("gravity", gravity)
@@ -373,6 +374,7 @@ describe("Gene", () => {
                 artists: [],
               },
             ],
+            aggregations: [],
           })
         )
 

--- a/schema/object_identification.js
+++ b/schema/object_identification.js
@@ -39,6 +39,7 @@ const SupportedTypes = {
     "./artist",
     "./artwork",
     "./gene",
+    "./filter_artworks",
     "./home/home_page_artwork_module",
     "./home/home_page_artist_module",
     "./me",
@@ -75,7 +76,7 @@ Object.defineProperty(SupportedTypes, "typeModules", {
 const isSupportedType = _.includes.bind(null, SupportedTypes.types)
 
 function argumentsForChild(type, id) {
-  return type.includes("HomePage") ? JSON.parse(id) : { id }
+  return type === "FilterArtworks" || type.startsWith("HomePage") ? JSON.parse(id) : { id }
 }
 
 function rootValueForChild(rootValue) {
@@ -117,7 +118,11 @@ const NodeField = {
   resolve: (root, { __id }, request, rootValue) => {
     const { type, id } = fromGlobalId(__id)
     if (isSupportedType(type)) {
-      const { resolve } = SupportedTypes.typeModules[type]
+      let exported = SupportedTypes.typeModules[type]
+      if (typeof exported === "function") {
+        exported = exported()
+      }
+      const { resolve } = exported
       return resolve(null, argumentsForChild(type, id), request, rootValueForChild(rootValue))
     }
   },


### PR DESCRIPTION
This lets subsequent pages (keeping the same filter) to be directly requested via `node(__id: ...)`. This works better with Relay pagination containers. The key is that we have a synthetic `__id` that encodes all the things required to do the fetch, thus letting Relay be able to easily update its store as subsequent pages are requested (Relay takes care of _not_ encoding pagination params in the key).