### PR TITLE
Remove deprecated fields from “Order”

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -2378,12 +2378,6 @@ type BuyOrder implements Order {
   # Buyer phone number
   buyerPhoneNumber: String
 
-  # Latest offer
-  lastOffer: Offer
-
-  # List of submitted offers made on this order so far
-  offers: OfferConnection
-
   # Total amount of latest offer
   offerTotalCents: Int @deprecated(reason: "Switch to ItemTotalCents")
 
@@ -5836,12 +5830,6 @@ type OfferOrder implements Order {
   # Buyer phone number
   buyerPhoneNumber: String
 
-  # Latest offer
-  lastOffer: Offer
-
-  # List of submitted offers made on this order so far
-  offers: OfferConnection
-
   # Total amount of latest offer
   offerTotalCents: Int @deprecated(reason: "Switch to ItemTotalCents")
 
@@ -5861,6 +5849,12 @@ type OfferOrder implements Order {
 
   # Waiting for one participants response
   awaitingResponseFrom: OrderParticipantEnum
+
+  # Latest offer
+  lastOffer: Offer
+
+  # List of submitted offers made on this order so far
+  offers: OfferConnection
 }
 
 interface Order {
@@ -6065,12 +6059,6 @@ interface Order {
 
   # Buyer phone number
   buyerPhoneNumber: String
-
-  # Latest offer
-  lastOffer: Offer
-
-  # List of submitted offers made on this order so far
-  offers: OfferConnection
 
   # Total amount of latest offer
   offerTotalCents: Int @deprecated(reason: "Switch to ItemTotalCents")

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -2377,20 +2377,6 @@ type BuyOrder implements Order {
 
   # Buyer phone number
   buyerPhoneNumber: String
-
-  # Total amount of latest offer
-  offerTotalCents: Int @deprecated(reason: "Switch to ItemTotalCents")
-
-  # A formatted price with various currency formatting options.
-  offerTotal(
-    decimal: String = "."
-
-    # Allows control of symbol position (%v = value, %s = symbol)
-    format: String = "%s%v"
-    precision: Int = 0
-    symbol: String
-    thousand: String = ","
-  ): String
 }
 
 enum CancelReasonType {
@@ -5830,20 +5816,6 @@ type OfferOrder implements Order {
   # Buyer phone number
   buyerPhoneNumber: String
 
-  # Total amount of latest offer
-  offerTotalCents: Int @deprecated(reason: "Switch to ItemTotalCents")
-
-  # A formatted price with various currency formatting options.
-  offerTotal(
-    decimal: String = "."
-
-    # Allows control of symbol position (%v = value, %s = symbol)
-    format: String = "%s%v"
-    precision: Int = 0
-    symbol: String
-    thousand: String = ","
-  ): String
-
   # Current User's latest offer
   myLastOffer: Offer
 
@@ -6059,20 +6031,6 @@ interface Order {
 
   # Buyer phone number
   buyerPhoneNumber: String
-
-  # Total amount of latest offer
-  offerTotalCents: Int @deprecated(reason: "Switch to ItemTotalCents")
-
-  # A formatted price with various currency formatting options.
-  offerTotal(
-    decimal: String = "."
-
-    # Allows control of symbol position (%v = value, %s = symbol)
-    format: String = "%s%v"
-    precision: Int = 0
-    symbol: String
-    thousand: String = ","
-  ): String
 }
 
 # A connection to a list of items.

--- a/src/schema/ecommerce/types/order.ts
+++ b/src/schema/ecommerce/types/order.ts
@@ -139,14 +139,6 @@ const orderFields = {
     type: GraphQLString,
     description: "Buyer phone number",
   },
-  lastOffer: {
-    type: OfferType,
-    description: "Latest offer",
-  },
-  offers: {
-    type: OfferConnection,
-    description: "List of submitted offers made on this order so far",
-  },
   offerTotalCents: {
     type: GraphQLInt,
     description: "Total amount of latest offer",

--- a/src/schema/ecommerce/types/order.ts
+++ b/src/schema/ecommerce/types/order.ts
@@ -139,13 +139,6 @@ const orderFields = {
     type: GraphQLString,
     description: "Buyer phone number",
   },
-  offerTotalCents: {
-    type: GraphQLInt,
-    description: "Total amount of latest offer",
-    deprecationReason: "Switch to ItemTotalCents",
-    resolve: ({ itemsTotalCents }) => itemsTotalCents,
-  },
-  offerTotal: amount(({ itemsTotalCents }) => itemsTotalCents),
 }
 
 export const OrderInterface = new GraphQLInterfaceType({


### PR DESCRIPTION
*Partially* resolves https://artsyproduct.atlassian.net/browse/PURCHASE-796. 

Removes the deprecated `lastOffer` and `offers` fields from the `Order` type. (They exist on `OrderOffer` instead.)

The following clients have been checked for use of these fields:

* Eigen: does not use them
* Force: does not use them
* Reaction: Was using `lastOffer`. [Reaction PR #1929](https://github.com/artsy/reaction/pull/1929) has been merged ~, but needs to be released to production before this PR can be merged~ [and deployed!!!](https://github.com/artsy/force/pull/3401).
* Volt: Was using `offers`. [Volt PR #3409](https://github.com/artsy/volt/pull/3409) ~needs to be merged & released to production before this PR can be merged~ [has been merged and deployed!!!](https://github.com/artsy/volt/pull/3414).

Once this PR makes it to production, [a followup PR](https://github.com/artsy/exchange/pull/381) that deprecates the fields in Exchange can be merged.