### PR TITLE
Update kaws example urls to https

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ GRAVITY_API_URL=https://stagingapi.artsy.net/
 GRAVITY_GRAPHQL_ENDPOINT=https://stagingapi.artsy.net/api
 HMAC_SECRET=https://www.youtube.com/watch?v=DLzxrzFCyOs
 IMPULSE_API_BASE=https://impulse-staging.artsy.net/api
-KAWS_API_BASE=http://kaws-staging.artsy.net
+KAWS_API_BASE=https://kaws-staging.artsy.net
 POSITRON_API_BASE=https://stagingwriter.artsy.net/api
 PREDICTION_ENDPOINT=https://live-staging.artsy.net
 VORTEX_API_BASE=https://vortex-staging.artsy.net/api

--- a/.env.test
+++ b/.env.test
@@ -10,7 +10,7 @@ GOOGLE_CSE_API_BASE=https://www.googleapis.test/customsearch/v1
 GRAVITY_API_BASE=https://api.artsy.test/api/v1
 GRAVITY_GRAPHQL_ENDPOINT=https://api.artsy.test/api
 GRAVITY_API_URL=https://api.artsy.test
-KAWS_API_BASE=http://kaws-staging.artsy.net
+KAWS_API_BASE=https://kaws-staging.artsy.net
 HMAC_SECRET=https://www.youtube.com/watch?v=F5bAa6gFvLs
 IMPULSE_API_BASE=https://impulse-staging.artsy.net/api
 IMPULSE_APPLICATION_ID=sdfsdf234234f


### PR DESCRIPTION
Found this while debugging some [pesky local development issues](https://artsy.slack.com/archives/C1HH3KNJG/p1581540116042300).