### PR TITLE
Avoid deprecation warning on every request

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -228,7 +228,7 @@ function startApp(appSchema, path: string) {
           graphiql: true,
           context,
           rootValue: {},
-          formatError: graphqlErrorHandler(enableSentry, {
+          customFormatErrorFn: graphqlErrorHandler(enableSentry, {
             req,
             // Why the checking on params? Do we reach this code if params is falsy?
             variables: params && params.variables,


### PR DESCRIPTION
Looks like:

```
formatError` is deprecated and replaced by `customFormatErrorFn`. It will be removed in version 1.0.0.
```
