### PR TITLE
Expose and structure artist insights from Gravity

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -258,6 +258,7 @@ type Artist implements Node {
   hometown: String
   image: Image
   initials(length: Int = 3): String
+  insights: [ArtistInsight]
   is_consignable: Boolean
 
   # Only specific Artists should show a link to auction results.
@@ -434,6 +435,17 @@ type ArtistHighlights {
   ): PartnerArtistConnection
 }
 
+type ArtistInsight {
+  # The type of insight.
+  type: String
+
+  # Label to use when displaying the insight.
+  label: String
+
+  # List of entities relevant to the insight.
+  entities: [String]
+}
+
 type ArtistItem implements Node {
   # A globally unique ID.
   __id: ID!
@@ -580,6 +592,7 @@ type ArtistItem implements Node {
   hometown: String
   image: Image
   initials(length: Int = 3): String
+  insights: [ArtistInsight]
   is_consignable: Boolean
 
   # Only specific Artists should show a link to auction results.

--- a/src/schema/artist/__tests__/insights.test.ts
+++ b/src/schema/artist/__tests__/insights.test.ts
@@ -1,0 +1,135 @@
+/* eslint-disable promise/always-return */
+import { runQuery } from "test/utils"
+
+describe("ArtistInsights type", () => {
+  let artist = null as any
+  let rootValue = null as any
+
+  beforeEach(() => {
+    artist = {
+      id: "foo-bar",
+      name: "Foo Bar",
+    }
+    rootValue = {
+      artistLoader: () => Promise.resolve(artist),
+    }
+  })
+
+  it("returns an empty list if field values are null", () => {
+    const query = `
+        {
+          artist(id: "foo-bar") {
+            id
+            insights {
+              type
+              label
+              entities
+            }
+          }
+        }
+      `
+
+    return runQuery(query, rootValue).then(data => {
+      expect(data!.artist.insights).toEqual([])
+    })
+  })
+
+  it("does not build an insight if the field contains an empty string", () => {
+    artist.solo_show_institutions = "  "
+
+    const query = `
+        {
+          artist(id: "foo-bar") {
+            id
+            insights {
+              type
+              label
+              entities
+            }
+          }
+        }
+      `
+
+    return runQuery(query, rootValue).then(data => {
+      expect(data!.artist.insights).toEqual([])
+    })
+  })
+
+  it("returns artist insights if available", () => {
+    artist.solo_show_institutions = "MoMA PS1|Museum of Modern Art (MoMA)"
+    artist.group_show_institutions = "Metropolitan Museum of Art"
+    artist.collections = "Museum of Modern Art (MoMA)"
+    artist.review_sources = "Artforum International Magazine"
+    artist.biennials = "frieze"
+
+    const query = `
+          {
+            artist(id: "foo-bar") {
+              id
+              insights {
+                type
+                label
+                entities
+              }
+            }
+          }
+        `
+
+    return runQuery(query, rootValue).then(data => {
+      expect(data!.artist.insights).toEqual([
+        {
+          type: "SOLO_SHOW",
+          label: "Solo show at a major institution",
+          entities: ["MoMA PS1", "Museum of Modern Art (MoMA)"],
+        },
+        {
+          type: "GROUP_SHOW",
+          label: "Group show at a major institution",
+          entities: ["Metropolitan Museum of Art"],
+        },
+        {
+          type: "COLLECTED",
+          label: "Collected by a major institution",
+          entities: ["Museum of Modern Art (MoMA)"],
+        },
+        {
+          type: "REVIEWED",
+          label: "Reviewed by a major art publication",
+          entities: ["Artforum International Magazine"],
+        },
+        {
+          type: "BIENNIAL",
+          label: "Participated in a major biennial",
+          entities: ["frieze"],
+        },
+      ])
+    })
+  })
+
+  it("splits Artist#collections by newline character", () => {
+    artist.collections = "MoMA PS1\nMuseum of Modern Art (MoMA)"
+
+    const query = `
+          {
+            artist(id: "foo-bar") {
+              id
+              insights {
+                type
+                label
+                entities
+              }
+            }
+          }
+        `
+
+    return runQuery(query, rootValue).then(data => {
+      expect(data!.artist.insights).toEqual([
+        {
+          type: "COLLECTED",
+          label: "Collected by a major institution",
+          entities: ["MoMA PS1", "Museum of Modern Art (MoMA)"],
+        },
+      ])
+    })
+  })
+})

--- a/src/schema/artist/index.ts
+++ b/src/schema/artist/index.ts
@@ -33,6 +33,7 @@ import SaleSorts from "schema/sale/sorts"
 import ArtistCarousel from "./carousel"
 import ArtistStatuses from "./statuses"
 import ArtistHighlights from "./highlights"
+import { ArtistInsights } from "./insights"
 import { CurrentEvent } from "./current"
 import {
   auctionResultConnection,
@@ -599,6 +600,7 @@ export const ArtistType = new GraphQLObjectType({
       hometown: { type: GraphQLString },
       image: Image,
       initials: initials("name"),
+      insights: ArtistInsights,
       is_consignable: {
         type: GraphQLBoolean,
         resolve: ({ consignable }) => consignable,

--- a/src/schema/artist/insights.ts
+++ b/src/schema/artist/insights.ts
@@ -1,0 +1,91 @@
+import { compact } from "lodash"
+
+import {
+  GraphQLObjectType,
+  GraphQLList,
+  GraphQLEnumType,
+  GraphQLString,
+} from "graphql"
+
+export const ArtistInsightType = new GraphQLEnumType({
+  name: "ArtistInsightType",
+  values: {
+    SOLO_SHOW: {
+      value: "Solo show at a major institution",
+    },
+    GROUP_SHOW: {
+      value: "Group show at a major institution",
+    },
+    COLLECTED: {
+      value: "Collected by a major institution",
+    },
+    REVIEWED: {
+      value: "Reviewed by a major art publication",
+    },
+    BIENNIAL: {
+      value: "Participated in a major biennial",
+    },
+  },
+})
+
+const ArtistInsightTypeMapping = {
+  solo_show_institutions: { type: ArtistInsightType.getValue("SOLO_SHOW") },
+  group_show_institutions: { type: ArtistInsightType.getValue("GROUP_SHOW") },
+  collections: {
+    type: ArtistInsightType.getValue("COLLECTED"),
+    delimiter: "\n",
+  },
+  review_sources: { type: ArtistInsightType.getValue("REVIEWED") },
+  biennials: { type: ArtistInsightType.getValue("BIENNIAL") },
+}
+
+const buildInsights = artist => {
+  const splitEntities = (entitiesString: String, delimiter): Array<String> => {
+    return entitiesString.split(delimiter).map(entity => {
+      return entity.trim()
+    })
+  }
+
+  const buildInsight = (mapping, entitiesString: String) => {
+    return {
+      type: mapping.type.name,
+      entities: splitEntities(entitiesString, mapping.delimiter || "|"),
+      label: mapping.type.value,
+    }
+  }
+
+  return compact(
+    Object.keys(ArtistInsightTypeMapping).map(key => {
+      const entitiesString = artist[key] && artist[key].trim()
+
+      if (entitiesString) {
+        return buildInsight(ArtistInsightTypeMapping[key], entitiesString)
+      }
+    })
+  )
+}
+
+const ArtistInsight = new GraphQLObjectType({
+  name: "ArtistInsight",
+  fields: {
+    type: {
+      type: GraphQLString,
+      description: "The type of insight.",
+    },
+    label: {
+      type: GraphQLString,
+      description: "Label to use when displaying the insight.",
+    },
+    entities: {
+      type: new GraphQLList(GraphQLString),
+      description: "List of entities relevant to the insight.",
+    },
+  },
+})
+
+export const ArtistInsights = {
+  type: new GraphQLList(ArtistInsight),
+  resolve: artist => {
+    return buildInsights(artist)
+  },
+}


### PR DESCRIPTION
We're beginning to load in new artist insights to show on the artist page.

This will expose insights from Gravity via GraphQL, when available for an artist.

Related to https://github.com/artsy/gravity/pull/12059 :lock: 

ticket: https://artsyproduct.atlassian.net/browse/DISCO-588 :lock: 

![2018-12-19-145432_1692x1207_scrot](https://user-images.githubusercontent.com/123595/50248345-b3f3d000-03a8-11e9-9f3d-f92d0cae7729.png)
