### PR TITLE
@dblandin => [Search] Expose aggregations for entity type and counts

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -7359,6 +7359,7 @@ type Query {
 
     # Mode of search to execute. Default: SITE.
     mode: SearchMode
+    aggregations: [SearchAggregation]
     after: String
     first: Int
     before: String
@@ -7996,6 +7997,9 @@ type SearchableConnection {
   edges: [SearchableEdge]
   pageCursors: PageCursors
   totalCount: Int
+
+  # Returns aggregation counts for the given filter query.
+  aggregations: [SearchAggregationResults]
 }
 
 # An edge in a connection.
@@ -8019,6 +8023,16 @@ type SearchableItem implements Node & Searchable {
   imageUrl: String
   href: String
   searchableType: String
+}
+
+enum SearchAggregation {
+  TYPE
+}
+
+# The results for a requested aggregations
+type SearchAggregationResults {
+  counts: [AggregationCount]
+  slice: SearchAggregation
 }
 
 enum SearchEntity {
@@ -9316,6 +9330,7 @@ type Viewer {
 
     # Mode of search to execute. Default: SITE.
     mode: SearchMode
+    aggregations: [SearchAggregation]
     after: String
     first: Int
     before: String

--- a/src/lib/loaders/searchLoader.ts
+++ b/src/lib/loaders/searchLoader.ts
@@ -3,13 +3,12 @@ import { SearchEntity } from "schema/search/SearchEntity"
 
 export const searchLoader = gravityLoader => {
   return gravityLoader(
-    ({ query, entities, mode, offset, size }) => {
+    ({ query, entities, mode, ...rest }) => {
       const queryParams = {
         term: query,
         "indexes[]":
           entities || SearchEntity.getValues().map(index => index.value),
-        size: size,
-        offset: offset,
+        ...rest,
       }
 
       switch (mode) {

--- a/src/schema/fields/pagination.ts
+++ b/src/schema/fields/pagination.ts
@@ -144,7 +144,7 @@ export function createPageCursors(
   return pageCursors
 }
 
-export function connectionWithCursorInfo(type) {
+export function connectionWithCursorInfo(type, connectionFields = {}) {
   return connectionDefinitions({
     nodeType: type,
     connectionFields: {
@@ -156,6 +156,7 @@ export function connectionWithCursorInfo(type) {
         type: GraphQLInt,
         resolve: ({ totalCount }) => totalCount,
       },
+      ...connectionFields,
     },
   }).connectionType
 }

--- a/src/schema/search/SearchAggregation.ts
+++ b/src/schema/search/SearchAggregation.ts
@@ -1,0 +1,30 @@
+import { map } from "lodash"
+import AggregationCount from "schema/aggregations/aggregation_count"
+import { GraphQLObjectType, GraphQLEnumType, GraphQLList } from "graphql"
+import { ResolverContext } from "types/graphql"
+
+export const SearchAggregation = new GraphQLEnumType({
+  name: "SearchAggregation",
+  values: {
+    TYPE: {
+      value: "_type",
+    },
+  },
+})
+
+export const SearchAggregationResultsType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "SearchAggregationResults",
+  description: "The results for a requested aggregations",
+  fields: () => ({
+    counts: {
+      type: new GraphQLList(AggregationCount.type),
+      resolve: ({ counts }) => map(counts, AggregationCount.resolve),
+    },
+    slice: {
+      type: SearchAggregation,
+    },
+  }),
+})


### PR DESCRIPTION
Still need to add some specs (and make sure it's all working right!).

You'll be able to include 

``` js
aggregations {
  slice
  counts {
    count
    name
  }
}
```

as a fragment on `SearchableConnection`.

The result will look like:
```
aggregations: [
  {
    slice: "TYPE",
    counts: [
      {
        count: 100
        name: "artwork"
      }
      {
        count: 100
        name: "artist"
      }
    ]
  }
]
```
