### PR TITLE
The hasNextPage flag should be false on page=100 when pagination results are capped to 100

### DIFF
--- a/src/schema/__tests__/filter_artworks.test.js
+++ b/src/schema/__tests__/filter_artworks.test.js
@@ -112,4 +112,63 @@ describe("Filter Artworks", () => {
       })
     })
   })
+
+  describe(`Pagination for the last page`, () => {
+    beforeEach(() => {
+      rootValue = {
+        filterArtworksLoader: sinon
+          .stub()
+          .withArgs("filter/artworks")
+          .returns(
+            Promise.resolve({
+              hits: [
+                {
+                  id: "oseberg-norway-queens-ship-0",
+                  cursor: Buffer.from("artwork:297").toString("base64"),
+                },
+                {
+                  id: "oseberg-norway-queens-ship-1",
+                  cursor: Buffer.from("artwork:298").toString("base64"),
+                },
+                {
+                  id: "oseberg-norway-queens-ship-2",
+                  cursor: Buffer.from("artwork:299").toString("base64"),
+                },
+                {
+                  id: "oseberg-norway-queens-ship-3",
+                  cursor: Buffer.from("artwork:300").toString("base64"),
+                },
+              ],
+              aggregations: {
+                total: {
+                  value: 303,
+                },
+              },
+            })
+          ),
+      }
+    })
+
+    it("caps pagination results to 100", () => {
+      const query = `
+        {
+          filter_artworks(aggregations:[TOTAL]){
+            artworks_connection(first: 3, after: "${Buffer.from(
+              "artwork:297"
+            ).toString("base64")}"){
+              pageInfo {
+                hasNextPage
+              }
+            }
+          }
+        }
+      `
+
+      return runQuery(query, rootValue).then(({ filter_artworks }) => {
+        expect(filter_artworks.artworks_connection.pageInfo).toEqual({
+          hasNextPage: false,
+        })
+      })
+    })
+  })
 })

--- a/src/schema/fields/pagination.js
+++ b/src/schema/fields/pagination.js
@@ -76,6 +76,11 @@ function pageCursorsToArray(start, end, currentPage, size) {
   return cursors
 }
 
+// Returns the total number of pagination results capped to PAGE_NUMBER_CAP.
+export function computeTotalPages(totalRecords, size) {
+  return Math.min(Math.ceil(totalRecords / size), PAGE_NUMBER_CAP)
+}
+
 export function createPageCursors(
   { page: currentPage, size },
   totalRecords,
@@ -87,7 +92,7 @@ export function createPageCursors(
     max = max + 1
   }
 
-  const totalPages = Math.min(Math.ceil(totalRecords / size), PAGE_NUMBER_CAP)
+  const totalPages = computeTotalPages(totalRecords, size)
 
   let pageCursors
   // Degenerate case of no records found.

--- a/src/schema/filter_artworks.js
+++ b/src/schema/filter_artworks.js
@@ -4,7 +4,7 @@ import Artwork from "./artwork"
 import Artist from "./artist"
 import Tag from "./tag"
 import numeral from "./fields/numeral"
-import { createPageCursors } from "./fields/pagination"
+import { computeTotalPages, createPageCursors } from "./fields/pagination"
 import { artworkConnection } from "./artwork"
 import { pageable } from "relay-cursor-paging"
 import {
@@ -108,6 +108,11 @@ export const FilterArtworksType = new GraphQLObjectType({
             throw new Error("This query must contain the total aggregation")
           }
 
+          const totalPages = computeTotalPages(
+            aggregations.total.value,
+            relayOptions.size
+          )
+
           return assign(
             {
               pageCursors: createPageCursors(
@@ -116,7 +121,10 @@ export const FilterArtworksType = new GraphQLObjectType({
               ),
             },
             connectionFromArraySlice(hits, args, {
-              arrayLength: aggregations.total.value,
+              arrayLength: Math.min(
+                aggregations.total.value,
+                totalPages * relayOptions.size
+              ),
               sliceStart: relayOptions.offset,
             })
           )


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/GROW-954

We've seen that the `Next` link is still enabled even when the user is on the `100` page. This is because the logic we compute the `hasNextPage` flag isn't based on the `totalPages` we compute in the `createPageCursors` function but instead we just use the `connectionFromArraySlice` from `graphql-relay`. What this means is that we can't easily apply this to all the connections globally but need to patch one-by-one. At the time of writing the `filter_artworks` is the only connection type we generate the pagination window for, so patching `filter_artworks` will fix the issue both in the Artist page and the Collect page. We may want to update the architecture if we find this pattern more common, but for now this should be good.

## Screenshots

![before](https://user-images.githubusercontent.com/386234/47239361-19c8d900-d3b3-11e8-8e93-5a9323d744f9.png) ![after](https://user-images.githubusercontent.com/386234/47239469-66acaf80-d3b3-11e8-9b9f-23e28888025f.png)
