### PR TITLE
Inject response body to HTTPError whenever possible

### DIFF
--- a/src/lib/__tests__/apis/fetch.test.ts
+++ b/src/lib/__tests__/apis/fetch.test.ts
@@ -41,3 +41,24 @@ it("tries to parse the response when there is a String and resolves with it", as
 
   return expectPromiseRejectionToMatch(fetch("foo/bar"), /Unexpected token/)
 })
+
+it("tries to parse the response when there is a String and resolves with it", done => {
+  let reqResponse = {
+    statusCode: 400,
+    request: {
+      uri: {
+        href: 'http://api.artsy.net/api/v1/me'
+      }
+    },
+    body: `{ "type": "other_error", "message": "undefined method \`[]' for nil:NilClass" }`,
+  }
+
+  mockRequest.mockImplementationOnce((_, __, callback) => callback(null, reqResponse))
+
+  fetch("foo/bar").catch(error => {
+    expect(error.message).toEqual(`http://api.artsy.net/api/v1/me - { "type": "other_error", "message": "undefined method \`[]' for nil:NilClass" }`)
+    expect(error.statusCode).toEqual(400)
+    expect(error.body).toEqual(`{ "type": "other_error", "message": "undefined method \`[]' for nil:NilClass" }`)
+    done()
+  })
+})

--- a/src/lib/apis/fetch.js
+++ b/src/lib/apis/fetch.js
@@ -33,7 +33,7 @@ export default (url, options = {}) => {
           get(response, "request.uri.href"),
           response.body,
         ]).join(" - ")
-        return reject(new HTTPError(message, response.statusCode))
+        return reject(new HTTPError(message, response.statusCode, response.body))
       }
 
       try {

--- a/src/lib/http_error.js
+++ b/src/lib/http_error.js
@@ -1,7 +1,8 @@
 export default class HTTPError extends Error {
-  constructor(message, statusCode) {
+  constructor(message, statusCode, body) {
     super(message)
     this.statusCode = statusCode
+    this.body = body
     Error.captureStackTrace(this, this.constructor)
   }
 }


### PR DESCRIPTION
We [construct an error message](https://github.com/artsy/metaphysics/blob/597405d0678e941948275c006cb256acb343eccd/src/lib/apis/fetch.js#L32-L35) based on the request URI and the response body and assign it to the error object. This is most useful when debugging in a client like GraphiQL, but sometimes we [split the error message back](https://github.com/artsy/metaphysics/blob/597405d0678e941948275c006cb256acb343eccd/src/schema/me/bidder_position_mutation.js#L50-L51) within Metaphysics to generate a more helpful error message for the end-user. We should not have to do this as you already have the response in place.

This PR updates the `fetch` function to assign the response body to the `HTTPError` object so we will gain direct access to the body.