### PR TITLE
Fix fair follows

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3499,7 +3499,7 @@ type FollowArtists {
 
 type followed_fair_content {
   artists: [Artist]
-  partners: [Partner]
+  galleries: [Partner]
 }
 
 type FollowedArtistsArtworksGroup implements Node {

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1083,6 +1083,7 @@ type ArtworkContextFair {
   # A type-specific Gravity Mongo Document ID.
   _id: String!
   about: String
+  followed_content: followed_fair_content
   artists(
     # Sorts for artists in a fair
     sort: FairArtistSorts
@@ -3204,6 +3205,7 @@ type Fair {
   # A type-specific Gravity Mongo Document ID.
   _id: String!
   about: String
+  followed_content: followed_fair_content
   artists(
     # Sorts for artists in a fair
     sort: FairArtistSorts
@@ -3493,6 +3495,11 @@ type FollowArtistPayload {
 type FollowArtists {
   artists: [Artist]
   counts: FollowArtistCounts
+}
+
+type followed_fair_content {
+  artists: [Artist]
+  partners: [Partner]
 }
 
 type FollowedArtistsArtworksGroup implements Node {
@@ -4365,6 +4372,7 @@ type HomePageModuleContextFair {
   # A type-specific Gravity Mongo Document ID.
   _id: String!
   about: String
+  followed_content: followed_fair_content
   artists(
     # Sorts for artists in a fair
     sort: FairArtistSorts

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1083,7 +1083,7 @@ type ArtworkContextFair {
   # A type-specific Gravity Mongo Document ID.
   _id: String!
   about: String
-  followed_content: followed_fair_content
+  followed_content: followed_content
   artists(
     # Sorts for artists in a fair
     sort: FairArtistSorts
@@ -3205,7 +3205,7 @@ type Fair {
   # A type-specific Gravity Mongo Document ID.
   _id: String!
   about: String
-  followed_content: followed_fair_content
+  followed_content: followed_content
   artists(
     # Sorts for artists in a fair
     sort: FairArtistSorts
@@ -3497,7 +3497,7 @@ type FollowArtists {
   counts: FollowArtistCounts
 }
 
-type followed_fair_content {
+type followed_content {
   artists: [Artist]
   galleries: [Partner]
 }
@@ -4372,7 +4372,7 @@ type HomePageModuleContextFair {
   # A type-specific Gravity Mongo Document ID.
   _id: String!
   about: String
-  followed_content: followed_fair_content
+  followed_content: followed_content
   artists(
     # Sorts for artists in a fair
     sort: FairArtistSorts

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1083,7 +1083,7 @@ type ArtworkContextFair {
   # A type-specific Gravity Mongo Document ID.
   _id: String!
   about: String
-  followed_content: followed_content
+  followed_content: FollowedContent
   artists(
     # Sorts for artists in a fair
     sort: FairArtistSorts
@@ -3205,7 +3205,7 @@ type Fair {
   # A type-specific Gravity Mongo Document ID.
   _id: String!
   about: String
-  followed_content: followed_content
+  followed_content: FollowedContent
   artists(
     # Sorts for artists in a fair
     sort: FairArtistSorts
@@ -3497,11 +3497,6 @@ type FollowArtists {
   counts: FollowArtistCounts
 }
 
-type followed_content {
-  artists: [Artist]
-  galleries: [Partner]
-}
-
 type FollowedArtistsArtworksGroup implements Node {
   # A globally unique ID.
   __id: ID!
@@ -3544,6 +3539,11 @@ type FollowedArtistsArtworksGroupEdge {
 
   # A cursor for use in pagination
   cursor: String!
+}
+
+type FollowedContent {
+  artists: [Artist]
+  galleries: [Partner]
 }
 
 # A connection to a list of items.
@@ -4372,7 +4372,7 @@ type HomePageModuleContextFair {
   # A type-specific Gravity Mongo Document ID.
   _id: String!
   about: String
-  followed_content: followed_content
+  followed_content: FollowedContent
   artists(
     # Sorts for artists in a fair
     sort: FairArtistSorts

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -46,6 +46,7 @@ export default (accessToken, userID, opts) => {
     unfollowShowLoader: gravityLoader("follow_shows", {}, { method: "DELETE" }),
     followedShowsLoader: gravityLoader("follow_shows", {}, { headers: true }),
     followedFairsLoader: gravityLoader("/me/follow/profiles", {}, { headers: true }),
+    followedPartnersLoader: gravityLoader("/me/follow/profiles", {}, { headers: true }),
     homepageModulesLoader: gravityLoader("me/modules"),
     homepageSuggestedArtworksLoader: gravityLoader("me/suggested/artworks/homepage"),
     inquiryRequestsLoader: gravityLoader("me/inquiry_requests", {}, { headers: true }),

--- a/src/schema/fair.ts
+++ b/src/schema/fair.ts
@@ -84,7 +84,7 @@ const FairType = new GraphQLObjectType({
           artists: followedArtistsLoader({ fair_id }).then(({ body }) => {
             return body.map(artist_follow => artist_follow.artist)
           }),
-          partners: followedPartnersLoader({
+          galleries: followedPartnersLoader({
             fair_id,
             owner_types: ["PartnerGallery"],
           }).then(({ body }) => {

--- a/src/schema/fair.ts
+++ b/src/schema/fair.ts
@@ -75,7 +75,7 @@ const FairType = new GraphQLObjectType({
       type: FollowedContentType(),
       resolve: (
         fair,
-        options,
+        _options,
         _request,
         { rootValue: { followedArtistsLoader, followedPartnersLoader } }
       ) => {

--- a/src/schema/fair.ts
+++ b/src/schema/fair.ts
@@ -29,7 +29,7 @@ import { allViaLoader } from "lib/all"
 import { FairArtistSortsType } from "./sorts/fairArtistSorts"
 
 const FollowedContentType = new GraphQLObjectType({
-  name: "followed_fair_content",
+  name: "followed_content",
   fields: () => ({
     artists: {
       type: new GraphQLList(Artist.type),

--- a/src/schema/fair.ts
+++ b/src/schema/fair.ts
@@ -9,6 +9,8 @@ import date from "./fields/date"
 import numeral from "./fields/numeral"
 import Profile from "./profile"
 import Image from "./image"
+import Artist from "./artist"
+import Partner from "./partner"
 import { showConnection } from "./show"
 import Location from "./location"
 import { GravityIDFields } from "./object_identification"
@@ -25,6 +27,25 @@ import { totalViaLoader } from "lib/total"
 import ShowSort from "./sorts/show_sort"
 import { allViaLoader } from "lib/all"
 import { FairArtistSortsType } from "./sorts/fairArtistSorts"
+
+const FollowedContentType = () =>
+  new GraphQLObjectType({
+    name: "followed_fair_content",
+    fields: {
+      artists: {
+        type: new GraphQLList(Artist.type),
+        resolve: () => {
+          return {}
+        },
+      },
+      partners: {
+        type: new GraphQLList(Partner.type),
+        resolve: () => {
+          return {}
+        },
+      },
+    },
+  })
 
 const FairOrganizerType = new GraphQLObjectType({
   name: "organizer",
@@ -55,6 +76,9 @@ const FairType = new GraphQLObjectType({
     ...GravityIDFields,
     about: {
       type: GraphQLString,
+    },
+    followed_content: {
+      type: FollowedContentType(),
     },
     artists: {
       type: artistConnection,

--- a/src/schema/fair.ts
+++ b/src/schema/fair.ts
@@ -34,15 +34,9 @@ const FollowedContentType = () =>
     fields: {
       artists: {
         type: new GraphQLList(Artist.type),
-        resolve: () => {
-          return {}
-        },
       },
       partners: {
         type: new GraphQLList(Partner.type),
-        resolve: () => {
-          return {}
-        },
       },
     },
   })
@@ -79,6 +73,24 @@ const FairType = new GraphQLObjectType({
     },
     followed_content: {
       type: FollowedContentType(),
+      resolve: (
+        fair,
+        options,
+        _request,
+        { rootValue: { followedArtistsLoader } }
+      ) => {
+        const fair_id = fair._id
+        console.log("Fair ID:", fair_id)
+
+        return {
+          artists: followedArtistsLoader({ ...options, fair_id }).then(
+            followed_artists => {
+              return followed_artists
+            }
+          ),
+          partners: [{ name: "Sam Spade" }],
+        }
+      },
     },
     artists: {
       type: artistConnection,

--- a/src/schema/fair.ts
+++ b/src/schema/fair.ts
@@ -29,7 +29,7 @@ import { allViaLoader } from "lib/all"
 import { FairArtistSortsType } from "./sorts/fairArtistSorts"
 
 const FollowedContentType = new GraphQLObjectType({
-  name: "followed_content",
+  name: "FollowedContent",
   fields: () => ({
     artists: {
       type: new GraphQLList(Artist.type),

--- a/src/schema/fair.ts
+++ b/src/schema/fair.ts
@@ -28,18 +28,17 @@ import ShowSort from "./sorts/show_sort"
 import { allViaLoader } from "lib/all"
 import { FairArtistSortsType } from "./sorts/fairArtistSorts"
 
-const FollowedContentType = () =>
-  new GraphQLObjectType({
-    name: "followed_fair_content",
-    fields: {
-      artists: {
-        type: new GraphQLList(Artist.type),
-      },
-      galleries: {
-        type: new GraphQLList(Partner.type),
-      },
+const FollowedContentType = new GraphQLObjectType({
+  name: "followed_fair_content",
+  fields: () => ({
+    artists: {
+      type: new GraphQLList(Artist.type),
     },
-  })
+    galleries: {
+      type: new GraphQLList(Partner.type),
+    },
+  }),
+})
 
 const FairOrganizerType = new GraphQLObjectType({
   name: "organizer",
@@ -72,7 +71,7 @@ const FairType = new GraphQLObjectType({
       type: GraphQLString,
     },
     followed_content: {
-      type: FollowedContentType(),
+      type: FollowedContentType,
       resolve: (
         fair,
         _options,

--- a/src/schema/fair.ts
+++ b/src/schema/fair.ts
@@ -77,18 +77,20 @@ const FairType = new GraphQLObjectType({
         fair,
         options,
         _request,
-        { rootValue: { followedArtistsLoader } }
+        { rootValue: { followedArtistsLoader, followedPartnersLoader } }
       ) => {
-        const fair_id = fair._id
-        console.log("Fair ID:", fair_id)
+        const fair_id = fair.id
 
         return {
-          artists: followedArtistsLoader({ ...options, fair_id }).then(
-            followed_artists => {
-              return followed_artists
-            }
-          ),
-          partners: [{ name: "Sam Spade" }],
+          artists: followedArtistsLoader({ fair_id }).then(({ body }) => {
+            return body.map(artist_follow => artist_follow.artist)
+          }),
+          partners: followedPartnersLoader({
+            fair_id,
+            owner_types: ["PartnerGallery"],
+          }).then(({ body }) => {
+            return body.map(profile_follow => profile_follow.profile.owner)
+          }),
         }
       },
     },

--- a/src/schema/fair.ts
+++ b/src/schema/fair.ts
@@ -35,7 +35,7 @@ const FollowedContentType = () =>
       artists: {
         type: new GraphQLList(Artist.type),
       },
-      partners: {
+      galleries: {
         type: new GraphQLList(Partner.type),
       },
     },


### PR DESCRIPTION
This adds a new field to fairs in metaphysics, `followed_content`. Inside of followed content are `artists` and `galleries`, which embed raw arrays containing artwork and galleries that the current user follows AND which are affiliated with this fair.

This is tricky to test, and gravity caching seems to make it a little trickier. The bulk of the work here was actually around getting viable data into gravity that represented sufficient complexity to test that this code works as expected. Right now, I just ran the data setup code you'll find below, so this data all lives on the gravity staging server. (It'll be wiped over the weekend, though, so someone should rerun it on Monday if necessary!)


```
## IF THIS RETURNS TRUE THEN JUST STOP NOW THE DATA EXISTS:
User.where(email:'local_disco_user@artsymail.com').count > 0

app = ClientApplication.where(name: 'Metaphysics').first
user = User.create!(email: 'local_disco_user@artsymail.com', password: 'localdisco_is_great')
token = UserTrust.create_for_token_authentication(app, user: user, expires_in: 10.years.from_now)

artist1 = Artist.create!(name: 'Cloud Strife')
follow_artist_1 = FollowArtist.create!(user: user, artist: artist1)
art1 = Artwork.create!(artist_ids: [artist1.id], title: 'Still Life with Materia', private: false, published: true)
art2 = Artwork.create!(artist_ids: [artist1.id], title: 'Sephiroth Portrait', private: false, published: true)

artist2 = Artist.create!(name: 'Squall Leonheart')
art3 = Artwork.create!(artist_ids: [artist2.id], title: 'Laguna Again?!', private: false, published: true)
art4 = Artwork.create!(artist_ids: [artist2.id], title: 'Boss Battle', private: false, published: true)

partner1 = Partner.create!(given_name: 'not_gallery_followed')
follow_partner_1 = FollowProfile.create!(user: user, profile: partner1.profile)
show1 = PartnerShow.create!(partner: partner1, start_at: 10.years.ago, end_at: 10.years.from_now)
show1.add_artwork! art1

partner2 = Partner.create!(given_name: 'not_gallery_not_followed')  
show2 = PartnerShow.create!(partner: partner2, start_at: 10.years.ago, end_at: 10.years.from_now)
show2.add_artwork! art2

gallery1 = PartnerGallery.create!(given_name: 'gallery_followed')
follow_gallery_1 = FollowProfile.create!(user: user, profile: gallery1.profile)
show3 = PartnerShow.create!(partner: gallery1, start_at: 10.years.ago, end_at: 10.years.from_now)
show3.add_artwork! art3

gallery2 = PartnerGallery.create!(given_name: 'gallery_not_followed')
show4 = PartnerShow.create!(partner: gallery2, start_at: 10.years.ago, end_at: 10.years.from_now)
show4.add_artwork! art4

fair = Fair.create!(name: 'local_disco_fair', start_at: 15.years.ago, end_at: 15.years.from_now, published: true)
fair.partner_shows << show1
fair.partner_shows << show2
fair.partner_shows << show3
fair.partner_shows << show4

FairPartnerShowIndex.reindex_fair fair
FairService.invalidate_shows_and_artworks_caches fair
puts "Fair ID: #{fair.id}"
puts "X-Access-Token: #{token}"
```

Here's a graphQL query to test this functionality (the fair ID was generated by the above script when I ran it):

```
query {
  fair(id:"5c522f0cbc007d0007b4761b") {
    id
    followed_content{
      artists {
        name
      }
      galleries {
        name
      }
    }
  }
}
```

The response to this query should embed 'Cloud Strife' and 'gallery_followed' as the artist and gallery name, respectively, from the dataset generated. If you get Squall back as an artist too then this query is ignoring your follows. If you get `not_gallery_followed` then this query is ignoring the constraint to only return `PartnerGallery` types and leave out `Partner` types. If you get `gallery_not_followed` it's like getting Squall back, it's part of the fair but not something you personally follow so this query should not return it.