### PR TITLE
[STI-36] Add is_online_exclusive flag to partner show

### DIFF
--- a/src/schema/__tests__/partner_show.test.js
+++ b/src/schema/__tests__/partner_show.test.js
@@ -35,6 +35,73 @@ describe("PartnerShow type", () => {
     PartnerShow.__ResetDependency__("total")
   })
 
+  it("include false is_online_exclusive flag for shows with location", () => {
+    showData.location = "test location"
+    const query = `
+      {
+        partner_show(id: "new-museum-1-2015-triennial-surround-audience") {
+          is_online_exclusive
+        }
+      }
+    `
+    return runQuery(query).then(data => {
+      expect(data).toEqual({
+        partner_show: {
+          is_online_exclusive: false,
+        },
+      })
+    })
+  })
+  it("include false is_online_exclusive flag for shows with fair_location", () => {
+    showData.fair_location = "test location"
+    const query = `
+      {
+        partner_show(id: "new-museum-1-2015-triennial-surround-audience") {
+          is_online_exclusive
+        }
+      }
+    `
+    return runQuery(query).then(data => {
+      expect(data).toEqual({
+        partner_show: {
+          is_online_exclusive: false,
+        },
+      })
+    })
+  })
+  it("include false is_online_exclusive flag for shows with partner_city", () => {
+    showData.partner_city = "test location"
+    const query = `
+      {
+        partner_show(id: "new-museum-1-2015-triennial-surround-audience") {
+          is_online_exclusive
+        }
+      }
+    `
+    return runQuery(query).then(data => {
+      expect(data).toEqual({
+        partner_show: {
+          is_online_exclusive: false,
+        },
+      })
+    })
+  })
+  it("include true is_online_exclusive flag for shows without any location", () => {
+    const query = `
+      {
+        partner_show(id: "new-museum-1-2015-triennial-surround-audience") {
+          is_online_exclusive
+        }
+      }
+    `
+    return runQuery(query).then(data => {
+      expect(data).toEqual({
+        partner_show: {
+          is_online_exclusive: true,
+        },
+      })
+    })
+  })
   it("doesn't return a show that’s not displayable", () => {
     showData.displayable = false
     const query = `

--- a/src/schema/__tests__/partner_show.test.js
+++ b/src/schema/__tests__/partner_show.test.js
@@ -35,69 +35,69 @@ describe("PartnerShow type", () => {
     PartnerShow.__ResetDependency__("total")
   })
 
-  it("include false is_online_exclusive flag for shows with location", () => {
+  it("include true has_location flag for shows with location", () => {
     showData.location = "test location"
     const query = `
       {
         partner_show(id: "new-museum-1-2015-triennial-surround-audience") {
-          is_online_exclusive
+          has_location
         }
       }
     `
     return runQuery(query).then(data => {
       expect(data).toEqual({
         partner_show: {
-          is_online_exclusive: false,
+          has_location: true,
         },
       })
     })
   })
-  it("include false is_online_exclusive flag for shows with fair_location", () => {
-    showData.fair_location = "test location"
+  it("include true has_location flag for shows with fair_location", () => {
+    showData.fair = "test location"
     const query = `
       {
         partner_show(id: "new-museum-1-2015-triennial-surround-audience") {
-          is_online_exclusive
+          has_location
         }
       }
     `
     return runQuery(query).then(data => {
       expect(data).toEqual({
         partner_show: {
-          is_online_exclusive: false,
+          has_location: true,
         },
       })
     })
   })
-  it("include false is_online_exclusive flag for shows with partner_city", () => {
+  it("include true has_location flag for shows with partner_city", () => {
     showData.partner_city = "test location"
     const query = `
       {
         partner_show(id: "new-museum-1-2015-triennial-surround-audience") {
-          is_online_exclusive
+          has_location
         }
       }
     `
     return runQuery(query).then(data => {
       expect(data).toEqual({
         partner_show: {
-          is_online_exclusive: false,
+          has_location: true,
         },
       })
     })
   })
-  it("include true is_online_exclusive flag for shows without any location", () => {
+  it("include false has_location flag for shows without any location", () => {
     const query = `
       {
         partner_show(id: "new-museum-1-2015-triennial-surround-audience") {
-          is_online_exclusive
+          has_location
         }
       }
     `
     return runQuery(query).then(data => {
       expect(data).toEqual({
         partner_show: {
-          is_online_exclusive: true,
+          has_location: false,
         },
       })
     })

--- a/src/schema/__tests__/show.test.js
+++ b/src/schema/__tests__/show.test.js
@@ -50,69 +50,69 @@ describe("Show type", () => {
     Show.__ResetDependency__("total")
   })
 
-  it("include false is_online_exclusive flag for shows with location", () => {
+  it("include true has_location flag for shows with location", () => {
     showData.location = "test location"
     const query = `
       {
         show(id: "new-museum-1-2015-triennial-surround-audience") {
-          is_online_exclusive
+          has_location
         }
       }
     `
     return runQuery(query).then(data => {
       expect(data).toEqual({
         show: {
-          is_online_exclusive: false,
+          has_location: true,
         },
       })
     })
   })
-  it("include false is_online_exclusive flag for shows with fair_location", () => {
-    showData.fair_location = "test location"
+  it("include true has_location flag for shows with fair_location", () => {
+    showData.fair = "test location"
     const query = `
       {
         show(id: "new-museum-1-2015-triennial-surround-audience") {
-          is_online_exclusive
+          has_location
         }
       }
     `
     return runQuery(query).then(data => {
       expect(data).toEqual({
         show: {
-          is_online_exclusive: false,
+          has_location: true,
         },
       })
     })
   })
-  it("include false is_online_exclusive flag for shows with partner_city", () => {
+  it("include true has_location flag for shows with partner_city", () => {
     showData.partner_city = "test location"
     const query = `
       {
         show(id: "new-museum-1-2015-triennial-surround-audience") {
-          is_online_exclusive
+          has_location
         }
       }
     `
     return runQuery(query).then(data => {
       expect(data).toEqual({
         show: {
-          is_online_exclusive: false,
+          has_location: true,
         },
       })
     })
   })
-  it("include true is_online_exclusive flag for shows without any location", () => {
+  it("include false has_location flag for shows without any location", () => {
     const query = `
       {
         show(id: "new-museum-1-2015-triennial-surround-audience") {
-          is_online_exclusive
+          has_location
         }
       }
     `
     return runQuery(query).then(data => {
       expect(data).toEqual({
         show: {
-          is_online_exclusive: true,
+          has_location: false,
         },
       })
     })

--- a/src/schema/__tests__/show.test.js
+++ b/src/schema/__tests__/show.test.js
@@ -50,6 +50,73 @@ describe("Show type", () => {
     Show.__ResetDependency__("total")
   })
 
+  it("include false is_online_exclusive flag for shows with location", () => {
+    showData.location = "test location"
+    const query = `
+      {
+        show(id: "new-museum-1-2015-triennial-surround-audience") {
+          is_online_exclusive
+        }
+      }
+    `
+    return runQuery(query).then(data => {
+      expect(data).toEqual({
+        show: {
+          is_online_exclusive: false,
+        },
+      })
+    })
+  })
+  it("include false is_online_exclusive flag for shows with fair_location", () => {
+    showData.fair_location = "test location"
+    const query = `
+      {
+        show(id: "new-museum-1-2015-triennial-surround-audience") {
+          is_online_exclusive
+        }
+      }
+    `
+    return runQuery(query).then(data => {
+      expect(data).toEqual({
+        show: {
+          is_online_exclusive: false,
+        },
+      })
+    })
+  })
+  it("include false is_online_exclusive flag for shows with partner_city", () => {
+    showData.partner_city = "test location"
+    const query = `
+      {
+        show(id: "new-museum-1-2015-triennial-surround-audience") {
+          is_online_exclusive
+        }
+      }
+    `
+    return runQuery(query).then(data => {
+      expect(data).toEqual({
+        show: {
+          is_online_exclusive: false,
+        },
+      })
+    })
+  })
+  it("include true is_online_exclusive flag for shows without any location", () => {
+    const query = `
+      {
+        show(id: "new-museum-1-2015-triennial-surround-audience") {
+          is_online_exclusive
+        }
+      }
+    `
+    return runQuery(query).then(data => {
+      expect(data).toEqual({
+        show: {
+          is_online_exclusive: true,
+        },
+      })
+    })
+  })
   it("doesn't return a show that’s neither displayable nor a reference", () => {
     showData.displayable = false
     showData.is_reference = false

--- a/src/schema/partner_show.js
+++ b/src/schema/partner_show.js
@@ -182,11 +182,11 @@ const PartnerShowType = new GraphQLObjectType({
         return gravity(`partner_show/${id}/images`, options).then(Image.resolve)
       },
     },
-    is_online_exclusive: {
+    has_location: {
       type: GraphQLBoolean,
-      description: "Flag showing if show is online exclusive or not.",
-      resolve: ({ location, fair_location, partner_city }) => {
-        return !location && !fair_location && !partner_city
+      description: "Flag showing if show has any location.",
+      resolve: ({ location, fair, partner_city }) => {
+        return isExisty(location || fair || partner_city)
       },
     },
     is_active: {

--- a/src/schema/partner_show.js
+++ b/src/schema/partner_show.js
@@ -182,6 +182,13 @@ const PartnerShowType = new GraphQLObjectType({
         return gravity(`partner_show/${id}/images`, options).then(Image.resolve)
       },
     },
+    is_online_exclusive: {
+      type: GraphQLBoolean,
+      description: "Flag showing if show is online exclusive or not.",
+      resolve: ({ location, fair_location, partner_city }) => {
+        return !location && !fair_location && !partner_city
+      },
+    },
     is_active: {
       type: GraphQLBoolean,
       description:

--- a/src/schema/show.js
+++ b/src/schema/show.js
@@ -231,6 +231,13 @@ export const ShowType = new GraphQLObjectType({
         return gravity(`partner_show/${id}/images`, options).then(Image.resolve)
       },
     },
+    is_online_exclusive: {
+      type: GraphQLBoolean,
+      description: "Flag showing if show is online exclusive or not.",
+      resolve: ({ location, fair_location, partner_city }) => {
+        return !location && !fair_location && !partner_city
+      },
+    },
     is_active: {
       type: GraphQLBoolean,
       description:

--- a/src/schema/show.js
+++ b/src/schema/show.js
@@ -231,11 +231,11 @@ export const ShowType = new GraphQLObjectType({
         return gravity(`partner_show/${id}/images`, options).then(Image.resolve)
       },
     },
-    is_online_exclusive: {
+    has_location: {
       type: GraphQLBoolean,
-      description: "Flag showing if show is online exclusive or not.",
-      resolve: ({ location, fair_location, partner_city }) => {
-        return !location && !fair_location && !partner_city
+      description: "Flag showing if show has any location.",
+      resolve: ({ location, fair, partner_city }) => {
+        return isExisty(location || fair || partner_city)
       },
     },
     is_active: {


### PR DESCRIPTION
# Problem
We want to be able to distinguish between `online_exclusive` shows and shows with actual locations.

# Solution
Add new `boolean` field to `partnerShow` which based on `location`, `fair_location` and `partner_city` of the PartnerShow returns flag showing if it's `has_location` or not.