### PR TITLE
@joeyAghion => [Patch] Add specs around variable coercion patch

### DIFF
--- a/src/integration/__tests__/integration.test.ts
+++ b/src/integration/__tests__/integration.test.ts
@@ -2,43 +2,113 @@ jest.mock("lib/apis/fetch", () => jest.fn())
 import fetch from "lib/apis/fetch"
 const mockFetch = fetch as jest.Mock
 
-const isOnCI = process.env.CI
+// These tests ensure that *any* query works against our express app.
+const request = require("supertest")
+const app = require("../../index").default
+const gql = require("lib/gql").default
 
-if (!isOnCI) {
-  // These tests launch new processes, and would change on almost every MP edit
-  // You don't want them in watch mode.
-  it("Skips integration tests in watch mode", () => {})
-} else {
-  // These tests ensure that *any* query works against our express app.
-  const request = require("supertest")
-  const app = require("../../index")
-  const gql = require("lib/gql")
+beforeEach(() => {
+  mockFetch.mockClear()
+})
 
-  it("It should bail for an unknown GET request", async () => {
-    const response = await request(app).get("/")
-    expect(response.statusCode).toBe(400)
+it("It should bail for an unknown GET request", async () => {
+  const response = await request(app).get("/")
+  expect(response.statusCode).toBe(400)
+})
+
+it("can make a request against the schema", async () => {
+  // Mock the fetch for the Artist loader
+  mockFetch.mockResolvedValueOnce(
+    Promise.resolve({ body: { name: "Mr Bank" } })
+  )
+
+  const response = await request(app)
+    .post("/")
+    .set("Accept", "application/json")
+    .send({
+      query: gql`
+        {
+          artist(id: "banksy") {
+            name
+          }
+        }
+      `,
+    })
+
+  expect(response.body.data).toEqual({ artist: { name: "Mr Bank" } })
+  expect(response.statusCode).toBe(200)
+})
+
+describe("variable parsing and coercion", () => {
+  beforeEach(() => {
+    mockFetch.mockResolvedValueOnce(
+      Promise.resolve({ body: [{ id: "catty-sale" }] })
+    )
   })
 
-  it("It can make a request against the schema", async () => {
-    // Mock the fetch for the Artist loader
-    mockFetch.mockResolvedValueOnce(
-      Promise.resolve({ body: { name: "Mr Bank" } })
-    )
-
+  it("converts the string 'true' to a boolean", async () => {
     const response = await request(app)
       .post("/")
       .set("Accept", "application/json")
       .send({
         query: gql`
-          {
-            artist(id: "banksy") {
-              name
+          query SalesQuery($is_auction: Boolean!) {
+            sales(is_auction: $is_auction) {
+              id
             }
           }
         `,
+        variables: {
+          is_auction: "true",
+        },
       })
 
-    expect(response.body.data).toEqual({ artist: { name: "Mr Bank" } })
+    // We are checking that this works w/ string variables
+    expect(response.body.data).toEqual({ sales: [{ id: "catty-sale" }] })
     expect(response.statusCode).toBe(200)
   })
-}
+
+  it("converts the string 'true' to a boolean", async () => {
+    const response = await request(app)
+      .post("/")
+      .set("Accept", "application/json")
+      .send({
+        query: gql`
+          query SalesQuery($is_auction: Boolean!) {
+            sales(is_auction: $is_auction) {
+              id
+            }
+          }
+        `,
+        variables: {
+          is_auction: "false",
+        },
+      })
+
+    // We are checking that this works w/ string variables
+    expect(response.body.data).toEqual({ sales: [{ id: "catty-sale" }] })
+    expect(response.statusCode).toBe(200)
+  })
+
+  it("converts the integer strings to integers", async () => {
+    const response = await request(app)
+      .post("/")
+      .set("Accept", "application/json")
+      .send({
+        query: gql`
+          query SalesQuery($size: Int!) {
+            sales(size: $size) {
+              id
+            }
+          }
+        `,
+        variables: {
+          size: "1",
+        },
+      })
+
+    // We are checking that this works w/ string variables
+    expect(response.body.data).toEqual({ sales: [{ id: "catty-sale" }] })
+    expect(response.statusCode).toBe(200)
+  })
+})


### PR DESCRIPTION
Trying to write a spec for recent patches, and noticed we have this handy integration spec.

However, it is guarded to  _only_ run on CI, and I can't get it work locally.

I'm pretty skeptical this is being run on CI...