### PR TITLE
Removes the newly created resolvers, and fixes the internal schema resolving for exchange 

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -4348,35 +4348,6 @@ type Mutation {
   submitOrder(input: SubmitOrderInput!): SubmitOrderPayload
 
   # Creates an order with an artwork
-  ecommerce_createOrderWithArtwork(
-    input: CreateOrderWithArtworkInput!
-  ): CreateOrderWithArtworkPayload
-
-  # Sets shipping information for an order
-  ecommerce_setOrderShipping(
-    input: SetOrderShippingInput!
-  ): SetOrderShippingPayload
-
-  # Sets payment information on an order
-  ecommerce_setOrderPayment(
-    input: SetOrderPaymentInput!
-  ): SetOrderPaymentPayload
-
-  # Approves an order with payment
-  ecommerce_approveOrder(input: ApproveOrderInput!): ApproveOrderPayload
-
-  # Fulfills an Order with one fulfillment by setting this fulfillment to all line items of this order
-  ecommerce_fulfillOrderAtOnce(
-    input: FulfillOrderAtOnceInput!
-  ): FulfillOrderAtOncePayload
-
-  # Rejects an order
-  ecommerce_rejectOrder(input: RejectOrderInput!): RejectOrderPayload
-
-  # Submits an order
-  ecommerce_submitOrder(input: SubmitOrderInput!): SubmitOrderPayload
-
-  # Creates an order with an artwork
   ecommerceCreateOrderWithArtwork(
     input: CreateOrderWithArtworkInput!
   ): CreateOrderWithArtworkPayload
@@ -5736,19 +5707,6 @@ type Query {
 
   # Returns list of orders
   orders(
-    buyerId: String
-    buyerType: String
-    sellerId: String
-    sellerType: String
-    state: String
-    sort: OrdersSortMethodType
-  ): OrderConnection
-
-  # Returns a single Order
-  ecommerce_order(id: String!): Order
-
-  # Returns list of orders
-  ecommerce_orders(
     buyerId: String
     buyerType: String
     sellerId: String

--- a/src/lib/stitching/exchange/schema.ts
+++ b/src/lib/stitching/exchange/schema.ts
@@ -17,16 +17,18 @@ export const executableExchangeSchema = async () => {
   })
 
   // Return the new modified schema
-  return transformSchema(schema, [
-    // Apply a prefix to all the typenames
-    new RenameTypes(name => {
-      return `Ecommerce${name}`
-    }),
-    // Rename all the root fields to be camelCased
-    new RenameRootFields(
-      (_operation, name) =>
-        `ecommerce${name.charAt(0).toUpperCase() + name.slice(1)}`
-    ),
-  ])
+  return transformSchema(schema, transformsForExchange)
   // Note that changes in this will need to be
 }
+
+export const transformsForExchange = [
+  // Apply a prefix to all the typenames
+  new RenameTypes(name => {
+    return `Ecommerce${name}`
+  }),
+  // Rename all the root fields to be camelCased
+  new RenameRootFields(
+    (_operation, name) =>
+      `ecommerce${name.charAt(0).toUpperCase() + name.slice(1)}`
+  ),
+]

--- a/src/lib/stitching/exchange/schema.ts
+++ b/src/lib/stitching/exchange/schema.ts
@@ -28,4 +28,5 @@ export const executableExchangeSchema = async () => {
         `ecommerce${name.charAt(0).toUpperCase() + name.slice(1)}`
     ),
   ])
+  // Note that changes in this will need to be
 }

--- a/src/schema/ecommerce/approve_order_mutation.ts
+++ b/src/schema/ecommerce/approve_order_mutation.ts
@@ -28,7 +28,7 @@ export const ApproveOrderMutation = mutationWithClientMutationId({
     }
     const mutation = gql`
       mutation approveOrder($orderId: ID!) {
-        ecommerce_approveOrder(input: {
+        ecommerceApproveOrder(input: {
           id: $orderId,
         }) {
           orderOrError {
@@ -81,6 +81,6 @@ export const ApproveOrderMutation = mutationWithClientMutationId({
     `
     return graphql(exchangeSchema, mutation, null, context, {
       orderId,
-    }).then(extractEcommerceResponse("ecommerce_approveOrder"))
+    }).then(extractEcommerceResponse("ecommerceApproveOrder"))
   },
 })

--- a/src/schema/ecommerce/create_order_with_artwork_mutation.ts
+++ b/src/schema/ecommerce/create_order_with_artwork_mutation.ts
@@ -57,7 +57,7 @@ export const CreateOrderWithArtworkMutation = mutationWithClientMutationId({
         $editionSetId: String
         $quantity: Int
       ) {
-        ecommerce_createOrderWithArtwork(
+        ecommerceCreateOrderWithArtwork(
           input: {
             artworkId: $artworkId
             editionSetId: $editionSetId
@@ -117,6 +117,6 @@ export const CreateOrderWithArtworkMutation = mutationWithClientMutationId({
       artworkId,
       editionSetId,
       quantity,
-    }).then(extractEcommerceResponse("ecommerce_createOrderWithArtwork"))
+    }).then(extractEcommerceResponse("ecommerceCreateOrderWithArtwork"))
   },
 })

