### PR TITLE
update k8s deployments

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -7,6 +7,7 @@ metadata:
 spec:
   strategy:
     rollingUpdate:
+      maxSurge: 0
       maxUnavailable: 20%
     type: RollingUpdate
   template:

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -3,6 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: metaphysics-web
+  namespace: default
 spec:
   strategy:
     rollingUpdate:
@@ -17,7 +18,6 @@ spec:
         component: web
         temperament: cpu-hog
       name: metaphysics-web
-      namespace: default
     spec:
       containers:
       - name: metaphysics-web

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -7,8 +7,7 @@ metadata:
 spec:
   strategy:
     rollingUpdate:
-      maxSurge: 2
-      maxUnavailable: 0
+      maxUnavailable: 20%
     type: RollingUpdate
   template:
     metadata:
@@ -63,16 +62,14 @@ spec:
                 values:
                 - foreground
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 50
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: temperament
-                  operator: In
-                  values:
-                  - cpu-hog
-              topologyKey: "kubernetes.io/hostname"
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: temperament
+                operator: In
+                values:
+                - cpu-hog
+            topologyKey: "kubernetes.io/hostname"
 
 
 ---
@@ -86,8 +83,8 @@ spec:
     apiVersion: extensions/v1beta1
     kind: Deployment
     name: metaphysics-web
-  minReplicas: 10
-  maxReplicas: 20
+  minReplicas: 8
+  maxReplicas: 15
   targetCPUUtilizationPercentage: 80
 
 ---

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -7,8 +7,7 @@ metadata:
 spec:
   strategy:
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+      maxUnavailable: 20%
     type: RollingUpdate
   template:
     metadata:
@@ -63,16 +62,14 @@ spec:
                 values:
                 - foreground
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 50
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: temperament
-                  operator: In
-                  values:
-                  - cpu-hog
-              topologyKey: "kubernetes.io/hostname"
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: temperament
+                operator: In
+                values:
+                - cpu-hog
+            topologyKey: "kubernetes.io/hostname"
 
 ---
 apiVersion: autoscaling/v1

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -7,6 +7,7 @@ metadata:
 spec:
   strategy:
     rollingUpdate:
+      maxSurge: 0
       maxUnavailable: 20%
     type: RollingUpdate
   template:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -3,6 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: metaphysics-web
+  namespace: default
 spec:
   strategy:
     rollingUpdate:
@@ -17,7 +18,6 @@ spec:
         component: web
         temperament: cpu-hog
       name: metaphysics-web
-      namespace: default
     spec:
       containers:
       - name: metaphysics-web


### PR DESCRIPTION
- remove extraneous `default` namespace from pod template
- use `maxUnavailable` so as not to block rollouts
- adjust autoscaling params
- make cpu-pod scheduling a hard requirement to keep away from Gravity pods