### PR TITLE
Increases artst carousel slides from 7 to 10

### DIFF
--- a/src/schema/artist/__tests__/carousel.test.js
+++ b/src/schema/artist/__tests__/carousel.test.js
@@ -33,7 +33,7 @@ describe("ArtistCarousel type", () => {
       context.artistArtworksLoader = sinon
         .stub()
         .withArgs(artist.id, {
-          size: 7,
+          size: 10,
           sort: "-iconicity",
           published: true,
         })

--- a/src/schema/artist/carousel.ts
+++ b/src/schema/artist/carousel.ts
@@ -30,7 +30,7 @@ const ArtistCarousel: GraphQLFieldConfig<{ id: string }, ResolverContext> = {
         top_tier: true,
       }),
       artistArtworksLoader(id, {
-        size: 7,
+        size: 10,
         sort: "-iconicity",
         published: true,
       }),


### PR DESCRIPTION
## Problem
- Some artists ( e.g. https://www.artsy.net/artist/andy-warhol ) carousels do not display enough images which leads to a single image being cropped. This leads to strange UX when the carousel only advances 10-20 pixels.

## Solution
- Increases artist carousel slides from 7 to 10