### PR TITLE
CSGN-327: Stitch in diffusion schema

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,8 @@
 # Services
 CONVECTION_API_BASE=https://convection-staging.artsy.net/api
 CONVECTION_APP_ID=123412341
+DIFFUSION_API_BASE=https://diffusion-staging.artsy.net/api
+DIFFUSION_TOKEN=REPLACE
 DELTA_API_BASE=http://delta.artsy.test
 EMBEDLY_ENDPOINT=https://i.embed.ly.test/1/display
 GALAXY_API_BASE=https://galaxy-staging-herokuapp.com

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -9116,6 +9116,35 @@ enum MarketingGroupTypes {
   OtherCollections
 }
 
+# Market Price Insights
+type MarketPriceInsights {
+  annualLotsSold: Int
+  annualValueSoldCents: Int
+  artistId: ID
+  artistName: String
+  artsyQInventory: Int
+  createdAt: ISO8601DateTime
+  demandRank: Float
+  demandTrend: Float
+  highRangeCents: Int
+  largeHighRangeCents: Int
+  largeLowRangeCents: Int
+  largeMidRangeCents: Int
+  liquidityRank: Float
+  lowRangeCents: Int
+  medianSaleToEstimateRatio: Float
+  medium: String
+  mediumHighRangeCents: Int
+  mediumLowRangeCents: Int
+  mediumMidRangeCents: Int
+  midRangeCents: Int
+  sellThroughRate: Float
+  smallHighRangeCents: Int
+  smallLowRangeCents: Int
+  smallMidRangeCents: Int
+  updatedAt: ISO8601DateTime
+}
+
 type Me implements Node {
   # A globally unique ID.
   __id: ID!
@@ -11710,6 +11739,9 @@ type Query {
     slugs: [String!]
   ): [MarketingCollection!]!
   marketingHubCollections: [MarketingCollection!]!
+
+  # Get price insights for a market.
+  marketPriceInsights(artistId: ID!, medium: String!): MarketPriceInsights
 
   # A Search for Artists
   match_artist(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6767,6 +6767,35 @@ enum MarketingGroupTypes {
   OtherCollections
 }
 
+# Market Price Insights
+type MarketPriceInsights {
+  annualLotsSold: Int
+  annualValueSoldCents: Int
+  artistId: ID
+  artistName: String
+  artsyQInventory: Int
+  createdAt: ISO8601DateTime
+  demandRank: Float
+  demandTrend: Float
+  highRangeCents: Int
+  largeHighRangeCents: Int
+  largeLowRangeCents: Int
+  largeMidRangeCents: Int
+  liquidityRank: Float
+  lowRangeCents: Int
+  medianSaleToEstimateRatio: Float
+  medium: String
+  mediumHighRangeCents: Int
+  mediumLowRangeCents: Int
+  mediumMidRangeCents: Int
+  midRangeCents: Int
+  sellThroughRate: Float
+  smallHighRangeCents: Int
+  smallLowRangeCents: Int
+  smallMidRangeCents: Int
+  updatedAt: ISO8601DateTime
+}
+
 type Me implements Node {
   # A list of the current user’s inquiry requests
   artworkInquiriesConnection(
@@ -8316,6 +8345,9 @@ type Query {
     slugs: [String!]
   ): [MarketingCollection!]!
   marketingHubCollections: [MarketingCollection!]!
+
+  # Get price insights for a market.
+  marketPriceInsights(artistId: ID!, medium: String!): MarketPriceInsights
   me: Me
 
   # Fetches an object given its globally unique ID.

--- a/src/data/diffusion.graphql
+++ b/src/data/diffusion.graphql
@@ -1,0 +1,42 @@
+"""
+An ISO 8601-encoded datetime
+"""
+scalar ISO8601DateTime
+
+"""
+Market Price Insights
+"""
+type MarketPriceInsights {
+  annualLotsSold: Int
+  annualValueSoldCents: Int
+  artistId: ID
+  artistName: String
+  artsyQInventory: Int
+  createdAt: ISO8601DateTime
+  demandRank: Float
+  demandTrend: Float
+  highRangeCents: Int
+  largeHighRangeCents: Int
+  largeLowRangeCents: Int
+  largeMidRangeCents: Int
+  liquidityRank: Float
+  lowRangeCents: Int
+  medianSaleToEstimateRatio: Float
+  medium: String
+  mediumHighRangeCents: Int
+  mediumLowRangeCents: Int
+  mediumMidRangeCents: Int
+  midRangeCents: Int
+  sellThroughRate: Float
+  smallHighRangeCents: Int
+  smallLowRangeCents: Int
+  smallMidRangeCents: Int
+  updatedAt: ISO8601DateTime
+}
+
+type Query {
+  """
+  Get price insights for a market.
+  """
+  marketPriceInsights(artistId: ID!, medium: String!): MarketPriceInsights
+}

--- a/src/lib/stitching/diffusion/link.ts
+++ b/src/lib/stitching/diffusion/link.ts
@@ -1,0 +1,33 @@
+import { setContext } from "apollo-link-context"
+import { createHttpLink } from "apollo-link-http"
+import config from "config"
+import { headers as requestIDHeaders } from "lib/requestIDs"
+import fetch from "node-fetch"
+import urljoin from "url-join"
+
+import { middlewareLink } from "../lib/middlewareLink"
+import { responseLoggerLink } from "../logLinkMiddleware"
+import { ResolverContext } from "types/graphql"
+
+const { DIFFUSION_API_BASE } = config
+
+export const createDiffusionLink = () => {
+  const httpLink = createHttpLink({
+    fetch,
+    uri: urljoin(DIFFUSION_API_BASE, "graphql"),
+  })
+
+  const authMiddleware = setContext(
+    (_request, { graphqlContext }: { graphqlContext: ResolverContext }) => {
+      const headers = {
+        ...(graphqlContext && requestIDHeaders(graphqlContext.requestIDs)),
+      }
+      return { headers }
+    }
+  )
+
+  return middlewareLink
+    .concat(authMiddleware)
+    .concat(responseLoggerLink("Diffusion"))
+    .concat(httpLink)
+}

--- a/src/lib/stitching/diffusion/schema.ts
+++ b/src/lib/stitching/diffusion/schema.ts
@@ -1,0 +1,30 @@
+import { createDiffusionLink } from "./link"
+import {
+  makeRemoteExecutableSchema,
+  transformSchema,
+  RenameTypes,
+} from "graphql-tools"
+import { readFileSync } from "fs"
+
+export const executableDiffusionSchema = () => {
+  const diffusionLink = createDiffusionLink()
+  const diffusionTypeDefs = readFileSync("src/data/diffusion.graphql", "utf8")
+
+  // Setup the default Schema
+  const schema = makeRemoteExecutableSchema({
+    schema: diffusionTypeDefs,
+    link: diffusionLink,
+  })
+
+  // Remap the names of certain types from Diffusion to fit in the larger
+  // metaphysics ecosystem.
+  const remap = {}
+
+  // Return the new modified schema
+  return transformSchema(schema, [
+    new RenameTypes((name) => {
+      const newName = remap[name] || name
+      return newName
+    }),
+  ])
+}

--- a/src/lib/stitching/diffusion/stitching.ts
+++ b/src/lib/stitching/diffusion/stitching.ts
@@ -1,0 +1,12 @@
+import { GraphQLSchema } from "graphql"
+
+export const diffusionStitchingEnvironment = (
+  _localSchema: GraphQLSchema,
+  _diffusionSchema: GraphQLSchema & { transforms: any }
+) => ({
+  // The SDL used to declare how to stitch an object
+  extensionSchema: "",
+
+  // Resolvers for the above
+  resolvers: {},
+})

--- a/src/lib/stitching/mergeSchemas.ts
+++ b/src/lib/stitching/mergeSchemas.ts
@@ -1,6 +1,7 @@
 import { mergeSchemas as _mergeSchemas } from "graphql-tools"
 import { executableGravitySchema } from "lib/stitching/gravity/schema"
 import { executableCausalitySchema } from "lib/stitching/causality/schema"
+import { executableDiffusionSchema } from "lib/stitching/diffusion/schema"
 import { executableConvectionSchema } from "lib/stitching/convection/schema"
 import { consignmentStitchingEnvironment } from "lib/stitching/convection/stitching"
 import {
@@ -60,6 +61,9 @@ export const incrementalMergeSchemas = (
 
   const causalitySchema = executableCausalitySchema()
   schemas.push(causalitySchema)
+
+  const diffusionSchema = executableDiffusionSchema()
+  schemas.push(diffusionSchema)
 
   useStitchingEnvironment(
     causalityStitchingEnvironment({ causalitySchema, localSchema })


### PR DESCRIPTION
This PR stitches in the diffusion GQL schema. It is about as basic as possible - it does not do anything to forward the auth, for example. Which means that the query actually fails because diffusion is setup with authentication but that's not this PR's problem!

I will follow up on this topic if a future PR - either relaxing diffusion's checks or improving this stitching code to properly pass auth creds over to diffusion.

https://artsyproduct.atlassian.net/browse/CSGN-327

/cc @artsy/csgn-devs 