### PR TITLE
move from Alpine to Debian base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-FROM node:8.4.0-alpine
-
-RUN apk update && apk upgrade && apk add alpine-sdk
+FROM node:8.4.0
 
 # Set up deploy user and working directory
-RUN adduser -D -g '' deploy
+RUN adduser --disabled-password --gecos '' deploy
 RUN mkdir -p /app
 
 RUN npm install -g yarn@1.0.1


### PR DESCRIPTION
Looking into DNS resolution errors from Metaphysics, I came across [hints](https://kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/#known-issues) that Alpine may be the source of the problem.  Try the base Debian image instead of Alpine.  This will significantly increase the image size, but may fix our issues:

- https://sentry.io/artsynet/metaphysics-production/issues/485726406/?query=is:unresolved
- https://sentry.io/artsynet/metaphysics-production/issues/486003936/events/16130527608/

cc @mzikherman 