### PR TITLE
@dblandin => [Autosuggest] Correct href attribute for marketing collection results

### DIFF
--- a/src/schema/__tests__/search.test.ts
+++ b/src/schema/__tests__/search.test.ts
@@ -73,6 +73,12 @@ describe("Search", () => {
         label: "Sale",
         model: "sale",
       },
+      {
+        _id: "collectionID",
+        id: "catty-collection",
+        label: "MarketingCollection",
+        model: "marketingcollection",
+      },
     ]
 
     context = {
@@ -154,6 +160,12 @@ describe("Search", () => {
       const auctionSearchableItemNode = data!.search.edges[6].node
       expect(auctionSearchableItemNode.searchableType).toBe("Auction")
       expect(auctionSearchableItemNode.href).toBe("/auction/catty-auction")
+
+      const collectionSearchableItemNode = data!.search.edges[7].node
+      expect(collectionSearchableItemNode.searchableType).toBe("Collection")
+      expect(collectionSearchableItemNode.href).toBe(
+        "/collection/catty-collection"
+      )
     })
   })
 

--- a/src/schema/searchableItem.ts
+++ b/src/schema/searchableItem.ts
@@ -20,6 +20,8 @@ const hrefFromAutosuggestResult = item => {
       return `/auction/${item.id}`
     case "City":
       return `/shows/${item.id}`
+    case "MarketingCollection":
+      return `/collection/${item.id}`
     default:
       return `/${item.model}/${item.id}`
   }


### PR DESCRIPTION
Fixes the href for a marketing collection search result item (from `/marketingcollection/:slug` to `/collection/:slug`).