### PR TITLE
Set keyword_match_exact when keywords are set on a Kaws collection.

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -246,6 +246,9 @@ type Artist implements Node & Searchable {
     sort: String
     tag_id: String
     keyword: String
+
+    # When true, will only return exact keyword match
+    keyword_match_exact: Boolean
   ): FilterArtworks
 
   # A string showing the total number of works and those for sale
@@ -585,6 +588,9 @@ type ArtistItem implements Node & Searchable {
     sort: String
     tag_id: String
     keyword: String
+
+    # When true, will only return exact keyword match
+    keyword_match_exact: Boolean
   ): FilterArtworks
 
   # A string showing the total number of works and those for sale
@@ -1196,6 +1202,9 @@ type ArtworkContextFair {
     sort: String
     tag_id: String
     keyword: String
+
+    # When true, will only return exact keyword match
+    keyword_match_exact: Boolean
   ): FilterArtworks
 }
 
@@ -1498,6 +1507,9 @@ type ArtworkFilterGene implements Node {
     sort: String
     tag_id: String
     keyword: String
+
+    # When true, will only return exact keyword match
+    keyword_match_exact: Boolean
   ): FilterArtworks
 }
 
@@ -1556,6 +1568,9 @@ type ArtworkFilterTag implements Node {
     sort: String
     tag_id: String
     keyword: String
+
+    # When true, will only return exact keyword match
+    keyword_match_exact: Boolean
   ): FilterArtworks
 }
 
@@ -3323,6 +3338,9 @@ type Fair {
     sort: String
     tag_id: String
     keyword: String
+
+    # When true, will only return exact keyword match
+    keyword_match_exact: Boolean
   ): FilterArtworks
 }
 
@@ -3786,6 +3804,9 @@ type Gene implements Node {
     sort: String
     tag_id: String
     keyword: String
+
+    # When true, will only return exact keyword match
+    keyword_match_exact: Boolean
     after: String
     first: Int
     before: String
@@ -3833,6 +3854,9 @@ type Gene implements Node {
     sort: String
     tag_id: String
     keyword: String
+
+    # When true, will only return exact keyword match
+    keyword_match_exact: Boolean
   ): FilterArtworks
   href: String
   image: Image
@@ -3972,6 +3996,9 @@ type GeneItem implements Node {
     sort: String
     tag_id: String
     keyword: String
+
+    # When true, will only return exact keyword match
+    keyword_match_exact: Boolean
     after: String
     first: Int
     before: String
@@ -4019,6 +4046,9 @@ type GeneItem implements Node {
     sort: String
     tag_id: String
     keyword: String
+
+    # When true, will only return exact keyword match
+    keyword_match_exact: Boolean
   ): FilterArtworks
   href: String
   image: Image
@@ -4490,6 +4520,9 @@ type HomePageModuleContextFair {
     sort: String
     tag_id: String
     keyword: String
+
+    # When true, will only return exact keyword match
+    keyword_match_exact: Boolean
   ): FilterArtworks
 }
 
@@ -4557,6 +4590,9 @@ type HomePageModuleContextGene implements Node {
     sort: String
     tag_id: String
     keyword: String
+
+    # When true, will only return exact keyword match
+    keyword_match_exact: Boolean
     after: String
     first: Int
     before: String
@@ -4604,6 +4640,9 @@ type HomePageModuleContextGene implements Node {
     sort: String
     tag_id: String
     keyword: String
+
+    # When true, will only return exact keyword match
+    keyword_match_exact: Boolean
   ): FilterArtworks
   href: String
   image: Image
@@ -6973,6 +7012,9 @@ type Query {
     sort: String
     tag_id: String
     keyword: String
+
+    # When true, will only return exact keyword match
+    keyword_match_exact: Boolean
   ): FilterArtworks
 
   # Sale Artworks Elastic Search results
@@ -8178,6 +8220,9 @@ type Show implements Node {
     sort: String
     tag_id: String
     keyword: String
+
+    # When true, will only return exact keyword match
+    keyword_match_exact: Boolean
   ): FilterArtworks
 
   # A path to the show on Artsy
@@ -8474,6 +8519,9 @@ type Tag implements Node {
     sort: String
     tag_id: String
     keyword: String
+
+    # When true, will only return exact keyword match
+    keyword_match_exact: Boolean
   ): FilterArtworks
 }
 
@@ -8887,6 +8935,9 @@ type Viewer {
     sort: String
     tag_id: String
     keyword: String
+
+    # When true, will only return exact keyword match
+    keyword_match_exact: Boolean
   ): FilterArtworks
 
   # Sale Artworks Elastic Search results

--- a/src/lib/stitching/kaws/__tests__/stitching.test.ts
+++ b/src/lib/stitching/kaws/__tests__/stitching.test.ts
@@ -1,0 +1,81 @@
+import { runQuery } from "test/utils"
+
+describe("MarketingCollectionArtwork", () => {
+  it.skip("sets keyword_match_exact to true when keywords are set", async () => {
+    const query = `
+      {
+        marketingCollection(slug: "kaws-snoopy") {
+          slug
+          query {
+            keyword
+          }
+          artworks {
+            hits {
+              title
+            }
+          }
+        }
+      }
+    `
+    const rootValue = {
+      accessToken: null,
+      userID: null,
+      filterArtworksLoader: jest.fn(() => Promise.resolve()),
+    }
+
+    await runQuery(query, rootValue)
+    expect(rootValue.filterArtworksLoader.mock.calls[0]).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "aggregations": Array [],
+    "artist_ids": Array [
+      "4e934002e340fa0001005336",
+    ],
+    "gene_ids": Array [],
+    "keyword": "Snoopy, Woodstock, Man’s Best Friend, No One's Home, Isolation Tower, Stay Steady, The Things that Comfort",
+    "keyword_match_exact": true,
+  },
+]
+`)
+  })
+
+  it.skip("sets keyword_match_exact to false when keywords are not set", async () => {
+    const query = `
+      {
+        marketingCollection(slug: "alexander-calder-mobiles") {
+          slug
+          query {
+            keyword
+          }
+          artworks {
+            hits {
+              title
+            }
+          }
+        }
+      }
+    `
+
+    const rootValue = {
+      accessToken: null,
+      userID: null,
+      filterArtworksLoader: jest.fn(() => Promise.resolve()),
+    }
+
+    await runQuery(query, rootValue)
+    expect(rootValue.filterArtworksLoader.mock.calls[0]).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "aggregations": Array [],
+    "artist_ids": Array [
+      "4dde70a1306f6800010036ef",
+    ],
+    "gene_ids": Array [
+      "kinetic-sculpture",
+    ],
+    "keyword_match_exact": false,
+  },
+]
+`)
+  })
+})

