### PR TITLE
Add formattedEndAt to viewingRoom

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -12833,6 +12833,7 @@ type ViewingRoom {
     after: String
     before: String
   ): ArtworkConnection
+  formattedEndAt: String
   partner: Partner
 }
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8526,6 +8526,7 @@ type ViewingRoom {
     after: String
     before: String
   ): ArtworkConnection
+  formattedEndAt: String
   partner: Partner
 }
 

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "memcached": "2.2.2",
     "moment": "2.19.3",
     "moment-timezone": "0.5.25",
+    "moment.distance": "^1.2.0",
     "node-fetch": "1.7.3",
     "numeral": "1.5.6",
     "opentracing": "0.14.1",

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -1,5 +1,7 @@
 import gql from "lib/gql"
 import { GraphQLSchema } from "graphql"
+import moment from "moment"
+import "moment.distance"
 
 export const gravityStitchingEnvironment = (
   localSchema: GraphQLSchema,
@@ -19,6 +21,7 @@ export const gravityStitchingEnvironment = (
           after: String
           before: String
         ): ArtworkConnection
+        formattedEndAt: String
         partner: Partner
       }
 
@@ -72,6 +75,25 @@ export const gravityStitchingEnvironment = (
               context,
               info,
             })
+          },
+        },
+        formattedEndAt: {
+          fragment: gql`
+            ... on ViewingRoom {
+              startAt
+              endAt
+            }
+          `,
+          resolve: ({ startAt: sa, endAt: ea }) => {
+            const startAt = moment(sa)
+            const endAt = moment(ea)
+            if (endAt > moment().add(30, "days")) {
+              return null
+            }
+            const label =
+              // @ts-ignore - .distance() is a moment plugin
+              "Closes in " + moment.duration(endAt.diff(startAt)).distance()
+            return label
           },
         },
         partner: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6929,6 +6929,11 @@ moment-timezone@0.5.25:
   dependencies:
     moment ">= 2.9.0"
 
+moment.distance@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/moment.distance/-/moment.distance-1.2.0.tgz#4d9621d181d993bb3905f7b1610924898c3aa7a9"
+  integrity sha512-m+X94soJ/sotjU+V2hdc9k4ufp2XcFfZCOM+tU4qQj329pwdJaNgxeFHvmhJ8qUEaed17Rveyvfqs15tChdQrA==
+
 moment@*, moment@2.19.3, "moment@>= 2.9.0", moment@>=2.14.0:
   version "2.19.3"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.3.tgz#bdb99d270d6d7fda78cc0fbace855e27fe7da69f"


### PR DESCRIPTION
This adds a new `formattedEndAt` field to our stitched viewingRoom field off of Gravity. 

This doesn't match the comps exactly, but gets close via the [moment.distance](https://github.com/SokratisVidros/moment.distance.js) plugin. 