### PR TITLE
@mzikherman => Search fairs by [:ids]

### DIFF
--- a/src/schema/__tests__/fairs.test.js
+++ b/src/schema/__tests__/fairs.test.js
@@ -1,0 +1,24 @@
+import { runQuery } from "test/utils"
+import gql from "test/gql"
+
+describe("Fairs", () => {
+  it("returns a list of fairs matching array of ids", async () => {
+    const fairsLoader = ({ id }) => {
+      if (id) {
+        return Promise.resolve(
+          id.map(_id => ({ _id }))
+        )
+      }
+      throw new Error("Unexpected invocation")
+    }
+    const query = gql`
+      {
+        fairs(ids: ["5a9075da8b3b817ede4f8767"]) {
+          _id
+        }
+      }
+    `
+    const { fairs } = await runQuery(query, { fairsLoader })
+    expect(fairs[0]._id).toEqual("5a9075da8b3b817ede4f8767")
+  })
+})

--- a/src/schema/fairs.js
+++ b/src/schema/fairs.js
@@ -21,6 +21,13 @@ const Fairs = {
     has_listing: {
       type: GraphQLBoolean,
     },
+    ids: {
+      type: new GraphQLList(GraphQLString),
+      description: `
+        Only return fairs matching specified ids.
+        Accepts list of ids.
+      `,
+    },
     near: {
       type: Near,
     },
@@ -41,6 +48,10 @@ const Fairs = {
         near: `${options.near.lat},${options.near.lng}`,
         max_distance: options.near.max_distance,
       })
+    }
+    if (options.ids) {
+      gravityOptions.id = options.ids
+      delete gravityOptions.ids
     }
     return fairsLoader(gravityOptions)
   },


### PR DESCRIPTION
Very similar to https://github.com/artsy/metaphysics/pull/949, adds `:ids` param to Fairs endpoint.  