### PR TITLE
Adds max bounds per city to constrain LD map panning

### DIFF
--- a/src/schema/city/cityDataSortedByDisplayPreference.json
+++ b/src/schema/city/cityDataSortedByDisplayPreference.json
@@ -2,31 +2,55 @@
   {
     "slug": "new-york-ny-usa",
     "name": "New York",
-    "coordinates": { "lat": 40.71, "lng": -74.01 }
+    "coordinates": { "lat": 40.71, "lng": -74.01 },
+    "maxBounds": {
+      "sw": { "lat": 40.144, "lng": -74.754 },
+      "ne": { "lat": 41.272, "lng": -73.266 }
+    }
   },
   {
     "slug": "los-angeles-ca-usa",
     "name": "Los Angeles",
-    "coordinates": { "lat": 34.05, "lng": -118.24 }
+    "coordinates": { "lat": 34.05, "lng": -118.24 },
+    "maxBounds": {
+      "sw": { "lat": 33.453, "lng": -118.959 },
+      "ne": { "lat": 34.644, "lng": -117.521 }
+    }
   },
   {
     "slug": "london-united-kingdom",
     "name": "London",
-    "coordinates": { "lat": 51.51, "lng": -0.13 }
+    "coordinates": { "lat": 51.51, "lng": -0.13 },
+    "maxBounds": {
+      "sw": { "lat": 50.895, "lng": -1.118 },
+      "ne": { "lat": 52.127, "lng": 0.862 }
+    }
   },
   {
     "slug": "berlin-germany",
     "name": "Berlin",
-    "coordinates": { "lat": 52.52, "lng": 13.4 }
+    "coordinates": { "lat": 52.52, "lng": 13.4 },
+    "maxBounds": {
+      "sw": { "lat": 51.882, "lng": 12.352 },
+      "ne": { "lat": 53.159, "lng": 14.452 }
+    }
   },
   {
     "slug": "paris-france",
     "name": "Paris",
-    "coordinates": { "lat": 48.86, "lng": 2.35 }
+    "coordinates": { "lat": 48.86, "lng": 2.35 },
+    "maxBounds": {
+      "sw": { "lat": 48.339, "lng": 1.561 },
+      "ne": { "lat": 49.377, "lng": 3.139 }
+    }
   },
   {
     "slug": "hong-kong-hong-kong",
     "name": "Hong Kong",
-    "coordinates": { "lat": 22.3, "lng": 114.2 }
+    "coordinates": { "lat": 22.3, "lng": 114.2 },
+    "maxBounds": {
+      "sw": { "lat": 21.66, "lng": 113.509 },
+      "ne": { "lat": 22.938, "lng": 114.891 }
+    }
   }
 ]


### PR DESCRIPTION
Now that (a) we've consolidated LD geo truth in this file, and (b) we might be ready to tackle map viewport constraints, I'm adding these max bounds to our city file.

These results come from my Observable notebook. Here's the NYC example:

- Purple represents our LD search radius of 25km
- Red represents a buffer of 50km beyond that
- Green represents the bounding box that encompasses the buffer area

In my experience we'd want a generous buffer zone around the area of interest so as not to make the map feel overly confining. But this is all tune-able, of course.

![Screen Shot 2019-03-12 at 11 21 53 PM](https://user-images.githubusercontent.com/140521/54251442-a8cebd00-451d-11e9-83ef-910e7a4d6f08.png)

As for how to specify the actual bounding box rect 🙄 of course there are like seventeen ways to do this.

But according to this ["Restrict map panning to an area"](https://docs.mapbox.com/ios/maps/examples/constraining-gestures/) API doc, the native iOS lib wants the bounds specified as a SW and NE point, with each point specified as a lat,lng object, so that's why this data is shaped the way it is in this version.