### PR TITLE
Re-enable Partners root field, convert to connection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6932,6 +6932,17 @@ enum PartnerClassification {
   PRIVATE_DEALER
 }
 
+# A connection to a list of items.
+type PartnerConnection {
+  # A list of edges.
+  edges: [PartnerEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
 type PartnerCounts {
   artistDocuments(
     # Returns a `String` when format is specified. e.g.`'0,0.0000''`
@@ -6988,6 +6999,15 @@ type PartnerCounts {
     format: String
     label: String
   ): FormattedNumber
+}
+
+# An edge in a connection.
+type PartnerEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: Partner
 }
 
 enum PartnerShowPartnerType {
@@ -7404,6 +7424,15 @@ type Query {
     # The slug or ID of the Partner
     id: String!
   ): Partner
+
+  # A list of Partners
+  partners(
+    after: String
+    before: String
+    first: Int
+    ids: [String]
+    last: Int
+  ): PartnerConnection
 
   # A Sale
   sale(
@@ -9256,6 +9285,15 @@ type Viewer {
     # The slug or ID of the Partner
     id: String!
   ): Partner
+
+  # A list of Partners
+  partners(
+    after: String
+    before: String
+    first: Int
+    ids: [String]
+    last: Int
+  ): PartnerConnection
 
   # A Sale
   sale(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6881,8 +6881,6 @@ type PartnerCategory {
   internalID: ID!
   name: String
   partners(
-    after: String
-    before: String
     defaultProfilePublic: Boolean
     eligibleForCarousel: Boolean
 
@@ -6894,10 +6892,8 @@ type PartnerCategory {
 
     # Indicates tier 3/4 for gallery, 2 for institution
     eligibleForSecondaryBucket: Boolean
-    first: Int
     hasFullProfile: Boolean
     ids: [String]
-    last: Int
 
     # Coordinates to find partners closest to
     near: String
@@ -6914,7 +6910,7 @@ type PartnerCategory {
     # term used for searching Partners
     term: String
     type: [PartnerClassification]
-  ): PartnerConnection
+  ): [Partner]
 
   # A slug ID.
   slug: ID!
@@ -6934,17 +6930,6 @@ enum PartnerClassification {
   INSTITUTIONAL_SELLER
   PRIVATE_COLLECTOR
   PRIVATE_DEALER
-}
-
-# A connection to a list of items.
-type PartnerConnection {
-  # A list of edges.
-  edges: [PartnerEdge]
-  pageCursors: PageCursors!
-
-  # Information to aid in pagination.
-  pageInfo: PageInfo!
-  totalCount: Int
 }
 
 type PartnerCounts {
@@ -7003,15 +6988,6 @@ type PartnerCounts {
     format: String
     label: String
   ): FormattedNumber
-}
-
-# An edge in a connection.
-type PartnerEdge {
-  # A cursor for use in pagination
-  cursor: String!
-
-  # The item at the end of the edge
-  node: Partner
 }
 
 enum PartnerShowPartnerType {
@@ -7428,43 +7404,6 @@ type Query {
     # The slug or ID of the Partner
     id: String!
   ): Partner
-
-  # A list of Partners
-  partners(
-    after: String
-    before: String
-    defaultProfilePublic: Boolean
-    eligibleForCarousel: Boolean
-
-    # Indicates an active subscription
-    eligibleForListing: Boolean
-
-    # Indicates tier 1/2 for gallery, 1 for institution
-    eligibleForPrimaryBucket: Boolean
-
-    # Indicates tier 3/4 for gallery, 2 for institution
-    eligibleForSecondaryBucket: Boolean
-    first: Int
-    hasFullProfile: Boolean
-    ids: [String]
-    last: Int
-
-    # Coordinates to find partners closest to
-    near: String
-    page: Int
-
-    #
-    #         Only return partners of the specified partner categories.
-    #         Accepts list of slugs.
-    #
-    partnerCategories: [String]
-    size: Int
-    sort: PartnersSortType
-
-    # term used for searching Partners
-    term: String
-    type: [PartnerClassification]
-  ): PartnerConnection
 
   # A Sale
   sale(
@@ -9317,43 +9256,6 @@ type Viewer {
     # The slug or ID of the Partner
     id: String!
   ): Partner
-
-  # A list of Partners
-  partners(
-    after: String
-    before: String
-    defaultProfilePublic: Boolean
-    eligibleForCarousel: Boolean
-
-    # Indicates an active subscription
-    eligibleForListing: Boolean
-
-    # Indicates tier 1/2 for gallery, 1 for institution
-    eligibleForPrimaryBucket: Boolean
-
-    # Indicates tier 3/4 for gallery, 2 for institution
-    eligibleForSecondaryBucket: Boolean
-    first: Int
-    hasFullProfile: Boolean
-    ids: [String]
-    last: Int
-
-    # Coordinates to find partners closest to
-    near: String
-    page: Int
-
-    #
-    #         Only return partners of the specified partner categories.
-    #         Accepts list of slugs.
-    #
-    partnerCategories: [String]
-    size: Int
-    sort: PartnersSortType
-
-    # term used for searching Partners
-    term: String
-    type: [PartnerClassification]
-  ): PartnerConnection
 
   # A Sale
   sale(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6881,6 +6881,8 @@ type PartnerCategory {
   internalID: ID!
   name: String
   partners(
+    after: String
+    before: String
     defaultProfilePublic: Boolean
     eligibleForCarousel: Boolean
 
@@ -6892,8 +6894,10 @@ type PartnerCategory {
 
     # Indicates tier 3/4 for gallery, 2 for institution
     eligibleForSecondaryBucket: Boolean
+    first: Int
     hasFullProfile: Boolean
     ids: [String]
+    last: Int
 
     # Coordinates to find partners closest to
     near: String
@@ -6910,7 +6914,7 @@ type PartnerCategory {
     # term used for searching Partners
     term: String
     type: [PartnerClassification]
-  ): [Partner]
+  ): PartnerConnection
 
   # A slug ID.
   slug: ID!
@@ -6930,6 +6934,17 @@ enum PartnerClassification {
   INSTITUTIONAL_SELLER
   PRIVATE_COLLECTOR
   PRIVATE_DEALER
+}
+
+# A connection to a list of items.
+type PartnerConnection {
+  # A list of edges.
+  edges: [PartnerEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
 }
 
 type PartnerCounts {
@@ -6988,6 +7003,15 @@ type PartnerCounts {
     format: String
     label: String
   ): FormattedNumber
+}
+
+# An edge in a connection.
+type PartnerEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: Partner
 }
 
 enum PartnerShowPartnerType {
@@ -7407,6 +7431,8 @@ type Query {
 
   # A list of Partners
   partners(
+    after: String
+    before: String
     defaultProfilePublic: Boolean
     eligibleForCarousel: Boolean
 
@@ -7418,8 +7444,10 @@ type Query {
 
     # Indicates tier 3/4 for gallery, 2 for institution
     eligibleForSecondaryBucket: Boolean
+    first: Int
     hasFullProfile: Boolean
     ids: [String]
+    last: Int
 
     # Coordinates to find partners closest to
     near: String
@@ -7436,7 +7464,7 @@ type Query {
     # term used for searching Partners
     term: String
     type: [PartnerClassification]
-  ): [Partner]
+  ): PartnerConnection
 
   # A Sale
   sale(
@@ -9292,6 +9320,8 @@ type Viewer {
 
   # A list of Partners
   partners(
+    after: String
+    before: String
     defaultProfilePublic: Boolean
     eligibleForCarousel: Boolean
 
@@ -9303,8 +9333,10 @@ type Viewer {
 
     # Indicates tier 3/4 for gallery, 2 for institution
     eligibleForSecondaryBucket: Boolean
+    first: Int
     hasFullProfile: Boolean
     ids: [String]
+    last: Int
 
     # Coordinates to find partners closest to
     near: String
@@ -9321,7 +9353,7 @@ type Viewer {
     # term used for searching Partners
     term: String
     type: [PartnerClassification]
-  ): [Partner]
+  ): PartnerConnection
 
   # A Sale
   sale(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7426,7 +7426,7 @@ type Query {
   ): Partner
 
   # A list of Partners
-  partners(
+  partnersConnection(
     after: String
     before: String
     first: Int
@@ -9287,7 +9287,7 @@ type Viewer {
   ): Partner
 
   # A list of Partners
-  partners(
+  partnersConnection(
     after: String
     before: String
     first: Int

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7405,6 +7405,39 @@ type Query {
     id: String!
   ): Partner
 
+  # A list of Partners
+  partners(
+    defaultProfilePublic: Boolean
+    eligibleForCarousel: Boolean
+
+    # Indicates an active subscription
+    eligibleForListing: Boolean
+
+    # Indicates tier 1/2 for gallery, 1 for institution
+    eligibleForPrimaryBucket: Boolean
+
+    # Indicates tier 3/4 for gallery, 2 for institution
+    eligibleForSecondaryBucket: Boolean
+    hasFullProfile: Boolean
+    ids: [String]
+
+    # Coordinates to find partners closest to
+    near: String
+    page: Int
+
+    #
+    #         Only return partners of the specified partner categories.
+    #         Accepts list of slugs.
+    #
+    partnerCategories: [String]
+    size: Int
+    sort: PartnersSortType
+
+    # term used for searching Partners
+    term: String
+    type: [PartnerClassification]
+  ): [Partner]
+
   # A Sale
   sale(
     # The slug or ID of the Sale
@@ -9256,6 +9289,39 @@ type Viewer {
     # The slug or ID of the Partner
     id: String!
   ): Partner
+
+  # A list of Partners
+  partners(
+    defaultProfilePublic: Boolean
+    eligibleForCarousel: Boolean
+
+    # Indicates an active subscription
+    eligibleForListing: Boolean
+
+    # Indicates tier 1/2 for gallery, 1 for institution
+    eligibleForPrimaryBucket: Boolean
+
+    # Indicates tier 3/4 for gallery, 2 for institution
+    eligibleForSecondaryBucket: Boolean
+    hasFullProfile: Boolean
+    ids: [String]
+
+    # Coordinates to find partners closest to
+    near: String
+    page: Int
+
+    #
+    #         Only return partners of the specified partner categories.
+    #         Accepts list of slugs.
+    #
+    partnerCategories: [String]
+    size: Int
+    sort: PartnersSortType
+
+    # term used for searching Partners
+    term: String
+    type: [PartnerClassification]
+  ): [Partner]
 
   # A Sale
   sale(

--- a/src/schema/v2/__tests__/partners.test.js
+++ b/src/schema/v2/__tests__/partners.test.js
@@ -1,7 +1,7 @@
 import { runQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
 
-xdescribe("Partners", () => {
+describe("Partners", () => {
   it("returns a list of partners matching array of ids", async () => {
     const partnersLoader = ({ id }) => {
       if (id) {
@@ -19,11 +19,17 @@ xdescribe("Partners", () => {
     const query = gql`
       {
         partners(ids: ["5a958e8e7622dd49f4f4176d"]) {
-          internalID
+          edges {
+            node {
+              internalID
+            }
+          }
         }
       }
     `
     const { partners } = await runQuery(query, { partnersLoader })
-    expect(partners[0].internalID).toEqual("5a958e8e7622dd49f4f4176d")
+    expect(partners.edges[0].node.internalID).toEqual(
+      "5a958e8e7622dd49f4f4176d"
+    )
   })
 })

--- a/src/schema/v2/__tests__/partners.test.js
+++ b/src/schema/v2/__tests__/partners.test.js
@@ -16,7 +16,7 @@ describe("PartnersConnection", () => {
 
     const query = gql`
       {
-        partners(ids: ["5a958e8e7622dd49f4f4176d"]) {
+        partnersConnection(ids: ["5a958e8e7622dd49f4f4176d"]) {
           edges {
             node {
               internalID
@@ -25,8 +25,8 @@ describe("PartnersConnection", () => {
         }
       }
     `
-    const { partners } = await runQuery(query, { partnersLoader })
-    expect(partners.edges[0].node.internalID).toEqual(
+    const { partnersConnection } = await runQuery(query, { partnersLoader })
+    expect(partnersConnection.edges[0].node.internalID).toEqual(
       "5a958e8e7622dd49f4f4176d"
     )
   })

--- a/src/schema/v2/__tests__/partners.test.js
+++ b/src/schema/v2/__tests__/partners.test.js
@@ -1,6 +1,37 @@
 import { runQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
 
+describe("PartnersConnection", () => {
+  it("returns a list of partners matching array of ids", async () => {
+    const partnersLoader = ({ id }) => {
+      if (id) {
+        return Promise.resolve(
+          id.map((id) => ({
+            _id: id,
+          }))
+        )
+      }
+      throw new Error("Unexpected invocation")
+    }
+
+    const query = gql`
+      {
+        partners(ids: ["5a958e8e7622dd49f4f4176d"]) {
+          edges {
+            node {
+              internalID
+            }
+          }
+        }
+      }
+    `
+    const { partners } = await runQuery(query, { partnersLoader })
+    expect(partners.edges[0].node.internalID).toEqual(
+      "5a958e8e7622dd49f4f4176d"
+    )
+  })
+})
+
 xdescribe("Partners", () => {
   it("returns a list of partners matching array of ids", async () => {
     const partnersLoader = ({ id }) => {

--- a/src/schema/v2/__tests__/partners.test.js
+++ b/src/schema/v2/__tests__/partners.test.js
@@ -1,7 +1,7 @@
 import { runQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
 
-describe("Partners", () => {
+xdescribe("Partners", () => {
   it("returns a list of partners matching array of ids", async () => {
     const partnersLoader = ({ id }) => {
       if (id) {
@@ -19,17 +19,11 @@ describe("Partners", () => {
     const query = gql`
       {
         partners(ids: ["5a958e8e7622dd49f4f4176d"]) {
-          edges {
-            node {
-              internalID
-            }
-          }
+          internalID
         }
       }
     `
     const { partners } = await runQuery(query, { partnersLoader })
-    expect(partners.edges[0].node.internalID).toEqual(
-      "5a958e8e7622dd49f4f4176d"
-    )
+    expect(partners[0].internalID).toEqual("5a958e8e7622dd49f4f4176d")
   })
 })

--- a/src/schema/v2/filter_partners.ts
+++ b/src/schema/v2/filter_partners.ts
@@ -1,5 +1,5 @@
 import _ from "lodash"
-import Partners from "./partners"
+import { Partners } from "./partners"
 import {
   FilterPartnersType,
   PartnersAggregation,

--- a/src/schema/v2/partner_category.ts
+++ b/src/schema/v2/partner_category.ts
@@ -14,7 +14,7 @@ import { ResolverContext } from "types/graphql"
 export const PartnerCategoryType = new GraphQLObjectType<any, ResolverContext>({
   name: "PartnerCategory",
   fields: () => {
-    const Partners = require("./partners").default
+    const { Partners } = require("./partners")
     return {
       ...SlugAndInternalIDFields,
       cached,

--- a/src/schema/v2/partners.ts
+++ b/src/schema/v2/partners.ts
@@ -1,5 +1,5 @@
 import { clone } from "lodash"
-import Partner from "./partner"
+import Partner, { PartnerType } from "./partner"
 import PartnerTypeType from "./input_fields/partner_type_type"
 import {
   GraphQLString,
@@ -10,6 +10,13 @@ import {
   GraphQLFieldConfig,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { pageable } from "relay-cursor-paging"
+import {
+  connectionWithCursorInfo,
+  createPageCursors,
+} from "./fields/pagination"
+import { connectionFromArray } from "graphql-relay"
 
 export const Partners: GraphQLFieldConfig<void, ResolverContext> = {
   type: new GraphQLList(Partner.type),
@@ -129,4 +136,29 @@ export const Partners: GraphQLFieldConfig<void, ResolverContext> = {
   },
 }
 
-// export default Partners
+export const PartnersConnection: GraphQLFieldConfig<void, ResolverContext> = {
+  type: connectionWithCursorInfo({ nodeType: PartnerType }).connectionType,
+  description: "A list of Partners",
+  args: pageable({
+    ids: {
+      type: new GraphQLList(GraphQLString),
+    },
+  }),
+  resolve: (_root, { ..._options }, { partnersLoader }) => {
+    const { page, size } = convertConnectionArgsToGravityArgs(_options)
+    const options: any = {
+      id: _options.ids,
+      page,
+      size,
+    }
+
+    return partnersLoader(options).then((body) => {
+      const totalCount = body.length
+      return {
+        totalCount,
+        pageCursors: createPageCursors({ page, size }, totalCount),
+        ...connectionFromArray(body, options),
+      }
+    })
+  },
+}

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -134,7 +134,7 @@ const rootFields = {
   partner: Partner,
   // partnerCategories: PartnerCategories,
   // partnerCategory: PartnerCategory,
-  partners: PartnersConnection,
+  partnersConnection: PartnersConnection,
   // profile: Profile,
   sale: Sale,
   saleArtwork: SaleArtwork,

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -40,7 +40,7 @@ import OrderedSet from "./ordered_set"
 import OrderedSets from "./ordered_sets"
 // import Profile from "./profile"
 // import Partner from "./partner"
-// import Partners from "./partners"
+import Partners from "./partners"
 // import FilterPartners from "./filter_partners"
 import { filterArtworksConnection } from "./filterArtworksConnection"
 // import PartnerCategory from "./partner_category"
@@ -134,7 +134,7 @@ const rootFields = {
   partner: Partner,
   // partnerCategories: PartnerCategories,
   // partnerCategory: PartnerCategory,
-  // partners: Partners,
+  partners: Partners,
   // profile: Profile,
   sale: Sale,
   saleArtwork: SaleArtwork,

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -40,7 +40,7 @@ import OrderedSet from "./ordered_set"
 import OrderedSets from "./ordered_sets"
 // import Profile from "./profile"
 // import Partner from "./partner"
-import Partners from "./partners"
+// import { Partners } from "./partners"
 // import FilterPartners from "./filter_partners"
 import { filterArtworksConnection } from "./filterArtworksConnection"
 // import PartnerCategory from "./partner_category"
@@ -134,7 +134,7 @@ const rootFields = {
   partner: Partner,
   // partnerCategories: PartnerCategories,
   // partnerCategory: PartnerCategory,
-  partners: Partners,
+  // partners: Partners,
   // profile: Profile,
   sale: Sale,
   saleArtwork: SaleArtwork,

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -40,7 +40,7 @@ import OrderedSet from "./ordered_set"
 import OrderedSets from "./ordered_sets"
 // import Profile from "./profile"
 // import Partner from "./partner"
-// import { Partners } from "./partners"
+import { PartnersConnection } from "./partners"
 // import FilterPartners from "./filter_partners"
 import { filterArtworksConnection } from "./filterArtworksConnection"
 // import PartnerCategory from "./partner_category"
@@ -134,7 +134,7 @@ const rootFields = {
   partner: Partner,
   // partnerCategories: PartnerCategories,
   // partnerCategory: PartnerCategory,
-  // partners: Partners,
+  partners: PartnersConnection,
   // profile: Profile,
   sale: Sale,
   saleArtwork: SaleArtwork,


### PR DESCRIPTION
Partners is required for Positron to use v2, https://github.com/artsy/positron/pull/2734

Addresses: https://artsyproduct.atlassian.net/browse/PLATFORM-2491
Related conversation: https://artsy.slack.com/archives/C1HH3KNJG/p1591886620093000