### PR TITLE
Query articles from editorial feed on artists

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ GRAVITY_API_URL=https://stagingapi.artsy.net/
 HMAC_SECRET=https://www.youtube.com/watch?v=DLzxrzFCyOs
 IMPULSE_API_BASE=https://impulse-staging.artsy.net/api
 LEWITT_API_BASE=https://lewitt-api-staging.artsy.net
-POSITRON_API_BASE=https://writer-staging.artsy.net/api
+POSITRON_API_BASE=https://stagingwriter.artsy.net/api
 PREDICTION_ENDPOINT=https://live-staging.artsy.net
 REDIS_URL=redis://127.0.0.1:6379
 

--- a/src/schema/artist/index.js
+++ b/src/schema/artist/index.js
@@ -143,6 +143,9 @@ export const ArtistType = new GraphQLObjectType({
           limit: {
             type: GraphQLInt,
           },
+          in_editorial_feed: {
+            type: GraphQLBoolean,
+          },
         },
         type: new GraphQLList(Article.type),
         resolve: (
@@ -583,7 +586,7 @@ export const ArtistType = new GraphQLObjectType({
         type: GraphQLBoolean,
         resolve: (
           { id },
-          {},
+          { },
           request,
           { rootValue: { followedArtistLoader } }
         ) => {


### PR DESCRIPTION
Editorial wants to restrict the articles attached to artist pages -- this adds the option to include an `in_editorial_field` boolean on the articles query to positron.  

Also updates the env.example to use the correct positron staging url. 