### PR TITLE
Allow for formatting of markdown description for artist series

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1275,6 +1275,7 @@ type ArtistSeries {
   artworkIDs: [ID!]!
   artworksConnection(after: String, first: Int): ArtworkConnection
   description: String
+  descriptionFormatted(format: Format): String
   featured: Boolean!
   forSaleArtworksCount: Int!
   image: Image

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1011,6 +1011,7 @@ type ArtistSeries {
   artworkIDs: [ID!]!
   artworksConnection(after: String, first: Int): ArtworkConnection
   description: String
+  descriptionFormatted(format: Format): String
   featured: Boolean!
   filterArtworksConnection(
     acquireable: Boolean

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -671,4 +671,28 @@ describe("gravity/stitching", () => {
       })
     })
   })
+
+  describe("#descriptionFormatted", () => {
+    it("converts from markdown to HTML", async () => {
+      const { resolvers } = await getGravityStitchedSchema()
+      const { descriptionFormatted } = resolvers.ArtistSeries
+      const formattedDescription = await descriptionFormatted.resolve(
+        { description: "**Bold Type**" },
+        { format: "HTML" }
+      )
+      expect(formattedDescription).toEqual(
+        "<p><strong>Bold Type</strong></p>\n"
+      )
+    })
+
+    it("keeps markdown", async () => {
+      const { resolvers } = await getGravityStitchedSchema()
+      const { descriptionFormatted } = resolvers.ArtistSeries
+      const formattedDescription = await descriptionFormatted.resolve(
+        { description: "**Bold Type**" },
+        { format: "MARKDOWN" }
+      )
+      expect(formattedDescription).toEqual("**Bold Type**")
+    })
+  })
 })

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -8,9 +8,10 @@ import {
   isEnumType,
 } from "graphql"
 import moment from "moment"
-import { defineCustomLocale } from "lib/helpers"
+import { defineCustomLocale, isExisty } from "lib/helpers"
 import { pageableFilterArtworksArgs } from "schema/v2/filterArtworksConnection"
 import { normalizeImageData, getDefault } from "schema/v2/image"
+import { formatMarkdownValue } from "schema/v2/fields/markdown"
 
 const LocaleEnViewingRoomRelativeShort = "en-viewing-room-relative-short"
 defineCustomLocale(LocaleEnViewingRoomRelativeShort, {
@@ -112,6 +113,7 @@ export const gravityStitchingEnvironment = (
               ).join("\n")}): FilterArtworksConnection`
             : ""
         }
+        descriptionFormatted(format: Format): String
       }
 
       extend type Partner {
@@ -174,6 +176,25 @@ export const gravityStitchingEnvironment = (
               context,
               info,
             })
+          },
+        },
+        descriptionFormatted: {
+          fragment: gql`
+            ... on ArtistSeries {
+              description
+            }
+          `,
+          resolve: async ({ description }, { format }) => {
+            if (!isExisty(description) || typeof description !== "string")
+              return null
+
+            const formats = {
+              HTML: "html",
+              PLAIN: "plain",
+              MARKDOWN: "markdown",
+            }
+
+            return formatMarkdownValue(description, formats[format])
           },
         },
         image: {

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -12,6 +12,7 @@ import { defineCustomLocale, isExisty } from "lib/helpers"
 import { pageableFilterArtworksArgs } from "schema/v2/filterArtworksConnection"
 import { normalizeImageData, getDefault } from "schema/v2/image"
 import { formatMarkdownValue } from "schema/v2/fields/markdown"
+import Format from "schema/v2/input_fields/format"
 
 const LocaleEnViewingRoomRelativeShort = "en-viewing-room-relative-short"
 defineCustomLocale(LocaleEnViewingRoomRelativeShort, {
@@ -187,6 +188,13 @@ export const gravityStitchingEnvironment = (
           resolve: async ({ description }, { format }) => {
             if (!isExisty(description) || typeof description !== "string")
               return null
+
+            const { type: formatType } = Format
+            const desiredFormat = formatType
+              ?.getValues()
+              ?.find((e) => e.name === format)?.value
+
+            return formatMarkdownValue(description, desiredFormat)
 
             const formats = {
               HTML: "html",


### PR DESCRIPTION
## Problem
We need to be able to input markdown for Artist Series descriptions and have them render properly. While we do have a coffeescript-based markdown -> html converter already in force, it seems that we prefer to be able to return multiple formats from metaphysics and have this layer do the conversion.

[Note: happy to adjust course if we want to handle markdown in force, but converting to HTML here seemed like the cleanest option that followed existing patterns].

## Solution
For types defined in metaphysics, we have an easy way to include handling for different formats. However, `ArtistSeries` is a type stitched in from Gravity. I extended the type in gravity's stitching file as `descriptionFormatted`. The naming was chosen so that it would show up alphabetically next to `description` in the docs.

## Issues
The type of the `format: ` arg appears to be correct from the perspective of the schema (i.e. I'm forced to enter a correct value), but I could not figure out how to automatically convert the inputted val (like `HTML`, `MARKDOWN`, etc.) into the enum format (`"html"`, `"markdown"`, etc.) so I had to repeat the definition. I'm hoping there's an easy way to do this!!

![image](https://user-images.githubusercontent.com/2081340/89788631-76980500-daed-11ea-9dd9-a56bf6572183.png)
