### PR TITLE
Add partners to viewing rooms

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -12814,6 +12814,7 @@ type ViewingRoom {
     after: String
     before: String
   ): ArtworkConnection
+  partner: Partner
 }
 
 # Title, image, text, and caption for a viewing room section

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8382,6 +8382,7 @@ type ViewingRoom {
     after: String
     before: String
   ): ArtworkConnection
+  partner: Partner
 }
 
 # Title, image, text, and caption for a viewing room section

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -54,7 +54,7 @@ it("resolves the partner field on ViewingRoom", async () => {
   partner.resolve({ partnerID: "fakeid" }, {}, {}, info)
 
   expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
-    args: { partnerID: "fakeid" },
+    args: { id: "fakeid" },
     operation: "query",
     fieldName: "partner",
     schema: expect.anything(),

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -14,6 +14,16 @@ it("extends the ViewingRoom type with an artworksConnection field", async () => 
   expect(artworkConnectionFields).toContain("artworksConnection")
 })
 
+it("extends the ViewingRoom type with a partner field", async () => {
+  const mergedSchema = await getGravityMergedSchema()
+  const artworkConnectionFields = await getFieldsForTypeFromSchema(
+    "ViewingRoom",
+    mergedSchema
+  )
+
+  expect(artworkConnectionFields).toContain("partner")
+})
+
 it("resolves the artworks field on ViewingRoom as a paginated list", async () => {
   const { resolvers } = await getGravityStitchedSchema()
   const { artworksConnection } = resolvers.ViewingRoom
@@ -30,6 +40,23 @@ it("resolves the artworks field on ViewingRoom as a paginated list", async () =>
     args: { ids: ["1", "2", "3"], first: 2 },
     operation: "query",
     fieldName: "artworks",
+    schema: expect.anything(),
+    context: expect.anything(),
+    info: expect.anything(),
+  })
+})
+
+it("resolves the partner field on ViewingRoom", async () => {
+  const { resolvers } = await getGravityStitchedSchema()
+  const { partner } = resolvers.ViewingRoom
+  const info = { mergeInfo: { delegateToSchema: jest.fn() } }
+
+  partner.resolve({ partnerID: "fakeid" }, {}, {}, info)
+
+  expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
+    args: { partnerID: "fakeid" },
+    operation: "query",
+    fieldName: "partner",
     schema: expect.anything(),
     context: expect.anything(),
     info: expect.anything(),

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -19,6 +19,7 @@ export const gravityStitchingEnvironment = (
           after: String
           before: String
         ): ArtworkConnection
+        partner: Partner
       }
     `,
     resolvers: {
@@ -51,6 +52,25 @@ export const gravityStitchingEnvironment = (
               args: {
                 ids,
                 ...args,
+              },
+              context,
+              info,
+            })
+          },
+        },
+        partner: {
+          fragment: gql`
+            ... on ViewingRoom {
+              partnerID
+            }
+          `,
+          resolve: ({ partnerID: id }, _args, context, info) => {
+            return info.mergeInfo.delegateToSchema({
+              schema: localSchema,
+              operation: "query",
+              fieldName: "partner",
+              args: {
+                id,
               },
               context,
               info,


### PR DESCRIPTION
Stitching is fun! This PR allows us to access the `partner` type on `viewingRoom` queries so that we can display the partner name and logo in viewing rooms.

I'll note that it looks like not all partners have a `profile` (e.g. an attempt to query for Invoicing Demo Partner's `profile` returns null) and I'm not entirely clear on why they would/wouldn't - might just be a matter of someone having entered information into CMS. Either way, we should make sure to account for the scenario when `profile` is null, but I'm of the opinion that that's Eigen's responsibility.

An example query that gets a partner name and icon:
![Screen Shot 2020-04-23 at 5 50 48 PM](https://user-images.githubusercontent.com/5361806/80153214-21120980-858b-11ea-805b-92679d06befa.png)
