### PR TITLE
Add is_auction to sale_artworks filter query

### DIFF
--- a/src/schema/__tests__/sale_artworks.test.js
+++ b/src/schema/__tests__/sale_artworks.test.js
@@ -10,7 +10,7 @@ describe("Sale Artworks", () => {
     })
   }
 
-  it("pulls from /sale_artworks endpoint if `live_sale=true` and `include_lots_by_followed_artists=true`", async () => {
+  it("pulls from /sale_artworks if `live_sale, include_lots_by_followed_artists, is_auction to true` ", async () => {
     const hits = _.fill(Array(10), { id: "foo" })
     const totalCount = hits.length * 2
     const gravityResponse = {
@@ -24,6 +24,7 @@ describe("Sale Artworks", () => {
         sale_artworks(
           live_sale: true
           include_artworks_by_followed_artists: true
+          is_auction: true
         ) {
           counts {
             total

--- a/src/schema/filter_sale_artworks.js
+++ b/src/schema/filter_sale_artworks.js
@@ -32,6 +32,9 @@ export const filterSaleArtworksArgs = {
   live_sale: {
     type: GraphQLBoolean,
   },
+  is_auction: {
+    type: GraphQLBoolean,
+  },
   gene_ids: {
     type: new GraphQLList(GraphQLString),
   },


### PR DESCRIPTION
# Change
Gravity's `sales_artworks` endpoint has been updated to include `is_auction` flag to filter lots only in auction. We need to update MP to include that param.

# Weirdness?
I _think_ there is only one args `filterSaleArtworksArgs` is defined for accessing both `filters` and `sales_artworks` endpoints in Gravity, I added `is_auction` which currently would only be applicable to `sales_artworks` and can be ignored for `filter` endpoint, hope thats ok.