### PR TITLE
[MyCollection] Refactor mutations

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7040,6 +7040,11 @@ type Mutation {
     input: MyCollectionCreateArtworkInput!
   ): MyCollectionCreateArtworkPayload
 
+  # Deletes an artwork from my collection
+  myCollectionDeleteArtwork(
+    input: MyCollectionDeleteArtworkInput!
+  ): MyCollectionDeleteArtworkPayload
+
   # Update an artwork in my collection
   myCollectionUpdateArtwork(
     input: MyCollectionUpdateArtworkInput!
@@ -7109,6 +7114,19 @@ type Mutation {
   ): UpdateViewingRoomSubsectionsPayload
 }
 
+type MyCollectionArtworkMutationFailure {
+  mutationError: GravityMutationError
+}
+
+type MyCollectionArtworkMutationSuccess {
+  artwork: Artwork
+  artworkEdge: MyCollectionEdge
+}
+
+union MyCollectionArtworkMutationType =
+    MyCollectionArtworkMutationFailure
+  | MyCollectionArtworkMutationSuccess
+
 # A connection to a list of items.
 type MyCollectionConnection {
   default: Boolean!
@@ -7135,8 +7153,17 @@ input MyCollectionCreateArtworkInput {
 }
 
 type MyCollectionCreateArtworkPayload {
-  artwork: Artwork
-  artworkEdge: MyCollectionEdge
+  artworkOrError: MyCollectionArtworkMutationType
+  clientMutationId: String
+}
+
+input MyCollectionDeleteArtworkInput {
+  artworkId: String!
+  clientMutationId: String
+}
+
+type MyCollectionDeleteArtworkPayload {
+  artworkOrError: MyCollectionArtworkMutationType
   clientMutationId: String
 }
 
@@ -7160,7 +7187,7 @@ input MyCollectionUpdateArtworkInput {
 }
 
 type MyCollectionUpdateArtworkPayload {
-  artwork: Artwork
+  artworkOrError: MyCollectionArtworkMutationType
   clientMutationId: String
 }
 

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -191,6 +191,14 @@ export default (accessToken, userID, opts) => {
       },
       { method: "PUT" }
     ),
