### PR TITLE
@kierangillen => [v2] Allow a fair to be retrieved as a node

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3674,7 +3674,7 @@ type ExternalPartner {
   name: String
 }
 
-type Fair implements EntityWithFilterArtworksConnectionInterface {
+type Fair implements Node & EntityWithFilterArtworksConnectionInterface {
   # A globally unique ID.
   id: ID!
 

--- a/src/schema/v2/__tests__/object_identification.test.js
+++ b/src/schema/v2/__tests__/object_identification.test.js
@@ -49,6 +49,11 @@ describe("Object Identification", () => {
         display_on_partner_profile: true,
       },
     },
+    Fair: {
+      fairLoader: {
+        id: "foo-bar",
+      },
+    },
   }
 
   _.keys(loaderTests).forEach(typeName => {

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -14,7 +14,11 @@ import Artist from "./artist"
 import Partner from "./partner"
 import { ShowsConnection } from "./show"
 import { LocationType } from "./location"
-import { SlugAndInternalIDFields, SlugIDField } from "./object_identification"
+import {
+  SlugAndInternalIDFields,
+  SlugIDField,
+  NodeInterface,
+} from "./object_identification"
 import {
   GraphQLObjectType,
   GraphQLID,
@@ -69,7 +73,7 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
     const {
       EntityWithFilterArtworksConnectionInterface,
     } = require("./filterArtworksConnection")
-    return [EntityWithFilterArtworksConnectionInterface]
+    return [NodeInterface, EntityWithFilterArtworksConnectionInterface]
   },
   fields: () => {
     const { filterArtworksConnection } = require("./filterArtworksConnection")

--- a/src/schema/v2/object_identification.ts
+++ b/src/schema/v2/object_identification.ts
@@ -52,6 +52,7 @@ const SupportedTypes: any = {
     "./me/conversation/invoice",
     "./partner",
     "./show",
+    "./fair",
     "./sale",
     "./collection",
     "./sale_artwork",


### PR DESCRIPTION
This should allow `node(id: ...)` to resolve a fair. This might help address issues noticed in the inf. scroll grid of a fair view (which is shared among other types and thus uses the `Node` interface to fetch).