### PR TITLE
[WIP] Ranked stats stitching

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -44,6 +44,14 @@ type AggregationCount {
   sortable_id: String
 }
 
+type AnalyticsArtist {
+  entityId: String!
+}
+
+type AnalyticsArtwork {
+  entityId: String!
+}
+
 # Publish artwork Series Stats
 type AnalyticsArtworksPublishedStats {
   percentageChanged: Int!
@@ -110,24 +118,12 @@ type AnalyticsPartnerAudienceStats {
   uniqueVisitors: Int!
 }
 
-# Inquiry count time series data of a partner
-type AnalyticsPartnerInquiryCountTimeSeriesStats {
-  count: Int
-  endTime: AnalyticsDateTime
-  startTime: AnalyticsDateTime
-}
-
 # Inquiry stats of a partner
 type AnalyticsPartnerInquiryStats {
   inquiryCount: Int!
   inquiryResponseTime: Int
   partnerId: String!
   period: AnalyticsQueryPeriodEnum!
-
-  # Partner inquiry count time series
-  timeSeries(
-    cumulative: Boolean = false
-  ): [AnalyticsPartnerInquiryCountTimeSeriesStats!]
 }
 
 # Sales stats of a partner
@@ -183,10 +179,27 @@ type AnalyticsPartnerStats {
   pageviews(period: AnalyticsQueryPeriodEnum!): AnalyticsPageviewStats
   partnerId: String!
 
+  # Artworks, shows, and artists ranked by views
+  rankedStats(
+    # Returns the elements in the list that come after the specified cursor.
+    after: String
+
+    # Returns the elements in the list that come before the specified cursor.
+    before: String
+
+    # Returns the first _n_ elements from the list.
+    first: Int
+
+    # Returns the last _n_ elements from the list.
+    last: Int
+    objectType: AnalyticsRankedStatsObjectTypeEnum!
+    period: AnalyticsQueryPeriodEnum!
+  ): AnalyticsRankedStatsConnection
+
   # Sales stats
   sales(period: AnalyticsQueryPeriodEnum!): AnalyticsPartnerSalesStats
 
-  # Artworks ranked by views
+  # Top artworks ranked by views
   topArtworks(
     # Returns the elements in the list that come after the specified cursor.
     after: String
@@ -199,8 +212,8 @@ type AnalyticsPartnerStats {
 
     # Returns the last _n_ elements from the list.
     last: Int
-    period: AnalyticsQueryPeriodEnum!
-  ): AnalyticsTopArtworksConnection
+  ): AnalyticsRankedStatsConnection
+    @deprecated(reason: "Use rankedStats(objectType: ) instead")
 
   # Number of unique visitors
   uniqueVisitors(period: AnalyticsQueryPeriodEnum!): Int
@@ -308,33 +321,55 @@ enum AnalyticsQueryPeriodEnum {
   SIXTEEN_WEEKS
 }
 
-# Top artworks from a partner
-type AnalyticsTopArtworks {
-  artworkId: String!
+# Top artworks, shows, or artists from a partner
+type AnalyticsRankedStats {
   period: AnalyticsQueryPeriodEnum!
+  rankedEntity: AnalyticsRankedStatsUnion!
   value: Int!
   artwork: Artwork
+  show: PartnerShow
 }
 
-# The connection type for TopArtworks.
-type AnalyticsTopArtworksConnection {
+# The connection type for RankedStats.
+type AnalyticsRankedStatsConnection {
   # A list of edges.
-  edges: [AnalyticsTopArtworksEdge]
+  edges: [AnalyticsRankedStatsEdge]
 
   # A list of nodes.
-  nodes: [AnalyticsTopArtworks]
+  nodes: [AnalyticsRankedStats]
 
   # Information to aid in pagination.
   pageInfo: AnalyticsPageInfo!
 }
 
 # An edge in a connection.
-type AnalyticsTopArtworksEdge {
+type AnalyticsRankedStatsEdge {
   # A cursor for use in pagination.
   cursor: String!
 
   # The item at the end of the edge.
-  node: AnalyticsTopArtworks
+  node: AnalyticsRankedStats
+}
+
+enum AnalyticsRankedStatsObjectTypeEnum {
+  # Artist
+  ARTIST
+
+  # Artwork
+  ARTWORK
+
+  # Show
+  SHOW
+}
+
+# An artwork, artist, or show
+union AnalyticsRankedStatsUnion =
+    AnalyticsArtist
+  | AnalyticsArtwork
+  | AnalyticsShow
+
+type AnalyticsShow {
+  entityId: String!
 }
 
 input ApproveOrderInput {

--- a/src/data/vortex.graphql
+++ b/src/data/vortex.graphql
@@ -1,3 +1,11 @@
+type Artist {
+  entityId: String!
+}
+
+type Artwork {
+  entityId: String!
+}
+
 """
 Publish artwork Series Stats
 """
@@ -71,15 +79,6 @@ type PartnerAudienceStats {
 }
 
 """
-Inquiry count time series data of a partner
-"""
-type PartnerInquiryCountTimeSeriesStats {
-  count: Int
-  endTime: DateTime
-  startTime: DateTime
-}
-
-"""
 Inquiry stats of a partner
 """
 type PartnerInquiryStats {
@@ -87,11 +86,6 @@ type PartnerInquiryStats {
   inquiryResponseTime: Int
   partnerId: String!
   period: QueryPeriodEnum!
-
-  """
-  Partner inquiry count time series
-  """
-  timeSeries(cumulative: Boolean = false): [PartnerInquiryCountTimeSeriesStats!]
 }
 
 """
@@ -146,12 +140,39 @@ type PartnerStats {
   partnerId: String!
 
   """
+  Artworks, shows, and artists ranked by views
+  """
+  rankedStats(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+    objectType: RankedStatsObjectTypeEnum!
+    period: QueryPeriodEnum!
+  ): RankedStatsConnection
+
+  """
   Sales stats
   """
   sales(period: QueryPeriodEnum!): PartnerSalesStats
 
   """
-  Artworks ranked by views
+  Top artworks ranked by views
   """
   topArtworks(
     """
@@ -173,14 +194,12 @@ type PartnerStats {
     Returns the last _n_ elements from the list.
     """
     last: Int
-    period: QueryPeriodEnum!
-  ): TopArtworksConnection
+  ): RankedStatsConnection @deprecated(reason: "Use rankedStats(objectType: ) instead")
 
   """
   Number of unique visitors
   """
-  uniqueVisitors(period: QueryPeriodEnum!): Int
-    @deprecated(reason: "Use audience() { uniqueVisitors } instead")
+  uniqueVisitors(period: QueryPeriodEnum!): Int @deprecated(reason: "Use audience() { uniqueVisitors } instead")
 }
 
 """
@@ -331,11 +350,7 @@ type Query {
   """
   Pricing Context Histograms
   """
-  pricingContext(
-    artistId: String!
-    category: PricingContextCategoryEnum!
-    sizeScore: Int!
-  ): PricingContext
+  pricingContext(artistId: String!, category: PricingContextCategoryEnum!, sizeScore: Int!): PricingContext
 }
 
 enum QueryPeriodEnum {
@@ -356,27 +371,27 @@ enum QueryPeriodEnum {
 }
 
 """
-Top artworks from a partner
+Top artworks, shows, or artists from a partner
 """
-type TopArtworks {
-  artworkId: String!
+type RankedStats {
   period: QueryPeriodEnum!
+  rankedEntity: RankedStatsUnion!
   value: Int!
 }
 
 """
-The connection type for TopArtworks.
+The connection type for RankedStats.
 """
-type TopArtworksConnection {
+type RankedStatsConnection {
   """
   A list of edges.
   """
-  edges: [TopArtworksEdge]
+  edges: [RankedStatsEdge]
 
   """
   A list of nodes.
   """
-  nodes: [TopArtworks]
+  nodes: [RankedStats]
 
   """
   Information to aid in pagination.
@@ -387,7 +402,7 @@ type TopArtworksConnection {
 """
 An edge in a connection.
 """
-type TopArtworksEdge {
+type RankedStatsEdge {
   """
   A cursor for use in pagination.
   """
@@ -396,5 +411,31 @@ type TopArtworksEdge {
   """
   The item at the end of the edge.
   """
-  node: TopArtworks
+  node: RankedStats
+}
+
+enum RankedStatsObjectTypeEnum {
+  """
+  Artist
+  """
+  ARTIST
+
+  """
+  Artwork
+  """
+  ARTWORK
+
+  """
+  Show
+  """
+  SHOW
+}
+
+"""
+An artwork, artist, or show
+"""
+union RankedStatsUnion = Artist | Artwork | Show
+
+type Show {
+  entityId: String!
 }

--- a/src/lib/stitching/vortex/__tests__/rankedStats.test.ts
+++ b/src/lib/stitching/vortex/__tests__/rankedStats.test.ts
@@ -5,7 +5,7 @@ import { ResolverContext } from "types/graphql"
 jest.mock("../link")
 require("../link").mockFetch as jest.Mock<any>
 
-describe("TopArtworks type", () => {
+describe("RankedStats type", () => {
   const artwork = {
     id: "lona-misa",
     artist: {
@@ -15,7 +15,11 @@ describe("TopArtworks type", () => {
     category: "Painting",
     title: "Lona Misa",
   }
+  const show = {
+    id: "show-id",
+  }
   const artworkLoader = jest.fn(() => Promise.resolve(artwork))
+  const showLoader = jest.fn(() => Promise.resolve(show))
   const artistLoader = jest.fn(() =>
     Promise.resolve({
       _id: "artist-id",
@@ -28,12 +32,13 @@ describe("TopArtworks type", () => {
     artworkLoader,
     artistLoader,
     partnerLoader,
+    showLoader,
   }
   const query = gql`
     query {
       partner(id: "lol") {
         analytics {
-          topArtworks(period: FOUR_WEEKS) {
+          rankedStats(objectType: ARTWORK, period: FOUR_WEEKS) {
             edges {
               node {
                 value


### PR DESCRIPTION
**Update:**
~renamed `statType` to `rankedEntity` and `typeId` to `entityId` so some sections of queries below are slightly different.~ (updated it in queries below)

TODO:
- [ ] fix the failing test 😓 
- [ ] do I need to update `v2` schema? It fails when doing `dump-schema`

Sample query:
```graphql
query {
  partner(id: "4d8b92c44eb68a1b2c0004cb") {
   analytics {
     topArtworks: rankedStats(first: 1, objectType: ARTWORK, period: ONE_YEAR) {
      edges {
        node {
          value
          # this is what vortex returns. rankedEntity is a Union of Artwork, Artist and Show
          rankedEntity {
            ... on AnalyticsArtwork {
               __typename
               entityId  # ID of the object
	     }
           }
           # this is being stitched in MP, works fine
           artwork {
             id
             title
             artist_names
           }
           # But I don't want to even be able to query show (the same about subquery below)
           show { 
             name
          }
        }
      }
    }  
    topShows: rankedStats(first: 1, objectType: SHOW, period: ONE_YEAR) {
      edges {
        node {
            value
            rankedEntity {
              ... on AnalyticsArtwork {
                 __typename
                 entityId
               }
            }          
            show {
              id
              name
              artists {
                name
              }
            }
            # artwork shouldn't be available here!
            artwork {
              title
            }
          }
        }
      }     
    }
  }
}
```

It works fine and it returns the correct data
```
"data": {
    "partner": {
      "analytics": {
        "topArtworks": {
          "edges": [
            {
              "node": {
                "value": 2945,
                "rankedEntity": {
                  "__typename": "AnalyticsArtwork",
                  "entityId": "4dbd8b36db8e540221001f96"
                },
                "artwork": {
                  "id": "gregory-crewdson-untitled-75",
                  "title": "Untitled",
                  "artist_names": "Gregory Crewdson"
                },
                "show": null
              }
            }
          ]
        },
        "topShows": {
          "edges": [
            {
              "node": {
                "value": 1775,
                "rankedEntity": {},
                "show": {
                  "id": "gagosian-takashi-murakami-prints",
                  "name": "Takashi Murakami: Prints",
                  "artists": [
                    {
                      "name": "Takashi Murakami"
                    }
                  ]
                },
                "artwork": null
              }
            }
          ]
        }
      }
    }
  }
```

~but it also returns an error:~ (not anymore. see 👇 )
```JSON
"errors": [
    {
      "message": "https://stagingapi.artsy.net/api/v1/artwork/5ada11591a1e8629930f29f7? - {\"error\":\"Artwork Not Found\"}",
      "locations": [
        {
          "line": 43,
          "column": 12
        }
      ],
      "path": [
        "partner",
        "analytics",
        "topShows",
        "edges",
        0,
        "node",
        "artwork"
      ]
    }
  ]
```

because it is trying to query the artwork with show `id` in the second query.

~This could be avoided [here](https://github.com/artsy/metaphysics/pull/1762/files?file-filters%5B%5D=.ts&owned-by%5B%5D=#diff-7e804a266de6111194edd60c2104b605R266) by checking if the `__typename` (`fieldName` here) is "artwork" and returning `null` if not but I think that should not even be available in the schema.~ (already done this)

My other idea was to also have a the corresponding union type in MP and resolve the stitching result to that union type to be able to use inline fragments to have `Artwork`, `Show` or `Artist` based on the type of union. Ideally something like this:

```graphql
query {
  partner(id: "4d8b92c44eb68a1b2c0004cb") {
   analytics {
     topArtworks: rankedStats(first: 1, objectType: ARTWORK, period: ONE_YEAR) {
      edges {
        node {
           rankedEntity {
              ... on Artwork {
                  
                     id
                     title
                     artist_names
           }
           ...
```

tried it [here](https://github.com/sepans/metaphysics/commit/8c1f49ef755b67d181645ccb4203d3ab23082375#diff-fcbe8035c7989ce5637280740e0cc1df) but wasn't able to get it to work.



This is how the vortex query is
```graphql
query {
  partnerStats(partnerId: "4d8b92c44eb68a1b2c0004cb") {
    topArtworks: rankedStats(first: 1, objectType: ARTWORK, period: ONE_YEAR) {
      edges {
        node {
	  __typename
          rankedEntity {
              __typename
              ... on Artwork {
                  entityId
            }
          }
        }
      }
    }
    topShows: rankedStats(first: 1, objectType: SHOW, period: ONE_YEAR) {
      edges {
        node {
	  __typename
          rankedEntity {
              __typename
              ... on Show {
                  entityId
            }
          }
        }
      }
    }       
  }
}
```

And returns
```json
{
  "data": {
    "partnerStats": {
      "topArtworks": {
        "edges": [
          {
            "node": {
              "__typename": "RankedStats",
              "rankedEntity": {
                "__typename": "Artwork",
                "entityId": "4dbd8b36db8e540221001f96"
              }
            }
          }
        ]
      },
      "topShows": {
        "edges": [
          {
            "node": {
              "__typename": "RankedStats",
              "rankedEntity": {
                "__typename": "Show",
                "entityId": "5ada11591a1e8629930f29f7"
              }
            }
          }
        ]
      }
    }
  }
}
```