### PR TITLE
Revert "Hotfix: hardcode `canRequestEmailConfirmation` to `false`"

### DIFF
--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -59,7 +59,8 @@ const Me = new GraphQLObjectType<any, ResolverContext>({
     canRequestEmailConfirmation: {
       type: new GraphQLNonNull(GraphQLBoolean),
       description: "Whether user is allowed to request email confirmation",
-      resolve: () => false, // HOTFIX: Will be removed when we fix gravity.
+      resolve: ({ can_request_email_confirmation }) =>
+        can_request_email_confirmation,
     },
     followsAndSaves: {
       type: new GraphQLObjectType<any, ResolverContext>({


### PR DESCRIPTION
Reverts artsy/metaphysics#2444

Now that https://github.com/artsy/gravity/pull/13132 is deployed to production, we can re-enable our MP to Gravity proxy, unblocking further QA/work on email verification.
