### PR TITLE
[MX-252] Fix bug in For You query

### DIFF
--- a/src/schema/v2/home/context.ts
+++ b/src/schema/v2/home/context.ts
@@ -122,7 +122,7 @@ const moduleContext: HomePageArtworkModuleResolvers<ContextSource> = {
     }
     // Backward compatibility for Force.
     return featuredGene(followedGenesLoader).then(fetchedGene => {
-      return fetchedGene && ({ ...fetchedGene, context_type: GeneType } )
+      return fetchedGene && ({ ...fetchedGene, context_type: GeneType })
     })
   },
   generic_gene: ({ geneLoader }, params) => {

--- a/src/schema/v2/home/context.ts
+++ b/src/schema/v2/home/context.ts
@@ -122,7 +122,7 @@ const moduleContext: HomePageArtworkModuleResolvers<ContextSource> = {
     }
     // Backward compatibility for Force.
     return featuredGene(followedGenesLoader).then(fetchedGene => {
-      return { ...fetchedGene, context_type: GeneType }
+      return fetchedGene && ({ ...fetchedGene, context_type: GeneType } )
     })
   },
   generic_gene: ({ geneLoader }, params) => {

--- a/src/schema/v2/home/fetch.ts
+++ b/src/schema/v2/home/fetch.ts
@@ -74,7 +74,7 @@ export const featuredGene = followedGenesLoader => {
       return first(follows).gene
     }
 
-    return undefined
+    return null
   })
 }
 


### PR DESCRIPTION
This `featuredGene` loader can return `undefined` (changed to `null` here for TypeScript's sake), but the result was being treated as a valid `Gene` object here. This caused problems further down the line when trying to extract data from the gene. The solution is just to propagate the `null` so that downstream we don't expect any data to be there.

Here's an example error report that this fixes: https://sentry.io/organizations/artsynet/issues/1214701920/?project=299996&query=is%3Aunresolved

https://artsyproduct.atlassian.net/browse/MX-252