### PR TITLE
Remove un-resovled EditionSet from Order

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -4690,8 +4690,8 @@ type OrderLineItem {
   # Artwork that is being ordered
   artwork: Artwork
 
-  # Edition set on the artwork
-  editionSet: EditionSet
+  # ID of the selected Edition set from the artwork
+  editionSetId: String
 
   # Unit price in cents
   priceCents: Int

--- a/src/schema/ecommerce/types/order_line_item.ts
+++ b/src/schema/ecommerce/types/order_line_item.ts
@@ -1,7 +1,11 @@
-import { GraphQLID, GraphQLInt, GraphQLObjectType } from "graphql"
+import {
+  GraphQLID,
+  GraphQLInt,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
 import { connectionDefinitions } from "graphql-relay"
 import Artwork from "schema/artwork"
-import EditionSet from "schema/edition_set"
 import { OrderFulfillmentConnection } from "./order_fulfillment"
 import { amount } from "schema/fields/money"
 import date from "schema/fields/date"
@@ -23,10 +27,9 @@ export const OrderLineItemType = new GraphQLObjectType({
         { rootValue: { authenticatedArtworkLoader } }
       ) => authenticatedArtworkLoader(artworkId),
     },
-    editionSet: {
-      type: EditionSet.type,
-      description: "Edition set on the artwork",
-      resolve: ({ editionSetId }) => editionSetId,
+    editionSetId: {
+      type: GraphQLString,
+      description: "ID of the selected Edition set from the artwork",
     },
     priceCents: {
       type: GraphQLInt,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "strict": true,
     "target": "es5"
   },
-  "exclude": ["build", "node_modules", "**/node_modules/*"]
+  "exclude": ["build", "node_modules", "**/node_modules/*", "dangerfile.ts"]
 }


### PR DESCRIPTION
# Problem
Some apps where requesting edition set details https://github.com/artsy/volt/pull/3227 by doing 

```graohql
order{
  editionSet{
    id
   }
}
```
Which raises error.

# Cause
We had `editionSet` as a field with type `EditionSet.type` on an `Order` but we were not actually resolving it to an `EditionSet` and we were just returning `editionSetId`.

# Solution
Remove `editionSet` field and just expose `editionSetId`.