### PR TITLE
Adds inventory id to order return

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.js
+++ b/src/lib/loaders/loaders_with_authentication/gravity.js
@@ -11,7 +11,7 @@ export default (accessToken, userID, opts) => {
   )
 
   return {
-    artworkLoader: gravityLoader(id => `artwork/${id}`),
+    authenticatedArtworkLoader: gravityLoader(id => `artwork/${id}`),
     collectionLoader: gravityLoader(id => `collection/${id}`, {
       user_id: userID,
     }),

--- a/src/lib/loaders/loaders_with_authentication/gravity.js
+++ b/src/lib/loaders/loaders_with_authentication/gravity.js
@@ -11,6 +11,7 @@ export default (accessToken, userID, opts) => {
   )
 
   return {
+    artworkLoader: gravityLoader(id => `artwork/${id}`),
     collectionLoader: gravityLoader(id => `collection/${id}`, {
       user_id: userID,
     }),

--- a/src/schema/__tests__/ecommerce/create_order_mutation.test.js
+++ b/src/schema/__tests__/ecommerce/create_order_mutation.test.js
@@ -56,7 +56,7 @@ describe("Create Order Mutation", () => {
       })
     )
 
-    const artworkLoader = sinon.stub().returns(
+    const authenticatedArtworkLoader = sinon.stub().returns(
       Promise.resolve({
         id: "hubert-farnsworth-smell-o-scope",
         title: "Smell-O-Scope",
@@ -70,7 +70,7 @@ describe("Create Order Mutation", () => {
       exchangeSchema,
       partnerLoader,
       userByIDLoader,
-      artworkLoader,
+      authenticatedArtworkLoader,
       accessToken,
     }
   })

--- a/src/schema/__tests__/ecommerce/order.test.js
+++ b/src/schema/__tests__/ecommerce/order.test.js
@@ -50,7 +50,7 @@ describe("Order type", () => {
       })
     )
 
-    const artworkLoader = sinon.stub().returns(
+    const authenticatedArtworkLoader = sinon.stub().returns(
       Promise.resolve({
         id: "hubert-farnsworth-smell-o-scope",
         title: "Smell-O-Scope",
@@ -58,7 +58,12 @@ describe("Order type", () => {
       })
     )
 
-    rootValue = { exchangeSchema, partnerLoader, userByIDLoader, artworkLoader }
+    rootValue = {
+      exchangeSchema,
+      partnerLoader,
+      userByIDLoader,
+      authenticatedArtworkLoader,
+    }
   })
   it("fetches order by id", () => {
     const query = `

--- a/src/schema/__tests__/ecommerce/orders.test.js
+++ b/src/schema/__tests__/ecommerce/orders.test.js
@@ -49,7 +49,7 @@ describe("Order type", () => {
       })
     )
 
-    const artworkLoader = sinon.stub().returns(
+    const authenticatedArtworkLoader = sinon.stub().returns(
       Promise.resolve({
         id: "hubert-farnsworth-smell-o-scope",
         title: "Smell-O-Scope",
@@ -57,7 +57,7 @@ describe("Order type", () => {
       })
     )
 
-    rootValue = { exchangeSchema, partnerLoader, userByIDLoader, artworkLoader }
+    rootValue = { exchangeSchema, partnerLoader, userByIDLoader, authenticatedArtworkLoader }
   })
   it("fetches order by partner id", () => {
     const query = `

--- a/src/schema/__tests__/ecommerce/submit_order_mutation.test.js
+++ b/src/schema/__tests__/ecommerce/submit_order_mutation.test.js
@@ -56,7 +56,7 @@ describe("Submit Order Mutation", () => {
       })
     )
 
-    const artworkLoader = sinon.stub().returns(
+    const authenticatedArtworkLoader = sinon.stub().returns(
       Promise.resolve({
         id: "hubert-farnsworth-smell-o-scope",
         title: "Smell-O-Scope",
@@ -70,7 +70,7 @@ describe("Submit Order Mutation", () => {
       exchangeSchema,
       partnerLoader,
       userByIDLoader,
-      artworkLoader,
+      authenticatedArtworkLoader,
       accessToken,
     }
   })

--- a/src/schema/artwork/index.js
+++ b/src/schema/artwork/index.js
@@ -310,6 +310,10 @@ export const artworkFields = () => {
         return Image.resolve(size ? _.take(sorted, size) : sorted)
       },
     },
+    inventory_id: {
+      type: GraphQLString,
+      description: "Private text field for partner use",
+    },
     is_acquireable: {
       type: GraphQLBoolean,
       description: "Whether a work can be purchased through e-commerce",

--- a/src/schema/ecommerce/types/order_line_item.js
+++ b/src/schema/ecommerce/types/order_line_item.js
@@ -19,8 +19,8 @@ export const OrderLineItemType = new GraphQLObjectType({
         { artworkId },
         _args,
         _context,
-        { rootValue: { artworkLoader } }
-      ) => artworkLoader(artworkId),
+        { rootValue: { authenticatedArtworkLoader } }
+      ) => authenticatedArtworkLoader(artworkId),
     },
     editionSet: {
       type: EditionSet.type,


### PR DESCRIPTION
<img width="945" alt="screen shot 2018-07-02 at 3 52 57 pm" src="https://user-images.githubusercontent.com/687513/42183512-20d82e1a-7e10-11e8-8e7e-41819d32afb1.png">

`artworkLoader` which was previously used was under `loaders_without_authentication` so it was receiving `artwork` object visible to  regular users without `inventory_id`. Suggestions about naming and better ways of handling this case is welcomed.
