### PR TITLE
Undeprecate Viewer

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6079,9 +6079,6 @@ type Query {
 
   # A wildcard used to support complex root queries in Relay
   viewer: Viewer
-    @deprecated(
-      reason: "Viewer has been deprecated in V2. Rely on root fields instead. [Will be removed in v2]"
-    )
 
   # Autocomplete resolvers.
   _unused_gravity_matchPartners(

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -85,7 +85,6 @@ import ObjectIdentification from "./object_identification"
 import { ResolverContext } from "types/graphql"
 import config from "config"
 import { ArtworkVersionType } from "./artwork_version"
-import { deprecate } from "lib/deprecation"
 import { HighlightsField } from "./Highlights"
 
 const { ENABLE_CONSIGNMENTS_STITCHING } = config
@@ -169,10 +168,6 @@ const Viewer = {
   type: ViewerType,
   description: "A wildcard used to support complex root queries in Relay",
   resolve: x => x,
-  deprecationReason: deprecate({
-    inVersion: 2,
-    reason: "Viewer has been deprecated in V2. Rely on root fields instead.",
-  }),
 }
 
 export default new GraphQLSchema({


### PR DESCRIPTION
This undeprecates `viewer`, which we're still using extensively across our frontend code and have found to still be valuable. 