### PR TITLE
[Circle config] fix pip installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,8 @@ jobs:
       - run:
           name: Install hokusai
           command: |
-            sudo apt install python-pip
+            sudo apt update
+            sudo apt install --assume-yes python-pip
             pip install awscli --upgrade
             pip install hokusai
       - hokusai/configure-hokusai


### PR DESCRIPTION
more fallout from #2315 – need to run `apt-get upgrade` before installing pip with this new image

I've tested this locally with the circleci cli tool.

#trivial #selfmerging