### PR TITLE
Expose an isActive flag on Fair

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1121,9 +1121,10 @@ type ArtworkContextFair {
   hours: String
   href: String
   image: Image
+  is_active: Boolean @deprecated(reason: "Prefer isActive instead")
 
   # Are we currently in the fair's active period?
-  is_active: Boolean
+  isActive: Boolean
   links: String
   mobile_image: Image
   is_published: Boolean
@@ -1150,6 +1151,14 @@ type ArtworkContextFair {
     timezone: String
   ): String
   end_at(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
+  active_start_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
     format: String
@@ -3303,9 +3312,10 @@ type Fair {
   hours: String
   href: String
   image: Image
+  is_active: Boolean @deprecated(reason: "Prefer isActive instead")
 
   # Are we currently in the fair's active period?
-  is_active: Boolean
+  isActive: Boolean
   links: String
   mobile_image: Image
   is_published: Boolean
@@ -3332,6 +3342,14 @@ type Fair {
     timezone: String
   ): String
   end_at(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
+  active_start_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
     format: String
@@ -4560,9 +4578,10 @@ type HomePageModuleContextFair {
   hours: String
   href: String
   image: Image
+  is_active: Boolean @deprecated(reason: "Prefer isActive instead")
 
   # Are we currently in the fair's active period?
-  is_active: Boolean
+  isActive: Boolean
   links: String
   mobile_image: Image
   is_published: Boolean
@@ -4589,6 +4608,14 @@ type HomePageModuleContextFair {
     timezone: String
   ): String
   end_at(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
+  active_start_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
     format: String

--- a/src/schema/fair.ts
+++ b/src/schema/fair.ts
@@ -170,11 +170,21 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
     image: Image,
     is_active: {
       type: GraphQLBoolean,
-      description: "Are we currently in the fair's active period?",
+      deprecationReason: "Prefer isActive instead",
       resolve: ({ autopublish_artworks_at, end_at }) => {
         const start = moment.utc(autopublish_artworks_at).subtract(7, "days")
         const end = moment.utc(end_at).add(14, "days")
         return moment.utc().isBetween(start, end)
+      },
+    },
+    isActive: {
+      type: GraphQLBoolean,
+      description: "Are we currently in the fair's active period?",
+      resolve: ({ active_start_at, end_at }) => {
+        const activeStart = moment.utc(active_start_at)
+        const end = moment.utc(end_at)
+        const now = moment.utc()
+        return now.isBetween(activeStart, end)
       },
     },
     links: {
@@ -254,6 +264,7 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
     },
     start_at: date,
     end_at: date,
+    active_start_at: date,
     organizer: {
       type: FairOrganizerType,
     },


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/LD-503

This adds a new `isActive` field (and deprecates the old `is_active` field).

The new `isActive` field's definition is:

- true when the fair's `active_start_at` is in the past and `end_at` is in the future
- false otherwise

![Screen Shot 2019-03-18 at 5 31 06 PM](https://user-images.githubusercontent.com/140521/54565033-9fbd7000-49a3-11e9-93fb-0d94661464c6.png)

#skip_camel