### PR TITLE
Returns null for missing dates

### DIFF
--- a/src/schema/fields/__tests__/date.test.js
+++ b/src/schema/fields/__tests__/date.test.js
@@ -1,4 +1,4 @@
-import { date } from "schema/fields/date"
+import dateField, { date } from "schema/fields/date"
 
 describe("date", () => {
   const rawDate = "2020-12-31T12:00:00+00:00"
@@ -25,5 +25,18 @@ describe("date", () => {
       "12/31/2020 5:00 -07:00"
     )
     expect(date(rawDate, format, "Pacific/Fiji")).toBe("1/1/2021 1:00 +13:00")
+  })
+})
+
+describe("dateField", () => {
+  it("should return null for a missing date", () => {
+    expect(
+      dateField.resolve(
+        { date: null },
+        { timezone: "America/Boise" },
+        {},
+        { fieldName: "date" }
+      )
+    ).toBeNull()
   })
 })

--- a/src/schema/fields/date.ts
+++ b/src/schema/fields/date.ts
@@ -43,6 +43,9 @@ const dateField: GraphQLFieldConfig<DateSource, ResolverContext> = {
   },
   resolve: (obj, { format, timezone }, { defaultTimezone }, { fieldName }) => {
     const rawDate = obj[fieldName]
+    if (!rawDate) {
+      return null
+    }
     const timezoneString = timezone ? timezone : defaultTimezone
     return date(rawDate, format, timezoneString)
   },


### PR DESCRIPTION
I came across some weird behaviour from Metaphysics when working on [this PR](https://github.com/artsy/reaction/pull/2282). It appeared as though various dates on MP's `Sale` type were being resolve to that literal string `"Invalid date"`:

<img width="271" alt="Screen Shot 2019-04-10 at 2 19 14 PM" src="https://user-images.githubusercontent.com/498212/55903457-b10d2d00-5b9b-11e9-8f04-111c93a150c3.png">

I confirmed with Reaction's MP logging middleware that these strings were _actually_ being returned from MP, but visiting the in-browser GrapiQL interface shows all the results as `null`:

<img width="239" alt="Screen Shot 2019-04-10 at 2 20 53 PM" src="https://user-images.githubusercontent.com/498212/55903527-de59db00-5b9b-11e9-9d85-d364cf2f2bb6.png">

So this is weird, eh? We even have code in Reaction that works around this bug:

https://github.com/artsy/reaction/blob/2d9f867189e716f6881d8d8c6792bcd24a47c23b/src/Components/v2/AuctionTimer.tsx#L25-L28

`"Invalid date"` is [moment's default value for unparsable dates](https://github.com/moment/moment/blob/d0f0dd8f40be987593767a3dc5e27c45c6a3fa49/moment.js#L451); I took a closer look and the reason we see different values in the browser GraphiQL and Reaction Storybooks is because Metaphysics behaves differently if it gets an `X-TIMEZONE` HTTP header. Adding this header reproduces the bug:

<img width="380" alt="Screen Shot 2019-04-10 at 2 25 08 PM" src="https://user-images.githubusercontent.com/498212/55903836-81aaf000-5b9c-11e9-8af3-c17c37d80404.png">

This PR fixes the bug by having a check for `null` dates (which avoids moment parsing altogether). This is a pretty wide-reaching change, and while I don't expect any problems after merging, I want to kick the tires around staging before we promote.