### PR TITLE
@alloy => Update homepage related code to use new data loaders

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.js
+++ b/src/lib/loaders/loaders_with_authentication/gravity.js
@@ -37,6 +37,11 @@ export default (accessToken, userID, requestIDs) => {
       {},
       { headers: true }
     ),
+    followedProfilesArtworksLoader: gravityLoader(
+      "me/follow/profiles/artworks",
+      {},
+      { headers: true }
+    ),
     followedGenesLoader: gravityLoader(
       "me/follow/genes",
       {},
@@ -47,6 +52,10 @@ export default (accessToken, userID, requestIDs) => {
       "profiles",
       "is_followed",
       "profile"
+    ),
+    homepageModulesLoader: gravityLoader("me/modules"),
+    homepageSuggestedArtworksLoader: gravityLoader(
+      "me/suggested/artworks/homepage"
     ),
     inquiryRequestsLoader: gravityLoader(
       "me/inquiry_requests",
@@ -72,6 +81,10 @@ export default (accessToken, userID, requestIDs) => {
       {},
       { headers: true }
     ),
+    savedArtworksLoader: gravityLoader("collection/saved-artwork/artworks", {
+      user_id: userID,
+      private: true,
+    }),
     filterArtworksLoader: gravityLoader("filter/artworks"),
     saleArtworksAllLoader: gravityLoader(
       "sale_artworks",
@@ -83,6 +96,9 @@ export default (accessToken, userID, requestIDs) => {
       "me/suggested/artists",
       {},
       { headers: true }
+    ),
+    suggestedSimilarArtistsLoader: gravityLoader(
+      `user/${userID}/suggested/similar/artists`
     ),
     updateCollectorProfileLoader: gravityLoader(
       "me/collector_profile",

--- a/src/lib/loaders/loaders_without_authentication/gravity.js
+++ b/src/lib/loaders/loaders_without_authentication/gravity.js
@@ -21,7 +21,7 @@ export default requestIDs => {
     filterArtworksLoader: gravityLoader("filter/artworks"),
     geneArtistsLoader: gravityLoader(id => `gene/${id}/artists`),
     geneFamiliesLoader: gravityLoader("gene_families"),
-    geneLoader: gravityLoader(id => `/gene/${id}`),
+    geneLoader: gravityLoader(id => `gene/${id}`),
     heroUnitsLoader: gravityLoader("site_hero_units"),
     incrementsLoader: gravityLoader("increments"),
     matchGeneLoader: gravityLoader("match/genes"),

--- a/src/schema/home/__tests__/home_page_artist_module.test.js
+++ b/src/schema/home/__tests__/home_page_artist_module.test.js
@@ -1,12 +1,8 @@
 import { graphql } from "graphql"
-
 import schema from "schema"
-import { runQuery, runAuthenticatedQuery } from "test/utils"
+import { runAuthenticatedQuery } from "test/utils"
 
 describe("HomePageArtistModule", () => {
-  const HomePage = schema.__get__("HomePage")
-  const HomePageArtistModule = HomePage.__get__("HomePageArtistModule")
-
   const query = key => {
     return `
       {
@@ -21,75 +17,80 @@ describe("HomePageArtistModule", () => {
     `
   }
 
-  beforeEach(() => {
-    const gravity = sinon.stub()
-    gravity.with = sinon.stub().returns(gravity)
+  const trendingArtistData = [
+    {
+      id: "trending",
+      birthday: null,
+      artworks_count: null,
+    },
+  ]
 
-    gravity.withArgs("artists/trending").returns(
-      Promise.resolve([
-        {
-          id: "trending",
-          birthday: null,
-          artworks_count: null,
-        },
-      ])
-    )
+  const popularArtistData = [
+    {
+      id: "popular",
+      birthday: null,
+      artworks_count: null,
+    },
+  ]
 
-    gravity.withArgs("artists/popular").returns(
-      Promise.resolve([
-        {
-          id: "popular",
-          birthday: null,
-          artworks_count: null,
-        },
-      ])
-    )
+  const similarArtistData = [
+    {
+      artist: {
+        id: "suggested",
+        birthday: null,
+        artworks_count: null,
+      },
+    },
+  ]
 
-    gravity.withArgs("user/user-42/suggested/similar/artists").returns(
-      Promise.resolve([
-        {
-          artist: {
-            id: "suggested",
-            birthday: null,
-            artworks_count: null,
-          },
-        },
-      ])
-    )
-
-    HomePageArtistModule.__Rewire__("gravity", gravity)
-  })
-
-  afterEach(() => {
-    HomePageArtistModule.__ResetDependency__("gravity")
-  })
-
-  const shared = queryRunner => {
-    it("returns trending artists", () => {
-      return queryRunner(query("TRENDING")).then(({ home_page }) => {
-        expect(home_page.artist_module.results).toEqual([{ id: "trending" }])
-      })
-    })
-
-    it("returns popular artists", () => {
-      return queryRunner(query("POPULAR")).then(({ home_page }) => {
-        expect(home_page.artist_module.results).toEqual([{ id: "popular" }])
-      })
-    })
+  const rootValue = {
+    trendingArtistsLoader: () => Promise.resolve(trendingArtistData),
+    popularArtistsLoader: () => Promise.resolve(popularArtistData),
+    suggestedSimilarArtistsLoader: () => Promise.resolve(similarArtistData),
   }
 
   describe("when signed-in", () => {
-    shared(runAuthenticatedQuery)
+    it("returns trending artists", () => {
+      return runAuthenticatedQuery(query("TRENDING"), rootValue).then(
+        ({ home_page }) => {
+          expect(home_page.artist_module.results).toEqual([{ id: "trending" }])
+        }
+      )
+    })
+
+    it("returns trending artists", () => {
+      return runAuthenticatedQuery(query("TRENDING"), rootValue).then(
+        ({ home_page }) => {
+          expect(home_page.artist_module.results).toEqual([{ id: "trending" }])
+        }
+      )
+    })
 
     it("returns suggestions", () => {
-      return runAuthenticatedQuery(query("SUGGESTED")).then(({ home_page }) => {
-        expect(home_page.artist_module.results).toEqual([{ id: "suggested" }])
-      })
+      return runAuthenticatedQuery(query("SUGGESTED"), rootValue).then(
+        ({ home_page }) => {
+          expect(home_page.artist_module.results).toEqual([{ id: "suggested" }])
+        }
+      )
     })
   })
 
   describe("when signed-out", () => {
-    shared(runQuery)
+    it("returns trending artists", () => {
+      return runAuthenticatedQuery(query("TRENDING"), rootValue).then(
+        ({ home_page }) => {
+          expect(home_page.artist_module.results).toEqual([{ id: "trending" }])
+        }
+      )
+    })
+
+    it("returns trending artists", () => {
+      return runAuthenticatedQuery(query("TRENDING"), rootValue).then(
+        ({ home_page }) => {
+          expect(home_page.artist_module.results).toEqual([{ id: "trending" }])
+        }
+      )
+    })
 
     it("does not return any suggestions", () => {
       return graphql(schema, query("SUGGESTED")).then(response => {

--- a/src/schema/home/__tests__/home_page_artwork_module.test.js
+++ b/src/schema/home/__tests__/home_page_artwork_module.test.js
@@ -1,4 +1,3 @@
-import schema from "schema"
 import { runQuery } from "test/utils"
 import gql from "test/gql"
 
@@ -65,20 +64,6 @@ describe("HomePageArtworkModule", () => {
   })
 
   describe("when signed out", () => {
-    const HomePage = schema.__get__("HomePage")
-    const HomePageArtworkModule = HomePage.__get__("HomePageArtworkModule")
-
-    beforeEach(() => {
-      const gravity = sinon.stub()
-      gravity.with = sinon.stub().returns(gravity)
-
-      HomePageArtworkModule.__Rewire__("gravity", gravity)
-    })
-
-    afterEach(() => {
-      HomePageArtworkModule.__ResetDependency__("gravity")
-    })
-
     it("returns the proper title for popular_artists", () => {
       const query = gql`
         {

--- a/src/schema/home/__tests__/home_page_artwork_modules.test.js
+++ b/src/schema/home/__tests__/home_page_artwork_modules.test.js
@@ -1,16 +1,12 @@
 import { map, find } from "lodash"
-
-import schema from "schema"
 import { runAuthenticatedQuery } from "test/utils"
 
 describe("HomePageArtworkModules", () => {
-  const HomePage = schema.__get__("HomePage")
-  const HomePageArtworkModules = HomePage.__get__("HomePageArtworkModules")
+  let rootValue = null
 
   let gravity
   let modules
   let relatedArtistsResponse
-  let relatedArtists
 
   beforeEach(() => {
     modules = {
@@ -27,31 +23,24 @@ describe("HomePageArtworkModules", () => {
 
     relatedArtistsResponse = [
       {
-        sim_artist: { id: "pablo-picasso" },
+        sim_artist: { id: "pablo-picasso", forsale_artworks_count: 1 },
         artist: { id: "charles-broskoski" },
       },
       {
-        sim_artist: { id: "ann-craven" },
+        sim_artist: { id: "ann-craven", forsale_artworks_count: 1 },
         artist: { id: "margaret-lee" },
       },
     ]
 
     gravity = sinon.stub()
     gravity.with = sinon.stub().returns(gravity)
-    relatedArtists = sinon.stub()
 
-    HomePageArtworkModules.__Rewire__("gravity", gravity)
-    HomePageArtworkModules.__Rewire__("relatedArtists", relatedArtists)
-
-    gravity
-      // Modules fetch
-      .onCall(0)
-      .returns(Promise.resolve(modules))
-    relatedArtists.onCall(0).returns(Promise.resolve(relatedArtistsResponse))
-  })
-
-  afterEach(() => {
-    HomePageArtworkModules.__ResetDependency__("gravity")
+    rootValue = {
+      homepageModulesLoader: () => Promise.resolve(modules),
+      suggestedSimilarArtistsLoader: () =>
+        Promise.resolve(relatedArtistsResponse),
+      followedGenesLoader: () => Promise.resolve({ body: [] }),
+    }
   })
 
   it("shows all modules that should be returned", () => {
@@ -69,7 +58,7 @@ describe("HomePageArtworkModules", () => {
       }
     `
 
-    return runAuthenticatedQuery(query).then(({ home_page }) => {
+    return runAuthenticatedQuery(query, rootValue).then(({ home_page }) => {
       const keys = map(home_page.artwork_modules, "key")
 
       // the default module response is 8 keys
@@ -88,22 +77,24 @@ describe("HomePageArtworkModules", () => {
       const relatedArtistsModule = find(home_page.artwork_modules, {
         key: "related_artists",
       })
-      expect(relatedArtistsModule.params).toEqual({
-        related_artist_id: "charles-broskoski",
-        followed_artist_id: "pablo-picasso",
-      })
+
+      const relatedArtistId = relatedArtistsModule.params.related_artist_id
+      expect(["charles-broskoski", "margaret-lee"]).toContain(relatedArtistId)
+
+      const followedArtistId = relatedArtistsModule.params.followed_artist_id
+      expect(["pablo-picasso", "ann-craven"]).toContain(followedArtistId)
     })
   })
 
   it("shows skips the followed_artist module if no 2nd pair is returned", () => {
     relatedArtistsResponse = [
       {
-        sim_artist: { id: "pablo-picasso" },
+        sim_artist: { id: "pablo-picasso", forsale_artworks_count: 1 },
         artist: { id: "charles-broskoski" },
       },
     ]
-
-    relatedArtists.onCall(0).returns(Promise.resolve(relatedArtistsResponse))
+    rootValue.suggestedSimilarArtistsLoader = () =>
+      Promise.resolve(relatedArtistsResponse)
 
     const query = `
       {
@@ -119,7 +110,7 @@ describe("HomePageArtworkModules", () => {
       }
     `
 
-    return runAuthenticatedQuery(query).then(({ home_page }) => {
+    return runAuthenticatedQuery(query, rootValue).then(({ home_page }) => {
       const keys = map(home_page.artwork_modules, "key")
 
       // the default module response is 8 keys
@@ -145,8 +136,7 @@ describe("HomePageArtworkModules", () => {
   })
 
   it("skips the followed_artist module if the pairs are empty", () => {
-    relatedArtists.onCall(0).returns(Promise.resolve([]))
-
+    rootValue.suggestedSimilarArtistsLoader = () => Promise.resolve([])
     const query = `
       {
         home_page {
@@ -161,7 +151,7 @@ describe("HomePageArtworkModules", () => {
       }
     `
 
-    return runAuthenticatedQuery(query).then(({ home_page }) => {
+    return runAuthenticatedQuery(query, rootValue).then(({ home_page }) => {
       const keys = map(home_page.artwork_modules, "key")
       expect(keys).toEqual([
         "followed_galleries",
@@ -186,7 +176,7 @@ describe("HomePageArtworkModules", () => {
       }
     `
 
-    return runAuthenticatedQuery(query).then(
+    return runAuthenticatedQuery(query, rootValue).then(
       ({ home_page: { artwork_modules } }) => {
         // The order of rails not included in the preferred order list is left as-is from Gravity’s
         // modules endpoint response. Rails in the preferred order list that aren’t even included in
@@ -217,7 +207,7 @@ describe("HomePageArtworkModules", () => {
       }
     `
 
-    return runAuthenticatedQuery(query).then(({ home_page }) => {
+    return runAuthenticatedQuery(query, rootValue).then(({ home_page }) => {
       const keys = map(home_page.artwork_modules, "key")
       expect(keys).not.toContain("recommended_works")
     })

--- a/src/schema/home/fetch.js
+++ b/src/schema/home/fetch.js
@@ -12,7 +12,7 @@ import {
 import blacklist from "lib/artist_blacklist"
 
 export const featuredFair = fairsLoader => {
-  fairsLoader({
+  return fairsLoader({
     size: 5,
     active: true,
     has_homepage_section: true,

--- a/src/schema/home/home_page_artist_module.js
+++ b/src/schema/home/home_page_artist_module.js
@@ -18,6 +18,7 @@ export const HomePageArtistModuleTypes = {
   SUGGESTED: {
     description: "Artists recommended for the specific user.",
     display: ({ rootValue: { suggestedSimilarArtistsLoader } }) => {
+      if (!suggestedSimilarArtistsLoader) return Promise.resolve(false)
       return totalViaLoader(
         suggestedSimilarArtistsLoader,
         {},
@@ -25,9 +26,14 @@ export const HomePageArtistModuleTypes = {
           exclude_followed_artists: true,
           exclude_artists_without_forsale_artworks: true,
         }
-      ).then(response => response.body.total > 0)
+      ).then(total => total > 0)
     },
     resolve: ({ rootValue: { suggestedSimilarArtistsLoader } }) => {
+      if (!suggestedSimilarArtistsLoader) {
+        throw new Error(
+          "Both the X-USER-ID and X-ACCESS-TOKEN headers are required."
+        )
+      }
       return suggestedSimilarArtistsLoader({
         exclude_followed_artists: true,
         exclude_artists_without_forsale_artworks: true,

--- a/src/schema/home/home_page_artist_module.js
+++ b/src/schema/home/home_page_artist_module.js
@@ -1,7 +1,5 @@
 import { map } from "lodash"
 import Artist from "schema/artist"
-import gravity from "lib/loaders/legacy/gravity"
-import { total } from "lib/loaders/legacy/total"
 import { NodeInterface } from "schema/object_identification"
 import { toGlobalId } from "graphql-relay"
 import {
@@ -12,51 +10,41 @@ import {
   GraphQLObjectType,
   GraphQLString,
 } from "graphql"
-
-function fetchArtists(path) {
-  return accessToken => {
-    const loader = accessToken ? gravity.with(accessToken) : gravity
-    return loader(path, accessToken && { exclude_followed_artists: true })
-  }
-}
+import { totalViaLoader } from "../../lib/loaders/legacy/total"
 
 // This object is used for both the `key` argument enum and to do fetching.
 // The order of the artists should be 1. suggested, 2. trending, 3. popular
 export const HomePageArtistModuleTypes = {
   SUGGESTED: {
     description: "Artists recommended for the specific user.",
-    display: (accessToken, userID) => {
-      if (!accessToken || !userID) {
-        return Promise.resolve(false)
-      }
-      return total(`user/${userID}/suggested/similar/artists`, accessToken, {
-        exclude_followed_artists: true,
-        exclude_artists_without_forsale_artworks: true,
-      }).then(response => response.body.total > 0)
-    },
-    resolve: (accessToken, userID) => {
-      if (!accessToken || !userID) {
-        throw new Error(
-          "Both the X-USER-ID and X-ACCESS-TOKEN headers are required."
-        )
-      }
-      return gravity
-        .with(accessToken)(`user/${userID}/suggested/similar/artists`, {
+    display: ({ rootValue: { suggestedSimilarArtistsLoader } }) => {
+      return totalViaLoader(
+        suggestedSimilarArtistsLoader,
+        {},
+        {
           exclude_followed_artists: true,
           exclude_artists_without_forsale_artworks: true,
-        })
-        .then(results => map(results, "artist"))
+        }
+      ).then(response => response.body.total > 0)
+    },
+    resolve: ({ rootValue: { suggestedSimilarArtistsLoader } }) => {
+      return suggestedSimilarArtistsLoader({
+        exclude_followed_artists: true,
+        exclude_artists_without_forsale_artworks: true,
+      }).then(results => map(results, "artist"))
     },
   },
   TRENDING: {
     description: "The trending artists.",
     display: () => Promise.resolve(true),
-    resolve: fetchArtists("artists/trending"),
+    resolve: ({ rootValue: { trendingArtistsLoader } }) =>
+      trendingArtistsLoader(),
   },
   POPULAR: {
     description: "The most searched for artists.",
     display: () => Promise.resolve(true),
-    resolve: fetchArtists("artists/popular"),
+    resolve: ({ rootValue: { popularArtistsLoader } }) =>
+      popularArtistsLoader(),
   },
 }
 
@@ -77,13 +65,8 @@ export const HomePageArtistModuleType = new GraphQLObjectType({
     },
     results: {
       type: new GraphQLList(Artist.type),
-      resolve: (
-        { key },
-        options,
-        request,
-        { rootValue: { accessToken, userID } }
-      ) => {
-        return HomePageArtistModuleTypes[key].resolve(accessToken, userID)
+      resolve: ({ key }, options, request, { rootValue }) => {
+        return HomePageArtistModuleTypes[key].resolve({ rootValue })
       },
     },
   },

--- a/src/schema/home/home_page_artist_modules.js
+++ b/src/schema/home/home_page_artist_modules.js
@@ -8,11 +8,11 @@ import { GraphQLList } from "graphql"
 const HomePageArtistModules = {
   type: new GraphQLList(HomePageArtistModuleType),
   description: "Artist modules to show on the home screen",
-  resolve: (root, params, request, { rootValue: { accessToken, userID } }) => {
+  resolve: (root, params, request, { rootValue }) => {
     // First check each type if they can display…
     return Promise.all(
       map(HomePageArtistModuleTypes, ({ display }, key) => {
-        return display(accessToken, userID).then(displayable => ({
+        return display({ rootValue }).then(displayable => ({
           key,
           displayable,
         }))

--- a/src/schema/home/results.js
+++ b/src/schema/home/results.js
@@ -18,7 +18,7 @@ const moduleResults = {
   current_fairs: ({ rootValue: { fairsLoader, filterArtworksLoader } }) => {
     return featuredFair(fairsLoader).then(fair => {
       if (fair) {
-        filterArtworksLoader({
+        return filterArtworksLoader({
           fair_id: fair.id,
           for_sale: true,
           size: 60,

--- a/src/schema/home/results.js
+++ b/src/schema/home/results.js
@@ -1,5 +1,3 @@
-import gravity from "lib/loaders/legacy/gravity"
-import uncachedGravity from "lib/apis/gravity"
 import {
   activeSaleArtworks,
   featuredAuction,
@@ -9,18 +7,18 @@ import {
   popularArtists,
 } from "./fetch"
 import { map, assign, keys, without, shuffle, slice } from "lodash"
-import { toQueryString } from "lib/helpers"
 import Artwork from "schema/artwork/index"
 import { GraphQLList } from "graphql"
 
 const RESULTS_SIZE = 20
 
 const moduleResults = {
-  active_bids: ({ accessToken }) => activeSaleArtworks(accessToken),
-  current_fairs: () => {
-    return featuredFair().then(fair => {
+  active_bids: ({ rootValue: { lotStandingLoader } }) =>
+    activeSaleArtworks(lotStandingLoader),
+  current_fairs: ({ rootValue: { fairsLoader, filterArtworksLoader } }) => {
+    return featuredFair(fairsLoader).then(fair => {
       if (fair) {
-        return gravity("filter/artworks", {
+        filterArtworksLoader({
           fair_id: fair.id,
           for_sale: true,
           size: 60,
@@ -30,88 +28,83 @@ const moduleResults = {
       }
     })
   },
-  followed_artist: ({ params }) => {
-    return gravity("filter/artworks", {
+  followed_artist: ({ rootValue: { filterArtworksLoader }, params }) => {
+    return filterArtworksLoader({
       artist_id: params.followed_artist_id,
       for_sale: true,
       size: RESULTS_SIZE,
     }).then(({ hits }) => hits)
   },
-  followed_artists: ({ accessToken }) => {
-    return gravity.with(accessToken)("me/follow/artists/artworks", {
+  followed_artists: ({ rootValue: { followedArtistsArtworksLoader } }) => {
+    return followedArtistsArtworksLoader({
       for_sale: true,
       size: RESULTS_SIZE,
+    }).then(({ body }) => body)
+  },
+  followed_galleries: ({ rootValue: { followedProfilesArtworksLoader } }) => {
+    return followedProfilesArtworksLoader({
+      for_sale: true,
+      size: 60,
+    }).then(({ body }) => {
+      return slice(shuffle(body), 0, RESULTS_SIZE)
     })
   },
-  followed_galleries: ({ accessToken }) => {
-    return gravity
-      .with(accessToken)("me/follow/profiles/artworks", {
-        for_sale: true,
-        size: 60,
-      })
-      .then(artworks => {
-        return slice(shuffle(artworks), 0, RESULTS_SIZE)
-      })
-  },
-  genes: ({ accessToken, params: { id } }) => {
+  genes: ({
+    rootValue: { filterArtworksLoader, followedGenesLoader },
+    params: { id },
+  }) => {
     if (id) {
-      return geneArtworks(id, RESULTS_SIZE)
+      return geneArtworks(filterArtworksLoader, id, RESULTS_SIZE)
     }
     // Backward compatibility for Force.
-    return featuredGene(accessToken).then(gene => {
+    return featuredGene(followedGenesLoader).then(gene => {
       if (gene) {
-        return geneArtworks(gene.id, RESULTS_SIZE)
+        return geneArtworks(filterArtworksLoader, gene.id, RESULTS_SIZE)
       }
     })
   },
-  generic_gene: ({ params }) => {
-    return gravity(
-      "filter/artworks",
+  generic_gene: ({ rootValue: { filterArtworksLoader }, params }) => {
+    return filterArtworksLoader(
       assign({}, params, { size: RESULTS_SIZE, for_sale: true })
     ).then(({ hits }) => hits)
   },
-  live_auctions: () => {
-    return featuredAuction().then(auction => {
+  live_auctions: ({ rootValue: { salesLoader, saleArtworksLoader } }) => {
+    return featuredAuction(salesLoader).then(auction => {
       if (auction) {
-        return gravity(`sale/${auction.id}/sale_artworks`, {
+        return saleArtworksLoader(auction.id, {
           size: RESULTS_SIZE,
-        }).then(sale_artworks => {
-          return map(sale_artworks, "artwork")
+        }).then(({ body }) => {
+          return map(body, "artwork")
         })
       }
     })
   },
-  popular_artists: () => {
+  popular_artists: ({ rootValue: { filterArtworksLoader, deltaLoader } }) => {
     // TODO This appears to largely replicate Gravity’s /api/v1/artists/popular endpoint
-    return popularArtists().then(artists => {
+    return popularArtists(deltaLoader).then(artists => {
       const ids = without(keys(artists), "cached", "context_type")
-      return uncachedGravity(
-        "filter/artworks?" +
-          toQueryString({
-            artist_ids: ids,
-            size: RESULTS_SIZE,
-            sort: "-partner_updated_at",
-          })
-      ).then(({ body: { hits } }) => hits)
+      return filterArtworksLoader({
+        artist_ids: ids,
+        size: RESULTS_SIZE,
+        sort: "-partner_updated_at",
+      }).then(({ hits }) => hits)
     })
   },
-  recommended_works: ({ accessToken }) => {
-    return gravity.with(accessToken)("me/suggested/artworks/homepage", {
+  recommended_works: ({ rootValue: { homepageSuggestedArtworksLoader } }) => {
+    return homepageSuggestedArtworksLoader({
       limit: RESULTS_SIZE,
     })
   },
-  related_artists: ({ params }) => {
-    return gravity("filter/artworks", {
+  related_artists: ({ rootValue: { filterArtworksLoader }, params }) => {
+    return filterArtworksLoader({
       artist_id: params.related_artist_id,
       for_sale: true,
       size: RESULTS_SIZE,
     }).then(({ hits }) => hits)
   },
-  saved_works: ({ accessToken, userID }) => {
-    return gravity.with(accessToken)("collection/saved-artwork/artworks", {
+  saved_works: ({ rootValue: { savedArtworksLoader } }) => {
+    return savedArtworksLoader({
       size: RESULTS_SIZE,
-      user_id: userID,
-      private: true,
       sort: "-position",
     })
   },
@@ -119,14 +112,9 @@ const moduleResults = {
 
 export default {
   type: new GraphQLList(Artwork.type),
-  resolve: (
-    { key, display, params },
-    options,
-    request,
-    { rootValue: { accessToken, userID } }
-  ) => {
+  resolve: ({ key, display, params }, options, request, { rootValue }) => {
     if (display) {
-      return moduleResults[key]({ accessToken, userID, params: params || {} })
+      return moduleResults[key]({ rootValue, params: params || {} })
     }
   },
 }


### PR DESCRIPTION
Making some more progress! 

This refactors home page related code to use new data loaders. The main idea of the refactor, is that there were lots of helpers/methods that were getting `userID` and `accessToken` plucked out of `rootValue` and explicitly passed around, and fetching data. Now, similarly to `totalViaLoader` and `allViaLoader`, these helper methods now accept an actual data loader, as opposed to tokens/ids.

Then, the places that were calling the various helper methods were updated to pass the loaders in.

Force homepage looks fine pointing to staging/prod, both logged in and logged out. I checked the various types of homepage rails/contexts and all matched what's currently deployed.

Figured I'd open the PR early.