### PR TITLE
[formatted_number] Fix validation

### DIFF
--- a/src/schema/types/formatted_number.ts
+++ b/src/schema/types/formatted_number.ts
@@ -10,7 +10,7 @@ const FormattedNumber = new GraphQLScalarType({
   serialize: x => x,
   parseValue: x => x,
   parseLiteral: ast => {
-    if (ast.kind !== Kind.STRING || ast.kind !== Kind.INT) {
+    if (ast.kind !== Kind.STRING && ast.kind !== Kind.INT) {
       const error = `Query error: Can only parse strings and ints, got a: ${
         ast.kind
       }`


### PR DESCRIPTION
Turns out that when I pulled this into Reaction as a TS file, the compiler pointed out that the second part of the condition would always pass.