### PR TITLE
FX-2272: Adds sponsored content for Gallery Weekend Berlin

### DIFF
--- a/src/lib/sponsoredContent/data.json
+++ b/src/lib/sponsoredContent/data.json
@@ -88,6 +88,10 @@
     "frieze-los-angeles-2020": {
       "activationText": "As one of Frieze Art Fair’s long-term partners, BMW will celebrate the world premiere of a multi-tiered project of BMW M GmbH with eminent international contemporary artist FUTURA 2000 at the Los Angeles edition in the Paramount Studios. In addition, BMW contributes to the multi-faceted program of talks, performances, gallery openings and other events during Frieze week with an art talk at the Soho Warehouse, featuring FUTURA 2000 and Lupe Fiasco, on February 12 as well as a night of art and music with Frieze Music at NeueHouse Hollywood on February 14. Lastly, BMW will provide a BMW 7 Series and a BMW i3 Shuttle service transporting the fair’s VIP guests.",
       "pressReleaseUrl": "https://www.press.bmwgroup.com/global/article/detail/T0305267EN/bmw-m2-by-futura-2000:-three-exclusive-originals-and-a-limited-edition-of-the-bmw-m2-competition"
+    },
+    "gallery-weekend-berlin": {
+      "activationText": "Munich/Berlin. From September 11 to 13, 2020, the Gallery Weekend Berlin presents its 16th edition with productions by emerging artists alongside more established positions at 48 participating galleries. BMW supports the Gallery Weekend as main partner from the beginning and will again provide the traditional VIP shuttle service for the galleries.",
+      "pressReleaseUrl": "https://www.press.bmwgroup.com/global/article/detail/T0315631EN/bmw-is-main-partner-of-the-gallery-weekend-berlin-2020-postponed-art-weekend-takes-place-from-september-11-to-13-2020"
     }
   }
 }


### PR DESCRIPTION
Addresses the request outlined in [this ticket](https://artsyproduct.atlassian.net/browse/FX-2272).

<img width="908" alt="image" src="https://user-images.githubusercontent.com/2081340/92482381-90446f00-f1b5-11ea-9d50-226624d9be3a.png">
