### PR TITLE
[PURCHASE-1959] Add `include_delivery_pending` flag to impulse `message_details` query

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4922,6 +4922,14 @@ type Feature {
   subheadline(format: Format): String
 }
 
+# An illustrated link chosen to highlight a Gene from a given GeneFamily
+type FeaturedGeneLink {
+  href: String!
+  image: Image
+  internalID: String!
+  title: String!
+}
+
 type FeaturedLink {
   description(format: Format): String
   href: String
@@ -5403,6 +5411,40 @@ type GeneEdge {
 
   # The item at the end of the edge
   node: Gene
+}
+
+# A user-facing thematic grouping of Genes
+type GeneFamily {
+  featuredGeneLinks: [FeaturedGeneLink]
+  genes: [Gene]
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+  name: String!
+
+  # A slug ID.
+  slug: ID!
+}
+
+# A connection to a list of items.
+type GeneFamilyConnection {
+  # A list of edges.
+  edges: [GeneFamilyEdge]
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+}
+
+# An edge in a connection.
+type GeneFamilyEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: GeneFamily
 }
 
 type GravityMutationError {
@@ -7341,6 +7383,14 @@ type Query {
     id: String!
   ): Gene
 
+  # A list of Gene Families
+  geneFamiliesConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): GeneFamilyConnection
+
   # A list of Genes
   genes(
     size: Int
@@ -9261,6 +9311,14 @@ type Viewer {
     # The slug or ID of the Gene
     id: String!
   ): Gene
+
+  # A list of Gene Families
+  geneFamiliesConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): GeneFamilyConnection
 
   # A list of Genes
   genes(

--- a/src/lib/loaders/loaders_with_authentication/impulse.ts
+++ b/src/lib/loaders/loaders_with_authentication/impulse.ts
@@ -39,7 +39,9 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" }
     ),
-    conversationMessagesLoader: impulseLoader("message_details"),
+    conversationMessagesLoader: impulseLoader("message_details", {
+      include_delivery_pending: true,
+    }),
     conversationCreateMessageLoader: impulseLoader(
       (id) => `conversations/${id}/messages`,
       {


### PR DESCRIPTION
Fixes [PURCHASE-1959](https://artsyproduct.atlassian.net/browse/PURCHASE-1959) and last piece of [PURCHASE-1954](https://artsyproduct.atlassian.net/browse/PURCHASE-1954)

Follow up to https://github.com/artsy/impulse/pull/621 we want the client to see authorized pending delivery messages