### PR TITLE
expose gallery website urls in Shows field

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -6398,6 +6398,9 @@ type Partner implements Node {
     status: EventStatus
   ): [PartnerShow]
   type: String
+
+  # The gallery partner's web address
+  website: String
 }
 
 type PartnerArtist {
@@ -8165,9 +8168,6 @@ type Show implements Node {
 
   # The partner that represents this show, could be a non-Artsy partner
   partner: PartnerTypes
-
-  # The website of the partners in the show
-  partner_url: String
 
   # The press release for this show
   press_release(format: Format): String

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -8166,6 +8166,9 @@ type Show implements Node {
   # The partner that represents this show, could be a non-Artsy partner
   partner: PartnerTypes
 
+  # The website of the partners in the show
+  partner_url: String
+
   # The press release for this show
   press_release(format: Format): String
 

--- a/src/schema/__tests__/partner.test.js
+++ b/src/schema/__tests__/partner.test.js
@@ -19,6 +19,7 @@ describe("Partner type", () => {
           name: "Blue Chip",
         },
       ],
+      website: "https://www.newmuseum.org/",
     }
 
     rootValue = {
@@ -27,6 +28,26 @@ describe("Partner type", () => {
         .withArgs(partnerData.id)
         .returns(Promise.resolve(partnerData)),
     }
+  })
+
+  it("includes the gallery website address in shows", async () => {
+    partnerData.partner = {
+      website: "https://www.newmuseum.org/",
+    }
+    const query = gql`
+      {
+        partner(id: "new-museum-1-2015-triennial-surround-audience") {
+          website
+        }
+      }
+    `
+    const data = await runQuery(query, rootValue)
+
+    expect(data).toEqual({
+      partner: {
+        website: "https://www.newmuseum.org/",
+      },
+    })
   })
 
   it("returns a partner and categories", () => {

--- a/src/schema/__tests__/show.test.js
+++ b/src/schema/__tests__/show.test.js
@@ -18,7 +18,6 @@ describe("Show type", () => {
       partner: {
         id: "new-museum",
       },
-      partner_url: "https://www.newmuseum.org/",
       display_on_partner_profile: true,
       eligible_artworks_count: 8,
       is_reference: true,
@@ -58,26 +57,6 @@ describe("Show type", () => {
       galaxyGalleriesLoader: sinon.stub().returns(Promise.resolve(galaxyData)),
       partnerShowLoader: sinon.stub().returns(Promise.resolve(showData)),
     }
-  })
-
-  it("includes the gallery website address in shows", async () => {
-    showData.partner = {
-      website: "https://www.newmuseum.org/",
-    }
-    const query = gql`
-      {
-        show(id: "new-museum-1-2015-triennial-surround-audience") {
-          partner_url
-        }
-      }
-    `
-    const data = await runQuery(query, rootValue)
-
-    expect(data).toEqual({
-      show: {
-        partner_url: "https://www.newmuseum.org/",
-      },
-    })
   })
 
   it("include true has_location flag for shows with location", async () => {

--- a/src/schema/__tests__/show.test.js
+++ b/src/schema/__tests__/show.test.js
@@ -18,6 +18,7 @@ describe("Show type", () => {
       partner: {
         id: "new-museum",
       },
+      partner_url: "https://www.newmuseum.org/",
       display_on_partner_profile: true,
       eligible_artworks_count: 8,
       is_reference: true,
@@ -46,14 +47,37 @@ describe("Show type", () => {
 
     rootValue = {
       showLoader: sinon.stub().returns(Promise.resolve(showData)),
-      showsWithHeadersLoader: sinon
-        .stub()
-        .returns(
-          Promise.resolve({ body: [showData], headers: { "x-total-count": 1 } })
-        ),
+      showsWithHeadersLoader: sinon.stub().returns(
+        Promise.resolve({
+          body: [showData],
+          headers: {
+            "x-total-count": 1,
+          },
+        })
+      ),
       galaxyGalleriesLoader: sinon.stub().returns(Promise.resolve(galaxyData)),
       partnerShowLoader: sinon.stub().returns(Promise.resolve(showData)),
     }
+  })
+
+  it("includes the gallery website address in shows", async () => {
+    showData.partner = {
+      website: "https://www.newmuseum.org/",
+    }
+    const query = gql`
+      {
+        show(id: "new-museum-1-2015-triennial-surround-audience") {
+          partner_url
+        }
+      }
+    `
+    const data = await runQuery(query, rootValue)
+
+    expect(data).toEqual({
+      show: {
+        partner_url: "https://www.newmuseum.org/",
+      },
+    })
   })
 
   it("include true has_location flag for shows with location", async () => {
@@ -684,7 +708,11 @@ describe("Show type", () => {
         show: {
           nearbyShows: {
             edges: [
-              { node: { id: "new-museum-1-2015-triennial-surround-audience" } },
+              {
+                node: {
+                  id: "new-museum-1-2015-triennial-surround-audience",
+                },
+              },
             ],
           },
         },
@@ -738,7 +766,9 @@ describe("Show type", () => {
       await runQuery(query, rootValue)
       const gravityOptions = rootValue.showsWithHeadersLoader.args[0][0]
 
-      expect(gravityOptions).toMatchObject({ displayable: true })
+      expect(gravityOptions).toMatchObject({
+        displayable: true,
+      })
       expect(gravityOptions).not.toHaveProperty("discoverable")
     })
 
@@ -765,7 +795,9 @@ describe("Show type", () => {
       await runQuery(query, rootValue)
       const gravityOptions = rootValue.showsWithHeadersLoader.args[0][0]
 
-      expect(gravityOptions).toMatchObject({ discoverable: true })
+      expect(gravityOptions).toMatchObject({
+        discoverable: true,
+      })
       expect(gravityOptions).not.toHaveProperty("displayable")
     })
   })
@@ -875,7 +907,9 @@ describe("Show type", () => {
         partnerShowArtworksLoader: () =>
           Promise.resolve({
             body: artworksResponse,
-            headers: { "x-total-count": artworksResponse.length },
+            headers: {
+              "x-total-count": artworksResponse.length,
+            },
           }),
         showLoader: () => Promise.resolve(showData),
       }
@@ -982,8 +1016,14 @@ describe("Show type", () => {
         filterArtworksLoader: jest.fn().mockReturnValue(
           Promise.resolve({
             hits: [
-              { id: "1", title: "foo-artwork" },
-              { id: "2", title: "bar-artwork" },
+              {
+                id: "1",
+                title: "foo-artwork",
+              },
+              {
+                id: "2",
+                title: "bar-artwork",
+              },
             ],
             aggregations: {
               total: {
@@ -1023,7 +1063,10 @@ describe("Show type", () => {
             artworks_connection: {
               edges: [
                 {
-                  node: { id: "1", title: "foo-artwork" },
+                  node: {
+                    id: "1",
+                    title: "foo-artwork",
+                  },
                 },
               ],
             },

--- a/src/schema/partner.ts
+++ b/src/schema/partner.ts
@@ -278,6 +278,15 @@ const PartnerType = new GraphQLObjectType({
           return exceptions[type] || type
         },
       },
+      website: {
+        description: "The gallery partner's web address",
+        type: GraphQLString,
+        resolve: root => {
+          if (root.website) {
+            return root.website || ""
+          }
+        },
+      },
     }
   },
 })

--- a/src/schema/partner.ts
+++ b/src/schema/partner.ts
@@ -283,7 +283,7 @@ const PartnerType = new GraphQLObjectType({
         type: GraphQLString,
         resolve: root => {
           if (root.website) {
-            return root.website || ""
+            return root.website
           }
         },
       },

--- a/src/schema/show.ts
+++ b/src/schema/show.ts
@@ -597,6 +597,13 @@ export const ShowType = new GraphQLObjectType({
         }
       },
     },
+    partner_url: {
+      description: "The website of the partners in the show",
+      type: GraphQLString,
+      resolve: (show, _options, _request) => {
+        if (show.partner) return show.partner.website || ""
+      },
+    },
     press_release: {
       description: "The press release for this show",
       ...markdown(),

--- a/src/schema/show.ts
+++ b/src/schema/show.ts
@@ -597,13 +597,6 @@ export const ShowType = new GraphQLObjectType({
         }
       },
     },
-    partner_url: {
-      description: "The website of the partners in the show",
-      type: GraphQLString,
-      resolve: (show, _options, _request) => {
-        if (show.partner) return show.partner.website || ""
-      },
-    },
     press_release: {
       description: "The press release for this show",
       ...markdown(),


### PR DESCRIPTION
This PR adds a partner url field  in the Shows schema to expose the web address galleries have directly uploaded to CMS.

[Links to LD-148](https://artsyproduct.atlassian.net/browse/LD-148)
[Also links to LD-129](https://artsyproduct.atlassian.net/browse/LD-129)