### PR TITLE
Shore up nullable ids

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -4158,8 +4158,8 @@ type Conversation implements Node {
   # A globally unique ID.
   __id: ID!
 
-  # A type-specific ID likely used as a database ID.
-  id: ID!
+  # A type-specific ID.
+  id: ID
 
   # Gravity inquiry id.
   inquiry_id: String
@@ -4956,7 +4956,7 @@ type FairExhibitor {
   __id: ID!
 
   # A type-specific ID.
-  id: ID!
+  id: ID
 
   # A type-specific Gravity Mongo Document ID.
   _id: ID!

--- a/src/schema/fair.ts
+++ b/src/schema/fair.ts
@@ -14,7 +14,7 @@ import Artist from "./artist"
 import Partner from "./partner"
 import { showConnection } from "./show"
 import Location from "./location"
-import { GravityIDFields } from "./object_identification"
+import { GravityIDFields, NullableIDField } from "./object_identification"
 import filterArtworks from "./filter_artworks"
 import {
   GraphQLObjectType,
@@ -313,6 +313,7 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
                   name: "FairExhibitor",
                   fields: {
                     ...GravityIDFields,
+                    ...NullableIDField,
                     name: {
                       type: GraphQLString,
                       description: "Exhibitor name",

--- a/src/schema/index_v2.ts
+++ b/src/schema/index_v2.ts
@@ -46,6 +46,8 @@ const KnownTypesWithNullableIDFields = [
   "FeaturedLinkItem",
   "HomePageModulesParams",
   "Image",
+  "Conversation",
+  "FairExhibitor",
 ]
 
 class IdRenamer implements Transform {

--- a/src/schema/me/conversation/index.ts
+++ b/src/schema/me/conversation/index.ts
@@ -21,6 +21,7 @@ import {
   GlobalIDField,
   NodeInterface,
   InternalIDFields,
+  NullableIDField,
 } from "schema/object_identification"
 import { MessageType } from "./message"
 import { ResolverContext } from "types/graphql"
@@ -157,7 +158,7 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
   interfaces: [NodeInterface],
   fields: {
     __id: GlobalIDField,
-    ...InternalIDFields,
+    ...NullableIDField,
     inquiry_id: {
       description: "Gravity inquiry id.",
       type: GraphQLString,


### PR DESCRIPTION
Upon performing an audit of the `id` fields that have changed since #1678 these types had `id`s that went from nullable to non-nullable:

- BuyOrder
- Offer
- OfferOrder
- Order
- OrderFulfillment
- OrderLineItem
- Conversation
- FairExhibitor

According to @ashkan18 the order/offer types should add have ids present and the reason they were left nullable was a misunderstanding of the `ID` type. (It was assumed that a field typed as `ID` was always non-nullable). 

The last two on the list we're not confident about so I've reinstated their nullability just to be on the safe side. 

Getting this in before #1727. 