### PR TITLE
Make sure that we're comparing timestamps in the same zone

### DIFF
--- a/src/schema/SearchableItem/SearchableItemPresenter.ts
+++ b/src/schema/SearchableItem/SearchableItemPresenter.ts
@@ -172,8 +172,8 @@ export class SearchableItemPresenter {
     }
 
     const now = moment.utc()
-    const startAt = moment(start_at)
-    const endAt = moment(end_at)
+    const startAt = moment.utc(start_at)
+    const endAt = moment.utc(end_at)
 
     const startDiff = startAt.diff(now, "days")
     const endDiff = endAt.diff(now, "days")


### PR DESCRIPTION
When building up the description for shows and fair booth search result items, make sure that we're comparing moment timestamps within the same UTC zone.

Should address this flickering spec: https://circleci.com/gh/artsy/metaphysics/4712