### PR TITLE
update to use most recent version of vortex schema

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -48,15 +48,8 @@ type AggregationCount {
 type AnalyticsArtworksPublishedStats {
   percentageChanged: Int!
   period: AnalyticsQueryPeriodEnum!
-  timeSeries: [AnalyticsArtworksPublishedTimeSeriesStats!]
+  timeSeries: [AnalyticsPartnerTimeSeriesStats!]!
   totalCount: Int!
-}
-
-# Publish artwork Series Stats
-type AnalyticsArtworksPublishedTimeSeriesStats implements AnalyticsPartnerTimeSeriesStats {
-  count: Int
-  endTime: AnalyticsDateTime
-  startTime: AnalyticsDateTime
 }
 
 # An ISO 8601 datetime
@@ -98,12 +91,27 @@ type AnalyticsPageInfo {
   startCursor: String
 }
 
+# Stats for pageviews of partner content
+type AnalyticsPageviewStats {
+  artworkViews: Int
+  galleryViews: Int
+  percentageChanged: Int!
+  period: AnalyticsQueryPeriodEnum!
+  showViews: Int
+  timeSeries: [AnalyticsPartnerTimeSeriesStats!]!
+  totalCount: Int!
+  uniqueVisitors: Int
+}
+
 # Partner Stats
 type AnalyticsPartnerStats {
   # Time series data on number of artworks published
   artworksPublished(
     period: AnalyticsQueryPeriodEnum!
   ): AnalyticsArtworksPublishedStats
+
+  # Different types of partner pageviews
+  pageviews(period: AnalyticsQueryPeriodEnum!): AnalyticsPageviewStats
   partnerId: String!
 
   # Artworks ranked by views
@@ -127,7 +135,8 @@ type AnalyticsPartnerStats {
 }
 
 # Partner Time Series Stats
-interface AnalyticsPartnerTimeSeriesStats {
+type AnalyticsPartnerTimeSeriesStats {
+  count: Int
   endTime: AnalyticsDateTime
   startTime: AnalyticsDateTime
 }

--- a/src/data/vortex.graphql
+++ b/src/data/vortex.graphql
@@ -4,17 +4,8 @@ Publish artwork Series Stats
 type ArtworksPublishedStats {
   percentageChanged: Int!
   period: QueryPeriodEnum!
-  timeSeries: [ArtworksPublishedTimeSeriesStats!]
+  timeSeries: [PartnerTimeSeriesStats!]!
   totalCount: Int!
-}
-
-"""
-Publish artwork Series Stats
-"""
-type ArtworksPublishedTimeSeriesStats implements PartnerTimeSeriesStats {
-  count: Int
-  endTime: DateTime
-  startTime: DateTime
 }
 
 """
@@ -57,6 +48,20 @@ type PageInfo {
 }
 
 """
+Stats for pageviews of partner content
+"""
+type PageviewStats {
+  artworkViews: Int
+  galleryViews: Int
+  percentageChanged: Int!
+  period: QueryPeriodEnum!
+  showViews: Int
+  timeSeries: [PartnerTimeSeriesStats!]!
+  totalCount: Int!
+  uniqueVisitors: Int
+}
+
+"""
 Partner Stats
 """
 type PartnerStats {
@@ -64,6 +69,11 @@ type PartnerStats {
   Time series data on number of artworks published
   """
   artworksPublished(period: QueryPeriodEnum!): ArtworksPublishedStats
+
+  """
+  Different types of partner pageviews
+  """
+  pageviews(period: QueryPeriodEnum!): PageviewStats
   partnerId: String!
 
   """
@@ -101,7 +111,8 @@ type PartnerStats {
 """
 Partner Time Series Stats
 """
-interface PartnerTimeSeriesStats {
+type PartnerTimeSeriesStats {
+  count: Int
   endTime: DateTime
   startTime: DateTime
 }


### PR DESCRIPTION
This PR brings MP up to date with current Vortex schema, which includes info on Pageviews that will be consumed by the Activity section of the new Partner Analytics dashboard ([spec](https://app.zeplin.io/project/5aabc6f28d835c7b2585fdf4/screen/5c9a75f087814d603e229d7a)).

Note that the change to `timeSeries` is theoretically breaking (but only for the cms.artsy.net/analytics route, which is only accessible to users with the CMS lab flag) - that said, as far as @ansor4 and I can tell it should already be breaking things and isn't. Might be because the format of the data hasn't changed at all, only the type expected.