### PR TITLE
Fixes shows resolver to accept null status/dayThreshold values

### DIFF
--- a/src/schema/__tests__/city.test.ts
+++ b/src/schema/__tests__/city.test.ts
@@ -246,6 +246,31 @@ describe("City", () => {
       })
     })
 
+    it("works with null status and dayThreshold", async () => {
+      query = gql`
+        {
+          city(slug: "sacramende-ca-usa") {
+            name
+            shows(first: 1, status: null, dayThreshold: null) {
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+          }
+        }
+      `
+      await runQuery(query, context)
+
+      expect(context.showsWithHeadersLoader).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          day_threshold: expect.anything(),
+          status: expect.anything(),
+        })
+      )
+    })
+
     describe("filtering by partner type", () => {
       it("can filter to gallery shows", async () => {
         query = gql`

--- a/src/schema/city/index.ts
+++ b/src/schema/city/index.ts
@@ -94,7 +94,7 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
           // default Enum value for status is not properly resolved
           // so we have to manually resolve it by lowercasing the value
           // https://github.com/apollographql/graphql-tools/issues/715
-          status: args.status.toLowerCase(),
+          ...(args.status && { status: args.status.toLowerCase() }),
           displayable: true,
           include_local_discovery:
             args.includeStubShows || args.discoverable === true,


### PR DESCRIPTION
The schema permits sending `null` values, and Emission needs to do that so we can use a single query renderer for city section lists (ie: upcoming, galleries, museums, closing soon). 