### PR TITLE
inventory_id -> inventoryId, 2nd attempt

### DIFF
--- a/src/schema/__tests__/ecommerce/create_order_mutation.test.js
+++ b/src/schema/__tests__/ecommerce/create_order_mutation.test.js
@@ -61,6 +61,7 @@ describe("Create Order Mutation", () => {
         id: "hubert-farnsworth-smell-o-scope",
         title: "Smell-O-Scope",
         display: "Smell-O-Scope (2017)",
+        inventory_id: "inventory note",
       })
     )
 
@@ -112,6 +113,7 @@ describe("Create Order Mutation", () => {
                       artwork {
                         id
                         title
+                        inventoryId
                       }
                     }
                   }

--- a/src/schema/__tests__/ecommerce/order.test.js
+++ b/src/schema/__tests__/ecommerce/order.test.js
@@ -55,6 +55,7 @@ describe("Order type", () => {
         id: "hubert-farnsworth-smell-o-scope",
         title: "Smell-O-Scope",
         display: "Smell-O-Scope (2017)",
+        inventory_id: "inventory note",
       })
     )
 
@@ -92,6 +93,7 @@ describe("Order type", () => {
                 artwork {
                   id
                   title
+                  inventoryId
                 }
               }
             }

--- a/src/schema/__tests__/ecommerce/orders.test.js
+++ b/src/schema/__tests__/ecommerce/orders.test.js
@@ -54,10 +54,16 @@ describe("Order type", () => {
         id: "hubert-farnsworth-smell-o-scope",
         title: "Smell-O-Scope",
         display: "Smell-O-Scope (2017)",
+        inventory_id: "inventory note",
       })
     )
 
-    rootValue = { exchangeSchema, partnerLoader, userByIDLoader, authenticatedArtworkLoader }
+    rootValue = {
+      exchangeSchema,
+      partnerLoader,
+      userByIDLoader,
+      authenticatedArtworkLoader,
+    }
   })
   it("fetches order by partner id", () => {
     const query = `
@@ -88,6 +94,7 @@ describe("Order type", () => {
                     artwork {
                       id
                       title
+                      inventoryId
                     }
                   }
                 }

--- a/src/schema/__tests__/ecommerce/submit_order_mutation.test.js
+++ b/src/schema/__tests__/ecommerce/submit_order_mutation.test.js
@@ -61,6 +61,7 @@ describe("Submit Order Mutation", () => {
         id: "hubert-farnsworth-smell-o-scope",
         title: "Smell-O-Scope",
         display: "Smell-O-Scope (2017)",
+        inventory_id: "inventory note",
       })
     )
 
@@ -106,6 +107,7 @@ describe("Submit Order Mutation", () => {
                       artwork {
                         id
                         title
+                        inventoryId
                       }
                     }
                   }

--- a/src/schema/artwork/index.js
+++ b/src/schema/artwork/index.js
@@ -313,6 +313,7 @@ export const artworkFields = () => {
     inventoryId: {
       type: GraphQLString,
       description: "Private text field for partner use",
+      resolve: ({ inventory_id }) => inventory_id,
     },
     is_acquireable: {
       type: GraphQLBoolean,

--- a/src/test/fixtures/results/sample_order.js
+++ b/src/test/fixtures/results/sample_order.js
@@ -23,6 +23,7 @@ export default {
           artwork: {
             id: "hubert-farnsworth-smell-o-scope",
             title: "Smell-O-Scope",
+            inventoryId: "inventory note",
           },
         },
       },


### PR DESCRIPTION
Missed a piece in the [previous PR](https://github.com/artsy/metaphysics/pull/1155) to rename `inventory_id` to `inventoryId`. To make up for that adding it to tests.