### PR TITLE
Add git remote option to MP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: artsy/hokusai:0.4.6
+      - image: artsy/hokusai:latest
     steps:
       - add_ssh_keys
       - checkout
@@ -12,7 +12,7 @@ jobs:
           command: hokusai test
   push:
     docker:
-      - image: artsy/hokusai:0.4.6
+      - image: artsy/hokusai:latest
     steps:
       - add_ssh_keys
       - checkout
@@ -22,7 +22,7 @@ jobs:
           command: hokusai registry push --tag $CIRCLE_SHA1 --force --overwrite
   deploy:
     docker:
-      - image: artsy/hokusai:0.4.6
+      - image: artsy/hokusai:latest
     steps:
       - add_ssh_keys
       - checkout
@@ -31,7 +31,7 @@ jobs:
           command: hokusai configure --kubectl-version 1.6.3 --s3-bucket artsy-citadel --s3-key k8s/config --platform linux
       - run:
           name: Deploy
-          command: hokusai staging deploy $CIRCLE_SHA1 --git-remote origin
+          command: hokusai staging deploy $CIRCLE_SHA1
 workflows:
   version: 2
   default:

--- a/hokusai/config.yml
+++ b/hokusai/config.yml
@@ -2,3 +2,4 @@
 aws-account-id: '585031190124'
 aws-ecr-region: us-east-1
 project-name: metaphysics
+git-remote: git@github.com:artsy/metaphysics.git


### PR DESCRIPTION
This should ensure that Git tags are always pushed when a `hokusai
pipeline promote` or `hokusai staging` are invoked. 