### PR TITLE
Returns empty formatted schedules for empty schedules.

### DIFF
--- a/src/schema/__tests__/formattedDaySchedules.test.ts
+++ b/src/schema/__tests__/formattedDaySchedules.test.ts
@@ -129,4 +129,8 @@ describe("FormattedDaySchedules.resolve", () => {
       },
     ])
   })
+
+  it("handles empty schedules", () => {
+    expect(formatDaySchedules([])).toEqual([])
+  })
 })

--- a/src/schema/types/formattedDaySchedules.ts
+++ b/src/schema/types/formattedDaySchedules.ts
@@ -54,6 +54,9 @@ function formatDaySchedule(day: DayOfWeek, daySchedules: Array<DaySchedule>) {
 // Returns an array of formatted 'day schedule' objects for a 7 day week:
 // [{ start: 'Monday', hours: '10am – 7pm'}, {start: 'Tuesday, hours: 'Closed'}, ... ]
 export function formatDaySchedules(daySchedules: Array<DaySchedule>) {
+  if (_.isEmpty(daySchedules)) {
+    return []
+  }
   const formattedDaySchedules = () =>
     _.map(Object.values(DayOfWeek), day => {
       return formatDaySchedule(day, daySchedules)


### PR DESCRIPTION
This change is to support a fix for the bug described in [LD-211](https://artsyproduct.atlassian.net/browse/LD-211), which is where an empty schedule was showing up in the app as the following ("Monday–Sunday: Closed"):


<img width="553" alt="image 2019-02-12 at 2 57 43 pm" src="https://user-images.githubusercontent.com/498212/52818986-28c84b00-3076-11e9-8a4e-715baa8543ab.png">

Gravity is serving up an empty `location.day_schedules` array, so the issue is that Metaphysics is misinterpreting empty data. There was no test for empty schedules, so I asked on Slack if this was intended (not likely, since this logic was recently ported from Force and isn't used in Reaction, Volt, or even Force itself yet). 

With the new change, clients can check for an empty array. Here's the difference in the query response:

| Before | After |
|--------|-------|
| <img width="1211" alt="screen shot 2019-02-14 at 4 27 27 pm" src="https://user-images.githubusercontent.com/498212/52818705-785a4700-3075-11e9-887c-5c911211be37.png">   | <img width="1009" alt="screen shot 2019-02-14 at 4 27 36 pm" src="https://user-images.githubusercontent.com/498212/52818712-7c866480-3075-11e9-98c1-8206a1f427c1.png">  |

