### PR TITLE
@l2succes => Pass `marketable` as a param when stitching filter artworks

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -4525,6 +4525,7 @@ type MarketingCollection {
     include_artworks_by_followed_artists: Boolean
     include_medium_filter_in_aggregation: Boolean
     inquireable_only: Boolean
+    marketable: Boolean
     for_sale: Boolean
     gene_id: String
     gene_ids: [String]

--- a/src/lib/stitching/kaws/stitching.ts
+++ b/src/lib/stitching/kaws/stitching.ts
@@ -21,6 +21,7 @@ export const kawsStitchingEnvironment = (
         include_artworks_by_followed_artists: Boolean
         include_medium_filter_in_aggregation: Boolean
         inquireable_only: Boolean
+        marketable: Boolean
         for_sale: Boolean
         gene_id: String
         gene_ids: [String]
@@ -70,6 +71,7 @@ export const kawsStitchingEnvironment = (
               gene_ids
               height
               width
+              marketable
               medium
               period
               periods


### PR DESCRIPTION
Was adding this in Reaction and realized that for Collection pages, that's stitched thru the Kaws schema. So I think I need to add this param like so?