### PR TITLE
@damassi => Add support for jumping in to the search connection w/ arbitrary page

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -7592,6 +7592,9 @@ type Query {
     # Mode of search to execute. Default: SITE.
     mode: SearchMode
     aggregations: [SearchAggregation]
+
+    # If present, will be used for pagination instead of cursors.
+    page: Int
     after: String
     first: Int
     before: String
@@ -9606,6 +9609,9 @@ type Viewer {
     # Mode of search to execute. Default: SITE.
     mode: SearchMode
     aggregations: [SearchAggregation]
+
+    # If present, will be used for pagination instead of cursors.
+    page: Int
     after: String
     first: Int
     before: String

--- a/src/schema/__tests__/filter_artworks.test.js
+++ b/src/schema/__tests__/filter_artworks.test.js
@@ -155,6 +155,9 @@ describe("Filter Artworks", () => {
             name
             filtered_artworks(aggregations:[TOTAL], medium: "*", for_sale: true, page: 20){
               artworks_connection(first: 30, after: "") {
+                pageInfo {
+                  endCursor
+                }
                 edges {
                   node {
                     id
@@ -170,13 +173,19 @@ describe("Filter Artworks", () => {
         ({
           gene: {
             filtered_artworks: {
-              artworks_connection: { edges },
+              artworks_connection: {
+                edges,
+                pageInfo: { endCursor },
+              },
             },
           },
         }) => {
           expect(edges).toEqual([
             { node: { id: "oseberg-norway-queens-ship" } },
           ])
+          // Check that the cursor points to the end of page 20, size 30.
+          // Base64 encoded string: `arrayconnection:599`
+          expect(endCursor).toEqual("YXJyYXljb25uZWN0aW9uOjU5OQ==")
         }
       )
     })

--- a/src/schema/fields/pagination.ts
+++ b/src/schema/fields/pagination.ts
@@ -57,10 +57,14 @@ export const PageCursorsType = new GraphQLObjectType<any, ResolverContext>({
   }),
 })
 
+export function pageToCursor(page, size) {
+  return toGlobalId(PREFIX, String((page - 1) * size - 1))
+}
+
 // Returns an opaque cursor for a page.
-function pageToCursor(page, currentPage, size) {
+function pageToCursorObject(page, currentPage, size) {
   return {
-    cursor: toGlobalId(PREFIX, String((page - 1) * size - 1)),
+    cursor: pageToCursor(page, size),
     page,
     isCurrent: currentPage === page,
   }
@@ -74,7 +78,7 @@ function pageCursorsToArray(start, end, currentPage, size) {
   for (page = start; page <= end; page++) {
     // FIXME: Argument of type '{ cursor: string; page: any; isCurrent: boolean; }' is not assignable to parameter of type 'never'.
     // @ts-ignore
-    cursors.push(pageToCursor(page, currentPage, size))
+    cursors.push(pageToCursorObject(page, currentPage, size))
   }
   return cursors
 }
@@ -100,7 +104,7 @@ export function createPageCursors(
   let pageCursors
   // Degenerate case of no records found.
   if (totalPages === 0) {
-    pageCursors = { around: [pageToCursor(1, 1, size)] }
+    pageCursors = { around: [pageToCursorObject(1, 1, size)] }
   } else if (totalPages <= max) {
     // Collection is short, and `around` includes page 1 and the last page.
     pageCursors = {
@@ -109,13 +113,13 @@ export function createPageCursors(
   } else if (currentPage <= Math.floor(max / 2) + 1) {
     // We are near the beginning, and `around` will include page 1.
     pageCursors = {
-      last: pageToCursor(totalPages, currentPage, size),
+      last: pageToCursorObject(totalPages, currentPage, size),
       around: pageCursorsToArray(1, max - 1, currentPage, size),
     }
   } else if (currentPage >= totalPages - Math.floor(max / 2)) {
     // We are near the end, and `around` will include the last page.
     pageCursors = {
-      first: pageToCursor(1, currentPage, size),
+      first: pageToCursorObject(1, currentPage, size),
       around: pageCursorsToArray(
         totalPages - max + 2,
         totalPages,
@@ -127,19 +131,23 @@ export function createPageCursors(
     // We are in the middle, and `around` doesn't include the first or last page.
     const offset = Math.floor((max - 3) / 2)
     pageCursors = {
-      first: pageToCursor(1, currentPage, size),
+      first: pageToCursorObject(1, currentPage, size),
       around: pageCursorsToArray(
         currentPage - offset,
         currentPage + offset,
         currentPage,
         size
       ),
-      last: pageToCursor(totalPages, currentPage, size),
+      last: pageToCursorObject(totalPages, currentPage, size),
     }
   }
 
   if (currentPage > 1 && totalPages > 1) {
-    pageCursors.previous = pageToCursor(currentPage - 1, currentPage, size)
+    pageCursors.previous = pageToCursorObject(
+      currentPage - 1,
+      currentPage,
+      size
+    )
   }
   return pageCursors
 }


### PR DESCRIPTION
Much like https://github.com/artsy/metaphysics/pull/1633

There's also a bug fix for that initial PR. I noticed that when jumping in on an arbitrary page from the URL, clicking 'Next' wasn't working since our calculation for `endCursor` was incorrect. We need to calculate that ourselves from the incoming page param, vs rely on the lib to calculate it from the connection cursor params...since there _are_ no incoming cursor params when you initially load at an arbitrary page.

I tested this locally and everything seems hunky-dory. Also have a Reaction PR that adds pagination to 'Artists' tab.