### PR TITLE
Hotfix: hardcode `canRequestEmailConfirmation` to `false`

### DIFF
--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -59,8 +59,7 @@ const Me = new GraphQLObjectType<any, ResolverContext>({
     canRequestEmailConfirmation: {
       type: new GraphQLNonNull(GraphQLBoolean),
       description: "Whether user is allowed to request email confirmation",
-      resolve: ({ can_request_email_confirmation }) =>
-        can_request_email_confirmation,
+      resolve: () => false, // HOTFIX: Will be removed when we fix gravity.
     },
     followsAndSaves: {
       type: new GraphQLObjectType<any, ResolverContext>({


### PR DESCRIPTION
It was assumed that Gravity was respecting the feature flag, but it
wasn't, caused this to be released too early.