### PR TITLE
@l2succes => Add `marketable` as a filter artworks param

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -209,6 +209,9 @@ type Artist implements Node {
     height: String
     width: String
 
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
+
     # A string from the list of allocations, or * to denote all mediums
     medium: String
     period: String
@@ -517,6 +520,9 @@ type ArtistItem implements Node {
     gene_ids: [String]
     height: String
     width: String
+
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
 
     # A string from the list of allocations, or * to denote all mediums
     medium: String
@@ -1353,6 +1359,9 @@ type ArtworkFilterGene implements Node {
     height: String
     width: String
 
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
+
     # A string from the list of allocations, or * to denote all mediums
     medium: String
     period: String
@@ -1406,6 +1415,9 @@ type ArtworkFilterTag implements Node {
     gene_ids: [String]
     height: String
     width: String
+
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
 
     # A string from the list of allocations, or * to denote all mediums
     medium: String
@@ -3407,6 +3419,9 @@ type Gene implements Node {
     height: String
     width: String
 
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
+
     # A string from the list of allocations, or * to denote all mediums
     medium: String
     period: String
@@ -3449,6 +3464,9 @@ type Gene implements Node {
     gene_ids: [String]
     height: String
     width: String
+
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
 
     # A string from the list of allocations, or * to denote all mediums
     medium: String
@@ -3585,6 +3603,9 @@ type GeneItem implements Node {
     height: String
     width: String
 
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
+
     # A string from the list of allocations, or * to denote all mediums
     medium: String
     period: String
@@ -3627,6 +3648,9 @@ type GeneItem implements Node {
     gene_ids: [String]
     height: String
     width: String
+
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
 
     # A string from the list of allocations, or * to denote all mediums
     medium: String
@@ -4092,6 +4116,9 @@ type HomePageModuleContextGene implements Node {
     height: String
     width: String
 
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
+
     # A string from the list of allocations, or * to denote all mediums
     medium: String
     period: String
@@ -4134,6 +4161,9 @@ type HomePageModuleContextGene implements Node {
     gene_ids: [String]
     height: String
     width: String
+
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
 
     # A string from the list of allocations, or * to denote all mediums
     medium: String
@@ -6156,6 +6186,9 @@ type Query {
     height: String
     width: String
 
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
+
     # A string from the list of allocations, or * to denote all mediums
     medium: String
     period: String
@@ -7475,6 +7508,9 @@ type Tag implements Node {
     height: String
     width: String
 
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
+
     # A string from the list of allocations, or * to denote all mediums
     medium: String
     period: String
@@ -7874,6 +7910,9 @@ type Viewer {
     gene_ids: [String]
     height: String
     width: String
+
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
 
     # A string from the list of allocations, or * to denote all mediums
     medium: String

--- a/src/schema/filter_artworks.js
+++ b/src/schema/filter_artworks.js
@@ -244,6 +244,11 @@ export const filterArtworksArgs = {
   width: {
     type: GraphQLString,
   },
+  marketable: {
+    type: GraphQLBoolean,
+    description:
+      "When true, will only return `marketable` works (not nude or provocative).",
+  },
   medium: {
     type: GraphQLString,
     description:


### PR DESCRIPTION
We want to add this to the landing page/initial query for Collect and Collections (https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=57&projectKey=DISCO&modal=detail&selectedIssue=DISCO-493) , to ensure no nude or provocative images appear (which is essential for marketing purposes).

This safe to merge, even though the Gravity part hasn't been deployed yet.