### PR TITLE
@mzikherman => [Patch] Only attempt variable coercion on string fields

### DIFF
--- a/patches/express-graphql+0.9.0.patch
+++ b/patches/express-graphql+0.9.0.patch
@@ -13,7 +13,7 @@ patch-package
 +  ) {
 +    parsedValue = Number(value)
 +  } else if (
-+    value !== null &&
++    value !== null && typeof value === "string" &&
 +    (value.toLowerCase() === "true" || value.toLowerCase() === "false")
 +  ) {
 +    parsedValue = value.toLowerCase() === "true"


### PR DESCRIPTION
I forgot to hit 'Save' when I added this check and ran `patch-package`. This was failing on staging for non-string params, (but working locally, where I modified the `node_modules/` file directly), before I realized 😓 

#mergeongreen