### PR TITLE
[v2] Add KAWS stitching of filterArtworksConnection

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -7501,8 +7501,7 @@ type MarketingCollection {
     gene_ids: [String]
     height: String
     width: String
-
-    # A string from the list of allocations, or * to denote all mediums
+    marketable: Boolean
     medium: String
     period: String
     periods: [String]
@@ -7516,6 +7515,7 @@ type MarketingCollection {
     sort: String
     tag_id: String
     keyword: String
+    keyword_match_exact: Boolean
   ): FilterArtworks
 }
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -724,6 +724,7 @@ type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInt
   statuses: ArtistStatuses
   highlights: ArtistHighlights
   years: String
+  marketingCollections(size: Int): [MarketingCollection]
 }
 
 type ArtistArtworkGrid implements ArtworkContextGrid {
@@ -4741,6 +4742,46 @@ type MarketingCollection {
   # IDs of artists that should be excluded from Featured Artists for this collection
   featuredArtistExclusionIds: [String!]
   relatedCollections: [MarketingCollection!]!
+  artworksConnection(
+    acquireable: Boolean
+    offerable: Boolean
+    aggregationPartnerCities: [String]
+    aggregations: [ArtworkAggregation]
+    artistID: String
+    artistIDs: [String]
+    atAuction: Boolean
+    attributionClass: [String]
+    color: String
+    dimensionRange: String
+    extraAggregationGeneIDs: [String]
+    includeArtworksByFollowedArtists: Boolean
+    includeMediumFilterInAggregation: Boolean
+    inquireableOnly: Boolean
+    forSale: Boolean
+    geneID: String
+    geneIDs: [String]
+    height: String
+    width: String
+    marketable: Boolean
+    medium: String
+    period: String
+    periods: [String]
+    majorPeriods: [String]
+    partnerID: ID
+    partnerCities: [String]
+    priceRange: String
+    page: Int
+    saleID: ID
+    size: Int
+    sort: String
+    tagID: String
+    keyword: String
+    keywordMatchExact: Boolean
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): FilterArtworksConnection
 }
 
 type MarketingCollectionCategory {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -85,13 +85,18 @@ export const markdownToText = str => {
 
 export const convertConnectionArgsToGravityArgs = <T extends CursorPageable>(
   options: T
-) => {
+): { page: number; size: number; offset: number } & T => {
   const { limit: size, offset } = getPagingParameters(options)
   // If a size of 0 explicitly requested, it doesn't really matter what
   // the page is.
   const page = size ? Math.round((size + offset) / size) : 1
   const gravityArgs = omit(options, ["first", "after", "last", "before"])
-  return Object.assign({}, { page, size, offset }, gravityArgs)
+  return {
+    ...gravityArgs,
+    page,
+    size,
+    offset,
+  } as any
 }
 
 export const removeNulls = object => {

--- a/src/lib/stitching/mergeSchemas.ts
+++ b/src/lib/stitching/mergeSchemas.ts
@@ -7,7 +7,10 @@ import {
   transformsForExchange,
 } from "lib/stitching/exchange/schema"
 import { executableKawsSchema } from "lib/stitching/kaws/schema"
-import { kawsStitchingEnvironment } from "lib/stitching/kaws/stitching"
+import {
+  kawsStitchingEnvironmentV1,
+  kawsStitchingEnvironmentV2,
+} from "lib/stitching/kaws/stitching"
 import config from "config"
 
 import { GraphQLSchema } from "graphql"
@@ -76,7 +79,9 @@ export const incrementalMergeSchemas = (
   // TODO: In v2 we dropped the legacy style filter artworks, so this needs to
   //       be redone with the new connection.
   if (version === 1) {
-    useStitchingEnvironment(kawsStitchingEnvironment(localSchema, kawsSchema))
+    useStitchingEnvironment(kawsStitchingEnvironmentV1(localSchema, kawsSchema))
+  } else {
+    useStitchingEnvironment(kawsStitchingEnvironmentV2(localSchema, kawsSchema))
   }
 
   // The order should only matter in that extension schemas come after the

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -124,7 +124,7 @@ export const runQueryMerged = async (
   const { incrementalMergeSchemas } = require("lib/stitching/mergeSchemas")
 
   if (!mergedSchema) {
-    mergedSchema = await incrementalMergeSchemas(localSchema, {
+    mergedSchema = await incrementalMergeSchemas(localSchema, 1, {
       ENABLE_COMMERCE_STITCHING: true,
       ENABLE_CONSIGNMENTS_STITCHING: true,
     })


### PR DESCRIPTION
Alright, got KAWS stitching in V2 and use the filter artworks connection instead. I also automated the schema extension so that it’s always up-to-date with the filter args defined in MP.