### PR TITLE
@mzikherman => Correct href for genes

### DIFF
--- a/src/schema/gene.js
+++ b/src/schema/gene.js
@@ -131,7 +131,7 @@ export const GeneType = new GraphQLObjectType({
       filtered_artworks: filterArtworks("gene_id"),
       href: {
         type: GraphQLString,
-        resolve: ({ id }) => `gene/${id}`,
+        resolve: ({ id }) => `/gene/${id}`,
       },
       image: Image,
       is_published: {


### PR DESCRIPTION
This is breaking gene links on the new artist page. Our convention on these is to prefix with the slash.