### PR TITLE
@sepans => use smart quotes when returning bidder position messages

### DIFF
--- a/src/schema/me/__tests__/bidder_position.test.js
+++ b/src/schema/me/__tests__/bidder_position.test.js
@@ -97,7 +97,7 @@ describe("BidderPosition", () => {
       expect(me).toEqual({
         bidder_position: {
           status: "RESERVE_NOT_MET",
-          message_header: "Your bid wasn't high enough",
+          message_header: "Your bid wasn’t high enough",
           message_description_md: `Your bid didn’t meet the reserve price\nfor this work.\n\nBid again to take the lead.`,
           position: {
             processed_at: "2018-04-26T14:15:52+00:00",
@@ -111,7 +111,7 @@ describe("BidderPosition", () => {
       expect(me).toEqual({
         bidder_position: {
           status: "OUTBID",
-          message_header: "Your bid wasn't high enough",
+          message_header: "Your bid wasn’t high enough",
           message_description_md: `Another bidder placed a higher max bid\nor the same max bid before you did.\n\nBid again to take the lead.`,
           position: {
             processed_at: "2018-04-26T14:15:52+00:00",

--- a/src/schema/me/__tests__/bidder_position_mutation.test.js
+++ b/src/schema/me/__tests__/bidder_position_mutation.test.js
@@ -32,13 +32,15 @@ describe("Bidder position mutation", () => {
   describe("success", () => {
     it("creates a bidder position", async () => {
       const rootValue = {
-        createBidderPositionLoader: sinon.stub().returns(
-          Promise.resolve(createBidderPosition)
-        ),
+        createBidderPositionLoader: sinon
+          .stub()
+          .returns(Promise.resolve(createBidderPosition)),
       }
 
       const data = await runAuthenticatedQuery(query, rootValue)
-      expect(data.createBidderPosition.result.position.suggested_next_bid_cents).toEqual(110000)
+      expect(
+        data.createBidderPosition.result.position.suggested_next_bid_cents
+      ).toEqual(110000)
       expect(data.createBidderPosition.result.message_header).toBeNull()
       expect(data.createBidderPosition.result.message_description_md).toBeNull()
     })
@@ -46,25 +48,26 @@ describe("Bidder position mutation", () => {
 
   describe("error", () => {
     it("creates correct message when bid is not high enough", async () => {
-      const errorObjectString =
-        `{"type": "param_error", "message":"Please enter a bid higher than $37,000.","detail"\
+      const errorObjectString = `{"type": "param_error", "message":"Please enter a bid higher than $37,000.","detail"\
 :{"base":["Please enter a bid higher than $37,000"]}}`
       const errorMessage = {
         message: errorMEssageTemplate + errorObjectString,
       }
       const rootValue = {
-        createBidderPositionLoader: sinon.stub().returns(
-          Promise.reject(errorMessage)
-        ),
+        createBidderPositionLoader: sinon
+          .stub()
+          .returns(Promise.reject(errorMessage)),
       }
 
       const data = await runAuthenticatedQuery(query, rootValue)
 
       expect(data.createBidderPosition.result.position).toBeNull()
-      expect(data.createBidderPosition.result.message_header).toEqual("Your bid wasn't high enough")
+      expect(data.createBidderPosition.result.message_header).toEqual(
+        "Your bid wasn’t high enough"
+      )
       expect(data.createBidderPosition.result.message_description_md).toEqual(
         "Another bidder placed a higher max bid\nor the same max bid before you did.\n\n" +
-        "Bid again to take the lead."
+          "Bid again to take the lead."
       )
     })
 
@@ -74,18 +77,19 @@ describe("Bidder position mutation", () => {
         message: errorMEssageTemplate + errorObjectString,
       }
       const rootValue = {
-        createBidderPositionLoader: sinon.stub().returns(
-          Promise.reject(errorMessage)
-        ),
+        createBidderPositionLoader: sinon
+          .stub()
+          .returns(Promise.reject(errorMessage)),
       }
 
       const data = await runAuthenticatedQuery(query, rootValue)
 
       expect(data.createBidderPosition.result.position).toBeNull()
-      expect(data.createBidderPosition.result.message_header).toEqual("Lot closed")
+      expect(data.createBidderPosition.result.message_header).toEqual(
+        "Lot closed"
+      )
       expect(data.createBidderPosition.result.message_description_md).toEqual(
-        "Sorry, your bid wasn’t received\n"+
-        "before the lot closed."
+        "Sorry, your bid wasn’t received\n" + "before the lot closed."
       )
     })
   })
@@ -96,19 +100,23 @@ describe("Bidder position mutation", () => {
       message: errorMEssageTemplate + errorObjectString,
     }
     const rootValue = {
-      createBidderPositionLoader: sinon.stub().returns(
-        Promise.reject(errorMessage)
-      ),
+      createBidderPositionLoader: sinon
+        .stub()
+        .returns(Promise.reject(errorMessage)),
     }
 
     const data = await runAuthenticatedQuery(query, rootValue)
 
     expect(data.createBidderPosition.result.position).toBeNull()
-    expect(data.createBidderPosition.result.message_header).toEqual("Live bidding has started")
+    expect(data.createBidderPosition.result.message_header).toEqual(
+      "Live bidding has started"
+    )
     expect(data.createBidderPosition.result.message_description_md).toEqual(
       "Sorry, your bid wasn’t received before\n" +
-      "live bidding started. To continue\n" +
-      `bidding, please [join the live auction](${config.PREDICTION_ENDPOINT}/sixteen-year-of-resistance-benefit-auction-2032).`
+        "live bidding started. To continue\n" +
+        `bidding, please [join the live auction](${
+          config.PREDICTION_ENDPOINT
+        }/sixteen-year-of-resistance-benefit-auction-2032).`
     )
   })
 })
@@ -119,18 +127,20 @@ it("creates correct message when bidder is not qualifdied", async () => {
     message: errorMEssageTemplate + errorObjectString,
   }
   const rootValue = {
-    createBidderPositionLoader: sinon.stub().returns(
-      Promise.reject(errorMessage)
-    ),
+    createBidderPositionLoader: sinon
+      .stub()
+      .returns(Promise.reject(errorMessage)),
   }
 
   const data = await runAuthenticatedQuery(query, rootValue)
 
   expect(data.createBidderPosition.result.position).toBeNull()
-  expect(data.createBidderPosition.result.message_header).toEqual("Bid not placed")
+  expect(data.createBidderPosition.result.message_header).toEqual(
+    "Bid not placed"
+  )
   expect(data.createBidderPosition.result.message_description_md).toEqual(
     "Your bid can’t be placed at this time.\n" +
-    "Please contact [support@artsy.net](mailto:support@artsy.net) for\n" +
-    "more information."
+      "Please contact [support@artsy.net](mailto:support@artsy.net) for\n" +
+      "more information."
   )
 })

--- a/src/schema/me/bidder_position_messages.js
+++ b/src/schema/me/bidder_position_messages.js
@@ -3,37 +3,45 @@ export const BiddingMessages = [
   {
     id: "OUTBID",
     gravity_key: "Please enter a bid higher than",
-    header: "Your bid wasn't high enough",
-    description_md: () => `Another bidder placed a higher max bid\nor the same max bid before you did.\n\nBid again to take the lead.`,
+    header: "Your bid wasn’t high enough",
+    description_md: () =>
+      `Another bidder placed a higher max bid\nor the same max bid before you did.\n\nBid again to take the lead.`,
   },
   {
     id: "RESERVE_NOT_MET",
     gravity_key: "Please enter a bid higher than",
-    header: "Your bid wasn't high enough",
-    description_md: () => `Your bid didn’t meet the reserve price\nfor this work.\n\nBid again to take the lead.`,
+    header: "Your bid wasn’t high enough",
+    description_md: () =>
+      `Your bid didn’t meet the reserve price\nfor this work.\n\nBid again to take the lead.`,
   },
   {
     id: "SALE_CLOSED",
     gravity_key: "Sale Closed to Bids",
     header: "Lot closed",
-    description_md: () => "Sorry, your bid wasn’t received\nbefore the lot closed.",
+    description_md: () =>
+      "Sorry, your bid wasn’t received\nbefore the lot closed.",
   },
   {
     id: "LIVE_BIDDING_STARTED",
     gravity_key: "Live Bidding has Started",
     header: "Live bidding has started",
-    description_md: (params) => `Sorry, your bid wasn’t received before\nlive bidding started. To continue\nbidding, please [join the live auction](${params.liveAuctionUrl}).`,
+    description_md: params =>
+      `Sorry, your bid wasn’t received before\nlive bidding started. To continue\nbidding, please [join the live auction](${
+        params.liveAuctionUrl
+      }).`,
   },
   {
     id: "BIDDER_NOT_QUALIFIED",
     gravity_key: "Bidder not qualified to bid on this auction.",
     header: "Bid not placed",
-    description_md: () => `Your bid can’t be placed at this time.\nPlease contact [support@artsy.net](mailto:support@artsy.net) for\nmore information.`,
+    description_md: () =>
+      `Your bid can’t be placed at this time.\nPlease contact [support@artsy.net](mailto:support@artsy.net) for\nmore information.`,
   },
   {
     id: "ERROR",
     gravity_key: "unknown error",
     header: "Bid not placed",
-    description_md: () => `Your bid can’t be placed at this time.\nPlease contact [support@artsy.net](mailto:support@artsy.net) for\nmore information.`,
+    description_md: () =>
+      `Your bid can’t be placed at this time.\nPlease contact [support@artsy.net](mailto:support@artsy.net) for\nmore information.`,
   },
 ]


### PR DESCRIPTION
#superminor we weren't using smart quotes in a few places here!

Looks like there are some extra white space changes which I think should be fine (just from prettier I'd guess).