### PR TITLE
creditCardResolver returns null if the id is null

### DIFF
--- a/src/lib/stitching/exchange/__tests__/stitching.test.ts
+++ b/src/lib/stitching/exchange/__tests__/stitching.test.ts
@@ -121,3 +121,18 @@ it("delegates to the local schema for an Order's creditCard", async () => {
     ...restOfResolveArgs,
   })
 })
+
+it("doesn't delegate to the local schema for an Order's creditCard if creditCardId is null", async () => {
+  const { resolvers } = await getExchangeStitchedSchema()
+  const creditCardResolver = resolvers.CommerceBuyOrder.creditCard.resolve
+  const mergeInfo = { delegateToSchema: jest.fn() }
+
+  creditCardResolver({ creditCardId: null }, {}, {}, { mergeInfo })
+
+  expect(mergeInfo.delegateToSchema).not.toHaveBeenCalledWith({
+    args: { id: null },
+    fieldName: "credit_card",
+    operation: "query",
+    ...restOfResolveArgs,
+  })
+})

--- a/src/lib/stitching/exchange/stitching.ts
+++ b/src/lib/stitching/exchange/stitching.ts
@@ -109,17 +109,21 @@ export const exchangeStitchingEnvironment = (
     fragment: `fragment CommerceOrderCreditCard on CommerceOrder { creditCardId }`,
     resolve: (parent, _args, context, info) => {
       const id = parent.creditCardId
-      return info.mergeInfo.delegateToSchema({
-        schema: localSchema,
-        operation: "query",
-        fieldName: "credit_card",
-        args: {
-          id,
-        },
-        context,
-        info,
-        transforms: exchangeSchema.transforms,
-      })
+      if (!id) {
+        return null
+      } else {
+        return info.mergeInfo.delegateToSchema({
+          schema: localSchema,
+          operation: "query",
+          fieldName: "credit_card",
+          args: {
+            id,
+          },
+          context,
+          info,
+          transforms: exchangeSchema.transforms,
+        })
+      }
     },
   }
 


### PR DESCRIPTION
creditCardResolver should return null if the id is null rather than trying to delegate the request to gravity

See discussion here: 
https://artsy.slack.com/archives/C9YNS4X32/p1564760261125200