### PR TITLE
@dblandin => [Feedback] Add mutation to send feedback

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3488,6 +3488,17 @@ type FeaturedLinkItem {
   title: String
 }
 
+type Feedback {
+  # A globally unique ID.
+  __id: ID!
+
+  # A type-specific ID.
+  id: String!
+
+  # Feedback message
+  message: String!
+}
+
 type FilterArtworks implements Node {
   # The ID of the object.
   __id: ID!
@@ -5498,6 +5509,9 @@ type Mutation {
   sendConversationMessage(
     input: SendConversationMessageMutationInput!
   ): SendConversationMessageMutationPayload
+
+  # Send a feedback message
+  sendFeedback(input: SendFeedbackMutationInput!): SendFeedbackMutationPayload
 
   # Save (or remove) an artwork to (from) a users default collection.
   saveArtwork(input: SaveArtworkInput!): SaveArtworkPayload
@@ -8183,6 +8197,38 @@ type SendConversationMessageMutationPayload {
   messageEdge: MessageEdge
   clientMutationId: String
 }
+
+type SendFeedbackMutationFailure {
+  mutationError: GravityMutationError
+}
+
+input SendFeedbackMutationInput {
+  # Message to be sent.
+  message: String!
+
+  # Email to associate with message (only used if logged out).
+  email: String
+
+  # Name to associate with message (only used if logged out).
+  name: String
+
+  # URL of page where feedback originated.
+  url: String
+  clientMutationId: String
+}
+
+type SendFeedbackMutationPayload {
+  feedbackOrError: SendFeedbackMutationType
+  clientMutationId: String
+}
+
+type SendFeedbackMutationSuccess {
+  feedback: Feedback
+}
+
+union SendFeedbackMutationType =
+    SendFeedbackMutationSuccess
+  | SendFeedbackMutationFailure
 
 type Services {
   convection: Convection!

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -88,6 +88,7 @@ export default (accessToken, userID, opts) => {
       }
     ),
     savedArtworksLoader: gravityLoader("collection/saved-artwork/artworks", { user_id: userID, private: true }),
+    sendFeedbackLoader: gravityLoader("feedback", {}, { method: "POST" }),
     suggestedArtistsLoader: gravityLoader("me/suggested/artists", {}, { headers: true }),
     suggestedSimilarArtistsLoader: gravityLoader(`user/${userID}/suggested/similar/artists`, {}, { headers: true }),
     unfollowArtistLoader: gravityLoader(id => `me/follow/artist/${id}`, {}, { method: "DELETE" }),

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -70,6 +70,7 @@ export default opts => {
     saleLoader: batchSaleLoader,
     salesLoader: batchSalesLoader,
     searchLoader: searchLoader(gravityLoader),
+    sendFeedbackLoader: gravityLoader("feedback", {}, { method: "POST" }),
     setItemsLoader: gravityLoader(id => `set/${id}/items`),
     setLoader: gravityLoader(id => `set/${id}`),
     setsLoader: gravityLoader("sets"),

--- a/src/schema/__tests__/sendFeedbackMutation.test.ts
+++ b/src/schema/__tests__/sendFeedbackMutation.test.ts
@@ -1,0 +1,66 @@
+/* eslint-disable promise/always-return */
+import { runAuthenticatedQuery } from "test/utils"
+
+describe("Send Feedback", () => {
+  const feedback = {
+    id: "id",
+    message: "Catty message",
+  }
+
+  const query = `
+  mutation {
+    sendFeedback(input: {message: "Catty message"}) {
+      feedbackOrError {
+        ... on SendFeedbackMutationSuccess {
+          feedback {
+            message
+          }
+        }
+        ... on SendFeedbackMutationFailure {
+          mutationError {
+            type
+            message
+            detail
+          }
+        }
+      }
+    }
+  }
+  `
+
+  const context = {
+    sendFeedbackLoader: () => Promise.resolve(feedback),
+  }
+
+  it("returns a formatted error message", async () => {
+    const errorRootValue = {
+      sendFeedbackLoader: () =>
+        Promise.reject(
+          new Error(
+            `https://stagingapi.artsy.net/api/v1/feedback - {"error":"Message Cant Not Be Blank"}`
+          )
+        ),
+    }
+    const data = await runAuthenticatedQuery(query, errorRootValue)
+    expect(data).toEqual({
+      sendFeedback: {
+        feedbackOrError: {
+          mutationError: {
+            detail: null,
+            message: "Message Cant Not Be Blank",
+            type: "error",
+          },
+        },
+      },
+    })
+  })
+
+  it("sends a feedback message", async () => {
+    const data = await runAuthenticatedQuery(query, context)
+    expect(data).toEqual({
+      sendFeedback: {
+        feedbackOrError: { feedback: { message: "Catty message" } },
+      },
+    })
+  })
+})

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -86,6 +86,7 @@ import createBidderMutation from "./me/create_bidder_mutation"
 import createCreditCardMutation from "./me/create_credit_card_mutation"
 import { deleteCreditCardMutation } from "./me/delete_credit_card_mutation"
 import { BidderPositionMutation } from "./me/bidder_position_mutation"
+import { sendFeedbackMutation } from "./sendFeedbackMutation"
 
 import CausalityJWT from "./causality_jwt"
 import ObjectIdentification from "./object_identification"
@@ -232,6 +233,7 @@ export default new GraphQLSchema({
       updateMyUserProfile: UpdateMyUserProfileMutation,
       updateConversation: UpdateConversationMutation,
       sendConversationMessage: SendConversationMessageMutation,
+      sendFeedback: sendFeedbackMutation,
       saveArtwork: SaveArtworkMutation,
       endSale: endSaleMutation,
       requestCredentialsForAssetUpload: CreateAssetRequestLoader,

--- a/src/schema/sendFeedbackMutation.ts
+++ b/src/schema/sendFeedbackMutation.ts
@@ -1,0 +1,110 @@
+import {
+  GraphQLNonNull,
+  GraphQLString,
+  GraphQLInputObjectType,
+  GraphQLObjectType,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import {
+  GravityMutationErrorType,
+  formatGravityError,
+} from "lib/gravityErrorHandler"
+import { IDFields } from "./object_identification"
+
+const FeedbackType = new GraphQLObjectType<any, ResolverContext>({
+  name: "Feedback",
+  fields: () => ({
+    ...IDFields,
+    message: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "Feedback message",
+    },
+  }),
+})
+
+const SendFeedbackMutationSuccessType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "SendFeedbackMutationSuccess",
+  isTypeOf: data => data.id,
+  fields: () => ({
+    feedback: {
+      type: FeedbackType,
+      resolve: feedback => feedback,
+    },
+  }),
+})
+
+const SendFeedbackMutationFailureType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "SendFeedbackMutationFailure",
+  isTypeOf: data => {
+    return data._type === "GravityMutationError"
+  },
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: err => err,
+    },
+  }),
+})
+
+const SendFeedbackMutationType = new GraphQLUnionType({
+  name: "SendFeedbackMutationType",
+  types: [SendFeedbackMutationSuccessType, SendFeedbackMutationFailureType],
+})
+
+const SendFeedbackMutationInputType = new GraphQLInputObjectType({
+  name: "SendFeedbackMutationInput",
+  fields: {
+    message: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "Message to be sent.",
+    },
+    email: {
+      type: GraphQLString,
+      description: "Email to associate with message (only used if logged out).",
+    },
+    name: {
+      type: GraphQLString,
+      description: "Name to associate with message (only used if logged out).",
+    },
+    url: {
+      type: GraphQLString,
+      description: "URL of page where feedback originated.",
+    },
+  },
+})
+
+export const sendFeedbackMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "SendFeedbackMutation",
+  description: "Send a feedback message",
+  inputFields: SendFeedbackMutationInputType.getFields(),
+  outputFields: {
+    feedbackOrError: {
+      type: SendFeedbackMutationType,
+      resolve: result => result,
+    },
+  },
+  mutateAndGetPayload: (params, { sendFeedbackLoader }) => {
+    return sendFeedbackLoader(params)
+      .then(result => result)
+      .catch(error => {
+        const formattedErr = formatGravityError(error)
+        if (formattedErr) {
+          return { ...formattedErr, _type: "GravityMutationError" }
+        } else {
+          throw new Error(error)
+        }
+      })
+  },
+})


### PR DESCRIPTION
This adds a mutation that lets us send feedback (currently needed for search results).

It uses the existing `/api/v1/feedback` endpoint so that it's hooked into the same place our current 'Send Feedback' functionality lives. It is emailed to support@, and also an event is propagated on event queues, so there's other things happening: posts to Slack, semantic analysis on whether the message is positive/negative/neutral, etc.

<img width="1276" alt="Screen Shot 2019-03-14 at 1 33 24 PM" src="https://user-images.githubusercontent.com/1457859/54378466-c7d46880-465d-11e9-97e5-a3836193ee2d.png">
