### PR TITLE
fix size

### DIFF
--- a/src/schema/v1/filter_artworks.ts
+++ b/src/schema/v1/filter_artworks.ts
@@ -371,7 +371,7 @@ const filterArtworksTypeFactory = (
     if (Object.keys(connectionArgs).length) {
       relayOptions = convertConnectionArgsToGravityArgs(connectionArgs)
     } else {
-      relayOptions.size = 0
+      relayOptions.size = relayOptions.size || 0
     }
 
     if (!!gravityOptions.page) relayOptions.page = gravityOptions.page


### PR DESCRIPTION
I closed the  [PR](https://github.com/artsy/metaphysics/pull/1902). I open a new one. Now the changes in the queryMap are removed.

Related to a [change made 10 days ago](https://github.com/artsy/metaphysics/commit/01e0635e4217aefd5a6036d0a27a72c86daacbde), the filterartworks query returns zero artworks. This is because the `relayOptions` size property overwrites the size argument that come from the collections query. To fix this we check for `gravityOptions.size` before setting it to zero.


![Screen Shot 2019-08-23 at 15 52 12](https://user-images.githubusercontent.com/45926410/63619968-1f3c1480-c5be-11e9-9087-b4087b40f21a.png)