### PR TITLE
[rateLimiter] Trust clients based on having set a DataDog header.

### DIFF
--- a/src/lib/__tests__/rateLimiter.test.ts
+++ b/src/lib/__tests__/rateLimiter.test.ts
@@ -8,15 +8,15 @@ describe("rateLimiter", () => {
         headers: {},
         body: {},
       }
-      expect(skip(req as Request)).toBeFalsy
+      expect(skip(req as Request)).toBeFalsy()
     })
 
     it("skips a request if it has the header", () => {
       const req: Partial<Request> = {
-        headers: { "x-request-id": "abcde-fghij-klmno-pqrst-uvwxy" },
+        headers: { "x-datadog-trace-id": "abcde-fghij-klmno-pqrst-uvwxy" },
         body: {},
       }
-      expect(skip(req as Request)).toBeTruthy
+      expect(skip(req as Request)).toBeTruthy()
     })
   })
 
@@ -26,7 +26,7 @@ describe("rateLimiter", () => {
         headers: {},
         body: {},
       }
-      expect(skip(req as Request)).toBeFalsy
+      expect(skip(req as Request)).toBeFalsy()
     })
 
     it("does not skip a request if it includes the artist page query", () => {
@@ -34,7 +34,7 @@ describe("rateLimiter", () => {
         headers: {},
         body: { query: "query routes_OverviewQueryRendererQuery {}" },
       }
-      expect(skip(req as Request)).toBeFalsy
+      expect(skip(req as Request)).toBeFalsy()
     })
 
     it("skips a request if it does not include the artist page query", () => {
@@ -42,7 +42,7 @@ describe("rateLimiter", () => {
         headers: {},
         body: { query: "query anotherQuery {}" },
       }
-      expect(skip(req as Request)).toBeTruthy
+      expect(skip(req as Request)).toBeTruthy()
     })
   })
 })

--- a/src/lib/rateLimiter.ts
+++ b/src/lib/rateLimiter.ts
@@ -4,9 +4,10 @@ import { client } from "./cache"
 import { Request } from "express"
 import config from "../config"
 
+// We expect our own services to include DataDog headers.
 export const skip = (req: Request) =>
   !!(
-    req.headers["x-request-id"] ||
+    req.headers["x-datadog-trace-id"] ||
     (req.body.query &&
       !req.body.query.includes("routes_OverviewQueryRendererQuery"))
   )


### PR DESCRIPTION
Because the DD libs already patch all outgoing HTTP requests to include
this, meaning we don’t need to go through all our code to find the
places where we make requests and update each of those.

Additionally we shouldn’t rely on these types of headers at all in the
long run, so using this for pragmatic reasons seems fine.