### PR TITLE
@alloy => Dont send 401/403, and 404 to Sentry

### DIFF
--- a/src/lib/graphqlErrorHandler.js
+++ b/src/lib/graphqlErrorHandler.js
@@ -1,27 +1,36 @@
 import raven from "raven"
 import { assign } from "lodash"
 
+const shouldLogError = originalError => {
+  if (originalError && originalError.statusCode) {
+    return originalError.statusCode !== 404
+  }
+  return true
+}
+
 export default function graphqlErrorHandler(
   req,
   { isProduction, enableSentry }
 ) {
   return error => {
     if (enableSentry) {
-      raven.captureException(
-        error,
-        assign(
-          {},
-          {
-            tags: { graphql: "exec_error" },
-            extra: {
-              source: error.source && error.source.body,
-              positions: error.positions,
-              path: error.path,
+      if (shouldLogError(error.originalError)) {
+        raven.captureException(
+          error,
+          assign(
+            {},
+            {
+              tags: { graphql: "exec_error" },
+              extra: {
+                source: error.source && error.source.body,
+                positions: error.positions,
+                path: error.path,
+              },
             },
-          },
-          raven.parsers.parseRequest(req)
+            raven.parsers.parseRequest(req)
+          )
         )
-      )
+      }
     }
     return {
       message: error.message,

--- a/src/lib/graphqlErrorHandler.js
+++ b/src/lib/graphqlErrorHandler.js
@@ -1,9 +1,10 @@
 import raven from "raven"
 import { assign } from "lodash"
 
+const blacklistHttpStatuses = [401, 403, 404]
 const shouldLogError = originalError => {
   if (originalError && originalError.statusCode) {
-    return originalError.statusCode !== 404
+    return !blacklistHttpStatuses.includes(originalError.statusCode)
   }
   return true
 }


### PR DESCRIPTION
If we determine that the error is a 404, don't send to Sentry. Seems to work locally for things like `artist(id: "andy-waarhol")`.