### PR TITLE
Update stale expectation

### DIFF
--- a/src/schema/artist/__tests__/current.test.js
+++ b/src/schema/artist/__tests__/current.test.js
@@ -153,7 +153,7 @@ describe("Artist type", () => {
         expect(status).toBe("Currently on view")
         expect(href).toBe("/show/catty-show")
         expect(partner).toBe("Catty Partner")
-        expect(details).toBe("Quonochontaug, Dec 21 – 31")
+        expect(details).toBe("Quonochontaug, Dec 21 – 31, 2018")
         expect(event).toEqual({ __typename: "Show", id: "catty-show" })
       }
     )


### PR DESCRIPTION
The format of the date for this show comes from a helper in `src/lib/date.ts` called `exhibitionPeriod` and it has logic about showing and hiding the year. That behavior is tested over in the helper so covering it here isn't necessary so I just updated the expectation to include this concept.