### PR TITLE
Insert rootValue object to resolvers for those that relied on it.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,7 @@ async function startApp() {
         schema,
         graphiql: true,
         context,
+        rootValue: {},
         formatError: graphqlErrorHandler(enableSentry, {
           req,
           // Why the checking on params? Do we reach this code if params is falsy?


### PR DESCRIPTION
Follow-up to #1520

Fixes queries that use `viewer`.