### PR TITLE
#migration add goreplay sidecar container and forward scraped traffic... again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,11 @@ ADD https://github.com/buger/goreplay/releases/download/v0.16.1/gor_0.16.1_x64.t
 RUN tar xfvz /tmp/goreplay.tar.gz
 RUN mv goreplay /usr/local/bin/
 RUN rm -f /tmp/goreplay.tar.gz
+RUN addgroup gor
+RUN addgroup deploy gor
+RUN chgrp gor /usr/local/bin/goreplay
+RUN chmod 0750 /usr/local/bin/goreplay
+RUN setcap "cap_net_raw,cap_net_admin+eip" /usr/local/bin/goreplay
 
 RUN npm install -g yarn@1.0.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,12 @@ ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_a
 RUN chown deploy:deploy /usr/local/bin/dumb-init
 RUN chmod +x /usr/local/bin/dumb-init
 
+# Set up goreplay
+ADD https://github.com/buger/goreplay/releases/download/v0.16.1/gor_0.16.1_x64.tar.gz /tmp/goreplay.tar.gz
+RUN tar xfvz /tmp/goreplay.tar.gz
+RUN mv goreplay /usr/local/bin/
+RUN rm -f /tmp/goreplay.tar.gz
+
 RUN npm install -g yarn@1.0.1
 
 # Set up /app for deploy user

--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -20,5 +20,8 @@ services:
     extends:
       file: common.yml
       service: metaphysics
-    command: ["/usr/local/bin/goreplay", "--input-raw", ":5001", "--output-stdout"]
+    environment:
+    - GOREPLAY_PORT=5001
+    - GOREPLAY_OUTPUT=stdout
+    command: ["./scripts/run-goreplay.sh"]
     privileged: true

--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -16,3 +16,9 @@ services:
     image: memcached
     ports:
     - 11211:11211
+  metaphysics-goreplay:
+    extends:
+      file: common.yml
+      service: metaphysics
+    command: ["/usr/local/bin/goreplay", "--input-raw", ":5001", "--output-stdout"]
+    privileged: true

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -53,9 +53,12 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 5
       - name: metaphysics-goreplay
+        envFrom:
+        - configMapRef:
+            name: metaphysics-environment
         image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/metaphysics:production
         imagePullPolicy: Always
-        args: ["/usr/local/bin/goreplay", "--input-raw", ":3000", "--output-tcp", "goreplay.prd.artsy.systems:80"]
+        args: ["./scripts/run-goreplay.sh"]
         securityContext:
           capabilities:
             add:

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -53,7 +53,8 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 5
       - name: metaphysics-goreplay
-        image: artsy/goreplay:latest
+        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/metaphysics:production
+        imagePullPolicy: Always
         args: ["/usr/local/bin/goreplay", "--input-raw", ":3000", "--output-tcp", "goreplay.prd.artsy.systems:80"]
         securityContext:
           capabilities:

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -52,6 +52,14 @@ spec:
               value: https
           initialDelaySeconds: 5
           periodSeconds: 5
+      - name: metaphysics-goreplay
+        image: artsy/goreplay:latest
+        args: ["/usr/local/bin/goreplay", "--input-raw", ":3000", "--output-tcp", "goreplay.prd.artsy.systems:80"]
+        securityContext:
+          capabilities:
+            add:
+            - NET_RAW
+            - NET_ADMIN
       dnsPolicy: Default
       affinity:
         nodeAffinity:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -53,9 +53,12 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 5
       - name: metaphysics-goreplay
+        envFrom:
+        - configMapRef:
+            name: metaphysics-environment
         image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/metaphysics:staging
         imagePullPolicy: Always
-        args: ["/usr/local/bin/goreplay", "--input-raw", ":3000", "--output-tcp", "goreplay.stg.artsy.systems:80"]
+        args: ["./scripts/run-goreplay.sh"]
         securityContext:
           capabilities:
             add:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -53,7 +53,8 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 5
       - name: metaphysics-goreplay
-        image: artsy/goreplay:latest
+        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/metaphysics:staging
+        imagePullPolicy: Always
         args: ["/usr/local/bin/goreplay", "--input-raw", ":3000", "--output-tcp", "goreplay.stg.artsy.systems:80"]
         securityContext:
           capabilities:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -52,6 +52,14 @@ spec:
               value: https
           initialDelaySeconds: 5
           periodSeconds: 5
+      - name: metaphysics-goreplay
+        image: artsy/goreplay:latest
+        args: ["/usr/local/bin/goreplay", "--input-raw", ":3000", "--output-tcp", "goreplay.stg.artsy.systems:80"]
+        securityContext:
+          capabilities:
+            add:
+            - NET_RAW
+            - NET_ADMIN
       dnsPolicy: Default
       affinity:
         nodeAffinity:

--- a/scripts/run-goreplay.sh
+++ b/scripts/run-goreplay.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+if [[ -z $GOREPLAY_PORT || -z $GOREPLAY_OUTPUT ]]; then
+  echo "Not running goreplay."
+  while true; do sleep 10; done
+else
+  echo "Running /usr/local/bin/goreplay --input-raw :$GOREPLAY_PORT --output-$GOREPLAY_OUTPUT"
+  /usr/local/bin/goreplay --input-raw :$GOREPLAY_PORT --output-$GOREPLAY_OUTPUT
+fi


### PR DESCRIPTION
Follow-up to https://github.com/artsy/metaphysics/pull/1212

Install Goreplay inline and use the same image ref to run the sidecar container, working around the Hokusai guard that all containers in a Pod need to reference the same image tag.

As before, I'd let this sit on staging for a bit and check that everything is flowing correctly and it doesn't step on the toes of the normal application operation / ci pipeline before promoting to production and running the migration.

# Migration

After merging, sync your local `master` branch then run:

Staging: `hokusai staging update`

Production: `hokusai production update`