### PR TITLE
Don't allow highlighting artworks in the artists carousel which are not canonical artworks

### DIFF
--- a/src/schema/artist/__tests__/carousel.test.js
+++ b/src/schema/artist/__tests__/carousel.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable promise/always-return */
 import { runQuery } from "test/utils"
+import { removeReproductionsFromArtworks } from "../carousel"
 
 describe("ArtistCarousel type", () => {
   let artist = null
@@ -90,4 +91,36 @@ describe("ArtistCarousel type", () => {
       })
     })
   })
+})
+
+it("filters artworks with an attribution class other than what we want", () => {
+  const before = [
+    {
+      title: "No attribution class",
+      attribution_class: undefined,
+    },
+    {
+      title: "Wanted attribution class",
+      attribution_class: "unique",
+    },
+    {
+      title: "Skipped attribution class",
+      attribution_class: "ephemera",
+    },
+  ]
+  const filtered = removeReproductionsFromArtworks(before)
+
+  expect(filtered).toHaveLength(2)
+  expect(filtered).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "attribution_class": undefined,
+    "title": "No attribution class",
+  },
+  Object {
+    "attribution_class": "unique",
+    "title": "Wanted attribution class",
+  },
+]
+`)
 })

--- a/src/schema/artist/carousel.ts
+++ b/src/schema/artist/carousel.ts
@@ -2,6 +2,7 @@ import _ from "lodash"
 import Image from "schema/image"
 import { error } from "lib/loggers"
 import { GraphQLObjectType, GraphQLList } from "graphql"
+import { GravityArtwork } from "types/gravity/artworkResponse"
 
 const ArtistCarouselType = new GraphQLObjectType({
   name: "ArtistCarousel",
@@ -31,7 +32,7 @@ const ArtistCarousel = {
         top_tier: true,
       }),
       artistArtworksLoader(id, {
-        size: 7,
+        size: 10, // we only show a max of 7 though, a hotfix for AS-285
         sort: "-iconicity",
         published: true,
       }),
@@ -55,17 +56,38 @@ const ArtistCarousel = {
           })
           .then(showsWithImages => {
             return showsWithImages.concat(
-              artworks.map(artwork => {
-                return _.assign(
-                  { href: `/artwork/${artwork.id}`, title: artwork.title },
-                  _.find(artwork.images, i => i.is_default)
-                )
-              })
+              removeReproductionsFromArtworks(artworks)
+                .slice(0, 6) // Always return the top 7 artworks
+                .map(artwork => {
+                  return _.assign(
+                    { href: `/artwork/${artwork.id}`, title: artwork.title },
+                    _.find(artwork.images, i => i.is_default)
+                  )
+                })
             )
           })
       })
       .catch(error)
   },
+}
+
+export const removeReproductionsFromArtworks = (artworks: GravityArtwork[]) => {
+  return artworks.filter(a => {
+    // Considering it's likely that we've not covered most artworks
+    // with attribution metadata, I'd prefer to be conservative and
+    // let works without attribution class on the banner
+    if (!a.attribution_class) {
+      return true
+    }
+
+    // Only return unique or limited edition works as these are what we
+    // want to highlight. This gives gallery reps the ability to correctly
+    // set attribution classes on works which shouldn't be in the carousel
+    return (
+      a.attribution_class === "unique" ||
+      a.attribution_class === "limited edition"
+    )
+  })
 }
 
 export default ArtistCarousel

--- a/src/types/gravity/artworkResponse.d.ts
+++ b/src/types/gravity/artworkResponse.d.ts
@@ -1,0 +1,170 @@
+// This is generated from taking a few Artwork responses from
+// Gravity and throwing them into QuickType. You should consider it
+// 90% accurate, but not perfect.
+
+// If you want to make it 100% you should look at alloy/gravitype
+
+/// So, that you can write with types against gravity responses
+export interface GravityArtwork {
+  artist: Artist
+  partner: Partner
+  images: Image[]
+  cultural_makers: any[]
+  artists: Artist[]
+  _id: string
+  id: string
+  title: string
+  display: string
+  manufacturer: null
+  category: string
+  medium: string
+  unique: boolean
+  forsale: boolean
+  sold: boolean
+  date: string
+  dimensions: Dimensions
+  price: string
+  availability: string
+  availability_hidden: boolean
+  ecommerce: boolean
+  offer: boolean
+  collecting_institution: string
+  blurb: string
+  edition_sets_count: number
+  published: boolean
+  private: boolean
+  price_currency: string
+  sale_message: null | string
+  inquireable: boolean
+  acquireable: boolean
+  offerable: boolean
+  published_at: string
+  can_share: boolean
+  can_share_image: boolean
+  deleted_at: null
+  cultural_maker: null
+  sale_ids: any[]
+  /// https://github.com/artsy/gravity/blob/master/app/models/domain/attribution.rb
+  attribution_class:
+    | null
+    | "editioned multiple"
+    | "ephemera"
+    | "limited edition"
+    | "made-to-order"
+    | "non-editioned multiple"
+    | "reproduction"
+    | "unique"
+  cached: number
+}
+
+export interface Artist {
+  _id: string
+  id: string
+  sortable_id: string
+  name: string
+  years: string
+  public: boolean
+  birthday: string
+  consignable: boolean
+  deathday: string
+  nationality: string
+  published_artworks_count: number
+  forsale_artworks_count: number
+  artworks_count: number
+  original_width: null
+  original_height: null
+  image_url: string
+  image_versions: ImageVersion[]
+  image_urls: ArtistImageUrls
+}
+
+export interface ArtistImageUrls {
+  four_thirds: string
+  large: string
+  square: string
+  tall: string
+}
+
+export enum ImageVersion {
+  FourThirds = "four_thirds",
+  Large = "large",
+  Square = "square",
+  Tall = "tall",
+}
+
+export interface Dimensions {
+  in: null | string
+  cm: null | string
+}
+
+export interface Image {
+  id: string
+  position: number
+  aspect_ratio: number
+  downloadable: boolean
+  original_width: number
+  original_height: number
+  is_default: boolean
+  image_url: string
+  image_versions: string[]
+  image_urls: ImageImageUrls
+  tile_size: number
+  tile_overlap: number
+  tile_format: string
+  tile_base_url: null | string
+  max_tiled_height: number
+  max_tiled_width: number
+  gemini_token: string
+  gemini_token_updated_at: null | string
+}
+
+export interface ImageImageUrls {
+  large: string
+  large_rectangle: string
+  larger?: string
+  medium: string
+  medium_rectangle: string
+  normalized?: string
+  small: string
+  square: string
+  tall: string
+}
+
+export interface Partner {
+  partner_categories: PartnerCategory[]
+  _id: string
+  id: string
+  default_profile_id: string
+  default_profile_public: boolean
+  sortable_id: string
+  type:
+    | "Auction"
+    | "Demo"
+    | "Gallery"
+    | "Private Collector"
+    | "Private Dealer"
+    | "Institution"
+    | "Institutional Seller"
+    | "Brand"
+
+  name: string
+  short_name: string
+  pre_qualify: boolean
+  website: string
+  has_full_profile: boolean
+  has_fair_partnership: boolean
+  has_limited_fair_partnership: boolean
+  profile_layout: string
+  display_works_section: boolean
+  profile_banner_display: null | string
+  profile_artists_layout: null | string
+  display_artists_section: boolean
+}
+
+export interface PartnerCategory {
+  _id: string
+  id: string
+  category_type: string
+  name: string
+  internal: boolean
+}


### PR DESCRIPTION
This addresses AS-285 as a reasonable hot-fix at the metaphysics layer

Before:

<img width="1354" alt="screen shot 2019-01-16 at 5 17 14 pm" src="https://user-images.githubusercontent.com/49038/51333491-d3cfef80-1a4b-11e9-815d-33558a488c5c.png">

See that blue lady sitting? That's a print that isn't  really *that* iconic, maybe the original is, then there's an edition multiple after that and so on. These works aren't the most canonical works for an artist, and so we don't want to be highlighting them inside the Artists carousel. This PR removes their ability to show up. 

<img width="1580" alt="screen shot 2019-01-17 at 11 18 22 am" src="https://user-images.githubusercontent.com/49038/51333545-fa8e2600-1a4b-11e9-87e2-be780eed7fdb.png">

It does this by over asking for artworks, and filters out artworks based on their attribution types.

---

Also adds a type definition for a gravity API response, so that you can feel safer working with those rest responses.