### PR TITLE
Dynamic field fetch take ii

### DIFF
--- a/src/lib/__tests__/hasFieldSelection.test.ts
+++ b/src/lib/__tests__/hasFieldSelection.test.ts
@@ -1,0 +1,118 @@
+import { parse, GraphQLResolveInfo } from "graphql"
+import gql from "lib/gql"
+import {
+  hasFieldSelection,
+  hasIntersectionWithSelectionSet,
+  includesFieldsOtherThanSelectionSet,
+} from "lib/hasFieldSelection"
+
+const ast = parse(gql`
+  fragment Start on Artwork {
+    id
+    ...TestEditionSet
+  }
+  fragment TestEditionSet on Artwork {
+    edition_of
+    edition_sets {
+      id
+    }
+  }
+`)
+
+const [firstNode, ...otherNodes] = ast.definitions as any
+let fragments = {}
+otherNodes.map(node => {
+  fragments[node.name.value] = node
+})
+
+const info: GraphQLResolveInfo = {
+  fieldNodes: [firstNode],
+  fragments: fragments,
+} as any
+
+const multipleFieldNodes = parse(gql`
+  query {
+    viewer {
+      ...CollectApp_viewer_3XOIsA
+    }
+  }
+
+  fragment CollectApp_viewer_3XOIsA on Viewer {
+    filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {
+      __id
+    }
+    ...CollectFilterContainer_viewer_3XOIsA
+  }
+
+  fragment CollectFilterContainer_viewer_3XOIsA on Viewer {
+    filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {
+      aggregations {
+        slice
+        counts {
+          name
+          id
+          __id
+        }
+      }
+      __id
+    }
+  }
+`)
+
+const [
+  query,
+  firstFragment,
+  secondFragment,
+] = multipleFieldNodes.definitions as any
+
+let fragmentDefs = [firstFragment, secondFragment]
+let multipleFieldNodesFragments = {}
+
+fragmentDefs.map(node => {
+  multipleFieldNodesFragments[node.name.value] = node
+})
+
+const multipleFieldNodesInfo: GraphQLResolveInfo = {
+  fieldNodes: [query, secondFragment],
+  fragments: multipleFieldNodesFragments,
+} as any
+
+describe("hasFieldSelection", () => {
+  it("returns correct response based on match function", () => {
+    const matchByName = nodeName => nodeName === "edition_of"
+    expect(hasFieldSelection(info, matchByName)).toEqual(true)
+
+    const matchByRandomName = nodeName => nodeName === "random"
+    expect(hasFieldSelection(info, matchByRandomName)).toEqual(false)
+  })
+})
+
+describe("hasIntersectionWithSelectionSet", () => {
+  it("returns correct response based on match function", () => {
+    expect(
+      hasIntersectionWithSelectionSet(info, ["edition_of", "random"])
+    ).toEqual(true)
+
+    expect(hasIntersectionWithSelectionSet(info, ["random"])).toEqual(false)
+  })
+})
+
+describe("includesFieldsOtherThanSelectionSet", () => {
+  it("returns true when asked for other fields other than filtered", () => {
+    expect(
+      includesFieldsOtherThanSelectionSet(multipleFieldNodesInfo, [
+        "edition_of",
+        "random",
+      ])
+    ).toEqual(true)
+  })
+
+  it("returns false when not asked for other fields other than filters", () => {
+    expect(
+      includesFieldsOtherThanSelectionSet(multipleFieldNodesInfo, [
+        "__id",
+        "aggregations",
+      ])
+    ).toEqual(false)
+  })
+})

--- a/src/lib/hasFieldSelection.ts
+++ b/src/lib/hasFieldSelection.ts
@@ -1,0 +1,61 @@
+/* eslint-disable require-yield */
+
+import {
+  FieldNode,
+  visit,
+  FragmentDefinitionNode,
+  BREAK,
+  GraphQLResolveInfo,
+} from "graphql"
+
+export const hasFieldSelection = (
+  resolveInfo: GraphQLResolveInfo,
+  match: (fieldName: string) => boolean
+): boolean => {
+  if (!resolveInfo.fieldNodes) return false
+  // TODO: we only check first field node from the fields
+  // this is fine in general but to fully support we may need to revisit later
+  let matched: boolean = false
+
+  const visitor = (
+    fieldNode: FieldNode | FragmentDefinitionNode,
+    fragments?: { [key: string]: FragmentDefinitionNode }
+  ): void => {
+    visit(fieldNode, {
+      Field(node, _key, _parent, path, _ancestors) {
+        if (path.length > 3) {
+          return false
+        }
+        if (path.length === 3 && match(node.name.value)) {
+          matched = true
+          return BREAK
+        }
+      },
+      FragmentSpread(node) {
+        const fragmentDef = resolveInfo.fragments[node.name.value]
+        visitor(fragmentDef, fragments)
+      },
+    })
+  }
+  resolveInfo.fieldNodes.map(f => visitor(f))
+  return matched
+}
+
+export const hasIntersectionWithSelectionSet = (
+  resolveInfo: GraphQLResolveInfo,
+  fieldNames: string[]
+): boolean => {
+  return hasFieldSelection(resolveInfo, nodeName =>
+    fieldNames.includes(nodeName)
+  )
+}
+
+export const includesFieldsOtherThanSelectionSet = (
+  resolveInfo: GraphQLResolveInfo,
+  fieldNames: string[]
+): boolean => {
+  return hasFieldSelection(
+    resolveInfo,
+    nodeName => !fieldNames.includes(nodeName)
+  )
+}

