### PR TITLE
DISCO-494: Return null shipping info if artwork is not acquirable

### DIFF
--- a/src/schema/artwork/__tests__/artwork.test.js
+++ b/src/schema/artwork/__tests__/artwork.test.js
@@ -1467,8 +1467,35 @@ describe("Artwork type", () => {
       }
     `
 
+    beforeEach(() => {
+      artwork.acquireable = true
+    })
+
     it("is null when shipping_origin is null", () => {
       artwork.shipping_origin = null
+      return runQuery(query, rootValue).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            shippingOrigin: null,
+          },
+        })
+      })
+    })
+
+    it("is null when artwork is not acquireable", () => {
+      artwork.acquireable = false
+      artwork.shipping_origin = ["Kharkov", "Ukraine"]
+      return runQuery(query, rootValue).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            shippingOrigin: null,
+          },
+        })
+      })
+    })
+
+    it("is null if shipping origin is not present", () => {
+      artwork.shipping_origin = []
       return runQuery(query, rootValue).then(data => {
         expect(data).toEqual({
           artwork: {

--- a/src/schema/artwork/__tests__/artwork.test.js
+++ b/src/schema/artwork/__tests__/artwork.test.js
@@ -1304,13 +1304,13 @@ describe("Artwork type", () => {
       })
     })
 
-    it("is set to prompt string when its domestic_shipping_fee_cents is null and international_shipping_fee_cents is null", () => {
+    it("is null when domestic_shipping_fee_cents is null and international_shipping_fee_cents is null", () => {
       artwork.domestic_shipping_fee_cents = null
       artwork.international_shipping_fee_cents = null
       return runQuery(query, rootValue).then(data => {
         expect(data).toEqual({
           artwork: {
-            shippingInfo: "Shipping, tax, and service quoted by seller",
+            shippingInfo: null,
           },
         })
       })

--- a/src/schema/artwork/__tests__/artwork.test.js
+++ b/src/schema/artwork/__tests__/artwork.test.js
@@ -1286,6 +1286,24 @@ describe("Artwork type", () => {
       }
     `
 
+    beforeEach(() => {
+      artwork.acquireable = true
+    })
+
+    it("is null if artwork is not enrolled in in an e-commerce program", () => {
+      artwork.acquireable = false
+      artwork.domestic_shipping_fee_cents = 1000
+      artwork.international_shipping_fee_cents = null
+
+      return runQuery(query, rootValue).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            shippingInfo: null,
+          },
+        })
+      })
+    })
+
     it("is set to prompt string when its domestic_shipping_fee_cents is null and international_shipping_fee_cents is null", () => {
       artwork.domestic_shipping_fee_cents = null
       artwork.international_shipping_fee_cents = null

--- a/src/schema/artwork/index.ts
+++ b/src/schema/artwork/index.ts
@@ -626,7 +626,13 @@ export const artworkFields = () => {
       description:
         "Minimal location information describing from where artwork will be shipped.",
       resolve: artwork => {
-        return artwork.shipping_origin && artwork.shipping_origin.join(", ")
+        if (
+          !artwork.acquireable ||
+          !(artwork.shipping_origin && artwork.shipping_origin.length)
+        )
+          return null
+
+        return artwork.shipping_origin.join(", ")
       },
     },
     provenance: markdown(({ provenance }) =>

--- a/src/schema/artwork/index.ts
+++ b/src/schema/artwork/index.ts
@@ -577,6 +577,8 @@ export const artworkFields = () => {
       description:
         "The string that describes domestic and international shipping.",
       resolve: artwork => {
+        if (!artwork.acquireable) return null
+
         if (
           artwork.domestic_shipping_fee_cents == null &&
           artwork.international_shipping_fee_cents == null

--- a/src/schema/artwork/index.ts
+++ b/src/schema/artwork/index.ts
@@ -577,13 +577,13 @@ export const artworkFields = () => {
       description:
         "The string that describes domestic and international shipping.",
       resolve: artwork => {
-        if (!artwork.acquireable) return null
-
         if (
-          artwork.domestic_shipping_fee_cents == null &&
-          artwork.international_shipping_fee_cents == null
+          !artwork.acquireable ||
+          (artwork.domestic_shipping_fee_cents == null &&
+            artwork.international_shipping_fee_cents == null)
         )
-          return "Shipping, tax, and service quoted by seller"
+          return null
+
         if (
           artwork.domestic_shipping_fee_cents === 0 &&
           artwork.international_shipping_fee_cents == null


### PR DESCRIPTION
Pages for artworks which were previously enrolled in an e-commerce program still display shipping information provided during enrollment in the program.

This creates an inconsistent user experience. If an artwork is removed from a program, we should not display any shipping information previously entered during enrollment.

This commit updates Metaphysics to return a `null` value for `shippingInfo` unless the artwork is `acquirable` designating active enrollment in one or more of our e-commerce programs.

ticket: https://artsyproduct.atlassian.net/browse/DISCO-494