### PR TITLE
@damassi => Last connection pieces of info for artist page

### DIFF
--- a/src/schema/__tests__/auction_results.test.js
+++ b/src/schema/__tests__/auction_results.test.js
@@ -184,4 +184,22 @@ describe("Artist type", () => {
       }
     )
   })
+
+  it("returns the total number of records", () => {
+    const query = `
+      {
+        artist(id: "percy-z") {
+          auctionResults(recordsTrusted: true, first: 10) {
+            totalCount
+          }
+        }
+      }
+    `
+
+    return runQuery(query, rootValue).then(
+      ({ artist: { auctionResults: { totalCount } } }) => {
+        expect(totalCount).toBe(35)
+      }
+    )
+  })
 })

--- a/src/schema/artist/__tests__/index.test.js
+++ b/src/schema/artist/__tests__/index.test.js
@@ -852,7 +852,7 @@ describe("Artist type", () => {
   })
 
   describe("showsConnection", () => {
-    it("returns connection of shows augmented by cursor info", () => {
+    it("returns connection of shows augmented by cursor and pagination info", () => {
       const relatedShowsLoader = jest.fn().mockReturnValueOnce(
         Promise.resolve({
           body: [
@@ -869,7 +869,7 @@ describe("Artist type", () => {
       const query = `
         {
           artist(id: "percy") {
-            showsConnection(first: 10) {
+            showsConnection(first: 10, after: "YXJyYXljb25uZWN0aW9uOjk=") {
               pageCursors {
                 first {
                   page
@@ -880,6 +880,10 @@ describe("Artist type", () => {
                 last {
                   page
                 }
+              }
+              pageInfo {
+                hasNextPage
+                hasPreviousPage
               }
               edges {
                 node {
@@ -892,7 +896,15 @@ describe("Artist type", () => {
       `
 
       return runQuery(query, rootValue).then(
-        ({ artist: { showsConnection: { pageCursors, edges } } }) => {
+        ({
+          artist: {
+            showsConnection: {
+              pageInfo: { hasNextPage, hasPreviousPage },
+              pageCursors,
+              edges,
+            },
+          },
+        }) => {
           // Check expected page cursors exist in response.
           const { first, around, last } = pageCursors
           expect(first).toEqual(null)
@@ -902,8 +914,11 @@ describe("Artist type", () => {
           for (index = 0; index < 4; index++) {
             expect(around[index].page).toBe(index + 1)
           }
-          // Check article data included in edges.
+          // Check show data included in edges.
           expect(edges[0].node.name).toEqual("Catty Art Show")
+          // Check that there is a previous and next page.
+          expect(hasNextPage).toBe(true)
+          expect(hasPreviousPage).toBe(true)
         }
       )
     })

--- a/src/schema/artist/index.js
+++ b/src/schema/artist/index.js
@@ -275,6 +275,9 @@ export const ArtistType = new GraphQLObjectType({
                     total_count
                   ),
                 },
+                {
+                  totalCount: total_count,
+                },
                 connectionFromArraySlice(_embedded.items, options, {
                   arrayLength: total_count,
                   sliceStart: offset,

--- a/src/schema/fields/pagination.js
+++ b/src/schema/fields/pagination.js
@@ -130,6 +130,10 @@ export function connectionWithCursorInfo(type) {
         type: PageCursorsType,
         resolve: ({ pageCursors }) => pageCursors,
       },
+      totalCount: {
+        type: GraphQLInt,
+        resolve: ({ totalCount }) => totalCount,
+      },
     },
   }).connectionType
 }


### PR DESCRIPTION
This adds two last pieces of information we need:

- includes `totalCount` in the connection metadata, which we need to display on the 'Auction Results' tab. We do get a total back when we're doing artwork filtering, but that's via an aggregation which is specific to artwork filtering, so I chose to add this as a connection metadata field (next to `pageInfo`, `edges`, etc.). Seems reasonable that clients may want this more generally. Then, I augmented the auction results connection resolver to include that.

- Injects our own computation for `hasNextPage` and `hasPreviousPage` (which enables the Prev/Next in pagination), analogous to what we did for auction results, but for shows.