### PR TITLE
fixes failing test

### DIFF
--- a/src/schema/__tests__/fair.test.js
+++ b/src/schema/__tests__/fair.test.js
@@ -240,7 +240,7 @@ describe("Fair", () => {
       }
     `
 
-    const data = await runQuery(query, rootValue)
+    const data = await runQuery(query, context)
     expect(data).toEqual({
       fair: {
         exhibition_period: "Feb 15 – 17",


### PR DESCRIPTION
Some how this failing spec slipped passed Circle CI in [this PR](https://github.com/artsy/metaphysics/pull/1536). This open PR fixes that and [restores the master build](https://circleci.com/gh/artsy/metaphysics/4202). It's weird because the [build on the initial PR showed green](https://circleci.com/gh/artsy/metaphysics/4197) but failed when it ran against master. I've seen this happen in kaws and I thought it was an isolated issue.

@orta and ideas why this is?