### PR TITLE
[debug] Still log cache read duration even if timed out.

### DIFF
--- a/src/lib/__tests__/cache.test.js
+++ b/src/lib/__tests__/cache.test.js
@@ -18,7 +18,7 @@ describe("Cache", () => {
       it("deletes the data", () => {
         cache.delete("get_foo")
         return cache.get("get_foo").catch(e => {
-          expect(e.message).toEqual("cache#get did not return `data`")
+          expect(e.message).toEqual("[Cache#get] Cache miss")
         })
       })
     })


### PR DESCRIPTION
This simplifies the code a little, but most importantly it makes it so that the promise rejects once the timeout passes but we still get logs if the read passed the `CACHE_QUERY_LOGGING_THRESHOLD_MS` so we still know how long long reads are taking.