### PR TITLE
Query Bidder Position by ID

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.js
+++ b/src/lib/loaders/loaders_with_authentication/gravity.js
@@ -72,7 +72,7 @@ export default (accessToken, userID, opts) => {
     meLoader: gravityLoader("me"),
     meBiddersLoader: gravityLoader("me/bidders"),
     meBidderPositionsLoader: gravityLoader("me/bidder_positions"),
-    bidderPositionStatus: gravityLoader(
+    bidderPositionLoader: gravityLoader(
       ({ id }) => `me/bidder_position/${id}/`,
       {},
       { headers: true }

--- a/src/lib/loaders/loaders_with_authentication/gravity.js
+++ b/src/lib/loaders/loaders_with_authentication/gravity.js
@@ -72,7 +72,7 @@ export default (accessToken, userID, opts) => {
     meLoader: gravityLoader("me"),
     meBiddersLoader: gravityLoader("me/bidders"),
     meBidderPositionsLoader: gravityLoader("me/bidder_positions"),
-    bidderPositionLoader: gravityLoader(
+    meBidderPositionLoader: gravityLoader(
       ({ id }) => `me/bidder_position/${id}/`,
       {},
       { headers: true }

--- a/src/lib/loaders/loaders_with_authentication/gravity.js
+++ b/src/lib/loaders/loaders_with_authentication/gravity.js
@@ -72,6 +72,11 @@ export default (accessToken, userID, opts) => {
     meLoader: gravityLoader("me"),
     meBiddersLoader: gravityLoader("me/bidders"),
     meBidderPositionsLoader: gravityLoader("me/bidder_positions"),
+    bidderPositionStatus: gravityLoader(
+      ({ id }) => `me/bidder_position/${id}/`,
+      {},
+      { headers: true }
+    ),
     createBidderPositionLoader: gravityLoader(
       "me/bidder_position",
       {},

--- a/src/schema/me/__tests__/bidder_position.test.js
+++ b/src/schema/me/__tests__/bidder_position.test.js
@@ -3,7 +3,7 @@ import { runAuthenticatedQuery } from "test/utils"
 describe("BidderPosition", () => {
   it("returns processed_at", () => {
     const rootValue = {
-      bidderPositionLoader: sinon.stub().returns(
+      bidderPositionLoader: () =>
         Promise.resolve({
           body: {
             bidder: {
@@ -21,7 +21,6 @@ describe("BidderPosition", () => {
             processed_at: "2018-04-26T14:15:52+00:00",
           },
         }),
-      ),
     }
     const query = `
       {

--- a/src/schema/me/__tests__/bidder_position.test.js
+++ b/src/schema/me/__tests__/bidder_position.test.js
@@ -1,0 +1,44 @@
+import { runAuthenticatedQuery } from "test/utils"
+
+describe("BidderPosition", () => {
+  it("returns processed_at", () => {
+    const rootValue = {
+      bidderPositionLoader: sinon.stub().returns(
+        Promise.resolve({
+          body: {
+            bidder: {
+              sale: {
+                _id: "5acd52f3275b2464e5e7f512",
+                id: "art-for-life-benefit-auction-2018",
+                name: "Art For Life: Benefit Auction 2018",
+                is_auction: true,
+              },
+              user: {
+                id: "5647404b258faf41db000161",
+                name: "Alexander Graham Bell",
+              },
+            },
+            processed_at: "2018-04-26T14:15:52+00:00",
+          },
+        }),
+      ),
+    }
+    const query = `
+      {
+        me {
+          bidder_position(id: "5ae1df168b3b8141bfc32e5d") {
+            processed_at
+          }
+        }
+      }
+    `
+
+    return runAuthenticatedQuery(query, rootValue).then(({ me }) => {
+      expect(me).toEqual({
+        bidder_position: {
+          processed_at: "2018-04-26T14:15:52+00:00",
+        },
+      })
+    })
+  })
+})

--- a/src/schema/me/bidder_position.js
+++ b/src/schema/me/bidder_position.js
@@ -1,8 +1,8 @@
 import { GraphQLNonNull, GraphQLString } from "graphql"
-import BidderPosition from "schema/bidder_position"
+import BidderPositionType from "schema/bidder_position"
 
-export const BidderPositionStatus = {
-  type: BidderPosition.type,
+export const BidderPosition = {
+  type: BidderPositionType.type,
   description: "Returns the bidder position status",
   args: {
     id: {
@@ -13,9 +13,9 @@ export const BidderPositionStatus = {
     root,
     { id },
     request,
-    { rootValue: { bidderPositionStatus } }
+    { rootValue: { bidderPositionLoader } }
   ) =>
-    bidderPositionStatus({
+    bidderPositionLoader({
       id,
     }).then(response => response.body),
 }

--- a/src/schema/me/bidder_position.js
+++ b/src/schema/me/bidder_position.js
@@ -3,7 +3,7 @@ import BidderPositionType from "schema/bidder_position"
 
 export const BidderPosition = {
   type: BidderPositionType.type,
-  description: "Returns the bidder position status",
+  description: "Returns a single bidder position",
   args: {
     id: {
       type: new GraphQLNonNull(GraphQLString),

--- a/src/schema/me/bidder_position_status.js
+++ b/src/schema/me/bidder_position_status.js
@@ -1,0 +1,21 @@
+import { GraphQLNonNull, GraphQLString } from "graphql"
+import BidderPosition from "schema/bidder_position"
+
+export const BidderPositionStatus = {
+  type: BidderPosition.type,
+  description: "Returns the bidder position status",
+  args: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+  },
+  resolve: (
+    root,
+    { id },
+    request,
+    { rootValue: { bidderPositionStatus } }
+  ) =>
+    bidderPositionStatus({
+      id,
+    }).then(response => response.body),
+}

--- a/src/schema/me/index.js
+++ b/src/schema/me/index.js
@@ -10,6 +10,7 @@ import ArtworkInquiries from "./artwork_inquiries"
 import BidderPositions from "./bidder_positions"
 import Bidders from "./bidders"
 import BidderStatus from "./bidder_status"
+import { BidderPositionStatus } from "./bidder_position_status"
 import CollectorProfile from "./collector_profile"
 import Conversation from "./conversation"
 import Conversations from "./conversations"
@@ -45,6 +46,7 @@ const Me = new GraphQLObjectType({
     bidders: Bidders,
     bidder_status: BidderStatus,
     bidder_positions: BidderPositions,
+    bidder_position_status: BidderPositionStatus,
     collector_profile: CollectorProfile,
     conversation: Conversation,
     conversations: Conversations,

--- a/src/schema/me/index.js
+++ b/src/schema/me/index.js
@@ -10,7 +10,7 @@ import ArtworkInquiries from "./artwork_inquiries"
 import BidderPositions from "./bidder_positions"
 import Bidders from "./bidders"
 import BidderStatus from "./bidder_status"
-import { BidderPositionStatus } from "./bidder_position_status"
+import { BidderPosition } from "./bidder_position"
 import CollectorProfile from "./collector_profile"
 import Conversation from "./conversation"
 import Conversations from "./conversations"
@@ -46,7 +46,7 @@ const Me = new GraphQLObjectType({
     bidders: Bidders,
     bidder_status: BidderStatus,
     bidder_positions: BidderPositions,
-    bidder_position_status: BidderPositionStatus,
+    bidder_position: BidderPosition,
     collector_profile: CollectorProfile,
     conversation: Conversation,
     conversations: Conversations,
@@ -121,6 +121,7 @@ export default {
       "suggested_artists",
       "bidders",
       "bidder_positions",
+      "bidder_position",
       "bidder_status",
       "lot_standing",
       "lot_standings",


### PR DESCRIPTION
Fixes: https://artsyproduct.atlassian.net/browse/PURCHASE-98

Makes it possible to send queries like
```
query {
  me {
   bidder_position(id: "5ae1df168b3b8141bfc32e5d") {
    processed_at
   }
  }
 }
```

and check to see if the bidding position is successfully created.
