### PR TITLE
#migration test cache compression in metaphysics-web-green deployment

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -63,6 +63,78 @@ spec:
                 values:
                 - foreground
 
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: metaphysics-web-green
+spec:
+  replicas: 2
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: metaphysics
+        layer: application
+        component: web
+      name: metaphysics-web-green
+      namespace: default
+    spec:
+      containers:
+      - name: metaphysics-web-green
+        env:
+        - name: DD_TRACER_SERVICE_NAME
+          value: metaphysics-green
+        - name: CACHE_COMPRESSION_DISABLED
+          value: "true"
+        - name: DD_TRACER_HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: STATSD_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        envFrom:
+        - configMapRef:
+            name: metaphysics-environment
+        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/metaphysics:production
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 3000
+        resources:
+          requests:
+            cpu: "0.5"
+            memory: "512Mi"
+          limits:
+            cpu: "1"
+            memory: "1Gi"
+        readinessProbe:
+          httpGet:
+            port: 3000
+            path: /health
+            httpHeaders:
+            - name: X-FORWARDED-PROTO
+              value: https
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      dnsPolicy: Default
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: tier
+                operator: In
+                values:
+                - foreground
+
+
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler


### PR DESCRIPTION
This sets up a "green" production deployment to test against the current "blue" deployment with cache compression disabled (all env vars hardcoded in the kubernetes yaml spec override any pulled in from the config map (set with `hokusai [staging|prouduction] env`)

The deployment will create 2 replicas which will be targeted by the metaphysics service along with the existing replicas, and so will receive a proportional amount of the traffic (around 8% with the current metaphysics scaling parameters)

We will be able to compare metrics taken from this sample set to existing metrics as they will come up as separate "metaphysics-green" services set by `DD_TRACER_SERVICE_NAME`

# Migration

Run `hokusai production update` to create the new deployment
