### PR TITLE
Attempt to extend expiration of memoized filter responses

### DIFF
--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -29,7 +29,7 @@ export default opts => {
     fairPartnersLoader: gravityLoader(id => `fair/${id}/partners`, {}, { headers: true }),
     fairLoader: gravityLoader(id => `fair/${id}`),
     fairsLoader: gravityLoader("fairs", {}, { headers: true }),
-    filterArtworksLoader: gravityLoader("filter/artworks"),
+    filterArtworksLoader: gravityLoader("filter/artworks", {}, { requestThrottleMs: 1000 * 60 * 60 }),
     geneArtistsLoader: gravityLoader(id => `gene/${id}/artists`),
     geneFamiliesLoader: gravityLoader("gene_families"),
     geneLoader: gravityLoader(id => `gene/${id}`),


### PR DESCRIPTION
The other day, we struggled to confirm _any_ visible performance improvements from switching to the cached and unauthenticated loaders for any filter requests that don't require personalized responses. This was even after confirming locally and in staging the expected behavior. This [we think] was due to a few things:
* The request-throttling is only good for 5 seconds and handled _per-process_. In production there are quite a few horizontally scaled processes serving traffic, so we wouldn't see rapid consolidation of requests.
* There are still multiple search requests being made to serve each response. We couldn't figure out why, but ticketed the most egregious cases.

This PR doesn't solve either of those, but does attempt to extend the 5 second period in which any single pod won't refresh its API data to 1 hour. Combined with the previous work (https://github.com/artsy/metaphysics/pull/1597) to use the unauthenticated loader when authenticated callers don't actually need personalized responses, I think this should apply to essentially all filter requests.