### PR TITLE
Partner.locationsConnection & Partner.cities

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4685,6 +4685,37 @@ type Location {
   summary: String
 }
 
+# A connection to a list of items.
+type LocationConnection implements LocationsConnectionInterface {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # A list of edges.
+  edges: [LocationEdge]
+  pageCursors: PageCursors!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type LocationEdge implements LocationsEdgeInterface {
+  # The item at the end of the edge
+  node: Location
+
+  # A cursor for use in pagination
+  cursor: String!
+}
+
+interface LocationsConnectionInterface {
+  pageCursors: PageCursors!
+  pageInfo: PageInfo!
+  edges: [LocationsEdgeInterface]
+}
+
+interface LocationsEdgeInterface {
+  node: Location
+  cursor: String
+}
+
 type LotStanding {
   # Your bid if it is currently winning
   activeBid: BidderPosition
@@ -5353,6 +5384,9 @@ type Partner implements Node {
   categories: [PartnerCategory]
   collectingInstitution: String
   counts: PartnerCounts
+
+  # A list of the partners unique city locations
+  cities(size: Int = 25): [String]
   defaultProfileID: String
   hasFairPartnership: Boolean
   href: String
@@ -5360,7 +5394,14 @@ type Partner implements Node {
   isDefaultProfilePublic: Boolean
   isLinkable: Boolean
   isPreQualify: Boolean
-  locations(size: Int = 25): [Location]
+
+  # A connection of locations from a Partner.
+  locationsConnection(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): LocationConnection
   name: String
   profile: Profile
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4686,7 +4686,7 @@ type Location {
 }
 
 # A connection to a list of items.
-type LocationConnection implements LocationsConnectionInterface {
+type LocationConnection {
   # Information to aid in pagination.
   pageInfo: PageInfo!
 
@@ -4697,23 +4697,12 @@ type LocationConnection implements LocationsConnectionInterface {
 }
 
 # An edge in a connection.
-type LocationEdge implements LocationsEdgeInterface {
+type LocationEdge {
   # The item at the end of the edge
   node: Location
 
   # A cursor for use in pagination
   cursor: String!
-}
-
-interface LocationsConnectionInterface {
-  pageCursors: PageCursors!
-  pageInfo: PageInfo!
-  edges: [LocationsEdgeInterface]
-}
-
-interface LocationsEdgeInterface {
-  node: Location
-  cursor: String
 }
 
 type LotStanding {

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -55,7 +55,7 @@ export default opts => {
     partnerCategoriesLoader: gravityLoader("partner_categories"),
     partnerCategoryLoader: gravityLoader(id => `partner_category/${id}`),
     partnerLoader: gravityLoader(id => `partner/${id}`),
-    partnerLocationsLoader: gravityLoader(id => `partner/${id}/locations`),
+    partnerLocationsLoader: gravityLoader<any, { page: number, published: boolean, size: number, total_count: boolean }>(id => `partner/${id}/locations`, {}, { headers: true }),
     partnerShowArtworksLoader: gravityLoader<any, { partner_id: string, show_id: string }>(({ partner_id, show_id }) => `partner/${partner_id}/show/${show_id}/artworks`, {}, { headers: true }),
     partnerShowImagesLoader: gravityLoader(id => `partner_show/${id}/images`),
     partnerShowArtistsLoader: gravityLoader<any, { partner_id: string, show_id: string }>(({ partner_id, show_id }) => `partner/${partner_id}/show/${show_id}/artists`, {}, { headers: true }),

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -13,7 +13,7 @@ import Image from "./image"
 import Artist from "./artist"
 import Partner from "./partner"
 import { ShowsConnection } from "./show"
-import { LocationField } from "./location"
+import { LocationType } from "./location"
 import { SlugAndInternalIDFields, SlugIDField } from "./object_identification"
 import {
   GraphQLObjectType,
@@ -211,7 +211,7 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ published }) => published,
       },
       location: {
-        type: LocationField.type,
+        type: LocationType,
         resolve: ({ id, location, published }, options, { fairLoader }) => {
           if (location) {
             return location

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -13,7 +13,7 @@ import Image from "./image"
 import Artist from "./artist"
 import Partner from "./partner"
 import { ShowsConnection } from "./show"
-import Location from "./location"
+import { LocationField } from "./location"
 import { SlugAndInternalIDFields, SlugIDField } from "./object_identification"
 import {
   GraphQLObjectType,
@@ -211,7 +211,7 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ published }) => published,
       },
       location: {
-        type: Location.type,
+        type: LocationField.type,
         resolve: ({ id, location, published }, options, { fairLoader }) => {
           if (location) {
             return location

--- a/src/schema/v2/location.ts
+++ b/src/schema/v2/location.ts
@@ -12,6 +12,7 @@ import {
   GraphQLUnionType,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { connectionWithCursorInfo } from "./fields/pagination"
 
 export const LatLngType = new GraphQLObjectType<any, ResolverContext>({
   name: "LatLng",
@@ -119,9 +120,11 @@ export const LocationType = new GraphQLObjectType<any, ResolverContext>({
   }),
 })
 
-const Location: GraphQLFieldConfig<void, ResolverContext> = {
+export const LocationField: GraphQLFieldConfig<void, ResolverContext> = {
   type: LocationType,
   description: "A Location",
 }
 
-export default Location
+export const locationsConnection = connectionWithCursorInfo({
+  nodeType: LocationType,
+})

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -21,7 +21,7 @@ import { PartnerType } from "./partner"
 import { ExternalPartnerType } from "./external_partner"
 import Fair from "./fair"
 import { artworkConnection } from "./artwork"
-import Location from "./location"
+import { LocationField } from "./location"
 import Image, { getDefault, normalizeImageData } from "./image"
 import ShowEventType from "./show_event"
 import { connectionWithCursorInfo } from "schema/v2/fields/pagination"
@@ -414,7 +414,7 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
       location: {
         description:
           "Where the show is located (Could also be a fair location)",
-        type: Location.type,
+        type: LocationField.type,
         resolve: ({ location, fair_location }) => location || fair_location,
       },
       metaImage: {

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -21,7 +21,7 @@ import { PartnerType } from "./partner"
 import { ExternalPartnerType } from "./external_partner"
 import Fair from "./fair"
 import { artworkConnection } from "./artwork"
-import { LocationField } from "./location"
+import { LocationType } from "./location"
 import Image, { getDefault, normalizeImageData } from "./image"
 import ShowEventType from "./show_event"
 import { connectionWithCursorInfo } from "schema/v2/fields/pagination"
@@ -414,7 +414,7 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
       location: {
         description:
           "Where the show is located (Could also be a fair location)",
-        type: LocationField.type,
+        type: LocationType,
         resolve: ({ location, fair_location }) => location || fair_location,
       },
       metaImage: {


### PR DESCRIPTION
- Adds `Partner.locationsConnection`, `Partner.locations` is now removed and had not been used prior to the future `6.0` release.
- Adds `Partner.cities`, in cases we were using the original `Partner.locations` it was just cases where we need a list of the `cities`, this new resolver provides a unique array of the Partners' cities. 

<img width="1342" alt="Screen Shot 2019-11-08 at 12 22 34 PM" src="https://user-images.githubusercontent.com/21182806/68497889-911e1480-0223-11ea-9cc2-86102cf8e521.png">

<img width="1316" alt="Screen Shot 2019-11-08 at 12 19 10 PM" src="https://user-images.githubusercontent.com/21182806/68497904-94190500-0223-11ea-9af4-083cd080af38.png">
