### PR TITLE
Removes alloy as an assignee and adds matt as a reviewer

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "extends": ["@artsy:app"],
-  "assignees": ["zephraph", "alloy"]
+  "assignees": ["zephraph"],
+  "reviewers": ["mzikherman"]
 }


### PR DESCRIPTION
This removes @alloy from being an assignee in renovate and adds @mzikherman as a reviewer. 

@joeyAghion I'm not sure if it would be more appropriate to have someone else as the assignee. Open to suggestions. 