### PR TITLE
[MX-291] Adds homePage.marketingCollectionModule.results

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4952,7 +4952,7 @@ type HomePageMarketingCollectionsModule {
     @deprecated(
       reason: "This field only exists to satisfy the GraphQL Schema validation"
     )
-  results: [MarketingCollection]
+  results: [MarketingCollection]!
 }
 
 type HomePageModulesParams {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4835,6 +4835,7 @@ type HomePage {
   heroUnits(platform: HomePageHeroUnitPlatform!): [HomePageHeroUnit]
   fairsModule: HomePageFairsModule
   salesModule: HomePageSalesModule
+  marketingCollectionsModule: HomePageMarketingCollectionsModule
 }
 
 type HomePageArtistModule implements Node {
@@ -4944,6 +4945,14 @@ enum HomePageHeroUnitPlatform {
   MOBILE
   DESKTOP
   MARTSY
+}
+
+type HomePageMarketingCollectionsModule {
+  _unusedField: String
+    @deprecated(
+      reason: "This field only exists to satisfy the GraphQL Schema validation"
+    )
+  results: [MarketingCollection]
 }
 
 type HomePageModulesParams {

--- a/src/lib/stitching/kaws/__tests__/stitching.test.ts
+++ b/src/lib/stitching/kaws/__tests__/stitching.test.ts
@@ -24,24 +24,17 @@ describe("KAWS Stitching", () => {
       expect(homePageMarketingCollectionsModuleFields).toContain("results")
     })
 
-    it("passes through slugs to kaws when querying HomePageMarketingCollectionsModule.results", async () => {
+    it("returns an array even if the kaws request fails", async () => {
       const { resolvers } = await getKawsStitchedSchema()
       const resultsResolver =
         resolvers.HomePageMarketingCollectionsModule.results.resolve
-      const mergeInfo = { delegateToSchema: jest.fn() }
-      resultsResolver({}, {}, {}, { mergeInfo })
-
-      expect(mergeInfo.delegateToSchema).toHaveBeenCalledWith(
-        expect.objectContaining({
-          args: {
-            slugs: [
-              "new-this-week",
-              "auction-highlights",
-              "trending-emerging-artists",
-            ],
-          },
-        })
+      const delegateToSchemaMock = jest.fn()
+      delegateToSchemaMock.mockRejectedValue(
+        "simulating a kaws request failure"
       )
+      const mergeInfo = { delegateToSchema: delegateToSchemaMock }
+      const results = await resultsResolver({}, {}, {}, { mergeInfo })
+      expect(results).toEqual([])
     })
   })
 
@@ -52,7 +45,7 @@ describe("KAWS Stitching", () => {
         resolvers.Artist.marketingCollections.resolve
       const mergeInfo = { delegateToSchema: jest.fn() }
 
-      marketingCollectionsResolver(
+      await marketingCollectionsResolver(
         { internalID: "artist-internal-id" },
         {},
         {},

--- a/src/lib/stitching/kaws/__tests__/stitching.test.ts
+++ b/src/lib/stitching/kaws/__tests__/stitching.test.ts
@@ -14,6 +14,37 @@ describe("KAWS Stitching", () => {
     expect(viewerFields).toContain("marketingCollections")
   })
 
+  describe("HomePageMarketingCollectionsModule", () => {
+    it("extends the HomePageMarketingCollectionsModule object", async () => {
+      const mergedSchema = await getKawsMergedSchema()
+      const homePageMarketingCollectionsModuleFields = await getFieldsForTypeFromSchema(
+        "HomePageMarketingCollectionsModule",
+        mergedSchema
+      )
+      expect(homePageMarketingCollectionsModuleFields).toContain("results")
+    })
+
+    it("passes through slugs to kaws when querying HomePageMarketingCollectionsModule.results", async () => {
+      const { resolvers } = await getKawsStitchedSchema()
+      const resultsResolver =
+        resolvers.HomePageMarketingCollectionsModule.results.resolve
+      const mergeInfo = { delegateToSchema: jest.fn() }
+      resultsResolver({}, {}, {}, { mergeInfo })
+
+      expect(mergeInfo.delegateToSchema).toHaveBeenCalledWith(
+        expect.objectContaining({
+          args: {
+            slugs: [
+              "new-this-week",
+              "auction-highlights",
+              "trending-emerging-artists",
+            ],
+          },
+        })
+      )
+    })
+  })
+
   describe("marketingCollections", () => {
     it("passes artist internalID to kaws' artistID arg when querying `... on Artist`", async () => {
       const { resolvers } = await getKawsStitchedSchema()

--- a/src/lib/stitching/kaws/stitching.ts
+++ b/src/lib/stitching/kaws/stitching.ts
@@ -119,7 +119,7 @@ export const kawsStitchingEnvironmentV2 = (
       )}): FilterArtworksConnection
     }
     extend type HomePageMarketingCollectionsModule {
-      results: [MarketingCollection]
+      results: [MarketingCollection]!
     }
   `,
 
@@ -157,24 +157,31 @@ export const kawsStitchingEnvironmentV2 = (
               __typename
             }
           `,
-          resolve: (_source, _args, context, info) => {
-            // We hard-code the collections slugs here in MP so that the app can
-            // display different collections based only on an MP change (and not
-            // an app deploy).
-            return info.mergeInfo.delegateToSchema({
-              schema: kawsSchema,
-              operation: "query",
-              fieldName: "marketingCollections",
-              args: {
-                slugs: [
-                  "new-this-week",
-                  "auction-highlights",
-                  "trending-emerging-artists",
-                ],
-              },
-              context,
-              info,
-            })
+          resolve: async (_source, _args, context, info) => {
+            try {
+              // We hard-code the collections slugs here in MP so that the app
+              // can display different collections based only on an MP change
+              // (and not an app deploy).
+              return await info.mergeInfo.delegateToSchema({
+                schema: kawsSchema,
+                operation: "query",
+                fieldName: "marketingCollections",
+                args: {
+                  slugs: [
+                    "new-this-week",
+                    "auction-highlights",
+                    "trending-emerging-artists",
+                  ],
+                },
+                context,
+                info,
+              })
+            } catch (error) {
+              // The schema guarantees a present array for results, so fall back
+              // to an empty one if the request to kaws fails. Note that we
+              // still bubble-up any errors in the GraphQL response.
+              return []
+            }
           },
         },
       },

--- a/src/lib/stitching/kaws/stitching.ts
+++ b/src/lib/stitching/kaws/stitching.ts
@@ -118,6 +118,9 @@ export const kawsStitchingEnvironmentV2 = (
         "\n"
       )}): FilterArtworksConnection
     }
+    extend type HomePageMarketingCollectionsModule {
+      results: [MarketingCollection]
+    }
   `,
 
     // Resolvers for the above, this passes in ALL potential parameters
@@ -140,6 +143,34 @@ export const kawsStitchingEnvironmentV2 = (
               args: {
                 artistID,
                 ...args,
+              },
+              context,
+              info,
+            })
+          },
+        },
+      },
+      HomePageMarketingCollectionsModule: {
+        results: {
+          fragment: gql`
+            ... on HomePageMarketingCollectionsModule {
+              __typename
+            }
+          `,
+          resolve: (_source, _args, context, info) => {
+            // We hard-code the collections slugs here in MP so that the app can
+            // display different collections based only on an MP change (and not
+            // an app deploy).
+            return info.mergeInfo.delegateToSchema({
+              schema: kawsSchema,
+              operation: "query",
+              fieldName: "marketingCollections",
+              args: {
+                slugs: [
+                  "new-this-week",
+                  "auction-highlights",
+                  "trending-emerging-artists",
+                ],
               },
               context,
               info,

--- a/src/schema/v2/home/homePageMarketingCollectionsModule.ts
+++ b/src/schema/v2/home/homePageMarketingCollectionsModule.ts
@@ -1,0 +1,23 @@
+import { GraphQLObjectType, GraphQLString } from "graphql"
+import { ResolverContext } from "types/graphql"
+
+// This type exists only to be extended in the kaws/stitching.ts file.
+export const HomePageMarketingCollectionsModuleType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "HomePageMarketingCollectionsModule",
+  fields: {
+    _unusedField: {
+      type: GraphQLString,
+      resolve: () => null,
+      deprecationReason:
+        "This field only exists to satisfy the GraphQL Schema validation",
+    },
+  },
+})
+
+export const HomePageMarketingCollectionsModule = {
+  type: HomePageMarketingCollectionsModuleType,
+  resolve: (_root, obj) => obj,
+}

--- a/src/schema/v2/home/index.ts
+++ b/src/schema/v2/home/index.ts
@@ -5,6 +5,7 @@ import HomePageArtistModules from "./home_page_artist_modules"
 import HomePageHeroUnits from "./home_page_hero_units"
 import HomePageFairsModule from "./home_page_fairs_module"
 import HomePageSalesModule from "./home_page_sales_module"
+import { HomePageMarketingCollectionsModule } from "./homePageMarketingCollectionsModule"
 
 import { GraphQLObjectType, GraphQLFieldConfig } from "graphql"
 import { ResolverContext } from "types/graphql"
@@ -19,6 +20,7 @@ const HomePageType = new GraphQLObjectType<any, ResolverContext>({
     heroUnits: HomePageHeroUnits,
     fairsModule: HomePageFairsModule,
     salesModule: HomePageSalesModule,
+    marketingCollectionsModule: HomePageMarketingCollectionsModule,
   },
 })
 


### PR DESCRIPTION
This PR adds a new module to the top-level `homePage` field so that we can make queries like this:

```graphql
{
  homePage {
    marketingCollectionsModule {
      results {
        title
        artworksConnection(first: 3) {
          edges {
            node {
              slug
            }
          }
        }
      }
    }
  }
}
```

Here it is working locally:

![Screen Shot 2020-05-07 at 11 57 02](https://user-images.githubusercontent.com/498212/81317188-87eaf480-905a-11ea-9f6b-8f8ef161b213.png)


This is to support MX work to include three collections (New this Week, Highlights at Auction, and Trending Emerging Artists) in the app's home page. I chose to add this `homePage` module, rather than have the app query the collections itself, so that MP is the source of truth for which collections get displayed in the app.

![Screen Shot 2020-05-07 at 12 00 28](https://user-images.githubusercontent.com/498212/81317065-60942780-905a-11ea-8070-21948f83d7d0.png)

GraphQL objects must have _at least one_ field prior to being stitched, so I had to add an `_unusedField` field. I marked it as deprecated with a clear explainer and it always returns `null`, but I'm open to other suggestions.