### PR TITLE
Adds dayThreshold and status to Partner shows

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5245,7 +5245,7 @@ type Partner implements Node {
     sort: ShowSorts
 
     # Filter shows by chronological event status
-    status: EventStatus = CURRENT
+    status: EventStatus
 
     # Only used when status is CLOSING_SOON or UPCOMING. Number of days used to filter upcoming and closing soon shows
     dayThreshold: Int

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5243,6 +5243,12 @@ type Partner implements Node {
   # A connection of shows from a Partner.
   showsConnection(
     sort: ShowSorts
+
+    # Filter shows by chronological event status
+    status: EventStatus = CURRENT
+
+    # Only used when status is CLOSING_SOON or UPCOMING. Number of days used to filter upcoming and closing soon shows
+    dayThreshold: Int
     after: String
     first: Int
     before: String

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -241,7 +241,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           },
           status: {
             type: EventStatus.type,
-            defaultValue: "CURRENT",
+            defaultValue: "current",
             description: "Filter shows by chronological event status",
           },
           dayThreshold: {
@@ -268,10 +268,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             page,
             size,
             sort: args.sort,
-            // default Enum value for status is not properly resolved
-            // so we have to manually resolve it by lowercasing the value
-            // https://github.com/apollographql/graphql-tools/issues/715
-            ...(args.status && { status: args.status.toLowerCase() }),
+            ...(args.status && { status: args.status }),
             ...(args.dayThreshold && { day_threshold: args.dayThreshold }),
           }
 

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -16,6 +16,7 @@ import cached from "./fields/cached"
 import initials from "./fields/initials"
 import Profile from "./profile"
 import Location from "./location"
+import EventStatus from "schema/v2/input_fields/event_status"
 import { NodeInterface, SlugAndInternalIDFields } from "./object_identification"
 import { artworkConnection } from "./artwork"
 import numeral from "./fields/numeral"
@@ -238,6 +239,16 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           sort: {
             type: ShowSorts,
           },
+          status: {
+            type: EventStatus.type,
+            defaultValue: "CURRENT",
+            description: "Filter shows by chronological event status",
+          },
+          dayThreshold: {
+            type: GraphQLInt,
+            description:
+              "Only used when status is CLOSING_SOON or UPCOMING. Number of days used to filter upcoming and closing soon shows",
+          },
         }),
         resolve: ({ id }, args, { partnerShowsLoader }) => {
           const pageOptions = convertConnectionArgsToGravityArgs(args)
@@ -248,6 +259,8 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             size: number
             total_count: boolean
             sort: string
+            status: string
+            day_threshold: number
           }
 
           const gravityArgs: GravityArgs = {
@@ -255,6 +268,11 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             page,
             size,
             sort: args.sort,
+            // default Enum value for status is not properly resolved
+            // so we have to manually resolve it by lowercasing the value
+            // https://github.com/apollographql/graphql-tools/issues/715
+            ...(args.status && { status: args.status.toLowerCase() }),
+            ...(args.dayThreshold && { day_threshold: args.dayThreshold }),
           }
 
           return partnerShowsLoader(id, gravityArgs).then(

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -268,8 +268,8 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             page,
             size,
             sort: args.sort,
-            ...(args.status && { status: args.status }),
-            ...(args.dayThreshold && { day_threshold: args.dayThreshold }),
+            status: args.status,
+            day_threshold: args.dayThreshold,
           }
 
           return partnerShowsLoader(id, gravityArgs).then(


### PR DESCRIPTION
- We need to surface Current & Upcoming, and Closed shows for the Partner page.
- This borrows from the City model's `showConnection`'s `dayThreshold` and `status` fields

<img width="1133" alt="Screen Shot 2019-10-24 at 12 39 52 PM" src="https://user-images.githubusercontent.com/21182806/67506631-6b0d4780-f65b-11e9-942e-c3f7a4ef0fdd.png">
