### PR TITLE
[stitching] Remove default aggregations for MarketingCollection #trivial

### DIFF
--- a/src/lib/stitching/kaws/stitching.ts
+++ b/src/lib/stitching/kaws/stitching.ts
@@ -95,7 +95,6 @@ export const kawsStitchingEnvironment = (
             args: {
               ...query,
               ..._args,
-              aggregations: ["TOTAL"],
             },
             context,
             info,


### PR DESCRIPTION
This removes aggregation hardcoded value so one can be passed in.