### PR TITLE
@zephraph => Allow cv status for artist page to take in an optional minShowCount

### DIFF
--- a/src/schema/artist/__tests__/statuses.test.js
+++ b/src/schema/artist/__tests__/statuses.test.js
@@ -50,4 +50,26 @@ describe("Artist Statuses", () => {
       })
     })
   })
+
+  it("allows an optional min show count arg for the CV status", () => {
+    const query = `
+      {
+        artist(id: "foo-bar") {
+          statuses {
+            cv(minShowCount: 43)
+          }
+        }
+      }
+    `
+
+    return runQuery(query, rootValue).then(data => {
+      expect(data).toEqual({
+        artist: {
+          statuses: {
+            cv: false,
+          },
+        },
+      })
+    })
+  })
 })

--- a/src/schema/artist/statuses.js
+++ b/src/schema/artist/statuses.js
@@ -1,4 +1,4 @@
-import { GraphQLObjectType, GraphQLBoolean } from "graphql"
+import { GraphQLObjectType, GraphQLBoolean, GraphQLInt } from "graphql"
 import { totalViaLoader } from "lib/total"
 
 const ArtistStatusesType = new GraphQLObjectType({
@@ -67,7 +67,16 @@ const ArtistStatusesType = new GraphQLObjectType({
     },
     cv: {
       type: GraphQLBoolean,
-      resolve: ({ partner_shows_count }) => partner_shows_count > 15,
+      args: {
+        minShowCount: {
+          type: GraphQLInt,
+          description:
+            "Suppress the cv tab when artist show count is less than this.",
+          defaultValue: 15,
+        },
+      },
+      resolve: ({ partner_shows_count }, { minShowCount }) =>
+        partner_shows_count > minShowCount,
     },
     shows: {
       type: GraphQLBoolean,


### PR DESCRIPTION
This will allow the Reaction implementation to specify `cv(minShowCount: 1)`, in order for that to show up if there's at least one show (while the current artist page keeps its default 15 value).