### PR TITLE
@anandaroop => [ArtistSeries] Expose artworksConnection

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1262,6 +1262,7 @@ type ArtistSeries {
   artistIDs: [String!]!
   artists(page: Int, size: Int): [Artist]
   artworkIDs: [ID!]!
+  artworksConnection(after: String, first: Int): ArtworkConnection
   description: String
   featured: Boolean!
   forSaleArtworksCount: Int!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -998,6 +998,7 @@ type ArtistSeries {
   artistIDs: [String!]!
   artists(page: Int, size: Int): [Artist]
   artworkIDs: [ID!]!
+  artworksConnection(after: String, first: Int): ArtworkConnection
   description: String
   featured: Boolean!
   filterArtworksConnection(

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -117,6 +117,29 @@ describe("gravity/stitching", () => {
         info: expect.anything(),
       })
     })
+
+    it("resolves the artworksConnection field on ArtistSeries for the V2 schema", async () => {
+      const schemaVersion = 2
+      const { resolvers } = await getGravityStitchedSchema(schemaVersion)
+      const { artworksConnection } = resolvers.ArtistSeries
+      const info = { mergeInfo: { delegateToSchema: jest.fn() } }
+
+      artworksConnection.resolve(
+        { artworkIDs: ["abc123"] },
+        { first: 2 },
+        {},
+        info
+      )
+
+      expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
+        args: { ids: ["abc123"], first: 2 },
+        operation: "query",
+        fieldName: "artworks",
+        schema: expect.anything(),
+        context: expect.anything(),
+        info: expect.anything(),
+      })
+    })
   })
 
   describe("#distanceToOpen", () => {

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -104,6 +104,7 @@ export const gravityStitchingEnvironment = (
       extend type ArtistSeries {
         artists(page: Int, size: Int): [Artist]
         image: Image
+        artworksConnection(first: Int, after: String): ArtworkConnection
         ${
           schemaVersion === 2
             ? `filterArtworksConnection(${argsToSDL(
@@ -155,6 +156,26 @@ export const gravityStitchingEnvironment = (
         },
       },
       ArtistSeries: {
+        artworksConnection: {
+          fragment: gql`
+          ... on ArtistSeries {
+            artworkIDs
+          }
+          `,
+          resolve: async ({ artworkIDs: ids }, _args, context, info) => {
+            return await info.mergeInfo.delegateToSchema({
+              args: {
+                ids,
+                ..._args,
+              },
+              schema: localSchema,
+              operation: "query",
+              fieldName: "artworks",
+              context,
+              info,
+            })
+          },
+        },
         image: {
           fragment: gql`
           ... on ArtistSeries {


### PR DESCRIPTION
Whoops forgot this one! Exposes a plain `artworksConnection` which skips ES.