### PR TITLE
@damassi => Combine main/contemporary related artists

### DIFF
--- a/src/schema/artist/__tests__/related.test.js
+++ b/src/schema/artist/__tests__/related.test.js
@@ -7,16 +7,26 @@ describe("Artist type", () => {
     birthday: "2012",
   }
 
-  const artistsResponse = {
+  const contemporaryArtistsResponse = {
+    headers: { "x-total-count": 35 },
+    body: [{ id: "contemporary-percy-z", birthday: "2012" }],
+  }
+  const mainArtistsResponse = {
     headers: { "x-total-count": 35 },
     body: [{ id: "percy-z", birthday: "2012" }],
   }
-  const loader = jest.fn().mockReturnValue(Promise.resolve(artistsResponse))
+  const relatedContemporaryArtistsLoader = jest
+    .fn()
+    .mockReturnValue(Promise.resolve(contemporaryArtistsResponse))
+
+  const relatedMainArtistsLoader = jest
+    .fn()
+    .mockReturnValue(Promise.resolve(mainArtistsResponse))
 
   const artistLoader = () => Promise.resolve(artist)
   const rootValue = {
-    relatedContemporaryArtistsLoader: loader,
-    relatedMainArtistsLoader: loader,
+    relatedContemporaryArtistsLoader,
+    relatedMainArtistsLoader,
     artistLoader,
   }
 
@@ -25,7 +35,7 @@ describe("Artist type", () => {
       {
         artist(id: "percy-z") {
           related {
-            contemporary(first: 10) {
+            artists(kind: CONTEMPORARY, first: 10) {
               pageCursors {
                 first {
                   page
@@ -49,7 +59,7 @@ describe("Artist type", () => {
     `
 
     return runQuery(query, rootValue).then(
-      ({ artist: { related: { contemporary: { pageCursors, edges } } } }) => {
+      ({ artist: { related: { artists: { pageCursors, edges } } } }) => {
         // Check expected page cursors exist in response.
         const { first, around, last } = pageCursors
         expect(first).toEqual(null)
@@ -60,7 +70,7 @@ describe("Artist type", () => {
           expect(around[index].page).toBe(index + 1)
         }
         // Check auction result included in edges.
-        expect(edges[0].node.id).toEqual("percy-z")
+        expect(edges[0].node.id).toEqual("contemporary-percy-z")
       }
     )
   })
@@ -70,7 +80,7 @@ describe("Artist type", () => {
       {
         artist(id: "percy-z") {
           related {
-            main(first: 10) {
+            artists(kind: MAIN, first: 10) {
               pageCursors {
                 first {
                   page
@@ -94,7 +104,7 @@ describe("Artist type", () => {
     `
 
     return runQuery(query, rootValue).then(
-      ({ artist: { related: { main: { pageCursors, edges } } } }) => {
+      ({ artist: { related: { artists: { pageCursors, edges } } } }) => {
         // Check expected page cursors exist in response.
         const { first, around, last } = pageCursors
         expect(first).toEqual(null)


### PR DESCRIPTION
Added these two related artists fields (to be able to use them as a connection w/ pagination), but actually they're exactly the same thing, just a different 'kind' of related artists.

So combines them into one, like:

```
artist(id: "andy-warhol") {
  related {
    artists(kind: CONTEMPORARY) {
      ...
    }
  }
}
````