### PR TITLE
@sweir27 => [XAPP] Change default setting of xapp token constant to better support reloading

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import chalk from "chalk"
+import xapp from "@artsy/xapp"
 
 require("dotenv").config({
   path: require("path").join(process.cwd(), ".env"),
@@ -175,8 +176,9 @@ export default {
   GRAVITY_API_URL,
   GRAVITY_ID,
   GRAVITY_SECRET,
-  // Gets set from src/index.js
-  GRAVITY_XAPP_TOKEN: null as string | null,
+  // Gets set (+ refreshed) from src/index.js.
+  // Initially set from library for hot-reloading.
+  GRAVITY_XAPP_TOKEN: xapp.token,
   KAWS_API_BASE,
   HMAC_SECRET: HMAC_SECRET as string,
   IMPULSE_API_BASE,


### PR DESCRIPTION
This is a weird one! Basically, when you triggered a hot-reload of schema files, eventually the `config` file would get reloaded (I think). And there...the `GRAVITY_XAPP_TOKEN` is set to `null`. All subsequent unauthenticated requests would then fail (after any 60 second long cached data expired). Making authenticated requests wouldn't result in an error as sending an access token is sufficient.

That's pretty annoying! (and sort of breaks the benefit of hot reloading completely).