### PR TITLE
Do not filter out stub shows from show query

### DIFF
--- a/src/schema/__tests__/show.test.js
+++ b/src/schema/__tests__/show.test.js
@@ -128,9 +128,10 @@ describe("Show type", () => {
     })
   })
 
-  it("doesn't return a show that’s neither displayable nor a reference", async () => {
+  it("doesn't return a show that’s neither displayable nor a reference show nor a stub show", async () => {
     showData.displayable = false
     showData.is_reference = false
+    showData.is_local_discovery = false
     const query = gql`
       {
         show(id: "new-museum-1-2015-triennial-surround-audience") {
@@ -166,6 +167,21 @@ describe("Show type", () => {
     `
     const data = await runQuery(query, context)
     expect(data.show.fair.id).toEqual("the-art-show-2019")
+  })
+
+  it("returns a local discovery stub show even with displayable set to false", async () => {
+    showData.is_local_discovery = true
+    showData.displayable = false
+
+    const query = gql`
+      {
+        show(id: "new-museum-1-2015-triennial-surround-audience") {
+          name
+        }
+      }
+    `
+    const data = await runQuery(query, context)
+    expect(data.show.name).toEqual("Whitespace Abounds")
   })
 
   describe("is_followed", () => {

--- a/src/schema/show.ts
+++ b/src/schema/show.ts
@@ -650,7 +650,14 @@ const Show: GraphQLFieldConfig<void, ResolverContext> = {
   resolve: (_root, { id }, { showLoader }) => {
     return showLoader(id)
       .then(show => {
-        if (!show.displayable && !show.is_reference && !isExisty(show.fair)) {
+        if (
+          !(
+            show.displayable ||
+            show.is_local_discovery ||
+            show.is_reference ||
+            isExisty(show.fair)
+          )
+        ) {
           return new HTTPError("Show Not Found", 404)
         }
         return show


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/LD-468

We've observed that it's not possible to tap into _some_ shows in the app, usually (but not always) stub shows.

Gravity returns them but MP doesn't. That is likely because they are being 404'd due to not being [_either a displayable show or a reference show or a fair booth_](https://github.com/artsy/metaphysics/blob/0e1658cb735102ff53640a9e7c8ab4e54f61ce92/src/schema/show.ts#L653-L655)

This PR prevents stub shows by being filtered out in this way, by adding stub shows to the allowlist above.

A good question is why we don't see this more often. I'm not certain, but it's possibly because we tend to tap into stubs that _also_ happen to be displayable by virtue of having install shots (such as the sponsored content shows).

In any case, this change seems warranted.

### Before 

<img width="828" alt="b4" src="https://user-images.githubusercontent.com/140521/54447302-85736000-471f-11e9-8584-5dda88b3c9eb.png">

### After
<img width="828" alt="a4" src="https://user-images.githubusercontent.com/140521/54447318-8f955e80-471f-11e9-82fa-2b858d56727b.png">
