### PR TITLE
Add field for returning whether user has credit cards at all

### DIFF
--- a/src/schema/me/__tests__/index.test.js
+++ b/src/schema/me/__tests__/index.test.js
@@ -53,4 +53,51 @@ describe("me/index", () => {
       })
     })
   })
+
+  describe("has_credit_cards", () => {
+    const creditCardQuery = gql`
+      query {
+        me {
+          has_credit_cards
+        }
+      }
+    `
+    it("returns true for has_credit_cards if one is returned from the me/credit_cards endpoint", () => {
+      const creditCardsResponse = [
+        {
+          id: "aabbccddee",
+          brand: "Visa",
+          name: "Test User",
+          last_digits: "4242",
+          created_at: "2018-04-25T14:53:44.000Z",
+          expiration_month: 3,
+          expiration_year: 2022,
+          deactivated_at: null,
+          created_by_admin: null,
+          created_by_trusted_client: null,
+          qualified_for_bidding: false,
+          provider: "Stripe",
+          address_zip_check: "pass",
+          address_line1_check: "pass",
+          cvc_check: "pass",
+        },
+      ]
+
+      return runAuthenticatedQuery(creditCardQuery, {
+        meCreditCardsLoader: () => Promise.resolve(creditCardsResponse),
+      }).then(data => {
+        expect(data).toEqual({ me: { has_credit_cards: true } })
+      })
+    })
+
+    it("returns false for has_qualified_credit_cards if none are returned from the me/credit_cards endpoint", () => {
+      const creditCardsResponse = []
+
+      return runAuthenticatedQuery(creditCardQuery, {
+        meCreditCardsLoader: () => Promise.resolve(creditCardsResponse),
+      }).then(data => {
+        expect(data).toEqual({ me: { has_credit_cards: false } })
+      })
+    })
+  })
 })

--- a/src/schema/me/index.js
+++ b/src/schema/me/index.js
@@ -72,6 +72,19 @@ const Me = new GraphQLObjectType({
       }),
       resolve: () => ({}),
     },
+    has_credit_cards: {
+      type: GraphQLBoolean,
+      resolve: (
+        root,
+        options,
+        request,
+        { rootValue: { meCreditCardsLoader } }
+      ) => {
+        return meCreditCardsLoader().then(results => {
+          return results.length > 0
+        })
+      },
+    },
     has_qualified_credit_cards: {
       type: GraphQLBoolean,
       resolve: (
@@ -127,6 +140,7 @@ export default {
       "follow_artists",
       "followed_artists_connection",
       "followed_genes",
+      "has_credit_cards",
       "has_qualified_credit_cards",
       "suggested_artists",
       "bidders",


### PR DESCRIPTION
We tracked the bug this morning to the fact that we were checking for `has_qualified_credit_cards` in one place, but only checking whether the user had credit cards at all (qualified or not) in another place.

This adds a field for us to check whether or not a user has a credit card on file at all.