### PR TITLE
[Artwork#meta] Add new `share` field

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -769,7 +769,6 @@ type Artwork implements Node & Sellable {
   artist_names: String
   articles(size: Int): [Article]
   availability: String
-  myLotStanding(live: Boolean = null): [LotStanding!]
   can_share_image: Boolean
     @deprecated(reason: "Favor `is_`-prefixed boolean attributes")
   category: String
@@ -857,6 +856,7 @@ type Artwork implements Node & Sellable {
   medium: String
   metric: String @deprecated(reason: "Prefer dimensions instead.")
   meta: ArtworkMeta
+  myLotStanding(live: Boolean = null): [LotStanding!]
 
   # [DO NOT USE] Weekly pageview data (static).
   pageviews: Int
@@ -1597,7 +1597,6 @@ type ArtworkItem implements Node & Sellable {
   artist_names: String
   articles(size: Int): [Article]
   availability: String
-  myLotStanding(live: Boolean = null): [LotStanding!]
   can_share_image: Boolean
     @deprecated(reason: "Favor `is_`-prefixed boolean attributes")
   category: String
@@ -1685,6 +1684,7 @@ type ArtworkItem implements Node & Sellable {
   medium: String
   metric: String @deprecated(reason: "Prefer dimensions instead.")
   meta: ArtworkMeta
+  myLotStanding(live: Boolean = null): [LotStanding!]
 
   # [DO NOT USE] Weekly pageview data (static).
   pageviews: Int
@@ -1765,6 +1765,7 @@ type ArtworkLayer {
 type ArtworkMeta {
   description(limit: Int = 155): String
   image: String
+  share: String
   title: String
 }
 

--- a/src/schema/artwork/__tests__/meta.test.ts
+++ b/src/schema/artwork/__tests__/meta.test.ts
@@ -1,0 +1,77 @@
+import { runQuery } from "test/utils"
+
+describe("Meta", () => {
+  const artworkData = {
+    artists: [
+      {
+        name: "Hans Hartung",
+      },
+    ],
+    title: "P. 25-1975-H-8",
+    date: "1975",
+    forsale: true,
+    dimensions: {
+      in: "22 4/5 × 30 7/10 in",
+      cm: "58 × 78 cm",
+    },
+    medium: "Acrylic on baryte card",
+    metric: "cm",
+    partner: {
+      name: "Galerie Michel Descours",
+    },
+  }
+
+  const rootValue = {
+    artworkLoader: () => Promise.resolve(artworkData),
+  }
+
+  describe("#description", () => {
+    it("returns properly formatted string", async () => {
+      const query = `
+        {
+          artwork(id:"hans-hartung-p-25-1975-h-8") {
+            meta {
+              description
+            }
+          }
+        }
+      `
+
+      const data = await runQuery(query, rootValue as any)
+
+      expect(data).toEqual({
+        artwork: {
+          meta: {
+            description:
+              "Available for sale from Galerie Michel Descours, Hans Hartung, P. 25-1975-H-8 (1975), Acrylic on baryte card, 58 × 78 cm",
+          },
+        },
+      })
+    })
+  })
+
+  describe("#share", () => {
+    it("returns properly formatted string", async () => {
+      const query = `
+        {
+          artwork(id:"hans-hartung-p-25-1975-h-8") {
+            meta {
+              share
+            }
+          }
+        }
+      `
+
+      const data = await runQuery(query, rootValue as any)
+
+      expect(data).toEqual({
+        artwork: {
+          meta: {
+            share:
+              "Check out Hans Hartung, P. 25-1975-H-8 (1975), From Galerie Michel Descours",
+          },
+        },
+      })
+    })
+  })
+})

--- a/src/schema/artwork/index.ts
+++ b/src/schema/artwork/index.ts
@@ -113,19 +113,7 @@ export const artworkFields = () => {
         }).then(({ results }) => results),
     },
     availability: { type: GraphQLString },
-    myLotStanding: {
-      type: new GraphQLList(new GraphQLNonNull(LotStandingType)),
-      args: { live: { type: GraphQLBoolean, defaultValue: null } },
-      resolve: (
-        { id },
-        { live },
-        _request,
-        { rootValue: { lotStandingLoader } }
-      ) => {
-        if (!lotStandingLoader) return null
-        return lotStandingLoader({ artwork_id: id, live })
-      },
-    },
+
     can_share_image: {
       type: GraphQLBoolean,
       deprecationReason: "Favor `is_`-prefixed boolean attributes",
@@ -523,6 +511,19 @@ export const artworkFields = () => {
       deprecationReason: "Prefer dimensions instead.",
     },
     meta: Meta,
+    myLotStanding: {
+      type: new GraphQLList(new GraphQLNonNull(LotStandingType)),
+      args: { live: { type: GraphQLBoolean, defaultValue: null } },
+      resolve: (
+        { id },
+        { live },
+        _request,
+        { rootValue: { lotStandingLoader } }
+      ) => {
+        if (!lotStandingLoader) return null
+        return lotStandingLoader({ artwork_id: id, live })
+      },
+    },
     pageviews: {
       type: GraphQLInt,
       description: "[DO NOT USE] Weekly pageview data (static).",


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/DISCO-628

Adds a new `share` field for returning a properly formatted description in a share context. 

```gql
{
  artwork(id:"hans-hartung-p-25-1975-h-8") {
    meta {
      share
    }
  }
}
```

```json
{
  "data": {
    "artwork": {
      "meta": {
        "share": "Check out Hans Hartung, P. 25-1975-H-8 (1975), From Galerie Michel Descours"
      }
    }
  }
}
```