### PR TITLE
[v2] drop IDs transform

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3247,9 +3247,7 @@ type CitySponsoredContent {
 type Collection implements Node {
   # A globally unique ID.
   id: ID!
-
-  # A slug ID.
-  slug: ID!
+  slug: String!
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
@@ -7933,7 +7931,7 @@ input Near {
 
 # An object with a Globally Unique ID
 interface Node {
-  # The ID of the object.
+  # A globally unique ID.
   id: ID!
 }
 
@@ -9700,9 +9698,9 @@ type Query {
   ): [Gene]
   me: Me
 
-  # Fetches an object given its Globally Unique ID
+  # Fetches an object given its globally unique ID.
   node(
-    # The globally unique ID of the node
+    # The globally unique ID of the node.
     id: ID!
   ): Node
 
@@ -11827,9 +11825,9 @@ type Viewer {
   ): [Gene]
   me: Me
 
-  # Fetches an object given its Globally Unique ID
+  # Fetches an object given its globally unique ID.
   node(
-    # The globally unique ID of the node
+    # The globally unique ID of the node.
     id: ID!
   ): Node
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9702,7 +9702,7 @@ type Query {
 
   # Fetches an object given its Globally Unique ID
   node(
-    # The ID of the object
+    # The globally unique ID of the node
     id: ID!
   ): Node
 
@@ -11829,7 +11829,7 @@ type Viewer {
 
   # Fetches an object given its Globally Unique ID
   node(
-    # The ID of the object
+    # The globally unique ID of the node
     id: ID!
   ): Node
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3247,7 +3247,9 @@ type CitySponsoredContent {
 type Collection implements Node {
   # A globally unique ID.
   id: ID!
-  slug: String!
+
+  # A slug ID.
+  slug: ID!
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!

--- a/package.json
+++ b/package.json
@@ -155,7 +155,8 @@
       "/src/test/helper.js",
       "/src/test/utils.js",
       "/src/test/gql.js",
-      "/src/test/__mocks__"
+      "/src/test/__mocks__",
+      "/src/schema/v2"
     ],
     "transform": {
       "^.+\\.(js|ts)$": "babel-jest"

--- a/src/schema/v2/SearchableItem/index.ts
+++ b/src/schema/v2/SearchableItem/index.ts
@@ -19,8 +19,8 @@ export const SearchableItem = new GraphQLObjectType<any, ResolverContext>({
   interfaces: [NodeInterface, Searchable],
   fields: {
     ...SlugAndInternalIDFields,
-    __id: {
-      ...SlugAndInternalIDFields.__id,
+    id: {
+      ...SlugAndInternalIDFields.id,
       type: new GraphQLNonNull(GraphQLID),
       resolve: item => toGlobalId("SearchableItem", item._id),
     },

--- a/src/schema/v2/__tests__/filter_artworks.test.js
+++ b/src/schema/v2/__tests__/filter_artworks.test.js
@@ -104,7 +104,7 @@ describe("Filter Artworks", () => {
 
       const query = `
         {
-          node(__id: "${generatedId}") {
+          node(id: "${generatedId}") {
             __id
           }
         }

--- a/src/schema/v2/__tests__/object_identification.test.js
+++ b/src/schema/v2/__tests__/object_identification.test.js
@@ -77,7 +77,7 @@ describe("Object Identification", () => {
       it("resolves a node", () => {
         const query = `
           {
-            node(__id: "${toGlobalId(typeName, "foo-bar")}") {
+            node(id: "${toGlobalId(typeName, "foo-bar")}") {
               __typename
               ... on ${typeName} {
                 id
@@ -118,7 +118,7 @@ describe("Object Identification", () => {
     it("resolves a node", () => {
       const query = `
         {
-          node(__id: "${globalId}") {
+          node(id: "${globalId}") {
             __typename
             ... on Me {
               id
@@ -165,7 +165,7 @@ describe("Object Identification", () => {
       it("resolves a node", () => {
         const query = `
           {
-            node(__id: "${globalId}") {
+            node(id: "${globalId}") {
               __typename
               ... on HomePageArtworkModule {
                 key
@@ -211,7 +211,7 @@ describe("Object Identification", () => {
       it("resolves a node", () => {
         const query = `
           {
-            node(__id: "${globalId}") {
+            node(id: "${globalId}") {
               __typename
               ... on HomePageArtworkModule {
                 key
@@ -269,7 +269,7 @@ describe("Object Identification", () => {
       it("resolves a node", () => {
         const query = `
           {
-            node(__id: "${globalId}") {
+            node(id: "${globalId}") {
               __typename
               ... on HomePageArtworkModule {
                 key
@@ -324,7 +324,7 @@ describe("Object Identification", () => {
     it("resolves a node", () => {
       const query = `
         {
-          node(__id: "${globalId}") {
+          node(id: "${globalId}") {
             __typename
             ... on HomePageArtistModule {
               key
@@ -352,7 +352,7 @@ describe("Object Identification", () => {
     it("should pass the proper inline fragment AST", () => {
       const query = `
         {
-          node(__id: "${globalId}") {
+          node(id: "${globalId}") {
             ... on Me {
               id
             }
@@ -370,7 +370,7 @@ describe("Object Identification", () => {
     it("should pass the proper spread fragment AST", () => {
       const query = `
         {
-          node(__id: "${globalId}") {
+          node(id: "${globalId}") {
             ... fields
           }
         }

--- a/src/schema/v2/__tests__/users.test.js
+++ b/src/schema/v2/__tests__/users.test.js
@@ -5,18 +5,18 @@ describe("Users", () => {
   it("returns a list of users matching array of ids", async () => {
     const usersLoader = data => {
       if (data.id) {
-        return Promise.resolve(data.id.map(id => ({ id })))
+        return Promise.resolve(data.id.map(id => ({ internalID: id })))
       }
       throw new Error("Unexpected invocation")
     }
     const query = gql`
       {
         users(ids: ["5a9075da8b3b817ede4f8767"]) {
-          id
+          internalID
         }
       }
     `
     const { users } = await runAuthenticatedQuery(query, { usersLoader })
-    expect(users[0].id).toEqual("5a9075da8b3b817ede4f8767")
+    expect(users[0].internalID).toEqual("5a9075da8b3b817ede4f8767")
   })
 })

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -15,7 +15,7 @@ describe("Artwork type", () => {
   const artworkImages = [
     {
       is_default: false,
-      id: "56b6311876143f4e82000188",
+      internalID: "56b6311876143f4e82000188",
       image_url: "https://xxx.cloudfront.net/xxx/:version.jpg",
       image_versions: ["icon", "large"],
       image_urls: {
@@ -25,7 +25,7 @@ describe("Artwork type", () => {
     },
     {
       is_default: true,
-      id: "56b64ed2cd530e670c0000b2",
+      internalID: "56b64ed2cd530e670c0000b2",
       image_url: "https://xxx.cloudfront.net/xxx/:version.jpg",
       image_versions: ["icon", "large"],
       image_urls: {
@@ -37,7 +37,7 @@ describe("Artwork type", () => {
 
   beforeEach(() => {
     artwork = {
-      id: "richard-prince-untitled-portrait",
+      slug: "richard-prince-untitled-portrait",
       title: "Untitled (Portrait)",
       forsale: true,
       acquireable: false,
@@ -59,7 +59,7 @@ describe("Artwork type", () => {
     const query = `
       {
         artwork(id: "richard-prince-untitled-portrait") {
-          id
+          slug
           width
           height
           metric
@@ -86,7 +86,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             width: "2",
             height: "3",
             metric: "cm",
@@ -100,7 +100,7 @@ describe("Artwork type", () => {
     const query = `
       {
         artwork(id: "richard-prince-untitled-portrait") {
-          id
+          slug
           sizeScore
         }
       }
@@ -123,7 +123,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             sizeScore: 2.5,
           },
         })
@@ -135,7 +135,7 @@ describe("Artwork type", () => {
     const query = `
       {
         artwork(id: "richard-prince-untitled-portrait") {
-          id
+          slug
           is_contactable
         }
       }
@@ -152,7 +152,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             is_contactable: true,
           },
         })
@@ -166,7 +166,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             is_contactable: false,
           },
         })
@@ -178,7 +178,7 @@ describe("Artwork type", () => {
     const query = `
       {
         artwork(id: "richard-prince-untitled-portrait") {
-          id
+          slug
           is_downloadable
         }
       }
@@ -198,7 +198,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             is_downloadable: true,
           },
         })
@@ -222,7 +222,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             is_downloadable: false,
           },
         })
@@ -236,7 +236,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             is_downloadable: false,
           },
         })
@@ -248,7 +248,7 @@ describe("Artwork type", () => {
     const query = `
       {
         artwork(id: "richard-prince-untitled-portrait") {
-          id
+          slug
           is_purchasable
         }
       }
@@ -261,7 +261,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             is_purchasable: null,
           },
         })
@@ -273,7 +273,7 @@ describe("Artwork type", () => {
     const query = `
       {
         artwork(id: "richard-prince-untitled-portrait") {
-          id
+          slug
           is_offerable
         }
       }
@@ -285,7 +285,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             is_offerable: true,
           },
         })
@@ -359,7 +359,7 @@ describe("Artwork type", () => {
     const query = `
       {
         artwork(id: "richard-prince-untitled-portrait") {
-          id
+          slug
           pickup_available
         }
       }
@@ -371,7 +371,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             pickup_available: true,
           },
         })
@@ -384,7 +384,7 @@ describe("Artwork type", () => {
       {
         artwork(id: "richard-prince-untitled-portrait") {
           image {
-            id
+            internalID
           }
         }
       }
@@ -397,7 +397,7 @@ describe("Artwork type", () => {
         expect(data).toEqual({
           artwork: {
             image: {
-              id: "56b64ed2cd530e670c0000b2",
+              internalID: "56b64ed2cd530e670c0000b2",
             },
           },
         })
@@ -511,23 +511,23 @@ describe("Artwork type", () => {
     it("can sort by price ascending", () => {
       artwork.edition_sets = [
         {
-          id: "$200",
+          internalID: "$200",
           price_cents: [200],
         },
         {
-          id: "$100-400",
+          internalID: "$100-400",
           price_cents: [100, 400],
         },
         {
-          id: "Under 400",
+          internalID: "Under 400",
           price_cents: [null, 400],
         },
         {
-          id: "$400 and up",
+          internalID: "$400 and up",
           price_cents: [400, null],
         },
         {
-          id: "not for sale",
+          internalID: "not for sale",
           price_cents: [],
         },
       ]
@@ -536,7 +536,7 @@ describe("Artwork type", () => {
       {
         artwork(id: "richard-prince-untitled-portrait") {
           edition_sets(sort: PRICE_ASC) {
-            id
+            internalID 
           }
         }
       }
@@ -546,19 +546,19 @@ describe("Artwork type", () => {
           artwork: {
             edition_sets: [
               {
-                id: "Under 400",
+                internalID: "Under 400",
               },
               {
-                id: "$100-400",
+                internalID: "$100-400",
               },
               {
-                id: "$200",
+                internalID: "$200",
               },
               {
-                id: "$400 and up",
+                internalID: "$400 and up",
               },
               {
-                id: "not for sale",
+                internalID: "not for sale",
               },
             ],
           },
@@ -571,7 +571,7 @@ describe("Artwork type", () => {
     const query = `
       {
         artwork(id: "richard-prince-untitled-portrait") {
-          id
+          slug
           is_in_auction
         }
       }
@@ -587,7 +587,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             is_in_auction: true,
           },
         })
@@ -600,7 +600,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             is_in_auction: false,
           },
         })
@@ -612,7 +612,7 @@ describe("Artwork type", () => {
     const query = `
       {
         artwork(id: "richard-prince-untitled-portrait") {
-          id
+          slug
           sale_message
         }
       }
@@ -626,7 +626,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             sale_message: "On hold",
           },
         })
@@ -641,7 +641,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             sale_message: "$420,000, on hold",
           },
         })
@@ -654,7 +654,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             sale_message: "Sold",
           },
         })
@@ -667,7 +667,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             sale_message: null,
           },
         })
@@ -681,7 +681,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             sale_message: "On loan",
           },
         })
@@ -696,7 +696,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             sale_message: null,
           },
         })
@@ -710,7 +710,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             sale_message: "Permanent collection",
           },
         })
@@ -724,7 +724,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             sale_message: "something from gravity",
           },
         })
@@ -736,7 +736,7 @@ describe("Artwork type", () => {
     const query = `
       {
         artwork(id: "richard-prince-untitled-portrait") {
-          id
+          slug
           contact_message
         }
       }
@@ -748,7 +748,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             contact_message:
               "Hello, I am interested in placing a bid on this work. Please send me more information.", // eslint-disable-line max-len
           },
@@ -763,7 +763,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             contact_message: null,
           },
         })
@@ -776,7 +776,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             contact_message:
               "Hi, I’m interested in similar works by this artist. Could you please let me know if you have anything available?", // eslint-disable-line max-len
           },
@@ -789,7 +789,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             contact_message:
               "Hi, I’m interested in similar works by this artist. Could you please let me know if you have anything available?", // eslint-disable-line max-len
           },
@@ -801,7 +801,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             contact_message:
               "Hi, I’m interested in purchasing this work. Could you please provide more information about the piece?", // eslint-disable-line max-len
           },
@@ -813,7 +813,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             contact_message: null,
           },
         })
@@ -871,7 +871,7 @@ describe("Artwork type", () => {
     const query = `
       {
         artwork(id: "richard-prince-untitled-portrait") {
-          id
+          slug
           is_biddable
         }
       }
@@ -882,7 +882,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             is_biddable: true,
           },
         })
@@ -894,7 +894,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             is_biddable: false,
           },
         })
@@ -906,7 +906,7 @@ describe("Artwork type", () => {
     const query = `
       {
         artwork(id: "richard-prince-untitled-portrait") {
-          id
+          slug
           is_buy_nowable
         }
       }
@@ -917,14 +917,14 @@ describe("Artwork type", () => {
       context.salesLoader = sinon.stub().returns(
         Promise.resolve([
           {
-            id: "sale-id",
+            slug: "sale-id",
           },
         ])
       )
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             is_buy_nowable: true,
           },
         })
@@ -936,14 +936,14 @@ describe("Artwork type", () => {
       context.salesLoader = sinon.stub().returns(
         Promise.resolve([
           {
-            id: "sale-id",
+            slug: "sale-id",
           },
         ])
       )
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             is_buy_nowable: false,
           },
         })
@@ -956,7 +956,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             is_buy_nowable: false,
           },
         })
@@ -1008,7 +1008,7 @@ describe("Artwork type", () => {
       const query = `
         {
           artwork(id: "richard-prince-untitled-portrait") {
-            id
+            slug
             is_shareable
           }
         }
@@ -1026,7 +1026,7 @@ describe("Artwork type", () => {
       const query = `
         {
           artwork(id: "richard-prince-untitled-portrait") {
-            id
+            slug
             is_hangable
           }
         }
@@ -1111,7 +1111,7 @@ describe("Artwork type", () => {
       const query = `
         {
           artwork(id: "richard-prince-untitled-portrait") {
-            id
+            slug
             is_inquireable
           }
         }
@@ -1147,7 +1147,7 @@ describe("Artwork type", () => {
       const query = `
         {
           artwork(id: "richard-prince-untitled-portrait") {
-            id
+            slug
             signature(format: HTML)
           }
         }
@@ -1166,7 +1166,7 @@ describe("Artwork type", () => {
     const query = `
       {
         artwork(id: "richard-prince-untitled-portrait") {
-          id
+          slug
           is_price_range
         }
       }
@@ -1177,7 +1177,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             is_price_range: true,
           },
         })
@@ -1189,7 +1189,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             is_price_range: false,
           },
         })
@@ -1202,7 +1202,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             is_price_range: false,
           },
         })
@@ -1215,7 +1215,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             is_price_range: true,
           },
         })
@@ -1228,7 +1228,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            id: "richard-prince-untitled-portrait",
+            slug: "richard-prince-untitled-portrait",
             is_price_range: false,
           },
         })
@@ -1270,8 +1270,8 @@ describe("Artwork type", () => {
 
   describe("#myLotStanding", () => {
     const lotStandings = [
-      { sale_artwork: { id: "past" } },
-      { sale_artwork: { id: "live" } },
+      { sale_artwork: { slug: "past" } },
+      { sale_artwork: { slug: "live" } },
     ]
 
     function query(live) {
@@ -1280,7 +1280,7 @@ describe("Artwork type", () => {
           artwork(id: "richard-prince-untitled-portrait") {
             myLotStanding${live === undefined ? "" : `(live: ${live})`} {
               sale_artwork {
-                id
+                slug
               }
             }
           }
@@ -1303,8 +1303,8 @@ describe("Artwork type", () => {
       return runQuery(query(undefined), context).then(
         ({ artwork: { myLotStanding } }) => {
           expect(myLotStanding).toEqual([
-            { sale_artwork: { id: "past" } },
-            { sale_artwork: { id: "live" } },
+            { sale_artwork: { slug: "past" } },
+            { sale_artwork: { slug: "live" } },
           ])
         }
       )
@@ -1314,8 +1314,8 @@ describe("Artwork type", () => {
       return runQuery(query(null), context).then(
         ({ artwork: { myLotStanding } }) => {
           expect(myLotStanding).toEqual([
-            { sale_artwork: { id: "past" } },
-            { sale_artwork: { id: "live" } },
+            { sale_artwork: { slug: "past" } },
+            { sale_artwork: { slug: "live" } },
           ])
         }
       )
@@ -1324,7 +1324,7 @@ describe("Artwork type", () => {
     it("returns only lot standings for live sales", () => {
       return runQuery(query(true), context).then(
         ({ artwork: { myLotStanding } }) => {
-          expect(myLotStanding).toEqual([{ sale_artwork: { id: "live" } }])
+          expect(myLotStanding).toEqual([{ sale_artwork: { slug: "live" } }])
         }
       )
     })
@@ -1332,7 +1332,7 @@ describe("Artwork type", () => {
     it("returns only lot standings for not-live sales", () => {
       return runQuery(query(false), context).then(
         ({ artwork: { myLotStanding } }) => {
-          expect(myLotStanding).toEqual([{ sale_artwork: { id: "past" } }])
+          expect(myLotStanding).toEqual([{ sale_artwork: { slug: "past" } }])
         }
       )
     })
@@ -1637,7 +1637,7 @@ describe("Artwork type", () => {
       })
     })
 
-    it("is set to concatinated values from shipping_origin when shipping origin is present", () => {
+    it("is set to concatenated values from shipping_origin when shipping origin is present", () => {
       artwork.shipping_origin = ["Kharkov", "Ukraine"]
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
@@ -1654,7 +1654,7 @@ describe("Artwork type", () => {
       {
         artwork(id: "richard-prince-untitled-portrait") {
           framed {
-            label,
+            label
             details
           }
         }
@@ -1693,7 +1693,7 @@ describe("Artwork type", () => {
       {
         artwork(id: "richard-prince-untitled-portrait") {
           signatureInfo {
-            label,
+            label
             details
           }
         }
@@ -1792,7 +1792,7 @@ describe("Artwork type", () => {
       {
         artwork(id: "richard-prince-untitled-portrait") {
           conditionDescription {
-            label,
+            label
             details
           }
         }
@@ -1857,7 +1857,7 @@ describe("Artwork type", () => {
       {
         artwork(id: "richard-prince-untitled-portrait") {
           certificateOfAuthenticity {
-            label,
+            label
             details
           }
         }

--- a/src/schema/v2/artwork/artworkContextGrids/__tests__/fairContext.test.ts
+++ b/src/schema/v2/artwork/artworkContextGrids/__tests__/fairContext.test.ts
@@ -16,7 +16,7 @@ describe("Show Context", () => {
           artworks(first: 2) {
             edges {
               node {
-                id
+                slug
                 title
               }
             }
@@ -43,21 +43,21 @@ describe("Show Context", () => {
     })
 
     const artistArtworks = [
-      { id: "artwork1", title: "Artwork 1" },
-      { id: "artwork2", title: "Artwork 2" },
-      { id: "artwork3", title: "Artwork 3" },
+      { slug: "artwork1", title: "Artwork 1" },
+      { slug: "artwork2", title: "Artwork 2" },
+      { slug: "artwork3", title: "Artwork 3" },
     ]
 
     const partnerArtworks = [
-      { id: "partnerArtwork1", title: "Partner Artwork 1" },
-      { id: "partnerArtwork2", title: "Partner Artwork 2" },
-      { id: "partnerArtwork3", title: "Partner Artwork 3" },
+      { slug: "partnerArtwork1", title: "Partner Artwork 1" },
+      { slug: "partnerArtwork2", title: "Partner Artwork 2" },
+      { slug: "partnerArtwork3", title: "Partner Artwork 3" },
     ]
 
     const showArtworks = [
-      { id: "showArtwork1", title: "Show Artwork 1" },
-      { id: "showArtwork2", title: "Show Artwork 2" },
-      { id: "showArtwork3", title: "Show Artwork 3" },
+      { slug: "showArtwork1", title: "Show Artwork 1" },
+      { slug: "showArtwork2", title: "Show Artwork 2" },
+      { slug: "showArtwork3", title: "Show Artwork 3" },
     ]
 
     context = {
@@ -122,9 +122,9 @@ describe("Show Context", () => {
     context.relatedLayersLoader = () => Promise.resolve([{ id: "main" }])
     context.relatedLayerArtworksLoader = () =>
       Promise.resolve([
-        { id: "relatedArtwork1", title: "Related Artwork 1" },
-        { id: "relatedArtwork2", title: "Related Artwork 2" },
-        { id: "relatedArtwork3", title: "Related Artwork 3" },
+        { slug: "relatedArtwork1", title: "Related Artwork 1" },
+        { slug: "relatedArtwork2", title: "Related Artwork 2" },
+        { slug: "relatedArtwork3", title: "Related Artwork 3" },
       ])
 
     return runAuthenticatedQuery(query, context).then(data => {
@@ -142,7 +142,7 @@ describe("Show Context", () => {
       expect(showTitle).toEqual("Other works from Cool Show")
       expect(showCtaTitle).toEqual("View all works from the booth")
       expect(showctaHref).toEqual("/show/cool-show")
-      expect(showArtworks.edges.map(({ node }) => node.id)).toEqual([
+      expect(showArtworks.edges.map(({ node }) => node.slug)).toEqual([
         "showArtwork1",
         "showArtwork2",
       ])
@@ -158,7 +158,7 @@ describe("Show Context", () => {
       expect(artistTitle).toEqual("Other works by Andy Warhol")
       expect(artistCtaTitle).toEqual("View all works by Andy Warhol")
       expect(artistctaHref).toEqual("/artist/andy-warhol")
-      expect(artistArtworks.edges.map(({ node }) => node.id)).toEqual([
+      expect(artistArtworks.edges.map(({ node }) => node.slug)).toEqual([
         "artwork1",
         "artwork2",
       ])
@@ -174,7 +174,7 @@ describe("Show Context", () => {
       expect(relatedTitle).toEqual("Related works")
       expect(relatedCtaTitle).toEqual(null)
       expect(relatedctaHref).toEqual(null)
-      expect(relatedArtworks.edges.map(({ node }) => node.id)).toEqual([
+      expect(relatedArtworks.edges.map(({ node }) => node.slug)).toEqual([
         "relatedArtwork1",
         "relatedArtwork2",
       ])

--- a/src/schema/v2/collection.ts
+++ b/src/schema/v2/collection.ts
@@ -79,9 +79,6 @@ export const CollectionType = new GraphQLObjectType<any, ResolverContext>({
     private: {
       type: new GraphQLNonNull(GraphQLBoolean),
     },
-    slug: {
-      type: new GraphQLNonNull(GraphQLString),
-    },
   },
 })
 

--- a/src/schema/v2/featured_link.ts
+++ b/src/schema/v2/featured_link.ts
@@ -8,9 +8,9 @@ const FeaturedLinkType = new GraphQLObjectType<any, ResolverContext>({
   name: "FeaturedLink",
   fields: {
     ...InternalIDFields,
-    id: {
+    internalID: {
       type: GraphQLString,
-      description: InternalIDFields.id.description,
+      description: InternalIDFields.internalID.description,
       resolve: ({ href }) =>
         href
           .split("/")

--- a/src/schema/v2/filter_artworks.ts
+++ b/src/schema/v2/filter_artworks.ts
@@ -88,7 +88,7 @@ export const FilterArtworksType = new GraphQLObjectType<any, ResolverContext>({
   name: "FilterArtworks",
   interfaces: [NodeInterface],
   fields: () => ({
-    __id: {
+    id: {
       type: new GraphQLNonNull(GraphQLID),
       description: "The ID of the object.",
       resolve: ({ options }) =>

--- a/src/schema/v2/home/home_page_artist_module.ts
+++ b/src/schema/v2/home/home_page_artist_module.ts
@@ -68,7 +68,7 @@ export const HomePageArtistModuleType = new GraphQLObjectType<
   name: "HomePageArtistModule",
   interfaces: [NodeInterface],
   fields: {
-    __id: {
+    id: {
       type: new GraphQLNonNull(GraphQLID),
       description: "A globally unique ID.",
       resolve: ({ key }) => {

--- a/src/schema/v2/home/home_page_artwork_module.ts
+++ b/src/schema/v2/home/home_page_artwork_module.ts
@@ -26,7 +26,7 @@ export const HomePageArtworkModuleType = new GraphQLObjectType<
   name: "HomePageArtworkModule",
   interfaces: [NodeInterface],
   fields: () => ({
-    __id: {
+    id: {
       type: new GraphQLNonNull(GraphQLID),
       description: "A globally unique ID.",
       resolve: ({ key, params }) => {

--- a/src/schema/v2/match/__tests__/gene.test.js
+++ b/src/schema/v2/match/__tests__/gene.test.js
@@ -6,21 +6,21 @@ describe("MatchGene", () => {
     const query = `
       {
         match_gene(term: "pop") {
-          id
+          slug
           name
-          _id
+          internalID
         }
       }
     `
     const response = [
       {
         family: {
-          _id: "575ac46debad644c13000005",
-          id: "styles-and-movements",
+          internalID: "575ac46debad644c13000005",
+          slug: "styles-and-movements",
           name: "Styles and Movements",
         },
-        _id: "123456",
-        id: "pop-art",
+        internalID: "123456",
+        slug: "pop-art",
         name: "Pop Art",
         image_urls: {
           big_and_tall:
@@ -40,7 +40,9 @@ describe("MatchGene", () => {
 
     return runQuery(query, { matchGeneLoader }).then(data => {
       expect(data).toEqual({
-        match_gene: [{ id: "pop-art", name: "Pop Art", _id: "123456" }],
+        match_gene: [
+          { slug: "pop-art", name: "Pop Art", internalID: "123456" },
+        ],
       })
     })
   })

--- a/src/schema/v2/me/conversation/index.ts
+++ b/src/schema/v2/me/conversation/index.ts
@@ -158,7 +158,7 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
   description: "A conversation.",
   interfaces: [NodeInterface],
   fields: {
-    __id: GlobalIDField,
+    id: GlobalIDField,
     ...NullableIDField,
     inquiry_id: {
       description: "Gravity inquiry id.",

--- a/src/schema/v2/me/conversation/message.ts
+++ b/src/schema/v2/me/conversation/message.ts
@@ -40,7 +40,6 @@ export const MessageType = new GraphQLObjectType<any, ResolverContext>({
   description: "A message in a conversation.",
   interfaces: [NodeInterface],
   fields: {
-    __id: GlobalIDField,
     ...InternalIDFields,
     // This alias exists specifically because our fork of Relay Classic did not yet properly support using `__id`
     // instead of `id`, which lead to Relay overwriting `id` fields with the `__id` value. Thus using a completely

--- a/src/schema/v2/me/conversation/message.ts
+++ b/src/schema/v2/me/conversation/message.ts
@@ -7,7 +7,6 @@ import {
   GraphQLNonNull,
 } from "graphql"
 import {
-  GlobalIDField,
   NodeInterface,
   InternalIDFields,
 } from "schema/v2/object_identification"

--- a/src/schema/v2/me/followed_artists_artworks_group.ts
+++ b/src/schema/v2/me/followed_artists_artworks_group.ts
@@ -24,7 +24,7 @@ const FollowedArtistsArtworksGroupType = new GraphQLObjectType<
   name: "FollowedArtistsArtworksGroup",
   interfaces: [NodeInterface],
   fields: () => ({
-    __id: GlobalIDField,
+    id: GlobalIDField,
     href: {
       type: GraphQLString,
       resolve: ({ artistSlug }) => `/artist/${artistSlug}`,

--- a/src/schema/v2/me/notifications.ts
+++ b/src/schema/v2/me/notifications.ts
@@ -20,7 +20,7 @@ const NotificationsFeedItemType = new GraphQLObjectType<any, ResolverContext>({
   name: "NotificationsFeedItem",
   interfaces: [NodeInterface],
   fields: () => ({
-    __id: GlobalIDField,
+    id: GlobalIDField,
     artists: {
       type: GraphQLString,
       resolve: ({ actors }) => actors,

--- a/src/schema/v2/object_identification.ts
+++ b/src/schema/v2/object_identification.ts
@@ -108,22 +108,22 @@ function rootValueForChild(rootValue) {
 export const NodeInterface = new GraphQLInterfaceType({
   name: "Node",
   description: "An object with a Globally Unique ID",
-  fields: () => ({
-    __id: {
-      type: new GraphQLNonNull(GraphQLID),
-      description: "The ID of the object.",
-    },
-  }),
+  fields: () => {
+    const { resolve, ...id } = GlobalIDField
+    return {
+      id,
+    }
+  },
   resolveType: ({ __type }) => __type,
 })
 
 const NodeField: GraphQLFieldConfig<any, ResolverContext> = {
-  description: "Fetches an object given its Globally Unique ID",
+  description: "Fetches an object given its globally unique ID.",
   type: NodeInterface,
   args: {
     id: {
       type: new GraphQLNonNull(GraphQLID),
-      description: "The globally unique ID of the node",
+      description: "The globally unique ID of the node.",
     },
   },
   // Re-uses (slightly abuses) the existing GraphQL `resolve` function.
@@ -162,15 +162,15 @@ export const GlobalIDField: GraphQLFieldConfig<any, ResolverContext> = {
 }
 
 export const NullableIDField: GraphQLFieldConfigMap<any, ResolverContext> = {
-  id: {
+  internalID: {
     description: "An optional type-specific ID.",
     type: GraphQLID,
   },
 }
 
 export const IDFields: GraphQLFieldConfigMap<any, ResolverContext> = {
-  __id: GlobalIDField,
-  id: {
+  id: GlobalIDField,
+  internalID: {
     description: "A type-specific ID.",
     type: new GraphQLNonNull(GraphQLID),
   },
@@ -178,14 +178,14 @@ export const IDFields: GraphQLFieldConfigMap<any, ResolverContext> = {
 
 export const GravityIDFields: GraphQLFieldConfigMap<any, ResolverContext> = {
   ...IDFields,
-  _id: {
+  internalID: {
     description: "A type-specific Gravity Mongo Document ID.",
     type: new GraphQLNonNull(GraphQLID),
   },
 }
 
 export const SlugIDField: GraphQLFieldConfigMap<any, ResolverContext> = {
-  id: {
+  slug: {
     description: "A slug ID.",
     type: new GraphQLNonNull(GraphQLID),
   },
@@ -195,20 +195,20 @@ export const SlugAndInternalIDFields: GraphQLFieldConfigMap<
   any,
   ResolverContext
 > = {
-  __id: GlobalIDField,
-  id: {
+  id: GlobalIDField,
+  slug: {
     description: "A slug ID.",
     type: new GraphQLNonNull(GraphQLID),
   },
-  _id: {
+  internalID: {
     description: "A type-specific ID likely used as a database ID.",
     type: new GraphQLNonNull(GraphQLID),
   },
 }
 
 export const InternalIDFields: GraphQLFieldConfigMap<any, ResolverContext> = {
-  __id: GlobalIDField,
-  id: {
+  id: GlobalIDField,
+  internalID: {
     description: "A type-specific ID likely used as a database ID.",
     type: new GraphQLNonNull(GraphQLID),
   },

--- a/src/schema/v2/object_identification.ts
+++ b/src/schema/v2/object_identification.ts
@@ -32,6 +32,7 @@ import {
   GraphQLID,
   GraphQLInterfaceType,
   GraphQLFieldConfig,
+  GraphQLFieldConfigMap,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
 
@@ -120,14 +121,14 @@ const NodeField: GraphQLFieldConfig<any, ResolverContext> = {
   description: "Fetches an object given its Globally Unique ID",
   type: NodeInterface,
   args: {
-    __id: {
+    id: {
       type: new GraphQLNonNull(GraphQLID),
-      description: "The ID of the object",
+      description: "The globally unique ID of the node",
     },
   },
   // Re-uses (slightly abuses) the existing GraphQL `resolve` function.
-  resolve: (_root, { __id }, context, rootValue) => {
-    const { type: typeName, id } = fromGlobalId(__id)
+  resolve: (_root, { id: globalID }, context, rootValue) => {
+    const { type: typeName, id } = fromGlobalId(globalID)
     if (isSupportedType(typeName)) {
       let exported = SupportedTypes.typeModules[typeName]
       if (typeof exported === "function") {
@@ -150,8 +151,7 @@ const NodeField: GraphQLFieldConfig<any, ResolverContext> = {
   },
 }
 
-export const GlobalIDField = {
-  name: "__id",
+export const GlobalIDField: GraphQLFieldConfig<any, ResolverContext> = {
   description: "A globally unique ID.",
   type: new GraphQLNonNull(GraphQLID),
   // Ensure we never encode a null `id`, as it would silently work. Instead return `null`, so that
@@ -161,14 +161,14 @@ export const GlobalIDField = {
   },
 }
 
-export const NullableIDField = {
+export const NullableIDField: GraphQLFieldConfigMap<any, ResolverContext> = {
   id: {
     description: "An optional type-specific ID.",
     type: GraphQLID,
   },
 }
 
-export const IDFields = {
+export const IDFields: GraphQLFieldConfigMap<any, ResolverContext> = {
   __id: GlobalIDField,
   id: {
     description: "A type-specific ID.",
@@ -176,7 +176,7 @@ export const IDFields = {
   },
 }
 
-export const GravityIDFields = {
+export const GravityIDFields: GraphQLFieldConfigMap<any, ResolverContext> = {
   ...IDFields,
   _id: {
     description: "A type-specific Gravity Mongo Document ID.",
@@ -184,14 +184,17 @@ export const GravityIDFields = {
   },
 }
 
-export const SlugIDField = {
+export const SlugIDField: GraphQLFieldConfigMap<any, ResolverContext> = {
   id: {
     description: "A slug ID.",
     type: new GraphQLNonNull(GraphQLID),
   },
 }
 
-export const SlugAndInternalIDFields = {
+export const SlugAndInternalIDFields: GraphQLFieldConfigMap<
+  any,
+  ResolverContext
+> = {
   __id: GlobalIDField,
   id: {
     description: "A slug ID.",
@@ -203,7 +206,7 @@ export const SlugAndInternalIDFields = {
   },
 }
 
-export const InternalIDFields = {
+export const InternalIDFields: GraphQLFieldConfigMap<any, ResolverContext> = {
   __id: GlobalIDField,
   id: {
     description: "A type-specific ID likely used as a database ID.",

--- a/src/schema/v2/object_identification.ts
+++ b/src/schema/v2/object_identification.ts
@@ -154,8 +154,9 @@ const NodeField: GraphQLFieldConfig<any, ResolverContext> = {
 export const GlobalIDField: GraphQLFieldConfig<any, ResolverContext> = {
   description: "A globally unique ID.",
   type: new GraphQLNonNull(GraphQLID),
-  // Ensure we never encode a null `id`, as it would silently work. Instead return `null`, so that
-  // e.g. Relay will complain about the result not matching the type specified in the schema.
+  // Ensure we never encode a null `id`, as it would silently work. Instead
+  // return `null`, so that graphql-js will complain about the result not
+  // matching the type specified in the schema.
   resolve: (obj, _args, _request, info) => {
     return obj.id && toGlobalId(info.parentType.name, obj.id)
   },
@@ -165,6 +166,7 @@ export const NullableIDField: GraphQLFieldConfigMap<any, ResolverContext> = {
   internalID: {
     description: "An optional type-specific ID.",
     type: GraphQLID,
+    resolve: ({ id }) => id,
   },
 }
 
@@ -173,6 +175,7 @@ export const IDFields: GraphQLFieldConfigMap<any, ResolverContext> = {
   internalID: {
     description: "A type-specific ID.",
     type: new GraphQLNonNull(GraphQLID),
+    resolve: ({ id }) => id,
   },
 }
 
@@ -181,6 +184,7 @@ export const GravityIDFields: GraphQLFieldConfigMap<any, ResolverContext> = {
   internalID: {
     description: "A type-specific Gravity Mongo Document ID.",
     type: new GraphQLNonNull(GraphQLID),
+    resolve: ({ _id }) => _id,
   },
 }
 
@@ -188,6 +192,7 @@ export const SlugIDField: GraphQLFieldConfigMap<any, ResolverContext> = {
   slug: {
     description: "A slug ID.",
     type: new GraphQLNonNull(GraphQLID),
+    resolve: ({ id }) => id,
   },
 }
 
@@ -199,10 +204,12 @@ export const SlugAndInternalIDFields: GraphQLFieldConfigMap<
   slug: {
     description: "A slug ID.",
     type: new GraphQLNonNull(GraphQLID),
+    resolve: ({ id }) => id,
   },
   internalID: {
     description: "A type-specific ID likely used as a database ID.",
     type: new GraphQLNonNull(GraphQLID),
+    resolve: ({ _id }) => _id,
   },
 }
 
@@ -211,6 +218,7 @@ export const InternalIDFields: GraphQLFieldConfigMap<any, ResolverContext> = {
   internalID: {
     description: "A type-specific ID likely used as a database ID.",
     type: new GraphQLNonNull(GraphQLID),
+    resolve: ({ _id }) => _id,
   },
 }
 

--- a/src/schema/v2/sale_artwork.ts
+++ b/src/schema/v2/sale_artwork.ts
@@ -178,7 +178,6 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: new GraphQLObjectType<any, ResolverContext>({
           name: "SaleArtworkHighestBid",
           fields: {
-            ...NullableIDField,
             created_at: date,
             is_cancelled: {
               type: GraphQLBoolean,

--- a/src/schema/v2/sale_artwork.ts
+++ b/src/schema/v2/sale_artwork.ts
@@ -9,7 +9,6 @@ import Artwork from "./artwork"
 import Sale from "./sale"
 import {
   GravityIDFields,
-  NullableIDField,
   SlugAndInternalIDFields,
 } from "./object_identification"
 import {

--- a/src/schema/v2/v2/__tests__/v2.test.ts
+++ b/src/schema/v2/v2/__tests__/v2.test.ts
@@ -8,7 +8,6 @@ import {
   InternalIDFields,
   IDFields,
   NullableIDField,
-  GlobalIDField,
   SlugAndInternalIDFields,
 } from "schema/v2/object_identification"
 import {

--- a/src/schema/v2/v2/__tests__/v2.test.ts
+++ b/src/schema/v2/v2/__tests__/v2.test.ts
@@ -62,28 +62,6 @@ describe(transformToV2, () => {
       expect(schema.getType("GetRidOfMe")).toBeUndefined()
     })
 
-    it("filters out ID fields", () => {
-      const schema = createSchema({
-        fields: {
-          foo: {
-            type: new GraphQLObjectType({
-              name: "GetRidOfID",
-              fields: {
-                ...InternalIDFields,
-                thisIsJustSoGetRidOfIDExists: {
-                  type: GraphQLString,
-                },
-              },
-            }),
-          },
-        },
-        filterIDFieldFromTypes: ["GetRidOfID"],
-      })
-      expect(
-        schema.getType("GetRidOfID").getFields().internalID
-      ).toBeUndefined()
-    })
-
     it("removes previously deprecated fields", () => {
       const schema = createSchema({
         fields: {

--- a/src/schema/v2/v2/__tests__/v2.test.ts
+++ b/src/schema/v2/v2/__tests__/v2.test.ts
@@ -139,55 +139,6 @@ describe(transformToV2, () => {
   })
 
   describe("concerning ID renaming", () => {
-    it("renames __id arg to id", async () => {
-      const rootValue = {
-        node: {
-          id: "global id",
-        },
-      }
-      const iface = new GraphQLInterfaceType({
-        name: "Node",
-        fields: {
-          __id: GlobalIDField,
-        },
-        resolveType: () => "AnyType",
-      })
-      const AnyType = new GraphQLObjectType({
-        name: "AnyType",
-        fields: {
-          __id: GlobalIDField,
-        },
-        interfaces: () => [iface],
-      })
-      const data = await runQueryOrThrow({
-        schema: createSchema({
-          fields: {
-            node: {
-              type: iface,
-              args: {
-                __id: {
-                  type: new GraphQLNonNull(GraphQLID),
-                  description: "The ID of the object",
-                },
-              },
-            },
-            thisIsJustSoAnyTypeExists: {
-              type: AnyType,
-            },
-          },
-        }),
-        rootValue,
-        source: gql`
-          query {
-            node(id: "global id") {
-              id
-            }
-          }
-        `,
-      })
-      expect(data.node.id).toEqual(toGlobalId("AnyType", "global id"))
-    })
-
     it("renames __id field to id", async () => {
       const rootValue = {
         fieldWithGlobalID: {

--- a/src/schema/v2/v2/index.ts
+++ b/src/schema/v2/v2/index.ts
@@ -1,15 +1,8 @@
 import { GraphQLSchema, isNullableType } from "graphql"
 import { transformSchema, FilterTypes } from "graphql-tools"
-import { RenameArguments } from "./RenameArguments"
 import { shouldBeRemoved } from "lib/deprecation"
 import { FilterFields } from "./FilterFields"
 import { RenameFields } from "./RenameFields"
-import {
-  GravityIDFields,
-  NullableIDField,
-  InternalIDFields,
-  SlugAndInternalIDFields,
-} from "schema/v2/object_identification"
 
 // TODO: Flip this switch before we go public with v2 and update clients. Until
 //       then this gives clients an extra window of opportunity to update.

--- a/src/schema/v2/v2/index.ts
+++ b/src/schema/v2/v2/index.ts
@@ -84,6 +84,12 @@ export const transformToV2 = (
       return !opt.filterTypes.includes(type.name)
     }),
     new RenameFields((type, field) => {
+      // Only rename ID fields on stitched services.
+      if (
+        !opt.stitchedTypePrefixes.some(prefix => type.name.startsWith(prefix))
+      ) {
+        return undefined
+      }
       if (field.name === "id") {
         if (
           isNullableType(field.type) &&
@@ -91,34 +97,8 @@ export const transformToV2 = (
         ) {
           throw new Error(`Do not add new nullable id fields (${type.name})`)
         } else {
-          if (field.description === SlugAndInternalIDFields.id.description) {
-            return "slug"
-          } else if (
-            field.description === GravityIDFields.id.description ||
-            (field.description === NullableIDField.id.description &&
-              opt.allowedGravityTypesWithNullableIDField.includes(type.name))
-          ) {
-            return "internalID"
-          } else if (
-            field.description === InternalIDFields.id.description ||
-            field.description === SlugAndInternalIDFields.id.description ||
-            (field.description === NullableIDField.id.description &&
-              opt.allowedNonGravityTypesWithNullableIDField.includes(
-                type.name
-              )) ||
-            opt.stitchedTypePrefixes.some(prefix =>
-              type.name.startsWith(prefix)
-            )
-          ) {
-            return "internalID"
-          } else {
-            throw new Error(`Do not add new id fields (${type.name})`)
-          }
+          return "internalID"
         }
-      } else if (field.name === "_id") {
-        return "internalID"
-      } else if (field.name === "__id") {
-        return "id"
       }
       return undefined
     }),

--- a/src/schema/v2/v2/index.ts
+++ b/src/schema/v2/v2/index.ts
@@ -127,7 +127,6 @@ export const transformToV2 = (
         return field.name.substring(3)
       }
     }),
-    new RenameArguments((_field, arg) => (arg.name === "__id" ? "id" : null)),
     ...(FILTER_DEPRECATIONS
       ? [
           new FilterFields(

--- a/src/schema/v2/v2/index.ts
+++ b/src/schema/v2/v2/index.ts
@@ -27,9 +27,6 @@ const FilterTypeNames = [
     : []),
 ]
 
-// Omit this id field entirely from the v2 schema, as it's a no-op
-const FilterIDFieldFromTypeNames = ["SaleArtworkHighestBid"]
-
 // TODO: These types should have their id fields renamed to internalID upstream,
 //       but that requires us to do some transformation work _back_ on the v1
 //       schema for it to remain backwards compatible, so we can do that at a
@@ -76,7 +73,6 @@ export const transformToV2 = (
     allowedNonGravityTypesWithNullableIDField: KnownNonGravityTypesWithNullableIDFields,
     stitchedTypePrefixes: StitchedTypePrefixes,
     filterTypes: FilterTypeNames,
-    filterIDFieldFromTypes: FilterIDFieldFromTypeNames,
     ...options,
   }
   const allowedTypesWithNullableIDField = [
@@ -87,10 +83,6 @@ export const transformToV2 = (
     new FilterTypes(type => {
       return !opt.filterTypes.includes(type.name)
     }),
-    new FilterFields(
-      (type, field) =>
-        field.name !== "id" || !opt.filterIDFieldFromTypes.includes(type.name)
-    ),
     new RenameFields((type, field) => {
       if (field.name === "id") {
         if (


### PR DESCRIPTION
This addresses the ID fields for types defined in MP’s local schema, not yet for upstream services like Exchange–which we still transform and [will be addressed separately](https://artsyproduct.atlassian.net/browse/PLATFORM-1448).

(Note, for now we're not running v2 tests, we'll fix the test suite after we have everything up and running.)