### PR TITLE
LD-304 - Updates date exhibitionPeriod format

### DIFF
--- a/src/lib/__tests__/date.test.ts
+++ b/src/lib/__tests__/date.test.ts
@@ -28,12 +28,12 @@ describe("date", () => {
       expect(period).toBe("Jan 1 – 19, 2011")
     })
 
-    it("does not include the year of the end date if it’s in the current year", () => {
+    it("If one date's year is different show both years", () => {
       const period = exhibitionPeriod(
         moment("2011-01-01"),
         moment().format("YYYY-04-19")
       )
-      expect(period).toBe("Jan 1, 2011 – Apr 19")
+      expect(period).toBe("Jan 1, 2011 – Apr 19, 2019")
     })
 
     it("does not include a year at all if both start and end date are in the current year", () => {

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -3,7 +3,7 @@ import moment from "moment"
 export function exhibitionPeriod(startAt, endAt) {
   const startMoment = moment(startAt)
   const endMoment = moment(endAt)
-  const thisMoment = moment()
+  const thisMoment = moment.utc(Date.now())
   let startFormat = "MMM D"
   let endFormat = "D"
   let singleDateFormat = "MMM D"

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -3,25 +3,22 @@ import moment from "moment"
 export function exhibitionPeriod(startAt, endAt) {
   const startMoment = moment(startAt)
   const endMoment = moment(endAt)
-  const thisMoment = moment.utc(Date.now())
+  const thisMoment = moment()
   let startFormat = "MMM D"
   let endFormat = "D"
   let singleDateFormat = "MMM D"
 
   if (startMoment.year() !== endMoment.year()) {
+    // Adds years if the dates are not the same year
     startFormat = startFormat.concat(", YYYY")
+    endFormat = endFormat.concat(", YYYY")
+  } else if (endMoment.year() !== thisMoment.year()) {
+    // Otherwise if they're the same year, but not this year, add year to endFormat
+    endFormat = endFormat.concat(", YYYY")
   }
 
-  if (endMoment.year() !== thisMoment.year()) {
-    endFormat = endFormat.concat(", YYYY")
-    singleDateFormat = singleDateFormat.concat(", YYYY")
-  }
-  if (
-    !(
-      startMoment.year() === endMoment.year() &&
-      startMoment.month() === endMoment.month()
-    )
-  ) {
+  if (startMoment.month() !== endMoment.month()) {
+    // Show the end month if the month is different
     endFormat = "MMM ".concat(endFormat)
   }
 
@@ -30,8 +27,12 @@ export function exhibitionPeriod(startAt, endAt) {
     startMoment.year() === endMoment.year()
   ) {
     // Duration is the same day
+    if (endMoment.year() !== thisMoment.year()) {
+      singleDateFormat = singleDateFormat.concat(", YYYY")
+    }
     return `${endMoment.format(singleDateFormat)}`
   } else {
+    // Show date range if not the same day
     return `${startMoment.format(startFormat)} – ${endMoment.format(endFormat)}`
   }
 }

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -3,7 +3,7 @@ import moment from "moment"
 export function exhibitionPeriod(startAt, endAt) {
   const startMoment = moment(startAt)
   const endMoment = moment(endAt)
-  const thisMoment = moment.utc(Date.now())
+  const thisMoment = moment()
   let startFormat = "MMM D"
   let endFormat = "D"
   let singleDateFormat = "MMM D"


### PR DESCRIPTION
- https://artsyproduct.atlassian.net/browse/LD-304
- Previously the date range didn't include the end year if the end year was the same as the present year. E.g. It would display `Apr 10, 2016 - Feb 16` instead of `Apr 10, 2016 - Feb 16, 2019`