### PR TITLE
[package] Update dd-trace client to latest, again.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "compression": "^1.7.2",
     "cors": "^2.7.1",
     "dataloader": "^1.3.0",
-    "dd-trace": "artsy/dd-trace-js#artsy",
+    "dd-trace": "^0.7.3",
     "debug": "^2.2.0",
     "express": "^4.13.3",
     "express-force-ssl": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2382,15 +2382,18 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
   integrity sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==
 
-dd-trace@artsy/dd-trace-js#artsy:
-  version "0.6.0"
-  resolved "https://codeload.github.com/artsy/dd-trace-js/tar.gz/8331e739b8878eb17600c02b49e7ac55c1de771d"
+dd-trace@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-0.7.3.tgz#bc028454e2e4a83b13d2ec8346c1a749a3b8ba69"
+  integrity sha512-aIOmLl5Tu1V8C37tsh+esxFot2kq/N/Fuj8zsZaOOrD5C7m6IYJGinkHQINWxep+MN56Q3x95z473zcuqCiFdg==
   dependencies:
     async-hook-jl "^1.7.6"
     int64-buffer "^0.1.9"
     koalas "^1.0.2"
     lodash.kebabcase "^4.1.1"
     lodash.memoize "^4.1.2"
+    lodash.pick "^4.4.0"
+    lodash.truncate "^4.4.2"
     lodash.uniq "^4.5.0"
     methods "^1.1.2"
     msgpack-lite "^0.1.26"
@@ -5590,6 +5593,11 @@ lodash.once@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
+lodash.pick@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+  integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
+
 lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
@@ -5599,6 +5607,11 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
+
+lodash.truncate@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
+  integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
 lodash.unescape@4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Going to do an orchestrated deploy of this and the Force equivalent: https://github.com/artsy/force/pull/3474