### PR TITLE
add Nginx and metaphysics-web-internal service to production #PLATFORM-1306

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -51,6 +51,35 @@ spec:
               value: https
           initialDelaySeconds: 5
           periodSeconds: 5
+      - name: metaphysics-nginx
+        image: artsy/docker-nginx:1.14.2
+        ports:
+          - containerPort: 80
+          - containerPort: 443
+        readinessProbe:
+          tcpSocket:
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 15
+          timeoutSeconds: 10
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/usr/sbin/nginx", "-s", "quit"]
+        env:
+          - name: 'NGINX_DEFAULT_CONF'
+            valueFrom:
+              configMapKeyRef:
+                name: nginx-config
+                key: metaphysics
+        volumeMounts:
+          - name: nginx-secrets
+            mountPath: /etc/nginx/ssl
+      volumes:
+        - name: nginx-secrets
+          secret:
+            secretName: nginx-secrets
+            defaultMode: 420
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:
@@ -115,3 +144,29 @@ spec:
     component: web
   sessionAffinity: None
   type: LoadBalancer
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: metaphysics
+    layer: application
+    component: web
+  name: metaphysics-web-internal
+  namespace: default
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    name: http
+    targetPort: 80
+  - port: 443
+    protocol: TCP
+    name: https
+    targetPort: 443
+  selector:
+    app: metaphysics
+    layer: application
+    component: web
+  type: ClusterIP


### PR DESCRIPTION
Set up Nginx and metaphysics for internal Kubernetes DNS resolving `metaphysics-production.artsy.net` to `metaphysics-web-internal.default.svc.cluster.local`