### PR TITLE
Expose formatted total fields for partner sales stats (GALL-1671)

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -114,6 +114,13 @@ type AnalyticsPartnerSalesStats {
     cumulative: Boolean = false
   ): [AnalyticsPartnerSalesTimeSeriesStats!]
   totalCents: Int!
+  total(
+    decimal: String = "."
+    format: String = "%s%v"
+    precision: Int = 0
+    symbol: String
+    thousand: String = ","
+  ): String
 }
 
 # Sales time series data of a partner
@@ -122,6 +129,13 @@ type AnalyticsPartnerSalesTimeSeriesStats {
   endTime: AnalyticsDateTime
   startTime: AnalyticsDateTime
   totalCents: Int!
+  total(
+    decimal: String = "."
+    format: String = "%s%v"
+    precision: Int = 0
+    symbol: String
+    thousand: String = ","
+  ): String
 }
 
 # Partner Stats

--- a/src/lib/stitching/vortex/__mocks__/link.ts
+++ b/src/lib/stitching/vortex/__mocks__/link.ts
@@ -102,6 +102,22 @@ export const mockFetch = jest.fn(() =>
                 },
               ],
             },
+            sales: {
+              partnerId: "5748d153cd530e2d5100031c",
+              totalCents: 3682500,
+              timeSeries: [
+                {
+                  startTime: "2019-05-04T00:00:00Z",
+                  endTime: "2019-05-05T00:00:00Z",
+                  totalCents: 0,
+                },
+                {
+                  startTime: "2019-05-05T00:00:00Z",
+                  endTime: "2019-05-06T00:00:00Z",
+                  totalCents: 280000,
+                },
+              ],
+            },
           },
         },
       })

--- a/src/lib/stitching/vortex/__tests__/partnerStatsSales.test.ts
+++ b/src/lib/stitching/vortex/__tests__/partnerStatsSales.test.ts
@@ -1,0 +1,116 @@
+import { runQuery } from "test/utils"
+import gql from "lib/gql"
+import { ResolverContext } from "types/graphql"
+
+jest.mock("../link")
+require("../link").mockFetch as jest.Mock<any>
+
+describe("PartnerStatsSales type", () => {
+  const partnerLoader = jest.fn(() =>
+    Promise.resolve({ _id: "5748d153cd530e2d5100031c" })
+  )
+  const context: Partial<ResolverContext> = {
+    partnerLoader,
+  }
+
+  it("is accessible through the partner type", async () => {
+    const query = gql`
+      query {
+        partner(id: "5748d153cd530e2d5100031c") {
+          analytics {
+            sales(period: FOUR_WEEKS) {
+              partnerId
+              totalCents
+              timeSeries {
+                startTime
+                endTime
+                totalCents
+              }
+            }
+          }
+        }
+      }
+    `
+    const result = await runQuery(query, context)
+    expect(result).toMatchInlineSnapshot(`
+Object {
+  "partner": Object {
+    "analytics": Object {
+      "sales": Object {
+        "partnerId": "5748d153cd530e2d5100031c",
+        "timeSeries": Array [
+          Object {
+            "endTime": "2019-05-05T00:00:00Z",
+            "startTime": "2019-05-04T00:00:00Z",
+            "totalCents": 0,
+          },
+          Object {
+            "endTime": "2019-05-06T00:00:00Z",
+            "startTime": "2019-05-05T00:00:00Z",
+            "totalCents": 280000,
+          },
+        ],
+        "totalCents": 3682500,
+      },
+    },
+  },
+}
+`)
+  })
+
+  it("exposes formatted total fields", async () => {
+    const query = gql`
+      query {
+        partner(id: "5748d153cd530e2d5100031c") {
+          analytics {
+            sales(period: FOUR_WEEKS) {
+              partnerId
+              totalCents
+              total
+              timeSeries {
+                startTime
+                endTime
+                totalCents
+                total(
+                  symbol: "¥"
+                  precision: 3
+                  format: "%v %s"
+                  thousand: "|"
+                  decimal: "。"
+                )
+              }
+            }
+          }
+        }
+      }
+    `
+    const result = await runQuery(query, context)
+    expect(result).toMatchInlineSnapshot(`
+Object {
+  "partner": Object {
+    "analytics": Object {
+      "sales": Object {
+        "partnerId": "5748d153cd530e2d5100031c",
+        "timeSeries": Array [
+          Object {
+            "endTime": "2019-05-05T00:00:00Z",
+            "startTime": "2019-05-04T00:00:00Z",
+            "total": "0。000 ¥",
+            "totalCents": 0,
+          },
+          Object {
+            "endTime": "2019-05-06T00:00:00Z",
+            "startTime": "2019-05-05T00:00:00Z",
+            "total": "2|800。000 ¥",
+            "totalCents": 280000,
+          },
+        ],
+        "total": "$36,825",
+        "totalCents": 3682500,
+      },
+    },
+  },
+}
+`)
+  })
+})

