### PR TITLE
@izakp => [Rate Limiting] Wrap middleware to timeout when cache is slow

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "node-fetch": "1.7.3",
     "numeral": "1.5.6",
     "opentracing": "0.14.1",
-    "patch-package": "5.1.2",
+    "patch-package": "^6.2.0",
     "performance-now": "2.1.0",
     "postinstall-prepare": "1.0.1",
     "qs": "5.2.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import {
 } from "./lib/stitching/exchange/schema"
 import { middleware as requestIDsAdder } from "./lib/requestIDs"
 import { nameOldEigenQueries } from "./lib/modifyOldEigenQueries"
-import { rateLimiter } from "./lib/rateLimiter"
+import { rateLimiterMiddleware } from "./lib/rateLimiter"
 import { graphqlErrorHandler } from "./lib/graphqlErrorHandler"
 
 import { ResolverContext } from "types/graphql"
@@ -116,7 +116,7 @@ function startApp(appSchema, path: string) {
     morgan,
     // Gotta parse the JSON body before passing it to logQueryDetails/fetchPersistedQuery
     bodyParser.json(),
-    rateLimiter,
+    rateLimiterMiddleware,
     // Ensure this divider is logged before both fetchPersistedQuery and graphqlHTTP
     (_req, _res, next) => {
       info("----------")

--- a/src/lib/rateLimiter.ts
+++ b/src/lib/rateLimiter.ts
@@ -7,14 +7,55 @@ import config from "../config"
 // We expect our own services to include DataDog headers.
 export const skip = (req: Request) => !!req.headers["x-datadog-trace-id"]
 
-export const rateLimiter = new RateLimit({
-  max: config.RATE_LIMIT_MAX,
-  skip,
-  windowMs: config.RATE_LIMIT_WINDOW_MS,
-  // statusCode: 500, // In case we don’t want to inform the offender
-  store: new MemcachedStore({
-    client,
-    prefix: "limit-ip:",
-    expiration: config.RATE_LIMIT_WINDOW_MS / 1000,
-  }),
-})
+// Wrap `RateLimit` with a timeout. This helps in the case of
+// slow memcache responses. We see those in production, and the
+// underlying memcache client can sometimes hang. It's good to
+// wrap cache access with a timeout to avoid this.
+export const rateLimiterMiddleware = async (req, res, next) => {
+  try {
+    await new Promise((resolve, reject) => {
+      // Timeout handler, will reject if hit.
+      let timeoutId: NodeJS.Timer | null = setTimeout(() => {
+        timeoutId = null
+        const error = new Error(
+          `Timeout of ${config.CACHE_RETRIEVAL_TIMEOUT_MS}ms, skipping...`
+        )
+        reject(error)
+      }, config.CACHE_RETRIEVAL_TIMEOUT_MS)
+      const resetTimer = () => {
+        if (timeoutId) clearTimeout(timeoutId)
+      }
+
+      // Handlers for a rate limit being hit or not.
+      const rateLimitHit = () => {
+        resetTimer()
+        res.status(429).send("Too many requests, please try again later.")
+      }
+
+      const requestAllowed = () => {
+        resetTimer()
+        resolve()
+      }
+
+      new RateLimit({
+        max: config.RATE_LIMIT_MAX,
+        skip,
+        windowMs: config.RATE_LIMIT_WINDOW_MS,
+        // statusCode: 500, // In case we don’t want to inform the offender
+        store: new MemcachedStore({
+          client,
+          prefix: "limit-ip:",
+          expiration: config.RATE_LIMIT_WINDOW_MS / 1000,
+        }),
+        handler: rateLimitHit,
+      })(req, res, requestAllowed)
+    })
+  } catch (e) {
+    console.log(`[Rate Limiter]: ${e.message}`)
+  } finally {
+    // If the request is allowed, or if the cache is down/times out
+    // and an error is thrown, we will end up here, so we always want
+    // to call `next()`.
+    next()
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1526,6 +1526,11 @@
   dependencies:
     tslib "^1.9.3"
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -2939,7 +2944,7 @@ create-react-class@^15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-cross-spawn@^5.0.1, cross-spawn@^5.1.0:
+cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
@@ -4002,6 +4007,14 @@ find-up@^4.0.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-yarn-workspace-root@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz#40eb8e6e7c2502ddfaa2577c176f221422f860db"
+  integrity sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==
+  dependencies:
+    fs-extra "^4.0.3"
+    micromatch "^3.1.4"
+
 flat-cache@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
@@ -4102,10 +4115,19 @@ fs-exists-sync@^0.1.0:
   resolved "https://registry.yarnpkg.com/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
   integrity sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=
 
-fs-extra@^4.0.1:
+fs-extra@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
   integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -5993,6 +6015,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+
 kleur@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
@@ -7174,7 +7203,7 @@ os-name@^3.0.0:
     macos-release "^2.0.0"
     windows-release "^3.1.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
+os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -7382,19 +7411,24 @@ pascalcase@^0.1.1:
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
-patch-package@5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-5.1.2.tgz#01753261026dbf6fb223cc0bbd2931a29da9dfc2"
-  integrity sha512-6NA7/hcAG/eZ6TcugOIkmRMA9wg/CVm+gyJpWJwc7Z8E0dkMeQwnVw5oDvhG+bEHBhsQLn+rF7PAx7p2QWnfNA==
+patch-package@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.2.0.tgz#677de858e352b6ca4e6cb48a6efde2cec9fde566"
+  integrity sha512-HWlQflaBBMjLBfOWomfolF8aqsFDeNbSNro1JDUgYqnVvPM5OILJ9DQdwIRiKmGaOsmHvhkl1FYkvv1I9r2ZJw==
   dependencies:
-    chalk "^1.1.3"
-    cross-spawn "^5.1.0"
-    fs-extra "^4.0.1"
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^1.2.1"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
     minimist "^1.2.0"
-    rimraf "^2.6.1"
-    slash "^1.0.0"
-    tmp "^0.0.31"
-    update-notifier "^2.2.0"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+    update-notifier "^2.5.0"
 
 path-dirname@^1.0.0:
   version "1.0.2"
@@ -8578,11 +8612,6 @@ sisteransi@^1.0.0:
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.0.tgz#77d9622ff909080f1c19e5f4a1df0c1b0a27b88c"
   integrity sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==
 
-slash@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
-  integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
-
 slash@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
@@ -9147,13 +9176,6 @@ tiny-glob@^0.2.6:
     globalyzer "^0.1.0"
     globrex "^0.1.1"
 
-tmp@^0.0.31:
-  version "0.0.31"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
-  integrity sha1-jzirlDjhcxXl29izZX6L+yd65Kc=
-  dependencies:
-    os-tmpdir "~1.0.1"
-
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -9411,7 +9433,7 @@ upath@^1.1.1:
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.2.tgz#3db658600edaeeccbe6db5e684d67ee8c2acd068"
   integrity sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==
 
-update-notifier@^2.2.0:
+update-notifier@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.5.0.tgz#d0744593e13f161e406acb1d9408b72cad08aff6"
   integrity sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==


### PR DESCRIPTION
Today we saw very very slow memcache server responses, as there was some brief AWS infrastructure issues.

Simulating this locally by using http://slowwly.robertomurray.co.uk/ and setting slow response times, I saw that when removing rate limiting, locally things actually worked!

The step that accesses the cache during query resolution (at the data loader level), is [already wrapped](https://github.com/artsy/metaphysics/blob/64253ff75e9bc47515ddd813f259d10651eb884f/src/lib/cache.ts#L89) to add some custom behavior around the default memcache client. Specifically, early timeouts, datadog logging, etc. We've seen occasions of high memcache latency frequently enough to warrant this. Indeed, this step timed out locally and it fell back to the underlying API. That's a good thing for resilience!

However, when I re-added rate limiting, and experimented against very slow or non existent memcache responses, I was able to replicate what we saw in production. Namely, requests never completed, and things seemed to hang.

I noticed that the [client](https://github.com/artsy/metaphysics/blob/64253ff75e9bc47515ddd813f259d10651eb884f/src/lib/rateLimiter.ts#L3) being passed in to rate limiting is the [default memcached client from the library](https://github.com/artsy/metaphysics/blob/64253ff75e9bc47515ddd813f259d10651eb884f/src/lib/cache.ts#L71-L81), and not our safe wrapper. Rather than try to start retrofitting things, I chose to patch the rate limiter library to be able to enforce a timeout around memcache access.

-----
Testing locally and this seems to work! When memcache is responding, rate limiting works fine. When memcache is down/slow, rate limiting is bypassed...

```
 [Rate Limiter]: Timeout of 100ms hit, skipping...
```

appears in logs.