### PR TITLE
[Saleable] Add interface to Artwork & EditionSet.

### DIFF
--- a/src/schema/artwork/index.js
+++ b/src/schema/artwork/index.js
@@ -18,6 +18,7 @@ import Meta, { artistNames } from "./meta"
 import Highlight from "./highlight"
 import Dimensions from "schema/dimensions"
 import EditionSet from "schema/edition_set"
+import { Saleable } from "schema/saleable"
 import ArtworkLayer from "./layer"
 import ArtworkLayers, { artworkLayers } from "./layers"
 import { GravityIDFields, NodeInterface } from "schema/object_identification"
@@ -292,7 +293,7 @@ export const artworkFields = () => {
     },
     is_acquireable: {
       type: GraphQLBoolean,
-      description: "Whether work can be purchased through e-commerce",
+      description: "Whether a work can be purchased through e-commerce",
       resolve: ({ acquireable }) => acquireable,
     },
     is_biddable: {
@@ -474,7 +475,7 @@ export const artworkFields = () => {
     },
     is_saved: {
       type: GraphQLBoolean,
-      resolve: ({ id }, {}, request, { rootValue: { savedArtworkLoader } }) => {
+      resolve: ({ id }, { }, request, { rootValue: { savedArtworkLoader } }) => {
         if (!savedArtworkLoader) return false
         return savedArtworkLoader(id).then(({ is_saved }) => is_saved)
       },
@@ -729,7 +730,7 @@ export const artworkFields = () => {
 
 export const ArtworkType = new GraphQLObjectType({
   name: "Artwork",
-  interfaces: [NodeInterface],
+  interfaces: [NodeInterface, Saleable],
   fields: () => {
     return {
       ...artworkFields(),

--- a/src/schema/edition_set.js
+++ b/src/schema/edition_set.js
@@ -3,6 +3,7 @@ import { IDFields } from "./object_identification"
 import Dimensions from "./dimensions"
 import { GraphQLString, GraphQLBoolean, GraphQLObjectType } from "graphql"
 import { capitalizeFirstCharacter } from "lib/helpers"
+import { Saleable } from "./saleable"
 
 const EditionSetAvailabilities = [
   "sold",
@@ -13,6 +14,7 @@ const EditionSetAvailabilities = [
 
 const EditionSetType = new GraphQLObjectType({
   name: "EditionSet",
+  interfaces: [Saleable],
   fields: {
     ...IDFields,
     dimensions: Dimensions,

--- a/src/schema/saleable.ts
+++ b/src/schema/saleable.ts
@@ -1,0 +1,29 @@
+import Dimensions from "./dimensions"
+import { GraphQLInterfaceType, GraphQLBoolean, GraphQLString } from "graphql"
+
+export const Saleable = new GraphQLInterfaceType({
+  name: "Saleable",
+  description: "A piece that can be sold",
+  fields: {
+    dimensions: Dimensions,
+    edition_of: {
+      type: GraphQLString,
+    },
+    is_acquireable: {
+      type: GraphQLBoolean,
+      description: "Whether a piece can be purchased through e-commerce",
+    },
+    is_for_sale: {
+      type: GraphQLBoolean,
+    },
+    is_sold: {
+      type: GraphQLBoolean,
+    },
+    price: {
+      type: GraphQLString,
+    },
+    sale_message: {
+      type: GraphQLString,
+    },
+  }
+})


### PR DESCRIPTION
Yay, our first real interface!

I’m not sure why the `EditionSet` type is called like that, isn’t each an entry in the set? Anyways, after thinking about `Edition`, `Piece`, etc for a while, I figured I’d go with an adjective form for interfaces as can be found in various examples, e.g. [`Searchable`](https://medium.com/the-graphqlhub/graphql-tour-interfaces-and-unions-7dd5be35de0d). Obviously I then had to choose between the various flavours of English (sellable, saleable, scalable) and settled on the one that seemed the most used in both English and Simplified (US) English.

----

This now allows you to have a fragment on `Saleable` and query any type that implements it:

```graphql
{
  artwork(id: "banksy-flower-bomber-by-brandalism") {
    ...Piece
    edition_sets {
      ...Piece
    }
  }
}

fragment Piece on Saleable {
  dimensions {
    in
  }
  edition_of
}
```

Meaning that containers that fetch this data can now be generic:

```tsx
export class SizeInfo extends React.Component<SizeInfoProps> {
  render() {
    const {
      piece: { dimensions, edition_of },
    } = this.props
    const dimensionsDescription = dimensions &&
            (dimensions.in || dimensions.cm) &&
            [dimensions.in, dimensions.cm].join("; ")
    return (
      <SizeInfoContainer color="black60" textAlign="left">
        <Serif size="2">
          {dimensionsDescription}
        </Serif>
        {edition_of && <Serif size="2">{edition_of}</Serif>}
      </SizeInfoContainer>
    )
  }
}

export const SizeInfoFragmentContainer = createFragmentContainer(
  SizeInfo,
  graphql`
    fragment SizeInfo_piece on Saleable {
      dimensions {
        in
        cm
      }
      edition_of
    }
  `
)
```

…and be instantiated with any type that implements the interface:

```tsx
<SizeInfo piece={this.props.artwork} />
<SizeInfo piece={this.props.artwork.edition_sets[0]} />
```