### PR TITLE
@zephraph => [KAWS] Fix stitching transform issue causing price fields to be renamed

### DIFF
--- a/src/lib/stitching/kaws/stitching.ts
+++ b/src/lib/stitching/kaws/stitching.ts
@@ -139,7 +139,6 @@ export const kawsStitchingEnvironment = (
             },
             context,
             info,
-            transforms: kawsSchema.transforms,
           })
         },
       },


### PR DESCRIPTION
Definitely not sure what's going on here, but this seems to fix the failing query (and all tests pass, although there are no true integration tests exercising KAWS stitching and running a real query, unlike some of the other stitched apps/environments). I will try to add some tests here.

The docs seem to be pretty clear that you _do_ want to pass in the transforms used on the remote schema, here:  https://www.apollographql.com/docs/graphql-tools/schema-delegation/#transforms-arraytransform

But, I think there's some bug there, and if this seems to work, maybe it's fine? The specifically extended schema here, adding filtered artworks under a marketing collection, wouldn't really need to know any of the transforms used for KAWS, would it? I'm sure there is a circumstance where it would (such as mixing other KAWS types in there), so the prescription is to pass it along, but maybe there's edge cases (and we can safely not).

Marked this as a WIP in case others see it, but I'll try to add some specs. If the specs wind up passing (and I can match the production failure which would be fixed by this change), that might give us some confidence to deploy this, with a TODO to investigate it within the lib more thoroughly?