### PR TITLE
[STI-15] Filter out shows without location in exhibition highlights query

### DIFF
--- a/src/schema/artist/__tests__/index.test.js
+++ b/src/schema/artist/__tests__/index.test.js
@@ -143,7 +143,7 @@ describe("Artist type", () => {
     })
   })
 
-  it("rincludes collections data", () => {
+  it("includes collections data", () => {
     const query = `
       {
         artist(id: "foo-bar") {

--- a/src/schema/artist/index.js
+++ b/src/schema/artist/index.js
@@ -473,6 +473,7 @@ export const ArtistType = new GraphQLObjectType({
             sort: "-relevance,-start_at",
             is_reference: true,
             visible_to_public: false,
+            has_location: true,
             size: options.size,
           }).then(shows => showsWithBLacklistedPartnersRemoved(shows))
         },


### PR DESCRIPTION
# Problem
We want to filter out online exclusive shows from artist's exhibition highlights.
https://artsyproduct.atlassian.net/browse/STI-15

# Solution
In `exhibition_highlights` resolver, add `has_location: true` to make sure we filter shows without location.

# Depends on STI-39
Gravity change to support filter by `has_location`.
https://artsyproduct.atlassian.net/browse/STI-39
