### PR TITLE
Viewer fix for statuses

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -13749,7 +13749,11 @@ type Viewer {
 
   # A list of Users
   users(ids: [String]): [User]
-  viewingRoomsConnection(after: String, first: Int): ViewingRoomConnection
+  viewingRoomsConnection(
+    after: String
+    first: Int
+    statuses: [ViewingRoomStatusEnum!]
+  ): ViewingRoomConnection
 }
 
 # An artwork viewing room

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9893,7 +9893,11 @@ type Viewer {
     ids: [String]
     last: Int
   ): UserConnection
-  viewingRoomsConnection(after: String, first: Int): ViewingRoomConnection
+  viewingRoomsConnection(
+    after: String
+    first: Int
+    statuses: [ViewingRoomStatusEnum!]
+  ): ViewingRoomConnection
 }
 
 # An artwork viewing room

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -453,7 +453,7 @@ describe("gravity/stitching", () => {
     })
   })
 
-  describe("#viewingRoomsConnection", () => {
+  describe("#viewingRoomsConnection in Partner", () => {
     it("extends the Partner type with a viewingRoomsConnection field", async () => {
       const mergedSchema = await getGravityMergedSchema()
       const partnerFields = await getFieldsForTypeFromSchema(
@@ -484,6 +484,18 @@ describe("gravity/stitching", () => {
         context: expect.anything(),
         info: expect.anything(),
       })
+    })
+  })
+
+  describe("#viewingRoomsConnection in Viewer", () => {
+    it("extends the Viewer type with a viewingRoomsConnection field", async () => {
+      const mergedSchema = await getGravityMergedSchema()
+      const viewerFields = await getFieldsForTypeFromSchema(
+        "Viewer",
+        mergedSchema
+      )
+
+      expect(viewerFields).toContain("viewingRoomsConnection")
     })
   })
 

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -137,7 +137,7 @@ export const gravityStitchingEnvironment = (
       }
 
       extend type Viewer {
-        viewingRoomsConnection(first: Int, after: String): ViewingRoomConnection
+        viewingRoomsConnection(first: Int, after: String, statuses: [ViewingRoomStatusEnum!]): ViewingRoomConnection
       }
     `,
     resolvers: {


### PR DESCRIPTION
This PR adds the `statuses` field in the viewer we created for force for `viewingRooms`


I tried adding a test for `inputFields include statuses`, but I couldn't add this in an easy way.

I tried getting it by using something like `getFieldsForTypeFromSchema` but for inputFields, but there is no "type" that these are attached to.

I did find and try [this](https://gist.githubusercontent.com/craigbeck/b90915d49fda19d5b2b17ead14dcd6da/raw/e50819812a7a8a95b303ac0ea1464e2679e3e4bc/introspection-query.graphql) which worked and gave me the whole schema basically. I'm sure we could use this in a test and get everything and them map it in an object that we can ask like `Viewer.viewingRoomsConnection.inputFields includes statuses`.