### PR TITLE
Fix circleci node image tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
   push-schema-changes:
     executor:
       name: node/default
-      tag: "10"
+      tag: "10.19"
     steps:
       - run:
           name: Let hokusai modify /usr/local/bin


### PR DESCRIPTION
 #2315 failed [here](https://circleci.com/gh/artsy/metaphysics/8649) because I accidentally used a tag from the `circleci/node` docker images when the new orb had switched to `cimg/node` 🤷‍♂️ . This is trivial again so #self-merging