### PR TITLE
Adds new fields to Auction and creates new date fields

### DIFF
--- a/src/lib/__tests__/date.test.ts
+++ b/src/lib/__tests__/date.test.ts
@@ -5,9 +5,11 @@ import {
   exhibitionStatus,
   dateTimeRange,
   singleDate,
+  singleDateWithDay,
   singleDateTime,
   singleTime,
   formattedOpeningHours,
+  formattedStartingHours,
   datesAreSameDay,
   timeRange,
 } from "lib/date"
@@ -77,6 +79,43 @@ describe("date formatting", () => {
         "America/New_York"
       )
       expect(period).toBe(false)
+    })
+  })
+
+  describe(formattedStartingHours, () => {
+    const realNow = Date.now
+    beforeEach(() => {
+      Date.now = () => new Date("2018-01-30T03:24:00") as any
+    })
+    afterEach(() => {
+      Date.now = realNow
+    })
+
+    it("includes 'Starts' when event starts in the future", () => {
+      const period = formattedStartingHours(
+        "2021-12-05T20:00:00+00:00",
+        "2022-12-30T17:00:00+00:00",
+        "UTC"
+      )
+      expect(period).toBe("Starts Dec 5 at 8:00pm UTC")
+    })
+
+    it("includes 'Ends' when event is running and terminates in the future", () => {
+      const period = formattedStartingHours(
+        "2017-12-05T20:00:00+00:00",
+        "2019-12-30T17:00:00+00:00",
+        "UTC"
+      )
+      expect(period).toBe("Ends Dec 30 at 5:00pm UTC")
+    })
+
+    it("includes 'Ended' when event ended in the past and is closed", () => {
+      const period = formattedStartingHours(
+        "2016-12-05T20:00:00+00:00",
+        "2016-12-30T17:00:00+00:00",
+        "UTC"
+      )
+      expect(period).toBe("Ended")
     })
   })
 
@@ -166,13 +205,33 @@ describe("date formatting", () => {
       Date.now = realNow
     })
 
-    it("includes single date with only day of week and month day when in current year", () => {
+    it("includes single date with month day when in current year", () => {
       const period = singleDate("2018-12-05T20:00:00+00:00", "UTC")
-      expect(period).toBe("Wed, Dec 5")
+      expect(period).toBe("Dec 5")
     })
 
     it("also includes the year when not in current year", () => {
       const period = singleDate("2021-12-05T20:00:00+00:00", "UTC")
+      expect(period).toBe("Dec 5, 2021")
+    })
+  })
+
+  describe(singleDateWithDay, () => {
+    const realNow = Date.now
+    beforeEach(() => {
+      Date.now = () => new Date("2018-01-30T03:24:00") as any
+    })
+    afterEach(() => {
+      Date.now = realNow
+    })
+
+    it("includes single date with only day of week and month day when in current year", () => {
+      const period = singleDateWithDay("2018-12-05T20:00:00+00:00", "UTC")
+      expect(period).toBe("Wed, Dec 5")
+    })
+
+    it("also includes the year when not in current year", () => {
+      const period = singleDateWithDay("2021-12-05T20:00:00+00:00", "UTC")
       expect(period).toBe("Sun, Dec 5, 2021")
     })
   })

--- a/src/lib/__tests__/date.test.ts
+++ b/src/lib/__tests__/date.test.ts
@@ -9,7 +9,7 @@ import {
   singleDateTime,
   singleTime,
   formattedOpeningHours,
-  formattedStartingHours,
+  formattedStartDateTime,
   datesAreSameDay,
   timeRange,
 } from "lib/date"
@@ -82,7 +82,7 @@ describe("date formatting", () => {
     })
   })
 
