### PR TITLE
DO NOT MERGE [PURCHASE-1539: "Ended invalid date" in auction entity header

### DIFF
--- a/src/lib/__tests__/date.test.ts
+++ b/src/lib/__tests__/date.test.ts
@@ -117,6 +117,15 @@ describe("date formatting", () => {
       )
       expect(period).toBe("Ended Dec 30, 2016")
     })
+
+    it("returns null if endAt is null and the sale has already started", () => {
+      const period = formattedStartDateTime(
+        "2016-12-05T20:00:00+00:00",
+        null,
+        "UTC"
+      )
+      expect(period).toBe(null)
+    })
   })
 
   describe(formattedOpeningHours, () => {

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -262,6 +262,8 @@ export function formattedStartDateTime(startAt, endAt, timezone) {
     return `Starts ${singleDateTime(startAt, timezone)}`
   } else if (thisMoment.isBefore(endMoment)) {
     return `Ends ${singleDateTime(endAt, timezone)}`
+  } else if (endAt === null) {
+    return null
   } else {
     return `Ended ${singleDate(endAt, timezone)}`
   }


### PR DESCRIPTION
# [PURCHASE-1539]: "Ended invalid date" in auction entity header

https://www.notion.so/artsy/Ended-invalid-date-in-auction-entity-header-f981deec4bdd43acbee9febb789806f9

`formattedStartDateTime` was returning "ended Invalid date" when endAt was null. I added and `else if` so that `formattedStartDateTime` returns null when endAt is null. For all other cases behavior will remain the same.





[PURCHASE-1539]: https://artsyproduct.atlassian.net/browse/PURCHASE-1539