### PR TITLE
Some updates to credit card schema/mutation

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -4318,7 +4318,6 @@ type Me implements Node {
 
   # A list of the current user’s credit cards
   creditCards(
-    limit: Int
     after: String
     first: Int
     before: String

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -2488,8 +2488,6 @@ type CreditCardConnection {
 
   # A list of edges.
   edges: [CreditCardEdge]
-  pageCursors: PageCursors
-  totalCount: Int
 }
 
 # An edge in a connection.
@@ -2513,6 +2511,7 @@ type CreditCardMutationFailure {
 
 type CreditCardMutationSuccess {
   creditCard: CreditCard
+  creditCardEdge: CreditCardEdge
 }
 
 union CreditCardMutationType =
@@ -4319,6 +4318,7 @@ type Me implements Node {
 
   # A list of the current user’s credit cards
   creditCards(
+    limit: Int
     after: String
     first: Int
     before: String

--- a/src/schema/credit_card.js
+++ b/src/schema/credit_card.js
@@ -7,6 +7,10 @@ import {
 } from "graphql"
 import { GravityIDFields } from "schema/object_identification"
 import { GravityMutationErrorType } from "lib/gravityErrorHandler"
+import {
+  connectionDefinitions,
+  cursorForObjectInConnection,
+} from "graphql-relay"
 
 const CreditCardMutationSuccessType = new GraphQLObjectType({
   name: "CreditCardMutationSuccess",
@@ -15,6 +19,15 @@ const CreditCardMutationSuccessType = new GraphQLObjectType({
     creditCard: {
       type: CreditCard.type,
       resolve: creditCard => creditCard,
+    },
+    creditCardEdge: {
+      type: CreditCardEdge,
+      resolve: creditCard => {
+        return {
+          cursor: cursorForObjectInConnection([creditCard], creditCard),
+          node: creditCard,
+        }
+      },
     },
   }),
 })
@@ -86,6 +99,13 @@ const CreditCardType = new GraphQLObjectType({
       description: "Billing address postal code",
     },
   }),
+})
+
+export const {
+  connectionType: CreditCardConnection,
+  edgeType: CreditCardEdge,
+} = connectionDefinitions({
+  nodeType: CreditCardType,
 })
 
 export const CreditCard = {

--- a/src/schema/me/__tests__/create_credit_card_mutation.test.js
+++ b/src/schema/me/__tests__/create_credit_card_mutation.test.js
@@ -63,6 +63,51 @@ describe("Credit card mutation", () => {
     })
   })
 
+  it("creates a credit card and returns an edge", async () => {
+    const edgeQuery = `
+    mutation {
+      createCreditCard(input: {token: "tok_foo", oneTimeUse: true}) {
+        creditCardOrError {
+          ... on CreditCardMutationSuccess {
+            creditCardEdge {
+              node {
+                id
+                name
+                last_digits
+                expiration_month
+                expiration_year
+              }
+            }
+          }
+          ... on CreditCardMutationFailure {
+            mutationError {
+              type
+              message
+              detail
+            }
+          }
+        }
+      }
+    }
+    `
+    const data = await runAuthenticatedQuery(edgeQuery, rootValue)
+    expect(data).toEqual({
+      createCreditCard: {
+        creditCardOrError: {
+          creditCardEdge: {
+            node: {
+              id: "foo-foo",
+              name: "Foo User",
+              last_digits: "1234",
+              expiration_month: 3,
+              expiration_year: 2018,
+            },
+          },
+        },
+      },
+    })
+  })
+
   it("creates a credit card with an error message", async () => {
     const errorRootValue = {
       createCreditCardLoader: () =>

--- a/src/schema/me/__tests__/credit_cards.test.ts
+++ b/src/schema/me/__tests__/credit_cards.test.ts
@@ -18,7 +18,7 @@ describe("CreditCards", () => {
     const query = gql`
       {
         me {
-          creditCards(first: 1) {
+          creditCards(first: 1, limit: 1) {
             edges {
               node {
                 id

--- a/src/schema/me/__tests__/credit_cards.test.ts
+++ b/src/schema/me/__tests__/credit_cards.test.ts
@@ -10,7 +10,8 @@ describe("CreditCards", () => {
       { id: "6789", brand: "Mastercard" },
     ]
     rootValue = {
-      meCreditCardsLoader: () => Promise.resolve({ body: creditCards }),
+      meCreditCardsLoader: () =>
+        Promise.resolve({ body: creditCards, headers: { "x-total-count": 2 } }),
     }
   })
 
@@ -18,7 +19,7 @@ describe("CreditCards", () => {
     const query = gql`
       {
         me {
-          creditCards(first: 1, limit: 1) {
+          creditCards(first: 1) {
             edges {
               node {
                 id

--- a/src/schema/me/credit_cards.ts
+++ b/src/schema/me/credit_cards.ts
@@ -4,15 +4,10 @@ import { CreditCardConnection } from "schema/credit_card"
 import { pageable } from "relay-cursor-paging"
 import { connectionFromArraySlice } from "graphql-relay"
 import { parseRelayOptions } from "lib/helpers"
-import { GraphQLInt } from "graphql"
 
 export const CreditCards = {
   type: CreditCardConnection,
-  args: pageable({
-    limit: {
-      type: GraphQLInt,
-    },
-  }),
+  args: pageable({}),
   description: "A list of the current user’s credit cards",
   resolve: (
     _root,
@@ -21,11 +16,13 @@ export const CreditCards = {
     { rootValue: { accessToken, meCreditCardsLoader } }
   ) => {
     if (!accessToken) return null
-    const { page, size } = parseRelayOptions(options)
-    return meCreditCardsLoader({ page, size }).then(({ body }) => {
+    const { page, size, offset } = parseRelayOptions(options)
+    const gravityArgs = { page, size, total_count: true }
+
+    return meCreditCardsLoader(gravityArgs).then(({ body, headers }) => {
       return connectionFromArraySlice(body, options, {
-        arrayLength: body && body.length,
-        sliceStart: 0,
+        arrayLength: headers["x-total-count"],
+        sliceStart: offset,
       })
     })
   },

--- a/src/schema/me/credit_cards.ts
+++ b/src/schema/me/credit_cards.ts
@@ -1,13 +1,18 @@
 // @ts-check
 
-import { CreditCard } from "schema/credit_card"
+import { CreditCardConnection } from "schema/credit_card"
 import { pageable } from "relay-cursor-paging"
-import { connectionWithCursorInfo } from "schema/fields/pagination"
 import { connectionFromArraySlice } from "graphql-relay"
+import { parseRelayOptions } from "lib/helpers"
+import { GraphQLInt } from "graphql"
 
 export const CreditCards = {
-  type: connectionWithCursorInfo(CreditCard.type),
-  args: pageable(),
+  type: CreditCardConnection,
+  args: pageable({
+    limit: {
+      type: GraphQLInt,
+    },
+  }),
   description: "A list of the current user’s credit cards",
   resolve: (
     _root,
@@ -16,7 +21,8 @@ export const CreditCards = {
     { rootValue: { accessToken, meCreditCardsLoader } }
   ) => {
     if (!accessToken) return null
-    return meCreditCardsLoader().then(({ body }) => {
+    const { page, size } = parseRelayOptions(options)
+    return meCreditCardsLoader({ page, size }).then(({ body }) => {
       return connectionFromArraySlice(body, options, {
         arrayLength: body && body.length,
         sliceStart: 0,


### PR DESCRIPTION
Finally!

With these few changes my relay dreams will be a reality. ✨ 

This PR:
- Adds `limit` to the `me: creditCards` query so that we can pull a high number from gravity (it's a little hacky, but the UI is also not optimized for someone viewing 100 credit cards at once so I think it's OK for now).
- Returns a `creditCardEdge` from the `createCreditCardMutation` so that we can update our relay store with the result and have our UI magically be complete.