### PR TITLE
Fix viewing rooms not filtered by partner id

### DIFF
--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -167,7 +167,7 @@ describe("gravity/stitching", () => {
       )
 
       expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
-        args: { partner_id: "partner-id", first: 2 },
+        args: { partnerId: "partner-id", first: 2 },
         operation: "query",
         fieldName: "viewingRooms",
         schema: expect.anything(),

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -133,13 +133,13 @@ export const gravityStitchingEnvironment = (
               internalID
             }
           `,
-          resolve: ({ internalID: partner_id }, args, context, info) => {
+          resolve: ({ internalID: partnerId }, args, context, info) => {
             return info.mergeInfo.delegateToSchema({
               schema: gravitySchema,
               operation: "query",
               fieldName: "viewingRooms",
               args: {
-                partner_id,
+                partnerId,
                 ...args,
               },
               context,


### PR DESCRIPTION
Followup on https://github.com/artsy/eigen/pull/3322

We learned that the viewing rooms connection stitched under partner is returning _all_ viewing rooms, regardless of specified partner id. It turns out to be another 🐍 vs. 🐫 issue.

### Before
![Screen Shot 2020-05-19 at 10 29 25 AM](https://user-images.githubusercontent.com/796573/82340506-4e50ac80-99bd-11ea-9211-4890fa1a5353.png)

### After
![Screen Shot 2020-05-19 at 10 25 49 AM](https://user-images.githubusercontent.com/796573/82340520-514b9d00-99bd-11ea-9dc1-790eb9c4100f.png)
