### PR TITLE
Adds isBenefit and isGalleryAuction to sale schema

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1245,7 +1245,9 @@ type ArtworkContextAuction implements Node {
   href: String
   name: String
   is_auction: Boolean
-  is_benefit: Boolean
+  is_benefit: Boolean @deprecated(reason: "Favor `isBenefit`")
+  isBenefit: Boolean
+  isGalleryAuction: Boolean
   is_auction_promo: Boolean
   is_closed: Boolean
   is_open: Boolean
@@ -1615,7 +1617,9 @@ type ArtworkContextSale implements Node {
   href: String
   name: String
   is_auction: Boolean
-  is_benefit: Boolean
+  is_benefit: Boolean @deprecated(reason: "Favor `isBenefit`")
+  isBenefit: Boolean
+  isGalleryAuction: Boolean
   is_auction_promo: Boolean
   is_closed: Boolean
   is_open: Boolean
@@ -5125,7 +5129,9 @@ type HomePageModuleContextSale implements Node {
   href: String
   name: String
   is_auction: Boolean
-  is_benefit: Boolean
+  is_benefit: Boolean @deprecated(reason: "Favor `isBenefit`")
+  isBenefit: Boolean
+  isGalleryAuction: Boolean
   is_auction_promo: Boolean
   is_closed: Boolean
   is_open: Boolean
@@ -7969,7 +7975,9 @@ type Sale implements Node {
   href: String
   name: String
   is_auction: Boolean
-  is_benefit: Boolean
+  is_benefit: Boolean @deprecated(reason: "Favor `isBenefit`")
+  isBenefit: Boolean
+  isGalleryAuction: Boolean
   is_auction_promo: Boolean
   is_closed: Boolean
   is_open: Boolean

--- a/src/schema/sale/__tests__/index.test.js
+++ b/src/schema/sale/__tests__/index.test.js
@@ -412,6 +412,39 @@ describe("Sale type", () => {
     })
   })
 
+  describe("isGalleryAuction, isBenefit", () => {
+    const query = `
+      {
+        sale(id: "foo-foo") {
+          isBenefit
+          isGalleryAuction
+        }
+      }
+    `
+
+    it("returns whether the gallery is a gallery auction", async () => {
+      sale.is_benefit = false
+      sale.is_gallery_auction = true
+      expect(await execute(query)).toEqual({
+        sale: {
+          isBenefit: false,
+          isGalleryAuction: true,
+        },
+      })
+    })
+
+    it("returns whether the gallery is a benefit auction", async () => {
+      sale.is_benefit = true
+      sale.is_gallery_auction = false
+      expect(await execute(query)).toEqual({
+        sale: {
+          isBenefit: true,
+          isGalleryAuction: false,
+        },
+      })
+    })
+  })
+
   describe("display_timely_at", () => {
     const testData = [
       [

--- a/src/schema/sale/index.ts
+++ b/src/schema/sale/index.ts
@@ -131,10 +131,7 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
             page: number
             size: number
           }
-          const gravityArgs: GravityArgs = {
-            page,
-            size,
-          }
+          const gravityArgs: GravityArgs = { page, size }
 
           if (options.exclude) {
             gravityArgs.exclude_ids = flatten([options.exclude])
@@ -194,7 +191,6 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
       description: { type: GraphQLString },
       display_timely_at: {
         type: GraphQLString,
-
         resolve: (sale, _options, { meBiddersLoader }) => {
           return displayTimelyAt({ sale, meBiddersLoader })
         },
@@ -206,7 +202,18 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
       href: { type: GraphQLString, resolve: ({ id }) => `/auction/${id}` },
       name: { type: GraphQLString },
       is_auction: { type: GraphQLBoolean },
-      is_benefit: { type: GraphQLBoolean },
+      is_benefit: {
+        type: GraphQLBoolean,
+        deprecationReason: "Favor `isBenefit`",
+      },
+      isBenefit: {
+        type: GraphQLBoolean,
+        resolve: ({ is_benefit }) => is_benefit,
+      },
+      isGalleryAuction: {
+        type: GraphQLBoolean,
+        resolve: ({ is_gallery_auction }) => is_gallery_auction,
+      },
       is_auction_promo: {
         type: GraphQLBoolean,
         resolve: ({ sale_type }) => sale_type === "auction promo",


### PR DESCRIPTION
Fixes: https://artsyproduct.atlassian.net/browse/PURCHASE-1020

Since we're trying to move to camelCase anyways, I took the opportunity to add `isBenefit` and deprecate `is_benefit`.

#skip_camel