### PR TITLE
Revert "Partner.locationsConnection & Partner.cities"

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4685,26 +4685,6 @@ type Location {
   summary: String
 }
 
-# A connection to a list of items.
-type LocationConnection {
-  # Information to aid in pagination.
-  pageInfo: PageInfo!
-
-  # A list of edges.
-  edges: [LocationEdge]
-  pageCursors: PageCursors!
-  totalCount: Int
-}
-
-# An edge in a connection.
-type LocationEdge {
-  # The item at the end of the edge
-  node: Location
-
-  # A cursor for use in pagination
-  cursor: String!
-}
-
 type LotStanding {
   # Your bid if it is currently winning
   activeBid: BidderPosition
@@ -5373,9 +5353,6 @@ type Partner implements Node {
   categories: [PartnerCategory]
   collectingInstitution: String
   counts: PartnerCounts
-
-  # A list of the partners unique city locations
-  cities(size: Int = 25): [String]
   defaultProfileID: String
   hasFairPartnership: Boolean
   href: String
@@ -5383,14 +5360,7 @@ type Partner implements Node {
   isDefaultProfilePublic: Boolean
   isLinkable: Boolean
   isPreQualify: Boolean
-
-  # A connection of locations from a Partner.
-  locationsConnection(
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): LocationConnection
+  locations(size: Int = 25): [Location]
   name: String
   profile: Profile
 

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -55,7 +55,7 @@ export default opts => {
     partnerCategoriesLoader: gravityLoader("partner_categories"),
     partnerCategoryLoader: gravityLoader(id => `partner_category/${id}`),
     partnerLoader: gravityLoader(id => `partner/${id}`),
-    partnerLocationsLoader: gravityLoader<any, { page: number, published: boolean, size: number, total_count: boolean }>(id => `partner/${id}/locations`, {}, { headers: true }),
+    partnerLocationsLoader: gravityLoader(id => `partner/${id}/locations`),
     partnerShowArtworksLoader: gravityLoader<any, { partner_id: string, show_id: string }>(({ partner_id, show_id }) => `partner/${partner_id}/show/${show_id}/artworks`, {}, { headers: true }),
     partnerShowImagesLoader: gravityLoader(id => `partner_show/${id}/images`),
     partnerShowArtistsLoader: gravityLoader<any, { partner_id: string, show_id: string }>(({ partner_id, show_id }) => `partner/${partner_id}/show/${show_id}/artists`, {}, { headers: true }),

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -13,7 +13,7 @@ import Image from "./image"
 import Artist from "./artist"
 import Partner from "./partner"
 import { ShowsConnection } from "./show"
-import { LocationType } from "./location"
+import Location from "./location"
 import { SlugAndInternalIDFields, SlugIDField } from "./object_identification"
 import {
   GraphQLObjectType,
@@ -211,7 +211,7 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ published }) => published,
       },
       location: {
-        type: LocationType,
+        type: Location.type,
         resolve: ({ id, location, published }, options, { fairLoader }) => {
           if (location) {
             return location

--- a/src/schema/v2/location.ts
+++ b/src/schema/v2/location.ts
@@ -12,7 +12,6 @@ import {
   GraphQLUnionType,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
-import { connectionWithCursorInfo } from "./fields/pagination"
 
 export const LatLngType = new GraphQLObjectType<any, ResolverContext>({
   name: "LatLng",
@@ -120,11 +119,9 @@ export const LocationType = new GraphQLObjectType<any, ResolverContext>({
   }),
 })
 
-export const LocationField: GraphQLFieldConfig<void, ResolverContext> = {
+const Location: GraphQLFieldConfig<void, ResolverContext> = {
   type: LocationType,
   description: "A Location",
 }
 
-export const locationsConnection = connectionWithCursorInfo({
-  nodeType: LocationType,
-})
+export default Location

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -15,7 +15,7 @@ import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import cached from "./fields/cached"
 import initials from "./fields/initials"
 import Profile from "./profile"
-import { locationsConnection } from "./location"
+import Location from "./location"
 import EventStatus from "schema/v2/input_fields/event_status"
 import { NodeInterface, SlugAndInternalIDFields } from "./object_identification"
 import { artworkConnection } from "./artwork"
@@ -183,33 +183,6 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         }),
         resolve: artist => artist,
       },
-      cities: {
-        description: "A list of the partners unique city locations",
-        type: new GraphQLList(GraphQLString),
-        args: {
-          size: {
-            type: GraphQLInt,
-            defaultValue: 25,
-          },
-        },
-        resolve: ({ id }, options, { partnerLocationsLoader }) => {
-          return partnerLocationsLoader(id, options).then(locations => {
-            const locationCities = locations.body.map(location => {
-              return location.city
-            })
-            const filteredForDuplicatesAndBlanks = locationCities.filter(
-              (city, pos) => {
-                return (
-                  city &&
-                  locationCities.indexOf(city) === pos &&
-                  city.length > 0
-                )
-              }
-            )
-            return filteredForDuplicatesAndBlanks
-          })
-        },
-      },
       defaultProfileID: {
         type: GraphQLString,
         resolve: ({ default_profile_id }) => default_profile_id,
@@ -239,31 +212,16 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLBoolean,
         resolve: ({ pre_qualify }) => pre_qualify,
       },
-      locationsConnection: {
-        description: "A connection of locations from a Partner.",
-        type: locationsConnection.connectionType,
-        args: pageable({}),
-        resolve: ({ id }, args, { partnerLocationsLoader }) => {
-          const { page, size, offset } = convertConnectionArgsToGravityArgs(
-            args
-          )
-
-          const gravityArgs = {
-            published: true,
-            total_count: true,
-            page,
-            size,
-          }
-
-          return partnerLocationsLoader(id, gravityArgs).then(
-            ({ body, headers }) => {
-              return connectionFromArraySlice(body, args, {
-                arrayLength: parseInt(headers["x-total-count"] || "0", 10),
-                sliceStart: offset,
-              })
-            }
-          )
+      locations: {
+        type: new GraphQLList(Location.type),
+        args: {
+          size: {
+            type: GraphQLInt,
+            defaultValue: 25,
+          },
         },
+        resolve: ({ id }, options, { partnerLocationsLoader }) =>
+          partnerLocationsLoader(id, options),
       },
       name: {
         type: GraphQLString,

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -21,7 +21,7 @@ import { PartnerType } from "./partner"
 import { ExternalPartnerType } from "./external_partner"
 import Fair from "./fair"
 import { artworkConnection } from "./artwork"
-import { LocationType } from "./location"
+import Location from "./location"
 import Image, { getDefault, normalizeImageData } from "./image"
 import ShowEventType from "./show_event"
 import { connectionWithCursorInfo } from "schema/v2/fields/pagination"
@@ -414,7 +414,7 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
       location: {
         description:
           "Where the show is located (Could also be a fair location)",
-        type: LocationType,
+        type: Location.type,
         resolve: ({ location, fair_location }) => location || fair_location,
       },
       metaImage: {


### PR DESCRIPTION
Reverts artsy/metaphysics#2049

`Partner.locations` is still being used-- this reverts that change to fix an incident.