### PR TITLE
@anandaroop => [Artwork] Stitch in artistSeriesConnection

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1261,6 +1261,7 @@ type ArtistSeries {
   # List of Mongo IDs for associated Artists
   artistIDs: [String!]!
   artists(page: Int, size: Int): [Artist]
+  artworkIDs: [ID!]!
   description: String
   featured: Boolean!
   forSaleArtworksCount: Int!
@@ -1347,6 +1348,12 @@ type Artwork implements Node & Searchable & Sellable {
     # Use whatever is in the original response instead of making a request
     shallow: Boolean
   ): [Artist]
+  artistSeriesConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtistSeriesConnection
 
   # Attribution class object
   attribution_class: AttributionClass
@@ -10789,13 +10796,16 @@ type Query {
   # Find an artist series by ID
   artistSeries(id: ID!): ArtistSeries
 
-  # List all artist series, optionally filtered by artist
+  # List all artist series, optionally filtered by artist or artwork
   artistSeriesConnection(
     # Returns the elements in the list that come after the specified cursor.
     after: String
 
     # ID of the artist by which to filter results
     artistID: ID
+
+    # ID of the artwork by which to filter results
+    artworkID: ID
 
     # Returns the elements in the list that come before the specified cursor.
     before: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -997,6 +997,7 @@ type ArtistSeries {
   # List of Mongo IDs for associated Artists
   artistIDs: [String!]!
   artists(page: Int, size: Int): [Artist]
+  artworkIDs: [ID!]!
   description: String
   featured: Boolean!
   filterArtworksConnection(
@@ -1147,6 +1148,12 @@ type Artwork implements Node & Searchable & Sellable {
     # Use whatever is in the original response instead of making a request
     shallow: Boolean
   ): [Artist]
+  artistSeriesConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtistSeriesConnection
 
   # Attribution class object
   attributionClass: AttributionClass
@@ -7310,13 +7317,16 @@ type Query {
   # Find an artist series by ID
   artistSeries(id: ID!): ArtistSeries
 
-  # List all artist series, optionally filtered by artist
+  # List all artist series, optionally filtered by artist or artwork
   artistSeriesConnection(
     # Returns the elements in the list that come after the specified cursor.
     after: String
 
     # ID of the artist by which to filter results
     artistID: ID
+
+    # ID of the artwork by which to filter results
+    artworkID: ID
 
     # Returns the elements in the list that come before the specified cursor.
     before: String

--- a/src/data/gravity.graphql
+++ b/src/data/gravity.graphql
@@ -75,6 +75,7 @@ type ArtistSeries {
   List of Mongo IDs for associated Artists
   """
   artistIDs: [String!]!
+  artworkIDs: [ID!]!
   description: String
   featured: Boolean!
   forSaleArtworksCount: Int!
@@ -890,7 +891,7 @@ type Query {
   artistSeries(id: ID!): ArtistSeries
 
   """
-  List all artist series, optionally filtered by artist
+  List all artist series, optionally filtered by artist or artwork
   """
   artistSeriesConnection(
     """
@@ -902,6 +903,11 @@ type Query {
     ID of the artist by which to filter results
     """
     artistID: ID
+
+    """
+    ID of the artwork by which to filter results
+    """
+    artworkID: ID
 
     """
     Returns the elements in the list that come before the specified cursor.

--- a/src/lib/stitching/gravity/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/gravity/__tests__/__snapshots__/schema.test.ts.snap
@@ -27,6 +27,7 @@ union AppSecondFactorOrErrorsUnion = AppSecondFactor | Errors
 type ArtistSeries {
   # List of Mongo IDs for associated Artists
   artistIDs: [String!]!
+  artworkIDs: [ID!]!
   description: String
   featured: Boolean!
   forSaleArtworksCount: Int!
@@ -431,13 +432,16 @@ type Query {
   # Find an artist series by ID
   artistSeries(id: ID!): ArtistSeries
 
-  # List all artist series, optionally filtered by artist
+  # List all artist series, optionally filtered by artist or artwork
   artistSeriesConnection(
     # Returns the elements in the list that come after the specified cursor.
     after: String
 
     # ID of the artist by which to filter results
     artistID: ID
+
+    # ID of the artwork by which to filter results
+    artworkID: ID
 
     # Returns the elements in the list that come before the specified cursor.
     before: String

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -524,6 +524,37 @@ describe("gravity/stitching", () => {
     })
   })
 
+  describe("#artwork", () => {
+    it("extends the Artwork type with an artistSeriesConnection field", async () => {
+      const mergedSchema = await getGravityMergedSchema()
+      const artwork = await getFieldsForTypeFromSchema("Artwork", mergedSchema)
+
+      expect(artwork).toContain("artistSeriesConnection")
+    })
+
+    it("resolves the artistSeriesConnection field on Artwork", async () => {
+      const { resolvers } = await getGravityStitchedSchema()
+      const { artistSeriesConnection } = resolvers.Artwork
+      const info = { mergeInfo: { delegateToSchema: jest.fn() } }
+
+      artistSeriesConnection.resolve(
+        { internalID: "fakeid" },
+        { first: 5 },
+        {},
+        info
+      )
+
+      expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
+        args: { artworkID: "fakeid", first: 5 },
+        operation: "query",
+        fieldName: "artistSeriesConnection",
+        schema: expect.anything(),
+        context: expect.anything(),
+        info: expect.anything(),
+      })
+    })
+  })
+
   describe("#image", () => {
     it("includes an image for an artist series", async () => {
       const { resolvers } = await getGravityStitchedSchema()

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -126,6 +126,15 @@ export const gravityStitchingEnvironment = (
           ): ArtistSeriesConnection
       }
 
+      extend type Artwork {
+        artistSeriesConnection(
+          first: Int
+          last: Int
+          after: String
+          before: String
+          ): ArtistSeriesConnection
+      }
+
       extend type Viewer {
         viewingRoomsConnection(first: Int, after: String): ViewingRoomConnection
       }
@@ -451,6 +460,28 @@ export const gravityStitchingEnvironment = (
               fieldName: "artistSeriesConnection",
               args: {
                 artistID,
+                ...args,
+              },
+              context,
+              info,
+            })
+          },
+        },
+      },
+      Artwork: {
+        artistSeriesConnection: {
+          fragment: gql`
+            ... on Artwork {
+              internalID
+            }
+            `,
+          resolve: ({ internalID: artworkID }, args, context, info) => {
+            return info.mergeInfo.delegateToSchema({
+              schema: gravitySchema,
+              operation: "query",
+              fieldName: "artistSeriesConnection",
+              args: {
+                artworkID,
                 ...args,
               },
               context,


### PR DESCRIPTION
Pretty much an exact duplicate of what was already done in https://github.com/artsy/metaphysics/pull/2524 to stitch in an `artistSeriesConnection` under an `Artist`.

This follows that pattern, but for `Artwork`. The reality is most likely an artwork will be in one series (and the designs for 'More works from this series' with one rail should select the first one based on the default order), but, we support multiples so it seems easier to keep that consistent. For an `Artist`, it's of course more natural than for an `Artwork` to have multiple series to return and display.