### PR TITLE
@dblandin => Allow edition sets to be sorted by price

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -776,7 +776,7 @@ type Artwork implements Node & Sellable {
   # Returns an HTML string representing the embedded content (video)
   embed(width: Int = 853, height: Int = 450, autoplay: Boolean = false): String
   edition_of: String
-  edition_sets: [EditionSet]
+  edition_sets(sort: EditionSetSorts): [EditionSet]
   exhibition_history(format: Format): String
   fair: Fair
   height: String @deprecated(reason: "Prefer dimensions instead.")
@@ -1592,7 +1592,7 @@ type ArtworkItem implements Node & Sellable {
   # Returns an HTML string representing the embedded content (video)
   embed(width: Int = 853, height: Int = 450, autoplay: Boolean = false): String
   edition_of: String
-  edition_sets: [EditionSet]
+  edition_sets(sort: EditionSetSorts): [EditionSet]
   exhibition_history(format: Format): String
   fair: Fair
   height: String @deprecated(reason: "Prefer dimensions instead.")
@@ -3114,6 +3114,10 @@ type EditionSet implements Sellable {
   is_sold: Boolean
   price: String @deprecated(reason: "Prefer to use `sale_message`.")
   sale_message: String
+}
+
+enum EditionSetSorts {
+  PRICE_ASC
 }
 
 input EndSaleInput {

--- a/src/schema/artwork/__tests__/artwork.test.js
+++ b/src/schema/artwork/__tests__/artwork.test.js
@@ -430,6 +430,64 @@ describe("Artwork type", () => {
         })
       })
     })
+
+    it("can sort by price ascending", () => {
+      artwork.edition_sets = [
+        {
+          id: "$200",
+          price_cents: [200],
+        },
+        {
+          id: "$100-400",
+          price_cents: [100, 400],
+        },
+        {
+          id: "Under 400",
+          price_cents: [null, 400],
+        },
+        {
+          id: "$400 and up",
+          price_cents: [400, null],
+        },
+        {
+          id: "not for sale",
+          price_cents: [],
+        },
+      ]
+
+      const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          edition_sets(sort: PRICE_ASC) {
+            id
+          }
+        }
+      }
+    `
+      return runQuery(query, rootValue).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            edition_sets: [
+              {
+                id: "Under 400",
+              },
+              {
+                id: "$100-400",
+              },
+              {
+                id: "$200",
+              },
+              {
+                id: "$400 and up",
+              },
+              {
+                id: "not for sale",
+              },
+            ],
+          },
+        })
+      })
+    })
   })
 
   describe("#is_in_auction", () => {

--- a/src/schema/artwork/index.ts
+++ b/src/schema/artwork/index.ts
@@ -17,7 +17,7 @@ import Context from "./context"
 import Meta, { artistNames } from "./meta"
 import Highlight from "./highlight"
 import Dimensions from "schema/dimensions"
-import EditionSet from "schema/edition_set"
+import EditionSet, { EditionSetSorts } from "schema/edition_set"
 import { Sellable } from "schema/sellable"
 import ArtworkLayer from "./layer"
 import ArtworkLayers, { artworkLayers } from "./layers"
@@ -206,7 +206,26 @@ export const artworkFields = () => {
     },
     edition_sets: {
       type: new GraphQLList(EditionSet.type),
-      resolve: ({ edition_sets }) => edition_sets,
+      args: {
+        sort: EditionSetSorts,
+      },
+      resolve: ({ edition_sets }, { sort }) => {
+        if (sort) {
+          // Only ascending price sort supported currently.
+          return edition_sets.sort(
+            ({ price_cents: aPrice }, { price_cents: bPrice }) => {
+              if (!aPrice || aPrice.length === 0) {
+                return 1
+              } else if (!bPrice || bPrice.length === 0) {
+                return -1
+              } else {
+                return aPrice[0] - bPrice[0]
+              }
+            }
+          )
+        }
+        return edition_sets
+      },
     },
     exhibition_history: markdown(),
     fair: {

--- a/src/schema/edition_set.ts
+++ b/src/schema/edition_set.ts
@@ -1,9 +1,25 @@
 import { isEmpty, includes } from "lodash"
 import { IDFields } from "./object_identification"
 import Dimensions from "./dimensions"
-import { GraphQLString, GraphQLBoolean, GraphQLObjectType } from "graphql"
+import {
+  GraphQLString,
+  GraphQLBoolean,
+  GraphQLObjectType,
+  GraphQLEnumType,
+} from "graphql"
 import { capitalizeFirstCharacter } from "lib/helpers"
 import { Sellable } from "./sellable"
+
+export const EditionSetSorts = {
+  type: new GraphQLEnumType({
+    name: "EditionSetSorts",
+    values: {
+      PRICE_ASC: {
+        value: "price",
+      },
+    },
+  }),
+}
 
 const EditionSetAvailabilities = [
   "sold",


### PR DESCRIPTION
Now that https://github.com/artsy/gravity/pull/12050 is merged, we can offer a price-sorted list of edition sets.

Once this is merged (and the schema in Reaction updated), we can do `edition_sets(sort: PRICE_ASC)` and drop the sorting there.