### PR TITLE
Support showing an artwork as VIRable when it's depth is under and inch

### DIFF
--- a/src/schema/artwork/__tests__/artwork.test.js
+++ b/src/schema/artwork/__tests__/artwork.test.js
@@ -965,6 +965,16 @@ describe("Artwork type", () => {
           })
         })
 
+        it("is hangable if artwork is 2d with a reasonable dimensions + tiny depth", () => {
+          artwork.width = 100
+          artwork.height = 100
+          artwork.depth = 0.5
+          artwork.category = "ink"
+          return runQuery(query, context).then(data => {
+            expect(data.artwork.is_hangable).toBe(true)
+          })
+        })
+
         it("is hangable if painting artwork is 2d and has reasonable dimensions", () => {
           artwork.width = 100
           artwork.height = 100

--- a/src/schema/artwork/utilities.ts
+++ b/src/schema/artwork/utilities.ts
@@ -1,16 +1,17 @@
 import { parse } from "url"
 
 export const isDimensional = value => parseFloat(value) > 0
-
-export const isThreeDimensional = ({ depth, diameter }) => {
-  return isDimensional(depth) || isDimensional(diameter)
-}
+export const isTinyDimensional = value => parseFloat(value) > 1
 
 export const isTwoDimensional = ({ width, height, depth, diameter }) => {
   return (
     isDimensional(width) &&
     isDimensional(height) &&
-    !isThreeDimensional({ depth, diameter })
+    !isDimensional(diameter) &&
+    // It's quite reasonable for a gallery to put on a depth of under an
+    // inch for an artwork that we should treat as being something we can
+    // up for view in room.
+    !isTinyDimensional(depth)
   )
 }
 


### PR DESCRIPTION
Had a chat with Stephen about why [this work](https://staging.artsy.net/artwork/robert-natkin-sonoma-mission-inn-signed-twice-and-inscribed-with-heart-drawing
) wasn't available for VIR. Figured we could give it a shot for 2d works with depth under and inch.