### PR TITLE
#migration scale up replicas

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -6,7 +6,7 @@ metadata:
 spec:
   strategy:
     rollingUpdate:
-      maxSurge: 1
+      maxSurge: 2
       maxUnavailable: 0
     type: RollingUpdate
   template:
@@ -55,8 +55,8 @@ spec:
     apiVersion: extensions/v1beta1
     kind: Deployment
     name: metaphysics-web
-  minReplicas: 3
-  maxReplicas: 6
+  minReplicas: 6
+  maxReplicas: 10
   targetCPUUtilizationPercentage: 100
 
 ---

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -55,8 +55,8 @@ spec:
     apiVersion: extensions/v1beta1
     kind: Deployment
     name: metaphysics-web
-  minReplicas: 1
-  maxReplicas: 3
+  minReplicas: 2
+  maxReplicas: 4
   targetCPUUtilizationPercentage: 95
 
 ---


### PR DESCRIPTION
We've been running between 5 and 6 pods since the downtime the other week, which led to the cache investigation.  The spec was still set to the old min replicas and this is definitely insufficient.

Let's throw more resource at it.  We have the capacity.

# Migration

`hokusai staging update && hokusai production update`

cc @joeyAghion @alloy @mzikherman 