### PR TITLE
@damassi => Show pagination

### DIFF
--- a/src/lib/loaders/loaders_without_authentication/gravity.js
+++ b/src/lib/loaders/loaders_without_authentication/gravity.js
@@ -74,7 +74,7 @@ export default opts => {
       { headers: true }
     ),
     relatedSalesLoader: gravityLoader("related/sales"),
-    relatedShowsLoader: gravityLoader("related/shows"),
+    relatedShowsLoader: gravityLoader("related/shows", {}, { headers: true }),
     saleLoader: gravityLoader(id => `sale/${id}`),
     salesLoader: gravityLoader("sales"),
     saleArtworkLoader: gravityLoader(

--- a/src/schema/artist/__tests__/carousel.test.js
+++ b/src/schema/artist/__tests__/carousel.test.js
@@ -27,7 +27,7 @@ describe("ArtistCarousel type", () => {
           solo_show: true,
           top_tier: true,
         })
-        .returns(Promise.resolve([]))
+        .returns(Promise.resolve({ body: [] }))
 
       rootValue.artistArtworksLoader = sinon
         .stub()

--- a/src/schema/artist/__tests__/index.test.js
+++ b/src/schema/artist/__tests__/index.test.js
@@ -584,12 +584,9 @@ describe("Artist type", () => {
         .stub()
         .withArgs(artist.id)
         .returns(
-          Promise.resolve([
-            privateShow,
-            publicShow,
-            partnerlessShow,
-            galaxyShow,
-          ])
+          Promise.resolve({
+            body: [privateShow, publicShow, partnerlessShow, galaxyShow],
+          })
         )
     })
     it("excludes shows from private partners for related shows", () => {

--- a/src/schema/artist/carousel.js
+++ b/src/schema/artist/carousel.js
@@ -38,7 +38,7 @@ const ArtistCarousel = {
         published: true,
       }),
     ])
