### PR TITLE
@joeyAghion => allow reserve to be passed when updating an order

### DIFF
--- a/src/schema/me/__tests__/order/update_order_mutation.test.js
+++ b/src/schema/me/__tests__/order/update_order_mutation.test.js
@@ -9,6 +9,7 @@ describe("Me", () => {
         mutation {
           updateOrder(input: {
             id: "fooid123",
+            reserve: true,
             telephone: "6073499419",
             shipping_address: {
               name: "sarah sarah",
@@ -82,6 +83,7 @@ describe("Me", () => {
           mutation {
             updateOrder(input: {
               id: "fooid123",
+              reserve: true,
               telephone: "6073499419",
               session_id: "session123",
               shipping_address: {
@@ -154,6 +156,7 @@ describe("Me", () => {
           mutation {
             updateOrder(input: {
               id: "fooid123",
+              reserve: true,
               telephone: "6073499419",
               shipping_address: {
                 name: "sarah sarah",

--- a/src/schema/me/order/update_order_mutation.js
+++ b/src/schema/me/order/update_order_mutation.js
@@ -1,4 +1,9 @@
-import { GraphQLInputObjectType, GraphQLNonNull, GraphQLString } from "graphql"
+import {
+  GraphQLBoolean,
+  GraphQLInputObjectType,
+  GraphQLNonNull,
+  GraphQLString,
+} from "graphql"
 import { OrderType } from "schema/me/order"
 import { mutationWithClientMutationId } from "graphql-relay"
 
@@ -44,6 +49,10 @@ export const OrderInputType = new GraphQLInputObjectType({
       type: GraphQLString,
       description: "Additional notes",
     },
+    reserve: {
+      type: GraphQLBoolean,
+      description: "Whether or not to put the order on reserve",
+    },
     session_id: {
       type: GraphQLString,
       description: "Session ID necessary if there is no user present",
@@ -73,6 +82,7 @@ export default mutationWithClientMutationId({
       id,
       email,
       notes,
+      reserve,
       session_id,
       shipping_address: { name, street, city, region, postal_code, use_id },
       telephone,
@@ -89,6 +99,7 @@ export default mutationWithClientMutationId({
     return updateOrderLoader(id, {
       email,
       notes,
+      reserve,
       session_id,
       shipping_address: { name, street, city, region, postal_code, use_id },
       telephone,


### PR DESCRIPTION
Per your comment on my previous PR!

We need to be able to pass `reserve: true` when we update an order.