### PR TITLE
Add artistSeriesConnection and stitch into Artist

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -624,6 +624,7 @@ type Artist implements Node & Searchable {
     # The number of Artists to return
     size: Int
   ): [Artist]
+  artistSeriesConnection: ArtistSeriesConnection
   artworks(
     exclude: [String]
     filter: [ArtistArtworksFilters]
@@ -1257,12 +1258,37 @@ type ArtistSeries {
   artists(page: Int, size: Int): [Artist]
   description: String
   featured: Boolean!
+  imageHeight: Int
+  imageURL: String
+  imageWidth: Int
 
   # Unique ID for this artist series
   internalID: ID!
   published: Boolean!
+  representativeArtworkID: ID
   slug: String!
   title: String!
+}
+
+# The connection type for ArtistSeries.
+type ArtistSeriesConnection {
+  # A list of edges.
+  edges: [ArtistSeriesEdge]
+
+  # A list of nodes.
+  nodes: [ArtistSeries]
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+}
+
+# An edge in a connection.
+type ArtistSeriesEdge {
+  # A cursor for use in pagination.
+  cursor: String!
+
+  # The item at the end of the edge.
+  node: ArtistSeries
 }
 
 enum ArtistSorts {
@@ -10731,6 +10757,24 @@ type Query {
 
   # Find an artist series by ID
   artistSeries(id: ID!): ArtistSeries
+
+  # List all artist series, optionally filtered by artist
+  artistSeriesConnection(
+    # Returns the elements in the list that come after the specified cursor.
+    after: String
+
+    # ID of the artist by which to filter results
+    artistID: ID
+
+    # Returns the elements in the list that come before the specified cursor.
+    before: String
+
+    # Returns the first _n_ elements from the list.
+    first: Int
+
+    # Returns the last _n_ elements from the list.
+    last: Int
+  ): ArtistSeriesConnection
 
   # An Artwork
   artwork(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -579,6 +579,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     limit: Int
     sort: ArticleSorts
   ): ArticleConnection
+  artistSeriesConnection: ArtistSeriesConnection
   artworksConnection(
     after: String
     before: String
@@ -1035,12 +1036,37 @@ type ArtistSeries {
     tagID: String
     width: String
   ): FilterArtworksConnection
+  imageHeight: Int
+  imageURL: String
+  imageWidth: Int
 
   # Unique ID for this artist series
   internalID: ID!
   published: Boolean!
+  representativeArtworkID: ID
   slug: String!
   title: String!
+}
+
+# The connection type for ArtistSeries.
+type ArtistSeriesConnection {
+  # A list of edges.
+  edges: [ArtistSeriesEdge]
+
+  # A list of nodes.
+  nodes: [ArtistSeries]
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+}
+
+# An edge in a connection.
+type ArtistSeriesEdge {
+  # A cursor for use in pagination.
+  cursor: String!
+
+  # The item at the end of the edge.
+  node: ArtistSeries
 }
 
 enum ArtistSorts {
@@ -7228,6 +7254,24 @@ type Query {
 
   # Find an artist series by ID
   artistSeries(id: ID!): ArtistSeries
+
+  # List all artist series, optionally filtered by artist
+  artistSeriesConnection(
+    # Returns the elements in the list that come after the specified cursor.
+    after: String
+
+    # ID of the artist by which to filter results
+    artistID: ID
+
+    # Returns the elements in the list that come before the specified cursor.
+    before: String
+
+    # Returns the first _n_ elements from the list.
+    first: Int
+
+    # Returns the last _n_ elements from the list.
+    last: Int
+  ): ArtistSeriesConnection
 
   # An Artwork
   artwork(

--- a/src/data/gravity.graphql
+++ b/src/data/gravity.graphql
@@ -77,14 +77,53 @@ type ArtistSeries {
   artistIDs: [String!]!
   description: String
   featured: Boolean!
+  imageHeight: Int
+  imageURL: String
+  imageWidth: Int
 
   """
   Unique ID for this artist series
   """
   internalID: ID!
   published: Boolean!
+  representativeArtworkID: ID
   slug: String!
   title: String!
+}
+
+"""
+The connection type for ArtistSeries.
+"""
+type ArtistSeriesConnection {
+  """
+  A list of edges.
+  """
+  edges: [ArtistSeriesEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [ArtistSeries]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type ArtistSeriesEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: ArtistSeries
 }
 
 """
@@ -816,6 +855,36 @@ type Query {
   Find an artist series by ID
   """
   artistSeries(id: ID!): ArtistSeries
+
+  """
+  List all artist series, optionally filtered by artist
+  """
+  artistSeriesConnection(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    ID of the artist by which to filter results
+    """
+    artistID: ID
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): ArtistSeriesConnection
 
   """
   Find artists by ID

--- a/src/lib/stitching/gravity/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/gravity/__tests__/__snapshots__/schema.test.ts.snap
@@ -29,12 +29,37 @@ type ArtistSeries {
   artistIDs: [String!]!
   description: String
   featured: Boolean!
+  imageHeight: Int
+  imageURL: String
+  imageWidth: Int
 
   # Unique ID for this artist series
   internalID: ID!
   published: Boolean!
+  representativeArtworkID: ID
   slug: String!
   title: String!
+}
+
+# The connection type for ArtistSeries.
+type ArtistSeriesConnection {
+  # A list of edges.
+  edges: [ArtistSeriesEdge]
+
+  # A list of nodes.
+  nodes: [ArtistSeries]
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+}
+
+# An edge in a connection.
+type ArtistSeriesEdge {
+  # A cursor for use in pagination.
+  cursor: String!
+
+  # The item at the end of the edge.
+  node: ArtistSeries
 }
 
 # Backup Two-Factor Authentication factor
@@ -386,6 +411,24 @@ type PageInfo {
 type Query {
   # Find an artist series by ID
   artistSeries(id: ID!): ArtistSeries
+
+  # List all artist series, optionally filtered by artist
+  artistSeriesConnection(
+    # Returns the elements in the list that come after the specified cursor.
+    after: String
+
+    # ID of the artist by which to filter results
+    artistID: ID
+
+    # Returns the elements in the list that come before the specified cursor.
+    before: String
+
+    # Returns the first _n_ elements from the list.
+    first: Int
+
+    # Returns the last _n_ elements from the list.
+    last: Int
+  ): ArtistSeriesConnection
 
   # Autocomplete resolvers.
   _unused_gravity_matchPartners(matchType: String, page: Int = 1, size: Int = 5, term: String!): [DoNotUseThisPartner!]

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -492,4 +492,30 @@ describe("gravity/stitching", () => {
       })
     })
   })
+
+  describe("#artist", () => {
+    it("extends the Artist type with an artistSeriesConnection field", async () => {
+      const mergedSchema = await getGravityMergedSchema()
+      const artist = await getFieldsForTypeFromSchema("Artist", mergedSchema)
+
+      expect(artist).toContain("artistSeriesConnection")
+    })
+
+    it("resolves the artistSeriesConnection field on Artist", async () => {
+      const { resolvers } = await getGravityStitchedSchema()
+      const { artistSeriesConnection } = resolvers.Artist
+      const info = { mergeInfo: { delegateToSchema: jest.fn() } }
+
+      artistSeriesConnection.resolve({ internalID: "fakeid" }, {}, {}, info)
+
+      expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
+        args: { artistID: "fakeid" },
+        operation: "query",
+        fieldName: "artistSeriesConnection",
+        schema: expect.anything(),
+        context: expect.anything(),
+        info: expect.anything(),
+      })
+    })
+  })
 })

--- a/src/lib/stitching/gravity/schema.ts
+++ b/src/lib/stitching/gravity/schema.ts
@@ -8,7 +8,12 @@ import {
 } from "graphql-tools"
 import { readFileSync } from "fs"
 
-const allowList = ["viewingRoom", "viewingRooms", "artistSeries"]
+const allowList = [
+  "viewingRoom",
+  "viewingRooms",
+  "artistSeries",
+  "artistSeriesConnection",
+]
 
 export const executableGravitySchema = () => {
   const gravityTypeDefs = readFileSync("src/data/gravity.graphql", "utf8")

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -114,6 +114,10 @@ export const gravityStitchingEnvironment = (
       extend type Partner {
         viewingRoomsConnection(published: Boolean = true): ViewingRoomConnection
       }
+
+      extend type Artist {
+        artistSeriesConnection: ArtistSeriesConnection
+      }
     `,
     resolvers: {
       Me: {
@@ -353,6 +357,28 @@ export const gravityStitchingEnvironment = (
               fieldName: "viewingRooms",
               args: {
                 partnerID,
+                ...args,
+              },
+              context,
+              info,
+            })
+          },
+        },
+      },
+      Artist: {
+        artistSeriesConnection: {
+          fragment: gql`
+            ... on Artist {
+              internalID
+            }
+          `,
+          resolve: ({ internalID: artistID }, args, context, info) => {
+            return info.mergeInfo.delegateToSchema({
+              schema: gravitySchema,
+              operation: "query",
+              fieldName: "artistSeriesConnection",
+              args: {
+                artistID,
                 ...args,
               },
               context,


### PR DESCRIPTION
[FX-2059](https://artsyproduct.atlassian.net/browse/FX-2059)
---
# Problem

Users want to be able to see lists of artist series, including all the artist series by a given artist. Currently, we can only query that information from Gravity, which means clients can't query for it.

# Solution

Add `artistSeriesConnection` type to Metaphysics and stitch into `Artist`.

### Screenshots

![Screen Shot 2020-07-14 at 3 58 49 PM](https://user-images.githubusercontent.com/4432348/87472725-65db9880-c5ee-11ea-9f40-317bb4f5141d.png)
![Screen Shot 2020-07-14 at 3 58 18 PM](https://user-images.githubusercontent.com/4432348/87472727-66742f00-c5ee-11ea-88f6-9c079528a18c.png)
![Screen Shot 2020-07-14 at 3 57 39 PM](https://user-images.githubusercontent.com/4432348/87472729-66742f00-c5ee-11ea-957b-3bbab221c5a5.png)

