### PR TITLE
dont batch data loaders that dont fetch in batch

### DIFF
--- a/src/lib/loaders/api/loader_with_authentication_factory.ts
+++ b/src/lib/loaders/api/loader_with_authentication_factory.ts
@@ -61,7 +61,7 @@ export const apiLoaderWithAuthenticationFactory = (
           )
         },
         {
-          batch: true,
+          batch: false,
           cache: true,
         }
       )


### PR DESCRIPTION
I think we only want batching to be enabled on our data loaders when we can make the underlying data fetch as a batch. Otherwise, slowest response dominates the batch. Asking for a bunch of review just because I'm not sure whether the batching was intentional for reasons I'm overlooking.