### PR TITLE
 [ConsignmentSubmission] Remove ID fields other than DB ID

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -4059,15 +4059,9 @@ type ConfirmPickupPayload {
 }
 
 # A work to be consigned to the user
-type ConsignmentSubmission implements Node {
-  # A globally unique ID.
-  __id: ID!
-
-  # A type-specific ID.
-  id: ID!
-
-  # A type-specific Gravity Mongo Document ID.
-  _id: ID!
+type ConsignmentSubmission {
+  # An optional type-specific ID.
+  id: ID
 
   # The gravity ID for an Artist
   artist_id: String!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4059,15 +4059,9 @@ type ConfirmPickupPayload {
 }
 
 # A work to be consigned to the user
-type ConsignmentSubmission implements Node {
-  # A globally unique ID.
-  id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
-
-  # A type-specific Gravity Mongo Document ID.
-  internalID: ID!
+type ConsignmentSubmission {
+  # An optional type-specific ID.
+  internalID: ID
 
   # The gravity ID for an Artist
   artist_id: String!

--- a/src/schema/index_v2.ts
+++ b/src/schema/index_v2.ts
@@ -88,7 +88,6 @@ class IdRenamer implements Transform {
               } else {
                 if (
                   field.description === GravityIDFields.id.description ||
-                  // TODO: We transform them to non-nullable, so make sure they are!
                   (field.description === NullableIDField.id.description &&
                     KnownGravityTypesWithNullableIDFields.includes(
                       type.name
@@ -102,7 +101,6 @@ class IdRenamer implements Transform {
                   }
                 } else if (
                   field.description === InternalIDFields.id.description ||
-                  // TODO: We transform them to non-nullable, so make sure they are!
                   (field.description === NullableIDField.id.description &&
                     KnownNonGravityTypesWithNullableIDFields.includes(
                       type.name
@@ -161,7 +159,6 @@ class IdRenamer implements Transform {
           if (field.name === "id") {
             if (
               field.description === GravityIDFields.id.description ||
-              // TODO: We transform them to non-nullable, so make sure they are!
               (field.description === NullableIDField.id.description &&
                 KnownGravityTypesWithNullableIDFields.includes(type.name)) ||
               type.name === "DoNotUseThisPartner"
@@ -173,7 +170,6 @@ class IdRenamer implements Transform {
               }
             } else if (
               field.description === InternalIDFields.id.description ||
-              // TODO: We transform them to non-nullable, so make sure they are!
               (field.description === NullableIDField.id.description &&
                 KnownNonGravityTypesWithNullableIDFields.includes(type.name)) ||
               KAWSTypes.includes(type.name) ||

--- a/src/schema/index_v2.ts
+++ b/src/schema/index_v2.ts
@@ -52,7 +52,10 @@ const KnownGravityTypesWithNullableIDFields = [
   "Image",
   "FairExhibitor",
 ]
-const KnownNonGravityTypesWithNullableIDFields = ["Conversation"]
+const KnownNonGravityTypesWithNullableIDFields = [
+  "Conversation",
+  "ConsignmentSubmission",
+]
 const KnownTypesWithNullableIDFields = [
   ...KnownGravityTypesWithNullableIDFields,
   ...KnownNonGravityTypesWithNullableIDFields,

--- a/src/schema/me/consignments/submission.ts
+++ b/src/schema/me/consignments/submission.ts
@@ -7,7 +7,7 @@ import {
   GraphQLInt,
   GraphQLID,
 } from "graphql"
-import { GravityIDFields, NodeInterface } from "schema/object_identification"
+import { NullableIDField } from "schema/object_identification"
 import Artist from "schema/artist"
 import { ResolverContext } from "types/graphql"
 
@@ -178,9 +178,8 @@ export const SharedInputOutputFields = {
 export const SubmissionType = new GraphQLObjectType<any, ResolverContext>({
   name: "ConsignmentSubmission",
   description: "A work to be consigned to the user",
-  interfaces: [NodeInterface],
   fields: {
-    ...GravityIDFields,
+    ...NullableIDField,
     ...SharedInputOutputFields,
     artist: {
       type: Artist.type,


### PR DESCRIPTION
`ConsignmentSubmission` has all the id fields right now, but no clients should be using anything other than `id` on v1, so I’m just going to remove the others as it keeps transforming slightly simpler.