### PR TITLE
Add filtered artworks to Show, Fair

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3265,8 +3265,6 @@ type FilterArtworks implements Node {
 
   # Returns aggregation counts for the given filter query.
   aggregations: [ArtworksAggregationResults]
-
-  # This has been deprecated. Favour artwork connections that take filter arguments.
   artworks_connection(
     sort: String
     after: String
@@ -3274,6 +3272,9 @@ type FilterArtworks implements Node {
     before: String
     last: Int
   ): ArtworkConnection
+    @deprecated(
+      reason: "Use only for filtering over ElasticSearch-backed fields, otherwise favor artwork connections that take filter arguments."
+    )
   counts: FilterArtworksCounts
   followed_artists_total: Int
     @deprecated(reason: "Favor `favor counts.followed_artists`")

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1116,6 +1116,46 @@ type ArtworkContextFair {
 
   # The exhibitors with booths in this fair.
   exhibitors_grouped_by_name: [FairExhibitorsGroup]
+
+  # Artworks Elastic Search results
+  filteredArtworks(
+    acquireable: Boolean
+    aggregation_partner_cities: [String]
+    aggregations: [ArtworkAggregation]
+    artist_id: String
+    artist_ids: [String]
+    at_auction: Boolean
+    attribution_class: [String]
+    color: String
+    dimension_range: String
+    extra_aggregation_gene_ids: [String]
+    include_artworks_by_followed_artists: Boolean
+    include_medium_filter_in_aggregation: Boolean
+    inquireable_only: Boolean
+    for_sale: Boolean
+    gene_id: String
+    gene_ids: [String]
+    height: String
+    width: String
+
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
+
+    # A string from the list of allocations, or * to denote all mediums
+    medium: String
+    period: String
+    periods: [String]
+    major_periods: [String]
+    partner_id: ID
+    partner_cities: [String]
+    price_range: String
+    page: Int
+    sale_id: ID
+    size: Int
+    sort: String
+    tag_id: String
+    keyword: String
+  ): FilterArtworks
 }
 
 type ArtworkContextPartnerShow implements Node {
@@ -3150,6 +3190,46 @@ type Fair {
 
   # The exhibitors with booths in this fair.
   exhibitors_grouped_by_name: [FairExhibitorsGroup]
+
+  # Artworks Elastic Search results
+  filteredArtworks(
+    acquireable: Boolean
+    aggregation_partner_cities: [String]
+    aggregations: [ArtworkAggregation]
+    artist_id: String
+    artist_ids: [String]
+    at_auction: Boolean
+    attribution_class: [String]
+    color: String
+    dimension_range: String
+    extra_aggregation_gene_ids: [String]
+    include_artworks_by_followed_artists: Boolean
+    include_medium_filter_in_aggregation: Boolean
+    inquireable_only: Boolean
+    for_sale: Boolean
+    gene_id: String
+    gene_ids: [String]
+    height: String
+    width: String
+
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
+
+    # A string from the list of allocations, or * to denote all mediums
+    medium: String
+    period: String
+    periods: [String]
+    major_periods: [String]
+    partner_id: ID
+    partner_cities: [String]
+    price_range: String
+    page: Int
+    sale_id: ID
+    size: Int
+    sort: String
+    tag_id: String
+    keyword: String
+  ): FilterArtworks
 }
 
 type FairExhibitorsGroup {
@@ -4162,6 +4242,46 @@ type HomePageModuleContextFair {
 
   # The exhibitors with booths in this fair.
   exhibitors_grouped_by_name: [FairExhibitorsGroup]
+
+  # Artworks Elastic Search results
+  filteredArtworks(
+    acquireable: Boolean
+    aggregation_partner_cities: [String]
+    aggregations: [ArtworkAggregation]
+    artist_id: String
+    artist_ids: [String]
+    at_auction: Boolean
+    attribution_class: [String]
+    color: String
+    dimension_range: String
+    extra_aggregation_gene_ids: [String]
+    include_artworks_by_followed_artists: Boolean
+    include_medium_filter_in_aggregation: Boolean
+    inquireable_only: Boolean
+    for_sale: Boolean
+    gene_id: String
+    gene_ids: [String]
+    height: String
+    width: String
+
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
+
+    # A string from the list of allocations, or * to denote all mediums
+    medium: String
+    period: String
+    periods: [String]
+    major_periods: [String]
+    partner_id: ID
+    partner_cities: [String]
+    price_range: String
+    page: Int
+    sale_id: ID
+    size: Int
+    sort: String
+    tag_id: String
+    keyword: String
+  ): FilterArtworks
 }
 
 type HomePageModuleContextFollowArtists {
@@ -7681,6 +7801,46 @@ type Show implements Node {
 
   # If the show is in a Fair, then that fair
   fair: Fair
+
+  # Artworks Elastic Search results
+  filteredArtworks(
+    acquireable: Boolean
+    aggregation_partner_cities: [String]
+    aggregations: [ArtworkAggregation]
+    artist_id: String
+    artist_ids: [String]
+    at_auction: Boolean
+    attribution_class: [String]
+    color: String
+    dimension_range: String
+    extra_aggregation_gene_ids: [String]
+    include_artworks_by_followed_artists: Boolean
+    include_medium_filter_in_aggregation: Boolean
+    inquireable_only: Boolean
+    for_sale: Boolean
+    gene_id: String
+    gene_ids: [String]
+    height: String
+    width: String
+
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
+
+    # A string from the list of allocations, or * to denote all mediums
+    medium: String
+    period: String
+    periods: [String]
+    major_periods: [String]
+    partner_id: ID
+    partner_cities: [String]
+    price_range: String
+    page: Int
+    sale_id: ID
+    size: Int
+    sort: String
+    tag_id: String
+    keyword: String
+  ): FilterArtworks
 
   # A path to the show on Artsy
   href: String

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3272,9 +3272,6 @@ type FilterArtworks implements Node {
     before: String
     last: Int
   ): ArtworkConnection
-    @deprecated(
-      reason: "Use only for filtering over ElasticSearch-backed fields, otherwise favor artwork connections that take filter arguments."
-    )
   counts: FilterArtworksCounts
   followed_artists_total: Int
     @deprecated(reason: "Favor `favor counts.followed_artists`")

--- a/src/schema/__tests__/show.test.js
+++ b/src/schema/__tests__/show.test.js
@@ -887,4 +887,61 @@ describe("Show type", () => {
       })
     })
   })
+  describe("#filteredArtworks", () => {
+    it("fetches FilterArtworks using the show id and partner id", async () => {
+      rootValue = {
+        ...rootValue,
+        filterArtworksLoader: jest.fn().mockReturnValue(
+          Promise.resolve({
+            hits: [
+              { id: "1", title: "foo-artwork" },
+              { id: "2", title: "bar-artwork" },
+            ],
+            aggregations: {
+              total: {
+                value: 303,
+              },
+            },
+          })
+        ),
+      }
+
+      const query = gql`
+        {
+          show(id: "new-museum-1-2015-triennial-surround-audience") {
+            filteredArtworks(aggregations: [TOTAL]) {
+              artworks_connection(first: 1) {
+                edges {
+                  node {
+                    id
+                    title
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+      const data = await runQuery(query, rootValue)
+      expect(rootValue.filterArtworksLoader).toHaveBeenCalledWith(
+        expect.objectContaining({
+          show_id: "new-museum-1-2015-triennial-surround-audience",
+          partner_id: "new-museum",
+        })
+      )
+      expect(data).toEqual({
+        show: {
+          filteredArtworks: {
+            artworks_connection: {
+              edges: [
+                {
+                  node: { id: "1", title: "foo-artwork" },
+                },
+              ],
+            },
+          },
+        },
+      })
+    })
+  })
 })

--- a/src/schema/fair.ts
+++ b/src/schema/fair.ts
@@ -10,6 +10,7 @@ import Image from "./image"
 import { showConnection } from "./show"
 import Location from "./location"
 import { GravityIDFields } from "./object_identification"
+import filterArtworks from "./filter_artworks"
 import {
   GraphQLObjectType,
   GraphQLID,
@@ -235,6 +236,7 @@ const FairType = new GraphQLObjectType({
         })
       },
     },
+    filteredArtworks: filterArtworks("fair_id"),
   }),
 })
 

--- a/src/schema/filter_artworks.ts
+++ b/src/schema/filter_artworks.ts
@@ -86,13 +86,10 @@ export const FilterArtworksType = new GraphQLObjectType({
     aggregations: ArtworkFilterAggregations,
     artworks_connection: {
       type: artworkConnection,
-      description:
-        "This has been deprecated. Favour artwork connections that take filter arguments.",
-
       // FIXME: Uncomment deprecationReason once https://github.com/apollographql/apollo-tooling/issues/805
       // has been addressed.
-      // deprecationReason:
-      //   "Favour artwork connections that take filter arguments.",
+      deprecationReason:
+        "Use only for filtering over ElasticSearch-backed fields, otherwise favor artwork connections that take filter arguments.",
       args: pageable({
         sort: {
           type: GraphQLString,

--- a/src/schema/filter_artworks.ts
+++ b/src/schema/filter_artworks.ts
@@ -88,8 +88,8 @@ export const FilterArtworksType = new GraphQLObjectType({
       type: artworkConnection,
       // FIXME: Uncomment deprecationReason once https://github.com/apollographql/apollo-tooling/issues/805
       // has been addressed.
-      deprecationReason:
-        "Use only for filtering over ElasticSearch-backed fields, otherwise favor artwork connections that take filter arguments.",
+      //deprecationReason:
+      //  "Use only for filtering over ElasticSearch-backed fields, otherwise favor artwork connections that take filter arguments.",
       args: pageable({
         sort: {
           type: GraphQLString,

--- a/src/schema/show.ts
+++ b/src/schema/show.ts
@@ -22,6 +22,7 @@ import Location from "./location"
 import Image, { getDefault } from "./image"
 import PartnerShowEventType from "./partner_show_event"
 import { connectionWithCursorInfo } from "schema/fields/pagination"
+import { filterArtworksWithParams } from "schema/filter_artworks"
 import { GravityIDFields, NodeInterface } from "./object_identification"
 import {
   GraphQLObjectType,
@@ -358,6 +359,10 @@ export const ShowType = new GraphQLObjectType({
       type: Fair.type,
       resolve: ({ fair }) => fair,
     },
+    filteredArtworks: filterArtworksWithParams(({ id, partner }) => ({
+      show_id: id,
+      partner_id: partner.id,
+    })),
     href: {
       description: "A path to the show on Artsy",
       type: GraphQLString,


### PR DESCRIPTION
The Show and Fair screens implement as part of Local Discovery contain an "All works" screen that allows filtering over all associated works: https://app.zeplin.io/project/5bef4c7dae2b6a3eb6a75f4a/screen/5bf32e8c072fb97e8f6b295f. This PR exposes `filteredArtworks` fields to both `Show` and `Fair` using the existing `filter_artworks` field type.

Implements [LD-72](https://artsyproduct.atlassian.net/browse/LD-72).

Note that a similar filtered view exists for fairs on the web: https://staging.artsy.net/ink-miami-2018/browse/artworks?for_sale=. This view is also ES backed, making use of Force's [`filter2`](https://github.com/artsy/force/blob/master/src/desktop/components/filter2/README.md) component.

<img width="1438" alt="screen shot 2018-12-04 at 12 17 40 pm" src="https://user-images.githubusercontent.com/5216744/49460149-ab9f7080-f7be-11e8-867d-81f5773ad368.png">
<img width="1440" alt="screen shot 2018-12-04 at 12 17 52 pm" src="https://user-images.githubusercontent.com/5216744/49460150-ac380700-f7be-11e8-8d05-ca0fa00be0d9.png">

