### PR TITLE
Update 'exchange.graphql' with latest schema from Exchange

### DIFF
--- a/src/data/exchange.graphql
+++ b/src/data/exchange.graphql
@@ -60,7 +60,6 @@ type BuyOrder implements Order {
   # Item total in cents, for Offer Orders this field reflects current offer
   itemsTotalCents: Int
   lastApprovedAt: DateTime
-  lastOffer: Offer @deprecated(reason: "Switch to OfferOrder lastOffer")
   lastSubmittedAt: DateTime
   lineItems(
     # Returns the elements in the list that come after the specified cursor.
@@ -76,21 +75,6 @@ type BuyOrder implements Order {
     last: Int
   ): LineItemConnection
   mode: OrderModeEnum
-  offers(
-    # Returns the elements in the list that come after the specified cursor.
-    after: String
-
-    # Returns the elements in the list that come before the specified cursor.
-    before: String
-
-    # Returns the first _n_ elements from the list.
-    first: Int
-    fromId: String
-    fromType: String
-
-    # Returns the last _n_ elements from the list.
-    last: Int
-  ): OfferConnection @deprecated(reason: "Switch to OfferOrder offers")
   requestedFulfillment: RequestedFulfillmentUnion
   seller: OrderPartyUnion!
   sellerTotalCents: Int
@@ -337,8 +321,10 @@ type LineItem {
   ): FulfillmentConnection
   id: ID!
   listPriceCents: Int!
+  order: Order!
   priceCents: Int! @deprecated(reason: "switch to use listPriceCents")
   quantity: Int!
+  shippingTotalCents: Int
   updatedAt: DateTime!
 }
 
@@ -513,7 +499,6 @@ interface Order {
   # Item total in cents, for Offer Orders this field reflects current offer
   itemsTotalCents: Int
   lastApprovedAt: DateTime
-  lastOffer: Offer @deprecated(reason: "Switch to OfferOrder lastOffer")
   lastSubmittedAt: DateTime
   lineItems(
     # Returns the elements in the list that come after the specified cursor.
@@ -529,21 +514,6 @@ interface Order {
     last: Int
   ): LineItemConnection
   mode: OrderModeEnum
-  offers(
-    # Returns the elements in the list that come after the specified cursor.
-    after: String
-
-    # Returns the elements in the list that come before the specified cursor.
-    before: String
-
-    # Returns the first _n_ elements from the list.
-    first: Int
-    fromId: String
-    fromType: String
-
-    # Returns the last _n_ elements from the list.
-    last: Int
-  ): OfferConnection @deprecated(reason: "Switch to OfferOrder offers")
   requestedFulfillment: RequestedFulfillmentUnion
   seller: OrderPartyUnion!
   sellerTotalCents: Int
@@ -586,10 +556,12 @@ type OrderConnectionWithTotalCount {
 
   # A list of nodes.
   nodes: [Order]
+  pageCursors: PageCursors
 
   # Information to aid in pagination.
   pageInfo: PageInfo!
-  totalCount: Int!
+  totalCount: Int
+  totalPages: Int
 }
 
 # An edge in a connection.
@@ -664,6 +636,28 @@ type OrderWithMutationSuccess {
   order: Order!
 }
 
+type PageCursor {
+  # first cursor on the page
+  cursor: String!
+
+  # is this the current page?
+  isCurrent: Boolean!
+
+  # page number out of totalPages
+  page: Int!
+}
+
+type PageCursors {
+  around: [PageCursor!]!
+
+  # optional, may be included in field around
+  first: PageCursor
+
+  # optional, may be included in field around
+  last: PageCursor
+  previous: PageCursor
+}
+
 # Information about pagination in a connection.
 type PageInfo {
   # When paginating forwards, the cursor to continue.
@@ -689,6 +683,38 @@ type Pickup {
 }
 
 type Query {
+  # Find list of competing orders
+  competingOrders(
+    # Returns the elements in the list that come after the specified cursor.
+    after: String
+
+    # Returns the elements in the list that come before the specified cursor.
+    before: String
+
+    # Returns the first _n_ elements from the list.
+    first: Int
+
+    # Returns the last _n_ elements from the list.
+    last: Int
+    orderId: ID!
+  ): OrderConnectionWithTotalCount
+  lineItems(
+    # Returns the elements in the list that come after the specified cursor.
+    after: String
+    artworkId: String
+
+    # Returns the elements in the list that come before the specified cursor.
+    before: String
+    editionSetId: String
+
+    # Returns the first _n_ elements from the list.
+    first: Int
+
+    # Returns the last _n_ elements from the list.
+    last: Int
+    orderStates: [OrderStateEnum!]
+  ): LineItemConnection
+
   # Find an order by ID
   order(code: String, id: ID): Order
 

--- a/src/lib/stitching/exchange/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/exchange/__tests__/__snapshots__/schema.test.ts.snap
@@ -114,7 +114,6 @@ type EcommerceBuyOrder implements EcommerceOrder {
   # Item total in cents, for Offer Orders this field reflects current offer
   itemsTotalCents: Int
   lastApprovedAt: EcommerceDateTime
-  lastOffer: EcommerceOffer @deprecated(reason: \\"Switch to OfferOrder lastOffer\\")
   lastSubmittedAt: EcommerceDateTime
   lineItems(
     # Returns the elements in the list that come after the specified cursor.
@@ -130,21 +129,6 @@ type EcommerceBuyOrder implements EcommerceOrder {
     last: Int
   ): EcommerceLineItemConnection
   mode: EcommerceOrderModeEnum
-  offers(
-    # Returns the elements in the list that come after the specified cursor.
-    after: String
-
-    # Returns the elements in the list that come before the specified cursor.
-    before: String
-
-    # Returns the first _n_ elements from the list.
-    first: Int
-    fromId: String
-    fromType: String
-
-    # Returns the last _n_ elements from the list.
-    last: Int
-  ): EcommerceOfferConnection @deprecated(reason: \\"Switch to OfferOrder offers\\")
   requestedFulfillment: EcommerceRequestedFulfillmentUnion
   seller: EcommerceOrderPartyUnion!
   sellerTotalCents: Int
@@ -338,8 +322,10 @@ type EcommerceLineItem {
   ): EcommerceFulfillmentConnection
   id: ID!
   listPriceCents: Int!
+  order: EcommerceOrder!
   priceCents: Int! @deprecated(reason: \\"switch to use listPriceCents\\")
   quantity: Int!
+  shippingTotalCents: Int
   updatedAt: EcommerceDateTime!
 }
 
@@ -483,7 +469,6 @@ interface EcommerceOrder {
   # Item total in cents, for Offer Orders this field reflects current offer
   itemsTotalCents: Int
   lastApprovedAt: EcommerceDateTime
-  lastOffer: EcommerceOffer @deprecated(reason: \\"Switch to OfferOrder lastOffer\\")
   lastSubmittedAt: EcommerceDateTime
   lineItems(
     # Returns the elements in the list that come after the specified cursor.
@@ -499,21 +484,6 @@ interface EcommerceOrder {
     last: Int
   ): EcommerceLineItemConnection
   mode: EcommerceOrderModeEnum
-  offers(
-    # Returns the elements in the list that come after the specified cursor.
-    after: String
-
-    # Returns the elements in the list that come before the specified cursor.
-    before: String
-
-    # Returns the first _n_ elements from the list.
-    first: Int
-    fromId: String
-    fromType: String
-
-    # Returns the last _n_ elements from the list.
-    last: Int
-  ): EcommerceOfferConnection @deprecated(reason: \\"Switch to OfferOrder offers\\")
   requestedFulfillment: EcommerceRequestedFulfillmentUnion
   seller: EcommerceOrderPartyUnion!
   sellerTotalCents: Int
@@ -556,10 +526,12 @@ type EcommerceOrderConnectionWithTotalCount {
 
   # A list of nodes.
   nodes: [EcommerceOrder]
+  pageCursors: EcommercePageCursors
 
   # Information to aid in pagination.
   pageInfo: EcommercePageInfo!
-  totalCount: Int!
+  totalCount: Int
+  totalPages: Int
 }
 
 # An edge in a connection.
@@ -632,6 +604,28 @@ type EcommerceOrderWithMutationFailure {
 # A successfully returned order type
 type EcommerceOrderWithMutationSuccess {
   order: EcommerceOrder!
+}
+
+type EcommercePageCursor {
+  # first cursor on the page
+  cursor: String!
+
+  # is this the current page?
+  isCurrent: Boolean!
+
+  # page number out of totalPages
+  page: Int!
+}
+
+type EcommercePageCursors {
+  around: [EcommercePageCursor!]!
+
+  # optional, may be included in field around
+  first: EcommercePageCursor
+
+  # optional, may be included in field around
+  last: EcommercePageCursor
+  previous: EcommercePageCursor
 }
 
 # Information about pagination in a connection.
@@ -862,6 +856,38 @@ type Mutation {
 }
 
 type Query {
+  # Find list of competing orders
+  ecommerceCompetingOrders(
+    # Returns the elements in the list that come after the specified cursor.
+    after: String
+
+    # Returns the elements in the list that come before the specified cursor.
+    before: String
+
+    # Returns the first _n_ elements from the list.
+    first: Int
+
+    # Returns the last _n_ elements from the list.
+    last: Int
+    orderId: ID!
+  ): EcommerceOrderConnectionWithTotalCount
+  ecommerceLineItems(
+    # Returns the elements in the list that come after the specified cursor.
+    after: String
+    artworkId: String
+
+    # Returns the elements in the list that come before the specified cursor.
+    before: String
+    editionSetId: String
+
+    # Returns the first _n_ elements from the list.
+    first: Int
+
+    # Returns the last _n_ elements from the list.
+    last: Int
+    orderStates: [EcommerceOrderStateEnum!]
+  ): EcommerceLineItemConnection
+
   # Find an order by ID
   ecommerceOrder(code: String, id: ID): EcommerceOrder
 


### PR DESCRIPTION
This is the final step (as far as I'm aware) in removing some fields from Exchange, addressing https://artsyproduct.atlassian.net/browse/PURCHASE-796. It updates the copy of the Exchange schema in metaphysics.

There are more changes in here than just mine. I *think* this schema is in metaphysics for reference only, and that whatever I got from Exchange is what we want in MP. If I'm wrong, and I need to track down the owners of the changes, let me know! 

The changes other than my own are:

* Addition of `order` and `shippingTotalCents` to type LineItem
* Addition of `pageCursors`, `totalCount`, and `totalPages` to type OrderConnectionWithTotalCount
* Addition of types PageCursor & PageCursors
* Addition of `competingOrders` and `lineItems` to type Query

