### PR TITLE
Lot standings endpoint supports inputting the sale_artwork_id 

### DIFF
--- a/src/schema/me/lot_standing.js
+++ b/src/schema/me/lot_standing.js
@@ -72,21 +72,26 @@ export default {
   description: "The current user's status relating to bids on artworks",
   args: {
     artwork_id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: GraphQLString,
     },
     sale_id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: GraphQLString,
+    },
+    sale_artwork_id: {
+      type: GraphQLString,
     },
   },
   resolve: (
     root,
-    { sale_id, artwork_id },
+    { sale_id, artwork_id, sale_artwork_id },
     request,
     { rootValue: { lotStandingLoader } }
   ) => {
     if (!lotStandingLoader) return null
-    return lotStandingLoader({ sale_id, artwork_id }).then(([lotStanding]) => {
-      return lotStanding
-    })
+    return lotStandingLoader({ sale_id, artwork_id, sale_artwork_id }).then(
+      ([lotStanding]) => {
+        return lotStanding
+      }
+    )
   },
 }


### PR DESCRIPTION
The gravity endpoint supports an optional `sale_artwork_id` param, and I'd like to use this from emission's side (since we'll be scoped by sale artwork at the point of entering the bid flow).

It means we don't get fancy validations around the inputs. Not sure if there's a way to say `(artwork_id && sale_id) || sale_artwork_id` with the types there.