### PR TITLE
Preserve empty array in query string for viewing room artworks (GALL-2836)

### DIFF
--- a/src/lib/__tests__/helpers.test.ts
+++ b/src/lib/__tests__/helpers.test.ts
@@ -1,10 +1,11 @@
 import {
   exclude,
-  toKey,
   isExisty,
   removeNulls,
-  stripTags,
   resolveBlueGreen,
+  stripTags,
+  toKey,
+  toQueryString,
 } from "lib/helpers"
 
 describe("exclude", () => {
@@ -22,6 +23,26 @@ describe("exclude", () => {
 
   it("simply returns the list if invoked without arguments", () => {
     expect(exclude()(xs)).toEqual(xs)
+  })
+})
+
+describe("toQueryString", () => {
+  it("stringifies regular arraies", () => {
+    expect(
+      toQueryString({ ids: [13, 27], visible: true, availability: "for sale" })
+    ).toBe("availability=for%20sale&ids%5B%5D=13&ids%5B%5D=27&visible=true")
+  })
+
+  it("ignores empty arraies", () => {
+    expect(
+      toQueryString({ ids: [], visible: true, availability: "for sale" })
+    ).toBe("availability=for%20sale&visible=true")
+  })
+
+  it("stringifies [null] as an empty array", () => {
+    expect(
+      toQueryString({ ids: [null], visible: true, availability: "for sale" })
+    ).toBe("availability=for%20sale&ids%5B%5D=&visible=true")
   })
 })
 

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -46,6 +46,23 @@ it("resolves the artworks field on ViewingRoom as a paginated list", async () =>
   })
 })
 
+it("converts empty artworkIDs argument", async () => {
+  const { resolvers } = await getGravityStitchedSchema()
+  const { artworksConnection } = resolvers.ViewingRoom
+  const info = { mergeInfo: { delegateToSchema: jest.fn() } }
+
+  artworksConnection.resolve({ artworkIDs: [] }, { first: 2 }, {}, info)
+
+  expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
+    args: { ids: [null], first: 2 },
+    operation: "query",
+    fieldName: "artworks",
+    schema: expect.anything(),
+    context: expect.anything(),
+    info: expect.anything(),
+  })
+})
+
 it("resolves the partner field on ViewingRoom", async () => {
   const { resolvers } = await getGravityStitchedSchema()
   const { partner } = resolvers.ViewingRoom

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -49,6 +49,18 @@ export const gravityStitchingEnvironment = (
             }
           `,
           resolve: ({ artworkIDs: ids }, args, context, info) => {
+            // qs ignores empty array/object and prevents us from sending `?array[]=`.
+            // This is a workaround to map an empty array to `[null]` so it gets treated
+            // as an empty string.
+            // https://github.com/ljharb/qs/issues/362
+            //
+            // Note that we can't easily change this globally as there are multiple places
+            // clients are sending params of empty array but expecting Gravity to return
+            // non-empty data. This only fixes the issue for viewing room artworks.
+            if (ids.length === 0) {
+              ids = [null]
+            }
+
             return info.mergeInfo.delegateToSchema({
               schema: localSchema,
               operation: "query",


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GALL-2836

In https://github.com/artsy/metaphysics/pull/2351, we changed the behavior globally. Unfortunately, there are multiple places clients are sending empty array params but expecting APIs (e.g. Gravity) to ignore that and return non-empty results.

It seems not easy to exhaustively fix everywhere so this is a fix just for viewing room artworks.

Tests are trying to catch issues by this workaround in case the underlying implementation changes. Ideally I'd be interested in more integration type of tests but I'm not sure how. So my approach here is:

- Test that we are mapping argument properly for dataloader to use.
- Then test with the mapped argument, the query string conversion that dataloader is relying on converts the argument to desired query string.

Welcome any ideas!

## Before
![Screen Shot 2020-05-04 at 9 25 21 AM](https://user-images.githubusercontent.com/796573/81346507-63a60c80-9088-11ea-85b2-34d2f99520e2.png)

## After
![Screen Shot 2020-05-07 at 5 29 44 PM](https://user-images.githubusercontent.com/796573/81346497-5ee15880-9088-11ea-8cd8-7bb2b9ec5528.png)
