### PR TITLE
Remove unused Image type from kaws schema

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -7594,13 +7594,6 @@ enum MarketingGroupTypes {
   OtherCollections
 }
 
-type MarketingImage {
-  id: ID!
-  small: String!
-  medium: String!
-  large: String!
-}
-
 type Me implements Node {
   # A globally unique ID.
   __id: ID!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4878,13 +4878,6 @@ enum MarketingGroupTypes {
   OtherCollections
 }
 
-type MarketingImage {
-  id: ID!
-  small: String!
-  medium: String!
-  large: String!
-}
-
 type Me implements Node {
   # A globally unique ID.
   id: ID!

--- a/src/data/kaws.graphql
+++ b/src/data/kaws.graphql
@@ -135,13 +135,6 @@ enum GroupTypes {
   OtherCollections
 }
 
-type Image {
-  id: ID!
-  small: String!
-  medium: String!
-  large: String!
-}
-
 type Query {
   collections(
     category: String

--- a/src/lib/stitching/kaws/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/kaws/__tests__/__snapshots__/schema.test.ts.snap
@@ -133,13 +133,6 @@ enum MarketingGroupTypes {
   OtherCollections
 }
 
-type MarketingImage {
-  id: ID!
-  small: String!
-  medium: String!
-  large: String!
-}
-
 type Query {
   marketingCollections(category: String, randomizationSeed: String, size: Int, isFeaturedArtistContent: Boolean, showOnEditorial: Boolean, artistID: String): [MarketingCollection!]!
   marketingCategories: [MarketingCollectionCategory!]!


### PR DESCRIPTION
Related to https://github.com/artsy/kaws/pull/172 this removes the unused `Image` type from the KAWS schema.