### PR TITLE
When a list endpoint is requested without an id, skip batching

### DIFF
--- a/src/lib/loaders/__tests__/batchLoader.test.ts
+++ b/src/lib/loaders/__tests__/batchLoader.test.ts
@@ -66,6 +66,21 @@ describe("batchLoader", () => {
       })
     })
 
+    it("should skip batching when called without an id", async () => {
+      const multipleLoader = jest.fn()
+      const DL = jest.genMockFromModule("dataloader")
+      const dataLoaderMock = {
+        load: jest.fn(),
+      }
+      const loaderOptions = { sort: "latest" }
+      // @ts-ignore
+      DL.mockImplementation(() => dataLoaderMock)
+      const batch = batchLoader({ multipleLoader, DL })
+      await batch(loaderOptions)
+      expect(dataLoaderMock.load).not.toBeCalled()
+      expect(multipleLoader).toBeCalledWith(loaderOptions)
+    })
+
     it("should group multiple calls together", async () => {
       const multipleLoader = jest.fn(paramSet =>
         paramSet.id.map(id => ({

--- a/src/lib/loaders/batchLoader.ts
+++ b/src/lib/loaders/batchLoader.ts
@@ -88,16 +88,22 @@ interface BatchLoaderArgs {
    */
   singleLoader?: any
   multipleLoader: any
+  /**
+   * A reference of the DataLoader class, used primarily for dependency injection
+   * in tests.
+   */
+  DL?: typeof DataLoader
 }
 
 export const batchLoader = ({
   singleLoader,
   multipleLoader,
+  DL = DataLoader,
 }: BatchLoaderArgs) => {
   if (!ENABLE_RESOLVER_BATCHING) {
     return singleLoader ? singleLoader : multipleLoader
   }
-  const dl = new DataLoader(
+  const dl = new DL(
     async (idWithParamsList: IdWithParams[]) => {
       const [paramGroups, groupedParams] = groupByParams(idWithParamsList)
       const data = await Promise.all(

--- a/src/lib/loaders/batchLoader.ts
+++ b/src/lib/loaders/batchLoader.ts
@@ -145,6 +145,9 @@ export const batchLoader = ({
      * so the results are always formatted into an array
      */
     if (typeof key === "object" && key !== null) {
+      if (!key.id) {
+        return multipleLoader(key)
+      }
       if (key.id.length === 1) {
         return dl
           .load({ ...key, id: key.id[0] })


### PR DESCRIPTION
When the sales endpoint is being called _without_ an id, ensure we short circuit the batching process. 