### PR TITLE
@mzikherman => Allow param that will return correct medium aggregations for a gene filter

### DIFF
--- a/schema/filter_artworks.js
+++ b/schema/filter_artworks.js
@@ -164,6 +164,9 @@ export const filterArtworksArgs = {
   include_artworks_by_followed_artists: {
     type: GraphQLBoolean,
   },
+  include_medium_filter_in_aggregation: {
+    type: GraphQLBoolean,
+  },
   for_sale: {
     type: GraphQLBoolean,
   },


### PR DESCRIPTION
cc @alloy This fixes the issue where the 'Medium' dropdown aggregation was not including the gene filter, forgot I added it exactly for this reason for the gene page filter a while back.