### PR TITLE
@acjay: Temporarily boost replicas

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -55,7 +55,7 @@ spec:
     apiVersion: extensions/v1beta1
     kind: Deployment
     name: metaphysics-web
-  minReplicas: 6
+  minReplicas: 10
   maxReplicas: 10
   targetCPUUtilizationPercentage: 100
 


### PR DESCRIPTION
This isn't intended to be more than a temporary measure, but I wanted to commit the change I made locally (and applied to production).

Note that updating the deployment's YAML via the kubernetes dash _or_ using its built-in dialog to "scale" the deployment or the replica set didn't persist across refreshes.