### PR TITLE
Correctly destructure partnerShowImagesLoader in Show

### DIFF
--- a/src/schema/show.js
+++ b/src/schema/show.js
@@ -277,7 +277,7 @@ export const ShowType = new GraphQLObjectType({
         { id },
         options,
         request,
-        { rootValue: partnerShowImagesLoader }
+        { rootValue: { partnerShowImagesLoader } }
       ) => {
         return partnerShowImagesLoader(id, options).then(Image.resolve)
       },


### PR DESCRIPTION
Fixes a typo that breaks querying for `images` on `show`.