### PR TITLE
hotfix - use dumb-init to proxy signals correctly to node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@ FROM node:8.4.0
 RUN adduser --disabled-password --gecos '' deploy
 RUN mkdir -p /app
 
+# Set up dumb-init
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
+RUN chown deploy:deploy /usr/local/bin/dumb-init
+RUN chmod +x /usr/local/bin/dumb-init
+
 RUN npm install -g yarn@1.0.1
 
 # Set up /app for deploy user
@@ -22,4 +27,5 @@ RUN yarn install
 # Run babel compiler
 RUN yarn build
 
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 CMD node build/index.js


### PR DESCRIPTION
https://github.com/artsy/metaphysics/pull/1182 is not working correctly on k8s because k8s sends a `SIGTERM` to PID 1 in the container on termination, which is by default `sh -c` which does not proxy signals to the process(es) it spawns.  `dumb-init` is designed to fix this problem as well as others arising from processes run as PID 1.