### PR TITLE
consistency with auctions existing filter for size buckets

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -698,7 +698,9 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     priceRange: String
     saleID: ID
     size: Int
-    sizeBuckets: [ArtworkSizes]
+
+    # Filter results by Artwork sizes
+    sizes: [ArtworkSizes]
     sort: String
     tagID: String
     width: String
@@ -4045,7 +4047,9 @@ interface EntityWithFilterArtworksConnectionInterface {
     priceRange: String
     saleID: ID
     size: Int
-    sizeBuckets: [ArtworkSizes]
+
+    # Filter results by Artwork sizes
+    sizes: [ArtworkSizes]
     sort: String
     tagID: String
     width: String
@@ -4183,7 +4187,9 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
     priceRange: String
     saleID: ID
     size: Int
-    sizeBuckets: [ArtworkSizes]
+
+    # Filter results by Artwork sizes
+    sizes: [ArtworkSizes]
     sort: String
     tagID: String
     width: String
@@ -4783,7 +4789,9 @@ type Gene implements Node & Searchable {
     priceRange: String
     saleID: ID
     size: Int
-    sizeBuckets: [ArtworkSizes]
+
+    # Filter results by Artwork sizes
+    sizes: [ArtworkSizes]
     sort: String
     tagID: String
     width: String
@@ -5364,7 +5372,7 @@ type MarketingCollection {
     priceRange: String
     saleID: ID
     size: Int
-    sizeBuckets: [ArtworkSizes]
+    sizes: [ArtworkSizes]
     sort: String
     tagID: String
     width: String
@@ -6579,7 +6587,9 @@ type Query {
     priceRange: String
     saleID: ID
     size: Int
-    sizeBuckets: [ArtworkSizes]
+
+    # Filter results by Artwork sizes
+    sizes: [ArtworkSizes]
     sort: String
     tagID: String
     width: String
@@ -7735,7 +7745,9 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
     priceRange: String
     saleID: ID
     size: Int
-    sizeBuckets: [ArtworkSizes]
+
+    # Filter results by Artwork sizes
+    sizes: [ArtworkSizes]
     sort: String
     tagID: String
     width: String
@@ -8113,7 +8125,9 @@ type Tag implements Node {
     priceRange: String
     saleID: ID
     size: Int
-    sizeBuckets: [ArtworkSizes]
+
+    # Filter results by Artwork sizes
+    sizes: [ArtworkSizes]
     sort: String
     tagID: String
     width: String
@@ -8474,7 +8488,9 @@ type Viewer {
     priceRange: String
     saleID: ID
     size: Int
-    sizeBuckets: [ArtworkSizes]
+
+    # Filter results by Artwork sizes
+    sizes: [ArtworkSizes]
     sort: String
     tagID: String
     width: String

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -120,8 +120,9 @@ export const filterArtworksArgs: GraphQLFieldConfigArgumentMap = {
   color: {
     type: GraphQLString,
   },
-  sizeBuckets: {
+  sizes: {
     type: new GraphQLList(ArtworkSizes),
+    description: "Filter results by Artwork sizes",
   },
   dimensionRange: {
     type: GraphQLString,
@@ -369,7 +370,7 @@ const filterArtworksConnectionTypeFactory = (
       artistIDs,
       atAuction,
       attributionClass,
-      sizeBuckets,
+      sizes,
       dimensionRange,
       extraAggregationGeneIDs,
       includeArtworksByFollowedArtists,
@@ -399,7 +400,7 @@ const filterArtworksConnectionTypeFactory = (
       artist_ids: artistIDs,
       at_auction: atAuction,
       attribution_class: attributionClass,
-      size_bucket: sizeBuckets,
+      size_bucket: sizes,
       dimension_range: dimensionRange,
       extra_aggregation_gene_ids: extraAggregationGeneIDs,
       include_artworks_by_followed_artists: includeArtworksByFollowedArtists,

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -400,7 +400,7 @@ const filterArtworksConnectionTypeFactory = (
       artist_ids: artistIDs,
       at_auction: atAuction,
       attribution_class: attributionClass,
-      size_bucket: sizes,
+      sizes: sizes,
       dimension_range: dimensionRange,
       extra_aggregation_gene_ids: extraAggregationGeneIDs,
       include_artworks_by_followed_artists: includeArtworksByFollowedArtists,


### PR DESCRIPTION
~~⚠️ Dont merge before https://github.com/artsy/gravity/pull/13109 is deployed. ⚠️~~

Artist Auction Results already has a field called `sizes`, so we can use the same, for consistency.