### PR TITLE
@joeyAghion => [Rate Limiting] Skip middleware entirely when disabled

### DIFF
--- a/src/lib/rateLimiter.ts
+++ b/src/lib/rateLimiter.ts
@@ -12,6 +12,7 @@ export const skip = (req: Request) => !!req.headers["x-datadog-trace-id"]
 // underlying memcache client can sometimes hang. It's good to
 // wrap cache access with a timeout to avoid this.
 export const rateLimiterMiddleware = async (req, res, next) => {
+  if (!config.RATE_LIMIT_MAX) return next()
   try {
     await new Promise((resolve, reject) => {
       // Timeout handler, will reject if hit.


### PR DESCRIPTION
When disabled with a value of 0, the cache access, incrementing, etc. is all invoked. It's only at the [very end](https://github.com/nfriedly/express-rate-limit/blob/757fb450241748ba970315c81df203a9bbd394ba/lib/express-rate-limit.js#L123-L127) where the actual request is simply not blocked.