### PR TITLE
PURCHASE-1745: add support for filter by organization

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -577,6 +577,9 @@ type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInt
   auctionResultsConnection(
     sort: AuctionResultSorts
 
+    # Filter auction results by organization
+    organization: String
+
     # When true, will only return records for allowed artists.
     recordsTrusted: Boolean = false
     after: String
@@ -1400,6 +1403,7 @@ type AuctionResult implements Node {
   currency: String
   description: String
   externalURL: String
+  boughtIn: Boolean
   images: AuctionLotImages
   estimate: AuctionLotEstimate
   priceRealized: AuctionResultPriceRealized

--- a/src/integration/__tests__/integration.test.ts
+++ b/src/integration/__tests__/integration.test.ts
@@ -63,7 +63,7 @@ describe("integration tests", () => {
     )
   })
 
-  it("does't include `extensions` by default", async () => {
+  it("doesn't include `extensions` by default", async () => {
     // Mock the fetch for the Artist loader
     mockFetch.mockResolvedValueOnce(
       Promise.resolve({ body: { name: "Mr Bank" } })

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -204,6 +204,10 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
         type: auctionResultConnection.connectionType,
         args: pageable({
           sort: AuctionResultSorts,
+          organization: {
+            type: GraphQLString,
+            description: "Filter auction results by organization",
+          },
           recordsTrusted: {
             type: GraphQLBoolean,
             defaultValue: false,
@@ -224,6 +228,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
             page,
             size,
             artist_id: _id,
+            organization: options.organization,
             sort: options.sort,
           }
           return auctionLotLoader(diffusionArgs).then(

--- a/src/schema/v2/auction_result.ts
+++ b/src/schema/v2/auction_result.ts
@@ -7,6 +7,7 @@ import {
   GraphQLString,
   GraphQLObjectType,
   GraphQLEnumType,
+  GraphQLBoolean,
 } from "graphql"
 import { indexOf } from "lodash"
 import { connectionWithCursorInfo } from "schema/v2/fields/pagination"
@@ -108,6 +109,10 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
     externalURL: {
       type: GraphQLString,
       resolve: ({ external_url }) => external_url,
+    },
+    boughtIn: {
+      type: GraphQLBoolean,
+      resolve: ({ bought_in }) => bought_in,
     },
     images: {
       type: new GraphQLObjectType<any, ResolverContext>({


### PR DESCRIPTION
# Change
Following https://github.com/artsy/diffusion/pull/182 we now add support for filtering by organization for `Artist.auctionResults`. 

- Also added `boughtIn` that is now exposed from diffusion

Note:  I didn't make this change in V1, assuming all clients of this change are/will be on V2.