### PR TITLE
Add stitched ArtistSeries field

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1251,6 +1251,17 @@ type ArtistRelatedData {
   ): ArtistConnection
 }
 
+type ArtistSeries {
+  description: String
+  featured: Boolean!
+
+  # Unique ID for this artist series
+  internalID: ID!
+  published: Boolean!
+  slug: String!
+  title: String!
+}
+
 enum ArtistSorts {
   sortable_id_asc
     @deprecated(
@@ -10688,6 +10699,9 @@ type Query {
     sort: ArtistSorts
   ): [Artist]
 
+  # Find an artist series by ID
+  artistSeries(id: ID!): ArtistSeries
+
   # An Artwork
   artwork(
     # The slug or ID of the Artwork
@@ -13546,22 +13560,17 @@ type ViewingRoom {
 
 # Basic viewing room attributes
 input ViewingRoomAttributes {
-  # Main text
   body: String
 
-  # End datetime
+  # Datetime (in UTC) when Viewing Room closes
   endAt: ISO8601DateTime
-
-  # Introduction
   introStatement: String
-
-  # Pullquote
   pullQuote: String
 
-  # Start datetime
+  # Datetime (in UTC) when Viewing Room opens
   startAt: ISO8601DateTime
 
-  # Timezone
+  # Time zone (tz database format, e.g. America/New_York) in which start_at/end_at attributes were input
   timeZone: String
 
   # Title

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -986,6 +986,17 @@ type ArtistRelatedData {
   ): ArtistConnection
 }
 
+type ArtistSeries {
+  description: String
+  featured: Boolean!
+
+  # Unique ID for this artist series
+  internalID: ID!
+  published: Boolean!
+  slug: String!
+  title: String!
+}
+
 enum ArtistSorts {
   SORTABLE_ID_ASC
   SORTABLE_ID_DESC
@@ -7076,6 +7087,9 @@ type Query {
     sort: ArtistSorts
   ): [Artist]
 
+  # Find an artist series by ID
+  artistSeries(id: ID!): ArtistSeries
+
   # An Artwork
   artwork(
     # The slug or ID of the Artwork
@@ -9350,22 +9364,17 @@ type ViewingRoom {
 
 # Basic viewing room attributes
 input ViewingRoomAttributes {
-  # Main text
   body: String
 
-  # End datetime
+  # Datetime (in UTC) when Viewing Room closes
   endAt: ISO8601DateTime
-
-  # Introduction
   introStatement: String
-
-  # Pullquote
   pullQuote: String
 
-  # Start datetime
+  # Datetime (in UTC) when Viewing Room opens
   startAt: ISO8601DateTime
 
-  # Timezone
+  # Time zone (tz database format, e.g. America/New_York) in which start_at/end_at attributes were input
   timeZone: String
 
   # Title

--- a/src/data/gravity.graphql
+++ b/src/data/gravity.graphql
@@ -70,6 +70,19 @@ type ArtistEdge {
   node: Artist
 }
 
+type ArtistSeries {
+  description: String
+  featured: Boolean!
+
+  """
+  Unique ID for this artist series
+  """
+  internalID: ID!
+  published: Boolean!
+  slug: String!
+  title: String!
+}
+
 """
 Artwork or design object
 """
@@ -796,6 +809,11 @@ type Query {
   artist(id: ID!): Artist
 
   """
+  Find an artist series by ID
+  """
+  artistSeries(id: ID!): ArtistSeries
+
+  """
   Find artists by ID
   """
   artists(ids: [ID!]!): [Artist!]
@@ -1174,33 +1192,22 @@ type ViewingRoom {
 Basic viewing room attributes
 """
 input ViewingRoomAttributes {
-  """
-  Main text
-  """
   body: String
 
   """
-  End datetime
+  Datetime (in UTC) when Viewing Room closes
   """
   endAt: ISO8601DateTime
-
-  """
-  Introduction
-  """
   introStatement: String
-
-  """
-  Pullquote
-  """
   pullQuote: String
 
   """
-  Start datetime
+  Datetime (in UTC) when Viewing Room opens
   """
   startAt: ISO8601DateTime
 
   """
-  Timezone
+  Time zone (tz database format, e.g. America/New_York) in which start_at/end_at attributes were input
   """
   timeZone: String
 

--- a/src/lib/stitching/gravity/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/gravity/__tests__/__snapshots__/schema.test.ts.snap
@@ -24,6 +24,17 @@ input AppSecondFactorAttributes {
 # An app second factor or errors
 union AppSecondFactorOrErrorsUnion = AppSecondFactor | Errors
 
+type ArtistSeries {
+  description: String
+  featured: Boolean!
+
+  # Unique ID for this artist series
+  internalID: ID!
+  published: Boolean!
+  slug: String!
+  title: String!
+}
+
 # Backup Two-Factor Authentication factor
 type BackupSecondFactor implements SecondFactor {
   code: String!
@@ -371,6 +382,9 @@ type PageInfo {
 }
 
 type Query {
+  # Find an artist series by ID
+  artistSeries(id: ID!): ArtistSeries
+
   # Autocomplete resolvers.
   _unused_gravity_matchPartners(matchType: String, page: Int = 1, size: Int = 5, term: String!): [DoNotUseThisPartner!]
 
@@ -579,22 +593,17 @@ type ViewingRoom {
 
 # Basic viewing room attributes
 input ViewingRoomAttributes {
-  # Main text
   body: String
 
-  # End datetime
+  # Datetime (in UTC) when Viewing Room closes
   endAt: ISO8601DateTime
-
-  # Introduction
   introStatement: String
-
-  # Pullquote
   pullQuote: String
 
-  # Start datetime
+  # Datetime (in UTC) when Viewing Room opens
   startAt: ISO8601DateTime
 
-  # Timezone
+  # Time zone (tz database format, e.g. America/New_York) in which start_at/end_at attributes were input
   timeZone: String
 
   # Title

--- a/src/lib/stitching/gravity/schema.ts
+++ b/src/lib/stitching/gravity/schema.ts
@@ -8,7 +8,7 @@ import {
 } from "graphql-tools"
 import { readFileSync } from "fs"
 
-const allowList = ["viewingRoom", "viewingRooms"]
+const allowList = ["viewingRoom", "viewingRooms", "artistSeries"]
 
 export const executableGravitySchema = () => {
   const gravityTypeDefs = readFileSync("src/data/gravity.graphql", "utf8")


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2005

This PR stitches `ArtistSeries` field from Gravity into Metaphysics.

`DO NOT MERGE` until we have clarity on schema changes from Viewing Room.

collab: @ashleyjelks @anandaroop 

### Questions

- [x] Do we need to write a test for querying `ArtistSeries`? Wouldn't we just be testing stitching at that level?
- [x] Should we leave out whitespace changes to the schema? Do we have a convention we want to follow?
- [x] Updating Gravity's schema pulled in schema changes to another type that didn't seem to be present on master -- need to confirm that this is right

