### PR TITLE
Add excludeIDs as argument for artistSeriesConnection

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -638,6 +638,7 @@ type Artist implements Node & Searchable {
   artistSeriesConnection(
     after: String
     before: String
+    excludeIDs: [ID]
     first: Int
     last: Int
   ): ArtistSeriesConnection
@@ -1363,6 +1364,7 @@ type Artwork implements Node & Searchable & Sellable {
   artistSeriesConnection(
     after: String
     before: String
+    excludeIDs: [ID]
     first: Int
     last: Int
   ): ArtistSeriesConnection

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -593,6 +593,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   artistSeriesConnection(
     after: String
     before: String
+    excludeIDs: [ID]
     first: Int
     last: Int
   ): ArtistSeriesConnection
@@ -1163,6 +1164,7 @@ type Artwork implements Node & Searchable & Sellable {
   artistSeriesConnection(
     after: String
     before: String
+    excludeIDs: [ID]
     first: Int
     last: Int
   ): ArtistSeriesConnection

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -531,13 +531,13 @@ describe("gravity/stitching", () => {
 
       artistSeriesConnection.resolve(
         { internalID: "fakeid" },
-        { first: 5 },
+        { first: 5, excludeIDs: ["abc123"] },
         {},
         info
       )
 
       expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
-        args: { artistID: "fakeid", first: 5 },
+        args: { artistID: "fakeid", first: 5, excludeIDs: ["abc123"] },
         operation: "query",
         fieldName: "artistSeriesConnection",
         schema: expect.anything(),
@@ -562,13 +562,13 @@ describe("gravity/stitching", () => {
 
       artistSeriesConnection.resolve(
         { internalID: "fakeid" },
-        { first: 5 },
+        { first: 5, excludeIDs: ["abc123"] },
         {},
         info
       )
 
       expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
-        args: { artworkID: "fakeid", first: 5 },
+        args: { artworkID: "fakeid", first: 5, excludeIDs: ["abc123"] },
         operation: "query",
         fieldName: "artistSeriesConnection",
         schema: expect.anything(),

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -124,6 +124,7 @@ export const gravityStitchingEnvironment = (
           last: Int
           after: String
           before: String
+          excludeIDs: [ID]
           ): ArtistSeriesConnection
       }
 
@@ -133,6 +134,7 @@ export const gravityStitchingEnvironment = (
           last: Int
           after: String
           before: String
+          excludeIDs: [ID]
           ): ArtistSeriesConnection
       }
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2120

# Problem

We want to show lists of related artist series but exclude some artist series from showing, e.g. the current artist series the user is looking at.

# Solution

Expose `excludeIDs` as an argument for `artistSeriesConnection` on `Artist` and `Artwork`.


**Before**
![Screen Shot 2020-07-31 at 11 40 42 AM](https://user-images.githubusercontent.com/4432348/89053299-ff13ea00-d324-11ea-9eae-45205e194a93.png)

**After**
![Screen Shot 2020-07-31 at 11 40 23 AM](https://user-images.githubusercontent.com/4432348/89053313-05a26180-d325-11ea-9c52-66b2ea407231.png)
