### PR TITLE
PURCHASE-1168: Serves the artwork attribution class descriptions from Metaphysics instead of storing them in-app

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -8629,6 +8629,9 @@ type ProfileCounts {
 }
 
 type Query {
+  # List of all artwork attribution classes
+  artworkAttributionClasses: [AttributionClass]
+
   # An Article
   article(
     # The ID of the Article
@@ -10708,6 +10711,9 @@ type User {
 
 # A wildcard used to support complex root queries in Relay
 type Viewer {
+  # List of all artwork attribution classes
+  artworkAttributionClasses: [AttributionClass]
+
   # An Article
   article(
     # The ID of the Article

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -2253,10 +2253,16 @@ type AttributionClass {
   info: String
 
   # Longer version of attribution class display
-  short_description: String
+  short_description: String @deprecated(reason: "Prefer shortDescription")
 
   # Long descriptive phrase used as companion for short_description
-  long_description: String
+  long_description: String @deprecated(reason: "Prefer longDescription")
+
+  # Longer version of attribution class display
+  shortDescription: String
+
+  # Long descriptive phrase used as companion for short_description
+  longDescription: String
 }
 
 # In centimeters.

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6657,6 +6657,7 @@ type MarketingCollection {
 
   # Collection has prioritized connection to artist
   is_featured_artist_content: Boolean!
+  relatedCollections: [MarketingCollection!]!
   artworks(
     acquireable: Boolean
     offerable: Boolean
@@ -8611,6 +8612,9 @@ type ProfileCounts {
 }
 
 type Query {
+  # List of all artwork attribution classes
+  artworkAttributionClasses: [AttributionClass]
+
   # An Article
   article(
     # The ID of the Article
@@ -10677,6 +10681,9 @@ type User {
 
 # A wildcard used to support complex root queries in Relay
 type Viewer {
+  # List of all artwork attribution classes
+  artworkAttributionClasses: [AttributionClass]
+
   # An Article
   article(
     # The ID of the Article

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2253,10 +2253,16 @@ type AttributionClass {
   info: String
 
   # Longer version of attribution class display
-  short_description: String
+  short_description: String @deprecated(reason: "Prefer shortDescription")
 
   # Long descriptive phrase used as companion for short_description
-  long_description: String
+  long_description: String @deprecated(reason: "Prefer longDescription")
+
+  # Longer version of attribution class display
+  shortDescription: String
+
+  # Long descriptive phrase used as companion for short_description
+  longDescription: String
 }
 
 # In centimeters.

--- a/src/schema/__tests__/artworkAttributionClasses.test.ts
+++ b/src/schema/__tests__/artworkAttributionClasses.test.ts
@@ -9,8 +9,8 @@ describe("ArtworkAttributionClasses type", () => {
           id
           name
           info
-          short_description
-          long_description
+          shortDescription
+          longDescription
         }
       }
     `
@@ -18,10 +18,10 @@ describe("ArtworkAttributionClasses type", () => {
     return runQuery(query).then(data => {
       expect(data!.artworkAttributionClasses[0].id).toBe("unique")
       expect(data!.artworkAttributionClasses[0].name).toBe("Unique")
-      expect(data!.artworkAttributionClasses[0].short_description).toBe(
+      expect(data!.artworkAttributionClasses[0].shortDescription).toBe(
         "This is a unique work"
       )
-      expect(data!.artworkAttributionClasses[0].long_description).toBe(
+      expect(data!.artworkAttributionClasses[0].longDescription).toBe(
         "One of a kind piece, created by the artist."
       )
     })

--- a/src/schema/__tests__/artworkAttributionClasses.test.ts
+++ b/src/schema/__tests__/artworkAttributionClasses.test.ts
@@ -16,12 +16,12 @@ describe("ArtworkAttributionClasses type", () => {
     `
 
     return runQuery(query).then(data => {
-      expect(data.artworkAttributionClasses[0].id).toBe("unique")
-      expect(data.artworkAttributionClasses[0].name).toBe("Unique")
-      expect(data.artworkAttributionClasses[0].short_description).toBe(
+      expect(data!.artworkAttributionClasses[0].id).toBe("unique")
+      expect(data!.artworkAttributionClasses[0].name).toBe("Unique")
+      expect(data!.artworkAttributionClasses[0].short_description).toBe(
         "This is a unique work"
       )
-      expect(data.artworkAttributionClasses[0].long_description).toBe(
+      expect(data!.artworkAttributionClasses[0].long_description).toBe(
         "One of a kind piece, created by the artist."
       )
     })

--- a/src/schema/__tests__/artworkAttributionClasses.test.ts
+++ b/src/schema/__tests__/artworkAttributionClasses.test.ts
@@ -1,0 +1,29 @@
+/* eslint-disable promise/always-return */
+import { runQuery } from "test/utils"
+
+describe("ArtworkAttributionClasses type", () => {
+  it("fetches artworkAttributionClasses", () => {
+    const query = `
+      {
+        artworkAttributionClasses {
+          id
+          name
+          info
+          short_description
+          long_description
+        }
+      }
+    `
+
+    return runQuery(query).then(data => {
+      expect(data.artworkAttributionClasses[0].id).toBe("unique")
+      expect(data.artworkAttributionClasses[0].name).toBe("Unique")
+      expect(data.artworkAttributionClasses[0].short_description).toBe(
+        "This is a unique work"
+      )
+      expect(data.artworkAttributionClasses[0].long_description).toBe(
+        "One of a kind piece, created by the artist."
+      )
+    })
+  })
+})

--- a/src/schema/artwork/attributionClass.ts
+++ b/src/schema/artwork/attributionClass.ts
@@ -18,12 +18,29 @@ const AttributionClass = new GraphQLObjectType<any, ResolverContext>({
     },
     short_description: {
       type: GraphQLString,
+      deprecationReason: "Prefer shortDescription",
       description: "Longer version of attribution class display",
     },
     long_description: {
       type: GraphQLString,
+      deprecationReason: "Prefer longDescription",
       description:
         "Long descriptive phrase used as companion for short_description",
+    },
+    shortDescription: {
+      type: GraphQLString,
+      description: "Longer version of attribution class display",
+      resolve: ({ short_description }) => {
+        return short_description
+      },
+    },
+    longDescription: {
+      type: GraphQLString,
+      description:
+        "Long descriptive phrase used as companion for short_description",
+      resolve: ({ long_description }) => {
+        return long_description
+      },
     },
   },
 })

--- a/src/schema/artworkAttributionClasses.ts
+++ b/src/schema/artworkAttributionClasses.ts
@@ -1,0 +1,12 @@
+import { GraphQLList, GraphQLFieldConfig } from "graphql"
+import { ResolverContext } from "types/graphql"
+import AttributionClass from "./artwork/attributionClass"
+import attributionClasses from "lib/attributionClasses"
+
+const ArtworkAttributionClasses: GraphQLFieldConfig<void, ResolverContext> = {
+  type: new GraphQLList(AttributionClass),
+  description: "List of all artwork attribution classes",
+  resolve: (_root, _args, _context) => Object.values(attributionClasses),
+}
+
+export default ArtworkAttributionClasses

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -97,10 +97,12 @@ import config from "config"
 import { BuyOrderType, OfferOrderType } from "./ecommerce/types/order"
 import { AddInitialOfferToOrderMutation } from "./ecommerce/add_initial_offer_to_order_mutation"
 import { SearchableItem } from "./SearchableItem"
+import ArtworkAttributionClasses from "./artworkAttributionClasses"
 const { ENABLE_CONSIGNMENTS_STITCHING } = config
 
 // TODO: Remove this any
 const rootFields: any = {
+  artworkAttributionClasses: ArtworkAttributionClasses,
   article: Article,
   articles: Articles,
   artwork: Artwork,


### PR DESCRIPTION
Subtask of https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=41&modal=detail&selectedIssue=PURCHASE-1105

__User Story__
As a user, I can tap on the attribution class below the tombstone to learn more. Tapping on the link will open a new page with all of Artsy’s classifications.
I can click the back button or “OK” to go back to the artwork page.

__Spec__
https://zpl.io/aX3O198