### PR TITLE
Revert "#migration add goreplay sidecar container and forward scraped traffic"

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -52,14 +52,6 @@ spec:
               value: https
           initialDelaySeconds: 5
           periodSeconds: 5
-      - name: metaphysics-goreplay
-        image: artsy/goreplay:latest
-        args: ["/usr/local/bin/goreplay", "--input-raw", ":3000", "--output-tcp", "goreplay.prd.artsy.systems:80"]
-        securityContext:
-          capabilities:
-            add:
-            - NET_RAW
-            - NET_ADMIN
       dnsPolicy: Default
       affinity:
         nodeAffinity:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -52,14 +52,6 @@ spec:
               value: https
           initialDelaySeconds: 5
           periodSeconds: 5
-      - name: metaphysics-goreplay
-        image: artsy/goreplay:latest
-        args: ["/usr/local/bin/goreplay", "--input-raw", ":3000", "--output-tcp", "goreplay.stg.artsy.systems:80"]
-        securityContext:
-          capabilities:
-            add:
-            - NET_RAW
-            - NET_ADMIN
       dnsPolicy: Default
       affinity:
         nodeAffinity:


### PR DESCRIPTION
Reverts artsy/metaphysics#1212

This caused the `hokusai pipeline promote` task to fail oddly.