### PR TITLE
Only collect and expose process metrics

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,9 +37,8 @@ const app = express()
 app.use(compression())
 
 if (enableMetrics) {
-  app.use(expressMetrics.middleware)
   app.get('/metrics', (req, res) => {
-    res.send(expressMetrics.metrics.getAll())
+    res.send(expressMetrics.metrics.processMetrics())
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -36,12 +36,6 @@ const app = express()
 
 app.use(compression())
 
-if (enableMetrics) {
-  app.get('/metrics', (req, res) => {
-    res.send(expressMetrics.metrics.processMetrics())
-  })
-}
-
 xapp.on("error", err => {
   error(err)
   process.exit(1)
@@ -69,6 +63,12 @@ function bootApp() {
       .set({ "Content-Type": "image/x-icon" })
       .end()
   })
+
+  if (enableMetrics) {
+    app.get('/metrics', (req, res) => {
+      res.send(expressMetrics.metrics.processMetrics())
+    })
+  }
 
   app.all("/graphql", (_req, res) => res.redirect("/"))
 


### PR DESCRIPTION
Collecting express metrics as middleware was creating a new route for each GraphQL query.  Not sure why the query params were collected - the express [getRoute helper](https://github.com/idanto/express-node-metrics/blob/master/src/middleware.js#L32) is called in the middleware module of the metrics library.

In any case I am hesitant to throw this out on production - let's just start with basic Node and GC metrics before re-enabling this (or possibly just writing our own middleware function).
