### PR TITLE
Add hasSecondFactorEnabled attribute to Me type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5327,6 +5327,7 @@ type Me implements Node {
   followsAndSaves: FollowsAndSaves
   hasCreditCards: Boolean
   hasQualifiedCreditCards: Boolean
+  hasSecondFactorEnabled: Boolean!
 
   # An invoice
   invoice(

--- a/src/schema/v2/me/__tests__/index.test.js
+++ b/src/schema/v2/me/__tests__/index.test.js
@@ -10,6 +10,7 @@ describe("me/index", () => {
         email
         paddleNumber
         identityVerified
+        hasSecondFactorEnabled
       }
     }
   `
@@ -20,6 +21,7 @@ describe("me/index", () => {
       email: "test@email.com",
       paddle_number: "123456",
       identity_verified: true,
+      second_factor_enabled: true,
     }
 
     return runAuthenticatedQuery(query, {
@@ -31,6 +33,7 @@ describe("me/index", () => {
           email: "test@email.com",
           paddleNumber: "123456",
           identityVerified: true,
+          hasSecondFactorEnabled: true,
         },
       })
     })

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -90,6 +90,10 @@ const Me = new GraphQLObjectType<any, ResolverContext>({
         )
       },
     },
+    hasSecondFactorEnabled: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      resolve: ({ second_factor_enabled }) => second_factor_enabled,
+    },
     invoice: Invoice,
     identityVerification: IdentityVerification,
     identityVerified: {


### PR DESCRIPTION
Add an attribute to the Me type to represent 2FA enrollment status.

Depends upon this API update :lock: : https://github.com/artsy/gravity/pull/12947