### PR TITLE
@orta: add price currency to artwork schema

### DIFF
--- a/src/schema/artwork/index.js
+++ b/src/schema/artwork/index.js
@@ -513,6 +513,7 @@ export const artworkFields = () => {
       },
     },
     price: { type: GraphQLString },
+    price_currency: { type: GraphQLString },
     shippingInfo: {
       type: GraphQLString,
       description:


### PR DESCRIPTION
This adds the `price_currency` to the artwork schema for https://artsyproduct.atlassian.net/browse/GROW-845.