### PR TITLE
Returns non-exchange order errors to client.

### DIFF
--- a/src/schema/ecommerce/approve_order_mutation.js
+++ b/src/schema/ecommerce/approve_order_mutation.js
@@ -70,6 +70,9 @@ export const ApproveOrderMutation = mutationWithClientMutationId({
     return graphql(exchangeSchema, mutation, null, context, {
       orderId,
     }).then(result => {
+      if (result.errors) {
+        throw Error(result.errors.map(d => d.message))
+      }
       const { order, errors } = result.data.ecommerce_approveOrder
       return {
         order,

--- a/src/schema/ecommerce/create_order_with_artwork_mutation.js
+++ b/src/schema/ecommerce/create_order_with_artwork_mutation.js
@@ -99,7 +99,9 @@ export const CreateOrderWithArtworkMutation = mutationWithClientMutationId({
       editionSetId,
       quantity,
     }).then(result => {
-      console.log(result)
+      if (result.errors) {
+        throw Error(result.errors.map(d => d.message))
+      }
       const { order, errors } = result.data.ecommerce_createOrderWithArtwork
       return {
         order,

--- a/src/schema/ecommerce/fulfill_order_at_once_mutation.ts
+++ b/src/schema/ecommerce/fulfill_order_at_once_mutation.ts
@@ -120,7 +120,9 @@ export const FulfillOrderAtOnceMutation = mutationWithClientMutationId({
       orderId,
       fulfillment,
     }).then(result => {
-      console.log(result)
+      if (result.errors) {
+        throw Error(result.errors.map(d => d.message))
+      }
       const { order, errors } = result.data.ecommerce_fulfillAtOnce
       return {
         order,

--- a/src/schema/ecommerce/reject_order_mutation.js
+++ b/src/schema/ecommerce/reject_order_mutation.js
@@ -72,6 +72,9 @@ export const RejectOrderMutation = mutationWithClientMutationId({
       orderId,
       creditCardId,
     }).then(result => {
+      if (result.errors) {
+        throw Error(result.errors.map(d => d.message))
+      }
       const { order, errors } = result.data.ecommerce_rejectOrder
       return {
         order,

--- a/src/schema/ecommerce/set_order_payment_mutation.ts
+++ b/src/schema/ecommerce/set_order_payment_mutation.ts
@@ -90,6 +90,9 @@ export const SetOrderPaymentMutation = mutationWithClientMutationId({
       orderId,
       creditCardId,
     }).then(result => {
+      if (result.errors) {
+        throw Error(result.errors.map(d => d.message))
+      }
       const { order, errors } = result.data.ecommerce_setPayment
       return {
         order,

--- a/src/schema/ecommerce/set_order_shipping_mutation.ts
+++ b/src/schema/ecommerce/set_order_shipping_mutation.ts
@@ -138,6 +138,9 @@ export const SetOrderShippingMutation = mutationWithClientMutationId({
       shippingCountry,
       shippingPostalCode,
     }).then(result => {
+      if (result.errors) {
+        throw Error(result.errors.map(d => d.message))
+      }
       const { order, errors } = result.data.ecommerce_setShipping
       return {
         order,

--- a/src/schema/ecommerce/submit_order_mutation.js
+++ b/src/schema/ecommerce/submit_order_mutation.js
@@ -86,6 +86,9 @@ export const SubmitOrderMutation = mutationWithClientMutationId({
       orderId,
       creditCardId,
     }).then(result => {
+      if (result.errors) {
+        throw Error(result.errors.map(d => d.message))
+      }
       const { order, errors } = result.data.ecommerce_submitOrder
       return { order, errors }
     })


### PR DESCRIPTION
In cases where running a mutation causes an error which is not coming from exchange (like authentication errors from gravity)
the error is in `result.errors` and not in `result.data.<query/mutation-name>.errors` so 
```
const { order, errors } = result.data.<query/mutation-name>
```
 throws a javascript runtime error in metaphysics and client receives the ambiguous error message: *Cannot match against 'undefined' or 'null'.*

This change saves developers debugging time for now, while we are figuring out the best pattern to handle graphql errors for order mutations.

(cc @orta)

