### PR TITLE
#migration schedule MP pods on api tier nodes

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -72,7 +72,16 @@ spec:
               - key: tier
                 operator: In
                 values:
+                - api
                 - foreground
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: tier
+                operator: In
+                values:
+                - api
 
 ---
 apiVersion: autoscaling/v1


### PR DESCRIPTION
Schedule MP pods on `tier=api` nodes (our [fixed capacity group](https://github.com/artsy/substance/blob/master/clusters/production/federation/kubernetes-production-orion.artsy.systems/spec.yml#L93) in k8s production) preferentially, [as we do in Gravity](https://github.com/artsy/gravity/blob/master/hokusai/production.yml#L57) 


## Migration

`hokusai production update`
