### PR TITLE
Adds press release info for Paris Photo 2019

### DIFF
--- a/src/lib/sponsoredContent/data.json
+++ b/src/lib/sponsoredContent/data.json
@@ -80,6 +80,10 @@
     "frieze-london-2019": {
       "activationText": "BMW is long term partner of Frieze Art Fair. During the 2019 London edition the third BMW Open Work by Frieze commission will be unveiled: Sirens created by French artist Camille Blatrix. BMW Open Work gives artists the opportunity to push the boundaries of their artistic work, utilizing technology and design to pursue practice in innovate new directions. The commissions are created in close dialogue with BMW engineers, designers or technicians creating a distinct encounter between industrial knowledge, technology, and artistic thought. Furthermore, BMW is partner of Frieze Music and supplies a shuttle service for VIP guests of the fair.",
       "pressReleaseUrl": "https://www.press.bmwgroup.com/global/article/detail/T0299793EN/camille-blatrix-to-explore-concept-of-desire-for-bmw-open-work-2019-artwork-inspired-by-bmw-technology-to-premiere-at-frieze-london-in-october-2019"
+    },
+    "paris-photo-2019": {
+      "activationText": "From November 7 until 10 the 23rd edition of Paris Photo will take place at the Grand Palais Paris. The fair is the largest international art fair dedicated to the photographic medium and is held each November. Since 1997, its mission is to promote and nurture photographic creation and the galleries, publishers and artists at its source. BMW is official partner of Paris Photo since 2003 and stages every year the winner of the BMW Residency at the GOBELINS School of Visual Arts. In 2019, artist Emeric Lhuisset presents “L’autre rive.”",
+      "pressReleaseUrl": "https://www.press.bmwgroup.com/global/article/detail/T0302354EN/as-long-term-partner-of-paris-photo-bmw-presents-haunting-photographs-by-emeric-lhuisset-the-winner-of-the-bmw-residency-at-the-gobelins-school-of-visual-arts-displays-%E2%80%9Cthe-other-shore%E2%80%9D"
     }
   }
 }


### PR DESCRIPTION
This PR adds the press release information to Paris Photo 2019 fair.

[Links to GROW-1650](https://artsyproduct.atlassian.net/browse/GROW-1650)

<img width="1025" alt="Screen Shot 2019-11-07 at 2 53 40 PM" src="https://user-images.githubusercontent.com/10385964/68394616-79d11f80-016e-11ea-852a-5f6a5d2730c9.png">
