### PR TITLE
Fixes an intermittent test

### DIFF
--- a/src/schema/sale/__tests__/index.test.js
+++ b/src/schema/sale/__tests__/index.test.js
@@ -433,10 +433,10 @@ describe("Sale type", () => {
       ],
       [
         {
-          live_start_at: moment().add(1, "minutes"),
+          live_start_at: moment().add(2, "minutes"),
           registration_ends_at: moment().subtract(2, "days"),
         },
-        "live in 1m",
+        "live in 2m",
       ],
       [
         {


### PR DESCRIPTION
This test checks for 1m, but if you've not got a babel cache set up yet then it takes enough time to go from 1m into seconds. 

See how it takes 20s here:

![screen shot 2018-11-26 at 11 12 03 am](https://user-images.githubusercontent.com/49038/49027093-69967f00-f16d-11e8-912f-304429aa9ec4.png) 

Which matches the time difference in the fail.

The 2nd run would then take about 0.8s so it doesn't get hit