### PR TITLE
Exclude shows that were blocked from discovery

### DIFF
--- a/src/schema/__tests__/city.test.ts
+++ b/src/schema/__tests__/city.test.ts
@@ -162,6 +162,14 @@ describe("City", () => {
       expect(gravityOptions).toMatchObject({ displayable: true })
       expect(gravityOptions).not.toHaveProperty("discoverable")
     })
+
+    it("requests non-blocked discovery shows, by default", async () => {
+      await runQuery(query, context)
+      const gravityOptions = context.showsWithHeadersLoader.mock.calls[0][0]
+
+      expect(gravityOptions).toMatchObject({ include_discovery_blocked: false })
+    })
+
     it("requests shows with location, by default", async () => {
       await runQuery(query, context)
       const gravityOptions = context.showsWithHeadersLoader.mock.calls[0][0]

--- a/src/schema/city/index.ts
+++ b/src/schema/city/index.ts
@@ -99,6 +99,7 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
           displayable: true,
           include_local_discovery:
             args.includeStubShows || args.discoverable === true,
+          include_discovery_blocked: false,
         }),
     },
     fairs: {


### PR DESCRIPTION
# Problem
We want to by default exclude shows that were blocked from discovery in `city` query used in City Guide.

https://artsyproduct.atlassian.net/browse/LD-370

# Solution
Use [newly added Gravity param](https://github.com/artsy/gravity/pull/12214) and send `false` by default to exclude these shows.