### PR TITLE
hotfix - logging redis client info

### DIFF
--- a/src/lib/cache.js
+++ b/src/lib/cache.js
@@ -109,8 +109,7 @@ export default {
             offlineQueueLength: client.offlineQueueLength,
             pipelineQueueLength: client.pipeline_queue.length
           }
-          error(`Redis Client Info: ${util.inspect(clientInfo)}`)
-          error(`Redis Client commandQueue: ${util.inspect(client.command_queue.toArray())}`)
+          verbose(`Redis Client Info: ${util.inspect(clientInfo)}`)
         }
 
         if (timeoutId) {


### PR DESCRIPTION
move redis client info to verbose - drop logging full command queue as it's too noisy

cc @alloy @mbilokonsky 