### PR TITLE
[step 1] UNUSED API BREAKING CHANGE: Rename identityVerification{Wizard,Flow}Url …Rename wizard to flow

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7253,7 +7253,7 @@ type StartIdentityVerificationSuccess {
   identityVerificationId: String
 
   # URL that hosts the user-facing identity verification flow (Jumio)
-  identityVerificationWizardUrl: String
+  identityVerificationFlowUrl: String
 }
 
 type StaticContent {

--- a/src/schema/v2/__tests__/startIdentityVerificationMutation.test.ts
+++ b/src/schema/v2/__tests__/startIdentityVerificationMutation.test.ts
@@ -6,7 +6,7 @@ mutation {
   startIdentityVerification(input: { identityVerificationId: "id-123"}) {
     startIdentityVerificationResponseOrError {
       ... on StartIdentityVerificationSuccess {
-        identityVerificationWizardUrl
+        identityVerificationFlowUrl
         identityVerificationId
       }
       ... on StartIdentityVerificationFailure {
@@ -46,7 +46,7 @@ describe("starting an identity verification", () => {
       startIdentityVerification: {
         startIdentityVerificationResponseOrError: {
           identityVerificationId: "idv-123",
-          identityVerificationWizardUrl:
+          identityVerificationFlowUrl:
             "https://artsytest.netverify.com/something",
         },
       },

--- a/src/schema/v2/startIdentityVerificationMutation.ts
+++ b/src/schema/v2/startIdentityVerificationMutation.ts
@@ -44,7 +44,7 @@ const SuccessType = new GraphQLObjectType<any, ResolverContext>({
       description: "Primary ID of the started identity verification",
       resolve: res => res.identity_verification_id,
     },
-    identityVerificationWizardUrl: {
+    identityVerificationFlowUrl: {
       type: GraphQLString,
       description:
         "URL that hosts the user-facing identity verification flow (Jumio)",


### PR DESCRIPTION
builds off of https://github.com/artsy/metaphysics/pull/2202

- We want to keep language consistent everywhere – "flow" in Gravity but "wizard" in MP is no good
- THIS MUTATION ISN'T YET USED IN REACTION YET
  + so this should be safe to deploy with 0 production risks

STEP 2: https://github.com/artsy/reaction/pull/3205