### PR TITLE
Revert "DISCO-494: Return null shipping info if artwork is not acquirable"

### DIFF
--- a/src/schema/artwork/__tests__/artwork.test.js
+++ b/src/schema/artwork/__tests__/artwork.test.js
@@ -1320,31 +1320,13 @@ describe("Artwork type", () => {
       }
     `
 
-    beforeEach(() => {
-      artwork.acquireable = true
-    })
-
-    it("is null if artwork is not enrolled in in an e-commerce program", () => {
-      artwork.acquireable = false
-      artwork.domestic_shipping_fee_cents = 1000
-      artwork.international_shipping_fee_cents = null
-
-      return runQuery(query, rootValue).then(data => {
-        expect(data).toEqual({
-          artwork: {
-            shippingInfo: null,
-          },
-        })
-      })
-    })
-
-    it("is null when domestic_shipping_fee_cents is null and international_shipping_fee_cents is null", () => {
+    it("is set to prompt string when its domestic_shipping_fee_cents is null and international_shipping_fee_cents is null", () => {
       artwork.domestic_shipping_fee_cents = null
       artwork.international_shipping_fee_cents = null
       return runQuery(query, rootValue).then(data => {
         expect(data).toEqual({
           artwork: {
-            shippingInfo: null,
+            shippingInfo: "Shipping, tax, and service quoted by seller",
           },
         })
       })
@@ -1501,35 +1483,8 @@ describe("Artwork type", () => {
       }
     `
 
-    beforeEach(() => {
-      artwork.acquireable = true
-    })
-
     it("is null when shipping_origin is null", () => {
       artwork.shipping_origin = null
-      return runQuery(query, rootValue).then(data => {
-        expect(data).toEqual({
-          artwork: {
-            shippingOrigin: null,
-          },
-        })
-      })
-    })
-
-    it("is null when artwork is not acquireable", () => {
-      artwork.acquireable = false
-      artwork.shipping_origin = ["Kharkov", "Ukraine"]
-      return runQuery(query, rootValue).then(data => {
-        expect(data).toEqual({
-          artwork: {
-            shippingOrigin: null,
-          },
-        })
-      })
-    })
-
-    it("is null if shipping origin is not present", () => {
-      artwork.shipping_origin = []
       return runQuery(query, rootValue).then(data => {
         expect(data).toEqual({
           artwork: {

--- a/src/schema/artwork/index.ts
+++ b/src/schema/artwork/index.ts
@@ -580,12 +580,10 @@ export const artworkFields = () => {
         "The string that describes domestic and international shipping.",
       resolve: artwork => {
         if (
-          !artwork.acquireable ||
-          (artwork.domestic_shipping_fee_cents == null &&
-            artwork.international_shipping_fee_cents == null)
+          artwork.domestic_shipping_fee_cents == null &&
+          artwork.international_shipping_fee_cents == null
         )
-          return null
-
+          return "Shipping, tax, and service quoted by seller"
         if (
           artwork.domestic_shipping_fee_cents === 0 &&
           artwork.international_shipping_fee_cents == null
@@ -628,13 +626,7 @@ export const artworkFields = () => {
       description:
         "Minimal location information describing from where artwork will be shipped.",
       resolve: artwork => {
-        if (
-          !artwork.acquireable ||
-          !(artwork.shipping_origin && artwork.shipping_origin.length)
-        )
-          return null
-
-        return artwork.shipping_origin.join(", ")
+        return artwork.shipping_origin && artwork.shipping_origin.join(", ")
       },
     },
     provenance: markdown(({ provenance }) =>


### PR DESCRIPTION
Reverts artsy/metaphysics#1385

ticket: https://artsyproduct.atlassian.net/browse/DISCO-544 :lock: 

This caused a regression in the order flow preventing shipping information from displaying on the receipt once an order is submitted.

We've updated Force (desktop and mobile) to hide shipping information for artworks not enrolled in an e-commerce program ([PR](https://github.com/artsy/force/pull/3161)). We can now remove this logic from Metaphysics.

There's an ongoing discussion on how client-specific responses from Metaphysics should be. There's more context available in the original PR [here](https://github.com/artsy/metaphysics/pull/1385#issuecomment-441789606) and in the Force PR [here](https://github.com/artsy/force/pull/3161#issue-235886148). 