### PR TITLE
[v2] Don't override pagination size when it is specified.

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -93,8 +93,8 @@ export const convertConnectionArgsToGravityArgs = <T extends CursorPageable>(
   const gravityArgs = omit(options, ["first", "after", "last", "before"])
   return {
     ...gravityArgs,
+    size: Number.isInteger(size) ? size : gravityArgs.size,
     page,
-    size,
     offset,
   } as any
 }


### PR DESCRIPTION
Perhaps allowing the `size` argument rather than always using `first` has made this more complex than necessary, but that ship has sailed 🤷‍♂ 