### PR TITLE
Adds copy + press release url for Frieze LA 2020 fair

### DIFF
--- a/src/lib/sponsoredContent/data.json
+++ b/src/lib/sponsoredContent/data.json
@@ -84,6 +84,10 @@
     "paris-photo-2019": {
       "activationText": "From November 7 until 10 the 23rd edition of Paris Photo will take place at the Grand Palais Paris. The fair is the largest international art fair dedicated to the photographic medium and is held each November. Since 1997, its mission is to promote and nurture photographic creation and the galleries, publishers and artists at its source. BMW is official partner of Paris Photo since 2003 and stages every year the winner of the BMW Residency at the GOBELINS School of Visual Arts. In 2019, artist Emeric Lhuisset presents “L’autre rive.”",
       "pressReleaseUrl": "https://www.press.bmwgroup.com/global/article/detail/T0302354EN/as-long-term-partner-of-paris-photo-bmw-presents-haunting-photographs-by-emeric-lhuisset-the-winner-of-the-bmw-residency-at-the-gobelins-school-of-visual-arts-displays-%E2%80%9Cthe-other-shore%E2%80%9D"
+    },
+    "frieze-los-angeles-2020": {
+      "activationText": "As one of Frieze Art Fair’s long-term partners, BMW will celebrate the world premiere of a multi-tiered project of BMW M GmbH with eminent international contemporary artist FUTURA 2000 at the Los Angeles edition in the Paramount Studios. In addition, BMW contributes to the multi-faceted program of talks, performances, gallery openings and other events during Frieze week with an art talk at the Soho Warehouse, featuring FUTURA 2000 and Lupe Fiasco, on February 12 as well as a night of art and music with Frieze Music at NeueHouse Hollywood on February 14. Lastly, BMW will provide a BMW 7 Series and a BMW i3 Shuttle service transporting the fair’s VIP guests.",
+      "pressReleaseUrl": "https://www.press.bmwgroup.com/global/article/detail/T0304972EN/bmw-meets-futura-2000:-three-exclusive-originals-and-a-limited-edition-of-the-bmw-m2-competition"
     }
   }
 }


### PR DESCRIPTION
<img width="1440" alt="Screen Shot 2020-02-11 at 6 49 29 PM" src="https://user-images.githubusercontent.com/10385964/74263793-c729d380-4cff-11ea-9885-e32d769626a2.png">


https://artsyproduct.atlassian.net/browse/FX-1791