### PR TITLE
Make credit card billing address fields nullable

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -2408,22 +2408,22 @@ type CreditCard {
   expiration_year: Int!
 
   # Billing address street1
-  street1: String!
+  street1: String
 
   # Billing address street2
   street2: String
 
   # Billing address city
-  city: String!
+  city: String
 
   # Billing address state
-  state: String!
+  state: String
 
   # Billing address country code
-  country: String!
+  country: String
 
   # Billing address postal code
-  postal_code: String!
+  postal_code: String
 }
 
 # A connection to a list of items.

--- a/src/schema/credit_card.js
+++ b/src/schema/credit_card.js
@@ -62,7 +62,7 @@ const CreditCardType = new GraphQLObjectType({
       description: "Credit card's expiration year",
     },
     street1: {
-      type: GraphQLNonNull(GraphQLString),
+      type: GraphQLString,
       description: "Billing address street1",
     },
     street2: {
@@ -70,19 +70,19 @@ const CreditCardType = new GraphQLObjectType({
       description: "Billing address street2",
     },
     city: {
-      type: GraphQLNonNull(GraphQLString),
+      type: GraphQLString,
       description: "Billing address city",
     },
     state: {
-      type: GraphQLNonNull(GraphQLString),
+      type: GraphQLString,
       description: "Billing address state",
     },
     country: {
-      type: GraphQLNonNull(GraphQLString), // TODO: We may make this type more strict by throwing ISO "ALPHA-2 Codes
+      type: GraphQLString, // TODO: We may make this type more strict by throwing ISO "ALPHA-2 Codes
       description: "Billing address country code",
     },
     postal_code: {
-      type: GraphQLNonNull(GraphQLString),
+      type: GraphQLString,
       description: "Billing address postal code",
     },
   }),


### PR DESCRIPTION
A lot of credit cards in Gravity do not have these fields filled in and marking them as NonNull would make it impossible to query.