### PR TITLE
bidder_position returns status/message 

### DIFF
--- a/src/schema/me/__tests__/bidder_position.test.js
+++ b/src/schema/me/__tests__/bidder_position.test.js
@@ -54,6 +54,7 @@ describe("BidderPosition", () => {
           bidder_position(id: "5ae1df168b3b8141bfc32e5d") {
             status
             message_header
+            message_description_md
             position {
               processed_at
             }
@@ -61,12 +62,13 @@ describe("BidderPosition", () => {
         }
       }
     `
-  it("returns success when processed and reserve is met and active", () => {
+  it("returns winning when processed and reserve is met and active", () => {
     return runAuthenticatedQuery(query, rootValue).then(({ me }) => {
       expect(me).toEqual({
         bidder_position: {
-          status: "SUCCESS",
+          status: "WINNING",
           message_header: null,
+          message_description_md: null,
           position: {
             processed_at: "2018-04-26T14:15:52+00:00",
           },
@@ -80,6 +82,7 @@ describe("BidderPosition", () => {
         bidder_position: {
           status: "PENDING",
           message_header: null,
+          message_description_md: null,
           position: {
             processed_at: null,
           },
@@ -91,8 +94,10 @@ describe("BidderPosition", () => {
     return runAuthenticatedQuery(query, rootValue).then(({ me }) => {
       expect(me).toEqual({
         bidder_position: {
-          status: "ERROR_RESERVE_NOT_MET",
+          status: "RESERVE_NOT_MET",
           message_header: "Your bid wasn't high enough",
+          message_description_md: `Your bid didn’t meet the reserve price for this work.  \
+ Bid again to take the lead.`,
           position: {
             processed_at: "2018-04-26T14:15:52+00:00",
           },
@@ -104,8 +109,10 @@ describe("BidderPosition", () => {
     return runAuthenticatedQuery(query, rootValue).then(({ me }) => {
       expect(me).toEqual({
         bidder_position: {
-          status: "ERROR_BID_LOW",
+          status: "OUTBID",
           message_header: "Your bid wasn't high enough",
+          message_description_md: `Another bidder placed a higher max bid or the same max bid before you did.  \
+ Bid again to take the lead.`,
           position: {
             processed_at: "2018-04-26T14:15:52+00:00",
           },

--- a/src/schema/me/__tests__/bidder_position.test.js
+++ b/src/schema/me/__tests__/bidder_position.test.js
@@ -1,41 +1,114 @@
 import { runAuthenticatedQuery } from "test/utils"
 
 describe("BidderPosition", () => {
-  it("returns processed_at", () => {
-    const rootValue = {
-      meBidderPositionLoader: () =>
+  const rootValue = {
+    meBidderPositionLoader: jest.fn()
+      .mockReturnValueOnce(
         Promise.resolve({
           body: {
-            bidder: {
-              sale: {
-                _id: "5acd52f3275b2464e5e7f512",
-                id: "art-for-life-benefit-auction-2018",
-                name: "Art For Life: Benefit Auction 2018",
-                is_auction: true,
-              },
-              user: {
-                id: "5647404b258faf41db000161",
-                name: "Alexander Graham Bell",
-              },
-            },
             processed_at: "2018-04-26T14:15:52+00:00",
+            active: true,
+            sale_artwork: {
+              reserve_status: "no_reserve",
+            },
           },
         }),
-    }
-    const query = `
+    )
+      .mockReturnValueOnce(
+        Promise.resolve({
+          body: {
+            processed_at: null,
+            active: false,
+            sale_artwork: {
+              reserve_status: "no_reserve",
+            },
+          },
+        }),
+    )
+      .mockReturnValueOnce(
+        Promise.resolve({
+          body: {
+            processed_at: "2018-04-26T14:15:52+00:00",
+            active: false,
+            sale_artwork: {
+              reserve_status: "reserve_not_met",
+            },
+          },
+        }),
+    )
+      .mockReturnValueOnce(
+        Promise.resolve({
+          body: {
+            processed_at: "2018-04-26T14:15:52+00:00",
+            active: false,
+            sale_artwork: {
+              reserve_status: "reserve_met",
+            },
+          },
+        }),
+    ),
+  }
+  const query = `
       {
         me {
           bidder_position(id: "5ae1df168b3b8141bfc32e5d") {
-            processed_at
+            status
+            message_header
+            position {
+              processed_at
+            }
           }
         }
       }
     `
-
+  it("returns success when processed and reserve is met and active", () => {
     return runAuthenticatedQuery(query, rootValue).then(({ me }) => {
       expect(me).toEqual({
         bidder_position: {
-          processed_at: "2018-04-26T14:15:52+00:00",
+          status: "SUCCESS",
+          message_header: null,
+          position: {
+            processed_at: "2018-04-26T14:15:52+00:00",
+          },
+        },
+      })
+    })
+  })
+  it("returns pending when not processed yet", () => {
+    return runAuthenticatedQuery(query, rootValue).then(({ me }) => {
+      expect(me).toEqual({
+        bidder_position: {
+          status: "PENDING",
+          message_header: null,
+          position: {
+            processed_at: null,
+          },
+        },
+      })
+    })
+  })
+  it("returns reserve not met when reserve not met", () => {
+    return runAuthenticatedQuery(query, rootValue).then(({ me }) => {
+      expect(me).toEqual({
+        bidder_position: {
+          status: "ERROR_RESERVE_NOT_MET",
+          message_header: "Your bid wasn't high enough",
+          position: {
+            processed_at: "2018-04-26T14:15:52+00:00",
+          },
+        },
+      })
+    })
+  })
+  it("returns outbid when not active but reserve is met", () => {
+    return runAuthenticatedQuery(query, rootValue).then(({ me }) => {
+      expect(me).toEqual({
+        bidder_position: {
+          status: "ERROR_BID_LOW",
+          message_header: "Your bid wasn't high enough",
+          position: {
+            processed_at: "2018-04-26T14:15:52+00:00",
+          },
         },
       })
     })

--- a/src/schema/me/bidder_position.js
+++ b/src/schema/me/bidder_position.js
@@ -1,8 +1,15 @@
 import { GraphQLNonNull, GraphQLString } from "graphql"
-import BidderPositionType from "schema/bidder_position"
+import { BiddingMessages } from "./bidder_position_messages"
+import { BidderPositionResultType } from "../types/bidder_position_result"
+
+const ANY_RESERVE_MET_STATUSES = ["no_reserve", "reserve_met"]
+
+const anyReserveMet = (position) => {
+  return ANY_RESERVE_MET_STATUSES.indexOf(position.sale_artwork.reserve_status) > -1
+}
 
 export const BidderPosition = {
-  type: BidderPositionType.type,
+  type: BidderPositionResultType,
   description: "Returns a single bidder position",
   args: {
     id: {
@@ -17,5 +24,35 @@ export const BidderPosition = {
   ) =>
     meBidderPositionLoader({
       id,
-    }).then(response => response.body),
+    }).then(response => {
+      const position = response.body
+      let status
+      if (anyReserveMet(position) && position.processed_at && position.active) {
+        return {
+          status: "SUCCESS",
+          position,
+        }
+      } else if (!position.processed_at) {
+        return {
+          status: "PENDING",
+          position,
+        }
+      } else if (position.processed_at && !anyReserveMet(position)) {
+        status = "ERROR_RESERVE_NOT_MET"
+      } else if (position.processed_at && !position.active) {
+        status = "ERROR_BID_LOW"
+      } else {
+        status = "ERROR_UNKNOWN"
+      }
+      const error = BiddingMessages.find(d => status.trim().startsWith(d.id)) || {
+        header: "",
+        description_md: () => "",
+      }
+      return {
+        status,
+        message_header: error.header,
+        message_description_md: error.description_md(),
+        position,
+      }
+    }),
 }

--- a/src/schema/me/bidder_position.js
+++ b/src/schema/me/bidder_position.js
@@ -29,7 +29,7 @@ export const BidderPosition = {
       let status
       if (anyReserveMet(position) && position.processed_at && position.active) {
         return {
-          status: "SUCCESS",
+          status: "WINNING",
           position,
         }
       } else if (!position.processed_at) {
@@ -38,20 +38,18 @@ export const BidderPosition = {
           position,
         }
       } else if (position.processed_at && !anyReserveMet(position)) {
-        status = "ERROR_RESERVE_NOT_MET"
+        status = "RESERVE_NOT_MET"
       } else if (position.processed_at && !position.active) {
-        status = "ERROR_BID_LOW"
+        status = "OUTBID"
       } else {
-        status = "ERROR_UNKNOWN"
+        status = "ERROR"
       }
-      const error = BiddingMessages.find(d => status.trim().startsWith(d.id)) || {
-        header: "",
-        description_md: () => "",
-      }
+      const message = BiddingMessages.find(d => status.trim().startsWith(d.id)) ||
+        BiddingMessages[BiddingMessages.length - 1] // error
       return {
         status,
-        message_header: error.header,
-        message_description_md: error.description_md(),
+        message_header: message.header,
+        message_description_md: message.description_md(),
         position,
       }
     }),

--- a/src/schema/me/bidder_position_messages.js
+++ b/src/schema/me/bidder_position_messages.js
@@ -1,0 +1,45 @@
+// the description_md must be a function to delay interpolation of string literal
+export const BiddingMessages = [
+  {
+    id: "ERROR_BID_LOW",
+    gravity_key: "Please enter a bid higher than",
+    header: "Your bid wasn't high enough",
+    description_md: () => `Another bidder placed a higher max bid or the same max bid before you did.  \
+ Bid again to take the lead.`,
+  },
+  {
+    id: "ERROR_RESERVE_NOT_MET",
+    gravity_key: "Please enter a bid higher than",
+    header: "Your bid wasn't high enough",
+    description_md: () => `Another bidder placed a higher max bid or the same max bid before you did.  \
+ Bid again to take the lead.`,
+  },
+  {
+    id: "ERROR_SALE_CLOSED",
+    gravity_key: "Sale Closed to Bids",
+    header: "Lot closed",
+    description_md: () => "Sorry, your bid wasn’t received before the lot closed.",
+  },
+  {
+    id: "ERROR_LIVE_BIDDING_STARTED",
+    gravity_key: "Live Bidding has Started",
+    header: "Live bidding has started",
+    description_md: (params) => `Sorry, your bid wasn’t received before live bidding started.\
+ To continue bidding, please [join the live auction](${params.liveAuctionUrl}).`,
+  },
+  {
+    id: "ERROR_BIDDER_NOT_QUALIFIED",
+    gravity_key: "Bidder not qualified to bid on this auction.",
+    header: "Bid not placed",
+    description_md: () => `Your bid can’t be placed at this time.\
+ Please contact [support@artsy.net](mailto:support@artsy.net) for more information.`,
+
+  },
+  {
+    id: "ERROR_UNKNOWN",
+    gravity_key: "unknown error",
+    header: "Bid not placed",
+    description_md: () => `Your bid can’t be placed at this time.\
+ Please contact [support@artsy.net](mailto:support@artsy.net) for more information.`,
+  },
+]

--- a/src/schema/me/bidder_position_messages.js
+++ b/src/schema/me/bidder_position_messages.js
@@ -1,34 +1,34 @@
 // the description_md must be a function to delay interpolation of string literal
 export const BiddingMessages = [
   {
-    id: "ERROR_BID_LOW",
+    id: "OUTBID",
     gravity_key: "Please enter a bid higher than",
     header: "Your bid wasn't high enough",
     description_md: () => `Another bidder placed a higher max bid or the same max bid before you did.  \
  Bid again to take the lead.`,
   },
   {
-    id: "ERROR_RESERVE_NOT_MET",
+    id: "RESERVE_NOT_MET",
     gravity_key: "Please enter a bid higher than",
     header: "Your bid wasn't high enough",
-    description_md: () => `Another bidder placed a higher max bid or the same max bid before you did.  \
+    description_md: () => `Your bid didn’t meet the reserve price for this work.  \
  Bid again to take the lead.`,
   },
   {
-    id: "ERROR_SALE_CLOSED",
+    id: "SALE_CLOSED",
     gravity_key: "Sale Closed to Bids",
     header: "Lot closed",
     description_md: () => "Sorry, your bid wasn’t received before the lot closed.",
   },
   {
-    id: "ERROR_LIVE_BIDDING_STARTED",
+    id: "LIVE_BIDDING_STARTED",
     gravity_key: "Live Bidding has Started",
     header: "Live bidding has started",
     description_md: (params) => `Sorry, your bid wasn’t received before live bidding started.\
  To continue bidding, please [join the live auction](${params.liveAuctionUrl}).`,
   },
   {
-    id: "ERROR_BIDDER_NOT_QUALIFIED",
+    id: "BIDDER_NOT_QUALIFIED",
     gravity_key: "Bidder not qualified to bid on this auction.",
     header: "Bid not placed",
     description_md: () => `Your bid can’t be placed at this time.\
@@ -36,7 +36,7 @@ export const BiddingMessages = [
 
   },
   {
-    id: "ERROR_UNKNOWN",
+    id: "ERROR",
     gravity_key: "unknown error",
     header: "Bid not placed",
     description_md: () => `Your bid can’t be placed at this time.\

--- a/src/schema/me/bidder_position_mutation.js
+++ b/src/schema/me/bidder_position_mutation.js
@@ -1,69 +1,13 @@
 // @ts-check
 
-import { GraphQLString, GraphQLFloat, GraphQLObjectType, GraphQLNonNull } from "graphql"
+import { GraphQLString, GraphQLFloat, GraphQLNonNull } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 
+import { BidderPositionResultType } from "../types/bidder_position_result"
+import { BiddingMessages } from "./bidder_position_messages"
 import config from "config"
-import BidderPosition from "schema/bidder_position"
 
 const { PREDICTION_ENDPOINT } = config
-
-// the description_md must be a function to delay interpolation of string literal
-const biddingErrors = [
-  {
-    id: "ERROR_BID_LOW",
-    gravity_key: "Please enter a bid higher than",
-    header: "Your bid wasn't high enough",
-    description_md: () => `Another bidder placed a higher max bid or the same max bid before you did.  \
- Bid again to take the lead.`,
-  },
-  {
-    id: "ERROR_SALE_CLOSED",
-    gravity_key: "Sale Closed to Bids",
-    header: "Lot closed",
-    description_md: () => "Sorry, your bid wasn’t received before the lot closed.",
-  },
-  {
-    id: "ERROR_LIVE_BIDDING_STARTED",
-    gravity_key: "Live Bidding has Started",
-    header: "Live bidding has started",
-    description_md: (params) => `Sorry, your bid wasn’t received before live bidding started.\
- To continue bidding, please [join the live auction](${params.liveAuctionUrl}).`,
-  },
-  {
-    id: "ERROR_BIDDER_NOT_QUALIFIED",
-    gravity_key: "Bidder not qualified to bid on this auction.",
-    header: "Bid not placed",
-    description_md: () => `Your bid can’t be placed at this time.\
- Please contact [support@artsy.net](mailto:support@artsy.net) for more information.`,
-
-  },
-  {
-    id: "ERROR_UNKNOWN",
-    gravity_key: "unknown error",
-    header: "Bid not placed",
-    description_md: () => `Your bid can’t be placed at this time.\
- Please contact [support@artsy.net](mailto:support@artsy.net) for more information.`,
-  },
-]
-
-const BidderPositionMutationResultType = new GraphQLObjectType({
-  name: "BidderPositionMutationResult",
-  fields: () => ({
-    status: {
-      type: new GraphQLNonNull(GraphQLString),
-    },
-    message_header: {
-      type: GraphQLString,
-    },
-    message_description_md: {
-      type: GraphQLString,
-    },
-    position: {
-      type: BidderPosition.type,
-    },
-  }),
-})
 
 // @ts-ignore
 export const BidderPositionMutation = mutationWithClientMutationId({
@@ -83,7 +27,7 @@ export const BidderPositionMutation = mutationWithClientMutationId({
   },
   outputFields: {
     result: {
-      type: BidderPositionMutationResultType,
+      type: BidderPositionResultType,
       resolve: (result) => result,
     },
   },
@@ -107,7 +51,7 @@ export const BidderPositionMutation = mutationWithClientMutationId({
         const errorObject = errorSplit.length > 1 ? JSON.parse(e.message.split(" - ")[1]) : null
         if (errorObject) {
           const errorMessage = errorObject.message || errorObject.error
-          const error = biddingErrors.find(d => errorMessage.trim().startsWith(d.gravity_key)) ||
+          const error = BiddingMessages.find(d => errorMessage.trim().startsWith(d.gravity_key)) ||
             errorObject.ERROR_UNKNOWN
           const liveAuctionUrl = `${PREDICTION_ENDPOINT}/${sale_id}`
           return {

--- a/src/schema/me/bidder_position_mutation.js
+++ b/src/schema/me/bidder_position_mutation.js
@@ -51,13 +51,13 @@ export const BidderPositionMutation = mutationWithClientMutationId({
         const errorObject = errorSplit.length > 1 ? JSON.parse(e.message.split(" - ")[1]) : null
         if (errorObject) {
           const errorMessage = errorObject.message || errorObject.error
-          const error = BiddingMessages.find(d => errorMessage.trim().startsWith(d.gravity_key)) ||
-            errorObject.ERROR_UNKNOWN
+          const message = BiddingMessages.find(d => errorMessage.trim().startsWith(d.gravity_key)) ||
+            BiddingMessages[BiddingMessages.length - 1]
           const liveAuctionUrl = `${PREDICTION_ENDPOINT}/${sale_id}`
           return {
-            status: error.id,
-            message_header: error.header,
-            message_description_md: error.description_md({ liveAuctionUrl }),
+            status: message.id,
+            message_header: message.header,
+            message_description_md: message.description_md({ liveAuctionUrl }),
           }
         }
         return new Error(e)

--- a/src/schema/types/bidder_position_result.js
+++ b/src/schema/types/bidder_position_result.js
@@ -1,0 +1,20 @@
+import { GraphQLString, GraphQLObjectType, GraphQLNonNull } from "graphql"
+import BidderPosition from "schema/bidder_position"
+
+export const BidderPositionResultType = new GraphQLObjectType({
+  name: "BidderPositionResult",
+  fields: () => ({
+    status: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    message_header: {
+      type: GraphQLString,
+    },
+    message_description_md: {
+      type: GraphQLString,
+    },
+    position: {
+      type: BidderPosition.type,
+    },
+  }),
+})


### PR DESCRIPTION
`bidder_position_mutation` returns status and error message when an error occurs at the time of placing the bidder position. After that the client (emission) polls MP to check if the bidder position is processed and then if it is active and met reserve.
 
This PR adds `status` and `message_header` and `message_description_md` to `bidder_position`  query returns similar to `bidder_position_mutation` to make the flow consistent on the client, also move the logic of checking bidder position status to MP.

**Note:** `bidder_position` (https://github.com/artsy/metaphysics/pull/1023) query is pretty new and hasn't been used on production yet so it is okay to change its return type.

sample query:
```
{
  me {
    bidder_position(id: "5af9fce35acaa60020dbeeed") {
      status
      position {
        processed_at
        is_active
        sale_artwork {
          reserve_status
        }
      }
    }
  }
}
```

response:
```
{
  "data": {
    "me": {
      "bidder_position": {
        "status": "SUCCESS",
        "position": {
          "processed_at": "2018-05-14T21:17:24+00:00",
          "is_active": true,
          "sale_artwork": {
            "reserve_status": "no_reserve"
          }
        }
      }
    }
  },
  "extensions": {
    "requests": {
      "gravity": {
        "requests": {
          "me/bidder_position/5af9fce35acaa60020dbeeed/": {
            "time": "0s 205.429ms",
            "cache": false
          },
          "sale_artwork/5af9f7bf02ac643526028809": {
            "time": "0s 14.294ms",
            "cache": true
          }
        }
      }
    },
    "requestID": "cec839b0-5959-11e8-a39a-7ba93b93d692"
  }
}
```

If you also have suggestion about name/location of the files let me know.