### PR TITLE
Add CalculatedCost type to SaleArtwork

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3258,7 +3258,7 @@ type BuyOrder implements Order {
 }
 
 type CalculatedCost {
-  buyers_premium: BuyersPremiumAmount
+  buyersPremium: BuyersPremiumAmount
   subtotal: SubtotalAmount
 }
 
@@ -10606,9 +10606,9 @@ type SaleArtwork {
   reserve_status: String
   sale_id: String
   sale: Sale
-  calculated_cost(
+  calculatedCost(
     # Max bid price for the sale artwork
-    bid_amount_cents: Int
+    bidAmountCents: Int
   ): CalculatedCost
 
   # Currency symbol (e.g. "$")

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3028,6 +3028,25 @@ type BuyersPremium {
   percent: Float
 }
 
+type BuyersPremiumAmount {
+  # A formatted price with various currency formatting options.
+  amount(
+    decimal: String = "."
+
+    # Allows control of symbol position (%v = value, %s = symbol)
+    format: String = "%s%v"
+    precision: Int = 0
+    symbol: String
+    thousand: String = ","
+  ): String
+
+  # An amount of money expressed in cents.
+  cents: Float
+
+  # A pre-formatted price.
+  display: String
+}
+
 type BuyOrder implements Order {
   # A globally unique ID.
   __id: ID!
@@ -3236,6 +3255,11 @@ type BuyOrder implements Order {
 
   # Buyer phone number
   buyerPhoneNumber: String
+}
+
+type CalculatedCost {
+  buyers_premium: BuyersPremiumAmount
+  subtotal: SubtotalAmount
 }
 
 enum CancelReasonType {
@@ -10582,6 +10606,10 @@ type SaleArtwork {
   reserve_status: String
   sale_id: String
   sale: Sale
+  calculated_cost(
+    # Max bid price for the sale artwork
+    bid_amount_cents: Int
+  ): CalculatedCost
 
   # Currency symbol (e.g. "$")
   symbol: String
@@ -11507,6 +11535,25 @@ input submitPendingOfferInput {
 type submitPendingOfferPayload {
   orderOrError: OrderOrFailureUnionType
   clientMutationId: String
+}
+
+type SubtotalAmount {
+  # A formatted price with various currency formatting options.
+  amount(
+    decimal: String = "."
+
+    # Allows control of symbol position (%v = value, %s = symbol)
+    format: String = "%s%v"
+    precision: Int = 0
+    symbol: String
+    thousand: String = ","
+  ): String
+
+  # An amount of money expressed in cents.
+  cents: Float
+
+  # A pre-formatted price.
+  display: String
 }
 
 type System {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1496,6 +1496,30 @@ type BuyersPremium {
   percent: Float
 }
 
+type BuyersPremiumAmount {
+  # A formatted price with various currency formatting options.
+  amount(
+    decimal: String = "."
+
+    # Allows control of symbol position (%v = value, %s = symbol)
+    format: String = "%s%v"
+    precision: Int = 0
+    symbol: String
+    thousand: String = ","
+  ): String
+
+  # An amount of money expressed in cents.
+  cents: Float
+
+  # A pre-formatted price.
+  display: String
+}
+
+type CalculatedCost {
+  buyersPremium: BuyersPremiumAmount
+  subtotal: SubtotalAmount
+}
+
 type City {
   slug: String
   name: String
@@ -5841,6 +5865,10 @@ type SaleArtwork implements Node & ArtworkEdgeInterface {
   reserveStatus: String
   saleID: String
   sale: Sale
+  calculatedCost(
+    # Max bid price for the sale artwork
+    bidAmountCents: Int
+  ): CalculatedCost
 
   # Currency symbol (e.g. "$")
   symbol: String
@@ -6618,6 +6646,25 @@ enum SubmissionStateAggregation {
   SUBMITTED
   APPROVED
   REJECTED
+}
+
+type SubtotalAmount {
+  # A formatted price with various currency formatting options.
+  amount(
+    decimal: String = "."
+
+    # Allows control of symbol position (%v = value, %s = symbol)
+    format: String = "%s%v"
+    precision: Int = 0
+    symbol: String
+    thousand: String = ","
+  ): String
+
+  # An amount of money expressed in cents.
+  cents: Float
+
+  # A pre-formatted price.
+  display: String
 }
 
 type System {

--- a/src/schema/v1/__tests__/sale_artwork.test.js
+++ b/src/schema/v1/__tests__/sale_artwork.test.js
@@ -440,4 +440,44 @@ describe("SaleArtwork type", () => {
       ])
     })
   })
+
+  describe("calculated_cost", () => {
+    it("returns calculated_cost", async () => {
+      const query = `
+        {
+          sale_artwork(id: "54c7ed2a7261692bfa910200") {
+            calculated_cost(bid_amount_cents: 1000000) {
+              buyers_premium {
+                cents
+                display
+              }
+              subtotal {
+                cents
+                display
+              }
+            }
+          }
+        }
+      `
+
+      const data = await execute(query, saleArtwork, {
+        saleArtworkRootLoader: () => Promise.resolve(saleArtwork),
+      })
+
+      expect(data).toEqual({
+        sale_artwork: {
+          calculated_cost: {
+            buyers_premium: {
+              cents: 200000,
+              display: "$2,000.00",
+            },
+            subtotal: {
+              cents: 1200000,
+              display: "$12,000.00",
+            },
+          },
+        },
+      })
+    })
+  })
 })

--- a/src/schema/v1/__tests__/sale_artwork.test.js
+++ b/src/schema/v1/__tests__/sale_artwork.test.js
@@ -446,8 +446,8 @@ describe("SaleArtwork type", () => {
       const query = `
         {
           sale_artwork(id: "54c7ed2a7261692bfa910200") {
-            calculated_cost(bid_amount_cents: 1000000) {
-              buyers_premium {
+            calculatedCost(bidAmountCents: 1000000) {
+              buyersPremium {
                 cents
                 display
               }
@@ -466,8 +466,8 @@ describe("SaleArtwork type", () => {
 
       expect(data).toEqual({
         sale_artwork: {
-          calculated_cost: {
-            buyers_premium: {
+          calculatedCost: {
+            buyersPremium: {
               cents: 200000,
               display: "$2,000.00",
             },

--- a/src/schema/v1/sale_artwork.ts
+++ b/src/schema/v1/sale_artwork.ts
@@ -26,6 +26,7 @@ import config from "config"
 import { ResolverContext } from "types/graphql"
 import { LoadersWithoutAuthentication } from "lib/loaders/loaders_without_authentication"
 import { deprecate } from "lib/deprecation"
+import { CalculatedCostType } from "./types/calculated_cost"
 
 const { BIDDER_POSITION_MAX_BID_AMOUNT_CENTS_LIMIT } = config
 
@@ -368,6 +369,31 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ sale, sale_id }, _options, { saleLoader }) => {
           if (!!sale) return sale
           return saleLoader(sale_id)
+        },
+      },
+      calculated_cost: {
+        type: CalculatedCostType,
+        args: {
+          bid_amount_cents: {
+            type: GraphQLInt,
+            description: "Max bid price for the sale artwork",
+          },
+        },
+        resolve: (_params, { bid_amount_cents }, _loaders) => {
+          return {
+            buyers_premium: {
+              cents: bid_amount_cents * 0.2,
+              display: `$${((bid_amount_cents * 0.2) / 100)
+                .toFixed(2)
+                .replace(/\d(?=(\d{3})+\.)/g, "$&,")}`,
+            },
+            subtotal: {
+              cents: bid_amount_cents * 1.2,
+              display: `$${((bid_amount_cents * 1.2) / 100)
+                .toFixed(2)
+                .replace(/\d(?=(\d{3})+\.)/g, "$&,")}`,
+            },
+          }
         },
       },
       symbol: {

--- a/src/schema/v1/sale_artwork.ts
+++ b/src/schema/v1/sale_artwork.ts
@@ -371,25 +371,25 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
           return saleLoader(sale_id)
         },
       },
-      calculated_cost: {
+      calculatedCost: {
         type: CalculatedCostType,
         args: {
-          bid_amount_cents: {
+          bidAmountCents: {
             type: GraphQLInt,
             description: "Max bid price for the sale artwork",
           },
         },
-        resolve: (_params, { bid_amount_cents }, _loaders) => {
+        resolve: (_params, { bidAmountCents }, _loaders) => {
           return {
-            buyers_premium: {
-              cents: bid_amount_cents * 0.2,
-              display: `$${((bid_amount_cents * 0.2) / 100)
+            buyersPremium: {
+              cents: bidAmountCents * 0.2,
+              display: `$${((bidAmountCents * 0.2) / 100)
                 .toFixed(2)
                 .replace(/\d(?=(\d{3})+\.)/g, "$&,")}`,
             },
             subtotal: {
-              cents: bid_amount_cents * 1.2,
-              display: `$${((bid_amount_cents * 1.2) / 100)
+              cents: bidAmountCents * 1.2,
+              display: `$${((bidAmountCents * 1.2) / 100)
                 .toFixed(2)
                 .replace(/\d(?=(\d{3})+\.)/g, "$&,")}`,
             },

--- a/src/schema/v1/types/calculated_cost.ts
+++ b/src/schema/v1/types/calculated_cost.ts
@@ -5,9 +5,9 @@ import money from "../fields/money"
 export const CalculatedCostType = new GraphQLObjectType<any, ResolverContext>({
   name: "CalculatedCost",
   fields: {
-    buyers_premium: money({
+    buyersPremium: money({
       name: "BuyersPremiumAmount",
-      resolve: ({ buyers_premium }) => buyers_premium,
+      resolve: ({ buyersPremium }) => buyersPremium,
     }),
     subtotal: money({
       name: "SubtotalAmount",

--- a/src/schema/v1/types/calculated_cost.ts
+++ b/src/schema/v1/types/calculated_cost.ts
@@ -1,0 +1,17 @@
+import { GraphQLObjectType } from "graphql"
+import { ResolverContext } from "types/graphql"
+import money from "../fields/money"
+
+export const CalculatedCostType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CalculatedCost",
+  fields: {
+    buyers_premium: money({
+      name: "BuyersPremiumAmount",
+      resolve: ({ buyers_premium }) => buyers_premium,
+    }),
+    subtotal: money({
+      name: "SubtotalAmount",
+      resolve: ({ subtotal }) => subtotal,
+    }),
+  },
+})

--- a/src/schema/v2/__tests__/sale_artwork.test.js
+++ b/src/schema/v2/__tests__/sale_artwork.test.js
@@ -459,4 +459,46 @@ describe("SaleArtwork type", () => {
       ])
     })
   })
+
+  describe("calculatedCost", () => {
+    it("returns calculatedCost", async () => {
+      const query = gql`
+        {
+          node(id: "${toGlobalId("SaleArtwork", "54c7ed2a7261692bfa910200")}") {
+            ... on SaleArtwork {
+              calculatedCost(bidAmountCents: 1000000) {
+                buyersPremium {
+                  cents
+                  display
+                }
+                subtotal {
+                  cents
+                  display
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const data = await execute(query, saleArtwork, {
+        saleArtworkRootLoader: () => Promise.resolve(saleArtwork),
+      })
+
+      expect(data).toEqual({
+        node: {
+          calculatedCost: {
+            buyersPremium: {
+              cents: 200000,
+              display: "$2,000.00",
+            },
+            subtotal: {
+              cents: 1200000,
+              display: "$12,000.00",
+            },
+          },
+        },
+      })
+    })
+  })
 })

--- a/src/schema/v2/sale_artwork.ts
+++ b/src/schema/v2/sale_artwork.ts
@@ -7,6 +7,7 @@ import { formatMoney } from "accounting"
 import numeral from "./fields/numeral"
 import Artwork from "./artwork"
 import Sale from "./sale"
+import { CalculatedCostType } from "./types/calculated_cost"
 import {
   GravityIDFields,
   SlugAndInternalIDFields,
@@ -314,6 +315,31 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ sale, sale_id }, _options, { saleLoader }) => {
           if (!!sale) return sale
           return saleLoader(sale_id)
+        },
+      },
+      calculatedCost: {
+        type: CalculatedCostType,
+        args: {
+          bidAmountCents: {
+            type: GraphQLInt,
+            description: "Max bid price for the sale artwork",
+          },
+        },
+        resolve: (_params, { bidAmountCents }, _loaders) => {
+          return {
+            buyersPremium: {
+              cents: bidAmountCents * 0.2,
+              display: `$${((bidAmountCents * 0.2) / 100)
+                .toFixed(2)
+                .replace(/\d(?=(\d{3})+\.)/g, "$&,")}`,
+            },
+            subtotal: {
+              cents: bidAmountCents * 1.2,
+              display: `$${((bidAmountCents * 1.2) / 100)
+                .toFixed(2)
+                .replace(/\d(?=(\d{3})+\.)/g, "$&,")}`,
+            },
+          }
         },
       },
       symbol: {

--- a/src/schema/v2/types/calculated_cost.ts
+++ b/src/schema/v2/types/calculated_cost.ts
@@ -1,0 +1,17 @@
+import { GraphQLObjectType } from "graphql"
+import { ResolverContext } from "types/graphql"
+import money from "../fields/money"
+
+export const CalculatedCostType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CalculatedCost",
+  fields: {
+    buyersPremium: money({
+      name: "BuyersPremiumAmount",
+      resolve: ({ buyersPremium }) => buyersPremium,
+    }),
+    subtotal: money({
+      name: "SubtotalAmount",
+      resolve: ({ subtotal }) => subtotal,
+    }),
+  },
+})


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/AUCT-671

This PR adds a new `calculatedCost` field to the `SaleArtwork` type. The actual logic that does the math isn't implemented yet, but this should allow us to work on GraphQL clients since they need the schema to be updated.

## Query

![Screen Shot 2019-10-18 at 1 05 56 PM](https://user-images.githubusercontent.com/386234/67115728-dc0cb500-f1ac-11e9-8359-3fda72820c29.png)
