### PR TITLE
Ensure InternalIDFields maps to id instead of _id

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2513,7 +2513,7 @@ type Bidder {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID.
+  # A type-specific ID likely used as a database ID.
   internalID: ID!
   created_at(
     format: String
@@ -4665,7 +4665,7 @@ type CreditCard {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID.
+  # A type-specific ID likely used as a database ID.
   internalID: ID!
 
   # Brand of credit card

--- a/src/schema/v2/bidder.ts
+++ b/src/schema/v2/bidder.ts
@@ -6,13 +6,13 @@ import {
 } from "graphql"
 import { ResolverContext } from "types/graphql"
 import date from "./fields/date"
-import { IDFields } from "./object_identification"
+import { InternalIDFields } from "./object_identification"
 import Sale from "./sale/index"
 
 const BidderType = new GraphQLObjectType<any, ResolverContext>({
   name: "Bidder",
   fields: () => ({
-    ...IDFields,
+    ...InternalIDFields,
     created_at: date,
     pin: {
       type: GraphQLString,

--- a/src/schema/v2/credit_card.ts
+++ b/src/schema/v2/credit_card.ts
@@ -6,7 +6,7 @@ import {
   GraphQLUnionType,
   GraphQLFieldConfig,
 } from "graphql"
-import { IDFields } from "schema/v2/object_identification"
+import { InternalIDFields } from "schema/v2/object_identification"
 import { GravityMutationErrorType } from "lib/gravityErrorHandler"
 import {
   connectionDefinitions,
@@ -61,7 +61,7 @@ export const CreditCardMutationType = new GraphQLUnionType({
 const CreditCardType = new GraphQLObjectType<any, ResolverContext>({
   name: "CreditCard",
   fields: () => ({
-    ...IDFields,
+    ...InternalIDFields,
     brand: {
       type: new GraphQLNonNull(GraphQLString),
       description: "Brand of credit card",

--- a/src/schema/v2/object_identification.ts
+++ b/src/schema/v2/object_identification.ts
@@ -218,7 +218,7 @@ export const InternalIDFields: GraphQLFieldConfigMap<any, ResolverContext> = {
   internalID: {
     description: "A type-specific ID likely used as a database ID.",
     type: new GraphQLNonNull(GraphQLID),
-    resolve: ({ _id }) => _id,
+    resolve: ({ id }) => id,
   },
 }
 


### PR DESCRIPTION
@kierangillen reported an issue where a query for edition sets was failing. 

Here's a [minimal repro](https://metaphysics-staging.artsy.net/v2/?query=%7B%0A%20%20artwork(id%3A%20%22alex-dordoy-5th-genome-test-partner-test-2%22)%20%7B%0A%20%20%20%20edition_sets%20%7B%0A%20%20%20%20%20%20internalID%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A). Here's the error:

```
Cannot return null for non-nullable field EditionSet.internalID.
```

I checked the [edition set id definition](https://github.com/artsy/metaphysics/blob/3aebfd943cdb6d131e1dfa011e56910cde205eb8/src/schema/v2/edition_set.ts#L39) to see where the id was coming from. That pointed to the `object_identification` file's `internalIDFields` definition. 

https://github.com/artsy/metaphysics/blob/2b4328130668c226e76361723baeba1f6661e16f/src/schema/v2/object_identification.ts#L216-L223

It's loading the `_id` property, so I checked gravity to ensure it was defined. Turns out, gravity only has `id` (as seen [here](https://github.com/artsy/gravity/blob/master/app/models/domain/edition_set.rb#L82)). Sounded like a v2 issue to me, so I cross referenced what the v1 version of `object_identification` was doing, and sure enough, it used `id`.

https://github.com/artsy/metaphysics/blob/2b4328130668c226e76361723baeba1f6661e16f/src/schema/v1/object_identification.ts#L208-L211

In the end, I just needed to update the resolver. 