### PR TITLE
remove cpu-hog constraints from metaphysics-web pods

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -16,7 +16,6 @@ spec:
         app: metaphysics
         layer: application
         component: web
-        temperament: cpu-hog
       name: metaphysics-web
     spec:
       containers:
@@ -74,15 +73,6 @@ spec:
                 operator: In
                 values:
                 - foreground
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: temperament
-                operator: In
-                values:
-                - cpu-hog
-            topologyKey: "kubernetes.io/hostname"
 
 ---
 apiVersion: autoscaling/v1

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -16,7 +16,6 @@ spec:
         app: metaphysics
         layer: application
         component: web
-        temperament: cpu-hog
       name: metaphysics-web
     spec:
       containers:
@@ -74,15 +73,6 @@ spec:
                 operator: In
                 values:
                 - foreground
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: temperament
-                operator: In
-                values:
-                - cpu-hog
-            topologyKey: "kubernetes.io/hostname"
 
 ---
 apiVersion: autoscaling/v1


### PR DESCRIPTION
antiAffinity scheduling rules based on the label `cpu-hog` (ensuring only one pod with the label `cpu-hog` is run per node) are not used in Gravity any more as of https://github.com/artsy/gravity/pull/11945 so they are redundant here as well