### PR TITLE
Buyer/Seller is the new User/Partner

### DIFF
--- a/src/data/exchange.graphql
+++ b/src/data/exchange.graphql
@@ -167,6 +167,7 @@ type MutationError {
 
 # An Order
 type Order {
+  buyer: OrderPartyUnion!
   buyerTotalCents: Int
   code: String!
   commissionFeeCents: Int
@@ -188,8 +189,8 @@ type Order {
     # Returns the last _n_ elements from the list.
     last: Int
   ): LineItemConnection
-  partnerId: String!
   requestedFulfillment: RequestedFulfillmentUnion
+  seller: OrderPartyUnion!
   sellerTotalCents: Int
   shippingTotalCents: Int
   state: OrderStateEnum!
@@ -198,7 +199,6 @@ type Order {
   taxTotalCents: Int
   transactionFeeCents: Int
   updatedAt: DateTime!
-  userId: String!
 }
 
 # The connection type for Order.
@@ -239,21 +239,27 @@ enum OrderFulfillmentTypeEnum {
 # Represents either a resolved Order or a potential failure
 union OrderOrFailureUnion = OrderWithMutationFailure | OrderWithMutationSuccess
 
+# Represents either a partner or a user
+union OrderPartyUnion = Partner | User
+
 enum OrderStateEnum {
   # order is abandoned by collector and never submitted
   ABANDONED
 
-  # order is approved by partner
+  # order is approved by seller
   APPROVED
 
-  # order is fulfilled by partner
+  # order is fulfilled by seller
   FULFILLED
 
   # order is still pending submission by collector
   PENDING
 
-  # order is rejected by partner
+  # order is rejected by seller
   REJECTED
+
+  # order was lapsed by the seller
+  SELLER_LAPSED
 
   # order is submitted by collector
   SUBMITTED
@@ -284,6 +290,10 @@ type PageInfo {
   startCursor: String
 }
 
+type Partner {
+  id: String!
+}
+
 type Pickup {
   fulfillmentType: String!
 }
@@ -299,16 +309,18 @@ type Query {
 
     # Returns the elements in the list that come before the specified cursor.
     before: String
+    buyerId: String
+    buyerType: String
 
     # Returns the first _n_ elements from the list.
     first: Int
 
     # Returns the last _n_ elements from the list.
     last: Int
-    partnerId: String
+    sellerId: String
+    sellerType: String
     sort: OrderConnectionSortEnum
     state: OrderStateEnum
-    userId: String
   ): OrderConnection
 }
 
@@ -397,4 +409,8 @@ type SubmitOrderPayload {
   clientMutationId: String
   errors: [String!]!
   order: Order
+}
+
+type User {
+  id: String!
 }

--- a/src/schema/__tests__/ecommerce/order.test.js
+++ b/src/schema/__tests__/ecommerce/order.test.js
@@ -9,7 +9,7 @@ import { OrderSellerFields } from "./order_fields"
 
 let rootValue
 
-describe("Order type", () => {
+describe("Order query", () => {
   beforeEach(() => {
     const resolvers = { Query: { order: () => exchangeOrderJSON } }
 

--- a/src/schema/__tests__/ecommerce/order_fields.ts
+++ b/src/schema/__tests__/ecommerce/order_fields.ts
@@ -38,13 +38,25 @@ export const OrderBuyerFields = gql`
   createdAt
   stateUpdatedAt
   stateExpiresAt
-  partner {
-    id
-    name
+  seller {
+    ...on Partner {
+      id
+      name
+    }
+    ... on User {
+      id
+      email
+    }
   }
-  user {
-    id
-    email
+  buyer {
+    ... on User {
+      id
+      email
+    }
+    ...on Partner {
+      id
+      name
+    }
   }
   creditCard {
     id
@@ -113,13 +125,17 @@ export const OrderSellerFields = gql`
   createdAt
   stateUpdatedAt
   stateExpiresAt
-  partner {
-    id
-    name
+  seller {
+    ...on Partner {
+      id
+      name
+    }
   }
-  user {
-    id
-    email
+  buyer {
+    ... on User {
+      id
+      email
+    }
   }
   creditCard {
     id

--- a/src/schema/__tests__/ecommerce/orders.test.js
+++ b/src/schema/__tests__/ecommerce/orders.test.js
@@ -9,15 +9,15 @@ import { OrderSellerFields } from "./order_fields"
 
 let rootValue
 
-describe("Order type", () => {
+describe("Orders query", () => {
   beforeEach(() => {
     const resolvers = { Query: { orders: () => exchangeOrdersJSON } }
     rootValue = mockxchange(resolvers)
   })
-  it("fetches orders by partner id", () => {
+  it("fetches orders by seller id", () => {
     const query = gql`
       {
-        orders(partnerId: "581b45e4cd530e658b000124") {
+        orders(sellerId: "581b45e4cd530e658b000124") {
           edges {
             node {
               ${OrderSellerFields}

--- a/src/schema/ecommerce/approve_order_mutation.js
+++ b/src/schema/ecommerce/approve_order_mutation.js
@@ -2,7 +2,10 @@ import { graphql } from "graphql"
 import { OrderReturnType } from "schema/ecommerce/types/order_return"
 import { OrderMutationInputType } from "schema/ecommerce/types/order_mutation_input"
 import { mutationWithClientMutationId } from "graphql-relay"
-import { RequestedFulfillmentFragment } from "./query_helpers"
+import {
+  RequestedFulfillmentFragment,
+  BuyerSellerFields,
+} from "./query_helpers"
 import gql from "lib/gql"
 
 export const ApproveOrderMutation = mutationWithClientMutationId({
@@ -33,8 +36,7 @@ export const ApproveOrderMutation = mutationWithClientMutationId({
             code
             currencyCode
             state
-            partnerId
-            userId
+            ${BuyerSellerFields}
             requestedFulfillment {
               ${RequestedFulfillmentFragment}
             }

--- a/src/schema/ecommerce/create_order_with_artwork_mutation.ts
+++ b/src/schema/ecommerce/create_order_with_artwork_mutation.ts
@@ -9,7 +9,10 @@ import {
 import { mutationWithClientMutationId } from "graphql-relay"
 import { OrderOrFailureUnionType } from "schema/ecommerce/types/order_or_error_union"
 import gql from "lib/gql"
-import { RequestedFulfillmentFragment } from "./query_helpers"
+import {
+  RequestedFulfillmentFragment,
+  BuyerSellerFields,
+} from "./query_helpers"
 
 const CreateOrderInputType = new GraphQLInputObjectType({
   name: "CreateOrderInput",
@@ -70,7 +73,7 @@ export const CreateOrderWithArtworkMutation = mutationWithClientMutationId({
                 createdAt
                 currencyCode
                 itemsTotalCents
-                partnerId
+                ${BuyerSellerFields}
                 sellerTotalCents
                 requestedFulfillment {
                   ${RequestedFulfillmentFragment}
@@ -82,7 +85,6 @@ export const CreateOrderWithArtworkMutation = mutationWithClientMutationId({
                 taxTotalCents
                 transactionFeeCents
                 updatedAt
-                userId
                 lineItems {
                   edges {
                     node {

--- a/src/schema/ecommerce/fulfill_order_at_once_mutation.ts
+++ b/src/schema/ecommerce/fulfill_order_at_once_mutation.ts
@@ -6,7 +6,11 @@ import {
 } from "graphql"
 import { OrderReturnType } from "schema/ecommerce/types/order_return"
 import { mutationWithClientMutationId } from "graphql-relay"
-import { RequestedFulfillmentFragment } from "./query_helpers"
+import {
+  RequestedFulfillmentFragment,
+  BuyerSellerFields,
+} from "./query_helpers"
+import gql from "lib/gql"
 
 const FulfillmentInputType = new GraphQLInputObjectType({
   name: "FulfillmentInputType",
@@ -60,7 +64,7 @@ export const FulfillOrderAtOnceMutation = mutationWithClientMutationId({
       return new Error("You need to be signed in to perform this action")
     }
 
-    const mutation = `
+    const mutation = gql`
       mutation fulfillOrderAtOnce($orderId: ID!, $fulfillment: EcommerceFulfillmentAttributes!) {
         ecommerce_fulfillAtOnce(input: {
           id: $orderId,
@@ -71,8 +75,7 @@ export const FulfillOrderAtOnceMutation = mutationWithClientMutationId({
             code
             currencyCode
             state
-            partnerId
-            userId
+            ${BuyerSellerFields}
             requestedFulfillment {
               ${RequestedFulfillmentFragment}
             }

--- a/src/schema/ecommerce/order.js
+++ b/src/schema/ecommerce/order.js
@@ -1,21 +1,24 @@
 import { graphql, GraphQLNonNull, GraphQLString } from "graphql"
 import { OrderType } from "schema/ecommerce/types/order"
-import { RequestedFulfillmentFragment } from "./query_helpers"
+import {
+  RequestedFulfillmentFragment,
+  BuyerSellerFields,
+} from "./query_helpers"
+import gql from "lib/gql"
 export const Order = {
   name: "Order",
   type: OrderType,
   description: "Returns a single Order",
   args: { id: { type: new GraphQLNonNull(GraphQLString) } },
   resolve: (_parent, { id }, context, { rootValue: { exchangeSchema } }) => {
-    const query = `
+    const query = gql`
       query EcommerceOrder($id: ID!) {
         ecommerce_order(id: $id) {
           id
           code
           currencyCode
           state
-          partnerId
-          userId
+          ${BuyerSellerFields}
           creditCardId
           requestedFulfillment {
             ${RequestedFulfillmentFragment}

--- a/src/schema/ecommerce/orders.js
+++ b/src/schema/ecommerce/orders.js
@@ -2,34 +2,44 @@ import { graphql, GraphQLString } from "graphql"
 import { OrderConnection } from "schema/ecommerce/types/order"
 import { OrdersSortMethodTypeEnum } from "schema/ecommerce/types/orders_sort_method_enum"
 import gql from "lib/gql"
-import { PageInfo, RequestedFulfillmentFragment } from "./query_helpers"
+import {
+  PageInfo,
+  RequestedFulfillmentFragment,
+  BuyerSellerFields,
+} from "./query_helpers"
 
 export const Orders = {
   name: "Orders",
   type: OrderConnection,
   description: "Returns list of orders",
   args: {
-    userId: { type: GraphQLString },
-    partnerId: { type: GraphQLString },
+    buyerId: { type: GraphQLString },
+    buyerType: { type: GraphQLString },
+    sellerId: { type: GraphQLString },
+    sellerType: { type: GraphQLString },
     state: { type: GraphQLString },
     sort: { type: OrdersSortMethodTypeEnum },
   },
   resolve: (
     _parent,
-    { userId, partnerId, state, sort },
+    { sellerId, sellerType, buyerId, buyerType, state, sort },
     context,
     { rootValue: { exchangeSchema } }
   ) => {
     const query = gql`
       query EcommerceOrders(
-        $userId: String
-        $partnerId: String
+        $buyerId: String
+        $buyerType: String
+        $sellerId: String
+        $sellerType: String
         $state: EcommerceOrderStateEnum
         $sort: EcommerceOrderConnectionSortEnum
       ) {
         ecommerce_orders(
-          userId: $userId
-          partnerId: $partnerId
+          buyerId: $buyerId
+          buyerType: $buyerType
+          sellerId: $sellerId
+          sellerType: $sellerType
           state: $state
           sort: $sort
         ) {
@@ -40,8 +50,7 @@ export const Orders = {
               code
               currencyCode
               state
-              partnerId
-              userId
+              ${BuyerSellerFields}
               updatedAt
               createdAt
               requestedFulfillment {
@@ -74,8 +83,10 @@ export const Orders = {
       }
     `
     return graphql(exchangeSchema, query, null, context, {
-      userId,
-      partnerId,
+      buyerId,
+      buyerType,
+      sellerId,
+      sellerType,
       state,
       sort,
     }).then(result => {

--- a/src/schema/ecommerce/query_helpers.ts
+++ b/src/schema/ecommerce/query_helpers.ts
@@ -23,3 +23,24 @@ export const PageInfo = gql`
     endCursor
   }
 `
+
+export const BuyerSellerFields = gql`
+  seller {
+    __typename
+    ... on EcommercePartner{
+      id
+    }
+    ... on EcommerceUser {
+      id
+    }
+  }
+  buyer {
+    __typename
+    ... on EcommerceUser {
+      id
+    }
+    ... on EcommercePartner{
+      id
+    }
+  }
+`

--- a/src/schema/ecommerce/reject_order_mutation.js
+++ b/src/schema/ecommerce/reject_order_mutation.js
@@ -2,7 +2,10 @@ import { graphql } from "graphql"
 import { OrderReturnType } from "schema/ecommerce/types/order_return"
 import { OrderMutationInputType } from "schema/ecommerce/types/order_mutation_input"
 import { mutationWithClientMutationId } from "graphql-relay"
-import { RequestedFulfillmentFragment } from "./query_helpers"
+import {
+  RequestedFulfillmentFragment,
+  BuyerSellerFields,
+} from "./query_helpers"
 import gql from "lib/gql"
 
 export const RejectOrderMutation = mutationWithClientMutationId({
@@ -34,8 +37,7 @@ export const RejectOrderMutation = mutationWithClientMutationId({
             code
             currencyCode
             state
-            partnerId
-            userId
+            ${BuyerSellerFields}
             requestedFulfillment {
               ${RequestedFulfillmentFragment}
             }

--- a/src/schema/ecommerce/set_order_payment_mutation.ts
+++ b/src/schema/ecommerce/set_order_payment_mutation.ts
@@ -6,7 +6,10 @@ import {
 } from "graphql"
 import { OrderReturnType } from "schema/ecommerce/types/order_return"
 import { mutationWithClientMutationId } from "graphql-relay"
-import { RequestedFulfillmentFragment } from "./query_helpers"
+import {
+  RequestedFulfillmentFragment,
+  BuyerSellerFields,
+} from "./query_helpers"
 import gql from "lib/gql"
 
 const SetOrderPaymentInputType = new GraphQLInputObjectType({
@@ -52,8 +55,7 @@ export const SetOrderPaymentMutation = mutationWithClientMutationId({
             code
             currencyCode
             state
-            partnerId
-            userId
+            ${BuyerSellerFields}
             requestedFulfillment {
               ${RequestedFulfillmentFragment}
             }

--- a/src/schema/ecommerce/set_order_shipping_mutation.ts
+++ b/src/schema/ecommerce/set_order_shipping_mutation.ts
@@ -9,7 +9,10 @@ import { OrderReturnType } from "schema/ecommerce/types/order_return"
 import { OrderFulfillmentTypeEnum } from "./types/order_fulfillment_type_enum"
 import { mutationWithClientMutationId } from "graphql-relay"
 import gql from "lib/gql"
-import { RequestedFulfillmentFragment } from "./query_helpers"
+import {
+  RequestedFulfillmentFragment,
+  BuyerSellerFields,
+} from "./query_helpers"
 
 const ShippingInputField = new GraphQLInputObjectType({
   name: "ShippingInputField",
@@ -100,8 +103,7 @@ export const SetOrderShippingMutation = mutationWithClientMutationId({
             code
             currencyCode
             state
-            partnerId
-            userId
+            ${BuyerSellerFields}
             requestedFulfillment {
               ${RequestedFulfillmentFragment}
             }

--- a/src/schema/ecommerce/submit_order_mutation.js
+++ b/src/schema/ecommerce/submit_order_mutation.js
@@ -7,7 +7,10 @@ import {
 import { OrderReturnType } from "schema/ecommerce/types/order_return"
 import { mutationWithClientMutationId } from "graphql-relay"
 import gql from "lib/gql"
-import { RequestedFulfillmentFragment } from "./query_helpers"
+import {
+  RequestedFulfillmentFragment,
+  BuyerSellerFields,
+} from "./query_helpers"
 
 const SubmitOrderInputType = new GraphQLInputObjectType({
   name: "SubmitOrderInput",
@@ -48,8 +51,7 @@ export const SubmitOrderMutation = mutationWithClientMutationId({
             code
             currencyCode
             state
-            partnerId
-            userId
+            ${BuyerSellerFields}
             requestedFulfillment {
               ${RequestedFulfillmentFragment}
             }

--- a/src/schema/ecommerce/types/order.ts
+++ b/src/schema/ecommerce/types/order.ts
@@ -4,16 +4,14 @@ import {
   GraphQLString,
   GraphQLInt,
 } from "graphql"
-import { OrderFulfillmentTypeEnum } from "./order_fulfillment_type_enum"
 import { connectionDefinitions } from "graphql-relay"
 
-import Partner from "schema/partner"
 import { amount } from "schema/fields/money"
 import date from "schema/fields/date"
-import { UserByID } from "schema/user"
 import { CreditCard } from "schema/credit_card"
 import { OrderLineItemConnection } from "./order_line_item"
 import { RequestedFulfillmentUnionType } from "./requested_fulfillment_union_type"
+import { OrderPartyUnionType } from "./order_party_union"
 
 export const OrderType = new GraphQLObjectType({
   name: "Order",
@@ -77,25 +75,25 @@ export const OrderType = new GraphQLObjectType({
       type: OrderLineItemConnection,
       description: "List of order line items",
     },
-    partner: {
-      type: Partner.type,
-      description: "Partner of this order",
+    seller: {
+      type: OrderPartyUnionType,
+      description: "Seller of this order",
       resolve: (
-        { partnerId },
+        { seller },
         _args,
         _context,
-        { rootValue: { partnerLoader } }
-      ) => partnerLoader(partnerId),
+        { rootValue: { userByIDLoader, partnerLoader } }
+      ) => resolveOrderParty(seller, userByIDLoader, partnerLoader),
     },
-    user: {
-      type: UserByID.type,
-      description: "User of this order",
+    buyer: {
+      type: OrderPartyUnionType,
+      description: "Buyer of this order",
       resolve: (
-        { userId },
+        { buyer },
         _args,
         _context,
-        { rootValue: { userByIDLoader } }
-      ) => (userId ? userByIDLoader(userId) : null),
+        { rootValue: { userByIDLoader, partnerLoader } }
+      ) => resolveOrderParty(buyer, userByIDLoader, partnerLoader),
     },
     creditCard: {
       type: CreditCard.type,
@@ -114,6 +112,22 @@ export const OrderType = new GraphQLObjectType({
     stateExpiresAt: date as any,
   }),
 })
+
+const resolveOrderParty = async (orderParty, userByIDLoader, partnerLoader) => {
+  if (orderParty.id) {
+    if (orderParty.__typename === "EcommerceUser") {
+      const user = await userByIDLoader(orderParty.id)
+      user.__typename = "User"
+      return user
+    } else if (orderParty.__typename === "EcommercePartner") {
+      const partner = await partnerLoader(orderParty.id)
+      partner.__typename = "Partner"
+      return partner
+    }
+  } else {
+    return null
+  }
+}
 
 export const {
   connectionType: OrderConnection,

--- a/src/schema/ecommerce/types/order_party_union.ts
+++ b/src/schema/ecommerce/types/order_party_union.ts
@@ -1,0 +1,9 @@
+import { GraphQLUnionType } from "graphql"
+import Partner from "schema/partner"
+import { UserType } from "schema/user"
+
+export const OrderPartyUnionType = new GraphQLUnionType({
+  name: "OrderParty",
+  types: [Partner.type, UserType],
+  resolveType: obj => (obj.__typename === "User" ? UserType : Partner.type),
+})

--- a/src/test/fixtures/exchange/mockxchange.js
+++ b/src/test/fixtures/exchange/mockxchange.js
@@ -26,8 +26,17 @@ export const mockxchange = resolvers => {
       __resolveType(obj, context, info) {
         if (obj.country) {
           return "Ship"
-        } else if (obj.error) {
+        } else {
           return "Pickup"
+        }
+      },
+    },
+    OrderPartyUnion: {
+      __resolveType(obj, _context, _info) {
+        if (obj.__typename === "User") {
+          return "User"
+        } else {
+          return "Partner"
         }
       },
     },

--- a/src/test/fixtures/exchange/order.json
+++ b/src/test/fixtures/exchange/order.json
@@ -3,8 +3,14 @@
   "code": "1",
   "state": "PENDING",
   "currencyCode": "usd",
-  "partnerId": "111",
-  "userId": "111",
+  "seller":{
+    "id": "111",
+    "__typename": "Partner"
+  },
+  "buyer":{
+    "id": "111",
+    "__typename": "User"
+  },
   "creditCardId": "card123",
   "requestedFulfillment": {
     "name": "Dr Collector",

--- a/src/test/fixtures/exchange/orders.json
+++ b/src/test/fixtures/exchange/orders.json
@@ -12,8 +12,14 @@
         "code": "1",
         "state": "PENDING",
         "currencyCode": "usd",
-        "partnerId": "111",
-        "userId": "111",
+        "seller":{
+          "id": "111",
+          "__typename": "Partner"
+        },
+        "buyer":{
+          "id": "111",
+          "__typename": "User"
+        },
         "requestedFulfillment": {
           "name": "Dr Collector",
           "addressLine1": "Vanak 123",

--- a/src/test/fixtures/results/sample_order.js
+++ b/src/test/fixtures/results/sample_order.js
@@ -31,11 +31,11 @@ const defaultResponse = {
   stateUpdatedAt: "2018-07-03 17:57:47 UTC",
   stateExpiresAt: "2018-07-03 17:57:47 UTC",
   creditCard: null,
-  partner: {
+  seller: {
     id: "111",
     name: "Subscription Partner",
   },
-  user: {
+  buyer: {
     id: "111",
     email: "bob@ross.com",
   },


### PR DESCRIPTION
# Problem
`User` and `Partner` are very specific terms and not clear when it comes to ecommerce platform, we decided to [rename](https://github.com/artsy/exchange/pull/121) these fields in Exchange. This PR matches those changes by:
- Adding `OrderPartyUnionType`
- Switch all the places we use `user` and `partner`

# Update Notes
## CMS Side
Make sure to update your `orders` query. Replace `partnerId` argument to `sellerId` and `sellerType` with seller type being `Partner` (we can make this an enum too later.

## CMS and Collectors
in your queries replaces
```
userId
partnerId
 ```
to 
```graphql
seller {
    ...on Partner {
      id
      name
    }
    ... on User {
      id
      email
    }
  }
buyer {
    ... on User {
      id
      email
    }
    ...on Partner {
      id
      name
    }
  }
```

Ideally this gets deployed around the same time as https://github.com/artsy/exchange/pull/121