### PR TITLE
Display DaySchedule union

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3077,6 +3077,10 @@ type DaySchedule {
   day_of_week: String
 }
 
+type DayScheduleText {
+  text: String
+}
+
 type DeepZoom {
   Image: DeepZoomImage
 }
@@ -3805,10 +3809,16 @@ enum Format {
   markdown @deprecated(reason: "deprecated")
 }
 
+type FormattedArray {
+  schedules: [FormattedDaySchedules]
+}
+
 type FormattedDaySchedules {
   days: String
   hours: String
 }
+
+union FormattedDaySchedulesOrTextUnionType = FormattedArray | DayScheduleText
 
 # The `FormattedNumber` type represents a number that can optionally be returnedas
 # a formatted String. It does not try to coerce the type.
@@ -5014,7 +5024,7 @@ type Location {
 
   # Alternate Markdown-supporting free text representation of a location's opening hours
   day_schedule_text: String
-  displayDaySchedules: [FormattedDaySchedules]
+  displayDaySchedules: FormattedDaySchedulesOrTextUnionType
   display: String
   phone: String
   postal_code: String

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3810,10 +3810,6 @@ type FormattedDaySchedules {
   hours: String
 }
 
-union FormattedDaySchedulesOrTextUnionType =
-    OpeningHoursArray
-  | OpeningHoursText
-
 # The `FormattedNumber` type represents a number that can optionally be returnedas
 # a formatted String. It does not try to coerce the type.
 scalar FormattedNumber
@@ -5022,7 +5018,7 @@ type Location {
     @deprecated(reason: "Use openingHours instead")
 
   # Union returning opening hours in formatted structure or a string
-  openingHours: FormattedDaySchedulesOrTextUnionType
+  openingHours: OpeningHoursUnion
   display: String
   phone: String
   postal_code: String
@@ -6028,6 +6024,8 @@ type OpeningHoursArray {
 type OpeningHoursText {
   text: String
 }
+
+union OpeningHoursUnion = OpeningHoursArray | OpeningHoursText
 
 interface Order {
   # ID of the order

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3809,7 +3809,7 @@ enum Format {
   markdown @deprecated(reason: "deprecated")
 }
 
-type FormattedArray {
+type FormattedDayScheduleArray {
   schedules: [FormattedDaySchedules]
 }
 
@@ -3818,7 +3818,9 @@ type FormattedDaySchedules {
   hours: String
 }
 
-union FormattedDaySchedulesOrTextUnionType = FormattedArray | DayScheduleText
+union FormattedDaySchedulesOrTextUnionType =
+    FormattedDayScheduleArray
+  | DayScheduleText
 
 # The `FormattedNumber` type represents a number that can optionally be returnedas
 # a formatted String. It does not try to coerce the type.

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3077,10 +3077,6 @@ type DaySchedule {
   day_of_week: String
 }
 
-type DayScheduleText {
-  text: String
-}
-
 type DeepZoom {
   Image: DeepZoomImage
 }
@@ -3809,18 +3805,14 @@ enum Format {
   markdown @deprecated(reason: "deprecated")
 }
 
-type FormattedDayScheduleArray {
-  schedules: [FormattedDaySchedules]
-}
-
 type FormattedDaySchedules {
   days: String
   hours: String
 }
 
 union FormattedDaySchedulesOrTextUnionType =
-    FormattedDayScheduleArray
-  | DayScheduleText
+    OpeningHoursArray
+  | OpeningHoursText
 
 # The `FormattedNumber` type represents a number that can optionally be returnedas
 # a formatted String. It does not try to coerce the type.
@@ -5026,7 +5018,11 @@ type Location {
 
   # Alternate Markdown-supporting free text representation of a location's opening hours
   day_schedule_text: String
-  displayDaySchedules: FormattedDaySchedulesOrTextUnionType
+  displayDaySchedules: [FormattedDaySchedules]
+    @deprecated(reason: "Use openingHours instead")
+
+  # Union returning opening hours in formatted structure or a string
+  openingHours: FormattedDaySchedulesOrTextUnionType
   display: String
   phone: String
   postal_code: String
@@ -6023,6 +6019,14 @@ type OfferOrder implements Order {
 
   # List of submitted offers made on this order so far
   offers: OfferConnection
+}
+
+type OpeningHoursArray {
+  schedules: [FormattedDaySchedules]
+}
+
+type OpeningHoursText {
+  text: String
 }
 
 interface Order {

--- a/src/schema/location.ts
+++ b/src/schema/location.ts
@@ -30,12 +30,13 @@ const DayScheduleText = new GraphQLObjectType<any, ResolverContext>({
   fields: {
     text: {
       type: GraphQLString,
+      resolve: ({ day_schedule_text }) => day_schedule_text,
     },
   },
 })
 
-const FormattedArray = new GraphQLObjectType<any, ResolverContext>({
-  name: "FormattedArray",
+const FormattedDayScheduleArray = new GraphQLObjectType<any, ResolverContext>({
+  name: "FormattedDayScheduleArray",
   fields: {
     schedules: {
       type: new GraphQLList(FormattedDaySchedules.type),
@@ -46,10 +47,10 @@ const FormattedArray = new GraphQLObjectType<any, ResolverContext>({
 
 const FormattedDaySchedulesOrTextUnion = new GraphQLUnionType({
   name: "FormattedDaySchedulesOrTextUnionType",
-  types: [FormattedArray, DayScheduleText],
+  types: [FormattedDayScheduleArray, DayScheduleText],
   resolveType: object => {
     if (object.schedules) {
-      return FormattedArray
+      return FormattedDayScheduleArray
     } else return DayScheduleText
   },
 })

--- a/src/schema/location.ts
+++ b/src/schema/location.ts
@@ -30,7 +30,7 @@ const OpeningHoursText = new GraphQLObjectType<any, ResolverContext>({
   fields: {
     text: {
       type: GraphQLString,
-      resolve: ({ day_schedule_text }) => day_schedule_text,
+      resolve: ops => ops.day_schedule_text,
     },
   },
 })
@@ -47,10 +47,10 @@ const OpeningHoursArray = new GraphQLObjectType<any, ResolverContext>({
 })
 
 const OpeningHoursUnion = new GraphQLUnionType({
-  name: "FormattedDaySchedulesOrTextUnionType",
+  name: "OpeningHoursUnion",
   types: [OpeningHoursArray, OpeningHoursText],
   resolveType: object => {
-    if (object.day_schedules) {
+    if (object.day_schedules && object.day_schedules.length > 0) {
       return OpeningHoursArray
     } else return OpeningHoursText
   },
@@ -96,7 +96,9 @@ export const LocationType = new GraphQLObjectType<any, ResolverContext>({
     openingHours: {
       type: OpeningHoursUnion,
       resolve: ({ day_schedules, day_schedule_text }) =>
-        day_schedules ? { day_schedules } : { day_schedule_text },
+        day_schedules && day_schedules.length > 0
+          ? { day_schedules }
+          : { day_schedule_text },
       description:
         "Union returning opening hours in formatted structure or a string",
     },

--- a/src/schema/location.ts
+++ b/src/schema/location.ts
@@ -25,13 +25,32 @@ export const LatLngType = new GraphQLObjectType<any, ResolverContext>({
   },
 })
 
+const DayScheduleText = new GraphQLObjectType<any, ResolverContext>({
+  name: "DayScheduleText",
+  fields: {
+    text: {
+      type: GraphQLString,
+    },
+  },
+})
+
+const FormattedArray = new GraphQLObjectType<any, ResolverContext>({
+  name: "FormattedArray",
+  fields: {
+    schedules: {
+      type: new GraphQLList(FormattedDaySchedules.type),
+      resolve: ({ schedules }) => FormattedDaySchedules.resolve(schedules),
+    },
+  },
+})
+
 const FormattedDaySchedulesOrTextUnion = new GraphQLUnionType({
   name: "FormattedDaySchedulesOrTextUnionType",
-  types: [FormattedDaySchedules, GraphQLString],
+  types: [FormattedArray, DayScheduleText],
   resolveType: object => {
-    if (object.day_schedules) {
-      return FormattedDaySchedules
-    } else return GraphQLString
+    if (object.schedules) {
+      return FormattedArray
+    } else return DayScheduleText
   },
 })
 
@@ -69,8 +88,8 @@ export const LocationType = new GraphQLObjectType<any, ResolverContext>({
       type: FormattedDaySchedulesOrTextUnion,
       resolve: ({ day_schedules, day_schedule_text }) =>
         day_schedules
-          ? FormattedDaySchedules.resolve(day_schedules)
-          : day_schedule_text,
+          ? { schedules: day_schedules }
+          : { text: day_schedule_text },
     },
     display: {
       type: GraphQLString,

--- a/src/schema/location.ts
+++ b/src/schema/location.ts
@@ -25,8 +25,8 @@ export const LatLngType = new GraphQLObjectType<any, ResolverContext>({
   },
 })
 
-const DayScheduleText = new GraphQLObjectType<any, ResolverContext>({
-  name: "DayScheduleText",
+const OpeningHoursText = new GraphQLObjectType<any, ResolverContext>({
+  name: "OpeningHoursText",
   fields: {
     text: {
       type: GraphQLString,
@@ -35,23 +35,24 @@ const DayScheduleText = new GraphQLObjectType<any, ResolverContext>({
   },
 })
 
-const FormattedDayScheduleArray = new GraphQLObjectType<any, ResolverContext>({
-  name: "FormattedDayScheduleArray",
+const OpeningHoursArray = new GraphQLObjectType<any, ResolverContext>({
+  name: "OpeningHoursArray",
   fields: {
     schedules: {
       type: new GraphQLList(FormattedDaySchedules.type),
-      resolve: ({ schedules }) => FormattedDaySchedules.resolve(schedules),
+      resolve: ({ day_schedules }) =>
+        FormattedDaySchedules.resolve(day_schedules),
     },
   },
 })
 
-const FormattedDaySchedulesOrTextUnion = new GraphQLUnionType({
+const OpeningHoursUnion = new GraphQLUnionType({
   name: "FormattedDaySchedulesOrTextUnionType",
-  types: [FormattedDayScheduleArray, DayScheduleText],
+  types: [OpeningHoursArray, OpeningHoursText],
   resolveType: object => {
-    if (object.schedules) {
-      return FormattedDayScheduleArray
-    } else return DayScheduleText
+    if (object.day_schedules) {
+      return OpeningHoursArray
+    } else return OpeningHoursText
   },
 })
 
@@ -85,13 +86,21 @@ export const LocationType = new GraphQLObjectType<any, ResolverContext>({
         "Alternate Markdown-supporting free text representation of a location's opening hours",
       type: GraphQLString,
     },
+
     displayDaySchedules: {
-      type: FormattedDaySchedulesOrTextUnion,
-      resolve: ({ day_schedules, day_schedule_text }) =>
-        day_schedules
-          ? { schedules: day_schedules }
-          : { text: day_schedule_text },
+      type: new GraphQLList(FormattedDaySchedules.type),
+      resolve: ({ day_schedules }) =>
+        FormattedDaySchedules.resolve(day_schedules),
+      deprecationReason: "Use openingHours instead",
     },
+    openingHours: {
+      type: OpeningHoursUnion,
+      resolve: ({ day_schedules, day_schedule_text }) =>
+        day_schedules ? { day_schedules } : { day_schedule_text },
+      description:
+        "Union returning opening hours in formatted structure or a string",
+    },
+
     display: {
       type: GraphQLString,
     },

--- a/src/schema/location.ts
+++ b/src/schema/location.ts
@@ -9,6 +9,7 @@ import {
   GraphQLFloat,
   GraphQLList,
   GraphQLFieldConfig,
+  GraphQLUnionType,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
 
@@ -21,6 +22,16 @@ export const LatLngType = new GraphQLObjectType<any, ResolverContext>({
     lng: {
       type: GraphQLFloat,
     },
+  },
+})
+
+const FormattedDaySchedulesOrTextUnion = new GraphQLUnionType({
+  name: "FormattedDaySchedulesOrTextUnionType",
+  types: [FormattedDaySchedules, GraphQLString],
+  resolveType: object => {
+    if (object.day_schedules) {
+      return FormattedDaySchedules
+    } else return GraphQLString
   },
 })
 
@@ -55,9 +66,11 @@ export const LocationType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
     },
     displayDaySchedules: {
-      type: new GraphQLList(FormattedDaySchedules.type),
-      resolve: ({ day_schedules }) =>
-        FormattedDaySchedules.resolve(day_schedules),
+      type: FormattedDaySchedulesOrTextUnion,
+      resolve: ({ day_schedules, day_schedule_text }) =>
+        day_schedules
+          ? FormattedDaySchedules.resolve(day_schedules)
+          : day_schedule_text,
     },
     display: {
       type: GraphQLString,


### PR DESCRIPTION
# Problem
https://artsyproduct.atlassian.net/browse/LD-221
We already have 3 fields describing day schedules in different ways for a `Location`

- `day_schedules`: Array of `DayScheduleType` set mostly by partners themselves
- `day_schedule_text`: A string set by artsy admins
- `displayDaySchedules`: currently a field that formats `day_schedules` data to array of `FormattedDaySchedules`

Currently clients need to decide which field to use, we want to have MP be the source of truth and have the priority logic about which one to use?

# Solution
Added a new `openingHours` field which is a union of `OpeningHoursArray` and `OpeningHoursText`, if we have `day_schedules` we resolve this field to `OpeningHoursArray` otherwise we use `OpeningHoursText`.

```graphql
{
  show(id: "galerie-crone-emmanuel-bornstein-clinamen") {
    id
    location{
      day_schedule_text
      day_schedules {
        start_time
        end_time
        day_of_week
      }
      openingHours{
        ... on OpeningHoursArray {
          schedules{
            days
            hours
          }
        }
        ... on OpeningHoursText {
          text
        }
      }
    }
  }
}
```

# Question
Currently there doesn't seem to be a way to have a union of Scalar Types, right? something like
```
[FormattedDaySchedule] | GraphQLString
``` 
if we could have ☝️ then the change in emission would have been minimal since it already checks the type


# Selfie
![image](https://user-images.githubusercontent.com/1230819/54130480-d49b5700-43e6-11e9-82a4-5bf77bc2b08f.png)
