### PR TITLE
Display when a sale is available for live bidding, when available

### DIFF
--- a/src/schema/SearchableItem/SearchItemRawResponse.ts
+++ b/src/schema/SearchableItem/SearchItemRawResponse.ts
@@ -1,4 +1,5 @@
 export type SearchItemRawResponse = {
+  artist_names: string[]
   description: string
   display: string
   end_at: string
@@ -7,12 +8,12 @@ export type SearchItemRawResponse = {
   id: string
   image_url: string
   label: string
+  live_start_at: string
   location: string
   model: string
   owner_type: string
   profile_id: string
   published_at: string
   start_at: string
-  artist_names: string[]
   venue: string
 }

--- a/src/schema/SearchableItem/SearchableItemPresenter.ts
+++ b/src/schema/SearchableItem/SearchableItemPresenter.ts
@@ -103,9 +103,13 @@ export class SearchableItemPresenter {
   }
 
   private formattedEventDescription(title: string, timezone?: string): string {
-    const { description, location, start_at, end_at } = this.item
+    const { description, location, live_start_at, start_at, end_at } = this.item
 
-    const formattedStartAt = this.formattedTime(start_at, DATE_FORMAT, timezone)
+    const formattedStartAt = this.formattedTime(
+      live_start_at || start_at,
+      DATE_FORMAT,
+      timezone
+    )
     const formattedEndAt = this.formattedTime(end_at, DATE_FORMAT, timezone)
 
     if (formattedStartAt && formattedEndAt) {

--- a/src/schema/SearchableItem/__tests__/SearchableItemPresenter.test.ts
+++ b/src/schema/SearchableItem/__tests__/SearchableItemPresenter.test.ts
@@ -5,6 +5,7 @@ import { SearchItemRawResponse } from "../SearchItemRawResponse"
 
 describe("SearchableItemPresenter", () => {
   const BASE_ITEM: SearchItemRawResponse = {
+    artist_names: [""],
     description: "",
     display: "",
     end_at: "",
@@ -13,13 +14,13 @@ describe("SearchableItemPresenter", () => {
     id: "",
     image_url: "",
     label: "",
+    live_start_at: "",
     location: "",
     model: "",
     owner_type: "",
     profile_id: "",
     published_at: "",
     start_at: "",
-    artist_names: [""],
     venue: "",
   }
 
@@ -151,6 +152,17 @@ describe("SearchableItemPresenter", () => {
         expect(description).toBe(
           "Sale opening May 16th, 2018 (at 6:00am EDT) in New York, NY"
         )
+      })
+
+      it("prefers live_start_at to start_at date", () => {
+        let presenter = new SearchableItemPresenter({
+          ...buildSearchableItem("Auction"),
+          live_start_at: "2018-05-30T12:00:00.000Z",
+          end_at: "",
+        })
+        let description = presenter.formattedDescription()
+
+        expect(description).toBe("Sale opening May 30th, 2018 (at 8:00am EDT)")
       })
 
       it("supports a location if provided", () => {


### PR DESCRIPTION
There are 5 possible states a live sale could be in (live as in live auction integration):

1. Published on Artsy, open for registration, but not yet open for any kind of bidding
2. Open for registration & pre-bidding, but not yet open for live bidding
3. Registration closed, pre-bidding open to those who previously registered, but not yet open for live bidding
4. Open for live bidding
5. Closed

_Thanks to Melanie Borinstein for this context!_

For live auctions, we want to display the date an auction becomes available for live bidding (4), not when the auction enters any previous state (1-3). We currently display the date corresponding to state 2, when an auction is open for registration and pre-bidding.

Depends on https://github.com/artsy/gravity/pull/12316

ticket: https://artsyproduct.atlassian.net/browse/DISCO-944 :lock: