### PR TITLE
Add horizon/block step to release Circle CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,11 @@
 version: 2.1
 
 orbs:
-  hokusai: artsy/hokusai@0.7.3
-  yarn: artsy/yarn@4.0.2
-  node: circleci/node@2.1.0
   codecov: codecov/codecov@1.0.5
+  hokusai: artsy/hokusai@0.7.3
+  horizon: artsy/release@0.0.1
+  node: circleci/node@2.1.0
+  yarn: artsy/yarn@4.0.2
 
 not_staging_or_release: &not_staging_or_release
   filters:
@@ -101,5 +102,12 @@ workflows:
             - deploy-staging
 
       # release
+      - horizon/block:
+          <<: *only_release
+          context: horizon
+          project_id: 18
+
       - hokusai/deploy-production:
           <<: *only_release
+          requires:
+            - horizon/block


### PR DESCRIPTION
Halt the CI release if a Horizon deploy block is found.