+    myCollectionDeleteArtworkLoader: gravityLoader(
+      (id) => `my-collection/artworks/${id}`,
+      {
+        user_id: userID,
+        private: true,
+      },
+      { method: "DELETE" }
+    ),
     notificationsFeedLoader: gravityLoader("me/notifications/feed"),
     partnerArtworksLoader: gravityLoader(
       (id) => `partner/${id}/artworks`,

--- a/src/schema/v2/me/__tests__/myCollectionDeleteArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionDeleteArtworkMutation.test.ts
@@ -1,0 +1,59 @@
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("myCollectionDeleteArtworkMutation", () => {
+  const mutation = gql`
+    mutation {
+      myCollectionDeleteArtwork(input: { artworkId: "foo" }) {
+        artworkOrError {
+          ... on MyCollectionArtworkMutationDeleteSuccess {
+            success
+          }
+          ... on MyCollectionArtworkMutationFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("returns an error", async () => {
+    const context = {
+      myCollectionDeleteArtworkLoader: () =>
+        Promise.reject(
+          new Error(
+            `https://stagingapi.artsy.net/api/v1/my_collection/artworks/foo - {"error":"Error deleting artwork"}`
+          )
+        ),
+    }
+
+    const data = await runAuthenticatedQuery(mutation, context)
+    expect(data).toEqual({
+      myCollectionDeleteArtwork: {
+        artworkOrError: {
+          mutationError: {
+            message: "Error deleting artwork",
+          },
+        },
+      },
+    })
+  })
+
+  it("deletes an artwork", async () => {
+    const context = {
+      myCollectionDeleteArtworkLoader: () =>
+        Promise.resolve({ name: "My Collection" }),
+    }
+
+    const data = await runAuthenticatedQuery(mutation, context)
+    expect(data).toEqual({
+      myCollectionDeleteArtwork: {
+        artworkOrError: {
+          success: true,
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
@@ -2,30 +2,62 @@ import { runAuthenticatedQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
 
 describe("myCollectionUpdateArtworkMutation", () => {
-  it("updates an artwork", async () => {
-    const mutation = gql`
-      mutation {
-        myCollectionUpdateArtwork(
-          input: {
-            artworkId: "foo"
-            artistIds: ["4d8b92b34eb68a1b2c0003f4"]
-            medium: "Painting"
-            dimensions: "20x20"
-            title: "hey now"
-            year: "1990"
-          }
-        ) {
-          artwork {
-            medium
-          }
-          artworkEdge {
-            node {
+  const mutation = gql`
+    mutation {
+      myCollectionUpdateArtwork(
+        input: {
+          artworkId: "foo"
+          artistIds: ["4d8b92b34eb68a1b2c0003f4"]
+          medium: "Painting"
+          dimensions: "20x20"
+          title: "hey now"
+          year: "1990"
+        }
+      ) {
+        artworkOrError {
+          ... on MyCollectionArtworkMutationSuccess {
+            artwork {
               medium
+            }
+            artworkEdge {
+              node {
+                medium
+              }
+            }
+          }
+          ... on MyCollectionArtworkMutationFailure {
+            mutationError {
+              message
             }
           }
         }
       }
-    `
+    }
+  `
+
+  it("returns an error", async () => {
+    const context = {
+      myCollectionUpdateArtworkLoader: () =>
+        Promise.reject(
+          new Error(
+            `https://stagingapi.artsy.net/api/v1/my_collection/artworks/foo - {"error":"Error updating artwork"}`
+          )
+        ),
+    }
+
+    const data = await runAuthenticatedQuery(mutation, context)
+    expect(data).toEqual({
+      myCollectionUpdateArtwork: {
+        artworkOrError: {
+          mutationError: {
+            message: "Error updating artwork",
+          },
+        },
+      },
+    })
+  })
+
+  it("updates an artwork", async () => {
     const context = {
       myCollectionUpdateArtworkLoader: () => Promise.resolve({ id: "foo" }),
       myCollectionArtworkLoader: () =>
@@ -37,12 +69,14 @@ describe("myCollectionUpdateArtworkMutation", () => {
     const data = await runAuthenticatedQuery(mutation, context)
     expect(data).toEqual({
       myCollectionUpdateArtwork: {
-        artwork: {
-          medium: "Updated",
-        },
-        artworkEdge: {
-          node: {
+        artworkOrError: {
+          artwork: {
             medium: "Updated",
+          },
+          artworkEdge: {
+            node: {
+              medium: "Updated",
+            },
           },
         },
       },

--- a/src/schema/v2/me/myCollectionDeleteArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionDeleteArtworkMutation.ts
@@ -1,34 +1,19 @@
-import { GraphQLString, GraphQLList, GraphQLNonNull } from "graphql"
+import { GraphQLString, GraphQLNonNull } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 import { ResolverContext } from "types/graphql"
 import { MyCollectionArtworkMutationType } from "./myCollection"
 import { formatGravityError } from "lib/gravityErrorHandler"
 
-export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
+export const myCollectionDeleteArtworkMutation = mutationWithClientMutationId<
   any,
   any,
   ResolverContext
 >({
-  name: "MyCollectionUpdateArtwork",
-  description: "Update an artwork in my collection",
+  name: "MyCollectionDeleteArtwork",
+  description: "Deletes an artwork from my collection",
   inputFields: {
     artworkId: {
       type: new GraphQLNonNull(GraphQLString),
-    },
-    artistIds: {
-      type: new GraphQLList(GraphQLString),
-    },
-    dimensions: {
-      type: GraphQLString,
-    },
-    medium: {
-      type: GraphQLString,
-    },
-    title: {
-      type: GraphQLString,
-    },
-    year: {
-      type: GraphQLString,
     },
   },
   outputFields: {
@@ -38,28 +23,28 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    { artworkId, artistIds, dimensions, medium, title, year },
-    { myCollectionUpdateArtworkLoader }
+    { artworkId },
+    { myCollectionDeleteArtworkLoader }
   ) => {
-    if (!myCollectionUpdateArtworkLoader) {
+    if (!myCollectionDeleteArtworkLoader) {
       return new Error("You need to be signed in to perform this action")
     }
 
     try {
-      const response = await myCollectionUpdateArtworkLoader(artworkId, {
-        artist_ids: artistIds,
-        dimensions,
-        medium,
-        title,
-        year,
-      })
+      const response = await myCollectionDeleteArtworkLoader(artworkId)
+
+      // Response from DELETE isn't internalID of deleted artwork and as such
+      // we don't want to match on the MyCollectionArtworkMutationSuccess  type,
+      // which looks for an `id` property.
+      delete response.id
 
       return {
         ...response,
-        id: artworkId,
+        artworkId: artworkId,
       }
     } catch (error) {
       const formattedErr = formatGravityError(error)
+
       if (formattedErr) {
         return { ...formattedErr, _type: "GravityMutationError" }
       } else {

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -96,6 +96,7 @@ import { Shows } from "./shows"
 import PartnerArtworks from "./partnerArtworks"
 import Image from "./image"
 import VanityURLEntity from "./vanityURLEntity"
+import { myCollectionDeleteArtworkMutation } from "./me/myCollectionDeleteArtworkMutation"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -194,6 +195,7 @@ export default new GraphQLSchema({
       followShow: FollowShow,
       myCollectionCreateArtwork: myCollectionCreateArtworkMutation,
       myCollectionUpdateArtwork: myCollectionUpdateArtworkMutation,
+      myCollectionDeleteArtwork: myCollectionDeleteArtworkMutation,
       requestCredentialsForAssetUpload: CreateAssetRequestLoader,
       saveArtwork: saveArtworkMutation,
       sendConfirmationEmail: sendConfirmationEmailMutation,


### PR DESCRIPTION
Digging through other mutations for example code I noticed that we were using an interesting `thingOrDelete` pattern which seemed more robust than the more vanilla mutations we were currently using in My Collection. This refactors things per [Alloy's blog post](https://artsy.github.io/blog/2018/10/19/where-art-thou-my-error/). 

Additionally, this DRYs things up and adds a delete mutation. 


```graphql
# Create 

mutation CreateArtwork($input: MyCollectionCreateArtworkInput!) {
  myCollectionCreateArtwork(input: $input) {
    artworkOrError {
      ... on MyCollectionArtworkMutationSuccess {
        artworkEdge {
          node {
            medium
            id
            internalID
            dimensions {
              cm
              in
            }
          }
        }
      }
      ... on MyCollectionArtworkMutationFailure {
        mutationError {
          error
        }
      }
    }
  }
}
```

```graphql
# Delete 

mutation DeleteArtwork($input: MyCollectionDeleteArtworkInput!) {
  myCollectionDeleteArtwork(input: $input) {
    artworkOrError {
      ... on MyCollectionArtworkMutationDeleteSuccess {
        success 
      }
      ... on MyCollectionArtworkMutationFailure {
        mutationError {
          message
        }
      }
    }
  }
}
```