### PR TITLE
Return credit card ID from buyer counter mutation

### DIFF
--- a/src/schema/__tests__/ecommerce/buyer_counter_offer_mutation.test.ts
+++ b/src/schema/__tests__/ecommerce/buyer_counter_offer_mutation.test.ts
@@ -42,7 +42,11 @@ describe("BuyerCounterOffer Mutation", () => {
 
     return runQuery(mutation, context).then(data => {
       expect(data!.ecommerceBuyerCounterOffer.orderOrError.order).toEqual(
-        sampleOrder({ mode: "OFFER", includeOfferFields: true })
+        sampleOrder({
+          mode: "OFFER",
+          includeOfferFields: true,
+          includeCreditCard: true,
+        })
       )
     })
   })

--- a/src/schema/ecommerce/buyer_counter_offer_mutation.ts
+++ b/src/schema/ecommerce/buyer_counter_offer_mutation.ts
@@ -61,6 +61,7 @@ export const BuyerCounterOfferMutation = mutationWithClientMutationId<
             ... on EcommerceOrderWithMutationSuccess {
               order {
                 ${BuyerOrderFields}
+                creditCardId
               }
             }
             ... on EcommerceOrderWithMutationFailure {


### PR DESCRIPTION
Related to #incident-36

The response from this mutation gets used to populate the relay store and render the counter offer "review" page. Because we weren't including the `creditCardId` here, metaphysics was unable to resolve and was returning `null` for the credit card.

Since we recently [updated the display](https://github.com/artsy/reaction/pull/2275/files#diff-a25e611754f0b81c6407b2690f479f87R30) of the `CreditCardDetails`, a `null` credit card started causing the page rendering to error based on this missing field. (Note this wasn't an issue before because after the response from the mutation, we make another query that _does_ include the proper `creditCardId`).

The real follow-up is to remove all of this fake-stitching. 😄 