### PR TITLE
[PartnerShow] Add saleArtworks connection

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -7538,28 +7538,23 @@ type Show implements Node {
 
   # The artworks featured in this show
   artworks(
-    # Number of artworks to return
-    size: Int = 25
-    published: Boolean = true
-    page: Int = 1
-    all: Boolean
-    for_sale: Boolean
-
     # List of artwork IDs to exclude from the response (irrespective of size)
     exclude: [String]
+    for_sale: Boolean
+    published: Boolean = true
+    all: Boolean
+    page: Int = 1
+
+    # Number of artworks to return
+    size: Int = 25
   ): [Artwork] @deprecated(reason: "Use artworks_connection instead")
 
   # The artworks featured in the show
   artworks_connection(
-    # Number of artworks to return
-    size: Int = 25
-    published: Boolean = true
-    page: Int = 1
-    all: Boolean
-    for_sale: Boolean
-
     # List of artwork IDs to exclude from the response (irrespective of size)
     exclude: [String]
+    for_sale: Boolean
+    published: Boolean = true
     after: String
     first: Int
     before: String

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1125,18 +1125,31 @@ type ArtworkContextPartnerShow implements Node {
   _id: String!
   cached: Int
   artists: [Artist]
-  artworks(
-    all: Boolean
 
+  # The artworks featured in the show
+  artworks(
     # List of artwork IDs to exclude from the response (irrespective of size)
     exclude: [String]
     for_sale: Boolean
     published: Boolean = true
+    all: Boolean
     page: Int = 1
 
     # Number of artworks to return
     size: Int = 25
   ): [Artwork]
+
+  # A connection of artworks featured in the show
+  artworksConnection(
+    # List of artwork IDs to exclude from the response (irrespective of size)
+    exclude: [String]
+    for_sale: Boolean
+    published: Boolean = true
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtworkConnection
   counts: PartnerShowCounts
   cover_image: Image
   created_at(
@@ -3796,18 +3809,31 @@ type HighlightedShow implements Node {
   _id: String!
   cached: Int
   artists: [Artist]
-  artworks(
-    all: Boolean
 
+  # The artworks featured in the show
+  artworks(
     # List of artwork IDs to exclude from the response (irrespective of size)
     exclude: [String]
     for_sale: Boolean
     published: Boolean = true
+    all: Boolean
     page: Int = 1
 
     # Number of artworks to return
     size: Int = 25
   ): [Artwork]
+
+  # A connection of artworks featured in the show
+  artworksConnection(
+    # List of artwork IDs to exclude from the response (irrespective of size)
+    exclude: [String]
+    for_sale: Boolean
+    published: Boolean = true
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtworkConnection
   counts: PartnerShowCounts
   cover_image: Image
   created_at(
@@ -6137,18 +6163,31 @@ type PartnerShow implements Node {
   _id: String!
   cached: Int
   artists: [Artist]
-  artworks(
-    all: Boolean
 
+  # The artworks featured in the show
+  artworks(
     # List of artwork IDs to exclude from the response (irrespective of size)
     exclude: [String]
     for_sale: Boolean
     published: Boolean = true
+    all: Boolean
     page: Int = 1
 
     # Number of artworks to return
     size: Int = 25
   ): [Artwork]
+
+  # A connection of artworks featured in the show
+  artworksConnection(
+    # List of artwork IDs to exclude from the response (irrespective of size)
+    exclude: [String]
+    for_sale: Boolean
+    published: Boolean = true
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtworkConnection
   counts: PartnerShowCounts
   cover_image: Image
   created_at(

--- a/src/schema/__tests__/partner_show.test.js
+++ b/src/schema/__tests__/partner_show.test.js
@@ -290,7 +290,6 @@ describe("PartnerShow type", () => {
             headers: { "x-total-count": artworksResponse.length },
           }),
         showLoader: () => Promise.resolve(showData),
-        totalViaLoader: () => Promise.resolve(artworksResponse.length),
       }
     })
 

--- a/src/schema/__tests__/partner_show.test.js
+++ b/src/schema/__tests__/partner_show.test.js
@@ -267,4 +267,125 @@ describe("PartnerShow type", () => {
       })
     })
   })
+
+  describe("#artworksConnection", () => {
+    let artworksResponse
+
+    beforeEach(() => {
+      artworksResponse = [
+        {
+          id: "michelangelo-pistoletto-untitled-12",
+        },
+        {
+          id: "lucio-fontana-concetto-spaziale-attese-139",
+        },
+        {
+          id: "pier-paolo-calzolari-untitled-146",
+        },
+      ]
+      rootValue = {
+        partnerShowArtworksLoader: () =>
+          Promise.resolve({
+            body: artworksResponse,
+            headers: { "x-total-count": artworksResponse.length },
+          }),
+        showLoader: () => Promise.resolve(showData),
+        totalViaLoader: () => Promise.resolve(artworksResponse.length),
+      }
+    })
+
+    it("returns artworks", async () => {
+      const query = `
+        {
+          partner_show(id: "cardi-gallery-cardi-gallery-at-art-basel-miami-beach-2018") {
+            artworksConnection(first: 3) {
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const data = await runQuery(query, rootValue)
+
+      expect(data).toEqual({
+        partner_show: {
+          artworksConnection: {
+            edges: [
+              {
+                node: {
+                  id: "michelangelo-pistoletto-untitled-12",
+                },
+              },
+              {
+                node: {
+                  id: "lucio-fontana-concetto-spaziale-attese-139",
+                },
+              },
+              {
+                node: {
+                  id: "pier-paolo-calzolari-untitled-146",
+                },
+              },
+            ],
+          },
+        },
+      })
+    })
+
+    it("returns hasNextPage=true when first is below total", async () => {
+      const query = `
+        {
+          partner_show(id: "cardi-gallery-cardi-gallery-at-art-basel-miami-beach-2018") {
+            artworksConnection(first: 1) {
+              pageInfo {
+                hasNextPage
+              }
+            }
+          }
+        }
+      `
+
+      const data = await runQuery(query, rootValue)
+
+      expect(data).toEqual({
+        partner_show: {
+          artworksConnection: {
+            pageInfo: {
+              hasNextPage: true,
+            },
+          },
+        },
+      })
+    })
+
+    it("returns hasNextPage=false when first is above total", async () => {
+      const query = `
+        {
+          partner_show(id: "cardi-gallery-cardi-gallery-at-art-basel-miami-beach-2018") {
+            artworksConnection(first: 3) {
+              pageInfo {
+                hasNextPage
+              }
+            }
+          }
+        }
+      `
+
+      const data = await runQuery(query, rootValue)
+
+      expect(data).toEqual({
+        partner_show: {
+          artworksConnection: {
+            pageInfo: {
+              hasNextPage: false,
+            },
+          },
+        },
+      })
+    })
+  })
 })

--- a/src/schema/__tests__/show.test.js
+++ b/src/schema/__tests__/show.test.js
@@ -767,4 +767,124 @@ describe("Show type", () => {
       })
     })
   })
+
+  describe("#artworks_connection", () => {
+    let artworksResponse
+
+    beforeEach(() => {
+      artworksResponse = [
+        {
+          id: "michelangelo-pistoletto-untitled-12",
+        },
+        {
+          id: "lucio-fontana-concetto-spaziale-attese-139",
+        },
+        {
+          id: "pier-paolo-calzolari-untitled-146",
+        },
+      ]
+      rootValue = {
+        partnerShowArtworksLoader: () =>
+          Promise.resolve({
+            body: artworksResponse,
+            headers: { "x-total-count": artworksResponse.length },
+          }),
+        showLoader: () => Promise.resolve(showData),
+      }
+    })
+
+    it("returns artworks", async () => {
+      const query = `
+        {
+          show(id:"cardi-gallery-cardi-gallery-at-art-basel-miami-beach-2018") {
+            artworks_connection(first: 3) {
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const data = await runQuery(query, rootValue)
+
+      expect(data).toEqual({
+        show: {
+          artworks_connection: {
+            edges: [
+              {
+                node: {
+                  id: "michelangelo-pistoletto-untitled-12",
+                },
+              },
+              {
+                node: {
+                  id: "lucio-fontana-concetto-spaziale-attese-139",
+                },
+              },
+              {
+                node: {
+                  id: "pier-paolo-calzolari-untitled-146",
+                },
+              },
+            ],
+          },
+        },
+      })
+    })
+
+    it("returns hasNextPage=true when first is below total", async () => {
+      const query = `
+        {
+          show(id:"cardi-gallery-cardi-gallery-at-art-basel-miami-beach-2018") {
+            artworks_connection(first: 1) {
+              pageInfo {
+                hasNextPage
+              }
+            }
+          }
+        }
+      `
+
+      const data = await runQuery(query, rootValue)
+
+      expect(data).toEqual({
+        show: {
+          artworks_connection: {
+            pageInfo: {
+              hasNextPage: true,
+            },
+          },
+        },
+      })
+    })
+
+    it("returns hasNextPage=false when first is above total", async () => {
+      const query = `
+        {
+          show(id:"cardi-gallery-cardi-gallery-at-art-basel-miami-beach-2018") {
+            artworks_connection(first: 3) {
+              pageInfo {
+                hasNextPage
+              }
+            }
+          }
+        }
+      `
+
+      const data = await runQuery(query, rootValue)
+
+      expect(data).toEqual({
+        show: {
+          artworks_connection: {
+            pageInfo: {
+              hasNextPage: false,
+            },
+          },
+        },
+      })
+    })
+  })
 })

--- a/src/schema/partner_show.ts
+++ b/src/schema/partner_show.ts
@@ -56,7 +56,6 @@ const artworksArgs = {
 
 const PartnerShowType = new GraphQLObjectType({
   name: "PartnerShow",
-  // FIXME: Why is this field not in the type?
   // @ts-ignore
   deprecationReason: "Prefer to use Show schema",
   interfaces: [NodeInterface],

--- a/src/schema/partner_show.ts
+++ b/src/schema/partner_show.ts
@@ -1,6 +1,10 @@
 import moment from "moment"
-import { isExisty, exclude } from "lib/helpers"
-import { find } from "lodash"
+import {
+  isExisty,
+  exclude,
+  convertConnectionArgsToGravityArgs,
+} from "lib/helpers"
+import { find, flatten } from "lodash"
 import HTTPError from "lib/http_error"
 import numeral from "./fields/numeral"
 import { exhibitionPeriod, exhibitionStatus } from "lib/date"
@@ -10,11 +14,12 @@ import { markdown } from "./fields/markdown"
 import Artist from "./artist"
 import Partner from "./partner"
 import Fair from "./fair"
-import Artwork from "./artwork"
+import Artwork, { artworkConnection } from "./artwork"
 import Location from "./location"
 import Image, { getDefault } from "./image"
 import PartnerShowEventType from "./partner_show_event"
 import { GravityIDFields, NodeInterface } from "./object_identification"
+import { pageable } from "relay-cursor-paging"
 import {
   GraphQLObjectType,
   GraphQLString,
@@ -25,6 +30,7 @@ import {
 } from "graphql"
 import { allViaLoader } from "../lib/all"
 import { totalViaLoader } from "lib/total"
+import { connectionFromArraySlice } from "graphql-relay"
 
 const kind = ({ artists, fair }) => {
   if (isExisty(fair)) return "fair"
@@ -32,8 +38,26 @@ const kind = ({ artists, fair }) => {
   if (artists.length === 1) return "solo"
 }
 
+const artworksArgs = {
+  exclude: {
+    type: new GraphQLList(GraphQLString),
+    description:
+      "List of artwork IDs to exclude from the response (irrespective of size)",
+  },
+  for_sale: {
+    type: GraphQLBoolean,
+    default: false,
+  },
+  published: {
+    type: GraphQLBoolean,
+    defaultValue: true,
+  },
+}
+
 const PartnerShowType = new GraphQLObjectType({
   name: "PartnerShow",
+  // FIXME: Why is this field not in the type?
+  // @ts-ignore
   deprecationReason: "Prefer to use Show schema",
   interfaces: [NodeInterface],
   fields: () => ({
@@ -45,23 +69,12 @@ const PartnerShowType = new GraphQLObjectType({
     },
     artworks: {
       type: new GraphQLList(Artwork.type),
+      description: "The artworks featured in the show",
       args: {
+        ...artworksArgs,
         all: {
           type: GraphQLBoolean,
           default: false,
-        },
-        exclude: {
-          type: new GraphQLList(GraphQLString),
-          description:
-            "List of artwork IDs to exclude from the response (irrespective of size)",
-        },
-        for_sale: {
-          type: GraphQLBoolean,
-          default: false,
-        },
-        published: {
-          type: GraphQLBoolean,
-          defaultValue: true,
         },
         page: {
           type: GraphQLInt,
@@ -76,7 +89,7 @@ const PartnerShowType = new GraphQLObjectType({
       resolve: (
         show,
         options,
-        request,
+        _request,
         { rootValue: { partnerShowArtworksLoader } }
       ) => {
         let fetch = null
@@ -93,7 +106,54 @@ const PartnerShowType = new GraphQLObjectType({
           ).then(({ body }) => body)
         }
 
+        // @ts-ignore
+        // FIXME: Update with Gravity param when ready
         return fetch.then(exclude(options.exclude, "id"))
+      },
+    },
+    artworksConnection: {
+      description: "A connection of artworks featured in the show",
+      type: artworkConnection,
+      args: pageable(artworksArgs),
+      resolve: (
+        show,
+        options,
+        _request,
+        { rootValue: { partnerShowArtworksLoader } }
+      ) => {
+        const loaderOptions = {
+          partner_id: show.partner.id,
+          show_id: show.id,
+        }
+        const { page, size, offset } = convertConnectionArgsToGravityArgs(
+          options
+        )
+
+        interface GravityArgs {
+          exclude_ids?: string[]
+          page: number
+          size: number
+          total_count: boolean
+        }
+
+        const gravityArgs: GravityArgs = {
+          page,
+          size,
+          total_count: true,
+        }
+
+        if (options.exclude) {
+          gravityArgs.exclude_ids = flatten([options.exclude])
+        }
+
+        return partnerShowArtworksLoader(loaderOptions, gravityArgs).then(
+          ({ body, headers }) => {
+            return connectionFromArraySlice(body, options, {
+              arrayLength: headers["x-total-count"],
+              sliceStart: offset,
+            })
+          }
+        )
       },
     },
     counts: {
@@ -111,7 +171,7 @@ const PartnerShowType = new GraphQLObjectType({
             resolve: (
               { id, partner },
               options,
-              request,
+              _request,
               { rootValue: { partnerShowArtworksLoader } }
             ) => {
               return totalViaLoader(
@@ -132,8 +192,8 @@ const PartnerShowType = new GraphQLObjectType({
       type: Image.type,
       resolve: (
         { id, partner, image_versions, image_url },
-        options,
-        request,
+        _options,
+        _request,
         { rootValue: { partnerShowArtworksLoader } }
       ) => {
         if (image_versions && image_versions.length && image_url) {
@@ -168,8 +228,8 @@ const PartnerShowType = new GraphQLObjectType({
       type: new GraphQLList(PartnerShowEventType),
       resolve: (
         { partner, id },
-        options,
-        request,
+        _options,
+        _request,
         { rootValue: { partnerShowLoader } }
       ) =>
         // Gravity redirects from /api/v1/show/:id => /api/v1/partner/:partner_id/show/:show_id
@@ -210,7 +270,7 @@ const PartnerShowType = new GraphQLObjectType({
       resolve: (
         { id },
         options,
-        request,
+        _request,
         { rootValue: { partnerShowImagesLoader } }
       ) => {
         return partnerShowImagesLoader(id, options).then(Image.resolve)
@@ -245,8 +305,8 @@ const PartnerShowType = new GraphQLObjectType({
       type: GraphQLString,
       resolve: (
         show,
-        options,
-        request,
+        _options,
+        _request,
         { rootValue: { partnerShowLoader } }
       ) => {
         if (show.artists) return kind(show)
@@ -264,8 +324,8 @@ const PartnerShowType = new GraphQLObjectType({
       type: Image.type,
       resolve: (
         { id, partner, image_versions, image_url },
-        options,
-        request,
+        _options,
+        _request,
         { rootValue: { partnerShowArtworksLoader } }
       ) => {
         if (image_versions && image_versions.length && image_url) {
@@ -325,7 +385,7 @@ const PartnerShow = {
       description: "The slug or ID of the PartnerShow",
     },
   },
-  resolve: (root, { id }, request, { rootValue: { showLoader } }) => {
+  resolve: (_root, { id }, _request, { rootValue: { showLoader } }) => {
     return showLoader(id).then(show => {
       if (!show.displayable) {
         return new HTTPError("Show Not Found", 404)

--- a/src/schema/show.ts
+++ b/src/schema/show.ts
@@ -34,7 +34,7 @@ import {
 } from "graphql"
 import { allViaLoader } from "../lib/all"
 import { totalViaLoader } from "lib/total"
-import { find } from "lodash"
+import { find, flatten } from "lodash"
 
 import PartnerShowSorts from "./sorts/partner_show_sorts"
 import EventStatus from "./input_fields/event_status"
@@ -58,31 +58,18 @@ const kind = ({ artists, fair, artists_without_artworks, group }) => {
 }
 
 const artworksArgs = {
-  size: {
-    type: GraphQLInt,
-    description: "Number of artworks to return",
-    defaultValue: 25,
-  },
-  published: {
-    type: GraphQLBoolean,
-    defaultValue: true,
-  },
-  page: {
-    type: GraphQLInt,
-    defaultValue: 1,
-  },
-  all: {
-    type: GraphQLBoolean,
-    default: false,
+  exclude: {
+    type: new GraphQLList(GraphQLString),
+    description:
+      "List of artwork IDs to exclude from the response (irrespective of size)",
   },
   for_sale: {
     type: GraphQLBoolean,
     default: false,
   },
-  exclude: {
-    type: new GraphQLList(GraphQLString),
-    description:
-      "List of artwork IDs to exclude from the response (irrespective of size)",
+  published: {
+    type: GraphQLBoolean,
+    defaultValue: true,
   },
 }
 
@@ -103,7 +90,22 @@ export const ShowType = new GraphQLObjectType({
       description: "The artworks featured in this show",
       deprecationReason: "Use artworks_connection instead",
       type: new GraphQLList(Artwork.type),
-      args: artworksArgs,
+      args: {
+        ...artworksArgs,
+        all: {
+          type: GraphQLBoolean,
+          default: false,
+        },
+        page: {
+          type: GraphQLInt,
+          defaultValue: 1,
+        },
+        size: {
+          type: GraphQLInt,
+          description: "Number of artworks to return",
+          defaultValue: 25,
+        },
+      },
       resolve: (
         show,
         options,
@@ -148,24 +150,35 @@ export const ShowType = new GraphQLObjectType({
           partner_id: show.partner.id,
           show_id: show.id,
         }
-        const gravityOptions = convertConnectionArgsToGravityArgs(options)
-        delete gravityOptions.page
+        const { page, size, offset } = convertConnectionArgsToGravityArgs(
+          options
+        )
 
-        return Promise.all([
-          totalViaLoader(
-            partnerShowArtworksLoader,
-            loaderOptions,
-            Object.assign({}, gravityOptions, {
-              size: 0,
+        interface GravityArgs {
+          exclude_ids?: string[]
+          page: number
+          size: number
+          total_count: boolean
+        }
+
+        const gravityArgs: GravityArgs = {
+          page,
+          size,
+          total_count: true,
+        }
+
+        if (options.exclude) {
+          gravityArgs.exclude_ids = flatten([options.exclude])
+        }
+
+        return partnerShowArtworksLoader(loaderOptions, gravityArgs).then(
+          ({ body, headers }) => {
+            return connectionFromArraySlice(body, options, {
+              arrayLength: headers["x-total-count"],
+              sliceStart: offset,
             })
-          ),
-          partnerShowArtworksLoader(loaderOptions, gravityOptions),
-        ]).then(([count, { body }]) => {
-          return connectionFromArraySlice(body, options, {
-            arrayLength: count,
-            sliceStart: gravityOptions.offset,
-          })
-        })
+          }
+        )
       },
     },
     artists_without_artworks: {


### PR DESCRIPTION
Adds a new `saleArtworks` connection to `PartnerShows` and converts the file to TypeScript. 

Related: https://github.com/artsy/gravity/pull/12027

```gql
{
  partner_show(id: "cardi-gallery-cardi-gallery-at-art-basel-miami-beach-2018") {
    artworksConnection(first: 2) {
      pageInfo {
        hasNextPage
      }
      edges {
        node {
          id
        }
      }
    }
  }
}
```

```json
{
  "data": {
    "partner_show": {
      "artworksConnection": {
        "pageInfo": {
          "hasNextPage": true
        },
        "edges": [
          {
            "node": {
              "id": "michelangelo-pistoletto-untitled-12"
            }
          },
          {
            "node": {
              "id": "lucio-fontana-concetto-spaziale-attese-139"
            }
          }
        ]
      }
    },
  }
}
```