### PR TITLE
#quickfix for bidder_position

### DIFF
--- a/src/schema/me/__tests__/bidder_position.test.js
+++ b/src/schema/me/__tests__/bidder_position.test.js
@@ -3,7 +3,7 @@ import { runAuthenticatedQuery } from "test/utils"
 describe("BidderPosition", () => {
   it("returns processed_at", () => {
     const rootValue = {
-      bidderPositionLoader: () =>
+      meBidderPositionLoader: () =>
         Promise.resolve({
           body: {
             bidder: {

--- a/src/schema/me/bidder_position.js
+++ b/src/schema/me/bidder_position.js
@@ -13,9 +13,9 @@ export const BidderPosition = {
     root,
     { id },
     request,
-    { rootValue: { bidderPositionLoader } }
+    { rootValue: { meBidderPositionLoader } }
   ) =>
-    bidderPositionLoader({
+    meBidderPositionLoader({
       id,
     }).then(response => response.body),
 }


### PR DESCRIPTION
Missed to update loader from `bidderPosition` to `meBidderPosition` in all places in the previous PR: https://github.com/artsy/metaphysics/pull/1023

This PR fixes that.