### PR TITLE
use the correct size property

### DIFF
--- a/src/schema/v1/filter_artworks.ts
+++ b/src/schema/v1/filter_artworks.ts
@@ -371,7 +371,7 @@ const filterArtworksTypeFactory = (
     if (Object.keys(connectionArgs).length) {
       relayOptions = convertConnectionArgsToGravityArgs(connectionArgs)
     } else {
-      relayOptions.size = relayOptions.size || 0
+      relayOptions.size = gravityOptions.size || 0
     }
 
     if (!!gravityOptions.page) relayOptions.page = gravityOptions.page


### PR DESCRIPTION
Related to https://github.com/artsy/metaphysics/pull/1905. We were attempting to fix the size property which was getting overwritten to zero. We checked for `relayOptions.size` when it should be `gravityOptions.size`.

For more context, the query below returns zero artwork hits because the gravityOptions contains the size param and not relayOptions.

```graphql
{
  marketingCollection(slug: "street-art-now") {
    title
    id   
    linkedCollections {
      name
      groupType
      members {
        slug
        headerImage
        thumbnail
        title
        price_guidance
        artworks(size: 3) {
          hits {
            artist {
              name
            }
            title
            image {
              url(version: "small")
            }
          }
        }
      }
    }
  }
}
```