### PR TITLE
[Addition] Add new `artworksByInternalID` root field

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -4807,6 +4807,9 @@ type ConsignmentSubmissionCategoryAsset {
 
   # Uniq ID for this asset
   id: ID!
+
+  # known image urls
+  image_urls: JSON
   submissionID: ID
   submission_id: ID!
 }
@@ -7458,7 +7461,6 @@ scalar ISO8601DateTime
 
 union Item = ArtistItem | ArtworkItem | FeaturedLinkItem | GeneItem
 
-# Represents untyped JSON
 scalar JSON
 
 type LatLng {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3115,6 +3115,9 @@ type ConsignmentSubmissionCategoryAsset {
 
   # Uniq ID for this asset
   id: ID!
+
+  # known image urls
+  image_urls: JSON
   submissionID: ID
   submission_id: ID!
 }
@@ -4836,7 +4839,6 @@ enum InvoiceState {
 
 scalar ISO8601DateTime
 
-# Represents untyped JSON
 scalar JSON
 
 type LatLng {
@@ -5897,6 +5899,9 @@ type Query {
     # The slug or ID of the Artwork
     id: String!
   ): Artwork
+
+  # A list of artworks by internalID.
+  artworksByInternalID(ids: [String]!): [Artwork]
 
   # Artworks Elastic Search results
   artworksConnection(
@@ -7567,6 +7572,9 @@ type Viewer {
     # The slug or ID of the Artwork
     id: String!
   ): Artwork
+
+  # A list of artworks by internalID.
+  artworksByInternalID(ids: [String]!): [Artwork]
 
   # Artworks Elastic Search results
   artworksConnection(

--- a/src/schema/v2/__tests__/artworksByInternalID.test.ts
+++ b/src/schema/v2/__tests__/artworksByInternalID.test.ts
@@ -1,0 +1,48 @@
+import gql from "lib/gql"
+import { runQuery } from "schema/v2/test/utils"
+
+describe("ArtworksByInternalID", () => {
+  it("returns an empty array if no artworks", async () => {
+    const artworksLoader = () => Promise.resolve([])
+    const query = gql`
+      {
+        artworksByInternalID(ids: ["invalid-id-1", "invalid-id-2"]) {
+          internalID
+        }
+      }
+    `
+
+    const { artworksByInternalID } = await runQuery(query, { artworksLoader })
+    expect(artworksByInternalID).toEqual([])
+  })
+
+  it("returns a list of artworks by internalID", async () => {
+    const artworksLoader = () =>
+      Promise.resolve([
+        {
+          _id: "foo",
+        },
+        {
+          _id: "bar",
+        },
+      ])
+
+    const query = gql`
+      {
+        artworksByInternalID(ids: ["foo", "bar"]) {
+          internalID
+        }
+      }
+    `
+
+    const { artworksByInternalID } = await runQuery(query, { artworksLoader })
+    expect(artworksByInternalID).toEqual([
+      {
+        internalID: "foo",
+      },
+      {
+        internalID: "bar",
+      },
+    ])
+  })
+})

--- a/src/schema/v2/artworksByInternalID.ts
+++ b/src/schema/v2/artworksByInternalID.ts
@@ -1,0 +1,21 @@
+import Artwork from "./artwork"
+import {
+  GraphQLList,
+  GraphQLString,
+  GraphQLFieldConfig,
+  GraphQLNonNull,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+
+export const ArtworksByInternalID: GraphQLFieldConfig<void, ResolverContext> = {
+  type: new GraphQLList(Artwork.type),
+  description: "A list of artworks by internalID.",
+  args: {
+    ids: {
+      type: new GraphQLNonNull(new GraphQLList(GraphQLString)),
+    },
+  },
+  resolve: (_root, options, { artworksLoader }) => {
+    return artworksLoader(options)
+  },
+}

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -83,6 +83,7 @@ import { ResolverContext } from "types/graphql"
 import { ArtworkVersionType } from "./artwork_version"
 import { HighlightsField } from "./Highlights"
 import { startIdentityVerificationMutation } from "./startIdentityVerificationMutation"
+import { ArtworksByInternalID } from "./artworksByInternalID"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -95,6 +96,7 @@ const rootFields = {
   // articles: Articles,
   artwork: Artwork,
   // artworkVersion: ArtworkVersionResolver,
+  artworksByInternalID: ArtworksByInternalID,
   artworksConnection: filterArtworksConnection(),
   artist: Artist,
   artists: Artists,


### PR DESCRIPTION
Adds a new root field `artworksByInternalID` which allows us to query for a specific array of artworks:

```graphql
{  
  artworksByInternalID(ids:["597ff9ba2a893a25d8244bac"]) {
    internalID
  }
}
```

<img width="962" alt="Screen Shot 2020-03-13 at 9 51 40 AM" src="https://user-images.githubusercontent.com/236943/76642348-47ff0980-6510-11ea-8a16-a911d28a3c63.png">
