### PR TITLE
Fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ You can learn more about this work from [our blog][footer_blog] and by following
 our [job postings][footer_jobs]!
 
 [footer_website]: https://www.artsy.net/
-[footer_principles]: culture/engineering-principles.md
-[footer_open]: culture/engineering-principles.md#open-source-by-default
+[footer_principles]: https://github.com/artsy/README/blob/master/culture/engineering-principles.md
+[footer_open]: https://github.com/artsy/README/blob/master/culture/engineering-principles.md#open-source-by-default
 [footer_blog]: https://artsy.github.io/
 [footer_twitter]: https://twitter.com/ArtsyOpenSource
 [footer_api]: https://developers.artsy.net/


### PR DESCRIPTION
Instead of the _relative_ links from [README](https://github.com/artsy/README/blob/master/README.md), we should use absolute links.