### PR TITLE
[PUR-1602] Sort Other Works By section by merchandisability rating

### DIFF
--- a/src/schema/v2/artwork/artworkContextGrids/ArtistArtworkGrid.ts
+++ b/src/schema/v2/artwork/artworkContextGrids/ArtistArtworkGrid.ts
@@ -45,7 +45,7 @@ export const ArtistArtworkGridType = new GraphQLObjectType<
           options,
           artwork,
         })
-        gravityArgs.sort = "-published_at"
+        gravityArgs.sort = "-merchandisability"
 
         return artistArtworksLoader(artist.id, gravityArgs).then(artworks => {
           if (!artworks) return null

--- a/src/schema/v2/artwork/artworkContextGrids/__tests__/defaultContext.test.ts
+++ b/src/schema/v2/artwork/artworkContextGrids/__tests__/defaultContext.test.ts
@@ -71,6 +71,28 @@ describe("Default Context", () => {
     }
   })
 
+  it("Calls the loader class with the correct arguments", async () => {
+    const artistArtworks = [
+      { id: "artwork1", title: "Artwork 1" },
+      { id: "artwork2", title: "Artwork 2" },
+      { id: "artwork3", title: "Artwork 3" },
+    ]
+    context.artistArtworksLoader = jest.fn(() =>
+      Promise.resolve(artistArtworks)
+    )
+
+    await runAuthenticatedQuery(query, context).then(data => {
+      expect(data.artwork.contextGrids.length).toEqual(3)
+      expect(context.artistArtworksLoader).toHaveBeenCalledWith("andy-warhol", {
+        exclude_ids: ["abc123"],
+        page: 1,
+        size: 2,
+        sort: "-merchandisability",
+      })
+    })
+    expect.assertions(2)
+  })
+
   it("Returns the correct values for metadata fields when there is just artist data", async () => {
     parentArtwork.partner = null
     context.partnerArtworksLoader = Promise.resolve(null)
@@ -109,7 +131,6 @@ describe("Default Context", () => {
         ctaHref,
         artworksConnection,
       } = data.artwork.contextGrids[0]
-
       expect(title).toEqual("Other works from CAMA Gallery")
       expect(ctaTitle).toEqual("View all works from CAMA Gallery")
       expect(ctaHref).toEqual("/cama-gallery")


### PR DESCRIPTION
Update sorting in the Other Works By section of the artist page to be based on desc merchandisability
[Jira Ticket](https://artsyproduct.atlassian.net/browse/PURCHASE-1602)

Paired with @sepans 🎉 


Testing
To test this change we ran metaphysics locally and saw the data sorting change

Before code change:
`artist/jr/artworks?exclude_ids%5B%5D=5b5ca00b5622c23c3700fa8b&page=1&size=8&sort=-published_at`

<img width="1680" alt="Screen Shot 2020-01-29 at 3 00 43 PM" src="https://user-images.githubusercontent.com/12748344/73394133-004b5800-42ab-11ea-8adc-61f5b844158e.png">




After code change:
`artist/jr/artworks?exclude_ids%5B%5D=5b5ca00b5622c23c3700fa8b&page=1&size=8&sort=-merchandisability`


<img width="1676" alt="Screen Shot 2020-01-29 at 3 00 05 PM" src="https://user-images.githubusercontent.com/12748344/73394138-03464880-42ab-11ea-9385-f84bb369e737.png">
