### PR TITLE
@joeyAghion => Pass thru display_on_partner_profile to /partner_artists API

### DIFF
--- a/src/schema/artist/__tests__/highlights.test.js
+++ b/src/schema/artist/__tests__/highlights.test.js
@@ -25,6 +25,7 @@ describe("Artist Statuses", () => {
     rootValue = {
       partnerArtistsLoader: sinon
         .stub()
+        .withArgs("partner_artists", sinon.match({ display_on_partner_profile: true }))
         .returns(Promise.resolve({ headers: { "x-total-count": 1 }, body: partnerArtistResp })),
       artistLoader: sinon.stub().returns(Promise.resolve(artist)),
     }
@@ -35,7 +36,7 @@ describe("Artist Statuses", () => {
       {
         artist(id: "foo-bar") {
           highlights {
-            partners(first: 1) {
+            partners(first: 1, display_on_partner_profile: true) {
               edges {
                 is_represented_by
                 node {

--- a/src/schema/artist/highlights.js
+++ b/src/schema/artist/highlights.js
@@ -14,6 +14,9 @@ const ArtistHighlightsType = new GraphQLObjectType({
         partner_category: {
           type: new GraphQLList(GraphQLString),
         },
+        display_on_partner_profile: {
+          type: GraphQLBoolean,
+        },
       }),
       resolve: ({ id: artist_id }, options, _request, { rootValue: { partnerArtistsLoader } }) => {
         return partnersForArtist(artist_id, options, partnerArtistsLoader)

--- a/src/schema/partner_artist.js
+++ b/src/schema/partner_artist.js
@@ -85,8 +85,16 @@ export const partnersForArtist = (artist_id, options, loader) => {
   // Convert `after` cursors to page params
   const { limit: size, offset } = getPagingParameters(options)
   // Construct an object of all the params gravity will listen to
-  const { represented_by, partner_category } = options
-  const gravityArgs = { total_count: true, size, offset, artist_id, represented_by, partner_category }
+  const { represented_by, partner_category, display_on_partner_profile } = options
+  const gravityArgs = {
+    total_count: true,
+    size,
+    offset,
+    artist_id,
+    display_on_partner_profile,
+    represented_by,
+    partner_category,
+  }
 
   return loader(gravityArgs).then(({ body, headers }) => {
     const connection = connectionFromArraySlice(body, options, {


### PR DESCRIPTION
Once https://github.com/artsy/gravity/pull/11506 is merged, the param will be respected in the API.

Then, we can update the [client](https://github.com/artsy/reaction/blob/759382ad7ee0229395c82d15d40f31480292261a/src/Components/Artist/MarketInsights/MarketInsights.tsx#L199) to pass `display_on_partner_profile: true`.