### PR TITLE
Expose stub shows for local discovery

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -2325,6 +2325,12 @@ type City {
   shows(
     sort: PartnerShowSorts
     status: EventStatus
+
+    # Whether to include only displayable shows
+    displayable: Boolean = true
+
+    # Whether to include local discovery stubs as well as displayable shows
+    discoverable: Boolean
     after: String
     first: Int
     before: String

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -2326,9 +2326,6 @@ type City {
     sort: PartnerShowSorts
     status: EventStatus
 
-    # Whether to include only displayable shows
-    displayable: Boolean = true
-
     # Whether to include local discovery stubs as well as displayable shows
     discoverable: Boolean
     after: String
@@ -7735,9 +7732,6 @@ type Show implements Node {
   nearbyShows(
     sort: PartnerShowSorts
     status: EventStatus
-
-    # Whether to include only displayable shows
-    displayable: Boolean = true
 
     # Whether to include local discovery stubs as well as displayable shows
     discoverable: Boolean

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -7729,6 +7729,12 @@ type Show implements Node {
   nearbyShows(
     sort: PartnerShowSorts
     status: EventStatus
+
+    # Whether to include only displayable shows
+    displayable: Boolean = true
+
+    # Whether to include local discovery stubs as well as displayable shows
+    discoverable: Boolean
     after: String
     first: Int
     before: String

--- a/src/schema/__tests__/city.test.ts
+++ b/src/schema/__tests__/city.test.ts
@@ -85,6 +85,7 @@ describe("City", () => {
       expect(mockShowsLoader).toHaveBeenCalledWith(
         expect.objectContaining({
           near: "38.5,-121.8",
+          discoverable: true,
         })
       )
     })

--- a/src/schema/__tests__/city.test.ts
+++ b/src/schema/__tests__/city.test.ts
@@ -44,50 +44,85 @@ describe("City", () => {
     )
   })
 
-  it("resolves nearby shows", () => {
-    const query = gql`
-      {
-        city(slug: "sacramende-ca-usa") {
-          name
-          shows(first: 1) {
-            edges {
-              node {
-                id
+  describe("shows", () => {
+    let query, rootValue, mockShows, mockShowsLoader
+
+    beforeEach(() => {
+      query = gql`
+        {
+          city(slug: "sacramende-ca-usa") {
+            name
+            shows(first: 1) {
+              edges {
+                node {
+                  id
+                }
               }
             }
           }
         }
-      }
-    `
+      `
 
-    const mockShows = [{ id: "first-show" }]
-    const mockShowsLoader = jest.fn(() =>
-      Promise.resolve({ body: mockShows, headers: { "x-total-count": 1 } })
-    )
-    const rootValue = {
-      showsWithHeadersLoader: mockShowsLoader,
-      accessToken: null,
-      userID: null,
-    }
-
-    return runQuery(query, rootValue).then(result => {
-      expect(result!.city).toEqual({
-        name: "Sacramende",
-        shows: {
-          edges: [
-            {
-              node: mockShows[0],
-            },
-          ],
-        },
-      })
-
-      expect(mockShowsLoader).toHaveBeenCalledWith(
-        expect.objectContaining({
-          near: "38.5,-121.8",
-          discoverable: true,
-        })
+      mockShows = [{ id: "first-show" }]
+      mockShowsLoader = jest.fn(() =>
+        Promise.resolve({ body: mockShows, headers: { "x-total-count": 1 } })
       )
+      rootValue = {
+        showsWithHeadersLoader: mockShowsLoader,
+        accessToken: null,
+        userID: null,
+      }
+    })
+
+    it("resolves nearby shows", () => {
+      return runQuery(query, rootValue).then(result => {
+        expect(result!.city).toEqual({
+          name: "Sacramende",
+          shows: {
+            edges: [
+              {
+                node: mockShows[0],
+              },
+            ],
+          },
+        })
+
+        expect(mockShowsLoader).toHaveBeenCalledWith(
+          expect.objectContaining({
+            near: "38.5,-121.8",
+          })
+        )
+      })
+    })
+
+    it("requests displayable shows, by default", async () => {
+      await runQuery(query, rootValue)
+      const gravityOptions = rootValue.showsWithHeadersLoader.mock.calls[0][0]
+
+      expect(gravityOptions).toMatchObject({ displayable: true })
+      expect(gravityOptions).not.toHaveProperty("discoverable")
+    })
+
+    it("can request all discoverable shows, optionally", async () => {
+      query = gql`
+        {
+          city(slug: "sacramende-ca-usa") {
+            name
+            shows(first: 1, discoverable: true) {
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+          }
+        }
+      `
+      await runQuery(query, rootValue)
+      const gravityOptions = rootValue.showsWithHeadersLoader.mock.calls[0][0]
+
+      expect(gravityOptions).toMatchObject({ discoverable: true })
+      expect(gravityOptions).not.toHaveProperty("displayable")
     })
   })
 

--- a/src/schema/__tests__/show.test.js
+++ b/src/schema/__tests__/show.test.js
@@ -629,7 +629,7 @@ describe("Show type", () => {
       showData.location = {
         coordinates: {
           lat: 0.23,
-          long: 0.34,
+          lng: 0.34,
         },
       }
       const query = gql`
@@ -679,6 +679,60 @@ describe("Show type", () => {
           },
         },
       })
+    })
+
+    it("requests displayable shows, by default", async () => {
+      showData.location = {
+        coordinates: {
+          lat: 0.23,
+          lng: 0.34,
+        },
+      }
+      const query = gql`
+        {
+          show(id: "new-museum-1-2015-triennial-surround-audience") {
+            nearbyShows(first: 1) {
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+          }
+        }
+      `
+      await runQuery(query, rootValue)
+      const gravityOptions = rootValue.showsWithHeadersLoader.args[0][0]
+
+      expect(gravityOptions).toMatchObject({ displayable: true })
+      expect(gravityOptions).not.toHaveProperty("discoverable")
+    })
+
+    it("can request all discoverable shows, optionally", async () => {
+      showData.location = {
+        coordinates: {
+          lat: 0.23,
+          lng: 0.34,
+        },
+      }
+      const query = gql`
+        {
+          show(id: "new-museum-1-2015-triennial-surround-audience") {
+            nearbyShows(first: 1, discoverable: true) {
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+          }
+        }
+      `
+      await runQuery(query, rootValue)
+      const gravityOptions = rootValue.showsWithHeadersLoader.args[0][0]
+
+      expect(gravityOptions).toMatchObject({ discoverable: true })
+      expect(gravityOptions).not.toHaveProperty("displayable")
     })
   })
 

--- a/src/schema/city/index.ts
+++ b/src/schema/city/index.ts
@@ -37,11 +37,6 @@ const CityType = new GraphQLObjectType({
       args: pageable({
         sort: PartnerShowSorts,
         status: EventStatus,
-        displayable: {
-          type: GraphQLBoolean,
-          defaultValue: true,
-          description: "Whether to include only displayable shows",
-        },
         discoverable: {
           type: GraphQLBoolean,
           description:
@@ -56,7 +51,7 @@ const CityType = new GraphQLObjectType({
       ) => {
         const gravityOptions = {
           ...convertConnectionArgsToGravityArgs(args),
-          displayable: args.displayable,
+          displayable: true,
           near: `${city.coordinates.lat},${city.coordinates.lng}`,
           max_distance: LOCAL_DISCOVERY_RADIUS_KM,
           total_count: true,

--- a/src/schema/city/index.ts
+++ b/src/schema/city/index.ts
@@ -45,7 +45,7 @@ const CityType = new GraphQLObjectType({
       ) => {
         const gravityOptions = {
           ...convertConnectionArgsToGravityArgs(args),
-          displayable: true,
+          discoverable: true,
           near: `${city.coordinates.lat},${city.coordinates.lng}`,
           max_distance: LOCAL_DISCOVERY_RADIUS_KM,
           total_count: true,

--- a/src/schema/show.ts
+++ b/src/schema/show.ts
@@ -495,11 +495,6 @@ export const ShowType = new GraphQLObjectType({
       args: pageable({
         sort: PartnerShowSorts,
         status: EventStatus,
-        displayable: {
-          type: GraphQLBoolean,
-          defaultValue: true,
-          description: "Whether to include only displayable shows",
-        },
         discoverable: {
           type: GraphQLBoolean,
           description:
@@ -520,7 +515,7 @@ export const ShowType = new GraphQLObjectType({
         const coordinates = show.location.coordinates
         const gravityOptions = {
           ...convertConnectionArgsToGravityArgs(args),
-          displayable: args.displayable,
+          displayable: true,
           near: `${coordinates.lat},${coordinates.lng}`,
 
           max_distance: LOCAL_DISCOVERY_RADIUS_KM,

--- a/src/schema/show.ts
+++ b/src/schema/show.ts
@@ -495,6 +495,16 @@ export const ShowType = new GraphQLObjectType({
       args: pageable({
         sort: PartnerShowSorts,
         status: EventStatus,
+        displayable: {
+          type: GraphQLBoolean,
+          defaultValue: true,
+          description: "Whether to include only displayable shows",
+        },
+        discoverable: {
+          type: GraphQLBoolean,
+          description:
+            "Whether to include local discovery stubs as well as displayable shows",
+        },
       }),
       resolve: async (
         show,
@@ -510,13 +520,17 @@ export const ShowType = new GraphQLObjectType({
         const coordinates = show.location.coordinates
         const gravityOptions = {
           ...convertConnectionArgsToGravityArgs(args),
-          displayable: true,
+          displayable: args.displayable,
           near: `${coordinates.lat},${coordinates.lng}`,
 
           max_distance: LOCAL_DISCOVERY_RADIUS_KM,
           total_count: true,
         }
         delete gravityOptions.page
+
+        if (args.discoverable) {
+          delete gravityOptions.displayable
+        }
 
         const response = await showsWithHeadersLoader(gravityOptions)
         const { headers, body: cities } = response


### PR DESCRIPTION
Implements https://artsyproduct.atlassian.net/browse/LD-40

Allows clients to request a list of shows that includes local discovery stubs, as well as regular displayable shows.

We do this by taking the new `discoverable` scope that was [added](https://github.com/artsy/gravity/pull/11995) to Gravity's `/shows` endpoint, and bring it into MP in two places:

- as an optional arg provided to a city's `shows` resolver

![city](https://user-images.githubusercontent.com/140521/49592028-12976380-f93e-11e8-9459-b1059297fe88.png)

- as an optional arg provided to a show's `nearbyShows` resolver

![show](https://user-images.githubusercontent.com/140521/49534359-4ebfbb00-f88f-11e8-9b1a-2d0615e6fb68.png)
