### PR TITLE
Fix gene pagination

### DIFF
--- a/src/schema/v2/gene.ts
+++ b/src/schema/v2/gene.ts
@@ -116,8 +116,16 @@ export const GeneType = new GraphQLObjectType<any, ResolverContext>({
           },
         }),
         description: "A list of genes similar to the specified gene",
-        resolve: (gene, { excludeGeneIDs }, { similarGenesLoader }) => {
-          const options: any = {
+        resolve: (
+          gene,
+          { excludeGeneIDs, before, after, first, last },
+          { similarGenesLoader }
+        ) => {
+          const options = {
+            before,
+            after,
+            first,
+            last,
             exclude_gene_ids: excludeGeneIDs,
           }
           const { limit: size, offset } = getPagingParameters(options)


### PR DESCRIPTION
Genes weren't paginating because we weren't actually passing pagination options into `getPagingingParameters` which means we always got 0 results. 