### PR TITLE
raise resource limits

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -30,10 +30,9 @@ spec:
         resources:
           requests:
             cpu: "0.5"
-            memory: "512Mi"
-          limits:
-            cpu: "1"
             memory: "768Mi"
+          limits:
+            memory: "1Gi"
         readinessProbe:
           httpGet:
             port: 3000

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -32,8 +32,8 @@ spec:
             cpu: "0.2"
             memory: "512Mi"
           limits:
-            cpu: "0.5"
-            memory: "768Mi"
+            cpu: "1"
+            memory: "1Gi"
         readinessProbe:
           httpGet:
             port: 3000


### PR DESCRIPTION
Let's see how it behaves with a 1Gi ceiling

Also removing CPU limit in production as we have more threads running under the `UV_THREADPOOL`