### PR TITLE
Fix Exchange CommerceDateTime issue

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3353,7 +3353,7 @@ type CommerceBuyOrder implements CommerceOrder {
   code: String!
   commissionFeeCents: Int
   commissionRate: Float
-  createdAt: CommerceDateTime!
+  createdAt: String!
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
@@ -3361,8 +3361,22 @@ type CommerceBuyOrder implements CommerceOrder {
 
   # Item total in cents, for Offer Orders this field reflects current offer
   itemsTotalCents: Int
-  lastApprovedAt: CommerceDateTime
-  lastSubmittedAt: CommerceDateTime
+  lastApprovedAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
+  lastSubmittedAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   lastTransactionFailed: Boolean
   lineItems(
     # Returns the elements in the list that come after the specified cursor.
@@ -3383,13 +3397,27 @@ type CommerceBuyOrder implements CommerceOrder {
   sellerTotalCents: Int
   shippingTotalCents: Int
   state: CommerceOrderStateEnum!
-  stateExpiresAt: CommerceDateTime
+  stateExpiresAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   stateReason: String
-  stateUpdatedAt: CommerceDateTime
+  stateUpdatedAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   taxTotalCents: Int
   totalListPriceCents: Int!
   transactionFeeCents: Int
-  updatedAt: CommerceDateTime!
+  updatedAt: String!
   buyerDetails: OrderParty
   sellerDetails: OrderParty
   itemsTotal(
@@ -3723,7 +3751,7 @@ type CommerceLineItemEdge {
 type CommerceOffer {
   amountCents: Int!
   buyerTotalCents: Int
-  createdAt: CommerceDateTime!
+  createdAt: String!
   creatorId: String!
   from: CommerceOrderPartyUnion!
   fromParticipant: CommerceOrderParticipantEnum
@@ -3732,7 +3760,14 @@ type CommerceOffer {
   order: CommerceOrder!
   respondsTo: CommerceOffer
   shippingTotalCents: Int
-  submittedAt: CommerceDateTime
+  submittedAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   taxTotalCents: Int
   fromDetails: OrderParty
   amount(
@@ -3802,7 +3837,7 @@ type CommerceOfferOrder implements CommerceOrder {
   code: String!
   commissionFeeCents: Int
   commissionRate: Float
-  createdAt: CommerceDateTime!
+  createdAt: String!
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
@@ -3810,11 +3845,25 @@ type CommerceOfferOrder implements CommerceOrder {
 
   # Item total in cents, for Offer Orders this field reflects current offer
   itemsTotalCents: Int
-  lastApprovedAt: CommerceDateTime
+  lastApprovedAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
 
   # Last submitted offer
   lastOffer: CommerceOffer
-  lastSubmittedAt: CommerceDateTime
+  lastSubmittedAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   lastTransactionFailed: Boolean
   lineItems(
     # Returns the elements in the list that come after the specified cursor.
@@ -3851,13 +3900,27 @@ type CommerceOfferOrder implements CommerceOrder {
   sellerTotalCents: Int
   shippingTotalCents: Int
   state: CommerceOrderStateEnum!
-  stateExpiresAt: CommerceDateTime
+  stateExpiresAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   stateReason: String
-  stateUpdatedAt: CommerceDateTime
+  stateUpdatedAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   taxTotalCents: Int
   totalListPriceCents: Int!
   transactionFeeCents: Int
-  updatedAt: CommerceDateTime!
+  updatedAt: String!
   buyerDetails: OrderParty
   sellerDetails: OrderParty
   itemsTotal(
@@ -3951,7 +4014,7 @@ interface CommerceOrder {
   code: String!
   commissionFeeCents: Int
   commissionRate: Float
-  createdAt: CommerceDateTime!
+  createdAt: String!
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
@@ -3959,8 +4022,22 @@ interface CommerceOrder {
 
   # Item total in cents, for Offer Orders this field reflects current offer
   itemsTotalCents: Int
-  lastApprovedAt: CommerceDateTime
-  lastSubmittedAt: CommerceDateTime
+  lastApprovedAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
+  lastSubmittedAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   lastTransactionFailed: Boolean
   lineItems(
     # Returns the elements in the list that come after the specified cursor.
@@ -3981,13 +4058,27 @@ interface CommerceOrder {
   sellerTotalCents: Int
   shippingTotalCents: Int
   state: CommerceOrderStateEnum!
-  stateExpiresAt: CommerceDateTime
+  stateExpiresAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   stateReason: String
-  stateUpdatedAt: CommerceDateTime
+  stateUpdatedAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   taxTotalCents: Int
   totalListPriceCents: Int!
   transactionFeeCents: Int
-  updatedAt: CommerceDateTime!
+  updatedAt: String!
   buyerDetails: OrderParty
   sellerDetails: OrderParty
   itemsTotal(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3331,7 +3331,7 @@ type CommerceBuyOrder implements CommerceOrder {
   code: String!
   commissionFeeCents: Int
   commissionRate: Float
-  createdAt: CommerceDateTime!
+  createdAt: String!
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
@@ -3339,8 +3339,22 @@ type CommerceBuyOrder implements CommerceOrder {
 
   # Item total in cents, for Offer Orders this field reflects current offer
   itemsTotalCents: Int
-  lastApprovedAt: CommerceDateTime
-  lastSubmittedAt: CommerceDateTime
+  lastApprovedAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
+  lastSubmittedAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   lastTransactionFailed: Boolean
   lineItems(
     # Returns the elements in the list that come after the specified cursor.
@@ -3361,13 +3375,27 @@ type CommerceBuyOrder implements CommerceOrder {
   sellerTotalCents: Int
   shippingTotalCents: Int
   state: CommerceOrderStateEnum!
-  stateExpiresAt: CommerceDateTime
+  stateExpiresAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   stateReason: String
-  stateUpdatedAt: CommerceDateTime
+  stateUpdatedAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   taxTotalCents: Int
   totalListPriceCents: Int!
   transactionFeeCents: Int
-  updatedAt: CommerceDateTime!
+  updatedAt: String!
   buyerDetails: OrderParty
   sellerDetails: OrderParty
   itemsTotal(
@@ -3701,7 +3729,7 @@ type CommerceLineItemEdge {
 type CommerceOffer {
   amountCents: Int!
   buyerTotalCents: Int
-  createdAt: CommerceDateTime!
+  createdAt: String!
   creatorId: String!
   from: CommerceOrderPartyUnion!
   fromParticipant: CommerceOrderParticipantEnum
@@ -3710,7 +3738,14 @@ type CommerceOffer {
   order: CommerceOrder!
   respondsTo: CommerceOffer
   shippingTotalCents: Int
-  submittedAt: CommerceDateTime
+  submittedAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   taxTotalCents: Int
   fromDetails: OrderParty
   amount(
@@ -3780,7 +3815,7 @@ type CommerceOfferOrder implements CommerceOrder {
   code: String!
   commissionFeeCents: Int
   commissionRate: Float
-  createdAt: CommerceDateTime!
+  createdAt: String!
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
@@ -3788,11 +3823,25 @@ type CommerceOfferOrder implements CommerceOrder {
 
   # Item total in cents, for Offer Orders this field reflects current offer
   itemsTotalCents: Int
-  lastApprovedAt: CommerceDateTime
+  lastApprovedAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
 
   # Last submitted offer
   lastOffer: CommerceOffer
-  lastSubmittedAt: CommerceDateTime
+  lastSubmittedAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   lastTransactionFailed: Boolean
   lineItems(
     # Returns the elements in the list that come after the specified cursor.
@@ -3829,13 +3878,27 @@ type CommerceOfferOrder implements CommerceOrder {
   sellerTotalCents: Int
   shippingTotalCents: Int
   state: CommerceOrderStateEnum!
-  stateExpiresAt: CommerceDateTime
+  stateExpiresAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   stateReason: String
-  stateUpdatedAt: CommerceDateTime
+  stateUpdatedAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   taxTotalCents: Int
   totalListPriceCents: Int!
   transactionFeeCents: Int
-  updatedAt: CommerceDateTime!
+  updatedAt: String!
   buyerDetails: OrderParty
   sellerDetails: OrderParty
   itemsTotal(
@@ -3929,7 +3992,7 @@ interface CommerceOrder {
   code: String!
   commissionFeeCents: Int
   commissionRate: Float
-  createdAt: CommerceDateTime!
+  createdAt: String!
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
@@ -3937,8 +4000,22 @@ interface CommerceOrder {
 
   # Item total in cents, for Offer Orders this field reflects current offer
   itemsTotalCents: Int
-  lastApprovedAt: CommerceDateTime
-  lastSubmittedAt: CommerceDateTime
+  lastApprovedAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
+  lastSubmittedAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   lastTransactionFailed: Boolean
   lineItems(
     # Returns the elements in the list that come after the specified cursor.
@@ -3959,13 +4036,27 @@ interface CommerceOrder {
   sellerTotalCents: Int
   shippingTotalCents: Int
   state: CommerceOrderStateEnum!
-  stateExpiresAt: CommerceDateTime
+  stateExpiresAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   stateReason: String
-  stateUpdatedAt: CommerceDateTime
+  stateUpdatedAt(
+    # This arg is deprecated, use timezone instead
+    convert_to_utc: Boolean
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   taxTotalCents: Int
   totalListPriceCents: Int!
   transactionFeeCents: Int
-  updatedAt: CommerceDateTime!
+  updatedAt: String!
   buyerDetails: OrderParty
   sellerDetails: OrderParty
   itemsTotal(

--- a/src/lib/stitching/exchange/__tests__/replaceComerceDateTime.test.ts
+++ b/src/lib/stitching/exchange/__tests__/replaceComerceDateTime.test.ts
@@ -30,7 +30,7 @@ const schema = transformSchema(originalSchema, [
 ])
 
 describe(ReplaceCommerceDateTimeType, () => {
-  it("renames fields on object types", async () => {
+  it("replaces CommerceDateTime fields", async () => {
     const data = await runQueryOrThrow({
       schema,
       source: gql`

--- a/src/lib/stitching/exchange/__tests__/replaceComerceDateTime.test.ts
+++ b/src/lib/stitching/exchange/__tests__/replaceComerceDateTime.test.ts
@@ -1,0 +1,56 @@
+import { GraphQLSchema, GraphQLObjectType, GraphQLScalarType } from "graphql"
+import { runQueryOrThrow } from "test/utils"
+import gql from "lib/gql"
+import { transformSchema } from "graphql-tools"
+import { ReplaceCommerceDateTimeType } from "../transformers/replaceCommerceDateTimeType"
+
+const originalSchema = new GraphQLSchema({
+  query: new GraphQLObjectType({
+    name: "Query",
+    fields: {
+      someRootField: {
+        type: new GraphQLObjectType({
+          name: "SomeType",
+          fields: {
+            someDateField: {
+              type: new GraphQLScalarType({
+                name: "CommerceDateTime",
+                serialize: x => x,
+              }),
+            },
+          },
+        }),
+      },
+    },
+  }),
+})
+
+const schema = transformSchema(originalSchema, [
+  new ReplaceCommerceDateTimeType(),
+])
+
+describe(ReplaceCommerceDateTimeType, () => {
+  it("renames fields on object types", async () => {
+    const data = await runQueryOrThrow({
+      schema,
+      source: gql`
+        query {
+          someRootField {
+            someDateField(format: "[The year is] YYYY")
+          }
+        }
+      `,
+      rootValue: {
+        someRootField: {
+          someDateField: "2019-07-16T19:39:10.001Z",
+        },
+      },
+      contextValue: {},
+    })
+    expect(data).toEqual({
+      someRootField: {
+        someDateField: "The year is 2019",
+      },
+    })
+  })
+})

--- a/src/lib/stitching/exchange/schema.ts
+++ b/src/lib/stitching/exchange/schema.ts
@@ -6,7 +6,7 @@ import {
   RenameRootFields,
 } from "graphql-tools"
 import { readFileSync } from "fs"
-import { ReplaceCommerceTimeDateType } from "./transformers/replaceCommerceDateTimeType"
+import { ReplaceCommerceDateTimeType } from "./transformers/replaceCommerceDateTimeType"
 
 export const executableExchangeSchema = transforms => {
   const exchangeSDL = readFileSync("src/data/exchange.graphql", "utf8")
@@ -33,7 +33,7 @@ export const transformsForExchange = [
       `commerce${name.charAt(0).toUpperCase() + name.slice(1)}`
   ),
   // replace CommerceDateTime field with MP's dateField
-  new ReplaceCommerceTimeDateType(),
+  new ReplaceCommerceDateTimeType(),
 ]
 
 export const legacyTransformsForExchange = [

--- a/src/lib/stitching/exchange/schema.ts
+++ b/src/lib/stitching/exchange/schema.ts
@@ -6,6 +6,7 @@ import {
   RenameRootFields,
 } from "graphql-tools"
 import { readFileSync } from "fs"
+import { ReplaceCommerceTimeDateType } from "./transformers/replaceCommerceDateTimeType"
 
 export const executableExchangeSchema = transforms => {
   const exchangeSDL = readFileSync("src/data/exchange.graphql", "utf8")
@@ -31,6 +32,8 @@ export const transformsForExchange = [
     (_operation, name) =>
       `commerce${name.charAt(0).toUpperCase() + name.slice(1)}`
   ),
+  // replace CommerceDateTime field with MP's dateField
+  new ReplaceCommerceTimeDateType(),
 ]
 
 export const legacyTransformsForExchange = [

--- a/src/lib/stitching/exchange/transformers/replaceCommerceDateTimeType.ts
+++ b/src/lib/stitching/exchange/transformers/replaceCommerceDateTimeType.ts
@@ -1,0 +1,90 @@
+import { Transform } from "graphql-tools"
+import {
+  GraphQLSchema,
+  GraphQLObjectType,
+  GraphQLInterfaceType,
+  GraphQLFieldConfigMap,
+} from "graphql"
+import {
+  visitSchema,
+  VisitSchemaKind,
+  TypeVisitor,
+} from "graphql-tools/dist/transforms/visitSchema"
+import {
+  createResolveType,
+  fieldToFieldConfig,
+} from "graphql-tools/dist/stitching/schemaRecreation"
+import dateField from "schema/fields/date"
+
+type TypeWithSelectableFields =
+  | GraphQLObjectType<any, any>
+  | GraphQLInterfaceType
+
+export class ReplaceCommerceTimeDateType implements Transform {
+  public transformSchema(schema: GraphQLSchema): GraphQLSchema {
+    const newSchema = visitSchema(schema, {
+      [VisitSchemaKind.OBJECT_TYPE]: ((type: GraphQLObjectType<any, any>) => {
+        const fields = this.transformFields(type)
+        return (
+          fields &&
+          new GraphQLObjectType({
+            fields,
+            name: type.name,
+            description: type.description,
+            astNode: type.astNode,
+            extensionASTNodes: type.extensionASTNodes,
+            isTypeOf: type.isTypeOf,
+            interfaces: type.getInterfaces(),
+          })
+        )
+      }) as TypeVisitor,
+
+      [VisitSchemaKind.INTERFACE_TYPE]: ((type: GraphQLInterfaceType) => {
+        const fields = this.transformFields(type)
+        return (
+          fields &&
+          new GraphQLInterfaceType({
+            fields,
+            name: type.name,
+            description: type.description,
+            astNode: type.astNode,
+            resolveType: type.resolveType,
+            extensionASTNodes: type.extensionASTNodes,
+          })
+        )
+      }) as TypeVisitor,
+    })
+
+    return newSchema
+  }
+
+  private transformFields(type: TypeWithSelectableFields) {
+    let madeChanges = false
+    const fields = type.getFields()
+    const newFields: GraphQLFieldConfigMap<any, any> = {}
+    const resolveType = createResolveType((_name, type) => {
+      if (type.name === "CommerceDateTime") {
+        return dateField.type
+      }
+      return type
+    })
+
+    Object.entries(fields).forEach(([fieldName, fieldDefinition]) => {
+      const fieldConfig = fieldToFieldConfig(fieldDefinition, resolveType, true)
+      // If it's not a type we want to replace, just skip it
+      if (fieldDefinition.type.name !== "CommerceDateTime") {
+        newFields[fieldName] = fieldConfig
+      } else {
+        madeChanges = true
+        newFields[fieldName] = {
+          ...fieldConfig,
+          type: dateField.type,
+          args: { ...dateField.args },
+          resolve: dateField.resolve,
+        }
+      }
+    })
+
+    return madeChanges ? newFields : undefined
+  }
+}

--- a/src/lib/stitching/exchange/transformers/replaceCommerceDateTimeType.ts
+++ b/src/lib/stitching/exchange/transformers/replaceCommerceDateTimeType.ts
@@ -20,7 +20,7 @@ type TypeWithSelectableFields =
   | GraphQLObjectType<any, any>
   | GraphQLInterfaceType
 
-export class ReplaceCommerceTimeDateType implements Transform {
+export class ReplaceCommerceDateTimeType implements Transform {
   public transformSchema(schema: GraphQLSchema): GraphQLSchema {
     const newSchema = visitSchema(schema, {
       [VisitSchemaKind.OBJECT_TYPE]: ((type: GraphQLObjectType<any, any>) => {
@@ -78,9 +78,7 @@ export class ReplaceCommerceTimeDateType implements Transform {
         madeChanges = true
         newFields[fieldName] = {
           ...fieldConfig,
-          type: dateField.type,
-          args: { ...dateField.args },
-          resolve: dateField.resolve,
+          ...dateField,
         }
       }
     })


### PR DESCRIPTION
# Problem
Exchange date fields are exposed as `CommerceDateTime`, when switched to Exchange stitched version, this is different than our old merged version of MP's `dateField`. This makes our switch to stitched Exchange schema painful and almost not possible in a clean way.

# Solution
Before stitchign, transform Exchange's schema by adding a new `Transformer` that replaces `CommerceDateTime` fields with MP's `dateField`.

# Selfie
![image](https://user-images.githubusercontent.com/1230819/60606172-de2b3f00-9d88-11e9-9b46-1c0463136029.png)
