### PR TITLE
Add includeStubShows and displayable and deprecate discoverable

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -2453,7 +2453,13 @@ type City {
     # Filter shows by partner type
     partnerType: PartnerShowPartnerType
 
-    # Whether to include local discovery stubs as well as displayable shows
+    # Whether to include local discovery stubs
+    includeLocalDiscovery: Boolean
+
+    # Filter by displayable shows
+    displayable: Boolean = true
+
+    # Whether to include local discovery stubs
     discoverable: Boolean
     after: String
     first: Int

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -2456,9 +2456,6 @@ type City {
     # Whether to include local discovery stubs
     includeStubShows: Boolean
 
-    # Filter by displayable shows
-    displayable: Boolean = true
-
     # Whether to include stub shows or not
     discoverable: Boolean
     after: String

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -2454,12 +2454,12 @@ type City {
     partnerType: PartnerShowPartnerType
 
     # Whether to include local discovery stubs
-    includeLocalDiscovery: Boolean
+    includeStubShows: Boolean
 
     # Filter by displayable shows
     displayable: Boolean = true
 
-    # Whether to include local discovery stubs
+    # Whether to include stub shows or not
     discoverable: Boolean
     after: String
     first: Int

--- a/src/schema/__tests__/city.test.ts
+++ b/src/schema/__tests__/city.test.ts
@@ -221,29 +221,6 @@ describe("City", () => {
       })
     })
 
-    it("can filter by displayable", async () => {
-      query = gql`
-        {
-          city(slug: "sacramende-ca-usa") {
-            name
-            shows(first: 1, displayable: true) {
-              edges {
-                node {
-                  id
-                }
-              }
-            }
-          }
-        }
-      `
-      await runQuery(query, context)
-      const gravityOptions = context.showsWithHeadersLoader.mock.calls[0][0]
-
-      expect(gravityOptions).toMatchObject({
-        displayable: true,
-      })
-    })
-
     describe("filtering by single partner type", () => {
       it("can filter to gallery shows", async () => {
         query = gql`

--- a/src/schema/__tests__/city.test.ts
+++ b/src/schema/__tests__/city.test.ts
@@ -217,6 +217,7 @@ describe("City", () => {
 
       expect(gravityOptions).toMatchObject({
         include_local_discovery: true,
+        displayable: true,
       })
     })
 

--- a/src/schema/__tests__/city.test.ts
+++ b/src/schema/__tests__/city.test.ts
@@ -191,8 +191,56 @@ describe("City", () => {
       await runQuery(query, context)
       const gravityOptions = context.showsWithHeadersLoader.mock.calls[0][0]
 
-      expect(gravityOptions).toMatchObject({ discoverable: true })
-      expect(gravityOptions).not.toHaveProperty("displayable")
+      expect(gravityOptions).toMatchObject({
+        include_local_discovery: true,
+        displayable: true,
+      })
+    })
+
+    it("can ask for inclduing local_discovery shows", async () => {
+      query = gql`
+        {
+          city(slug: "sacramende-ca-usa") {
+            name
+            shows(first: 1, includeLocalDiscovery: true) {
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+          }
+        }
+      `
+      await runQuery(query, context)
+      const gravityOptions = context.showsWithHeadersLoader.mock.calls[0][0]
+
+      expect(gravityOptions).toMatchObject({
+        include_local_discovery: true,
+      })
+    })
+
+    it("can filter by displayable", async () => {
+      query = gql`
+        {
+          city(slug: "sacramende-ca-usa") {
+            name
+            shows(first: 1, displayable: true) {
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+          }
+        }
+      `
+      await runQuery(query, context)
+      const gravityOptions = context.showsWithHeadersLoader.mock.calls[0][0]
+
+      expect(gravityOptions).toMatchObject({
+        displayable: true,
+      })
     })
 
     describe("filtering by single partner type", () => {

--- a/src/schema/__tests__/city.test.ts
+++ b/src/schema/__tests__/city.test.ts
@@ -197,12 +197,12 @@ describe("City", () => {
       })
     })
 
-    it("can ask for inclduing local_discovery shows", async () => {
+    it("can ask for including stubbed shows", async () => {
       query = gql`
         {
           city(slug: "sacramende-ca-usa") {
             name
-            shows(first: 1, includeLocalDiscovery: true) {
+            shows(first: 1, includeStubShows: true) {
               edges {
                 node {
                   id

--- a/src/schema/__tests__/city.test.ts
+++ b/src/schema/__tests__/city.test.ts
@@ -221,7 +221,7 @@ describe("City", () => {
       })
     })
 
-    describe("filtering by single partner type", () => {
+    describe("filtering by partner type", () => {
       it("can filter to gallery shows", async () => {
         query = gql`
           {

--- a/src/schema/city/index.ts
+++ b/src/schema/city/index.ts
@@ -66,7 +66,7 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
           type: PartnerShowPartnerType,
           description: "Filter shows by partner type",
         },
-        includeLocalDiscovery: {
+        includeStubShows: {
           type: GraphQLBoolean,
           description: "Whether to include local discovery stubs",
         },
@@ -77,9 +77,9 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
         },
         discoverable: {
           type: GraphQLBoolean,
-          description: "Whether to include local discovery stubs",
+          description: "Whether to include stub shows or not",
           deprecationReason:
-            "Use `includeLocalDiscovery` and `displayable` combination",
+            "Use `includeStubShows` and `displayable` combination",
         },
       }),
       resolve: async (city, args, { showsWithHeadersLoader }) =>
@@ -95,7 +95,7 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
           // https://github.com/apollographql/graphql-tools/issues/715
           status: args.status.toLowerCase(),
           include_local_discovery:
-            args.discoverable === true || args.includeLocalDiscovery,
+            args.discoverable === true || args.includeStubShows,
           displayable: args.discoverable === true || args.displayable,
         }),
     },

--- a/src/schema/city/index.ts
+++ b/src/schema/city/index.ts
@@ -66,10 +66,20 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
           type: PartnerShowPartnerType,
           description: "Filter shows by partner type",
         },
+        includeLocalDiscovery: {
+          type: GraphQLBoolean,
+          description: "Whether to include local discovery stubs",
+        },
+        displayable: {
+          type: GraphQLBoolean,
+          defaultValue: true,
+          description: "Filter by displayable shows",
+        },
         discoverable: {
           type: GraphQLBoolean,
-          description:
-            "Whether to include local discovery stubs as well as displayable shows",
+          description: "Whether to include local discovery stubs",
+          deprecationReason:
+            "Use `includeLocalDiscovery` and `displayable` combination",
         },
       }),
       resolve: async (city, args, { showsWithHeadersLoader }) =>
@@ -84,14 +94,9 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
           // so we have to manually resolve it by lowercasing the value
           // https://github.com/apollographql/graphql-tools/issues/715
           status: args.status.toLowerCase(),
-          // This is to ensure the key never makes its way into the `baseParams`
-          // object if not needed,
-          ...(typeof args.discoverable === "undefined"
-            ? undefined
-            : { discoverable: args.discoverable }),
-          ...(typeof args.discoverable === "undefined"
-            ? { displayable: true }
-            : undefined),
+          include_local_discovery:
+            args.discoverable === true || args.includeLocalDiscovery,
+          displayable: args.discoverable === true || args.displayable,
         }),
     },
     fairs: {

--- a/src/schema/city/index.ts
+++ b/src/schema/city/index.ts
@@ -94,9 +94,9 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
           // so we have to manually resolve it by lowercasing the value
           // https://github.com/apollographql/graphql-tools/issues/715
           status: args.status.toLowerCase(),
+          displayable: true,
           include_local_discovery:
             args.discoverable === true || args.includeStubShows,
-          displayable: args.discoverable === true || args.displayable,
         }),
     },
     fairs: {

--- a/src/schema/city/index.ts
+++ b/src/schema/city/index.ts
@@ -70,16 +70,10 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
           type: GraphQLBoolean,
           description: "Whether to include local discovery stubs",
         },
-        displayable: {
-          type: GraphQLBoolean,
-          defaultValue: true,
-          description: "Filter by displayable shows",
-        },
         discoverable: {
           type: GraphQLBoolean,
           description: "Whether to include stub shows or not",
-          deprecationReason:
-            "Use `includeStubShows` and `displayable` combination",
+          deprecationReason: "Use `includeStubShows`",
         },
       }),
       resolve: async (city, args, { showsWithHeadersLoader }) =>
@@ -96,7 +90,7 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
           status: args.status.toLowerCase(),
           displayable: true,
           include_local_discovery:
-            args.discoverable === true || args.includeStubShows,
+            args.includeStubShows || args.discoverable === true,
         }),
     },
     fairs: {


### PR DESCRIPTION
Depends on https://github.com/artsy/gravity/pull/12191

# Change

Deprecate current `discoverable` argument and for time being resolve that to `displayable: true` and `include_local_discovery: true`.

Introduce new `includeStubShows` and `displayable` as alternative of `discoverable`. 