### PR TITLE
[test] Fix leak that retains memory across tests.

### DIFF
--- a/__mocks__/dd-trace.js
+++ b/__mocks__/dd-trace.js
@@ -1,0 +1,1 @@
+// No-op: make sure we never load dd-trace in tests, as we run into memory issues.

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -3,8 +3,8 @@ import { isArray } from "lodash"
 import config from "config"
 import { error, verbose } from "./loggers"
 import Memcached from "memcached"
-import { cacheTracer } from "./tracer"
-import { statsClient } from "./stats"
+import { createCacheTracer } from "./tracer"
+import { createStatsClient } from "./stats"
 
 const {
   NODE_ENV,
@@ -79,6 +79,12 @@ function createMemcachedClient() {
 }
 
 export const client = isTest ? createMockClient() : createMemcachedClient()
+
+const cacheTracer: ReturnType<typeof createCacheTracer> = isTest
+  ? { get: x => x, set: x => x, delete: x => x }
+  : createCacheTracer()
+
+const statsClient = isTest ? null : createStatsClient()
 
 function _get<T>(key) {
   return new Promise<T>((resolve, reject) => {

--- a/src/lib/stats.js
+++ b/src/lib/stats.js
@@ -4,88 +4,92 @@ import StatsD from "hot-shots"
 import config from "config"
 import { error } from "./loggers"
 
-const {
-  NODE_ENV,
-  ENABLE_METRICS,
-  STATSD_HOST,
-  STATSD_PORT,
-  DD_TRACER_SERVICE_NAME,
-} = config
+export function createStatsClient() {
+  const {
+    NODE_ENV,
+    ENABLE_METRICS,
+    STATSD_HOST,
+    STATSD_PORT,
+    DD_TRACER_SERVICE_NAME,
+  } = config
 
-const isProd = NODE_ENV === "production"
-const enableMetrics = ENABLE_METRICS === "true"
-const appMetricsDisable = [
-  "http",
-  "http-outbound",
-  "mongo",
-  "socketio",
-  "mqlight",
-  "postgresql",
-  "mqtt",
-  "mysql",
-  "redis",
-  "riak",
-  "memcached",
-  "oracledb",
-  "oracle",
-  "strong-oracle",
-]
+  const isProd = NODE_ENV === "production"
+  const enableMetrics = ENABLE_METRICS === "true"
+  const appMetricsDisable = [
+    "http",
+    "http-outbound",
+    "mongo",
+    "socketio",
+    "mqlight",
+    "postgresql",
+    "mqtt",
+    "mysql",
+    "redis",
+    "riak",
+    "memcached",
+    "oracledb",
+    "oracle",
+    "strong-oracle",
+  ]
 
-export const statsClient = new StatsD({
-  host: STATSD_HOST,
-  port: STATSD_PORT,
-  globalTags: { service: DD_TRACER_SERVICE_NAME, pod_name: os.hostname() },
-  mock: !isProd,
-  errorHandler: function(err) {
-    error(`Statsd client error ${err}`)
-  },
-})
-
-if (enableMetrics && isProd) {
-  const appmetrics = require("appmetrics")
-  appmetrics.configure({
-    mqtt: "off",
-  })
-  const monitoring = appmetrics.monitor()
-  _.forEach(appMetricsDisable, (val, idx) => {
-    appmetrics.disable(val)
+  const statsClient = new StatsD({
+    host: STATSD_HOST,
+    port: STATSD_PORT,
+    globalTags: { service: DD_TRACER_SERVICE_NAME, pod_name: os.hostname() },
+    mock: !isProd,
+    errorHandler: function(err) {
+      error(`Statsd client error ${err}`)
+    },
   })
 
-  monitoring.on("loop", loopMetrics => {
-    statsClient.timing("loop.count_per_five_seconds", loopMetrics.count)
-    statsClient.timing("loop.minimum_loop_duration", loopMetrics.minimum)
-    statsClient.timing("loop.maximum_loop_duration", loopMetrics.maximum)
-    statsClient.timing("loop.cpu_usage_in_userland", loopMetrics.cpu_user)
-    statsClient.timing("loop.cpu_usage_in_system", loopMetrics.cpu_system)
-  })
-
-  monitoring.on("eventloop", eventloopMetrics => {
-    statsClient.timing("eventloop.latency.min", eventloopMetrics.latency.min)
-    statsClient.timing("eventloop.latency.max", eventloopMetrics.latency.max)
-    statsClient.timing("eventloop.latency.avg", eventloopMetrics.latency.avg)
-  })
-
-  monitoring.on("memory", memoryMetrics => {
-    statsClient.gauge("memory.physical", memoryMetrics.physical)
-    statsClient.gauge("memory.virtual", memoryMetrics.virtual)
-  })
-
-  monitoring.on("gc", gcMetrics => {
-    statsClient.gauge("gc.heap_size", gcMetrics.size)
-    statsClient.gauge("gc.heap_used", gcMetrics.used)
-    statsClient.timing("gc.sweep_duration", gcMetrics.duration, {
-      sweep_type: gcMetrics.type,
+  if (enableMetrics && isProd) {
+    const appmetrics = require("appmetrics")
+    appmetrics.configure({
+      mqtt: "off",
     })
-  })
+    const monitoring = appmetrics.monitor()
+    _.forEach(appMetricsDisable, (val, idx) => {
+      appmetrics.disable(val)
+    })
 
-  setInterval(() => {
-    statsClient.gauge(
-      "process.active_handles",
-      process._getActiveHandles().length
-    )
-    statsClient.gauge(
-      "process.active_requests",
-      process._getActiveRequests().length
-    )
-  }, 5000)
+    monitoring.on("loop", loopMetrics => {
+      statsClient.timing("loop.count_per_five_seconds", loopMetrics.count)
+      statsClient.timing("loop.minimum_loop_duration", loopMetrics.minimum)
+      statsClient.timing("loop.maximum_loop_duration", loopMetrics.maximum)
+      statsClient.timing("loop.cpu_usage_in_userland", loopMetrics.cpu_user)
+      statsClient.timing("loop.cpu_usage_in_system", loopMetrics.cpu_system)
+    })
+
+    monitoring.on("eventloop", eventloopMetrics => {
+      statsClient.timing("eventloop.latency.min", eventloopMetrics.latency.min)
+      statsClient.timing("eventloop.latency.max", eventloopMetrics.latency.max)
+      statsClient.timing("eventloop.latency.avg", eventloopMetrics.latency.avg)
+    })
+
+    monitoring.on("memory", memoryMetrics => {
+      statsClient.gauge("memory.physical", memoryMetrics.physical)
+      statsClient.gauge("memory.virtual", memoryMetrics.virtual)
+    })
+
+    monitoring.on("gc", gcMetrics => {
+      statsClient.gauge("gc.heap_size", gcMetrics.size)
+      statsClient.gauge("gc.heap_used", gcMetrics.used)
+      statsClient.timing("gc.sweep_duration", gcMetrics.duration, {
+        sweep_type: gcMetrics.type,
+      })
+    })
+
+    setInterval(() => {
+      statsClient.gauge(
+        "process.active_handles",
+        process._getActiveHandles().length
+      )
+      statsClient.gauge(
+        "process.active_requests",
+        process._getActiveRequests().length
+      )
+    }, 5000)
+  }
+
+  return statsClient
 }

--- a/src/lib/tracer.ts
+++ b/src/lib/tracer.ts
@@ -66,8 +66,10 @@ const createCommand = (command: string) => <T>(
   )
 }
 
-export const cacheTracer = {
-  get: createCommand("get"),
-  set: createCommand("set"),
-  delete: createCommand("delete"),
+export function createCacheTracer() {
+  return {
+    get: createCommand("get"),
+    set: createCommand("set"),
+    delete: createCommand("delete"),
+  }
 }


### PR DESCRIPTION
The combination of dd-trace and (probably) statsd seems to be causing
this. I dug a bit into dd-trace upto TracerProxy, but still unsure where
the exact cycle is. For now, and also in general, not loading these
libraries at all during tests is a good enough solution.