### PR TITLE
PURCHASE-1282: Use currencyCode to determine symbol in amount() helper, if it exists

### DIFF
--- a/src/schema/v1/fields/__tests__/money.test.ts
+++ b/src/schema/v1/fields/__tests__/money.test.ts
@@ -55,4 +55,9 @@ describe(amount, () => {
     obj = { symbol: "£", currencyCode: "GBP" }
     expect(getResult()).toMatchInlineSnapshot(`"$12.34"`)
   })
+
+  it("doesn't break when it can't find a currencyCode", () => {
+    obj = { currencyCode: "BLAH" }
+    expect(getResult()).toMatchInlineSnapshot(`"$12.34"`)
+  })
 })

--- a/src/schema/v1/fields/__tests__/money.test.ts
+++ b/src/schema/v1/fields/__tests__/money.test.ts
@@ -1,63 +1,70 @@
 import { amount } from "../money"
 
 describe(amount, () => {
-  let amountCents: number
-  let args: any
-  let obj: any
-
-  beforeEach(() => {
-    obj = {}
-    args = { symbol: "$" }
-    amountCents = 1234
-  })
-
-  const getResult = () => amount(() => amountCents).resolve(obj, args)
+  const getResult = ({
+    obj = {},
+    args = { symbol: "$" } as object,
+    amountCents = 1234 as any,
+  }) => amount(() => amountCents).resolve(obj, args)
 
   it("formats dollars", () => {
-    expect(getResult()).toMatchInlineSnapshot(`"$12.34"`)
+    expect(getResult({})).toMatchInlineSnapshot(`"$12.34"`)
   })
 
   it("formats euros", () => {
-    args = { symbol: "€" }
-    expect(getResult()).toMatchInlineSnapshot(`"€12.34"`)
+    expect(getResult({ args: { symbol: "€" } })).toMatchInlineSnapshot(
+      `"€12.34"`
+    )
   })
 
   it("formats yen", () => {
-    args = { symbol: "¥" }
-    expect(getResult()).toMatchInlineSnapshot(`"¥12.34"`)
+    expect(getResult({ args: { symbol: "¥" } })).toMatchInlineSnapshot(
+      `"¥12.34"`
+    )
   })
 
   it("handles zeroes", () => {
-    amountCents = 0
-    expect(getResult()).toMatchInlineSnapshot(`"$0.00"`)
+    expect(getResult({ amountCents: 0 })).toMatchInlineSnapshot(`"$0.00"`)
   })
 
   it("handles null/undefined", () => {
-    amountCents = null as any
-    expect(getResult()).toMatchInlineSnapshot(`null`)
-    amountCents = undefined as any
-    expect(getResult()).toMatchInlineSnapshot(`null`)
+    expect(getResult({ amountCents: null })).toMatchInlineSnapshot(`null`)
+
+    // custom handling since undefined won't override a default argument
+    expect(amount(() => undefined).resolve({}, {})).toMatchInlineSnapshot(
+      `null`
+    )
   })
 
   it("formats from a currencyCode if provided", () => {
-    obj = { currencyCode: "GBP" }
-    args = {}
-    expect(getResult()).toMatchInlineSnapshot(`"£12.34"`)
+    expect(
+      getResult({
+        obj: { currencyCode: "GBP" },
+        args: {},
+      })
+    ).toMatchInlineSnapshot(`"£12.34"`)
   })
 
   it("prefers object symbol over currencyCode", () => {
-    obj = { symbol: "$", currencyCode: "GBP" }
-    args = {}
-    expect(getResult()).toMatchInlineSnapshot(`"$12.34"`)
+    expect(
+      getResult({
+        obj: { symbol: "$", currencyCode: "GBP" },
+        args: {},
+      })
+    ).toMatchInlineSnapshot(`"$12.34"`)
   })
 
   it("prefers argument symbol over currencyCode", () => {
-    obj = { symbol: "£", currencyCode: "GBP" }
-    expect(getResult()).toMatchInlineSnapshot(`"$12.34"`)
+    expect(
+      getResult({
+        obj: { symbol: "£", currencyCode: "GBP" },
+      })
+    ).toMatchInlineSnapshot(`"$12.34"`)
   })
 
   it("doesn't break when it can't find a currencyCode", () => {
-    obj = { currencyCode: "BLAH" }
-    expect(getResult()).toMatchInlineSnapshot(`"$12.34"`)
+    expect(getResult({ obj: { currencyCode: "BLAH" } })).toMatchInlineSnapshot(
+      `"$12.34"`
+    )
   })
 })

