### PR TITLE
[graphqlTimeoutMiddleware] Clear timers.

### DIFF
--- a/src/lib/__tests__/graphqlErrorHandler.test.js
+++ b/src/lib/__tests__/graphqlErrorHandler.test.js
@@ -1,25 +1,32 @@
-import { shouldLogError } from "../graphqlErrorHandler"
+import { shouldReportError } from "../graphqlErrorHandler"
+import { GraphQLTimeoutError } from "lib/graphqlTimeoutMiddleware"
 
 describe("graphqlErrorHandler", () => {
-  it("reports non-HTTP errors", () => {
-    expect(shouldLogError({ statusCode: undefined })).toBeTruthy()
-  })
-
-  it("reports HTTP client errors that are not blacklisted", () => {
-    ;[400, 418].forEach(statusCode => {
-      expect(shouldLogError({ statusCode })).toBeTruthy()
+  describe("shouldReportError", () => {
+    it("reports non-HTTP errors", () => {
+      expect(shouldReportError({ statusCode: undefined })).toBeTruthy()
     })
-  })
 
-  it("does not report blacklisted HTTP client errors", () => {
-    ;[401, 403, 404].forEach(statusCode => {
-      expect(shouldLogError({ statusCode })).toBeFalsy()
+    it("reports HTTP client errors that are not blacklisted", () => {
+      ;[400, 418].forEach(statusCode => {
+        expect(shouldReportError({ statusCode })).toBeTruthy()
+      })
     })
-  })
 
-  it("does not report HTTP server errors", () => {
-    ;[500, 511].forEach(statusCode => {
-      expect(shouldLogError({ statusCode })).toBeFalsy()
+    it("does not report blacklisted HTTP client errors", () => {
+      ;[401, 403, 404].forEach(statusCode => {
+        expect(shouldReportError({ statusCode })).toBeFalsy()
+      })
+    })
+
+    it("does not report HTTP server errors", () => {
+      ;[500, 511].forEach(statusCode => {
+        expect(shouldReportError({ statusCode })).toBeFalsy()
+      })
+    })
+
+    it("does not report resolver timeout errors", () => {
+      expect(shouldReportError(new GraphQLTimeoutError("oh noes"))).toBeFalsy()
     })
   })
 })

--- a/src/lib/__tests__/graphqlTimeoutMiddleware.test.ts
+++ b/src/lib/__tests__/graphqlTimeoutMiddleware.test.ts
@@ -154,7 +154,7 @@ describe("graphQLTimeoutMiddleware", () => {
       expect(response.data).toEqual({ artwork: null })
       expect(response.errors!.length).toEqual(1)
       expect(response.errors![0].message).toMatch(
-        /GraphQL Error: Query\.artwork has timed out after waiting for \d+ms/
+        /Query\.artwork has timed out after waiting for \d+ms/
       )
     })
 
@@ -183,7 +183,7 @@ describe("graphQLTimeoutMiddleware", () => {
       })
       expect(response.errors!.length).toEqual(2)
       expect(response.errors![0].message).toMatch(
-        /GraphQL Error: Artist\.name has timed out after waiting for \d+ms/
+        /Artist\.name has timed out after waiting for \d+ms/
       )
     })
 

--- a/src/lib/graphqlTimeoutMiddleware.ts
+++ b/src/lib/graphqlTimeoutMiddleware.ts
@@ -2,6 +2,13 @@ import { IMiddleware } from "graphql-middleware"
 import { GraphQLResolveInfo, GraphQLField } from "graphql"
 import invariant from "invariant"
 
+export class GraphQLTimeoutError extends Error {
+  constructor(message) {
+    super(message)
+    Error.captureStackTrace(this, this.constructor)
+  }
+}
+
 export function fieldFromResolveInfo(resolveInfo: GraphQLResolveInfo) {
   return resolveInfo.parentType.getFields()[resolveInfo.fieldName]
 }
@@ -40,7 +47,7 @@ export const graphqlTimeoutMiddleware = (defaultTimeoutInMS: number) => {
       new Promise((_resolve, reject) => {
         timeoutID = setTimeout(() => {
           const field = `${info.parentType}.${info.fieldName}`;
-          reject(new Error(`GraphQL Error: ${field} has timed out after waiting for ${timeoutInMS}ms`))
+          reject(new GraphQLTimeoutError(`GraphQL Timeout Error: ${field} has timed out after waiting for ${timeoutInMS}ms`))
         }, timeoutInMS)
       }),
       new Promise(async (resolve, reject) => {

--- a/src/lib/graphqlTimeoutMiddleware.ts
+++ b/src/lib/graphqlTimeoutMiddleware.ts
@@ -35,14 +35,26 @@ export const graphqlTimeoutMiddleware = (defaultTimeoutInMS: number) => {
     // TODO: Maybe cache if it turns out to take significant time.
     //       Should probably be cached on the schema instance.
     const timeoutInMS = timeoutForField(fieldFromResolveInfo(info)) || defaultTimeoutInMS
+    let timeoutID
     return Promise.race([
       new Promise((_resolve, reject) => {
-        setTimeout(() => {
+        timeoutID = setTimeout(() => {
           const field = `${info.parentType}.${info.fieldName}`;
           reject(new Error(`GraphQL Error: ${field} has timed out after waiting for ${timeoutInMS}ms`))
         }, timeoutInMS)
       }),
-      new Promise(resolve => resolve(middlewareResolver(parent, args, context, info))),
+      new Promise(async (resolve, reject) => {
+        try {
+          const result = await middlewareResolver(parent, args, context, info)
+          resolve(result)
+        }
+        catch (error) {
+          reject(error)
+        }
+        finally {
+          clearTimeout(timeoutID)
+        }
+      })
     ])
   }
   return middleware


### PR DESCRIPTION
Gotta clean up after ourselves!

Also log all error messages (to paper trail) that don’t get reported to Sentry.