### PR TITLE
Remove the "bid again to take the lead" message from the bidder position mutation

### DIFF
--- a/src/schema/me/__tests__/bidder_position.test.js
+++ b/src/schema/me/__tests__/bidder_position.test.js
@@ -98,7 +98,7 @@ describe("BidderPosition", () => {
         bidder_position: {
           status: "RESERVE_NOT_MET",
           message_header: "Your bid wasn’t high enough",
-          message_description_md: `Your bid didn’t meet the reserve price\nfor this work.\n\nBid again to take the lead.`,
+          message_description_md: `Your bid didn’t meet the reserve price\nfor this work.`,
           position: {
             processed_at: "2018-04-26T14:15:52+00:00",
           },
@@ -112,7 +112,7 @@ describe("BidderPosition", () => {
         bidder_position: {
           status: "OUTBID",
           message_header: "Your bid wasn’t high enough",
-          message_description_md: `Another bidder placed a higher max bid\nor the same max bid before you did.\n\nBid again to take the lead.`,
+          message_description_md: `Another bidder placed a higher max bid\nor the same max bid before you did.`,
           position: {
             processed_at: "2018-04-26T14:15:52+00:00",
           },

--- a/src/schema/me/__tests__/bidder_position_mutation.test.js
+++ b/src/schema/me/__tests__/bidder_position_mutation.test.js
@@ -66,8 +66,7 @@ describe("Bidder position mutation", () => {
         "Your bid wasn’t high enough"
       )
       expect(data.createBidderPosition.result.message_description_md).toEqual(
-        "Another bidder placed a higher max bid\nor the same max bid before you did.\n\n" +
-          "Bid again to take the lead."
+        "Another bidder placed a higher max bid\nor the same max bid before you did."
       )
     })
 

--- a/src/schema/me/bidder_position_messages.js
+++ b/src/schema/me/bidder_position_messages.js
@@ -5,14 +5,14 @@ export const BiddingMessages = [
     gravity_key: "Please enter a bid higher than",
     header: "Your bid wasn’t high enough",
     description_md: () =>
-      `Another bidder placed a higher max bid\nor the same max bid before you did.\n\nBid again to take the lead.`,
+      `Another bidder placed a higher max bid\nor the same max bid before you did.`,
   },
   {
     id: "RESERVE_NOT_MET",
     gravity_key: "Please enter a bid higher than",
     header: "Your bid wasn’t high enough",
     description_md: () =>
-      `Your bid didn’t meet the reserve price\nfor this work.\n\nBid again to take the lead.`,
+      `Your bid didn’t meet the reserve price\nfor this work.`,
   },
   {
     id: "SALE_CLOSED",


### PR DESCRIPTION
Per our mocktion yesterday. This messaging can be misleading.