### PR TITLE
[Consignments] Add artworksConnection to microfunnel & realizedPrice to Artwork

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1020,6 +1020,23 @@ type ArtistTargetSupplyMicrofunnel {
     # Number of artworks to return
     size: Int
   ): [ArtistTargetSupplyMicrofunnelArtwork]
+    @deprecated(
+      reason: "Prefer to use `artworksConnection`. [Will be removed in v2]"
+    )
+
+  # A list of recently sold artworks.
+  artworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+
+    # Randomize the order of artworks for display purposes.
+    randomize: Boolean
+
+    # Number of artworks to return
+    size: Int
+  ): ArtworkConnection
   metadata: ArtistTargetSupplyMicrofunnelMetadata
 }
 
@@ -1175,6 +1192,11 @@ type Artwork implements Node & Searchable & Sellable {
   # Whether this Artwork is Published of not
   published: Boolean!
   publisher(format: Format): String
+
+  # Price which an artwork was sold for. This generally only applies to artworks
+  # in the target supply microfunnel and (currently) queries against hardcoded
+  # spreadsheet data.
+  realizedPrice: String
   related(size: Int): [Artwork]
   sale: Sale
   saleArtwork(saleID: String = null): SaleArtwork

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "husky": "3.1.0",
     "jest": "24.9.0",
     "lint-staged": "7.3.0",
-    "prettier": "1.14.3",
+    "prettier": "^2.0.5",
     "sinon": "1.17.7",
     "superagent": "3.8.3",
     "supertest": "3.1.0",

--- a/src/schema/v2/artist/targetSupply/__tests__/index.test.ts
+++ b/src/schema/v2/artist/targetSupply/__tests__/index.test.ts
@@ -68,7 +68,7 @@ describe("ArtistTargetSupply", () => {
     })
   })
 
