### PR TITLE
DISCO-720: Remove stale artwork filter

### DIFF
--- a/src/schema/artist/__tests__/carousel.test.js
+++ b/src/schema/artist/__tests__/carousel.test.js
@@ -92,35 +92,3 @@ describe("ArtistCarousel type", () => {
     })
   })
 })
-
-it("filters artworks with an attribution class other than what we want", () => {
-  const before = [
-    {
-      title: "No attribution class",
-      attribution_class: undefined,
-    },
-    {
-      title: "Wanted attribution class",
-      attribution_class: "unique",
-    },
-    {
-      title: "Skipped attribution class",
-      attribution_class: "ephemera",
-    },
-  ]
-  const filtered = removeReproductionsFromArtworks(before)
-
-  expect(filtered).toHaveLength(2)
-  expect(filtered).toMatchInlineSnapshot(`
-Array [
-  Object {
-    "attribution_class": undefined,
-    "title": "No attribution class",
-  },
-  Object {
-    "attribution_class": "unique",
-    "title": "Wanted attribution class",
-  },
-]
-`)
-})

--- a/src/schema/artist/carousel.ts
+++ b/src/schema/artist/carousel.ts
@@ -2,7 +2,6 @@ import _ from "lodash"
 import Image from "schema/image"
 import { error } from "lib/loggers"
 import { GraphQLObjectType, GraphQLList, GraphQLFieldConfig } from "graphql"
-import { GravityArtwork } from "types/gravity/artworkResponse"
 import { ResolverContext } from "types/graphql"
 
 const ArtistCarouselType = new GraphQLObjectType<any, ResolverContext>({

--- a/src/schema/artist/carousel.ts
+++ b/src/schema/artist/carousel.ts
@@ -31,7 +31,7 @@ const ArtistCarousel: GraphQLFieldConfig<{ id: string }, ResolverContext> = {
         top_tier: true,
       }),
       artistArtworksLoader(id, {
-        size: 10, // we only show a max of 7 though, a hotfix for AS-285
+        size: 7,
         sort: "-iconicity",
         published: true,
       }),
@@ -56,7 +56,6 @@ const ArtistCarousel: GraphQLFieldConfig<{ id: string }, ResolverContext> = {
           .then(showsWithImages => {
             return showsWithImages.concat(
               artworks
-                .slice(0, 6) // Always return the top 7 artworks
                 .map(artwork => {
                   return _.assign(
                     { href: `/artwork/${artwork.id}`, title: artwork.title },

--- a/src/schema/artist/carousel.ts
+++ b/src/schema/artist/carousel.ts
@@ -55,7 +55,7 @@ const ArtistCarousel: GraphQLFieldConfig<{ id: string }, ResolverContext> = {
           })
           .then(showsWithImages => {
             return showsWithImages.concat(
-              removeReproductionsFromArtworks(artworks)
+              artworks
                 .slice(0, 6) // Always return the top 7 artworks
                 .map(artwork => {
                   return _.assign(
@@ -68,25 +68,6 @@ const ArtistCarousel: GraphQLFieldConfig<{ id: string }, ResolverContext> = {
       })
       .catch(error)
   },
-}
-
-export const removeReproductionsFromArtworks = (artworks: GravityArtwork[]) => {
-  return artworks.filter(a => {
-    // Considering it's likely that we've not covered most artworks
-    // with attribution metadata, I'd prefer to be conservative and
-    // let works without attribution class on the banner
-    if (!a.attribution_class) {
-      return true
-    }
-
-    // Only return unique or limited edition works as these are what we
-    // want to highlight. This gives gallery reps the ability to correctly
-    // set attribution classes on works which shouldn't be in the carousel
-    return (
-      a.attribution_class === "unique" ||
-      a.attribution_class === "limited edition"
-    )
-  })
 }
 
 export default ArtistCarousel


### PR DESCRIPTION
This was added at a time where we were trying to filter out ephemera and reproductions from the carousel. Since that time, upstream changes have caused this filtering to be no longer needed and, in fact, to be filtering more than it should be.

All this PR does is remove the filtering function.