### PR TITLE
log redis client info on cache timeouts

### DIFF
--- a/src/lib/cache.js
+++ b/src/lib/cache.js
@@ -86,6 +86,16 @@ export default {
         const time = Date.now() - start
         if (time > CACHE_QUERY_LOGGING_THRESHOLD_MS) {
           error(`[Cache#get] Slow read of ${time}ms for key ${key}`)
+
+          const clientInfo = {
+            'ready': client.ready,
+            'connected': client.connected,
+            'shouldBuffer': client.shouldBuffer,
+            'commandQueueLength': client.commandQueueLength,
+            'offlineQueueLength': client.offlineQueueLength,
+            'pipelineQueueLength': client.pipeline_queue.length
+          }
+          error(`Redis Client Info: ${util.inspect(clientInfo)}`)
         }
 
         if (timeoutId) {

--- a/src/lib/cache.js
+++ b/src/lib/cache.js
@@ -1,3 +1,4 @@
+import util from 'util'
 import { isNull, isArray } from "lodash"
 import config from "config"
 import { error, verbose } from "./loggers"
@@ -88,12 +89,12 @@ export default {
           error(`[Cache#get] Slow read of ${time}ms for key ${key}`)
 
           const clientInfo = {
-            'ready': client.ready,
-            'connected': client.connected,
-            'shouldBuffer': client.shouldBuffer,
-            'commandQueueLength': client.commandQueueLength,
-            'offlineQueueLength': client.offlineQueueLength,
-            'pipelineQueueLength': client.pipeline_queue.length
+            ready: client.ready,
+            connected: client.connected,
+            shouldBuffer: client.shouldBuffer,
+            commandQueueLength: client.commandQueueLength,
+            offlineQueueLength: client.offlineQueueLength,
+            pipelineQueueLength: client.pipeline_queue.length
           }
           error(`Redis Client Info: ${util.inspect(clientInfo)}`)
         }


### PR DESCRIPTION
Thought not a fire any longer, we are still experiencing [cache timeouts](https://papertrailapp.com/groups/3675843/events?q=host%3Ametaphysics-web%20Cache).

I want to log some diagonistic info about the redis client when we hit the timeout, particularly whether the internal [should_buffer](https://github.com/NodeRedis/node_redis/blob/master/index.js#L118) flag has been set, and the length of the various internal queues particularly the [pipeline_queue](https://github.com/NodeRedis/node_redis/blob/master/index.js#L129).

The `should_buffer` flag is going to be set to `true` when the socket's [stream write method](https://nodejs.org/api/stream.html#stream_writable_write_chunk_encoding_callback) returns `false`, i.e. when

> Returns: <boolean> false if the stream wishes for the calling code to wait for the 'drain' event to be emitted before continuing to write additional data; otherwise true.

As @cavvia noted, if the command string is greater than 4mb, the [library writes directly to the socket](https://github.com/NodeRedis/node_redis/blob/master/index.js#L996), otherwise it concatenates commands to pipeline.

My hypothesis is that large `SET` commands exhaust the connection stream's buffer and, as the library retains a number of internal queues, the commands we are waiting on from the `client.get` and `client.set` methods may just be stuck in these internal queues (which would account for both cache timeouts and memory bloat observed).

cc @joeyAghion @dblock @cavvia @damassi as well - I am a bit lost in the internals of this library (i hope my reading of it is accurate) but maybe you can help provide some more insight as to the implementation details and how we can instrument it better... AFAICT the `node_redis` library imports the `redis-commands` [library](https://github.com/NodeRedis/redis-commands) and generally calls the `internal_send_command` [function](https://github.com/NodeRedis/node_redis/blob/7e9dda184b0ff8f3d119d6f26cd683c6667dfbff/index.js#L872) which contains a lot of branching that determines how a given command is sent to the server - i.e. if it is [written to the socket immediately or sent to the pipeline queue](https://github.com/NodeRedis/node_redis/blob/7e9dda184b0ff8f3d119d6f26cd683c6667dfbff/index.js#L1017) during the `write` operation or if gets executed as part of a [MULTI command](https://github.com/NodeRedis/node_redis/blob/7e9dda184b0ff8f3d119d6f26cd683c6667dfbff/index.js#L945)...  tbh I am starting to wonder if this is a good client implementation for our use-case (as opposed to using connection pooling, [which the maintainers don't seem to want to implement](https://github.com/NodeRedis/node_redis/issues/1184))

After gathering some metrics we should decide how to move forward.  I see the following options:
- Sticking with the `node_redis` client library and setting up connection pooling on top of it (may alleviate some pressure on the single socket connection)
- Setting up a master / slave Redis configuration and balancing load across the servers.  We would however, need to switch to https://github.com/luin/ioredis 
- Switching back to Memcached as the original motivation of switching to Redis was to get away from limited and unmaintained Memcachier client supporting basic auth, which we don't require any longer as we are on k8s in the VPC, and can use the much-better supported [memcached library supporting connection pooling out of the box](https://github.com/3rd-Eden/memcached/blob/master/lib/memcached.js#L86).
