### PR TITLE
@joeyAghion => [Account Request] Add mutation to create account request

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,1 @@
-src/lib/loaders/loaders_without_authentication/gravity.ts
-src/lib/loaders/loaders_with_authentication/gravity.ts
 node_modules

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1,5 +1,14 @@
 directive @principalField on FIELD
 
+type AccountRequest {
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+  notes: String
+}
+
 input AddAssetToConsignmentSubmissionInput {
   # The type of the asset
   assetType: String!
@@ -3218,6 +3227,41 @@ type ConversationResponder {
   initials(length: Int = 3): String
 }
 
+type CreateAccountRequestMutationFailure {
+  mutationError: GravityMutationError
+}
+
+input CreateAccountRequestMutationInput {
+  # Message to be sent.
+  notes: String!
+
+  # Email to associate with message.
+  email: String
+
+  # Name to associate with message.
+  name: String
+
+  # Used when logged in.
+  userID: String
+
+  # Type of account request.
+  action: String
+  clientMutationId: String
+}
+
+type CreateAccountRequestMutationPayload {
+  accountRequestOrError: CreateAccountRequestMutationType
+  clientMutationId: String
+}
+
+type CreateAccountRequestMutationSuccess {
+  accountRequest: AccountRequest
+}
+
+union CreateAccountRequestMutationType =
+    CreateAccountRequestMutationSuccess
+  | CreateAccountRequestMutationFailure
+
 input CreateBidderInput {
   saleID: String!
   clientMutationId: String
@@ -5126,6 +5170,11 @@ type Money {
 }
 
 type Mutation {
+  # Create an account request
+  createAccountRequest(
+    input: CreateAccountRequestMutationInput!
+  ): CreateAccountRequestMutationPayload
+
   # Create a bidder
   createBidder(input: CreateBidderInput!): CreateBidderPayload
 

--- a/src/lib/loaders/__tests__/api.test.ts
+++ b/src/lib/loaders/__tests__/api.test.ts
@@ -71,6 +71,7 @@ describe("API loaders", () => {
       apiLoader = apiLoaderWithoutAuthenticationFactory(api, "test_name", {
         requestIDs: { requestID: "1234", xForwardedFor: "42.42.42.42" },
         userAgent: "catty browser",
+        method: "GET",
       })
       loader = apiLoader("some/path")
     })
@@ -96,6 +97,20 @@ describe("API loaders", () => {
             expect(spy).toHaveBeenCalled()
           })
         })
+    })
+
+    it("doesnt cache the response in memcache for non GETs", () => {
+      loader = apiLoader("some/gravity/post/path", {}, { method: "POST" })
+      return loader().then(() => {
+        return cache
+          .get("some/gravity/post/path?")
+          .then(() => {
+            throw new Error("Did not expect response to be cached")
+          })
+          .catch(() => {
+            // swallow the error, because this is the expected code-path
+          })
+      })
     })
   })
 

--- a/src/lib/loaders/api/loader_without_authentication_factory.ts
+++ b/src/lib/loaders/api/loader_without_authentication_factory.ts
@@ -106,7 +106,10 @@ export const apiLoaderWithoutAuthenticationFactory = <T = any>(
               return data
             }
 
