### PR TITLE
set --max_old_space_size via NODE_OPTIONS 

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -30,6 +30,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: NODE_OPTIONS
+              value: "--max_old_space_size=1024"
           envFrom:
             - configMapRef:
                 name: metaphysics-environment

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -30,6 +30,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: NODE_OPTIONS
+              value: "--max_old_space_size=768"
           envFrom:
             - configMapRef:
                 name: metaphysics-environment


### PR DESCRIPTION
…in Kubernetes specs in accordance with memory limits

Following up on the success of https://github.com/artsy/force/pull/4759 why not do the same in Metaphysics?

Also setting this flag via `NODE_OPTIONS` means we can keep it in Kubernetes spec files so we remember to update it when we update container mem limits.