### PR TITLE
update kaws schema with relatedCollections field

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -6674,6 +6674,7 @@ type MarketingCollection {
 
   # Collection has prioritized connection to artist
   is_featured_artist_content: Boolean!
+  relatedCollections: [MarketingCollection!]!
   artworks(
     acquireable: Boolean
     offerable: Boolean

--- a/src/data/kaws.graphql
+++ b/src/data/kaws.graphql
@@ -36,6 +36,7 @@ type Collection {
 
   # Collection has prioritized connection to artist
   is_featured_artist_content: Boolean!
+  relatedCollections: [Collection!]!
 }
 
 type CollectionCategory {

--- a/src/lib/stitching/kaws/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/kaws/__tests__/__snapshots__/schema.test.ts.snap
@@ -39,6 +39,7 @@ type MarketingCollection {
 
   # Collection has prioritized connection to artist
   is_featured_artist_content: Boolean!
+  relatedCollections: [MarketingCollection!]!
 }
 
 type MarketingCollectionCategory {


### PR DESCRIPTION
This updates the kaws schema as part of [GROW-1284](https://artsyproduct.atlassian.net/browse/GROW-1284).