### PR TITLE
@xtina-starr => Update Kaws schema

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -2589,8 +2589,6 @@ type CurrentEvent {
   href: String
 }
 
-scalar DateTime
-
 type DaySchedule {
   start_time: Int
   end_time: Int
@@ -4224,8 +4222,8 @@ type MarketingCollection {
 
   # Structured object used to build filtered artworks query
   query: MarketingCollectionQuery!
-  createdAt: DateTime!
-  updatedAt: DateTime!
+  createdAt: MarketingDateTime!
+  updatedAt: MarketingDateTime!
   artworks(
     acquireable: Boolean
     aggregation_partner_cities: [String]
@@ -4263,6 +4261,11 @@ type MarketingCollection {
   ): FilterArtworks
 }
 
+type MarketingCollectionCategory {
+  name: String!
+  collections: [MarketingCollection!]!
+}
+
 type MarketingCollectionQuery {
   id: ID
   acquireable: Boolean
@@ -4295,6 +4298,8 @@ type MarketingCollectionQuery {
   tag_id: String
   keyword: String
 }
+
+scalar MarketingDateTime
 
 type Me implements Node {
   # A globally unique ID.
@@ -6205,6 +6210,7 @@ type Query {
   # Find partners by ID
   _unused_gravity_partners(ids: [ID]!): [DoNotUseThisPartner]
   marketingCollections: [MarketingCollection!]!
+  marketingCategories: [MarketingCollectionCategory!]!
   marketingCollection(slug: String!): MarketingCollection
 }
 

--- a/src/data/kaws.graphql
+++ b/src/data/kaws.graphql
@@ -29,6 +29,11 @@ type Collection {
   updatedAt: DateTime!
 }
 
+type CollectionCategory {
+  name: String!
+  collections: [Collection!]!
+}
+
 type CollectionQuery {
   id: ID
   acquireable: Boolean
@@ -67,5 +72,6 @@ scalar DateTime
 
 type Query {
   collections: [Collection!]!
+  categories: [CollectionCategory!]!
   collection(slug: String!): Collection
 }

--- a/src/lib/stitching/kaws/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/kaws/__tests__/__snapshots__/schema.test.ts.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`creates an SDL 1`] = `
-"scalar DateTime
-
-# Object representing a collection page
+"# Object representing a collection page
 type MarketingCollection {
   id: ID!
 
@@ -30,8 +28,13 @@ type MarketingCollection {
 
   # Structured object used to build filtered artworks query
   query: MarketingCollectionQuery!
-  createdAt: DateTime!
-  updatedAt: DateTime!
+  createdAt: MarketingDateTime!
+  updatedAt: MarketingDateTime!
+}
+
+type MarketingCollectionCategory {
+  name: String!
+  collections: [MarketingCollection!]!
 }
 
 type MarketingCollectionQuery {
@@ -67,8 +70,11 @@ type MarketingCollectionQuery {
   keyword: String
 }
 
+scalar MarketingDateTime
+
 type Query {
   marketingCollections: [MarketingCollection!]!
+  marketingCategories: [MarketingCollectionCategory!]!
   marketingCollection(slug: String!): MarketingCollection
 }
 "

--- a/src/lib/stitching/kaws/__tests__/schema.test.ts
+++ b/src/lib/stitching/kaws/__tests__/schema.test.ts
@@ -9,9 +9,9 @@ it("Does not include kaws core types", async () => {
   const kawsSchema = await executableKawsSchema()
   const kawsTypes = await getTypesFromSchema(kawsSchema)
 
-  expect(kawsTypes).not.toContain("Artist")
-  expect(kawsTypes).not.toContain("Artwork")
-  expect(kawsTypes).not.toContain("Partner")
+  expect(kawsTypes).not.toContain("Collection")
+  expect(kawsTypes).not.toContain("CollectionCategory")
+  expect(kawsTypes).not.toContain("CollectionQuery")
 
   expect(kawsTypes).toContain("MarketingCollection")
 })
@@ -20,6 +20,7 @@ it("Does not include the root query fields", async () => {
   const kawsSchema = await executableKawsSchema()
   const rootFields = await getRootFieldsFromSchema(kawsSchema)
 
+  expect(rootFields).not.toContain("categories")
   expect(rootFields).not.toContain("collection")
   expect(rootFields).not.toContain("collections")
 })

--- a/src/lib/stitching/kaws/schema.ts
+++ b/src/lib/stitching/kaws/schema.ts
@@ -17,19 +17,10 @@ export const executableKawsSchema = () => {
     link: kawsLink,
   })
 
-  // Remap the names of certain types from kaws to fit in the larger
-  // metaphysics ecosystem.
-  const remap = {
-    Collection: "MarketingCollection",
-    CollectionQuery: "MarketingCollectionQuery",
-    Image: "MarketingImage",
-  }
-
   // Return the new modified schema
   return transformSchema(schema, [
     new RenameTypes(name => {
-      const newName = remap[name] || name
-      return newName
+      return `Marketing${name}`
     }),
     new RenameRootFields(
       (_operation, name) =>


### PR DESCRIPTION
Pair session with @l2succes 

- Updates schema to include `categories` from Kaws as `MarketingCollectionCategories`
- Updates name remapping when using Kaws queries in Metaphysics 
- Fixes tests to look for Kaws variables instead of Metaphysics