### PR TITLE
Emission queries for 'running_and_upcoming' now redirect correctly.

### DIFF
--- a/src/schema/input_fields/event_status.ts
+++ b/src/schema/input_fields/event_status.ts
@@ -41,7 +41,7 @@ const EventStatus = {
         description: "End date is in near future",
       },
       RUNNING_AND_UPCOMING: {
-        value: "current",
+        value: "running_and_upcoming",
         description:
           "Special filtering option which is used to show running and upcoming shows",
       },

--- a/src/schema/me/__tests__/followed_shows.test.ts
+++ b/src/schema/me/__tests__/followed_shows.test.ts
@@ -40,44 +40,84 @@ describe("returns followed shows for a user", () => {
     })
   })
 
-  it("generates a predictable URL with a city slug input", async () => {
-    const nyc = cityData[0]
-    expect(nyc.slug).toBe("new-york-ny-usa")
-    const query = generate_query(`(first: 10, city: "${nyc.slug}")`)
-    await runAuthenticatedQuery(query, { followedShowsLoader })
-    expect(followedShowsLoader).toHaveBeenCalledWith({
-      size: 10,
-      offset: 0,
-      total_count: true,
-      near: `${nyc.coordinates.lat},${nyc.coordinates.lng}`,
-      max_distance: LOCAL_DISCOVERY_RADIUS_KM,
+  describe("filter by status", () => {
+    const assert_status_supported = async status => {
+      const query = generate_query(
+        `(first: 10, status: ${status.toUpperCase()})`
+      )
+      await runAuthenticatedQuery(query, { followedShowsLoader })
+      expect(followedShowsLoader).toHaveBeenCalledWith({
+        size: 10,
+        offset: 0,
+        total_count: true,
+        status: status,
+      })
+    }
+
+    const assert_invalid_status_fails = async status => {
+      const query = generate_query(
+        `(first: 10, status: ${status.toUpperCase()})`
+      )
+      await expect(
+        runAuthenticatedQuery(query, { followedShowsLoader })
+      ).rejects.toMatchInlineSnapshot(
+        `[GraphQLError: Expected type EventStatus, found RANDOM_INVALID_STATUS.]`
+      )
+    }
+
+    it("handles all supported status definitions", async () => {
+      await assert_status_supported("closed")
+      await assert_status_supported("running")
+      await assert_status_supported("upcoming")
+      await assert_status_supported("closing_soon")
+      await assert_status_supported("running_and_upcoming")
+    })
+
+    it("throws an error if an unsupported status is supplied", async () => {
+      await assert_invalid_status_fails("random_invalid_status")
     })
   })
 
-  it("throws an error if presented with an invalid city slug", async () => {
-    const query = generate_query(`(first: 10, city: "this-is-not-a-city")`)
-    await expect(
-      runAuthenticatedQuery(query, { followedShowsLoader })
-    ).rejects.toMatchInlineSnapshot(
-      `[Error: City slug must be one of: new-york-ny-usa, los-angeles-ca-usa, london-united-kingdom, berlin-germany, paris-france, hong-kong-hong-kong]`
-    )
-  })
-
-  it("relies on the state of cityData", () => {
-    cityData
-      .map(city => ({
-        name: city.name,
-        slug: city.slug,
-        lat: city.coordinates.lat,
-        lng: city.coordinates.lng,
-      }))
-      .forEach(city => {
-        expect(city).toMatchObject({
-          name: expect.any(String),
-          slug: expect.any(String),
-          lat: expect.any(Number),
-          lng: expect.any(Number),
-        })
+  describe("filter by city", () => {
+    it("generates a predictable URL with a city slug input", async () => {
+      const nyc = cityData[0]
+      expect(nyc.slug).toBe("new-york-ny-usa")
+      const query = generate_query(`(first: 10, city: "${nyc.slug}")`)
+      await runAuthenticatedQuery(query, { followedShowsLoader })
+      expect(followedShowsLoader).toHaveBeenCalledWith({
+        size: 10,
+        offset: 0,
+        total_count: true,
+        near: `${nyc.coordinates.lat},${nyc.coordinates.lng}`,
+        max_distance: LOCAL_DISCOVERY_RADIUS_KM,
       })
+    })
+
+    it("throws an error if presented with an invalid city slug", async () => {
+      const query = generate_query(`(first: 10, city: "this-is-not-a-city")`)
+      await expect(
+        runAuthenticatedQuery(query, { followedShowsLoader })
+      ).rejects.toMatchInlineSnapshot(
+        `[Error: City slug must be one of: new-york-ny-usa, los-angeles-ca-usa, london-united-kingdom, berlin-germany, paris-france, hong-kong-hong-kong]`
+      )
+    })
+
+    it("relies on the state of cityData", () => {
+      cityData
+        .map(city => ({
+          name: city.name,
+          slug: city.slug,
+          lat: city.coordinates.lat,
+          lng: city.coordinates.lng,
+        }))
+        .forEach(city => {
+          expect(city).toMatchObject({
+            name: expect.any(String),
+            slug: expect.any(String),
+            lat: expect.any(Number),
+            lng: expect.any(Number),
+          })
+        })
+    })
   })
 })


### PR DESCRIPTION
This is a tiny change in the source file, but I took the opportunity to add a few more tests to our followed_show spec. Now, there's a case to be made that this test doesn't really help us - that the GraphQLEnumType constrains values enough. But this change made me think about the fact that for a while we had:

```
RUNNING_AND_UPCOMING : {
  value: "current"
}
```

I dunno about y'all but once I have enum keys to read I rarely go look at the values. In this case, it seemed reasonable to assert that our enum keys correspond directly to our enum values - if that ever changes again, this test will have to change, and anyone reading the tests to figure out why they keep requesting `status=FOO` but the system keeps returning data as if it had requested `status=BAR` will get a useful piece of information. 