### PR TITLE
[MyCollection] Trim sort options 

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6918,7 +6918,7 @@ type Me implements Node {
     before: String
     first: Int
     last: Int
-    sort: ArtworkSorts
+    sort: MyCollectionArtworkSorts
   ): MyCollectionConnection
   name: String
   orders(
@@ -7295,6 +7295,13 @@ union MyCollectionArtworkMutationType =
     MyCollectionArtworkMutationDeleteSuccess
   | MyCollectionArtworkMutationFailure
   | MyCollectionArtworkMutationSuccess
+
+enum MyCollectionArtworkSorts {
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  POSITION_ASC
+  POSITION_DESC
+}
 
 # A connection to a list of items.
 type MyCollectionConnection {

--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -17,9 +17,9 @@ import {
   GraphQLBoolean,
   GraphQLObjectType,
   GraphQLUnionType,
+  GraphQLEnumType,
 } from "graphql"
 import { GravityMutationErrorType } from "lib/gravityErrorHandler"
-import ArtworkSorts from "../sorts/artwork_sorts"
 
 const MyCollectionConnection = connectionWithCursorInfo({
   name: "MyCollection",
@@ -48,7 +48,25 @@ export const {
 export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
   type: MyCollectionConnection.connectionType,
   args: pageable({
-    sort: ArtworkSorts,
+    sort: {
+      type: new GraphQLEnumType({
+        name: "MyCollectionArtworkSorts",
+        values: {
+          CREATED_AT_ASC: {
+            value: "created_at",
+          },
+          CREATED_AT_DESC: {
+            value: "-created_at",
+          },
+          POSITION_ASC: {
+            value: "position",
+          },
+          POSITION_DESC: {
+            value: "-position",
+          },
+        },
+      }),
+    },
   }),
   resolve: ({ id: userId }, options, { myCollectionArtworksLoader }) => {
     if (!myCollectionArtworksLoader) {


### PR DESCRIPTION
Follow-up PR to https://github.com/artsy/gravity/pull/13439 which trims our sort options down to those attached to the `CollectionArtwork` vs `Artwork`:

- `position`
- `created_at`