### PR TITLE
Stitch AnalyticsRankedStats union

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -44,6 +44,14 @@ type AggregationCount {
   sortable_id: String
 }
 
+type AnalyticsArtist {
+  entityId: String!
+}
+
+type AnalyticsArtwork {
+  entityId: String!
+}
+
 # Publish artwork Series Stats
 type AnalyticsArtworksPublishedStats {
   percentageChanged: Int!
@@ -54,6 +62,8 @@ type AnalyticsArtworksPublishedStats {
 
 # An ISO 8601 datetime
 scalar AnalyticsDateTime
+
+union AnalyticsEntityUnion = Artwork | PartnerShow | Artist
 
 # A histogram bin
 type AnalyticsHistogramBin {
@@ -110,24 +120,12 @@ type AnalyticsPartnerAudienceStats {
   uniqueVisitors: Int!
 }
 
-# Inquiry count time series data of a partner
-type AnalyticsPartnerInquiryCountTimeSeriesStats {
-  count: Int
-  endTime: AnalyticsDateTime
-  startTime: AnalyticsDateTime
-}
-
 # Inquiry stats of a partner
 type AnalyticsPartnerInquiryStats {
   inquiryCount: Int!
   inquiryResponseTime: Int
   partnerId: String!
   period: AnalyticsQueryPeriodEnum!
-
-  # Partner inquiry count time series
-  timeSeries(
-    cumulative: Boolean = false
-  ): [AnalyticsPartnerInquiryCountTimeSeriesStats!]
 }
 
 # Sales stats of a partner
@@ -183,10 +181,27 @@ type AnalyticsPartnerStats {
   pageviews(period: AnalyticsQueryPeriodEnum!): AnalyticsPageviewStats
   partnerId: String!
 
+  # Artworks, shows, and artists ranked by views
+  rankedStats(
+    # Returns the elements in the list that come after the specified cursor.
+    after: String
+
+    # Returns the elements in the list that come before the specified cursor.
+    before: String
+
+    # Returns the first _n_ elements from the list.
+    first: Int
+
+    # Returns the last _n_ elements from the list.
+    last: Int
+    objectType: AnalyticsRankedStatsObjectTypeEnum!
+    period: AnalyticsQueryPeriodEnum!
+  ): AnalyticsRankedStatsConnection
+
   # Sales stats
   sales(period: AnalyticsQueryPeriodEnum!): AnalyticsPartnerSalesStats
 
-  # Artworks ranked by views
+  # Top artworks ranked by views
   topArtworks(
     # Returns the elements in the list that come after the specified cursor.
     after: String
@@ -199,8 +214,8 @@ type AnalyticsPartnerStats {
 
     # Returns the last _n_ elements from the list.
     last: Int
-    period: AnalyticsQueryPeriodEnum!
-  ): AnalyticsTopArtworksConnection
+  ): AnalyticsRankedStatsConnection
+    @deprecated(reason: "Use rankedStats(objectType: ) instead")
 
   # Number of unique visitors
   uniqueVisitors(period: AnalyticsQueryPeriodEnum!): Int
@@ -308,33 +323,54 @@ enum AnalyticsQueryPeriodEnum {
   SIXTEEN_WEEKS
 }
 
-# Top artworks from a partner
-type AnalyticsTopArtworks {
-  artworkId: String!
+# Top artworks, shows, or artists from a partner
+type AnalyticsRankedStats {
   period: AnalyticsQueryPeriodEnum!
+  rankedEntity: AnalyticsRankedStatsUnion!
   value: Int!
-  artwork: Artwork
+  entity: AnalyticsEntityUnion
 }
 
-# The connection type for TopArtworks.
-type AnalyticsTopArtworksConnection {
+# The connection type for RankedStats.
+type AnalyticsRankedStatsConnection {
   # A list of edges.
-  edges: [AnalyticsTopArtworksEdge]
+  edges: [AnalyticsRankedStatsEdge]
 
   # A list of nodes.
-  nodes: [AnalyticsTopArtworks]
+  nodes: [AnalyticsRankedStats]
 
   # Information to aid in pagination.
   pageInfo: AnalyticsPageInfo!
 }
 
 # An edge in a connection.
-type AnalyticsTopArtworksEdge {
+type AnalyticsRankedStatsEdge {
   # A cursor for use in pagination.
   cursor: String!
 
   # The item at the end of the edge.
-  node: AnalyticsTopArtworks
+  node: AnalyticsRankedStats
+}
+
+enum AnalyticsRankedStatsObjectTypeEnum {
+  # Artist
+  ARTIST
+
+  # Artwork
+  ARTWORK
+
+  # Show
+  SHOW
+}
+
+# An artwork, artist, or show
+union AnalyticsRankedStatsUnion =
+    AnalyticsArtist
+  | AnalyticsArtwork
+  | AnalyticsShow
+
+type AnalyticsShow {
+  entityId: String!
 }
 
 input ApproveOrderInput {

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -63,7 +63,7 @@ type AnalyticsArtworksPublishedStats {
 # An ISO 8601 datetime
 scalar AnalyticsDateTime
 
-union AnalyticsEntityUnion = Artwork | PartnerShow | Artist
+union AnalyticsEntityUnion = Artwork | Show | Artist
 
 # A histogram bin
 type AnalyticsHistogramBin {

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -63,8 +63,6 @@ type AnalyticsArtworksPublishedStats {
 # An ISO 8601 datetime
 scalar AnalyticsDateTime
 
-union AnalyticsEntityUnion = Artwork | Show | Artist
-
 # A histogram bin
 type AnalyticsHistogramBin {
   maxPriceCents: Int!
@@ -323,12 +321,14 @@ enum AnalyticsQueryPeriodEnum {
   SIXTEEN_WEEKS
 }
 
+union AnalyticsRankedEntityUnion = Artwork | Show | Artist
+
 # Top artworks, shows, or artists from a partner
 type AnalyticsRankedStats {
   period: AnalyticsQueryPeriodEnum!
   rankedEntity: AnalyticsRankedStatsUnion!
   value: Int!
-  entity: AnalyticsEntityUnion
+  entity: AnalyticsRankedEntityUnion
 }
 
 # The connection type for RankedStats.

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -63,7 +63,7 @@ type AnalyticsArtworksPublishedStats {
 # An ISO 8601 datetime
 scalar AnalyticsDateTime
 
-union AnalyticsEntityUnion = Artwork | PartnerShow | Artist
+union AnalyticsEntityUnion = Artwork | Show | Artist
 
 # A histogram bin
 type AnalyticsHistogramBin {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -44,6 +44,14 @@ type AggregationCount {
   sortable_id: String
 }
 
+type AnalyticsArtist {
+  entityId: String!
+}
+
+type AnalyticsArtwork {
+  entityId: String!
+}
+
 # Publish artwork Series Stats
 type AnalyticsArtworksPublishedStats {
   percentageChanged: Int!
@@ -54,6 +62,8 @@ type AnalyticsArtworksPublishedStats {
 
 # An ISO 8601 datetime
 scalar AnalyticsDateTime
+
+union AnalyticsEntityUnion = Artwork | PartnerShow | Artist
 
 # A histogram bin
 type AnalyticsHistogramBin {
@@ -110,24 +120,12 @@ type AnalyticsPartnerAudienceStats {
   uniqueVisitors: Int!
 }
 
-# Inquiry count time series data of a partner
-type AnalyticsPartnerInquiryCountTimeSeriesStats {
-  count: Int
-  endTime: AnalyticsDateTime
-  startTime: AnalyticsDateTime
-}
-
 # Inquiry stats of a partner
 type AnalyticsPartnerInquiryStats {
   inquiryCount: Int!
   inquiryResponseTime: Int
   partnerId: String!
   period: AnalyticsQueryPeriodEnum!
-
-  # Partner inquiry count time series
-  timeSeries(
-    cumulative: Boolean = false
-  ): [AnalyticsPartnerInquiryCountTimeSeriesStats!]
 }
 
 # Sales stats of a partner
@@ -183,10 +181,27 @@ type AnalyticsPartnerStats {
   pageviews(period: AnalyticsQueryPeriodEnum!): AnalyticsPageviewStats
   partnerId: String!
 
+  # Artworks, shows, and artists ranked by views
+  rankedStats(
+    # Returns the elements in the list that come after the specified cursor.
+    after: String
+
+    # Returns the elements in the list that come before the specified cursor.
+    before: String
+
+    # Returns the first _n_ elements from the list.
+    first: Int
+
+    # Returns the last _n_ elements from the list.
+    last: Int
+    objectType: AnalyticsRankedStatsObjectTypeEnum!
+    period: AnalyticsQueryPeriodEnum!
+  ): AnalyticsRankedStatsConnection
+
   # Sales stats
   sales(period: AnalyticsQueryPeriodEnum!): AnalyticsPartnerSalesStats
 
-  # Artworks ranked by views
+  # Top artworks ranked by views
   topArtworks(
     # Returns the elements in the list that come after the specified cursor.
     after: String
@@ -199,8 +214,8 @@ type AnalyticsPartnerStats {
 
     # Returns the last _n_ elements from the list.
     last: Int
-    period: AnalyticsQueryPeriodEnum!
-  ): AnalyticsTopArtworksConnection
+  ): AnalyticsRankedStatsConnection
+    @deprecated(reason: "Use rankedStats(objectType: ) instead")
 
   # Number of unique visitors
   uniqueVisitors(period: AnalyticsQueryPeriodEnum!): Int
@@ -308,33 +323,54 @@ enum AnalyticsQueryPeriodEnum {
   SIXTEEN_WEEKS
 }
 
-# Top artworks from a partner
-type AnalyticsTopArtworks {
-  artworkId: String!
+# Top artworks, shows, or artists from a partner
+type AnalyticsRankedStats {
   period: AnalyticsQueryPeriodEnum!
+  rankedEntity: AnalyticsRankedStatsUnion!
   value: Int!
-  artwork: Artwork
+  entity: AnalyticsEntityUnion
 }
 
-# The connection type for TopArtworks.
-type AnalyticsTopArtworksConnection {
+# The connection type for RankedStats.
+type AnalyticsRankedStatsConnection {
   # A list of edges.
-  edges: [AnalyticsTopArtworksEdge]
+  edges: [AnalyticsRankedStatsEdge]
 
   # A list of nodes.
-  nodes: [AnalyticsTopArtworks]
+  nodes: [AnalyticsRankedStats]
 
   # Information to aid in pagination.
   pageInfo: AnalyticsPageInfo!
 }
 
 # An edge in a connection.
-type AnalyticsTopArtworksEdge {
+type AnalyticsRankedStatsEdge {
   # A cursor for use in pagination.
   cursor: String!
 
   # The item at the end of the edge.
-  node: AnalyticsTopArtworks
+  node: AnalyticsRankedStats
+}
+
+enum AnalyticsRankedStatsObjectTypeEnum {
+  # Artist
+  ARTIST
+
+  # Artwork
+  ARTWORK
+
+  # Show
+  SHOW
+}
+
+# An artwork, artist, or show
+union AnalyticsRankedStatsUnion =
+    AnalyticsArtist
+  | AnalyticsArtwork
+  | AnalyticsShow
+
+type AnalyticsShow {
+  entityId: String!
 }
 
 input ApproveOrderInput {
@@ -6657,6 +6693,7 @@ type MarketingCollection {
 
   # Collection has prioritized connection to artist
   is_featured_artist_content: Boolean!
+  relatedCollections: [MarketingCollection!]!
   artworks(
     acquireable: Boolean
     offerable: Boolean

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -63,8 +63,6 @@ type AnalyticsArtworksPublishedStats {
 # An ISO 8601 datetime
 scalar AnalyticsDateTime
 
-union AnalyticsEntityUnion = Artwork | Show | Artist
-
 # A histogram bin
 type AnalyticsHistogramBin {
   maxPriceCents: Int!
@@ -323,12 +321,14 @@ enum AnalyticsQueryPeriodEnum {
   SIXTEEN_WEEKS
 }
 
+union AnalyticsRankedEntityUnion = Artwork | Show | Artist
+
 # Top artworks, shows, or artists from a partner
 type AnalyticsRankedStats {
   period: AnalyticsQueryPeriodEnum!
   rankedEntity: AnalyticsRankedStatsUnion!
   value: Int!
-  entity: AnalyticsEntityUnion
+  entity: AnalyticsRankedEntityUnion
 }
 
 # The connection type for RankedStats.

--- a/src/data/vortex.graphql
+++ b/src/data/vortex.graphql
@@ -1,3 +1,11 @@
+type Artist {
+  entityId: String!
+}
+
+type Artwork {
+  entityId: String!
+}
+
 """
 Publish artwork Series Stats
 """
@@ -71,15 +79,6 @@ type PartnerAudienceStats {
 }
 
 """
-Inquiry count time series data of a partner
-"""
-type PartnerInquiryCountTimeSeriesStats {
-  count: Int
-  endTime: DateTime
-  startTime: DateTime
-}
-
-"""
 Inquiry stats of a partner
 """
 type PartnerInquiryStats {
@@ -87,11 +86,6 @@ type PartnerInquiryStats {
   inquiryResponseTime: Int
   partnerId: String!
   period: QueryPeriodEnum!
-
-  """
-  Partner inquiry count time series
-  """
-  timeSeries(cumulative: Boolean = false): [PartnerInquiryCountTimeSeriesStats!]
 }
 
 """
@@ -146,12 +140,39 @@ type PartnerStats {
   partnerId: String!
 
   """
+  Artworks, shows, and artists ranked by views
+  """
+  rankedStats(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+    objectType: RankedStatsObjectTypeEnum!
+    period: QueryPeriodEnum!
+  ): RankedStatsConnection
+
+  """
   Sales stats
   """
   sales(period: QueryPeriodEnum!): PartnerSalesStats
 
   """
-  Artworks ranked by views
+  Top artworks ranked by views
   """
   topArtworks(
     """
@@ -173,8 +194,8 @@ type PartnerStats {
     Returns the last _n_ elements from the list.
     """
     last: Int
-    period: QueryPeriodEnum!
-  ): TopArtworksConnection
+  ): RankedStatsConnection
+    @deprecated(reason: "Use rankedStats(objectType: ) instead")
 
   """
   Number of unique visitors
@@ -356,27 +377,27 @@ enum QueryPeriodEnum {
 }
 
 """
-Top artworks from a partner
+Top artworks, shows, or artists from a partner
 """
-type TopArtworks {
-  artworkId: String!
+type RankedStats {
   period: QueryPeriodEnum!
+  rankedEntity: RankedStatsUnion!
   value: Int!
 }
 
 """
-The connection type for TopArtworks.
+The connection type for RankedStats.
 """
-type TopArtworksConnection {
+type RankedStatsConnection {
   """
   A list of edges.
   """
-  edges: [TopArtworksEdge]
+  edges: [RankedStatsEdge]
 
   """
   A list of nodes.
   """
-  nodes: [TopArtworks]
+  nodes: [RankedStats]
 
   """
   Information to aid in pagination.
@@ -387,7 +408,7 @@ type TopArtworksConnection {
 """
 An edge in a connection.
 """
-type TopArtworksEdge {
+type RankedStatsEdge {
   """
   A cursor for use in pagination.
   """
@@ -396,5 +417,31 @@ type TopArtworksEdge {
   """
   The item at the end of the edge.
   """
-  node: TopArtworks
+  node: RankedStats
+}
+
+enum RankedStatsObjectTypeEnum {
+  """
+  Artist
+  """
+  ARTIST
+
+  """
+  Artwork
+  """
+  ARTWORK
+
+  """
+  Show
+  """
+  SHOW
+}
+
+"""
+An artwork, artist, or show
+"""
+union RankedStatsUnion = Artist | Artwork | Show
+
+type Show {
+  entityId: String!
 }

--- a/src/lib/stitching/vortex/__mocks__/link.ts
+++ b/src/lib/stitching/vortex/__mocks__/link.ts
@@ -84,19 +84,15 @@ export const mockFetch = jest.fn(() =>
                 },
               ],
             },
-            topArtworks: {
+            rankedStats: {
               edges: [
                 {
                   node: {
-                    artworkId: "5c12d91fe55c1e2b4010df28",
+                    rankedEntity: {
+                      __typename: "Artwork",
+                      entityId: "5bfec60b2bc43f4416ec7509",
+                    },
                     value: 76.0,
-                    period: "FOUR_WEEKS",
-                  },
-                },
-                {
-                  node: {
-                    artworkId: "5bfec60b2bc43f4416ec7509",
-                    value: 51.0,
                     period: "FOUR_WEEKS",
                   },
                 },

--- a/src/lib/stitching/vortex/__tests__/rankedStats.test.ts
+++ b/src/lib/stitching/vortex/__tests__/rankedStats.test.ts
@@ -5,7 +5,7 @@ import { ResolverContext } from "types/graphql"
 jest.mock("../link")
 require("../link").mockFetch as jest.Mock<any>
 
-describe("TopArtworks type", () => {
+describe("AnalyticsRankedStats type", () => {
   const artwork = {
     id: "lona-misa",
     artist: {
@@ -33,14 +33,17 @@ describe("TopArtworks type", () => {
     query {
       partner(id: "lol") {
         analytics {
-          topArtworks(period: FOUR_WEEKS) {
+          topArtworks: rankedStats(
+            first: 1
+            objectType: ARTWORK
+            period: ONE_YEAR
+          ) {
             edges {
               node {
-                value
-                period
-                artwork {
-                  id
-                  title
+                entity {
+                  ... on Artwork {
+                    title
+                  }
                 }
               }
             }
@@ -53,36 +56,23 @@ describe("TopArtworks type", () => {
   it("is accessible through the partner type", async () => {
     const result = await runQuery(query, context)
     expect(result).toMatchInlineSnapshot(`
-Object {
-  "partner": Object {
-    "analytics": Object {
-      "topArtworks": Object {
-        "edges": Array [
-          Object {
-            "node": Object {
-              "artwork": Object {
-                "id": "lona-misa",
-                "title": "Lona Misa",
-              },
-              "period": "FOUR_WEEKS",
-              "value": 76,
+      Object {
+        "partner": Object {
+          "analytics": Object {
+            "topArtworks": Object {
+              "edges": Array [
+                Object {
+                  "node": Object {
+                    "entity": Object {
+                      "title": "Lona Misa",
+                    },
+                  },
+                },
+              ],
             },
           },
-          Object {
-            "node": Object {
-              "artwork": Object {
-                "id": "lona-misa",
-                "title": "Lona Misa",
-              },
-              "period": "FOUR_WEEKS",
-              "value": 51,
-            },
-          },
-        ],
-      },
-    },
-  },
-}
-`)
+        },
+      }
+    `)
   })
 })

--- a/src/lib/stitching/vortex/stitching.ts
+++ b/src/lib/stitching/vortex/stitching.ts
@@ -16,7 +16,7 @@ const getMaxPrice = (thing: { listPrice: any }) => {
 export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
   // The SDL used to declare how to stitch an object
   extensionSchema: gql`
-    union AnalyticsEntityUnion = Artwork | PartnerShow | Artist
+    union AnalyticsEntityUnion = Artwork | Show | Artist
     extend type AnalyticsPricingContext {
       appliedFiltersDisplay: String
     }
@@ -293,24 +293,9 @@ export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
           }
         `,
         resolve: (parent, _args, context, info) => {
-          const toSnakeCase = s =>
-            s
-              .replace(/\.?([A-Z])/g, (_x, y) => "_" + y.toLowerCase())
-              .replace(/^_/, "")
-          const getMPNameFromTypeName = (typename: string): string => {
-            switch (typename) {
-              case "AnalyticsArtwork":
-                return "Artwork"
-              case "AnalyticsArtist":
-                return "Artist"
-              case "AnalyticsShow":
-                return "PartnerShow"
-              default:
-                return ""
-            }
-          }
+          const removeVortexPrefix = name => name.replace("Analytics", "")
           const typename = parent.rankedEntity.__typename
-          const fieldName = toSnakeCase(getMPNameFromTypeName(typename))
+          const fieldName = removeVortexPrefix(typename).toLowerCase()
           const id = parent.rankedEntity.entityId
           return info.mergeInfo
             .delegateToSchema({
@@ -325,7 +310,7 @@ export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
               transforms: vortexSchema.transforms,
             })
             .then(response => {
-              response.__typename = getMPNameFromTypeName(typename)
+              response.__typename = removeVortexPrefix(typename)
               return response
             })
         },

--- a/src/lib/stitching/vortex/stitching.ts
+++ b/src/lib/stitching/vortex/stitching.ts
@@ -16,7 +16,7 @@ const getMaxPrice = (thing: { listPrice: any }) => {
 export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
   // The SDL used to declare how to stitch an object
   extensionSchema: gql`
-    union AnalyticsEntityUnion = Artwork | Show | Artist
+    union AnalyticsRankedEntityUnion = Artwork | Show | Artist
     extend type AnalyticsPricingContext {
       appliedFiltersDisplay: String
     }
@@ -64,7 +64,7 @@ export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
       ): String
     }
     extend type AnalyticsRankedStats {
-      entity: AnalyticsEntityUnion
+      entity: AnalyticsRankedEntityUnion
     }
   `,
   resolvers: {
@@ -280,7 +280,7 @@ export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
           ... on AnalyticsRankedStats {
             rankedEntity{
               __typename
-              ... on AnalyticsArtwork{
+              ... on AnalyticsArtwork {
                 entityId
               }
               ... on AnalyticsShow {

--- a/src/lib/stitching/vortex/stitching.ts
+++ b/src/lib/stitching/vortex/stitching.ts
@@ -16,6 +16,7 @@ const getMaxPrice = (thing: { listPrice: any }) => {
 export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
   // The SDL used to declare how to stitch an object
   extensionSchema: gql`
+    union AnalyticsEntityUnion = Artwork | PartnerShow | Artist
     extend type AnalyticsPricingContext {
       appliedFiltersDisplay: String
     }
@@ -44,9 +45,6 @@ export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
     extend type Partner {
       analytics: AnalyticsPartnerStats
     }
-    extend type AnalyticsTopArtworks {
-      artwork: Artwork
-    }
     extend type AnalyticsPartnerSalesStats {
       total(
         decimal: String = "."
@@ -64,6 +62,9 @@ export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
         symbol: String
         thousand: String = ","
       ): String
+    }
+    extend type AnalyticsRankedStats {
+      entity: AnalyticsEntityUnion
     }
   `,
   resolvers: {
@@ -251,25 +252,6 @@ export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
         },
       },
     },
-    AnalyticsTopArtworks: {
-      artwork: {
-        fragment: `fragment AnalyticsTopArtworksArtwork on AnalyticsTopArtworks { artworkId }`,
-        resolve: async (parent, _args, context, info) => {
-          const id = parent.artworkId
-          return await info.mergeInfo.delegateToSchema({
-            schema: localSchema,
-            operation: "query",
-            fieldName: "artwork",
-            args: {
-              id,
-            },
-            context,
-            info,
-            transforms: vortexSchema.transforms,
-          })
-        },
-      },
-    },
     AnalyticsPartnerSalesStats: {
       total: {
         fragment: gql`
@@ -290,6 +272,63 @@ export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
         `,
         resolve: (parent, args, _context, _info) =>
           amount(_ => parent.totalCents).resolve({}, args),
+      },
+    },
+    AnalyticsRankedStats: {
+      entity: {
+        fragment: gql`
+          ... on AnalyticsRankedStats {
+            rankedEntity{
+              __typename
+              ... on AnalyticsArtwork{
+                entityId
+              }
+              ... on AnalyticsShow {
+                entityId
+              }
+              ... on AnalyticsArtist {
+                entityId
+              }
+            }
+          }
+        `,
+        resolve: (parent, _args, context, info) => {
+          const toSnakeCase = s =>
+            s
+              .replace(/\.?([A-Z])/g, (_x, y) => "_" + y.toLowerCase())
+              .replace(/^_/, "")
+          const getMPNameFromTypeName = (typename: string): string => {
+            switch (typename) {
+              case "AnalyticsArtwork":
+                return "Artwork"
+              case "AnalyticsArtist":
+                return "Artist"
+              case "AnalyticsShow":
+                return "PartnerShow"
+              default:
+                return ""
+            }
+          }
+          const typename = parent.rankedEntity.__typename
+          const fieldName = toSnakeCase(getMPNameFromTypeName(typename))
+          const id = parent.rankedEntity.entityId
+          return info.mergeInfo
+            .delegateToSchema({
+              schema: localSchema,
+              operation: "query",
+              fieldName,
+              args: {
+                id,
+              },
+              context,
+              info,
+              transforms: vortexSchema.transforms,
+            })
+            .then(response => {
+              response.__typename = getMPNameFromTypeName(typename)
+              return response
+            })
+        },
       },
     },
   },


### PR DESCRIPTION
~depends on https://github.com/artsy/vortex/pull/149~ (deployed to production)

We tried two other approaches ([1](https://github.com/artsy/metaphysics/pull/1762) , [2](https://github.com/artsy/metaphysics/compare/master...sepans:ranked-stats-2?expand=1)) but with this one we got it right:

cc: @alloy 

query:
```graphql
query {
  partner(id: "4d8b92c44eb68a1b2c0004cb") {
    analytics {
      topArtworks: rankedStats(first: 1, objectType: ARTWORK, period: ONE_YEAR) {
        edges{
          node{
            entity {
              ... on Artwork{
                title
                artists {
                  name
                }
              }
              ... on PartnerShow{
                name
              }
            }
          }
        }
      }      
      topShows: rankedStats(first: 1, objectType: SHOW, period: ONE_YEAR) {
        edges{
          node{
            entity {
              ... on Artwork{
                title
                artists {
                  name
                }
              }
              ... on PartnerShow{
                name
              }
            }
          }
        }
      }
    }
  }
}
```

response:
```JSON
{
"data": {
    "partner": {
      "analytics": {
        "topArtworks": {
          "edges": [
            {
              "node": {
                "entity": {
                  "title": "Untitled",
                  "artists": [
                    {
                      "name": "Gregory Crewdson"
                    }
                  ]
                }
              }
            }
          ]
        },
        "topShows": {
          "edges": [
            {
              "node": {
                "entity": {
                  "name": "Takashi Murakami: Prints"
                }
              }
            }
          ]
        }
      }
    }
  }
}
```
