### PR TITLE
[Partner] Add artworksConnection field

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+src/lib/loaders/loaders_without_authentication/gravity.ts
+src/lib/loaders/loaders_with_authentication/gravity.ts

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,7 @@
     "schema": "${workspaceRoot}/schema",
     "test": "${workspaceRoot}/test"
   },
+  "typescript.tsdk": "./node_modules/typescript/lib",
   "cSpell.words": [
     "Ecommerce",
     "Refetch",

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -5923,11 +5923,22 @@ type Partner implements Node {
   _id: String!
   cached: Int
   artworks(
-    size: Int
     for_sale: Boolean
     sort: ArtworkSorts
     exclude: [String]
+    size: Int
   ): [Artwork]
+
+  # A connection of artworks from a Partner.
+  artworksConnection(
+    for_sale: Boolean
+    sort: ArtworkSorts
+    exclude: [String]
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtworkConnection
   categories: [Category]
   collecting_institution: String
   contact_message: String

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -6,186 +6,74 @@ import trackedEntityLoaderFactory from "lib/loaders/loaders_with_authentication/
 export default (accessToken, userID, opts) => {
   const gravityAccessTokenLoader = () => Promise.resolve(accessToken)
   const { gravityLoaderWithAuthenticationFactory } = factories(opts)
-  const gravityLoader = gravityLoaderWithAuthenticationFactory(
-    gravityAccessTokenLoader
-  )
+  const gravityLoader = gravityLoaderWithAuthenticationFactory(gravityAccessTokenLoader)
 
   return {
     authenticatedArtworkLoader: gravityLoader(id => `artwork/${id}`),
-    authenticatedArtworkVersionLoader: gravityLoader(
-      id => `artwork_version/${id}`
-    ),
-    collectionLoader: gravityLoader(id => `collection/${id}`, {
-      user_id: userID,
-    }),
-    collectionArtworksLoader: gravityLoader(
-      id => `collection/${id}/artworks`,
-      { user_id: userID },
-      { headers: true }
-    ),
+    authenticatedArtworkVersionLoader: gravityLoader(id => `artwork_version/${id}`),
+    collectionArtworksLoader: gravityLoader(id => `collection/${id}/artworks`, { user_id: userID }, { headers: true }),
+    collectionLoader: gravityLoader(id => `collection/${id}`, { user_id: userID }),
     collectorProfileLoader: gravityLoader("me/collector_profile"),
-    creditCardLoader: gravityLoader(id => `credit_card/${id}`),
     createBidderLoader: gravityLoader("bidder", {}, { method: "POST" }),
-    createCreditCardLoader: gravityLoader(
-      "me/credit_cards",
-      {},
-      { method: "POST" }
-    ),
-    meCreditCardsLoader: gravityLoader(
-      "me/credit_cards",
-      {},
-      { headers: true }
-    ),
-    deleteCreditCardLoader: gravityLoader(
-      id => `me/credit_card/${id}`,
-      {},
-      { method: "DELETE" }
-    ),
-    followGeneLoader: gravityLoader("me/follow/gene", {}, { method: "POST" }),
-    followedGeneLoader: trackedEntityLoaderFactory(
-      gravityLoader("me/follow/genes"),
-      "genes",
-      "is_followed",
-      "gene"
-    ),
+    createBidderPositionLoader: gravityLoader("me/bidder_position", {}, { method: "POST" }),
+    createCreditCardLoader: gravityLoader("me/credit_cards", {}, { method: "POST" }),
+    creditCardLoader: gravityLoader(id => `credit_card/${id}`),
+    deleteArtworkLoader: gravityLoader(id => `collection/saved-artwork/artwork/${id}`, {}, { method: "DELETE" }),
+    deleteCreditCardLoader: gravityLoader(id => `me/credit_card/${id}`, {}, { method: "DELETE" }),
+    endSaleLoader: gravityLoader(id => `sale/${id}/end_sale`, {}, { method: "PUT" }),
+    filterArtworksLoader: gravityLoader("filter/artworks"),
+    followArtistLoader: gravityLoader("me/follow/artist", {}, { method: "POST" }),
+    followedArtistsArtworksLoader: gravityLoader("me/follow/artists/artworks", {}, { headers: true }),
+    followedArtistsLoader: gravityLoader("me/follow/artists", {}, { headers: true }),
     followedArtistLoader: trackedEntityLoaderFactory(
       gravityLoader("me/follow/artists"),
-      "artists",
-      "is_followed",
-      "artist"
-    ),
-    followedArtistsLoader: gravityLoader(
-      "me/follow/artists",
-      {},
-      { headers: true }
-    ),
-    followedArtistsArtworksLoader: gravityLoader(
-      "me/follow/artists/artworks",
-      {},
-      { headers: true }
-    ),
-    followedProfilesArtworksLoader: gravityLoader(
-      "me/follow/profiles/artworks",
-      {},
-      { headers: true }
-    ),
-    followedGenesLoader: gravityLoader(
-      "me/follow/genes",
-      {},
-      { headers: true }
-    ),
+        "artists",
+        "is_followed",
+        "artist"
+      ),
+    followedGeneLoader: trackedEntityLoaderFactory(gravityLoader("me/follow/genes"), "genes", "is_followed", "gene"),
+    followedGenesLoader: gravityLoader("me/follow/genes", {}, { headers: true }),
+    followedProfilesArtworksLoader: gravityLoader("me/follow/profiles/artworks", {}, { headers: true }),
+    followGeneLoader: gravityLoader("me/follow/gene", {}, { method: "POST" }),
+    followProfileLoader: gravityLoader("me/follow/profile", {}, { method: "POST" }),
     followedProfileLoader: trackedEntityLoaderFactory(
       gravityLoader("me/follow/profiles"),
-      "profiles",
-      "is_followed",
-      "profile"
-    ),
+        "profiles",
+        "is_followed",
+        "profile"
+      ),
     homepageModulesLoader: gravityLoader("me/modules"),
-    homepageSuggestedArtworksLoader: gravityLoader(
-      "me/suggested/artworks/homepage"
-    ),
-    inquiryRequestsLoader: gravityLoader(
-      "me/inquiry_requests",
-      {},
-      { headers: true }
-    ),
+    homepageSuggestedArtworksLoader: gravityLoader("me/suggested/artworks/homepage"),
+    inquiryRequestsLoader: gravityLoader("me/inquiry_requests", {}, { headers: true }),
     lotStandingLoader: gravityLoader("me/lot_standings"),
-    meLoader: gravityLoader("me"),
-    meBiddersLoader: gravityLoader("me/bidders"),
+    meBidderPositionLoader: gravityLoader(({ id }) => `me/bidder_position/${id}/`, {}, { headers: true }),
     meBidderPositionsLoader: gravityLoader("me/bidder_positions"),
-    meBidderPositionLoader: gravityLoader(
-      ({ id }) => `me/bidder_position/${id}/`,
-      {},
-      { headers: true }
-    ),
-    createBidderPositionLoader: gravityLoader(
-      "me/bidder_position",
-      {},
-      { method: "POST" }
-    ),
+    meBiddersLoader: gravityLoader("me/bidders"),
+    meCreditCardsLoader: gravityLoader("me/credit_cards", {}, { headers: true }),
+    meLoader: gravityLoader("me"),
     mePartnersLoader: gravityLoader("me/partners"),
     notificationsFeedLoader: gravityLoader("me/notifications/feed"),
     popularArtistsLoader: gravityLoader("artists/popular"),
+    recordArtworkViewLoader: gravityLoader("me/recently_viewed_artworks", {}, { method: "POST" }),
+    saleArtworksAllLoader: gravityLoader("sale_artworks", {}, { headers: true }),
+    saleArtworksFilterLoader: gravityLoader("filter/sale_artworks"),
+    saleArtworksLoader: gravityLoader(id => `sale/${id}/sale_artworks`, {}, { headers: true }),
+    saveArtworkLoader: gravityLoader(id => `collection/saved-artwork/artwork/${id}`, {}, { method: "POST" }),
     savedArtworkLoader: trackedEntityLoaderFactory(
       gravityLoader("collection/saved-artwork/artworks", {
         user_id: userID,
         private: true,
       }),
-      "artworks",
-      "is_saved"
-    ),
-    saleArtworksLoader: gravityLoader(
-      id => `sale/${id}/sale_artworks`,
-      {},
-      { headers: true }
-    ),
-    endSaleLoader: gravityLoader(
-      id => `sale/${id}/end_sale`,
-      {},
-      { method: "PUT" }
-    ),
-    savedArtworksLoader: gravityLoader("collection/saved-artwork/artworks", {
-      user_id: userID,
-      private: true,
-    }),
-    filterArtworksLoader: gravityLoader("filter/artworks"),
-    saleArtworksAllLoader: gravityLoader(
-      "sale_artworks",
-      {},
-      { headers: true }
-    ),
-    saleArtworksFilterLoader: gravityLoader("filter/sale_artworks"),
-    suggestedArtistsLoader: gravityLoader(
-      "me/suggested/artists",
-      {},
-      { headers: true }
-    ),
-    suggestedSimilarArtistsLoader: gravityLoader(
-      `user/${userID}/suggested/similar/artists`,
-      {},
-      { headers: true }
-    ),
-    updateCollectorProfileLoader: gravityLoader(
-      "me/collector_profile",
-      {},
-      { method: "PUT" }
-    ),
+        "artworks",
+        "is_saved"
+      ),
+    savedArtworksLoader: gravityLoader("collection/saved-artwork/artworks", { user_id: userID, private: true }),
+    suggestedArtistsLoader: gravityLoader("me/suggested/artists", {}, { headers: true }),
+    suggestedSimilarArtistsLoader: gravityLoader(`user/${userID}/suggested/similar/artists`, {}, { headers: true }),
+    unfollowArtistLoader: gravityLoader(id => `me/follow/artist/${id}`, {}, { method: "DELETE" }),
+    unfollowProfileLoader: gravityLoader(id => `me/follow/profile/${id}`, {}, { method: "DELETE" }),
+    updateCollectorProfileLoader: gravityLoader("me/collector_profile", {}, { method: "PUT" }),
     updateMeLoader: gravityLoader("me", {}, { method: "PUT" }),
-    recordArtworkViewLoader: gravityLoader(
-      "me/recently_viewed_artworks",
-      {},
-      { method: "POST" }
-    ),
-    followArtistLoader: gravityLoader(
-      "me/follow/artist",
-      {},
-      { method: "POST" }
-    ),
-    unfollowArtistLoader: gravityLoader(
-      id => `me/follow/artist/${id}`,
-      {},
-      { method: "DELETE" }
-    ),
-    followProfileLoader: gravityLoader(
-      "me/follow/profile",
-      {},
-      { method: "POST" }
-    ),
-    unfollowProfileLoader: gravityLoader(
-      id => `me/follow/profile/${id}`,
-      {},
-      { method: "DELETE" }
-    ),
-    saveArtworkLoader: gravityLoader(
-      id => `collection/saved-artwork/artwork/${id}`,
-      {},
-      { method: "POST" }
-    ),
-    deleteArtworkLoader: gravityLoader(
-      id => `collection/saved-artwork/artwork/${id}`,
-      {},
-      { method: "DELETE" }
-    ),
     usersLoader: gravityLoader("users"),
   }
 }

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -9,112 +9,66 @@ export default opts => {
   const gravityUncachedLoader = uncachedLoaderFactory(gravity, "gravity")
 
   return {
-    artworksLoader: gravityLoader("artworks"),
-    artworkImageLoader: gravityLoader(
-      ({ artwork_id, image_id }) => `artwork/${artwork_id}/image/${image_id}`
-    ),
     artistArtworksLoader: gravityLoader(id => `artist/${id}/artworks`),
     artistGenesLoader: gravityLoader(({ id }) => `artist/${id}/genome/genes`),
     artistLoader: gravityLoader(id => `artist/${id}`),
     artistsLoader: gravityLoader("artists"),
+    artworkImageLoader: gravityLoader(({ artwork_id, image_id }) => `artwork/${artwork_id}/image/${image_id}`),
     artworkLoader: gravityLoader(id => `artwork/${id}`),
+    artworksLoader: gravityLoader("artworks"),
+    fairBoothsLoader: gravityLoader(id => `fair/${id}/shows`, {}, { headers: true }),
     fairLoader: gravityLoader(id => `fair/${id}`),
-    fairBoothsLoader: gravityLoader(
-      id => `fair/${id}/shows`,
-      {},
-      { headers: true }
-    ),
     fairsLoader: gravityLoader("fairs"),
     filterArtworksLoader: gravityLoader("filter/artworks"),
-    genesLoader: gravityLoader("genes"),
     geneArtistsLoader: gravityLoader(id => `gene/${id}/artists`),
     geneFamiliesLoader: gravityLoader("gene_families"),
     geneLoader: gravityLoader(id => `gene/${id}`),
+    genesLoader: gravityLoader("genes"),
     heroUnitsLoader: gravityLoader("site_hero_units"),
     incrementsLoader: gravityLoader("increments"),
-    matchGeneLoader: gravityLoader("match/genes"),
     matchArtistsLoader: gravityLoader("match/artists"),
-    partnerArtistsForArtistLoader: gravityLoader(
-      id => `artist/${id}/partner_artists`
-    ),
-    partnerArtistsLoader: gravityLoader(
-      "partner_artists",
-      {},
-      { headers: true }
-    ),
-    partnerArtistLoader: gravityLoader(
-      ({ artist_id, partner_id }) => `partner/${partner_id}/artist/${artist_id}`
-    ),
-    partnerArtworksLoader: gravityLoader(id => `partner/${id}/artworks`),
+    matchGeneLoader: gravityLoader("match/genes"),
+    partnerArtistLoader: gravityLoader(({ artist_id, partner_id }) => `partner/${partner_id}/artist/${artist_id}`),
+    partnerArtistsForArtistLoader: gravityLoader(id => `artist/${id}/partner_artists`),
+    partnerArtistsLoader: gravityLoader("partner_artists", {}, { headers: true }),
+    partnerArtworksLoader: gravityLoader(id => `partner/${id}/artworks`, {}, { headers: true }),
     partnerCategoriesLoader: gravityLoader("partner_categories"),
     partnerCategoryLoader: gravityLoader(id => `partner_category/${id}`),
     partnerLoader: gravityLoader(id => `partner/${id}`),
     partnerLocationsLoader: gravityLoader(id => `partner/${id}/locations`),
-    partnerShowLoader: gravityLoader(
-      ({ partner_id, show_id }) => `partner/${partner_id}/show/${show_id}`
-    ),
-    partnerShowArtworksLoader: gravityLoader(
-      ({ partner_id, show_id }) =>
-        `partner/${partner_id}/show/${show_id}/artworks`,
-      {},
-      { headers: true }
-    ),
+    partnerShowArtworksLoader: gravityLoader(({ partner_id, show_id }) => `partner/${partner_id}/show/${show_id}/artworks`, {}, { headers: true }),
     partnerShowImagesLoader: gravityLoader(id => `partner_show/${id}/images`),
+    partnerShowLoader: gravityLoader(({ partner_id, show_id }) => `partner/${partner_id}/show/${show_id}`),
     partnersLoader: gravityLoader("partners"),
     popularArtistsLoader: gravityLoader(`artists/popular`),
     profileLoader: gravityLoader(id => `profile/${id}`),
     relatedArtworksLoader: gravityLoader("related/artworks"),
-    relatedLayersLoader: gravityLoader("related/layers"),
-    relatedLayerArtworksLoader: gravityLoader(
-      ({ type, id }) => `related/layer/${type}/${id}/artworks`
-    ),
-    relatedContemporaryArtistsLoader: gravityLoader(
-      "related/layer/contemporary/artists",
-      {},
-      { headers: true }
-    ),
+    relatedContemporaryArtistsLoader: gravityLoader("related/layer/contemporary/artists", {}, { headers: true }),
     relatedFairsLoader: gravityLoader("related/fairs"),
     relatedGenesLoader: gravityLoader("related/genes"),
-    relatedMainArtistsLoader: gravityLoader(
-      "related/layer/main/artists",
-      {},
-      { headers: true }
-    ),
+    relatedLayerArtworksLoader: gravityLoader(({ type, id }) => `related/layer/${type}/${id}/artworks`),
+    relatedLayersLoader: gravityLoader("related/layers"),
+    relatedMainArtistsLoader: gravityLoader("related/layer/main/artists", {}, { headers: true }),
     relatedSalesLoader: gravityLoader("related/sales"),
     relatedShowsLoader: gravityLoader("related/shows", {}, { headers: true }),
+    saleArtworkRootLoader: gravityUncachedLoader(id => `sale_artwork/${id}`, null),
+    saleArtworksFilterLoader: gravityLoader("filter/sale_artworks"),
+    saleArtworksLoader: gravityLoader(id => `sale/${id}/sale_artworks`, {}, { headers: true }),
+    saleArtworkLoader: gravityUncachedLoader(({ saleId, saleArtworkId }) => `sale/${saleId}/sale_artwork/${saleArtworkId}`, null),
     saleLoader: gravityLoader(id => `sale/${id}`),
     salesLoader: gravityLoader("sales"),
-    saleArtworkLoader: gravityUncachedLoader(
-      ({ saleId, saleArtworkId }) =>
-        `sale/${saleId}/sale_artwork/${saleArtworkId}`,
-      null
-    ),
-    saleArtworkRootLoader: gravityUncachedLoader(
-      id => `sale_artwork/${id}`,
-      null
-    ),
-    saleArtworksLoader: gravityLoader(
-      id => `sale/${id}/sale_artworks`,
-      {},
-      { headers: true }
-    ),
-    saleArtworksFilterLoader: gravityLoader("filter/sale_artworks"),
-    setLoader: gravityLoader(id => `set/${id}`),
     setItemsLoader: gravityLoader(id => `set/${id}/items`),
+    setLoader: gravityLoader(id => `set/${id}`),
     setsLoader: gravityLoader("sets"),
     showLoader: gravityLoader(id => `show/${id}`),
     showsLoader: gravityLoader("shows"),
     showsWithHeadersLoader: gravityLoader("shows", {}, { headers: true }),
     similarArtworksLoader: gravityLoader("related/artworks"),
-    similarGenesLoader: gravityLoader(
-      id => `gene/${id}/similar`,
-      {},
-      { headers: true }
-    ),
+    similarGenesLoader: gravityLoader(id => `gene/${id}/similar`, {}, { headers: true }),
     systemTimeLoader: gravityUncachedLoader("system/time", null),
     tagLoader: gravityLoader(id => `tag/${id}`),
     trendingArtistsLoader: gravityLoader("artists/trending"),
-    userByIDLoader: gravityLoader(id => `user/${id}`, {}, { method: "GET" }),
     userByEmailLoader: gravityLoader("user", {}, { method: "GET" }),
+    userByIDLoader: gravityLoader(id => `user/${id}`, {}, { method: "GET" }),
   }
 }

