### PR TITLE
[WIP] First pass in replacing types on V2

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1407,8 +1407,12 @@ type ArtworkContextAuction implements Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+
+  # A formatted description of when the auction starts or ends or if it has ended
+  formattedStartDateTime: String
   href: String
   name: String
+  initials(length: Int = 3): String
   is_auction: Boolean
   is_benefit: Boolean
     @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")
@@ -1876,8 +1880,12 @@ type ArtworkContextSale implements Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+
+  # A formatted description of when the auction starts or ends or if it has ended
+  formattedStartDateTime: String
   href: String
   name: String
+  initials(length: Int = 3): String
   is_auction: Boolean
   is_benefit: Boolean
     @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")
@@ -6801,8 +6809,12 @@ type HomePageModuleContextSale implements Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+
+  # A formatted description of when the auction starts or ends or if it has ended
+  formattedStartDateTime: String
   href: String
   name: String
+  initials(length: Int = 3): String
   is_auction: Boolean
   is_benefit: Boolean
     @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")
@@ -9899,8 +9911,12 @@ type Sale implements Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+
+  # A formatted description of when the auction starts or ends or if it has ended
+  formattedStartDateTime: String
   href: String
   name: String
+  initials(length: Int = 3): String
   is_auction: Boolean
   is_benefit: Boolean
     @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1275,13 +1275,13 @@ type Artwork implements Node & Searchable & Sellable {
     active: Boolean
     at_a_fair: Boolean
     sort: PartnerShowSorts
-  ): PartnerShow
+  ): Show
   shows(
     size: Int
     active: Boolean
     at_a_fair: Boolean
     sort: PartnerShowSorts
-  ): [PartnerShow]
+  ): [Show]
   signature(format: Format): String
   title: String
   to_s: String
@@ -1407,8 +1407,12 @@ type ArtworkContextAuction implements Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+
+  # A formatted description of when the auction starts or ends or if it has ended
+  formattedStartDateTime: String
   href: String
   name: String
+  initials(length: Int = 3): String
   is_auction: Boolean
   is_benefit: Boolean
     @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")
@@ -1876,8 +1880,12 @@ type ArtworkContextSale implements Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+
+  # A formatted description of when the auction starts or ends or if it has ended
+  formattedStartDateTime: String
   href: String
   name: String
+  initials(length: Int = 3): String
   is_auction: Boolean
   is_benefit: Boolean
     @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")
@@ -2270,13 +2278,13 @@ type ArtworkItem implements Node & Searchable & Sellable {
     active: Boolean
     at_a_fair: Boolean
     sort: PartnerShowSorts
-  ): PartnerShow
+  ): Show
   shows(
     size: Int
     active: Boolean
     at_a_fair: Boolean
     sort: PartnerShowSorts
-  ): [PartnerShow]
+  ): [Show]
   signature(format: Format): String
   title: String
   to_s: String
@@ -6784,8 +6792,12 @@ type HomePageModuleContextSale implements Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+
+  # A formatted description of when the auction starts or ends or if it has ended
+  formattedStartDateTime: String
   href: String
   name: String
+  initials(length: Int = 3): String
   is_auction: Boolean
   is_benefit: Boolean
     @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")
