### PR TITLE
Add static sponsored content

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1209,6 +1209,7 @@ type ArtworkContextFair {
     # When true, will only return exact keyword match
     keyword_match_exact: Boolean
   ): FilterArtworks
+  sponsoredContent: FairSponsoredContent
 }
 
 type ArtworkContextPartnerShow implements Node {
@@ -2464,6 +2465,12 @@ type City {
     before: String
     last: Int
   ): FairConnection
+  sponsoredContent: CitySponsoredContent
+}
+
+type CitySponsoredContent {
+  introText: String
+  artGuideUrl: String
 }
 
 type Collection implements Node {
@@ -3360,6 +3367,7 @@ type Fair {
     # When true, will only return exact keyword match
     keyword_match_exact: Boolean
   ): FilterArtworks
+  sponsoredContent: FairSponsoredContent
 }
 
 enum FairArtistSorts {
@@ -3439,6 +3447,11 @@ enum FairSorts {
   NAME_DESC
   START_AT_ASC
   START_AT_DESC
+}
+
+type FairSponsoredContent {
+  activationText: String
+  pressReleaseUrl: String
 }
 
 type FeaturedLinkItem {
@@ -4591,6 +4604,7 @@ type HomePageModuleContextFair {
     # When true, will only return exact keyword match
     keyword_match_exact: Boolean
   ): FilterArtworks
+  sponsoredContent: FairSponsoredContent
 }
 
 type HomePageModuleContextFollowArtists {

--- a/src/lib/sponsoredContent/data.json
+++ b/src/lib/sponsoredContent/data.json
@@ -1,0 +1,52 @@
+{
+  "cities": {
+    "new-york-ny-usa": {
+      "introText": "The BMW Art Guide is your go-to-guide to discover private collections of modern and contemporary art which are accessible to the public. Please see below for collections in New York.",
+      "artGuideUrl": "https://www.bmw-art-guide.com/",
+      "partnerIds": []
+    },
+    "london-united-kingdom": {
+      "introText": "The BMW Art Guide is your go-to-guide to discover private collections of modern and contemporary art which are accessible to the public. Please see below for collections in London.",
+      "artGuideUrl": "https://www.bmw-art-guide.com/",
+      "partnerIds": []
+    },
+    "los-angeles-ca-usa": {
+      "introText": "The BMW Art Guide is your go-to-guide to discover private collections of modern and contemporary art which are accessible to the public. Please see below for collections in Los Angeles.",
+      "artGuideUrl": "https://www.bmw-art-guide.com/",
+      "partnerIds": []
+    },
+    "paris-france": {
+      "introText": "The BMW Art Guide is your go-to-guide to discover private collections of modern and contemporary art which are accessible to the public. Please see below for collections in Paris.",
+      "artGuideUrl": "https://www.bmw-art-guide.com/",
+      "partnerIds": []
+    },
+    "berlin-germany": {
+      "introText": "The BMW Art Guide is your go-to-guide to discover private collections of modern and contemporary art which are accessible to the public. Please see below for collections in Berlin.",
+      "artGuideUrl": "https://www.bmw-art-guide.com/",
+      "partnerIds": []
+    },
+    "hong-kong-hong-kong": {
+      "introText": "The BMW Art Guide is your go-to-guide to discover private collections of modern and contemporary art which are accessible to the public. Please see below for collections in Hong Kong.",
+      "artGuideUrl": "https://www.bmw-art-guide.com/",
+      "partnerIds": []
+    }
+  },
+  "fairs": {
+    "art-basel-hong-kong-2019": {
+      "activationText": "Labore excepteur culpa minim dolor. Magna anim mollit enim mollit sit ipsum aliqua velit proident magna eu. Pariatur proident aliqua et eu commodo consequat laborum irure velit. Sunt minim dolor deserunt proident irure officia ea sint.",
+      "pressReleaseUrl": "https://www.example.com"
+    },
+    "frieze-new-york-2019": {
+      "activationText": "In quis ex pariatur esse consectetur occaecat nulla quis consequat do in. Ipsum in cillum ut magna sunt proident. Ullamco culpa nisi commodo incididunt. Qui sunt consequat ullamco magna anim.",
+      "pressReleaseUrl": "https://www.example.com"
+    },
+    "frieze-london-2018": {
+      "activationText": "Dolore qui quis non ea dolore laboris ad aute reprehenderit irure. Deserunt veniam est nisi eu ipsum deserunt deserunt non in pariatur duis. Cillum tempor deserunt reprehenderit Lorem eiusmod. Tempor deserunt aute aliquip ea aliqua dolore adipisicing ut ad quis elit consectetur cupidatat. Et amet velit elit cillum. Anim elit minim excepteur duis cillum magna commodo amet id sit fugiat.",
+      "pressReleaseUrl": "https://www.example.com"
+    },
+    "paris-photo-2018": {
+      "activationText": "Occaecat dolor reprehenderit deserunt veniam nulla eu. Magna consequat commodo duis nulla fugiat elit velit consequat aute excepteur eiusmod nostrud tempor. Consequat consectetur nisi nostrud magna mollit velit ullamco sunt magna et mollit anim ea.",
+      "pressReleaseUrl": "https://www.example.com"
+    }
+  }
+}

--- a/src/lib/sponsoredContent/index.ts
+++ b/src/lib/sponsoredContent/index.ts
@@ -1,0 +1,23 @@
+import sponsoredContentData from "./data.json"
+
+interface CitySponsoredContent {
+  /** Prose content for city */
+  introText: string
+
+  /** Link to external guide */
+  artGuideUrl: string
+}
+
+interface FairSponsoredContent {
+  /** Prose content for fair */
+  activationText: string
+
+  /** Link to external press release */
+  pressReleaseUrl: string
+}
+
+export const sponsoredContentForCity = (slug: string): CitySponsoredContent =>
+  sponsoredContentData.cities[slug]
+
+export const sponsoredContentForFair = (id: string): FairSponsoredContent =>
+  sponsoredContentData.fairs[id]

--- a/src/schema/__tests__/city.test.ts
+++ b/src/schema/__tests__/city.test.ts
@@ -11,8 +11,18 @@ const mockCities = {
   },
 }
 
+const mockSponsoredContent = {
+  cities: {
+    "sacramende-ca-usa": {
+      introText: "Lorem ipsum dolot sit amet",
+      artGuideUrl: "https://www.example.com/",
+    },
+  },
+}
+
 jest.mock("../city/city_data.json", () => mockCities)
-jest.mock("../../lib/all.ts")
+jest.mock("lib/all.ts")
+jest.mock("lib/sponsoredContent/data.json", () => mockSponsoredContent)
 
 import { runQuery } from "test/utils"
 import gql from "lib/gql"
@@ -268,6 +278,26 @@ describe("City", () => {
         mockFairsLoader,
         expect.anything()
       )
+    })
+  })
+
+  it("includes sponsored content", async () => {
+    const query = gql`
+      {
+        city(slug: "sacramende-ca-usa") {
+          sponsoredContent {
+            introText
+            artGuideUrl
+          }
+        }
+      }
+    `
+
+    const result = await runQuery(query)
+
+    expect(result!.city.sponsoredContent).toEqual({
+      introText: "Lorem ipsum dolot sit amet",
+      artGuideUrl: "https://www.example.com/",
     })
   })
 })

