### PR TITLE
removing periods from info and short description for attribution class

### DIFF
--- a/src/lib/attributionClasses.js
+++ b/src/lib/attributionClasses.js
@@ -2,15 +2,15 @@ export default {
   unique: {
     id: "unique",
     name: "Unique",
-    info: "One of a kind piece.",
-    short_description: "This is a unique work.",
+    info: "One of a kind piece",
+    short_description: "This is a unique work",
     long_description: "One of a kind piece, created by the artist.",
   },
   "limited edition": {
     id: "limited edition",
     name: "Limited edition",
-    info: "Original works created in multiple.",
-    short_description: "This is part of a limited edition set.",
+    info: "Original works created in multiple",
+    short_description: "This is part of a limited edition set",
     long_description: [
       "Original works created in multiple with direct involvement of the artist.",
       "Generally, less than 150 pieces total.",
@@ -19,15 +19,16 @@ export default {
   "made-to-order": {
     id: "made-to-order",
     name: "Made-to-order",
-    info: "A made-to-order piece.",
-    short_description: "This is a made-to-order piece.",
-    long_description: "A piece that is made-to-order, taking into account the collector’s preferences.",
+    info: "A made-to-order piece",
+    short_description: "This is a made-to-order piece",
+    long_description:
+      "A piece that is made-to-order, taking into account the collector’s preferences.",
   },
   reproduction: {
     id: "reproduction",
     name: "Reproduction",
-    info: "Reproduction authorized by artist’s studio or estate.",
-    short_description: "This work is a reproduction.",
+    info: "Reproduction authorized by artist’s studio or estate",
+    short_description: "This work is a reproduction",
     long_description: [
       "Reproduction of an original work authorized by artist’s studio or estate.",
       "The artist was not directly involved in production.",
@@ -36,8 +37,8 @@ export default {
   "editioned multiple": {
     id: "editioned multiple",
     name: "Editioned multiple",
-    info: "High quantity editions, without direct artist involvement.",
-    short_description: "This is an editioned multiple.",
+    info: "High quantity editions, without direct artist involvement",
+    short_description: "This is an editioned multiple",
     long_description: [
       "Pieces created in larger limited editions, authorized by the artist’s studio or estate.",
       "Not produced with direct involvement of the artist.",
@@ -46,8 +47,8 @@ export default {
   "non-editioned multiple": {
     id: "non-editioned multiple",
     name: "Non-editioned multiple",
-    info: "Works made in unlimited or unknown numbers of copies.",
-    short_description: "This is a non-editioned multiple.",
+    info: "Works made in unlimited or unknown numbers of copies",
+    short_description: "This is a non-editioned multiple",
     long_description: [
       "Works made in unlimited or unknown numbers of copies, authorized by the artist’s studio or estate.",
       "Not produced with direct involvement of the artist.",
@@ -56,8 +57,8 @@ export default {
   ephemera: {
     id: "ephemera",
     name: "Ephemera",
-    info: "Peripheral artifacts related to the artist.",
-    short_description: "This is ephemera, an artifact related to the artist.",
+    info: "Peripheral artifacts related to the artist",
+    short_description: "This is ephemera, an artifact related to the artist",
     long_description: [
       "Items related to the artist, created or manufactured for a specific, limited use.",
       "This includes exhibition materials, memorabilia, autographs, etc.",

--- a/src/schema/artwork/__tests__/artwork.test.js
+++ b/src/schema/artwork/__tests__/artwork.test.js
@@ -965,7 +965,7 @@ describe("Artwork type", () => {
         expect(data).toEqual({
           artwork: {
             attribution_class: {
-              info: "One of a kind piece.",
+              info: "One of a kind piece",
             },
           },
         })
@@ -986,7 +986,7 @@ describe("Artwork type", () => {
         expect(data).toEqual({
           artwork: {
             attribution_class: {
-              short_description: "This is a unique work.",
+              short_description: "This is a unique work",
             },
           },
         })


### PR DESCRIPTION
One of the changes requested by this latest artwork info design update is to make attribution link not incluse `.`, like dot at the end should not be underlined. I think the easiest way to achieve that is not to include `.` as part of link and just insert it at the end.

![screen shot 2018-04-18 at 3 30 06 pm](https://user-images.githubusercontent.com/437156/38953760-c233c8ce-431d-11e8-8273-03fb116eca0e.png)
