### PR TITLE
Blocked: Add SendConfirmationEmail mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5708,6 +5708,11 @@ type Mutation {
     input: UpdateConversationMutationInput!
   ): UpdateConversationMutationPayload
 
+  # Send a confirmation email
+  sendConfirmationEmail(
+    input: SendConfirmationEmailMutationInput!
+  ): SendConfirmationEmailMutationPayload
+
   # Appending a message to a conversation thread
   sendConversationMessage(
     input: SendConversationMessageMutationInput!
@@ -7441,6 +7446,28 @@ interface Sellable {
   isSold: Boolean
   saleMessage: String
 }
+
+type SendConfirmationEmailMutationFailure {
+  mutationError: GravityMutationError
+}
+
+input SendConfirmationEmailMutationInput {
+  clientMutationId: String
+}
+
+type SendConfirmationEmailMutationPayload {
+  confirmationOrError: SendConfirmationEmailMutationType
+  clientMutationId: String
+}
+
+type SendConfirmationEmailMutationSuccess {
+  confirmationSentAt: String
+  unconfirmedEmail: String
+}
+
+union SendConfirmationEmailMutationType =
+    SendConfirmationEmailMutationSuccess
+  | SendConfirmationEmailMutationFailure
 
 input SendConversationMessageMutationInput {
   # The id of the conversation to be updated

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -199,6 +199,11 @@ export default (accessToken, userID, opts) => {
       user_id: userID,
       private: true,
     }),
+    sendConfirmationEmailLoader: gravityLoader(
+      "me/confirmation_emails",
+      {},
+      { method: "POST" }
+    ),
     sendFeedbackLoader: gravityLoader("feedback", {}, { method: "POST" }),
     showLoader: gravityLoader(id => `show/${id}`),
     startIdentityVerificationLoader: gravityLoader(

--- a/src/schema/v2/me/__tests__/send_confirmation_email_mutation.test.js
+++ b/src/schema/v2/me/__tests__/send_confirmation_email_mutation.test.js
@@ -1,0 +1,91 @@
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("Send confirmation email mutation", () => {
+  const successResponse = {
+    id: "foo",
+    confirmation_sent_at: "2020-05-18T12:00:00+00:00",
+    unconfirmed_email: "yuki@awesomemail.com",
+  }
+
+  const query = `
+    mutation {
+      sendConfirmationEmail(input: { }) {
+        confirmationOrError {
+          ... on SendConfirmationEmailMutationSuccess {
+            confirmationSentAt
+            unconfirmedEmail
+          }
+          ... on SendConfirmationEmailMutationFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  const context = {
+    sendConfirmationEmailLoader: () => Promise.resolve(successResponse),
+  }
+
+  it("sends a confirmation email", async () => {
+    const data = await runAuthenticatedQuery(query, context)
+
+    expect(data).toEqual({
+      sendConfirmationEmail: {
+        confirmationOrError: {
+          confirmationSentAt: "2020-05-18T12:00:00+00:00",
+          unconfirmedEmail: "yuki@awesomemail.com",
+        },
+      },
+    })
+  })
+
+  it("returns a SendConfirmationEmailMutationFailure object when the user's email is already confirmed", async () => {
+    const context = {
+      sendConfirmationEmailLoader: () =>
+        Promise.reject(
+          new Error(
+            `https://stagingapi.artsy.net/api/v1/me/confirmation_emails - {"error":"email is already confirmed"}`
+          )
+        ),
+    }
+
+    const data = await runAuthenticatedQuery(query, context)
+
+    expect(data).toEqual({
+      sendConfirmationEmail: {
+        confirmationOrError: {
+          mutationError: {
+            message: "email is already confirmed",
+          },
+        },
+      },
+    })
+  })
+
+  it("throws an error if the user is not signed in", () => {
+    const context = {
+      sendConfirmationEmailLoader: undefined,
+    }
+
+    return runAuthenticatedQuery(query, context).catch(error => {
+      expect(error.message).toEqual(
+        "You need to be signed in to perform this action"
+      )
+    })
+  })
+
+  it("throws an error if there is one we don't recognize", () => {
+    const errorRootValue = {
+      sendConfirmationEmailLoader: () => {
+        throw new Error("ETIMEOUT service unreachable")
+      },
+    }
+
+    return runAuthenticatedQuery(query, errorRootValue).catch(error => {
+      expect(error.message).toEqual("ETIMEOUT service unreachable")
+    })
+  })
+})

