### PR TITLE
Add artistsConnection to Fair

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1065,6 +1065,14 @@ type ArtworkContextFair {
 
   # A type-specific Gravity Mongo Document ID.
   _id: String!
+  artists(
+    # Sorts for artists in a fair
+    sort: FairArtistSorts
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtistConnection
   cached: Int
   banner_size: String
   has_full_feature: Boolean
@@ -3160,6 +3168,14 @@ type Fair {
 
   # A type-specific Gravity Mongo Document ID.
   _id: String!
+  artists(
+    # Sorts for artists in a fair
+    sort: FairArtistSorts
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtistConnection
   cached: Int
   banner_size: String
   has_full_feature: Boolean
@@ -3251,6 +3267,11 @@ type Fair {
     tag_id: String
     keyword: String
   ): FilterArtworks
+}
+
+enum FairArtistSorts {
+  NAME_ASC
+  NAME_DESC
 }
 
 type FairExhibitorsGroup {
@@ -4210,6 +4231,14 @@ type HomePageModuleContextFair {
 
   # A type-specific Gravity Mongo Document ID.
   _id: String!
+  artists(
+    # Sorts for artists in a fair
+    sort: FairArtistSorts
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtistConnection
   cached: Int
   banner_size: String
   has_full_feature: Boolean

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -16,6 +16,7 @@ export default opts => {
     artworkImageLoader: gravityLoader(({ artwork_id, image_id }) => `artwork/${artwork_id}/image/${image_id}`),
     artworkLoader: gravityLoader(id => `artwork/${id}`),
     artworksLoader: gravityLoader("artworks"),
+    fairArtistsLoader: gravityLoader(id => `fair/${id}/artists`, {}, { headers: true }),
     fairBoothsLoader: gravityLoader(id => `fair/${id}/shows`, {}, { headers: true }),
     fairPartnersLoader: gravityLoader(id => `fair/${id}/partners`, {}, { headers: true }),
     fairLoader: gravityLoader(id => `fair/${id}`),

--- a/src/schema/sorts/fairArtistSorts.ts
+++ b/src/schema/sorts/fairArtistSorts.ts
@@ -1,0 +1,13 @@
+import { GraphQLEnumType } from "graphql"
+
+export const FairArtistSortsType = new GraphQLEnumType({
+  name: "FairArtistSorts",
+  values: {
+    NAME_ASC: {
+      value: "name",
+    },
+    NAME_DESC: {
+      value: "-name",
+    },
+  },
+})


### PR DESCRIPTION
~Depends on: https://github.com/artsy/gravity/pull/12048~ (Merged!)

Implements: [LD-83](https://artsyproduct.atlassian.net/browse/LD-83).

Uses Gravity's [FairArtistsEndpoint](https://github.com/artsy/gravity/blob/master/app/api/v1/fairs_artists_endpoint.rb) to expose an `artistsConnection` field on Fair. This field backs the mock seen [here](https://app.zeplin.io/project/5bef4c7dae2b6a3eb6a75f4a/screen/5bf32e8aa6dc5049913296b9). Emission will paginate over this field, sorted by name, and build alphabetical groupings as more data is fetched.

