### PR TITLE
Allows null partner type for show parameters

### DIFF
--- a/src/schema/__tests__/city.test.ts
+++ b/src/schema/__tests__/city.test.ts
@@ -265,6 +265,27 @@ describe("City", () => {
           partner_types: ["Institution", "Institutional Seller"],
         })
       })
+
+      it("works with a null partner type", async () => {
+        query = gql`
+          {
+            city(slug: "sacramende-ca-usa") {
+              name
+              shows(first: 1, partnerType: null) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+          }
+        `
+        await runQuery(query, context)
+        const gravityOptions = context.showsWithHeadersLoader.mock.calls[0][0]
+
+        expect(gravityOptions.partner_types).toBeUndefined()
+      })
     })
 
     it("can request all shows [that match other filter parameters]", async () => {

--- a/src/schema/city/index.ts
+++ b/src/schema/city/index.ts
@@ -82,7 +82,7 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
           max_distance: LOCAL_DISCOVERY_RADIUS_KM,
           has_location: true,
           at_a_fair: false,
-          partner_types: args.partnerType,
+          ...(args.partnerType ? { partner_types: args.partnerType } : {}),
           sort: args.sort,
           // default Enum value for status is not properly resolved
           // so we have to manually resolve it by lowercasing the value

--- a/src/schema/city/index.ts
+++ b/src/schema/city/index.ts
@@ -82,7 +82,7 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
           max_distance: LOCAL_DISCOVERY_RADIUS_KM,
           has_location: true,
           at_a_fair: false,
-          ...(args.partnerType ? { partner_types: args.partnerType } : {}),
+          ...(args.partnerType && { partner_types: args.partnerType }),
           sort: args.sort,
           // default Enum value for status is not properly resolved
           // so we have to manually resolve it by lowercasing the value


### PR DESCRIPTION
Discussed here: 
https://github.com/artsy/emission/pull/1385#discussion_r263934065 Follow up from #1559.

When making a query with a null `partnerType` (something the schema allows), Gravity was throwing an error:

```
https://stagingapi.artsy.net/api/v1/shows?at_a_fair=false&displayable=true&has_location=true&include_local_discovery=true&max_distance=25&near=51.51%2C-0.13&page=3&partner_types=&size=10&sort=start_at&status=current&total_count=true - {\"type\":\"param_error\",\"message\":\"Invalid parameters.\",\"detail\":{\"partner_types\":[\"does not have a valid value\"]}}
```

This PR changes metaphysics to only send the `partnerType` param to Gravity if it's truthy. 