### PR TITLE
[Kaws/Stitching] Fix deprecated _id field

### DIFF
--- a/src/lib/stitching/kaws/__tests__/stitching.test.ts
+++ b/src/lib/stitching/kaws/__tests__/stitching.test.ts
@@ -1,4 +1,7 @@
-import { getKawsMergedSchema } from "lib/stitching/kaws/__tests__/testingUtils"
+import {
+  getKawsMergedSchema,
+  getKawsStitchedSchema,
+} from "lib/stitching/kaws/__tests__/testingUtils"
 import { getFieldsForTypeFromSchema } from "lib/stitching/lib/getTypesFromSchema"
 
 describe("KAWS Stitching", () => {
@@ -9,5 +12,28 @@ describe("KAWS Stitching", () => {
       mergedSchema
     )
     expect(viewerFields).toContain("marketingCollections")
+  })
+
+  describe("marketingCollections", () => {
+    it("passes artist internalID to kaws' artistID arg when querying `... on Artist`", async () => {
+      const { resolvers } = await getKawsStitchedSchema()
+      const marketingCollectionsResolver =
+        resolvers.Artist.marketingCollections.resolve
+      const mergeInfo = { delegateToSchema: jest.fn() }
+
+      marketingCollectionsResolver(
+        { internalID: "artist-internal-id" },
+        {},
+        {},
+        { mergeInfo }
+      )
+
+      expect(mergeInfo.delegateToSchema).toHaveBeenCalledWith(
+        expect.objectContaining({
+          args: { artistID: "artist-internal-id" },
+          fieldName: "marketingCollections",
+        })
+      )
+    })
   })
 })

--- a/src/lib/stitching/kaws/stitching.ts
+++ b/src/lib/stitching/kaws/stitching.ts
@@ -128,10 +128,10 @@ export const kawsStitchingEnvironmentV2 = (
         marketingCollections: {
           fragment: `
           ... on Artist {
-            _id
+            internalID
           }
         `,
-          resolve: ({ _id: artistID }, args, context, info) => {
+          resolve: ({ internalID: artistID }, args, context, info) => {
             return info.mergeInfo.delegateToSchema({
               schema: kawsSchema,
               operation: "query",


### PR DESCRIPTION
Noticed we were getting back a default collection when querying `... on Artist` and saw that we were passing old v1 `_id`. Updated to pass `internalID`. 