### PR TITLE
set memory requests equal to limits in production to avoid evictions - set CPU requests to 1 core and deprioritize scheduling on API nodes

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -38,7 +38,7 @@ spec:
         - containerPort: 3000
         resources:
           requests:
-            cpu: 500m
+            cpu: '1'
             memory: 1536Mi
           limits:
             memory: 1536Mi

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -66,14 +66,6 @@ spec:
                 values:
                 - api
                 - foreground
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            preference:
-              matchExpressions:
-              - key: tier
-                operator: In
-                values:
-                - api
 
 ---
 apiVersion: autoscaling/v1

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -39,7 +39,7 @@ spec:
         resources:
           requests:
             cpu: 500m
-            memory: 1Gi
+            memory: 1536Mi
           limits:
             memory: 1536Mi
         readinessProbe:


### PR DESCRIPTION
Since we're scheduling concurrently with Causality and Gravity now, I would like that we don't get into the position of nodes evicting pods - so request as much memory as the limit.

Also set CPU requests to 1 core to avoid overscheduling on any given node.  Seeing high CPU consumption and scheduling of up to 4 metaphysics pods on a given `tier=api` node.  Setting this request higher will avoid over-allocation.
```
$ kubectl top pods --selector app=metaphysics
NAME                              CPU(cores)   MEMORY(bytes)
metaphysics-web-c45f9fb4c-4ffcn   853m         1203Mi
metaphysics-web-c45f9fb4c-7hr5g   889m         1143Mi
metaphysics-web-c45f9fb4c-7j9mr   1173m        844Mi
metaphysics-web-c45f9fb4c-cpft6   802m         1219Mi
metaphysics-web-c45f9fb4c-dnh78   759m         690Mi
metaphysics-web-c45f9fb4c-lxrpn   464m         1195Mi
metaphysics-web-c45f9fb4c-qksv6   1209m        1251Mi
metaphysics-web-c45f9fb4c-qrcnl   1150m        1349Mi
metaphysics-web-c45f9fb4c-vstnl   1016m        888Mi
metaphysics-web-c45f9fb4c-wvk5z   1164m        1448Mi
metaphysics-web-c45f9fb4c-xlrbd   922m         1373Mi
```

Removed the preference to schedule on `tier=api` nodes to also avoid over-allocation.