### PR TITLE
Add registered argument to salesConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7792,6 +7792,9 @@ type Query {
 
     # Limit by published status.
     published: Boolean = true
+
+    # Returns sales the user has registered for if true, returns sales the user has not registered for if false.
+    registered: Boolean
     sort: SaleSorts
   ): SaleConnection
 
@@ -9836,6 +9839,9 @@ type Viewer {
 
     # Limit by published status.
     published: Boolean = true
+
+    # Returns sales the user has registered for if true, returns sales the user has not registered for if false.
+    registered: Boolean
     sort: SaleSorts
   ): SaleConnection
 

--- a/src/schema/v2/__tests__/salesConnection.test.ts
+++ b/src/schema/v2/__tests__/salesConnection.test.ts
@@ -1,0 +1,59 @@
+/* eslint-disable promise/always-return */
+import { runQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+import sinon from "sinon"
+
+describe("salesConnection", () => {
+  describe(`Provides filter results`, () => {
+    it("returns a connection, and makes one gravity call when args passed inline", async () => {
+      const context = {
+        salesLoaderWithHeaders: sinon
+          .stub()
+          .withArgs("sales", {
+            first: 5,
+            isAuction: true,
+            live: true,
+            published: true,
+            registered: true,
+          })
+          .returns(
+            Promise.resolve({
+              headers: {
+                "x-total-count": 1,
+              },
+              body: [
+                {
+                  name: "Heritage: Photographs",
+                  slug: "heritage-photographs-14",
+                },
+              ],
+            })
+          ),
+      }
+
+      const query = gql`
+        {
+          salesConnection(
+            first: 5
+            isAuction: true
+            live: true
+            published: true
+            registered: true
+          ) {
+            edges {
+              node {
+                name
+              }
+            }
+          }
+        }
+      `
+
+      const { salesConnection } = await runQuery(query, context as any)
+
+      expect(salesConnection.edges).toEqual([
+        { node: { name: "Heritage: Photographs" } },
+      ])
+    })
+  })
+})

--- a/src/schema/v2/sales.ts
+++ b/src/schema/v2/sales.ts
@@ -43,11 +43,17 @@ export const SalesConnectionField: GraphQLFieldConfig<void, ResolverContext> = {
       type: GraphQLBoolean,
       defaultValue: true,
     },
+    registered: {
+      description:
+        "Returns sales the user has registered for if true, returns sales the user has not registered for if false.",
+      type: GraphQLBoolean,
+      defaultValue: undefined,
+    },
     sort: SaleSorts,
   }),
   resolve: async (
     _root,
-    { ids, isAuction, live, published, sort, ...paginationArgs },
+    { ids, isAuction, live, published, sort, registered, ...paginationArgs },
     { salesLoaderWithHeaders }
   ) => {
     const { page, size, offset } = convertConnectionArgsToGravityArgs(
@@ -61,6 +67,7 @@ export const SalesConnectionField: GraphQLFieldConfig<void, ResolverContext> = {
         live,
         published,
         sort,
+        registered,
         page,
         size,
         total_count: true,


### PR DESCRIPTION
partially addresses https://artsyproduct.atlassian.net/browse/AUCT-1151
blocked by https://github.com/artsy/gravity/pull/13354

This simply exposes the new `registered` argument [being added to Gravity](https://github.com/artsy/gravity/pull/13354). I also added a new test file `src/schema/v2/__tests__/salesConnection.test.ts` since there didn't seem to be a test for `salesConnection`.