### PR TITLE
@dblandin => [SearchableItem] Add gravity id fields (id/_id) to response

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -7848,6 +7848,12 @@ type SearchableEdge {
 
 type SearchableItem implements Node & Searchable {
   __id: ID!
+
+  # A type-specific ID.
+  id: String!
+
+  # A type-specific Gravity Mongo Document ID.
+  _id: String!
   displayLabel: String
   imageUrl: String
   href: String

--- a/src/schema/__tests__/search.test.ts
+++ b/src/schema/__tests__/search.test.ts
@@ -47,6 +47,8 @@ describe("Search", () => {
 
               ... on SearchableItem {
                 searchableType
+                id
+                _id
               }
             }
           }
@@ -64,6 +66,8 @@ describe("Search", () => {
         "https://example.com/artist.jpg"
       )
       expect(artistSearchableItemNode.href).toBe("/artist/david-bowie")
+      expect(artistSearchableItemNode.id).toBe("david-bowie")
+      expect(artistSearchableItemNode._id).toBe("artistId")
 
       const artworkSearchableItemNode = data!.search.edges[1].node
 
@@ -76,6 +80,9 @@ describe("Search", () => {
       expect(artworkSearchableItemNode.href).toBe(
         "/artwork/david-bowie-self-portrait"
       )
+
+      expect(artworkSearchableItemNode.id).toBe("david-bowie-self-portrait")
+      expect(artworkSearchableItemNode._id).toBe("artworkId")
     })
   })
 

--- a/src/schema/searchableItem.ts
+++ b/src/schema/searchableItem.ts
@@ -6,12 +6,13 @@ import {
 } from "graphql"
 import { toGlobalId } from "graphql-relay"
 import { Searchable } from "schema/searchable"
-import { NodeInterface } from "schema/object_identification"
+import { NodeInterface, GravityIDFields } from "schema/object_identification"
 
 export const SearchableItem = new GraphQLObjectType({
   name: "SearchableItem",
   interfaces: [NodeInterface, Searchable],
   fields: {
+    ...GravityIDFields,
     __id: {
       type: new GraphQLNonNull(GraphQLID),
       resolve: item => toGlobalId("SearchableItem", item._id),


### PR DESCRIPTION
Re: https://github.com/artsy/reaction/pull/1997#discussion_r254482426 , this adds id fields to `SearchableItem`.