### PR TITLE
[MX-325] Limits home page sales to auctions #trivial

### DIFF
--- a/src/schema/v2/home/home_page_sales_module.ts
+++ b/src/schema/v2/home/home_page_sales_module.ts
@@ -14,6 +14,7 @@ export const HomePageSalesModuleType = new GraphQLObjectType<
         // Check for all sales that are currently running
         const gravityOptions = {
           live: true,
+          is_auction: true,
           size: 10,
           sort: "timely_at,name",
         }


### PR DESCRIPTION
We were showing all the sales on the home page instead of just the sales that are auctions (a slight difference, but basically we have some BNMO sales that aren't auctions – see the ticket for more info). This PR updates the home page to return the same data as fetched in the Auctions view in the app:

https://github.com/artsy/eigen/blob/dd7c200a809fa81a423c94fab28097cc261ff15c/src/lib/Scenes/Sales/index.tsx#L115

By fixing this on MP, we'll get this to all users without an app update. 