### PR TITLE
Adds is_followed to show

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -8183,6 +8183,9 @@ type Show implements Node {
   # An image representing the show, or a sharable image from an artwork in the show
   meta_image: Image
 
+  # Is the user following this show
+  is_followed: Boolean
+
   # The exhibition title
   name: String
 

--- a/src/lib/loaders/__tests__/tracked_entity.test.js
+++ b/src/lib/loaders/__tests__/tracked_entity.test.js
@@ -58,4 +58,22 @@ describe("trackedEntityLoader", () => {
       })
     })
   })
+  it("marks is_followed as true for custom ID key paths", () => {
+    const gravityLoader = jest.fn(() =>
+      Promise.resolve([{ id: "queens-ship", _id: "abcdefg123456" }])
+    )
+    const savedArtworksLoader = trackedEntityLoaderFactory(
+      gravityLoader,
+      "artworks",
+      "is_saved",
+      null,
+      "_id"
+    )
+    return savedArtworksLoader("abcdefg123456").then(queens_ship => {
+      expect(queens_ship.is_saved).toEqual(true)
+      return savedArtworksLoader("zyxwvut987654").then(kings_ship => {
+        expect(kings_ship.is_saved).toEqual(false)
+      })
+    })
+  })
 })

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -45,6 +45,12 @@ export default (accessToken, userID, opts) => {
     followShowLoader: gravityLoader("follow_shows", {}, { method: "POST" }),
     unfollowShowLoader: gravityLoader("follow_shows", {}, { method: "DELETE" }),
     followedShowsLoader: gravityLoader("follow_shows", {}, { headers: true }),
+    followedShowLoader: trackedEntityLoaderFactory(
+      gravityLoader("follow_shows"),
+      "shows",
+      "is_followed",
+      "partner_show"
+    ),
     followedFairsLoader: gravityLoader("/me/follow/profiles", {}, { headers: true }),
     homepageModulesLoader: gravityLoader("me/modules"),
     homepageSuggestedArtworksLoader: gravityLoader("me/suggested/artworks/homepage"),

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -49,7 +49,8 @@ export default (accessToken, userID, opts) => {
       gravityLoader("follow_shows"),
       "show_ids",
       "is_followed",
-      "partner_show"
+      "partner_show",
+      "_id",
     ),
     followedFairsLoader: gravityLoader("/me/follow/profiles", {}, { headers: true }),
     homepageModulesLoader: gravityLoader("me/modules"),

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -47,7 +47,7 @@ export default (accessToken, userID, opts) => {
     followedShowsLoader: gravityLoader("follow_shows", {}, { headers: true }),
     followedShowLoader: trackedEntityLoaderFactory(
       gravityLoader("follow_shows"),
-      "shows",
+      "show_ids",
       "is_followed",
       "partner_show"
     ),

--- a/src/lib/loaders/loaders_with_authentication/tracked_entity.ts
+++ b/src/lib/loaders/loaders_with_authentication/tracked_entity.ts
@@ -9,19 +9,23 @@ import { map, find, extend } from "lodash"
  * @param {string} paramKey the key that’s to be used for the list of IDs param that’s sent with the API request
  * @param {string} trackingKey the key that’s to be used for this entity, e.g. `is_followed` or `is_saved`.
  * @param {string} [entityKeyPath] an optional path to a nested entity
+ * @param {string} [entityIDKeyPath] an optional path to the IDs used to compare entities (defaults to `id`, but `_id` is sometimes useful).
  */
 const trackedEntityLoaderFactory = (
   dataLoader: (id: any) => Promise<any>,
   paramKey: string,
   trackingKey: string,
-  entityKeyPath?: string
+  entityKeyPath?: string,
+  entityIDKeyPath: string = "id"
 ) => {
   const trackedEntityLoader = new DataLoader(
     ids => {
       return dataLoader({ [paramKey]: ids }).then(body => {
         const parsedResults = map(ids, id => {
           const match = find(body, [
-            entityKeyPath ? `${entityKeyPath}.id` : "id",
+            entityKeyPath
+              ? `${entityKeyPath}.${entityIDKeyPath}`
+              : entityIDKeyPath,
             id,
           ])
           if (match) {

--- a/src/schema/__tests__/show.test.js
+++ b/src/schema/__tests__/show.test.js
@@ -144,6 +144,49 @@ describe("Show type", () => {
     }
   })
 
+  describe.only("is_followed", () => {
+    const query = gql`
+      {
+        show(id: "new-museum-1-2015-triennial-surround-audience") {
+          is_followed
+        }
+      }
+    `
+
+    it("returns false if user is not following show", () => {
+      rootValue.followedShowsLoader = () =>
+        Promise.resolve({
+          body: [],
+        })
+
+      return runQuery(query, rootValue).then(({ show }) => {
+        expect(show).toEqual({
+          is_followed: false,
+        })
+      })
+    })
+
+    it("returns true if user is following show", () => {
+      rootValue.followedShowsLoader = () =>
+        Promise.resolve({
+          body: [
+            {
+              partner_show: {
+                id: "new-museum-1-2015-triennial-surround-audience",
+                _id: "54ef55f57261694bbf7f2500",
+              },
+            },
+          ],
+        })
+
+      return runQuery(query, rootValue).then(({ show }) => {
+        expect(show).toEqual({
+          is_followed: true,
+        })
+      })
+    })
+  })
+
   describe("name", () => {
     it("strips whitespace from the name", async () => {
       const query = gql`

--- a/src/schema/show.ts
+++ b/src/schema/show.ts
@@ -507,6 +507,25 @@ export const ShowType = new GraphQLObjectType({
         })
       },
     },
+    is_followed: {
+      type: GraphQLBoolean,
+      description: "Is the user following this show",
+      resolve: async (
+        show,
+        _args,
+        _context,
+        { rootValue: { followedShowsLoader } }
+      ) => {
+        if (!followedShowsLoader) return null
+
+        const response = await followedShowsLoader({ size: 100 })
+        const { body: followed_shows } = response
+        const returnedShows = followed_shows.find(
+          fs => fs.partner_show.id === show.id
+        )
+        return !!returnedShows
+      },
+    },
     name: {
       type: GraphQLString,
       description: "The exhibition title",

--- a/src/schema/show.ts
+++ b/src/schema/show.ts
@@ -511,19 +511,13 @@ export const ShowType = new GraphQLObjectType({
       type: GraphQLBoolean,
       description: "Is the user following this show",
       resolve: async (
-        show,
+        { id },
         _args,
         _context,
-        { rootValue: { followedShowsLoader } }
+        { rootValue: { followedShowLoader } }
       ) => {
-        if (!followedShowsLoader) return null
-
-        const response = await followedShowsLoader({ size: 100 })
-        const { body: followed_shows } = response
-        const returnedShows = followed_shows.find(
-          fs => fs.partner_show.id === show.id
-        )
-        return !!returnedShows
+        if (!followedShowLoader) return null
+        return followedShowLoader(id).then(({ is_followed }) => is_followed)
       },
     },
     name: {

--- a/src/schema/show.ts
+++ b/src/schema/show.ts
@@ -511,13 +511,13 @@ export const ShowType = new GraphQLObjectType({
       type: GraphQLBoolean,
       description: "Is the user following this show",
       resolve: async (
-        { id },
+        { _id },
         _args,
         _context,
         { rootValue: { followedShowLoader } }
       ) => {
         if (!followedShowLoader) return null
-        return followedShowLoader(id).then(({ is_followed }) => is_followed)
+        return followedShowLoader(_id).then(({ is_followed }) => is_followed)
       },
     },
     name: {


### PR DESCRIPTION
Supersedes #1485. I modified the Gravity endpoint [on Matt's suggestion](https://github.com/artsy/metaphysics/pull/1485#discussion_r253689096) in [this PR](https://github.com/artsy/gravity/pull/12144). Fixes LD-184.

This is a WIP until the Gravity deploy is confirmed. I'm actually not sure how the process works for blocking PRs with dependent Gravity changes, but my gut says this should be fine to merge since it's only an addition. 