### PR TITLE
Add new running_and_upcoming status

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3256,6 +3256,9 @@ enum EventStatus {
 
   # End date is in near future
   CLOSING_SOON
+
+  # Special filtering option which is used to show running and upcoming shows
+  RUNNING_AND_UPCOMING
 }
 
 type ExternalPartner {

--- a/src/schema/input_fields/event_status.ts
+++ b/src/schema/input_fields/event_status.ts
@@ -40,6 +40,11 @@ const EventStatus = {
         value: "closing_soon",
         description: "End date is in near future",
       },
+      RUNNING_AND_UPCOMING: {
+        value: "current",
+        description:
+          "Special filtering option which is used to show running and upcoming shows",
+      },
     },
   }),
 }


### PR DESCRIPTION
This is to unblock Emission, for now mapping it to `current` till we figure out how to support this in Gravity.