### PR TITLE
[GALL-1627] Partner loader query fix for partner analytics

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -15,8 +15,6 @@ import now from "performance-now"
 import { stringify } from "qs"
 import { getPagingParameters, CursorPageable } from "relay-cursor-paging"
 import { formatMarkdownValue } from "schema/v1/fields/markdown"
-import { includesFieldsOtherThanSelectionSet } from "./hasFieldSelection"
-import { GraphQLResolveInfo } from "graphql"
 
 const loadNs = now()
 const loadMs = Date.now()
@@ -83,14 +81,6 @@ export const stripTags = (str?: string) => {
 }
 export const markdownToText = str => {
   return stripTags(formatMarkdownValue(str, "html"))
-}
-
-export const queriedForFieldsOtherThanBlacklisted = (
-  info: GraphQLResolveInfo,
-  blacklistedFields
-) => {
-  if (!info) return true
-  return includesFieldsOtherThanSelectionSet(info, blacklistedFields)
 }
 
 export const convertConnectionArgsToGravityArgs = <T extends CursorPageable>(

--- a/src/schema/v1/collection.ts
+++ b/src/schema/v1/collection.ts
@@ -4,10 +4,7 @@ import { warn } from "lib/loggers"
 import cached from "./fields/cached"
 import CollectionSorts from "./sorts/collection_sorts"
 import { artworkConnection } from "./artwork"
-import {
-  queriedForFieldsOtherThanBlacklisted,
-  convertConnectionArgsToGravityArgs,
-} from "lib/helpers"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { NodeInterface, SlugAndInternalIDFields } from "./object_identification"
 import {
   GraphQLObjectType,
@@ -18,6 +15,7 @@ import {
   GraphQLFieldConfig,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { includesFieldsOtherThanSelectionSet } from "lib/hasFieldSelection"
 
 // Note to developers working on collections, the staging server does not get a copy
 // of all artwork saves, so you will need to add some each week in order to have data
@@ -93,9 +91,9 @@ export const collectionResolverFactory = (
     if (!collectionLoader) return null
 
     const id = collection_id || options.id
-    const blacklistedFields = ["artworks_connection", "id", "__id"]
+    const fieldsNotRequireLoader = ["artworks_connection", "id", "__id"]
 
-    if (queriedForFieldsOtherThanBlacklisted(info, blacklistedFields)) {
+    if (includesFieldsOtherThanSelectionSet(info, fieldsNotRequireLoader)) {
       return collectionLoader(id)
     }
 

--- a/src/schema/v1/collection.ts
+++ b/src/schema/v1/collection.ts
@@ -89,13 +89,13 @@ export const CollectionType = new GraphQLObjectType<any, ResolverContext>({
 export const collectionResolverFactory = (
   collection_id
 ): GraphQLFieldResolver<void, ResolverContext> => {
-  return (_root, options, { collectionLoader }, { fieldNodes }) => {
+  return (_root, options, { collectionLoader }, info) => {
     if (!collectionLoader) return null
 
     const id = collection_id || options.id
     const blacklistedFields = ["artworks_connection", "id", "__id"]
 
-    if (queriedForFieldsOtherThanBlacklisted(fieldNodes, blacklistedFields)) {
+    if (queriedForFieldsOtherThanBlacklisted(info, blacklistedFields)) {
       return collectionLoader(id)
     }
 

--- a/src/schema/v1/gene.ts
+++ b/src/schema/v1/gene.ts
@@ -10,10 +10,7 @@ import filterArtworks, {
   filterArtworksArgs,
   FilterArtworksCounts,
 } from "./filter_artworks"
-import {
-  queriedForFieldsOtherThanBlacklisted,
-  convertConnectionArgsToGravityArgs,
-} from "lib/helpers"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { NodeInterface, SlugAndInternalIDFields } from "./object_identification"
 import {
   GraphQLObjectType,
@@ -25,6 +22,7 @@ import {
   GraphQLFieldConfig,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { includesFieldsOtherThanSelectionSet } from "lib/hasFieldSelection"
 
 const SUBJECT_MATTER_MATCHES = [
   "content",
@@ -211,8 +209,8 @@ const Gene: GraphQLFieldConfig<void, ResolverContext> = {
   resolve: (_root, { id }, { geneLoader }, info) => {
     // If you are just making an artworks call ( e.g. if paginating )
     // do not make a Gravity call for the gene data.
-    const blacklistedFields = ["filtered_artworks", "id", "__id"]
-    if (queriedForFieldsOtherThanBlacklisted(info, blacklistedFields)) {
+    const fieldsNotRequireLoader = ["filtered_artworks", "id", "__id"]
+    if (includesFieldsOtherThanSelectionSet(info, fieldsNotRequireLoader)) {
       return geneLoader(id)
     }
 

--- a/src/schema/v1/gene.ts
+++ b/src/schema/v1/gene.ts
@@ -208,11 +208,11 @@ const Gene: GraphQLFieldConfig<void, ResolverContext> = {
       type: new GraphQLNonNull(GraphQLString),
     },
   },
-  resolve: (_root, { id }, { geneLoader }, { fieldNodes }) => {
+  resolve: (_root, { id }, { geneLoader }, info) => {
     // If you are just making an artworks call ( e.g. if paginating )
     // do not make a Gravity call for the gene data.
     const blacklistedFields = ["filtered_artworks", "id", "__id"]
-    if (queriedForFieldsOtherThanBlacklisted(fieldNodes, blacklistedFields)) {
+    if (queriedForFieldsOtherThanBlacklisted(info, blacklistedFields)) {
       return geneLoader(id)
     }
 

--- a/src/schema/v1/me/index.ts
+++ b/src/schema/v1/me/index.ts
@@ -9,7 +9,6 @@ import {
 } from "graphql"
 
 import { IDFields, NodeInterface } from "schema/v1/object_identification"
-import { queriedForFieldsOtherThanBlacklisted } from "lib/helpers"
 
 import date from "schema/v1/fields/date"
 import initials from "schema/v1/fields/initials"
@@ -40,6 +39,7 @@ import SuggestedArtists from "./suggested_artists"
 import Submissions from "./consignments/submissions"
 import config from "config"
 import { ResolverContext } from "types/graphql"
+import { includesFieldsOtherThanSelectionSet } from "lib/hasFieldSelection"
 
 // @ts-ignore
 const { ENABLE_CONVECTION_STITCHING } = config
@@ -133,7 +133,7 @@ const MeField: GraphQLFieldConfig<void, ResolverContext> = {
   type: Me,
   resolve: (_root, _options, { userID, meLoader }, info) => {
     if (!meLoader) return null
-    const blacklistedFields = [
+    const fieldsNotRequireLoader = [
       "id",
       "__id",
       "creditCards",
@@ -159,7 +159,7 @@ const MeField: GraphQLFieldConfig<void, ResolverContext> = {
       "followsAndSaves",
       "saved_artworks",
     ]
-    if (queriedForFieldsOtherThanBlacklisted(info, blacklistedFields)) {
+    if (includesFieldsOtherThanSelectionSet(info, fieldsNotRequireLoader)) {
       return meLoader().catch(() => null)
     }
     // The email and is_collector are here so that the type system's `isTypeOf`

--- a/src/schema/v1/me/index.ts
+++ b/src/schema/v1/me/index.ts
@@ -131,7 +131,7 @@ const Me = new GraphQLObjectType<any, ResolverContext>({
 
 const MeField: GraphQLFieldConfig<void, ResolverContext> = {
   type: Me,
-  resolve: (_root, _options, { userID, meLoader }, { fieldNodes }) => {
+  resolve: (_root, _options, { userID, meLoader }, info) => {
     if (!meLoader) return null
     const blacklistedFields = [
       "id",
@@ -159,7 +159,7 @@ const MeField: GraphQLFieldConfig<void, ResolverContext> = {
       "followsAndSaves",
       "saved_artworks",
     ]
-    if (queriedForFieldsOtherThanBlacklisted(fieldNodes, blacklistedFields)) {
+    if (queriedForFieldsOtherThanBlacklisted(info, blacklistedFields)) {
       return meLoader().catch(() => null)
     }
     // The email and is_collector are here so that the type system's `isTypeOf`

--- a/src/schema/v1/partner.ts
+++ b/src/schema/v1/partner.ts
@@ -290,14 +290,15 @@ const Partner: GraphQLFieldConfig<void, ResolverContext> = {
       description: "The slug or ID of the Partner",
     },
   },
-  resolve: (_root, { id }, { partnerLoader }, { fieldNodes }) => {
-    const blacklistedFields = ["analytics"]
+  resolve: (_root, { id }, { partnerLoader }, info) => {
+    // when the query is partner analytics, vortex stitching fragment only has _id
+    const blacklistedFields = ["_id"]
     const isSlug = !/[0-9a-f]{24}/.test(id)
-    // vortex can only load analytics data by id so if id passed by client is slug load
-    // partner from gravity
+    // vortex can only load analytics data by id so if id passed by client is slug,
+    // then partner from gravity
     if (
       isSlug ||
-      queriedForFieldsOtherThanBlacklisted(fieldNodes, blacklistedFields)
+      queriedForFieldsOtherThanBlacklisted(info, blacklistedFields)
     ) {
       return partnerLoader(id)
     }

--- a/src/schema/v1/partner.ts
+++ b/src/schema/v1/partner.ts
@@ -9,7 +9,7 @@ import Artwork, { artworkConnection } from "./artwork"
 import numeral from "./fields/numeral"
 import ArtworkSorts from "./sorts/artwork_sorts"
 import { pageable } from "relay-cursor-paging"
-import { queriedForFieldsOtherThanBlacklisted } from "lib/helpers"
+import { includesFieldsOtherThanSelectionSet } from "lib/hasFieldSelection"
 
 import {
   GraphQLString,
@@ -292,13 +292,13 @@ const Partner: GraphQLFieldConfig<void, ResolverContext> = {
   },
   resolve: (_root, { id }, { partnerLoader }, info) => {
     // when the query is partner analytics, vortex stitching fragment only has _id
-    const blacklistedFields = ["_id"]
+    const fieldsNotRequireLoader = ["_id"]
     const isSlug = !/[0-9a-f]{24}/.test(id)
     // vortex can only load analytics data by id so if id passed by client is slug,
     // then partner from gravity
     if (
       isSlug ||
-      queriedForFieldsOtherThanBlacklisted(info, blacklistedFields)
+      includesFieldsOtherThanSelectionSet(info, fieldsNotRequireLoader)
     ) {
       return partnerLoader(id)
     }

--- a/src/schema/v1/tag.ts
+++ b/src/schema/v1/tag.ts
@@ -9,7 +9,7 @@ import {
   GraphQLFieldConfig,
 } from "graphql"
 import filterArtworks from "./filter_artworks"
-import { queriedForFieldsOtherThanBlacklisted } from "lib/helpers"
+import { includesFieldsOtherThanSelectionSet } from "lib/hasFieldSelection"
 import { ResolverContext } from "types/graphql"
 
 const TagType = new GraphQLObjectType<any, ResolverContext>({
@@ -49,8 +49,8 @@ const Tag: GraphQLFieldConfig<void, ResolverContext> = {
   resolve: (_root, { id }, { tagLoader }, info) => {
     // If you are just making an artworks call ( e.g. if paginating )
     // do not make a Gravity call for the gene data.
-    const blacklistedFields = ["filtered_artworks", "id", "__id"]
-    if (queriedForFieldsOtherThanBlacklisted(info, blacklistedFields)) {
+    const fieldsNotRequireLoader = ["filtered_artworks", "id", "__id"]
+    if (includesFieldsOtherThanSelectionSet(info, fieldsNotRequireLoader)) {
       return tagLoader(id).then(tag => {
         return Object.assign(tag, { _type: "Tag" }, {})
       })

--- a/src/schema/v1/tag.ts
+++ b/src/schema/v1/tag.ts
@@ -46,11 +46,11 @@ const Tag: GraphQLFieldConfig<void, ResolverContext> = {
       type: new GraphQLNonNull(GraphQLString),
     },
   },
-  resolve: (_root, { id }, { tagLoader }, { fieldNodes }) => {
+  resolve: (_root, { id }, { tagLoader }, info) => {
     // If you are just making an artworks call ( e.g. if paginating )
     // do not make a Gravity call for the gene data.
     const blacklistedFields = ["filtered_artworks", "id", "__id"]
-    if (queriedForFieldsOtherThanBlacklisted(fieldNodes, blacklistedFields)) {
+    if (queriedForFieldsOtherThanBlacklisted(info, blacklistedFields)) {
       return tagLoader(id).then(tag => {
         return Object.assign(tag, { _type: "Tag" }, {})
       })

--- a/src/schema/v2/collection.ts
+++ b/src/schema/v2/collection.ts
@@ -4,10 +4,7 @@ import { warn } from "lib/loggers"
 import cached from "./fields/cached"
 import CollectionSorts from "./sorts/collection_sorts"
 import { artworkConnection } from "./artwork"
-import {
-  queriedForFieldsOtherThanBlacklisted,
-  convertConnectionArgsToGravityArgs,
-} from "lib/helpers"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { NodeInterface, SlugAndInternalIDFields } from "./object_identification"
 import {
   GraphQLObjectType,
@@ -18,6 +15,7 @@ import {
   GraphQLFieldConfig,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { includesFieldsOtherThanSelectionSet } from "lib/hasFieldSelection"
 
 // Note to developers working on collections, the staging server does not get a copy
 // of all artwork saves, so you will need to add some each week in order to have data
@@ -91,9 +89,9 @@ export const collectionResolverFactory = (
     if (!collectionLoader) return null
 
     const id = collection_id || options.id
-    const blacklistedFields = ["artworks", "id", "internalID"]
+    const fieldsNotRequireLoader = ["artworks", "id", "internalID"]
 
-    if (queriedForFieldsOtherThanBlacklisted(info, blacklistedFields)) {
+    if (includesFieldsOtherThanSelectionSet(info, fieldsNotRequireLoader)) {
       return collectionLoader(id)
     }
 

--- a/src/schema/v2/collection.ts
+++ b/src/schema/v2/collection.ts
@@ -87,13 +87,13 @@ export const CollectionType = new GraphQLObjectType<any, ResolverContext>({
 export const collectionResolverFactory = (
   collection_id
 ): GraphQLFieldResolver<void, ResolverContext> => {
-  return (_root, options, { collectionLoader }, { fieldNodes }) => {
+  return (_root, options, { collectionLoader }, info) => {
     if (!collectionLoader) return null
 
     const id = collection_id || options.id
     const blacklistedFields = ["artworks", "id", "internalID"]
 
-    if (queriedForFieldsOtherThanBlacklisted(fieldNodes, blacklistedFields)) {
+    if (queriedForFieldsOtherThanBlacklisted(info, blacklistedFields)) {
       return collectionLoader(id)
     }
 

--- a/src/schema/v2/gene.ts
+++ b/src/schema/v2/gene.ts
@@ -4,10 +4,7 @@ import _ from "lodash"
 import cached from "./fields/cached"
 import Artist, { artistConnection } from "./artist"
 import Image from "./image"
-import {
-  queriedForFieldsOtherThanBlacklisted,
-  convertConnectionArgsToGravityArgs,
-} from "lib/helpers"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { NodeInterface, SlugAndInternalIDFields } from "./object_identification"
 import {
   GraphQLObjectType,
@@ -19,6 +16,7 @@ import {
   GraphQLFieldConfig,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { includesFieldsOtherThanSelectionSet } from "lib/hasFieldSelection"
 
 const SUBJECT_MATTER_MATCHES = [
   "content",
@@ -163,8 +161,12 @@ const Gene: GraphQLFieldConfig<void, ResolverContext> = {
   resolve: (_root, { id }, { geneLoader }, info) => {
     // If you are just making an artworks call ( e.g. if paginating )
     // do not make a Gravity call for the gene data.
-    const blacklistedFields = ["filterArtworksConnection", "id", "internalID"]
-    if (queriedForFieldsOtherThanBlacklisted(info, blacklistedFields)) {
+    const fieldsNotRequireLoader = [
+      "filterArtworksConnection",
+      "id",
+      "internalID",
+    ]
+    if (includesFieldsOtherThanSelectionSet(info, fieldsNotRequireLoader)) {
       return geneLoader(id)
     }
 

--- a/src/schema/v2/gene.ts
+++ b/src/schema/v2/gene.ts
@@ -160,11 +160,11 @@ const Gene: GraphQLFieldConfig<void, ResolverContext> = {
       type: new GraphQLNonNull(GraphQLString),
     },
   },
-  resolve: (_root, { id }, { geneLoader }, { fieldNodes }) => {
+  resolve: (_root, { id }, { geneLoader }, info) => {
     // If you are just making an artworks call ( e.g. if paginating )
     // do not make a Gravity call for the gene data.
     const blacklistedFields = ["filterArtworksConnection", "id", "internalID"]
-    if (queriedForFieldsOtherThanBlacklisted(fieldNodes, blacklistedFields)) {
+    if (queriedForFieldsOtherThanBlacklisted(info, blacklistedFields)) {
       return geneLoader(id)
     }
 

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -9,7 +9,7 @@ import {
 } from "graphql"
 
 import { IDFields, NodeInterface } from "schema/v2/object_identification"
-import { queriedForFieldsOtherThanBlacklisted } from "lib/helpers"
+import { includesFieldsOtherThanSelectionSet } from "lib/hasFieldSelection"
 
 import date from "schema/v2/fields/date"
 import initials from "schema/v2/fields/initials"
@@ -130,7 +130,7 @@ const MeField: GraphQLFieldConfig<void, ResolverContext> = {
   type: Me,
   resolve: (_root, _options, { userID, meLoader }, info) => {
     if (!meLoader) return null
-    const blacklistedFields = [
+    const fieldsNotRequireLoader = [
       "id",
       "internalID",
       "creditCards",
@@ -154,7 +154,7 @@ const MeField: GraphQLFieldConfig<void, ResolverContext> = {
       "followsAndSaves",
       "savedArtworks",
     ]
-    if (queriedForFieldsOtherThanBlacklisted(info, blacklistedFields)) {
+    if (includesFieldsOtherThanSelectionSet(info, fieldsNotRequireLoader)) {
       return meLoader().catch(() => null)
     }
     // The email and is_collector are here so that the type system's `isTypeOf`

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -128,7 +128,7 @@ const Me = new GraphQLObjectType<any, ResolverContext>({
 
 const MeField: GraphQLFieldConfig<void, ResolverContext> = {
   type: Me,
-  resolve: (_root, _options, { userID, meLoader }, { fieldNodes }) => {
+  resolve: (_root, _options, { userID, meLoader }, info) => {
     if (!meLoader) return null
     const blacklistedFields = [
       "id",
@@ -154,7 +154,7 @@ const MeField: GraphQLFieldConfig<void, ResolverContext> = {
       "followsAndSaves",
       "savedArtworks",
     ]
-    if (queriedForFieldsOtherThanBlacklisted(fieldNodes, blacklistedFields)) {
+    if (queriedForFieldsOtherThanBlacklisted(info, blacklistedFields)) {
       return meLoader().catch(() => null)
     }
     // The email and is_collector are here so that the type system's `isTypeOf`

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -21,7 +21,7 @@ import { NodeInterface, SlugAndInternalIDFields } from "./object_identification"
 import { artworkConnection } from "./artwork"
 import numeral from "./fields/numeral"
 import ArtworkSorts from "./sorts/artwork_sorts"
-import { queriedForFieldsOtherThanBlacklisted } from "lib/helpers"
+import { includesFieldsOtherThanSelectionSet } from "lib/hasFieldSelection"
 import { ResolverContext } from "types/graphql"
 import { PartnerCategoryType } from "./partner_category"
 
@@ -227,13 +227,13 @@ const Partner: GraphQLFieldConfig<void, ResolverContext> = {
     },
   },
   resolve: (_root, { id }, { partnerLoader }, info) => {
-    const blacklistedFields = ["analytics"]
+    const fieldsNotRequireLoader = ["analytics"]
     const isSlug = !/[0-9a-f]{24}/.test(id)
     // vortex can only load analytics data by id so if id passed by client is slug load
     // partner from gravity
     if (
       isSlug ||
-      queriedForFieldsOtherThanBlacklisted(info, blacklistedFields)
+      includesFieldsOtherThanSelectionSet(info, fieldsNotRequireLoader)
     ) {
       return partnerLoader(id)
     }

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -227,7 +227,7 @@ const Partner: GraphQLFieldConfig<void, ResolverContext> = {
     },
   },
   resolve: (_root, { id }, { partnerLoader }, info) => {
-    const fieldsNotRequireLoader = ["analytics"]
+    const fieldsNotRequireLoader = ["internalID"]
     const isSlug = !/[0-9a-f]{24}/.test(id)
     // vortex can only load analytics data by id so if id passed by client is slug load
     // partner from gravity

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -226,14 +226,14 @@ const Partner: GraphQLFieldConfig<void, ResolverContext> = {
       description: "The slug or ID of the Partner",
     },
   },
-  resolve: (_root, { id }, { partnerLoader }, { fieldNodes }) => {
+  resolve: (_root, { id }, { partnerLoader }, info) => {
     const blacklistedFields = ["analytics"]
     const isSlug = !/[0-9a-f]{24}/.test(id)
     // vortex can only load analytics data by id so if id passed by client is slug load
     // partner from gravity
     if (
       isSlug ||
-      queriedForFieldsOtherThanBlacklisted(fieldNodes, blacklistedFields)
+      queriedForFieldsOtherThanBlacklisted(info, blacklistedFields)
     ) {
       return partnerLoader(id)
     }

--- a/src/schema/v2/tag.ts
+++ b/src/schema/v2/tag.ts
@@ -8,7 +8,7 @@ import {
   GraphQLNonNull,
   GraphQLFieldConfig,
 } from "graphql"
-import { queriedForFieldsOtherThanBlacklisted } from "lib/helpers"
+import { includesFieldsOtherThanSelectionSet } from "lib/hasFieldSelection"
 import { ResolverContext } from "types/graphql"
 
 export const TagType = new GraphQLObjectType<any, ResolverContext>({
@@ -47,8 +47,8 @@ const Tag: GraphQLFieldConfig<void, ResolverContext> = {
   resolve: (_root, { id }, { tagLoader }, info) => {
     // If you are just making an artworks call ( e.g. if paginating )
     // do not make a Gravity call for the gene data.
-    const blacklistedFields = ["filteredArtworks", "id", "internalID"]
-    if (queriedForFieldsOtherThanBlacklisted(info, blacklistedFields)) {
+    const fieldsNotRequireLoader = ["filteredArtworks", "id", "internalID"]
+    if (includesFieldsOtherThanSelectionSet(info, fieldsNotRequireLoader)) {
       return tagLoader(id).then(tag => {
         return Object.assign(tag, { _type: "Tag" }, {})
       })

--- a/src/schema/v2/tag.ts
+++ b/src/schema/v2/tag.ts
@@ -44,11 +44,11 @@ const Tag: GraphQLFieldConfig<void, ResolverContext> = {
       type: new GraphQLNonNull(GraphQLString),
     },
   },
-  resolve: (_root, { id }, { tagLoader }, { fieldNodes }) => {
+  resolve: (_root, { id }, { tagLoader }, info) => {
     // If you are just making an artworks call ( e.g. if paginating )
     // do not make a Gravity call for the gene data.
     const blacklistedFields = ["filteredArtworks", "id", "internalID"]
-    if (queriedForFieldsOtherThanBlacklisted(fieldNodes, blacklistedFields)) {
+    if (queriedForFieldsOtherThanBlacklisted(info, blacklistedFields)) {
       return tagLoader(id).then(tag => {
         return Object.assign(tag, { _type: "Tag" }, {})
       })

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -49,7 +49,8 @@ export const runQuery = (
   context: Partial<ResolverContext> = {
     accessToken: undefined,
     userID: undefined,
-  }
+  },
+  variableValues: { [variableName: string]: any } = {}
 ) => {
   const schema = require("schema/v1").default
   return runQueryOrThrow({
@@ -63,6 +64,7 @@ export const runQuery = (
       },
       ...context,
     },
+    variableValues,
   })
 }
 


### PR DESCRIPTION
Fixes [GALL-1627](https://artsyproduct.atlassian.net/browse/GALL-1627)


## Problem:
`parseFieldASTsIntoArray` function assumes the top level `fieldASTs`s are of type `Field` so with `map(flatMap(fieldASTs, "selectionSet.selections"), "name.value")` it gets the name of all of them, but when that assumption is not true (e.g. top level `fieldAST` is an inline fragment) it doesn't go deeper into the tree.

This hasn't been previously a problem but when we stitched `analytics` under `partner` the top level AST is [this](https://github.com/artsy/metaphysics/blob/master/src/lib/stitching/vortex/stitching.ts#L239-L241) inline fragment and `parseFieldASTsIntoArray` returns `[undefined]` and the `queriedForFieldsOtherThanBlacklisted` function fails to recognize that there are no other fields in the query and always queries gravity for partner data even when the `id` is already provided in the query and no other data is needed from gravity.

## Solution
In the [first attempt](https://github.com/artsy/metaphysics/pull/1915) using a library but @alloy pointed out that we already have the exact same helper function available ❤️ 

So now using `includesFieldsOtherThanSelectionSet` instead of `parseFieldASTsIntoArray` in `queriedForFieldsOtherThanBlacklisted`

Finally I updated the specs to test the `partnerLoader` is only being called when the `id` passed to the query is the slug. 

It also required updating a bunch of loader classes to pass `GraphQLResolveInfo` instead of just `FieldNodes` to `queriedForFieldsOtherThanBlacklisted`

Other than tests passing also verified the result of `includesFieldsOtherThanSelectionSet` is exactly the same as the previous implementation when running tests.

## TODO:
- [ ] V2. (Just updating `analytics` to `_id` in `v2/partner.ts` is it still called `_id`?)