### PR TITLE
Run relay-compiler when updating emission/eigen

### DIFF
--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -4,47 +4,44 @@ const { updateRepo } = require("@artsy/update-repo")
 const { execSync } = require("child_process")
 const path = require("path")
 
+/**
+ * @param {'eigen' | 'reaction'} repo
+ */
+async function updateSchemaFile(repo) {
+  await updateRepo({
+    repo: {
+      owner: "artsy",
+      repo,
+    },
+    branch: "update-schema",
+    title: "Update metaphysics schema",
+    targetBranch: "master",
+    commitMessage: "Update metaphysics schema",
+    body:
+      "Greetings human :robot: this PR was automatically created as part of metaphysics's deploy process",
+    assignees: ["artsyit"],
+    labels: ["Merge On Green"],
+    update: repoDir => {
+      execSync(
+        `cp _schemaV2.graphql '${path.join(repoDir, "data/schema.graphql")}'`
+      )
+      execSync("yarn install --ignore-engines", { cwd: repoDir })
+      execSync("./node_modules/.bin/relay-compiler")
+      execSync("./node_modules/.bin/prettier --write data/schema.graphql", {
+        cwd: repoDir,
+      })
+    },
+  })
+}
+
 async function main() {
   try {
     console.log("∙ Dumping staging schema")
 
     execSync("yarn dump:staging")
 
-    const updateSchemaAction = {
-      branch: "update-schema",
-      title: "Update metaphysics schema",
-      targetBranch: "master",
-      commitMessage: "Update metaphysics schema",
-      body:
-        "Greetings human :robot: this PR was automatically created as part of metaphysics's deploy process",
-      assignees: ["artsyit"],
-      labels: ["Merge On Green"],
-      update: repoDir => {
-        execSync(
-          `cp _schemaV2.graphql '${path.join(repoDir, "data/schema.graphql")}'`
-        )
-        execSync("yarn install --ignore-engines", { cwd: repoDir })
-        execSync("./node_modules/.bin/prettier --write data/schema.graphql", {
-          cwd: repoDir,
-        })
-      },
-    }
-
-    await updateRepo({
-      repo: {
-        owner: "artsy",
-        repo: "eigen",
-      },
-      ...updateSchemaAction,
-    })
-
-    await updateRepo({
-      repo: {
-        owner: "artsy",
-        repo: "reaction",
-      },
-      ...updateSchemaAction,
-    })
+    await updateSchemaFile("eigen")
+    await updateSchemaFile("reaction")
   } catch (error) {
     console.error(error)
     process.exit(1)


### PR DESCRIPTION
Reimplementation of #2396 

This time we call relay-compiler directly instead of using `yarn`, to avoid the engines check (MP is on node 10 while eigen and reaction are on 12). I also moved the code around a little to make sure that TypeScript can check the data we pass to `updateRepo` (cc @damassi)

Gonna self-merge before y'all wake up to make sure it works this time.