### PR TITLE
Adds another eigen query

### DIFF
--- a/src/lib/nameOldEigenQueries.ts
+++ b/src/lib/nameOldEigenQueries.ts
@@ -15,6 +15,9 @@ export const nameOldEigenQueries: RequestHandler = (req, _res, next) => {
       } else if (query.includes("totalUnreadCount")) {
         // https://github.com/artsy/eigen/blob/master/Artsy/Networking/conversations.graphql
         req.body.query = `query TotalUnreadCountQuery ${query}`
+      } else if (query.includes("recordArtworkView")) {
+        // https://github.com/artsy/eigen/blob/master/Artsy/Networking/record_artwork_view_mutation.graphql
+        req.body.query = `query RecordArtworkView ${query}`
       } else {
         error(`Unexpected Eigen query: ${query}`)
       }


### PR DESCRIPTION
Been reading the logs, and I found this testing stitching:

```
Thu, 13 Sep 2018 19:04:29 GMT error Unexpected Eigen query: mutation recordArtworkView($artwork_id: String!) {
  recordArtworkView(
    input: { artwork_id: $artwork_id }
  ) {
    artwork_id
  }
}
```