### PR TITLE
[PURCHASE-1268] If work is "Not Signed", we should show "Not signed" in Signature section under artwork details

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -175,6 +175,7 @@ type AnalyticsPageviewStats {
 
 # Audience stats of a partner
 type AnalyticsPartnerAudienceStats {
+  commercialVisitors: Int!
   partnerId: String!
   period: AnalyticsQueryPeriodEnum!
   uniqueVisitors: Int!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -175,6 +175,7 @@ type AnalyticsPageviewStats {
 
 # Audience stats of a partner
 type AnalyticsPartnerAudienceStats {
+  commercialVisitors: Int!
   partnerId: String!
   period: AnalyticsQueryPeriodEnum!
   uniqueVisitors: Int!

--- a/src/schema/artwork/__tests__/artwork.test.js
+++ b/src/schema/artwork/__tests__/artwork.test.js
@@ -1745,7 +1745,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            signatureInfo: { label: "Signature", details: "Not included" },
+            signatureInfo: { label: "Signature", details: "Not signed" },
           },
         })
       })

--- a/src/schema/artwork/__tests__/artwork.test.js
+++ b/src/schema/artwork/__tests__/artwork.test.js
@@ -1705,6 +1705,8 @@ describe("Artwork type", () => {
       artwork.stamped_by_artist_estate = null
       artwork.sticker_label = null
       artwork.signed_other = null
+      artwork.not_signed = null
+
       return runQuery(query, context).then(data => {
         expect(data).toEqual({ artwork: { signatureInfo: null } })
       })
@@ -1715,6 +1717,7 @@ describe("Artwork type", () => {
       artwork.stamped_by_artist_estate = false
       artwork.sticker_label = false
       artwork.signed_other = false
+      artwork.not_signed = false
       return runQuery(query, context).then(data => {
         expect(data).toEqual({ artwork: { signatureInfo: null } })
       })
@@ -1725,13 +1728,29 @@ describe("Artwork type", () => {
       artwork.stamped_by_artist_estate = false
       artwork.sticker_label = false
       artwork.signed_other = true
+      artwork.not_signed = false
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: { signatureInfo: { label: "Signature", details: "" } },
         })
       })
     })
-    it("is set to proper object when several fileds are true", () => {
+    it("is set to proper object when not_signed is true", () => {
+      artwork.signature = ""
+      artwork.signed_by_artist = false
+      artwork.stamped_by_artist_estate = false
+      artwork.sticker_label = false
+      artwork.signed_other = false
+      artwork.not_signed = true
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            signatureInfo: { label: "Signature", details: "Not included" },
+          },
+        })
+      })
+    })
+    it("is set to proper object when several fields are true", () => {
       artwork.signature = "some details about signature"
       artwork.signed_by_artist = true
       artwork.stamped_by_artist_estate = true

--- a/src/schema/artwork/index.ts
+++ b/src/schema/artwork/index.ts
@@ -832,8 +832,8 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           if (signature && signature.length > 0) {
             detailsParts.push(signature)
           }
-          if (detailsParts.length === 0 && not_signed) {
-            detailsParts.push("not included")
+          if (not_signed) {
+            detailsParts.push("not signed")
           }
           if (detailsParts.length === 0 && !signed_other) {
             return null

--- a/src/schema/artwork/index.ts
+++ b/src/schema/artwork/index.ts
@@ -817,6 +817,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           stamped_by_artist_estate,
           sticker_label,
           signed_other,
+          not_signed,
         }) => {
           let detailsParts: string[] = []
           if (signed_by_artist) {
@@ -830,6 +831,9 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           }
           if (signature && signature.length > 0) {
             detailsParts.push(signature)
+          }
+          if (detailsParts.length === 0 && not_signed) {
+            detailsParts.push("not included")
           }
           if (detailsParts.length === 0 && !signed_other) {
             return null


### PR DESCRIPTION
I updated the resolver for signatureInfo so that "Not signed" is added to its details. Previously, if "Not signed" was checked it but there was no data for other fields signatureInfo would resolve to null. I will also update Emission so that we show the details field of signatureInfo instead of just showing signature. If other fields are selected or filled out in addition to "not signed" (Such as "stamped by artist estate") the will be comma separated and will all be displayed.

I am not sure why the "commercialVisitors" schema changes are showing as part of my changes. I did not add them.