### PR TITLE
[dev] Make sure app is fully started on initial request.

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,15 +64,18 @@ function bootApp() {
       .end()
   })
 
-  app.get('/health', (req, res) => {
+  app.get("/health", (req, res) => {
     if (isShuttingDown) {
       return res.status(503).end()
     }
-    cache.isAvailable().then((stats) => {
-      return res.status(200).end()
-    }).catch((err) => {
-      return res.status(503).end()
-    })
+    cache
+      .isAvailable()
+      .then(stats => {
+        return res.status(200).end()
+      })
+      .catch(err => {
+        return res.status(503).end()
+      })
   })
 
   app.all("/graphql", (_req, res) => res.redirect("/"))
@@ -85,19 +88,21 @@ function bootApp() {
     app.use(require("./src").default)
   }
 
-  server = require('http-shutdown')(app.listen(port, () =>
-    info(`[Metaphysics] Listening on http://localhost:${port}`)
-  ))
+  server = require("http-shutdown")(
+    app.listen(port, () =>
+      info(`[Metaphysics] Listening on http://localhost:${port}`)
+    )
+  )
 }
 
-process.on('SIGTERM', gracefulExit)
+process.on("SIGTERM", gracefulExit)
 
 function gracefulExit() {
   if (isShuttingDown) return
   isShuttingDown = true
-  console.log('Received signal SIGTERM, shutting down')
-  server.shutdown(function () {
-    console.log('Closed existing connections.')
+  console.log("Received signal SIGTERM, shutting down")
+  server.shutdown(function() {
+    console.log("Closed existing connections.")
     process.exit(0)
   })
 }

--- a/src/index.js
+++ b/src/index.js
@@ -73,9 +73,9 @@ function logQueryDetailsIfEnabled() {
   return (req, res, next) => next()
 }
 
-const app = express()
-
 async function startApp() {
+  const app = express()
+
   config.GRAVITY_XAPP_TOKEN = xapp.token
 
   let schema = localSchema
@@ -189,7 +189,19 @@ async function startApp() {
   if (enableSentry) {
     app.use(raven.errorHandler())
   }
+
+  return app
 }
 
-startApp()
-export default app
+let startedApp = null
+
+export default async (req, res, next) => {
+  try {
+    if (!startedApp) {
+      startedApp = await startApp()
+    }
+    startedApp(req, res, next)
+  } catch (err) {
+    next(err)
+  }
+}


### PR DESCRIPTION
Previously the app would start launching when the initial request comes
in, but not yet be finished launching, which would lead to the inital
request failing. This was especially painful when that initial request
was an introspection query being performed by e.g. GraphiQL and then
leading to the app not knowing the schema.