### PR TITLE
[PURCHASE-1764] Add `categories` (also known as medium in UI) to auction results

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -583,6 +583,9 @@ type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInt
     # Filter auction results by Artwork sizes
     sizes: [ArtworkSizes]
 
+    # Filter auction results by category (medium)
+    categories: [String]
+
     # When true, will only return records for allowed artists.
     recordsTrusted: Boolean = false
     after: String

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -213,6 +213,10 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
             type: new GraphQLList(ArtworkSizes),
             description: "Filter auction results by Artwork sizes",
           },
+          categories: {
+            type: new GraphQLList(GraphQLString),
+            description: "Filter auction results by category (medium)",
+          },
           recordsTrusted: {
             type: GraphQLBoolean,
             defaultValue: false,
@@ -231,12 +235,15 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
             size,
             offset,
             sizes,
+            organizations,
+            categories,
           } = convertConnectionArgsToGravityArgs(options)
           const diffusionArgs = {
             page,
             size,
             artist_id: _id,
-            organizations: options.organizations || [options.organization],
+            organizations,
+            categories,
             sizes,
             sort: options.sort,
           }


### PR DESCRIPTION
Fixes [PURCHASE-1764](https://artsyproduct.atlassian.net/browse/PURCHASE-1764)

~Depends on https://github.com/artsy/diffusion/pull/191 to work but since diffusion is REST this is _safe_ to merge.~ (merged)

Also removed the last pieces of old `organization` param (replaced by `organizations`)

**Screenshot:**

<img width="1513" alt="Screen Shot 2020-02-28 at 10 41 41 AM" src="https://user-images.githubusercontent.com/687513/75562674-f71ee980-5a16-11ea-944f-a7b8c0f415fb.png">

