### PR TITLE
Pin comparison date to start of day

### DIFF
--- a/src/schema/SearchableItem/SearchableItemPresenter.ts
+++ b/src/schema/SearchableItem/SearchableItemPresenter.ts
@@ -179,7 +179,7 @@ export class SearchableItemPresenter {
       return fair_id ? "Fair booth" : "Show"
     }
 
-    const now = moment.utc()
+    const now = moment.utc().startOf("day")
     const startAt = moment.utc(start_at)
     const endAt = moment.utc(end_at)
 


### PR DESCRIPTION
Compare now, at the beginning of the day, with show / fair booth start/end timestamps.