--- a/src/schema/ecommerce/fulfill_order_at_once_mutation.ts
+++ b/src/schema/ecommerce/fulfill_order_at_once_mutation.ts
@@ -66,7 +66,7 @@ export const FulfillOrderAtOnceMutation = mutationWithClientMutationId({
 
     const mutation = gql`
       mutation fulfillOrderAtOnce($orderId: ID!, $fulfillment: EcommerceFulfillmentAttributes!) {
-        ecommerce_fulfillAtOnce(input: {
+        ecommerceFulfillAtOnce(input: {
           id: $orderId,
           fulfillment: $fulfillment
         }) {
@@ -131,6 +131,6 @@ export const FulfillOrderAtOnceMutation = mutationWithClientMutationId({
     return graphql(exchangeSchema, mutation, null, context, {
       orderId,
       fulfillment,
-    }).then(extractEcommerceResponse("ecommerce_fulfillAtOnce"))
+    }).then(extractEcommerceResponse("ecommerceFulfillAtOnce"))
   },
 })

--- a/src/schema/ecommerce/order.js
+++ b/src/schema/ecommerce/order.js
@@ -15,7 +15,7 @@ export const Order = {
   resolve: (_parent, { id }, context, { rootValue: { exchangeSchema } }) => {
     const query = gql`
       query EcommerceOrder($id: ID!) {
-        ecommerce_order(id: $id) {
+        ecommerceOrder(id: $id) {
           id
           code
           currencyCode
@@ -63,6 +63,6 @@ export const Order = {
     `
     return graphql(exchangeSchema, query, null, context, {
       id,
-    }).then(extractEcommerceResponse("ecommerce_order"))
+    }).then(extractEcommerceResponse("ecommerceOrder"))
   },
 }

--- a/src/schema/ecommerce/orders.js
+++ b/src/schema/ecommerce/orders.js
@@ -36,7 +36,7 @@ export const Orders = {
         $state: EcommerceOrderStateEnum
         $sort: EcommerceOrderConnectionSortEnum
       ) {
-        ecommerce_orders(
+        ecommerceOrders(
           buyerId: $buyerId
           buyerType: $buyerType
           sellerId: $sellerId
@@ -92,6 +92,6 @@ export const Orders = {
       sellerType,
       state,
       sort,
-    }).then(extractEcommerceResponse("ecommerce_orders"))
+    }).then(extractEcommerceResponse("ecommerceOrders"))
   },
 }

--- a/src/schema/ecommerce/reject_order_mutation.ts
+++ b/src/schema/ecommerce/reject_order_mutation.ts
@@ -29,7 +29,7 @@ export const RejectOrderMutation = mutationWithClientMutationId({
 
     const mutation = gql`
       mutation rejectOrder($orderId: ID!) {
-        ecommerce_rejectOrder(input: {
+        ecommerceRejectOrder(input: {
           id: $orderId,
         }) {
           orderOrError {
@@ -83,6 +83,6 @@ export const RejectOrderMutation = mutationWithClientMutationId({
     return graphql(exchangeSchema, mutation, null, context, {
       orderId,
       creditCardId,
-    }).then(extractEcommerceResponse("ecommerce_rejectOrder"))
+    }).then(extractEcommerceResponse("ecommerceRejectOrder"))
   },
 })

--- a/src/schema/ecommerce/set_order_payment_mutation.ts
+++ b/src/schema/ecommerce/set_order_payment_mutation.ts
@@ -46,7 +46,7 @@ export const SetOrderPaymentMutation = mutationWithClientMutationId({
     }
     const mutation = gql`
       mutation setOrderPayment($orderId: ID!, $creditCardId: String!) {
-        ecommerce_setPayment(input: {
+        ecommerceSetPayment(input: {
           id: $orderId,
           creditCardId: $creditCardId,
         }) {
@@ -101,6 +101,6 @@ export const SetOrderPaymentMutation = mutationWithClientMutationId({
     return graphql(exchangeSchema, mutation, null, context, {
       orderId,
       creditCardId,
-    }).then(extractEcommerceResponse("ecommerce_setPayment"))
+    }).then(extractEcommerceResponse("ecommerceSetPayment"))
   },
 })

--- a/src/schema/ecommerce/set_order_shipping_mutation.ts
+++ b/src/schema/ecommerce/set_order_shipping_mutation.ts
@@ -95,7 +95,7 @@ export const SetOrderShippingMutation = mutationWithClientMutationId({
         $fulfillmentType: EcommerceOrderFulfillmentTypeEnum!
         $shipping: EcommerceShippingAttributes
       ) {
-        ecommerce_setShipping(
+        ecommerceSetShipping(
           input: {
             id: $orderId
             fulfillmentType: $fulfillmentType
@@ -154,6 +154,6 @@ export const SetOrderShippingMutation = mutationWithClientMutationId({
       orderId,
       fulfillmentType,
       shipping,
-    }).then(extractEcommerceResponse("ecommerce_setShipping"))
+    }).then(extractEcommerceResponse("ecommerceSetShipping"))
   },
 })

--- a/src/schema/ecommerce/submit_order_mutation.ts
+++ b/src/schema/ecommerce/submit_order_mutation.ts
@@ -43,7 +43,7 @@ export const SubmitOrderMutation = mutationWithClientMutationId({
 
     const mutation = gql`
       mutation submitOrder($orderId: ID!) {
-        ecommerce_submitOrder(input: {
+        ecommerceSubmitOrder(input: {
           id: $orderId
         }) {
           orderOrError {
@@ -97,6 +97,6 @@ export const SubmitOrderMutation = mutationWithClientMutationId({
     return graphql(exchangeSchema, mutation, null, context, {
       orderId,
       creditCardId,
-    }).then(extractEcommerceResponse("ecommerce_submitOrder"))
+    }).then(extractEcommerceResponse("ecommerceSubmitOrder"))
   },
 })

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -170,10 +170,6 @@ if (!ENABLE_ECOMMERCE_STITCHING) {
   stitchedRootFields.order = Order
   stitchedRootFields.orders = Orders
 
-  // Also deprecated
-  stitchedRootFields.ecommerce_order = Order
-  stitchedRootFields.ecommerce_orders = Orders
-
   stitchedRootFields.ecommerceOrder = Order
   stitchedRootFields.ecommerceOrders = Orders
 
@@ -185,15 +181,6 @@ if (!ENABLE_ECOMMERCE_STITCHING) {
   stitchedMutations.fulfillOrderAtOnce = FulfillOrderAtOnceMutation
   stitchedMutations.rejectOrder = RejectOrderMutation
   stitchedMutations.submitOrder = SubmitOrderMutation
-
-  // Also deprecated
-  stitchedMutations.ecommerce_createOrderWithArtwork = CreateOrderWithArtworkMutation
-  stitchedMutations.ecommerce_setOrderShipping = SetOrderShippingMutation
-  stitchedMutations.ecommerce_setOrderPayment = SetOrderPaymentMutation
-  stitchedMutations.ecommerce_approveOrder = ApproveOrderMutation
-  stitchedMutations.ecommerce_fulfillOrderAtOnce = FulfillOrderAtOnceMutation
-  stitchedMutations.ecommerce_rejectOrder = RejectOrderMutation
-  stitchedMutations.ecommerce_submitOrder = SubmitOrderMutation
 
   stitchedMutations.ecommerceCreateOrderWithArtwork = CreateOrderWithArtworkMutation
   stitchedMutations.ecommerceSetOrderShipping = SetOrderShippingMutation

--- a/src/test/fixtures/exchange/mockxchange.js
+++ b/src/test/fixtures/exchange/mockxchange.js
@@ -6,6 +6,7 @@ import {
 } from "graphql-tools"
 import fs from "fs"
 import path from "path"
+import { transformsForExchange } from "lib/stitching/exchange/schema"
 
 export const mockxchange = resolvers => {
   const typeDefs = fs.readFileSync(
@@ -48,15 +49,7 @@ export const mockxchange = resolvers => {
   })
 
   // namespace schema similar to src/lib/stitching/exchange/schema.ts
-  const exchangeSchema = transformSchema(schema, [
-    new RenameTypes(name => {
-      return `Ecommerce${name}`
-    }),
-    new RenameRootFields(
-      (_operation, name) =>
-        `ecommerce${name.charAt(0).toUpperCase() + name.slice(1)}`
-    ),
-  ])
+  const exchangeSchema = transformSchema(schema, transformsForExchange)
 
   const partnerLoader = sinon.stub().returns(
     Promise.resolve({

--- a/src/test/fixtures/exchange/mockxchange.js
+++ b/src/test/fixtures/exchange/mockxchange.js
@@ -52,7 +52,10 @@ export const mockxchange = resolvers => {
     new RenameTypes(name => {
       return `Ecommerce${name}`
     }),
-    new RenameRootFields((_operation, name) => `ecommerce_${name}`),
+    new RenameRootFields(
+      (_operation, name) =>
+        `ecommerce${name.charAt(0).toUpperCase() + name.slice(1)}`
+    ),
   ])
 
   const partnerLoader = sinon.stub().returns(


### PR DESCRIPTION
OK, so this one *really* fixes the issues we were seeing. What happened is:

- Adding #1279 changed the exchange schema manipulations for fields
- This broke the *internal* graphql resolving for exchange
- I thought it broke the external resolving (thus #1289 which this reverts)

Now the internal schema (and its test fixtures) are always in sync.