### PR TITLE
Commit generated changes from v2 schema

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4477,6 +4477,46 @@ type Gene implements Node {
     last: Int
   ): ArtistConnection
   artworksConnection(
+    acquireable: Boolean
+    offerable: Boolean
+    aggregationPartnerCities: [String]
+    aggregations: [ArtworkAggregation]
+    artistID: String
+    artistIDs: [String]
+    atAuction: Boolean
+    attributionClass: [String]
+    color: String
+    dimensionRange: String
+    extraAggregationGeneIDs: [String]
+    includeArtworksByFollowedArtists: Boolean
+    includeMediumFilterInAggregation: Boolean
+    inquireableOnly: Boolean
+    forSale: Boolean
+    geneID: String
+    geneIDs: [String]
+    height: String
+    width: String
+
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
+
+    # A string from the list of allocations, or * to denote all mediums
+    medium: String
+    period: String
+    periods: [String]
+    majorPeriods: [String]
+    partnerID: ID
+    partnerCities: [String]
+    priceRange: String
+    page: Int
+    saleID: ID
+    size: Int
+    sort: String
+    tagID: String
+    keyword: String
+
+    # When true, will only return exact keyword match
+    keywordMatchExact: Boolean
     after: String
     first: Int
     before: String


### PR DESCRIPTION
This just removes the `__allowedLegacyNames` entry with `__id` in it. 

@alloy the `_schemaV2.graphql` updates might be from it not properly being updated in #1874?

I can revert that part if needed. 