### PR TITLE
Adds sales module to home page

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4636,6 +4636,7 @@ type HomePage {
   # A list of enabled hero units to show on the requested platform
   heroUnits(platform: HomePageHeroUnitPlatform!): [HomePageHeroUnit]
   fairsModule: HomePageFairsModule
+  salesModule: HomePageSalesModule
 }
 
 type HomePageArtistModule implements Node {
@@ -4760,6 +4761,10 @@ type HomePageModulesParams {
 type HomePageRelatedArtistArtworkModule {
   artist: Artist
   basedOn: Artist
+}
+
+type HomePageSalesModule {
+  results: [Sale]!
 }
 
 type IdentityVerification {

--- a/src/schema/v2/home/__tests__/home_page_sales_module.test.js
+++ b/src/schema/v2/home/__tests__/home_page_sales_module.test.js
@@ -1,0 +1,38 @@
+import { runQuery } from "schema/v2/test/utils"
+
+describe("HomePageFairsModule", () => {
+  it("works", async () => {
+    const liveSales = [
+      {
+        id: "the-greatest-sale-ever",
+        name: "The Greatest Sale Ever",
+      },
+    ]
+
+    const query = `
+      {
+        homePage {
+          salesModule {
+            results {
+              slug
+              name
+            }
+          }
+        }
+      }
+    `
+
+    const response = await runQuery(query, {
+      salesLoader: () => Promise.resolve(liveSales),
+    })
+    const {
+      homePage: {
+        salesModule: { results },
+      },
+    } = response
+    expect(results).toHaveLength(1)
+    expect(results[0]).toMatchObject(
+      expect.objectContaining({ slug: "the-greatest-sale-ever" })
+    )
+  })
+})

--- a/src/schema/v2/home/home_page_sales_module.ts
+++ b/src/schema/v2/home/home_page_sales_module.ts
@@ -1,0 +1,31 @@
+import Sale from "schema/v2/sale"
+import { GraphQLList, GraphQLObjectType, GraphQLNonNull } from "graphql"
+import { ResolverContext } from "types/graphql"
+
+export const HomePageSalesModuleType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "HomePageSalesModule",
+  fields: {
+    results: {
+      type: new GraphQLNonNull(new GraphQLList(Sale.type)),
+      resolve: (_root, _options, { salesLoader }) => {
+        // Check for all sales that are currently running
+        const gravityOptions = {
+          live: true,
+          size: 10,
+          sort: "timely_at,name",
+        }
+        return salesLoader(gravityOptions)
+      },
+    },
+  },
+})
+
+const HomePageSalesModule = {
+  type: HomePageSalesModuleType,
+  resolve: (_root, obj) => obj,
+}
+
+export default HomePageSalesModule

--- a/src/schema/v2/home/index.ts
+++ b/src/schema/v2/home/index.ts
@@ -4,6 +4,7 @@ import HomePageArtistModule from "./home_page_artist_module"
 import HomePageArtistModules from "./home_page_artist_modules"
 import HomePageHeroUnits from "./home_page_hero_units"
 import HomePageFairsModule from "./home_page_fairs_module"
+import HomePageSalesModule from "./home_page_sales_module"
 
 import { GraphQLObjectType, GraphQLFieldConfig } from "graphql"
 import { ResolverContext } from "types/graphql"
@@ -17,6 +18,7 @@ const HomePageType = new GraphQLObjectType<any, ResolverContext>({
     artworkModules: HomePageArtworkModules,
     heroUnits: HomePageHeroUnits,
     fairsModule: HomePageFairsModule,
+    salesModule: HomePageSalesModule,
   },
 })
 


### PR DESCRIPTION
This is to support an in-progress Eigen PR: https://github.com/artsy/eigen/pull/3142

It supports a query that looks like this:

![Screen Shot 2020-04-03 at 15 32 15](https://user-images.githubusercontent.com/498212/78398009-4df08380-75c0-11ea-8be0-a0e7fe907a21.png)

I'm adding it to the `HomePage` type because that's what the app uses for its home screen. We want to show live sales on that screen (instead of, as currently, showing some artworks from a [single "featured" sale](https://github.com/artsy/metaphysics/blob/4bad8cfc0ece757a981f9fda93a3845ffd0c534b/src/schema/v2/home/fetch.ts#L48-L60)).

I've got an `any` on `HomePageSalesModuleType` that I don't like but I'm not familiar enough with Metaphysics to figure out what it's _supposed_ to be. 