### PR TITLE
[allViaLoader] No longer need to fetch any content to get /shows count.

### DIFF
--- a/src/lib/all.ts
+++ b/src/lib/all.ts
@@ -24,7 +24,7 @@ export const allViaLoader = (
   const countParams = {
     ...params,
     page: 1,
-    size: 1, // FIXME: The /shows endpoint does not return a count with size=0
+    size: 0,
     total_count: true,
   }
   return invokeLoader(countParams)

--- a/src/schema/city/index.ts
+++ b/src/schema/city/index.ts
@@ -198,8 +198,8 @@ async function loadData(
     offset = connectionParams.offset
     response = await loader({
       ...baseParams,
-      size: connectionParams.size,
-      page: connectionParams.page,
+      size: connectionParams.size || 0,
+      page: connectionParams.page || 1,
       total_count: true,
     })
   }


### PR DESCRIPTION
Fixed by https://github.com/artsy/gravity/pull/12196
Related to https://artsyproduct.atlassian.net/browse/LD-305

Still want to test this out first when Gravity is deployed to staging.