### PR TITLE
 [graphqlErrorHandler] Add tests and don’t report server errors.

### DIFF
--- a/src/lib/__tests__/graphqlErrorHandler.test.js
+++ b/src/lib/__tests__/graphqlErrorHandler.test.js
@@ -1,0 +1,25 @@
+import { shouldLogError } from "../graphqlErrorHandler"
+
+describe("graphqlErrorHandler", () => {
+  it("reports non-HTTP errors", () => {
+    expect(shouldLogError({ statusCode: undefined })).toBeTruthy()
+  })
+
+  it("reports HTTP client errors that are not blacklisted", () => {
+    ;[400, 418].forEach(statusCode => {
+      expect(shouldLogError({ statusCode })).toBeTruthy()
+    })
+  })
+
+  it("does not report blacklisted HTTP client errors", () => {
+    ;[401, 403, 404].forEach(statusCode => {
+      expect(shouldLogError({ statusCode })).toBeFalsy()
+    })
+  })
+
+  it("does not report HTTP server errors", () => {
+    ;[500, 511].forEach(statusCode => {
+      expect(shouldLogError({ statusCode })).toBeFalsy()
+    })
+  })
+})

--- a/src/lib/graphqlErrorHandler.js
+++ b/src/lib/graphqlErrorHandler.js
@@ -2,9 +2,13 @@ import raven from "raven"
 import { assign } from "lodash"
 
 const blacklistHttpStatuses = [401, 403, 404]
-const shouldLogError = originalError => {
+
+export const shouldLogError = originalError => {
   if (originalError && originalError.statusCode) {
-    return !blacklistHttpStatuses.includes(originalError.statusCode)
+    return (
+      originalError.statusCode < 500 &&
+      !blacklistHttpStatuses.includes(originalError.statusCode)
+    )
   }
   return true
 }


### PR DESCRIPTION
I initially wanted to blacklist 504 errors, but realised that Gravity actually only returns 500s for timeouts of proxied requests. After giving it some more thought, I realised that it’s not MP’s responsibility at all to report server errors, only client errors (except for the blacklisted ones of course).