### PR TITLE
Fixes an issue where Gemini-related mutations always return an error

### DIFF
--- a/src/schema/asset_uploads/__tests__/create_asset_request_mutation.test.js
+++ b/src/schema/asset_uploads/__tests__/create_asset_request_mutation.test.js
@@ -18,7 +18,7 @@ describe("addAssetToConsignmentSubmission", () => {
     `
 
     const rootValue = {
-      createNewGeminiAssetLoader: () =>
+      createNewGeminiAssetLoader: () => () =>
         Promise.resolve({
           policy_encoded: "12345==",
           policy_document: {

--- a/src/schema/asset_uploads/__tests__/finalize_asset_mutation.test.js
+++ b/src/schema/asset_uploads/__tests__/finalize_asset_mutation.test.js
@@ -22,7 +22,7 @@ describe("CreateGeminiEntryForAsset", () => {
     `
 
     const rootValue = {
-      createNewGeminiEntryAssetLoader: () =>
+      createNewGeminiEntryAssetLoader: () => () =>
         Promise.resolve({
           token: "zVHJce-Fey3OIsazH8WDTg",
           image_urls: {},

--- a/src/schema/asset_uploads/create_asset_request_mutation.ts
+++ b/src/schema/asset_uploads/create_asset_request_mutation.ts
@@ -95,6 +95,6 @@ export default mutationWithClientMutationId({
     { rootValue: { createNewGeminiAssetLoader } }
   ) => {
     if (!createNewGeminiAssetLoader) return null
-    return createNewGeminiAssetLoader({ name, acl })
+    return createNewGeminiAssetLoader({ name, acl })()
   },
 })

--- a/src/schema/asset_uploads/finalize_asset_mutation.ts
+++ b/src/schema/asset_uploads/finalize_asset_mutation.ts
@@ -55,6 +55,6 @@ export default mutationWithClientMutationId({
       source_key,
       source_bucket,
       metadata,
-    })
+    })()
   },
 })


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/AUCT-64

It seems that a `()` is missing when a function is returned from a factory `loader` function, causing the `createGeminiEntryForAsset` and `requestCredentialsForAssetUpload` mutations to fail due to a return value mismatch. This PR adds a missing `()` so the function actually does the work.

## before

### The `createGeminiEntryForAsset` mutation:

![create-gemini-entry-for-asset-before](https://user-images.githubusercontent.com/386234/52972131-d47bde80-3387-11e9-8c64-06c1cc7c7e02.png)

### The `requestCredentialsForAssetUpload` mutation:

![request-credentials-for-asset-upload-before](https://user-images.githubusercontent.com/386234/52972137-d80f6580-3387-11e9-9872-241f39bcb892.png)

## After

### The `createGeminiEntryForAsset` mutation:

![create-gemini-entry-for-asset-after](https://user-images.githubusercontent.com/386234/52972150-df367380-3387-11e9-9d72-402ab40dd978.png)


### The `requestCredentialsForAssetUpload` mutation:

![request-credentials-for-asset-upload-after](https://user-images.githubusercontent.com/386234/52972154-e198cd80-3387-11e9-9293-e28def990c08.png)
