### PR TITLE
@dzucconi => [ArtistSeries] Exclude current artwork from filterArtworksConnection

### DIFF
--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -47,12 +47,16 @@ describe("gravity/stitching", () => {
       filterArtworksConnection.resolve(
         { internalID: "abc123" },
         { first: 2 },
-        {},
+        { currentArtworkID: "catty-artwork" },
         info
       )
 
       expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
-        args: { artistSeriesID: "abc123", first: 2 },
+        args: {
+          artistSeriesID: "abc123",
+          first: 2,
+          excludeArtworkIDs: ["catty-artwork"],
+        },
         operation: "query",
         fieldName: "artworksConnection",
         schema: expect.anything(),

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -311,6 +311,9 @@ export const gravityStitchingEnvironment = (
                 fieldName: "artworksConnection",
                 args: {
                   artistSeriesID,
+                  ...(!!context.currentArtworkID && {
+                    excludeArtworkIDs: [context.currentArtworkID],
+                  }),
                   ...args,
                 },
                 context,


### PR DESCRIPTION
When we switch the artwork rail to use `filterArtworksConnection` (instead of `artworksConnection`), we'll want to exclude the current artwork (which is set if the context the field is being used in started with an artwork).