### PR TITLE
[Consignments] Add Artist.isTargetSupply

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -701,6 +701,7 @@ type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInt
   isFollowed: Boolean
   isPublic: Boolean
   isShareable: Boolean
+  isTargetSupply: Boolean
   displayLabel: String
   location: String
   meta: ArtistMeta
@@ -968,7 +969,10 @@ type ArtistStatuses {
 }
 
 type ArtistTargetSupply {
-  # Returns whether an artist is in within the microfunnel list.
+  # True if artist is in target supply list.
+  isTargetSupply: Boolean
+
+  # True if an artist is in within the microfunnel list.
   isInMicrofunnel: Boolean
   microfunnel: ArtistTargetSupplyMicrofunnel
 }

--- a/src/schema/v2/artist/targetSupply/__tests__/index.test.ts
+++ b/src/schema/v2/artist/targetSupply/__tests__/index.test.ts
@@ -1,6 +1,29 @@
 import { runQuery } from "schema/v2/test/utils"
 
 describe("ArtistTargetSupply", () => {
+  describe("isTargetSupply", () => {
+    it("returns boolean if in target supply", async () => {
+      const query = `
+      {
+        artist(id:"andy-warhol") {
+          targetSupply {
+            isTargetSupply
+          }
+        }
+      }
+    `
+      const context = {
+        artistLoader: () => {
+          return Promise.resolve({
+            id: "andy-warhol",
+            target_supply: true,
+          })
+        },
+      }
+      const response = await runQuery(query, context)
+      expect(response.artist.targetSupply.isTargetSupply).toEqual(true)
+    })
+  })
   describe("isInMicrofunnel", () => {
     it("returns false if artist not in microfunnel", async () => {
       const query = `

--- a/src/schema/v2/artist/targetSupply/index.ts
+++ b/src/schema/v2/artist/targetSupply/index.ts
@@ -14,13 +14,16 @@ import { ArtworkType } from "schema/v2/artwork"
 const ArtistTargetSupplyType = new GraphQLObjectType<any, ResolverContext>({
   name: "ArtistTargetSupply",
   fields: {
+    isTargetSupply: {
+      description: "True if artist is in target supply list.",
+      type: GraphQLBoolean,
+      resolve: artist => artist.target_supply,
+    },
     isInMicrofunnel: {
-      description:
-        "Returns whether an artist is in within the microfunnel list.",
+      description: "True if an artist is in within the microfunnel list.",
       type: GraphQLBoolean,
       resolve: artist => Boolean(getMicrofunnelData(`/artist/${artist.id}`)),
     },
-
     microfunnel: {
       type: new GraphQLObjectType<any, ResolverContext>({
         name: "ArtistTargetSupplyMicrofunnel",


### PR DESCRIPTION
Adds a new field `isTargetSupply` under our `targetSupply` field namespace. 

#### Query
```gql
{
  artist(id: "andy-warhol") {
    targetSupply {
      isTargetSupply
    }
  }
}
```

#### Response
```json
{
  "data": {
    "artist": {
      "targetSupply": {
        "isTargetSupply": true
      }
    }
  }
}
```