### PR TITLE
Fixes an issue where snake case date fields are present

### DIFF
--- a/src/schema/v2/fields/date.ts
+++ b/src/schema/v2/fields/date.ts
@@ -2,6 +2,7 @@ import moment from "moment"
 import "moment-timezone"
 import { GraphQLString, GraphQLFieldConfig } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { snakeCase } from "lodash"
 
 export function date(rawDate, format, timezone) {
   if (timezone) {
@@ -38,7 +39,7 @@ const dateField: GraphQLFieldConfig<DateSource, ResolverContext> = {
     },
   },
   resolve: (obj, { format, timezone }, { defaultTimezone }, { fieldName }) => {
-    const rawDate = obj[fieldName]
+    const rawDate = obj[fieldName] || obj[snakeCase(fieldName)]
     if (!rawDate) {
       return null
     }


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/AUCT-539

GIven the query:

```graphql
{
  sale(id: "yuki-contemporary-art-august-5th") {
    endAt
    liveStartAt
    startAt
  }
}
```

or for v1:

```graphql
{
  sale(id: "yuki-contemporary-art-august-5th") {
    end_at
    live_start_at
    start_at
  }
}

```

They should return the same data except the keys are cameCase in v2. However, in v2, camelCase keys are not properly snake_cased on resolving. As a result, these date field always end up being `null`.

### v1:

<img width="1090" alt="AUCT-529-mp-v1" src="https://user-images.githubusercontent.com/386234/62479523-ad6d6980-b77b-11e9-903f-022bb902ebfd.png">

### v2:

<img width="1090" alt="AUCT-529-mp-v2" src="https://user-images.githubusercontent.com/386234/62479526-ae9e9680-b77b-11e9-8a49-7b08d8a87f67.png">

## Fixes

In the `date` resolver, look up the date value with a snake cased key when the value corresponding to the original field name is not present in the object:

<img width="1090" alt="AUCT-529-mp-v2-fixed" src="https://user-images.githubusercontent.com/386234/62479543-b3fbe100-b77b-11e9-9a65-e38547aa83e3.png">

This would probably affect any other date fields so I wanted to make sure this is a safe change. Also, I wonder if there is other place that requires a case conversation. Let me know what you think.