### PR TITLE
Add partner-type filtering to city shows field

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -2447,8 +2447,11 @@ type City {
   shows(
     sort: PartnerShowSorts
 
-    # By default we filter shows by current
+    # Filter shows by chronological event status
     status: EventStatus = CURRENT
+
+    # Filter shows by partner type
+    partnerType: PartnerShowPartnerType
 
     # Whether to include local discovery stubs as well as displayable shows
     discoverable: Boolean
@@ -6842,6 +6845,11 @@ type PartnerShowEventType {
 
   # A formatted description of the start to end dates
   exhibitionPeriod: String
+}
+
+enum PartnerShowPartnerType {
+  GALLERY
+  MUSEUM
 }
 
 enum PartnerShowSorts {

--- a/src/schema/__tests__/city.test.ts
+++ b/src/schema/__tests__/city.test.ts
@@ -195,6 +195,52 @@ describe("City", () => {
       expect(gravityOptions).not.toHaveProperty("displayable")
     })
 
+    describe("filtering by single partner type", () => {
+      it("can filter to gallery shows", async () => {
+        query = gql`
+          {
+            city(slug: "sacramende-ca-usa") {
+              name
+              shows(first: 1, partnerType: GALLERY) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+          }
+        `
+        await runQuery(query, context)
+        const gravityOptions = context.showsWithHeadersLoader.mock.calls[0][0]
+
+        expect(gravityOptions).toMatchObject({ partner_types: ["Gallery"] })
+      })
+
+      it("can filter to museum shows", async () => {
+        query = gql`
+          {
+            city(slug: "sacramende-ca-usa") {
+              name
+              shows(first: 1, partnerType: MUSEUM) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+          }
+        `
+        await runQuery(query, context)
+        const gravityOptions = context.showsWithHeadersLoader.mock.calls[0][0]
+
+        expect(gravityOptions).toMatchObject({
+          partner_types: ["Institution", "Institutional Seller"],
+        })
+      })
+    })
+
     it("can request all shows [that match other filter parameters]", async () => {
       allViaLoader.mockImplementation(() => Promise.resolve(mockShows))
 

--- a/src/schema/city/index.ts
+++ b/src/schema/city/index.ts
@@ -1,5 +1,6 @@
 import {
   GraphQLBoolean,
+  GraphQLEnumType,
   GraphQLObjectType,
   GraphQLString,
   GraphQLFieldConfig,
@@ -11,7 +12,6 @@ import PartnerShowSorts from "schema/sorts/partner_show_sorts"
 import { FairType } from "schema/fair"
 import FairSorts from "schema/sorts/fair_sorts"
 import EventStatus from "schema/input_fields/event_status"
-
 import cityData from "./city_data.json"
 import { pageable } from "relay-cursor-paging"
 import { connectionFromArraySlice } from "graphql-relay"
@@ -28,6 +28,18 @@ import { allViaLoader, MAX_GRAPHQL_INT } from "lib/all"
 import { StaticPathLoader } from "lib/loaders/api/loader_interface"
 import { BodyAndHeaders } from "lib/loaders"
 import { sponsoredContentForCity } from "lib/sponsoredContent"
+
+const PartnerShowPartnerType = new GraphQLEnumType({
+  name: "PartnerShowPartnerType",
+  values: {
+    GALLERY: {
+      value: ["Gallery"],
+    },
+    MUSEUM: {
+      value: ["Institution", "Institutional Seller"],
+    },
+  },
+})
 
 const CityType = new GraphQLObjectType<any, ResolverContext>({
   name: "City",
@@ -48,7 +60,11 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
         status: {
           type: EventStatus.type,
           defaultValue: "CURRENT",
-          description: "By default we filter shows by current",
+          description: "Filter shows by chronological event status",
+        },
+        partnerType: {
+          type: PartnerShowPartnerType,
+          description: "Filter shows by partner type",
         },
         discoverable: {
           type: GraphQLBoolean,
@@ -62,6 +78,7 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
           max_distance: LOCAL_DISCOVERY_RADIUS_KM,
           has_location: true,
           at_a_fair: false,
+          partner_types: args.partnerType,
           sort: args.sort,
           // default Enum value for status is not properly resolved
           // so we have to manually resolve it by lowercasing the value


### PR DESCRIPTION
Closes: https://artsyproduct.atlassian.net/browse/LD-315
Implements subtask: https://artsyproduct.atlassian.net/browse/LD-333

This closes the loop on partner type bucketing in the city shows query (following https://github.com/artsy/gravity/pull/12190 and https://github.com/artsy/gravity/pull/12198).

<img width="1552" alt="museum" src="https://user-images.githubusercontent.com/140521/54032839-b7654f00-4180-11e9-8c1b-8a09e72e143c.png">
