### PR TITLE
@zephraph => [FilterArtworks] Fix for Emission using count/cursor instead of first/after

### DIFF
--- a/src/lib/hasFieldSelection.ts
+++ b/src/lib/hasFieldSelection.ts
@@ -102,10 +102,19 @@ export const parseConnectionArgsFromConnection = (
                       arg.name.value
                     )
                   ) {
-                    const val =
+                    let val =
                       (arg as any).value.value ||
                       info.variableValues[arg.name.value] ||
                       0
+
+                    // Emission sends back `count` and `cursor` as the
+                    // variables for `first` and `after`.
+                    // TODO: Improve introspection/visiting so we don't need this.
+                    if (arg.name.value === "first" && !val) {
+                      val = info.variableValues["count"]
+                    } else if (arg.name.value === "after" && !val) {
+                      val = info.variableValues["cursor"]
+                    }
 
                     connectionArgs[arg.name.value] = parseInt(val) || val
                   }


### PR DESCRIPTION
This fixes the issue (I hadn't tested scrolling in Emission w/ the update).

This is more of a 'hot-fix', as the TODO item should be addressed. I think my understanding of fully parsing the AST for a query and traversing the various fragments isn't complete.