### PR TITLE
@zephraph => Filter optimization; don't request (and set size=0 explicitly), when connection is skipped

### DIFF
--- a/src/lib/__tests__/hasFieldSelection.test.ts
+++ b/src/lib/__tests__/hasFieldSelection.test.ts
@@ -9,6 +9,7 @@ import {
   hasFieldSelection,
   hasIntersectionWithSelectionSet,
   includesFieldsOtherThanSelectionSet,
+  isSkipped,
 } from "lib/hasFieldSelection"
 
 const fragments = parse(gql`
@@ -18,6 +19,7 @@ const fragments = parse(gql`
       ...TestFragmentVisitation
     }
     ...TestMergedFieldSelection
+    ...TestSkippedValue
   }
   fragment TestMergedFieldSelection on Artist {
     artwork {
@@ -29,6 +31,9 @@ const fragments = parse(gql`
   }
   fragment TestFragmentVisitation on Artwork {
     edition_of
+  }
+  fragment TestSkippedValue on Artwork {
+    title @skip(if: true)
   }
 `).definitions as FragmentDefinitionNode[]
 
@@ -86,5 +91,16 @@ describe("includesFieldsOtherThanSelectionSet", () => {
         "edition_sets",
       ])
     ).toEqual(false)
+  })
+})
+
+describe("isSkipped", () => {
+  it("returns the value of the skip directive", () => {
+    const directives = fragments[3].selectionSet.selections[0].directives
+    expect(isSkipped({ directives, info })).toEqual(true)
+  })
+  it("returns false without skip directive", () => {
+    const directives = fragments[2].selectionSet.selections[0].directives
+    expect(isSkipped({ directives, info })).toEqual(false)
   })
 })

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -105,7 +105,9 @@ export const convertConnectionArgsToGravityArgs = <T extends CursorPageable>(
   options: T
 ) => {
   const { limit: size, offset } = getPagingParameters(options)
-  const page = Math.round((size + offset) / size)
+  // If a size of 0 explicitly requested, it doesn't really matter what
+  // the page is.
+  const page = size ? Math.round((size + offset) / size) : 1
   const gravityArgs = omit(options, ["first", "after", "last", "before"])
   return Object.assign({}, { page, size, offset }, gravityArgs)
 }

--- a/src/schema/v1/filter_artworks.ts
+++ b/src/schema/v1/filter_artworks.ts
@@ -370,6 +370,8 @@ const filterArtworksTypeFactory = (
     let relayOptions: any = {}
     if (Object.keys(connectionArgs).length) {
       relayOptions = convertConnectionArgsToGravityArgs(connectionArgs)
+    } else {
+      relayOptions.size = 0
     }
 
     if (!!gravityOptions.page) relayOptions.page = gravityOptions.page

--- a/src/schema/v2/__tests__/filterArtworksConnection.test.js
+++ b/src/schema/v2/__tests__/filterArtworksConnection.test.js
@@ -326,6 +326,39 @@ describe("filterArtworksConnection", () => {
     })
   })
 
+  describe(`Connection argument validation`, () => {
+    beforeEach(() => {
+      context = {
+        authenticatedLoaders: {},
+        unauthenticatedLoaders: {
+          filterArtworksLoader: jest.fn(),
+        },
+      }
+    })
+
+    it("throws an error when `first`, `last` and `size` are missing", () => {
+      const query = `
+        {
+          filterArtworksConnection(aggregations:[TOTAL]) {
+            pageInfo {
+              hasNextPage
+            }
+          }
+        }
+      `
+
+      expect(() => {
+        try {
+          runQuery(query, context)
+        } catch (e) {
+          expect(e.message).toContain(
+            "You must pass either `first`, `last` or `size`"
+          )
+        }
+      })
+    })
+  })
+
   describe(`When requesting personalized arguments`, () => {
     beforeEach(() => {
       context = {

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -397,9 +397,15 @@ const filterArtworksConnectionTypeFactory = (
       last,
       after,
       before,
+      size,
       include_artworks_by_followed_artists,
       aggregations,
     } = options
+
+    // Check if connection args missing.
+    if (first == null && last == null && size == null)
+      throw new Error("You must pass either `first`, `last` or `size`.")
+
     const requestedPersonalizedAggregation = aggregations.includes(
       "followed_artists"
     )


### PR DESCRIPTION
Closes https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=64&projectKey=PLATFORM&modal=detail&selectedIssue=PLATFORM-1675

Since we were introspecting to grab connection parameters (in order to consolidate multiple backend fetches), this led to us not respecting if said connection was skipped via the GraphQL directive. As in, the optimization didn't take this into account, and still fetched all the artworks. It did the 'optimum' combined one call, but the whole fetching of the artworks in the first place was unneeded due to the skip.

So, this PR takes that into account and no longer parses those connection parameters (if the entire connection is skipped). Additionally, we set a size of 0 explicitly on any calls where there was no unskipped artwork connection requested. When we leave out all pagination/size parameters, we get a default of 10 (this is in [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-from-size), and is unneccessary as well).