### PR TITLE
Forward original user agent to exchange

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,8 +131,11 @@ async function startApp() {
       })
 
       // Share with e.g. the Convection ApolloLink in mergedSchema.
-      res.locals.dataLoaders = loaders // eslint-disable-line no-param-reassign
-      res.locals.accessToken = accessToken // eslint-disable-line no-param-reassign
+      res.locals.dataLoaders = loaders
+      res.locals.accessToken = accessToken
+
+      // suppply userAgent for analytics
+      res.locals.userAgent = userAgent
 
       return {
         schema,

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,7 @@ async function startApp() {
       res.locals.dataLoaders = loaders
       res.locals.accessToken = accessToken
 
-      // suppply userAgent for analytics
+      // Supply userAgent for analytics
       res.locals.userAgent = userAgent
 
       return {

--- a/src/lib/stitching/exchange/link.ts
+++ b/src/lib/stitching/exchange/link.ts
@@ -40,7 +40,9 @@ export const createExchangeLink = () => {
       ...context.graphqlContext,
       headers: {
         ...context.graphqlContext.headers,
-        "x-origin-user-agent": locals.userAgent,
+        "User-Agent": locals.userAgent
+          ? locals.userAgent + "; Metaphysics"
+          : "Metaphysics",
       },
     }
   })

--- a/src/lib/stitching/exchange/link.ts
+++ b/src/lib/stitching/exchange/link.ts
@@ -33,7 +33,20 @@ export const createExchangeLink = () => {
     return { headers }
   })
 
+  const analyticsMiddleware = setContext((_request, context) => {
+    const locals = context.graphqlContext && context.graphqlContext.res.locals
+    if (!locals) return context.graphqlContext
+    return {
+      ...context.graphqlContext,
+      headers: {
+        ...context.graphqlContext.headers,
+        "x-origin-user-agent": locals.userAgent,
+      },
+    }
+  })
+
   return middlewareLink
+    .concat(analyticsMiddleware)
     .concat(authMiddleware)
     .concat(responseLoggerLink("Exchange"))
     .concat(httpLink)


### PR DESCRIPTION
First part of https://artsyproduct.atlassian.net/browse/PURCHASE-574

tl;dr we want to track user agent and ip address at bnmo order creation time. We're already correctly setting the `x-forwarded-for` header, which supplies the user's ip address to exchange. This PR forwards the user agent too.