### PR TITLE
Change the definition of is_inquireable to mean just inquireable

### DIFF
--- a/src/schema/artwork/index.ts
+++ b/src/schema/artwork/index.ts
@@ -37,8 +37,8 @@ import { LotStandingType } from "../me/lot_standing"
 import { amount } from "schema/fields/money"
 import { capitalizeFirstCharacter } from "lib/helpers"
 
-const is_inquireable = ({ inquireable, acquireable }) => {
-  return inquireable && !acquireable
+const is_inquireable = ({ inquireable }) => {
+  return inquireable
 }
 
 const has_price_range = price => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2068,7 +2068,7 @@ dd-trace@artsy/dd-trace-js#artsy:
     safe-buffer "^5.1.1"
     semver "^5.5.0"
     shimmer "^1.2.0"
-    url-parse "^1.4.3"
+    url-parse "^1.2.0"
   optionalDependencies:
     "@airbnb/node-memwatch" "^1.0.2"
 


### PR DESCRIPTION
This is probably controversial but here's what's up:

Right now in force, we need control over both the fact that an artwork is `inquireable` and `acquireable`. i.e. for now, if a work has `{ acquireable: true, inquireable: true }`, we want to be able to show the inquiry button _unless_ they have the lab feature enabled. This is currently impossible because we don't expose `inquireable` in its truthful form.

☝️ that's the practical requirement, which could be solved in multiple ways.

The second important piece is that I don't think we should have `is_inquireable` conflate the meaning of what it means to be `inquireable` and `acquireable`. What if an offering we give to galleries is the ability to both buy _or_ inquire on a work? Now that metaphysics is acting as an API and not just as a view-helper-layer, I think it would be good to update this definition.

_Is this change scary?_

Maybe. But this would only affect works that are currently `acquireable`. (If a work is `inquireable` and _not_ `acquireable`, this will return the same value).

The only works that we have (right now) that are `acquireable` are:
1. the ones we're testing out for ecommerce (so only admins can see)
2. auction works which are also enabled for ecommerce

The auction case is handled by a separate component entirely in force, so I believe that should be okay.

I put this as #DONTMERGE for now because I want to discuss and also because it's somewhat dependent on another run-through of force to make sure we're not missing anything. We're not currently consuming this field in Eigen or Emission, and only in the new artwork page in reaction (which isn't in prod yet).