### PR TITLE
set span resource names explicitly

### DIFF
--- a/src/lib/cache.js
+++ b/src/lib/cache.js
@@ -145,19 +145,22 @@ function finishSpan(span, promise) {
 
 export default {
   get: key => {
-    return cacheTracer("get").then(span => {
+    return cacheTracer().then(span => {
+      span.setTag("resource.name", "get")
       return finishSpan(span, _get(key))
     })
   },
 
   set: (key, data) => {
-    return cacheTracer("set").then(span => {
+    return cacheTracer().then(span => {
+      span.setTag("resource.name", "set")
       return finishSpan(span, _set(key, data))
     })
   },
 
   delete: key => {
-    return cacheTracer("delete").then(span => {
+    return cacheTracer().then(span => {
+      span.setTag("resource.name", "delete")
       return finishSpan(span, _delete(key))
     })
   },

--- a/src/lib/tracer.js
+++ b/src/lib/tracer.js
@@ -13,8 +13,8 @@ tracer.use("http", {
   service: DD_TRACER_SERVICE_NAME + ".http-client",
 })
 
-export function cacheTracer(resource) {
-  return tracer.trace("cache." + resource, {
+export function cacheTracer() {
+  return tracer.trace("cache", {
     service: DD_TRACER_SERVICE_NAME + ".memcached"
   })
 }


### PR DESCRIPTION
Try to get Datadog resource names set correctly as they do in plugins https://github.com/DataDog/dd-trace-js/blob/master/src/plugins/redis.js#L39  cc @alloy 