### PR TITLE
@damassi => compress responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ import "moment-timezone"
 import "artsy-newrelic"
 import Bluebird from "bluebird"
 import xapp from "artsy-xapp"
+import compression from "compression"
 import express from "express"
 import forceSSL from "express-force-ssl"
 import bodyParser from "body-parser"
@@ -29,6 +30,8 @@ if (enableAsyncStackTraces) {
 }
 
 const app = express()
+
+app.use(compression())
 
 xapp.on("error", err => {
   error(err)

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "basic-auth": "^1.0.3",
     "bluebird": "^3.3.4",
     "body-parser": "^1.15.2",
+    "compression": "^1.7.2",
     "cors": "^2.7.1",
     "datadog-tracer": "github:artsy/datadog-tracer-js#99c3f411cc19bb11729b56c699fd21d50f24507d",
     "dataloader": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1291,6 +1291,24 @@ component-emitter@~1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
 
+compressible@~2.0.13:
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.13.tgz#0d1020ab924b2fdb4d6279875c7d6daba6baa7a9"
+  dependencies:
+    mime-db ">= 1.33.0 < 2"
+
+compression@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.2.tgz#aaffbcd6aaf854b44ebb280353d5ad1651f59a69"
+  dependencies:
+    accepts "~1.3.4"
+    bytes "3.0.0"
+    compressible "~2.0.13"
+    debug "2.6.9"
+    on-headers "~1.0.1"
+    safe-buffer "5.1.1"
+    vary "~1.1.2"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -3693,6 +3711,10 @@ micromatch@^2.1.5, micromatch@^2.3.11:
     object.omit "^2.0.0"
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
+
+"mime-db@>= 1.33.0 < 2":
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
 
 mime-db@~1.30.0:
   version "1.30.0"


### PR DESCRIPTION
This PR adds gzip compression via the handy [compression](https://github.com/expressjs/compression) package. Part of @yuki24 and I's sprint to improve front-end performance.

We have been using webpagetest.org to benchmark performance of the major force pages (artsy.net, artsy.net/collect, and artsy.net/artist/....). It included this recommendation for how we can improve:
<img width="908" alt="screen shot 2018-02-27 at 12 03 51 pm" src="https://user-images.githubusercontent.com/2081340/36742746-75e04148-1bb6-11e8-99fc-cfb2c7033dac.png">

