### PR TITLE
@damassi => [FilterArtworks] Allow a page param to be specified and override cursor

### DIFF
--- a/src/schema/filter_artworks.ts
+++ b/src/schema/filter_artworks.ts
@@ -109,6 +109,8 @@ export const FilterArtworksType = new GraphQLObjectType<any, ResolverContext>({
         }
       ) => {
         const relayOptions = convertConnectionArgsToGravityArgs(args)
+        if (!!gravityOptions.page) relayOptions.page = gravityOptions.page
+
         const {
           include_artworks_by_followed_artists,
           aggregations,


### PR DESCRIPTION
This was all that was needed to allow the Reaction component to specify a `page: $page` style variable for the filter, and thus load any arbitrary page from a number! This was that annoying bug where the filter wouldn't respect an incoming page param from URL.