### PR TITLE
@mzikherman => Users endpoint/schema

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.js
+++ b/src/lib/loaders/loaders_with_authentication/gravity.js
@@ -128,9 +128,6 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "DELETE" }
     ),
-    usersLoader: gravityLoader(
-      "users",
-      {}
-    ),
+    usersLoader: gravityLoader("users"),
   }
 }

--- a/src/lib/loaders/loaders_with_authentication/gravity.js
+++ b/src/lib/loaders/loaders_with_authentication/gravity.js
@@ -130,8 +130,7 @@ export default (accessToken, userID, opts) => {
     ),
     usersLoader: gravityLoader(
       "users",
-      {},
-      { headers: true }
+      {}
     ),
   }
 }

--- a/src/lib/loaders/loaders_with_authentication/gravity.js
+++ b/src/lib/loaders/loaders_with_authentication/gravity.js
@@ -128,5 +128,10 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "DELETE" }
     ),
+    usersLoader: gravityLoader(
+      "users",
+      {},
+      { headers: true }
+    ),
   }
 }

--- a/src/lib/loaders/loaders_without_authentication/gravity.js
+++ b/src/lib/loaders/loaders_without_authentication/gravity.js
@@ -98,6 +98,5 @@ export default opts => {
     ),
     tagLoader: gravityLoader(id => `tag/${id}`),
     trendingArtistsLoader: gravityLoader("artists/trending"),
-    usersLoader: gravityLoader("users"),
   }
 }

--- a/src/lib/loaders/loaders_without_authentication/gravity.js
+++ b/src/lib/loaders/loaders_without_authentication/gravity.js
@@ -98,5 +98,6 @@ export default opts => {
     ),
     tagLoader: gravityLoader(id => `tag/${id}`),
     trendingArtistsLoader: gravityLoader("artists/trending"),
+    usersLoader: gravityLoader("users"),
   }
 }

--- a/src/schema/__tests__/users.test.js
+++ b/src/schema/__tests__/users.test.js
@@ -1,0 +1,24 @@
+import { runAuthenticatedQuery } from "test/utils"
+import gql from "test/gql"
+
+describe("Users", () => {
+  it("returns a list of users matching array of ids", async () => {
+    const usersLoader = ({ ids }) => {
+      if (ids) {
+        return Promise.resolve(
+          ids.map(id => ({ id }))
+        )
+      }
+      throw new Error("Unexpected invocation")
+    }
+    const query = gql`
+      {
+        users(ids: ["5a9075da8b3b817ede4f8767"]) {
+          id
+        }
+      }
+    `
+    const { users } = await runAuthenticatedQuery(query, { usersLoader })
+    expect(users[0].id).toEqual("5a9075da8b3b817ede4f8767")
+  })
+})

--- a/src/schema/__tests__/users.test.js
+++ b/src/schema/__tests__/users.test.js
@@ -3,10 +3,10 @@ import gql from "test/gql"
 
 describe("Users", () => {
   it("returns a list of users matching array of ids", async () => {
-    const usersLoader = ({ ids }) => {
-      if (ids) {
+    const usersLoader = (data) => {
+      if (data.id) {
         return Promise.resolve(
-          ids.map(id => ({ id }))
+          data.id.map(id => ({ id }))
         )
       }
       throw new Error("Unexpected invocation")

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -39,6 +39,7 @@ import Show from "./show"
 import SuggestedGenes from "./suggested_genes"
 import Tag from "./tag"
 import TrendingArtists from "./artists/trending"
+import Users from "./users"
 import MatchArtist from "./match/artist"
 import MatchGene from "./match/gene"
 import Me from "./me"
@@ -105,6 +106,7 @@ const rootFields = {
   status: Status,
   tag: Tag,
   trending_artists: TrendingArtists,
+  users: Users,
   popular_artists: PopularArtists,
 }
 
@@ -123,10 +125,10 @@ const Viewer = {
 const convectionMutations = enableSchemaStitching
   ? {}
   : {
-      createConsignmentSubmission: CreateSubmissionMutation,
-      updateConsignmentSubmission: UpdateSubmissionMutation,
-      addAssetToConsignmentSubmission: AddAssetToConsignmentSubmission,
-    }
+    createConsignmentSubmission: CreateSubmissionMutation,
+    updateConsignmentSubmission: UpdateSubmissionMutation,
+    addAssetToConsignmentSubmission: AddAssetToConsignmentSubmission,
+  }
 
 const schema = new GraphQLSchema({
   allowedLegacyNames: ["__id"],

--- a/src/schema/users.js
+++ b/src/schema/users.js
@@ -1,0 +1,16 @@
+import UserType from "./user"
+import { GraphQLList, GraphQLString } from "graphql"
+
+const Users = {
+  type: new GraphQLList(UserType),
+  description: "A list of Users",
+  args: {
+    ids: {
+      type: new GraphQLList(GraphQLString),
+    },
+  },
+  resolve: (root, options, request, { rootValue: { usersLoader } }) =>
+    usersLoader(options),
+}
+
+export default Users

--- a/src/schema/users.js
+++ b/src/schema/users.js
@@ -1,3 +1,4 @@
+import { clone } from "lodash"
 import UserType from "./user"
 import { GraphQLList, GraphQLString } from "graphql"
 
@@ -9,8 +10,15 @@ const Users = {
       type: new GraphQLList(GraphQLString),
     },
   },
-  resolve: (root, options, request, { rootValue: { usersLoader } }) =>
-    usersLoader(options),
+  resolve: (root, options, request, { rootValue: { usersLoader } }) => {
+    const cleanedOptions = clone(options)
+    // make ids singular to match gravity :id
+    if (options.ids) {
+      cleanedOptions.id = options.ids
+      delete cleanedOptions.ids
+    }
+    return usersLoader(cleanedOptions)
+  },
 }
 
 export default Users


### PR DESCRIPTION
- Adds an endpoint for Users to query by [:ids]
- Adds gravityLoader for Users

Wasn't completely sure that I needed to use the authenticated loader here, but it seemed like the right idea for user info.  We are passing in the user access token in positron's fetch, so I'm assuming that will be enough to get what we need.  (When I run the query on the local version, I get `"Not authorized"` error.