### PR TITLE
Stitched the Exchange mutation for a buyer to reject an offer

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -2103,6 +2103,17 @@ type buyerCounterOfferPayload {
   clientMutationId: String
 }
 
+input buyerRejectOfferInput {
+  # Offer ID
+  offerId: String!
+  clientMutationId: String
+}
+
+type buyerRejectOfferPayload {
+  orderOrError: OrderOrFailureUnionType
+  clientMutationId: String
+}
+
 type BuyersPremium {
   # A globally unique ID.
   __id: ID!
@@ -5197,20 +5208,25 @@ type Mutation {
     input: sellerAcceptOfferInput!
   ): sellerAcceptOfferPayload
 
-  # Rejects an offer
-  ecommerceSellerRejectOffer(
-    input: sellerRejectOfferInput!
-  ): sellerRejectOfferPayload
+  # Buyer counters sellers offer
+  ecommerceBuyerCounterOffer(
+    input: buyerCounterOfferInput!
+  ): buyerCounterOfferPayload
 
   # Seller counters buyers offer
   ecommerceSellerCounterOffer(
     input: sellerCounterOfferInput!
   ): sellerCounterOfferPayload
 
-  # Buyer counters sellers offer
-  ecommerceBuyerCounterOffer(
-    input: buyerCounterOfferInput!
-  ): buyerCounterOfferPayload
+  # Buyer rejects a submitted offer from seller
+  ecommerceBuyerRejectOffer(
+    input: buyerRejectOfferInput!
+  ): buyerRejectOfferPayload
+
+  # Rejects an offer
+  ecommerceSellerRejectOffer(
+    input: sellerRejectOfferInput!
+  ): sellerRejectOfferPayload
 
   # Confirms pickup for an ecommerce order
   ecommerceConfirmPickup(input: ConfirmPickupInput!): ConfirmPickupPayload

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -2106,6 +2106,9 @@ type buyerCounterOfferPayload {
 input buyerRejectOfferInput {
   # Offer ID
   offerId: String!
+
+  # Reason for rejecting offer
+  rejectReason: CancelReasonType
   clientMutationId: String
 }
 
@@ -2363,7 +2366,9 @@ type BuyOrder implements Order {
 }
 
 enum CancelReasonType {
+  BUYER_REJECTED
   SELLER_LAPSED
+  SELLER_REJECTED
   SELLER_REJECTED_OFFER_TOO_LOW
   SELLER_REJECTED_SHIPPING_UNAVAILABLE
   SELLER_REJECTED_ARTWORK_UNAVAILABLE

--- a/src/schema/__tests__/ecommerce/buyer_reject_offer_mutation.test.ts
+++ b/src/schema/__tests__/ecommerce/buyer_reject_offer_mutation.test.ts
@@ -1,0 +1,74 @@
+import gql from "lib/gql"
+import { OrderBuyerFields } from "./order_fields"
+import exchangeOrderJSON from "test/fixtures/exchange/buy_order.json"
+import { mockxchange } from "test/fixtures/exchange/mockxchange"
+import { runQuery } from "test/utils"
+import { sampleOrder } from "test/fixtures/results/sample_order"
+
+let rootValue
+
+describe("BuyerRejectOffer Mutation", () => {
+  const mutation = gql`
+    mutation {
+      ecommerceBuyerRejectOffer(input: {offerId: "111"}) {
+        orderOrError {
+          ... on OrderWithMutationSuccess {
+            order {
+              ${OrderBuyerFields}
+            }
+          }
+          ... on OrderWithMutationFailure {
+            error {
+              type
+              code
+              data
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("rejects the seller offer", () => {
+    const resolvers = {
+      Mutation: {
+        buyerRejectOffer: () => ({
+          orderOrError: { order: exchangeOrderJSON },
+        }),
+      },
+    }
+
+    rootValue = mockxchange(resolvers)
+
+    return runQuery(mutation, rootValue).then(data => {
+      expect(data!.ecommerceBuyerRejectOffer.orderOrError.order).toEqual(
+        sampleOrder()
+      )
+    })
+  })
+
+  it("returns an error if there is one", () => {
+    const resolvers = {
+      Mutation: {
+        buyerRejectOffer: () => ({
+          orderOrError: {
+            error: {
+              type: "application_error",
+              code: "404",
+            },
+          },
+        }),
+      },
+    }
+
+    rootValue = mockxchange(resolvers)
+
+    return runQuery(mutation, rootValue).then(data => {
+      expect(data!.ecommerceBuyerRejectOffer.orderOrError.error).toEqual({
+        type: "application_error",
+        code: "404",
+        data: null,
+      })
+    })
+  })
+})

--- a/src/schema/ecommerce/buyer_reject_offer_mutation.ts
+++ b/src/schema/ecommerce/buyer_reject_offer_mutation.ts
@@ -1,22 +1,22 @@
-import { OfferMutationInputType } from "./types/offer_mutation_input_type"
 import { OrderOrFailureUnionType } from "./types/order_or_error_union"
 import { mutationWithClientMutationId } from "graphql-relay"
 import gql from "lib/gql"
 import { BuyerOrderFields } from "./query_helpers"
 import { graphql } from "graphql"
 import { extractEcommerceResponse } from "./extractEcommerceResponse"
+import { RejectOfferMutationInputType } from "./types/reject_offer_mutation_input_type"
 
 export const BuyerRejectOfferMutation = mutationWithClientMutationId({
   name: "buyerRejectOffer",
   description: "Buyer rejects a submitted offer from seller",
-  inputFields: OfferMutationInputType.getFields(),
+  inputFields: RejectOfferMutationInputType.getFields(),
   outputFields: {
     orderOrError: {
       type: OrderOrFailureUnionType,
     },
   },
   mutateAndGetPayload: (
-    { offerId },
+    { offerId, rejectReason },
     context,
     { rootValue: { accessToken, exchangeSchema } }
   ) => {
@@ -24,8 +24,8 @@ export const BuyerRejectOfferMutation = mutationWithClientMutationId({
       return new Error("You need to be signed in to perform this action")
     }
     const mutation = gql`
-      mutation buyerRejectOffer($offerId: ID!) {
-        ecommerceBuyerRejectOffer(input: { offerId: $offerId }) {
+      mutation buyerRejectOffer($offerId: ID!, $rejectReason: EcommerceCancelReasonTypeEnum) {
+        ecommerceBuyerRejectOffer(input: { offerId: $offerId, rejectReason: $rejectReason, }) {
           orderOrError {
             __typename
             ... on EcommerceOrderWithMutationSuccess {
@@ -46,6 +46,7 @@ export const BuyerRejectOfferMutation = mutationWithClientMutationId({
     `
     return graphql(exchangeSchema, mutation, null, context, {
       offerId,
+      rejectReason,
     }).then(extractEcommerceResponse("ecommerceBuyerRejectOffer"))
   },
 })

--- a/src/schema/ecommerce/buyer_reject_offer_mutation.ts
+++ b/src/schema/ecommerce/buyer_reject_offer_mutation.ts
@@ -1,0 +1,51 @@
+import { OfferMutationInputType } from "./types/offer_mutation_input_type"
+import { OrderOrFailureUnionType } from "./types/order_or_error_union"
+import { mutationWithClientMutationId } from "graphql-relay"
+import gql from "lib/gql"
+import { BuyerOrderFields } from "./query_helpers"
+import { graphql } from "graphql"
+import { extractEcommerceResponse } from "./extractEcommerceResponse"
+
+export const BuyerRejectOfferMutation = mutationWithClientMutationId({
+  name: "buyerRejectOffer",
+  description: "Buyer rejects a submitted offer from seller",
+  inputFields: OfferMutationInputType.getFields(),
+  outputFields: {
+    orderOrError: {
+      type: OrderOrFailureUnionType,
+    },
+  },
+  mutateAndGetPayload: (
+    { offerId },
+    context,
+    { rootValue: { accessToken, exchangeSchema } }
+  ) => {
+    if (!accessToken) {
+      return new Error("You need to be signed in to perform this action")
+    }
+    const mutation = gql`
+      mutation buyerRejectOffer($offerId: ID!) {
+        ecommerceBuyerRejectOffer(input: { offerId: $offerId }) {
+          orderOrError {
+            __typename
+            ... on EcommerceOrderWithMutationSuccess {
+              order {
+                ${BuyerOrderFields}
+              }
+            }
+            ... on EcommerceOrderWithMutationFailure {
+              error {
+                type
+                code
+                data
+              }
+            }
+          }
+        }
+      }
+    `
+    return graphql(exchangeSchema, mutation, null, context, {
+      offerId,
+    }).then(extractEcommerceResponse("ecommerceBuyerRejectOffer"))
+  },
+})

--- a/src/schema/ecommerce/seller_reject_offer_mutation.ts
+++ b/src/schema/ecommerce/seller_reject_offer_mutation.ts
@@ -1,34 +1,15 @@
-import {
-  graphql,
-  GraphQLInputObjectType,
-  GraphQLNonNull,
-  GraphQLString,
-} from "graphql"
+import { graphql } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 import { OrderOrFailureUnionType } from "./types/order_or_error_union"
 import { SellerOrderFields } from "./query_helpers"
 import gql from "lib/gql"
 import { extractEcommerceResponse } from "./extractEcommerceResponse"
-import { CancelReasonTypeEnum } from "./types/cancel_reason_type_enum"
-
-const SellerRejectOfferMutationInputType = new GraphQLInputObjectType({
-  name: "OfferMutationInput",
-  fields: {
-    offerId: {
-      type: new GraphQLNonNull(GraphQLString),
-      description: "Offer ID",
-    },
-    rejectReason: {
-      type: CancelReasonTypeEnum,
-      description: "Reason for rejecting offer",
-    },
-  },
-})
+import { RejectOfferMutationInputType } from "./types/reject_offer_mutation_input_type"
 
 export const SellerRejectOfferMutation = mutationWithClientMutationId({
   name: "sellerRejectOffer",
   description: "Rejects an offer",
-  inputFields: SellerRejectOfferMutationInputType.getFields(),
+  inputFields: RejectOfferMutationInputType.getFields(),
   outputFields: {
     orderOrError: {
       type: OrderOrFailureUnionType,

--- a/src/schema/ecommerce/types/cancel_reason_type_enum.ts
+++ b/src/schema/ecommerce/types/cancel_reason_type_enum.ts
@@ -3,8 +3,14 @@ import { GraphQLEnumType } from "graphql"
 export const CancelReasonTypeEnum = new GraphQLEnumType({
   name: "CancelReasonType",
   values: {
+    BUYER_REJECTED: {
+      value: "BUYER_REJECTED",
+    },
     SELLER_LAPSED: {
       value: "SELLER_LAPSED",
+    },
+    SELLER_REJECTED: {
+      value: "SELLER_REJECTED",
     },
     SELLER_REJECTED_OFFER_TOO_LOW: {
       value: "SELLER_REJECTED_OFFER_TOO_LOW",

--- a/src/schema/ecommerce/types/reject_offer_mutation_input_type.ts
+++ b/src/schema/ecommerce/types/reject_offer_mutation_input_type.ts
@@ -1,0 +1,16 @@
+import { GraphQLInputObjectType, GraphQLNonNull, GraphQLString } from "graphql"
+import { CancelReasonTypeEnum } from "./cancel_reason_type_enum"
+
+export const RejectOfferMutationInputType = new GraphQLInputObjectType({
+  name: "OfferMutationInput",
+  fields: {
+    offerId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "Offer ID",
+    },
+    rejectReason: {
+      type: CancelReasonTypeEnum,
+      description: "Reason for rejecting offer",
+    },
+  },
+})

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -27,9 +27,10 @@ import { SubmitOrderWithOfferMutation } from "./ecommerce/submit_order_with_offe
 import { ApproveOrderMutation } from "./ecommerce/approve_order_mutation"
 import { BuyerAcceptOfferMutation } from "./ecommerce/buyer_accept_offer_mutation"
 import { SellerAcceptOfferMutation } from "./ecommerce/seller_accept_offer_mutation"
-import { SellerRejectOfferMutation } from "./ecommerce/seller_reject_offer_mutation"
-import { SellerCounterOfferMutation } from "./ecommerce/seller_counter_offer_mutation"
 import { BuyerCounterOfferMutation } from "./ecommerce/buyer_counter_offer_mutation"
+import { SellerCounterOfferMutation } from "./ecommerce/seller_counter_offer_mutation"
+import { BuyerRejectOfferMutation } from "./ecommerce/buyer_reject_offer_mutation"
+import { SellerRejectOfferMutation } from "./ecommerce/seller_reject_offer_mutation"
 import { FulfillOrderAtOnceMutation } from "./ecommerce/fulfill_order_at_once_mutation"
 import { ConfirmPickupMutation } from "./ecommerce/confirm_pickup_mutation"
 import { RejectOrderMutation } from "./ecommerce/reject_order_mutation"
@@ -180,9 +181,10 @@ if (!ENABLE_ECOMMERCE_STITCHING) {
   stitchedMutations.ecommerceApproveOrder = ApproveOrderMutation
   stitchedMutations.ecommerceBuyerAcceptOffer = BuyerAcceptOfferMutation
   stitchedMutations.ecommerceSellerAcceptOffer = SellerAcceptOfferMutation
-  stitchedMutations.ecommerceSellerRejectOffer = SellerRejectOfferMutation
-  stitchedMutations.ecommerceSellerCounterOffer = SellerCounterOfferMutation
   stitchedMutations.ecommerceBuyerCounterOffer = BuyerCounterOfferMutation
+  stitchedMutations.ecommerceSellerCounterOffer = SellerCounterOfferMutation
+  stitchedMutations.ecommerceBuyerRejectOffer = BuyerRejectOfferMutation
+  stitchedMutations.ecommerceSellerRejectOffer = SellerRejectOfferMutation
   stitchedMutations.ecommerceConfirmPickup = ConfirmPickupMutation
   stitchedMutations.ecommerceFulfillOrderAtOnce = FulfillOrderAtOnceMutation
   stitchedMutations.ecommerceRejectOrder = RejectOrderMutation


### PR DESCRIPTION
I forgot to manually stitch the new buyerRejectOffer mutation from Exchange into Metaphysics when I was working on [PLATFORM-689](https://artsyproduct.atlassian.net/browse/PURCHASE-689) so this PR does that.

I also rearranged some of the accept, counter, and reject declarations in the schema so that that they would follow the following order:
1. buyer accept
2. seller accept
3. buyer counter
4. seller counter
5. buyer reject
6. seller reject