### PR TITLE
Use custom date resolver for partner show events

### DIFF
--- a/src/schema/__tests__/partner_show_events.test.ts
+++ b/src/schema/__tests__/partner_show_events.test.ts
@@ -75,10 +75,10 @@ describe("date resolving", () => {
     })
   })
 
-  describe("with Eigen 4.x", () => {
+  describe("with Eigen 4.4.x", () => {
     it("truncates the UTC offset", async () => {
       context.userAgent =
-        "Mozilla/5.0 Artsy-Mobile/4.3.3 Eigen/2018.11.09.15/4.3.3 (iPhone; iOS 12.1.4; Scale/3.00) AppleWebKit/601.1.46 (KHTML, like Gecko); Metaphysics"
+        "iPhone9,1 Mozilla/5.0 Artsy-Mobile/4.4.1 Eigen/2019.03.15.11/4.4.1 (iPhone; iOS 12.1.4; Scale/2.00) AppleWebKit/601.1.46 (KHTML, like Gecko)"
 
       const data = await runQuery(query, context)
       expect(data).toEqual({

--- a/src/schema/__tests__/partner_show_events.test.ts
+++ b/src/schema/__tests__/partner_show_events.test.ts
@@ -132,7 +132,7 @@ describe("date resolving", () => {
     })
   })
 
-  describe("if user agent is returned as an array", () => {
+  describe("When an Eigen user agent is returned as part of an array", () => {
     it("truncates the UTC offset", async () => {
       context.userAgent = [
         "x86_64 Mozilla/5.0 Artsy-Mobile/5.0.1 Eigen/2019.02.28.17/5.0.1 (iPhone; iOS 12.2; Scale/2.00) AppleWebKit/60 1.1.46 (KHTML, like Gecko)",

--- a/src/schema/__tests__/partner_show_events.test.ts
+++ b/src/schema/__tests__/partner_show_events.test.ts
@@ -1,0 +1,154 @@
+import { runQuery } from "test/utils"
+import gql from "lib/gql"
+import moment from "moment"
+import { ResolverContext } from "types/graphql"
+
+// This time-bomb spec will fail starting at some defined point in the future,
+// indicating that we should consider reverting this behavior of sending
+// different raw date representations to different versions of Eigen
+// (in the hope that usage of older versions has dropped below some minimum threshold).
+
+it("is not yet time to rethink this UA-sniffing behavior for resolving dates", () => {
+  const today = moment()
+  const deadline = moment("2020-10-01") // about 18 months after adding this behavior
+
+  let itIsTimeToRethinkThis = today.isAfter(deadline)
+
+  expect(itIsTimeToRethinkThis).toBe(false)
+})
+
+// In the meantime, here is the custom date resolving behavior
+
+describe("date resolving", () => {
+  const showData = {
+    id: "helwaser-gallery-anton-ginzburg-views",
+    displayable: true,
+    partner: {
+      id: "helwaser-gallery",
+    },
+    events: [
+      {
+        event_type: "Opening Reception",
+        start_at: "2019-03-28T18:00:00+00:00",
+        end_at: "2019-03-28T21:00:00+00:00",
+      },
+    ],
+  }
+
+  const mockLoader = jest.fn(() => Promise.resolve(showData))
+
+  const query = gql`
+    {
+      show(id: "helwaser-gallery-anton-ginzburg-views") {
+        events {
+          start_at
+          end_at
+        }
+      }
+    }
+  `
+
+  let context: Partial<ResolverContext>
+
+  beforeEach(() => {
+    context = {
+      showLoader: mockLoader,
+      partnerShowLoader: mockLoader,
+    }
+  })
+
+  describe("default behavior", () => {
+    it("returns dates with UTC offset", async () => {
+      context.userAgent = "some browser"
+
+      const data = await runQuery(query, context)
+      expect(data).toEqual({
+        show: {
+          events: [
+            {
+              end_at: "2019-03-28T21:00:00+00:00",
+              start_at: "2019-03-28T18:00:00+00:00",
+            },
+          ],
+        },
+      })
+    })
+  })
+
+  describe("with Eigen 4.x", () => {
+    it("truncates the UTC offset", async () => {
+      context.userAgent =
+        "Mozilla/5.0 Artsy-Mobile/4.3.3 Eigen/2018.11.09.15/4.3.3 (iPhone; iOS 12.1.4; Scale/3.00) AppleWebKit/601.1.46 (KHTML, like Gecko); Metaphysics"
+
+      const data = await runQuery(query, context)
+      expect(data).toEqual({
+        show: {
+          events: [
+            {
+              end_at: "2019-03-28T21:00:00",
+              start_at: "2019-03-28T18:00:00",
+            },
+          ],
+        },
+      })
+    })
+  })
+
+  describe("with Eigen 5.0.0", () => {
+    it("truncates the UTC offset", async () => {
+      context.userAgent =
+        "iPhone11,6 Mozilla/5.0 Artsy-Mobile/5.0.0 Eigen/2019.03.20.14/5.0.0 (iPhone; iOS 12.1.4; Scale/3.00) AppleWebKit/601.1.46 (KHTML, like Gecko)"
+
+      const data = await runQuery(query, context)
+      expect(data).toEqual({
+        show: {
+          events: [
+            {
+              end_at: "2019-03-28T21:00:00",
+              start_at: "2019-03-28T18:00:00",
+            },
+          ],
+        },
+      })
+    })
+  })
+
+  describe("with Eigen 5.0.1", () => {
+    it("truncates the UTC offset", async () => {
+      context.userAgent =
+        "x86_64 Mozilla/5.0 Artsy-Mobile/5.0.1 Eigen/2019.02.28.17/5.0.1 (iPhone; iOS 12.2; Scale/2.00) AppleWebKit/60 1.1.46 (KHTML, like Gecko)"
+
+      const data = await runQuery(query, context)
+      expect(data).toEqual({
+        show: {
+          events: [
+            {
+              end_at: "2019-03-28T21:00:00",
+              start_at: "2019-03-28T18:00:00",
+            },
+          ],
+        },
+      })
+    })
+  })
+
+  describe("if user agent is returned as an array", () => {
+    it("truncates the UTC offset", async () => {
+      context.userAgent = [
+        "x86_64 Mozilla/5.0 Artsy-Mobile/5.0.1 Eigen/2019.02.28.17/5.0.1 (iPhone; iOS 12.2; Scale/2.00) AppleWebKit/60 1.1.46 (KHTML, like Gecko)",
+      ]
+
+      const data = await runQuery(query, context)
+      expect(data).toEqual({
+        show: {
+          events: [
+            {
+              end_at: "2019-03-28T21:00:00",
+              start_at: "2019-03-28T18:00:00",
+            },
+          ],
+        },
+      })
+    })
+  })
+})

--- a/src/schema/partner_show_event.ts
+++ b/src/schema/partner_show_event.ts
@@ -3,12 +3,12 @@ import { GraphQLString, GraphQLObjectType, GraphQLFieldConfig } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { exhibitionPeriod } from "lib/date"
 
-const hasOldEmissionUserAgentString = (userAgent): boolean =>
+const hasOldEmissionUserAgentString = (userAgent: string | string[]): boolean =>
   userAgent!.indexOf("Artsy-Mobile/4") > 0 ||
   userAgent!.indexOf("Artsy-Mobile/5.0.0") > 0 ||
   userAgent!.indexOf("Artsy-Mobile/5.0.1") > 0
 
-const isOlderEmissionVersion = (userAgent): boolean => {
+const isOlderEmissionVersion = (userAgent: string | string[]): boolean => {
   let result = false
   if (typeof userAgent === "string") {
     result = hasOldEmissionUserAgentString(userAgent)

--- a/src/schema/partner_show_event.ts
+++ b/src/schema/partner_show_event.ts
@@ -4,7 +4,7 @@ import { ResolverContext } from "types/graphql"
 import { exhibitionPeriod } from "lib/date"
 
 const hasOldEmissionUserAgentString = (userAgent: string | string[]): boolean =>
-  userAgent!.indexOf("Artsy-Mobile/4") > 0 ||
+  userAgent!.indexOf("Artsy-Mobile/4.4") > 0 ||
   userAgent!.indexOf("Artsy-Mobile/5.0.0") > 0 ||
   userAgent!.indexOf("Artsy-Mobile/5.0.1") > 0
 

--- a/src/schema/partner_show_event.ts
+++ b/src/schema/partner_show_event.ts
@@ -3,7 +3,7 @@ import { GraphQLString, GraphQLObjectType, GraphQLFieldConfig } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { exhibitionPeriod } from "lib/date"
 
-const checkUserAgent = (userAgent): boolean =>
+const hasOldEmissionUserAgentString = (userAgent): boolean =>
   userAgent!.indexOf("Artsy-Mobile/4") > 0 ||
   userAgent!.indexOf("Artsy-Mobile/5.0.0") > 0 ||
   userAgent!.indexOf("Artsy-Mobile/5.0.1") > 0
@@ -11,9 +11,9 @@ const checkUserAgent = (userAgent): boolean =>
 const isOlderEmissionVersion = (userAgent): boolean => {
   let result = false
   if (typeof userAgent === "string") {
-    result = checkUserAgent(userAgent)
+    result = hasOldEmissionUserAgentString(userAgent)
   } else if (Array.isArray(userAgent)) {
-    result = userAgent.some(ua => checkUserAgent(ua))
+    result = userAgent.some(ua => hasOldEmissionUserAgentString(ua))
   }
   return result
 }

--- a/src/schema/partner_show_event.ts
+++ b/src/schema/partner_show_event.ts
@@ -13,7 +13,7 @@ const isOlderEmissionVersion = (userAgent): boolean => {
   if (typeof userAgent === "string") {
     result = hasOldEmissionUserAgentString(userAgent)
   } else if (Array.isArray(userAgent)) {
-    result = userAgent.some(ua => hasOldEmissionUserAgentString(ua))
+    result = userAgent.some(hasOldEmissionUserAgentString)
   }
   return result
 }
@@ -32,7 +32,7 @@ const dateFieldForPartnerShowEvent: GraphQLFieldConfig<
     const rawDate = obj[fieldName]
 
     if (userAgent && isOlderEmissionVersion(userAgent)) {
-      const dateWithoutOffset = rawDate.replace(/[-+]\d\d:\d\d$/g, "")
+      const dateWithoutOffset = rawDate.replace(/[-+]\d\d:\d\d$/, "")
       return dateWithoutOffset
     }
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/LD-561

@kierangillen and I have been pairing on this fix for incorrect times displaying in City Guide for partner show events.

Currently datetimes for `PartnerShowEvents` — e.g. opening receptions, artist talks, and other one-off events that are associated with a show — are sent from CMS to Gravity without timezone information, and these get stored in the db as having a UTC offset of +00:00. They are returned this way over the wire as well by MP:

```graphql
{
  "data": {
    "show": {
      "id": "helwaser-gallery-anton-ginzburg-views",
      "events": [
        {
          "start_at": "2019-03-28T18:00:00+00:00",
          "end_at": "2019-03-28T21:00:00+00:00"
        },
        {
          "start_at": "2019-04-13T14:00:00+00:00",
          "end_at": "2019-04-13T16:00:00+00:00"
        }
      ]
    }
  }
}
```

Previously other clients [have treated](https://github.com/artsy/force/blob/33ece666e9df1cf32f9c6cbe7914811815a860cc/src/desktop/apps/show/helpers/view_helpers.coffee#L11-L12) these ambiguous datetimes by parsing them with `moment.utc(someDate)` so that e.g. **6pm** in means **6pm** out, regardless of the user's or event's timezone.

The first versions of Eigen that contain ~City Guide~ the new Show screens parse these fields with `moment`, which causes them to be parsed and displayed as local times in the user's timezone, so for the example in the ticket **6pm** becomes **2pm**.

In order to fix this display issue for current versions of Eigen that are _already_ out in the wild, we introduced a custom date field resolver here  — based on the shared one currently in use across MP — that does some user-agent sniffing and returns a modified version of these partner show event datetimes to selected versions of Eigen.

So `2019-03-28T18:00:00+00:00` has its offset stripped out and becomes `2019-03-28T18:00:00`, which will force it to display without timezone conversion, just as if it had been parsed with `moment.utc`.

This fixes the pressing issue with incorrect event times being displayed to users, but note that we have deferred a longer-term fix at the level of the Gravity/CMS or other admin apps; as well as updates to clients that rely on `moment`.