### PR TITLE
Sync schema to reaction on update

### DIFF
--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -10,8 +10,7 @@ async function main() {
 
     execSync("yarn dump:staging")
 
-    await updateRepo({
-      repo: { owner: "artsy", repo: "eigen" },
+    const updateSchemaAction = {
       branch: "update-schema",
       title: "Update metaphysics schema",
       targetBranch: "master",
@@ -20,18 +19,34 @@ async function main() {
         "Greetings human :robot: this PR was automatically created as part of metaphysics's deploy process",
       assignees: ["artsyit"],
       labels: ["Merge On Green"],
-      update: eigenDir => {
+      update: repoDir => {
         execSync(
-          `cp _schemaV2.graphql '${path.join(eigenDir, "data/schema.graphql")}'`
+          `cp _schemaV2.graphql '${path.join(repoDir, "data/schema.graphql")}'`
         )
-        execSync("yarn install --ignore-engines", { cwd: eigenDir })
+        execSync("yarn install --ignore-engines", { cwd: repoDir })
         execSync("./node_modules/.bin/prettier --write data/schema.graphql", {
-          cwd: eigenDir,
+          cwd: repoDir,
         })
       },
+    }
+
+    await updateRepo({
+      repo: {
+        owner: "artsy",
+        repo: "eigen",
+      },
+      ...updateSchemaAction,
     })
-  } catch (e) {
-    console.error(e)
+
+    await updateRepo({
+      repo: {
+        owner: "artsy",
+        repo: "reaction",
+      },
+      ...updateSchemaAction,
+    })
+  } catch (error) {
+    console.error(error)
     process.exit(1)
   }
 }


### PR DESCRIPTION
Following [recent work to sync changes to Eigen](https://github.com/artsy/metaphysics/pull/2288/), lets carry it on to Reaction 🥳 

Ran script locally and seemed to work great, but no actual changes to sync yet: 

<img width="583" alt="Screen Shot 2020-04-09 at 3 48 28 PM" src="https://user-images.githubusercontent.com/236943/78947284-cac8a500-7a79-11ea-904d-43410f3c4e71.png">

@ds300 - https://github.com/artsy/update-repo is seriously cool! Lets broadcast it. 
