### PR TITLE
Tune resource assignment based on observed use.

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -42,10 +42,10 @@ spec:
               containerPort: 3000
           resources:
             requests:
-              cpu: "1"
-              memory: 1536Mi
+              cpu: 1000m
+              memory: 768Mi
             limits:
-              memory: 1536Mi
+              memory: 1.5Gi
           readinessProbe:
             httpGet:
               port: mp-http
@@ -114,8 +114,8 @@ spec:
     kind: Deployment
     name: metaphysics-web
   minReplicas: 10
-  maxReplicas: 20
-  targetCPUUtilizationPercentage: 60
+  maxReplicas: 25
+  targetCPUUtilizationPercentage: 70
 
 ---
 apiVersion: v1

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -31,7 +31,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: NODE_OPTIONS
-              value: "--max_old_space_size=1024"
+              value: "--max_old_space_size=768"
           envFrom:
             - configMapRef:
                 name: metaphysics-environment

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -112,9 +112,9 @@ spec:
     apiVersion: extensions/v1beta1
     kind: Deployment
     name: metaphysics-web
-  minReplicas: 2
-  maxReplicas: 4
-  targetCPUUtilizationPercentage: 95
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
 
 ---
 apiVersion: v1


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/PLATFORM-2646

Prod
---
- Reduce memory request due to lower usage. `max_old_space_size` adjusted to match.
- Horizontal pod scaler (HPA) CPU threshold at 60% seems too low. This limits pod utilization to only 60% of requested CPU. Only when max pod count is reached do they burst above 60%. Recommending to increase it to 70% which is default in Hokusai template: https://github.com/artsy/artsy-hokusai-templates/blob/ac33c4db8754143318612497f68361b64ea1abd6/nodejs/hokusai/production.yml.j2#L130
- HPA max replicas at 20. We have been hitting this limit (see DD dashboard linked below). Recommending to increase it to 25.

Staging
---
Similar changes.

Resources
---
Tuning guideline:
https://www.notion.so/artsy/Guidelines-on-tuning-an-app-s-CPU-and-memory-consumption-in-a-Kubernetes-cluster-797977be895643af84015a7d4b60a5dc
Prod usage dashboard (please change filters to see staging deployments).
https://app.datadoghq.com/dashboard/2n5-6tr-ypp/kubernetes-cpumemory-usage-by-deployment?from_ts=1595196124428&live=true&to_ts=1595368924428&tpl_var_container=metaphysics-web&tpl_var_deployment=metaphysics-web&tpl_var_env=production&tpl_var_hpa=metaphysics-web