### PR TITLE
dump client command queue to error logs

### DIFF
--- a/src/lib/cache.js
+++ b/src/lib/cache.js
@@ -97,6 +97,7 @@ export default {
             pipelineQueueLength: client.pipeline_queue.length
           }
           error(`Redis Client Info: ${util.inspect(clientInfo)}`)
+          error(`Redis Client commandQueue: ${util.inspect(client.command_queue.toArray())}`)
         }
 
         if (timeoutId) {


### PR DESCRIPTION
Follow-up to https://github.com/artsy/metaphysics/pull/1077 - I want to see the position of the timed-out command within the redis client's [command_queue](https://github.com/NodeRedis/node_redis/blob/master/index.js#L127)