### PR TITLE
Fix not honoring ended_at for live auctions

### DIFF
--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -262,18 +262,23 @@ export function formattedStartDateTime(startAt, endAt, liveStartAt, timezone) {
 
   if (thisMoment.isBefore(startMoment)) {
     return `Starts ${singleDateTime(startAt, timezone)}`
-  } else if (liveStartAt && thisMoment.isBefore(liveStartMoment)) {
-    return `Live ${singleDateTime(liveStartAt, timezone)}`
-  } else if (
-    liveStartAt &&
-    thisMoment.isAfter(liveStartMoment) &&
-    (thisMoment.isBefore(endMoment) || !endAt)
-  ) {
-    return `In progress`
+  }
+
+  if (thisMoment.isAfter(endMoment)) {
+    return `Ended ${singleDate(endAt, timezone)}`
+  }
+
+  if (liveStartAt) {
+    if (thisMoment.isBefore(liveStartMoment)) {
+      return `Live ${singleDateTime(liveStartAt, timezone)}`
+    } else if (
+      thisMoment.isAfter(liveStartMoment) &&
+      (thisMoment.isBefore(endMoment) || !endAt)
+    ) {
+      return `In progress`
+    }
   } else if (thisMoment.isBefore(endMoment)) {
     return `Ends ${singleDateTime(endAt, timezone)}`
-  } else if (thisMoment.isAfter(endMoment)) {
-    return `Ended ${singleDate(endAt, timezone)}`
   } else {
     return null
   }

--- a/src/schema/v1/sale/index.ts
+++ b/src/schema/v1/sale/index.ts
@@ -213,13 +213,13 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
         description:
           "A formatted description of when the auction starts or ends or if it has ended",
         resolve: (
-          { start_at, end_at, live_start_at },
+          { start_at, end_at, ended_at, live_start_at },
           _options,
           { defaultTimezone }
         ) =>
           formattedStartDateTime(
             start_at,
-            end_at,
+            ended_at || end_at,
             live_start_at,
             defaultTimezone || DEFAULT_TZ
           ),

--- a/src/schema/v2/sale/__tests__/index.test.js
+++ b/src/schema/v2/sale/__tests__/index.test.js
@@ -670,6 +670,87 @@ describe("Sale type", () => {
     })
   })
 
+  describe("formattedStartDateTime", () => {
+    const query = `
+      {
+        sale(id: "foo-foo") {
+          formattedStartDateTime
+        }
+      }
+    `
+
+    it("returns Start time when start_at is in the future", async () => {
+      const response = await execute(query, {
+        start_at: moment().add(1, "hours"),
+      })
+      expect(response.sale.formattedStartDateTime).toContain("Start")
+    })
+
+    it("returns End time when end_at is in the past", async () => {
+      const response = await execute(query, {
+        start_at: moment().subtract(2, "hours"),
+        end_at: moment().subtract(1, "hours"),
+      })
+      expect(response.sale.formattedStartDateTime).toContain("Ended")
+    })
+
+    it("returns End time when end_at is in the past", async () => {
+      const response = await execute(query, {
+        start_at: moment().subtract(2, "hours"),
+        end_at: null,
+        ended_at: moment().subtract(1, "hours"),
+      })
+      expect(response.sale.formattedStartDateTime).toContain("Ended")
+    })
+
+    it("returns End time when ended_at is in the past but end_at is in the future", async () => {
+      const response = await execute(query, {
+        start_at: moment().subtract(2, "hours"),
+        end_at: moment().add(1, "hours"),
+        ended_at: moment().subtract(1, "hours"),
+      })
+      expect(response.sale.formattedStartDateTime).toContain("Ended")
+    })
+
+    it("returns Live start time if live_start_at is in the future", async () => {
+      const response = await execute(query, {
+        start_at: moment().subtract(2, "hours"),
+        live_start_at: moment().add(2, "hours"),
+      })
+      expect(response.sale.formattedStartDateTime).toContain("Live")
+    })
+
+    it("returns In Progress when its live and end_at is in the future", async () => {
+      const response = await execute(query, {
+        start_at: moment().subtract(2, "hours"),
+        live_start_at: moment().subtract(1, "hours"),
+        end_at: moment().add(2, "hours"),
+        ended_at: null,
+      })
+      expect(response.sale.formattedStartDateTime).toContain("In progress")
+    })
+
+    it("returns In Progress when its live and ended_at is in the future", async () => {
+      const response = await execute(query, {
+        start_at: moment().subtract(2, "hours"),
+        live_start_at: moment().subtract(1, "hours"),
+        ended_at: moment().add(2, "hours"),
+        end_at: null,
+      })
+      expect(response.sale.formattedStartDateTime).toContain("In progress")
+    })
+
+    it("returns End time", async () => {
+      const response = await execute(query, {
+        start_at: moment().subtract(3, "hours"),
+        live_start_at: null,
+        end_at: moment().add(1, "hours"),
+        ended_at: null,
+      })
+      expect(response.sale.formattedStartDateTime).toContain("Ends")
+    })
+  })
+
   describe("registration status", () => {
     it("returns null if not registered for this sale", async () => {
       const query = gql`

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -174,13 +174,13 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
         description:
           "A formatted description of when the auction starts or ends or if it has ended",
         resolve: (
-          { start_at, end_at, live_start_at },
+          { start_at, end_at, ended_at, live_start_at },
           _options,
           { defaultTimezone }
         ) => {
           return formattedStartDateTime(
             start_at,
-            end_at,
+            ended_at || end_at,
             live_start_at,
             defaultTimezone || DEFAULT_TZ
           )


### PR DESCRIPTION
# Problem
https://artsyproduct.atlassian.net/browse/PURCHASE-1598

# Cause
We were not honoring `ended_at` field of the auction and we were only using `end_at`.

`end_at` can be `null` and `ended_at` is for live auctions where we store the actual time the auction ended.

# Solution
When calling `formattedStartDateTime` use `ended_at` and if it's null, use `end_at`.