### PR TITLE
Adds required Vortex env vars to example env config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ IMPULSE_API_BASE=https://impulse-staging.artsy.net/api
 KAWS_API_BASE=http://kaws-staging.artsy.net
 POSITRON_API_BASE=https://stagingwriter.artsy.net/api
 PREDICTION_ENDPOINT=https://live-staging.artsy.net
+VORTEX_API_URL=https://vortex-staging.artsy.net/api/graphql
 
 MEMCACHED_URL=localhost:11211
 
@@ -27,6 +28,8 @@ EMBEDLY_KEY=**
 GALAXY_TOKEN=**
 GOOGLE_CSE_CX=**
 GOOGLE_CSE_KEY=**
+VORTEX_API_BASE=**
+VORTEX_APP_ID=**
 
 # OSS version of the .env file
 # Note: The GRAVITY_ID & GRAVITY_SECRET are known keys for Artsy OSS


### PR DESCRIPTION
This PR adds env vars that are required for setup. The readme specifies to copy this file over to `.env`, but doing so will error out based on these changes: https://github.com/artsy/metaphysics/commit/7cb6cba79ce514a335a4359babe1a48a447ab15f#diff-7e82dc7533620e594f349d3ea425b5b4R79