--- a/src/schema/v1/fields/__tests__/money.test.ts
+++ b/src/schema/v1/fields/__tests__/money.test.ts
@@ -3,12 +3,15 @@ import { amount } from "../money"
 describe(amount, () => {
   let amountCents: number
   let args: any
+  let obj: any
+
   beforeEach(() => {
+    obj = {}
     args = { symbol: "$" }
     amountCents = 1234
   })
 
-  const getResult = () => amount(() => amountCents).resolve({}, args)
+  const getResult = () => amount(() => amountCents).resolve(obj, args)
 
   it("formats dollars", () => {
     expect(getResult()).toMatchInlineSnapshot(`"$12.34"`)
@@ -34,5 +37,22 @@ describe(amount, () => {
     expect(getResult()).toMatchInlineSnapshot(`null`)
     amountCents = undefined as any
     expect(getResult()).toMatchInlineSnapshot(`null`)
+  })
+
+  it("formats from a currencyCode if provided", () => {
+    obj = { currencyCode: "GBP" }
+    args = {}
+    expect(getResult()).toMatchInlineSnapshot(`"£12.34"`)
+  })
+
+  it("prefers object symbol over currencyCode", () => {
+    obj = { symbol: "$", currencyCode: "GBP" }
+    args = {}
+    expect(getResult()).toMatchInlineSnapshot(`"$12.34"`)
+  })
+
+  it("prefers argument symbol over currencyCode", () => {
+    obj = { symbol: "£", currencyCode: "GBP" }
+    expect(getResult()).toMatchInlineSnapshot(`"$12.34"`)
   })
 })

--- a/src/schema/v1/fields/money.ts
+++ b/src/schema/v1/fields/money.ts
@@ -59,7 +59,8 @@ export const amount = centsResolver => ({
 
     // Some objects return a currencyCode instead of a symbol.
     const symbolFromCurrencyCode = obj.currencyCode
-      ? currencyCodes[obj.currencyCode.toLowerCase()].symbol
+      ? currencyCodes[obj.currencyCode.toLowerCase()] &&
+        currencyCodes[obj.currencyCode.toLowerCase()].symbol
       : null
 
     const symbol = options.symbol || obj.symbol || symbolFromCurrencyCode

--- a/src/schema/v1/fields/money.ts
+++ b/src/schema/v1/fields/money.ts
@@ -10,6 +10,9 @@ import {
 } from "graphql"
 import { ResolverContext } from "types/graphql"
 
+// Taken from https://github.com/RubyMoney/money/blob/master/config/currency_iso.json
+import currencyCodes from "lib/currency_codes.json"
+
 export const amountSDL = name => `
   ${name}(
     decimal: String = "."
@@ -53,7 +56,14 @@ export const amount = centsResolver => ({
     if (typeof cents !== "number") {
       return null
     }
-    const symbol = options.symbol || obj.symbol
+
+    // Some objects return a currencyCode instead of a symbol.
+    const symbolFromCurrencyCode = obj.currencyCode
+      ? currencyCodes[obj.currencyCode.toLowerCase()].symbol
+      : null
+
+    const symbol = options.symbol || obj.symbol || symbolFromCurrencyCode
+
     return formatMoney(
       cents / 100,
       assign({}, options, {

--- a/src/schema/v2/fields/__tests__/money.test.ts
+++ b/src/schema/v2/fields/__tests__/money.test.ts
@@ -55,4 +55,9 @@ describe(amount, () => {
     obj = { symbol: "£", currencyCode: "GBP" }
     expect(getResult()).toMatchInlineSnapshot(`"$12.34"`)
   })
+
+  it("doesn't break when it can't find a currencyCode", () => {
+    obj = { currencyCode: "BLAH" }
+    expect(getResult()).toMatchInlineSnapshot(`"$12.34"`)
+  })
 })

--- a/src/schema/v2/fields/__tests__/money.test.ts
+++ b/src/schema/v2/fields/__tests__/money.test.ts
@@ -1,63 +1,70 @@
 import { amount } from "../money"
 
 describe(amount, () => {
-  let amountCents: number
-  let args: any
-  let obj: any
-
-  beforeEach(() => {
-    obj = {}
-    args = { symbol: "$" }
-    amountCents = 1234
-  })
-
-  const getResult = () => amount(() => amountCents).resolve(obj, args)
+  const getResult = ({
+    obj = {},
+    args = { symbol: "$" } as object,
+    amountCents = 1234 as any,
+  }) => amount(() => amountCents).resolve(obj, args)
 
   it("formats dollars", () => {
-    expect(getResult()).toMatchInlineSnapshot(`"$12.34"`)
+    expect(getResult({})).toMatchInlineSnapshot(`"$12.34"`)
   })
 
   it("formats euros", () => {
-    args = { symbol: "€" }
-    expect(getResult()).toMatchInlineSnapshot(`"€12.34"`)
+    expect(getResult({ args: { symbol: "€" } })).toMatchInlineSnapshot(
+      `"€12.34"`
+    )
   })
 
   it("formats yen", () => {
-    args = { symbol: "¥" }
-    expect(getResult()).toMatchInlineSnapshot(`"¥12.34"`)
+    expect(getResult({ args: { symbol: "¥" } })).toMatchInlineSnapshot(
+      `"¥12.34"`
+    )
   })
 
   it("handles zeroes", () => {
-    amountCents = 0
-    expect(getResult()).toMatchInlineSnapshot(`"$0.00"`)
+    expect(getResult({ amountCents: 0 })).toMatchInlineSnapshot(`"$0.00"`)
   })
 
   it("handles null/undefined", () => {
-    amountCents = null as any
-    expect(getResult()).toMatchInlineSnapshot(`null`)
-    amountCents = undefined as any
-    expect(getResult()).toMatchInlineSnapshot(`null`)
+    expect(getResult({ amountCents: null })).toMatchInlineSnapshot(`null`)
+
+    // custom handling since undefined won't override a default argument
+    expect(amount(() => undefined).resolve({}, {})).toMatchInlineSnapshot(
+      `null`
+    )
   })
 
   it("formats from a currencyCode if provided", () => {
-    obj = { currencyCode: "GBP" }
-    args = {}
-    expect(getResult()).toMatchInlineSnapshot(`"£12.34"`)
+    expect(
+      getResult({
+        obj: { currencyCode: "GBP" },
+        args: {},
+      })
+    ).toMatchInlineSnapshot(`"£12.34"`)
   })
 
   it("prefers object symbol over currencyCode", () => {
-    obj = { symbol: "$", currencyCode: "GBP" }
-    args = {}
-    expect(getResult()).toMatchInlineSnapshot(`"$12.34"`)
+    expect(
+      getResult({
+        obj: { symbol: "$", currencyCode: "GBP" },
+        args: {},
+      })
+    ).toMatchInlineSnapshot(`"$12.34"`)
   })
 
   it("prefers argument symbol over currencyCode", () => {
-    obj = { symbol: "£", currencyCode: "GBP" }
-    expect(getResult()).toMatchInlineSnapshot(`"$12.34"`)
+    expect(
+      getResult({
+        obj: { symbol: "£", currencyCode: "GBP" },
+      })
+    ).toMatchInlineSnapshot(`"$12.34"`)
   })
 
   it("doesn't break when it can't find a currencyCode", () => {
-    obj = { currencyCode: "BLAH" }
-    expect(getResult()).toMatchInlineSnapshot(`"$12.34"`)
+    expect(getResult({ obj: { currencyCode: "BLAH" } })).toMatchInlineSnapshot(
+      `"$12.34"`
+    )
   })
 })

--- a/src/schema/v2/fields/__tests__/money.test.ts
+++ b/src/schema/v2/fields/__tests__/money.test.ts
@@ -3,12 +3,15 @@ import { amount } from "../money"
 describe(amount, () => {
   let amountCents: number
   let args: any
+  let obj: any
+
   beforeEach(() => {
+    obj = {}
     args = { symbol: "$" }
     amountCents = 1234
   })
 
-  const getResult = () => amount(() => amountCents).resolve({}, args)
+  const getResult = () => amount(() => amountCents).resolve(obj, args)
 
   it("formats dollars", () => {
     expect(getResult()).toMatchInlineSnapshot(`"$12.34"`)
@@ -34,5 +37,22 @@ describe(amount, () => {
     expect(getResult()).toMatchInlineSnapshot(`null`)
     amountCents = undefined as any
     expect(getResult()).toMatchInlineSnapshot(`null`)
+  })
+
+  it("formats from a currencyCode if provided", () => {
+    obj = { currencyCode: "GBP" }
+    args = {}
+    expect(getResult()).toMatchInlineSnapshot(`"£12.34"`)
+  })
+
+  it("prefers object symbol over currencyCode", () => {
+    obj = { symbol: "$", currencyCode: "GBP" }
+    args = {}
+    expect(getResult()).toMatchInlineSnapshot(`"$12.34"`)
+  })
+
+  it("prefers argument symbol over currencyCode", () => {
+    obj = { symbol: "£", currencyCode: "GBP" }
+    expect(getResult()).toMatchInlineSnapshot(`"$12.34"`)
   })
 })

--- a/src/schema/v2/fields/money.ts
+++ b/src/schema/v2/fields/money.ts
@@ -59,7 +59,8 @@ export const amount = centsResolver => ({
 
     // Some objects return a currencyCode instead of a symbol.
     const symbolFromCurrencyCode = obj.currencyCode
-      ? currencyCodes[obj.currencyCode.toLowerCase()].symbol
+      ? currencyCodes[obj.currencyCode.toLowerCase()] &&
+        currencyCodes[obj.currencyCode.toLowerCase()].symbol
       : null
 
     const symbol = options.symbol || obj.symbol || symbolFromCurrencyCode

--- a/src/schema/v2/fields/money.ts
+++ b/src/schema/v2/fields/money.ts
@@ -10,6 +10,9 @@ import {
 } from "graphql"
 import { ResolverContext } from "types/graphql"
 
+// Taken from https://github.com/RubyMoney/money/blob/master/config/currency_iso.json
+import currencyCodes from "lib/currency_codes.json"
+
 export const amountSDL = name => `
   ${name}(
     decimal: String = "."
@@ -53,7 +56,14 @@ export const amount = centsResolver => ({
     if (typeof cents !== "number") {
       return null
     }
-    const symbol = options.symbol || obj.symbol
+
+    // Some objects return a currencyCode instead of a symbol.
+    const symbolFromCurrencyCode = obj.currencyCode
+      ? currencyCodes[obj.currencyCode.toLowerCase()].symbol
+      : null
+
+    const symbol = options.symbol || obj.symbol || symbolFromCurrencyCode
+
     return formatMoney(
       cents / 100,
       assign({}, options, {


### PR DESCRIPTION
We have an `amount` wrapper that we use to resolve money-related fields, such as those returned from Exchange.

To determine the relevant currency symbol, the helper uses either a `symbol` arg that's passed in, or the `symbol` on the parent object passed in.

This PR updates the helper to also use the parent object's `currencyCode` to determine which symbol to show.

This will allow us to return the correct amounts from metaphysics (via Exchange) when an order is in a currency other than USD.

Note that `currencyCode` is suggested naming [here](https://www.notion.so/artsy/Currency-Best-Practices-95081d370e664509928509e3dbd74c81), although metaphysics does not yet comply with the best practices set in that doc. That feels out of scope of this!

![image](https://user-images.githubusercontent.com/2081340/62081623-05a6e780-b221-11e9-864a-83cbb972b6ca.png)
