### PR TITLE
@orta => [Stitching] Pass size param to KAWS collections for an artist

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -347,7 +347,7 @@ type Artist implements Node & Searchable {
   statuses: ArtistStatuses
   highlights: ArtistHighlights
   years: String
-  marketingCollections: [MarketingCollection]
+  marketingCollections(size: Int): [MarketingCollection]
 }
 
 enum ArtistArtworksFilters {
@@ -7328,6 +7328,7 @@ type Query {
   # Find partners by ID
   _unused_gravity_partners(ids: [ID]!): [DoNotUseThisPartner]
   marketingCollections(
+    size: Int
     showOnEditorial: Boolean
     artistID: String
   ): [MarketingCollection!]!

--- a/src/data/kaws.graphql
+++ b/src/data/kaws.graphql
@@ -77,7 +77,11 @@ type CollectionQuery {
 scalar DateTime
 
 type Query {
-  collections(showOnEditorial: Boolean, artistID: String): [Collection!]!
+  collections(
+    size: Int
+    showOnEditorial: Boolean
+    artistID: String
+  ): [Collection!]!
   categories: [CollectionCategory!]!
   collection(slug: String!): Collection
 }

--- a/src/lib/stitching/kaws/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/kaws/__tests__/__snapshots__/schema.test.ts.snap
@@ -79,7 +79,7 @@ type MarketingCollectionQuery {
 scalar MarketingDateTime
 
 type Query {
-  marketingCollections(showOnEditorial: Boolean, artistID: String): [MarketingCollection!]!
+  marketingCollections(size: Int, showOnEditorial: Boolean, artistID: String): [MarketingCollection!]!
   marketingCategories: [MarketingCollectionCategory!]!
   marketingCollection(slug: String!): MarketingCollection
 }

--- a/src/lib/stitching/kaws/stitching.ts
+++ b/src/lib/stitching/kaws/stitching.ts
@@ -7,7 +7,7 @@ export const kawsStitchingEnvironment = (
   // The SDL used to declare how to stitch an object
   extensionSchema: `
     extend type Artist {
-      marketingCollections: [MarketingCollection]
+      marketingCollections(size: Int): [MarketingCollection]
     }
     extend type MarketingCollection {
       artworks(
@@ -60,13 +60,15 @@ export const kawsStitchingEnvironment = (
             _id
           }
         `,
-        resolve: ({ _id: artistID }, _args, context, info) => {
+        resolve: ({ _id: artistID }, { size }, context, info) => {
           return info.mergeInfo.delegateToSchema({
             schema: kawsSchema,
             operation: "query",
             fieldName: "marketingCollections",
+
             args: {
               artistID,
+              size,
             },
             context,
             info,


### PR DESCRIPTION
~~Unfortunately this doesn't work :((~~

~~I think everything is updated properly, and this seems to conform to examples.~~

~~It doesn't like the `size` param.~~

```
{
  artist(id:"kaws") {
    marketingCollections(size: 4) {
      id
    }
  }
}
```

~~results in `"Unknown argument \"size\" on field \"marketingCollections\" of type \"Artist\"`~~

EDIT: works!!