### PR TITLE
Adds creditCardLoader to return creditCard information in root and ecommerce orders

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.js
+++ b/src/lib/loaders/loaders_with_authentication/gravity.js
@@ -21,6 +21,7 @@ export default (accessToken, userID, opts) => {
       { headers: true }
     ),
     collectorProfileLoader: gravityLoader("me/collector_profile"),
+    creditCardLoader: gravityLoader(id => `credit_card/${id}`),
     createBidderLoader: gravityLoader("bidder", {}, { method: "POST" }),
     createCreditCardLoader: gravityLoader(
       "me/credit_cards",

--- a/src/schema/__tests__/credit_card.test.js
+++ b/src/schema/__tests__/credit_card.test.js
@@ -1,0 +1,37 @@
+/* eslint-disable promise/always-return */
+import { runQuery } from "test/utils"
+
+describe("CreditCard type", () => {
+  let creditCard = null
+  let rootValue = null
+
+  beforeEach(() => {
+    creditCard = {
+      id: "card123",
+      brand: "Visa",
+      last_digits: "4242",
+    }
+
+    rootValue = {
+      creditCardLoader: () => Promise.resolve(creditCard),
+    }
+  })
+
+  it("fetches a credit card ID", () => {
+    const query = `
+      {
+        credit_card(id: "card123") {
+          id
+          brand
+          last_digits
+        }
+      }
+    `
+
+    return runQuery(query, rootValue).then(data => {
+      expect(data.credit_card.id).toBe("card123")
+      expect(data.credit_card.brand).toBe("Visa")
+      expect(data.credit_card.last_digits).toBe("4242")
+    })
+  })
+})

--- a/src/schema/__tests__/ecommerce/order.test.js
+++ b/src/schema/__tests__/ecommerce/order.test.js
@@ -54,6 +54,11 @@ describe("Order type", () => {
             id
             email
           }
+          creditCard {
+            id
+            brand
+            last_digits
+          }
           lineItems {
             edges {
               node {
@@ -80,7 +85,7 @@ describe("Order type", () => {
     `
 
     return runQuery(query, rootValue).then(data => {
-      expect(data.order).toEqual(sampleOrder(true, true))
+      expect(data.order).toEqual(sampleOrder(true, true, true))
     })
   })
 })

--- a/src/schema/credit_card.js
+++ b/src/schema/credit_card.js
@@ -1,0 +1,47 @@
+import {
+  GraphQLInt,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLNonNull,
+} from "graphql"
+import { GravityIDFields } from "schema/object_identification"
+
+const CreditCardType = new GraphQLObjectType({
+  name: "CreditCard",
+  fields: () => ({
+    ...GravityIDFields,
+    brand: {
+      type: GraphQLString,
+      description: "Brand of credit card",
+    },
+    name: {
+      type: GraphQLString,
+      description: "Name on the credit card",
+    },
+    last_digits: {
+      type: GraphQLString,
+      description: "Last four digits on the credit card",
+    },
+    expiration_month: {
+      type: GraphQLInt,
+      description: "Credit card's expiration month",
+    },
+    expiration_year: {
+      type: GraphQLInt,
+      description: "Credit card's expiration year",
+    },
+  }),
+})
+
+export const CreditCard = {
+  type: CreditCardType,
+  description: "A user's credit card",
+  args: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the Credit Card",
+    },
+  },
+  resolve: (root, { id }, request, { rootValue: { creditCardLoader } }) =>
+    creditCardLoader(id),
+}

--- a/src/schema/credit_card.js
+++ b/src/schema/credit_card.js
@@ -11,7 +11,7 @@ const CreditCardType = new GraphQLObjectType({
   fields: () => ({
     ...GravityIDFields,
     brand: {
-      type: GraphQLString,
+      type: new GraphQLNonNull(GraphQLString),
       description: "Brand of credit card",
     },
     name: {
@@ -19,15 +19,15 @@ const CreditCardType = new GraphQLObjectType({
       description: "Name on the credit card",
     },
     last_digits: {
-      type: GraphQLString,
+      type: GraphQLNonNull(GraphQLString),
       description: "Last four digits on the credit card",
     },
     expiration_month: {
-      type: GraphQLInt,
+      type: GraphQLNonNull(GraphQLInt),
       description: "Credit card's expiration month",
     },
     expiration_year: {
-      type: GraphQLInt,
+      type: GraphQLNonNull(GraphQLInt),
       description: "Credit card's expiration year",
     },
   }),

--- a/src/schema/ecommerce/order.js
+++ b/src/schema/ecommerce/order.js
@@ -15,6 +15,7 @@ export const Order = {
           state
           partnerId
           userId
+          creditCardId
           fulfillmentType
           shippingAddressLine1
           shippingAddressLine2

--- a/src/schema/ecommerce/types/order.ts
+++ b/src/schema/ecommerce/types/order.ts
@@ -11,6 +11,7 @@ import Partner from "schema/partner"
 import { amount } from "schema/fields/money"
 import date from "schema/fields/date"
 import { UserByID } from "schema/user"
+import { CreditCard } from "schema/credit_card"
 import { OrderLineItemConnection } from "./order_line_item"
 
 export const OrderType = new GraphQLObjectType({
@@ -118,6 +119,16 @@ export const OrderType = new GraphQLObjectType({
         _context,
         { rootValue: { userByIDLoader } }
       ) => (userId ? userByIDLoader(userId) : null),
+    },
+    creditCard: {
+      type: CreditCard.type,
+      description: "Credit card on this order",
+      resolve: (
+        { creditCardId },
+        _args,
+        _context,
+        { rootValue: { creditCardLoader } }
+      ) => (creditCardId ? creditCardLoader(creditCardId) : null),
     },
     updatedAt: date,
     createdAt: date,

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -8,6 +8,7 @@ import Artworks from "./artworks"
 import Artist from "./artist"
 import Artists from "./artists"
 import Collection from "./collection"
+import { CreditCard } from "./credit_card"
 import ExternalPartner from "./external_partner"
 import Fair from "./fair"
 import Fairs from "./fairs"
@@ -91,6 +92,7 @@ const rootFields: any = {
   artists: Artists,
   causality_jwt: CausalityJWT,
   collection: Collection,
+  credit_card: CreditCard,
   external_partner: ExternalPartner,
   fair: Fair,
   fairs: Fairs,

--- a/src/schema/me/create_credit_card_mutation.js
+++ b/src/schema/me/create_credit_card_mutation.js
@@ -1,50 +1,22 @@
 import {
-  GraphQLInt,
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
   GraphQLUnionType,
 } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
-import { GravityIDFields } from "schema/object_identification"
 import {
   formatGravityError,
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
-
-export const CreditCardType = new GraphQLObjectType({
-  name: "CreditCard",
-  fields: () => ({
-    ...GravityIDFields,
-    brand: {
-      type: GraphQLString,
-      description: "Brand of credit card",
-    },
-    name: {
-      type: GraphQLString,
-      description: "Name on the credit card",
-    },
-    last_digits: {
-      type: GraphQLString,
-      description: "Last four digits on the credit card",
-    },
-    expiration_month: {
-      type: GraphQLInt,
-      description: "Credit card's expiration month",
-    },
-    expiration_year: {
-      type: GraphQLInt,
-      description: "Credit card's expiration year",
-    },
-  }),
-})
+import { CreditCard } from "../credit_card"
 
 export const CreditCardMutationSuccessType = new GraphQLObjectType({
   name: "CreditCardMutationSuccess",
   isTypeOf: data => data.id,
   fields: () => ({
     creditCard: {
-      type: CreditCardType,
+      type: CreditCard.type,
       resolve: creditCard => creditCard,
     },
   }),
@@ -78,7 +50,7 @@ export default mutationWithClientMutationId({
   },
   outputFields: {
     credit_card: {
-      type: CreditCardType,
+      type: CreditCard.type,
       deprecationReason: "Favor `creditCardOrError`",
       resolve: result => {
         return result && result.id ? result : null

--- a/src/test/fixtures/exchange/mockxchange.js
+++ b/src/test/fixtures/exchange/mockxchange.js
@@ -40,6 +40,14 @@ export const mockxchange = resolvers => {
     })
   )
 
+  const creditCardLoader = sinon.stub().returns(
+    Promise.resolve({
+      id: "card123",
+      brand: "Visa",
+      last_digits: "4242",
+    })
+  )
+
   const authenticatedArtworkLoader = sinon.stub().returns(
     Promise.resolve({
       id: "hubert-farnsworth-smell-o-scope",
@@ -55,6 +63,7 @@ export const mockxchange = resolvers => {
     exchangeSchema,
     partnerLoader,
     userByIDLoader,
+    creditCardLoader,
     authenticatedArtworkLoader,
     accessToken,
   }

--- a/src/test/fixtures/exchange/order.json
+++ b/src/test/fixtures/exchange/order.json
@@ -5,6 +5,7 @@
   "currencyCode": "usd",
   "partnerId": "111",
   "userId": "111",
+  "creditCardId": "card123",
   "fulfillmentType": "SHIP",
   "shippingAddressLine1": "Vanak 123",
   "shippingAddressLine2": "P 80",

--- a/src/test/fixtures/results/sample_order.js
+++ b/src/test/fixtures/results/sample_order.js
@@ -39,6 +39,12 @@ const defaultResponse = {
   lineItems: [],
 }
 
+const creditCard = {
+  id: "card123",
+  brand: "Visa",
+  last_digits: "4242",
+}
+
 function sampleFulfillments() {
   return {
     edges: [
@@ -86,10 +92,23 @@ function sampleLineItems(fulfillments = false) {
   }
 }
 
-export default function sampleResponse(lineItems = true, fulfillments = false) {
+export default function sampleResponse(
+  lineItems = true,
+  fulfillments = false,
+  includeCreditCard = false
+) {
+  let orderResponse = defaultResponse
+
   if (lineItems) {
-    return { ...defaultResponse, lineItems: sampleLineItems(fulfillments) }
-  } else {
-    return defaultResponse
+    orderResponse = {
+      ...defaultResponse,
+      lineItems: sampleLineItems(fulfillments),
+    }
   }
+
+  if (includeCreditCard) {
+    orderResponse = { ...orderResponse, creditCard }
+  }
+
+  return orderResponse
 }


### PR DESCRIPTION
Since this PR: https://github.com/artsy/gravity/pull/11861, a user can view their credit card information on an order.

This updates the MP schema to return credit card information as part of the root (mostly useful right now for testing), and as part of an `order`. 

```graphql
query {
  credit_card(id: "test123") {
    brand
  }
}
```

```graphql
query order {
  order(id: "130") {
    createdAt
    id
    creditCard {
      id
      brand
      last_digits
    }
  }
}
```