### PR TITLE
Stitch MP Artwork under Grav ViewingRoomArtwork

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -12572,6 +12572,7 @@ type ViewingRoom {
 type ViewingRoomArtwork {
   # Unique ID
   internalID: ID!
+  artwork: Artwork
 }
 
 # The connection type for ViewingRoomArtwork.

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -701,7 +701,6 @@ type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInt
   isFollowed: Boolean
   isPublic: Boolean
   isShareable: Boolean
-  isTargetSupply: Boolean
   displayLabel: String
   location: String
   meta: ArtistMeta
@@ -8102,6 +8101,7 @@ type ViewingRoom {
 type ViewingRoomArtwork {
   # Unique ID
   internalID: ID!
+  artwork: Artwork
 }
 
 # The connection type for ViewingRoomArtwork.

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -1,0 +1,38 @@
+import gql from "lib/gql"
+import { GraphQLSchema } from "graphql"
+
+export const gravityStitchingEnvironment = (localSchema: GraphQLSchema) => {
+  return {
+    // The SDL used to declare how to stitch an object
+    extensionSchema: gql`
+      extend type ViewingRoomArtwork {
+        artwork: Artwork
+      }
+    `,
+
+    resolvers: {
+      ViewingRoomArtwork: {
+        artwork: {
+          fragment: `
+            ... on ViewingRoomArtwork {
+              artworkID
+            }
+          `,
+          resolve: (parent, _args, context, info) => {
+            return info.mergeInfo.delegateToSchema({
+              schema: localSchema,
+              operation: "query",
+              fieldName: "artwork",
+
+              args: {
+                id: parent.artworkID,
+              },
+              context,
+              info,
+            })
+          },
+        },
+      },
+    },
+  }
+}

--- a/src/lib/stitching/mergeSchemas.ts
+++ b/src/lib/stitching/mergeSchemas.ts
@@ -18,6 +18,7 @@ import { exchangeStitchingEnvironment } from "./exchange/stitching"
 import { executableVortexSchema } from "lib/stitching/vortex/schema"
 import { vortexStitchingEnvironment as vortexStitchingEnvironmentv1 } from "./vortex/stitchingv1"
 import { vortexStitchingEnvironment as vortexStitchingEnvironmentv2 } from "./vortex/stitching"
+import { gravityStitchingEnvironment } from "./gravity/stitching"
 
 /**
  * Incrementally merges in schemas according to `process.env`
@@ -50,6 +51,8 @@ export const incrementalMergeSchemas = (
 
   const gravitySchema = executableGravitySchema()
   schemas.push(gravitySchema)
+
+  useStitchingEnvironment(gravityStitchingEnvironment(localSchema))
 
   if (ENABLE_COMMERCE_STITCHING) {
     const exchangeSchema = executableExchangeSchema(transformsForExchange)


### PR DESCRIPTION
Turns out that because we effectively [erase Gravity's version](https://github.com/artsy/metaphysics/blob/19246f1b3caa99f7e9f143168621c3bc8680643b/src/lib/stitching/gravity/schema.ts#L26) of the GQL `Artwork` type when merging Gravity's schema into MP, we were losing that type under `ViewingRoomArtwork`. In other words, we couldn't run a query like this:
```graphql
{
  viewingRoom(id: "") {
    title
    artworksConnection(first: 1) {
      edges {
        node {
          internalID
          artwork {
            id
          }
        }
      }
    }
  }
}
```
...because Metaphysics' schema only had `internalID` inside of `node`.

@mzikherman was kind enough to sit down with me and work through this. With this PR, we're now referencing MP's own `Artwork` type, which is actually handy in the long run since Gravity's `Artwork` type was missing some things like `price` that we'll need. 

This PR is dependent on https://github.com/artsy/gravity/pull/12934, which changes `ViewingRoomArtwork`'s `artwork` field to `artworkID` so that we can use it in the fragment that allows us to reference a MP Artwork.

Matt also raised the point that with this method as-is, we'd effectively be making 10 separate queries every time we requested 10 artworks - we should think about batching those requests for efficiency in the future.

Screenshot of this in action: 

![Screen Shot 2020-04-08 at 7 24 10 PM](https://user-images.githubusercontent.com/5361806/78843243-45d58100-79d0-11ea-9398-79c380a7ba89.png)


[Slack thread](https://artsy.slack.com/archives/C1HH3KNJG/p1586382589020800)