### PR TITLE
Fix null itemsTotalCents

### DIFF
--- a/src/schema/__tests__/ecommerce/create_order_mutation.test.js
+++ b/src/schema/__tests__/ecommerce/create_order_mutation.test.js
@@ -92,6 +92,7 @@ describe("Create Order Mutation", () => {
                 id
                 code
                 currencyCode
+                itemsTotalCents
                 state
                 partner {
                   id

--- a/src/schema/__tests__/ecommerce/order.test.js
+++ b/src/schema/__tests__/ecommerce/order.test.js
@@ -64,9 +64,10 @@ describe("Order type", () => {
     const query = `
       {
         order(id: "52dd3c2e4b8480091700027f") {
-           id
+          id
           code
           currencyCode
+          itemsTotalCents
           state
           partner {
             id

--- a/src/schema/__tests__/ecommerce/orders.test.js
+++ b/src/schema/__tests__/ecommerce/orders.test.js
@@ -64,11 +64,12 @@ describe("Order type", () => {
       {
         orders(partnerId: "581b45e4cd530e658b000124") {
           edges {
-            node {          
+            node {
               id
               code
               currencyCode
               state
+              itemsTotalCents
               partner {
                 id
                 name

--- a/src/schema/__tests__/ecommerce/submit_order_mutation.test.js
+++ b/src/schema/__tests__/ecommerce/submit_order_mutation.test.js
@@ -86,6 +86,7 @@ describe("Submit Order Mutation", () => {
                 id
                 code
                 currencyCode
+                itemsTotalCents
                 state
                 partner {
                   id

--- a/src/schema/ecommerce/create_order_mutation.js
+++ b/src/schema/ecommerce/create_order_mutation.js
@@ -84,7 +84,7 @@ export const CreateOrderMutation = mutationWithClientMutationId({
             state
             partnerId
             userId
-            createdAt
+            itemsTotalCents
             updatedAt
             createdAt
             lineItems{

--- a/src/schema/ecommerce/order.js
+++ b/src/schema/ecommerce/order.js
@@ -35,7 +35,6 @@ export const Order = {
     return graphql(exchangeSchema, query, null, context, {
       id,
     }).then(result => {
-      console.log(result)
       if (result.errors) {
         throw Error(result.errors.map(d => d.message))
       }

--- a/src/schema/ecommerce/order.js
+++ b/src/schema/ecommerce/order.js
@@ -15,6 +15,7 @@ export const Order = {
           state
           partnerId
           userId
+          itemsTotalCents
           updatedAt
           createdAt
           lineItems{
@@ -34,6 +35,7 @@ export const Order = {
     return graphql(exchangeSchema, query, null, context, {
       id,
     }).then(result => {
+      console.log(result)
       if (result.errors) {
         throw Error(result.errors.map(d => d.message))
       }

--- a/src/schema/ecommerce/orders.js
+++ b/src/schema/ecommerce/orders.js
@@ -29,6 +29,7 @@ export const Orders = {
               userId
               updatedAt
               createdAt
+              itemsTotalCents
               lineItems{
                 edges{
                   node{

--- a/src/schema/ecommerce/submit_order_mutation.js
+++ b/src/schema/ecommerce/submit_order_mutation.js
@@ -53,6 +53,7 @@ export const SubmitOrderMutation = mutationWithClientMutationId({
             state
             partnerId
             userId
+            itemsTotalCents
             updatedAt
             createdAt
             lineItems{

--- a/src/test/fixtures/exchange/order.json
+++ b/src/test/fixtures/exchange/order.json
@@ -5,6 +5,7 @@
   "currencyCode": "usd",
   "partnerId": "111",
   "userId": "111",
+  "itemsTotalCents": "420000",
   "updatedAt": "",
   "createdAt": "",
   "lineItems": {

--- a/src/test/fixtures/exchange/orders.json
+++ b/src/test/fixtures/exchange/orders.json
@@ -1,4 +1,4 @@
-{ 
+{
   "edges": [
     {
       "node": {
@@ -8,6 +8,7 @@
         "currencyCode": "usd",
         "partnerId": "111",
         "userId": "111",
+        "itemsTotalCents": "420000",
         "updatedAt": "",
         "createdAt": "",
         "lineItems": {

--- a/src/test/fixtures/results/sample_order.js
+++ b/src/test/fixtures/results/sample_order.js
@@ -2,6 +2,7 @@ export default {
   id: "fooid123",
   code: "1",
   currencyCode: "usd",
+  itemsTotalCents: "$4,200",
   state: "PENDING",
   partner: {
     id: "111",


### PR DESCRIPTION
# Problem
`itemsTotalCents` was added in https://github.com/artsy/metaphysics/pull/1144 but it was not added to queries made to Exchange for fetching it, it was always null because of that.

# Solution
Add it :)

# Follow up
Add other price related fields, tax, shipping etc.