### PR TITLE
Update sponsored content text

### DIFF
--- a/src/lib/sponsoredContent/data.json
+++ b/src/lib/sponsoredContent/data.json
@@ -72,6 +72,9 @@
     "art-basel-hong-kong-2019": {
       "activationText": "Hong Kong. From March 29 to 31, the Art Basel show in Hong Kong will open its doors offering again extensive insights into the modern and contemporary works by emerging and established artists, presented by 242 of the world’s leading galleries. As an official partner of the show, BMW will not only provide the VIP shuttle service, but also present the world’s first BMW Art Car (BMW 3.0 CSL, 1975), created by legendary artist Alexander Calder, in the BMW Lounge at the Hong Kong Convention and Exhibition Centre. Furthermore, the latest BMW Art Journey awardee Zac Langdon-Pole will be on-site documenting his journey and the next BMW Art Journey shortlist will be announced.",
       "pressReleaseUrl": "https://www.press.bmwgroup.com/global/article/detail/T0292765EN/bmw-is-official-partner-of-art-basel-in-hong-kong-2019-next-bmw-art-journey-shortlist-to-be-announced-and-bmw-art-car-1-by-alexander-calder-on-display"
+    },
+    "frieze-new-york-2019": {
+      "activationText": "BMW supports Frieze Art Fair New York with a VIP shuttle service and is working on various joint initiatives such as the art commission BMW Open Work or Frieze Music for the other fair editions. Learn more on Instagram @bmwgroupculture."
     }
   }
 }


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GROW-1224

This adds a sponsored content blurb (but no url) to Frieze New York 2019.

Trivial text update, no tests…

