### PR TITLE
[Convection] Stitch in currency fields

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -4905,11 +4905,29 @@ type ConsignmentOffer {
   createdById: ID
   currency: String
   deadlineToConsign: String
+  highEstimateAmount(
+    decimal: String = "."
+
+    # Allows control of symbol position (%v = value, %s = symbol)
+    format: String = "%s%v"
+    precision: Int = 0
+    symbol: String
+    thousand: String = ","
+  ): String
   highEstimateCents: Int
 
   # Uniq ID for this offer
   id: ID!
   insuranceInfo: String
+  lowEstimateAmount(
+    decimal: String = "."
+
+    # Allows control of symbol position (%v = value, %s = symbol)
+    format: String = "%s%v"
+    precision: Int = 0
+    symbol: String
+    thousand: String = ","
+  ): String
   lowEstimateCents: Int
   notes: String
   offerType: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3309,11 +3309,29 @@ type ConsignmentOffer {
   createdById: ID
   currency: String
   deadlineToConsign: String
+  highEstimateAmount(
+    decimal: String = "."
+
+    # Allows control of symbol position (%v = value, %s = symbol)
+    format: String = "%s%v"
+    precision: Int = 0
+    symbol: String
+    thousand: String = ","
+  ): String
   highEstimateCents: Int
 
   # Uniq ID for this offer
   id: ID!
   insuranceInfo: String
+  lowEstimateAmount(
+    decimal: String = "."
+
+    # Allows control of symbol position (%v = value, %s = symbol)
+    format: String = "%s%v"
+    precision: Int = 0
+    symbol: String
+    thousand: String = ","
+  ): String
   lowEstimateCents: Int
   notes: String
   offerType: String

--- a/src/lib/stitching/convection/__tests__/testingUtils.ts
+++ b/src/lib/stitching/convection/__tests__/testingUtils.ts
@@ -1,0 +1,84 @@
+import { executableConvectionSchema } from "../schema"
+
+import {
+  getTypesFromSchema,
+  getRootFieldsFromSchema,
+  getFieldsForTypeFromSchema,
+} from "lib/stitching/lib/getTypesFromSchema"
+import { consignmentStitchingEnvironment } from "../stitching"
+
+import { mergeSchemas } from "graphql-tools"
+import { GraphQLSchema } from "graphql"
+import localSchema from "schema/v2/schema"
+
+/**
+ * Common helpers for use in our tests
+ */
+export async function useConvectionStitching() {
+  const schema = await getConvectionMergedSchema()
+  const getFields = async (type) =>
+    await getFieldsForTypeFromSchema(type, schema)
+  const rootFields = await getRootFieldsFromSchema(schema)
+  const { resolvers } = await getConvectionStitchedSchema()
+  const types = await getTypesFromSchema(schema)
+
+  return {
+    getFields,
+    rootFields,
+    resolvers,
+    schema,
+    types,
+  }
+}
+
+/**
+ * The following is used for internal setup, initializing convection's schema /
+ * stitching environment and then caching the results.
+ */
+
+let cachedSchema: GraphQLSchema & { transforms: any }
+let stitchedSchema: ReturnType<typeof consignmentStitchingEnvironment>
+let mergedSchema: GraphQLSchema & { transforms: any }
+
+/**
+ * Gets a cached copy of the transformed convection schema
+ */
+const getConvectionTransformedSchema = async () => {
+  if (!cachedSchema) {
+    cachedSchema = await executableConvectionSchema()
+  }
+  return cachedSchema
+}
+
+/**
+ * Gets a cached copy of the stitched schema, independent of being merged into
+ * the local schema
+ */
+const getConvectionStitchedSchema = async () => {
+  if (!stitchedSchema) {
+    const cachedSchema = await getConvectionTransformedSchema()
+    stitchedSchema = consignmentStitchingEnvironment(localSchema, cachedSchema)
+  }
+  return stitchedSchema
+}
+
+/**
+ * Gets a cached fully setup schema with convection and the localSchema
+ */
+const getConvectionMergedSchema = async () => {
+  if (!stitchedSchema) {
+    const cachedSchema = await getConvectionTransformedSchema()
+    const { extensionSchema, resolvers } = await getConvectionStitchedSchema()
+
+    // The order should only matter in that extension schemas come after the
+    // objects that they are expected to build upon
+    mergedSchema = mergeSchemas({
+      schemas: [localSchema, cachedSchema, extensionSchema],
+      resolvers: resolvers,
+    }) as GraphQLSchema & { transforms: any }
+
+    const anyMergedSchema = mergedSchema as any
+    anyMergedSchema.__allowedLegacyNames = ["__id"]
+  }
+  return mergedSchema
+}

--- a/src/lib/stitching/convection/stitching.ts
+++ b/src/lib/stitching/convection/stitching.ts
@@ -1,9 +1,5 @@
 import { GraphQLSchema } from "graphql"
-import {
-  amount,
-  amountSDL,
-  symbolFromCurrencyCode,
-} from "schema/v2/fields/money"
+import { amount, amountSDL } from "schema/v2/fields/money"
 import gql from "lib/gql"
 
 export const consignmentStitchingEnvironment = (
@@ -54,11 +50,10 @@ export const consignmentStitchingEnvironment = (
         `,
         resolve: (parent, args) =>
           amount((_) => parent.lowEstimateCents).resolve(
-            {},
             {
-              ...args,
-              symbol: symbolFromCurrencyCode(parent.currency),
-            }
+              currencyCode: parent.currency,
+            },
+            args
           ),
       },
       highEstimateAmount: {
@@ -70,11 +65,10 @@ export const consignmentStitchingEnvironment = (
         `,
         resolve: (parent, args) =>
           amount((_) => parent.highEstimateCents).resolve(
-            {},
             {
-              ...args,
-              symbol: symbolFromCurrencyCode(parent.currency),
-            }
+              currencyCode: parent.currency,
+            },
+            args
           ),
       },
     },

--- a/src/lib/stitching/convection/stitching.ts
+++ b/src/lib/stitching/convection/stitching.ts
@@ -1,4 +1,10 @@
 import { GraphQLSchema } from "graphql"
+import {
+  amount,
+  amountSDL,
+  symbolFromCurrencyCode,
+} from "schema/v2/fields/money"
+import gql from "lib/gql"
 
 export const consignmentStitchingEnvironment = (
   localSchema: GraphQLSchema,
@@ -8,6 +14,11 @@ export const consignmentStitchingEnvironment = (
   extensionSchema: `
     extend type ConsignmentSubmission {
       artist: Artist
+    }
+
+    extend type ConsignmentOffer {
+      ${amountSDL("lowEstimateAmount")}
+      ${amountSDL("highEstimateAmount")}
     }
   `,
 
@@ -30,6 +41,41 @@ export const consignmentStitchingEnvironment = (
             transforms: convectionSchema.transforms,
           })
         },
+      },
+    },
+
+    ConsignmentOffer: {
+      lowEstimateAmount: {
+        fragment: gql`
+          fragment ConsignmentOfferLowEstimateAmount on ConsignmentOffer {
+            currency
+            lowEstimateCents
+          }
+        `,
+        resolve: (parent, args) =>
+          amount((_) => parent.lowEstimateCents).resolve(
+            {},
+            {
+              ...args,
+              symbol: symbolFromCurrencyCode(parent.currency),
+            }
+          ),
+      },
+      highEstimateAmount: {
+        fragment: gql`
+          fragment ConsignmentOfferLowEstimateAmount on ConsignmentOffer {
+            currency
+            highEstimateCents
+          }
+        `,
+        resolve: (parent, args) =>
+          amount((_) => parent.highEstimateCents).resolve(
+            {},
+            {
+              ...args,
+              symbol: symbolFromCurrencyCode(parent.currency),
+            }
+          ),
       },
     },
   },

