### PR TITLE
Bring back last message snippet

### DIFF
--- a/src/schema/v2/me/conversation/index.ts
+++ b/src/schema/v2/me/conversation/index.ts
@@ -211,7 +211,8 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
     lastMessage: {
       type: GraphQLString,
       description: "This is a snippet of text from the last message.",
-      resolve: () => null,
+      resolve: conversation =>
+        get(conversation, "_embedded.last_message.snippet"),
     },
     lastMessageAt: date,
 


### PR DESCRIPTION
# Change
As part of https://github.com/artsy/metaphysics/pull/926 we removed message snippet from conversation. Now that the original issue is solved. I think we are safe to bring this back.

# Keep in mind
I only brought back snippet for V2 schema. V1 still returns `null`.