### PR TITLE
@dblandin => [Searchable] Translate some labels into more UI friendly strings

### DIFF
--- a/src/schema/__tests__/search.test.ts
+++ b/src/schema/__tests__/search.test.ts
@@ -21,6 +21,34 @@ describe("Search", () => {
         display: "Self Portrait",
         image_url: "https://example.com/artwork.jpg",
       },
+      {
+        _id: "galleryID",
+        id: "catty-gallery",
+        label: "Profile",
+        owner_type: "PartnerGallery",
+      },
+      {
+        _id: "museumID",
+        id: "catty-museum",
+        label: "Profile",
+        owner_type: "PartnerInstitution",
+      },
+      {
+        _id: "fairID",
+        id: "catty-fair",
+        label: "Profile",
+        owner_type: "FairOrganizer",
+      },
+      {
+        _id: "geneID",
+        id: "catty-gene",
+        label: "Gene",
+      },
+      {
+        _id: "auctionID",
+        id: "catty-auction",
+        label: "Sale",
+      },
     ]
 
     rootValue = {
@@ -83,6 +111,21 @@ describe("Search", () => {
 
       expect(artworkSearchableItemNode.id).toBe("david-bowie-self-portrait")
       expect(artworkSearchableItemNode._id).toBe("artworkId")
+
+      const gallerySearchableItemNode = data!.search.edges[2].node
+      expect(gallerySearchableItemNode.searchableType).toBe("Gallery")
+
+      const museumSearchableItemNode = data!.search.edges[3].node
+      expect(museumSearchableItemNode.searchableType).toBe("Institution")
+
+      const fairSearchableItemNode = data!.search.edges[4].node
+      expect(fairSearchableItemNode.searchableType).toBe("Fair")
+
+      const geneSearchableItemNode = data!.search.edges[5].node
+      expect(geneSearchableItemNode.searchableType).toBe("Category")
+
+      const auctionSearchableItemNode = data!.search.edges[6].node
+      expect(auctionSearchableItemNode.searchableType).toBe("Auction")
     })
   })
 

--- a/src/schema/searchableItem.ts
+++ b/src/schema/searchableItem.ts
@@ -40,7 +40,33 @@ export const SearchableItem = new GraphQLObjectType({
     },
     searchableType: {
       type: GraphQLString,
-      resolve: item => item.label,
+      resolve: ({ label, owner_type }) => {
+        switch (label) {
+          case "Profile":
+            const institutionTypes = [
+              "PartnerInstitution",
+              "PartnerInstitutionalSeller",
+            ]
+            if (institutionTypes.includes(owner_type)) {
+              return "Institution"
+            } else if (owner_type === "FairOrganizer") {
+              return "Fair"
+            } else {
+              return "Gallery"
+            }
+          case "Gene":
+            return "Category"
+
+          // TODO: How do we correctly display Sale/Auction types?
+          // There's nothing to distinguish the two types present
+          // in the special `match` JSON returned from the Gravity API.
+          case "Sale":
+            return "Auction"
+
+          default:
+            return label
+        }
+      },
     },
   },
 })


### PR DESCRIPTION
Noticed that we get Genes back (but display them as 'Category'), Profiles (but display them as Gallery/Institution/Fair), and also Sales (but display them as 'Auction').

Left one very big TODO about the sale/auction stuff!