### PR TITLE
Preserve empty array in query string

### DIFF
--- a/src/lib/__tests__/helpers.test.ts
+++ b/src/lib/__tests__/helpers.test.ts
@@ -1,10 +1,11 @@
 import {
   exclude,
-  toKey,
   isExisty,
   removeNulls,
-  stripTags,
   resolveBlueGreen,
+  stripTags,
+  toKey,
+  toQueryString,
 } from "lib/helpers"
 
 describe("exclude", () => {
@@ -22,6 +23,20 @@ describe("exclude", () => {
 
   it("simply returns the list if invoked without arguments", () => {
     expect(exclude()(xs)).toEqual(xs)
+  })
+})
+
+describe("toQueryString", () => {
+  it("stringifies regular arraies", () => {
+    expect(
+      toQueryString({ ids: [13, 27], visible: true, availability: "for sale" })
+    ).toBe("availability=for%20sale&ids%5B%5D=13&ids%5B%5D=27&visible=true")
+  })
+
+  it("preserves empty arraies", () => {
+    expect(
+      toQueryString({ ids: [], visible: true, availability: "for sale" })
+    ).toBe("availability=for%20sale&ids%5B%5D=&visible=true")
   })
 })
 


### PR DESCRIPTION
https://artsy.slack.com/archives/CP9P4KR35/p1588364384042800

When working on https://github.com/artsy/metaphysics/pull/2345 I noticed a viewing room without any artworks will return artworks connection with `totalCount 0` but with real artwork nodes (see screenshot below).

It turns out qs [`stringify`](https://github.com/artsy/metaphysics/blob/c501f9063d1c3d573db86d1006b58939dc2357f8/src/lib/helpers.ts#L71) [ignores empty array/object](https://github.com/ljharb/qs/issues/362) so we are not sending `ids[]=` to Gravity when it's empty. Therefore, Gravity is returning _all_ artworks.

This adds a regression test and uses qs `filter` function as a workaround to map empty array to value that it respects. It's a workaround, but since it's implementation details of the `toQueryString` helper and covered by tests, I hope it's acceptable. Other ideas welcome!

![Screen Shot 2020-05-04 at 9 25 21 AM](https://user-images.githubusercontent.com/796573/80970589-6505d980-8de9-11ea-9d42-a35b75f46c82.png)
