### PR TITLE
Switch to the native promise in node

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 import "moment-timezone"
-import Bluebird from "bluebird"
 import xapp from "artsy-xapp"
 import compression from "compression"
 import express from "express"
@@ -17,8 +16,6 @@ const {
   NODE_ENV,
   PORT,
 } = config
-
-global.Promise = Bluebird
 
 const port = PORT
 const isDevelopment = NODE_ENV === "development"
@@ -62,12 +59,15 @@ function bootApp() {
       .end()
   })
 
-  app.get('/health', (req, res) => {
-    cache.isAvailable().then((stats) => {
-      return res.status(200).end()
-    }).catch((err) => {
-      return res.status(503).end()
-    })
+  app.get("/health", (req, res) => {
+    cache
+      .isAvailable()
+      .then(stats => {
+        return res.status(200).end()
+      })
+      .catch(err => {
+        return res.status(503).end()
+      })
   })
 
   app.all("/graphql", (_req, res) => res.redirect("/"))

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "babel-plugin-module-resolver": "^3.0.0",
     "babel-plugin-transform-flow-strip-types": "7.0.0-beta.3",
     "basic-auth": "^1.0.3",
-    "bluebird": "^3.3.4",
     "body-parser": "^1.15.2",
     "compression": "^1.7.2",
     "cors": "^2.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1436,10 +1436,6 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.3.4:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
-
 body-parser@1.18.2, body-parser@^1.15.2:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.2.tgz#87678a19d84b47d859b83199bd59bce222b10454"


### PR DESCRIPTION
There's a possibility that we're using features in bluebird that aren't available in the native implementation (and without types, we don't know) so I'm doing a run through - FWIW, tests all pass, including a single integration test.