### PR TITLE
SELL-1150: Update exchange.graphql to reflect artsy/exchange#271

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -4695,6 +4695,11 @@ type Mutation {
   # Approves an order with payment
   ecommerceApproveOrder(input: ApproveOrderInput!): ApproveOrderPayload
 
+  # Approves an order with payment
+  ecommerceSellerAcceptOffer(
+    input: sellerAcceptOfferInput!
+  ): sellerAcceptOfferPayload
+
   # Confirms pickup for an ecommerce order
   ecommerceConfirmPickup(input: ConfirmPickupInput!): ConfirmPickupPayload
 
@@ -6742,6 +6747,17 @@ interface Sellable {
   is_sold: Boolean
   price: String
   sale_message: String
+}
+
+input sellerAcceptOfferInput {
+  # Offer ID
+  offerId: String!
+  clientMutationId: String
+}
+
+type sellerAcceptOfferPayload {
+  orderOrError: OrderOrFailureUnionType
+  clientMutationId: String
 }
 
 input SendConversationMessageMutationInput {

--- a/src/data/exchange.graphql
+++ b/src/data/exchange.graphql
@@ -221,12 +221,8 @@ type LineItemEdge {
 type Mutation {
   approveOrder(input: ApproveOrderInput!): ApproveOrderPayload
   confirmPickup(input: ConfirmPickupInput!): ConfirmPickupPayload
-  createOfferOrderWithArtwork(
-    input: CreateOfferOrderWithArtworkInput!
-  ): CreateOfferOrderWithArtworkPayload
-  createOrderWithArtwork(
-    input: CreateOrderWithArtworkInput!
-  ): CreateOrderWithArtworkPayload
+  createOfferOrderWithArtwork(input: CreateOfferOrderWithArtworkInput!): CreateOfferOrderWithArtworkPayload
+  createOrderWithArtwork(input: CreateOrderWithArtworkInput!): CreateOrderWithArtworkPayload
 
   # Fulfill an order with one Fulfillment, it sets this fulfillment to each line item in order
   fulfillAtOnce(input: FulfillAtOnceInput!): FulfillAtOncePayload
@@ -304,10 +300,7 @@ type Order {
     last: Int
   ): LineItemConnection
   mode: OrderModeEnum
-  offerTotalCents: Int!
-    @deprecated(
-      reason: "itemsTotalCents reflects offer total for offer orders."
-    )
+  offerTotalCents: Int! @deprecated(reason: "itemsTotalCents reflects offer total for offer orders.")
   offers(
     # Returns the elements in the list that come after the specified cursor.
     after: String

--- a/src/schema/__tests__/ecommerce/seller_accept_offer_mutation.test.ts
+++ b/src/schema/__tests__/ecommerce/seller_accept_offer_mutation.test.ts
@@ -1,0 +1,74 @@
+import { runQuery } from "test/utils"
+import { sampleOrder } from "test/fixtures/results/sample_order"
+import gql from "lib/gql"
+import { mockxchange } from "test/fixtures/exchange/mockxchange"
+import { OrderSellerFields } from "./order_fields"
+import exchangeOrderJSON from "test/fixtures/exchange/order.json"
+
+let rootValue
+
+describe("SellerAcceptOffer Mutation", () => {
+  const mutation = gql`
+    mutation {
+      ecommerceSellerAcceptOffer(input: { offerId: "111" }) {
+        orderOrError {
+          ... on OrderWithMutationSuccess {
+            order {
+              ${OrderSellerFields}
+            }
+          }
+          ... on OrderWithMutationFailure {
+            error {
+              type
+              code
+              data
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("approves the order of the offer", () => {
+    const resolvers = {
+      Mutation: {
+        sellerAcceptOffer: () => ({
+          orderOrError: { order: exchangeOrderJSON },
+        }),
+      },
+    }
+
+    rootValue = mockxchange(resolvers)
+
+    return runQuery(mutation, rootValue).then(data => {
+      expect(data!.ecommerceSellerAcceptOffer.orderOrError.order).toEqual(
+        sampleOrder()
+      )
+    })
+  })
+
+  it("returns an error if there is one", () => {
+    const resolvers = {
+      Mutation: {
+        sellerAcceptOffer: () => ({
+          orderOrError: {
+            error: {
+              type: "application_error",
+              code: "404",
+            },
+          },
+        }),
+      },
+    }
+
+    rootValue = mockxchange(resolvers)
+
+    return runQuery(mutation, rootValue).then(data => {
+      expect(data!.ecommerceSellerAcceptOffer.orderOrError.error).toEqual({
+        type: "application_error",
+        code: "404",
+        data: null,
+      })
+    })
+  })
+})

--- a/src/schema/ecommerce/query_helpers.ts
+++ b/src/schema/ecommerce/query_helpers.ts
@@ -135,6 +135,17 @@ export const SellerOrderFields = gql`
   itemsTotalCents
   lastApprovedAt
   lastSubmittedAt
+  lineItems {
+    edges {
+      node {
+        id
+        priceCents
+        artworkId
+        editionSetId
+        quantity
+      }
+    }
+  }
   mode
   sellerTotalCents
   shippingTotalCents

--- a/src/schema/ecommerce/seller_accept_offer_mutation.ts
+++ b/src/schema/ecommerce/seller_accept_offer_mutation.ts
@@ -33,17 +33,6 @@ export const SellerAcceptOfferMutation = mutationWithClientMutationId({
             ... on EcommerceOrderWithMutationSuccess {
               order {
                 ${SellerOrderFields}
-                lineItems {
-                  edges {
-                    node {
-                      id
-                      priceCents
-                      artworkId
-                      editionSetId
-                      quantity
-                    }
-                  }
-                }
               }
             }
             ... on EcommerceOrderWithMutationFailure {

--- a/src/schema/ecommerce/seller_accept_offer_mutation.ts
+++ b/src/schema/ecommerce/seller_accept_offer_mutation.ts
@@ -1,0 +1,64 @@
+import { graphql } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { OfferMutationInputType } from "schema/ecommerce/types/offer_mutation_input_type"
+import { OrderOrFailureUnionType } from "./types/order_or_error_union"
+import { SellerOrderFields } from "./query_helpers"
+import gql from "lib/gql"
+import { extractEcommerceResponse } from "./extractEcommerceResponse"
+
+export const SellerAcceptOfferMutation = mutationWithClientMutationId({
+  name: "sellerAcceptOffer",
+  description: "Approves an order with payment",
+  inputFields: OfferMutationInputType.getFields(),
+  outputFields: {
+    orderOrError: {
+      type: OrderOrFailureUnionType,
+    },
+  },
+  mutateAndGetPayload: (
+    { offerId },
+    context,
+    { rootValue: { accessToken, exchangeSchema } }
+  ) => {
+    if (!accessToken) {
+      return new Error("You need to be signed in to perform this action")
+    }
+    const mutation = gql`
+      mutation sellerAcceptOffer($offerId: ID!) {
+        ecommerceSellerAcceptOffer(input: {
+          offerId: $offerId,
+        }) {
+          orderOrError {
+            __typename
+            ... on EcommerceOrderWithMutationSuccess {
+              order {
+                ${SellerOrderFields}
+                lineItems {
+                  edges {
+                    node {
+                      id
+                      priceCents
+                      artworkId
+                      editionSetId
+                      quantity
+                    }
+                  }
+                }
+              }
+            }
+            ... on EcommerceOrderWithMutationFailure {
+              error {
+                type
+                code
+                data
+              }
+            }
+          }
+        }
+      }
+    `
+    return graphql(exchangeSchema, mutation, null, context, {
+      offerId,
+    }).then(extractEcommerceResponse("ecommerceSellerAcceptOffer"))
+  },
+})

--- a/src/schema/ecommerce/types/offer_mutation_input_type.ts
+++ b/src/schema/ecommerce/types/offer_mutation_input_type.ts
@@ -1,0 +1,11 @@
+import { GraphQLInputObjectType, GraphQLNonNull, GraphQLString } from "graphql"
+
+export const OfferMutationInputType = new GraphQLInputObjectType({
+  name: "OfferMutationInput",
+  fields: {
+    offerId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "Offer ID",
+    },
+  },
+})

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -24,6 +24,7 @@ import { SetOrderShippingMutation } from "./ecommerce/set_order_shipping_mutatio
 import { SetOrderPaymentMutation } from "./ecommerce/set_order_payment_mutation"
 import { SubmitOrderMutation } from "./ecommerce/submit_order_mutation"
 import { ApproveOrderMutation } from "./ecommerce/approve_order_mutation"
+import { SellerAcceptOfferMutation } from "./ecommerce/seller_accept_offer_mutation"
 import { FulfillOrderAtOnceMutation } from "./ecommerce/fulfill_order_at_once_mutation"
 import { ConfirmPickupMutation } from "./ecommerce/confirm_pickup_mutation"
 import { RejectOrderMutation } from "./ecommerce/reject_order_mutation"
@@ -183,6 +184,7 @@ if (!ENABLE_ECOMMERCE_STITCHING) {
   stitchedMutations.ecommerceSetOrderShipping = SetOrderShippingMutation
   stitchedMutations.ecommerceSetOrderPayment = SetOrderPaymentMutation
   stitchedMutations.ecommerceApproveOrder = ApproveOrderMutation
+  stitchedMutations.ecommerceSellerAcceptOffer = SellerAcceptOfferMutation
   stitchedMutations.ecommerceConfirmPickup = ConfirmPickupMutation
   stitchedMutations.ecommerceFulfillOrderAtOnce = FulfillOrderAtOnceMutation
   stitchedMutations.ecommerceRejectOrder = RejectOrderMutation


### PR DESCRIPTION
Jira: https://artsyproduct.atlassian.net/browse/SELL-1150

Adds `sellerAcceptOfferMutation` to MP, so that it can be consumed by force.

WARNING: If this deployed to production before, Exchange https://github.com/artsy/exchange/commit/b03a4a6f51cb88ca5d9637f5012586b8a0306af0 is deployed to production, then MP might break as MP-prod will have a newer version of Exchange's schema than Exchange-prod.


----

N.B: local MP is on my dev branch, integrating with Gravity staging.

![screen shot 2018-11-09 at 6 21 47 pm](https://user-images.githubusercontent.com/1561546/48293361-a6b00100-e44c-11e8-8484-476f6d604b38.png)
