### PR TITLE
[WIP] Add user fields to sale and artwork bidding status

### DIFF
--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -32,6 +32,6 @@ it("It can make a request against the schema", async () => {
       `,
     })
 
-  expect(response.body).toEqual({ data: { artist: { name: "Mr Bank" } } })
+  expect(response.body.data).toEqual({ artist: { name: "Mr Bank" } })
   expect(response.statusCode).toBe(200)
 })

--- a/src/schema/artwork/index.js
+++ b/src/schema/artwork/index.js
@@ -33,6 +33,7 @@ import {
 import AttributionClass from "schema/artwork/attributionClass"
 // Mapping of attribution_class ids to AttributionClass values
 import attributionClasses from "../../lib/attributionClasses.js"
+import { LotStandingType } from "../me/lot_standing"
 
 const is_inquireable = ({ inquireable, acquireable }) => {
   return inquireable && !acquireable
@@ -122,6 +123,24 @@ export const artworkFields = () => {
     },
     availability: {
       type: GraphQLString,
+    },
+    bidderStatus: {
+      type: new GraphQLList(new GraphQLNonNull(LotStandingType)),
+      args: {
+        live: {
+          type: GraphQLBoolean,
+          defaultValue: null,
+        },
+      },
+      resolve: (
+        { id },
+        { live },
+        _request,
+        { rootValue: { lotStandingLoader } }
+      ) => {
+        if (!lotStandingLoader) return null
+        return lotStandingLoader({ artwork_id: id, live })
+      },
     },
     can_share_image: {
       type: GraphQLBoolean,
@@ -475,7 +494,7 @@ export const artworkFields = () => {
     },
     is_saved: {
       type: GraphQLBoolean,
-      resolve: ({ id }, { }, request, { rootValue: { savedArtworkLoader } }) => {
+      resolve: ({ id }, {}, request, { rootValue: { savedArtworkLoader } }) => {
         if (!savedArtworkLoader) return false
         return savedArtworkLoader(id).then(({ is_saved }) => is_saved)
       },

--- a/src/schema/sale/index.js
+++ b/src/schema/sale/index.js
@@ -1,4 +1,5 @@
 import Artwork from "schema/artwork"
+import Bidder from "schema/bidder"
 import Image from "schema/image/index"
 import Profile from "schema/profile"
 import Partner from "schema/partner"
@@ -319,6 +320,19 @@ export const SaleType = new GraphQLObjectType({
         },
       },
       registration_ends_at: date,
+      registrationStatus: {
+        type: Bidder.type,
+        description: "A registration for this sale",
+        resolve: (
+          { id },
+          _args,
+          _request,
+          { rootValue: { meBiddersLoader } }
+        ) => {
+          if (!meBiddersLoader) return null
+          return meBiddersLoader({ sale_id: id }).then(([bidder]) => bidder)
+        },
+      },
       require_bidder_approval: {
         type: GraphQLBoolean,
       },

--- a/src/schema/sale/index.js
+++ b/src/schema/sale/index.js
@@ -322,7 +322,7 @@ export const SaleType = new GraphQLObjectType({
       registration_ends_at: date,
       registrationStatus: {
         type: Bidder.type,
-        description: "A registration for this sale",
+        description: "A registration for this sale or null",
         resolve: (
           { id },
           _args,


### PR DESCRIPTION
Depends on https://github.com/artsy/gravity/pull/11796

This example still uses the incorrect `Artwork.sale` field which assumes that there’s only ever 1 live sale, but the `Artwork. bidderStatus` schema addition in this PR will correctly return a list, which for now the client should just select the first entry from.

```graphql
{
  artwork(id: "yohei-imamura-self-portrait") {
    sale {
      registrationStatus {
        qualified_for_bidding
      }
    }
    bidderStatus(live: true) {
      is_highest_bidder
    }
  }
}
```

```json
{
  "data": {
    "artwork": {
      "sale": {
        "registrationStatus": {
          "qualified_for_bidding": true
        }
      },
      "bidderStatus": [
        {
          "is_highest_bidder": true
        }
      ]
    }
  }
}
```