### PR TITLE
Workaround DNS issues - use default DNS resolvers inherited from the host machine

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -20,6 +20,15 @@ spec:
     spec:
       containers:
       - name: metaphysics-web
+        env:
+        - name: DD_TRACER_HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: STATSD_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         envFrom:
         - configMapRef:
             name: metaphysics-environment
@@ -43,6 +52,7 @@ spec:
               value: https
           initialDelaySeconds: 5
           periodSeconds: 5
+      dnsPolicy: Default
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -20,6 +20,15 @@ spec:
     spec:
       containers:
       - name: metaphysics-web
+        env:
+        - name: DD_TRACER_HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: STATSD_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         envFrom:
         - configMapRef:
             name: metaphysics-environment
@@ -43,6 +52,7 @@ spec:
               value: https
           initialDelaySeconds: 5
           periodSeconds: 5
+      dnsPolicy: Default
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Use the pod config `dnsPolicy: Default` to bypass internal DNS - this directly inherits `/etc/resolv.conf` from the host machine, and in our case in AWS it is set to:

```
nameserver 10.0.0.2
search ec2.internal
```

This will completely bypass the Kubernetes DNS service and use the AWS internal DNS resolvers - the pod will not be able to resolve other internal service names like `gravity-web` and `datadog`, but it will work around the known [ndots problem](https://rsmitty.github.io/KubeDNS-Tweaks/) and avoid redundant DNS queries for `api.artsy.net.default.svc.cluster.local` / `api.artsy.net.svc.cluster.local` / `api.artsy.net.ec2.internal` - without `ndots` specified, only domains without _any_ dots are treated as un-fully-qualified and the search domains are applied.

We do need to talk to Datadog running in k8s so set `DD_TRACER_HOSTNAME` and `STATSD_HOST` from the node name.
