### PR TITLE
Update schema for inquiry stats from Vortex (GALL-1503)

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -103,6 +103,14 @@ type AnalyticsPageviewStats {
   uniqueVisitors: Int
 }
 
+# Inquiry stats of a partner
+type AnalyticsPartnerInquiryStats {
+  inquiryCount: Int!
+  inquiryResponseTime: Int
+  partnerId: String!
+  period: AnalyticsQueryPeriodEnum!
+}
+
 # Sales stats of a partner
 type AnalyticsPartnerSalesStats {
   orderCount: Int!
@@ -145,6 +153,9 @@ type AnalyticsPartnerStats {
   artworksPublished(
     period: AnalyticsQueryPeriodEnum!
   ): AnalyticsArtworksPublishedStats
+
+  # Inquiry stats
+  inquiry(period: AnalyticsQueryPeriodEnum!): AnalyticsPartnerInquiryStats
 
   # Different types of partner pageviews
   pageviews(period: AnalyticsQueryPeriodEnum!): AnalyticsPageviewStats

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -103,6 +103,14 @@ type AnalyticsPageviewStats {
   uniqueVisitors: Int
 }
 
+# Inquiry stats of a partner
+type AnalyticsPartnerInquiryStats {
+  inquiryCount: Int!
+  inquiryResponseTime: Int
+  partnerId: String!
+  period: AnalyticsQueryPeriodEnum!
+}
+
 # Sales stats of a partner
 type AnalyticsPartnerSalesStats {
   orderCount: Int!
@@ -145,6 +153,9 @@ type AnalyticsPartnerStats {
   artworksPublished(
     period: AnalyticsQueryPeriodEnum!
   ): AnalyticsArtworksPublishedStats
+
+  # Inquiry stats
+  inquiry(period: AnalyticsQueryPeriodEnum!): AnalyticsPartnerInquiryStats
 
   # Different types of partner pageviews
   pageviews(period: AnalyticsQueryPeriodEnum!): AnalyticsPageviewStats

--- a/src/data/vortex.graphql
+++ b/src/data/vortex.graphql
@@ -62,6 +62,16 @@ type PageviewStats {
 }
 
 """
+Inquiry stats of a partner
+"""
+type PartnerInquiryStats {
+  inquiryCount: Int!
+  inquiryResponseTime: Int
+  partnerId: String!
+  period: QueryPeriodEnum!
+}
+
+"""
 Sales stats of a partner
 """
 type PartnerSalesStats {
@@ -95,6 +105,11 @@ type PartnerStats {
   Time series data on number of artworks published
   """
   artworksPublished(period: QueryPeriodEnum!): ArtworksPublishedStats
+
+  """
+  Inquiry stats
+  """
+  inquiry(period: QueryPeriodEnum!): PartnerInquiryStats
 
   """
   Different types of partner pageviews


### PR DESCRIPTION
### What?
This PR adds the `PartnerInquiryStats` type from the Vortex GraphQL schema into Metaphysics and exposes it as `AnalyticsPartnerInquiryStats`.

### Why?
This change allows the CMS to display information about a partner's inquiries (specifically, how many they received and how soon they were able to respond to them in a given time period) to the Sales section of the analytics dashboard.

### Show me!
![query](https://user-images.githubusercontent.com/44589599/58820190-ecf2ca80-85ff-11e9-8fd1-d94af207f280.png)
