### PR TITLE
Exclude fair-booths from shows in a city

### DIFF
--- a/src/schema/__tests__/city.test.ts
+++ b/src/schema/__tests__/city.test.ts
@@ -150,6 +150,18 @@ describe("City", () => {
       expect(gravityOptions).toMatchObject({ displayable: true })
       expect(gravityOptions).not.toHaveProperty("discoverable")
     })
+    it("requests shows with location, by default", async () => {
+      await runQuery(query, context)
+      const gravityOptions = context.showsWithHeadersLoader.mock.calls[0][0]
+
+      expect(gravityOptions).toMatchObject({ has_location: true })
+    })
+    it("excludes fair booths, by default", async () => {
+      await runQuery(query, context)
+      const gravityOptions = context.showsWithHeadersLoader.mock.calls[0][0]
+
+      expect(gravityOptions).toMatchObject({ at_a_fair: false })
+    })
 
     it("can filter by discoverable shows", async () => {
       query = gql`

--- a/src/schema/city/index.ts
+++ b/src/schema/city/index.ts
@@ -60,6 +60,7 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
           near: `${city.coordinates.lat},${city.coordinates.lng}`,
           max_distance: LOCAL_DISCOVERY_RADIUS_KM,
           has_location: true,
+          at_a_fair: false,
           sort: args.sort,
           // default Enum value for status is not properly resolved
           // so we have to manually resolve it by lowercasing the value


### PR DESCRIPTION
# Problem
When getting shows in a city, we were getting fair booths, these would show up as shows with location id but without coordinates.

![image](https://user-images.githubusercontent.com/1230819/53832945-70dfdc80-3f55-11e9-8ee0-4bc381a86217.png)

# Solution
Gravity provides a param for filtering out fair booths, we now by default set `at_a_fair` flag to `false` for these queries.