### PR TITLE
resolve ipv6-formatted addresses to ipv4

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "hot-shots": "^5.6.1",
     "http-shutdown": "^1.2.0",
     "i": "^0.3.5",
+    "ip": "^1.1.5",
     "invariant": "^2.2.4",
     "jwt-simple": "^0.5.0",
     "lodash": "^4.3.0",

--- a/src/lib/loaders/__tests__/request_id.test.js
+++ b/src/lib/loaders/__tests__/request_id.test.js
@@ -1,6 +1,7 @@
 import { runAuthenticatedQuery, runQuery } from "test/utils"
 import createLoaders from "../../../lib/loaders"
 import gql from "lib/gql"
+import { resolveIPv4 } from "../../../lib/requestIDs"
 
 jest.mock("../../apis/gravity", () => jest.fn(() => Promise.resolve({})))
 import gravity from "../../apis/gravity"
@@ -44,5 +45,14 @@ describe("requestID (with the real data loaders)", () => {
     expect(gravity).toBeCalledWith("me/lot_standings?", "secret", {
       requestIDs,
     })
+  })
+})
+
+describe("resolve ipv4 addresses", () => {
+  it("resolves an ipv6 address to ipv4", () => {
+    expect(resolveIPv4('::ffff:127.0.0.1')).toEqual('127.0.0.1')
+  })
+  it("resolves an ipv4 address to an ipv4 address", () => {
+    expect(resolveIPv4('127.0.0.1')).toEqual('127.0.0.1')
   })
 })

--- a/src/lib/requestIDs.ts
+++ b/src/lib/requestIDs.ts
@@ -1,4 +1,5 @@
 import uuid from "uuid/v1"
+import ip from "ip"
 
 export function headers({ requestID, xForwardedFor }) {
   const headers = {
@@ -8,11 +9,20 @@ export function headers({ requestID, xForwardedFor }) {
   return headers
 }
 
+export function resolveIPv4(ipAddress) {
+  if(ip.isV6Format(ipAddress) && ~ipAddress.indexOf('::ffff')){
+    return ipAddress.split('::ffff:')[1]
+  }
+  return ipAddress
+}
+
 function resolveProxies(req) {
+  var ipAddress = resolveIPv4(req.connection.remoteAddress)
+
   if (req.headers["x-forwarded-for"]) {
-    return `${req.headers["x-forwarded-for"]}, ${req.connection.remoteAddress}`
+    return `${req.headers["x-forwarded-for"]}, ${ipAddress}`
   } else {
-    return req.connection.remoteAddress
+    return ipAddress
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3537,7 +3537,7 @@ ip6@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/ip6/-/ip6-0.0.4.tgz#44c5a9db79e39d405201b4d78d13b3870e48db31"
 
-ip@~1.1.0:
+ip@^1.1.5, ip@~1.1.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
 


### PR DESCRIPTION
Seeing some remote ip addresses set to ipv6 notation in the proxy chain `X-Forwarded-For` headers rather than ipv4. See https://stackoverflow.com/questions/29411551/express-js-req-ip-is-returning-ffff127-0-0-1

Resolve ipv6 to ipv4 notation where appropriate.