### PR TITLE
Fix skipping not null CommerceDateTime in stitching replacement

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3457,7 +3457,12 @@ type CommerceBuyOrder implements CommerceOrder {
   code: String!
   commissionFeeCents: Int
   commissionRate: Float
-  createdAt: String!
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
@@ -3514,7 +3519,12 @@ type CommerceBuyOrder implements CommerceOrder {
   taxTotalCents: Int
   totalListPriceCents: Int!
   transactionFeeCents: Int
-  updatedAt: String!
+  updatedAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   buyerDetails: OrderParty
   sellerDetails: OrderParty
   creditCard: CreditCard
@@ -3747,13 +3757,23 @@ type CommerceFulfillAtOncePayload {
 # A Fulfillment for an order
 type CommerceFulfillment {
   courier: String!
-  createdAt: CommerceDateTime!
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   estimatedDelivery: CommerceDate
   id: ID!
   internalID: ID!
   notes: String
   trackingId: String
-  updatedAt: CommerceDateTime!
+  updatedAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
 }
 
 # Attributes of a Fulfillment
@@ -3790,7 +3810,12 @@ type CommerceLineItem {
   artworkId: String!
   artworkVersionId: String!
   commissionFeeCents: Int
-  createdAt: CommerceDateTime!
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   editionSetId: String
   fulfillments(
     # Returns the elements in the list that come after the specified cursor.
@@ -3812,7 +3837,12 @@ type CommerceLineItem {
   priceCents: Int! @deprecated(reason: "switch to use listPriceCents")
   quantity: Int!
   shippingTotalCents: Int
-  updatedAt: CommerceDateTime!
+  updatedAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   artwork: Artwork
   artworkVersion: ArtworkVersion
   shippingTotal(
@@ -3869,7 +3899,12 @@ type CommerceLineItemEdge {
 type CommerceOffer {
   amountCents: Int!
   buyerTotalCents: Int
-  createdAt: String!
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   creatorId: String!
   currencyCode: String!
   from: CommerceOrderPartyUnion!
@@ -3955,7 +3990,12 @@ type CommerceOfferOrder implements CommerceOrder {
   code: String!
   commissionFeeCents: Int
   commissionRate: Float
-  createdAt: String!
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
@@ -4031,7 +4071,12 @@ type CommerceOfferOrder implements CommerceOrder {
   taxTotalCents: Int
   totalListPriceCents: Int!
   transactionFeeCents: Int
-  updatedAt: String!
+  updatedAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   buyerDetails: OrderParty
   sellerDetails: OrderParty
   creditCard: CreditCard
@@ -4126,7 +4171,12 @@ interface CommerceOrder {
   code: String!
   commissionFeeCents: Int
   commissionRate: Float
-  createdAt: String!
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
@@ -4183,7 +4233,12 @@ interface CommerceOrder {
   taxTotalCents: Int
   totalListPriceCents: Int!
   transactionFeeCents: Int
-  updatedAt: String!
+  updatedAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   buyerDetails: OrderParty
   sellerDetails: OrderParty
   creditCard: CreditCard

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3462,7 +3462,7 @@ type CommerceBuyOrder implements CommerceOrder {
 
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
-  ): String
+  ): String!
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
@@ -3524,7 +3524,7 @@ type CommerceBuyOrder implements CommerceOrder {
 
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
-  ): String
+  ): String!
   buyerDetails: OrderParty
   sellerDetails: OrderParty
   creditCard: CreditCard
@@ -3762,8 +3762,13 @@ type CommerceFulfillment {
 
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
+  ): String!
+  estimatedDelivery(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
   ): String
-  estimatedDelivery: CommerceDate
   id: ID!
   internalID: ID!
   notes: String
@@ -3773,7 +3778,7 @@ type CommerceFulfillment {
 
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
-  ): String
+  ): String!
 }
 
 # Attributes of a Fulfillment
@@ -3815,7 +3820,7 @@ type CommerceLineItem {
 
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
-  ): String
+  ): String!
   editionSetId: String
   fulfillments(
     # Returns the elements in the list that come after the specified cursor.
@@ -3842,7 +3847,7 @@ type CommerceLineItem {
 
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
-  ): String
+  ): String!
   artwork: Artwork
   artworkVersion: ArtworkVersion
   shippingTotal(
@@ -3904,7 +3909,7 @@ type CommerceOffer {
 
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
-  ): String
+  ): String!
   creatorId: String!
   currencyCode: String!
   from: CommerceOrderPartyUnion!
@@ -3995,7 +4000,7 @@ type CommerceOfferOrder implements CommerceOrder {
 
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
-  ): String
+  ): String!
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
@@ -4076,7 +4081,7 @@ type CommerceOfferOrder implements CommerceOrder {
 
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
-  ): String
+  ): String!
   buyerDetails: OrderParty
   sellerDetails: OrderParty
   creditCard: CreditCard
@@ -4176,7 +4181,7 @@ interface CommerceOrder {
 
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
-  ): String
+  ): String!
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
@@ -4238,7 +4243,7 @@ interface CommerceOrder {
 
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
-  ): String
+  ): String!
   buyerDetails: OrderParty
   sellerDetails: OrderParty
   creditCard: CreditCard

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2059,7 +2059,12 @@ type CommerceBuyOrder implements CommerceOrder {
   code: String!
   commissionFeeCents: Int
   commissionRate: Float
-  createdAt: String!
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
@@ -2115,7 +2120,12 @@ type CommerceBuyOrder implements CommerceOrder {
   taxTotalCents: Int
   totalListPriceCents: Int!
   transactionFeeCents: Int
-  updatedAt: String!
+  updatedAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   buyerDetails: OrderParty
   sellerDetails: OrderParty
   creditCard: CreditCard
@@ -2348,12 +2358,22 @@ type CommerceFulfillAtOncePayload {
 # A Fulfillment for an order
 type CommerceFulfillment {
   courier: String!
-  createdAt: CommerceDateTime!
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   estimatedDelivery: CommerceDate
   internalID: ID!
   notes: String
   trackingId: String
-  updatedAt: CommerceDateTime!
+  updatedAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
 }
 
 # Attributes of a Fulfillment
@@ -2390,7 +2410,12 @@ type CommerceLineItem {
   artworkId: String!
   artworkVersionId: String!
   commissionFeeCents: Int
-  createdAt: CommerceDateTime!
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   editionSetId: String
   fulfillments(
     # Returns the elements in the list that come after the specified cursor.
@@ -2411,7 +2436,12 @@ type CommerceLineItem {
   priceCents: Int! @deprecated(reason: "switch to use listPriceCents")
   quantity: Int!
   shippingTotalCents: Int
-  updatedAt: CommerceDateTime!
+  updatedAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   artwork: Artwork
   artworkVersion: ArtworkVersion
   shippingTotal(
@@ -2468,7 +2498,12 @@ type CommerceLineItemEdge {
 type CommerceOffer {
   amountCents: Int!
   buyerTotalCents: Int
-  createdAt: String!
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   creatorId: String!
   currencyCode: String!
   from: CommerceOrderPartyUnion!
@@ -2553,7 +2588,12 @@ type CommerceOfferOrder implements CommerceOrder {
   code: String!
   commissionFeeCents: Int
   commissionRate: Float
-  createdAt: String!
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
@@ -2628,7 +2668,12 @@ type CommerceOfferOrder implements CommerceOrder {
   taxTotalCents: Int
   totalListPriceCents: Int!
   transactionFeeCents: Int
-  updatedAt: String!
+  updatedAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   buyerDetails: OrderParty
   sellerDetails: OrderParty
   creditCard: CreditCard
@@ -2723,7 +2768,12 @@ interface CommerceOrder {
   code: String!
   commissionFeeCents: Int
   commissionRate: Float
-  createdAt: String!
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
@@ -2779,7 +2829,12 @@ interface CommerceOrder {
   taxTotalCents: Int
   totalListPriceCents: Int!
   transactionFeeCents: Int
-  updatedAt: String!
+  updatedAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
   buyerDetails: OrderParty
   sellerDetails: OrderParty
   creditCard: CreditCard

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2064,7 +2064,7 @@ type CommerceBuyOrder implements CommerceOrder {
 
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
-  ): String
+  ): String!
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
@@ -2125,7 +2125,7 @@ type CommerceBuyOrder implements CommerceOrder {
 
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
-  ): String
+  ): String!
   buyerDetails: OrderParty
   sellerDetails: OrderParty
   creditCard: CreditCard
@@ -2363,8 +2363,13 @@ type CommerceFulfillment {
 
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
+  ): String!
+  estimatedDelivery(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
   ): String
-  estimatedDelivery: CommerceDate
   internalID: ID!
   notes: String
   trackingId: String
@@ -2373,7 +2378,7 @@ type CommerceFulfillment {
 
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
-  ): String
+  ): String!
 }
 
 # Attributes of a Fulfillment
@@ -2415,7 +2420,7 @@ type CommerceLineItem {
 
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
-  ): String
+  ): String!
   editionSetId: String
   fulfillments(
     # Returns the elements in the list that come after the specified cursor.
@@ -2441,7 +2446,7 @@ type CommerceLineItem {
 
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
-  ): String
+  ): String!
   artwork: Artwork
   artworkVersion: ArtworkVersion
   shippingTotal(
@@ -2503,7 +2508,7 @@ type CommerceOffer {
 
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
-  ): String
+  ): String!
   creatorId: String!
   currencyCode: String!
   from: CommerceOrderPartyUnion!
@@ -2593,7 +2598,7 @@ type CommerceOfferOrder implements CommerceOrder {
 
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
-  ): String
+  ): String!
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
@@ -2673,7 +2678,7 @@ type CommerceOfferOrder implements CommerceOrder {
 
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
-  ): String
+  ): String!
   buyerDetails: OrderParty
   sellerDetails: OrderParty
   creditCard: CreditCard
@@ -2773,7 +2778,7 @@ interface CommerceOrder {
 
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
-  ): String
+  ): String!
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
@@ -2834,7 +2839,7 @@ interface CommerceOrder {
 
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
-  ): String
+  ): String!
   buyerDetails: OrderParty
   sellerDetails: OrderParty
   creditCard: CreditCard

--- a/src/lib/stitching/exchange/transformers/replaceCommerceDateTimeType.ts
+++ b/src/lib/stitching/exchange/transformers/replaceCommerceDateTimeType.ts
@@ -63,7 +63,10 @@ export class ReplaceCommerceDateTimeType implements Transform {
     const fields = type.getFields()
     const newFields: GraphQLFieldConfigMap<any, any> = {}
     const resolveType = createResolveType((_name, type) => {
-      if (type.name === "CommerceDateTime") {
+      if (
+        type.name === "CommerceDateTime" ||
+        (type.ofType && type.ofType.name === "CommerceDateTime")
+      ) {
         return dateField.type
       }
       return type
@@ -72,14 +75,18 @@ export class ReplaceCommerceDateTimeType implements Transform {
     Object.entries(fields).forEach(([fieldName, fieldDefinition]) => {
       const fieldConfig = fieldToFieldConfig(fieldDefinition, resolveType, true)
       // If it's not a type we want to replace, just skip it
-      if (fieldDefinition.type.name !== "CommerceDateTime") {
-        newFields[fieldName] = fieldConfig
-      } else {
+      if (
+        fieldDefinition.type.name === "CommerceDateTime" ||
+        (fieldDefinition.type.ofType &&
+          fieldDefinition.type.ofType.name === "CommerceDateTime")
+      ) {
         madeChanges = true
         newFields[fieldName] = {
           ...fieldConfig,
           ...dateField,
         }
+      } else {
+        newFields[fieldName] = fieldConfig
       }
     })
 

--- a/src/lib/stitching/exchange/transformers/replaceCommerceDateTimeType.ts
+++ b/src/lib/stitching/exchange/transformers/replaceCommerceDateTimeType.ts
@@ -4,6 +4,8 @@ import {
   GraphQLObjectType,
   GraphQLInterfaceType,
   GraphQLFieldConfigMap,
+  GraphQLNonNull,
+  GraphQLString,
 } from "graphql"
 import {
   visitSchema,
@@ -77,13 +79,23 @@ export class ReplaceCommerceDateTimeType implements Transform {
       // If it's not a type we want to replace, just skip it
       if (
         fieldDefinition.type.name === "CommerceDateTime" ||
-        (fieldDefinition.type.ofType &&
-          fieldDefinition.type.ofType.name === "CommerceDateTime")
+        fieldDefinition.type.name === "CommerceDate"
       ) {
         madeChanges = true
         newFields[fieldName] = {
           ...fieldConfig,
           ...dateField,
+        }
+      } else if (
+        fieldDefinition.type.ofType &&
+        (fieldDefinition.type.ofType.name === "CommerceDateTime" ||
+          fieldDefinition.type.ofType.name === "CommerceDate")
+      ) {
+        madeChanges = true
+        newFields[fieldName] = {
+          ...fieldConfig,
+          ...dateField,
+          type: new GraphQLNonNull(GraphQLString),
         }
       } else {
         newFields[fieldName] = fieldConfig

--- a/src/lib/stitching/exchange/transformers/replaceCommerceDateTimeType.ts
+++ b/src/lib/stitching/exchange/transformers/replaceCommerceDateTimeType.ts
@@ -6,6 +6,7 @@ import {
   GraphQLFieldConfigMap,
   GraphQLNonNull,
   GraphQLString,
+  getNamedType,
 } from "graphql"
 import {
   visitSchema,
@@ -78,8 +79,7 @@ export class ReplaceCommerceDateTimeType implements Transform {
       const fieldConfig = fieldToFieldConfig(fieldDefinition, resolveType, true)
       // If it's not a type we want to replace, just skip it
       if (
-        fieldDefinition.type.name === "CommerceDateTime" ||
-        fieldDefinition.type.name === "CommerceDate"
+        ["CommerceDateTime", "CommerceDate"].includes(fieldDefinition.type.name)
       ) {
         madeChanges = true
         newFields[fieldName] = {
@@ -87,9 +87,9 @@ export class ReplaceCommerceDateTimeType implements Transform {
           ...dateField,
         }
       } else if (
-        fieldDefinition.type.ofType &&
-        (fieldDefinition.type.ofType.name === "CommerceDateTime" ||
-          fieldDefinition.type.ofType.name === "CommerceDate")
+        ["CommerceDateTime!", "CommerceDate!"].includes(
+          getNamedType(fieldDefinition).type.toString()
+        )
       ) {
         madeChanges = true
         newFields[fieldName] = {


### PR DESCRIPTION
# Problem
As part of #1803 , we replaced all `CommerceDateTime` fields with MP's `dateTime`. But `createdAt` field under `Order` is still coming as `CommerceDateTime`.

# Cause
When we did replacement, the transformer replaces the field resolver based on `type.name` of the field, but when a field is not nullable, the type is `GraphQLNotNull` and `type.ofType.name` for that field would be `CommerceDateTime`.

# Solution
Check for `type.ofType` when there is available also.