### PR TITLE
[V2] - Adds Partner.locationsConnection & Partner.cities while leaving Partner.locations

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4685,6 +4685,26 @@ type Location {
   summary: String
 }
 
+# A connection to a list of items.
+type LocationConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # A list of edges.
+  edges: [LocationEdge]
+  pageCursors: PageCursors!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type LocationEdge {
+  # The item at the end of the edge
+  node: Location
+
+  # A cursor for use in pagination
+  cursor: String!
+}
+
 type LotStanding {
   # Your bid if it is currently winning
   activeBid: BidderPosition
@@ -5353,6 +5373,9 @@ type Partner implements Node {
   categories: [PartnerCategory]
   collectingInstitution: String
   counts: PartnerCounts
+
+  # A list of the partners unique city locations
+  cities(size: Int = 25): [String]
   defaultProfileID: String
   hasFairPartnership: Boolean
   href: String
@@ -5360,7 +5383,17 @@ type Partner implements Node {
   isDefaultProfilePublic: Boolean
   isLinkable: Boolean
   isPreQualify: Boolean
+
+  # This field is deprecated and is being used in Eigen release predating the 6.0 release
   locations(size: Int = 25): [Location]
+
+  # A connection of locations from a Partner.
+  locationsConnection(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): LocationConnection
   name: String
   profile: Profile
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5386,6 +5386,9 @@ type Partner implements Node {
 
   # This field is deprecated and is being used in Eigen release predating the 6.0 release
   locations(size: Int = 25): [Location]
+    @deprecated(
+      reason: "Prefer to use `locationsConnection`. [Will be removed in vundefined]"
+    )
 
   # A connection of locations from a Partner.
   locationsConnection(

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -11,7 +11,9 @@ export default opts => {
 
   const [batchSaleLoader, batchSalesLoader] = createBatchLoaders({
     singleLoader: gravityLoader(id => `sale/${id}`),
-    multipleLoader: gravityLoader<{ id: string, is_auction: boolean }[]>('sales')
+    multipleLoader: gravityLoader<{ id: string; is_auction: boolean }[]>(
+      "sales"
+    ),
   })
 
   type GravityCalculatedCostResponse = {
@@ -29,16 +31,35 @@ export default opts => {
     artistGenesLoader: gravityLoader(id => `artist/${id}/genome/genes`),
     artistLoader: gravityLoader(id => `artist/${id}`),
     artistsLoader: gravityLoader("artists"),
-    artworkImageLoader: gravityLoader<any, { artwork_id: string, image_id: string }>(({ artwork_id, image_id }) => `artwork/${artwork_id}/image/${image_id}`),
+    artworkImageLoader: gravityLoader<
+      any,
+      { artwork_id: string; image_id: string }
+    >(({ artwork_id, image_id }) => `artwork/${artwork_id}/image/${image_id}`),
     artworkLoader: gravityLoader(id => `artwork/${id}`),
     artworksLoader: gravityLoader("artworks"),
     bidderLoader: gravityLoader(id => `bidder/${id}`),
-    fairArtistsLoader: gravityLoader(id => `fair/${id}/artists`, {}, { headers: true }),
-    fairBoothsLoader: gravityLoader(id => `fair/${id}/shows`, {}, { headers: true }),
-    fairPartnersLoader: gravityLoader(id => `fair/${id}/partners`, {}, { headers: true }),
+    fairArtistsLoader: gravityLoader(
+      id => `fair/${id}/artists`,
+      {},
+      { headers: true }
+    ),
+    fairBoothsLoader: gravityLoader(
+      id => `fair/${id}/shows`,
+      {},
+      { headers: true }
+    ),
+    fairPartnersLoader: gravityLoader(
+      id => `fair/${id}/partners`,
+      {},
+      { headers: true }
+    ),
     fairLoader: gravityLoader(id => `fair/${id}`),
     fairsLoader: gravityLoader("fairs", {}, { headers: true }),
-    filterArtworksLoader: gravityLoader("filter/artworks", {}, { requestThrottleMs: 1000 * 60 * 60 }),
+    filterArtworksLoader: gravityLoader(
+      "filter/artworks",
+      {},
+      { requestThrottleMs: 1000 * 60 * 60 }
+    ),
     geneArtistsLoader: gravityLoader(id => `gene/${id}/artists`),
     geneFamiliesLoader: gravityLoader("gene_families"),
     geneLoader: gravityLoader(id => `gene/${id}`),
@@ -47,43 +68,119 @@ export default opts => {
     incrementsLoader: gravityLoader("increments"),
     matchArtistsLoader: gravityLoader("match/artists"),
     matchGeneLoader: gravityLoader("match/genes"),
-    partnerArtistLoader: gravityLoader<any, { artist_id: string, partner_id: string }>(({ artist_id, partner_id }) => `partner/${partner_id}/artist/${artist_id}`),
-    partnerArtistsForArtistLoader: gravityLoader(id => `artist/${id}/partner_artists`),
-    partnerArtistsForPartnerLoader: gravityLoader(id => `partner/${id}/partner_artists`, {}, { headers: true }),
-    partnerArtistsLoader: gravityLoader("partner_artists", {}, { headers: true }),
-    partnerArtworksLoader: gravityLoader(id => `partner/${id}/artworks`, {}, { headers: true }),
+    partnerArtistLoader: gravityLoader<
+      any,
+      { artist_id: string; partner_id: string }
+    >(
+      ({ artist_id, partner_id }) => `partner/${partner_id}/artist/${artist_id}`
+    ),
+    partnerArtistsForArtistLoader: gravityLoader(
+      id => `artist/${id}/partner_artists`
+    ),
+    partnerArtistsForPartnerLoader: gravityLoader(
+      id => `partner/${id}/partner_artists`,
+      {},
+      { headers: true }
+    ),
+    partnerArtistsLoader: gravityLoader(
+      "partner_artists",
+      {},
+      { headers: true }
+    ),
+    partnerArtworksLoader: gravityLoader(
+      id => `partner/${id}/artworks`,
+      {},
+      { headers: true }
+    ),
     partnerCategoriesLoader: gravityLoader("partner_categories"),
     partnerCategoryLoader: gravityLoader(id => `partner_category/${id}`),
     partnerLoader: gravityLoader(id => `partner/${id}`),
     partnerLocationsLoader: gravityLoader(id => `partner/${id}/locations`),
-    partnerShowArtworksLoader: gravityLoader<any, { partner_id: string, show_id: string }>(({ partner_id, show_id }) => `partner/${partner_id}/show/${show_id}/artworks`, {}, { headers: true }),
+    partnerLocationsConnectionLoader: gravityLoader<
+      any,
+      { page: number; published: boolean; size: number; total_count: boolean }
+    >(id => `partner/${id}/locations`, {}, { headers: true }),
+    partnerShowArtworksLoader: gravityLoader<
+      any,
+      { partner_id: string; show_id: string }
+    >(
+      ({ partner_id, show_id }) =>
+        `partner/${partner_id}/show/${show_id}/artworks`,
+      {},
+      { headers: true }
+    ),
     partnerShowImagesLoader: gravityLoader(id => `partner_show/${id}/images`),
-    partnerShowArtistsLoader: gravityLoader<any, { partner_id: string, show_id: string }>(({ partner_id, show_id }) => `partner/${partner_id}/show/${show_id}/artists`, {}, { headers: true }),
-    partnerShowLoader: gravityLoader<any, { partner_id: string, show_id: string }>(({ partner_id, show_id }) => `partner/${partner_id}/show/${show_id}`),
-    partnerShowsLoader: gravityLoader(partner_id => `partner/${partner_id}/shows`, {}, { headers: true }),
+    partnerShowArtistsLoader: gravityLoader<
+      any,
+      { partner_id: string; show_id: string }
+    >(
+      ({ partner_id, show_id }) =>
+        `partner/${partner_id}/show/${show_id}/artists`,
+      {},
+      { headers: true }
+    ),
+    partnerShowLoader: gravityLoader<
+      any,
+      { partner_id: string; show_id: string }
+    >(({ partner_id, show_id }) => `partner/${partner_id}/show/${show_id}`),
+    partnerShowsLoader: gravityLoader(
+      partner_id => `partner/${partner_id}/shows`,
+      {},
+      { headers: true }
+    ),
     partnersLoader: gravityLoader("partners"),
     popularArtistsLoader: gravityLoader(`artists/popular`),
     profileLoader: gravityLoader(id => `profile/${id}`),
     relatedArtworksLoader: gravityLoader("related/artworks"),
-    relatedContemporaryArtistsLoader: gravityLoader("related/layer/contemporary/artists", {}, { headers: true }),
-    relatedFairsLoader: gravityLoader<{ has_full_feature: boolean }[]>("related/fairs"),
+    relatedContemporaryArtistsLoader: gravityLoader(
+      "related/layer/contemporary/artists",
+      {},
+      { headers: true }
+    ),
+    relatedFairsLoader: gravityLoader<{ has_full_feature: boolean }[]>(
+      "related/fairs"
+    ),
     relatedGenesLoader: gravityLoader("related/genes"),
-    relatedLayerArtworksLoader: gravityLoader<any, { id: string, type: string }>(({ type, id }) => `related/layer/${type}/${id}/artworks`),
+    relatedLayerArtworksLoader: gravityLoader<
+      any,
+      { id: string; type: string }
+    >(({ type, id }) => `related/layer/${type}/${id}/artworks`),
     relatedLayersLoader: gravityLoader("related/layers"),
-    relatedMainArtistsLoader: gravityLoader("related/layer/main/artists", {}, { headers: true }),
+    relatedMainArtistsLoader: gravityLoader(
+      "related/layer/main/artists",
+      {},
+      { headers: true }
+    ),
     relatedSalesLoader: gravityLoader("related/sales"),
     relatedShowsLoader: gravityLoader("related/shows", {}, { headers: true }),
-    saleArtworkRootLoader: gravityUncachedLoader(id => `sale_artwork/${id}`, null),
+    saleArtworkRootLoader: gravityUncachedLoader(
+      id => `sale_artwork/${id}`,
+      null
+    ),
     saleArtworksFilterLoader: gravityLoader("filter/sale_artworks"),
-    saleArtworksLoader: gravityLoader(id => `sale/${id}/sale_artworks`, {}, { headers: true }),
-    saleArtworkLoader: gravityUncachedLoader<any, { saleId: string, saleArtworkId: string }>(({ saleId, saleArtworkId }) => `sale/${saleId}/sale_artwork/${saleArtworkId}`, null),
-    saleArtworkCalculatedCostLoader: gravityLoader<GravityCalculatedCostResponse, { saleId: string, saleArtworkId: string, bidAmountMinor: number }>(
+    saleArtworksLoader: gravityLoader(
+      id => `sale/${id}/sale_artworks`,
+      {},
+      { headers: true }
+    ),
+    saleArtworkLoader: gravityUncachedLoader<
+      any,
+      { saleId: string; saleArtworkId: string }
+    >(
+      ({ saleId, saleArtworkId }) =>
+        `sale/${saleId}/sale_artwork/${saleArtworkId}`,
+      null
+    ),
+    saleArtworkCalculatedCostLoader: gravityLoader<
+      GravityCalculatedCostResponse,
+      { saleId: string; saleArtworkId: string; bidAmountMinor: number }
+    >(
       ({ saleId, saleArtworkId, bidAmountMinor }) =>
         `sale/${saleId}/sale_artwork/${saleArtworkId}/calculated_cost?bid_amount_cents=${bidAmountMinor}`
     ),
     saleLoader: batchSaleLoader,
     salesLoader: batchSalesLoader,
-    salesLoaderWithHeaders: gravityLoader('sales', {}, { headers: true }),
+    salesLoaderWithHeaders: gravityLoader("sales", {}, { headers: true }),
     searchLoader: searchLoader(gravityLoader),
     sendFeedbackLoader: gravityLoader("feedback", {}, { method: "POST" }),
     setItemsLoader: gravityLoader(id => `set/${id}/items`),
@@ -93,7 +190,11 @@ export default opts => {
     showsLoader: gravityLoader("shows"),
     showsWithHeadersLoader: gravityLoader("shows", {}, { headers: true }),
     similarArtworksLoader: gravityLoader("related/artworks"),
-    similarGenesLoader: gravityLoader(id => `gene/${id}/similar`, {}, { headers: true }),
+    similarGenesLoader: gravityLoader(
+      id => `gene/${id}/similar`,
+      {},
+      { headers: true }
+    ),
     staticContentLoader: gravityLoader(id => `page/${id}`),
     systemTimeLoader: gravityUncachedLoader("system/time", null),
     tagLoader: gravityLoader(id => `tag/${id}`),

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -13,7 +13,7 @@ import Image from "./image"
 import Artist from "./artist"
 import Partner from "./partner"
 import { ShowsConnection } from "./show"
-import Location from "./location"
+import { LocationType } from "./location"
 import { SlugAndInternalIDFields, SlugIDField } from "./object_identification"
 import {
   GraphQLObjectType,
@@ -211,7 +211,7 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ published }) => published,
       },
       location: {
-        type: Location.type,
+        type: LocationType,
         resolve: ({ id, location, published }, options, { fairLoader }) => {
           if (location) {
             return location

--- a/src/schema/v2/location.ts
+++ b/src/schema/v2/location.ts
@@ -12,6 +12,7 @@ import {
   GraphQLUnionType,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { connectionWithCursorInfo } from "./fields/pagination"
 
 export const LatLngType = new GraphQLObjectType<any, ResolverContext>({
   name: "LatLng",
@@ -119,9 +120,11 @@ export const LocationType = new GraphQLObjectType<any, ResolverContext>({
   }),
 })
 
-const Location: GraphQLFieldConfig<void, ResolverContext> = {
+export const LocationField: GraphQLFieldConfig<void, ResolverContext> = {
   type: LocationType,
   description: "A Location",
 }
 
-export default Location
+export const locationsConnection = connectionWithCursorInfo({
+  nodeType: LocationType,
+})

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -247,6 +247,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         description:
           "This field is deprecated and is being used in Eigen release predating the 6.0 release",
         deprecationReason: deprecate({
+          inVersion: 2,
           preferUsageOf: "locationsConnection",
         }),
         args: {

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -30,6 +30,7 @@ import ShowSorts from "./sorts/show_sorts"
 import ArtistSorts from "./sorts/artist_sorts"
 import { fields as partnerArtistFields } from "./partner_artist"
 import { connectionWithCursorInfo } from "./fields/pagination"
+import { deprecate } from "lib/deprecation"
 
 const artworksArgs: GraphQLFieldConfigArgumentMap = {
   forSale: {
@@ -245,6 +246,9 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         type: new GraphQLList(LocationType),
         description:
           "This field is deprecated and is being used in Eigen release predating the 6.0 release",
+        deprecationReason: deprecate({
+          preferUsageOf: "locationsConnection",
+        }),
         args: {
           size: {
             type: GraphQLInt,

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -21,7 +21,7 @@ import { PartnerType } from "./partner"
 import { ExternalPartnerType } from "./external_partner"
 import Fair from "./fair"
 import { artworkConnection } from "./artwork"
-import Location from "./location"
+import { LocationType } from "./location"
 import Image, { getDefault, normalizeImageData } from "./image"
 import ShowEventType from "./show_event"
 import { connectionWithCursorInfo } from "schema/v2/fields/pagination"
@@ -414,7 +414,7 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
       location: {
         description:
           "Where the show is located (Could also be a fair location)",
-        type: Location.type,
+        type: LocationType,
         resolve: ({ location, fair_location }) => location || fair_location,
       },
       metaImage: {


### PR DESCRIPTION
- Reapplies this revert: https://github.com/artsy/metaphysics/pull/2051 while fixing the initial issue. Initially `Partner.locations` was removed, this PR leaves `Partner.locations` while adding `Partner.locationsConnection` as a separate field. 