### PR TITLE
[MyCollection] Add edge to create artwork mutation response

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7136,6 +7136,7 @@ input MyCollectionCreateArtworkInput {
 
 type MyCollectionCreateArtworkPayload {
   artwork: Artwork
+  artworkEdge: MyCollectionEdge
   clientMutationId: String
 }
 

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -17,6 +17,11 @@ describe("myCollectionCreateArtworkMutation", () => {
           artwork {
             medium
           }
+          artworkEdge {
+            node {
+              medium
+            }
+          }
         }
       }
     `
@@ -33,6 +38,11 @@ describe("myCollectionCreateArtworkMutation", () => {
       myCollectionCreateArtwork: {
         artwork: {
           medium: "Painting",
+        },
+        artworkEdge: {
+          node: {
+            medium: "Painting",
+          },
         },
       },
     })

--- a/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
@@ -18,6 +18,11 @@ describe("myCollectionUpdateArtworkMutation", () => {
           artwork {
             medium
           }
+          artworkEdge {
+            node {
+              medium
+            }
+          }
         }
       }
     `
@@ -34,6 +39,11 @@ describe("myCollectionUpdateArtworkMutation", () => {
       myCollectionUpdateArtwork: {
         artwork: {
           medium: "Updated",
+        },
+        artworkEdge: {
+          node: {
+            medium: "Updated",
+          },
         },
       },
     })

--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -32,6 +32,11 @@ const MyCollectionConnection = connectionWithCursorInfo({
   },
 })
 
+export const {
+  connectionType: MyCollectionConnectionType,
+  edgeType: MyCollectionEdgeType,
+} = MyCollectionConnection
+
 export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
   type: MyCollectionConnection.connectionType,
   args: pageable({}),

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -1,8 +1,12 @@
 import { GraphQLString, GraphQLList } from "graphql"
-import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  mutationWithClientMutationId,
+  cursorForObjectInConnection,
+} from "graphql-relay"
 import { ArtworkType } from "schema/v2/artwork/index"
 import { ResolverContext } from "types/graphql"
 import { GraphQLNonNull } from "graphql"
+import { MyCollectionEdgeType } from "./myCollection"
 
 export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
   any,
@@ -35,6 +39,20 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
         if (myCollectionArtworkLoader) {
           return myCollectionArtworkLoader(id)
         }
+      },
+    },
+    artworkEdge: {
+      type: MyCollectionEdgeType,
+      resolve: async ({ id }, _, { myCollectionArtworkLoader }) => {
+        if (!myCollectionArtworkLoader) {
+          return null
+        }
+        const artwork = await myCollectionArtworkLoader(id)
+        const edge = {
+          cursor: cursorForObjectInConnection([artwork], artwork),
+          node: artwork,
+        }
+        return edge
       },
     },
   },

--- a/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
@@ -1,7 +1,11 @@
 import { GraphQLString, GraphQLList, GraphQLNonNull } from "graphql"
-import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  mutationWithClientMutationId,
+  cursorForObjectInConnection,
+} from "graphql-relay"
 import { ArtworkType } from "schema/v2/artwork/index"
 import { ResolverContext } from "types/graphql"
+import { MyCollectionEdgeType } from "./myCollection"
 
 export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
   any,
@@ -37,6 +41,20 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
         if (myCollectionArtworkLoader) {
           return myCollectionArtworkLoader(artworkId)
         }
+      },
+    },
+    artworkEdge: {
+      type: MyCollectionEdgeType,
+      resolve: async ({ id }, _, { myCollectionArtworkLoader }) => {
+        if (!myCollectionArtworkLoader) {
+          return null
+        }
+        const artwork = await myCollectionArtworkLoader(id)
+        const edge = {
+          cursor: cursorForObjectInConnection([artwork], artwork),
+          node: artwork,
+        }
+        return edge
       },
     },
   },


### PR DESCRIPTION
In what appears to be an endless journey to get a list to update after a mutation via the [declarative mutation update API](https://relay.dev/docs/en/v2.0.0/mutations.html#range_add), this adds a new artwork edge return object to our mutation response. Applies to both Create / Update: 

```graphql
mutation CreateArtwork($input: MyCollectionCreateArtworkInput!) {
  myCollectionCreateArtwork(input: $input) {
    artworkEdge {
      node {
        medium
      }
    }
  }
}
```