### PR TITLE
Fake an upstream GraphQL change to valdiate schema changing

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -5348,6 +5348,10 @@ type MarketingCollectionQuery {
 
 scalar MarketingDateTime
 
+type MarketingNewTypeAddedByMeThatIsntUpstream {
+  name: String!
+}
+
 type Me implements Node {
   # A globally unique ID.
   __id: ID!

--- a/src/data/kaws.graphql
+++ b/src/data/kaws.graphql
@@ -43,6 +43,10 @@ type CollectionCategory {
   collections: [Collection!]!
 }
 
+type NewTypeAddedByMeThatIsntUpstream {
+  name: String!
+}
+
 type CollectionQuery {
   id: ID
   acquireable: Boolean


### PR DESCRIPTION
This PR adds a type that doesn't exist inside the Kaws schema, so it would be classed as missing from the staging schema. This should trigger a peril run which will validate the local data against that schema, which should present a warning.

<!-- 41234430-56f4-11e9-9ad1-4f03bcdb080b -->