### PR TITLE
Update Vortex schema with partner sales stats (GALL-1671)

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -103,6 +103,26 @@ type AnalyticsPageviewStats {
   uniqueVisitors: Int
 }
 
+# Sales stats of a partner
+type AnalyticsPartnerSalesStats {
+  partnerId: String!
+  period: AnalyticsQueryPeriodEnum!
+
+  # Partner sales time series
+  timeSeries(
+    cumulative: Boolean = false
+  ): [AnalyticsPartnerSalesTimeSeriesStats!]
+  totalCents: Int!
+}
+
+# Sales time series data of a partner
+type AnalyticsPartnerSalesTimeSeriesStats {
+  count: Int
+  endTime: AnalyticsDateTime
+  startTime: AnalyticsDateTime
+  totalCents: Int!
+}
+
 # Partner Stats
 type AnalyticsPartnerStats {
   # Time series data on number of artworks published
@@ -113,6 +133,9 @@ type AnalyticsPartnerStats {
   # Different types of partner pageviews
   pageviews(period: AnalyticsQueryPeriodEnum!): AnalyticsPageviewStats
   partnerId: String!
+
+  # Sales stats
+  sales(period: AnalyticsQueryPeriodEnum!): AnalyticsPartnerSalesStats
 
   # Artworks ranked by views
   topArtworks(

--- a/src/data/vortex.graphql
+++ b/src/data/vortex.graphql
@@ -62,6 +62,30 @@ type PageviewStats {
 }
 
 """
+Sales stats of a partner
+"""
+type PartnerSalesStats {
+  partnerId: String!
+  period: QueryPeriodEnum!
+
+  """
+  Partner sales time series
+  """
+  timeSeries(cumulative: Boolean = false): [PartnerSalesTimeSeriesStats!]
+  totalCents: Int!
+}
+
+"""
+Sales time series data of a partner
+"""
+type PartnerSalesTimeSeriesStats {
+  count: Int
+  endTime: DateTime
+  startTime: DateTime
+  totalCents: Int!
+}
+
+"""
 Partner Stats
 """
 type PartnerStats {
@@ -75,6 +99,11 @@ type PartnerStats {
   """
   pageviews(period: QueryPeriodEnum!): PageviewStats
   partnerId: String!
+
+  """
+  Sales stats
+  """
+  sales(period: QueryPeriodEnum!): PartnerSalesStats
 
   """
   Artworks ranked by views
@@ -256,11 +285,7 @@ type Query {
   """
   Pricing Context Histograms
   """
-  pricingContext(
-    artistId: String!
-    category: PricingContextCategoryEnum!
-    sizeScore: Int!
-  ): PricingContext
+  pricingContext(artistId: String!, category: PricingContextCategoryEnum!, sizeScore: Int!): PricingContext
 }
 
 enum QueryPeriodEnum {


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GALL-1671

- Update Vortex schema with the [sales stats change](https://github.com/artsy/vortex/pull/115) and [cumulative sales time series](https://github.com/artsy/vortex/pull/125).
- ~Stitch in formatted `total` fields for sales stats and time series.~ Decided to pull the stitching part out to a separate branch and unblock UI development.

![Screen Shot 2019-05-17 at 3 42 01 PM](https://user-images.githubusercontent.com/796573/57952182-637e9100-78ba-11e9-9e67-84684870e544.png)
