### PR TITLE
If initial message undefined, don't blow up

### DIFF
--- a/src/schema/v2/me/conversation/index.ts
+++ b/src/schema/v2/me/conversation/index.ts
@@ -267,6 +267,7 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
         "This field is no longer required. Prefer the first message from the MessageConnection.",
       type: new GraphQLNonNull(GraphQLString),
       resolve: ({ initial_message, from_name }) => {
+        if (!initial_message) return ""
         const parts = initial_message.split(
           "Message from " + from_name + ":\n\n"
         )


### PR DESCRIPTION
This is a first step to fix https://artsyproduct.atlassian.net/browse/MX-499 and https://artsyproduct.atlassian.net/browse/PURCHASE-2074. It at least ensures metaphysics doesn't throw an exception if the `intial_message` is `undefined`. 