### PR TITLE
Filter out unwanted shows from artist's shows connection

### DIFF
--- a/src/schema/artist/__tests__/index.test.js
+++ b/src/schema/artist/__tests__/index.test.js
@@ -882,6 +882,16 @@ describe("Artist type", () => {
             {
               id: "foo-bar",
               name: "Catty Art Show",
+              partner: {
+                type: "Gallery",
+              },
+            },
+            {
+              id: "oops",
+              name: "Private Dealer Art Show",
+              partner: {
+                type: "Private Dealer",
+              },
             },
           ],
           headers: { "x-total-count": 35 },
@@ -939,6 +949,8 @@ describe("Artist type", () => {
           for (index = 0; index < 4; index++) {
             expect(around[index].page).toBe(index + 1)
           }
+          // Check that blacklisted shows are not included
+          expect(edges).toHaveLength(1)
           // Check show data included in edges.
           expect(edges[0].node.name).toEqual("Catty Art Show")
           // Check that there is a previous and next page.

--- a/src/schema/artist/shows.ts
+++ b/src/schema/artist/shows.ts
@@ -84,26 +84,31 @@ export const ShowsConnectionField = {
         sort: "-end_at",
         total_count: true,
       })
-    ).then(({ body, headers }) => {
-      const totalCount = headers["x-total-count"]
-      const totalPages = Math.ceil(totalCount / size)
+    )
+      .then(({ body, headers }) => {
+        const whitelistedShows = showsWithBLacklistedPartnersRemoved(body)
+        return { body: whitelistedShows, headers }
+      })
+      .then(({ body, headers }) => {
+        const totalCount = headers["x-total-count"]
+        const totalPages = Math.ceil(totalCount / size)
 
-      return merge(
-        {
-          pageCursors: createPageCursors(pageOptions, totalCount),
-          totalCount,
-        },
-        connectionFromArraySlice(body, args, {
-          arrayLength: totalCount,
-          sliceStart: offset,
-        }),
-        {
-          pageInfo: {
-            hasPreviousPage: page > 1,
-            hasNextPage: page < totalPages,
+        return merge(
+          {
+            pageCursors: createPageCursors(pageOptions, totalCount),
+            totalCount,
           },
-        }
-      )
-    })
+          connectionFromArraySlice(body, args, {
+            arrayLength: totalCount,
+            sliceStart: offset,
+          }),
+          {
+            pageInfo: {
+              hasPreviousPage: page > 1,
+              hasNextPage: page < totalPages,
+            },
+          }
+        )
+      })
   },
 }


### PR DESCRIPTION
The responsive artist page's CV tabs is using the shows connection to fulfill its list of shows.

That was not using the previously existing blacklist logic, this PR adds that.