### PR TITLE
Conditionally show histogram on artwork page

### DIFF
--- a/src/lib/stitching/vortex/stitching.ts
+++ b/src/lib/stitching/vortex/stitching.ts
@@ -63,21 +63,36 @@ export const vortexStitchingEnvironment = () => ({
               _id
             }
             category
+            is_for_sale
             is_price_hidden
+            is_in_auction
+            price_currency
+            artists {
+              _id
+            }
           }
         `,
         resolve: async (source, _, context, info) => {
           const {
+            artist,
+            artists,
+            category,
+            heightCm,
+            is_for_sale,
+            is_in_auction,
+            is_price_hidden,
+            price_currency,
             priceCents,
             widthCm,
-            heightCm,
-            artist,
-            category,
-            is_price_hidden,
           } = source
           // fail if we don't have enough info to request a histogram
+
           if (
             is_price_hidden ||
+            is_in_auction ||
+            price_currency !== "USD" ||
+            (artists && artists.length > 1) ||
+            !is_for_sale ||
             !priceCents ||
             !artist ||
             !widthCm ||


### PR DESCRIPTION
This PR updates our logic to hide the histogram in some more cases!

Current logic is:
- artwork is _not_ in an auction
- artwork has a visible price listed in USD (could be range or exact)
- artwork has 1 artist
- artwork is for sale
- artwork has a width/height
- artwork has a category (edited) 

Verified with these artworks:
- not for sale: andy-warhol-mao-102
- no height or width: andy-warhol-chateau-mouton-rothschild-premier-cru-classe-en-1975
- no category: andy-warhol-dollar-sign-yellow-fs-ii-dot-278
- non-USD: andy-warhol-heian-shrine-kyoto-japan
- multiple artists: andy-warhol-andy-warhol-and-jamie-wyeth-portraits-of-each-other-signed-by-both-wyeth-and-warhol
- no list price: andy-warhol-volkswagen
- hidden list price: andy-warhol-alexander-the-great-trial-proof-fs-iib-dot-291