### PR TITLE
Revert changes to GraphQL timeout middleware

### DIFF
--- a/src/lib/__tests__/graphqlTimeoutMiddleware.test.ts
+++ b/src/lib/__tests__/graphqlTimeoutMiddleware.test.ts
@@ -207,39 +207,6 @@ describe("graphQLTimeoutMiddleware", () => {
       expect(nestedResolver).not.toBeCalled()
     })
 
-    describe("concerning cases where no timeout is needed", () => {
-
-      beforeEach(() => {
-        jest.useFakeTimers()
-      })
-
-      afterEach(() => {
-        jest.useRealTimers()
-      })
-
-      it("does not start a timeout when a resolver does not return a promise", async () => {
-
-        resolvers = {
-          Query: {
-            artwork: () => responseData,
-          },
-        }
-        await query()
-        expect(setTimeout).not.toBeCalled()
-      })
-
-      it("does not start a timeout when a resolver returns a promise that’s no longer pending", async () => {
-
-        resolvers = {
-          Query: {
-            artwork: () => Promise.resolve(responseData),
-          },
-        }
-        await query()
-        expect(setTimeout).not.toBeCalled()
-      })
-    })
-
     describe("concerning clearing timeouts", () => {
       beforeAll(() => {
         jest.useFakeTimers()
@@ -250,11 +217,9 @@ describe("graphQLTimeoutMiddleware", () => {
       })
 
       it("clears the timeout when a resolver succeeds", async () => {
-        const promise = Promise.resolve(responseData)
-        promise.isPending = () => true
         resolvers = {
           Query: {
-            artwork: () => promise,
+            artwork: () => responseData,
           },
         }
         await query()
@@ -262,11 +227,9 @@ describe("graphQLTimeoutMiddleware", () => {
       })
 
       it("clears the timeout when a resolver fails", async () => {
-        const promise = Promise.reject(new Error("oh noes"))
-        promise.isPending = () => true
         resolvers = {
           Query: {
-            artwork: () => promise,
+            artwork: () => Promise.reject(new Error("oh noes")),
           },
         }
         await query()

--- a/src/lib/graphqlTimeoutMiddleware.ts
+++ b/src/lib/graphqlTimeoutMiddleware.ts
@@ -15,26 +15,16 @@ export function fieldFromResolveInfo(resolveInfo: GraphQLResolveInfo) {
 
 export function timeoutForField(field: GraphQLField<any, any>) {
   const fieldDirectives = field.astNode && field.astNode.directives
-  const directive =
-    fieldDirectives &&
-    fieldDirectives.find(directive => directive.name.value === "timeout")
+  const directive = fieldDirectives && fieldDirectives.find(directive => directive.name.value === "timeout")
   if (directive) {
     const args = directive && directive.arguments
     const arg = args && args[0]
-    invariant(
-      arg && arg.name.value === "ms",
-      "graphqlTimeoutMiddleware: The `@timeout(ms: …)` argument is required."
-    )
+    invariant(arg && arg.name.value === "ms", "graphqlTimeoutMiddleware: The `@timeout(ms: …)` argument is required.")
     const value = arg!.value
     if (value.kind === "IntValue") {
       return parseInt(value.value)
     } else {
-      invariant(
-        false,
-        `graphqlTimeoutMiddleware: Expected \`@timeout(ms: …)\` to be a \`IntValue\`, got \`${
-          value.kind
-        }\` instead.`
-      )
+      invariant(false, `graphqlTimeoutMiddleware: Expected \`@timeout(ms: …)\` to be a \`IntValue\`, got \`${value.kind}\` instead.`)
       return null
     }
   }
@@ -44,16 +34,16 @@ export function timeoutForField(field: GraphQLField<any, any>) {
 function isPendingPromise(value) {
   return Boolean(
     value &&
-      typeof value.then === "function" &&
-      /**
-       * In case of using a user-land Promise wrapper, such as Bluebird, check if
-       * it has a ‘pending’ check, in which case we can further reduce the number
-       * of time-outs needed.
-       *
-       * Alas this check can’t be done once on start-up, because async/await usage
-       * will return an unwrapped native `Promise`.
-       */
-      (typeof value.isPending === "function" ? value.isPending() : true)
+    typeof value.then === "function" &&
+    /**
+     * In case of using a user-land Promise wrapper, such as Bluebird, check if
+     * it has a ‘pending’ check, in which case we can further reduce the number
+     * of time-outs needed.
+     *
+     * Alas this check can’t be done once on start-up, because async/await usage
+     * will return an unwrapped native `Promise`.
+     */
+    (typeof value.isPending === "function" ? value.isPending() : true)
   )
 }
 
@@ -72,32 +62,25 @@ export const graphqlTimeoutMiddleware = (defaultTimeoutInMS: number) => {
     }
     // TODO: Maybe cache if it turns out to take significant time.
     //       Should probably be cached on the schema instance.
-    const timeoutInMS =
-      timeoutForField(fieldFromResolveInfo(info)) || defaultTimeoutInMS
+    const timeoutInMS = timeoutForField(fieldFromResolveInfo(info)) || defaultTimeoutInMS
     let timeoutID
     return Promise.race([
       new Promise((_resolve, reject) => {
         timeoutID = setTimeout(() => {
-          const field = `${info.parentType}.${info.fieldName}`
-          reject(
-            new GraphQLTimeoutError(
-              `GraphQL Timeout Error: ${
-                field
-              } has timed out after waiting for ${timeoutInMS}ms`
-            )
-          )
+          const field = `${info.parentType}.${info.fieldName}`;
+          reject(new GraphQLTimeoutError(`GraphQL Timeout Error: ${field} has timed out after waiting for ${timeoutInMS}ms`))
         }, timeoutInMS)
       }),
       resolverResult.then(
         result => {
           clearTimeout(timeoutID)
-          return result
+          result
         },
         error => {
           clearTimeout(timeoutID)
           throw error
         }
-      ),
+      )
     ])
   }
   return middleware

--- a/src/test/helper.js
+++ b/src/test/helper.js
@@ -11,9 +11,6 @@ if (fs.existsSync(".env.test")) {
 import sinon from "sinon"
 global.sinon = sinon
 
-import Bluebird from "bluebird"
-global.Promise = Bluebird
-
 // prettier-ignore
 
 /**


### PR DESCRIPTION
Changes here cause us to lose HTTP / Memcached metrics and processed exhibited sawtooth memory growth.

This was in production from today, June 21st @ 10:38 UTC (see image tag `production--2018-06-21--10-38-53`) until reverted @ 12:00 UTC (see image tag `production--2018-06-21--12-00-31`)

Other metrics appear unchanged - overall query latency / eventloop latency seemed unaffected.

See:

https://app.datadoghq.com/apm/service/metaphysics.graphql-query/graphql.query
https://app.datadoghq.com/apm/service/metaphysics.memcached/cache
https://app.datadoghq.com/apm/service/metaphysics.http-client/http.request
https://app.datadoghq.com/dash/635153

Would advise taking another pass at this but first implementing GC metrics collection and comparing before / after