### PR TITLE
Nudge Hong Kong for LD

### DIFF
--- a/src/schema/city/cityDataSortedByDisplayPreference.json
+++ b/src/schema/city/cityDataSortedByDisplayPreference.json
@@ -2,7 +2,7 @@
   {
     "slug": "new-york-ny-usa",
     "name": "New York",
-    "coordinates": { "lat": 40.71, "lng": -74.01 },
+    "coordinates": { "lat": 40.713, "lng": -74.006 },
     "maxBounds": {
       "sw": { "lat": 40.144, "lng": -74.754 },
       "ne": { "lat": 41.272, "lng": -73.266 }
@@ -11,7 +11,7 @@
   {
     "slug": "los-angeles-ca-usa",
     "name": "Los Angeles",
-    "coordinates": { "lat": 34.05, "lng": -118.24 },
+    "coordinates": { "lat": 34.052, "lng": -118.244 },
     "maxBounds": {
       "sw": { "lat": 33.453, "lng": -118.959 },
       "ne": { "lat": 34.644, "lng": -117.521 }
@@ -20,7 +20,7 @@
   {
     "slug": "london-united-kingdom",
     "name": "London",
-    "coordinates": { "lat": 51.51, "lng": -0.13 },
+    "coordinates": { "lat": 51.507, "lng": -0.128 },
     "maxBounds": {
       "sw": { "lat": 50.895, "lng": -1.118 },
       "ne": { "lat": 52.127, "lng": 0.862 }
@@ -29,7 +29,7 @@
   {
     "slug": "berlin-germany",
     "name": "Berlin",
-    "coordinates": { "lat": 52.52, "lng": 13.4 },
+    "coordinates": { "lat": 52.52, "lng": 13.405 },
     "maxBounds": {
       "sw": { "lat": 51.882, "lng": 12.352 },
       "ne": { "lat": 53.159, "lng": 14.452 }
@@ -38,7 +38,7 @@
   {
     "slug": "paris-france",
     "name": "Paris",
-    "coordinates": { "lat": 48.86, "lng": 2.35 },
+    "coordinates": { "lat": 48.857, "lng": 2.352 },
     "maxBounds": {
       "sw": { "lat": 48.339, "lng": 1.561 },
       "ne": { "lat": 49.377, "lng": 3.139 }
@@ -47,7 +47,7 @@
   {
     "slug": "hong-kong-hong-kong",
     "name": "Hong Kong",
-    "coordinates": { "lat": 22.3, "lng": 114.2 },
+    "coordinates": { "lat": 22.282, "lng": 114.158 },
     "maxBounds": {
       "sw": { "lat": 21.66, "lng": 113.509 },
       "ne": { "lat": 22.938, "lng": 114.891 }


### PR DESCRIPTION
We chose a center point for HK that was a sort of good centroid-ish point based on the actual distribution of partners we had there. However that point happened to fall on a body of water, which is leading to bad UX in the current iteration of the LD map. 

IANA HK expert but I am nudging the center point to a major intersection near a cluster of partners in the Central district:

![hk](https://user-images.githubusercontent.com/140521/54396067-14cd3480-4688-11e9-82e9-15647a6923f0.png)

And while I'm in here finessing neighborhoods I'm also going to drop my earlier pedantry about the precision these lat/lng floats should have. Bumping up to 3 sig digs, which gives us [neighborhood/street level precision](https://en.wikipedia.org/wiki/Decimal_degrees#Precision).