### PR TITLE
[Blocked] Add exclude artist ids to suggested artist args

### DIFF
--- a/src/schema/artists/popular.js
+++ b/src/schema/artists/popular.js
@@ -24,9 +24,7 @@ const PopularArtists = {
       description: "Number of results to return",
     },
   },
-  resolve: (_root, options, _request, { rootValue: { popularArtistsLoader } }) => {
-    return popularArtistsLoader(options)
-  },
+  resolve: (_root, options, _request, { rootValue: { popularArtistsLoader } }) => popularArtistsLoader(options),
 }
 
 export default PopularArtists

--- a/src/schema/artists/popular.js
+++ b/src/schema/artists/popular.js
@@ -1,5 +1,5 @@
 import Artist from "../artist"
-import { GraphQLObjectType, GraphQLList, GraphQLInt, GraphQLBoolean } from "graphql"
+import { GraphQLObjectType, GraphQLList, GraphQLInt, GraphQLBoolean, GraphQLString } from "graphql"
 
 const PopularArtistsType = new GraphQLObjectType({
   name: "PopularArtists",
@@ -18,6 +18,10 @@ const PopularArtists = {
     exclude_followed_artists: {
       type: GraphQLBoolean,
       description: "If true, will exclude followed artists for the user",
+    },
+    exclude_artist_ids: {
+      type: new GraphQLList(GraphQLString),
+      description: "Exclude these ids from results, may result in all artists being excluded.",
     },
     size: {
       type: GraphQLInt,


### PR DESCRIPTION
This PR depends on https://github.com/artsy/gravity/pull/11488. It needs to be merged before this PR.

We are working on https://github.com/artsy/collector-experience/issues/811, and this PR adds the `exclude_artist_ids` option so we can exclude already displayed popular artists on the onboarding flow.