### PR TITLE
[rateLimiter] Use request ID to (naively) recognize legit clients.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build:remote-schemas": "cp src/data/*.graphql build/src/data/",
     "precommit": "lint-staged; yarn dump-schema _schema.graphql",
     "prepare": "patch-package",
-    "prettier-project": "prettier --write '**/*.js'",
+    "prettier-project": "prettier --write 'src/**/*.{js,ts,tsx}'",
     "type-check": "tsc --noEmit --pretty"
   },
   "author": "Art.sy Inc",

--- a/src/lib/__tests__/rateLimiter.test.ts
+++ b/src/lib/__tests__/rateLimiter.test.ts
@@ -2,7 +2,7 @@ import { skip } from "../rateLimiter"
 import { Request } from "express"
 
 describe("rateLimiter", () => {
-  describe("concerning x-forwarded-for", () => {
+  describe("concerning x-request-id", () => {
     it("does not skip a request if the header doesn’t exist", () => {
       const req: Partial<Request> = {
         headers: {},
@@ -11,17 +11,9 @@ describe("rateLimiter", () => {
       expect(skip(req as Request)).toBeFalsy
     })
 
-    it("does not skip a request if it originated from a single host", () => {
+    it("skips a request if it has the header", () => {
       const req: Partial<Request> = {
-        headers: { "x-forwarded-for": "4.4.4.4" },
-        body: {},
-      }
-      expect(skip(req as Request)).toBeFalsy
-    })
-
-    it("skips a request if it originated from at least 2 hosts, one of which presumably is a front-end service of ours", () => {
-      const req: Partial<Request> = {
-        headers: { "x-forwarded-for": "4.4.4.4,8.8.8.8" },
+        headers: { "x-request-id": "abcde-fghij-klmno-pqrst-uvwxy" },
         body: {},
       }
       expect(skip(req as Request)).toBeTruthy

--- a/src/lib/rateLimiter.ts
+++ b/src/lib/rateLimiter.ts
@@ -5,9 +5,11 @@ import { Request } from "express"
 import config from "../config"
 
 export const skip = (req: Request) =>
-  req.headers["x-request-id"] ||
-  (req.body.query &&
-    !req.body.query.includes("routes_OverviewQueryRendererQuery"))
+  !!(
+    req.headers["x-request-id"] ||
+    (req.body.query &&
+      !req.body.query.includes("routes_OverviewQueryRendererQuery"))
+  )
 
 export const rateLimiter = new RateLimit({
   max: config.RATE_LIMIT_MAX,

--- a/src/lib/rateLimiter.ts
+++ b/src/lib/rateLimiter.ts
@@ -5,8 +5,7 @@ import { Request } from "express"
 import config from "../config"
 
 export const skip = (req: Request) =>
-  (req.headers["x-forwarded-for"] &&
-    (req.headers["x-forwarded-for"] as string).split(",").length > 1) ||
+  req.headers["x-request-id"] ||
   (req.body.query &&
     !req.body.query.includes("routes_OverviewQueryRendererQuery"))
 


### PR DESCRIPTION
Turns out that Force does not add its own IP to the `x-forwarded-for` list (@izakp is this correct?) so we can’t detect legit clients based on that. Instead just detect if the `x-request-id` header exists.