### PR TITLE
Fea take heapsnapshots

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN adduser --disabled-password --gecos '' deploy
 RUN mkdir -p /app
 
 # Set up dumb-init
-ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 /usr/local/bin/dumb-init
 RUN chown deploy:deploy /usr/local/bin/dumb-init
 RUN chmod +x /usr/local/bin/dumb-init
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ RUN chmod 0750 /usr/local/bin/goreplay
 RUN setcap "cap_net_raw,cap_net_admin+eip" /usr/local/bin/goreplay
 
 RUN npm install -g yarn@1.0.1
+# Set up mc
+ADD https://dl.minio.io/client/mc/release/linux-amd64/mc /usr/local/bin/mc
+RUN chmod +x /usr/local/bin/mc
 
 # Set up /app for deploy user
 ADD . /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,10 @@ RUN chmod 0750 /usr/local/bin/goreplay
 RUN setcap "cap_net_raw,cap_net_admin+eip" /usr/local/bin/goreplay
 
 RUN npm install -g yarn@1.0.1
+
 # Set up mc
 ADD https://dl.minio.io/client/mc/release/linux-amd64/mc /usr/local/bin/mc
+RUN chown deploy:deploy /usr/local/bin/mc
 RUN chmod +x /usr/local/bin/mc
 
 # Set up /app for deploy user

--- a/scripts/create-heapsnapshot.sh
+++ b/scripts/create-heapsnapshot.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+
+if [[ -z $AWS_ACCESS_KEY_ID || -z $AWS_SECRET_ACCESS_KEY || -z $AWS_BUCKET || -z $AWS_BUCKET_PATH ]]; then
+  echo "Unset require env vars AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_BUCKET and AWS_BUCKET_PATH"
+  exit 1
+fi
+
+# Configure mc
+/usr/local/bin/mc config host add s3 https://s3.amazonaws.com $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
+
+# create heapsnapshot - dumb-init proxies signal to children
+kill -USR2 1
+
+# find heapsnapshots
+for heapsnapshot in $(ls -l | grep heapsnapshot | awk '{print $9}')
+do
+  # wait for heapsnapshot placeholder to be replaced with full heapdump
+  while [ ! -s $heapsnapshot ]; do sleep 1; done
+  echo "Created $heapsnapshot"
+
+  # Upload heapsnpshot to S3
+  /usr/local/bin/mc cp $heapsnapshot s3/$AWS_BUCKET/$AWS_BUCKET_PATH/$heapsnapshot
+done
+
+# Clean up
+rm -rf /home/deploy/.mc
+rm -f *.heapsnapshot

--- a/scripts/create-heapsnapshot.sh
+++ b/scripts/create-heapsnapshot.sh
@@ -2,7 +2,7 @@
 
 # Check required env vars
 if [[ -z $AWS_ACCESS_KEY_ID || -z $AWS_SECRET_ACCESS_KEY || -z $AWS_BUCKET || -z $AWS_BUCKET_PATH ]]; then
-  echo "Unset required env vars AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_BUCKET and AWS_BUCKET_PATH"
+  echo "Set required env vars AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_BUCKET and AWS_BUCKET_PATH"
   exit 1
 fi
 

--- a/scripts/create-heapsnapshot.sh
+++ b/scripts/create-heapsnapshot.sh
@@ -1,7 +1,8 @@
 #! /bin/bash
 
+# Check required env vars
 if [[ -z $AWS_ACCESS_KEY_ID || -z $AWS_SECRET_ACCESS_KEY || -z $AWS_BUCKET || -z $AWS_BUCKET_PATH ]]; then
-  echo "Unset require env vars AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_BUCKET and AWS_BUCKET_PATH"
+  echo "Unset required env vars AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_BUCKET and AWS_BUCKET_PATH"
   exit 1
 fi
 
@@ -10,6 +11,7 @@ fi
 
 # create heapsnapshot - dumb-init proxies signal to children
 kill -USR2 1
+sleep 1
 
 # find heapsnapshots
 for heapsnapshot in $(ls -l | grep heapsnapshot | awk '{print $9}')
@@ -19,7 +21,7 @@ do
   echo "Created $heapsnapshot"
 
   # Upload heapsnpshot to S3
-  /usr/local/bin/mc cp $heapsnapshot s3/$AWS_BUCKET/$AWS_BUCKET_PATH/$heapsnapshot
+  /usr/local/bin/mc cp $heapsnapshot s3/$AWS_BUCKET/$AWS_BUCKET_PATH/$(date '+%Y-%m-%d--%H-%M-%S')-$(hostname)-$heapsnapshot
 done
 
 # Clean up


### PR DESCRIPTION
Take heapsnapshots and upload to s3 with https://docs.minio.io/docs/minio-client-complete-guide

Includes an update to dumb-init

Invoke `./scripts/create-heapsnapshot.sh` with env vars "AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_BUCKET and AWS_BUCKET_PATH"

Execute on a running pod - i.e. for pod `metaphysics-web-2612115710-645fg` (which you would find via `hokusai [staging|production] status`), and passing in your own AWS credentials to upload to the `artsy-data` bucket, `metaphysics/heapsnapshots/staging` path, you would run:

```
kubectl exec metaphysics-web-2612115710-645fg -- bash -c "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY AWS_BUCKET=artsy-data AWS_BUCKET_PATH=metaphysics/heapsnapshots/staging ./scripts/create-heapsnapshot.sh"
```

Snapshots ( sometimes 2 identical files are created...  not sure why cc @orta ) are uploaded with a timestamp and the hostname (in Kubernetes' case, the pod name prepended to the snapshot name) for later inspection.

To start with let's manually trigger the script at times of low and high memory consumption and take a look at the comparison of snapshots for a given pod over its lifetime.  In the future we may want to trigger this automatically, i.e. when a pod is terminated it can take a final snapshot using the `preStop` [lifecycle hook](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/).