### PR TITLE
Adds featuredArtworksConnection resolver to artist

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -654,6 +654,12 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     # The number of Shows to return
     size: Int = 5
   ): [Show]
+  featuredArtworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
 
   # Artworks Elastic Search results
   filterArtworksConnection(

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -35,7 +35,11 @@ export default opts => {
       {},
       { method: "POST" }
     ),
-    artistArtworksLoader: gravityLoader(id => `artist/${id}/artworks`),
+    artistArtworksLoader: gravityLoader(
+      id => `artist/${id}/artworks`,
+      {},
+      { headers: true }
+    ),
     artistGenesLoader: gravityLoader(id => `artist/${id}/genome/genes`),
     artistLoader: gravityLoader(id => `artist/${id}`),
     artistsLoader: gravityLoader("artists"),

--- a/src/schema/v1/artist/__tests__/carousel.test.js
+++ b/src/schema/v1/artist/__tests__/carousel.test.js
@@ -38,20 +38,22 @@ describe("ArtistCarousel type", () => {
           published: true,
         })
         .returns(
-          Promise.resolve([
-            {
-              id: "foo-bar-artwork-1",
-              images: [
-                {
-                  original_height: 2333,
-                  original_width: 3500,
-                  image_url: "https://xxx.cloudfront.net/xxx/:version.jpg",
-                  image_versions: ["large"],
-                  is_default: true,
-                },
-              ],
-            },
-          ])
+          Promise.resolve({
+            body: [
+              {
+                id: "foo-bar-artwork-1",
+                images: [
+                  {
+                    original_height: 2333,
+                    original_width: 3500,
+                    image_url: "https://xxx.cloudfront.net/xxx/:version.jpg",
+                    image_versions: ["large"],
+                    is_default: true,
+                  },
+                ],
+              },
+            ],
+          })
         )
     })
 