--- a/src/lib/stitching/vortex/__tests__/topArtworks.test.ts
+++ b/src/lib/stitching/vortex/__tests__/topArtworks.test.ts
@@ -50,7 +50,7 @@ describe("TopArtworks type", () => {
     }
   `
 
-  it("is accessible through the artwork type", async () => {
+  it("is accessible through the partner type", async () => {
     const result = await runQuery(query, context)
     expect(result).toMatchInlineSnapshot(`
 Object {

--- a/src/lib/stitching/vortex/stitching.ts
+++ b/src/lib/stitching/vortex/stitching.ts
@@ -47,6 +47,24 @@ export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
     extend type AnalyticsTopArtworks {
       artwork: Artwork
     }
+    extend type AnalyticsPartnerSalesStats {
+      total(
+        decimal: String = "."
+        format: String = "%s%v"
+        precision: Int = 0
+        symbol: String
+        thousand: String = ","
+      ): String
+    }
+    extend type AnalyticsPartnerSalesTimeSeriesStats {
+      total(
+        decimal: String = "."
+        format: String = "%s%v"
+        precision: Int = 0
+        symbol: String
+        thousand: String = ","
+      ): String
+    }
   `,
   resolvers: {
     AnalyticsPricingContext: {
@@ -250,6 +268,28 @@ export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
             transforms: vortexSchema.transforms,
           })
         },
+      },
+    },
+    AnalyticsPartnerSalesStats: {
+      total: {
+        fragment: gql`
+          ... on AnalyticsPartnerSalesStats {
+            totalCents
+          }
+        `,
+        resolve: (parent, args, _context, _info) =>
+          amount(_ => parent.totalCents).resolve({}, args),
+      },
+    },
+    AnalyticsPartnerSalesTimeSeriesStats: {
+      total: {
+        fragment: gql`
+          ... on AnalyticsPartnerSalesStats {
+            totalCents
+          }
+        `,
+        resolve: (parent, args, _context, _info) =>
+          amount(_ => parent.totalCents).resolve({}, args),
       },
     },
   },

--- a/src/lib/stitching/vortex/stitching.ts
+++ b/src/lib/stitching/vortex/stitching.ts
@@ -284,7 +284,7 @@ export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
     AnalyticsPartnerSalesTimeSeriesStats: {
       total: {
         fragment: gql`
-          ... on AnalyticsPartnerSalesStats {
+          ... on AnalyticsPartnerSalesTimeSeriesStats {
             totalCents
           }
         `,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GALL-1671

Following existing patterns, this exposes formatted string fields for `totalCents` on `AnalyticsPartnerSalesStats` and `AnalyticsPartnerSalesTimeSeriesStats`.

![Screen Shot 2019-05-23 at 11 50 43 PM](https://user-images.githubusercontent.com/796573/58301725-a1e1e780-7db5-11e9-8f2c-9dd0225dfb5b.png)

