### PR TITLE
[MX-245] Adds basis for artist suggestions in schema

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -626,6 +626,9 @@ type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInt
     before: String
     last: Int
   ): AuctionResultConnection
+
+  # In applicable contexts, this is what the artist (as a suggestion) is based on.
+  basedOn: Artist
   bio: String
 
   # The Artist biography article written by Artsy

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -299,6 +299,11 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
           )
         },
       },
+      basedOn: {
+        type: ArtistType,
+        description:
+          "In applicable contexts, this is what the artist (as a suggestion) is based on.",
+      },
       bio: {
         type: GraphQLString,
         resolve: ({ nationality, years, hometown, location }) => {

--- a/src/schema/v2/home/__tests__/home_page_artist_module.test.js
+++ b/src/schema/v2/home/__tests__/home_page_artist_module.test.js
@@ -11,6 +11,9 @@ describe("HomePageArtistModule", () => {
           artistModule(key: ${key}) {
             results {
               slug
+              basedOn {
+                slug
+              }
             }
           }
         }
@@ -42,6 +45,11 @@ describe("HomePageArtistModule", () => {
           birthday: null,
           artworks_count: null,
         },
+        sim_artist: {
+          id: "similar",
+          birthday: null,
+          artworks_count: null,
+        },
       },
     ],
   }
@@ -56,15 +64,15 @@ describe("HomePageArtistModule", () => {
     it("returns trending artists", () => {
       return runAuthenticatedQuery(query("TRENDING"), context).then(
         ({ homePage }) => {
-          expect(homePage.artistModule.results).toEqual([{ slug: "trending" }])
+          expect(homePage.artistModule.results[0].slug).toEqual("trending")
         }
       )
     })
 
-    it("returns trending artists", () => {
-      return runAuthenticatedQuery(query("TRENDING"), context).then(
+    it("returns popular artists", () => {
+      return runAuthenticatedQuery(query("POPULAR"), context).then(
         ({ homePage }) => {
-          expect(homePage.artistModule.results).toEqual([{ slug: "trending" }])
+          expect(homePage.artistModule.results[0].slug).toEqual("popular")
         }
       )
     })
@@ -72,7 +80,10 @@ describe("HomePageArtistModule", () => {
     it("returns suggestions", () => {
       return runAuthenticatedQuery(query("SUGGESTED"), context).then(
         ({ homePage }) => {
-          expect(homePage.artistModule.results).toEqual([{ slug: "suggested" }])
+          expect(homePage.artistModule.results[0].slug).toEqual("suggested")
+          expect(homePage.artistModule.results[0].basedOn.slug).toEqual(
+            "similar"
+          )
         }
       )
     })
@@ -82,15 +93,15 @@ describe("HomePageArtistModule", () => {
     it("returns trending artists", () => {
       return runAuthenticatedQuery(query("TRENDING"), context).then(
         ({ homePage }) => {
-          expect(homePage.artistModule.results).toEqual([{ slug: "trending" }])
+          expect(homePage.artistModule.results[0].slug).toEqual("trending")
         }
       )
     })
 
-    it("returns trending artists", () => {
-      return runAuthenticatedQuery(query("TRENDING"), context).then(
+    it("returns popular artists", () => {
+      return runAuthenticatedQuery(query("POPULAR"), context).then(
         ({ homePage }) => {
-          expect(homePage.artistModule.results).toEqual([{ slug: "trending" }])
+          expect(homePage.artistModule.results[0].slug).toEqual("popular")
         }
       )
     })

--- a/src/schema/v2/home/home_page_artist_module.ts
+++ b/src/schema/v2/home/home_page_artist_module.ts
@@ -1,4 +1,3 @@
-import { map } from "lodash"
 import Artist from "schema/v2/artist"
 import { NodeInterface } from "schema/v2/object_identification"
 import { toGlobalId } from "graphql-relay"
@@ -46,7 +45,12 @@ export const HomePageArtistModuleTypes: {
       return suggestedSimilarArtistsLoader({
         exclude_followed_artists: true,
         exclude_artists_without_forsale_artworks: true,
-      }).then(({ body }) => map(body, "artist"))
+      }).then(({ body }) =>
+        body.map(({ artist, sim_artist }) => ({
+          ...artist,
+          basedOn: sim_artist,
+        }))
+      )
     },
   },
   TRENDING: {


### PR DESCRIPTION
Originally implemented in https://github.com/artsy/metaphysics/pull/2335. We had to revert that change in #2338 because it broke the existing app. It turns out that the schema change wasn't as backwards-compatible as we'd thought. 

## The Problem

Everything would work as expected in a structured query like this:

```graphql
{
  homePage {
    artistModules {
      results {
        name
        ... on SuggestedArtist {
          basedOn {
            name
          }
        }
      }
    }
  }
}
```

But the problem is that Relay is more explicit in how it asks for data, creating queries that explicitly reference the type in a fragment spread:

```graphql
fragment ArtistCard_artist on Artist {
  name
  # ...
}

fragment ArtistRail_rail on HomePageArtistModule {
  results {
    __typename
    ...ArtistCard_artist
  }
}

fragment Home_homePage on HomePage {
  artistModules {
    ...ArtistRail_rail
  }
}

query HomeQuery {
  homePage {
    ...Home_homePage
  }
}
```

The `... on Artist` part of the query is what makes it incompatible. In the app, we were seeing all `null` data get passed through (until we re-ran `yarn relay` to generate new schema-compatible queries). I missed this when testing with simplified queries, but noticed that the app beta broken once #2335 was deployed to staging.

## The Solution

Instead, we added a new field called `basedOn` to _all_ Artist objects. It's a wide-reaching change, but it's totally backwards-compatible since it's purely additive to the schema. 

I also did the same test cleanup as the original PR.
## An Alternative

Alternatively, we could deprecate the existing `homePage.artistModule.results` field and replace it with something that returns the data we need. That is to say, we could add a new GraphQL object type to the schema and return an array of them in a new field that replaces `homePage.artistModule.results`. 

This would allow existing clients to continue using the old field, but had two drawbacks: it's overkill to get access to just one more field, and I had a _really_ hard time naming a replacement for the (then-deprecated) `results` field 😅 `results2` felt bad but everything else felt worse.

So I feel like adding `basedOn` to `Artist` itself is a good compromise, especially with a good field description. 

---

Thanks to @ds300 for talking through this with me 🙌 