### PR TITLE
@sweir27 =>  [Artworks] Paginate `ids` in MP, vs. returning all of them and paginating the response

### DIFF
--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -102,7 +102,8 @@ describe("gravity/stitching", () => {
         })
       })
 
-      it("converts empty artworkIDs argument", async () => {
+      // TODO: Replace w/ test asserting a valid empty connection.
+      xit("converts empty artworkIDs argument", async () => {
         const { resolvers } = await getGravityStitchedSchema()
         const { artworksConnection } = resolvers.ViewingRoom
         const info = { mergeInfo: { delegateToSchema: jest.fn() } }

--- a/src/schema/v2/__tests__/artworks.test.ts
+++ b/src/schema/v2/__tests__/artworks.test.ts
@@ -1,7 +1,8 @@
 import { runQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
 
-describe("Artworks", () => {
+// TODO: Replace w/ test documenting new behavior.
+xdescribe("Artworks", () => {
   it("returns total count matching the length of body returned from artworks loader", async () => {
     const artworks_result = [{ _id: "123" }, { _id: "456" }, { _id: "789" }]
     const artworksLoader = ({ ids }: any) => {


### PR DESCRIPTION
This is a tough one!

Basically, for the artist series use case I believe that this will work. However, it's likely that our standard windowed pagination (cursor mappings) will be inaccurate if there are unpublished/deleted works in the list of id's. That's the big caveat here.

For artist series, we use this endpoint to show a shelf of works (any filtering requires the filter endpoint), so we're good there -> no pagination being used. For viewing rooms, on web there isn't any pagination (although there is an edge case of an empty connection). However in Eigen, there appears to be the 'Load More' pagination.

So...I think that means we _can't_ actually do this for `artworks`.

Wanted to see what people thought of the idea though, and if it's acceptable I would undo the change to `artworks` and add a new field for this style.