### PR TITLE
Fixes a bug where lot condition report can not be enabled

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -916,7 +916,7 @@ describe("Artwork type", () => {
     it("is true if the artwork's sale is an auction, live, and has lot conditions report enabled", () => {
       context.saleLoader = sinon.stub().returns(
         Promise.resolve({
-          live: true,
+          auction_state: "open",
           is_auction: true,
           lot_conditions_report_enabled: true,
         })
@@ -934,7 +934,9 @@ describe("Artwork type", () => {
     it("is false if the artwork's sale is not an auction", () => {
       context.saleLoader = sinon.stub().returns(
         Promise.resolve({
-          live: true,
+          // auction_state would always be `null` for non-auction sales but
+          // this adds extra layer of protection in case Gravity has a bug.
+          auction_state: "open",
           is_auction: false,
           lot_conditions_report_enabled: true,
         })
@@ -949,10 +951,28 @@ describe("Artwork type", () => {
       })
     })
 
-    it("is false if the artwork's sale is an auction but has not started yet or is already closed", () => {
+    it("is false if the artwork's sale is closed", () => {
       context.saleLoader = sinon.stub().returns(
         Promise.resolve({
-          live: false,
+          auction_state: "closed",
+          is_auction: true,
+          lot_conditions_report_enabled: true,
+        })
+      )
+
+      return runQuery(query, context).then(data => {
+        expect(data).toEqual({
+          artwork: {
+            canRequestLotConditionsReport: false,
+          },
+        })
+      })
+    })
+
+    it("is false if the artwork's sale state is preview", () => {
+      context.saleLoader = sinon.stub().returns(
+        Promise.resolve({
+          auction_state: "preview",
           is_auction: true,
           lot_conditions_report_enabled: true,
         })
@@ -970,7 +990,7 @@ describe("Artwork type", () => {
     it("is false if the lot conditions report for the sale is not enabled", () => {
       context.saleLoader = sinon.stub().returns(
         Promise.resolve({
-          live: true,
+          auction_state: "open",
           is_auction: true,
           lot_conditions_report_enabled: false,
         })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -347,7 +347,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
               .catch(() => false) // don't error if the sale is not found or unpublished
               .then(sale => {
                 return (
-                  !!sale.live &&
+                  sale.auction_state === "open" &&
                   sale.is_auction &&
                   sale.lot_conditions_report_enabled
                 )


### PR DESCRIPTION
Apparently `sale.live` is not a thing in Gravity API v1 and this was always evaluating to `false` in staging. Instead, we should be looking at [`auction_state`](https://github.com/artsy/gravity/blob/6f3f75b39fd88dbc7181c71a53f128aefd00e8f5/app/models/domain/sale.rb#L201-L207), which has no ambiguity 😎 I've also added one more test for the `preview` state.