### PR TITLE
Resolve viewing room artworks as a batch instead of individually (GALL-2766)

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -12643,7 +12643,12 @@ type ViewingRoom {
 
   # Viewing room name
   title: String!
-  artworks: ArtworkConnection
+  artworks(
+    first: Int
+    last: Int
+    after: String
+    before: String
+  ): ArtworkConnection
 }
 
 # An artwork associated with a viewing room. Note that the full artwork is stitched in in Metaphysics!
@@ -12652,7 +12657,6 @@ type ViewingRoomArtwork {
 
   # Unique ID
   internalID: ID!
-  artwork: Artwork
 }
 
 # The connection type for ViewingRoomArtwork.

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -12643,6 +12643,7 @@ type ViewingRoom {
 
   # Viewing room name
   title: String!
+  artworks: ArtworkConnection
 }
 
 # An artwork associated with a viewing room. Note that the full artwork is stitched in in Metaphysics!

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -12603,19 +12603,7 @@ type Viewer {
 
 # An artwork viewing room
 type ViewingRoom {
-  artworksConnection(
-    # Returns the elements in the list that come after the specified cursor.
-    after: String
-
-    # Returns the elements in the list that come before the specified cursor.
-    before: String
-
-    # Returns the first _n_ elements from the list.
-    first: Int
-
-    # Returns the last _n_ elements from the list.
-    last: Int
-  ): ViewingRoomArtworkConnection
+  artworkIDs: [String!]
 
   # Body copy
   body: String
@@ -12643,41 +12631,12 @@ type ViewingRoom {
 
   # Viewing room name
   title: String!
-  artworks(
+  artworksConnection(
     first: Int
     last: Int
     after: String
     before: String
   ): ArtworkConnection
-}
-
-# An artwork associated with a viewing room. Note that the full artwork is stitched in in Metaphysics!
-type ViewingRoomArtwork {
-  artworkID: String!
-
-  # Unique ID
-  internalID: ID!
-}
-
-# The connection type for ViewingRoomArtwork.
-type ViewingRoomArtworkConnection {
-  # A list of edges.
-  edges: [ViewingRoomArtworkEdge]
-
-  # A list of nodes.
-  nodes: [ViewingRoomArtwork]
-
-  # Information to aid in pagination.
-  pageInfo: PageInfo!
-}
-
-# An edge in a connection.
-type ViewingRoomArtworkEdge {
-  # A cursor for use in pagination.
-  cursor: String!
-
-  # The item at the end of the edge.
-  node: ViewingRoomArtwork
 }
 
 # Title, image, text, and caption for a viewing room section

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8187,7 +8187,12 @@ type ViewingRoom {
 
   # Viewing room name
   title: String!
-  artworks: ArtworkConnection
+  artworks(
+    first: Int
+    last: Int
+    after: String
+    before: String
+  ): ArtworkConnection
 }
 
 # An artwork associated with a viewing room. Note that the full artwork is stitched in in Metaphysics!
@@ -8196,7 +8201,6 @@ type ViewingRoomArtwork {
 
   # Unique ID
   internalID: ID!
-  artwork: Artwork
 }
 
 # The connection type for ViewingRoomArtwork.

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6170,6 +6170,18 @@ type Query {
     last: Int
   ): FilterArtworksConnection
 
+  # A list of Artworks
+  artworks(
+    ids: [String]
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtworkConnection
+    @deprecated(
+      reason: "This is only for use in resolving stitched queries, not for first-class client use."
+    )
+
   # An Artist
   artist(
     # The slug or ID of the Artist
@@ -7932,6 +7944,18 @@ type Viewer {
     before: String
     last: Int
   ): FilterArtworksConnection
+
+  # A list of Artworks
+  artworks(
+    ids: [String]
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtworkConnection
+    @deprecated(
+      reason: "This is only for use in resolving stitched queries, not for first-class client use."
+    )
 
   # An Artist
   artist(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8187,6 +8187,7 @@ type ViewingRoom {
 
   # Viewing room name
   title: String!
+  artworks: ArtworkConnection
 }
 
 # An artwork associated with a viewing room. Note that the full artwork is stitched in in Metaphysics!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8147,19 +8147,7 @@ type Viewer {
 
 # An artwork viewing room
 type ViewingRoom {
-  artworksConnection(
-    # Returns the elements in the list that come after the specified cursor.
-    after: String
-
-    # Returns the elements in the list that come before the specified cursor.
-    before: String
-
-    # Returns the first _n_ elements from the list.
-    first: Int
-
-    # Returns the last _n_ elements from the list.
-    last: Int
-  ): ViewingRoomArtworkConnection
+  artworkIDs: [String!]
 
   # Body copy
   body: String
@@ -8187,41 +8175,12 @@ type ViewingRoom {
 
   # Viewing room name
   title: String!
-  artworks(
+  artworksConnection(
     first: Int
     last: Int
     after: String
     before: String
   ): ArtworkConnection
-}
-
-# An artwork associated with a viewing room. Note that the full artwork is stitched in in Metaphysics!
-type ViewingRoomArtwork {
-  artworkID: String!
-
-  # Unique ID
-  internalID: ID!
-}
-
-# The connection type for ViewingRoomArtwork.
-type ViewingRoomArtworkConnection {
-  # A list of edges.
-  edges: [ViewingRoomArtworkEdge]
-
-  # A list of nodes.
-  nodes: [ViewingRoomArtwork]
-
-  # Information to aid in pagination.
-  pageInfo: PageInfo!
-}
-
-# An edge in a connection.
-type ViewingRoomArtworkEdge {
-  # A cursor for use in pagination.
-  cursor: String!
-
-  # The item at the end of the edge.
-  node: ViewingRoomArtwork
 }
 
 # Title, image, text, and caption for a viewing room section

--- a/src/data/gravity.graphql
+++ b/src/data/gravity.graphql
@@ -724,27 +724,7 @@ type SmsSecondFactor implements SecondFactor {
 An artwork viewing room
 """
 type ViewingRoom {
-  artworksConnection(
-    """
-    Returns the elements in the list that come after the specified cursor.
-    """
-    after: String
-
-    """
-    Returns the elements in the list that come before the specified cursor.
-    """
-    before: String
-
-    """
-    Returns the first _n_ elements from the list.
-    """
-    first: Int
-
-    """
-    Returns the last _n_ elements from the list.
-    """
-    last: Int
-  ): ViewingRoomArtworkConnection
+  artworkIDs: [String!]
 
   """
   Body copy
@@ -788,53 +768,6 @@ type ViewingRoom {
   Viewing room name
   """
   title: String!
-}
-
-"""
-An artwork associated with a viewing room. Note that the full artwork is stitched in in Metaphysics!
-"""
-type ViewingRoomArtwork {
-  artworkID: String!
-
-  """
-  Unique ID
-  """
-  internalID: ID!
-}
-
-"""
-The connection type for ViewingRoomArtwork.
-"""
-type ViewingRoomArtworkConnection {
-  """
-  A list of edges.
-  """
-  edges: [ViewingRoomArtworkEdge]
-
-  """
-  A list of nodes.
-  """
-  nodes: [ViewingRoomArtwork]
-
-  """
-  Information to aid in pagination.
-  """
-  pageInfo: PageInfo!
-}
-
-"""
-An edge in a connection.
-"""
-type ViewingRoomArtworkEdge {
-  """
-  A cursor for use in pagination.
-  """
-  cursor: String!
-
-  """
-  The item at the end of the edge.
-  """
-  node: ViewingRoomArtwork
 }
 
 """

--- a/src/lib/stitching/gravity/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/gravity/__tests__/__snapshots__/schema.test.ts.snap
@@ -285,19 +285,7 @@ type SmsSecondFactor implements SecondFactor {
 
 # An artwork viewing room
 type ViewingRoom {
-  artworksConnection(
-    # Returns the elements in the list that come after the specified cursor.
-    after: String
-
-    # Returns the elements in the list that come before the specified cursor.
-    before: String
-
-    # Returns the first _n_ elements from the list.
-    first: Int
-
-    # Returns the last _n_ elements from the list.
-    last: Int
-  ): ViewingRoomArtworkConnection
+  artworkIDs: [String!]
 
   # Body copy
   body: String
@@ -325,35 +313,6 @@ type ViewingRoom {
 
   # Viewing room name
   title: String!
-}
-
-# An artwork associated with a viewing room. Note that the full artwork is stitched in in Metaphysics!
-type ViewingRoomArtwork {
-  artworkID: String!
-
-  # Unique ID
-  internalID: ID!
-}
-
-# The connection type for ViewingRoomArtwork.
-type ViewingRoomArtworkConnection {
-  # A list of edges.
-  edges: [ViewingRoomArtworkEdge]
-
-  # A list of nodes.
-  nodes: [ViewingRoomArtwork]
-
-  # Information to aid in pagination.
-  pageInfo: PageInfo!
-}
-
-# An edge in a connection.
-type ViewingRoomArtworkEdge {
-  # A cursor for use in pagination.
-  cursor: String!
-
-  # The item at the end of the edge.
-  node: ViewingRoomArtwork
 }
 
 # Title, image, text, and caption for a viewing room section

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -4,42 +4,22 @@ import {
   getGravityStitchedSchema,
 } from "./testingUtils"
 
-it("extends the ViewingRoom type with an artworks field", async () => {
+it("extends the ViewingRoom type with an artworksConnection field", async () => {
   const mergedSchema = await getGravityMergedSchema()
   const artworkConnectionFields = await getFieldsForTypeFromSchema(
     "ViewingRoom",
     mergedSchema
   )
 
-  expect(artworkConnectionFields).toContain("artworks")
+  expect(artworkConnectionFields).toContain("artworksConnection")
 })
 
 it("resolves the artworks field on ViewingRoom as a paginated list", async () => {
   const { resolvers } = await getGravityStitchedSchema()
-  const artworksResolver = resolvers.ViewingRoom.artworks.resolve
+  const artworksResolver = resolvers.ViewingRoom.artworksConnection.resolve
 
   const artworks = await artworksResolver(
-    {
-      artworksConnection: {
-        edges: [
-          {
-            node: {
-              artworkID: "1",
-            },
-          },
-          {
-            node: {
-              artworkID: "2",
-            },
-          },
-          {
-            node: {
-              artworkID: "3",
-            },
-          },
-        ],
-      },
-    },
+    { artworkIDs: ["1", "2", "3"] },
     { first: 2 },
     {
       artworksLoader: () =>

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -1,0 +1,69 @@
+import { getFieldsForTypeFromSchema } from "lib/stitching/lib/getTypesFromSchema"
+import {
+  getGravityMergedSchema,
+  getGravityStitchedSchema,
+} from "./testingUtils"
+
+it("extends the ViewingRoom type with an artworks field", async () => {
+  const mergedSchema = await getGravityMergedSchema()
+  const artworkConnectionFields = await getFieldsForTypeFromSchema(
+    "ViewingRoom",
+    mergedSchema
+  )
+
+  expect(artworkConnectionFields).toContain("artworks")
+})
+
+it("resolves the artworks field on ViewingRoom as a paginated list", async () => {
+  const { resolvers } = await getGravityStitchedSchema()
+  const artworksResolver = resolvers.ViewingRoom.artworks.resolve
+
+  const artworks = await artworksResolver(
+    {
+      artworksConnection: {
+        edges: [
+          {
+            node: {
+              artworkID: "1",
+            },
+          },
+          {
+            node: {
+              artworkID: "2",
+            },
+          },
+          {
+            node: {
+              artworkID: "3",
+            },
+          },
+        ],
+      },
+    },
+    { first: 2 },
+    {
+      artworksLoader: () =>
+        Promise.resolve([
+          {
+            id: "1",
+            title: "Artwork 1",
+          },
+          {
+            id: "2",
+            title: "Artwork 2",
+          },
+          {
+            id: "3",
+            title: "Artwork 3",
+          },
+        ]),
+    },
+    {}
+  )
+
+  expect(artworks.edges.length).toBe(2)
+  expect(artworks.pageInfo.startCursor).not.toBe(null)
+  expect(artworks.pageInfo.endCursor).not.toBe(null)
+  expect(artworks.pageInfo.hasNextPage).toBe(true)
+  expect(artworks.pageInfo.hasPreviousPage).toBe(false)
+})

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -46,4 +46,5 @@ it("resolves the artworks field on ViewingRoom as a paginated list", async () =>
   expect(artworks.pageInfo.endCursor).not.toBe(null)
   expect(artworks.pageInfo.hasNextPage).toBe(true)
   expect(artworks.pageInfo.hasPreviousPage).toBe(false)
+  expect(artworks.totalCount).toBe(3)
 })

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -16,35 +16,22 @@ it("extends the ViewingRoom type with an artworksConnection field", async () => 
 
 it("resolves the artworks field on ViewingRoom as a paginated list", async () => {
   const { resolvers } = await getGravityStitchedSchema()
-  const artworksResolver = resolvers.ViewingRoom.artworksConnection.resolve
+  const { artworksConnection } = resolvers.ViewingRoom
+  const info = { mergeInfo: { delegateToSchema: jest.fn() } }
 
-  const artworks = await artworksResolver(
+  artworksConnection.resolve(
     { artworkIDs: ["1", "2", "3"] },
     { first: 2 },
-    {
-      artworksLoader: () =>
-        Promise.resolve([
-          {
-            id: "1",
-            title: "Artwork 1",
-          },
-          {
-            id: "2",
-            title: "Artwork 2",
-          },
-          {
-            id: "3",
-            title: "Artwork 3",
-          },
-        ]),
-    },
-    {}
+    {},
+    info
   )
 
-  expect(artworks.edges.length).toBe(2)
-  expect(artworks.pageInfo.startCursor).not.toBe(null)
-  expect(artworks.pageInfo.endCursor).not.toBe(null)
-  expect(artworks.pageInfo.hasNextPage).toBe(true)
-  expect(artworks.pageInfo.hasPreviousPage).toBe(false)
-  expect(artworks.totalCount).toBe(3)
+  expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
+    args: { ids: ["1", "2", "3"], first: 2 },
+    operation: "query",
+    fieldName: "artworks",
+    schema: expect.anything(),
+    context: expect.anything(),
+    info: expect.anything(),
+  })
 })

--- a/src/lib/stitching/gravity/__tests__/testingUtils.ts
+++ b/src/lib/stitching/gravity/__tests__/testingUtils.ts
@@ -1,0 +1,45 @@
+import { mergeSchemas } from "graphql-tools"
+import { gravityStitchingEnvironment } from "../stitching"
+import { GraphQLSchema } from "graphql"
+import { executableGravitySchema } from "../schema"
+import localSchema from "schema/v2/schema"
+
+let cachedSchema: GraphQLSchema & { transforms: any }
+let stitchedSchema: ReturnType<typeof gravityStitchingEnvironment>
+let mergedSchema: GraphQLSchema & { transforms: any }
+
+/** Gets a cached copy of the transformed gravity schema  */
+export const getGravityTransformedSchema = async () => {
+  if (!cachedSchema) {
+    cachedSchema = await executableGravitySchema()
+  }
+  return cachedSchema
+}
+
+/** Gets a cached copy of the stitched schema, independent of being merged into the local schema */
+export const getGravityStitchedSchema = async () => {
+  if (!stitchedSchema) {
+    const cachedSchema = await getGravityTransformedSchema()
+    stitchedSchema = gravityStitchingEnvironment(cachedSchema)
+  }
+  return stitchedSchema
+}
+
+/** Gets a cached fully setup schema with gravity and the localSchema set up */
+export const getGravityMergedSchema = async () => {
+  if (!mergedSchema) {
+    const cachedSchema = await getGravityTransformedSchema()
+    const { extensionSchema, resolvers } = await getGravityStitchedSchema()
+
+    // The order should only matter in that extension schemas come after the
+    // objects that they are expected to build upon
+    mergedSchema = mergeSchemas({
+      schemas: [localSchema, cachedSchema, extensionSchema],
+      resolvers: resolvers,
+    }) as GraphQLSchema & { transforms: any }
+
+    const anyMergedSchema = mergedSchema as any
+    anyMergedSchema.__allowedLegacyNames = ["__id"]
+  }
+  return mergedSchema
+}

--- a/src/lib/stitching/gravity/__tests__/testingUtils.ts
+++ b/src/lib/stitching/gravity/__tests__/testingUtils.ts
@@ -20,7 +20,7 @@ export const getGravityTransformedSchema = async () => {
 export const getGravityStitchedSchema = async () => {
   if (!stitchedSchema) {
     const cachedSchema = await getGravityTransformedSchema()
-    stitchedSchema = gravityStitchingEnvironment(cachedSchema)
+    stitchedSchema = gravityStitchingEnvironment(localSchema, cachedSchema)
   }
   return stitchedSchema
 }

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -43,13 +43,13 @@ export const gravityStitchingEnvironment = (
               artworkIDs
             }
           `,
-          resolve: (parent, args, context, _info) => {
-            return context
-              .artworksLoader({ ids: parent.artworkIDs })
-              .then(body => {
-                console.log(body)
-                return connectionFromArray(body, args)
-              })
+          resolve: ({ artworkIDs }, args, context, _info) => {
+            return context.artworksLoader({ ids: artworkIDs }).then(body => {
+              return {
+                totalCount: artworkIDs.length,
+                ...connectionFromArray(body, args),
+              }
+            })
           },
         },
       },

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -1,8 +1,8 @@
-import { connectionFromArray } from "graphql-relay"
 import gql from "lib/gql"
 import { GraphQLSchema } from "graphql"
 
 export const gravityStitchingEnvironment = (
+  localSchema: GraphQLSchema,
   gravitySchema: GraphQLSchema & { transforms: any }
 ) => {
   return {
@@ -43,12 +43,17 @@ export const gravityStitchingEnvironment = (
               artworkIDs
             }
           `,
-          resolve: ({ artworkIDs }, args, context, _info) => {
-            return context.artworksLoader({ ids: artworkIDs }).then(body => {
-              return {
-                totalCount: artworkIDs.length,
-                ...connectionFromArray(body, args),
-              }
+          resolve: ({ artworkIDs: ids }, args, context, info) => {
+            return info.mergeInfo.delegateToSchema({
+              schema: localSchema,
+              operation: "query",
+              fieldName: "artworks",
+              args: {
+                ids,
+                ...args,
+              },
+              context,
+              info,
             })
           },
         },

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -13,7 +13,7 @@ export const gravityStitchingEnvironment = (
       }
 
       extend type ViewingRoom {
-        artworks(
+        artworksConnection(
           first: Int
           last: Int
           after: String
@@ -37,34 +37,19 @@ export const gravityStitchingEnvironment = (
         },
       },
       ViewingRoom: {
-        artworks: {
+        artworksConnection: {
           fragment: gql`
             ... on ViewingRoom {
-              artworksConnection {
-                edges {
-                  node {
-                    artworkID
-                  }
-                }
-              }
+              artworkIDs
             }
           `,
           resolve: (parent, args, context, _info) => {
-            let ids = []
-
-            if (parent.artworksConnection) {
-              ids = parent.artworksConnection.edges.map(
-                edge => edge.node.artworkID
-              )
-            }
-
-            if (ids.length === 0) {
-              return connectionFromArray(ids, args)
-            }
-
-            return context.artworksLoader({ ids }).then(body => {
-              return connectionFromArray(body, args)
-            })
+            return context
+              .artworksLoader({ ids: parent.artworkIDs })
+              .then(body => {
+                console.log(body)
+                return connectionFromArray(body, args)
+              })
           },
         },
       },

--- a/src/lib/stitching/mergeSchemas.ts
+++ b/src/lib/stitching/mergeSchemas.ts
@@ -52,7 +52,9 @@ export const incrementalMergeSchemas = (
   const gravitySchema = executableGravitySchema()
   schemas.push(gravitySchema)
 
-  useStitchingEnvironment(gravityStitchingEnvironment(gravitySchema))
+  useStitchingEnvironment(
+    gravityStitchingEnvironment(localSchema, gravitySchema)
+  )
 
   if (ENABLE_COMMERCE_STITCHING) {
     const exchangeSchema = executableExchangeSchema(transformsForExchange)

--- a/src/lib/stitching/mergeSchemas.ts
+++ b/src/lib/stitching/mergeSchemas.ts
@@ -52,9 +52,7 @@ export const incrementalMergeSchemas = (
   const gravitySchema = executableGravitySchema()
   schemas.push(gravitySchema)
 
-  useStitchingEnvironment(
-    gravityStitchingEnvironment(localSchema, gravitySchema)
-  )
+  useStitchingEnvironment(gravityStitchingEnvironment(gravitySchema))
 
   if (ENABLE_COMMERCE_STITCHING) {
     const exchangeSchema = executableExchangeSchema(transformsForExchange)

--- a/src/schema/v2/artworks.ts
+++ b/src/schema/v2/artworks.ts
@@ -1,0 +1,32 @@
+import { artworkConnection } from "./artwork"
+import { GraphQLList, GraphQLString, GraphQLFieldConfig } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { pageable } from "relay-cursor-paging"
+import { connectionFromArray } from "graphql-relay"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { createPageCursors } from "./fields/pagination"
+
+const Artworks: GraphQLFieldConfig<void, ResolverContext> = {
+  type: artworkConnection.connectionType,
+  description: "A list of Artworks",
+  deprecationReason:
+    "This is only for use in resolving stitched queries, not for first-class client use.",
+  args: pageable({
+    ids: {
+      type: new GraphQLList(GraphQLString),
+    },
+  }),
+  resolve: (_root, options, { artworksLoader }) => {
+    const { ids } = options
+    const { page, size } = convertConnectionArgsToGravityArgs(options)
+    return artworksLoader({ ids }).then(body => {
+      return {
+        totalCount: ids.length,
+        pageCursors: createPageCursors({ page, size }, ids.length),
+        ...connectionFromArray(body, options),
+      }
+    })
+  },
+}
+
+export default Artworks

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -88,6 +88,7 @@ import Fairs from "./fairs"
 import Articles from "./articles"
 import SaleArtwork from "./sale_artwork"
 import { SaleArtworksConnectionField } from "./sale_artworks"
+import Artworks from "./artworks"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -101,6 +102,7 @@ const rootFields = {
   artwork: Artwork,
   // artworkVersion: ArtworkVersionResolver,
   artworksConnection: filterArtworksConnection(),
+  artworks: Artworks,
   artist: Artist,
   artists: Artists,
   // causalityJWT: CausalityJWT, // TODO: Perhaps this should go into `system` ?


### PR DESCRIPTION
This PR updates the Gravity stitching library to extend the `ViewingRoom` type with an artwork connection field that will fetch all artworks in a viewing room as a paginated batch.

A resolver for the `ViewingRoomArtwork` type already exist, and its job is to fetch an individual artwork that matches the `artworkID` field. What I am attempting to do is fetch all of the artworks in a viewing room with one query by stitching-in a new connection field on the `ViewingRoom` type that fetches all associated `artworkID`s at once.