### PR TITLE
set X-Forwarded-For header on downstream requests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -107,6 +107,9 @@ async function startApp() {
   }
 
   app.use(requestIDsAdder)
+  if (isProduction) {
+    app.set('trust proxy', true)
+  }
 
   if (enableSentry) {
     raven.config(SENTRY_PRIVATE_DSN).install()

--- a/src/lib/loaders/__tests__/request_id.test.js
+++ b/src/lib/loaders/__tests__/request_id.test.js
@@ -15,7 +15,7 @@ describe("requestID (with the real data loaders)", () => {
       }
     `
 
-    const requestIDs = { requestId: "request-id" }
+    const requestIDs = { requestId: "request-id", xForwardedFor: "192.168.0.1" }
     const rootValue = createLoaders("access-token", "user-id", { requestIDs })
     expect.assertions(1)
 
@@ -36,7 +36,7 @@ describe("requestID (with the real data loaders)", () => {
         }
       }
     `
-    const requestIDs = { requestId: "request-id" }
+    const requestIDs = { requestId: "request-id", xForwardedFor: "192.168.0.1" }
     const rootValue = createLoaders("secret", "user-42", { requestIDs })
     expect.assertions(1)
     await runAuthenticatedQuery(query, rootValue)

--- a/src/lib/requestIDs.js
+++ b/src/lib/requestIDs.js
@@ -11,7 +11,7 @@ export function headers({ requestID, traceId, parentSpanId, xForwardedFor }) {
 
 function resolveProxies(req) {
   if (req.headers["x-forwarded-for"]) {
-    return req.headers["x-forwarded-for"] + ", " + req.connection.remoteAddress
+    return `${req.headers["x-forwarded-for"]}, ${req.connection.remoteAddress}`
   } else {
     return req.connection.remoteAddress
   }


### PR DESCRIPTION
Set the `X-Forwarded-For` [header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#Directives) on downstream requests to represent a proxy chain to downstream services.

If the header exists, append the Client IP to the header from `req.connection.remoteAddress` - if it does not exist, simply set it to the Client IP.