### PR TITLE
Add SearchableItem description formatting for PartnerShow entity type

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -8261,7 +8261,8 @@ type SearchableItem implements Node & Searchable {
   displayLabel: String
   imageUrl: String
   href: String
-  searchableType: String
+  searchableType: String @deprecated(reason: "Switch to use `displayType`")
+  displayType: String
 }
 
 enum SearchAggregation {

--- a/src/schema/SearchableItem/SearchItemRawResponse.ts
+++ b/src/schema/SearchableItem/SearchItemRawResponse.ts
@@ -2,6 +2,7 @@ export type SearchItemRawResponse = {
   description: string
   display: string
   end_at: string
+  fair_id: string
   href: string
   id: string
   label: string

--- a/src/schema/SearchableItem/SearchItemRawResponse.ts
+++ b/src/schema/SearchableItem/SearchItemRawResponse.ts
@@ -11,4 +11,6 @@ export type SearchItemRawResponse = {
   profile_id: string
   published_at: string
   start_at: string
+  artist_names: string[]
+  venue: string
 }

--- a/src/schema/SearchableItem/SearchableItemPresenter.ts
+++ b/src/schema/SearchableItem/SearchableItemPresenter.ts
@@ -15,7 +15,7 @@ export class SearchableItemPresenter {
   formattedDescription(): string | undefined {
     const { description, display } = this.item
 
-    switch (this.searchableType()) {
+    switch (this.displayType()) {
       case "Article":
         return this.formattedArticleDescription()
       case "Fair":
@@ -27,7 +27,8 @@ export class SearchableItemPresenter {
       case "Gallery":
       case "Page":
         return description
-      case "PartnerShow":
+      case "Booth":
+      case "Show":
         return this.formattedShowDescription()
       case "City":
         return `Browse current exhibitions in ${display}`
@@ -53,13 +54,16 @@ export class SearchableItemPresenter {
         return `/shows/${id}`
       case "MarketingCollection":
         return `/collection/${id}`
+      case "Booth":
+      case "PartnerShow":
+        return `/show/${id}`
       default:
         return `/${model}/${id}`
     }
   }
 
-  searchableType(): string {
-    const { label, owner_type } = this.item
+  displayType(): string {
+    const { fair_id, label, owner_type } = this.item
 
     switch (label) {
       case "Profile":
@@ -81,6 +85,8 @@ export class SearchableItemPresenter {
       // in the special `match` JSON returned from the Gravity API.
       case "Sale":
         return "Auction"
+      case "PartnerShow":
+        return fair_id ? "Booth" : "Show"
       case "MarketingCollection":
         return "Collection"
       default:

--- a/src/schema/SearchableItem/SearchableItemPresenter.ts
+++ b/src/schema/SearchableItem/SearchableItemPresenter.ts
@@ -159,10 +159,10 @@ export class SearchableItemPresenter {
   }
 
   private formattedLeadHeading(): string {
-    const { start_at, end_at } = this.item
+    const { fair_id, start_at, end_at } = this.item
 
     if (!start_at || !end_at) {
-      return "Show"
+      return fair_id ? "Fair booth" : "Show"
     }
 
     const now = moment.utc()
@@ -181,7 +181,9 @@ export class SearchableItemPresenter {
       statusLabel = "Current"
     }
 
-    return `${statusLabel} show`
+    const type = fair_id ? "fair booth" : "show"
+
+    return `${statusLabel} ${type}`
   }
 
   private formattedRunningTime(): string | null {

--- a/src/schema/SearchableItem/__tests__/SearchableItemPresenter.test.ts
+++ b/src/schema/SearchableItem/__tests__/SearchableItemPresenter.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable promise/always-return */
 import { SearchableItemPresenter } from "../SearchableItemPresenter"
+import * as moment from "moment"
 
 describe("SearchableItemPresenter", () => {
   describe("#formattedDescription", () => {
@@ -72,7 +73,7 @@ describe("SearchableItemPresenter", () => {
       })
     })
 
-    describe("for a Fair or Sale types", () => {
+    describe("for a Fair or Auction types", () => {
       const buildSearchableItem = label => {
         return {
           start_at: "2018-05-16T11:28:00.000Z",
@@ -89,7 +90,7 @@ describe("SearchableItemPresenter", () => {
           "Art fair running from May 16th, 2018 to May 30th, 2018"
         )
 
-        presenter = new SearchableItemPresenter(buildSearchableItem("Sale"))
+        presenter = new SearchableItemPresenter(buildSearchableItem("Auction"))
         description = presenter.formattedDescription()
 
         expect(description).toBe(
@@ -136,6 +137,98 @@ describe("SearchableItemPresenter", () => {
         expect(description).toBe(
           "Brian Donnelly, better known as KAWS, spent the first year of his career as an animator for Disney."
         )
+      })
+    })
+
+    describe("for a PartnerShow type", () => {
+      it("returns a formatted description for a past show", () => {
+        const searchableItem = {
+          start_at: "2018-03-26T12:00:00.000Z",
+          end_at: "2018-05-19T12:00:00.000Z",
+          label: "PartnerShow",
+          artist_names: ["KAWS"],
+          venue: "Yorkshire Sculpture Park",
+        }
+
+        const presenter = new SearchableItemPresenter(searchableItem)
+        const description = presenter.formattedDescription()
+        expect(description).toBe(
+          "Past show featuring works by KAWS at Yorkshire Sculpture Park Mar 26th – May 19th 2018"
+        )
+      })
+
+      it("returns a formatted description for a current show", () => {
+        const now = moment.utc()
+
+        const searchableItem = {
+          start_at: now.valueOf(),
+          end_at: now.add(1, "week").valueOf(),
+          label: "PartnerShow",
+          artist_names: ["KAWS"],
+          venue: "Yorkshire Sculpture Park",
+        }
+
+        const presenter = new SearchableItemPresenter(searchableItem)
+        const description = presenter.formattedDescription()
+        expect(description).toMatch(
+          "Current show featuring works by KAWS at Yorkshire Sculpture Park"
+        )
+      })
+
+      it("returns a formatted description for an upcoming show", () => {
+        const now = moment.utc()
+
+        const searchableItem = {
+          start_at: now.add(1, "day").valueOf(),
+          end_at: now.add(1, "week").valueOf(),
+          label: "PartnerShow",
+          artist_names: ["KAWS"],
+          venue: "Yorkshire Sculpture Park",
+        }
+
+        const presenter = new SearchableItemPresenter(searchableItem)
+        const description = presenter.formattedDescription()
+        expect(description).toMatch(
+          "Upcoming show featuring works by KAWS at Yorkshire Sculpture Park"
+        )
+      })
+
+      it("returns a formatted description with multiple artists", () => {
+        let searchableItem = {
+          label: "PartnerShow",
+          artist_names: ["KAWS", "Andy Warhol"],
+          venue: "Yorkshire Sculpture Park",
+        }
+
+        let presenter = new SearchableItemPresenter(searchableItem)
+        let description = presenter.formattedDescription()
+        expect(description).toBe(
+          "Show featuring works by KAWS and Andy Warhol at Yorkshire Sculpture Park"
+        )
+
+        searchableItem = {
+          label: "PartnerShow",
+          artist_names: ["KAWS", "Andy Warhol", "Ridley Howard"],
+          venue: "Yorkshire Sculpture Park",
+        }
+
+        presenter = new SearchableItemPresenter(searchableItem)
+        description = presenter.formattedDescription()
+        expect(description).toBe(
+          "Show featuring works by KAWS, Andy Warhol and Ridley Howard at Yorkshire Sculpture Park"
+        )
+      })
+
+      it("returns a formatted description with a location", () => {
+        const searchableItem = {
+          label: "PartnerShow",
+          artist_names: ["KAWS"],
+          location: "New York, NY",
+        }
+
+        const presenter = new SearchableItemPresenter(searchableItem)
+        const description = presenter.formattedDescription()
+        expect(description).toBe("Show featuring works by KAWS New York, NY")
       })
     })
   })

--- a/src/schema/SearchableItem/__tests__/SearchableItemPresenter.test.ts
+++ b/src/schema/SearchableItem/__tests__/SearchableItemPresenter.test.ts
@@ -175,6 +175,25 @@ describe("SearchableItemPresenter", () => {
         )
       })
 
+      it("returns a formatted description for a current fair booth", () => {
+        const now = moment.utc()
+
+        const searchableItem = {
+          start_at: now.valueOf(),
+          end_at: now.add(1, "week").valueOf(),
+          label: "PartnerShow",
+          artist_names: ["KAWS"],
+          venue: "Yorkshire Sculpture Park",
+          fair_id: "abc123",
+        }
+
+        const presenter = new SearchableItemPresenter(searchableItem)
+        const description = presenter.formattedDescription()
+        expect(description).toMatch(
+          "Current fair booth featuring works by KAWS at Yorkshire Sculpture Park"
+        )
+      })
+
       it("returns a formatted description for an upcoming show", () => {
         const now = moment.utc()
 
@@ -229,6 +248,21 @@ describe("SearchableItemPresenter", () => {
         const presenter = new SearchableItemPresenter(searchableItem)
         const description = presenter.formattedDescription()
         expect(description).toBe("Show featuring works by KAWS New York, NY")
+      })
+
+      it("returns a formatted description for a fair booth", () => {
+        const searchableItem = {
+          label: "PartnerShow",
+          artist_names: ["KAWS"],
+          location: "New York, NY",
+          fair_id: "abc123",
+        }
+
+        const presenter = new SearchableItemPresenter(searchableItem)
+        const description = presenter.formattedDescription()
+        expect(description).toBe(
+          "Fair booth featuring works by KAWS New York, NY"
+        )
       })
     })
   })

--- a/src/schema/SearchableItem/index.ts
+++ b/src/schema/SearchableItem/index.ts
@@ -37,7 +37,12 @@ export const SearchableItem = new GraphQLObjectType<any, ResolverContext>({
     },
     searchableType: {
       type: GraphQLString,
-      resolve: item => new SearchableItemPresenter(item).searchableType(),
+      deprecationReason: "Switch to use `displayType`",
+      resolve: item => new SearchableItemPresenter(item).displayType(),
+    },
+    displayType: {
+      type: GraphQLString,
+      resolve: item => new SearchableItemPresenter(item).displayType(),
     },
   },
 })


### PR DESCRIPTION
Use `start_at`, `end_at`, `venue`, `location`, and `artist_name` attributes of the search result item from Elasticsearch to generate a formatted description for `PartnerShow` entities.

ticket: https://artsyproduct.atlassian.net/browse/DISCO-867 :lock: 