### PR TITLE
@acjay: Lower production memory limit to kill runaway pods earlier

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -30,10 +30,10 @@ spec:
         resources:
           requests:
             cpu: "0.5"
-            memory: "512Mi"
+            memory: "256Mi"
           limits:
             cpu: "1"
-            memory: "768Mi"
+            memory: "512Mi"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -30,10 +30,10 @@ spec:
         resources:
           requests:
             cpu: "0.5"
-            memory: "256Mi"
+            memory: "512Mi"
           limits:
             cpu: "1"
-            memory: "512Mi"
+            memory: "768Mi"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -30,10 +30,10 @@ spec:
         resources:
           requests:
             cpu: "0.2"
-            memory: "256Mi"
+            memory: "512Mi"
           limits:
             cpu: "0.5"
-            memory: "512Mi"
+            memory: "768Mi"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
We've seen pods get into a bad state, with high latency and high memory usage. As a mitigating measure, we [discussed](https://artsy.slack.com/archives/CA8SANW3W/p1528376895000157) lowering the memory limit, in order to kill those runaway pods earlier in their degradation.

This brings the `production.yml` in line with `staging.yml`. Both of these were part of the original transition (https://github.com/artsy/metaphysics/pull/968). This has been applied already (via `hokusai production update`), but is worth monitoring for a bit.

CC @izakp 