--- a/src/schema/v2/me/sendConfirmationEmailMutation.ts
+++ b/src/schema/v2/me/sendConfirmationEmailMutation.ts
@@ -1,0 +1,79 @@
+import { GraphQLObjectType, GraphQLString, GraphQLUnionType } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import {
+  GravityMutationErrorType,
+  formatGravityError,
+} from "lib/gravityErrorHandler"
+
+const SendConfirmationEmailMutationSuccess = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "SendConfirmationEmailMutationSuccess",
+  isTypeOf: data => data.id,
+  fields: () => ({
+    confirmationSentAt: {
+      type: GraphQLString,
+      resolve: ({ confirmation_sent_at }) => confirmation_sent_at,
+    },
+    unconfirmedEmail: {
+      type: GraphQLString,
+      resolve: ({ unconfirmed_email }) => unconfirmed_email,
+    },
+  }),
+})
+
+const SendConfirmationEmailMutationFailure = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "SendConfirmationEmailMutationFailure",
+  isTypeOf: data => {
+    return data._type === "GravityMutationError"
+  },
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: err => err,
+    },
+  }),
+})
+
+export const sendConfirmationEmailMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "SendConfirmationEmailMutation",
+  description: "Send a confirmation email",
+  inputFields: {}, // TODO: Is this the right way to say "This mutation does not take any arguments"?
+  outputFields: {
+    confirmationOrError: {
+      type: new GraphQLUnionType({
+        name: "SendConfirmationEmailMutationType",
+        types: [
+          SendConfirmationEmailMutationSuccess,
+          SendConfirmationEmailMutationFailure,
+        ],
+      }),
+      resolve: result => result,
+    },
+  },
+  mutateAndGetPayload: (_, { sendConfirmationEmailLoader }) => {
+    if (!sendConfirmationEmailLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    return sendConfirmationEmailLoader()
+      .then(result => result)
+      .catch(error => {
+        const formattedErr = formatGravityError(error)
+        if (formattedErr) {
+          return { ...formattedErr, _type: "GravityMutationError" }
+        } else {
+          throw new Error(error)
+        }
+      })
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -68,6 +68,7 @@ import createBidderMutation from "./me/create_bidder_mutation"
 import createCreditCardMutation from "./me/create_credit_card_mutation"
 import { deleteCreditCardMutation } from "./me/delete_credit_card_mutation"
 import { BidderPositionMutation } from "./me/bidder_position_mutation"
+import { sendConfirmationEmailMutation } from "./me/sendConfirmationEmailMutation"
 import { sendFeedbackMutation } from "./sendFeedbackMutation"
 import { OrderPartyUnionType } from "./ecommerce/types/order_party_union"
 import { createAccountRequestMutation } from "./createAccountRequestMutation"
@@ -180,6 +181,7 @@ export default new GraphQLSchema({
       updateCollectorProfile: UpdateCollectorProfile,
       updateMyUserProfile: UpdateMyUserProfileMutation,
       updateConversation: UpdateConversationMutation,
+      sendConfirmationEmail: sendConfirmationEmailMutation,
       sendConversationMessage: SendConversationMessageMutation,
       sendFeedback: sendFeedbackMutation,
       saveArtwork: SaveArtworkMutation,


### PR DESCRIPTION
This PR adds a new mutation `sendConfirmationEmail`:

```graphql
mutation {
  sendConfirmationEmail(input: {}) {
    confirmationOrError {
      ... on SendConfirmationEmailMutationSuccess {
        confirmationSentAt
        unconfirmedEmail
      }
      ... on SendConfirmationEmailMutationFailure {
        mutationError {
          message
        }
      }
    }
  }
}
```

The empty `input: {}` is a little odd, but I wasn't sure how I could make a mutation without inputs, so I just left it there. In the future, it might make sense to update it to e.g. `sendConfirmationEmail(input: { newEmail: "..." })` so users can request an email update using the same mutation, so it might not be that bad.

## Todos (or questions)

 * [x] Merge https://github.com/artsy/gravity/pull/13056 
 * [x] Wait until https://github.com/artsy/gravity/pull/13073 is merged and QA locally
 * [x] ~~Remove the mutation input entirely~~ not sure how I could remove it, so let's leave it for now
 * [x] Add one more test for expected error
 * [x] ~~Is `ClientMutationId` required? if not, is it okay to get rid of it? (and how?)~~ not entirely resolved, but `current_user.id` is used as a `ClientMutationId` just to make it work for now.
 * [x] ~~Fix the type error beflow:~~ this is still happening, but I'm not sure why. Let's discuss on PR review.
    ```
    src/schema/v2/me/sendConfirmationEmailMutation.ts:74:12 - error TS2722: Cannot invoke an object which is possibly 'undefined'.

    74     return emailConfirmationLoader()
                  ~~~~~~~~~~~~~~~~~~~~~~~
    ```

## Screenshots

<img width="1116" alt="Screen Shot 2020-05-12 at 2 41 29 PM" src="https://user-images.githubusercontent.com/386234/81732611-b6a00b00-945e-11ea-9b2a-e7cfb77e0368.png">
