### PR TITLE
Adds remaining fair-related fields

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4842,6 +4842,7 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
   ): ArtistConnection
   bannerSize: String
   cached: Int
+  contact(format: Format): String
   counts: FairCounts
   endAt(
     format: String
@@ -4915,7 +4916,7 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
   hasHomepageSection: Boolean
   hasLargeBanner: Boolean
   hasListing: Boolean
-  hours: String
+  hours(format: Format): String
   href: String
 
   # A globally unique ID.
@@ -4928,7 +4929,7 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
   # Are we currently in the fair's active period?
   isActive: Boolean
   isPublished: Boolean
-  links: String
+  links(format: Format): String
   location: Location
   mobileImage: Image
   name: String
@@ -4958,7 +4959,9 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
     # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
     timezone: String
   ): String
+  summary: String
   tagline: String
+  tickets(format: Format): String
   ticketsLink: String
 }
 

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -34,6 +34,7 @@ import { FairArtistSortsType } from "./sorts/fairArtistSorts"
 import { ResolverContext } from "types/graphql"
 import { sponsoredContentForFair } from "lib/sponsoredContent"
 import { connectionWithCursorInfo } from "./fields/pagination"
+import { markdown } from "./fields/markdown"
 
 const FollowedContentType = new GraphQLObjectType<any, ResolverContext>({
   name: "FollowedContent",
@@ -179,9 +180,7 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLBoolean,
         resolve: ({ has_listing }) => has_listing,
       },
-      hours: {
-        type: GraphQLString,
-      },
+      hours: markdown(),
       href: {
         type: GraphQLString,
         resolve: ({ default_profile_id, organizer }) => {
@@ -199,9 +198,7 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
           return now.isAfter(activeStart)
         },
       },
-      links: {
-        type: GraphQLString,
-      },
+      links: markdown(),
       mobileImage: {
         /**
          * cannot use Image normalizer because it will grab other image versions; mobile icon is expected to be correctly
@@ -288,6 +285,11 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       startAt: date,
+      summary: {
+        type: GraphQLString,
+      },
+      tickets: markdown(),
+      contact: markdown(),
       endAt: date,
       activeStartAt: date,
       organizer: {


### PR DESCRIPTION
This PR adds the remaining fields we need to populate the "More info" page on the new fair landing.

It also makes a few of the fields `markdown`-style, which means they can be formatted into `HTML`. By default (if you don't pass a `format: HTML` argument) it returns the same value that's been inputted so it should be backwards-compatible.

I didn't add tests since we're just passing through fields from gravity so I didn't think they added much, but happy to!

![image](https://user-images.githubusercontent.com/2081340/90450141-f8240000-e0b6-11ea-896b-f80877e29e5d.png)
