### PR TITLE
Reenable users endpoint, convert to connection.

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7688,6 +7688,15 @@ type Query {
     id: String
   ): User
 
+  # A list of Users
+  usersConnection(
+    after: String
+    before: String
+    first: Int
+    ids: [String]
+    last: Int
+  ): UserConnection
+
   # A wildcard used to support complex root queries in Relay
   viewer: Viewer
 
@@ -9191,6 +9200,26 @@ type User {
   userAlreadyExists: Boolean
 }
 
+# A connection to a list of items.
+type UserConnection {
+  # A list of edges.
+  edges: [UserEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type UserEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: User
+}
+
 # A wildcard used to support complex root queries in Relay
 type Viewer {
   # An Article
@@ -9555,6 +9584,15 @@ type Viewer {
     # ID of the user
     id: String
   ): User
+
+  # A list of Users
+  usersConnection(
+    after: String
+    before: String
+    first: Int
+    ids: [String]
+    last: Int
+  ): UserConnection
 }
 
 # An artwork viewing room

--- a/src/schema/v2/__tests__/users.test.js
+++ b/src/schema/v2/__tests__/users.test.js
@@ -11,12 +11,20 @@ describe("Users", () => {
     }
     const query = gql`
       {
-        users(ids: ["5a9075da8b3b817ede4f8767"]) {
-          internalID
+        usersConnection(ids: ["5a9075da8b3b817ede4f8767"]) {
+          edges {
+            node {
+              internalID
+            }
+          }
         }
       }
     `
-    const { users } = await runAuthenticatedQuery(query, { usersLoader })
-    expect(users[0].internalID).toEqual("5a9075da8b3b817ede4f8767")
+    const { usersConnection } = await runAuthenticatedQuery(query, {
+      usersLoader,
+    })
+    expect(usersConnection.edges[0].node.internalID).toEqual(
+      "5a9075da8b3b817ede4f8767"
+    )
   })
 })

--- a/src/schema/v2/__tests__/users.test.js
+++ b/src/schema/v2/__tests__/users.test.js
@@ -1,7 +1,7 @@
 import { runAuthenticatedQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
 
-xdescribe("Users", () => {
+describe("Users", () => {
   it("returns a list of users matching array of ids", async () => {
     const usersLoader = (data) => {
       if (data.id) {

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -47,7 +47,7 @@ import { filterArtworksConnection } from "./filterArtworksConnection"
 // import SuggestedGenes from "./suggested_genes"
 import { TagField } from "./tag"
 // import TrendingArtists from "./artists/trending"
-// import Users from "./users"
+import Users from "./users"
 import { UserField } from "./user"
 // import MatchGene from "./match/gene"
 // import CausalityJWT from "./causality_jwt"
@@ -152,7 +152,7 @@ const rootFields = {
   targetSupply: TargetSupply,
   // trendingArtists: TrendingArtists,
   user: UserField,
-  // users: Users,
+  users: Users,
   // popularArtists: PopularArtists,
 }
 

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -47,7 +47,7 @@ import { filterArtworksConnection } from "./filterArtworksConnection"
 // import SuggestedGenes from "./suggested_genes"
 import { TagField } from "./tag"
 // import TrendingArtists from "./artists/trending"
-import Users from "./users"
+import { Users } from "./users"
 import { UserField } from "./user"
 // import MatchGene from "./match/gene"
 // import CausalityJWT from "./causality_jwt"
@@ -152,7 +152,7 @@ const rootFields = {
   targetSupply: TargetSupply,
   // trendingArtists: TrendingArtists,
   user: UserField,
-  users: Users,
+  usersConnection: Users,
   // popularArtists: PopularArtists,
 }
 

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -9,6 +9,7 @@ import cached from "./fields/cached"
 import { InternalIDFields } from "./object_identification"
 import { LocationType } from "schema/v2/location"
 import { ResolverContext } from "types/graphql"
+import { connectionWithCursorInfo } from "./fields/pagination"
 
 export const UserType = new GraphQLObjectType<any, ResolverContext>({
   name: "User",
@@ -86,3 +87,5 @@ export const UserField: GraphQLFieldConfig<void, ResolverContext> = {
       })
   },
 }
+
+export const UsersConnection = connectionWithCursorInfo({ nodeType: UserType })


### PR DESCRIPTION
Required for Positron to migrate to v2.

Re-enables `users` endpoint as `usersConnection`.

Addresses https://artsyproduct.atlassian.net/browse/PLATFORM-2574
Related to https://artsyproduct.atlassian.net/browse/PLATFORM-2473