### PR TITLE
Update SaleArtwork#calculatedCost to run calculation via Gravity

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3028,25 +3028,6 @@ type BuyersPremium {
   percent: Float
 }
 
-type BuyersPremiumAmount {
-  # A formatted price with various currency formatting options.
-  amount(
-    decimal: String = "."
-
-    # Allows control of symbol position (%v = value, %s = symbol)
-    format: String = "%s%v"
-    precision: Int = 0
-    symbol: String
-    thousand: String = ","
-  ): String
-
-  # An amount of money expressed in cents.
-  cents: Float
-
-  # A pre-formatted price.
-  display: String
-}
-
 type BuyOrder implements Order {
   # A globally unique ID.
   __id: ID!
@@ -3258,8 +3239,9 @@ type BuyOrder implements Order {
 }
 
 type CalculatedCost {
-  buyersPremium: BuyersPremiumAmount
-  subtotal: SubtotalAmount
+  bidAmount: Money
+  buyersPremium: Money
+  subtotal: Money
 }
 
 enum CancelReasonType {
@@ -10619,7 +10601,7 @@ type SaleArtwork {
   sale: Sale
   calculatedCost(
     # Max bid price for the sale artwork
-    bidAmountCents: Int
+    bidAmountMinor: Int!
   ): CalculatedCost
 
   # Currency symbol (e.g. "$")
@@ -11546,25 +11528,6 @@ input submitPendingOfferInput {
 type submitPendingOfferPayload {
   orderOrError: OrderOrFailureUnionType
   clientMutationId: String
-}
-
-type SubtotalAmount {
-  # A formatted price with various currency formatting options.
-  amount(
-    decimal: String = "."
-
-    # Allows control of symbol position (%v = value, %s = symbol)
-    format: String = "%s%v"
-    precision: Int = 0
-    symbol: String
-    thousand: String = ","
-  ): String
-
-  # An amount of money expressed in cents.
-  cents: Float
-
-  # A pre-formatted price.
-  display: String
 }
 
 type System {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1584,28 +1584,10 @@ type BuyersPremium {
   percent: Float
 }
 
-type BuyersPremiumAmount {
-  # A formatted price with various currency formatting options.
-  amount(
-    decimal: String = "."
-
-    # Allows control of symbol position (%v = value, %s = symbol)
-    format: String = "%s%v"
-    precision: Int = 0
-    symbol: String
-    thousand: String = ","
-  ): String
-
-  # An amount of money expressed in cents.
-  cents: Float
-
-  # A pre-formatted price.
-  display: String
-}
-
 type CalculatedCost {
-  buyersPremium: BuyersPremiumAmount
-  subtotal: SubtotalAmount
+  bidAmount: Money
+  buyersPremium: Money
+  subtotal: Money
 }
 
 type City {
@@ -5997,7 +5979,7 @@ type SaleArtwork implements Node & ArtworkEdgeInterface {
   sale: Sale
   calculatedCost(
     # Max bid price for the sale artwork
-    bidAmountCents: Int
+    bidAmountMinor: Int!
   ): CalculatedCost
 
   # Currency symbol (e.g. "$")
@@ -6776,25 +6758,6 @@ enum SubmissionStateAggregation {
   SUBMITTED
   APPROVED
   REJECTED
-}
-
-type SubtotalAmount {
-  # A formatted price with various currency formatting options.
-  amount(
-    decimal: String = "."
-
-    # Allows control of symbol position (%v = value, %s = symbol)
-    format: String = "%s%v"
-    precision: Int = 0
-    symbol: String
-    thousand: String = ","
-  ): String
-
-  # An amount of money expressed in cents.
-  cents: Float
-
-  # A pre-formatted price.
-  display: String
 }
 
 type System {

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -67,6 +67,10 @@ export default opts => {
     saleArtworksFilterLoader: gravityLoader("filter/sale_artworks"),
     saleArtworksLoader: gravityLoader(id => `sale/${id}/sale_artworks`, {}, { headers: true }),
     saleArtworkLoader: gravityUncachedLoader<any, { saleId: string, saleArtworkId: string }>(({ saleId, saleArtworkId }) => `sale/${saleId}/sale_artwork/${saleArtworkId}`, null),
+    saleArtworkCalculatedCostLoader: gravityLoader<any, { saleId: string, saleArtworkId: string, bidAmountMinor: number }>(
+      ({ saleId, saleArtworkId, bidAmountMinor }) =>
+        `sale/${saleId}/sale_artwork/${saleArtworkId}/calculated_cost?bid_amount_cents=${bidAmountMinor}`
+    ),
     saleLoader: batchSaleLoader,
     salesLoader: batchSalesLoader,
     salesLoaderWithHeaders: gravityLoader('sales', {}, { headers: true }),

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -14,6 +14,16 @@ export default opts => {
     multipleLoader: gravityLoader<{ id: string, is_auction: boolean }[]>('sales')
   })
 
+  type GravityCalculatedCostResponse = {
+    display_bid_amount: string
+    bid_amount_cents: number
+    buyers_premium_cents: number
+    display_buyers_premium: string
+    subtotal_cents: number
+    display_subtotal: string
+    currency: string
+  }
+
   return {
     artistArtworksLoader: gravityLoader(id => `artist/${id}/artworks`),
     artistGenesLoader: gravityLoader(id => `artist/${id}/genome/genes`),
@@ -67,7 +77,7 @@ export default opts => {
     saleArtworksFilterLoader: gravityLoader("filter/sale_artworks"),
     saleArtworksLoader: gravityLoader(id => `sale/${id}/sale_artworks`, {}, { headers: true }),
     saleArtworkLoader: gravityUncachedLoader<any, { saleId: string, saleArtworkId: string }>(({ saleId, saleArtworkId }) => `sale/${saleId}/sale_artwork/${saleArtworkId}`, null),
-    saleArtworkCalculatedCostLoader: gravityLoader<any, { saleId: string, saleArtworkId: string, bidAmountMinor: number }>(
+    saleArtworkCalculatedCostLoader: gravityLoader<GravityCalculatedCostResponse, { saleId: string, saleArtworkId: string, bidAmountMinor: number }>(
       ({ saleId, saleArtworkId, bidAmountMinor }) =>
         `sale/${saleId}/sale_artwork/${saleArtworkId}/calculated_cost?bid_amount_cents=${bidAmountMinor}`
     ),

--- a/src/schema/v1/__tests__/sale_artwork.test.js
+++ b/src/schema/v1/__tests__/sale_artwork.test.js
@@ -441,39 +441,69 @@ describe("SaleArtwork type", () => {
     })
   })
 
-  describe("calculated_cost", () => {
-    it("returns calculated_cost", async () => {
+  describe("calculatedCost", () => {
+    it("returns calculatedCost", async () => {
       const query = `
         {
           sale_artwork(id: "54c7ed2a7261692bfa910200") {
-            calculatedCost(bidAmountCents: 1000000) {
-              buyersPremium {
-                cents
+            calculatedCost(bidAmountMinor: 10000) {
+              bidAmount {
+                minor
+                major
                 display
+                currencyCode
+              }
+              buyersPremium {
+                minor
+                major
+                display
+                currencyCode
               }
               subtotal {
-                cents
+                minor
+                major
                 display
+                currencyCode
               }
             }
           }
         }
       `
 
+      const calculatedCost = {
+        bid_amount_cents: 10000,
+        display_bid_amount: "$100.00",
+        buyers_premium_cents: 2000,
+        display_buyers_premium: "$20.00",
+        subtotal_cents: 12000,
+        display_subtotal: "$120.00",
+        currency: "USD",
+      }
+
       const data = await execute(query, saleArtwork, {
-        saleArtworkRootLoader: () => Promise.resolve(saleArtwork),
+        saleArtworkCalculatedCostLoader: () => Promise.resolve(calculatedCost),
       })
 
       expect(data).toEqual({
         sale_artwork: {
           calculatedCost: {
+            bidAmount: {
+              minor: 10000,
+              major: 100.0,
+              display: "$100.00",
+              currencyCode: "USD",
+            },
             buyersPremium: {
-              cents: 200000,
-              display: "$2,000.00",
+              minor: 2000,
+              major: 20.0,
+              display: "$20.00",
+              currencyCode: "USD",
             },
             subtotal: {
-              cents: 1200000,
-              display: "$12,000.00",
+              minor: 12000,
+              major: 120.0,
+              display: "$120.00",
+              currencyCode: "USD",
             },
           },
         },

--- a/src/schema/v1/sale_artwork.ts
+++ b/src/schema/v1/sale_artwork.ts
@@ -26,7 +26,7 @@ import config from "config"
 import { ResolverContext } from "types/graphql"
 import { LoadersWithoutAuthentication } from "lib/loaders/loaders_without_authentication"
 import { deprecate } from "lib/deprecation"
-import { CalculatedCostType } from "./types/calculated_cost"
+import { CalculatedCost } from "./types/calculated_cost"
 
 const { BIDDER_POSITION_MAX_BID_AMOUNT_CENTS_LIMIT } = config
 
@@ -372,26 +372,39 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       calculatedCost: {
-        type: CalculatedCostType,
+        type: CalculatedCost,
         args: {
-          bidAmountCents: {
-            type: GraphQLInt,
+          bidAmountMinor: {
+            type: new GraphQLNonNull(GraphQLInt),
             description: "Max bid price for the sale artwork",
           },
         },
-        resolve: (_params, { bidAmountCents }, _loaders) => {
+        resolve: async (
+          { id, sale_id },
+          { bidAmountMinor },
+          { saleArtworkCalculatedCostLoader }
+        ) => {
+          const data = await saleArtworkCalculatedCostLoader({
+            saleId: sale_id,
+            saleArtworkId: id,
+            bidAmountMinor,
+          })
+
           return {
             buyersPremium: {
-              cents: bidAmountCents * 0.2,
-              display: `$${((bidAmountCents * 0.2) / 100)
-                .toFixed(2)
-                .replace(/\d(?=(\d{3})+\.)/g, "$&,")}`,
+              cents: data.buyers_premium_cents,
+              currency: data.currency,
+              display: data.display_buyers_premium,
             },
             subtotal: {
-              cents: bidAmountCents * 1.2,
-              display: `$${((bidAmountCents * 1.2) / 100)
-                .toFixed(2)
-                .replace(/\d(?=(\d{3})+\.)/g, "$&,")}`,
+              cents: data.subtotal_cents,
+              display: data.display_subtotal,
+              currency: data.currency,
+            },
+            bidAmount: {
+              cents: data.bid_amount_cents,
+              display: data.display_bid_amount,
+              currency: data.currency,
             },
           }
         },

--- a/src/schema/v1/types/calculated_cost.ts
+++ b/src/schema/v1/types/calculated_cost.ts
@@ -1,17 +1,21 @@
 import { GraphQLObjectType } from "graphql"
 import { ResolverContext } from "types/graphql"
-import money from "../fields/money"
+import { Money } from "schema/v1/fields/money"
 
-export const CalculatedCostType = new GraphQLObjectType<any, ResolverContext>({
+export const CalculatedCost = new GraphQLObjectType<any, ResolverContext>({
   name: "CalculatedCost",
   fields: {
-    buyersPremium: money({
-      name: "BuyersPremiumAmount",
+    bidAmount: {
+      type: Money,
+      resolve: ({ bidAmount }) => bidAmount,
+    },
+    buyersPremium: {
+      type: Money,
       resolve: ({ buyersPremium }) => buyersPremium,
-    }),
-    subtotal: money({
-      name: "SubtotalAmount",
+    },
+    subtotal: {
+      type: Money,
       resolve: ({ subtotal }) => subtotal,
-    }),
+    },
   },
 })

--- a/src/schema/v2/__tests__/sale_artwork.test.js
+++ b/src/schema/v2/__tests__/sale_artwork.test.js
@@ -466,14 +466,24 @@ describe("SaleArtwork type", () => {
         {
           node(id: "${toGlobalId("SaleArtwork", "54c7ed2a7261692bfa910200")}") {
             ... on SaleArtwork {
-              calculatedCost(bidAmountCents: 1000000) {
-                buyersPremium {
-                  cents
+              calculatedCost(bidAmountMinor: 10000) {
+                bidAmount {
+                  minor
+                  major
                   display
+                  currencyCode
+                }
+                buyersPremium {
+                  minor
+                  major
+                  display
+                  currencyCode
                 }
                 subtotal {
-                  cents
+                  minor
+                  major
                   display
+                  currencyCode
                 }
               }
             }
@@ -481,20 +491,40 @@ describe("SaleArtwork type", () => {
         }
       `
 
+      const calculatedCost = {
+        bid_amount_cents: 10000,
+        display_bid_amount: "$100.00",
+        buyers_premium_cents: 2000,
+        display_buyers_premium: "$20.00",
+        subtotal_cents: 12000,
+        display_subtotal: "$120.00",
+        currency: "USD",
+      }
+
       const data = await execute(query, saleArtwork, {
-        saleArtworkRootLoader: () => Promise.resolve(saleArtwork),
+        saleArtworkCalculatedCostLoader: () => Promise.resolve(calculatedCost),
       })
 
       expect(data).toEqual({
         node: {
           calculatedCost: {
+            bidAmount: {
+              minor: 10000,
+              major: 100.0,
+              display: "$100.00",
+              currencyCode: "USD",
+            },
             buyersPremium: {
-              cents: 200000,
-              display: "$2,000.00",
+              minor: 2000,
+              major: 20.0,
+              display: "$20.00",
+              currencyCode: "USD",
             },
             subtotal: {
-              cents: 1200000,
-              display: "$12,000.00",
+              minor: 12000,
+              major: 120.0,
+              display: "$120.00",
+              currencyCode: "USD",
             },
           },
         },

--- a/src/schema/v2/types/calculated_cost.ts
+++ b/src/schema/v2/types/calculated_cost.ts
@@ -1,17 +1,21 @@
 import { GraphQLObjectType } from "graphql"
 import { ResolverContext } from "types/graphql"
-import money from "../fields/money"
+import { Money } from "schema/v2/fields/money"
 
-export const CalculatedCostType = new GraphQLObjectType<any, ResolverContext>({
+export const CalculatedCost = new GraphQLObjectType<any, ResolverContext>({
   name: "CalculatedCost",
   fields: {
-    buyersPremium: money({
-      name: "BuyersPremiumAmount",
+    bidAmount: {
+      type: Money,
+      resolve: ({ bidAmount }) => bidAmount,
+    },
+    buyersPremium: {
+      type: Money,
       resolve: ({ buyersPremium }) => buyersPremium,
-    }),
-    subtotal: money({
-      name: "SubtotalAmount",
+    },
+    subtotal: {
+      type: Money,
       resolve: ({ subtotal }) => subtotal,
-    }),
+    },
   },
 })


### PR DESCRIPTION
Update the `calculatedCost` field on sale artworks to pull calculation
results from the Gravity API.

The following subfields are exposed:

- `bidAmount`: Echos the input provided by the client along with formatted
  results
- `buyersPremium`: The calculated buyer's premium for the bid amount
  provided
- `subtotal`: The combination of the supplied bid amount and the
  calculated buyer's premium

_Note: This does break the API contract defined along with the mock data. I think it's worth making this change now and early to align with defined naming preferences._

**Request**

```graphql
{
  sale(id: "finarte-photographs-4") {
    saleArtwork(id: "franco-fontana-paesaggio-baia-delle-zagare") {
      calculatedCost(bidAmountCents: 100000) {
        bidAmount {
          display
          minor
          currencyCode
          major
        }
        buyersPremium {
          display
          minor
          currencyCode
          major
        }
        subtotal {
          display
          minor
          currencyCode
          major
        }
      }
    }
  }
}
```

**Response**

```json

{
  "data": {
    "sale": {
      "saleArtwork": {
        "calculatedCost": {
          "bidAmount": {
            "display": "€100,000.00",
            "minor": 10000000,
            "currencyCode": "EUR",
            "major": 100000
          },
          "buyersPremium": {
            "display": "€19,237.20",
            "minor": 1923720,
            "currencyCode": "EUR",
            "major": 19237.2
          },
          "subtotal": {
            "display": "€119,237.20",
            "minor": 11923720,
            "currencyCode": "EUR",
            "major": 119237.2
          }
        }
      }
    }
  }
}
```