### PR TITLE
@yuki24 => return whether or not I have qualified credit cards

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.js
+++ b/src/lib/loaders/loaders_with_authentication/gravity.js
@@ -25,6 +25,7 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    meCreditCardsLoader: gravityLoader("me/credit_cards", {}),
     followGeneLoader: gravityLoader("me/follow/gene", {}, { method: "POST" }),
     followedArtistLoader: trackedEntityLoaderFactory(
       gravityLoader("me/follow/artists"),

--- a/src/schema/me/__tests__/index.test.js
+++ b/src/schema/me/__tests__/index.test.js
@@ -1,0 +1,55 @@
+import { runAuthenticatedQuery } from "test/utils"
+import gql from "test/gql"
+
+describe("me/index", () => {
+  describe("has_qualified_credit_cards", () => {
+    const creditCardQuery = gql`
+      query {
+        me {
+          has_qualified_credit_cards
+        }
+      }
+    `
+    it("returns true for has_qualified_credit_cards if one is returned from the me/credit_cards endpoint", () => {
+      const creditCardsResponse = [
+        {
+          id: "aabbccddee",
+          brand: "Visa",
+          name: "Test User",
+          last_digits: "4242",
+          created_at: "2018-04-25T14:53:44.000Z",
+          expiration_month: 3,
+          expiration_year: 2022,
+          deactivated_at: null,
+          created_by_admin: null,
+          created_by_trusted_client: null,
+          qualified_for_bidding: true,
+          provider: "Stripe",
+          address_zip_check: "pass",
+          address_line1_check: "pass",
+          cvc_check: "pass",
+        },
+      ]
+
+      return runAuthenticatedQuery(creditCardQuery, {
+        meCreditCardsLoader: () => Promise.resolve(creditCardsResponse),
+      }).then(data => {
+        expect(data).toEqual({ me: { has_qualified_credit_cards: true } })
+      })
+    })
+
+    it("returns false for has_qualified_credit_cards if none are returned from the me/credit_cards endpoint", () => {
+      const creditCardsResponse = []
+
+      return runAuthenticatedQuery(creditCardQuery, {
+        meCreditCardsLoader: () => Promise.resolve(creditCardsResponse),
+      }).then(data => {
+        expect(data).toEqual({
+          me: {
+            has_qualified_credit_cards: false,
+          },
+        })
+      })
+    })
+  })
+})

--- a/src/schema/me/index.js
+++ b/src/schema/me/index.js
@@ -1,4 +1,4 @@
-import { GraphQLString, GraphQLObjectType } from "graphql"
+import { GraphQLBoolean, GraphQLString, GraphQLObjectType } from "graphql"
 
 import { IDFields, NodeInterface } from "schema/object_identification"
 import { queriedForFieldsOtherThanBlacklisted } from "lib/helpers"
@@ -64,6 +64,21 @@ const Me = new GraphQLObjectType({
       }),
       resolve: () => ({}),
     },
+    has_qualified_credit_cards: {
+      type: GraphQLBoolean,
+      resolve: (
+        root,
+        options,
+        request,
+        { rootValue: { meCreditCardsLoader } }
+      ) => {
+        return meCreditCardsLoader({ qualified_for_bidding: true }).then(
+          results => {
+            return results.length > 0
+          }
+        )
+      },
+    },
     invoice: Invoice,
     lot_standing: LotStanding,
     lot_standings: LotStandings,
@@ -100,6 +115,7 @@ export default {
       "follow_artists",
       "followed_artists_connection",
       "followed_genes",
+      "has_qualified_credit_cards",
       "suggested_artists",
       "bidders",
       "bidder_positions",


### PR DESCRIPTION
Don't merge this until https://github.com/artsy/gravity/pull/11689 is deployed to production (I'll do that in the morning)!-- but looking for comments.

This PR adds a the field `has_qualified_credit_cards` on `me`, so we will know whether or not to show the credit card form when you attempt to confirm a bid.