### PR TITLE
does not pass NaN as a page value

### DIFF
--- a/src/schema/filter_artworks.ts
+++ b/src/schema/filter_artworks.ts
@@ -113,7 +113,9 @@ export const FilterArtworksType = new GraphQLObjectType<any, ResolverContext>({
         }
       ) => {
         const relayOptions = convertConnectionArgsToGravityArgs(args)
-        if (!!gravityOptions.page) relayOptions.page = gravityOptions.page
+        if (!!gravityOptions.page && !isNaN(gravityOptions.page)) {
+          relayOptions.page = gravityOptions.page
+        }
 
         const { page, size } = relayOptions
         const {


### PR DESCRIPTION
Metaphysics right now seems to be passing `NaN` as the value of the `page` parameter when it queries for collections through `filter_artworks`, leading to e.g. no artworks showing up on pages like this: https://www.artsy.net/collection/andy-warhol-jean-michel-basquiat

This is an emergency patch to get these things rendering correctly again. Additional debugging is ongoing.