### PR TITLE
update kaws schema to include new randomize argument

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -7404,6 +7404,7 @@ type Query {
   # Find partners by ID
   _unused_gravity_partners(ids: [ID]!): [DoNotUseThisPartner]
   marketingCollections(
+    randomize: Boolean
     size: Int
     showOnEditorial: Boolean
     artistID: String

--- a/src/data/kaws.graphql
+++ b/src/data/kaws.graphql
@@ -78,6 +78,7 @@ scalar DateTime
 
 type Query {
   collections(
+    randomize: Boolean
     size: Int
     showOnEditorial: Boolean
     artistID: String

--- a/src/lib/stitching/kaws/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/kaws/__tests__/__snapshots__/schema.test.ts.snap
@@ -79,7 +79,7 @@ type MarketingCollectionQuery {
 scalar MarketingDateTime
 
 type Query {
-  marketingCollections(size: Int, showOnEditorial: Boolean, artistID: String): [MarketingCollection!]!
+  marketingCollections(randomize: Boolean, size: Int, showOnEditorial: Boolean, artistID: String): [MarketingCollection!]!
   marketingCategories: [MarketingCollectionCategory!]!
   marketingCollection(slug: String!): MarketingCollection
 }


### PR DESCRIPTION
Address: https://artsyproduct.atlassian.net/browse/GROW-1145

This is a part of the work to add support for randomizing collections and updates the kaws schema in metaphysics. 

<img width="1276" alt="screen shot 2019-02-26 at 4 55 30 pm" src="https://user-images.githubusercontent.com/5201004/53449354-9d40a980-39e7-11e9-9069-c394c96d47d1.png">
