### PR TITLE
Stitch creditCard on Exchange Order

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3517,6 +3517,7 @@ type CommerceBuyOrder implements CommerceOrder {
   updatedAt: String!
   buyerDetails: OrderParty
   sellerDetails: OrderParty
+  creditCard: CreditCard
   itemsTotal(
     decimal: String = "."
 
@@ -4033,6 +4034,7 @@ type CommerceOfferOrder implements CommerceOrder {
   updatedAt: String!
   buyerDetails: OrderParty
   sellerDetails: OrderParty
+  creditCard: CreditCard
   itemsTotal(
     decimal: String = "."
 
@@ -4184,6 +4186,7 @@ interface CommerceOrder {
   updatedAt: String!
   buyerDetails: OrderParty
   sellerDetails: OrderParty
+  creditCard: CreditCard
   itemsTotal(
     decimal: String = "."
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2118,6 +2118,7 @@ type CommerceBuyOrder implements CommerceOrder {
   updatedAt: String!
   buyerDetails: OrderParty
   sellerDetails: OrderParty
+  creditCard: CreditCard
   itemsTotal(
     decimal: String = "."
 
@@ -2630,6 +2631,7 @@ type CommerceOfferOrder implements CommerceOrder {
   updatedAt: String!
   buyerDetails: OrderParty
   sellerDetails: OrderParty
+  creditCard: CreditCard
   itemsTotal(
     decimal: String = "."
 
@@ -2780,6 +2782,7 @@ interface CommerceOrder {
   updatedAt: String!
   buyerDetails: OrderParty
   sellerDetails: OrderParty
+  creditCard: CreditCard
   itemsTotal(
     decimal: String = "."
 
@@ -4474,46 +4477,6 @@ type Gene implements Node {
     last: Int
   ): ArtistConnection
   artworksConnection(
-    acquireable: Boolean
-    offerable: Boolean
-    aggregationPartnerCities: [String]
-    aggregations: [ArtworkAggregation]
-    artistID: String
-    artistIDs: [String]
-    atAuction: Boolean
-    attributionClass: [String]
-    color: String
-    dimensionRange: String
-    extraAggregationGeneIDs: [String]
-    includeArtworksByFollowedArtists: Boolean
-    includeMediumFilterInAggregation: Boolean
-    inquireableOnly: Boolean
-    forSale: Boolean
-    geneID: String
-    geneIDs: [String]
-    height: String
-    width: String
-
-    # When true, will only return `marketable` works (not nude or provocative).
-    marketable: Boolean
-
-    # A string from the list of allocations, or * to denote all mediums
-    medium: String
-    period: String
-    periods: [String]
-    majorPeriods: [String]
-    partnerID: ID
-    partnerCities: [String]
-    priceRange: String
-    page: Int
-    saleID: ID
-    size: Int
-    sort: String
-    tagID: String
-    keyword: String
-
-    # When true, will only return exact keyword match
-    keywordMatchExact: Boolean
     after: String
     first: Int
     before: String

--- a/src/lib/stitching/exchange/__tests__/stitching.test.ts
+++ b/src/lib/stitching/exchange/__tests__/stitching.test.ts
@@ -16,6 +16,7 @@ it("extends the Order objects", async () => {
 
     expect(orderableFields).toContain("buyerDetails")
     expect(orderableFields).toContain("sellerDetails")
+    expect(orderableFields).toContain("creditCard")
 
     // Any field inside the CommerceBuyOrder & CommerceOfferOrder which
     // ends in cents should have a version without cents which is a
@@ -101,6 +102,21 @@ it("delegates to the local schema for an LineItem's artwork", async () => {
   expect(mergeInfo.delegateToSchema).toHaveBeenCalledWith({
     args: { id: "ARTWORK-ID" },
     fieldName: "artwork",
+    operation: "query",
+    ...restOfResolveArgs,
+  })
+})
+
+it("delegates to the local schema for an Order's creditCard", async () => {
+  const { resolvers } = await getExchangeStitchedSchema()
+  const creditCardResolver = resolvers.CommerceBuyOrder.creditCard.resolve
+  const mergeInfo = { delegateToSchema: jest.fn() }
+
+  creditCardResolver({ creditCardId: "CC-1" }, {}, {}, { mergeInfo })
+
+  expect(mergeInfo.delegateToSchema).toHaveBeenCalledWith({
+    args: { id: "CC-1" },
+    fieldName: "credit_card",
     operation: "query",
     ...restOfResolveArgs,
   })

--- a/src/lib/stitching/exchange/stitching.ts
+++ b/src/lib/stitching/exchange/stitching.ts
@@ -105,6 +105,24 @@ export const exchangeStitchingEnvironment = (
     to: "fromDetails",
   })
 
+  const creditCardResolver = {
+    fragment: `fragment CommerceOrderCreditCard on CommerceOrder { creditCardId }`,
+    resolve: (parent, _args, context, info) => {
+      const id = parent.creditCardId
+      return info.mergeInfo.delegateToSchema({
+        schema: localSchema,
+        operation: "query",
+        fieldName: "credit_card",
+        args: {
+          id,
+        },
+        context,
+        info,
+        transforms: exchangeSchema.transforms,
+      })
+    },
+  }
+
   // Map the totals array to a set of resolvers that call the amount function
   // the type param is only used for the fragment name
   const totalsResolvers = (type, totalSDLS) =>
@@ -134,6 +152,7 @@ export const exchangeStitchingEnvironment = (
     extend type CommerceBuyOrder {
       buyerDetails: OrderParty
       sellerDetails: OrderParty
+      creditCard: CreditCard
 
       ${orderTotalsSDL.join("\n")}
     }
@@ -141,6 +160,7 @@ export const exchangeStitchingEnvironment = (
     extend type CommerceOfferOrder {
       buyerDetails: OrderParty
       sellerDetails: OrderParty
+      creditCard: CreditCard
 
       ${orderTotalsSDL.join("\n")}
       ${amountSDL("offerTotal")}
@@ -149,6 +169,7 @@ export const exchangeStitchingEnvironment = (
     extend interface CommerceOrder {
       buyerDetails: OrderParty
       sellerDetails: OrderParty
+      creditCard: CreditCard
 
       ${orderTotalsSDL.join("\n")}
     }
@@ -166,11 +187,13 @@ export const exchangeStitchingEnvironment = (
         ...totalsResolvers("CommerceBuyOrder", orderTotals),
         buyerDetails: buyerDetailsResolver,
         sellerDetails: sellerDetailsResolver,
+        creditCard: creditCardResolver,
       },
       CommerceOfferOrder: {
         ...totalsResolvers("CommerceOfferOrder", orderTotals),
         buyerDetails: buyerDetailsResolver,
         sellerDetails: sellerDetailsResolver,
+        creditCard: creditCardResolver,
       },
       CommerceLineItem: {
         artwork: {


### PR DESCRIPTION
# Problem
When we stitched Exchange schema we missed resolving `Order.creditCardId` and adding `Order.creditCard`.

# Solution 
Stitch `creditCard` using `Order.creditCardId` on both `buy` and `offer` orders.

# Problem
When we try to `delegateToSchema` the `fieldName` on V1 is `credit_card` while this has change in V2 to `creditCard`. Current stitched code is shared between V1 and V2 and current code would only work for V1.
Knowing this is only used by Reaction (`V1`) at the moment, this may be fine for now but we may want to duplicate exchange stitching to get `V2` version actually working.