### PR TITLE
PURCHASE-1471, PURCHASE-1468, 1476: Updates to inquiry fees description, shippingInfo returns non-country specific strings, new fields added related to shipping

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1400,6 +1400,9 @@ type Artwork implements Node & Searchable & Sellable {
 
   # Minimal location information describing from where artwork will be shipped.
   shippingOrigin: String
+
+  # The country an artwork will be shipped from.
+  shippingCountry: String
   provenance(format: Format): String
   publisher(format: Format): String
   related(size: Int): [Artwork]
@@ -2436,6 +2439,9 @@ type ArtworkItem implements Node & Searchable & Sellable {
 
   # Minimal location information describing from where artwork will be shipped.
   shippingOrigin: String
+
+  # The country an artwork will be shipped from.
+  shippingCountry: String
   provenance(format: Format): String
   publisher(format: Format): String
   related(size: Int): [Artwork]

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1388,6 +1388,12 @@ type Artwork implements Node & Searchable & Sellable {
 
   # Is this work available for shipping only within the Contenental US?
   shipsToContinentalUSOnly: Boolean
+    @deprecated(
+      reason: "Prefer to use `onlyShipsDomestically`. [Will be removed in v2]"
+    )
+
+  # Is this work only available for shipping domestically?
+  onlyShipsDomestically: Boolean
 
   # The string that describes domestic and international shipping.
   shippingInfo: String
@@ -2418,6 +2424,12 @@ type ArtworkItem implements Node & Searchable & Sellable {
 
   # Is this work available for shipping only within the Contenental US?
   shipsToContinentalUSOnly: Boolean
+    @deprecated(
+      reason: "Prefer to use `onlyShipsDomestically`. [Will be removed in v2]"
+    )
+
+  # Is this work only available for shipping domestically?
+  onlyShipsDomestically: Boolean
 
   # The string that describes domestic and international shipping.
   shippingInfo: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -969,6 +969,9 @@ type Artwork implements Node & Searchable & Sellable {
 
   # Minimal location information describing from where artwork will be shipped.
   shippingOrigin: String
+
+  # The country an artwork will be shipped from.
+  shippingCountry: String
   provenance(format: Format): String
   publisher(format: Format): String
   related(size: Int): [Artwork]

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -957,6 +957,12 @@ type Artwork implements Node & Searchable & Sellable {
 
   # Is this work available for shipping only within the Contenental US?
   shipsToContinentalUSOnly: Boolean
+    @deprecated(
+      reason: "Prefer to use `onlyShipsDomestically`. [Will be removed in v2]"
+    )
+
+  # Is this work only available for shipping domestically?
+  onlyShipsDomestically: Boolean
 
   # The string that describes domestic and international shipping.
   shippingInfo: String

--- a/src/schema/v1/artwork/__tests__/artwork.test.js
+++ b/src/schema/v1/artwork/__tests__/artwork.test.js
@@ -1469,7 +1469,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            shippingInfo: "Shipping, tax, and service quoted by seller",
+            shippingInfo: "Shipping, tax, and additional fees quoted by seller",
           },
         })
       })

--- a/src/schema/v1/artwork/__tests__/artwork.test.js
+++ b/src/schema/v1/artwork/__tests__/artwork.test.js
@@ -1481,7 +1481,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            shippingInfo: "Free shipping within continental US only",
+            shippingInfo: "Free domestic shipping",
           },
         })
       })
@@ -1505,7 +1505,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            shippingInfo: "Shipping: $10 continental US only",
+            shippingInfo: "Shipping: $10 domestic only",
           },
         })
       })
@@ -1517,7 +1517,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            shippingInfo: "Shipping: $10 continental US, free rest of world",
+            shippingInfo: "Shipping: $10 domestic, free rest of world",
           },
         })
       })
@@ -1529,7 +1529,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            shippingInfo: "Shipping: Free continental US, $100 rest of world",
+            shippingInfo: "Shipping: Free domestic, $100 rest of world",
           },
         })
       })
