### PR TITLE
[tracer] Update to latest version of upstream v0.6.0 branch.

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,6 @@
 # yarn lockfile v1
 
 
-"@airbnb/node-memwatch@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@airbnb/node-memwatch/-/node-memwatch-1.0.2.tgz#a82e311ae27e05df4fb2cf8e4fbc75caaf7190a4"
-  dependencies:
-    bindings "^1.3.0"
-    nan "^2.9.2"
-
 "@artsy/express-reloadable@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@artsy/express-reloadable/-/express-reloadable-1.3.0.tgz#93ba96f42f7c4ae65aa696ed45cc4d663e7ac88b"
@@ -1414,10 +1407,6 @@ binary-extensions@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
 
-bindings@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
-
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
@@ -2049,7 +2038,7 @@ date-fns@^1.27.2:
 
 dd-trace@artsy/dd-trace-js#artsy:
   version "0.6.0"
-  resolved "https://codeload.github.com/artsy/dd-trace-js/tar.gz/31b194b04ad02e90ae82f95b22d340b347fa60fd"
+  resolved "https://codeload.github.com/artsy/dd-trace-js/tar.gz/9945be573c86a5827a00b8e258cdcf88af7a0cbd"
   dependencies:
     async-hook-jl "^1.7.6"
     int64-buffer "^0.1.9"
@@ -2068,9 +2057,7 @@ dd-trace@artsy/dd-trace-js#artsy:
     safe-buffer "^5.1.1"
     semver "^5.5.0"
     shimmer "^1.2.0"
-    url-parse "^1.2.0"
-  optionalDependencies:
-    "@airbnb/node-memwatch" "^1.0.2"
+    url-parse "^1.4.3"
 
 debug@2, debug@2.6.9, debug@^2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
@@ -4950,10 +4937,6 @@ nan@2.x:
 nan@^2.3.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
-
-nan@^2.9.2:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.0.tgz#574e360e4d954ab16966ec102c0c049fd961a099"
 
 nanomatch@^1.2.9:
   version "1.2.9"


### PR DESCRIPTION
https://github.com/DataDog/dd-trace-js/compare/27c00ff3428ae4fa76a61590de9787d5cf37fa6e...9945be573c86a5827a00b8e258cdcf88af7a0cbd