### PR TITLE
[FIXME] Comment out used deprecations

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -844,9 +844,6 @@ type Artwork implements Node & Sellable {
 
   # [DO NOT USE] Weekly pageview data (static).
   pageviews: Int
-    @deprecated(
-      reason: "Do not use! This is for an AB test and will be imminently deprecated."
-    )
   partner(
     # Use whatever is in the original response instead of making a request
     shallow: Boolean
@@ -1623,9 +1620,6 @@ type ArtworkItem implements Node & Sellable {
 
   # [DO NOT USE] Weekly pageview data (static).
   pageviews: Int
-    @deprecated(
-      reason: "Do not use! This is for an AB test and will be imminently deprecated."
-    )
   partner(
     # Use whatever is in the original response instead of making a request
     shallow: Boolean
@@ -3191,6 +3185,8 @@ type FilterArtworks implements Node {
 
   # Returns aggregation counts for the given filter query.
   aggregations: [ArtworksAggregationResults]
+
+  # This has been deprecated. Favour artwork connections that take filter arguments.
   artworks_connection(
     sort: String
     after: String
@@ -3198,9 +3194,6 @@ type FilterArtworks implements Node {
     before: String
     last: Int
   ): ArtworkConnection
-    @deprecated(
-      reason: "Favour artwork connections that take filter arguments."
-    )
   counts: FilterArtworksCounts
   followed_artists_total: Int
     @deprecated(reason: "Favor `favor counts.followed_artists`")

--- a/src/schema/artwork/index.ts
+++ b/src/schema/artwork/index.ts
@@ -507,8 +507,10 @@ export const artworkFields = () => {
     pageviews: {
       type: GraphQLInt,
       description: "[DO NOT USE] Weekly pageview data (static).",
-      deprecationReason:
-        "Do not use! This is for an AB test and will be imminently deprecated.",
+      // FIXME: Uncomment deprecationReason once https://github.com/apollographql/apollo-tooling/issues/805
+      // has been addressed.
+      // deprecationReason:
+      //   "Do not use! This is for an AB test and will be imminently deprecated.",
       resolve: ({ _id }) => artworkPageviews[_id],
     },
     partner: {

--- a/src/schema/filter_artworks.ts
+++ b/src/schema/filter_artworks.ts
@@ -86,8 +86,13 @@ export const FilterArtworksType = new GraphQLObjectType({
     aggregations: ArtworkFilterAggregations,
     artworks_connection: {
       type: artworkConnection,
-      deprecationReason:
-        "Favour artwork connections that take filter arguments.",
+      description:
+        "This has been deprecated. Favour artwork connections that take filter arguments.",
+
+      // FIXME: Uncomment deprecationReason once https://github.com/apollographql/apollo-tooling/issues/805
+      // has been addressed.
+      // deprecationReason:
+      //   "Favour artwork connections that take filter arguments.",
       args: pageable({
         sort: {
           type: GraphQLString,


### PR DESCRIPTION
Comments out two currently-used deprecations until https://github.com/apollographql/apollo-tooling/issues/805 is addressed. (Deprecation notice has been moved to `description` field.)

<img width="653" alt="screen shot 2018-12-05 at 6 55 02 am" src="https://user-images.githubusercontent.com/236943/49528516-eb229700-f868-11e8-8899-0423cd664899.png">
