### PR TITLE
[FX-2123] Add a formatted artwork count to ArtistSeries

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1281,6 +1281,10 @@ type ArtistSeries {
   artworkIDs: [ID!]!
   artworksConnection(after: String, first: Int): ArtworkConnection
   artworksCount: Int!
+
+  # A formatted string that shows the number of available works or
+  # (as a fallback) the number of works in general.
+  artworksCountMessage: String
   description: String
   descriptionFormatted(format: Format): String
   featured: Boolean!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1017,6 +1017,10 @@ type ArtistSeries {
   artworkIDs: [ID!]!
   artworksConnection(after: String, first: Int): ArtworkConnection
   artworksCount: Int!
+
+  # A formatted string that shows the number of available works or
+  # (as a fallback) the number of works in general.
+  artworksCountMessage: String
   description: String
   descriptionFormatted(format: Format): String
   featured: Boolean!

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -710,4 +710,48 @@ describe("gravity/stitching", () => {
       expect(formattedDescription).toEqual("**Bold Type**")
     })
   })
+
+  describe("#artworksCountMessage", () => {
+    it("prefers for-sale artworks count", async () => {
+      const { resolvers } = await getGravityStitchedSchema()
+      const { artworksCountMessage } = resolvers.ArtistSeries
+      const value = await artworksCountMessage.resolve({
+        forSaleArtworksCount: 20,
+        artworksCount: 10,
+      })
+      expect(value).toEqual("20 available")
+    })
+
+    it("falls back to general artworks count", async () => {
+      const { resolvers } = await getGravityStitchedSchema()
+      const { artworksCountMessage } = resolvers.ArtistSeries
+      const value = await artworksCountMessage.resolve({
+        forSaleArtworksCount: 0,
+        artworksCount: 10,
+      })
+      expect(value).toEqual("10 works")
+    })
+
+    it("pluralizes correctly", async () => {
+      const { resolvers } = await getGravityStitchedSchema()
+      const { artworksCountMessage } = resolvers.ArtistSeries
+
+      const zero = await artworksCountMessage.resolve({
+        forSaleArtworksCount: 0,
+        artworksCount: 0,
+      })
+      const one = await artworksCountMessage.resolve({
+        forSaleArtworksCount: 0,
+        artworksCount: 1,
+      })
+      const many = await artworksCountMessage.resolve({
+        forSaleArtworksCount: 0,
+        artworksCount: 42,
+      })
+
+      expect(zero).toEqual("0 works")
+      expect(one).toEqual("1 work")
+      expect(many).toEqual("42 works")
+    })
+  })
 })

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -115,6 +115,11 @@ export const gravityStitchingEnvironment = (
             : ""
         }
         descriptionFormatted(format: Format): String
+        """
+        A formatted string that shows the number of available works or
+        (as a fallback) the number of works in general.
+        """
+        artworksCountMessage: String
       }
 
       extend type Partner {
@@ -195,6 +200,27 @@ export const gravityStitchingEnvironment = (
               ?.find((e) => e.name === format)?.value
 
             return formatMarkdownValue(description, desiredFormat)
+          },
+        },
+        artworksCountMessage: {
+          fragment: gql`
+            ... on ArtistSeries {
+              forSaleArtworksCount
+              artworksCount
+            }
+          `,
+          resolve: async ({ forSaleArtworksCount, artworksCount }) => {
+            let artworksCountMessage
+
+            if (forSaleArtworksCount) {
+              artworksCountMessage = `${forSaleArtworksCount} available`
+            } else {
+              artworksCountMessage = `${artworksCount} ${
+                artworksCount === 1 ? "work" : "works"
+              }`
+            }
+
+            return artworksCountMessage
           },
         },
         image: {


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2123

### Problem

When an artist series has no for-sale works we don't want to simply show "0 available"

### Solution

- Use the count of all works (not just for-sale ones) as a fallback
- Return a consistently formatted string ("42 available" when there are for-sale works vs "42 works" when there are no for-sale works)

Originally I had this logic living in Force and Eigen, but for the sake of consistency and reusability it seemed sensible to have this in MP, since it is a common formatting concern across clients and surfaces. 

So this will be followed up by PRs to Force and Eigen to simply use the new `artworksCountMessage` field.

![Screen Shot 2020-08-12 at 4 43 20 PM](https://user-images.githubusercontent.com/140521/90065898-f6bf9580-dcba-11ea-9c62-1440d3827ae6.png)

![Screen Shot 2020-08-12 at 4 43 26 PM](https://user-images.githubusercontent.com/140521/90065900-f7582c00-dcba-11ea-9ddd-4af5b5afe020.png)
