### PR TITLE
[WIP][PossibleSolution] Possible solution for snippet issue

### DIFF
--- a/src/schema/me/conversation/index.js
+++ b/src/schema/me/conversation/index.js
@@ -199,8 +199,25 @@ export const ConversationFields = {
   last_message: {
     type: GraphQLString,
     description: "This is a snippet of text from the last message.",
-    resolve: conversation => {
-      return get(conversation, "_embedded.last_message.snippet")
+    resolve: (
+      conversation,
+      options,
+      request,
+      { rootValue: { conversationMessagesLoader } }
+    ) => {
+      // return ""
+
+      return conversationMessagesLoader({
+        conversation_id: conversation.id,
+        "expand[]": "deliveries",
+      }).then(({ message_details }) => {
+        const relevantDelivery = message_details.find(
+          m =>
+            m.from_email === conversation.from_email ||
+            m.deliveries.find(d => d.email === conversation.from_email)
+        )
+        return relevantDelivery.snippet
+      })
     },
   },
   last_message_at: date,


### PR DESCRIPTION
# Problem
As part of https://github.com/artsy/radiation/issues/311 we decided to filter conversation messages with conversation `from_email` in https://github.com/artsy/radiation/issues/312 and https://github.com/artsy/impulse/pull/426. While those changes guarantee we don't see unrelated messages when clicking on message itself, we still get `snippet` from conversation's `last_message` which in problematic cases may end up being wrong message.

# Possible (slow ⏳⌛️) Solution
We talked about changing MP to return `nil` for `snippet` while we work on longer term solution. I added that as commented out line for now in this PR to possibly explore/suggest another approach (not a very performant one) where we actually _resolve_ `last_message` by getting all of the messages of each conversation and we try to find the last message where current user was either the sender of he/she was in the list of deliveries. This will perform pretty bad compare to what we have now but it will somewhat accurate. I haven't done any testing yet but just wanted to throw the possible solution out there before offering to removing `snippet`.

# Another consideration
Event if we decided to just return `nil` for `snippet` we may want to still consider this logic for showing actually inbox and ignore radiation and impulse changes, not sure what pagination impacts we may have here but looks like MP is capable of possibly filtering unrelated messages.


NOTE: im little (not too much) worried that tests passed with this somewhat big change i just made.