### PR TITLE
Fix ID mismatch between v1 and v2

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4703,10 +4703,10 @@ type HomePageRelatedArtistArtworkModule {
 
 type IdentityVerification {
   # A globally unique ID.
-  __id: ID!
+  id: ID!
 
   # A type-specific ID likely used as a database ID.
-  id: ID!
+  internalID: ID!
 
   # Where the identity verification is in its lifecycle
   state: String!

--- a/src/schema/v2/me/__tests__/identity_verification.test.ts
+++ b/src/schema/v2/me/__tests__/identity_verification.test.ts
@@ -3,7 +3,7 @@ import { runAuthenticatedQuery } from "schema/v2/test/utils"
 import { IdentityVerificationGravityResponse } from "../identity_verification"
 
 describe("IdentityVerification type", () => {
-  it("returns the resolved identity verification", () => {
+  it("returns the resolved identity verification", async () => {
     const gravityIdentityVerification: IdentityVerificationGravityResponse = {
       id: "123",
       state: "pending",
@@ -16,7 +16,7 @@ describe("IdentityVerification type", () => {
       {
         me {
           identityVerification(id: "123") {
-            id
+            internalID
             state
             userID
             invitationExpiresAt
@@ -25,19 +25,19 @@ describe("IdentityVerification type", () => {
       }
     `
 
-    return runAuthenticatedQuery(query, {
+    const { me } = await runAuthenticatedQuery(query, {
       identityVerificationLoader: () =>
         Promise.resolve(gravityIdentityVerification),
-    }).then(({ me }) => {
-      expect(me).toEqual({
-        identityVerification: {
-          id: "123",
-          state: "pending",
-          userID: "user1",
-          invitationExpiresAt:
-            "Mon Feb 10 2020 00:00:00 GMT-0500 (Eastern Standard Time)",
-        },
-      })
+    })
+
+    expect(me).toEqual({
+      identityVerification: {
+        internalID: "123",
+        state: "pending",
+        userID: "user1",
+        invitationExpiresAt:
+          "Mon Feb 10 2020 00:00:00 GMT-0500 (Eastern Standard Time)",
+      },
     })
   })
 })

--- a/src/schema/v2/me/identity_verification.ts
+++ b/src/schema/v2/me/identity_verification.ts
@@ -5,7 +5,7 @@ import {
   GraphQLNonNull,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
-import { InternalIDFields } from "schema/v1/object_identification"
+import { InternalIDFields } from "schema/v2/object_identification"
 import dateField, { date } from "../fields/date"
 
 export type IdentityVerificationGravityResponse = {


### PR DESCRIPTION
Noticed that there was a v1 import into v2, which included an invalid `__id` field. This fixes the import reference. 

For reference, started noticing test failures downstream as can be [seen here](https://circleci.com/gh/artsy/reaction/52499?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link). 