### PR TITLE
@orta => [MarketingCollections] Use stitching to expose marketing collections for an artist

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -342,6 +342,7 @@ type Artist implements Node {
   statuses: ArtistStatuses
   highlights: ArtistHighlights
   years: String
+  marketingCollections: [MarketingCollection]
 }
 
 enum ArtistArtworksFilters {
@@ -7270,7 +7271,7 @@ type Query {
 
   # Find partners by ID
   _unused_gravity_partners(ids: [ID]!): [DoNotUseThisPartner]
-  marketingCollections: [MarketingCollection!]!
+  marketingCollections(artistID: String): [MarketingCollection!]!
   marketingCategories: [MarketingCollectionCategory!]!
   marketingCollection(slug: String!): MarketingCollection
 }

--- a/src/data/kaws.graphql
+++ b/src/data/kaws.graphql
@@ -71,7 +71,7 @@ type CollectionQuery {
 scalar DateTime
 
 type Query {
-  collections: [Collection!]!
+  collections(artistID: String): [Collection!]!
   categories: [CollectionCategory!]!
   collection(slug: String!): Collection
 }

--- a/src/lib/stitching/kaws/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/kaws/__tests__/__snapshots__/schema.test.ts.snap
@@ -73,7 +73,7 @@ type MarketingCollectionQuery {
 scalar MarketingDateTime
 
 type Query {
-  marketingCollections: [MarketingCollection!]!
+  marketingCollections(artistID: String): [MarketingCollection!]!
   marketingCategories: [MarketingCollectionCategory!]!
   marketingCollection(slug: String!): MarketingCollection
 }

--- a/src/lib/stitching/kaws/stitching.ts
+++ b/src/lib/stitching/kaws/stitching.ts
@@ -6,6 +6,9 @@ export const kawsStitchingEnvironment = (
 ) => ({
   // The SDL used to declare how to stitch an object
   extensionSchema: `
+    extend type Artist {
+      marketingCollections: [MarketingCollection]
+    }
     extend type MarketingCollection {
       artworks(
         acquireable: Boolean
@@ -50,6 +53,27 @@ export const kawsStitchingEnvironment = (
   // from KAWS into filter_artworks to allow end users to dynamically
   // modify query filters using an admin tool
   resolvers: {
+    Artist: {
+      marketingCollections: {
+        fragment: `
+          ... on Artist {
+            _id
+          }
+        `,
+        resolve: ({ _id: artistID }, _args, context, info) => {
+          return info.mergeInfo.delegateToSchema({
+            schema: kawsSchema,
+            operation: "query",
+            fieldName: "marketingCollections",
+            args: {
+              artistID,
+            },
+            context,
+            info,
+          })
+        },
+      },
+    },
     MarketingCollection: {
       artworks: {
         fragment: `


### PR DESCRIPTION
cc @alloy @l2succes in case you have any suggestions/thoughts.

~~This uses https://github.com/artsy/kaws/pull/53 to stitch in marketing collections for a given artist. Namely:~~

```
artist(id: "kaws") {
  marketingCollections {
    // all fields from MarketingCollection
  }
}
```

~~However, I'm running into an issue with trying to issue a query to a remote schema with arguments. To me, it appears to me this: https://github.com/apollographql/graphql-tools/issues/820 , which is a blocker for being able to do it. Current uses of stitching in Metaphysics enhance remote schemas with local things (so the other way around, here we are trying to enhance the local Metaphysics schema with a remote one).~~

~~I attempted to also accomplish this by writing out the query and selecting all available fields from a collection, and getting the results via `graphql(schema, query,....).then(response => .....)` directly in a resolver on the artist schema, but I was stumped how to type that field. `type: MarketingCollection` doesn't work since that doesn't exist in the local schema.~~

EDIT: Nevermind! I'm realizing the issue now, and actually this is all working locally. Updating...