### PR TITLE
Add isArtsyLicensed to the sale type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8029,6 +8029,7 @@ type Sale implements Node {
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
+  isArtsyLicensed: Boolean!
   isAuction: Boolean
   isAuctionPromo: Boolean
   isBenefit: Boolean

--- a/src/schema/v2/sale/__tests__/index.test.ts
+++ b/src/schema/v2/sale/__tests__/index.test.ts
@@ -15,6 +15,7 @@ describe("Sale type", () => {
     id: "foo-foo",
     _id: "123",
     currency: "$",
+    is_artsy_licensed: false,
     is_auction: true,
     is_preliminary: false,
     increment_strategy: "default",
@@ -56,6 +57,7 @@ describe("Sale type", () => {
       {
         sale(id: "foo-foo") {
           internalID
+          isArtsyLicensed
           isPreview
           isOpen
           isLiveOpen
@@ -74,6 +76,7 @@ describe("Sale type", () => {
       expect(await execute(query)).toEqual({
         sale: {
           internalID: "123",
+          isArtsyLicensed: false,
           isPreview: false,
           isOpen: false,
           isLiveOpen: false,
@@ -92,6 +95,7 @@ describe("Sale type", () => {
       expect(await execute(query)).toEqual({
         sale: {
           internalID: "123",
+          isArtsyLicensed: false,
           isPreview: true,
           isOpen: false,
           isLiveOpen: false,
@@ -111,6 +115,7 @@ describe("Sale type", () => {
       expect(await execute(query)).toEqual({
         sale: {
           internalID: "123",
+          isArtsyLicensed: false,
           isPreview: false,
           isOpen: true,
           isLiveOpen: false,
@@ -130,6 +135,7 @@ describe("Sale type", () => {
       expect(await execute(query)).toEqual({
         sale: {
           internalID: "123",
+          isArtsyLicensed: false,
           isPreview: false,
           isOpen: true,
           isLiveOpen: true,
@@ -149,6 +155,7 @@ describe("Sale type", () => {
       expect(await execute(query)).toEqual({
         sale: {
           internalID: "123",
+          isArtsyLicensed: false,
           isPreview: false,
           isOpen: true,
           isLiveOpen: true,

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -206,6 +206,10 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLBoolean,
         resolve: ({ is_gallery_auction }) => is_gallery_auction,
       },
+      isArtsyLicensed: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        resolve: ({ is_artsy_licensed }) => is_artsy_licensed,
+      },
       isAuctionPromo: {
         type: GraphQLBoolean,
         resolve: ({ sale_type }) => sale_type === "auction promo",


### PR DESCRIPTION
Partially addresses https://artsyproduct.atlassian.net/browse/AUCT-1164

This exposed the newly added `is_artsy_licensed` flag on the sale model so our clients can use that in e.g. sale winning emails.

## Screenshot

<img width="1472" alt="Screen Shot 2020-07-27 at 3 39 57 PM" src="https://user-images.githubusercontent.com/386234/88584325-71cc4f00-d01f-11ea-87e0-a634cd90ba4e.png">
