### PR TITLE
@alloy => Can return artists by array of ids

### DIFF
--- a/src/schema/__tests__/artists.test.js
+++ b/src/schema/__tests__/artists.test.js
@@ -26,4 +26,27 @@ describe("Artists", () => {
     const { artists } = await runQuery(query, { artistsLoader })
     expect(artists).toEqual([{ name: "Han Myung-Ok" }])
   })
+
+  it("returns a list of artists matching array of ids", async () => {
+    const artistsLoader = ({ ids }) => {
+      if (ids) {
+        return Promise.resolve([
+          {
+            _id: "52c721e5b202a3edf1000072",
+            name: "Han Myung-Ok",
+          },
+        ])
+      }
+      throw new Error("Unexpected invocation")
+    }
+    const query = gql`
+      {
+        artists(ids: ["52c721e5b202a3edf1000072"]) {
+          _id
+        }
+      }
+    `
+    const { artists } = await runQuery(query, { artistsLoader })
+    expect(artists[0]._id).toEqual("52c721e5b202a3edf1000072")
+  })
 })

--- a/src/schema/artists.js
+++ b/src/schema/artists.js
@@ -1,11 +1,18 @@
 import Artist from "./artist"
 import ArtistSorts from "./sorts/artist_sorts"
-import { GraphQLList, GraphQLInt } from "graphql"
+import { GraphQLList, GraphQLInt, GraphQLString } from "graphql"
 
 const Artists = {
   type: new GraphQLList(Artist.type),
   description: "A list of Artists",
   args: {
+    ids: {
+      type: new GraphQLList(GraphQLString),
+      description: `
+        Only return artists matching specified ids.
+        Accepts list of ids.
+      `,
+    },
     page: {
       type: GraphQLInt,
       defaultValue: 1,


### PR DESCRIPTION
Adds `ids` param to `artists` schema, to return artists matching an array of passed ids.