### PR TITLE
@damassi => Add artworksConnection to notification bundles, for use in grid component

### DIFF
--- a/src/schema/me/__tests__/followed_artists_artwork_groups.test.js
+++ b/src/schema/me/__tests__/followed_artists_artwork_groups.test.js
@@ -17,6 +17,13 @@ describe("Me", () => {
                   node {
                     summary
                     artists
+                    artworksConnection(first: 10) {
+                      edges {
+                        node {
+                          title
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -39,6 +46,16 @@ describe("Me", () => {
             node: {
               summary: "2 Works Added",
               artists: "Percy Z",
+              artworksConnection: {
+                edges: [
+                  {
+                    node: { title: "Artwork1" },
+                  },
+                  {
+                    node: { title: "Artwork2" },
+                  },
+                ],
+              },
             },
           },
         ],

--- a/src/schema/me/followed_artists_artworks_group.js
+++ b/src/schema/me/followed_artists_artworks_group.js
@@ -1,6 +1,6 @@
 import { pageable } from "relay-cursor-paging"
 import { connectionDefinitions, connectionFromArraySlice } from "graphql-relay"
-import Artwork from "schema/artwork"
+import Artwork, { artworkConnection } from "schema/artwork"
 import ArtworkSorts from "schema/sorts/artwork_sorts"
 import Image from "schema/image"
 import { GraphQLList, GraphQLObjectType, GraphQLString } from "graphql"
@@ -16,6 +16,16 @@ const FollowedArtistsArtworksGroupType = new GraphQLObjectType({
     artworks: {
       type: new GraphQLList(Artwork.type),
       description: "List of artworks in this group.",
+    },
+    artworksConnection: {
+      type: artworkConnection,
+      args: pageable({}),
+      resolve: ({ artworks }, args) => {
+        return connectionFromArraySlice(artworks, args, {
+          arrayLength: artworks.length,
+          sliceStart: 0,
+        })
+      },
     },
     artists: {
       type: GraphQLString,


### PR DESCRIPTION
expose a connection of artworks, vs just a flat list, for each notification group. This is for https://github.com/artsy/reaction/pull/1154