### PR TITLE
Add artworkSizes filter to auction results and remove unused arg

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -577,11 +577,11 @@ type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInt
   auctionResultsConnection(
     sort: AuctionResultSorts
 
-    # (Deprecated) Filter auction results by organizations
-    organization: String
-
     # Filter auction results by organizations
     organizations: [String]
+
+    # Filter auction results by Artwork sizes
+    sizes: [ArtworkSizes]
 
     # When true, will only return records for allowed artists.
     recordsTrusted: Boolean = false
@@ -1250,6 +1250,12 @@ type ArtworkMeta {
 type ArtworksAggregationResults {
   counts: [AggregationCount]
   slice: ArtworkAggregation
+}
+
+enum ArtworkSizes {
+  SMALL
+  MEDIUM
+  LARGE
 }
 
 enum ArtworkSorts {

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -56,6 +56,7 @@ import { connectionFromArraySlice } from "graphql-relay"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { totalViaLoader } from "lib/total"
 import { ResolverContext } from "types/graphql"
+import ArtworkSizes from "../artwork/artworkSizes"
 
 // Manually curated list of artist id's who has verified auction lots that can be
 // returned, when queried for via `recordsTrusted: true`.
@@ -204,13 +205,13 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
         type: auctionResultConnection.connectionType,
         args: pageable({
           sort: AuctionResultSorts,
-          organization: {
-            type: GraphQLString,
-            description: "(Deprecated) Filter auction results by organizations",
-          },
           organizations: {
             type: new GraphQLList(GraphQLString),
             description: "Filter auction results by organizations",
+          },
+          sizes: {
+            type: new GraphQLList(ArtworkSizes),
+            description: "Filter auction results by Artwork sizes",
           },
           recordsTrusted: {
             type: GraphQLBoolean,
@@ -225,14 +226,18 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
           }
 
           // Convert `after` cursors to page params
-          const { page, size, offset } = convertConnectionArgsToGravityArgs(
-            options
-          )
+          const {
+            page,
+            size,
+            offset,
+            sizes,
+          } = convertConnectionArgsToGravityArgs(options)
           const diffusionArgs = {
             page,
             size,
             artist_id: _id,
             organizations: options.organizations || [options.organization],
+            sizes,
             sort: options.sort,
           }
           return auctionLotLoader(diffusionArgs).then(

--- a/src/schema/v2/artwork/artworkSizes.ts
+++ b/src/schema/v2/artwork/artworkSizes.ts
@@ -1,0 +1,18 @@
+import { GraphQLEnumType } from "graphql"
+
+const ArtworkSizes = new GraphQLEnumType({
+  name: "ArtworkSizes",
+  values: {
+    SMALL: {
+      value: "small",
+    },
+    MEDIUM: {
+      value: "medium",
+    },
+    LARGE: {
+      value: "large",
+    },
+  },
+})
+
+export default ArtworkSizes


### PR DESCRIPTION
Depends on https://github.com/artsy/diffusion/pull/188

# Change
Adds search by list of new `ArtworkSizes` enum when filtering auction results.