### PR TITLE
Revert "Preserve empty array in query string"

### DIFF
--- a/src/lib/__tests__/helpers.test.ts
+++ b/src/lib/__tests__/helpers.test.ts
@@ -1,11 +1,10 @@
 import {
   exclude,
+  toKey,
   isExisty,
   removeNulls,
-  resolveBlueGreen,
   stripTags,
-  toKey,
-  toQueryString,
+  resolveBlueGreen,
 } from "lib/helpers"
 
 describe("exclude", () => {
@@ -23,20 +22,6 @@ describe("exclude", () => {
 
   it("simply returns the list if invoked without arguments", () => {
     expect(exclude()(xs)).toEqual(xs)
-  })
-})
-
-describe("toQueryString", () => {
-  it("stringifies regular arraies", () => {
-    expect(
-      toQueryString({ ids: [13, 27], visible: true, availability: "for sale" })
-    ).toBe("availability=for%20sale&ids%5B%5D=13&ids%5B%5D=27&visible=true")
-  })
-
-  it("preserves empty arraies", () => {
-    expect(
-      toQueryString({ ids: [], visible: true, availability: "for sale" })
-    ).toBe("availability=for%20sale&ids%5B%5D=&visible=true")
   })
 })
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -58,29 +58,20 @@ export const truncate = (string, length, append = "…") => {
   const limit = ~~length
   return x.length > limit ? x.slice(0, limit) + append : x
 }
-export const toQueryString = (options = {}) => {
-  // qs ignores empty array/object and prevents us from sending `?array[]=`.
-  // This is a workaround to map an empty array to `[null]` so it gets treated
-  // as an empty string.
-  // https://github.com/ljharb/qs/issues/362
-  const mapEmptyArray = a => (Array.isArray(a) && a.length === 0 ? [null] : a)
-
+export const toQueryString = (options = {}) =>
   /**
    * In the case of batched requests we want to explicitly _not_ sort the
    * params because the order matters to dataloader
    */
   // @ts-ignore
-  return options.batched
+  options.batched
     ? stringify(options, {
         arrayFormat: "brackets",
-        filter: (_prefix, v) => mapEmptyArray(v),
       })
     : stringify(options, {
         arrayFormat: "brackets",
         sort: (a, b) => a.localeCompare(b),
-        filter: (_prefix, v) => mapEmptyArray(v),
       })
-}
 export const toKey = (path, options = {}) => `${path}?${toQueryString(options)}`
 export const exclude = (values?: any[], property?: any) => xs =>
   reject(xs, x => includes(values, x[property]))


### PR DESCRIPTION
Reverts artsy/metaphysics#2351

Rather than fixing this globally, we should just fix these as they come up. So in the specific case of `artworks`, it can be addressed specifically there (removing the param entirely if empty).