### PR TITLE
'amount' helper should handle zero correctly [PURCHASE-995]

### DIFF
--- a/src/schema/artwork/index.ts
+++ b/src/schema/artwork/index.ts
@@ -560,11 +560,12 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           )
             return "Free shipping worldwide"
           var domesticShipping = amount(
-            ({ domestic_shipping_fee_cents }) => domestic_shipping_fee_cents
+            ({ domestic_shipping_fee_cents }) =>
+              domestic_shipping_fee_cents || null
           ).resolve(artwork, { precision: 0 })
           var internationalShipping = amount(
             ({ international_shipping_fee_cents }) =>
-              international_shipping_fee_cents
+              international_shipping_fee_cents || null
           ).resolve(artwork, { precision: 0 })
 
           if (

--- a/src/schema/fields/__tests__/money.test.ts
+++ b/src/schema/fields/__tests__/money.test.ts
@@ -1,0 +1,38 @@
+import { amount } from "../money"
+
+describe(amount, () => {
+  let amountCents: number
+  let args: any
+  beforeEach(() => {
+    args = { symbol: "$" }
+    amountCents = 1234
+  })
+
+  const getResult = () => amount(() => amountCents).resolve({}, args)
+
+  it("formats dollars", () => {
+    expect(getResult()).toMatchInlineSnapshot(`"$12.34"`)
+  })
+
+  it("formats euros", () => {
+    args = { symbol: "€" }
+    expect(getResult()).toMatchInlineSnapshot(`"€12.34"`)
+  })
+
+  it("formats yen", () => {
+    args = { symbol: "¥" }
+    expect(getResult()).toMatchInlineSnapshot(`"¥12.34"`)
+  })
+
+  it("handles zeroes", () => {
+    amountCents = 0
+    expect(getResult()).toMatchInlineSnapshot(`"$0.00"`)
+  })
+
+  it("handles null/undefined", () => {
+    amountCents = null as any
+    expect(getResult()).toMatchInlineSnapshot(`null`)
+    amountCents = undefined as any
+    expect(getResult()).toMatchInlineSnapshot(`null`)
+  })
+})

--- a/src/schema/fields/money.ts
+++ b/src/schema/fields/money.ts
@@ -50,7 +50,9 @@ export const amount = centsResolver => ({
   },
   resolve: (obj, options) => {
     const cents = centsResolver(obj)
-    if (!cents) return null
+    if (typeof cents !== "number") {
+      return null
+    }
     const symbol = options.symbol || obj.symbol
     return formatMoney(
       cents / 100,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PURCHASE-995

Need to check that we're not breaking usages of this before merging (I'm checking in reaction, emission, and volt):

 ### BuyOrder/OfferOrder
  - [x] itemsTotal
  - [x] sellerTotal
  - [x] commissionFee
  - [x] totalListPrice
  - [x] buyerTotal
  - [x] taxTotal
  - [x] shippingTotal
  - [x] transactionFee
 ### LineItem
  - [x] shippingTotal
  - [x] listPrice
  - [x] commissionFee
 ### Offer
  - [x] amount
  - [x] taxTotal
  - [x] shippingTotal
  - [x] buyerTotal
 ### AnalyticsHistogramBin
  - [x] minPrice
  - [x] maxPrice
 ### HighestBid
  - [x] amount
 ### Invoice
  - [x] total
 ### BuyersPremium
  - [x] amount
 ### SaleArtworkHighestBid
  - [x] amount