### PR TITLE
return empty array for sale artworks when internalIDs == empty array

### DIFF
--- a/src/schema/v2/sale/__tests__/index.test.js
+++ b/src/schema/v2/sale/__tests__/index.test.js
@@ -266,6 +266,29 @@ describe("Sale type", () => {
     })
   })
 
+  it("returns and empty array if the internalIDs argument is []", () => {
+    const query = `
+      {
+        sale(id: "foo-foo") {
+          saleArtworksConnection(internalIDs: []) {
+            edges {
+              node {
+                slug
+              }
+            }
+          }
+        }
+      }
+    `
+    const context = {
+      saleLoader: () => Promise.resolve(sale),
+    }
+
+    return runAuthenticatedQuery(query, context).then(data => {
+      expect(data.sale.saleArtworksConnection.edges).toEqual([])
+    })
+  })
+
   describe("saleArtworks", () => {
     const saleArtworks = [
       {

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -17,7 +17,7 @@ import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { map } from "lodash"
 import { NodeInterface } from "schema/v2/object_identification"
 import { isLiveOpen, displayTimelyAt } from "./display"
-import { flatten } from "lodash"
+import { flatten, isEmpty } from "lodash"
 
 import {
   GraphQLString,
@@ -267,6 +267,12 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
         resolve: (sale, options, { saleArtworksLoader }) => {
           const { limit: size, offset } = getPagingParameters(options)
           const { internalIDs: ids } = options
+          if (ids !== undefined && isEmpty(ids)) {
+            return connectionFromArraySlice([], options, {
+              arrayLength: 0,
+              sliceStart: 0,
+            })
+          }
 
           return saleArtworksLoader(sale.id, {
             size,


### PR DESCRIPTION
Paired with @yuki24 on this. When passing an empty array to metaphysics, it removes the empty array rather than passing `ids: []` to gravity as expected.
