### PR TITLE
Ecommerce Mutations for Users

### DIFF
--- a/src/lib/stitching/exchange/link.ts
+++ b/src/lib/stitching/exchange/link.ts
@@ -19,8 +19,6 @@ export const createExchangeLink = () => {
     const locals = context.graphqlContext && context.graphqlContext.res.locals
     const tokenLoader = locals && locals.dataLoaders.exchangeTokenLoader
     const headers = { ...(locals && requestIDHeaders(locals.requestIDs)) }
-    // console.log("---> locals ", locals)
-    console.log("---> tokenloadr", tokenLoader)
     // If a token loader exists for Exchange (i.e. this is an authenticated request), use that token to make
     // authenticated requests to Exchange.
     if (tokenLoader) {

--- a/src/lib/stitching/exchange/link.ts
+++ b/src/lib/stitching/exchange/link.ts
@@ -19,6 +19,8 @@ export const createExchangeLink = () => {
     const locals = context.graphqlContext && context.graphqlContext.res.locals
     const tokenLoader = locals && locals.dataLoaders.exchangeTokenLoader
     const headers = { ...(locals && requestIDHeaders(locals.requestIDs)) }
+    // console.log("---> locals ", locals)
+    console.log("---> tokenloadr", tokenLoader)
     // If a token loader exists for Exchange (i.e. this is an authenticated request), use that token to make
     // authenticated requests to Exchange.
     if (tokenLoader) {

--- a/src/schema/__tests__/ecommerce/create_order_mutation.test.js
+++ b/src/schema/__tests__/ecommerce/create_order_mutation.test.js
@@ -87,36 +87,39 @@ describe("Create Order Mutation", () => {
               priceCents: 300000
             }]
           }) {
-            order {
-              id
-              code
-              currencyCode
-              state
-              partner {
+            result {
+              order {
                 id
-                name
-              }
-              user {
-                id
-                email
-              }
-              lineItems {
-                edges {
-                  node {
-                    artwork {
-                      id
-                      title
+                code
+                currencyCode
+                state
+                partner {
+                  id
+                  name
+                }
+                user {
+                  id
+                  email
+                }
+                lineItems {
+                  edges {
+                    node {
+                      artwork {
+                        id
+                        title
+                      }
                     }
                   }
                 }
               }
+              errors
             }
           }
         }
     `
 
     return runQuery(mutation, rootValue).then(data => {
-      expect(data.createOrder.order).toEqual(sampleOrder)
+      expect(data.createOrder.result.order).toEqual(sampleOrder)
     })
   })
 })

--- a/src/schema/__tests__/ecommerce/create_order_mutation.test.js
+++ b/src/schema/__tests__/ecommerce/create_order_mutation.test.js
@@ -1,0 +1,122 @@
+/* eslint-disable promise/always-return */
+import { runQuery } from "test/utils"
+import {
+  makeExecutableSchema,
+  transformSchema,
+  RenameTypes,
+  RenameRootFields,
+} from "graphql-tools"
+import fs from "fs"
+import path from "path"
+import sampleOrder from "test/fixtures/results/sample_order"
+import exchangeOrderJSON from "test/fixtures/exchange/order.json"
+
+let rootValue
+
+describe("Create Order Mutation", () => {
+  beforeEach(() => {
+    const typeDefs = fs.readFileSync(
+      path.resolve(__dirname, "../../../data/exchange.graphql"),
+      "utf8"
+    )
+
+    const resolvers = {
+      Mutation: {
+        createOrder: () => ({
+          order: exchangeOrderJSON,
+          errors: [],
+        }),
+      },
+    }
+
+    const schema = makeExecutableSchema({
+      typeDefs,
+      resolvers,
+    })
+
+    // namespace schema similar to src/lib/stitching/exchange/schema.ts
+    const exchangeSchema = transformSchema(schema, [
+      new RenameTypes(name => {
+        return `Ecommerce${name}`
+      }),
+      new RenameRootFields((_operation, name) => `ecommerce_${name}`),
+    ])
+
+    const partnerLoader = sinon.stub().returns(
+      Promise.resolve({
+        id: "111",
+        name: "Subscription Partner",
+      })
+    )
+
+    const userByIDLoader = sinon.stub().returns(
+      Promise.resolve({
+        id: "111",
+        email: "bob@ross.com",
+      })
+    )
+
+    const artworkLoader = sinon.stub().returns(
+      Promise.resolve({
+        id: "hubert-farnsworth-smell-o-scope",
+        title: "Smell-O-Scope",
+        display: "Smell-O-Scope (2017)",
+      })
+    )
+
+    const accessToken = "open-sesame"
+
+    rootValue = {
+      exchangeSchema,
+      partnerLoader,
+      userByIDLoader,
+      artworkLoader,
+      accessToken,
+    }
+  })
+  it("fetches order by id", () => {
+    const mutation = `
+      mutation {
+        createOrder(input: {
+            partnerId: "111",
+            userId: "111",
+            currencyCode: "usd",
+            lineItems: [{
+              artworkId: "111",
+              quantity: 1
+              priceCents: 300000
+            }]
+          }) {
+            order {
+              id
+              code
+              currencyCode
+              state
+              partner {
+                id
+                name
+              }
+              user {
+                id
+                email
+              }
+              lineItems {
+                edges {
+                  node {
+                    artwork {
+                      id
+                      title
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+    `
+
+    return runQuery(mutation, rootValue).then(data => {
+      expect(data.createOrder.order).toEqual(sampleOrder)
+    })
+  })
+})

--- a/src/schema/__tests__/ecommerce/submit_order_mutation.test.js
+++ b/src/schema/__tests__/ecommerce/submit_order_mutation.test.js
@@ -81,36 +81,39 @@ describe("Submit Order Mutation", () => {
             orderId: "111",
             creditCardId: "111",
           }) {
-            order {
-              id
-              code
-              currencyCode
-              state
-              partner {
+            result {
+              order {
                 id
-                name
-              }
-              user {
-                id
-                email
-              }
-              lineItems {
-                edges {
-                  node {
-                    artwork {
-                      id
-                      title
+                code
+                currencyCode
+                state
+                partner {
+                  id
+                  name
+                }
+                user {
+                  id
+                  email
+                }
+                lineItems {
+                  edges {
+                    node {
+                      artwork {
+                        id
+                        title
+                      }
                     }
                   }
                 }
               }
+              errors
             }
           }
         }
     `
 
     return runQuery(mutation, rootValue).then(data => {
-      expect(data.submitOrder.order).toEqual(sampleOrder)
+      expect(data.submitOrder.result.order).toEqual(sampleOrder)
     })
   })
 })

--- a/src/schema/__tests__/ecommerce/submit_order_mutation.test.js
+++ b/src/schema/__tests__/ecommerce/submit_order_mutation.test.js
@@ -1,0 +1,116 @@
+/* eslint-disable promise/always-return */
+import { runQuery } from "test/utils"
+import {
+  makeExecutableSchema,
+  transformSchema,
+  RenameTypes,
+  RenameRootFields,
+} from "graphql-tools"
+import fs from "fs"
+import path from "path"
+import sampleOrder from "test/fixtures/results/sample_order"
+import exchangeOrderJSON from "test/fixtures/exchange/order.json"
+
+let rootValue
+
+describe("Submit Order Mutation", () => {
+  beforeEach(() => {
+    const typeDefs = fs.readFileSync(
+      path.resolve(__dirname, "../../../data/exchange.graphql"),
+      "utf8"
+    )
+
+    const resolvers = {
+      Mutation: {
+        submitOrder: () => ({
+          order: exchangeOrderJSON,
+          errors: [],
+        }),
+      },
+    }
+
+    const schema = makeExecutableSchema({
+      typeDefs,
+      resolvers,
+    })
+
+    // namespace schema similar to src/lib/stitching/exchange/schema.ts
+    const exchangeSchema = transformSchema(schema, [
+      new RenameTypes(name => {
+        return `Ecommerce${name}`
+      }),
+      new RenameRootFields((_operation, name) => `ecommerce_${name}`),
+    ])
+
+    const partnerLoader = sinon.stub().returns(
+      Promise.resolve({
+        id: "111",
+        name: "Subscription Partner",
+      })
+    )
+
+    const userByIDLoader = sinon.stub().returns(
+      Promise.resolve({
+        id: "111",
+        email: "bob@ross.com",
+      })
+    )
+
+    const artworkLoader = sinon.stub().returns(
+      Promise.resolve({
+        id: "hubert-farnsworth-smell-o-scope",
+        title: "Smell-O-Scope",
+        display: "Smell-O-Scope (2017)",
+      })
+    )
+
+    const accessToken = "open-sesame"
+
+    rootValue = {
+      exchangeSchema,
+      partnerLoader,
+      userByIDLoader,
+      artworkLoader,
+      accessToken,
+    }
+  })
+  it("fetches order by id", () => {
+    const mutation = `
+      mutation {
+        submitOrder(input: {
+            orderId: "111",
+            creditCardId: "111",
+          }) {
+            order {
+              id
+              code
+              currencyCode
+              state
+              partner {
+                id
+                name
+              }
+              user {
+                id
+                email
+              }
+              lineItems {
+                edges {
+                  node {
+                    artwork {
+                      id
+                      title
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+    `
+
+    return runQuery(mutation, rootValue).then(data => {
+      expect(data.submitOrder.order).toEqual(sampleOrder)
+    })
+  })
+})

--- a/src/schema/ecommerce/create_order_mutation.js
+++ b/src/schema/ecommerce/create_order_mutation.js
@@ -1,0 +1,110 @@
+import {
+  GraphQLInputObjectType,
+  GraphQLNonNull,
+  GraphQLString,
+  GraphQLList,
+  GraphQLInt,
+  graphql,
+} from "graphql"
+import { OrderType } from "schema/ecommerce/types/order"
+import { mutationWithClientMutationId } from "graphql-relay"
+
+const LineItemInputType = new GraphQLInputObjectType({
+  name: "LineItemInput",
+  fields: {
+    artworkId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "ID of artwork",
+    },
+    quantity: {
+      type: new GraphQLNonNull(GraphQLInt),
+      description: "quantity of artwork",
+    },
+    priceCents: {
+      type: new GraphQLNonNull(GraphQLInt),
+      description: "Price in cents",
+    },
+  },
+})
+
+const CreateOrderInputType = new GraphQLInputObjectType({
+  name: "CreateOrderInput",
+  fields: {
+    userId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "ID of user submitting the order",
+    },
+    partnerId: {
+      type: GraphQLString,
+      description: "ID of partner representing artwork",
+    },
+    currencyCode: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "Currency code",
+    },
+    lineItems: {
+      type: new GraphQLList(LineItemInputType),
+      description: "Line items in the order",
+    },
+  },
+})
+
+export const CreateOrderMutation = mutationWithClientMutationId({
+  name: "CreateOrder",
+  decription: "Creates an order with payment",
+  inputFields: CreateOrderInputType.getFields(),
+  outputFields: {
+    order: {
+      type: OrderType,
+      resolve: order => order,
+    },
+  },
+  mutateAndGetPayload: (
+    { userId, partnerId, currencyCode, lineItems },
+    context,
+    { rootValue: { accessToken, exchangeSchema } }
+  ) => {
+    if (!accessToken) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    const mutation = `
+      mutation creatorder($currencyCode: String!, $partnerId: String!, $userId: String!) {
+        ecommerce_createOrder(input: {
+          partnerId: $partnerId,
+          userId: $userId,
+          currencyCode: $currencyCode,
+        }) {
+          order {
+           id
+            code
+            currencyCode
+            state
+            partnerId
+            userId
+            updatedAt
+            createdAt
+            lineItems{
+              edges{
+                node{
+                  id
+                  priceCents
+                  artworkId
+                  editionSetId
+                  quantity
+                }
+              }
+            }
+          }
+          errors
+        }
+      }
+    `
+    return graphql(exchangeSchema, mutation, null, context, {
+      userId,
+      partnerId,
+      currencyCode,
+      lineItems,
+    }).then(result => result.data.ecommerce_createOrder.order)
+  },
+})

--- a/src/schema/ecommerce/create_order_mutation.js
+++ b/src/schema/ecommerce/create_order_mutation.js
@@ -69,11 +69,12 @@ export const CreateOrderMutation = mutationWithClientMutationId({
     }
 
     const mutation = `
-      mutation creatorder($currencyCode: String!, $partnerId: String!, $userId: String!) {
+      mutation creatorder($currencyCode: String!, $partnerId: String!, $userId: String!, $lineItems: [EcommerceLineItemAttributes!]) {
         ecommerce_createOrder(input: {
           partnerId: $partnerId,
           userId: $userId,
           currencyCode: $currencyCode,
+          lineItems: $lineItems,
         }) {
           order {
            id

--- a/src/schema/ecommerce/create_order_mutation.js
+++ b/src/schema/ecommerce/create_order_mutation.js
@@ -1,12 +1,13 @@
 import {
   GraphQLInputObjectType,
   GraphQLNonNull,
-  GraphQLString,
   GraphQLList,
   GraphQLInt,
+  GraphQLString,
   graphql,
 } from "graphql"
-import { OrderType } from "schema/ecommerce/types/order"
+
+import { OrderReturnType } from "schema/ecommerce/types/order_return"
 import { mutationWithClientMutationId } from "graphql-relay"
 
 const LineItemInputType = new GraphQLInputObjectType({
@@ -54,9 +55,9 @@ export const CreateOrderMutation = mutationWithClientMutationId({
   decription: "Creates an order with payment",
   inputFields: CreateOrderInputType.getFields(),
   outputFields: {
-    order: {
-      type: OrderType,
-      resolve: order => order,
+    result: {
+      type: OrderReturnType,
+      resolve: result => result,
     },
   },
   mutateAndGetPayload: (
@@ -83,6 +84,7 @@ export const CreateOrderMutation = mutationWithClientMutationId({
             state
             partnerId
             userId
+            createdAt
             updatedAt
             createdAt
             lineItems{
@@ -106,6 +108,12 @@ export const CreateOrderMutation = mutationWithClientMutationId({
       partnerId,
       currencyCode,
       lineItems,
-    }).then(result => result.data.ecommerce_createOrder.order)
+    }).then(result => {
+      const { order, errors } = result.data.ecommerce_createOrder
+      return {
+        order,
+        errors,
+      }
+    })
   },
 })

--- a/src/schema/ecommerce/submit_order_mutation.js
+++ b/src/schema/ecommerce/submit_order_mutation.js
@@ -1,0 +1,79 @@
+import {
+  GraphQLInputObjectType,
+  GraphQLNonNull,
+  GraphQLString,
+  graphql,
+} from "graphql"
+import { OrderType } from "schema/ecommerce/types/order"
+import { mutationWithClientMutationId } from "graphql-relay"
+
+const SubmitOrderInputType = new GraphQLInputObjectType({
+  name: "SubmitOrderInput",
+  fields: {
+    orderId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "Order ID",
+    },
+    creditCardId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "Credit card ID",
+    },
+  },
+})
+
+export const SubmitOrderMutation = mutationWithClientMutationId({
+  name: "SubmitOrder",
+  decription: "Submitss an order with payment",
+  inputFields: SubmitOrderInputType.getFields(),
+  outputFields: {
+    order: {
+      type: OrderType,
+      resolve: order => order,
+    },
+  },
+  mutateAndGetPayload: (
+    { orderId, creditCardId },
+    context,
+    { rootValue: { accessToken, exchangeSchema } }
+  ) => {
+    if (!accessToken) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    const mutation = `
+      mutation submitOrder($orderId: ID!, $creditCardId: String!) {
+        ecommerce_submitOrder(input: {
+          id: $orderId,
+          creditCardId: $creditCardId,
+        }) {
+          order {
+           id
+            code
+            currencyCode
+            state
+            partnerId
+            userId
+            updatedAt
+            createdAt
+            lineItems{
+              edges{
+                node{
+                  id
+                  priceCents
+                  artworkId
+                  editionSetId
+                  quantity
+                }
+              }
+            }
+          }
+          errors
+        }
+      }
+    `
+    return graphql(exchangeSchema, mutation, null, context, {
+      orderId,
+      creditCardId,
+    }).then(result => result.data.ecommerce_submitOrder.order)
+  },
+})

--- a/src/schema/ecommerce/submit_order_mutation.js
+++ b/src/schema/ecommerce/submit_order_mutation.js
@@ -4,7 +4,7 @@ import {
   GraphQLString,
   graphql,
 } from "graphql"
-import { OrderType } from "schema/ecommerce/types/order"
+import { OrderReturnType } from "schema/ecommerce/types/order_return"
 import { mutationWithClientMutationId } from "graphql-relay"
 
 const SubmitOrderInputType = new GraphQLInputObjectType({
@@ -26,9 +26,9 @@ export const SubmitOrderMutation = mutationWithClientMutationId({
   decription: "Submitss an order with payment",
   inputFields: SubmitOrderInputType.getFields(),
   outputFields: {
-    order: {
-      type: OrderType,
-      resolve: order => order,
+    result: {
+      type: OrderReturnType,
+      resolve: result => result,
     },
   },
   mutateAndGetPayload: (
@@ -74,6 +74,9 @@ export const SubmitOrderMutation = mutationWithClientMutationId({
     return graphql(exchangeSchema, mutation, null, context, {
       orderId,
       creditCardId,
-    }).then(result => result.data.ecommerce_submitOrder.order)
+    }).then(result => {
+      const { order, errors } = result.data.ecommerce_submitOrder
+      return { order, errors }
+    })
   },
 })

--- a/src/schema/ecommerce/types/order.js
+++ b/src/schema/ecommerce/types/order.js
@@ -60,7 +60,7 @@ export const OrderType = new GraphQLObjectType({
         _args,
         _context,
         { rootValue: { userByIDLoader } }
-      ) => userByIDLoader(userId),
+      ) => (userId ? userByIDLoader(userId) : null),
     },
     updatedAt: date,
     createdAt: date,

--- a/src/schema/ecommerce/types/order_return.js
+++ b/src/schema/ecommerce/types/order_return.js
@@ -1,0 +1,18 @@
+import { GraphQLObjectType, GraphQLString, GraphQLList } from "graphql"
+
+import { OrderType } from "schema/ecommerce/types/order"
+
+//TODO: use OrderReturnType for all ecomerce query/mutations
+export const OrderReturnType = new GraphQLObjectType({
+  name: "OrderReturnType",
+  fields: {
+    order: {
+      type: OrderType,
+      decription: "Returned order object",
+    },
+    errors: {
+      type: new GraphQLList(GraphQLString),
+      decription: "Errors",
+    },
+  },
+})

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -18,6 +18,7 @@ import GeneFamily from "./gene_family"
 import HomePage from "./home"
 import { Order } from "./ecommerce/order"
 import { Orders } from "./ecommerce/orders"
+import { CreateOrderMutation } from "./ecommerce/create_order_mutation"
 import OrderedSet from "./ordered_set"
 import OrderedSets from "./ordered_sets"
 import Profile from "./profile"
@@ -159,6 +160,7 @@ const schema = new GraphQLSchema({
       updateCollectorProfile: UpdateCollectorProfile,
       updateMyUserProfile: UpdateMyUserProfileMutation,
       updateConversation: UpdateConversationMutation,
+      createOrder: CreateOrderMutation,
       sendConversationMessage: SendConversationMessageMutation,
       saveArtwork: SaveArtworkMutation,
       endSale: endSaleMutation,

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -19,6 +19,7 @@ import HomePage from "./home"
 import { Order } from "./ecommerce/order"
 import { Orders } from "./ecommerce/orders"
 import { CreateOrderMutation } from "./ecommerce/create_order_mutation"
+import { SubmitOrderMutation } from "./ecommerce/submit_order_mutation"
 import OrderedSet from "./ordered_set"
 import OrderedSets from "./ordered_sets"
 import Profile from "./profile"
@@ -161,6 +162,7 @@ const schema = new GraphQLSchema({
       updateMyUserProfile: UpdateMyUserProfileMutation,
       updateConversation: UpdateConversationMutation,
       createOrder: CreateOrderMutation,
+      submitOrder: SubmitOrderMutation,
       sendConversationMessage: SendConversationMessageMutation,
       saveArtwork: SaveArtworkMutation,
       endSale: endSaleMutation,


### PR DESCRIPTION
MP mutation endpoints that call express mutations to [create](https://github.com/artsy/exchange#create-an-order) or [submit](https://github.com/artsy/exchange#submit-an-order) an order.

I am not completely familiar with MP filename conventions so I wasn't sure if these mutations need to be under `/me/` path since they are triggered by a user from force, or better grouped with other e-commerce endpoints where it is now?

#### Sample queries:

* create
```
mutation {
  createOrder(input: {
      partnerId: "111",
      userId: "111",
      currencyCode: "usd",
      lineItems: [{
        artworkId: "111",
        quantity: 1
        priceCents: 300000
      }]
    }) {
      result {
        order {
          id
          code
          currencyCode
          state
          partner {
            id
            name
          }
          user {
            id
            email
          }
          lineItems {
            edges {
              node {
                artwork {
                  id
                  title
                }
              }
          }
        }
      }
    }
  }
``` 

* submit
```
mutation {
  submitOrder(input: {
      orderId: "111",
      creditCardId: "111",
    }) {
      order {
        id
        code
        currencyCode
        state
        partner {
          id
          name
        }
        user {
          id
          email
        }
        lineItems {
          edges {
            node {
              artwork {
                id
                title
              }
            }
          }
        }
      }
    }
  }
```