### PR TITLE
Convert 'published' on an artwork to be 'is_published'

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -839,7 +839,7 @@ type Artwork implements Node & Sellable {
   to_s: String
 
   # Whether this Artwork is Published of not
-  published: Boolean!
+  is_published: Boolean!
 
   # If the category is video, then it returns the href for the (youtube/vimeo) video, otherwise returns the website from CMS
   website: String
@@ -1557,7 +1557,7 @@ type ArtworkItem implements Node & Sellable {
   to_s: String
 
   # Whether this Artwork is Published of not
-  published: Boolean!
+  is_published: Boolean!
 
   # If the category is video, then it returns the href for the (youtube/vimeo) video, otherwise returns the website from CMS
   website: String

--- a/src/schema/artwork/index.ts
+++ b/src/schema/artwork/index.ts
@@ -700,9 +700,10 @@ export const artworkFields = () => {
         ]).join(", ")
       },
     },
-    published: {
+    is_published: {
       type: new GraphQLNonNull(GraphQLBoolean),
       description: "Whether this Artwork is Published of not",
+      resolve: ({ published }) => published,
     },
     website: {
       type: GraphQLString,


### PR DESCRIPTION
When I looked through the schema, `published` stood out as not being an `is_` this fixes that. I was the only consumer of the field, so it's fine to break.