### PR TITLE
[City Guide] Add sponsored content for Frieze London 2019

### DIFF
--- a/src/lib/sponsoredContent/data.json
+++ b/src/lib/sponsoredContent/data.json
@@ -76,6 +76,10 @@
     },
     "frieze-new-york-2019": {
       "activationText": "BMW supports Frieze Art Fair New York with a VIP shuttle service and is working on various joint initiatives such as the art commission BMW Open Work or Frieze Music for the other fair editions. Learn more on Instagram @bmwgroupculture."
+    },
+    "frieze-london-2019": {
+      "activationText": "London/Munich. For the third consecutive year BMW and Frieze continue their long-term partnership with the major art initiative BMW Open Work by Frieze. Drawing inspiration from BMW Design and engineering, the commission brings together art, technology and design in a pioneering multi-platform format. The artist chosen to create this year’s BMW Open Work by Frieze is Paris-based Camille Blatrix.",
+      "pressReleaseUrl": "https://www.press.bmwgroup.com/global/article/detail/T0299793EN/camille-blatrix-to-explore-concept-of-desire-for-bmw-open-work-2019-artwork-inspired-by-bmw-technology-to-premiere-at-frieze-london-in-october-2019"
     }
   }
 }

--- a/src/lib/sponsoredContent/data.json
+++ b/src/lib/sponsoredContent/data.json
@@ -78,7 +78,7 @@
       "activationText": "BMW supports Frieze Art Fair New York with a VIP shuttle service and is working on various joint initiatives such as the art commission BMW Open Work or Frieze Music for the other fair editions. Learn more on Instagram @bmwgroupculture."
     },
     "frieze-london-2019": {
-      "activationText": "London/Munich. For the third consecutive year BMW and Frieze continue their long-term partnership with the major art initiative BMW Open Work by Frieze. Drawing inspiration from BMW Design and engineering, the commission brings together art, technology and design in a pioneering multi-platform format. The artist chosen to create this year’s BMW Open Work by Frieze is Paris-based Camille Blatrix.",
+      "activationText": "BMW is long term partner of Frieze Art Fair. During the 2019 London edition the third BMW Open Work by Frieze commission will be unveiled: Sirens created by French artist Camille Blatrix. BMW Open Work gives artists the opportunity to push the boundaries of their artistic work, utilizing technology and design to pursue practice in innovate new directions. The commissions are created in close dialogue with BMW engineers, designers or technicians creating a distinct encounter between industrial knowledge, technology, and artistic thought. Furthermore, BMW is partner of Frieze Music and supplies a shuttle service for VIP guests of the fair.",
       "pressReleaseUrl": "https://www.press.bmwgroup.com/global/article/detail/T0299793EN/camille-blatrix-to-explore-concept-of-desire-for-bmw-open-work-2019-artwork-inspired-by-bmw-technology-to-premiere-at-frieze-london-in-october-2019"
     }
   }


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GROW-1550

This fulfills a time-sensitive content sponsor request: https://artsy.slack.com/archives/C9SATFLUU/p1569513951321800

In lieu of having final copy, not that I pulled the first ¶ from the provided [press release](https://www.press.bmwgroup.com/global/article/detail/T0299793EN/camille-blatrix-to-explore-concept-of-desire-for-bmw-open-work-2019-artwork-inspired-by-bmw-technology-to-premiere-at-frieze-london-in-october-2019) body to use as the "activation text."

This is similar but not _identical_ to how the copy for previous fairs was handled — **please confirm that this text is okay (or update this PR as necessary) before merging**.

<img width="1072" alt="Screen Shot 2019-09-26 at 11 52 51 PM" src="https://user-images.githubusercontent.com/140521/65741509-45bc0680-e0ba-11e9-9191-b3289fb6ad1e.png">
