### PR TITLE
Query for ArtworkVersions on orders using Node [GALL-2963]

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1390,7 +1390,7 @@ type ArtworkVersion implements Node {
   artistNames: String
 
   # The artists related to this Artwork Version
-  artists: String
+  artists: [Artist]
 
   # The Image id
   defaultImageID: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1385,7 +1385,7 @@ enum ArtworkSorts {
   TITLE_DESC
 }
 
-type ArtworkVersion {
+type ArtworkVersion implements Node {
   # The names for the artists related to this Artwork Version
   artistNames: String
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@babel/preset-env": "7.4.5",
     "@babel/preset-typescript": "7.3.3",
     "@babel/register": "7.4.4",
+    "@graphql-tools/delegate": "^6.0.10",
     "@heroku/foreman": "2.0.2",
     "accounting": "0.4.1",
     "apollo-link": "1.2.1",

--- a/src/lib/stitching/exchange/stitching.ts
+++ b/src/lib/stitching/exchange/stitching.ts
@@ -1,6 +1,7 @@
 import { GraphQLSchema } from "graphql"
 import { amountSDL, amount } from "schema/v1/fields/money"
 import gql from "lib/gql"
+import { toGlobalId } from "graphql-relay"
 
 const orderTotals = [
   "itemsTotal",
@@ -230,17 +231,23 @@ export const exchangeStitchingEnvironment = ({
           fragment: `fragment CommerceLineItemArtwork on CommerceLineItem { artworkVersionId }`,
           resolve: (parent, _args, context, info) => {
             const id = parent.artworkVersionId
-            return info.mergeInfo.delegateToSchema({
-              schema: localSchema,
-              operation: "query",
-              fieldName: "artworkVersion",
-              args: {
-                id,
-              },
-              context,
-              info,
-              transforms: exchangeSchema.transforms,
-            })
+            const globalID = toGlobalId("ArtworkVersion", id)
+            return info.mergeInfo
+              .delegateToSchema({
+                schema: localSchema,
+                operation: "query",
+                fieldName: "node",
+                args: {
+                  id: globalID,
+                },
+                context,
+                info,
+                transforms: exchangeSchema.transforms,
+              })
+              .then((result) => {
+                console.log("vvv", result)
+                return result
+              })
           },
         },
         ...totalsResolvers("CommerceLineItem", lineItemTotals),

--- a/src/lib/stitching/exchange/stitching.ts
+++ b/src/lib/stitching/exchange/stitching.ts
@@ -2,6 +2,8 @@ import { GraphQLSchema } from "graphql"
 import { amountSDL, amount } from "schema/v1/fields/money"
 import gql from "lib/gql"
 import { toGlobalId } from "graphql-relay"
+import { delegateToSchema } from "@graphql-tools/delegate"
+import { ArtworkVersionType } from "schema/v2/artwork_version"
 
 const orderTotals = [
   "itemsTotal",
@@ -232,22 +234,18 @@ export const exchangeStitchingEnvironment = ({
           resolve: (parent, _args, context, info) => {
             const id = parent.artworkVersionId
             const globalID = toGlobalId("ArtworkVersion", id)
-            return info.mergeInfo
-              .delegateToSchema({
-                schema: localSchema,
-                operation: "query",
-                fieldName: "node",
-                args: {
-                  id: globalID,
-                },
-                context,
-                info,
-                transforms: exchangeSchema.transforms,
-              })
-              .then((result) => {
-                console.log("vvv", result)
-                return result
-              })
+            return delegateToSchema({
+              schema: localSchema,
+              operation: "query",
+              fieldName: "node",
+              args: {
+                id: globalID,
+              },
+              context,
+              info,
+              transforms: exchangeSchema.transforms,
+              returnType: ArtworkVersionType,
+            })
           },
         },
         ...totalsResolvers("CommerceLineItem", lineItemTotals),

--- a/src/schema/v2/artwork_version.ts
+++ b/src/schema/v2/artwork_version.ts
@@ -3,11 +3,13 @@ import {
   GraphQLString,
   GraphQLNonNull,
   GraphQLFieldConfig,
+  GraphQLList,
 } from "graphql"
 import { artistNames } from "./artwork/meta"
 import Image from "./image"
 import { ResolverContext } from "types/graphql"
 import { InternalIDFields, NodeInterface } from "./object_identification"
+import Artist from "./artist"
 
 export const ArtworkVersionType = new GraphQLObjectType<any, ResolverContext>({
   name: "ArtworkVersion",
@@ -27,7 +29,7 @@ export const ArtworkVersionType = new GraphQLObjectType<any, ResolverContext>({
     },
 
     artists: {
-      type: GraphQLString,
+      type: new GraphQLList(Artist.type),
       description: "The artists related to this Artwork Version",
       resolve: (version, _options, { artistsLoader }) =>
         artistsLoader({ ids: version.artist_ids }),
@@ -38,7 +40,7 @@ export const ArtworkVersionType = new GraphQLObjectType<any, ResolverContext>({
       description: "The names for the artists related to this Artwork Version",
       resolve: async (version, _options, { artistsLoader }) => {
         const artists = await artistsLoader({ ids: version.artist_ids })
-        return artistNames(artists)
+        return artistNames({ artists })
       },
     },
 

--- a/src/schema/v2/artwork_version.ts
+++ b/src/schema/v2/artwork_version.ts
@@ -7,10 +7,11 @@ import {
 import { artistNames } from "./artwork/meta"
 import Image from "./image"
 import { ResolverContext } from "types/graphql"
-import { InternalIDFields } from "./object_identification"
+import { InternalIDFields, NodeInterface } from "./object_identification"
 
 export const ArtworkVersionType = new GraphQLObjectType<any, ResolverContext>({
   name: "ArtworkVersion",
+  interfaces: [NodeInterface],
   fields: () => ({
     ...InternalIDFields,
 
@@ -70,3 +71,5 @@ export const ArtworkVersionResolver: GraphQLFieldConfig<
       ? authenticatedArtworkVersionLoader(id)
       : null,
 }
+
+export default ArtworkVersionResolver

--- a/src/schema/v2/object_identification.ts
+++ b/src/schema/v2/object_identification.ts
@@ -42,6 +42,7 @@ const SupportedTypes: any = {
     "./article",
     "./artist",
     "./artwork",
+    "./artwork_version",
     "./bidder",
     "./gene",
     "./filterArtworksConnection",

--- a/yarn.lock
+++ b/yarn.lock
@@ -923,6 +923,32 @@
   dependencies:
     dependency-graph "0.8.1"
 
+"@graphql-tools/delegate@^6.0.10":
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/delegate/-/delegate-6.0.10.tgz#f2fe8eea6cd5ce23f1e8f3dacfa6e136cad157da"
+  integrity sha512-FBHrmpSI9QpNbvqc5D4wdQW0WrNVUA2ylFhzsNRk9yvlKzcVKqiTrOpb++j7TLB+tG06dpSkfAssPcgZvU60fw==
+  dependencies:
+    "@graphql-tools/schema" "6.0.10"
+    "@graphql-tools/utils" "6.0.10"
+    aggregate-error "3.0.1"
+    tslib "~2.0.0"
+
+"@graphql-tools/schema@6.0.10":
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-6.0.10.tgz#69b36fad35ea5780f8539c92e776f9e83d929575"
+  integrity sha512-g8iy36dgf/Cpyz7bHSE2axkE8PdM5VYdS2tntmytLvPaN3Krb8IxBpZBJhmiICwyAAkruQE7OjDfYr8vP8jY4A==
+  dependencies:
+    "@graphql-tools/utils" "6.0.10"
+    tslib "~2.0.0"
+
+"@graphql-tools/utils@6.0.10":
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-6.0.10.tgz#ed15110a20acc5474a8dda5c0b99f970ba696c75"
+  integrity sha512-1s3vBnYUIDLBGEaV1VF3lv1Xq54lT8Oz7tNNypv7K7cv3auKX7idRtjP8RM6hKpGod46JNZgu3NNOshMUEyEyA==
+  dependencies:
+    aggregate-error "3.0.1"
+    camel-case "4.1.1"
+
 "@heroku/foreman@2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@heroku/foreman/-/foreman-2.0.2.tgz#e24f8611bb0633ca89095648243d3a90564749fc"
@@ -1749,6 +1775,14 @@ agent-base@^2:
   dependencies:
     extend "~3.0.0"
     semver "~5.0.1"
+
+aggregate-error@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.1.tgz#db2fe7246e536f40d9b5442a39e117d7dd6a24e0"
+  integrity sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==
+  dependencies:
+    clean-stack "^2.0.0"
+    indent-string "^4.0.0"
 
 ajv@^5.1.0:
   version "5.5.0"
@@ -2590,6 +2624,14 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.0.0.tgz#fb7eb569b72ad7a45812f93fd9430a3e410b3dd3"
   integrity sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==
 
+camel-case@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.1.tgz#1fc41c854f00e2f7d0139dfeba1542d6896fe547"
+  integrity sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==
+  dependencies:
+    pascal-case "^3.1.1"
+    tslib "^1.10.0"
+
 camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
@@ -2728,6 +2770,11 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+clean-stack@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
+  integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
 cli-cursor@^1.0.2:
   version "1.0.2"
@@ -4944,6 +4991,11 @@ indent-string@^3.0.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
   integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
 
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -6503,6 +6555,13 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   dependencies:
     js-tokens "^3.0.0"
 
+lower-case@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.1.tgz#39eeb36e396115cc05e29422eaea9e692c9408c7"
+  integrity sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==
+  dependencies:
+    tslib "^1.10.0"
+
 lru-cache@^4.0.1:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
@@ -6914,6 +6973,14 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+no-case@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.3.tgz#c21b434c1ffe48b39087e86cfb4d2582e9df18f8"
+  integrity sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==
+  dependencies:
+    lower-case "^2.0.1"
+    tslib "^1.10.0"
 
 node-cleanup@^2.1.2:
   version "2.1.2"
@@ -7487,6 +7554,14 @@ parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
   integrity sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=
+
+pascal-case@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.1.tgz#5ac1975133ed619281e88920973d2cd1f279de5f"
+  integrity sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==
+  dependencies:
+    no-case "^3.0.3"
+    tslib "^1.10.0"
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -9322,6 +9397,11 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
+tslib@^1.10.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
+  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
 tslib@^1.8.1:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
@@ -9331,6 +9411,11 @@ tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+tslib@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
+  integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
 
 tsutils@^3.17.1:
   version "3.17.1"


### PR DESCRIPTION
@zephraph and I paired on this for a while this afternoon. We removed `ArtworkVersions` as a root field from MP v2 and we rely on it for some orders (see Jira ticket linked below for more details). We figured that instead of just re-adding `ArtworkVersions` as a root field, we might be able to instead have it `implement Node` and stitch it into MP's Exchange schema that way.

We got pretty far with that approach, but we got stuck at the end: we could return `id` and `__typename`, but not the actual contents of `ArtworkVersions`. When running a query ourselves, we did that by adding `... on ArtworkVersions`, but we're unsure if it's possible to add that to the `ArtworkVersion` fragment.

@mzikherman any ideas on this? @zephraph anything I missed?

Some screenshots that demonstrate this:

Successfully querying in browser: 
<img width="1792" alt="Screen Shot 2020-06-15 at 6 04 36 PM" src="https://user-images.githubusercontent.com/5361806/84710697-bbab1b00-af32-11ea-9ae2-06bfb37b091b.png">

Returning `null` for fields when we try to use the stitched query:
<img width="1792" alt="Screen Shot 2020-06-15 at 6 05 43 PM" src="https://user-images.githubusercontent.com/5361806/84710793-e6956f00-af32-11ea-8506-5a212474a687.png">

[Jira ticket](https://artsyproduct.atlassian.net/browse/GALL-2963)