### PR TITLE
Fixes an issue where an incorrect use of edition size type prevents users from submitting consignments

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -4710,7 +4710,7 @@ type ConsignmentSubmission {
   edition_number: String
 
   # The whole size of the set of works
-  edition_size: Int
+  edition_size: String
 
   # The height of the work
   height: String
@@ -5006,7 +5006,7 @@ input CreateSubmissionMutationInput {
   edition_number: String
 
   # The whole size of the set of works
-  edition_size: Int
+  edition_size: String
 
   # The height of the work
   height: String
@@ -11631,7 +11631,7 @@ input UpdateSubmissionMutationInput {
   edition_number: String
 
   # The whole size of the set of works
-  edition_size: Int
+  edition_size: String
 
   # The height of the work
   height: String

--- a/src/schema/v1/me/__tests__/consignments/__snapshots__/submissions.test.js.snap
+++ b/src/schema/v1/me/__tests__/consignments/__snapshots__/submissions.test.js.snap
@@ -12,6 +12,7 @@ Object {
             },
             "artist_id": "123",
             "authenticity_certificate": true,
+            "edition_size": "100",
             "id": "106",
             "title": "The best photo yet",
           },

--- a/src/schema/v1/me/__tests__/consignments/create_submission_mutation.test.js
+++ b/src/schema/v1/me/__tests__/consignments/create_submission_mutation.test.js
@@ -22,6 +22,7 @@ describe("UpdateSubmissionMutation", () => {
           input: {
             artist_id: "andy-warhol"
             clientMutationId: "2"
+            edition_size: "100"
             authenticity_certificate: true
             dimensions_metric: CM
           }

--- a/src/schema/v1/me/__tests__/consignments/submissions.test.js
+++ b/src/schema/v1/me/__tests__/consignments/submissions.test.js
@@ -14,6 +14,7 @@ describe("submissions", () => {
                 authenticity_certificate
                 title
                 artist_id
+                edition_size
                 artist {
                   name
                 }
@@ -32,6 +33,7 @@ describe("submissions", () => {
             authenticity_certificate: true,
             artist_id: "123",
             title: "The best photo yet",
+            edition_size: 100, // Edition sizes are stored as Int in Convection
           },
         ]),
       artistLoader: () =>
@@ -39,6 +41,7 @@ describe("submissions", () => {
           name: "Larissa Croft",
           birthday: "April 2011",
           artworks_count: 1,
+          edition_size: "100",
         }),
     }
 

--- a/src/schema/v1/me/__tests__/consignments/update_submission_mutation.test.js
+++ b/src/schema/v1/me/__tests__/consignments/update_submission_mutation.test.js
@@ -22,6 +22,7 @@ describe("UpdateSubmissionMutation", () => {
             id: "108"
             artist_id: "andy-warhol"
             depth: "123"
+            edition_size: "100"
             clientMutationId: "123123"
           }
         ) {

--- a/src/schema/v1/me/consignments/create_submission_mutation.ts
+++ b/src/schema/v1/me/consignments/create_submission_mutation.ts
@@ -10,7 +10,6 @@ import {
   GraphQLNonNull,
   GraphQLString,
   GraphQLBoolean,
-  GraphQLInt,
   GraphQLID,
 } from "graphql"
 
@@ -48,7 +47,7 @@ export const config: MutationConfig<any, any, ResolverContext> = {
     },
     edition_size: {
       description: "The whole size of the set of works",
-      type: GraphQLInt,
+      type: GraphQLString,
     },
     height: {
       description: "The height of the work",

--- a/src/schema/v1/me/consignments/submission.ts
+++ b/src/schema/v1/me/consignments/submission.ts
@@ -4,7 +4,6 @@ import {
   GraphQLNonNull,
   GraphQLBoolean,
   GraphQLEnumType,
-  GraphQLInt,
   GraphQLID,
 } from "graphql"
 import { NullableIDField } from "schema/v1/object_identification"
@@ -127,7 +126,7 @@ export const SubmissionType = new GraphQLObjectType<any, ResolverContext>({
     },
     edition_size: {
       description: "The whole size of the set of works",
-      type: GraphQLInt,
+      type: GraphQLString,
     },
     height: {
       description: "The height of the work",

--- a/src/schema/v1/me/consignments/update_submission_mutation.ts
+++ b/src/schema/v1/me/consignments/update_submission_mutation.ts
@@ -10,7 +10,6 @@ import {
   GraphQLNonNull,
   GraphQLString,
   GraphQLBoolean,
-  GraphQLInt,
   GraphQLID,
 } from "graphql"
 
@@ -52,7 +51,7 @@ export const config: MutationConfig<any, any, ResolverContext> = {
     },
     edition_size: {
       description: "The whole size of the set of works",
-      type: GraphQLInt,
+      type: GraphQLString,
     },
     height: {
       description: "The height of the work",


### PR DESCRIPTION
fixes [slack #incident-55](https://artsy.slack.com/archives/CMLQ0288K/p1567453723004300).

Apparently [the type of `edition_size` has been set to `String` in Emission](https://github.com/artsy/emission/blob/07d6b28ca5903e821faeed41a119d1aa849dca9d/src/lib/Components/Consignments/index.tsx#L43) since the beginning but the actual type of it is `Int`, so Metaphysics has been rejecting any submission mutation with a `edition_size` from the iOS app. This PR updates the type to `String` to make it consistent with Emission so we can fix it without cutting a new Eigen release. 

I believe this started being reported to Sentry since we deployed #1910. This deploy had this line: https://github.com/artsy/metaphysics/pull/1910/files#diff-f41e9d04a45c83f3b6f6e630f10117feR202

```
formatError: graphqlErrorHandler(enableSentry, {
```

Which reports more error that hadn't been reported before, and this might the tip of the iceberg.
