### PR TITLE
Update `Artwork.price` deprecation to point to `listPrice`

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1376,7 +1376,7 @@ type Artwork implements Node & Searchable & Sellable {
   ): Partner
   pickup_available: Boolean
   price: String
-    @deprecated(reason: "Prefer to use `sale_message`. [Will be removed in v2]")
+    @deprecated(reason: "Prefer to use `listPrice`. [Will be removed in v2]")
   priceCents: PriceCents
     @deprecated(reason: "Prefer to use `listPrice`. [Will be removed in v2]")
   listPrice: ListPrice
@@ -2400,7 +2400,7 @@ type ArtworkItem implements Node & Searchable & Sellable {
   ): Partner
   pickup_available: Boolean
   price: String
-    @deprecated(reason: "Prefer to use `sale_message`. [Will be removed in v2]")
+    @deprecated(reason: "Prefer to use `listPrice`. [Will be removed in v2]")
   priceCents: PriceCents
     @deprecated(reason: "Prefer to use `listPrice`. [Will be removed in v2]")
   listPrice: ListPrice
@@ -10731,7 +10731,7 @@ interface Sellable {
   is_for_sale: Boolean
   is_sold: Boolean
   price: String
-    @deprecated(reason: "Prefer to use `sale_message`. [Will be removed in v2]")
+    @deprecated(reason: "Prefer to use `listPrice`. [Will be removed in v2]")
   sale_message: String
 }
 

--- a/src/schema/v1/artwork/index.ts
+++ b/src/schema/v1/artwork/index.ts
@@ -526,7 +526,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLString,
         deprecationReason: deprecate({
           inVersion: 2,
-          preferUsageOf: "sale_message",
+          preferUsageOf: "listPrice",
         }),
       },
       priceCents: {

--- a/src/schema/v1/sellable.ts
+++ b/src/schema/v1/sellable.ts
@@ -29,7 +29,7 @@ export const Sellable = new GraphQLInterfaceType({
       type: GraphQLString,
       deprecationReason: deprecate({
         inVersion: 2,
-        preferUsageOf: "sale_message",
+        preferUsageOf: "listPrice",
       }),
     },
     sale_message: {


### PR DESCRIPTION
The pass-through field `Artwork.price` is used in a few different ways in Reaction, from analytics to JSONLD, with the suggested field `sale_message` being different in form from the parseable `price`. Since `price` usage is being discouraged, this updates the deprecation pointer to suggest `listPrice`. 