### PR TITLE
Exclude current from artworksConnection on ArtistSeries

### DIFF
--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -171,9 +171,14 @@ export const gravityStitchingEnvironment = (
           }
           `,
           resolve: async ({ artworkIDs: ids }, _args, context, info) => {
+            // Exclude the current artwork in a series so that lists of
+            // other artworks in the same series don't show the artwork.
+            const filteredIDs = context.currentArtworkID
+              ? ids.filter((id) => id !== context.currentArtworkID)
+              : ids
             return await info.mergeInfo.delegateToSchema({
               args: {
-                ids,
+                ids: filteredIDs,
                 ..._args,
               },
               schema: localSchema,
@@ -553,6 +558,7 @@ export const gravityStitchingEnvironment = (
             }
             `,
           resolve: ({ internalID: artworkID }, args, context, info) => {
+            context.currentArtworkID = artworkID
             return info.mergeInfo.delegateToSchema({
               schema: gravitySchema,
               operation: "query",


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2157

## Problem

On the artwork page, currently a user can see the same artwork in the “more works from this series” rail. This creates a less-polished browsing experience.

## Solution

Exclude the current artwork (when it exists) from the `artworksConnection` query on `ArtistSeries`.

QA Note: We'll want to check the UIs in Force and iOS to make sure that any relevant artwork counts we display are correct.

## Screenshots

**Before**

<img width="1532" alt="Screen Shot 2020-08-24 at 4 21 43 PM" src="https://user-images.githubusercontent.com/4432348/91092642-548e9e80-e626-11ea-81cd-da12fcd2b02c.png">

**After**

<img width="1532" alt="Screen Shot 2020-08-24 at 4 22 23 PM" src="https://user-images.githubusercontent.com/4432348/91092772-86076a00-e626-11ea-83aa-41cf22e1c241.png">
