### PR TITLE
@joeyAghion => [Tracing] Remove graphql resolver tracking

### DIFF
--- a/src/lib/tracer.ts
+++ b/src/lib/tracer.ts
@@ -21,14 +21,6 @@ export function init() {
   tracer.use("http", {
     service: `${DD_TRACER_SERVICE_NAME}.http-client`,
   })
-  tracer.use("graphql", {
-    service: `${DD_TRACER_SERVICE_NAME}.graphql`,
-    /**
-     * NOTE: This means we capture _all_ variables. When/if needed, we can
-     *       use this callback to redact sensitive variables.
-     */
-    variables: variables => variables,
-  } as any)
 }
 
 const createCommand = (command: string) => <T>(


### PR DESCRIPTION
Was thinking about doing `hokusai env unset ENABLE_QUERY_TRACING && hokusai refresh`, but looks like that would turn off _all_ the Datadog tracing here, whereas the others here (`express` and `http`) are still moderately useful.