### PR TITLE
@damassi => Add `articlesConnection` and enable cursor info on `auctionResults`

### DIFF
--- a/src/schema/__tests__/auction_results.test.js
+++ b/src/schema/__tests__/auction_results.test.js
@@ -14,7 +14,7 @@ describe("Artist type", () => {
     }
 
     const auctionResultResponse = {
-      total_count: 1,
+      total_count: 35,
       _embedded: {
         items: [
           {
@@ -106,5 +106,48 @@ describe("Artist type", () => {
         },
       })
     })
+  })
+
+  it("returns cursor info", () => {
+    const query = `
+      {
+        artist(id: "percy-z") {
+          auctionResults(recordsTrusted: true, first: 10) {
+            pageCursors {
+              first {
+                page
+              }
+              around {
+                page
+              }
+              last {
+                page
+              }
+            }
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+      }
+    `
+
+    return runQuery(query, rootValue).then(
+      ({ artist: { auctionResults: { pageCursors, edges } } }) => {
+        // Check expected page cursors exist in response.
+        const { first, around, last } = pageCursors
+        expect(first).toEqual(null)
+        expect(last).toEqual(null)
+        expect(around.length).toEqual(4)
+        let index
+        for (index = 0; index < 4; index++) {
+          expect(around[index].page).toBe(index + 1)
+        }
+        // Check auction result included in edges.
+        expect(edges[0].node.id).toEqual("1")
+      }
+    )
   })
 })

--- a/src/schema/article.js
+++ b/src/schema/article.js
@@ -1,4 +1,5 @@
 import cached from "./fields/cached"
+import { connectionWithCursorInfo } from "schema/fields/pagination"
 import AuthorType from "./author"
 import Image from "./image"
 import date from "./fields/date"
@@ -70,3 +71,5 @@ const Article = {
 }
 
 export default Article
+
+export const articleConnection = connectionWithCursorInfo(ArticleType)

--- a/src/schema/artist/__tests__/index.test.js
+++ b/src/schema/artist/__tests__/index.test.js
@@ -794,4 +794,63 @@ describe("Artist type", () => {
       )
     })
   })
+
+  describe("articlesConnection", () => {
+    it("returns connection of articles augmented by cursor info", () => {
+      const articlesLoader = jest.fn().mockReturnValueOnce(
+        Promise.resolve({
+          results: [
+            {
+              id: "foo-bar",
+              slug: "foo-bar",
+              title: "My Awesome Article",
+            },
+          ],
+          count: 35,
+        })
+      )
+      rootValue.articlesLoader = articlesLoader
+
+      const query = `
+        {
+          artist(id: "percy") {
+            articlesConnection(first: 10) {
+              pageCursors {
+                first {
+                  page
+                }
+                around {
+                  page
+                }
+                last {
+                  page
+                }
+              }
+              edges {
+                node {
+                  title
+                }
+              }
+            }
+          }
+        }
+      `
+
+      return runQuery(query, rootValue).then(
+        ({ artist: { articlesConnection: { pageCursors, edges } } }) => {
+          // Check expected page cursors exist in response.
+          const { first, around, last } = pageCursors
+          expect(first).toEqual(null)
+          expect(last).toEqual(null)
+          expect(around.length).toEqual(4)
+          let index
+          for (index = 0; index < 4; index++) {
+            expect(around[index].page).toBe(index + 1)
+          }
+          // Check article data included in edges.
+          expect(edges[0].node.title).toEqual("My Awesome Article")
+        }
+      )
+    })
+  })
 })

--- a/src/schema/artwork/index.js
+++ b/src/schema/artwork/index.js
@@ -1,7 +1,6 @@
 import _ from "lodash"
 import { isTwoDimensional, isTooBig, isEmbeddedVideo, embed } from "./utilities"
 import { enhance, existyValue, isExisty } from "lib/helpers"
-import { connectionDefinitions } from "graphql-relay"
 import cached from "schema/fields/cached"
 import { markdown } from "schema/fields/markdown"
 import Article from "schema/article"
@@ -10,7 +9,7 @@ import Image, { getDefault } from "schema/image"
 import Fair from "schema/fair"
 import Sale from "schema/sale"
 import SaleArtwork from "schema/sale_artwork"
-import { PageCursorsType } from "schema/fields/pagination"
+import { connectionWithCursorInfo } from "schema/fields/pagination"
 import PartnerShow from "schema/partner_show"
 import PartnerShowSorts from "schema/sorts/partner_show_sorts"
 import Partner from "schema/partner"
@@ -755,12 +754,4 @@ Artwork = {
 
 export default Artwork
 
-export const artworkConnection = connectionDefinitions({
-  nodeType: Artwork.type,
-  connectionFields: {
-    pageCursors: {
-      type: PageCursorsType,
-      resolve: ({ pageCursors }) => pageCursors,
-    },
-  },
-}).connectionType
+export const artworkConnection = connectionWithCursorInfo(ArtworkType)

--- a/src/schema/auction_result.js
+++ b/src/schema/auction_result.js
@@ -9,8 +9,8 @@ import {
   GraphQLObjectType,
   GraphQLEnumType,
 } from "graphql"
-import { connectionDefinitions } from "graphql-relay"
 import { indexOf } from "lodash"
+import { connectionWithCursorInfo } from "schema/fields/pagination"
 import Image from "schema/image"
 
 // Taken from https://github.com/RubyMoney/money/blob/master/config/currency_iso.json
@@ -163,6 +163,6 @@ const AuctionResultType = new GraphQLObjectType({
   }),
 })
 
-export const auctionResultConnection = connectionDefinitions({
-  nodeType: AuctionResultType,
-}).connectionType
+export const auctionResultConnection = connectionWithCursorInfo(
+  AuctionResultType
+)

--- a/src/schema/fields/pagination.js
+++ b/src/schema/fields/pagination.js
@@ -6,7 +6,7 @@ import {
   GraphQLNonNull,
   GraphQLList,
 } from "graphql"
-import { toGlobalId } from "graphql-relay"
+import { connectionDefinitions, toGlobalId } from "graphql-relay"
 import { warn } from "lib/loggers"
 
 const PREFIX = "arrayconnection"
@@ -120,4 +120,16 @@ export function createPageCursors(
       last: pageToCursor(totalPages, currentPage, size),
     }
   }
+}
+
+export function connectionWithCursorInfo(type) {
+  return connectionDefinitions({
+    nodeType: type,
+    connectionFields: {
+      pageCursors: {
+        type: PageCursorsType,
+        resolve: ({ pageCursors }) => pageCursors,
+      },
+    },
+  }).connectionType
 }


### PR DESCRIPTION
This is on top of https://github.com/artsy/metaphysics/pull/1087 so there's a large diff which will go away, the only new commit adding that is: https://github.com/artsy/metaphysics/commit/8461bc7fc84756f99109261d538b7b81b8ae38b4

It's relatively straightforward, the existing `articles` field under artist (currently in use) just returns a flat list of articles, so I added a new proper connection. `auctionResults` already was a connection so I just added the page cursor info.

Tested it locally via GraphiQL, works! 👍 

I'll add shows and related artists similarly, but I wanted to refactor those a bit (since they will require new connection types, as currently they are just flat lists).