### PR TITLE
Add `total_count` arg to Gravity request for partner locations

### DIFF
--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -198,23 +198,19 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             total_count: true,
             ...options,
           }).then(locations => {
-            if (locations.body) {
-              const locationCities = locations.body.map(location => {
-                return location.city
-              })
-              const filteredForDuplicatesAndBlanks = locationCities.filter(
-                (city, pos) => {
-                  return (
-                    city &&
-                    locationCities.indexOf(city) === pos &&
-                    city.length > 0
-                  )
-                }
-              )
-              return filteredForDuplicatesAndBlanks
-            } else {
-              return null
-            }
+            const locationCities = locations.body.map(location => {
+              return location.city
+            })
+            const filteredForDuplicatesAndBlanks = locationCities.filter(
+              (city, pos) => {
+                return (
+                  city &&
+                  locationCities.indexOf(city) === pos &&
+                  city.length > 0
+                )
+              }
+            )
+            return filteredForDuplicatesAndBlanks
           })
         },
       },

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -194,8 +194,11 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           },
         },
         resolve: ({ id }, options, { partnerLocationsConnectionLoader }) => {
-          return partnerLocationsConnectionLoader(id, options).then(
-            locations => {
+          return partnerLocationsConnectionLoader(id, {
+            total_count: true,
+            ...options,
+          }).then(locations => {
+            if (locations.body) {
               const locationCities = locations.body.map(location => {
                 return location.city
               })
@@ -209,8 +212,10 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
                 }
               )
               return filteredForDuplicatesAndBlanks
+            } else {
+              return null
             }
-          )
+          })
         },
       },
       defaultProfileID: {


### PR DESCRIPTION
- Adds `total_count` to `Cities` to ensure `body` is returned