### PR TITLE
Restructures exhibitors_grouped_by_name

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1154,7 +1154,7 @@ type ArtworkContextFair {
   tagline: String
   ticketsLink: String
 
-  # The exhibitors with booths in this fair.
+  # The exhibitors with booths in this fair with letter.
   exhibitors_grouped_by_name: [FairExhibitorsGroup]
 
   # Artworks Elastic Search results
@@ -3281,7 +3281,7 @@ type Fair {
   tagline: String
   ticketsLink: String
 
-  # The exhibitors with booths in this fair.
+  # The exhibitors with booths in this fair with letter.
   exhibitors_grouped_by_name: [FairExhibitorsGroup]
 
   # Artworks Elastic Search results
@@ -3354,15 +3354,23 @@ type FairCounts {
   ): FormattedNumber
 }
 
+type FairExhibitor {
+  # Exhibitor name
+  exhibitor_name: String
+
+  # Exhibitors id
+  exhibitor_id: String
+
+  # Partner default profile id
+  profile_id: String
+}
+
 type FairExhibitorsGroup {
   # Letter exhibitors group belongs to
   letter: String
 
-  # Exhibitors sorted by name
-  exhibitors: [String]
-
-  # Partner/Exhibitor default profile id
-  profile_ids: [String]
+  # The exhibitor data.
+  exhibitors: [FairExhibitor]
 }
 
 enum FairSorts {
@@ -4448,7 +4456,7 @@ type HomePageModuleContextFair {
   tagline: String
   ticketsLink: String
 
-  # The exhibitors with booths in this fair.
+  # The exhibitors with booths in this fair with letter.
   exhibitors_grouped_by_name: [FairExhibitorsGroup]
 
   # Artworks Elastic Search results

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3356,10 +3356,10 @@ type FairCounts {
 
 type FairExhibitor {
   # Exhibitor name
-  exhibitor_name: String
+  name: String
 
   # Exhibitors id
-  exhibitor_id: String
+  id: String
 
   # Partner default profile id
   profile_id: String

--- a/src/schema/__tests__/fair.test.js
+++ b/src/schema/__tests__/fair.test.js
@@ -13,7 +13,7 @@ describe("Fair type", () => {
     },
   }
 
-  const query = `
+  const query = gql`
     {
       fair(id: "the-armory-show-2017") {
         id
@@ -135,8 +135,13 @@ describe("Fair", () => {
         exhibitors_grouped_by_name: [
           {
             letter: "A",
-            exhibitors: ["ArtHelix Gallery"],
-            profile_ids: ["arthelix-gallery"],
+            exhibitors: [
+              {
+                name: "ArtHelix Gallery",
+                id: "arthelix-gallery",
+                profile_id: "arthelix-gallery",
+              },
+            ],
           },
         ],
       },
@@ -168,7 +173,8 @@ describe("Fair", () => {
         Promise.resolve({
           body: {
             name: "ArtHelix Gallery",
-            default_profile_id: "arthelix-gallery",
+            id: "arthelix-gallery",
+            partner_show_ids: ["arthelix-gallery"],
           },
           headers: {
             "x-total-count": 1,
@@ -186,8 +192,11 @@ describe("Fair", () => {
           name
           exhibitors_grouped_by_name {
             letter
-            exhibitors
-            profile_ids
+            exhibitors {
+              name
+              id
+              profile_id
+            }
           }
         }
       }
@@ -202,8 +211,13 @@ describe("Fair", () => {
         exhibitors_grouped_by_name: [
           {
             letter: "A",
-            exhibitors: ["ArtHelix Gallery"],
-            profile_ids: ["arthelix-gallery"],
+            exhibitors: [
+              {
+                name: "ArtHelix Gallery",
+                id: "arthelix-gallery",
+                profile_id: "arthelix-gallery",
+              },
+            ],
           },
         ],
       },

--- a/src/schema/fair.ts
+++ b/src/schema/fair.ts
@@ -281,7 +281,7 @@ const FairType = new GraphQLObjectType({
       resolve: ({ tickets_link }) => tickets_link,
     },
     exhibitors_grouped_by_name: {
-      description: "The exhibitors with booths in this fair.",
+      description: "The exhibitors with booths in this fair with letter.",
       type: new GraphQLList(
         new GraphQLObjectType({
           name: "FairExhibitorsGroup",
@@ -291,12 +291,26 @@ const FairType = new GraphQLObjectType({
               description: "Letter exhibitors group belongs to",
             },
             exhibitors: {
-              type: new GraphQLList(GraphQLString),
-              description: "Exhibitors sorted by name",
-            },
-            profile_ids: {
-              type: new GraphQLList(GraphQLString),
-              description: "Partner/Exhibitor default profile id",
+              description: "The exhibitor data.",
+              type: new GraphQLList(
+                new GraphQLObjectType({
+                  name: "FairExhibitor",
+                  fields: {
+                    exhibitor_name: {
+                      type: GraphQLString,
+                      description: "Exhibitor name",
+                    },
+                    exhibitor_id: {
+                      type: GraphQLString,
+                      description: "Exhibitors id",
+                    },
+                    profile_id: {
+                      type: GraphQLString,
+                      description: "Partner default profile id",
+                    },
+                  },
+                })
+              ),
             },
           },
         })
@@ -313,8 +327,13 @@ const FairType = new GraphQLObjectType({
         const exhibitor_groups: {
           [letter: string]: {
             letter: string
-            exhibitors: [String]
-            profile_ids: [String]
+            exhibitors: [
+              {
+                exhibitor_name: string
+                profile_id: string
+                exhibitor_id: string
+              }
+            ]
           }
         } = {}
         const fetch = allViaLoader(fairPartnersLoader, root._id)
@@ -332,15 +351,21 @@ const FairType = new GraphQLObjectType({
             const firstName = names[0]
             const letter = firstName.charAt(0).toUpperCase()
             if (exhibitor_groups[letter]) {
-              exhibitor_groups[letter].exhibitors.push(fairExhibitor.name)
-              exhibitor_groups[letter].profile_ids.push(
-                fairExhibitor.default_profile_id
-              )
+              exhibitor_groups[letter].exhibitors.push({
+                exhibitor_name: fairExhibitor.name,
+                profile_id: fairExhibitor.partner_show_ids[0],
+                exhibitor_id: fairExhibitor.id,
+              })
             } else {
               exhibitor_groups[letter] = {
                 letter,
-                exhibitors: [fairExhibitor.name],
-                profile_ids: [fairExhibitor.default_profile_id],
+                exhibitors: [
+                  {
+                    exhibitor_name: fairExhibitor.name,
+                    profile_id: fairExhibitor.partner_show_ids[0],
+                    exhibitor_id: fairExhibitor.id,
+                  },
+                ],
               }
             }
           }

--- a/src/schema/fair.ts
+++ b/src/schema/fair.ts
@@ -337,10 +337,8 @@ const FairType = new GraphQLObjectType({
           }
         } = {}
         const fetch = allViaLoader(fairPartnersLoader, root._id)
-        console.log("fairPartnersLoader", fairPartnersLoader())
 
         return fetch.then(result => {
-          console.log("results???", result)
           const fairExhibitors = result.sort((a, b) => {
             const asc = a.name.toLowerCase()
             const desc = b.name.toLowerCase()

--- a/src/schema/fair.ts
+++ b/src/schema/fair.ts
@@ -296,11 +296,11 @@ const FairType = new GraphQLObjectType({
                 new GraphQLObjectType({
                   name: "FairExhibitor",
                   fields: {
-                    exhibitor_name: {
+                    name: {
                       type: GraphQLString,
                       description: "Exhibitor name",
                     },
-                    exhibitor_id: {
+                    id: {
                       type: GraphQLString,
                       description: "Exhibitors id",
                     },
@@ -329,16 +329,18 @@ const FairType = new GraphQLObjectType({
             letter: string
             exhibitors: [
               {
-                exhibitor_name: string
+                name: string
                 profile_id: string
-                exhibitor_id: string
+                id: string
               }
             ]
           }
         } = {}
         const fetch = allViaLoader(fairPartnersLoader, root._id)
+        console.log("fairPartnersLoader", fairPartnersLoader())
 
         return fetch.then(result => {
+          console.log("results???", result)
           const fairExhibitors = result.sort((a, b) => {
             const asc = a.name.toLowerCase()
             const desc = b.name.toLowerCase()
@@ -352,18 +354,18 @@ const FairType = new GraphQLObjectType({
             const letter = firstName.charAt(0).toUpperCase()
             if (exhibitor_groups[letter]) {
               exhibitor_groups[letter].exhibitors.push({
-                exhibitor_name: fairExhibitor.name,
+                name: fairExhibitor.name,
                 profile_id: fairExhibitor.partner_show_ids[0],
-                exhibitor_id: fairExhibitor.id,
+                id: fairExhibitor.id,
               })
             } else {
               exhibitor_groups[letter] = {
                 letter,
                 exhibitors: [
                   {
-                    exhibitor_name: fairExhibitor.name,
+                    name: fairExhibitor.name,
                     profile_id: fairExhibitor.partner_show_ids[0],
-                    exhibitor_id: fairExhibitor.id,
+                    id: fairExhibitor.id,
                   },
                 ],
               }


### PR DESCRIPTION
- Restructures `exhibitors_grouped_by_name` to have one array of `exhibitor` objects and adds correct `profile_id`


<img width="976" alt="screen shot 2019-02-19 at 2 31 57 pm" src="https://user-images.githubusercontent.com/21182806/53041984-42d9a300-3453-11e9-8469-081d7f69e5bf.png">
