### PR TITLE
Exclude show from suggest search

### DIFF
--- a/src/lib/loaders/searchLoader.ts
+++ b/src/lib/loaders/searchLoader.ts
@@ -1,8 +1,8 @@
 import * as url from "url"
-import { DEFAULT_ENTITIES } from "schema/search/SearchEntity"
+import { DEFAULT_ENTITIES, SUGGEST_ENTITIES } from "schema/search/SearchEntity"
 
 const modeMap = {
-  AUTOSUGGEST: { fallbackEntities: DEFAULT_ENTITIES, pathname: "/match/suggest" },
+  AUTOSUGGEST: { fallbackEntities: SUGGEST_ENTITIES, pathname: "/match/suggest" },
   DEFAULT: { fallbackEntities: DEFAULT_ENTITIES, pathname: "/match" },
 }
 

--- a/src/lib/loaders/searchLoader.ts
+++ b/src/lib/loaders/searchLoader.ts
@@ -1,21 +1,24 @@
 import * as url from "url"
 import { DEFAULT_ENTITIES } from "schema/search/SearchEntity"
 
+const modeMap = {
+  AUTOSUGGEST: { fallbackEntities: DEFAULT_ENTITIES, pathname: "/match/suggest" },
+  DEFAULT: { fallbackEntities: DEFAULT_ENTITIES, pathname: "/match" },
+}
+
 export const searchLoader = gravityLoader => {
   return gravityLoader(
     ({ query, entities, mode, ...rest }) => {
+      const { fallbackEntities, pathname } = modeMap[mode] || modeMap.DEFAULT
+      const indexes =  entities || fallbackEntities.map(index => index.value)
+
       const queryParams = {
         term: query,
-        "indexes[]": entities || DEFAULT_ENTITIES.map(index => index.value),
+        "indexes[]": indexes,
         ...rest,
       }
 
-      switch (mode) {
-        case "AUTOSUGGEST":
-          return url.format({ pathname: "/match/suggest", query: queryParams })
-        default:
-          return url.format({ pathname: "/match", query: queryParams })
-      }
+      return url.format({ pathname, query: queryParams })
     },
     {},
     { headers: true }

--- a/src/lib/loaders/searchLoader.ts
+++ b/src/lib/loaders/searchLoader.ts
@@ -2,7 +2,10 @@ import * as url from "url"
 import { DEFAULT_ENTITIES, SUGGEST_ENTITIES } from "schema/search/SearchEntity"
 
 const modeMap = {
-  AUTOSUGGEST: { fallbackEntities: SUGGEST_ENTITIES, pathname: "/match/suggest" },
+  AUTOSUGGEST: {
+    fallbackEntities: SUGGEST_ENTITIES,
+    pathname: "/match/suggest",
+  },
   DEFAULT: { fallbackEntities: DEFAULT_ENTITIES, pathname: "/match" },
 }
 
@@ -10,7 +13,7 @@ export const searchLoader = gravityLoader => {
   return gravityLoader(
     ({ query, entities, mode, ...rest }) => {
       const { fallbackEntities, pathname } = modeMap[mode] || modeMap.DEFAULT
-      const indexes =  entities || fallbackEntities.map(index => index.value)
+      const indexes = entities || fallbackEntities.map(index => index.value)
 
       const queryParams = {
         term: query,

--- a/src/schema/artist/carousel.ts
+++ b/src/schema/artist/carousel.ts
@@ -54,13 +54,12 @@ const ArtistCarousel: GraphQLFieldConfig<{ id: string }, ResolverContext> = {
           })
           .then(showsWithImages => {
             return showsWithImages.concat(
-              artworks
-                .map(artwork => {
-                  return _.assign(
-                    { href: `/artwork/${artwork.id}`, title: artwork.title },
-                    _.find(artwork.images, i => i.is_default)
-                  )
-                })
+              artworks.map(artwork => {
+                return _.assign(
+                  { href: `/artwork/${artwork.id}`, title: artwork.title },
+                  _.find(artwork.images, i => i.is_default)
+                )
+              })
             )
           })
       })

--- a/src/schema/search/SearchEntity.ts
+++ b/src/schema/search/SearchEntity.ts
@@ -48,6 +48,8 @@ export const SearchEntity = new GraphQLEnumType({
   },
 })
 
+const defaultBlockList = ["gallery", "institution"]
+
 export const DEFAULT_ENTITIES = SearchEntity.getValues().filter(
-  index => index.value !== "gallery" && index.value !== "institution"
+  index => defaultBlockList.includes(index.value)
 )

--- a/src/schema/search/SearchEntity.ts
+++ b/src/schema/search/SearchEntity.ts
@@ -51,5 +51,11 @@ export const SearchEntity = new GraphQLEnumType({
 const defaultBlockList = ["gallery", "institution"]
 
 export const DEFAULT_ENTITIES = SearchEntity.getValues().filter(
-  index => defaultBlockList.includes(index.value)
+  index => !defaultBlockList.includes(index.value)
+)
+
+const suggestBlockList = ["gallery", "institution", "show"]
+
+export const SUGGEST_ENTITIES = SearchEntity.getValues().filter(
+  index => !suggestBlockList.includes(index.value)
 )


### PR DESCRIPTION
Over on artsy/reaction#2182 I added the list of entities that would work for autosuggest searches, but @mzikherman advised me to move that up the chain so that MP actually knows which ones are right for suggest searches. This PR refactors the search loader to use objects for the fallback entities and path, then I added a new const to list the suggest entities.