--- a/src/schema/__tests__/partner.test.js
+++ b/src/schema/__tests__/partner.test.js
@@ -3,11 +3,11 @@ import { runQuery } from "test/utils"
 import gql from "lib/gql"
 
 describe("Partner type", () => {
-  let partner = null
+  let partnerData = null
   let rootValue = null
 
   beforeEach(() => {
-    partner = {
+    partnerData = {
       id: "catty-partner",
       _id: "catty-partner",
       name: "Catty Partner",
@@ -24,8 +24,8 @@ describe("Partner type", () => {
     rootValue = {
       partnerLoader: sinon
         .stub()
-        .withArgs(partner.id)
-        .returns(Promise.resolve(partner)),
+        .withArgs(partnerData.id)
+        .returns(Promise.resolve(partnerData)),
     }
   })
 
@@ -54,6 +54,128 @@ describe("Partner type", () => {
               name: "Blue Chip",
             },
           ],
+        },
+      })
+    })
+  })
+
+  describe("#artworksConnection", () => {
+    let artworksResponse
+
+    beforeEach(() => {
+      artworksResponse = [
+        {
+          id: "cara-barer-iceberg",
+        },
+        {
+          id: "david-leventi-rezzonico",
+        },
+        {
+          id: "virginia-mak-hidden-nature-08",
+        },
+      ]
+      rootValue = {
+        partnerArtworksLoader: () =>
+          Promise.resolve({
+            body: artworksResponse,
+            headers: {
+              "x-total-count": artworksResponse.length,
+            },
+          }),
+        partnerLoader: () => Promise.resolve(partnerData),
+      }
+    })
+
+    it("returns artworks", async () => {
+      const query = `
+        {
+          partner(id:"bau-xi-gallery") {
+            artworksConnection(first:3) {
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const data = await runQuery(query, rootValue)
+
+      expect(data).toEqual({
+        partner: {
+          artworksConnection: {
+            edges: [
+              {
+                node: {
+                  id: "cara-barer-iceberg",
+                },
+              },
+              {
+                node: {
+                  id: "david-leventi-rezzonico",
+                },
+              },
+              {
+                node: {
+                  id: "virginia-mak-hidden-nature-08",
+                },
+              },
+            ],
+          },
+        },
+      })
+    })
+
+    it("returns hasNextPage=true when first is below total", async () => {
+      const query = `
+        {
+          partner(id:"bau-xi-gallery") {
+            artworksConnection(first:1) {
+              pageInfo {
+                hasNextPage
+              }
+            }
+          }
+        }
+      `
+
+      const data = await runQuery(query, rootValue)
+
+      expect(data).toEqual({
+        partner: {
+          artworksConnection: {
+            pageInfo: {
+              hasNextPage: true,
+            },
+          },
+        },
+      })
+    })
+
+    it("returns hasNextPage=false when first is above total", async () => {
+      const query = `
+        {
+          partner(id:"bau-xi-gallery") {
+            artworksConnection(first:3) {
+              pageInfo {
+                hasNextPage
+              }
+            }
+          }
+        }
+      `
+
+      const data = await runQuery(query, rootValue)
+
+      expect(data).toEqual({
+        partner: {
+          artworksConnection: {
+            pageInfo: {
+              hasNextPage: false,
+            },
+          },
         },
       })
     })

--- a/src/schema/ecommerce/initial_offer_mutation.ts
+++ b/src/schema/ecommerce/initial_offer_mutation.ts
@@ -9,6 +9,7 @@ import { moneyFieldToUnit } from "lib/moneyHelper"
 
 export const InitialOfferMutation = mutationWithClientMutationId({
   name: "InitialOffer",
+  // @ts-ignore
   deprecationReason: "Use AddInitialOfferToOrder instead.",
   description: "Deprecated.",
   inputFields: InitialOfferInputType.getFields(),


### PR DESCRIPTION
Adds a new `artworksConnection` field to `Partner`.

(Need to follow up with Gravity PR for `exclude`) 

```gql
{
  partner(id:"bau-xi-gallery") {
    artworksConnection(first:3) {
      pageInfo {
        hasNextPage
      }
      edges {
        node {
          id
        }
      }
    }
  }
}
```

```json
{
  "data": {
    "partner": {
      "artworksConnection": {
        "pageInfo": {
          "hasNextPage": true
        },
        "edges": [
          {
            "node": {
              "id": "cara-barer-iceberg"
            }
          },
          {
            "node": {
              "id": "david-leventi-rezzonico"
            }
          },
          {
            "node": {
              "id": "virginia-mak-hidden-nature-08"
            }
          }
        ]
      }
    },
  }
}
```