### PR TITLE
[MX-195] Adds support for excluding generic genes from homepage modules

### DIFF
--- a/src/schema/v2/home/__tests__/home_page_artwork_modules.test.js
+++ b/src/schema/v2/home/__tests__/home_page_artwork_modules.test.js
@@ -278,7 +278,7 @@ describe("HomePageArtworkModules", () => {
     const query = `
     {
       homePage {
-        artworkModules(exclude: [RECOMMENDED_WORKS]) {
+        artworkModules(exclude: [RECOMMENDED_WORKS, GENERIC_GENES]) {
           key
         }
       }
@@ -288,6 +288,7 @@ describe("HomePageArtworkModules", () => {
     return runAuthenticatedQuery(query, context).then(({ homePage }) => {
       const keys = map(homePage.artworkModules, "key")
       expect(keys).not.toContain("recommended_works")
+      expect(keys).not.toContain("generic_gene")
     })
   })
 })

--- a/src/schema/v2/home/home_page_artwork_modules.ts
+++ b/src/schema/v2/home/home_page_artwork_modules.ts
@@ -27,8 +27,17 @@ import {
   HomePageArtworkModuleTypes,
 } from "./types"
 
-const filterModules = (modules, max_rails) => {
-  const allModules = addGenericGenes(filter(modules, ["display", true]))
+const filterModules = (
+  modules: HomePageArtworkModuleDetails[],
+  max_rails: number,
+  exclude: string[]
+) => {
+  let allModules: HomePageArtworkModuleDetails[]
+  if (exclude.includes("generic_gene")) {
+    allModules = filter(modules, ["display", true])
+  } else {
+    allModules = addGenericGenes(filter(modules, ["display", true]))
+  }
   return max_rails < 0 ? allModules : slice(allModules, 0, max_rails)
 }
 
@@ -134,7 +143,7 @@ const HomePageArtworkModules: GraphQLFieldConfig<void, ResolverContext> = {
         ).then(allModulesToDisplay => {
           let modules = allModulesToDisplay
 
-          modules = filterModules(modules, max_rails)
+          modules = filterModules(modules, max_rails, exclude)
           modules = reorderModules(modules, order)
 
           // For the related artists rail, we need to fetch a random
@@ -192,7 +201,7 @@ const HomePageArtworkModules: GraphQLFieldConfig<void, ResolverContext> = {
       featuredFair(fairsLoader),
     ]).then(([auction, fair]) => {
       const modules = loggedOutModules(auction, fair)
-      return filterModules(modules, max_rails)
+      return filterModules(modules, max_rails, exclude)
     })
   },
 }


### PR DESCRIPTION
Mobile Experience is going to be removing the generic genes from the home page of the app, but we found that Metaphysics was _always_ adding them (despite including them in the `exclude` parameter). This PR adds support for this use case, as well as some typings.

Co-authored-by: David Sheldrick <david.sheldrick@artsymail.com>
Co-authored-by: Brian Beckerle <brian.beckerle@artsymail.com>