### PR TITLE
LD-85 Expose opening_reception_text on Show

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -7899,6 +7899,9 @@ type Show implements Node {
     last: Int
   ): ShowConnection
 
+  # Alternate Markdown-supporting free text representation of the opening reception event’s date/time
+  opening_reception_text: String
+
   # The partner that represents this show, could be a non-Artsy partner
   partner: PartnerTypes
 

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -7900,7 +7900,7 @@ type Show implements Node {
   ): ShowConnection
 
   # Alternate Markdown-supporting free text representation of the opening reception event’s date/time
-  opening_reception_text: String
+  openingReceptionText: String
 
   # The partner that represents this show, could be a non-Artsy partner
   partner: PartnerTypes

--- a/src/schema/show.ts
+++ b/src/schema/show.ts
@@ -550,6 +550,7 @@ export const ShowType = new GraphQLObjectType({
       type: GraphQLString,
       description:
         "Alternate Markdown-supporting free text representation of the opening reception event’s date/time",
+      resolve: ({ opening_reception_text }) => opening_reception_text,
     },
     partner: {
       description:

--- a/src/schema/show.ts
+++ b/src/schema/show.ts
@@ -546,6 +546,11 @@ export const ShowType = new GraphQLObjectType({
         return results
       },
     },
+    opening_reception_text: {
+      type: GraphQLString,
+      description:
+        "Alternate Markdown-supporting free text representation of the opening reception event’s date/time",
+    },
     partner: {
       description:
         "The partner that represents this show, could be a non-Artsy partner",

--- a/src/schema/show.ts
+++ b/src/schema/show.ts
@@ -546,7 +546,7 @@ export const ShowType = new GraphQLObjectType({
         return results
       },
     },
-    opening_reception_text: {
+    openingReceptionText: {
       type: GraphQLString,
       description:
         "Alternate Markdown-supporting free text representation of the opening reception event’s date/time",


### PR DESCRIPTION
Implements https://artsyproduct.atlassian.net/browse/LD-85

This supports the opening reception free text that was [added to shows](https://github.com/artsy/gravity/pull/12047) for local discovery stubs

![open](https://user-images.githubusercontent.com/140521/49761002-cfb5f280-fc93-11e8-97eb-8228d9f6d98d.png)
