### PR TITLE
Resolve new fields for PartnerShow & PartnerLocation

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -4520,6 +4520,9 @@ type Location {
   country: String
   coordinates: LatLng
   day_schedules: [DaySchedule]
+
+  # Alternate free text representation of a location's opening hours
+  day_schedule_text: String
   displayDaySchedules: [FormattedDaySchedules]
   display: String
   phone: String

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -4521,7 +4521,7 @@ type Location {
   coordinates: LatLng
   day_schedules: [DaySchedule]
 
-  # Alternate free text representation of a location's opening hours
+  # Alternate Markdown-supporting free text representation of a location's opening hours
   day_schedule_text: String
   displayDaySchedules: [FormattedDaySchedules]
   display: String

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -7687,6 +7687,9 @@ type Show implements Node {
   # Is it a stubbed show?
   is_reference: Boolean
 
+  # Is it an outsourced local discovery stub show?
+  is_local_discovery: Boolean
+
   # Whether the show is in a fair, group or solo
   kind: String
 

--- a/src/schema/location.ts
+++ b/src/schema/location.ts
@@ -49,7 +49,7 @@ export const LocationType = new GraphQLObjectType({
     },
     day_schedule_text: {
       description:
-        "Alternate free text representation of a location's opening hours",
+        "Alternate Markdown-supporting free text representation of a location's opening hours",
       type: GraphQLString,
     },
     displayDaySchedules: {

--- a/src/schema/location.ts
+++ b/src/schema/location.ts
@@ -47,6 +47,11 @@ export const LocationType = new GraphQLObjectType({
       type: new GraphQLList(DayScheduleType),
       resolve: ({ day_schedules }) => day_schedules,
     },
+    day_schedule_text: {
+      description:
+        "Alternate free text representation of a location's opening hours",
+      type: GraphQLString,
+    },
     displayDaySchedules: {
       type: new GraphQLList(FormattedDaySchedules.type),
       resolve: ({ day_schedules }) =>

--- a/src/schema/show.ts
+++ b/src/schema/show.ts
@@ -424,6 +424,10 @@ export const ShowType = new GraphQLObjectType({
       type: GraphQLBoolean,
       resolve: ({ is_reference }) => is_reference,
     },
+    is_local_discovery: {
+      description: "Is it an outsourced local discovery stub show?",
+      type: GraphQLBoolean,
+    },
     kind: {
       description: "Whether the show is in a fair, group or solo",
       type: GraphQLString,


### PR DESCRIPTION
This exposes the new fields from Gravity's api responses:

- `PartnerShow#is_local_discovery`
- `PartnerLocation#day_schedule_text`

<img width="1552" alt="mp" src="https://user-images.githubusercontent.com/140521/49182180-870f4880-f327-11e8-8c10-4db85af58321.png">
