### PR TITLE
Expose pressReleaseUrl on Show

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -8649,6 +8649,9 @@ type Show implements Node {
   # The press release for this show
   press_release(format: Format): String
 
+  # Link to the press release for this show
+  pressReleaseUrl: String
+
   # When this show starts
   start_at(
     # This arg is deprecated, use timezone instead

--- a/src/schema/show.ts
+++ b/src/schema/show.ts
@@ -601,6 +601,11 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
       description: "The press release for this show",
       ...markdown(),
     },
+    pressReleaseUrl: {
+      type: GraphQLString,
+      description: "Link to the press release for this show",
+      resolve: ({ press_release_url }) => press_release_url,
+    },
     start_at: {
       description: "When this show starts",
       ...date,


### PR DESCRIPTION
This just exposes the `press_release_url` field on the underlying show.  The field does not exist / has not been populated yet, but will be shortly. This work simply unblocks some Emission work for the next release.

```graphql
{
  show(id: "pace-prints-david-hockney-etchings-1") {
    id
    pressReleaseUrl
  }
}
```