### PR TITLE
Moving commerceMyOrders under me root field

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -10400,6 +10400,25 @@ type Query {
     orderStates: [CommerceOrderStateEnum!]
   ): CommerceLineItemConnection
 
+  # Return my orders
+  commerceMyOrders(
+    # Returns the elements in the list that come after the specified cursor.
+    after: String
+
+    # Returns the elements in the list that come before the specified cursor.
+    before: String
+
+    # Returns the first _n_ elements from the list.
+    first: Int
+
+    # Returns the last _n_ elements from the list.
+    last: Int
+    mode: CommerceOrderModeEnum
+    sellerId: String
+    sort: CommerceOrderConnectionSortEnum
+    state: CommerceOrderStateEnum
+  ): CommerceOrderConnectionWithTotalCount
+
   # Find an order by ID
   commerceOrder(code: String, id: ID): CommerceOrder
 

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -7931,6 +7931,16 @@ type Me implements Node {
     size: Int
   ): [Artist]
   type: String
+  orders(
+    first: Int
+    last: Int
+    after: String
+    before: String
+    mode: CommerceOrderModeEnum
+    sellerId: String
+    sort: CommerceOrderConnectionSortEnum
+    state: CommerceOrderStateEnum
+  ): CommerceOrderConnectionWithTotalCount
 }
 
 # A message in a conversation.
@@ -10389,25 +10399,6 @@ type Query {
     last: Int
     orderStates: [CommerceOrderStateEnum!]
   ): CommerceLineItemConnection
-
-  # Return my orders
-  commerceMyOrders(
-    # Returns the elements in the list that come after the specified cursor.
-    after: String
-
-    # Returns the elements in the list that come before the specified cursor.
-    before: String
-
-    # Returns the first _n_ elements from the list.
-    first: Int
-
-    # Returns the last _n_ elements from the list.
-    last: Int
-    mode: CommerceOrderModeEnum
-    sellerId: String
-    sort: CommerceOrderConnectionSortEnum
-    state: CommerceOrderStateEnum
-  ): CommerceOrderConnectionWithTotalCount
 
   # Find an order by ID
   commerceOrder(code: String, id: ID): CommerceOrder

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5222,6 +5222,16 @@ type Me implements Node {
     last: Int
   ): ArtworkConnection
   type: String
+  orders(
+    first: Int
+    last: Int
+    after: String
+    before: String
+    mode: CommerceOrderModeEnum
+    sellerId: String
+    sort: CommerceOrderConnectionSortEnum
+    state: CommerceOrderStateEnum
+  ): CommerceOrderConnectionWithTotalCount
 }
 
 # A message in a conversation.
@@ -6119,25 +6129,6 @@ type Query {
     last: Int
     orderStates: [CommerceOrderStateEnum!]
   ): CommerceLineItemConnection
-
-  # Return my orders
-  commerceMyOrders(
-    # Returns the elements in the list that come after the specified cursor.
-    after: String
-
-    # Returns the elements in the list that come before the specified cursor.
-    before: String
-
-    # Returns the first _n_ elements from the list.
-    first: Int
-
-    # Returns the last _n_ elements from the list.
-    last: Int
-    mode: CommerceOrderModeEnum
-    sellerId: String
-    sort: CommerceOrderConnectionSortEnum
-    state: CommerceOrderStateEnum
-  ): CommerceOrderConnectionWithTotalCount
 
   # Find an order by ID
   commerceOrder(code: String, id: ID): CommerceOrder

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6130,6 +6130,25 @@ type Query {
     orderStates: [CommerceOrderStateEnum!]
   ): CommerceLineItemConnection
 
+  # Return my orders
+  commerceMyOrders(
+    # Returns the elements in the list that come after the specified cursor.
+    after: String
+
+    # Returns the elements in the list that come before the specified cursor.
+    before: String
+
+    # Returns the first _n_ elements from the list.
+    first: Int
+
+    # Returns the last _n_ elements from the list.
+    last: Int
+    mode: CommerceOrderModeEnum
+    sellerId: String
+    sort: CommerceOrderConnectionSortEnum
+    state: CommerceOrderStateEnum
+  ): CommerceOrderConnectionWithTotalCount
+
   # Find an order by ID
   commerceOrder(code: String, id: ID): CommerceOrder
 

