### PR TITLE
#donotmerge set ELB connection idle timeout to 5 seconds

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -106,7 +106,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
     service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "5"
 spec:
   ports:
   - port: 443

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -97,7 +97,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
     service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "5"
 spec:
   ports:
   - port: 443


### PR DESCRIPTION
Update ELB configuration to set the backend connection idle timeout to 5 seconds, matching Node's [server keepalive timeout](https://nodejs.org/api/http.html#http_server_keepalivetimeout) and preventing the ELB using connections Node has closed.

## Migration

Staging: `hokusai staging update`
Production: `hokusai production update`