### PR TITLE
Return null for snippet till we come up with long term solution

### DIFF
--- a/src/schema/me/conversation/index.js
+++ b/src/schema/me/conversation/index.js
@@ -199,9 +199,7 @@ export const ConversationFields = {
   last_message: {
     type: GraphQLString,
     description: "This is a snippet of text from the last message.",
-    resolve: conversation => {
-      return get(conversation, "_embedded.last_message.snippet")
-    },
+    resolve: () => null,
   },
   last_message_at: date,
 


### PR DESCRIPTION
# Problem
`last_message.snippet` may sometime be message unrelated to this user.

# Solution
For now return `null` till we come up with long term solution.

Simple solution of https://github.com/artsy/metaphysics/pull/925