### PR TITLE
@anandaroop => [Patch] Dont coerce variables when there are none

### DIFF
--- a/patches/express-graphql+0.9.0.patch
+++ b/patches/express-graphql+0.9.0.patch
@@ -30,7 +30,7 @@ patch-package
        query = params.query;
        variables = params.variables;
 +      const parsedVariables = {}
-+      Object.entries(variables).forEach(([name, value]) => {
++      Object.entries(variables || {}).forEach(([name, value]) => {
 +        parsedVariables[`${name}`] = parseValue(value)
 +      })
        operationName = params.operationName;


### PR DESCRIPTION
Our patch was breaking when there were no variables (`undefined`), which is what you'd get when hitting GraphiQL directly.

Side note- as this sits on staging for a bit I will add some specs for the patch. I added that in https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=64&projectKey=PLATFORM&modal=detail&selectedIssue=PLATFORM-1766