### PR TITLE
@l2succes: adds userLoader to loaders without authentication

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.js
+++ b/src/lib/loaders/loaders_with_authentication/gravity.js
@@ -164,7 +164,6 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "DELETE" }
     ),
-    userLoader: gravityLoader("user", {}, { method: "GET" }),
     usersLoader: gravityLoader("users"),
   }
 }

--- a/src/lib/loaders/loaders_without_authentication/gravity.js
+++ b/src/lib/loaders/loaders_without_authentication/gravity.js
@@ -103,6 +103,7 @@ export default opts => {
       {},
       { method: "PUT" }
     ),
+    userLoader: gravityLoader("user", {}, { method: "GET" }),
     submitOrderLoader: gravityLoader(
       id => `me/order/${id}/submit`,
       {},


### PR DESCRIPTION
This just adds the `userLoader` to loaders without authentication. We discovered last week that we don't need a user token to make this request but simple an app token.