### PR TITLE
@damassi => Related artists pagination

### DIFF
--- a/src/schema/artist/__tests__/related.test.js
+++ b/src/schema/artist/__tests__/related.test.js
@@ -1,0 +1,112 @@
+/* eslint-disable promise/always-return */
+import { runQuery } from "test/utils"
+
+describe("Artist type", () => {
+  const artist = {
+    id: "percy-z",
+    birthday: "2012",
+  }
+
+  const artistsResponse = {
+    headers: { "x-total-count": 35 },
+    body: [{ id: "percy-z", birthday: "2012" }],
+  }
+  const loader = jest.fn().mockReturnValue(Promise.resolve(artistsResponse))
+
+  const artistLoader = () => Promise.resolve(artist)
+  const rootValue = {
+    relatedContemporaryArtistsLoader: loader,
+    relatedMainArtistsLoader: loader,
+    artistLoader,
+  }
+
+  it("returns contemporary artists", () => {
+    const query = `
+      {
+        artist(id: "percy-z") {
+          related {
+            contemporary(first: 10) {
+              pageCursors {
+                first {
+                  page
+                }
+                around {
+                  page
+                }
+                last {
+                  page
+                }
+              }
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+
+    return runQuery(query, rootValue).then(
+      ({ artist: { related: { contemporary: { pageCursors, edges } } } }) => {
+        // Check expected page cursors exist in response.
+        const { first, around, last } = pageCursors
+        expect(first).toEqual(null)
+        expect(last).toEqual(null)
+        expect(around.length).toEqual(4)
+        let index
+        for (index = 0; index < 4; index++) {
+          expect(around[index].page).toBe(index + 1)
+        }
+        // Check auction result included in edges.
+        expect(edges[0].node.id).toEqual("percy-z")
+      }
+    )
+  })
+
+  it("returns main related artists", () => {
+    const query = `
+      {
+        artist(id: "percy-z") {
+          related {
+            main(first: 10) {
+              pageCursors {
+                first {
+                  page
+                }
+                around {
+                  page
+                }
+                last {
+                  page
+                }
+              }
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+
+    return runQuery(query, rootValue).then(
+      ({ artist: { related: { main: { pageCursors, edges } } } }) => {
+        // Check expected page cursors exist in response.
+        const { first, around, last } = pageCursors
+        expect(first).toEqual(null)
+        expect(last).toEqual(null)
+        expect(around.length).toEqual(4)
+        let index
+        for (index = 0; index < 4; index++) {
+          expect(around[index].page).toBe(index + 1)
+        }
+        // Check auction result included in edges.
+        expect(edges[0].node.id).toEqual("percy-z")
+      }
+    )
+  })
+})

--- a/src/schema/artist/related.js
+++ b/src/schema/artist/related.js
@@ -1,0 +1,127 @@
+import { GraphQLBoolean, GraphQLObjectType } from "graphql"
+import { pageable, getPagingParameters } from "relay-cursor-paging"
+import { SuggestedArtistsArgs } from "schema/me/suggested_artists_args"
+import { artistConnection } from "schema/artist"
+import { parseRelayOptions } from "lib/helpers"
+import { createPageCursors } from "schema/fields/pagination"
+import { assign } from "lodash"
+import { connectionFromArraySlice } from "graphql-relay"
+
+export const RelatedArtists = {
+  type: new GraphQLObjectType({
+    name: "RelatedArtists",
+    fields: () => ({
+      contemporary: {
+        type: artistConnection,
+        args: pageable({
+          exclude_artists_without_artworks: {
+            type: GraphQLBoolean,
+            defaultValue: true,
+          },
+        }),
+        resolve: (
+          { id },
+          args,
+          _request,
+          { rootValue: { relatedContemporaryArtistsLoader } }
+        ) => {
+          const { page, size, offset } = parseRelayOptions(args)
+          const { exclude_artists_without_artworks } = args
+          const gravityArgs = {
+            page,
+            size,
+            artist: [id],
+            total_count: true,
+            exclude_artists_without_artworks,
+          }
+
+          return relatedContemporaryArtistsLoader(gravityArgs).then(
+            ({ body, headers }) => {
+              const totalCount = headers["x-total-count"]
+              const pageCursors = createPageCursors({ page, size }, totalCount)
+
+              return assign({
+                pageCursors,
+                ...connectionFromArraySlice(body, args, {
+                  arrayLength: totalCount,
+                  sliceStart: offset,
+                }),
+              })
+            }
+          )
+        },
+      },
+      main: {
+        type: artistConnection,
+        args: pageable({
+          exclude_artists_without_artworks: {
+            type: GraphQLBoolean,
+            defaultValue: true,
+          },
+        }),
+        resolve: (
+          { id },
+          args,
+          _request,
+          { rootValue: { relatedMainArtistsLoader } }
+        ) => {
+          const { page, size, offset } = parseRelayOptions(args)
+          const { exclude_artists_without_artworks } = args
+          const gravityArgs = {
+            page,
+            size,
+            artist: [id],
+            total_count: true,
+            exclude_artists_without_artworks,
+          }
+
+          return relatedMainArtistsLoader(gravityArgs).then(
+            ({ body, headers }) => {
+              const totalCount = headers["x-total-count"]
+              const pageCursors = createPageCursors({ page, size }, totalCount)
+              debugger
+              return assign({
+                pageCursors,
+                ...connectionFromArraySlice(body, args, {
+                  arrayLength: totalCount,
+                  sliceStart: offset,
+                }),
+              })
+            }
+          )
+        },
+      },
+      suggested: {
+        type: artistConnection,
+        args: pageable(SuggestedArtistsArgs),
+        description:
+          "A list of the current user’s suggested artists, based on a single artist",
+        resolve: (
+          { id },
+          options,
+          request,
+          { rootValue: { suggestedArtistsLoader } }
+        ) => {
+          if (!suggestedArtistsLoader) return null
+          const { offset } = getPagingParameters(options)
+          const gravityOptions = assign(
+            { artist_id: id, total_count: true },
+            options,
+            {}
+          )
+          return suggestedArtistsLoader(gravityOptions).then(
+            ({ body, headers }) => {
+              const suggestedArtists = body
+              const totalCount = headers["x-total-count"]
+              return connectionFromArraySlice(suggestedArtists, options, {
+                arrayLength: totalCount,
+                sliceStart: offset,
+              })
+            }
+          )
+        },
+      },
+    }),
+  }),
+  resolve: artist => artist,
+}


### PR DESCRIPTION
This should be the last pagination we need, for `main` and `contemporary` related artists.

We already had a `related` field for an artist w/ `suggested` artists, so I added `main` and `contemporary` there as well.
```
artist {
  related {
    suggested {
      ...
     }
    main {
      ...
    }
    contemporary {
      ...
    }
  }
}
```

