### PR TITLE
[FilterArtworks] Omit `medium` filter when `null`.

### DIFF
--- a/src/schema/filter_artworks.js
+++ b/src/schema/filter_artworks.js
@@ -245,7 +245,7 @@ function filterArtworks(primaryKey) {
       // Support queries that show all mediums using the medium param.
       // If you specify "*" it results in metaphysics removing the query option
       // making the graphQL queries between all and a subset of mediums the same shape.
-      if (options.medium === "*") {
+      if (gravityOptions.medium === "*" || !gravityOptions.medium) {
         delete gravityOptions.medium
       }
 

--- a/src/schema/gene.js
+++ b/src/schema/gene.js
@@ -71,7 +71,7 @@ export const GeneType = new GraphQLObjectType({
           gravityOptions.aggregations = options.aggregations || []
           gravityOptions.aggregations.push("total")
           // Remove medium if we are trying to get all mediums
-          if (options.medium === "*") {
+          if (gravityOptions.medium === "*" || !gravityOptions.medium) {
             delete gravityOptions.medium
           }
           // Manually set the gene_id to the current id


### PR DESCRIPTION
Fixes https://github.com/artsy/collector-experience/issues/893

I’ve got a much larger PR coming in with refactoring and tests.