### PR TITLE
fix dump-schema.ts

### DIFF
--- a/scripts/dump-schema.ts
+++ b/scripts/dump-schema.ts
@@ -1,7 +1,7 @@
 import fs from "fs"
+import { printSchema } from "graphql/utilities"
 import path from "path"
 import schema from "schema"
-import { printSchema } from "graphql/utilities"
 
 const message =
   "Usage: dump-schema.js /path/to/output/directory or /path/to/filename.graphql"
@@ -13,16 +13,14 @@ if (destination === undefined) {
 }
 
 // Support both passing a folder or a filename
-const folder = path.dirname(destination)
-const filename = path.basename(destination) || "schema.graphql"
-if (!fs.existsSync(folder)) {
-  console.error(message)
-  process.exit(1)
-}
+const schemaPath =
+  fs.existsSync(destination) && fs.statSync(destination).isDirectory()
+    ? path.join(destination, "schema.graphql")
+    : destination
 
 // Save user readable type system shorthand of schema
 fs.writeFileSync(
-  path.join(folder, filename),
+  schemaPath,
   printSchema(schema, { commentDescriptions: true }),
   "utf8"
 )


### PR DESCRIPTION
I tried synching reaction to metaphysics and got this error: 

```
$ babel-node --extensions '.ts,.js' ./scripts/dump-schema.ts ../../data
fs.js:646
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^

Error: EISDIR: illegal operation on a directory, open '../../data'
    at Object.fs.openSync (fs.js:646:18)
    at Object.fs.writeFileSync (fs.js:1299:33)
    at Object.<anonymous> (/Users/davidsheldrick/code/artsy/reaction/externals/metaphysics/scripts/dump-schema.ts:24:4)
...
```

The dump-schema.ts file was recently changed to allow specifying either a folder or a file path, but it seems like the folder path option was no longer working properly.