### PR TITLE
Add total count to messagesConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -610,7 +610,6 @@ type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInt
 
     # Filter auction results by empty artwork created date values
     allowEmptyCreatedDates: Boolean = true
-
     after: String
     first: Int
     before: String
@@ -3326,6 +3325,15 @@ type Conversation implements Node {
     first: Int
     before: String
     last: Int
+  ): MessageConnection @deprecated(reason: "Prefer messagesConnection")
+
+  # A connection for all messages in a single conversation
+  messagesConnection(
+    sort: sort
+    after: String
+    first: Int
+    before: String
+    last: Int
   ): MessageConnection
 
   # True if there is an unread message by the user.
@@ -5457,6 +5465,7 @@ type MessageConnection {
 
   # A list of edges.
   edges: [MessageEdge]
+  totalCount: Int
 }
 
 # An edge in a connection.

--- a/src/schema/v2/me/__tests__/conversation/__snapshots__/message.test.js.snap
+++ b/src/schema/v2/me/__tests__/conversation/__snapshots__/message.test.js.snap
@@ -48,7 +48,7 @@ Object {
     },
     "initialMessage": "Loved some of the works at your fair booth!",
     "internalID": "420",
-    "messages": Object {
+    "messagesConnection": Object {
       "edges": Array [
         Object {
           "node": Object {
@@ -61,6 +61,7 @@ Object {
           },
         },
       ],
+      "totalCount": 1,
     },
   },
 }

--- a/src/schema/v2/me/__tests__/conversation/message.test.js
+++ b/src/schema/v2/me/__tests__/conversation/message.test.js
@@ -43,7 +43,8 @@ describe("Me", () => {
                 from {
                   email
                 }
-                messages(first: 10) {
+                messagesConnection(first: 10) {
+                  totalCount
                   edges {
                     node {
                       body


### PR DESCRIPTION
Addresses PURCHASE-1868

This PR does 2 things

1. Adds a `totalCount` response to the `MessagesConnection` type. 
2. It deprecates the `messages` field in favor of `messagesConnection`. This wasn't strictly necessary, but was performed for the sake of good schema hygiene. 