### PR TITLE
Adds a script to compare the unstitched vs stitched schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ flow-typed
 package-lock.json
 yarn-error.log
 resourceRegistry.log
+tmp
+_schema.graphql 

--- a/scripts/compare-stitched-schema.sh
+++ b/scripts/compare-stitched-schema.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+if ! type "schema_comparator" > /dev/null; then
+  echo ""
+  echo "Please run 'gem install graphql-schema_comparator'"
+  echo ""
+  exit 1
+fi
+
+mkdir -p tmp
+yarn dump-schema _schema.graphql
+ENABLE_SCHEMA_STITCHING=true yarn dump-schema tmp/stitched.graphql
+
+schema_comparator compare  _schema.graphql tmp/stitched.graphql

--- a/scripts/dump-schema.ts
+++ b/scripts/dump-schema.ts
@@ -3,14 +3,26 @@ import path from "path"
 import schema from "schema"
 import { printSchema } from "graphql/utilities"
 
+const message =
+  "Usage: dump-schema.js /path/to/output/directory or /path/to/filename.graphql"
+
 const destination = process.argv[2]
-if (destination === undefined || !fs.existsSync(destination)) {
-  console.error("Usage: dump-schema.js /path/to/output/directory")
+if (destination === undefined) {
+  console.error(message)
+  process.exit(1)
+}
+
+// Support both passing a folder or a filename
+const folder = path.dirname(destination)
+const filename = path.basename(destination) || "schema.graphql"
+if (!fs.existsSync(folder)) {
+  console.error(message)
   process.exit(1)
 }
 
 // Save user readable type system shorthand of schema
 fs.writeFileSync(
-  path.join(destination, "schema.graphql"),
-  printSchema(schema, { commentDescriptions: true })
+  path.join(folder, filename),
+  printSchema(schema, { commentDescriptions: true }),
+  "utf8"
 )


### PR DESCRIPTION
This gives us insight into what is different in the schemas between stitched and unstitched today.

Looks like gravql and convection issues. Personally, I'm a little surprised that exchange is perfect, but maybe I shouldn't be? Maybe it's because all that code is being included anyway.

This PR doesn't attempt to fix, but to provide a way to get insight.

```sh
~/d/p/a/j/a/metaphysics  $ ./scripts/compare-stitched-schema.sh                                                                                                                     stitch_vs_unstitched
yarn run v1.9.4
$ babel-node --extensions '.ts,.js' ./scripts/dump-schema.ts _schema.graphql
✨  Done in 1.30s.
yarn run v1.9.4
$ babel-node --extensions '.ts,.js' ./scripts/dump-schema.ts tmp/stitched.graphql
✨  Done in 1.36s.
⏳  Checking for changes...
Name "__id" must not begin with "__", which is reserved by GraphQL introspection. x 100
🎉  Done! Result:

Detected the following changes between schemas:

🛑  Type `ConsignmentSubmissionConnection` was removed
🛑  Field `addAssetToConsignmentSubmission` was removed from object type `Mutation`
🛑  Field `updateConsignmentSubmission` was removed from object type `Mutation`
🛑  Field `createConsignmentSubmission` was removed from object type `Mutation`
🛑  Field `consignment_submissions` was removed from object type `Me`
🛑  Type `RecordArtworkViewInput` was removed
🛑  Type `RecordArtworkViewPayload` was removed
🛑  Type `AddAssetToConsignmentSubmissionInput` was removed
🛑  Type `Asset` was removed
🛑  Type `AddAssetToConsignmentSubmissionPayload` was removed
🛑  Type `UpdateSubmissionMutationInput` was removed
🛑  Type `UpdateSubmissionMutationPayload` was removed
🛑  Type `CreateSubmissionMutationInput` was removed
🛑  Type `CreateSubmissionMutationPayload` was removed
🛑  Type `SubmissionStateAggregation` was removed
🛑  Type `SubmissionDimensionAggregation` was removed
🛑  Type `SubmissionCategoryAggregation` was removed
🛑  Type `ConsignmentSubmission` was removed
🛑  Type `ConsignmentSubmissionEdge` was removed
🛑  Field `recordArtworkView` was removed from object type `Mutation`
```