### PR TITLE
Properly format error description for BidderPositionResult with '\n'

### DIFF
--- a/src/schema/me/__tests__/bidder_position.test.js
+++ b/src/schema/me/__tests__/bidder_position.test.js
@@ -98,8 +98,7 @@ describe("BidderPosition", () => {
         bidder_position: {
           status: "RESERVE_NOT_MET",
           message_header: "Your bid wasn't high enough",
-          message_description_md: `Your bid didn’t meet the reserve price for this work.  \
- Bid again to take the lead.`,
+          message_description_md: `Your bid didn’t meet the reserve price\nfor this work.\n\nBid again to take the lead.`,
           position: {
             processed_at: "2018-04-26T14:15:52+00:00",
           },
@@ -113,8 +112,7 @@ describe("BidderPosition", () => {
         bidder_position: {
           status: "OUTBID",
           message_header: "Your bid wasn't high enough",
-          message_description_md: `Another bidder placed a higher max bid or the same max bid before you did.  \
- Bid again to take the lead.`,
+          message_description_md: `Another bidder placed a higher max bid\nor the same max bid before you did.\n\nBid again to take the lead.`,
           position: {
             processed_at: "2018-04-26T14:15:52+00:00",
           },

--- a/src/schema/me/__tests__/bidder_position_mutation.test.js
+++ b/src/schema/me/__tests__/bidder_position_mutation.test.js
@@ -36,6 +36,7 @@ describe("Bidder position mutation", () => {
           Promise.resolve(createBidderPosition)
         ),
       }
+
       const data = await runAuthenticatedQuery(query, rootValue)
       expect(data.createBidderPosition.result.position.suggested_next_bid_cents).toEqual(110000)
       expect(data.createBidderPosition.result.message_header).toBeNull()
@@ -56,12 +57,15 @@ describe("Bidder position mutation", () => {
           Promise.reject(errorMessage)
         ),
       }
+
       const data = await runAuthenticatedQuery(query, rootValue)
+
       expect(data.createBidderPosition.result.position).toBeNull()
       expect(data.createBidderPosition.result.message_header).toEqual("Your bid wasn't high enough")
-      expect(data.createBidderPosition.result.message_description_md).toEqual(`Another bidder placed a\
- higher max bid or the same max bid before you did.  \
- Bid again to take the lead.`)
+      expect(data.createBidderPosition.result.message_description_md).toEqual(
+        "Another bidder placed a higher max bid\nor the same max bid before you did.\n\n" +
+        "Bid again to take the lead."
+      )
     })
 
     it("creates correct message when sale is closed", async () => {
@@ -74,13 +78,18 @@ describe("Bidder position mutation", () => {
           Promise.reject(errorMessage)
         ),
       }
+
       const data = await runAuthenticatedQuery(query, rootValue)
+
       expect(data.createBidderPosition.result.position).toBeNull()
       expect(data.createBidderPosition.result.message_header).toEqual("Lot closed")
       expect(data.createBidderPosition.result.message_description_md).toEqual(
-        "Sorry, your bid wasn’t received before the lot closed.")
+        "Sorry, your bid wasn’t received\n"+
+        "before the lot closed."
+      )
     })
   })
+
   it("creates correct message when live bidding has started", async () => {
     const errorObjectString = `{"error":"Live Bidding has Started"}`
     const errorMessage = {
@@ -91,14 +100,16 @@ describe("Bidder position mutation", () => {
         Promise.reject(errorMessage)
       ),
     }
+
     const data = await runAuthenticatedQuery(query, rootValue)
-    const { PREDICTION_ENDPOINT } = config
+
     expect(data.createBidderPosition.result.position).toBeNull()
     expect(data.createBidderPosition.result.message_header).toEqual("Live bidding has started")
     expect(data.createBidderPosition.result.message_description_md).toEqual(
-      `Sorry, your bid wasn’t received before live bidding started.\
- To continue bidding, please\
- [join the live auction](${PREDICTION_ENDPOINT}/sixteen-year-of-resistance-benefit-auction-2032).`)
+      "Sorry, your bid wasn’t received before\n" +
+      "live bidding started. To continue\n" +
+      `bidding, please [join the live auction](${config.PREDICTION_ENDPOINT}/sixteen-year-of-resistance-benefit-auction-2032).`
+    )
   })
 })
 
