### PR TITLE
Ensure non-stub sponsored shows follow normal displayable rules

### DIFF
--- a/src/schema/__tests__/city.test.ts
+++ b/src/schema/__tests__/city.test.ts
@@ -474,6 +474,7 @@ describe("City", () => {
       expect(gravityOptions).toMatchObject({
         id: ["abc", "123", "def", "456"],
         include_local_discovery: true,
+        displayable: true,
       })
     })
   })

--- a/src/schema/city/index.ts
+++ b/src/schema/city/index.ts
@@ -138,6 +138,7 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
               return loadData(args, showsWithHeadersLoader, {
                 id: citySponsoredContent.showIds,
                 include_local_discovery: true,
+                displayable: true,
                 sort: args.sort,
                 status: args.status,
               })


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/LD-392

Follow-up to https://github.com/artsy/metaphysics/pull/1563#discussion_r264039531

Sponsored content shows can be either stubs shows _or_ plain old partner-provided shows. If the latter, they should obey the normal constraints around `displayable`-ness, which is what this PR adds. h/t @ashkan18 for catching this.

#trivial