### PR TITLE
@mzikherman => Add filter artworks to tag schema (analogous to gene)

### DIFF
--- a/schema/__tests__/tag.test.js
+++ b/schema/__tests__/tag.test.js
@@ -1,0 +1,59 @@
+import schema from "schema"
+import { runQuery } from "test/utils"
+
+describe("Tag", () => {
+  describe("For just querying the tag artworks", () => {
+    const Tag = schema.__get__("Tag")
+    const filterArtworks = Tag.__get__("filterArtworks")
+
+    // If this test fails because it's making a gravity request to /tag/x, it's
+    // because the AST checks to find out which nodes we're requesting
+    // is not working correctly. This test is to make sure we don't
+    // request to gravity.
+
+    beforeEach(() => {
+      const gravity = sinon.stub()
+      gravity.with = sinon.stub().returns(gravity)
+      gravity
+        .withArgs("filter/artworks", {
+          tag_id: "butt",
+          aggregations: ["total"],
+        })
+        .returns(
+          Promise.resolve({
+            hits: [
+              {
+                id: "oseberg-norway-queens-ship",
+                title: "Queen's Ship",
+                artists: [],
+              },
+            ],
+            aggregations: [],
+          })
+        )
+      filterArtworks.__Rewire__("gravity", gravity)
+    })
+
+    afterEach(() => {
+      filterArtworks.__ResetDependency__("gravity")
+    })
+
+    it("returns filtered artworks", () => {
+      const query = `
+        {
+          tag(id: "butt") {
+            filtered_artworks(aggregations:[TOTAL]){
+              hits {
+                id
+              }
+            }
+          }
+        }
+      `
+
+      return runQuery(query).then(({ tag: { filtered_artworks: { hits } } }) => {
+        expect(hits).toEqual([{ id: "oseberg-norway-queens-ship" }])
+      })
+    })
+  })
+})

--- a/schema/tag.js
+++ b/schema/tag.js
@@ -1,28 +1,35 @@
 import gravity from "lib/loaders/legacy/gravity"
 import cached from "./fields/cached"
 import Image from "./image"
-import { GravityIDFields } from "./object_identification"
+import { GravityIDFields, NodeInterface } from "./object_identification"
 import { GraphQLObjectType, GraphQLString, GraphQLInt, GraphQLNonNull } from "graphql"
+import filterArtworks from "./filter_artworks"
+import { queriedForFieldsOtherThanBlacklisted } from "lib/helpers"
 
 const TagType = new GraphQLObjectType({
   name: "Tag",
-  fields: {
-    ...GravityIDFields,
-    cached,
-    description: {
-      type: GraphQLString,
-    },
-    name: {
-      type: GraphQLString,
-    },
-    href: {
-      type: GraphQLString,
-      resolve: ({ id }) => `tag/${id}`,
-    },
-    image: Image,
-    count: {
-      type: GraphQLInt,
-    },
+  interfaces: [NodeInterface],
+  isTypeOf: obj => obj._type === "Tag",
+  fields: () => {
+    return {
+      ...GravityIDFields,
+      cached,
+      description: {
+        type: GraphQLString,
+      },
+      name: {
+        type: GraphQLString,
+      },
+      href: {
+        type: GraphQLString,
+        resolve: ({ id }) => `tag/${id}`,
+      },
+      image: Image,
+      count: {
+        type: GraphQLInt,
+      },
+      filtered_artworks: filterArtworks("tag_id"),
+    }
   },
 })
 
@@ -34,7 +41,20 @@ const Tag = {
       type: new GraphQLNonNull(GraphQLString),
     },
   },
-  resolve: (root, { id }) => gravity(`tag/${id}`),
+  resolve: (root, { id }, request, { fieldNodes }) => {
+    // If you are just making an artworks call ( e.g. if paginating )
+    // do not make a Gravity call for the gene data.
+    const blacklistedFields = ["filtered_artworks", "id", "__id"]
+    if (queriedForFieldsOtherThanBlacklisted(fieldNodes, blacklistedFields)) {
+      return gravity(`tag/${id}`).then(tag => {
+        return Object.assign(tag, { _type: "Tag" }, {})
+      })
+    }
+
+    // The family and browsable are here so that the type system's `isTypeOf`
+    // resolves correctly when we're skipping gravity data
+    return { id, _type: "Tag" }
+  },
 }
 
 export default Tag


### PR DESCRIPTION
Now that the filter artworks schema under Gene is working great, I'm going to use the same pattern for Tag.