### PR TITLE
Add an authenticated sales loader

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -185,6 +185,7 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    salesLoaderWithHeaders: gravityLoader("sales", {}, { headers: true }),
     saveArtworkLoader: gravityLoader(
       (id) => `collection/saved-artwork/artwork/${id}`,
       {},

--- a/src/schema/v2/__tests__/salesConnection.test.ts
+++ b/src/schema/v2/__tests__/salesConnection.test.ts
@@ -7,28 +7,31 @@ describe("salesConnection", () => {
   describe(`Provides filter results`, () => {
     it("returns a connection, and makes one gravity call when args passed inline", async () => {
       const context = {
-        salesLoaderWithHeaders: sinon
-          .stub()
-          .withArgs("sales", {
-            first: 5,
-            isAuction: true,
-            live: true,
-            published: true,
-            registered: true,
-          })
-          .returns(
-            Promise.resolve({
-              headers: {
-                "x-total-count": 1,
-              },
-              body: [
-                {
-                  name: "Heritage: Photographs",
-                  slug: "heritage-photographs-14",
-                },
-              ],
+        authenticatedLoaders: {
+          salesLoaderWithHeaders: sinon
+            .stub()
+            .withArgs("sales", {
+              first: 5,
+              isAuction: true,
+              live: true,
+              published: true,
+              registered: true,
             })
-          ),
+            .returns(
+              Promise.resolve({
+                headers: {
+                  "x-total-count": 1,
+                },
+                body: [
+                  {
+                    name: "Heritage: Photographs",
+                    slug: "heritage-photographs-14",
+                  },
+                ],
+              })
+            ),
+        },
+        unauthenticatedLoaders: {},
       }
 
       const query = gql`
@@ -39,6 +42,58 @@ describe("salesConnection", () => {
             live: true
             published: true
             registered: true
+          ) {
+            edges {
+              node {
+                name
+              }
+            }
+          }
+        }
+      `
+
+      const { salesConnection } = await runQuery(query, context as any)
+
+      expect(salesConnection.edges).toEqual([
+        { node: { name: "Heritage: Photographs" } },
+      ])
+    })
+
+    it("uses the unauthenticated loader if registered is not specified", async () => {
+      const context = {
+        authenticatedLoaders: {},
+        unauthenticatedLoaders: {
+          salesLoaderWithHeaders: sinon
+            .stub()
+            .withArgs("sales", {
+              first: 5,
+              isAuction: true,
+              live: true,
+              published: true,
+            })
+            .returns(
+              Promise.resolve({
+                headers: {
+                  "x-total-count": 1,
+                },
+                body: [
+                  {
+                    name: "Heritage: Photographs",
+                    slug: "heritage-photographs-14",
+                  },
+                ],
+              })
+            ),
+        },
+      }
+
+      const query = gql`
+        {
+          salesConnection(
+            first: 5
+            isAuction: true
+            live: true
+            published: true
           ) {
             edges {
               node {

--- a/src/schema/v2/sales.ts
+++ b/src/schema/v2/sales.ts
@@ -54,13 +54,17 @@ export const SalesConnectionField: GraphQLFieldConfig<void, ResolverContext> = {
   resolve: async (
     _root,
     { ids, isAuction, live, published, sort, registered, ...paginationArgs },
-    { salesLoaderWithHeaders }
+    {
+      unauthenticatedLoaders: { salesLoaderWithHeaders: loaderWithCache },
+      authenticatedLoaders: { salesLoaderWithHeaders: loaderWithoutCache },
+    }
   ) => {
     const { page, size, offset } = convertConnectionArgsToGravityArgs(
       paginationArgs
     )
 
-    const { body: sales, headers } = ((await salesLoaderWithHeaders(
+    const loader = registered ? loaderWithoutCache : loaderWithCache
+    const { body: sales, headers } = ((await loader!(
       {
         id: ids,
         is_auction: isAuction,


### PR DESCRIPTION
I added a new `registered` argument to filter sales by registration, which requires authentication: https://github.com/artsy/metaphysics/pull/2584

Apparently, the authenticated loader also need to exist in `src/lib/loaders/loaders_with_authentication/gravity.ts` otherwise the loaders with authentication headers will never delegate the `X-ACCESS-TOKEN` header value. To fix this issue, I just simply added the same loader to `src/lib/loaders/loaders_with_authentication/gravity.ts`. While this seems to be working fine, I wasn't 100% sure that two different loaders with the same name could co-exist. There does seem to be other examples such as `filterArtworksLoader`, `partnerArtworksLoader`, and `popularArtistsLoader`, but please let me know if this could cause a problem.
