### PR TITLE
Add creditCardId to response coming back from Exchange

### DIFF
--- a/src/schema/__tests__/ecommerce/set_order_payment_mutation.test.ts
+++ b/src/schema/__tests__/ecommerce/set_order_payment_mutation.test.ts
@@ -47,7 +47,7 @@ describe("Approve Order Mutation", () => {
 
     return runQuery(mutation, rootValue).then(data => {
       expect(data!.setOrderPayment.orderOrError.order).toEqual(
-        sampleOrder(true, false)
+        sampleOrder(true, false, true)
       )
     })
   })

--- a/src/schema/ecommerce/set_order_payment_mutation.ts
+++ b/src/schema/ecommerce/set_order_payment_mutation.ts
@@ -54,26 +54,27 @@ export const SetOrderPaymentMutation = mutationWithClientMutationId({
             __typename
             ... on EcommerceOrderWithMutationSuccess {
               order {
-              id
-                code
-                currencyCode
-                state
+                id
                 ${BuyerSellerFields}
                 ${RequestedFulfillmentFragment}
-                itemsTotalCents
-                shippingTotalCents
-                taxTotalCents
-                commissionFeeCents
-                transactionFeeCents
                 buyerPhoneNumber
                 buyerTotalCents
-                sellerTotalCents
-                updatedAt
+                code
+                commissionFeeCents
                 createdAt
-                stateUpdatedAt
-                stateExpiresAt
+                creditCardId
+                currencyCode
+                itemsTotalCents
                 lastApprovedAt
                 lastSubmittedAt
+                sellerTotalCents
+                shippingTotalCents
+                state
+                stateExpiresAt
+                stateUpdatedAt
+                taxTotalCents
+                transactionFeeCents
+                updatedAt
                 lineItems{
                   edges{
                     node{


### PR DESCRIPTION
# Problem
When getting `creditCard` info back after `setOrderPayment` mutation, we were getting `null` even when credit card was set properly on the order.

# Cause
We were missing getting `creditCardId` from the Exchange's response coming back.

# Solution
Well... add it!