### PR TITLE
Add filterArtworksLoaderWithCache

### DIFF
--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -30,6 +30,7 @@ export default opts => {
     fairLoader: gravityLoader(id => `fair/${id}`),
     fairsLoader: gravityLoader("fairs", {}, { headers: true }),
     filterArtworksLoader: gravityLoader("filter/artworks"),
+    filterArtworksLoaderWithCache: gravityLoader("filter/artworks", {}, { requestThrottleMs: 1000 * 60 * 60 }), // 1 hour
     geneArtistsLoader: gravityLoader(id => `gene/${id}/artists`),
     geneFamiliesLoader: gravityLoader("gene_families"),
     geneLoader: gravityLoader(id => `gene/${id}`),

--- a/src/lib/stitching/kaws/__tests__/stitching.test.ts
+++ b/src/lib/stitching/kaws/__tests__/stitching.test.ts
@@ -1,7 +1,7 @@
 import { runQuery } from "test/utils"
 
 describe("MarketingCollectionArtwork", () => {
-  it.skip("sets keyword_match_exact to true when keywords are set", async () => {
+  it("sets keyword_match_exact to true when keywords are set", async () => {
     const query = `
       {
         marketingCollection(slug: "kaws-snoopy") {
@@ -18,11 +18,12 @@ describe("MarketingCollectionArtwork", () => {
       }
     `
     const context = {
-      filterArtworksLoader: jest.fn(() => Promise.resolve()),
+      filterArtworksLoaderWithCache: jest.fn(() => Promise.resolve()),
     }
 
     await runQuery(query, context)
-    expect(context.filterArtworksLoader.mock.calls[0]).toMatchInlineSnapshot(`
+    expect(context.filterArtworksLoaderWithCache.mock.calls[0])
+      .toMatchInlineSnapshot(`
 Array [
   Object {
     "aggregations": Array [],
@@ -37,7 +38,7 @@ Array [
 `)
   })
 
-  it.skip("sets keyword_match_exact to false when keywords are not set", async () => {
+  it("sets keyword_match_exact to false when keywords are not set", async () => {
     const query = `
       {
         marketingCollection(slug: "alexander-calder-mobiles") {
@@ -55,11 +56,12 @@ Array [
     `
 
     const context = {
-      filterArtworksLoader: jest.fn(() => Promise.resolve()),
+      filterArtworksLoaderWithCache: jest.fn(() => Promise.resolve()),
     }
 
     await runQuery(query, context)
-    expect(context.filterArtworksLoader.mock.calls[0]).toMatchInlineSnapshot(`
+    expect(context.filterArtworksLoaderWithCache.mock.calls[0])
+      .toMatchInlineSnapshot(`
 Array [
   Object {
     "aggregations": Array [],

--- a/src/lib/stitching/kaws/stitching.ts
+++ b/src/lib/stitching/kaws/stitching.ts
@@ -117,6 +117,10 @@ export const kawsStitchingEnvironment = (
         resolve: (parent, _args, context, info) => {
           const query = parent.query
           const hasKeyword = Boolean(parent.query.keyword)
+          const contextWithCache = { ...context }
+          const filterArtworksLoader = context.filterArtworksLoaderWithCache
+          contextWithCache.filterArtworksLoader = filterArtworksLoader
+
           return info.mergeInfo.delegateToSchema({
             schema: localSchema,
             operation: "query",
@@ -126,7 +130,7 @@ export const kawsStitchingEnvironment = (
               keyword_match_exact: hasKeyword,
               ..._args,
             },
-            context,
+            context: contextWithCache,
             info,
             transforms: kawsSchema.transforms,
           })


### PR DESCRIPTION
Adds new dataloader `filterArtworksLoaderWithCache` for use on collections.  Current cache time is 1 hour.