@@ -9427,7 +9439,7 @@ type Query {
   partner_show(
     # The slug or ID of the PartnerShow
     id: String!
-  ): PartnerShow
+  ): Show
 
   # A list of PartnerShows
   partner_shows(
@@ -9446,7 +9458,7 @@ type Query {
     size: Int
     sort: PartnerShowSorts
     status: EventStatus
-  ): [PartnerShow]
+  ): [Show]
 
   # A list of Partners
   partners(
@@ -9871,8 +9883,12 @@ type Sale implements Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+
+  # A formatted description of when the auction starts or ends or if it has ended
+  formattedStartDateTime: String
   href: String
   name: String
+  initials(length: Int = 3): String
   is_auction: Boolean
   is_benefit: Boolean
     @deprecated(reason: "Prefer to use `isBenefit`. [Will be removed in v2]")
@@ -11521,7 +11537,7 @@ type Viewer {
   partner_show(
     # The slug or ID of the PartnerShow
     id: String!
-  ): PartnerShow
+  ): Show
 
   # A list of PartnerShows
   partner_shows(
@@ -11540,7 +11556,7 @@ type Viewer {
     size: Int
     sort: PartnerShowSorts
     status: EventStatus
-  ): [PartnerShow]
+  ): [Show]
 
   # A list of Partners
   partners(

--- a/src/schema/v2/ReplaceType.ts
+++ b/src/schema/v2/ReplaceType.ts
@@ -1,0 +1,140 @@
+import { Transform, Request } from "graphql-tools"
+import {
+  GraphQLSchema,
+  GraphQLObjectType,
+  GraphQLInterfaceType,
+  GraphQLFieldConfigMap,
+  GraphQLField,
+  TypeInfo,
+  visit,
+  visitWithTypeInfo,
+  Kind,
+  getNamedType,
+  isLeafType,
+  GraphQLUnionType,
+} from "graphql"
+import {
+  visitSchema,
+  VisitSchemaKind,
+  TypeVisitor,
+} from "graphql-tools/dist/transforms/visitSchema"
+import {
+  createResolveType,
+  fieldToFieldConfig,
+} from "graphql-tools/dist/stitching/schemaRecreation"
+import Show from "schema/show"
+
+type TypeWithSelectableFields =
+  | GraphQLObjectType<any, any>
+  | GraphQLInterfaceType
+
+interface ReplaceTypeMap {
+  [oldType: string]: {
+    newTypeName: string
+    type: TypeWithSelectableFields
+  }
+}
+
+export class ReplaceType implements Transform {
+  private newSchema?: GraphQLSchema
+  private changedFields: { [fieldName: string]: string }
+  private typesToReplace: ReplaceTypeMap
+
+  constructor(input: ReplaceTypeMap) {
+    this.changedFields = {}
+    this.typesToReplace = input
+  }
+
+  public transformSchema(schema: GraphQLSchema): GraphQLSchema {
+    const newSchema = visitSchema(schema, {
+      [VisitSchemaKind.OBJECT_TYPE]: ((type: GraphQLObjectType<any, any>) => {
+        const fields = this.transformFields(type)
+        return (
+          fields &&
+          new GraphQLObjectType({
+            fields,
+            name: type.name,
+            description: type.description,
+            astNode: type.astNode,
+            extensionASTNodes: type.extensionASTNodes,
+            isTypeOf: type.isTypeOf,
+            interfaces: type.getInterfaces(),
+          })
+        )
+      }) as TypeVisitor,
+
+      [VisitSchemaKind.INTERFACE_TYPE]: ((type: GraphQLInterfaceType) => {
+        const fields = this.transformFields(type)
+        return (
+          fields &&
+          new GraphQLInterfaceType({
+            fields,
+            name: type.name,
+            description: type.description,
+            astNode: type.astNode,
+            resolveType: type.resolveType,
+            extensionASTNodes: type.extensionASTNodes,
+          })
+        )
+      }) as TypeVisitor,
+    })
+
+    this.newSchema = newSchema
+    return newSchema
+  }
+
+  private transformFields(type: TypeWithSelectableFields) {
+    let madeChanges = false
+    const fields = type.getFields()
+    const newFields: GraphQLFieldConfigMap<any, any> = {}
+    const replacementTypes = Object.keys(this.typesToReplace)
+    const resolveType = createResolveType((name, type) => {
+      if (replacementTypes.includes(name)) {
+        return this.typesToReplace[name].type
+      }
+      return type
+    })
+
+    Object.entries(fields).forEach(([fieldName, fieldDefinition]) => {
+      const fieldConfig = fieldToFieldConfig(fieldDefinition, resolveType, true)
+      // If it's not a type we want to replace, just skip it
+      if (!replacementTypes.includes(fieldDefinition.type.name)) {
+        newFields[fieldName] = fieldConfig
+      } else {
+        madeChanges = true
+        const replacementType = this.typesToReplace[fieldDefinition.type.name]
+          .type
+        newFields[fieldName] = {
+          ...fieldConfig,
+          type: replacementType,
+        }
+        console.log("====>2", newFields[fieldName])
+      }
+    })
+
+    return madeChanges ? newFields : undefined
+
+    // Object.keys(fields).forEach(name => {
+    //   const field = fields[name]
+    //   console.log("====>1", field.type, name)
+    //   console.log("=====>3", Object.keys(this.typesToReplace))
+    //   if (Object.keys(this.typesToReplace).includes(field.type.toString())) {
+    //     const oldField = fieldToFieldConfig(field, resolveType, true)
+    //     console.log("=================> Got Here", oldField)
+    //     newFields[name] = {
+    //       ...oldField,
+    //       type: this.typesToReplace[field.type].type,
+    //     }
+    //     console.log("====>2", newFields)
+    //     madeChanges = true
+    //   }
+    //   this.changedFields[fieldKey(type, name)] = name
+    // })
+
+    // return madeChanges ? newFields : undefined
+  }
+}
+
+function fieldKey(type: TypeWithSelectableFields, fieldName: string) {
+  return `${type.name}.${fieldName}`
+}

--- a/src/schema/v2/index.ts
+++ b/src/schema/v2/index.ts
@@ -9,6 +9,7 @@ import {
   NullableIDField,
   InternalIDFields,
 } from "schema/object_identification"
+import { ReplaceType } from "./ReplaceType"
 
 // TODO: Flip this switch before we go public with v2 and update clients. Until
 //       then this gives clients an extra window of opportunity to update.
@@ -83,6 +84,12 @@ export const transformToV2 = (
     ...opt.allowedNonGravityTypesWithNullableIDField,
   ]
   return transformSchema(schema, [
+    new ReplaceType({
+      PartnerShow: {
+        newTypeName: "Show",
+        type: schema.getType("Show"),
+      },
+    }),
     new FilterTypes(type => {
       return !opt.filterTypes.includes(type.name)
     }),


### PR DESCRIPTION
# What we want to do?
https://artsyproduct.atlassian.net/browse/PURCHASE-1210
Basically, replace `PartnerShow` with `Show` in V2 for all types who currently use `PartnerShow`

# So Far
We've managed to replace the type of single `partner_show` in the schema BUT 👇 

# Issues
- `Show` is a superset of `PartnerShow`, looks like at the moment we are missing something in our  resolver, all fields are that in `Show` but not `PartnerShow` are not being resolved properly and are always `null`.
- We had trouble getting this worked under fragments, meaning `... on Show` on the fields where returning `null` for all included fields under fragment, outside of fragment we can use `PartneShow` fields.
- We still need to replace Array and connection fields.