### PR TITLE
Add `shows` as `Show` in Artwork v2

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1276,7 +1276,7 @@ type Artwork implements Node & Searchable & Sellable {
     at_a_fair: Boolean
     sort: PartnerShowSorts
   ): PartnerShow
-  v2Shows(
+  v2_shows(
     size: Int
     active: Boolean
     at_a_fair: Boolean
@@ -2285,7 +2285,7 @@ type ArtworkItem implements Node & Searchable & Sellable {
     at_a_fair: Boolean
     sort: PartnerShowSorts
   ): PartnerShow
-  v2Shows(
+  v2_shows(
     size: Int
     active: Boolean
     at_a_fair: Boolean

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1280,7 +1280,7 @@ type Artwork implements Node & Searchable & Sellable {
     size: Int
     active: Boolean
     at_a_fair: Boolean
-    sort: PartnerShowSorts
+    sort: ShowSort
   ): [Show]
   shows(
     size: Int
@@ -2289,7 +2289,7 @@ type ArtworkItem implements Node & Searchable & Sellable {
     size: Int
     active: Boolean
     at_a_fair: Boolean
-    sort: PartnerShowSorts
+    sort: ShowSort
   ): [Show]
   shows(
     size: Int

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1276,6 +1276,12 @@ type Artwork implements Node & Searchable & Sellable {
     at_a_fair: Boolean
     sort: PartnerShowSorts
   ): PartnerShow
+  v2Shows(
+    size: Int
+    active: Boolean
+    at_a_fair: Boolean
+    sort: PartnerShowSorts
+  ): [Show]
   shows(
     size: Int
     active: Boolean
@@ -2279,6 +2285,12 @@ type ArtworkItem implements Node & Searchable & Sellable {
     at_a_fair: Boolean
     sort: PartnerShowSorts
   ): PartnerShow
+  v2Shows(
+    size: Int
+    active: Boolean
+    at_a_fair: Boolean
+    sort: PartnerShowSorts
+  ): [Show]
   shows(
     size: Int
     active: Boolean

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1276,12 +1276,7 @@ type Artwork implements Node & Searchable & Sellable {
     at_a_fair: Boolean
     sort: PartnerShowSorts
   ): PartnerShow
-  shows(
-    size: Int
-    active: Boolean
-    at_a_fair: Boolean
-    sort: PartnerShowSorts
-  ): [Show]
+  shows(size: Int, active: Boolean, at_a_fair: Boolean, sort: ShowSort): [Show]
   deprecatedShows(
     size: Int
     active: Boolean
@@ -2289,7 +2284,7 @@ type ArtworkItem implements Node & Searchable & Sellable {
     size: Int
     active: Boolean
     at_a_fair: Boolean
-    sort: PartnerShowSorts
+    sort: ShowSort
   ): [Show]
   shows(
     size: Int

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -36,6 +36,9 @@ type AddInitialOfferToOrderPayload {
 type AggregationCount {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
   count: Int
   name: String
   sortable_id: String
@@ -396,6 +399,9 @@ type ApproveOrderPayload {
 type Article implements Node {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
   cached: Int
   author: Author
   channel_id: String
@@ -453,6 +459,9 @@ enum ArticleSorts {
 type Artist implements Node & Searchable {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -796,6 +805,9 @@ type ArtistItem implements Node & Searchable {
   # A globally unique ID.
   id: ID!
 
+  # A type-specific ID.
+  gravityID: ID!
+
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   cached: Int
@@ -1111,6 +1123,9 @@ type Artwork implements Node & Searchable & Sellable {
   # A globally unique ID.
   id: ID!
 
+  # A type-specific ID.
+  gravityID: ID!
+
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   cached: Int
@@ -1325,6 +1340,9 @@ type ArtworkContextAuction implements Node {
   # A globally unique ID.
   id: ID!
 
+  # A type-specific ID.
+  gravityID: ID!
+
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   cached: Int
@@ -1456,6 +1474,9 @@ type ArtworkContextAuction implements Node {
 type ArtworkContextFair {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -1591,6 +1612,12 @@ type ArtworkContextFair {
 type ArtworkContextPartnerShow implements Node {
   # A globally unique ID.
   id: ID!
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # A type-specific ID.
+  gravityID: ID!
     @deprecated(
       reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
     )
@@ -1786,6 +1813,9 @@ type ArtworkContextSale implements Node {
   # A globally unique ID.
   id: ID!
 
+  # A type-specific ID.
+  gravityID: ID!
+
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   cached: Int
@@ -1929,6 +1959,9 @@ type ArtworkFilterGene implements Node {
   # A globally unique ID.
   id: ID!
 
+  # A type-specific ID.
+  gravityID: ID!
+
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   cached: Int
@@ -1986,6 +2019,9 @@ type ArtworkFilterGene implements Node {
 type ArtworkFilterTag implements Node {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -2054,6 +2090,9 @@ type ArtworkInquiry {
   # A globally unique ID.
   id: ID!
 
+  # A type-specific ID.
+  gravityID: ID!
+
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   artwork: Artwork!
@@ -2081,6 +2120,9 @@ type ArtworkInquiryEdge {
 type ArtworkItem implements Node & Searchable & Sellable {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -2262,6 +2304,9 @@ type ArtworkItem implements Node & Searchable & Sellable {
 type ArtworkLayer {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
   artworks: [Artwork]
 
   # A connection of artworks from a Layer.
@@ -2353,6 +2398,9 @@ type ArtworkVersion {
   # A globally unique ID.
   id: ID!
 
+  # A type-specific ID.
+  gravityID: ID!
+
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
 
@@ -2405,6 +2453,9 @@ type AttributionClass {
   # A globally unique ID.
   id: ID!
 
+  # A type-specific ID.
+  gravityID: ID!
+
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
 
@@ -2454,6 +2505,9 @@ type AuctionLotImages {
 type AuctionResult implements Node {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
   title: String
   artist_id: String!
   date(
@@ -2526,6 +2580,9 @@ enum AuctionResultSorts {
 type Author {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
   name: String
   href: String
     @deprecated(
@@ -2537,6 +2594,9 @@ type Author {
 type Bidder {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
   created_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -2553,6 +2613,9 @@ type Bidder {
 type BidderPosition {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
   created_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -2712,6 +2775,9 @@ type buyerRejectOfferPayload {
 type BuyersPremium {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -2952,6 +3018,9 @@ type Category {
   # A globally unique ID.
   id: ID!
 
+  # A type-specific ID.
+  gravityID: ID!
+
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   category_type: String
@@ -3019,6 +3088,9 @@ type Collection implements Node {
   # A globally unique ID.
   id: ID!
 
+  # A type-specific ID.
+  gravityID: ID!
+
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   cached: Int
@@ -3045,6 +3117,9 @@ enum CollectionSorts {
 type CollectorProfileType {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
   email: String
   name: String
   confirmed_buyer_at(
@@ -4343,6 +4418,9 @@ type Conversation implements Node {
   # A globally unique ID.
   id: ID!
 
+  # An optional type-specific ID.
+  internalID: ID
+
   # Gravity inquiry id.
   inquiry_id: String
 
@@ -4627,6 +4705,9 @@ type CreditCard {
   # A globally unique ID.
   id: ID!
 
+  # A type-specific ID.
+  gravityID: ID!
+
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
 
@@ -4856,6 +4937,9 @@ input EditableLocation {
 type EditionSet implements Sellable {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
   dimensions: dimensions
   edition_of: String
   is_acquireable: Boolean
@@ -4926,6 +5010,9 @@ type ExactPrice {
 type ExternalPartner {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
   city: String
   name: String
 }
@@ -4933,6 +5020,9 @@ type ExternalPartner {
 type Fair {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -5117,6 +5207,9 @@ type FairExhibitor {
   # A globally unique ID.
   id: ID!
 
+  # An optional type-specific ID.
+  gravityID: ID
+
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
 
@@ -5165,6 +5258,9 @@ type FeaturedLinkItem {
 type Feedback {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
 
   # Feedback message
   message: String!
@@ -5260,6 +5356,9 @@ type FollowArtist {
 
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
 }
 
 # A connection to a list of items.
@@ -5402,6 +5501,9 @@ type FollowGene {
 
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
 }
 
 # A connection to a list of items.
@@ -5543,6 +5645,9 @@ type GeminiEntry {
 type Gene implements Node {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -5709,6 +5814,9 @@ type GeneFamily {
   # A globally unique ID.
   id: ID!
 
+  # A type-specific ID.
+  gravityID: ID!
+
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   name: String!
@@ -5736,6 +5844,9 @@ type GeneFamilyEdge {
 type GeneItem implements Node {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -5868,6 +5979,9 @@ type GravityMutationError {
 type HighestBid {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
   created_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -5902,6 +6016,9 @@ union Highlighted = HighlightedShow | HighlightedArticle
 type HighlightedArticle implements Node {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
   cached: Int
   author: Author
   channel_id: String
@@ -5934,6 +6051,9 @@ type HighlightedArticle implements Node {
 type HighlightedShow implements Node {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -6268,6 +6388,9 @@ type HomePageHeroUnit {
   # A globally unique ID.
   id: ID!
 
+  # A type-specific ID.
+  gravityID: ID!
+
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   cached: Int
@@ -6316,6 +6439,9 @@ union HomePageModuleContext =
 type HomePageModuleContextFair {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -6461,6 +6587,9 @@ type HomePageModuleContextGene implements Node {
   # A globally unique ID.
   id: ID!
 
+  # A type-specific ID.
+  gravityID: ID!
+
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   cached: Int
@@ -6590,6 +6719,9 @@ type HomePageModuleContextRelatedArtist {
 type HomePageModuleContextSale implements Node {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -6779,6 +6911,9 @@ type Invoice implements Node {
   # A globally unique ID.
   id: ID!
 
+  # A type-specific ID.
+  gravityID: ID!
+
   # Lewitt's invoice id.
   lewitt_invoice_id: String!
 
@@ -6822,6 +6957,9 @@ union ListPrice = PriceRange | ExactPrice
 type Location {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
   cached: Int
   address: String
   address_2: String
@@ -6981,6 +7119,9 @@ scalar MarketingDateTime
 type Me implements Node {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
 
   # A list of the current user’s consignment submissions
   consignment_submissions(
@@ -7183,6 +7324,9 @@ type Me implements Node {
 type Message implements Node {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
 
   # Impulse message id.
   impulse_id: String!
@@ -8133,6 +8277,9 @@ type OrderEdge {
 type OrderedSet {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
   cached: Int
   description: String
   key: String
@@ -8361,6 +8508,9 @@ type Partner implements Node {
   # A globally unique ID.
   id: ID!
 
+  # A type-specific ID.
+  gravityID: ID!
+
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   cached: Int
@@ -8428,6 +8578,9 @@ type Partner implements Node {
 type PartnerArtist {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
   artist: Artist
   biography: String
   counts: PartnerArtistCounts
@@ -8470,6 +8623,9 @@ type PartnerArtistEdge {
 
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
   artist: Artist
   biography: String
   counts: PartnerArtistCounts
@@ -8483,6 +8639,9 @@ type PartnerArtistEdge {
 type PartnerCategory {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
   cached: Int
   category_type: CategoryType
   name: String
@@ -8603,6 +8762,12 @@ type PartnersAggregationResults {
 type PartnerShow implements Node {
   # A globally unique ID.
   id: ID!
+    @deprecated(
+      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
+    )
+
+  # A type-specific ID.
+  gravityID: ID!
     @deprecated(
       reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
     )
@@ -8919,6 +9084,9 @@ type PriceRange {
 type Profile {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -9643,6 +9811,9 @@ type Sale implements Node {
   # A globally unique ID.
   id: ID!
 
+  # A type-specific ID.
+  gravityID: ID!
+
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   cached: Int
@@ -9774,6 +9945,9 @@ type Sale implements Node {
 type SaleArtwork {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -10105,6 +10279,9 @@ type SearchableEdge {
 type SearchableItem implements Node & Searchable {
   id: ID!
 
+  # A type-specific ID.
+  gravityID: ID!
+
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   description: String
@@ -10348,6 +10525,9 @@ input ShippingInputField {
 type Show implements Node {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -10747,6 +10927,9 @@ type Tag implements Node {
   # A globally unique ID.
   id: ID!
 
+  # A type-specific ID.
+  gravityID: ID!
+
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   cached: Int
@@ -10838,6 +11021,9 @@ input UpdateCollectorProfileInput {
 type UpdateCollectorProfilePayload {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
   email: String
   name: String
   confirmed_buyer_at(
@@ -10995,6 +11181,9 @@ type UpdateSubmissionMutationPayload {
 type User {
   # A globally unique ID.
   id: ID!
+
+  # A type-specific ID.
+  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -36,9 +36,6 @@ type AddInitialOfferToOrderPayload {
 type AggregationCount {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
   count: Int
   name: String
   sortable_id: String
@@ -399,9 +396,6 @@ type ApproveOrderPayload {
 type Article implements Node {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
   cached: Int
   author: Author
   channel_id: String
@@ -459,9 +453,6 @@ enum ArticleSorts {
 type Artist implements Node & Searchable {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -805,9 +796,6 @@ type ArtistItem implements Node & Searchable {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID.
-  gravityID: ID!
-
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   cached: Int
@@ -1123,9 +1111,6 @@ type Artwork implements Node & Searchable & Sellable {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID.
-  gravityID: ID!
-
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   cached: Int
@@ -1277,12 +1262,6 @@ type Artwork implements Node & Searchable & Sellable {
     sort: PartnerShowSorts
   ): PartnerShow
   shows(size: Int, active: Boolean, at_a_fair: Boolean, sort: ShowSort): [Show]
-  deprecatedShows(
-    size: Int
-    active: Boolean
-    at_a_fair: Boolean
-    sort: PartnerShowSorts
-  ): [PartnerShow]
   signature(format: Format): String
   title: String
   to_s: String
@@ -1345,9 +1324,6 @@ union ArtworkContext =
 type ArtworkContextAuction implements Node {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -1480,9 +1456,6 @@ type ArtworkContextAuction implements Node {
 type ArtworkContextFair {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -1618,12 +1591,6 @@ type ArtworkContextFair {
 type ArtworkContextPartnerShow implements Node {
   # A globally unique ID.
   id: ID!
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # A type-specific ID.
-  gravityID: ID!
     @deprecated(
       reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
     )
@@ -1819,9 +1786,6 @@ type ArtworkContextSale implements Node {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID.
-  gravityID: ID!
-
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   cached: Int
@@ -1965,9 +1929,6 @@ type ArtworkFilterGene implements Node {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID.
-  gravityID: ID!
-
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   cached: Int
@@ -2025,9 +1986,6 @@ type ArtworkFilterGene implements Node {
 type ArtworkFilterTag implements Node {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -2096,9 +2054,6 @@ type ArtworkInquiry {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID.
-  gravityID: ID!
-
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   artwork: Artwork!
@@ -2126,9 +2081,6 @@ type ArtworkInquiryEdge {
 type ArtworkItem implements Node & Searchable & Sellable {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -2280,18 +2232,7 @@ type ArtworkItem implements Node & Searchable & Sellable {
     at_a_fair: Boolean
     sort: PartnerShowSorts
   ): PartnerShow
-  v2Shows(
-    size: Int
-    active: Boolean
-    at_a_fair: Boolean
-    sort: ShowSort
-  ): [Show]
-  shows(
-    size: Int
-    active: Boolean
-    at_a_fair: Boolean
-    sort: PartnerShowSorts
-  ): [PartnerShow]
+  shows(size: Int, active: Boolean, at_a_fair: Boolean, sort: ShowSort): [Show]
   signature(format: Format): String
   title: String
   to_s: String
@@ -2321,9 +2262,6 @@ type ArtworkItem implements Node & Searchable & Sellable {
 type ArtworkLayer {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
   artworks: [Artwork]
 
   # A connection of artworks from a Layer.
@@ -2415,9 +2353,6 @@ type ArtworkVersion {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID.
-  gravityID: ID!
-
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
 
@@ -2470,9 +2405,6 @@ type AttributionClass {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID.
-  gravityID: ID!
-
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
 
@@ -2522,9 +2454,6 @@ type AuctionLotImages {
 type AuctionResult implements Node {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
   title: String
   artist_id: String!
   date(
@@ -2597,9 +2526,6 @@ enum AuctionResultSorts {
 type Author {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
   name: String
   href: String
     @deprecated(
@@ -2611,9 +2537,6 @@ type Author {
 type Bidder {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
   created_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -2630,9 +2553,6 @@ type Bidder {
 type BidderPosition {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
   created_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -2792,9 +2712,6 @@ type buyerRejectOfferPayload {
 type BuyersPremium {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -3035,9 +2952,6 @@ type Category {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID.
-  gravityID: ID!
-
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   category_type: String
@@ -3105,9 +3019,6 @@ type Collection implements Node {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID.
-  gravityID: ID!
-
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   cached: Int
@@ -3134,9 +3045,6 @@ enum CollectionSorts {
 type CollectorProfileType {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
   email: String
   name: String
   confirmed_buyer_at(
@@ -4435,9 +4343,6 @@ type Conversation implements Node {
   # A globally unique ID.
   id: ID!
 
-  # An optional type-specific ID.
-  internalID: ID
-
   # Gravity inquiry id.
   inquiry_id: String
 
@@ -4722,9 +4627,6 @@ type CreditCard {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID.
-  gravityID: ID!
-
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
 
@@ -4954,9 +4856,6 @@ input EditableLocation {
 type EditionSet implements Sellable {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
   dimensions: dimensions
   edition_of: String
   is_acquireable: Boolean
@@ -5027,9 +4926,6 @@ type ExactPrice {
 type ExternalPartner {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
   city: String
   name: String
 }
@@ -5037,9 +4933,6 @@ type ExternalPartner {
 type Fair {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -5224,9 +5117,6 @@ type FairExhibitor {
   # A globally unique ID.
   id: ID!
 
-  # An optional type-specific ID.
-  gravityID: ID
-
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
 
@@ -5275,9 +5165,6 @@ type FeaturedLinkItem {
 type Feedback {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
 
   # Feedback message
   message: String!
@@ -5373,9 +5260,6 @@ type FollowArtist {
 
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
 }
 
 # A connection to a list of items.
@@ -5518,9 +5402,6 @@ type FollowGene {
 
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
 }
 
 # A connection to a list of items.
@@ -5662,9 +5543,6 @@ type GeminiEntry {
 type Gene implements Node {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -5831,9 +5709,6 @@ type GeneFamily {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID.
-  gravityID: ID!
-
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   name: String!
@@ -5861,9 +5736,6 @@ type GeneFamilyEdge {
 type GeneItem implements Node {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -5996,9 +5868,6 @@ type GravityMutationError {
 type HighestBid {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
   created_at(
     # This arg is deprecated, use timezone instead
     convert_to_utc: Boolean
@@ -6033,9 +5902,6 @@ union Highlighted = HighlightedShow | HighlightedArticle
 type HighlightedArticle implements Node {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
   cached: Int
   author: Author
   channel_id: String
@@ -6068,9 +5934,6 @@ type HighlightedArticle implements Node {
 type HighlightedShow implements Node {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -6405,9 +6268,6 @@ type HomePageHeroUnit {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID.
-  gravityID: ID!
-
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   cached: Int
@@ -6456,9 +6316,6 @@ union HomePageModuleContext =
 type HomePageModuleContextFair {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -6604,9 +6461,6 @@ type HomePageModuleContextGene implements Node {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID.
-  gravityID: ID!
-
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   cached: Int
@@ -6736,9 +6590,6 @@ type HomePageModuleContextRelatedArtist {
 type HomePageModuleContextSale implements Node {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -6928,9 +6779,6 @@ type Invoice implements Node {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID.
-  gravityID: ID!
-
   # Lewitt's invoice id.
   lewitt_invoice_id: String!
 
@@ -6974,9 +6822,6 @@ union ListPrice = PriceRange | ExactPrice
 type Location {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
   cached: Int
   address: String
   address_2: String
@@ -7136,9 +6981,6 @@ scalar MarketingDateTime
 type Me implements Node {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
 
   # A list of the current user’s consignment submissions
   consignment_submissions(
@@ -7341,9 +7183,6 @@ type Me implements Node {
 type Message implements Node {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID likely used as a database ID.
-  internalID: ID!
 
   # Impulse message id.
   impulse_id: String!
@@ -8294,9 +8133,6 @@ type OrderEdge {
 type OrderedSet {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
   cached: Int
   description: String
   key: String
@@ -8525,9 +8361,6 @@ type Partner implements Node {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID.
-  gravityID: ID!
-
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   cached: Int
@@ -8595,9 +8428,6 @@ type Partner implements Node {
 type PartnerArtist {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
   artist: Artist
   biography: String
   counts: PartnerArtistCounts
@@ -8640,9 +8470,6 @@ type PartnerArtistEdge {
 
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
   artist: Artist
   biography: String
   counts: PartnerArtistCounts
@@ -8656,9 +8483,6 @@ type PartnerArtistEdge {
 type PartnerCategory {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
   cached: Int
   category_type: CategoryType
   name: String
@@ -8779,12 +8603,6 @@ type PartnersAggregationResults {
 type PartnerShow implements Node {
   # A globally unique ID.
   id: ID!
-    @deprecated(
-      reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
-    )
-
-  # A type-specific ID.
-  gravityID: ID!
     @deprecated(
       reason: "The `PartnerShow` type is deprecated in favor of the `Show` type. [Will be removed in v2]"
     )
@@ -9101,9 +8919,6 @@ type PriceRange {
 type Profile {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -9828,9 +9643,6 @@ type Sale implements Node {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID.
-  gravityID: ID!
-
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   cached: Int
@@ -9962,9 +9774,6 @@ type Sale implements Node {
 type SaleArtwork {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -10296,9 +10105,6 @@ type SearchableEdge {
 type SearchableItem implements Node & Searchable {
   id: ID!
 
-  # A type-specific ID.
-  gravityID: ID!
-
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   description: String
@@ -10542,9 +10348,6 @@ input ShippingInputField {
 type Show implements Node {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
@@ -10944,9 +10747,6 @@ type Tag implements Node {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID.
-  gravityID: ID!
-
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   cached: Int
@@ -11038,9 +10838,6 @@ input UpdateCollectorProfileInput {
 type UpdateCollectorProfilePayload {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
   email: String
   name: String
   confirmed_buyer_at(
@@ -11198,9 +10995,6 @@ type UpdateSubmissionMutationPayload {
 type User {
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID.
-  gravityID: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1281,6 +1281,12 @@ type Artwork implements Node & Searchable & Sellable {
     active: Boolean
     at_a_fair: Boolean
     sort: PartnerShowSorts
+  ): [Show]
+  deprecatedShows(
+    size: Int
+    active: Boolean
+    at_a_fair: Boolean
+    sort: PartnerShowSorts
   ): [PartnerShow]
   signature(format: Format): String
   title: String
@@ -2279,6 +2285,12 @@ type ArtworkItem implements Node & Searchable & Sellable {
     at_a_fair: Boolean
     sort: PartnerShowSorts
   ): PartnerShow
+  v2Shows(
+    size: Int
+    active: Boolean
+    at_a_fair: Boolean
+    sort: PartnerShowSorts
+  ): [Show]
   shows(
     size: Int
     active: Boolean

--- a/src/schema/artwork/index.ts
+++ b/src/schema/artwork/index.ts
@@ -45,6 +45,7 @@ import { ResolverContext } from "types/graphql"
 import { listPrice } from "schema/fields/listPrice"
 import { deprecate } from "lib/deprecation"
 import Show from "schema/show"
+import ShowSort from "schema/sorts/show_sort"
 
 const has_price_range = price => {
   return new RegExp(/\-/).test(price)
@@ -721,7 +722,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           size: { type: GraphQLInt },
           active: { type: GraphQLBoolean },
           at_a_fair: { type: GraphQLBoolean },
-          sort: { type: PartnerShowSorts.type },
+          sort: { type: ShowSort },
         },
         resolve: (
           { id },

--- a/src/schema/artwork/index.ts
+++ b/src/schema/artwork/index.ts
@@ -716,7 +716,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             .then(({ body }) => body)
             .then(_.first),
       },
-      v2Shows: {
+      v2_shows: {
         type: new GraphQLList(Show.type),
         args: {
           size: { type: GraphQLInt },

--- a/src/schema/artwork/index.ts
+++ b/src/schema/artwork/index.ts
@@ -44,6 +44,7 @@ import artworkPageviews from ".././../data/weeklyArtworkPageviews.json"
 import { ResolverContext } from "types/graphql"
 import { listPrice } from "schema/fields/listPrice"
 import { deprecate } from "lib/deprecation"
+import Show from "schema/show"
 
 const has_price_range = price => {
   return new RegExp(/\-/).test(price)
@@ -713,6 +714,30 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           })
             .then(({ body }) => body)
             .then(_.first),
+      },
+      v2Shows: {
+        type: new GraphQLList(Show.type),
+        args: {
+          size: { type: GraphQLInt },
+          active: { type: GraphQLBoolean },
+          at_a_fair: { type: GraphQLBoolean },
+          sort: { type: PartnerShowSorts.type },
+        },
+        resolve: (
+          { id },
+          { size, active, sort, at_a_fair },
+          { relatedShowsLoader }
+        ) => {
+          return relatedShowsLoader({
+            artwork: [id],
+            active,
+            size,
+            sort,
+            at_a_fair,
+          }).then(({ body }) => {
+            return body
+          })
+        },
       },
       shows: {
         type: new GraphQLList(PartnerShow.type),

--- a/src/schema/v2/RenameFields.ts
+++ b/src/schema/v2/RenameFields.ts
@@ -153,13 +153,12 @@ function fieldKey(type: TypeWithSelectableFields, fieldName: string) {
 function getTypeWithSelectableFields(
   typeInfo: TypeInfo
 ): TypeWithSelectableFields {
-  let type
   if (typeInfo.getType() instanceof GraphQLList) {
     return getNamedType(typeInfo.getParentType())
   } else {
-    type = getNamedType(typeInfo.getType())
+    const type = getNamedType(typeInfo.getType())
+    return isLeafType(type) || type instanceof GraphQLUnionType
+      ? getNamedType(typeInfo.getParentType())
+      : type
   }
-  return isLeafType(type) || type instanceof GraphQLUnionType
-    ? getNamedType(typeInfo.getParentType())
-    : type
 }

--- a/src/schema/v2/RenameFields.ts
+++ b/src/schema/v2/RenameFields.ts
@@ -9,9 +9,6 @@ import {
   visit,
   visitWithTypeInfo,
   Kind,
-  getNamedType,
-  isLeafType,
-  GraphQLUnionType,
 } from "graphql"
 import {
   visitSchema,
@@ -94,8 +91,7 @@ export class RenameFields implements Transform {
           ...newField,
           resolve: source => source[oldName],
         }
-
-        this.changedFields[fieldKey(type, newName)] = oldName
+        this.changedFields[newName] = oldName
       } else {
         newFields[oldName] = newField
       }
@@ -120,8 +116,7 @@ export class RenameFields implements Transform {
               return
             }
 
-            const type = getTypeWithSelectableFields(typeInfo)
-            const oldName = this.changedFields[fieldKey(type, node.name.value)]
+            const oldName = this.changedFields[node.name.value]
             if (oldName) {
               return {
                 ...node,
@@ -142,18 +137,4 @@ export class RenameFields implements Transform {
       document: newDocument,
     }
   }
-}
-
-function fieldKey(type: TypeWithSelectableFields, fieldName: string) {
-  return `${type.name}.${fieldName}`
-}
-
-// FIXME: Unsure why the `typeInfo` methods return `any`.
-function getTypeWithSelectableFields(
-  typeInfo: TypeInfo
-): TypeWithSelectableFields {
-  const type = getNamedType(typeInfo.getType())
-  return isLeafType(type) || type instanceof GraphQLUnionType
-    ? getNamedType(typeInfo.getParentType())
-    : type
 }

--- a/src/schema/v2/__tests__/v2.test.ts
+++ b/src/schema/v2/__tests__/v2.test.ts
@@ -18,6 +18,7 @@ import {
   GraphQLID,
   GraphQLInterfaceType,
   GraphQLString,
+  GraphQLInt,
 } from "graphql"
 import gql from "lib/gql"
 import { toGlobalId } from "graphql-relay"
@@ -103,6 +104,59 @@ describe(transformToV2, () => {
         expect(deprecatedField).not.toBeUndefined()
       }
     })
+  })
+
+  it("puts fields with the v2 prefix in place", async () => {
+    const rootValue = {
+      fieldForV2: {
+        someField: 42,
+        v2_someField: "a v2 value",
+      },
+    }
+    const data = await runQueryOrThrow({
+      schema: createSchema({
+        fields: {
+          fieldForV2: {
+            type: new GraphQLObjectType({
+              name: "AnyType",
+              fields: {
+                v2_someField: {
+                  type: GraphQLString,
+                },
+                someField: {
+                  type: GraphQLInt,
+                },
+              },
+              interfaces: [
+                new GraphQLInterfaceType({
+                  name: "AnInterface",
+                  fields: {
+                    someField: {
+                      type: GraphQLInt,
+                    },
+                    v2_someField: {
+                      type: GraphQLString,
+                    },
+                  },
+                }),
+              ],
+            }),
+          },
+        },
+      }),
+      rootValue,
+      source: gql`
+        query {
+          fieldForV2 {
+            someField
+            ... on AnInterface {
+              someField
+            }
+          }
+        }
+      `,
+    })
+    expect(data.fieldForV2.someField).toEqual("a v2 value")
   })
 
   describe("concerning ID renaming", () => {

--- a/src/schema/v2/index.ts
+++ b/src/schema/v2/index.ts
@@ -126,6 +126,11 @@ export const transformToV2 = (
       }
       return undefined
     }),
+    new RenameFields((_type, field) => {
+      if (field.name.startsWith("v2_")) {
+        return field.name.substring(3)
+      }
+    }),
     new RenameArguments((_field, arg) => (arg.name === "__id" ? "id" : null)),
     ...(FILTER_DEPRECATIONS
       ? [
@@ -142,10 +147,5 @@ export const transformToV2 = (
           ),
         ]
       : []),
-    new RenameFields((_type, field) => {
-      if (field.name.startsWith("v2_")) {
-        return field.name.substring(3)
-      }
-    }),
   ])
 }

--- a/src/schema/v2/index.ts
+++ b/src/schema/v2/index.ts
@@ -142,12 +142,9 @@ export const transformToV2 = (
           ),
         ]
       : []),
-    new RenameFields((type, field) => {
-      if (field.name === "v2Shows" && type.name === "Artwork") {
-        return "shows"
-      }
-      if (field.name === "shows" && type.name === "Artwork") {
-        return "deprecatedShows"
+    new RenameFields((_type, field) => {
+      if (field.name.startsWith("v2_")) {
+        return field.name.substring(3)
       }
     }),
   ])

--- a/src/schema/v2/index.ts
+++ b/src/schema/v2/index.ts
@@ -91,6 +91,12 @@ export const transformToV2 = (
         field.name !== "id" || !opt.filterIDFieldFromTypes.includes(type.name)
     ),
     new RenameFields((type, field) => {
+      if (field.name === "v2Shows" && type.name === "Artwork") {
+        return "shows"
+      }
+      if (field.name === "shows" && type.name === "Artwork") {
+        return "deprecatedShows"
+      }
       if (field.name === "id") {
         if (
           isNullableType(field.type) &&

--- a/src/schema/v2/index.ts
+++ b/src/schema/v2/index.ts
@@ -91,12 +91,6 @@ export const transformToV2 = (
         field.name !== "id" || !opt.filterIDFieldFromTypes.includes(type.name)
     ),
     new RenameFields((type, field) => {
-      if (field.name === "v2Shows" && type.name === "Artwork") {
-        return "shows"
-      }
-      if (field.name === "shows" && type.name === "Artwork") {
-        return "deprecatedShows"
-      }
       if (field.name === "id") {
         if (
           isNullableType(field.type) &&
@@ -148,5 +142,13 @@ export const transformToV2 = (
           ),
         ]
       : []),
+    new RenameFields((type, field) => {
+      if (field.name === "v2Shows" && type.name === "Artwork") {
+        return "shows"
+      }
+      if (field.name === "shows" && type.name === "Artwork") {
+        return "deprecatedShows"
+      }
+    }),
   ])
 }


### PR DESCRIPTION
We did this by adding `v2Shows` to `Artwork` and then rename `shows` to `deprecatedShows` and then `v2Shows` to `shows` on V2 version of `Artwork`.

follow up on #1792 

# Selfie
![image](https://user-images.githubusercontent.com/1230819/60144739-922d3880-9791-11e9-9ae9-d037d49d5a46.png)
