### PR TITLE
Refactors trackedEntityLoaderFactory to use options param

### DIFF
--- a/src/lib/loaders/__tests__/tracked_entity.test.js
+++ b/src/lib/loaders/__tests__/tracked_entity.test.js
@@ -6,11 +6,10 @@ describe("trackedEntityLoader", () => {
     const gravityLoader = jest.fn(() =>
       Promise.resolve([{ id: "queens-ship" }])
     )
-    const savedArtworksLoader = trackedEntityLoaderFactory(
-      gravityLoader,
-      "artworks",
-      "is_saved"
-    )
+    const savedArtworksLoader = trackedEntityLoaderFactory(gravityLoader, {
+      paramKey: "artworks",
+      trackingKey: "is_saved",
+    })
     const queens_ship = await savedArtworksLoader("queens-ship")
     expect(queens_ship.is_saved).toEqual(true)
     const kings_ship = await savedArtworksLoader("kings-ship")
@@ -25,12 +24,11 @@ describe("trackedEntityLoader", () => {
       gravityLoader = jest.fn(() =>
         Promise.resolve([{ artist: { id: "cab", name: "Cab" } }])
       )
-      followedArtistLoader = trackedEntityLoaderFactory(
-        gravityLoader,
-        "artists",
-        "is_followed",
-        "artist"
-      )
+      followedArtistLoader = trackedEntityLoaderFactory(gravityLoader, {
+        paramKey: "artists",
+        trackingKey: "is_followed",
+        entityKeyPath: "artist",
+      })
     })
 
     it("passes the params to gravity and batches multiple requests", async () => {
@@ -58,13 +56,11 @@ describe("trackedEntityLoader", () => {
       .fn()
       .mockResolvedValue([{ id: "queens-ship", _id: "abcdefg123456" }])
 
-    const savedArtworksLoader = trackedEntityLoaderFactory(
-      gravityLoader,
-      "artworks",
-      "is_saved",
-      null,
-      "_id"
-    )
+    const savedArtworksLoader = trackedEntityLoaderFactory(gravityLoader, {
+      paramKey: "artworks",
+      trackingKey: "is_saved",
+      entityIDKeyPath: "_id",
+    })
     const queens_ship = await savedArtworksLoader("abcdefg123456")
     expect(queens_ship.is_saved).toEqual(true)
     const kings_ship = await savedArtworksLoader("zyxwvut987654")

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -27,30 +27,38 @@ export default (accessToken, userID, opts) => {
     followedArtistsLoader: gravityLoader("me/follow/artists", {}, { headers: true }),
     followedArtistLoader: trackedEntityLoaderFactory(
       gravityLoader("me/follow/artists"),
-      "artists",
-      "is_followed",
-      "artist"
+      {
+        paramKey: "artists",
+        trackingKey: "is_followed",
+        entityKeyPath: "artist"
+      }
     ),
-    followedGeneLoader: trackedEntityLoaderFactory(gravityLoader("me/follow/genes"), "genes", "is_followed", "gene"),
+    followedGeneLoader: trackedEntityLoaderFactory(gravityLoader("me/follow/genes"), {
+      paramKey: "genes", trackingKey: "is_followed", entityKeyPath: "gene"
+    }),
     followedGenesLoader: gravityLoader("me/follow/genes", {}, { headers: true }),
     followedProfilesArtworksLoader: gravityLoader("me/follow/profiles/artworks", {}, { headers: true }),
     followGeneLoader: gravityLoader("me/follow/gene", {}, { method: "POST" }),
     followProfileLoader: gravityLoader("me/follow/profile", {}, { method: "POST" }),
     followedProfileLoader: trackedEntityLoaderFactory(
       gravityLoader("me/follow/profiles"),
-      "profiles",
-      "is_followed",
-      "profile"
+      {
+        paramKey: "profiles",
+        trackingKey: "is_followed",
+        entityKeyPath: "profile"
+      }
     ),
     followShowLoader: gravityLoader("follow_shows", {}, { method: "POST" }),
     unfollowShowLoader: gravityLoader("follow_shows", {}, { method: "DELETE" }),
     followedShowsLoader: gravityLoader("follow_shows", {}, { headers: true }),
     followedShowLoader: trackedEntityLoaderFactory(
       gravityLoader("follow_shows"),
-      "show_ids",
-      "is_followed",
-      "partner_show",
-      "_id",
+      {
+        paramKey: "show_ids",
+        trackingKey: "is_followed",
+        entityKeyPath: "partner_show",
+        entityIDKeyPath: "_id",
+      }
     ),
     followedFairsLoader: gravityLoader("/me/follow/profiles", {}, { headers: true }),
     homepageModulesLoader: gravityLoader("me/modules"),
@@ -75,8 +83,10 @@ export default (accessToken, userID, opts) => {
         user_id: userID,
         private: true,
       }),
-      "artworks",
-      "is_saved"
+      {
+        paramKey: "artworks",
+        trackingKey: "is_saved"
+      }
     ),
     savedArtworksLoader: gravityLoader("collection/saved-artwork/artworks", { user_id: userID, private: true }),
     suggestedArtistsLoader: gravityLoader("me/suggested/artists", {}, { headers: true }),

--- a/src/lib/loaders/loaders_with_authentication/tracked_entity.ts
+++ b/src/lib/loaders/loaders_with_authentication/tracked_entity.ts
@@ -1,23 +1,42 @@
 import DataLoader from "dataloader"
 import { map, find, extend } from "lodash"
 
+export interface TrackedEntityLoaderFactoryOptions {
+  /**
+   * The key that’s to be used for the list of IDs param that’s sent with the API request
+   */
+  paramKey: string
+  /**
+   * The key that’s to be used for this entity, e.g. `is_followed` or `is_saved`.
+   */
+  trackingKey: string
+  /**
+   * An optional path to a nested entity
+   */
+  entityKeyPath?: string
+  /**
+   * An optional path to the IDs used to compare entities (defaults to `id`, but `_id` is sometimes useful).
+   */
+  entityIDKeyPath?: string
+}
+
 /**
  * Produces a loader that checks if an entity is followed/saved and does so by batching API requests. The endpoint needs
  * to accept an `ids` param for this to work.
  *
- * @param {*} dataLoader a configured (with path and default params) data loader that will make the actual API request
- * @param {string} paramKey the key that’s to be used for the list of IDs param that’s sent with the API request
- * @param {string} trackingKey the key that’s to be used for this entity, e.g. `is_followed` or `is_saved`.
- * @param {string} [entityKeyPath] an optional path to a nested entity
- * @param {string} [entityIDKeyPath] an optional path to the IDs used to compare entities (defaults to `id`, but `_id` is sometimes useful).
+ * @param {*} dataLoader a configured (with path and default params) data loader that will make the actual API request.
+ * @param {TrackedEntityLoaderFactoryOptions} options configuration for the tracked entity loader.
  */
 const trackedEntityLoaderFactory = (
   dataLoader: (id: any) => Promise<any>,
-  paramKey: string,
-  trackingKey: string,
-  entityKeyPath?: string,
-  entityIDKeyPath: string = "id"
+  options: TrackedEntityLoaderFactoryOptions
 ) => {
+  const {
+    paramKey,
+    trackingKey,
+    entityKeyPath,
+    entityIDKeyPath = "id",
+  } = options
   const trackedEntityLoader = new DataLoader(
     ids => {
       return dataLoader({ [paramKey]: ids }).then(body => {

--- a/src/schema/__tests__/gene.test.js
+++ b/src/schema/__tests__/gene.test.js
@@ -391,12 +391,11 @@ describe("Gene", () => {
           { gene: { id: "brooklyn-artists", name: "Brooklyn Artists" } },
         ])
       )
-      followedGeneLoader = trackedEntityLoaderFactory(
-        gravityLoader,
-        "genes",
-        "is_followed",
-        "gene"
-      )
+      followedGeneLoader = trackedEntityLoaderFactory(gravityLoader, {
+        paramKey: "genes",
+        trackingKey: "is_followed",
+        entityKeyPath: "gene",
+      })
     })
 
     it("returns true if gene is returned", () => {

--- a/src/schema/__tests__/show.test.js
+++ b/src/schema/__tests__/show.test.js
@@ -151,12 +151,11 @@ describe("Show type", () => {
 
     beforeEach(() => {
       gravityLoader = jest.fn()
-      rootValue.followedShowLoader = trackedEntityLoaderFactory(
-        gravityLoader,
-        "show_ids",
-        "is_followed",
-        "partner_show"
-      )
+      rootValue.followedShowLoader = trackedEntityLoaderFactory(gravityLoader, {
+        paramKey: "show_ids",
+        trackingKey: "is_followed",
+        entityKeyPath: "partner_show",
+      })
     })
 
     it("returns true if the show is returned", async () => {


### PR DESCRIPTION
This came up in [a PR discussion yesterday](
https://github.com/artsy/metaphysics/pull/1497#discussion_r254783623). This PR refactors `trackedEntityLoaderFactory` to use an options object instead of positional parameters; we agreed this was a good idea and doing it sooner is easier than waiting. 