### PR TITLE
Update to v3 of graphql-tools pre-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "graphql": "^0.13.2",
     "graphql-depth-limit": "^1.1.0",
     "graphql-relay": "^0.5.4",
-    "graphql-tools": "^3.0.0-alpha.11",
+    "graphql-tools": "^3.0.0-alpha.12",
     "graphql-type-json": "^0.1.4",
     "i": "^0.3.5",
     "jwt-simple": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "graphql": "^0.13.2",
     "graphql-depth-limit": "^1.1.0",
     "graphql-relay": "^0.5.4",
-    "graphql-tools": "^2.23.1",
+    "graphql-tools": "^3.0.0-alpha.11",
     "graphql-type-json": "^0.1.4",
     "i": "^0.3.5",
     "jwt-simple": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "graphql": "^0.13.2",
     "graphql-depth-limit": "^1.1.0",
     "graphql-relay": "^0.5.4",
-    "graphql-tools": "^3.0.0-alpha.12",
+    "graphql-tools": "^3.0.0-alpha.13",
     "graphql-type-json": "^0.1.4",
     "i": "^0.3.5",
     "jwt-simple": "^0.5.0",

--- a/src/lib/mergeSchemas.js
+++ b/src/lib/mergeSchemas.js
@@ -59,7 +59,11 @@ export async function mergeSchemas() {
   `
 
   const mergedSchema = _mergeSchemas({
-    schemas: [localSchema, convectionSchema, linkTypeDefs],
+    schemas: [
+      { name: "local", schema: localSchema },
+      { name: "convection", schema: convectionSchema },
+      { name: "links", schema: linkTypeDefs },
+    ],
     // Prefer others over the local MP schema.
     onTypeConflict: (_leftType, rightType) => {
       console.warn(`[!] Type collision ${rightType}`) // eslint-disable-line no-console

--- a/src/lib/mergeSchemas.js
+++ b/src/lib/mergeSchemas.js
@@ -65,17 +65,24 @@ export async function mergeSchemas() {
       console.warn(`[!] Type collision ${rightType}`) // eslint-disable-line no-console
       return rightType
     },
-    resolvers: mergeInfo => ({
+    resolvers: {
       Submission: {
         artist: {
           fragment: `fragment SubmissionArtist on Submission { artist_id }`,
           resolve: (parent, args, context, info) => {
             const id = parent.artist_id
-            return mergeInfo.delegate("query", "artist", { id }, context, info)
+            return info.mergeInfo.delegateToSchema(
+              localSchema,
+              "query",
+              "artist",
+              { id },
+              context,
+              info
+            )
           },
         },
       },
-    }),
+    },
   })
   mergedSchema.__allowedLegacyNames = ["__id"]
   return mergedSchema

--- a/yarn.lock
+++ b/yarn.lock
@@ -2820,9 +2820,9 @@ graphql-relay@^0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/graphql-relay/-/graphql-relay-0.5.4.tgz#58050cfe16118595f82ab3aabfc974546ce755a8"
 
-graphql-tools@^3.0.0-alpha.12:
-  version "3.0.0-alpha.12"
-  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-3.0.0-alpha.12.tgz#966d49ea2ba8795f7b636e0db1656e462abd7b3c"
+graphql-tools@^3.0.0-alpha.13:
+  version "3.0.0-alpha.13"
+  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-3.0.0-alpha.13.tgz#f5c74642dd50cd96d5d5ebdb70060d9ee915d9cf"
   dependencies:
     apollo-link "^1.2.1"
     apollo-utilities "^1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2820,9 +2820,9 @@ graphql-relay@^0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/graphql-relay/-/graphql-relay-0.5.4.tgz#58050cfe16118595f82ab3aabfc974546ce755a8"
 
-graphql-tools@^3.0.0-alpha.11:
-  version "3.0.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-3.0.0-alpha.11.tgz#b5985e0a635032b2d1dea1815cf8ade00f6cfd1c"
+graphql-tools@^3.0.0-alpha.12:
+  version "3.0.0-alpha.12"
+  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-3.0.0-alpha.12.tgz#966d49ea2ba8795f7b636e0db1656e462abd7b3c"
   dependencies:
     apollo-link "^1.2.1"
     apollo-utilities "^1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2820,9 +2820,9 @@ graphql-relay@^0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/graphql-relay/-/graphql-relay-0.5.4.tgz#58050cfe16118595f82ab3aabfc974546ce755a8"
 
-graphql-tools@^2.23.1:
-  version "2.23.1"
-  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-2.23.1.tgz#23f43000e2b9dc5a89920fe846fc5f71a320efdb"
+graphql-tools@^3.0.0-alpha.11:
+  version "3.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-3.0.0-alpha.11.tgz#b5985e0a635032b2d1dea1815cf8ade00f6cfd1c"
   dependencies:
     apollo-link "^1.2.1"
     apollo-utilities "^1.0.1"


### PR DESCRIPTION
v3 should have a fix for interface and union fragments with fragment
spreads