@@ -74,7 +76,7 @@ describe("ArtistCarousel type", () => {
         }
       `
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data.artist.carousel).toEqual({
           images: [
             {

--- a/src/schema/v1/artist/__tests__/index.test.js
+++ b/src/schema/v1/artist/__tests__/index.test.js
@@ -27,14 +27,14 @@ describe("Artist type", () => {
   })
 
   it("returns null for an empty ID string", () => {
-    return runQuery(`{ artist(id: "") { id } }`, context).then(data => {
+    return runQuery(`{ artist(id: "") { id } }`, context).then((data) => {
       expect(data.artist).toBe(null)
     })
   })
 
   it("fetches an artist by ID", () => {
     return runQuery(`{ artist(id: "foo-bar") { id, name } }`, context).then(
-      data => {
+      (data) => {
         expect(data.artist.id).toBe("foo-bar")
         expect(data.artist.name).toBe("Foo Bar")
       }
@@ -52,7 +52,7 @@ describe("Artist type", () => {
       }
     `
 
-    return runQuery(query, context).then(data => {
+    return runQuery(query, context).then((data) => {
       expect(data).toEqual({
         artist: {
           counts: {
@@ -74,7 +74,7 @@ describe("Artist type", () => {
       }
     `
 
-    return runQuery(query, context).then(data => {
+    return runQuery(query, context).then((data) => {
       expect(data).toEqual({
         artist: {
           counts: {
@@ -96,7 +96,7 @@ describe("Artist type", () => {
       }
     `
 
-    return runQuery(query, context).then(data => {
+    return runQuery(query, context).then((data) => {
       expect(data).toEqual({
         artist: {
           counts: {
@@ -116,7 +116,7 @@ describe("Artist type", () => {
       }
     `
 
-    return runQuery(query, context).then(data => {
+    return runQuery(query, context).then((data) => {
       expect(data).toEqual({
         artist: {
           has_metadata: false,
@@ -134,7 +134,7 @@ describe("Artist type", () => {
       }
     `
 
-    return runQuery(query, context).then(data => {
+    return runQuery(query, context).then((data) => {
       expect(data).toEqual({
         artist: {
           collections: [
@@ -158,7 +158,7 @@ describe("Artist type", () => {
         }
       `
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formatted_nationality_and_birthday: "b. 2000",
@@ -178,7 +178,7 @@ describe("Artist type", () => {
         }
       `
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formatted_nationality_and_birthday: "b. 2000",
@@ -198,7 +198,7 @@ describe("Artist type", () => {
         }
       `
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formatted_nationality_and_birthday: "Est. 2000",
@@ -219,7 +219,7 @@ describe("Artist type", () => {
         }
       `
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formatted_nationality_and_birthday: "Martian, b. 2000",
@@ -239,7 +239,7 @@ describe("Artist type", () => {
         }
       `
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formatted_nationality_and_birthday: "Martian",
@@ -261,7 +261,7 @@ describe("Artist type", () => {
         }
       `
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formatted_nationality_and_birthday: "Martian, 2000–2012",
@@ -277,7 +277,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formatted_nationality_and_birthday: null,
@@ -294,7 +294,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formatted_nationality_and_birthday: null,
@@ -308,7 +308,7 @@ describe("Artist type", () => {
       const count = 20
       artist.published_artworks_count = count
       artist.forsale_artworks_count = count
-      const artworks = Promise.resolve(Array(count))
+      const artworks = Promise.resolve({ body: Array(count) })
       context.artistArtworksLoader = sinon
         .stub()
         .withArgs(artist.id)
@@ -326,7 +326,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             artworks_connection: {
@@ -350,7 +350,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             artworks_connection: {
@@ -374,7 +374,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             artworks_connection: {
@@ -397,7 +397,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             blurb: "catty blurb",
@@ -436,7 +436,7 @@ describe("Artist type", () => {
               }
             }
           `
-          return runQuery(query, context).then(data => {
+          return runQuery(query, context).then((data) => {
             expect(data).toEqual({
               artist: {
                 biography_blurb: {
@@ -470,7 +470,7 @@ describe("Artist type", () => {
               }
             }
           `
-          return runQuery(query, context).then(data => {
+          return runQuery(query, context).then((data) => {
             expect(data).toEqual({
               artist: {
                 biography_blurb: {
@@ -497,7 +497,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             biography_blurb: {
@@ -534,7 +534,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             biography_blurb: {
@@ -599,7 +599,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             shows: [
@@ -624,7 +624,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             exhibition_highlights: [
@@ -651,7 +651,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formatted_artworks_count: "42 works, 21 for sale",
@@ -669,7 +669,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formatted_artworks_count: "42 works",
@@ -687,7 +687,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formatted_artworks_count: null,
@@ -705,7 +705,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formatted_artworks_count: "1 work",
@@ -726,7 +726,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             genes: [{ name: "Foo Bar" }],

--- a/src/schema/v1/artist/carousel.ts
+++ b/src/schema/v1/artist/carousel.ts
@@ -35,7 +35,7 @@ const ArtistCarousel: GraphQLFieldConfig<{ id: string }, ResolverContext> = {
         published: true,
       }),
     ])
-      .then(([{ body: shows }, artworks]) => {
+      .then(([{ body: shows }, { body: artworks }]) => {
         const elligibleShows = shows.filter(show => show.images_count > 0)
         return Promise.all(
           elligibleShows.map(show =>

--- a/src/schema/v1/artist/index.ts
+++ b/src/schema/v1/artist/index.ts
@@ -228,11 +228,12 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
             gravityArgs.exclude_ids = flatten([options.exclude])
           }
 
-          return artistArtworksLoader(artist.id, gravityArgs).then(artworks =>
-            connectionFromArraySlice(artworks, options, {
-              arrayLength: artistArtworkArrayLength(artist, filter),
-              sliceStart: offset,
-            })
+          return artistArtworksLoader(artist.id, gravityArgs).then(
+            ({ body: artworks }) =>
+              connectionFromArraySlice(artworks, options, {
+                arrayLength: artistArtworkArrayLength(artist, filter),
+                sliceStart: offset,
+              })
           )
         },
       },
@@ -548,7 +549,10 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       gender: { type: GraphQLString },
-      href: { type: GraphQLString, resolve: artist => `/artist/${artist.id}` },
+      href: {
+        type: GraphQLString,
+        resolve: artist => `/artist/${artist.id}`,
+      },
       has_metadata: {
         type: GraphQLBoolean,
         resolve: ({ blurb, nationality, years, hometown, location }) => {

--- a/src/schema/v2/artist/__tests__/carousel.test.js
+++ b/src/schema/v2/artist/__tests__/carousel.test.js
@@ -38,20 +38,22 @@ describe("ArtistCarousel type", () => {
           published: true,
         })
         .returns(
-          Promise.resolve([
-            {
-              id: "foo-bar-artwork-1",
-              images: [
-                {
-                  original_height: 2333,
-                  original_width: 3500,
-                  image_url: "https://xxx.cloudfront.net/xxx/:version.jpg",
-                  image_versions: ["large"],
-                  is_default: true,
-                },
-              ],
-            },
-          ])
+          Promise.resolve({
+            body: [
+              {
+                id: "foo-bar-artwork-1",
+                images: [
+                  {
+                    original_height: 2333,
+                    original_width: 3500,
+                    image_url: "https://xxx.cloudfront.net/xxx/:version.jpg",
+                    image_versions: ["large"],
+                    is_default: true,
+                  },
+                ],
+              },
+            ],
+          })
         )
     })
 
@@ -74,7 +76,7 @@ describe("ArtistCarousel type", () => {
         }
       `
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data.artist.carousel).toEqual({
           images: [
             {

--- a/src/schema/v2/artist/__tests__/index.test.js
+++ b/src/schema/v2/artist/__tests__/index.test.js
@@ -27,14 +27,14 @@ describe("Artist type", () => {
   })
 
   it("returns null for an empty ID string", () => {
-    return runQuery(`{ artist(id: "") { slug } }`, context).then(data => {
+    return runQuery(`{ artist(id: "") { slug } }`, context).then((data) => {
       expect(data.artist).toBe(null)
     })
   })
 
   it("fetches an artist by ID", () => {
     return runQuery(`{ artist(id: "foo-bar") { slug, name } }`, context).then(
-      data => {
+      (data) => {
         expect(data.artist.slug).toBe("foo-bar")
         expect(data.artist.name).toBe("Foo Bar")
       }
@@ -52,7 +52,7 @@ describe("Artist type", () => {
       }
     `
 
-    return runQuery(query, context).then(data => {
+    return runQuery(query, context).then((data) => {
       expect(data).toEqual({
         artist: {
           counts: {
@@ -74,7 +74,7 @@ describe("Artist type", () => {
       }
     `
 
-    return runQuery(query, context).then(data => {
+    return runQuery(query, context).then((data) => {
       expect(data).toEqual({
         artist: {
           counts: {
@@ -96,7 +96,7 @@ describe("Artist type", () => {
       }
     `
 
-    return runQuery(query, context).then(data => {
+    return runQuery(query, context).then((data) => {
       expect(data).toEqual({
         artist: {
           counts: {
@@ -116,7 +116,7 @@ describe("Artist type", () => {
       }
     `
 
-    return runQuery(query, context).then(data => {
+    return runQuery(query, context).then((data) => {
       expect(data).toEqual({
         artist: {
           hasMetadata: false,
@@ -134,7 +134,7 @@ describe("Artist type", () => {
       }
     `
 
-    return runQuery(query, context).then(data => {
+    return runQuery(query, context).then((data) => {
       expect(data).toEqual({
         artist: {
           collections: [
@@ -158,7 +158,7 @@ describe("Artist type", () => {
         }
       `
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formattedNationalityAndBirthday: "b. 2000",
@@ -178,7 +178,7 @@ describe("Artist type", () => {
         }
       `
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formattedNationalityAndBirthday: "b. 2000",
@@ -198,7 +198,7 @@ describe("Artist type", () => {
         }
       `
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formattedNationalityAndBirthday: "Est. 2000",
@@ -219,7 +219,7 @@ describe("Artist type", () => {
         }
       `
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formattedNationalityAndBirthday: "Martian, b. 2000",
@@ -239,7 +239,7 @@ describe("Artist type", () => {
         }
       `
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formattedNationalityAndBirthday: "Martian",
@@ -261,7 +261,7 @@ describe("Artist type", () => {
         }
       `
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formattedNationalityAndBirthday: "Martian, 2000–2012",
@@ -277,7 +277,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formattedNationalityAndBirthday: null,
@@ -294,7 +294,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formattedNationalityAndBirthday: null,
@@ -303,12 +303,13 @@ describe("Artist type", () => {
       })
     })
   })
+
   describe("artworksConnection", () => {
     beforeEach(() => {
       const count = 20
       artist.published_artworks_count = count
       artist.forsale_artworks_count = count
-      const artworks = Promise.resolve(Array(count))
+      const artworks = Promise.resolve({ body: Array(count) })
       context.artistArtworksLoader = sinon
         .stub()
         .withArgs(artist.id)
@@ -326,7 +327,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             artworksConnection: {
@@ -350,7 +351,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             artworksConnection: {
@@ -374,7 +375,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             artworksConnection: {
@@ -387,6 +388,124 @@ describe("Artist type", () => {
       })
     })
   })
+
+  describe("featuredArtworksConnection", () => {
+    beforeEach(() => {
+      const count = 20
+      const response = Promise.resolve({
+        body: Array(count),
+        headers: { "x-total-count": count },
+      })
+      context.artistArtworksLoader = sinon
+        .stub()
+        .withArgs(artist.id)
+        .returns(response)
+    })
+    it("does not have a next page when the requested amount exceeds the count", () => {
+      const query = `
+        {
+          artist(id: "foo-bar") {
+            featuredArtworksConnection(first: 40) {
+              pageInfo {
+                hasNextPage
+              }
+            }
+          }
+        }
+      `
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artist: {
+            featuredArtworksConnection: {
+              pageInfo: {
+                hasNextPage: false,
+              },
+            },
+          },
+        })
+      })
+    })
+
+    it("has a next page when the amount requested is less than the count", () => {
+      const query = `
+        {
+          artist(id: "foo-bar") {
+            featuredArtworksConnection(first: 10) {
+              pageInfo {
+                hasNextPage
+              }
+            }
+          }
+        }
+      `
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artist: {
+            featuredArtworksConnection: {
+              pageInfo: {
+                hasNextPage: true,
+              },
+            },
+          },
+        })
+      })
+    })
+
+    it("returns basic artwork data", () => {
+      const query = `
+        {
+          artist(id: "foo-bar") {
+            featuredArtworksConnection(first: 10) {
+              edges {
+                node {
+                  title
+                }
+              }
+            }
+          }
+        }
+      `
+
+      context.artistArtworksLoader = sinon
+        .stub()
+        .withArgs(artist.id)
+        .returns(
+          Promise.resolve({
+            body: [
+              {
+                title: "Artwork 1",
+              },
+              {
+                title: "Artwork 2",
+              },
+            ],
+            headers: { "x-total-count": 2 },
+          })
+        )
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artist: {
+            featuredArtworksConnection: {
+              edges: [
+                {
+                  node: {
+                    title: "Artwork 1",
+                  },
+                },
+                {
+                  node: {
+                    title: "Artwork 2",
+                  },
+                },
+              ],
+            },
+          },
+        })
+      })
+    })
+  })
+
   describe("biographyBlurb", () => {
     it("returns the blurb if present", () => {
       artist.blurb = "catty blurb"
@@ -397,7 +516,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             blurb: "catty blurb",
@@ -436,7 +555,7 @@ describe("Artist type", () => {
               }
             }
           `
-          return runQuery(query, context).then(data => {
+          return runQuery(query, context).then((data) => {
             expect(data).toEqual({
               artist: {
                 biographyBlurb: {
@@ -470,7 +589,7 @@ describe("Artist type", () => {
               }
             }
           `
-          return runQuery(query, context).then(data => {
+          return runQuery(query, context).then((data) => {
             expect(data).toEqual({
               artist: {
                 biographyBlurb: {
@@ -497,7 +616,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             biographyBlurb: {
@@ -534,7 +653,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             biographyBlurb: {
@@ -604,7 +723,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             edges: [
@@ -629,7 +748,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             exhibitionHighlights: [
@@ -656,7 +775,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formattedArtworksCount: "42 works, 21 for sale",
@@ -674,7 +793,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formattedArtworksCount: "42 works",
@@ -692,7 +811,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formattedArtworksCount: null,
@@ -710,7 +829,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             formattedArtworksCount: "1 work",
@@ -731,7 +850,7 @@ describe("Artist type", () => {
           }
         }
       `
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
             genes: [{ name: "Foo Bar" }],
@@ -773,7 +892,7 @@ describe("Artist type", () => {
         }
       `
 
-      return runQuery(query, context).then(data => {
+      return runQuery(query, context).then((data) => {
         expect(filterArtworksLoader.mock.calls[0][0]).not.toHaveProperty(
           "partnerID"
         )

--- a/src/schema/v2/artist/carousel.ts
+++ b/src/schema/v2/artist/carousel.ts
@@ -35,7 +35,7 @@ const ArtistCarousel: GraphQLFieldConfig<{ id: string }, ResolverContext> = {
         published: true,
       }),
     ])
-      .then(([{ body: shows }, artworks]) => {
+      .then(([{ body: shows }, { body: artworks }]) => {
         const elligibleShows = shows.filter(show => show.images_count > 0)
         return Promise.all(
           elligibleShows.map(show =>

--- a/src/schema/v2/artwork/artworkContextGrids/ArtistArtworkGrid.ts
+++ b/src/schema/v2/artwork/artworkContextGrids/ArtistArtworkGrid.ts
@@ -47,14 +47,16 @@ export const ArtistArtworkGridType = new GraphQLObjectType<
         })
         gravityArgs.sort = "-merchandisability"
 
-        return artistArtworksLoader(artist.id, gravityArgs).then(artworks => {
-          if (!artworks) return null
+        return artistArtworksLoader(artist.id, gravityArgs).then(
+          ({ body: artworks }) => {
+            if (!artworks) return null
 
-          return connectionFromArraySlice(artworks, options, {
-            arrayLength: artistArtworkArrayLength(artist, options.filter),
-            sliceStart: offset,
-          })
-        })
+            return connectionFromArraySlice(artworks, options, {
+              arrayLength: artistArtworkArrayLength(artist, options.filter),
+              sliceStart: offset,
+            })
+          }
+        )
       },
     },
   }),

--- a/src/schema/v2/artwork/artworkContextGrids/__tests__/auctionContext.test.ts
+++ b/src/schema/v2/artwork/artworkContextGrids/__tests__/auctionContext.test.ts
@@ -63,7 +63,7 @@ describe("Default Context", () => {
 
     context = {
       artworkLoader: () => Promise.resolve(parentArtwork),
-      artistArtworksLoader: () => Promise.resolve(artistArtworks),
+      artistArtworksLoader: () => Promise.resolve({ body: artistArtworks }),
       relatedFairsLoader: () => Promise.resolve(null),
       relatedShowsLoader: () => Promise.resolve(null),
       partnerArtworksLoader: () => {

--- a/src/schema/v2/artwork/artworkContextGrids/__tests__/defaultContext.test.ts
+++ b/src/schema/v2/artwork/artworkContextGrids/__tests__/defaultContext.test.ts
@@ -57,7 +57,7 @@ describe("Default Context", () => {
 
     context = {
       artworkLoader: () => Promise.resolve(parentArtwork),
-      artistArtworksLoader: () => Promise.resolve(artistArtworks),
+      artistArtworksLoader: () => Promise.resolve({ body: artistArtworks }),
       relatedFairsLoader: () => Promise.resolve(null),
       relatedShowsLoader: () => Promise.resolve(null),
       partnerArtworksLoader: () => {
@@ -78,7 +78,7 @@ describe("Default Context", () => {
       { id: "artwork3", title: "Artwork 3" },
     ]
     context.artistArtworksLoader = jest.fn(() =>
-      Promise.resolve(artistArtworks)
+      Promise.resolve({ body: artistArtworks })
     )
 
     await runAuthenticatedQuery(query, context).then(data => {

--- a/src/schema/v2/artwork/artworkContextGrids/__tests__/fairContext.test.ts
+++ b/src/schema/v2/artwork/artworkContextGrids/__tests__/fairContext.test.ts
@@ -62,7 +62,7 @@ describe("Show Context", () => {
 
     context = {
       artworkLoader: () => Promise.resolve(parentArtwork),
-      artistArtworksLoader: () => Promise.resolve(artistArtworks),
+      artistArtworksLoader: () => Promise.resolve({ body: artistArtworks }),
       relatedFairsLoader: () =>
         Promise.resolve([{ id: "fair1", has_full_feature: true }]),
       relatedShowsLoader: () => {

--- a/src/schema/v2/artwork/artworkContextGrids/__tests__/showContext.test.ts
+++ b/src/schema/v2/artwork/artworkContextGrids/__tests__/showContext.test.ts
@@ -63,7 +63,7 @@ describe("Show Context", () => {
 
     context = {
       artworkLoader: () => Promise.resolve(parentArtwork),
-      artistArtworksLoader: () => Promise.resolve(artistArtworks),
+      artistArtworksLoader: () => Promise.resolve({ body: artistArtworks }),
       relatedFairsLoader: () => Promise.resolve(null),
       relatedShowsLoader: () => {
         return Promise.resolve({


### PR DESCRIPTION
This PR:
- Adds a new resolver to the `Artist` schema for `featuredArtworksConnection`. This will be used to power a carousel of works on web (a re-purposed header carousel) and iOS.
- Updates everywhere we used the `artistArtworksLoader` since we changed it to have a `{ body: ..., headers: ...}` return type.

It relates to: https://artsyproduct.atlassian.net/browse/FX-1972

Essentially, this is a new/different version of our existing `carousel` type, which wraps underlying querying logic so it can be updated without needing to change clients. The big difference between this and `carousel` is the latter returns a list of shows and artworks under a generic type. Since we _only_ want to return artworks in this iteration, our type returns an artwork connection.

Note that we _do_ want to eventually update the logic within this new resolver (either to call a different sort value, add curated works, etc.) but _for now_ it just fetches based on `-iconicity` which matches the current carousel implementation.