### PR TITLE
[MX-245] Exposes basis of artist suggestions through schema

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -567,7 +567,7 @@ enum ArticleSorts {
   PUBLISHED_AT_DESC
 }
 
-type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInterface {
+type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInterface & HomePageArtist {
   # A globally unique ID.
   id: ID!
 
@@ -4827,13 +4827,31 @@ type HomePage {
   salesModule: HomePageSalesModule
 }
 
+# An artist returned in a home page module
+interface HomePageArtist {
+  # A globally unique ID.
+  id: ID!
+
+  # A slug ID.
+  slug: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+  href: String
+  name: String
+  formattedNationalityAndBirthday: String
+  formattedArtworksCount: String
+  image: Image
+  artworksConnection: ArtworkConnection
+}
+
 type HomePageArtistModule implements Node {
   # A globally unique ID.
   id: ID!
 
   # Module identifier.
   key: String
-  results: [Artist]
+  results: [HomePageArtist]
 }
 
 enum HomePageArtistModuleTypes {
@@ -7756,6 +7774,24 @@ type SubmissionEdge {
 
   # The item at the end of the edge.
   node: ConsignmentSubmission
+}
+
+type SuggestedArtist implements Node & HomePageArtist {
+  # A globally unique ID.
+  id: ID!
+
+  # A slug ID.
+  slug: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+  href: String
+  name: String
+  formattedNationalityAndBirthday: String
+  formattedArtworksCount: String
+  image: Image
+  artworksConnection: ArtworkConnection
+  basedOn: Artist
 }
 
 type System {

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -84,10 +84,12 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
     } = require("../filterArtworksConnection")
     const { Searchable } = require("schema/v2/searchable")
     const { NodeInterface } = require("schema/v2/object_identification")
+    const { HomePageArtist } = require("schema/v2/home/homePageArtistInterface")
     return [
       NodeInterface,
       Searchable,
       EntityWithFilterArtworksConnectionInterface,
+      HomePageArtist,
     ]
   },
   fields: () => {

--- a/src/schema/v2/home/__tests__/home_page_artist_module.test.js
+++ b/src/schema/v2/home/__tests__/home_page_artist_module.test.js
@@ -10,7 +10,13 @@ describe("HomePageArtistModule", () => {
         homePage {
           artistModule(key: ${key}) {
             results {
+              __typename
               slug
+              ... on SuggestedArtist {
+                basedOn {
+                  slug
+                }
+              }
             }
           }
         }
@@ -42,6 +48,11 @@ describe("HomePageArtistModule", () => {
           birthday: null,
           artworks_count: null,
         },
+        sim_artist: {
+          id: "similar",
+          birthday: null,
+          artworks_count: null,
+        },
       },
     ],
   }
@@ -56,15 +67,17 @@ describe("HomePageArtistModule", () => {
     it("returns trending artists", () => {
       return runAuthenticatedQuery(query("TRENDING"), context).then(
         ({ homePage }) => {
-          expect(homePage.artistModule.results).toEqual([{ slug: "trending" }])
+          expect(homePage.artistModule.results[0].slug).toEqual("trending")
+          expect(homePage.artistModule.results[0].__typename).toEqual("Artist")
         }
       )
     })
 
-    it("returns trending artists", () => {
-      return runAuthenticatedQuery(query("TRENDING"), context).then(
+    it("returns popular artists", () => {
+      return runAuthenticatedQuery(query("POPULAR"), context).then(
         ({ homePage }) => {
-          expect(homePage.artistModule.results).toEqual([{ slug: "trending" }])
+          expect(homePage.artistModule.results[0].slug).toEqual("popular")
+          expect(homePage.artistModule.results[0].__typename).toEqual("Artist")
         }
       )
     })
@@ -72,7 +85,13 @@ describe("HomePageArtistModule", () => {
     it("returns suggestions", () => {
       return runAuthenticatedQuery(query("SUGGESTED"), context).then(
         ({ homePage }) => {
-          expect(homePage.artistModule.results).toEqual([{ slug: "suggested" }])
+          expect(homePage.artistModule.results[0].slug).toEqual("suggested")
+          expect(homePage.artistModule.results[0].__typename).toEqual(
+            "SuggestedArtist"
+          )
+          expect(homePage.artistModule.results[0].basedOn.slug).toEqual(
+            "similar"
+          )
         }
       )
     })
@@ -82,15 +101,15 @@ describe("HomePageArtistModule", () => {
     it("returns trending artists", () => {
       return runAuthenticatedQuery(query("TRENDING"), context).then(
         ({ homePage }) => {
-          expect(homePage.artistModule.results).toEqual([{ slug: "trending" }])
+          expect(homePage.artistModule.results[0].slug).toEqual("trending")
         }
       )
     })
 
-    it("returns trending artists", () => {
-      return runAuthenticatedQuery(query("TRENDING"), context).then(
+    it("returns popular artists", () => {
+      return runAuthenticatedQuery(query("POPULAR"), context).then(
         ({ homePage }) => {
-          expect(homePage.artistModule.results).toEqual([{ slug: "trending" }])
+          expect(homePage.artistModule.results[0].slug).toEqual("popular")
         }
       )
     })

--- a/src/schema/v2/home/homePageArtistInterface.ts
+++ b/src/schema/v2/home/homePageArtistInterface.ts
@@ -1,0 +1,28 @@
+import { GraphQLInterfaceType, GraphQLString } from "graphql"
+import Image from "schema/v2/image"
+import { artworkConnection } from "schema/v2/artwork"
+import { SlugAndInternalIDFields } from "schema/v2/object_identification"
+
+export const HomePageArtist = new GraphQLInterfaceType({
+  name: "HomePageArtist",
+  description: "An artist returned in a home page module",
+  fields: {
+    ...SlugAndInternalIDFields,
+    href: {
+      type: GraphQLString,
+    },
+    name: {
+      type: GraphQLString,
+    },
+    formattedNationalityAndBirthday: {
+      type: GraphQLString,
+    },
+    formattedArtworksCount: {
+      type: GraphQLString,
+    },
+    image: Image,
+    artworksConnection: {
+      type: artworkConnection.connectionType,
+    },
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -78,6 +78,7 @@ import { AuctionArtworkGridType } from "./artwork/artworkContextGrids/AuctionArt
 import { PartnerArtworkGridType } from "./artwork/artworkContextGrids/PartnerArtworkGrid"
 import { RelatedArtworkGridType } from "./artwork/artworkContextGrids/RelatedArtworkGrid"
 import { ShowArtworkGridType } from "./artwork/artworkContextGrids/ShowArtworkGrid"
+import { SuggestedArtist } from "./home/home_page_artist_module"
 
 import ObjectIdentification from "./object_identification"
 import { ResolverContext } from "types/graphql"
@@ -205,6 +206,7 @@ export default new GraphQLSchema({
     PartnerArtworkGridType,
     RelatedArtworkGridType,
     ShowArtworkGridType,
+    SuggestedArtist,
   ],
   directives: specifiedDirectives.concat([PrincipalFieldDirective]),
 })


### PR DESCRIPTION
These were being returned from Gravity but then discarded. This exposes them through a new GraphQL Interface using a conditionally backwards-compatible schema change (ie: we need to make sure to expose any data clients are expecting in the new Interface). I've checked Emission's history to gather them all, and the resolver isn't currently referenced in Reaction, so we should be fine.

This allows us to continue requesting the data in queries as-is, but also expose a new `basedOn` field for `SuggestedArtist` objects. Existing queries work, and we don't need to deprecate anything to get the data 🎉  

The query looks like this:

```graphql
{
  homePage {
    artistModules {
      id
      key
      results {
        __typename
        name
        ... on SuggestedArtist {
          basedOn {
            name
          }
        }
      }
    }
  }
}
```

And we receive results like this:

```json
{
  "data": {
    "homePage": {
      "artistModules": [
        {
          "id": "SG9tZVBhZ2VBcnRpc3RNb2R1bGU6eyJrZXkiOiJTVUdHRVNURUQifQ==",
          "key": "SUGGESTED",
          "results": [
            {
              "__typename": "SuggestedArtist",
              "name": "Dennis Adams",
              "basedOn": {
                "name": "Paul Pfeiffer"
              }
            },
            {
              "__typename": "SuggestedArtist",
              "name": "Zhou Xiaohu",
              "basedOn": {
                "name": "Paul Pfeiffer"
              }
            },
            /* ... */
          ]
        },
        {
          "id": "SG9tZVBhZ2VBcnRpc3RNb2R1bGU6eyJrZXkiOiJUUkVORElORyJ9",
          "key": "TRENDING",
          "results": [
            {
              "__typename": "Artist",
              "name": "Hisao Hanafusa"
            },
            {
              "__typename": "Artist",
              "name": "Harumi Nakashima"
            },
            /* ... */
          ]
        },
        {
          "id": "SG9tZVBhZ2VBcnRpc3RNb2R1bGU6eyJrZXkiOiJQT1BVTEFSIn0=",
          "key": "POPULAR",
          "results": [
            {
              "__typename": "Artist",
              "name": "Pablo Picasso"
            },
            {
              "__typename": "Artist",
              "name": "Banksy"
            },
            /* ... */
          ]
        }
      ]
    }
  }
}
```

Big thanks to @dblandin for his help pairing on this 🙌 