### PR TITLE
[v2] Formalize deprecation and add ability to drop all in v2

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -487,13 +487,13 @@ type Artist implements Node & Searchable {
     exclude_artists_without_artworks: Boolean = true
   ): [Artist]
   consignable: Boolean
-    @deprecated(reason: "Favor `is_`-prefixed boolean attributes")
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   counts: ArtistCounts
   currentEvent: CurrentEvent
   deathday: String
   disablePriceContext: Boolean
   display_auction_link: Boolean
-    @deprecated(reason: "Favor `is_`-prefixed boolean attributes")
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
 
   # Custom-sorted list of shows for an artist, in order of significance.
   exhibition_highlights(
@@ -597,8 +597,10 @@ type Artist implements Node & Searchable {
     top_tier: Boolean
     visible_to_public: Boolean
     sort: PartnerShowSorts
-  ): [PartnerShow] @deprecated(reason: "Prefer to use shows attribute")
-  public: Boolean @deprecated(reason: "Favor `is_`-prefixed boolean attributes")
+  ): [PartnerShow]
+    @deprecated(reason: "Prefer to use `shows`. [Will be removed in v2]")
+  public: Boolean
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   related: ArtistRelatedData
   sales(
     live: Boolean
@@ -830,13 +832,13 @@ type ArtistItem implements Node & Searchable {
     exclude_artists_without_artworks: Boolean = true
   ): [Artist]
   consignable: Boolean
-    @deprecated(reason: "Favor `is_`-prefixed boolean attributes")
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   counts: ArtistCounts
   currentEvent: CurrentEvent
   deathday: String
   disablePriceContext: Boolean
   display_auction_link: Boolean
-    @deprecated(reason: "Favor `is_`-prefixed boolean attributes")
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
 
   # Custom-sorted list of shows for an artist, in order of significance.
   exhibition_highlights(
@@ -940,8 +942,10 @@ type ArtistItem implements Node & Searchable {
     top_tier: Boolean
     visible_to_public: Boolean
     sort: PartnerShowSorts
-  ): [PartnerShow] @deprecated(reason: "Prefer to use shows attribute")
-  public: Boolean @deprecated(reason: "Favor `is_`-prefixed boolean attributes")
+  ): [PartnerShow]
+    @deprecated(reason: "Prefer to use `shows`. [Will be removed in v2]")
+  public: Boolean
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   related: ArtistRelatedData
   sales(
     live: Boolean
@@ -1036,9 +1040,18 @@ type ArtistRelatedData {
 }
 
 enum ArtistSorts {
-  sortable_id_asc @deprecated(reason: "use capital enums")
-  sortable_id_desc @deprecated(reason: "use capital enums")
-  trending_desc @deprecated(reason: "use capital enums")
+  sortable_id_asc
+    @deprecated(
+      reason: "Prefer to use `SORTABLE_ID_ASC`. [Will be removed in v2]"
+    )
+  sortable_id_desc
+    @deprecated(
+      reason: "Prefer to use `SORTABLE_ID_DESC`. [Will be removed in v2]"
+    )
+  trending_desc
+    @deprecated(
+      reason: "Prefer to use `TRENDING_DESC`. [Will be removed in v2]"
+    )
   SORTABLE_ID_ASC
   SORTABLE_ID_DESC
   TRENDING_DESC
@@ -1081,7 +1094,7 @@ type Artwork implements Node & Searchable & Sellable {
   articles(size: Int): [Article]
   availability: String
   can_share_image: Boolean
-    @deprecated(reason: "Favor `is_`-prefixed boolean attributes")
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   category: String
 
   # Attribution class object
@@ -1105,7 +1118,8 @@ type Artwork implements Node & Searchable & Sellable {
   edition_sets(sort: EditionSetSorts): [EditionSet]
   exhibition_history(format: Format): String
   fair: Fair
-  height: String @deprecated(reason: "Prefer dimensions instead.")
+  height: String
+    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
 
   # Returns the highlighted shows and articles
   highlights: [Highlighted]
@@ -1133,11 +1147,16 @@ type Artwork implements Node & Searchable & Sellable {
   is_comparable_with_auction_results: Boolean
 
   # Are we able to display a contact form on artwork pages?
-  is_contactable: Boolean @deprecated(reason: "Prefer to use is_inquireable")
+  is_contactable: Boolean
+    @deprecated(
+      reason: "Prefer to use `is_inquireable`. [Will be removed in v2]"
+    )
   is_downloadable: Boolean
   is_embeddable_video: Boolean
   is_ecommerce: Boolean
-    @deprecated(reason: "Should not be used to determine anything UI-level")
+    @deprecated(
+      reason: "Should not be used to determine anything UI-level. [Will be removed in v2]"
+    )
   is_for_sale: Boolean
   is_hangable: Boolean
 
@@ -1155,7 +1174,7 @@ type Artwork implements Node & Searchable & Sellable {
   is_price_range: Boolean
   is_purchasable: Boolean
     @deprecated(
-      reason: "Purchase requests are not supported. Replaced by buy now."
+      reason: "Purchase requests are not supported. Replaced by buy now. [Will be removed in v2]"
     )
   is_saved: Boolean
   is_shareable: Boolean
@@ -1167,19 +1186,24 @@ type Artwork implements Node & Searchable & Sellable {
   literature(format: Format): String
   manufacturer(format: Format): String
   medium: String
-  metric: String @deprecated(reason: "Prefer dimensions instead.")
+  metric: String
+    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
   meta: ArtworkMeta
   myLotStanding(live: Boolean = null): [LotStanding!]
 
   # [DO NOT USE] Weekly pageview data (static).
   pageviews: Int
+    @deprecated(
+      reason: "This is for an AB test and will be imminently deprecated. [Will be removed in v2]"
+    )
   partner(
     # Use whatever is in the original response instead of making a request
     shallow: Boolean
   ): Partner
   pickup_available: Boolean
   price: String
-  priceCents: PriceCents @deprecated(reason: "Prefer `listPrice` instead.")
+  priceCents: PriceCents
+    @deprecated(reason: "Prefer to use `listPrice`. [Will be removed in v2]")
   listPrice: ListPrice
   price_currency: String
 
@@ -1219,7 +1243,8 @@ type Artwork implements Node & Searchable & Sellable {
 
   # If the category is video, then it returns the href for the (youtube/vimeo) video, otherwise returns the website from CMS
   website: String
-  width: String @deprecated(reason: "Prefer dimensions instead.")
+  width: String
+    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
   framed: ArtworkInfoRow
   signatureInfo: ArtworkInfoRow
   conditionDescription: ArtworkInfoRow
@@ -1298,7 +1323,7 @@ type ArtworkContextAuction implements Node {
   ): ArtworkConnection
   associated_sale: Sale
   auction_state: String
-    @deprecated(reason: "Favor `status` for consistency with other models")
+    @deprecated(reason: "Prefer to use `status`. [Will be removed in v2]")
 
   # A bid increment policy that explains minimum bids in ranges.
   bid_increments: [BidIncrement]
@@ -1337,7 +1362,8 @@ type ArtworkContextAuction implements Node {
   href: String
   name: String
   is_auction: Boolean
-  is_benefit: Boolean @deprecated(reason: "Favor `isBenefit`")
+  is_benefit: Boolean
+    @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")
   isBenefit: Boolean
   isGalleryAuction: Boolean
   is_auction_promo: Boolean
@@ -1433,7 +1459,8 @@ type ArtworkContextFair {
   hours: String
   href: String
   image: Image
-  is_active: Boolean @deprecated(reason: "Prefer isActive instead")
+  is_active: Boolean
+    @deprecated(reason: "Prefer to use `isActive`. [Will be removed in v2]")
 
   # Are we currently in the fair's active period?
   isActive: Boolean
@@ -1482,7 +1509,7 @@ type ArtworkContextFair {
   ): String
   organizer: organizer
   published: Boolean
-    @deprecated(reason: "Prefix Boolean returning fields with `is_`")
+    @deprecated(reason: "Prefer to use `is_published`. [Will be removed in v2]")
   tagline: String
   ticketsLink: String
 
@@ -1538,14 +1565,29 @@ type ArtworkContextFair {
 type ArtworkContextPartnerShow implements Node {
   # A globally unique ID.
   __id: ID!
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # A type-specific ID.
   id: ID!
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # A type-specific Gravity Mongo Document ID.
   _id: ID!
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   cached: Int
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   artists: [Artist]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # The artworks featured in the show
   artworks(
@@ -1559,6 +1601,9 @@ type ArtworkContextPartnerShow implements Node {
     # Number of artworks to return
     size: Int = 25
   ): [Artwork]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # A connection of artworks featured in the show
   artworksConnection(
@@ -1571,8 +1616,17 @@ type ArtworkContextPartnerShow implements Node {
     before: String
     last: Int
   ): ArtworkConnection
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   counts: PartnerShowCounts
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   cover_image: Image
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   created_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -1581,9 +1635,17 @@ type ArtworkContextPartnerShow implements Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   description: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   displayable: Boolean
-    @deprecated(reason: "Prefix Boolean returning fields with `is_`")
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   end_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -1592,12 +1654,27 @@ type ArtworkContextPartnerShow implements Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   events: [PartnerShowEventType]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # A formatted description of the start to end dates
   exhibition_period: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   fair: Fair
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   href: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   images(
     # Number of images to return
     size: Int
@@ -1606,22 +1683,55 @@ type ArtworkContextPartnerShow implements Node {
     default: Boolean
     page: Int
   ): [Image]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # Flag showing if show has any location.
   has_location: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # Gravity doesn’t expose the `active` flag. Temporarily re-state its logic.
   is_active: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   is_displayable: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   is_fair_booth: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   kind: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   location: Location
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   meta_image: Image
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # The exhibition title
   name: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   partner: Partner
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   press_release(format: Format): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   start_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -1630,14 +1740,26 @@ type ArtworkContextPartnerShow implements Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   status: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # A formatted update on upcoming status changes
   status_update(
     # Before this many days no update will be generated
     max_days: Int
   ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   type: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 }
 
 type ArtworkContextSale implements Node {
@@ -1670,7 +1792,7 @@ type ArtworkContextSale implements Node {
   ): ArtworkConnection
   associated_sale: Sale
   auction_state: String
-    @deprecated(reason: "Favor `status` for consistency with other models")
+    @deprecated(reason: "Prefer to use `status`. [Will be removed in v2]")
 
   # A bid increment policy that explains minimum bids in ranges.
   bid_increments: [BidIncrement]
@@ -1709,7 +1831,8 @@ type ArtworkContextSale implements Node {
   href: String
   name: String
   is_auction: Boolean
-  is_benefit: Boolean @deprecated(reason: "Favor `isBenefit`")
+  is_benefit: Boolean
+    @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")
   isBenefit: Boolean
   isGalleryAuction: Boolean
   is_auction_promo: Boolean
@@ -1966,7 +2089,7 @@ type ArtworkItem implements Node & Searchable & Sellable {
   articles(size: Int): [Article]
   availability: String
   can_share_image: Boolean
-    @deprecated(reason: "Favor `is_`-prefixed boolean attributes")
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   category: String
 
   # Attribution class object
@@ -1990,7 +2113,8 @@ type ArtworkItem implements Node & Searchable & Sellable {
   edition_sets(sort: EditionSetSorts): [EditionSet]
   exhibition_history(format: Format): String
   fair: Fair
-  height: String @deprecated(reason: "Prefer dimensions instead.")
+  height: String
+    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
 
   # Returns the highlighted shows and articles
   highlights: [Highlighted]
@@ -2018,11 +2142,16 @@ type ArtworkItem implements Node & Searchable & Sellable {
   is_comparable_with_auction_results: Boolean
 
   # Are we able to display a contact form on artwork pages?
-  is_contactable: Boolean @deprecated(reason: "Prefer to use is_inquireable")
+  is_contactable: Boolean
+    @deprecated(
+      reason: "Prefer to use `is_inquireable`. [Will be removed in v2]"
+    )
   is_downloadable: Boolean
   is_embeddable_video: Boolean
   is_ecommerce: Boolean
-    @deprecated(reason: "Should not be used to determine anything UI-level")
+    @deprecated(
+      reason: "Should not be used to determine anything UI-level. [Will be removed in v2]"
+    )
   is_for_sale: Boolean
   is_hangable: Boolean
 
@@ -2040,7 +2169,7 @@ type ArtworkItem implements Node & Searchable & Sellable {
   is_price_range: Boolean
   is_purchasable: Boolean
     @deprecated(
-      reason: "Purchase requests are not supported. Replaced by buy now."
+      reason: "Purchase requests are not supported. Replaced by buy now. [Will be removed in v2]"
     )
   is_saved: Boolean
   is_shareable: Boolean
@@ -2052,19 +2181,24 @@ type ArtworkItem implements Node & Searchable & Sellable {
   literature(format: Format): String
   manufacturer(format: Format): String
   medium: String
-  metric: String @deprecated(reason: "Prefer dimensions instead.")
+  metric: String
+    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
   meta: ArtworkMeta
   myLotStanding(live: Boolean = null): [LotStanding!]
 
   # [DO NOT USE] Weekly pageview data (static).
   pageviews: Int
+    @deprecated(
+      reason: "This is for an AB test and will be imminently deprecated. [Will be removed in v2]"
+    )
   partner(
     # Use whatever is in the original response instead of making a request
     shallow: Boolean
   ): Partner
   pickup_available: Boolean
   price: String
-  priceCents: PriceCents @deprecated(reason: "Prefer `listPrice` instead.")
+  priceCents: PriceCents
+    @deprecated(reason: "Prefer to use `listPrice`. [Will be removed in v2]")
   listPrice: ListPrice
   price_currency: String
 
@@ -2104,7 +2238,8 @@ type ArtworkItem implements Node & Searchable & Sellable {
 
   # If the category is video, then it returns the href for the (youtube/vimeo) video, otherwise returns the website from CMS
   website: String
-  width: String @deprecated(reason: "Prefer dimensions instead.")
+  width: String
+    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
   framed: ArtworkInfoRow
   signatureInfo: ArtworkInfoRow
   conditionDescription: ArtworkInfoRow
@@ -2155,18 +2290,50 @@ type ArtworksAggregationResults {
 }
 
 enum ArtworkSorts {
-  availability_desc @deprecated(reason: "use capital enums")
-  created_at_asc @deprecated(reason: "use capital enums")
-  created_at_desc @deprecated(reason: "use capital enums")
-  deleted_at_asc @deprecated(reason: "use capital enums")
-  deleted_at_desc @deprecated(reason: "use capital enums")
-  iconicity_desc @deprecated(reason: "use capital enums")
-  merchandisability_desc @deprecated(reason: "use capital enums")
-  published_at_asc @deprecated(reason: "use capital enums")
-  published_at_desc @deprecated(reason: "use capital enums")
-  partner_updated_at_desc @deprecated(reason: "use capital enums")
-  title_asc @deprecated(reason: "use capital enums")
-  title_desc @deprecated(reason: "use capital enums")
+  availability_desc
+    @deprecated(
+      reason: "Prefer to use `AVAILABILITY_DESC`. [Will be removed in v2]"
+    )
+  created_at_asc
+    @deprecated(
+      reason: "Prefer to use `CREATED_AT_ASC`. [Will be removed in v2]"
+    )
+  created_at_desc
+    @deprecated(
+      reason: "Prefer to use `CREATED_AT_DESC`. [Will be removed in v2]"
+    )
+  deleted_at_asc
+    @deprecated(
+      reason: "Prefer to use `DELETED_AT_ASC`. [Will be removed in v2]"
+    )
+  deleted_at_desc
+    @deprecated(
+      reason: "Prefer to use `DELETED_AT_DESC`. [Will be removed in v2]"
+    )
+  iconicity_desc
+    @deprecated(
+      reason: "Prefer to use `ICONICITY_DESC`. [Will be removed in v2]"
+    )
+  merchandisability_desc
+    @deprecated(
+      reason: "Prefer to use `MERCHANDISABILITY_DESC`. [Will be removed in v2]"
+    )
+  published_at_asc
+    @deprecated(
+      reason: "Prefer to use `PUBLISHED_AT_ASC`. [Will be removed in v2]"
+    )
+  published_at_desc
+    @deprecated(
+      reason: "Prefer to use `PUBLISHED_AT_DESC`. [Will be removed in v2]"
+    )
+  partner_updated_at_desc
+    @deprecated(
+      reason: "Prefer to use `PARTNER_UPDATED_AT_DESC`. [Will be removed in v2]"
+    )
+  title_asc
+    @deprecated(reason: "Prefer to use `TITLE_ASC`. [Will be removed in v2]")
+  title_desc
+    @deprecated(reason: "Prefer to use `TITLE_DESC`. [Will be removed in v2]")
   AVAILABILITY_DESC
   CREATED_AT_ASC
   CREATED_AT_DESC
@@ -2367,7 +2534,7 @@ type Author {
   name: String
   href: String
     @deprecated(
-      reason: "Profiles have been removed and thus author hrefs don't exist anymore."
+      reason: "Profiles have been removed and thus author hrefs don't exist anymore. [Will be removed in v2]"
     )
   profile_handle: String
 }
@@ -2421,20 +2588,26 @@ type BidderPosition {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
-  display_max_bid_amount_dollars: String @deprecated(reason: "Favor `max_bid`")
+  display_max_bid_amount_dollars: String
+    @deprecated(reason: "Prefer to use `max_bid`. [Will be removed in v2]")
   display_suggested_next_bid_dollars: String
-    @deprecated(reason: "Favor `suggested_next_bid`")
+    @deprecated(
+      reason: "Prefer to use `suggested_next_bid`. [Will be removed in v2]"
+    )
   highest_bid: HighestBid
   is_active: Boolean
   is_retracted: Boolean
   is_with_bid_max: Boolean
   is_winning: Boolean
   max_bid: BidderPositionMaxBid
-  max_bid_amount_cents: Int @deprecated(reason: "Favor `max_bid`")
+  max_bid_amount_cents: Int
+    @deprecated(reason: "Prefer to use `max_bid`. [Will be removed in v2]")
   sale_artwork: SaleArtwork
   suggested_next_bid: BidderPositionSuggestedNextBid
   suggested_next_bid_cents: Int
-    @deprecated(reason: "Favor `suggested_next_bid`")
+    @deprecated(
+      reason: "Prefer to use `suggested_next_bid`. [Will be removed in v2]"
+    )
 }
 
 input BidderPositionInput {
@@ -4223,7 +4396,7 @@ type Conversation implements Node {
   ): String
   purchase_request: Boolean
     @deprecated(
-      reason: "Purchase requests are not supported. Replaced by buy now."
+      reason: "Purchase requests are not supported. Replaced by buy now. [Will be removed in v2]"
     )
   from_last_viewed_message_id: String
   initial_message: String!
@@ -4246,7 +4419,8 @@ type Conversation implements Node {
   is_last_message_to_user: Boolean
 
   # Timestamp if the user opened the last message, null in all other cases
-  last_message_open: String @deprecated(reason: "Prefer to use `unread`")
+  last_message_open: String
+    @deprecated(reason: "Prefer to use `unread`. [Will be removed in v2]")
 
   # Delivery id if the user is a recipient of the last message, null otherwise.
   last_message_delivery_id: String
@@ -4557,7 +4731,10 @@ union CreditCardMutationType =
   | CreditCardMutationFailure
 
 type CreditCardPayload {
-  credit_card: CreditCard @deprecated(reason: "Favor `creditCardOrError`")
+  credit_card: CreditCard
+    @deprecated(
+      reason: "Prefer to use `creditCardOrError`. [Will be removed in v2]"
+    )
   creditCardOrError: CreditCardMutationType
   clientMutationId: String
 }
@@ -4734,7 +4911,8 @@ type EditionSet implements Sellable {
   is_offerable: Boolean
   is_for_sale: Boolean
   is_sold: Boolean
-  price: String @deprecated(reason: "Prefer to use `sale_message`.")
+  price: String
+    @deprecated(reason: "Prefer to use `sale_message`. [Will be removed in v2]")
   listPrice: ListPrice
 
   # score assigned to an artwork based on its dimensions
@@ -4763,10 +4941,13 @@ type EndSalePayload {
 }
 
 enum EventStatus {
-  closed @deprecated(reason: "use capital enums")
-  current @deprecated(reason: "use capital enums")
-  running @deprecated(reason: "use capital enums")
-  upcoming @deprecated(reason: "use capital enums")
+  closed @deprecated(reason: "Prefer to use `CLOSED`. [Will be removed in v2]")
+  current
+    @deprecated(reason: "Prefer to use `CURRENT`. [Will be removed in v2]")
+  running
+    @deprecated(reason: "Prefer to use `RUNNING`. [Will be removed in v2]")
+  upcoming
+    @deprecated(reason: "Prefer to use `UPCOMING`. [Will be removed in v2]")
 
   # End date is in the past
   CLOSED
@@ -4836,7 +5017,8 @@ type Fair {
   hours: String
   href: String
   image: Image
-  is_active: Boolean @deprecated(reason: "Prefer isActive instead")
+  is_active: Boolean
+    @deprecated(reason: "Prefer to use `isActive`. [Will be removed in v2]")
 
   # Are we currently in the fair's active period?
   isActive: Boolean
@@ -4885,7 +5067,7 @@ type Fair {
   ): String
   organizer: organizer
   published: Boolean
-    @deprecated(reason: "Prefix Boolean returning fields with `is_`")
+    @deprecated(reason: "Prefer to use `is_published`. [Will be removed in v2]")
   tagline: String
   ticketsLink: String
 
@@ -5064,14 +5246,17 @@ type FilterArtworks implements Node {
   ): ArtworkConnection
   counts: FilterArtworksCounts
   followed_artists_total: Int
-    @deprecated(reason: "Favor `favor counts.followed_artists`")
+    @deprecated(
+      reason: "Prefer to use `counts.followed_artists`. [Will be removed in v2]"
+    )
 
   # Artwork results.
   hits: [Artwork]
 
   # Returns a list of merchandisable artists sorted by merch score.
   merchandisable_artists: [Artist]
-  total: Int @deprecated(reason: "Favor `counts.total`")
+  total: Int
+    @deprecated(reason: "Prefer to use `counts.total`. [Will be removed in v2]")
   facet: ArtworkFilterFacet
 }
 
@@ -5376,7 +5561,10 @@ type FollowShowPayload {
 enum Format {
   HTML
   PLAIN
-  markdown @deprecated(reason: "deprecated")
+  markdown
+    @deprecated(
+      reason: "Deprecated when we deprecated lower-case enum entries, but no alternative was provided. Add an alternative to MP if this is still needed. [Will be removed in v2]"
+    )
 }
 
 type FormattedDaySchedules {
@@ -5782,8 +5970,10 @@ type HighestBid {
   ): String
   cents: Int
   display: String
-  amount_cents: Int @deprecated(reason: "Favor `cents`")
-  display_amount_dollars: String @deprecated(reason: "Favor `display`")
+  amount_cents: Int
+    @deprecated(reason: "Prefer to use `cents`. [Will be removed in v2]")
+  display_amount_dollars: String
+    @deprecated(reason: "Prefer to use `display`. [Will be removed in v2]")
 }
 
 union Highlighted = HighlightedShow | HighlightedArticle
@@ -5833,9 +6023,11 @@ type HighlightedShow implements Node {
   # A type-specific Gravity Mongo Document ID.
   _id: ID!
   cached: Int
+
+  # The Artists presenting in this show
   artists: [Artist]
 
-  # The artworks featured in the show
+  # The artworks featured in this show
   artworks(
     # List of artwork IDs to exclude from the response (irrespective of size)
     exclude: [String]
@@ -5847,9 +6039,12 @@ type HighlightedShow implements Node {
     # Number of artworks to return
     size: Int = 25
   ): [Artwork]
+    @deprecated(
+      reason: "Prefer to use `artworks_connection`. [Will be removed in v2]"
+    )
 
-  # A connection of artworks featured in the show
-  artworksConnection(
+  # The artworks featured in the show
+  artworks_connection(
     # List of artwork IDs to exclude from the response (irrespective of size)
     exclude: [String]
     for_sale: Boolean
@@ -5859,19 +6054,28 @@ type HighlightedShow implements Node {
     before: String
     last: Int
   ): ArtworkConnection
-  counts: PartnerShowCounts
-  cover_image: Image
-  created_at(
-    # This arg is deprecated, use timezone instead
-    convert_to_utc: Boolean
-    format: String
 
-    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
-    timezone: String
-  ): String
+  # Artists inside the show who do not have artworks present
+  artists_without_artworks: [Artist]
+
+  # Artists in the show grouped by last name
+  artists_grouped_by_name: [ArtistGroup]
+
+  # The general city, derived from a fair location, a show location or a potential city
+  city: String
+
+  # The image you should use to represent this show
+  cover_image: Image
+
+  # An object that represents some of the numbers you might want to highlight
+  counts: ShowCounts
+
+  # A description of the show
   description: String
   displayable: Boolean
-    @deprecated(reason: "Prefix Boolean returning fields with `is_`")
+    @deprecated(
+      reason: "Prefer to use `is_displayable`. [Will be removed in v2]"
+    )
   end_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -5880,12 +6084,64 @@ type HighlightedShow implements Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+
+  # Events from the partner that runs this show
   events: [PartnerShowEventType]
 
   # A formatted description of the start to end dates
   exhibition_period: String
+
+  # If the show is in a Fair, then that fair
   fair: Fair
+
+  # Artworks Elastic Search results
+  filteredArtworks(
+    acquireable: Boolean
+    offerable: Boolean
+    aggregation_partner_cities: [String]
+    aggregations: [ArtworkAggregation]
+    artist_id: String
+    artist_ids: [String]
+    at_auction: Boolean
+    attribution_class: [String]
+    color: String
+    dimension_range: String
+    extra_aggregation_gene_ids: [String]
+    include_artworks_by_followed_artists: Boolean
+    include_medium_filter_in_aggregation: Boolean
+    inquireable_only: Boolean
+    for_sale: Boolean
+    gene_id: String
+    gene_ids: [String]
+    height: String
+    width: String
+
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
+
+    # A string from the list of allocations, or * to denote all mediums
+    medium: String
+    period: String
+    periods: [String]
+    major_periods: [String]
+    partner_id: ID
+    partner_cities: [String]
+    price_range: String
+    page: Int
+    sale_id: ID
+    size: Int
+    sort: String
+    tag_id: String
+    keyword: String
+
+    # When true, will only return exact keyword match
+    keyword_match_exact: Boolean
+  ): FilterArtworks
+
+  # A path to the show on Artsy
   href: String
+
+  # Images that represent the show, you may be interested in meta_image or cover_image for a definitive thumbnail
   images(
     # Number of images to return
     size: Int
@@ -5900,16 +6156,64 @@ type HighlightedShow implements Node {
 
   # Gravity doesn’t expose the `active` flag. Temporarily re-state its logic.
   is_active: Boolean
+
+  # Is this something we can display to the front-end?
   is_displayable: Boolean
+
+  # Does the show exist as a fair booth?
   is_fair_booth: Boolean
+
+  # Is it a show provided for historical reference?
+  is_reference: Boolean
+  is_local_discovery: Boolean
+    @deprecated(reason: "Prefer to use `isStubShow`. [Will be removed in v2]")
+
+  # Is it an outsourced local discovery stub show?
+  isStubShow: Boolean
+
+  # Whether the show is in a fair, group or solo
   kind: String
+
+  # Where the show is located (Could also be a fair location)
   location: Location
+
+  # An image representing the show, or a sharable image from an artwork in the show
   meta_image: Image
+
+  # Is the user following this show
+  is_followed: Boolean
 
   # The exhibition title
   name: String
-  partner: Partner
+
+  # Shows that are near (~75km) from this show
+  nearbyShows(
+    sort: PartnerShowSorts
+
+    # By default show only current shows
+    status: EventStatus = CURRENT
+
+    # Whether to include local discovery stubs as well as displayable shows
+    discoverable: Boolean
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ShowConnection
+
+  # Alternate Markdown-supporting free text representation of the opening reception event’s date/time
+  openingReceptionText: String
+
+  # The partner that represents this show, could be a non-Artsy partner
+  partner: PartnerTypes
+
+  # The press release for this show
   press_release(format: Format): String
+
+  # Link to the press release for this show
+  pressReleaseUrl: String
+
+  # When this show starts
   start_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -5918,6 +6222,8 @@ type HighlightedShow implements Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+
+  # Is this show running, upcoming or closed?
   status: String
 
   # A formatted update on upcoming status changes
@@ -5925,7 +6231,17 @@ type HighlightedShow implements Node {
     # Before this many days no update will be generated
     max_days: Int
   ): String
+
+  # Is it a fair booth or a show?
   type: String
+
+  # A Connection of followed artists by current user for this show
+  followedArtists(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ShowFollowArtistConnection
 }
 
 type HomePage {
@@ -6002,7 +6318,7 @@ type HomePageArtworkModule implements Node {
   context: HomePageModuleContext
   display: String
     @deprecated(
-      reason: "Favor `is_`-prefixed Booleans (*and* this should be a Boolean)"
+      reason: "Prefer to use `is_displayable`. [Will be removed in v2]"
     )
   is_displayable: Boolean
   key: String
@@ -6120,7 +6436,8 @@ type HomePageModuleContextFair {
   hours: String
   href: String
   image: Image
-  is_active: Boolean @deprecated(reason: "Prefer isActive instead")
+  is_active: Boolean
+    @deprecated(reason: "Prefer to use `isActive`. [Will be removed in v2]")
 
   # Are we currently in the fair's active period?
   isActive: Boolean
@@ -6169,7 +6486,7 @@ type HomePageModuleContextFair {
   ): String
   organizer: organizer
   published: Boolean
-    @deprecated(reason: "Prefix Boolean returning fields with `is_`")
+    @deprecated(reason: "Prefer to use `is_published`. [Will be removed in v2]")
   tagline: String
   ticketsLink: String
 
@@ -6394,7 +6711,7 @@ type HomePageModuleContextSale implements Node {
   ): ArtworkConnection
   associated_sale: Sale
   auction_state: String
-    @deprecated(reason: "Favor `status` for consistency with other models")
+    @deprecated(reason: "Prefer to use `status`. [Will be removed in v2]")
 
   # A bid increment policy that explains minimum bids in ranges.
   bid_increments: [BidIncrement]
@@ -6433,7 +6750,8 @@ type HomePageModuleContextSale implements Node {
   href: String
   name: String
   is_auction: Boolean
-  is_benefit: Boolean @deprecated(reason: "Favor `isBenefit`")
+  is_benefit: Boolean
+    @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")
   isBenefit: Boolean
   isGalleryAuction: Boolean
   is_auction_promo: Boolean
@@ -6614,7 +6932,7 @@ type Location {
   # Alternate Markdown-supporting free text representation of a location's opening hours
   day_schedule_text: String
   displayDaySchedules: [FormattedDaySchedules]
-    @deprecated(reason: "Use openingHours instead")
+    @deprecated(reason: "Prefer to use `openingHours`. [Will be removed in v2]")
 
   # Union returning opening hours in formatted structure or a string
   openingHours: OpeningHoursUnion
@@ -6904,7 +7222,9 @@ type Me implements Node {
     before: String
     last: Int
   ): NotificationsFeedItemConnection
-    @deprecated(reason: "Prefer to use followed_artists_artwork_groups.")
+    @deprecated(
+      reason: "Prefer to use `followed_artists_artwork_groups`. [Will be removed in v2]"
+    )
   paddle_number: String
   recentlyViewedArtworkIds: [String]!
 
@@ -6975,12 +7295,12 @@ type Message implements Node {
   # True if message is from the user to the partner.
   is_from_user: Boolean
   from_email_address: String
-    @deprecated(reason: "Prefer to use the structured `from` field.")
+    @deprecated(reason: "Prefer to use `from`. [Will be removed in v2]")
   from: MessageInitiator
 
   # Full unsanitized text.
   raw_text: String!
-    @deprecated(reason: "Prefer to use the parsed/cleaned-up `body`.")
+    @deprecated(reason: "Prefer to use `body`. [Will be removed in v2]")
 
   # Unaltered text if possible, otherwise `body`: a parsed/sanitized version from Sendgrid.
   body: String
@@ -7985,7 +8305,10 @@ type OrderLineItem {
   editionSetId: String
 
   # Unit price in cents
-  priceCents: Int @deprecated(reason: "Switched to `listPriceCents`")
+  priceCents: Int
+    @deprecated(
+      reason: "Prefer to use `listPriceCents`. [Will be removed in v2]"
+    )
 
   # A formatted price with various currency formatting options.
   price(
@@ -8173,7 +8496,7 @@ type Partner implements Node {
   collecting_institution: String
   contact_message: String
     @deprecated(
-      reason: "Prefer artwork contact_message to handle availability-based prompts."
+      reason: "Prefer to use `Artwork.contact_message`. [Will be removed in v2]"
     )
   counts: PartnerCounts
   default_profile_id: String
@@ -8183,7 +8506,7 @@ type Partner implements Node {
   is_default_profile_public: Boolean
   is_limited_fair_partner: Boolean
     @deprecated(
-      reason: "This field no longer exists, this is for backwards compatibility"
+      reason: "This field no longer exists, this is for backwards compatibility [Will be removed in v2]"
     )
   is_linkable: Boolean
   is_pre_qualify: Boolean
@@ -8400,14 +8723,29 @@ type PartnersAggregationResults {
 type PartnerShow implements Node {
   # A globally unique ID.
   __id: ID!
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # A type-specific ID.
   id: ID!
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # A type-specific Gravity Mongo Document ID.
   _id: ID!
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   cached: Int
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   artists: [Artist]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # The artworks featured in the show
   artworks(
@@ -8421,6 +8759,9 @@ type PartnerShow implements Node {
     # Number of artworks to return
     size: Int = 25
   ): [Artwork]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # A connection of artworks featured in the show
   artworksConnection(
@@ -8433,8 +8774,17 @@ type PartnerShow implements Node {
     before: String
     last: Int
   ): ArtworkConnection
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   counts: PartnerShowCounts
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   cover_image: Image
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   created_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -8443,9 +8793,17 @@ type PartnerShow implements Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   description: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   displayable: Boolean
-    @deprecated(reason: "Prefix Boolean returning fields with `is_`")
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   end_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -8454,12 +8812,27 @@ type PartnerShow implements Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   events: [PartnerShowEventType]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # A formatted description of the start to end dates
   exhibition_period: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   fair: Fair
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   href: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   images(
     # Number of images to return
     size: Int
@@ -8468,22 +8841,55 @@ type PartnerShow implements Node {
     default: Boolean
     page: Int
   ): [Image]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # Flag showing if show has any location.
   has_location: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # Gravity doesn’t expose the `active` flag. Temporarily re-state its logic.
   is_active: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   is_displayable: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   is_fair_booth: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   kind: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   location: Location
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   meta_image: Image
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # The exhibition title
   name: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   partner: Partner
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   press_release(format: Format): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   start_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -8492,14 +8898,26 @@ type PartnerShow implements Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   status: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # A formatted update on upcoming status changes
   status_update(
     # Before this many days no update will be generated
     max_days: Int
   ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   type: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 }
 
 type PartnerShowCounts {
@@ -8548,16 +8966,36 @@ enum PartnerShowPartnerType {
 }
 
 enum PartnerShowSorts {
-  created_at_asc @deprecated(reason: "use capital enums")
-  created_at_desc @deprecated(reason: "use capital enums")
-  end_at_asc @deprecated(reason: "use capital enums")
-  end_at_desc @deprecated(reason: "use capital enums")
-  name_asc @deprecated(reason: "use capital enums")
-  name_desc @deprecated(reason: "use capital enums")
-  publish_at_asc @deprecated(reason: "use capital enums")
-  publish_at_desc @deprecated(reason: "use capital enums")
-  start_at_asc @deprecated(reason: "use capital enums")
-  start_at_desc @deprecated(reason: "use capital enums")
+  created_at_asc
+    @deprecated(
+      reason: "Prefer to use `CREATED_AT_ASC`. [Will be removed in v2]"
+    )
+  created_at_desc
+    @deprecated(
+      reason: "Prefer to use `CREATED_AT_DESC`. [Will be removed in v2]"
+    )
+  end_at_asc
+    @deprecated(reason: "Prefer to use `END_AT_ASC`. [Will be removed in v2]")
+  end_at_desc
+    @deprecated(reason: "Prefer to use `END_AT_DESC`. [Will be removed in v2]")
+  name_asc
+    @deprecated(reason: "Prefer to use `NAME_ASC`. [Will be removed in v2]")
+  name_desc
+    @deprecated(reason: "Prefer to use `NAME_DESC`. [Will be removed in v2]")
+  publish_at_asc
+    @deprecated(
+      reason: "Prefer to use `PUBLISH_AT_ASC`. [Will be removed in v2]"
+    )
+  publish_at_desc
+    @deprecated(
+      reason: "Prefer to use `PUBLISH_AT_DESC`. [Will be removed in v2]"
+    )
+  start_at_asc
+    @deprecated(reason: "Prefer to use `START_AT_ASC`. [Will be removed in v2]")
+  start_at_desc
+    @deprecated(
+      reason: "Prefer to use `START_AT_DESC`. [Will be removed in v2]"
+    )
   CREATED_AT_ASC
   CREATED_AT_DESC
   END_AT_ASC
@@ -8841,7 +9279,9 @@ type Query {
     size: Int
     sort: String
   ): FilterSaleArtworks
-    @deprecated(reason: "This type has been superceded by `sale_artworks`")
+    @deprecated(
+      reason: "Prefer to use `sale_artworks`. [Will be removed in v2]"
+    )
   gene(
     # The slug or ID of the Gene
     id: String!
@@ -9369,7 +9809,7 @@ type Sale implements Node {
   ): ArtworkConnection
   associated_sale: Sale
   auction_state: String
-    @deprecated(reason: "Favor `status` for consistency with other models")
+    @deprecated(reason: "Prefer to use `status`. [Will be removed in v2]")
 
   # A bid increment policy that explains minimum bids in ranges.
   bid_increments: [BidIncrement]
@@ -9408,7 +9848,8 @@ type Sale implements Node {
   href: String
   name: String
   is_auction: Boolean
-  is_benefit: Boolean @deprecated(reason: "Favor `isBenefit`")
+  is_benefit: Boolean
+    @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")
   isBenefit: Boolean
   isGalleryAuction: Boolean
   is_auction_promo: Boolean
@@ -9481,8 +9922,13 @@ type SaleArtwork {
   cached: Int
   artwork: Artwork
   bidder_positions_count: Int
-    @deprecated(reason: "Favor `counts.bidder_positions`")
-  bid_increments: [Float] @deprecated(reason: "Favor `increments.cents`")
+    @deprecated(
+      reason: "Prefer to use `counts.bidder_positions`. [Will be removed in v2]"
+    )
+  bid_increments: [Float]
+    @deprecated(
+      reason: "Prefer to use `increments.cents`. [Will be removed in v2]"
+    )
   counts: SaleArtworkCounts
 
   # Currency abbreviation (e.g. "USD")
@@ -9493,7 +9939,10 @@ type SaleArtwork {
   # Singular estimate field, if specified
   estimate_cents: Int
   high_estimate: SaleArtworkHighEstimate
-  high_estimate_cents: Float @deprecated(reason: "Favor `high_estimate")
+  high_estimate_cents: Float
+    @deprecated(
+      reason: "Prefer to use `high_estimate`. [Will be removed in v2]"
+    )
   highest_bid: SaleArtworkHighestBid
   increments(
     # Whether or not to start the increments at the user's latest bid
@@ -9505,13 +9954,19 @@ type SaleArtwork {
   is_biddable: Boolean
   is_with_reserve: Boolean
   lot_label: String
-  lot_number: String @deprecated(reason: "Favor `lot_label`")
+  lot_number: String
+    @deprecated(reason: "Prefer to use `lot_label`. [Will be removed in v2]")
   low_estimate: SaleArtworkLowEstimate
-  low_estimate_cents: Float @deprecated(reason: "Favor `low_estimate`")
+  low_estimate_cents: Float
+    @deprecated(reason: "Prefer to use `low_estimate`. [Will be removed in v2]")
   minimum_next_bid: SaleArtworkMinimumNextBid
-  minimum_next_bid_cents: Float @deprecated(reason: "Favor `minimum_next_bid`")
+  minimum_next_bid_cents: Float
+    @deprecated(
+      reason: "Prefer to use `minimum_next_bid`. [Will be removed in v2]"
+    )
   opening_bid: SaleArtworkOpeningBid
-  opening_bid_cents: Float @deprecated(reason: "Favor `opening_bid`")
+  opening_bid_cents: Float
+    @deprecated(reason: "Prefer to use `opening_bid`. [Will be removed in v2]")
   position: Float
   reserve: SaleArtworkReserve
   reserve_message: String
@@ -9600,7 +10055,8 @@ type SaleArtworkHighestBid {
   ): String
   cents: Int
   display: String
-  amount_cents: Float @deprecated(reason: "Favor `cents`")
+  amount_cents: Float
+    @deprecated(reason: "Prefer to use `cents`. [Will be removed in v2]")
 }
 
 type SaleArtworkHighEstimate {
@@ -9802,7 +10258,8 @@ type SearchableItem implements Node & Searchable {
   displayLabel: String
   imageUrl: String
   href: String
-  searchableType: String @deprecated(reason: "Switch to use `displayType`")
+  searchableType: String
+    @deprecated(reason: "Prefer to use `displayType`. [Will be removed in v2]")
   displayType: String
 }
 
@@ -10060,7 +10517,10 @@ type Show implements Node {
 
     # Number of artworks to return
     size: Int = 25
-  ): [Artwork] @deprecated(reason: "Use artworks_connection instead")
+  ): [Artwork]
+    @deprecated(
+      reason: "Prefer to use `artworks_connection`. [Will be removed in v2]"
+    )
 
   # The artworks featured in the show
   artworks_connection(
@@ -10092,7 +10552,9 @@ type Show implements Node {
   # A description of the show
   description: String
   displayable: Boolean
-    @deprecated(reason: "Prefix Boolean returning fields with `is_`")
+    @deprecated(
+      reason: "Prefer to use `is_displayable`. [Will be removed in v2]"
+    )
   end_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -10182,7 +10644,8 @@ type Show implements Node {
 
   # Is it a show provided for historical reference?
   is_reference: Boolean
-  is_local_discovery: Boolean @deprecated(reason: "Prefer isStubShow")
+  is_local_discovery: Boolean
+    @deprecated(reason: "Prefer to use `isStubShow`. [Will be removed in v2]")
 
   # Is it an outsourced local discovery stub show?
   isStubShow: Boolean
@@ -10923,7 +11386,9 @@ type Viewer {
     size: Int
     sort: String
   ): FilterSaleArtworks
-    @deprecated(reason: "This type has been superceded by `sale_artworks`")
+    @deprecated(
+      reason: "Prefer to use `sale_artworks`. [Will be removed in v2]"
+    )
   gene(
     # The slug or ID of the Gene
     id: String!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -201,10 +201,6 @@ type AnalyticsPartnerStats {
     last: Int
     period: AnalyticsQueryPeriodEnum!
   ): AnalyticsTopArtworksConnection
-
-  # Number of unique visitors
-  uniqueVisitors(period: AnalyticsQueryPeriodEnum!): Int
-    @deprecated(reason: "Use audience() { uniqueVisitors } instead")
 }
 
 # Partner Time Series Stats
@@ -486,14 +482,10 @@ type Artist implements Node & Searchable {
     size: Int
     exclude_artists_without_artworks: Boolean = true
   ): [Artist]
-  consignable: Boolean
-    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   counts: ArtistCounts
   currentEvent: CurrentEvent
   deathday: String
   disablePriceContext: Boolean
-  display_auction_link: Boolean
-    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
 
   # Custom-sorted list of shows for an artist, in order of significance.
   exhibition_highlights(
@@ -585,8 +577,6 @@ type Artist implements Node & Searchable {
     # The number of PartnerArtists to return
     size: Int
   ): [PartnerArtist]
-  public: Boolean
-    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   related: ArtistRelatedData
   sales(
     live: Boolean
@@ -817,14 +807,10 @@ type ArtistItem implements Node & Searchable {
     size: Int
     exclude_artists_without_artworks: Boolean = true
   ): [Artist]
-  consignable: Boolean
-    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   counts: ArtistCounts
   currentEvent: CurrentEvent
   deathday: String
   disablePriceContext: Boolean
-  display_auction_link: Boolean
-    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
 
   # Custom-sorted list of shows for an artist, in order of significance.
   exhibition_highlights(
@@ -916,8 +902,6 @@ type ArtistItem implements Node & Searchable {
     # The number of PartnerArtists to return
     size: Int
   ): [PartnerArtist]
-  public: Boolean
-    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   related: ArtistRelatedData
   sales(
     live: Boolean
@@ -1065,8 +1049,6 @@ type Artwork implements Node & Searchable & Sellable {
   artist_names: String
   articles(size: Int): [Article]
   availability: String
-  can_share_image: Boolean
-    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   category: String
 
   # Attribution class object
@@ -1090,8 +1072,6 @@ type Artwork implements Node & Searchable & Sellable {
   edition_sets(sort: EditionSetSorts): [EditionSet]
   exhibition_history(format: Format): String
   fair: Fair
-  height: String
-    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
 
   # Returns the highlighted shows and articles
   highlights: [Highlighted]
@@ -1117,18 +1097,8 @@ type Artwork implements Node & Searchable & Sellable {
   # When in an auction, can the work be bought immediately
   is_buy_nowable: Boolean
   is_comparable_with_auction_results: Boolean
-
-  # Are we able to display a contact form on artwork pages?
-  is_contactable: Boolean
-    @deprecated(
-      reason: "Prefer to use `is_inquireable`. [Will be removed in v2]"
-    )
   is_downloadable: Boolean
   is_embeddable_video: Boolean
-  is_ecommerce: Boolean
-    @deprecated(
-      reason: "Should not be used to determine anything UI-level. [Will be removed in v2]"
-    )
   is_for_sale: Boolean
   is_hangable: Boolean
 
@@ -1144,10 +1114,6 @@ type Artwork implements Node & Searchable & Sellable {
   is_on_hold: String
   is_price_hidden: Boolean
   is_price_range: Boolean
-  is_purchasable: Boolean
-    @deprecated(
-      reason: "Purchase requests are not supported. Replaced by buy now. [Will be removed in v2]"
-    )
   is_saved: Boolean
   is_shareable: Boolean
   is_sold: Boolean
@@ -1158,24 +1124,14 @@ type Artwork implements Node & Searchable & Sellable {
   literature(format: Format): String
   manufacturer(format: Format): String
   medium: String
-  metric: String
-    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
   meta: ArtworkMeta
   myLotStanding(live: Boolean = null): [LotStanding!]
-
-  # [DO NOT USE] Weekly pageview data (static).
-  pageviews: Int
-    @deprecated(
-      reason: "This is for an AB test and will be imminently deprecated. [Will be removed in v2]"
-    )
   partner(
     # Use whatever is in the original response instead of making a request
     shallow: Boolean
   ): Partner
   pickup_available: Boolean
   price: String
-  priceCents: PriceCents
-    @deprecated(reason: "Prefer to use `listPrice`. [Will be removed in v2]")
   listPrice: ListPrice
   price_currency: String
 
@@ -1203,8 +1159,6 @@ type Artwork implements Node & Searchable & Sellable {
 
   # If the category is video, then it returns the href for the (youtube/vimeo) video, otherwise returns the website from CMS
   website: String
-  width: String
-    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
   framed: ArtworkInfoRow
   signatureInfo: ArtworkInfoRow
   conditionDescription: ArtworkInfoRow
@@ -1250,7 +1204,6 @@ type ArtworkConnection {
 union ArtworkContext =
     ArtworkContextAuction
   | ArtworkContextFair
-  | ArtworkContextPartnerShow
   | ArtworkContextSale
 
 type ArtworkContextAuction implements Node {
@@ -1282,8 +1235,6 @@ type ArtworkContextAuction implements Node {
     last: Int
   ): ArtworkConnection
   associated_sale: Sale
-  auction_state: String
-    @deprecated(reason: "Prefer to use `status`. [Will be removed in v2]")
 
   # A bid increment policy that explains minimum bids in ranges.
   bid_increments: [BidIncrement]
@@ -1322,8 +1273,6 @@ type ArtworkContextAuction implements Node {
   href: String
   name: String
   is_auction: Boolean
-  is_benefit: Boolean
-    @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")
   isBenefit: Boolean
   isGalleryAuction: Boolean
   is_auction_promo: Boolean
@@ -1419,8 +1368,6 @@ type ArtworkContextFair {
   hours: String
   href: String
   image: Image
-  is_active: Boolean
-    @deprecated(reason: "Prefer to use `isActive`. [Will be removed in v2]")
 
   # Are we currently in the fair's active period?
   isActive: Boolean
@@ -1468,8 +1415,6 @@ type ArtworkContextFair {
     timezone: String
   ): String
   organizer: organizer
-  published: Boolean
-    @deprecated(reason: "Prefer to use `is_published`. [Will be removed in v2]")
   tagline: String
   ticketsLink: String
 
@@ -1522,206 +1467,6 @@ type ArtworkContextFair {
   sponsoredContent: FairSponsoredContent
 }
 
-type ArtworkContextPartnerShow implements Node {
-  # A globally unique ID.
-  id: ID!
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # A type-specific ID.
-  gravityID: ID!
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # A type-specific Gravity Mongo Document ID.
-  internalID: ID!
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  cached: Int
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  artists: [Artist]
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # The artworks featured in the show
-  artworks(
-    # List of artwork IDs to exclude from the response (irrespective of size)
-    exclude: [String]
-    for_sale: Boolean
-    published: Boolean = true
-    all: Boolean
-    page: Int = 1
-
-    # Number of artworks to return
-    size: Int = 25
-  ): [Artwork]
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # A connection of artworks featured in the show
-  artworksConnection(
-    # List of artwork IDs to exclude from the response (irrespective of size)
-    exclude: [String]
-    for_sale: Boolean
-    published: Boolean = true
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): ArtworkConnection
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  counts: PartnerShowCounts
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  cover_image: Image
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  created_at(
-    # This arg is deprecated, use timezone instead
-    convert_to_utc: Boolean
-    format: String
-
-    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
-    timezone: String
-  ): String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  description: String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  displayable: Boolean
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  end_at(
-    # This arg is deprecated, use timezone instead
-    convert_to_utc: Boolean
-    format: String
-
-    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
-    timezone: String
-  ): String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  events: [PartnerShowEventType]
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # A formatted description of the start to end dates
-  exhibition_period: String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  fair: Fair
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  href: String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  images(
-    # Number of images to return
-    size: Int
-
-    # Pass true/false to include cover or not
-    default: Boolean
-    page: Int
-  ): [Image]
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # Flag showing if show has any location.
-  has_location: Boolean
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # Gravity doesn’t expose the `active` flag. Temporarily re-state its logic.
-  is_active: Boolean
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  is_displayable: Boolean
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  is_fair_booth: Boolean
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  kind: String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  location: Location
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  meta_image: Image
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # The exhibition title
-  name: String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  partner: Partner
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  press_release(format: Format): String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  start_at(
-    # This arg is deprecated, use timezone instead
-    convert_to_utc: Boolean
-    format: String
-
-    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
-    timezone: String
-  ): String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  status: String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # A formatted update on upcoming status changes
-  status_update(
-    # Before this many days no update will be generated
-    max_days: Int
-  ): String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  type: String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-}
-
 type ArtworkContextSale implements Node {
   # A globally unique ID.
   id: ID!
@@ -1751,8 +1496,6 @@ type ArtworkContextSale implements Node {
     last: Int
   ): ArtworkConnection
   associated_sale: Sale
-  auction_state: String
-    @deprecated(reason: "Prefer to use `status`. [Will be removed in v2]")
 
   # A bid increment policy that explains minimum bids in ranges.
   bid_increments: [BidIncrement]
@@ -1791,8 +1534,6 @@ type ArtworkContextSale implements Node {
   href: String
   name: String
   is_auction: Boolean
-  is_benefit: Boolean
-    @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")
   isBenefit: Boolean
   isGalleryAuction: Boolean
   is_auction_promo: Boolean
@@ -2048,8 +1789,6 @@ type ArtworkItem implements Node & Searchable & Sellable {
   artist_names: String
   articles(size: Int): [Article]
   availability: String
-  can_share_image: Boolean
-    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   category: String
 
   # Attribution class object
@@ -2073,8 +1812,6 @@ type ArtworkItem implements Node & Searchable & Sellable {
   edition_sets(sort: EditionSetSorts): [EditionSet]
   exhibition_history(format: Format): String
   fair: Fair
-  height: String
-    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
 
   # Returns the highlighted shows and articles
   highlights: [Highlighted]
@@ -2100,18 +1837,8 @@ type ArtworkItem implements Node & Searchable & Sellable {
   # When in an auction, can the work be bought immediately
   is_buy_nowable: Boolean
   is_comparable_with_auction_results: Boolean
-
-  # Are we able to display a contact form on artwork pages?
-  is_contactable: Boolean
-    @deprecated(
-      reason: "Prefer to use `is_inquireable`. [Will be removed in v2]"
-    )
   is_downloadable: Boolean
   is_embeddable_video: Boolean
-  is_ecommerce: Boolean
-    @deprecated(
-      reason: "Should not be used to determine anything UI-level. [Will be removed in v2]"
-    )
   is_for_sale: Boolean
   is_hangable: Boolean
 
@@ -2127,10 +1854,6 @@ type ArtworkItem implements Node & Searchable & Sellable {
   is_on_hold: String
   is_price_hidden: Boolean
   is_price_range: Boolean
-  is_purchasable: Boolean
-    @deprecated(
-      reason: "Purchase requests are not supported. Replaced by buy now. [Will be removed in v2]"
-    )
   is_saved: Boolean
   is_shareable: Boolean
   is_sold: Boolean
@@ -2141,24 +1864,14 @@ type ArtworkItem implements Node & Searchable & Sellable {
   literature(format: Format): String
   manufacturer(format: Format): String
   medium: String
-  metric: String
-    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
   meta: ArtworkMeta
   myLotStanding(live: Boolean = null): [LotStanding!]
-
-  # [DO NOT USE] Weekly pageview data (static).
-  pageviews: Int
-    @deprecated(
-      reason: "This is for an AB test and will be imminently deprecated. [Will be removed in v2]"
-    )
   partner(
     # Use whatever is in the original response instead of making a request
     shallow: Boolean
   ): Partner
   pickup_available: Boolean
   price: String
-  priceCents: PriceCents
-    @deprecated(reason: "Prefer to use `listPrice`. [Will be removed in v2]")
   listPrice: ListPrice
   price_currency: String
 
@@ -2186,8 +1899,6 @@ type ArtworkItem implements Node & Searchable & Sellable {
 
   # If the category is video, then it returns the href for the (youtube/vimeo) video, otherwise returns the website from CMS
   website: String
-  width: String
-    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
   framed: ArtworkInfoRow
   signatureInfo: ArtworkInfoRow
   conditionDescription: ArtworkInfoRow
@@ -2480,10 +2191,6 @@ type Author {
   # A type-specific ID.
   gravityID: ID!
   name: String
-  href: String
-    @deprecated(
-      reason: "Profiles have been removed and thus author hrefs don't exist anymore. [Will be removed in v2]"
-    )
   profile_handle: String
 }
 
@@ -2536,26 +2243,14 @@ type BidderPosition {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
-  display_max_bid_amount_dollars: String
-    @deprecated(reason: "Prefer to use `max_bid`. [Will be removed in v2]")
-  display_suggested_next_bid_dollars: String
-    @deprecated(
-      reason: "Prefer to use `suggested_next_bid`. [Will be removed in v2]"
-    )
   highest_bid: HighestBid
   is_active: Boolean
   is_retracted: Boolean
   is_with_bid_max: Boolean
   is_winning: Boolean
   max_bid: BidderPositionMaxBid
-  max_bid_amount_cents: Int
-    @deprecated(reason: "Prefer to use `max_bid`. [Will be removed in v2]")
   sale_artwork: SaleArtwork
   suggested_next_bid: BidderPositionSuggestedNextBid
-  suggested_next_bid_cents: Int
-    @deprecated(
-      reason: "Prefer to use `suggested_next_bid`. [Will be removed in v2]"
-    )
 }
 
 input BidderPositionInput {
@@ -3471,7 +3166,6 @@ type CommerceLineItem {
   internalID: ID!
   listPriceCents: Int!
   order: CommerceOrder!
-  priceCents: Int! @deprecated(reason: "switch to use listPriceCents")
   quantity: Int!
   shippingTotalCents: Int
   updatedAt: CommerceDateTime!
@@ -4342,10 +4036,6 @@ type Conversation implements Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
-  purchase_request: Boolean
-    @deprecated(
-      reason: "Purchase requests are not supported. Replaced by buy now. [Will be removed in v2]"
-    )
   from_last_viewed_message_id: String
   initial_message: String!
 
@@ -4365,10 +4055,6 @@ type Conversation implements Node {
 
   # True if user/conversation initiator is a recipient.
   is_last_message_to_user: Boolean
-
-  # Timestamp if the user opened the last message, null in all other cases
-  last_message_open: String
-    @deprecated(reason: "Prefer to use `unread`. [Will be removed in v2]")
 
   # Delivery id if the user is a recipient of the last message, null otherwise.
   last_message_delivery_id: String
@@ -4679,10 +4365,6 @@ union CreditCardMutationType =
   | CreditCardMutationFailure
 
 type CreditCardPayload {
-  credit_card: CreditCard
-    @deprecated(
-      reason: "Prefer to use `creditCardOrError`. [Will be removed in v2]"
-    )
   creditCardOrError: CreditCardMutationType
   clientMutationId: String
 }
@@ -4842,8 +4524,6 @@ type EditionSet implements Sellable {
   is_offerable: Boolean
   is_for_sale: Boolean
   is_sold: Boolean
-  price: String
-    @deprecated(reason: "Prefer to use `sale_message`. [Will be removed in v2]")
   listPrice: ListPrice
 
   # score assigned to an artwork based on its dimensions
@@ -4948,8 +4628,6 @@ type Fair {
   hours: String
   href: String
   image: Image
-  is_active: Boolean
-    @deprecated(reason: "Prefer to use `isActive`. [Will be removed in v2]")
 
   # Are we currently in the fair's active period?
   isActive: Boolean
@@ -4997,8 +4675,6 @@ type Fair {
     timezone: String
   ): String
   organizer: organizer
-  published: Boolean
-    @deprecated(reason: "Prefer to use `is_published`. [Will be removed in v2]")
   tagline: String
   ticketsLink: String
 
@@ -5176,18 +4852,12 @@ type FilterArtworks implements Node {
     last: Int
   ): ArtworkConnection
   counts: FilterArtworksCounts
-  followed_artists_total: Int
-    @deprecated(
-      reason: "Prefer to use `counts.followed_artists`. [Will be removed in v2]"
-    )
 
   # Artwork results.
   hits: [Artwork]
 
   # Returns a list of merchandisable artists sorted by merch score.
   merchandisable_artists: [Artist]
-  total: Int
-    @deprecated(reason: "Prefer to use `counts.total`. [Will be removed in v2]")
   facet: ArtworkFilterFacet
 }
 
@@ -5901,10 +5571,6 @@ type HighestBid {
   ): String
   cents: Int
   display: String
-  amount_cents: Int
-    @deprecated(reason: "Prefer to use `cents`. [Will be removed in v2]")
-  display_amount_dollars: String
-    @deprecated(reason: "Prefer to use `display`. [Will be removed in v2]")
 }
 
 union Highlighted = HighlightedShow | HighlightedArticle
@@ -5958,22 +5624,6 @@ type HighlightedShow implements Node {
   # The Artists presenting in this show
   artists: [Artist]
 
-  # The artworks featured in this show
-  artworks(
-    # List of artwork IDs to exclude from the response (irrespective of size)
-    exclude: [String]
-    for_sale: Boolean
-    published: Boolean = true
-    all: Boolean
-    page: Int = 1
-
-    # Number of artworks to return
-    size: Int = 25
-  ): [Artwork]
-    @deprecated(
-      reason: "Prefer to use `artworks_connection`. [Will be removed in v2]"
-    )
-
   # The artworks featured in the show
   artworks_connection(
     # List of artwork IDs to exclude from the response (irrespective of size)
@@ -6003,10 +5653,6 @@ type HighlightedShow implements Node {
 
   # A description of the show
   description: String
-  displayable: Boolean
-    @deprecated(
-      reason: "Prefer to use `is_displayable`. [Will be removed in v2]"
-    )
   end_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -6096,8 +5742,6 @@ type HighlightedShow implements Node {
 
   # Is it a show provided for historical reference?
   is_reference: Boolean
-  is_local_discovery: Boolean
-    @deprecated(reason: "Prefer to use `isStubShow`. [Will be removed in v2]")
 
   # Is it an outsourced local discovery stub show?
   isStubShow: Boolean
@@ -6247,10 +5891,6 @@ type HomePageArtworkModule implements Node {
   # A globally unique ID.
   id: ID!
   context: HomePageModuleContext
-  display: String
-    @deprecated(
-      reason: "Prefer to use `is_displayable`. [Will be removed in v2]"
-    )
   is_displayable: Boolean
   key: String
   params: HomePageModulesParams
@@ -6367,8 +6007,6 @@ type HomePageModuleContextFair {
   hours: String
   href: String
   image: Image
-  is_active: Boolean
-    @deprecated(reason: "Prefer to use `isActive`. [Will be removed in v2]")
 
   # Are we currently in the fair's active period?
   isActive: Boolean
@@ -6416,8 +6054,6 @@ type HomePageModuleContextFair {
     timezone: String
   ): String
   organizer: organizer
-  published: Boolean
-    @deprecated(reason: "Prefer to use `is_published`. [Will be removed in v2]")
   tagline: String
   ticketsLink: String
 
@@ -6641,8 +6277,6 @@ type HomePageModuleContextSale implements Node {
     last: Int
   ): ArtworkConnection
   associated_sale: Sale
-  auction_state: String
-    @deprecated(reason: "Prefer to use `status`. [Will be removed in v2]")
 
   # A bid increment policy that explains minimum bids in ranges.
   bid_increments: [BidIncrement]
@@ -6681,8 +6315,6 @@ type HomePageModuleContextSale implements Node {
   href: String
   name: String
   is_auction: Boolean
-  is_benefit: Boolean
-    @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")
   isBenefit: Boolean
   isGalleryAuction: Boolean
   is_auction_promo: Boolean
@@ -6862,8 +6494,6 @@ type Location {
 
   # Alternate Markdown-supporting free text representation of a location's opening hours
   day_schedule_text: String
-  displayDaySchedules: [FormattedDaySchedules]
-    @deprecated(reason: "Prefer to use `openingHours`. [Will be removed in v2]")
 
   # Union returning opening hours in formatted structure or a string
   openingHours: OpeningHoursUnion
@@ -7145,17 +6775,6 @@ type Me implements Node {
   ): [LotStanding]
   name: String
   initials(length: Int = 3): String
-
-  # A list of feed items, indicating published artworks (grouped by date and artists).
-  notifications_connection(
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): NotificationsFeedItemConnection
-    @deprecated(
-      reason: "Prefer to use `followed_artists_artwork_groups`. [Will be removed in v2]"
-    )
   paddle_number: String
   recentlyViewedArtworkIds: [String]!
 
@@ -7225,13 +6844,7 @@ type Message implements Node {
 
   # True if message is from the user to the partner.
   is_from_user: Boolean
-  from_email_address: String
-    @deprecated(reason: "Prefer to use `from`. [Will be removed in v2]")
   from: MessageInitiator
-
-  # Full unsanitized text.
-  raw_text: String!
-    @deprecated(reason: "Prefer to use `body`. [Will be removed in v2]")
 
   # Unaltered text if possible, otherwise `body`: a parsed/sanitized version from Sendgrid.
   body: String
@@ -8235,12 +7848,6 @@ type OrderLineItem {
   # ID of the selected Edition set from the artwork
   editionSetId: String
 
-  # Unit price in cents
-  priceCents: Int
-    @deprecated(
-      reason: "Prefer to use `listPriceCents`. [Will be removed in v2]"
-    )
-
   # A formatted price with various currency formatting options.
   price(
     decimal: String = "."
@@ -8425,20 +8032,12 @@ type Partner implements Node {
   ): ArtworkConnection
   categories: [Category]
   collecting_institution: String
-  contact_message: String
-    @deprecated(
-      reason: "Prefer to use `Artwork.contact_message`. [Will be removed in v2]"
-    )
   counts: PartnerCounts
   default_profile_id: String
   has_fair_partnership: Boolean
   href: String
   initials(length: Int = 3): String
   is_default_profile_public: Boolean
-  is_limited_fair_partner: Boolean
-    @deprecated(
-      reason: "This field no longer exists, this is for backwards compatibility [Will be removed in v2]"
-    )
   is_linkable: Boolean
   is_pre_qualify: Boolean
   locations(size: Int = 25): [Location]
@@ -8979,24 +8578,6 @@ type Query {
     # When true, will only return exact keyword match
     keyword_match_exact: Boolean
   ): FilterArtworks
-
-  # Sale Artworks Elastic Search results
-  filter_sale_artworks(
-    aggregations: [SaleArtworkAggregation]
-    artist_ids: [String]
-    include_artworks_by_followed_artists: Boolean
-    live_sale: Boolean
-    is_auction: Boolean
-    gene_ids: [String]
-    estimate_range: String
-    page: Int
-    sale_id: ID
-    size: Int
-    sort: String
-  ): FilterSaleArtworks
-    @deprecated(
-      reason: "Prefer to use `sale_artworks`. [Will be removed in v2]"
-    )
   gene(
     # The slug or ID of the Gene
     id: String!
@@ -9487,8 +9068,6 @@ type Sale implements Node {
     last: Int
   ): ArtworkConnection
   associated_sale: Sale
-  auction_state: String
-    @deprecated(reason: "Prefer to use `status`. [Will be removed in v2]")
 
   # A bid increment policy that explains minimum bids in ranges.
   bid_increments: [BidIncrement]
@@ -9527,8 +9106,6 @@ type Sale implements Node {
   href: String
   name: String
   is_auction: Boolean
-  is_benefit: Boolean
-    @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")
   isBenefit: Boolean
   isGalleryAuction: Boolean
   is_auction_promo: Boolean
@@ -9600,14 +9177,6 @@ type SaleArtwork {
   internalID: ID!
   cached: Int
   artwork: Artwork
-  bidder_positions_count: Int
-    @deprecated(
-      reason: "Prefer to use `counts.bidder_positions`. [Will be removed in v2]"
-    )
-  bid_increments: [Float]
-    @deprecated(
-      reason: "Prefer to use `increments.cents`. [Will be removed in v2]"
-    )
   counts: SaleArtworkCounts
 
   # Currency abbreviation (e.g. "USD")
@@ -9618,10 +9187,6 @@ type SaleArtwork {
   # Singular estimate field, if specified
   estimate_cents: Int
   high_estimate: SaleArtworkHighEstimate
-  high_estimate_cents: Float
-    @deprecated(
-      reason: "Prefer to use `high_estimate`. [Will be removed in v2]"
-    )
   highest_bid: SaleArtworkHighestBid
   increments(
     # Whether or not to start the increments at the user's latest bid
@@ -9633,19 +9198,9 @@ type SaleArtwork {
   is_biddable: Boolean
   is_with_reserve: Boolean
   lot_label: String
-  lot_number: String
-    @deprecated(reason: "Prefer to use `lot_label`. [Will be removed in v2]")
   low_estimate: SaleArtworkLowEstimate
-  low_estimate_cents: Float
-    @deprecated(reason: "Prefer to use `low_estimate`. [Will be removed in v2]")
   minimum_next_bid: SaleArtworkMinimumNextBid
-  minimum_next_bid_cents: Float
-    @deprecated(
-      reason: "Prefer to use `minimum_next_bid`. [Will be removed in v2]"
-    )
   opening_bid: SaleArtworkOpeningBid
-  opening_bid_cents: Float
-    @deprecated(reason: "Prefer to use `opening_bid`. [Will be removed in v2]")
   position: Float
   reserve: SaleArtworkReserve
   reserve_message: String
@@ -9732,8 +9287,6 @@ type SaleArtworkHighestBid {
   ): String
   cents: Int
   display: String
-  amount_cents: Float
-    @deprecated(reason: "Prefer to use `cents`. [Will be removed in v2]")
 }
 
 type SaleArtworkHighEstimate {
@@ -9935,8 +9488,6 @@ type SearchableItem implements Node & Searchable {
   displayLabel: String
   imageUrl: String
   href: String
-  searchableType: String
-    @deprecated(reason: "Prefer to use `displayType`. [Will be removed in v2]")
   displayType: String
 }
 
@@ -10183,22 +9734,6 @@ type Show implements Node {
   # The Artists presenting in this show
   artists: [Artist]
 
-  # The artworks featured in this show
-  artworks(
-    # List of artwork IDs to exclude from the response (irrespective of size)
-    exclude: [String]
-    for_sale: Boolean
-    published: Boolean = true
-    all: Boolean
-    page: Int = 1
-
-    # Number of artworks to return
-    size: Int = 25
-  ): [Artwork]
-    @deprecated(
-      reason: "Prefer to use `artworks_connection`. [Will be removed in v2]"
-    )
-
   # The artworks featured in the show
   artworks_connection(
     # List of artwork IDs to exclude from the response (irrespective of size)
@@ -10228,10 +9763,6 @@ type Show implements Node {
 
   # A description of the show
   description: String
-  displayable: Boolean
-    @deprecated(
-      reason: "Prefer to use `is_displayable`. [Will be removed in v2]"
-    )
   end_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -10321,8 +9852,6 @@ type Show implements Node {
 
   # Is it a show provided for historical reference?
   is_reference: Boolean
-  is_local_discovery: Boolean
-    @deprecated(reason: "Prefer to use `isStubShow`. [Will be removed in v2]")
 
   # Is it an outsourced local discovery stub show?
   isStubShow: Boolean
@@ -11048,24 +10577,6 @@ type Viewer {
     # When true, will only return exact keyword match
     keyword_match_exact: Boolean
   ): FilterArtworks
-
-  # Sale Artworks Elastic Search results
-  filter_sale_artworks(
-    aggregations: [SaleArtworkAggregation]
-    artist_ids: [String]
-    include_artworks_by_followed_artists: Boolean
-    live_sale: Boolean
-    is_auction: Boolean
-    gene_ids: [String]
-    estimate_range: String
-    page: Int
-    sale_id: ID
-    size: Int
-    sort: String
-  ): FilterSaleArtworks
-    @deprecated(
-      reason: "Prefer to use `sale_artworks`. [Will be removed in v2]"
-    )
   gene(
     # The slug or ID of the Gene
     id: String!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -201,6 +201,10 @@ type AnalyticsPartnerStats {
     last: Int
     period: AnalyticsQueryPeriodEnum!
   ): AnalyticsTopArtworksConnection
+
+  # Number of unique visitors
+  uniqueVisitors(period: AnalyticsQueryPeriodEnum!): Int
+    @deprecated(reason: "Use audience() { uniqueVisitors } instead")
 }
 
 # Partner Time Series Stats
@@ -482,10 +486,14 @@ type Artist implements Node & Searchable {
     size: Int
     exclude_artists_without_artworks: Boolean = true
   ): [Artist]
+  consignable: Boolean
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   counts: ArtistCounts
   currentEvent: CurrentEvent
   deathday: String
   disablePriceContext: Boolean
+  display_auction_link: Boolean
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
 
   # Custom-sorted list of shows for an artist, in order of significance.
   exhibition_highlights(
@@ -577,6 +585,8 @@ type Artist implements Node & Searchable {
     # The number of PartnerArtists to return
     size: Int
   ): [PartnerArtist]
+  public: Boolean
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   related: ArtistRelatedData
   sales(
     live: Boolean
@@ -807,10 +817,14 @@ type ArtistItem implements Node & Searchable {
     size: Int
     exclude_artists_without_artworks: Boolean = true
   ): [Artist]
+  consignable: Boolean
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   counts: ArtistCounts
   currentEvent: CurrentEvent
   deathday: String
   disablePriceContext: Boolean
+  display_auction_link: Boolean
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
 
   # Custom-sorted list of shows for an artist, in order of significance.
   exhibition_highlights(
@@ -902,6 +916,8 @@ type ArtistItem implements Node & Searchable {
     # The number of PartnerArtists to return
     size: Int
   ): [PartnerArtist]
+  public: Boolean
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   related: ArtistRelatedData
   sales(
     live: Boolean
@@ -1049,6 +1065,8 @@ type Artwork implements Node & Searchable & Sellable {
   artist_names: String
   articles(size: Int): [Article]
   availability: String
+  can_share_image: Boolean
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   category: String
 
   # Attribution class object
@@ -1072,6 +1090,8 @@ type Artwork implements Node & Searchable & Sellable {
   edition_sets(sort: EditionSetSorts): [EditionSet]
   exhibition_history(format: Format): String
   fair: Fair
+  height: String
+    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
 
   # Returns the highlighted shows and articles
   highlights: [Highlighted]
@@ -1097,8 +1117,18 @@ type Artwork implements Node & Searchable & Sellable {
   # When in an auction, can the work be bought immediately
   is_buy_nowable: Boolean
   is_comparable_with_auction_results: Boolean
+
+  # Are we able to display a contact form on artwork pages?
+  is_contactable: Boolean
+    @deprecated(
+      reason: "Prefer to use `is_inquireable`. [Will be removed in v2]"
+    )
   is_downloadable: Boolean
   is_embeddable_video: Boolean
+  is_ecommerce: Boolean
+    @deprecated(
+      reason: "Should not be used to determine anything UI-level. [Will be removed in v2]"
+    )
   is_for_sale: Boolean
   is_hangable: Boolean
 
@@ -1114,6 +1144,10 @@ type Artwork implements Node & Searchable & Sellable {
   is_on_hold: String
   is_price_hidden: Boolean
   is_price_range: Boolean
+  is_purchasable: Boolean
+    @deprecated(
+      reason: "Purchase requests are not supported. Replaced by buy now. [Will be removed in v2]"
+    )
   is_saved: Boolean
   is_shareable: Boolean
   is_sold: Boolean
@@ -1124,14 +1158,24 @@ type Artwork implements Node & Searchable & Sellable {
   literature(format: Format): String
   manufacturer(format: Format): String
   medium: String
+  metric: String
+    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
   meta: ArtworkMeta
   myLotStanding(live: Boolean = null): [LotStanding!]
+
+  # [DO NOT USE] Weekly pageview data (static).
+  pageviews: Int
+    @deprecated(
+      reason: "This is for an AB test and will be imminently deprecated. [Will be removed in v2]"
+    )
   partner(
     # Use whatever is in the original response instead of making a request
     shallow: Boolean
   ): Partner
   pickup_available: Boolean
   price: String
+  priceCents: PriceCents
+    @deprecated(reason: "Prefer to use `listPrice`. [Will be removed in v2]")
   listPrice: ListPrice
   price_currency: String
 
@@ -1159,6 +1203,8 @@ type Artwork implements Node & Searchable & Sellable {
 
   # If the category is video, then it returns the href for the (youtube/vimeo) video, otherwise returns the website from CMS
   website: String
+  width: String
+    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
   framed: ArtworkInfoRow
   signatureInfo: ArtworkInfoRow
   conditionDescription: ArtworkInfoRow
@@ -1204,6 +1250,7 @@ type ArtworkConnection {
 union ArtworkContext =
     ArtworkContextAuction
   | ArtworkContextFair
+  | ArtworkContextPartnerShow
   | ArtworkContextSale
 
 type ArtworkContextAuction implements Node {
@@ -1235,6 +1282,8 @@ type ArtworkContextAuction implements Node {
     last: Int
   ): ArtworkConnection
   associated_sale: Sale
+  auction_state: String
+    @deprecated(reason: "Prefer to use `status`. [Will be removed in v2]")
 
   # A bid increment policy that explains minimum bids in ranges.
   bid_increments: [BidIncrement]
@@ -1273,6 +1322,8 @@ type ArtworkContextAuction implements Node {
   href: String
   name: String
   is_auction: Boolean
+  is_benefit: Boolean
+    @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")
   isBenefit: Boolean
   isGalleryAuction: Boolean
   is_auction_promo: Boolean
@@ -1368,6 +1419,8 @@ type ArtworkContextFair {
   hours: String
   href: String
   image: Image
+  is_active: Boolean
+    @deprecated(reason: "Prefer to use `isActive`. [Will be removed in v2]")
 
   # Are we currently in the fair's active period?
   isActive: Boolean
@@ -1415,6 +1468,8 @@ type ArtworkContextFair {
     timezone: String
   ): String
   organizer: organizer
+  published: Boolean
+    @deprecated(reason: "Prefer to use `is_published`. [Will be removed in v2]")
   tagline: String
   ticketsLink: String
 
@@ -1467,6 +1522,206 @@ type ArtworkContextFair {
   sponsoredContent: FairSponsoredContent
 }
 
+type ArtworkContextPartnerShow implements Node {
+  # A globally unique ID.
+  id: ID!
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # A type-specific ID.
+  gravityID: ID!
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # A type-specific Gravity Mongo Document ID.
+  internalID: ID!
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  cached: Int
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  artists: [Artist]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # The artworks featured in the show
+  artworks(
+    # List of artwork IDs to exclude from the response (irrespective of size)
+    exclude: [String]
+    for_sale: Boolean
+    published: Boolean = true
+    all: Boolean
+    page: Int = 1
+
+    # Number of artworks to return
+    size: Int = 25
+  ): [Artwork]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # A connection of artworks featured in the show
+  artworksConnection(
+    # List of artwork IDs to exclude from the response (irrespective of size)
+    exclude: [String]
+    for_sale: Boolean
+    published: Boolean = true
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtworkConnection
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  counts: PartnerShowCounts
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  cover_image: Image
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  created_at(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  description: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  displayable: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  end_at(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  events: [PartnerShowEventType]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # A formatted description of the start to end dates
+  exhibition_period: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  fair: Fair
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  href: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  images(
+    # Number of images to return
+    size: Int
+
+    # Pass true/false to include cover or not
+    default: Boolean
+    page: Int
+  ): [Image]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # Flag showing if show has any location.
+  has_location: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # Gravity doesn’t expose the `active` flag. Temporarily re-state its logic.
+  is_active: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  is_displayable: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  is_fair_booth: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  kind: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  location: Location
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  meta_image: Image
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # The exhibition title
+  name: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  partner: Partner
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  press_release(format: Format): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  start_at(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  status: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # A formatted update on upcoming status changes
+  status_update(
+    # Before this many days no update will be generated
+    max_days: Int
+  ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  type: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+}
+
 type ArtworkContextSale implements Node {
   # A globally unique ID.
   id: ID!
@@ -1496,6 +1751,8 @@ type ArtworkContextSale implements Node {
     last: Int
   ): ArtworkConnection
   associated_sale: Sale
+  auction_state: String
+    @deprecated(reason: "Prefer to use `status`. [Will be removed in v2]")
 
   # A bid increment policy that explains minimum bids in ranges.
   bid_increments: [BidIncrement]
@@ -1534,6 +1791,8 @@ type ArtworkContextSale implements Node {
   href: String
   name: String
   is_auction: Boolean
+  is_benefit: Boolean
+    @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")
   isBenefit: Boolean
   isGalleryAuction: Boolean
   is_auction_promo: Boolean
@@ -1789,6 +2048,8 @@ type ArtworkItem implements Node & Searchable & Sellable {
   artist_names: String
   articles(size: Int): [Article]
   availability: String
+  can_share_image: Boolean
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   category: String
 
   # Attribution class object
@@ -1812,6 +2073,8 @@ type ArtworkItem implements Node & Searchable & Sellable {
   edition_sets(sort: EditionSetSorts): [EditionSet]
   exhibition_history(format: Format): String
   fair: Fair
+  height: String
+    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
 
   # Returns the highlighted shows and articles
   highlights: [Highlighted]
@@ -1837,8 +2100,18 @@ type ArtworkItem implements Node & Searchable & Sellable {
   # When in an auction, can the work be bought immediately
   is_buy_nowable: Boolean
   is_comparable_with_auction_results: Boolean
+
+  # Are we able to display a contact form on artwork pages?
+  is_contactable: Boolean
+    @deprecated(
+      reason: "Prefer to use `is_inquireable`. [Will be removed in v2]"
+    )
   is_downloadable: Boolean
   is_embeddable_video: Boolean
+  is_ecommerce: Boolean
+    @deprecated(
+      reason: "Should not be used to determine anything UI-level. [Will be removed in v2]"
+    )
   is_for_sale: Boolean
   is_hangable: Boolean
 
@@ -1854,6 +2127,10 @@ type ArtworkItem implements Node & Searchable & Sellable {
   is_on_hold: String
   is_price_hidden: Boolean
   is_price_range: Boolean
+  is_purchasable: Boolean
+    @deprecated(
+      reason: "Purchase requests are not supported. Replaced by buy now. [Will be removed in v2]"
+    )
   is_saved: Boolean
   is_shareable: Boolean
   is_sold: Boolean
@@ -1864,14 +2141,24 @@ type ArtworkItem implements Node & Searchable & Sellable {
   literature(format: Format): String
   manufacturer(format: Format): String
   medium: String
+  metric: String
+    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
   meta: ArtworkMeta
   myLotStanding(live: Boolean = null): [LotStanding!]
+
+  # [DO NOT USE] Weekly pageview data (static).
+  pageviews: Int
+    @deprecated(
+      reason: "This is for an AB test and will be imminently deprecated. [Will be removed in v2]"
+    )
   partner(
     # Use whatever is in the original response instead of making a request
     shallow: Boolean
   ): Partner
   pickup_available: Boolean
   price: String
+  priceCents: PriceCents
+    @deprecated(reason: "Prefer to use `listPrice`. [Will be removed in v2]")
   listPrice: ListPrice
   price_currency: String
 
@@ -1899,6 +2186,8 @@ type ArtworkItem implements Node & Searchable & Sellable {
 
   # If the category is video, then it returns the href for the (youtube/vimeo) video, otherwise returns the website from CMS
   website: String
+  width: String
+    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
   framed: ArtworkInfoRow
   signatureInfo: ArtworkInfoRow
   conditionDescription: ArtworkInfoRow
@@ -2191,6 +2480,10 @@ type Author {
   # A type-specific ID.
   gravityID: ID!
   name: String
+  href: String
+    @deprecated(
+      reason: "Profiles have been removed and thus author hrefs don't exist anymore. [Will be removed in v2]"
+    )
   profile_handle: String
 }
 
@@ -2243,14 +2536,26 @@ type BidderPosition {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+  display_max_bid_amount_dollars: String
+    @deprecated(reason: "Prefer to use `max_bid`. [Will be removed in v2]")
+  display_suggested_next_bid_dollars: String
+    @deprecated(
+      reason: "Prefer to use `suggested_next_bid`. [Will be removed in v2]"
+    )
   highest_bid: HighestBid
   is_active: Boolean
   is_retracted: Boolean
   is_with_bid_max: Boolean
   is_winning: Boolean
   max_bid: BidderPositionMaxBid
+  max_bid_amount_cents: Int
+    @deprecated(reason: "Prefer to use `max_bid`. [Will be removed in v2]")
   sale_artwork: SaleArtwork
   suggested_next_bid: BidderPositionSuggestedNextBid
+  suggested_next_bid_cents: Int
+    @deprecated(
+      reason: "Prefer to use `suggested_next_bid`. [Will be removed in v2]"
+    )
 }
 
 input BidderPositionInput {
@@ -3166,6 +3471,7 @@ type CommerceLineItem {
   internalID: ID!
   listPriceCents: Int!
   order: CommerceOrder!
+  priceCents: Int! @deprecated(reason: "switch to use listPriceCents")
   quantity: Int!
   shippingTotalCents: Int
   updatedAt: CommerceDateTime!
@@ -4036,6 +4342,10 @@ type Conversation implements Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+  purchase_request: Boolean
+    @deprecated(
+      reason: "Purchase requests are not supported. Replaced by buy now. [Will be removed in v2]"
+    )
   from_last_viewed_message_id: String
   initial_message: String!
 
@@ -4055,6 +4365,10 @@ type Conversation implements Node {
 
   # True if user/conversation initiator is a recipient.
   is_last_message_to_user: Boolean
+
+  # Timestamp if the user opened the last message, null in all other cases
+  last_message_open: String
+    @deprecated(reason: "Prefer to use `unread`. [Will be removed in v2]")
 
   # Delivery id if the user is a recipient of the last message, null otherwise.
   last_message_delivery_id: String
@@ -4365,6 +4679,10 @@ union CreditCardMutationType =
   | CreditCardMutationFailure
 
 type CreditCardPayload {
+  credit_card: CreditCard
+    @deprecated(
+      reason: "Prefer to use `creditCardOrError`. [Will be removed in v2]"
+    )
   creditCardOrError: CreditCardMutationType
   clientMutationId: String
 }
@@ -4524,6 +4842,8 @@ type EditionSet implements Sellable {
   is_offerable: Boolean
   is_for_sale: Boolean
   is_sold: Boolean
+  price: String
+    @deprecated(reason: "Prefer to use `sale_message`. [Will be removed in v2]")
   listPrice: ListPrice
 
   # score assigned to an artwork based on its dimensions
@@ -4628,6 +4948,8 @@ type Fair {
   hours: String
   href: String
   image: Image
+  is_active: Boolean
+    @deprecated(reason: "Prefer to use `isActive`. [Will be removed in v2]")
 
   # Are we currently in the fair's active period?
   isActive: Boolean
@@ -4675,6 +4997,8 @@ type Fair {
     timezone: String
   ): String
   organizer: organizer
+  published: Boolean
+    @deprecated(reason: "Prefer to use `is_published`. [Will be removed in v2]")
   tagline: String
   ticketsLink: String
 
@@ -4852,12 +5176,18 @@ type FilterArtworks implements Node {
     last: Int
   ): ArtworkConnection
   counts: FilterArtworksCounts
+  followed_artists_total: Int
+    @deprecated(
+      reason: "Prefer to use `counts.followed_artists`. [Will be removed in v2]"
+    )
 
   # Artwork results.
   hits: [Artwork]
 
   # Returns a list of merchandisable artists sorted by merch score.
   merchandisable_artists: [Artist]
+  total: Int
+    @deprecated(reason: "Prefer to use `counts.total`. [Will be removed in v2]")
   facet: ArtworkFilterFacet
 }
 
@@ -5571,6 +5901,10 @@ type HighestBid {
   ): String
   cents: Int
   display: String
+  amount_cents: Int
+    @deprecated(reason: "Prefer to use `cents`. [Will be removed in v2]")
+  display_amount_dollars: String
+    @deprecated(reason: "Prefer to use `display`. [Will be removed in v2]")
 }
 
 union Highlighted = HighlightedShow | HighlightedArticle
@@ -5624,6 +5958,22 @@ type HighlightedShow implements Node {
   # The Artists presenting in this show
   artists: [Artist]
 
+  # The artworks featured in this show
+  artworks(
+    # List of artwork IDs to exclude from the response (irrespective of size)
+    exclude: [String]
+    for_sale: Boolean
+    published: Boolean = true
+    all: Boolean
+    page: Int = 1
+
+    # Number of artworks to return
+    size: Int = 25
+  ): [Artwork]
+    @deprecated(
+      reason: "Prefer to use `artworks_connection`. [Will be removed in v2]"
+    )
+
   # The artworks featured in the show
   artworks_connection(
     # List of artwork IDs to exclude from the response (irrespective of size)
@@ -5653,6 +6003,10 @@ type HighlightedShow implements Node {
 
   # A description of the show
   description: String
+  displayable: Boolean
+    @deprecated(
+      reason: "Prefer to use `is_displayable`. [Will be removed in v2]"
+    )
   end_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -5742,6 +6096,8 @@ type HighlightedShow implements Node {
 
   # Is it a show provided for historical reference?
   is_reference: Boolean
+  is_local_discovery: Boolean
+    @deprecated(reason: "Prefer to use `isStubShow`. [Will be removed in v2]")
 
   # Is it an outsourced local discovery stub show?
   isStubShow: Boolean
@@ -5891,6 +6247,10 @@ type HomePageArtworkModule implements Node {
   # A globally unique ID.
   id: ID!
   context: HomePageModuleContext
+  display: String
+    @deprecated(
+      reason: "Prefer to use `is_displayable`. [Will be removed in v2]"
+    )
   is_displayable: Boolean
   key: String
   params: HomePageModulesParams
@@ -6007,6 +6367,8 @@ type HomePageModuleContextFair {
   hours: String
   href: String
   image: Image
+  is_active: Boolean
+    @deprecated(reason: "Prefer to use `isActive`. [Will be removed in v2]")
 
   # Are we currently in the fair's active period?
   isActive: Boolean
@@ -6054,6 +6416,8 @@ type HomePageModuleContextFair {
     timezone: String
   ): String
   organizer: organizer
+  published: Boolean
+    @deprecated(reason: "Prefer to use `is_published`. [Will be removed in v2]")
   tagline: String
   ticketsLink: String
 
@@ -6277,6 +6641,8 @@ type HomePageModuleContextSale implements Node {
     last: Int
   ): ArtworkConnection
   associated_sale: Sale
+  auction_state: String
+    @deprecated(reason: "Prefer to use `status`. [Will be removed in v2]")
 
   # A bid increment policy that explains minimum bids in ranges.
   bid_increments: [BidIncrement]
@@ -6315,6 +6681,8 @@ type HomePageModuleContextSale implements Node {
   href: String
   name: String
   is_auction: Boolean
+  is_benefit: Boolean
+    @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")
   isBenefit: Boolean
   isGalleryAuction: Boolean
   is_auction_promo: Boolean
@@ -6494,6 +6862,8 @@ type Location {
 
   # Alternate Markdown-supporting free text representation of a location's opening hours
   day_schedule_text: String
+  displayDaySchedules: [FormattedDaySchedules]
+    @deprecated(reason: "Prefer to use `openingHours`. [Will be removed in v2]")
 
   # Union returning opening hours in formatted structure or a string
   openingHours: OpeningHoursUnion
@@ -6775,6 +7145,17 @@ type Me implements Node {
   ): [LotStanding]
   name: String
   initials(length: Int = 3): String
+
+  # A list of feed items, indicating published artworks (grouped by date and artists).
+  notifications_connection(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): NotificationsFeedItemConnection
+    @deprecated(
+      reason: "Prefer to use `followed_artists_artwork_groups`. [Will be removed in v2]"
+    )
   paddle_number: String
   recentlyViewedArtworkIds: [String]!
 
@@ -6844,7 +7225,13 @@ type Message implements Node {
 
   # True if message is from the user to the partner.
   is_from_user: Boolean
+  from_email_address: String
+    @deprecated(reason: "Prefer to use `from`. [Will be removed in v2]")
   from: MessageInitiator
+
+  # Full unsanitized text.
+  raw_text: String!
+    @deprecated(reason: "Prefer to use `body`. [Will be removed in v2]")
 
   # Unaltered text if possible, otherwise `body`: a parsed/sanitized version from Sendgrid.
   body: String
@@ -7848,6 +8235,12 @@ type OrderLineItem {
   # ID of the selected Edition set from the artwork
   editionSetId: String
 
+  # Unit price in cents
+  priceCents: Int
+    @deprecated(
+      reason: "Prefer to use `listPriceCents`. [Will be removed in v2]"
+    )
+
   # A formatted price with various currency formatting options.
   price(
     decimal: String = "."
@@ -8032,12 +8425,20 @@ type Partner implements Node {
   ): ArtworkConnection
   categories: [Category]
   collecting_institution: String
+  contact_message: String
+    @deprecated(
+      reason: "Prefer to use `Artwork.contact_message`. [Will be removed in v2]"
+    )
   counts: PartnerCounts
   default_profile_id: String
   has_fair_partnership: Boolean
   href: String
   initials(length: Int = 3): String
   is_default_profile_public: Boolean
+  is_limited_fair_partner: Boolean
+    @deprecated(
+      reason: "This field no longer exists, this is for backwards compatibility [Will be removed in v2]"
+    )
   is_linkable: Boolean
   is_pre_qualify: Boolean
   locations(size: Int = 25): [Location]
@@ -8578,6 +8979,24 @@ type Query {
     # When true, will only return exact keyword match
     keyword_match_exact: Boolean
   ): FilterArtworks
+
+  # Sale Artworks Elastic Search results
+  filter_sale_artworks(
+    aggregations: [SaleArtworkAggregation]
+    artist_ids: [String]
+    include_artworks_by_followed_artists: Boolean
+    live_sale: Boolean
+    is_auction: Boolean
+    gene_ids: [String]
+    estimate_range: String
+    page: Int
+    sale_id: ID
+    size: Int
+    sort: String
+  ): FilterSaleArtworks
+    @deprecated(
+      reason: "Prefer to use `sale_artworks`. [Will be removed in v2]"
+    )
   gene(
     # The slug or ID of the Gene
     id: String!
@@ -9068,6 +9487,8 @@ type Sale implements Node {
     last: Int
   ): ArtworkConnection
   associated_sale: Sale
+  auction_state: String
+    @deprecated(reason: "Prefer to use `status`. [Will be removed in v2]")
 
   # A bid increment policy that explains minimum bids in ranges.
   bid_increments: [BidIncrement]
@@ -9106,6 +9527,8 @@ type Sale implements Node {
   href: String
   name: String
   is_auction: Boolean
+  is_benefit: Boolean
+    @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")
   isBenefit: Boolean
   isGalleryAuction: Boolean
   is_auction_promo: Boolean
@@ -9177,6 +9600,14 @@ type SaleArtwork {
   internalID: ID!
   cached: Int
   artwork: Artwork
+  bidder_positions_count: Int
+    @deprecated(
+      reason: "Prefer to use `counts.bidder_positions`. [Will be removed in v2]"
+    )
+  bid_increments: [Float]
+    @deprecated(
+      reason: "Prefer to use `increments.cents`. [Will be removed in v2]"
+    )
   counts: SaleArtworkCounts
 
   # Currency abbreviation (e.g. "USD")
@@ -9187,6 +9618,10 @@ type SaleArtwork {
   # Singular estimate field, if specified
   estimate_cents: Int
   high_estimate: SaleArtworkHighEstimate
+  high_estimate_cents: Float
+    @deprecated(
+      reason: "Prefer to use `high_estimate`. [Will be removed in v2]"
+    )
   highest_bid: SaleArtworkHighestBid
   increments(
     # Whether or not to start the increments at the user's latest bid
@@ -9198,9 +9633,19 @@ type SaleArtwork {
   is_biddable: Boolean
   is_with_reserve: Boolean
   lot_label: String
+  lot_number: String
+    @deprecated(reason: "Prefer to use `lot_label`. [Will be removed in v2]")
   low_estimate: SaleArtworkLowEstimate
+  low_estimate_cents: Float
+    @deprecated(reason: "Prefer to use `low_estimate`. [Will be removed in v2]")
   minimum_next_bid: SaleArtworkMinimumNextBid
+  minimum_next_bid_cents: Float
+    @deprecated(
+      reason: "Prefer to use `minimum_next_bid`. [Will be removed in v2]"
+    )
   opening_bid: SaleArtworkOpeningBid
+  opening_bid_cents: Float
+    @deprecated(reason: "Prefer to use `opening_bid`. [Will be removed in v2]")
   position: Float
   reserve: SaleArtworkReserve
   reserve_message: String
@@ -9287,6 +9732,8 @@ type SaleArtworkHighestBid {
   ): String
   cents: Int
   display: String
+  amount_cents: Float
+    @deprecated(reason: "Prefer to use `cents`. [Will be removed in v2]")
 }
 
 type SaleArtworkHighEstimate {
@@ -9488,6 +9935,8 @@ type SearchableItem implements Node & Searchable {
   displayLabel: String
   imageUrl: String
   href: String
+  searchableType: String
+    @deprecated(reason: "Prefer to use `displayType`. [Will be removed in v2]")
   displayType: String
 }
 
@@ -9734,6 +10183,22 @@ type Show implements Node {
   # The Artists presenting in this show
   artists: [Artist]
 
+  # The artworks featured in this show
+  artworks(
+    # List of artwork IDs to exclude from the response (irrespective of size)
+    exclude: [String]
+    for_sale: Boolean
+    published: Boolean = true
+    all: Boolean
+    page: Int = 1
+
+    # Number of artworks to return
+    size: Int = 25
+  ): [Artwork]
+    @deprecated(
+      reason: "Prefer to use `artworks_connection`. [Will be removed in v2]"
+    )
+
   # The artworks featured in the show
   artworks_connection(
     # List of artwork IDs to exclude from the response (irrespective of size)
@@ -9763,6 +10228,10 @@ type Show implements Node {
 
   # A description of the show
   description: String
+  displayable: Boolean
+    @deprecated(
+      reason: "Prefer to use `is_displayable`. [Will be removed in v2]"
+    )
   end_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -9852,6 +10321,8 @@ type Show implements Node {
 
   # Is it a show provided for historical reference?
   is_reference: Boolean
+  is_local_discovery: Boolean
+    @deprecated(reason: "Prefer to use `isStubShow`. [Will be removed in v2]")
 
   # Is it an outsourced local discovery stub show?
   isStubShow: Boolean
@@ -10577,6 +11048,24 @@ type Viewer {
     # When true, will only return exact keyword match
     keyword_match_exact: Boolean
   ): FilterArtworks
+
+  # Sale Artworks Elastic Search results
+  filter_sale_artworks(
+    aggregations: [SaleArtworkAggregation]
+    artist_ids: [String]
+    include_artworks_by_followed_artists: Boolean
+    live_sale: Boolean
+    is_auction: Boolean
+    gene_ids: [String]
+    estimate_range: String
+    page: Int
+    sale_id: ID
+    size: Int
+    sort: String
+  ): FilterSaleArtworks
+    @deprecated(
+      reason: "Prefer to use `sale_artworks`. [Will be removed in v2]"
+    )
   gene(
     # The slug or ID of the Gene
     id: String!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -487,13 +487,13 @@ type Artist implements Node & Searchable {
     exclude_artists_without_artworks: Boolean = true
   ): [Artist]
   consignable: Boolean
-    @deprecated(reason: "Favor `is_`-prefixed boolean attributes")
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   counts: ArtistCounts
   currentEvent: CurrentEvent
   deathday: String
   disablePriceContext: Boolean
   display_auction_link: Boolean
-    @deprecated(reason: "Favor `is_`-prefixed boolean attributes")
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
 
   # Custom-sorted list of shows for an artist, in order of significance.
   exhibition_highlights(
@@ -585,20 +585,8 @@ type Artist implements Node & Searchable {
     # The number of PartnerArtists to return
     size: Int
   ): [PartnerArtist]
-  partner_shows(
-    active: Boolean
-    at_a_fair: Boolean
-    is_reference: Boolean
-
-    # The number of PartnerShows to return
-    size: Int
-    solo_show: Boolean
-    status: String
-    top_tier: Boolean
-    visible_to_public: Boolean
-    sort: PartnerShowSorts
-  ): [PartnerShow] @deprecated(reason: "Prefer to use shows attribute")
-  public: Boolean @deprecated(reason: "Favor `is_`-prefixed boolean attributes")
+  public: Boolean
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   related: ArtistRelatedData
   sales(
     live: Boolean
@@ -830,13 +818,13 @@ type ArtistItem implements Node & Searchable {
     exclude_artists_without_artworks: Boolean = true
   ): [Artist]
   consignable: Boolean
-    @deprecated(reason: "Favor `is_`-prefixed boolean attributes")
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   counts: ArtistCounts
   currentEvent: CurrentEvent
   deathday: String
   disablePriceContext: Boolean
   display_auction_link: Boolean
-    @deprecated(reason: "Favor `is_`-prefixed boolean attributes")
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
 
   # Custom-sorted list of shows for an artist, in order of significance.
   exhibition_highlights(
@@ -928,20 +916,8 @@ type ArtistItem implements Node & Searchable {
     # The number of PartnerArtists to return
     size: Int
   ): [PartnerArtist]
-  partner_shows(
-    active: Boolean
-    at_a_fair: Boolean
-    is_reference: Boolean
-
-    # The number of PartnerShows to return
-    size: Int
-    solo_show: Boolean
-    status: String
-    top_tier: Boolean
-    visible_to_public: Boolean
-    sort: PartnerShowSorts
-  ): [PartnerShow] @deprecated(reason: "Prefer to use shows attribute")
-  public: Boolean @deprecated(reason: "Favor `is_`-prefixed boolean attributes")
+  public: Boolean
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   related: ArtistRelatedData
   sales(
     live: Boolean
@@ -1036,9 +1012,18 @@ type ArtistRelatedData {
 }
 
 enum ArtistSorts {
-  sortable_id_asc @deprecated(reason: "use capital enums")
-  sortable_id_desc @deprecated(reason: "use capital enums")
-  trending_desc @deprecated(reason: "use capital enums")
+  sortable_id_asc
+    @deprecated(
+      reason: "Prefer to use `SORTABLE_ID_ASC`. [Will be removed in v2]"
+    )
+  sortable_id_desc
+    @deprecated(
+      reason: "Prefer to use `SORTABLE_ID_DESC`. [Will be removed in v2]"
+    )
+  trending_desc
+    @deprecated(
+      reason: "Prefer to use `TRENDING_DESC`. [Will be removed in v2]"
+    )
   SORTABLE_ID_ASC
   SORTABLE_ID_DESC
   TRENDING_DESC
@@ -1081,7 +1066,7 @@ type Artwork implements Node & Searchable & Sellable {
   articles(size: Int): [Article]
   availability: String
   can_share_image: Boolean
-    @deprecated(reason: "Favor `is_`-prefixed boolean attributes")
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   category: String
 
   # Attribution class object
@@ -1105,7 +1090,8 @@ type Artwork implements Node & Searchable & Sellable {
   edition_sets(sort: EditionSetSorts): [EditionSet]
   exhibition_history(format: Format): String
   fair: Fair
-  height: String @deprecated(reason: "Prefer dimensions instead.")
+  height: String
+    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
 
   # Returns the highlighted shows and articles
   highlights: [Highlighted]
@@ -1133,11 +1119,16 @@ type Artwork implements Node & Searchable & Sellable {
   is_comparable_with_auction_results: Boolean
 
   # Are we able to display a contact form on artwork pages?
-  is_contactable: Boolean @deprecated(reason: "Prefer to use is_inquireable")
+  is_contactable: Boolean
+    @deprecated(
+      reason: "Prefer to use `is_inquireable`. [Will be removed in v2]"
+    )
   is_downloadable: Boolean
   is_embeddable_video: Boolean
   is_ecommerce: Boolean
-    @deprecated(reason: "Should not be used to determine anything UI-level")
+    @deprecated(
+      reason: "Should not be used to determine anything UI-level. [Will be removed in v2]"
+    )
   is_for_sale: Boolean
   is_hangable: Boolean
 
@@ -1155,7 +1146,7 @@ type Artwork implements Node & Searchable & Sellable {
   is_price_range: Boolean
   is_purchasable: Boolean
     @deprecated(
-      reason: "Purchase requests are not supported. Replaced by buy now."
+      reason: "Purchase requests are not supported. Replaced by buy now. [Will be removed in v2]"
     )
   is_saved: Boolean
   is_shareable: Boolean
@@ -1167,19 +1158,24 @@ type Artwork implements Node & Searchable & Sellable {
   literature(format: Format): String
   manufacturer(format: Format): String
   medium: String
-  metric: String @deprecated(reason: "Prefer dimensions instead.")
+  metric: String
+    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
   meta: ArtworkMeta
   myLotStanding(live: Boolean = null): [LotStanding!]
 
   # [DO NOT USE] Weekly pageview data (static).
   pageviews: Int
+    @deprecated(
+      reason: "This is for an AB test and will be imminently deprecated. [Will be removed in v2]"
+    )
   partner(
     # Use whatever is in the original response instead of making a request
     shallow: Boolean
   ): Partner
   pickup_available: Boolean
   price: String
-  priceCents: PriceCents @deprecated(reason: "Prefer `listPrice` instead.")
+  priceCents: PriceCents
+    @deprecated(reason: "Prefer to use `listPrice`. [Will be removed in v2]")
   listPrice: ListPrice
   price_currency: String
 
@@ -1198,18 +1194,6 @@ type Artwork implements Node & Searchable & Sellable {
   sale_artwork(sale_id: String = null): SaleArtwork
   sale_message: String
   series(format: Format): String
-  show(
-    size: Int
-    active: Boolean
-    at_a_fair: Boolean
-    sort: PartnerShowSorts
-  ): PartnerShow
-  shows(
-    size: Int
-    active: Boolean
-    at_a_fair: Boolean
-    sort: PartnerShowSorts
-  ): [PartnerShow]
   signature(format: Format): String
   title: String
   to_s: String
@@ -1219,7 +1203,8 @@ type Artwork implements Node & Searchable & Sellable {
 
   # If the category is video, then it returns the href for the (youtube/vimeo) video, otherwise returns the website from CMS
   website: String
-  width: String @deprecated(reason: "Prefer dimensions instead.")
+  width: String
+    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
   framed: ArtworkInfoRow
   signatureInfo: ArtworkInfoRow
   conditionDescription: ArtworkInfoRow
@@ -1298,7 +1283,7 @@ type ArtworkContextAuction implements Node {
   ): ArtworkConnection
   associated_sale: Sale
   auction_state: String
-    @deprecated(reason: "Favor `status` for consistency with other models")
+    @deprecated(reason: "Prefer to use `status`. [Will be removed in v2]")
 
   # A bid increment policy that explains minimum bids in ranges.
   bid_increments: [BidIncrement]
@@ -1337,7 +1322,8 @@ type ArtworkContextAuction implements Node {
   href: String
   name: String
   is_auction: Boolean
-  is_benefit: Boolean @deprecated(reason: "Favor `isBenefit`")
+  is_benefit: Boolean
+    @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")
   isBenefit: Boolean
   isGalleryAuction: Boolean
   is_auction_promo: Boolean
@@ -1433,7 +1419,8 @@ type ArtworkContextFair {
   hours: String
   href: String
   image: Image
-  is_active: Boolean @deprecated(reason: "Prefer isActive instead")
+  is_active: Boolean
+    @deprecated(reason: "Prefer to use `isActive`. [Will be removed in v2]")
 
   # Are we currently in the fair's active period?
   isActive: Boolean
@@ -1482,7 +1469,7 @@ type ArtworkContextFair {
   ): String
   organizer: organizer
   published: Boolean
-    @deprecated(reason: "Prefix Boolean returning fields with `is_`")
+    @deprecated(reason: "Prefer to use `is_published`. [Will be removed in v2]")
   tagline: String
   ticketsLink: String
 
@@ -1538,14 +1525,29 @@ type ArtworkContextFair {
 type ArtworkContextPartnerShow implements Node {
   # A globally unique ID.
   id: ID!
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # A type-specific ID.
   gravityID: ID!
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   cached: Int
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   artists: [Artist]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # The artworks featured in the show
   artworks(
@@ -1559,6 +1561,9 @@ type ArtworkContextPartnerShow implements Node {
     # Number of artworks to return
     size: Int = 25
   ): [Artwork]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # A connection of artworks featured in the show
   artworksConnection(
@@ -1571,8 +1576,17 @@ type ArtworkContextPartnerShow implements Node {
     before: String
     last: Int
   ): ArtworkConnection
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   counts: PartnerShowCounts
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   cover_image: Image
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   created_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -1581,9 +1595,17 @@ type ArtworkContextPartnerShow implements Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   description: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   displayable: Boolean
-    @deprecated(reason: "Prefix Boolean returning fields with `is_`")
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   end_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -1592,12 +1614,27 @@ type ArtworkContextPartnerShow implements Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   events: [PartnerShowEventType]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # A formatted description of the start to end dates
   exhibition_period: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   fair: Fair
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   href: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   images(
     # Number of images to return
     size: Int
@@ -1606,22 +1643,55 @@ type ArtworkContextPartnerShow implements Node {
     default: Boolean
     page: Int
   ): [Image]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # Flag showing if show has any location.
   has_location: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # Gravity doesn’t expose the `active` flag. Temporarily re-state its logic.
   is_active: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   is_displayable: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   is_fair_booth: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   kind: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   location: Location
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   meta_image: Image
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # The exhibition title
   name: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   partner: Partner
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   press_release(format: Format): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   start_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -1630,14 +1700,26 @@ type ArtworkContextPartnerShow implements Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   status: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 
   # A formatted update on upcoming status changes
   status_update(
     # Before this many days no update will be generated
     max_days: Int
   ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
   type: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 }
 
 type ArtworkContextSale implements Node {
@@ -1670,7 +1752,7 @@ type ArtworkContextSale implements Node {
   ): ArtworkConnection
   associated_sale: Sale
   auction_state: String
-    @deprecated(reason: "Favor `status` for consistency with other models")
+    @deprecated(reason: "Prefer to use `status`. [Will be removed in v2]")
 
   # A bid increment policy that explains minimum bids in ranges.
   bid_increments: [BidIncrement]
@@ -1709,7 +1791,8 @@ type ArtworkContextSale implements Node {
   href: String
   name: String
   is_auction: Boolean
-  is_benefit: Boolean @deprecated(reason: "Favor `isBenefit`")
+  is_benefit: Boolean
+    @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")
   isBenefit: Boolean
   isGalleryAuction: Boolean
   is_auction_promo: Boolean
@@ -1966,7 +2049,7 @@ type ArtworkItem implements Node & Searchable & Sellable {
   articles(size: Int): [Article]
   availability: String
   can_share_image: Boolean
-    @deprecated(reason: "Favor `is_`-prefixed boolean attributes")
+    @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
   category: String
 
   # Attribution class object
@@ -1990,7 +2073,8 @@ type ArtworkItem implements Node & Searchable & Sellable {
   edition_sets(sort: EditionSetSorts): [EditionSet]
   exhibition_history(format: Format): String
   fair: Fair
-  height: String @deprecated(reason: "Prefer dimensions instead.")
+  height: String
+    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
 
   # Returns the highlighted shows and articles
   highlights: [Highlighted]
@@ -2018,11 +2102,16 @@ type ArtworkItem implements Node & Searchable & Sellable {
   is_comparable_with_auction_results: Boolean
 
   # Are we able to display a contact form on artwork pages?
-  is_contactable: Boolean @deprecated(reason: "Prefer to use is_inquireable")
+  is_contactable: Boolean
+    @deprecated(
+      reason: "Prefer to use `is_inquireable`. [Will be removed in v2]"
+    )
   is_downloadable: Boolean
   is_embeddable_video: Boolean
   is_ecommerce: Boolean
-    @deprecated(reason: "Should not be used to determine anything UI-level")
+    @deprecated(
+      reason: "Should not be used to determine anything UI-level. [Will be removed in v2]"
+    )
   is_for_sale: Boolean
   is_hangable: Boolean
 
@@ -2040,7 +2129,7 @@ type ArtworkItem implements Node & Searchable & Sellable {
   is_price_range: Boolean
   is_purchasable: Boolean
     @deprecated(
-      reason: "Purchase requests are not supported. Replaced by buy now."
+      reason: "Purchase requests are not supported. Replaced by buy now. [Will be removed in v2]"
     )
   is_saved: Boolean
   is_shareable: Boolean
@@ -2052,19 +2141,24 @@ type ArtworkItem implements Node & Searchable & Sellable {
   literature(format: Format): String
   manufacturer(format: Format): String
   medium: String
-  metric: String @deprecated(reason: "Prefer dimensions instead.")
+  metric: String
+    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
   meta: ArtworkMeta
   myLotStanding(live: Boolean = null): [LotStanding!]
 
   # [DO NOT USE] Weekly pageview data (static).
   pageviews: Int
+    @deprecated(
+      reason: "This is for an AB test and will be imminently deprecated. [Will be removed in v2]"
+    )
   partner(
     # Use whatever is in the original response instead of making a request
     shallow: Boolean
   ): Partner
   pickup_available: Boolean
   price: String
-  priceCents: PriceCents @deprecated(reason: "Prefer `listPrice` instead.")
+  priceCents: PriceCents
+    @deprecated(reason: "Prefer to use `listPrice`. [Will be removed in v2]")
   listPrice: ListPrice
   price_currency: String
 
@@ -2083,18 +2177,6 @@ type ArtworkItem implements Node & Searchable & Sellable {
   sale_artwork(sale_id: String = null): SaleArtwork
   sale_message: String
   series(format: Format): String
-  show(
-    size: Int
-    active: Boolean
-    at_a_fair: Boolean
-    sort: PartnerShowSorts
-  ): PartnerShow
-  shows(
-    size: Int
-    active: Boolean
-    at_a_fair: Boolean
-    sort: PartnerShowSorts
-  ): [PartnerShow]
   signature(format: Format): String
   title: String
   to_s: String
@@ -2104,7 +2186,8 @@ type ArtworkItem implements Node & Searchable & Sellable {
 
   # If the category is video, then it returns the href for the (youtube/vimeo) video, otherwise returns the website from CMS
   website: String
-  width: String @deprecated(reason: "Prefer dimensions instead.")
+  width: String
+    @deprecated(reason: "Prefer to use `dimensions`. [Will be removed in v2]")
   framed: ArtworkInfoRow
   signatureInfo: ArtworkInfoRow
   conditionDescription: ArtworkInfoRow
@@ -2155,18 +2238,50 @@ type ArtworksAggregationResults {
 }
 
 enum ArtworkSorts {
-  availability_desc @deprecated(reason: "use capital enums")
-  created_at_asc @deprecated(reason: "use capital enums")
-  created_at_desc @deprecated(reason: "use capital enums")
-  deleted_at_asc @deprecated(reason: "use capital enums")
-  deleted_at_desc @deprecated(reason: "use capital enums")
-  iconicity_desc @deprecated(reason: "use capital enums")
-  merchandisability_desc @deprecated(reason: "use capital enums")
-  published_at_asc @deprecated(reason: "use capital enums")
-  published_at_desc @deprecated(reason: "use capital enums")
-  partner_updated_at_desc @deprecated(reason: "use capital enums")
-  title_asc @deprecated(reason: "use capital enums")
-  title_desc @deprecated(reason: "use capital enums")
+  availability_desc
+    @deprecated(
+      reason: "Prefer to use `AVAILABILITY_DESC`. [Will be removed in v2]"
+    )
+  created_at_asc
+    @deprecated(
+      reason: "Prefer to use `CREATED_AT_ASC`. [Will be removed in v2]"
+    )
+  created_at_desc
+    @deprecated(
+      reason: "Prefer to use `CREATED_AT_DESC`. [Will be removed in v2]"
+    )
+  deleted_at_asc
+    @deprecated(
+      reason: "Prefer to use `DELETED_AT_ASC`. [Will be removed in v2]"
+    )
+  deleted_at_desc
+    @deprecated(
+      reason: "Prefer to use `DELETED_AT_DESC`. [Will be removed in v2]"
+    )
+  iconicity_desc
+    @deprecated(
+      reason: "Prefer to use `ICONICITY_DESC`. [Will be removed in v2]"
+    )
+  merchandisability_desc
+    @deprecated(
+      reason: "Prefer to use `MERCHANDISABILITY_DESC`. [Will be removed in v2]"
+    )
+  published_at_asc
+    @deprecated(
+      reason: "Prefer to use `PUBLISHED_AT_ASC`. [Will be removed in v2]"
+    )
+  published_at_desc
+    @deprecated(
+      reason: "Prefer to use `PUBLISHED_AT_DESC`. [Will be removed in v2]"
+    )
+  partner_updated_at_desc
+    @deprecated(
+      reason: "Prefer to use `PARTNER_UPDATED_AT_DESC`. [Will be removed in v2]"
+    )
+  title_asc
+    @deprecated(reason: "Prefer to use `TITLE_ASC`. [Will be removed in v2]")
+  title_desc
+    @deprecated(reason: "Prefer to use `TITLE_DESC`. [Will be removed in v2]")
   AVAILABILITY_DESC
   CREATED_AT_ASC
   CREATED_AT_DESC
@@ -2367,7 +2482,7 @@ type Author {
   name: String
   href: String
     @deprecated(
-      reason: "Profiles have been removed and thus author hrefs don't exist anymore."
+      reason: "Profiles have been removed and thus author hrefs don't exist anymore. [Will be removed in v2]"
     )
   profile_handle: String
 }
@@ -2421,20 +2536,26 @@ type BidderPosition {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
-  display_max_bid_amount_dollars: String @deprecated(reason: "Favor `max_bid`")
+  display_max_bid_amount_dollars: String
+    @deprecated(reason: "Prefer to use `max_bid`. [Will be removed in v2]")
   display_suggested_next_bid_dollars: String
-    @deprecated(reason: "Favor `suggested_next_bid`")
+    @deprecated(
+      reason: "Prefer to use `suggested_next_bid`. [Will be removed in v2]"
+    )
   highest_bid: HighestBid
   is_active: Boolean
   is_retracted: Boolean
   is_with_bid_max: Boolean
   is_winning: Boolean
   max_bid: BidderPositionMaxBid
-  max_bid_amount_cents: Int @deprecated(reason: "Favor `max_bid`")
+  max_bid_amount_cents: Int
+    @deprecated(reason: "Prefer to use `max_bid`. [Will be removed in v2]")
   sale_artwork: SaleArtwork
   suggested_next_bid: BidderPositionSuggestedNextBid
   suggested_next_bid_cents: Int
-    @deprecated(reason: "Favor `suggested_next_bid`")
+    @deprecated(
+      reason: "Prefer to use `suggested_next_bid`. [Will be removed in v2]"
+    )
 }
 
 input BidderPositionInput {
@@ -4223,7 +4344,7 @@ type Conversation implements Node {
   ): String
   purchase_request: Boolean
     @deprecated(
-      reason: "Purchase requests are not supported. Replaced by buy now."
+      reason: "Purchase requests are not supported. Replaced by buy now. [Will be removed in v2]"
     )
   from_last_viewed_message_id: String
   initial_message: String!
@@ -4246,7 +4367,8 @@ type Conversation implements Node {
   is_last_message_to_user: Boolean
 
   # Timestamp if the user opened the last message, null in all other cases
-  last_message_open: String @deprecated(reason: "Prefer to use `unread`")
+  last_message_open: String
+    @deprecated(reason: "Prefer to use `unread`. [Will be removed in v2]")
 
   # Delivery id if the user is a recipient of the last message, null otherwise.
   last_message_delivery_id: String
@@ -4557,7 +4679,10 @@ union CreditCardMutationType =
   | CreditCardMutationFailure
 
 type CreditCardPayload {
-  credit_card: CreditCard @deprecated(reason: "Favor `creditCardOrError`")
+  credit_card: CreditCard
+    @deprecated(
+      reason: "Prefer to use `creditCardOrError`. [Will be removed in v2]"
+    )
   creditCardOrError: CreditCardMutationType
   clientMutationId: String
 }
@@ -4717,7 +4842,8 @@ type EditionSet implements Sellable {
   is_offerable: Boolean
   is_for_sale: Boolean
   is_sold: Boolean
-  price: String @deprecated(reason: "Prefer to use `sale_message`.")
+  price: String
+    @deprecated(reason: "Prefer to use `sale_message`. [Will be removed in v2]")
   listPrice: ListPrice
 
   # score assigned to an artwork based on its dimensions
@@ -4746,10 +4872,13 @@ type EndSalePayload {
 }
 
 enum EventStatus {
-  closed @deprecated(reason: "use capital enums")
-  current @deprecated(reason: "use capital enums")
-  running @deprecated(reason: "use capital enums")
-  upcoming @deprecated(reason: "use capital enums")
+  closed @deprecated(reason: "Prefer to use `CLOSED`. [Will be removed in v2]")
+  current
+    @deprecated(reason: "Prefer to use `CURRENT`. [Will be removed in v2]")
+  running
+    @deprecated(reason: "Prefer to use `RUNNING`. [Will be removed in v2]")
+  upcoming
+    @deprecated(reason: "Prefer to use `UPCOMING`. [Will be removed in v2]")
 
   # End date is in the past
   CLOSED
@@ -4819,7 +4948,8 @@ type Fair {
   hours: String
   href: String
   image: Image
-  is_active: Boolean @deprecated(reason: "Prefer isActive instead")
+  is_active: Boolean
+    @deprecated(reason: "Prefer to use `isActive`. [Will be removed in v2]")
 
   # Are we currently in the fair's active period?
   isActive: Boolean
@@ -4868,7 +4998,7 @@ type Fair {
   ): String
   organizer: organizer
   published: Boolean
-    @deprecated(reason: "Prefix Boolean returning fields with `is_`")
+    @deprecated(reason: "Prefer to use `is_published`. [Will be removed in v2]")
   tagline: String
   ticketsLink: String
 
@@ -5047,14 +5177,17 @@ type FilterArtworks implements Node {
   ): ArtworkConnection
   counts: FilterArtworksCounts
   followed_artists_total: Int
-    @deprecated(reason: "Favor `favor counts.followed_artists`")
+    @deprecated(
+      reason: "Prefer to use `counts.followed_artists`. [Will be removed in v2]"
+    )
 
   # Artwork results.
   hits: [Artwork]
 
   # Returns a list of merchandisable artists sorted by merch score.
   merchandisable_artists: [Artist]
-  total: Int @deprecated(reason: "Favor `counts.total`")
+  total: Int
+    @deprecated(reason: "Prefer to use `counts.total`. [Will be removed in v2]")
   facet: ArtworkFilterFacet
 }
 
@@ -5359,7 +5492,10 @@ type FollowShowPayload {
 enum Format {
   HTML
   PLAIN
-  markdown @deprecated(reason: "deprecated")
+  markdown
+    @deprecated(
+      reason: "Deprecated when we deprecated lower-case enum entries, but no alternative was provided. Add an alternative to MP if this is still needed. [Will be removed in v2]"
+    )
 }
 
 type FormattedDaySchedules {
@@ -5765,8 +5901,10 @@ type HighestBid {
   ): String
   cents: Int
   display: String
-  amount_cents: Int @deprecated(reason: "Favor `cents`")
-  display_amount_dollars: String @deprecated(reason: "Favor `display`")
+  amount_cents: Int
+    @deprecated(reason: "Prefer to use `cents`. [Will be removed in v2]")
+  display_amount_dollars: String
+    @deprecated(reason: "Prefer to use `display`. [Will be removed in v2]")
 }
 
 union Highlighted = HighlightedShow | HighlightedArticle
@@ -5816,9 +5954,11 @@ type HighlightedShow implements Node {
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   cached: Int
+
+  # The Artists presenting in this show
   artists: [Artist]
 
-  # The artworks featured in the show
+  # The artworks featured in this show
   artworks(
     # List of artwork IDs to exclude from the response (irrespective of size)
     exclude: [String]
@@ -5830,9 +5970,12 @@ type HighlightedShow implements Node {
     # Number of artworks to return
     size: Int = 25
   ): [Artwork]
+    @deprecated(
+      reason: "Prefer to use `artworks_connection`. [Will be removed in v2]"
+    )
 
-  # A connection of artworks featured in the show
-  artworksConnection(
+  # The artworks featured in the show
+  artworks_connection(
     # List of artwork IDs to exclude from the response (irrespective of size)
     exclude: [String]
     for_sale: Boolean
@@ -5842,19 +5985,28 @@ type HighlightedShow implements Node {
     before: String
     last: Int
   ): ArtworkConnection
-  counts: PartnerShowCounts
-  cover_image: Image
-  created_at(
-    # This arg is deprecated, use timezone instead
-    convert_to_utc: Boolean
-    format: String
 
-    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
-    timezone: String
-  ): String
+  # Artists inside the show who do not have artworks present
+  artists_without_artworks: [Artist]
+
+  # Artists in the show grouped by last name
+  artists_grouped_by_name: [ArtistGroup]
+
+  # The general city, derived from a fair location, a show location or a potential city
+  city: String
+
+  # The image you should use to represent this show
+  cover_image: Image
+
+  # An object that represents some of the numbers you might want to highlight
+  counts: ShowCounts
+
+  # A description of the show
   description: String
   displayable: Boolean
-    @deprecated(reason: "Prefix Boolean returning fields with `is_`")
+    @deprecated(
+      reason: "Prefer to use `is_displayable`. [Will be removed in v2]"
+    )
   end_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -5863,12 +6015,64 @@ type HighlightedShow implements Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+
+  # Events from the partner that runs this show
   events: [PartnerShowEventType]
 
   # A formatted description of the start to end dates
   exhibition_period: String
+
+  # If the show is in a Fair, then that fair
   fair: Fair
+
+  # Artworks Elastic Search results
+  filteredArtworks(
+    acquireable: Boolean
+    offerable: Boolean
+    aggregation_partner_cities: [String]
+    aggregations: [ArtworkAggregation]
+    artist_id: String
+    artist_ids: [String]
+    at_auction: Boolean
+    attribution_class: [String]
+    color: String
+    dimension_range: String
+    extra_aggregation_gene_ids: [String]
+    include_artworks_by_followed_artists: Boolean
+    include_medium_filter_in_aggregation: Boolean
+    inquireable_only: Boolean
+    for_sale: Boolean
+    gene_id: String
+    gene_ids: [String]
+    height: String
+    width: String
+
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
+
+    # A string from the list of allocations, or * to denote all mediums
+    medium: String
+    period: String
+    periods: [String]
+    major_periods: [String]
+    partner_id: ID
+    partner_cities: [String]
+    price_range: String
+    page: Int
+    sale_id: ID
+    size: Int
+    sort: String
+    tag_id: String
+    keyword: String
+
+    # When true, will only return exact keyword match
+    keyword_match_exact: Boolean
+  ): FilterArtworks
+
+  # A path to the show on Artsy
   href: String
+
+  # Images that represent the show, you may be interested in meta_image or cover_image for a definitive thumbnail
   images(
     # Number of images to return
     size: Int
@@ -5883,16 +6087,64 @@ type HighlightedShow implements Node {
 
   # Gravity doesn’t expose the `active` flag. Temporarily re-state its logic.
   is_active: Boolean
+
+  # Is this something we can display to the front-end?
   is_displayable: Boolean
+
+  # Does the show exist as a fair booth?
   is_fair_booth: Boolean
+
+  # Is it a show provided for historical reference?
+  is_reference: Boolean
+  is_local_discovery: Boolean
+    @deprecated(reason: "Prefer to use `isStubShow`. [Will be removed in v2]")
+
+  # Is it an outsourced local discovery stub show?
+  isStubShow: Boolean
+
+  # Whether the show is in a fair, group or solo
   kind: String
+
+  # Where the show is located (Could also be a fair location)
   location: Location
+
+  # An image representing the show, or a sharable image from an artwork in the show
   meta_image: Image
+
+  # Is the user following this show
+  is_followed: Boolean
 
   # The exhibition title
   name: String
-  partner: Partner
+
+  # Shows that are near (~75km) from this show
+  nearbyShows(
+    sort: PartnerShowSorts
+
+    # By default show only current shows
+    status: EventStatus = CURRENT
+
+    # Whether to include local discovery stubs as well as displayable shows
+    discoverable: Boolean
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ShowConnection
+
+  # Alternate Markdown-supporting free text representation of the opening reception event’s date/time
+  openingReceptionText: String
+
+  # The partner that represents this show, could be a non-Artsy partner
+  partner: PartnerTypes
+
+  # The press release for this show
   press_release(format: Format): String
+
+  # Link to the press release for this show
+  pressReleaseUrl: String
+
+  # When this show starts
   start_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -5901,6 +6153,8 @@ type HighlightedShow implements Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+
+  # Is this show running, upcoming or closed?
   status: String
 
   # A formatted update on upcoming status changes
@@ -5908,7 +6162,17 @@ type HighlightedShow implements Node {
     # Before this many days no update will be generated
     max_days: Int
   ): String
+
+  # Is it a fair booth or a show?
   type: String
+
+  # A Connection of followed artists by current user for this show
+  followedArtists(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ShowFollowArtistConnection
 }
 
 type HomePage {
@@ -5985,7 +6249,7 @@ type HomePageArtworkModule implements Node {
   context: HomePageModuleContext
   display: String
     @deprecated(
-      reason: "Favor `is_`-prefixed Booleans (*and* this should be a Boolean)"
+      reason: "Prefer to use `is_displayable`. [Will be removed in v2]"
     )
   is_displayable: Boolean
   key: String
@@ -6103,7 +6367,8 @@ type HomePageModuleContextFair {
   hours: String
   href: String
   image: Image
-  is_active: Boolean @deprecated(reason: "Prefer isActive instead")
+  is_active: Boolean
+    @deprecated(reason: "Prefer to use `isActive`. [Will be removed in v2]")
 
   # Are we currently in the fair's active period?
   isActive: Boolean
@@ -6152,7 +6417,7 @@ type HomePageModuleContextFair {
   ): String
   organizer: organizer
   published: Boolean
-    @deprecated(reason: "Prefix Boolean returning fields with `is_`")
+    @deprecated(reason: "Prefer to use `is_published`. [Will be removed in v2]")
   tagline: String
   ticketsLink: String
 
@@ -6377,7 +6642,7 @@ type HomePageModuleContextSale implements Node {
   ): ArtworkConnection
   associated_sale: Sale
   auction_state: String
-    @deprecated(reason: "Favor `status` for consistency with other models")
+    @deprecated(reason: "Prefer to use `status`. [Will be removed in v2]")
 
   # A bid increment policy that explains minimum bids in ranges.
   bid_increments: [BidIncrement]
@@ -6416,7 +6681,8 @@ type HomePageModuleContextSale implements Node {
   href: String
   name: String
   is_auction: Boolean
-  is_benefit: Boolean @deprecated(reason: "Favor `isBenefit`")
+  is_benefit: Boolean
+    @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")
   isBenefit: Boolean
   isGalleryAuction: Boolean
   is_auction_promo: Boolean
@@ -6597,7 +6863,7 @@ type Location {
   # Alternate Markdown-supporting free text representation of a location's opening hours
   day_schedule_text: String
   displayDaySchedules: [FormattedDaySchedules]
-    @deprecated(reason: "Use openingHours instead")
+    @deprecated(reason: "Prefer to use `openingHours`. [Will be removed in v2]")
 
   # Union returning opening hours in formatted structure or a string
   openingHours: OpeningHoursUnion
@@ -6887,7 +7153,9 @@ type Me implements Node {
     before: String
     last: Int
   ): NotificationsFeedItemConnection
-    @deprecated(reason: "Prefer to use followed_artists_artwork_groups.")
+    @deprecated(
+      reason: "Prefer to use `followed_artists_artwork_groups`. [Will be removed in v2]"
+    )
   paddle_number: String
   recentlyViewedArtworkIds: [String]!
 
@@ -6958,12 +7226,12 @@ type Message implements Node {
   # True if message is from the user to the partner.
   is_from_user: Boolean
   from_email_address: String
-    @deprecated(reason: "Prefer to use the structured `from` field.")
+    @deprecated(reason: "Prefer to use `from`. [Will be removed in v2]")
   from: MessageInitiator
 
   # Full unsanitized text.
   raw_text: String!
-    @deprecated(reason: "Prefer to use the parsed/cleaned-up `body`.")
+    @deprecated(reason: "Prefer to use `body`. [Will be removed in v2]")
 
   # Unaltered text if possible, otherwise `body`: a parsed/sanitized version from Sendgrid.
   body: String
@@ -7968,7 +8236,10 @@ type OrderLineItem {
   editionSetId: String
 
   # Unit price in cents
-  priceCents: Int @deprecated(reason: "Switched to `listPriceCents`")
+  priceCents: Int
+    @deprecated(
+      reason: "Prefer to use `listPriceCents`. [Will be removed in v2]"
+    )
 
   # A formatted price with various currency formatting options.
   price(
@@ -8156,7 +8427,7 @@ type Partner implements Node {
   collecting_institution: String
   contact_message: String
     @deprecated(
-      reason: "Prefer artwork contact_message to handle availability-based prompts."
+      reason: "Prefer to use `Artwork.contact_message`. [Will be removed in v2]"
     )
   counts: PartnerCounts
   default_profile_id: String
@@ -8166,29 +8437,13 @@ type Partner implements Node {
   is_default_profile_public: Boolean
   is_limited_fair_partner: Boolean
     @deprecated(
-      reason: "This field no longer exists, this is for backwards compatibility"
+      reason: "This field no longer exists, this is for backwards compatibility [Will be removed in v2]"
     )
   is_linkable: Boolean
   is_pre_qualify: Boolean
   locations(size: Int = 25): [Location]
   name: String
   profile: Profile
-  shows(
-    at_a_fair: Boolean
-    displayable: Boolean = true
-    fair_id: String
-    featured: Boolean
-
-    #
-    #         Only return shows matching specified ids.
-    #         Accepts list of ids.
-    #
-    ids: [String]
-    near: Near
-    size: Int
-    sort: PartnerShowSorts
-    status: EventStatus
-  ): [PartnerShow]
   type: String
 
   # The gallery partner's web address
@@ -8380,111 +8635,6 @@ type PartnersAggregationResults {
   slice: PartnersAggregation
 }
 
-type PartnerShow implements Node {
-  # A globally unique ID.
-  id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
-
-  # A type-specific Gravity Mongo Document ID.
-  internalID: ID!
-  cached: Int
-  artists: [Artist]
-
-  # The artworks featured in the show
-  artworks(
-    # List of artwork IDs to exclude from the response (irrespective of size)
-    exclude: [String]
-    for_sale: Boolean
-    published: Boolean = true
-    all: Boolean
-    page: Int = 1
-
-    # Number of artworks to return
-    size: Int = 25
-  ): [Artwork]
-
-  # A connection of artworks featured in the show
-  artworksConnection(
-    # List of artwork IDs to exclude from the response (irrespective of size)
-    exclude: [String]
-    for_sale: Boolean
-    published: Boolean = true
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): ArtworkConnection
-  counts: PartnerShowCounts
-  cover_image: Image
-  created_at(
-    # This arg is deprecated, use timezone instead
-    convert_to_utc: Boolean
-    format: String
-
-    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
-    timezone: String
-  ): String
-  description: String
-  displayable: Boolean
-    @deprecated(reason: "Prefix Boolean returning fields with `is_`")
-  end_at(
-    # This arg is deprecated, use timezone instead
-    convert_to_utc: Boolean
-    format: String
-
-    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
-    timezone: String
-  ): String
-  events: [PartnerShowEventType]
-
-  # A formatted description of the start to end dates
-  exhibition_period: String
-  fair: Fair
-  href: String
-  images(
-    # Number of images to return
-    size: Int
-
-    # Pass true/false to include cover or not
-    default: Boolean
-    page: Int
-  ): [Image]
-
-  # Flag showing if show has any location.
-  has_location: Boolean
-
-  # Gravity doesn’t expose the `active` flag. Temporarily re-state its logic.
-  is_active: Boolean
-  is_displayable: Boolean
-  is_fair_booth: Boolean
-  kind: String
-  location: Location
-  meta_image: Image
-
-  # The exhibition title
-  name: String
-  partner: Partner
-  press_release(format: Format): String
-  start_at(
-    # This arg is deprecated, use timezone instead
-    convert_to_utc: Boolean
-    format: String
-
-    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
-    timezone: String
-  ): String
-  status: String
-
-  # A formatted update on upcoming status changes
-  status_update(
-    # Before this many days no update will be generated
-    max_days: Int
-  ): String
-  type: String
-}
-
 type PartnerShowCounts {
   artworks(
     # The slug or ID of an artist in the show.
@@ -8531,16 +8681,36 @@ enum PartnerShowPartnerType {
 }
 
 enum PartnerShowSorts {
-  created_at_asc @deprecated(reason: "use capital enums")
-  created_at_desc @deprecated(reason: "use capital enums")
-  end_at_asc @deprecated(reason: "use capital enums")
-  end_at_desc @deprecated(reason: "use capital enums")
-  name_asc @deprecated(reason: "use capital enums")
-  name_desc @deprecated(reason: "use capital enums")
-  publish_at_asc @deprecated(reason: "use capital enums")
-  publish_at_desc @deprecated(reason: "use capital enums")
-  start_at_asc @deprecated(reason: "use capital enums")
-  start_at_desc @deprecated(reason: "use capital enums")
+  created_at_asc
+    @deprecated(
+      reason: "Prefer to use `CREATED_AT_ASC`. [Will be removed in v2]"
+    )
+  created_at_desc
+    @deprecated(
+      reason: "Prefer to use `CREATED_AT_DESC`. [Will be removed in v2]"
+    )
+  end_at_asc
+    @deprecated(reason: "Prefer to use `END_AT_ASC`. [Will be removed in v2]")
+  end_at_desc
+    @deprecated(reason: "Prefer to use `END_AT_DESC`. [Will be removed in v2]")
+  name_asc
+    @deprecated(reason: "Prefer to use `NAME_ASC`. [Will be removed in v2]")
+  name_desc
+    @deprecated(reason: "Prefer to use `NAME_DESC`. [Will be removed in v2]")
+  publish_at_asc
+    @deprecated(
+      reason: "Prefer to use `PUBLISH_AT_ASC`. [Will be removed in v2]"
+    )
+  publish_at_desc
+    @deprecated(
+      reason: "Prefer to use `PUBLISH_AT_DESC`. [Will be removed in v2]"
+    )
+  start_at_asc
+    @deprecated(reason: "Prefer to use `START_AT_ASC`. [Will be removed in v2]")
+  start_at_desc
+    @deprecated(
+      reason: "Prefer to use `START_AT_DESC`. [Will be removed in v2]"
+    )
   CREATED_AT_ASC
   CREATED_AT_DESC
   END_AT_ASC
@@ -8824,7 +8994,9 @@ type Query {
     size: Int
     sort: String
   ): FilterSaleArtworks
-    @deprecated(reason: "This type has been superceded by `sale_artworks`")
+    @deprecated(
+      reason: "Prefer to use `sale_artworks`. [Will be removed in v2]"
+    )
   gene(
     # The slug or ID of the Gene
     id: String!
@@ -8928,31 +9100,6 @@ type Query {
     # The slug or ID of the PartnerCategory
     id: String!
   ): PartnerCategory
-
-  # A Partner Show
-  partner_show(
-    # The slug or ID of the PartnerShow
-    id: String!
-  ): PartnerShow
-
-  # A list of PartnerShows
-  partner_shows(
-    at_a_fair: Boolean
-    displayable: Boolean = true
-    fair_id: String
-    featured: Boolean
-
-    #
-    #         Only return shows matching specified ids.
-    #         Accepts list of ids.
-    #
-    ids: [String]
-    near: Near
-    partner_id: String
-    size: Int
-    sort: PartnerShowSorts
-    status: EventStatus
-  ): [PartnerShow]
 
   # A list of Partners
   partners(
@@ -9341,7 +9488,7 @@ type Sale implements Node {
   ): ArtworkConnection
   associated_sale: Sale
   auction_state: String
-    @deprecated(reason: "Favor `status` for consistency with other models")
+    @deprecated(reason: "Prefer to use `status`. [Will be removed in v2]")
 
   # A bid increment policy that explains minimum bids in ranges.
   bid_increments: [BidIncrement]
@@ -9380,7 +9527,8 @@ type Sale implements Node {
   href: String
   name: String
   is_auction: Boolean
-  is_benefit: Boolean @deprecated(reason: "Favor `isBenefit`")
+  is_benefit: Boolean
+    @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")
   isBenefit: Boolean
   isGalleryAuction: Boolean
   is_auction_promo: Boolean
@@ -9453,8 +9601,13 @@ type SaleArtwork {
   cached: Int
   artwork: Artwork
   bidder_positions_count: Int
-    @deprecated(reason: "Favor `counts.bidder_positions`")
-  bid_increments: [Float] @deprecated(reason: "Favor `increments.cents`")
+    @deprecated(
+      reason: "Prefer to use `counts.bidder_positions`. [Will be removed in v2]"
+    )
+  bid_increments: [Float]
+    @deprecated(
+      reason: "Prefer to use `increments.cents`. [Will be removed in v2]"
+    )
   counts: SaleArtworkCounts
 
   # Currency abbreviation (e.g. "USD")
@@ -9465,7 +9618,10 @@ type SaleArtwork {
   # Singular estimate field, if specified
   estimate_cents: Int
   high_estimate: SaleArtworkHighEstimate
-  high_estimate_cents: Float @deprecated(reason: "Favor `high_estimate")
+  high_estimate_cents: Float
+    @deprecated(
+      reason: "Prefer to use `high_estimate`. [Will be removed in v2]"
+    )
   highest_bid: SaleArtworkHighestBid
   increments(
     # Whether or not to start the increments at the user's latest bid
@@ -9477,13 +9633,19 @@ type SaleArtwork {
   is_biddable: Boolean
   is_with_reserve: Boolean
   lot_label: String
-  lot_number: String @deprecated(reason: "Favor `lot_label`")
+  lot_number: String
+    @deprecated(reason: "Prefer to use `lot_label`. [Will be removed in v2]")
   low_estimate: SaleArtworkLowEstimate
-  low_estimate_cents: Float @deprecated(reason: "Favor `low_estimate`")
+  low_estimate_cents: Float
+    @deprecated(reason: "Prefer to use `low_estimate`. [Will be removed in v2]")
   minimum_next_bid: SaleArtworkMinimumNextBid
-  minimum_next_bid_cents: Float @deprecated(reason: "Favor `minimum_next_bid`")
+  minimum_next_bid_cents: Float
+    @deprecated(
+      reason: "Prefer to use `minimum_next_bid`. [Will be removed in v2]"
+    )
   opening_bid: SaleArtworkOpeningBid
-  opening_bid_cents: Float @deprecated(reason: "Favor `opening_bid`")
+  opening_bid_cents: Float
+    @deprecated(reason: "Prefer to use `opening_bid`. [Will be removed in v2]")
   position: Float
   reserve: SaleArtworkReserve
   reserve_message: String
@@ -9570,7 +9732,8 @@ type SaleArtworkHighestBid {
   ): String
   cents: Int
   display: String
-  amount_cents: Float @deprecated(reason: "Favor `cents`")
+  amount_cents: Float
+    @deprecated(reason: "Prefer to use `cents`. [Will be removed in v2]")
 }
 
 type SaleArtworkHighEstimate {
@@ -9772,7 +9935,8 @@ type SearchableItem implements Node & Searchable {
   displayLabel: String
   imageUrl: String
   href: String
-  searchableType: String @deprecated(reason: "Switch to use `displayType`")
+  searchableType: String
+    @deprecated(reason: "Prefer to use `displayType`. [Will be removed in v2]")
   displayType: String
 }
 
@@ -10030,7 +10194,10 @@ type Show implements Node {
 
     # Number of artworks to return
     size: Int = 25
-  ): [Artwork] @deprecated(reason: "Use artworks_connection instead")
+  ): [Artwork]
+    @deprecated(
+      reason: "Prefer to use `artworks_connection`. [Will be removed in v2]"
+    )
 
   # The artworks featured in the show
   artworks_connection(
@@ -10062,7 +10229,9 @@ type Show implements Node {
   # A description of the show
   description: String
   displayable: Boolean
-    @deprecated(reason: "Prefix Boolean returning fields with `is_`")
+    @deprecated(
+      reason: "Prefer to use `is_displayable`. [Will be removed in v2]"
+    )
   end_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -10152,7 +10321,8 @@ type Show implements Node {
 
   # Is it a show provided for historical reference?
   is_reference: Boolean
-  is_local_discovery: Boolean @deprecated(reason: "Prefer isStubShow")
+  is_local_discovery: Boolean
+    @deprecated(reason: "Prefer to use `isStubShow`. [Will be removed in v2]")
 
   # Is it an outsourced local discovery stub show?
   isStubShow: Boolean
@@ -10893,7 +11063,9 @@ type Viewer {
     size: Int
     sort: String
   ): FilterSaleArtworks
-    @deprecated(reason: "This type has been superceded by `sale_artworks`")
+    @deprecated(
+      reason: "Prefer to use `sale_artworks`. [Will be removed in v2]"
+    )
   gene(
     # The slug or ID of the Gene
     id: String!
@@ -10997,31 +11169,6 @@ type Viewer {
     # The slug or ID of the PartnerCategory
     id: String!
   ): PartnerCategory
-
-  # A Partner Show
-  partner_show(
-    # The slug or ID of the PartnerShow
-    id: String!
-  ): PartnerShow
-
-  # A list of PartnerShows
-  partner_shows(
-    at_a_fair: Boolean
-    displayable: Boolean = true
-    fair_id: String
-    featured: Boolean
-
-    #
-    #         Only return shows matching specified ids.
-    #         Accepts list of ids.
-    #
-    ids: [String]
-    near: Near
-    partner_id: String
-    size: Int
-    sort: PartnerShowSorts
-    status: EventStatus
-  ): [PartnerShow]
 
   # A list of Partners
   partners(

--- a/patches/graphql-tools+4.0.4.patch
+++ b/patches/graphql-tools+4.0.4.patch
@@ -25,9 +25,65 @@ patch-package
                  deprecationReason: value.deprecationReason,
                  description: value.description,
                  astNode: value.astNode,
+--- a/node_modules/graphql-tools/dist/transforms/FilterTypes.js
++++ b/node_modules/graphql-tools/dist/transforms/FilterTypes.js
+@@ -1,6 +1,8 @@
+ /* tslint:disable:no-unused-expression */
+ Object.defineProperty(exports, "__esModule", { value: true });
+ var visitSchema_1 = require("../transforms/visitSchema");
++var graphql_1 = require("graphql");
++var schemaRecreation_1 = require("../stitching/schemaRecreation");
+ var FilterTypes = /** @class */ (function () {
+     function FilterTypes(filter) {
+         this.filter = filter;
+@@ -8,15 +10,43 @@ var FilterTypes = /** @class */ (function () {
+     FilterTypes.prototype.transformSchema = function (schema) {
+         var _this = this;
+         var _a;
++        var filteredTypes = [];
++        var resolveType = schemaRecreation_1.createResolveType((_name, type) => type);
+         return visitSchema_1.visitSchema(schema, (_a = {},
+             _a[visitSchema_1.VisitSchemaKind.TYPE] = function (type) {
+                 if (_this.filter(type)) {
+-                    return undefined;
++                  return undefined;
+                 }
+                 else {
++                  filteredTypes.push(type);
+                     return null;
+                 }
+             },
++            _a[visitSchema_1.VisitSchemaKind.UNION_TYPE] = function (type) {
++              const memberTypes = type.getTypes();
++              const filteredMemberTypes = filteredTypes.filter(t => memberTypes.includes(t));
++              if (filteredMemberTypes.length > 0) {
++                const remainingMemberTypes = memberTypes.filter(t => !filteredMemberTypes.includes(t));
++                if (remainingMemberTypes.length === 0) {
++                  // Remove the union entirely if it has no members anymore
++                  return null;
++                } else {
++                  // Return a new union with the remaining members
++                  return new graphql_1.GraphQLUnionType({
++                    name: type.name,
++                    description: type.description,
++                    astNode: type.astNode,
++                    types: remainingMemberTypes.map(function (memberType) {
++                      return resolveType(memberType);
++                    }),
++                    resolveType: type.resolveType
++                  });
++                }
++              }
++              else {
++                  return undefined;
++              }
++            },
+             _a));
+     };
+     return FilterTypes;
 --- a/node_modules/graphql-tools/dist/transforms/visitSchema.js
 +++ b/node_modules/graphql-tools/dist/transforms/visitSchema.js
-@@ -29,7 +29,20 @@ function visitSchema(schema, visitor, stripResolvers) {
+@@ -29,7 +29,31 @@ function visitSchema(schema, visitor, stripResolvers) {
      var mutationType = schema.getMutationType();
      var subscriptionType = schema.getSubscriptionType();
      var typeMap = schema.getTypeMap();
@@ -37,12 +93,23 @@ patch-package
 +    // transform both interface and object types and thus need to be able to
 +    // refer to the transformed interface types when creating the transformed
 +    // object types.
-+    var typeKeys = Object.keys(typeMap).sort(function (typeName) {
-+      if (typeMap[typeName] instanceof graphql_1.GraphQLInterfaceType) {
++    //
++    // Move union types to the end of the list, as we may need to adjust the
++    // members list based on types previously filtered from the schema.
++    var typeKeys = Object.keys(typeMap).sort(function (typeNameA, typeNameB) {
++      const typeA = typeMap[typeNameA];
++      const typeB = typeMap[typeNameB];
++      if (typeA instanceof graphql_1.GraphQLInterfaceType) {
 +        return -1;
-+      } else {
++      } else if (typeB instanceof graphql_1.GraphQLInterfaceType) {
 +        return 1;
 +      }
++      if (typeA instanceof graphql_1.GraphQLUnionType) {
++        return 1;
++      } else if (typeB instanceof graphql_1.GraphQLUnionType) {
++        return -1;
++      }
++      return 0;
 +    });
 +
 +    typeKeys.map(function (typeName) {

--- a/src/lib/__tests__/deprecate.test.ts
+++ b/src/lib/__tests__/deprecate.test.ts
@@ -1,0 +1,62 @@
+import { deprecate, shouldBeRemoved } from "../deprecation"
+
+describe("deprecation", () => {
+  describe(deprecate, () => {
+    it("generates a deprecation reason that encodes the version from whence the field will be removed", () => {
+      expect(
+        deprecate({ inVersion: 2, preferUsageOf: "foo" })
+      ).toMatchInlineSnapshot(
+        `"Prefer to use \`foo\`. [Will be removed in v2]"`
+      )
+    })
+
+    it("appends the encoded version from whence the field will be removed", () => {
+      expect(
+        deprecate({ inVersion: 2, reason: "Just don't do it." })
+      ).toMatchInlineSnapshot(`"Just don't do it. [Will be removed in v2]"`)
+    })
+  })
+
+  describe(shouldBeRemoved, () => {
+    it("should not be removed if there is no deprecation reason", () => {
+      expect(
+        shouldBeRemoved({
+          deprecationReason: null,
+          inVersion: 2,
+          typeName: "Foo",
+          fieldName: "bar",
+        })
+      ).toEqual(false)
+      expect(
+        shouldBeRemoved({
+          deprecationReason: undefined,
+          inVersion: 2,
+          typeName: "Foo",
+          fieldName: "bar",
+        })
+      ).toEqual(false)
+    })
+
+    it("should not be removed if the deprecation is for a newer version", () => {
+      expect(
+        shouldBeRemoved({
+          deprecationReason: deprecate({ preferUsageOf: "foo", inVersion: 2 }),
+          inVersion: 3,
+          typeName: "Foo",
+          fieldName: "bar",
+        })
+      ).toEqual(false)
+    })
+
+    it("should be removed if the deprecation is for the given version", () => {
+      expect(
+        shouldBeRemoved({
+          deprecationReason: deprecate({ preferUsageOf: "foo", inVersion: 2 }),
+          inVersion: 2,
+          typeName: "Foo",
+          fieldName: "bar",
+        })
+      ).toEqual(true)
+    })
+  })
+})

--- a/src/lib/deprecation.ts
+++ b/src/lib/deprecation.ts
@@ -1,0 +1,32 @@
+export function deprecate(
+  options: { inVersion: 2 } & (
+    | { preferUsageOf: string; reason?: undefined }
+    | { reason: string; preferUsageOf?: undefined })
+) {
+  const reason = options.reason || `Prefer to use \`${options.preferUsageOf}\`.`
+  return `${reason} [Will be removed in v${options.inVersion}]`
+}
+
+export function shouldBeRemoved(options: {
+  deprecationReason: string | null | undefined
+  inVersion: number
+  typeName: string
+  fieldName: string
+}) {
+  const reason = options.deprecationReason
+  if (reason) {
+    const match = reason.match(/\[Will be removed in v(\d+)\]$/)
+    if (match) {
+      const removeFromVersion = parseInt(match[1], 10)
+      return removeFromVersion >= options.inVersion
+    } else {
+      throw new Error(
+        `Use the \`deprecate\` function to define a deprecation. [${
+          options.typeName
+        }.${options.fieldName}]`
+      )
+    }
+  } else {
+    return false
+  }
+}

--- a/src/schema/SearchableItem/index.ts
+++ b/src/schema/SearchableItem/index.ts
@@ -9,6 +9,7 @@ import { Searchable } from "schema/searchable"
 import { NodeInterface, GravityIDFields } from "schema/object_identification"
 import { ResolverContext } from "types/graphql"
 import { SearchableItemPresenter } from "./SearchableItemPresenter"
+import { deprecate } from "lib/deprecation"
 
 export const SearchableItem = new GraphQLObjectType<any, ResolverContext>({
   name: "SearchableItem",
@@ -37,7 +38,10 @@ export const SearchableItem = new GraphQLObjectType<any, ResolverContext>({
     },
     searchableType: {
       type: GraphQLString,
-      deprecationReason: "Switch to use `displayType`",
+      deprecationReason: deprecate({
+        inVersion: 2,
+        preferUsageOf: "displayType",
+      }),
       resolve: item => new SearchableItemPresenter(item).displayType(),
     },
     displayType: {

--- a/src/schema/artist/index.ts
+++ b/src/schema/artist/index.ts
@@ -65,6 +65,7 @@ import { connectionFromArraySlice } from "graphql-relay"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { totalViaLoader } from "lib/total"
 import { ResolverContext } from "types/graphql"
+import { deprecate } from "lib/deprecation"
 
 // Manually curated list of artist id's who has verified auction lots that can be
 // returned, when queried for via `recordsTrusted: true`.
@@ -406,7 +407,10 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
       },
       consignable: {
         type: GraphQLBoolean,
-        deprecationReason: "Favor `is_`-prefixed boolean attributes",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "is_*",
+        }),
       },
       counts: {
         type: new GraphQLObjectType<any, ResolverContext>({
@@ -466,7 +470,10 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
       },
       display_auction_link: {
         type: GraphQLBoolean,
-        deprecationReason: "Favor `is_`-prefixed boolean attributes",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "is_*",
+        }),
       },
       exhibition_highlights: {
         args: {
@@ -619,11 +626,17 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
       partner_shows: {
         ...ShowField,
         type: new GraphQLList(PartnerShow.type),
-        deprecationReason: "Prefer to use shows attribute",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "shows",
+        }),
       },
       public: {
         type: GraphQLBoolean,
-        deprecationReason: "Favor `is_`-prefixed boolean attributes",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "is_*",
+        }),
       },
       related: Related,
       sales: {

--- a/src/schema/artwork/highlight.ts
+++ b/src/schema/artwork/highlight.ts
@@ -1,5 +1,5 @@
 import { create } from "lodash"
-import Show from "schema/partner_show"
+import Show from "schema/show"
 import Article from "schema/article"
 import { GraphQLUnionType } from "graphql"
 

--- a/src/schema/artwork/index.ts
+++ b/src/schema/artwork/index.ts
@@ -43,6 +43,7 @@ import { capitalizeFirstCharacter } from "lib/helpers"
 import artworkPageviews from ".././../data/weeklyArtworkPageviews.json"
 import { ResolverContext } from "types/graphql"
 import { listPrice } from "schema/fields/listPrice"
+import { deprecate } from "lib/deprecation"
 
 const has_price_range = price => {
   return new RegExp(/\-/).test(price)
@@ -109,7 +110,10 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
 
       can_share_image: {
         type: GraphQLBoolean,
-        deprecationReason: "Favor `is_`-prefixed boolean attributes",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "is_*",
+        }),
       },
       category: { type: GraphQLString },
       attribution_class: {
@@ -218,7 +222,10 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       height: {
         type: GraphQLString,
         // See note on `metric` field.
-        deprecationReason: "Prefer dimensions instead.",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "dimensions",
+        }),
       },
       highlights: {
         type: new GraphQLList(Highlight),
@@ -334,7 +341,10 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       is_contactable: {
         type: GraphQLBoolean,
         description: "Are we able to display a contact form on artwork pages?",
-        deprecationReason: "Prefer to use is_inquireable",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "is_inquireable",
+        }),
         resolve: (artwork, _options, { relatedSalesLoader }) => {
           return relatedSalesLoader({
             size: 1,
@@ -360,7 +370,10 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       is_embeddable_video: { type: GraphQLBoolean, resolve: isEmbeddedVideo },
       is_ecommerce: {
         type: GraphQLBoolean,
-        deprecationReason: "Should not be used to determine anything UI-level",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          reason: "Should not be used to determine anything UI-level.",
+        }),
         resolve: ({ ecommerce }) => ecommerce,
       },
       is_for_sale: { type: GraphQLBoolean, resolve: ({ forsale }) => forsale },
@@ -422,8 +435,10 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       },
       is_purchasable: {
         type: GraphQLBoolean,
-        deprecationReason:
-          "Purchase requests are not supported. Replaced by buy now.",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          reason: "Purchase requests are not supported. Replaced by buy now.",
+        }),
         resolve: () => null,
       },
       is_saved: {
@@ -460,8 +475,11 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       medium: { type: GraphQLString },
       metric: {
         type: GraphQLString,
-        // Used for Eigen compatibility, see converation at: https://github.com/artsy/metaphysics/pull/1350
-        deprecationReason: "Prefer dimensions instead.",
+        // Used for Eigen compatibility, see conversation at: https://github.com/artsy/metaphysics/pull/1350
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "dimensions",
+        }),
       },
       meta: Meta,
       myLotStanding: {
@@ -475,10 +493,10 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       pageviews: {
         type: GraphQLInt,
         description: "[DO NOT USE] Weekly pageview data (static).",
-        // FIXME: Uncomment deprecationReason once https://github.com/apollographql/apollo-tooling/issues/805
-        // has been addressed.
-        // deprecationReason:
-        //   "Do not use! This is for an AB test and will be imminently deprecated.",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          reason: "This is for an AB test and will be imminently deprecated.",
+        }),
         resolve: ({ _id }) => artworkPageviews[_id],
       },
       partner: {
@@ -499,7 +517,10 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       pickup_available: { type: GraphQLBoolean },
       price: { type: GraphQLString },
       priceCents: {
-        deprecationReason: "Prefer `listPrice` instead.",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "listPrice",
+        }),
         type: new GraphQLObjectType<any, ResolverContext>({
           name: "PriceCents",
           fields: {
@@ -745,7 +766,10 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       width: {
         type: GraphQLString,
         // See note on `metric` field.
-        deprecationReason: "Prefer dimensions instead.",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "dimensions",
+        }),
       },
       framed: {
         type: ArtworkInfoRowType,

--- a/src/schema/author.ts
+++ b/src/schema/author.ts
@@ -1,6 +1,7 @@
 import { IDFields } from "./object_identification"
 import { GraphQLString, GraphQLObjectType } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { deprecate } from "lib/deprecation"
 
 const AuthorType = new GraphQLObjectType<any, ResolverContext>({
   name: "Author",
@@ -12,8 +13,11 @@ const AuthorType = new GraphQLObjectType<any, ResolverContext>({
     href: {
       type: GraphQLString,
       resolve: ({ profile_handle }) => `/${profile_handle}`,
-      deprecationReason:
-        "Profiles have been removed and thus author hrefs don't exist anymore.",
+      deprecationReason: deprecate({
+        inVersion: 2,
+        reason:
+          "Profiles have been removed and thus author hrefs don't exist anymore.",
+      }),
     },
     profile_handle: {
       type: GraphQLString,

--- a/src/schema/bidder_position.ts
+++ b/src/schema/bidder_position.ts
@@ -11,6 +11,7 @@ import {
   GraphQLFieldConfig,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { deprecate } from "lib/deprecation"
 
 const BidderPositionType = new GraphQLObjectType<any, ResolverContext>({
   name: "BidderPosition",
@@ -21,11 +22,17 @@ const BidderPositionType = new GraphQLObjectType<any, ResolverContext>({
     processed_at: date,
     display_max_bid_amount_dollars: {
       type: GraphQLString,
-      deprecationReason: "Favor `max_bid`",
+      deprecationReason: deprecate({
+        inVersion: 2,
+        preferUsageOf: "max_bid",
+      }),
     },
     display_suggested_next_bid_dollars: {
       type: GraphQLString,
-      deprecationReason: "Favor `suggested_next_bid`",
+      deprecationReason: deprecate({
+        inVersion: 2,
+        preferUsageOf: "suggested_next_bid",
+      }),
     },
     highest_bid: {
       type: new GraphQLObjectType<any, ResolverContext>({
@@ -51,11 +58,17 @@ const BidderPositionType = new GraphQLObjectType<any, ResolverContext>({
           },
           amount_cents: {
             type: GraphQLInt,
-            deprecationReason: "Favor `cents`",
+            deprecationReason: deprecate({
+              inVersion: 2,
+              preferUsageOf: "cents",
+            }),
           },
           display_amount_dollars: {
             type: GraphQLString,
-            deprecationReason: "Favor `display`",
+            deprecationReason: deprecate({
+              inVersion: 2,
+              preferUsageOf: "display",
+            }),
           },
         },
       }),
@@ -91,7 +104,10 @@ const BidderPositionType = new GraphQLObjectType<any, ResolverContext>({
     }),
     max_bid_amount_cents: {
       type: GraphQLInt,
-      deprecationReason: "Favor `max_bid`",
+      deprecationReason: deprecate({
+        inVersion: 2,
+        preferUsageOf: "max_bid",
+      }),
     },
     sale_artwork: {
       type: SaleArtwork.type,
@@ -110,7 +126,10 @@ const BidderPositionType = new GraphQLObjectType<any, ResolverContext>({
     }),
     suggested_next_bid_cents: {
       type: GraphQLInt,
-      deprecationReason: "Favor `suggested_next_bid`",
+      deprecationReason: deprecate({
+        inVersion: 2,
+        preferUsageOf: "suggested_next_bid",
+      }),
     },
   }),
 })

--- a/src/schema/city/index.ts
+++ b/src/schema/city/index.ts
@@ -30,6 +30,7 @@ import { allViaLoader, MAX_GRAPHQL_INT } from "lib/all"
 import { StaticPathLoader } from "lib/loaders/api/loader_interface"
 import { BodyAndHeaders } from "lib/loaders"
 import { sponsoredContentForCity } from "lib/sponsoredContent"
+import { deprecate } from "lib/deprecation"
 
 const PartnerShowPartnerType = new GraphQLEnumType({
   name: "PartnerShowPartnerType",
@@ -80,7 +81,10 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
         discoverable: {
           type: GraphQLBoolean,
           description: "Whether to include stub shows or not",
-          deprecationReason: "Use `includeStubShows`",
+          deprecationReason: deprecate({
+            inVersion: 2,
+            preferUsageOf: "includeStubShows",
+          }),
         },
       }),
       resolve: async (city, args, { showsWithHeadersLoader }) =>

--- a/src/schema/ecommerce/types/order_line_item.ts
+++ b/src/schema/ecommerce/types/order_line_item.ts
@@ -7,6 +7,7 @@ import date from "schema/fields/date"
 import { ArtworkVersion } from "../../artwork_version"
 import { ResolverContext } from "types/graphql"
 import { InternalIDFields } from "schema/object_identification"
+import { deprecate } from "lib/deprecation"
 
 export const OrderLineItemType = new GraphQLObjectType<any, ResolverContext>({
   name: "OrderLineItem",
@@ -41,7 +42,10 @@ export const OrderLineItemType = new GraphQLObjectType<any, ResolverContext>({
     priceCents: {
       type: GraphQLInt,
       description: "Unit price in cents",
-      deprecationReason: "Switched to `listPriceCents`",
+      deprecationReason: deprecate({
+        inVersion: 2,
+        preferUsageOf: "listPriceCents",
+      }),
     },
     price: amount(({ priceCents }) => priceCents),
     listPriceCents: {

--- a/src/schema/edition_set.ts
+++ b/src/schema/edition_set.ts
@@ -13,6 +13,7 @@ import { capitalizeFirstCharacter } from "lib/helpers"
 import { Sellable } from "./sellable"
 import { ResolverContext } from "types/graphql"
 import { listPrice } from "./fields/listPrice"
+import { deprecate } from "lib/deprecation"
 
 export const EditionSetSorts = {
   type: new GraphQLEnumType({
@@ -64,7 +65,10 @@ const EditionSetType = new GraphQLObjectType<any, ResolverContext>({
         const fallback = forsale ? "Available" : "Not for Sale"
         return !isEmpty(price) ? price : fallback
       },
-      deprecationReason: "Prefer to use `sale_message`.",
+      deprecationReason: deprecate({
+        inVersion: 2,
+        preferUsageOf: "sale_message",
+      }),
     },
     listPrice,
     sizeScore: {

--- a/src/schema/fair.ts
+++ b/src/schema/fair.ts
@@ -30,6 +30,7 @@ import { allViaLoader } from "lib/all"
 import { FairArtistSortsType } from "./sorts/fairArtistSorts"
 import { ResolverContext } from "types/graphql"
 import { sponsoredContentForFair } from "lib/sponsoredContent"
+import { deprecate } from "lib/deprecation"
 
 const FollowedContentType = new GraphQLObjectType<any, ResolverContext>({
   name: "FollowedContent",
@@ -176,7 +177,10 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
     image: Image,
     is_active: {
       type: GraphQLBoolean,
-      deprecationReason: "Prefer isActive instead",
+      deprecationReason: deprecate({
+        inVersion: 2,
+        preferUsageOf: "isActive",
+      }),
       resolve: ({ autopublish_artworks_at, end_at }) => {
         const start = moment.utc(autopublish_artworks_at).subtract(7, "days")
         const end = moment.utc(end_at).add(14, "days")
@@ -287,7 +291,10 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
     },
     published: {
       type: GraphQLBoolean,
-      deprecationReason: "Prefix Boolean returning fields with `is_`",
+      deprecationReason: deprecate({
+        inVersion: 2,
+        preferUsageOf: "is_published",
+      }),
     },
     tagline: {
       type: GraphQLString,

--- a/src/schema/filter_artworks.ts
+++ b/src/schema/filter_artworks.ts
@@ -35,6 +35,7 @@ import {
 
 import { NodeInterface } from "schema/object_identification"
 import { ResolverContext } from "types/graphql"
+import { deprecate } from "lib/deprecation"
 
 const ArtworkFilterTagType = create(Tag.type, {
   name: "ArtworkFilterTag",
@@ -175,7 +176,10 @@ export const FilterArtworksType = new GraphQLObjectType<any, ResolverContext>({
     followed_artists_total: {
       type: GraphQLInt,
       resolve: ({ aggregations }) => aggregations.followed_artists.value,
-      deprecationReason: "Favor `favor counts.followed_artists`",
+      deprecationReason: deprecate({
+        inVersion: 2,
+        preferUsageOf: "counts.followed_artists",
+      }),
     },
     hits: {
       description: "Artwork results.",
@@ -197,7 +201,10 @@ export const FilterArtworksType = new GraphQLObjectType<any, ResolverContext>({
     total: {
       type: GraphQLInt,
       resolve: ({ aggregations }) => aggregations.total.value,
-      deprecationReason: "Favor `counts.total`",
+      deprecationReason: deprecate({
+        inVersion: 2,
+        preferUsageOf: "counts.total",
+      }),
     },
     facet: {
       type: ArtworkFilterFacetType,

--- a/src/schema/filter_sale_artworks.ts
+++ b/src/schema/filter_sale_artworks.ts
@@ -15,6 +15,7 @@ import {
   SaleArtworksAggregation,
 } from "./aggregations/filter_sale_artworks_aggregation"
 import { ResolverContext } from "types/graphql"
+import { deprecate } from "lib/deprecation"
 
 /**
  * NOTE: This type has been deprecated in favor of `SaleArtworks`.
@@ -102,7 +103,10 @@ export const FilterSaleArtworksType = new GraphQLObjectType<
 const FilterSaleArtworks: GraphQLFieldConfig<void, ResolverContext> = {
   type: FilterSaleArtworksType,
   description: "Sale Artworks Elastic Search results",
-  deprecationReason: "This type has been superceded by `sale_artworks`",
+  deprecationReason: deprecate({
+    inVersion: 2,
+    preferUsageOf: "sale_artworks",
+  }),
   args: filterSaleArtworksArgs,
   resolve: (_root, options, { saleArtworksFilterLoader }) => {
     return saleArtworksFilterLoader(options)

--- a/src/schema/home/home_page_artwork_module.ts
+++ b/src/schema/home/home_page_artwork_module.ts
@@ -15,6 +15,7 @@ import {
   GraphQLFieldConfig,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { deprecate } from "lib/deprecation"
 
 let possibleArgs
 
@@ -40,8 +41,10 @@ export const HomePageArtworkModuleType = new GraphQLObjectType<
     context: Context,
     display: {
       type: GraphQLString,
-      deprecationReason:
-        "Favor `is_`-prefixed Booleans (*and* this should be a Boolean)",
+      deprecationReason: deprecate({
+        inVersion: 2,
+        preferUsageOf: "is_displayable",
+      }),
     },
     is_displayable: {
       type: GraphQLBoolean,

--- a/src/schema/input_fields/event_status.ts
+++ b/src/schema/input_fields/event_status.ts
@@ -1,4 +1,5 @@
 import { GraphQLEnumType } from "graphql"
+import { deprecate } from "lib/deprecation"
 
 const EventStatus = {
   type: new GraphQLEnumType({
@@ -6,19 +7,31 @@ const EventStatus = {
     values: {
       closed: {
         value: "closed",
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "CLOSED",
+        }),
       },
       current: {
         value: "current",
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "CURRENT",
+        }),
       },
       running: {
         value: "running",
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "RUNNING",
+        }),
       },
       upcoming: {
         value: "upcoming",
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "UPCOMING",
+        }),
       },
       CLOSED: {
         value: "closed",

--- a/src/schema/input_fields/format.ts
+++ b/src/schema/input_fields/format.ts
@@ -1,4 +1,5 @@
 import { GraphQLEnumType } from "graphql"
+import { deprecate } from "lib/deprecation"
 
 const Format = {
   type: new GraphQLEnumType({
@@ -11,9 +12,12 @@ const Format = {
         value: "plain",
       },
       markdown: {
-        // Deprecated
         value: "markdown",
-        deprecationReason: "deprecated",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          reason:
+            "Deprecated when we deprecated lower-case enum entries, but no alternative was provided. Add an alternative to MP if this is still needed.",
+        }),
       },
     },
   }),

--- a/src/schema/location.ts
+++ b/src/schema/location.ts
@@ -12,6 +12,7 @@ import {
   GraphQLUnionType,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { deprecate } from "lib/deprecation"
 
 export const LatLngType = new GraphQLObjectType<any, ResolverContext>({
   name: "LatLng",
@@ -91,7 +92,10 @@ export const LocationType = new GraphQLObjectType<any, ResolverContext>({
       type: new GraphQLList(FormattedDaySchedules.type),
       resolve: ({ day_schedules }) =>
         FormattedDaySchedules.resolve(day_schedules),
-      deprecationReason: "Use openingHours instead",
+      deprecationReason: deprecate({
+        inVersion: 2,
+        preferUsageOf: "openingHours",
+      }),
     },
     openingHours: {
       type: OpeningHoursUnion,

--- a/src/schema/me/conversation/index.ts
+++ b/src/schema/me/conversation/index.ts
@@ -25,6 +25,7 @@ import {
 } from "schema/object_identification"
 import { MessageType } from "./message"
 import { ResolverContext } from "types/graphql"
+import { deprecate } from "lib/deprecation"
 
 export const BuyerOutcomeTypes = new GraphQLEnumType({
   name: "BuyerOutcomeTypes",
@@ -194,8 +195,10 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
     created_at: date,
     purchase_request: {
       type: GraphQLBoolean,
-      deprecationReason:
-        "Purchase requests are not supported. Replaced by buy now.",
+      deprecationReason: deprecate({
+        inVersion: 2,
+        reason: "Purchase requests are not supported. Replaced by buy now.",
+      }),
       resolve: () => null,
     },
     from_last_viewed_message_id: {
@@ -234,7 +237,10 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
     // If the user is a recipient of the last message, return their timestamped
     // 'read' event, otherwise null.
     last_message_open: {
-      deprecationReason: "Prefer to use `unread`",
+      deprecationReason: deprecate({
+        inVersion: 2,
+        preferUsageOf: "unread",
+      }),
       type: GraphQLString,
       description:
         "Timestamp if the user opened the last message, null in all other cases",

--- a/src/schema/me/conversation/message.ts
+++ b/src/schema/me/conversation/message.ts
@@ -16,6 +16,7 @@ import { DeliveryType } from "./delivery"
 import { InvoiceType } from "./invoice"
 import { isExisty } from "lib/helpers"
 import { ResolverContext } from "types/graphql"
+import { deprecate } from "lib/deprecation"
 
 const MessageInitiatorType = new GraphQLObjectType<any, ResolverContext>({
   name: "MessageInitiator",
@@ -68,7 +69,10 @@ export const MessageType = new GraphQLObjectType<any, ResolverContext>({
     },
     from_email_address: {
       type: GraphQLString,
-      deprecationReason: "Prefer to use the structured `from` field.",
+      deprecationReason: deprecate({
+        inVersion: 2,
+        preferUsageOf: "from",
+      }),
     },
 
     from: {
@@ -93,7 +97,10 @@ export const MessageType = new GraphQLObjectType<any, ResolverContext>({
     raw_text: {
       description: "Full unsanitized text.",
       type: new GraphQLNonNull(GraphQLString),
-      deprecationReason: "Prefer to use the parsed/cleaned-up `body`.",
+      deprecationReason: deprecate({
+        inVersion: 2,
+        preferUsageOf: "body",
+      }),
     },
 
     body: {

--- a/src/schema/me/create_credit_card_mutation.ts
+++ b/src/schema/me/create_credit_card_mutation.ts
@@ -3,6 +3,7 @@ import { mutationWithClientMutationId } from "graphql-relay"
 import { formatGravityError } from "lib/gravityErrorHandler"
 import { CreditCard, CreditCardMutationType } from "../credit_card"
 import { ResolverContext } from "types/graphql"
+import { deprecate } from "lib/deprecation"
 
 export default mutationWithClientMutationId<any, any, ResolverContext>({
   name: "CreditCard",
@@ -19,7 +20,10 @@ export default mutationWithClientMutationId<any, any, ResolverContext>({
   outputFields: {
     credit_card: {
       type: CreditCard.type,
-      deprecationReason: "Favor `creditCardOrError`",
+      deprecationReason: deprecate({
+        inVersion: 2,
+        preferUsageOf: "creditCardOrError",
+      }),
       resolve: result => {
         return result && result.id ? result : null
       },

--- a/src/schema/me/notifications.ts
+++ b/src/schema/me/notifications.ts
@@ -14,6 +14,7 @@ import { omit } from "lodash"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { GlobalIDField, NodeInterface } from "schema/object_identification"
 import { ResolverContext } from "types/graphql"
+import { deprecate } from "lib/deprecation"
 
 const NotificationsFeedItemType = new GraphQLObjectType<any, ResolverContext>({
   name: "NotificationsFeedItem",
@@ -62,7 +63,10 @@ const Notifications: GraphQLFieldConfig<void, ResolverContext> = {
   description:
     "A list of feed items, indicating published artworks (grouped by date and artists).",
   args: pageable({}),
-  deprecationReason: "Prefer to use followed_artists_artwork_groups.",
+  deprecationReason: deprecate({
+    inVersion: 2,
+    preferUsageOf: "followed_artists_artwork_groups",
+  }),
   resolve: (_root, options, { notificationsFeedLoader }) => {
     if (!notificationsFeedLoader) return null
     const gravityOptions = convertConnectionArgsToGravityArgs(options)

--- a/src/schema/partner.ts
+++ b/src/schema/partner.ts
@@ -22,6 +22,7 @@ import {
 } from "graphql"
 import { connectionFromArraySlice } from "graphql-relay"
 import { ResolverContext } from "types/graphql"
+import { deprecate } from "lib/deprecation"
 
 const PartnerCategoryType = new GraphQLObjectType<any, ResolverContext>({
   name: "Category",
@@ -130,8 +131,10 @@ const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       },
       contact_message: {
         type: GraphQLString,
-        deprecationReason:
-          "Prefer artwork contact_message to handle availability-based prompts.",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "Artwork.contact_message",
+        }),
         resolve: ({ type }) => {
           if (type === "Auction") {
             return [
@@ -204,8 +207,11 @@ const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       },
       is_limited_fair_partner: {
         type: GraphQLBoolean,
-        deprecationReason:
-          "This field no longer exists, this is for backwards compatibility",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          reason:
+            "This field no longer exists, this is for backwards compatibility",
+        }),
         resolve: () => false,
       },
       is_linkable: {

--- a/src/schema/partner_show.ts
+++ b/src/schema/partner_show.ts
@@ -33,6 +33,7 @@ import { allViaLoader } from "../lib/all"
 import { totalViaLoader } from "lib/total"
 import { connectionFromArraySlice } from "graphql-relay"
 import { ResolverContext } from "types/graphql"
+import { deprecate } from "lib/deprecation"
 
 const kind = ({ artists, fair }) => {
   if (isExisty(fair)) return "fair"
@@ -56,296 +57,313 @@ const artworksArgs = {
   },
 }
 
+/**
+ * This type is deprecated entirely, use Show instead.
+ */
 const PartnerShowType = new GraphQLObjectType<any, ResolverContext>({
   name: "PartnerShow",
-  // @ts-ignore
-  deprecationReason: "Prefer to use Show schema",
   interfaces: [NodeInterface],
-  fields: () => ({
-    ...GravityIDFields,
-    cached,
-    artists: {
-      type: new GraphQLList(Artist.type),
-      resolve: ({ artists }) => artists,
-    },
-    artworks: {
-      type: new GraphQLList(Artwork.type),
-      description: "The artworks featured in the show",
-      args: {
-        ...artworksArgs,
-        all: {
-          type: GraphQLBoolean,
-          default: false,
-        },
-        page: {
-          type: GraphQLInt,
-          defaultValue: 1,
-        },
-        size: {
-          type: GraphQLInt,
-          description: "Number of artworks to return",
-          defaultValue: 25,
-        },
+  fields: () => {
+    const fields = {
+      ...GravityIDFields,
+      cached,
+      artists: {
+        type: new GraphQLList(Artist.type),
+        resolve: ({ artists }) => artists,
       },
-      resolve: (show, options, { partnerShowArtworksLoader }) => {
-        let fetch: Promise<any>
-        if (options.all) {
-          fetch = allViaLoader(partnerShowArtworksLoader, {
-            path: { partner_id: show.partner.id, show_id: show.id },
-            params: options,
-          })
-        } else {
-          fetch = partnerShowArtworksLoader(
-            { partner_id: show.partner.id, show_id: show.id },
-            options
-          ).then(({ body }) => body)
-        }
-
-        // @ts-ignore
-        // FIXME: Update with Gravity param when ready
-        return fetch.then(exclude(options.exclude, "id"))
-      },
-    },
-    artworksConnection: {
-      description: "A connection of artworks featured in the show",
-      type: artworkConnection,
-      args: pageable(artworksArgs),
-      resolve: (show, options, { partnerShowArtworksLoader }) => {
-        const loaderOptions = {
-          partner_id: show.partner.id,
-          show_id: show.id,
-        }
-        const { page, size, offset } = convertConnectionArgsToGravityArgs(
-          options
-        )
-
-        interface GravityArgs {
-          exclude_ids?: string[]
-          page: number
-          size: number
-          total_count: boolean
-        }
-
-        const gravityArgs: GravityArgs = {
-          page,
-          size,
-          total_count: true,
-        }
-
-        if (options.exclude) {
-          gravityArgs.exclude_ids = flatten([options.exclude])
-        }
-
-        return partnerShowArtworksLoader(loaderOptions, gravityArgs).then(
-          ({ body, headers }) => {
-            return connectionFromArraySlice(body, options, {
-              arrayLength: parseInt(headers["x-total-count"] || "0", 10),
-              sliceStart: offset,
-            })
-          }
-        )
-      },
-    },
-    counts: {
-      type: new GraphQLObjectType<any, ResolverContext>({
-        name: "PartnerShowCounts",
-        fields: {
-          artworks: {
+      artworks: {
+        type: new GraphQLList(Artwork.type),
+        description: "The artworks featured in the show",
+        args: {
+          ...artworksArgs,
+          all: {
+            type: GraphQLBoolean,
+            default: false,
+          },
+          page: {
             type: GraphQLInt,
-            args: {
-              artist_id: {
-                type: GraphQLString,
-                description: "The slug or ID of an artist in the show.",
+            defaultValue: 1,
+          },
+          size: {
+            type: GraphQLInt,
+            description: "Number of artworks to return",
+            defaultValue: 25,
+          },
+        },
+        resolve: (show, options, { partnerShowArtworksLoader }) => {
+          let fetch: Promise<any>
+          if (options.all) {
+            fetch = allViaLoader(partnerShowArtworksLoader, {
+              path: { partner_id: show.partner.id, show_id: show.id },
+              params: options,
+            })
+          } else {
+            fetch = partnerShowArtworksLoader(
+              { partner_id: show.partner.id, show_id: show.id },
+              options
+            ).then(({ body }) => body)
+          }
+
+          // @ts-ignore
+          // FIXME: Update with Gravity param when ready
+          return fetch.then(exclude(options.exclude, "id"))
+        },
+      },
+      artworksConnection: {
+        description: "A connection of artworks featured in the show",
+        type: artworkConnection,
+        args: pageable(artworksArgs),
+        resolve: (show, options, { partnerShowArtworksLoader }) => {
+          const loaderOptions = {
+            partner_id: show.partner.id,
+            show_id: show.id,
+          }
+          const { page, size, offset } = convertConnectionArgsToGravityArgs(
+            options
+          )
+
+          interface GravityArgs {
+            exclude_ids?: string[]
+            page: number
+            size: number
+            total_count: boolean
+          }
+
+          const gravityArgs: GravityArgs = {
+            page,
+            size,
+            total_count: true,
+          }
+
+          if (options.exclude) {
+            gravityArgs.exclude_ids = flatten([options.exclude])
+          }
+
+          return partnerShowArtworksLoader(loaderOptions, gravityArgs).then(
+            ({ body, headers }) => {
+              return connectionFromArraySlice(body, options, {
+                arrayLength: parseInt(headers["x-total-count"] || "0", 10),
+                sliceStart: offset,
+              })
+            }
+          )
+        },
+      },
+      counts: {
+        type: new GraphQLObjectType<any, ResolverContext>({
+          name: "PartnerShowCounts",
+          fields: {
+            artworks: {
+              type: GraphQLInt,
+              args: {
+                artist_id: {
+                  type: GraphQLString,
+                  description: "The slug or ID of an artist in the show.",
+                },
+              },
+              resolve: (
+                { id, partner },
+                options,
+                { partnerShowArtworksLoader }
+              ) => {
+                return totalViaLoader(
+                  partnerShowArtworksLoader,
+                  { partner_id: partner.id, show_id: id },
+                  options
+                )
               },
             },
-            resolve: (
-              { id, partner },
-              options,
-              { partnerShowArtworksLoader }
-            ) => {
-              return totalViaLoader(
-                partnerShowArtworksLoader,
-                { partner_id: partner.id, show_id: id },
-                options
-              )
-            },
+            eligible_artworks: numeral(
+              ({ eligible_artworks_count }) => eligible_artworks_count
+            ),
           },
-          eligible_artworks: numeral(
-            ({ eligible_artworks_count }) => eligible_artworks_count
-          ),
-        },
-      }),
-      resolve: partner_show => partner_show,
-    },
-    cover_image: {
-      type: Image.type,
-      resolve: (
-        { id, partner, image_versions, image_url },
-        _options,
-        { partnerShowArtworksLoader }
-      ) => {
-        if (image_versions && image_versions.length && image_url) {
-          return normalizeImageData({ image_versions, image_url })
-        }
+        }),
+        resolve: partner_show => partner_show,
+      },
+      cover_image: {
+        type: Image.type,
+        resolve: (
+          { id, partner, image_versions, image_url },
+          _options,
+          { partnerShowArtworksLoader }
+        ) => {
+          if (image_versions && image_versions.length && image_url) {
+            return normalizeImageData({ image_versions, image_url })
+          }
 
-        return (
-          partner &&
-          partnerShowArtworksLoader(
+          return (
+            partner &&
+            partnerShowArtworksLoader(
+              { partner_id: partner.id, show_id: id },
+              {
+                size: 1,
+                published: true,
+              }
+            ).then(({ body }) => {
+              const artwork = body[0]
+              return artwork && normalizeImageData(getDefault(artwork.images))
+            })
+          )
+        },
+      },
+      created_at: date,
+      description: {
+        type: GraphQLString,
+      },
+      displayable: {
+        type: GraphQLBoolean,
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "is_displayable",
+        }),
+      },
+      end_at: date,
+      events: {
+        type: new GraphQLList(PartnerShowEventType),
+        resolve: ({ partner, id }, _options, { partnerShowLoader }) =>
+          // Gravity redirects from /api/v1/show/:id => /api/v1/partner/:partner_id/show/:show_id
+          // this creates issues where events will remain cached. Fetch the non-redirected
+          // route to circumvent this
+          partnerShowLoader({ partner_id: partner.id, show_id: id }).then(
+            ({ events }) => events
+          ),
+      },
+      exhibition_period: {
+        type: GraphQLString,
+        description: "A formatted description of the start to end dates",
+        resolve: ({ start_at, end_at }) => dateRange(start_at, end_at, "UTC"),
+      },
+      fair: {
+        type: Fair.type,
+        resolve: ({ fair }) => fair,
+      },
+      href: {
+        type: GraphQLString,
+        resolve: ({ id }) => `/show/${id}`,
+      },
+      images: {
+        type: new GraphQLList(Image.type),
+        args: {
+          size: {
+            type: GraphQLInt,
+            description: "Number of images to return",
+          },
+          default: {
+            type: GraphQLBoolean,
+            description: "Pass true/false to include cover or not",
+          },
+          page: {
+            type: GraphQLInt,
+          },
+        },
+        resolve: ({ id }, options, { partnerShowImagesLoader }) => {
+          return partnerShowImagesLoader(id, options).then(normalizeImageData)
+        },
+      },
+      has_location: {
+        type: GraphQLBoolean,
+        description: "Flag showing if show has any location.",
+        resolve: ({ location, fair, partner_city }) => {
+          return isExisty(location || fair || partner_city)
+        },
+      },
+      is_active: {
+        type: GraphQLBoolean,
+        description:
+          "Gravity doesn’t expose the `active` flag. Temporarily re-state its logic.",
+        resolve: ({ start_at, end_at }) => {
+          const start = moment.utc(start_at).subtract(7, "days")
+          const end = moment.utc(end_at).add(7, "days")
+          return moment.utc().isBetween(start, end)
+        },
+      },
+      is_displayable: {
+        type: GraphQLBoolean,
+        resolve: ({ displayable }) => displayable,
+      },
+      is_fair_booth: {
+        type: GraphQLBoolean,
+        resolve: ({ fair }) => isExisty(fair),
+      },
+      kind: {
+        type: GraphQLString,
+        resolve: (show, _options, { partnerShowLoader }) => {
+          if (show.artists) return kind(show)
+          return partnerShowLoader({
+            partner_id: show.partner.id,
+            show_id: show.id,
+          }).then(kind)
+        },
+      },
+      location: {
+        type: Location.type,
+        resolve: ({ location, fair_location }) => location || fair_location,
+      },
+      meta_image: {
+        type: Image.type,
+        resolve: (
+          { id, partner, image_versions, image_url },
+          _options,
+          { partnerShowArtworksLoader }
+        ) => {
+          if (image_versions && image_versions.length && image_url) {
+            return normalizeImageData({ image_versions, image_url })
+          }
+
+          return partnerShowArtworksLoader(
             { partner_id: partner.id, show_id: id },
             {
-              size: 1,
               published: true,
             }
           ).then(({ body }) => {
-            const artwork = body[0]
-            return artwork && normalizeImageData(getDefault(artwork.images))
+            return normalizeImageData(
+              getDefault(find(body, { can_share_image: true }))
+            )
           })
-        )
-      },
-    },
-    created_at: date,
-    description: {
-      type: GraphQLString,
-    },
-    displayable: {
-      type: GraphQLBoolean,
-      deprecationReason: "Prefix Boolean returning fields with `is_`",
-    },
-    end_at: date,
-    events: {
-      type: new GraphQLList(PartnerShowEventType),
-      resolve: ({ partner, id }, _options, { partnerShowLoader }) =>
-        // Gravity redirects from /api/v1/show/:id => /api/v1/partner/:partner_id/show/:show_id
-        // this creates issues where events will remain cached. Fetch the non-redirected
-        // route to circumvent this
-        partnerShowLoader({ partner_id: partner.id, show_id: id }).then(
-          ({ events }) => events
-        ),
-    },
-    exhibition_period: {
-      type: GraphQLString,
-      description: "A formatted description of the start to end dates",
-      resolve: ({ start_at, end_at }) => dateRange(start_at, end_at, "UTC"),
-    },
-    fair: {
-      type: Fair.type,
-      resolve: ({ fair }) => fair,
-    },
-    href: {
-      type: GraphQLString,
-      resolve: ({ id }) => `/show/${id}`,
-    },
-    images: {
-      type: new GraphQLList(Image.type),
-      args: {
-        size: {
-          type: GraphQLInt,
-          description: "Number of images to return",
-        },
-        default: {
-          type: GraphQLBoolean,
-          description: "Pass true/false to include cover or not",
-        },
-        page: {
-          type: GraphQLInt,
         },
       },
-      resolve: ({ id }, options, { partnerShowImagesLoader }) => {
-        return partnerShowImagesLoader(id, options).then(normalizeImageData)
+      name: {
+        type: GraphQLString,
+        description: "The exhibition title",
       },
-    },
-    has_location: {
-      type: GraphQLBoolean,
-      description: "Flag showing if show has any location.",
-      resolve: ({ location, fair, partner_city }) => {
-        return isExisty(location || fair || partner_city)
+      partner: {
+        type: Partner.type,
+        resolve: ({ partner }) => partner,
       },
-    },
-    is_active: {
-      type: GraphQLBoolean,
-      description:
-        "Gravity doesn’t expose the `active` flag. Temporarily re-state its logic.",
-      resolve: ({ start_at, end_at }) => {
-        const start = moment.utc(start_at).subtract(7, "days")
-        const end = moment.utc(end_at).add(7, "days")
-        return moment.utc().isBetween(start, end)
+      press_release: markdown(),
+      start_at: date,
+      status: {
+        type: GraphQLString,
       },
-    },
-    is_displayable: {
-      type: GraphQLBoolean,
-      resolve: ({ displayable }) => displayable,
-    },
-    is_fair_booth: {
-      type: GraphQLBoolean,
-      resolve: ({ fair }) => isExisty(fair),
-    },
-    kind: {
-      type: GraphQLString,
-      resolve: (show, _options, { partnerShowLoader }) => {
-        if (show.artists) return kind(show)
-        return partnerShowLoader({
-          partner_id: show.partner.id,
-          show_id: show.id,
-        }).then(kind)
-      },
-    },
-    location: {
-      type: Location.type,
-      resolve: ({ location, fair_location }) => location || fair_location,
-    },
-    meta_image: {
-      type: Image.type,
-      resolve: (
-        { id, partner, image_versions, image_url },
-        _options,
-        { partnerShowArtworksLoader }
-      ) => {
-        if (image_versions && image_versions.length && image_url) {
-          return normalizeImageData({ image_versions, image_url })
-        }
-
-        return partnerShowArtworksLoader(
-          { partner_id: partner.id, show_id: id },
-          {
-            published: true,
-          }
-        ).then(({ body }) => {
-          return normalizeImageData(
-            getDefault(find(body, { can_share_image: true }))
-          )
-        })
-      },
-    },
-    name: {
-      type: GraphQLString,
-      description: "The exhibition title",
-    },
-    partner: {
-      type: Partner.type,
-      resolve: ({ partner }) => partner,
-    },
-    press_release: markdown(),
-    start_at: date,
-    status: {
-      type: GraphQLString,
-    },
-    status_update: {
-      type: GraphQLString,
-      description: "A formatted update on upcoming status changes",
-      args: {
-        max_days: {
-          type: GraphQLInt,
-          description: "Before this many days no update will be generated",
+      status_update: {
+        type: GraphQLString,
+        description: "A formatted update on upcoming status changes",
+        args: {
+          max_days: {
+            type: GraphQLInt,
+            description: "Before this many days no update will be generated",
+          },
         },
+        resolve: ({ start_at, end_at }, options) =>
+          exhibitionStatus(start_at, end_at, options.max_days),
       },
-      resolve: ({ start_at, end_at }, options) =>
-        exhibitionStatus(start_at, end_at, options.max_days),
-    },
-    type: {
-      type: GraphQLString,
-      resolve: ({ fair }) => (isExisty(fair) ? "Fair Booth" : "Show"),
-    },
-  }),
+      type: {
+        type: GraphQLString,
+        resolve: ({ fair }) => (isExisty(fair) ? "Fair Booth" : "Show"),
+      },
+    }
+    Object.keys(fields).forEach(fieldName => {
+      fields[fieldName] = {
+        ...fields[fieldName],
+        deprecationReason: deprecate({
+          inVersion: 2,
+          reason:
+            "The `PartnerShow` type is deprecated in favor of the `Show` type.",
+        }),
+      }
+    })
+    return fields
+  },
 })
 
 const PartnerShow: GraphQLFieldConfig<void, ResolverContext> = {

--- a/src/schema/sale/index.ts
+++ b/src/schema/sale/index.ts
@@ -31,6 +31,7 @@ import {
 
 import config from "config"
 import { ResolverContext } from "types/graphql"
+import { deprecate } from "lib/deprecation"
 
 const { PREDICTION_ENDPOINT } = config
 
@@ -159,7 +160,10 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
       auction_state: {
         type: GraphQLString,
         resolve: ({ auction_state }) => auction_state,
-        deprecationReason: "Favor `status` for consistency with other models",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "status",
+        }),
       },
       bid_increments: {
         type: new GraphQLList(BidIncrement),
@@ -204,7 +208,10 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
       is_auction: { type: GraphQLBoolean },
       is_benefit: {
         type: GraphQLBoolean,
-        deprecationReason: "Favor `isBenefit`",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "isBenefit",
+        }),
       },
       isBenefit: {
         type: GraphQLBoolean,

--- a/src/schema/sale_artwork.ts
+++ b/src/schema/sale_artwork.ts
@@ -21,6 +21,7 @@ import {
 import config from "config"
 import { ResolverContext } from "types/graphql"
 import { LoadersWithoutAuthentication } from "lib/loaders/loaders_without_authentication"
+import { deprecate } from "lib/deprecation"
 
 const { BIDDER_POSITION_MAX_BID_AMOUNT_CENTS_LIMIT } = config
 
@@ -86,11 +87,17 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
       artwork: { type: Artwork.type, resolve: ({ artwork }) => artwork },
       bidder_positions_count: {
         type: GraphQLInt,
-        deprecationReason: "Favor `counts.bidder_positions`",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "counts.bidder_positions",
+        }),
       },
       bid_increments: {
         type: new GraphQLList(GraphQLFloat),
-        deprecationReason: "Favor `increments.cents`",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "increments.cents",
+        }),
         resolve: (
           { minimum_next_bid_cents, sale_id },
           _options,
@@ -158,7 +165,10 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
       }),
       high_estimate_cents: {
         type: GraphQLFloat,
-        deprecationReason: "Favor `high_estimate",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "high_estimate",
+        }),
       },
       highest_bid: {
         type: new GraphQLObjectType<any, ResolverContext>({
@@ -181,7 +191,10 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
             },
             amount_cents: {
               type: GraphQLFloat,
-              deprecationReason: "Favor `cents`",
+              deprecationReason: deprecate({
+                inVersion: 2,
+                preferUsageOf: "cents",
+              }),
             },
           },
         }),
@@ -267,7 +280,10 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
       lot_label: { type: GraphQLString },
       lot_number: {
         type: GraphQLString,
-        deprecationReason: "Favor `lot_label`",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "lot_label",
+        }),
       },
       low_estimate: money({
         name: "SaleArtworkLowEstimate",
@@ -278,7 +294,10 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
       }),
       low_estimate_cents: {
         type: GraphQLFloat,
-        deprecationReason: "Favor `low_estimate`",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "low_estimate",
+        }),
       },
       minimum_next_bid: money({
         name: "SaleArtworkMinimumNextBid",
@@ -292,7 +311,10 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
       }),
       minimum_next_bid_cents: {
         type: GraphQLFloat,
-        deprecationReason: "Favor `minimum_next_bid`",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "minimum_next_bid",
+        }),
       },
       opening_bid: money({
         name: "SaleArtworkOpeningBid",
@@ -303,7 +325,10 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
       }),
       opening_bid_cents: {
         type: GraphQLFloat,
-        deprecationReason: "Favor `opening_bid`",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "opening_bid",
+        }),
       },
       position: { type: GraphQLFloat },
       reserve: money({

--- a/src/schema/show.ts
+++ b/src/schema/show.ts
@@ -47,6 +47,7 @@ import EventStatus from "./input_fields/event_status"
 import { LOCAL_DISCOVERY_RADIUS_KM } from "./city/constants"
 import { ResolverContext } from "types/graphql"
 import followArtistsResolver from "lib/shared_resolvers/followedArtistsResolver"
+import { deprecate } from "lib/deprecation"
 
 const FollowArtistType = new GraphQLObjectType<any, ResolverContext>({
   name: "ShowFollowArtist",
@@ -105,7 +106,10 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
     },
     artworks: {
       description: "The artworks featured in this show",
-      deprecationReason: "Use artworks_connection instead",
+      deprecationReason: deprecate({
+        inVersion: 2,
+        preferUsageOf: "artworks_connection",
+      }),
       type: new GraphQLList(Artwork.type),
       args: {
         ...artworksArgs,
@@ -353,7 +357,10 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
     },
     displayable: {
       type: GraphQLBoolean,
-      deprecationReason: "Prefix Boolean returning fields with `is_`",
+      deprecationReason: deprecate({
+        inVersion: 2,
+        preferUsageOf: "is_displayable",
+      }),
     },
 
     end_at: date,
@@ -442,7 +449,10 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
       resolve: ({ is_reference }) => is_reference,
     },
     is_local_discovery: {
-      deprecationReason: "Prefer isStubShow",
+      deprecationReason: deprecate({
+        inVersion: 2,
+        preferUsageOf: "isStubShow",
+      }),
       type: GraphQLBoolean,
     },
     isStubShow: {

--- a/src/schema/sorts/artist_sorts.ts
+++ b/src/schema/sorts/artist_sorts.ts
@@ -1,19 +1,29 @@
 import { GraphQLEnumType } from "graphql"
+import { deprecate } from "lib/deprecation"
 
 const ArtistSorts = {
   type: new GraphQLEnumType({
     name: "ArtistSorts",
     values: {
       sortable_id_asc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "SORTABLE_ID_ASC",
+        }),
         value: "sortable_id",
       },
       sortable_id_desc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "SORTABLE_ID_DESC",
+        }),
         value: "-sortable_id",
       },
       trending_desc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "TRENDING_DESC",
+        }),
         value: "-trending",
       },
       SORTABLE_ID_ASC: {

--- a/src/schema/sorts/artwork_sorts.ts
+++ b/src/schema/sorts/artwork_sorts.ts
@@ -1,55 +1,92 @@
 import { GraphQLEnumType } from "graphql"
+import { deprecate } from "lib/deprecation"
 
 const ArtworkSorts = {
   type: new GraphQLEnumType({
     name: "ArtworkSorts",
     values: {
       availability_desc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "AVAILABILITY_DESC",
+        }),
         value: "-availability",
       },
       created_at_asc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "CREATED_AT_ASC",
+        }),
         value: "created_at",
       },
       created_at_desc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "CREATED_AT_DESC",
+        }),
         value: "-created_at",
       },
       deleted_at_asc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "DELETED_AT_ASC",
+        }),
         value: "deleted_at",
       },
       deleted_at_desc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "DELETED_AT_DESC",
+        }),
         value: "-deleted_at",
       },
       iconicity_desc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "ICONICITY_DESC",
+        }),
         value: "-iconicity",
       },
       merchandisability_desc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "MERCHANDISABILITY_DESC",
+        }),
         value: "-merchandisability",
       },
       published_at_asc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "PUBLISHED_AT_ASC",
+        }),
         value: "published_at",
       },
       published_at_desc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "PUBLISHED_AT_DESC",
+        }),
         value: "-published_at",
       },
       partner_updated_at_desc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "PARTNER_UPDATED_AT_DESC",
+        }),
         value: "-partner_updated_at",
       },
       title_asc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "TITLE_ASC",
+        }),
         value: "title",
       },
       title_desc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "TITLE_DESC",
+        }),
         value: "-title",
       },
       AVAILABILITY_DESC: {

--- a/src/schema/sorts/partner_show_sorts.ts
+++ b/src/schema/sorts/partner_show_sorts.ts
@@ -1,47 +1,78 @@
 import { GraphQLEnumType } from "graphql"
+import { deprecate } from "lib/deprecation"
 
 const PartnerShowSorts = {
   type: new GraphQLEnumType({
     name: "PartnerShowSorts",
     values: {
       created_at_asc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "CREATED_AT_ASC",
+        }),
         value: "created_at",
       },
       created_at_desc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "CREATED_AT_DESC",
+        }),
         value: "-created_at",
       },
       end_at_asc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "END_AT_ASC",
+        }),
         value: "end_at",
       },
       end_at_desc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "END_AT_DESC",
+        }),
         value: "-end_at",
       },
       name_asc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "NAME_ASC",
+        }),
         value: "name",
       },
       name_desc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "NAME_DESC",
+        }),
         value: "-name",
       },
       publish_at_asc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "PUBLISH_AT_ASC",
+        }),
         value: "publish_at",
       },
       publish_at_desc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "PUBLISH_AT_DESC",
+        }),
         value: "-publish_at",
       },
       start_at_asc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "START_AT_ASC",
+        }),
         value: "start_at",
       },
       start_at_desc: {
-        deprecationReason: "use capital enums",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "START_AT_DESC",
+        }),
         value: "-start_at",
       },
       CREATED_AT_ASC: {

--- a/src/schema/v2/RemoveDeprecatedFields.ts
+++ b/src/schema/v2/RemoveDeprecatedFields.ts
@@ -1,0 +1,73 @@
+import { Transform, defaultMergedResolver } from "graphql-tools"
+import {
+  GraphQLSchema,
+  GraphQLObjectType,
+  GraphQLInterfaceType,
+  GraphQLFieldConfigMap,
+} from "graphql"
+import {
+  visitSchema,
+  VisitSchemaKind,
+  TypeVisitor,
+} from "graphql-tools/dist/transforms/visitSchema"
+import {
+  createResolveType,
+  fieldToFieldConfig,
+} from "graphql-tools/dist/stitching/schemaRecreation"
+import { shouldBeRemoved } from "lib/deprecation"
+
+export class RemoveDeprecatedFields implements Transform {
+  // eslint-disable-next-line no-useless-constructor
+  constructor(private options: { fromVersion: number }) {}
+
+  public transformSchema(schema: GraphQLSchema): GraphQLSchema {
+    const newSchema = visitSchema(schema, {
+      [VisitSchemaKind.OBJECT_TYPE]: ((type: GraphQLObjectType<any, any>) => {
+        return new GraphQLObjectType({
+          name: type.name,
+          description: type.description,
+          astNode: type.astNode,
+          fields: this.transformFields(type),
+          extensionASTNodes: type.extensionASTNodes,
+          isTypeOf: type.isTypeOf,
+          interfaces: type.getInterfaces(),
+        })
+      }) as TypeVisitor,
+
+      [VisitSchemaKind.INTERFACE_TYPE]: ((type: GraphQLInterfaceType) => {
+        return new GraphQLInterfaceType({
+          name: type.name,
+          description: type.description,
+          astNode: type.astNode,
+          fields: this.transformFields(type),
+          resolveType: type.resolveType,
+          extensionASTNodes: type.extensionASTNodes,
+        })
+      }) as TypeVisitor,
+    })
+
+    return newSchema
+  }
+
+  private transformFields(
+    type: GraphQLObjectType<any, any> | GraphQLInterfaceType
+  ) {
+    const fields = type.getFields()
+    const newFields: GraphQLFieldConfigMap<any, any> = {}
+    const resolveType = createResolveType((_name, type) => type)
+    Object.keys(fields).forEach(fieldName => {
+      const field = fields[fieldName]
+      if (
+        !shouldBeRemoved({
+          inVersion: this.options.fromVersion,
+          deprecationReason: field.deprecationReason,
+          typeName: type.name,
+          fieldName,
+        })
+      ) {
+        newFields[fieldName] = fieldToFieldConfig(field, resolveType, true)
+      }
+    })
+    return newFields
+  }
+}

--- a/src/schema/v2/__tests__/v2.test.ts
+++ b/src/schema/v2/__tests__/v2.test.ts
@@ -1,4 +1,8 @@
-import { transformToV2, TransformToV2Options } from "../index"
+import {
+  transformToV2,
+  TransformToV2Options,
+  FILTER_DEPRECATIONS,
+} from "../index"
 import {
   GravityIDFields,
   InternalIDFields,
@@ -102,14 +106,19 @@ describe(transformToV2, () => {
           },
         },
       })
-      expect(
-        schema.getQueryType().getFields()["deprecatedField"]
-      ).toBeUndefined()
+      const deprecatedField = schema.getQueryType().getFields()[
+        "deprecatedField"
+      ]
+      if (FILTER_DEPRECATIONS) {
+        expect(deprecatedField).toBeUndefined()
+      } else {
+        expect(deprecatedField).not.toBeUndefined()
+      }
     })
   })
 
   describe("concerning ID renaming", () => {
-    it("renames __id arg to id", async () => {
+    it.only("renames __id arg to id", async () => {
       const rootValue = {
         node: {
           id: "global id",

--- a/src/schema/v2/__tests__/v2.test.ts
+++ b/src/schema/v2/__tests__/v2.test.ts
@@ -15,6 +15,7 @@ import {
   GraphQLID,
   GraphQLInterfaceType,
   GraphQLArgs,
+  GraphQLString,
 } from "graphql"
 import gql from "lib/gql"
 import { toGlobalId } from "graphql-relay"
@@ -22,6 +23,7 @@ import {
   ExecutionResultDataDefault,
   ExecutionResult,
 } from "graphql/execution/execute"
+import { deprecate } from "lib/deprecation"
 
 function createSchema({
   fields,
@@ -85,6 +87,23 @@ describe(transformToV2, () => {
       })
       expect(
         schema.getType("GetRidOfID").getFields().internalID
+      ).toBeUndefined()
+    })
+
+    it("removes previously deprecated fields", () => {
+      const schema = createSchema({
+        fields: {
+          deprecatedField: {
+            type: GraphQLString,
+            deprecationReason: deprecate({
+              inVersion: 2,
+              preferUsageOf: "bar",
+            }),
+          },
+        },
+      })
+      expect(
+        schema.getQueryType().getFields()["deprecatedField"]
       ).toBeUndefined()
     })
   })

--- a/src/schema/v2/index.ts
+++ b/src/schema/v2/index.ts
@@ -6,7 +6,7 @@ import { RemoveDeprecatedFields } from "./RemoveDeprecatedFields"
 
 // TODO: Flip this switch before we go public with v2 and update clients. Until
 //       then this gives clients an extra window of opportunity to update.
-const FILTER_DEPRECATIONS = false
+export const FILTER_DEPRECATIONS = false
 
 // These should not show up in v2 at all.
 const FilterTypeNames = [

--- a/src/schema/v2/index.ts
+++ b/src/schema/v2/index.ts
@@ -6,7 +6,7 @@ import { RemoveDeprecatedFields } from "./RemoveDeprecatedFields"
 
 // TODO: Flip this switch before we go public with v2 and update clients. Until
 //       then this gives clients an extra window of opportunity to update.
-const FILTER_DEPRECATIONS = true
+const FILTER_DEPRECATIONS = false
 
 // These should not show up in v2 at all.
 const FilterTypeNames = [

--- a/src/schema/v2/index.ts
+++ b/src/schema/v2/index.ts
@@ -2,6 +2,7 @@ import { GraphQLSchema } from "graphql"
 import { transformSchema, FilterTypes } from "graphql-tools"
 import { RenameIDFields } from "./RenameIDFields"
 import { RenameArguments } from "./RenameArguments"
+import { RemoveDeprecatedFields } from "./RemoveDeprecatedFields"
 
 // These should not show up in v2 at all.
 const FilterTypeNames = ["DoNotUseThisPartner"]
@@ -61,5 +62,6 @@ export const transformToV2 = (
       opt.filterIDFieldFromTypes
     ),
     new RenameArguments((_field, arg) => (arg.name === "__id" ? "id" : null)),
+    new RemoveDeprecatedFields({ fromVersion: 2 }),
   ])
 }


### PR DESCRIPTION
Closes https://artsyproduct.atlassian.net/browse/PLATFORM-1468

Not yet enabled, so clients have a longer window of opportunity to clean deprecated usage up while still receiving info about what fields to use instead, but this should be enabled before v2 goes live in an App Store version of the iOS app.

See [this commit](https://github.com/artsy/metaphysics/commit/2ead0cff34126313f32ca71ca26abf297062e271) for all dropped fields/types.