### PR TITLE
@sweir27 => Use float instead of int for some legacy _cents fields

### DIFF
--- a/src/schema/sale_artwork.js
+++ b/src/schema/sale_artwork.js
@@ -128,7 +128,7 @@ const SaleArtworkType = new GraphQLObjectType({
         }),
       }),
       high_estimate_cents: {
-        type: GraphQLInt,
+        type: GraphQLFloat,
         deprecationReason: "Favor `high_estimate",
       },
       highest_bid: {
@@ -153,7 +153,7 @@ const SaleArtworkType = new GraphQLObjectType({
               resolve: ({ display_amount_dollars }) => display_amount_dollars,
             },
             amount_cents: {
-              type: GraphQLInt,
+              type: GraphQLFloat,
               deprecationReason: "Favor `cents`",
             },
           },
@@ -206,7 +206,7 @@ const SaleArtworkType = new GraphQLObjectType({
         }),
       }),
       low_estimate_cents: {
-        type: GraphQLInt,
+        type: GraphQLFloat,
         deprecationReason: "Favor `low_estimate`",
       },
       minimum_next_bid: money({
@@ -220,7 +220,7 @@ const SaleArtworkType = new GraphQLObjectType({
         }),
       }),
       minimum_next_bid_cents: {
-        type: GraphQLInt,
+        type: GraphQLFloat,
         deprecationReason: "Favor `minimum_next_bid`",
       },
       opening_bid: money({
@@ -231,7 +231,7 @@ const SaleArtworkType = new GraphQLObjectType({
         }),
       }),
       opening_bid_cents: {
-        type: GraphQLInt,
+        type: GraphQLFloat,
         deprecationReason: "Favor `opening_bid`",
       },
       position: {


### PR DESCRIPTION
Similar to https://github.com/artsy/metaphysics/pull/969 , noticed some requests to fields would fail with a type error in Sentry.

These are all deprecated (I guess some client is still out there!), and the newer fields use float: https://github.com/artsy/metaphysics/blob/eddb94804de02558e4b01c7b320f423ee2c867eb/src/schema/fields/money.js#L56