### PR TITLE
@kierangillen => [AuctionResults] Be allowing of null images from Diffusion response

### DIFF
--- a/src/schema/auction_result.ts
+++ b/src/schema/auction_result.ts
@@ -114,7 +114,7 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
         },
       }),
       resolve: ({ images }) => {
-        if (images.length < 1) {
+        if (!images || images.length < 1) {
           return null
         }
         return {


### PR DESCRIPTION
Closes https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=57&projectKey=DISCO&modal=detail&selectedIssue=DISCO-954

A bunch of recent-ish data that was imported (and so is showing up near the front of 'Auction Result' tabs for a bunch of artists) are lacking images (rather than an empty array), so was crashing when requesting the data. This makes that code more defensive by simply allowing nulls, and the possible data-quality issue has been raised in #data-team.