### PR TITLE
Fix wrong artwork filtering on show page

### DIFF
--- a/src/schema/__tests__/show.test.js
+++ b/src/schema/__tests__/show.test.js
@@ -1107,7 +1107,7 @@ describe("Show type", () => {
       const data = await runQuery(query, context)
       expect(context.filterArtworksLoader).toHaveBeenCalledWith(
         expect.objectContaining({
-          show_id: "new-museum-1-2015-triennial-surround-audience",
+          partner_show_id: "abcdefg123456",
           partner_id: "new-museum",
         })
       )

--- a/src/schema/show.ts
+++ b/src/schema/show.ts
@@ -361,8 +361,8 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
       type: Fair.type,
       resolve: ({ fair }) => fair,
     },
-    filteredArtworks: filterArtworksWithParams(({ id, partner }) => ({
-      show_id: id,
+    filteredArtworks: filterArtworksWithParams(({ _id, partner }) => ({
+      partner_show_id: _id,
       partner_id: partner.id,
     })),
     href: {


### PR DESCRIPTION
fixes https://artsyproduct.atlassian.net/browse/LD-300

We were passing wrong param to Gravity when filtering by show.