### PR TITLE
Removes GraphQL syntax errors from sentry

### DIFF
--- a/src/lib/__tests__/graphqlErrorHandler.test.ts
+++ b/src/lib/__tests__/graphqlErrorHandler.test.ts
@@ -1,12 +1,39 @@
 import {
   formattedGraphQLError,
   shouldReportParentError,
+  shouldReportError,
 } from "../graphqlErrorHandler"
 import { GraphQLTimeoutError } from "lib/graphqlTimeoutMiddleware"
 import { HTTPError } from "lib/HTTPError"
 import { GraphQLError } from "graphql"
 
 describe("graphqlErrorHandler", () => {
+  describe(shouldReportError, () => {
+    it("passes on null-y errors", () => {
+      expect(shouldReportError(null)).toBeTruthy()
+      expect(shouldReportError(undefined)).toBeTruthy()
+    })
+
+    it("passes on non-HTTP errors", () => {
+      expect(shouldReportError(new Error())).toBeTruthy()
+    })
+
+    it("passes on non-GraphQL errors", () => {
+      expect(shouldReportError(new GraphQLTimeoutError("oh noes"))).toBeTruthy()
+    })
+
+    it("passes general GraphQL errors", () => {
+      expect(shouldReportError(new GraphQLError("Wrong Args"))).toBeTruthy()
+    })
+
+    it("denies general GraphQL syntax errors", () => {
+      expect(
+        shouldReportError(
+          new GraphQLError("Syntax Error: Unexpected Name 'danger'")
+        )
+      ).toBeFalsy()
+    })
+  })
   describe(shouldReportParentError, () => {
     it("reports when the error is null", () => {
       expect(shouldReportParentError(null)).toBeTruthy()


### PR DESCRIPTION
I saw [this in](https://sentry.io/artsynet/metaphysics-production/issues/868039286/?environment=production&referrer=alert_email) my email inbox and got annoyed

<img width="687" alt="screen shot 2019-02-01 at 3 00 04 pm" src="https://user-images.githubusercontent.com/49038/52146577-24417280-2632-11e9-8a4a-04a00ff0a404.png">

Now Metaphysics won't send GraphQL syntax errors to Sentry. 