### PR TITLE
@zephraph => [Error Handling] Restore error formatting and extensions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ import {
 import { middleware as requestIDsAdder } from "./lib/requestIDs"
 import { nameOldEigenQueries } from "./lib/modifyOldEigenQueries"
 import { rateLimiter } from "./lib/rateLimiter"
-// import { graphqlErrorHandler } from "./lib/graphqlErrorHandler"
+import { graphqlErrorHandler } from "./lib/graphqlErrorHandler"
 
 import { ResolverContext } from "types/graphql"
 import { logQueryDetails } from "./lib/logQueryDetails"
@@ -156,7 +156,7 @@ function startApp(appSchema, path: string) {
   } else {
     const graphqlHTTP = require("express-graphql")
     app.use(
-      graphqlHTTP((req, res /*, params */) => {
+      graphqlHTTP((req, res, params) => {
         console.log("Request from", path)
         const accessToken = req.headers["x-access-token"] as string | undefined
         const userID = req.headers["x-user-id"] as string | undefined
@@ -199,12 +199,12 @@ function startApp(appSchema, path: string) {
           context,
           rootValue: {},
           // FIXME: This needs to be updated as per the release notes of graphql-js v14
-          // formatError: graphqlErrorHandler(enableSentry, {
-          //   req,
-          //   // Why the checking on params? Do we reach this code if params is falsy?
-          //   variables: params && params.variables,
-          //   query: (params && params.query)!,
-          // }),
+          formatError: graphqlErrorHandler(enableSentry, {
+            req,
+            // Why the checking on params? Do we reach this code if params is falsy?
+            variables: params && params.variables,
+            query: (params && params.query)!,
+          }),
           validationRules: QUERY_DEPTH_LIMIT
             ? [depthLimit(QUERY_DEPTH_LIMIT)]
             : null,

--- a/src/schema/v1/index.ts
+++ b/src/schema/v1/index.ts
@@ -12,11 +12,11 @@ const enableSchemaStitching = !DISABLE_SCHEMA_STITCHING
 if (enableSchemaStitching) {
   try {
     if (typeof jest == "undefined") {
-      console.warn("[FEATURE] Enabling Schema Stitching")
+      console.warn("[V1] [FEATURE] Enabling Schema Stitching")
     }
     exportedSchema = incrementalMergeSchemas(exportedSchema, 1)
   } catch (err) {
-    console.log("Error merging schemas:", err)
+    console.log("[V1] Error merging schemas:", err)
   }
 }
 export const schema = exportedSchema

--- a/src/schema/v2/index.ts
+++ b/src/schema/v2/index.ts
@@ -13,11 +13,11 @@ const enableSchemaStitching = !DISABLE_SCHEMA_STITCHING
 if (enableSchemaStitching) {
   try {
     if (typeof jest == "undefined") {
-      console.warn("[FEATURE] Enabling Schema Stitching")
+      console.warn("[V2] [FEATURE] Enabling Schema Stitching")
     }
     exportedSchema = incrementalMergeSchemas(exportedSchema, 2)
   } catch (err) {
-    console.log("Error merging schemas:", err)
+    console.log("[V2] Error merging schemas:", err)
   }
 }
 export const schema = transformToV2(exportedSchema)


### PR DESCRIPTION
I might be missing some context here.

Our recommended [.env.example](https://github.com/artsy/metaphysics/blob/ffc54b0c297080b5b6e90faa38d330b3fac4a9de/.env.example#L51) file includes `ENABLE_APOLLO=true`. This is set to `false` in the staging env, and not set at all in production. However, it looks like that needs to be explicitly set to true: https://github.com/artsy/metaphysics/blob/ffc54b0c297080b5b6e90faa38d330b3fac4a9de/src/config.ts#L152 , so at least staging + prod are equivalent. But, they're different than development.

Locally I was seeing properly formatted GraphQL errors, but on staging/prod that didn't seem to happen. Investigating further, I found this commented out section in the 'apollo not enabled' branch of setup.

It alludes to something breaking in v14 of GraphQL-js, however checking the lockfile, and we haven't updated to that yet.

So I think this may have been prematurely commented out (or rather, not commented back in after Apollo was possibly deployed/feature-flagged/etc- I don't recall the sequence of events there).

In that case, for now, I think we should comment this back in, leaving the `FIXME` for when we truly are upgrading. This also unblocks relevant proper error propagation cards, as that relies on MP being able to properly format and include the additional info in the extension.

