### PR TITLE
[WIP] [GALL-1627] Partner blacklist

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "graphql": "0.13.2",
     "graphql-depth-limit": "1.1.0",
     "graphql-extensions": "0.5.7",
+    "graphql-list-fields": "^2.0.2",
     "graphql-middleware": "1.2.6",
     "graphql-relay": "0.5.4",
     "graphql-tools": "4.0.4",

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -3,21 +3,21 @@ import {
   camelCase,
   compact,
   difference,
-  flatMap,
   flow,
   includes,
   isEmpty,
   isObject,
   isString,
-  map,
   omit,
   reject,
   trim,
+  uniq,
 } from "lodash"
 import now from "performance-now"
 import { stringify } from "qs"
 import { getPagingParameters, CursorPageable } from "relay-cursor-paging"
 import { formatMarkdownValue } from "schema/v1/fields/markdown"
+import getFieldNames from "graphql-list-fields"
 
 const loadNs = now()
 const loadMs = Date.now()
@@ -86,9 +86,13 @@ export const markdownToText = str => {
   return stripTags(formatMarkdownValue(str, "html"))
 }
 export const parseFieldASTsIntoArray = fieldASTs => {
-  // TODO: when fieldASTs[*].selectionSet.selections.kind === "InlineFragment" recursively go deeper
-  return map(flatMap(fieldASTs, "selectionSet.selections"), "name.value")
+  const fieldNames = getFieldNames({ fieldASTs: fieldASTs })
+  return filterTopLevelFieldNames(fieldNames)
 }
+
+const filterTopLevelFieldNames = dottedFieldNameArray =>
+  uniq(dottedFieldNameArray.map(name => name.split(".")[0]))
+
 export const queriedForFieldsOtherThanBlacklisted = (
   fieldASTs,
   blacklistedFields

--- a/src/schema/v1/partner.ts
+++ b/src/schema/v1/partner.ts
@@ -291,10 +291,11 @@ const Partner: GraphQLFieldConfig<void, ResolverContext> = {
     },
   },
   resolve: (_root, { id }, { partnerLoader }, { fieldNodes }) => {
-    const blacklistedFields = ["analytics"]
+    // when the query is partner analytics, vortex stitching fragment only has _id
+    const blacklistedFields = ["_id"]
     const isSlug = !/[0-9a-f]{24}/.test(id)
-    // vortex can only load analytics data by id so if id passed by client is slug load
-    // partner from gravity
+    // vortex can only load analytics data by id so if id passed by client is slug,
+    // then partner from gravity
     if (
       isSlug ||
       queriedForFieldsOtherThanBlacklisted(fieldNodes, blacklistedFields)

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -49,7 +49,8 @@ export const runQuery = (
   context: Partial<ResolverContext> = {
     accessToken: undefined,
     userID: undefined,
-  }
+  },
+  variableValues: { [variableName: string]: any } = {}
 ) => {
   const schema = require("schema/v1").default
   return runQueryOrThrow({
@@ -63,6 +64,7 @@ export const runQuery = (
       },
       ...context,
     },
+    variableValues,
   })
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4253,6 +4253,11 @@ graphql-language-service-utils@0.0.17:
     graphql "^0.10.1"
     graphql-language-service-types "0.0.21"
 
+graphql-list-fields@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/graphql-list-fields/-/graphql-list-fields-2.0.2.tgz#a4ade3cfa2028a2ac32d3f2870f5f8c5b5d5b466"
+  integrity sha512-9TSAwcVA3KWw7JWYep5NCk2aw3wl1ayLtbMpmG7l26vh1FZ+gZexNPP+XJfUFyJa71UU0zcKSgtgpsrsA3Xv9Q==
+
 graphql-middleware@1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/graphql-middleware/-/graphql-middleware-1.2.6.tgz#11392687aaa2ef7cc90d46b8ac883d60b526b56d"


### PR DESCRIPTION
Fixes [GALL-1627](https://artsyproduct.atlassian.net/browse/GALL-1627)

## Problem:
`parseFieldASTsIntoArray` function assumes the top level `fieldASTs`s are of type `Field` so with `map(flatMap(fieldASTs, "selectionSet.selections"), "name.value")` it gets the name of all of them, but when that assumption is not true (e.g. top level `fieldAST` is an inline fragment) it doesn't go deeper into the tree.

This hasn't been previously a problem but when we stitched `analytics` under `partner` the top level AST is [this](https://github.com/artsy/metaphysics/blob/master/src/lib/stitching/vortex/stitching.ts#L239-L241) inline fragment and `parseFieldASTsIntoArray` returns `[undefined]` and the `queriedForFieldsOtherThanBlacklisted` function fails to recognize that there are no other fields in the query and always queries gravity for partner data even when the `id` is already provided in the query and no other data is needed from gravity.

## Solution
The naive solution would have been adding an extra if block and handle the case where AST is an `InlineFragment` but the elegant solution which makes  `parseFieldASTsIntoArray` handle all cases was to recursively iterate over the tree.
I was going to implement the tree traversal code but randomly came across [graphql-list-fields](https://github.com/jakepusateri/graphql-list-fields) library. It has decent amount of tests and simple enough that we can contribute/maintain it. I am open to having our own implementation of it but it would be pretty much the same code.

Finally I updated the specs to test the `partnerLoader` is only being called when the `id` passed to the query is the slug. 

## TODO:
- [ ] V2. (Just copy V1?)