### PR TITLE
@orta => Remove `all` legacy loader, remove couple rewire uses

### DIFF
--- a/src/lib/__tests__/all.test.js
+++ b/src/lib/__tests__/all.test.js
@@ -1,34 +1,18 @@
-import all from "lib/all"
+import { allViaLoader } from "lib/all"
 
 describe("all", () => {
-  afterEach(() => {
-    all.__ResetDependency__("total")
-    all.__ResetDependency__("gravity")
-  })
+  it("fans out all the requests", () => {
+    const loader = jest
+      .fn()
+      .mockReturnValueOnce(
+        Promise.resolve({
+          headers: { "x-total-count": 42 },
+        })
+      )
+      .mockReturnValue(Promise.resolve({}))
 
-  it("fans out all the request", () => {
-    const gravity = sinon.stub()
-
-    all.__Rewire__("total", sinon.stub().returns(Promise.resolve(120)))
-    all.__Rewire__("gravity", gravity.returns(Promise.resolve([{}])))
-
-    return all(`artist/foo-bar/artworks`, { size: 10 }).then(artworks => {
-      expect(gravity.args).toEqual([
-        ["artist/foo-bar/artworks", { size: 10, page: 1 }],
-        ["artist/foo-bar/artworks", { size: 10, page: 2 }],
-        ["artist/foo-bar/artworks", { size: 10, page: 3 }],
-        ["artist/foo-bar/artworks", { size: 10, page: 4 }],
-        ["artist/foo-bar/artworks", { size: 10, page: 5 }],
-        ["artist/foo-bar/artworks", { size: 10, page: 6 }],
-        ["artist/foo-bar/artworks", { size: 10, page: 7 }],
-        ["artist/foo-bar/artworks", { size: 10, page: 8 }],
-        ["artist/foo-bar/artworks", { size: 10, page: 9 }],
-        ["artist/foo-bar/artworks", { size: 10, page: 10 }],
-        ["artist/foo-bar/artworks", { size: 10, page: 11 }],
-        ["artist/foo-bar/artworks", { size: 10, page: 12 }],
-      ])
-
-      expect(artworks.length).toBe(12) // 12 pages
+    return allViaLoader(loader, {}, { size: 10 }).then(artworks => {
+      expect(artworks.length).toBe(5) // 5 pages fo 10 each to get 42 works
     })
   })
 })

--- a/src/lib/__tests__/all.test.js
+++ b/src/lib/__tests__/all.test.js
@@ -6,13 +6,21 @@ describe("all", () => {
       .fn()
       .mockReturnValueOnce(
         Promise.resolve({
-          headers: { "x-total-count": 42 },
+          headers: { "x-total-count": 22 },
         })
       )
       .mockReturnValue(Promise.resolve({}))
 
     return allViaLoader(loader, {}, { size: 10 }).then(artworks => {
-      expect(artworks.length).toBe(5) // 5 pages fo 10 each to get 42 works
+      expect(artworks.length).toBe(3) // 3 pages of 10 each to get 22 works
+
+      // Initial count fetch
+      expect(loader.mock.calls[0].slice(-1)[0].size).toBe(0)
+      expect(loader.mock.calls[0].slice(-1)[0].page).toBe(1)
+      expect(loader.mock.calls[0].slice(-1)[0].total_count).toBe(true)
+      expect(loader.mock.calls[1].slice(-1)[0].page).toBe(1)
+      expect(loader.mock.calls[2].slice(-1)[0].page).toBe(2)
+      expect(loader.mock.calls[3].slice(-1)[0].page).toBe(3)
     })
   })
 })

--- a/src/lib/all.js
+++ b/src/lib/all.js
@@ -1,19 +1,6 @@
 // @ts-check
 
 import { assign, times, flatten } from "lodash"
-import total from "./loaders/legacy/total"
-import gravity from "./loaders/legacy/gravity"
-
-export const all = (path, options = {}) => {
-  return total(path, options)
-    .then(n => {
-      const pages = Math.ceil(n / (options.size || 25))
-      return Promise.all(
-        times(pages, i => gravity(path, assign({}, options, { page: i + 1 })))
-      )
-    })
-    .then(flatten)
-}
 
 export const allViaLoader = (loader, loaderOptions, apiOptions = {}) => {
   const countOptions = assign({}, apiOptions, {
@@ -36,5 +23,3 @@ export const allViaLoader = (loader, loaderOptions, apiOptions = {}) => {
     })
     .then(flatten)
 }
-
-export default all

--- a/src/lib/loaders/legacy/gravity.js
+++ b/src/lib/loaders/legacy/gravity.js
@@ -2,7 +2,6 @@ import { toKey } from "lib/helpers"
 import gravity from "lib/apis/gravity"
 import httpLoader from "./http"
 import authenticatedHttpLoader from "./authenticated_http"
-import all from "lib/all"
 
 export const gravityLoader = httpLoader(gravity)
 
@@ -25,7 +24,5 @@ load.with = (accessToken, loaderOptions = {}) => {
     return gravityLoader.load(key)
   }
 }
-
-load.all = all
 
 export default load

--- a/src/schema/__tests__/partner_show.test.js
+++ b/src/schema/__tests__/partner_show.test.js
@@ -1,16 +1,11 @@
 import moment from "moment"
-import schema from "schema"
 import { runQuery } from "test/utils"
 
 describe("PartnerShow type", () => {
-  const PartnerShow = schema.__get__("PartnerShow")
-  let total = null
   let showData = null
   let rootValue = null
 
   beforeEach(() => {
-    total = sinon.stub()
-
     showData = {
       id: "new-museum-1-2015-triennial-surround-audience",
       start_at: "2015-02-25T12:00:00+00:00",
@@ -27,11 +22,6 @@ describe("PartnerShow type", () => {
     rootValue = {
       showLoader: sinon.stub().returns(Promise.resolve(showData)),
     }
-    PartnerShow.__Rewire__("total", total)
-  })
-
-  afterEach(() => {
-    PartnerShow.__ResetDependency__("total")
   })
 
   it("include true has_location flag for shows with location", () => {
@@ -192,7 +182,9 @@ describe("PartnerShow type", () => {
     })
   })
   it("includes the total number of artworks", () => {
-    total.onCall(0).returns(Promise.resolve(42))
+    rootValue.partnerShowArtworksLoader = sinon
+      .stub()
+      .returns(Promise.resolve({ headers: { "x-total-count": 42 } }))
     const query = `
       {
         partner_show(id: "new-museum-1-2015-triennial-surround-audience") {
@@ -233,7 +225,9 @@ describe("PartnerShow type", () => {
     })
   })
   it("includes the number of artworks by a specific artist", () => {
-    total.onCall(0).returns(Promise.resolve(2))
+    rootValue.partnerShowArtworksLoader = sinon
+      .stub()
+      .returns(Promise.resolve({ headers: { "x-total-count": 2 } }))
     const query = `
       {
         partner_show(id: "new-museum-1-2015-triennial-surround-audience") {

--- a/src/schema/__tests__/show.test.js
+++ b/src/schema/__tests__/show.test.js
@@ -1,17 +1,12 @@
 import moment from "moment"
-import schema from "schema"
 import { runQuery } from "test/utils"
 
 describe("Show type", () => {
-  const Show = schema.__get__("Show")
-  let total = null
   let showData = null
   let rootValue = null
   let galaxyData = null
 
   beforeEach(() => {
-    total = sinon.stub()
-
     showData = {
       id: "new-museum-1-2015-triennial-surround-audience",
       start_at: "2015-02-25T12:00:00+00:00",
@@ -38,11 +33,6 @@ describe("Show type", () => {
       galaxyGalleriesLoader: sinon.stub().returns(Promise.resolve(galaxyData)),
       partnerShowLoader: sinon.stub().returns(Promise.resolve(showData)),
     }
-    Show.__Rewire__("total", total)
-  })
-
-  afterEach(() => {
-    Show.__ResetDependency__("total")
   })
 
   it("include true has_location flag for shows with location", () => {
@@ -475,7 +465,9 @@ describe("Show type", () => {
     })
   })
   it("includes the total number of artworks", () => {
-    total.onCall(0).returns(Promise.resolve(42))
+    rootValue.partnerShowArtworksLoader = sinon
+      .stub()
+      .returns(Promise.resolve({ headers: { "x-total-count": 42 } }))
     const query = `
       {
         show(id: "new-museum-1-2015-triennial-surround-audience") {
@@ -516,7 +508,9 @@ describe("Show type", () => {
     })
   })
   it("includes the number of artworks by a specific artist", () => {
-    total.onCall(0).returns(Promise.resolve(2))
+    rootValue.partnerShowArtworksLoader = sinon
+      .stub()
+      .returns(Promise.resolve({ headers: { "x-total-count": 2 } }))
     const query = `
       {
         show(id: "new-museum-1-2015-triennial-surround-audience") {

--- a/src/schema/partner_show.js
+++ b/src/schema/partner_show.js
@@ -1,7 +1,6 @@
 import moment from "moment"
 import { isExisty, exclude } from "lib/helpers"
 import { find, has } from "lodash"
-import total from "lib/loaders/legacy/total"
 import HTTPError from "lib/http_error"
 import numeral from "./fields/numeral"
 import { exhibitionPeriod, exhibitionStatus } from "lib/date"
@@ -25,6 +24,7 @@ import {
   GraphQLBoolean,
 } from "graphql"
 import { allViaLoader } from "../lib/all"
+import { totalViaLoader } from "../lib/loaders/legacy/total"
 
 const kind = ({ artists, fair }) => {
   if (isExisty(fair)) return "fair"
@@ -110,8 +110,17 @@ const PartnerShowType = new GraphQLObjectType({
                 description: "The slug or ID of an artist in the show.",
               },
             },
-            resolve: ({ id, partner }, options) => {
-              return total(`partner/${partner.id}/show/${id}/artworks`, options)
+            resolve: (
+              { id, partner },
+              options,
+              request,
+              { rootValue: { partnerShowArtworksLoader } }
+            ) => {
+              return totalViaLoader(
+                partnerShowArtworksLoader,
+                { partner_id: partner.id, show_id: id },
+                options
+              )
             },
           },
           eligible_artworks: numeral(

--- a/src/schema/show.js
+++ b/src/schema/show.js
@@ -3,7 +3,6 @@ import { pageable } from "relay-cursor-paging"
 import { connectionFromArraySlice, connectionDefinitions } from "graphql-relay"
 import { isExisty, exclude, existyValue, parseRelayOptions } from "lib/helpers"
 import { find, has } from "lodash"
-import total from "lib/loaders/legacy/total"
 import HTTPError from "lib/http_error"
 import numeral from "./fields/numeral"
 import { exhibitionPeriod, exhibitionStatus } from "lib/date"
@@ -198,8 +197,17 @@ export const ShowType = new GraphQLObjectType({
                 description: "The slug or ID of an artist in the show.",
               },
             },
-            resolve: ({ id, partner }, options) => {
-              return total(`partner/${partner.id}/show/${id}/artworks`, options)
+            resolve: (
+              { id, partner },
+              options,
+              request,
+              { rootValue: { partnerShowArtworksLoader } }
+            ) => {
+              return totalViaLoader(
+                partnerShowArtworksLoader,
+                { partner_id: partner.id, show_id: id },
+                options
+              )
             },
           },
           eligible_artworks: numeral(


### PR DESCRIPTION
As I'm working thru remaining legacy data loaders (home page ones coming next!), I figured it's a good idea to PR early and often. Much like voting.

So this removes a legacy `all` helper, that was being used like: `gravity.all("artworks")`, which would continue paginating the API until exhausted. We have a `allViaLoader` helper which is used in a couple places instead (and an open issue to remove the client code in Force which requests that since it's a horrible pattern).

Also removes some rewire/stubbing via explicit DI of the loaders. Definitely doing a lot of this in these PRs, @alloy mentions we can't easily have both Rewire and Jest stubs in the same project, and so it'd be preferable to remove rewire entirely?