### PR TITLE
#migration require pod execution on foreground nodes and autoscale deployment

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -4,7 +4,6 @@ kind: Deployment
 metadata:
   name: metaphysics-web
 spec:
-  replicas: 2
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -29,6 +28,8 @@ spec:
         ports:
         - containerPort: 3000
         resources:
+          requests:
+            cpu: "1"
           limits:
             memory: "768Mi"
       affinity:
@@ -41,6 +42,23 @@ spec:
                 operator: In
                 values:
                 - foreground
+                - foreground
+
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: metaphysics-web
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: metaphysics-web
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+
 ---
 apiVersion: v1
 kind: Service

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -29,7 +29,7 @@ spec:
         - containerPort: 3000
         resources:
           requests:
-            cpu: "1"
+            cpu: "0.7"
           limits:
             memory: "768Mi"
       affinity:

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -34,14 +34,12 @@ spec:
             memory: "768Mi"
       affinity:
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            preference:
-              matchExpressions:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
               - key: tier
                 operator: In
                 values:
-                - foreground
                 - foreground
 
 ---

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -4,7 +4,6 @@ kind: Deployment
 metadata:
   name: metaphysics-web
 spec:
-  replicas: 1
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -29,6 +28,8 @@ spec:
         ports:
         - containerPort: 3000
         resources:
+          requests:
+            cpu: "0.5"
           limits:
             memory: "512Mi"
       affinity:
@@ -41,6 +42,22 @@ spec:
                 operator: In
                 values:
                 - foreground
+
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: metaphysics-web
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: metaphysics-web
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+
 ---
 apiVersion: v1
 kind: Service

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -34,10 +34,9 @@ spec:
             memory: "512Mi"
       affinity:
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            preference:
-              matchExpressions:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
               - key: tier
                 operator: In
                 values:


### PR DESCRIPTION
Use the [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) to scale metaphysics-web in response to load.

Also use the "hard" `requiredDuringSchedulingIgnoredDuringExecution` `nodeAffinity` selector to ensure these pods are always scheduled on `tier=foreground` nodes, and if resource is unavailable, prompt the [cluster autoscaler](https://github.com/artsy/substance/pull/77) to scale up this node group.

## Migration

Staging: `hokusai staging update`
Production: `hokusai production update`

cc @alloy @saolsen 
