### PR TITLE
set credit_card_enabled to false if partner_product_merchant_account not found for partner

### DIFF
--- a/src/schema/__tests__/partner.test.js
+++ b/src/schema/__tests__/partner.test.js
@@ -127,5 +127,35 @@ describe("Partner type", () => {
         })
       })
     })
+
+    it("returns false if partner_product_merchant_account call to lewitt returns errors", () => {
+      const typeDefs = fs.readFileSync(
+        path.resolve(__dirname, "../../data/lewitt.graphql"),
+        "utf8"
+      )
+
+      const resolvers = {
+        RootQuery: {
+          partner_product_merchant_account: () => {
+            throw new Error("Lewitt error")
+          },
+        },
+      }
+
+      const lewittSchema = makeExecutableSchema({
+        typeDefs,
+        resolvers,
+      })
+
+      rootValue.lewittSchema = lewittSchema
+
+      return runQuery(query, rootValue).then(data => {
+        expect(data).toEqual({
+          partner: {
+            acceptsCardPayments: false,
+          },
+        })
+      })
+    })
   })
 })

--- a/src/schema/partner.js
+++ b/src/schema/partner.js
@@ -247,9 +247,8 @@ const PartnerType = new GraphQLObjectType({
             partner_id: _id,
           }).then(response => {
             if (response.errors) {
-              throw new Error(
-                `Lewitt errors: ${JSON.stringify(response.errors)}`
-              )
+              // Something is off in Lewitt so cards are not accepted at the moment
+              return false
             }
             const { data: { partner_product_merchant_account } } = response
             return partner_product_merchant_account.credit_card_enabled


### PR DESCRIPTION
Partner Merchant account might not be crated for partner at all or it might not be configured properly. In case of merchant account never created for partner Lewitt GraphQL request returns `Document not found` error when queried for merchant account, which I think is correct. However metaphysics should handle it with setting `acceptsCardPayments` to false rather than rethrowing the error.

Not sure exactly how to properly test it but the logic is correct I believe.