### PR TITLE
Add euShippingOrigin as an attribute on the Artwork

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1404,6 +1404,9 @@ type Artwork implements Node & Searchable & Sellable {
   # Minimal location information describing from where artwork will be shipped.
   shippingOrigin: String
 
+  # Flags if artwork located in one of EU local shipping countries.
+  euShippingOrigin: Boolean
+
   # The country an artwork will be shipped from.
   shippingCountry: String
   provenance(format: Format): String
@@ -2456,6 +2459,9 @@ type ArtworkItem implements Node & Searchable & Sellable {
 
   # Minimal location information describing from where artwork will be shipped.
   shippingOrigin: String
+
+  # Flags if artwork located in one of EU local shipping countries.
+  euShippingOrigin: Boolean
 
   # The country an artwork will be shipped from.
   shippingCountry: String

--- a/src/schema/v1/artwork/__tests__/artwork.test.js
+++ b/src/schema/v1/artwork/__tests__/artwork.test.js
@@ -1854,6 +1854,27 @@ describe("Artwork type", () => {
     })
   })
 
+  describe("#euShippingOrigin", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          euShippingOrigin
+        }
+      }
+    `
+
+    it("returns artworks eu_shipping_origin", () => {
+      artwork.eu_shipping_origin = true
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            euShippingOrigin: true,
+          },
+        })
+      })
+    })
+  })
+
   describe("#shippingCountry", () => {
     const query = `
       {

--- a/src/schema/v1/artwork/index.ts
+++ b/src/schema/v1/artwork/index.ts
@@ -677,6 +677,14 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           return artwork.shipping_origin && artwork.shipping_origin.join(", ")
         },
       },
+      euShippingOrigin: {
+        type: GraphQLBoolean,
+        description:
+          "Flags if artwork located in one of EU local shipping countries.",
+        resolve: artwork => {
+          return artwork.eu_shipping_origin
+        },
+      },
       shippingCountry: {
         type: GraphQLString,
         description: "The country an artwork will be shipped from.",


### PR DESCRIPTION
Pairing with @ansor4 

This will be used to calculate local shipping for artworks within EU local shipping zone.

We've added this eu_shipping_origin in Gravity here: https://github.com/artsy/gravity/pull/12795