### PR TITLE
PURCHASE-1475: Adds priceIncludesTaxDisplay field to artwork schema

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1387,6 +1387,7 @@ type Artwork implements Node & Searchable & Sellable {
   listPrice: ListPrice
   price_currency: String
   priceIncludesTax: Boolean
+  priceIncludesTaxDisplay: String
 
   # Is this work available for shipping only within the Contenental US?
   shipsToContinentalUSOnly: Boolean
@@ -2417,6 +2418,7 @@ type ArtworkItem implements Node & Searchable & Sellable {
   listPrice: ListPrice
   price_currency: String
   priceIncludesTax: Boolean
+  priceIncludesTaxDisplay: String
 
   # Is this work available for shipping only within the Contenental US?
   shipsToContinentalUSOnly: Boolean

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -956,6 +956,7 @@ type Artwork implements Node & Searchable & Sellable {
   listPrice: ListPrice
   priceCurrency: String
   priceIncludesTax: Boolean
+  priceIncludesTaxDisplay: String
 
   # Is this work available for shipping only within the Contenental US?
   shipsToContinentalUSOnly: Boolean

--- a/src/schema/v1/artwork/__tests__/artwork.test.js
+++ b/src/schema/v1/artwork/__tests__/artwork.test.js
@@ -379,6 +379,43 @@ describe("Artwork type", () => {
     })
   })
 
+  describe("#priceIncludesTaxDisplay", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          id
+          priceIncludesTaxDisplay
+        }
+      }
+    `
+
+    it("returns a string if price_includes_tax is true", () => {
+      artwork.price_includes_tax = true
+
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            id: "richard-prince-untitled-portrait",
+            priceIncludesTaxDisplay: "VAT included in price",
+          },
+        })
+      })
+    })
+
+    it("returns null if price_includes_tax is false", () => {
+      artwork.price_includes_tax = false
+
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            id: "richard-prince-untitled-portrait",
+            priceIncludesTaxDisplay: null,
+          },
+        })
+      })
+    })
+  })
+
   describe("#images", () => {
     const query = `
       {

--- a/src/schema/v1/artwork/index.ts
+++ b/src/schema/v1/artwork/index.ts
@@ -581,6 +581,12 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLBoolean,
         resolve: ({ price_includes_tax }) => price_includes_tax,
       },
+      priceIncludesTaxDisplay: {
+        type: GraphQLString,
+        resolve: ({ price_includes_tax }) => {
+          return price_includes_tax ? "VAT included in price" : null
+        },
+      },
       shipsToContinentalUSOnly: {
         type: GraphQLBoolean,
         description:

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -315,6 +315,40 @@ describe("Artwork type", () => {
     })
   })
 
+  describe("#priceIncludesTaxDisplay", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          priceIncludesTaxDisplay
+        }
+      }
+    `
+
+    it("returns a string if price_includes_tax is true", () => {
+      artwork.price_includes_tax = true
+
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            priceIncludesTaxDisplay: "VAT included in price",
+          },
+        })
+      })
+    })
+
+    it("returns null if price_includes_tax is false", () => {
+      artwork.price_includes_tax = false
+
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            priceIncludesTaxDisplay: null,
+          },
+        })
+      })
+    })
+  })
+
   describe("#images", () => {
     const query = `
       {
@@ -472,7 +506,7 @@ describe("Artwork type", () => {
       {
         artwork(id: "richard-prince-untitled-portrait") {
           editionSets(sort: PRICE_ASC) {
-            internalID 
+            internalID
           }
         }
       }

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -480,6 +480,12 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLBoolean,
         resolve: ({ price_includes_tax }) => price_includes_tax,
       },
+      priceIncludesTaxDisplay: {
+        type: GraphQLString,
+        resolve: ({ price_includes_tax }) => {
+          return price_includes_tax ? "VAT included in price" : null
+        },
+      },
       shipsToContinentalUSOnly: {
         type: GraphQLBoolean,
         description:


### PR DESCRIPTION
Putting this field here means we'll be able to remove this logic from Emission/Reaction (and it should be easier to iterate on).

![image](https://user-images.githubusercontent.com/2081340/64567868-423d2700-d327-11e9-9cfa-8bc409c4514d.png)