### PR TITLE
Pass through gravity field for exhibitionHistory

### DIFF
--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -213,7 +213,9 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           return edition_sets
         },
       },
-      exhibitionHistory: markdown(),
+      exhibitionHistory: markdown(
+        ({ exhibition_history }) => exhibition_history
+      ),
       fair: {
         type: Fair.type,
         resolve: ({ id }, _options, { relatedFairsLoader }) => {


### PR DESCRIPTION
#minor 

I scanned through the rest of the codebase and I _think_ this is the last instance of this, but it's possible there are still more places where we're assuming the shape of the data is the same as the shape of the field we're returning.

![image](https://user-images.githubusercontent.com/2081340/65330894-a1056a80-db89-11e9-9a80-b83a7fe12fd5.png)
