### PR TITLE
@damassi => Expose min and max price in cents for an artwork

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -810,6 +810,7 @@ type Artwork implements Node & Sellable {
   ): Partner
   pickup_available: Boolean
   price: String
+  priceCents: PriceCents
   price_currency: String
 
   # Is this work available for shipping only within the Contenental US?
@@ -1533,6 +1534,7 @@ type ArtworkItem implements Node & Sellable {
   ): Partner
   pickup_available: Boolean
   price: String
+  priceCents: PriceCents
   price_currency: String
 
   # Is this work available for shipping only within the Contenental US?
@@ -5423,6 +5425,12 @@ type Pickup {
 
 type PopularArtists {
   artists: [Artist]
+}
+
+type PriceCents {
+  min: Int
+  max: Int
+  exact: Boolean
 }
 
 type Profile {

--- a/src/schema/artwork/__tests__/artwork.test.js
+++ b/src/schema/artwork/__tests__/artwork.test.js
@@ -193,6 +193,68 @@ describe("Artwork type", () => {
     })
   })
 
+  describe("#priceCents", () => {
+    const query = `
+    {
+        artwork(id: "richard-prince-untitled-portrait") {
+          priceCents {
+            min
+            max
+            exact
+          }
+        }
+      }
+    `
+
+    it("returns correct data for an exact priced work", () => {
+      // Exact priced at $420
+      artwork.price_cents = [42000]
+      return runQuery(query, rootValue).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            priceCents: {
+              min: 42000,
+              max: 42000,
+              exact: true,
+            },
+          },
+        })
+      })
+    })
+
+    it("returns correct data for an 'Under X' priced work", () => {
+      // Priced at Under $420
+      artwork.price_cents = [null, 42000]
+      return runQuery(query, rootValue).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            priceCents: {
+              min: null,
+              max: 42000,
+              exact: false,
+            },
+          },
+        })
+      })
+    })
+
+    it("returns correct data for an 'Starting at X' priced work", () => {
+      // Priced at Starting at $420
+      artwork.price_cents = [42000, null]
+      return runQuery(query, rootValue).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            priceCents: {
+              min: 42000,
+              max: null,
+              exact: false,
+            },
+          },
+        })
+      })
+    })
+  })
+
   describe("#pickup_available", () => {
     const query = `
       {

--- a/src/schema/artwork/index.ts
+++ b/src/schema/artwork/index.ts
@@ -510,6 +510,33 @@ export const artworkFields = () => {
     },
     pickup_available: { type: GraphQLBoolean },
     price: { type: GraphQLString },
+    priceCents: {
+      type: new GraphQLObjectType({
+        name: "PriceCents",
+        fields: {
+          min: {
+            type: GraphQLInt,
+          },
+          max: {
+            type: GraphQLInt,
+          },
+          exact: {
+            type: GraphQLBoolean,
+          },
+        },
+      }),
+      resolve: ({ price_cents }) => {
+        if (!price_cents || price_cents.length === 0) {
+          return null
+        }
+        const isExactPrice = price_cents.length === 1
+        return {
+          exact: isExactPrice,
+          min: price_cents[0],
+          max: isExactPrice ? price_cents[0] : price_cents[1],
+        }
+      },
+    },
     price_currency: { type: GraphQLString },
     shipsToContinentalUSOnly: {
       type: GraphQLBoolean,


### PR DESCRIPTION
This exposes the price (in cents) of a work. Since works can be exact priced, or in a range, we provide a min/max/exact object for clients.

This hasn't been needed up until now, and the only use case is the comparables visualizer will grab this for a given artwork, and pipe the results back into a filter query (adding 10% buffer to the min/max).