### PR TITLE
Update relay types when updating Eigen's copy of MP schema

### DIFF
--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -49,7 +49,7 @@ async function main() {
         owner: "artsy",
         repo: "reaction",
       },
-      ...updateSchemaAction(),
+      ...updateSchemaAction(true),
     })
   } catch (error) {
     console.error(error)

--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -10,24 +10,30 @@ async function main() {
 
     execSync("yarn dump:staging")
 
-    const updateSchemaAction = {
-      branch: "update-schema",
-      title: "Update metaphysics schema",
-      targetBranch: "master",
-      commitMessage: "Update metaphysics schema",
-      body:
-        "Greetings human :robot: this PR was automatically created as part of metaphysics's deploy process",
-      assignees: ["artsyit"],
-      labels: ["Merge On Green"],
-      update: repoDir => {
-        execSync(
-          `cp _schemaV2.graphql '${path.join(repoDir, "data/schema.graphql")}'`
-        )
-        execSync("yarn install --ignore-engines", { cwd: repoDir })
-        execSync("./node_modules/.bin/prettier --write data/schema.graphql", {
-          cwd: repoDir,
-        })
-      },
+    const updateSchemaAction = (generateRelayTypes = false) => {
+      return {
+        branch: "update-schema",
+        title: "Update metaphysics schema",
+        targetBranch: "master",
+        commitMessage: "Update metaphysics schema",
+        body:
+          "Greetings human :robot: this PR was automatically created as part of metaphysics's deploy process",
+        assignees: ["artsyit"],
+        labels: ["Merge On Green"],
+        update: repoDir => {
+          execSync(
+            `cp _schemaV2.graphql '${path.join(
+              repoDir,
+              "data/schema.graphql"
+            )}'`
+          )
+          execSync("yarn install --ignore-engines", { cwd: repoDir })
+          generateRelayTypes && execSync("yarn relay", { cwd: repoDir })
+          execSync("./node_modules/.bin/prettier --write data/schema.graphql", {
+            cwd: repoDir,
+          })
+        },
+      }
     }
 
     await updateRepo({
@@ -35,7 +41,7 @@ async function main() {
         owner: "artsy",
         repo: "eigen",
       },
-      ...updateSchemaAction,
+      ...updateSchemaAction(true),
     })
 
     await updateRepo({
@@ -43,7 +49,7 @@ async function main() {
         owner: "artsy",
         repo: "reaction",
       },
-      ...updateSchemaAction,
+      ...updateSchemaAction(),
     })
   } catch (error) {
     console.error(error)


### PR DESCRIPTION
Following up on https://github.com/artsy/eigen/pull/3319, this PR adds a conditional `yarn relay` that is triggered when updating Eigen's copy of MP schema.

@ds300 I'm not sure how to go about testing this, either writing tests or just running them in my terminal. Any advice for me?