### PR TITLE
hotfix - use tcp health check to bypass force-ssl middleware

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -35,9 +35,8 @@ spec:
             cpu: "1"
             memory: "768Mi"
         readinessProbe:
-          httpGet:
+          tcpSocket:
             port: 3000
-            path: /health
           initialDelaySeconds: 5
           periodSeconds: 5
       affinity:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -35,9 +35,8 @@ spec:
             cpu: "0.5"
             memory: "768Mi"
         readinessProbe:
-          httpGet:
+          tcpSocket:
             port: 3000
-            path: /health
           initialDelaySeconds: 5
           periodSeconds: 5
       affinity:


### PR DESCRIPTION
Express [force-ssl middleware](https://www.npmjs.com/package/express-force-ssl) is causing the health check route to return a 301 redirect when hit via the Kubernetes readiness probe.

The middleware doesn't appear to allow you to disable for certain routes.  Until we fix use a tcp probe on port 3000 for a readiness check.