### PR TITLE
Add support for PARTNER_ASC sort option for partner_shows

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -6904,6 +6904,7 @@ enum PartnerShowSorts {
   PUBLISH_AT_DESC
   START_AT_ASC
   START_AT_DESC
+  PARTNER_ASC
 }
 
 enum PartnersSortType {

--- a/src/schema/sorts/partner_show_sorts.ts
+++ b/src/schema/sorts/partner_show_sorts.ts
@@ -76,7 +76,7 @@ const PartnerShowSorts = {
       },
       PARTNER_ASC: {
         // TODO: Change to proper order once Gravity supports this type of sort
-        value: "name",
+        value: "end_at",
       },
     },
   }),

--- a/src/schema/sorts/partner_show_sorts.ts
+++ b/src/schema/sorts/partner_show_sorts.ts
@@ -74,6 +74,10 @@ const PartnerShowSorts = {
       START_AT_DESC: {
         value: "-start_at",
       },
+      PARTNER_ASC: {
+        // TODO: Change to proper order once Gravity supports this type of sort
+        value: "name",
+      },
     },
   }),
 }


### PR DESCRIPTION
# Change
Add support for new `PARTNER_ASC` sort for `PartnerShow` type.

At the moment Gravity doesn't support it yet but this is so Emission could start using it while we figure out how to support it on Gravity end. For now it will just do a `name` sort. 


https://artsyproduct.atlassian.net/browse/LD-380