### PR TITLE
Add bash to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:12.14-alpine
 WORKDIR /app
 
 RUN apk --no-cache --quiet add \
+  bash \
   build-base \
   dumb-init \
   git \


### PR DESCRIPTION
Potential fix to post-deploy errors, adds bash to Dockerfile (node upgrade pr included switch to alpine). I'm guessing that we aren't able to run the script because we don't have bash installed. The error itself is `[dumb-init] .circleci/deploy_event.sh: No such file or directory` however.

https://circleci.com/gh/artsy/metaphysics/10090