### PR TITLE
Remove unused gravity loaders

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -148,17 +148,6 @@ export default (accessToken, userID, opts) => {
       { method: "PUT" }
     ),
     updateMeLoader: gravityLoader("me", {}, { method: "PUT" }),
-    orderLoader: gravityLoader(id => `order/${id}`, {}, { headers: true }),
-    updateOrderLoader: gravityLoader(
-      id => `me/order/${id}`,
-      {},
-      { method: "PUT" }
-    ),
-    submitOrderLoader: gravityLoader(
-      id => `me/order/${id}/submit`,
-      {},
-      { method: "PUT" }
-    ),
     recordArtworkViewLoader: gravityLoader(
       "me/recently_viewed_artworks",
       {},


### PR DESCRIPTION
Removing order loader, these are not currently used and also wont be useable after https://github.com/artsy/gravity/pull/11968, we've switched to Exchange's order