### PR TITLE
Add Artists field to Artist Series

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1252,6 +1252,9 @@ type ArtistRelatedData {
 }
 
 type ArtistSeries {
+  # List of Mongo IDs for associated Artists
+  artistIDs: [String!]!
+  artists(page: Int, size: Int): [Artist]
   description: String
   featured: Boolean!
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -987,6 +987,9 @@ type ArtistRelatedData {
 }
 
 type ArtistSeries {
+  # List of Mongo IDs for associated Artists
+  artistIDs: [String!]!
+  artists(page: Int, size: Int): [Artist]
   description: String
   featured: Boolean!
 

--- a/src/data/gravity.graphql
+++ b/src/data/gravity.graphql
@@ -71,6 +71,10 @@ type ArtistEdge {
 }
 
 type ArtistSeries {
+  """
+  List of Mongo IDs for associated Artists
+  """
+  artistIDs: [String!]!
   description: String
   featured: Boolean!
 

--- a/src/lib/stitching/gravity/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/gravity/__tests__/__snapshots__/schema.test.ts.snap
@@ -25,6 +25,8 @@ input AppSecondFactorAttributes {
 union AppSecondFactorOrErrorsUnion = AppSecondFactor | Errors
 
 type ArtistSeries {
+  # List of Mongo IDs for associated Artists
+  artistIDs: [String!]!
   description: String
   featured: Boolean!
 

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -176,4 +176,33 @@ describe("gravity/stitching", () => {
       })
     })
   })
+
+  describe("#artists", () => {
+    it("extends the ArtistSeries type with artists field", async () => {
+      const mergedSchema = await getGravityMergedSchema()
+      const artists = await getFieldsForTypeFromSchema(
+        "ArtistSeries",
+        mergedSchema
+      )
+
+      expect(artists).toContain("artists")
+    })
+
+    it("resolves the artists field on ArtistSeries", async () => {
+      const { resolvers } = await getGravityStitchedSchema()
+      const { artists } = resolvers.ArtistSeries
+      const info = { mergeInfo: { delegateToSchema: jest.fn() } }
+
+      artists.resolve({ artistIDs: ["fakeid"] }, {}, {}, info)
+
+      expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
+        args: { ids: ["fakeid"] },
+        operation: "query",
+        fieldName: "artists",
+        schema: expect.anything(),
+        context: expect.anything(),
+        info: expect.anything(),
+      })
+    })
+  })
 })

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -29,6 +29,10 @@ export const gravityStitchingEnvironment = (
         partner: Partner
       }
 
+      extend type ArtistSeries {
+        artists(page: Int, size: Int): [Artist]
+      }
+
       extend type Partner {
         viewingRoomsConnection: ViewingRoomConnection
       }
@@ -42,6 +46,32 @@ export const gravityStitchingEnvironment = (
               operation: "query",
               fieldName: "_unused_gravity_secondFactors",
               args: args,
+              context,
+              info,
+            })
+          },
+        },
+      },
+      ArtistSeries: {
+        artists: {
+          fragment: gql`
+          ... on ArtistSeries {
+            artistIDs
+          }
+        `,
+          resolve: ({ artistIDs: ids }, args, context, info) => {
+            if (ids.length === 0) {
+              ids = [null]
+            }
+
+            return info.mergeInfo.delegateToSchema({
+              schema: localSchema,
+              operation: "query",
+              fieldName: "artists",
+              args: {
+                ids,
+                ...args,
+              },
               context,
               info,
             })

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -61,7 +61,7 @@ export const gravityStitchingEnvironment = (
         `,
           resolve: ({ artistIDs: ids }, args, context, info) => {
             if (ids.length === 0) {
-              ids = [null]
+              return []
             }
 
             return info.mergeInfo.delegateToSchema({


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2054

Allow for metaphysics to return an artist series' artists. 

Current artists fields is a list, rather than an artistsConnection field, this is reasonable for our use case because we don't expect the list of artists to be so long that it needs pagination. 

We followed existing patterns from Viewing Rooms. 

![Screen Shot 2020-06-24 at 3 12 19 PM](https://user-images.githubusercontent.com/10385964/85617363-1fb59980-b62d-11ea-9d43-02aba6870de1.png)


