### PR TITLE
Add followedContents to fetch followed artists in a show

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,6 +33,7 @@
     "mockxchange",
     "orderable",
     "orderables",
+    "pageable",
     "urljoin"
   ],
   "debug.node.autoAttach": "on",

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -8395,6 +8395,7 @@ type Show implements Node {
 
   # Is it a fair booth or a show?
   type: String
+  followedContent: ShowsFollowedContent
 }
 
 # A connection to a list of items.
@@ -8428,6 +8429,10 @@ type ShowEdge {
 
   # A cursor for use in pagination
   cursor: String!
+}
+
+type ShowsFollowedContent {
+  artists: [Artist]
 }
 
 enum ShowSort {

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -5203,7 +5203,7 @@ type Me implements Node {
   # A list of the current user’s artist follows
   follow_artists(page: Int, size: Int): FollowArtists
 
-  # A list of the current user’s inquiry requests
+  # A Connection of followed artists by current user
   followed_artists_connection(
     after: String
     first: Int
@@ -8395,7 +8395,14 @@ type Show implements Node {
 
   # Is it a fair booth or a show?
   type: String
-  followedContent: ShowsFollowedContent
+
+  # A Connection of followed artists by current user for this show
+  followedArtists(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ShowFollowArtistConnection
 }
 
 # A connection to a list of items.
@@ -8431,8 +8438,26 @@ type ShowEdge {
   cursor: String!
 }
 
-type ShowsFollowedContent {
-  artists: [Artist]
+type ShowFollowArtist {
+  artist: Artist
+}
+
+# A connection to a list of items.
+type ShowFollowArtistConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # A list of edges.
+  edges: [ShowFollowArtistEdge]
+}
+
+# An edge in a connection.
+type ShowFollowArtistEdge {
+  # The item at the end of the edge
+  node: ShowFollowArtist
+
+  # A cursor for use in pagination
+  cursor: String!
 }
 
 enum ShowSort {

--- a/src/lib/shared_resolvers/followedArtistsResolver.ts
+++ b/src/lib/shared_resolvers/followedArtistsResolver.ts
@@ -1,0 +1,23 @@
+import { getPagingParameters } from "relay-cursor-paging"
+import { connectionFromArraySlice } from "graphql-relay"
+
+// options are connection related arguments
+// params are params passed into gravity to scope the results
+const followArtistsResolver = (params, options, config) => {
+  if (!config.followedArtistsLoader) return null
+  const { limit: size, offset } = getPagingParameters(options)
+  const gravityArgs = {
+    size,
+    offset,
+    total_count: true,
+    ...params,
+  }
+  return config.followedArtistsLoader(gravityArgs).then(({ body, headers }) => {
+    return connectionFromArraySlice(body, options, {
+      arrayLength: parseInt(headers["x-total-count"] || "0", 10),
+      sliceStart: offset,
+    })
+  })
+}
+
+export default followArtistsResolver

--- a/src/schema/me/followed_artists.ts
+++ b/src/schema/me/followed_artists.ts
@@ -1,12 +1,13 @@
 import Artist from "schema/artist"
 import { IDFields } from "schema/object_identification"
 
-import { pageable, getPagingParameters } from "relay-cursor-paging"
-import { connectionDefinitions, connectionFromArraySlice } from "graphql-relay"
+import { pageable } from "relay-cursor-paging"
+import { connectionDefinitions } from "graphql-relay"
 import { GraphQLObjectType, GraphQLBoolean, GraphQLFieldConfig } from "graphql"
 import { ResolverContext } from "types/graphql"
+import followArtistsResolver from "lib/shared_resolvers/followedArtistsResolver"
 
-export const FollowArtistType = new GraphQLObjectType<any, ResolverContext>({
+const FollowArtistType = new GraphQLObjectType<any, ResolverContext>({
   name: "FollowArtist",
   fields: {
     artist: {
@@ -22,22 +23,8 @@ export const FollowArtistType = new GraphQLObjectType<any, ResolverContext>({
 const FollowedArtists: GraphQLFieldConfig<void, ResolverContext> = {
   type: connectionDefinitions({ nodeType: FollowArtistType }).connectionType,
   args: pageable({}),
-  description: "A list of the current user’s inquiry requests",
-  resolve: (_root, options, { followedArtistsLoader }) => {
-    if (!followedArtistsLoader) return null
-    const { limit: size, offset } = getPagingParameters(options)
-    const gravityArgs = {
-      size,
-      offset,
-      total_count: true,
-    }
-    return followedArtistsLoader(gravityArgs).then(({ body, headers }) => {
-      return connectionFromArraySlice(body, options, {
-        arrayLength: parseInt(headers["x-total-count"] || "0", 10),
-        sliceStart: offset,
-      })
-    })
-  },
+  description: "A Connection of followed artists by current user",
+  resolve: (_parent, args, context) => followArtistsResolver({}, args, context),
 }
 
 export default FollowedArtists

--- a/src/schema/show.ts
+++ b/src/schema/show.ts
@@ -43,6 +43,15 @@ import EventStatus from "./input_fields/event_status"
 import { LOCAL_DISCOVERY_RADIUS_KM } from "./city/constants"
 import { ResolverContext } from "types/graphql"
 
+const ShowsFollowedContentType = new GraphQLObjectType<any, ResolverContext>({
+  name: "ShowsFollowedContent",
+  fields: () => ({
+    artists: {
+      type: new GraphQLList(Artist.type),
+    },
+  }),
+})
+
 const kind = ({ artists, fair, artists_without_artworks, group }) => {
   if (isExisty(fair)) return "fair"
   if (
@@ -606,6 +615,19 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
       description: "Is it a fair booth or a show?",
       type: GraphQLString,
       resolve: ({ fair }) => (isExisty(fair) ? "Fair Booth" : "Show"),
+    },
+    followedContent: {
+      type: ShowsFollowedContentType,
+      resolve: (show, _options, { followedArtistsLoader }) => {
+        if (!followedArtistsLoader) return null
+        return {
+          artists: followedArtistsLoader({ show_id: show.id }).then(
+            ({ body }) => {
+              return body.map(artist_follow => artist_follow.artist)
+            }
+          ),
+        }
+      },
     },
   }),
 })


### PR DESCRIPTION
# Depends on
https://github.com/artsy/gravity/pull/12185

# Change
Add `followedContents` to `show` type so we can get user's followed artists in a specific show.

We can wait till https://github.com/artsy/gravity/pull/12185 gets into prod to merge this.

# Example Query
```graphql
show(id:'something') {
  followedArtists{
    id
    edges {
      node{
        artist{
          id
        }
      }
    }
  }
}
```