### PR TITLE
Include authenticated & unauthenticated loaders in context

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,7 @@ async function startApp() {
         requestIDs,
         userAgent,
       })
-      const unauhtenticatedLoaders = createLoaders(accessToken, userID, {
+      const unauhtenticatedLoaders = createLoaders(null, null, {
         requestIDs,
         userAgent,
       })

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,7 @@ async function startApp() {
         requestIDs,
         userAgent,
       })
-      const unauhtenticatedLoaders = createLoaders(null, null, {
+      const unauthenticatedLoaders = createLoaders(null, null, {
         requestIDs,
         userAgent,
       })
@@ -144,7 +144,7 @@ async function startApp() {
         defaultTimezone,
         ...loaders,
         authenticatedLoaders: loaders,
-        unauhtenticatedLoaders,
+        unauthenticatedLoaders,
         // For stitching purposes
         exchangeSchema,
         requestIDs,

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,12 +133,18 @@ async function startApp() {
         requestIDs,
         userAgent,
       })
+      const unauhtenticatedLoaders = createLoaders(accessToken, userID, {
+        requestIDs,
+        userAgent,
+      })
 
       const context: ResolverContext = {
         accessToken,
         userID,
         defaultTimezone,
         ...loaders,
+        authenticatedLoaders: loaders,
+        unauhtenticatedLoaders,
         // For stitching purposes
         exchangeSchema,
         requestIDs,

--- a/src/lib/stitching/kaws/__tests__/stitching.test.ts
+++ b/src/lib/stitching/kaws/__tests__/stitching.test.ts
@@ -18,13 +18,13 @@ describe("MarketingCollectionArtwork", () => {
       }
     `
     const context = {
-      unauhtenticatedLoaders: {
+      unauthenticatedLoaders: {
         filterArtworksLoader: jest.fn(() => Promise.resolve()),
       },
     }
 
     await runQuery(query, context)
-    expect(context.unauhtenticatedLoaders.filterArtworksLoader.mock.calls[0])
+    expect(context.unauthenticatedLoaders.filterArtworksLoader.mock.calls[0])
       .toMatchInlineSnapshot(`
 Array [
   Object {
@@ -61,13 +61,13 @@ Array [
     `
 
     const context = {
-      unauhtenticatedLoaders: {
+      unauthenticatedLoaders: {
         filterArtworksLoader: jest.fn(() => Promise.resolve()),
       },
     }
 
     await runQuery(query, context)
-    expect(context.unauhtenticatedLoaders.filterArtworksLoader.mock.calls[0])
+    expect(context.unauthenticatedLoaders.filterArtworksLoader.mock.calls[0])
       .toMatchInlineSnapshot(`
 Array [
   Object {

--- a/src/lib/stitching/kaws/__tests__/stitching.test.ts
+++ b/src/lib/stitching/kaws/__tests__/stitching.test.ts
@@ -18,11 +18,14 @@ describe("MarketingCollectionArtwork", () => {
       }
     `
     const context = {
-      filterArtworksLoader: jest.fn(() => Promise.resolve()),
+      unauhtenticatedLoaders: {
+        filterArtworksLoader: jest.fn(() => Promise.resolve()),
+      },
     }
 
     await runQuery(query, context)
-    expect(context.filterArtworksLoader.mock.calls[0]).toMatchInlineSnapshot(`
+    expect(context.unauhtenticatedLoaders.filterArtworksLoader.mock.calls[0])
+      .toMatchInlineSnapshot(`
 Array [
   Object {
     "aggregations": Array [],
@@ -58,11 +61,14 @@ Array [
     `
 
     const context = {
-      filterArtworksLoader: jest.fn(() => Promise.resolve()),
+      unauhtenticatedLoaders: {
+        filterArtworksLoader: jest.fn(() => Promise.resolve()),
+      },
     }
 
     await runQuery(query, context)
-    expect(context.filterArtworksLoader.mock.calls[0]).toMatchInlineSnapshot(`
+    expect(context.unauhtenticatedLoaders.filterArtworksLoader.mock.calls[0])
+      .toMatchInlineSnapshot(`
 Array [
   Object {
     "aggregations": Array [],

--- a/src/lib/stitching/kaws/stitching.ts
+++ b/src/lib/stitching/kaws/stitching.ts
@@ -120,7 +120,7 @@ export const kawsStitchingEnvironment = (
           const contextWithCache = {
             ...context,
             filterArtworksLoader: loaderParams =>
-              context.unauhtenticatedLoaders.filterArtworksLoader(
+              context.unauthenticatedLoaders.filterArtworksLoader(
                 { ...loaderParams },
                 { requestThrottleMs: 1000 * 60 * 60 } // 1 hour
               ),

--- a/src/lib/stitching/kaws/stitching.ts
+++ b/src/lib/stitching/kaws/stitching.ts
@@ -120,7 +120,7 @@ export const kawsStitchingEnvironment = (
           const contextWithCache = {
             ...context,
             filterArtworksLoader: loaderParams =>
-              context.filterArtworksLoader(
+              context.unauhtenticatedLoaders.filterArtworksLoader(
                 { ...loaderParams },
                 { requestThrottleMs: 1000 * 60 * 60 } // 1 hour
               ),

--- a/src/types/graphql.d.ts
+++ b/src/types/graphql.d.ts
@@ -12,6 +12,10 @@ export interface ResolverContextValues {
   /** The schema used by the internal exchange graphql engine */
   exchangeSchema: GraphQLSchema
 
+  /** To bypass logic sending loader based on accessToken */
+  unauhtenticatedLoaders: createLoaders
+  authenticatedLoaders: createLoaders
+
   /**
    * TODO: Why is this shaped like this, instead of a single ID?
    */

--- a/src/types/graphql.d.ts
+++ b/src/types/graphql.d.ts
@@ -13,7 +13,7 @@ export interface ResolverContextValues {
   exchangeSchema: GraphQLSchema
 
   /** To bypass logic sending loader based on accessToken */
-  unauhtenticatedLoaders: createLoaders
+  unauthenticatedLoaders: createLoaders
   authenticatedLoaders: createLoaders
 
   /**


### PR DESCRIPTION
Explicitly defines authenticated & unauthenticated loaders in context for instances where we might want to use one specifically, rather than allowing `/lib/loaders` to toggle based on presence of an `X-ACCESS-TOKEN`.  

Kaws's stitching for Gravity `filter_artworks` has been updated to explicitly use an `unauthenticatedLoader`, so we can take advantage custom caching times (an authenticated loader bypasses the cache entirely). 

Related slack convo:
https://artsy.slack.com/archives/C1HH3KNJG/p1552419551049700

Related PR:
https://github.com/artsy/metaphysics/pull/1589#discussion_r265758944