### PR TITLE
adjust horizontal pod autoscaler parameters for metaphysics-web 

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -98,9 +98,9 @@ spec:
     apiVersion: extensions/v1beta1
     kind: Deployment
     name: metaphysics-web
-  minReplicas: 12
+  minReplicas: 7
   maxReplicas: 15
-  targetCPUUtilizationPercentage: 80
+  targetCPUUtilizationPercentage: 70
 
 ---
 apiVersion: v1


### PR DESCRIPTION
Seems like 70% target CPU utilization gets Metaphysics to run around 10-12 replicas during normal morning hours traffic, (9-12am EST today, 26th October) - let's see if taking down the floor of min replicas can scale back for overnight periods - 12 replicas probably too generous for all traffic hous

@dleve123 for some context - Metaphysics does a lot of waiting on downstream I/O and memory consumption tends to sawtooth , so we've kept it over-provisioned and set with a fixed memory limit, so it's getting OOMKilled quite frequently but keeps it HA 