### PR TITLE
@ashfurrow => [Show] Allow cover_image to return null if the show doesnt exist

### DIFF
--- a/src/schema/show.ts
+++ b/src/schema/show.ts
@@ -283,10 +283,12 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
               size: 1,
               published: true,
             }
-          ).then(({ body }) => {
-            const artwork = body[0]
-            return artwork && normalizeImageData(getDefault(artwork.images))
-          })
+          )
+            .then(({ body }) => {
+              const artwork = body[0]
+              return artwork && normalizeImageData(getDefault(artwork.images))
+            })
+            .catch(() => null)
         }
 
         return null


### PR DESCRIPTION
The data for a show is cached with a long TTL by the 'city' loader/schema.

Some of the fields of a show schema, wind up needing to make further requests to resolve (and can't just be resolved from the cached show data).

For fields in the show schema that make further requests (such as `cover_image`), they need to be made resilient to these further requests crashing, due to inconsistencies in the long lived cache of city shows, and actual shows (for example, a show might be deleted).

This adds that to `cover_image`. If you can take a look at the various queries used for Local Discovery, if there are other references to fields in this schema that need to make further requests to resolve, we can add a `catch` there too.