### PR TITLE
@joeyAghion => Allow number formatting to be specified for display prices

### DIFF
--- a/src/schema/__tests__/auction_results.test.js
+++ b/src/schema/__tests__/auction_results.test.js
@@ -94,7 +94,7 @@ describe("Artist type", () => {
                   price_realized: {
                     cents: 420000,
                     cents_usd: 100000,
-                    display: "¥ JPY420k",
+                    display: "JPY ¥420k",
                   },
                 },
               },

--- a/src/schema/__tests__/auction_results.test.js
+++ b/src/schema/__tests__/auction_results.test.js
@@ -29,8 +29,8 @@ describe("Artist type", () => {
               },
             ],
             currency: "JPY",
-            price_realized_cents: 420,
-            price_realized_cents_usd: 100,
+            price_realized_cents: 420000,
+            price_realized_cents_usd: 100000,
           },
         ],
       },
@@ -63,7 +63,7 @@ describe("Artist type", () => {
                 }
                 currency
                 price_realized {
-                  display
+                  display(format: "0a")
                   cents
                   cents_usd
                 }
@@ -92,9 +92,9 @@ describe("Artist type", () => {
                   },
                   currency: "JPY",
                   price_realized: {
-                    cents: 420,
-                    cents_usd: 100,
-                    display: "¥ JPY420",
+                    cents: 420000,
+                    cents_usd: 100000,
+                    display: "¥ JPY420k",
                   },
                 },
               },

--- a/src/schema/auction_result.js
+++ b/src/schema/auction_result.js
@@ -1,4 +1,5 @@
 import date from "./fields/date"
+import numeral from "numeral"
 import { IDFields, NodeInterface } from "./object_identification"
 import { GraphQLFloat, GraphQLInt, GraphQLNonNull, GraphQLString, GraphQLObjectType, GraphQLEnumType } from "graphql"
 import { connectionDefinitions } from "graphql-relay"
@@ -121,7 +122,14 @@ const AuctionResultType = new GraphQLObjectType({
           },
           display: {
             type: GraphQLString,
-            resolve: ({ currency, price_realized_cents }) => {
+            args: {
+              format: {
+                type: GraphQLString,
+                description: "Passes in to numeral, such as `'0.00'`",
+                defaultValue: "",
+              },
+            },
+            resolve: ({ currency, price_realized_cents }, { format }) => {
               const { symbol, subunit_to_unit } = currencyCodes[currency.toLowerCase()]
               let display = ""
 
@@ -133,7 +141,9 @@ const AuctionResultType = new GraphQLObjectType({
                 display += " " + currency
               }
 
-              display += Math.round(price_realized_cents / subunit_to_unit).toLocaleString()
+              const amount = Math.round(price_realized_cents / subunit_to_unit)
+
+              display += numeral(amount).format(format)
 
               return display
             },

--- a/src/schema/auction_result.js
+++ b/src/schema/auction_result.js
@@ -131,14 +131,14 @@ const AuctionResultType = new GraphQLObjectType({
             },
             resolve: ({ currency, price_realized_cents }, { format }) => {
               const { symbol, subunit_to_unit } = currencyCodes[currency.toLowerCase()]
-              let display = ""
-
-              if (symbol) {
-                display = symbol
-              }
+              let display
 
               if (indexOf(symbolOnly, currency) === -1) {
-                display += " " + currency
+                display = currency
+              }
+
+              if (symbol) {
+                display = display ? display + " " + symbol : symbol
               }
 
               const amount = Math.round(price_realized_cents / subunit_to_unit)


### PR DESCRIPTION
Passes in `format` arg to `numeral`. This allows clients to have some control over the display, in this case the string `0a` will work for our auction lot abbreviation.

1234 -> 1k
1234567 -> 1m

etc.