### PR TITLE
@mzikherman => [BUGFIX artist] Fix issue where statuses shows article erroneously

### DIFF
--- a/src/schema/artist/statuses.js
+++ b/src/schema/artist/statuses.js
@@ -24,9 +24,12 @@ const ArtistStatusesType = new GraphQLObjectType({
         articlesLoader({
           artist_id: _id,
           published: true,
+          in_editorial_feed: true,
           limit: 0,
           count: true,
-        }).then(({ count }) => count > 0),
+        }).then(({ count }) => {
+          return count > 0
+        }),
     },
     artworks: {
       type: GraphQLBoolean,


### PR DESCRIPTION
Right now articles should only appear if `in_editorial_feed` is `true`; however, in code that determines whether we should show the Articles tab, this condition isn't accounted for, leading to a situation where the tab appears yet no articles are rendered. 