### PR TITLE
@l2succes => Fix for overfetching related artist and article counts

### DIFF
--- a/src/schema/artist/index.js
+++ b/src/schema/artist/index.js
@@ -428,45 +428,41 @@ export const ArtistType = new GraphQLObjectType({
             partner_shows: numeral(
               ({ partner_shows_count }) => partner_shows_count
             ),
-            related_artists: numeral(({ related_artists }) => related_artists),
-            articles: numeral(({ articles }) => articles),
+            related_artists: {
+              type: GraphQLInt,
+              resolve: (
+                { id },
+                _options,
+                _request,
+                { rootValue: { relatedMainArtistsLoader } }
+              ) => {
+                return totalViaLoader(
+                  relatedMainArtistsLoader,
+                  {},
+                  {
+                    artist: [id],
+                  }
+                )
+              },
+            },
+            articles: {
+              type: GraphQLInt,
+              resolve: (
+                { _id },
+                _options,
+                _request,
+                { rootValue: { articlesLoader } }
+              ) =>
+                articlesLoader({
+                  artist_id: _id,
+                  published: true,
+                  limit: 0,
+                  count: true,
+                }).then(({ count }) => count),
+            },
           },
         }),
-        resolve: (
-          {
-            published_artworks_count,
-            forsale_artworks_count,
-            partner_shows_count,
-            follow_count,
-            id,
-            _id,
-          },
-          _options,
-          _request,
-          { rootValue: { articlesLoader, relatedMainArtistsLoader } }
-        ) => {
-          const related_artists = totalViaLoader(
-            relatedMainArtistsLoader,
-            {},
-            {
-              artist: [id],
-            }
-          )
-          const articles = articlesLoader({
-            artist_id: _id,
-            published: true,
-            limit: 1,
-            count: true,
-          }).then(({ count }) => count)
-          return {
-            published_artworks_count,
-            forsale_artworks_count,
-            follow_count,
-            partner_shows_count,
-            related_artists,
-            articles,
-          }
-        },
+        resolve: artist => artist,
       },
       deathday: {
         type: GraphQLString,


### PR DESCRIPTION
I inadvertently changed the 'level' that a resolver was fetching counts for articles and related artists, so any query to `counts { ... }` would fetch those, even if you _werent_ requesting article counts (for example).

This update moves that back up, but in the process, I discovered that https://github.com/artsy/metaphysics/blob/master/src/schema/fields/numeral.js is very inflexible in that you can't pass in your own resolver. So this just simplifies those and drops that custom field support entirely for these fields.

I checked in Force/Eigen/Emission and we were just using them as numbers anyway, and not _formatted numbers_ (ie- we weren't ever calling `counts { articles(label: .., format: ...) }` which would no longer work. `counts { articles }` remains a number.