### PR TITLE
Add Show.counts.artists

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -8015,6 +8015,7 @@ type ShowCounts {
     format: String
     label: String
   ): FormattedNumber
+  artists: Int
 }
 
 # An edge in a connection.

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -39,6 +39,7 @@ export default opts => {
     partnerLocationsLoader: gravityLoader(id => `partner/${id}/locations`),
     partnerShowArtworksLoader: gravityLoader(({ partner_id, show_id }) => `partner/${partner_id}/show/${show_id}/artworks`, {}, { headers: true }),
     partnerShowImagesLoader: gravityLoader(id => `partner_show/${id}/images`),
+    partnerShowArtistsLoader: gravityLoader(({ partner_id, show_id }) => `partner/${partner_id}/show/${show_id}/artists`, {}, { headers: true }),
     partnerShowLoader: gravityLoader(({ partner_id, show_id }) => `partner/${partner_id}/show/${show_id}`),
     partnersLoader: gravityLoader("partners"),
     popularArtistsLoader: gravityLoader(`artists/popular`),

--- a/src/schema/__tests__/show.test.js
+++ b/src/schema/__tests__/show.test.js
@@ -536,6 +536,13 @@ describe("Show type", () => {
         },
       })
     )
+    rootValue.partnerShowArtistsLoader = jest.fn(() =>
+      Promise.resolve({
+        headers: {
+          "x-total-count": 21,
+        },
+      })
+    )
     const query = gql`
       {
         show(id: "new-museum-1-2015-triennial-surround-audience") {
@@ -550,6 +557,33 @@ describe("Show type", () => {
       show: {
         counts: {
           artworks: 42,
+        },
+      },
+    })
+  })
+
+  it("includes the total number of artists", async () => {
+    rootValue.partnerShowArtistsLoader = jest.fn(() =>
+      Promise.resolve({
+        headers: {
+          "x-total-count": 21,
+        },
+      })
+    )
+    const query = gql`
+      {
+        show(id: "new-museum-1-2015-triennial-surround-audience") {
+          counts {
+            artists
+          }
+        }
+      }
+    `
+    const data = await runQuery(query, rootValue)
+    expect(data).toEqual({
+      show: {
+        counts: {
+          artists: 21,
         },
       },
     })

--- a/src/schema/show.ts
+++ b/src/schema/show.ts
@@ -321,6 +321,24 @@ export const ShowType = new GraphQLObjectType({
           eligible_artworks: numeral(
             ({ eligible_artworks_count }) => eligible_artworks_count
           ),
+          artists: {
+            type: GraphQLInt,
+            resolve: (
+              { id, partner },
+              options,
+              _request,
+              { rootValue: { partnerShowArtistsLoader } }
+            ) => {
+              return totalViaLoader(
+                partnerShowArtistsLoader,
+                {
+                  partner_id: partner.id,
+                  show_id: id,
+                },
+                options
+              )
+            },
+          },
         },
       }),
       resolve: partner_show => partner_show,


### PR DESCRIPTION
Exposes the count of artists associated with a show, as part of [LD-51](https://artsyproduct.atlassian.net/browse/LD-51), which is [designed to include text with "X works by Y artists"](https://app.zeplin.io/project/5bef4c7dae2b6a3eb6a75f4a/screen/5c1427dea15cd3246ec6a953).