### PR TITLE
implement health check

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -34,6 +34,12 @@ spec:
           limits:
             cpu: "1"
             memory: "768Mi"
+        readinessProbe:
+          httpGet:
+            port: 3000
+            path: /health
+          initialDelaySeconds: 5
+          periodSeconds: 5
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -34,6 +34,12 @@ spec:
           limits:
             cpu: "0.5"
             memory: "768Mi"
+        readinessProbe:
+          httpGet:
+            port: 3000
+            path: /health
+          initialDelaySeconds: 5
+          periodSeconds: 5
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ import forceSSL from "express-force-ssl"
 import bodyParser from "body-parser"
 import { info, error } from "./src/lib/loggers"
 import config from "config"
+import { client } from "lib/cache"
 
 const {
   ENABLE_ASYNC_STACK_TRACES,
@@ -42,6 +43,14 @@ if (enableMetrics) {
     res.send(expressMetrics.metrics.getAll())
   })
 }
+
+app.get('/health', (req, res) => {
+  if (client.ping()) {
+    res.status(200).end()
+  } else {
+    res.status(503).end()
+  }
+})
 
 xapp.on("error", err => {
   error(err)

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ import forceSSL from "express-force-ssl"
 import bodyParser from "body-parser"
 import { info, error } from "./src/lib/loggers"
 import config from "config"
-import { client } from "lib/cache"
+import cache from "lib/cache"
 
 const {
   ENABLE_ASYNC_STACK_TRACES,
@@ -73,7 +73,7 @@ function bootApp() {
   })
 
   app.get('/health', (req, res) => {
-    if (client.ping()) {
+    if (cache.isAvailable()) {
       res.status(200).end()
     } else {
       res.status(503).end()

--- a/index.js
+++ b/index.js
@@ -44,14 +44,6 @@ if (enableMetrics) {
   })
 }
 
-app.get('/health', (req, res) => {
-  if (client.ping()) {
-    res.status(200).end()
-  } else {
-    res.status(503).end()
-  }
-})
-
 xapp.on("error", err => {
   error(err)
   process.exit(1)
@@ -78,6 +70,14 @@ function bootApp() {
       .status(200)
       .set({ "Content-Type": "image/x-icon" })
       .end()
+  })
+
+  app.get('/health', (req, res) => {
+    if (client.ping()) {
+      res.status(200).end()
+    } else {
+      res.status(503).end()
+    }
   })
 
   app.all("/graphql", (_req, res) => res.redirect("/"))

--- a/src/index.js
+++ b/src/index.js
@@ -167,6 +167,7 @@ async function startApp() {
   if (enableSentry) {
     app.use(raven.errorHandler())
   }
+
 }
 
 startApp()

--- a/src/lib/cache.js
+++ b/src/lib/cache.js
@@ -149,4 +149,8 @@ export default {
         resolve(response)
       })
     ),
+
+  isAvailable: () => {
+    return client.ping()
+  }
 }


### PR DESCRIPTION
Simple health check endpoint that tests the Redis connection.

I want to also test that the application is completely bootstrapped but don't know how to go about this.  (Sometimes when I start the node process, the first time I hit an endpoint I get a `200` but the body is `Cannot GET /` - the next time I hit it I get the GraphiQL interface.

@alloy is there some lazy loading going on when `src/index.js` is imported via `index.js`?  The `startApp()` [function](https://github.com/artsy/metaphysics/blob/master/src/index.js#L67) in the former file appears to be `async`.

Ideally I want the app to be completely loaded and ready to serve traffic before the the `/health` endpoint returns `200`

Finally, if we want to react on a certain metric we can take the pod out of service by evaluating the metric value in the health check as well.