### PR TITLE
@alloy => [Loaders] Always use cached loader when filter arguments permit

### DIFF
--- a/src/lib/stitching/kaws/__tests__/stitching.test.ts
+++ b/src/lib/stitching/kaws/__tests__/stitching.test.ts
@@ -17,12 +17,16 @@ describe("MarketingCollectionArtwork", () => {
         }
       }
     `
-    const context = {
-      filterArtworksLoader: jest.fn(() => Promise.resolve()),
+    const context: any = {
+      authenticatedLoaders: {},
+      unauthenticatedLoaders: {
+        filterArtworksLoader: jest.fn(() => Promise.resolve()),
+      },
     }
 
     await runQuery(query, context)
-    expect(context.filterArtworksLoader.mock.calls[0]).toMatchInlineSnapshot(`
+    expect(context.unauthenticatedLoaders.filterArtworksLoader.mock.calls[0])
+      .toMatchInlineSnapshot(`
 Array [
   Object {
     "aggregations": Array [],
@@ -32,9 +36,6 @@ Array [
     "gene_ids": Array [],
     "keyword": "Snoopy, Woodstock, Man’s Best Friend, No One's Home, Isolation Tower, Stay Steady, The Things that Comfort",
     "keyword_match_exact": true,
-  },
-  Object {
-    "requestThrottleMs": 3600000,
   },
 ]
 `)
@@ -57,12 +58,16 @@ Array [
       }
     `
 
-    const context = {
-      filterArtworksLoader: jest.fn(() => Promise.resolve()),
+    const context: any = {
+      authenticatedLoaders: {},
+      unauthenticatedLoaders: {
+        filterArtworksLoader: jest.fn(() => Promise.resolve()),
+      },
     }
 
     await runQuery(query, context)
-    expect(context.filterArtworksLoader.mock.calls[0]).toMatchInlineSnapshot(`
+    expect(context.unauthenticatedLoaders.filterArtworksLoader.mock.calls[0])
+      .toMatchInlineSnapshot(`
 Array [
   Object {
     "aggregations": Array [],
@@ -73,9 +78,6 @@ Array [
       "kinetic-sculpture",
     ],
     "keyword_match_exact": false,
-  },
-  Object {
-    "requestThrottleMs": 3600000,
   },
 ]
 `)

