### PR TITLE
Use artwork version when resolving orders

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -5081,7 +5081,6 @@ type OrderLineItem {
 
   # Artwork that is being ordered
   artwork: Artwork
-    @deprecated(reason: "Prefer artworkVersion or your data can be out of date")
 
   # Artwork version that is being ordered
   artworkVersion: ArtworkVersion

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1644,6 +1644,26 @@ enum ArtworkSorts {
   TITLE_DESC
 }
 
+type ArtworkVersion {
+  # ID of the order line item
+  id: ID!
+
+  # Artwork title
+  title: String
+
+  # The Image id
+  defaultImageID: String
+
+  # The artists related to this Artwork Version
+  artists: String
+
+  # The names for the artists related to this Artwork Version
+  artistNames: String
+
+  # The image representing the Artwork Version
+  image: Image
+}
+
 # An asset which is assigned to a consignment submission
 type Asset {
   # Convection asset ID.
@@ -5061,6 +5081,10 @@ type OrderLineItem {
 
   # Artwork that is being ordered
   artwork: Artwork
+    @deprecated(reason: "Prefer artworkVersion or your data can be out of date")
+
+  # Artwork version that is being ordered
+  artworkVersion: ArtworkVersion
 
   # ID of the selected Edition set from the artwork
   editionSetId: String

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -12,6 +12,9 @@ export default (accessToken, userID, opts) => {
 
   return {
     authenticatedArtworkLoader: gravityLoader(id => `artwork/${id}`),
+    authenticatedArtworkVersionLoader: gravityLoader(
+      id => `artwork_version/${id}`
+    ),
     collectionLoader: gravityLoader(id => `collection/${id}`, {
       user_id: userID,
     }),

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -10,6 +10,9 @@ export default opts => {
 
   return {
     artworksLoader: gravityLoader("artworks"),
+    artworkImageLoader: gravityLoader(
+      ({ artwork_id, image_id }) => `artwork/${artwork_id}/image/${image_id}`
+    ),
     artistArtworksLoader: gravityLoader(id => `artist/${id}/artworks`),
     artistGenesLoader: gravityLoader(({ id }) => `artist/${id}/genome/genes`),
     artistLoader: gravityLoader(id => `artist/${id}`),

--- a/src/schema/artwork_version.ts
+++ b/src/schema/artwork_version.ts
@@ -1,0 +1,69 @@
+import {
+  GraphQLID,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLNonNull,
+} from "graphql"
+import { artistNames } from "./artwork/meta.js"
+import Image from "./image"
+
+export const ArtworkVersion = new GraphQLObjectType({
+  name: "ArtworkVersion",
+  fields: () => ({
+    id: {
+      type: new GraphQLNonNull(GraphQLID),
+      description: "ID of the order line item",
+    },
+
+    title: {
+      type: GraphQLString,
+      description: "Artwork title",
+    },
+
+    defaultImageID: {
+      type: GraphQLString,
+      description: "The Image id",
+      resolve: ({ default_image_id }) => default_image_id,
+    },
+
+    artists: {
+      type: GraphQLString,
+      description: "The artists related to this Artwork Version",
+      resolve: (
+        version,
+        _options,
+        _request,
+        { rootValue: { artistsLoader } }
+      ) => artistsLoader({ id: version.artist_ids }),
+    },
+
+    artistNames: {
+      type: GraphQLString,
+      description: "The names for the artists related to this Artwork Version",
+      resolve: async (
+        version,
+        _options,
+        _request,
+        { rootValue: { artistsLoader } }
+      ) => {
+        const artists = await artistsLoader({ id: version.artist_ids })
+        return artistNames(artists)
+      },
+    },
+
+    image: {
+      type: Image.type,
+      description: "The image representing the Artwork Version",
+      resolve: (
+        version,
+        _options,
+        _request,
+        { rootValue: { artworkImageLoader } }
+      ) =>
+        artworkImageLoader({
+          artwork_id: version.artwork_id,
+          image_id: version.default_image_id,
+        }),
+    },
+  }),
+})

--- a/src/schema/ecommerce/types/order_line_item.ts
+++ b/src/schema/ecommerce/types/order_line_item.ts
@@ -9,6 +9,7 @@ import Artwork from "schema/artwork"
 import { OrderFulfillmentConnection } from "./order_fulfillment"
 import { amount } from "schema/fields/money"
 import date from "schema/fields/date"
+import { ArtworkVersion } from "../../artwork_version"
 
 export const OrderLineItemType = new GraphQLObjectType({
   name: "OrderLineItem",
@@ -20,6 +21,19 @@ export const OrderLineItemType = new GraphQLObjectType({
     artwork: {
       type: Artwork.type,
       description: "Artwork that is being ordered",
+      deprecationReason:
+        "Prefer artworkVersion or your data can be out of date",
+      resolve: (
+        { artworkId },
+        _args,
+        _context,
+        { rootValue: { authenticatedArtworkLoader } }
+      ) => authenticatedArtworkLoader(artworkId),
+    },
+    artworkVersion: {
+      type: ArtworkVersion,
+      description: "Artwork version that is being ordered",
+
       resolve: (
         { artworkVersionId },
         _args,

--- a/src/schema/ecommerce/types/order_line_item.ts
+++ b/src/schema/ecommerce/types/order_line_item.ts
@@ -21,11 +21,11 @@ export const OrderLineItemType = new GraphQLObjectType({
       type: Artwork.type,
       description: "Artwork that is being ordered",
       resolve: (
-        { artworkId },
+        { artworkVersionId },
         _args,
         _context,
-        { rootValue: { authenticatedArtworkLoader } }
-      ) => authenticatedArtworkLoader(artworkId),
+        { rootValue: { authenticatedArtworkVersionLoader } }
+      ) => authenticatedArtworkVersionLoader(artworkVersionId),
     },
     editionSetId: {
       type: GraphQLString,

--- a/src/schema/ecommerce/types/order_line_item.ts
+++ b/src/schema/ecommerce/types/order_line_item.ts
@@ -21,8 +21,6 @@ export const OrderLineItemType = new GraphQLObjectType({
     artwork: {
       type: Artwork.type,
       description: "Artwork that is being ordered",
-      deprecationReason:
-        "Prefer artworkVersion or your data can be out of date",
       resolve: (
         { artworkId },
         _args,


### PR DESCRIPTION
I'm working on this ticket:

https://artsyproduct.atlassian.net/browse/SELL-1031

And had a convo with @ashkan18 on Slack here:

https://artsy.slack.com/archives/CB110C6LE/p1539269193000100

What I'm attempting to do with this PR is have orders resolve their artwork using the particular version of the artwork at the time of the sale. This should ensure that any mutations on the artwork won't cause the order detail page in CMS to blow up.

I have no idea if I have done this correctly, so looking for direction, but this seemed like all I had to do!