### PR TITLE
scale out MP more aggressively

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -113,9 +113,9 @@ spec:
     apiVersion: extensions/v1beta1
     kind: Deployment
     name: metaphysics-web
-  minReplicas: 7
-  maxReplicas: 15
-  targetCPUUtilizationPercentage: 70
+  minReplicas: 10
+  maxReplicas: 20
+  targetCPUUtilizationPercentage: 60
 
 ---
 apiVersion: v1


### PR DESCRIPTION
Seeing that CPU use is not so evenly distributed between pods - some close to 1 while some at 0.2

To apply immediately w/out a deploy, pull these changes locally then run `hokusai production update`