### PR TITLE
Add eslint-config-prettier (fixes #705)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,15 +6,14 @@
     "jasmine": true,
     "es6": true
   },
-  "extends": "airbnb",
+  "extends": [
+    "airbnb",
+    "prettier"
+  ],
   "parser": "babel-eslint",
   "rules": {
     "camelcase": 0,
-    "max-len": [2, 120],
-    "quotes": [2, "double"],
-    "semi": [0],
-    "no-extra-semi": 0,
-    "indent": 0
+    "max-len": [2, 120]
   },
   "ignore": ["/flow-typed/npm/*"],
   "globals": {

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "dotenv": "^5.0.1",
     "eslint": "^1.10.3",
     "eslint-config-airbnb": "^3.1.0",
+    "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-react": "^3.14.0",
     "expect.js": "^0.3.1",
     "husky": "^0.13.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2172,6 +2172,12 @@ eslint-config-airbnb@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-3.1.0.tgz#8d030b4b80da1716a670e466a2fafe46f67466f4"
 
+eslint-config-prettier@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz#5ecd65174d486c22dff389fe036febf502d468a3"
+  dependencies:
+    get-stdin "^5.0.1"
+
 eslint-plugin-react@^3.14.0:
   version "3.16.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-3.16.1.tgz#262d96b77d7c4a42af809a73c0e527a58612293c"
@@ -2694,6 +2700,10 @@ generate-object-property@^1.1.0:
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
+
+get-stdin@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
 
 get-stream@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
The plugin is configured and conflicting rules have been removed. It errors out though due to the current version of eslint being too far out of date.
