### PR TITLE
[HOLD] - [Refactor] Fix deprecated type: PartnerShow -> Show

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1227,7 +1227,7 @@ type Artwork implements Node & Searchable & Sellable {
     active: Boolean
     at_a_fair: Boolean
     sort: PartnerShowSorts
-  ): PartnerShow
+  ): Show
   shows(
     size: Int
     active: Boolean
@@ -1290,7 +1290,7 @@ type ArtworkConnection {
 union ArtworkContext =
     ArtworkContextAuction
   | ArtworkContextFair
-  | ArtworkContextPartnerShow
+  | ArtworkContextShow
   | ArtworkContextSale
 
 type ArtworkContextAuction implements Node {
@@ -1562,206 +1562,6 @@ type ArtworkContextFair {
   sponsoredContent: FairSponsoredContent
 }
 
-type ArtworkContextPartnerShow implements Node {
-  # A globally unique ID.
-  __id: ID!
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # A type-specific ID.
-  id: ID!
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # A type-specific Gravity Mongo Document ID.
-  _id: ID!
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  cached: Int
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  artists: [Artist]
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # The artworks featured in the show
-  artworks(
-    # List of artwork IDs to exclude from the response (irrespective of size)
-    exclude: [String]
-    for_sale: Boolean
-    published: Boolean = true
-    all: Boolean
-    page: Int = 1
-
-    # Number of artworks to return
-    size: Int = 25
-  ): [Artwork]
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # A connection of artworks featured in the show
-  artworksConnection(
-    # List of artwork IDs to exclude from the response (irrespective of size)
-    exclude: [String]
-    for_sale: Boolean
-    published: Boolean = true
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): ArtworkConnection
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  counts: PartnerShowCounts
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  cover_image: Image
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  created_at(
-    # This arg is deprecated, use timezone instead
-    convert_to_utc: Boolean
-    format: String
-
-    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
-    timezone: String
-  ): String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  description: String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  displayable: Boolean
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  end_at(
-    # This arg is deprecated, use timezone instead
-    convert_to_utc: Boolean
-    format: String
-
-    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
-    timezone: String
-  ): String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  events: [PartnerShowEventType]
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # A formatted description of the start to end dates
-  exhibition_period: String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  fair: Fair
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  href: String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  images(
-    # Number of images to return
-    size: Int
-
-    # Pass true/false to include cover or not
-    default: Boolean
-    page: Int
-  ): [Image]
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # Flag showing if show has any location.
-  has_location: Boolean
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # Gravity doesn’t expose the `active` flag. Temporarily re-state its logic.
-  is_active: Boolean
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  is_displayable: Boolean
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  is_fair_booth: Boolean
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  kind: String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  location: Location
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  meta_image: Image
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # The exhibition title
-  name: String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  partner: Partner
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  press_release(format: Format): String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  start_at(
-    # This arg is deprecated, use timezone instead
-    convert_to_utc: Boolean
-    format: String
-
-    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
-    timezone: String
-  ): String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  status: String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # A formatted update on upcoming status changes
-  status_update(
-    # Before this many days no update will be generated
-    max_days: Int
-  ): String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  type: String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-}
-
 type ArtworkContextSale implements Node {
   # A globally unique ID.
   __id: ID!
@@ -1891,6 +1691,237 @@ type ArtworkContextSale implements Node {
   status: String
   sale_artwork(id: String!): SaleArtwork
   symbol: String
+}
+
+type ArtworkContextShow implements Node {
+  # A globally unique ID.
+  __id: ID!
+
+  # A type-specific ID.
+  id: ID!
+
+  # A type-specific Gravity Mongo Document ID.
+  _id: ID!
+  cached: Int
+
+  # The Artists presenting in this show
+  artists: [Artist]
+
+  # The artworks featured in this show
+  artworks(
+    # List of artwork IDs to exclude from the response (irrespective of size)
+    exclude: [String]
+    for_sale: Boolean
+    published: Boolean = true
+    all: Boolean
+    page: Int = 1
+
+    # Number of artworks to return
+    size: Int = 25
+  ): [Artwork]
+    @deprecated(
+      reason: "Prefer to use `artworks_connection`. [Will be removed in v2]"
+    )
+
+  # The artworks featured in the show
+  artworks_connection(
+    # List of artwork IDs to exclude from the response (irrespective of size)
+    exclude: [String]
+    for_sale: Boolean
+    published: Boolean = true
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtworkConnection
+
+  # Artists inside the show who do not have artworks present
+  artists_without_artworks: [Artist]
+
+  # Artists in the show grouped by last name
+  artists_grouped_by_name: [ArtistGroup]
+
+  # The general city, derived from a fair location, a show location or a potential city
+  city: String
+
+  # The image you should use to represent this show
+  cover_image: Image
+
+  # An object that represents some of the numbers you might want to highlight
+  counts: ShowCounts
+
+  # A description of the show
+  description: String
+  displayable: Boolean
+    @deprecated(
+      reason: "Prefer to use `is_displayable`. [Will be removed in v2]"
+    )
+  end_at(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
+
+  # Events from the partner that runs this show
+  events: [PartnerShowEventType]
+
+  # A formatted description of the start to end dates
+  exhibition_period: String
+
+  # If the show is in a Fair, then that fair
+  fair: Fair
+
+  # Artworks Elastic Search results
+  filteredArtworks(
+    acquireable: Boolean
+    offerable: Boolean
+    aggregation_partner_cities: [String]
+    aggregations: [ArtworkAggregation]
+    artist_id: String
+    artist_ids: [String]
+    at_auction: Boolean
+    attribution_class: [String]
+    color: String
+    dimension_range: String
+    extra_aggregation_gene_ids: [String]
+    include_artworks_by_followed_artists: Boolean
+    include_medium_filter_in_aggregation: Boolean
+    inquireable_only: Boolean
+    for_sale: Boolean
+    gene_id: String
+    gene_ids: [String]
+    height: String
+    width: String
+
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
+
+    # A string from the list of allocations, or * to denote all mediums
+    medium: String
+    period: String
+    periods: [String]
+    major_periods: [String]
+    partner_id: ID
+    partner_cities: [String]
+    price_range: String
+    page: Int
+    sale_id: ID
+    size: Int
+    sort: String
+    tag_id: String
+    keyword: String
+
+    # When true, will only return exact keyword match
+    keyword_match_exact: Boolean
+  ): FilterArtworks
+
+  # A path to the show on Artsy
+  href: String
+
+  # Images that represent the show, you may be interested in meta_image or cover_image for a definitive thumbnail
+  images(
+    # Number of images to return
+    size: Int
+
+    # Pass true/false to include cover or not
+    default: Boolean
+    page: Int
+  ): [Image]
+
+  # Flag showing if show has any location.
+  has_location: Boolean
+
+  # Gravity doesn’t expose the `active` flag. Temporarily re-state its logic.
+  is_active: Boolean
+
+  # Is this something we can display to the front-end?
+  is_displayable: Boolean
+
+  # Does the show exist as a fair booth?
+  is_fair_booth: Boolean
+
+  # Is it a show provided for historical reference?
+  is_reference: Boolean
+  is_local_discovery: Boolean
+    @deprecated(reason: "Prefer to use `isStubShow`. [Will be removed in v2]")
+
+  # Is it an outsourced local discovery stub show?
+  isStubShow: Boolean
+
+  # Whether the show is in a fair, group or solo
+  kind: String
+
+  # Where the show is located (Could also be a fair location)
+  location: Location
+
+  # An image representing the show, or a sharable image from an artwork in the show
+  meta_image: Image
+
+  # Is the user following this show
+  is_followed: Boolean
+
+  # The exhibition title
+  name: String
+
+  # Shows that are near (~75km) from this show
+  nearbyShows(
+    sort: PartnerShowSorts
+
+    # By default show only current shows
+    status: EventStatus = CURRENT
+
+    # Whether to include local discovery stubs as well as displayable shows
+    discoverable: Boolean
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ShowConnection
+
+  # Alternate Markdown-supporting free text representation of the opening reception event’s date/time
+  openingReceptionText: String
+
+  # The partner that represents this show, could be a non-Artsy partner
+  partner: PartnerTypes
+
+  # The press release for this show
+  press_release(format: Format): String
+
+  # Link to the press release for this show
+  pressReleaseUrl: String
+
+  # When this show starts
+  start_at(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
+
+  # Is this show running, upcoming or closed?
+  status: String
+
+  # A formatted update on upcoming status changes
+  status_update(
+    # Before this many days no update will be generated
+    max_days: Int
+  ): String
+
+  # Is it a fair booth or a show?
+  type: String
+
+  # A Connection of followed artists by current user for this show
+  followedArtists(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ShowFollowArtistConnection
 }
 
 # An edge in a connection.
@@ -2222,7 +2253,7 @@ type ArtworkItem implements Node & Searchable & Sellable {
     active: Boolean
     at_a_fair: Boolean
     sort: PartnerShowSorts
-  ): PartnerShow
+  ): Show
   shows(
     size: Int
     active: Boolean

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1290,6 +1290,7 @@ type ArtworkConnection {
 union ArtworkContext =
     ArtworkContextAuction
   | ArtworkContextFair
+  | ArtworkContextPartnerShow
   | ArtworkContextShow
   | ArtworkContextSale
 
@@ -1560,6 +1561,206 @@ type ArtworkContextFair {
     keyword_match_exact: Boolean
   ): FilterArtworks
   sponsoredContent: FairSponsoredContent
+}
+
+type ArtworkContextPartnerShow implements Node {
+  # A globally unique ID.
+  __id: ID!
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # A type-specific ID.
+  id: ID!
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # A type-specific Gravity Mongo Document ID.
+  _id: ID!
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  cached: Int
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  artists: [Artist]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # The artworks featured in the show
+  artworks(
+    # List of artwork IDs to exclude from the response (irrespective of size)
+    exclude: [String]
+    for_sale: Boolean
+    published: Boolean = true
+    all: Boolean
+    page: Int = 1
+
+    # Number of artworks to return
+    size: Int = 25
+  ): [Artwork]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # A connection of artworks featured in the show
+  artworksConnection(
+    # List of artwork IDs to exclude from the response (irrespective of size)
+    exclude: [String]
+    for_sale: Boolean
+    published: Boolean = true
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtworkConnection
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  counts: PartnerShowCounts
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  cover_image: Image
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  created_at(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  description: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  displayable: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  end_at(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  events: [PartnerShowEventType]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # A formatted description of the start to end dates
+  exhibition_period: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  fair: Fair
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  href: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  images(
+    # Number of images to return
+    size: Int
+
+    # Pass true/false to include cover or not
+    default: Boolean
+    page: Int
+  ): [Image]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # Flag showing if show has any location.
+  has_location: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # Gravity doesn’t expose the `active` flag. Temporarily re-state its logic.
+  is_active: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  is_displayable: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  is_fair_booth: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  kind: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  location: Location
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  meta_image: Image
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # The exhibition title
+  name: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  partner: Partner
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  press_release(format: Format): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  start_at(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  status: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # A formatted update on upcoming status changes
+  status_update(
+    # Before this many days no update will be generated
+    max_days: Int
+  ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  type: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 }
 
 type ArtworkContextSale implements Node {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1290,6 +1290,7 @@ type ArtworkConnection {
 union ArtworkContext =
     ArtworkContextAuction
   | ArtworkContextFair
+  | ArtworkContextPartnerShow
   | ArtworkContextShow
   | ArtworkContextSale
 
@@ -1560,6 +1561,206 @@ type ArtworkContextFair {
     keyword_match_exact: Boolean
   ): FilterArtworks
   sponsoredContent: FairSponsoredContent
+}
+
+type ArtworkContextPartnerShow implements Node {
+  # A globally unique ID.
+  id: ID!
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # A type-specific ID.
+  gravityID: ID!
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # A type-specific Gravity Mongo Document ID.
+  internalID: ID!
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  cached: Int
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  artists: [Artist]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # The artworks featured in the show
+  artworks(
+    # List of artwork IDs to exclude from the response (irrespective of size)
+    exclude: [String]
+    for_sale: Boolean
+    published: Boolean = true
+    all: Boolean
+    page: Int = 1
+
+    # Number of artworks to return
+    size: Int = 25
+  ): [Artwork]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # A connection of artworks featured in the show
+  artworksConnection(
+    # List of artwork IDs to exclude from the response (irrespective of size)
+    exclude: [String]
+    for_sale: Boolean
+    published: Boolean = true
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtworkConnection
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  counts: PartnerShowCounts
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  cover_image: Image
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  created_at(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  description: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  displayable: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  end_at(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  events: [PartnerShowEventType]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # A formatted description of the start to end dates
+  exhibition_period: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  fair: Fair
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  href: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  images(
+    # Number of images to return
+    size: Int
+
+    # Pass true/false to include cover or not
+    default: Boolean
+    page: Int
+  ): [Image]
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # Flag showing if show has any location.
+  has_location: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # Gravity doesn’t expose the `active` flag. Temporarily re-state its logic.
+  is_active: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  is_displayable: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  is_fair_booth: Boolean
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  kind: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  location: Location
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  meta_image: Image
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # The exhibition title
+  name: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  partner: Partner
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  press_release(format: Format): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  start_at(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  status: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # A formatted update on upcoming status changes
+  status_update(
+    # Before this many days no update will be generated
+    max_days: Int
+  ): String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+  type: String
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
 }
 
 type ArtworkContextSale implements Node {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1227,7 +1227,7 @@ type Artwork implements Node & Searchable & Sellable {
     active: Boolean
     at_a_fair: Boolean
     sort: PartnerShowSorts
-  ): PartnerShow
+  ): Show
   shows(
     size: Int
     active: Boolean
@@ -1290,7 +1290,7 @@ type ArtworkConnection {
 union ArtworkContext =
     ArtworkContextAuction
   | ArtworkContextFair
-  | ArtworkContextPartnerShow
+  | ArtworkContextShow
   | ArtworkContextSale
 
 type ArtworkContextAuction implements Node {
@@ -1562,206 +1562,6 @@ type ArtworkContextFair {
   sponsoredContent: FairSponsoredContent
 }
 
-type ArtworkContextPartnerShow implements Node {
-  # A globally unique ID.
-  id: ID!
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # A type-specific ID.
-  gravityID: ID!
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # A type-specific Gravity Mongo Document ID.
-  internalID: ID!
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  cached: Int
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  artists: [Artist]
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # The artworks featured in the show
-  artworks(
-    # List of artwork IDs to exclude from the response (irrespective of size)
-    exclude: [String]
-    for_sale: Boolean
-    published: Boolean = true
-    all: Boolean
-    page: Int = 1
-
-    # Number of artworks to return
-    size: Int = 25
-  ): [Artwork]
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # A connection of artworks featured in the show
-  artworksConnection(
-    # List of artwork IDs to exclude from the response (irrespective of size)
-    exclude: [String]
-    for_sale: Boolean
-    published: Boolean = true
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): ArtworkConnection
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  counts: PartnerShowCounts
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  cover_image: Image
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  created_at(
-    # This arg is deprecated, use timezone instead
-    convert_to_utc: Boolean
-    format: String
-
-    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
-    timezone: String
-  ): String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  description: String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  displayable: Boolean
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  end_at(
-    # This arg is deprecated, use timezone instead
-    convert_to_utc: Boolean
-    format: String
-
-    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
-    timezone: String
-  ): String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  events: [PartnerShowEventType]
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # A formatted description of the start to end dates
-  exhibition_period: String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  fair: Fair
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  href: String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  images(
-    # Number of images to return
-    size: Int
-
-    # Pass true/false to include cover or not
-    default: Boolean
-    page: Int
-  ): [Image]
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # Flag showing if show has any location.
-  has_location: Boolean
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # Gravity doesn’t expose the `active` flag. Temporarily re-state its logic.
-  is_active: Boolean
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  is_displayable: Boolean
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  is_fair_booth: Boolean
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  kind: String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  location: Location
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  meta_image: Image
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # The exhibition title
-  name: String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  partner: Partner
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  press_release(format: Format): String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  start_at(
-    # This arg is deprecated, use timezone instead
-    convert_to_utc: Boolean
-    format: String
-
-    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
-    timezone: String
-  ): String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  status: String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # A formatted update on upcoming status changes
-  status_update(
-    # Before this many days no update will be generated
-    max_days: Int
-  ): String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-  type: String
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-}
-
 type ArtworkContextSale implements Node {
   # A globally unique ID.
   id: ID!
@@ -1891,6 +1691,237 @@ type ArtworkContextSale implements Node {
   status: String
   sale_artwork(id: String!): SaleArtwork
   symbol: String
+}
+
+type ArtworkContextShow implements Node {
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
+
+  # A type-specific Gravity Mongo Document ID.
+  internalID: ID!
+  cached: Int
+
+  # The Artists presenting in this show
+  artists: [Artist]
+
+  # The artworks featured in this show
+  artworks(
+    # List of artwork IDs to exclude from the response (irrespective of size)
+    exclude: [String]
+    for_sale: Boolean
+    published: Boolean = true
+    all: Boolean
+    page: Int = 1
+
+    # Number of artworks to return
+    size: Int = 25
+  ): [Artwork]
+    @deprecated(
+      reason: "Prefer to use `artworks_connection`. [Will be removed in v2]"
+    )
+
+  # The artworks featured in the show
+  artworks_connection(
+    # List of artwork IDs to exclude from the response (irrespective of size)
+    exclude: [String]
+    for_sale: Boolean
+    published: Boolean = true
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtworkConnection
+
+  # Artists inside the show who do not have artworks present
+  artists_without_artworks: [Artist]
+
+  # Artists in the show grouped by last name
+  artists_grouped_by_name: [ArtistGroup]
+
+  # The general city, derived from a fair location, a show location or a potential city
+  city: String
+
+  # The image you should use to represent this show
+  cover_image: Image
+
+  # An object that represents some of the numbers you might want to highlight
+  counts: ShowCounts
+
+  # A description of the show
+  description: String
+  displayable: Boolean
+    @deprecated(
+      reason: "Prefer to use `is_displayable`. [Will be removed in v2]"
+    )
+  end_at(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
+
+  # Events from the partner that runs this show
+  events: [PartnerShowEventType]
+
+  # A formatted description of the start to end dates
+  exhibition_period: String
+
+  # If the show is in a Fair, then that fair
+  fair: Fair
+
+  # Artworks Elastic Search results
+  filteredArtworks(
+    acquireable: Boolean
+    offerable: Boolean
+    aggregation_partner_cities: [String]
+    aggregations: [ArtworkAggregation]
+    artist_id: String
+    artist_ids: [String]
+    at_auction: Boolean
+    attribution_class: [String]
+    color: String
+    dimension_range: String
+    extra_aggregation_gene_ids: [String]
+    include_artworks_by_followed_artists: Boolean
+    include_medium_filter_in_aggregation: Boolean
+    inquireable_only: Boolean
+    for_sale: Boolean
+    gene_id: String
+    gene_ids: [String]
+    height: String
+    width: String
+
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
+
+    # A string from the list of allocations, or * to denote all mediums
+    medium: String
+    period: String
+    periods: [String]
+    major_periods: [String]
+    partner_id: ID
+    partner_cities: [String]
+    price_range: String
+    page: Int
+    sale_id: ID
+    size: Int
+    sort: String
+    tag_id: String
+    keyword: String
+
+    # When true, will only return exact keyword match
+    keyword_match_exact: Boolean
+  ): FilterArtworks
+
+  # A path to the show on Artsy
+  href: String
+
+  # Images that represent the show, you may be interested in meta_image or cover_image for a definitive thumbnail
+  images(
+    # Number of images to return
+    size: Int
+
+    # Pass true/false to include cover or not
+    default: Boolean
+    page: Int
+  ): [Image]
+
+  # Flag showing if show has any location.
+  has_location: Boolean
+
+  # Gravity doesn’t expose the `active` flag. Temporarily re-state its logic.
+  is_active: Boolean
+
+  # Is this something we can display to the front-end?
+  is_displayable: Boolean
+
+  # Does the show exist as a fair booth?
+  is_fair_booth: Boolean
+
+  # Is it a show provided for historical reference?
+  is_reference: Boolean
+  is_local_discovery: Boolean
+    @deprecated(reason: "Prefer to use `isStubShow`. [Will be removed in v2]")
+
+  # Is it an outsourced local discovery stub show?
+  isStubShow: Boolean
+
+  # Whether the show is in a fair, group or solo
+  kind: String
+
+  # Where the show is located (Could also be a fair location)
+  location: Location
+
+  # An image representing the show, or a sharable image from an artwork in the show
+  meta_image: Image
+
+  # Is the user following this show
+  is_followed: Boolean
+
+  # The exhibition title
+  name: String
+
+  # Shows that are near (~75km) from this show
+  nearbyShows(
+    sort: PartnerShowSorts
+
+    # By default show only current shows
+    status: EventStatus = CURRENT
+
+    # Whether to include local discovery stubs as well as displayable shows
+    discoverable: Boolean
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ShowConnection
+
+  # Alternate Markdown-supporting free text representation of the opening reception event’s date/time
+  openingReceptionText: String
+
+  # The partner that represents this show, could be a non-Artsy partner
+  partner: PartnerTypes
+
+  # The press release for this show
+  press_release(format: Format): String
+
+  # Link to the press release for this show
+  pressReleaseUrl: String
+
+  # When this show starts
+  start_at(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
+
+  # Is this show running, upcoming or closed?
+  status: String
+
+  # A formatted update on upcoming status changes
+  status_update(
+    # Before this many days no update will be generated
+    max_days: Int
+  ): String
+
+  # Is it a fair booth or a show?
+  type: String
+
+  # A Connection of followed artists by current user for this show
+  followedArtists(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ShowFollowArtistConnection
 }
 
 # An edge in a connection.
@@ -2222,7 +2253,7 @@ type ArtworkItem implements Node & Searchable & Sellable {
     active: Boolean
     at_a_fair: Boolean
     sort: PartnerShowSorts
-  ): PartnerShow
+  ): Show
   shows(
     size: Int
     active: Boolean

--- a/src/schema/artwork/context.ts
+++ b/src/schema/artwork/context.ts
@@ -1,6 +1,7 @@
 import { assign, create, first, flow, compact } from "lodash"
 import Fair from "schema/fair"
 import Sale from "schema/sale/index"
+import PartnerShow from "schema/partner_show"
 import { GraphQLUnionType, GraphQLFieldConfig } from "graphql"
 import { ResolverContext } from "types/graphql"
 import Show from "schema/show"
@@ -20,7 +21,12 @@ export const ArtworkContextAuctionType = create(Sale.type, {
   isTypeOf: ({ context_type }) => context_type === "Auction",
 })
 
-export const ArtworkContextPartnerShowType = create(Show.type, {
+export const ArtworkContextPartnerShowType = create(PartnerShow.type, {
+  name: "ArtworkContextPartnerShow",
+  isTypeOf: ({ context_type }) => context_type === "PartnerShow",
+})
+
+export const ArtworkContextShowType = create(Show.type, {
   name: "ArtworkContextShow",
   isTypeOf: ({ context_type }) => context_type === "Show",
 })
@@ -31,6 +37,7 @@ export const ArtworkContextType = new GraphQLUnionType({
     ArtworkContextAuctionType,
     ArtworkContextFairType,
     ArtworkContextPartnerShowType,
+    ArtworkContextShowType,
     ArtworkContextSaleType,
   ],
 })

--- a/src/schema/artwork/context.ts
+++ b/src/schema/artwork/context.ts
@@ -1,9 +1,9 @@
 import { assign, create, first, flow, compact } from "lodash"
 import Fair from "schema/fair"
 import Sale from "schema/sale/index"
-import PartnerShow from "schema/partner_show"
 import { GraphQLUnionType, GraphQLFieldConfig } from "graphql"
 import { ResolverContext } from "types/graphql"
+import Show from "schema/show"
 
 export const ArtworkContextFairType = create(Fair.type, {
   name: "ArtworkContextFair",
@@ -20,9 +20,9 @@ export const ArtworkContextAuctionType = create(Sale.type, {
   isTypeOf: ({ context_type }) => context_type === "Auction",
 })
 
-export const ArtworkContextPartnerShowType = create(PartnerShow.type, {
-  name: "ArtworkContextPartnerShow",
-  isTypeOf: ({ context_type }) => context_type === "PartnerShow",
+export const ArtworkContextPartnerShowType = create(Show.type, {
+  name: "ArtworkContextShow",
+  isTypeOf: ({ context_type }) => context_type === "Show",
 })
 
 export const ArtworkContextType = new GraphQLUnionType({

--- a/src/schema/artwork/index.ts
+++ b/src/schema/artwork/index.ts
@@ -9,6 +9,7 @@ import Image, { getDefault, normalizeImageData } from "schema/image"
 import { setVersion } from "schema/image/normalize"
 import Fair from "schema/fair"
 import Sale from "schema/sale"
+import Show from "schema/show"
 import SaleArtwork from "schema/sale_artwork"
 import { connectionWithCursorInfo } from "schema/fields/pagination"
 import PartnerShow from "schema/partner_show"
@@ -692,7 +693,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       },
       series: markdown(),
       show: {
-        type: PartnerShow.type,
+        type: Show.type,
         args: {
           size: { type: GraphQLInt },
           active: { type: GraphQLBoolean },


### PR DESCRIPTION
Related: 

This PR addresses some deprecations as seen in, namely the `PartnerShow` type should be referencing `Show`:


<img width="1009" alt="Screen Shot 2019-06-14 at 1 20 24 PM" src="https://user-images.githubusercontent.com/236943/59535952-34524400-8ea7-11e9-96be-7a0ccba38c26.png">

@alloy / @zephraph - this relates to some of your recent deprecation work. I'm not sure if i'm missing anything so wanted to tag you both. Note that I **did not** address all of the deprecated `PartnerShow` fields -- only the ones as referenced in Reaction. 