-            if (CACHE_DISABLED) {
+            // Short-circuits any reading or writing to the cache.
+            const skipCache = CACHE_DISABLED || apiOptions.method !== "GET"
+
+            if (skipCache) {
               return callApi()
                 .then(
                   finish({

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -4,46 +4,108 @@ import trackedEntityLoaderFactory from "lib/loaders/loaders_with_authentication/
 export default (accessToken, userID, opts) => {
   const gravityAccessTokenLoader = () => Promise.resolve(accessToken)
   const { gravityLoaderWithAuthenticationFactory } = factories(opts)
-  const gravityLoader = gravityLoaderWithAuthenticationFactory(gravityAccessTokenLoader)
+  const gravityLoader = gravityLoaderWithAuthenticationFactory(
+    gravityAccessTokenLoader
+  )
 
   return {
+    createAccountRequestLoader: gravityLoader(
+      "account_requests",
+      {},
+      { method: "POST" }
+    ),
     artworkLoader: gravityLoader(id => `artwork/${id}`),
-    authenticatedArtworkVersionLoader: gravityLoader(id => `artwork_version/${id}`),
-    collectionArtworksLoader: gravityLoader(id => `collection/${id}/artworks`, { user_id: userID }, { headers: true }),
-    collectionLoader: gravityLoader(id => `collection/${id}`, { user_id: userID }),
+    authenticatedArtworkVersionLoader: gravityLoader(
+      id => `artwork_version/${id}`
+    ),
+    collectionArtworksLoader: gravityLoader(
+      id => `collection/${id}/artworks`,
+      { user_id: userID },
+      { headers: true }
+    ),
+    collectionLoader: gravityLoader(id => `collection/${id}`, {
+      user_id: userID,
+    }),
     collectorProfileLoader: gravityLoader("me/collector_profile"),
     createBidderLoader: gravityLoader("bidder", {}, { method: "POST" }),
-    createBidderPositionLoader: gravityLoader("me/bidder_position", {}, { method: "POST" }),
-    createCreditCardLoader: gravityLoader("me/credit_cards", {}, { method: "POST" }),
+    createBidderPositionLoader: gravityLoader(
+      "me/bidder_position",
+      {},
+      { method: "POST" }
+    ),
+    createCreditCardLoader: gravityLoader(
+      "me/credit_cards",
+      {},
+      { method: "POST" }
+    ),
     creditCardLoader: gravityLoader(id => `credit_card/${id}`),
-    deleteArtworkLoader: gravityLoader(id => `collection/saved-artwork/artwork/${id}`, {}, { method: "DELETE" }),
-    deleteCreditCardLoader: gravityLoader(id => `me/credit_card/${id}`, {}, { method: "DELETE" }),
-    endSaleLoader: gravityLoader(id => `sale/${id}/end_sale`, {}, { method: "PUT" }),
+    deleteArtworkLoader: gravityLoader(
+      id => `collection/saved-artwork/artwork/${id}`,
+      {},
+      { method: "DELETE" }
+    ),
+    deleteCreditCardLoader: gravityLoader(
+      id => `me/credit_card/${id}`,
+      {},
+      { method: "DELETE" }
+    ),
+    endSaleLoader: gravityLoader(
+      id => `sale/${id}/end_sale`,
+      {},
+      { method: "PUT" }
+    ),
     filterArtworksLoader: gravityLoader("filter/artworks"),
-    followArtistLoader: gravityLoader("me/follow/artist", {}, { method: "POST" }),
-    followedArtistsArtworksLoader: gravityLoader("me/follow/artists/artworks", {}, { headers: true }),
-    followedArtistsLoader: gravityLoader("me/follow/artists", {}, { headers: true }),
+    followArtistLoader: gravityLoader(
+      "me/follow/artist",
+      {},
+      { method: "POST" }
+    ),
+    followedArtistsArtworksLoader: gravityLoader(
+      "me/follow/artists/artworks",
+      {},
+      { headers: true }
+    ),
+    followedArtistsLoader: gravityLoader(
+      "me/follow/artists",
+      {},
+      { headers: true }
+    ),
     followedArtistLoader: trackedEntityLoaderFactory(
       gravityLoader("me/follow/artists"),
       {
         paramKey: "artists",
         trackingKey: "is_followed",
-        entityKeyPath: "artist"
+        entityKeyPath: "artist",
       }
     ),
-    followedGeneLoader: trackedEntityLoaderFactory(gravityLoader("me/follow/genes"), {
-      paramKey: "genes", trackingKey: "is_followed", entityKeyPath: "gene"
-    }),
-    followedGenesLoader: gravityLoader<{ gene: { id: string, name: string } }[]>("me/follow/genes", {}, { headers: true }),
-    followedProfilesArtworksLoader: gravityLoader("me/follow/profiles/artworks", {}, { headers: true }),
+    followedGeneLoader: trackedEntityLoaderFactory(
+      gravityLoader("me/follow/genes"),
+      {
+        paramKey: "genes",
+        trackingKey: "is_followed",
+        entityKeyPath: "gene",
+      }
+    ),
+    followedGenesLoader: gravityLoader<
+      { gene: { id: string; name: string } }[]
+    >("me/follow/genes", {}, { headers: true }),
+    followedProfilesArtworksLoader: gravityLoader(
+      "me/follow/profiles/artworks",
+      {},
+      { headers: true }
+    ),
     followGeneLoader: gravityLoader("me/follow/gene", {}, { method: "POST" }),
-    followProfileLoader: gravityLoader("me/follow/profile", {}, { method: "POST" }),
+    followProfileLoader: gravityLoader(
+      "me/follow/profile",
+      {},
+      { method: "POST" }
+    ),
     followedProfileLoader: trackedEntityLoaderFactory(
       gravityLoader("me/follow/profiles"),
       {
         paramKey: "profiles",
         trackingKey: "is_followed",
-        entityKeyPath: "profile"
+        entityKeyPath: "profile",
       }
     ),
     followShowLoader: gravityLoader("follow_shows", {}, { method: "POST" }),
@@ -58,25 +120,63 @@ export default (accessToken, userID, opts) => {
         entityIDKeyPath: "_id",
       }
     ),
-    followedFairsLoader: gravityLoader("/me/follow/profiles", {}, { headers: true }),
-    followedPartnersLoader: gravityLoader("/me/follow/profiles", {}, { headers: true }),
+    followedFairsLoader: gravityLoader(
+      "/me/follow/profiles",
+      {},
+      { headers: true }
+    ),
+    followedPartnersLoader: gravityLoader(
+      "/me/follow/profiles",
+      {},
+      { headers: true }
+    ),
     homepageModulesLoader: gravityLoader("me/modules"),
-    homepageSuggestedArtworksLoader: gravityLoader("me/suggested/artworks/homepage"),
-    inquiryRequestsLoader: gravityLoader("me/inquiry_requests", {}, { headers: true }),
+    homepageSuggestedArtworksLoader: gravityLoader(
+      "me/suggested/artworks/homepage"
+    ),
+    inquiryRequestsLoader: gravityLoader(
+      "me/inquiry_requests",
+      {},
+      { headers: true }
+    ),
     lotStandingLoader: gravityLoader("me/lot_standings"),
-    meBidderPositionLoader: gravityLoader(id => `me/bidder_position/${id}/`, {}, { headers: true }),
+    meBidderPositionLoader: gravityLoader(
+      id => `me/bidder_position/${id}/`,
+      {},
+      { headers: true }
+    ),
     meBidderPositionsLoader: gravityLoader("me/bidder_positions"),
     meBiddersLoader: gravityLoader("me/bidders"),
-    meCreditCardsLoader: gravityLoader("me/credit_cards", {}, { headers: true }),
+    meCreditCardsLoader: gravityLoader(
+      "me/credit_cards",
+      {},
+      { headers: true }
+    ),
     meLoader: gravityLoader("me"),
     mePartnersLoader: gravityLoader("me/partners"),
     notificationsFeedLoader: gravityLoader("me/notifications/feed"),
     popularArtistsLoader: gravityLoader("artists/popular"),
-    recordArtworkViewLoader: gravityLoader("me/recently_viewed_artworks", {}, { method: "POST" }),
-    saleArtworksAllLoader: gravityLoader("sale_artworks", {}, { headers: true }),
+    recordArtworkViewLoader: gravityLoader(
+      "me/recently_viewed_artworks",
+      {},
+      { method: "POST" }
+    ),
+    saleArtworksAllLoader: gravityLoader(
+      "sale_artworks",
+      {},
+      { headers: true }
+    ),
     saleArtworksFilterLoader: gravityLoader("filter/sale_artworks"),
-    saleArtworksLoader: gravityLoader(id => `sale/${id}/sale_artworks`, {}, { headers: true }),
-    saveArtworkLoader: gravityLoader(id => `collection/saved-artwork/artwork/${id}`, {}, { method: "POST" }),
+    saleArtworksLoader: gravityLoader(
+      id => `sale/${id}/sale_artworks`,
+      {},
+      { headers: true }
+    ),
+    saveArtworkLoader: gravityLoader(
+      id => `collection/saved-artwork/artwork/${id}`,
+      {},
+      { method: "POST" }
+    ),
     savedArtworkLoader: trackedEntityLoaderFactory(
       gravityLoader("collection/saved-artwork/artworks", {
         user_id: userID,
@@ -84,17 +184,40 @@ export default (accessToken, userID, opts) => {
       }),
       {
         paramKey: "artworks",
-        trackingKey: "is_saved"
+        trackingKey: "is_saved",
       }
     ),
-    savedArtworksLoader: gravityLoader("collection/saved-artwork/artworks", { user_id: userID, private: true }),
+    savedArtworksLoader: gravityLoader("collection/saved-artwork/artworks", {
+      user_id: userID,
+      private: true,
+    }),
     sendFeedbackLoader: gravityLoader("feedback", {}, { method: "POST" }),
     showLoader: gravityLoader(id => `show/${id}`),
-    suggestedArtistsLoader: gravityLoader("me/suggested/artists", {}, { headers: true }),
-    suggestedSimilarArtistsLoader: gravityLoader(`user/${userID}/suggested/similar/artists`, {}, { headers: true }),
-    unfollowArtistLoader: gravityLoader(id => `me/follow/artist/${id}`, {}, { method: "DELETE" }),
-    unfollowProfileLoader: gravityLoader(id => `me/follow/profile/${id}`, {}, { method: "DELETE" }),
-    updateCollectorProfileLoader: gravityLoader("me/collector_profile", {}, { method: "PUT" }),
+    suggestedArtistsLoader: gravityLoader(
+      "me/suggested/artists",
+      {},
+      { headers: true }
+    ),
+    suggestedSimilarArtistsLoader: gravityLoader(
+      `user/${userID}/suggested/similar/artists`,
+      {},
+      { headers: true }
+    ),
+    unfollowArtistLoader: gravityLoader(
+      id => `me/follow/artist/${id}`,
+      {},
+      { method: "DELETE" }
+    ),
+    unfollowProfileLoader: gravityLoader(
+      id => `me/follow/profile/${id}`,
+      {},
+      { method: "DELETE" }
+    ),
+    updateCollectorProfileLoader: gravityLoader(
+      "me/collector_profile",
+      {},
+      { method: "PUT" }
+    ),
     updateMeLoader: gravityLoader("me", {}, { method: "PUT" }),
     usersLoader: gravityLoader("users"),
   }

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -27,6 +27,11 @@ export default opts => {
   }
 
   return {
+    createAccountRequestLoader: gravityLoader(
+      "account_requests",
+      {},
+      { method: "POST" }
+    ),
     artistArtworksLoader: gravityLoader(id => `artist/${id}/artworks`),
     artistGenesLoader: gravityLoader(id => `artist/${id}/genome/genes`),
     artistLoader: gravityLoader(id => `artist/${id}`),

--- a/src/schema/v2/__tests__/createAccountRequestMutation.test.ts
+++ b/src/schema/v2/__tests__/createAccountRequestMutation.test.ts
@@ -1,0 +1,43 @@
+/* eslint-disable promise/always-return */
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("creating an account request", () => {
+  const accountRequest = {
+    id: "mongo id",
+    notes: "Catty message",
+  }
+
+  const query = `
+  mutation {
+    createAccountRequest(input: {action: "user_data", notes: "Catty message", userID: "catty id"}) {
+      accountRequestOrError {
+        ... on CreateAccountRequestMutationSuccess {
+          accountRequest {
+            notes
+          }
+        }
+        ... on CreateAccountRequestMutationFailure {
+          mutationError {
+            type
+            message
+            detail
+          }
+        }
+      }
+    }
+  }
+  `
+
+  const context = {
+    createAccountRequestLoader: () => Promise.resolve(accountRequest),
+  }
+
+  it("creates an account request", async () => {
+    const data = await runAuthenticatedQuery(query, context)
+    expect(data).toEqual({
+      createAccountRequest: {
+        accountRequestOrError: { accountRequest: { notes: "Catty message" } },
+      },
+    })
+  })
+})

--- a/src/schema/v2/createAccountRequestMutation.ts
+++ b/src/schema/v2/createAccountRequestMutation.ts
@@ -1,0 +1,124 @@
+import {
+  GraphQLNonNull,
+  GraphQLString,
+  GraphQLInputObjectType,
+  GraphQLObjectType,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import {
+  GravityMutationErrorType,
+  formatGravityError,
+} from "lib/gravityErrorHandler"
+import { InternalIDFields } from "./object_identification"
+
+const AccountRequestType = new GraphQLObjectType<any, ResolverContext>({
+  name: "AccountRequest",
+  fields: () => ({
+    ...InternalIDFields,
+    notes: { type: GraphQLString },
+  }),
+})
+
+const CreateAccountRequestMutationSuccessType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "CreateAccountRequestMutationSuccess",
+  isTypeOf: data => data.id,
+  fields: () => ({
+    accountRequest: {
+      type: AccountRequestType,
+      resolve: accountRequest => accountRequest,
+    },
+  }),
+})
+
+const CreateAccountRequestMutationFailureType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "CreateAccountRequestMutationFailure",
+  isTypeOf: data => {
+    return data._type === "GravityMutationError"
+  },
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: err => err,
+    },
+  }),
+})
+
+const CreateAccountRequestMutationType = new GraphQLUnionType({
+  name: "CreateAccountRequestMutationType",
+  types: [
+    CreateAccountRequestMutationSuccessType,
+    CreateAccountRequestMutationFailureType,
+  ],
+})
+
+const CreateAccountRequestInputType = new GraphQLInputObjectType({
+  name: "CreateAccountRequestInput",
+  fields: {
+    notes: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "Message to be sent.",
+    },
+    email: {
+      type: GraphQLString,
+      description: "Email to associate with message.",
+    },
+    name: {
+      type: GraphQLString,
+      description: "Name to associate with message.",
+    },
+    userID: {
+      type: GraphQLString,
+      description: "Used when logged in.",
+    },
+    action: {
+      type: GraphQLString,
+      description: "Type of account request.",
+    },
+  },
+})
+
+export const createAccountRequestMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "CreateAccountRequestMutation",
+  description: "Create an account request",
+  inputFields: CreateAccountRequestInputType.getFields(),
+  outputFields: {
+    accountRequestOrError: {
+      type: CreateAccountRequestMutationType,
+      resolve: result => result,
+    },
+  },
+  mutateAndGetPayload: (
+    { notes, email, userID, action, name },
+    { createAccountRequestLoader }
+  ) => {
+    const gravityOptions = {
+      notes,
+      email,
+      user_id: userID,
+      action,
+      name,
+    }
+    return createAccountRequestLoader(gravityOptions)
+      .then(result => result)
+      .catch(error => {
+        const formattedErr = formatGravityError(error)
+        if (formattedErr) {
+          return { ...formattedErr, _type: "GravityMutationError" }
+        } else {
+          throw new Error(error)
+        }
+      })
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -72,6 +72,7 @@ import { deleteCreditCardMutation } from "./me/delete_credit_card_mutation"
 import { BidderPositionMutation } from "./me/bidder_position_mutation"
 import { sendFeedbackMutation } from "./sendFeedbackMutation"
 import { OrderPartyUnionType } from "./ecommerce/types/order_party_union"
+import { createAccountRequestMutation } from "./createAccountRequestMutation"
 
 import { SearchableItem } from "./SearchableItem"
 import { ArtistArtworkGridType } from "./artwork/artworkContextGrids/ArtistArtworkGrid"
@@ -178,6 +179,7 @@ export default new GraphQLSchema({
   mutation: new GraphQLObjectType<any, ResolverContext>({
     name: "Mutation",
     fields: {
+      createAccountRequest: createAccountRequestMutation,
       createBidder: createBidderMutation,
       createBidderPosition: BidderPositionMutation,
       createCreditCard: createCreditCardMutation,


### PR DESCRIPTION
Uses https://github.com/artsy/gravity/pull/12707/files

Rather than stitch a new mutation in, this adds a bespoke one pointing to the V1 API endpoint, which is already in use by other clients.

Looks like:

![search](https://user-images.githubusercontent.com/1457859/71300663-ea21b200-2364-11ea-990b-812d01c27cc8.gif)

```
gravity:development> AccountRequest.first
=> #<AccountRequest _id: 5dfd70d310f20c7e6501824f, created_at: 2019-12-21 01:09:39 UTC, updated_at: 2019-12-21 01:09:39 UTC, requester_id: nil, user_id: nil, action: "user_data", tracking_number: "257C7A31DEF6", notes: "dont sell", email: "percy@cat.com", name: "percy", stripe_customer_id: nil>
```
