### PR TITLE
@mzikherman => Match stitched mutation output

### DIFF
--- a/src/schema/me/__tests__/recently_viewed_artworks.test.js
+++ b/src/schema/me/__tests__/recently_viewed_artworks.test.js
@@ -94,15 +94,15 @@ describe("RecentlyViewedArtworks", () => {
     const mutation = gql`
       mutation {
         recordArtworkView(input: { artwork_id: "percy" }) {
-          success
+          artwork_id
         }
       }
     `
 
     expect.assertions(1)
     return runAuthenticatedQuery(mutation, rootValue).then(
-      ({ recordArtworkView: { success } }) => {
-        expect(success).toEqual(true)
+      ({ recordArtworkView: { artwork_id } }) => {
+        expect(artwork_id).toEqual("percy")
       }
     )
   })

--- a/src/schema/me/recently_viewed_artworks.ts
+++ b/src/schema/me/recently_viewed_artworks.ts
@@ -40,9 +40,9 @@ export const recordArtworkViewMutation = mutationWithClientMutationId({
     },
   },
   outputFields: {
-    success: {
-      type: GraphQLBoolean,
-      resolve: () => true,
+    artwork_id: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ artwork_id }) => artwork_id,
     },
   },
   mutateAndGetPayload: (
@@ -55,6 +55,8 @@ export const recordArtworkViewMutation = mutationWithClientMutationId({
         "Missing recordArtworkViewLoader. Check that `X-Access-Token` and `X-User-Id` headers are set."
       )
     }
-    return recordArtworkViewLoader({ artwork_id })
+    return recordArtworkViewLoader({ artwork_id }).then(() => {
+      return { artwork_id }
+    })
   },
 })


### PR DESCRIPTION
Just return the inputted `artwork_id`, to match the stitched Gravity mutation, so we can use them exactly the same by clients, whether or not stitching is enabled.