--- a/src/schema/__tests__/fair.test.js
+++ b/src/schema/__tests__/fair.test.js
@@ -1,3 +1,14 @@
+const mockSponsoredContent = {
+  fairs: {
+    "the-armory-show-2017": {
+      activationText: "Lorem ipsum dolor sit amet",
+      pressReleaseUrl: "https://www.example.com",
+    },
+  },
+}
+
+jest.mock("lib/sponsoredContent/data.json", () => mockSponsoredContent)
+
 /* eslint-disable promise/always-return */
 import { runQuery } from "test/utils"
 import gql from "lib/gql"
@@ -13,7 +24,7 @@ describe("Fair type", () => {
     },
   }
 
-  const query = gql`
+  let query = gql`
     {
       fair(id: "the-armory-show-2017") {
         id
@@ -116,6 +127,26 @@ describe("Fair type", () => {
           },
         },
       })
+    })
+  })
+
+  it("includes sponsored content", async () => {
+    query = gql`
+      {
+        fair(id: "the-armory-show-2017") {
+          sponsoredContent {
+            activationText
+            pressReleaseUrl
+          }
+        }
+      }
+    `
+
+    const result = await runQuery(query, context)
+
+    expect(result.fair.sponsoredContent).toEqual({
+      activationText: "Lorem ipsum dolor sit amet",
+      pressReleaseUrl: "https://www.example.com",
     })
   })
 })

