### PR TITLE
Update to Hokusai v0.5.8 and add new SSL certs via artsyNetWildcardSSLCert template variable

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 node_modules
+hokusai/*.yml

--- a/hokusai/config.yml
+++ b/hokusai/config.yml
@@ -1,4 +1,6 @@
 project-name: metaphysics
 git-remote: git@github.com:artsy/metaphysics.git
 post-deploy: .circleci/deploy_event.sh
-hokusai-required-version: "~=0.5"
+hokusai-required-version: ">=0.5.8"
+template-config-files:
+  - s3://artsy-citadel/k8s/hokusai-vars.yml

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -128,7 +128,7 @@ metadata:
   name: metaphysics-web
   namespace: default
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "arn:aws:iam::585031190124:server-certificate/2018-01-17_artsy-net-wildcard"
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ artsyNetWildcardSSLCert }}
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -127,7 +127,7 @@ metadata:
   name: metaphysics-web
   namespace: default
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "arn:aws:iam::585031190124:server-certificate/2018-01-17_artsy-net-wildcard"
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ artsyNetWildcardSSLCert }}
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"


### PR DESCRIPTION
- Update Hokusai to v0.5.8 and add hokusai-vars.yml to ./hokusai/config.yml

- Use artsyNetWildcardSSLCert variable in ./hokusai/staging.yml and ./hokusai/production.yml