### PR TITLE
Support additional entity types during search

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -7861,8 +7861,17 @@ type SearchableItem implements Node & Searchable {
 }
 
 enum SearchEntity {
-  ARTWORK
   ARTIST
+  ARTWORK
+  ARTICLE
+  CITY
+  COLLECTION
+  FAIR
+  FEATURE
+  GENE
+  PROFILE
+  SALE
+  TAG
 }
 
 enum SearchMode {

--- a/src/lib/loaders/searchLoader.ts
+++ b/src/lib/loaders/searchLoader.ts
@@ -1,5 +1,5 @@
 import * as url from "url"
-import { SearchEntity } from "schema/search"
+import { SearchEntity } from "schema/search/SearchEntity"
 
 export const searchLoader = gravityLoader => {
   return gravityLoader(

--- a/src/schema/search/SearchEntity.ts
+++ b/src/schema/search/SearchEntity.ts
@@ -1,0 +1,40 @@
+import { GraphQLEnumType } from "graphql"
+
+export const SearchEntity = new GraphQLEnumType({
+  name: "SearchEntity",
+  values: {
+    ARTIST: {
+      value: "Artist",
+    },
+    ARTWORK: {
+      value: "Artwork",
+    },
+    ARTICLE: {
+      value: "Article",
+    },
+    CITY: {
+      value: "City",
+    },
+    COLLECTION: {
+      value: "MarketingCollection",
+    },
+    FAIR: {
+      value: "Fair",
+    },
+    FEATURE: {
+      value: "Feature",
+    },
+    GENE: {
+      value: "Gene",
+    },
+    PROFILE: {
+      value: "Profile",
+    },
+    SALE: {
+      value: "Sale",
+    },
+    TAG: {
+      value: "Tag",
+    },
+  },
+})

--- a/src/schema/search/index.ts
+++ b/src/schema/search/index.ts
@@ -15,18 +15,7 @@ import { createPageCursors } from "schema/fields/pagination"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { SearchableItem } from "schema/searchableItem"
 import { Searchable } from "schema/searchable"
-
-export const SearchEntity = new GraphQLEnumType({
-  name: "SearchEntity",
-  values: {
-    ARTWORK: {
-      value: "Artwork",
-    },
-    ARTIST: {
-      value: "Artist",
-    },
-  },
-})
+import { SearchEntity } from "./SearchEntity"
 
 export const SearchMode = new GraphQLEnumType({
   name: "SearchMode",


### PR DESCRIPTION
Expand the current list of supported entity types (Artist, Artwork) to:

Artist, Artwork, Article, City, Collection, Fair, Feature, Gene, Profile, Sale, and Tag.

Note: The `Collection` entity type is currently only supported for the `AUTOSUGGEST` search mode.

Next steps:

- Add support for the `Collection` entity type on the `SITE` search mode in Gravity.
- Add `Searchable` interface support to these full types in Metaphysics, allowing queries including type-specific attributes.

ticket: https://artsyproduct.atlassian.net/browse/DISCO-729 :lock: 