### PR TITLE
[FX-1697] update kaws schema with new size arg for relatedCollections

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -7615,7 +7615,7 @@ type MarketingCollection {
 
   # IDs of artists that should be excluded from Featured Artists for this collection
   featuredArtistExclusionIds: [String!]
-  relatedCollections: [MarketingCollection!]!
+  relatedCollections(size: Int = 10): [MarketingCollection!]!
   artworks(
     acquireable: Boolean
     offerable: Boolean

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4969,7 +4969,7 @@ type MarketingCollection {
 
   # IDs of artists that should be excluded from Featured Artists for this collection
   featuredArtistExclusionIds: [String!]
-  relatedCollections: [MarketingCollection!]!
+  relatedCollections(size: Int = 10): [MarketingCollection!]!
   artworksConnection(
     acquireable: Boolean
     offerable: Boolean

--- a/src/data/kaws.graphql
+++ b/src/data/kaws.graphql
@@ -59,7 +59,7 @@ type Collection {
 
   # IDs of artists that should be excluded from Featured Artists for this collection
   featuredArtistExclusionIds: [String!]
-  relatedCollections: [Collection!]!
+  relatedCollections(size: Int = 10): [Collection!]!
 }
 
 type CollectionCategory {

--- a/src/lib/stitching/kaws/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/kaws/__tests__/__snapshots__/schema.test.ts.snap
@@ -61,7 +61,7 @@ type MarketingCollection {
 
   # IDs of artists that should be excluded from Featured Artists for this collection
   featuredArtistExclusionIds: [String!]
-  relatedCollections: [MarketingCollection!]!
+  relatedCollections(size: Int = 10): [MarketingCollection!]!
 }
 
 type MarketingCollectionCategory {


### PR DESCRIPTION
Addresses: [FX-1697](https://artsyproduct.atlassian.net/browse/FX-1697)

This is follow up to [kaws work](https://github.com/artsy/kaws/pull/196) that introduces a new `size` argument that allows for limiting the number of collections that `relatedCollections` returns.
 
<img width="1575" alt="Screen Shot 2020-02-13 at 10 47 43 AM" src="https://user-images.githubusercontent.com/5201004/74451939-60670000-4e4e-11ea-89d4-775ea969be17.png">
