### PR TITLE
[AUCT-528] Fixes ID fields for CreditCards and Bidders (?)

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2513,7 +2513,7 @@ type Bidder {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID likely used as a database ID.
+  # A type-specific ID.
   internalID: ID!
   created_at(
     format: String
@@ -4665,7 +4665,7 @@ type CreditCard {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID likely used as a database ID.
+  # A type-specific ID.
   internalID: ID!
 
   # Brand of credit card

--- a/src/schema/v2/bidder.ts
+++ b/src/schema/v2/bidder.ts
@@ -6,13 +6,13 @@ import {
 } from "graphql"
 import { ResolverContext } from "types/graphql"
 import date from "./fields/date"
-import { InternalIDFields } from "./object_identification"
+import { IDFields } from "./object_identification"
 import Sale from "./sale/index"
 
 const BidderType = new GraphQLObjectType<any, ResolverContext>({
   name: "Bidder",
   fields: () => ({
-    ...InternalIDFields,
+    ...IDFields,
     created_at: date,
     pin: {
       type: GraphQLString,

--- a/src/schema/v2/credit_card.ts
+++ b/src/schema/v2/credit_card.ts
@@ -6,7 +6,7 @@ import {
   GraphQLUnionType,
   GraphQLFieldConfig,
 } from "graphql"
-import { InternalIDFields } from "schema/v2/object_identification"
+import { IDFields } from "schema/v2/object_identification"
 import { GravityMutationErrorType } from "lib/gravityErrorHandler"
 import {
   connectionDefinitions,
@@ -61,7 +61,7 @@ export const CreditCardMutationType = new GraphQLUnionType({
 const CreditCardType = new GraphQLObjectType<any, ResolverContext>({
   name: "CreditCard",
   fields: () => ({
-    ...InternalIDFields,
+    ...IDFields,
     brand: {
       type: new GraphQLNonNull(GraphQLString),
       description: "Brand of credit card",


### PR DESCRIPTION
Last week, we saw that auction registration wasn't working. We traced it down to an error returned from Metaphysics:

```
[ { message: 'Cannot return null for non-nullable field CreditCard.internalID.',
  locations: [ { line: 9, column: 11 } ],
  path: 
  [ 'createCreditCard',
    'creditCardOrError',
    'creditCard',
    'internalID' ] } ],
```

Looking into MP's v2 schema, we found that Bidders and CreditCards were expecting `_id` fields from Gravity, but were actually getting `id` fields.

Daniel and I _think_ this is the right change to make, but we have two questions:

- Is this the correct change? 
- How can we be rigorous about testing these kinds of mappings, from MP v2 and Gravity IDs? Specifically, how can we make sure there aren't more Gravity models that are breaking this expectation?

We saw that the v2 tests were ignored and weren't sure of the best approach to test this PR.