### PR TITLE
[Do Not Merge] Update Viewing Room artworks connection to use new API V1 endpoint

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7541,6 +7541,19 @@ type Query {
   # Find a viewing room by ID
   viewingRoom(id: ID!): ViewingRoom
 
+  # A list of Viewing Room artworks
+  viewingRoomArtworks(
+    after: String
+    before: String
+    first: Int
+    includeUnlisted: Boolean = false
+    last: Int
+    viewingRoomID: String
+  ): ArtworkConnection
+    @deprecated(
+      reason: "This is only for use in resolving stitched queries, not for first-class client use."
+    )
+
   # List viewing rooms
   viewingRooms(
     # Returns the elements in the list that come after the specified cursor.
@@ -9356,6 +9369,19 @@ type Viewer {
     # ID of the user
     id: String
   ): User
+
+  # A list of Viewing Room artworks
+  viewingRoomArtworks(
+    after: String
+    before: String
+    first: Int
+    includeUnlisted: Boolean = false
+    last: Int
+    viewingRoomID: String
+  ): ArtworkConnection
+    @deprecated(
+      reason: "This is only for use in resolving stitched queries, not for first-class client use."
+    )
 }
 
 # An artwork viewing room

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -45,6 +45,13 @@ export default (opts) => {
     >(({ artwork_id, image_id }) => `artwork/${artwork_id}/image/${image_id}`),
     artworkLoader: gravityLoader((id) => `artwork/${id}`),
     artworksLoader: gravityLoader("artworks"),
+    viewingRoomArtworksLoader: gravityLoader<
+      any,
+      { viewingRoomID: string; includeUnlisted: boolean }
+    >(
+      ({ viewingRoomID, includeUnlisted }) =>
+        `viewing_room/${viewingRoomID}/artworks?include_unlisted=${includeUnlisted}`
+    ),
     bidderLoader: gravityLoader((id) => `bidder/${id}`),
     exchangeRatesLoader: gravityLoader(
       "exchange_rates",

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -33,34 +33,12 @@ describe("gravity/stitching", () => {
       const { artworksConnection } = resolvers.ViewingRoom
       const info = { mergeInfo: { delegateToSchema: jest.fn() } }
 
-      artworksConnection.resolve(
-        { artworkIDs: ["1", "2", "3"] },
-        { first: 2 },
-        {},
-        info
-      )
+      artworksConnection.resolve({ internalID: "1" }, { first: 2 }, {}, info)
 
       expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
-        args: { ids: ["1", "2", "3"], first: 2 },
+        args: { viewingRoomID: "1", first: 2 },
         operation: "query",
-        fieldName: "artworks",
-        schema: expect.anything(),
-        context: expect.anything(),
-        info: expect.anything(),
-      })
-    })
-
-    it("converts empty artworkIDs argument", async () => {
-      const { resolvers } = await getGravityStitchedSchema()
-      const { artworksConnection } = resolvers.ViewingRoom
-      const info = { mergeInfo: { delegateToSchema: jest.fn() } }
-
-      artworksConnection.resolve({ artworkIDs: [] }, { first: 2 }, {}, info)
-
-      expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
-        args: { ids: [null], first: 2 },
-        operation: "query",
-        fieldName: "artworks",
+        fieldName: "viewingRoomArtworks",
         schema: expect.anything(),
         context: expect.anything(),
         info: expect.anything(),

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -88,28 +88,16 @@ export const gravityStitchingEnvironment = (
         artworksConnection: {
           fragment: gql`
             ... on ViewingRoom {
-              artworkIDs
+              internalID
             }
           `,
-          resolve: ({ artworkIDs: ids }, args, context, info) => {
-            // qs ignores empty array/object and prevents us from sending `?array[]=`.
-            // This is a workaround to map an empty array to `[null]` so it gets treated
-            // as an empty string.
-            // https://github.com/ljharb/qs/issues/362
-            //
-            // Note that we can't easily change this globally as there are multiple places
-            // clients are sending params of empty array but expecting Gravity to return
-            // non-empty data. This only fixes the issue for viewing room artworks.
-            if (ids.length === 0) {
-              ids = [null]
-            }
-
+          resolve: ({ internalID: viewingRoomID }, args, context, info) => {
             return info.mergeInfo.delegateToSchema({
               schema: localSchema,
               operation: "query",
-              fieldName: "artworks",
+              fieldName: "viewingRoomArtworks",
               args: {
-                ids,
+                viewingRoomID,
                 ...args,
               },
               context,

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -91,6 +91,7 @@ import Articles from "./articles"
 import SaleArtwork from "./sale_artwork"
 import { SaleArtworksConnectionField } from "./sale_artworks"
 import Artworks from "./artworks"
+import ViewingRoomArtworks from "./viewingRoomArtworks"
 import { TargetSupply } from "./TargetSupply"
 
 const PrincipalFieldDirective = new GraphQLDirective({
@@ -150,6 +151,7 @@ const rootFields = {
   targetSupply: TargetSupply,
   // trendingArtists: TrendingArtists,
   user: UserField,
+  viewingRoomArtworks: ViewingRoomArtworks,
   // users: Users,
   // popularArtists: PopularArtists,
 }

--- a/src/schema/v2/viewingRoomArtworks.ts
+++ b/src/schema/v2/viewingRoomArtworks.ts
@@ -1,0 +1,40 @@
+import { artworkConnection } from "./artwork"
+import { GraphQLString, GraphQLFieldConfig, GraphQLBoolean } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { pageable } from "relay-cursor-paging"
+import { connectionFromArray } from "graphql-relay"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { createPageCursors } from "./fields/pagination"
+
+const ViewingRoomArtworks: GraphQLFieldConfig<void, ResolverContext> = {
+  type: artworkConnection.connectionType,
+  description: "A list of Viewing Room artworks",
+  deprecationReason:
+    "This is only for use in resolving stitched queries, not for first-class client use.",
+  args: pageable({
+    viewingRoomID: {
+      type: GraphQLString,
+    },
+    includeUnlisted: {
+      type: GraphQLBoolean,
+      defaultValue: false,
+    },
+  }),
+  resolve: (_root, options, { viewingRoomArtworksLoader }) => {
+    const { viewingRoomID, includeUnlisted } = options
+    const { page, size } = convertConnectionArgsToGravityArgs(options)
+
+    const params = { viewingRoomID, includeUnlisted: includeUnlisted }
+
+    return viewingRoomArtworksLoader(params).then((body) => {
+      const totalCount = body.length
+      return {
+        totalCount,
+        pageCursors: createPageCursors({ page, size }, totalCount),
+        ...connectionFromArray(body, options),
+      }
+    })
+  },
+}
+
+export default ViewingRoomArtworks


### PR DESCRIPTION
Use `/api/v1/viewing_room/:id/artworks` for viewing room artworks.

Related Gravity PR: https://github.com/artsy/gravity/pull/13206