### PR TITLE
Provide isFirstMessage from Message, remove need for initialMessage

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3312,6 +3312,9 @@ type Conversation implements Node {
   ): String
   fromLastViewedMessageID: String
   initialMessage: String!
+    @deprecated(
+      reason: "This field is no longer required. Prefer the first message from the MessageConnection."
+    )
 
   # This is a snippet of text from the last message.
   lastMessage: String
@@ -5542,6 +5545,9 @@ type Message implements Node {
 
   # Impulse message id.
   impulseID: String!
+
+  # True if message is the first in the conversation.
+  isFirstMessage: Boolean
 
   # True if message is from the user to the partner.
   isFromUser: Boolean

--- a/src/schema/v2/me/__tests__/conversation/__snapshots__/message.test.js.snap
+++ b/src/schema/v2/me/__tests__/conversation/__snapshots__/message.test.js.snap
@@ -25,6 +25,17 @@ Object {
       "edges": Array [
         Object {
           "node": Object {
+            "body": "Loved some of the works at your fair booth!",
+            "from": Object {
+              "email": "fancy_german_person@posteo.de",
+              "name": "Percy Z",
+            },
+            "internalID": "222",
+            "isFromUser": true,
+          },
+        },
+        Object {
+          "node": Object {
             "body": "I'm a cat oh yea!",
             "from": Object {
               "email": "fancy_german_person@posteo.de",
@@ -52,16 +63,28 @@ Object {
       "edges": Array [
         Object {
           "node": Object {
+            "body": "Loved some of the works at your fair booth!",
+            "from": Object {
+              "email": "fancy_german_person@posteo.de",
+              "name": "Percy Z",
+            },
+            "internalID": "222",
+            "isFirstMessage": true,
+          },
+        },
+        Object {
+          "node": Object {
             "body": "I'm a cat oh yea!",
             "from": Object {
               "email": "fancy_german_person@posteo.de",
               "name": "Percy Z",
             },
             "internalID": "222",
+            "isFirstMessage": false,
           },
         },
       ],
-      "totalCount": 1,
+      "totalCount": 2,
     },
   },
 }

--- a/src/schema/v2/me/__tests__/conversation/message.test.js
+++ b/src/schema/v2/me/__tests__/conversation/message.test.js
@@ -13,11 +13,28 @@ describe("Me", () => {
           }),
         conversationMessagesLoader: () =>
           Promise.resolve({
-            total_count: 1,
+            total_count: 2,
             message_details: [
               {
                 id: "222",
                 raw_text: "I'm a cat",
+                is_first_message: true,
+                from_email_address: "fancy_german_person@posteo.de",
+                from_id: null,
+                attachments: [],
+                metadata: {
+                  lewitt_invoice_id: "420i",
+                },
+                from: `"Percy Z" <percy@cat.com>`,
+                from_principal: true,
+                original_text:
+                  "Loved some of the works at your fair booth! ABOUT THIS COLLECTOR: blah, blah",
+                body: "I'm a cat",
+              },
+              {
+                id: "222",
+                raw_text: "I'm a cat",
+                is_first_message: false,
                 from_email_address: "fancy_german_person@posteo.de",
                 from_id: null,
                 attachments: [],
@@ -47,6 +64,7 @@ describe("Me", () => {
                   totalCount
                   edges {
                     node {
+                      isFirstMessage
                       body
                       internalID
                       from {

--- a/src/schema/v2/me/conversation/index.ts
+++ b/src/schema/v2/me/conversation/index.ts
@@ -176,7 +176,7 @@ const messagesConnection = {
     },
   }),
   resolve: (
-    { id, from_email },
+    { id, from_email, initial_message, from_name },
     options,
     { conversationMessagesLoader }: { conversationMessagesLoader?: any }
   ) => {
@@ -196,6 +196,8 @@ const messagesConnection = {
       /* eslint-disable no-param-reassign */
       message_details = message_details.map(message => {
         return merge(message, {
+          conversation_initial_message: initial_message,
+          conversation_from_name: from_name,
           conversation_from_address: from_email,
           conversation_id: id,
         })
@@ -257,6 +259,8 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
       resolve: ({ from_last_viewed_message_id }) => from_last_viewed_message_id,
     },
     initialMessage: {
+      deprecationReason:
+        "This field is no longer required. Prefer the first message from the MessageConnection.",
       type: new GraphQLNonNull(GraphQLString),
       resolve: ({ initial_message, from_name }) => {
         const parts = initial_message.split(

--- a/src/schema/v2/me/conversation/message.ts
+++ b/src/schema/v2/me/conversation/message.ts
@@ -47,6 +47,11 @@ export const MessageType = new GraphQLObjectType<any, ResolverContext>({
       type: new GraphQLNonNull(GraphQLString),
       resolve: ({ id }) => id,
     },
+    isFirstMessage: {
+      description: "True if message is the first in the conversation.",
+      type: GraphQLBoolean,
+      resolve: ({ is_first_message }) => is_first_message,
+    },
     isFromUser: {
       description: "True if message is from the user to the partner.",
       type: GraphQLBoolean,
@@ -86,7 +91,19 @@ export const MessageType = new GraphQLObjectType<any, ResolverContext>({
       description:
         "Unaltered text if possible, otherwise `body`: a parsed/sanitized version from Sendgrid.",
       type: GraphQLString,
-      resolve: ({ body, original_text }) => {
+      resolve: ({
+        body,
+        original_text,
+        conversation_from_name,
+        conversation_initial_message,
+        is_first_message,
+      }) => {
+        if (is_first_message) {
+          const parts = conversation_initial_message.split(
+            "Message from " + conversation_from_name + ":\n\n"
+          )
+          return parts[parts.length - 1]
+        }
         if (original_text) {
           return original_text
         }

--- a/src/schema/v2/me/conversation/message.ts
+++ b/src/schema/v2/me/conversation/message.ts
@@ -100,7 +100,7 @@ export const MessageType = new GraphQLObjectType<any, ResolverContext>({
       }) => {
         if (is_first_message) {
           if (!conversation_initial_message) {
-            return "Hi, I’m interested in purchasing this work. Could you please provide more information about the piece?"
+            return ""
           }
           const parts = conversation_initial_message.split(
             "Message from " + conversation_from_name + ":\n\n"

--- a/src/schema/v2/me/conversation/message.ts
+++ b/src/schema/v2/me/conversation/message.ts
@@ -100,9 +100,7 @@ export const MessageType = new GraphQLObjectType<any, ResolverContext>({
       }) => {
         if (is_first_message) {
           if (!conversation_initial_message) {
-            throw new Error(
-              "This is the first message, but initial_message not provided"
-            )
+            return "Hi, I’m interested in purchasing this work. Could you please provide more information about the piece?"
           }
           const parts = conversation_initial_message.split(
             "Message from " + conversation_from_name + ":\n\n"

--- a/src/schema/v2/me/conversation/message.ts
+++ b/src/schema/v2/me/conversation/message.ts
@@ -99,6 +99,11 @@ export const MessageType = new GraphQLObjectType<any, ResolverContext>({
         is_first_message,
       }) => {
         if (is_first_message) {
+          if (!conversation_initial_message) {
+            throw new Error(
+              "This is the first message, but initial_message not provided"
+            )
+          }
           const parts = conversation_initial_message.split(
             "Message from " + conversation_from_name + ":\n\n"
           )

--- a/src/schema/v2/me/conversation/message.ts
+++ b/src/schema/v2/me/conversation/message.ts
@@ -100,7 +100,7 @@ export const MessageType = new GraphQLObjectType<any, ResolverContext>({
       }) => {
         if (is_first_message) {
           if (!conversation_initial_message) {
-            return ""
+            return null
           }
           const parts = conversation_initial_message.split(
             "Message from " + conversation_from_name + ":\n\n"


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/PURCHASE-1867

This PR does a few things:

1. Exposes the new `is_first_message` field from impulse as `isFirstMessage` on the `Message` object. This is a useful field to simplify the rendering logic that clients have to perform for rendering the first message. 
2. Updates how `Message.body` renders when it's the first message. Previously, [clients had to determine](https://github.com/artsy/eigen/blob/1c5994a58f6ffb7f1fa83bf9c6e23601f66e01a5/src/lib/Components/Inbox/Conversations/Message.tsx#L140) if they should use `initialMessage` from the conversation or the message. This is unnecessary logic for the clients to have to perform because we _never_ want to show the collector what was being displayed as the first message text. Now, clients won't have to do any fiddling when displaying messages. They can just display the first message like any other message. 
3. Deprecates `initialMessage` on conversation. It's not really needed if the first message is that exact same thing.  