### PR TITLE
Disable failing snapshot test

### DIFF
--- a/src/schema/v2/home/__tests__/home_page_fairs_module.test.js
+++ b/src/schema/v2/home/__tests__/home_page_fairs_module.test.js
@@ -103,7 +103,8 @@ describe("HomePageFairsModule", () => {
     })
   })
 
-  it("does not return fairs that do not have mobile images", () => {
+  // FIXME: Snapshot seems to change
+  it.skip("does not return fairs that do not have mobile images", () => {
     const aFair = [
       {
         id: "artissima-2017",


### PR DESCRIPTION
This particular test seems to have a field that flip flops based on whether jest cache is available or not. I'm just gonna disable it for now until we can dig into it further. 