### PR TITLE
[PURCHASE-1870] Add filter to allow filtering for lots with empty date info

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -607,6 +607,10 @@ type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInt
 
     # Filter auction results by latest created at year
     latestCreatedYear: Int
+
+    # Filter auction results by empty artwork created date values
+    allowEmptyCreatedDates: Boolean = true
+
     after: String
     first: Int
     before: String

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -232,6 +232,12 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
             type: GraphQLInt,
             description: "Filter auction results by latest created at year",
           },
+          allowEmptyCreatedDates: {
+            type: GraphQLBoolean,
+            defaultValue: true,
+            description:
+              "Filter auction results by empty artwork created date values",
+          },
         }),
         resolve: ({ _id }, options, { auctionLotLoader }) => {
           if (options.recordsTrusted && !includes(auctionRecordsTrusted, _id)) {
@@ -255,6 +261,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
             categories,
             earliest_created_year: options.earliestCreatedYear,
             latest_created_year: options.latestCreatedYear,
+            allow_empty_created_dates: options.allowEmptyCreatedDates,
             sizes,
             sort: options.sort,
           }


### PR DESCRIPTION
Add new filter allows users to filter out lots where created date information is blank.
diffusion changes: https://github.com/artsy/diffusion/pull/226

This can also be used in combination with other date filters:
`allowEmptyCreatedDates=true`
<img width="1389" alt="Screen Shot 2020-04-14 at 3 02 35 PM" src="https://user-images.githubusercontent.com/12748344/79264063-f379e180-7e61-11ea-89dc-21e76d7e6c90.png">

`allowEmptyCreatedDates=false`
<img width="1347" alt="Screen Shot 2020-04-14 at 3 02 18 PM" src="https://user-images.githubusercontent.com/12748344/79264148-13110a00-7e62-11ea-894c-0cb991ea38d6.png">

when not present - it defaults to true
<img width="1349" alt="Screen Shot 2020-04-14 at 3 12 00 PM" src="https://user-images.githubusercontent.com/12748344/79264269-4ce21080-7e62-11ea-9de5-ecd45f6cba1e.png">



