### PR TITLE
@joeyAghion => Add is_limited_fair_partner for backwards caompatability

### DIFF
--- a/src/schema/__tests__/partner.test.js
+++ b/src/schema/__tests__/partner.test.js
@@ -31,6 +31,7 @@ describe("Partner type", () => {
       {
         partner(id: "catty-partner") {
           name
+          is_limited_fair_partner
           categories {
             id
             name
@@ -43,6 +44,7 @@ describe("Partner type", () => {
       expect(data).toEqual({
         partner: {
           name: "Catty Partner",
+          is_limited_fair_partner: false,
           categories: [
             {
               id: "blue-chip",

--- a/src/schema/partner.js
+++ b/src/schema/partner.js
@@ -158,6 +158,12 @@ const PartnerType = new GraphQLObjectType({
         type: GraphQLBoolean,
         resolve: ({ default_profile_public }) => default_profile_public,
       },
+      is_limited_fair_partner: {
+        type: GraphQLBoolean,
+        deprecationReason:
+          "This field no longer exists, this is for backwards compatability",
+        resolve: () => false,
+      },
       is_linkable: {
         type: GraphQLBoolean,
         resolve: ({ default_profile_id, default_profile_public, type }) =>


### PR DESCRIPTION
Some client is consistently requesting this, over a year since it was removed from the schema (and all Artsy clients). We can't figure out where it's coming from (and it _is_ raising errors in Sentry and returning 400), so let's be good schema stewards and remain backwards compatible.