--- a/src/lib/stitching/__tests__/mergeSchemas.test.js
+++ b/src/lib/stitching/__tests__/mergeSchemas.test.js
@@ -1,7 +1,7 @@
 import { runQueryMerged } from "test/utils"
 import gql from "lib/gql"
 
-describe("stiched schema regressions", () => {
+describe("stitched schema regressions", () => {
   it("union in interface fragment issue", async () => {
     const artworkResponse = {
       id: "banksy-di-faced-tenner-21",

--- a/src/lib/stitching/exchange/__tests__/stitching.test.ts
+++ b/src/lib/stitching/exchange/__tests__/stitching.test.ts
@@ -28,6 +28,12 @@ it("extends the Order objects", async () => {
   }
 })
 
+it("extends the Me object", async () => {
+  const mergedSchema = await getExchangeMergedSchema()
+  const meFields = await getFieldsForTypeFromSchema("Me", mergedSchema)
+  expect(meFields).toContain("orders")
+})
+
 it("resolves amount fields on CommerceOrder", async () => {
   const { resolvers } = await getExchangeStitchedSchema()
   const totalListPriceResolver = resolvers.CommerceOrder.totalListPrice.resolve

--- a/src/lib/stitching/exchange/schema.ts
+++ b/src/lib/stitching/exchange/schema.ts
@@ -4,6 +4,7 @@ import {
   transformSchema,
   RenameTypes,
   RenameRootFields,
+  FilterRootFields,
 } from "graphql-tools"
 import { readFileSync } from "fs"
 import { ReplaceCommerceDateTimeType } from "./transformers/replaceCommerceDateTimeType"
@@ -22,7 +23,12 @@ export const executableExchangeSchema = transforms => {
   // Note that changes in this will need to be
 }
 
+const removeRootFieldList = ["myOrders"]
+
 export const transformsForExchange = [
+  new FilterRootFields(
+    (_operation, name) => !removeRootFieldList.includes(name)
+  ),
   // Apply a prefix to all the typenames
   new RenameTypes(name => {
     return `Commerce${name}`

--- a/src/lib/stitching/exchange/schema.ts
+++ b/src/lib/stitching/exchange/schema.ts
@@ -4,7 +4,6 @@ import {
   transformSchema,
   RenameTypes,
   RenameRootFields,
-  FilterRootFields,
 } from "graphql-tools"
 import { readFileSync } from "fs"
 import { ReplaceCommerceDateTimeType } from "./transformers/replaceCommerceDateTimeType"
@@ -23,12 +22,7 @@ export const executableExchangeSchema = transforms => {
   // Note that changes in this will need to be
 }
 
-const removeRootFieldList = ["myOrders"]
-
 export const transformsForExchange = [
-  new FilterRootFields(
-    (_operation, name) => !removeRootFieldList.includes(name)
-  ),
   // Apply a prefix to all the typenames
   new RenameTypes(name => {
     return `Commerce${name}`

--- a/src/lib/stitching/exchange/stitching.ts
+++ b/src/lib/stitching/exchange/stitching.ts
@@ -262,19 +262,14 @@ export const exchangeStitchingEnvironment = ({
             __typename
           }`,
           resolve: async (_source, args, context, info) => {
-            console.log("------> here", args, _source)
-            const result = await info.mergeInfo.delegateToSchema({
+            return await info.mergeInfo.delegateToSchema({
               schema: exchangeSchema,
               operation: "query",
-              fieldName: "myOrders",
-              args: {
-                first: 10,
-              },
+              fieldName: "commerceMyOrders",
+              args,
               context,
               info,
             })
-            console.log("======>", result)
-            return result
           },
         },
       },


### PR DESCRIPTION
# Problem
We want to move newly added `commerceMyOrders` root field coming from Exchange to under `me` root field.

# Followup
We need to update Reaction's newly my purchases query to use this field under `me`. If we managed to remove `commerceMyOrders` root field here it may break that page but since it's admin only it should be ok.