### PR TITLE
Allow querying for user stats information in vortex

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -470,6 +470,12 @@ type AnalyticsShow {
   entityId: String!
 }
 
+# Statistics for users
+type AnalyticsUserStats {
+  numberOfPurchases: Int!
+  userId: String!
+}
+
 type AnalyticsVisitorsByCountry {
   metric: String!
   name: String!
@@ -10817,6 +10823,9 @@ type Query {
 
   # Find PartnerStats
   analyticsPartnerStats(partnerId: String!): AnalyticsPartnerStats
+
+  # Query UserStats
+  analyticsUserStats(userId: String!): AnalyticsUserStats
 
   # An Article
   article(

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -472,7 +472,7 @@ type AnalyticsShow {
 
 # Statistics for users
 type AnalyticsUserStats {
-  numberOfPurchases: Int!
+  totalPurchaseCount: Int!
   userId: String!
 }
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -458,7 +458,7 @@ type AnalyticsShow {
 
 # Statistics for users
 type AnalyticsUserStats {
-  numberOfPurchases: Int!
+  totalPurchaseCount: Int!
   userId: String!
 }
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -456,6 +456,12 @@ type AnalyticsShow {
   entityId: String!
 }
 
+# Statistics for users
+type AnalyticsUserStats {
+  numberOfPurchases: Int!
+  userId: String!
+}
+
 type AnalyticsVisitorsByCountry {
   metric: String!
   name: String!
@@ -7341,6 +7347,9 @@ type Query {
   # Find PartnerStats
   analyticsPartnerStats(partnerId: String!): AnalyticsPartnerStats
 
+  # Query UserStats
+  analyticsUserStats(userId: String!): AnalyticsUserStats
+
   # An Article
   article(
     # The ID of the Article
@@ -9442,6 +9451,7 @@ type UpdateViewingRoomSubsectionsPayload {
 }
 
 type User {
+  analytics: AnalyticsUserStats
   cached: Int
 
   # The given email of the user.

--- a/src/data/vortex.graphql
+++ b/src/data/vortex.graphql
@@ -496,6 +496,11 @@ type Query {
     category: PricingContextCategoryEnum!
     sizeScore: Int!
   ): PricingContext
+
+  """
+  Query UserStats
+  """
+  userStats(userId: String!): UserStats
 }
 
 enum QueryPeriodEnum {
@@ -583,6 +588,14 @@ union RankedStatsUnion = Artist | Artwork | Show
 
 type Show {
   entityId: String!
+}
+
+"""
+Statistics for users
+"""
+type UserStats {
+  numberOfPurchases: Int!
+  userId: String!
 }
 
 type VisitorsByCountry {

--- a/src/data/vortex.graphql
+++ b/src/data/vortex.graphql
@@ -594,7 +594,7 @@ type Show {
 Statistics for users
 """
 type UserStats {
-  numberOfPurchases: Int!
+  totalPurchaseCount: Int!
   userId: String!
 }
 

--- a/src/lib/stitching/vortex/schema.ts
+++ b/src/lib/stitching/vortex/schema.ts
@@ -20,7 +20,7 @@ export const executableVortexSchema = ({
     link: vortexLink,
   })
 
-  const removeRootFieldList = ["pricingContext", "partnerStat"]
+  const removeRootFieldList = ["pricingContext", "partnerStat", "userStat"]
 
   // Return the new modified schema
   return transformSchema(schema, [

--- a/src/lib/stitching/vortex/stitching.ts
+++ b/src/lib/stitching/vortex/stitching.ts
@@ -45,6 +45,9 @@ export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
     extend type Partner {
       analytics: AnalyticsPartnerStats
     }
+    extend type User {
+      analytics: AnalyticsUserStats
+    }
     extend type AnalyticsPartnerSalesStats {
       total(
         decimal: String = "."
@@ -253,6 +256,24 @@ export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
             schema: vortexSchema,
             operation: "query",
             fieldName: "analyticsPartnerStats",
+            args,
+            context,
+            info,
+          })
+        },
+      },
+    },
+    User: {
+      analytics: {
+        fragment: gql`... on User {
+          internalID
+        }`,
+        resolve: async (source, _, context, info) => {
+          const args = { userId: source.internalID }
+          return await info.mergeInfo.delegateToSchema({
+            schema: vortexSchema,
+            operation: "query",
+            fieldName: "analyticsUserStats",
             args,
             context,
             info,


### PR DESCRIPTION
Metaphysics wrapper to expose new Vortex user stats graphQL endpoint to client
Vortex API work here: https://github.com/artsy/vortex/pull/260

The only client currently accessing the endpoint will be Volt (sketch PR here: https://github.com/artsy/volt/pull/4529)


Allow authenticated partners and admins to query against a user's total purchase counts
<img width="1309" alt="Screen Shot 2020-08-09 at 10 09 26 AM" src="https://user-images.githubusercontent.com/12748344/89734298-4850f180-da29-11ea-8719-1d239934503a.png">

---

<img width="1680" alt="Screen Shot 2020-08-09 at 10 08 08 AM" src="https://user-images.githubusercontent.com/12748344/89734306-530b8680-da29-11ea-906e-ca46810cb10c.png">





Unauthenticated users/non-partner users will not be authorized to hit this endpoint
<img width="1680" alt="Screen Shot 2020-08-07 at 9 34 25 AM" src="https://user-images.githubusercontent.com/12748344/89652706-e1e69a80-d893-11ea-9571-457834300fd6.png">