### PR TITLE
Rename external_operator to externalOperator

### DIFF
--- a/src/schema/__tests__/causality_jwt.test.js
+++ b/src/schema/__tests__/causality_jwt.test.js
@@ -145,7 +145,7 @@ describe("CausalityJWT", () => {
     return runAuthenticatedQuery(query, rootValue).then(data => {
       expect(omit(jwt.decode(data.causality_jwt, HMAC_SECRET), "iat")).toEqual({
         aud: "auctions",
-        role: "external_operator",
+        role: "externalOperator",
         userId: "craig",
         saleId: "foo",
         bidderId: "123",

--- a/src/schema/causality_jwt.js
+++ b/src/schema/causality_jwt.js
@@ -111,7 +111,7 @@ export default {
               return jwt.encode(
                 {
                   aud: "auctions",
-                  role: "external_operator",
+                  role: "externalOperator",
                   userId: me._id,
                   saleId: sale._id,
                   bidderId: me.paddle_number,


### PR DESCRIPTION
Causality expects a JWT with `externalOperator` instead of `external_operator`, so we're renaming to match what Causality expects.