@@ -112,10 +123,14 @@ it("creates correct message when bidder is not qualifdied", async () => {
       Promise.reject(errorMessage)
     ),
   }
+
   const data = await runAuthenticatedQuery(query, rootValue)
+
   expect(data.createBidderPosition.result.position).toBeNull()
   expect(data.createBidderPosition.result.message_header).toEqual("Bid not placed")
   expect(data.createBidderPosition.result.message_description_md).toEqual(
-    `Your bid can’t be placed at this time.\
- Please contact [support@artsy.net](mailto:support@artsy.net) for more information.`)
+    "Your bid can’t be placed at this time.\n" +
+    "Please contact [support@artsy.net](mailto:support@artsy.net) for\n" +
+    "more information."
+  )
 })

--- a/src/schema/me/bidder_position_messages.js
+++ b/src/schema/me/bidder_position_messages.js
@@ -4,42 +4,36 @@ export const BiddingMessages = [
     id: "OUTBID",
     gravity_key: "Please enter a bid higher than",
     header: "Your bid wasn't high enough",
-    description_md: () => `Another bidder placed a higher max bid or the same max bid before you did.  \
- Bid again to take the lead.`,
+    description_md: () => `Another bidder placed a higher max bid\nor the same max bid before you did.\n\nBid again to take the lead.`,
   },
   {
     id: "RESERVE_NOT_MET",
     gravity_key: "Please enter a bid higher than",
     header: "Your bid wasn't high enough",
-    description_md: () => `Your bid didn’t meet the reserve price for this work.  \
- Bid again to take the lead.`,
+    description_md: () => `Your bid didn’t meet the reserve price\nfor this work.\n\nBid again to take the lead.`,
   },
   {
     id: "SALE_CLOSED",
     gravity_key: "Sale Closed to Bids",
     header: "Lot closed",
-    description_md: () => "Sorry, your bid wasn’t received before the lot closed.",
+    description_md: () => "Sorry, your bid wasn’t received\nbefore the lot closed.",
   },
   {
     id: "LIVE_BIDDING_STARTED",
     gravity_key: "Live Bidding has Started",
     header: "Live bidding has started",
-    description_md: (params) => `Sorry, your bid wasn’t received before live bidding started.\
- To continue bidding, please [join the live auction](${params.liveAuctionUrl}).`,
+    description_md: (params) => `Sorry, your bid wasn’t received before\nlive bidding started. To continue\nbidding, please [join the live auction](${params.liveAuctionUrl}).`,
   },
   {
     id: "BIDDER_NOT_QUALIFIED",
     gravity_key: "Bidder not qualified to bid on this auction.",
     header: "Bid not placed",
-    description_md: () => `Your bid can’t be placed at this time.\
- Please contact [support@artsy.net](mailto:support@artsy.net) for more information.`,
-
+    description_md: () => `Your bid can’t be placed at this time.\nPlease contact [support@artsy.net](mailto:support@artsy.net) for\nmore information.`,
   },
   {
     id: "ERROR",
     gravity_key: "unknown error",
     header: "Bid not placed",
-    description_md: () => `Your bid can’t be placed at this time.\
- Please contact [support@artsy.net](mailto:support@artsy.net) for more information.`,
+    description_md: () => `Your bid can’t be placed at this time.\nPlease contact [support@artsy.net](mailto:support@artsy.net) for\nmore information.`,
   },
 ]


### PR DESCRIPTION
Now that we have https://github.com/artsy/emission/pull/1083 in and we should update the error descriptions for `BidderPositionResult`. I confirmed the `\n` syntax adds a line break properly. Let me know if there's any feedback!

<img width="598" alt="screen shot 2018-06-25 at 10 13 17 am" src="https://user-images.githubusercontent.com/386234/41856631-93ad6cbe-7863-11e8-9ccb-ed613253009b.png">
