### PR TITLE
Remove placeholder content from sponsored content fair activations

### DIFF
--- a/src/lib/sponsoredContent/data.json
+++ b/src/lib/sponsoredContent/data.json
@@ -72,18 +72,6 @@
     "art-basel-hong-kong-2019": {
       "activationText": "Hong Kong. From March 29 to 31, the Art Basel show in Hong Kong will open its doors offering again extensive insights into the modern and contemporary works by emerging and established artists, presented by 242 of the world’s leading galleries. As an official partner of the show, BMW will not only provide the VIP shuttle service, but also present the world’s first BMW Art Car (BMW 3.0 CSL, 1975), created by legendary artist Alexander Calder, in the BMW Lounge at the Hong Kong Convention and Exhibition Centre. Furthermore, the latest BMW Art Journey awardee Zac Langdon-Pole will be on-site documenting his journey and the next BMW Art Journey shortlist will be announced.",
       "pressReleaseUrl": "https://www.press.bmwgroup.com/global/article/detail/T0292765EN/bmw-is-official-partner-of-art-basel-in-hong-kong-2019-next-bmw-art-journey-shortlist-to-be-announced-and-bmw-art-car-1-by-alexander-calder-on-display"
-    },
-    "frieze-new-york-2019": {
-      "activationText": "In quis ex pariatur esse consectetur occaecat nulla quis consequat do in. Ipsum in cillum ut magna sunt proident. Ullamco culpa nisi commodo incididunt. Qui sunt consequat ullamco magna anim.",
-      "pressReleaseUrl": "https://www.example.com"
-    },
-    "frieze-london-2018": {
-      "activationText": "Dolore qui quis non ea dolore laboris ad aute reprehenderit irure. Deserunt veniam est nisi eu ipsum deserunt deserunt non in pariatur duis. Cillum tempor deserunt reprehenderit Lorem eiusmod. Tempor deserunt aute aliquip ea aliqua dolore adipisicing ut ad quis elit consectetur cupidatat. Et amet velit elit cillum. Anim elit minim excepteur duis cillum magna commodo amet id sit fugiat.",
-      "pressReleaseUrl": "https://www.example.com"
-    },
-    "paris-photo-2018": {
-      "activationText": "Occaecat dolor reprehenderit deserunt veniam nulla eu. Magna consequat commodo duis nulla fugiat elit velit consequat aute excepteur eiusmod nostrud tempor. Consequat consectetur nisi nostrud magna mollit velit ullamco sunt magna et mollit anim ea.",
-      "pressReleaseUrl": "https://www.example.com"
     }
   }
 }


### PR DESCRIPTION
This simply removes some dummy content to prevent it showing up in the iOS app.

#trivial