### PR TITLE
@zephraph => [Error Handling] Suppress stack traces in a production environment

### DIFF
--- a/src/lib/__tests__/graphqlErrorHandler.test.ts
+++ b/src/lib/__tests__/graphqlErrorHandler.test.ts
@@ -5,6 +5,7 @@ import {
 import { GraphQLTimeoutError } from "lib/graphqlTimeoutMiddleware"
 import { HTTPError } from "lib/HTTPError"
 import { GraphQLError } from "graphql"
+import config from "config"
 
 describe("graphqlErrorHandler", () => {
   describe(shouldReportError, () => {
@@ -58,6 +59,22 @@ describe("graphqlErrorHandler", () => {
   })
 
   describe(formattedGraphQLError, () => {
+    describe("stack traces", () => {
+      it("are not present in production", () => {
+        config.PRODUCTION_ENV = true
+        expect(
+          Object.keys(formattedGraphQLError(new GraphQLError("something")))
+        ).not.toContain("stack")
+        config.PRODUCTION_ENV = false
+      })
+
+      it("are present in a non-production environment", () => {
+        expect(
+          Object.keys(formattedGraphQLError(new GraphQLError("something")))
+        ).toContain("stack")
+      })
+    })
+
     describe("concerning upstream HTTP status codes", () => {
       it("does not include a HTTP status code for non HTTP errors", () => {
         expect(

--- a/src/lib/graphqlErrorHandler.ts
+++ b/src/lib/graphqlErrorHandler.ts
@@ -97,9 +97,13 @@ export const formattedGraphQLError = (
   if (topLevelError.locations) {
     result.locations = topLevelError.locations
   }
-  // Question: Should this be a flag on Sentry enabled, or on being in the production env?
-  if (config.PRODUCTION_ENV) {
+
+  if (topLevelError.path) {
     result.path = topLevelError.path
+  }
+
+  const includeStackTrace = !config.PRODUCTION_ENV
+  if (includeStackTrace) {
     result.stack = topLevelError.stack
   }
 


### PR DESCRIPTION
Now that error handling is back, noticing that full stack traces were coming up in staging/prod (but not development). This flag was backwards (h/t @alloy).