### PR TITLE
@orta => Pass option to printSchema method to avoid breaking change

### DIFF
--- a/scripts/dump-schema.js
+++ b/scripts/dump-schema.js
@@ -23,4 +23,4 @@ graphql(schema, introspectionQuery).then(
 )
 
 // Save user readable type system shorthand of schema
-fs.writeFileSync(path.join(destination, "schema.graphql"), printSchema(schema))
+fs.writeFileSync(path.join(destination, "schema.graphql"), printSchema(schema, { commentDescriptions: true }))


### PR DESCRIPTION
This seems to be fallout from the `graphql*` updates, specifically this PR https://github.com/graphql/graphql-js/pull/927

I don't _fully_ understand it yet tbh, but when running `printSchema` on latest master, I was getting output that would crash when being imported into Emission, with extra quotes around our `description` fields:

```
[1] ERROR:
[1] Error loading schema. Expected the schema to be a .graphql or a .json
[1] file, describing your GraphQL server's API. Error detail:
[1] 
[1] GraphQLError: Syntax Error GraphQL request (6:3) Expected Name, found String
[1] 
[1] 5:   input AddAssetToConsignmentSubmissionInput {
[1] 6:   """The type of the asset"""
[1]      ^
[1] 7:   asset_type: String!
[1] 
[1]     at syntaxError (/Users/mzikherman/code/Artsy/emission/node_modules/relay-compiler/node_modules/graphql/error/syntaxError.js:31:15)
[1]     at expect (/Users/mzikherman/code/Artsy/emission/node_modules/relay-compiler/node_modules/graphql/language/parser.js:973:32)
```

This option fixes it.