### PR TITLE
Fix build after changing file tree.

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,6 @@
+# Services
 CONVECTION_API_BASE=https://convection-staging.artsy.net/api
-CONVECTION_APP_ID=xxx_app_id_xxx
+DELTA_API_BASE=http://delta.artsy.test
 EMBEDLY_ENDPOINT=https://i.embed.ly.test/1/display
 GALAXY_API_BASE=https://galaxy-staging-herokuapp.com
 GEMINI_ENDPOINT=https://gemini.cloudfront.test
@@ -11,24 +12,24 @@ IMPULSE_API_BASE=https://impulse-staging.artsy.net/api
 MEMCACHE_SERVERS=localhost:11211
 METAPHYSICS_PRODUCTION_ENDPOINT=https://metaphysics-production.artsy.net
 METAPHYSICS_STAGING_ENDPOINT=https://metaphysics-staging.artsy.net
-PORT=5001
 POSITRON_API_BASE=https://writer.artsy.test/api
 PREDICTION_ENDPOINT=https://live.artsy.net
-QUERY_DEPTH_LIMIT=10
 
-NODE_ENV=test
-GRAVITY_ID=xxx_artsy_id_xxx
-GRAVITY_SECRET=xxx_artsy_secret_xxx
-
-BASIC_AUTH_PASSWORD=bar
-BASIC_AUTH_USERNAME=foo
+# Keys/Secrets
+CONVECTION_APP_ID=xxx_convection_id_xxx
 EMBEDLY_KEY=xxx_embedly_key_xxx
 GALAXY_TOKEN=galaxy_token
 GOOGLE_CSE_CX=xxx_google_cse_cx_xxx
 GOOGLE_CSE_KEY=xxx_google_cse_key_xxx
+GRAVITY_ID=xxx_artsy_id_xxx
+GRAVITY_SECRET=xxx_artsy_secret_xxx
 IMPULSE_APPLICATION_ID=xxx_impulse_id_xxx
-RESIZING_SERVICE=gemini
 
-GRAPHQL_NO_NAME_WARNING=true
-ENABLE_SCHEMA_STITCHING=false
+# Options
 ENABLE_QUERY_TRACING=false
+ENABLE_SCHEMA_STITCHING=false
+GRAPHQL_NO_NAME_WARNING=true
+NODE_ENV=test
+PORT=5001
+QUERY_DEPTH_LIMIT=10
+RESIZING_SERVICE=gemini

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const isProduction = NODE_ENV === "production"
 
 xapp.on("error", err => {
   error(err)
-  process.exit()
+  process.exit(1)
 })
 
 const xappConfig = {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "fix": "eslint . --fix",
     "promote": "heroku pipelines:promote -r staging",
     "dump-schema": "babel-node ./scripts/dump-schema.js",
-    "heroku-postbuild": "babel ./src/index.js ./src/config.js -s inline -d build && babel ./src/lib -s inline -d build/lib && babel ./src/schema -s inline -d build/schema",
+    "heroku-postbuild":
+      "babel src --ignore src/test,src/integration,src/**/__tests__ -s inline -d build/src && babel index.js -s inline -d build",
     "precommit": "lint-staged",
     "prettier-project": "prettier --write '**/*.js'",
     "type-check": "tsc --noEmit --pretty"
@@ -124,14 +125,7 @@
     "bracketSpacing": true
   },
   "lint-staged": {
-    "*.json, *.md": [
-      "yarn prettier --write",
-      "git add"
-    ],
-    "*.js": [
-      "eslint --fix",
-      "yarn prettier --write",
-      "git add"
-    ]
+    "*.json, *.md": ["yarn prettier --write", "git add"],
+    "*.js": ["eslint --fix", "yarn prettier --write", "git add"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@artsy/express-reloadable@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@artsy/express-reloadable/-/express-reloadable-1.1.2.tgz#4cf6313d70a0e046a5bd1e65c731665c75c8b134"
+"@artsy/express-reloadable@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@artsy/express-reloadable/-/express-reloadable-1.2.0.tgz#acd68d38c48978b9bd6f383c6a7f017aa05c1d59"
   dependencies:
     chokidar "^1.7.0"
 


### PR DESCRIPTION
The Heroku build step was putting the `src/{config,index}.js` files inside `build/src/` but others were stored in `build/{lib,schema}` and the root `index.js` file was completely missing.