### PR TITLE
Deprecate is_local_discovery in favor of isStubShow

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -8381,11 +8381,12 @@ type Show implements Node {
   # Does the show exist as a fair booth?
   is_fair_booth: Boolean
 
-  # Is it a stubbed show?
+  # Is it a show provided for historical reference?
   is_reference: Boolean
+  is_local_discovery: Boolean @deprecated(reason: "Prefer isStubShow")
 
   # Is it an outsourced local discovery stub show?
-  is_local_discovery: Boolean
+  isStubShow: Boolean
 
   # Whether the show is in a fair, group or solo
   kind: String

--- a/src/schema/show.ts
+++ b/src/schema/show.ts
@@ -435,13 +435,18 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
       resolve: ({ fair }) => isExisty(fair),
     },
     is_reference: {
-      description: "Is it a stubbed show?",
+      description: "Is it a show provided for historical reference?",
       type: GraphQLBoolean,
       resolve: ({ is_reference }) => is_reference,
     },
     is_local_discovery: {
+      deprecationReason: "Prefer isStubShow",
+      type: GraphQLBoolean,
+    },
+    isStubShow: {
       description: "Is it an outsourced local discovery stub show?",
       type: GraphQLBoolean,
+      resolve: ({ is_local_discovery }) => is_local_discovery,
     },
     kind: {
       description: "Whether the show is in a fair, group or solo",


### PR DESCRIPTION
This converts the field name on Show to our favored terminology, deprecates the old one (and fixes an ambiguous related description).

![Screen Shot 2019-03-10 at 3 30 35 AM](https://user-images.githubusercontent.com/140521/54081992-e5fc3a80-42e4-11e9-9a77-0b0082794cc9.png)

#skip_camel