### PR TITLE
Revert prod HPA threshold to 60%.

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -115,7 +115,7 @@ spec:
     name: metaphysics-web
   minReplicas: 10
   maxReplicas: 25
-  targetCPUUtilizationPercentage: 70
+  targetCPUUtilizationPercentage: 60
 
 ---
 apiVersion: v1


### PR DESCRIPTION
HPA threshold was raised to 70% under this PR:

https://github.com/artsy/metaphysics/pull/2552

After its release p95 latency increased.
This PR is to revert the threshold to 60%.

![Screenshot from 2020-07-23 15-36-26](https://user-images.githubusercontent.com/63004951/88331031-56e59c00-ccfa-11ea-81b6-c88411bb3176.png)
