### PR TITLE
Ensure that eigen receives the same shaped query response

### DIFF
--- a/src/lib/__tests__/modifyOldEigenQueries.test.ts
+++ b/src/lib/__tests__/modifyOldEigenQueries.test.ts
@@ -70,9 +70,10 @@ describe(nameOldEigenQueries, () => {
   })
 
   it("renames Exchange create offer", () => {
-    const after = gql`
+    expect(rewriteEcommerceMutations(beforeOffer)).toMatchInlineSnapshot(`
+"
       mutation createOfferOrder($artworkId: String!, $quantity: Int) {
-        commerceCreateOfferOrderWithArtwork(
+        ecommerceCreateOfferOrderWithArtwork: commerceCreateOfferOrderWithArtwork(
           input: { artworkId: $artworkId, quantity: $quantity }
         ) {
           orderOrError {
@@ -91,15 +92,15 @@ describe(nameOldEigenQueries, () => {
           }
         }
       }
-    `
-
-    expect(rewriteEcommerceMutations(beforeOffer)).toEqual(after)
+    "
+`)
   })
 
   it("renames Exchange create order", () => {
-    const after = gql`
+    expect(rewriteEcommerceMutations(beforeOrder)).toMatchInlineSnapshot(`
+"
       mutation createOrder($input: CommerceCreateOrderWithArtworkInput!) {
-        commerceCreateOrderWithArtwork(input: $input) {
+        ecommerceCreateOrderWithArtwork: commerceCreateOrderWithArtwork(input: $input) {
           orderOrError {
             ... on CommerceOrderWithMutationSuccess {
               order {
@@ -116,9 +117,8 @@ describe(nameOldEigenQueries, () => {
           }
         }
       }
-    `
-
-    expect(rewriteEcommerceMutations(beforeOrder)).toEqual(after)
+    "
+`)
   })
 })
 

--- a/src/lib/modifyOldEigenQueries.ts
+++ b/src/lib/modifyOldEigenQueries.ts
@@ -51,16 +51,19 @@ export const rewriteEcommerceMutations = (query: string) => {
   const befores = [
     "... on OrderWithMutationSuccess",
     "... on OrderWithMutationFailure",
-    "ecommerceCreateOfferOrderWithArtwork",
-    "ecommerceCreateOrderWithArtwork",
     "CreateOrderWithArtworkInput",
+    "ecommerceCreateOfferOrderWithArtwork(",
+    "ecommerceCreateOrderWithArtwork(",
   ]
   const afters = [
+    // Different type names
     "... on CommerceOrderWithMutationSuccess",
     "... on CommerceOrderWithMutationFailure",
-    "commerceCreateOfferOrderWithArtwork",
-    "commerceCreateOrderWithArtwork",
     "CommerceCreateOrderWithArtworkInput",
+    // Different root fields, but we need to ensure they get the
+    // same response shape.
+    "ecommerceCreateOfferOrderWithArtwork: commerceCreateOfferOrderWithArtwork(",
+    "ecommerceCreateOrderWithArtwork: commerceCreateOrderWithArtwork(",
   ]
 
   befores.forEach(before => {


### PR DESCRIPTION
Follows on from #1491,  #1488  and #1487 

This ensures that Eigen responses are the same JSON shape as it expects. Switched to use `inlineSnapshots` as the prettier 80 char limit was faffing with whitespace.