### PR TITLE
[trackedEntityLoader] Batch in chunks of 200 IDs.

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/tracked_entity.ts
+++ b/src/lib/loaders/loaders_with_authentication/tracked_entity.ts
@@ -18,6 +18,10 @@ export interface TrackedEntityLoaderFactoryOptions {
    * An optional path to the IDs used to compare entities (defaults to `id`, but `_id` is sometimes useful).
    */
   entityIDKeyPath?: string
+  /**
+   * The maximum number of requests to batch in a single request (defaults to 200).
+   */
+  batchSize?: number
 }
 
 /**
@@ -36,6 +40,7 @@ const trackedEntityLoaderFactory = (
     trackingKey,
     entityKeyPath,
     entityIDKeyPath = "id",
+    batchSize = 200,
   } = options
   const trackedEntityLoader = new DataLoader(
     ids => {
@@ -57,7 +62,7 @@ const trackedEntityLoaderFactory = (
         return parsedResults
       })
     },
-    { batch: true, cache: true }
+    { batch: true, cache: true, maxBatchSize: batchSize }
   )
   return id => trackedEntityLoader.load(id)
 }


### PR DESCRIPTION
This is to avoid running into a `414 – Request-URI Too Long` from Gravity.

<img width="1649" alt="screenshot 2019-03-05 at 12 34 41" src="https://user-images.githubusercontent.com/2320/53806545-84874500-3f4d-11e9-871f-c2e415bd9685.png">