@@ -1541,7 +1541,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            shippingInfo: "Shipping: Free continental US, $100 rest of world",
+            shippingInfo: "Shipping: Free domestic, $100 rest of world",
           },
         })
       })
@@ -1553,7 +1553,20 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            shippingInfo: "Shipping: $10 continental US, $20 rest of world",
+            shippingInfo: "Shipping: $10 domestic, $20 rest of world",
+          },
+        })
+      })
+    })
+
+    it("shows shipping costs in the same currency as list price", () => {
+      artwork.domestic_shipping_fee_cents = 1000
+      artwork.international_shipping_fee_cents = 2000
+      artwork.price_currency = "GBP"
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            shippingInfo: "Shipping: £10 domestic, £20 rest of world",
           },
         })
       })
@@ -1611,6 +1624,63 @@ describe("Artwork type", () => {
         expect(data).toEqual({
           artwork: {
             shipsToContinentalUSOnly: false,
+          },
+        })
+      })
+    })
+  })
+
+  describe("#onlyShipsDomestically", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          onlyShipsDomestically
+        }
+      }
+    `
+    it("is true when domestic_shipping_fee_cents is present and international_shipping_fee_cents is null", () => {
+      artwork.domestic_shipping_fee_cents = 1000
+      artwork.international_shipping_fee_cents = null
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            onlyShipsDomestically: true,
+          },
+        })
+      })
+    })
+
+    it("is false when work ships free internationally", () => {
+      artwork.domestic_shipping_fee_cents = 1000
+      artwork.international_shipping_fee_cents = 0
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            onlyShipsDomestically: false,
+          },
+        })
+      })
+    })
+
+    it("is false when work ships free worldwide", () => {
+      artwork.domestic_shipping_fee_cents = 0
+      artwork.international_shipping_fee_cents = 0
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            onlyShipsDomestically: false,
+          },
+        })
+      })
+    })
+
+    it("is false when work ships worldwide", () => {
+      artwork.domestic_shipping_fee_cents = 1000
+      artwork.international_shipping_fee_cents = 1000
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            onlyShipsDomestically: false,
           },
         })
       })

--- a/src/schema/v1/artwork/__tests__/artwork.test.js
+++ b/src/schema/v1/artwork/__tests__/artwork.test.js
@@ -1481,7 +1481,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            shippingInfo: "Free domestic shipping",
+            shippingInfo: "Free domestic shipping only",
           },
         })
       })

--- a/src/schema/v1/artwork/__tests__/artwork.test.js
+++ b/src/schema/v1/artwork/__tests__/artwork.test.js
@@ -1719,6 +1719,38 @@ describe("Artwork type", () => {
     })
   })
 
+  describe("#shippingCountry", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          shippingCountry
+        }
+      }
+    `
+
+    it("is null when shipping_origin is null", () => {
+      artwork.shipping_origin = null
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            shippingCountry: null,
+          },
+        })
+      })
+    })
+
+    it("is set to concatinated values from shipping_origin when shipping origin is present", () => {
+      artwork.shipping_origin = ["Kharkov", "Ukraine"]
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            shippingCountry: "Ukraine",
+          },
+        })
+      })
+    })
+  })
+
   describe("#framed", () => {
     const query = `
       {

--- a/src/schema/v1/artwork/index.ts
+++ b/src/schema/v1/artwork/index.ts
@@ -671,6 +671,16 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           return artwork.shipping_origin && artwork.shipping_origin.join(", ")
         },
       },
+      shippingCountry: {
+        type: GraphQLString,
+        description: "The country an artwork will be shipped from.",
+        resolve: artwork => {
+          return (
+            artwork.shipping_origin &&
+            artwork.shipping_origin[artwork.shipping_origin.length - 1]
+          )
+        },
+      },
       provenance: markdown(({ provenance }) =>
         provenance.replace(/^provenance:\s+/i, "")
       ),

--- a/src/schema/v1/artwork/index.ts
+++ b/src/schema/v1/artwork/index.ts
@@ -41,7 +41,7 @@ import AttributionClass from "schema/v1/artwork/attributionClass"
 // Mapping of attribution_class ids to AttributionClass values
 import attributionClasses from "lib/attributionClasses"
 import { LotStandingType } from "../me/lot_standing"
-import { moneyDisplay, symbolFromCurrencyCode } from "schema/v1/fields/money"
+import { symbolFromCurrencyCode, amount } from "schema/v1/fields/money"
 import { capitalizeFirstCharacter } from "lib/helpers"
 import artworkPageviews from "data/weeklyArtworkPageviews.json"
 import { ResolverContext } from "types/graphql"
@@ -627,18 +627,21 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           )
             return "Free shipping worldwide"
 
-          const moneySymbol = symbolFromCurrencyCode(artwork.price_currency)
-          var domesticShipping = moneyDisplay(
-            artwork.domestic_shipping_fee_cents || null,
-            moneySymbol,
-            { precision: 0 }
-          )
+          var domesticShipping = amount(
+            ({ domestic_shipping_fee_cents }) =>
+              domestic_shipping_fee_cents || null
+          ).resolve(artwork, {
+            precision: 0,
+            symbol: symbolFromCurrencyCode(artwork.price_currency),
+          })
 
-          var internationalShipping = moneyDisplay(
-            artwork.international_shipping_fee_cents || null,
-            moneySymbol,
-            { precision: 0 }
-          )
+          var internationalShipping = amount(
+            ({ international_shipping_fee_cents }) =>
+              international_shipping_fee_cents || null
+          ).resolve(artwork, {
+            precision: 0,
+            symbol: symbolFromCurrencyCode(artwork.price_currency),
+          })
 
           if (
             domesticShipping &&

--- a/src/schema/v1/artwork/index.ts
+++ b/src/schema/v1/artwork/index.ts
@@ -620,7 +620,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             artwork.domestic_shipping_fee_cents === 0 &&
             artwork.international_shipping_fee_cents == null
           )
-            return "Free domestic shipping"
+            return "Free domestic shipping only"
           if (
             artwork.domestic_shipping_fee_cents === 0 &&
             artwork.international_shipping_fee_cents === 0

--- a/src/schema/v1/artwork/index.ts
+++ b/src/schema/v1/artwork/index.ts
@@ -615,7 +615,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             artwork.domestic_shipping_fee_cents == null &&
             artwork.international_shipping_fee_cents == null
           )
-            return "Shipping, tax, and service quoted by seller"
+            return "Shipping, tax, and additional fees quoted by seller"
           if (
             artwork.domestic_shipping_fee_cents === 0 &&
             artwork.international_shipping_fee_cents == null

--- a/src/schema/v1/fields/money.ts
+++ b/src/schema/v1/fields/money.ts
@@ -55,7 +55,18 @@ export const amount = centsResolver => ({
     const cents = centsResolver(obj)
     const symbol =
       options.symbol || obj.symbol || symbolFromCurrencyCode(obj.currencyCode)
-    return moneyDisplay(cents, symbol, options)
+
+    if (typeof cents !== "number") {
+      return null
+    }
+
+    // Some objects return a currencyCode instead of a symbol.
+    return formatMoney(
+      cents / 100,
+      assign({}, options, {
+        symbol,
+      })
+    )
   },
 })
 
@@ -64,20 +75,6 @@ export const symbolFromCurrencyCode = currencyCode => {
     ? currencyCodes[currencyCode.toLowerCase()] &&
         currencyCodes[currencyCode.toLowerCase()].symbol
     : null
-}
-
-export const moneyDisplay = (cents, symbol, options) => {
-  if (typeof cents !== "number") {
-    return null
-  }
-
-  // Some objects return a currencyCode instead of a symbol.
-  return formatMoney(
-    cents / 100,
-    assign({}, options, {
-      symbol,
-    })
-  )
 }
 
 const money = ({ name, resolve }) => ({

--- a/src/schema/v1/fields/money.ts
+++ b/src/schema/v1/fields/money.ts
@@ -53,26 +53,32 @@ export const amount = centsResolver => ({
   },
   resolve: (obj, options) => {
     const cents = centsResolver(obj)
-    if (typeof cents !== "number") {
-      return null
-    }
-
-    // Some objects return a currencyCode instead of a symbol.
-    const symbolFromCurrencyCode = obj.currencyCode
-      ? currencyCodes[obj.currencyCode.toLowerCase()] &&
-        currencyCodes[obj.currencyCode.toLowerCase()].symbol
-      : null
-
-    const symbol = options.symbol || obj.symbol || symbolFromCurrencyCode
-
-    return formatMoney(
-      cents / 100,
-      assign({}, options, {
-        symbol,
-      })
-    )
+    const symbol =
+      options.symbol || obj.symbol || symbolFromCurrencyCode(obj.currencyCode)
+    return moneyDisplay(cents, symbol, options)
   },
 })
+
+export const symbolFromCurrencyCode = currencyCode => {
+  return currencyCode
+    ? currencyCodes[currencyCode.toLowerCase()] &&
+        currencyCodes[currencyCode.toLowerCase()].symbol
+    : null
+}
+
+export const moneyDisplay = (cents, symbol, options) => {
+  if (typeof cents !== "number") {
+    return null
+  }
+
+  // Some objects return a currencyCode instead of a symbol.
+  return formatMoney(
+    cents / 100,
+    assign({}, options, {
+      symbol,
+    })
+  )
+}
 
 const money = ({ name, resolve }) => ({
   resolve: x => x,

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -1405,7 +1405,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            shippingInfo: "Shipping, tax, and service quoted by seller",
+            shippingInfo: "Shipping, tax, and additional fees quoted by seller",
           },
         })
       })

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -1655,6 +1655,38 @@ describe("Artwork type", () => {
     })
   })
 
+  describe("#shippingCountry", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          shippingCountry
+        }
+      }
+    `
+
+    it("is null when shipping_origin is null", () => {
+      artwork.shipping_origin = null
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            shippingCountry: null,
+          },
+        })
+      })
+    })
+
+    it("is set to concatenated values from shipping_origin when shipping origin is present", () => {
+      artwork.shipping_origin = ["New York", "NY", "US"]
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            shippingCountry: "US",
+          },
+        })
+      })
+    })
+  })
+
   describe("#framed", () => {
     const query = `
       {

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -1417,7 +1417,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            shippingInfo: "Free shipping within continental US only",
+            shippingInfo: "Free domestic shipping",
           },
         })
       })
@@ -1441,7 +1441,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            shippingInfo: "Shipping: $10 continental US only",
+            shippingInfo: "Shipping: $10 domestic only",
           },
         })
       })
@@ -1453,7 +1453,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            shippingInfo: "Shipping: $10 continental US, free rest of world",
+            shippingInfo: "Shipping: $10 domestic, free rest of world",
           },
         })
       })
@@ -1465,7 +1465,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            shippingInfo: "Shipping: Free continental US, $100 rest of world",
+            shippingInfo: "Shipping: Free domestic, $100 rest of world",
           },
         })
       })
@@ -1477,7 +1477,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            shippingInfo: "Shipping: Free continental US, $100 rest of world",
+            shippingInfo: "Shipping: Free domestic, $100 rest of world",
           },
         })
       })
@@ -1489,7 +1489,20 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            shippingInfo: "Shipping: $10 continental US, $20 rest of world",
+            shippingInfo: "Shipping: $10 domestic, $20 rest of world",
+          },
+        })
+      })
+    })
+
+    it("shows shipping costs in the same currency as list price", () => {
+      artwork.domestic_shipping_fee_cents = 1000
+      artwork.international_shipping_fee_cents = 2000
+      artwork.price_currency = "GBP"
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            shippingInfo: "Shipping: £10 domestic, £20 rest of world",
           },
         })
       })
@@ -1547,6 +1560,63 @@ describe("Artwork type", () => {
         expect(data).toEqual({
           artwork: {
             shipsToContinentalUSOnly: false,
+          },
+        })
+      })
+    })
+  })
+
+  describe("#onlyShipsDomestically", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          onlyShipsDomestically
+        }
+      }
+    `
+    it("is true when domestic_shipping_fee_cents is present and international_shipping_fee_cents is null", () => {
+      artwork.domestic_shipping_fee_cents = 1000
+      artwork.international_shipping_fee_cents = null
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            onlyShipsDomestically: true,
+          },
+        })
+      })
+    })
+
+    it("is false when work ships free internationally", () => {
+      artwork.domestic_shipping_fee_cents = 1000
+      artwork.international_shipping_fee_cents = 0
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            onlyShipsDomestically: false,
+          },
+        })
+      })
+    })
+
+    it("is false when work ships free worldwide", () => {
+      artwork.domestic_shipping_fee_cents = 0
+      artwork.international_shipping_fee_cents = 0
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            onlyShipsDomestically: false,
+          },
+        })
+      })
+    })
+
+    it("is false when work ships worldwide", () => {
+      artwork.domestic_shipping_fee_cents = 1000
+      artwork.international_shipping_fee_cents = 1000
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            onlyShipsDomestically: false,
           },
         })
       })

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -1417,7 +1417,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            shippingInfo: "Free domestic shipping",
+            shippingInfo: "Free domestic shipping only",
           },
         })
       })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -571,6 +571,16 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           return artwork.shipping_origin && artwork.shipping_origin.join(", ")
         },
       },
