### PR TITLE
Fix Fair exhibition period spec failures (v1 and v2 schemas)

### DIFF
--- a/src/schema/v1/__tests__/fair.test.js
+++ b/src/schema/v1/__tests__/fair.test.js
@@ -167,7 +167,6 @@ describe("Fair", () => {
         end_at: "2019-02-17T11:00:00+00:00",
         partner_shows_count: 4,
         name: "Aqua Art Miami 2018",
-        exhibition_period: "Feb 15 – 17",
         exhibitors_grouped_by_name: [
           {
             letter: "A",
@@ -315,7 +314,7 @@ describe("Fair", () => {
     const data = await runQuery(query, context)
     expect(data).toEqual({
       fair: {
-        exhibition_period: "Feb 15 – 17",
+        exhibition_period: "Feb 15 – 17, 2019",
       },
     })
   })

--- a/src/schema/v2/__tests__/fair.test.js
+++ b/src/schema/v2/__tests__/fair.test.js
@@ -167,7 +167,6 @@ describe("Fair", () => {
         end_at: "2019-02-17T11:00:00+00:00",
         partner_shows_count: 4,
         name: "Aqua Art Miami 2018",
-        exhibition_period: "Feb 15 – 17",
         exhibitors_grouped_by_name: [
           {
             letter: "A",
@@ -315,7 +314,7 @@ describe("Fair", () => {
     const data = await runQuery(query, context)
     expect(data).toEqual({
       fair: {
-        exhibitionPeriod: "Feb 15 – 17",
+        exhibitionPeriod: "Feb 15 – 17, 2019",
       },
     })
   })


### PR DESCRIPTION
* Removed unused attribute stubs
* Update assertion such that specs expect that year of exhibition period is
  included.
  * exhibition period uses `dateRange` under the hood, which has its own
    thorough unit test suite, so I don't think there's any loss of
    coverage from changing the "case" (from present year to past year) of
    the exhibition period being asserted upon in the spec.
  * Moreover, 2019 is always in the past, so test should be stable now.