### PR TITLE
@alloy => [Error Handling] Expose status code for errors occurring during stitching

### DIFF
--- a/src/lib/__tests__/graphqlErrorHandler.test.ts
+++ b/src/lib/__tests__/graphqlErrorHandler.test.ts
@@ -6,6 +6,7 @@ import { GraphQLTimeoutError } from "lib/graphqlTimeoutMiddleware"
 import { HTTPError } from "lib/HTTPError"
 import { GraphQLError } from "graphql"
 import config from "config"
+import { ServerError } from "apollo-link-http-common"
 
 describe("graphqlErrorHandler", () => {
   describe(shouldReportError, () => {
@@ -80,6 +81,27 @@ describe("graphqlErrorHandler", () => {
         expect(
           Object.keys(formattedGraphQLError(new GraphQLError("something")))
         ).not.toContain("extensions")
+      })
+
+      it("does include a HTTP status code when a response is present", () => {
+        const originalError: ServerError = {
+          message: "underlying",
+          response: { status: 404 },
+          name: "ServerError",
+          result: [],
+          statusCode: 200,
+        }
+        const error = new GraphQLError(
+          "not found",
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          originalError
+        )
+        expect(formattedGraphQLError(error).extensions).toEqual({
+          httpStatusCodes: [404],
+        })
       })
 
       it("does include a HTTP status code for HTTP errors", () => {


### PR DESCRIPTION
So far, I'm able to generate 401/404 and 500s downstream, and verify that the correct `httpStatusCheck` comes back.

For instance, `/orders/234234` (if you're not authorized to view that order, or it doesn't exist), now  correctly returns a 404, without this [custom logic](https://github.com/artsy/force/blob/3f46e35ecda1d0b92615eb70a89584709f780043/src/desktop/apps/order/routes.tsx#L60-L66). Reaction will correctly serve and render the relevant error page.