### PR TITLE
PURCHASE-1231: Update resolvers for framed and certificate_of_authenticity

### DIFF
--- a/src/schema/artwork/__tests__/artwork.test.js
+++ b/src/schema/artwork/__tests__/artwork.test.js
@@ -1666,18 +1666,22 @@ describe("Artwork type", () => {
         expect(data).toEqual({ artwork: { framed: null } })
       })
     })
-    it("is null when framed is false", () => {
-      artwork.framed = false
-      return runQuery(query, context).then(data => {
-        expect(data).toEqual({ artwork: { framed: null } })
-      })
-    })
     it("is set to proper object when framed is true", () => {
       artwork.framed = true
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            framed: { label: "Framed", details: null },
+            framed: { label: "Framed", details: "Included" },
+          },
+        })
+      })
+    })
+    it("is set to proper object when framed is false", () => {
+      artwork.framed = false
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            framed: { label: "Framed", details: "Not included" },
           },
         })
       })
@@ -1848,16 +1852,6 @@ describe("Artwork type", () => {
         })
       })
     })
-    it("is null when certificate_of_authenticity is false", () => {
-      artwork.certificate_of_authenticity = false
-      return runQuery(query, context).then(data => {
-        expect(data).toEqual({
-          artwork: {
-            certificateOfAuthenticity: null,
-          },
-        })
-      })
-    })
     it("is set to proper object when certificate_of_authenticity is true", () => {
       artwork.certificate_of_authenticity = true
       return runQuery(query, context).then(data => {
@@ -1865,7 +1859,20 @@ describe("Artwork type", () => {
           artwork: {
             certificateOfAuthenticity: {
               label: "Certificate of authenticity",
-              details: null,
+              details: "Included",
+            },
+          },
+        })
+      })
+    })
+    it("is set to proper object when certificate_of_authenticity is false", () => {
+      artwork.certificate_of_authenticity = false
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            certificateOfAuthenticity: {
+              label: "Certificate of authenticity",
+              details: "Not included",
             },
           },
         })

--- a/src/schema/artwork/index.ts
+++ b/src/schema/artwork/index.ts
@@ -774,10 +774,13 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       framed: {
         type: ArtworkInfoRowType,
         resolve: ({ framed }) => {
-          if (!framed) {
+          if (framed) {
+            return { label: "Framed", details: "Included" }
+          } else if (framed === false) {
+            return { label: "Framed", details: "Not included" }
+          } else {
             return null
           }
-          return { label: "Framed", details: null }
         },
       },
       signatureInfo: {
@@ -826,10 +829,16 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       certificateOfAuthenticity: {
         type: ArtworkInfoRowType,
         resolve: ({ certificate_of_authenticity }) => {
-          if (!certificate_of_authenticity) {
+          if (certificate_of_authenticity) {
+            return { label: "Certificate of authenticity", details: "Included" }
+          } else if (certificate_of_authenticity === false) {
+            return {
+              label: "Certificate of authenticity",
+              details: "Not included",
+            }
+          } else {
             return null
           }
-          return { label: "Certificate of authenticity", details: null }
         },
       },
       widthCm: {


### PR DESCRIPTION
# Problem
Previously, when framed and `certificate_of_authenticity` were `true` they resolved to an object with a label field with the value "Framed"/"Certificate of authenticity" and a details field that was `null`.

When they were `false` or `null` they resolved to `null`. 

Because of this we had no way to distinguish between a case where the partner checked the "no" box and a case where they left both boxes unchecked. We want a different behavior for these cases in emission, so this needed to change. 

# Solution

## `framed`

When `true` it returns
```
{ label: "Framed", details: "Included" }
``` 
when `false` it returns 
```
{ label: "Framed", details: "Not included" }
```
and when `null` it returns `null`.

## `certificate_of_authenticity`

When `certificate_of_authenticity` is `true` it returns
```
{ label: "Certificate of authenticity", details: "Included" }
``` 

when `false` it returns 
```
{ label: "Certificate of authenticity", details: "Not included" }
```
and when `null` it returns `null`.

This will allow us to display "Included" or "Not included" or hide the field in Emission and Reaction.