### PR TITLE
Read the correct field from gravity

### DIFF
--- a/src/schema/v2/image/index.ts
+++ b/src/schema/v2/image/index.ts
@@ -21,7 +21,7 @@ export { normalize as normalizeImageData } from "./normalize"
 
 export const getDefault = images => {
   if (isArray(images)) {
-    return find(images, { is_default: true } as any) || first(images)
+    return find(images, { default: true } as any) || first(images)
   }
   return images
 }

--- a/src/schema/v2/image/index.ts
+++ b/src/schema/v2/image/index.ts
@@ -58,7 +58,7 @@ const ImageType = new GraphQLObjectType<any, ResolverContext>({
     },
     isDefault: {
       type: GraphQLBoolean,
-      resolve: ({ is_default }) => is_default,
+      resolve: ({ default: is_default }) => is_default,
     },
     isZoomable: {
       type: GraphQLBoolean,

--- a/src/schema/v2/image/index.ts
+++ b/src/schema/v2/image/index.ts
@@ -21,7 +21,10 @@ export { normalize as normalizeImageData } from "./normalize"
 
 export const getDefault = images => {
   if (isArray(images)) {
-    return find(images, { default: true } as any) || first(images)
+    return (
+      find(images, img => img.is_default === true || img.default === true) ||
+      first(images)
+    )
   }
   return images
 }
@@ -58,7 +61,7 @@ const ImageType = new GraphQLObjectType<any, ResolverContext>({
     },
     isDefault: {
       type: GraphQLBoolean,
-      resolve: ({ default: is_default }) => is_default,
+      resolve: image => image.is_default || image.default,
     },
     isZoomable: {
       type: GraphQLBoolean,

--- a/src/types/gravity/artworkResponse.d.ts
+++ b/src/types/gravity/artworkResponse.d.ts
@@ -105,7 +105,7 @@ export interface Image {
   downloadable: boolean
   original_width: number
   original_height: number
-  is_default: boolean
+  default: boolean
   image_url: string
   image_versions: string[]
   image_urls: ImageImageUrls

--- a/src/types/gravity/artworkResponse.d.ts
+++ b/src/types/gravity/artworkResponse.d.ts
@@ -105,7 +105,10 @@ export interface Image {
   downloadable: boolean
   original_width: number
   original_height: number
-  default: boolean
+
+  default?: boolean // Appears in `Image`
+  is_default?: boolean //Appears in `AdditionalImage`
+
   image_url: string
   image_versions: string[]
   image_urls: ImageImageUrls


### PR DESCRIPTION
We were using the wrong name coming from gravity.

Using this query
```
{
  show(id: "5e6e2efe4d2aa0000e2be3da") {
    name
    images {
      imageURL
      isDefault
    }
  }
}
```
I would get something like
```
{
  "data": {
    "show": {
      "name": "ART ON PAPER",
      "images": [
        {
          "imageURL": "https://d32dm0rphc51dk.cloudfront.net/7vFrlr0sqJBwP7T478Vvbw/:version.jpg",
          "isDefault": null
        },
        {
          "imageURL": "https://d2v80f5yrouhh2.cloudfront.net/prVTNCjKDNEdVPYoq41prQ/:version.jpg",
          "isDefault": null
        },
        {
          "imageURL": "https://d2v80f5yrouhh2.cloudfront.net/6aAeK7lCF1bQxBeeXxteIA/:version.jpg",
          "isDefault": null
        }
      ]
    }
  }
```
but now I get
```
{
  "data": {
    "show": {
      "name": "ART ON PAPER",
      "images": [
        {
          "imageURL": "https://d32dm0rphc51dk.cloudfront.net/7vFrlr0sqJBwP7T478Vvbw/:version.jpg",
          "isDefault": false
        },
        {
          "imageURL": "https://d2v80f5yrouhh2.cloudfront.net/prVTNCjKDNEdVPYoq41prQ/:version.jpg",
          "isDefault": false
        },
        {
          "imageURL": "https://d2v80f5yrouhh2.cloudfront.net/6aAeK7lCF1bQxBeeXxteIA/:version.jpg",
          "isDefault": true
        }
      ]
    }
  }
```

PS: I wasn't sure how to make a transformation to name the incoming json data from `default` to `is_default` and keep the rest of the code same, so I kept the json same and changed the field we read. In this case, because `default` is a reserved name in js, I would prefer the former, but I guess the latter works too. If there is an obvious place I missed, let me know and I can patch this PR.

PPS: I wasn't sure on who to tag for this, to review and assign. Feel free to swap around if I have the completely wrong people. 😅 