### PR TITLE
 Introduce `Me.canRequestEmailConfirmation`

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5484,6 +5484,9 @@ type Me implements Node {
     last: Int
   ): CreditCardConnection
   email: String
+
+  # Allow the user to request email confirmation if they do not have a confirmed email
+  canRequestEmailConfirmation: Boolean!
   followsAndSaves: FollowsAndSaves
   hasCreditCards: Boolean
   hasQualifiedCreditCards: Boolean

--- a/src/schema/v2/me/__tests__/index.test.ts
+++ b/src/schema/v2/me/__tests__/index.test.ts
@@ -188,4 +188,54 @@ describe("me/index", () => {
       })
     })
   })
+
+  describe("canRequestEmailConfirmation", () => {
+    it("returns false when the user has a non-empty confirmed_at", async () => {
+      const meLoaderResponse = {
+        name: "Test User",
+        email: "test@email.com",
+        paddle_number: "123456",
+        identity_verified: true,
+        second_factor_enabled: true,
+        confirmed_at: "2020-05-18T22:34:33+00:00",
+      }
+      const query = gql`
+        query {
+          me {
+            canRequestEmailConfirmation
+          }
+        }
+      `
+
+      const response = await runAuthenticatedQuery(query, {
+        meLoader: () => Promise.resolve(meLoaderResponse),
+      })
+
+      expect(response).toEqual({ me: { canRequestEmailConfirmation: false } })
+    })
+
+    it("returns true when the user has an empty confirmed_at", async () => {
+      const meLoaderResponse = {
+        name: "Test User",
+        email: "test@email.com",
+        paddle_number: "123456",
+        identity_verified: true,
+        second_factor_enabled: true,
+        confirmed_at: null,
+      }
+      const query = gql`
+        query {
+          me {
+            canRequestEmailConfirmation
+          }
+        }
+      `
+
+      const response = await runAuthenticatedQuery(query, {
+        meLoader: () => Promise.resolve(meLoaderResponse),
+      })
+
+      expect(response).toEqual({ me: { canRequestEmailConfirmation: true } })
+    })
+  })
 })

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -56,6 +56,12 @@ const Me = new GraphQLObjectType<any, ResolverContext>({
     email: {
       type: GraphQLString,
     },
+    canRequestEmailConfirmation: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description:
+        "Allow the user to request email confirmation if they do not have a confirmed email",
+      resolve: ({ confirmed_at }) => !confirmed_at,
+    },
     followsAndSaves: {
       type: new GraphQLObjectType<any, ResolverContext>({
         name: "FollowsAndSaves",


### PR DESCRIPTION
Builds off of https://github.com/artsy/metaphysics/pull/2402 (but OK to merge this in before that I think)

## Problem

One feature of email verification is the ability for an existing user to
verify their email from web or iOS via a banner on web and a sash on
iOS.

One important aspect of these UIs is knowing _whether it is
appropriate to display them or not_.

Moreover, we have been bitten a bit in the past by pushing too much of
this "should I display this UI" logic directly to Reaction or Eigen.
This has resulted in:

1. High risk of code duplication and therefore drift between web and iOS
   clients

2. iOS binary lock-in: Important "should I display this UI" logic lives
   forever in old binaries of Eigen, making it hard for our engineering
   team to ensure a particular experience and locking us in to old APIs.

## Solution

* Introduce `me.canRequestEmailConfirmation`, a field which will evolve
  in its implementation, but remain consistent in its contract.

## Self QA

### User confirmed; cannot request email confirmation

<img width="2560" alt="user-already-confirmed-cannot-request-email-confirmation" src="https://user-images.githubusercontent.com/1561546/82344140-adb0bb80-99c1-11ea-9ffa-c43227a185ab.png">


### User not confirmed; can request email confirmation

<img width="2559" alt="user-unconfirmed-can-request-email-confirmation" src="https://user-images.githubusercontent.com/1561546/82344180-b903e700-99c1-11ea-8b4c-fbf3256e5548.png">


Jira: https://artsyproduct.atlassian.net/browse/AUCT-997