### PR TITLE
Updates logic around increments when useMyMaxBid is true

### DIFF
--- a/src/schema/__tests__/sale_artwork.test.js
+++ b/src/schema/__tests__/sale_artwork.test.js
@@ -364,9 +364,14 @@ describe("SaleArtwork type", () => {
       ])
     })
 
-    it("returns increments from the most recent bid if greater than the minimum_next_bid_cents", async () => {
+    it("returns increments from the most recent bid if you are leading", async () => {
       const lotStandingLoader = () => {
-        return [{ max_position: { max_bid_amount_cents: 390000 } }]
+        return [
+          {
+            max_position: { max_bid_amount_cents: 390000 },
+            leading_position: { max_bid_amount_cents: 390000 },
+          },
+        ]
       }
 
       const data = await execute(query, saleArtwork, {
@@ -374,10 +379,6 @@ describe("SaleArtwork type", () => {
         lotStandingLoader: lotStandingLoader,
       })
       expect(data.sale_artwork.increments.slice(0, 5)).toEqual([
-        {
-          cents: 390000,
-          display: "€3,900",
-        },
         {
           cents: 395000,
           display: "€3,950",
@@ -394,12 +395,21 @@ describe("SaleArtwork type", () => {
           cents: 420000,
           display: "€4,200",
         },
+        {
+          cents: 430000,
+          display: "€4,300",
+        },
       ])
     })
 
-    it("returns increments from the minimum_next_bid_cents if greater than my most recent bid", async () => {
+    it("returns increments from the minimum_next_bid_cents if you are not leading", async () => {
       const lotStandingLoader = () => {
-        return [{ max_position: { max_bid_amount_cents: 340000 } }]
+        return [
+          {
+            max_position: { max_bid_amount_cents: 340000 },
+            leading_position: null,
+          },
+        ]
       }
 
       const data = await execute(query, saleArtwork, {


### PR DESCRIPTION
While testing this out again, I noticed two minor things:
- If you attempt to pass `useMyMaxBid: true` but aren't logged in, we'd get an error from `lotStandingLoader` not existing. I updated this to check if that's there-- if not we return the generic increments.
- I think we can actually update the logic to consider your `leading` status (leading means you're the highest bidder on the lot-- I don't way "winning" since that has other implications around the reserve). More explanation below...

Current logic:
- If you have no bids on the lot, we return increments beginning at the `minimum_next_bid_cents`
- If you have a bid on the lot but aren't _leading_, we return increments beginning at the `minumum_next_bid_cents`. In this case, your max bid must be lower than the `minimum_next_bid` or else you would be the leader.
- If you have a bid on the lot and you _are_ leading, we return increments beginning at _your_ asking price. This will be one increment above your current maximum position on the lot.