### PR TITLE
Add offer notes to offer mutations

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -21,6 +21,9 @@ input AddInitialOfferToOrderInput {
 
   # Offer price
   offerPrice: MoneyInput
+
+  # Offer note
+  note: String
   clientMutationId: String
 }
 
@@ -5602,6 +5605,9 @@ type Offer {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+
+  # Offer note
+  note: String
 }
 
 # A connection to a list of items.
@@ -7888,6 +7894,9 @@ input sellerCounterOfferInput {
 
   # Offer price
   offerPrice: MoneyInput
+
+  # Offer note
+  note: String
   clientMutationId: String
 }
 

--- a/src/data/exchange.graphql
+++ b/src/data/exchange.graphql
@@ -4,6 +4,7 @@ input AddInitialOfferToOrderInput {
 
   # A unique identifier for the client performing the mutation.
   clientMutationId: String
+  note: String
   orderId: ID!
 }
 
@@ -111,6 +112,7 @@ input BuyerCounterOfferInput {
 
   # A unique identifier for the client performing the mutation.
   clientMutationId: String
+  note: String
   offerId: ID!
 }
 
@@ -350,20 +352,14 @@ type LineItemEdge {
 }
 
 type Mutation {
-  addInitialOfferToOrder(
-    input: AddInitialOfferToOrderInput!
-  ): AddInitialOfferToOrderPayload
+  addInitialOfferToOrder(input: AddInitialOfferToOrderInput!): AddInitialOfferToOrderPayload
   approveOrder(input: ApproveOrderInput!): ApproveOrderPayload
   buyerAcceptOffer(input: BuyerAcceptOfferInput!): BuyerAcceptOfferPayload
   buyerCounterOffer(input: BuyerCounterOfferInput!): BuyerCounterOfferPayload
   buyerRejectOffer(input: BuyerRejectOfferInput!): BuyerRejectOfferPayload
   confirmPickup(input: ConfirmPickupInput!): ConfirmPickupPayload
-  createOfferOrderWithArtwork(
-    input: CreateOfferOrderWithArtworkInput!
-  ): CreateOfferOrderWithArtworkPayload
-  createOrderWithArtwork(
-    input: CreateOrderWithArtworkInput!
-  ): CreateOrderWithArtworkPayload
+  createOfferOrderWithArtwork(input: CreateOfferOrderWithArtworkInput!): CreateOfferOrderWithArtworkPayload
+  createOrderWithArtwork(input: CreateOrderWithArtworkInput!): CreateOrderWithArtworkPayload
 
   # Fulfill an order with one Fulfillment, it sets this fulfillment to each line item in order
   fulfillAtOnce(input: FulfillAtOnceInput!): FulfillAtOncePayload
@@ -374,9 +370,7 @@ type Mutation {
   setPayment(input: SetPaymentInput!): SetPaymentPayload
   setShipping(input: SetShippingInput!): SetShippingPayload
   submitOrder(input: SubmitOrderInput!): SubmitOrderPayload
-  submitOrderWithOffer(
-    input: SubmitOrderWithOfferInput!
-  ): SubmitOrderWithOfferPayload
+  submitOrderWithOffer(input: SubmitOrderWithOfferInput!): SubmitOrderWithOfferPayload
   submitPendingOffer(input: SubmitPendingOfferInput!): SubmitPendingOfferPayload
 }
 
@@ -389,6 +383,7 @@ type Offer {
   from: OrderPartyUnion!
   fromParticipant: OrderParticipantEnum
   id: ID!
+  note: String
   order: Order!
   respondsTo: Offer
   shippingTotalCents: Int
@@ -683,6 +678,21 @@ type Pickup {
 }
 
 type Query {
+  # Find list of competing orders
+  competingOrders(
+    # Returns the elements in the list that come after the specified cursor.
+    after: String
+
+    # Returns the elements in the list that come before the specified cursor.
+    before: String
+
+    # Returns the first _n_ elements from the list.
+    first: Int
+
+    # Returns the last _n_ elements from the list.
+    last: Int
+    orderId: ID!
+  ): OrderConnectionWithTotalCount
   lineItems(
     # Returns the elements in the list that come after the specified cursor.
     after: String
@@ -767,6 +777,7 @@ input SellerCounterOfferInput {
 
   # A unique identifier for the client performing the mutation.
   clientMutationId: String
+  note: String
   offerId: ID!
 }
 

--- a/src/data/exchange.graphql
+++ b/src/data/exchange.graphql
@@ -352,14 +352,20 @@ type LineItemEdge {
 }
 
 type Mutation {
-  addInitialOfferToOrder(input: AddInitialOfferToOrderInput!): AddInitialOfferToOrderPayload
+  addInitialOfferToOrder(
+    input: AddInitialOfferToOrderInput!
+  ): AddInitialOfferToOrderPayload
   approveOrder(input: ApproveOrderInput!): ApproveOrderPayload
   buyerAcceptOffer(input: BuyerAcceptOfferInput!): BuyerAcceptOfferPayload
   buyerCounterOffer(input: BuyerCounterOfferInput!): BuyerCounterOfferPayload
   buyerRejectOffer(input: BuyerRejectOfferInput!): BuyerRejectOfferPayload
   confirmPickup(input: ConfirmPickupInput!): ConfirmPickupPayload
-  createOfferOrderWithArtwork(input: CreateOfferOrderWithArtworkInput!): CreateOfferOrderWithArtworkPayload
-  createOrderWithArtwork(input: CreateOrderWithArtworkInput!): CreateOrderWithArtworkPayload
+  createOfferOrderWithArtwork(
+    input: CreateOfferOrderWithArtworkInput!
+  ): CreateOfferOrderWithArtworkPayload
+  createOrderWithArtwork(
+    input: CreateOrderWithArtworkInput!
+  ): CreateOrderWithArtworkPayload
 
   # Fulfill an order with one Fulfillment, it sets this fulfillment to each line item in order
   fulfillAtOnce(input: FulfillAtOnceInput!): FulfillAtOncePayload
@@ -370,7 +376,9 @@ type Mutation {
   setPayment(input: SetPaymentInput!): SetPaymentPayload
   setShipping(input: SetShippingInput!): SetShippingPayload
   submitOrder(input: SubmitOrderInput!): SubmitOrderPayload
-  submitOrderWithOffer(input: SubmitOrderWithOfferInput!): SubmitOrderWithOfferPayload
+  submitOrderWithOffer(
+    input: SubmitOrderWithOfferInput!
+  ): SubmitOrderWithOfferPayload
   submitPendingOffer(input: SubmitPendingOfferInput!): SubmitPendingOfferPayload
 }
 

--- a/src/schema/__tests__/ecommerce/add_initial_offer_to_order_mutation.test.ts
+++ b/src/schema/__tests__/ecommerce/add_initial_offer_to_order_mutation.test.ts
@@ -11,7 +11,7 @@ describe("AddInitialOfferToOrder Mutation", () => {
   const mutation = gql`
     mutation {
       ecommerceAddInitialOfferToOrder(
-        input: { orderId: "111", offerPrice: { amount: 1, currencyCode: "USD" } }
+        input: { orderId: "111", offerPrice: { amount: 1, currencyCode: "USD" }, note: "C sharp" }
       ) {
         orderOrError {
           ... on OrderWithMutationSuccess {

--- a/src/schema/__tests__/ecommerce/buyer_counter_offer_mutation.test.ts
+++ b/src/schema/__tests__/ecommerce/buyer_counter_offer_mutation.test.ts
@@ -2,7 +2,7 @@ import { runQuery } from "test/utils"
 import { sampleOrder } from "test/fixtures/results/sample_order"
 import gql from "lib/gql"
 import { mockxchange } from "test/fixtures/exchange/mockxchange"
-import exchangeOrderJSON from "test/fixtures/exchange/buy_order.json"
+import exchangeOrderJSON from "test/fixtures/exchange/offer_order.json"
 import { OrderBuyerFields } from "./order_fields"
 
 let rootValue
@@ -42,7 +42,7 @@ describe("BuyerCounterOffer Mutation", () => {
 
     return runQuery(mutation, rootValue).then(data => {
       expect(data!.ecommerceBuyerCounterOffer.orderOrError.order).toEqual(
-        sampleOrder()
+        sampleOrder({ mode: "OFFER", includeOfferFields: true })
       )
     })
   })

--- a/src/schema/__tests__/ecommerce/order_fields.ts
+++ b/src/schema/__tests__/ecommerce/order_fields.ts
@@ -100,6 +100,7 @@ export const OrderBuyerFields = gql`
       amountCents
       buyerTotalCents
       fromParticipant
+      note
     }
     lastOffer {
       id
@@ -108,6 +109,7 @@ export const OrderBuyerFields = gql`
       shippingTotalCents
       buyerTotalCents
       fromParticipant
+      note
     }
     offers {
       edges {

--- a/src/schema/__tests__/ecommerce/order_fields.ts
+++ b/src/schema/__tests__/ecommerce/order_fields.ts
@@ -210,5 +210,37 @@ export const OrderSellerFields = gql`
       }
     }
   }
+  ... on OfferOrder {
+    myLastOffer {
+      id
+      taxTotalCents
+      shippingTotalCents
+      amountCents
+      buyerTotalCents
+      fromParticipant
+      note
+    }
+    lastOffer {
+      id
+      amountCents
+      taxTotalCents
+      shippingTotalCents
+      buyerTotalCents
+      fromParticipant
+    }
+    offers {
+      edges {
+        node {
+          id
+          amountCents
+          taxTotalCents
+          shippingTotalCents
+          buyerTotalCents
+          fromParticipant
+        }
+      }
+    }
+    awaitingResponseFrom
+  }
 }
 `

--- a/src/schema/__tests__/ecommerce/seller_counter_offer_mutation.test.ts
+++ b/src/schema/__tests__/ecommerce/seller_counter_offer_mutation.test.ts
@@ -3,14 +3,14 @@ import { sampleOrder } from "test/fixtures/results/sample_order"
 import gql from "lib/gql"
 import { mockxchange } from "test/fixtures/exchange/mockxchange"
 import { OrderSellerFields } from "./order_fields"
-import exchangeOrderJSON from "test/fixtures/exchange/buy_order.json"
+import exchangeOrderJSON from "test/fixtures/exchange/offer_order.json"
 
 let rootValue
 
 describe("SellerCounterOffer Mutation", () => {
   const mutation = gql`
     mutation {
-      ecommerceSellerCounterOffer(input: { offerId: "111", offerPrice: { amount: 1, currencyCode: "USD" } }) {
+      ecommerceSellerCounterOffer(input: {offerId: "111", offerPrice: { amount: 1, currencyCode: "USD" }, note: "A minor" } ) {
         orderOrError {
           ... on OrderWithMutationSuccess {
             order {
@@ -41,9 +41,9 @@ describe("SellerCounterOffer Mutation", () => {
     rootValue = mockxchange(resolvers)
 
     return runQuery(mutation, rootValue).then(data => {
-      expect(
-        data!.ecommerceSellerCounterOffer.orderOrError.order
-      ).toEqual(sampleOrder())
+      expect(data!.ecommerceSellerCounterOffer.orderOrError.order).toEqual(
+        sampleOrder({ mode: "OFFER", includeOfferFields: true })
+      )
     })
   })
 
@@ -64,9 +64,7 @@ describe("SellerCounterOffer Mutation", () => {
     rootValue = mockxchange(resolvers)
 
     return runQuery(mutation, rootValue).then(data => {
-      expect(
-        data!.ecommerceSellerCounterOffer.orderOrError.error
-      ).toEqual({
+      expect(data!.ecommerceSellerCounterOffer.orderOrError.error).toEqual({
         type: "application_error",
         code: "404",
         data: null,

--- a/src/schema/__tests__/ecommerce/seller_counter_offer_mutation.test.ts
+++ b/src/schema/__tests__/ecommerce/seller_counter_offer_mutation.test.ts
@@ -10,7 +10,7 @@ let rootValue
 describe("SellerCounterOffer Mutation", () => {
   const mutation = gql`
     mutation {
-      ecommerceSellerCounterOffer(input: {offerId: "111", offerPrice: { amount: 1, currencyCode: "USD" }, note: "A minor" } ) {
+      ecommerceSellerCounterOffer(input: {offerId: "111", offerPrice: { amount: 1, currencyCode: "USD" }} ) {
         orderOrError {
           ... on OrderWithMutationSuccess {
             order {

--- a/src/schema/ecommerce/query_helpers.ts
+++ b/src/schema/ecommerce/query_helpers.ts
@@ -81,6 +81,7 @@ export const OfferFields = gql`
     createdAt
     creatorId
     amountCents
+    note
     shippingTotalCents
     taxTotalCents
     respondsTo {
@@ -88,6 +89,7 @@ export const OfferFields = gql`
       createdAt
       creatorId
       amountCents
+      note
       shippingTotalCents
       taxTotalCents
       buyerTotalCents

--- a/src/schema/ecommerce/seller_counter_offer_mutation.ts
+++ b/src/schema/ecommerce/seller_counter_offer_mutation.ts
@@ -23,6 +23,10 @@ const SellerCounterOfferMutationInputType = new GraphQLInputObjectType({
       type: MoneyInput,
       description: "Offer price",
     },
+    note: {
+      type: GraphQLString,
+      description: "Offer note",
+    },
   },
 })
 

--- a/src/schema/ecommerce/types/initial_offer_input_type.ts
+++ b/src/schema/ecommerce/types/initial_offer_input_type.ts
@@ -1,4 +1,9 @@
-import { GraphQLInputObjectType, GraphQLNonNull, GraphQLID } from "graphql"
+import {
+  GraphQLInputObjectType,
+  GraphQLNonNull,
+  GraphQLID,
+  GraphQLString,
+} from "graphql"
 import { MoneyInput } from "schema/fields/money"
 
 export const InitialOfferInputType = new GraphQLInputObjectType({
@@ -11,6 +16,10 @@ export const InitialOfferInputType = new GraphQLInputObjectType({
     offerPrice: {
       type: MoneyInput,
       description: "Offer price",
+    },
+    note: {
+      type: GraphQLString,
+      description: "Offer note",
     },
   },
 })

--- a/src/schema/ecommerce/types/offer.ts
+++ b/src/schema/ecommerce/types/offer.ts
@@ -82,6 +82,10 @@ export const OfferType = new GraphQLObjectType({
       description: "The order on which the offer was made",
     },
     submittedAt: date,
+    note: {
+      type: GraphQLString,
+      description: "Offer note",
+    },
   }),
 })
 

--- a/src/test/fixtures/exchange/offer_order.json
+++ b/src/test/fixtures/exchange/offer_order.json
@@ -82,7 +82,7 @@
       "id": "111"
     },
     "fromParticipant": "BUYER",
-    "note": "A minor"
+    "note": "C sharp"
   },
   "lastOffer": null,
   "offers": null,

--- a/src/test/fixtures/exchange/offer_order.json
+++ b/src/test/fixtures/exchange/offer_order.json
@@ -81,7 +81,8 @@
       "__typename": "USER",
       "id": "111"
     },
-    "fromParticipant": "BUYER"
+    "fromParticipant": "BUYER",
+    "note": "A minor"
   },
   "lastOffer": null,
   "offers": null,

--- a/src/test/fixtures/results/sample_order.js
+++ b/src/test/fixtures/results/sample_order.js
@@ -96,6 +96,7 @@ const offerFields = {
     shippingTotalCents: 20000,
     buyerTotalCents: 80000,
     fromParticipant: "BUYER",
+    note: "C sharp",
   },
   lastOffer: null,
   offers: null,


### PR DESCRIPTION
This adds the `note` field to "buyer counter offer", "seller counter offer", and "initial offer" mutations, along with corresponding tests.

Completes https://artsyproduct.atlassian.net/browse/GALL-1372