### PR TITLE
Cap pagination results to 100

### DIFF
--- a/src/schema/fields/__tests__/pagination.test.js
+++ b/src/schema/fields/__tests__/pagination.test.js
@@ -113,4 +113,14 @@ describe("createPageCursors", () => {
     expect(around[0].isCurrent).toBe(true)
     expect(offsetFromCursor(around[0])).toBe("-1")
   })
+
+  it("caps the page number to 100", () => {
+    const size = 10
+    const totalPages = 101
+    const totalRecords = totalPages * size
+
+    const pageCursors = createPageCursors({ page: 1, size }, totalRecords)
+
+    expect(pageCursors.last.page).toBe(100)
+  })
 })

--- a/src/schema/fields/pagination.js
+++ b/src/schema/fields/pagination.js
@@ -11,6 +11,15 @@ import { warn } from "lib/loggers"
 
 const PREFIX = "arrayconnection"
 
+// In most cases Gravity caps the pagination results to 100 pages and we may not want to return more than that
+// otherwise we'll generate links that do not work. As of writing there are three endpoints that do this:
+//
+// * https://github.com/artsy/gravity/blob/52635528/app/api/v1/filter_endpoint.rb#L38
+// * https://github.com/artsy/gravity/blob/52635528/app/api/v1/filter_endpoint.rb#L79
+// * https://github.com/artsy/gravity/blob/52635528/app/api/v1/partners_endpoint.rb#L168
+//
+const PAGE_NUMBER_CAP = 100
+
 const PageCursor = new GraphQLObjectType({
   name: "PageCursor",
   fields: () => ({
@@ -78,7 +87,8 @@ export function createPageCursors(
     max = max + 1
   }
 
-  const totalPages = Math.ceil(totalRecords / size)
+  const totalPages = Math.min(Math.ceil(totalRecords / size), PAGE_NUMBER_CAP)
+
   let pageCursors
   // Degenerate case of no records found.
   if (totalPages === 0) {


### PR DESCRIPTION
We've discussed this in many places (in standup, in slack, and even on Github https://github.com/artsy/reaction/pull/1412#discussion_r225246844), but seems like we just want to cap the results to 100 for the time being. This PR updates the `createPageCursors`  function to check the `totalPages` and replaces it with `100` if it exceeds more than that. This may affect pagination results globally, and I wonder if there should be a way of capping a more specific element. Open to suggestions. Let me know what you all think!