### PR TITLE
Restore handling of null page number in search resolver

### DIFF
--- a/src/schema/search/SearchResolver.ts
+++ b/src/schema/search/SearchResolver.ts
@@ -88,6 +88,10 @@ export class SearchResolver {
   }
 
   resolve() {
+    if (!this.args.page) {
+      delete this.args.page
+    }
+
     const pageOptions = convertConnectionArgsToGravityArgs(this.args)
     if (!!this.args.page) pageOptions.page = this.args.page
     const { page, size, offset, ...rest } = pageOptions


### PR DESCRIPTION
This was accidentally left out during a recent change:

https://github.com/artsy/metaphysics/pull/1643/files#r272283282