### PR TITLE
add Nginx to metaphysics staging and internal cluster service

### DIFF
--- a/hokusai/config.yml
+++ b/hokusai/config.yml
@@ -4,3 +4,4 @@ aws-ecr-region: us-east-1
 project-name: metaphysics
 git-remote: git@github.com:artsy/metaphysics.git
 post-deploy: .circleci/deploy_event.sh
+hokusai-required-version: ">=0.5.2"

--- a/hokusai/config.yml
+++ b/hokusai/config.yml
@@ -4,4 +4,4 @@ aws-ecr-region: us-east-1
 project-name: metaphysics
 git-remote: git@github.com:artsy/metaphysics.git
 post-deploy: .circleci/deploy_event.sh
-hokusai-required-version: ">=0.5.2"
+hokusai-required-version: ">=0.5.3"

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -51,6 +51,29 @@ spec:
               value: https
           initialDelaySeconds: 5
           periodSeconds: 5
+      - name: metaphysics-nginx
+        image: artsy/docker-nginx:1.14.2
+        ports:
+          - containerPort: 80
+          - containerPort: 443
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/usr/sbin/nginx", "-s", "quit"]
+        env:
+          - name: 'NGINX_DEFAULT_CONF'
+            valueFrom:
+              configMapKeyRef:
+                name: nginx-config
+                key: metaphysics
+        volumeMounts:
+          - name: nginx-secrets
+            mountPath: /etc/nginx/ssl
+      volumes:
+        - name: nginx-secrets
+          secret:
+            secretName: nginx-secrets
+            defaultMode: 420
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:
@@ -114,3 +137,29 @@ spec:
     component: web
   sessionAffinity: None
   type: LoadBalancer
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: metaphysics
+    layer: application
+    component: web
+  name: metaphysics-web-internal
+  namespace: default
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    name: http
+    targetPort: 80
+  - port: 443
+    protocol: TCP
+    name: https
+    targetPort: 443
+  selector:
+    app: metaphysics
+    layer: application
+    component: web
+  type: ClusterIP

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -56,6 +56,12 @@ spec:
         ports:
           - containerPort: 80
           - containerPort: 443
+        readinessProbe:
+          tcpSocket:
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 15
+          timeoutSeconds: 10
         lifecycle:
           preStop:
             exec:


### PR DESCRIPTION
Set up Nginx as a sidecar container in Metaphysics staging, serving both http and https with artsy.net wildcard certificates.  Also create an internal cluster service for Metaphysics mapping ports 80 and 443 to the Nginx container.  This will allow us to resolve, for example, `metaphysics-staging.artsy.net` to `metaphysics-web-internal.default.svc.cluster.local` by means of Kubernetes' internal DNS server, and transparently route all traffic originating from within the cluster through the cluster-internal service (fixing the "hairpin" traffic pattern we now have, where `metaphysics-staging.artsy.net` resolves to the CNAME of an external ELB, and traffic is routed out of Kubernetes' internal network, to the external ELB then back into the Kubernetes' internal network.

Also running a sidecar container requires Hokusai version >=0.5.2 so pin this in hokusai config.  (Running a Hokusai deployment at a version < 0.5.2 will overwrite the Nginx container with a metaphysics container and break internal routing, though if this happens the Nginx readinessProbe will fail and block the deployment).

DNS config changes in https://github.com/artsy/substance/pull/115 - for now just redirecting `metaphysics-staging-test.artsy.net` to `metaphysics-web-internal.default.svc.cluster.local`
