### PR TITLE
@damassi => Support recently viewed artworks homepage rail

### DIFF
--- a/src/schema/home/context.js
+++ b/src/schema/home/context.js
@@ -78,6 +78,7 @@ export const moduleContext = {
   },
   followed_galleries: () => null,
   saved_works: () => null,
+  recently_viewed_works: () => null,
   recommended_works: () => null,
   live_auctions: ({ rootValue: { salesLoader } }) => {
     return featuredAuction(salesLoader).then(sale => {

--- a/src/schema/home/home_page_artwork_modules.js
+++ b/src/schema/home/home_page_artwork_modules.js
@@ -101,6 +101,9 @@ const HomePageArtworkModuleTypes = new GraphQLEnumType({
     SAVED_WORKS: {
       value: "saved_works",
     },
+    RECENTLY_VIEWED_WORKS: {
+      value: "recently_viewed_works",
+    },
   },
 })
 

--- a/src/schema/home/results.js
+++ b/src/schema/home/results.js
@@ -108,6 +108,15 @@ const moduleResults = {
       sort: "-position",
     })
   },
+  recently_viewed_works: ({ rootValue: { meLoader, artworksLoader } }) => {
+    return meLoader().then(({ recently_viewed_artwork_ids }) => {
+      if (recently_viewed_artwork_ids.length === 0) {
+        return []
+      }
+      const ids = recently_viewed_artwork_ids.slice(RESULTS_SIZE)
+      return artworksLoader({ ids })
+    })
+  },
 }
 
 export default {

--- a/src/schema/home/title.js
+++ b/src/schema/home/title.js
@@ -46,6 +46,7 @@ const moduleTitle = {
     })
   },
   saved_works: () => "Recently Saved Works",
+  recently_viewed_works: () => "Recently Viewed Works",
 }
 
 export default {


### PR DESCRIPTION
Pretty simple, if `recently_viewed_works: true` is a value that Gravity returns for the initial query as to which 'modules' (aka rails/sections) on the homepage to show, from https://github.com/artsy/gravity/blob/846fdd4798b92c6679aad29be3901014f76a297c/app/api/v1/me_modules_endpoint.rb , then you can request is in the usual way:

<img width="744" alt="screen shot 2018-04-20 at 7 11 43 pm" src="https://user-images.githubusercontent.com/1457859/39077277-b3740062-44ce-11e8-8c26-1458ff90a666.png">


This should be safe to merge, I'll make the Gravity change be dependent on a lab feature/flag so that we can see how it looks in Emission/Force. I don't think it will break those b/c AFAIK they work by 'opting-in' to rails: https://github.com/artsy/force/blob/45de3408bb8fa55eb6d517fc7f7cebfcc4e2ad73/src/desktop/apps/home/queries/initial.coffee#L6 and similarly in Emission