### PR TITLE
Allow finding a local discovery city nearest to an arbitrary point

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -6766,7 +6766,10 @@ type Query {
   # A city-based entry point for local discovery
   city(
     # A slug for the city, conforming to Gravity's city slug naming conventions
-    slug: String!
+    slug: String
+
+    # A point which will be used to locate the nearest local discovery city within a threshold
+    near: Near
   ): City
   collection(
     # The slug or ID of the Collection
@@ -8581,7 +8584,10 @@ type Viewer {
   # A city-based entry point for local discovery
   city(
     # A slug for the city, conforming to Gravity's city slug naming conventions
-    slug: String!
+    slug: String
+
+    # A point which will be used to locate the nearest local discovery city within a threshold
+    near: Near
   ): City
   collection(
     # The slug or ID of the Collection

--- a/src/lib/__tests__/geospatial.test.ts
+++ b/src/lib/__tests__/geospatial.test.ts
@@ -1,0 +1,13 @@
+import { distance } from "lib/geospatial"
+
+describe("distance", () => {
+  it("calculates the haversine distance between two points", () => {
+    const newYork = { lat: 40.71427, lng: -74.00597 }
+    const london = { lat: 51.50853, lng: -0.12574 }
+    const expectedDistance = 5570214 // meters, rounded
+
+    const roundedDistance = Math.round(distance(newYork, london))
+
+    expect(roundedDistance).toEqual(expectedDistance)
+  })
+})

--- a/src/lib/geospatial.ts
+++ b/src/lib/geospatial.ts
@@ -1,0 +1,24 @@
+interface LatLng {
+  lat: number
+  lng: number
+}
+
+const EARTH_RADIUS_IN_METERS = 6371e3
+
+const toRadians = (degrees: number): number => degrees * (Math.PI / 180)
+
+const haversineDistance = (point1: LatLng, point2: LatLng): number => {
+  const φ1 = toRadians(point1.lat)
+  const φ2 = toRadians(point2.lat)
+  const Δφ = toRadians(point2.lat - point1.lat)
+  const Δλ = toRadians(point2.lng - point1.lng)
+
+  const a =
+    Math.sin(Δφ / 2) * Math.sin(Δφ / 2) +
+    Math.cos(φ1) * Math.cos(φ2) * Math.sin(Δλ / 2) * Math.sin(Δλ / 2)
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+
+  return EARTH_RADIUS_IN_METERS * c
+}
+
+export { haversineDistance as distance }

--- a/src/lib/geospatial.ts
+++ b/src/lib/geospatial.ts
@@ -1,12 +1,19 @@
 /**
  * Represents a latitude/longitude coordinate pair
  */
-interface LatLng {
+export interface LatLng {
   /** Latitude in decimal degrees */
   lat: number
 
   /** Longitude in decimal degrees */
   lng: number
+}
+
+/**
+ * Represents a geospatial point feature
+ */
+export interface Point {
+  coordinates: LatLng
 }
 
 const EARTH_RADIUS_IN_METERS = 6371e3 // https://en.wikipedia.org/wiki/Earth_radius#Mean_radius

--- a/src/lib/geospatial.ts
+++ b/src/lib/geospatial.ts
@@ -3,10 +3,29 @@ interface LatLng {
   lng: number
 }
 
-const EARTH_RADIUS_IN_METERS = 6371e3
+const EARTH_RADIUS_IN_METERS = 6371e3 // https://en.wikipedia.org/wiki/Earth_radius#Mean_radius
 
+/**
+ * Convert angular distance from degrees to radians
+ *
+ * @param {number} degrees - decimal degrees
+ * @returns {number} radians
+ */
 const toRadians = (degrees: number): number => degrees * (Math.PI / 180)
 
+/**
+ * Calculates the haversine (spherical) distance between two geographic points.
+ * Arguments are supplied as `LatLng` objects, with coordinates specified
+ * as `lat` and `lng` properties in decimal degrees.
+ *
+ * See:
+ * https://en.wikipedia.org/wiki/Haversine_formula
+ * https://www.movable-type.co.uk/scripts/latlong.html
+ *
+ * @param {LatLng} point1 - an object with `lat` and `lng` properties
+ * @param {LatLng} point2 - an object with `lat` and `lng` properties
+ * @returns {number} Distance between point1 and point2, in meters
+ */
 const haversineDistance = (point1: LatLng, point2: LatLng): number => {
   const φ1 = toRadians(point1.lat)
   const φ2 = toRadians(point2.lat)

--- a/src/lib/geospatial.ts
+++ b/src/lib/geospatial.ts
@@ -1,5 +1,11 @@
+/**
+ * Represents a latitude/longitude coordinate pair
+ */
 interface LatLng {
+  /** Latitude in decimal degrees */
   lat: number
+
+  /** Longitude in decimal degrees */
   lng: number
 }
 
@@ -15,16 +21,12 @@ const toRadians = (degrees: number): number => degrees * (Math.PI / 180)
 
 /**
  * Calculates the haversine (spherical) distance between two geographic points.
- * Arguments are supplied as `LatLng` objects, with coordinates specified
- * as `lat` and `lng` properties in decimal degrees.
  *
  * See:
  * https://en.wikipedia.org/wiki/Haversine_formula
  * https://www.movable-type.co.uk/scripts/latlong.html
  *
- * @param {LatLng} point1 - an object with `lat` and `lng` properties
- * @param {LatLng} point2 - an object with `lat` and `lng` properties
- * @returns {number} Distance between point1 and point2, in meters
+ * @returns Distance between point1 and point2, in meters
  */
 const haversineDistance = (point1: LatLng, point2: LatLng): number => {
   const φ1 = toRadians(point1.lat)

--- a/src/schema/__tests__/city.test.ts
+++ b/src/schema/__tests__/city.test.ts
@@ -19,65 +19,69 @@ beforeEach(() => {
 })
 
 describe("City", () => {
-  it("finds a city by its slug", () => {
-    const query = gql`
-      {
-        city(slug: "sacramende-ca-usa") {
-          name
+  describe("finding by slug", () => {
+    it("finds a city by its slug", () => {
+      const query = gql`
+        {
+          city(slug: "sacramende-ca-usa") {
+            name
+          }
         }
-      }
-    `
+      `
 
-    return runQuery(query).then(result => {
-      expect(result!.city).toEqual({
-        name: "Sacramende",
+      return runQuery(query).then(result => {
+        expect(result!.city).toEqual({
+          name: "Sacramende",
+        })
       })
+    })
+
+    it("returns a helpful error for unknown slugs", () => {
+      expect.assertions(1)
+      const query = gql`
+        {
+          city(slug: "sacramundo") {
+            name
+          }
+        }
+      `
+      return runQuery(query).catch(e =>
+        expect(e.message).toMatch(/City sacramundo not found in:/)
+      )
     })
   })
 
-  it("returns a helpful error for unknown slugs", () => {
-    expect.assertions(1)
-    const query = gql`
-      {
-        city(slug: "sacramundo") {
-          name
+  describe("finding by lat/lng", () => {
+    it("finds the city nearest to a supplied point", () => {
+      const pointNearSmallville = "{ lat: 40, lng: -100 }"
+      const query = `
+        {
+          city(near: ${pointNearSmallville}) {
+            name
+          }
         }
-      }
-    `
-    return runQuery(query).catch(e =>
-      expect(e.message).toMatch(/City sacramundo not found in:/)
-    )
-  })
+      `
 
-  it("finds the city nearest to a supplied point", () => {
-    const pointNearSmallville = "{ lat: 40, lng: -100 }"
-    const query = `
-      {
-        city(near: ${pointNearSmallville}) {
-          name
-        }
-      }
-    `
-
-    return runQuery(query).then(result => {
-      expect(result!.city).toEqual({
-        name: "Smallville",
+      return runQuery(query).then(result => {
+        expect(result!.city).toEqual({
+          name: "Smallville",
+        })
       })
     })
-  })
 
-  it("returns null if no cities are within a defined threshold", () => {
-    const veryRemotePoint = "{ lat: 90, lng: 0 }"
-    const query = gql`
-      {
-        city(near: ${veryRemotePoint}) {
-          name
+    it("returns null if no cities are within a defined threshold", () => {
+      const veryRemotePoint = "{ lat: 90, lng: 0 }"
+      const query = gql`
+        {
+          city(near: ${veryRemotePoint}) {
+            name
+          }
         }
-      }
-    `
+      `
 
-    return runQuery(query).then(result => {
-      expect(result!.city).toBeNull()
+      return runQuery(query).then(result => {
+        expect(result!.city).toBeNull()
+      })
     })
   })
 
@@ -163,37 +167,39 @@ describe("City", () => {
     })
   })
 
-  it("resolves nearby fairs", () => {
-    const query = gql`
-      {
-        city(slug: "sacramende-ca-usa") {
-          name
-          fairs {
-            id
+  describe("fairs", () => {
+    it("resolves nearby fairs", () => {
+      const query = gql`
+        {
+          city(slug: "sacramende-ca-usa") {
+            name
+            fairs {
+              id
+            }
           }
         }
+      `
+
+      const mockFairs = [{ id: "first-fair" }]
+      const mockFairsLoader = jest.fn(() => Promise.resolve(mockFairs))
+      const rootValue = {
+        fairsLoader: mockFairsLoader,
+        accessToken: null,
+        userID: null,
       }
-    `
 
-    const mockFairs = [{ id: "first-fair" }]
-    const mockFairsLoader = jest.fn(() => Promise.resolve(mockFairs))
-    const rootValue = {
-      fairsLoader: mockFairsLoader,
-      accessToken: null,
-      userID: null,
-    }
-
-    return runQuery(query, rootValue).then(result => {
-      expect(result!.city).toEqual({
-        name: "Sacramende",
-        fairs: mockFairs,
-      })
-
-      expect(mockFairsLoader).toHaveBeenCalledWith(
-        expect.objectContaining({
-          near: "38.5,-121.8",
+      return runQuery(query, rootValue).then(result => {
+        expect(result!.city).toEqual({
+          name: "Sacramende",
+          fairs: mockFairs,
         })
-      )
+
+        expect(mockFairsLoader).toHaveBeenCalledWith(
+          expect.objectContaining({
+            near: "38.5,-121.8",
+          })
+        )
+      })
     })
   })
 })

--- a/src/schema/__tests__/city.test.ts
+++ b/src/schema/__tests__/city.test.ts
@@ -7,6 +7,11 @@ const mockCities = {
     name: "Sacramende",
     coordinates: { lat: 38.5, lng: -121.8 },
   },
+  "smallville-usa": {
+    slug: "smallvile-usa",
+    name: "Smallville",
+    coordinates: { lat: 39.78, lng: -100.45 },
+  },
 }
 
 beforeEach(() => {
@@ -42,6 +47,38 @@ describe("City", () => {
     return runQuery(query).catch(e =>
       expect(e.message).toMatch(/City sacramundo not found in:/)
     )
+  })
+
+  it("finds the city nearest to a supplied point", () => {
+    const pointNearSmallville = "{ lat: 40, lng: -100 }"
+    const query = `
+      {
+        city(near: ${pointNearSmallville}) {
+          name
+        }
+      }
+    `
+
+    return runQuery(query).then(result => {
+      expect(result!.city).toEqual({
+        name: "Smallville",
+      })
+    })
+  })
+
+  it("returns null if no cities are within a defined threshold", () => {
+    const veryRemotePoint = "{ lat: 90, lng: 0 }"
+    const query = gql`
+      {
+        city(near: ${veryRemotePoint}) {
+          name
+        }
+      }
+    `
+
+    return runQuery(query).then(result => {
+      expect(result!.city).toBeNull()
+    })
   })
 
   describe("shows", () => {

--- a/src/schema/city/constants.ts
+++ b/src/schema/city/constants.ts
@@ -1,1 +1,2 @@
 export const LOCAL_DISCOVERY_RADIUS_KM = 75
+export const NEAREST_CITY_THRESHOLD_KM = 150

--- a/src/schema/city/index.ts
+++ b/src/schema/city/index.ts
@@ -2,7 +2,6 @@ import {
   GraphQLBoolean,
   GraphQLInt,
   GraphQLList,
-  GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
 } from "graphql"
@@ -17,8 +16,13 @@ import EventStatus from "schema/input_fields/event_status"
 import cityData from "./city_data.json"
 import { pageable } from "relay-cursor-paging"
 import { connectionFromArraySlice } from "graphql-relay"
-import { LOCAL_DISCOVERY_RADIUS_KM } from "./constants"
+import {
+  LOCAL_DISCOVERY_RADIUS_KM,
+  NEAREST_CITY_THRESHOLD_KM,
+} from "./constants"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import Near from "schema/input_fields/near"
+import { distance } from "lib/geospatial"
 
 const CityType = new GraphQLObjectType({
   name: "City",
@@ -100,13 +104,29 @@ export const City = {
   description: "A city-based entry point for local discovery",
   args: {
     slug: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: GraphQLString,
       description:
         "A slug for the city, conforming to Gravity's city slug naming conventions",
     },
+    near: {
+      type: Near,
+      description:
+        "A point which will be used to locate the nearest local discovery city within a threshold",
+    },
   },
-  resolve: (_obj, args) => {
-    return lookupCity(args.slug)
+  resolve: (_obj, { slug, near }) => {
+    if (slug && near) {
+      throw new Error('The "slug" and "near" arguments are mutually exclusive.')
+    }
+    if (!slug && !near) {
+      throw new Error('One of the arguments "slug" or "near" is required.')
+    }
+    if (slug) {
+      return lookupCity(slug)
+    }
+    if (near) {
+      return nearestCityOrNull(near)
+    }
   },
 }
 
@@ -117,4 +137,28 @@ const lookupCity = slug => {
     )
   }
   return cityData[slug]
+}
+
+const nearestCityOrNull = latLng => {
+  const orderedCities = citiesOrderedByDistance(latLng)
+  const closestCity = orderedCities[0]
+
+  if (isCloseEnough(latLng, closestCity)) {
+    return closestCity
+  }
+  return null
+}
+
+const citiesOrderedByDistance = latLng => {
+  let cities = Object.values(cityData)
+  cities.sort((a: any, b: any) => {
+    const distanceA = distance(latLng, a.coordinates)
+    const distanceB = distance(latLng, b.coordinates)
+    return distanceA - distanceB
+  })
+  return cities
+}
+
+const isCloseEnough = (latLng, city) => {
+  return distance(latLng, city.coordinates) < NEAREST_CITY_THRESHOLD_KM * 1000
 }

--- a/src/schema/city/index.ts
+++ b/src/schema/city/index.ts
@@ -22,7 +22,7 @@ import {
 } from "./constants"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import Near from "schema/input_fields/near"
-import { distance } from "lib/geospatial"
+import { LatLng, Point, distance } from "lib/geospatial"
 
 const CityType = new GraphQLObjectType({
   name: "City",
@@ -125,12 +125,12 @@ export const City = {
       return lookupCity(slug)
     }
     if (near) {
-      return nearestCityOrNull(near)
+      return nearestCity(near)
     }
   },
 }
 
-const lookupCity = slug => {
+const lookupCity = (slug: string) => {
   if (!cityData.hasOwnProperty(slug)) {
     throw new Error(
       `City ${slug} not found in: ${Object.keys(cityData).join(", ")}`
@@ -139,9 +139,9 @@ const lookupCity = slug => {
   return cityData[slug]
 }
 
-const nearestCityOrNull = latLng => {
-  const orderedCities = citiesOrderedByDistance(latLng)
-  const closestCity = orderedCities[0]
+const nearestCity = (latLng: LatLng) => {
+  const orderedCities: Point[] = citiesOrderedByDistance(latLng)
+  const closestCity: Point = orderedCities[0]
 
   if (isCloseEnough(latLng, closestCity)) {
     return closestCity
@@ -149,9 +149,9 @@ const nearestCityOrNull = latLng => {
   return null
 }
 
-const citiesOrderedByDistance = latLng => {
-  let cities = Object.values(cityData)
-  cities.sort((a: any, b: any) => {
+const citiesOrderedByDistance = (latLng: LatLng): Point[] => {
+  let cities: Point[] = Object.values(cityData)
+  cities.sort((a: Point, b: Point) => {
     const distanceA = distance(latLng, a.coordinates)
     const distanceB = distance(latLng, b.coordinates)
     return distanceA - distanceB
@@ -159,6 +159,6 @@ const citiesOrderedByDistance = latLng => {
   return cities
 }
 
-const isCloseEnough = (latLng, city) => {
+const isCloseEnough = (latLng: LatLng, city: Point) => {
   return distance(latLng, city.coordinates) < NEAREST_CITY_THRESHOLD_KM * 1000
 }

--- a/src/schema/city/index.ts
+++ b/src/schema/city/index.ts
@@ -140,8 +140,8 @@ const lookupCity = (slug: string) => {
 }
 
 const nearestCity = (latLng: LatLng) => {
-  const orderedCities: Point[] = citiesOrderedByDistance(latLng)
-  const closestCity: Point = orderedCities[0]
+  const orderedCities = citiesOrderedByDistance(latLng)
+  const closestCity = orderedCities[0]
 
   if (isCloseEnough(latLng, closestCity)) {
     return closestCity
@@ -151,7 +151,7 @@ const nearestCity = (latLng: LatLng) => {
 
 const citiesOrderedByDistance = (latLng: LatLng): Point[] => {
   let cities: Point[] = Object.values(cityData)
-  cities.sort((a: Point, b: Point) => {
+  cities.sort((a, b) => {
     const distanceA = distance(latLng, a.coordinates)
     const distanceB = distance(latLng, b.coordinates)
     return distanceA - distanceB
@@ -159,6 +159,5 @@ const citiesOrderedByDistance = (latLng: LatLng): Point[] => {
   return cities
 }
 
-const isCloseEnough = (latLng: LatLng, city: Point) => {
-  return distance(latLng, city.coordinates) < NEAREST_CITY_THRESHOLD_KM * 1000
-}
+const isCloseEnough = (latLng: LatLng, city: Point) =>
+  distance(latLng, city.coordinates) < NEAREST_CITY_THRESHOLD_KM * 1000


### PR DESCRIPTION
Implements: https://artsyproduct.atlassian.net/browse/LD-64
Follow-up to: https://github.com/artsy/emission/pull/1252#discussion_r243255869

This allows a client to find a local discovery city by latititude/longitude, as obtained e.g. via a device's geolocation API.

To do this we modify the root `city` query to allow lookup by lat/lng (in addition to the already implemented lookup by slug).

The lat/lng lookup is subject to a threshold, such that if you supply a point close enough to an existing city you will get a result:

![found](https://user-images.githubusercontent.com/140521/50493427-6a7c3400-09eb-11e9-810f-83783f880c9e.png)

But if you supply a point not close enough, you will get `null`:

![null](https://user-images.githubusercontent.com/140521/50493432-6f40e800-09eb-11e9-8e74-0bc43caef4f7.png)

In the Emission thread we discussed having this query return the city if an appropriate one is found, or else `null` or something representing _no city found_. I've modeled this as a simple `null` for now but am open to suggestion, if that is not idiomatic GraphQL.