### PR TITLE
Disables GraphiQL in production

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -226,7 +226,7 @@ function startApp(appSchema, path: string) {
 
         return {
           schema: appSchema,
-          graphiql: true,
+          graphiql: !PRODUCTION_ENV,
           context,
           rootValue: {},
           customFormatErrorFn: graphqlErrorHandler(enableSentry, {


### PR DESCRIPTION
Context here is that Googlebot (and others?) are erroneously crawling and causing undue load on Metaphysics, leading to instability in Force. See `#incident-96` for more details.

Already mentioned in the README is:

![](https://static.damonzucconi.com/_capture/7kDXTSHm4VaS.png)

So I think we just need to make it known to anyone who was still relying on the hosted instances.