### PR TITLE
@damassi => Updates for windowed pagination

### DIFF
--- a/src/lib/__tests__/helpers.test.js
+++ b/src/lib/__tests__/helpers.test.js
@@ -1,4 +1,12 @@
-import { exclude, toKey, isExisty, removeNulls, stripTags } from "lib/helpers"
+import {
+  exclude,
+  toKey,
+  isExisty,
+  removeNulls,
+  stripTags,
+  totalPages,
+  validatePagingParams,
+} from "lib/helpers"
 
 describe("exclude", () => {
   const xs = [
@@ -121,5 +129,32 @@ describe("removeNulls", () => {
     expect(objWithNulls).toHaveProperty("a", "percy")
     expect(objWithNulls).not.toHaveProperty("b")
     expect(objWithNulls).not.toHaveProperty("c")
+  })
+})
+
+describe("totalPages", () => {
+  it("removes total pages for a given total + size", () => {
+    expect(totalPages(74, 10)).toEqual(8)
+  })
+})
+
+describe("validatePagingParams", () => {
+  it("raises an error when exactly one of page and size are passed in", () => {
+    try {
+      validatePagingParams({ page: 1 })
+      throw new Error("Expected to raise error, but didnt")
+    } catch (error) {
+      expect(error.message).toEqual("Must specify both a page and size param.")
+    }
+  })
+  it("raises an error when page/size and cursor args are passed in", () => {
+    try {
+      validatePagingParams({ page: 1, size: 10, first: 10 })
+      throw new Error("Expected to raise error, but didnt")
+    } catch (error) {
+      expect(error.message).toEqual(
+        "Must specify either page/size or cursor args, but not both."
+      )
+    }
   })
 })

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -100,3 +100,28 @@ export const parseRelayOptions = options => {
 export const removeNulls = object => {
   Object.keys(object).forEach(key => object[key] == null && delete object[key]) // eslint-disable-line eqeqeq, no-param-reassign, max-len
 }
+// Validates Relay cursor or page/size pagination
+export const validatePagingParams = args => {
+  const { page, size, first, last } = args
+  if ((page && !size) || (size && !page)) {
+    throw new Error("Must specify both a page and size param.")
+  }
+  if (page && size && (first || last)) {
+    throw new Error(
+      "Must specify either page/size or cursor args, but not both."
+    )
+  }
+}
+// Returns `pagingOptions` and `offset`.
+// `pagingOptions` are valid for Gravity API V1.
+// `offset` can be used for connection slicing.
+export const parsePagingParams = args => {
+  const { page, size } = args
+  const pagingOptions = page && size ? { page, size } : parseRelayOptions(args)
+  const offset = page && size ? (page - 1) * size : pagingOptions.offset
+
+  return { pagingOptions, offset }
+}
+export const totalPages = (total, size) => {
+  return Math.ceil(total / size)
+}

--- a/src/schema/artist/__tests__/index.test.js
+++ b/src/schema/artist/__tests__/index.test.js
@@ -749,7 +749,7 @@ describe("Artist type", () => {
               artists: ["percy"],
             },
           ],
-          aggregations: [],
+          aggregations: { total: { value: 74 } },
         })
       )
       rootValue.filterArtworksLoader = filterArtworksLoader
@@ -758,8 +758,13 @@ describe("Artist type", () => {
         {
           artist(id: "percy") {
             filtered_artworks(aggregations:[TOTAL], partner_id: null){
-              hits {
-                id
+              artworks: artworks_connection(page: 1, size: 10) {
+                totalPages
+                edges {
+                  node {
+                    id
+                  }
+                }
               }
             }
           }
@@ -767,11 +772,14 @@ describe("Artist type", () => {
       `
 
       return runQuery(query, rootValue).then(
-        ({ artist: { filtered_artworks: { hits } } }) => {
+        ({
+          artist: { filtered_artworks: { artworks: { totalPages, edges } } },
+        }) => {
           expect(filterArtworksLoader.mock.calls[0][0]).not.toHaveProperty(
             "partner_id"
           )
-          expect(hits).toEqual([{ id: "im-a-cat" }])
+          expect(edges).toEqual([{ node: { id: "im-a-cat" } }])
+          expect(totalPages).toEqual(8)
         }
       )
     })

--- a/src/schema/artwork/index.js
+++ b/src/schema/artwork/index.js
@@ -756,4 +756,10 @@ export default Artwork
 
 export const artworkConnection = connectionDefinitions({
   nodeType: Artwork.type,
+  connectionFields: {
+    totalPages: {
+      type: GraphQLInt,
+      resolve: ({ totalPages }) => totalPages,
+    },
+  },
 }).connectionType


### PR DESCRIPTION
This adds the following functionality:
  - artwork connections now can include `totalPages` in the Metadata. It's up to the resolver which returns a connection to populate this field (added it to our filtered artworks schema).
  - the filtered artwork connection, which previously worked using first/last/after/before (cursor-based), can now accept page/size as well (with things working as expected there).
  - added a bit of validation/sanity around the above args ^

I've been running Reaction pointed to my local Metaphysics, this gets windowed pagination w/ arbitrary page access working (although I'm still finishing up the Reaction PR, getting rid of `src/__generated__`, etc.). That will be incoming shortly.