### PR TITLE
@alloy => Log out if old artist query is being used

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ import {
   fetchLoggerRequestDone,
 } from "lib/loaders/api/logger"
 import { fetchPersistedQuery } from "./lib/fetchPersistedQuery"
+import { checkForProblematicArtistQuery } from "./lib/checkForProblematicArtistQuery"
 import { info } from "./lib/loggers"
 import { mergeSchemas } from "./lib/stitching/mergeSchemas"
 import { executableLewittSchema } from "./lib/stitching/lewitt/schema"
@@ -124,6 +125,7 @@ async function startApp() {
       next()
     },
     logQueryDetailsIfEnabled(),
+    checkForProblematicArtistQuery,
     fetchPersistedQuery,
     crunchInterceptor,
     graphqlHTTP((req, res, params) => {

--- a/src/lib/checkForProblematicArtistQuery.ts
+++ b/src/lib/checkForProblematicArtistQuery.ts
@@ -1,0 +1,15 @@
+import { error } from "./loggers"
+import { RequestHandler } from "express"
+
+export const checkForProblematicArtistQuery: RequestHandler = (
+  req,
+  res,
+  next
+) => {
+  const { query } = req.body
+  if (query && query.includes("Overview_artist_3vi6l5")) {
+    error(`Problematic artist query, IP: ${req.ip}`)
+    return res.status(500).end()
+  }
+  next()
+}


### PR DESCRIPTION
Middleware that will log out and return a 500 immediately if the old artist page query is being used (Force was deployed yesterday).