### PR TITLE
@joeyAghion => [BugFix] Fix followed gene rail

### DIFF
--- a/src/schema/home/__tests__/home_page_artwork_module.test.js
+++ b/src/schema/home/__tests__/home_page_artwork_module.test.js
@@ -64,6 +64,53 @@ describe("HomePageArtworkModule", () => {
     })
   })
 
+  describe("genes", () => {
+    it("fetches the gene and results if an id is provided", async () => {
+      const query = gql`
+        {
+          home_page {
+            artwork_module(key: "genes", id: "catty-art") {
+              results {
+                id
+              }
+            }
+          }
+        }
+      `
+      const data = await runQuery(query, {
+        geneLoader: id => Promise.resolve({ id }),
+        filterArtworksLoader: () =>
+          Promise.resolve({ hits: [{ id: "catty-art-work" }] }),
+      })
+      expect(data.home_page.artwork_module.results).toEqual([
+        { id: "catty-art-work" },
+      ])
+    })
+  })
+
+  it("fetches a followed gene and results without an id", async () => {
+    const query = gql`
+      {
+        home_page {
+          artwork_module(key: "genes") {
+            results {
+              id
+            }
+          }
+        }
+      }
+    `
+    const data = await runQuery(query, {
+      followedGenesLoader: () =>
+        Promise.resolve({ body: [{ gene: { id: "catty-art" } }] }),
+      filterArtworksLoader: () =>
+        Promise.resolve({ hits: [{ id: "catty-art-work" }] }),
+    })
+    expect(data.home_page.artwork_module.results).toEqual([
+      { id: "catty-art-work" },
+    ])
+  })
+
   describe("when signed out", () => {
     it("returns the proper title for popular_artists", () => {
       const query = gql`

--- a/src/schema/home/home_page_artwork_module.ts
+++ b/src/schema/home/home_page_artwork_module.ts
@@ -92,10 +92,16 @@ const HomePageArtworkModule: GraphQLFieldConfig<void, ResolverContext> = {
     switch (key) {
       case "generic_gene":
         return { key, display, params: find(genericGenes, ["id", id]) }
+      // Emission may include an `id` param here,
+      // but Force does not.
       case "genes":
-        return geneLoader(id).then(gene => {
-          return { key, display, params: { id, gene } }
-        })
+        if (id) {
+          return geneLoader(id).then(gene => {
+            return { key, display, params: { id, gene } }
+          })
+        }
+
+        return { key, display, params: {} }
       case "followed_artist":
         return { key, display, params: { followed_artist_id } }
       case "related_artists":


### PR DESCRIPTION
I think this was broken from some past refactors :(

It looks like this param signifies 'this user has followed categories, so there should be a rail of those'.

The results for such a rail are fetched here: https://github.com/artsy/metaphysics/blob/065d05b7d206917efdcea24950ef21d955c31b64/src/schema/home/results.ts#L64-L69 , and it looks like Emission expects an `id` (a specific followed gene?) to be present.

Whereas Force won't, and so a 'featured gene' needs to be fetched from the user's follows.

I attempted to keep this backwards compatible for any clients/use-cases that are passing a valid id.