### PR TITLE
exclude noisy Sentry errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,14 @@ function startApp(appSchema, path: string) {
   }
 
   if (enableSentry) {
-    raven.config(SENTRY_PRIVATE_DSN).install()
+    raven
+      .config(SENTRY_PRIVATE_DSN, {
+        ignoreErrors: [
+          "Response not successful: Received status code 404",
+          "Must provide query string",
+        ],
+      })
+      .install()
     app.use(raven.requestHandler())
   }
 


### PR DESCRIPTION
 Use Raven's config to ignore 404s from Gravity and requests without a query. I tested locally with Sentry staging's DSN.

https://artsyproduct.atlassian.net/browse/AUCT-1088 🔒 