### PR TITLE
Adds an integration test that lives almost entirely outside of the schema resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "lodash": "^4.3.0",
     "longjohn": "^0.2.12",
     "marked": "^0.3.9",
+    "memcached": "^2.2.2",
     "moment": "^2.14.1",
     "moment-timezone": "^0.5.5",
     "node-fetch": "^1.7.3",
@@ -91,7 +92,6 @@
     "raven": "^2.4.2",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
-    "memcached": "^2.2.2",
     "relay-cursor-paging": "^0.2.0",
     "request": "^2.67.0",
     "source-map-support": "^0.4.3",
@@ -131,6 +131,7 @@
     "lint-staged": "^3.4.0",
     "prettier": "^1.7",
     "sinon": "^1.17.2",
+    "superagent": "^3.8.3",
     "supertest": "^3.1.0",
     "typescript": "^2.7.2",
     "typescript-babel-jest": "^1.0.5"
@@ -164,11 +165,11 @@
     "bracketSpacing": true
   },
   "lint-staged": {
-    "*.json, *.md": [
+    "*.@(json|md|ts)": [
       "yarn prettier --write",
       "git add"
     ],
-    "*.@(js|ts)": [
+    "*.@(js)": [
       "eslint --fix",
       "yarn prettier --write",
       "git add"

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -1,0 +1,37 @@
+import request from "supertest"
+import app from "../index"
+import gql from "test/gql"
+
+jest.mock("lib/apis/fetch", () => jest.fn())
+import fetch from "lib/apis/fetch"
+const mockFetch = fetch as jest.Mock
+
+// These tests ensure that *any* query works against our express app.
+
+it("It should bail for an unknown GET request", async () => {
+  const response = await request(app).get("/")
+  expect(response.statusCode).toBe(400)
+})
+
+it("It can make a request against the schema", async () => {
+  // Mock the fetch for the Artist loader
+  mockFetch.mockResolvedValueOnce(
+    Promise.resolve({ body: { name: "Mr Bank" } })
+  )
+
+  const response = await request(app)
+    .post("/")
+    .set("Accept", "application/json")
+    .send({
+      query: gql`
+        {
+          artist(id: "banksy") {
+            name
+          }
+        }
+      `,
+    })
+
+  expect(response.body).toEqual({ data: { artist: { name: "Mr Bank" } } })
+  expect(response.statusCode).toBe(200)
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2850,7 +2850,7 @@ formatio@1.1.1:
   dependencies:
     samsam "~1.1"
 
-formidable@^1.1.1:
+formidable@^1.1.1, formidable@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
 
@@ -5497,7 +5497,7 @@ readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
-readable-stream@^2.0.5:
+readable-stream@^2.0.5, readable-stream@^2.3.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -6334,6 +6334,21 @@ superagent@^1.2.0:
     qs "2.3.3"
     readable-stream "1.0.27-1"
     reduce-component "1.0.1"
+
+superagent@^3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.3.tgz#460ea0dbdb7d5b11bc4f78deba565f86a178e128"
+  dependencies:
+    component-emitter "^1.2.0"
+    cookiejar "^2.1.0"
+    debug "^3.1.0"
+    extend "^3.0.0"
+    form-data "^2.3.1"
+    formidable "^1.2.0"
+    methods "^1.1.1"
+    mime "^1.4.1"
+    qs "^6.5.1"
+    readable-stream "^2.3.5"
 
 supertest@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
This adds a test that runs a query at express level, instead of directly against the known schema. This means it'll run though everything set up in app.js.

Also amends https://github.com/artsy/metaphysics/pull/1122 as eslint can't parse ts files