### PR TITLE
Adds StaticContent

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -10047,7 +10047,7 @@ type Query {
 
   # Content for a specific page or view
   staticContent(
-    # The slug for the view
+    # The slug or id for the view
     id: String!
   ): StaticContent
 
@@ -11365,6 +11365,14 @@ enum sort {
 }
 
 type StaticContent {
+  # A globally unique ID.
+  __id: ID!
+
+  # A slug ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  _id: ID!
   name: String
   content: String
 }
@@ -12214,7 +12222,7 @@ type Viewer {
 
   # Content for a specific page or view
   staticContent(
-    # The slug for the view
+    # The slug or id for the view
     id: String!
   ): StaticContent
 

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -10045,6 +10045,12 @@ type Query {
   ): Show
   status: Status
 
+  # Content for a specific page or view
+  staticContent(
+    # The slug for the view
+    id: String!
+  ): StaticContent
+
   # Fields related to internal systems.
   system: System
   tag(
@@ -11358,6 +11364,11 @@ enum sort {
   ASC
 }
 
+type StaticContent {
+  name: String
+  content: String
+}
+
 type Status {
   gravity: StatusGravity
 
@@ -12200,6 +12211,12 @@ type Viewer {
     id: String!
   ): Show
   status: Status
+
+  # Content for a specific page or view
+  staticContent(
+    # The slug for the view
+    id: String!
+  ): StaticContent
 
   # Fields related to internal systems.
   system: System

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5479,7 +5479,7 @@ type Query {
 
   # Content for a specific page or view
   staticContent(
-    # The slug for the view
+    # The slug or id for the view
     id: String!
   ): StaticContent
 
@@ -6534,6 +6534,14 @@ enum sort {
 }
 
 type StaticContent {
+  # A globally unique ID.
+  id: ID!
+
+  # A slug ID.
+  slug: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
   name: String
   content: String
 }
@@ -6904,7 +6912,7 @@ type Viewer {
 
   # Content for a specific page or view
   staticContent(
-    # The slug for the view
+    # The slug or id for the view
     id: String!
   ): StaticContent
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5477,6 +5477,12 @@ type Query {
     id: String!
   ): Show
 
+  # Content for a specific page or view
+  staticContent(
+    # The slug for the view
+    id: String!
+  ): StaticContent
+
   # Fields related to internal systems.
   system: System
 
@@ -6527,6 +6533,11 @@ enum sort {
   ASC
 }
 
+type StaticContent {
+  name: String
+  content: String
+}
+
 enum SubmissionCategoryAggregation {
   PAINTING
   SCULPTURE
@@ -6890,6 +6901,12 @@ type Viewer {
     # The slug or ID of the Show
     id: String!
   ): Show
+
+  # Content for a specific page or view
+  staticContent(
+    # The slug for the view
+    id: String!
+  ): StaticContent
 
   # Fields related to internal systems.
   system: System

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -78,6 +78,7 @@ export default opts => {
     showsWithHeadersLoader: gravityLoader("shows", {}, { headers: true }),
     similarArtworksLoader: gravityLoader("related/artworks"),
     similarGenesLoader: gravityLoader(id => `gene/${id}/similar`, {}, { headers: true }),
+    staticContentLoader: gravityLoader(id => `page/${id}`),
     systemTimeLoader: gravityUncachedLoader("system/time", null),
     tagLoader: gravityLoader(id => `tag/${id}`),
     trendingArtistsLoader: gravityLoader("artists/trending"),

--- a/src/schema/v1/schema.ts
+++ b/src/schema/v1/schema.ts
@@ -87,6 +87,7 @@ import createCreditCardMutation from "./me/create_credit_card_mutation"
 import { deleteCreditCardMutation } from "./me/delete_credit_card_mutation"
 import { BidderPositionMutation } from "./me/bidder_position_mutation"
 import { sendFeedbackMutation } from "./sendFeedbackMutation"
+import StaticContent from "./static_content"
 
 import CausalityJWT from "./causality_jwt"
 import ObjectIdentification from "./object_identification"
@@ -160,6 +161,7 @@ const rootFields: GraphQLFieldConfigMap<any, ResolverContext> = {
   services: Services,
   show: Show,
   status: Status,
+  staticContent: StaticContent,
   system: System,
   tag: Tag,
   trending_artists: TrendingArtists,

--- a/src/schema/v1/static_content.ts
+++ b/src/schema/v1/static_content.ts
@@ -1,0 +1,3 @@
+import StaticContent from "../v2/static_content"
+
+export default StaticContent

--- a/src/schema/v1/static_content.ts
+++ b/src/schema/v1/static_content.ts
@@ -1,3 +1,37 @@
-import StaticContent from "../v2/static_content"
+import {
+  GraphQLObjectType,
+  GraphQLFieldConfig,
+  GraphQLNonNull,
+  GraphQLString,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import { SlugAndInternalIDFields } from "./object_identification"
+
+const StaticContentType = new GraphQLObjectType<any, ResolverContext>({
+  name: "StaticContent",
+  fields: {
+    ...SlugAndInternalIDFields,
+    name: {
+      type: GraphQLString,
+    },
+    content: {
+      type: GraphQLString,
+    },
+  },
+})
+
+const StaticContent: GraphQLFieldConfig<void, ResolverContext> = {
+  type: StaticContentType,
+  description: "Content for a specific page or view",
+  args: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The slug or id for the view",
+    },
+  },
+  resolve: (_root, { id }, { staticContentLoader }) => {
+    return staticContentLoader(id)
+  },
+}
 
 export default StaticContent

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -12,6 +12,7 @@ import Artist from "./artist"
 import Fair from "./fair"
 import Gene from "./gene"
 import HomePage from "./home"
+import StaticContent from "./static_content"
 import { City } from "./city"
 import FollowArtist from "./me/follow_artist"
 import FollowProfile from "./me/follow_profile"
@@ -144,6 +145,7 @@ const rootFields = {
   salesConnection: SalesConnectionField,
   searchConnection: Search,
   show: Show,
+  staticContent: StaticContent,
   // status: Status,
   system: System,
 

--- a/src/schema/v2/static_content.ts
+++ b/src/schema/v2/static_content.ts
@@ -5,10 +5,12 @@ import {
   GraphQLString,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { SlugAndInternalIDFields } from "./object_identification"
 
 const StaticContentType = new GraphQLObjectType<any, ResolverContext>({
   name: "StaticContent",
   fields: {
+    ...SlugAndInternalIDFields,
     name: {
       type: GraphQLString,
     },
@@ -24,7 +26,7 @@ const StaticContent: GraphQLFieldConfig<void, ResolverContext> = {
   args: {
     id: {
       type: new GraphQLNonNull(GraphQLString),
-      description: "The slug for the view",
+      description: "The slug or id for the view",
     },
   },
   resolve: (_root, { id }, { staticContentLoader }) => {

--- a/src/schema/v2/static_content.ts
+++ b/src/schema/v2/static_content.ts
@@ -1,0 +1,35 @@
+import {
+  GraphQLObjectType,
+  GraphQLFieldConfig,
+  GraphQLNonNull,
+  GraphQLString,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+
+const StaticContentType = new GraphQLObjectType<any, ResolverContext>({
+  name: "StaticContent",
+  fields: {
+    name: {
+      type: GraphQLString,
+    },
+    content: {
+      type: GraphQLString,
+    },
+  },
+})
+
+const StaticContent: GraphQLFieldConfig<void, ResolverContext> = {
+  type: StaticContentType,
+  description: "Content for a specific page or view",
+  args: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The slug for the view",
+    },
+  },
+  resolve: (_root, { id }, { staticContentLoader }) => {
+    return staticContentLoader(id)
+  },
+}
+
+export default StaticContent


### PR DESCRIPTION
- Adds `staticContent` to resolve page content from Gravity's `Page` model

Example:

```
{
  staticContent(id: "how-auctions-work-bidding") {
    content
    name
  }
}
```

<img width="1082" alt="Screen Shot 2019-09-26 at 2 36 54 PM" src="https://user-images.githubusercontent.com/21182806/65715616-74f75700-e06b-11e9-9d3b-ccf6e037d5f9.png">
