### PR TITLE
Adds a flag to ensure that only conversations with messages come through

### DIFF
--- a/lib/loaders/loaders_with_authentication/impulse.js
+++ b/lib/loaders/loaders_with_authentication/impulse.js
@@ -21,7 +21,7 @@ export default (accessToken, userID, requestIDs) => {
       from_id: userID,
       from_type: "User",
     }),
-    conversationLoader: impulseLoader(id => `conversations/${id}`),
+    conversationLoader: impulseLoader(id => `conversations/${id}`, { has_message: true }),
     conversationUpdateLoader: impulseLoader(id => `conversations/${id}`, {}, { method: "PUT" }),
     conversationMessagesLoader: impulseLoader("message_details"),
     conversationInvoiceLoader: impulseLoader("invoice_detail"),


### PR DESCRIPTION
There's a bunch of pre-radiation conversations ( roughly 0.5% ) which cannot be shown as a set of messages today. If you happen to have one of those lucky conversations then we can't really show messaging for your data. This flag removes them from the API.