### PR TITLE
Allow page types to be exposed in search

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7104,6 +7104,7 @@ enum SearchEntity {
   GALLERY
   GENE
   INSTITUTION
+  PAGE
   PROFILE
   SALE
   SHOW

--- a/src/lib/loaders/searchLoader.ts
+++ b/src/lib/loaders/searchLoader.ts
@@ -2,7 +2,7 @@ import * as url from "url"
 import {
   DEFAULT_ENTITIES,
   SUGGEST_ENTITIES,
-} from "schema/v1/search/SearchEntity"
+} from "schema/v2/search/SearchEntity"
 
 const modeMap = {
   AUTOSUGGEST: {

--- a/src/schema/v2/search/SearchEntity.ts
+++ b/src/schema/v2/search/SearchEntity.ts
@@ -33,6 +33,9 @@ export const SearchEntity = new GraphQLEnumType({
     INSTITUTION: {
       value: "institution",
     },
+    PAGE: {
+      value: "Page",
+    },
     PROFILE: {
       value: "Profile",
     },


### PR DESCRIPTION
I noticed that we'd stopped exposing static pages in our search/autocomplete results! Tracked the issue down to here.

This works as expected:
![image](https://user-images.githubusercontent.com/2081340/79359648-dc45fd00-7f10-11ea-9b35-1cda1659a09c.png)

(And with local force pointing this way:)
<img width="1086" alt="Screen Shot 2020-04-15 at 11 38 40 AM" src="https://user-images.githubusercontent.com/2081340/79359693-e667fb80-7f10-11ea-90c8-845e1ce82fec.png">
