### PR TITLE
updated KAWS schema with new collection hub data

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -7064,6 +7064,9 @@ type MarketingCollection {
 
   # Collection has prioritized connection to artist
   is_featured_artist_content: Boolean!
+
+  # CollectionGroups of this collection
+  linkedCollections: [MarketingCollectionGroup!]!
   relatedCollections: [MarketingCollection!]!
   artworks(
     acquireable: Boolean
@@ -7108,6 +7111,13 @@ type MarketingCollectionCategory {
   collections: [MarketingCollection!]!
 }
 
+type MarketingCollectionGroup {
+  id: ID!
+  groupType: MarketingGroupTypes!
+  name: String!
+  members: [String!]!
+}
+
 type MarketingCollectionQuery {
   id: ID
   acquireable: Boolean
@@ -7142,6 +7152,13 @@ type MarketingCollectionQuery {
 }
 
 scalar MarketingDateTime
+
+# Available types of CollectionGroup
+enum MarketingGroupTypes {
+  ArtistSeries
+  FeaturedCollections
+  OtherCollections
+}
 
 type Me implements Node {
   # A globally unique ID.

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7047,6 +7047,9 @@ type MarketingCollection {
 
   # Collection has prioritized connection to artist
   is_featured_artist_content: Boolean!
+
+  # CollectionGroups of this collection
+  linkedCollections: [MarketingCollectionGroup!]!
   relatedCollections: [MarketingCollection!]!
   artworks(
     acquireable: Boolean
@@ -7091,6 +7094,13 @@ type MarketingCollectionCategory {
   collections: [MarketingCollection!]!
 }
 
+type MarketingCollectionGroup {
+  internalID: ID!
+  groupType: MarketingGroupTypes!
+  name: String!
+  members: [String!]!
+}
+
 type MarketingCollectionQuery {
   internalID: ID
   acquireable: Boolean
@@ -7125,6 +7135,13 @@ type MarketingCollectionQuery {
 }
 
 scalar MarketingDateTime
+
+# Available types of CollectionGroup
+enum MarketingGroupTypes {
+  ArtistSeries
+  FeaturedCollections
+  OtherCollections
+}
 
 type Me implements Node {
   # A globally unique ID.

--- a/src/data/kaws.graphql
+++ b/src/data/kaws.graphql
@@ -36,12 +36,22 @@ type Collection {
 
   # Collection has prioritized connection to artist
   is_featured_artist_content: Boolean!
+
+  # CollectionGroups of this collection
+  linkedCollections: [CollectionGroup!]!
   relatedCollections: [Collection!]!
 }
 
 type CollectionCategory {
   name: String!
   collections: [Collection!]!
+}
+
+type CollectionGroup {
+  id: ID!
+  groupType: GroupTypes!
+  name: String!
+  members: [String!]!
 }
 
 type CollectionQuery {
@@ -79,6 +89,13 @@ type CollectionQuery {
 
 # The javascript `Date` as string. Type represents date and time as the ISO Date string.
 scalar DateTime
+
+# Available types of CollectionGroup
+enum GroupTypes {
+  ArtistSeries
+  FeaturedCollections
+  OtherCollections
+}
 
 type Query {
   collections(

--- a/src/lib/stitching/kaws/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/kaws/__tests__/__snapshots__/schema.test.ts.snap
@@ -39,12 +39,22 @@ type MarketingCollection {
 
   # Collection has prioritized connection to artist
   is_featured_artist_content: Boolean!
+
+  # CollectionGroups of this collection
+  linkedCollections: [MarketingCollectionGroup!]!
   relatedCollections: [MarketingCollection!]!
 }
 
 type MarketingCollectionCategory {
   name: String!
   collections: [MarketingCollection!]!
+}
+
+type MarketingCollectionGroup {
+  id: ID!
+  groupType: MarketingGroupTypes!
+  name: String!
+  members: [String!]!
 }
 
 type MarketingCollectionQuery {
@@ -81,6 +91,13 @@ type MarketingCollectionQuery {
 }
 
 scalar MarketingDateTime
+
+# Available types of CollectionGroup
+enum MarketingGroupTypes {
+  ArtistSeries
+  FeaturedCollections
+  OtherCollections
+}
 
 type Query {
   marketingCollections(category: String, randomizationSeed: String, size: Int, isFeaturedArtistContent: Boolean, showOnEditorial: Boolean, artistID: String): [MarketingCollection!]!


### PR DESCRIPTION
Copying over schema updates generated [here](https://github.com/artsy/kaws/pull/108). This satisfies [GROW-1337](https://artsyproduct.atlassian.net/browse/GROW-1337).