### PR TITLE
Uses uncached gravity loader for artworks' sale artworks

### DIFF
--- a/src/lib/loaders/loaders_without_authentication/gravity.js
+++ b/src/lib/loaders/loaders_without_authentication/gravity.js
@@ -81,9 +81,10 @@ export default opts => {
     relatedShowsLoader: gravityLoader("related/shows", {}, { headers: true }),
     saleLoader: gravityLoader(id => `sale/${id}`),
     salesLoader: gravityLoader("sales"),
-    saleArtworkLoader: gravityLoader(
+    saleArtworkLoader: gravityUncachedLoader(
       ({ saleId, saleArtworkId }) =>
-        `sale/${saleId}/sale_artwork/${saleArtworkId}`
+        `sale/${saleId}/sale_artwork/${saleArtworkId}`,
+      null
     ),
     saleArtworkRootLoader: gravityUncachedLoader(
       id => `sale_artwork/${id}`,


### PR DESCRIPTION
Sale artworks have bid increments which change often, so we don't want to cache them. https://github.com/artsy/metaphysics/pull/1178 changed the sale artwork _root_ loader to not use the cache, but sale artworks accessed through the artwork schema were still being cached. Consider the following two ways to access the same information:

```graphql
{
  artwork(id:"5b4de57ef0676200017a0b15")  {
    sale_artwork {
      minimum_next_bid {
        display
      }
    }
  }
  
  sale_artwork(id:"5b4de57ff0676200017a0b1c") {
    minimum_next_bid {
      display
    }
  }
}
```

Even though they operate on the same model, they use different caching strategies. This PR would make them both uncached.

This is a fix for [PURCHASE-297](
https://artsyproduct.atlassian.net/browse/PURCHASE-297).