### PR TITLE
Add commissionRate to EcommerceOrder

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -4718,6 +4718,12 @@ type Order {
     thousand: String = ","
   ): String
 
+  # Partner commission rate used to calculate commission fee
+  commissionRate: Float
+
+  # Partner commission rate formatted into percentage
+  displayCommissionRate: String
+
   # Buyer total in cents
   buyerTotalCents: Int
 

--- a/src/data/exchange.graphql
+++ b/src/data/exchange.graphql
@@ -132,6 +132,7 @@ type FulfillmentEdge {
 # A Line Item
 type LineItem {
   artworkId: String!
+  commissionFeeCents: Int
   createdAt: DateTime!
   editionSetId: String
   fulfillments(
@@ -196,9 +197,11 @@ type Order {
   buyerTotalCents: Int
   code: String!
   commissionFeeCents: Int
+  commissionRate: Float
   createdAt: DateTime!
   creditCardId: String
   currencyCode: String!
+  displayCommissionRate: String
   id: ID!
   itemsTotalCents: Int!
   lastApprovedAt: DateTime
@@ -296,6 +299,9 @@ enum OrderStateEnum {
   # order is still pending submission by buyer
   PENDING
 
+  # order is refunded after being approved or fulfilled
+  REFUNDED
+
   # order is submitted by buyer
   SUBMITTED
 }
@@ -327,6 +333,7 @@ type PageInfo {
 
 type Partner {
   id: String!
+  type: String!
 }
 
 type Pickup {

--- a/src/lib/stitching/exchange/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/exchange/__tests__/__snapshots__/schema.test.ts.snap
@@ -133,6 +133,7 @@ type EcommerceFulfillmentEdge {
 # A Line Item
 type EcommerceLineItem {
   artworkId: String!
+  commissionFeeCents: Int
   createdAt: EcommerceDateTime!
   editionSetId: String
   fulfillments(
@@ -182,9 +183,11 @@ type EcommerceOrder {
   buyerTotalCents: Int
   code: String!
   commissionFeeCents: Int
+  commissionRate: Float
   createdAt: EcommerceDateTime!
   creditCardId: String
   currencyCode: String!
+  displayCommissionRate: String
   id: ID!
   itemsTotalCents: Int!
   lastApprovedAt: EcommerceDateTime
@@ -282,6 +285,9 @@ enum EcommerceOrderStateEnum {
   # order is still pending submission by buyer
   PENDING
 
+  # order is refunded after being approved or fulfilled
+  REFUNDED
+
   # order is submitted by buyer
   SUBMITTED
 }
@@ -313,6 +319,7 @@ type EcommercePageInfo {
 
 type EcommercePartner {
   id: String!
+  type: String!
 }
 
 type EcommercePickup {

--- a/src/schema/ecommerce/approve_order_mutation.ts
+++ b/src/schema/ecommerce/approve_order_mutation.ts
@@ -47,6 +47,8 @@ export const ApproveOrderMutation = mutationWithClientMutationId({
                 shippingTotalCents
                 taxTotalCents
                 commissionFeeCents
+                commissionRate
+                displayCommissionRate
                 transactionFeeCents
                 buyerTotalCents
                 sellerTotalCents

--- a/src/schema/ecommerce/confirm_pickup_mutation.ts
+++ b/src/schema/ecommerce/confirm_pickup_mutation.ts
@@ -47,6 +47,8 @@ export const ConfirmPickupMutation = mutationWithClientMutationId({
                 shippingTotalCents
                 taxTotalCents
                 commissionFeeCents
+                commissionRate
+                displayCommissionRate
                 transactionFeeCents
                 buyerTotalCents
                 sellerTotalCents

--- a/src/schema/ecommerce/create_order_with_artwork_mutation.ts
+++ b/src/schema/ecommerce/create_order_with_artwork_mutation.ts
@@ -73,6 +73,8 @@ export const CreateOrderWithArtworkMutation = mutationWithClientMutationId({
                 buyerPhoneNumber
                 code
                 commissionFeeCents
+                commissionRate
+                displayCommissionRate
                 createdAt
                 currencyCode
                 itemsTotalCents

--- a/src/schema/ecommerce/fulfill_order_at_once_mutation.ts
+++ b/src/schema/ecommerce/fulfill_order_at_once_mutation.ts
@@ -85,6 +85,8 @@ export const FulfillOrderAtOnceMutation = mutationWithClientMutationId({
                 shippingTotalCents
                 taxTotalCents
                 commissionFeeCents
+                commissionRate
+                displayCommissionRate
                 transactionFeeCents
                 buyerPhoneNumber
                 buyerTotalCents

--- a/src/schema/ecommerce/order.ts
+++ b/src/schema/ecommerce/order.ts
@@ -38,6 +38,8 @@ export const Order = {
           stateExpiresAt
           lastApprovedAt
           lastSubmittedAt
+          commissionRate
+          displayCommissionRate
           lineItems{
             edges{
               node{

--- a/src/schema/ecommerce/orders.ts
+++ b/src/schema/ecommerce/orders.ts
@@ -70,6 +70,8 @@ export const Orders = {
               shippingTotalCents
               taxTotalCents
               commissionFeeCents
+              commissionRate
+              displayCommissionRate
               transactionFeeCents
               buyerPhoneNumber
               buyerTotalCents

--- a/src/schema/ecommerce/reject_order_mutation.ts
+++ b/src/schema/ecommerce/reject_order_mutation.ts
@@ -47,6 +47,8 @@ export const RejectOrderMutation = mutationWithClientMutationId({
                 shippingTotalCents
                 taxTotalCents
                 commissionFeeCents
+                commissionRate
+                displayCommissionRate
                 transactionFeeCents
                 buyerPhoneNumber
                 buyerTotalCents

--- a/src/schema/ecommerce/set_order_payment_mutation.ts
+++ b/src/schema/ecommerce/set_order_payment_mutation.ts
@@ -61,6 +61,8 @@ export const SetOrderPaymentMutation = mutationWithClientMutationId({
                 buyerTotalCents
                 code
                 commissionFeeCents
+                commissionRate
+                displayCommissionRate
                 createdAt
                 creditCardId
                 currencyCode

--- a/src/schema/ecommerce/set_order_shipping_mutation.ts
+++ b/src/schema/ecommerce/set_order_shipping_mutation.ts
@@ -117,6 +117,8 @@ export const SetOrderShippingMutation = mutationWithClientMutationId({
                 shippingTotalCents
                 taxTotalCents
                 commissionFeeCents
+                commissionRate
+                displayCommissionRate
                 transactionFeeCents
                 buyerTotalCents
                 sellerTotalCents

--- a/src/schema/ecommerce/submit_order_mutation.ts
+++ b/src/schema/ecommerce/submit_order_mutation.ts
@@ -60,6 +60,8 @@ export const SubmitOrderMutation = mutationWithClientMutationId({
                 shippingTotalCents
                 taxTotalCents
                 commissionFeeCents
+                commissionRate
+                displayCommissionRate
                 transactionFeeCents
                 buyerPhoneNumber
                 buyerTotalCents

--- a/src/schema/ecommerce/types/order.ts
+++ b/src/schema/ecommerce/types/order.ts
@@ -3,6 +3,7 @@ import {
   GraphQLObjectType,
   GraphQLString,
   GraphQLInt,
+  GraphQLFloat,
 } from "graphql"
 import { connectionDefinitions } from "graphql-relay"
 
@@ -65,6 +66,14 @@ export const OrderType = new GraphQLObjectType({
       description: "Commission fee in cents",
     },
     commissionFee: amount(({ commissionFeeCents }) => commissionFeeCents),
+    commissionRate: {
+      type: GraphQLFloat,
+      description: "Partner commission rate used to calculate commission fee",
+    },
+    displayCommissionRate: {
+      type: GraphQLString,
+      description: "Partner commission rate formatted into percentage",
+    },
     buyerTotalCents: {
       type: GraphQLInt,
       description: "Buyer total in cents",


### PR DESCRIPTION
Exposes `commissionRate` and `displayCommissionRate` on Order as implemented in https://github.com/artsy/exchange/pull/224.