### PR TITLE
Fix Http health checks

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -38,6 +38,9 @@ spec:
           httpGet:
             port: 3000
             path: /health
+            httpHeaders:
+            - name: X-FORWARDED-PROTO
+              value: https
           initialDelaySeconds: 5
           periodSeconds: 5
       affinity:

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -35,8 +35,9 @@ spec:
             cpu: "1"
             memory: "768Mi"
         readinessProbe:
-          tcpSocket:
+          httpGet:
             port: 3000
+            path: /health
           initialDelaySeconds: 5
           periodSeconds: 5
       affinity:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -38,6 +38,9 @@ spec:
           httpGet:
             port: 3000
             path: /health
+            httpHeaders:
+            - name: X-FORWARDED-PROTO
+              value: https
           initialDelaySeconds: 5
           periodSeconds: 5
       affinity:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -35,8 +35,9 @@ spec:
             cpu: "0.5"
             memory: "768Mi"
         readinessProbe:
-          tcpSocket:
+          httpGet:
             port: 3000
+            path: /health
           initialDelaySeconds: 5
           periodSeconds: 5
       affinity:


### PR DESCRIPTION
Set `X-FORWARDED-PROTO:https` header to bypass redirect to https on the health check