### PR TITLE
Fix total count from v2 root artworks field (GALL-2844)

### DIFF
--- a/src/schema/v2/__tests__/artworks.test.ts
+++ b/src/schema/v2/__tests__/artworks.test.ts
@@ -1,0 +1,22 @@
+import { runQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("Artworks", () => {
+  it("returns total count matching the number of non-empty ids", async () => {
+    const artworksLoader = ({ ids }: any) => {
+      if (ids) {
+        return Promise.resolve(ids.map(_id => ({ _id })))
+      }
+      throw new Error("Unexpected invocation")
+    }
+    const query = gql`
+      {
+        artworks(ids: [null]) {
+          totalCount
+        }
+      }
+    `
+    const { artworks } = await runQuery(query, { artworksLoader })
+    expect(artworks.totalCount).toEqual(0)
+  })
+})

--- a/src/schema/v2/__tests__/artworks.test.ts
+++ b/src/schema/v2/__tests__/artworks.test.ts
@@ -2,16 +2,35 @@ import { runQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
 
 describe("Artworks", () => {
-  it("returns total count matching the number of non-empty ids", async () => {
+  it("returns total count matching the length of body returned from artworks loader", async () => {
+    const artworks_result = [{ _id: "123" }, { _id: "456" }, { _id: "789" }]
     const artworksLoader = ({ ids }: any) => {
       if (ids) {
-        return Promise.resolve(ids.map(_id => ({ _id })))
+        return Promise.resolve(artworks_result)
       }
       throw new Error("Unexpected invocation")
     }
     const query = gql`
       {
-        artworks(ids: [null]) {
+        artworks(ids: ["123", "456", "789", "-1"]) {
+          totalCount
+        }
+      }
+    `
+    const { artworks } = await runQuery(query, { artworksLoader })
+    expect(artworks.totalCount).toEqual(3)
+  })
+
+  it("returns total count 0 when artworks loader returns an empty array", async () => {
+    const artworksLoader = ({ ids }: any) => {
+      if (ids) {
+        return Promise.resolve([])
+      }
+      throw new Error("Unexpected invocation")
+    }
+    const query = gql`
+      {
+        artworks(ids: [null, "-1", "-2", "-3"]) {
           totalCount
         }
       }

--- a/src/schema/v2/artworks.ts
+++ b/src/schema/v2/artworks.ts
@@ -20,9 +20,10 @@ const Artworks: GraphQLFieldConfig<void, ResolverContext> = {
     const { ids } = options
     const { page, size } = convertConnectionArgsToGravityArgs(options)
     return artworksLoader({ ids }).then(body => {
+      const totalCount = body.length
       return {
-        totalCount: ids.length,
-        pageCursors: createPageCursors({ page, size }, ids.length),
+        totalCount,
+        pageCursors: createPageCursors({ page, size }, totalCount),
         ...connectionFromArray(body, options),
       }
     })


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GALL-2844

Following up on https://github.com/artsy/metaphysics/pull/2364, the workaround of using `[null]` as the empty `ids` param ended up causing the artworks loader to return `totalCount: 1` when it should be `0`.

In fact, the total count should not rely on the `ids` params caller passed in, and should instead calculated from the response. In this case when `ids` are passed in, Gravity [doesn't paginate](https://github.com/artsy/gravity/blob/6df1e3524d1bcb60a6c6773a487b4a560788b5db/app/api/v1/artworks_endpoint.rb#L166-L169) (and include the `X-TOTAL-COUNT` in the headers), so we can simply use the length of the response body.

![Screen Shot 2020-05-12 at 5 20 14 PM](https://user-images.githubusercontent.com/796573/81746641-dc380f00-9474-11ea-9002-09870417dd11.png)
