### PR TITLE
@sweir27 => Propagate original user agent, and append with Metaphysics

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,7 @@ async function startApp() {
       const accessToken = req.headers["x-access-token"]
       const userID = req.headers["x-user-id"]
       const timezone = req.headers["x-timezone"]
+      const userAgent = req.headers["user-agent"]
 
       const { requestIDs, span } = res.locals
       const requestID = requestIDs.requestID
@@ -85,7 +86,10 @@ async function startApp() {
         defaultTimezone = timezone
       }
 
-      const loaders = createLoaders(accessToken, userID, requestID)
+      const loaders = createLoaders(accessToken, userID, {
+        requestID,
+        userAgent,
+      })
       // Share with e.g. the Convection ApolloLink in mergedSchema.
       res.locals.dataLoaders = loaders // eslint-disable-line no-param-reassign
 
@@ -97,7 +101,7 @@ async function startApp() {
           userID,
           defaultTimezone,
           span,
-          ...createLoaders(accessToken, userID, requestIDs),
+          ...createLoaders(accessToken, userID, { requestIDs, userAgent }),
         },
         formatError: graphqlErrorHandler(req, { enableSentry, isProduction }),
         validationRules: [depthLimit(queryLimit)],

--- a/src/lib/__tests__/apis/galaxy.test.js
+++ b/src/lib/__tests__/apis/galaxy.test.js
@@ -21,6 +21,7 @@ describe("APIs", () => {
             Accept: "application/vnd.galaxy-public+json",
             "Content-Type": "application/hal+json",
             "Http-Authorization": "galaxy_token",
+            "User-Agent": "Metaphysics",
           },
           method: "GET",
           timeout: 5000,

--- a/src/lib/__tests__/apis/gravity.test.js
+++ b/src/lib/__tests__/apis/gravity.test.js
@@ -18,14 +18,21 @@ describe("APIs", () => {
       const request = sinon.stub().yields(null, { statusCode: 200, body: {} })
       fetch.__Rewire__("request", request)
 
-      return gravity("foo/bar").then(() => {
-        expect(request.args[0][0]).toBe("https://api.artsy.test/api/v1/foo/bar")
-        expect(request.args[0][1]).toEqual({
-          headers: { "X-XAPP-TOKEN": "secret" },
-          method: "GET",
-          timeout: 5000,
-        })
-      })
+      return gravity("foo/bar", null, { userAgent: "catty browser" }).then(
+        () => {
+          expect(request.args[0][0]).toBe(
+            "https://api.artsy.test/api/v1/foo/bar"
+          )
+          expect(request.args[0][1]).toEqual({
+            headers: {
+              "X-XAPP-TOKEN": "secret",
+              "User-Agent": "catty browser; Metaphysics",
+            },
+            method: "GET",
+            timeout: 5000,
+          })
+        }
+      )
     })
 
     it("resolves when there is a successful JSON response", () => {

--- a/src/lib/apis/fetch.js
+++ b/src/lib/apis/fetch.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { get, defaults, compact } from "lodash"
+import { assign, get, defaults, compact } from "lodash"
 import request from "request"
 import config from "config"
 import HTTPError from "lib/http_error"
@@ -11,6 +11,13 @@ export default (url, options = {}) => {
       method: "GET",
       timeout: config.REQUEST_TIMEOUT_MS,
     })
+
+    // Wrap user agent
+    const userAgent = opts.userAgent
+      ? opts.userAgent + "; Metaphysics"
+      : "Metaphysics"
+    delete opts.userAgent
+    opts.headers = assign({}, { "User-Agent": userAgent }, opts.headers)
 
     request(url, opts, (err, response) => {
       // If there is an error or non-200 status code, reject.

--- a/src/lib/loaders/__tests__/api.test.js
+++ b/src/lib/loaders/__tests__/api.test.js
@@ -66,6 +66,7 @@ describe("API loaders", () => {
     beforeEach(() => {
       apiLoader = apiLoaderWithoutAuthenticationFactory(api, "test_name", {
         requestIDs: { requestID: "1234" },
+        userAgent: "catty browser",
       })
       loader = apiLoader("some/path")
     })
@@ -100,7 +101,10 @@ describe("API loaders", () => {
   describe("with authentication", () => {
     beforeEach(() => {
       apiLoader = apiLoaderWithAuthenticationFactory(api, "test_name", {
-        requestID: 1234,
+        userAgent: "catty browser",
+        requestIDs: {
+          requestID: 1234,
+        },
       })(() => Promise.resolve("secret-token"))
       loader = apiLoader("some/path")
     })

--- a/src/lib/loaders/__tests__/user_agent.test.js
+++ b/src/lib/loaders/__tests__/user_agent.test.js
@@ -4,8 +4,8 @@ import gql from "test/gql"
 
 import factories from "../../../lib/loaders/api"
 
-describe("requestID (with the real data loaders)", () => {
-  it("resolves to add the initial request ID to a gravity header", () => {
+describe("User-Agent (with the real data loaders)", () => {
+  it("resolves to add the initial user agent to a gravity header", () => {
     const query = gql`
       {
         artist(id: "andy-warhol") {
@@ -15,12 +15,14 @@ describe("requestID (with the real data loaders)", () => {
     `
     const gravity = jest.fn(() => Promise.resolve({}))
     factories.__Rewire__("gravity", gravity)
-    const requestIDs = { requestId: "request-id" }
-    const rootValue = createLoaders("access-token", "user-id", { requestIDs })
+    const userAgent = "catty browser"
+    const rootValue = createLoaders("access-token", "user-id", {
+      userAgent,
+    })
     expect.assertions(1)
     return runQuery(query, rootValue).then(() => {
       expect(gravity).toBeCalledWith("artist/andy-warhol?", null, {
-        requestIDs,
+        userAgent,
       })
     })
   })
@@ -37,12 +39,12 @@ describe("requestID (with the real data loaders)", () => {
     `
     const gravity = jest.fn(() => Promise.resolve({}))
     factories.__Rewire__("gravity", gravity)
-    const requestIDs = { requestId: "request-id" }
-    const rootValue = createLoaders("secret", "user-42", { requestIDs })
+    const userAgent = "catty browser"
+    const rootValue = createLoaders("secret", "user-42", { userAgent })
     expect.assertions(1)
     return runAuthenticatedQuery(query, rootValue).then(() => {
       expect(gravity).toBeCalledWith("me/lot_standings?", "secret", {
-        requestIDs,
+        userAgent,
       })
     })
   })

--- a/src/lib/loaders/api/index.js
+++ b/src/lib/loaders/api/index.js
@@ -12,7 +12,7 @@ import positron from "lib/apis/positron"
 import { apiLoaderWithAuthenticationFactory } from "lib/loaders/api/loader_with_authentication_factory"
 import { apiLoaderWithoutAuthenticationFactory } from "lib/loaders/api/loader_without_authentication_factory"
 
-export default requestIDs => ({
+export default opts => ({
   // Unauthenticated loaders
 
   /**
@@ -22,7 +22,8 @@ export default requestIDs => ({
     delta,
     "delta",
     {
-      requestIDs,
+      requestIDs: opts.requestIDs,
+      userAgent: opts.userAgent,
     }
   ),
 
@@ -33,7 +34,8 @@ export default requestIDs => ({
     diffusion,
     "diffusion",
     {
-      requestIDs,
+      requestIDs: opts.requestIDs,
+      userAgent: opts.userAgent,
       requestThrottleMs: config.DIFFUSION_REQUEST_THROTTLE_MS,
     }
   ),
@@ -46,7 +48,10 @@ export default requestIDs => ({
   galaxyLoaderWithoutAuthenticationFactory: apiLoaderWithoutAuthenticationFactory(
     galaxy,
     "galaxy",
-    { requestIDs }
+    {
+      requestIDs: opts.requestIDs,
+      userAgent: opts.userAgent,
+    }
   ),
 
   /**
@@ -57,7 +62,10 @@ export default requestIDs => ({
   gravityLoaderWithoutAuthenticationFactory: apiLoaderWithoutAuthenticationFactory(
     gravity,
     "gravity",
-    { requestIDs }
+    {
+      requestIDs: opts.requestIDs,
+      userAgent: opts.userAgent,
+    }
   ),
 
   /**
@@ -69,7 +77,8 @@ export default requestIDs => ({
     positron,
     "positron",
     {
-      requestIDs,
+      requestIDs: opts.requestIDs,
+      userAgent: opts.userAgent,
     }
   ),
 
@@ -85,7 +94,8 @@ export default requestIDs => ({
     convection,
     "convection",
     {
-      requestIDs,
+      requestIDs: opts.requestIDs,
+      userAgent: opts.userAgent,
     }
   ),
 
@@ -98,7 +108,10 @@ export default requestIDs => ({
   gravityLoaderWithAuthenticationFactory: apiLoaderWithAuthenticationFactory(
     gravity,
     "gravity",
-    { requestIDs }
+    {
+      requestIDs: opts.requestIDs,
+      userAgent: opts.userAgent,
+    }
   ),
 
   /**
@@ -110,6 +123,9 @@ export default requestIDs => ({
   impulseLoaderWithAuthenticationFactory: apiLoaderWithAuthenticationFactory(
     impulse,
     "impulse",
-    { requestIDs }
+    {
+      requestIDs: opts.requestIDs,
+      userAgent: opts.userAgent,
+    }
   ),
 })

--- a/src/lib/loaders/index.js
+++ b/src/lib/loaders/index.js
@@ -10,13 +10,13 @@ import loadersWithoutAuthentication from "./loaders_without_authentication"
  * Only if credentials are provided will the set include authenticated loaders, so before using an authenticated loader
  * it would be wise to check if the loader is not in fact `undefined`.
  */
-export default (accessToken, userID, requestIDs) => {
-  const loaders = loadersWithoutAuthentication(requestIDs)
+export default (accessToken, userID, opts) => {
+  const loaders = loadersWithoutAuthentication(opts)
   if (accessToken) {
     return Object.assign(
       {},
       loaders,
-      loadersWithAuthentication(accessToken, userID, requestIDs)
+      loadersWithAuthentication(accessToken, userID, opts)
     )
   }
   return loaders

--- a/src/lib/loaders/loaders_with_authentication/convection.js
+++ b/src/lib/loaders/loaders_with_authentication/convection.js
@@ -4,14 +4,14 @@ import config from "config"
 
 const { CONVECTION_APP_ID } = config
 
-export default (accessToken, requestIDs) => {
+export default (accessToken, opts) => {
   let convectionTokenLoader
   const gravityAccessTokenLoader = () => Promise.resolve(accessToken)
 
   const {
     gravityLoaderWithAuthenticationFactory,
     convectionLoaderWithAuthenticationFactory,
-  } = factories(requestIDs)
+  } = factories(opts)
 
   const convectionAccessTokenLoader = () =>
     convectionTokenLoader().then(data => data.token)

--- a/src/lib/loaders/loaders_with_authentication/gravity.js
+++ b/src/lib/loaders/loaders_with_authentication/gravity.js
@@ -3,9 +3,9 @@
 import factories from "../api"
 import trackedEntityLoaderFactory from "lib/loaders/loaders_with_authentication/tracked_entity"
 
-export default (accessToken, userID, requestIDs) => {
+export default (accessToken, userID, opts) => {
   const gravityAccessTokenLoader = () => Promise.resolve(accessToken)
-  const { gravityLoaderWithAuthenticationFactory } = factories(requestIDs)
+  const { gravityLoaderWithAuthenticationFactory } = factories(opts)
   const gravityLoader = gravityLoaderWithAuthenticationFactory(
     gravityAccessTokenLoader
   )

--- a/src/lib/loaders/loaders_with_authentication/impulse.js
+++ b/src/lib/loaders/loaders_with_authentication/impulse.js
@@ -3,7 +3,7 @@ import config from "config"
 
 const { IMPULSE_APPLICATION_ID } = config
 
-export default (accessToken, userID, requestIDs) => {
+export default (accessToken, userID, opts) => {
   let impulseTokenLoader
   const gravityAccessTokenLoader = () => Promise.resolve(accessToken)
   const impulseAccessTokenLoader = () =>
@@ -12,7 +12,7 @@ export default (accessToken, userID, requestIDs) => {
   const {
     gravityLoaderWithAuthenticationFactory,
     impulseLoaderWithAuthenticationFactory,
-  } = factories(requestIDs)
+  } = factories(opts)
   const gravityLoader = gravityLoaderWithAuthenticationFactory(
     gravityAccessTokenLoader
   )

--- a/src/lib/loaders/loaders_with_authentication/index.js
+++ b/src/lib/loaders/loaders_with_authentication/index.js
@@ -2,8 +2,8 @@ import convectionLoaders from "./convection"
 import impulseLoaders from "./impulse"
 import gravityLoaders from "./gravity"
 
-export default (accessToken, userID, requestIDs) => ({
-  ...gravityLoaders(accessToken, userID, requestIDs),
-  ...convectionLoaders(accessToken, requestIDs),
-  ...impulseLoaders(accessToken, userID, requestIDs),
+export default (accessToken, userID, opts) => ({
+  ...gravityLoaders(accessToken, userID, opts),
+  ...convectionLoaders(accessToken, opts),
+  ...impulseLoaders(accessToken, userID, opts),
 })

--- a/src/lib/loaders/loaders_without_authentication/delta.js
+++ b/src/lib/loaders/loaders_without_authentication/delta.js
@@ -1,7 +1,7 @@
 // @ts-check
 import factories from "../api"
 
-export default requestIDs => {
-  const { deltaLoaderWithoutAuthenticationFactory } = factories(requestIDs)
+export default opts => {
+  const { deltaLoaderWithoutAuthenticationFactory } = factories(opts)
   return { deltaLoader: deltaLoaderWithoutAuthenticationFactory("/") }
 }

--- a/src/lib/loaders/loaders_without_authentication/diffusion.js
+++ b/src/lib/loaders/loaders_without_authentication/diffusion.js
@@ -1,8 +1,8 @@
 // @ts-check
 import factories from "../api"
 
-export default requestID => {
-  const { diffusionLoaderWithoutAuthenticationFactory } = factories(requestID)
+export default opts => {
+  const { diffusionLoaderWithoutAuthenticationFactory } = factories(opts)
   const diffusionLoader = diffusionLoaderWithoutAuthenticationFactory
 
   return {

--- a/src/lib/loaders/loaders_without_authentication/galaxy.js
+++ b/src/lib/loaders/loaders_without_authentication/galaxy.js
@@ -1,8 +1,8 @@
 // @ts-check
 import factories from "../api"
 
-export default requestIDs => {
-  const { galaxyLoaderWithoutAuthenticationFactory } = factories(requestIDs)
+export default opts => {
+  const { galaxyLoaderWithoutAuthenticationFactory } = factories(opts)
   const galaxyLoader = galaxyLoaderWithoutAuthenticationFactory
 
   return {

--- a/src/lib/loaders/loaders_without_authentication/gravity.js
+++ b/src/lib/loaders/loaders_without_authentication/gravity.js
@@ -1,8 +1,8 @@
 // @ts-check
 import factories from "../api"
 
-export default requestIDs => {
-  const { gravityLoaderWithoutAuthenticationFactory } = factories(requestIDs)
+export default opts => {
+  const { gravityLoaderWithoutAuthenticationFactory } = factories(opts)
   const gravityLoader = gravityLoaderWithoutAuthenticationFactory
 
   return {

--- a/src/lib/loaders/loaders_without_authentication/index.js
+++ b/src/lib/loaders/loaders_without_authentication/index.js
@@ -7,11 +7,11 @@ import geminiLoaders from "./gemini"
 import gravityLoaders from "./gravity"
 import positronLoaders from "./positron"
 
-export default requestIDs => ({
-  ...deltaLoaders(requestIDs),
-  ...diffusionLoaders(requestIDs),
-  ...galaxyLoaders(requestIDs),
+export default opts => ({
+  ...deltaLoaders(opts),
+  ...diffusionLoaders(opts),
+  ...galaxyLoaders(opts),
   ...geminiLoaders(),
-  ...gravityLoaders(requestIDs),
-  ...positronLoaders(requestIDs),
+  ...gravityLoaders(opts),
+  ...positronLoaders(opts),
 })

--- a/src/lib/loaders/loaders_without_authentication/positron.js
+++ b/src/lib/loaders/loaders_without_authentication/positron.js
@@ -2,8 +2,8 @@
 
 import factories from "../api"
 
-export default requestIDs => {
-  const { positronLoaderWithoutAuthenticationFactory } = factories(requestIDs)
+export default opts => {
+  const { positronLoaderWithoutAuthenticationFactory } = factories(opts)
   const positronLoader = positronLoaderWithoutAuthenticationFactory
 
   return {


### PR DESCRIPTION
This changes that last arg to the loaders/factory to be an object, including the request id and user agent, vs having it just be the user agent. This way, (hopefully!), if we want to add another option, we don't have to keep modifying the signature all the way around.

Closes https://github.com/artsy/metaphysics/issues/937