-  describe("microfunnel", () => {
+  describe("#microfunnel", () => {
     it("returns null if artist not in microfunnel", async () => {
       const query = `
         {
@@ -96,8 +96,9 @@ describe("ArtistTargetSupply", () => {
       })
     })
 
-    it("returns data if artist is in microfunnel", async () => {
-      const query = `
+    describe("#metadata", () => {
+      it("returns metadata", async () => {
+        const query = `
         {
           artist(id:"alex-katz") {
             targetSupply {
@@ -112,178 +113,189 @@ describe("ArtistTargetSupply", () => {
                   uniqueVisitors
                   views
                 }
-                artworks {
-                  artwork {
-                    internalID
-                  }
-                  realizedPrice
-                }
               }
             }
           }
         }
       `
-      const context = {
-        artistLoader: () => {
-          return Promise.resolve({
-            id: "banksy",
-            name: "Banksy",
-          })
-        },
-        artworksLoader: () => {
-          return Promise.resolve([
-            {
-              _id: "5e3854df108c9200113cd354",
-            },
-            {
-              _id: "5e3854d523363e000f352f7f",
-            },
-            {
-              _id: "5e3854cf20273e00122131a5",
-            },
-            {
-              _id: "5e3854ce662102000e73328f",
-            },
-            {
-              _id: "59d6a884c9dc240f49917380",
-            },
-            {
-              _id: "5de86d009a893d001244f5fe",
-            },
-            {
-              _id: "5dcdc5a4f78568000ede76dc",
-            },
-          ])
-        },
-      }
-      const response = await runQuery(query, context)
-      expect(response.artist.targetSupply).toEqual({
-        microfunnel: {
-          metadata: {
-            highestRealized: "12.16M",
-            realized: "184%",
-            recentlySoldArtworkIDs: [
-              "5e3854df108c9200113cd354",
-              "5e3854d523363e000f352f7f",
-              "5e3854cf20273e00122131a5",
-              "5e3854ce662102000e73328f",
-              "59d6a884c9dc240f49917380",
-              "5de86d009a893d001244f5fe",
-              "5dcdc5a4f78568000ede76dc",
-            ],
-            roundedUniqueVisitors: "5,600",
-            roundedViews: "16,000",
-            str: "95%",
-            uniqueVisitors: "5,610",
-            views: "16,159",
+        const context = {
+          artistLoader: () => {
+            return Promise.resolve({
+              id: "banksy",
+              name: "Banksy",
+            })
           },
-          artworks: [
-            {
-              artwork: {
-                internalID: "5e3854df108c9200113cd354",
+          artworksLoader: () => {
+            return Promise.resolve([
+              {
+                _id: "5e3854df108c9200113cd354",
               },
-              realizedPrice: "$41,595",
-            },
-            {
-              artwork: {
-                internalID: "5e3854d523363e000f352f7f",
+              {
+                _id: "5e3854d523363e000f352f7f",
               },
-              realizedPrice: "$36,395",
-            },
-            {
-              artwork: {
-                internalID: "5e3854cf20273e00122131a5",
+              {
+                _id: "5e3854cf20273e00122131a5",
               },
-              realizedPrice: "$4,549",
-            },
-            {
-              artwork: {
-                internalID: "5e3854ce662102000e73328f",
+              {
+                _id: "5e3854ce662102000e73328f",
               },
-              realizedPrice: "$20,797",
-            },
-            {
-              artwork: {
-                internalID: "59d6a884c9dc240f49917380",
+              {
+                _id: "59d6a884c9dc240f49917380",
               },
-              realizedPrice: "$1,850",
-            },
-            {
-              artwork: {
-                internalID: "5de86d009a893d001244f5fe",
+              {
+                _id: "5de86d009a893d001244f5fe",
               },
-              realizedPrice: "$2,500",
-            },
-            {
-              artwork: {
-                internalID: "5dcdc5a4f78568000ede76dc",
+              {
+                _id: "5dcdc5a4f78568000ede76dc",
               },
-              realizedPrice: "$325",
+            ])
+          },
+        }
+        const response = await runQuery(query, context)
+        expect(response.artist.targetSupply).toEqual({
+          microfunnel: {
+            metadata: {
+              highestRealized: "12.16M",
+              realized: "184%",
+              recentlySoldArtworkIDs: [
+                "5e3854df108c9200113cd354",
+                "5e3854d523363e000f352f7f",
+                "5e3854cf20273e00122131a5",
+                "5e3854ce662102000e73328f",
+                "59d6a884c9dc240f49917380",
+                "5de86d009a893d001244f5fe",
+                "5dcdc5a4f78568000ede76dc",
+              ],
+              roundedUniqueVisitors: "5,600",
+              roundedViews: "16,000",
+              str: "95%",
+              uniqueVisitors: "5,610",
+              views: "16,159",
             },
-          ],
-        },
+          },
+        })
       })
     })
 
-    it("randomizes artworks if `randomize` argument is passed", async () => {
-      const query = `
-        {
-          artist(id:"alex-katz") {
-            targetSupply {
-              microfunnel {
-                artworks(randomize: true) {
-                  artwork {
-                    internalID
+    describe("#artworksConnection", () => {
+      it("returns a list of artworks", async () => {
+        const query = `
+          {
+            artist(id:"alex-katz") {
+              targetSupply {
+                microfunnel {
+                  artworksConnection {
+                    edges {
+                      node {
+                        internalID
+                        realizedPrice
+                      }
+                    }
                   }
-                  realizedPrice
                 }
               }
             }
           }
+        `
+        const context = {
+          artistLoader: () => {
+            return Promise.resolve({
+              id: "banksy",
+              name: "Banksy",
+            })
+          },
+          artworksLoader: () => {
+            return Promise.resolve([
+              {
+                _id: "5e3854df108c9200113cd354",
+              },
+              {
+                _id: "5e3854d523363e000f352f7f",
+              },
+            ])
+          },
         }
-      `
-      const context = {
-        artistLoader: () => {
-          return Promise.resolve({
-            id: "banksy",
-            name: "Banksy",
-          })
-        },
-        artworksLoader: () => {
-          return Promise.resolve([
-            {
-              _id: "5e3854df108c9200113cd354",
+        const response = await runQuery(query, context)
+        expect(response.artist.targetSupply).toEqual({
+          microfunnel: {
+            artworksConnection: {
+              edges: [
+                {
+                  node: {
+                    internalID: "5e3854df108c9200113cd354",
+                    realizedPrice: "$41,595",
+                  },
+                },
+                {
+                  node: {
+                    internalID: "5e3854d523363e000f352f7f",
+                    realizedPrice: "$36,395",
+                  },
+                },
+              ],
             },
-            {
-              _id: "5e3854d523363e000f352f7f",
-            },
-            {
-              _id: "5e3854cf20273e00122131a5",
-            },
-            {
-              _id: "5e3854ce662102000e73328f",
-            },
-            {
-              _id: "59d6a884c9dc240f49917380",
-            },
-            {
-              _id: "5de86d009a893d001244f5fe",
-            },
-            {
-              _id: "5dcdc5a4f78568000ede76dc",
-            },
-          ])
-        },
-      }
-      const responseA = await runQuery(query, context)
-      const responseB = await runQuery(query, context)
-      const idsA = responseA.artist.targetSupply.microfunnel.artworks.map(
-        ({ artwork }) => artwork.internalID
-      )
-      const idsB = responseB.artist.targetSupply.microfunnel.artworks.map(
-        ({ artwork }) => artwork.internalID
-      )
-      expect(idsA).not.toEqual(idsB)
+          },
+        })
+      })
+    })
+
+    // Deprecated
+    describe("#artworks", () => {
+      it("returns a list of artworks", async () => {
+        const query = `
+          {
+            artist(id:"alex-katz") {
+              targetSupply {
+                microfunnel {
+                  artworks {
+                    artwork {
+                      internalID
+                    }
+                    realizedPrice
+                  }
+                }
+              }
+            }
+          }
+        `
+        const context = {
+          artistLoader: () => {
+            return Promise.resolve({
+              id: "banksy",
+              name: "Banksy",
+            })
+          },
+          artworksLoader: () => {
+            return Promise.resolve([
+              {
+                _id: "5e3854df108c9200113cd354",
+              },
+              {
+                _id: "5e3854d523363e000f352f7f",
+              },
+            ])
+          },
+        }
+        const response = await runQuery(query, context)
+        expect(response.artist.targetSupply).toEqual({
+          microfunnel: {
+            artworks: [
+              {
+                artwork: {
+                  internalID: "5e3854df108c9200113cd354",
+                },
+                realizedPrice: "$41,595",
+              },
+              {
+                artwork: {
+                  internalID: "5e3854d523363e000f352f7f",
+                },
+                realizedPrice: "$36,395",
+              },
+            ],
+          },
+        })
+      })
     })
   })
 })

--- a/src/schema/v2/artist/targetSupply/utils/getMicrofunnelData.ts
+++ b/src/schema/v2/artist/targetSupply/utils/getMicrofunnelData.ts
@@ -79,3 +79,12 @@ export function getMicrofunnelData(pathname: string): ArtistConsignment {
   const microfunnelData = mappedData[pathname]
   return microfunnelData
 }
+
+export function getMicrofunnelDataByArtworkInternalID(internalID: string) {
+  const dataGroupedByInternalID = groupBy(
+    staticCSVToJSONData,
+    "Artwork ids (recently sold) (comma separated)"
+  )
+  const microfunnelData = dataGroupedByInternalID[internalID]
+  return microfunnelData?.[0]
+}

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -4,6 +4,9 @@ import moment from "moment"
 
 import { runQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
+import { getMicrofunnelDataByArtworkInternalID } from "schema/v2/artist/targetSupply/utils/getMicrofunnelData"
+
+jest.mock("schema/v2/artist/targetSupply/utils/getMicrofunnelData")
 
 describe("Artwork type", () => {
   const partner = { id: "existy" }
@@ -83,7 +86,7 @@ describe("Artwork type", () => {
     })
 
     it("returns width and height", () => {
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -120,7 +123,7 @@ describe("Artwork type", () => {
     })
 
     it("returns sizeScore", () => {
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -152,7 +155,7 @@ describe("Artwork type", () => {
           downloadable: false,
         },
       ]
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -176,7 +179,7 @@ describe("Artwork type", () => {
       const sales = Promise.resolve([sale])
       context.relatedSalesLoader = sinon.stub().returns(sales)
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -190,7 +193,7 @@ describe("Artwork type", () => {
       const sales = Promise.resolve([sale])
       context.relatedSalesLoader = sinon.stub().returns(sales)
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -214,7 +217,7 @@ describe("Artwork type", () => {
     it("will return the value of offerable", () => {
       artwork.offerable = true
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -235,7 +238,7 @@ describe("Artwork type", () => {
               major
               display
               currencyCode
-             
+
             }
             ... on PriceRange {
               display
@@ -262,7 +265,7 @@ describe("Artwork type", () => {
       artwork.price_cents = [42000]
       artwork.price = "$420"
       artwork.price_currency = "USD"
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             listPrice: {
@@ -281,7 +284,7 @@ describe("Artwork type", () => {
       artwork.price_cents = [null, 42000]
       artwork.price = "Under $420"
       artwork.price_currency = "USD"
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             listPrice: {
@@ -304,7 +307,7 @@ describe("Artwork type", () => {
       artwork.price_cents = [42000, null]
       artwork.price = "Starting at $420"
       artwork.price_currency = "USD"
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             listPrice: {
@@ -336,7 +339,7 @@ describe("Artwork type", () => {
     it("passes true from gravity", () => {
       artwork.pickup_available = true
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -359,7 +362,7 @@ describe("Artwork type", () => {
     it("returns a string if price_includes_tax is true", () => {
       artwork.price_includes_tax = true
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             priceIncludesTaxDisplay: "VAT included in price",
@@ -371,7 +374,7 @@ describe("Artwork type", () => {
     it("returns null if price_includes_tax is false", () => {
       artwork.price_includes_tax = false
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             priceIncludesTaxDisplay: null,
@@ -395,7 +398,7 @@ describe("Artwork type", () => {
     it("returns the first default image", () => {
       artwork.images = artworkImages
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             image: {
@@ -440,7 +443,7 @@ describe("Artwork type", () => {
         { forsale: true },
       ]
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             editionSets: [
@@ -491,7 +494,7 @@ describe("Artwork type", () => {
       }
     `
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             editionSets: [
@@ -543,7 +546,7 @@ describe("Artwork type", () => {
         }
       }
     `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             editionSets: [
@@ -586,7 +589,7 @@ describe("Artwork type", () => {
       ]
       context.salesLoader = sinon.stub().returns(Promise.resolve(sales))
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -599,7 +602,7 @@ describe("Artwork type", () => {
     it("is false if the artwork is not in any sales that are auctions", () => {
       context.salesLoader = sinon.stub().returns(Promise.resolve([]))
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -625,7 +628,7 @@ describe("Artwork type", () => {
       artwork.price = null
       artwork.availability = "on hold"
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -640,7 +643,7 @@ describe("Artwork type", () => {
       artwork.price = "$420,000"
       artwork.availability = "on hold"
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -653,7 +656,7 @@ describe("Artwork type", () => {
     it("returns 'Sold' if work is sold", () => {
       artwork.sale_message = "$420,000 - Sold"
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -666,7 +669,7 @@ describe("Artwork type", () => {
     it("returns null if work is not for sale", () => {
       artwork.availability = "not for sale"
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -680,7 +683,7 @@ describe("Artwork type", () => {
       artwork.sale_message = "Not for sale"
       artwork.availability = "on loan"
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -695,7 +698,7 @@ describe("Artwork type", () => {
       artwork.availability = "on loan"
       artwork.availability_hidden = true
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -709,7 +712,7 @@ describe("Artwork type", () => {
       artwork.sale_message = "for sale"
       artwork.availability = "permanent collection"
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -723,7 +726,7 @@ describe("Artwork type", () => {
       artwork.availability = "for sale"
       artwork.sale_message = "something from gravity"
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -747,7 +750,7 @@ describe("Artwork type", () => {
     it("returns bid text for an auction partner type", () => {
       artwork.partner = { type: "Auction" }
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -762,7 +765,7 @@ describe("Artwork type", () => {
       artwork.availability = "sold"
       artwork.availability_hidden = true
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -775,7 +778,7 @@ describe("Artwork type", () => {
     it("returns similar work text for a sold work", () => {
       artwork.availability = "sold"
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -788,7 +791,7 @@ describe("Artwork type", () => {
     it("returns similar work text for a on loan work", () => {
       artwork.availability = "on loan"
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -800,7 +803,7 @@ describe("Artwork type", () => {
     })
     it("returns purchase text for an on hold work", () => {
       artwork.availability = "on hold"
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -812,7 +815,7 @@ describe("Artwork type", () => {
     })
     it("returns nothing for a not for sale work", () => {
       artwork.availability = "not for sale"
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -881,7 +884,7 @@ describe("Artwork type", () => {
 
     it("is true if the artwork has any sales that are open auctions", () => {
       context.salesLoader = sinon.stub().returns(Promise.resolve([{}]))
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -893,7 +896,7 @@ describe("Artwork type", () => {
 
     it("is false if the artwork is not in any sales that are auctions", () => {
       context.salesLoader = sinon.stub().returns(Promise.resolve([]))
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -922,7 +925,7 @@ describe("Artwork type", () => {
         })
       )
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             canRequestLotConditionsReport: true,
@@ -942,7 +945,7 @@ describe("Artwork type", () => {
         })
       )
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             canRequestLotConditionsReport: false,
@@ -960,7 +963,7 @@ describe("Artwork type", () => {
         })
       )
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             canRequestLotConditionsReport: false,
@@ -978,7 +981,7 @@ describe("Artwork type", () => {
         })
       )
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             canRequestLotConditionsReport: false,
@@ -996,7 +999,7 @@ describe("Artwork type", () => {
         })
       )
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             canRequestLotConditionsReport: false,
@@ -1025,7 +1028,7 @@ describe("Artwork type", () => {
           },
         ])
       )
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -1044,7 +1047,7 @@ describe("Artwork type", () => {
           },
         ])
       )
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -1057,7 +1060,7 @@ describe("Artwork type", () => {
     it("is false if the artwork is acquireable but not in any open sales", () => {
       artwork.acquireable = false
       context.salesLoader = sinon.stub().returns(Promise.resolve([]))
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -1096,7 +1099,7 @@ describe("Artwork type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data.artwork.banner).toEqual({
           __typename: "Sale",
           name: "Y2K",
@@ -1120,7 +1123,7 @@ describe("Artwork type", () => {
 
       it("returns false if the artwork is not shareable", () => {
         artwork.can_share_image = false
-        return runQuery(query, context).then(data => {
+        return runQuery(query, context).then((data) => {
           expect(data.artwork.isShareable).toBe(false)
         })
       })
@@ -1141,7 +1144,7 @@ describe("Artwork type", () => {
           artwork.width = 100
           artwork.height = 100
           artwork.category = "ink"
-          return runQuery(query, context).then(data => {
+          return runQuery(query, context).then((data) => {
             expect(data.artwork.isHangable).toBe(true)
           })
         })
@@ -1151,7 +1154,7 @@ describe("Artwork type", () => {
           artwork.height = 100
           artwork.depth = 0.5
           artwork.category = "ink"
-          return runQuery(query, context).then(data => {
+          return runQuery(query, context).then((data) => {
             expect(data.artwork.isHangable).toBe(true)
           })
         })
@@ -1160,7 +1163,7 @@ describe("Artwork type", () => {
           artwork.width = 100
           artwork.height = 100
           artwork.category = "painting"
-          return runQuery(query, context).then(data => {
+          return runQuery(query, context).then((data) => {
             expect(data.artwork.isHangable).toBe(true)
           })
         })
@@ -1171,7 +1174,7 @@ describe("Artwork type", () => {
           artwork.category = "sculpture"
           artwork.width = 100
           artwork.height = 100
-          return runQuery(query, context).then(data => {
+          return runQuery(query, context).then((data) => {
             expect(data.artwork.isHangable).toBe(false)
           })
         })
@@ -1180,7 +1183,7 @@ describe("Artwork type", () => {
           artwork.category = "installation"
           artwork.width = 100
           artwork.height = 100
-          return runQuery(query, context).then(data => {
+          return runQuery(query, context).then((data) => {
             expect(data.artwork.isHangable).toBe(false)
           })
         })
@@ -1189,7 +1192,7 @@ describe("Artwork type", () => {
           artwork.width = 100
           artwork.height = 100
           artwork.depth = 100
-          return runQuery(query, context).then(data => {
+          return runQuery(query, context).then((data) => {
             expect(data.artwork.isHangable).toBe(false)
           })
         })
@@ -1198,14 +1201,14 @@ describe("Artwork type", () => {
           artwork.width = "10000"
           artwork.height = "10000"
           artwork.metric = "cm"
-          return runQuery(query, context).then(data => {
+          return runQuery(query, context).then((data) => {
             expect(data.artwork.isHangable).toBe(false)
           })
         })
 
         it("is not hangable if there is no dimensions", () => {
           artwork.dimensions = {}
-          return runQuery(query, context).then(data => {
+          return runQuery(query, context).then((data) => {
             expect(data.artwork.isHangable).toBe(false)
           })
         })
@@ -1224,7 +1227,7 @@ describe("Artwork type", () => {
       it("returns false for ecommerce works regardless of work inquireable status", () => {
         artwork.inquireable = true
         artwork.ecommerce = true
-        return runQuery(query, context).then(data => {
+        return runQuery(query, context).then((data) => {
           expect(data.artwork.isInquireable).toBe(false)
         })
       })
@@ -1232,7 +1235,7 @@ describe("Artwork type", () => {
       it("returns true for inquireable non ecommerce works", () => {
         artwork.inquireable = true
         artwork.ecommerce = false
-        return runQuery(query, context).then(data => {
+        return runQuery(query, context).then((data) => {
           expect(data.artwork.isInquireable).toBe(true)
         })
       })
@@ -1240,7 +1243,7 @@ describe("Artwork type", () => {
       it("returns false for non inquireable non ecommerce works", () => {
         artwork.inquireable = false
         artwork.ecommerce = false
-        return runQuery(query, context).then(data => {
+        return runQuery(query, context).then((data) => {
           expect(data.artwork.isInquireable).toBe(false)
         })
       })
@@ -1278,7 +1281,7 @@ describe("Artwork type", () => {
 
     it("returns true if artwork price is a range.", () => {
       artwork.price = "$200 - $300"
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -1290,7 +1293,7 @@ describe("Artwork type", () => {
 
     it("returns false if artwork price is not a range.", () => {
       artwork.price = "$1000"
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -1303,7 +1306,7 @@ describe("Artwork type", () => {
     it("returns false if artwork price with single edition is not a range.", () => {
       artwork.price = "$200"
       artwork.edition_sets = [{}]
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -1316,7 +1319,7 @@ describe("Artwork type", () => {
     it("returns true if artwork price with single edition is a range.", () => {
       artwork.price = "$200 - $300"
       artwork.edition_sets = [{}]
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -1329,7 +1332,7 @@ describe("Artwork type", () => {
     it("returns false if artwork price with multiple editions is a range.", () => {
       artwork.price = "$200 - $300"
       artwork.edition_sets = [{}, {}]
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
@@ -1351,7 +1354,7 @@ describe("Artwork type", () => {
 
     it("is Untitled when its title is null", () => {
       artwork.title = null
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             title: "Untitled",
@@ -1362,7 +1365,7 @@ describe("Artwork type", () => {
 
     it("is Untitled title when its title is empty", () => {
       artwork.title = ""
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             title: "Untitled",
@@ -1393,7 +1396,7 @@ describe("Artwork type", () => {
     }
 
     beforeEach(() => {
-      context.lotStandingLoader = params => {
+      context.lotStandingLoader = (params) => {
         if (params.live === true) {
           return Promise.resolve([lotStandings[1]])
         } else if (params.live === false) {
@@ -1453,7 +1456,7 @@ describe("Artwork type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             attributionClass: {
@@ -1474,7 +1477,7 @@ describe("Artwork type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             attributionClass: {
@@ -1495,7 +1498,7 @@ describe("Artwork type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             attributionClass: {
@@ -1516,7 +1519,7 @@ describe("Artwork type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             attributionClass: {
@@ -1545,7 +1548,7 @@ describe("Artwork type", () => {
     it("returns null appropriately and doesnt error", () => {
       artwork.partner = null
       artwork.title = "A Cat"
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             partner: null,
@@ -1570,7 +1573,7 @@ describe("Artwork type", () => {
     it("is set to prompt string when its domestic_shipping_fee_cents is null and international_shipping_fee_cents is null", () => {
       artwork.domestic_shipping_fee_cents = null
       artwork.international_shipping_fee_cents = null
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             shippingInfo: "Shipping, tax, and additional fees quoted by seller",
@@ -1582,7 +1585,7 @@ describe("Artwork type", () => {
     it("is set to free domestic shipping only when its domestic_shipping_fee_cents is 0 and international_shipping_fee_cents is null", () => {
       artwork.domestic_shipping_fee_cents = 0
       artwork.international_shipping_fee_cents = null
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             shippingInfo: "Free domestic shipping only",
@@ -1594,7 +1597,7 @@ describe("Artwork type", () => {
     it("is set to free shipping string when its domestic_shipping_fee_cents is 0 and international_shipping_fee_cents is 0", () => {
       artwork.domestic_shipping_fee_cents = 0
       artwork.international_shipping_fee_cents = 0
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             shippingInfo: "Free shipping worldwide",
@@ -1606,7 +1609,7 @@ describe("Artwork type", () => {
     it("is set to domestic shipping only when its domestic_shipping_fee_cents is present and international_shipping_fee_cents is null", () => {
       artwork.domestic_shipping_fee_cents = 1000
       artwork.international_shipping_fee_cents = null
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             shippingInfo: "Shipping: $10 domestic only",
@@ -1618,7 +1621,7 @@ describe("Artwork type", () => {
     it("is set to free international shipping when domestic_shipping_fee_cents is 0 and domestic_shipping_fee_cents is present", () => {
       artwork.domestic_shipping_fee_cents = 1000
       artwork.international_shipping_fee_cents = 0
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             shippingInfo: "Shipping: $10 domestic, free rest of world",
@@ -1630,7 +1633,7 @@ describe("Artwork type", () => {
     it("is set to free domestic shipping when domestic_shipping_fee_cents is 0 and international_shipping_fee_cents is present", () => {
       artwork.domestic_shipping_fee_cents = 0
       artwork.international_shipping_fee_cents = 10000
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             shippingInfo: "Shipping: Free domestic, $100 rest of world",
@@ -1642,7 +1645,7 @@ describe("Artwork type", () => {
     it("is set to domestic and intermational shipping when both domestic_shipping_fee_cents and present and international_shipping_fee_cents are set", () => {
       artwork.domestic_shipping_fee_cents = 1000
       artwork.international_shipping_fee_cents = 2000
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             shippingInfo: "Shipping: $10 domestic, $20 rest of world",
@@ -1655,7 +1658,7 @@ describe("Artwork type", () => {
       artwork.domestic_shipping_fee_cents = 1000
       artwork.international_shipping_fee_cents = 2000
       artwork.price_currency = "GBP"
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             shippingInfo: "Shipping: £10 domestic, £20 rest of world",
@@ -1673,7 +1676,7 @@ describe("Artwork type", () => {
         artwork.domestic_shipping_fee_cents = null
         artwork.international_shipping_fee_cents = null
 
-        return runQuery(query, context).then(data => {
+        return runQuery(query, context).then((data) => {
           expect(data).toEqual({
             artwork: {
               shippingInfo:
@@ -1686,7 +1689,7 @@ describe("Artwork type", () => {
       it("is set to free euro shipping only when its domestic_shipping_fee_cents is 0 and international_shipping_fee_cents is null", () => {
         artwork.domestic_shipping_fee_cents = 0
         artwork.international_shipping_fee_cents = null
-        return runQuery(query, context).then(data => {
+        return runQuery(query, context).then((data) => {
           expect(data).toEqual({
             artwork: {
               shippingInfo: "Free shipping within Continental Europe only",
@@ -1698,7 +1701,7 @@ describe("Artwork type", () => {
       it("is set to free shipping string when its domestic_shipping_fee_cents is 0 and international_shipping_fee_cents is 0", () => {
         artwork.domestic_shipping_fee_cents = 0
         artwork.international_shipping_fee_cents = 0
-        return runQuery(query, context).then(data => {
+        return runQuery(query, context).then((data) => {
           expect(data).toEqual({
             artwork: {
               shippingInfo: "Free shipping worldwide",
@@ -1710,7 +1713,7 @@ describe("Artwork type", () => {
       it("is set to domestic shipping only when its domestic_shipping_fee_cents is present and international_shipping_fee_cents is null", () => {
         artwork.domestic_shipping_fee_cents = 1000
         artwork.international_shipping_fee_cents = null
-        return runQuery(query, context).then(data => {
+        return runQuery(query, context).then((data) => {
           expect(data).toEqual({
             artwork: {
               shippingInfo: "Shipping: $10 within Continental Europe only",
@@ -1722,7 +1725,7 @@ describe("Artwork type", () => {
       it("is set to free international shipping when domestic_shipping_fee_cents is 0 and domestic_shipping_fee_cents is present", () => {
         artwork.domestic_shipping_fee_cents = 1000
         artwork.international_shipping_fee_cents = 0
-        return runQuery(query, context).then(data => {
+        return runQuery(query, context).then((data) => {
           expect(data).toEqual({
             artwork: {
               shippingInfo:
@@ -1735,7 +1738,7 @@ describe("Artwork type", () => {
       it("is set to free domestic shipping when domestic_shipping_fee_cents is 0 and international_shipping_fee_cents is present", () => {
         artwork.domestic_shipping_fee_cents = 0
         artwork.international_shipping_fee_cents = 10000
-        return runQuery(query, context).then(data => {
+        return runQuery(query, context).then((data) => {
           expect(data).toEqual({
             artwork: {
               shippingInfo:
@@ -1748,7 +1751,7 @@ describe("Artwork type", () => {
       it("is set to domestic and intermational shipping when both domestic_shipping_fee_cents and present and international_shipping_fee_cents are set", () => {
         artwork.domestic_shipping_fee_cents = 1000
         artwork.international_shipping_fee_cents = 2000
-        return runQuery(query, context).then(data => {
+        return runQuery(query, context).then((data) => {
           expect(data).toEqual({
             artwork: {
               shippingInfo:
@@ -1762,7 +1765,7 @@ describe("Artwork type", () => {
         artwork.domestic_shipping_fee_cents = 1000
         artwork.international_shipping_fee_cents = 2000
         artwork.price_currency = "EUR"
-        return runQuery(query, context).then(data => {
+        return runQuery(query, context).then((data) => {
           expect(data).toEqual({
             artwork: {
               shippingInfo:
@@ -1785,7 +1788,7 @@ describe("Artwork type", () => {
     it("is true when domestic_shipping_fee_cents is present and international_shipping_fee_cents is null", () => {
       artwork.domestic_shipping_fee_cents = 1000
       artwork.international_shipping_fee_cents = null
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             shipsToContinentalUSOnly: true,
@@ -1797,7 +1800,7 @@ describe("Artwork type", () => {
     it("is false when work ships free internationally", () => {
       artwork.domestic_shipping_fee_cents = 1000
       artwork.international_shipping_fee_cents = 0
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             shipsToContinentalUSOnly: false,
@@ -1809,7 +1812,7 @@ describe("Artwork type", () => {
     it("is false when work ships free worldwide", () => {
       artwork.domestic_shipping_fee_cents = 0
       artwork.international_shipping_fee_cents = 0
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             shipsToContinentalUSOnly: false,
@@ -1821,7 +1824,7 @@ describe("Artwork type", () => {
     it("is false when work ships worldwide", () => {
       artwork.domestic_shipping_fee_cents = 1000
       artwork.international_shipping_fee_cents = 1000
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             shipsToContinentalUSOnly: false,
@@ -1842,7 +1845,7 @@ describe("Artwork type", () => {
     it("is true when domestic_shipping_fee_cents is present and international_shipping_fee_cents is null", () => {
       artwork.domestic_shipping_fee_cents = 1000
       artwork.international_shipping_fee_cents = null
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             onlyShipsDomestically: true,
@@ -1854,7 +1857,7 @@ describe("Artwork type", () => {
     it("is false when work ships free internationally", () => {
       artwork.domestic_shipping_fee_cents = 1000
       artwork.international_shipping_fee_cents = 0
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             onlyShipsDomestically: false,
@@ -1866,7 +1869,7 @@ describe("Artwork type", () => {
     it("is false when work ships free worldwide", () => {
       artwork.domestic_shipping_fee_cents = 0
       artwork.international_shipping_fee_cents = 0
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             onlyShipsDomestically: false,
@@ -1878,7 +1881,7 @@ describe("Artwork type", () => {
     it("is false when work ships worldwide", () => {
       artwork.domestic_shipping_fee_cents = 1000
       artwork.international_shipping_fee_cents = 1000
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             onlyShipsDomestically: false,
@@ -1899,7 +1902,7 @@ describe("Artwork type", () => {
 
     it("is null when shipping_origin is null", () => {
       artwork.shipping_origin = null
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             shippingOrigin: null,
@@ -1910,7 +1913,7 @@ describe("Artwork type", () => {
 
     it("is set to concatenated values from shipping_origin when shipping origin is present", () => {
       artwork.shipping_origin = ["Kharkov", "Ukraine"]
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             shippingOrigin: "Kharkov, Ukraine",
@@ -1931,7 +1934,7 @@ describe("Artwork type", () => {
 
     it("returns artworks eu_shipping_origin", () => {
       artwork.eu_shipping_origin = true
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({ artwork: { euShippingOrigin: true } })
       })
     })
@@ -1948,7 +1951,7 @@ describe("Artwork type", () => {
 
     it("is null when shipping_origin is null", () => {
       artwork.shipping_origin = null
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             shippingCountry: null,
@@ -1959,7 +1962,7 @@ describe("Artwork type", () => {
 
     it("is set to concatenated values from shipping_origin when shipping origin is present", () => {
       artwork.shipping_origin = ["New York", "NY", "US"]
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             shippingCountry: "US",
@@ -1982,13 +1985,13 @@ describe("Artwork type", () => {
     `
     it("is null when framed is null", () => {
       artwork.framed = null
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({ artwork: { framed: null } })
       })
     })
     it("is set to proper object when framed is true", () => {
       artwork.framed = true
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             framed: { label: "Framed", details: "Included" },
@@ -1998,7 +2001,7 @@ describe("Artwork type", () => {
     })
     it("is set to proper object when framed is false", () => {
       artwork.framed = false
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             framed: { label: "Framed", details: "Not included" },
@@ -2027,7 +2030,7 @@ describe("Artwork type", () => {
       artwork.signed_other = null
       artwork.not_signed = null
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({ artwork: { signatureInfo: null } })
       })
     })
@@ -2038,7 +2041,7 @@ describe("Artwork type", () => {
       artwork.sticker_label = false
       artwork.signed_other = false
       artwork.not_signed = false
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({ artwork: { signatureInfo: null } })
       })
     })
@@ -2049,7 +2052,7 @@ describe("Artwork type", () => {
       artwork.sticker_label = false
       artwork.signed_other = true
       artwork.not_signed = false
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: { signatureInfo: { label: "Signature", details: "" } },
         })
@@ -2062,7 +2065,7 @@ describe("Artwork type", () => {
       artwork.sticker_label = false
       artwork.signed_other = false
       artwork.not_signed = true
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             signatureInfo: { label: "Signature", details: "Not signed" },
@@ -2076,7 +2079,7 @@ describe("Artwork type", () => {
       artwork.stamped_by_artist_estate = true
       artwork.sticker_label = true
       artwork.signed_other = true
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             signatureInfo: {
@@ -2094,7 +2097,7 @@ describe("Artwork type", () => {
       artwork.stamped_by_artist_estate = false
       artwork.sticker_label = false
       artwork.signed_other = true
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             signatureInfo: {
@@ -2120,19 +2123,19 @@ describe("Artwork type", () => {
     `
     it("is null when condition_description is null", () => {
       artwork.condition_description = null
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({ artwork: { conditionDescription: null } })
       })
     })
     it("is null when condition_description is blank", () => {
       artwork.condition_description = ""
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({ artwork: { conditionDescription: null } })
       })
     })
     it("is set to proper object when condition_description is present", () => {
       artwork.condition_description = "very detailed description of condition"
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             conditionDescription: {
@@ -2159,14 +2162,14 @@ describe("Artwork type", () => {
     `
     it("is null when certificate_of_authenticity is null", () => {
       artwork.certificate_of_authenticity = null
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data.artwork.certificateOfAuthenticity).toBe(null)
         expect(data.artwork.hasCertificateOfAuthenticity).toBe(false)
       })
     })
     it("is set to proper object when certificate_of_authenticity is true", () => {
       artwork.certificate_of_authenticity = true
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data.artwork.certificateOfAuthenticity).toEqual({
           label: "Certificate of authenticity",
           details: "Included",
@@ -2176,13 +2179,53 @@ describe("Artwork type", () => {
     })
     it("is set to proper object when certificate_of_authenticity is false", () => {
       artwork.certificate_of_authenticity = false
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data.artwork.certificateOfAuthenticity).toEqual({
           label: "Certificate of authenticity",
           details: "Not included",
         })
         expect(data.artwork.hasCertificateOfAuthenticity).toBe(false)
       })
+    })
+  })
+
+  describe("#realizedPrice", () => {
+    it("returns null if no realized price", async () => {
+      const query = `
+        {
+          artwork(id: "richard-prince-untitled-portrait") {
+            realizedPrice
+          }
+        }
+      `
+
+      const data = await runQuery(query, context)
+      expect(data.artwork.realizedPrice).toBe(null)
+    })
+
+    it("returns realized price for select artists", async () => {
+      getMicrofunnelDataByArtworkInternalID.mockImplementation(() => ({
+        "Artwork ids (recently sold) (comma separated)":
+          "5d126f9bba46ba0012c3134f",
+        "Realized Price (in dollars)": "$8,500",
+      }))
+      const query = `
+        {
+          artwork(id: "alex-katz-luna-park-2-maravell-67-schroder-68") {
+            realizedPrice
+          }
+        }
+      `
+      const context = {
+        artworkLoader: () => {
+          return Promise.resolve({
+            _id: "5d9ca6fe8f1aee0011475cf7",
+            id: "alex-katz-luna-park-2-maravell-67-schroder-68",
+          })
+        },
+      }
+      const data = await runQuery(query, context)
+      expect(data.artwork.realizedPrice).toBe("$8,500")
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -7671,10 +7671,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@1.14.3:
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
-  integrity sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==
+prettier@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
 pretty-format@^23.5.0:
   version "23.5.0"


### PR DESCRIPTION
Adds a new `artworksConnection` to `microfunnel` and moves `realizedPrice` directly to the artwork type, which fixes a handful of issues around querying for microfunnel data inside of a connection context. This should also make work in https://github.com/artsy/metaphysics/pull/2414 much more seamless. 

```graphql
{
  artist(id: "alex-katz") {
    targetSupply {
      microfunnel {
        artworksConnection(randomize: true, first: 1) {
          edges {
            node {
              realizedPrice
            }
          }
        }
      }
    }
  }
}
```
```json
{
  "data": {
    "artist": {
      "targetSupply": {
        "microfunnel": {
          "artworksConnection": {
            "edges": [
              {
                "node": {
                  "realizedPrice": "$5,000"
                }
              }
            ]
          }
        }
      }
    }
  }
}
```