### PR TITLE
Fix typo in docs

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -971,7 +971,7 @@ type ArtistTargetSupply {
   # True if artist is in target supply list.
   isTargetSupply: Boolean
 
-  # True if an artist is in within the microfunnel list.
+  # True if an artist is in the microfunnel list.
   isInMicrofunnel: Boolean
   microfunnel: ArtistTargetSupplyMicrofunnel
 }

--- a/src/schema/v2/artist/targetSupply/index.ts
+++ b/src/schema/v2/artist/targetSupply/index.ts
@@ -20,7 +20,7 @@ const ArtistTargetSupplyType = new GraphQLObjectType<any, ResolverContext>({
       resolve: artist => artist.target_supply,
     },
     isInMicrofunnel: {
-      description: "True if an artist is in within the microfunnel list.",
+      description: "True if an artist is in the microfunnel list.",
       type: GraphQLBoolean,
       resolve: artist => Boolean(getMicrofunnelData(`/artist/${artist.id}`)),
     },


### PR DESCRIPTION
Forcing a schema rebuild. Something happened where `targetSupply` field was removed from production schema. 