### PR TITLE
Adds optional arg to sale_artwork field.

### DIFF
--- a/src/schema/artwork/__tests__/artwork.test.js
+++ b/src/schema/artwork/__tests__/artwork.test.js
@@ -613,6 +613,27 @@ describe("Artwork type", () => {
       )
       expect(sale_id).toEqual(artwork.sale_ids[0])
     })
+
+    it("returns the specified sale artwork", async () => {
+      const query = gql`
+        {
+          artwork(id: "richard-prince-untitled-portrait") {
+            sale_artwork(sale_id: "sale-id-auction") {
+              sale_id
+            }
+          }
+        }
+      `
+      rootValue.saleArtworkLoader = ({ saleId, saleArtworkId }) =>
+        saleId === artwork.sale_ids[1] &&
+        saleArtworkId === "richard-prince-untitled-portrait" &&
+        Promise.resolve({ sale_id: saleId })
+      const { artwork: { sale_artwork: { sale_id } } } = await runQuery(
+        query,
+        rootValue
+      )
+      expect(sale_id).toEqual(artwork.sale_ids[1])
+    })
   })
 
   describe("#is_biddable", () => {

--- a/src/schema/artwork/index.js
+++ b/src/schema/artwork/index.js
@@ -577,17 +577,25 @@ export const artworkFields = () => {
     },
     sale_artwork: {
       type: SaleArtwork.type,
+      args: {
+        sale_id: {
+          type: GraphQLString,
+          defaultValue: null,
+        },
+      },
       resolve: (
         { id, sale_ids },
-        _args,
+        { sale_id },
         _request,
         { rootValue: { saleArtworkLoader } }
       ) => {
+        // Note that we don't even try to call the saleArtworkLoader unless there's
+        // at least one element in sale_ids.
         if (sale_ids && sale_ids.length > 0) {
-          const sale_id = _.first(sale_ids)
+          const loader_sale_id = sale_id || _.first(sale_ids)
           // don't error if the sale/artwork is unpublished
           return saleArtworkLoader({
-            saleId: sale_id,
+            saleId: loader_sale_id,
             saleArtworkId: id,
           }).catch(() => null)
         }


### PR DESCRIPTION
This PR is follow-up from [a discussion in eigen](https://github.com/artsy/eigen/pull/2609#issuecomment-388435489) about routing the new bid flow.

This PR adds a new, optional parameter to the `sale_artwork` field in the `Artwork` type. Theoretically, but not in practice, artworks can be in more than one sale; metaphysics simply returns the sale artwork from the first sale, which could cause problems down the road. 