### PR TITLE
Adds union type for returning success and failure on credit card mutation

### DIFF
--- a/src/lib/__tests__/gravityErrorHandler.test.js
+++ b/src/lib/__tests__/gravityErrorHandler.test.js
@@ -10,7 +10,6 @@ describe("gravityErrorHandler", () => {
       expect(formatGravityError(expectedErrorFormat)).toEqual({
         detail: "Your card has expired.",
         message: "Payment information could not be processed.",
-        statusCode: 400,
         type: "payment_error",
       })
     })
@@ -21,7 +20,6 @@ describe("gravityErrorHandler", () => {
       }
       expect(formatGravityError(unexpectedErrorFormat)).toEqual({
         message: '{"fooError"',
-        statusCode: 400,
       })
     })
     it("returns null if the error is unrecognizable", () => {

--- a/src/lib/__tests__/gravityErrorHandler.test.js
+++ b/src/lib/__tests__/gravityErrorHandler.test.js
@@ -1,0 +1,36 @@
+import { formatGravityError } from "../gravityErrorHandler"
+
+describe("gravityErrorHandler", () => {
+  describe("formatGravityError", () => {
+    it("returns a parsed error if of an expected format", () => {
+      const expectedErrorFormat = {
+        message: `https://stagingapi.artsy.net/api/v1/me/credit_cards?provider=stripe&token=tok_chargeDeclinedExpiredCard - {"type":"payment_error","message":"Payment information could not be processed.","detail":"Your card has expired."}`,
+        statusCode: 400,
+      }
+      expect(formatGravityError(expectedErrorFormat)).toEqual({
+        detail: "Your card has expired.",
+        message: "Payment information could not be processed.",
+        statusCode: 400,
+        type: "payment_error",
+      })
+    })
+    it("returns an unparsed error if the format is different", () => {
+      const unexpectedErrorFormat = {
+        message: `https://stagingapi.artsy.net/api/v1/me/credit_cards?provider=stripe&token=tok_chargeDeclinedExpiredCard - {"fooError"`,
+        statusCode: 400,
+      }
+      expect(formatGravityError(unexpectedErrorFormat)).toEqual({
+        message: '{"fooError"',
+        statusCode: 400,
+      })
+    })
+    it("returns null if the error is unrecognizable", () => {
+      const unrecognizableError = {
+        message:
+          "getaddrinfo ENOTFOUND stagingapi.artsy.net stagingapi.artsy.net:443",
+      }
+
+      expect(formatGravityError(unrecognizableError)).toEqual(null)
+    })
+  })
+})

--- a/src/lib/graphqlErrorHandler.js
+++ b/src/lib/graphqlErrorHandler.js
@@ -20,13 +20,6 @@ export const shouldReportError = originalError => {
   return true
 }
 
-export const formatGravityError = error => {
-  const errorSplit = error.message.split(" - ")
-  const errorObject =
-    errorSplit && errorSplit.length > 1 ? JSON.parse(errorSplit[1]) : null
-  return errorObject
-}
-
 export default function graphqlErrorHandler(
   req,
   { isProduction, enableSentry }

--- a/src/lib/graphqlErrorHandler.js
+++ b/src/lib/graphqlErrorHandler.js
@@ -20,6 +20,13 @@ export const shouldReportError = originalError => {
   return true
 }
 
+export const formatGravityError = error => {
+  const errorSplit = error.message.split(" - ")
+  const errorObject =
+    errorSplit && errorSplit.length > 1 ? JSON.parse(errorSplit[1]) : null
+  return errorObject
+}
+
 export default function graphqlErrorHandler(
   req,
   { isProduction, enableSentry }
@@ -42,7 +49,10 @@ export default function graphqlErrorHandler(
         )
       )
     } else {
-      const path = error.path && error.path.length > 0 ? ` (${JSON.stringify(error.path)})` : ""
+      const path =
+        error.path && error.path.length > 0
+          ? ` (${JSON.stringify(error.path)})`
+          : ""
       log(`${error.message}${path}`)
     }
     return {

--- a/src/lib/gravityErrorHandler.js
+++ b/src/lib/gravityErrorHandler.js
@@ -1,0 +1,34 @@
+import { GraphQLString, GraphQLInt, GraphQLObjectType } from "graphql"
+
+export const GravityMutationErrorType = new GraphQLObjectType({
+  name: "GravityMutationError",
+  fields: () => ({
+    type: {
+      type: GraphQLString,
+    },
+    message: {
+      type: GraphQLString,
+    },
+    detail: {
+      type: GraphQLString,
+    },
+    statusCode: {
+      type: GraphQLInt,
+    },
+  }),
+})
+
+export const formatGravityError = error => {
+  const errorSplit = error.message.split(" - ")
+  const statusCode = error.statusCode
+
+  if (errorSplit && errorSplit.length > 1) {
+    try {
+      return { ...JSON.parse(errorSplit[1]), statusCode }
+    } catch (e) {
+      return { message: errorSplit[1], statusCode }
+    }
+  } else {
+    return null
+  }
+}

--- a/src/lib/gravityErrorHandler.js
+++ b/src/lib/gravityErrorHandler.js
@@ -15,6 +15,9 @@ export const GravityMutationErrorType = new GraphQLObjectType({
     statusCode: {
       type: GraphQLInt,
     },
+    error: {
+      type: GraphQLString,
+    },
   }),
 })
 

--- a/src/lib/gravityErrorHandler.js
+++ b/src/lib/gravityErrorHandler.js
@@ -12,9 +12,6 @@ export const GravityMutationErrorType = new GraphQLObjectType({
     detail: {
       type: GraphQLString,
     },
-    statusCode: {
-      type: GraphQLInt,
-    },
     error: {
       type: GraphQLString,
     },
@@ -23,13 +20,12 @@ export const GravityMutationErrorType = new GraphQLObjectType({
 
 export const formatGravityError = error => {
   const errorSplit = error.message.split(" - ")
-  const statusCode = error.statusCode
 
   if (errorSplit && errorSplit.length > 1) {
     try {
-      return { ...JSON.parse(errorSplit[1]), statusCode }
+      return { ...JSON.parse(errorSplit[1]) }
     } catch (e) {
-      return { message: errorSplit[1], statusCode }
+      return { message: errorSplit[1] }
     }
   } else {
     return null

--- a/src/schema/me/__tests__/create_credit_card_mutation.test.js
+++ b/src/schema/me/__tests__/create_credit_card_mutation.test.js
@@ -11,7 +11,7 @@ describe("Credit card mutation", () => {
     expiration_year: 2018,
   }
 
-  const query = `
+  const oldQuery = `
   mutation {
     createCreditCard(input: {token: "123abc"}) {
       credit_card {
@@ -24,22 +24,76 @@ describe("Credit card mutation", () => {
   }
   `
 
+  const newQuery = `
+  mutation {
+    createCreditCard(input: {token: "tok_foo"}) {
+      creditCardOrError {
+        ... on CreditCardMutationSuccess {
+          credit_card {
+            id
+          }
+        }
+        ... on CreditCardMutationFailure {
+          mutationError {
+            type
+            message
+            detail
+            statusCode
+          }
+        }
+      }
+    }
+  }
+  `
+
   const rootValue = {
     createCreditCardLoader: () => Promise.resolve(creditCard),
   }
 
-  it("creates a credit card", async () => {
-    return runAuthenticatedQuery(query, rootValue).then(data => {
-      expect(data).toEqual({
-        createCreditCard: {
-          credit_card: {
-            name: "Foo User",
-            last_digits: "1234",
-            expiration_month: 3,
-            expiration_year: 2018,
+  it("creates a credit card with the old-style query", async () => {
+    const data = await runAuthenticatedQuery(oldQuery, rootValue)
+    expect(data).toEqual({
+      createCreditCard: {
+        credit_card: {
+          name: "Foo User",
+          last_digits: "1234",
+          expiration_month: 3,
+          expiration_year: 2018,
+        },
+      },
+    })
+  })
+
+  it("creates a credit card with an error message", async () => {
+    const errorRootValue = {
+      createCreditCardLoader: () =>
+        Promise.reject(
+          new Error(
+            `https://stagingapi.artsy.net/api/v1/me/credit_cards?provider=stripe&token=tok_chargeDeclinedExpiredCard - {"type":"payment_error","message":"Payment information could not be processed.","detail":"Your card has expired."}`
+          )
+        ),
+    }
+    const data = await runAuthenticatedQuery(newQuery, errorRootValue)
+    expect(data).toEqual({
+      createCreditCard: {
+        creditCardOrError: {
+          mutationError: {
+            detail: "Your card has expired.",
+            message: "Payment information could not be processed.",
+            statusCode: null,
+            type: "payment_error",
           },
         },
-      })
+      },
+    })
+  })
+
+  it("creates a credit card successfully with the new-style query", async () => {
+    const data = await runAuthenticatedQuery(newQuery, rootValue)
+    expect(data).toEqual({
+      createCreditCard: {
+        creditCardOrError: { credit_card: { id: "foo-foo" } },
+      },
     })
   })
 })

--- a/src/schema/me/__tests__/create_credit_card_mutation.test.js
+++ b/src/schema/me/__tests__/create_credit_card_mutation.test.js
@@ -29,7 +29,7 @@ describe("Credit card mutation", () => {
     createCreditCard(input: {token: "tok_foo"}) {
       creditCardOrError {
         ... on CreditCardMutationSuccess {
-          credit_card {
+          creditCard {
             id
           }
         }
@@ -38,7 +38,6 @@ describe("Credit card mutation", () => {
             type
             message
             detail
-            statusCode
           }
         }
       }
@@ -80,7 +79,6 @@ describe("Credit card mutation", () => {
           mutationError: {
             detail: "Your card has expired.",
             message: "Payment information could not be processed.",
-            statusCode: null,
             type: "payment_error",
           },
         },
@@ -92,7 +90,7 @@ describe("Credit card mutation", () => {
     const data = await runAuthenticatedQuery(newQuery, rootValue)
     expect(data).toEqual({
       createCreditCard: {
-        creditCardOrError: { credit_card: { id: "foo-foo" } },
+        creditCardOrError: { creditCard: { id: "foo-foo" } },
       },
     })
   })

--- a/src/schema/me/__tests__/create_credit_card_mutation.test.js
+++ b/src/schema/me/__tests__/create_credit_card_mutation.test.js
@@ -86,6 +86,17 @@ describe("Credit card mutation", () => {
     })
   })
 
+  it("throws an error if there is one we don't recognize", async () => {
+    const errorRootValue = {
+      createCreditCardLoader: () => {
+        throw new Error("ETIMEOUT service unreachable")
+      },
+    }
+    runAuthenticatedQuery(newQuery, errorRootValue).catch(error => {
+      expect(error.message).toEqual("ETIMEOUT service unreachable")
+    })
+  })
+
   it("creates a credit card successfully with the new-style query", async () => {
     const data = await runAuthenticatedQuery(newQuery, rootValue)
     expect(data).toEqual({

--- a/src/schema/me/create_credit_card_mutation.js
+++ b/src/schema/me/create_credit_card_mutation.js
@@ -95,7 +95,7 @@ export default mutationWithClientMutationId({
     { rootValue: { accessToken, createCreditCardLoader } }
   ) => {
     if (!accessToken) {
-      return new Error("You need to be signed in to perform this action")
+      throw new Error("You need to be signed in to perform this action")
     }
 
     return createCreditCardLoader({ token, provider: "stripe" })
@@ -105,7 +105,7 @@ export default mutationWithClientMutationId({
         if (formattedErr) {
           return { ...formattedErr, _type: "GravityMutationError" }
         } else {
-          return new Error(error)
+          throw new Error(error)
         }
       })
   },

--- a/src/schema/me/create_credit_card_mutation.js
+++ b/src/schema/me/create_credit_card_mutation.js
@@ -52,7 +52,9 @@ export const CreditCardMutationSuccessType = new GraphQLObjectType({
 
 export const CreditCardMutationFailureType = new GraphQLObjectType({
   name: "CreditCardMutationFailure",
-  isTypeOf: data => data.type && data.message,
+  isTypeOf: data => {
+    return data._type === "GravityMutationError"
+  },
   fields: () => ({
     mutationError: {
       type: GravityMutationErrorType,
@@ -101,7 +103,7 @@ export default mutationWithClientMutationId({
       .catch(error => {
         const formattedErr = formatGravityError(error)
         if (formattedErr) {
-          return formattedErr
+          return { ...formattedErr, _type: "GravityMutationError" }
         } else {
           return new Error(error)
         }

--- a/src/schema/me/create_credit_card_mutation.js
+++ b/src/schema/me/create_credit_card_mutation.js
@@ -7,22 +7,10 @@ import {
 } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 import { GravityIDFields } from "schema/object_identification"
-import { formatGravityError } from "lib/graphqlErrorHandler"
-
-export const GravityMutationErrorType = new GraphQLObjectType({
-  name: "GravityMutationError",
-  fields: () => ({
-    type: {
-      type: GraphQLString,
-    },
-    message: {
-      type: GraphQLString,
-    },
-    detail: {
-      type: GraphQLString,
-    },
-  }),
-})
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
 
 export const CreditCardType = new GraphQLObjectType({
   name: "CreditCard",
@@ -87,7 +75,16 @@ export default mutationWithClientMutationId({
     },
   },
   outputFields: {
-    result: {
+    credit_card: {
+      type: CreditCardType,
+      deprecationReason: "Favor `creditCardOrError`",
+      resolve: result => {
+        // have to return a dummy id since it is a non-nullable field
+        // TODO: remove in favor of creditCardOrError
+        return result && result.id ? result : { id: "", _id: "" }
+      },
+    },
+    creditCardOrError: {
       type: CreditCardMutationType,
       resolve: result => result,
     },

--- a/src/schema/me/create_credit_card_mutation.js
+++ b/src/schema/me/create_credit_card_mutation.js
@@ -43,9 +43,9 @@ export const CreditCardMutationSuccessType = new GraphQLObjectType({
   name: "CreditCardMutationSuccess",
   isTypeOf: data => data.id,
   fields: () => ({
-    credit_card: {
+    creditCard: {
       type: CreditCardType,
-      resolve: credit_card => credit_card,
+      resolve: creditCard => creditCard,
     },
   }),
 })
@@ -79,9 +79,7 @@ export default mutationWithClientMutationId({
       type: CreditCardType,
       deprecationReason: "Favor `creditCardOrError`",
       resolve: result => {
-        // have to return a dummy id since it is a non-nullable field
-        // TODO: remove in favor of creditCardOrError
-        return result && result.id ? result : { id: "", _id: "" }
+        return result && result.id ? result : null
       },
     },
     creditCardOrError: {


### PR DESCRIPTION
Marking this a WIP since I want to get some feedback before I write tests.

This represents yet another version of error handling... informed heavily by [this discussion](https://github.com/facebook/graphql/issues/298).

Some thoughts:
- For many mutations, the errors are known and useful to clients. We want to be able to present these in a first-class way, so it's beneficial to be able to do some formatting at the metaphysics level.
- It seems that there's a difference between errors (that should be handled as actual errors) and known validation failures and things like that. Overloading the `errors` field to include both doesn't seem quite right.

This solution allows us to query for both successes and failures in a first-class way:
![image](https://user-images.githubusercontent.com/2081340/42548095-66e6c5f4-8493-11e8-8c6d-55834f7c1077.png)

![image](https://user-images.githubusercontent.com/2081340/42548105-757036f0-8493-11e8-8e25-c9dd5c7d642a.png)