### PR TITLE
Change sale_artwork.position from int to float

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -6481,7 +6481,7 @@ type SaleArtwork {
   minimum_next_bid_cents: Float @deprecated(reason: "Favor `minimum_next_bid`")
   opening_bid: SaleArtworkOpeningBid
   opening_bid_cents: Float @deprecated(reason: "Favor `opening_bid`")
-  position: Int
+  position: Float
   reserve: SaleArtworkReserve
   reserve_message: String
   reserve_status: String

--- a/src/schema/sale_artwork.js
+++ b/src/schema/sale_artwork.js
@@ -308,7 +308,7 @@ const SaleArtworkType = new GraphQLObjectType({
         type: GraphQLFloat,
         deprecationReason: "Favor `opening_bid`",
       },
-      position: { type: GraphQLInt },
+      position: { type: GraphQLFloat },
       reserve: money({
         name: "SaleArtworkReserve",
         resolve: ({ display_reserve_dollars, reserve_cents }) => ({


### PR DESCRIPTION
Gravity consider's a SaleArtwork's `position` to be a float.  Metaphysics had it as an integer.

Auction ops relies on it being a float, so we update Metaphysics here. Downstream clients may need to be updated as well.