### PR TITLE
Update is_from_user to use from_principal if available

### DIFF
--- a/src/schema/me/__tests__/conversation/__snapshots__/conversation.test.js.snap
+++ b/src/schema/me/__tests__/conversation/__snapshots__/conversation.test.js.snap
@@ -66,7 +66,7 @@ Object {
               "state": "UNPAID",
               "total": "$4,200",
             },
-            "is_from_user": false,
+            "is_from_user": true,
             "is_invoice": true,
           },
         },

--- a/src/schema/me/__tests__/conversation/__snapshots__/message.test.js.snap
+++ b/src/schema/me/__tests__/conversation/__snapshots__/message.test.js.snap
@@ -13,6 +13,33 @@ Object {
 }
 `;
 
+exports[`Me Conversation Message returns proper is_from_user 1`] = `
+Object {
+  "conversation": Object {
+    "from": Object {
+      "email": "collector@example.com",
+    },
+    "id": "420",
+    "initial_message": "Loved some of the works at your fair booth!",
+    "messages": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "body": "I'm a cat oh yea!",
+            "from": Object {
+              "email": "fancy_german_person@posteo.de",
+              "name": "Percy Z",
+            },
+            "id": "222",
+            "is_from_user": true,
+          },
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`Me Conversation Message returns sanitized messages 1`] = `
 Object {
   "conversation": Object {

--- a/src/schema/me/__tests__/conversation/conversation.test.js
+++ b/src/schema/me/__tests__/conversation/conversation.test.js
@@ -57,6 +57,7 @@ describe("Me", () => {
               lewitt_invoice_id: "420i",
             },
             from: `"Percy Z" <percy@cat.com>`,
+            from_principal: true,
             body: "I'm a cat",
           },
           {
@@ -67,6 +68,7 @@ describe("Me", () => {
             attachments: [],
             metadata: {},
             from: `"Bitty Z" <Bitty@cat.com>`,
+            from_principal: false,
             body: "",
           },
           {
@@ -87,6 +89,7 @@ describe("Me", () => {
             attachments: [],
             metadata: {},
             from: "<email@email.com>",
+            from_principal: null,
             deliveries: [
               {
                 opened_at: "2020-12-31T12:00:00+00:00",
@@ -264,6 +267,7 @@ describe("Me", () => {
                   edges {
                     node {
                       id
+                      is_from_user
                     }
                   }
                 }
@@ -291,6 +295,19 @@ describe("Me", () => {
           ({ me: { conversation: { messages } } }) => {
             expect(messages.edges.length).toEqual(4)
             expect(messages.edges[0].node.id).toEqual("243")
+          }
+        )
+      })
+      it("returns proper is_from_user for different values of `from_principal`", () => {
+        const query = getQuery()
+
+        return runAuthenticatedQuery(query, rootValue).then(
+          ({ me: { conversation: { messages } } }) => {
+            expect(messages.edges.length).toEqual(4)
+            expect(messages.edges[0].node.is_from_user).toEqual(true)
+            expect(messages.edges[1].node.is_from_user).toEqual(false)
+            expect(messages.edges[2].node.is_from_user).toEqual(true)
+            expect(messages.edges[3].node.is_from_user).toEqual(false)
           }
         )
       })

--- a/src/schema/me/__tests__/conversation/message.test.js
+++ b/src/schema/me/__tests__/conversation/message.test.js
@@ -24,6 +24,7 @@ describe("Me", () => {
                   lewitt_invoice_id: "420i",
                 },
                 from: `"Percy Z" <percy@cat.com>`,
+                from_principal: true,
                 original_text: "I'm a cat oh yea!",
                 body: "I'm a cat",
               },
@@ -103,6 +104,41 @@ describe("Me", () => {
 
         return runAuthenticatedQuery(query, customRootValue).then(
           ({ me: { conversation } }) => {
+            expect(conversation).toMatchSnapshot()
+          }
+        )
+      })
+
+      it("returns proper is_from_user", () => {
+        const query = `
+          {
+            me {
+              conversation(id: "420") {
+                id
+                initial_message
+                from {
+                  email
+                }
+                messages(first: 10) {
+                  edges {
+                    node {
+                      body
+                      id
+                      is_from_user
+                      from {
+                        email
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        `
+
+        return runAuthenticatedQuery(query, rootValue).then(
+          ({ me: conversation }) => {
             expect(conversation).toMatchSnapshot()
           }
         )

--- a/src/schema/me/conversation/index.js
+++ b/src/schema/me/conversation/index.js
@@ -137,7 +137,8 @@ export const {
 
 const isLastMessageToUser = ({ _embedded, from_email }) => {
   const lastMessageFromEmail = get(_embedded, "last_message.from_email_address")
-  return from_email !== lastMessageFromEmail
+  const lastMessagePrincipal = get(_embedded, "last_message.from_principal")
+  return lastMessagePrincipal === false || from_email !== lastMessageFromEmail
 }
 
 const lastMessageId = conversation => {

--- a/src/schema/me/conversation/message.js
+++ b/src/schema/me/conversation/message.js
@@ -51,11 +51,17 @@ export const MessageType = new GraphQLObjectType({
       description: "True if message is from the user to the partner.",
       type: GraphQLBoolean,
       resolve: (
-        { from_id, from_email_address, conversation_from_address },
+        {
+          from_id,
+          from_email_address,
+          conversation_from_address,
+          from_principal,
+        },
         options,
         req,
         { rootValue: { userID } }
       ) =>
+        from_principal ||
         (userID && from_id === userID) ||
         from_email_address === conversation_from_address,
     },


### PR DESCRIPTION
# Change
Impulse [now](https://github.com/artsy/impulse/pull/441) offers `from_principal` as one of the fields in `Message` json. We can use that here to detect `is_from_user` and `last_message_from_user` easier.