### PR TITLE
Submission pagination in convection

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -4769,6 +4769,28 @@ type ConsignmentOffer {
   state: String
 }
 
+type ConsignmentPageCursor {
+  # first cursor on the page
+  cursor: String!
+
+  # is this the current page?
+  isCurrent: Boolean!
+
+  # page number out of totalPages
+  page: Int!
+}
+
+type ConsignmentPageCursors {
+  around: [ConsignmentPageCursor!]!
+
+  # optional, may be included in field around
+  first: ConsignmentPageCursor
+
+  # optional, may be included in field around
+  last: ConsignmentPageCursor
+  previous: ConsignmentPageCursor
+}
+
 # Consignment Submission
 type ConsignmentSubmission {
   additionalInfo: String
@@ -4846,9 +4868,12 @@ type ConsignmentSubmissionConnection {
 
   # A list of nodes.
   nodes: [ConsignmentSubmission]
+  pageCursors: ConsignmentPageCursors
 
   # Information to aid in pagination.
   pageInfo: PageInfo!
+  totalCount: Int
+  totalPages: Int
 }
 
 enum ConsignmentSubmissionStateAggregation {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3118,6 +3118,28 @@ type ConsignmentOffer {
   state: String
 }
 
+type ConsignmentPageCursor {
+  # first cursor on the page
+  cursor: String!
+
+  # is this the current page?
+  isCurrent: Boolean!
+
+  # page number out of totalPages
+  page: Int!
+}
+
+type ConsignmentPageCursors {
+  around: [ConsignmentPageCursor!]!
+
+  # optional, may be included in field around
+  first: ConsignmentPageCursor
+
+  # optional, may be included in field around
+  last: ConsignmentPageCursor
+  previous: ConsignmentPageCursor
+}
+
 # Consignment Submission
 type ConsignmentSubmission {
   additionalInfo: String
@@ -3195,9 +3217,12 @@ type ConsignmentSubmissionConnection {
 
   # A list of nodes.
   nodes: [ConsignmentSubmission]
+  pageCursors: ConsignmentPageCursors
 
   # Information to aid in pagination.
   pageInfo: PageInfo!
+  totalCount: Int
+  totalPages: Int
 }
 
 enum ConsignmentSubmissionStateAggregation {

--- a/src/data/convection.graphql
+++ b/src/data/convection.graphql
@@ -171,10 +171,18 @@ scalar JSON
 Mutation root for this schema
 """
 type Mutation {
-  addAssetToConsignmentSubmission(input: AddAssetToConsignmentSubmissionInput!): AddAssetToConsignmentSubmissionPayload
-  createConsignmentOffer(input: CreateOfferMutationInput!): CreateOfferMutationPayload
-  createConsignmentSubmission(input: CreateSubmissionMutationInput!): CreateSubmissionMutationPayload
-  updateConsignmentSubmission(input: UpdateSubmissionMutationInput!): UpdateSubmissionMutationPayload
+  addAssetToConsignmentSubmission(
+    input: AddAssetToConsignmentSubmissionInput!
+  ): AddAssetToConsignmentSubmissionPayload
+  createConsignmentOffer(
+    input: CreateOfferMutationInput!
+  ): CreateOfferMutationPayload
+  createConsignmentSubmission(
+    input: CreateSubmissionMutationInput!
+  ): CreateSubmissionMutationPayload
+  updateConsignmentSubmission(
+    input: UpdateSubmissionMutationInput!
+  ): UpdateSubmissionMutationPayload
 }
 
 """
@@ -202,6 +210,38 @@ type Offer {
   saleName: String
   shippingInfo: String
   state: String
+}
+
+type PageCursor {
+  """
+  first cursor on the page
+  """
+  cursor: String!
+
+  """
+  is this the current page?
+  """
+  isCurrent: Boolean!
+
+  """
+  page number out of totalPages
+  """
+  page: Int!
+}
+
+type PageCursors {
+  around: [PageCursor!]!
+
+  """
+  optional, may be included in field around
+  """
+  first: PageCursor
+
+  """
+  optional, may be included in field around
+  """
+  last: PageCursor
+  previous: PageCursor
 }
 
 """
@@ -334,11 +374,14 @@ type SubmissionConnection {
   A list of nodes.
   """
   nodes: [Submission]
+  pageCursors: PageCursors
 
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  totalCount: Int
+  totalPages: Int
 }
 
 """

--- a/src/lib/stitching/convection/schema.ts
+++ b/src/lib/stitching/convection/schema.ts
@@ -22,6 +22,8 @@ export const executableConvectionSchema = () => {
     Asset: "ConsignmentSubmissionCategoryAsset",
     Category: "ConsignmentSubmissionCategoryAggregation",
     Offer: "ConsignmentOffer",
+    PageCursor: "ConsignmentPageCursor",
+    PageCursors: "ConsignmentPageCursors",
     State: "ConsignmentSubmissionStateAggregation",
     Submission: "ConsignmentSubmission",
     SubmissionConnection: "ConsignmentSubmissionConnection",


### PR DESCRIPTION
Partially addresses https://artsyproduct.atlassian.net/browse/CSGN-37.
Depends on https://github.com/artsy/convection/pull/568.

This PR updates the schemas to account for new pagination fields on convection submissions. 

