### PR TITLE
Un-stitch Gravity IdentityVerification.

### DIFF
--- a/src/data/gravity.graphql
+++ b/src/data/gravity.graphql
@@ -456,13 +456,6 @@ An ISO 8601-encoded datetime
 """
 scalar ISO8601DateTime
 
-type IdentityVerification {
-  internalID: ID!
-  invitationExpiresAt: ISO8601DateTime
-  state: String!
-  userID: ID!
-}
-
 type InventoryHold {
   capturedAt: String
   id: ID!
@@ -720,11 +713,6 @@ type Query {
   Find artworks by ID
   """
   artworks(ids: [ID!]!): [Artwork!]
-
-  """
-  Find an identity verification by id
-  """
-  identityVerification(id: ID!): IdentityVerification
 
   """
   Autocomplete resolvers.

--- a/src/lib/stitching/gravity/schema.ts
+++ b/src/lib/stitching/gravity/schema.ts
@@ -28,7 +28,6 @@ export const executableGravitySchema = () => {
     "ArtworkEdge",
     "ArtworkConnection",
     "ArtistConnection",
-    "IdentityVerification",
     "Money",
     "MoneyInput",
   ]


### PR DESCRIPTION
For ticket: https://artsyproduct.atlassian.net/browse/AUCT-1007
To un-stitch Gravity `IdentityVerification` graphql schema/type which has not been in use.

Related Gravity PR: https://github.com/artsy/gravity/pull/13054

Metaphysics PR is to be merged/deployed first. Then Gravity PR.

The type was listed in `lib/stitching/gravity/schema.ts` under `duplicatedTypes`. My understanding is is that MP has a type of the same name (resolving to Gravity's REST endpoints). `duplicatedTypes` hides Gravity's version so it has not been visible to clients. Therefore, this change does not require any client-side changes.