### PR TITLE
[graphqlErrorHandler] Include upstream HTTP status code.

### DIFF
--- a/src/lib/__tests__/graphqlErrorHandler.test.ts
+++ b/src/lib/__tests__/graphqlErrorHandler.test.ts
@@ -1,6 +1,10 @@
-import { shouldReportParentError } from "../graphqlErrorHandler"
+import {
+  formattedGraphQLError,
+  shouldReportParentError,
+} from "../graphqlErrorHandler"
 import { GraphQLTimeoutError } from "lib/graphqlTimeoutMiddleware"
 import { HTTPError } from "lib/HTTPError"
+import { GraphQLError } from "graphql"
 
 describe("graphqlErrorHandler", () => {
   describe(shouldReportParentError, () => {
@@ -44,6 +48,65 @@ describe("graphqlErrorHandler", () => {
       expect(
         shouldReportParentError(new GraphQLTimeoutError("oh noes"))
       ).toBeFalsy()
+    })
+  })
+
+  describe(formattedGraphQLError, () => {
+    describe("concerning upstream HTTP status codes", () => {
+      it("does not include a HTTP status code for non HTTP errors", () => {
+        expect(
+          Object.keys(formattedGraphQLError(new GraphQLError("something")))
+        ).not.toContain("extensions")
+      })
+
+      it("does include a HTTP status code for HTTP errors", () => {
+        expect(
+          formattedGraphQLError(
+            new GraphQLError(
+              "not found",
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              new HTTPError("not found", 404)
+            )
+          ).extensions
+        ).toEqual({ httpStatusCodes: [404] })
+      })
+
+      it("does include a HTTP status code for combined HTTP errors", () => {
+        expect(
+          formattedGraphQLError(
+            new GraphQLError(
+              "not found",
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              ({
+                errors: [
+                  new GraphQLError(
+                    "not found",
+                    undefined,
+                    undefined,
+                    undefined,
+                    undefined,
+                    new HTTPError("not found", 404)
+                  ),
+                  new GraphQLError(
+                    "unauthorized",
+                    undefined,
+                    undefined,
+                    undefined,
+                    undefined,
+                    new HTTPError("unauthorized", 403)
+                  ),
+                ],
+              } as any) as Error
+            )
+          ).extensions
+        ).toEqual({ httpStatusCodes: [404, 403] })
+      })
     })
   })
 })

--- a/src/lib/graphqlErrorHandler.ts
+++ b/src/lib/graphqlErrorHandler.ts
@@ -3,7 +3,7 @@ import { error as log } from "lib/loggers"
 import { GraphQLTimeoutError } from "lib/graphqlTimeoutMiddleware"
 import { Request } from "../../node_modules/@types/express"
 import config from "config"
-import { GraphQLError } from "graphql/error/GraphQLError"
+import { GraphQLError, GraphQLFormattedError } from "graphql/error"
 import { HTTPError } from "./HTTPError"
 
 const blacklistHttpStatuses = [401, 403, 404]
@@ -14,8 +14,19 @@ declare class CombinedError extends Error {
 }
 
 const isCombinedError = (
-  error: Error | CombinedError
-): error is CombinedError => error.hasOwnProperty("errors")
+  error?: Error | CombinedError | null
+): error is CombinedError => !!error && error.hasOwnProperty("errors")
+
+const flattenErrors = (error: GraphQLError) => {
+  const originalTopLevelError = error.originalError as
+    | null
+    | undefined
+    | Error
+    | CombinedError
+  return isCombinedError(originalTopLevelError)
+    ? originalTopLevelError.errors
+    : [error]
+}
 
 interface QueryContext {
   req: Request
@@ -63,46 +74,56 @@ const reportErrorToSentry = (
   })
 }
 
+type WriteablePartial<T> = { -readonly [P in keyof T]+?: T[P] }
+
+export const formattedGraphQLError = (
+  topLevelError: GraphQLError,
+  flattenedErrors?: ReadonlyArray<GraphQLError>
+) => {
+  const result: WriteablePartial<GraphQLFormattedError> = {
+    message: topLevelError.message,
+  }
+  if (topLevelError.locations) {
+    result.locations = topLevelError.locations
+  }
+  // Question: Should this be a flag on Sentry enabled, or on being in the production env?
+  if (config.PRODUCTION_ENV) {
+    result.path = topLevelError.path
+    result.stack = topLevelError.stack
+  }
+
+  const httpStatusCodes: number[] = []
+  ;(flattenedErrors || flattenErrors(topLevelError)).forEach(
+    e =>
+      e.originalError instanceof HTTPError &&
+      httpStatusCodes.push(e.originalError.statusCode)
+  )
+  if (httpStatusCodes.length > 0) {
+    result.extensions = { httpStatusCodes }
+  }
+
+  return result
+}
+
 export const graphqlErrorHandler = (
   enableSentry: boolean,
   queryContext: QueryContext
 ) => {
-  return (error: GraphQLError) => {
+  return (topLevelError: GraphQLError) => {
+    const flattenedErrors = flattenErrors(topLevelError)
     if (enableSentry) {
-      const originalTopLevelError = error.originalError as
-        | null
-        | undefined
-        | Error
-        | CombinedError
-
-      if (originalTopLevelError) {
-        if (isCombinedError(originalTopLevelError)) {
-          originalTopLevelError.errors.forEach(error => {
-            if (shouldReportParentError(error.originalError)) {
-              reportErrorToSentry(error, queryContext)
-            }
-          })
-        } else {
-          if (shouldReportParentError(originalTopLevelError)) {
-            reportErrorToSentry(error, queryContext)
-          }
+      flattenedErrors.forEach(e => {
+        if (shouldReportParentError(e.originalError)) {
+          reportErrorToSentry(e, queryContext)
         }
-      } else {
-        reportErrorToSentry(error, queryContext)
-      }
+      })
     } else {
       const path =
-        error.path && error.path.length > 0
-          ? ` (${JSON.stringify(error.path)})`
+        topLevelError.path && topLevelError.path.length > 0
+          ? ` (${JSON.stringify(topLevelError.path)})`
           : ""
-      log(`${error.message}${path}`)
+      log(`${topLevelError.message}${path}`)
     }
-    return {
-      message: error.message,
-      locations: error.locations,
-      // Question: Should this be a flag on Sentry enabled, or on being in the production env?
-      path: config.PRODUCTION_ENV ? null : error.path,
-      stack: config.PRODUCTION_ENV ? null : error.stack,
-    }
+    return formattedGraphQLError(topLevelError, flattenedErrors)
   }
 }


### PR DESCRIPTION
Part of https://artsyproduct.atlassian.net/browse/DISCO-671

Augments an error with `extensions`, as described in the spec https://facebook.github.io/graphql/draft/#sec-Errors.

<img width="1122" alt="screenshot 2019-01-11 at 14 09 34" src="https://user-images.githubusercontent.com/2320/51035529-8c101a80-15aa-11e9-8aa7-970c79da7c8b.png">