### PR TITLE
Endpoint for retrieving an order

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.js
+++ b/src/lib/loaders/loaders_with_authentication/gravity.js
@@ -137,11 +137,7 @@ export default (accessToken, userID, opts) => {
       { method: "PUT" }
     ),
     updateMeLoader: gravityLoader("me", {}, { method: "PUT" }),
-    orderLoader: gravityLoader(
-      ({ id }) => `order/${id}`,
-      {},
-      { headers: true }
-    ),
+    orderLoader: gravityLoader(id => `order/${id}`, {}, { headers: true }),
     updateOrderLoader: gravityLoader(
       id => `me/order/${id}`,
       {},

--- a/src/lib/loaders/loaders_with_authentication/gravity.js
+++ b/src/lib/loaders/loaders_with_authentication/gravity.js
@@ -137,6 +137,11 @@ export default (accessToken, userID, opts) => {
       { method: "PUT" }
     ),
     updateMeLoader: gravityLoader("me", {}, { method: "PUT" }),
+    orderLoader: gravityLoader(
+      ({ id }) => `order/${id}`,
+      {},
+      { headers: true }
+    ),
     updateOrderLoader: gravityLoader(
       id => `me/order/${id}`,
       {},

--- a/src/schema/__tests__/order.test.js
+++ b/src/schema/__tests__/order.test.js
@@ -71,7 +71,7 @@ describe("Order type", () => {
     `
 
     const rootValue = {
-      orderLoader: sinon.stub().returns(
+      orderLoader: jest.fn().mockReturnValueOnce(
         Promise.resolve({
           body: exampleOrder,
         })
@@ -79,6 +79,7 @@ describe("Order type", () => {
     }
 
     return runQuery(query, rootValue).then(data => {
+      expect(rootValue.orderLoader).toBeCalledWith("52dd3c2e4b8480091700027f")
       expect(data.order).toEqual(exampleOrder)
     })
   })

--- a/src/schema/__tests__/order.test.js
+++ b/src/schema/__tests__/order.test.js
@@ -1,0 +1,85 @@
+/* eslint-disable promise/always-return */
+
+import { runQuery } from "test/utils"
+
+const exampleOrder = {
+  id: "fooid123",
+  telephone: "6073499419",
+  email: "",
+  line_items: [
+    {
+      quantity: 1,
+      artwork: {
+        id: "hubert-farnsworth-good-news",
+        title: "Good News",
+        artist: {
+          name: "Hubert Farnsworth",
+        },
+      },
+      partner: null,
+      partner_location: null,
+      shipping_note: null,
+      sale_conditions_url: null,
+    },
+  ],
+  shipping_address: {
+    name: "sarah sarah",
+    street: "401 Broadway, 25th Floor",
+    city: "New York",
+    region: "NY",
+    postal_code: null,
+    country: null,
+  },
+}
+
+describe("Order type", () => {
+  it("fetches order by id", () => {
+    const query = `
+      {
+        order(id: "52dd3c2e4b8480091700027f") {
+              id
+              telephone
+              email
+              line_items {
+                quantity
+                artwork {
+                  id
+                  title
+                  artist(shallow: true) {
+                    name
+                  }
+                }
+                partner {
+                  id
+                }
+                partner_location {
+                  id
+                }
+                shipping_note
+                sale_conditions_url
+              }
+              shipping_address {
+                name
+                street
+                city
+                region
+                postal_code
+                country
+              }
+            }
+      }
+    `
+
+    const rootValue = {
+      orderLoader: sinon.stub().returns(
+        Promise.resolve({
+          body: exampleOrder,
+        })
+      ),
+    }
+
+    return runQuery(query, rootValue).then(data => {
+      expect(data.order).toEqual(exampleOrder)
+    })
+  })
+})

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -16,6 +16,7 @@ import Genes from "./genes"
 import GeneFamilies from "./gene_families"
 import GeneFamily from "./gene_family"
 import HomePage from "./home"
+import { Order } from "./order"
 import OrderedSet from "./ordered_set"
 import OrderedSets from "./ordered_sets"
 import Profile from "./profile"
@@ -98,6 +99,7 @@ const rootFields = {
   match_gene: MatchGene,
   me: Me,
   node: ObjectIdentification.NodeField,
+  order: Order,
   ordered_set: OrderedSet,
   ordered_sets: OrderedSets,
   partner: Partner,

--- a/src/schema/order.js
+++ b/src/schema/order.js
@@ -1,0 +1,13 @@
+import { GraphQLNonNull, GraphQLString } from "graphql"
+import { OrderType } from "schema/me/order"
+
+export const Order = {
+  name: "Order",
+  type: OrderType,
+  description: "Returns a single Order",
+  args: { id: { type: new GraphQLNonNull(GraphQLString) } },
+  resolve: (root, { id }, request, { rootValue: { orderLoader } }) =>
+    orderLoader({
+      id,
+    }).then(response => response.body),
+}

--- a/src/schema/order.js
+++ b/src/schema/order.js
@@ -7,7 +7,5 @@ export const Order = {
   description: "Returns a single Order",
   args: { id: { type: new GraphQLNonNull(GraphQLString) } },
   resolve: (root, { id }, request, { rootValue: { orderLoader } }) =>
-    orderLoader({
-      id,
-    }).then(response => response.body),
+    orderLoader(id).then(response => response.body),
 }


### PR DESCRIPTION
Adds endpoint to query an Order by ID to be used from volt to show user orders in volt.

Sample Query:
```
query {
  order(id:"5b185c215070dc001f2af229") {
          id 
          telephone
          email
          line_items {
            quantity
            artwork {
              id
              title
              artist(shallow: true) {
                name
              }
            }
            edition_set {
              id
              is_for_sale
              is_sold
              price
              is_acquireable
              edition_of
            }
            partner {
              id
            }
            partner_location {
              id
            }
            shipping_note
            sale_conditions_url
          }
          item_total {
            amount
            display
          }
          shipping_address {
            name
            street
            city
            region
            postal_code
            country
          }
        }
  }
```