### PR TITLE
Add optional `city` argument to me.followsAndSaves.shows

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3773,7 +3773,10 @@ type FollowsAndSaves {
 
   # A list of the current user’s currently followed shows
   shows(
-    near: Near
+    # A string representing one of the supported cities in the City Guide, which
+    # are: new-york-ny-usa, los-angeles-ca-usa, london-united-kingdom,
+    # berlin-germany, paris-france, hong-kong-hong-kong
+    city: String
     after: String
     first: Int
     before: String

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3773,6 +3773,7 @@ type FollowsAndSaves {
 
   # A list of the current user’s currently followed shows
   shows(
+    near: Near
     after: String
     first: Int
     before: String

--- a/src/schema/me/followed_shows.ts
+++ b/src/schema/me/followed_shows.ts
@@ -42,7 +42,14 @@ const FollowedShows: GraphQLFieldConfig<void, ResolverContext> = {
       offset,
       total_count: true,
       near: !!options.near ? `${options.near.lat},${options.near.lng}` : null,
-      distance: !!options.near ? options.distance || 75 : null,
+      max_distance: !!options.near ? options.near.max_distance || 75 : null,
+    }
+
+    // this feels weirdly messy to me, but it works. TypeScript complains
+    // if I try to add these after initialization, rather than removing.
+    if (!gravityArgs.near) {
+      delete gravityArgs.near
+      delete gravityArgs.max_distance
     }
 
     return followedShowsLoader(gravityArgs).then(({ body, headers }) => {

--- a/src/schema/me/followed_shows.ts
+++ b/src/schema/me/followed_shows.ts
@@ -5,6 +5,7 @@ import { pageable, getPagingParameters } from "relay-cursor-paging"
 import { connectionDefinitions, connectionFromArraySlice } from "graphql-relay"
 import { GraphQLObjectType, GraphQLFieldConfig } from "graphql"
 import { ResolverContext } from "types/graphql"
+import Near from "../input_fields/near"
 
 const FollowedShowEdge = new GraphQLObjectType<any, ResolverContext>({
   name: "FollowedShowEdge",
@@ -26,7 +27,11 @@ export const FollowedShowConnection = connectionDefinitions({
 
 const FollowedShows: GraphQLFieldConfig<void, ResolverContext> = {
   type: FollowedShowConnection.connectionType,
-  args: pageable({}),
+  args: pageable({
+    near: {
+      type: Near,
+    },
+  }),
   description: "A list of the current user’s currently followed shows",
   resolve: (_root, options, { followedShowsLoader }) => {
     if (!followedShowsLoader) return null
@@ -36,6 +41,8 @@ const FollowedShows: GraphQLFieldConfig<void, ResolverContext> = {
       size,
       offset,
       total_count: true,
+      near: !!options.near ? `${options.near.lat},${options.near.lng}` : null,
+      distance: !!options.near ? options.distance || 75 : null,
     }
 
     return followedShowsLoader(gravityArgs).then(({ body, headers }) => {


### PR DESCRIPTION
This allows consumers of the `me.followsAndSaves.shows` query to use an optional `city` argument. This argument must be one of the pre-determined city slugs that are tracked in `metaphysics/src/schema/city/cityDataSortedByDisplayPreference.json`, and Metaphysics will return an error that enumerates valid city slugs if an invalid string is passed in.

## Data Creation
First, we've got to create some mock data. Let's create two shows, one in New York and one in Hong Kong, and then follow both with the User we're using in GraphiQL. As this PR, the following data already exists - feel free to lookup and reuse for your own testing, or feel free to make your own.

```ruby
user = User.find_by_email("mykola.bilokonsky@artsymail.com").first
location_nyc = PartnerLocation.create!(name: 'nyc_location', coordinates:  [-74, 40.5])
location_hk = PartnerLocation.create!(name: 'hk_location', coordinates: [114.1, 22.3])
  
partner = Partner.create!(given_name: 'ld_test')

nyc_show = PartnerShow.create!(name: 'nyc-based-show', partner: partner, start_at: 10.years.ago, end_at: 10.years.from_now, partner_location: location_nyc)
hk_show = PartnerShow.create!(name: 'hk-based-show', partner: partner, start_at: 10.years.ago, end_at: 10.years.from_now, partner_location: location_hk)

nyc_follow = FollowShow.create!(user: user, partner_show: nyc_show)
hk_follow = FollowShow.create!(user: user, partner_show: hk_show)
```

## GraphiQL Example
The following query tests four different cases - we first make sure that our user is indeed following both of the shows we care about. We then filter to NYC and confirm that we get the one correct show there. We then filter to Hong Kong and confirm that we get the correct one there. Finally, we attempt to filter to an invalid city string.
```graphql
query {
  me {
    followsAndSaves {
      all_shows: shows(first: 4) {
        edges {
          node {
            id            
          }
        }
      }
      new_york_shows: shows(first: 4, city: "new-york-ny-usa") {
        edges {
          node {
            id
          }
        }
      }
      hong_kong_shows: shows(first: 4, city: "hong-kong-hong-kong") {
        edges {
          node {
            id
          }
        }
      }
      invalid_query: shows(first: 4, city: "random string") {
        edges {
          node{
            id
          }
        }
      }
    }
  }
}
```

To which Metaphysics responds with:
```json
{
  "errors": [
    {
      "message": "City slug must be one of: new-york-ny-usa, los-angeles-ca-usa, london-united-kingdom, berlin-germany, paris-france, hong-kong-hong-kong",
      "locations": [
        {
          "line": 25,
          "column": 7
        }
      ]
    }
  ],
  "data": {
    "me": {
      "followsAndSaves": {
        "all_shows": {
          "edges": [
            {
              "node": {
                "id": "ld-test-nyc-based-show"
              }
            },
            {
              "node": {
                "id": "ld-test-hk-based-show"
              }
            }
          ]
        },
        "new_york_shows": {
          "edges": [
            {
              "node": {
                "id": "ld-test-nyc-based-show"
              }
            }
          ]
        },
        "hong_kong_shows": {
          "edges": [
            {
              "node": {
                "id": "ld-test-hk-based-show"
              }
            }
          ]
        },
        "invalid_query": null
      }
    }
  },
  "extensions": {
    "requests": {
      "gravity": {
        "requests": {
          "follow_shows?max_distance=25&near=22.3%2C114.2&offset=0&size=4&total_count=true": {
            "time": "0s 182.636ms",
            "cache": false,
            "length": "2 KB"
          },
          "follow_shows?max_distance=25&near=40.71%2C-74.01&offset=0&size=4&total_count=true": {
            "time": "0s 233.382ms",
            "cache": false,
            "length": "2 KB"
          },
          "follow_shows?offset=0&size=4&total_count=true": {
            "time": "0s 241.167ms",
            "cache": false,
            "length": "3 KB"
          }
        }
      }
    },
    "requestID": "aec265d0-44f6-11e9-889f-a9e2c4d6beff"
  }
}
```