### PR TITLE
@williardx => [ArtistSeries] Include pagination args for stitched connection under artist

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -624,7 +624,12 @@ type Artist implements Node & Searchable {
     # The number of Artists to return
     size: Int
   ): [Artist]
-  artistSeriesConnection: ArtistSeriesConnection
+  artistSeriesConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtistSeriesConnection
   artworks(
     exclude: [String]
     filter: [ArtistArtworksFilters]

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -579,7 +579,12 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     limit: Int
     sort: ArticleSorts
   ): ArticleConnection
-  artistSeriesConnection: ArtistSeriesConnection
+  artistSeriesConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtistSeriesConnection
   artworksConnection(
     after: String
     before: String

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -506,10 +506,15 @@ describe("gravity/stitching", () => {
       const { artistSeriesConnection } = resolvers.Artist
       const info = { mergeInfo: { delegateToSchema: jest.fn() } }
 
-      artistSeriesConnection.resolve({ internalID: "fakeid" }, {}, {}, info)
+      artistSeriesConnection.resolve(
+        { internalID: "fakeid" },
+        { first: 5 },
+        {},
+        info
+      )
 
       expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
-        args: { artistID: "fakeid" },
+        args: { artistID: "fakeid", first: 5 },
         operation: "query",
         fieldName: "artistSeriesConnection",
         schema: expect.anything(),

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -118,7 +118,12 @@ export const gravityStitchingEnvironment = (
       }
 
       extend type Artist {
-        artistSeriesConnection: ArtistSeriesConnection
+        artistSeriesConnection(
+          first: Int
+          last: Int
+          after: String
+          before: String
+          ): ArtistSeriesConnection
       }
 
       extend type Viewer {


### PR DESCRIPTION
Pretty minor! We have to include the standard pagination arguments in this stitched file (ie- `first` for the size), even though all we do is pass it through to the underlying subschema.