### PR TITLE
Fixes for return value of setsLoader

### DIFF
--- a/src/schema/v1/__tests__/ordered_sets.test.js
+++ b/src/schema/v1/__tests__/ordered_sets.test.js
@@ -19,15 +19,17 @@ describe("OrderedSets type", () => {
 
   const context = {
     setsLoader: sinon.stub().returns(
-      Promise.resolve([
-        {
-          id: "52dd3c2e4b8480091700027f",
-          item_type: "Gene",
-          key: "artists:featured-genes",
-          name: "Featured Genes",
-          description: "These Genes are featured",
-        },
-      ])
+      Promise.resolve({
+        body: [
+          {
+            id: "52dd3c2e4b8480091700027f",
+            item_type: "Gene",
+            key: "artists:featured-genes",
+            name: "Featured Genes",
+            description: "These Genes are featured",
+          },
+        ],
+      })
     ),
     setItemsLoader: sinon.stub().returns(
       Promise.resolve({

--- a/src/schema/v1/ordered_sets.ts
+++ b/src/schema/v1/ordered_sets.ts
@@ -30,7 +30,10 @@ const OrderedSets: GraphQLFieldConfig<void, ResolverContext> = {
       defaultValue: 10,
     },
   },
-  resolve: (_root, options, { setsLoader }) => setsLoader(options),
+  resolve: async (_root, args, { setsLoader }) => {
+    const { body } = await setsLoader(args)
+    return body
+  },
 }
 
 export default OrderedSets

--- a/src/schema/v2/__tests__/ordered_sets.test.js
+++ b/src/schema/v2/__tests__/ordered_sets.test.js
@@ -19,15 +19,17 @@ xdescribe("OrderedSets type", () => {
 
   const context = {
     setsLoader: sinon.stub().returns(
-      Promise.resolve([
-        {
-          id: "52dd3c2e4b8480091700027f",
-          item_type: "Gene",
-          key: "artists:featured-genes",
-          name: "Featured Genes",
-          description: "These Genes are featured",
-        },
-      ])
+      Promise.resolve({
+        body: [
+          {
+            id: "52dd3c2e4b8480091700027f",
+            item_type: "Gene",
+            key: "artists:featured-genes",
+            name: "Featured Genes",
+            description: "These Genes are featured",
+          },
+        ],
+      })
     ),
     setItemsLoader: sinon.stub().returns(
       Promise.resolve([

--- a/src/schema/v2/ordered_sets.ts
+++ b/src/schema/v2/ordered_sets.ts
@@ -30,7 +30,10 @@ const OrderedSets: GraphQLFieldConfig<void, ResolverContext> = {
       defaultValue: 10,
     },
   },
-  resolve: (_root, options, { setsLoader }) => setsLoader(options),
+  resolve: async (_root, args, { setsLoader }) => {
+    const { body } = await setsLoader(args)
+    return body
+  },
 }
 
 export default OrderedSets


### PR DESCRIPTION
This is only exposed in v1 apparently. Used for fetching sets of pre-defined genes.