-  describe(formattedStartingHours, () => {
+  describe(formattedStartDateTime, () => {
     const realNow = Date.now
     beforeEach(() => {
       Date.now = () => new Date("2018-01-30T03:24:00") as any
@@ -92,30 +92,30 @@ describe("date formatting", () => {
     })
 
     it("includes 'Starts' when event starts in the future", () => {
-      const period = formattedStartingHours(
-        "2021-12-05T20:00:00+00:00",
-        "2022-12-30T17:00:00+00:00",
+      const period = formattedStartDateTime(
+        "2045-12-05T20:00:00+00:00",
+        "2050-12-30T17:00:00+00:00",
         "UTC"
       )
-      expect(period).toBe("Starts Dec 5 at 8:00pm UTC")
+      expect(period).toBe("Starts Dec 5, 2045 at 8:00pm UTC")
     })
 
     it("includes 'Ends' when event is running and terminates in the future", () => {
-      const period = formattedStartingHours(
+      const period = formattedStartDateTime(
         "2017-12-05T20:00:00+00:00",
-        "2019-12-30T17:00:00+00:00",
+        "2045-12-30T17:00:00+00:00",
         "UTC"
       )
-      expect(period).toBe("Ends Dec 30 at 5:00pm UTC")
+      expect(period).toBe("Ends Dec 30, 2045 at 5:00pm UTC")
     })
 
-    it("includes 'Ended' when event ended in the past and is closed", () => {
-      const period = formattedStartingHours(
+    it("includes 'Ended on date' when event ended in the past and is now closed", () => {
+      const period = formattedStartDateTime(
         "2016-12-05T20:00:00+00:00",
         "2016-12-30T17:00:00+00:00",
         "UTC"
       )
-      expect(period).toBe("Ended")
+      expect(period).toBe("Ended Dec 30, 2016")
     })
   })
 
@@ -130,20 +130,20 @@ describe("date formatting", () => {
 
     it("includes 'Opens' when event opens in the future", () => {
       const period = formattedOpeningHours(
-        "2021-12-05T20:00:00+00:00",
-        "2022-12-30T17:00:00+00:00",
+        "2045-12-05T20:00:00+00:00",
+        "2046-12-30T17:00:00+00:00",
         "UTC"
       )
-      expect(period).toBe("Opens Dec 5 at 8:00pm UTC")
+      expect(period).toBe("Opens Dec 5, 2045 at 8:00pm UTC")
     })
 
     it("includes 'Closes' when event is running and closes in the future", () => {
       const period = formattedOpeningHours(
         "2017-12-05T20:00:00+00:00",
-        "2019-12-30T17:00:00+00:00",
+        "2045-12-30T17:00:00+00:00",
         "UTC"
       )
-      expect(period).toBe("Closes Dec 30 at 5:00pm UTC")
+      expect(period).toBe("Closes Dec 30, 2045 at 5:00pm UTC")
     })
 
     it("includes 'Closed' when event ended in the past and is closed", () => {

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,21 +1,6 @@
 import moment from "moment"
 
 /**
- * Jan 5 at 5:00pm
- * Jan 15 at 5:30pm
- */
-const formattedOpeningHoursDate = (date, timezone) => {
-  const momentToUse = moment.tz(date, timezone)
-  const momentDate = momentToUse.format("MMM D")
-  const momentHour = momentToUse.format("h:mma z")
-  if (momentHour && momentDate) {
-    return `${momentDate} at ${momentHour}`
-  } else if (momentDate) {
-    return momentDate
-  }
-}
-
-/**
  * Returns true if dates are on same day, timezone must be the same for both timestamps
  */
 export function datesAreSameDay(startAt, endAt, timezone) {
@@ -256,9 +241,9 @@ export function formattedOpeningHours(startAt, endAt, timezone) {
   const startMoment = moment.tz(startAt, timezone)
   const endMoment = moment.tz(endAt, timezone)
   if (thisMoment.isBefore(startMoment)) {
-    return `Opens ${formattedOpeningHoursDate(startAt, timezone)}`
+    return `Opens ${singleDateTime(startAt, timezone)}`
   } else if (thisMoment.isBefore(endMoment)) {
-    return `Closes ${formattedOpeningHoursDate(endAt, timezone)}`
+    return `Closes ${singleDateTime(endAt, timezone)}`
   } else {
     return "Closed"
   }
@@ -267,17 +252,17 @@ export function formattedOpeningHours(startAt, endAt, timezone) {
 /**
  * Starts Mar 29 at 4:00pm
  * Ends Apr 3 at 12:30pm
- * Ended
+ * Ended Apr 3 2017
  */
-export function formattedStartingHours(startAt, endAt, timezone) {
+export function formattedStartDateTime(startAt, endAt, timezone) {
   const thisMoment = moment()
   const startMoment = moment.tz(startAt, timezone)
   const endMoment = moment.tz(endAt, timezone)
   if (thisMoment.isBefore(startMoment)) {
-    return `Starts ${formattedOpeningHoursDate(startAt, timezone)}`
+    return `Starts ${singleDateTime(startAt, timezone)}`
   } else if (thisMoment.isBefore(endMoment)) {
-    return `Ends ${formattedOpeningHoursDate(endAt, timezone)}`
+    return `Ends ${singleDateTime(endAt, timezone)}`
   } else {
-    return "Ended"
+    return `Ended ${singleDate(endAt, timezone)}`
   }
 }

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -78,10 +78,24 @@ export function singleDateTime(date, timezone) {
 }
 
 /**
+ * Apr 24
+ * if not this year:  April 24, 2022
+ */
+export function singleDate(date, timezone) {
+  const thisMoment = moment.tz(date, timezone)
+  const now = moment()
+  if (now.year() !== thisMoment.year()) {
+    return `${thisMoment.format("MMM D, YYYY")}`
+  } else {
+    return `${thisMoment.format("MMM D")}`
+  }
+}
+
+/**
  * Wed, Apr 24
  * if not this year:   Wed, April 24, 2022
  */
-export function singleDate(date, timezone) {
+export function singleDateWithDay(date, timezone) {
   const thisMoment = moment.tz(date, timezone)
   const now = moment()
   if (now.year() !== thisMoment.year()) {
@@ -247,5 +261,23 @@ export function formattedOpeningHours(startAt, endAt, timezone) {
     return `Closes ${formattedOpeningHoursDate(endAt, timezone)}`
   } else {
     return "Closed"
+  }
+}
+
+/**
+ * Starts Mar 29 at 4:00pm
+ * Ends Apr 3 at 12:30pm
+ * Ended
+ */
+export function formattedStartingHours(startAt, endAt, timezone) {
+  const thisMoment = moment()
+  const startMoment = moment.tz(startAt, timezone)
+  const endMoment = moment.tz(endAt, timezone)
+  if (thisMoment.isBefore(startMoment)) {
+    return `Starts ${formattedOpeningHoursDate(startAt, timezone)}`
+  } else if (thisMoment.isBefore(endMoment)) {
+    return `Ends ${formattedOpeningHoursDate(endAt, timezone)}`
+  } else {
+    return "Ended"
   }
 }

--- a/src/schema/sale/index.ts
+++ b/src/schema/sale/index.ts
@@ -8,7 +8,7 @@ import initials from "schema/fields/initials"
 import cached from "schema/fields/cached"
 import date from "schema/fields/date"
 import moment from "moment"
-import { formattedStartingHours } from "lib/date"
+import { formattedStartDateTime } from "lib/date"
 import { GravityIDFields } from "schema/object_identification"
 import { pageable, getPagingParameters } from "relay-cursor-paging"
 import { connectionFromArraySlice, connectionDefinitions } from "graphql-relay"
@@ -205,12 +205,12 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
       end_at: date,
       event_start_at: date,
       event_end_at: date,
-      formattedStartingHours: {
+      formattedStartDateTime: {
         type: GraphQLString,
         description:
           "A formatted description of when the auction starts or ends or if it has ended",
         resolve: ({ start_at, end_at }) =>
-          formattedStartingHours(start_at, end_at, "UTC"),
+          formattedStartDateTime(start_at, end_at, "UTC"),
       },
       href: { type: GraphQLString, resolve: ({ id }) => `/auction/${id}` },
       name: { type: GraphQLString },

--- a/src/schema/sale/index.ts
+++ b/src/schema/sale/index.ts
@@ -4,9 +4,11 @@ import Image from "schema/image/index"
 import Profile from "schema/profile"
 import Partner from "schema/partner"
 import SaleArtwork from "schema/sale_artwork"
+import initials from "schema/fields/initials"
 import cached from "schema/fields/cached"
 import date from "schema/fields/date"
 import moment from "moment"
+import { formattedStartingHours } from "lib/date"
 import { GravityIDFields } from "schema/object_identification"
 import { pageable, getPagingParameters } from "relay-cursor-paging"
 import { connectionFromArraySlice, connectionDefinitions } from "graphql-relay"
@@ -203,8 +205,16 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
       end_at: date,
       event_start_at: date,
       event_end_at: date,
+      formattedStartingHours: {
+        type: GraphQLString,
+        description:
+          "A formatted description of when the auction starts or ends or if it has ended",
+        resolve: ({ start_at, end_at }) =>
+          formattedStartingHours(start_at, end_at, "UTC"),
+      },
       href: { type: GraphQLString, resolve: ({ id }) => `/auction/${id}` },
       name: { type: GraphQLString },
+      initials: initials("name"),
       is_auction: { type: GraphQLBoolean },
       is_benefit: {
         type: GraphQLBoolean,


### PR DESCRIPTION
-  Adds `formattedStartDateTime` and `initials` to auctions for the `AuctionsEntityItem` (see image below)

![Screen Shot 2019-06-21 at 2 50 16 PM](https://user-images.githubusercontent.com/21182806/59945768-95918e80-9436-11e9-8443-0335489cb517.png)

- Removes unnecessary `formattedOpeningHoursDate` from dates.ts
- Creates `formattedStartDateTime`
- Removes hours displaying from `singleDate` and creates new field `singleDateTime` to show date with hours. `singleDate` isn't used yet, so this fix will have no breaking changes.