### PR TITLE
Make sure salesConection resolver uses a loader without cache if registered is false

### DIFF
--- a/src/schema/v2/__tests__/salesConnection.test.ts
+++ b/src/schema/v2/__tests__/salesConnection.test.ts
@@ -12,16 +12,11 @@ describe("salesConnection", () => {
             .stub()
             .withArgs("sales", {
               first: 5,
-              isAuction: true,
-              live: true,
-              published: true,
               registered: true,
             })
             .returns(
               Promise.resolve({
-                headers: {
-                  "x-total-count": 1,
-                },
+                headers: { "x-total-count": 1 },
                 body: [
                   {
                     name: "Heritage: Photographs",
@@ -36,13 +31,50 @@ describe("salesConnection", () => {
 
       const query = gql`
         {
-          salesConnection(
-            first: 5
-            isAuction: true
-            live: true
-            published: true
-            registered: true
-          ) {
+          salesConnection(first: 5, registered: true) {
+            edges {
+              node {
+                name
+              }
+            }
+          }
+        }
+      `
+
+      const { salesConnection } = await runQuery(query, context as any)
+
+      expect(salesConnection.edges).toEqual([
+        { node: { name: "Heritage: Photographs" } },
+      ])
+    })
+
+    it("resolves a connection with an authenticated loader", async () => {
+      const context = {
+        authenticatedLoaders: {
+          salesLoaderWithHeaders: sinon
+            .stub()
+            .withArgs("sales", {
+              first: 5,
+              registered: false,
+            })
+            .returns(
+              Promise.resolve({
+                headers: { "x-total-count": 1 },
+                body: [
+                  {
+                    name: "Heritage: Photographs",
+                    slug: "heritage-photographs-14",
+                  },
+                ],
+              })
+            ),
+        },
+        unauthenticatedLoaders: {},
+      }
+
+      const query = gql`
+        {
+          salesConnection(first: 5, registered: false) {
             edges {
               node {
                 name

--- a/src/schema/v2/sales.ts
+++ b/src/schema/v2/sales.ts
@@ -63,7 +63,8 @@ export const SalesConnectionField: GraphQLFieldConfig<void, ResolverContext> = {
       paginationArgs
     )
 
-    const loader = registered ? loaderWithoutCache : loaderWithCache
+    const loader =
+      typeof registered === "boolean" ? loaderWithoutCache : loaderWithCache
     const { body: sales, headers } = ((await loader!(
       {
         id: ids,


### PR DESCRIPTION
addresses https://github.com/artsy/metaphysics/pull/2616#discussion_r470315496

@mzikherman has pointed out that we aren't using the `loaderWithoutCache` properly when the `registered` argument is `false`. I wasn't sure how I should check it in JS as it could be `undefined` or `null` when it's not specified, so I ended up checking the type of the value and pick up the `loaderWithoutCache` if it's a boolean value. I'm still not 100% confidenent, but at least the test should demonstrate that the authenticated loader is properly picked up.

Let me know if there is anything to think about in this PR.