### PR TITLE
Fix builds by increasing wait time

### DIFF
--- a/src/lib/__tests__/graphqlTimeoutMiddleware.test.ts
+++ b/src/lib/__tests__/graphqlTimeoutMiddleware.test.ts
@@ -178,7 +178,7 @@ describe("graphQLTimeoutMiddleware", () => {
         },
         Artist: {
           name: async () => {
-            await delay(defaultTimeout + 2)
+            await delay(defaultTimeout + 10)
             return "Some artist"
           },
         },


### PR DESCRIPTION
For some reason the delay call does not wait enough in CI, so let's see if increasing delay fixes it.