### PR TITLE
sample number of active handles and requests and send to custom metrics

### DIFF
--- a/src/lib/stats.js
+++ b/src/lib/stats.js
@@ -69,4 +69,9 @@ if (enableMetrics && isProd) {
     statsClient.gauge("gc.heap_used", gcMetrics.used)
     statsClient.timing("gc.sweep_duration", gcMetrics.duration, {sweep_type: gcMetrics.type})
   })
+
+  setInterval(() => {
+    statsClient.gauge("process.active_handles", process._getActiveHandles().length)
+    statsClient.gauge("process.active_requests", process._getActiveRequests().length)
+  }, 5000)
 }


### PR DESCRIPTION
[Folks say](https://github.com/nodejs/node/issues/1128) that you should watch node's `process._getActiveHandles()` and `process._getActiveRequests()` as this can give an indication of "pending work" queued throughout the event loop's internal phases.
