### PR TITLE
Remove error handling from meLoader

### DIFF
--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -162,7 +162,7 @@ const MeField: GraphQLFieldConfig<void, ResolverContext> = {
       "unreadNotificationsCount",
     ]
     if (includesFieldsOtherThanSelectionSet(info, fieldsNotRequireLoader)) {
-      return meLoader().catch(() => null)
+      return meLoader()
     }
     // The email and is_collector are here so that the type system's `isTypeOf`
     // resolves correctly when we're skipping gravity data


### PR DESCRIPTION
This seems like a pattern we had adapted a long time ago that no longer seems to be valid. WIth this change, we will be able to see the error in the `errors` property in the response:

<img width="4064" alt="catch-error" src="https://user-images.githubusercontent.com/386234/81718545-db3db800-9449-11ea-9bc4-2859b5c77227.png">
