### PR TITLE
Use Eastern Time when formatting timestamps for auction search results

### DIFF
--- a/src/schema/SearchableItem/SearchableItemPresenter.ts
+++ b/src/schema/SearchableItem/SearchableItemPresenter.ts
@@ -1,5 +1,5 @@
 import { compact } from "lodash"
-import moment from "moment"
+import moment from "moment-timezone"
 import { stripTags } from "lib/helpers"
 import { SearchItemRawResponse } from "./SearchItemRawResponse"
 
@@ -21,7 +21,7 @@ export class SearchableItemPresenter {
       case "Fair":
         return this.formattedEventDescription("Art fair")
       case "Auction":
-        return this.formattedEventDescription("Sale")
+        return this.formattedEventDescription("Sale", "America/New_York")
       case "Artwork":
       case "Feature":
       case "Gallery":
@@ -102,11 +102,22 @@ export class SearchableItemPresenter {
     return this.item.image_url
   }
 
-  private formattedEventDescription(title: string): string {
+  private formattedEventDescription(title: string, timezone?: string): string {
     const { description, location, start_at, end_at } = this.item
 
-    const formattedStartAt = moment.utc(start_at).format(DATE_FORMAT)
-    const formattedEndAt = moment.utc(end_at).format(DATE_FORMAT)
+    const startAt = moment.utc(start_at)
+    const endAt = moment.utc(end_at)
+    let formattedStartAt = startAt.format(DATE_FORMAT)
+    let formattedEndAt = endAt.format(DATE_FORMAT)
+
+    if (timezone) {
+      formattedStartAt = `${formattedStartAt} (at ${startAt
+        .tz(timezone)
+        .format("h:mma z")})`
+      formattedEndAt = `${formattedEndAt} (at ${endAt
+        .tz(timezone)
+        .format("h:mma z")})`
+    }
 
     if (start_at && end_at) {
       let formattedDescription = `${title} running from ${formattedStartAt} to ${formattedEndAt}`

--- a/src/schema/SearchableItem/SearchableItemPresenter.ts
+++ b/src/schema/SearchableItem/SearchableItemPresenter.ts
@@ -105,27 +105,16 @@ export class SearchableItemPresenter {
   private formattedEventDescription(title: string, timezone?: string): string {
     const { description, location, start_at, end_at } = this.item
 
-    const startAt = moment.utc(start_at)
-    const endAt = moment.utc(end_at)
-    let formattedStartAt = startAt.format(DATE_FORMAT)
-    let formattedEndAt = endAt.format(DATE_FORMAT)
+    let formattedStartAt = this.formattedTime(start_at, DATE_FORMAT, timezone)
+    let formattedEndAt = this.formattedTime(end_at, DATE_FORMAT, timezone)
 
-    if (timezone) {
-      formattedStartAt = `${formattedStartAt} (at ${startAt
-        .tz(timezone)
-        .format("h:mma z")})`
-      formattedEndAt = `${formattedEndAt} (at ${endAt
-        .tz(timezone)
-        .format("h:mma z")})`
-    }
-
-    if (start_at && end_at) {
+    if (formattedStartAt && formattedEndAt) {
       let formattedDescription = `${title} running from ${formattedStartAt} to ${formattedEndAt}`
       if (location) {
         formattedDescription += ` in ${location}`
       }
       return formattedDescription
-    } else if (start_at) {
+    } else if (formattedStartAt) {
       return `${title} opening ${formattedStartAt}`
     } else {
       return description
@@ -135,14 +124,32 @@ export class SearchableItemPresenter {
   private formattedArticleDescription(): string {
     const { description, published_at } = this.item
 
-    const formattedPublishedAt = moment.utc(published_at).format(DATE_FORMAT)
+    const formattedPublishedAt = this.formattedTime(published_at, DATE_FORMAT)
 
-    if (published_at && description) {
+    if (formattedPublishedAt && description) {
       return `${formattedPublishedAt} ... ${description}`
-    } else if (published_at) {
+    } else if (formattedPublishedAt) {
       return formattedPublishedAt
     } else {
       return description
+    }
+  }
+
+  private formattedTime(
+    timestamp: string,
+    format: string,
+    timezone?: string
+  ): string | null {
+    const momentTime = moment.utc(timestamp)
+
+    if (!momentTime.isValid()) {
+      return null
+    } else if (timezone) {
+      return `${momentTime.tz(timezone).format(format)} (at ${momentTime.format(
+        "h:mma z"
+      )})`
+    } else {
+      return momentTime.format(format)
     }
   }
 

--- a/src/schema/SearchableItem/SearchableItemPresenter.ts
+++ b/src/schema/SearchableItem/SearchableItemPresenter.ts
@@ -105,17 +105,15 @@ export class SearchableItemPresenter {
   private formattedEventDescription(title: string, timezone?: string): string {
     const { description, location, start_at, end_at } = this.item
 
-    let formattedStartAt = this.formattedTime(start_at, DATE_FORMAT, timezone)
-    let formattedEndAt = this.formattedTime(end_at, DATE_FORMAT, timezone)
+    const formattedStartAt = this.formattedTime(start_at, DATE_FORMAT, timezone)
+    const formattedEndAt = this.formattedTime(end_at, DATE_FORMAT, timezone)
 
     if (formattedStartAt && formattedEndAt) {
-      let formattedDescription = `${title} running from ${formattedStartAt} to ${formattedEndAt}`
-      if (location) {
-        formattedDescription += ` in ${location}`
-      }
-      return formattedDescription
+      return `${title} running from ${formattedStartAt} to ${formattedEndAt}${location &&
+        ` in ${location}`}`
     } else if (formattedStartAt) {
-      return `${title} opening ${formattedStartAt}`
+      return `${title} opening ${formattedStartAt}${location &&
+        ` in ${location}`}`
     } else {
       return description
     }

--- a/src/schema/SearchableItem/__tests__/SearchableItemPresenter.test.ts
+++ b/src/schema/SearchableItem/__tests__/SearchableItemPresenter.test.ts
@@ -124,6 +124,24 @@ describe("SearchableItemPresenter", () => {
         )
       })
 
+      it("formats the event period if only start time is available", () => {
+        let presenter = new SearchableItemPresenter({
+          ...buildSearchableItem("Fair"),
+          end_at: "",
+        })
+        let description = presenter.formattedDescription()
+
+        expect(description).toBe("Art fair opening May 16th, 2018")
+
+        presenter = new SearchableItemPresenter({
+          ...buildSearchableItem("Auction"),
+          end_at: "",
+        })
+        description = presenter.formattedDescription()
+
+        expect(description).toBe("Sale opening May 16th, 2018 (at 6:00am EDT)")
+      })
+
       it("supports a location if provided", () => {
         const searchableItem = Object.assign(buildSearchableItem("Fair"), {
           location: "New York, NY",

--- a/src/schema/SearchableItem/__tests__/SearchableItemPresenter.test.ts
+++ b/src/schema/SearchableItem/__tests__/SearchableItemPresenter.test.ts
@@ -140,6 +140,17 @@ describe("SearchableItemPresenter", () => {
         description = presenter.formattedDescription()
 
         expect(description).toBe("Sale opening May 16th, 2018 (at 6:00am EDT)")
+
+        presenter = new SearchableItemPresenter({
+          ...buildSearchableItem("Auction"),
+          end_at: "",
+          location: "New York, NY",
+        })
+        description = presenter.formattedDescription()
+
+        expect(description).toBe(
+          "Sale opening May 16th, 2018 (at 6:00am EDT) in New York, NY"
+        )
       })
 
       it("supports a location if provided", () => {

--- a/src/schema/SearchableItem/__tests__/SearchableItemPresenter.test.ts
+++ b/src/schema/SearchableItem/__tests__/SearchableItemPresenter.test.ts
@@ -102,8 +102,8 @@ describe("SearchableItemPresenter", () => {
       const buildSearchableItem = label => {
         return {
           ...BASE_ITEM,
-          start_at: "2018-05-16T11:28:00.000Z",
-          end_at: "2018-05-30T18:40:09.000Z",
+          start_at: "2018-05-16T10:00:00.000Z",
+          end_at: "2018-05-30T18:30:00.000Z",
           label: label,
         }
       }
@@ -120,7 +120,7 @@ describe("SearchableItemPresenter", () => {
         description = presenter.formattedDescription()
 
         expect(description).toBe(
-          "Sale running from May 16th, 2018 to May 30th, 2018"
+          "Sale running from May 16th, 2018 (at 6:00am EDT) to May 30th, 2018 (at 2:30pm EDT)"
         )
       })
 


### PR DESCRIPTION
Auction start and end times are currently input by Artsy staff in UTC time.

Staying consistent with how we display auction times on artsy.net, convert the timestamps from UTC to the `America_New_York` timezone for display on the search results page.

ticket: https://artsyproduct.atlassian.net/browse/DISCO-905 :lock: 