### PR TITLE
Adds sort to orders query

### DIFF
--- a/src/schema/ecommerce/orders.js
+++ b/src/schema/ecommerce/orders.js
@@ -1,5 +1,6 @@
 import { graphql, GraphQLString } from "graphql"
 import { OrderConnection } from "schema/ecommerce/types/order"
+import { OrdersSortMethodTypeEnum } from "schema/ecommerce/types/orders_sort_method_enum"
 
 export const Orders = {
   name: "Orders",
@@ -9,10 +10,11 @@ export const Orders = {
     userId: { type: GraphQLString },
     partnerId: { type: GraphQLString },
     state: { type: GraphQLString },
+    sort: { type: OrdersSortMethodTypeEnum },
   },
   resolve: (
     _parent,
-    { userId, partnerId, state },
+    { userId, partnerId, state, sort },
     context,
     { rootValue: { exchangeSchema } }
   ) => {
@@ -65,6 +67,7 @@ export const Orders = {
       userId,
       partnerId,
       state,
+      sort,
     }).then(result => {
       if (result.errors) {
         throw Error(result.errors.map(d => d.message))

--- a/src/schema/ecommerce/types/orders_sort_method_enum.ts
+++ b/src/schema/ecommerce/types/orders_sort_method_enum.ts
@@ -1,0 +1,17 @@
+import { GraphQLEnumType } from "graphql"
+
+export const OrdersSortMethodTypeEnum = new GraphQLEnumType({
+  name: "OrdersSortMethodType",
+  values: {
+    UPDATED_AT_ASC: {
+      value: "UPDATED_AT_ASC",
+      description:
+        "Sort by latest timestamp order was updated in ascending order",
+    },
+    UPDATED_AT_DESC: {
+      value: "UPDATED_AT_DESC",
+      description:
+        "Sort by latest timestamp order was updated in descending order",
+    },
+  },
+})


### PR DESCRIPTION
Adds `sort` parameter to `orders` query. The param was there in exchange but not exposed through MP.

**Sample query:**

```
query sortedOrders {
  orders(partnerId: "581b45e4cd530e658b000124", state: "SUBMITTED", sort: UPDATED_AT_ASC){
        edges {
          node {
            state
            id
            stateUpdatedAt
            stateExpiresAt
            createdAt
            updatedAt
          }
        }
  }
}
```