### PR TITLE
Revert "[package] Update to test agent v0.4"

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "compression": "^1.7.2",
     "cors": "^2.7.1",
     "dataloader": "^1.3.0",
-    "dd-trace": "artsy/dd-trace-js#artsy-with-agent-v0.4-test",
+    "dd-trace": "artsy/dd-trace-js#artsy",
     "debug": "^2.2.0",
     "express": "^4.13.3",
     "express-force-ssl": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2074,9 +2074,9 @@ date-fns@^1.27.2:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
 
-dd-trace@artsy/dd-trace-js#artsy-with-agent-v0.4-test:
+dd-trace@artsy/dd-trace-js#artsy:
   version "0.5.6"
-  resolved "https://codeload.github.com/artsy/dd-trace-js/tar.gz/ae09d248314ee6bce92b14330156d62427d89ea2"
+  resolved "https://codeload.github.com/artsy/dd-trace-js/tar.gz/10a28ad1ee22316c7499dad15d01eff0f73bf534"
   dependencies:
     async-hook-jl "^1.7.6"
     int64-buffer "^0.1.9"


### PR DESCRIPTION
This reverts commit 853c329c1c7b753ea4ca88623e94dcd284e38100.

For when I’m done testing in production.