### PR TITLE
updated sale_message to include Permanent Collection

### DIFF
--- a/src/schema/artwork/__tests__/artwork.test.js
+++ b/src/schema/artwork/__tests__/artwork.test.js
@@ -489,7 +489,7 @@ describe("Artwork type", () => {
       })
     })
 
-    it("returns null if work is part of permanent collection", () => {
+    it("returns Permanent Collection if work is part of permanent collection", () => {
       artwork.sale_message = "for sale"
       artwork.availability = "permanent collection"
 
@@ -497,7 +497,7 @@ describe("Artwork type", () => {
         expect(data).toEqual({
           artwork: {
             id: "richard-prince-untitled-portrait",
-            sale_message: null,
+            sale_message: "Permanent collection",
           },
         })
       })

--- a/src/schema/artwork/index.js
+++ b/src/schema/artwork/index.js
@@ -612,16 +612,20 @@ export const artworkFields = () => {
     sale_message: {
       type: GraphQLString,
       resolve: ({ sale_message, availability, availability_hidden, price }) => {
-        // Don't display anything if availability is hidden, or it is not for sale
-        // or in a permanent collection (generally institutional).
-        if (availability_hidden) {
+        // Don't display anything if availability is hidden, or artwork is not for sale.
+        if (availability_hidden || availability === "not for sale") {
           return null
         }
-        if (
-          availability === "not for sale" ||
-          availability === "permanent collection"
-        ) {
-          return null
+
+        // If permanent collection, on loan or sold, just return those, do not include price.
+        if (availability === "permanent collection") {
+          return "Permanent collection"
+        }
+        if (availability === "on loan") {
+          return "On loan"
+        }
+        if (sale_message && sale_message.indexOf("Sold") > -1) {
+          return "Sold"
         }
 
         // If on hold, prepend the price (if there is one).
@@ -632,13 +636,6 @@ export const artworkFields = () => {
           return "On hold"
         }
 
-        // If on loan or sold, just return those, do not include price.
-        if (availability === "on loan") {
-          return "On loan"
-        }
-        if (sale_message && sale_message.indexOf("Sold") > -1) {
-          return "Sold"
-        }
         return sale_message
       },
     },


### PR DESCRIPTION
This I *think* will allow us to rely only on `sale_message` and `is_inquireable` to display all the variations of availability+price from those designs: https://app.zeplin.io/project/5b113f413ede4bb10dbfdc42/screen/5b114000413156335e285483

Should not affect any current force displays because we are checking availability there directly before looking as `sale_message`