### PR TITLE
Introduce Sale.userNeedsIdentityVerification field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6849,7 +6849,9 @@ type Sale implements Node {
   registrationStatus: Bidder
   requireBidderApproval: Boolean
   requireIdentityVerification: Boolean
-  requiresIdentityVerificationFor: Boolean
+
+  # True if the current client needs to undergo identity verification for this sale, false otherwise
+  userNeedsIdentityVerification: Boolean
   saleArtworksConnection(
     # List of sale artwork internal IDs to fetch
     internalIDs: [ID]

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6849,7 +6849,7 @@ type Sale implements Node {
   registrationStatus: Bidder
   requireBidderApproval: Boolean
   requireIdentityVerification: Boolean
-  requiresIdentityVerificationFor(user_id: ID): Boolean
+  requiresIdentityVerificationFor: Boolean
   saleArtworksConnection(
     # List of sale artwork internal IDs to fetch
     internalIDs: [ID]

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6849,6 +6849,7 @@ type Sale implements Node {
   registrationStatus: Bidder
   requireBidderApproval: Boolean
   requireIdentityVerification: Boolean
+  requiresIdentityVerificationFor(user_id: ID): Boolean
   saleArtworksConnection(
     # List of sale artwork internal IDs to fetch
     internalIDs: [ID]

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6850,7 +6850,7 @@ type Sale implements Node {
   requireBidderApproval: Boolean
   requireIdentityVerification: Boolean
 
-  # True if the current client needs to undergo identity verification for this sale, false otherwise
+  # True if the current user needs to undergo identity verification for this sale, false otherwise
   userNeedsIdentityVerification: Boolean
   saleArtworksConnection(
     # List of sale artwork internal IDs to fetch

--- a/src/schema/v2/sale/__tests__/index.test.js
+++ b/src/schema/v2/sale/__tests__/index.test.js
@@ -825,7 +825,7 @@ describe("Sale type", () => {
         const query = gql`
           {
             sale(id: "foo-foo") {
-              requiresIdentityVerificationFor(user_id: "not-a-user-id")
+              requiresIdentityVerificationFor
             }
           }
         `
@@ -864,17 +864,19 @@ describe("Sale type", () => {
 
           const context = {
             saleLoader: () => Promise.resolve(sale),
-            meBiddersLoader: () => Promise.resolve([]),
           }
 
-          const data = await runAuthenticatedQuery(query, context)
+          const data = await runQuery(query, context)
           expect(data.sale.requiresIdentityVerificationFor).toEqual(true)
         })
       })
 
       describe("when there is a current user", () => {
-        describe("when the user is identity verification", () => {
-          it("returns false", async () => {
+        describe("when the user is registered for the sale", () => {
+          it.todo("returns bidder.needs_identity_verification?")
+        })
+        describe("when the user is not registered for the sale", () => {
+          it("returns false when the user is identity verified", async () => {
             const sale = {
               id: "foo-foo",
               _id: "123",
@@ -896,11 +898,40 @@ describe("Sale type", () => {
 
             const context = {
               saleLoader: () => Promise.resolve(sale),
-              meBiddersLoader: () => Promise.resolve([]),
+              meLoader: () => Promise.resolve({ identity_verified: true }),
             }
 
             const data = await runAuthenticatedQuery(query, context)
             expect(data.sale.requiresIdentityVerificationFor).toEqual(false)
+          })
+
+          it("returns true when the user is not identity verified", async () => {
+            const sale = {
+              id: "foo-foo",
+              _id: "123",
+              currency: "$",
+              is_auction: true,
+              is_preliminary: false,
+              increment_strategy: "default",
+              lot_conditions_report_enabled: true,
+              require_identity_verification: true,
+            }
+
+            const query = gql`
+              {
+                sale(id: "foo-foo") {
+                  requiresIdentityVerificationFor
+                }
+              }
+            `
+
+            const context = {
+              saleLoader: () => Promise.resolve(sale),
+              meLoader: () => Promise.resolve({ identity_verified: false }),
+            }
+
+            const data = await runAuthenticatedQuery(query, context)
+            expect(data.sale.requiresIdentityVerificationFor).toEqual(true)
           })
         })
       })

--- a/src/schema/v2/sale/__tests__/index.test.js
+++ b/src/schema/v2/sale/__tests__/index.test.js
@@ -808,6 +808,105 @@ describe("Sale type", () => {
     })
   })
 
+  describe.only("requiresIdentityVerificationFor(user_id)", () => {
+    describe("when the sale doesn't requires identity verification", () => {
+      it("returns false", async () => {
+        const sale = {
+          id: "foo-foo",
+          _id: "123",
+          currency: "$",
+          is_auction: true,
+          is_preliminary: false,
+          increment_strategy: "default",
+          lot_conditions_report_enabled: true,
+          require_identity_verification: false,
+        }
+
+        const query = gql`
+          {
+            sale(id: "foo-foo") {
+              requiresIdentityVerificationFor(user_id: "not-a-user-id")
+            }
+          }
+        `
+
+        const context = {
+          saleLoader: () => Promise.resolve(sale),
+          meBiddersLoader: () => Promise.resolve([]),
+        }
+
+        const data = await runAuthenticatedQuery(query, context)
+        expect(data.sale.requiresIdentityVerificationFor).toEqual(false)
+      })
+    })
+
+    describe("when the sale does require identity verification", () => {
+      describe("when there is no current user", () => {
+        it("returns true", async () => {
+          const sale = {
+            id: "foo-foo",
+            _id: "123",
+            currency: "$",
+            is_auction: true,
+            is_preliminary: false,
+            increment_strategy: "default",
+            lot_conditions_report_enabled: true,
+            require_identity_verification: true,
+          }
+
+          const query = gql`
+            {
+              sale(id: "foo-foo") {
+                requiresIdentityVerificationFor
+              }
+            }
+          `
+
+          const context = {
+            saleLoader: () => Promise.resolve(sale),
+            meBiddersLoader: () => Promise.resolve([]),
+          }
+
+          const data = await runAuthenticatedQuery(query, context)
+          expect(data.sale.requiresIdentityVerificationFor).toEqual(true)
+        })
+      })
+
+      describe("when there is a current user", () => {
+        describe("when the user is identity verification", () => {
+          it("returns false", async () => {
+            const sale = {
+              id: "foo-foo",
+              _id: "123",
+              currency: "$",
+              is_auction: true,
+              is_preliminary: false,
+              increment_strategy: "default",
+              lot_conditions_report_enabled: true,
+              require_identity_verification: true,
+            }
+
+            const query = gql`
+              {
+                sale(id: "foo-foo") {
+                  requiresIdentityVerificationFor
+                }
+              }
+            `
+
+            const context = {
+              saleLoader: () => Promise.resolve(sale),
+              meBiddersLoader: () => Promise.resolve([]),
+            }
+
+            const data = await runAuthenticatedQuery(query, context)
+            expect(data.sale.requiresIdentityVerificationFor).toEqual(false)
+          })
+        })
+      })
+    })
+  })
+
   describe("artworksConnection", () => {
     it("returns data from gravity", () => {
       const query = `

--- a/src/schema/v2/sale/__tests__/index.test.js
+++ b/src/schema/v2/sale/__tests__/index.test.js
@@ -863,7 +863,6 @@ describe("Sale type", () => {
 
           const context = {
             saleLoader: () => Promise.resolve(sale),
-            meBiddersLoader: () => Promise.resolve([]),
           }
 
           const data = await runQuery(query, context)
@@ -873,7 +872,7 @@ describe("Sale type", () => {
 
       describe("when there is a current user", () => {
         describe("when the user is registered for the sale", () => {
-          it("returns false bidder.needs_identity_verification? is false", async () => {
+          it("returns false bidder.needs_identity_verification is false", async () => {
             const bidder = {
               id: "bidder-id",
               sale: { _id: "sale-id", id: "sale-slug" },
@@ -897,7 +896,7 @@ describe("Sale type", () => {
             expect(data.sale.userNeedsIdentityVerification).toEqual(false)
           })
 
-          it("returns true when bidder.needs_identity_verification? is true", async () => {
+          it("returns true when bidder.needs_identity_verification is true", async () => {
             const bidder = {
               id: "bidder-id",
               sale: { _id: "sale-id", id: "sale-slug" },

--- a/src/schema/v2/sale/__tests__/index.test.js
+++ b/src/schema/v2/sale/__tests__/index.test.js
@@ -832,7 +832,6 @@ describe("Sale type", () => {
 
         const context = {
           saleLoader: () => Promise.resolve(sale),
-          meBiddersLoader: () => Promise.resolve([]),
         }
 
         const data = await runAuthenticatedQuery(query, context)

--- a/src/schema/v2/sale/__tests__/index.test.js
+++ b/src/schema/v2/sale/__tests__/index.test.js
@@ -810,18 +810,18 @@ describe("Sale type", () => {
 
   describe("userNeedsIdentityVerification", () => {
     describe("when the sale doesn't requires identity verification", () => {
-      it("returns false", async () => {
-        const sale = {
-          id: "foo-foo",
-          _id: "123",
-          currency: "$",
-          is_auction: true,
-          is_preliminary: false,
-          increment_strategy: "default",
-          lot_conditions_report_enabled: true,
-          require_identity_verification: false,
-        }
+      let sale = {
+        id: "foo-foo",
+        _id: "123",
+        currency: "$",
+        is_auction: true,
+        is_preliminary: false,
+        increment_strategy: "default",
+        lot_conditions_report_enabled: true,
+        require_identity_verification: false,
+      }
 
+      it("returns false", async () => {
         const query = gql`
           {
             sale(id: "foo-foo") {
@@ -841,19 +841,19 @@ describe("Sale type", () => {
     })
 
     describe("when the sale does require identity verification", () => {
+      let sale = {
+        id: "foo-foo",
+        _id: "123",
+        currency: "$",
+        is_auction: true,
+        is_preliminary: false,
+        increment_strategy: "default",
+        lot_conditions_report_enabled: true,
+        require_identity_verification: true,
+      }
+
       describe("when there is no current user", () => {
         it("returns true", async () => {
-          const sale = {
-            id: "foo-foo",
-            _id: "123",
-            currency: "$",
-            is_auction: true,
-            is_preliminary: false,
-            increment_strategy: "default",
-            lot_conditions_report_enabled: true,
-            require_identity_verification: true,
-          }
-
           const query = gql`
             {
               sale(id: "foo-foo") {
@@ -875,16 +875,6 @@ describe("Sale type", () => {
       describe("when there is a current user", () => {
         describe("when the user is registered for the sale", () => {
           it("returns false bidder.needs_identity_verification? is false", async () => {
-            const sale = {
-              id: "foo-foo",
-              _id: "123",
-              currency: "$",
-              is_auction: true,
-              is_preliminary: false,
-              increment_strategy: "default",
-              lot_conditions_report_enabled: true,
-              require_identity_verification: true,
-            }
             const bidder = {
               id: "bidder-id",
               sale: { _id: "sale-id", id: "sale-slug" },
@@ -909,17 +899,6 @@ describe("Sale type", () => {
           })
 
           it("returns true when bidder.needs_identity_verification? is true", async () => {
-            const sale = {
-              id: "foo-foo",
-              _id: "123",
-              currency: "$",
-              is_auction: true,
-              is_preliminary: false,
-              increment_strategy: "default",
-              lot_conditions_report_enabled: true,
-              require_identity_verification: true,
-            }
-
             const bidder = {
               id: "bidder-id",
               sale: { _id: "sale-id", id: "sale-slug" },
@@ -945,17 +924,6 @@ describe("Sale type", () => {
         })
         describe("when the user is not registered for the sale", () => {
           it("returns false when the user is identity verified", async () => {
-            const sale = {
-              id: "foo-foo",
-              _id: "123",
-              currency: "$",
-              is_auction: true,
-              is_preliminary: false,
-              increment_strategy: "default",
-              lot_conditions_report_enabled: true,
-              require_identity_verification: true,
-            }
-
             const query = gql`
               {
                 sale(id: "foo-foo") {
@@ -975,17 +943,6 @@ describe("Sale type", () => {
           })
 
           it("returns true when the user is not identity verified", async () => {
-            const sale = {
-              id: "foo-foo",
-              _id: "123",
-              currency: "$",
-              is_auction: true,
-              is_preliminary: false,
-              increment_strategy: "default",
-              lot_conditions_report_enabled: true,
-              require_identity_verification: true,
-            }
-
             const query = gql`
               {
                 sale(id: "foo-foo") {

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -287,24 +287,19 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
           _options,
           { meLoader, meBiddersLoader }
         ) => {
-          if (require_identity_verification) {
-            if (!meLoader || !meBiddersLoader) {
-              return true
+          if (!require_identity_verification) return false
+          if (!meLoader || !meBiddersLoader) return true
+
+          return meBiddersLoader({ sale_id: id }).then(bidders => {
+            if (bidders.length > 0) {
+              const bidder = bidders[0]
+              return bidder.needs_identity_verification
             } else {
-              return meBiddersLoader({ sale_id: id }).then(bidders => {
-                if (bidders.length > 0) {
-                  const bidder = bidders[0]
-                  return bidder.needs_identity_verification
-                } else {
-                  return meLoader().then(({ identity_verified }) => {
-                    return !identity_verified
-                  })
-                }
+              return meLoader().then(({ identity_verified }) => {
+                return !identity_verified
               })
             }
-          } else {
-            return false
-          }
+          })
         },
       },
       saleArtworksConnection: {

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -278,19 +278,28 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ require_identity_verification }) =>
           require_identity_verification,
       },
-      requiresIdentityVerificationFor: {
+      userNeedsIdentityVerification: {
         type: GraphQLBoolean,
+        description:
+          "True if the current client needs to undergo identity verification for this sale, false otherwise",
         resolve: (
-          { require_identity_verification },
+          { require_identity_verification, id },
           _options,
-          { meLoader }
+          { meLoader, meBiddersLoader }
         ) => {
           if (require_identity_verification) {
-            if (!meLoader) {
+            if (!meLoader || !meBiddersLoader) {
               return true
             } else {
-              return meLoader().then(({ identity_verified }) => {
-                return !identity_verified
+              return meBiddersLoader({ sale_id: id }).then(bidders => {
+                if (bidders.length > 0) {
+                  const bidder = bidders[0]
+                  return bidder.needs_identity_verification
+                } else {
+                  return meLoader().then(({ identity_verified }) => {
+                    return !identity_verified
+                  })
+                }
               })
             }
           } else {

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -281,7 +281,7 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
       userNeedsIdentityVerification: {
         type: GraphQLBoolean,
         description:
-          "True if the current client needs to undergo identity verification for this sale, false otherwise",
+          "True if the current user needs to undergo identity verification for this sale, false otherwise",
         resolve: (
           { require_identity_verification, id },
           _options,

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -280,9 +280,23 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
       },
       requiresIdentityVerificationFor: {
         type: GraphQLBoolean,
-        args: { user_id: { type: GraphQLID } },
-        resolve: ({ require_identity_verification }) =>
-          require_identity_verification,
+        resolve: (
+          { require_identity_verification },
+          _options,
+          { meLoader }
+        ) => {
+          if (require_identity_verification) {
+            if (!meLoader) {
+              return true
+            } else {
+              return meLoader().then(({ identity_verified }) => {
+                return !identity_verified
+              })
+            }
+          } else {
+            return false
+          }
+        },
       },
       saleArtworksConnection: {
         type: saleArtworkConnection,

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -278,6 +278,12 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ require_identity_verification }) =>
           require_identity_verification,
       },
+      requiresIdentityVerificationFor: {
+        type: GraphQLBoolean,
+        args: { user_id: { type: GraphQLID } },
+        resolve: ({ require_identity_verification }) =>
+          require_identity_verification,
+      },
       saleArtworksConnection: {
         type: saleArtworkConnection,
         args: pageable({


### PR DESCRIPTION
Problem:

Logic about whether the current user needs to undergo identity
verification is scattered around Reaction and Eigen, increasing risk
that business logic starts to drift and generally is a larger code
surface area than needed.

Solution:

Introduce new field to `Sale` which is the source of truth as to whether
the current user needs to undergo identity verification or not for the
sale in question.

Why introduce this field to `Sale` instead of `me`, `User`, or `Bidder`?

- See this [Slack convo][0].

- Because there are times where the user isn't yet registered to bid, but we
need to know if the current user needs to undergo identity verification
or not, so extending `Bidder` doesn't seem to make sense.

- Moreover, there are even times whether there's no reference to a
current user (`me`). In that case, we want to display that the "current
user" needs to undergo identity verification, so extending `me`/`User`
doesn't seems to make sense.

- We always have reference to a `Sale`, so extending that type with this
field makes the most sense. This is a similar pattern to
`Sale.registrationStatus`.

Jira: https://artsyproduct.atlassian.net/browse/AUCT-983
Related PR: https://github.com/artsy/gravity/pull/12996

[0]:https://artsy.slack.com/archives/CA3D02SDN/p1587581641465800

---

Documentation of the behavior of `Sale.userNeedsIdentityVerification`

```
    userNeedsIdentityVerification
      when the sale doesn't requires identity verification
        ✓ returns false (10ms)
      when the sale does require identity verification
        when there is no current user
          ✓ returns true (5ms)
        when there is a current user
          when the user is registered for the sale
            ✓ returns false bidder.needs_identity_verification is false (5ms)
            ✓ returns true when bidder.needs_identity_verification is true (4ms)
          when the user is not registered for the sale
            ✓ returns false when the user is identity verified (3ms)
            ✓ returns true when the user is not identity verified (4ms)
```