### PR TITLE
Fix markdown formatter args handling

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4922,6 +4922,14 @@ type Feature {
   subheadline(format: Format): String
 }
 
+# An illustrated link chosen to highlight a Gene from a given GeneFamily
+type FeaturedGeneLink {
+  href: String!
+  image: Image
+  internalID: String!
+  title: String!
+}
+
 type FeaturedLink {
   description(format: Format): String
   href: String
@@ -5403,6 +5411,40 @@ type GeneEdge {
 
   # The item at the end of the edge
   node: Gene
+}
+
+# A user-facing thematic grouping of Genes
+type GeneFamily {
+  featuredGeneLinks: [FeaturedGeneLink]
+  genes: [Gene]
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+  name: String!
+
+  # A slug ID.
+  slug: ID!
+}
+
+# A connection to a list of items.
+type GeneFamilyConnection {
+  # A list of edges.
+  edges: [GeneFamilyEdge]
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+}
+
+# An edge in a connection.
+type GeneFamilyEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: GeneFamily
 }
 
 type GravityMutationError {
@@ -7341,6 +7383,14 @@ type Query {
     id: String!
   ): Gene
 
+  # A list of Gene Families
+  geneFamiliesConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): GeneFamilyConnection
+
   # A list of Genes
   genes(
     size: Int
@@ -9261,6 +9311,14 @@ type Viewer {
     # The slug or ID of the Gene
     id: String!
   ): Gene
+
+  # A list of Gene Families
+  geneFamiliesConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): GeneFamilyConnection
 
   # A list of Genes
   genes(

--- a/src/schema/v2/__tests__/show.test.js
+++ b/src/schema/v2/__tests__/show.test.js
@@ -616,7 +616,7 @@ describe("Show type", () => {
     const query = gql`
       {
         show(id: "new-museum-1-2015-triennial-surround-audience") {
-          pressRelease(format: MARKDOWN)
+          pressRelease(format: HTML)
         }
       }
     `

--- a/src/schema/v2/fields/__tests__/markdown.test.ts
+++ b/src/schema/v2/fields/__tests__/markdown.test.ts
@@ -1,0 +1,42 @@
+import { formatMarkdownValue, markdown } from "../markdown"
+
+describe(formatMarkdownValue, () => {
+  it("formats markdown as html", () => {
+    expect(formatMarkdownValue("Here's some *emphasis* !", "html"))
+      .toMatchInlineSnapshot(`
+      "<p>Here&#39;s some <em>emphasis</em> !</p>
+      "
+    `)
+  })
+  it("formats markdown as markdown", () => {
+    expect(
+      formatMarkdownValue("Here's some *emphasis* !", "markdown")
+    ).toMatchInlineSnapshot(`"Here's some *emphasis* !"`)
+  })
+})
+
+describe(markdown, () => {
+  it("resolves markdown as html", () => {
+    expect(
+      markdown().resolve?.(
+        { description: "Here's a **description** with some *emphasis* !" },
+        { format: "html" },
+        {} as any,
+        { fieldName: "description" } as any
+      )
+    ).toMatchInlineSnapshot(`
+      "<p>Here&#39;s a <strong>description</strong> with some <em>emphasis</em> !</p>
+      "
+    `)
+  })
+  it("resolves markdown as html", () => {
+    expect(
+      markdown().resolve?.(
+        { description: "Here's a **description** with some *emphasis* !" },
+        { format: "markdown" },
+        {} as any,
+        { fieldName: "description" } as any
+      )
+    ).toMatchInlineSnapshot(`"Here's a **description** with some *emphasis* !"`)
+  })
+})

--- a/src/schema/v2/fields/__tests__/markdown.test.ts
+++ b/src/schema/v2/fields/__tests__/markdown.test.ts
@@ -29,7 +29,7 @@ describe(markdown, () => {
       "
     `)
   })
-  it("resolves markdown as html", () => {
+  it("resolves markdown as markdown", () => {
     expect(
       markdown().resolve?.(
         { description: "Here's a **description** with some *emphasis* !" },

--- a/src/schema/v2/fields/markdown.ts
+++ b/src/schema/v2/fields/markdown.ts
@@ -8,7 +8,7 @@ type Format = "html" | "markdown"
 type Value = string | null | undefined
 
 export const formatMarkdownValue = (value: string, format: Format): string => {
-  if (format === "html" || format === "markdown") {
+  if (format === "html") {
     const renderer = new marked.Renderer()
 
     marked.setOptions({


### PR DESCRIPTION
We have this `markdown` helper for text fields. It's for text that contains markdown. It has an optional parameter called `format` which can have a value of either `HTML` or `MARKDOWN`. the `HTML` option is used in web clients to avoid the need to convert the markdown to html in the client itself.

So if you request a text field like

```graphql
someObject {
  textField
}
```

you get markdown back

and if you request a text field like

```graphql
someObject {
  textField(format: HTML)
}
```

you get HTML back

but if you request a text field like

```graphql
someObject {
  textField(format: MARKDOWN)
}
```

you _also get HTML back_ !

This PR fixes that.

This won't be a breaking change. I checked the whole of the artsy org and didn't find any places where the 'markdown' format option is explicitly used.