### PR TITLE
set dnsPolicy: ClusterFirst and dnsConfig option ndots: 1

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -63,7 +63,11 @@ spec:
             add:
             - NET_RAW
             - NET_ADMIN
-      dnsPolicy: Default
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -63,7 +63,11 @@ spec:
             add:
             - NET_RAW
             - NET_ADMIN
-      dnsPolicy: Default
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Another k8s update - reconfigure Metaphysics to use the in-cluster DNS service.

Update `dnsPolicy` and `dnsConfig` options - this will create an `/etc/resolv.conf` file with the following content, where `100.x.x.x` is the IP of the internal cluster  [kube-dns service](https://kubernetes.artsy.net/#!/service/kube-system/kube-dns?namespace=kube-system):

```
nameserver 100.x.x.x
search default.svc.cluster.local svc.cluster.local cluster.local ec2.internal
options ndots:1
```

With this configuration, all DNS queries will use the in-cluster DNS service, and any domain name with at least one `.` will be considered fully-qualified.
