### PR TITLE
Pass user token to diffusion when available

### DIFF
--- a/src/lib/apis/diffusion.ts
+++ b/src/lib/apis/diffusion.ts
@@ -5,9 +5,10 @@ import config from "config"
 
 const { DIFFUSION_API_BASE, DIFFUSION_TOKEN } = config
 
-export default (path, _accessToken, fetchOptions = {}) => {
+export default (path, accessToken, fetchOptions = {}) => {
   const headers = { Accept: "application/json" }
-  assign(headers, { Authorization: `Bearer ${DIFFUSION_TOKEN}` })
+  const token = accessToken || DIFFUSION_TOKEN
+  assign(headers, { Authorization: `Bearer ${token}` })
   return fetch(
     urljoin(DIFFUSION_API_BASE, path),
     assign({}, fetchOptions, { headers })


### PR DESCRIPTION
I believe this is all that's required to send a user's token to diffusion so that it can verify that the user is signed in and has access to the data being requested. This won't do much until this one lands: https://github.com/artsy/diffusion/pull/319.

/cc @artsy/csgn-devs 