--- a/src/schema/v2/fields/__tests__/money.test.ts
+++ b/src/schema/v2/fields/__tests__/money.test.ts
@@ -47,6 +47,15 @@ describe(amount, () => {
     ).toMatchInlineSnapshot(`"£12.34"`)
   })
 
+  it("respects major / minor unit conversion ratio if currencyCode passed in", () => {
+    expect(
+      getResult({
+        obj: { currencyCode: "CLF" },
+        args: {},
+      })
+    ).toMatchInlineSnapshot(`"UF0.12"`)
+  })
+
   it("prefers object symbol over currencyCode", () => {
     expect(
       getResult({

--- a/src/schema/v2/fields/money.ts
+++ b/src/schema/v2/fields/money.ts
@@ -60,9 +60,13 @@ export const amount = (centsResolver) => ({
       return null
     }
 
+    const factor =
+      currencyCodes[obj?.currencyCode?.toLowerCase()]?.subunit_to_unit ?? 100
+    const major = cents / factor
+
     // Some objects return a currencyCode instead of a symbol.
     return formatMoney(
-      cents / 100,
+      major,
       assign({}, options, {
         symbol,
       })


### PR DESCRIPTION
This PR stitches in a few new fields which piggy back on our [money utils](https://github.com/damassi/metaphysics/blob/2e1c89f763d9f15d16c02f5ca193d5d1d641048c/src/schema/v2/fields/money.ts#L28) and will allow us to extend things around different currencies, etc:
- `lowEstimateAmount` 
- `highEstimateAmount`

<img width="343" alt="Screen Shot 2020-08-06 at 5 27 10 PM" src="https://user-images.githubusercontent.com/236943/89595717-1c0b5a00-d80a-11ea-94ef-5204dd9d3469.png">

Additionally cleaned up our testing environment by setting up some common things based on existing patterns. 

### Output: 

```graphql
{
  offers(gravityPartnerId: "-----") {
    edges {
      node {
        currency
        id
        highEstimateAmount
        highEstimateCents
        lowEstimateCents
        submission {
          id
        }
      }
    }
  }
}
```
```js
{
  "data": {
    "offers": {
      "edges": [
       {
          "node": {
            "currency": "USD",
            "id": "4477",
            "highEstimateAmount": "$100,000",
            "highEstimateCents": 10000000,
            "lowEstimateAmount": "$10,000",
            "lowEstimateCents": 1000000,
            "submission": {
              "id": "35599"
            }
          }
       }
     }
   }
 }
```