### PR TITLE
Add excluded artist ids to suggested artist arguments

### DIFF
--- a/schema/me/suggested_artists_args.js
+++ b/schema/me/suggested_artists_args.js
@@ -1,4 +1,4 @@
-import { GraphQLBoolean, GraphQLString, GraphQLInt } from "graphql"
+import { GraphQLBoolean, GraphQLString, GraphQLInt, GraphQLList } from "graphql"
 
 export const SuggestedArtistsArgs = {
   artist_id: {
@@ -16,6 +16,10 @@ export const SuggestedArtistsArgs = {
   exclude_followed_artists: {
     type: GraphQLBoolean,
     description: "Exclude artists the user already follows",
+  },
+  exclude_artist_ids: {
+    type: new GraphQLList(GraphQLString),
+    description: "Exclude these ids from results, may result in all artists being excluded.",
   },
   page: {
     type: GraphQLInt,


### PR DESCRIPTION
I've found another edge case where a duplicate artist could be suggested after searching and following (see https://github.com/artsy/collector-experience/issues/842#issuecomment-353200862). Gravity already has[ a way to exclude specified artists](https://github.com/artsy/gravity/blob/637e2bc8a4e3ee00d538871081ba92cbaf3d1848/app/api/v1/me_suggestions_endpoint.rb#L46), so MP should be able to send the `exclude_artist_ids` argument over to Gravity.