### PR TITLE
Port daySchedules formatting logic from force

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3361,6 +3361,11 @@ enum Format {
   markdown @deprecated(reason: "deprecated")
 }
 
+type FormattedDaySchedules {
+  days: String
+  hours: String
+}
+
 # The `FormattedNumber` type represents a number that can optionally be returnedas
 # a formatted String. It does not try to coerce the type.
 scalar FormattedNumber
@@ -4473,6 +4478,7 @@ type Location {
   country: String
   coordinates: LatLng
   day_schedules: [DaySchedule]
+  displayDaySchedules: [FormattedDaySchedules]
   display: String
   phone: String
   postal_code: String

--- a/src/schema/__tests__/formattedDaySchedules.test.ts
+++ b/src/schema/__tests__/formattedDaySchedules.test.ts
@@ -1,0 +1,132 @@
+import {
+  FormattedDaySchedules,
+  DaySchedule,
+} from "../types/formattedDaySchedules"
+
+const formatDaySchedules = FormattedDaySchedules.resolve
+
+describe("FormattedDaySchedules.resolve", () => {
+  it("collapses times duplicated across days", () => {
+    const daySchedules = [
+      {
+        day_of_week: "Monday",
+        start_time: 37800,
+        end_time: 68400,
+      },
+      {
+        day_of_week: "Tuesday",
+        start_time: 37800,
+        end_time: 68400,
+      },
+      {
+        day_of_week: "Wednesday",
+        start_time: 37800,
+        end_time: 68400,
+      },
+      {
+        day_of_week: "Thursday",
+        start_time: 37800,
+        end_time: 68400,
+      },
+      {
+        day_of_week: "Friday",
+        start_time: 37800,
+        end_time: 68400,
+      },
+      {
+        day_of_week: "Saturday",
+        start_time: 37800,
+        end_time: 68400,
+      },
+    ]
+    expect(formatDaySchedules(daySchedules as Array<DaySchedule>)).toEqual([
+      {
+        days: "Monday–Saturday",
+        hours: "10:30am–7pm",
+      },
+      {
+        days: "Sunday",
+        hours: "Closed",
+      },
+    ])
+  })
+
+  it("handles multiple time segments in a single day", () => {
+    const daySchedules = [
+      {
+        start_time: 39600,
+        end_time: 50400,
+        day_of_week: "Sunday",
+      },
+      {
+        start_time: 61200,
+        end_time: 72000,
+        day_of_week: "Sunday",
+      },
+      {
+        start_time: 39600,
+        end_time: 50400,
+        day_of_week: "Monday",
+      },
+      {
+        start_time: 64800,
+        end_time: 72000,
+        day_of_week: "Monday",
+      },
+      {
+        start_time: 39600,
+        end_time: 50400,
+        day_of_week: "Wednesday",
+      },
+      {
+        start_time: 64800,
+        end_time: 72000,
+        day_of_week: "Wednesday",
+      },
+      {
+        start_time: 39600,
+        end_time: 50400,
+        day_of_week: "Thursday",
+      },
+      {
+        start_time: 64800,
+        end_time: 72000,
+        day_of_week: "Thursday",
+      },
+      {
+        start_time: 39600,
+        end_time: 50400,
+        day_of_week: "Friday",
+      },
+      {
+        start_time: 64800,
+        end_time: 72000,
+        day_of_week: "Friday",
+      },
+      {
+        start_time: 39600,
+        end_time: 50400,
+        day_of_week: "Saturday",
+      },
+      {
+        start_time: 64800,
+        end_time: 72000,
+        day_of_week: "Saturday",
+      },
+    ]
+    expect(formatDaySchedules(daySchedules as Array<DaySchedule>)).toEqual([
+      {
+        days: "Monday, Wednesday–Saturday",
+        hours: "11am–2pm, 6pm–8pm",
+      },
+      {
+        days: "Tuesday",
+        hours: "Closed",
+      },
+      {
+        days: "Sunday",
+        hours: "11am–2pm, 5pm–8pm",
+      },
+    ])
+  })
+})

--- a/src/schema/location.js
+++ b/src/schema/location.js
@@ -1,6 +1,7 @@
 import { existyValue } from "lib/helpers"
 import cached from "./fields/cached"
 import DayScheduleType from "./day_schedule"
+import { FormattedDaySchedules } from "./types/formattedDaySchedules"
 import { IDFields } from "./object_identification"
 import {
   GraphQLString,
@@ -45,6 +46,11 @@ export const LocationType = new GraphQLObjectType({
     day_schedules: {
       type: new GraphQLList(DayScheduleType),
       resolve: ({ day_schedules }) => day_schedules,
+    },
+    displayDaySchedules: {
+      type: new GraphQLList(FormattedDaySchedules.type),
+      resolve: ({ day_schedules }) =>
+        FormattedDaySchedules.resolve(day_schedules),
     },
     display: {
       type: GraphQLString,

--- a/src/schema/types/formattedDaySchedules.ts
+++ b/src/schema/types/formattedDaySchedules.ts
@@ -1,0 +1,109 @@
+import { GraphQLString, GraphQLObjectType } from "graphql"
+import moment from "moment"
+import _ from "lodash"
+
+enum DayOfWeek {
+  Monday = "Monday",
+  Tuesday = "Tuesday",
+  Wednesday = "Wednesday",
+  Thursday = "Thursday",
+  Friday = "Friday",
+  Saturday = "Saturday",
+  Sunday = "Sunday",
+}
+
+export interface DaySchedule {
+  day_of_week: DayOfWeek
+  start_time: number
+  end_time: number
+}
+
+// Takes a day of the week as a string and returns a formatted schedule for a day of the week or closed:
+// { start: 'Monday', hours: '10:30am–7pm' } or { start: 'Tuesday', hours: 'Closed'}
+function formatDaySchedule(day: DayOfWeek, daySchedules: Array<DaySchedule>) {
+  const filteredDaySchedules = _.filter(daySchedules, { day_of_week: day })
+  if (filteredDaySchedules.length) {
+    const hours: Array<String> = []
+    filteredDaySchedules.forEach(daySchedule => {
+      const startHour = moment().hour(daySchedule["start_time"] / 60 / 60)
+      const startMinute = moment().minutes(daySchedule["start_time"] / 60)
+      const endHour = moment().hour(daySchedule["end_time"] / 60 / 60)
+      const endMinute = moment().minutes(daySchedule["end_time"] / 60)
+      hours.push(
+        startHour.format("h") +
+          (startMinute.format("mm") === "00" ? "" : startMinute.format(":mm")) +
+          startHour.format("a") +
+          "–" +
+          endHour.format("h") +
+          (endMinute.format("mm") === "00" ? "" : endMinute.format(":mm")) +
+          endHour.format("a")
+      )
+    })
+    return {
+      start: day,
+      hours: _.uniq(hours).join(", "),
+    }
+  } else {
+    return {
+      start: day,
+      hours: "Closed",
+    }
+  }
+}
+
+// Returns an array of formatted 'day schedule' objects for a 7 day week:
+// [{ start: 'Monday', hours: '10am – 7pm'}, {start: 'Tuesday, hours: 'Closed'}, ... ]
+export function formatDaySchedules(daySchedules: Array<DaySchedule>) {
+  const formattedDaySchedules = () =>
+    _.map(Object.values(DayOfWeek), day => {
+      return formatDaySchedule(day, daySchedules)
+    })
+
+  const daysOpen = [formattedDaySchedules()[0]]
+  _.each(formattedDaySchedules().slice(1), function(daySchedule) {
+    if (
+      daySchedule &&
+      daySchedule["hours"] === (_.last(daysOpen) as Object)["hours"]
+    ) {
+      return _.extend(_.last(daysOpen), { end: daySchedule["start"] })
+    } else {
+      return daysOpen.push({
+        start: daySchedule["start"],
+        hours: daySchedule["hours"],
+      })
+    }
+  })
+
+  return _.chain(daysOpen)
+    .groupBy("hours")
+    .map(schedule =>
+      _.chain(schedule)
+        .map(day => ({
+          days: day["end"] ? day["start"] + "–" + day["end"] : day["start"],
+          hours: schedule[0]["hours"],
+        }))
+        .reduce(function(memo, iteratee) {
+          memo["days"] = memo["days"] + ", " + iteratee["days"]
+          return memo
+        })
+        .value()
+    )
+    .value()
+}
+
+const FormattedDaySchedulesType = new GraphQLObjectType({
+  name: "FormattedDaySchedules",
+  fields: () => ({
+    days: {
+      type: GraphQLString,
+    },
+    hours: {
+      type: GraphQLString,
+    },
+  }),
+})
+
+export const FormattedDaySchedules = {
+  type: FormattedDaySchedulesType,
+  resolve: formatDaySchedules,
+}


### PR DESCRIPTION
We want to format `Location.day_schedules` for display as part of ongoing local discovery work. Force contains some logic that deduplicates and squashes this data [here](https://github.com/javamonn/force/blob/55e47edd24106806705bef82cdd74314148097af/src/desktop/models/partner_show.coffee#L201-L255). This PR runs that coffeescript through [decaffinate](https://github.com/decaffeinate/decaffeinate), cleans it up a bit, and adds the formatted result as a `displayDaySchedules` on `Location`.