### PR TITLE
Update money helper to return $0.00 if cents field is 0

### DIFF
--- a/src/schema/__tests__/ecommerce/order.test.ts
+++ b/src/schema/__tests__/ecommerce/order.test.ts
@@ -10,12 +10,10 @@ import { OrderSellerFields } from "./order_fields"
 let rootValue
 
 describe("Order query", () => {
-  beforeEach(() => {
-    const resolvers = { Query: { order: () => exchangeOrderJSON } }
-
-    rootValue = mockxchange(resolvers)
-  })
   it("fetches order by id", () => {
+    const resolvers = { Query: { order: () => exchangeOrderJSON } }
+    rootValue = mockxchange(resolvers)
+
     const query = gql`
       {
         order(id: "52dd3c2e4b8480091700027f") {
@@ -26,6 +24,80 @@ describe("Order query", () => {
 
     return runQuery(query, rootValue).then(data => {
       expect(data!.order).toEqual(sampleOrder(true, true, true))
+    })
+  })
+
+  it("handles orders with 0 shipping and tax", () => {
+    const testOrder = {
+      id: "foo123",
+      code: "foofoo",
+      shippingTotalCents: 0,
+      taxTotalCents: 0,
+      itemsTotalCents: 12000,
+      currencyCode: "$",
+      state: "PENDING",
+      seller: { id: "111", __typename: "Partner" },
+      buyer: { id: "111", __typename: "User" },
+      updatedAt: "2018-07-03 17:57:47 UTC",
+      createdAt: "2018-07-03 17:57:47 UTC",
+    }
+    const resolvers = {
+      Query: {
+        order: () => testOrder,
+      },
+    }
+    rootValue = mockxchange(resolvers)
+
+    const query = gql`
+      {
+        order(id: "52dd3c2e4b8480091700027f") {
+          id
+          shippingTotal(precision: 2)
+          taxTotal(precision: 2)
+        }
+      }
+    `
+    return runQuery(query, rootValue).then(data => {
+      expect(data!.order).toEqual({
+        id: "foo123",
+        shippingTotal: "$0.00",
+        taxTotal: "$0.00",
+      })
+    })
+  })
+
+  it("handles orders with null shipping and tax", () => {
+    const testOrder = {
+      id: "foo123",
+      code: "foofoo",
+      shippingTotalCents: null,
+      taxTotalCents: null,
+      itemsTotalCents: 12000,
+      currencyCode: "$",
+      state: "PENDING",
+      seller: { id: "111", __typename: "Partner" },
+      buyer: { id: "111", __typename: "User" },
+      updatedAt: "2018-07-03 17:57:47 UTC",
+      createdAt: "2018-07-03 17:57:47 UTC",
+    }
+    const resolvers = { Query: { order: () => testOrder } }
+    rootValue = mockxchange(resolvers)
+
+    const query = gql`
+      {
+        order(id: "52dd3c2e4b8480091700027f") {
+          id
+          shippingTotal(precision: 2)
+          taxTotal(precision: 2)
+        }
+      }
+    `
+    return runQuery(query, rootValue).then(data => {
+      expect(data!.order).toEqual({
+        id: "foo123",
+        shippingTotal: null,
+        taxTotal: null,
+      })
     })
   })
 })

--- a/src/schema/fields/money.js
+++ b/src/schema/fields/money.js
@@ -35,7 +35,7 @@ export const amount = resolve => ({
   },
   resolve: (obj, options) => {
     const cents = resolve(obj)
-    if (!cents) return null
+    if (!cents && cents !== 0) return null
     const symbol = options.symbol || obj.symbol
     return formatMoney(
       cents / 100,


### PR DESCRIPTION
This makes a change across-the-board for the `amount` helper, but I think it's the right one.

Since `0` is falsey in javascript, we're currently returning `null` when you request the amount if the cents field is `0`. This updates to return `$0` in the case where you have `0` cents, not `null`.