### PR TITLE
Fixes extensions object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -221,7 +221,7 @@ function startApp(appSchema, path: string) {
               ? fetchLoggerRequestDone(requestID)
               : {}
 
-            return { ...principalFieldExtensions, requestLoggerExtensions }
+            return { ...principalFieldExtensions, ...requestLoggerExtensions }
           },
         }
       })


### PR DESCRIPTION
Pairing with @ds300  on the graphql issue we're seeing now in Emission -- Looks like `requestLoggerExtensions` needs to be spread as `res.json.extensions` is missing the `requests` object.