### PR TITLE
[WIP] [FX-1795] Exclude Collection search results from some Eigen versions

### DIFF
--- a/src/lib/loaders/searchLoader.ts
+++ b/src/lib/loaders/searchLoader.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_ENTITIES,
   SUGGEST_ENTITIES,
 } from "schema/v1/search/SearchEntity"
+import { without } from "lodash"
 
 const modeMap = {
   AUTOSUGGEST: {
@@ -14,9 +15,13 @@ const modeMap = {
 
 export const searchLoader = gravityLoader => {
   return gravityLoader(
-    ({ query, entities, mode, ...rest }) => {
+    ({ query, entities, mode, shouldExcludeCollections, ...rest }) => {
       const { fallbackEntities, pathname } = modeMap[mode] || modeMap.DEFAULT
-      const indexes = entities || fallbackEntities.map(index => index.value)
+      let indexes = entities || fallbackEntities.map(index => index.value)
+
+      if (shouldExcludeCollections) {
+        indexes = without(indexes, "MarketingCollection")
+      }
 
       const queryParams = {
         term: query,

--- a/src/schema/v2/search/SearchResolver.ts
+++ b/src/schema/v2/search/SearchResolver.ts
@@ -94,6 +94,15 @@ export class SearchResolver {
     }
   }
 
+  isForEigenVersionRequiringWorkaround() {
+    const { userAgent } = this.context
+    return (
+      userAgent &&
+      (userAgent.includes("Artsy-Mobile/6.2.0") ||
+        userAgent.includes("Artsy-Mobile/6.2.1"))
+    )
+  }
+
   resolve() {
     if (!this.args.page) {
       delete this.args.page
@@ -106,6 +115,7 @@ export class SearchResolver {
       ...rest,
       page,
       size,
+      shouldExcludeCollections: this.isForEigenVersionRequiringWorkaround(),
       entities: this.args.entities,
       total_count: true,
     }


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-1795

Update: closing this in favor of #2160 — since the required change can basically be accomplished by changing a single GraphQL query argument, @ashfurrow had the slick idea of intercepting this at the persisted query layer.