### PR TITLE
use __typename for resolving type on orderOrError

### DIFF
--- a/src/schema/ecommerce/approve_order_mutation.ts
+++ b/src/schema/ecommerce/approve_order_mutation.ts
@@ -32,6 +32,7 @@ export const ApproveOrderMutation = mutationWithClientMutationId({
           id: $orderId,
         }) {
           orderOrError {
+            __typename
             ... on EcommerceOrderWithMutationSuccess {
               order {
               id

--- a/src/schema/ecommerce/create_order_with_artwork_mutation.ts
+++ b/src/schema/ecommerce/create_order_with_artwork_mutation.ts
@@ -65,6 +65,7 @@ export const CreateOrderWithArtworkMutation = mutationWithClientMutationId({
           }
         ) {
           orderOrError {
+            __typename
             ... on EcommerceOrderWithMutationSuccess {
               order {
                 id

--- a/src/schema/ecommerce/fulfill_order_at_once_mutation.ts
+++ b/src/schema/ecommerce/fulfill_order_at_once_mutation.ts
@@ -71,6 +71,7 @@ export const FulfillOrderAtOnceMutation = mutationWithClientMutationId({
           fulfillment: $fulfillment
         }) {
           orderOrError {
+            __typename
             ... on EcommerceOrderWithMutationSuccess {
               order {
               id

--- a/src/schema/ecommerce/reject_order_mutation.ts
+++ b/src/schema/ecommerce/reject_order_mutation.ts
@@ -33,6 +33,7 @@ export const RejectOrderMutation = mutationWithClientMutationId({
           id: $orderId,
         }) {
           orderOrError {
+            __typename
             ... on EcommerceOrderWithMutationSuccess {
               order {
               id

--- a/src/schema/ecommerce/set_order_payment_mutation.ts
+++ b/src/schema/ecommerce/set_order_payment_mutation.ts
@@ -51,6 +51,7 @@ export const SetOrderPaymentMutation = mutationWithClientMutationId({
           creditCardId: $creditCardId,
         }) {
           orderOrError {
+            __typename
             ... on EcommerceOrderWithMutationSuccess {
               order {
               id

--- a/src/schema/ecommerce/set_order_shipping_mutation.ts
+++ b/src/schema/ecommerce/set_order_shipping_mutation.ts
@@ -99,6 +99,7 @@ export const SetOrderShippingMutation = mutationWithClientMutationId({
           }
         ) {
           orderOrError {
+            __typename
             ... on EcommerceOrderWithMutationSuccess {
               order {
                 id

--- a/src/schema/ecommerce/submit_order_mutation.ts
+++ b/src/schema/ecommerce/submit_order_mutation.ts
@@ -47,6 +47,7 @@ export const SubmitOrderMutation = mutationWithClientMutationId({
           id: $orderId
         }) {
           orderOrError {
+            __typename
             ... on EcommerceOrderWithMutationSuccess {
               order {
                 id

--- a/src/schema/ecommerce/types/order_or_error_union.ts
+++ b/src/schema/ecommerce/types/order_or_error_union.ts
@@ -9,7 +9,6 @@ import { OrderType } from "schema/ecommerce/types/order"
 
 export const OrderWithMutationSuccess = new GraphQLObjectType({
   name: "OrderWithMutationSuccess",
-  isTypeOf: data => data.order,
   fields: () => ({
     order: { type: OrderType },
   }),
@@ -17,7 +16,6 @@ export const OrderWithMutationSuccess = new GraphQLObjectType({
 
 export const EcommerceError = new GraphQLObjectType({
   name: "EcommerceError",
-  isTypeOf: data => data.order,
   fields: {
     description: {
       type: new GraphQLNonNull(GraphQLString),
@@ -28,7 +26,6 @@ export const EcommerceError = new GraphQLObjectType({
 
 export const OrderWithMutationFailure = new GraphQLObjectType({
   name: "OrderWithMutationFailure",
-  isTypeOf: data => data.error,
   fields: {
     error: { type: EcommerceError },
   },
@@ -37,4 +34,8 @@ export const OrderWithMutationFailure = new GraphQLObjectType({
 export const OrderOrFailureUnionType = new GraphQLUnionType({
   name: "OrderOrFailureUnionType",
   types: [OrderWithMutationSuccess, OrderWithMutationFailure],
+  resolveType: object =>
+    object.__typename === "EcommerceOrderWithMutationSuccess"
+      ? OrderWithMutationSuccess
+      : OrderWithMutationFailure,
 })


### PR DESCRIPTION
# Problem
Seeing 
```
"errors": [
		{
			"message": "Cannot convert object to primitive value",
			"locations": [
				{
					"line": 22,
					"column": 5
				}
			],
			"path": null,
			"stack": null
		}
	],
	"data": {
		"setOrderShipping": {
			"orderOrError": {
				"__typename": "OrderWithMutationFailure",
				"error": null
			}
		}
	},
	"extensions": {
		"requests": {
			"gravity": {
				"requests": {
					"me/token?client_application_id=5b228bb2f7052934876c02cb": {
						"time": "0s 39.629ms",
						"cache": false
					}
				}
			}
		},
		"requestID": "b35cfe70-ac99-11e8-9220-75cee4201e72"
	}
```

When getting errors from Exchange.

# Solution
Looks like there was an issue in resolving the response and map it properly to our failure type. Switched to use `resolveType: ` on union type.
 