### PR TITLE
Expose filteredArtworksConnection under ArtistSeries

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -663,6 +663,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     aggregations: [ArtworkAggregation]
     artistID: String
     artistIDs: [String]
+    artistSeriesID: String
     atAuction: Boolean
     attributionClass: [String]
     before: String
@@ -992,6 +993,48 @@ type ArtistSeries {
   artists(page: Int, size: Int): [Artist]
   description: String
   featured: Boolean!
+  filterArtworksConnection(
+    acquireable: Boolean
+    after: String
+    aggregationPartnerCities: [String]
+    aggregations: [ArtworkAggregation]
+    artistID: String
+    artistIDs: [String]
+    artistSeriesID: String
+    atAuction: Boolean
+    attributionClass: [String]
+    before: String
+    color: String
+    dimensionRange: String
+    extraAggregationGeneIDs: [String]
+    first: Int
+    forSale: Boolean
+    geneID: String
+    geneIDs: [String]
+    height: String
+    includeArtworksByFollowedArtists: Boolean
+    includeMediumFilterInAggregation: Boolean
+    inquireableOnly: Boolean
+    keyword: String
+    keywordMatchExact: Boolean
+    last: Int
+    majorPeriods: [String]
+    marketable: Boolean
+    medium: String
+    offerable: Boolean
+    page: Int
+    partnerCities: [String]
+    partnerID: ID
+    period: String
+    periods: [String]
+    priceRange: String
+    saleID: ID
+    size: Int
+    sizes: [ArtworkSizes]
+    sort: String
+    tagID: String
+    width: String
+  ): FilterArtworksConnection
 
   # Unique ID for this artist series
   internalID: ID!
@@ -4573,6 +4616,7 @@ interface EntityWithFilterArtworksConnectionInterface {
     aggregations: [ArtworkAggregation]
     artistID: String
     artistIDs: [String]
+    artistSeriesID: String
     atAuction: Boolean
     attributionClass: [String]
     before: String
@@ -4713,6 +4757,7 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
     aggregations: [ArtworkAggregation]
     artistID: String
     artistIDs: [String]
+    artistSeriesID: String
     atAuction: Boolean
     attributionClass: [String]
     before: String
@@ -5315,6 +5360,7 @@ type Gene implements Node & Searchable {
     aggregations: [ArtworkAggregation]
     artistID: String
     artistIDs: [String]
+    artistSeriesID: String
     atAuction: Boolean
     attributionClass: [String]
     before: String
@@ -5922,6 +5968,7 @@ type MarketingCollection {
     aggregations: [ArtworkAggregation]
     artistID: String
     artistIDs: [String]
+    artistSeriesID: String
     atAuction: Boolean
     attributionClass: [String]
     before: String
@@ -7152,6 +7199,7 @@ type Query {
     aggregations: [ArtworkAggregation]
     artistID: String
     artistIDs: [String]
+    artistSeriesID: String
     atAuction: Boolean
     attributionClass: [String]
     before: String
@@ -8351,6 +8399,7 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
     aggregations: [ArtworkAggregation]
     artistID: String
     artistIDs: [String]
+    artistSeriesID: String
     atAuction: Boolean
     attributionClass: [String]
     before: String
@@ -8731,6 +8780,7 @@ type Tag implements Node {
     aggregations: [ArtworkAggregation]
     artistID: String
     artistIDs: [String]
+    artistSeriesID: String
     atAuction: Boolean
     attributionClass: [String]
     before: String
@@ -9114,6 +9164,7 @@ type Viewer {
     aggregations: [ArtworkAggregation]
     artistID: String
     artistIDs: [String]
+    artistSeriesID: String
     atAuction: Boolean
     attributionClass: [String]
     before: String

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -17,6 +17,57 @@ const momentSubtract = (...args) => {
 }
 
 describe("gravity/stitching", () => {
+  describe("filterArtworksConnection", () => {
+    it("extends the ArtistSeries type with a filterArtworksConnection field for the V2 schema", async () => {
+      const schemaVersion = 2
+      const mergedSchema = await getGravityMergedSchema(schemaVersion)
+      const artistSeriesFields = await getFieldsForTypeFromSchema(
+        "ArtistSeries",
+        mergedSchema
+      )
+      expect(artistSeriesFields).toContain("filterArtworksConnection")
+    })
+
+    it("does not extend the ArtistSeries type with a filterArtworksConnection field for the V1 schema", async () => {
+      const schemaVersion = 1
+      const mergedSchema = await getGravityMergedSchema(schemaVersion)
+      const artistSeriesFields = await getFieldsForTypeFromSchema(
+        "ArtistSeries",
+        mergedSchema
+      )
+      expect(artistSeriesFields).not.toContain("filterArtworksConnection")
+    })
+
+    it("resolves the filterArtworksConnection field on ArtistSeries for the V2 schema", async () => {
+      const schemaVersion = 2
+      const { resolvers } = await getGravityStitchedSchema(schemaVersion)
+      const { filterArtworksConnection } = resolvers.ArtistSeries
+      const info = { mergeInfo: { delegateToSchema: jest.fn() } }
+
+      filterArtworksConnection.resolve(
+        { internalID: "abc123" },
+        { first: 2 },
+        {},
+        info
+      )
+
+      expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
+        args: { artistSeriesID: "abc123", first: 2 },
+        operation: "query",
+        fieldName: "artworksConnection",
+        schema: expect.anything(),
+        context: expect.anything(),
+        info: expect.anything(),
+      })
+    })
+
+    it("does not resolve the filterArtworksConnection field on ArtistSeries for the V1 schema", async () => {
+      const schemaVersion = 1
+      const { resolvers } = await getGravityStitchedSchema(schemaVersion)
+      expect(resolvers.ArtistSeries.filterArtworksConnection).toBeUndefined()
+    })
+  })
+
   describe("#artworksConnection", () => {
     it("extends the ViewingRoom type with an artworksConnection field", async () => {
       const mergedSchema = await getGravityMergedSchema()

--- a/src/lib/stitching/gravity/__tests__/testingUtils.ts
+++ b/src/lib/stitching/gravity/__tests__/testingUtils.ts
@@ -5,8 +5,6 @@ import { executableGravitySchema } from "../schema"
 import localSchema from "schema/v2/schema"
 
 let cachedSchema: GraphQLSchema & { transforms: any }
-let stitchedSchema: ReturnType<typeof gravityStitchingEnvironment>
-let mergedSchema: GraphQLSchema & { transforms: any }
 
 /** Gets a cached copy of the transformed gravity schema  */
 export const getGravityTransformedSchema = async () => {
@@ -17,29 +15,27 @@ export const getGravityTransformedSchema = async () => {
 }
 
 /** Gets a cached copy of the stitched schema, independent of being merged into the local schema */
-export const getGravityStitchedSchema = async () => {
-  if (!stitchedSchema) {
-    const cachedSchema = await getGravityTransformedSchema()
-    stitchedSchema = gravityStitchingEnvironment(localSchema, cachedSchema)
-  }
-  return stitchedSchema
+export const getGravityStitchedSchema = async (schemaVersion = 2) => {
+  const cachedSchema = await getGravityTransformedSchema()
+  return gravityStitchingEnvironment(localSchema, cachedSchema, schemaVersion)
 }
 
 /** Gets a cached fully setup schema with gravity and the localSchema set up */
-export const getGravityMergedSchema = async () => {
-  if (!mergedSchema) {
-    const cachedSchema = await getGravityTransformedSchema()
-    const { extensionSchema, resolvers } = await getGravityStitchedSchema()
+export const getGravityMergedSchema = async (schemaVersion = 2) => {
+  const cachedSchema = await getGravityTransformedSchema()
+  const { extensionSchema, resolvers } = await getGravityStitchedSchema(
+    schemaVersion
+  )
 
-    // The order should only matter in that extension schemas come after the
-    // objects that they are expected to build upon
-    mergedSchema = mergeSchemas({
-      schemas: [localSchema, cachedSchema, extensionSchema],
-      resolvers: resolvers,
-    }) as GraphQLSchema & { transforms: any }
+  // The order should only matter in that extension schemas come after the
+  // objects that they are expected to build upon
+  const mergedSchema = mergeSchemas({
+    schemas: [localSchema, cachedSchema, extensionSchema],
+    resolvers: resolvers,
+  }) as GraphQLSchema & { transforms: any }
 
-    const anyMergedSchema = mergedSchema as any
-    anyMergedSchema.__allowedLegacyNames = ["__id"]
-  }
+  const anyMergedSchema = mergedSchema as any
+  anyMergedSchema.__allowedLegacyNames = ["__id"]
+
   return mergedSchema
 }

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -1,7 +1,15 @@
 import gql from "lib/gql"
-import { GraphQLSchema } from "graphql"
+import {
+  GraphQLSchema,
+  GraphQLFieldConfigArgumentMap,
+  GraphQLType,
+  isScalarType,
+  isListType,
+  isEnumType,
+} from "graphql"
 import moment from "moment"
 import { defineCustomLocale } from "lib/helpers"
+import { pageableFilterArtworksArgs } from "schema/v2/filterArtworksConnection"
 
 const LocaleEnViewingRoomRelativeShort = "en-viewing-room-relative-short"
 defineCustomLocale(LocaleEnViewingRoomRelativeShort, {
@@ -42,9 +50,30 @@ defineCustomLocale(LocaleEnViewingRoomRelativeLong, {
   },
 })
 
+function argsToSDL(args: GraphQLFieldConfigArgumentMap) {
+  const result: string[] = []
+  Object.keys(args).forEach((argName) => {
+    result.push(`${argName}: ${printType(args[argName].type)}`)
+  })
+  return result
+}
+
+function printType(type: GraphQLType): string {
+  if (isScalarType(type)) {
+    return type.name
+  } else if (isListType(type)) {
+    return `[${printType(type.ofType)}]`
+  } else if (isEnumType(type)) {
+    return type.name
+  } else {
+    throw new Error(`Unknown type: ${JSON.stringify(type)}`)
+  }
+}
+
 export const gravityStitchingEnvironment = (
   localSchema: GraphQLSchema,
-  gravitySchema: GraphQLSchema & { transforms: any }
+  gravitySchema: GraphQLSchema & { transforms: any },
+  schemaVersion: number
 ) => {
   return {
     // The SDL used to declare how to stitch an object
@@ -67,6 +96,13 @@ export const gravityStitchingEnvironment = (
 
       extend type ArtistSeries {
         artists(page: Int, size: Int): [Artist]
+        ${
+          schemaVersion === 2
+            ? `filterArtworksConnection(${argsToSDL(
+                pageableFilterArtworksArgs
+              ).join("\n")}): FilterArtworksConnection`
+            : ""
+        }
       }
 
       extend type Partner {
@@ -113,6 +149,28 @@ export const gravityStitchingEnvironment = (
             })
           },
         },
+        ...(schemaVersion === 2 && {
+          filterArtworksConnection: {
+            fragment: `
+          ... on ArtistSeries {
+            internalID
+          }
+        `,
+            resolve: ({ internalID: artistSeriesID }, args, context, info) => {
+              return info.mergeInfo.delegateToSchema({
+                schema: localSchema,
+                operation: "query",
+                fieldName: "artworksConnection",
+                args: {
+                  artistSeriesID,
+                  ...args,
+                },
+                context,
+                info,
+              })
+            },
+          },
+        }),
       },
       ViewingRoom: {
         artworksConnection: {

--- a/src/lib/stitching/mergeSchemas.ts
+++ b/src/lib/stitching/mergeSchemas.ts
@@ -53,7 +53,7 @@ export const incrementalMergeSchemas = (
   schemas.push(gravitySchema)
 
   useStitchingEnvironment(
-    gravityStitchingEnvironment(localSchema, gravitySchema)
+    gravityStitchingEnvironment(localSchema, gravitySchema, version)
   )
 
   if (ENABLE_COMMERCE_STITCHING) {

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -204,7 +204,12 @@ export const filterArtworksArgs: GraphQLFieldConfigArgumentMap = {
     type: GraphQLBoolean,
     description: "When true, will only return exact keyword match",
   },
+  artistSeriesID: {
+    type: GraphQLString,
+  },
 }
+
+export const pageableFilterArtworksArgs = pageable(filterArtworksArgs)
 
 export const FilterArtworksFields = () => {
   return {
@@ -368,6 +373,7 @@ const filterArtworksConnectionTypeFactory = (
       aggregationPartnerCities,
       artistID,
       artistIDs,
+      artistSeriesID,
       atAuction,
       attributionClass,
       sizes,
@@ -398,6 +404,7 @@ const filterArtworksConnectionTypeFactory = (
       aggregation_partner_cities: aggregationPartnerCities,
       artist_id: artistID,
       artist_ids: artistIDs,
+      artist_series_id: artistSeriesID,
       at_auction: atAuction,
       attribution_class: attributionClass,
       sizes: sizes,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2035

---

## Problem

Users need to be able to look up all the artworks associated with a given artist series.

## Solution

After modifying the `/filter/artworks` endpoint to be able to query for artworks associated with an artist series (https://github.com/artsy/gravity/pull/13211), we now need to expose querying for an artist series's artworks in Metaphysics. Once this is merged, a frontend client will be able to request the artworks associated with an artist series.

The bulk of this work is stitching `FilterArtworks` into `ArtistSeries` for v2. We did _not_ stitch for v1 because we are deprecating v1.

![Screen Shot 2020-07-06 at 1 45 13 PM](https://user-images.githubusercontent.com/4432348/86623090-f7179300-bf8e-11ea-92c2-b96e0e5b7d32.png)
