### PR TITLE
Adds new formatted date fields

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -8410,9 +8410,6 @@ type PartnerShowEventType {
     timezone: String
   ): String
 
-  # Returns true if dates are on same day
-  datesAreSameDay: Boolean
-
   # A formatted description of the dates with hours
   dateTimeRange: String
 

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -8410,6 +8410,12 @@ type PartnerShowEventType {
     timezone: String
   ): String
 
+  # Returns true if dates are on same day
+  datesAreSameDay: Boolean
+
+  # A formatted description of the dates with hours
+  datesWithHours: String
+
   # A formatted description of the start to end dates
   exhibitionPeriod: String
 }

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -8414,7 +8414,7 @@ type PartnerShowEventType {
   datesAreSameDay: Boolean
 
   # A formatted description of the dates with hours
-  datesWithHours: String
+  dateTimeRange: String
 
   # A formatted description of the start to end dates
   exhibitionPeriod: String

--- a/src/lib/__tests__/date.test.ts
+++ b/src/lib/__tests__/date.test.ts
@@ -226,7 +226,7 @@ describe("date formatting", () => {
         expect(period).toBe("Dec 5, 2019 from 8:00 – 10:00pm UTC")
       })
 
-      it("does not include year both dates are same day and the current year", () => {
+      it("does not include year when both dates are same day and the current year", () => {
         const period = dateTimeRange(
           "2018-12-05T20:00:00+00:00",
           "2018-12-05T22:00:00+00:00",

--- a/src/lib/__tests__/date.test.ts
+++ b/src/lib/__tests__/date.test.ts
@@ -17,7 +17,8 @@ describe("date formatting", () => {
     it("If within same am/pm only display one am or pm", () => {
       const period = timeRange(
         "2022-12-30T08:00:00+00:00",
-        "2022-12-30T10:00:00+00:00"
+        "2022-12-30T10:00:00+00:00",
+        "UTC"
       )
       expect(period).toBe("8:00 – 10:00am UTC")
     })
@@ -25,7 +26,8 @@ describe("date formatting", () => {
     it("If not within same am/pm show both time periods", () => {
       const period = timeRange(
         "2021-12-05T08:00:00+00:00",
-        "2022-12-30T17:00:00+00:00"
+        "2022-12-30T17:00:00+00:00",
+        "UTC"
       )
       expect(period).toBe("8:00am – 5:00pm UTC")
     })
@@ -44,7 +46,8 @@ describe("date formatting", () => {
     it("Dates are the same day returns true", () => {
       const period = datesAreSameDay(
         "2022-12-30T20:00:00+00:00",
-        "2022-12-30T17:00:00+00:00"
+        "2022-12-30T17:00:00+00:00",
+        "UTC"
       )
       expect(period).toBe(true)
     })
@@ -52,7 +55,8 @@ describe("date formatting", () => {
     it("Dates are not the same day returns false", () => {
       const period = datesAreSameDay(
         "2021-12-05T20:00:00+00:00",
-        "2022-12-30T17:00:00+00:00"
+        "2022-12-30T17:00:00+00:00",
+        "UTC"
       )
       expect(period).toBe(false)
     })
@@ -88,7 +92,8 @@ describe("date formatting", () => {
     it("Event opens in the future", () => {
       const period = formattedOpeningHours(
         "2021-12-05T20:00:00+00:00",
-        "2022-12-30T17:00:00+00:00"
+        "2022-12-30T17:00:00+00:00",
+        "UTC"
       )
       expect(period).toBe("Opens Dec 5 at 8:00pm UTC")
     })
@@ -96,7 +101,8 @@ describe("date formatting", () => {
     it("Event is running and closes in the future", () => {
       const period = formattedOpeningHours(
         "2017-12-05T20:00:00+00:00",
-        "2019-12-30T17:00:00+00:00"
+        "2019-12-30T17:00:00+00:00",
+        "UTC"
       )
       expect(period).toBe("Closes Dec 30 at 5:00pm UTC")
     })
@@ -104,7 +110,8 @@ describe("date formatting", () => {
     it("Event ended in the past and is closed", () => {
       const period = formattedOpeningHours(
         "2016-12-05T20:00:00+00:00",
-        "2016-12-30T17:00:00+00:00"
+        "2016-12-30T17:00:00+00:00",
+        "UTC"
       )
       expect(period).toBe("Closed")
     })
@@ -112,7 +119,7 @@ describe("date formatting", () => {
 
   describe(singleTime, () => {
     it("Return singleTime moment by the hour using default UTC timezone", () => {
-      const period = singleTime("2018-12-05T20:00:00+00:00")
+      const period = singleTime("2018-12-05T20:00:00+00:00", "UTC")
       expect(period).toBe("8:00pm UTC")
     })
 
@@ -132,12 +139,12 @@ describe("date formatting", () => {
     })
 
     it("Returns single date and time in this year", () => {
-      const period = singleDateTime("2018-12-05T20:00:00+00:00")
+      const period = singleDateTime("2018-12-05T20:00:00+00:00", "UTC")
       expect(period).toBe("Dec 5 at 8:00pm UTC")
     })
 
     it("Returns single date in different year from now", () => {
-      const period = singleDateTime("2021-12-05T20:00:00+00:00")
+      const period = singleDateTime("2021-12-05T20:00:00+00:00", "UTC")
       expect(period).toBe("Dec 5, 2021 at 8:00pm UTC")
     })
 
@@ -160,12 +167,12 @@ describe("date formatting", () => {
     })
 
     it("Returns single date in this year with day of week", () => {
-      const period = singleDate("2018-12-05T20:00:00+00:00")
+      const period = singleDate("2018-12-05T20:00:00+00:00", "UTC")
       expect(period).toBe("Wed, Dec 5")
     })
 
     it("Returns single date with day of week in different year from now", () => {
-      const period = singleDate("2021-12-05T20:00:00+00:00")
+      const period = singleDate("2021-12-05T20:00:00+00:00", "UTC")
       expect(period).toBe("Sun, Dec 5, 2021")
     })
   })
@@ -182,7 +189,8 @@ describe("date formatting", () => {
     it("Returns start and end datetimes with different years", () => {
       const period = dateTimeRange(
         "2021-12-05T20:00:00+00:00",
-        "2022-12-30T17:00:00+00:00"
+        "2022-12-30T17:00:00+00:00",
+        "UTC"
       )
       expect(period).toBe("Dec 5, 2021 at 8:00pm – Dec 30, 2022 at 5:00pm UTC")
     })
@@ -190,7 +198,8 @@ describe("date formatting", () => {
     it("Returns the start and end date with different year from now", () => {
       const period = dateTimeRange(
         "2040-12-05T20:00:00+00:00",
-        "2040-12-30T17:00:00+00:00"
+        "2040-12-30T17:00:00+00:00",
+        "UTC"
       )
       expect(period).toBe("Dec 5, 2040 at 8:00pm – Dec 30, 2040 at 5:00pm UTC")
     })
@@ -198,7 +207,8 @@ describe("date formatting", () => {
     it("Returns the start and end datetimes in current year", () => {
       const period = dateTimeRange(
         "2018-12-05T20:00:00+00:00",
-        "2018-12-30T17:00:00+00:00"
+        "2018-12-30T17:00:00+00:00",
+        "UTC"
       )
       expect(period).toBe("Dec 5 at 8:00pm – Dec 30 at 5:00pm UTC")
     })
@@ -206,7 +216,8 @@ describe("date formatting", () => {
     it("Returns single datetime in different year from now", () => {
       const period = dateTimeRange(
         "2019-12-05T20:00:00+00:00",
-        "2019-12-05T22:00:00+00:00"
+        "2019-12-05T22:00:00+00:00",
+        "UTC"
       )
       expect(period).toBe("Dec 5, 2019 from 8:00 – 10:00pm UTC")
     })
@@ -214,7 +225,8 @@ describe("date formatting", () => {
     it("Displays just date and time if dates are the same day and same year", () => {
       const period = dateTimeRange(
         "2018-12-05T20:00:00+00:00",
-        "2018-12-05T22:00:00+00:00"
+        "2018-12-05T22:00:00+00:00",
+        "UTC"
       )
       expect(period).toBe("Dec 5 from 8:00 – 10:00pm UTC")
     })
@@ -223,6 +235,7 @@ describe("date formatting", () => {
       const period = dateTimeRange(
         "2021-12-05T20:00:00+00:00",
         "2022-12-30T17:00:00+00:00",
+        "UTC",
         true
       )
       expect(period).toBe(
@@ -234,6 +247,7 @@ describe("date formatting", () => {
       const period = dateTimeRange(
         "2020-12-05T20:00:00+00:00",
         "2020-12-30T17:00:00+00:00",
+        "UTC",
         true
       )
       expect(period).toBe(
@@ -245,6 +259,7 @@ describe("date formatting", () => {
       const period = dateTimeRange(
         "2018-12-05T20:00:00+00:00",
         "2018-12-30T17:00:00+00:00",
+        "UTC",
         true
       )
       expect(period).toBe("Wed, Dec 5 at 8:00pm – Sun, Dec 30 at 5:00pm UTC")
@@ -254,6 +269,7 @@ describe("date formatting", () => {
       const period = dateTimeRange(
         "2019-12-05T20:00:00+00:00",
         "2019-12-05T22:00:00+00:00",
+        "UTC",
         true
       )
       expect(period).toBe("Thu, Dec 5, 2019 from 8:00 – 10:00pm UTC")
@@ -263,6 +279,7 @@ describe("date formatting", () => {
       const period = dateTimeRange(
         "2018-12-05T20:00:00+00:00",
         "2018-12-05T22:00:00+00:00",
+        "UTC",
         true
       )
       expect(period).toBe("Wed, Dec 5 from 8:00 – 10:00pm UTC")
@@ -272,8 +289,8 @@ describe("date formatting", () => {
       const period = dateTimeRange(
         "2018-12-05T20:00:00+00:00",
         "2018-12-05T22:00:00+00:00",
-        true,
-        "America/Costa_Rica"
+        "America/Costa_Rica",
+        true
       )
       expect(period).toBe("Wed, Dec 5 from 2:00 – 4:00pm CST")
     })
@@ -281,29 +298,46 @@ describe("date formatting", () => {
 
   describe(dateRange, () => {
     it("Returns date range with two different dates in two different years", () => {
-      const period = dateRange(moment("2011-01-01"), moment("2014-04-19"))
+      const period = dateRange(
+        moment("2011-01-01"),
+        moment("2014-04-19"),
+        "UTC"
+      )
       expect(period).toBe("Jan 1, 2011 – Apr 19, 2014")
     })
 
     it("Returns date range with different years and same month", () => {
-      const period = dateRange(moment("2011-01-01"), moment("2014-01-04"))
+      const period = dateRange(
+        moment("2011-01-01"),
+        moment("2014-01-04"),
+        "UTC"
+      )
       expect(period).toBe("Jan 1, 2011 – Jan 4, 2014")
     })
 
     it("Returns date range with that has same year for both dates, which displays only one year", () => {
-      const period = dateRange(moment("2011-01-01"), moment("2011-04-19"))
+      const period = dateRange(
+        moment("2011-01-01"),
+        moment("2011-04-19"),
+        "UTC"
+      )
       expect(period).toBe("Jan 1 – Apr 19, 2011")
     })
 
     it("Displays one month if the start and end dates have the same month", () => {
-      const period = dateRange(moment("2011-01-01"), moment("2011-01-19"))
+      const period = dateRange(
+        moment("2011-01-01"),
+        moment("2011-01-19"),
+        "UTC"
+      )
       expect(period).toBe("Jan 1 – 19, 2011")
     })
 
     it("If years are different always show both years", () => {
       const period = dateRange(
         moment("2011-01-01"),
-        moment().format("YYYY-04-19")
+        moment().format("YYYY-04-19"),
+        "UTC"
       )
       expect(period).toBe("Jan 1, 2011 – Apr 19, 2019")
     })
@@ -311,7 +345,8 @@ describe("date formatting", () => {
     it("If both dates are within the present year don't display a year", () => {
       const period = dateRange(
         moment().format("YYYY-01-01"),
-        moment().format("YYYY-01-19")
+        moment().format("YYYY-01-19"),
+        "UTC"
       )
       expect(period).toBe("Jan 1 – 19")
     })
@@ -332,24 +367,28 @@ describe("date formatting", () => {
       })
 
       it("states that an exhibition opens today", () => {
-        const status = exhibitionStatus(today, future)
+        const status = exhibitionStatus(today, future, "UTC")
         expect(status).toBe("Opening today")
       })
 
       it("states that an exhibition opens tomorrow", () => {
-        const status = exhibitionStatus(today.add(1, "d"), future)
+        const status = exhibitionStatus(today.add(1, "d"), future, "UTC")
         expect(status).toBe("Opening tomorrow")
       })
 
       it("states that an exhibition opens in a few days", () => {
         for (let days = 2; days <= 5; days++) {
-          const status = exhibitionStatus(today.clone().add(days, "d"), future)
+          const status = exhibitionStatus(
+            today.clone().add(days, "d"),
+            future,
+            "UTC"
+          )
           expect(status).toBe(`Opening in ${days} days`)
         }
       })
 
       it("returns nothing when it opens in more than a few days", () => {
-        const status = exhibitionStatus(today.add(6, "d"), future)
+        const status = exhibitionStatus(today.add(6, "d"), future, "UTC")
         expect(isNull(status)).toBe(true)
       })
     })
@@ -362,24 +401,28 @@ describe("date formatting", () => {
       })
 
       it("states that an exhibition will close today", () => {
-        const status = exhibitionStatus(past, today)
+        const status = exhibitionStatus(past, today, "UTC")
         expect(status).toBe("Closing today")
       })
 
       it("states that an exhibition will close tomorrow", () => {
-        const status = exhibitionStatus(past, today.add(1, "d"))
+        const status = exhibitionStatus(past, today.add(1, "d"), "UTC")
         expect(status).toBe("Closing tomorrow")
       })
 
       it("states that an exhibition is about to close in a few days", () => {
         for (let days = 2; days <= 5; days++) {
-          const status = exhibitionStatus(past, today.clone().add(days, "d"))
+          const status = exhibitionStatus(
+            past,
+            today.clone().add(days, "d"),
+            "UTC"
+          )
           expect(status).toBe(`Closing in ${days} days`)
         }
       })
 
       it("returns nothing when it closes in more than a few days", () => {
-        const status = exhibitionStatus(past, today.add(6, "d"))
+        const status = exhibitionStatus(past, today.add(6, "d"), "UTC")
         expect(isNull(status)).toBe(true)
       })
     })

--- a/src/lib/__tests__/date.test.ts
+++ b/src/lib/__tests__/date.test.ts
@@ -1,9 +1,241 @@
 import { isNull } from "lodash"
 import moment, { Moment } from "moment"
-import { exhibitionPeriod, exhibitionStatus } from "lib/date"
+import {
+  dateRange,
+  exhibitionStatus,
+  datesWithHours,
+  datesWithDaysAndHours,
+  singleDateWithoutHour,
+  singleDate,
+  singleHour,
+  formattedOpeningHours,
+  datesAreSameDay,
+  formattedHours,
+} from "lib/date"
 
-describe("date", () => {
-  describe("exhibitionPeriod", () => {
+describe("date formatting", () => {
+  describe("formattedHours", () => {
+    it("If within same am/pm", () => {
+      const period = formattedHours(
+        "2022-12-30T08:00:00+00:00",
+        "2022-12-30T10:00:00+00:00"
+      )
+      expect(period).toBe("8:00 – 10:00am")
+    })
+
+    it("If within across both am/pm", () => {
+      const period = formattedHours(
+        "2021-12-05T08:00:00+00:00",
+        "2022-12-30T17:00:00+00:00"
+      )
+      expect(period).toBe("8:00am – 5:00pm")
+    })
+  })
+
+  describe("datesAreSameDay", () => {
+    it("Dates are the same day", () => {
+      const period = datesAreSameDay(
+        "2022-12-30T20:00:00+00:00",
+        "2022-12-30T17:00:00+00:00"
+      )
+      expect(period).toBe(true)
+    })
+
+    it("Dates are not the same day", () => {
+      const period = datesAreSameDay(
+        "2021-12-05T20:00:00+00:00",
+        "2022-12-30T17:00:00+00:00"
+      )
+      expect(period).toBe(false)
+    })
+  })
+
+  describe("formattedOpeningHours", () => {
+    const realNow = Date.now
+    beforeEach(() => {
+      Date.now = () => new Date("2018-01-30T03:24:00") as any
+    })
+    afterEach(() => {
+      Date.now = realNow
+    })
+
+    it("Event opens in the future", () => {
+      const period = formattedOpeningHours(
+        "2021-12-05T20:00:00+00:00",
+        "2022-12-30T17:00:00+00:00"
+      )
+      expect(period).toBe("Opens Dec 5 at 8pm")
+    })
+
+    it("Event is running and closes in the future", () => {
+      const period = formattedOpeningHours(
+        "2017-12-05T20:00:00+00:00",
+        "2019-12-30T17:00:00+00:00"
+      )
+      expect(period).toBe("Closes Dec 30 at 5pm")
+    })
+
+    it("Event ended in the past and is closed", () => {
+      const period = formattedOpeningHours(
+        "2016-12-05T20:00:00+00:00",
+        "2016-12-30T17:00:00+00:00"
+      )
+      expect(period).toBe("Closed")
+    })
+  })
+
+  describe("singleHour", () => {
+    it("includes single date in this year", () => {
+      const period = singleHour("2018-12-05T20:00:00+00:00")
+      expect(period).toBe("8:00pm")
+    })
+  })
+
+  describe("singleDate", () => {
+    const realNow = Date.now
+    beforeEach(() => {
+      Date.now = () => new Date("2018-01-30T03:24:00") as any
+    })
+    afterEach(() => {
+      Date.now = realNow
+    })
+
+    it("includes single date in this year", () => {
+      const period = singleDate("2018-12-05T20:00:00+00:00")
+      expect(period).toBe("Dec 5 at 8:00pm")
+    })
+
+    it("includes single date in different year from now", () => {
+      const period = singleDate("2021-12-05T20:00:00+00:00")
+      expect(period).toBe("Dec 5, 2021 at 8:00pm")
+    })
+  })
+
+  describe("singleDateWithoutHour", () => {
+    const realNow = Date.now
+    beforeEach(() => {
+      Date.now = () => new Date("2018-01-30T03:24:00") as any
+    })
+    afterEach(() => {
+      Date.now = realNow
+    })
+
+    it("includes single date in this year", () => {
+      const period = singleDateWithoutHour("2018-12-05T20:00:00+00:00")
+      expect(period).toBe("Wed, Dec 5")
+    })
+
+    it("includes single date in different year from now", () => {
+      const period = singleDateWithoutHour("2021-12-05T20:00:00+00:00")
+      expect(period).toBe("Sun, Dec 5, 2021")
+    })
+  })
+
+  describe("datesWithHours", () => {
+    const realNow = Date.now
+    beforeEach(() => {
+      Date.now = () => new Date("2018-01-30T03:24:00") as any
+    })
+    afterEach(() => {
+      Date.now = realNow
+    })
+
+    it("includes the start and end date with different years", () => {
+      const period = datesWithHours(
+        "2021-12-05T20:00:00+00:00",
+        "2022-12-30T17:00:00+00:00"
+      )
+      expect(period).toBe("Dec 5, 2021 at 8:00pm – Dec 30, 2022 at 5:00pm")
+    })
+
+    it("includes the start and end date with different year from now", () => {
+      const period = datesWithHours(
+        "2020-12-05T20:00:00+00:00",
+        "2020-12-30T17:00:00+00:00"
+      )
+      expect(period).toBe("Dec 5, 2020 at 8:00pm – Dec 30, 2020 at 5:00pm")
+    })
+
+    it("includes the start and end date in current year", () => {
+      const period = datesWithHours(
+        "2018-12-05T20:00:00+00:00",
+        "2018-12-30T17:00:00+00:00"
+      )
+      expect(period).toBe("Dec 5 at 8:00pm – Dec 30 at 5:00pm")
+    })
+
+    it("date is same day in different year from now", () => {
+      const period = datesWithHours(
+        "2019-12-05T20:00:00+00:00",
+        "2019-12-05T22:00:00+00:00"
+      )
+      expect(period).toBe("Dec 5, 2019 from 8:00 – 10:00pm")
+    })
+
+    it("date is same day in same year as now", () => {
+      const period = datesWithHours(
+        "2018-12-05T20:00:00+00:00",
+        "2018-12-05T22:00:00+00:00"
+      )
+      expect(period).toBe("Dec 5 from 8:00 – 10:00pm")
+    })
+  })
+
+  describe("datesWithDaysAndHours", () => {
+    const realNow = Date.now
+    beforeEach(() => {
+      Date.now = () => new Date("2018-01-30T03:24:00") as any
+    })
+    afterEach(() => {
+      Date.now = realNow
+    })
+
+    it("includes the start and end date with different years", () => {
+      const period = datesWithDaysAndHours(
+        "2021-12-05T20:00:00+00:00",
+        "2022-12-30T17:00:00+00:00"
+      )
+      expect(period).toBe(
+        "Sun, Dec 5, 2021 at 8:00pm – Fri, Dec 30, 2022 at 5:00pm"
+      )
+    })
+
+    it("includes the start and end date with different year from now", () => {
+      const period = datesWithDaysAndHours(
+        "2020-12-05T20:00:00+00:00",
+        "2020-12-30T17:00:00+00:00"
+      )
+      expect(period).toBe(
+        "Sat, Dec 5, 2020 at 8:00pm – Wed, Dec 30, 2020 at 5:00pm"
+      )
+    })
+
+    it("includes the start and end date in current year", () => {
+      const period = datesWithDaysAndHours(
+        "2018-12-05T20:00:00+00:00",
+        "2018-12-30T17:00:00+00:00"
+      )
+      expect(period).toBe("Wed, Dec 5 at 8:00pm – Sun, Dec 30 at 5:00pm")
+    })
+
+    it("date is same day in different year from now", () => {
+      const period = datesWithDaysAndHours(
+        "2019-12-05T20:00:00+00:00",
+        "2019-12-05T22:00:00+00:00"
+      )
+      expect(period).toBe("Thu, Dec 5, 2019 from 8:00 – 10:00pm")
+    })
+
+    it("date is same day in same year as now", () => {
+      const period = datesWithDaysAndHours(
+        "2018-12-05T20:00:00+00:00",
+        "2018-12-05T22:00:00+00:00"
+      )
+      expect(period).toBe("Wed, Dec 5 from 8:00 – 10:00pm")
+    })
+  })
+
+  describe("dateRange", () => {
     it("includes the start and end date", () => {
       const period = exhibitionPeriod(
         moment("2011-01-01T00:00-0400"),
@@ -45,7 +277,7 @@ describe("date", () => {
     })
 
     it("does not include a year at all if both start and end date are in the current year", () => {
-      const period = exhibitionPeriod(
+      const period = dateRange(
         moment().format("YYYY-01-01"),
         moment().format("YYYY-01-19")
       )

--- a/src/lib/__tests__/date.test.ts
+++ b/src/lib/__tests__/date.test.ts
@@ -14,7 +14,7 @@ import {
 
 describe("date formatting", () => {
   describe(timeRange, () => {
-    it("If within same am/pm only display one am or pm", () => {
+    it("if within same am/pm only display one am or pm", () => {
       const period = timeRange(
         "2022-12-30T08:00:00+00:00",
         "2022-12-30T10:00:00+00:00",
@@ -23,7 +23,7 @@ describe("date formatting", () => {
       expect(period).toBe("8:00 – 10:00am UTC")
     })
 
-    it("If not within same am/pm show both time periods", () => {
+    it("if not within same am/pm show both time periods", () => {
       const period = timeRange(
         "2021-12-05T08:00:00+00:00",
         "2022-12-30T17:00:00+00:00",
@@ -32,7 +32,7 @@ describe("date formatting", () => {
       expect(period).toBe("8:00am – 5:00pm UTC")
     })
 
-    it("Displays timeRange with unique timezone", () => {
+    it("returns timeRange with a specific timezone", () => {
       const period = timeRange(
         "2021-12-05T08:00:00+00:00",
         "2022-12-30T17:00:00+00:00",
@@ -43,7 +43,7 @@ describe("date formatting", () => {
   })
 
   describe(datesAreSameDay, () => {
-    it("Dates are the same day returns true", () => {
+    it("if dates are the same day returns true", () => {
       const period = datesAreSameDay(
         "2022-12-30T20:00:00+00:00",
         "2022-12-30T17:00:00+00:00",
@@ -52,7 +52,7 @@ describe("date formatting", () => {
       expect(period).toBe(true)
     })
 
-    it("Dates are not the same day returns false", () => {
+    it("if dates are not the same day returns false", () => {
       const period = datesAreSameDay(
         "2021-12-05T20:00:00+00:00",
         "2022-12-30T17:00:00+00:00",
@@ -61,7 +61,7 @@ describe("date formatting", () => {
       expect(period).toBe(false)
     })
 
-    it("Dates are not the same day with timezone", () => {
+    it("if dates are not the same day with specific timezone", () => {
       const period = datesAreSameDay(
         "2021-12-05T20:00:00+00:00",
         "2022-12-30T17:00:00+00:00",
@@ -70,7 +70,7 @@ describe("date formatting", () => {
       expect(period).toBe(false)
     })
 
-    it("Dates are not the same day with timezone", () => {
+    it("if dates are not the same day with specific timezone", () => {
       const period = datesAreSameDay(
         "2021-12-05T20:00:00+00:00",
         "2022-12-30T17:00:00+00:00",
@@ -89,7 +89,7 @@ describe("date formatting", () => {
       Date.now = realNow
     })
 
-    it("Event opens in the future", () => {
+    it("includes 'Opens' when event opens in the future", () => {
       const period = formattedOpeningHours(
         "2021-12-05T20:00:00+00:00",
         "2022-12-30T17:00:00+00:00",
@@ -98,7 +98,7 @@ describe("date formatting", () => {
       expect(period).toBe("Opens Dec 5 at 8:00pm UTC")
     })
 
-    it("Event is running and closes in the future", () => {
+    it("includes 'closes' when event is running and closes in the future", () => {
       const period = formattedOpeningHours(
         "2017-12-05T20:00:00+00:00",
         "2019-12-30T17:00:00+00:00",
@@ -107,7 +107,7 @@ describe("date formatting", () => {
       expect(period).toBe("Closes Dec 30 at 5:00pm UTC")
     })
 
-    it("Event ended in the past and is closed", () => {
+    it("includes 'Closed' when event ended in the past and is closed", () => {
       const period = formattedOpeningHours(
         "2016-12-05T20:00:00+00:00",
         "2016-12-30T17:00:00+00:00",
@@ -118,12 +118,12 @@ describe("date formatting", () => {
   })
 
   describe(singleTime, () => {
-    it("Return singleTime moment by the hour using default UTC timezone", () => {
+    it("includes hour using default UTC timezone", () => {
       const period = singleTime("2018-12-05T20:00:00+00:00", "UTC")
       expect(period).toBe("8:00pm UTC")
     })
 
-    it("Return singleTime in EST timezone", () => {
+    it("also includes hour using specific timezone", () => {
       const period = singleTime("2018-12-05T20:00:00+00:00", "America/New_York")
       expect(period).toBe("3:00pm EST")
     })
@@ -138,17 +138,17 @@ describe("date formatting", () => {
       Date.now = realNow
     })
 
-    it("Returns single date and time in this year", () => {
+    it("includes only the month day and time for dates in the current year", () => {
       const period = singleDateTime("2018-12-05T20:00:00+00:00", "UTC")
       expect(period).toBe("Dec 5 at 8:00pm UTC")
     })
 
-    it("Returns single date in different year from now", () => {
+    it("also includes the year for dates in a different year from now", () => {
       const period = singleDateTime("2021-12-05T20:00:00+00:00", "UTC")
       expect(period).toBe("Dec 5, 2021 at 8:00pm UTC")
     })
 
-    it("Returns single date with timezone", () => {
+    it("returns the dates with a specific timezone", () => {
       const period = singleDateTime(
         "2021-12-05T20:00:00+00:00",
         "America/Costa_Rica"
@@ -166,12 +166,12 @@ describe("date formatting", () => {
       Date.now = realNow
     })
 
-    it("Returns single date in this year with day of week", () => {
+    it("includes single date with only day of week and month day when in current year", () => {
       const period = singleDate("2018-12-05T20:00:00+00:00", "UTC")
       expect(period).toBe("Wed, Dec 5")
     })
 
-    it("Returns single date with day of week in different year from now", () => {
+    it("also includes the year when not in current year", () => {
       const period = singleDate("2021-12-05T20:00:00+00:00", "UTC")
       expect(period).toBe("Sun, Dec 5, 2021")
     })
@@ -185,119 +185,126 @@ describe("date formatting", () => {
     afterEach(() => {
       Date.now = realNow
     })
+    describe("if displayDayOfWeek param is false (the default), does not include day of week", () => {
+      it("includes month day, hour, and both years when years are different", () => {
+        const period = dateTimeRange(
+          "2021-12-05T20:00:00+00:00",
+          "2022-12-30T17:00:00+00:00",
+          "UTC"
+        )
+        expect(period).toBe(
+          "Dec 5, 2021 at 8:00pm – Dec 30, 2022 at 5:00pm UTC"
+        )
+      })
 
-    it("Returns start and end datetimes with different years", () => {
-      const period = dateTimeRange(
-        "2021-12-05T20:00:00+00:00",
-        "2022-12-30T17:00:00+00:00",
-        "UTC"
-      )
-      expect(period).toBe("Dec 5, 2021 at 8:00pm – Dec 30, 2022 at 5:00pm UTC")
+      it("also includes both years when the years are not the present year", () => {
+        const period = dateTimeRange(
+          "2040-12-05T20:00:00+00:00",
+          "2040-12-30T17:00:00+00:00",
+          "UTC"
+        )
+        expect(period).toBe(
+          "Dec 5, 2040 at 8:00pm – Dec 30, 2040 at 5:00pm UTC"
+        )
+      })
+
+      it("does not include year when the years are the present year", () => {
+        const period = dateTimeRange(
+          "2018-12-05T20:00:00+00:00",
+          "2018-12-30T17:00:00+00:00",
+          "UTC"
+        )
+        expect(period).toBe("Dec 5 at 8:00pm – Dec 30 at 5:00pm UTC")
+      })
+
+      it("includes the year when both dates are the same day but not the current year", () => {
+        const period = dateTimeRange(
+          "2019-12-05T20:00:00+00:00",
+          "2019-12-05T22:00:00+00:00",
+          "UTC"
+        )
+        expect(period).toBe("Dec 5, 2019 from 8:00 – 10:00pm UTC")
+      })
+
+      it("does not include year both dates are same day and the current year", () => {
+        const period = dateTimeRange(
+          "2018-12-05T20:00:00+00:00",
+          "2018-12-05T22:00:00+00:00",
+          "UTC"
+        )
+        expect(period).toBe("Dec 5 from 8:00 – 10:00pm UTC")
+      })
     })
 
-    it("Returns the start and end date with different year from now", () => {
-      const period = dateTimeRange(
-        "2040-12-05T20:00:00+00:00",
-        "2040-12-30T17:00:00+00:00",
-        "UTC"
-      )
-      expect(period).toBe("Dec 5, 2040 at 8:00pm – Dec 30, 2040 at 5:00pm UTC")
-    })
+    describe("if displayDayOfWeek param is true includes day of week", () => {
+      it("includes month day, hour, and both years when years are different", () => {
+        const period = dateTimeRange(
+          "2021-12-05T20:00:00+00:00",
+          "2022-12-30T17:00:00+00:00",
+          "UTC",
+          true
+        )
+        expect(period).toBe(
+          "Sun, Dec 5, 2021 at 8:00pm – Fri, Dec 30, 2022 at 5:00pm UTC"
+        )
+      })
 
-    it("Returns the start and end datetimes in current year", () => {
-      const period = dateTimeRange(
-        "2018-12-05T20:00:00+00:00",
-        "2018-12-30T17:00:00+00:00",
-        "UTC"
-      )
-      expect(period).toBe("Dec 5 at 8:00pm – Dec 30 at 5:00pm UTC")
-    })
+      it("also includes both years when the years are not the present year", () => {
+        const period = dateTimeRange(
+          "2020-12-05T20:00:00+00:00",
+          "2020-12-30T17:00:00+00:00",
+          "UTC",
+          true
+        )
+        expect(period).toBe(
+          "Sat, Dec 5, 2020 at 8:00pm – Wed, Dec 30, 2020 at 5:00pm UTC"
+        )
+      })
 
-    it("Returns single datetime in different year from now", () => {
-      const period = dateTimeRange(
-        "2019-12-05T20:00:00+00:00",
-        "2019-12-05T22:00:00+00:00",
-        "UTC"
-      )
-      expect(period).toBe("Dec 5, 2019 from 8:00 – 10:00pm UTC")
-    })
+      it("does not include year when the years are the present year", () => {
+        const period = dateTimeRange(
+          "2018-12-05T20:00:00+00:00",
+          "2018-12-30T17:00:00+00:00",
+          "UTC",
+          true
+        )
+        expect(period).toBe("Wed, Dec 5 at 8:00pm – Sun, Dec 30 at 5:00pm UTC")
+      })
 
-    it("Displays just date and time if dates are the same day and same year", () => {
-      const period = dateTimeRange(
-        "2018-12-05T20:00:00+00:00",
-        "2018-12-05T22:00:00+00:00",
-        "UTC"
-      )
-      expect(period).toBe("Dec 5 from 8:00 – 10:00pm UTC")
-    })
+      it("includes the year when both dates are the same day but not the current year", () => {
+        const period = dateTimeRange(
+          "2019-12-05T20:00:00+00:00",
+          "2019-12-05T22:00:00+00:00",
+          "UTC",
+          true
+        )
+        expect(period).toBe("Thu, Dec 5, 2019 from 8:00 – 10:00pm UTC")
+      })
 
-    it("Returns the start and end datetime range with separate years which displays both years", () => {
-      const period = dateTimeRange(
-        "2021-12-05T20:00:00+00:00",
-        "2022-12-30T17:00:00+00:00",
-        "UTC",
-        true
-      )
-      expect(period).toBe(
-        "Sun, Dec 5, 2021 at 8:00pm – Fri, Dec 30, 2022 at 5:00pm UTC"
-      )
-    })
+      it("does not include the year when the dates are the same day and the same year as the present year", () => {
+        const period = dateTimeRange(
+          "2018-12-05T20:00:00+00:00",
+          "2018-12-05T22:00:00+00:00",
+          "UTC",
+          true
+        )
+        expect(period).toBe("Wed, Dec 5 from 8:00 – 10:00pm UTC")
+      })
 
-    it("Returns date range with the start and end dates falling in a different year from now", () => {
-      const period = dateTimeRange(
-        "2020-12-05T20:00:00+00:00",
-        "2020-12-30T17:00:00+00:00",
-        "UTC",
-        true
-      )
-      expect(period).toBe(
-        "Sat, Dec 5, 2020 at 8:00pm – Wed, Dec 30, 2020 at 5:00pm UTC"
-      )
-    })
-
-    it("Returns date range in same year as now", () => {
-      const period = dateTimeRange(
-        "2018-12-05T20:00:00+00:00",
-        "2018-12-30T17:00:00+00:00",
-        "UTC",
-        true
-      )
-      expect(period).toBe("Wed, Dec 5 at 8:00pm – Sun, Dec 30 at 5:00pm UTC")
-    })
-
-    it("Returns single date in different year from now", () => {
-      const period = dateTimeRange(
-        "2019-12-05T20:00:00+00:00",
-        "2019-12-05T22:00:00+00:00",
-        "UTC",
-        true
-      )
-      expect(period).toBe("Thu, Dec 5, 2019 from 8:00 – 10:00pm UTC")
-    })
-
-    it("Returns same day in same year as now", () => {
-      const period = dateTimeRange(
-        "2018-12-05T20:00:00+00:00",
-        "2018-12-05T22:00:00+00:00",
-        "UTC",
-        true
-      )
-      expect(period).toBe("Wed, Dec 5 from 8:00 – 10:00pm UTC")
-    })
-
-    it("Returns dateTimeRange with timezone", () => {
-      const period = dateTimeRange(
-        "2018-12-05T20:00:00+00:00",
-        "2018-12-05T22:00:00+00:00",
-        "America/Costa_Rica",
-        true
-      )
-      expect(period).toBe("Wed, Dec 5 from 2:00 – 4:00pm CST")
+      it("returns the dates with a specific timezone", () => {
+        const period = dateTimeRange(
+          "2018-12-05T20:00:00+00:00",
+          "2018-12-05T22:00:00+00:00",
+          "America/Costa_Rica",
+          true
+        )
+        expect(period).toBe("Wed, Dec 5 from 2:00 – 4:00pm CST")
+      })
     })
   })
 
   describe(dateRange, () => {
-    it("Returns date range with two different dates in two different years", () => {
+    it("includes month day and both years when years are different years", () => {
       const period = dateRange(
         moment("2011-01-01"),
         moment("2014-04-19"),
@@ -306,7 +313,7 @@ describe("date formatting", () => {
       expect(period).toBe("Jan 1, 2011 – Apr 19, 2014")
     })
 
-    it("Returns date range with different years and same month", () => {
+    it("includes month twice when years are different even if the same month", () => {
       const period = dateRange(
         moment("2011-01-01"),
         moment("2014-01-04"),
@@ -315,7 +322,7 @@ describe("date formatting", () => {
       expect(period).toBe("Jan 1, 2011 – Jan 4, 2014")
     })
 
-    it("Returns date range with that has same year for both dates, which displays only one year", () => {
+    it("if the dates have the same year include the year once", () => {
       const period = dateRange(
         moment("2011-01-01"),
         moment("2011-04-19"),
@@ -324,7 +331,7 @@ describe("date formatting", () => {
       expect(period).toBe("Jan 1 – Apr 19, 2011")
     })
 
-    it("Displays one month if the start and end dates have the same month", () => {
+    it("include only one month if dates have same month and same year", () => {
       const period = dateRange(
         moment("2011-01-01"),
         moment("2011-01-19"),
@@ -333,7 +340,7 @@ describe("date formatting", () => {
       expect(period).toBe("Jan 1 – 19, 2011")
     })
 
-    it("If years are different always show both years", () => {
+    it("if the dates are not the same year always show both years even if one year is the same as the present year", () => {
       const period = dateRange(
         moment("2011-01-01"),
         moment().format("YYYY-04-19"),
@@ -342,7 +349,7 @@ describe("date formatting", () => {
       expect(period).toBe("Jan 1, 2011 – Apr 19, 2019")
     })
 
-    it("If both dates are within the present year don't display a year", () => {
+    it("dont include the year if both years are the same as the present year", () => {
       const period = dateRange(
         moment().format("YYYY-01-01"),
         moment().format("YYYY-01-19"),

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,15 +1,14 @@
 import moment from "moment"
 
-// TODO: ADD timezone to end of strings with hours
-
-const formattedOpeningHoursDate = date => {
-  const momentToUse = moment.utc(date)
+/**
+ * Jan 5 at 5:00pm
+ * Jan 15 at 5:30pm
+ */
+const formattedOpeningHoursDate = (date, timezone = "UTC") => {
+  const momentToUse = moment.tz(date, timezone)
   const momentDate = momentToUse.format("MMM D")
-  const momentHour = momentToUse.format("ha")
-  if (momentHour && momentDate && momentToUse.minutes() !== 0) {
-    const momentHourWithMinutes = momentToUse.format("h:mma")
-    return `${momentDate} at ${momentHourWithMinutes}`
-  } else if (momentHour && momentDate) {
+  const momentHour = momentToUse.format("h:mma z")
+  if (momentHour && momentDate) {
     return `${momentDate} at ${momentHour}`
   } else if (momentDate) {
     return momentDate
@@ -17,14 +16,39 @@ const formattedOpeningHoursDate = date => {
 }
 
 /**
+ * Returns true if dates are on same day, timezone must be the same for both timestamps
+ */
+export function datesAreSameDay(startAt, endAt, timezone = "UTC") {
+  const startMoment = moment.tz(startAt, timezone)
+  const endMoment = moment.tz(endAt, timezone)
+  if (
+    startMoment.dayOfYear() === endMoment.dayOfYear() &&
+    startMoment.year() === endMoment.year()
+  ) {
+    return true
+  } else {
+    return false
+  }
+}
+
+/**
+ * 5:00pm
+ * 5:30pm
+ * TODO: Use 24h clock if not Canada (except Québec), Australia, New Zealand, the Philippines, United States.
+ */
+export function singleTime(date, timezone = "UTC") {
+  return moment.tz(date, timezone).format("h:mma z")
+}
+
+/**
  * If within same am/pm:   9:00 – 11:30pm
  * If within across both am/pm:   9:00am – 12:30pm EST
  */
-export function formattedHours(startAt, endAt) {
-  const startMoment = moment.utc(startAt)
-  const endMoment = moment.utc(endAt)
+export function timeRange(startAt, endAt, timezone = "UTC") {
+  const startMoment = moment.tz(startAt, timezone)
+  const endMoment = moment.tz(endAt, timezone)
   let startHour
-  let endHour = endMoment.format("h:mma")
+  let endHour = endMoment.format("h:mma z")
   if (
     (startMoment.hours() <= 12 && endMoment.hours() <= 12) ||
     (startMoment.hours() >= 12 && endMoment.hours() >= 12)
@@ -38,59 +62,18 @@ export function formattedHours(startAt, endAt) {
 }
 
 /**
- * Returns true if dates are on same day
- */
-export function datesAreSameDay(startAt, endAt) {
-  const startMoment = moment.utc(startAt)
-  const endMoment = moment.utc(endAt)
-  if (
-    startMoment.dayOfYear() === endMoment.dayOfYear() &&
-    startMoment.year() === endMoment.year()
-  ) {
-    return true
-  } else {
-    return false
-  }
-}
-
-/**
- * Opens Mar 29 at 4:00pm
- * Closes Apr 3 at 12:30pm
- * Closed
- */
-export function formattedOpeningHours(startAt, endAt) {
-  const thisMoment = moment()
-  const startMoment = moment.utc(startAt)
-  const endMoment = moment.utc(endAt)
-  if (thisMoment.isBefore(startMoment)) {
-    return `Opens ${formattedOpeningHoursDate(startAt)}`
-  } else if (thisMoment.isBefore(endMoment)) {
-    return `Closes ${formattedOpeningHoursDate(endAt)}`
-  } else {
-    return "Closed"
-  }
-}
-
-/**
- * 5:00pm
- * 5:30pm
- * TODO: Use 24h clock if not Canada (except Québec), Australia, New Zealand, the Philippines, United States.
- */
-export function singleHour(date) {
-  return moment.utc(date).format("h:mma")
-}
-
-/**
  * Aug 5 at 5:00pm
  * Aug 5, 2022 at 5:00pm
  */
-export function singleDate(date) {
-  const now = moment()
-  const thisMoment = moment.utc(date)
+export function singleDateTime(date, timezone = "UTC") {
+  const now = moment.tz(moment(), timezone)
+  const thisMoment = moment.tz(date, timezone)
   if (now.year() !== thisMoment.year()) {
-    return `${thisMoment.format("MMM D, YYYY")} at ${singleHour(thisMoment)}`
+    return `${thisMoment.format("MMM D, YYYY")} at ${thisMoment.format(
+      "h:mma z"
+    )}`
   } else {
-    return `${thisMoment.format("MMM D")} at ${singleHour(thisMoment)}`
+    return `${thisMoment.format("MMM D")} at ${thisMoment.format("h:mma z")}`
   }
 }
 
@@ -98,28 +81,40 @@ export function singleDate(date) {
  * Wed, Apr 24
  * if not this year:   Wed, April 24, 2022
  */
-export function singleDateWithoutHour(date) {
-  const thisMoment = moment(date)
+export function singleDate(date, timezone = "UTC") {
+  const thisMoment = moment.tz(date, timezone)
   const now = moment()
-  if (now.year() === thisMoment.year()) {
-    return `${thisMoment.format("ddd")}, ${thisMoment.format("MMM D")}`
-  } else {
+  if (now.year() !== thisMoment.year()) {
     return `${thisMoment.format("ddd")}, ${thisMoment.format("MMM D, YYYY")}`
+  } else {
+    return `${thisMoment.format("ddd")}, ${thisMoment.format("MMM D")}`
   }
 }
 
 /**
- * Dec 5 from 8:00pm – 9:00pm
- * Dec 5, 2022 from 8:00pm – 9:00pm
+ * Dec 5 at 8:00pm – 9:00pm
+ * Dec 5, 2022 at 8:00pm – 9:00pm
  * Dec 5 at 8:00pm – Dec 30 at 5:00pm
  * Dec 5, 2018 at 8:00pm – Jan 5, 2019 at 5:00pm
+ * Thu, Nov 15 at 6:00pm – 9:30pm
+ * Thu, Nov 15, 2022 at 6:00pm – 9:30pm
+ * Thu, Nov 15 at 6:00pm – Thu, Oct 18 at 6:30pm
+ * Dec 5, 2022 at 8:00pm – Dec 30, 2022 at 5:00pm EST
  */
-export function datesWithHours(startAt, endAt) {
-  const now = moment()
-  const startMoment = moment.utc(startAt)
-  const endMoment = moment.utc(endAt)
-  const hourFormat = "h:mma"
+export function dateTimeRange(
+  startAt,
+  endAt,
+  displayDayOfWeek = false,
+  timezone = "UTC"
+) {
+  const now = moment.tz(moment(), timezone)
+  const startMoment = moment.tz(startAt, timezone)
+  const endMoment = moment.tz(endAt, timezone)
+  const startHourFormat = "h:mma"
+  const endHourFormat = "h:mma z"
   let monthFormat = "MMM D"
+  const dayFormat = "ddd"
+
   if (
     startMoment.year() !== endMoment.year() ||
     now.year() !== startMoment.year()
@@ -129,49 +124,29 @@ export function datesWithHours(startAt, endAt) {
   }
 
   if (datesAreSameDay(startAt, endAt)) {
-    return `${startMoment.format(monthFormat)} from ${formattedHours(
-      startAt,
-      endAt
-    )}`
+    return displayDayOfWeek
+      ? `${startMoment.format(dayFormat)}, ${startMoment.format(
+          monthFormat
+        )} from ${timeRange(startAt, endAt, timezone)}`
+      : `${startMoment.format(monthFormat)} from ${timeRange(
+          startAt,
+          endAt,
+          timezone
+        )}`
   } else {
-    return `${startMoment.format(monthFormat)} at ${startMoment.format(
-      hourFormat
-    )} – ${endMoment.format(monthFormat)} at ${endMoment.format(hourFormat)}`
-  }
-}
-
-/**
- * Thu, Nov 15 from 6:00pm – 9:30pm
- * Thu, Nov 15, 2022 from 6:00pm – 9:30pm
- * Thu, Nov 15 at 6:00pm – Thu, Oct 18 at 6:30pm
- * Sun, Dec 5, 2022 at 8:00pm – Sun, Dec 30, 2022 at 5:00pm EST
- */
-export function datesWithDaysAndHours(startAt, endAt) {
-  const now = moment()
-  const startMoment = moment.utc(startAt)
-  const endMoment = moment.utc(endAt)
-  const dayFormat = "ddd"
-  const hourFormat = "h:mma"
-  let monthFormat = "MMM D"
-
-  if (
-    startMoment.year() !== endMoment.year() ||
-    now.year() !== startMoment.year()
-  ) {
-    // Adds years if the dates are not the same year or not this year
-    monthFormat = monthFormat.concat(", YYYY")
-  }
-
-  if (datesAreSameDay(startAt, endAt)) {
-    return `${startMoment.format(dayFormat)}, ${startMoment.format(
-      monthFormat
-    )} from ${formattedHours(startAt, endAt)}`
-  } else {
-    return `${startMoment.format(dayFormat)}, ${startMoment.format(
-      monthFormat
-    )} at ${startMoment.format(hourFormat)} – ${endMoment.format(
-      dayFormat
-    )}, ${endMoment.format(monthFormat)} at ${endMoment.format(hourFormat)}`
+    return displayDayOfWeek
+      ? `${startMoment.format(dayFormat)}, ${startMoment.format(
+          monthFormat
+        )} at ${startMoment.format(startHourFormat)} – ${endMoment.format(
+          dayFormat
+        )}, ${endMoment.format(monthFormat)} at ${endMoment.format(
+          endHourFormat
+        )}`
+      : `${startMoment.format(monthFormat)} at ${startMoment.format(
+          startHourFormat
+        )} – ${endMoment.format(monthFormat)} at ${endMoment.format(
+          endHourFormat
+        )}`
   }
 }
 
@@ -180,9 +155,9 @@ export function datesWithDaysAndHours(startAt, endAt) {
  * Nov 1 – 4, 2018
  * Nov 1, 2018 – Jan 4, 2019
  */
-export function dateRange(startAt, endAt) {
-  const startMoment = moment.utc(startAt)
-  const endMoment = moment.utc(endAt)
+export function dateRange(startAt, endAt, timezone = "UTC") {
+  const startMoment = moment.tz(startAt, timezone)
+  const endMoment = moment.tz(endAt, timezone)
   const thisMoment = moment()
   let startFormat = "MMM D"
   let endFormat = "D"
@@ -239,10 +214,38 @@ function relativeDays(prefix, today, other, max) {
  * Closing tomorrow
  * Opening in 5 days
  */
-export function exhibitionStatus(startAt, endAt, max = 5) {
-  const today = moment().startOf("day")
+export function exhibitionStatus(startAt, endAt, timezone = "UTC", max = 5) {
+  const today = moment.tz(moment(), timezone).startOf("day")
   return (
-    relativeDays("Opening", today, moment(startAt).startOf("day"), max) ||
-    relativeDays("Closing", today, moment(endAt).startOf("day"), max)
+    relativeDays(
+      "Opening",
+      today,
+      moment.tz(startAt, timezone).startOf("day"),
+      max
+    ) ||
+    relativeDays(
+      "Closing",
+      today,
+      moment.tz(endAt, timezone).startOf("day"),
+      max
+    )
   )
+}
+
+/**
+ * Opens Mar 29 at 4:00pm
+ * Closes Apr 3 at 12:30pm
+ * Closed
+ */
+export function formattedOpeningHours(startAt, endAt, timezone = "UTC") {
+  const thisMoment = moment()
+  const startMoment = moment.tz(startAt, timezone)
+  const endMoment = moment.tz(endAt, timezone)
+  if (thisMoment.isBefore(startMoment)) {
+    return `Opens ${formattedOpeningHoursDate(startAt)}`
+  } else if (thisMoment.isBefore(endMoment)) {
+    return `Closes ${formattedOpeningHoursDate(endAt)}`
+  } else {
+    return "Closed"
+  }
 }

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,5 +1,7 @@
 import moment from "moment"
 
+// TODO: ADD timezone to end of strings with hours
+
 const formattedOpeningHoursDate = date => {
   const momentToUse = moment.utc(date)
   const momentDate = momentToUse.format("MMM D")
@@ -14,10 +16,52 @@ const formattedOpeningHoursDate = date => {
   }
 }
 
+/**
+ * If within same am/pm:   9:00 – 11:30pm
+ * If within across both am/pm:   9:00am – 12:30pm EST
+ */
+export function formattedHours(startAt, endAt) {
+  const startMoment = moment.utc(startAt)
+  const endMoment = moment.utc(endAt)
+  let startHour
+  let endHour = endMoment.format("h:mma")
+  if (
+    (startMoment.hours() <= 12 && endMoment.hours() <= 12) ||
+    (startMoment.hours() >= 12 && endMoment.hours() >= 12)
+  ) {
+    startHour = startMoment.format("h:mm")
+  } else {
+    startHour = startMoment.format("h:mma")
+  }
+
+  return `${startHour} – ${endHour}`
+}
+
+/**
+ * Returns true if dates are on same day
+ */
+export function datesAreSameDay(startAt, endAt) {
+  const startMoment = moment.utc(startAt)
+  const endMoment = moment.utc(endAt)
+  if (
+    startMoment.dayOfYear() === endMoment.dayOfYear() &&
+    startMoment.year() === endMoment.year()
+  ) {
+    return true
+  } else {
+    return false
+  }
+}
+
+/**
+ * Opens Mar 29 at 4:00pm
+ * Closes Apr 3 at 12:30pm
+ * Closed
+ */
 export function formattedOpeningHours(startAt, endAt) {
   const thisMoment = moment()
-  const startMoment = moment(startAt)
-  const endMoment = moment(endAt)
+  const startMoment = moment.utc(startAt)
+  const endMoment = moment.utc(endAt)
   if (thisMoment.isBefore(startMoment)) {
     return `Opens ${formattedOpeningHoursDate(startAt)}`
   } else if (thisMoment.isBefore(endMoment)) {
@@ -27,7 +71,116 @@ export function formattedOpeningHours(startAt, endAt) {
   }
 }
 
-export function exhibitionPeriod(startAt, endAt) {
+/**
+ * 5:00pm
+ * 5:30pm
+ * TODO: Use 24h clock if not Canada (except Québec), Australia, New Zealand, the Philippines, United States.
+ */
+export function singleHour(date) {
+  return moment.utc(date).format("h:mma")
+}
+
+/**
+ * Aug 5 at 5:00pm
+ * Aug 5, 2022 at 5:00pm
+ */
+export function singleDate(date) {
+  const now = moment()
+  const thisMoment = moment.utc(date)
+  if (now.year() !== thisMoment.year()) {
+    return `${thisMoment.format("MMM D, YYYY")} at ${singleHour(thisMoment)}`
+  } else {
+    return `${thisMoment.format("MMM D")} at ${singleHour(thisMoment)}`
+  }
+}
+
+/**
+ * Wed, Apr 24
+ * if not this year:   Wed, April 24, 2022
+ */
+export function singleDateWithoutHour(date) {
+  const thisMoment = moment(date)
+  const now = moment()
+  if (now.year() === thisMoment.year()) {
+    return `${thisMoment.format("ddd")}, ${thisMoment.format("MMM D")}`
+  } else {
+    return `${thisMoment.format("ddd")}, ${thisMoment.format("MMM D, YYYY")}`
+  }
+}
+
+/**
+ * Dec 5 from 8:00pm – 9:00pm
+ * Dec 5, 2022 from 8:00pm – 9:00pm
+ * Dec 5 at 8:00pm – Dec 30 at 5:00pm
+ * Dec 5, 2018 at 8:00pm – Jan 5, 2019 at 5:00pm
+ */
+export function datesWithHours(startAt, endAt) {
+  const now = moment()
+  const startMoment = moment.utc(startAt)
+  const endMoment = moment.utc(endAt)
+  const hourFormat = "h:mma"
+  let monthFormat = "MMM D"
+  if (
+    startMoment.year() !== endMoment.year() ||
+    now.year() !== startMoment.year()
+  ) {
+    // Adds years if the dates are not the same year
+    monthFormat = monthFormat.concat(", YYYY")
+  }
+
+  if (datesAreSameDay(startAt, endAt)) {
+    return `${startMoment.format(monthFormat)} from ${formattedHours(
+      startAt,
+      endAt
+    )}`
+  } else {
+    return `${startMoment.format(monthFormat)} at ${startMoment.format(
+      hourFormat
+    )} – ${endMoment.format(monthFormat)} at ${endMoment.format(hourFormat)}`
+  }
+}
+
+/**
+ * Thu, Nov 15 from 6:00pm – 9:30pm
+ * Thu, Nov 15, 2022 from 6:00pm – 9:30pm
+ * Thu, Nov 15 at 6:00pm – Thu, Oct 18 at 6:30pm
+ * Sun, Dec 5, 2022 at 8:00pm – Sun, Dec 30, 2022 at 5:00pm EST
+ */
+export function datesWithDaysAndHours(startAt, endAt) {
+  const now = moment()
+  const startMoment = moment.utc(startAt)
+  const endMoment = moment.utc(endAt)
+  const dayFormat = "ddd"
+  const hourFormat = "h:mma"
+  let monthFormat = "MMM D"
+
+  if (
+    startMoment.year() !== endMoment.year() ||
+    now.year() !== startMoment.year()
+  ) {
+    // Adds years if the dates are not the same year or not this year
+    monthFormat = monthFormat.concat(", YYYY")
+  }
+
+  if (datesAreSameDay(startAt, endAt)) {
+    return `${startMoment.format(dayFormat)}, ${startMoment.format(
+      monthFormat
+    )} from ${formattedHours(startAt, endAt)}`
+  } else {
+    return `${startMoment.format(dayFormat)}, ${startMoment.format(
+      monthFormat
+    )} at ${startMoment.format(hourFormat)} – ${endMoment.format(
+      dayFormat
+    )}, ${endMoment.format(monthFormat)} at ${endMoment.format(hourFormat)}`
+  }
+}
+
+/**
+ * A formated date range without hours
+ * Nov 1 – 4, 2018
+ * Nov 1, 2018 – Jan 4, 2019
+ */
+export function dateRange(startAt, endAt) {
   const startMoment = moment.utc(startAt)
   const endMoment = moment.utc(endAt)
   const thisMoment = moment()
@@ -81,6 +234,11 @@ function relativeDays(prefix, today, other, max) {
   return null
 }
 
+/**
+ * Opening today
+ * Closing tomorrow
+ * Opening in 5 days
+ */
 export function exhibitionStatus(startAt, endAt, max = 5) {
   const today = moment().startOf("day")
   return (

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -4,7 +4,7 @@ import moment from "moment"
  * Jan 5 at 5:00pm
  * Jan 15 at 5:30pm
  */
-const formattedOpeningHoursDate = (date, timezone = "UTC") => {
+const formattedOpeningHoursDate = (date, timezone) => {
   const momentToUse = moment.tz(date, timezone)
   const momentDate = momentToUse.format("MMM D")
   const momentHour = momentToUse.format("h:mma z")
@@ -18,7 +18,7 @@ const formattedOpeningHoursDate = (date, timezone = "UTC") => {
 /**
  * Returns true if dates are on same day, timezone must be the same for both timestamps
  */
-export function datesAreSameDay(startAt, endAt, timezone = "UTC") {
+export function datesAreSameDay(startAt, endAt, timezone) {
   const startMoment = moment.tz(startAt, timezone)
   const endMoment = moment.tz(endAt, timezone)
   if (
@@ -36,7 +36,7 @@ export function datesAreSameDay(startAt, endAt, timezone = "UTC") {
  * 5:30pm
  * TODO: Use 24h clock if not Canada (except Québec), Australia, New Zealand, the Philippines, United States.
  */
-export function singleTime(date, timezone = "UTC") {
+export function singleTime(date, timezone) {
   return moment.tz(date, timezone).format("h:mma z")
 }
 
@@ -44,7 +44,7 @@ export function singleTime(date, timezone = "UTC") {
  * If within same am/pm:   9:00 – 11:30pm
  * If within across both am/pm:   9:00am – 12:30pm EST
  */
-export function timeRange(startAt, endAt, timezone = "UTC") {
+export function timeRange(startAt, endAt, timezone) {
   const startMoment = moment.tz(startAt, timezone)
   const endMoment = moment.tz(endAt, timezone)
   let startHour
@@ -65,7 +65,7 @@ export function timeRange(startAt, endAt, timezone = "UTC") {
  * Aug 5 at 5:00pm
  * Aug 5, 2022 at 5:00pm
  */
-export function singleDateTime(date, timezone = "UTC") {
+export function singleDateTime(date, timezone) {
   const now = moment.tz(moment(), timezone)
   const thisMoment = moment.tz(date, timezone)
   if (now.year() !== thisMoment.year()) {
@@ -81,7 +81,7 @@ export function singleDateTime(date, timezone = "UTC") {
  * Wed, Apr 24
  * if not this year:   Wed, April 24, 2022
  */
-export function singleDate(date, timezone = "UTC") {
+export function singleDate(date, timezone) {
   const thisMoment = moment.tz(date, timezone)
   const now = moment()
   if (now.year() !== thisMoment.year()) {
@@ -104,8 +104,8 @@ export function singleDate(date, timezone = "UTC") {
 export function dateTimeRange(
   startAt,
   endAt,
-  displayDayOfWeek = false,
-  timezone = "UTC"
+  timezone,
+  displayDayOfWeek = false
 ) {
   const now = moment.tz(moment(), timezone)
   const startMoment = moment.tz(startAt, timezone)
@@ -123,7 +123,7 @@ export function dateTimeRange(
     monthFormat = monthFormat.concat(", YYYY")
   }
 
-  if (datesAreSameDay(startAt, endAt)) {
+  if (datesAreSameDay(startAt, endAt, timezone)) {
     return displayDayOfWeek
       ? `${startMoment.format(dayFormat)}, ${startMoment.format(
           monthFormat
@@ -155,7 +155,7 @@ export function dateTimeRange(
  * Nov 1 – 4, 2018
  * Nov 1, 2018 – Jan 4, 2019
  */
-export function dateRange(startAt, endAt, timezone = "UTC") {
+export function dateRange(startAt, endAt, timezone) {
   const startMoment = moment.tz(startAt, timezone)
   const endMoment = moment.tz(endAt, timezone)
   const thisMoment = moment()
@@ -214,7 +214,7 @@ function relativeDays(prefix, today, other, max) {
  * Closing tomorrow
  * Opening in 5 days
  */
-export function exhibitionStatus(startAt, endAt, timezone = "UTC", max = 5) {
+export function exhibitionStatus(startAt, endAt, timezone, max = 5) {
   const today = moment.tz(moment(), timezone).startOf("day")
   return (
     relativeDays(
@@ -237,14 +237,14 @@ export function exhibitionStatus(startAt, endAt, timezone = "UTC", max = 5) {
  * Closes Apr 3 at 12:30pm
  * Closed
  */
-export function formattedOpeningHours(startAt, endAt, timezone = "UTC") {
+export function formattedOpeningHours(startAt, endAt, timezone) {
   const thisMoment = moment()
   const startMoment = moment.tz(startAt, timezone)
   const endMoment = moment.tz(endAt, timezone)
   if (thisMoment.isBefore(startMoment)) {
-    return `Opens ${formattedOpeningHoursDate(startAt)}`
+    return `Opens ${formattedOpeningHoursDate(startAt, timezone)}`
   } else if (thisMoment.isBefore(endMoment)) {
-    return `Closes ${formattedOpeningHoursDate(endAt)}`
+    return `Closes ${formattedOpeningHoursDate(endAt, timezone)}`
   } else {
     return "Closed"
   }

--- a/src/schema/__tests__/fair.test.js
+++ b/src/schema/__tests__/fair.test.js
@@ -494,7 +494,7 @@ describe("Fair", () => {
 
         expect(data).toEqual({
           fair: {
-            formattedOpeningHours: "Opens Feb 6 at 12pm",
+            formattedOpeningHours: "Opens Feb 6 at 12:00pm UTC",
           },
         })
       })
@@ -514,7 +514,7 @@ describe("Fair", () => {
 
         expect(data).toEqual({
           fair: {
-            formattedOpeningHours: "Opens Feb 6 at 12:30pm",
+            formattedOpeningHours: "Opens Feb 6 at 12:30pm UTC",
           },
         })
       })
@@ -536,7 +536,7 @@ describe("Fair", () => {
 
         expect(data).toEqual({
           fair: {
-            formattedOpeningHours: "Closes Feb 4 at 12pm",
+            formattedOpeningHours: "Closes Feb 4 at 12:00pm UTC",
           },
         })
       })

--- a/src/schema/artist/current.ts
+++ b/src/schema/artist/current.ts
@@ -56,7 +56,7 @@ const showDetails = show => {
   if (show.location && show.location.city) {
     status += show.location.city + ", "
   }
-  status += dateRange(show.start_at, show.end_at)
+  status += dateRange(show.start_at, show.end_at, "UTC")
   return status
 }
 

--- a/src/schema/artist/current.ts
+++ b/src/schema/artist/current.ts
@@ -7,7 +7,7 @@ import {
 } from "graphql"
 import Image, { normalizeImageData } from "schema/image"
 import { error } from "lib/loggers"
-import { exhibitionPeriod } from "lib/date"
+import { dateRange } from "lib/date"
 import { ShowType } from "../show"
 import { SaleType } from "../sale"
 import { date as DateFormat } from "schema/fields/date"
@@ -56,7 +56,7 @@ const showDetails = show => {
   if (show.location && show.location.city) {
     status += show.location.city + ", "
   }
-  status += exhibitionPeriod(show.start_at, show.end_at)
+  status += dateRange(show.start_at, show.end_at)
   return status
 }
 

--- a/src/schema/fair.ts
+++ b/src/schema/fair.ts
@@ -142,14 +142,14 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
     exhibition_period: {
       type: GraphQLString,
       description: "A formatted description of the start to end dates",
-      resolve: ({ start_at, end_at }) => dateRange(start_at, end_at),
+      resolve: ({ start_at, end_at }) => dateRange(start_at, end_at, "UTC"),
     },
     formattedOpeningHours: {
       type: GraphQLString,
       description:
         "A formatted description of when the fair starts or closes or if it is closed",
       resolve: ({ start_at, end_at }) =>
-        formattedOpeningHours(start_at, end_at),
+        formattedOpeningHours(start_at, end_at, "UTC"),
     },
     has_full_feature: {
       type: GraphQLBoolean,

--- a/src/schema/fair.ts
+++ b/src/schema/fair.ts
@@ -2,7 +2,7 @@ import { omit, map } from "lodash"
 import { pageable } from "relay-cursor-paging"
 import { connectionFromArraySlice } from "graphql-relay"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
-import { exhibitionPeriod, formattedOpeningHours } from "lib/date"
+import { dateRange, formattedOpeningHours } from "lib/date"
 import { artistConnection } from "./artist"
 import moment from "moment"
 import cached from "./fields/cached"
@@ -142,7 +142,7 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
     exhibition_period: {
       type: GraphQLString,
       description: "A formatted description of the start to end dates",
-      resolve: ({ start_at, end_at }) => exhibitionPeriod(start_at, end_at),
+      resolve: ({ start_at, end_at }) => dateRange(start_at, end_at),
     },
     formattedOpeningHours: {
       type: GraphQLString,

--- a/src/schema/partner_show.ts
+++ b/src/schema/partner_show.ts
@@ -7,7 +7,7 @@ import {
 import { find, flatten } from "lodash"
 import { HTTPError } from "lib/HTTPError"
 import numeral from "./fields/numeral"
-import { exhibitionPeriod, exhibitionStatus } from "lib/date"
+import { dateRange, exhibitionStatus } from "lib/date"
 import cached from "./fields/cached"
 import date from "./fields/date"
 import { markdown } from "./fields/markdown"
@@ -225,7 +225,7 @@ const PartnerShowType = new GraphQLObjectType<any, ResolverContext>({
     exhibition_period: {
       type: GraphQLString,
       description: "A formatted description of the start to end dates",
-      resolve: ({ start_at, end_at }) => exhibitionPeriod(start_at, end_at),
+      resolve: ({ start_at, end_at }) => dateRange(start_at, end_at),
     },
     fair: {
       type: Fair.type,

--- a/src/schema/partner_show.ts
+++ b/src/schema/partner_show.ts
@@ -225,7 +225,7 @@ const PartnerShowType = new GraphQLObjectType<any, ResolverContext>({
     exhibition_period: {
       type: GraphQLString,
       description: "A formatted description of the start to end dates",
-      resolve: ({ start_at, end_at }) => dateRange(start_at, end_at),
+      resolve: ({ start_at, end_at }) => dateRange(start_at, end_at, "UTC"),
     },
     fair: {
       type: Fair.type,

--- a/src/schema/partner_show_event.ts
+++ b/src/schema/partner_show_event.ts
@@ -1,7 +1,12 @@
 import dateField, { date, DateSource } from "./fields/date"
-import { GraphQLString, GraphQLObjectType, GraphQLFieldConfig } from "graphql"
+import {
+  GraphQLString,
+  GraphQLBoolean,
+  GraphQLObjectType,
+  GraphQLFieldConfig,
+} from "graphql"
 import { ResolverContext } from "types/graphql"
-import { exhibitionPeriod } from "lib/date"
+import { dateRange, datesWithHours, datesAreSameDay } from "lib/date"
 
 const hasOldEmissionUserAgentString = (userAgent: string | string[]): boolean =>
   userAgent!.indexOf("Artsy-Mobile/4.4") > 0 ||
@@ -58,10 +63,20 @@ const PartnerShowEventType = new GraphQLObjectType<any, ResolverContext>({
     },
     start_at: dateFieldForPartnerShowEvent,
     end_at: dateFieldForPartnerShowEvent,
+    datesAreSameDay: {
+      type: GraphQLBoolean,
+      description: "Returns true if dates are on same day",
+      resolve: ({ start_at, end_at }) => datesAreSameDay(start_at, end_at),
+    },
+    datesWithHours: {
+      type: GraphQLString,
+      description: "A formatted description of the dates with hours",
+      resolve: ({ start_at, end_at }) => datesWithHours(start_at, end_at),
+    },
     exhibitionPeriod: {
       type: GraphQLString,
       description: "A formatted description of the start to end dates",
-      resolve: ({ start_at, end_at }) => exhibitionPeriod(start_at, end_at),
+      resolve: ({ start_at, end_at }) => dateRange(start_at, end_at),
     },
   },
 })

--- a/src/schema/partner_show_event.ts
+++ b/src/schema/partner_show_event.ts
@@ -1,12 +1,7 @@
 import dateField, { date, DateSource } from "./fields/date"
-import {
-  GraphQLString,
-  GraphQLBoolean,
-  GraphQLObjectType,
-  GraphQLFieldConfig,
-} from "graphql"
+import { GraphQLString, GraphQLObjectType, GraphQLFieldConfig } from "graphql"
 import { ResolverContext } from "types/graphql"
-import { dateRange, dateTimeRange, datesAreSameDay } from "lib/date"
+import { dateRange, dateTimeRange } from "lib/date"
 
 const hasOldEmissionUserAgentString = (userAgent: string | string[]): boolean =>
   userAgent!.indexOf("Artsy-Mobile/4.4") > 0 ||
@@ -63,20 +58,16 @@ const PartnerShowEventType = new GraphQLObjectType<any, ResolverContext>({
     },
     start_at: dateFieldForPartnerShowEvent,
     end_at: dateFieldForPartnerShowEvent,
-    datesAreSameDay: {
-      type: GraphQLBoolean,
-      description: "Returns true if dates are on same day",
-      resolve: ({ start_at, end_at }) => datesAreSameDay(start_at, end_at),
-    },
     dateTimeRange: {
       type: GraphQLString,
       description: "A formatted description of the dates with hours",
-      resolve: ({ start_at, end_at }) => dateTimeRange(start_at, end_at, true),
+      resolve: ({ start_at, end_at }) =>
+        dateTimeRange(start_at, end_at, "UTC", true),
     },
     exhibitionPeriod: {
       type: GraphQLString,
       description: "A formatted description of the start to end dates",
-      resolve: ({ start_at, end_at }) => dateRange(start_at, end_at),
+      resolve: ({ start_at, end_at }) => dateRange(start_at, end_at, "UTC"),
     },
   },
 })

--- a/src/schema/partner_show_event.ts
+++ b/src/schema/partner_show_event.ts
@@ -6,7 +6,7 @@ import {
   GraphQLFieldConfig,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
-import { dateRange, datesWithHours, datesAreSameDay } from "lib/date"
+import { dateRange, dateTimeRange, datesAreSameDay } from "lib/date"
 
 const hasOldEmissionUserAgentString = (userAgent: string | string[]): boolean =>
   userAgent!.indexOf("Artsy-Mobile/4.4") > 0 ||
@@ -68,10 +68,10 @@ const PartnerShowEventType = new GraphQLObjectType<any, ResolverContext>({
       description: "Returns true if dates are on same day",
       resolve: ({ start_at, end_at }) => datesAreSameDay(start_at, end_at),
     },
-    datesWithHours: {
+    dateTimeRange: {
       type: GraphQLString,
       description: "A formatted description of the dates with hours",
-      resolve: ({ start_at, end_at }) => datesWithHours(start_at, end_at),
+      resolve: ({ start_at, end_at }) => dateTimeRange(start_at, end_at, true),
     },
     exhibitionPeriod: {
       type: GraphQLString,

--- a/src/schema/show.ts
+++ b/src/schema/show.ts
@@ -369,7 +369,7 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
     exhibition_period: {
       type: GraphQLString,
       description: "A formatted description of the start to end dates",
-      resolve: ({ start_at, end_at }) => dateRange(start_at, end_at),
+      resolve: ({ start_at, end_at }) => dateRange(start_at, end_at, "UTC"),
     },
     fair: {
       description: "If the show is in a Fair, then that fair",

--- a/src/schema/show.ts
+++ b/src/schema/show.ts
@@ -13,7 +13,7 @@ import {
 } from "lib/helpers"
 import { HTTPError } from "lib/HTTPError"
 import numeral from "./fields/numeral"
-import { exhibitionPeriod, exhibitionStatus } from "lib/date"
+import { dateRange, exhibitionStatus } from "lib/date"
 import cached from "./fields/cached"
 import date from "./fields/date"
 import { markdown } from "./fields/markdown"
@@ -369,7 +369,7 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
     exhibition_period: {
       type: GraphQLString,
       description: "A formatted description of the start to end dates",
-      resolve: ({ start_at, end_at }) => exhibitionPeriod(start_at, end_at),
+      resolve: ({ start_at, end_at }) => dateRange(start_at, end_at),
     },
     fair: {
       description: "If the show is in a Fair, then that fair",


### PR DESCRIPTION
- Creates date formatting fields to match formatting documented here: https://www.notion.so/artsy/Formatting-Time-f6f4aaeeba414583a207013fec5a9794


- `Current.CurrentEvent`, `Show.exhibition_period`, `PartnerShowEvent.dateTimeRange`, `PartnerShowEvent.exhibitionPeriod`, `PartnerShow.exhibition_period`, `Fair.exhibition_period`, `Fair.formattedOpeningHours` now take a hardcoded `"UTC"` timezone which we can replace once corresponding inputs handle timezone entry.