### PR TITLE
bugfix in scripts/create-heapsnapshot.sh

### DIFF
--- a/scripts/create-heapsnapshot.sh
+++ b/scripts/create-heapsnapshot.sh
@@ -9,17 +9,23 @@ fi
 # Configure mc
 /usr/local/bin/mc config host add s3 https://s3.amazonaws.com $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
 
-# create heapsnapshot - dumb-init proxies signal to children
-kill -USR2 1
+echo "Creating snapshots..."
+# create heapsnapshot
+kill -USR2 $(pidof node)
 sleep 1
+
+echo "Waiting for snapshots to finish..."
+while true; do
+    ls -l /proc/$(pidof node)/fd/ | grep heapsnapshot > /dev/null
+    if [ $? -eq 1 ]; then
+        break
+    fi
+    sleep 1
+done
 
 # find heapsnapshots
 for heapsnapshot in $(ls -l | grep heapsnapshot | awk '{print $9}')
 do
-  # wait for heapsnapshot placeholder to be replaced with full heapdump
-  while [ ! -s $heapsnapshot ]; do sleep 1; done
-  echo "Created $heapsnapshot"
-
   # Upload heapsnpshot to S3
   /usr/local/bin/mc cp $heapsnapshot s3/$AWS_BUCKET/$AWS_BUCKET_PATH/$(date '+%Y-%m-%d--%H-%M-%S')-$(hostname)-$heapsnapshot
 done


### PR DESCRIPTION
Snapshots are being updated prematurely (before the full snapshot file contents were written to disk) wait for the node process to release all `.heapsnapshot` file descriptors before moving to upload stage