### PR TITLE
Dumping a schema first applies the example env vars, then your own

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged; yarn dump-schema _schema.graphql"
+      "pre-commit": "lint-staged; yarn dump-schema _schema.graphql; git add _schema.graphql"
     }
   }
 }

--- a/scripts/dump-schema.ts
+++ b/scripts/dump-schema.ts
@@ -1,3 +1,11 @@
+// This means that  the .env.example is first applied (setting defaults)
+// then your .env is applied (it's set up in the schema files)
+// ensuring consistency across dev's machines
+//
+require("dotenv").config({
+  path: require("path").join(process.cwd(), ".env.example"),
+})
+
 import fs from "fs"
 import { printSchema } from "graphql/utilities"
 import path from "path"


### PR DESCRIPTION
This means the defaults are always set for schema dumping.