### PR TITLE
Partner operator shouldn't be able to access another partner's auctions

### DIFF
--- a/src/schema/__tests__/causality_jwt.test.js
+++ b/src/schema/__tests__/causality_jwt.test.js
@@ -127,7 +127,7 @@ describe("CausalityJWT", () => {
     })
   })
 
-  it("does not allow a non-admin user or user not associated with sale partner to be operator", () => {
+  it("does not allow a non-admin user to be operator", () => {
     expect.assertions(1)
 
     const query = `{
@@ -139,6 +139,28 @@ describe("CausalityJWT", () => {
         partner: undefined, // in production partner is undefined when user is not an admin or a partner
       })
     )
+
+    return runAuthenticatedQuery(query, context).catch(e => {
+      expect(e.message).toEqual("Unauthorized to be operator")
+    })
+  })
+
+  it("does not allow a user not associated with sale partner to be operator", () => {
+    expect.assertions(1)
+
+    const query = `{
+      causality_jwt(role: OPERATOR, sale_id: "foo")
+    }`
+
+    context.saleLoader = sinon.stub().returns(
+      Promise.resolve({
+        ...sale,
+        partner: {
+          _id: "partner-id",
+        },
+      })
+    )
+    context.mePartnersLoader = sinon.stub().returns(Promise.resolve([]))
 
     return runAuthenticatedQuery(query, context).catch(e => {
       expect(e.message).toEqual("Unauthorized to be operator")

--- a/src/schema/causality_jwt.ts
+++ b/src/schema/causality_jwt.ts
@@ -102,7 +102,12 @@ const CausalityJWT: GraphQLFieldConfig<void, ResolverContext> = {
 
           if (sale.partner) {
             return mePartnersLoader({ "partner_ids[]": sale.partner._id }).then(
-              () => {
+              mePartners => {
+                // Check if current user has access to partner running the sale
+                if (mePartners.length === 0) {
+                  throw new Error("Unauthorized to be operator")
+                }
+
                 return jwt.encode(
                   {
                     aud: "auctions",


### PR DESCRIPTION
fixes https://artsyproduct.atlassian.net/browse/AUCT-313

The check that got removed in this commit: https://github.com/artsy/metaphysics/commit/9e39a429e85052f54348986ddb7fb8a6356b7b13?w=1#diff-873fe1c7874f0eb5e4c8c9caed5efd90L105 should not have been removed. Because of the lack of the check any partner could open the Operator2 for any auction. This PR brings the check back to fix it.