### PR TITLE
@zephraph => [filterArtworksConnection] Pass proper params to connection helper

### DIFF
--- a/src/schema/v2/__tests__/filterArtworksConnection.test.js
+++ b/src/schema/v2/__tests__/filterArtworksConnection.test.js
@@ -268,6 +268,64 @@ describe("filterArtworksConnection", () => {
     })
   })
 
+  describe(`Returns proper pagination information`, () => {
+    beforeEach(() => {
+      context = {
+        authenticatedLoaders: {},
+        unauthenticatedLoaders: {
+          filterArtworksLoader: sinon
+            .stub()
+            .withArgs("filter/artworks")
+            .returns(
+              Promise.resolve({
+                hits: [
+                  {
+                    id: "oseberg-norway-queens-ship-0",
+                  },
+                  {
+                    id: "oseberg-norway-queens-ship-1",
+                  },
+                  {
+                    id: "oseberg-norway-queens-ship-2",
+                  },
+                  {
+                    id: "oseberg-norway-queens-ship-3",
+                  },
+                ],
+                aggregations: {
+                  total: {
+                    value: 5,
+                  },
+                },
+              })
+            ),
+        },
+      }
+    })
+
+    it("returns `true` for `hasNextPage` when there is more data", () => {
+      const query = `
+        {
+          filterArtworksConnection(first: 4, after: "", aggregations:[TOTAL]) {
+            pageInfo {
+              hasNextPage
+            }
+          }
+        }
+      `
+
+      return runQuery(query, context).then(
+        ({
+          filterArtworksConnection: {
+            pageInfo: { hasNextPage },
+          },
+        }) => {
+          expect(hasNextPage).toBeTruthy()
+        }
+      )
+    })
+  })
+
   describe(`When requesting personalized arguments`, () => {
     beforeEach(() => {
       context = {

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -392,7 +392,14 @@ const filterArtworksConnectionTypeFactory = (
       keyword_match_exact: keywordMatchExact,
       ..._options,
     }
-    const { include_artworks_by_followed_artists, aggregations } = options
+    const {
+      first,
+      last,
+      after,
+      before,
+      include_artworks_by_followed_artists,
+      aggregations,
+    } = options
     const requestedPersonalizedAggregation = aggregations.includes(
       "followed_artists"
     )
@@ -439,13 +446,17 @@ const filterArtworksConnectionTypeFactory = (
         gravityOptions.size
       )
 
-      const connection = connectionFromArraySlice(hits, gravityOptions, {
-        arrayLength: Math.min(
-          aggregations.total.value,
-          totalPages * gravityOptions.size
-        ),
-        sliceStart: gravityOptions.offset,
-      })
+      const connection = connectionFromArraySlice(
+        hits,
+        { first, last, after, before },
+        {
+          arrayLength: Math.min(
+            aggregations.total.value,
+            totalPages * gravityOptions.size
+          ),
+          sliceStart: gravityOptions.offset,
+        }
+      )
 
       connection.pageInfo.endCursor = pageToCursor(
         gravityOptions.page + 1,

--- a/src/schema/v2/object_identification.ts
+++ b/src/schema/v2/object_identification.ts
@@ -60,6 +60,10 @@ const typeNames = {
   "./filterArtworksConnection": "filterArtworksConnection",
 }
 
+const exportNames = {
+  filterArtworksConnection: "filterArtworksConnection",
+}
+
 SupportedTypes.typeMap = SupportedTypes.files.reduce((typeMap, file) => {
   const type = typeNames[file] || _.upperFirst(_.camelCase(basename(file)))
   typeMap[type] = file
@@ -73,7 +77,8 @@ Object.defineProperty(SupportedTypes, "typeModules", {
     if (SupportedTypes._typeModules === undefined) {
       SupportedTypes._typeModules = SupportedTypes.types.reduce(
         (modules, type) => {
-          modules[type] = require(SupportedTypes.typeMap[type]).default
+          const exportType = exportNames[type] || "default"
+          modules[type] = require(SupportedTypes.typeMap[type])[exportType]
           return modules
         },
         {}


### PR DESCRIPTION
Closes https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=64&projectKey=PLATFORM&modal=detail&selectedIssue=PLATFORM-1685

Goofed and passed the wrong set of params to the connection helper. The Relay connection args are expected, but was passing the underlying API options instead. Added a spec that passes locally.