### PR TITLE
Adds unreadNotificationsCount to "Me"

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5262,6 +5262,9 @@ type Me implements Node {
     last: Int
   ): ArtworkConnection
   type: String
+
+  # A count of unread notifications.
+  unreadNotificationsCount: Int!
   orders(
     first: Int
     last: Int

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -6,6 +6,7 @@ import {
   GraphQLObjectType,
   GraphQLFieldConfig,
   GraphQLFieldConfigMap,
+  GraphQLInt,
 } from "graphql"
 
 import { IDFields, NodeInterface } from "schema/v2/object_identification"
@@ -125,6 +126,18 @@ const Me = new GraphQLObjectType<any, ResolverContext>({
     type: {
       type: GraphQLString,
     },
+    unreadNotificationsCount: {
+      type: new GraphQLNonNull(GraphQLInt),
+      description: "A count of unread notifications.",
+      resolve: (_root, options, { notificationsFeedLoader }) => {
+        if (!notificationsFeedLoader)
+          throw new Error("You need to be signed in to perform this action")
+
+        return notificationsFeedLoader(options).then(({ total_unread }) => {
+          return total_unread || 0
+        })
+      },
+    },
   },
 })
 
@@ -153,6 +166,7 @@ const MeField: GraphQLFieldConfig<void, ResolverContext> = {
       "followsAndSaves",
       "lotsByFollowedArtistsConnection",
       "identityVerification",
+      "unreadNotificationsCount",
     ]
     if (includesFieldsOtherThanSelectionSet(info, fieldsNotRequireLoader)) {
       return meLoader().catch(() => null)


### PR DESCRIPTION
This PR adds `unreadNotificationsCount`, which returns only the `total_unread` count from gravity's notifications API.

Currently, the `NotificationsBadge` in reaction uses a different count (one that _won't_ get updated when a user views their `/works-for-you` tab). This means that users are never able to "dismiss" that badge. I believe this is just a regression from when we added the new nav bar.

After this, I'll update reaction to pull from this value when setting the server-side "notifications count". This should fix the regression.

[Note that there are [many ways to skin this cat](https://artsy.slack.com/archives/CA8SANW3W/p1582140879406800)! We should have a larger conversation about what these "notifications" even _mean_ and whether we need a cross-platform solution, but I'd like to fix the current issue in any case.]

Gravity API Response:
![image](https://user-images.githubusercontent.com/2081340/75057012-131a0c80-54a6-11ea-9b17-2bdd72360ef3.png)

Metaphysics Query:
![image](https://user-images.githubusercontent.com/2081340/75057029-1ad9b100-54a6-11ea-8657-aff60dc4b46f.png)
