### PR TITLE
@sepans: Temporarily boost minReplicas

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -96,7 +96,7 @@ spec:
     apiVersion: extensions/v1beta1
     kind: Deployment
     name: metaphysics-web
-  minReplicas: 8
+  minReplicas: 12
   maxReplicas: 15
   targetCPUUtilizationPercentage: 80
 


### PR DESCRIPTION
We just observed a spike in search requests that caused API latency to increase. It recovered after ~5 minutes, but Metaphysics latency couldn't recover. All pods' logs were filled with messages like:

```
...[Cache#get] Timeout...
```
or
```
...[Cache#get] Slow read of 1537ms for key...
```
The pods were getting OOM-killed and all entered the `CrashLoopBackOff` state. (It reminded me of [recent outages](https://github.com/artsy/post_mortems/issues/32).)

I don't know how much it helped, but we ended up updating the `minReplicas` in an effort to give the pods more breathing room and start to actually handle requests.