### PR TITLE
Update formattedStartDateTime to account for live sales and fix bugs

### DIFF
--- a/src/lib/__tests__/date.test.ts
+++ b/src/lib/__tests__/date.test.ts
@@ -146,14 +146,6 @@ describe("date formatting", () => {
       const date = formattedStartDateTime(startAt, endAt, liveStartAt, "UTC")
       expect(date).toEqual("In progress")
     })
-
-    it("is null if endAt is null and startAt and liveStartAt are in the past", () => {
-      const startAt = "2012-12-05T20:00:00+00:00"
-      const liveStartAt = "2012-12-05T20:00:00+00:00"
-      const endAt = null
-      const date = formattedStartDateTime(startAt, endAt, liveStartAt, "UTC")
-      expect(date).toEqual(null)
-    })
   })
 
   describe(formattedOpeningHours, () => {

--- a/src/lib/__tests__/date.test.ts
+++ b/src/lib/__tests__/date.test.ts
@@ -95,6 +95,7 @@ describe("date formatting", () => {
       const period = formattedStartDateTime(
         "2045-12-05T20:00:00+00:00",
         "2050-12-30T17:00:00+00:00",
+        null,
         "UTC"
       )
       expect(period).toBe("Starts Dec 5, 2045 at 8:00pm UTC")
@@ -104,6 +105,7 @@ describe("date formatting", () => {
       const period = formattedStartDateTime(
         "2017-12-05T20:00:00+00:00",
         "2045-12-30T17:00:00+00:00",
+        null,
         "UTC"
       )
       expect(period).toBe("Ends Dec 30, 2045 at 5:00pm UTC")
@@ -113,9 +115,44 @@ describe("date formatting", () => {
       const period = formattedStartDateTime(
         "2016-12-05T20:00:00+00:00",
         "2016-12-30T17:00:00+00:00",
+        null,
         "UTC"
       )
       expect(period).toBe("Ended Dec 30, 2016")
+    })
+
+    it("includes 'Starts' when event starts in the future", () => {
+      const period = formattedStartDateTime(
+        "2045-12-05T20:00:00+00:00",
+        "2050-12-30T17:00:00+00:00",
+        null,
+        "UTC"
+      )
+      expect(period).toBe("Starts Dec 5, 2045 at 8:00pm UTC")
+    })
+
+    it("includes 'Live' string when auction has started but live sale has not", () => {
+      const startAt = "2012-12-05T20:00:00+00:00"
+      const liveStartAt = "2045-12-05T20:00:00+00:00"
+      const endAt = "2045-12-05T20:00:00+00:00"
+      const date = formattedStartDateTime(startAt, endAt, liveStartAt, "UTC")
+      expect(date).toEqual("Live Dec 5, 2045 at 8:00pm UTC")
+    })
+
+    it("includes 'In progress' string when auction is live", () => {
+      const startAt = "2012-12-05T20:00:00+00:00"
+      const liveStartAt = "2012-12-05T20:00:00+00:00"
+      const endAt = "2045-12-05T20:00:00+00:00"
+      const date = formattedStartDateTime(startAt, endAt, liveStartAt, "UTC")
+      expect(date).toEqual("In progress")
+    })
+
+    it("is null if endAt is null and startAt and liveStartAt are in the past", () => {
+      const startAt = "2012-12-05T20:00:00+00:00"
+      const liveStartAt = "2012-12-05T20:00:00+00:00"
+      const endAt = null
+      const date = formattedStartDateTime(startAt, endAt, liveStartAt, "UTC")
+      expect(date).toEqual(null)
     })
   })
 

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -254,15 +254,27 @@ export function formattedOpeningHours(startAt, endAt, timezone) {
  * Ends Apr 3 at 12:30pm
  * Ended Apr 3 2017
  */
-export function formattedStartDateTime(startAt, endAt, timezone) {
-  const thisMoment = moment()
+export function formattedStartDateTime(startAt, endAt, liveStartAt, timezone) {
+  const thisMoment = moment.tz(moment(), timezone)
   const startMoment = moment.tz(startAt, timezone)
   const endMoment = moment.tz(endAt, timezone)
+  const liveStartMoment = moment.tz(liveStartAt, timezone)
+
   if (thisMoment.isBefore(startMoment)) {
     return `Starts ${singleDateTime(startAt, timezone)}`
+  } else if (liveStartAt && thisMoment.isBefore(liveStartMoment)) {
+    return `Live ${singleDateTime(liveStartAt, timezone)}`
+  } else if (
+    liveStartAt &&
+    thisMoment.isAfter(liveStartMoment) &&
+    (thisMoment.isBefore(endMoment) || !endAt)
+  ) {
+    return `In progress`
   } else if (thisMoment.isBefore(endMoment)) {
     return `Ends ${singleDateTime(endAt, timezone)}`
-  } else {
+  } else if (thisMoment.isAfter(endMoment)) {
     return `Ended ${singleDate(endAt, timezone)}`
+  } else {
+    return null
   }
 }

--- a/src/schema/v1/sale/index.ts
+++ b/src/schema/v1/sale/index.ts
@@ -211,7 +211,11 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLString,
         description:
           "A formatted description of when the auction starts or ends or if it has ended",
-        resolve: ({ start_at, end_at, live_start_at, defaultTimezone }) =>
+        resolve: (
+          { start_at, end_at, live_start_at },
+          _options,
+          { defaultTimezone }
+        ) =>
           formattedStartDateTime(
             start_at,
             end_at,

--- a/src/schema/v1/sale/index.ts
+++ b/src/schema/v1/sale/index.ts
@@ -37,6 +37,8 @@ import { deprecate } from "lib/deprecation"
 
 const { PREDICTION_ENDPOINT } = config
 
+const DEFAULT_TZ = "UTC"
+
 const BidIncrement = new GraphQLObjectType<any, ResolverContext>({
   name: "BidIncrement",
   fields: {
@@ -209,8 +211,13 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLString,
         description:
           "A formatted description of when the auction starts or ends or if it has ended",
-        resolve: ({ start_at, end_at }) =>
-          formattedStartDateTime(start_at, end_at, "UTC"),
+        resolve: ({ start_at, end_at, live_start_at, defaultTimezone }) =>
+          formattedStartDateTime(
+            start_at,
+            end_at,
+            live_start_at,
+            defaultTimezone || DEFAULT_TZ
+          ),
       },
       href: { type: GraphQLString, resolve: ({ id }) => `/auction/${id}` },
       name: { type: GraphQLString },

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -35,6 +35,8 @@ import { ResolverContext } from "types/graphql"
 
 const { PREDICTION_ENDPOINT } = config
 
+const DEFAULT_TZ = "UTC"
+
 const BidIncrement = new GraphQLObjectType<any, ResolverContext>({
   name: "BidIncrement",
   fields: {
@@ -170,8 +172,13 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLString,
         description:
           "A formatted description of when the auction starts or ends or if it has ended",
-        resolve: ({ start_at, end_at }) =>
-          formattedStartDateTime(start_at, end_at, "UTC"),
+        resolve: ({ start_at, end_at, live_start_at, defaultTimezone }) =>
+          formattedStartDateTime(
+            start_at,
+            end_at,
+            live_start_at,
+            defaultTimezone || DEFAULT_TZ
+          ),
       },
       href: { type: GraphQLString, resolve: ({ id }) => `/auction/${id}` },
       name: { type: GraphQLString },

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -173,13 +173,18 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLString,
         description:
           "A formatted description of when the auction starts or ends or if it has ended",
-        resolve: ({ start_at, end_at, live_start_at, defaultTimezone }) =>
-          formattedStartDateTime(
+        resolve: (
+          { start_at, end_at, live_start_at },
+          _options,
+          { defaultTimezone }
+        ) => {
+          return formattedStartDateTime(
             start_at,
             end_at,
             live_start_at,
             defaultTimezone || DEFAULT_TZ
-          ),
+          )
+        },
       },
       href: { type: GraphQLString, resolve: ({ id }) => `/auction/${id}` },
       name: { type: GraphQLString },


### PR DESCRIPTION
Semi-related to [PURCHASE-1584] and [PURCHASE-1539]

This will allow the context card to show messaging about auction start/end times that will be consistent with the auction timer (I have another PR in emission to update that). I also fixed a bug where the string was coming back with "Invalid date" in some cases. I also made the dateTimes timezone specific but defaulting to UTC, whereas before they were always in UTC. 

__Before:__
<img width="428" alt="Screen Shot 2019-10-09 at 3 11 57 PM" src="https://user-images.githubusercontent.com/5643895/66512655-65363480-eaa7-11e9-8018-50ee0a2a420e.png">

__After:__
<img width="488" alt="Screen Shot 2019-10-09 at 3 12 17 PM" src="https://user-images.githubusercontent.com/5643895/66512668-6c5d4280-eaa7-11e9-847a-9b683de564b8.png">

__After (when it gets timezone from the client):__
<img width="490" alt="Screen Shot 2019-10-09 at 4 29 15 PM" src="https://user-images.githubusercontent.com/5643895/66517932-09bd7400-eab2-11e9-9d54-5be375cc232b.png">

[PURCHASE-1584]: https://artsyproduct.atlassian.net/browse/PURCHASE-1584
[PURCHASE-1539]: https://artsyproduct.atlassian.net/browse/PURCHASE-1539