### PR TITLE
[v2] Make Gene Searchable

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4222,7 +4222,10 @@ type GeminiEntry {
   token: String!
 }
 
-type Gene implements Node {
+type Gene implements Node & Searchable {
+  displayLabel: String
+  imageUrl: String
+
   # A globally unique ID.
   id: ID!
 

--- a/src/schema/v2/__tests__/search.test.ts
+++ b/src/schema/v2/__tests__/search.test.ts
@@ -85,6 +85,7 @@ describe("Search", () => {
     context = {
       artistLoader: () => Promise.resolve({ hometown: "London, UK" }),
       artworkLoader: () => Promise.resolve({ title: "Self Portrait" }),
+      geneLoader: () => Promise.resolve({ name: "Minimalism" }),
     }
 
     searchResponse = Promise.resolve({
@@ -297,6 +298,32 @@ describe("Search", () => {
 
       expect(artworkNode.__typename).toBe("Artwork")
       expect(artworkNode.title).toBe("Self Portrait")
+    })
+  })
+
+  it("fetches gene if Gene-specific attributes are requested", () => {
+    const query = `
+      {
+        searchConnection(query: "minimalism", first: 10) {
+          edges {
+            node {
+              __typename
+
+              ... on Gene {
+                name
+              }
+            }
+          }
+        }
+      }
+    `
+    context.searchLoader = jest.fn().mockImplementation(() => searchResponse)
+
+    return runQuery(query, context).then(data => {
+      const geneNode = data!.searchConnection.edges[5].node
+
+      expect(geneNode.__typename).toBe("Gene")
+      expect(geneNode.name).toBe("Minimalism")
     })
   })
 })

--- a/src/schema/v2/gene.ts
+++ b/src/schema/v2/gene.ts
@@ -17,6 +17,9 @@ import {
 } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { includesFieldsOtherThanSelectionSet } from "lib/hasFieldSelection"
+import { Searchable } from "./searchable"
+import { setVersion } from "./image/normalize"
+import { getDefault } from "./image"
 
 const SUBJECT_MATTER_MATCHES = [
   "content",
@@ -32,10 +35,20 @@ const SUBJECT_MATTER_REGEX = new RegExp(SUBJECT_MATTER_MATCHES.join("|"), "i")
 
 export const GeneType = new GraphQLObjectType<any, ResolverContext>({
   name: "Gene",
-  interfaces: [NodeInterface],
+  interfaces: [NodeInterface, Searchable],
   fields: () => {
     const { filterArtworksConnection } = require("./filterArtworksConnection")
     return {
+      // Searchable
+      displayLabel: {
+        type: GraphQLString,
+        resolve: ({ display_name }) => display_name,
+      },
+      imageUrl: {
+        type: GraphQLString,
+        resolve: ({ images }) => setVersion(getDefault(images), ["square"]),
+      },
+      // Rest
       ...SlugAndInternalIDFields,
       cached,
       artistsConnection: {

--- a/src/schema/v2/search/SearchResolver.ts
+++ b/src/schema/v2/search/SearchResolver.ts
@@ -23,16 +23,23 @@ export class SearchResolver {
   }
 
   fetch(searchResultItem) {
-    const { artistLoader, artworkLoader } = this.context
+    const { artistLoader, artworkLoader, geneLoader } = this.context
     const loaderMapping = {
       Artist: artistLoader,
       Artwork: artworkLoader,
+      Gene: geneLoader,
     }
 
     const loader = loaderMapping[searchResultItem.label]
 
     if (loader) {
       return loader(searchResultItem.id)
+    } else {
+      throw new Error(
+        `[SearchResolver] No loader configured for model type: ${
+          searchResultItem.label
+        }`
+      )
     }
   }
 


### PR DESCRIPTION
```graphql
{
  searchConnection(query: "minim", first: 10, entities: [GENE], mode: AUTOSUGGEST) {
    edges {
      node {
        ... on Gene {
          name
        }
      }
    }
  }
}
```

```json
{
  "data": {
    "searchConnection": {
      "edges": [
        {
          "node": {
            "name": "Minimalism"
          }
        },
        {
          "node": {
            "name": "Minimalism and Contemporary Minimalist"
          }
        },
        {
          "node": {
            "name": "Contemporary Minimalist"
          }
        },
        {
          "node": {
            "name": "Political Minimalism"
          }
        },
        {
          "node": {
            "name": "Postminimalism"
          }
        }
      ]
    }
  }
}
```