### PR TITLE
Make image id nullable again

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -6460,11 +6460,8 @@ type HomePageModulesParams {
 }
 
 type Image {
-  # A globally unique ID.
-  __id: ID!
-
   # A type-specific ID.
-  id: ID!
+  id: ID
   aspect_ratio: Float!
   caption: String
   cropped(width: Int!, height: Int!, version: [String]): CroppedImageUrl

--- a/src/schema/image/index.ts
+++ b/src/schema/image/index.ts
@@ -15,7 +15,7 @@ import DeepZoom, { isZoomable } from "./deep_zoom"
 import { ImageData, normalize } from "./normalize"
 import ResizedUrl from "./resized"
 import VersionedUrl from "./versioned"
-import { IDFields } from "schema/object_identification"
+import { NullableIDField } from "schema/object_identification"
 
 export { normalize as normalizeImageData } from "./normalize"
 
@@ -29,7 +29,7 @@ export const getDefault = images => {
 const ImageType = new GraphQLObjectType<any, ResolverContext>({
   name: "Image",
   fields: (): any => ({
-    ...IDFields,
+    ...NullableIDField,
     aspect_ratio: {
       type: new GraphQLNonNull(GraphQLFloat),
       resolve: ({ aspect_ratio }) => {

--- a/src/schema/index_v2.ts
+++ b/src/schema/index_v2.ts
@@ -45,6 +45,7 @@ const KnownTypesWithNullableIDFields = [
   "MarketingCollectionQuery",
   "FeaturedLinkItem",
   "HomePageModulesParams",
+  "Image",
 ]
 
 class IdRenamer implements Transform {


### PR DESCRIPTION
Sentry is reporting the following error:

```
Cannot return null for non-nullable field Image.__id.
       __id
```

Previously, `__id` wasn't present on the `Image` and its `id` field is nullable. I'm restoring it back to the old nullable field and we can follow up later on how to resolve it. 

It _does_ seem like there are places in reaction that's actually querying `__id` on the image. 