### PR TITLE
Updated list price to use new Price type

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -7393,7 +7393,7 @@ type LatLng {
   lng: Float
 }
 
-union ListPrice = PriceRange | Price
+union ListPrice = PriceRange | Money
 
 type Location {
   # A globally unique ID.
@@ -7895,6 +7895,20 @@ type Metaphysics {
   stitchingGravity: Boolean!
   stitchingKaws: Boolean!
   environment: String!
+}
+
+type Money {
+  # An amount of money expressed in minor units (like cents).
+  minor: Int!
+
+  # The ISO-4217 alphabetic currency code, as per https://en.wikipedia.org/wiki/ISO_4217
+  currencyCode: String!
+
+  # A pre-formatted price.
+  display: String
+
+  # An amount of money expressed in major units (like dollars).
+  major: Float!
 }
 
 input MoneyInput {
@@ -9620,20 +9634,6 @@ type PopularArtists {
   artists: [Artist]
 }
 
-type Price {
-  # An amount of money expressed in minor units (like cents).
-  minor: Int!
-
-  # The ISO-4217 alphabetic currency code, as per https://en.wikipedia.org/wiki/ISO_4217
-  currencyCode: String!
-
-  # A pre-formatted price.
-  display: String
-
-  # An amount of money expressed in major units (like dollars).
-  major: Float!
-}
-
 type PriceCents {
   min: Int
   max: Int
@@ -9642,8 +9642,8 @@ type PriceCents {
 
 type PriceRange {
   display: String
-  minPrice: Price
-  maxPrice: Price
+  minPrice: Money
+  maxPrice: Money
 }
 
 type Profile {

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -9621,8 +9621,8 @@ type PopularArtists {
 }
 
 type Price {
-  # An amount of money expressed in cents (minor units).
-  cents: Float
+  # An amount of money expressed in minor units (like cents).
+  minorUnits: Float
 
   # The ISO-4217 alphabetic currency code, as per https://en.wikipedia.org/wiki/ISO_4217
   currency: String
@@ -9630,8 +9630,8 @@ type Price {
   # A pre-formatted price.
   display: String
 
-  # An amount of money expressed in dollars (major units).
-  dollars: Float
+  # An amount of money expressed in major units (like dollars).
+  majorUnits: Float
 }
 
 type PriceCents {

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -9622,16 +9622,16 @@ type PopularArtists {
 
 type Price {
   # An amount of money expressed in minor units (like cents).
-  minor: Float
+  minor: Int!
 
   # The ISO-4217 alphabetic currency code, as per https://en.wikipedia.org/wiki/ISO_4217
-  currencyCode: String
+  currencyCode: String!
 
   # A pre-formatted price.
   display: String
 
   # An amount of money expressed in major units (like dollars).
-  major: Float
+  major: Float!
 }
 
 type PriceCents {

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -9622,16 +9622,16 @@ type PopularArtists {
 
 type Price {
   # An amount of money expressed in minor units (like cents).
-  minorUnits: Float
+  minor: Float
 
   # The ISO-4217 alphabetic currency code, as per https://en.wikipedia.org/wiki/ISO_4217
-  currency: String
+  currencyCode: String
 
   # A pre-formatted price.
   display: String
 
   # An amount of money expressed in major units (like dollars).
-  majorUnits: Float
+  major: Float
 }
 
 type PriceCents {

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -5448,7 +5448,8 @@ enum EventStatus {
 }
 
 type ExactPrice {
-  priceCents: Int!
+  priceCents: Int! @deprecated(reason: "Prefer usage of price")
+  price: Price
 }
 
 type ExternalPartner {
@@ -9624,6 +9625,20 @@ type PopularArtists {
   artists: [Artist]
 }
 
+type Price {
+  # An amount of money expressed in cents (minor units).
+  cents: Float
+
+  # The ISO-4217 alphabetic currency code, as per https://en.wikipedia.org/wiki/ISO_4217
+  currency: String
+
+  # A pre-formatted price.
+  display: String
+
+  # An amount of money expressed in dollars (major units).
+  dollars: Float
+}
+
 type PriceCents {
   min: Int
   max: Int
@@ -9631,8 +9646,11 @@ type PriceCents {
 }
 
 type PriceRange {
-  minPriceCents: Int!
-  maxPriceCents: Int!
+  display: String
+  minPriceCents: Int! @deprecated(reason: "Prefer usage of minPrice")
+  minPrice: Price
+  maxPrice: Price
+  maxPriceCents: Int! @deprecated(reason: "Prefer usage of maxPrice")
 }
 
 type Profile {

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -5447,11 +5447,6 @@ enum EventStatus {
   RUNNING_AND_UPCOMING
 }
 
-type ExactPrice {
-  priceCents: Int! @deprecated(reason: "Prefer usage of price")
-  price: Price
-}
-
 type ExternalPartner {
   # A globally unique ID.
   __id: ID!
@@ -7398,7 +7393,7 @@ type LatLng {
   lng: Float
 }
 
-union ListPrice = PriceRange | ExactPrice
+union ListPrice = PriceRange | Price
 
 type Location {
   # A globally unique ID.
@@ -9647,10 +9642,8 @@ type PriceCents {
 
 type PriceRange {
   display: String
-  minPriceCents: Int! @deprecated(reason: "Prefer usage of minPrice")
   minPrice: Price
   maxPrice: Price
-  maxPriceCents: Int! @deprecated(reason: "Prefer usage of maxPrice")
 }
 
 type Profile {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3615,7 +3615,8 @@ enum EventStatus {
 }
 
 type ExactPrice {
-  priceCents: Int!
+  priceCents: Int! @deprecated(reason: "Prefer usage of price")
+  price: Price
 }
 
 type ExternalPartner {
@@ -5473,9 +5474,26 @@ type PopularArtists {
   artists: [Artist]
 }
 
+type Price {
+  # An amount of money expressed in cents (minor units).
+  cents: Float
+
+  # The ISO-4217 alphabetic currency code, as per https://en.wikipedia.org/wiki/ISO_4217
+  currency: String
+
+  # A pre-formatted price.
+  display: String
+
+  # An amount of money expressed in dollars (major units).
+  dollars: Float
+}
+
 type PriceRange {
-  minPriceCents: Int!
-  maxPriceCents: Int!
+  display: String
+  minPriceCents: Int! @deprecated(reason: "Prefer usage of minPrice")
+  minPrice: Price
+  maxPrice: Price
+  maxPriceCents: Int! @deprecated(reason: "Prefer usage of maxPrice")
 }
 
 type Profile {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5471,16 +5471,16 @@ type PopularArtists {
 
 type Price {
   # An amount of money expressed in minor units (like cents).
-  minor: Float
+  minor: Int!
 
   # The ISO-4217 alphabetic currency code, as per https://en.wikipedia.org/wiki/ISO_4217
-  currencyCode: String
+  currencyCode: String!
 
   # A pre-formatted price.
   display: String
 
   # An amount of money expressed in major units (like dollars).
-  major: Float
+  major: Float!
 }
 
 type PriceRange {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3614,11 +3614,6 @@ enum EventStatus {
   RUNNING_AND_UPCOMING
 }
 
-type ExactPrice {
-  priceCents: Int! @deprecated(reason: "Prefer usage of price")
-  price: Price
-}
-
 type ExternalPartner {
   # A globally unique ID.
   id: ID!
@@ -4590,7 +4585,7 @@ type LatLng {
   lng: Float
 }
 
-union ListPrice = PriceRange | ExactPrice
+union ListPrice = PriceRange | Price
 
 type Location {
   # A globally unique ID.
@@ -5490,10 +5485,8 @@ type Price {
 
 type PriceRange {
   display: String
-  minPriceCents: Int! @deprecated(reason: "Prefer usage of minPrice")
   minPrice: Price
   maxPrice: Price
-  maxPriceCents: Int! @deprecated(reason: "Prefer usage of maxPrice")
 }
 
 type Profile {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5471,16 +5471,16 @@ type PopularArtists {
 
 type Price {
   # An amount of money expressed in minor units (like cents).
-  minorUnits: Float
+  minor: Float
 
   # The ISO-4217 alphabetic currency code, as per https://en.wikipedia.org/wiki/ISO_4217
-  currency: String
+  currencyCode: String
 
   # A pre-formatted price.
   display: String
 
   # An amount of money expressed in major units (like dollars).
-  majorUnits: Float
+  major: Float
 }
 
 type PriceRange {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5470,8 +5470,8 @@ type PopularArtists {
 }
 
 type Price {
-  # An amount of money expressed in cents (minor units).
-  cents: Float
+  # An amount of money expressed in minor units (like cents).
+  minorUnits: Float
 
   # The ISO-4217 alphabetic currency code, as per https://en.wikipedia.org/wiki/ISO_4217
   currency: String
@@ -5479,8 +5479,8 @@ type Price {
   # A pre-formatted price.
   display: String
 
-  # An amount of money expressed in dollars (major units).
-  dollars: Float
+  # An amount of money expressed in major units (like dollars).
+  majorUnits: Float
 }
 
 type PriceRange {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4585,7 +4585,7 @@ type LatLng {
   lng: Float
 }
 
-union ListPrice = PriceRange | Price
+union ListPrice = PriceRange | Money
 
 type Location {
   # A globally unique ID.
@@ -4979,6 +4979,20 @@ type MetaphysicsService {
   stitchingGravity: Boolean!
   stitchingKaws: Boolean!
   environment: String!
+}
+
+type Money {
+  # An amount of money expressed in minor units (like cents).
+  minor: Int!
+
+  # The ISO-4217 alphabetic currency code, as per https://en.wikipedia.org/wiki/ISO_4217
+  currencyCode: String!
+
+  # A pre-formatted price.
+  display: String
+
+  # An amount of money expressed in major units (like dollars).
+  major: Float!
 }
 
 type Mutation {
@@ -5469,24 +5483,10 @@ type PopularArtists {
   artists: [Artist]
 }
 
-type Price {
-  # An amount of money expressed in minor units (like cents).
-  minor: Int!
-
-  # The ISO-4217 alphabetic currency code, as per https://en.wikipedia.org/wiki/ISO_4217
-  currencyCode: String!
-
-  # A pre-formatted price.
-  display: String
-
-  # An amount of money expressed in major units (like dollars).
-  major: Float!
-}
-
 type PriceRange {
   display: String
-  minPrice: Price
-  maxPrice: Price
+  minPrice: Money
+  maxPrice: Money
 }
 
 type Profile {

--- a/src/lib/stitching/vortex/stitching.ts
+++ b/src/lib/stitching/vortex/stitching.ts
@@ -10,7 +10,7 @@ const getMaxPrice = (thing: { listPrice: any }) => {
   if (!thing.listPrice) {
     return 0
   }
-  return thing.listPrice.priceCents || thing.listPrice.maxPriceCents
+  return thing.listPrice.cents || thing.listPrice.maxPrice.cents
 }
 
 export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
@@ -113,22 +113,30 @@ export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
               listPrice {
                 __typename
                 ... on PriceRange {
-                  minPriceCents
-                  maxPriceCents
+                  minPrice {
+                    cents
+                  }
+                  maxPrice {
+                    cents
+                  }
                 }
-                ... on ExactPrice {
-                  priceCents
+                ... on Price {
+                  cents
                 }
               }
             }
             listPrice {
               __typename
               ... on PriceRange {
-                minPriceCents
-                maxPriceCents
+                minPrice {
+                  cents
+                }
+                maxPrice {
+                  cents
+                }
               }
-              ... on ExactPrice {
-                priceCents
+              ... on Price {
+                cents
               }
             }
             artist {

--- a/src/lib/stitching/vortex/stitching.ts
+++ b/src/lib/stitching/vortex/stitching.ts
@@ -10,7 +10,7 @@ const getMaxPrice = (thing: { listPrice: any }) => {
   if (!thing.listPrice) {
     return 0
   }
-  return thing.listPrice.cents || thing.listPrice.maxPrice.cents
+  return thing.listPrice.minorUnits || thing.listPrice.maxPrice.minorUnits
 }
 
 export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
@@ -114,14 +114,14 @@ export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
                 __typename
                 ... on PriceRange {
                   minPrice {
-                    cents
+                    minorUnits
                   }
                   maxPrice {
-                    cents
+                    minorUnits
                   }
                 }
                 ... on Price {
-                  cents
+                  minorUnits
                 }
               }
             }
@@ -129,14 +129,14 @@ export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
               __typename
               ... on PriceRange {
                 minPrice {
-                  cents
+                  minorUnits
                 }
                 maxPrice {
-                  cents
+                  minorUnits
                 }
               }
               ... on Price {
-                cents
+                minorUnits
               }
             }
             artist {

--- a/src/lib/stitching/vortex/stitching.ts
+++ b/src/lib/stitching/vortex/stitching.ts
@@ -10,7 +10,7 @@ const getMaxPrice = (thing: { listPrice: any }) => {
   if (!thing.listPrice) {
     return 0
   }
-  return thing.listPrice.minorUnits || thing.listPrice.maxPrice.minorUnits
+  return thing.listPrice.minor || thing.listPrice.maxPrice.minor
 }
 
 export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
@@ -114,14 +114,14 @@ export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
                 __typename
                 ... on PriceRange {
                   minPrice {
-                    minorUnits
+                    minor
                   }
                   maxPrice {
-                    minorUnits
+                    minor
                   }
                 }
                 ... on Price {
-                  minorUnits
+                  minor
                 }
               }
             }
@@ -129,14 +129,14 @@ export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
               __typename
               ... on PriceRange {
                 minPrice {
-                  minorUnits
+                  minor
                 }
                 maxPrice {
-                  minorUnits
+                  minor
                 }
               }
               ... on Price {
-                minorUnits
+                minor
               }
             }
             artist {

--- a/src/schema/v1/artwork/__tests__/artwork.test.js
+++ b/src/schema/v1/artwork/__tests__/artwork.test.js
@@ -361,9 +361,8 @@ describe("Artwork type", () => {
         artwork(id: "richard-prince-untitled-portrait") {
           listPrice {
             ... on Price {
-      
-              cents
-              dollars
+              minorUnits 
+              majorUnits
               display
               currency
              
@@ -371,16 +370,16 @@ describe("Artwork type", () => {
             ... on PriceRange {
               display
               minPrice {
-                cents
+                minorUnits
+                majorUnits
                 currency
                 display
-                dollars
               }
               maxPrice {
-                cents
+                minorUnits
+                majorUnits
                 currency
                 display
-                dollars
               }
             }
           }
@@ -397,8 +396,8 @@ describe("Artwork type", () => {
         expect(data).toEqual({
           artwork: {
             listPrice: {
-              cents: 42000,
-              dollars: 420,
+              minorUnits: 42000,
+              majorUnits: 420,
               display: "$420",
               currency: "USD",
             },
@@ -419,8 +418,8 @@ describe("Artwork type", () => {
               display: "Under $420",
               minPrice: null,
               maxPrice: {
-                cents: 42000,
-                dollars: 420,
+                minorUnits: 42000,
+                majorUnits: 420,
                 display: null,
                 currency: "USD",
               },
@@ -441,8 +440,8 @@ describe("Artwork type", () => {
             listPrice: {
               display: "Starting at $420",
               minPrice: {
-                cents: 42000,
-                dollars: 420,
+                minorUnits: 42000,
+                majorUnits: 420,
                 display: null,
                 currency: "USD",
               },

--- a/src/schema/v1/artwork/__tests__/artwork.test.js
+++ b/src/schema/v1/artwork/__tests__/artwork.test.js
@@ -361,24 +361,24 @@ describe("Artwork type", () => {
         artwork(id: "richard-prince-untitled-portrait") {
           listPrice {
             ... on Price {
-              minorUnits 
-              majorUnits
+              minor 
+              major
               display
-              currency
+              currencyCode
              
             }
             ... on PriceRange {
               display
               minPrice {
-                minorUnits
-                majorUnits
-                currency
+                minor
+                major
+                currencyCode
                 display
               }
               maxPrice {
-                minorUnits
-                majorUnits
-                currency
+                minor
+                major
+                currencyCode
                 display
               }
             }
@@ -396,10 +396,10 @@ describe("Artwork type", () => {
         expect(data).toEqual({
           artwork: {
             listPrice: {
-              minorUnits: 42000,
-              majorUnits: 420,
+              minor: 42000,
+              major: 420,
               display: "$420",
-              currency: "USD",
+              currencyCode: "USD",
             },
           },
         })
@@ -418,10 +418,10 @@ describe("Artwork type", () => {
               display: "Under $420",
               minPrice: null,
               maxPrice: {
-                minorUnits: 42000,
-                majorUnits: 420,
+                minor: 42000,
+                major: 420,
                 display: null,
-                currency: "USD",
+                currencyCode: "USD",
               },
             },
           },
@@ -440,10 +440,10 @@ describe("Artwork type", () => {
             listPrice: {
               display: "Starting at $420",
               minPrice: {
-                minorUnits: 42000,
-                majorUnits: 420,
+                minor: 42000,
+                major: 420,
                 display: null,
-                currency: "USD",
+                currencyCode: "USD",
               },
               maxPrice: null,
             },

--- a/src/schema/v1/artwork/__tests__/artwork.test.js
+++ b/src/schema/v1/artwork/__tests__/artwork.test.js
@@ -355,6 +355,105 @@ describe("Artwork type", () => {
     })
   })
 
+  describe("#listPrice", () => {
+    const query = `
+    {
+        artwork(id: "richard-prince-untitled-portrait") {
+          listPrice {
+            ... on Price {
+      
+              cents
+              dollars
+              display
+              currency
+             
+            }
+            ... on PriceRange {
+              display
+              minPrice {
+                cents
+                currency
+                display
+                dollars
+              }
+              maxPrice {
+                cents
+                currency
+                display
+                dollars
+              }
+            }
+          }
+        }
+      }
+    `
+
+    it("returns correct data for an exact priced work", () => {
+      // Exact priced at $420
+      artwork.price_cents = [42000]
+      artwork.price = "$420"
+      artwork.price_currency = "USD"
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            listPrice: {
+              cents: 42000,
+              dollars: 420,
+              display: "$420",
+              currency: "USD",
+            },
+          },
+        })
+      })
+    })
+
+    it("returns correct data for an 'Under X' priced work", () => {
+      // Priced at under $420
+      artwork.price_cents = [null, 42000]
+      artwork.price = "Under $420"
+      artwork.price_currency = "USD"
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            listPrice: {
+              display: "Under $420",
+              minPrice: null,
+              maxPrice: {
+                cents: 42000,
+                dollars: 420,
+                display: null,
+                currency: "USD",
+              },
+            },
+          },
+        })
+      })
+    })
+
+    it("returns correct data for an 'Starting at X' priced work", () => {
+      // Priced at Starting at $420
+      artwork.price_cents = [42000, null]
+      artwork.price = "Starting at $420"
+      artwork.price_currency = "USD"
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            listPrice: {
+              display: "Starting at $420",
+              minPrice: {
+                cents: 42000,
+                dollars: 420,
+                display: null,
+                currency: "USD",
+              },
+              maxPrice: null,
+            },
+          },
+        })
+      })
+    })
+  })
+
   describe("#pickup_available", () => {
     const query = `
       {

--- a/src/schema/v1/fields/listPrice.ts
+++ b/src/schema/v1/fields/listPrice.ts
@@ -4,7 +4,7 @@ import {
   GraphQLUnionType,
   GraphQLString,
 } from "graphql"
-import { Price } from "./money"
+import { Money } from "./money"
 
 const PriceRange = new GraphQLObjectType({
   name: "PriceRange",
@@ -13,7 +13,7 @@ const PriceRange = new GraphQLObjectType({
       type: GraphQLString,
     },
     minPrice: {
-      type: Price,
+      type: Money,
       resolve: ({ minPriceCents, price_currency }) => {
         if (!minPriceCents) return null
         return {
@@ -23,7 +23,7 @@ const PriceRange = new GraphQLObjectType({
       },
     },
     maxPrice: {
-      type: Price,
+      type: Money,
       resolve: ({ maxPriceCents, price_currency }) => {
         if (!maxPriceCents) return null
         return {
@@ -38,7 +38,7 @@ const PriceRange = new GraphQLObjectType({
 export const listPrice: GraphQLFieldConfig<any, any> = {
   type: new GraphQLUnionType({
     name: "ListPrice",
-    types: [PriceRange, Price],
+    types: [PriceRange, Money],
   }),
   resolve: ({ price_cents, price, price_currency }) => {
     if (!price_cents || price_cents.length === 0) {
@@ -48,7 +48,7 @@ export const listPrice: GraphQLFieldConfig<any, any> = {
 
     return isExactPrice
       ? {
-          __typename: Price.name,
+          __typename: Money.name,
           cents: price_cents[0],
           display: price,
           currency: price_currency,

--- a/src/schema/v1/fields/listPrice.ts
+++ b/src/schema/v1/fields/listPrice.ts
@@ -4,16 +4,41 @@ import {
   GraphQLInt,
   GraphQLUnionType,
   GraphQLNonNull,
+  GraphQLString,
 } from "graphql"
+import { Price } from "./money"
 
 const PriceRange = new GraphQLObjectType({
   name: "PriceRange",
   fields: {
+    display: {
+      type: GraphQLString,
+    },
     minPriceCents: {
       type: new GraphQLNonNull(GraphQLInt),
+      deprecationReason: "Prefer usage of minPrice",
+    },
+    minPrice: {
+      type: Price,
+      resolve: ({ minPriceCents, price_currency }) => {
+        return {
+          cents: minPriceCents,
+          currency: price_currency,
+        }
+      },
+    },
+    maxPrice: {
+      type: Price,
+      resolve: ({ maxPriceCents, price_currency }) => {
+        return {
+          cents: maxPriceCents,
+          currency: price_currency,
+        }
+      },
     },
     maxPriceCents: {
       type: new GraphQLNonNull(GraphQLInt),
+      deprecationReason: "Prefer usage of maxPrice",
     },
   },
 })
@@ -23,6 +48,17 @@ const ExactPrice = new GraphQLObjectType({
   fields: {
     priceCents: {
       type: new GraphQLNonNull(GraphQLInt),
+      deprecationReason: "Prefer usage of price",
+    },
+    price: {
+      type: Price,
+      resolve: ({ price, price_cents, price_currency }) => {
+        return {
+          cents: price_cents && price_cents[0],
+          display: price,
+          currency: price_currency,
+        }
+      },
     },
   },
 })
@@ -32,7 +68,7 @@ export const listPrice: GraphQLFieldConfig<any, any> = {
     name: "ListPrice",
     types: [PriceRange, ExactPrice],
   }),
-  resolve: ({ price_cents }) => {
+  resolve: ({ price_cents, price, price_currency }) => {
     if (!price_cents || price_cents.length === 0) {
       return null
     }
@@ -40,13 +76,24 @@ export const listPrice: GraphQLFieldConfig<any, any> = {
 
     return isExactPrice
       ? {
+          // For deprecated types
           __typename: ExactPrice.name,
           priceCents: price_cents[0],
+
+          // For preferred types
+          price_cents,
+          price_currency,
+          price,
         }
       : {
+          // For deprecated types
           __typename: PriceRange.name,
           minPriceCents: price_cents[0],
           maxPriceCents: price_cents[1],
+
+          // For preferred types
+          price_currency,
+          display: price,
         }
   },
 }

--- a/src/schema/v1/fields/money.ts
+++ b/src/schema/v1/fields/money.ts
@@ -112,9 +112,10 @@ const money = ({ name, resolve }) => ({
 export const Price = new GraphQLObjectType<any, ResolverContext>({
   name: "Price",
   fields: {
-    cents: {
+    minorUnits: {
       type: GraphQLFloat,
-      description: "An amount of money expressed in cents (minor units).",
+      description: "An amount of money expressed in minor units (like cents).",
+      resolve: ({ cents }) => cents,
     },
     currency: {
       type: GraphQLString,
@@ -125,9 +126,10 @@ export const Price = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
       description: "A pre-formatted price.",
     },
-    dollars: {
+    majorUnits: {
       type: GraphQLFloat,
-      description: "An amount of money expressed in dollars (major units).",
+      description:
+        "An amount of money expressed in major units (like dollars).",
       resolve: ({ cents, currency }) => {
         const factor = currencyCodes[currency.toLowerCase()].subunit_to_unit
         // TODO: Should we round or used a fixed precision?

--- a/src/schema/v1/fields/money.ts
+++ b/src/schema/v1/fields/money.ts
@@ -113,12 +113,12 @@ export const Price = new GraphQLObjectType<any, ResolverContext>({
   name: "Price",
   fields: {
     minor: {
-      type: GraphQLFloat,
+      type: new GraphQLNonNull(GraphQLInt),
       description: "An amount of money expressed in minor units (like cents).",
       resolve: ({ cents }) => cents,
     },
     currencyCode: {
-      type: GraphQLString,
+      type: new GraphQLNonNull(GraphQLString),
       description:
         "The ISO-4217 alphabetic currency code, as per https://en.wikipedia.org/wiki/ISO_4217",
       resolve: ({ currency }) => currency,
@@ -128,7 +128,7 @@ export const Price = new GraphQLObjectType<any, ResolverContext>({
       description: "A pre-formatted price.",
     },
     major: {
-      type: GraphQLFloat,
+      type: new GraphQLNonNull(GraphQLFloat),
       description:
         "An amount of money expressed in major units (like dollars).",
       resolve: ({ cents, currency }) => {

--- a/src/schema/v1/fields/money.ts
+++ b/src/schema/v1/fields/money.ts
@@ -78,7 +78,7 @@ export const symbolFromCurrencyCode = currencyCode => {
 }
 
 /**
- * @deprecated Don't use this constructor directly. Prefer using the `Price`
+ * @deprecated Don't use this constructor directly. Prefer using the `Money`
  * type instead.
  */
 const money = ({ name, resolve }) => ({
@@ -109,8 +109,8 @@ const money = ({ name, resolve }) => ({
   }),
 })
 
-export const Price = new GraphQLObjectType<any, ResolverContext>({
-  name: "Price",
+export const Money = new GraphQLObjectType<any, ResolverContext>({
+  name: "Money",
   fields: {
     minor: {
       type: new GraphQLNonNull(GraphQLInt),

--- a/src/schema/v1/fields/money.ts
+++ b/src/schema/v1/fields/money.ts
@@ -112,21 +112,22 @@ const money = ({ name, resolve }) => ({
 export const Price = new GraphQLObjectType<any, ResolverContext>({
   name: "Price",
   fields: {
-    minorUnits: {
+    minor: {
       type: GraphQLFloat,
       description: "An amount of money expressed in minor units (like cents).",
       resolve: ({ cents }) => cents,
     },
-    currency: {
+    currencyCode: {
       type: GraphQLString,
       description:
         "The ISO-4217 alphabetic currency code, as per https://en.wikipedia.org/wiki/ISO_4217",
+      resolve: ({ currency }) => currency,
     },
     display: {
       type: GraphQLString,
       description: "A pre-formatted price.",
     },
-    majorUnits: {
+    major: {
       type: GraphQLFloat,
       description:
         "An amount of money expressed in major units (like dollars).",

--- a/src/schema/v1/fields/money.ts
+++ b/src/schema/v1/fields/money.ts
@@ -77,6 +77,10 @@ export const symbolFromCurrencyCode = currencyCode => {
     : null
 }
 
+/**
+ * @deprecated Don't use this constructor directly. Prefer using the `Price`
+ * type instead.
+ */
 const money = ({ name, resolve }) => ({
   resolve: x => x,
   type: new GraphQLObjectType<any, ResolverContext>({
@@ -103,6 +107,34 @@ const money = ({ name, resolve }) => ({
       },
     },
   }),
+})
+
+export const Price = new GraphQLObjectType<any, ResolverContext>({
+  name: "Price",
+  fields: {
+    cents: {
+      type: GraphQLFloat,
+      description: "An amount of money expressed in cents (minor units).",
+    },
+    currency: {
+      type: GraphQLString,
+      description:
+        "The ISO-4217 alphabetic currency code, as per https://en.wikipedia.org/wiki/ISO_4217",
+    },
+    display: {
+      type: GraphQLString,
+      description: "A pre-formatted price.",
+    },
+    dollars: {
+      type: GraphQLFloat,
+      description: "An amount of money expressed in dollars (major units).",
+      resolve: ({ cents, currency }) => {
+        const factor = currencyCodes[currency.toLowerCase()].subunit_to_unit
+        // TODO: Should we round or used a fixed precision?
+        return cents / factor
+      },
+    },
+  },
 })
 
 export const MoneyInput = new GraphQLInputObjectType({

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -231,24 +231,24 @@ describe("Artwork type", () => {
         artwork(id: "richard-prince-untitled-portrait") {
           listPrice {
             ... on Price {
-              minorUnits
-              majorUnits
+              minor
+              major
               display
-              currency
+              currencyCode
              
             }
             ... on PriceRange {
               display
               minPrice {
-                minorUnits
-                majorUnits
-                currency
+                minor
+                major
+                currencyCode
                 display
               }
               maxPrice {
-                minorUnits
-                majorUnits
-                currency
+                minor
+                major
+                currencyCode
                 display
               }
             }
@@ -266,10 +266,10 @@ describe("Artwork type", () => {
         expect(data).toEqual({
           artwork: {
             listPrice: {
-              minorUnits: 42000,
-              majorUnits: 420,
+              minor: 42000,
+              major: 420,
               display: "$420",
-              currency: "USD",
+              currencyCode: "USD",
             },
           },
         })
@@ -288,10 +288,10 @@ describe("Artwork type", () => {
               display: "Under $420",
               minPrice: null,
               maxPrice: {
-                minorUnits: 42000,
-                majorUnits: 420,
+                minor: 42000,
+                major: 420,
                 display: null,
-                currency: "USD",
+                currencyCode: "USD",
               },
             },
           },
@@ -310,10 +310,10 @@ describe("Artwork type", () => {
             listPrice: {
               display: "Starting at $420",
               minPrice: {
-                minorUnits: 42000,
-                majorUnits: 420,
+                minor: 42000,
+                major: 420,
                 display: null,
-                currency: "USD",
+                currencyCode: "USD",
               },
               maxPrice: null,
             },

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -231,9 +231,8 @@ describe("Artwork type", () => {
         artwork(id: "richard-prince-untitled-portrait") {
           listPrice {
             ... on Price {
-      
-              cents
-              dollars
+              minorUnits
+              majorUnits
               display
               currency
              
@@ -241,16 +240,16 @@ describe("Artwork type", () => {
             ... on PriceRange {
               display
               minPrice {
-                cents
+                minorUnits
+                majorUnits
                 currency
                 display
-                dollars
               }
               maxPrice {
-                cents
+                minorUnits
+                majorUnits
                 currency
                 display
-                dollars
               }
             }
           }
@@ -267,8 +266,8 @@ describe("Artwork type", () => {
         expect(data).toEqual({
           artwork: {
             listPrice: {
-              cents: 42000,
-              dollars: 420,
+              minorUnits: 42000,
+              majorUnits: 420,
               display: "$420",
               currency: "USD",
             },
@@ -289,8 +288,8 @@ describe("Artwork type", () => {
               display: "Under $420",
               minPrice: null,
               maxPrice: {
-                cents: 42000,
-                dollars: 420,
+                minorUnits: 42000,
+                majorUnits: 420,
                 display: null,
                 currency: "USD",
               },
@@ -311,8 +310,8 @@ describe("Artwork type", () => {
             listPrice: {
               display: "Starting at $420",
               minPrice: {
-                cents: 42000,
-                dollars: 420,
+                minorUnits: 42000,
+                majorUnits: 420,
                 display: null,
                 currency: "USD",
               },

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -225,65 +225,98 @@ describe("Artwork type", () => {
     })
   })
 
-  describe("#priceCents", () => {
+  describe("#listPrice", () => {
     const query = `
     {
-      artwork(id: "richard-prince-untitled-portrait") {
-        listPrice {
-          ... on ExactPrice {
-            priceCents
-          }
-          ... on PriceRange {
-            minPriceCents
-            maxPriceCents
+        artwork(id: "richard-prince-untitled-portrait") {
+          listPrice {
+            ... on Price {
+      
+              cents
+              dollars
+              display
+              currency
+             
+            }
+            ... on PriceRange {
+              display
+              minPrice {
+                cents
+                currency
+                display
+                dollars
+              }
+              maxPrice {
+                cents
+                currency
+                display
+                dollars
+              }
+            }
           }
         }
       }
-    }
     `
 
     it("returns correct data for an exact priced work", () => {
       // Exact priced at $420
       artwork.price_cents = [42000]
+      artwork.price = "$420"
+      artwork.price_currency = "USD"
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
             listPrice: {
-              priceCents: 42000,
+              cents: 42000,
+              dollars: 420,
+              display: "$420",
+              currency: "USD",
             },
           },
         })
       })
     })
 
-    // FIXME: fails with "Did not fetch typename for object, unable to resolve interface"
-    it.skip("returns correct data for an 'Under X' priced work", () => {
-      // Priced at Under $420
+    it("returns correct data for an 'Under X' priced work", () => {
+      // Priced at under $420
       artwork.price_cents = [null, 42000]
+      artwork.price = "Under $420"
+      artwork.price_currency = "USD"
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            priceCents: {
-              min: null,
-              max: 42000,
-              exact: false,
+            listPrice: {
+              display: "Under $420",
+              minPrice: null,
+              maxPrice: {
+                cents: 42000,
+                dollars: 420,
+                display: null,
+                currency: "USD",
+              },
             },
           },
         })
       })
     })
 
-    // FIXME: fails with "Did not fetch typename for object, unable to resolve interface"
-    it.skip("returns correct data for an 'Starting at X' priced work", () => {
+    it("returns correct data for an 'Starting at X' priced work", () => {
       // Priced at Starting at $420
       artwork.price_cents = [42000, null]
+      artwork.price = "Starting at $420"
+      artwork.price_currency = "USD"
       return runQuery(query, context).then(data => {
         expect(data).toEqual({
           artwork: {
-            priceCents: {
-              min: 42000,
-              max: null,
-              exact: false,
+            listPrice: {
+              display: "Starting at $420",
+              minPrice: {
+                cents: 42000,
+                dollars: 420,
+                display: null,
+                currency: "USD",
+              },
+              maxPrice: null,
             },
           },
         })

--- a/src/schema/v2/fields/listPrice.ts
+++ b/src/schema/v2/fields/listPrice.ts
@@ -4,7 +4,7 @@ import {
   GraphQLUnionType,
   GraphQLString,
 } from "graphql"
-import { Price } from "./money"
+import { Money } from "./money"
 
 const PriceRange = new GraphQLObjectType({
   name: "PriceRange",
@@ -13,7 +13,7 @@ const PriceRange = new GraphQLObjectType({
       type: GraphQLString,
     },
     minPrice: {
-      type: Price,
+      type: Money,
       resolve: ({ minPriceCents, price_currency }) => {
         if (!minPriceCents) return null
         return {
@@ -23,7 +23,7 @@ const PriceRange = new GraphQLObjectType({
       },
     },
     maxPrice: {
-      type: Price,
+      type: Money,
       resolve: ({ maxPriceCents, price_currency }) => {
         if (!maxPriceCents) return null
         return {
@@ -38,7 +38,7 @@ const PriceRange = new GraphQLObjectType({
 export const listPrice: GraphQLFieldConfig<any, any> = {
   type: new GraphQLUnionType({
     name: "ListPrice",
-    types: [PriceRange, Price],
+    types: [PriceRange, Money],
   }),
   resolve: ({ price_cents, price, price_currency }) => {
     if (!price_cents || price_cents.length === 0) {
@@ -48,7 +48,7 @@ export const listPrice: GraphQLFieldConfig<any, any> = {
 
     return isExactPrice
       ? {
-          __typename: Price.name,
+          __typename: Money.name,
           cents: price_cents[0],
           display: price,
           currency: price_currency,

--- a/src/schema/v2/fields/listPrice.ts
+++ b/src/schema/v2/fields/listPrice.ts
@@ -4,16 +4,41 @@ import {
   GraphQLInt,
   GraphQLUnionType,
   GraphQLNonNull,
+  GraphQLString,
 } from "graphql"
+import { Price } from "./money"
 
 const PriceRange = new GraphQLObjectType({
   name: "PriceRange",
   fields: {
+    display: {
+      type: GraphQLString,
+    },
     minPriceCents: {
       type: new GraphQLNonNull(GraphQLInt),
+      deprecationReason: "Prefer usage of minPrice",
+    },
+    minPrice: {
+      type: Price,
+      resolve: ({ minPriceCents, price_currency }) => {
+        return {
+          cents: minPriceCents,
+          currency: price_currency,
+        }
+      },
+    },
+    maxPrice: {
+      type: Price,
+      resolve: ({ maxPriceCents, price_currency }) => {
+        return {
+          cents: maxPriceCents,
+          currency: price_currency,
+        }
+      },
     },
     maxPriceCents: {
       type: new GraphQLNonNull(GraphQLInt),
+      deprecationReason: "Prefer usage of maxPrice",
     },
   },
 })
@@ -23,6 +48,17 @@ const ExactPrice = new GraphQLObjectType({
   fields: {
     priceCents: {
       type: new GraphQLNonNull(GraphQLInt),
+      deprecationReason: "Prefer usage of price",
+    },
+    price: {
+      type: Price,
+      resolve: ({ price, price_cents, price_currency }) => {
+        return {
+          cents: price_cents && price_cents[0],
+          display: price,
+          currency: price_currency,
+        }
+      },
     },
   },
 })
@@ -32,7 +68,7 @@ export const listPrice: GraphQLFieldConfig<any, any> = {
     name: "ListPrice",
     types: [PriceRange, ExactPrice],
   }),
-  resolve: ({ price_cents }) => {
+  resolve: ({ price_cents, price, price_currency }) => {
     if (!price_cents || price_cents.length === 0) {
       return null
     }
@@ -40,13 +76,24 @@ export const listPrice: GraphQLFieldConfig<any, any> = {
 
     return isExactPrice
       ? {
+          // For deprecated types
           __typename: ExactPrice.name,
           priceCents: price_cents[0],
+
+          // For preferred types
+          price_cents,
+          price_currency,
+          price,
         }
       : {
+          // For deprecated types
           __typename: PriceRange.name,
           minPriceCents: price_cents[0],
           maxPriceCents: price_cents[1],
+
+          // For preferred types
+          price_currency,
+          display: price,
         }
   },
 }

--- a/src/schema/v2/fields/money.ts
+++ b/src/schema/v2/fields/money.ts
@@ -112,9 +112,10 @@ const money = ({ name, resolve }) => ({
 export const Price = new GraphQLObjectType<any, ResolverContext>({
   name: "Price",
   fields: {
-    cents: {
+    minorUnits: {
       type: GraphQLFloat,
-      description: "An amount of money expressed in cents (minor units).",
+      description: "An amount of money expressed in minor units (like cents).",
+      resolve: ({ cents }) => cents,
     },
     currency: {
       type: GraphQLString,
@@ -125,9 +126,10 @@ export const Price = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
       description: "A pre-formatted price.",
     },
-    dollars: {
+    majorUnits: {
       type: GraphQLFloat,
-      description: "An amount of money expressed in dollars (major units).",
+      description:
+        "An amount of money expressed in major units (like dollars).",
       resolve: ({ cents, currency }) => {
         const factor = currencyCodes[currency.toLowerCase()].subunit_to_unit
         // TODO: Should we round or used a fixed precision?

--- a/src/schema/v2/fields/money.ts
+++ b/src/schema/v2/fields/money.ts
@@ -55,6 +55,7 @@ export const amount = centsResolver => ({
     const cents = centsResolver(obj)
     const symbol =
       options.symbol || obj.symbol || symbolFromCurrencyCode(obj.currencyCode)
+
     if (typeof cents !== "number") {
       return null
     }
@@ -76,6 +77,10 @@ export const symbolFromCurrencyCode = currencyCode => {
     : null
 }
 
+/**
+ * @deprecated Don't use this constructor directly. Prefer using the `Price`
+ * type instead.
+ */
 const money = ({ name, resolve }) => ({
   resolve: x => x,
   type: new GraphQLObjectType<any, ResolverContext>({
@@ -102,6 +107,34 @@ const money = ({ name, resolve }) => ({
       },
     },
   }),
+})
+
+export const Price = new GraphQLObjectType<any, ResolverContext>({
+  name: "Price",
+  fields: {
+    cents: {
+      type: GraphQLFloat,
+      description: "An amount of money expressed in cents (minor units).",
+    },
+    currency: {
+      type: GraphQLString,
+      description:
+        "The ISO-4217 alphabetic currency code, as per https://en.wikipedia.org/wiki/ISO_4217",
+    },
+    display: {
+      type: GraphQLString,
+      description: "A pre-formatted price.",
+    },
+    dollars: {
+      type: GraphQLFloat,
+      description: "An amount of money expressed in dollars (major units).",
+      resolve: ({ cents, currency }) => {
+        const factor = currencyCodes[currency.toLowerCase()].subunit_to_unit
+        // TODO: Should we round or used a fixed precision?
+        return cents / factor
+      },
+    },
+  },
 })
 
 export const MoneyInput = new GraphQLInputObjectType({

--- a/src/schema/v2/fields/money.ts
+++ b/src/schema/v2/fields/money.ts
@@ -113,12 +113,12 @@ export const Price = new GraphQLObjectType<any, ResolverContext>({
   name: "Price",
   fields: {
     minor: {
-      type: GraphQLFloat,
+      type: new GraphQLNonNull(GraphQLInt),
       description: "An amount of money expressed in minor units (like cents).",
       resolve: ({ cents }) => cents,
     },
     currencyCode: {
-      type: GraphQLString,
+      type: new GraphQLNonNull(GraphQLString),
       description:
         "The ISO-4217 alphabetic currency code, as per https://en.wikipedia.org/wiki/ISO_4217",
       resolve: ({ currency }) => currency,
@@ -128,7 +128,7 @@ export const Price = new GraphQLObjectType<any, ResolverContext>({
       description: "A pre-formatted price.",
     },
     major: {
-      type: GraphQLFloat,
+      type: new GraphQLNonNull(GraphQLFloat),
       description:
         "An amount of money expressed in major units (like dollars).",
       resolve: ({ cents, currency }) => {

--- a/src/schema/v2/fields/money.ts
+++ b/src/schema/v2/fields/money.ts
@@ -78,7 +78,7 @@ export const symbolFromCurrencyCode = currencyCode => {
 }
 
 /**
- * @deprecated Don't use this constructor directly. Prefer using the `Price`
+ * @deprecated Don't use this constructor directly. Prefer using the `Money`
  * type instead.
  */
 const money = ({ name, resolve }) => ({
@@ -109,8 +109,8 @@ const money = ({ name, resolve }) => ({
   }),
 })
 
-export const Price = new GraphQLObjectType<any, ResolverContext>({
-  name: "Price",
+export const Money = new GraphQLObjectType<any, ResolverContext>({
+  name: "Money",
   fields: {
     minor: {
       type: new GraphQLNonNull(GraphQLInt),

--- a/src/schema/v2/fields/money.ts
+++ b/src/schema/v2/fields/money.ts
@@ -112,21 +112,22 @@ const money = ({ name, resolve }) => ({
 export const Price = new GraphQLObjectType<any, ResolverContext>({
   name: "Price",
   fields: {
-    minorUnits: {
+    minor: {
       type: GraphQLFloat,
       description: "An amount of money expressed in minor units (like cents).",
       resolve: ({ cents }) => cents,
     },
-    currency: {
+    currencyCode: {
       type: GraphQLString,
       description:
         "The ISO-4217 alphabetic currency code, as per https://en.wikipedia.org/wiki/ISO_4217",
+      resolve: ({ currency }) => currency,
     },
     display: {
       type: GraphQLString,
       description: "A pre-formatted price.",
     },
-    majorUnits: {
+    major: {
       type: GraphQLFloat,
       description:
         "An amount of money expressed in major units (like dollars).",


### PR DESCRIPTION
This work was spawned from https://github.com/artsy/reaction/pull/2939. 

For structured data google needs the currency amounts of work in unformatted fields. @mzikherman and I paired on adding this field to `ListPrice` on the artwork type. The `ListPrice` only provided cents which isn't directly useful from a display perspective. We added an enhanced `Price` type.

In doing so we noticed that there were a lot of [duplicated types](https://artsy.slack.com/archives/C1HH3KNJG/p1571769864042100) because they used the [money](https://github.com/artsy/metaphysics/blob/ca2f97377170399ff86d3a91c00c284733c66979/src/schema/v1/fields/money.ts#L80) factory. Generally this is an anti-pattern because it creates duplicate types throughout the schema. We've depreciated this factory pattern in favor of using the `Price` type and we should do a follow up  to refactor those  types if they're not used in emission. (This was also discovered and discussed [here](https://github.com/artsy/metaphysics/pull/2004/files#r336697618)).

<!-- Co-authored-by: Matt Zikherman <mzikherman@gmail.com> -->