### PR TITLE
[debug] Make sure we log errors comming from `redis.get()`

### DIFF
--- a/src/lib/cache.js
+++ b/src/lib/cache.js
@@ -102,9 +102,14 @@ export default {
         if (time > CACHE_QUERY_LOGGING_THRESHOLD_MS) {
           error(`Slow Cache#Get: ${time}ms key:${key}`)
         }
-        if (err) return reject(err)
-        if (data) return resolve(JSON.parse(data))
-        reject(new Error("cache#get did not return `data`"))
+        if (err) {
+          error(err)
+          reject(err)
+        } else if (data) {
+          resolve(JSON.parse(data))
+        } else {
+          reject(new Error("cache#get did not return `data`"))
+        }
       })
     })
   },


### PR DESCRIPTION
The docs aren’t entirely clear on whether or not the global event
listener on the client will always log errors or truly only when
individual commands do not have callback handlers attached. However,
this code in the library does seem to suggest that the latter is the
case: https://github.com/NodeRedis/node_redis/blob/9bb1454ca183f4132dbec8d12d010f28303cdebd/lib/utils.js#L87-L93