### PR TITLE
GALL-1753: Add order response time to Vortex schema

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -105,6 +105,7 @@ type AnalyticsPageviewStats {
 
 # Sales stats of a partner
 type AnalyticsPartnerSalesStats {
+  orderResponseTime: Int!
   partnerId: String!
   period: AnalyticsQueryPeriodEnum!
 

--- a/src/data/vortex.graphql
+++ b/src/data/vortex.graphql
@@ -65,6 +65,7 @@ type PageviewStats {
 Sales stats of a partner
 """
 type PartnerSalesStats {
+  orderResponseTime: Int!
   partnerId: String!
   period: QueryPeriodEnum!
 
@@ -285,7 +286,11 @@ type Query {
   """
   Pricing Context Histograms
   """
-  pricingContext(artistId: String!, category: PricingContextCategoryEnum!, sizeScore: Int!): PricingContext
+  pricingContext(
+    artistId: String!
+    category: PricingContextCategoryEnum!
+    sizeScore: Int!
+  ): PricingContext
 }
 
 enum QueryPeriodEnum {


### PR DESCRIPTION
This PR updates MP's copy of Vortex schema with a new field, `OrderResponseTime`. That field is implemented in [Vortex #134](https://github.com/artsy/vortex/pull/134).

Although this is a non-breaking change and is not currently being consumed by anything, I marked as `Do not merge` in case we decide to do something like change the field name. Once the associated Vortex PR is merged, I'll update the title and we can go for it.