### PR TITLE
Add Shows endpoint

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7487,6 +7487,15 @@ type Query {
     id: String!
   ): Show
 
+  # A list of Shows
+  shows(
+    after: String
+    before: String
+    first: Int
+    ids: [String]
+    last: Int
+  ): ShowConnection
+
   # Content for a specific page or view
   staticContent(
     # The slug or id for the view
@@ -9338,6 +9347,15 @@ type Viewer {
     # The slug or ID of the Show
     id: String!
   ): Show
+
+  # A list of Shows
+  shows(
+    after: String
+    before: String
+    first: Int
+    ids: [String]
+    last: Int
+  ): ShowConnection
 
   # Content for a specific page or view
   staticContent(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7488,7 +7488,7 @@ type Query {
   ): Show
 
   # A list of Shows
-  shows(
+  showsConnection(
     after: String
     before: String
     first: Int
@@ -9349,7 +9349,7 @@ type Viewer {
   ): Show
 
   # A list of Shows
-  shows(
+  showsConnection(
     after: String
     before: String
     first: Int

--- a/src/schema/v2/__tests__/shows.test.js
+++ b/src/schema/v2/__tests__/shows.test.js
@@ -1,0 +1,31 @@
+import gql from "lib/gql"
+import { runQuery } from "test/utils"
+
+describe("Shows", () => {
+  it("returns a list of shows matching array of ids", async () => {
+    const showsLoader = ({ id }) => {
+      if (id) {
+        return Promise.resolve(
+          id.map((id) => ({
+            _id: id,
+          }))
+        )
+      }
+      throw new Error("Unexpected invocation")
+    }
+
+    const query = gql`
+      {
+        shows(ids: ["5c406911d545090509a857b9"]) {
+          edges {
+            node {
+              internalID
+            }
+          }
+        }
+      }
+    `
+    const { shows } = await runQuery(query, { showsLoader })
+    expect(shows.edges[0].node.internalID).toEqual("5c406911d545090509a857b9")
+  })
+})

--- a/src/schema/v2/__tests__/shows.test.js
+++ b/src/schema/v2/__tests__/shows.test.js
@@ -1,5 +1,5 @@
 import gql from "lib/gql"
-import { runQuery } from "test/utils"
+import { runQuery } from "schema/v2/test/utils"
 
 describe("Shows", () => {
   it("returns a list of shows matching array of ids", async () => {
@@ -16,7 +16,7 @@ describe("Shows", () => {
 
     const query = gql`
       {
-        shows(ids: ["5c406911d545090509a857b9"]) {
+        showsConnection(ids: ["5c406911d545090509a857b9"]) {
           edges {
             node {
               internalID
@@ -25,7 +25,9 @@ describe("Shows", () => {
         }
       }
     `
-    const { shows } = await runQuery(query, { showsLoader })
-    expect(shows.edges[0].node.internalID).toEqual("5c406911d545090509a857b9")
+    const { showsConnection } = await runQuery(query, { showsLoader })
+    expect(showsConnection.edges[0].node.internalID).toEqual(
+      "5c406911d545090509a857b9"
+    )
   })
 })

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -143,7 +143,7 @@ const rootFields = {
   salesConnection: SalesConnectionField,
   searchConnection: Search,
   show: Show,
-  shows: Shows,
+  showsConnection: Shows,
   staticContent: StaticContent,
   // status: Status,
   system: System,

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -92,6 +92,7 @@ import SaleArtwork from "./sale_artwork"
 import { SaleArtworksConnectionField } from "./sale_artworks"
 import Artworks from "./artworks"
 import { TargetSupply } from "./TargetSupply"
+import { Shows } from "./shows"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -142,6 +143,7 @@ const rootFields = {
   salesConnection: SalesConnectionField,
   searchConnection: Search,
   show: Show,
+  shows: Shows,
   staticContent: StaticContent,
   // status: Status,
   system: System,

--- a/src/schema/v2/shows.ts
+++ b/src/schema/v2/shows.ts
@@ -1,0 +1,37 @@
+import { GraphQLFieldConfig, GraphQLList, GraphQLString } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { createPageCursors } from "./fields/pagination"
+import { ShowsConnection } from "./show"
+import { pageable } from "relay-cursor-paging"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { connectionFromArray } from "graphql-relay"
+
+/**
+ * Root field used (only) by Positron to fetch related content on articles
+ */
+export const Shows: GraphQLFieldConfig<void, ResolverContext> = {
+  type: ShowsConnection.connectionType,
+  description: "A list of Shows",
+  args: pageable({
+    ids: {
+      type: new GraphQLList(GraphQLString),
+    },
+  }),
+  resolve: (_root, { ..._options }, { showsLoader }) => {
+    const { page, size } = convertConnectionArgsToGravityArgs(_options)
+    const options: any = {
+      id: _options.ids,
+      page,
+      size,
+    }
+
+    return showsLoader(options).then((body) => {
+      const totalCount = body.length
+      return {
+        totalCount,
+        pageCursors: createPageCursors({ page, size }, totalCount),
+        ...connectionFromArray(body, options),
+      }
+    })
+  },
+}


### PR DESCRIPTION
Add endpoint `Shows` to fetch a list of shows by id, required for Positron to use v2: artsy/positron#2734

Addresses: https://artsyproduct.atlassian.net/browse/PLATFORM-2541
Related conversation: https://artsy.slack.com/archives/C1HH3KNJG/p1591886620093000
