### PR TITLE
@sweir27 -> [FilterArtworks] Add excludeArtworkIDs as an argument

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -692,6 +692,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     before: String
     color: String
     dimensionRange: String
+    excludeArtworkIDs: [String]
     extraAggregationGeneIDs: [String]
     first: Int
     forSale: Boolean
@@ -1037,6 +1038,7 @@ type ArtistSeries {
     before: String
     color: String
     dimensionRange: String
+    excludeArtworkIDs: [String]
     extraAggregationGeneIDs: [String]
     first: Int
     forSale: Boolean
@@ -4729,6 +4731,7 @@ interface EntityWithFilterArtworksConnectionInterface {
     before: String
     color: String
     dimensionRange: String
+    excludeArtworkIDs: [String]
     extraAggregationGeneIDs: [String]
     first: Int
     forSale: Boolean
@@ -4878,6 +4881,7 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
     before: String
     color: String
     dimensionRange: String
+    excludeArtworkIDs: [String]
     extraAggregationGeneIDs: [String]
     first: Int
     forSale: Boolean
@@ -5505,6 +5509,7 @@ type Gene implements Node & Searchable {
     before: String
     color: String
     dimensionRange: String
+    excludeArtworkIDs: [String]
     extraAggregationGeneIDs: [String]
     first: Int
     forSale: Boolean
@@ -6154,6 +6159,7 @@ type MarketingCollection {
     before: String
     color: String
     dimensionRange: String
+    excludeArtworkIDs: [String]
     extraAggregationGeneIDs: [String]
     first: Int
     forSale: Boolean
@@ -7586,6 +7592,7 @@ type Query {
     before: String
     color: String
     dimensionRange: String
+    excludeArtworkIDs: [String]
     extraAggregationGeneIDs: [String]
     first: Int
     forSale: Boolean
@@ -8862,6 +8869,7 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
     before: String
     color: String
     dimensionRange: String
+    excludeArtworkIDs: [String]
     extraAggregationGeneIDs: [String]
     first: Int
     forSale: Boolean
@@ -9251,6 +9259,7 @@ type Tag implements Node {
     before: String
     color: String
     dimensionRange: String
+    excludeArtworkIDs: [String]
     extraAggregationGeneIDs: [String]
     first: Int
     forSale: Boolean
@@ -9751,6 +9760,7 @@ type Viewer {
     before: String
     color: String
     dimensionRange: String
+    excludeArtworkIDs: [String]
     extraAggregationGeneIDs: [String]
     first: Int
     forSale: Boolean

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -127,6 +127,9 @@ export const filterArtworksArgs: GraphQLFieldConfigArgumentMap = {
   dimensionRange: {
     type: GraphQLString,
   },
+  excludeArtworkIDs: {
+    type: new GraphQLList(GraphQLString),
+  },
   extraAggregationGeneIDs: {
     type: new GraphQLList(GraphQLString),
   },
@@ -378,6 +381,7 @@ const filterArtworksConnectionTypeFactory = (
       attributionClass,
       sizes,
       dimensionRange,
+      excludeArtworkIDs,
       extraAggregationGeneIDs,
       includeArtworksByFollowedArtists,
       includeMediumFilterInAggregation,
@@ -409,6 +413,7 @@ const filterArtworksConnectionTypeFactory = (
       attribution_class: attributionClass,
       sizes: sizes,
       dimension_range: dimensionRange,
+      exclude_artwork_ids: excludeArtworkIDs,
       extra_aggregation_gene_ids: extraAggregationGeneIDs,
       include_artworks_by_followed_artists: includeArtworksByFollowedArtists,
       include_medium_filter_in_aggregation: includeMediumFilterInAggregation,


### PR DESCRIPTION
In order for an artwork rail ('More works from this series') to exclude the current artwork (in a first-class way), we'll want to pass that in. Gravity already supports the `exclude_artwork_ids` param.