### PR TITLE
add loop metrics

### DIFF
--- a/src/lib/stats.js
+++ b/src/lib/stats.js
@@ -1,43 +1,61 @@
-import os from 'os'
+import os from "os"
 import _ from "lodash"
 import StatsD from "hot-shots"
 import config from "config"
 import { error } from "./loggers"
 
-const {
-  NODE_ENV,
-  ENABLE_METRICS,
-  STATSD_HOST,
-  STATSD_PORT,
-} = config
+const { NODE_ENV, ENABLE_METRICS, STATSD_HOST, STATSD_PORT } = config
 
 const isTest = NODE_ENV === "test"
 const enableMetrics = ENABLE_METRICS === "true"
-const appMetricsDisable = ["http", "http-outbound", "mongo", "socketio", "mqlight", "postgresql", "mqtt", "mysql", "redis", "riak", "memcached", "oracledb", "oracle", "strong-oracle"]
+const appMetricsDisable = [
+  "http",
+  "http-outbound",
+  "mongo",
+  "socketio",
+  "mqlight",
+  "postgresql",
+  "mqtt",
+  "mysql",
+  "redis",
+  "riak",
+  "memcached",
+  "oracledb",
+  "oracle",
+  "strong-oracle",
+]
 
 export const statsClient = new StatsD({
   host: STATSD_HOST,
   port: STATSD_PORT,
-  globalTags: { service: 'metaphysics', hostname: os.hostname() },
+  globalTags: { service: "metaphysics", hostname: os.hostname() },
   mock: isTest,
-  errorHandler: function (err) {
-    error(`Statsd client error ${err}`);
-  }
+  errorHandler: function(err) {
+    error(`Statsd client error ${err}`)
+  },
 })
 
 if (enableMetrics && !isTest) {
   const appmetrics = require("appmetrics")
   appmetrics.configure({
-    mqtt: 'off'
+    mqtt: "off",
   })
   const monitoring = appmetrics.monitor()
   _.forEach(appMetricsDisable, (val, idx) => {
     appmetrics.disable(val)
   })
 
-  monitoring.on('eventloop', (eventloopMetrics) => {
-    statsClient.timing('eventloop.latency.min', eventloopMetrics.latency.min)
-    statsClient.timing('eventloop.latency.max', eventloopMetrics.latency.max)
-    statsClient.timing('eventloop.latency.avg', eventloopMetrics.latency.avg)
+  monitoring.on("loop", loopMetrics => {
+    statsClient.histogram("loop.count_per_five_seconds", loopMetrics.count)
+    statsClient.histogram("loop.minimum_loop_duration", loopMetrics.minimum)
+    statsClient.histogram("loop.maximum_loop_duration", loopMetrics.maximum)
+    statsClient.histogram("loop.cpu_usage_in_userland", loopMetrics.cpu_user)
+    statsClient.histogram("loop.cpu_usage_in_system", loopMetrics.cpu_system)
+  })
+
+  monitoring.on("eventloop", eventloopMetrics => {
+    statsClient.timing("eventloop.latency.min", eventloopMetrics.latency.min)
+    statsClient.timing("eventloop.latency.max", eventloopMetrics.latency.max)
+    statsClient.timing("eventloop.latency.avg", eventloopMetrics.latency.avg)
   })
 }

--- a/src/lib/stats.js
+++ b/src/lib/stats.js
@@ -46,11 +46,11 @@ if (enableMetrics && !isTest) {
   })
 
   monitoring.on("loop", loopMetrics => {
-    statsClient.histogram("loop.count_per_five_seconds", loopMetrics.count)
-    statsClient.histogram("loop.minimum_loop_duration", loopMetrics.minimum)
-    statsClient.histogram("loop.maximum_loop_duration", loopMetrics.maximum)
-    statsClient.histogram("loop.cpu_usage_in_userland", loopMetrics.cpu_user)
-    statsClient.histogram("loop.cpu_usage_in_system", loopMetrics.cpu_system)
+    statsClient.timing("loop.count_per_five_seconds", loopMetrics.count)
+    statsClient.timing("loop.minimum_loop_duration", loopMetrics.minimum)
+    statsClient.timing("loop.maximum_loop_duration", loopMetrics.maximum)
+    statsClient.timing("loop.cpu_usage_in_userland", loopMetrics.cpu_user)
+    statsClient.timing("loop.cpu_usage_in_system", loopMetrics.cpu_system)
   })
 
   monitoring.on("eventloop", eventloopMetrics => {


### PR DESCRIPTION
`loop` gives us actual timings where `eventLoop` gives us latencies. This PR adds loop timing data to our log, which also includes CPU usage both in user land and in system land during the measured period.

I'm writing this all to histograms, which feels right but may not be the most useful?