### PR TITLE
Fixes a bug where CausalityJWT resolver fails due to Cannot read property '_id' of null

### DIFF
--- a/src/schema/causality_jwt.ts
+++ b/src/schema/causality_jwt.ts
@@ -99,25 +99,26 @@ const CausalityJWT: GraphQLFieldConfig<void, ResolverContext> = {
               HMAC_SECRET
             )
           }
-          return mePartnersLoader({ "partner_ids[]": sale.partner._id }).then(
-            mePartners => {
-              // Check if current user has access to partner running the sale
-              if (mePartners.length === 0) {
-                throw new Error("Unauthorized to be operator")
+
+          if (sale.partner) {
+            return mePartnersLoader({ "partner_ids[]": sale.partner._id }).then(
+              () => {
+                return jwt.encode(
+                  {
+                    aud: "auctions",
+                    role: "externalOperator",
+                    userId: me._id,
+                    saleId: sale._id,
+                    bidderId: me.paddle_number,
+                    iat: new Date().getTime(),
+                  },
+                  HMAC_SECRET
+                )
               }
-              return jwt.encode(
-                {
-                  aud: "auctions",
-                  role: "externalOperator",
-                  userId: me._id,
-                  saleId: sale._id,
-                  bidderId: me.paddle_number,
-                  iat: new Date().getTime(),
-                },
-                HMAC_SECRET
-              )
-            }
-          )
+            )
+          } else {
+            throw new Error("Unauthorized to be operator")
+          }
         }
       )
     }


### PR DESCRIPTION
There is a [bug][1] where Metaphysics raises an exception due to `sale.partner` being `null`. This commit fixes it so the client can run a more reliable check rather than just checking a raw Javascript error message.

Also, the test needs to call `done()` otherwise the test will call no `expect`s and it will just pass.

[1]: https://sentry.io/organizations/artsynet/issues/841789531/?project=299973&query=is%3Aunresolved&statsPeriod=14d&utc=false