### PR TITLE
Reflect changes to the viewing room schema in Gravity

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -12549,19 +12549,7 @@ type ViewingRoom {
 
   # Datetime when the viewing room is viewable
   startAt: ISO8601DateTime
-  subsectionsConnection(
-    # Returns the elements in the list that come after the specified cursor.
-    after: String
-
-    # Returns the elements in the list that come before the specified cursor.
-    before: String
-
-    # Returns the first _n_ elements from the list.
-    first: Int
-
-    # Returns the last _n_ elements from the list.
-    last: Int
-  ): ViewingRoomSubsectionConnection
+  subsections: [ViewingRoomSubsection!]
   timeZone: String
 
   # Viewing room name
@@ -12611,25 +12599,4 @@ type ViewingRoomSubsection {
 
   # Section header
   title: String
-}
-
-# The connection type for ViewingRoomSubsection.
-type ViewingRoomSubsectionConnection {
-  # A list of edges.
-  edges: [ViewingRoomSubsectionEdge]
-
-  # A list of nodes.
-  nodes: [ViewingRoomSubsection]
-
-  # Information to aid in pagination.
-  pageInfo: PageInfo!
-}
-
-# An edge in a connection.
-type ViewingRoomSubsectionEdge {
-  # A cursor for use in pagination.
-  cursor: String!
-
-  # The item at the end of the edge.
-  node: ViewingRoomSubsection
 }

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -701,7 +701,6 @@ type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInt
   isFollowed: Boolean
   isPublic: Boolean
   isShareable: Boolean
-  isTargetSupply: Boolean
   displayLabel: String
   location: String
   meta: ArtistMeta
@@ -8079,19 +8078,7 @@ type ViewingRoom {
 
   # Datetime when the viewing room is viewable
   startAt: ISO8601DateTime
-  subsectionsConnection(
-    # Returns the elements in the list that come after the specified cursor.
-    after: String
-
-    # Returns the elements in the list that come before the specified cursor.
-    before: String
-
-    # Returns the first _n_ elements from the list.
-    first: Int
-
-    # Returns the last _n_ elements from the list.
-    last: Int
-  ): ViewingRoomSubsectionConnection
+  subsections: [ViewingRoomSubsection!]
   timeZone: String
 
   # Viewing room name
@@ -8141,27 +8128,6 @@ type ViewingRoomSubsection {
 
   # Section header
   title: String
-}
-
-# The connection type for ViewingRoomSubsection.
-type ViewingRoomSubsectionConnection {
-  # A list of edges.
-  edges: [ViewingRoomSubsectionEdge]
-
-  # A list of nodes.
-  nodes: [ViewingRoomSubsection]
-
-  # Information to aid in pagination.
-  pageInfo: PageInfo!
-}
-
-# An edge in a connection.
-type ViewingRoomSubsectionEdge {
-  # A cursor for use in pagination.
-  cursor: String!
-
-  # The item at the end of the edge.
-  node: ViewingRoomSubsection
 }
 
 type YearRange {

--- a/src/data/gravity.graphql
+++ b/src/data/gravity.graphql
@@ -702,27 +702,7 @@ type ViewingRoom {
   Datetime when the viewing room is viewable
   """
   startAt: ISO8601DateTime
-  subsectionsConnection(
-    """
-    Returns the elements in the list that come after the specified cursor.
-    """
-    after: String
-
-    """
-    Returns the elements in the list that come before the specified cursor.
-    """
-    before: String
-
-    """
-    Returns the first _n_ elements from the list.
-    """
-    first: Int
-
-    """
-    Returns the last _n_ elements from the list.
-    """
-    last: Int
-  ): ViewingRoomSubsectionConnection
+  subsections: [ViewingRoomSubsection!]
   timeZone: String
 
   """
@@ -809,39 +789,4 @@ type ViewingRoomSubsection {
   Section header
   """
   title: String
-}
-
-"""
-The connection type for ViewingRoomSubsection.
-"""
-type ViewingRoomSubsectionConnection {
-  """
-  A list of edges.
-  """
-  edges: [ViewingRoomSubsectionEdge]
-
-  """
-  A list of nodes.
-  """
-  nodes: [ViewingRoomSubsection]
-
-  """
-  Information to aid in pagination.
-  """
-  pageInfo: PageInfo!
-}
-
-"""
-An edge in a connection.
-"""
-type ViewingRoomSubsectionEdge {
-  """
-  A cursor for use in pagination.
-  """
-  cursor: String!
-
-  """
-  The item at the end of the edge.
-  """
-  node: ViewingRoomSubsection
 }

--- a/src/lib/stitching/gravity/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/gravity/__tests__/__snapshots__/schema.test.ts.snap
@@ -259,19 +259,7 @@ type ViewingRoom {
 
   # Datetime when the viewing room is viewable
   startAt: ISO8601DateTime
-  subsectionsConnection(
-    # Returns the elements in the list that come after the specified cursor.
-    after: String
-
-    # Returns the elements in the list that come before the specified cursor.
-    before: String
-
-    # Returns the first _n_ elements from the list.
-    first: Int
-
-    # Returns the last _n_ elements from the list.
-    last: Int
-  ): ViewingRoomSubsectionConnection
+  subsections: [ViewingRoomSubsection!]
   timeZone: String
 
   # Viewing room name
@@ -321,27 +309,6 @@ type ViewingRoomSubsection {
 
   # Section header
   title: String
-}
-
-# The connection type for ViewingRoomSubsection.
-type ViewingRoomSubsectionConnection {
-  # A list of edges.
-  edges: [ViewingRoomSubsectionEdge]
-
-  # A list of nodes.
-  nodes: [ViewingRoomSubsection]
-
-  # Information to aid in pagination.
-  pageInfo: PageInfo!
-}
-
-# An edge in a connection.
-type ViewingRoomSubsectionEdge {
-  # A cursor for use in pagination.
-  cursor: String!
-
-  # The item at the end of the edge.
-  node: ViewingRoomSubsection
 }
 "
 `;


### PR DESCRIPTION
The purpose of this PR is to reflect changes that were made to the Gravity GraphQL schema in https://github.com/artsy/gravity/pull/12933. This replaces the `subsectionConnection` that is queryable in a viewing room with a simple array of subsections for simplicity.