### PR TITLE
Adds SellerCounterOfferOnOrderMutation

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -5184,6 +5184,11 @@ type Mutation {
     input: sellerRejectOfferInput!
   ): sellerRejectOfferPayload
 
+  # Seller counters buyers offer
+  ecommerceSellerCounterOffer(
+    input: sellerCounterOfferInput!
+  ): sellerCounterOfferPayload
+
   # Confirms pickup for an ecommerce order
   ecommerceConfirmPickup(input: ConfirmPickupInput!): ConfirmPickupPayload
 
@@ -7602,6 +7607,20 @@ input sellerAcceptOfferInput {
 }
 
 type sellerAcceptOfferPayload {
+  orderOrError: OrderOrFailureUnionType
+  clientMutationId: String
+}
+
+input sellerCounterOfferInput {
+  # The ID of the offer to counter
+  offerId: String!
+
+  # Offer price
+  offerPrice: MoneyInput
+  clientMutationId: String
+}
+
+type sellerCounterOfferPayload {
   orderOrError: OrderOrFailureUnionType
   clientMutationId: String
 }

--- a/src/data/exchange.graphql
+++ b/src/data/exchange.graphql
@@ -337,19 +337,13 @@ type LineItemEdge {
 }
 
 type Mutation {
-  addInitialOfferToOrder(
-    input: AddInitialOfferToOrderInput!
-  ): AddInitialOfferToOrderPayload
+  addInitialOfferToOrder(input: AddInitialOfferToOrderInput!): AddInitialOfferToOrderPayload
   approveOrder(input: ApproveOrderInput!): ApproveOrderPayload
   buyerAcceptOffer(input: BuyerAcceptOfferInput!): BuyerAcceptOfferPayload
   buyerRejectOffer(input: BuyerRejectOfferInput!): BuyerRejectOfferPayload
   confirmPickup(input: ConfirmPickupInput!): ConfirmPickupPayload
-  createOfferOrderWithArtwork(
-    input: CreateOfferOrderWithArtworkInput!
-  ): CreateOfferOrderWithArtworkPayload
-  createOrderWithArtwork(
-    input: CreateOrderWithArtworkInput!
-  ): CreateOrderWithArtworkPayload
+  createOfferOrderWithArtwork(input: CreateOfferOrderWithArtworkInput!): CreateOfferOrderWithArtworkPayload
+  createOrderWithArtwork(input: CreateOrderWithArtworkInput!): CreateOrderWithArtworkPayload
 
   # Fulfill an order with one Fulfillment, it sets this fulfillment to each line item in order
   fulfillAtOnce(input: FulfillAtOnceInput!): FulfillAtOncePayload
@@ -360,9 +354,7 @@ type Mutation {
   setPayment(input: SetPaymentInput!): SetPaymentPayload
   setShipping(input: SetShippingInput!): SetShippingPayload
   submitOrder(input: SubmitOrderInput!): SubmitOrderPayload
-  submitOrderWithOffer(
-    input: SubmitOrderWithOfferInput!
-  ): SubmitOrderWithOfferPayload
+  submitOrderWithOffer(input: SubmitOrderWithOfferInput!): SubmitOrderWithOfferPayload
 }
 
 # An Offer

--- a/src/schema/__tests__/ecommerce/seller_counter_offer_mutation.test.ts
+++ b/src/schema/__tests__/ecommerce/seller_counter_offer_mutation.test.ts
@@ -1,0 +1,76 @@
+import { runQuery } from "test/utils"
+import { sampleOrder } from "test/fixtures/results/sample_order"
+import gql from "lib/gql"
+import { mockxchange } from "test/fixtures/exchange/mockxchange"
+import { OrderSellerFields } from "./order_fields"
+import exchangeOrderJSON from "test/fixtures/exchange/buy_order.json"
+
+let rootValue
+
+describe("SellerCounterOffer Mutation", () => {
+  const mutation = gql`
+    mutation {
+      ecommerceSellerCounterOffer(input: { offerId: "111", offerPrice: { amount: 1, currencyCode: "USD" } }) {
+        orderOrError {
+          ... on OrderWithMutationSuccess {
+            order {
+              ${OrderSellerFields}
+            }
+          }
+          ... on OrderWithMutationFailure {
+            error {
+              type
+              code
+              data
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("counters buyers offer", () => {
+    const resolvers = {
+      Mutation: {
+        sellerCounterOffer: () => ({
+          orderOrError: { order: exchangeOrderJSON },
+        }),
+      },
+    }
+
+    rootValue = mockxchange(resolvers)
+
+    return runQuery(mutation, rootValue).then(data => {
+      expect(
+        data!.ecommerceSellerCounterOffer.orderOrError.order
+      ).toEqual(sampleOrder())
+    })
+  })
+
+  it("returns an error if there is one", () => {
+    const resolvers = {
+      Mutation: {
+        sellerCounterOffer: () => ({
+          orderOrError: {
+            error: {
+              type: "application_error",
+              code: "404",
+            },
+          },
+        }),
+      },
+    }
+
+    rootValue = mockxchange(resolvers)
+
+    return runQuery(mutation, rootValue).then(data => {
+      expect(
+        data!.ecommerceSellerCounterOffer.orderOrError.error
+      ).toEqual({
+        type: "application_error",
+        code: "404",
+        data: null,
+      })
+    })
+  })
+})

--- a/src/schema/ecommerce/seller_counter_offer_mutation.ts
+++ b/src/schema/ecommerce/seller_counter_offer_mutation.ts
@@ -1,0 +1,75 @@
+import {
+  graphql,
+  GraphQLNonNull,
+  GraphQLString,
+  GraphQLInputObjectType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { OrderOrFailureUnionType } from "./types/order_or_error_union"
+import { SellerOrderFields } from "./query_helpers"
+import gql from "lib/gql"
+import { extractEcommerceResponse } from "./extractEcommerceResponse"
+import { MoneyInput } from "schema/fields/money"
+import { moneyFieldToUnit } from "lib/moneyHelper"
+
+const SellerCounterOfferMutationInputType = new GraphQLInputObjectType({
+  name: "OfferMutationInput",
+  fields: {
+    offerId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the offer to counter",
+    },
+    offerPrice: {
+      type: MoneyInput,
+      description: "Offer price",
+    },
+  },
+})
+
+export const SellerCounterOfferMutation = mutationWithClientMutationId({
+  name: "sellerCounterOffer",
+  description: "Seller counters buyers offer",
+  inputFields: SellerCounterOfferMutationInputType.getFields(),
+  outputFields: {
+    orderOrError: {
+      type: OrderOrFailureUnionType,
+    },
+  },
+  mutateAndGetPayload: (
+    { offerId, offerPrice },
+    context,
+    { rootValue: { accessToken, exchangeSchema } }
+  ) => {
+    if (!accessToken) {
+      return new Error("You need to be signed in to perform this action")
+    }
+    const mutation = gql`
+      mutation sellerCounterOffer($offerId: ID!, $amountCents: Int!) {
+        ecommerceSellerCounterOffer(input: {
+          offerId: $offerId,
+          amountCents: $amountCents
+        }) {
+          orderOrError {
+            __typename
+            ... on EcommerceOrderWithMutationSuccess {
+              order {
+                ${SellerOrderFields}
+              }
+            }
+            ... on EcommerceOrderWithMutationFailure {
+              error {
+                type
+                code
+                data
+              }
+            }
+          }
+        }
+      }
+    `
+    return graphql(exchangeSchema, mutation, null, context, {
+      offerId,
+      amountCents: moneyFieldToUnit(offerPrice),
+    }).then(extractEcommerceResponse("ecommerceSellerCounterOffer"))
+  },
+})

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -28,6 +28,7 @@ import { ApproveOrderMutation } from "./ecommerce/approve_order_mutation"
 import { BuyerAcceptOfferMutation } from "./ecommerce/buyer_accept_offer_mutation"
 import { SellerAcceptOfferMutation } from "./ecommerce/seller_accept_offer_mutation"
 import { SellerRejectOfferMutation } from "./ecommerce/seller_reject_offer_mutation"
+import { SellerCounterOfferMutation } from "./ecommerce/seller_counter_offer_mutation"
 import { FulfillOrderAtOnceMutation } from "./ecommerce/fulfill_order_at_once_mutation"
 import { ConfirmPickupMutation } from "./ecommerce/confirm_pickup_mutation"
 import { RejectOrderMutation } from "./ecommerce/reject_order_mutation"
@@ -179,6 +180,7 @@ if (!ENABLE_ECOMMERCE_STITCHING) {
   stitchedMutations.ecommerceBuyerAcceptOffer = BuyerAcceptOfferMutation
   stitchedMutations.ecommerceSellerAcceptOffer = SellerAcceptOfferMutation
   stitchedMutations.ecommerceSellerRejectOffer = SellerRejectOfferMutation
+  stitchedMutations.ecommerceSellerCounterOffer = SellerCounterOfferMutation
   stitchedMutations.ecommerceConfirmPickup = ConfirmPickupMutation
   stitchedMutations.ecommerceFulfillOrderAtOnce = FulfillOrderAtOnceMutation
   stitchedMutations.ecommerceRejectOrder = RejectOrderMutation


### PR DESCRIPTION
Fixes [SELL-1177](https://artsyproduct.atlassian.net/browse/SELL-1177)

Followed the same input pattern as `AddInitialOfferToOrderMutation` using `MoneyInput`

Sample query:
```graphql
mutation sellerCounterOffer($offerId: String!, $offerPrice: MoneyInput!){
  ecommerceSellerCounterOffer(input: {offerId: $offerId, offerPrice: $offerPrice}){
    orderOrError {
      ... on OrderWithMutationSuccess {
        order{
          id
          mode
          buyer {
            __typename
            ... on User {
              id
              name
            }
          }
          seller {
            __typename
            ... on Partner {
              id
              name
            }
          }
          itemsTotalCents
          shippingTotalCents
          commissionFeeCents
          taxTotalCents
          buyerTotalCents
          sellerTotalCents
          itemsTotal
          shippingTotal
          commissionFee
          taxTotal
          buyerTotal
          sellerTotal
          lineItems{
            edges{
              node{
                id
                artwork{
                  title
                  artist{
                    name
                  }
                }
              }
            }
          }
          ... on OfferOrder {
            myLastOffer {
              id
              amount
              shippingTotal
              taxTotal
              buyerTotal
            }
            lastOffer {
              id
              amount
              shippingTotal
              taxTotal
              buyerTotal
            }
            awaitingResponseFrom
          }
         }
      }
      ... on OrderWithMutationFailure {
        error {
          type
          code
          data
        }
      }
    }
  }
}
```

with:

```json
{
  "offerId": "c72165ca-fa98-4ec7-a595-e24f1b2411c4",
  "offerPrice": {
    "amount": 299,
    "currencyCode": "USD"
  }
}
```