### PR TITLE
Update fields of current event to match domain model

### DIFF
--- a/src/schema/artist/__tests__/current.test.js
+++ b/src/schema/artist/__tests__/current.test.js
@@ -16,8 +16,11 @@ describe("Artist type", () => {
         partner: {
           name: "Catty Partner",
         },
-        id: "contemporary-percy-z",
+        id: "catty-show",
         name: "Catty Show",
+        location: {
+          city: "Quonochontaug",
+        },
       },
     ],
   }
@@ -28,7 +31,7 @@ describe("Artist type", () => {
   const salesResponse = [
     {
       live_start_at: "2018-12-28T12:00:00+00:00",
-      id: "percy-z",
+      id: "catty-sale",
       name: "Catty Sale",
     },
   ]
@@ -43,19 +46,23 @@ describe("Artist type", () => {
       {
         artist(id: "percy-z") {
           currentEvent {
-            name
-            status 
+            status
             details
+            name
+            href
           }
         }
       }
     `
 
     return runQuery(query, rootValue).then(
-      ({ artist: { currentEvent: { name, status, details } } }) => {
+      ({
+        artist: { currentEvent: { status, partner, details, name, href } },
+      }) => {
         expect(name).toBe("Catty Sale")
         expect(status).toBe("Currently at auction")
         expect(details).toBe("Live bidding begins at Dec 28, 2018")
+        expect(href).toBe("/auction/catty-sale")
       }
     )
   })
@@ -67,19 +74,25 @@ describe("Artist type", () => {
         
         artist(id: "percy-z") {
           currentEvent {
-            name
-            status 
+            status
             details
+            name
+            href
+            partner
           }
         }
       }
     `
 
     return runQuery(query, rootValue).then(
-      ({ artist: { currentEvent: { name, status, details } } }) => {
+      ({
+        artist: { currentEvent: { name, status, details, href, partner } },
+      }) => {
         expect(name).toBe("Catty Show")
         expect(status).toBe("Currently on view")
-        expect(details).toMatch(/Catty Partner/)
+        expect(href).toBe("/show/catty-show")
+        expect(partner).toBe("Catty Partner")
+        expect(details).toBe("Quonochontaug, Dec 21 – 31")
       }
     )
   })

--- a/src/schema/artist/__tests__/current.test.js
+++ b/src/schema/artist/__tests__/current.test.js
@@ -44,18 +44,18 @@ describe("Artist type", () => {
         artist(id: "percy-z") {
           currentEvent {
             name
-            headline
-            subHeadline
+            status 
+            details
           }
         }
       }
     `
 
     return runQuery(query, rootValue).then(
-      ({ artist: { currentEvent: { name, headline, subHeadline } } }) => {
+      ({ artist: { currentEvent: { name, status, details } } }) => {
         expect(name).toBe("Catty Sale")
-        expect(headline).toBe("Currently at auction")
-        expect(subHeadline).toBe("Live bidding begins at Dec 28, 2018")
+        expect(status).toBe("Currently at auction")
+        expect(details).toBe("Live bidding begins at Dec 28, 2018")
       }
     )
   })
@@ -68,18 +68,18 @@ describe("Artist type", () => {
         artist(id: "percy-z") {
           currentEvent {
             name
-            headline
-            subHeadline
+            status 
+            details
           }
         }
       }
     `
 
     return runQuery(query, rootValue).then(
-      ({ artist: { currentEvent: { name, headline, subHeadline } } }) => {
+      ({ artist: { currentEvent: { name, status, details } } }) => {
         expect(name).toBe("Catty Show")
-        expect(headline).toBe("Currently on view")
-        expect(subHeadline).toMatch(/Catty Partner/)
+        expect(status).toBe("Currently on view")
+        expect(details).toMatch(/Catty Partner/)
       }
     )
   })

--- a/src/schema/artist/current.js
+++ b/src/schema/artist/current.js
@@ -10,25 +10,36 @@ const CurrentEventType = new GraphQLObjectType({
     image: {
       type: Image.type,
     },
-    headline: {
+    status: {
       type: GraphQLString,
+      description: "The state of the event",
     },
-    subHeadline: {
+    partner: {
       type: GraphQLString,
+      description: "Name of the partner associated to the event",
+    },
+    details: {
+      type: GraphQLString,
+      description: "Location and date of the event if available",
     },
     name: {
       type: GraphQLString,
+      description: "Name of the event",
+    },
+    page: {
+      type: GraphQLString,
+      description: "Link to the event",
     },
   },
 })
 
-const showSubHeadline = show => {
-  let headline = show.partner.name + "\n"
+const showDetails = show => {
+  let status = ""
   if (show.location && show.location.city) {
-    headline += show.location.city + ", "
+    status += show.location.city + ", "
   }
-  headline += exhibitionPeriod(show.start_at, show.end_at)
-  return headline
+  status += exhibitionPeriod(show.start_at, show.end_at)
+  return status
 }
 
 export const CurrentEvent = {
@@ -62,9 +73,9 @@ export const CurrentEvent = {
           const liveMoment = moment(sale.live_start_at)
           const { image_versions, image_url } = sale
           return {
-            headline: "Currently at auction",
+            status: "Currently at auction",
             name: sale.name,
-            subHeadline: `Live bidding begins at ${liveMoment.format(
+            details: `Live bidding begins at ${liveMoment.format(
               "MMM DD, YYYY"
             )}`,
             image: Image.resolve({ image_versions, image_url }),
@@ -73,9 +84,11 @@ export const CurrentEvent = {
           const show = shows[0]
           const { image_versions, image_url } = show
           return {
-            headline: "Currently on view",
+            status: "Currently on view",
             name: show.name,
-            subHeadline: showSubHeadline(show),
+            page: show.page,
+            partner: show.partner.name,
+            details: showDetails(show),
             image: Image.resolve({ image_versions, image_url }),
           }
         } else {

--- a/src/schema/artist/current.js
+++ b/src/schema/artist/current.js
@@ -26,7 +26,7 @@ const CurrentEventType = new GraphQLObjectType({
       type: GraphQLString,
       description: "Name of the event",
     },
-    page: {
+    href: {
       type: GraphQLString,
       description: "Link to the event",
     },
@@ -75,6 +75,7 @@ export const CurrentEvent = {
           return {
             status: "Currently at auction",
             name: sale.name,
+            href: `/auction/${sale.id}`,
             details: `Live bidding begins at ${liveMoment.format(
               "MMM DD, YYYY"
             )}`,
@@ -86,7 +87,7 @@ export const CurrentEvent = {
           return {
             status: "Currently on view",
             name: show.name,
-            page: show.page,
+            href: `/show/${show.id}`,
             partner: show.partner.name,
             details: showDetails(show),
             image: Image.resolve({ image_versions, image_url }),


### PR DESCRIPTION
There will be a sibling reaction PR shortly.

This PR aims to update the fields of the current event to match a little closer to what they are as opposed to the placeholders that were there previously. 

![image](https://user-images.githubusercontent.com/3087225/42293200-7beea436-7fa6-11e8-9a78-8109bb214e8c.png)

It also adds fields that were missing before... the fields should be

- image
- event status
- event name
- partner
- event details
- page (url to the event page)

Some tests should probably be added. I wasn't sure about some things... like if sales have partners associated with them. The designs actually don't show displaying a partner if it's an auction, but I'm not sure if that was intentional or if it was an oversight. 

Also, @mzikherman, I need to have a link to the show or sale... that's what the **page** field represents currently. I don't know that that's the best name for that field. I also don't know that how I'm grabbing it from the show is right 😅 . Lastly, I don't know what field it is from the sale object... halp?
