### PR TITLE
 [v2] Properly rename nullable id field on non-Gravity types

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -4158,7 +4158,7 @@ type Conversation implements Node {
   # A globally unique ID.
   __id: ID!
 
-  # A type-specific ID.
+  # An optional type-specific ID.
   id: ID
 
   # Gravity inquiry id.
@@ -4955,7 +4955,7 @@ type FairExhibitor {
   # A globally unique ID.
   __id: ID!
 
-  # A type-specific ID.
+  # An optional type-specific ID.
   id: ID
 
   # A type-specific Gravity Mongo Document ID.
@@ -6464,7 +6464,7 @@ type HomePageModuleContextTrending {
 }
 
 type HomePageModulesParams {
-  # A type-specific ID.
+  # An optional type-specific ID.
   id: ID
   followed_artist_id: ID
   gene_id: String
@@ -6474,7 +6474,7 @@ type HomePageModulesParams {
 }
 
 type Image {
-  # A type-specific ID.
+  # An optional type-specific ID.
   id: ID
   aspect_ratio: Float!
   caption: String
@@ -9536,7 +9536,7 @@ type SaleArtworkEdge {
 }
 
 type SaleArtworkHighestBid {
-  # A type-specific ID.
+  # An optional type-specific ID.
   id: ID
   created_at(
     # This arg is deprecated, use timezone instead

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4158,8 +4158,8 @@ type Conversation implements Node {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID.
-  gravityID: ID
+  # An optional type-specific ID.
+  internalID: ID
 
   # Gravity inquiry id.
   inquiry_id: String
@@ -4955,7 +4955,7 @@ type FairExhibitor {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID.
+  # An optional type-specific ID.
   gravityID: ID
 
   # A type-specific Gravity Mongo Document ID.
@@ -6464,7 +6464,7 @@ type HomePageModuleContextTrending {
 }
 
 type HomePageModulesParams {
-  # A type-specific ID.
+  # An optional type-specific ID.
   gravityID: ID
   followed_artist_id: ID
   gene_id: String
@@ -6474,7 +6474,7 @@ type HomePageModulesParams {
 }
 
 type Image {
-  # A type-specific ID.
+  # An optional type-specific ID.
   gravityID: ID
   aspect_ratio: Float!
   caption: String

--- a/index.js
+++ b/index.js
@@ -32,6 +32,9 @@ const enableQueryTracing = ENABLE_QUERY_TRACING === "true"
 
 let server, isShuttingDown
 
+// Always load the source on startup so any file level issues surface sooner.
+require("./src")
+
 // This needs to happen as early as possible so the plugins can hook into the
 // modules we use before any other code gets a chance to use them.
 if (enableQueryTracing) {

--- a/src/schema/object_identification.ts
+++ b/src/schema/object_identification.ts
@@ -158,7 +158,7 @@ export const GlobalIDField = {
 
 export const NullableIDField = {
   id: {
-    description: "A type-specific ID.",
+    description: "An optional type-specific ID.",
     type: GraphQLID,
   },
 }


### PR DESCRIPTION
Noticed that `Conversation`, which comes from impulse, had a `gravityID` instead of `internalID`.