### PR TITLE
#POC #DONOTMERGE failover to backup server

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -55,6 +55,43 @@ spec:
                   value: https
             initialDelaySeconds: 5
             periodSeconds: 5
+        - name: metaphysics-web-alt
+          env:
+            - name: PORT
+              value: "3001"
+            - name: DD_TRACER_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: STATSD_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: NODE_OPTIONS
+              value: "--max_old_space_size=256"
+          envFrom:
+            - configMapRef:
+                name: metaphysics-environment
+          image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/metaphysics:production
+          imagePullPolicy: Always
+          ports:
+            - name: mp-http-alt
+              containerPort: 3001
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              port: mp-http-alt
+              path: /health
+              httpHeaders:
+                - name: X-FORWARDED-PROTO
+                  value: https
+            initialDelaySeconds: 5
+            periodSeconds: 5
         - name: metaphysics-nginx
           image: artsy/docker-nginx:1.14.2
           ports:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -55,6 +55,43 @@ spec:
                   value: https
             initialDelaySeconds: 5
             periodSeconds: 5
+        - name: metaphysics-web-alt
+          env:
+            - name: PORT
+              value: "3001"
+            - name: DD_TRACER_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: STATSD_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: NODE_OPTIONS
+              value: "--max_old_space_size=256"
+          envFrom:
+            - configMapRef:
+                name: metaphysics-environment
+          image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/metaphysics:staging
+          imagePullPolicy: Always
+          ports:
+            - name: mp-http-alt
+              containerPort: 3001
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              port: mp-http-alt
+              path: /health
+              httpHeaders:
+                - name: X-FORWARDED-PROTO
+                  value: https
+            initialDelaySeconds: 5
+            periodSeconds: 5
         - name: metaphysics-nginx
           image: artsy/docker-nginx:1.14.2
           ports:


### PR DESCRIPTION
Written in response to Incident-96 as it appears Metaphysics instability has resurfaced.  This is an attempt to mitigate service downtime by failing over to a backup metaphysics node server in the same pod as the primary node and Nginx servers.

This PR sets up a `mp-web-alt container` as a failover server.  Nginx can be configured to fail over to this server on port 3001 with the following configuration block:

```
upstream metaphysics {
    server 127.0.0.1:3000 fail_timeout=5s max_fails=1;
    server 127.0.0.1:3001 backup;
}
```

Nginx will fail over requests to the backup upstream server if the first is considered down, which here means one failed request within 5 seconds.  For further configuration of server directives governing failover behavior see http://nginx.org/en/docs/http/ngx_http_upstream_module.html#server

For parameters governing when a server is marked as down upon which Nginx tires the next server in the  server's location block see:
- https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream
- https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream_timeout
- https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream_tries

The intended behavior is to temporarily route requests to the backup server while the primary server restarts, due to a crash or running OOM.  It remains to be proven if this would mitigate the downtime and thrashing we usually see when Metaphysics is overwhelmed with requests, or if it such request spikes would simply crash the backup servers.

## TODO

- Validate this setup can withstand the primary MP server restarting
- Load test (possibly with Goreplay)

