### PR TITLE
Create external operator role in causality_jwt

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.js
+++ b/src/lib/loaders/loaders_with_authentication/gravity.js
@@ -89,6 +89,7 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    mePartnersLoader: gravityLoader("me/partners"),
     notificationsFeedLoader: gravityLoader("me/notifications/feed"),
     popularArtistsLoader: gravityLoader("artists/popular"),
     savedArtworkLoader: trackedEntityLoaderFactory(

--- a/src/schema/__tests__/causality_jwt.test.js
+++ b/src/schema/__tests__/causality_jwt.test.js
@@ -128,11 +128,11 @@ describe("CausalityJWT", () => {
     })
   })
 
-  it("denies a non-admin operator", () => {
+  it("does not allow a non-admin user or user not associated with sale partner to be operator", () => {
     const query = `{
       causality_jwt(role: OPERATOR, sale_id: "foo")
     }`
-
+    rootValue.mePartnersLoader = sinon.stub().returns(Promise.resolve([]))
     return runAuthenticatedQuery(query, rootValue).catch(e => {
       expect(e.message).toEqual("Unauthorized to be operator")
     })
@@ -140,7 +140,7 @@ describe("CausalityJWT", () => {
 
   it("allows a user associated with the sale partner to be an external operator for that sale", () => {
     const query = `{
-      causality_jwt(role: EXTERNAL_OPERATOR, sale_id: "foo")
+      causality_jwt(role: OPERATOR, sale_id: "foo")
     }`
     return runAuthenticatedQuery(query, rootValue).then(data => {
       expect(omit(jwt.decode(data.causality_jwt, HMAC_SECRET), "iat")).toEqual({
@@ -150,16 +150,6 @@ describe("CausalityJWT", () => {
         saleId: "foo",
         bidderId: "123",
       })
-    })
-  })
-
-  it("does not allow an unauthorized user to become an external operator", () => {
-    const query = `{
-      causality_jwt(role: EXTERNAL_OPERATOR, sale_id: "foo")
-    }`
-    rootValue.mePartnersLoader = sinon.stub().returns(Promise.resolve([]))
-    return runAuthenticatedQuery(query, rootValue).catch(e => {
-      expect(e.message).toEqual("Unauthorized to be operator for this sale")
     })
   })
 })

--- a/src/schema/__tests__/causality_jwt.test.js
+++ b/src/schema/__tests__/causality_jwt.test.js
@@ -16,11 +16,19 @@ describe("CausalityJWT", () => {
       type: "User",
     }
 
-    const sale = { _id: "foo", name: "Foo sale", id: "slug" }
+    const sale = {
+      _id: "foo",
+      name: "Foo sale",
+      id: "slug",
+      partner: { _id: "fooPartner" },
+    }
+
+    const mePartners = [{ _id: "fooPartner" }]
 
     rootValue = {
       saleLoader: sinon.stub().returns(Promise.resolve(sale)),
       meLoader: sinon.stub().returns(Promise.resolve(me)),
+      mePartnersLoader: sinon.stub().returns(Promise.resolve(mePartners)),
       accessToken: "token",
       meBiddersLoader: sinon.stub().returns(
         Promise.resolve([
@@ -130,11 +138,28 @@ describe("CausalityJWT", () => {
     })
   })
 
-  it("does not allow an unauthorized user to become an external operator", () => {
-
+  it("allows a user associated with the sale partner to be an external operator for that sale", () => {
+    const query = `{
+      causality_jwt(role: EXTERNAL_OPERATOR, sale_id: "foo")
+    }`
+    return runAuthenticatedQuery(query, rootValue).then(data => {
+      expect(omit(jwt.decode(data.causality_jwt, HMAC_SECRET), "iat")).toEqual({
+        aud: "auctions",
+        role: "external_operator",
+        userId: "craig",
+        saleId: "foo",
+        bidderId: "123",
+      })
+    })
   })
 
-  it("allows a user associated with the sale partner to be an external operator for that sale", () => {
-
+  it("does not allow an unauthorized user to become an external operator", () => {
+    const query = `{
+      causality_jwt(role: EXTERNAL_OPERATOR, sale_id: "foo")
+    }`
+    rootValue.mePartnersLoader = sinon.stub().returns(Promise.resolve([]))
+    return runAuthenticatedQuery(query, rootValue).catch(e => {
+      expect(e.message).toEqual("Unauthorized to be operator for this sale")
+    })
   })
 })

--- a/src/schema/__tests__/causality_jwt.test.js
+++ b/src/schema/__tests__/causality_jwt.test.js
@@ -129,4 +129,12 @@ describe("CausalityJWT", () => {
       expect(e.message).toEqual("Unauthorized to be operator")
     })
   })
+
+  it("does not allow an unauthorized user to become an external operator", () => {
+
+  })
+
+  it("allows a user associated with the sale partner to be an external operator for that sale", () => {
+
+  })
 })

--- a/src/schema/causality_jwt.js
+++ b/src/schema/causality_jwt.js
@@ -1,13 +1,8 @@
 import jwt from "jwt-simple"
 import { GraphQLString, GraphQLNonNull, GraphQLEnumType } from "graphql"
 import config from "config"
-import { includes } from "lodash"
 
 const { HMAC_SECRET } = config
-
-const isExternalOperatorAuthorized = (sale, mePartners) => {
-  return includes(mePartners.map(p => p._id), sale.partner._id)
-}
 
 export default {
   type: GraphQLString,
@@ -90,7 +85,7 @@ export default {
           HMAC_SECRET
         )
       })
-    // Operator role if logged in as an admin or if user has access to partner
+      // Operator role if logged in as an admin or if user has access to partner
     } else if (options.role === "OPERATOR") {
       return Promise.all([saleLoader(options.sale_id), meLoader()]).then(
         ([sale, me]) => {
@@ -110,7 +105,7 @@ export default {
           return mePartnersLoader({ "partner_ids[]": sale.partner._id }).then(
             mePartners => {
               // Check if current user has access to partner running the sale
-              if (!isExternalOperatorAuthorized(sale, mePartners)) {
+              if (mePartners.length === 0) {
                 throw new Error("Unauthorized to be operator")
               }
               return jwt.encode(

--- a/src/schema/sale/index.js
+++ b/src/schema/sale/index.js
@@ -1,6 +1,7 @@
 import Artwork from "schema/artwork"
 import Image from "schema/image/index"
 import Profile from "schema/profile"
+import Partner from "schema/partner"
 import SaleArtwork from "schema/sale_artwork"
 import cached from "schema/fields/cached"
 import date from "schema/fields/date"
@@ -292,6 +293,10 @@ export const SaleType = new GraphQLObjectType({
             return PREDICTION_ENDPOINT + "/" + sale.id
           }
         },
+      },
+      partner: {
+        type: Partner.type,
+        resolve: ({ partner }) => partner,
       },
       profile: {
         type: Profile.type,

--- a/src/schema/sale/index.js
+++ b/src/schema/sale/index.js
@@ -294,6 +294,8 @@ export const SaleType = new GraphQLObjectType({
           }
         },
       },
+      // Only fetches the partner info that's already included in the Sale object
+      // since we don't (at this time) need to load the full Partner object.
       partner: {
         type: Partner.type,
         resolve: ({ partner }) => partner,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/SELL-530

- Adds a new `external_operator` role to the Causality JWT. Checks if aspiring `OPERATOR` is first an admin; if not, checks whether or not they qualify to be an `external_operator`. External operators have access to the partner managing the sale. 
- Adds `mePartnersLoader` that fetches the partners the user currently has access to. Depends on https://github.com/artsy/gravity/pull/11736.
- Adds access to partner object in sale schema so that we can fetch the sale partner's ID in Prediction.