### PR TITLE
Move Kaws caching to stitching file

### DIFF
--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -30,7 +30,6 @@ export default opts => {
     fairLoader: gravityLoader(id => `fair/${id}`),
     fairsLoader: gravityLoader("fairs", {}, { headers: true }),
     filterArtworksLoader: gravityLoader("filter/artworks"),
-    filterArtworksLoaderWithCache: gravityLoader("filter/artworks", {}, { requestThrottleMs: 1000 * 60 * 60 }), // 1 hour
     geneArtistsLoader: gravityLoader(id => `gene/${id}/artists`),
     geneFamiliesLoader: gravityLoader("gene_families"),
     geneLoader: gravityLoader(id => `gene/${id}`),

--- a/src/lib/stitching/kaws/__tests__/stitching.test.ts
+++ b/src/lib/stitching/kaws/__tests__/stitching.test.ts
@@ -18,12 +18,11 @@ describe("MarketingCollectionArtwork", () => {
       }
     `
     const context = {
-      filterArtworksLoaderWithCache: jest.fn(() => Promise.resolve()),
+      filterArtworksLoader: jest.fn(() => Promise.resolve()),
     }
 
     await runQuery(query, context)
-    expect(context.filterArtworksLoaderWithCache.mock.calls[0])
-      .toMatchInlineSnapshot(`
+    expect(context.filterArtworksLoader.mock.calls[0]).toMatchInlineSnapshot(`
 Array [
   Object {
     "aggregations": Array [],
@@ -33,6 +32,9 @@ Array [
     "gene_ids": Array [],
     "keyword": "Snoopy, Woodstock, Man’s Best Friend, No One's Home, Isolation Tower, Stay Steady, The Things that Comfort",
     "keyword_match_exact": true,
+  },
+  Object {
+    "requestThrottleMs": 3600000,
   },
 ]
 `)
@@ -56,12 +58,11 @@ Array [
     `
 
     const context = {
-      filterArtworksLoaderWithCache: jest.fn(() => Promise.resolve()),
+      filterArtworksLoader: jest.fn(() => Promise.resolve()),
     }
 
     await runQuery(query, context)
-    expect(context.filterArtworksLoaderWithCache.mock.calls[0])
-      .toMatchInlineSnapshot(`
+    expect(context.filterArtworksLoader.mock.calls[0]).toMatchInlineSnapshot(`
 Array [
   Object {
     "aggregations": Array [],
@@ -72,6 +73,9 @@ Array [
       "kinetic-sculpture",
     ],
     "keyword_match_exact": false,
+  },
+  Object {
+    "requestThrottleMs": 3600000,
   },
 ]
 `)

--- a/src/lib/stitching/kaws/stitching.ts
+++ b/src/lib/stitching/kaws/stitching.ts
@@ -117,9 +117,14 @@ export const kawsStitchingEnvironment = (
         resolve: (parent, _args, context, info) => {
           const query = parent.query
           const hasKeyword = Boolean(parent.query.keyword)
-          const contextWithCache = { ...context }
-          const filterArtworksLoader = context.filterArtworksLoaderWithCache
-          contextWithCache.filterArtworksLoader = filterArtworksLoader
+          const contextWithCache = {
+            ...context,
+            filterArtworksLoader: loaderParams =>
+              context.filterArtworksLoader(
+                { ...loaderParams },
+                { requestThrottleMs: 1000 * 60 * 60 } // 1 hour
+              ),
+          }
 
           return info.mergeInfo.delegateToSchema({
             schema: localSchema,


### PR DESCRIPTION
Follow up to https://github.com/artsy/metaphysics/pull/1575, removes dataloader `filterArtworksLoaderWithCache` in favor of explicitly adding caching to the Kaws stitching file. 