### PR TITLE
Upstream schema checking

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,11 +22,13 @@
   },
   "typescript.tsdk": "./node_modules/typescript/lib",
   "cSpell.words": [
+    "API's",
     "Ecommerce",
     "Eigen",
     "Kubernetes",
     "Refetch",
     "Reloadable",
+    "SDLs",
     "consignable",
     "dataloader",
     "kaws",

--- a/peril/schemaValidatorUtils.ts
+++ b/peril/schemaValidatorUtils.ts
@@ -1,0 +1,53 @@
+import {
+  introspectionQuery,
+  buildClientSchema,
+  printSchema,
+  buildSchema,
+} from "graphql"
+
+// @ts-ignore (this is in the Peril runtime only)
+import { diff } from "@graphql-inspector/core"
+import fetch from "node-fetch"
+
+/**
+ * Grabs the Schema as SDL from a GraphQL url
+ * @param url The URL to grab the schema from
+ */
+export const downloadSchemaFromURL = async (url: string) => {
+  const postBody = {
+    query: introspectionQuery,
+    operationName: "IntrospectionQuery",
+  }
+
+  const response = await fetch(url, {
+    method: "POST",
+    body: JSON.stringify(postBody),
+    headers: {
+      "Content-Type": "application/json",
+    },
+  })
+  const { data } = await response.json()
+  // commentDescriptions is hidden
+  // @ts-ignore
+  return printSchema(buildClientSchema(data), { commentDescriptions: true })
+}
+
+/**
+ * Compares the SDLs and highlights whether there are changes from the version in MP
+ * and the version from upstream.
+ *
+ * @param localSchemaSDL The SDL from inside Metaphysics
+ * @param upstreamSchemaSDL The SDL from the external service
+ */
+export const getBreakingChanges = async (
+  localSchemaSDL: string,
+  upstreamSchemaSDL: string
+): Promise<string[]> => {
+  const allChanges = diff(
+    buildSchema(localSchemaSDL),
+    buildSchema(upstreamSchemaSDL)
+  )
+  const breakings = allChanges.filter(c => c.criticality.level === "BREAKING")
+  const messages = breakings.map(c => c.message)
+  return messages
+}

--- a/peril/upstreamSchemaValidator.ts
+++ b/peril/upstreamSchemaValidator.ts
@@ -1,0 +1,123 @@
+import { danger, warn, fail, markdown } from "danger"
+
+type EndPoints = {
+  [name: string]: {
+    production: string
+    staging: string
+    localSchemaPath: string
+    breakingChanges?: string[]
+  }
+}
+
+const serviceMap: EndPoints = {
+  kaws: {
+    production: "https://kaws.artsy.net/graphql",
+    // The http is on purpose here, probably a bug
+    staging: "http://kaws.artsy.net/graphql",
+    localSchemaPath: "src/data/kaws.graphql",
+  },
+  exchange: {
+    production: "https://exchange.artsy.net/api",
+    staging: "https://exchange-staging.artsy.net/api",
+    localSchemaPath: "src/data/exchange.graphql",
+  },
+  vortex: {
+    production: "https://vortex.artsy.net/api",
+    staging: "https://vortex-staging.artsy.net/api",
+    localSchemaPath: "src/data/vortex.graphql",
+  },
+  gravity: {
+    production: "https://api.artsy.net/api",
+    staging: "https://stagingapi.artsy.net/api",
+    localSchemaPath: "src/data/gravity.graphql",
+  },
+}
+
+export default async () => {
+  const allUpstreamGraphQLAPIs = Object.keys(serviceMap)
+
+  // This actually isn't possible right now, because MP doesn't do PR based
+  // deploys, but adding in anticipation of that maybe changing.
+  const isProductionDeployPR = false
+
+  // Find which APIs have corresponding, on a prod deploy we would
+  // want to check every service.
+  const servicesWhichAreChangedInThisPR = allUpstreamGraphQLAPIs.filter(
+    service =>
+      isProductionDeployPR ||
+      danger.git.modified_files.includes(serviceMap[service].localSchemaPath)
+  )
+
+  // Bail because there's no work to do
+  if (servicesWhichAreChangedInThisPR.length == 0) {
+    console.log("No GraphQL schemas changed in this PR. Skipping checks.")
+    return
+  }
+
+  // Wait till we know we have to do work before actually importing helpers
+  const {
+    downloadSchemaFromURL,
+    getBreakingChanges,
+  } = await import("./schemaValidatorUtils")
+
+  // This is a separate set of the endpoints with breaking changes
+  const servicesWithBreakingChanges: EndPoints = {}
+
+  // Loop through each API which changed, grab their new schema from
+  // the metaphysics repo then compare it to their API's schema
+  for (const serviceName of servicesWhichAreChangedInThisPR) {
+    const service = serviceMap[serviceName]
+    const localSchema = await danger.github.utils.fileContents(
+      service.localSchemaPath
+    )
+
+    const endpoint = isProductionDeployPR ? service.production : service.staging
+    const upstreamSchema = await downloadSchemaFromURL(endpoint)
+
+    const breakingChanges = await getBreakingChanges(
+      localSchema,
+      upstreamSchema
+    )
+
+    // Create a new copy of the service, with the breaking changes added
+    if (breakingChanges.length) {
+      servicesWithBreakingChanges[serviceName] = {
+        ...service,
+        breakingChanges,
+      }
+    }
+  }
+
+  // Reporting back to the PR - offer a single message for all of the potentially
+  // failed services,
+  const failedServiceNames = Object.keys(servicesWithBreakingChanges)
+  const failedServicesSentence = danger.utils.sentence(failedServiceNames)
+
+  if (failedServiceNames.length === 0) {
+    console.log(`No breaking changes for ${failedServicesSentence}`)
+    return
+  }
+
+  const version = isProductionDeployPR ? "staging" : "production"
+  const message = isProductionDeployPR ? fail : warn
+  const s = failedServiceNames.length === 1 ? "" : "s"
+  const are = failedServiceNames.length === 1 ? "is" : "are"
+
+  message(`
+    There ${are} a breaking difference${s} between the **${version}** deployed 
+    schema${s} for **${failedServiceNames}**. 
+    
+    The changes you have made  to the local schema${s} in metaphysics are 
+    relying on the deployment of the  upstream service${s}. You should deploy 
+    those changes.
+    `)
+
+  for (const serviceName of failedServiceNames) {
+    const service = servicesWithBreakingChanges[serviceName]
+    const url = isProductionDeployPR ? service.staging : service.production
+
+    markdown(`### <a href='${url}'>${serviceName}</a>
+${service.breakingChanges!.join("\n - ")}
+      `)
+  }
+}

--- a/src/integration/__tests__/runStoredQueryTests.ts
+++ b/src/integration/__tests__/runStoredQueryTests.ts
@@ -54,7 +54,7 @@ const variablesLookup = {
   },
 }
 
-// These are queries that should be skipped, becuase they are known to fail with
+// These are queries that should be skipped, because they are known to fail with
 // the current schema (and presumably for good reasons).
 const KnownToFail = [
   "e3c3792bba0779073c8650e4dc8e9112",


### PR DESCRIPTION
Adds a way for us to validate that a PR changing any `schema.graphql`s have been updated.

What it does is:

- There is a map of services to their prod/staging endpoints
- We see if any of the PRs modified files include the schemas for those endpoints
- If they do then compare the fs copy of the schema SDL in Metaphysics to the prod/staging SDL in the API
- Then do a breaking change check for all those schemas
- If anything is broken then fail/warn on the PR

What this can't do:

- Deploys are still done on a person's computer, so it can't do production check. If we moved to PR based deploys for MP, then it would check _all_ schemas to ensure no breaking changes between prod and the versions in the fs.

Could be a good reason to move to PR deploys.