+      shippingCountry: {
+        type: GraphQLString,
+        description: "The country an artwork will be shipped from.",
+        resolve: artwork => {
+          return (
+            artwork.shipping_origin &&
+            artwork.shipping_origin[artwork.shipping_origin.length - 1]
+          )
+        },
+      },
       provenance: markdown(({ provenance }) =>
         provenance.replace(/^provenance:\s+/i, "")
       ),

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -22,6 +22,7 @@ import { Sellable } from "schema/v2/sellable"
 import { Searchable } from "schema/v2/searchable"
 import ArtworkLayer from "./layer"
 import ArtworkLayers, { artworkLayers } from "./layers"
+import { deprecate } from "lib/deprecation"
 import {
   NodeInterface,
   SlugAndInternalIDFields,
@@ -41,7 +42,7 @@ import AttributionClass from "schema/v2/artwork/attributionClass"
 // Mapping of attribution_class ids to AttributionClass values
 import attributionClasses from "lib/attributionClasses"
 import { LotStandingType } from "../me/lot_standing"
-import { amount } from "schema/v2/fields/money"
+import { moneyDisplay, symbolFromCurrencyCode } from "schema/v2/fields/money"
 import { capitalizeFirstCharacter } from "lib/helpers"
 import { ResolverContext } from "types/graphql"
 import { listPrice } from "schema/v2/fields/listPrice"
@@ -484,6 +485,20 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLBoolean,
         description:
           "Is this work available for shipping only within the Contenental US?",
+        deprecationReason: deprecate({
+          inVersion: 2,
+          preferUsageOf: "onlyShipsDomestically",
+        }),
+        resolve: artwork => {
+          return Boolean(
+            artwork.domestic_shipping_fee_cents &&
+              artwork.international_shipping_fee_cents == null
+          )
+        },
+      },
+      onlyShipsDomestically: {
+        type: GraphQLBoolean,
+        description: "Is this work only available for shipping domestically?",
         resolve: artwork => {
           return Boolean(
             artwork.domestic_shipping_fee_cents &&
@@ -505,26 +520,31 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             artwork.domestic_shipping_fee_cents === 0 &&
             artwork.international_shipping_fee_cents == null
           )
-            return "Free shipping within continental US only"
+            return "Free domestic shipping"
           if (
             artwork.domestic_shipping_fee_cents === 0 &&
             artwork.international_shipping_fee_cents === 0
           )
             return "Free shipping worldwide"
-          var domesticShipping = amount(
-            ({ domestic_shipping_fee_cents }) =>
-              domestic_shipping_fee_cents || null
-          ).resolve(artwork, { precision: 0 })
-          var internationalShipping = amount(
-            ({ international_shipping_fee_cents }) =>
-              international_shipping_fee_cents || null
-          ).resolve(artwork, { precision: 0 })
+
+          const moneySymbol = symbolFromCurrencyCode(artwork.price_currency)
+          var domesticShipping = moneyDisplay(
+            artwork.domestic_shipping_fee_cents || null,
+            moneySymbol,
+            { precision: 0 }
+          )
+
+          var internationalShipping = moneyDisplay(
+            artwork.international_shipping_fee_cents || null,
+            moneySymbol,
+            { precision: 0 }
+          )
 
           if (
             domesticShipping &&
             artwork.international_shipping_fee_cents == null
           )
-            return "Shipping: " + domesticShipping + " continental US only"
+            return "Shipping: " + domesticShipping + " domestic only"
 
           if (artwork.domestic_shipping_fee_cents === 0)
             domesticShipping = "Free"
@@ -534,7 +554,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           return (
             "Shipping: " +
             domesticShipping +
-            " continental US, " +
+            " domestic, " +
             internationalShipping +
             " rest of world"
           )

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -520,7 +520,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             artwork.domestic_shipping_fee_cents === 0 &&
             artwork.international_shipping_fee_cents == null
           )
-            return "Free domestic shipping"
+            return "Free domestic shipping only"
           if (
             artwork.domestic_shipping_fee_cents === 0 &&
             artwork.international_shipping_fee_cents === 0

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -42,7 +42,7 @@ import AttributionClass from "schema/v2/artwork/attributionClass"
 // Mapping of attribution_class ids to AttributionClass values
 import attributionClasses from "lib/attributionClasses"
 import { LotStandingType } from "../me/lot_standing"
-import { moneyDisplay, symbolFromCurrencyCode } from "schema/v2/fields/money"
+import { amount, symbolFromCurrencyCode } from "schema/v2/fields/money"
 import { capitalizeFirstCharacter } from "lib/helpers"
 import { ResolverContext } from "types/graphql"
 import { listPrice } from "schema/v2/fields/listPrice"
@@ -527,18 +527,21 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           )
             return "Free shipping worldwide"
 
-          const moneySymbol = symbolFromCurrencyCode(artwork.price_currency)
-          var domesticShipping = moneyDisplay(
-            artwork.domestic_shipping_fee_cents || null,
-            moneySymbol,
-            { precision: 0 }
-          )
+          var domesticShipping = amount(
+            ({ domestic_shipping_fee_cents }) =>
+              domestic_shipping_fee_cents || null
+          ).resolve(artwork, {
+            precision: 0,
+            symbol: symbolFromCurrencyCode(artwork.price_currency),
+          })
 
-          var internationalShipping = moneyDisplay(
-            artwork.international_shipping_fee_cents || null,
-            moneySymbol,
-            { precision: 0 }
-          )
+          var internationalShipping = amount(
+            ({ international_shipping_fee_cents }) =>
+              international_shipping_fee_cents || null
+          ).resolve(artwork, {
+            precision: 0,
+            symbol: symbolFromCurrencyCode(artwork.price_currency),
+          })
 
           if (
             domesticShipping &&

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -515,7 +515,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             artwork.domestic_shipping_fee_cents == null &&
             artwork.international_shipping_fee_cents == null
           )
-            return "Shipping, tax, and service quoted by seller"
+            return "Shipping, tax, and additional fees quoted by seller"
           if (
             artwork.domestic_shipping_fee_cents === 0 &&
             artwork.international_shipping_fee_cents == null

--- a/src/schema/v2/fields/money.ts
+++ b/src/schema/v2/fields/money.ts
@@ -55,7 +55,17 @@ export const amount = centsResolver => ({
     const cents = centsResolver(obj)
     const symbol =
       options.symbol || obj.symbol || symbolFromCurrencyCode(obj.currencyCode)
-    return moneyDisplay(cents, symbol, options)
+    if (typeof cents !== "number") {
+      return null
+    }
+
+    // Some objects return a currencyCode instead of a symbol.
+    return formatMoney(
+      cents / 100,
+      assign({}, options, {
+        symbol,
+      })
+    )
   },
 })
 
@@ -64,20 +74,6 @@ export const symbolFromCurrencyCode = currencyCode => {
     ? currencyCodes[currencyCode.toLowerCase()] &&
         currencyCodes[currencyCode.toLowerCase()].symbol
     : null
-}
-
-export const moneyDisplay = (cents, symbol, options) => {
-  if (typeof cents !== "number") {
-    return null
-  }
-
-  // Some objects return a currencyCode instead of a symbol.
-  return formatMoney(
-    cents / 100,
-    assign({}, options, {
-      symbol,
-    })
-  )
 }
 
 const money = ({ name, resolve }) => ({

--- a/src/schema/v2/fields/money.ts
+++ b/src/schema/v2/fields/money.ts
@@ -53,26 +53,32 @@ export const amount = centsResolver => ({
   },
   resolve: (obj, options) => {
     const cents = centsResolver(obj)
-    if (typeof cents !== "number") {
-      return null
-    }
-
-    // Some objects return a currencyCode instead of a symbol.
-    const symbolFromCurrencyCode = obj.currencyCode
-      ? currencyCodes[obj.currencyCode.toLowerCase()] &&
-        currencyCodes[obj.currencyCode.toLowerCase()].symbol
-      : null
-
-    const symbol = options.symbol || obj.symbol || symbolFromCurrencyCode
-
-    return formatMoney(
-      cents / 100,
-      assign({}, options, {
-        symbol,
-      })
-    )
+    const symbol =
+      options.symbol || obj.symbol || symbolFromCurrencyCode(obj.currencyCode)
+    return moneyDisplay(cents, symbol, options)
   },
 })
+
+export const symbolFromCurrencyCode = currencyCode => {
+  return currencyCode
+    ? currencyCodes[currencyCode.toLowerCase()] &&
+        currencyCodes[currencyCode.toLowerCase()].symbol
+    : null
+}
+
+export const moneyDisplay = (cents, symbol, options) => {
+  if (typeof cents !== "number") {
+    return null
+  }
+
+  // Some objects return a currencyCode instead of a symbol.
+  return formatMoney(
+    cents / 100,
+    assign({}, options, {
+      symbol,
+    })
+  )
+}
 
 const money = ({ name, resolve }) => ({
   resolve: x => x,


### PR DESCRIPTION
### [PURCHASE-1471] 
> User should see shipping price for GBP BNMO artwork listed in GBP and domestic shipping as within the UK

#### User story: 
As a user on an artwork page with BN or MO where the price listed is in GBP
If there is a shipping fee 
Then I should see the price of shipping in GBP and the domestic price should refer to shipping within the UK

I also added a new field, `onlyShipsDomestically`, and deprecated the field `shipsToContinentalUSOnly` because the logic behind it would return true for artworks shipping from the UK but only within the UK, so the name no longer made sense. 

#### Screenshot of previous state:
https://cl.ly/1c0f8f80ac3d

Current state (I didn't want to link to reaction/force just for a screenshot, but here is proof the field is returning the correct messaging with appropriate currency symbols):
<img width="416" alt="Screen Shot 2019-09-09 at 5 45 19 PM" src="https://user-images.githubusercontent.com/5643895/64569252-dd83cb80-d32a-11e9-886d-e120536a621f.png">

### [PURCHASE-1468] 
> Inquiry work has "Shipping, tax, and service quoted by the seller" copy — inconsistent with desktop copy

Changed to "Shipping, tax, and _aditional_ _fees_ quoted by the seller"

### [PURCHASE-1476] 
> If work can only ship domestically, the shipping form only displays the artwork's origin country

As a user, If I'm buying a work that can only be shipped domestically, When I enter my shipping information, the shipping form has the artwork's origin country selected, and I cannot select any other country.

[PURCHASE-1471]: https://artsyproduct.atlassian.net/browse/PURCHASE-1471

[PURCHASE-1468]: https://artsyproduct.atlassian.net/browse/PURCHASE-1468