### PR TITLE
Add creditCard field to v2

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5706,6 +5706,12 @@ type Query {
     near: Near
   ): City
 
+  # A user's credit card
+  creditCard(
+    # The ID of the Credit Card
+    id: String!
+  ): CreditCard
+
   # A Fair
   fair(
     # The slug or ID of the Fair
@@ -7289,6 +7295,12 @@ type Viewer {
     # A point which will be used to locate the nearest local discovery city within a threshold
     near: Near
   ): City
+
+  # A user's credit card
+  creditCard(
+    # The ID of the Credit Card
+    id: String!
+  ): CreditCard
 
   # A Fair
   fair(

--- a/src/lib/stitching/exchange/__tests__/testingUtils.ts
+++ b/src/lib/stitching/exchange/__tests__/testingUtils.ts
@@ -20,10 +20,11 @@ export const getExchangeTransformedSchema = async () => {
 export const getExchangeStitchedSchema = async () => {
   if (!stitchedSchema) {
     const cachedSchema = await getExchangeTransformedSchema()
-    stitchedSchema = await exchangeStitchingEnvironment(
+    stitchedSchema = exchangeStitchingEnvironment({
       localSchema,
-      cachedSchema
-    )
+      exchangeSchema: cachedSchema,
+      version: 1,
+    })
   }
   return stitchedSchema
 }

--- a/src/lib/stitching/exchange/stitching.ts
+++ b/src/lib/stitching/exchange/stitching.ts
@@ -19,10 +19,15 @@ const lineItemTotalsSDL = lineItemTotals.map(amountSDL)
 
 const offerAmountFields = ["amount", "taxTotal", "shippingTotal", "buyerTotal"]
 const offerAmountFieldsSDL = offerAmountFields.map(amountSDL)
-export const exchangeStitchingEnvironment = (
-  localSchema: GraphQLSchema,
+export const exchangeStitchingEnvironment = ({
+  version,
+  localSchema,
+  exchangeSchema,
+}: {
+  version: number
+  localSchema: GraphQLSchema
   exchangeSchema: GraphQLSchema & { transforms: any }
-) => {
+}) => {
   type DetailsFactoryInput = { from: string; to: string }
 
   /**
@@ -115,7 +120,7 @@ export const exchangeStitchingEnvironment = (
         return info.mergeInfo.delegateToSchema({
           schema: localSchema,
           operation: "query",
-          fieldName: "credit_card",
+          fieldName: version >= 2 ? "creditCard" : "credit_card",
           args: {
             id,
           },

--- a/src/lib/stitching/mergeSchemas.ts
+++ b/src/lib/stitching/mergeSchemas.ts
@@ -55,7 +55,7 @@ export const incrementalMergeSchemas = (
     schemas.push(exchangeSchema)
 
     useStitchingEnvironment(
-      exchangeStitchingEnvironment(localSchema, exchangeSchema)
+      exchangeStitchingEnvironment({ localSchema, exchangeSchema, version })
     )
   }
 

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -29,7 +29,7 @@ import System from "./system"
 // import Status from "./status"
 import Artists from "./artists"
 // import Collection from "./collection"
-// import { CreditCard } from "./credit_card"
+import { CreditCard } from "./credit_card"
 // import ExternalPartner from "./external_partner"
 // import Fairs from "./fairs"
 import Genes from "./genes"
@@ -116,7 +116,7 @@ const rootFields = {
   // causalityJWT: CausalityJWT, // TODO: Perhaps this should go into `system` ?
   city: City,
   // collection: Collection,
-  // creditCard: CreditCard,
+  creditCard: CreditCard,
   // externalPartner: ExternalPartner,
   fair: Fair,
   // fairs: Fairs,


### PR DESCRIPTION
Exchange's stitching relied on the `Query#credit_card` field in v1, on it so I added it back in v2 with camelCase.