### PR TITLE
Exclude current artist series when querying for related artist series

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -638,7 +638,6 @@ type Artist implements Node & Searchable {
   artistSeriesConnection(
     after: String
     before: String
-    excludeIDs: [ID]
     first: Int
     last: Int
   ): ArtistSeriesConnection
@@ -1364,7 +1363,6 @@ type Artwork implements Node & Searchable & Sellable {
   artistSeriesConnection(
     after: String
     before: String
-    excludeIDs: [ID]
     first: Int
     last: Int
   ): ArtistSeriesConnection

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -593,7 +593,6 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   artistSeriesConnection(
     after: String
     before: String
-    excludeIDs: [ID]
     first: Int
     last: Int
   ): ArtistSeriesConnection
@@ -1164,7 +1163,6 @@ type Artwork implements Node & Searchable & Sellable {
   artistSeriesConnection(
     after: String
     before: String
-    excludeIDs: [ID]
     first: Int
     last: Int
   ): ArtistSeriesConnection

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -503,14 +503,19 @@ describe("gravity/stitching", () => {
       const { artists } = resolvers.ArtistSeries
       const info = { mergeInfo: { delegateToSchema: jest.fn() } }
 
-      artists.resolve({ artistIDs: ["fakeid"] }, {}, {}, info)
+      artists.resolve(
+        { artistIDs: ["fakeid"], internalID: "abc123" },
+        {},
+        {},
+        info
+      )
 
       expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
         args: { ids: ["fakeid"] },
         operation: "query",
         fieldName: "artists",
         schema: expect.anything(),
-        context: expect.anything(),
+        context: { currentArtistSeriesInternalID: "abc123" },
         info: expect.anything(),
       })
     })
@@ -531,18 +536,43 @@ describe("gravity/stitching", () => {
 
       artistSeriesConnection.resolve(
         { internalID: "fakeid" },
-        { first: 5, excludeIDs: ["abc123"] },
+        { first: 5 },
         {},
         info
       )
 
       expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
-        args: { artistID: "fakeid", first: 5, excludeIDs: ["abc123"] },
+        args: { artistID: "fakeid", first: 5 },
         operation: "query",
         fieldName: "artistSeriesConnection",
         schema: expect.anything(),
         context: expect.anything(),
         info: expect.anything(),
+      })
+    })
+
+    describe("with an artistSeriesConnection with a current artist series in context", () => {
+      it("resolves the artistSeriesConnection and excludes the current artist series", async () => {
+        const context = { currentArtistSeriesInternalID: "abc123" }
+        const { resolvers } = await getGravityStitchedSchema()
+        const { artistSeriesConnection } = resolvers.Artist
+        const info = { mergeInfo: { delegateToSchema: jest.fn() } }
+
+        artistSeriesConnection.resolve(
+          { internalID: "fakeid" },
+          { first: 5 },
+          context,
+          info
+        )
+
+        expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
+          args: { artistID: "fakeid", first: 5, excludeIDs: ["abc123"] },
+          operation: "query",
+          fieldName: "artistSeriesConnection",
+          schema: expect.anything(),
+          context: expect.anything(),
+          info: expect.anything(),
+        })
       })
     })
   })
@@ -562,13 +592,13 @@ describe("gravity/stitching", () => {
 
       artistSeriesConnection.resolve(
         { internalID: "fakeid" },
-        { first: 5, excludeIDs: ["abc123"] },
+        { first: 5 },
         {},
         info
       )
 
       expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
-        args: { artworkID: "fakeid", first: 5, excludeIDs: ["abc123"] },
+        args: { artworkID: "fakeid", first: 5 },
         operation: "query",
         fieldName: "artistSeriesConnection",
         schema: expect.anything(),

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -124,7 +124,6 @@ export const gravityStitchingEnvironment = (
           last: Int
           after: String
           before: String
-          excludeIDs: [ID]
           ): ArtistSeriesConnection
       }
 
@@ -134,7 +133,6 @@ export const gravityStitchingEnvironment = (
           last: Int
           after: String
           before: String
-          excludeIDs: [ID]
           ): ArtistSeriesConnection
       }
 
@@ -224,12 +222,15 @@ export const gravityStitchingEnvironment = (
           fragment: gql`
           ... on ArtistSeries {
             artistIDs
+            internalID
           }
         `,
-          resolve: ({ artistIDs: ids }, args, context, info) => {
+          resolve: ({ artistIDs: ids, internalID }, args, context, info) => {
             if (ids.length === 0) {
               return []
             }
+
+            context.currentArtistSeriesInternalID = internalID
 
             return info.mergeInfo.delegateToSchema({
               schema: localSchema,
@@ -484,6 +485,12 @@ export const gravityStitchingEnvironment = (
               args: {
                 artistID,
                 ...args,
+                // Exclude the current artist series so that lists of
+                // artist series by the artist don't include the current series
+                // if there is one.
+                ...(!!context.currentArtistSeriesInternalID && {
+                  excludeIDs: [context.currentArtistSeriesInternalID],
+                }),
               },
               context,
               info,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2122

# Problem

When viewing an artist series users can see a list of other series by that artist. We don't want that list to show the current artist series.

# Solution

When querying for an `artistSeriesConnection` on an artist, pass in the current artist series as an `excludeID` parameter to Gravity which will return a list without the current artist series. If there's no current artist series then we don't send the parameter.

This is an alternative solution to https://github.com/artsy/metaphysics/pull/2569 and undoes the work in that PR.

### Potential Issues

This bakes in an assumption in our product that, when querying for an `artistSeriesConnection` on an artist, we don't want to see the current artist series in that list if there is one. As of now there's no product use case where we would want that to occur.

### Screenshots

![Screen Shot 2020-08-03 at 11 58 28 AM](https://user-images.githubusercontent.com/4432348/89231498-752d8080-d5b3-11ea-8894-7662d8f5f5e8.png)

Force on an artist page (no current artist series, observe 5 artist series)

![Screen Shot 2020-08-03 at 12 00 15 PM](https://user-images.githubusercontent.com/4432348/89231559-92fae580-d5b3-11ea-931a-e0d175912027.png)

Force on the "pumpkins" artist series page (observe "pumpkins" omitted, 4 artist series)

![Screen Shot 2020-08-03 at 12 00 25 PM](https://user-images.githubusercontent.com/4432348/89231615-ab6b0000-d5b3-11ea-8bbc-e27eb5d80f23.png)


