### PR TITLE
@mzikherman => Make sure to return related artist statuses

### DIFF
--- a/src/schema/artist/__tests__/statuses.test.js
+++ b/src/schema/artist/__tests__/statuses.test.js
@@ -17,6 +17,8 @@ describe("Artist Statuses", () => {
 
     rootValue = {
       artistLoader: sinon.stub().returns(Promise.resolve(artist)),
+      relatedMainArtistsLoader: () =>
+        Promise.resolve({ headers: { "x-total-count": 3 } }),
     }
   })
 
@@ -25,6 +27,7 @@ describe("Artist Statuses", () => {
       {
         artist(id: "foo-bar") {
           statuses {
+            artists
             artworks
             shows
             cv
@@ -37,6 +40,7 @@ describe("Artist Statuses", () => {
       expect(data).toEqual({
         artist: {
           statuses: {
+            artists: true,
             artworks: true,
             shows: false,
             cv: true,

--- a/src/schema/artist/statuses.js
+++ b/src/schema/artist/statuses.js
@@ -11,13 +11,12 @@ const ArtistStatusesType = new GraphQLObjectType({
         options,
         request,
         { rootValue: { relatedMainArtistsLoader } }
-      ) => {
+      ) =>
         totalViaLoader(
           relatedMainArtistsLoader,
           {},
           { exclude_artists_without_artworks: true, artist: [id] }
-        ).then(count => count > 0)
-      },
+        ).then(count => count > 0),
     },
     articles: {
       type: GraphQLBoolean,


### PR DESCRIPTION
Forgot to return from the promise. This bug was spotted just minutes after being introduced in production (no 'Related Artists' tab on artist pages).