### PR TITLE
@mzikherman => Make sure to return an empty connection when RVA is empty

### DIFF
--- a/src/schema/me/__tests__/recently_viewed_artworks.test.js
+++ b/src/schema/me/__tests__/recently_viewed_artworks.test.js
@@ -57,6 +57,39 @@ describe("RecentlyViewedArtworks", () => {
     )
   })
 
+  it("can return an empty connection", () => {
+    const query = gql`
+      {
+        me {
+          recentlyViewedArtworks(first: 1) {
+            edges {
+              node {
+                id
+                title
+              }
+            }
+            pageInfo {
+              hasNextPage
+            }
+          }
+        }
+      }
+    `
+    rootValue.meLoader = () =>
+      Promise.resolve({ recently_viewed_artwork_ids: [] })
+    expect.assertions(1)
+    return runAuthenticatedQuery(query, rootValue).then(
+      ({ me: { recentlyViewedArtworks } }) => {
+        expect(recentlyViewedArtworks).toEqual({
+          edges: [],
+          pageInfo: {
+            hasNextPage: false,
+          },
+        })
+      }
+    )
+  })
+
   it("records an artwork view", () => {
     const mutation = gql`
       mutation {

--- a/src/schema/me/recently_viewed_artworks.ts
+++ b/src/schema/me/recently_viewed_artworks.ts
@@ -1,5 +1,6 @@
 import { GraphQLBoolean, GraphQLNonNull, GraphQLString } from "graphql"
 import {
+  connectionFromArray,
   connectionFromArraySlice,
   mutationWithClientMutationId,
 } from "graphql-relay"
@@ -17,6 +18,9 @@ export const RecentlyViewedArtworks = {
     _request,
     { rootValue: { artworksLoader } }
   ) => {
+    if (ids.length === 0) {
+      return connectionFromArray(ids, options)
+    }
     const { offset } = getPagingParameters(options)
     return artworksLoader({ ids }).then(body => {
       return connectionFromArraySlice(body, options, {


### PR DESCRIPTION
whoopsie, an empty array will just fall back to fetching `/artworks`