### PR TITLE
salesConnection endpoint can return unpublished content to team users

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7590,14 +7590,14 @@ type Query {
     ids: [String]
 
     # Limit by auction.
-    isAuction: Boolean = true
+    isAuction: Boolean
     last: Int
 
     # Limit by live status.
-    live: Boolean = true
+    live: Boolean
 
     # Limit by published status.
-    published: Boolean = true
+    published: Boolean
     sort: SaleSorts
   ): SaleConnection
 
@@ -9488,14 +9488,14 @@ type Viewer {
     ids: [String]
 
     # Limit by auction.
-    isAuction: Boolean = true
+    isAuction: Boolean
     last: Int
 
     # Limit by live status.
-    live: Boolean = true
+    live: Boolean
 
     # Limit by published status.
-    published: Boolean = true
+    published: Boolean
     sort: SaleSorts
   ): SaleConnection
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import { LoggingExtension } from "./extensions/loggingExtension"
 import { principalFieldDirectiveExtension } from "./extensions/principalFieldDirectiveExtension"
 import { principalFieldDirectiveValidation } from "validations/principalFieldDirectiveValidation"
 import * as Sentry from "@sentry/node"
+import { decodeUnverifiedJWT } from "./lib/decodeUnverifiedJWT"
 
 const {
   ENABLE_REQUEST_LOGGING,
@@ -209,9 +210,13 @@ function startApp(appSchema, path: string) {
           appToken,
         })
 
+        const decodedToken = accessToken && decodeUnverifiedJWT(accessToken)
+        const userRoles = (decodedToken && decodedToken.roles.split(",")) || []
+
         const context: ResolverContext = {
           accessToken,
           userID,
+          userRoles,
           defaultTimezone,
           ...loaders,
           // For stitching purposes

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -185,6 +185,7 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    salesLoaderWithHeaders: gravityLoader("sales", {}, { headers: true }),
     saveArtworkLoader: gravityLoader(
       (id) => `collection/saved-artwork/artwork/${id}`,
       {},

--- a/src/schema/v2/__tests__/sales.test.ts
+++ b/src/schema/v2/__tests__/sales.test.ts
@@ -1,0 +1,58 @@
+import { runQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+import sinon from "sinon"
+
+describe("SalesConnection", () => {
+  const salesData = {
+    body: [{ _id: "5a958e8e7622dd49f4f4176d" }],
+    headers: {
+      "x-total-count": 1,
+    },
+  }
+  const query = gql`
+    {
+      salesConnection(ids: ["5a958e8e7622dd49f4f4176d"]) {
+        edges {
+          node {
+            internalID
+          }
+        }
+      }
+    }
+  `
+  it("returns a list of sales matching array of ids", async () => {
+    const { salesConnection } = await runQuery(query, {
+      userRoles: [],
+      unauthenticatedLoaders: {
+        salesLoaderWithHeaders: sinon
+          .stub()
+          .returns(Promise.resolve(salesData)),
+      },
+      authenticatedLoaders: {
+        salesLoaderWithHeaders: sinon
+          .stub()
+          .returns(Promise.resolve(salesData)),
+      },
+    })
+    expect(salesConnection.edges[0].node.internalID).toEqual(
+      "5a958e8e7622dd49f4f4176d"
+    )
+  })
+
+  it("uses authenticated loader if userRoles includes team", async () => {
+    const { salesConnection } = await runQuery(query, {
+      userRoles: ["team"],
+      unauthenticatedLoaders: {
+        salesLoaderWithHeaders: sinon.stub().returns(Promise.resolve()),
+      },
+      authenticatedLoaders: {
+        salesLoaderWithHeaders: sinon
+          .stub()
+          .returns(Promise.resolve(salesData)),
+      },
+    })
+    expect(salesConnection.edges[0].node.internalID).toEqual(
+      "5a958e8e7622dd49f4f4176d"
+    )
+  })
+})

--- a/src/types/graphql.d.ts
+++ b/src/types/graphql.d.ts
@@ -6,6 +6,8 @@ export interface ResolverContextValues {
   accessToken?: string
   /** Optionally you can include a user token for a logged in user */
   userID?: string
+  /** Decoded roles from access token */
+  userRoles: string[]
   /** Optionally you should include a timezone for the user */
   defaultTimezone?: string
 


### PR DESCRIPTION
- Adds `userRoles` to `ResolverContext`, decoded from JWT when present
Updates `salesConnection` to:
- remove default arguments `published`, `isAdmin`, `isLive` (let gravity provide defaults)
- use authenticated loader if user role is `team`

Context:
Positron's admin UI allows artsy staff to link articles to gravity models. The `salesConnection` must return unpublished/non-live content so that these associations can be added or removed from an article despite changes to publish status. 

This endpoint is limited to `team` under the assumption that all `admin` users are also `team` users. The positron UI is currently limited to `admin`s only, but is ticketed to use `team` instead.

Follow up to https://github.com/artsy/metaphysics/pull/2499
Related to https://artsyproduct.atlassian.net/browse/PLATFORM-2473 and https://artsyproduct.atlassian.net/browse/PLATFORM-2320