### PR TITLE
Re-orders fair results so that fairs that haven't started yet are at the end

### DIFF
--- a/src/schema/v2/home/__tests__/home_page_fairs_module.test.js
+++ b/src/schema/v2/home/__tests__/home_page_fairs_module.test.js
@@ -59,6 +59,44 @@ describe("HomePageFairsModule", () => {
     })
   })
 
+  it("puts fairs that haven't started yet at the end of the results", async () => {
+    const fairs = [
+      {
+        mobile_image: {},
+        id: "future-fair",
+        start_at: "2027-11-03T10:00:00+00:00",
+        name: "Future Fair",
+      },
+      {
+        mobile_image: {},
+        id: "current-fair",
+        start_at: "2017-11-03T10:00:00+00:00",
+        name: "Current Fair",
+      },
+    ]
+
+    const query = `
+      {
+        homePage {
+          fairsModule {
+            results {
+              slug
+              name
+              isActive
+            }
+          }
+        }
+      }
+    `
+
+    const fairModule = await runQuery(query, {
+      fairsLoader: options => Promise.resolve({ body: fairs }),
+    })
+    const results = fairModule.homePage.fairsModule.results
+    expect(results[0].slug).toEqual("current-fair")
+    expect(results[1].slug).toEqual("future-fair")
+  })
+
   it("does not request past fairs if it has 8 running ones", () => {
     const aFair = {
       id: "artissima-2017",

--- a/src/schema/v2/home/home_page_fairs_module.ts
+++ b/src/schema/v2/home/home_page_fairs_module.ts
@@ -1,6 +1,8 @@
 import Fair from "schema/v2/fair"
 import { GraphQLList, GraphQLObjectType, GraphQLNonNull } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { groupBy } from "lodash"
+import moment from "moment"
 
 export const HomePageFairsModuleType = new GraphQLObjectType<
   any,
@@ -17,22 +19,36 @@ export const HomePageFairsModuleType = new GraphQLObjectType<
           sort: "-start_at",
           active: true,
         }
-        return fairsLoader(gravityOptions).then(({ body: runningFairs }) => {
-          // If there are less than 8, get the most recent closed fairs
-          if (runningFairs.length < 8) {
-            const newOptions = {
-              ...gravityOptions,
-              status: "closed",
-              active: false,
-              size: 8 - runningFairs.length,
-            }
-            return fairsLoader(newOptions).then(({ body: closedFairs }) => {
-              const allFairs = runningFairs.concat(closedFairs)
-              return allFairs.filter(fair => fair.mobile_image)
+        return fairsLoader(gravityOptions).then(
+          ({ body: ungroupedRunningFairs }) => {
+            // Gravity returns fairs that are both current and upcoming.
+            // Make sure the current ones appear first in the results list.
+            const now = moment.utc()
+            const returnValue = groupBy(ungroupedRunningFairs, fair => {
+              const startAt = moment.utc(fair.start_at)
+              return now.isAfter(startAt) ? "current" : "upcoming"
             })
+
+            const runningFairs = (returnValue["current"] || []).concat(
+              returnValue["upcoming"] || []
+            )
+
+            // If there are less than 8, get the most recent closed fairs
+            if (runningFairs.length < 8) {
+              const newOptions = {
+                ...gravityOptions,
+                status: "closed",
+                active: false,
+                size: 8 - runningFairs.length,
+              }
+              return fairsLoader(newOptions).then(({ body: closedFairs }) => {
+                const allFairs = runningFairs.concat(closedFairs)
+                return allFairs.filter(fair => fair.mobile_image)
+              })
+            }
+            return runningFairs.filter(fair => fair.mobile_image)
           }
-          return runningFairs.filter(fair => fair.mobile_image)
-        })
+        )
       },
     },
   },


### PR DESCRIPTION
We were seeing fairs listed in the app sorted only by start_at, which put some fairs that haven't actually started yet at the front of the list. This places fairs whose `start_at` is in the future at the end of the list.

I've taken a follow-up to re-examine some of the other logic in here, since it's kind of weird!