### PR TITLE
Fix availability sort to use correct value sent to gravity

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1247,7 +1247,7 @@ type ArtworksAggregationResults {
 }
 
 enum ArtworkSorts {
-  AVAILABILITY_DESC
+  AVAILABILITY_ASC
   CREATED_AT_ASC
   CREATED_AT_DESC
   DELETED_AT_ASC

--- a/src/schema/v2/sorts/artwork_sorts.ts
+++ b/src/schema/v2/sorts/artwork_sorts.ts
@@ -4,8 +4,8 @@ const ArtworkSorts = {
   type: new GraphQLEnumType({
     name: "ArtworkSorts",
     values: {
-      AVAILABILITY_DESC: {
-        value: "-availability",
+      AVAILABILITY_ASC: {
+        value: "availability",
       },
       CREATED_AT_ASC: {
         value: "created_at",


### PR DESCRIPTION
This looks like a breaking change, but `AVAILABILITY_DESC` must not be used by clients currently as it's not a valid sort value according to gravity, which only accepts [`availability`](https://github.com/artsy/gravity/blob/master/app/models/domain/artwork.rb#L153).

Indeed, passing `AVAILABILITY_DESC` returns an error:
<img width="1026" alt="Screen Shot 2020-01-22 at 2 27 59 PM" src="https://user-images.githubusercontent.com/2081340/72927193-bb13ad00-3d23-11ea-9a38-38a7317579c0.png">

This PR updates this sort to `AVAILABILITY_ASC`, which is a valid sort value.
<img width="1231" alt="Screen Shot 2020-01-22 at 2 29 05 PM" src="https://user-images.githubusercontent.com/2081340/72927222-c8c93280-3d23-11ea-99c6-387d58df4a89.png">