--- a/src/lib/stitching/kaws/stitching.ts
+++ b/src/lib/stitching/kaws/stitching.ts
@@ -30,7 +30,7 @@ export const kawsStitchingEnvironment = (
         gene_ids: [String]
         height: String
         width: String
-    
+
         # A string from the list of allocations, or * to denote all mediums
         medium: String
         period: String
@@ -79,7 +79,7 @@ export const kawsStitchingEnvironment = (
     MarketingCollection: {
       artworks: {
         fragment: `
-          fragment MarketingCollectionQuery on MarketingCollection { 
+          fragment MarketingCollectionQuery on MarketingCollection {
             query {
               acquireable
               offerable
@@ -111,17 +111,19 @@ export const kawsStitchingEnvironment = (
               sort
               tag_id
               keyword
-            } 
+            }
           }
         `,
         resolve: (parent, _args, context, info) => {
           const query = parent.query
+          const hasKeyword = Boolean(parent.query.keyword)
           return info.mergeInfo.delegateToSchema({
             schema: localSchema,
             operation: "query",
             fieldName: "filter_artworks",
             args: {
               ...query,
+              keyword_match_exact: hasKeyword,
               ..._args,
             },
             context,

--- a/src/schema/filter_artworks.ts
+++ b/src/schema/filter_artworks.ts
@@ -295,6 +295,10 @@ export const filterArtworksArgs = {
   keyword: {
     type: GraphQLString,
   },
+  keyword_match_exact: {
+    type: GraphQLBoolean,
+    description: "When true, will only return exact keyword match",
+  },
 }
 
 const filterArtworksTypeFactory = mapRootToFilterParams => ({


### PR DESCRIPTION
[[[GROW-1005]](https://artsyproduct.atlassian.net/browse/GROW-1005)](https://artsyproduct.atlassian.net/browse/GROW-1005)

When fetching collections info from Kaws, set keyword_match_exact parameter to true if collections has keywords for artwork filters.

[GROW-1005]: https://artsyproduct.atlassian.net/browse/GROW-1005