### PR TITLE
Add more auction-related fields to User and Sale

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1577,6 +1577,7 @@ type ArtworkContextAuction implements Node {
   is_open: Boolean
   is_live_open: Boolean
   is_preview: Boolean
+  is_preliminary: Boolean
   is_registration_closed: Boolean
   is_with_buyers_premium: Boolean
   live_start_at(
@@ -2063,6 +2064,7 @@ type ArtworkContextSale implements Node {
   is_open: Boolean
   is_live_open: Boolean
   is_preview: Boolean
+  is_preliminary: Boolean
   is_registration_closed: Boolean
   is_with_buyers_premium: Boolean
   live_start_at(
@@ -7197,6 +7199,7 @@ type HomePageModuleContextSale implements Node {
   is_open: Boolean
   is_live_open: Boolean
   is_preview: Boolean
+  is_preliminary: Boolean
   is_registration_closed: Boolean
   is_with_buyers_premium: Boolean
   live_start_at(
@@ -10395,6 +10398,7 @@ type Sale implements Node {
   is_open: Boolean
   is_live_open: Boolean
   is_preview: Boolean
+  is_preliminary: Boolean
   is_registration_closed: Boolean
   is_with_buyers_premium: Boolean
   live_start_at(
@@ -11722,6 +11726,12 @@ type User {
 
   # The price range the collector has selected
   price_range: String
+
+  # Pin for bidding at an auction
+  pin: String
+
+  # The paddle number of the user
+  paddle_number: String
 
   # Check whether a user exists by email address before creating an account.
   userAlreadyExists: Boolean

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5698,6 +5698,7 @@ type Sale implements Node {
   isOpen: Boolean
   isLiveOpen: Boolean
   isPreview: Boolean
+  isPreliminary: Boolean
   isRegistrationClosed: Boolean
   isWithBuyersPremium: Boolean
   liveStartAt(
@@ -6777,6 +6778,12 @@ type User {
 
   # The price range the collector has selected
   priceRange: String
+
+  # Pin for bidding at an auction
+  pin: String
+
+  # The paddle number of the user
+  paddleNumber: String
 
   # Check whether a user exists by email address before creating an account.
   userAlreadyExists: Boolean

--- a/src/schema/v1/__tests__/user.test.js
+++ b/src/schema/v1/__tests__/user.test.js
@@ -7,22 +7,30 @@ describe("User", () => {
       id: "123456",
       _id: "000012345",
       name: "foo bar",
+      pin: "3141",
+      paddle_number: "314159",
     }
+
     const userByEmailLoader = data => {
       if (data) {
         return Promise.resolve(foundUser)
       }
       throw new Error("Unexpected invocation")
     }
+
     const query = gql`
       {
         user(email: "foo@bar.com") {
+          pin
+          paddle_number
           userAlreadyExists
         }
       }
     `
 
     const { user } = await runAuthenticatedQuery(query, { userByEmailLoader })
+    expect(user.pin).toEqual("3141")
+    expect(user.paddle_number).toEqual("314159")
     expect(user.userAlreadyExists).toEqual(true)
   })
 
@@ -36,6 +44,7 @@ describe("User", () => {
       }
       throw error
     }
+
     const query = gql`
       {
         user(email: "nonexistentuser@bar.com") {
@@ -43,6 +52,7 @@ describe("User", () => {
         }
       }
     `
+
     const { user } = await runAuthenticatedQuery(query, { userByEmailLoader })
     expect(user.userAlreadyExists).toEqual(false)
   })

--- a/src/schema/v1/sale/__tests__/index.test.js
+++ b/src/schema/v1/sale/__tests__/index.test.js
@@ -11,6 +11,7 @@ describe("Sale type", () => {
     _id: "123",
     currency: "$",
     is_auction: true,
+    is_preliminary: false,
     increment_strategy: "default",
   }
 
@@ -30,6 +31,7 @@ describe("Sale type", () => {
           is_open
           is_live_open
           is_closed
+          is_preliminary
           is_registration_closed
           auction_state
           status
@@ -46,6 +48,7 @@ describe("Sale type", () => {
           is_open: false,
           is_live_open: false,
           is_closed: true,
+          is_preliminary: false,
           is_registration_closed: false,
           auction_state: "closed",
           status: "closed",
@@ -62,6 +65,7 @@ describe("Sale type", () => {
           is_open: false,
           is_live_open: false,
           is_closed: false,
+          is_preliminary: false,
           is_registration_closed: false,
           auction_state: "preview",
           status: "preview",
@@ -79,6 +83,7 @@ describe("Sale type", () => {
           is_open: true,
           is_live_open: false,
           is_closed: false,
+          is_preliminary: false,
           is_registration_closed: false,
           auction_state: "open",
           status: "open",
@@ -96,6 +101,7 @@ describe("Sale type", () => {
           is_open: true,
           is_live_open: true,
           is_closed: false,
+          is_preliminary: false,
           is_registration_closed: false,
           auction_state: "open",
           status: "open",
@@ -113,6 +119,7 @@ describe("Sale type", () => {
           is_open: true,
           is_live_open: true,
           is_closed: false,
+          is_preliminary: false,
           is_registration_closed: true,
           auction_state: "open",
           status: "open",

--- a/src/schema/v1/sale/index.ts
+++ b/src/schema/v1/sale/index.ts
@@ -248,6 +248,9 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLBoolean,
         resolve: ({ auction_state }) => auction_state === "preview",
       },
+      is_preliminary: {
+        type: GraphQLBoolean,
+      },
       is_registration_closed: {
         type: GraphQLBoolean,
         resolve: ({ registration_ends_at }) =>

--- a/src/schema/v1/user.ts
+++ b/src/schema/v1/user.ts
@@ -35,6 +35,14 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
       description: "The price range the collector has selected",
       type: GraphQLString,
     },
+    pin: {
+      description: "Pin for bidding at an auction",
+      type: GraphQLString,
+    },
+    paddle_number: {
+      description: "The paddle number of the user",
+      type: GraphQLString,
+    },
     userAlreadyExists: {
       description:
         "Check whether a user exists by email address before creating an account.",

--- a/src/schema/v2/__tests__/user.test.js
+++ b/src/schema/v2/__tests__/user.test.js
@@ -7,22 +7,30 @@ xdescribe("User", () => {
       id: "123456",
       _id: "000012345",
       name: "foo bar",
+      pin: "3141",
+      paddle_number: "314159",
     }
+
     const userByEmailLoader = data => {
       if (data) {
         return Promise.resolve(foundUser)
       }
       throw new Error("Unexpected invocation")
     }
+
     const query = gql`
       {
         user(email: "foo@bar.com") {
+          pin
+          paddleNumber
           userAlreadyExists
         }
       }
     `
 
     const { user } = await runAuthenticatedQuery(query, { userByEmailLoader })
+    expect(user.pin).toEqual("3141")
+    expect(user.paddleNumber).toEqual("314159")
     expect(user.userAlreadyExists).toEqual(true)
   })
 

--- a/src/schema/v2/sale/__tests__/index.test.js
+++ b/src/schema/v2/sale/__tests__/index.test.js
@@ -11,6 +11,7 @@ describe("Sale type", () => {
     _id: "123",
     currency: "$",
     is_auction: true,
+    is_preliminary: false,
     increment_strategy: "default",
   }
 
@@ -30,6 +31,7 @@ describe("Sale type", () => {
           isOpen
           isLiveOpen
           isClosed
+          isPreliminary
           isRegistrationClosed
           status
         }
@@ -45,6 +47,7 @@ describe("Sale type", () => {
           isOpen: false,
           isLiveOpen: false,
           isClosed: true,
+          isPreliminary: false,
           isRegistrationClosed: false,
           status: "closed",
         },
@@ -60,6 +63,7 @@ describe("Sale type", () => {
           isOpen: false,
           isLiveOpen: false,
           isClosed: false,
+          isPreliminary: false,
           isRegistrationClosed: false,
           status: "preview",
         },
@@ -76,6 +80,7 @@ describe("Sale type", () => {
           isOpen: true,
           isLiveOpen: false,
           isClosed: false,
+          isPreliminary: false,
           isRegistrationClosed: false,
           status: "open",
         },
@@ -92,6 +97,7 @@ describe("Sale type", () => {
           isOpen: true,
           isLiveOpen: true,
           isClosed: false,
+          isPreliminary: false,
           isRegistrationClosed: false,
           status: "open",
         },
@@ -108,6 +114,7 @@ describe("Sale type", () => {
           isOpen: true,
           isLiveOpen: true,
           isClosed: false,
+          isPreliminary: false,
           isRegistrationClosed: true,
           status: "open",
         },

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -205,6 +205,10 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLBoolean,
         resolve: ({ auction_state }) => auction_state === "preview",
       },
+      isPreliminary: {
+        type: GraphQLBoolean,
+        resolve: ({ is_preliminary }) => is_preliminary,
+      },
       isRegistrationClosed: {
         type: GraphQLBoolean,
         resolve: ({ registration_ends_at }) =>

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -36,6 +36,15 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
       resolve: ({ price_range }) => price_range,
     },
+    pin: {
+      description: "Pin for bidding at an auction",
+      type: GraphQLString,
+    },
+    paddleNumber: {
+      description: "The paddle number of the user",
+      type: GraphQLString,
+      resolve: ({ paddle_number }) => paddle_number,
+    },
     userAlreadyExists: {
       description:
         "Check whether a user exists by email address before creating an account.",


### PR DESCRIPTION
We need these additional fields in the new auctions emails: https://zpl.io/25GYlzo

## Query:

![Screen Shot 2019-09-16 at 11 03 40 AM](https://user-images.githubusercontent.com/386234/64973534-31d20280-d879-11e9-80b2-0160324a050e.png)