--- a/src/lib/hasFieldSelection.ts
+++ b/src/lib/hasFieldSelection.ts
@@ -8,35 +8,45 @@ import {
   GraphQLResolveInfo,
 } from "graphql"
 
+const SELECTION_DEPTH_THRESHOLD = 3
+
 export const hasFieldSelection = (
   resolveInfo: GraphQLResolveInfo,
   match: (fieldName: string) => boolean
 ): boolean => {
-  if (!resolveInfo.fieldNodes) return false
-  let matched: boolean = false
+  if (!resolveInfo.fieldNodes) return true
 
-  const visitor = (
-    fieldNode: FieldNode | FragmentDefinitionNode,
-    fragments?: { [key: string]: FragmentDefinitionNode }
-  ): void => {
-    visit(fieldNode, {
-      Field(node, _key, _parent, path, _ancestors) {
-        if (path.length > 3) {
-          return false
-        }
-        if (path.length === 3 && match(node.name.value)) {
-          matched = true
-          return BREAK
-        }
-      },
-      FragmentSpread(node) {
-        const fragmentDef = resolveInfo.fragments[node.name.value]
-        visitor(fragmentDef, fragments)
-      },
-    })
-  }
-  resolveInfo.fieldNodes.map(f => visitor(f))
-  return matched
+  return resolveInfo.fieldNodes.some(rootNode => {
+    let matched: boolean = false
+
+    const visitor = (
+      fieldNode: FieldNode | FragmentDefinitionNode,
+      fragments?: { [key: string]: FragmentDefinitionNode }
+    ): void => {
+      visit(fieldNode, {
+        Field(node, _key, _parent, path, _ancestors) {
+          // Stop recursion for nodes deeper than our threshold
+          if (path.length > SELECTION_DEPTH_THRESHOLD) {
+            return false
+          }
+          if (
+            path.length === SELECTION_DEPTH_THRESHOLD &&
+            match(node.name.value)
+          ) {
+            matched = true
+            return BREAK
+          }
+        },
+        FragmentSpread(node) {
+          const fragmentDef = resolveInfo.fragments[node.name.value]
+          visitor(fragmentDef, fragments)
+        },
+      })
+    }
+    visitor(rootNode)
+
+    return matched
+  })
 }
 
 export const hasIntersectionWithSelectionSet = (

--- a/src/lib/hasFieldSelection.ts
+++ b/src/lib/hasFieldSelection.ts
@@ -13,8 +13,6 @@ export const hasFieldSelection = (
   match: (fieldName: string) => boolean
 ): boolean => {
   if (!resolveInfo.fieldNodes) return false
-  // TODO: we only check first field node from the fields
-  // this is fine in general but to fully support we may need to revisit later
   let matched: boolean = false
 
   const visitor = (


### PR DESCRIPTION
# Problem
Once we deployed #1761 , `/collect` page broke.

# Cause
Thanks to @mzikherman we found the breaking query:
```graphql
query {
  viewer {
    ...CollectApp_viewer_3XOIsA
  }
}

fragment CollectApp_viewer_3XOIsA on Viewer {
  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {
    __id
  }
  ...CollectFilterContainer_viewer_3XOIsA
}

fragment CollectFilterContainer_viewer_3XOIsA on Viewer {
  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {
    aggregations {
      slice
      counts {
        name
        id
        __id
      }
    }
    __id
  }
}
```
Trying things locally, we found out that the fact that we limited visiting nodes only to  `fieldNodes[0]` in this specific query we were not traversing `CollectFilterContainer_viewer_3XOIsA`. 

# Solution
The fix here was to traverse all `fieldNodes` instead of only the first one.

## Do I need help?
YES! i wrote a test for this but having hard time getting it to work since I don't think my way of creating `GraphQLResolveInfo` is correct in this approach. 