### PR TITLE
[WIP] Increase non-nullability of connections

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -576,7 +576,7 @@ type ArticleConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [ArticleEdge]
+  edges: [ArticleEdge!]!
   pageCursors: PageCursors
   totalCount: Int
 }
@@ -584,7 +584,7 @@ type ArticleConnection {
 # An edge in a connection.
 type ArticleEdge {
   # The item at the end of the edge
-  node: Article
+  node: Article!
 
   # A cursor for use in pagination
   cursor: String!
@@ -871,7 +871,7 @@ type ArtistConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [ArtistEdge]
+  edges: [ArtistEdge!]!
   pageCursors: PageCursors
   totalCount: Int
 }
@@ -915,7 +915,7 @@ type ArtistCounts {
 # An edge in a connection.
 type ArtistEdge {
   # The item at the end of the edge
-  node: Artist
+  node: Artist!
 
   # A cursor for use in pagination
   cursor: String!
@@ -1513,7 +1513,7 @@ type ArtworkConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [ArtworkEdge]
+  edges: [ArtworkEdge!]!
   pageCursors: PageCursors
   totalCount: Int
 }
@@ -2156,7 +2156,7 @@ type ArtworkContextSale implements Node {
 # An edge in a connection.
 type ArtworkEdge {
   # The item at the end of the edge
-  node: Artwork
+  node: Artwork!
 
   # A cursor for use in pagination
   cursor: String!
@@ -2311,13 +2311,13 @@ type ArtworkInquiryConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [ArtworkInquiryEdge]
+  edges: [ArtworkInquiryEdge!]!
 }
 
 # An edge in a connection.
 type ArtworkInquiryEdge {
   # The item at the end of the edge
-  node: ArtworkInquiry
+  node: ArtworkInquiry!
 
   # A cursor for use in pagination
   cursor: String!
@@ -2787,7 +2787,7 @@ type AuctionResultConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [AuctionResultEdge]
+  edges: [AuctionResultEdge!]!
   pageCursors: PageCursors
   totalCount: Int
 }
@@ -2795,7 +2795,7 @@ type AuctionResultConnection {
 # An edge in a connection.
 type AuctionResultEdge {
   # The item at the end of the edge
-  node: AuctionResult
+  node: AuctionResult!
 
   # A cursor for use in pagination
   cursor: String!
@@ -5019,14 +5019,14 @@ type ConversationConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [ConversationEdge]
+  edges: [ConversationEdge!]!
   totalUnreadCount: Int
 }
 
 # An edge in a connection.
 type ConversationEdge {
   # The item at the end of the edge
-  node: Conversation
+  node: Conversation!
 
   # A cursor for use in pagination
   cursor: String!
@@ -5313,13 +5313,13 @@ type CreditCardConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [CreditCardEdge]
+  edges: [CreditCardEdge!]!
 }
 
 # An edge in a connection.
 type CreditCardEdge {
   # The item at the end of the edge
-  node: CreditCard
+  node: CreditCard!
 
   # A cursor for use in pagination
   cursor: String!
@@ -5807,7 +5807,7 @@ type FairConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [FairEdge]
+  edges: [FairEdge!]!
   pageCursors: PageCursors
   totalCount: Int
 }
@@ -5838,7 +5838,7 @@ type FairCounts {
 # An edge in a connection.
 type FairEdge {
   # The item at the end of the edge
-  node: Fair
+  node: Fair!
 
   # A cursor for use in pagination
   cursor: String!
@@ -6005,7 +6005,7 @@ type FollowArtistConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [FollowArtistEdge]
+  edges: [FollowArtistEdge!]!
 }
 
 type FollowArtistCounts {
@@ -6015,7 +6015,7 @@ type FollowArtistCounts {
 # An edge in a connection.
 type FollowArtistEdge {
   # The item at the end of the edge
-  node: FollowArtist
+  node: FollowArtist!
 
   # A cursor for use in pagination
   cursor: String!
@@ -6081,13 +6081,13 @@ type FollowedArtistsArtworksGroupConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [FollowedArtistsArtworksGroupEdge]
+  edges: [FollowedArtistsArtworksGroupEdge!]!
 }
 
 # An edge in a connection.
 type FollowedArtistsArtworksGroupEdge {
   # The item at the end of the edge
-  node: FollowedArtistsArtworksGroup
+  node: FollowedArtistsArtworksGroup!
 
   # A cursor for use in pagination
   cursor: String!
@@ -6104,13 +6104,13 @@ type FollowedFairConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [FollowedFairEdge]
+  edges: [FollowedFairEdge!]!
 }
 
 # An edge in a connection.
 type FollowedFairEdge {
   # The item at the end of the edge
-  node: Fair
+  node: Fair!
 
   # A cursor for use in pagination
   cursor: String!
@@ -6122,13 +6122,13 @@ type FollowedShowConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [FollowedShowEdge]
+  edges: [FollowedShowEdge!]!
 }
 
 # An edge in a connection.
 type FollowedShowEdge {
   # The item at the end of the edge
-  node: Show
+  node: Show!
 
   # A cursor for use in pagination
   cursor: String!
@@ -6150,13 +6150,13 @@ type FollowGeneConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [FollowGeneEdge]
+  edges: [FollowGeneEdge!]!
 }
 
 # An edge in a connection.
 type FollowGeneEdge {
   # The item at the end of the edge
-  node: FollowGene
+  node: FollowGene!
 
   # A cursor for use in pagination
   cursor: String!
@@ -6414,7 +6414,7 @@ type GeneArtworksConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [GeneArtworksEdge]
+  edges: [GeneArtworksEdge!]!
 
   # Returns aggregation counts for the given filter query.
   aggregations: [ArtworksAggregationResults]
@@ -6424,7 +6424,7 @@ type GeneArtworksConnection {
 # An edge in a connection.
 type GeneArtworksEdge {
   # The item at the end of the edge
-  node: Artwork
+  node: Artwork!
 
   # A cursor for use in pagination
   cursor: String!
@@ -6436,13 +6436,13 @@ type GeneConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [GeneEdge]
+  edges: [GeneEdge!]!
 }
 
 # An edge in a connection.
 type GeneEdge {
   # The item at the end of the edge
-  node: Gene
+  node: Gene!
 
   # A cursor for use in pagination
   cursor: String!
@@ -6467,13 +6467,13 @@ type GeneFamilyConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [GeneFamilyEdge]
+  edges: [GeneFamilyEdge!]!
 }
 
 # An edge in a connection.
 type GeneFamilyEdge {
   # The item at the end of the edge
-  node: GeneFamily
+  node: GeneFamily!
 
   # A cursor for use in pagination
   cursor: String!
@@ -8152,13 +8152,13 @@ type MessageConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [MessageEdge]
+  edges: [MessageEdge!]!
 }
 
 # An edge in a connection.
 type MessageEdge {
   # The item at the end of the edge
-  node: Message
+  node: Message!
 
   # A cursor for use in pagination
   cursor: String!
@@ -8515,13 +8515,13 @@ type NotificationsFeedItemConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [NotificationsFeedItemEdge]
+  edges: [NotificationsFeedItemEdge!]!
 }
 
 # An edge in a connection.
 type NotificationsFeedItemEdge {
   # The item at the end of the edge
-  node: NotificationsFeedItem
+  node: NotificationsFeedItem!
 
   # A cursor for use in pagination
   cursor: String!
@@ -8642,13 +8642,13 @@ type OfferConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [OfferEdge]
+  edges: [OfferEdge!]!
 }
 
 # An edge in a connection.
 type OfferEdge {
   # The item at the end of the edge
-  node: Offer
+  node: Offer!
 
   # A cursor for use in pagination
   cursor: String!
@@ -9102,7 +9102,7 @@ type OrderConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [OrderEdge]
+  edges: [OrderEdge!]!
   totalCount: Int
   totalPages: Int
   pageCursors: PageCursors
@@ -9111,7 +9111,7 @@ type OrderConnection {
 # An edge in a connection.
 type OrderEdge {
   # The item at the end of the edge
-  node: Order
+  node: Order!
 
   # A cursor for use in pagination
   cursor: String!
@@ -9159,13 +9159,13 @@ type OrderFulfillmentConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [OrderFulfillmentEdge]
+  edges: [OrderFulfillmentEdge!]!
 }
 
 # An edge in a connection.
 type OrderFulfillmentEdge {
   # The item at the end of the edge
-  node: OrderFulfillment
+  node: OrderFulfillment!
 
   # A cursor for use in pagination
   cursor: String!
@@ -9252,13 +9252,13 @@ type OrderLineItemConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [OrderLineItemEdge]
+  edges: [OrderLineItemEdge!]!
 }
 
 # An edge in a connection.
 type OrderLineItemEdge {
   # The item at the end of the edge
-  node: OrderLineItem
+  node: OrderLineItem!
 
   # A cursor for use in pagination
   cursor: String!
@@ -9457,7 +9457,7 @@ type PartnerArtistConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [PartnerArtistEdge]
+  edges: [PartnerArtistEdge!]!
 }
 
 type PartnerArtistCounts {
@@ -9476,7 +9476,7 @@ type PartnerArtistCounts {
 # An edge in a connection.
 type PartnerArtistEdge {
   # The item at the end of the edge
-  node: Partner
+  node: Partner!
 
   # A cursor for use in pagination
   cursor: String!
@@ -11021,7 +11021,7 @@ type SaleArtworkConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [SaleArtworkEdge]
+  edges: [SaleArtworkEdge!]!
 }
 
 type SaleArtworkCounts {
@@ -11054,7 +11054,7 @@ type SaleArtworkCurrentBid {
 # An edge in a connection.
 type SaleArtworkEdge {
   # The item at the end of the edge
-  node: SaleArtwork
+  node: SaleArtwork!
 
   # A cursor for use in pagination
   cursor: String!
@@ -11196,7 +11196,7 @@ type SaleArtworksConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [SaleArtworksEdge]
+  edges: [SaleArtworksEdge!]!
 
   # Returns aggregation counts for the given filter query.
   aggregations: [SaleArtworksAggregationResults]
@@ -11206,7 +11206,7 @@ type SaleArtworksConnection {
 # An edge in a connection.
 type SaleArtworksEdge {
   # The item at the end of the edge
-  node: SaleArtwork
+  node: SaleArtwork!
 
   # A cursor for use in pagination
   cursor: String!
@@ -11259,7 +11259,7 @@ type SearchableConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [SearchableEdge]
+  edges: [SearchableEdge!]!
   pageCursors: PageCursors
   totalCount: Int
 
@@ -11270,7 +11270,7 @@ type SearchableConnection {
 # An edge in a connection.
 type SearchableEdge {
   # The item at the end of the edge
-  node: Searchable
+  node: Searchable!
 
   # A cursor for use in pagination
   cursor: String!
@@ -11798,7 +11798,7 @@ type ShowConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [ShowEdge]
+  edges: [ShowEdge!]!
   pageCursors: PageCursors
   totalCount: Int
 }
@@ -11819,7 +11819,7 @@ type ShowCounts {
 # An edge in a connection.
 type ShowEdge {
   # The item at the end of the edge
-  node: Show
+  node: Show!
 
   # A cursor for use in pagination
   cursor: String!
@@ -11835,13 +11835,13 @@ type ShowFollowArtistConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [ShowFollowArtistEdge]
+  edges: [ShowFollowArtistEdge!]!
 }
 
 # An edge in a connection.
 type ShowFollowArtistEdge {
   # The item at the end of the edge
-  node: ShowFollowArtist
+  node: ShowFollowArtist!
 
   # A cursor for use in pagination
   cursor: String!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6893,8 +6893,8 @@ type SaleArtwork implements Node & ArtworkEdgeInterface {
   # A type-specific ID likely used as a database ID.
   internalID: ID!
   cached: Int
-  artwork: Artwork
-  node: Artwork
+  artwork: Artwork!
+  node: Artwork!
   cursor: String
   counts: SaleArtworkCounts
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -548,7 +548,7 @@ type ArticleConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [ArticleEdge]
+  edges: [ArticleEdge!]!
   pageCursors: PageCursors!
   totalCount: Int
 }
@@ -556,7 +556,7 @@ type ArticleConnection {
 # An edge in a connection.
 type ArticleEdge {
   # The item at the end of the edge
-  node: Article
+  node: Article!
 
   # A cursor for use in pagination
   cursor: String!
@@ -586,7 +586,7 @@ type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInt
     first: Int
     before: String
     last: Int
-  ): ArticleConnection
+  ): ArticleConnection!
   artworksConnection(
     # List of artwork IDs to exclude from the response.
     exclude: [String]
@@ -597,7 +597,7 @@ type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInt
     first: Int
     before: String
     last: Int
-  ): ArtworkConnection
+  ): ArtworkConnection!
   auctionResultsConnection(
     sort: AuctionResultSorts
 
@@ -704,7 +704,7 @@ type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInt
     first: Int
     before: String
     last: Int
-  ): FilterArtworksConnection
+  ): FilterArtworksConnection!
 
   # A string showing the total number of works and those for sale
   formattedArtworksCount: String
@@ -742,7 +742,7 @@ type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInt
     first: Int
     before: String
     last: Int
-  ): PartnerArtistConnection
+  ): PartnerArtistConnection!
   partnerArtists(
     # The number of PartnerArtists to return
     size: Int
@@ -772,7 +772,7 @@ type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInt
     first: Int
     before: String
     last: Int
-  ): ShowConnection
+  ): ShowConnection!
 
   # Use this attribute to sort by when sorting a collection of Artists
   sortableID: String
@@ -824,7 +824,7 @@ type ArtistConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [ArtistEdge]
+  edges: [ArtistEdge!]!
   pageCursors: PageCursors!
   totalCount: Int
 }
@@ -868,7 +868,7 @@ type ArtistCounts {
 # An edge in a connection.
 type ArtistEdge {
   # The item at the end of the edge
-  node: Artist
+  node: Artist!
 
   # A cursor for use in pagination
   cursor: String!
@@ -891,7 +891,7 @@ type ArtistHighlights {
     first: Int
     before: String
     last: Int
-  ): PartnerArtistConnection
+  ): PartnerArtistConnection!
 }
 
 type ArtistInsight {
@@ -916,7 +916,7 @@ type ArtistPartnerConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [ArtistPartnerEdge]
+  edges: [ArtistPartnerEdge!]!
   pageCursors: PageCursors!
   totalCount: Int
 }
@@ -924,7 +924,7 @@ type ArtistPartnerConnection {
 # An edge in a connection.
 type ArtistPartnerEdge {
   # The item at the end of the edge
-  node: Artist
+  node: Artist!
 
   # A cursor for use in pagination
   cursor: String!
@@ -945,7 +945,7 @@ type ArtistPartnerEdge {
 }
 
 type ArtistRelatedData {
-  genes(after: String, first: Int, before: String, last: Int): GeneConnection
+  genes(after: String, first: Int, before: String, last: Int): GeneConnection!
   artistsConnection(
     excludeArtistsWithoutArtworks: Boolean = true
     minForsaleArtworks: Int
@@ -954,7 +954,7 @@ type ArtistRelatedData {
     first: Int
     before: String
     last: Int
-  ): ArtistConnection
+  ): ArtistConnection!
 
   # A list of the current user’s suggested artists, based on a single artist
   suggestedConnection(
@@ -1224,7 +1224,7 @@ type ArtworkConnection implements ArtworkConnectionInterface {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [ArtworkEdge]
+  edges: [ArtworkEdge!]!
   pageCursors: PageCursors!
   totalCount: Int
 }
@@ -1232,7 +1232,7 @@ type ArtworkConnection implements ArtworkConnectionInterface {
 interface ArtworkConnectionInterface {
   pageCursors: PageCursors!
   pageInfo: PageInfo!
-  edges: [ArtworkEdgeInterface]
+  edges: [ArtworkEdgeInterface!]!
 }
 
 union ArtworkContext = Fair | Sale | Show
@@ -1253,14 +1253,14 @@ interface ArtworkContextGrid {
 # An edge in a connection.
 type ArtworkEdge implements ArtworkEdgeInterface {
   # The item at the end of the edge
-  node: Artwork
+  node: Artwork!
 
   # A cursor for use in pagination
   cursor: String!
 }
 
 interface ArtworkEdgeInterface {
-  node: Artwork
+  node: Artwork!
   cursor: String
 }
 
@@ -1293,13 +1293,13 @@ type ArtworkInquiryConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [ArtworkInquiryEdge]
+  edges: [ArtworkInquiryEdge!]!
 }
 
 # An edge in a connection.
 type ArtworkInquiryEdge {
   # The item at the end of the edge
-  node: ArtworkInquiry
+  node: ArtworkInquiry!
 
   # A cursor for use in pagination
   cursor: String!
@@ -1318,7 +1318,7 @@ type ArtworkLayer {
     first: Int
     before: String
     last: Int
-  ): ArtworkConnection
+  ): ArtworkConnection!
   description: String
   href: String
   name: String
@@ -1494,7 +1494,7 @@ type AuctionResultConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [AuctionResultEdge]
+  edges: [AuctionResultEdge!]!
   pageCursors: PageCursors!
   totalCount: Int
   createdYearRange: YearRange
@@ -1503,7 +1503,7 @@ type AuctionResultConnection {
 # An edge in a connection.
 type AuctionResultEdge {
   # The item at the end of the edge
-  node: AuctionResult
+  node: AuctionResult!
 
   # A cursor for use in pagination
   cursor: String!
@@ -1744,7 +1744,7 @@ type City {
     first: Int
     before: String
     last: Int
-  ): ShowConnection
+  ): ShowConnection!
   fairsConnection(
     sort: FairSorts
     status: EventStatus
@@ -1752,7 +1752,7 @@ type City {
     first: Int
     before: String
     last: Int
-  ): FairConnection
+  ): FairConnection!
   sponsoredContent: CitySponsoredContent
 }
 
@@ -1767,7 +1767,7 @@ type CitySponsoredContent {
     first: Int
     before: String
     last: Int
-  ): ShowConnection
+  ): ShowConnection!
 }
 
 enum CollectionSorts {
@@ -3372,14 +3372,14 @@ type ConversationConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [ConversationEdge]
+  edges: [ConversationEdge!]!
   totalUnreadCount: Int
 }
 
 # An edge in a connection.
 type ConversationEdge {
   # The item at the end of the edge
-  node: Conversation
+  node: Conversation!
 
   # A cursor for use in pagination
   cursor: String!
@@ -3662,13 +3662,13 @@ type CreditCardConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [CreditCardEdge]
+  edges: [CreditCardEdge!]!
 }
 
 # An edge in a connection.
 type CreditCardEdge {
   # The item at the end of the edge
-  node: CreditCard
+  node: CreditCard!
 
   # A cursor for use in pagination
   cursor: String!
@@ -4043,7 +4043,7 @@ type Fair implements Node & EntityWithFilterArtworksConnectionInterface {
     first: Int
     before: String
     last: Int
-  ): ArtistConnection
+  ): ArtistConnection!
   cached: Int
   bannerSize: String
   counts: FairCounts
@@ -4153,7 +4153,7 @@ type Fair implements Node & EntityWithFilterArtworksConnectionInterface {
     first: Int
     before: String
     last: Int
-  ): FilterArtworksConnection
+  ): FilterArtworksConnection!
   sponsoredContent: FairSponsoredContent
 }
 
@@ -4168,7 +4168,7 @@ type FairConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [FairEdge]
+  edges: [FairEdge!]!
   pageCursors: PageCursors!
   totalCount: Int
 }
@@ -4199,7 +4199,7 @@ type FairCounts {
 # An edge in a connection.
 type FairEdge {
   # The item at the end of the edge
-  node: Fair
+  node: Fair!
 
   # A cursor for use in pagination
   cursor: String!
@@ -4271,7 +4271,7 @@ type FilterArtworksConnection implements Node & ArtworkConnectionInterface {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [FilterArtworksEdge]
+  edges: [FilterArtworksEdge!]!
 
   # The ID of the object.
   id: ID!
@@ -4309,7 +4309,7 @@ type FilterArtworksCounts {
 # An edge in a connection.
 type FilterArtworksEdge implements ArtworkEdgeInterface {
   # The item at the end of the edge
-  node: Artwork
+  node: Artwork!
 
   # A cursor for use in pagination
   cursor: String!
@@ -4345,7 +4345,7 @@ type FollowArtistConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [FollowArtistEdge]
+  edges: [FollowArtistEdge!]!
 }
 
 type FollowArtistCounts {
@@ -4355,7 +4355,7 @@ type FollowArtistCounts {
 # An edge in a connection.
 type FollowArtistEdge {
   # The item at the end of the edge
-  node: FollowArtist
+  node: FollowArtist!
 
   # A cursor for use in pagination
   cursor: String!
@@ -4416,13 +4416,13 @@ type FollowedArtistsArtworksGroupConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [FollowedArtistsArtworksGroupEdge]
+  edges: [FollowedArtistsArtworksGroupEdge!]!
 }
 
 # An edge in a connection.
 type FollowedArtistsArtworksGroupEdge {
   # The item at the end of the edge
-  node: FollowedArtistsArtworksGroup
+  node: FollowedArtistsArtworksGroup!
 
   # A cursor for use in pagination
   cursor: String!
@@ -4439,13 +4439,13 @@ type FollowedFairConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [FollowedFairEdge]
+  edges: [FollowedFairEdge!]!
 }
 
 # An edge in a connection.
 type FollowedFairEdge {
   # The item at the end of the edge
-  node: Fair
+  node: Fair!
 
   # A cursor for use in pagination
   cursor: String!
@@ -4457,13 +4457,13 @@ type FollowedShowConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [FollowedShowEdge]
+  edges: [FollowedShowEdge!]!
 }
 
 # An edge in a connection.
 type FollowedShowEdge {
   # The item at the end of the edge
-  node: Show
+  node: Show!
 
   # A cursor for use in pagination
   cursor: String!
@@ -4485,13 +4485,13 @@ type FollowGeneConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [FollowGeneEdge]
+  edges: [FollowGeneEdge!]!
 }
 
 # An edge in a connection.
 type FollowGeneEdge {
   # The item at the end of the edge
-  node: FollowGene
+  node: FollowGene!
 
   # A cursor for use in pagination
   cursor: String!
@@ -4629,7 +4629,7 @@ type Gene implements Node & Searchable {
     first: Int
     before: String
     last: Int
-  ): ArtistConnection
+  ): ArtistConnection!
 
   # Artworks Elastic Search results
   filterArtworksConnection(
@@ -4677,7 +4677,7 @@ type Gene implements Node & Searchable {
     first: Int
     before: String
     last: Int
-  ): FilterArtworksConnection
+  ): FilterArtworksConnection!
   description: String
   displayName: String
   href: String
@@ -4705,13 +4705,13 @@ type GeneConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [GeneEdge]
+  edges: [GeneEdge!]!
 }
 
 # An edge in a connection.
 type GeneEdge {
   # The item at the end of the edge
-  node: Gene
+  node: Gene!
 
   # A cursor for use in pagination
   cursor: String!
@@ -5167,7 +5167,7 @@ type LocationConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [LocationEdge]
+  edges: [LocationEdge!]!
   pageCursors: PageCursors!
   totalCount: Int
 }
@@ -5175,7 +5175,7 @@ type LocationConnection {
 # An edge in a connection.
 type LocationEdge {
   # The item at the end of the edge
-  node: Location
+  node: Location!
 
   # A cursor for use in pagination
   cursor: String!
@@ -5446,7 +5446,7 @@ type Me implements Node {
     first: Int
     before: String
     last: Int
-  ): CreditCardConnection
+  ): CreditCardConnection!
   email: String
   followsAndSaves: FollowsAndSaves
   hasCreditCards: Boolean
@@ -5486,7 +5486,7 @@ type Me implements Node {
     first: Int
     before: String
     last: Int
-  ): SaleArtworksConnection
+  ): SaleArtworksConnection!
 
   # The current user's status relating to bids on artworks
   lotStanding(
@@ -5521,7 +5521,7 @@ type Me implements Node {
     first: Int
     before: String
     last: Int
-  ): ArtworkConnection
+  ): ArtworkConnection!
   type: String
 
   # A count of unread notifications.
@@ -5579,14 +5579,14 @@ type MessageConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [MessageEdge]
+  edges: [MessageEdge!]!
   totalCount: Int
 }
 
 # An edge in a connection.
 type MessageEdge {
   # The item at the end of the edge
-  node: Message
+  node: Message!
 
   # A cursor for use in pagination
   cursor: String!
@@ -5842,7 +5842,7 @@ type OrderedSet {
     first: Int
     before: String
     last: Int
-  ): ArtworkConnection
+  ): ArtworkConnection!
   name: String
 }
 
@@ -5916,7 +5916,7 @@ type Partner implements Node {
     first: Int
     before: String
     last: Int
-  ): ArtistPartnerConnection
+  ): ArtistPartnerConnection!
 
   # A connection of artworks from a Partner.
   artworksConnection(
@@ -5927,7 +5927,7 @@ type Partner implements Node {
     first: Int
     before: String
     last: Int
-  ): ArtworkConnection
+  ): ArtworkConnection!
   categories: [PartnerCategory]
   collectingInstitution: String
   counts: PartnerCounts
@@ -5954,7 +5954,7 @@ type Partner implements Node {
     first: Int
     before: String
     last: Int
-  ): LocationConnection
+  ): LocationConnection!
   name: String
   profile: Profile
 
@@ -5971,7 +5971,7 @@ type Partner implements Node {
     first: Int
     before: String
     last: Int
-  ): ShowConnection
+  ): ShowConnection!
   type: String
 
   # The gallery partner's web address
@@ -6004,7 +6004,7 @@ type PartnerArtistConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [PartnerArtistEdge]
+  edges: [PartnerArtistEdge!]!
 }
 
 type PartnerArtistCounts {
@@ -6023,7 +6023,7 @@ type PartnerArtistCounts {
 # An edge in a connection.
 type PartnerArtistEdge {
   # The item at the end of the edge
-  node: Partner
+  node: Partner!
 
   # A cursor for use in pagination
   cursor: String!
@@ -6305,7 +6305,7 @@ type Query {
     first: Int
     before: String
     last: Int
-  ): FilterArtworksConnection
+  ): FilterArtworksConnection!
 
   # A list of Artworks
   artworks(
@@ -6314,7 +6314,7 @@ type Query {
     first: Int
     before: String
     last: Int
-  ): ArtworkConnection
+  ): ArtworkConnection!
     @deprecated(
       reason: "This is only for use in resolving stitched queries, not for first-class client use."
     )
@@ -6450,7 +6450,7 @@ type Query {
     first: Int
     before: String
     last: Int
-  ): SaleArtworksConnection
+  ): SaleArtworksConnection!
 
   # A list of Sales
   salesConnection(
@@ -6473,7 +6473,7 @@ type Query {
     first: Int
     before: String
     last: Int
-  ): SaleConnection
+  ): SaleConnection!
 
   # Global search
   searchConnection(
@@ -6493,7 +6493,7 @@ type Query {
     first: Int
     before: String
     last: Int
-  ): SearchableConnection
+  ): SearchableConnection!
 
   # A Show
   show(
@@ -6948,7 +6948,7 @@ type SaleArtworkConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [SaleArtworkEdge]
+  edges: [SaleArtworkEdge!]!
 }
 
 type SaleArtworkCounts {
@@ -6981,7 +6981,7 @@ type SaleArtworkCurrentBid {
 # An edge in a connection.
 type SaleArtworkEdge {
   # The item at the end of the edge
-  node: SaleArtwork
+  node: SaleArtwork!
 
   # A cursor for use in pagination
   cursor: String!
@@ -7117,7 +7117,7 @@ type SaleArtworksConnection implements ArtworkConnectionInterface {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [SaleArtwork]
+  edges: [SaleArtwork!]!
   pageCursors: PageCursors!
   totalCount: Int
 
@@ -7132,7 +7132,7 @@ type SaleConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [SaleEdge]
+  edges: [SaleEdge!]!
   pageCursors: PageCursors!
   totalCount: Int
 }
@@ -7140,7 +7140,7 @@ type SaleConnection {
 # An edge in a connection.
 type SaleEdge {
   # The item at the end of the edge
-  node: Sale
+  node: Sale!
 
   # A cursor for use in pagination
   cursor: String!
@@ -7180,7 +7180,7 @@ type SavedArtworksConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [SavedArtworksEdge]
+  edges: [SavedArtworksEdge!]!
   pageCursors: PageCursors!
   totalCount: Int
   description: String!
@@ -7192,7 +7192,7 @@ type SavedArtworksConnection {
 # An edge in a connection.
 type SavedArtworksEdge {
   # The item at the end of the edge
-  node: Artwork
+  node: Artwork!
 
   # A cursor for use in pagination
   cursor: String!
@@ -7211,7 +7211,7 @@ type SearchableConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [SearchableEdge]
+  edges: [SearchableEdge!]!
   pageCursors: PageCursors!
   totalCount: Int
 
@@ -7222,7 +7222,7 @@ type SearchableConnection {
 # An edge in a connection.
 type SearchableEdge {
   # The item at the end of the edge
-  node: Searchable
+  node: Searchable!
 
   # A cursor for use in pagination
   cursor: String!
@@ -7397,7 +7397,7 @@ type Show implements Node & EntityWithFilterArtworksConnectionInterface {
     first: Int
     before: String
     last: Int
-  ): ArtworkConnection
+  ): ArtworkConnection!
 
   # Artists inside the show who do not have artworks present
   artistsWithoutArtworks: [Artist]
@@ -7478,7 +7478,7 @@ type Show implements Node & EntityWithFilterArtworksConnectionInterface {
     first: Int
     before: String
     last: Int
-  ): FilterArtworksConnection
+  ): FilterArtworksConnection!
 
   # A path to the show on Artsy
   href: String
@@ -7539,7 +7539,7 @@ type Show implements Node & EntityWithFilterArtworksConnectionInterface {
     first: Int
     before: String
     last: Int
-  ): ShowConnection
+  ): ShowConnection!
 
   # Alternate Markdown-supporting free text representation of the opening reception event’s date/time
   openingReceptionText: String
@@ -7579,7 +7579,7 @@ type Show implements Node & EntityWithFilterArtworksConnectionInterface {
     first: Int
     before: String
     last: Int
-  ): ShowFollowArtistConnection
+  ): ShowFollowArtistConnection!
 }
 
 type ShowArtworkGrid implements ArtworkContextGrid {
@@ -7600,7 +7600,7 @@ type ShowConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [ShowEdge]
+  edges: [ShowEdge!]!
   pageCursors: PageCursors!
   totalCount: Int
 }
@@ -7621,7 +7621,7 @@ type ShowCounts {
 # An edge in a connection.
 type ShowEdge {
   # The item at the end of the edge
-  node: Show
+  node: Show!
 
   # A cursor for use in pagination
   cursor: String!
@@ -7661,13 +7661,13 @@ type ShowFollowArtistConnection {
   pageInfo: PageInfo!
 
   # A list of edges.
-  edges: [ShowFollowArtistEdge]
+  edges: [ShowFollowArtistEdge!]!
 }
 
 # An edge in a connection.
 type ShowFollowArtistEdge {
   # The item at the end of the edge
-  node: ShowFollowArtist
+  node: ShowFollowArtist!
 
   # A cursor for use in pagination
   cursor: String!
@@ -7856,7 +7856,7 @@ type Tag implements Node {
     first: Int
     before: String
     last: Int
-  ): FilterArtworksConnection
+  ): FilterArtworksConnection!
 }
 
 type TrendingArtists {
@@ -8133,7 +8133,7 @@ type Viewer {
     first: Int
     before: String
     last: Int
-  ): FilterArtworksConnection
+  ): FilterArtworksConnection!
 
   # A list of Artworks
   artworks(
@@ -8142,7 +8142,7 @@ type Viewer {
     first: Int
     before: String
     last: Int
-  ): ArtworkConnection
+  ): ArtworkConnection!
     @deprecated(
       reason: "This is only for use in resolving stitched queries, not for first-class client use."
     )
@@ -8278,7 +8278,7 @@ type Viewer {
     first: Int
     before: String
     last: Int
-  ): SaleArtworksConnection
+  ): SaleArtworksConnection!
 
   # A list of Sales
   salesConnection(
@@ -8301,7 +8301,7 @@ type Viewer {
     first: Int
     before: String
     last: Int
-  ): SaleConnection
+  ): SaleConnection!
 
   # Global search
   searchConnection(
@@ -8321,7 +8321,7 @@ type Viewer {
     first: Int
     before: String
     last: Int
-  ): SearchableConnection
+  ): SearchableConnection!
 
   # A Show
   show(

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "node-fetch": "1.7.3",
     "numeral": "1.5.6",
     "opentracing": "0.14.1",
-    "patch-package": "6.2.0",
+    "patch-package": "^6.2.2",
     "performance-now": "2.1.0",
     "postinstall-prepare": "1.0.1",
     "qs": "6.9.1",

--- a/patches/@types+graphql-relay+0.4.9.patch
+++ b/patches/@types+graphql-relay+0.4.9.patch
@@ -1,12 +1,12 @@
 diff --git a/node_modules/@types/graphql-relay/index.d.ts b/node_modules/@types/graphql-relay/index.d.ts
-index 67edfa3..5779379 100644
+index 67edfa3..f9b2e1d 100644
 --- a/node_modules/@types/graphql-relay/index.d.ts
 +++ b/node_modules/@types/graphql-relay/index.d.ts
 @@ -67,11 +67,15 @@ export type ConnectionConfigNodeType =
  
  export interface ConnectionConfig {
      name?: string | null;
-+    nonNullable: boolean
++    nodeIsNonNullable: boolean
      nodeType: ConnectionConfigNodeType;
      resolveNode?: GraphQLFieldResolver<any, any> | null;
      resolveCursor?: GraphQLFieldResolver<any, any> | null;

--- a/patches/@types+graphql-relay+0.4.9.patch
+++ b/patches/@types+graphql-relay+0.4.9.patch
@@ -1,7 +1,12 @@
-patch-package
+diff --git a/node_modules/@types/graphql-relay/index.d.ts b/node_modules/@types/graphql-relay/index.d.ts
+index 67edfa3..5779379 100644
 --- a/node_modules/@types/graphql-relay/index.d.ts
 +++ b/node_modules/@types/graphql-relay/index.d.ts
-@@ -70,8 +70,11 @@ export interface ConnectionConfig {
+@@ -67,11 +67,15 @@ export type ConnectionConfigNodeType =
+ 
+ export interface ConnectionConfig {
+     name?: string | null;
++    nonNullable: boolean
      nodeType: ConnectionConfigNodeType;
      resolveNode?: GraphQLFieldResolver<any, any> | null;
      resolveCursor?: GraphQLFieldResolver<any, any> | null;
@@ -13,7 +18,7 @@ patch-package
  }
  
  export interface GraphQLConnectionDefinitions {
-@@ -104,6 +107,8 @@ export interface PageInfo {
+@@ -104,6 +108,8 @@ export interface PageInfo {
      hasNextPage?: boolean | null;
  }
  
@@ -22,7 +27,7 @@ patch-package
  /**
   * A flow type designed to be exposed as a `Connection` over GraphQL.
   */
-@@ -135,6 +140,8 @@ export interface ConnectionArguments {
+@@ -135,6 +141,8 @@ export interface ConnectionArguments {
  export interface ArraySliceMetaInfo {
      sliceStart: number;
      arrayLength: number;
@@ -31,7 +36,7 @@ patch-package
  }
  
  /**
-@@ -211,11 +218,11 @@ export function getOffsetWithDefault(
+@@ -211,11 +219,11 @@ export function getOffsetWithDefault(
  
  // mutation/mutation.js
  
@@ -47,7 +52,7 @@ patch-package
  
  /**
   * A description of a mutation consumable by mutationWithClientMutationId
-@@ -231,12 +238,12 @@ export type mutationFn = (
+@@ -231,12 +239,12 @@ export type mutationFn = (
   * input field, and it should return an Object with a key for each
   * output field. It may return synchronously, or return a Promise.
   */
@@ -63,7 +68,7 @@ patch-package
      deprecationReason?: string;
  }
  
-@@ -244,8 +251,8 @@ export interface MutationConfig {
+@@ -244,8 +252,8 @@ export interface MutationConfig {
   * Returns a GraphQLFieldConfig for the mutation described by the
   * provided MutationConfig.
   */

--- a/patches/graphql-relay+0.5.4.patch
+++ b/patches/graphql-relay+0.5.4.patch
@@ -60,7 +60,7 @@ index e8f9f52..1cf8cf8 100644
        return _extends({
          node: {
 -          type: nodeType,
-+          type: config.nonNullable ? new _graphql.GraphQLNonNull(nodeType) : nodeType,
++          type: config.nodeIsNonNullable ? new _graphql.GraphQLNonNull(nodeType) : nodeType,
            resolve: resolveNode,
            description: 'The item at the end of the edge'
          },

--- a/patches/graphql-relay+0.5.4.patch
+++ b/patches/graphql-relay+0.5.4.patch
@@ -1,4 +1,5 @@
-patch-package
+diff --git a/node_modules/graphql-relay/lib/connection/arrayconnection.js b/node_modules/graphql-relay/lib/connection/arrayconnection.js
+index 9ccedfa..b11e2de 100644
 --- a/node_modules/graphql-relay/lib/connection/arrayconnection.js
 +++ b/node_modules/graphql-relay/lib/connection/arrayconnection.js
 @@ -60,7 +60,9 @@ function connectionFromArraySlice(arraySlice, args, meta) {
@@ -33,6 +34,8 @@ patch-package
    });
  
    var firstEdge = edges[0];
+diff --git a/node_modules/graphql-relay/lib/connection/connection.js b/node_modules/graphql-relay/lib/connection/connection.js
+index e8f9f52..1cf8cf8 100644
 --- a/node_modules/graphql-relay/lib/connection/connection.js
 +++ b/node_modules/graphql-relay/lib/connection/connection.js
 @@ -3,7 +3,7 @@
@@ -44,7 +47,7 @@ patch-package
  
  var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; /**
                                                                                                                                                                                                                                                                     * Copyright (c) 2015-present, Facebook, Inc.
-@@ -66,9 +66,10 @@ function connectionDefinitions(config) {
+@@ -66,13 +66,14 @@ function connectionDefinitions(config) {
    var connectionFields = config.connectionFields || {};
    var resolveNode = config.resolveNode;
    var resolveCursor = config.resolveCursor;
@@ -56,6 +59,11 @@ patch-package
      fields: function fields() {
        return _extends({
          node: {
+-          type: nodeType,
++          type: config.nonNullable ? new _graphql.GraphQLNonNull(nodeType) : nodeType,
+           resolve: resolveNode,
+           description: 'The item at the end of the edge'
+         },
 @@ -88,6 +89,7 @@ function connectionDefinitions(config) {
    var connectionType = new _graphql.GraphQLObjectType({
      name: name + 'Connection',
@@ -64,6 +72,15 @@ patch-package
      fields: function fields() {
        return _extends({
          pageInfo: {
+@@ -95,7 +97,7 @@ function connectionDefinitions(config) {
+           description: 'Information to aid in pagination.'
+         },
+         edges: {
+-          type: new _graphql.GraphQLList(edgeType),
++          type: new _graphql.GraphQLNonNull(new _graphql.GraphQLList(new _graphql.GraphQLNonNull(edgeType))),
+           description: 'A list of edges.'
+         }
+       }, resolveMaybeThunk(connectionFields));
 @@ -108,7 +110,7 @@ function connectionDefinitions(config) {
  /**
   * The common page info type used by all connections.
@@ -73,6 +90,8 @@ patch-package
    name: 'PageInfo',
    description: 'Information about pagination in a connection.',
    fields: function fields() {
+diff --git a/node_modules/graphql-relay/lib/index.js b/node_modules/graphql-relay/lib/index.js
+index 1ed2f2d..18eab87 100644
 --- a/node_modules/graphql-relay/lib/index.js
 +++ b/node_modules/graphql-relay/lib/index.js
 @@ -30,6 +30,12 @@ Object.defineProperty(exports, 'forwardConnectionArgs', {

--- a/scripts/dump-staging-schema.js
+++ b/scripts/dump-staging-schema.js
@@ -22,4 +22,4 @@ const env = {
   ...getStagingEnv(),
 }
 
-execSync("yarn dump:local", { env })
+execSync("yarn dump:local", { env, stdio: "inherit" })

--- a/src/schema/v1/artwork/artworkContextGrids/__tests__/auctionContext.test.ts
+++ b/src/schema/v1/artwork/artworkContextGrids/__tests__/auctionContext.test.ts
@@ -1,6 +1,7 @@
 import gql from "lib/gql"
 import { runAuthenticatedQuery } from "schema/v1/test/utils"
 import { assign } from "lodash"
+import artworks from 'test/fixtures/gravity/artworks_array.json'
 
 describe("Default Context", () => {
   let context: any
@@ -56,9 +57,9 @@ describe("Default Context", () => {
     ]
 
     const saleArtworks = [
-      { id: "saleArtwork1", title: "Sale Artwork 1" },
-      { id: "saleArtwork2", title: "Sale Artwork 2" },
-      { id: "saleArtwork3", title: "Sale Artwork 3" },
+      { id: "saleArtwork1", title: "Sale Artwork 1", artwork: artworks[0] },
+      { id: "saleArtwork2", title: "Sale Artwork 2", artwork: artworks[1] },
+      { id: "saleArtwork3", title: "Sale Artwork 3", artwork: artworks[2] },
     ]
 
     context = {

--- a/src/schema/v1/credit_card.ts
+++ b/src/schema/v1/credit_card.ts
@@ -113,7 +113,7 @@ export const {
   connectionType: CreditCardConnection,
   edgeType: CreditCardEdge,
 } = connectionDefinitions({
-  nonNullable: true,
+  nodeIsNonNullable: true,
   nodeType: CreditCardType,
 })
 

--- a/src/schema/v1/credit_card.ts
+++ b/src/schema/v1/credit_card.ts
@@ -113,6 +113,7 @@ export const {
   connectionType: CreditCardConnection,
   edgeType: CreditCardEdge,
 } = connectionDefinitions({
+  nonNullable: true,
   nodeType: CreditCardType,
 })
 

--- a/src/schema/v1/ecommerce/types/offer.ts
+++ b/src/schema/v1/ecommerce/types/offer.ts
@@ -82,5 +82,6 @@ export const {
   connectionType: OfferConnection,
   edgeType: OfferEdge,
 } = connectionDefinitions({
+  nonNullable: true,
   nodeType: OfferType,
 })

--- a/src/schema/v1/ecommerce/types/offer.ts
+++ b/src/schema/v1/ecommerce/types/offer.ts
@@ -82,6 +82,6 @@ export const {
   connectionType: OfferConnection,
   edgeType: OfferEdge,
 } = connectionDefinitions({
-  nonNullable: true,
+  nodeIsNonNullable: true,
   nodeType: OfferType,
 })

--- a/src/schema/v1/ecommerce/types/order.ts
+++ b/src/schema/v1/ecommerce/types/order.ts
@@ -218,7 +218,7 @@ export const {
   connectionType: OrderConnection,
   edgeType: OrderEdge,
 } = connectionDefinitions({
-  nonNullable: true,
+  nodeIsNonNullable: true,
   nodeType: OrderInterface,
   connectionFields: {
     totalCount: {

--- a/src/schema/v1/ecommerce/types/order.ts
+++ b/src/schema/v1/ecommerce/types/order.ts
@@ -218,6 +218,7 @@ export const {
   connectionType: OrderConnection,
   edgeType: OrderEdge,
 } = connectionDefinitions({
+  nonNullable: true,
   nodeType: OrderInterface,
   connectionFields: {
     totalCount: {

--- a/src/schema/v1/ecommerce/types/order_fulfillment.ts
+++ b/src/schema/v1/ecommerce/types/order_fulfillment.ts
@@ -26,6 +26,6 @@ export const {
   connectionType: OrderFulfillmentConnection,
   edgeType: OrderFulfillmentEdge,
 } = connectionDefinitions({
-  nonNullable: true,
+  nodeIsNonNullable: true,
   nodeType: OrderFulfillmentType,
 })

--- a/src/schema/v1/ecommerce/types/order_fulfillment.ts
+++ b/src/schema/v1/ecommerce/types/order_fulfillment.ts
@@ -26,5 +26,6 @@ export const {
   connectionType: OrderFulfillmentConnection,
   edgeType: OrderFulfillmentEdge,
 } = connectionDefinitions({
+  nonNullable: true,
   nodeType: OrderFulfillmentType,
 })

--- a/src/schema/v1/ecommerce/types/order_line_item.ts
+++ b/src/schema/v1/ecommerce/types/order_line_item.ts
@@ -70,5 +70,6 @@ export const {
   connectionType: OrderLineItemConnection,
   edgeType: OrderLineItemEdge,
 } = connectionDefinitions({
+  nonNullable: true,
   nodeType: OrderLineItemType,
 })

--- a/src/schema/v1/ecommerce/types/order_line_item.ts
+++ b/src/schema/v1/ecommerce/types/order_line_item.ts
@@ -70,6 +70,6 @@ export const {
   connectionType: OrderLineItemConnection,
   edgeType: OrderLineItemEdge,
 } = connectionDefinitions({
-  nonNullable: true,
+  nodeIsNonNullable: true,
   nodeType: OrderLineItemType,
 })

--- a/src/schema/v1/fields/pagination.ts
+++ b/src/schema/v1/fields/pagination.ts
@@ -155,7 +155,7 @@ export function createPageCursors(
 export function connectionWithCursorInfo(type, connectionFields = {}) {
   return connectionDefinitions({
     nodeType: type,
-    nonNullable: true,
+    nodeIsNonNullable: true,
     connectionFields: {
       pageCursors: {
         type: PageCursorsType,

--- a/src/schema/v1/fields/pagination.ts
+++ b/src/schema/v1/fields/pagination.ts
@@ -155,6 +155,7 @@ export function createPageCursors(
 export function connectionWithCursorInfo(type, connectionFields = {}) {
   return connectionDefinitions({
     nodeType: type,
+    nonNullable: true,
     connectionFields: {
       pageCursors: {
         type: PageCursorsType,

--- a/src/schema/v1/gene.ts
+++ b/src/schema/v1/gene.ts
@@ -72,6 +72,7 @@ export const GeneType = new GraphQLObjectType<any, ResolverContext>({
       },
       artworks_connection: {
         type: connectionDefinitions({
+          nonNullable: true,
           name: "GeneArtworks",
           nodeType: ArtworkType,
           connectionFields: {
@@ -223,5 +224,6 @@ const Gene: GraphQLFieldConfig<void, ResolverContext> = {
 export default Gene
 
 export const geneConnection = connectionDefinitions({
+  nonNullable: true,
   nodeType: GeneType,
 }).connectionType

--- a/src/schema/v1/gene.ts
+++ b/src/schema/v1/gene.ts
@@ -72,7 +72,7 @@ export const GeneType = new GraphQLObjectType<any, ResolverContext>({
       },
       artworks_connection: {
         type: connectionDefinitions({
-          nonNullable: true,
+          nodeIsNonNullable: true,
           name: "GeneArtworks",
           nodeType: ArtworkType,
           connectionFields: {
@@ -224,6 +224,6 @@ const Gene: GraphQLFieldConfig<void, ResolverContext> = {
 export default Gene
 
 export const geneConnection = connectionDefinitions({
-  nonNullable: true,
+  nodeIsNonNullable: true,
   nodeType: GeneType,
 }).connectionType

--- a/src/schema/v1/gene_families.ts
+++ b/src/schema/v1/gene_families.ts
@@ -9,6 +9,7 @@ import { GraphQLFieldConfig } from "graphql"
 import { ResolverContext } from "types/graphql"
 
 const { connectionType: GeneFamilyConnection } = connectionDefinitions({
+  nonNullable: true,
   nodeType: GeneFamilyType,
 })
 

--- a/src/schema/v1/gene_families.ts
+++ b/src/schema/v1/gene_families.ts
@@ -9,7 +9,7 @@ import { GraphQLFieldConfig } from "graphql"
 import { ResolverContext } from "types/graphql"
 
 const { connectionType: GeneFamilyConnection } = connectionDefinitions({
-  nonNullable: true,
+  nodeIsNonNullable: true,
   nodeType: GeneFamilyType,
 })
 

--- a/src/schema/v1/me/artwork_inquiries.ts
+++ b/src/schema/v1/me/artwork_inquiries.ts
@@ -27,7 +27,7 @@ export const ArtworkInquiryType = new GraphQLObjectType<any, ResolverContext>({
 
 const ArtworkInquiries: GraphQLFieldConfig<void, ResolverContext> = {
   type: connectionDefinitions({
-    nonNullable: true,
+    nodeIsNonNullable: true,
     nodeType: ArtworkInquiryType,
   }).connectionType,
   args: pageable({}),

--- a/src/schema/v1/me/artwork_inquiries.ts
+++ b/src/schema/v1/me/artwork_inquiries.ts
@@ -26,7 +26,10 @@ export const ArtworkInquiryType = new GraphQLObjectType<any, ResolverContext>({
 })
 
 const ArtworkInquiries: GraphQLFieldConfig<void, ResolverContext> = {
-  type: connectionDefinitions({ nodeType: ArtworkInquiryType }).connectionType,
+  type: connectionDefinitions({
+    nonNullable: true,
+    nodeType: ArtworkInquiryType,
+  }).connectionType,
   args: pageable({}),
   description: "A list of the current user’s inquiry requests",
   resolve: (_root, options, { inquiryRequestsLoader }) => {

--- a/src/schema/v1/me/conversation/index.ts
+++ b/src/schema/v1/me/conversation/index.ts
@@ -140,7 +140,7 @@ export const {
   connectionType: MessageConnection,
   edgeType: MessageEdge,
 } = connectionDefinitions({
-  nonNullable: true,
+  nodeIsNonNullable: true,
   nodeType: MessageType,
 })
 

--- a/src/schema/v1/me/conversation/index.ts
+++ b/src/schema/v1/me/conversation/index.ts
@@ -140,6 +140,7 @@ export const {
   connectionType: MessageConnection,
   edgeType: MessageEdge,
 } = connectionDefinitions({
+  nonNullable: true,
   nodeType: MessageType,
 })
 

--- a/src/schema/v1/me/conversations.ts
+++ b/src/schema/v1/me/conversations.ts
@@ -9,7 +9,7 @@ import { ResolverContext } from "types/graphql"
 
 const Conversations: GraphQLFieldConfig<void, ResolverContext> = {
   type: connectionDefinitions({
-    nonNullable: true,
+    nodeIsNonNullable: true,
     nodeType: ConversationType,
     connectionFields: {
       totalUnreadCount: {

--- a/src/schema/v1/me/conversations.ts
+++ b/src/schema/v1/me/conversations.ts
@@ -9,6 +9,7 @@ import { ResolverContext } from "types/graphql"
 
 const Conversations: GraphQLFieldConfig<void, ResolverContext> = {
   type: connectionDefinitions({
+    nonNullable: true,
     nodeType: ConversationType,
     connectionFields: {
       totalUnreadCount: {

--- a/src/schema/v1/me/followed_artists.ts
+++ b/src/schema/v1/me/followed_artists.ts
@@ -21,7 +21,10 @@ const FollowArtistType = new GraphQLObjectType<any, ResolverContext>({
 })
 
 const FollowedArtists: GraphQLFieldConfig<void, ResolverContext> = {
-  type: connectionDefinitions({ nodeType: FollowArtistType }).connectionType,
+  type: connectionDefinitions({
+    nonNullable: true,
+    nodeType: FollowArtistType,
+  }).connectionType,
   args: pageable({}),
   description: "A Connection of followed artists by current user",
   resolve: (_parent, args, context) => followArtistsResolver({}, args, context),

--- a/src/schema/v1/me/followed_artists.ts
+++ b/src/schema/v1/me/followed_artists.ts
@@ -22,7 +22,7 @@ const FollowArtistType = new GraphQLObjectType<any, ResolverContext>({
 
 const FollowedArtists: GraphQLFieldConfig<void, ResolverContext> = {
   type: connectionDefinitions({
-    nonNullable: true,
+    nodeIsNonNullable: true,
     nodeType: FollowArtistType,
   }).connectionType,
   args: pageable({}),

--- a/src/schema/v1/me/followed_artists_artworks_group.ts
+++ b/src/schema/v1/me/followed_artists_artworks_group.ts
@@ -68,7 +68,7 @@ const FollowedArtistsArtworksGroup: GraphQLFieldConfig<
   ResolverContext
 > = {
   type: connectionDefinitions({
-    nonNullable: true,
+    nodeIsNonNullable: true,
     nodeType: FollowedArtistsArtworksGroupType,
   }).connectionType,
   description:

--- a/src/schema/v1/me/followed_artists_artworks_group.ts
+++ b/src/schema/v1/me/followed_artists_artworks_group.ts
@@ -67,8 +67,10 @@ const FollowedArtistsArtworksGroup: GraphQLFieldConfig<
   void,
   ResolverContext
 > = {
-  type: connectionDefinitions({ nodeType: FollowedArtistsArtworksGroupType })
-    .connectionType,
+  type: connectionDefinitions({
+    nonNullable: true,
+    nodeType: FollowedArtistsArtworksGroupType,
+  }).connectionType,
   description:
     "A list of published artworks by followed artists (grouped by date and artists).",
   args: pageable({

--- a/src/schema/v1/me/followed_fairs.ts
+++ b/src/schema/v1/me/followed_fairs.ts
@@ -6,6 +6,7 @@ import { GraphQLFieldConfig } from "graphql"
 import { ResolverContext } from "types/graphql"
 
 export const FollowedFairConnection = connectionDefinitions({
+  nonNullable: true,
   name: "FollowedFair",
   // This never ended up being used in the underlying lib.
   // edgeType: FollowedFairEdge,

--- a/src/schema/v1/me/followed_fairs.ts
+++ b/src/schema/v1/me/followed_fairs.ts
@@ -6,7 +6,7 @@ import { GraphQLFieldConfig } from "graphql"
 import { ResolverContext } from "types/graphql"
 
 export const FollowedFairConnection = connectionDefinitions({
-  nonNullable: true,
+  nodeIsNonNullable: true,
   name: "FollowedFair",
   // This never ended up being used in the underlying lib.
   // edgeType: FollowedFairEdge,

--- a/src/schema/v1/me/followed_genes.ts
+++ b/src/schema/v1/me/followed_genes.ts
@@ -17,7 +17,10 @@ export const FollowGeneType = new GraphQLObjectType<any, ResolverContext>({
 })
 
 const FollowedGenes: GraphQLFieldConfig<void, ResolverContext> = {
-  type: connectionDefinitions({ nodeType: FollowGeneType }).connectionType,
+  type: connectionDefinitions({
+    nonNullable: true,
+    nodeType: FollowGeneType,
+  }).connectionType,
   args: pageable({}),
   description: "A list of the current user’s inquiry requests",
   resolve: (_root, options, { followedGenesLoader }) => {

--- a/src/schema/v1/me/followed_genes.ts
+++ b/src/schema/v1/me/followed_genes.ts
@@ -18,7 +18,7 @@ export const FollowGeneType = new GraphQLObjectType<any, ResolverContext>({
 
 const FollowedGenes: GraphQLFieldConfig<void, ResolverContext> = {
   type: connectionDefinitions({
-    nonNullable: true,
+    nodeIsNonNullable: true,
     nodeType: FollowGeneType,
   }).connectionType,
   args: pageable({}),

--- a/src/schema/v1/me/followed_shows.ts
+++ b/src/schema/v1/me/followed_shows.ts
@@ -16,7 +16,7 @@ const location_by_city_slug = cityData.reduce((acc, val) => {
 const getValidCitySlugs = () => Object.keys(location_by_city_slug).join(", ")
 
 export const FollowedShowConnection = connectionDefinitions({
-  nonNullable: true,
+  nodeIsNonNullable: true,
   name: "FollowedShow",
   // This never ended up being used in the underlying lib.
   // edgeType: FollowedShowEdge,

--- a/src/schema/v1/me/followed_shows.ts
+++ b/src/schema/v1/me/followed_shows.ts
@@ -16,6 +16,7 @@ const location_by_city_slug = cityData.reduce((acc, val) => {
 const getValidCitySlugs = () => Object.keys(location_by_city_slug).join(", ")
 
 export const FollowedShowConnection = connectionDefinitions({
+  nonNullable: true,
   name: "FollowedShow",
   // This never ended up being used in the underlying lib.
   // edgeType: FollowedShowEdge,

--- a/src/schema/v1/me/notifications.ts
+++ b/src/schema/v1/me/notifications.ts
@@ -59,7 +59,7 @@ const NotificationsFeedItemType = new GraphQLObjectType<any, ResolverContext>({
 
 const Notifications: GraphQLFieldConfig<void, ResolverContext> = {
   type: connectionDefinitions({
-    nonNullable: true,
+    nodeIsNonNullable: true,
     nodeType: NotificationsFeedItemType,
   }).connectionType,
   description:

--- a/src/schema/v1/me/notifications.ts
+++ b/src/schema/v1/me/notifications.ts
@@ -58,8 +58,10 @@ const NotificationsFeedItemType = new GraphQLObjectType<any, ResolverContext>({
 })
 
 const Notifications: GraphQLFieldConfig<void, ResolverContext> = {
-  type: connectionDefinitions({ nodeType: NotificationsFeedItemType })
-    .connectionType,
+  type: connectionDefinitions({
+    nonNullable: true,
+    nodeType: NotificationsFeedItemType,
+  }).connectionType,
   description:
     "A list of feed items, indicating published artworks (grouped by date and artists).",
   args: pageable({}),

--- a/src/schema/v1/partner_artist.ts
+++ b/src/schema/v1/partner_artist.ts
@@ -98,6 +98,7 @@ export default PartnerArtist
 // The below can be used as the connection from an artist to its partners.
 // The edge is the PartnerArtist relationship, with the node being the partner.
 export const PartnerArtistConnection = connectionDefinitions({
+  nonNullable: true,
   name: "PartnerArtist",
   // This never ended up being used in the underlying lib.
   // edgeType: PartnerArtistType,

--- a/src/schema/v1/partner_artist.ts
+++ b/src/schema/v1/partner_artist.ts
@@ -98,7 +98,7 @@ export default PartnerArtist
 // The below can be used as the connection from an artist to its partners.
 // The edge is the PartnerArtist relationship, with the node being the partner.
 export const PartnerArtistConnection = connectionDefinitions({
-  nonNullable: true,
+  nodeIsNonNullable: true,
   name: "PartnerArtist",
   // This never ended up being used in the underlying lib.
   // edgeType: PartnerArtistType,

--- a/src/schema/v1/sale/index.ts
+++ b/src/schema/v1/sale/index.ts
@@ -71,7 +71,7 @@ const BuyersPremium = new GraphQLObjectType<any, ResolverContext>({
 })
 
 const saleArtworkConnection = connectionDefinitions({
-  nonNullable: true,
+  nodeIsNonNullable: true,
   nodeType: SaleArtworkType,
 }).connectionType
 

--- a/src/schema/v1/sale/index.ts
+++ b/src/schema/v1/sale/index.ts
@@ -71,6 +71,7 @@ const BuyersPremium = new GraphQLObjectType<any, ResolverContext>({
 })
 
 const saleArtworkConnection = connectionDefinitions({
+  nonNullable: true,
   nodeType: SaleArtworkType,
 }).connectionType
 

--- a/src/schema/v1/sale_artworks.ts
+++ b/src/schema/v1/sale_artworks.ts
@@ -16,7 +16,7 @@ const DEFAULTS = {
 }
 
 const SaleArtworksType = connectionDefinitions({
-  nonNullable: true,
+  nodeIsNonNullable: true,
   name: "SaleArtworks",
   nodeType: SaleArtworkType,
   connectionFields: {

--- a/src/schema/v1/sale_artworks.ts
+++ b/src/schema/v1/sale_artworks.ts
@@ -16,6 +16,7 @@ const DEFAULTS = {
 }
 
 const SaleArtworksType = connectionDefinitions({
+  nonNullable: true,
   name: "SaleArtworks",
   nodeType: SaleArtworkType,
   connectionFields: {

--- a/src/schema/v1/show.ts
+++ b/src/schema/v1/show.ts
@@ -645,8 +645,10 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
       resolve: ({ fair }) => (isExisty(fair) ? "Fair Booth" : "Show"),
     },
     followedArtists: {
-      type: connectionDefinitions({ nodeType: FollowArtistType })
-        .connectionType,
+      type: connectionDefinitions({
+        nonNullable: true,
+        nodeType: FollowArtistType,
+      }).connectionType,
       args: pageable({}),
       description:
         "A Connection of followed artists by current user for this show",

--- a/src/schema/v1/show.ts
+++ b/src/schema/v1/show.ts
@@ -646,7 +646,7 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
     },
     followedArtists: {
       type: connectionDefinitions({
-        nonNullable: true,
+        nodeIsNonNullable: true,
         nodeType: FollowArtistType,
       }).connectionType,
       args: pageable({}),

--- a/src/schema/v2/__tests__/sale_artworks.test.js
+++ b/src/schema/v2/__tests__/sale_artworks.test.js
@@ -1,6 +1,7 @@
 import _ from "lodash"
 import gql from "lib/gql"
 import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import artworks from 'test/fixtures/gravity/artworks_array.json'
 
 describe("Sale Artworks", () => {
   const execute = async (gravityResponse, query, context = {}) => {
@@ -11,7 +12,7 @@ describe("Sale Artworks", () => {
   }
 
   it("pulls from /sale_artworks if `live_sale, include_lots_by_followed_artists, is_auction to true` ", async () => {
-    const hits = _.fill(Array(10), { id: "foo" })
+    const hits = _.fill(Array(10), { id: "foo", artwork: artworks[0] })
     const totalCount = hits.length * 2
     const gravityResponse = {
       body: hits,
@@ -51,7 +52,7 @@ describe("Sale Artworks", () => {
   })
 
   it("returns 10 items by default", async () => {
-    const hits = _.fill(Array(10), { id: "foo" })
+    const hits = _.fill(Array(10), { id: "foo", artwork: artworks[0] })
     const totalCount = hits.length * 2
     const gravityResponse = {
       hits,
@@ -91,7 +92,7 @@ describe("Sale Artworks", () => {
 
   it("allows for adjustable size counts", async () => {
     const size = 1
-    const hits = _.fill(Array(size), { id: "foo" })
+    const hits = _.fill(Array(size), { id: "foo", artwork: artworks[0] })
     const gravityResponse = {
       hits,
       aggregations: {
@@ -122,7 +123,7 @@ describe("Sale Artworks", () => {
   })
 
   it("allows for cursor offsets", async () => {
-    const hits = _.fill(Array(20), { id: "foo" })
+    const hits = _.fill(Array(20), { id: "foo", artwork: artworks[0] })
     const gravityResponse = {
       hits,
       aggregations: {

--- a/src/schema/v2/article.ts
+++ b/src/schema/v2/article.ts
@@ -76,5 +76,6 @@ const Article: GraphQLFieldConfig<void, ResolverContext> = {
 
 export default Article
 export const articleConnection = connectionWithCursorInfo({
+  nonNullable: true,
   nodeType: ArticleType,
 })

--- a/src/schema/v2/article.ts
+++ b/src/schema/v2/article.ts
@@ -76,6 +76,6 @@ const Article: GraphQLFieldConfig<void, ResolverContext> = {
 
 export default Article
 export const articleConnection = connectionWithCursorInfo({
-  nonNullable: true,
+  nodeIsNonNullable: true,
   nodeType: ArticleType,
 })

--- a/src/schema/v2/artist/highlights.ts
+++ b/src/schema/v2/artist/highlights.ts
@@ -4,6 +4,7 @@ import {
   GraphQLList,
   GraphQLString,
   GraphQLFieldConfig,
+  GraphQLNonNull,
 } from "graphql"
 import { partnersForArtist } from "../partner_artist"
 import { pageable } from "relay-cursor-paging"
@@ -15,7 +16,7 @@ const ArtistHighlightsType = new GraphQLObjectType<any, ResolverContext>({
     const { PartnerArtistConnection } = require("../partnerArtistConnection")
     return {
       partnersConnection: {
-        type: PartnerArtistConnection,
+        type: new GraphQLNonNull(PartnerArtistConnection),
         args: pageable({
           representedBy: {
             type: GraphQLBoolean,

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -114,7 +114,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
             type: GraphQLBoolean,
           },
         }),
-        type: articleConnection.connectionType,
+        type: new GraphQLNonNull(articleConnection.connectionType),
         resolve: (
           { _id },
           { inEditorialFeed, ..._args },
@@ -153,7 +153,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       artworksConnection: {
-        type: artworkConnection.connectionType,
+        type: new GraphQLNonNull(artworkConnection.connectionType),
         args: pageable({
           exclude: {
             type: new GraphQLList(GraphQLString),
@@ -566,7 +566,10 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
       },
       highlights: ArtistHighlights,
       hometown: { type: GraphQLString },
-      href: { type: GraphQLString, resolve: artist => `/artist/${artist.id}` },
+      href: {
+        type: GraphQLString,
+        resolve: artist => `/artist/${artist.id}`,
+      },
       image: Image,
       imageUrl: {
         type: GraphQLString,
@@ -610,7 +613,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
       nationality: { type: GraphQLString },
       name: { type: GraphQLString },
       partnersConnection: {
-        type: PartnerArtistConnection,
+        type: new GraphQLNonNull(PartnerArtistConnection),
         args: pageable({
           representedBy: {
             type: GraphQLBoolean,
@@ -705,4 +708,5 @@ export default Artist
 
 export const artistConnection = connectionWithCursorInfo({
   nodeType: ArtistType,
+  nonNullable: true,
 })

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -708,5 +708,5 @@ export default Artist
 
 export const artistConnection = connectionWithCursorInfo({
   nodeType: ArtistType,
-  nonNullable: true,
+  nodeIsNonNullable: true,
 })

--- a/src/schema/v2/artist/related.ts
+++ b/src/schema/v2/artist/related.ts
@@ -5,6 +5,7 @@ import {
   GraphQLInt,
   GraphQLString,
   GraphQLList,
+  GraphQLNonNull,
 } from "graphql"
 import { pageable, getPagingParameters } from "relay-cursor-paging"
 import { artistConnection } from "schema/v2/artist"
@@ -34,7 +35,7 @@ export const Related = {
     name: "ArtistRelatedData",
     fields: () => ({
       genes: {
-        type: geneConnection,
+        type: new GraphQLNonNull(geneConnection),
         args: pageable({}),
         resolve: ({ id }, args, { relatedGenesLoader }) => {
           return relatedGenesLoader({ artist: [id] }).then(response => {
@@ -43,7 +44,7 @@ export const Related = {
         },
       },
       artistsConnection: {
-        type: artistConnection.connectionType,
+        type: new GraphQLNonNull(artistConnection.connectionType),
         args: pageable({
           excludeArtistsWithoutArtworks: {
             type: GraphQLBoolean,

--- a/src/schema/v2/artist/shows.ts
+++ b/src/schema/v2/artist/shows.ts
@@ -5,6 +5,7 @@ import {
   GraphQLBoolean,
   GraphQLFieldConfig,
   GraphQLFieldConfigArgumentMap,
+  GraphQLNonNull,
 } from "graphql"
 import ShowSorts from "schema/v2/sorts/show_sorts"
 import { merge, defaults, reject, includes } from "lodash"
@@ -69,7 +70,7 @@ export const ShowsConnectionField: GraphQLFieldConfig<
   { id: string },
   ResolverContext
 > = {
-  type: ShowsConnection.connectionType,
+  type: new GraphQLNonNull(ShowsConnection.connectionType),
   args: pageable(ShowArgs),
   resolve: ({ id }, args, { relatedShowsLoader }) => {
     const gravityArgs = {

--- a/src/schema/v2/artwork/artworkContextGrids/__tests__/auctionContext.test.ts
+++ b/src/schema/v2/artwork/artworkContextGrids/__tests__/auctionContext.test.ts
@@ -1,6 +1,7 @@
 import gql from "lib/gql"
 import { runAuthenticatedQuery } from "schema/v2/test/utils"
 import { assign } from "lodash"
+import artworks from 'test/fixtures/gravity/artworks_array.json'
 
 describe("Default Context", () => {
   let context: any
@@ -56,9 +57,9 @@ describe("Default Context", () => {
     ]
 
     const saleArtworks = [
-      { id: "saleArtwork1", title: "Sale Artwork 1" },
-      { id: "saleArtwork2", title: "Sale Artwork 2" },
-      { id: "saleArtwork3", title: "Sale Artwork 3" },
+      { id: "saleArtwork1", title: "Sale Artwork 1", artwork: artworks[0] },
+      { id: "saleArtwork2", title: "Sale Artwork 2", artwork: artworks[1] },
+      { id: "saleArtwork3", title: "Sale Artwork 3", artwork: artworks[2] },
     ]
 
     context = {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -899,7 +899,7 @@ export const ArtworkEdgeInterface = new GraphQLInterfaceType({
   name: "ArtworkEdgeInterface",
   fields: {
     node: {
-      type: ArtworkType,
+      type: new GraphQLNonNull(ArtworkType),
     },
     cursor: {
       type: GraphQLString,
@@ -912,11 +912,16 @@ export const ArtworkConnectionInterface = new GraphQLInterfaceType({
   fields: {
     pageCursors: { type: new GraphQLNonNull(PageCursorsType) },
     pageInfo: { type: new GraphQLNonNull(PageInfoType) },
-    edges: { type: new GraphQLList(ArtworkEdgeInterface) },
+    edges: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(ArtworkEdgeInterface))
+      ),
+    },
   },
 })
 
 export const artworkConnection = connectionWithCursorInfo({
+  nonNullable: true,
   nodeType: ArtworkType,
   connectionInterfaces: [ArtworkConnectionInterface],
   edgeInterfaces: [ArtworkEdgeInterface],

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -921,7 +921,7 @@ export const ArtworkConnectionInterface = new GraphQLInterfaceType({
 })
 
 export const artworkConnection = connectionWithCursorInfo({
-  nonNullable: true,
+  nodeIsNonNullable: true,
   nodeType: ArtworkType,
   connectionInterfaces: [ArtworkConnectionInterface],
   edgeInterfaces: [ArtworkEdgeInterface],

--- a/src/schema/v2/artwork/layer.ts
+++ b/src/schema/v2/artwork/layer.ts
@@ -1,6 +1,11 @@
 import { artworkConnection } from "./index"
 import { IDFields } from "schema/v2/object_identification"
-import { GraphQLObjectType, GraphQLString, GraphQLFieldConfig } from "graphql"
+import {
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLFieldConfig,
+  GraphQLNonNull,
+} from "graphql"
 import { pageable } from "relay-cursor-paging"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { connectionFromArraySlice } from "graphql-relay"
@@ -16,7 +21,7 @@ const ArtworkLayerType = new GraphQLObjectType<any, ResolverContext>({
     // hasNextPage is always false.
     artworksConnection: {
       description: "A connection of artworks from a Layer.",
-      type: artworkConnection.connectionType,
+      type: new GraphQLNonNull(artworkConnection.connectionType),
       args: pageable(),
       resolve: (
         { id, type, artwork_id },

--- a/src/schema/v2/artworks.ts
+++ b/src/schema/v2/artworks.ts
@@ -1,5 +1,10 @@
 import { artworkConnection } from "./artwork"
-import { GraphQLList, GraphQLString, GraphQLFieldConfig } from "graphql"
+import {
+  GraphQLList,
+  GraphQLString,
+  GraphQLFieldConfig,
+  GraphQLNonNull,
+} from "graphql"
 import { ResolverContext } from "types/graphql"
 import { pageable } from "relay-cursor-paging"
 import { connectionFromArray } from "graphql-relay"
@@ -7,7 +12,7 @@ import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { createPageCursors } from "./fields/pagination"
 
 const Artworks: GraphQLFieldConfig<void, ResolverContext> = {
-  type: artworkConnection.connectionType,
+  type: new GraphQLNonNull(artworkConnection.connectionType),
   description: "A list of Artworks",
   deprecationReason:
     "This is only for use in resolving stitched queries, not for first-class client use.",

--- a/src/schema/v2/auction_result.ts
+++ b/src/schema/v2/auction_result.ts
@@ -240,6 +240,7 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
 })
 
 export const auctionResultConnection = connectionWithCursorInfo({
+  nonNullable: true,
   nodeType: AuctionResultType,
   connectionFields: {
     createdYearRange: {

--- a/src/schema/v2/auction_result.ts
+++ b/src/schema/v2/auction_result.ts
@@ -240,7 +240,7 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
 })
 
 export const auctionResultConnection = connectionWithCursorInfo({
-  nonNullable: true,
+  nodeIsNonNullable: true,
   nodeType: AuctionResultType,
   connectionFields: {
     createdYearRange: {

--- a/src/schema/v2/city/index.ts
+++ b/src/schema/v2/city/index.ts
@@ -6,6 +6,7 @@ import {
   GraphQLList,
   GraphQLObjectType,
   GraphQLString,
+  GraphQLNonNull,
 } from "graphql"
 
 import { LatLngType } from "../location"
@@ -55,7 +56,7 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
       type: LatLngType,
     },
     showsConnection: {
-      type: ShowsConnection.connectionType,
+      type: new GraphQLNonNull(ShowsConnection.connectionType),
       args: pageable({
         sort: {
           type: ShowSorts,
@@ -99,7 +100,7 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
         }),
     },
     fairsConnection: {
-      type: fairConnection.connectionType,
+      type: new GraphQLNonNull(fairConnection.connectionType),
       args: pageable({
         sort: FairSorts,
         status: EventStatus,
@@ -133,7 +134,7 @@ const CityType = new GraphQLObjectType<any, ResolverContext>({
             },
           },
           showsConnection: {
-            type: ShowsConnection.connectionType,
+            type: new GraphQLNonNull(ShowsConnection.connectionType),
             args: pageable({
               sort: {
                 type: ShowSorts,

--- a/src/schema/v2/credit_card.ts
+++ b/src/schema/v2/credit_card.ts
@@ -118,7 +118,7 @@ export const {
   edgeType: CreditCardEdge,
 } = connectionDefinitions({
   nodeType: CreditCardType,
-  nonNullable: true,
+  nodeIsNonNullable: true,
 })
 
 export const CreditCard: GraphQLFieldConfig<void, ResolverContext> = {

--- a/src/schema/v2/credit_card.ts
+++ b/src/schema/v2/credit_card.ts
@@ -118,6 +118,7 @@ export const {
   edgeType: CreditCardEdge,
 } = connectionDefinitions({
   nodeType: CreditCardType,
+  nonNullable: true,
 })
 
 export const CreditCard: GraphQLFieldConfig<void, ResolverContext> = {

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -105,7 +105,7 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       artistsConnection: {
-        type: artistConnection.connectionType,
+        type: new GraphQLNonNull(artistConnection.connectionType),
         args: pageable({
           sort: {
             type: FairArtistSortsType,
@@ -429,4 +429,7 @@ const Fair: GraphQLFieldConfig<void, ResolverContext> = {
 
 export default Fair
 
-export const fairConnection = connectionWithCursorInfo({ nodeType: FairType })
+export const fairConnection = connectionWithCursorInfo({
+  nonNullable: true,
+  nodeType: FairType,
+})

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -430,6 +430,6 @@ const Fair: GraphQLFieldConfig<void, ResolverContext> = {
 export default Fair
 
 export const fairConnection = connectionWithCursorInfo({
-  nonNullable: true,
+  nodeIsNonNullable: true,
   nodeType: FairType,
 })

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -214,7 +214,7 @@ export const FilterArtworksFields = () => {
     },
     aggregations: ArtworkFilterAggregations,
     artworksConnection: {
-      type: artworkConnection.connectionType,
+      type: new GraphQLNonNull(artworkConnection.connectionType),
       // FIXME: Uncomment deprecationReason once https://github.com/apollographql/apollo-tooling/issues/805
       // has been addressed.
       //deprecationReason:
@@ -328,6 +328,7 @@ const connectionFields = () => {
 }
 
 const filterArtworksConnectionType = connectionDefinitions({
+  nonNullable: true,
   name: "FilterArtworks",
   nodeType: ArtworkType,
   connectionFields: {
@@ -354,7 +355,7 @@ const filterArtworksConnectionType = connectionDefinitions({
 const filterArtworksConnectionTypeFactory = (
   mapRootToFilterParams
 ): GraphQLFieldConfig<any, ResolverContext> => ({
-  type: filterArtworksConnectionType,
+  type: new GraphQLNonNull(filterArtworksConnectionType),
   description: "Artworks Elastic Search results",
   args: pageable(filterArtworksArgs),
   resolve: (

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -328,7 +328,7 @@ const connectionFields = () => {
 }
 
 const filterArtworksConnectionType = connectionDefinitions({
-  nonNullable: true,
+  nodeIsNonNullable: true,
   name: "FilterArtworks",
   nodeType: ArtworkType,
   connectionFields: {

--- a/src/schema/v2/gene.ts
+++ b/src/schema/v2/gene.ts
@@ -200,6 +200,6 @@ const Gene: GraphQLFieldConfig<void, ResolverContext> = {
 export default Gene
 
 export const geneConnection = connectionDefinitions({
-  nonNullable: true,
+  nodeIsNonNullable: true,
   nodeType: GeneType,
 }).connectionType

--- a/src/schema/v2/gene.ts
+++ b/src/schema/v2/gene.ts
@@ -52,7 +52,7 @@ export const GeneType = new GraphQLObjectType<any, ResolverContext>({
       ...SlugAndInternalIDFields,
       cached,
       artistsConnection: {
-        type: artistConnection.connectionType,
+        type: new GraphQLNonNull(artistConnection.connectionType),
         args: pageable(),
         resolve: ({ id, counts }, options, { geneArtistsLoader }) => {
           const parsedOptions = _.omit(
@@ -200,5 +200,6 @@ const Gene: GraphQLFieldConfig<void, ResolverContext> = {
 export default Gene
 
 export const geneConnection = connectionDefinitions({
+  nonNullable: true,
   nodeType: GeneType,
 }).connectionType

--- a/src/schema/v2/gene_families.ts
+++ b/src/schema/v2/gene_families.ts
@@ -5,15 +5,16 @@ import {
   connectionFromPromisedArray,
 } from "graphql-relay"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
-import { GraphQLFieldConfig } from "graphql"
+import { GraphQLFieldConfig, GraphQLNonNull } from "graphql"
 import { ResolverContext } from "types/graphql"
 
 const { connectionType: GeneFamilyConnection } = connectionDefinitions({
+  nonNullable: true,
   nodeType: GeneFamilyType,
 })
 
 const GeneFamilies: GraphQLFieldConfig<void, ResolverContext> = {
-  type: GeneFamilyConnection,
+  type: new GraphQLNonNull(GeneFamilyConnection),
   description: "A list of Gene Families",
   args: pageable(),
   resolve: (_root, options, { geneFamiliesLoader }) => {

--- a/src/schema/v2/gene_families.ts
+++ b/src/schema/v2/gene_families.ts
@@ -9,7 +9,7 @@ import { GraphQLFieldConfig, GraphQLNonNull } from "graphql"
 import { ResolverContext } from "types/graphql"
 
 const { connectionType: GeneFamilyConnection } = connectionDefinitions({
-  nonNullable: true,
+  nodeIsNonNullable: true,
   nodeType: GeneFamilyType,
 })
 

--- a/src/schema/v2/location.ts
+++ b/src/schema/v2/location.ts
@@ -126,5 +126,6 @@ export const LocationField: GraphQLFieldConfig<void, ResolverContext> = {
 }
 
 export const locationsConnection = connectionWithCursorInfo({
+  nonNullable: true,
   nodeType: LocationType,
 })

--- a/src/schema/v2/location.ts
+++ b/src/schema/v2/location.ts
@@ -126,6 +126,6 @@ export const LocationField: GraphQLFieldConfig<void, ResolverContext> = {
 }
 
 export const locationsConnection = connectionWithCursorInfo({
-  nonNullable: true,
+  nodeIsNonNullable: true,
   nodeType: LocationType,
 })

--- a/src/schema/v2/me/artwork_inquiries.ts
+++ b/src/schema/v2/me/artwork_inquiries.ts
@@ -27,7 +27,10 @@ export const ArtworkInquiryType = new GraphQLObjectType<any, ResolverContext>({
 })
 
 const ArtworkInquiries: GraphQLFieldConfig<void, ResolverContext> = {
-  type: connectionDefinitions({ nodeType: ArtworkInquiryType }).connectionType,
+  type: connectionDefinitions({
+    nonNullable: true,
+    nodeType: ArtworkInquiryType,
+  }).connectionType,
   args: pageable({}),
   description: "A list of the current user’s inquiry requests",
   resolve: (_root, options, { inquiryRequestsLoader }) => {

--- a/src/schema/v2/me/artwork_inquiries.ts
+++ b/src/schema/v2/me/artwork_inquiries.ts
@@ -28,7 +28,7 @@ export const ArtworkInquiryType = new GraphQLObjectType<any, ResolverContext>({
 
 const ArtworkInquiries: GraphQLFieldConfig<void, ResolverContext> = {
   type: connectionDefinitions({
-    nonNullable: true,
+    nodeIsNonNullable: true,
     nodeType: ArtworkInquiryType,
   }).connectionType,
   args: pageable({}),

--- a/src/schema/v2/me/conversation/index.ts
+++ b/src/schema/v2/me/conversation/index.ts
@@ -142,7 +142,7 @@ export const {
   edgeType: MessageEdge,
 } = connectionDefinitions({
   nodeType: MessageType,
-  nonNullable: true,
+  nodeIsNonNullable: true,
   connectionFields: {
     totalCount: {
       resolve: ({ total_count }) => total_count,

--- a/src/schema/v2/me/conversation/index.ts
+++ b/src/schema/v2/me/conversation/index.ts
@@ -142,6 +142,7 @@ export const {
   edgeType: MessageEdge,
 } = connectionDefinitions({
   nodeType: MessageType,
+  nonNullable: true,
   connectionFields: {
     totalCount: {
       resolve: ({ total_count }) => total_count,

--- a/src/schema/v2/me/conversations.ts
+++ b/src/schema/v2/me/conversations.ts
@@ -9,7 +9,7 @@ import { ResolverContext } from "types/graphql"
 
 const Conversations: GraphQLFieldConfig<void, ResolverContext> = {
   type: connectionDefinitions({
-    nonNullable: true,
+    nodeIsNonNullable: true,
     nodeType: ConversationType,
     connectionFields: {
       totalUnreadCount: {

--- a/src/schema/v2/me/conversations.ts
+++ b/src/schema/v2/me/conversations.ts
@@ -9,6 +9,7 @@ import { ResolverContext } from "types/graphql"
 
 const Conversations: GraphQLFieldConfig<void, ResolverContext> = {
   type: connectionDefinitions({
+    nonNullable: true,
     nodeType: ConversationType,
     connectionFields: {
       totalUnreadCount: {

--- a/src/schema/v2/me/credit_cards.ts
+++ b/src/schema/v2/me/credit_cards.ts
@@ -2,11 +2,11 @@ import { CreditCardConnection } from "schema/v2/credit_card"
 import { pageable } from "relay-cursor-paging"
 import { connectionFromArraySlice } from "graphql-relay"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
-import { GraphQLFieldConfig } from "graphql/type"
+import { GraphQLFieldConfig, GraphQLNonNull } from "graphql/type"
 import { ResolverContext } from "types/graphql"
 
 export const CreditCards: GraphQLFieldConfig<void, ResolverContext> = {
-  type: CreditCardConnection,
+  type: new GraphQLNonNull(CreditCardConnection),
   args: pageable({}),
   description: "A list of the current user’s credit cards",
   resolve: (_root, options, { meCreditCardsLoader }) => {

--- a/src/schema/v2/me/followed_artists.ts
+++ b/src/schema/v2/me/followed_artists.ts
@@ -21,7 +21,10 @@ const FollowArtistType = new GraphQLObjectType<any, ResolverContext>({
 })
 
 const FollowedArtists: GraphQLFieldConfig<void, ResolverContext> = {
-  type: connectionDefinitions({ nodeType: FollowArtistType }).connectionType,
+  type: connectionDefinitions({
+    nonNullable: true,
+    nodeType: FollowArtistType,
+  }).connectionType,
   args: pageable({}),
   description: "A Connection of followed artists by current user",
   resolve: (_parent, args, context) => followArtistsResolver({}, args, context),

--- a/src/schema/v2/me/followed_artists.ts
+++ b/src/schema/v2/me/followed_artists.ts
@@ -22,7 +22,7 @@ const FollowArtistType = new GraphQLObjectType<any, ResolverContext>({
 
 const FollowedArtists: GraphQLFieldConfig<void, ResolverContext> = {
   type: connectionDefinitions({
-    nonNullable: true,
+    nodeIsNonNullable: true,
     nodeType: FollowArtistType,
   }).connectionType,
   args: pageable({}),

--- a/src/schema/v2/me/followed_artists_artworks_group.ts
+++ b/src/schema/v2/me/followed_artists_artworks_group.ts
@@ -63,7 +63,7 @@ const FollowedArtistsArtworksGroup: GraphQLFieldConfig<
   ResolverContext
 > = {
   type: connectionDefinitions({
-    nonNullable: true,
+    nodeIsNonNullable: true,
     nodeType: FollowedArtistsArtworksGroupType,
   }).connectionType,
   description:

--- a/src/schema/v2/me/followed_artists_artworks_group.ts
+++ b/src/schema/v2/me/followed_artists_artworks_group.ts
@@ -62,8 +62,10 @@ const FollowedArtistsArtworksGroup: GraphQLFieldConfig<
   void,
   ResolverContext
 > = {
-  type: connectionDefinitions({ nodeType: FollowedArtistsArtworksGroupType })
-    .connectionType,
+  type: connectionDefinitions({
+    nonNullable: true,
+    nodeType: FollowedArtistsArtworksGroupType,
+  }).connectionType,
   description:
     "A list of published artworks by followed artists (grouped by date and artists).",
   args: pageable({

--- a/src/schema/v2/me/followed_fairs.ts
+++ b/src/schema/v2/me/followed_fairs.ts
@@ -7,6 +7,7 @@ import { FairType } from "schema/v2/fair"
 export const FollowedFairConnection = connectionDefinitions({
   name: "FollowedFair",
   nodeType: FairType,
+  nonNullable: true,
 })
 
 const FollowedFairs: GraphQLFieldConfig<void, ResolverContext> = {

--- a/src/schema/v2/me/followed_fairs.ts
+++ b/src/schema/v2/me/followed_fairs.ts
@@ -7,7 +7,7 @@ import { FairType } from "schema/v2/fair"
 export const FollowedFairConnection = connectionDefinitions({
   name: "FollowedFair",
   nodeType: FairType,
-  nonNullable: true,
+  nodeIsNonNullable: true,
 })
 
 const FollowedFairs: GraphQLFieldConfig<void, ResolverContext> = {

--- a/src/schema/v2/me/followed_genes.ts
+++ b/src/schema/v2/me/followed_genes.ts
@@ -19,7 +19,7 @@ export const FollowGeneType = new GraphQLObjectType<any, ResolverContext>({
 const FollowedGenes: GraphQLFieldConfig<void, ResolverContext> = {
   type: connectionDefinitions({
     nodeType: FollowGeneType,
-    nonNullable: true,
+    nodeIsNonNullable: true,
   }).connectionType,
   args: pageable({}),
   description: "A list of the current user’s inquiry requests",

--- a/src/schema/v2/me/followed_genes.ts
+++ b/src/schema/v2/me/followed_genes.ts
@@ -17,7 +17,10 @@ export const FollowGeneType = new GraphQLObjectType<any, ResolverContext>({
 })
 
 const FollowedGenes: GraphQLFieldConfig<void, ResolverContext> = {
-  type: connectionDefinitions({ nodeType: FollowGeneType }).connectionType,
+  type: connectionDefinitions({
+    nodeType: FollowGeneType,
+    nonNullable: true,
+  }).connectionType,
   args: pageable({}),
   description: "A list of the current user’s inquiry requests",
   resolve: (_root, options, { followedGenesLoader }) => {

--- a/src/schema/v2/me/followed_shows.ts
+++ b/src/schema/v2/me/followed_shows.ts
@@ -17,6 +17,7 @@ const getValidCitySlugs = () => Object.keys(location_by_city_slug).join(", ")
 
 export const FollowedShowConnection = connectionDefinitions({
   name: "FollowedShow",
+  nonNullable: true,
   nodeType: ShowType,
 })
 

--- a/src/schema/v2/me/followed_shows.ts
+++ b/src/schema/v2/me/followed_shows.ts
@@ -17,7 +17,7 @@ const getValidCitySlugs = () => Object.keys(location_by_city_slug).join(", ")
 
 export const FollowedShowConnection = connectionDefinitions({
   name: "FollowedShow",
-  nonNullable: true,
+  nodeIsNonNullable: true,
   nodeType: ShowType,
 })
 

--- a/src/schema/v2/me/recently_viewed_artworks.ts
+++ b/src/schema/v2/me/recently_viewed_artworks.ts
@@ -2,14 +2,14 @@ import { connectionFromArray, connectionFromArraySlice } from "graphql-relay"
 import { getPagingParameters, pageable } from "relay-cursor-paging"
 
 import { artworkConnection } from "schema/v2/artwork"
-import { GraphQLFieldConfig } from "graphql"
+import { GraphQLFieldConfig, GraphQLNonNull } from "graphql"
 import { ResolverContext } from "types/graphql"
 
 export const RecentlyViewedArtworks: GraphQLFieldConfig<
   { recently_viewed_artwork_ids: string[] },
   ResolverContext
 > = {
-  type: artworkConnection.connectionType,
+  type: new GraphQLNonNull(artworkConnection.connectionType),
   args: pageable({}),
   description: "A list of the current user’s recently viewed artworks.",
   resolve: (

--- a/src/schema/v2/me/saved_artworks.ts
+++ b/src/schema/v2/me/saved_artworks.ts
@@ -15,7 +15,7 @@ import { connectionFromArraySlice, connectionFromArray } from "graphql-relay"
 const SavedArtworksConnection = connectionWithCursorInfo({
   name: "SavedArtworks",
   nodeType: ArtworkType,
-  nonNullable: true,
+  nodeIsNonNullable: true,
   connectionFields: {
     description: {
       type: new GraphQLNonNull(GraphQLString),

--- a/src/schema/v2/me/saved_artworks.ts
+++ b/src/schema/v2/me/saved_artworks.ts
@@ -12,18 +12,10 @@ import CollectionSorts from "../sorts/collection_sorts"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { connectionFromArraySlice, connectionFromArray } from "graphql-relay"
 
-// Forward this directly to the collection resolver with known defaults.
-
-// const SavedArtworks: GraphQLFieldConfig<void, ResolverContext> = {
-//   type: CollectionType,
-//   resolve: collectionResolverFactory("saved-artwork"),
-// }
-
-// export default SavedArtworks
-
-export const SavedArtworksConnection = connectionWithCursorInfo({
+const SavedArtworksConnection = connectionWithCursorInfo({
   name: "SavedArtworks",
   nodeType: ArtworkType,
+  nonNullable: true,
   connectionFields: {
     description: {
       type: new GraphQLNonNull(GraphQLString),

--- a/src/schema/v2/object_identification.ts
+++ b/src/schema/v2/object_identification.ts
@@ -33,6 +33,7 @@ import {
   GraphQLInterfaceType,
   GraphQLFieldConfig,
   GraphQLFieldConfigMap,
+  isNonNullType,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
 
@@ -156,7 +157,7 @@ const NodeField: GraphQLFieldConfig<any, ResolverContext> = {
       ).then(data => {
         // Add the already known type so `NodeInterface` can pluck that out in
         // its `resolveType` implementation.
-        return { __type: type, ...data }
+        return { __type: isNonNullType(type) ? type.ofType : type, ...data }
       })
     }
   },

--- a/src/schema/v2/ordered_set.ts
+++ b/src/schema/v2/ordered_set.ts
@@ -40,7 +40,7 @@ const OrderedSetType = new GraphQLObjectType<any, ResolverContext>({
       },
     },
     itemsConnection: {
-      type: artworkConnection.connectionType,
+      type: new GraphQLNonNull(artworkConnection.connectionType),
       description:
         "Returns a connection of the items. Only Artwork supported right now.",
       args: pageable(),

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -51,6 +51,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       name: "ArtistPartner",
       nodeType: ArtistType,
       edgeFields: partnerArtistFields,
+      nonNullable: true,
     }).connectionType
 
     return {
@@ -58,7 +59,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       cached,
       artistsConnection: {
         description: "A connection of artists at a partner.",
-        type: ArtistPartnerConnection,
+        type: new GraphQLNonNull(ArtistPartnerConnection),
         args: pageable({
           sort: ArtistSorts,
           representedBy: {
@@ -98,7 +99,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       },
       artworksConnection: {
         description: "A connection of artworks from a Partner.",
-        type: artworkConnection.connectionType,
+        type: new GraphQLNonNull(artworkConnection.connectionType),
         args: pageable(artworksArgs),
         resolve: ({ id }, args, { partnerArtworksLoader }) => {
           const { page, size, offset } = convertConnectionArgsToGravityArgs(
@@ -262,7 +263,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       },
       locationsConnection: {
         description: "A connection of locations from a Partner.",
-        type: locationsConnection.connectionType,
+        type: new GraphQLNonNull(locationsConnection.connectionType),
         args: pageable({}),
         resolve: ({ id }, args, { partnerLocationsConnectionLoader }) => {
           const { page, size, offset } = convertConnectionArgsToGravityArgs(
@@ -301,7 +302,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       },
       showsConnection: {
         description: "A connection of shows from a Partner.",
-        type: ShowsConnection.connectionType,
+        type: new GraphQLNonNull(ShowsConnection.connectionType),
         args: pageable({
           sort: {
             type: ShowSorts,

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -51,7 +51,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       name: "ArtistPartner",
       nodeType: ArtistType,
       edgeFields: partnerArtistFields,
-      nonNullable: true,
+      nodeIsNonNullable: true,
     }).connectionType
 
     return {

--- a/src/schema/v2/partnerArtistConnection.ts
+++ b/src/schema/v2/partnerArtistConnection.ts
@@ -10,4 +10,5 @@ export const PartnerArtistConnection = connectionDefinitions({
   name: "PartnerArtist",
   nodeType: PartnerType,
   edgeFields: fields,
+  nonNullable: true,
 }).connectionType

--- a/src/schema/v2/partnerArtistConnection.ts
+++ b/src/schema/v2/partnerArtistConnection.ts
@@ -10,5 +10,5 @@ export const PartnerArtistConnection = connectionDefinitions({
   name: "PartnerArtist",
   nodeType: PartnerType,
   edgeFields: fields,
-  nonNullable: true,
+  nodeIsNonNullable: true,
 }).connectionType

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -70,6 +70,7 @@ const BuyersPremium = new GraphQLObjectType<any, ResolverContext>({
 
 const saleArtworkConnection = connectionDefinitions({
   nodeType: SaleArtworkType,
+  nonNullable: true,
 }).connectionType
 
 export const SaleType = new GraphQLObjectType<any, ResolverContext>({

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -70,7 +70,7 @@ const BuyersPremium = new GraphQLObjectType<any, ResolverContext>({
 
 const saleArtworkConnection = connectionDefinitions({
   nodeType: SaleArtworkType,
-  nonNullable: true,
+  nodeIsNonNullable: true,
 }).connectionType
 
 export const SaleType = new GraphQLObjectType<any, ResolverContext>({

--- a/src/schema/v2/sale_artwork.ts
+++ b/src/schema/v2/sale_artwork.ts
@@ -92,8 +92,14 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
     return {
       ...SlugAndInternalIDFields,
       cached,
-      artwork: { type: Artwork.type, resolve: ({ artwork }) => artwork },
-      node: { type: Artwork.type, resolve: ({ artwork }) => artwork },
+      artwork: {
+        type: new GraphQLNonNull(Artwork.type),
+        resolve: ({ artwork }) => artwork,
+      },
+      node: {
+        type: new GraphQLNonNull(Artwork.type),
+        resolve: ({ artwork }) => artwork,
+      },
       cursor: { type: GraphQLString },
       counts: {
         resolve: x => x,
@@ -130,9 +136,10 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
           display_estimate_dollars,
         }) => {
           return (
-            compact(
-              [display_low_estimate_dollars, display_high_estimate_dollars]
-            ).join("–") || display_estimate_dollars
+            compact([
+              display_low_estimate_dollars,
+              display_high_estimate_dollars,
+            ]).join("–") || display_estimate_dollars
           )
         },
       },

--- a/src/schema/v2/sale_artworks.ts
+++ b/src/schema/v2/sale_artworks.ts
@@ -6,6 +6,7 @@ import {
   GraphQLObjectType,
   GraphQLString,
   GraphQLInt,
+  GraphQLNonNull,
 } from "graphql"
 import { connectionFromArraySlice } from "graphql-relay"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
@@ -64,6 +65,7 @@ const SaleArtworksConnectionType = connectionWithCursorInfo({
     counts: SaleArtworkCounts,
   },
   connectionInterfaces: [ArtworkConnectionInterface],
+  nonNullable: true,
 }).connectionType
 
 export const SaleArtworksConnectionField: GraphQLFieldConfig<
@@ -110,7 +112,7 @@ export const SaleArtworksConnectionField: GraphQLFieldConfig<
     },
   }),
   description: "Sale Artworks search results",
-  type: SaleArtworksConnectionType,
+  type: new GraphQLNonNull(SaleArtworksConnectionType),
   resolve: async (
     _root,
     {

--- a/src/schema/v2/sale_artworks.ts
+++ b/src/schema/v2/sale_artworks.ts
@@ -65,7 +65,7 @@ const SaleArtworksConnectionType = connectionWithCursorInfo({
     counts: SaleArtworkCounts,
   },
   connectionInterfaces: [ArtworkConnectionInterface],
-  nonNullable: true,
+  nodeIsNonNullable: true,
 }).connectionType
 
 export const SaleArtworksConnectionField: GraphQLFieldConfig<

--- a/src/schema/v2/sales.ts
+++ b/src/schema/v2/sales.ts
@@ -18,7 +18,7 @@ export const SalesConnectionField: GraphQLFieldConfig<void, ResolverContext> = {
   type: new GraphQLNonNull(
     connectionWithCursorInfo({
       nodeType: SaleType,
-      nonNullable: true,
+      nodeIsNonNullable: true,
     }).connectionType
   ),
   description: "A list of Sales",

--- a/src/schema/v2/sales.ts
+++ b/src/schema/v2/sales.ts
@@ -5,6 +5,7 @@ import {
   GraphQLFieldConfig,
   GraphQLList,
   GraphQLString,
+  GraphQLNonNull,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { pageable } from "relay-cursor-paging"
@@ -14,7 +15,12 @@ import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { BodyAndHeaders } from "lib/loaders"
 
 export const SalesConnectionField: GraphQLFieldConfig<void, ResolverContext> = {
-  type: connectionWithCursorInfo({ nodeType: SaleType }).connectionType,
+  type: new GraphQLNonNull(
+    connectionWithCursorInfo({
+      nodeType: SaleType,
+      nonNullable: true,
+    }).connectionType
+  ),
   description: "A list of Sales",
   args: pageable({
     // TODO: This wasn’t needed by Emission and is a tad awkward of an arg. If

--- a/src/schema/v2/search/index.ts
+++ b/src/schema/v2/search/index.ts
@@ -70,10 +70,11 @@ const SearchConnection = connectionWithCursorInfo({
   connectionFields: {
     aggregations: SearchAggregations,
   },
+  nonNullable: true,
 })
 
 export const Search: GraphQLFieldConfig<void, ResolverContext> = {
-  type: SearchConnection.connectionType,
+  type: new GraphQLNonNull(SearchConnection.connectionType),
   description: "Global search",
   args: searchArgs,
   resolve: (_source, args, context, info) => {

--- a/src/schema/v2/search/index.ts
+++ b/src/schema/v2/search/index.ts
@@ -70,7 +70,7 @@ const SearchConnection = connectionWithCursorInfo({
   connectionFields: {
     aggregations: SearchAggregations,
   },
-  nonNullable: true,
+  nodeIsNonNullable: true,
 })
 
 export const Search: GraphQLFieldConfig<void, ResolverContext> = {

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -112,7 +112,7 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
       },
       artworksConnection: {
         description: "The artworks featured in the show",
-        type: artworkConnection.connectionType,
+        type: new GraphQLNonNull(artworkConnection.connectionType),
         args: pageable(artworksArgs),
         resolve: (show, options, { partnerShowArtworksLoader }) => {
           const loaderOptions = {
@@ -466,7 +466,7 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
       },
       nearbyShowsConnection: {
         description: "Shows that are near (~75km) from this show",
-        type: ShowsConnection.connectionType,
+        type: new GraphQLNonNull(ShowsConnection.connectionType),
         args: pageable({
           sort: {
             type: ShowSorts,
@@ -585,8 +585,13 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ fair }) => (isExisty(fair) ? "Fair Booth" : "Show"),
       },
       followedArtistsConnection: {
-        type: connectionDefinitions({ nodeType: FollowArtistType })
-          .connectionType,
+        // https://github.com/ds300/gravity/blob/4ebad08af27cc3b3a36414b2afb2bb992366737f/app/api/v1/me_follow_artists_endpoint.rb#L30
+        type: new GraphQLNonNull(
+          connectionDefinitions({
+            nodeType: FollowArtistType,
+            nonNullable: true,
+          }).connectionType
+        ),
         args: pageable({}),
         description:
           "A Connection of followed artists by current user for this show",
@@ -627,4 +632,7 @@ const Show: GraphQLFieldConfig<void, ResolverContext> = {
 }
 
 export default Show
-export const ShowsConnection = connectionWithCursorInfo({ nodeType: ShowType })
+export const ShowsConnection = connectionWithCursorInfo({
+  nodeType: ShowType,
+  nonNullable: true,
+})

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -589,7 +589,7 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
         type: new GraphQLNonNull(
           connectionDefinitions({
             nodeType: FollowArtistType,
-            nonNullable: true,
+            nodeIsNonNullable: true,
           }).connectionType
         ),
         args: pageable({}),
@@ -634,5 +634,5 @@ const Show: GraphQLFieldConfig<void, ResolverContext> = {
 export default Show
 export const ShowsConnection = connectionWithCursorInfo({
   nodeType: ShowType,
-  nonNullable: true,
+  nodeIsNonNullable: true,
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1735,13 +1735,6 @@ ajv@^6.10.0, ajv@^6.10.2:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ansi-align@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"
-  integrity sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=
-  dependencies:
-    string-width "^2.0.0"
-
 ansi-escapes@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
@@ -2399,19 +2392,6 @@ bowser@^2.5.3:
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.8.1.tgz#35b74165e17b80ba8af6aa4736c2861b001fc09e"
   integrity sha512-FxxltGKqMHkVa3KtpA+kdnxH0caHPDewccyrK3vW1bsMw6Zco4vRPmMunowX0pXlDZqhxkKSpToADQI2Sk4OeQ==
 
-boxen@^1.2.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.3.0.tgz#55c6c39a8ba58d9c61ad22cd877532deb665a20b"
-  integrity sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==
-  dependencies:
-    ansi-align "^2.0.0"
-    camelcase "^4.0.0"
-    chalk "^2.0.1"
-    cli-boxes "^1.0.0"
-    string-width "^2.0.0"
-    term-size "^1.2.0"
-    widest-line "^2.0.0"
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -2575,7 +2555,7 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.0.0.tgz#fb7eb569b72ad7a45812f93fd9430a3e410b3dd3"
   integrity sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==
 
-camelcase@^4.0.0, camelcase@^4.1.0:
+camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
@@ -2596,11 +2576,6 @@ capture-exit@^2.0.0:
   integrity sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==
   dependencies:
     rsvp "^4.8.4"
-
-capture-stack-trace@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz#a6c0bbe1f38f3aa0b92238ecb6ff42c344d4135d"
-  integrity sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -2709,11 +2684,6 @@ chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.3.tgz#42d837d5239688d55f303003a508230fa6727142"
   integrity sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==
 
-ci-info@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.2.tgz#03561259db48d0474c8bdc90f5b47b068b6bbfb4"
-  integrity sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==
-
 ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
@@ -2728,11 +2698,6 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
-
-cli-boxes@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
-  integrity sha1-T6kXw+WclKAEzWH47lCdplFocUM=
 
 cli-cursor@^1.0.2:
   version "1.0.2"
@@ -2906,18 +2871,6 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-configstore@^3.0.0:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/configstore/-/configstore-3.1.2.tgz#c6f25defaeef26df12dd33414b001fe81a543f8f"
-  integrity sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==
-  dependencies:
-    dot-prop "^4.1.0"
-    graceful-fs "^4.1.2"
-    make-dir "^1.0.0"
-    unique-string "^1.0.0"
-    write-file-atomic "^2.0.0"
-    xdg-basedir "^3.0.0"
-
 connection-parse@0.0.x:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/connection-parse/-/connection-parse-0.0.7.tgz#18e7318aab06a699267372b10c5226d25a1c9a69"
@@ -3062,13 +3015,6 @@ cosmiconfig@^5.2.1:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
-create-error-class@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
-  integrity sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=
-  dependencies:
-    capture-stack-trace "^1.0.0"
-
 create-react-class@^15.6.0:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.2.tgz#cf1ed15f12aad7f14ef5f2dfe05e6c42f91ef02a"
@@ -3109,11 +3055,6 @@ cryptiles@3.x.x:
   integrity sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=
   dependencies:
     boom "5.x.x"
-
-crypto-random-string@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
-  integrity sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=
 
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
@@ -3421,22 +3362,10 @@ domexception@^1.0.0:
   dependencies:
     webidl-conversions "^4.0.2"
 
-dot-prop@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
-  integrity sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==
-  dependencies:
-    is-obj "^1.0.0"
-
 dotenv@5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
   integrity sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==
-
-duplexer3@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
-  integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -4460,13 +4389,6 @@ glob@^7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-global-dirs@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"
-  integrity sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=
-  dependencies:
-    ini "^1.3.4"
-
 globals@^11.1.0:
   version "11.3.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.3.0.tgz#e04fdb7b9796d8adac9c8f64c14837b2313378b0"
@@ -4488,23 +4410,6 @@ globrex@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
   integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
-
-got@^6.7.1:
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
-  integrity sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=
-  dependencies:
-    create-error-class "^3.0.0"
-    duplexer3 "^0.1.4"
-    get-stream "^3.0.0"
-    is-redirect "^1.0.0"
-    is-retry-allowed "^1.0.0"
-    is-stream "^1.0.0"
-    lowercase-keys "^1.0.0"
-    safe-buffer "^5.0.1"
-    timed-out "^4.0.0"
-    unzip-response "^2.0.1"
-    url-parse-lax "^1.0.0"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.15"
@@ -4986,11 +4891,6 @@ import-fresh@^3.0.0:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-import-lazy@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
-  integrity sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=
-
 import-local@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-2.0.0.tgz#55070be38a5993cf18ef6db7e961f5bee5c5a09d"
@@ -5032,7 +4932,7 @@ inherits@2.0.4:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
+ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -5155,13 +5055,6 @@ is-callable@^1.1.4:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
   integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
 
-is-ci@^1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.0.10.tgz#f739336b2632365061a9d48270cd56ae3369318e"
-  integrity sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=
-  dependencies:
-    ci-info "^1.0.0"
-
 is-ci@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
@@ -5271,19 +5164,6 @@ is-glob@^4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
-is-installed-globally@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.1.0.tgz#0dfd98f5a9111716dd535dda6492f67bf3d25a80"
-  integrity sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=
-  dependencies:
-    global-dirs "^0.1.0"
-    is-path-inside "^1.0.0"
-
-is-npm@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
-  integrity sha1-8vtjpl5JBbQGyGBydloaTceTufQ=
-
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -5301,7 +5181,7 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-is-obj@^1.0.0, is-obj@^1.0.1:
+is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
   integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
@@ -5319,13 +5199,6 @@ is-odd@^2.0.0:
   integrity sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==
   dependencies:
     is-number "^4.0.0"
-
-is-path-inside@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
-  integrity sha1-jvW33lBDej/cprToZe96pVy0gDY=
-  dependencies:
-    path-is-inside "^1.0.1"
 
 is-plain-obj@^1.1.0:
   version "1.1.0"
@@ -5351,11 +5224,6 @@ is-promise@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
   integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
 
-is-redirect@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
-  integrity sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=
-
 is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
@@ -5368,12 +5236,7 @@ is-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
   integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
 
-is-retry-allowed@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
-  integrity sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=
-
-is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -6209,13 +6072,6 @@ kubernetes-client@^3.16.0:
     request "^2.83.0"
     util.promisify "^1.0.0"
 
-latest-version@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"
-  integrity sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=
-  dependencies:
-    package-json "^4.0.0"
-
 lcid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
@@ -6616,11 +6472,6 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   integrity sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=
   dependencies:
     js-tokens "^3.0.0"
-
-lowercase-keys@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
-  integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
 
 lru-cache@^4.0.1:
   version "4.1.5"
@@ -7515,16 +7366,6 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
   integrity sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==
 
-package-json@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/package-json/-/package-json-4.0.1.tgz#8869a0401253661c4c4ca3da6c2121ed555f5eed"
-  integrity sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=
-  dependencies:
-    got "^6.7.1"
-    registry-auth-token "^3.0.1"
-    registry-url "^3.0.3"
-    semver "^5.1.0"
-
 pako@~0.2.5:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
@@ -7615,10 +7456,10 @@ pascalcase@^0.1.1:
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
-patch-package@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.2.0.tgz#677de858e352b6ca4e6cb48a6efde2cec9fde566"
-  integrity sha512-HWlQflaBBMjLBfOWomfolF8aqsFDeNbSNro1JDUgYqnVvPM5OILJ9DQdwIRiKmGaOsmHvhkl1FYkvv1I9r2ZJw==
+patch-package@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.2.2.tgz#71d170d650c65c26556f0d0fbbb48d92b6cc5f39"
+  integrity sha512-YqScVYkVcClUY0v8fF0kWOjDYopzIM8e3bj/RU1DPeEF14+dCGm6UeOYm4jvCyxqIEQ5/eJzmbWfDWnUleFNMg==
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
     chalk "^2.4.2"
@@ -7632,7 +7473,6 @@ patch-package@6.2.0:
     semver "^5.6.0"
     slash "^2.0.0"
     tmp "^0.0.33"
-    update-notifier "^2.5.0"
 
 path-dirname@^1.0.0:
   version "1.0.2"
@@ -7654,7 +7494,7 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-path-is-inside@^1.0.1, path-is-inside@^1.0.2:
+path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
   integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
@@ -7793,11 +7633,6 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
-
-prepend-http@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
-  integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
 prettier@1.14.3:
   version "1.14.3"
@@ -8012,7 +7847,7 @@ raw-body@^2.4.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
+rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -8255,21 +8090,6 @@ regexpu-core@^4.5.4:
     regjsparser "^0.6.0"
     unicode-match-property-ecmascript "^1.0.4"
     unicode-match-property-value-ecmascript "^1.1.0"
-
-registry-auth-token@^3.0.1:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.3.2.tgz#851fd49038eecb586911115af845260eec983f20"
-  integrity sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==
-  dependencies:
-    rc "^1.1.6"
-    safe-buffer "^5.0.1"
-
-registry-url@^3.0.3:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
-  integrity sha1-PU74cPc93h138M+aOBQyRE4XSUI=
-  dependencies:
-    rc "^1.0.1"
 
 regjsgen@^0.5.0:
   version "0.5.0"
@@ -8620,22 +8440,10 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
-semver-diff@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
-  integrity sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=
-  dependencies:
-    semver "^5.0.3"
-
 "semver@2 || 3 || 4 || 5", semver@^5.5.0:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
   integrity sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==
-
-semver@^5.0.3, semver@^5.1.0, semver@^5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
-  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
 semver@^5.3.0:
   version "5.4.1"
@@ -8646,6 +8454,11 @@ semver@^5.4.1:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
   integrity sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
+
+semver@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
 semver@^5.7.0:
   version "5.7.0"
@@ -9338,13 +9151,6 @@ tar@^4.4.8:
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
 
-term-size@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
-  integrity sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=
-  dependencies:
-    execa "^0.7.0"
-
 test-exclude@^5.2.3:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-5.2.3.tgz#c3d3e1e311eb7ee405e092dac10aefd09091eac0"
@@ -9370,7 +9176,7 @@ through@^2.3.6:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
-timed-out@4.0.1, timed-out@^4.0.0:
+timed-out@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
@@ -9605,13 +9411,6 @@ union-value@^1.0.0:
     is-extendable "^0.1.1"
     set-value "^0.4.3"
 
-unique-string@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
-  integrity sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=
-  dependencies:
-    crypto-random-string "^1.0.0"
-
 universal-user-agent@^2.0.0, universal-user-agent@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-2.0.3.tgz#9f6f09f9cc33de867bb720d84c08069b14937c6c"
@@ -9651,31 +9450,10 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-unzip-response@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
-  integrity sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=
-
 upath@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.2.tgz#3db658600edaeeccbe6db5e684d67ee8c2acd068"
   integrity sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==
-
-update-notifier@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.5.0.tgz#d0744593e13f161e406acb1d9408b72cad08aff6"
-  integrity sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==
-  dependencies:
-    boxen "^1.2.1"
-    chalk "^2.0.1"
-    configstore "^3.0.0"
-    import-lazy "^2.1.0"
-    is-ci "^1.0.10"
-    is-installed-globally "^0.1.0"
-    is-npm "^1.0.0"
-    latest-version "^3.0.0"
-    semver-diff "^2.0.0"
-    xdg-basedir "^3.0.0"
 
 uri-js@^4.2.2:
   version "4.2.2"
@@ -9693,13 +9471,6 @@ url-join@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.0.tgz#4d3340e807d3773bda9991f8305acdcc2a665d2a"
   integrity sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo=
-
-url-parse-lax@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
-  integrity sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=
-  dependencies:
-    prepend-http "^1.0.1"
 
 url-parse@^1.4.3:
   version "1.4.3"
@@ -9866,13 +9637,6 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2"
 
-widest-line@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-2.0.1.tgz#7438764730ec7ef4381ce4df82fb98a53142a3fc"
-  integrity sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==
-  dependencies:
-    string-width "^2.1.1"
-
 windows-release@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/windows-release/-/windows-release-3.1.0.tgz#8d4a7e266cbf5a233f6c717dac19ce00af36e12e"
@@ -9926,15 +9690,6 @@ write-file-atomic@2.4.1:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
-write-file-atomic@^2.0.0:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.2.tgz#a7181706dfba17855d221140a9c06e15fcdd87b9"
-  integrity sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==
-  dependencies:
-    graceful-fs "^4.1.11"
-    imurmurhash "^0.1.4"
-    signal-exit "^3.0.2"
-
 write@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
@@ -9963,11 +9718,6 @@ ws@^6.0.0:
   integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
   dependencies:
     async-limiter "~1.0.0"
-
-xdg-basedir@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
-  integrity sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
eigen recently enabled TypeScript's `strict` mode. After doing that we noticed a lot of places in the MP schema where things that should be non-nullable are instead nullable. Happily going from `nullable`->`non-nullable` is a backwards compatible change, so we've set aside some time to do that in places where it would be most impactful. This is the first PR contributing to that effort.

This PR affects four things

- Makes connection types non-nullable where possible (the only nullable connection types I found were connections like `followedArtists` that only make sense for logged-in users)
- Makes the edges array non-nullable (it's always there when we use `connectionFromArraySlice`, which we use everywhere in MP)
- Makes the edges themselves non-nullable (again, they're always present with `connectionFromArraySlice`)
- Makes the edge nodes non-nullable where possible (I couldn't find any examples where nullability made sense, but I added a mandatory property for the config object to force people to choose either way when creating new connection types.)

This doesn't affect connections which were stitched in from other services, we'd have to update those manually.