### PR TITLE
Fea custom metrics

### DIFF
--- a/src/lib/stats.js
+++ b/src/lib/stats.js
@@ -7,6 +7,7 @@ import { error } from "./loggers"
 const { NODE_ENV, ENABLE_METRICS, STATSD_HOST, STATSD_PORT } = config
 
 const isTest = NODE_ENV === "test"
+const isDev = NODE_ENV === "development"
 const enableMetrics = ENABLE_METRICS === "true"
 const appMetricsDisable = [
   "http",
@@ -28,14 +29,14 @@ const appMetricsDisable = [
 export const statsClient = new StatsD({
   host: STATSD_HOST,
   port: STATSD_PORT,
-  globalTags: { service: "metaphysics", hostname: os.hostname() },
-  mock: isTest,
+  globalTags: { service: "metaphysics", pod_name: os.hostname() },
+  mock: isDev || isTest,
   errorHandler: function(err) {
     error(`Statsd client error ${err}`)
   },
 })
 
-if (enableMetrics && !isTest) {
+if (enableMetrics && !isDev && !isTest) {
   const appmetrics = require("appmetrics")
   appmetrics.configure({
     mqtt: "off",

--- a/src/lib/stats.js
+++ b/src/lib/stats.js
@@ -6,8 +6,7 @@ import { error } from "./loggers"
 
 const { NODE_ENV, ENABLE_METRICS, STATSD_HOST, STATSD_PORT } = config
 
-const isTest = NODE_ENV === "test"
-const isDev = NODE_ENV === "development"
+const isProd = NODE_ENV === "production"
 const enableMetrics = ENABLE_METRICS === "true"
 const appMetricsDisable = [
   "http",
@@ -30,13 +29,13 @@ export const statsClient = new StatsD({
   host: STATSD_HOST,
   port: STATSD_PORT,
   globalTags: { service: "metaphysics", pod_name: os.hostname() },
-  mock: isDev || isTest,
+  mock: !isProd,
   errorHandler: function(err) {
     error(`Statsd client error ${err}`)
   },
 })
 
-if (enableMetrics && !isDev && !isTest) {
+if (enableMetrics && isProd) {
   const appmetrics = require("appmetrics")
   appmetrics.configure({
     mqtt: "off",

--- a/src/lib/stats.js
+++ b/src/lib/stats.js
@@ -58,4 +58,15 @@ if (enableMetrics && !isTest) {
     statsClient.timing("eventloop.latency.max", eventloopMetrics.latency.max)
     statsClient.timing("eventloop.latency.avg", eventloopMetrics.latency.avg)
   })
+
+  monitoring.on("memory", memoryMetrics => {
+    statsClient.gauge("memory.physical", memoryMetrics.physical)
+    statsClient.gauge("memory.virtual", memoryMetrics.virtual)
+  })
+
+  monitoring.on("gc", gcMetrics => {
+    statsClient.gauge("gc.heap_size", gcMetrics.size)
+    statsClient.gauge("gc.heap_used", gcMetrics.used)
+    statsClient.timing("gc.sweep_duration", gcMetrics.duration, {sweep_type: gcMetrics.type})
+  })
 }


### PR DESCRIPTION
- Adds memory and GC metrics measured by Node's VM
- Only send metrics in production environments - change tagging to match `pod_name` rather than `hostname` so as to match metrics collected by the kubernetes integrations