### PR TITLE
Enable crunching with X-Crunch header

### DIFF
--- a/src/lib/__tests__/crunchInterceptor.test.js
+++ b/src/lib/__tests__/crunchInterceptor.test.js
@@ -32,6 +32,17 @@ describe("crunchInterceptor", () => {
       })
   })
 
+  it("should crunch the result when header is present", () => {
+    return request(app(crunchInterceptor))
+      .get("/?query={greeting}")
+      .set("Accept", "application/json")
+      .set("X-Crunch", true)
+      .expect(200)
+      .then(res => {
+        expect(res.body.data).toMatchObject(crunch({ greeting: "Hello World" }))
+      })
+  })
+
   it("should not try to crunch on an error", () => {
     const intercept = jest.fn()
     return request(app(invokeError(404), fakeCrunch(intercept)))

--- a/src/lib/crunchInterceptor.js
+++ b/src/lib/crunchInterceptor.js
@@ -2,7 +2,8 @@ import { crunch } from "graphql-crunch"
 import interceptor from "express-interceptor"
 
 export const interceptorCallback = req => ({
-  isInterceptable: () => req.query.hasOwnProperty("crunch"),
+  isInterceptable: () =>
+    req.query.hasOwnProperty("crunch") || req.headers["x-crunch"],
   intercept: (body, send) => {
     body = JSON.parse(body) // eslint-disable-line no-param-reassign
     if (body && body.data) {


### PR DESCRIPTION
This allows enabling the crunching of a response (#1042) via an `X-Crunch` header. It'll just be a little bit easier to integrate into some of the projects this way. 

In [emission](https://github.com/artsy/emission/blob/6d3c3496e407207f625dcbbb3946a7a69a05c48f/src/lib/metaphysics.ts#L10), the current approach would require us to process the URL to safely add the query parameter. Enabling it via a header would just be a bit cleaner. 

Hindsight. 