### PR TITLE
@sweir27 => Remove random shuffling of hero units

### DIFF
--- a/src/schema/home/home_page_hero_units.js
+++ b/src/schema/home/home_page_hero_units.js
@@ -142,7 +142,7 @@ const HomePageHeroUnits = {
     const params = { enabled: true }
     params[platform] = true
     return heroUnitsLoader(params).then(units => {
-      return shuffle(units.map(unit => Object.assign({ platform }, unit)))
+      return units.map(unit => Object.assign({ platform }, unit))
     })
   },
 }


### PR DESCRIPTION
The BNMO hero unit is in the first position, but it turns out we ignore the positioning entirely (except for returning them from the API _in_ that order), by shuffling them here. This just removes the shuffle.