--- a/src/schema/city/index.ts
+++ b/src/schema/city/index.ts
@@ -27,6 +27,7 @@ import { connectionWithCursorInfo } from "schema/fields/pagination"
 import { allViaLoader, MAX_GRAPHQL_INT } from "lib/all"
 import { StaticPathLoader } from "lib/loaders/api/loader_interface"
 import { BodyAndHeaders } from "lib/loaders"
+import { sponsoredContentForCity } from "lib/sponsoredContent"
 
 const CityType = new GraphQLObjectType<any, ResolverContext>({
   name: "City",
@@ -86,6 +87,20 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
           near: `${city.coordinates.lat},${city.coordinates.lng}`,
           max_distance: LOCAL_DISCOVERY_RADIUS_KM,
         }),
+    },
+    sponsoredContent: {
+      type: new GraphQLObjectType<any, ResolverContext>({
+        name: "CitySponsoredContent",
+        fields: {
+          introText: {
+            type: GraphQLString,
+          },
+          artGuideUrl: {
+            type: GraphQLString,
+          },
+        },
+      }),
+      resolve: city => sponsoredContentForCity(city.slug),
     },
   },
 })

--- a/src/schema/fair.ts
+++ b/src/schema/fair.ts
@@ -30,6 +30,7 @@ import ShowSort from "./sorts/show_sort"
 import { allViaLoader } from "lib/all"
 import { FairArtistSortsType } from "./sorts/fairArtistSorts"
 import { ResolverContext } from "types/graphql"
+import { sponsoredContentForFair } from "lib/sponsoredContent"
 
 const FollowedContentType = new GraphQLObjectType<any, ResolverContext>({
   name: "FollowedContent",
@@ -363,6 +364,20 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
       },
     },
     filteredArtworks: filterArtworks("fair_id"),
+    sponsoredContent: {
+      type: new GraphQLObjectType<any, ResolverContext>({
+        name: "FairSponsoredContent",
+        fields: {
+          activationText: {
+            type: GraphQLString,
+          },
+          pressReleaseUrl: {
+            type: GraphQLString,
+          },
+        },
+      }),
+      resolve: fair => sponsoredContentForFair(fair.id),
+    },
   }),
 })
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/LD-316

This PR introduces a home for the little bits of static sponsored content — prose descriptions, hyperlinks — that need to show up in certain client contexts such as the city view and the fair view in Eigen.

The content is stored in a [json file](https://github.com/artsy/metaphysics/commit/5f3d301323d707b0fa8179456115c92e38ffa97b#diff-545f2f7a00f714e6b0739c868b93f0b5), and made available through a `sponsoredContent` field that is now available on `city` and `fair`:

![sponsored](https://user-images.githubusercontent.com/140521/53828755-8c92b500-3f4c-11e9-8a77-ee0dd26acd2c.png)

If these fields are requested when there is no content, it's just `null`:

![nullsc](https://user-images.githubusercontent.com/140521/53829159-7f29fa80-3f4d-11e9-8d14-89eba3ace655.png)