### PR TITLE
Add new mobile hero unit resolution logic

### DIFF
--- a/src/schema/v2/home/__tests__/home_page_hero_units.test.js
+++ b/src/schema/v2/home/__tests__/home_page_hero_units.test.js
@@ -9,14 +9,18 @@ describe("HomePageHeroUnits", () => {
       link: "/artrio-2016",
       heading: "Featured Fair",
       name: "ArtRio 2016",
-      mobile_title: "ArtRio 2016",
+      mobile_title: "Mobile ArtRio 2016",
+      app_title: "App ArtRio 2016",
       background_image_url: "wide.jpg",
       background_image_mobile_url: "narrow.jpg",
+      background_image_app_phone_url: "app-narrow.jpg",
+      background_image_app_tablet_url: "app-wide.jpg",
       description: "Discover works on your laptop",
       mobile_description: "Discover works on your phone",
+      app_description: "Discover works in the artsy app",
     },
   ]
-  ;[("mobile", "desktop")].forEach((platform) => {
+  ;[("martsy", "desktop")].forEach((platform) => {
     it(`picks subtitle for ${platform}`, () => {
       const params = { enabled: true }
       params[platform] = true
@@ -95,7 +99,7 @@ describe("HomePageHeroUnits", () => {
     const query = `
       {
         homePage {
-          heroUnits(platform: MOBILE) {
+          heroUnits(platform: MARTSY) {
             backgroundImageURL(version: WIDE)
           }
         }
@@ -108,6 +112,76 @@ describe("HomePageHeroUnits", () => {
           backgroundImageURL: "wide.jpg",
         },
       ])
+    })
+  })
+
+  it("returns the correct wide image on 'mobile'", async () => {
+    const context = {
+      heroUnitsLoader: sinon.stub().returns(Promise.resolve(payload)),
+    }
+
+    const backgroundImageWideResult = await runQuery(
+      `
+      {
+        homePage {
+          heroUnits(platform: MOBILE) {
+            backgroundImageURL(version: WIDE)
+          }
+        }
+      }
+    `,
+      context
+    )
+
+    expect(
+      backgroundImageWideResult.homePage.heroUnits[0].backgroundImageURL
+    ).toBe("app-wide.jpg")
+  })
+
+  it("returns the correct narrow image on 'mobile'", async () => {
+    const context = {
+      heroUnitsLoader: sinon.stub().returns(Promise.resolve(payload)),
+    }
+
+    const backgroundImageNarrowResult = await runQuery(
+      `
+      {
+        homePage {
+          heroUnits(platform: MOBILE) {
+            backgroundImageURL(version: NARROW)
+          }
+        }
+      }
+    `,
+      context
+    )
+
+    expect(
+      backgroundImageNarrowResult.homePage.heroUnits[0].backgroundImageURL
+    ).toBe("app-narrow.jpg")
+  })
+  it("returns the correct title and subtitle on 'mobile'", async () => {
+    const context = {
+      heroUnitsLoader: sinon.stub().returns(Promise.resolve(payload)),
+    }
+
+    const result = await runQuery(
+      `
+      {
+        homePage {
+          heroUnits(platform: MOBILE) {
+            title
+            subtitle
+          }
+        }
+      }
+    `,
+      context
+    )
+
+    expect(result.homePage.heroUnits[0]).toEqual({
+      title: "App ArtRio 2016",
+      subtitle: "Discover works in the artsy app",
     })
   })
 })

--- a/src/schema/v2/home/home_page_hero_units.ts
+++ b/src/schema/v2/home/home_page_hero_units.ts
@@ -53,8 +53,15 @@ const HomePageHeroUnitType = new GraphQLObjectType<any, ResolverContext>({
     },
     title: {
       type: GraphQLString,
-      resolve: ({ mobile_title, name, platform }) => {
-        return platform === "desktop" ? name : mobile_title
+      resolve: ({ mobile_title, name, platform, app_title }) => {
+        switch (platform) {
+          case "desktop":
+            return name
+          case "mobile":
+            return app_title
+          case "martsy":
+            return mobile_title
+        }
       },
     },
     titleImageURL: {
@@ -70,8 +77,20 @@ const HomePageHeroUnitType = new GraphQLObjectType<any, ResolverContext>({
     },
     subtitle: {
       type: GraphQLString,
-      resolve: ({ mobile_description, description, platform }) => {
-        return platform === "desktop" ? description : mobile_description
+      resolve: ({
+        app_description,
+        mobile_description,
+        description,
+        platform,
+      }) => {
+        switch (platform) {
+          case "desktop":
+            return description
+          case "martsy":
+            return mobile_description
+          case "mobile":
+            return app_description
+        }
       },
     },
     linkText: {
@@ -102,9 +121,20 @@ const HomePageHeroUnitType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       resolve: (
-        { platform, background_image_url, background_image_mobile_url },
+        {
+          platform,
+          background_image_url,
+          background_image_mobile_url,
+          background_image_app_phone_url,
+          background_image_app_tablet_url,
+        },
         { version }
       ) => {
+        if (platform === "mobile") {
+          return version === "wide"
+            ? background_image_app_tablet_url
+            : background_image_app_phone_url
+        }
         if (version) {
           return version === "wide"
             ? background_image_url
@@ -142,8 +172,7 @@ const HomePageHeroUnits: GraphQLFieldConfig<void, ResolverContext> = {
     },
   },
   resolve: (_, { platform }, { heroUnitsLoader }) => {
-    const params = { enabled: true }
-    params[platform] = true
+    const params = { enabled: true, [platform]: true }
     return heroUnitsLoader(params).then((units) => {
       return units.map((unit) => Object.assign({ platform }, unit))
     })


### PR DESCRIPTION
Last one I'm pretty sure 🙈 

Follow-up to the work in gravity (https://github.com/artsy/gravity/pull/13153, https://github.com/artsy/gravity/pull/13163, https://github.com/artsy/gravity/pull/13179) and torque (https://github.com/artsy/torque/pull/1180).

This PR updates the resolution logic for the background image, the title, and the description (aka subtitle) to make sure that mobile (app, not web) hero units are taking data from the correct gravity fields.