-      .then(([shows, artworks]) => {
+      .then(([{ body: shows }, artworks]) => {
         const elligibleShows = shows.filter(show => show.images_count > 0)
         return Promise.all(
           elligibleShows.map(show =>

--- a/src/schema/artist/index.js
+++ b/src/schema/artist/index.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { pageable, getPagingParameters } from "relay-cursor-paging"
-import { assign, compact, defaults, first, reject, includes } from "lodash"
+import { assign, compact, defaults, first, omit, includes } from "lodash"
 import { exclude } from "lib/helpers"
 import cached from "schema/fields/cached"
 import initials from "schema/fields/initials"
@@ -18,11 +18,10 @@ import {
   partnersForArtist,
 } from "schema/partner_artist"
 import { GeneType } from "../gene"
-import Show from "schema/show"
+import Show, { showConnection } from "schema/show"
 import Sale from "schema/sale/index"
 import ArtworkSorts from "schema/sorts/artwork_sorts"
 import ArticleSorts from "schema/sorts/article_sorts"
-import PartnerShowSorts from "schema/sorts/partner_show_sorts"
 import SaleSorts from "schema/sale/sorts"
 import ArtistCarousel from "./carousel"
 import ArtistStatuses from "./statuses"
@@ -35,6 +34,11 @@ import ArtistArtworksFilters from "./artwork_filters"
 import { SuggestedArtistsArgs } from "schema/me/suggested_artists_args"
 import filterArtworks from "schema/filter_artworks"
 import { createPageCursors } from "schema/fields/pagination"
+import {
+  ShowField,
+  showsWithBLacklistedPartnersRemoved,
+  ShowsConnectionField,
+} from "./shows"
 import { GravityIDFields, NodeInterface } from "schema/object_identification"
 import {
   GraphQLObjectType,
@@ -65,70 +69,6 @@ const artistArtworkArrayLength = (artist, filter) => {
   return length
 }
 
-// TODO: Fix upstream, for now we remove shows from certain Partner types
-const blacklistedPartnerTypes = [
-  "Private Dealer",
-  "Demo",
-  "Private Collector",
-  "Auction",
-]
-const showsWithBLacklistedPartnersRemoved = shows => {
-  return reject(shows, show => {
-    if (show.partner) {
-      return includes(blacklistedPartnerTypes, show.partner.type)
-    }
-    if (show.galaxy_partner_id) {
-      return false
-    }
-    return true
-  })
-}
-
-// TODO Get rid of this when we remove the deprecated PartnerShow in favour of Show.
-const ShowField = {
-  args: {
-    active: {
-      type: GraphQLBoolean,
-    },
-    at_a_fair: {
-      type: GraphQLBoolean,
-    },
-    is_reference: {
-      type: GraphQLBoolean,
-    },
-    size: {
-      type: GraphQLInt,
-      description: "The number of PartnerShows to return",
-    },
-    solo_show: {
-      type: GraphQLBoolean,
-    },
-    status: {
-      type: GraphQLString,
-    },
-    top_tier: {
-      type: GraphQLBoolean,
-    },
-    visible_to_public: {
-      type: GraphQLBoolean,
-    },
-    sort: PartnerShowSorts,
-  },
-  resolve: (
-    { id },
-    options,
-    request,
-    { rootValue: { relatedShowsLoader } }
-  ) => {
-    return relatedShowsLoader(
-      defaults(options, {
-        artist_id: id,
-        sort: "-end_at",
-      })
-    ).then(shows => showsWithBLacklistedPartnersRemoved(shows))
-  },
-}
-
 export const ArtistType = new GraphQLObjectType({
   name: "Artist",
   interfaces: [NodeInterface],
@@ -155,18 +95,16 @@ export const ArtistType = new GraphQLObjectType({
           { rootValue: { articlesLoader } }
         ) => {
           const relayOptions = parseRelayOptions(args)
-
+          const gravityArgs = omit(args, ["first", "after", "last", "before"])
           return articlesLoader(
-            defaults(args, {
+            defaults(gravityArgs, relayOptions, {
               artist_id: _id,
               published: true,
               count: true,
             })
           ).then(({ results, count }) => {
             return assign(
-              {
-                pageCursors: createPageCursors(relayOptions, count),
-              },
+              { pageCursors: createPageCursors(relayOptions, count) },
               connectionFromArraySlice(results, args, {
                 arrayLength: count,
                 sliceStart: relayOptions.offset,
@@ -305,7 +243,9 @@ export const ArtistType = new GraphQLObjectType({
           return auctionLotLoader(diffusionArgs).then(
             ({ total_count, _embedded }) => {
               return assign(
-                { pageCursors: createPageCursors({ page, size }, total_count) },
+                {
+                  pageCursors: createPageCursors({ page, size }, total_count),
+                },
                 connectionFromArraySlice(_embedded.items, options, {
                   arrayLength: total_count,
                   sliceStart: offset,
@@ -523,7 +463,9 @@ export const ArtistType = new GraphQLObjectType({
             visible_to_public: false,
             has_location: true,
             size: options.size,
-          }).then(shows => showsWithBLacklistedPartnersRemoved(shows))
+          }).then(({ body: shows }) =>
+            showsWithBLacklistedPartnersRemoved(shows)
+          )
         },
       },
       filtered_artworks: filterArtworks("artist_id"),
@@ -727,6 +669,7 @@ export const ArtistType = new GraphQLObjectType({
           ),
       },
       shows: { type: new GraphQLList(Show.type), ...ShowField },
+      showsConnection: { type: showConnection, ...ShowsConnectionField },
       sortable_id: {
         type: GraphQLString,
         description:

--- a/src/schema/artist/shows.js
+++ b/src/schema/artist/shows.js
@@ -1,0 +1,96 @@
+import { pageable } from "relay-cursor-paging"
+import { GraphQLInt, GraphQLString, GraphQLBoolean } from "graphql"
+import PartnerShowSorts from "schema/sorts/partner_show_sorts"
+import { assign, defaults, reject, includes, omit } from "lodash"
+import { createPageCursors } from "schema/fields/pagination"
+import { parseRelayOptions } from "lib/helpers"
+import { connectionFromArraySlice } from "graphql-relay"
+
+// TODO: Fix upstream, for now we remove shows from certain Partner types
+const blacklistedPartnerTypes = [
+  "Private Dealer",
+  "Demo",
+  "Private Collector",
+  "Auction",
+]
+export function showsWithBLacklistedPartnersRemoved(shows) {
+  return reject(shows, show => {
+    if (show.partner) {
+      return includes(blacklistedPartnerTypes, show.partner.type)
+    }
+    if (show.galaxy_partner_id) {
+      return false
+    }
+    return true
+  })
+}
+
+const ShowArgs = {
+  active: {
+    type: GraphQLBoolean,
+  },
+  at_a_fair: {
+    type: GraphQLBoolean,
+  },
+  is_reference: {
+    type: GraphQLBoolean,
+  },
+  size: {
+    type: GraphQLInt,
+    description: "The number of PartnerShows to return",
+  },
+  solo_show: {
+    type: GraphQLBoolean,
+  },
+  status: {
+    type: GraphQLString,
+  },
+  top_tier: {
+    type: GraphQLBoolean,
+  },
+  visible_to_public: {
+    type: GraphQLBoolean,
+  },
+  sort: PartnerShowSorts,
+}
+
+// TODO: Get rid of this when we remove the deprecated PartnerShow in favour of Show.
+export const ShowField = {
+  args: ShowArgs,
+  resolve: (
+    { id },
+    options,
+    request,
+    { rootValue: { relatedShowsLoader } }
+  ) => {
+    return relatedShowsLoader(
+      defaults(options, {
+        artist_id: id,
+        sort: "-end_at",
+      })
+    ).then(({ body: shows }) => showsWithBLacklistedPartnersRemoved(shows))
+  },
+}
+
+export const ShowsConnectionField = {
+  args: pageable(ShowArgs),
+  resolve: ({ id }, args, _request, { rootValue: { relatedShowsLoader } }) => {
+    const relayOptions = parseRelayOptions(args)
+    const gravityArgs = omit(args, ["first", "after", "last", "before"])
+    return relatedShowsLoader(
+      defaults(gravityArgs, relayOptions, {
+        artist_id: id,
+        sort: "-end_at",
+        total_count: true,
+      })
+    ).then(({ body, headers }) => {
+      return assign({
+        pageCursors: createPageCursors(relayOptions, headers["x-total-count"]),
+        ...connectionFromArraySlice(body, args, {
+          arrayLength: headers["x-total-count"],
+          sliceStart: relayOptions.offset,
+        }),
+      })
+    })
+  },
+}

--- a/src/schema/artwork/context.js
+++ b/src/schema/artwork/context.js
@@ -71,6 +71,7 @@ export default {
       active: false,
       at_a_fair: false,
     })
+      .then(({ body }) => body)
       .then(first)
       .then(show => {
         if (!show) return null

--- a/src/schema/artwork/index.js
+++ b/src/schema/artwork/index.js
@@ -247,7 +247,7 @@ export const artworkFields = () => {
             published: true,
             limit: 1,
           }).then(({ results }) => results),
-        ]).then(([shows, articles]) => {
+        ]).then(([{ body: shows }, articles]) => {
           const highlightedShows = enhance(shows, { highlight_type: "Show" })
           const highlightedArticles = enhance(articles, {
             highlight_type: "Article",
@@ -439,7 +439,7 @@ export const artworkFields = () => {
         { rootValue: { relatedShowsLoader } }
       ) =>
         relatedShowsLoader({ active: true, size: 1, artwork: [id] }).then(
-          shows => shows.length > 0
+          ({ body: shows }) => shows.length > 0
         ),
     },
     is_not_for_sale: {
@@ -671,7 +671,9 @@ export const artworkFields = () => {
           active,
           sort,
           at_a_fair,
-        }).then(_.first),
+        })
+          .then(({ body }) => body)
+          .then(_.first),
     },
     shows: {
       type: new GraphQLList(PartnerShow.type),
@@ -701,7 +703,7 @@ export const artworkFields = () => {
           size,
           sort,
           at_a_fair,
-        }),
+        }).then(({ body }) => body),
     },
     signature: markdown(({ signature }) =>
       signature.replace(/^signature:\s+/i, "")

--- a/src/schema/show.js
+++ b/src/schema/show.js
@@ -1,6 +1,6 @@
 import moment from "moment"
 import { pageable } from "relay-cursor-paging"
-import { connectionFromArraySlice, connectionDefinitions } from "graphql-relay"
+import { connectionFromArraySlice } from "graphql-relay"
 import { isExisty, exclude, existyValue, parseRelayOptions } from "lib/helpers"
 import { find } from "lodash"
 import HTTPError from "lib/http_error"
@@ -17,6 +17,7 @@ import Artwork, { artworkConnection } from "./artwork"
 import Location from "./location"
 import Image, { getDefault } from "./image"
 import PartnerShowEventType from "./partner_show_event"
+import { connectionWithCursorInfo } from "schema/fields/pagination"
 import { GravityIDFields, NodeInterface } from "./object_identification"
 import {
   GraphQLObjectType,
@@ -425,6 +426,4 @@ const Show = {
   },
 }
 export default Show
-export const showConnection = connectionDefinitions({
-  nodeType: Show.type,
-}).connectionType
+export const showConnection = connectionWithCursorInfo(ShowType)


### PR DESCRIPTION
This adds a proper connection for shows with the cursor info we added for articles, auction results, and filter artworks.

I refactored a bit- moved all the 'related shows' stuff out of the artist index, and into its own file.