### PR TITLE
@alloy => [Util] Improve argument parsing during query introspection for connection optimization

### DIFF
--- a/src/lib/hasFieldSelection.ts
+++ b/src/lib/hasFieldSelection.ts
@@ -102,21 +102,21 @@ export const parseConnectionArgsFromConnection = (
                       arg.name.value
                     )
                   ) {
-                    let val =
-                      (arg as any).value.value ||
-                      info.variableValues[arg.name.value] ||
-                      0
+                    let val: string
 
-                    // Emission sends back `count` and `cursor` as the
-                    // variables for `first` and `after`.
-                    // TODO: Improve introspection/visiting so we don't need this.
-                    if (arg.name.value === "first" && !val) {
-                      val = info.variableValues["count"]
-                    } else if (arg.name.value === "after" && !val) {
-                      val = info.variableValues["cursor"]
+                    if (arg.value.kind === "Variable") {
+                      const variableName = arg.value.name.value
+                      val = info.variableValues[variableName]
+                    } else if (
+                      arg.value.kind === "IntValue" ||
+                      arg.value.kind === "StringValue"
+                    ) {
+                      val = arg.value.value
+                    } else {
+                      val = "0"
                     }
 
-                    connectionArgs[arg.name.value] = parseInt(val) || val
+                    connectionArgs[arg.name.value] = parseInt(val, 10) || val
                   }
                 })
               return BREAK

--- a/src/schema/v1/__tests__/filter_artworks.test.js
+++ b/src/schema/v1/__tests__/filter_artworks.test.js
@@ -64,7 +64,45 @@ describe("Filter Artworks", () => {
       )
     })
 
-    it("returns a connection, and makes one gravity call", () => {
+    it("returns a connection, and makes one gravity call when args passed inline", () => {
+      const query = `
+        {
+          gene(id: "500-1000-ce") {
+            name
+            filtered_artworks(aggregations:[TOTAL], medium: "*", for_sale: true) {
+              hits {
+                id
+              }
+              artworks_connection(first: 10, after: "") {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      return runQuery(query, context).then(
+        ({
+          gene: {
+            filtered_artworks: {
+              hits,
+              artworks_connection: { edges },
+            },
+          },
+        }) => {
+          expect(hits).toEqual([{ id: "oseberg-norway-queens-ship" }])
+          expect(edges).toEqual([
+            { node: { id: "oseberg-norway-queens-ship" } },
+          ])
+        }
+      )
+    })
+
+    it("returns a connection, and makes one gravity call when using variables", () => {
       const query = `
         query GeneFilter($count: Int, $cursor: String) {
           gene(id: "500-1000-ce") {

--- a/src/schema/v2/__tests__/filter_artworks.test.js
+++ b/src/schema/v2/__tests__/filter_artworks.test.js
@@ -64,7 +64,45 @@ describe("Filter Artworks", () => {
       )
     })
 
-    it("returns a connection, and makes one gravity call", () => {
+    it("returns a connection, and makes one gravity call when args passed inline", () => {
+      const query = `
+        {
+          gene(id: "500-1000-ce") {
+            name
+            filtered_artworks(aggregations:[TOTAL], medium: "*", for_sale: true) {
+              hits {
+                id
+              }
+              artworks_connection(first: 10, after: "") {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      return runQuery(query, context).then(
+        ({
+          gene: {
+            filtered_artworks: {
+              hits,
+              artworks_connection: { edges },
+            },
+          },
+        }) => {
+          expect(hits).toEqual([{ id: "oseberg-norway-queens-ship" }])
+          expect(edges).toEqual([
+            { node: { id: "oseberg-norway-queens-ship" } },
+          ])
+        }
+      )
+    })
+
+    it("returns a connection, and makes one gravity call when using variables", () => {
       const query = `
         query GeneFilter($count: Int, $cursor: String) {
           gene(id: "500-1000-ce") {


### PR DESCRIPTION
Taking a closer look, and I think this makes more sense logically (and clears up `as any`, and would have avoided the Eigen issue).

It's more generic, so whether arguments are passed in-line, or as variables (and whatever the variable is called), it works!