### PR TITLE
Creates a script for running emission stored queries against instances of metaphysics

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,6 +22,7 @@
   },
   "cSpell.words": [
     "Ecommerce",
+    "Refetch",
     "Reloadable",
     "consignable",
     "mockxchange",

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,31 @@
+There are two main types of tests in metaphysics:
+
+### Unit Tests
+
+These typically are your usual jest tests, they tend to look like this:
+
+```js
+it("returns false if user is not found by email", async () => {
+  const query = gql`
+    {
+      user(email: "nonexistentuser@bar.com") {
+        userAlreadyExists
+      }
+    }
+  `
+  // [setup the test]
+  const { user } = await runAuthenticatedQuery(query, { userByEmailLoader })
+  expect(user.userAlreadyExists).toEqual(false)
+})
+```
+
+We want a lot of these. They're simple to write, and time-cheap. You can run
+`yarn jest --watch` to have these running as you work.
+
+### Integration Tests
+
+There are two main sources for integration/functional tests:
+
+- [`src/__tests__/integration.test.ts`](/src/__tests__/integration.test.ts) launches the entire GraphQL server and makes a single dummy query. This is done to verify the entire schema works correctly. It runs in a normal jest run.
+
+- [`src/__tests__/runStoredQueryTests.ts`](/src/__tests__/runStoredQueryTests.ts) uses most of our stored queries to verify that no errors occurs in the query. This is a script, you can run it via `test:validQueries`.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "verbose-dev": "DEBUG=verbose,info,error nf start --procfile Procfile.dev",
     "dev": "DEBUG=info,warn,error nf start --procfile Procfile.dev -w",
     "test": "yarn type-check && yarn lint && jest",
+    "test:validQueries": "babel-node --extensions '.ts,.js' src/__tests__/runStoredQueryTests.ts",
     "watch": "jest --watch",
     "lint": "eslint .",
     "fix": "eslint . --fix",

--- a/src/__tests__/runStoredQueryTests.ts
+++ b/src/__tests__/runStoredQueryTests.ts
@@ -1,0 +1,134 @@
+import { readFileSync } from "fs"
+import fetch from "lib/apis/fetch"
+import chalk from "chalk"
+const { USER_ACCESS_TOKEN: accessToken, USER_ID: userID } = process.env
+
+if (!accessToken && !userID) {
+  console.error(`
+  Cannot run queries without a user access token and user ID. You can get one by 
+  - 1. Signing in on staging.artsy.net
+  - 2. Open a dev console
+  - 3. and get the values \`sd.CURRENT_USER.id\` and \`sd.CURRENT_USER.accessToken\`
+  - 4. you can add these to your .env as:
+
+       USER_ID=[id]
+       USER_ACCESS_TOKEN=[accessToken]
+
+    You can also grab these from Reaction's .env if you have that set up.
+  `)
+  process.exit(1)
+}
+
+enum Env {
+  Prod,
+  Staging,
+  Dev,
+}
+
+const url = getURL(Env.Prod)
+
+const saleArtworkID =
+  "georg-jensen-beaded-slash-kugle-sterling-silver-cutlery-60"
+
+// We want to be able to run queries that require non-null variables
+// this is a map of a query name to their hard-coded variables.
+//
+// I just picked some at random
+const variablesLookup = {
+  QueryRenderersArtistQuery: { artistID: "banksy", isPad: true },
+  SelectMaxBidRefetchQuery: { saleArtworkID },
+  QueryRenderersGeneQuery: { geneID: "feminist-art" },
+  QueryRenderersInquiryQuery: {
+    artworkID: "banksy-flower-bomber-by-brandalism",
+  },
+  QueryRenderersSaleQuery: { saleID: "phillips-summer-school-1" },
+  QueryRenderersWorksForYouQuery: { selectedArtist: "banksy" },
+  BidFlowConfirmBidScreenRendererQuery: { saleArtworkID },
+  BidFlowSelectMaxBidRendererQuery: { saleArtworkID },
+  QueryRenderersBidFlowQuery: {
+    artworkID: saleArtworkID,
+    saleID: "bruun-rasmussen-silver-ceramics-and-design",
+  },
+}
+
+const go = async () => {
+  const map = readFileSync("src/data/complete.queryMap.json", "utf8")
+  const queries = JSON.parse(map)
+  for (const key in queries) {
+    if (queries.hasOwnProperty(key)) {
+      const queryString: string = queries[key]
+      // Pull out the query name with some simple splitting
+      const name = queryString
+        .split("(")[0]
+        .split("{")[0]
+        .replace("query ", "")
+        .trim()
+
+      // Mutations aren't complicated queries generally
+      if (queryString.includes("mutation")) {
+        console.log(chalk.grey(`  ${name}: Skipping due to being a mutation`))
+      } else {
+        const queryHasArgs = queryString.includes("Query(")
+        const queryVariables = variablesLookup[name]
+        if (queryHasArgs && !queryVariables) {
+          const msg = chalk.grey(
+            `  ${name}: Skipping due to query args which aren't in the lookup`
+          )
+          console.log(msg)
+          continue
+        }
+
+        // Start making the query
+        process.stdout.write(`   ${chalk.bold.whiteBright(name)}: calling `)
+        const response = await request(queryString, queryVariables)
+        if (!response.errors) {
+          console.log(chalk.green.bold("✓"))
+        } else {
+          console.log(chalk.red.bold("✖"))
+          // It failed, so print out the errors from metaphysics
+          console.log(chalk.gray("\n\n------------------------\n\n"))
+          console.log(response.errors)
+          console.log(chalk.gray("\n\n------------------------\n\n"))
+        }
+      }
+    }
+  }
+}
+
+const request = (query: string, variables?: any) =>
+  fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "User-Agent": "Integration Tests",
+      "X-USER-ID": userID,
+      "X-ACCESS-TOKEN": accessToken,
+    },
+    body: JSON.stringify({ query, variables }),
+  }).then(response => {
+    if (!(response.status >= 200 && response.status < 300)) {
+      return response
+    } else {
+      const error: any = new Error(response.statusText)
+      error.response = response
+      throw error
+    }
+  })
+
+function getURL(environment) {
+  switch (environment) {
+    case Env.Prod:
+      return "https://metaphysics-production.artsy.net"
+
+    case Env.Staging:
+      return "https://metaphysics-staging.artsy.net"
+
+    case Env.Dev:
+      return "http://localhost:5001"
+  }
+}
+
+console.log("Starting up running queries against:")
+console.log("  " + chalk.bold.whiteBright(url!))
+console.log("")
+go()


### PR DESCRIPTION
OK, so given the results of #1257 - I took a step back and wondered what other linting tools can we have that don't require putting stitching on staging. One of them is to run our production queries against different hosts of metaphysics.

This PR takes our stored queries, loops through them and calls them against an instance of MP

<img width="1049" alt="screen shot 2018-08-31 at 5 00 29 pm" src="https://user-images.githubusercontent.com/49038/44935704-d9989300-ad3f-11e8-9997-3b590cd70e04.png">

- it handles looking up variables for a bunch of queries (I focused on root query renderers as they tend to have the complexity I'm interested in testing)
- it skips mutations
- it uses the same env var names as reaction, so you can C&P

It *does not* add to CI - that's feasible, I'm not too sure where the value lives there, but I'm open to ideas.