### PR TITLE
[date] Fix tests breakage due to TZ ambiguity.

### DIFF
--- a/src/lib/__tests__/date.test.ts
+++ b/src/lib/__tests__/date.test.ts
@@ -6,39 +6,39 @@ describe("date", () => {
   describe("exhibitionPeriod", () => {
     it("includes the start and end date", () => {
       const period = exhibitionPeriod(
-        moment("2011-01-01"),
-        moment("2014-04-19")
+        moment("2011-01-01 00:00 -0400"),
+        moment("2014-04-19 00:00 -0400")
       )
       expect(period).toBe("Jan 1, 2011 – Apr 19, 2014")
     })
 
     it("different years and same month", () => {
       const period = exhibitionPeriod(
-        moment("2011-01-01"),
-        moment("2014-01-04")
+        moment("2011-01-01 00:00 -0400"),
+        moment("2014-01-04 00:00 -0400")
       )
       expect(period).toBe("Jan 1, 2011 – Jan 4, 2014")
     })
 
     it("does not include the year of the start date if it’s the same year as the end date", () => {
       const period = exhibitionPeriod(
-        moment("2011-01-01"),
-        moment("2011-04-19")
+        moment("2011-01-01 00:00 -0400"),
+        moment("2011-04-19 00:00 -0400")
       )
       expect(period).toBe("Jan 1 – Apr 19, 2011")
     })
 
     it("does not include the month of the end date if it’s the same as the start date", () => {
       const period = exhibitionPeriod(
-        moment("2011-01-01"),
-        moment("2011-01-19")
+        moment("2011-01-01 00:00 -0400"),
+        moment("2011-01-19 00:00 -0400")
       )
       expect(period).toBe("Jan 1 – 19, 2011")
     })
 
     it("If one date's year is different show both years", () => {
       const period = exhibitionPeriod(
-        moment("2011-01-01"),
+        moment("2011-01-01 00:00 -0400"),
         moment().format("YYYY-04-19")
       )
       expect(period).toBe("Jan 1, 2011 – Apr 19, 2019")

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -60,7 +60,7 @@ export function exhibitionPeriod(startAt, endAt) {
     if (endMoment.year() !== thisMoment.year()) {
       singleDateFormat = singleDateFormat.concat(", YYYY")
     }
-    return `${endMoment.format(singleDateFormat)}`
+    return endMoment.format(singleDateFormat)
   } else {
     // Show date range if not the same day
     return `${startMoment.format(startFormat)} – ${endMoment.format(endFormat)}`


### PR DESCRIPTION
In my timezone, these tests were breaking with:

```
    Expected: "Jan 1, 2011 – Apr 19, 2014"
    Received: "Dec 31, 2010 – Apr 18, 2014"
```