### PR TITLE
If an artworks category is OTHER, dont show a histogram for that artwork

### DIFF
--- a/src/lib/stitching/vortex/__tests__/pricingContext.test.ts
+++ b/src/lib/stitching/vortex/__tests__/pricingContext.test.ts
@@ -225,4 +225,13 @@ Object {
     const result = (await runQuery(query, context)) as any
     expect(result.artwork.pricingContext).toBeNull()
   })
+
+  it("is null when category is OTHER", async () => {
+    artworkLoader.mockResolvedValueOnce({
+      ...artwork,
+      category: "OTHER",
+    })
+    const result = (await runQuery(query, context)) as any
+    expect(result.artwork.pricingContext).toBeNull()
+  })
 })

--- a/src/lib/stitching/vortex/stitching.ts
+++ b/src/lib/stitching/vortex/stitching.ts
@@ -34,7 +34,7 @@ export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
     }
     extend type AnalyticsTopArtworks {
       artwork: Artwork
-    }    
+    }
   `,
   resolvers: {
     AnalyticsHistogramBin: {
@@ -120,9 +120,19 @@ export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
             return null
           }
 
+          const vortexSupportedCategory = categoryMap[category]
+
+          // Don't show the histogram if the category is "Other"
+          if (
+            !vortexSupportedCategory ||
+            vortexSupportedCategory === categoryMap.Other
+          ) {
+            return null
+          }
+
           const args = {
             artistId: artist._id,
-            category: categoryMap[category] || "OTHER",
+            category: vortexSupportedCategory,
             widthCm: Math.round(widthCm),
             heightCm: Math.round(heightCm),
           }


### PR DESCRIPTION
Fixes: https://artsyproduct.atlassian.net/browse/PURCHASE-1010

Artworks with this category are too diverse to be grouped together.