### PR TITLE
[Node] Replace `isTypeOf` on types in favour of single `resolveType`.

### DIFF
--- a/src/schema/article.js
+++ b/src/schema/article.js
@@ -1,4 +1,3 @@
-import { has } from "lodash"
 import cached from "./fields/cached"
 import AuthorType from "./author"
 import Image from "./image"
@@ -15,7 +14,6 @@ import {
 const ArticleType = new GraphQLObjectType({
   name: "Article",
   interfaces: [NodeInterface],
-  isTypeOf: obj => has(obj, "title") && has(obj, "author"),
   fields: () => ({
     ...IDFields,
     cached,

--- a/src/schema/artist/index.js
+++ b/src/schema/artist/index.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { pageable, getPagingParameters } from "relay-cursor-paging"
-import { assign, compact, defaults, first, has, reject, includes } from "lodash"
+import { assign, compact, defaults, first, reject, includes } from "lodash"
 import { exclude } from "lib/helpers"
 import cached from "schema/fields/cached"
 import initials from "schema/fields/initials"
@@ -130,7 +130,6 @@ const ShowField = {
 export const ArtistType = new GraphQLObjectType({
   name: "Artist",
   interfaces: [NodeInterface],
-  isTypeOf: obj => has(obj, "birthday") && has(obj, "artworks_count"),
   fields: () => {
     return {
       ...GravityIDFields,

--- a/src/schema/artwork/index.js
+++ b/src/schema/artwork/index.js
@@ -693,7 +693,6 @@ export const artworkFields = () => {
 export const ArtworkType = new GraphQLObjectType({
   name: "Artwork",
   interfaces: [NodeInterface],
-  isTypeOf: obj => _.has(obj, "title") && _.has(obj, "artists"),
   fields: () => {
     return {
       ...artworkFields(),

--- a/src/schema/auction_result.js
+++ b/src/schema/auction_result.js
@@ -10,7 +10,7 @@ import {
   GraphQLEnumType,
 } from "graphql"
 import { connectionDefinitions } from "graphql-relay"
-import { has, indexOf } from "lodash"
+import { indexOf } from "lodash"
 import Image from "schema/image"
 
 // Taken from https://github.com/RubyMoney/money/blob/master/config/currency_iso.json
@@ -31,7 +31,6 @@ export const AuctionResultSorts = {
 const AuctionResultType = new GraphQLObjectType({
   name: "AuctionResult",
   interfaces: [NodeInterface],
-  isTypeOf: obj => has(obj, "sale_date") && has(obj, "organization"),
   fields: () => ({
     ...IDFields,
     title: {

--- a/src/schema/filter_artworks.js
+++ b/src/schema/filter_artworks.js
@@ -1,5 +1,5 @@
 import gravity from "lib/loaders/legacy/gravity"
-import { map, omit, keys, create, assign, has } from "lodash"
+import { map, omit, keys, create, assign } from "lodash"
 import { isExisty } from "lib/helpers"
 import Artwork from "./artwork"
 import Artist from "./artist"
@@ -75,7 +75,6 @@ export const FilterArtworksCounts = {
 export const FilterArtworksType = new GraphQLObjectType({
   name: "FilterArtworks",
   interfaces: [NodeInterface],
-  isTypeOf: obj => has(obj, "hits") && has(obj, "aggregations"),
   fields: () => ({
     __id: {
       type: new GraphQLNonNull(GraphQLID),

--- a/src/schema/home/home_page_artist_module.js
+++ b/src/schema/home/home_page_artist_module.js
@@ -1,4 +1,4 @@
-import { has, map } from "lodash"
+import { map } from "lodash"
 import Artist from "schema/artist"
 import gravity from "lib/loaders/legacy/gravity"
 import { total } from "lib/loaders/legacy/total"
@@ -63,7 +63,6 @@ export const HomePageArtistModuleTypes = {
 export const HomePageArtistModuleType = new GraphQLObjectType({
   name: "HomePageArtistModule",
   interfaces: [NodeInterface],
-  isTypeOf: obj => has(obj, "key") && !has(obj, "display"),
   fields: {
     __id: {
       type: new GraphQLNonNull(GraphQLID),

--- a/src/schema/home/home_page_artwork_module.js
+++ b/src/schema/home/home_page_artwork_module.js
@@ -1,4 +1,4 @@
-import { chain, find, has } from "lodash"
+import { chain, find } from "lodash"
 import gravity from "lib/loaders/legacy/gravity"
 import { params as genericGenes } from "./add_generic_genes"
 import Results from "./results"
@@ -20,7 +20,6 @@ let possibleArgs
 export const HomePageArtworkModuleType = new GraphQLObjectType({
   name: "HomePageArtworkModule",
   interfaces: [NodeInterface],
-  isTypeOf: obj => has(obj, "key") && has(obj, "display"),
   fields: () => ({
     __id: {
       type: new GraphQLNonNull(GraphQLID),

--- a/src/schema/me/conversation/index.js
+++ b/src/schema/me/conversation/index.js
@@ -1,7 +1,7 @@
 import { isExisty } from "lib/helpers"
 import date from "schema/fields/date"
 import initials from "schema/fields/initials"
-import { get, has, merge } from "lodash"
+import { get, merge } from "lodash"
 import {
   GraphQLBoolean,
   GraphQLList,
@@ -97,6 +97,16 @@ export const ConversationResponderType = new GraphQLObjectType({
 const ConversationItemType = new GraphQLUnionType({
   name: "ConversationItemType",
   types: [ArtworkType, ShowType],
+  resolveType: ({ __typename }) => {
+    switch (__typename) {
+      case "Artwork":
+        return ArtworkType
+      case "PartnerShow":
+        return ShowType
+      default:
+        return null
+    }
+  },
 })
 
 const ConversationItem = new GraphQLObjectType({
@@ -104,7 +114,10 @@ const ConversationItem = new GraphQLObjectType({
   fields: {
     item: {
       type: ConversationItemType,
-      resolve: ({ properties }) => properties,
+      resolve: ({ item_type, properties }) => ({
+        __typename: item_type,
+        ...properties,
+      }),
     },
     title: {
       type: GraphQLString,
@@ -382,7 +395,6 @@ export const ConversationType = new GraphQLObjectType({
   name: "Conversation",
   description: "A conversation.",
   interfaces: [NodeInterface],
-  isTypeOf: obj => has(obj, "initial_message") && has(obj, "from_email"),
   fields: ConversationFields,
 })
 

--- a/src/schema/me/conversation/message.js
+++ b/src/schema/me/conversation/message.js
@@ -1,5 +1,4 @@
 import date from "schema/fields/date"
-import { has } from "lodash"
 import {
   GraphQLBoolean,
   GraphQLList,
@@ -34,7 +33,6 @@ export const MessageType = new GraphQLObjectType({
   name: "Message",
   description: "A message in a conversation.",
   interfaces: [NodeInterface],
-  isTypeOf: obj => has(obj, "raw_text") && has(obj, "from_email_address"),
   fields: {
     __id: GlobalIDField,
     id: {

--- a/src/schema/me/followed_artists.js
+++ b/src/schema/me/followed_artists.js
@@ -1,5 +1,3 @@
-import { has } from "lodash"
-
 import Artist from "schema/artist"
 import { IDFields } from "schema/object_identification"
 
@@ -18,7 +16,6 @@ export const FollowArtistType = new GraphQLObjectType({
     },
     ...IDFields,
   },
-  isTypeOf: obj => has(obj, "artist") && has(obj, "auto"),
 })
 
 export default {

--- a/src/schema/me/followed_genes.js
+++ b/src/schema/me/followed_genes.js
@@ -1,5 +1,3 @@
-import { has } from "lodash"
-
 import Gene from "schema/gene"
 import { IDFields } from "schema/object_identification"
 
@@ -15,7 +13,6 @@ export const FollowGeneType = new GraphQLObjectType({
     },
     ...IDFields,
   },
-  isTypeOf: obj => has(obj, "gene"),
 })
 
 export default {

--- a/src/schema/me/index.js
+++ b/src/schema/me/index.js
@@ -1,5 +1,4 @@
 import { GraphQLString, GraphQLObjectType } from "graphql"
-import { has } from "lodash"
 
 import { IDFields, NodeInterface } from "schema/object_identification"
 import { queriedForFieldsOtherThanBlacklisted } from "lib/helpers"
@@ -39,7 +38,6 @@ const mySubmissions = enableSchemaStitching
 const Me = new GraphQLObjectType({
   name: "Me",
   interfaces: [NodeInterface],
-  isTypeOf: obj => has(obj, "email") && has(obj, "is_collector"),
   fields: {
     ...IDFields,
     ...mySubmissions,

--- a/src/schema/me/notifications.js
+++ b/src/schema/me/notifications.js
@@ -10,14 +10,13 @@ import {
   GraphQLObjectType,
   GraphQLString,
 } from "graphql"
-import { omit, has } from "lodash"
+import { omit } from "lodash"
 import { parseRelayOptions } from "lib/helpers"
 import { GlobalIDField, NodeInterface } from "schema/object_identification"
 
 const NotificationsFeedItemType = new GraphQLObjectType({
   name: "NotificationsFeedItem",
   interfaces: [NodeInterface],
-  isTypeOf: obj => has(obj, "actors") && has(obj, "object_ids"),
   fields: () => ({
     __id: GlobalIDField,
     artists: {

--- a/src/schema/sale/index.js
+++ b/src/schema/sale/index.js
@@ -11,7 +11,7 @@ import { pageable, getPagingParameters } from "relay-cursor-paging"
 import { connectionFromArraySlice, connectionDefinitions } from "graphql-relay"
 import { amount } from "schema/fields/money"
 import { exclude } from "lib/helpers"
-import { map, has } from "lodash"
+import { map } from "lodash"
 import { NodeInterface } from "schema/object_identification"
 
 import {
@@ -71,7 +71,6 @@ const saleArtworkConnection = connectionDefinitions({
 const SaleType = new GraphQLObjectType({
   name: "Sale",
   interfaces: [NodeInterface],
-  isTypeOf: obj => has(obj, "is_auction") && has(obj, "currency"),
   fields: () => {
     return {
       ...GravityIDFields,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/IN-60 #resolve
Closes #865

The specific problem in the linked Jira ticket was about a HTML only Message not being being recognised as such, because it had no `raw_text` field and thus failed `isTypeOf`.