### PR TITLE
[FX-1706] Add ability to limit number of merchandisable artists in a collection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4016,7 +4016,10 @@ type FilterArtworksConnection implements Node & ArtworkConnectionInterface {
     @deprecated(reason: "Prefer to use `edges`. [Will be removed in v2]")
 
   # Returns a list of merchandisable artists sorted by merch score.
-  merchandisableArtists: [Artist]
+  merchandisableArtists(
+    # The number of artists to return
+    size: Int
+  ): [Artist]
   facet: ArtworkFilterFacet
   pageCursors: PageCursors!
 }

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4018,7 +4018,7 @@ type FilterArtworksConnection implements Node & ArtworkConnectionInterface {
   # Returns a list of merchandisable artists sorted by merch score.
   merchandisableArtists(
     # The number of artists to return
-    size: Int
+    size: Int = 12
   ): [Artist]
   facet: ArtworkFilterFacet
   pageCursors: PageCursors!

--- a/src/schema/v2/__tests__/filterArtworksConnection.test.ts
+++ b/src/schema/v2/__tests__/filterArtworksConnection.test.ts
@@ -505,7 +505,7 @@ describe("artworksConnection", () => {
             first: 3
             aggregations: [MERCHANDISABLE_ARTISTS]
           ) {
-            merchandisableArtists(size: 3) {
+            merchandisableArtists(size: 2) {
               slug
             }
             edges {
@@ -520,13 +520,12 @@ describe("artworksConnection", () => {
       const { artworksConnection } = await runQuery(query, context)
       const artistIdsToLoad = context.artistsLoader.mock.calls[0][0].ids
 
-      expect(artistIdsToLoad).toEqual(["id-1", "id-2", "id-3"])
+      expect(artistIdsToLoad).toEqual(["id-1", "id-2"])
 
-      expect(artworksConnection.merchandisableArtists).toHaveLength(3)
+      expect(artworksConnection.merchandisableArtists).toHaveLength(2)
       expect(artworksConnection.merchandisableArtists).toEqual([
         { slug: "takashi-murakami" },
         { slug: "yamaguchi-ai" },
-        { slug: "yoshitomo-nara" },
       ])
     })
   })

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -273,12 +273,27 @@ export const FilterArtworksFields = () => {
       type: new GraphQLList(Artist.type),
       description:
         "Returns a list of merchandisable artists sorted by merch score.",
-      resolve: ({ aggregations }, _options, { artistsLoader }) => {
+      args: {
+        size: {
+          type: GraphQLInt,
+          description: "The number of artists to return",
+        },
+      },
+      resolve: (
+        { aggregations },
+        { size }: { size?: number },
+        { artistsLoader }
+      ) => {
         if (!isExisty(aggregations.merchandisable_artists)) {
           return null
         }
+
+        const artistIdsToReturn = size
+          ? keys(aggregations.merchandisable_artists).slice(0, size)
+          : keys(aggregations.merchandisable_artists)
+
         return artistsLoader({
-          ids: keys(aggregations.merchandisable_artists),
+          ids: artistIdsToReturn,
         })
       },
     },

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -277,20 +277,17 @@ export const FilterArtworksFields = () => {
         size: {
           type: GraphQLInt,
           description: "The number of artists to return",
+          default: 12,
         },
       },
-      resolve: (
-        { aggregations },
-        { size }: { size?: number },
-        { artistsLoader }
-      ) => {
+      resolve: ({ aggregations }, { size }: any, { artistsLoader }) => {
         if (!isExisty(aggregations.merchandisable_artists)) {
           return null
         }
 
-        const artistIdsToReturn = size
-          ? keys(aggregations.merchandisable_artists).slice(0, size)
-          : keys(aggregations.merchandisable_artists)
+        const artistIdsToReturn = keys(
+          aggregations.merchandisable_artists
+        ).slice(0, size)
 
         return artistsLoader({
           ids: artistIdsToReturn,

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -277,7 +277,7 @@ export const FilterArtworksFields = () => {
         size: {
           type: GraphQLInt,
           description: "The number of artists to return",
-          default: 12,
+          defaultValue: 12,
         },
       },
       resolve: ({ aggregations }, { size }: any, { artistsLoader }) => {


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-1706

When fetching artworks belonging to a collection, we usually also want to fetch a list of merchandisable artists that is extrapolated from that artwork result set.

Currently the list of merchandisable artists is unbounded. This PR adds the ability to cap that list at a provided `size`.

![size](https://user-images.githubusercontent.com/140521/72836423-97d0fb00-3c5a-11ea-9004-93599bf6464b.png)

Digging into this I [realized](https://artsy.slack.com/archives/C1HH3KNJG/p1579281411000500) that this root `artworksConnection` field had its specs [disabled](https://github.com/artsy/metaphysics/pull/1920) back in the v2 migration. So I re-enable them here, and update a few things while I'm at it in 04362de

Following that, the real business of adding the `size` argument is in c98c46f
