### PR TITLE
Add optional dayThreshold and new ClosingSoon status

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -2453,6 +2453,9 @@ type City {
     # Filter shows by partner type
     partnerType: PartnerShowPartnerType
 
+    # Only used when status is CLOSING_SOON or UPCOMING. Number of days used to filter upcoming and closing soon shows
+    dayThreshold: Int
+
     # Whether to include local discovery stubs
     includeStubShows: Boolean
 
@@ -3241,6 +3244,9 @@ enum EventStatus {
 
   # Start date is in the future
   UPCOMING
+
+  # End date is in near future
+  CLOSING_SOON
 }
 
 type ExternalPartner {

--- a/src/schema/__tests__/city.test.ts
+++ b/src/schema/__tests__/city.test.ts
@@ -221,7 +221,7 @@ describe("City", () => {
       })
     })
 
-    it("can filter to gallery shows", async () => {
+    it("can filter to shows by status and dayThreshold", async () => {
       query = gql`
         {
           city(slug: "sacramende-ca-usa") {

--- a/src/schema/__tests__/city.test.ts
+++ b/src/schema/__tests__/city.test.ts
@@ -221,6 +221,30 @@ describe("City", () => {
       })
     })
 
+    it("can filter to gallery shows", async () => {
+      query = gql`
+        {
+          city(slug: "sacramende-ca-usa") {
+            name
+            shows(first: 1, status: CLOSING_SOON, dayThreshold: 5) {
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+          }
+        }
+      `
+      await runQuery(query, context)
+      const gravityOptions = context.showsWithHeadersLoader.mock.calls[0][0]
+
+      expect(gravityOptions).toMatchObject({
+        day_threshold: 5,
+        status: "closing_soon",
+      })
+    })
+
     describe("filtering by partner type", () => {
       it("can filter to gallery shows", async () => {
         query = gql`

--- a/src/schema/city/index.ts
+++ b/src/schema/city/index.ts
@@ -4,6 +4,7 @@ import {
   GraphQLObjectType,
   GraphQLString,
   GraphQLFieldConfig,
+  GraphQLInt,
 } from "graphql"
 
 import { LatLngType } from "../location"
@@ -66,6 +67,11 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
           type: PartnerShowPartnerType,
           description: "Filter shows by partner type",
         },
+        dayThreshold: {
+          type: GraphQLInt,
+          description:
+            "Only used when status is CLOSING_SOON or UPCOMING. Number of days used to filter upcoming and closing soon shows",
+        },
         includeStubShows: {
           type: GraphQLBoolean,
           description: "Whether to include local discovery stubs",
@@ -83,6 +89,7 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
           has_location: true,
           at_a_fair: false,
           ...(args.partnerType && { partner_types: args.partnerType }),
+          ...(args.dayThreshold && { day_threshold: args.dayThreshold }),
           sort: args.sort,
           // default Enum value for status is not properly resolved
           // so we have to manually resolve it by lowercasing the value

--- a/src/schema/input_fields/event_status.ts
+++ b/src/schema/input_fields/event_status.ts
@@ -36,6 +36,10 @@ const EventStatus = {
         value: "upcoming",
         description: "Start date is in the future",
       },
+      CLOSING_SOON: {
+        value: "closing_soon",
+        description: "End date is in near future",
+      },
     },
   }),
 }


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/LD-337

# Changes
Added new `dayThreshold` argument to `city { shows (...)}` which can be used to filter shows in `UPCOMING` and `CLOSING_SOON` states.

# Depends on
https://github.com/artsy/gravity/pull/12204 