### PR TITLE
@damassi => Add cursor info for previous page, for better implementation of Prev 

### DIFF
--- a/src/schema/__tests__/auction_results.test.js
+++ b/src/schema/__tests__/auction_results.test.js
@@ -168,6 +168,11 @@ describe("Artist type", () => {
               hasNextPage
               hasPreviousPage
             }
+            pageCursors {
+              previous {
+                page
+              }
+            }
           }
         }
       }
@@ -176,11 +181,15 @@ describe("Artist type", () => {
     return runQuery(query, rootValue).then(
       ({
         artist: {
-          auctionResults: { pageInfo: { hasNextPage, hasPreviousPage } },
+          auctionResults: {
+            pageCursors: { previous: { page } },
+            pageInfo: { hasNextPage, hasPreviousPage },
+          },
         },
       }) => {
         expect(hasNextPage).toBe(true)
         expect(hasPreviousPage).toBe(true)
+        expect(page).toBe(1)
       }
     )
   })

--- a/src/schema/fields/__tests__/pagination.test.js
+++ b/src/schema/fields/__tests__/pagination.test.js
@@ -27,8 +27,9 @@ describe("createPageCursors", () => {
     const { around } = pageCursors
     expect(around.length).toBe(4)
 
-    // We are on the first page.
+    // We are on the first page, and there is no previous page info.
     expect(around[0].isCurrent).toBe(true)
+    expect(pageCursors).not.toHaveProperty("previous")
 
     checkCursorArray(around, size)
   })
@@ -46,8 +47,9 @@ describe("createPageCursors", () => {
     const { around } = pageCursors
     expect(around.length).toBe(4)
 
-    // We are on the first page.
+    // We are on the first page, and there is no previous page info.
     expect(around[0].isCurrent).toBe(true)
+    expect(pageCursors).not.toHaveProperty("previous")
 
     checkCursorArray(around, size)
   })
@@ -62,12 +64,13 @@ describe("createPageCursors", () => {
     // Last page starts at `70`.
     expect(offsetFromCursor(pageCursors.last)).toBe("69")
 
-    const { around } = pageCursors
+    const { around, previous } = pageCursors
     expect(around.length).toBe(3)
 
     // We are on the fourth page.
     expect(around[1].page).toBe(4)
     expect(around[1].isCurrent).toBe(true)
+    expect(previous.page).toBe(3)
 
     checkCursorArray(around, size)
   })
@@ -82,12 +85,13 @@ describe("createPageCursors", () => {
     // There shouldn't be a `last` as it is contained in `around`.
     expect(pageCursors).not.toHaveProperty("last")
 
-    const { around } = pageCursors
+    const { around, previous } = pageCursors
     expect(around.length).toBe(4)
 
     // We are on the seventh page.
     expect(around[2].page).toBe(7)
     expect(around[2].isCurrent).toBe(true)
+    expect(previous.page).toBe(6)
 
     checkCursorArray(around, size)
   })
@@ -99,6 +103,7 @@ describe("createPageCursors", () => {
     // There shouldn't be a `first` or `last` as it is contained in `around`.
     expect(pageCursors).not.toHaveProperty("last")
     expect(pageCursors).not.toHaveProperty("first")
+    expect(pageCursors).not.toHaveProperty("previous")
 
     const { around } = pageCursors
     expect(around.length).toBe(1)

--- a/src/schema/fields/pagination.js
+++ b/src/schema/fields/pagination.js
@@ -43,6 +43,7 @@ export const PageCursorsType = new GraphQLObjectType({
       type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(PageCursor))),
       description: "Always includes current page",
     },
+    previous: { type: PageCursor },
   }),
 })
 
@@ -78,26 +79,24 @@ export function createPageCursors(
   }
 
   const totalPages = Math.ceil(totalRecords / size)
-
+  let pageCursors
   // Degenerate case of no records found.
   if (totalPages === 0) {
-    return { around: [pageToCursor(1, 1, size)] }
-  }
-
-  if (totalPages <= max) {
+    pageCursors = { around: [pageToCursor(1, 1, size)] }
+  } else if (totalPages <= max) {
     // Collection is short, and `around` includes page 1 and the last page.
-    return {
+    pageCursors = {
       around: pageCursorsToArray(1, totalPages, currentPage, size),
     }
   } else if (currentPage <= Math.floor(max / 2) + 1) {
     // We are near the beginning, and `around` will include page 1.
-    return {
+    pageCursors = {
       last: pageToCursor(totalPages, currentPage, size),
       around: pageCursorsToArray(1, max - 1, currentPage, size),
     }
   } else if (currentPage >= totalPages - Math.floor(max / 2)) {
     // We are near the end, and `around` will include the last page.
-    return {
+    pageCursors = {
       first: pageToCursor(1, currentPage, size),
       around: pageCursorsToArray(
         totalPages - max + 2,
@@ -109,7 +108,7 @@ export function createPageCursors(
   } else {
     // We are in the middle, and `around` doesn't include the first or last page.
     const offset = Math.floor((max - 3) / 2)
-    return {
+    pageCursors = {
       first: pageToCursor(1, currentPage, size),
       around: pageCursorsToArray(
         currentPage - offset,
@@ -120,6 +119,11 @@ export function createPageCursors(
       last: pageToCursor(totalPages, currentPage, size),
     }
   }
+
+  if (currentPage > 1 && totalPages > 1) {
+    pageCursors.previous = pageToCursor(currentPage - 1, currentPage, size)
+  }
+  return pageCursors
 }
 
 export function connectionWithCursorInfo(type) {


### PR DESCRIPTION
As discussed, we want to settle on `first/after` style 'forward' pagination, so as to benefit from Relay caching.

We already do this when clicking 'Next', or when clicking on any page in a pagination bar. However, we were doing 'backward' pagination using `last/before` when clicking 'Previous', so we weren't benefiting from any caching (even if you had already loaded that page using forward pagination).

This adds a specific `previous` entry into the cursor metadata, which will enable 'Prev' pagination to use the same `first/after` values and save that call. Thanks for pointing this out!