### PR TITLE
Resource / Autoscaling tweaks - introduce cpu-hog label

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -146,7 +146,7 @@ spec:
     name: metaphysics-web
   minReplicas: 10
   maxReplicas: 20
-  targetCPUUtilizationPercentage: 70
+  targetCPUUtilizationPercentage: 80
 
 ---
 apiVersion: v1

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -63,14 +63,16 @@ spec:
                 values:
                 - foreground
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: temperament
-                operator: In
-                values:
-                - cpu-hog
-            topologyKey: "kubernetes.io/hostname"
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: temperament
+                  operator: In
+                  values:
+                  - cpu-hog
+              topologyKey: "kubernetes.io/hostname"
 
 
 ---

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -15,6 +15,7 @@ spec:
         app: metaphysics
         layer: application
         component: web
+        temperament: cpu-hog
       name: metaphysics-web
       namespace: default
     spec:
@@ -61,6 +62,15 @@ spec:
                 operator: In
                 values:
                 - foreground
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: temperament
+                operator: In
+                values:
+                - cpu-hog
+            topologyKey: "kubernetes.io/hostname"
 
 
 ---
@@ -81,6 +91,7 @@ spec:
         app: metaphysics
         layer: application
         component: web
+        temperament: cpu-hog
       name: metaphysics-web-green
       namespace: default
     spec:
@@ -131,6 +142,15 @@ spec:
                 operator: In
                 values:
                 - foreground
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: temperament
+                operator: In
+                values:
+                - cpu-hog
+            topologyKey: "kubernetes.io/hostname"
 
 
 ---

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -38,11 +38,10 @@ spec:
         - containerPort: 3000
         resources:
           requests:
-            cpu: "0.5"
-            memory: "512Mi"
+            cpu: 500m
+            memory: 768Mi
           limits:
-            cpu: "1"
-            memory: "1Gi"
+            memory: 1Gi
         readinessProbe:
           httpGet:
             port: 3000
@@ -109,11 +108,10 @@ spec:
         - containerPort: 3000
         resources:
           requests:
-            cpu: "0.5"
-            memory: "512Mi"
+            cpu: 500m
+            memory: 768Mi
           limits:
-            cpu: "1"
-            memory: "1Gi"
+            memory: 1Gi
         readinessProbe:
           httpGet:
             port: 3000

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -15,6 +15,7 @@ spec:
         app: metaphysics
         layer: application
         component: web
+        temperament: cpu-hog
       name: metaphysics-web
       namespace: default
     spec:
@@ -61,6 +62,15 @@ spec:
                 operator: In
                 values:
                 - foreground
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: temperament
+                operator: In
+                values:
+                - cpu-hog
+            topologyKey: "kubernetes.io/hostname"
 
 ---
 apiVersion: autoscaling/v1

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -63,14 +63,16 @@ spec:
                 values:
                 - foreground
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: temperament
-                operator: In
-                values:
-                - cpu-hog
-            topologyKey: "kubernetes.io/hostname"
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: temperament
+                  operator: In
+                  values:
+                  - cpu-hog
+              topologyKey: "kubernetes.io/hostname"
 
 ---
 apiVersion: autoscaling/v1

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -38,11 +38,10 @@ spec:
         - containerPort: 3000
         resources:
           requests:
-            cpu: "0.2"
-            memory: "512Mi"
+            cpu: 200m
+            memory: 512Mi
           limits:
-            cpu: "0.5"
-            memory: "1Gi"
+            memory: 1Gi
         readinessProbe:
           httpGet:
             port: 3000


### PR DESCRIPTION
- Bump memory request for better scheduling
- Unbounded CPU limit (shouldn't ever really go over 1 as node is single-threaded so no need to cap it)
- Add `temperament: cpu-hog` label and an [anti-affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) scheduling rule for this label - Metaphysics pods will "repel" one another as well as any other pods with the `temperament: cpu-hog` label applied - this will mean that no two Metaphysics pods should ever be scheduled on the same host, and no Metaphysics pod should be scheduled on the same host of any [gravity-web pod](https://github.com/artsy/gravity/pull/11829) as it also uses this label.