### PR TITLE
Update SearchableItemPresenter to use new type

### DIFF
--- a/src/schema/SearchableItem/SearchItemRawResponse.ts
+++ b/src/schema/SearchableItem/SearchItemRawResponse.ts
@@ -1,0 +1,14 @@
+export type SearchItemRawResponse = {
+  description: string
+  display: string
+  end_at: string
+  href: string
+  id: string
+  label: string
+  location: string
+  model: string
+  owner_type: string
+  profile_id: string
+  published_at: string
+  start_at: string
+}

--- a/src/schema/SearchableItem/SearchableItemPresenter.ts
+++ b/src/schema/SearchableItem/SearchableItemPresenter.ts
@@ -1,10 +1,11 @@
 import moment from "moment"
 import { stripTags } from "lib/helpers"
+import { SearchItemRawResponse } from "./SearchItemRawResponse"
 
 const DATE_FORMAT = "MMM Do, YYYY"
 
 export class SearchableItemPresenter {
-  private item: any
+  private item: SearchItemRawResponse
 
   constructor(item: any) {
     this.item = item


### PR DESCRIPTION
Define a `SearchItemRawResponse` type for objects returned from gravity and use instead of `any`.