### PR TITLE
Exclude danger for now

### DIFF
--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -10,7 +10,6 @@ services:
       - CI_PULL_REQUEST=$CI_PULL_REQUEST
       - CIRCLE_PULL_REQUEST=$CIRCLE_PULL_REQUEST
       - CIRCLE_BUILD_NUM=$CIRCLE_BUILD_NUM
-      - DANGER_GITHUB_API_TOKEN=$DANGER_GITHUB_API_TOKEN
     env_file: ../.env.test
     depends_on:
       - metaphysics-memcached

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:lib": "babel src --copy-files --extensions '.ts,.js' --ignore src/test,src/integration,src/**/__tests__ -s inline -d build/src",
     "build:remote-schemas": "cp src/data/*.graphql build/src/data/",
     "build": "yarn build:lib && yarn build:index && yarn build:fixtures && yarn build:remote-schemas",
-    "ci": "yarn test && yarn danger ci",
+    "ci": "yarn test",
     "dev": "DEBUG=info,warn,error nf start --procfile Procfile.dev -w",
     "dump-remote-schema": "babel-node --extensions '.ts,.js' ./scripts/dump-remote-schema.ts",
     "dump-schema": "babel-node --extensions '.ts,.js' ./scripts/dump-schema.ts",


### PR DESCRIPTION
Metaphysics PR builds have been failing ever since we stopped sharing secrets with forked PRs.

I honestly don't know how critical some of [Danger's current checks](https://github.com/artsy/metaphysics/blob/master/dangerfile.ts) are to our workflow. If they are, seems like our best option is migrating them to something like Peril. I don't think we should tolerate build failures until then, so I suggest we exclude Danger for now.