### PR TITLE
[MyCollection] Revise mutations

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7315,10 +7315,12 @@ type MyCollectionConnection {
 input MyCollectionCreateArtworkInput {
   artistIds: [String]!
   clientMutationId: String
-  dimensions: String!
+  date: String
+  depth: String!
+  height: String!
   medium: String!
   title: String
-  year: String
+  width: String!
 }
 
 type MyCollectionCreateArtworkPayload {
@@ -7349,10 +7351,12 @@ input MyCollectionUpdateArtworkInput {
   artistIds: [String]
   artworkId: String!
   clientMutationId: String
-  dimensions: String
+  date: String
+  depth: String
+  height: String
   medium: String
   title: String
-  year: String
+  width: String
 }
 
 type MyCollectionUpdateArtworkPayload {

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -8,9 +8,11 @@ describe("myCollectionCreateArtworkMutation", () => {
         input: {
           artistIds: ["4d8b92b34eb68a1b2c0003f4"]
           medium: "Painting"
-          dimensions: "20x20"
+          width: "20"
+          height: "20"
+          depth: "20"
           title: "hey now"
-          year: "1990"
+          date: "1990"
         }
       ) {
         artworkOrError {

--- a/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
@@ -9,9 +9,11 @@ describe("myCollectionUpdateArtworkMutation", () => {
           artworkId: "foo"
           artistIds: ["4d8b92b34eb68a1b2c0003f4"]
           medium: "Painting"
-          dimensions: "20x20"
+          width: "20"
+          height: "20"
+          depth: "20"
           title: "hey now"
-          year: "1990"
+          date: "1990"
         }
       ) {
         artworkOrError {

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -16,16 +16,24 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
     artistIds: {
       type: new GraphQLNonNull(new GraphQLList(GraphQLString)),
     },
-    dimensions: {
-      type: new GraphQLNonNull(GraphQLString),
-    },
     medium: {
       type: new GraphQLNonNull(GraphQLString),
     },
-    title: {
+    width: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    height: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    depth: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+
+    // Optional
+    date: {
       type: GraphQLString,
     },
-    year: {
+    title: {
       type: GraphQLString,
     },
   },
@@ -36,7 +44,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    { artistIds, dimensions, medium, title, year },
+    { artistIds, ...rest },
     { myCollectionCreateArtworkLoader }
   ) => {
     if (!myCollectionCreateArtworkLoader) {
@@ -46,10 +54,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
     try {
       const response = await myCollectionCreateArtworkLoader({
         artist_ids: artistIds,
-        dimensions,
-        medium,
-        title,
-        year,
+        ...rest,
       })
 
       return response

--- a/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
@@ -18,16 +18,22 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
     artistIds: {
       type: new GraphQLList(GraphQLString),
     },
-    dimensions: {
+    date: {
+      type: GraphQLString,
+    },
+    width: {
+      type: GraphQLString,
+    },
+    height: {
+      type: GraphQLString,
+    },
+    depth: {
       type: GraphQLString,
     },
     medium: {
       type: GraphQLString,
     },
     title: {
-      type: GraphQLString,
-    },
-    year: {
       type: GraphQLString,
     },
   },
@@ -38,7 +44,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    { artworkId, artistIds, dimensions, medium, title, year },
+    { artworkId, artistIds, ...rest },
     { myCollectionUpdateArtworkLoader }
   ) => {
     if (!myCollectionUpdateArtworkLoader) {
@@ -48,10 +54,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
     try {
       const response = await myCollectionUpdateArtworkLoader(artworkId, {
         artist_ids: artistIds,
-        dimensions,
-        medium,
-        title,
-        year,
+        ...rest,
       })
 
       return {


### PR DESCRIPTION
This updates our MyCollection artwork mutations to match actual artwork expectations:

- `year` -> `date`
- `dimensions` -> `width`, `height`, `depth`

(Gonna self-merge as this is pretty trivial)