### PR TITLE
Adds the size of the data to the extension logger

### DIFF
--- a/src/lib/loaders/api/extensionsLogger.ts
+++ b/src/lib/loaders/api/extensionsLogger.ts
@@ -71,7 +71,7 @@ export default extensionsLogger
 
 export const formatBytes = (bytes: number) => {
   if (bytes < 1024) return bytes + " B"
-  else if (bytes < 1048576) return (bytes / 1024).toFixed(3) + " KB"
-  else if (bytes < 1073741824) return (bytes / 1048576).toFixed(3) + " MB"
-  else return (bytes / 1073741824).toFixed(3) + " GB"
+  else if (bytes < 1048576) return (bytes / 1024).toFixed() + " KB"
+  else if (bytes < 1073741824) return (bytes / 1048576).toFixed() + " MB!"
+  else return (bytes / 1073741824).toFixed() + " GB!!"
 }

--- a/src/lib/loaders/api/extensionsLogger.ts
+++ b/src/lib/loaders/api/extensionsLogger.ts
@@ -68,3 +68,10 @@ export const fetchLoggerRequestDone = requestID => () => {
 }
 
 export default extensionsLogger
+
+export const formatBytes = (bytes: number) => {
+  if (bytes < 1024) return bytes + " B"
+  else if (bytes < 1048576) return (bytes / 1024).toFixed(3) + " KB"
+  else if (bytes < 1073741824) return (bytes / 1048576).toFixed(3) + " MB"
+  else return (bytes / 1073741824).toFixed(3) + " GB"
+}

--- a/src/lib/loaders/api/loader_with_authentication_factory.ts
+++ b/src/lib/loaders/api/loader_with_authentication_factory.ts
@@ -4,7 +4,7 @@ import { pick } from "lodash"
 import { loaderInterface } from "./loader_interface"
 import timer from "lib/timer"
 import { verbose, warn } from "lib/loggers"
-import extensionsLogger from "lib/loaders/api/extensionsLogger"
+import extensionsLogger, { formatBytes } from "lib/loaders/api/extensionsLogger"
 
 /**
  * This returns a function that takes an access token to create a data loader factory for the given `api`.
@@ -44,11 +44,14 @@ export const apiLoaderWithAuthenticationFactory = (
                         resolve(response.body)
                       }
                       const time = clock.end()
+                      const length = formatBytes(
+                        response.headers["content-length"]
+                      )
                       return extensionsLogger(
                         globalAPIOptions.requestIDs.requestID,
                         apiName,
                         key,
-                        { time, cache: false }
+                        { time, cache: false, length }
                       )
                     })
                     .catch(err => {

--- a/src/lib/loaders/api/loader_with_authentication_factory.ts
+++ b/src/lib/loaders/api/loader_with_authentication_factory.ts
@@ -45,7 +45,7 @@ export const apiLoaderWithAuthenticationFactory = (
                       }
                       const time = clock.end()
                       const length = formatBytes(
-                        response.headers["content-length"]
+                        (response && response.headers["content-length"]) || 0
                       )
                       return extensionsLogger(
                         globalAPIOptions.requestIDs.requestID,

--- a/src/lib/loaders/api/loader_without_authentication_factory.ts
+++ b/src/lib/loaders/api/loader_without_authentication_factory.ts
@@ -6,7 +6,7 @@ import cache from "lib/cache"
 import timer from "lib/timer"
 import { throttled } from "lib/throttle"
 import { verbose, warn } from "lib/loggers"
-import extensionsLogger from "lib/loaders/api/extensionsLogger"
+import extensionsLogger, { formatBytes } from "lib/loaders/api/extensionsLogger"
 import config from "config"
 
 const { CACHE_DISABLED } = config
@@ -62,6 +62,7 @@ export const apiLoaderWithoutAuthenticationFactory = (
                       {
                         time,
                         cache: true,
+                        length: "N/A",
                       }
                     )
 
@@ -99,12 +100,13 @@ export const apiLoaderWithoutAuthenticationFactory = (
                           resolve(body)
                         }
                         verbose(`Requested (Uncached): ${key}`)
+                        const length = formatBytes(headers["content-length"])
                         const time = clock.end()
                         extensionsLogger(
                           globalAPIOptions.requestIDs.requestID,
                           apiName,
                           key,
-                          { time, cache: false }
+                          { time, cache: false, length }
                         )
                         if (apiOptions.headers) {
                           return cache.set(key, { body, headers })

--- a/src/lib/loaders/api/loader_without_authentication_factory.ts
+++ b/src/lib/loaders/api/loader_without_authentication_factory.ts
@@ -100,7 +100,9 @@ export const apiLoaderWithoutAuthenticationFactory = (
                           resolve(body)
                         }
                         verbose(`Requested (Uncached): ${key}`)
-                        const length = formatBytes(headers["content-length"])
+                        const length = formatBytes(
+                          (headers && headers["content-length"]) || 0
+                        )
                         const time = clock.end()
                         extensionsLogger(
                           globalAPIOptions.requestIDs.requestID,


### PR DESCRIPTION
Adds the ability you log out the size of a request received by MP. Does not do it in cached requests, because there aren't headers for the size.

Uncached:
<img width="1525" alt="screen shot 2019-02-08 at 1 17 09 pm" src="https://user-images.githubusercontent.com/49038/52497378-f0bb9680-2ba3-11e9-9870-25850f71797b.png">

Cached:
<img width="1525" alt="screen shot 2019-02-08 at 1 17 12 pm" src="https://user-images.githubusercontent.com/49038/52497380-f1542d00-2ba3-11e9-8169-90c7915c1f9d.png">