### PR TITLE
@eessex => [principalDirective] Don't error when a non-principal error occurs

### DIFF
--- a/src/extensions/principalFieldDirectiveExtension.ts
+++ b/src/extensions/principalFieldDirectiveExtension.ts
@@ -7,6 +7,7 @@ export const principalFieldDirectiveExtension = (documentAST, result) => {
   let extensions = {}
   if (path.length && result.errors && result.errors.length) {
     const errors = result.errors.find(e => isEqual(e.path, path))
+    if (!errors) return extensions
 
     flattenErrors(errors).some(err => {
       const httpStatusCode = statusCodeForError(err)


### PR DESCRIPTION
Noticed this when testing out https://github.com/artsy/reaction/pull/2836 and I've seen it in Sentry as well. Just need to be defensive here.