### PR TITLE
@orta => Fix save/remove artwork mutations

### DIFF
--- a/src/schema/me/save_artwork_mutation.js
+++ b/src/schema/me/save_artwork_mutation.js
@@ -28,6 +28,6 @@ export default mutationWithClientMutationId({
   ) => {
     if (!accessToken) return new Error("You need to be signed in to perform this action")
     const loader = remove ? deleteArtworkLoader : saveArtworkLoader
-    return loader({ user_id: userID }).then(() => ({ artwork_id }))
+    return loader(artwork_id, { user_id: userID }).then(() => ({ artwork_id }))
   },
 })


### PR DESCRIPTION
Fallout from https://github.com/artsy/metaphysics/pull/879 , the signature of the loader wasn't right.

Reported as part of gene page QA ('save' button not working).