### PR TITLE
Add back the Bidder query to the top-level root field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5399,6 +5399,12 @@ type Query {
     id: String!
   ): Artist
 
+  # A Bidder
+  bidder(
+    # The ID of the bidder
+    id: String!
+  ): Bidder
+
   # A city-based entry point for local discovery
   city(
     # A slug for the city, conforming to Gravity's city slug naming conventions

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -9,6 +9,7 @@ import {
 import Artwork from "./artwork"
 import ArtworkAttributionClasses from "./artworkAttributionClasses"
 import Artist from "./artist"
+import Bidder from "./bidder"
 import Fair from "./fair"
 import Gene from "./gene"
 import HomePage from "./home"
@@ -137,6 +138,7 @@ export default new GraphQLSchema({
       // artworks: Artworks,
       artist: Artist,
       // artists: Artists,
+      bidder: Bidder,
       // causalityJWT: CausalityJWT, // TODO: Perhaps this should go into `system` ?
       city: City,
       // collection: Collection,


### PR DESCRIPTION
This PR adds back the top-level `Bidder` query to the root field.

In https://github.com/artsy/metaphysics/pull/1952 we initially discussed not adding a root filed unless absolutely necessary or it truly makes sense. I then switched the gear to changed it to an implementation of the `Node` type, which seems to be working fine [except the fact that the client needs to know how MP's global id is decoded/encoded](https://github.com/artsy/pulse/pull/415#discussion_r324298623). However, the use cases we have in Pulse are heavily relying on raw MongoDB ids and we can't easily take advantage of the generic  `Node` type as much as we do in other frontend repos.

So, I am proposing we add the `Bidder` query to the root field. The risk here is that this could start the whole series of "adding another type to root" PRs. I believe we have to add another top-level query for `SaleArtwork` which [will be used here](https://github.com/artsy/pulse/blob/1234d4a79a4b79df52b912c1e5db5014420de09b/app/services/lot_placed_on_block_service.rb#L5) and there might be a lot more going forward. let me know what you all think.
