### PR TITLE
Expose the date that a show was created in the v2 schema

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9128,6 +9128,12 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
 
   # The image you should use to represent this show
   coverImage: Image
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to `X-TIMEZONE` header
+    timezone: String
+  ): String
 
   # A description of the show
   description: String

--- a/src/schema/v2/__tests__/show.test.js
+++ b/src/schema/v2/__tests__/show.test.js
@@ -13,6 +13,7 @@ describe("Show type", () => {
     showData = {
       id: "new-museum-1-2015-triennial-surround-audience",
       _id: "abcdefg123456",
+      created_at: "2015-02-24T12:00:00+00:00",
       start_at: "2015-02-25T12:00:00+00:00",
       end_at: "2015-05-24T12:00:00+00:00",
       press_release: "**foo** *bar*",
@@ -557,11 +558,12 @@ describe("Show type", () => {
     })
   })
 
-  it("includes a formattable start and end date", async () => {
+  it("includes a formattable create, start, and end date", async () => {
     const query = gql`
       {
         show(id: "new-museum-1-2015-triennial-surround-audience") {
           slug
+          createdAt(format: "MM/DD/YYYY")
           startAt(format: "dddd, MMMM Do YYYY, h:mm:ss a")
           endAt(format: "YYYY")
         }
@@ -572,6 +574,7 @@ describe("Show type", () => {
     expect(data).toEqual({
       show: {
         slug: "new-museum-1-2015-triennial-surround-audience",
+        createdAt: "02/24/2015",
         startAt: "Wednesday, February 25th 2015, 12:00:00 pm",
         endAt: "2015",
       },

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -304,6 +304,7 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
         }),
         resolve: (partner_show) => partner_show,
       },
+      createdAt: date,
       description: {
         description: "A description of the show",
         type: GraphQLString,


### PR DESCRIPTION
This PR exposes the `created_at` field on a show in the v2 schema because Force is currently querying for it in the v1 schema (to pass on to Sailthru).

This work will unblock work to deprecate the use of v1 endpoints in Force.