### PR TITLE
@zephraph => [Danger] Warn when MP PR introduces breaking changes to V2 schema

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,10 @@ workflows:
           <<: *only_development
           name: schema-drift
           script: danger local -d scripts/schema-drift.ts
+      - yarn/run:
+          <<: *only_development
+          name: compare-reaction-schema
+          script: danger local -d scripts/compare-reaction-schema.ts
 
       # pre-staging
       - hokusai/test:

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
   },
   "devDependencies": {
     "@artsy/express-reloadable": "1.4.7",
+    "@graphql-inspector/core": "^1.27.0",
     "@types/express-rate-limit": "2.9.3",
     "@types/graphql-relay": "0.4.9",
     "@types/invariant": "2.2.29",

--- a/scripts/compare-reaction-schema.ts
+++ b/scripts/compare-reaction-schema.ts
@@ -1,0 +1,29 @@
+import { buildSchema } from "graphql"
+import { readFileSync } from "fs"
+const { diff: schemaDiff } = require("@graphql-inspector/core")
+import fetch from "node-fetch"
+
+// If there is a breaking change between the local schema,
+// and the current Reaction one, warn.
+;(async () => {
+  const forcePackageJSON = await (await fetch(
+    "https://raw.githubusercontent.com/artsy/force/release/package.json"
+  )).json()
+  const reactionVersion = forcePackageJSON["dependencies"]["@artsy/reaction"]
+  const reactionSchemaUrl = `https://github.com/artsy/reaction/raw/v${reactionVersion}/data/schema.graphql`
+
+  const reactionSchema = await (await fetch(reactionSchemaUrl)).text()
+  const localSchema = readFileSync("_schemaV2.graphql", "utf8")
+
+  const allChanges = schemaDiff(
+    buildSchema(reactionSchema),
+    buildSchema(localSchema)
+  )
+  const breakings = allChanges.filter(c => c.criticality.level === "BREAKING")
+  const messages = breakings.map(c => c.message)
+  if (messages.length) {
+    warn(
+      `The V2 schema in this PR has breaking changes with production Force. Remember to update Reaction if necessary:\n\n${messages}`
+    )
+  }
+})()

--- a/yarn.lock
+++ b/yarn.lock
@@ -872,6 +872,13 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@graphql-inspector/core@^1.27.0":
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/@graphql-inspector/core/-/core-1.27.0.tgz#87993675e9a1fd1e2f6cc1e1ea42afa098ae58b4"
+  integrity sha512-A5VnmNXj/5w8aoBLI3oEHWCYZAiRyMmmM0cJefKv/HYyBe6TYMzSRJLPvNp9mq3bKXU2szYp5NM5b1Bud2t5rQ==
+  dependencies:
+    dependency-graph "0.8.1"
+
 "@heroku/foreman@2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@heroku/foreman/-/foreman-2.0.2.tgz#e24f8611bb0633ca89095648243d3a90564749fc"
@@ -3228,6 +3235,11 @@ depd@~1.1.1, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
+dependency-graph@0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-0.8.1.tgz#9b8cae3aa2c7bd95ccb3347a09a2d1047a6c3c5a"
+  integrity sha512-g213uqF8fyk40W8SBjm079n3CZB4qSpCrA2ye1fLGzH/4HEgB6tzuW2CbLE7leb4t45/6h44Ud59Su1/ROTfqw==
 
 deprecated-decorator@^0.1.6:
   version "0.1.6"


### PR DESCRIPTION
(when compared to currently deployed Reaction).

I _think_ this makes sense as a check? It's sort of the Force production schema check (does MP production have any breaking changes when compared to the one included in the to-be-released version), but inverted.

Does this MP PR have any breaking changes when compared to the currently deployed Force version? If so, that makes Force undeployable.