### PR TITLE
PURCHASE-1497:  additionalInformation is null

### DIFF
--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -65,7 +65,9 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
     return {
       ...SlugAndInternalIDFields,
       cached,
-      additionalInformation: markdown(),
+      additionalInformation: markdown(
+        ({ additional_information }) => additional_information
+      ),
       artist: {
         type: Artist.type,
         args: {


### PR DESCRIPTION
[PURCHASE-1497]

I noticed that the additionalInformation field was coming up as null. It appears that someone accidentally forgot to pass something to `markdown()` in v2, so the field was always null and nothing was being displayed in emission. I fixed this and now the field returns the proper content.

__Before:__
<img width="338" alt="Screen Shot 2019-09-16 at 5 13 50 PM" src="https://user-images.githubusercontent.com/5643895/64995180-89d42d80-d8a8-11e9-80f8-5599f94f29c6.png">

__After:__
<img width="449" alt="Screen Shot 2019-09-16 at 5 13 20 PM" src="https://user-images.githubusercontent.com/5643895/64995183-8c368780-d8a8-11e9-8d29-f14ea0b7b6a8.png">


[PURCHASE-1497]: https://artsyproduct.atlassian.net/browse/PURCHASE-1497