### PR TITLE
allow to ask for non-shallow version of artwork in SaleArtwork

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -9457,7 +9457,10 @@ type SaleArtwork {
   # A type-specific Gravity Mongo Document ID.
   _id: ID!
   cached: Int
-  artwork: Artwork
+  artwork(
+    # Use whatever is in the original response instead of making a request
+    shallow: Boolean = true
+  ): Artwork
   bidder_positions_count: Int
     @deprecated(reason: "Favor `counts.bidder_positions`")
   bid_increments: [Float] @deprecated(reason: "Favor `increments.cents`")

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9457,7 +9457,10 @@ type SaleArtwork {
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   cached: Int
-  artwork: Artwork
+  artwork(
+    # Use whatever is in the original response instead of making a request
+    shallow: Boolean = true
+  ): Artwork
   bidder_positions_count: Int
     @deprecated(reason: "Favor `counts.bidder_positions`")
   bid_increments: [Float] @deprecated(reason: "Favor `increments.cents`")

--- a/src/schema/__tests__/sale_artwork.test.js
+++ b/src/schema/__tests__/sale_artwork.test.js
@@ -106,7 +106,7 @@ describe("SaleArtwork type", () => {
   })
 
   describe("artwork resolver", () => {
-    it("does not include edition sets when not asking for shallow version", async () => {
+    it("does not include edition sets when asking for shallow version", async () => {
       const query = `
         {
           sale_artwork(id: "54c7ed2a7261692bfa910200") {
@@ -128,7 +128,7 @@ describe("SaleArtwork type", () => {
         },
       })
     })
-    it("does includes edition sets when asking for shallow version", async () => {
+    it("includes edition sets when asking for non-shallow version", async () => {
       const query = `
         {
           sale_artwork(id: "54c7ed2a7261692bfa910200") {

--- a/src/schema/__tests__/sale_artwork.test.js
+++ b/src/schema/__tests__/sale_artwork.test.js
@@ -9,6 +9,10 @@ describe("SaleArtwork type", () => {
       amount_cents: 325000,
       display_amount_dollars: "€3,250",
     },
+    artwork: {
+      id: "artwork-1",
+      title: "Untitled1",
+    },
     bidder_positions_count: 7,
     highest_bid_amount_cents: 325000,
     display_highest_bid_amount_dollars: "€3,250",
@@ -25,6 +29,16 @@ describe("SaleArtwork type", () => {
     symbol: "€",
   }
 
+  const artwork = {
+    id: "artwork-1",
+    title: "Untitled 1",
+    edition_sets: [
+      {
+        id: "ed-1",
+      },
+    ],
+  }
+
   const execute = async (
     query,
     gravityResponse = saleArtwork,
@@ -32,6 +46,7 @@ describe("SaleArtwork type", () => {
   ) => {
     return await runQuery(query, {
       saleArtworkRootLoader: () => Promise.resolve(gravityResponse),
+      artworkLoader: () => Promise.resolve(artwork),
       ...context,
     })
   }
@@ -87,6 +102,57 @@ describe("SaleArtwork type", () => {
           display: "€3,250",
         },
       },
+    })
+  })
+
+  describe("artwork resolver", () => {
+    it("does not include edition sets when not asking for shallow version", async () => {
+      const query = `
+        {
+          sale_artwork(id: "54c7ed2a7261692bfa910200") {
+            artwork{
+              id
+              edition_sets{
+                id
+              }
+            }
+          }
+        }
+      `
+      expect(await execute(query)).toEqual({
+        sale_artwork: {
+          artwork: {
+            id: "artwork-1",
+            edition_sets: null,
+          },
+        },
+      })
+    })
+    it("does includes edition sets when asking for shallow version", async () => {
+      const query = `
+        {
+          sale_artwork(id: "54c7ed2a7261692bfa910200") {
+            artwork(shallow: false){
+              id
+              edition_sets{
+                id
+              }
+            }
+          }
+        }
+      `
+      expect(await execute(query)).toEqual({
+        sale_artwork: {
+          artwork: {
+            id: "artwork-1",
+            edition_sets: [
+              {
+                id: "ed-1",
+              },
+            ],
+          },
+        },
+      })
     })
   })
 

--- a/src/schema/sale_artwork.ts
+++ b/src/schema/sale_artwork.ts
@@ -83,7 +83,22 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
     return {
       ...GravityIDFields,
       cached,
-      artwork: { type: Artwork.type, resolve: ({ artwork }) => artwork },
+      artwork: {
+        type: Artwork.type,
+        args: {
+          shallow: {
+            type: GraphQLBoolean,
+            description:
+              "Use whatever is in the original response instead of making a request",
+            defaultValue: true,
+          },
+        },
+        resolve: ({ artwork }, { shallow }, { artworkLoader }) => {
+          if (!artwork) return null
+          if (shallow) return artwork
+          return artworkLoader(artwork.id).catch(() => null)
+        },
+      },
       bidder_positions_count: {
         type: GraphQLInt,
         deprecationReason: "Favor `counts.bidder_positions`",

--- a/src/schema/sale_artwork.ts
+++ b/src/schema/sale_artwork.ts
@@ -96,7 +96,7 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ artwork }, { shallow }, { artworkLoader }) => {
           if (!artwork) return null
           if (shallow) return artwork
-          return artworkLoader(artwork.id).catch(() => null)
+          return artworkLoader(artwork.id).catch(() => artwork)
         },
       },
       bidder_positions_count: {


### PR DESCRIPTION
# Problem
As part of https://github.com/artsy/prediction/pull/739 we started to expose more details about the artwork of each lot. But we are not getting edition set data back in MP for a `SaleArtwork` so we can't see edition set info.

![image](https://user-images.githubusercontent.com/1230819/58975135-3bd06980-8792-11e9-9b71-161c187aa657.png)

# Cause
`SaleArtwork` exposes `artwork` but since we haven't defined what `properties` to include it uses `short` by default which would not include `edition_sets`. In Metaphysics we currently rely on whats returned from Gravity as part of `SaleArtwork` response which would not include `edition_sets`.

# Solution
Follow same pattern as https://github.com/artsy/metaphysics/blob/6ddaa9fba54510af88f9a00967aa2ed0bb623152/src/schema/artwork/index.ts#L63-L75
to allow clients ask for a _non-shallow_ version of the artwork which forces a gravity fetch.

![image](https://user-images.githubusercontent.com/1230819/58989953-e5bfee00-87b2-11e9-9bde-fc393fce5668.png)


thanks to @joeyAghion and @mzikherman for suggesting this approach over https://github.com/artsy/gravity/pull/12391