### PR TITLE
Exposes lastTransactionFailed from exchange

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -2357,6 +2357,9 @@ type BuyOrder implements Order {
 
   # Credit card on this order
   creditCard: CreditCard
+
+  # Whether or not the last attempt to charge the buyer failed
+  lastTransactionFailed: Boolean
   lastApprovedAt(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -5896,6 +5899,9 @@ type OfferOrder implements Order {
 
   # Credit card on this order
   creditCard: CreditCard
+
+  # Whether or not the last attempt to charge the buyer failed
+  lastTransactionFailed: Boolean
   lastApprovedAt(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -6112,6 +6118,9 @@ interface Order {
 
   # Credit card on this order
   creditCard: CreditCard
+
+  # Whether or not the last attempt to charge the buyer failed
+  lastTransactionFailed: Boolean
   lastApprovedAt(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean

--- a/src/schema/ecommerce/query_helpers.ts
+++ b/src/schema/ecommerce/query_helpers.ts
@@ -156,6 +156,7 @@ export const BuyerOrderFields = gql`
   taxTotalCents
   totalListPriceCents
   transactionFeeCents
+  lastTransactionFailed
   updatedAt
   lineItems {
     edges {
@@ -209,6 +210,7 @@ export const SellerOrderFields = gql`
   taxTotalCents
   totalListPriceCents
   transactionFeeCents
+  lastTransactionFailed
   updatedAt
 `
 
@@ -241,4 +243,5 @@ export const AllOrderFields = gql`
   lastSubmittedAt
   commissionRate
   displayCommissionRate
+  lastTransactionFailed
 `

--- a/src/schema/ecommerce/types/order.ts
+++ b/src/schema/ecommerce/types/order.ts
@@ -6,6 +6,7 @@ import {
   GraphQLFloat,
   GraphQLInterfaceType,
   GraphQLFieldConfigMap,
+  GraphQLBoolean,
 } from "graphql"
 import { connectionDefinitions } from "graphql-relay"
 
@@ -138,6 +139,10 @@ const orderFields: GraphQLFieldConfigMap<
     description: "Credit card on this order",
     resolve: ({ creditCardId }, _args, { creditCardLoader }) =>
       creditCardId && creditCardLoader ? creditCardLoader(creditCardId) : null,
+  },
+  lastTransactionFailed: {
+    type: GraphQLBoolean,
+    description: "Whether or not the last attempt to charge the buyer failed",
   },
   lastApprovedAt: date,
   lastSubmittedAt: date,


### PR DESCRIPTION
We'll need to reference this in reaction when deciding whether or not to allow you to visit the `/payment/new` page.