### PR TITLE
rename port metaphysics-http to mp-http to observe 15 character limit on port names

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -36,7 +36,7 @@ spec:
           image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/metaphysics:production
           imagePullPolicy: Always
           ports:
-            - name: metaphysics-http
+            - name: mp-http
               containerPort: 3000
           resources:
             requests:
@@ -46,7 +46,7 @@ spec:
               memory: 1536Mi
           readinessProbe:
             httpGet:
-              port: metaphysics-http
+              port: mp-http
               path: /health
               httpHeaders:
                 - name: X-FORWARDED-PROTO
@@ -137,11 +137,11 @@ spec:
     - port: 443
       protocol: TCP
       name: https
-      targetPort: metaphysics-http
+      targetPort: mp-http
     - port: 80
       protocol: TCP
       name: http
-      targetPort: metaphysics-http
+      targetPort: mp-http
   selector:
     app: metaphysics
     layer: application

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -36,7 +36,7 @@ spec:
           image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/metaphysics:staging
           imagePullPolicy: Always
           ports:
-            - name: metaphysics-http
+            - name: mp-http
               containerPort: 3000
           resources:
             requests:
@@ -46,7 +46,7 @@ spec:
               memory: 1Gi
           readinessProbe:
             httpGet:
-              port: metaphysics-http
+              port: mp-http
               path: /health
               httpHeaders:
                 - name: X-FORWARDED-PROTO
@@ -136,11 +136,11 @@ spec:
     - port: 443
       protocol: TCP
       name: https
-      targetPort: metaphysics-http
+      targetPort: mp-http
     - port: 80
       protocol: TCP
       name: http
-      targetPort: metaphysics-http
+      targetPort: mp-http
   selector:
     app: metaphysics
     layer: application


### PR DESCRIPTION
Follow-up to https://github.com/artsy/metaphysics/pull/1764

Another gotcha!  `hokusai staging update --dry-run` succeeded but `hokusai staging update` failed with `"/Users/isacpetruzzi/Code/artsy/metaphysics/hokusai/staging.yml": Service "metaphysics-web" is invalid: [spec.ports[0].targetPort: Invalid value: "metaphysics-http": must be no more than 15 characters, spec.ports[1].targetPort: Invalid value: "metaphysics-http": must be no more than 15 characters]`