### PR TITLE
Line item changes

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -4872,6 +4872,20 @@ type Order {
     thousand: String = ","
   ): String
 
+  # Total list price in cents
+  totalListPriceCents: Int
+
+  # A formatted price with various currency formatting options.
+  totalListPrice(
+    decimal: String = "."
+
+    # Allows control of symbol position (%v = value, %s = symbol)
+    format: String = "%s%v"
+    precision: Int = 0
+    symbol: String
+    thousand: String = ","
+  ): String
+
   # Shipping total in cents
   shippingTotalCents: Int
 
@@ -5115,10 +5129,24 @@ type OrderLineItem {
   editionSetId: String
 
   # Unit price in cents
-  priceCents: Int
+  priceCents: Int @deprecated(reason: "Switched to `listPriceCents`")
 
   # A formatted price with various currency formatting options.
   price(
+    decimal: String = "."
+
+    # Allows control of symbol position (%v = value, %s = symbol)
+    format: String = "%s%v"
+    precision: Int = 0
+    symbol: String
+    thousand: String = ","
+  ): String
+
+  # Unit list price in cents
+  listPriceCents: Int
+
+  # A formatted price with various currency formatting options.
+  listPrice(
     decimal: String = "."
 
     # Allows control of symbol position (%v = value, %s = symbol)

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -4877,6 +4877,20 @@ type Order {
   # Shipping total in cents
   shippingTotalCents: Int
 
+  # Total amount of latest offer
+  offerTotalCents: Int @deprecated(reason: "Switch to ItemTotalCents")
+
+  # A formatted price with various currency formatting options.
+  offerTotal(
+    decimal: String = "."
+
+    # Allows control of symbol position (%v = value, %s = symbol)
+    format: String = "%s%v"
+    precision: Int = 0
+    symbol: String
+    thousand: String = ","
+  ): String
+
   # A formatted price with various currency formatting options.
   shippingTotal(
     decimal: String = "."

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -4842,18 +4842,6 @@ type Order {
 
   # Latest offer
   lastOffer: Offer
-  offerTotalCents: Int
-
-  # A formatted price with various currency formatting options.
-  offerTotal(
-    decimal: String = "."
-
-    # Allows control of symbol position (%v = value, %s = symbol)
-    format: String = "%s%v"
-    precision: Int = 0
-    symbol: String
-    thousand: String = ","
-  ): String
 
   # List of offers made on this order so far
   offers: OfferConnection

--- a/src/data/exchange.graphql
+++ b/src/data/exchange.graphql
@@ -302,6 +302,10 @@ type Order {
     last: Int
   ): LineItemConnection
   mode: OrderModeEnum
+  offerTotalCents: Int!
+    @deprecated(
+      reason: "itemsTotalCents reflects offer total for offer orders."
+    )
   offers(
     # Returns the elements in the list that come after the specified cursor.
     after: String

--- a/src/data/exchange.graphql
+++ b/src/data/exchange.graphql
@@ -191,7 +191,8 @@ type LineItem {
     last: Int
   ): FulfillmentConnection
   id: ID!
-  priceCents: Int!
+  listPriceCents: Int!
+  priceCents: Int! @deprecated(reason: "switch to use listPriceCents")
   quantity: Int!
   updatedAt: DateTime!
 }
@@ -324,6 +325,7 @@ type Order {
   stateReason: String
   stateUpdatedAt: DateTime
   taxTotalCents: Int
+  totalListPriceCents: Int!
   transactionFeeCents: Int
   updatedAt: DateTime!
 }

--- a/src/data/exchange.graphql
+++ b/src/data/exchange.graphql
@@ -282,6 +282,8 @@ type Order {
   currencyCode: String!
   displayCommissionRate: String
   id: ID!
+
+  # Item total in cents, for Offer Orders this field reflects current offer
   itemsTotalCents: Int!
   lastApprovedAt: DateTime
   lastOffer: Offer
@@ -300,7 +302,6 @@ type Order {
     last: Int
   ): LineItemConnection
   mode: OrderModeEnum
-  offerTotalCents: Int
   offers(
     # Returns the elements in the list that come after the specified cursor.
     after: String

--- a/src/lib/stitching/exchange/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/exchange/__tests__/__snapshots__/schema.test.ts.snap
@@ -264,6 +264,8 @@ type EcommerceOrder {
   currencyCode: String!
   displayCommissionRate: String
   id: ID!
+
+  # Item total in cents, for Offer Orders this field reflects current offer
   itemsTotalCents: Int!
   lastApprovedAt: EcommerceDateTime
   lastOffer: EcommerceOffer
@@ -282,7 +284,6 @@ type EcommerceOrder {
     last: Int
   ): EcommerceLineItemConnection
   mode: EcommerceOrderModeEnum
-  offerTotalCents: Int
   offers(
     # Returns the elements in the list that come after the specified cursor.
     after: String

--- a/src/lib/stitching/exchange/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/exchange/__tests__/__snapshots__/schema.test.ts.snap
@@ -192,7 +192,8 @@ type EcommerceLineItem {
     last: Int
   ): EcommerceFulfillmentConnection
   id: ID!
-  priceCents: Int!
+  listPriceCents: Int!
+  priceCents: Int! @deprecated(reason: \\"switch to use listPriceCents\\")
   quantity: Int!
   updatedAt: EcommerceDateTime!
 }
@@ -306,6 +307,7 @@ type EcommerceOrder {
   stateReason: String
   stateUpdatedAt: EcommerceDateTime
   taxTotalCents: Int
+  totalListPriceCents: Int!
   transactionFeeCents: Int
   updatedAt: EcommerceDateTime!
 }

--- a/src/lib/stitching/exchange/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/exchange/__tests__/__snapshots__/schema.test.ts.snap
@@ -284,6 +284,7 @@ type EcommerceOrder {
     last: Int
   ): EcommerceLineItemConnection
   mode: EcommerceOrderModeEnum
+  offerTotalCents: Int! @deprecated(reason: \\"itemsTotalCents reflects offer total for offer orders.\\")
   offers(
     # Returns the elements in the list that come after the specified cursor.
     after: String

--- a/src/schema/__tests__/ecommerce/order_fields.ts
+++ b/src/schema/__tests__/ecommerce/order_fields.ts
@@ -25,6 +25,7 @@ export const OrderBuyerFields = gql`
     }
   }
   itemsTotalCents
+  totalListPriceCents
   shippingTotalCents
   taxTotalCents
   commissionFeeCents
@@ -32,6 +33,7 @@ export const OrderBuyerFields = gql`
   buyerTotalCents
   sellerTotalCents
   itemsTotal
+  totalListPrice
   shippingTotal
   taxTotal
   commissionFee
@@ -118,6 +120,7 @@ export const OrderSellerFields = gql`
     }
   }
   itemsTotalCents
+  totalListPriceCents
   shippingTotalCents
   taxTotalCents
   commissionFeeCents
@@ -125,6 +128,7 @@ export const OrderSellerFields = gql`
   buyerTotalCents
   sellerTotalCents
   itemsTotal
+  totalListPrice
   shippingTotal
   taxTotal
   commissionFee

--- a/src/schema/ecommerce/query_helpers.ts
+++ b/src/schema/ecommerce/query_helpers.ts
@@ -103,6 +103,7 @@ export const BuyerOrderFields = gql`
   stateReason
   stateUpdatedAt
   taxTotalCents
+  totalListPriceCents
   transactionFeeCents
   updatedAt
   lineItems {
@@ -110,6 +111,7 @@ export const BuyerOrderFields = gql`
       node {
         id
         priceCents
+        listPriceCents
         artworkId
         editionSetId
         quantity
@@ -142,6 +144,7 @@ export const SellerOrderFields = gql`
   stateReason
   stateUpdatedAt
   taxTotalCents
+  totalListPriceCents
   transactionFeeCents
   updatedAt
 `
@@ -160,6 +163,7 @@ export const AllOrderFields = gql`
   itemsTotalCents
   shippingTotalCents
   taxTotalCents
+  totalListPriceCents
   commissionFeeCents
   transactionFeeCents
   buyerPhoneNumber

--- a/src/schema/ecommerce/query_helpers.ts
+++ b/src/schema/ecommerce/query_helpers.ts
@@ -69,7 +69,6 @@ export const OfferRelatedFields = gql`
   lastOffer {
     ${OfferFields}
   }
-  offerTotalCents
   offers {
     edges {
       node {

--- a/src/schema/ecommerce/types/order.ts
+++ b/src/schema/ecommerce/types/order.ts
@@ -51,11 +51,6 @@ export const OrderType = new GraphQLObjectType({
       type: OfferType,
       description: "Latest offer",
     },
-    offerTotalCents: {
-      type: GraphQLInt,
-      descrtiption: "Total amount of latest offer",
-    },
-    offerTotal: amount(({ offerTotalCents }) => offerTotalCents),
     offers: {
       type: OfferConnection,
       description: "List of offers made on this order so far",

--- a/src/schema/ecommerce/types/order.ts
+++ b/src/schema/ecommerce/types/order.ts
@@ -65,6 +65,11 @@ export const OrderType = new GraphQLObjectType({
       description: "Item total in cents",
     },
     itemsTotal: amount(({ itemsTotalCents }) => itemsTotalCents),
+    totalListPriceCents: {
+      type: GraphQLInt,
+      description: "Total list price in cents",
+    },
+    totalListPrice: amount(({ totalListPriceCents }) => totalListPriceCents),
     shippingTotalCents: {
       type: GraphQLInt,
       description: "Shipping total in cents",

--- a/src/schema/ecommerce/types/order.ts
+++ b/src/schema/ecommerce/types/order.ts
@@ -69,6 +69,13 @@ export const OrderType = new GraphQLObjectType({
       type: GraphQLInt,
       description: "Shipping total in cents",
     },
+    offerTotalCents: {
+      type: GraphQLInt,
+      description: "Total amount of latest offer",
+      deprecationReason: "Switch to ItemTotalCents",
+      resolve: ({ itemsTotalCents }) => itemsTotalCents,
+    },
+    offerTotal: amount(({ itemsTotalCents }) => itemsTotalCents),
     shippingTotal: amount(({ shippingTotalCents }) => shippingTotalCents),
     taxTotalCents: {
       type: GraphQLInt,

--- a/src/schema/ecommerce/types/order_line_item.ts
+++ b/src/schema/ecommerce/types/order_line_item.ts
@@ -46,8 +46,14 @@ export const OrderLineItemType = new GraphQLObjectType({
     priceCents: {
       type: GraphQLInt,
       description: "Unit price in cents",
+      deprecationReason: "Switched to `listPriceCents`",
     },
     price: amount(({ priceCents }) => priceCents),
+    listPriceCents: {
+      type: GraphQLInt,
+      description: "Unit list price in cents",
+    },
+    listPrice: amount(({ listPriceCents }) => listPriceCents),
     updatedAt: date,
     createdAt: date,
     quantity: {

--- a/src/test/fixtures/exchange/order.json
+++ b/src/test/fixtures/exchange/order.json
@@ -27,6 +27,7 @@
   },
   "buyerPhoneNumber": "093929821",
   "itemsTotalCents": "420000",
+  "totalListPriceCents": "421000",
   "shippingTotalCents": "420100",
   "taxTotalCents": "420200",
   "commissionFeeCents": "420300",
@@ -45,6 +46,7 @@
         "node": {
           "id": "1",
           "priceCents": 420000,
+          "listPriceCents": 420000,
           "artworkId": "541324567261693f97790b00",
           "artistId": "222",
           "editionSetId": null,

--- a/src/test/fixtures/exchange/orders.json
+++ b/src/test/fixtures/exchange/orders.json
@@ -36,6 +36,7 @@
         },
         "buyerPhoneNumber": "093929821",
         "itemsTotalCents": "420000",
+        "totalListPriceCents": "421000",
         "shippingTotalCents": "420100",
         "taxTotalCents": "420200",
         "commissionFeeCents": "420300",
@@ -60,6 +61,7 @@
               "node": {
                 "id": "1",
                 "priceCents": 420000,
+                "listPriceCents": 420000,
                 "artworkId": "541324567261693f97790b00",
                 "artistId": "222",
                 "editionSetId": null,

--- a/src/test/fixtures/results/sample_order.js
+++ b/src/test/fixtures/results/sample_order.js
@@ -16,6 +16,8 @@ const defaultResponse = {
   buyerPhoneNumber: "093929821",
   itemsTotalCents: 420000,
   itemsTotal: "$4,200",
+  totalListPriceCents: 421000,
+  totalListPrice: "$4,210",
   shippingTotalCents: 420100,
   shippingTotal: "$4,201",
   taxTotalCents: 420200,


### PR DESCRIPTION
# Depends On
https://github.com/artsy/exchange/pull/273

# Change
- Deprecate `offerTotal` fields from `Order`
- Add `totalListPrice` fields to `Order`
- Deprecated `priceCents` from `LineItem`
- Added `listPriceCents` to `LineItem`

This should make all these deploys safe as long as Exchange gets deployed first because of accessing `listPriceCents` in MP