### PR TITLE
@dzucconi => [OrderedSets] Readd root type to V2 schema

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7389,6 +7389,13 @@ type Query {
     id: String!
   ): OrderedSet
 
+  # A collection of OrderedSets
+  orderedSets(
+    # Key to the OrderedSet or group of OrderedSets
+    key: String!
+    public: Boolean = true
+  ): [OrderedSet]
+
   # A Partner
   partner(
     # The slug or ID of the Partner
@@ -9233,6 +9240,13 @@ type Viewer {
     # The ID of the OrderedSet
     id: String!
   ): OrderedSet
+
+  # A collection of OrderedSets
+  orderedSets(
+    # Key to the OrderedSet or group of OrderedSets
+    key: String!
+    public: Boolean = true
+  ): [OrderedSet]
 
   # A Partner
   partner(

--- a/src/schema/v2/__tests__/ordered_sets.test.js
+++ b/src/schema/v2/__tests__/ordered_sets.test.js
@@ -1,10 +1,10 @@
 /* eslint-disable promise/always-return */
 import { runQuery } from "schema/v2/test/utils"
 
-xdescribe("OrderedSets type", () => {
+describe("OrderedSets type", () => {
   const query = `
   {
-    orderedSets(key: "artists:featured-genes", page: 1, size: 5) {
+    orderedSets(key: "artists:featured-genes") {
       internalID
       name
       description
@@ -32,11 +32,13 @@ xdescribe("OrderedSets type", () => {
       })
     ),
     setItemsLoader: sinon.stub().returns(
-      Promise.resolve([
-        {
-          name: "Painting",
-        },
-      ])
+      Promise.resolve({
+        body: [
+          {
+            name: "Painting",
+          },
+        ],
+      })
     ),
   }
 

--- a/src/schema/v2/ordered_sets.ts
+++ b/src/schema/v2/ordered_sets.ts
@@ -4,7 +4,6 @@ import {
   GraphQLNonNull,
   GraphQLList,
   GraphQLBoolean,
-  GraphQLInt,
   GraphQLFieldConfig,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
@@ -20,14 +19,6 @@ const OrderedSets: GraphQLFieldConfig<void, ResolverContext> = {
     public: {
       type: GraphQLBoolean,
       defaultValue: true,
-    },
-    page: {
-      type: GraphQLInt,
-      defaultValue: 1,
-    },
-    size: {
-      type: GraphQLInt,
-      defaultValue: 10,
     },
   },
   resolve: async (_root, args, { setsLoader }) => {

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -37,7 +37,7 @@ import Genes from "./genes"
 // import GeneFamilies from "./gene_families"
 // import GeneFamily from "./gene_family"
 import OrderedSet from "./ordered_set"
-// import OrderedSets from "./ordered_sets"
+import OrderedSets from "./ordered_sets"
 // import Profile from "./profile"
 // import Partner from "./partner"
 // import Partners from "./partners"
@@ -130,7 +130,7 @@ const rootFields = {
   me: Me,
   node: ObjectIdentification.NodeField,
   orderedSet: OrderedSet,
-  // orderedSets: OrderedSets,
+  orderedSets: OrderedSets,
   partner: Partner,
   // partnerCategories: PartnerCategories,
   // partnerCategory: PartnerCategory,


### PR DESCRIPTION
This is needed for /artists to be converted to use Metaphysics V2. I was thinking about re-adding this as a connection, but all the use cases of this in Force truly use it as an array and want to fetch all of them (or rather, up to 10 since that's Gravity's default size, and none of the usages in Force specify any size or pagination).

So, I opted to re-add this as a straight list, but explicitly removed any pagination arguments (which were unused).