### PR TITLE
exposing partner/exhibitor profile ids in Fairs

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3350,6 +3350,9 @@ type FairExhibitorsGroup {
 
   # Exhibitors sorted by name
   exhibitors: [String]
+
+  # Partner/Exhibitor default profile id
+  profile_ids: [String]
 }
 
 enum FairSorts {

--- a/src/schema/__tests__/fair.test.js
+++ b/src/schema/__tests__/fair.test.js
@@ -136,6 +136,7 @@ describe("Fair", () => {
           {
             letter: "A",
             exhibitors: ["ArtHelix Gallery"],
+            profile_ids: ["arthelix-gallery"],
           },
         ],
       },
@@ -167,6 +168,7 @@ describe("Fair", () => {
         Promise.resolve({
           body: {
             name: "ArtHelix Gallery",
+            default_profile_id: "arthelix-gallery",
           },
           headers: {
             "x-total-count": 1,
@@ -185,6 +187,7 @@ describe("Fair", () => {
           exhibitors_grouped_by_name {
             letter
             exhibitors
+            profile_ids
           }
         }
       }
@@ -200,6 +203,7 @@ describe("Fair", () => {
           {
             letter: "A",
             exhibitors: ["ArtHelix Gallery"],
+            profile_ids: ["arthelix-gallery"],
           },
         ],
       },

--- a/src/schema/fair.ts
+++ b/src/schema/fair.ts
@@ -244,6 +244,10 @@ const FairType = new GraphQLObjectType({
               type: new GraphQLList(GraphQLString),
               description: "Exhibitors sorted by name",
             },
+            profile_ids: {
+              type: new GraphQLList(GraphQLString),
+              description: "Partner/Exhibitor default profile id",
+            },
           },
         })
       ),
@@ -257,7 +261,11 @@ const FairType = new GraphQLObjectType({
           return []
         }
         const exhibitor_groups: {
-          [letter: string]: { letter: string; exhibitors: [String] }
+          [letter: string]: {
+            letter: string
+            exhibitors: [String]
+            profile_ids: [String]
+          }
         } = {}
         const fetch = allViaLoader(fairPartnersLoader, root._id)
 
@@ -275,10 +283,14 @@ const FairType = new GraphQLObjectType({
             const letter = firstName.charAt(0).toUpperCase()
             if (exhibitor_groups[letter]) {
               exhibitor_groups[letter].exhibitors.push(fairExhibitor.name)
+              exhibitor_groups[letter].profile_ids.push(
+                fairExhibitor.default_profile_id
+              )
             } else {
               exhibitor_groups[letter] = {
                 letter,
                 exhibitors: [fairExhibitor.name],
+                profile_ids: [fairExhibitor.default_profile_id],
               }
             }
           }


### PR DESCRIPTION
This PR adds a new default profile id field in the Fairs exhibitors_grouped_by_name field.

[See LD-115](https://artsyproduct.atlassian.net/browse/LD-115)