### PR TITLE
Add Datadog Route Tracing for V2 Routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,11 +32,11 @@ const enableQueryTracing = ENABLE_QUERY_TRACING === "true"
 
 let server, isShuttingDown, hasBooted
 
-// Always load the source on startup so any file level issues surface sooner.
-require("./src")
-
 // This needs to happen as early as possible so the plugins can hook into the
-// modules we use before any other code gets a chance to use them.
+// modules we use before any other code gets a chance to use them. Additionally,
+// since dd-trace monkey patches express it needs to be loaded before creating
+// the graphql server otherwise we will not have accurate tracing on those
+// routes.
 if (enableQueryTracing) {
   if (isDevelopment) {
     console.warn(
@@ -46,6 +46,9 @@ if (enableQueryTracing) {
   console.warn("[FEATURE] Enabling query tracing")
   initTracer()
 }
+
+// Always load the source on startup so any file level issues surface sooner.
+require("./src")
 
 if (enableAsyncStackTraces) {
   console.warn("[FEATURE] Enabling long async stack traces") // eslint-disable-line
@@ -145,7 +148,7 @@ function gracefulExit() {
   if (isShuttingDown) return
   isShuttingDown = true
   console.log("Received signal SIGTERM, shutting down")
-  server.shutdown(function () {
+  server.shutdown(function() {
     console.log("Closed existing connections.")
     process.exit(0)
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -250,23 +250,8 @@ function startApp(appSchema, path: string) {
 
 const app = express()
 
-let appV1: express.Express
-let appV2: express.Express
-
-app.all("/", (req, res, next) => {
-  if (!appV1) {
-    appV1 = express()
-    appV1.use("/", startApp(schemaV1, "/"))
-  }
-  appV1(req, res, next)
-})
-
-app.all("/v2", (req, res, next) => {
-  if (!appV2) {
-    appV2 = express()
-    appV2.use("/", startApp(schemaV2, "/v2"))
-  }
-  appV2(req, res, next)
-})
+// This order is important for dd-trace to be able to find the nested routes.
+app.use("/v2", startApp(schemaV2, "/"))
+app.use("/", startApp(schemaV1, "/"))
 
 export default app


### PR DESCRIPTION
Problem

Currently, the V1 and V2 routes are being as originating from the
URL in Datadog. This is preventing us from being able to track how
many requests are hitting each endpoint and determine how many
clients are still using the V1 routes.

Solution

This change initializes Datadog earlier so that we will be able to 
differentiate the V1 and V2 APIs.

Due to the way that Datadog internally recognizes "valid" routes, if
dd-trace has not loaded and monkey patched express prior to a
route being defined. Datadog will associated it with the highest
applicable bucket. In this case that would be `/`.

Additionally, there is a minor refactoring that removes a extra 
express app that wasn't required.