### PR TITLE
Forces Gravity request for push notification settings fields.

### DIFF
--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -226,13 +226,6 @@ const MeField: GraphQLFieldConfig<void, ResolverContext> = {
       "lotsByFollowedArtistsConnection",
       "identityVerification",
       "unreadNotificationsCount",
-      "receivePurchaseNotification",
-      "receiveOutbidNotification",
-      "receiveLotOpeningSoonNotification",
-      "receiveSaleOpeningClosingNotification",
-      "receiveNewWorksNotification",
-      "receiveNewSalesNotification",
-      "receivePromotionNotification",
     ]
     if (includesFieldsOtherThanSelectionSet(info, fieldsNotRequireLoader)) {
       return meLoader()


### PR DESCRIPTION
I was QA'ing [MX-414] and I noticed that the fields were being returned as `null` and that Gravity wasn't being hit, unless I requested other fields.

Before:

![Screen Shot 2020-07-22 at 3 05 18 PM](https://user-images.githubusercontent.com/498212/88217927-487d7e80-cc2d-11ea-97ab-4d12eeaa0454.png)

After:

![Screen Shot 2020-07-22 at 3 05 25 PM](https://user-images.githubusercontent.com/498212/88217930-4b786f00-cc2d-11ea-84ce-c9cb86c98924.png)

Looks like this is to avoiding hitting Gravity unnecessarily. But in the case of Pulse, we might only be getting these attributes, so I've removed the fields from the list of things we don't need to ask Gravity about.

Follow-up from #2536.

[MX-414]: https://artsyproduct.atlassian.net/browse/MX-414