### PR TITLE
Add published and partnerID params to viewingRoomsConnection field

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -13799,6 +13799,8 @@ type Viewer {
   viewingRoomsConnection(
     after: String
     first: Int
+    partnerID: ID
+    published: Boolean = true
     statuses: [ViewingRoomStatusEnum!]
   ): ViewingRoomsConnection
 }

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10038,6 +10038,8 @@ type Viewer {
   viewingRoomsConnection(
     after: String
     first: Int
+    partnerID: ID
+    published: Boolean = true
     statuses: [ViewingRoomStatusEnum!]
   ): ViewingRoomsConnection
 }

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -145,7 +145,7 @@ export const gravityStitchingEnvironment = (
       }
 
       extend type Viewer {
-        viewingRoomsConnection(first: Int, after: String, statuses: [ViewingRoomStatusEnum!]): ViewingRoomsConnection
+        viewingRoomsConnection(first: Int, after: String, statuses: [ViewingRoomStatusEnum!], published: Boolean = true, partnerID: ID): ViewingRoomsConnection
       }
     `,
     resolvers: {


### PR DESCRIPTION
Follow up to https://github.com/artsy/metaphysics/pull/2621

Adds optional parameters to enable querying `viewingRoomsConnection` by `published` and `partnerID`.


![Screen Shot 2020-08-19 at 6 12 37 PM](https://user-images.githubusercontent.com/10385964/90694996-98109380-e247-11ea-8518-1e2ac76f5882.png)
