### PR TITLE
@sweir27 => Rename delete -> del to delete from Redis

### DIFF
--- a/src/lib/cache.js
+++ b/src/lib/cache.js
@@ -101,7 +101,7 @@ export default {
 
   delete: key =>
     new Promise((resolve, reject) =>
-      client.delete(key, (err, response) => {
+      client.del(key, (err, response) => {
         if (err) return reject(err)
         resolve(response)
       })


### PR DESCRIPTION
We were observing that unpublished artworks were still resolving from Metaphysics' cache (and had to be manually removed), even though they should have been deleted.

Basically, I think we got the `delete` command wrong (in Redis its `del`).

I skipped specs here since we use a completely stubbed client, I don't think it would have caught this necessarily.