### PR TITLE
Tune staging rolling update parameters.

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -55,6 +55,10 @@ spec:
                   value: https
             initialDelaySeconds: 5
             periodSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 10"]
         - name: metaphysics-nginx
           image: artsy/docker-nginx:1.14.2
           ports:
@@ -71,7 +75,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/usr/sbin/nginx", "-s", "quit"]
+                command: ["sh", "-c", "sleep 5 && /usr/sbin/nginx -s quit"]
           env:
             - name: "NGINX_DEFAULT_CONF"
               valueFrom:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -55,6 +55,10 @@ spec:
                   value: https
             initialDelaySeconds: 5
             periodSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 10"]
         - name: metaphysics-nginx
           image: artsy/docker-nginx:1.14.2
           ports:
@@ -71,7 +75,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/usr/sbin/nginx", "-s", "quit"]
+                command: ["sh", "-c", "sleep 5 && /usr/sbin/nginx -s quit"]
           env:
             - name: "NGINX_DEFAULT_CONF"
               valueFrom:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -6,8 +6,8 @@ metadata:
 spec:
   strategy:
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 20%
+      maxSurge: 1
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:


### PR DESCRIPTION
- The current staging rolling update settings (`maxSurge`, `maxUnavailable`), along with HPA `minReplicas` setting, allow the situation of having 0 pods during a rolling update. Changing rolling update settings to ensure that there's always at least 1 pod available during deployment.

- True up staging/prod preStop settings according to: https://github.com/artsy/artsy-hokusai-templates/blob/ac33c4db8754143318612497f68361b64ea1abd6/nodejs/hokusai/staging.yml.j2#L68

These changes should eliminate some Pingdom alerts.

---
Kubernetes doc on rolling update parameters: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#max-surge