### PR TITLE
Adds filteredArtworksConnection to Artist type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -534,7 +534,7 @@ enum ArticleSorts {
   PUBLISHED_AT_DESC
 }
 
-type Artist implements Node & Searchable {
+type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInterface {
   # A globally unique ID.
   id: ID!
 
@@ -603,6 +603,54 @@ type Artist implements Node & Searchable {
     # The number of Shows to return
     size: Int = 5
   ): [Show]
+
+  # Artworks Elastic Search results
+  filterArtworksConnection(
+    acquireable: Boolean
+    offerable: Boolean
+    aggregationPartnerCities: [String]
+    aggregations: [ArtworkAggregation]
+    artistID: String
+    artistIDs: [String]
+    atAuction: Boolean
+    attributionClass: [String]
+    color: String
+    dimensionRange: String
+    extraAggregationGeneIDs: [String]
+    includeArtworksByFollowedArtists: Boolean
+    includeMediumFilterInAggregation: Boolean
+    inquireableOnly: Boolean
+    forSale: Boolean
+    geneID: String
+    geneIDs: [String]
+    height: String
+    width: String
+
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
+
+    # A string from the list of allocations, or * to denote all mediums
+    medium: String
+    period: String
+    periods: [String]
+    majorPeriods: [String]
+    partnerID: ID
+    partnerCities: [String]
+    priceRange: String
+    page: Int
+    saleID: ID
+    size: Int
+    sort: String
+    tagID: String
+    keyword: String
+
+    # When true, will only return exact keyword match
+    keywordMatchExact: Boolean
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): FilterArtworksConnection
 
   # A string showing the total number of works and those for sale
   formattedArtworksCount: String

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -80,11 +80,23 @@ export const artistArtworkArrayLength = (artist, filter) => {
 
 export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
   name: "Artist",
-  interfaces: [NodeInterface, Searchable],
+  interfaces: () => {
+    const {
+      EntityWithFilterArtworksConnectionInterface,
+    } = require("../filterArtworksConnection")
+    return [
+      NodeInterface,
+      Searchable,
+      EntityWithFilterArtworksConnectionInterface,
+    ]
+  },
   fields: () => {
     const {
       PartnerArtistConnection,
     } = require("schema/v2/partnerArtistConnection")
+    const {
+      filterArtworksConnectionWithParams,
+    } = require("../filterArtworksConnection")
     return {
       ...SlugAndInternalIDFields,
       cached,
@@ -448,6 +460,11 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
           )
         },
       },
+      filterArtworksConnection: filterArtworksConnectionWithParams(
+        ({ _id }) => ({
+          artist_id: _id,
+        })
+      ),
       formattedArtworksCount: {
         type: GraphQLString,
         description:

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -35,7 +35,6 @@ import {
   AuctionResultSorts,
 } from "schema/v2/auction_result"
 import ArtistArtworksFilters from "./artwork_filters"
-import { Searchable } from "schema/v2/searchable"
 import { connectionWithCursorInfo } from "schema/v2/fields/pagination"
 import { Related } from "./related"
 import { createPageCursors } from "schema/v2/fields/pagination"
@@ -43,10 +42,7 @@ import {
   showsWithDenyListedPartnersRemoved,
   ShowsConnectionField,
 } from "./shows"
-import {
-  NodeInterface,
-  SlugAndInternalIDFields,
-} from "schema/v2/object_identification"
+import { SlugAndInternalIDFields } from "schema/v2/object_identification"
 import {
   GraphQLObjectType,
   GraphQLBoolean,
@@ -84,6 +80,8 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
     const {
       EntityWithFilterArtworksConnectionInterface,
     } = require("../filterArtworksConnection")
+    const { Searchable } = require("schema/v2/searchable")
+    const { NodeInterface } = require("schema/v2/object_identification")
     return [
       NodeInterface,
       Searchable,


### PR DESCRIPTION
Works locally, and I confirmed these are the same artworks as displayed on staging:

![Screen Shot 2019-10-25 at 12 30 27](https://user-images.githubusercontent.com/498212/67588094-3f559480-f723-11e9-9fe3-4ccaeddaab65.png)

I'm open to feedback on the tests – I tried to test the integration with the existing `filterArtworksConnection` rather than test the `filterArtworksConnection` itself. An inline snapshot works for me, but again, open to feedback 👍 

This is related to work on [ME-65](https://artsyproduct.atlassian.net/browse/ME-65).