### PR TITLE
WIP: Returns order query errors to client #minor

### DIFF
--- a/src/schema/ecommerce/order.js
+++ b/src/schema/ecommerce/order.js
@@ -33,6 +33,11 @@ export const Order = {
     `
     return graphql(exchangeSchema, query, null, context, {
       id,
-    }).then(result => (result.data ? result.data.ecommerce_order : null))
+    }).then(result => {
+      if (result.errors) {
+        throw Error(result.errors.map(d => d.message))
+      }
+      return result.data.ecommerce_order
+    })
   },
 }

--- a/src/schema/ecommerce/orders.js
+++ b/src/schema/ecommerce/orders.js
@@ -1,5 +1,4 @@
 import { graphql, GraphQLString } from "graphql"
-import { connectionDefinitions } from "graphql-relay"
 import { OrderConnection } from "schema/ecommerce/types/order"
 
 export const Orders = {
@@ -50,6 +49,11 @@ export const Orders = {
       userId,
       partnerId,
       state,
-    }).then(a => a.data.ecommerce_orders)
+    }).then(result => {
+      if (result.errors) {
+        throw Error(result.errors.map(d => d.message))
+      }
+      return result.data.ecommerce_orders
+    })
   },
 }


### PR DESCRIPTION
Paired with @ashkan18 to return errors coming from Exchange to client.

Sample result when there is an error:

```
{
  "errors": [
    {
      "message": "Not permitted",
      "locations": [
        {
          "line": 158,
          "column": 3
        }
      ],
      "path": [
        "orders"
      ],
      "stack": "Not permitted\n\nGraphQL request 
       ...
    }
  ],
  "data": {
    "orders": null
  },
  "extensions": {
    "requests": {
      "gravity": {
        "requests": {
          "me/token?client_application_id=5b228bb2f7052934876c02cb": {
            "time": "0s 146.66ms",
            "cache": false
          }
        }
      }
    },
    "requestID": "ea5cba50-7e27-11e8-a88b-8318a4ff5156"
  }
}
```