### PR TITLE
Switch to latest Exchange schema to add findActiveOrCreate

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -2790,6 +2790,11 @@ input CreateOfferOrderWithArtworkInput {
 
   # quantity of artwork
   quantity: Int
+
+  # When set to true, we will not reuse existing pending/submitted order.
+  # Otherwise if current user has pending/submitted orders on same artwork/edition
+  # with same quantity, we will return that
+  find_active_or_create: Boolean
   clientMutationId: String
 }
 

--- a/src/data/exchange.graphql
+++ b/src/data/exchange.graphql
@@ -209,9 +209,8 @@ input CreateOfferOrderWithArtworkInput {
   # EditionSet Id
   editionSetId: String
 
-  # When set to true, we will not reuse existing pending/submitted order.
-  # Otherwise if current user has pending/submitted orders on same artwork/edition
-  # with same quantity, we will return that
+  # When set to false, we will create a new order. Otherwise if current user has
+  # pending/submitted orders on same artwork/edition with same quantity, we will return that
   findActiveOrCreate: Boolean = true
 
   # Number of items in the line item, default is 1

--- a/src/data/exchange.graphql
+++ b/src/data/exchange.graphql
@@ -157,6 +157,9 @@ type BuyerRejectOfferPayload {
 }
 
 enum CancelReasonTypeEnum {
+  # cancelation reason is: buyer_lapsed
+  BUYER_LAPSED
+
   # cancelation reason is: buyer_rejected
   BUYER_REJECTED
 
@@ -206,6 +209,11 @@ input CreateOfferOrderWithArtworkInput {
   # EditionSet Id
   editionSetId: String
 
+  # When set to true, we will not reuse existing pending/submitted order.
+  # Otherwise if current user has pending/submitted orders on same artwork/edition
+  # with same quantity, we will return that
+  findActiveOrCreate: Boolean = true
+
   # Number of items in the line item, default is 1
   quantity: Int
 }
@@ -215,7 +223,9 @@ type CreateOfferOrderWithArtworkPayload {
   # A unique identifier for the client performing the mutation.
   clientMutationId: String
 
-  # A union of success/failure
+  # A union of success/failure. If find_active_or_create is not false, it will
+  # return existing pending/submitted order for current user if exists, otherwise
+  # it will return newly created order
   orderOrError: OrderOrFailureUnion!
 }
 

--- a/src/lib/stitching/exchange/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/exchange/__tests__/__snapshots__/schema.test.ts.snap
@@ -160,6 +160,9 @@ type EcommerceBuyOrder implements EcommerceOrder {
 }
 
 enum EcommerceCancelReasonTypeEnum {
+  # cancelation reason is: buyer_lapsed
+  BUYER_LAPSED
+
   # cancelation reason is: buyer_rejected
   BUYER_REJECTED
 
@@ -209,6 +212,11 @@ input EcommerceCreateOfferOrderWithArtworkInput {
   # EditionSet Id
   editionSetId: String
 
+  # When set to true, we will not reuse existing pending/submitted order.
+  # Otherwise if current user has pending/submitted orders on same artwork/edition
+  # with same quantity, we will return that
+  findActiveOrCreate: Boolean = true
+
   # Number of items in the line item, default is 1
   quantity: Int
 }
@@ -218,7 +226,9 @@ type EcommerceCreateOfferOrderWithArtworkPayload {
   # A unique identifier for the client performing the mutation.
   clientMutationId: String
 
-  # A union of success/failure
+  # A union of success/failure. If find_active_or_create is not false, it will
+  # return existing pending/submitted order for current user if exists, otherwise
+  # it will return newly created order
   orderOrError: EcommerceOrderOrFailureUnion!
 }
 

--- a/src/lib/stitching/exchange/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/exchange/__tests__/__snapshots__/schema.test.ts.snap
@@ -212,9 +212,8 @@ input EcommerceCreateOfferOrderWithArtworkInput {
   # EditionSet Id
   editionSetId: String
 
-  # When set to true, we will not reuse existing pending/submitted order.
-  # Otherwise if current user has pending/submitted orders on same artwork/edition
-  # with same quantity, we will return that
+  # When set to false, we will create a new order. Otherwise if current user has
+  # pending/submitted orders on same artwork/edition with same quantity, we will return that
   findActiveOrCreate: Boolean = true
 
   # Number of items in the line item, default is 1

--- a/src/schema/ecommerce/create_offer_order_with_artwork_mutation.ts
+++ b/src/schema/ecommerce/create_offer_order_with_artwork_mutation.ts
@@ -5,20 +5,20 @@ import { OrderOrFailureUnionType } from "schema/ecommerce/types/order_or_error_u
 import gql from "lib/gql"
 import { BuyerOrderFields } from "./query_helpers"
 import { extractEcommerceResponse } from "./extractEcommerceResponse"
-import { CreateOrderInputType } from "./types/create_order_input_type"
+import { CreateOfferOrderInputType } from "./types/create_order_input_type"
 
 export const CreateOfferOrderWithArtworkMutation = mutationWithClientMutationId(
   {
     name: "CreateOfferOrderWithArtwork",
     description: "Creates an order with an artwork",
-    inputFields: CreateOrderInputType.getFields(),
+    inputFields: CreateOfferOrderInputType.getFields(),
     outputFields: {
       orderOrError: {
         type: OrderOrFailureUnionType,
       },
     },
     mutateAndGetPayload: (
-      { artworkId, editionSetId, quantity },
+      { artworkId, editionSetId, quantity, findActiveOrCreate },
       context,
       { rootValue: { accessToken, exchangeSchema } }
     ) => {
@@ -31,12 +31,14 @@ export const CreateOfferOrderWithArtworkMutation = mutationWithClientMutationId(
           $artworkId: String!
           $editionSetId: String
           $quantity: Int
+          $findActiveOrCreate: Boolean
         ) {
           ecommerceCreateOfferOrderWithArtwork(
             input: {
               artworkId: $artworkId
               editionSetId: $editionSetId
               quantity: $quantity
+              findActiveOrCreate: $findActiveOrCreate
             }
           ) {
             orderOrError {
@@ -62,6 +64,7 @@ export const CreateOfferOrderWithArtworkMutation = mutationWithClientMutationId(
         artworkId,
         editionSetId,
         quantity,
+        findActiveOrCreate,
       }).then(extractEcommerceResponse("ecommerceCreateOfferOrderWithArtwork"))
     },
   }

--- a/src/schema/ecommerce/types/create_order_input_type.ts
+++ b/src/schema/ecommerce/types/create_order_input_type.ts
@@ -3,6 +3,7 @@ import {
   GraphQLNonNull,
   GraphQLString,
   GraphQLInt,
+  GraphQLBoolean,
 } from "graphql"
 
 export const CreateOrderInputType = new GraphQLInputObjectType({
@@ -19,6 +20,29 @@ export const CreateOrderInputType = new GraphQLInputObjectType({
     quantity: {
       type: GraphQLInt,
       description: "quantity of artwork",
+    },
+  },
+})
+
+export const CreateOfferOrderInputType = new GraphQLInputObjectType({
+  name: "CreateOrderInput",
+  fields: {
+    artworkId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "BSON ID of artwork",
+    },
+    editionSetId: {
+      type: GraphQLString,
+      description: "ID of artwork's edition set",
+    },
+    quantity: {
+      type: GraphQLInt,
+      description: "quantity of artwork",
+    },
+    find_active_or_create: {
+      type: GraphQLBoolean,
+      description:
+        "When set to true, we will not reuse existing pending/submitted order. Otherwise if current user has pending/submitted orders on same artwork/edition with same quantity, we will return that",
     },
   },
 })


### PR DESCRIPTION
# Change
Catch up with latest exchange which includes optional `findActiveOrCreate` flag for `createOfferOrderWithArtwork` mutation.