### PR TITLE
Add GraphQL interface for global Artsy search

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -112,7 +112,7 @@ enum ArticleSorts {
   PUBLISHED_AT_DESC
 }
 
-type Artist implements Node {
+type Artist implements Node & Searchable {
   # A globally unique ID.
   __id: ID!
 
@@ -258,6 +258,7 @@ type Artist implements Node {
   has_metadata: Boolean
   hometown: String
   image: Image
+  imageUrl: String
   initials(length: Int = 3): String
   insights: [ArtistInsight]
   is_consignable: Boolean
@@ -267,6 +268,7 @@ type Artist implements Node {
   is_followed: Boolean
   is_public: Boolean
   is_shareable: Boolean
+  displayLabel: String
   location: String
   meta: ArtistMeta
   nationality: String
@@ -448,7 +450,7 @@ type ArtistInsight {
   entities: [String]
 }
 
-type ArtistItem implements Node {
+type ArtistItem implements Node & Searchable {
   # A globally unique ID.
   __id: ID!
 
@@ -594,6 +596,7 @@ type ArtistItem implements Node {
   has_metadata: Boolean
   hometown: String
   image: Image
+  imageUrl: String
   initials(length: Int = 3): String
   insights: [ArtistInsight]
   is_consignable: Boolean
@@ -603,6 +606,7 @@ type ArtistItem implements Node {
   is_followed: Boolean
   is_public: Boolean
   is_shareable: Boolean
+  displayLabel: String
   location: String
   meta: ArtistMeta
   nationality: String
@@ -748,7 +752,7 @@ type ArtistStatuses {
   shows: Boolean
 }
 
-type Artwork implements Node & Sellable {
+type Artwork implements Node & Searchable & Sellable {
   # A globally unique ID.
   __id: ID!
 
@@ -800,6 +804,7 @@ type Artwork implements Node & Sellable {
   highlights: [Highlighted]
   href: String
   image: Image
+  imageUrl: String
   image_rights: String
   image_title: String
   images(size: Int): [Image]
@@ -849,6 +854,7 @@ type Artwork implements Node & Sellable {
   is_shareable: Boolean
   is_sold: Boolean
   is_unique: Boolean
+  displayLabel: String
   layer(id: String): ArtworkLayer
   layers: [ArtworkLayer]
   literature(format: Format): String
@@ -1581,7 +1587,7 @@ type ArtworkInquiryEdge {
   cursor: String!
 }
 
-type ArtworkItem implements Node & Sellable {
+type ArtworkItem implements Node & Searchable & Sellable {
   # A globally unique ID.
   __id: ID!
 
@@ -1633,6 +1639,7 @@ type ArtworkItem implements Node & Sellable {
   highlights: [Highlighted]
   href: String
   image: Image
+  imageUrl: String
   image_rights: String
   image_title: String
   images(size: Int): [Image]
@@ -1682,6 +1689,7 @@ type ArtworkItem implements Node & Sellable {
   is_shareable: Boolean
   is_sold: Boolean
   is_unique: Boolean
+  displayLabel: String
   layer(id: String): ArtworkLayer
   layers: [ArtworkLayer]
   literature(format: Format): String
@@ -7170,6 +7178,22 @@ type Query {
     sort: SaleSorts
   ): [Sale]
 
+  # Global search
+  search(
+    # Search query to perform. Required.
+    query: String!
+
+    # Entities to include in search. Default: [ARTIST, ARTWORK].
+    entities: [SearchEntity]
+
+    # Mode of search to exceute. Default: SITE.
+    mode: SearchMode
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): SearchableConnection
+
   # The schema for difference micro-service settings
   services: Services
 
@@ -7774,6 +7798,51 @@ input SaveArtworkInput {
 type SaveArtworkPayload {
   artwork: Artwork
   clientMutationId: String
+}
+
+# An object that may be searched for
+interface Searchable {
+  displayLabel: String
+  imageUrl: String
+  href: String
+}
+
+# A connection to a list of items.
+type SearchableConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # A list of edges.
+  edges: [SearchableEdge]
+  pageCursors: PageCursors
+  totalCount: Int
+}
+
+# An edge in a connection.
+type SearchableEdge {
+  # The item at the end of the edge
+  node: Searchable
+
+  # A cursor for use in pagination
+  cursor: String!
+}
+
+type SearchableItem implements Node & Searchable {
+  __id: ID!
+  displayLabel: String
+  imageUrl: String
+  href: String
+  searchableType: String
+}
+
+enum SearchEntity {
+  ARTWORK
+  ARTIST
+}
+
+enum SearchMode {
+  AUTOSUGGEST
+  SITE
 }
 
 # A piece that can be sold
@@ -8988,6 +9057,22 @@ type Viewer {
     size: Int
     sort: SaleSorts
   ): [Sale]
+
+  # Global search
+  search(
+    # Search query to perform. Required.
+    query: String!
+
+    # Entities to include in search. Default: [ARTIST, ARTWORK].
+    entities: [SearchEntity]
+
+    # Mode of search to exceute. Default: SITE.
+    mode: SearchMode
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): SearchableConnection
 
   # The schema for difference micro-service settings
   services: Services

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -2,6 +2,7 @@
 import factories from "../api"
 import { uncachedLoaderFactory } from "lib/loaders/api/loader_without_cache_factory"
 import gravity from "lib/apis/gravity"
+import { searchLoader } from "../searchLoader"
 
 export default opts => {
   const { gravityLoaderWithoutAuthenticationFactory } = factories(opts)
@@ -60,6 +61,7 @@ export default opts => {
     saleArtworkLoader: gravityUncachedLoader(({ saleId, saleArtworkId }) => `sale/${saleId}/sale_artwork/${saleArtworkId}`, null),
     saleLoader: gravityLoader(id => `sale/${id}`),
     salesLoader: gravityLoader("sales"),
+    searchLoader: searchLoader(gravityLoader),
     setItemsLoader: gravityLoader(id => `set/${id}/items`),
     setLoader: gravityLoader(id => `set/${id}`),
     setsLoader: gravityLoader("sets"),

--- a/src/lib/loaders/searchLoader.ts
+++ b/src/lib/loaders/searchLoader.ts
@@ -1,0 +1,25 @@
+import * as url from "url"
+import { SearchEntity } from "schema/search"
+
+export const searchLoader = gravityLoader => {
+  return gravityLoader(
+    ({ query, entities, mode, offset, size }) => {
+      const queryParams = {
+        term: query,
+        "indexes[]":
+          entities || SearchEntity.getValues().map(index => index.value),
+        size: size,
+        offset: offset,
+      }
+
+      switch (mode) {
+        case "AUTOSUGGEST":
+          return url.format({ pathname: "/match/suggest", query: queryParams })
+        default:
+          return url.format({ pathname: "/match", query: queryParams })
+      }
+    },
+    {},
+    { headers: true }
+  )
+}

--- a/src/schema/__tests__/search.test.ts
+++ b/src/schema/__tests__/search.test.ts
@@ -1,0 +1,131 @@
+/* eslint-disable promise/always-return */
+import { runQuery } from "test/utils"
+
+describe("Search", () => {
+  let searchResults: any
+  let rootValue: any
+
+  beforeEach(() => {
+    searchResults = [
+      {
+        _id: "artistId",
+        label: "Artist",
+        id: "david-bowie",
+        display: "David Bowie",
+        image_url: "https://example.com/artist.jpg",
+      },
+      {
+        _id: "artworkId",
+        id: "david-bowie-self-portrait",
+        label: "Artwork",
+        display: "Self Portrait",
+        image_url: "https://example.com/artwork.jpg",
+      },
+    ]
+
+    rootValue = {
+      searchLoader: () =>
+        Promise.resolve({
+          body: searchResults,
+          headers: { "x-total-count": 100 },
+        }),
+      artistLoader: () => Promise.resolve({ hometown: "London, UK" }),
+      artworkLoader: () => Promise.resolve({ title: "Self Portrait" }),
+    }
+  })
+
+  it("returns search results for a query", () => {
+    const query = `
+      {
+        search(query: "David Bowie", first: 10) {
+          edges {
+            node {
+              __typename
+              displayLabel
+              href
+              imageUrl
+
+              ... on SearchableItem {
+                searchableType
+              }
+            }
+          }
+        }
+      }
+    `
+
+    return runQuery(query, rootValue).then(data => {
+      const artistSearchableItemNode = data!.search.edges[0].node
+
+      expect(artistSearchableItemNode.__typename).toBe("SearchableItem")
+      expect(artistSearchableItemNode.searchableType).toBe("Artist")
+      expect(artistSearchableItemNode.displayLabel).toBe("David Bowie")
+      expect(artistSearchableItemNode.imageUrl).toBe(
+        "https://example.com/artist.jpg"
+      )
+      expect(artistSearchableItemNode.href).toBe("/artist/david-bowie")
+
+      const artworkSearchableItemNode = data!.search.edges[1].node
+
+      expect(artworkSearchableItemNode.__typename).toBe("SearchableItem")
+      expect(artworkSearchableItemNode.searchableType).toBe("Artwork")
+      expect(artworkSearchableItemNode.displayLabel).toBe("Self Portrait")
+      expect(artworkSearchableItemNode.imageUrl).toBe(
+        "https://example.com/artwork.jpg"
+      )
+      expect(artworkSearchableItemNode.href).toBe(
+        "/artwork/david-bowie-self-portrait"
+      )
+    })
+  })
+
+  it("fetches artist if Artist-specific attributes are requested", () => {
+    const query = `
+      {
+        search(query: "David Bowie", first: 10) {
+          edges {
+            node {
+              __typename
+
+              ... on Artist {
+                hometown
+              }
+            }
+          }
+        }
+      }
+    `
+
+    return runQuery(query, rootValue).then(data => {
+      const artistNode = data!.search.edges[0].node
+
+      expect(artistNode.__typename).toBe("Artist")
+      expect(artistNode.hometown).toBe("London, UK")
+    })
+  })
+
+  it("fetches artwork if Artwork-specific attributes are requested", () => {
+    const query = `
+      {
+        search(query: "David Bowie", first: 10) {
+          edges {
+            node {
+              __typename
+
+              ... on Artwork {
+                title
+              }
+            }
+          }
+        }
+      }
+    `
+
+    return runQuery(query, rootValue).then(data => {
+      const artworkNode = data!.search.edges[1].node
+
+      expect(artworkNode.__typename).toBe("Artwork")
+      expect(artworkNode.title).toBe("Self Portrait")
+    })
+  })
+})

--- a/src/schema/artist/index.ts
+++ b/src/schema/artist/index.ts
@@ -14,7 +14,8 @@ import cached from "schema/fields/cached"
 import initials from "schema/fields/initials"
 import { markdown, formatMarkdownValue } from "schema/fields/markdown"
 import numeral from "schema/fields/numeral"
-import Image from "schema/image"
+import Image, { getDefault } from "schema/image"
+import { setVersion } from "schema/image/normalize"
 import Article, { articleConnection } from "schema/article"
 import Artwork, { artworkConnection } from "schema/artwork"
 import PartnerArtist from "schema/partner_artist"
@@ -40,6 +41,7 @@ import {
   AuctionResultSorts,
 } from "schema/auction_result"
 import ArtistArtworksFilters from "./artwork_filters"
+import { Searchable } from "schema/searchable"
 import filterArtworks from "schema/filter_artworks"
 import { connectionWithCursorInfo } from "schema/fields/pagination"
 import { Related } from "./related"
@@ -81,7 +83,7 @@ const artistArtworkArrayLength = (artist, filter) => {
 
 export const ArtistType = new GraphQLObjectType({
   name: "Artist",
-  interfaces: [NodeInterface],
+  interfaces: [NodeInterface, Searchable],
   fields: (): any => {
     return {
       ...GravityIDFields,
@@ -603,6 +605,18 @@ export const ArtistType = new GraphQLObjectType({
       },
       hometown: { type: GraphQLString },
       image: Image,
+      imageUrl: {
+        type: GraphQLString,
+        resolve: ({ image_versions, image_url, image_urls }) =>
+          setVersion(
+            getDefault({
+              image_url: image_url,
+              images_urls: image_urls,
+              image_versions: image_versions,
+            }),
+            ["square"]
+          ),
+      },
       initials: initials("name"),
       insights: ArtistInsights,
       is_consignable: {
@@ -632,6 +646,7 @@ export const ArtistType = new GraphQLObjectType({
         type: GraphQLBoolean,
         resolve: artist => artist.published_artworks_count > 0,
       },
+      displayLabel: { type: GraphQLString, resolve: ({ name }) => name },
       location: { type: GraphQLString },
       meta: Meta,
       nationality: { type: GraphQLString },

--- a/src/schema/artwork/index.ts
+++ b/src/schema/artwork/index.ts
@@ -6,6 +6,7 @@ import { markdown } from "schema/fields/markdown"
 import Article from "schema/article"
 import Artist from "schema/artist"
 import Image, { getDefault } from "schema/image"
+import { setVersion } from "schema/image/normalize"
 import Fair from "schema/fair"
 import Sale from "schema/sale"
 import SaleArtwork from "schema/sale_artwork"
@@ -19,6 +20,7 @@ import Highlight from "./highlight"
 import Dimensions from "schema/dimensions"
 import EditionSet, { EditionSetSorts } from "schema/edition_set"
 import { Sellable } from "schema/sellable"
+import { Searchable } from "schema/searchable"
 import ArtworkLayer from "./layer"
 import ArtworkLayers, { artworkLayers } from "./layers"
 import { GravityIDFields, NodeInterface } from "schema/object_identification"
@@ -267,6 +269,10 @@ export const artworkFields = () => {
         return Image.resolve(getDefault(images))
       },
     },
+    imageUrl: {
+      type: GraphQLString,
+      resolve: ({ images }) => setVersion(getDefault(images), ["square"]),
+    },
     image_rights: { type: GraphQLString },
     image_title: {
       type: GraphQLString,
@@ -478,6 +484,7 @@ export const artworkFields = () => {
     },
     is_sold: { type: GraphQLBoolean, resolve: ({ sold }) => sold },
     is_unique: { type: GraphQLBoolean, resolve: ({ unique }) => unique },
+    displayLabel: { type: GraphQLString, resolve: ({ title }) => title },
     layer: {
       type: ArtworkLayer.type,
       args: { id: { type: GraphQLString } },
@@ -877,7 +884,7 @@ export const artworkFields = () => {
 
 export const ArtworkType = new GraphQLObjectType({
   name: "Artwork",
-  interfaces: [NodeInterface, Sellable],
+  interfaces: [NodeInterface, Searchable, Sellable],
   fields: () => {
     return {
       ...artworkFields(),

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -56,6 +56,7 @@ import Sale from "./sale/index"
 import Sales from "./sales"
 import SaleArtwork from "./sale_artwork"
 import SaleArtworks from "./sale_artworks"
+import { Search } from "./search"
 import Services from "./services"
 import Show from "./show"
 import SuggestedGenes from "./suggested_genes"
@@ -91,6 +92,7 @@ import { GraphQLSchema, GraphQLObjectType } from "graphql"
 import config from "config"
 import { BuyOrderType, OfferOrderType } from "./ecommerce/types/order"
 import { AddInitialOfferToOrderMutation } from "./ecommerce/add_initial_offer_to_order_mutation"
+import { SearchableItem } from "./searchableItem"
 const { ENABLE_CONSIGNMENTS_STITCHING, ENABLE_ECOMMERCE_STITCHING } = config
 
 // TODO: Remove this any
@@ -136,6 +138,7 @@ const rootFields: any = {
   sale_artwork: SaleArtwork,
   sale_artworks: SaleArtworks,
   sales: Sales,
+  search: Search,
   services: Services,
   show: Show,
   status: Status,
@@ -247,5 +250,5 @@ export default new GraphQLSchema({
   // but can’t be discovered by traversing the types and fields from query.
   //
   // In this case, the interface "Offer" is exposed everywhere, but the underlaying type BuyOrder needs to exist
-  types: [BuyOrderType, OfferOrderType],
+  types: [BuyOrderType, OfferOrderType, SearchableItem],
 })

--- a/src/schema/search.ts
+++ b/src/schema/search.ts
@@ -1,0 +1,167 @@
+import {
+  GraphQLList,
+  GraphQLEnumType,
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLFieldConfig,
+  visit,
+  BREAK,
+} from "graphql"
+import { connectionFromArraySlice } from "graphql-relay"
+import { pageable } from "relay-cursor-paging"
+
+import { connectionWithCursorInfo } from "schema/fields/pagination"
+import { createPageCursors } from "schema/fields/pagination"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { SearchableItem } from "schema/searchableItem"
+import { Searchable } from "schema/searchable"
+
+export const SearchEntity = new GraphQLEnumType({
+  name: "SearchEntity",
+  values: {
+    ARTWORK: {
+      value: "Artwork",
+    },
+    ARTIST: {
+      value: "Artist",
+    },
+  },
+})
+
+export const SearchMode = new GraphQLEnumType({
+  name: "SearchMode",
+  values: {
+    AUTOSUGGEST: {
+      value: "AUTOSUGGEST",
+    },
+    SITE: {
+      value: "SITE",
+    },
+  },
+})
+
+export const searchArgs = pageable({
+  query: {
+    type: new GraphQLNonNull(GraphQLString),
+    description: "Search query to perform. Required.",
+  },
+  entities: {
+    type: new GraphQLList(SearchEntity),
+    description: "Entities to include in search. Default: [ARTIST, ARTWORK].",
+  },
+  mode: {
+    type: SearchMode,
+    description: "Mode of search to exceute. Default: SITE.",
+  },
+})
+
+const fetch = (searchResultItem, root) => {
+  const loaderMapping = {
+    Artist: root.artistLoader,
+    Artwork: root.artworkLoader,
+  }
+
+  const loader = loaderMapping[searchResultItem.label]
+
+  if (loader) {
+    return loader(searchResultItem.id)
+  }
+}
+
+// Fetch the full object if the GraphQL query includes any inline fragments
+// referencing the search result item's type (like Artist or Artwork)
+const shouldFetch = (searchResultItem, info) => {
+  let fetch = false
+
+  visit(info.fieldNodes[0], {
+    Field(node) {
+      if (node.name.value === "node") {
+        visit(node, {
+          InlineFragment(node) {
+            if (
+              node.typeCondition &&
+              (node.typeCondition.name.value !== Searchable.name &&
+                node.typeCondition.name.value !== SearchableItem.name) &&
+              node.typeCondition.name.value === searchResultItem.label
+            ) {
+              fetch = true
+              return BREAK
+            }
+          },
+          FragmentSpread(_node) {
+            throw new Error(
+              "Named fragment spreads are currently unsupported for search."
+            )
+          },
+        })
+      }
+    },
+  })
+
+  return fetch
+}
+
+const SearchConnection = connectionWithCursorInfo(Searchable)
+
+const processSearchResultItem = (searchResultItem, info, source) => {
+  if (shouldFetch(searchResultItem, info)) {
+    return fetch(searchResultItem, source).then(response => {
+      return {
+        ...response,
+        __typename: searchResultItem.label,
+      }
+    })
+  } else {
+    return Promise.resolve({
+      ...searchResultItem,
+      __typename: "SearchableItem",
+    })
+  }
+}
+
+export const Search: GraphQLFieldConfig<any, any, any> = {
+  type: SearchConnection,
+  description: "Global search",
+  args: searchArgs,
+  resolve: (source, args, _request, info) => {
+    const pageOptions = convertConnectionArgsToGravityArgs(args)
+
+    const gravityArgs = {
+      ...pageOptions,
+      entities: args.entities,
+      total_count: true,
+    }
+
+    return source.searchLoader(gravityArgs).then(({ body, headers }) => {
+      const totalCount = parseInt(headers["x-total-count"])
+      const pageCursors = createPageCursors(pageOptions, totalCount)
+
+      return Promise.all(
+        body.map(searchResultItem =>
+          processSearchResultItem(searchResultItem, info, source)
+        )
+      ).then(procesedSearchResults => {
+        const connection = connectionFromArraySlice(
+          procesedSearchResults,
+          args,
+          {
+            arrayLength: totalCount,
+            sliceStart: pageOptions.offset,
+          }
+        )
+
+        return {
+          pageCursors: pageCursors,
+          totalCount,
+          ...connection,
+          pageInfo: {
+            ...connection.pageInfo,
+            hasPreviousPage: pageOptions.page > 1,
+            hasNextPage:
+              pageCursors.last && pageOptions.page < pageCursors.last.page,
+          },
+        }
+      })
+    })
+  },
+}

--- a/src/schema/searchable.ts
+++ b/src/schema/searchable.ts
@@ -1,0 +1,17 @@
+import { GraphQLInterfaceType, GraphQLString } from "graphql"
+
+export const Searchable = new GraphQLInterfaceType({
+  name: "Searchable",
+  description: "An object that may be searched for",
+  fields: {
+    displayLabel: {
+      type: GraphQLString,
+    },
+    imageUrl: {
+      type: GraphQLString,
+    },
+    href: {
+      type: GraphQLString,
+    },
+  },
+})

--- a/src/schema/searchableItem.ts
+++ b/src/schema/searchableItem.ts
@@ -1,0 +1,45 @@
+import {
+  GraphQLString,
+  GraphQLObjectType,
+  GraphQLID,
+  GraphQLNonNull,
+} from "graphql"
+import { toGlobalId } from "graphql-relay"
+import { Searchable } from "schema/searchable"
+import { NodeInterface } from "schema/object_identification"
+
+export const SearchableItem = new GraphQLObjectType({
+  name: "SearchableItem",
+  interfaces: [NodeInterface, Searchable],
+  fields: {
+    __id: {
+      type: new GraphQLNonNull(GraphQLID),
+      resolve: item => toGlobalId("SearchableItem", item._id),
+    },
+    displayLabel: {
+      type: GraphQLString,
+      resolve: item => item.display,
+    },
+    imageUrl: {
+      type: GraphQLString,
+      resolve: item => item.image_url,
+    },
+    href: {
+      type: GraphQLString,
+      resolve: item => {
+        switch (item.label) {
+          case "Artwork":
+            return `/artwork/${item.id}`
+          case "Artist":
+            return `/artist/${item.id}`
+          default:
+            return ""
+        }
+      },
+    },
+    searchableType: {
+      type: GraphQLString,
+      resolve: item => item.label,
+    },
+  },
+})


### PR DESCRIPTION
Alternate approach to https://github.com/artsy/metaphysics/pull/1475 which introduces a `Searchable` interface instead of defining a `SearchResult` type.

Add a new global search connection to support a reimplementation and redesign of the search bar and search results page on artsy.net.

This implementation introduces a new `Searchable` interface. Searchable entities represented in Metaphysics and supported by the Gravity API should implement this interface.

If entity-specific attributes are requested, the appropriate loader should be wired up so that the resolver can fetch the full object from Gravity and include it within the query response. We determine whether a
particular search result item should be fetched by inflecting on the GraphQL query AST and looking for an inline fragment matching the type of the search result item. If such an inline fragment is present, the
attributes provided by the `Searchable` interface alone may not satisfy the query.

**Example Queries**

Let's execute an `AUTOSUGGEST` search query, fetching the first 3 items of entity type `ARTIST` or `ARTWORK` based on the string "Bowi".

```graphql
{
  search(query: "Bowi", first: 3, entities: [ARTIST, ARTWORK], mode: AUTOSUGGEST) {
    edges {
      node {
        __typename
        displayLabel
        href
        imageUrl

        ... on SearchableItem {
          searchableType
        }
      }
    }
  }
}
```

```javascript
{
  "data": {
    "search": {
      "edges": [
        {
          "node": {
            "__typename": "SearchableItem",
            "displayLabel": "David Bowie",
            "href": "/artist/david-bowie",
            "imageUrl": "https://d32dm0rphc51dk.cloudfront.net/-c6JZBhhGEA0Rsdr3iyXLg/square.jpg",
            "searchableType": "Artist"
          }
        },
        {
          "node": {
            "__typename": "SearchableItem",
            "displayLabel": "Michi Broussard, BOWIE DIAMONDS - David Bowie (2018)",
            "href": "/artwork/5be09787783a6c00289d229f",
            "imageUrl": "https://d32dm0rphc51dk.cloudfront.net/7jIyO_OmESBkm9VGINxrDg/square.jpg",
            "searchableType": "Artwork"
          }
        },
        {
          "node": {
            "__typename": "SearchableItem",
            "displayLabel": "Michi Broussard, BOWIE - David Bowie (2018)",
            "href": "/artwork/5bcbca48bdc8dd5845c2928c",
            "imageUrl": "https://d32dm0rphc51dk.cloudfront.net/VzcDFWguDyEO6emGcM-EFA/square.jpg",
            "searchableType": "Artwork"
          }
        }
      ]
    }
  }
}
```

---

What if we want to execute the same query, but fetch additional Artist and Artwork-specific attributes as well? We can use inline fragments in our query.

Under the hood, this will trigger additional API requests for the entity types targeted by the inline fragments. See how the `__typename` changes from `SearchableItem` to `Artist` or `Artwork`.

```graphql
{
  search(query: "Bowie", first: 3, entities: [ARTIST, ARTWORK], mode: AUTOSUGGEST) {
    edges {
      node {
        __typename
        displayLabel
        href
        imageUrl

        ... on Artist {
          hometown
        }
        ... on Artwork {
          dimensions {
            in
            cm
          }
        }
      }
    }
  }
}
```

```javascript
{
  "data": {
    "search": {
      "totalCount": 3,
      "edges": [
        {
          "node": {
            "__typename": "Artist",
            "displayLabel": "David Bowie",
            "href": "/artist/david-bowie",
            "imageUrl": "https://d32dm0rphc51dk.cloudfront.net/-c6JZBhhGEA0Rsdr3iyXLg/square.jpg",
            "hometown": "Brixton, London, United Kingdom"
          }
        },
        {
          "node": {
            "__typename": "Artwork",
            "displayLabel": "BOWIE DIAMONDS - David Bowie",
            "href": "/artwork/michi-broussard-bowie-diamonds-david-bowie",
            "imageUrl": "https://d32dm0rphc51dk.cloudfront.net/7jIyO_OmESBkm9VGINxrDg/square.jpg",
            "dimensions": {
              "in": null,
              "cm": null
            }
          }
        },
        {
          "node": {
            "__typename": "Artwork",
            "displayLabel": "BOWIE - David Bowie",
            "href": "/artwork/michi-broussard-bowie-david-bowie",
            "imageUrl": "https://d32dm0rphc51dk.cloudfront.net/VzcDFWguDyEO6emGcM-EFA/square.jpg",
            "dimensions": {
              "in": "24 × 36 in",
              "cm": "61 × 91.4 cm"
            }
          }
        }
      ]
    }
  }
}
```

---

To execute a `SITE`-wide search (to be used eventually on the reimplemented / redesigned search results page), change the `mode` to `SITE`. You can also use inline fragements to fetch additional Artist and Artwork attributes with this search mode.

```graphql
{
  search(query: "Bowie", first: 3, entities: [ARTIST, ARTWORK], mode: SITE) {
    totalCount
    edges {
      node {
        __typename
        displayLabel
        href
        imageUrl
      }
    }
  }
}
```

```javascript
{
  "data": {
    "search": {
      "edges": [
        {
          "node": {
            "__typename": "SearchableItem",
            "displayLabel": "David Bowie",
            "href": "/artist/david-bowie",
            "imageUrl": "https://d32dm0rphc51dk.cloudfront.net/-c6JZBhhGEA0Rsdr3iyXLg/square.jpg",
            "searchableType": "Artist"
          }
        },
        {
          "node": {
            "__typename": "SearchableItem",
            "displayLabel": "Banz & Bowinkel",
            "href": "/artist/banz-and-bowinkel",
            "imageUrl": "https://d32dm0rphc51dk.cloudfront.net/Eja6bJ5dDp4tVRyJDx8NnA/square.jpg",
            "searchableType": "Artist"
          }
        },
        {
          "node": {
            "__typename": "SearchableItem",
            "displayLabel": "Wolf Böwig",
            "href": "/artist/wolf-bowig",
            "imageUrl": "https://d32dm0rphc51dk.cloudfront.net/tN4F_ZRQ4_ijtzmLJmCkOg/square.jpg",
            "searchableType": "Artist"
          }
        }
      ]
    }
  }
}
```