### PR TITLE
Add time_zone/timeZone to Sale

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1629,7 +1629,7 @@ type ArtworkContextAuction implements Node {
   status: String
   sale_artwork(id: String!): SaleArtwork
   symbol: String
-  time_zone: String
+  timeZone: String
 }
 
 type ArtworkContextFair {
@@ -2117,7 +2117,7 @@ type ArtworkContextSale implements Node {
   status: String
   sale_artwork(id: String!): SaleArtwork
   symbol: String
-  time_zone: String
+  timeZone: String
 }
 
 # An edge in a connection.
@@ -7253,7 +7253,7 @@ type HomePageModuleContextSale implements Node {
   status: String
   sale_artwork(id: String!): SaleArtwork
   symbol: String
-  time_zone: String
+  timeZone: String
 }
 
 type HomePageModuleContextTrending {
@@ -10453,7 +10453,7 @@ type Sale implements Node {
   status: String
   sale_artwork(id: String!): SaleArtwork
   symbol: String
-  time_zone: String
+  timeZone: String
 }
 
 type SaleArtwork {

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1629,6 +1629,7 @@ type ArtworkContextAuction implements Node {
   status: String
   sale_artwork(id: String!): SaleArtwork
   symbol: String
+  time_zone: String
 }
 
 type ArtworkContextFair {
@@ -2116,6 +2117,7 @@ type ArtworkContextSale implements Node {
   status: String
   sale_artwork(id: String!): SaleArtwork
   symbol: String
+  time_zone: String
 }
 
 # An edge in a connection.
@@ -7251,6 +7253,7 @@ type HomePageModuleContextSale implements Node {
   status: String
   sale_artwork(id: String!): SaleArtwork
   symbol: String
+  time_zone: String
 }
 
 type HomePageModuleContextTrending {
@@ -10450,6 +10453,7 @@ type Sale implements Node {
   status: String
   sale_artwork(id: String!): SaleArtwork
   symbol: String
+  time_zone: String
 }
 
 type SaleArtwork {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5739,6 +5739,7 @@ type Sale implements Node {
   status: String
   saleArtwork(id: String!): SaleArtwork
   symbol: String
+  timeZone: String
 }
 
 type SaleArtwork implements Node & ArtworkEdgeInterface {

--- a/src/schema/v1/sale/__tests__/index.test.js
+++ b/src/schema/v1/sale/__tests__/index.test.js
@@ -22,6 +22,24 @@ describe("Sale type", () => {
     })
   }
 
+  describe("sale time_zone", () => {
+    const query = `
+    {
+      sale(id: "foo-foo") {
+        time_zone
+      }
+    }`
+
+    it("returns the correct value for time_zone", async () => {
+      sale.time_zone = "America/Chicago"
+      expect(await execute(query)).toEqual({
+        sale: {
+          time_zone: "America/Chicago",
+        },
+      })
+    })
+  })
+
   describe("auction state", () => {
     const query = `
       {

--- a/src/schema/v1/sale/__tests__/index.test.js
+++ b/src/schema/v1/sale/__tests__/index.test.js
@@ -22,19 +22,19 @@ describe("Sale type", () => {
     })
   }
 
-  describe("sale time_zone", () => {
+  describe("sale timeZone", () => {
     const query = `
     {
       sale(id: "foo-foo") {
-        time_zone
+        timeZone
       }
     }`
 
-    it("returns the correct value for time_zone", async () => {
-      sale.time_zone = "America/Chicago"
+    it("returns the correct value for timeZone", async () => {
+      sale.timeZone = "America/Chicago"
       expect(await execute(query)).toEqual({
         sale: {
-          time_zone: "America/Chicago",
+          timeZone: "America/Chicago",
         },
       })
     })

--- a/src/schema/v1/sale/__tests__/index.test.js
+++ b/src/schema/v1/sale/__tests__/index.test.js
@@ -31,7 +31,7 @@ describe("Sale type", () => {
     }`
 
     it("returns the correct value for timeZone", async () => {
-      sale.timeZone = "America/Chicago"
+      sale.time_zone = "America/Chicago"
       expect(await execute(query)).toEqual({
         sale: {
           timeZone: "America/Chicago",

--- a/src/schema/v1/sale/index.ts
+++ b/src/schema/v1/sale/index.ts
@@ -344,7 +344,10 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       symbol: { type: GraphQLString },
-      timeZone: { type: GraphQLString },
+      timeZone: {
+        type: GraphQLString,
+        resolve: ({ time_zone }) => time_zone,
+      },
     }
   },
 })

--- a/src/schema/v1/sale/index.ts
+++ b/src/schema/v1/sale/index.ts
@@ -344,7 +344,7 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       symbol: { type: GraphQLString },
-      time_zone: { type: GraphQLString },
+      timeZone: { type: GraphQLString },
     }
   },
 })

--- a/src/schema/v1/sale/index.ts
+++ b/src/schema/v1/sale/index.ts
@@ -344,6 +344,7 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       symbol: { type: GraphQLString },
+      time_zone: { type: GraphQLString },
     }
   },
 })

--- a/src/schema/v2/sale/__tests__/index.test.js
+++ b/src/schema/v2/sale/__tests__/index.test.js
@@ -22,6 +22,24 @@ describe("Sale type", () => {
     })
   }
 
+  describe("sale timeZone", () => {
+    const query = `
+    {
+      sale(id: "foo-foo") {
+        timeZone
+      }
+    }`
+
+    it("returns the correct value for time_zone", async () => {
+      sale.timeZone = "America/Chicago"
+      expect(await execute(query)).toEqual({
+        sale: {
+          timeZone: "America/Chicago",
+        },
+      })
+    })
+  })
+
   describe("auction state", () => {
     const query = `
       {

--- a/src/schema/v2/sale/__tests__/index.test.js
+++ b/src/schema/v2/sale/__tests__/index.test.js
@@ -31,7 +31,7 @@ describe("Sale type", () => {
     }`
 
     it("returns the correct value for timeZone", async () => {
-      sale.timeZone = "America/Chicago"
+      sale.time_zone = "America/Chicago"
       expect(await execute(query)).toEqual({
         sale: {
           timeZone: "America/Chicago",

--- a/src/schema/v2/sale/__tests__/index.test.js
+++ b/src/schema/v2/sale/__tests__/index.test.js
@@ -30,7 +30,7 @@ describe("Sale type", () => {
       }
     }`
 
-    it("returns the correct value for time_zone", async () => {
+    it("returns the correct value for timeZone", async () => {
       sale.timeZone = "America/Chicago"
       expect(await execute(query)).toEqual({
         sale: {

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -288,6 +288,7 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       symbol: { type: GraphQLString },
+      timeZone: { type: GraphQLString },
     }
   },
 })

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -288,7 +288,10 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       symbol: { type: GraphQLString },
-      timeZone: { type: GraphQLString },
+      timeZone: {
+        type: GraphQLString,
+        resolve: ({ time_zone }) => time_zone,
+      },
     }
   },
 })


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/AUCT-626

We are only adding time zone, with the expectation that clients will manage formatting to local time zones for now. Times are still stored in UTC.

I had one question: Is it expected that adding time zone to Sale would cause it to appear in multiple places in the generated V1 schema file?