### PR TITLE
Support querying featured sponsored shows explicitly

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -2480,6 +2480,7 @@ type City {
 type CitySponsoredContent {
   introText: String
   artGuideUrl: String
+  featuredShows: [Show]
   shows(
     sort: PartnerShowSorts
     status: EventStatus

--- a/src/lib/sponsoredContent/data.json
+++ b/src/lib/sponsoredContent/data.json
@@ -3,6 +3,10 @@
     "new-york-ny-usa": {
       "introText": "The BMW Art Guide by Independent Collectors is your go-to-guide to discover private collections of modern and contemporary art which are accessible to the public. Please see below for collections in New York.",
       "artGuideUrl": "https://www.bmw-arts-design.com/bmw_art_guide",
+      "featuredShowIds": [
+        "5c8857f2702b1d000691f4f7",
+        "5c8857f4702b1d000691f501"
+      ],
       "showIds": [
         "5c8857f2702b1d000691f4f7",
         "5c8857f4702b1d000691f501",
@@ -13,6 +17,10 @@
     "london-united-kingdom": {
       "introText": "The BMW Art Guide by Independent Collectors is your go-to-guide to discover private collections of modern and contemporary art which are accessible to the public. Please see below for collections in London.",
       "artGuideUrl": "https://www.bmw-arts-design.com/bmw_art_guide",
+      "featuredShowIds": [
+        "5c8857f3702b1d000691f4f9",
+        "5c8857f6702b1d000691f50e"
+      ],
       "showIds": [
         "5c8857f3702b1d000691f4f9",
         "5c8857f6702b1d000691f50e",
@@ -25,6 +33,10 @@
     "los-angeles-ca-usa": {
       "introText": "The BMW Art Guide by Independent Collectors is your go-to-guide to discover private collections of modern and contemporary art which are accessible to the public. Please see below for collections in Los Angeles.",
       "artGuideUrl": "https://www.bmw-arts-design.com/bmw_art_guide",
+      "featuredShowIds": [
+        "5c8857f4702b1d000691f502",
+        "5c8857f5702b1d000691f507"
+      ],
       "showIds": [
         "5c8857f4702b1d000691f502",
         "5c8857f5702b1d000691f507",
@@ -39,6 +51,10 @@
     "berlin-germany": {
       "introText": "The BMW Art Guide by Independent Collectors is your go-to-guide to discover private collections of modern and contemporary art which are accessible to the public. Please see below for collections in Berlin.",
       "artGuideUrl": "https://www.bmw-arts-design.com/bmw_art_guide",
+      "featuredShowIds": [
+        "5c8857f1702b1d000691f4f5",
+        "5c8857f3702b1d000691f4fb"
+      ],
       "showIds": [
         "5c8857f1702b1d000691f4f5",
         "5c8857f3702b1d000691f4fb",
@@ -54,6 +70,10 @@
     "hong-kong-hong-kong": {
       "introText": "The BMW Art Guide by Independent Collectors is your go-to-guide to discover private collections of modern and contemporary art which are accessible to the public. Please see below for collections in Hong Kong.",
       "artGuideUrl": "https://www.bmw-arts-design.com/bmw_art_guide",
+      "featuredShowIds": [
+        "5c8857f4702b1d000691f500",
+        "5c8857f6702b1d000691f50d"
+      ],
       "showIds": ["5c8857f4702b1d000691f500", "5c8857f6702b1d000691f50d"]
     }
   },

--- a/src/lib/sponsoredContent/index.ts
+++ b/src/lib/sponsoredContent/index.ts
@@ -9,6 +9,9 @@ interface CitySponsoredContent {
 
   /** Manually curated list of sponsored shows */
   showIds: string
+
+  /** Within the curated list, shows to feature more prominently */
+  featuredShowIds: string
 }
 
 interface FairSponsoredContent {

--- a/src/schema/__tests__/city.test.ts
+++ b/src/schema/__tests__/city.test.ts
@@ -16,6 +16,7 @@ const mockSponsoredContent = {
     "sacramende-ca-usa": {
       introText: "Lorem ipsum dolot sit amet",
       artGuideUrl: "https://www.example.com/",
+      featuredShowIds: ["456", "def"],
       showIds: ["abc", "123", "def", "456"],
     },
   },
@@ -498,6 +499,39 @@ describe("City", () => {
 
       expect(gravityOptions).toMatchObject({
         id: ["abc", "123", "def", "456"],
+        include_local_discovery: true,
+        displayable: true,
+      })
+    })
+
+    it("includes featured shows", async () => {
+      const mockShows = [{ id: "featured-show" }]
+      const mockShowsLoader = jest.fn(() => Promise.resolve(mockShows))
+      const context = {
+        showsLoader: mockShowsLoader,
+      }
+
+      const query = gql`
+        {
+          city(slug: "sacramende-ca-usa") {
+            sponsoredContent {
+              featuredShows {
+                id
+              }
+            }
+          }
+        }
+      `
+
+      const result = await runQuery(query, context)
+      const gravityOptions = context.showsLoader.mock.calls[0][0]
+
+      expect(result!.city.sponsoredContent).toEqual({
+        featuredShows: [{ id: "featured-show" }],
+      })
+
+      expect(gravityOptions).toMatchObject({
+        id: ["456", "def"],
         include_local_discovery: true,
         displayable: true,
       })

--- a/src/schema/city/index.ts
+++ b/src/schema/city/index.ts
@@ -1,14 +1,15 @@
 import {
   GraphQLBoolean,
   GraphQLEnumType,
-  GraphQLObjectType,
-  GraphQLString,
   GraphQLFieldConfig,
   GraphQLInt,
+  GraphQLList,
+  GraphQLObjectType,
+  GraphQLString,
 } from "graphql"
 
 import { LatLngType } from "../location"
-import { showConnection } from "schema/show"
+import { showConnection, ShowType } from "schema/show"
 import PartnerShowSorts from "schema/sorts/partner_show_sorts"
 import { FairType } from "schema/fair"
 import FairSorts from "schema/sorts/fair_sorts"
@@ -123,6 +124,16 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
           },
           artGuideUrl: {
             type: GraphQLString,
+          },
+          featuredShows: {
+            type: new GraphQLList(ShowType),
+            resolve: (citySponsoredContent, _args, { showsLoader }) => {
+              return showsLoader({
+                id: citySponsoredContent.featuredShowIds,
+                include_local_discovery: true,
+                displayable: true,
+              })
+            },
           },
           shows: {
             type: showConnection,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/LD-454

This fixes an issue where sponsored content shows are returned from Grav to MP to Emission in unspecified order, which prevents us from relying on the order of results to pull out the first two shows for featuring in illustrated bricks.

Instead we can add a separate field guaranteed to have the correct shows.

```graphql
{
  city(slug: "new-york-ny-usa") {
    slug
    name
    sponsoredContent {
      featuredShows {
        id
      }
    }
  }
}
```