### PR TITLE
Ensure normalized is never an image default

### DIFF
--- a/src/schema/image/__tests__/normalize.test.js
+++ b/src/schema/image/__tests__/normalize.test.js
@@ -18,10 +18,11 @@ describe("grab", () => {
 describe("setVersion", () => {
   const image = {
     image_url: "https://xxx.cloudfront.net/xxx/:version.jpg", // JPG
-    image_versions: ["icon", "large"],
+    image_versions: ["icon", "large", "normalized"],
     image_urls: {
       icon: "https://xxx.cloudfront.net/xxx/icon.png", // PNG
       large: "https://xxx.cloudfront.net/xxx/large.jpg",
+      normalized: "https://xxx.cloudfront.net/xxx/normalized.jpg",
     },
   }
 
@@ -50,6 +51,10 @@ describe("setVersion", () => {
     expect(setVersion(image, ["garbage"])).toBe(
       "https://xxx.cloudfront.net/xxx/large.jpg"
     )
+  })
+
+  it("should not include normalized as a fallback", () => {
+    expect(setVersion(image)).toBe("https://xxx.cloudfront.net/xxx/large.jpg")
   })
 })
 

--- a/src/schema/image/normalize.js
+++ b/src/schema/image/normalize.js
@@ -24,7 +24,8 @@ export const setVersion = (
   versions
 ) => {
   const version =
-    find(versions, curry(includes)(image_versions)) || last(image_versions)
+    find(versions, curry(includes)(image_versions)) ||
+    last(image_versions.filter(version => version !== "normalized"))
   if (image_urls && version) return image_urls[version]
   if (includes(image_url, ":version") && version) {
     return image_url.replace(":version", version)

--- a/src/schema/image/normalize.js
+++ b/src/schema/image/normalize.js
@@ -20,7 +20,7 @@ export const grab = flow(
 )
 
 export const setVersion = (
-  { image_url, image_urls, image_versions },
+  { image_url, image_urls, image_versions = [] },
   versions
 ) => {
   const version =


### PR DESCRIPTION
We've had a few instances (that we know of) that a normalized image has been delivered in production. These images are huge and should likely _never_ be used. On the off chance they they are needed, they should be explicitly provided. 

Currently when querying and artwork image without specifying a size, there's a chance that normalized will return. 

Here are at least two issues that has been caused by this. 

https://github.com/artsy/force/pull/3032
https://github.com/artsy/force/pull/2233

This PR simply filters out `normalized` from the list of default options. 

I still have some concerns about this though. I thought that `image_versions` would be ordered from smallest size to largest size. The idea here seeming to be that if the image size isn't specified then we'd want to choose the _largest_ image to make sure it works in whatever scenario it's used. It doesn't seem like that's the case though. It kinda seems like it's ordered somewhat randomly. I'm afraid that this could cause images to be picked that are too small for where they appear. 

Ultimately I think the solution is to make the version argument for URL _required_. That's a breaking change though. Thoughts?

Running this query

```graphql
{
  artwork(id: "julian-opie-walking-in-melbourne-3-6") {
    image {
      url
    }
  }
}
```

yielded these `image_versions`

```javascript
[ 'large_rectangle',
 'tall',
'square',
'small',
'medium_rectangle',
'large',
'larger',
'medium',
'normalized' ]
```