### PR TITLE
Blue Chip / Emerging / Established Badges no longer appearing under Career Achievements

### DIFF
--- a/src/schema/v2/artist/highlights.ts
+++ b/src/schema/v2/artist/highlights.ts
@@ -28,14 +28,20 @@ const ArtistHighlightsType = new GraphQLObjectType<any, ResolverContext>({
           },
         }),
         resolve: (
-          { id: artist_id },
-          { representedBy, partnerCategory, displayOnPartnerProfile },
+          { id: artist_id, ...otherArgs },
+          {
+            representedBy,
+            partnerCategory,
+            displayOnPartnerProfile,
+            ...otherOptions
+          },
           { partnerArtistsLoader }
         ) => {
           const options: any = {
             represented_by: representedBy,
             partner_category: partnerCategory,
             display_on_partner_profile: displayOnPartnerProfile,
+            ...otherOptions,
           }
           return partnersForArtist(artist_id, options, partnerArtistsLoader)
         },

--- a/src/schema/v2/artist/highlights.ts
+++ b/src/schema/v2/artist/highlights.ts
@@ -28,7 +28,7 @@ const ArtistHighlightsType = new GraphQLObjectType<any, ResolverContext>({
           },
         }),
         resolve: (
-          { id: artist_id, ...otherArgs },
+          { id: artist_id },
           {
             representedBy,
             partnerCategory,


### PR DESCRIPTION
Can’t seem to find any more Blue Chip, Established, or Emerging badges under “Selected Career Achievements”.

Metaphysics was returning an empty array because not all options were being passed properly. Now an array of strings ("blue-chip", "emerging", etc) are being returned correctly.

__Before:__
<img width="326" alt="Screen Shot 2019-12-11 at 8 54 51 AM" src="https://user-images.githubusercontent.com/5643895/70627320-051d5500-1bf4-11ea-8494-995058021717.png">

__After:__
<img width="479" alt="Screen Shot 2019-12-11 at 8 53 35 AM" src="https://user-images.githubusercontent.com/5643895/70627242-dbfcc480-1bf3-11ea-8bc8-45357cf9a8ed.png">