--- a/src/schema/__tests__/gene.test.js
+++ b/src/schema/__tests__/gene.test.js
@@ -12,24 +12,27 @@ describe("Gene", () => {
 
     beforeEach(() => {
       context = {
-        filterArtworksLoader: sinon
-          .stub()
-          .withArgs("filter/artworks", {
-            gene_id: "500-1000-ce",
-            aggregations: ["total"],
-          })
-          .returns(
-            Promise.resolve({
-              hits: [
-                {
-                  id: "oseberg-norway-queens-ship",
-                  title: "Queen's Ship",
-                  artists: [],
-                },
-              ],
-              aggregations: [],
+        authenticatedLoaders: {},
+        unauthenticatedLoaders: {
+          filterArtworksLoader: sinon
+            .stub()
+            .withArgs("filter/artworks", {
+              gene_id: "500-1000-ce",
+              aggregations: ["total"],
             })
-          ),
+            .returns(
+              Promise.resolve({
+                hits: [
+                  {
+                    id: "oseberg-norway-queens-ship",
+                    title: "Queen's Ship",
+                    artists: [],
+                  },
+                ],
+                aggregations: [],
+              })
+            ),
+        },
       }
     })
 
@@ -62,6 +65,8 @@ describe("Gene", () => {
     beforeEach(() => {
       const gene = { id: "500-1000-ce", browseable: true, family: "" }
       context = {
+        authenticatedLoaders: {},
+        unauthenticatedLaders: {},
         geneLoader: sinon.stub().returns(Promise.resolve(gene)),
         filterArtworksLoader: sinon.stub().returns(
           Promise.resolve({
@@ -333,24 +338,27 @@ describe("Gene", () => {
     beforeEach(() => {
       const gene = { id: "500-1000-ce", browseable: true, family: "" }
       context = {
-        filterArtworksLoader: sinon
-          .stub()
-          .withArgs("filter/artworks", {
-            gene_id: "500-1000-ce",
-            aggregations: ["total"],
-          })
-          .returns(
-            Promise.resolve({
-              hits: [
-                {
-                  id: "oseberg-norway-queens-ship",
-                  title: "Queen's Ship",
-                  artists: [],
-                },
-              ],
-              aggregations: [],
+        authenticatedLoaders: {},
+        unauthenticatedLoaders: {
+          filterArtworksLoader: sinon
+            .stub()
+            .withArgs("filter/artworks", {
+              gene_id: "500-1000-ce",
+              aggregations: ["total"],
             })
-          ),
+            .returns(
+              Promise.resolve({
+                hits: [
+                  {
+                    id: "oseberg-norway-queens-ship",
+                    title: "Queen's Ship",
+                    artists: [],
+                  },
+                ],
+                aggregations: [],
+              })
+            ),
+        },
         geneLoader: sinon.stub().returns(Promise.resolve(gene)),
       }
     })

--- a/src/schema/__tests__/show.test.js
+++ b/src/schema/__tests__/show.test.js
@@ -1083,25 +1083,28 @@ describe("Show type", () => {
     it("fetches FilterArtworks using the show id and partner id", async () => {
       context = {
         ...context,
-        filterArtworksLoader: jest.fn().mockReturnValue(
-          Promise.resolve({
-            hits: [
-              {
-                id: "1",
-                title: "foo-artwork",
+        authenticatedLoaders: {},
+        unauthenticatedLoaders: {
+          filterArtworksLoader: jest.fn().mockReturnValue(
+            Promise.resolve({
+              hits: [
+                {
+                  id: "1",
+                  title: "foo-artwork",
+                },
+                {
+                  id: "2",
+                  title: "bar-artwork",
+                },
+              ],
+              aggregations: {
+                total: {
+                  value: 303,
+                },
               },
-              {
-                id: "2",
-                title: "bar-artwork",
-              },
-            ],
-            aggregations: {
-              total: {
-                value: 303,
-              },
-            },
-          })
-        ),
+            })
+          ),
+        },
       }
 
       const query = gql`
@@ -1121,7 +1124,9 @@ describe("Show type", () => {
         }
       `
       const data = await runQuery(query, context)
-      expect(context.filterArtworksLoader).toHaveBeenCalledWith(
+      expect(
+        context.unauthenticatedLoaders.filterArtworksLoader
+      ).toHaveBeenCalledWith(
         expect.objectContaining({
           partner_show_id: "abcdefg123456",
           partner_id: "new-museum",

--- a/src/schema/__tests__/tag.test.js
+++ b/src/schema/__tests__/tag.test.js
@@ -10,24 +10,27 @@ describe("Tag", () => {
 
     it("returns filtered artworks", () => {
       const context = {
-        filterArtworksLoader: sinon
-          .stub()
-          .withArgs("filter/artworks", {
-            tag_id: "butt",
-            aggregations: ["total"],
-          })
-          .returns(
-            Promise.resolve({
-              hits: [
-                {
-                  id: "oseberg-norway-queens-ship",
-                  title: "Queen's Ship",
-                  artists: [],
-                },
-              ],
-              aggregations: [],
+        authenticatedLoaders: {},
+        unauthenticatedLoaders: {
+          filterArtworksLoader: sinon
+            .stub()
+            .withArgs("filter/artworks", {
+              tag_id: "butt",
+              aggregations: ["total"],
             })
-          ),
+            .returns(
+              Promise.resolve({
+                hits: [
+                  {
+                    id: "oseberg-norway-queens-ship",
+                    title: "Queen's Ship",
+                    artists: [],
+                  },
+                ],
+                aggregations: [],
+              })
+            ),
+        },
       }
       const query = `
         {

--- a/src/schema/artist/__tests__/index.test.js
+++ b/src/schema/artist/__tests__/index.test.js
@@ -750,7 +750,8 @@ describe("Artist type", () => {
           aggregations: { total: { value: 75 } },
         })
       )
-      context.filterArtworksLoader = filterArtworksLoader
+      context.unauthenticatedLoaders = { filterArtworksLoader }
+      context.authenticatedLoaders = {}
 
       const query = `
         {


### PR DESCRIPTION
This implements what we've been discussing, namely, for our filter endpoint we can introspect on the params, and if they're not personalized, we can fall back to the cached loader.

Since all the loaders are merged at the root of context, we added a separate `unauthenticatedLoaders` and `authenticatedLoaders` key.

@eessex the KAWS stitching in place here: https://github.com/artsy/metaphysics/blob/1a7167465f572063b6c3970d4dd63600a73e3e4b/src/lib/stitching/kaws/stitching.ts#L122 is no longer quite valid, in all cases (auth and unauth) we will be using the cached loader w/ 5 second refresh. We can pair next week on cleaning that up and propagating.