### PR TITLE
Fix CommerceOrder stitching

### DIFF
--- a/src/lib/stitching/exchange/__tests__/stitching.test.ts
+++ b/src/lib/stitching/exchange/__tests__/stitching.test.ts
@@ -28,6 +28,18 @@ it("extends the Order objects", async () => {
   }
 })
 
+it("resolves amount fields on CommerceOrder", async () => {
+  const { resolvers } = await getExchangeStitchedSchema()
+  const totalListPriceResolver = resolvers.CommerceOrder.totalListPrice.resolve
+
+  expect(
+    totalListPriceResolver(
+      { currencyCode: "USD", totalListPriceCents: 100 },
+      {}
+    )
+  ).toEqual("$1.00")
+})
+
 // These are used in all delegate calls, and not useful to the test
 const restOfResolveArgs = {
   operation: "query",

--- a/src/lib/stitching/exchange/stitching.ts
+++ b/src/lib/stitching/exchange/stitching.ts
@@ -232,6 +232,13 @@ export const exchangeStitchingEnvironment = (
         },
         ...totalsResolvers("CommerceLineItem", lineItemTotals),
       },
+      CommerceOrder: {
+        // The money helper resolvers
+        ...totalsResolvers("CommerceOrder", orderTotals),
+        buyerDetails: buyerDetailsResolver,
+        sellerDetails: sellerDetailsResolver,
+        creditCard: creditCardResolver,
+      },
       CommerceOffer: {
         ...totalsResolvers("CommerceOffer", offerAmountFields),
         fromDetails: fromDetailsResolver,


### PR DESCRIPTION
@mdole noticed that our resolvers for `CommerceOrder` weren't working-- in particular, the fields under `CommerOrder` wrapped in the `amount` helper weren't resolving correctly.

It appears this issue is due to the fact that we weren't actually including the `CommerceOrder` in our resolvers for the stitched version of the schema.

This should fix!
![image](https://user-images.githubusercontent.com/2081340/62387125-ce3d8100-b527-11e9-9a62-6cb94830b353.png)
