### PR TITLE
hotfix - destroy keepalive HTTP connections on shutdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ RUN yarn install
 RUN yarn build
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
-CMD node build/index.js
+CMD ["node", "build/index.js"]

--- a/index.js
+++ b/index.js
@@ -85,9 +85,9 @@ function bootApp() {
     app.use(require("./src").default)
   }
 
-  server = app.listen(port, () =>
+  server = require('http-shutdown')(app.listen(port, () =>
     info(`[Metaphysics] Listening on http://localhost:${port}`)
-  )
+  ))
 }
 
 process.on('SIGTERM', gracefulExit)
@@ -96,7 +96,7 @@ function gracefulExit() {
   if (isShuttingDown) return
   isShuttingDown = true
   console.log('Received signal SIGTERM, shutting down')
-  server.close(function () {
+  server.shutdown(function () {
     console.log('Closed existing connections.')
     process.exit(0)
   })

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "graphql-relay": "^0.5.4",
     "graphql-tools": "^3.0.0",
     "graphql-type-json": "^0.1.4",
+    "http-shutdown": "^1.2.0",
     "hot-shots": "^5.6.1",
     "i": "^0.3.5",
     "invariant": "^2.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3419,6 +3419,10 @@ http-proxy@^1.16.2:
     eventemitter3 "1.x.x"
     requires-port "1.x.x"
 
+http-shutdown@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/http-shutdown/-/http-shutdown-1.2.0.tgz#df2d8067a8856e99d11e9dceb21609591e1df514"
+
 http-signature@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"


### PR DESCRIPTION
Follows up on https://github.com/artsy/metaphysics/pull/1192 and https://github.com/artsy/metaphysics/pull/1182 - keepalive HTTP connections need to be destroyed otherwise server will not shut down.  Use https://www.npmjs.com/package/http-shutdown to destroy keepalive connections.

Also a fix in Dockerfile `CMD` syntax

cc @alloy @orta 