### PR TITLE
@mzikherman => Adds my_increments to sale_artwork

### DIFF
--- a/src/schema/__tests__/sale_artwork.test.js
+++ b/src/schema/__tests__/sale_artwork.test.js
@@ -329,7 +329,7 @@ describe("SaleArtwork type", () => {
       query = `
         {
           sale_artwork(id: "54c7ed2a7261692bfa910200") {
-            my_increments {
+            increments(useMyMaxBid: true) {
               cents
               display
             }
@@ -340,7 +340,7 @@ describe("SaleArtwork type", () => {
 
     it("returns increments from the minimum next bid cents if the user has no lot standings", async () => {
       const data = await runAuthenticatedQuery(query, rootValue)
-      expect(data.sale_artwork.my_increments.slice(0, 5)).toEqual([
+      expect(data.sale_artwork.increments.slice(0, 5)).toEqual([
         {
           cents: 351000,
           display: "€3,510",
@@ -373,7 +373,7 @@ describe("SaleArtwork type", () => {
         ...rootValue,
         lotStandingLoader: lotStandingLoader,
       })
-      expect(data.sale_artwork.my_increments.slice(0, 5)).toEqual([
+      expect(data.sale_artwork.increments.slice(0, 5)).toEqual([
         {
           cents: 390000,
           display: "€3,900",
@@ -406,7 +406,7 @@ describe("SaleArtwork type", () => {
         ...rootValue,
         lotStandingLoader: lotStandingLoader,
       })
-      expect(data.sale_artwork.my_increments.slice(0, 5)).toEqual([
+      expect(data.sale_artwork.increments.slice(0, 5)).toEqual([
         {
           cents: 351000,
           display: "€3,510",

--- a/src/schema/me/lot_standings.js
+++ b/src/schema/me/lot_standings.js
@@ -23,10 +23,13 @@ export default {
       type: GraphQLString,
       description: "Only the lot standings for a specific auction",
     },
+    sale_artwork_id: {
+      type: GraphQLString,
+    },
   },
   resolve: (
     root,
-    { active_positions, artwork_id, live, sale_id },
+    { active_positions, artwork_id, live, sale_id, sale_artwork_id },
     request,
     { rootValue: { lotStandingLoader } }
   ) => {
@@ -36,6 +39,7 @@ export default {
       artwork_id,
       live,
       sale_id,
+      sale_artwork_id,
     }).then(lotStandings => {
       return lotStandings
     })


### PR DESCRIPTION
I'm opening this so we can start to have a discussion... _code talks_.

The problem I'm trying to solve is:
- in multiple places at Artsy (i.e. in emission and in force/reaction right now) we need to show users a dropdown list of increments that they can bid with. The logic for determining where to _start_ this increments list lives [here](https://github.com/artsy/force/blob/master/src/desktop/apps/artwork/components/auction/templates/bid.jade#L3-L4) right now, but as I'm working on adding it to emission it would live there as well.

This proposal moves the logic upstream to metaphysics, where it could potentially be re-used by force/reaction (I'm not sure if this has been implemented yet for the new artwork page, but presumably it would have to be).

Things I'm not sold on:
- `my_increments` isn't great naming, and I know we're always talking about camelCase.
- It's totally possible the client will need information about the lot standings as well (solo) and so technically they'd be fetching that twice. I guess with data loaders that shouldn't be an issue provided they're in the same query.
- I know @alloy was moving some things up to the `artwork` scope, but by the time we're querying for things like bid increments we must be scoping down to `sale_artwork` eventually. Increments make more sense to be here I think.

cc @alloy since this might affect some of the artwork page work.