### PR TITLE
Pass all arguments to marketingCollections stitching

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -750,7 +750,14 @@ type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInt
   statuses: ArtistStatuses
   targetSupply: ArtistTargetSupply
   years: String
-  marketingCollections(size: Int): [MarketingCollection]
+  marketingCollections(
+    slugs: [String!]
+    category: String
+    randomizationSeed: String
+    size: Int
+    isFeaturedArtistContent: Boolean
+    showOnEditorial: Boolean
+  ): [MarketingCollection]
 }
 
 type ArtistArtworkGrid implements ArtworkContextGrid {

--- a/src/lib/stitching/kaws/stitching.ts
+++ b/src/lib/stitching/kaws/stitching.ts
@@ -11,6 +11,9 @@ import { filterArtworksArgs as filterArtworksArgsV2WithoutPageable } from "schem
 import { pageable } from "relay-cursor-paging"
 import gql from "lib/gql"
 
+/**
+ * NOTE: V1 has been deprecated. See V2 below
+ */
 export const kawsStitchingEnvironmentV1 = (
   localSchema: GraphQLSchema,
   kawsSchema: GraphQLSchema & { transforms: any }
@@ -105,7 +108,7 @@ export const kawsStitchingEnvironmentV2 = (
     // The SDL used to declare how to stitch an object
     extensionSchema: gql`
     extend type Artist {
-      marketingCollections(size: Int): [MarketingCollection]
+      marketingCollections(slugs: [String!], category: String, randomizationSeed: String, size: Int, isFeaturedArtistContent: Boolean, showOnEditorial: Boolean): [MarketingCollection]
     }
     extend type Viewer {
       marketingCollections(slugs: [String!], category: String, randomizationSeed: String, size: Int, isFeaturedArtistContent: Boolean, showOnEditorial: Boolean, artistID: String): [MarketingCollection]
@@ -128,7 +131,7 @@ export const kawsStitchingEnvironmentV2 = (
             _id
           }
         `,
-          resolve: ({ _id: artistID }, { size }, context, info) => {
+          resolve: ({ _id: artistID }, args, context, info) => {
             return info.mergeInfo.delegateToSchema({
               schema: kawsSchema,
               operation: "query",
@@ -136,7 +139,7 @@ export const kawsStitchingEnvironmentV2 = (
 
               args: {
                 artistID,
-                size,
+                ...args,
               },
               context,
               info,


### PR DESCRIPTION
Noticed that not all arguments, when on Artist, were able to be passed in our stitching configuration for kaws:

<img width="908" alt="Screen Shot 2020-04-06 at 5 07 03 PM" src="https://user-images.githubusercontent.com/236943/78616480-2cde9b80-7829-11ea-9004-110d57009a5f.png">
