### PR TITLE
Support includeUnlisted argument for artworksConnection

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -13550,6 +13550,7 @@ type ViewingRoom {
     after: String
     before: String
     first: Int
+    includeUnlisted: Boolean! = false
     last: Int
   ): ArtworkConnection
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7124,9 +7124,7 @@ type Query {
   artwork(
     # The slug or ID of the Artwork
     id: String!
-
-    # Include unlisted artwork or not
-    includeUnlisted: Boolean
+    includeUnlisted: Boolean! = false
   ): Artwork
 
   # List of all artwork attribution classes
@@ -7138,6 +7136,7 @@ type Query {
     before: String
     first: Int
     ids: [String]
+    includeUnlisted: Boolean! = false
     last: Int
   ): ArtworkConnection
     @deprecated(
@@ -9086,9 +9085,7 @@ type Viewer {
   artwork(
     # The slug or ID of the Artwork
     id: String!
-
-    # Include unlisted artwork or not
-    includeUnlisted: Boolean
+    includeUnlisted: Boolean! = false
   ): Artwork
 
   # List of all artwork attribution classes
@@ -9100,6 +9097,7 @@ type Viewer {
     before: String
     first: Int
     ids: [String]
+    includeUnlisted: Boolean! = false
     last: Int
   ): ArtworkConnection
     @deprecated(
@@ -9368,6 +9366,7 @@ type ViewingRoom {
     after: String
     before: String
     first: Int
+    includeUnlisted: Boolean! = false
     last: Int
   ): ArtworkConnection
 

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -59,6 +59,7 @@ export const gravityStitchingEnvironment = (
           last: Int
           after: String
           before: String
+          includeUnlisted: Boolean! = false
         ): ArtworkConnection
         distanceToOpen(short: Boolean! = false): String
         distanceToClose(short: Boolean! = false): String
@@ -130,6 +131,7 @@ export const gravityStitchingEnvironment = (
             // Note that we can't easily change this globally as there are multiple places
             // clients are sending params of empty array but expecting Gravity to return
             // non-empty data. This only fixes the issue for viewing room artworks.
+
             if (ids.length === 0) {
               ids = [null]
             }

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -907,17 +907,15 @@ const Artwork: GraphQLFieldConfig<void, ResolverContext> = {
       description: "The slug or ID of the Artwork",
     },
     includeUnlisted: {
-      type: GraphQLBoolean,
-      description: "Include unlisted artwork or not",
+      type: new GraphQLNonNull(GraphQLBoolean),
+      defaultValue: false,
     },
   },
-  resolve: (_source, args, { artworkLoader }) => {
-    const { id } = args
-    const gravityParams = _.mapKeys(
-      _.pick(args, ["includeUnlisted"]),
-      (_v, k) => _.snakeCase(k)
-    )
-    return artworkLoader(id, gravityParams)
+  resolve: (_root, options, { artworkLoader }) => {
+    const { id, includeUnlisted } = options
+    const params = includeUnlisted ? { include_unlisted: true } : {}
+
+    return artworkLoader(id, params)
   },
 }
 

--- a/src/schema/v2/artworks.ts
+++ b/src/schema/v2/artworks.ts
@@ -1,5 +1,11 @@
 import { artworkConnection } from "./artwork"
-import { GraphQLList, GraphQLString, GraphQLFieldConfig } from "graphql"
+import {
+  GraphQLList,
+  GraphQLString,
+  GraphQLFieldConfig,
+  GraphQLBoolean,
+  GraphQLNonNull,
+} from "graphql"
 import { ResolverContext } from "types/graphql"
 import { pageable } from "relay-cursor-paging"
 import { connectionFromArray } from "graphql-relay"
@@ -15,11 +21,17 @@ const Artworks: GraphQLFieldConfig<void, ResolverContext> = {
     ids: {
       type: new GraphQLList(GraphQLString),
     },
+    includeUnlisted: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      defaultValue: false,
+    },
   }),
   resolve: (_root, options, { artworksLoader }) => {
-    const { ids } = options
+    const { ids, includeUnlisted } = options
+    const params = includeUnlisted ? { ids, include_unlisted: true } : { ids }
     const { page, size } = convertConnectionArgsToGravityArgs(options)
-    return artworksLoader({ ids }).then((body) => {
+
+    return artworksLoader(params).then((body) => {
       const totalCount = body.length
       return {
         totalCount,


### PR DESCRIPTION
Allow the client to request unlisted artworks during a query.

Related Gravity PR: https://github.com/artsy/gravity/pull/13206