### PR TITLE
Fix api loading without cache 

### DIFF
--- a/src/lib/loaders/api/loader_without_authentication_factory.ts
+++ b/src/lib/loaders/api/loader_without_authentication_factory.ts
@@ -114,28 +114,26 @@ export const apiLoaderWithoutAuthenticationFactory = (
                   }
                 )
               } else {
-                () => {
-                    api(key, null, apiOptions)
-                      .then(({ body, headers }) => {
-                        if (apiOptions.headers) {
-                          resolve({ body, headers })
-                        } else {
-                          resolve(body)
-                        }
-                        verbose(`Requested (Uncached): ${key}`)
-                        const time = clock.end()
-                        logger(
-                          globalAPIOptions.requestIDs.requestID,
-                          apiName,
-                          key,
-                          { time, cache: false }
-                        )
-                      })
-                      .catch(err => {
-                        warn(key, err)
-                        reject(err)
-                      })
-                  }
+                return api(key, null, apiOptions)
+                  .then(({ body, headers }) => {
+                    if (apiOptions.headers) {
+                      resolve({ body, headers })
+                    } else {
+                      resolve(body)
+                    }
+                    verbose(`Requested (Uncached): ${key}`)
+                    const time = clock.end()
+                    logger(
+                      globalAPIOptions.requestIDs.requestID,
+                      apiName,
+                      key,
+                      { time, cache: false }
+                    )
+                  })
+                  .catch(err => {
+                    warn(key, err)
+                    reject(err)
+                  })
               }
             })
           })


### PR DESCRIPTION
Remove function wrap and return promise in src/lib/loaders/api/loader_without_authentication_factory.ts - fixes api loading with cache disabled never returning

I think I found the bug preventing MP working with `CACHE_DISABLED=true` - it seems we were not returning the `api` promise and swallowing it by instead wrapping it in another function.

Testing locally with, `DEBUG=*` as well as `RESOLVER_TIMEOUT_MS=0` I saw the query never seemed to actually load the API request and the request hanging indefinitely.
```
metaphysics_1            | Wed, 22 Aug 2018 09:31:47 GMT info ----------
metaphysics_1            | Wed, 22 Aug 2018 09:31:47 GMT express:router <anonymous>  : /?
metaphysics_1            | Wed, 22 Aug 2018 09:31:47 GMT express:router checkForProblematicArtistQuery  : /?
metaphysics_1            | Wed, 22 Aug 2018 09:31:47 GMT express:router fetchPersistedQuery  : /?
metaphysics_1            | Wed, 22 Aug 2018 09:31:47 GMT express:router <anonymous>  : /?
metaphysics_1            | Wed, 22 Aug 2018 09:31:47 GMT express:router <anonymous>  : /?
metaphysics_1            | Wed, 22 Aug 2018 09:31:47 GMT info Loading: artist/walter-gropius?
```

After this change:
```
metaphysics_1            | Wed, 22 Aug 2018 09:41:20 GMT info ----------
metaphysics_1            | Wed, 22 Aug 2018 09:41:20 GMT express:router <anonymous>  : /?
metaphysics_1            | Wed, 22 Aug 2018 09:41:20 GMT express:router checkForProblematicArtistQuery  : /?
metaphysics_1            | Wed, 22 Aug 2018 09:41:20 GMT express:router fetchPersistedQuery  : /?
metaphysics_1            | Wed, 22 Aug 2018 09:41:20 GMT express:router <anonymous>  : /?
metaphysics_1            | Wed, 22 Aug 2018 09:41:20 GMT express:router <anonymous>  : /?
metaphysics_1            | Wed, 22 Aug 2018 09:41:20 GMT info Loading: artist/walter-gropius?
metaphysics_1            | Wed, 22 Aug 2018 09:41:20 GMT verbose Requested (Uncached): artist/walter-gropius?
metaphysics_1            | Wed, 22 Aug 2018 09:41:20 GMT info Elapsed: 0s 622.75ms - artist/walter-gropius?
metaphysics_1            | Wed, 22 Aug 2018 09:41:20 GMT express-interceptor end called
metaphysics_1            | Wed, 22 Aug 2018 09:41:20 GMT express-interceptor isIntercepting? undefined
metaphysics_1            | Wed, 22 Aug 2018 09:41:20 GMT compression gzip compression
metaphysics_1            | Wed, 22 Aug 2018 09:41:20 GMT morgan log request
metaphysics_1            | POST /? 200 729.738 ms - -
```

Lesson learned - be returning 😅