### PR TITLE
GALL-1811: [WIP] Update artwork stitching, add show stitching

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -110,24 +110,12 @@ type AnalyticsPartnerAudienceStats {
   uniqueVisitors: Int!
 }
 
-# Inquiry count time series data of a partner
-type AnalyticsPartnerInquiryCountTimeSeriesStats {
-  count: Int
-  endTime: AnalyticsDateTime
-  startTime: AnalyticsDateTime
-}
-
 # Inquiry stats of a partner
 type AnalyticsPartnerInquiryStats {
   inquiryCount: Int!
   inquiryResponseTime: Int
   partnerId: String!
   period: AnalyticsQueryPeriodEnum!
-
-  # Partner inquiry count time series
-  timeSeries(
-    cumulative: Boolean = false
-  ): [AnalyticsPartnerInquiryCountTimeSeriesStats!]
 }
 
 # Sales stats of a partner
@@ -183,10 +171,27 @@ type AnalyticsPartnerStats {
   pageviews(period: AnalyticsQueryPeriodEnum!): AnalyticsPageviewStats
   partnerId: String!
 
+  # Artworks, shows, and artists ranked by views
+  rankedStats(
+    # Returns the elements in the list that come after the specified cursor.
+    after: String
+
+    # Returns the elements in the list that come before the specified cursor.
+    before: String
+
+    # Returns the first _n_ elements from the list.
+    first: Int
+
+    # Returns the last _n_ elements from the list.
+    last: Int
+    objectType: String!
+    period: AnalyticsQueryPeriodEnum!
+  ): AnalyticsRankedStatsConnection
+
   # Sales stats
   sales(period: AnalyticsQueryPeriodEnum!): AnalyticsPartnerSalesStats
 
-  # Artworks ranked by views
+  # Top artworks ranked by views
   topArtworks(
     # Returns the elements in the list that come after the specified cursor.
     after: String
@@ -199,8 +204,8 @@ type AnalyticsPartnerStats {
 
     # Returns the last _n_ elements from the list.
     last: Int
-    period: AnalyticsQueryPeriodEnum!
-  ): AnalyticsTopArtworksConnection
+  ): AnalyticsRankedStatsConnection
+    @deprecated(reason: "Use rankedStats(objectType: ) instead")
 
   # Number of unique visitors
   uniqueVisitors(period: AnalyticsQueryPeriodEnum!): Int
@@ -308,33 +313,35 @@ enum AnalyticsQueryPeriodEnum {
   SIXTEEN_WEEKS
 }
 
-# Top artworks from a partner
-type AnalyticsTopArtworks {
-  artworkId: String!
+# Top artworks, shows, or artists from a partner
+type AnalyticsRankedStats {
+  objectId: String!
+  objectType: String!
   period: AnalyticsQueryPeriodEnum!
   value: Int!
   artwork: Artwork
+  show: Show
 }
 
-# The connection type for TopArtworks.
-type AnalyticsTopArtworksConnection {
+# The connection type for RankedStats.
+type AnalyticsRankedStatsConnection {
   # A list of edges.
-  edges: [AnalyticsTopArtworksEdge]
+  edges: [AnalyticsRankedStatsEdge]
 
   # A list of nodes.
-  nodes: [AnalyticsTopArtworks]
+  nodes: [AnalyticsRankedStats]
 
   # Information to aid in pagination.
   pageInfo: AnalyticsPageInfo!
 }
 
 # An edge in a connection.
-type AnalyticsTopArtworksEdge {
+type AnalyticsRankedStatsEdge {
   # A cursor for use in pagination.
   cursor: String!
 
   # The item at the end of the edge.
-  node: AnalyticsTopArtworks
+  node: AnalyticsRankedStats
 }
 
 input ApproveOrderInput {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -110,24 +110,12 @@ type AnalyticsPartnerAudienceStats {
   uniqueVisitors: Int!
 }
 
-# Inquiry count time series data of a partner
-type AnalyticsPartnerInquiryCountTimeSeriesStats {
-  count: Int
-  endTime: AnalyticsDateTime
-  startTime: AnalyticsDateTime
-}
-
 # Inquiry stats of a partner
 type AnalyticsPartnerInquiryStats {
   inquiryCount: Int!
   inquiryResponseTime: Int
   partnerId: String!
   period: AnalyticsQueryPeriodEnum!
-
-  # Partner inquiry count time series
-  timeSeries(
-    cumulative: Boolean = false
-  ): [AnalyticsPartnerInquiryCountTimeSeriesStats!]
 }
 
 # Sales stats of a partner
@@ -183,10 +171,27 @@ type AnalyticsPartnerStats {
   pageviews(period: AnalyticsQueryPeriodEnum!): AnalyticsPageviewStats
   partnerId: String!
 
+  # Artworks, shows, and artists ranked by views
+  rankedStats(
+    # Returns the elements in the list that come after the specified cursor.
+    after: String
+
+    # Returns the elements in the list that come before the specified cursor.
+    before: String
+
+    # Returns the first _n_ elements from the list.
+    first: Int
+
+    # Returns the last _n_ elements from the list.
+    last: Int
+    objectType: String!
+    period: AnalyticsQueryPeriodEnum!
+  ): AnalyticsRankedStatsConnection
+
   # Sales stats
   sales(period: AnalyticsQueryPeriodEnum!): AnalyticsPartnerSalesStats
 
-  # Artworks ranked by views
+  # Top artworks ranked by views
   topArtworks(
     # Returns the elements in the list that come after the specified cursor.
     after: String
@@ -199,8 +204,8 @@ type AnalyticsPartnerStats {
 
     # Returns the last _n_ elements from the list.
     last: Int
-    period: AnalyticsQueryPeriodEnum!
-  ): AnalyticsTopArtworksConnection
+  ): AnalyticsRankedStatsConnection
+    @deprecated(reason: "Use rankedStats(objectType: ) instead")
 
   # Number of unique visitors
   uniqueVisitors(period: AnalyticsQueryPeriodEnum!): Int
@@ -308,33 +313,35 @@ enum AnalyticsQueryPeriodEnum {
   SIXTEEN_WEEKS
 }
 
-# Top artworks from a partner
-type AnalyticsTopArtworks {
-  artworkId: String!
+# Top artworks, shows, or artists from a partner
+type AnalyticsRankedStats {
+  objectId: String!
+  objectType: String!
   period: AnalyticsQueryPeriodEnum!
   value: Int!
   artwork: Artwork
+  show: Show
 }
 
-# The connection type for TopArtworks.
-type AnalyticsTopArtworksConnection {
+# The connection type for RankedStats.
+type AnalyticsRankedStatsConnection {
   # A list of edges.
-  edges: [AnalyticsTopArtworksEdge]
+  edges: [AnalyticsRankedStatsEdge]
 
   # A list of nodes.
-  nodes: [AnalyticsTopArtworks]
+  nodes: [AnalyticsRankedStats]
 
   # Information to aid in pagination.
   pageInfo: AnalyticsPageInfo!
 }
 
 # An edge in a connection.
-type AnalyticsTopArtworksEdge {
+type AnalyticsRankedStatsEdge {
   # A cursor for use in pagination.
   cursor: String!
 
   # The item at the end of the edge.
-  node: AnalyticsTopArtworks
+  node: AnalyticsRankedStats
 }
 
 input ApproveOrderInput {

--- a/src/data/vortex.graphql
+++ b/src/data/vortex.graphql
@@ -71,15 +71,6 @@ type PartnerAudienceStats {
 }
 
 """
-Inquiry count time series data of a partner
-"""
-type PartnerInquiryCountTimeSeriesStats {
-  count: Int
-  endTime: DateTime
-  startTime: DateTime
-}
-
-"""
 Inquiry stats of a partner
 """
 type PartnerInquiryStats {
@@ -87,11 +78,6 @@ type PartnerInquiryStats {
   inquiryResponseTime: Int
   partnerId: String!
   period: QueryPeriodEnum!
-
-  """
-  Partner inquiry count time series
-  """
-  timeSeries(cumulative: Boolean = false): [PartnerInquiryCountTimeSeriesStats!]
 }
 
 """
@@ -146,12 +132,39 @@ type PartnerStats {
   partnerId: String!
 
   """
+  Artworks, shows, and artists ranked by views
+  """
+  rankedStats(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+    objectType: String!
+    period: QueryPeriodEnum!
+  ): RankedStatsConnection
+
+  """
   Sales stats
   """
   sales(period: QueryPeriodEnum!): PartnerSalesStats
 
   """
-  Artworks ranked by views
+  Top artworks ranked by views
   """
   topArtworks(
     """
@@ -173,8 +186,8 @@ type PartnerStats {
     Returns the last _n_ elements from the list.
     """
     last: Int
-    period: QueryPeriodEnum!
-  ): TopArtworksConnection
+  ): RankedStatsConnection
+    @deprecated(reason: "Use rankedStats(objectType: ) instead")
 
   """
   Number of unique visitors
@@ -356,27 +369,28 @@ enum QueryPeriodEnum {
 }
 
 """
-Top artworks from a partner
+Top artworks, shows, or artists from a partner
 """
-type TopArtworks {
-  artworkId: String!
+type RankedStats {
+  objectId: String!
+  objectType: String!
   period: QueryPeriodEnum!
   value: Int!
 }
 
 """
-The connection type for TopArtworks.
+The connection type for RankedStats.
 """
-type TopArtworksConnection {
+type RankedStatsConnection {
   """
   A list of edges.
   """
-  edges: [TopArtworksEdge]
+  edges: [RankedStatsEdge]
 
   """
   A list of nodes.
   """
-  nodes: [TopArtworks]
+  nodes: [RankedStats]
 
   """
   Information to aid in pagination.
@@ -387,7 +401,7 @@ type TopArtworksConnection {
 """
 An edge in a connection.
 """
-type TopArtworksEdge {
+type RankedStatsEdge {
   """
   A cursor for use in pagination.
   """
@@ -396,5 +410,5 @@ type TopArtworksEdge {
   """
   The item at the end of the edge.
   """
-  node: TopArtworks
+  node: RankedStats
 }

--- a/src/lib/stitching/vortex/stitching.ts
+++ b/src/lib/stitching/vortex/stitching.ts
@@ -44,8 +44,9 @@ export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
     extend type Partner {
       analytics: AnalyticsPartnerStats
     }
-    extend type AnalyticsTopArtworks {
+    extend type AnalyticsRankedStats {
       artwork: Artwork
+      show: Show
     }
     extend type AnalyticsPartnerSalesStats {
       total(
@@ -251,17 +252,37 @@ export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
         },
       },
     },
-    AnalyticsTopArtworks: {
+    AnalyticsRankedStats: {
       artwork: {
-        fragment: `fragment AnalyticsTopArtworksArtwork on AnalyticsTopArtworks { artworkId }`,
+        fragment: `fragment AnalyticsRankedStatsArtwork on AnalyticsRankedStats { objectId, objectType }`,
         resolve: async (parent, _args, context, info) => {
-          const id = parent.artworkId
+          const objectId = parent.objectId
+          const objectType = parent.objectType
           return await info.mergeInfo.delegateToSchema({
             schema: localSchema,
             operation: "query",
-            fieldName: "artwork",
+            fieldName: objectType,
             args: {
-              id,
+              id: objectId,
+            },
+            context,
+            info,
+            transforms: vortexSchema.transforms,
+          })
+        },
+      },
+
+      show: {
+        fragment: `fragment AnalyticsRankedStatsShow on AnalyticsRankedStats { objectId, objectType }`,
+        resolve: async (parent, _args, context, info) => {
+          const objectId = parent.objectId
+          const objectType = parent.objectType
+          return await info.mergeInfo.delegateToSchema({
+            schema: localSchema,
+            operation: "query",
+            fieldName: objectType,
+            args: {
+              id: objectId,
             },
             context,
             info,


### PR DESCRIPTION
This PR starts work on allowing show views surfaced in Vortex to be queryable in Metaphysics. The stitching for top artworks also needs to be updated since we changed how we're querying them in Vortex with https://github.com/artsy/vortex/pull/149

[Jira ticket](https://artsyproduct.atlassian.net/browse/GALL-1811)