### PR TITLE
@dblandin => [SearchResults] Fix `hasNextPage` calculation for short result sets

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -8110,9 +8110,11 @@ enum SearchEntity {
   COLLECTION
   FAIR
   FEATURE
+  GALLERY
   GENE
   PROFILE
   SALE
+  SHOW
   TAG
 }
 

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -84,4 +84,15 @@ export default async () => {
       }
     })
   })
+
+  // No `debugger` statements.
+  danger.git.modified_files
+    .concat(danger.git.created_files)
+    .filter(f => f.endsWith(".js") || f.endsWith(".ts"))
+    .forEach(file => {
+      const content = readFileSync(file, "utf8")
+      if (content.includes("debugger")) {
+        fail(`Found a debugger statement left in by accident.`, file)
+      }
+    })
 }

--- a/src/lib/loaders/searchLoader.ts
+++ b/src/lib/loaders/searchLoader.ts
@@ -7,7 +7,10 @@ export const searchLoader = gravityLoader => {
       const queryParams = {
         term: query,
         "indexes[]":
-          entities || SearchEntity.getValues().map(index => index.value),
+          entities ||
+          SearchEntity.getValues()
+            .filter(index => index.value !== "gallery")
+            .map(index => index.value),
         ...rest,
       }
 

--- a/src/schema/__tests__/search.test.ts
+++ b/src/schema/__tests__/search.test.ts
@@ -85,7 +85,7 @@ describe("Search", () => {
       searchLoader: () =>
         Promise.resolve({
           body: searchResults,
-          headers: { "x-total-count": 100 },
+          headers: { "x-total-count": 40 },
         }),
       artistLoader: () => Promise.resolve({ hometown: "London, UK" }),
       artworkLoader: () => Promise.resolve({ title: "Self Portrait" }),
@@ -166,6 +166,22 @@ describe("Search", () => {
       expect(collectionSearchableItemNode.href).toBe(
         "/collection/catty-collection"
       )
+    })
+  })
+
+  it("returns `hasNextPage`", () => {
+    const query = `
+      {
+        search(query: "David Bowie", first: 10) {
+          pageInfo {
+            hasNextPage
+          }
+        }
+      }
+    `
+
+    return runQuery(query, context).then(data => {
+      expect(data!.search.pageInfo.hasNextPage).toBeTruthy()
     })
   })
 

--- a/src/schema/search/SearchEntity.ts
+++ b/src/schema/search/SearchEntity.ts
@@ -24,6 +24,9 @@ export const SearchEntity = new GraphQLEnumType({
     FEATURE: {
       value: "Feature",
     },
+    GALLERY: {
+      value: "gallery",
+    },
     GENE: {
       value: "Gene",
     },
@@ -32,6 +35,9 @@ export const SearchEntity = new GraphQLEnumType({
     },
     SALE: {
       value: "Sale",
+    },
+    SHOW: {
+      value: "PartnerShow",
     },
     TAG: {
       value: "Tag",

--- a/src/schema/search/index.ts
+++ b/src/schema/search/index.ts
@@ -144,6 +144,7 @@ export const Search: GraphQLFieldConfig<void, ResolverContext> = {
   args: searchArgs,
   resolve: (_source, args, context, info) => {
     const pageOptions = convertConnectionArgsToGravityArgs(args)
+    const { page, size } = pageOptions
 
     const gravityArgs = {
       ...pageOptions,
@@ -152,9 +153,9 @@ export const Search: GraphQLFieldConfig<void, ResolverContext> = {
     }
 
     return context.searchLoader(gravityArgs).then(({ body, headers }) => {
-      debugger
       const totalCount = parseInt(headers["x-total-count"])
       const pageCursors = createPageCursors(pageOptions, totalCount)
+      const totalPages = Math.ceil(totalCount / size)
 
       let results = body
       if (args.aggregations) {
@@ -181,9 +182,8 @@ export const Search: GraphQLFieldConfig<void, ResolverContext> = {
           ...connection,
           pageInfo: {
             ...connection.pageInfo,
-            hasPreviousPage: pageOptions.page > 1,
-            hasNextPage:
-              pageCursors.last && pageOptions.page < pageCursors.last.page,
+            hasPreviousPage: page > 1,
+            hasNextPage: page < totalPages,
           },
         }
       })


### PR DESCRIPTION
For 'short' result sets (< 5 pages, for whatever the page size requested is), `pageCursors.last` isn't present (all the cursors are contained in `around`), and so this check was failing.

Updates the `hasNextPage` logic to be more consistent.

Also...noticed a `debugger` statement sneaked in :( , so added a Danger rule for there as a bonus 😅 