### PR TITLE
Document the semantics of EventStatus

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3054,9 +3054,17 @@ enum EventStatus {
   current @deprecated(reason: "use capital enums")
   running @deprecated(reason: "use capital enums")
   upcoming @deprecated(reason: "use capital enums")
+
+  # End date is in the past
   CLOSED
+
+  # Start date or end date is in the future
   CURRENT
+
+  # Start date is in the past and end date is in the future
   RUNNING
+
+  # Start date is in the future
   UPCOMING
 }
 

--- a/src/schema/input_fields/event_status.ts
+++ b/src/schema/input_fields/event_status.ts
@@ -22,15 +22,19 @@ const EventStatus = {
       },
       CLOSED: {
         value: "closed",
+        description: "End date is in the past",
       },
       CURRENT: {
         value: "current",
+        description: "Start date or end date is in the future",
       },
       RUNNING: {
         value: "running",
+        description: "Start date is in the past and end date is in the future",
       },
       UPCOMING: {
         value: "upcoming",
+        description: "Start date is in the future",
       },
     },
   }),


### PR DESCRIPTION
The distinction between `current` and `running` kept throwing me, so I thought I would just document this once and for all, based on [the upstream logic](https://github.com/artsy/gravity/blob/be864aacc0fcdacceb61387eec2e4cbd0fd19253/app/models/util/event_status.rb#L8-L14).

![screen shot 2018-12-19 at 4 13 20 pm](https://user-images.githubusercontent.com/140521/50248431-07661e00-03a9-11e9-82e3-2cc3e370f1e0.png)
