### PR TITLE
@jonallured => [Autosuggest] Hook up /href linking to searchable items

### DIFF
--- a/src/schema/__tests__/search.test.ts
+++ b/src/schema/__tests__/search.test.ts
@@ -10,6 +10,7 @@ describe("Search", () => {
       {
         _id: "artistId",
         label: "Artist",
+        model: "artist",
         id: "david-bowie",
         display: "David Bowie",
         image_url: "https://example.com/artist.jpg",
@@ -18,6 +19,7 @@ describe("Search", () => {
         _id: "artworkId",
         id: "david-bowie-self-portrait",
         label: "Artwork",
+        model: "artwork",
         display: "Self Portrait",
         image_url: "https://example.com/artwork.jpg",
       },
@@ -25,29 +27,34 @@ describe("Search", () => {
         _id: "galleryID",
         id: "catty-gallery",
         label: "Profile",
+        model: "profile",
         owner_type: "PartnerGallery",
       },
       {
         _id: "museumID",
         id: "catty-museum",
         label: "Profile",
+        model: "profile",
         owner_type: "PartnerInstitution",
       },
       {
         _id: "fairID",
         id: "catty-fair",
         label: "Profile",
+        model: "profile",
         owner_type: "FairOrganizer",
       },
       {
         _id: "geneID",
         id: "catty-gene",
         label: "Gene",
+        model: "gene",
       },
       {
         _id: "auctionID",
         id: "catty-auction",
         label: "Sale",
+        model: "sale",
       },
     ]
 
@@ -114,18 +121,22 @@ describe("Search", () => {
 
       const gallerySearchableItemNode = data!.search.edges[2].node
       expect(gallerySearchableItemNode.searchableType).toBe("Gallery")
+      expect(gallerySearchableItemNode.href).toBe("/catty-gallery")
 
       const museumSearchableItemNode = data!.search.edges[3].node
       expect(museumSearchableItemNode.searchableType).toBe("Institution")
+      expect(museumSearchableItemNode.href).toBe("/catty-museum")
 
       const fairSearchableItemNode = data!.search.edges[4].node
       expect(fairSearchableItemNode.searchableType).toBe("Fair")
 
       const geneSearchableItemNode = data!.search.edges[5].node
       expect(geneSearchableItemNode.searchableType).toBe("Category")
+      expect(geneSearchableItemNode.href).toBe("/gene/catty-gene")
 
       const auctionSearchableItemNode = data!.search.edges[6].node
       expect(auctionSearchableItemNode.searchableType).toBe("Auction")
+      expect(auctionSearchableItemNode.href).toBe("/auction/catty-auction")
     })
   })
 

--- a/src/schema/searchableItem.ts
+++ b/src/schema/searchableItem.ts
@@ -8,6 +8,22 @@ import { toGlobalId } from "graphql-relay"
 import { Searchable } from "schema/searchable"
 import { NodeInterface, GravityIDFields } from "schema/object_identification"
 
+const hrefFromAutosuggestResult = item => {
+  if (item.href) return item.href
+  switch (item.label) {
+    case "Profile":
+      return `/${item.id}`
+    case "Fair":
+      return `/${item.profile_id}`
+    case "Sale":
+      return `/auction/${item.id}`
+    case "City":
+      return `/shows/${item.id}`
+    default:
+      return `/${item.model}/${item.id}`
+  }
+}
+
 export const SearchableItem = new GraphQLObjectType({
   name: "SearchableItem",
   interfaces: [NodeInterface, Searchable],
@@ -27,16 +43,7 @@ export const SearchableItem = new GraphQLObjectType({
     },
     href: {
       type: GraphQLString,
-      resolve: item => {
-        switch (item.label) {
-          case "Artwork":
-            return `/artwork/${item.id}`
-          case "Artist":
-            return `/artist/${item.id}`
-          default:
-            return ""
-        }
-      },
+      resolve: item => hrefFromAutosuggestResult(item),
     },
     searchableType: {
       type: GraphQLString,
@@ -62,6 +69,9 @@ export const SearchableItem = new GraphQLObjectType({
           // in the special `match` JSON returned from the Gravity API.
           case "Sale":
             return "Auction"
+
+          case "MarketingCollection":
+            return "Collection"
 
           default:
             return label


### PR DESCRIPTION
Hooks up links to remaining items (cribbed from https://github.com/artsy/force/blob/a6ac904b489f8e07c25f96f8e0f01efba6ce0cb8/src/desktop/models/search_result.coffee#L37) so that other types work w/ linking. Also tweaked display so `MarketingCollection` -> `Collection`