### PR TITLE
Removes the gql reference which isnt transpiled from the app's main codepaths

### DIFF
--- a/src/lib/stitching/convection/stitching.ts
+++ b/src/lib/stitching/convection/stitching.ts
@@ -1,4 +1,3 @@
-import gql from "test/gql"
 import { GraphQLSchema } from "graphql"
 
 export const consignmentStitchingEnvironment = (
@@ -6,7 +5,7 @@ export const consignmentStitchingEnvironment = (
   convectionSchema: GraphQLSchema
 ) => ({
   // The SDL used to declare how to stitch an object
-  extensionSchema: gql`
+  extensionSchema: `
     extend type ConsignmentSubmission {
       artist: Artist
     }


### PR DESCRIPTION
`gql` is skipped from being compiled (because it lives in a testing folder) - which isn't actually needed here.