### PR TITLE
Remove auction results for now

### DIFF
--- a/src/schema/v2/__tests__/auction_results.test.js
+++ b/src/schema/v2/__tests__/auction_results.test.js
@@ -41,7 +41,7 @@ const auctionResultResponse = (item = {}) => {
   }
 }
 
-describe("Artist type", () => {
+xdescribe("Artist type", () => {
   beforeEach(() => {
     context.auctionLotLoader = jest
       .fn()

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -220,55 +220,46 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
               "When true, will only return records for allowed artists.",
           },
         }),
-        resolve: ({ _id }, options, { auctionLotLoader }) => {
+        resolve: ({ _id }, options, _context) => {
           if (options.recordsTrusted && !includes(auctionRecordsTrusted, _id)) {
             return null
           }
 
           // Convert `after` cursors to page params
-          const {
-            page,
-            size,
-            offset,
-            sizes,
-          } = convertConnectionArgsToGravityArgs(options)
-          const diffusionArgs = {
-            page,
-            size,
-            artist_id: _id,
-            organizations: options.organizations || [options.organization],
-            sizes,
-            sort: options.sort,
-          }
-          return auctionLotLoader(diffusionArgs).then(
-            ({ total_count, _embedded }) => {
-              const totalPages = Math.ceil(total_count / size)
-              return merge(
-                {
-                  pageCursors: createPageCursors(
-                    {
-                      page,
-                      size,
-                    },
-                    total_count
-                  ),
-                },
-                {
-                  totalCount: total_count,
-                },
-                connectionFromArraySlice(_embedded.items, options, {
-                  arrayLength: total_count,
-                  sliceStart: offset,
-                }),
-                {
-                  pageInfo: {
-                    hasPreviousPage: page > 1,
-                    hasNextPage: page < totalPages,
-                  },
-                }
-              )
-            }
+          const { page, size, offset } = convertConnectionArgsToGravityArgs(
+            options
           )
+
+          return Promise.resolve({
+            total_count: 0,
+            _embedded: { items: [] },
+          }).then(({ total_count, _embedded }) => {
+            const totalPages = Math.ceil(total_count / size)
+            return merge(
+              {
+                pageCursors: createPageCursors(
+                  {
+                    page,
+                    size,
+                  },
+                  total_count
+                ),
+              },
+              {
+                totalCount: total_count,
+              },
+              connectionFromArraySlice(_embedded.items, options, {
+                arrayLength: total_count,
+                sliceStart: offset,
+              }),
+              {
+                pageInfo: {
+                  hasPreviousPage: page > 1,
+                  hasNextPage: page < totalPages,
+                },
+              }
+            )
+          })
         },
       },
       bio: {


### PR DESCRIPTION
# Problem 
https://artsy.slack.com/archives/C0HP61PUJ/p1582318930117800

# For Now Solution
Right now when going to auction results page on artists we get an empty page because of current latency issues. We decided to return empty results back so artist page shows up but we won't have any auction results till database is back to normal.