### PR TITLE
@damassi => Auction result tweaks for integration into new page

### DIFF
--- a/src/schema/__tests__/auction_results.test.js
+++ b/src/schema/__tests__/auction_results.test.js
@@ -1,7 +1,5 @@
 /* eslint-disable promise/always-return */
-import {
-  runQuery
-} from "test/utils"
+import { runQuery } from "test/utils"
 
 describe("Artist type", () => {
   let artist = null
@@ -18,22 +16,26 @@ describe("Artist type", () => {
     const auctionResultResponse = {
       total_count: 35,
       _embedded: {
-        items: [{
-          dimension_text: "20 x 20",
-          organization: "Christie's",
-          category_text: "an old guitar",
-          sale_date: "yesterday",
-          id: "1",
-          images: [{
-            thumbnail: "https://path.to.thumbnail.jpg",
-            larger: "https://path.to.larger.jpg",
-          }, ],
-          currency: "JPY",
-          price_realized_cents: 420000,
-          price_realized_cents_usd: 100000,
-          low_estimate_cents: 200000,
-          high_estimate_cents: 500000,
-        }, ],
+        items: [
+          {
+            dimension_text: "20 x 20",
+            organization: "Christie's",
+            category_text: "an old guitar",
+            sale_date: "yesterday",
+            id: "1",
+            images: [
+              {
+                thumbnail: "https://path.to.thumbnail.jpg",
+                larger: "https://path.to.larger.jpg",
+              },
+            ],
+            currency: "JPY",
+            price_realized_cents: 420000,
+            price_realized_cents_usd: 100000,
+            low_estimate_cents: 200000,
+            high_estimate_cents: 500000,
+          },
+        ],
       },
     }
 
@@ -84,28 +86,30 @@ describe("Artist type", () => {
       expect(data).toEqual({
         artist: {
           auctionResults: {
-            edges: [{
-              node: {
-                category_text: "an old guitar",
-                images: {
-                  thumbnail: {
-                    image_url: "https://path.to.thumbnail.jpg",
+            edges: [
+              {
+                node: {
+                  category_text: "an old guitar",
+                  images: {
+                    thumbnail: {
+                      image_url: "https://path.to.thumbnail.jpg",
+                    },
+                    larger: {
+                      image_url: "https://path.to.larger.jpg",
+                    },
                   },
-                  larger: {
-                    image_url: "https://path.to.larger.jpg",
+                  currency: "JPY",
+                  price_realized: {
+                    cents: 420000,
+                    cents_usd: 100000,
+                    display: "JPY ¥420k",
+                  },
+                  estimate: {
+                    display: "JPY ¥200,000 - 500,000",
                   },
                 },
-                currency: "JPY",
-                price_realized: {
-                  cents: 420000,
-                  cents_usd: 100000,
-                  display: "JPY ¥420k",
-                },
-                estimate: {
-                  display: "JPY ¥200,000 - 500,000"
-                }
               },
-            }, ],
+            ],
           },
         },
       })
@@ -139,20 +143,9 @@ describe("Artist type", () => {
     `
 
     return runQuery(query, rootValue).then(
-      ({
-        artist: {
-          auctionResults: {
-            pageCursors,
-            edges
-          }
-        }
-      }) => {
+      ({ artist: { auctionResults: { pageCursors, edges } } }) => {
         // Check expected page cursors exist in response.
-        const {
-          first,
-          around,
-          last
-        } = pageCursors
+        const { first, around, last } = pageCursors
         expect(first).toEqual(null)
         expect(last).toEqual(null)
         expect(around.length).toEqual(4)
@@ -183,13 +176,8 @@ describe("Artist type", () => {
     return runQuery(query, rootValue).then(
       ({
         artist: {
-          auctionResults: {
-            pageInfo: {
-              hasNextPage,
-              hasPreviousPage
-            }
-          }
-        }
+          auctionResults: { pageInfo: { hasNextPage, hasPreviousPage } },
+        },
       }) => {
         expect(hasNextPage).toBe(true)
         expect(hasPreviousPage).toBe(true)

--- a/src/schema/artist/index.js
+++ b/src/schema/artist/index.js
@@ -1,15 +1,33 @@
-// @ts-check
-
-import { pageable, getPagingParameters } from "relay-cursor-paging"
-import { assign, compact, defaults, first, omit, includes } from "lodash"
-import { exclude } from "lib/helpers"
+import {
+  pageable,
+  getPagingParameters
+} from "relay-cursor-paging"
+import {
+  assign,
+  compact,
+  defaults,
+  first,
+  omit,
+  includes,
+  merge
+} from "lodash"
+import {
+  exclude
+} from "lib/helpers"
 import cached from "schema/fields/cached"
 import initials from "schema/fields/initials"
-import { markdown, formatMarkdownValue } from "schema/fields/markdown"
+import {
+  markdown,
+  formatMarkdownValue
+} from "schema/fields/markdown"
 import numeral from "schema/fields/numeral"
 import Image from "schema/image"
-import Article, { articleConnection } from "schema/article"
-import Artwork, { artworkConnection } from "schema/artwork"
+import Article, {
+  articleConnection
+} from "schema/article"
+import Artwork, {
+  artworkConnection
+} from "schema/artwork"
 import PartnerArtist from "schema/partner_artist"
 import Meta from "./meta"
 import PartnerShow from "schema/partner_show"
@@ -17,8 +35,12 @@ import {
   PartnerArtistConnection,
   partnersForArtist,
 } from "schema/partner_artist"
-import { GeneType } from "../gene"
-import Show, { showConnection } from "schema/show"
+import {
+  GeneType
+} from "../gene"
+import Show, {
+  showConnection
+} from "schema/show"
 import Sale from "schema/sale/index"
 import ArtworkSorts from "schema/sorts/artwork_sorts"
 import ArticleSorts from "schema/sorts/article_sorts"
@@ -32,15 +54,24 @@ import {
 } from "schema/auction_result"
 import ArtistArtworksFilters from "./artwork_filters"
 import filterArtworks from "schema/filter_artworks"
-import { connectionWithCursorInfo } from "schema/fields/pagination"
-import { RelatedArtists } from "./related"
-import { createPageCursors } from "schema/fields/pagination"
+import {
+  connectionWithCursorInfo
+} from "schema/fields/pagination"
+import {
+  RelatedArtists
+} from "./related"
+import {
+  createPageCursors
+} from "schema/fields/pagination"
 import {
   ShowField,
   showsWithBLacklistedPartnersRemoved,
   ShowsConnectionField,
 } from "./shows"
-import { GravityIDFields, NodeInterface } from "schema/object_identification"
+import {
+  GravityIDFields,
+  NodeInterface
+} from "schema/object_identification"
 import {
   GraphQLObjectType,
   GraphQLBoolean,
@@ -49,9 +80,15 @@ import {
   GraphQLList,
   GraphQLInt,
 } from "graphql"
-import { connectionFromArraySlice } from "graphql-relay"
-import { parseRelayOptions } from "lib/helpers"
-import { totalViaLoader } from "lib/total"
+import {
+  connectionFromArraySlice
+} from "graphql-relay"
+import {
+  parseRelayOptions
+} from "lib/helpers"
+import {
+  totalViaLoader
+} from "lib/total"
 
 // Manually curated list of artist id's who has verified auction lots that can be
 // returned, when queried for via `recordsTrusted: true`.
@@ -77,7 +114,9 @@ export const ArtistType = new GraphQLObjectType({
     return {
       ...GravityIDFields,
       cached,
-      alternate_names: { type: new GraphQLList(GraphQLString) },
+      alternate_names: {
+        type: new GraphQLList(GraphQLString)
+      },
       articlesConnection: {
         args: pageable({
           sort: ArticleSorts,
@@ -89,11 +128,15 @@ export const ArtistType = new GraphQLObjectType({
           },
         }),
         type: articleConnection,
-        resolve: (
-          { _id },
+        resolve: ({
+            _id
+          },
           args,
-          _request,
-          { rootValue: { articlesLoader } }
+          _request, {
+            rootValue: {
+              articlesLoader
+            }
+          }
         ) => {
           const relayOptions = parseRelayOptions(args)
           const gravityArgs = omit(args, ["first", "after", "last", "before"])
@@ -103,9 +146,13 @@ export const ArtistType = new GraphQLObjectType({
               published: true,
               count: true,
             })
-          ).then(({ results, count }) => {
-            return assign(
-              { pageCursors: createPageCursors(relayOptions, count) },
+          ).then(({
+            results,
+            count
+          }) => {
+            return assign({
+                pageCursors: createPageCursors(relayOptions, count)
+              },
               connectionFromArraySlice(results, args, {
                 arrayLength: count,
                 sliceStart: relayOptions.offset,
@@ -117,22 +164,32 @@ export const ArtistType = new GraphQLObjectType({
       articles: {
         args: {
           sort: ArticleSorts,
-          limit: { type: GraphQLInt },
-          in_editorial_feed: { type: GraphQLBoolean },
+          limit: {
+            type: GraphQLInt
+          },
+          in_editorial_feed: {
+            type: GraphQLBoolean
+          },
         },
         type: new GraphQLList(Article.type),
-        resolve: (
-          { _id },
-          options,
-          request,
-          { rootValue: { articlesLoader } }
-        ) =>
+        resolve: ({
+              _id
+            },
+            options,
+            request, {
+              rootValue: {
+                articlesLoader
+              }
+            }
+          ) =>
           articlesLoader(
             defaults(options, {
               artist_id: _id,
               published: true,
             })
-          ).then(({ results }) => results),
+          ).then(({
+            results
+          }) => results),
       },
       artists: {
         type: new GraphQLList(Artist.type),
@@ -146,17 +203,23 @@ export const ArtistType = new GraphQLObjectType({
             defaultValue: true,
           },
         },
-        resolve: (
-          { id },
-          options,
-          request,
-          { rootValue: { relatedMainArtistsLoader } }
-        ) =>
+        resolve: ({
+              id
+            },
+            options,
+            request, {
+              rootValue: {
+                relatedMainArtistsLoader
+              }
+            }
+          ) =>
           relatedMainArtistsLoader(
             defaults(options, {
               artist: [id],
             })
-          ).then(({ body }) => body),
+          ).then(({
+            body
+          }) => body),
       },
       artworks: {
         type: new GraphQLList(Artwork.type),
@@ -165,18 +228,31 @@ export const ArtistType = new GraphQLObjectType({
             type: GraphQLInt,
             description: "The number of Artworks to return",
           },
-          page: { type: GraphQLInt },
+          page: {
+            type: GraphQLInt
+          },
           sort: ArtworkSorts,
-          published: { type: GraphQLBoolean, defaultValue: true },
-          filter: { type: new GraphQLList(ArtistArtworksFilters) },
-          exclude: { type: new GraphQLList(GraphQLString) },
+          published: {
+            type: GraphQLBoolean,
+            defaultValue: true
+          },
+          filter: {
+            type: new GraphQLList(ArtistArtworksFilters)
+          },
+          exclude: {
+            type: new GraphQLList(GraphQLString)
+          },
         },
-        resolve: (
-          { id },
-          options,
-          request,
-          { rootValue: { artistArtworksLoader } }
-        ) =>
+        resolve: ({
+              id
+            },
+            options,
+            request, {
+              rootValue: {
+                artistArtworksLoader
+              }
+            }
+          ) =>
           artistArtworksLoader(id, options).then(
             exclude(options.exclude, "id")
           ),
@@ -196,14 +272,30 @@ export const ArtistType = new GraphQLObjectType({
         resolve: (
           artist,
           options,
-          request,
-          { rootValue: { artistArtworksLoader } }
+          request, {
+            rootValue: {
+              artistArtworksLoader
+            }
+          }
         ) => {
           // Convert `after` cursors to page params
-          const { limit: size, offset } = getPagingParameters(options)
+          const {
+            limit: size,
+            offset
+          } = getPagingParameters(options)
           // Construct an object of all the params gravity will listen to
-          const { sort, filter, published } = options
-          const gravityArgs = { size, offset, sort, filter, published }
+          const {
+            sort,
+            filter,
+            published
+          } = options
+          const gravityArgs = {
+            size,
+            offset,
+            sort,
+            filter,
+            published
+          }
           return artistArtworksLoader(artist.id, gravityArgs).then(artworks =>
             connectionFromArraySlice(artworks, options, {
               arrayLength: artistArtworkArrayLength(artist, filter),
@@ -219,22 +311,29 @@ export const ArtistType = new GraphQLObjectType({
           recordsTrusted: {
             type: GraphQLBoolean,
             defaultValue: false,
-            description:
-              "When true, will only return records for whitelisted artists.",
+            description: "When true, will only return records for whitelisted artists.",
           },
         }),
-        resolve: (
-          { _id },
+        resolve: ({
+            _id
+          },
           options,
-          _request,
-          { rootValue: { auctionLotLoader } }
+          _request, {
+            rootValue: {
+              auctionLotLoader
+            }
+          }
         ) => {
           if (options.recordsTrusted && !includes(auctionRecordsTrusted, _id)) {
             return null
           }
 
           // Convert `after` cursors to page params
-          const { page, size, offset } = parseRelayOptions(options)
+          const {
+            page,
+            size,
+            offset
+          } = parseRelayOptions(options)
           const diffusionArgs = {
             page,
             size,
@@ -242,23 +341,38 @@ export const ArtistType = new GraphQLObjectType({
             sort: options.sort,
           }
           return auctionLotLoader(diffusionArgs).then(
-            ({ total_count, _embedded }) => {
-              return assign(
-                {
-                  pageCursors: createPageCursors({ page, size }, total_count),
+            ({
+              total_count,
+              _embedded
+            }) => {
+              const totalPages = Math.ceil(total_count / size)
+              return merge({
+                  pageCursors: createPageCursors({
+                    page,
+                    size
+                  }, total_count),
                 },
                 connectionFromArraySlice(_embedded.items, options, {
                   arrayLength: total_count,
                   sliceStart: offset,
-                })
+                }), {
+                  pageInfo: {
+                    hasPreviousPage: page > 1,
+                    hasNextPage: page < totalPages
+                  }
+                }
               )
-            }
-          )
+            })
         },
       },
       bio: {
         type: GraphQLString,
-        resolve: ({ nationality, years, hometown, location }) => {
+        resolve: ({
+          nationality,
+          years,
+          hometown,
+          location
+        }) => {
           return compact([
             nationality,
             years,
@@ -270,12 +384,16 @@ export const ArtistType = new GraphQLObjectType({
       biography: {
         type: Article.type,
         description: "The Artist biography article written by Artsy",
-        resolve: (
-          { _id },
-          options,
-          request,
-          { rootValue: { articlesLoader } }
-        ) =>
+        resolve: ({
+              _id
+            },
+            options,
+            request, {
+              rootValue: {
+                articlesLoader
+              }
+            }
+          ) =>
           articlesLoader({
             published: true,
             biography_for_artist_id: _id,
@@ -283,8 +401,7 @@ export const ArtistType = new GraphQLObjectType({
           }).then(articles => first(articles.results)),
       },
       biography_blurb: {
-        args: assign(
-          {
+        args: assign({
             partner_bio: {
               type: GraphQLBoolean,
               description: "If true, will return featured bio over Artsy one.",
@@ -298,50 +415,75 @@ export const ArtistType = new GraphQLObjectType({
           fields: {
             credit: {
               type: GraphQLString,
-              resolve: ({ credit }) => credit,
+              resolve: ({
+                credit
+              }) => credit,
             },
             text: {
               type: GraphQLString,
-              resolve: ({ text }) => text,
+              resolve: ({
+                text
+              }) => text,
             },
             partner_id: {
               type: GraphQLString,
-              resolve: ({ partner_id }) => partner_id,
-              description:
-                "The partner id of the partner who submitted the featured bio.",
+              resolve: ({
+                partner_id
+              }) => partner_id,
+              description: "The partner id of the partner who submitted the featured bio.",
             },
           },
         }),
-        resolve: (
-          { blurb, id },
-          { format, partner_bio },
-          request,
-          { rootValue: { partnerArtistsForArtistLoader } }
+        resolve: ({
+            blurb,
+            id
+          }, {
+            format,
+            partner_bio
+          },
+          request, {
+            rootValue: {
+              partnerArtistsForArtistLoader
+            }
+          }
         ) => {
           if (!partner_bio && blurb && blurb.length) {
-            return { text: formatMarkdownValue(blurb, format) }
+            return {
+              text: formatMarkdownValue(blurb, format)
+            }
           }
           return partnerArtistsForArtistLoader(id, {
             size: 1,
             featured: true,
           }).then(partner_artists => {
             if (partner_artists && partner_artists.length) {
-              const { biography, partner } = first(partner_artists)
+              const {
+                biography,
+                partner
+              } = first(partner_artists)
               return {
                 text: formatMarkdownValue(biography, format),
                 credit: `Submitted by ${partner.name}`,
                 partner_id: partner.id,
               }
             }
-            return { text: formatMarkdownValue(blurb, format) }
+            return {
+              text: formatMarkdownValue(blurb, format)
+            }
           })
         },
       },
-      birthday: { type: GraphQLString },
+      birthday: {
+        type: GraphQLString
+      },
       blurb: {
         args: markdown().args,
         type: GraphQLString,
-        resolve: ({ blurb }, { format }) => {
+        resolve: ({
+          blurb
+        }, {
+          format
+        }) => {
           if (blurb.length) {
             return formatMarkdownValue(blurb, format)
           }
@@ -350,7 +492,9 @@ export const ArtistType = new GraphQLObjectType({
       carousel: ArtistCarousel,
       collections: {
         type: new GraphQLList(GraphQLString),
-        resolve: ({ collections }) => {
+        resolve: ({
+          collections
+        }) => {
           if (!collections) {
             return null
           }
@@ -369,17 +513,23 @@ export const ArtistType = new GraphQLObjectType({
             defaultValue: true,
           },
         },
-        resolve: (
-          { id },
-          options,
-          request,
-          { rootValue: { relatedContemporaryArtistsLoader } }
-        ) =>
+        resolve: ({
+              id
+            },
+            options,
+            request, {
+              rootValue: {
+                relatedContemporaryArtistsLoader
+              }
+            }
+          ) =>
           relatedContemporaryArtistsLoader(
             defaults(options, {
               artist: [id],
             })
-          ).then(({ body }) => body),
+          ).then(({
+            body
+          }) => body),
       },
       consignable: {
         type: GraphQLBoolean,
@@ -390,27 +540,37 @@ export const ArtistType = new GraphQLObjectType({
           name: "ArtistCounts",
           fields: {
             artworks: numeral(
-              ({ published_artworks_count }) => published_artworks_count
+              ({
+                published_artworks_count
+              }) => published_artworks_count
             ),
-            follows: numeral(({ follow_count }) => follow_count),
+            follows: numeral(({
+              follow_count
+            }) => follow_count),
             for_sale_artworks: numeral(
-              ({ forsale_artworks_count }) => forsale_artworks_count
+              ({
+                forsale_artworks_count
+              }) => forsale_artworks_count
             ),
             partner_shows: numeral(
-              ({ partner_shows_count }) => partner_shows_count
+              ({
+                partner_shows_count
+              }) => partner_shows_count
             ),
             related_artists: {
               type: GraphQLInt,
-              resolve: (
-                { id },
+              resolve: ({
+                  id
+                },
                 _options,
-                _request,
-                { rootValue: { relatedMainArtistsLoader } }
+                _request, {
+                  rootValue: {
+                    relatedMainArtistsLoader
+                  }
+                }
               ) => {
                 return totalViaLoader(
-                  relatedMainArtistsLoader,
-                  {},
-                  {
+                  relatedMainArtistsLoader, {}, {
                     artist: [id],
                   }
                 )
@@ -418,24 +578,32 @@ export const ArtistType = new GraphQLObjectType({
             },
             articles: {
               type: GraphQLInt,
-              resolve: (
-                { _id },
-                _options,
-                _request,
-                { rootValue: { articlesLoader } }
-              ) =>
+              resolve: ({
+                    _id
+                  },
+                  _options,
+                  _request, {
+                    rootValue: {
+                      articlesLoader
+                    }
+                  }
+                ) =>
                 articlesLoader({
                   artist_id: _id,
                   published: true,
                   limit: 0,
                   count: true,
-                }).then(({ count }) => count),
+                }).then(({
+                  count
+                }) => count),
             },
           },
         }),
         resolve: artist => artist,
       },
-      deathday: { type: GraphQLString },
+      deathday: {
+        type: GraphQLString
+      },
       display_auction_link: {
         type: GraphQLBoolean,
         deprecationReason: "Favor `is_`-prefixed boolean attributes",
@@ -449,13 +617,16 @@ export const ArtistType = new GraphQLObjectType({
           },
         },
         type: new GraphQLList(Show.type),
-        description:
-          "Custom-sorted list of shows for an artist, in order of significance.",
-        resolve: (
-          { id },
+        description: "Custom-sorted list of shows for an artist, in order of significance.",
+        resolve: ({
+            id
+          },
           options,
-          request,
-          { rootValue: { relatedShowsLoader } }
+          request, {
+            rootValue: {
+              relatedShowsLoader
+            }
+          }
         ) => {
           return relatedShowsLoader({
             artist_id: id,
@@ -464,7 +635,9 @@ export const ArtistType = new GraphQLObjectType({
             visible_to_public: false,
             has_location: true,
             size: options.size,
-          }).then(({ body: shows }) =>
+          }).then(({
+              body: shows
+            }) =>
             showsWithBLacklistedPartnersRemoved(shows)
           )
         },
@@ -472,29 +645,34 @@ export const ArtistType = new GraphQLObjectType({
       filtered_artworks: filterArtworks("artist_id"),
       formatted_artworks_count: {
         type: GraphQLString,
-        description:
-          "A string showing the total number of works and those for sale",
-        resolve: ({ published_artworks_count, forsale_artworks_count }) => {
+        description: "A string showing the total number of works and those for sale",
+        resolve: ({
+          published_artworks_count,
+          forsale_artworks_count
+        }) => {
           let totalWorks = null
           if (published_artworks_count) {
             totalWorks =
               published_artworks_count +
               (published_artworks_count > 1 ? " works" : " work")
           }
-          const forSaleWorks = forsale_artworks_count
-            ? forsale_artworks_count + " for sale"
-            : null
-          return forSaleWorks && totalWorks
-            ? totalWorks + ", " + forSaleWorks
-            : totalWorks
+          const forSaleWorks = forsale_artworks_count ?
+            forsale_artworks_count + " for sale" :
+            null
+          return forSaleWorks && totalWorks ?
+            totalWorks + ", " + forSaleWorks :
+            totalWorks
         },
       },
       formatted_nationality_and_birthday: {
         type: GraphQLString,
         description: `A string of the form "Nationality, Birthday (or Birthday-Deathday)"`,
-        resolve: ({ birthday, nationality, deathday }) => {
-          let formatted_bday =
-            !isNaN(birthday) && birthday ? "b. " + birthday : birthday
+        resolve: ({
+          birthday,
+          nationality,
+          deathday
+        }) => {
+          let formatted_bday = !isNaN(birthday) && birthday ? "b. " + birthday : birthday
           formatted_bday =
             formatted_bday && formatted_bday.replace(/born/i, "b.")
 
@@ -513,57 +691,93 @@ export const ArtistType = new GraphQLObjectType({
       genes: {
         description: `A list of genes associated with an artist`,
         type: new GraphQLList(GeneType),
-        resolve: (
-          { id },
+        resolve: ({
+            id
+          },
           options,
-          request,
-          { rootValue: { artistGenesLoader } }
+          request, {
+            rootValue: {
+              artistGenesLoader
+            }
+          }
         ) => {
-          return artistGenesLoader({ id }).then(genes => genes)
+          return artistGenesLoader({
+            id
+          }).then(genes => genes)
         },
       },
-      gender: { type: GraphQLString },
-      href: { type: GraphQLString, resolve: artist => `/artist/${artist.id}` },
+      gender: {
+        type: GraphQLString
+      },
+      href: {
+        type: GraphQLString,
+        resolve: artist => `/artist/${artist.id}`
+      },
       has_metadata: {
         type: GraphQLBoolean,
-        resolve: ({ blurb, nationality, years, hometown, location }) => {
+        resolve: ({
+          blurb,
+          nationality,
+          years,
+          hometown,
+          location
+        }) => {
           return !!(blurb || nationality || years || hometown || location)
         },
       },
-      hometown: { type: GraphQLString },
+      hometown: {
+        type: GraphQLString
+      },
       image: Image,
       initials: initials("name"),
       is_consignable: {
         type: GraphQLBoolean,
-        resolve: ({ consignable }) => consignable,
+        resolve: ({
+          consignable
+        }) => consignable,
       },
       is_display_auction_link: {
         type: GraphQLBoolean,
-        description:
-          "Only specific Artists should show a link to auction results.",
-        resolve: ({ display_auction_link }) => display_auction_link,
+        description: "Only specific Artists should show a link to auction results.",
+        resolve: ({
+          display_auction_link
+        }) => display_auction_link,
       },
       is_followed: {
         type: GraphQLBoolean,
-        resolve: (
-          { id },
-          {},
-          request,
-          { rootValue: { followedArtistLoader } }
+        resolve: ({
+            id
+          }, {},
+          request, {
+            rootValue: {
+              followedArtistLoader
+            }
+          }
         ) => {
           if (!followedArtistLoader) return false
-          return followedArtistLoader(id).then(({ is_followed }) => is_followed)
+          return followedArtistLoader(id).then(({
+            is_followed
+          }) => is_followed)
         },
       },
-      is_public: { type: GraphQLBoolean, resolve: artist => artist.public },
+      is_public: {
+        type: GraphQLBoolean,
+        resolve: artist => artist.public
+      },
       is_shareable: {
         type: GraphQLBoolean,
         resolve: artist => artist.published_artworks_count > 0,
       },
-      location: { type: GraphQLString },
+      location: {
+        type: GraphQLString
+      },
       meta: Meta,
-      nationality: { type: GraphQLString },
-      name: { type: GraphQLString },
+      nationality: {
+        type: GraphQLString
+      },
+      name: {
+        type: GraphQLString
+      },
       partners: {
         type: PartnerArtistConnection,
         args: pageable({
@@ -574,11 +788,15 @@ export const ArtistType = new GraphQLObjectType({
             type: new GraphQLList(GraphQLString),
           },
         }),
-        resolve: (
-          { id: artist_id },
+        resolve: ({
+            id: artist_id
+          },
           options,
-          _request,
-          { rootValue: { partnerArtistsLoader } }
+          _request, {
+            rootValue: {
+              partnerArtistsLoader
+            }
+          }
         ) => {
           return partnersForArtist(artist_id, options, partnerArtistsLoader)
         },
@@ -591,11 +809,15 @@ export const ArtistType = new GraphQLObjectType({
             description: "The number of PartnerArtists to return",
           },
         },
-        resolve: (
-          { id },
+        resolve: ({
+            id
+          },
           options,
-          request,
-          { rootValue: { partnerArtistsForArtistLoader } }
+          request, {
+            rootValue: {
+              partnerArtistsForArtistLoader
+            }
+          }
         ) => partnerArtistsForArtistLoader(id, options),
       },
       partner_shows: {
@@ -611,20 +833,28 @@ export const ArtistType = new GraphQLObjectType({
       sales: {
         type: new GraphQLList(Sale.type),
         args: {
-          live: { type: GraphQLBoolean },
-          is_auction: { type: GraphQLBoolean },
+          live: {
+            type: GraphQLBoolean
+          },
+          is_auction: {
+            type: GraphQLBoolean
+          },
           size: {
             type: GraphQLInt,
             description: "The number of Sales to return",
           },
           sort: SaleSorts,
         },
-        resolve: (
-          { id },
-          options,
-          _request,
-          { rootValue: { relatedSalesLoader } }
-        ) =>
+        resolve: ({
+              id
+            },
+            options,
+            _request, {
+              rootValue: {
+                relatedSalesLoader
+              }
+            }
+          ) =>
           relatedSalesLoader(
             defaults(options, {
               artist_id: id,
@@ -632,16 +862,23 @@ export const ArtistType = new GraphQLObjectType({
             })
           ),
       },
-      shows: { type: new GraphQLList(Show.type), ...ShowField },
-      showsConnection: { type: showConnection, ...ShowsConnectionField },
+      shows: {
+        type: new GraphQLList(Show.type),
+        ...ShowField
+      },
+      showsConnection: {
+        type: showConnection,
+        ...ShowsConnectionField
+      },
       sortable_id: {
         type: GraphQLString,
-        description:
-          "Use this attribute to sort by when sorting a collection of Artists",
+        description: "Use this attribute to sort by when sorting a collection of Artists",
       },
       statuses: ArtistStatuses,
       highlights: ArtistHighlights,
-      years: { type: GraphQLString },
+      years: {
+        type: GraphQLString
+      },
     }
   },
 })
@@ -655,11 +892,15 @@ const Artist = {
       type: new GraphQLNonNull(GraphQLString),
     },
   },
-  resolve: (_root, { id }, _request, resolver) => {
+  resolve: (_root, {
+    id
+  }, _request, resolver) => {
     if (id.length === 0) {
       return null
     }
-    const { artistLoader } = resolver.rootValue
+    const {
+      artistLoader
+    } = resolver.rootValue
     return artistLoader(id)
   },
 }

--- a/src/schema/artist/index.js
+++ b/src/schema/artist/index.js
@@ -1,33 +1,13 @@
-import {
-  pageable,
-  getPagingParameters
-} from "relay-cursor-paging"
-import {
-  assign,
-  compact,
-  defaults,
-  first,
-  omit,
-  includes,
-  merge
-} from "lodash"
-import {
-  exclude
-} from "lib/helpers"
+import { pageable, getPagingParameters } from "relay-cursor-paging"
+import { assign, compact, defaults, first, omit, includes, merge } from "lodash"
+import { exclude } from "lib/helpers"
 import cached from "schema/fields/cached"
 import initials from "schema/fields/initials"
-import {
-  markdown,
-  formatMarkdownValue
-} from "schema/fields/markdown"
+import { markdown, formatMarkdownValue } from "schema/fields/markdown"
 import numeral from "schema/fields/numeral"
 import Image from "schema/image"
-import Article, {
-  articleConnection
-} from "schema/article"
-import Artwork, {
-  artworkConnection
-} from "schema/artwork"
+import Article, { articleConnection } from "schema/article"
+import Artwork, { artworkConnection } from "schema/artwork"
 import PartnerArtist from "schema/partner_artist"
 import Meta from "./meta"
 import PartnerShow from "schema/partner_show"
@@ -35,12 +15,8 @@ import {
   PartnerArtistConnection,
   partnersForArtist,
 } from "schema/partner_artist"
-import {
-  GeneType
-} from "../gene"
-import Show, {
-  showConnection
-} from "schema/show"
+import { GeneType } from "../gene"
+import Show, { showConnection } from "schema/show"
 import Sale from "schema/sale/index"
 import ArtworkSorts from "schema/sorts/artwork_sorts"
 import ArticleSorts from "schema/sorts/article_sorts"
@@ -54,24 +30,15 @@ import {
 } from "schema/auction_result"
 import ArtistArtworksFilters from "./artwork_filters"
 import filterArtworks from "schema/filter_artworks"
-import {
-  connectionWithCursorInfo
-} from "schema/fields/pagination"
-import {
-  RelatedArtists
-} from "./related"
-import {
-  createPageCursors
-} from "schema/fields/pagination"
+import { connectionWithCursorInfo } from "schema/fields/pagination"
+import { RelatedArtists } from "./related"
+import { createPageCursors } from "schema/fields/pagination"
 import {
   ShowField,
   showsWithBLacklistedPartnersRemoved,
   ShowsConnectionField,
 } from "./shows"
-import {
-  GravityIDFields,
-  NodeInterface
-} from "schema/object_identification"
+import { GravityIDFields, NodeInterface } from "schema/object_identification"
 import {
   GraphQLObjectType,
   GraphQLBoolean,
@@ -80,15 +47,9 @@ import {
   GraphQLList,
   GraphQLInt,
 } from "graphql"
-import {
-  connectionFromArraySlice
-} from "graphql-relay"
-import {
-  parseRelayOptions
-} from "lib/helpers"
-import {
-  totalViaLoader
-} from "lib/total"
+import { connectionFromArraySlice } from "graphql-relay"
+import { parseRelayOptions } from "lib/helpers"
+import { totalViaLoader } from "lib/total"
 
 // Manually curated list of artist id's who has verified auction lots that can be
 // returned, when queried for via `recordsTrusted: true`.
@@ -115,7 +76,7 @@ export const ArtistType = new GraphQLObjectType({
       ...GravityIDFields,
       cached,
       alternate_names: {
-        type: new GraphQLList(GraphQLString)
+        type: new GraphQLList(GraphQLString),
       },
       articlesConnection: {
         args: pageable({
@@ -128,15 +89,11 @@ export const ArtistType = new GraphQLObjectType({
           },
         }),
         type: articleConnection,
-        resolve: ({
-            _id
-          },
+        resolve: (
+          { _id },
           args,
-          _request, {
-            rootValue: {
-              articlesLoader
-            }
-          }
+          _request,
+          { rootValue: { articlesLoader } }
         ) => {
           const relayOptions = parseRelayOptions(args)
           const gravityArgs = omit(args, ["first", "after", "last", "before"])
@@ -146,12 +103,10 @@ export const ArtistType = new GraphQLObjectType({
               published: true,
               count: true,
             })
-          ).then(({
-            results,
-            count
-          }) => {
-            return assign({
-                pageCursors: createPageCursors(relayOptions, count)
+          ).then(({ results, count }) => {
+            return assign(
+              {
+                pageCursors: createPageCursors(relayOptions, count),
               },
               connectionFromArraySlice(results, args, {
                 arrayLength: count,
@@ -165,31 +120,25 @@ export const ArtistType = new GraphQLObjectType({
         args: {
           sort: ArticleSorts,
           limit: {
-            type: GraphQLInt
+            type: GraphQLInt,
           },
           in_editorial_feed: {
-            type: GraphQLBoolean
+            type: GraphQLBoolean,
           },
         },
         type: new GraphQLList(Article.type),
-        resolve: ({
-              _id
-            },
-            options,
-            request, {
-              rootValue: {
-                articlesLoader
-              }
-            }
-          ) =>
+        resolve: (
+          { _id },
+          options,
+          request,
+          { rootValue: { articlesLoader } }
+        ) =>
           articlesLoader(
             defaults(options, {
               artist_id: _id,
               published: true,
             })
-          ).then(({
-            results
-          }) => results),
+          ).then(({ results }) => results),
       },
       artists: {
         type: new GraphQLList(Artist.type),
@@ -203,23 +152,17 @@ export const ArtistType = new GraphQLObjectType({
             defaultValue: true,
           },
         },
-        resolve: ({
-              id
-            },
-            options,
-            request, {
-              rootValue: {
-                relatedMainArtistsLoader
-              }
-            }
-          ) =>
+        resolve: (
+          { id },
+          options,
+          request,
+          { rootValue: { relatedMainArtistsLoader } }
+        ) =>
           relatedMainArtistsLoader(
             defaults(options, {
               artist: [id],
             })
-          ).then(({
-            body
-          }) => body),
+          ).then(({ body }) => body),
       },
       artworks: {
         type: new GraphQLList(Artwork.type),
@@ -229,30 +172,26 @@ export const ArtistType = new GraphQLObjectType({
             description: "The number of Artworks to return",
           },
           page: {
-            type: GraphQLInt
+            type: GraphQLInt,
           },
           sort: ArtworkSorts,
           published: {
             type: GraphQLBoolean,
-            defaultValue: true
+            defaultValue: true,
           },
           filter: {
-            type: new GraphQLList(ArtistArtworksFilters)
+            type: new GraphQLList(ArtistArtworksFilters),
           },
           exclude: {
-            type: new GraphQLList(GraphQLString)
+            type: new GraphQLList(GraphQLString),
           },
         },
-        resolve: ({
-              id
-            },
-            options,
-            request, {
-              rootValue: {
-                artistArtworksLoader
-              }
-            }
-          ) =>
+        resolve: (
+          { id },
+          options,
+          request,
+          { rootValue: { artistArtworksLoader } }
+        ) =>
           artistArtworksLoader(id, options).then(
             exclude(options.exclude, "id")
           ),
@@ -272,29 +211,19 @@ export const ArtistType = new GraphQLObjectType({
         resolve: (
           artist,
           options,
-          request, {
-            rootValue: {
-              artistArtworksLoader
-            }
-          }
+          request,
+          { rootValue: { artistArtworksLoader } }
         ) => {
           // Convert `after` cursors to page params
-          const {
-            limit: size,
-            offset
-          } = getPagingParameters(options)
+          const { limit: size, offset } = getPagingParameters(options)
           // Construct an object of all the params gravity will listen to
-          const {
-            sort,
-            filter,
-            published
-          } = options
+          const { sort, filter, published } = options
           const gravityArgs = {
             size,
             offset,
             sort,
             filter,
-            published
+            published,
           }
           return artistArtworksLoader(artist.id, gravityArgs).then(artworks =>
             connectionFromArraySlice(artworks, options, {
@@ -311,29 +240,22 @@ export const ArtistType = new GraphQLObjectType({
           recordsTrusted: {
             type: GraphQLBoolean,
             defaultValue: false,
-            description: "When true, will only return records for whitelisted artists.",
+            description:
+              "When true, will only return records for whitelisted artists.",
           },
         }),
-        resolve: ({
-            _id
-          },
+        resolve: (
+          { _id },
           options,
-          _request, {
-            rootValue: {
-              auctionLotLoader
-            }
-          }
+          _request,
+          { rootValue: { auctionLotLoader } }
         ) => {
           if (options.recordsTrusted && !includes(auctionRecordsTrusted, _id)) {
             return null
           }
 
           // Convert `after` cursors to page params
-          const {
-            page,
-            size,
-            offset
-          } = parseRelayOptions(options)
+          const { page, size, offset } = parseRelayOptions(options)
           const diffusionArgs = {
             page,
             size,
@@ -341,38 +263,36 @@ export const ArtistType = new GraphQLObjectType({
             sort: options.sort,
           }
           return auctionLotLoader(diffusionArgs).then(
-            ({
-              total_count,
-              _embedded
-            }) => {
+            ({ total_count, _embedded }) => {
               const totalPages = Math.ceil(total_count / size)
-              return merge({
-                  pageCursors: createPageCursors({
-                    page,
-                    size
-                  }, total_count),
+              return merge(
+                {
+                  pageCursors: createPageCursors(
+                    {
+                      page,
+                      size,
+                    },
+                    total_count
+                  ),
                 },
                 connectionFromArraySlice(_embedded.items, options, {
                   arrayLength: total_count,
                   sliceStart: offset,
-                }), {
+                }),
+                {
                   pageInfo: {
                     hasPreviousPage: page > 1,
-                    hasNextPage: page < totalPages
-                  }
+                    hasNextPage: page < totalPages,
+                  },
                 }
               )
-            })
+            }
+          )
         },
       },
       bio: {
         type: GraphQLString,
-        resolve: ({
-          nationality,
-          years,
-          hometown,
-          location
-        }) => {
+        resolve: ({ nationality, years, hometown, location }) => {
           return compact([
             nationality,
             years,
@@ -384,16 +304,12 @@ export const ArtistType = new GraphQLObjectType({
       biography: {
         type: Article.type,
         description: "The Artist biography article written by Artsy",
-        resolve: ({
-              _id
-            },
-            options,
-            request, {
-              rootValue: {
-                articlesLoader
-              }
-            }
-          ) =>
+        resolve: (
+          { _id },
+          options,
+          request,
+          { rootValue: { articlesLoader } }
+        ) =>
           articlesLoader({
             published: true,
             biography_for_artist_id: _id,
@@ -401,7 +317,8 @@ export const ArtistType = new GraphQLObjectType({
           }).then(articles => first(articles.results)),
       },
       biography_blurb: {
-        args: assign({
+        args: assign(
+          {
             partner_bio: {
               type: GraphQLBoolean,
               description: "If true, will return featured bio over Artsy one.",
@@ -415,41 +332,29 @@ export const ArtistType = new GraphQLObjectType({
           fields: {
             credit: {
               type: GraphQLString,
-              resolve: ({
-                credit
-              }) => credit,
+              resolve: ({ credit }) => credit,
             },
             text: {
               type: GraphQLString,
-              resolve: ({
-                text
-              }) => text,
+              resolve: ({ text }) => text,
             },
             partner_id: {
               type: GraphQLString,
-              resolve: ({
-                partner_id
-              }) => partner_id,
-              description: "The partner id of the partner who submitted the featured bio.",
+              resolve: ({ partner_id }) => partner_id,
+              description:
+                "The partner id of the partner who submitted the featured bio.",
             },
           },
         }),
-        resolve: ({
-            blurb,
-            id
-          }, {
-            format,
-            partner_bio
-          },
-          request, {
-            rootValue: {
-              partnerArtistsForArtistLoader
-            }
-          }
+        resolve: (
+          { blurb, id },
+          { format, partner_bio },
+          request,
+          { rootValue: { partnerArtistsForArtistLoader } }
         ) => {
           if (!partner_bio && blurb && blurb.length) {
             return {
-              text: formatMarkdownValue(blurb, format)
+              text: formatMarkdownValue(blurb, format),
             }
           }
           return partnerArtistsForArtistLoader(id, {
@@ -457,10 +362,7 @@ export const ArtistType = new GraphQLObjectType({
             featured: true,
           }).then(partner_artists => {
             if (partner_artists && partner_artists.length) {
-              const {
-                biography,
-                partner
-              } = first(partner_artists)
+              const { biography, partner } = first(partner_artists)
               return {
                 text: formatMarkdownValue(biography, format),
                 credit: `Submitted by ${partner.name}`,
@@ -468,22 +370,18 @@ export const ArtistType = new GraphQLObjectType({
               }
             }
             return {
-              text: formatMarkdownValue(blurb, format)
+              text: formatMarkdownValue(blurb, format),
             }
           })
         },
       },
       birthday: {
-        type: GraphQLString
+        type: GraphQLString,
       },
       blurb: {
         args: markdown().args,
         type: GraphQLString,
-        resolve: ({
-          blurb
-        }, {
-          format
-        }) => {
+        resolve: ({ blurb }, { format }) => {
           if (blurb.length) {
             return formatMarkdownValue(blurb, format)
           }
@@ -492,9 +390,7 @@ export const ArtistType = new GraphQLObjectType({
       carousel: ArtistCarousel,
       collections: {
         type: new GraphQLList(GraphQLString),
-        resolve: ({
-          collections
-        }) => {
+        resolve: ({ collections }) => {
           if (!collections) {
             return null
           }
@@ -513,23 +409,17 @@ export const ArtistType = new GraphQLObjectType({
             defaultValue: true,
           },
         },
-        resolve: ({
-              id
-            },
-            options,
-            request, {
-              rootValue: {
-                relatedContemporaryArtistsLoader
-              }
-            }
-          ) =>
+        resolve: (
+          { id },
+          options,
+          request,
+          { rootValue: { relatedContemporaryArtistsLoader } }
+        ) =>
           relatedContemporaryArtistsLoader(
             defaults(options, {
               artist: [id],
             })
-          ).then(({
-            body
-          }) => body),
+          ).then(({ body }) => body),
       },
       consignable: {
         type: GraphQLBoolean,
@@ -540,37 +430,27 @@ export const ArtistType = new GraphQLObjectType({
           name: "ArtistCounts",
           fields: {
             artworks: numeral(
-              ({
-                published_artworks_count
-              }) => published_artworks_count
+              ({ published_artworks_count }) => published_artworks_count
             ),
-            follows: numeral(({
-              follow_count
-            }) => follow_count),
+            follows: numeral(({ follow_count }) => follow_count),
             for_sale_artworks: numeral(
-              ({
-                forsale_artworks_count
-              }) => forsale_artworks_count
+              ({ forsale_artworks_count }) => forsale_artworks_count
             ),
             partner_shows: numeral(
-              ({
-                partner_shows_count
-              }) => partner_shows_count
+              ({ partner_shows_count }) => partner_shows_count
             ),
             related_artists: {
               type: GraphQLInt,
-              resolve: ({
-                  id
-                },
+              resolve: (
+                { id },
                 _options,
-                _request, {
-                  rootValue: {
-                    relatedMainArtistsLoader
-                  }
-                }
+                _request,
+                { rootValue: { relatedMainArtistsLoader } }
               ) => {
                 return totalViaLoader(
-                  relatedMainArtistsLoader, {}, {
+                  relatedMainArtistsLoader,
+                  {},
+                  {
                     artist: [id],
                   }
                 )
@@ -578,31 +458,25 @@ export const ArtistType = new GraphQLObjectType({
             },
             articles: {
               type: GraphQLInt,
-              resolve: ({
-                    _id
-                  },
-                  _options,
-                  _request, {
-                    rootValue: {
-                      articlesLoader
-                    }
-                  }
-                ) =>
+              resolve: (
+                { _id },
+                _options,
+                _request,
+                { rootValue: { articlesLoader } }
+              ) =>
                 articlesLoader({
                   artist_id: _id,
                   published: true,
                   limit: 0,
                   count: true,
-                }).then(({
-                  count
-                }) => count),
+                }).then(({ count }) => count),
             },
           },
         }),
         resolve: artist => artist,
       },
       deathday: {
-        type: GraphQLString
+        type: GraphQLString,
       },
       display_auction_link: {
         type: GraphQLBoolean,
@@ -617,16 +491,13 @@ export const ArtistType = new GraphQLObjectType({
           },
         },
         type: new GraphQLList(Show.type),
-        description: "Custom-sorted list of shows for an artist, in order of significance.",
-        resolve: ({
-            id
-          },
+        description:
+          "Custom-sorted list of shows for an artist, in order of significance.",
+        resolve: (
+          { id },
           options,
-          request, {
-            rootValue: {
-              relatedShowsLoader
-            }
-          }
+          request,
+          { rootValue: { relatedShowsLoader } }
         ) => {
           return relatedShowsLoader({
             artist_id: id,
@@ -635,9 +506,7 @@ export const ArtistType = new GraphQLObjectType({
             visible_to_public: false,
             has_location: true,
             size: options.size,
-          }).then(({
-              body: shows
-            }) =>
+          }).then(({ body: shows }) =>
             showsWithBLacklistedPartnersRemoved(shows)
           )
         },
@@ -645,34 +514,29 @@ export const ArtistType = new GraphQLObjectType({
       filtered_artworks: filterArtworks("artist_id"),
       formatted_artworks_count: {
         type: GraphQLString,
-        description: "A string showing the total number of works and those for sale",
-        resolve: ({
-          published_artworks_count,
-          forsale_artworks_count
-        }) => {
+        description:
+          "A string showing the total number of works and those for sale",
+        resolve: ({ published_artworks_count, forsale_artworks_count }) => {
           let totalWorks = null
           if (published_artworks_count) {
             totalWorks =
               published_artworks_count +
               (published_artworks_count > 1 ? " works" : " work")
           }
-          const forSaleWorks = forsale_artworks_count ?
-            forsale_artworks_count + " for sale" :
-            null
-          return forSaleWorks && totalWorks ?
-            totalWorks + ", " + forSaleWorks :
-            totalWorks
+          const forSaleWorks = forsale_artworks_count
+            ? forsale_artworks_count + " for sale"
+            : null
+          return forSaleWorks && totalWorks
+            ? totalWorks + ", " + forSaleWorks
+            : totalWorks
         },
       },
       formatted_nationality_and_birthday: {
         type: GraphQLString,
         description: `A string of the form "Nationality, Birthday (or Birthday-Deathday)"`,
-        resolve: ({
-          birthday,
-          nationality,
-          deathday
-        }) => {
-          let formatted_bday = !isNaN(birthday) && birthday ? "b. " + birthday : birthday
+        resolve: ({ birthday, nationality, deathday }) => {
+          let formatted_bday =
+            !isNaN(birthday) && birthday ? "b. " + birthday : birthday
           formatted_bday =
             formatted_bday && formatted_bday.replace(/born/i, "b.")
 
@@ -691,92 +555,74 @@ export const ArtistType = new GraphQLObjectType({
       genes: {
         description: `A list of genes associated with an artist`,
         type: new GraphQLList(GeneType),
-        resolve: ({
-            id
-          },
+        resolve: (
+          { id },
           options,
-          request, {
-            rootValue: {
-              artistGenesLoader
-            }
-          }
+          request,
+          { rootValue: { artistGenesLoader } }
         ) => {
           return artistGenesLoader({
-            id
+            id,
           }).then(genes => genes)
         },
       },
       gender: {
-        type: GraphQLString
+        type: GraphQLString,
       },
       href: {
         type: GraphQLString,
-        resolve: artist => `/artist/${artist.id}`
+        resolve: artist => `/artist/${artist.id}`,
       },
       has_metadata: {
         type: GraphQLBoolean,
-        resolve: ({
-          blurb,
-          nationality,
-          years,
-          hometown,
-          location
-        }) => {
+        resolve: ({ blurb, nationality, years, hometown, location }) => {
           return !!(blurb || nationality || years || hometown || location)
         },
       },
       hometown: {
-        type: GraphQLString
+        type: GraphQLString,
       },
       image: Image,
       initials: initials("name"),
       is_consignable: {
         type: GraphQLBoolean,
-        resolve: ({
-          consignable
-        }) => consignable,
+        resolve: ({ consignable }) => consignable,
       },
       is_display_auction_link: {
         type: GraphQLBoolean,
-        description: "Only specific Artists should show a link to auction results.",
-        resolve: ({
-          display_auction_link
-        }) => display_auction_link,
+        description:
+          "Only specific Artists should show a link to auction results.",
+        resolve: ({ display_auction_link }) => display_auction_link,
       },
       is_followed: {
         type: GraphQLBoolean,
-        resolve: ({
-            id
-          }, {},
-          request, {
-            rootValue: {
-              followedArtistLoader
-            }
-          }
+        resolve: (
+          { id },
+          {},
+          request,
+          { rootValue: { followedArtistLoader } }
         ) => {
           if (!followedArtistLoader) return false
-          return followedArtistLoader(id).then(({
-            is_followed
-          }) => is_followed)
+          return followedArtistLoader(id).then(({ is_followed }) => is_followed)
         },
       },
       is_public: {
         type: GraphQLBoolean,
-        resolve: artist => artist.public
+        resolve: artist => artist.public,
       },
       is_shareable: {
         type: GraphQLBoolean,
         resolve: artist => artist.published_artworks_count > 0,
       },
       location: {
-        type: GraphQLString
+        type: GraphQLString,
       },
       meta: Meta,
       nationality: {
-        type: GraphQLString
+        type: GraphQLString,
       },
       name: {
-        type: GraphQLString
+        type: GraphQLString,
       },
       partners: {
         type: PartnerArtistConnection,
@@ -788,15 +634,11 @@ export const ArtistType = new GraphQLObjectType({
             type: new GraphQLList(GraphQLString),
           },
         }),
-        resolve: ({
-            id: artist_id
-          },
+        resolve: (
+          { id: artist_id },
           options,
-          _request, {
-            rootValue: {
-              partnerArtistsLoader
-            }
-          }
+          _request,
+          { rootValue: { partnerArtistsLoader } }
         ) => {
           return partnersForArtist(artist_id, options, partnerArtistsLoader)
         },
@@ -809,15 +651,11 @@ export const ArtistType = new GraphQLObjectType({
             description: "The number of PartnerArtists to return",
           },
         },
-        resolve: ({
-            id
-          },
+        resolve: (
+          { id },
           options,
-          request, {
-            rootValue: {
-              partnerArtistsForArtistLoader
-            }
-          }
+          request,
+          { rootValue: { partnerArtistsForArtistLoader } }
         ) => partnerArtistsForArtistLoader(id, options),
       },
       partner_shows: {
@@ -834,10 +672,10 @@ export const ArtistType = new GraphQLObjectType({
         type: new GraphQLList(Sale.type),
         args: {
           live: {
-            type: GraphQLBoolean
+            type: GraphQLBoolean,
           },
           is_auction: {
-            type: GraphQLBoolean
+            type: GraphQLBoolean,
           },
           size: {
             type: GraphQLInt,
@@ -845,16 +683,12 @@ export const ArtistType = new GraphQLObjectType({
           },
           sort: SaleSorts,
         },
-        resolve: ({
-              id
-            },
-            options,
-            _request, {
-              rootValue: {
-                relatedSalesLoader
-              }
-            }
-          ) =>
+        resolve: (
+          { id },
+          options,
+          _request,
+          { rootValue: { relatedSalesLoader } }
+        ) =>
           relatedSalesLoader(
             defaults(options, {
               artist_id: id,
@@ -864,20 +698,21 @@ export const ArtistType = new GraphQLObjectType({
       },
       shows: {
         type: new GraphQLList(Show.type),
-        ...ShowField
+        ...ShowField,
       },
       showsConnection: {
         type: showConnection,
-        ...ShowsConnectionField
+        ...ShowsConnectionField,
       },
       sortable_id: {
         type: GraphQLString,
-        description: "Use this attribute to sort by when sorting a collection of Artists",
+        description:
+          "Use this attribute to sort by when sorting a collection of Artists",
       },
       statuses: ArtistStatuses,
       highlights: ArtistHighlights,
       years: {
-        type: GraphQLString
+        type: GraphQLString,
       },
     }
   },
@@ -892,15 +727,11 @@ const Artist = {
       type: new GraphQLNonNull(GraphQLString),
     },
   },
-  resolve: (_root, {
-    id
-  }, _request, resolver) => {
+  resolve: (_root, { id }, _request, resolver) => {
     if (id.length === 0) {
       return null
     }
-    const {
-      artistLoader
-    } = resolver.rootValue
+    const { artistLoader } = resolver.rootValue
     return artistLoader(id)
   },
 }

--- a/src/schema/auction_result.js
+++ b/src/schema/auction_result.js
@@ -1,6 +1,9 @@
 import date from "./fields/date"
 import numeral from "numeral"
-import { IDFields, NodeInterface } from "./object_identification"
+import {
+  IDFields,
+  NodeInterface
+} from "./object_identification"
 import {
   GraphQLFloat,
   GraphQLInt,
@@ -9,8 +12,12 @@ import {
   GraphQLObjectType,
   GraphQLEnumType,
 } from "graphql"
-import { indexOf } from "lodash"
-import { connectionWithCursorInfo } from "schema/fields/pagination"
+import {
+  indexOf
+} from "lodash"
+import {
+  connectionWithCursorInfo
+} from "schema/fields/pagination"
 import Image from "schema/image"
 
 // Taken from https://github.com/RubyMoney/money/blob/master/config/currency_iso.json
@@ -68,8 +75,16 @@ const AuctionResultType = new GraphQLObjectType({
           },
         },
       }),
-      resolve: ({ width_cm, height_cm, depth_cm }) => {
-        return { width: width_cm, height: height_cm, depth: depth_cm }
+      resolve: ({
+        width_cm,
+        height_cm,
+        depth_cm
+      }) => {
+        return {
+          width: width_cm,
+          height: height_cm,
+          depth: depth_cm
+        }
       },
     },
     organization: {
@@ -103,7 +118,9 @@ const AuctionResultType = new GraphQLObjectType({
           },
         },
       }),
-      resolve: ({ images }) => {
+      resolve: ({
+        images
+      }) => {
         if (images.length < 1) {
           return null
         }
@@ -113,18 +130,76 @@ const AuctionResultType = new GraphQLObjectType({
         }
       },
     },
+    estimate: {
+      type: new GraphQLObjectType({
+        name: "AuctionLotEstimate",
+        fields: {
+          low: {
+            type: GraphQLFloat,
+            resolve: ({
+              low_estimate_cents
+            }) => low_estimate_cents,
+          },
+          high: {
+            type: GraphQLFloat,
+            resolve: ({
+              high_estimate_cents
+            }) => high_estimate_cents,
+          },
+          display: {
+            type: GraphQLString,
+            resolve: ({
+              currency,
+              low_estimate_cents,
+              high_estimate_cents
+            }) => {
+              const {
+                symbol,
+                subunit_to_unit
+              } = currencyCodes[
+                currency.toLowerCase()
+              ]
+              let display
+              let amount
+              if (indexOf(symbolOnly, currency) === -1) {
+                display = currency
+              }
 
+              if (symbol) {
+                display = display ? display + " " + symbol : symbol
+              }
+              if (!low_estimate_cents || !high_estimate_cents) {
+                amount = Math.round((low_estimate_cents || high_estimate_cents) / subunit_to_unit)
+                display += numeral(amount).format("")
+              } else {
+                amount = Math.round(low_estimate_cents / subunit_to_unit)
+                display += numeral(amount).format("") + " - "
+                amount = Math.round(high_estimate_cents / subunit_to_unit)
+                display += numeral(amount).format("")
+              }
+
+              return display
+            }
+          }
+        }
+      }),
+      resolve: lot => lot,
+    },
     price_realized: {
       type: new GraphQLObjectType({
         name: "AuctionResultPriceRealized",
         fields: {
           cents: {
             type: GraphQLInt,
-            resolve: ({ price_realized_cents }) => price_realized_cents,
+            resolve: ({
+              price_realized_cents
+            }) => price_realized_cents,
           },
           cents_usd: {
             type: GraphQLInt,
-            resolve: ({ price_realized_cents_usd }) => price_realized_cents_usd,
+            resolve: ({
+              price_realized_cents_usd
+            }) => price_realized_cents_usd,
           },
           display: {
             type: GraphQLString,
@@ -135,8 +210,16 @@ const AuctionResultType = new GraphQLObjectType({
                 defaultValue: "",
               },
             },
-            resolve: ({ currency, price_realized_cents }, { format }) => {
-              const { symbol, subunit_to_unit } = currencyCodes[
+            resolve: ({
+              currency,
+              price_realized_cents
+            }, {
+              format
+            }) => {
+              const {
+                symbol,
+                subunit_to_unit
+              } = currencyCodes[
                 currency.toLowerCase()
               ]
               let display

--- a/src/schema/auction_result.js
+++ b/src/schema/auction_result.js
@@ -1,9 +1,6 @@
 import date from "./fields/date"
 import numeral from "numeral"
-import {
-  IDFields,
-  NodeInterface
-} from "./object_identification"
+import { IDFields, NodeInterface } from "./object_identification"
 import {
   GraphQLFloat,
   GraphQLInt,
@@ -12,12 +9,8 @@ import {
   GraphQLObjectType,
   GraphQLEnumType,
 } from "graphql"
-import {
-  indexOf
-} from "lodash"
-import {
-  connectionWithCursorInfo
-} from "schema/fields/pagination"
+import { indexOf } from "lodash"
+import { connectionWithCursorInfo } from "schema/fields/pagination"
 import Image from "schema/image"
 
 // Taken from https://github.com/RubyMoney/money/blob/master/config/currency_iso.json
@@ -75,15 +68,11 @@ const AuctionResultType = new GraphQLObjectType({
           },
         },
       }),
-      resolve: ({
-        width_cm,
-        height_cm,
-        depth_cm
-      }) => {
+      resolve: ({ width_cm, height_cm, depth_cm }) => {
         return {
           width: width_cm,
           height: height_cm,
-          depth: depth_cm
+          depth: depth_cm,
         }
       },
     },
@@ -118,9 +107,7 @@ const AuctionResultType = new GraphQLObjectType({
           },
         },
       }),
-      resolve: ({
-        images
-      }) => {
+      resolve: ({ images }) => {
         if (images.length < 1) {
           return null
         }
@@ -136,27 +123,20 @@ const AuctionResultType = new GraphQLObjectType({
         fields: {
           low: {
             type: GraphQLFloat,
-            resolve: ({
-              low_estimate_cents
-            }) => low_estimate_cents,
+            resolve: ({ low_estimate_cents }) => low_estimate_cents,
           },
           high: {
             type: GraphQLFloat,
-            resolve: ({
-              high_estimate_cents
-            }) => high_estimate_cents,
+            resolve: ({ high_estimate_cents }) => high_estimate_cents,
           },
           display: {
             type: GraphQLString,
             resolve: ({
               currency,
               low_estimate_cents,
-              high_estimate_cents
+              high_estimate_cents,
             }) => {
-              const {
-                symbol,
-                subunit_to_unit
-              } = currencyCodes[
+              const { symbol, subunit_to_unit } = currencyCodes[
                 currency.toLowerCase()
               ]
               let display
@@ -169,7 +149,9 @@ const AuctionResultType = new GraphQLObjectType({
                 display = display ? display + " " + symbol : symbol
               }
               if (!low_estimate_cents || !high_estimate_cents) {
-                amount = Math.round((low_estimate_cents || high_estimate_cents) / subunit_to_unit)
+                amount = Math.round(
+                  (low_estimate_cents || high_estimate_cents) / subunit_to_unit
+                )
                 display += numeral(amount).format("")
               } else {
                 amount = Math.round(low_estimate_cents / subunit_to_unit)
@@ -179,9 +161,9 @@ const AuctionResultType = new GraphQLObjectType({
               }
 
               return display
-            }
-          }
-        }
+            },
+          },
+        },
       }),
       resolve: lot => lot,
     },
@@ -191,15 +173,11 @@ const AuctionResultType = new GraphQLObjectType({
         fields: {
           cents: {
             type: GraphQLInt,
-            resolve: ({
-              price_realized_cents
-            }) => price_realized_cents,
+            resolve: ({ price_realized_cents }) => price_realized_cents,
           },
           cents_usd: {
             type: GraphQLInt,
-            resolve: ({
-              price_realized_cents_usd
-            }) => price_realized_cents_usd,
+            resolve: ({ price_realized_cents_usd }) => price_realized_cents_usd,
           },
           display: {
             type: GraphQLString,
@@ -210,16 +188,8 @@ const AuctionResultType = new GraphQLObjectType({
                 defaultValue: "",
               },
             },
-            resolve: ({
-              currency,
-              price_realized_cents
-            }, {
-              format
-            }) => {
-              const {
-                symbol,
-                subunit_to_unit
-              } = currencyCodes[
+            resolve: ({ currency, price_realized_cents }, { format }) => {
+              const { symbol, subunit_to_unit } = currencyCodes[
                 currency.toLowerCase()
               ]
               let display


### PR DESCRIPTION
So, since we're now displaying auction results completely from Diffusion, there's a couple things we still needed in the schema.

- estimate range display
- proper connection populating of `hasNextPage` and `hasPreviousPage` (for supporting prev/next pagination)