### PR TITLE
Update SaleArtworksConnection to accept the internalIDs argument

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5737,7 +5737,7 @@ type Sale implements Node {
   requireBidderApproval: Boolean
   saleArtworksConnection(
     # List of sale artwork internal IDs to fetch
-    internalIDs: [String]
+    internalIDs: [ID]
     after: String
     first: Int
     before: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5736,6 +5736,8 @@ type Sale implements Node {
   registrationStatus: Bidder
   requireBidderApproval: Boolean
   saleArtworksConnection(
+    # List of sale artwork internal IDs to fetch
+    internalIDs: [String]
     after: String
     first: Int
     before: String

--- a/src/schema/v2/sale/__tests__/__snapshots__/index.test.js.snap
+++ b/src/schema/v2/sale/__tests__/__snapshots__/index.test.js.snap
@@ -64,6 +64,27 @@ Object {
 }
 `;
 
+exports[`Sale type saleArtworksConnection accepts the internalIDs argument 1`] = `
+Object {
+  "sale": Object {
+    "saleArtworksConnection": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "slug": "sa-slug-0",
+          },
+        },
+        Object {
+          "node": Object {
+            "slug": "sa-slug-1",
+          },
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`Sale type saleArtworksConnection returns data from gravity 1`] = `
 Object {
   "sale": Object {

--- a/src/schema/v2/sale/__tests__/index.test.js
+++ b/src/schema/v2/sale/__tests__/index.test.js
@@ -229,6 +229,41 @@ describe("Sale type", () => {
         expect(data).toMatchSnapshot()
       })
     })
+
+    it("accepts the internalIDs argument", () => {
+      const query = `
+        {
+          sale(id: "foo-foo") {
+            saleArtworksConnection(internalIDs: ["sa-id-0", "sa-id-1"]) {
+              edges {
+                node {
+                  slug
+                }
+              }
+            }
+          }
+        }
+      `
+      sale.eligible_sale_artworks_count = 2
+
+      const saleArtworks = [{ id: "sa-slug-0" }, { id: "sa-slug-1" }]
+      const saleArtworksLoaderMock = jest
+        .fn()
+        .mockResolvedValue({ body: saleArtworks })
+      const context = {
+        saleLoader: () => Promise.resolve(sale),
+        saleArtworksLoader: saleArtworksLoaderMock,
+      }
+
+      return runAuthenticatedQuery(query, context).then(data => {
+        expect(saleArtworksLoaderMock.mock.calls[0][1].ids).toEqual([
+          "sa-id-0",
+          "sa-id-1",
+        ])
+
+        expect(data).toMatchSnapshot()
+      })
+    })
   })
 
   describe("saleArtworks", () => {

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -257,16 +257,24 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
       },
       saleArtworksConnection: {
         type: saleArtworkConnection,
-        args: pageable(),
+        args: pageable({
+          internalIDs: {
+            type: new GraphQLList(GraphQLString),
+            description: "List of sale artwork internal IDs to fetch",
+          },
+        }),
         resolve: (sale, options, { saleArtworksLoader }) => {
           const { limit: size, offset } = getPagingParameters(options)
+          const { internalIDs: ids } = options
+
           return saleArtworksLoader(sale.id, {
             size,
             offset,
+            ids,
           }).then(({ body }) =>
             connectionFromArraySlice(body, options, {
               arrayLength: sale.eligible_sale_artworks_count,
-              sliceStart: offset,
+              sliceStart: offset || 0,
             })
           )
         },

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -28,6 +28,7 @@ import {
   GraphQLInt,
   GraphQLFloat,
   GraphQLFieldConfig,
+  GraphQLID,
 } from "graphql"
 
 import config from "config"
@@ -259,7 +260,7 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
         type: saleArtworkConnection,
         args: pageable({
           internalIDs: {
-            type: new GraphQLList(GraphQLString),
+            type: new GraphQLList(GraphQLID),
             description: "List of sale artwork internal IDs to fetch",
           },
         }),

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -271,12 +271,22 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
             size,
             offset,
             ids,
-          }).then(({ body }) =>
-            connectionFromArraySlice(body, options, {
-              arrayLength: sale.eligible_sale_artworks_count,
-              sliceStart: offset || 0,
-            })
-          )
+          }).then(({ body }) => {
+            let meta
+            if (ids) {
+              meta = {
+                arrayLength: body && body.length,
+                sliceStart: 0,
+              }
+            } else {
+              meta = {
+                arrayLength: sale.eligible_sale_artworks_count,
+                sliceStart: offset,
+              }
+            }
+
+            return connectionFromArraySlice(body, options, meta)
+          })
         },
       },
       saleType: {


### PR DESCRIPTION
depends on https://github.com/artsy/gravity/pull/12610

In a Zeplin mockup like https://zpl.io/brLyq53, we would like to fetch a subset of sale artworks in a sale rather than loading every one of them or fetching each one-by-one. Right now we do this in an iteration which isn't efficient.

This PR adds a new `internalIDs` argument so the client can only get relevant data. It may not be the best name as it could be confusing when there are `id` and `internalID`, but I would like feedback on this as well.