### PR TITLE
Update "listening on" log to point to v2 and exclude from VSCode search

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,11 +8,13 @@
   "eslint.autoFixOnSave": false,
   "javascript.validate.enable": true,
   "search.exclude": {
-    "**/node_modules": true
+    "**/node_modules": true,
+    "src/schema/v1": true
   },
   "files.exclude": {
     "**/.git": true,
-    "**/build": true
+    "**/build": true,
+    "src/schema/v1": false
   },
   "path-intellisense.mappings": {
     "/": "${workspaceRoot}",

--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ function bootApp() {
 
   server = require("http-shutdown")(
     app.listen(port, () =>
-      info(`[Metaphysics] Listening on http://localhost:${port}`)
+      info(`[Metaphysics] Listening on http://localhost:${port}/v2`)
     )
   )
 
@@ -145,7 +145,7 @@ function gracefulExit() {
   if (isShuttingDown) return
   isShuttingDown = true
   console.log("Received signal SIGTERM, shutting down")
-  server.shutdown(function() {
+  server.shutdown(function () {
     console.log("Closed existing connections.")
     process.exit(0)
   })


### PR DESCRIPTION
The default (non v2) is now a bit confusing since most clients have been migrated. 