### PR TITLE
#migration add goreplay sidecar container and forward scraped traffic

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -52,6 +52,14 @@ spec:
               value: https
           initialDelaySeconds: 5
           periodSeconds: 5
+      - name: metaphysics-goreplay
+        image: artsy/goreplay:latest
+        args: ["/usr/local/bin/goreplay", "--input-raw", ":3000", "--output-tcp", "goreplay.prd.artsy.systems:80"]
+        securityContext:
+          capabilities:
+            add:
+            - NET_RAW
+            - NET_ADMIN
       dnsPolicy: Default
       affinity:
         nodeAffinity:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -52,6 +52,14 @@ spec:
               value: https
           initialDelaySeconds: 5
           periodSeconds: 5
+      - name: metaphysics-goreplay
+        image: artsy/goreplay:latest
+        args: ["/usr/local/bin/goreplay", "--input-raw", ":3000", "--output-tcp", "goreplay.stg.artsy.systems:80"]
+        securityContext:
+          capabilities:
+            add:
+            - NET_RAW
+            - NET_ADMIN
       dnsPolicy: Default
       affinity:
         nodeAffinity:


### PR DESCRIPTION
Depends on https://github.com/artsy/substance/pull/103 - Do not merge this PR until it is

Run [goreplay](https://goreplay.org/) as a sidecar container with Metaphysics (containers in the same Pod share a network interface as if they were on the same host) - scrape traffic and forward to `goreplay.stg.artsy.systems` / `goreplay.prd.artsy.systems` for later reply.

Enabling / disabling traffic scraping and forwarding can be done by commenting out these changes, then running `hokusai [staging|production] update` (can't think of a good way enable / disable with an env var as running another container or not alongside MP is the cleanest deployment strategy)

# Migration

After merging, sync your local `master` branch then run:

Staging: `hokusai staging update`

Production: `hokusai production update`