### PR TITLE
Update sponsored content for Gallery Weekend Berlin (again!)

### DIFF
--- a/src/lib/sponsoredContent/data.json
+++ b/src/lib/sponsoredContent/data.json
@@ -90,7 +90,7 @@
       "pressReleaseUrl": "https://www.press.bmwgroup.com/global/article/detail/T0305267EN/bmw-m2-by-futura-2000:-three-exclusive-originals-and-a-limited-edition-of-the-bmw-m2-competition"
     },
     "gallery-weekend-berlin-2020": {
-      "activationText": "Munich/Berlin. From September 11 to 13, 2020, the Gallery Weekend Berlin presents its 16th edition with productions by emerging artists alongside more established positions at 48 participating galleries. BMW supports the Gallery Weekend as main partner from the beginning and will again provide the traditional VIP shuttle service for the galleries.",
+      "activationText": "From September 11 to 13, 2020, the Gallery Weekend Berlin presents its 16th edition with productions by emerging artists alongside more established positions at 48 participating galleries. BMW supports the Gallery Weekend as main partner from the beginning and will again provide the traditional VIP shuttle service for the galleries.",
       "pressReleaseUrl": "https://www.press.bmwgroup.com/global/article/detail/T0315631EN/bmw-is-main-partner-of-the-gallery-weekend-berlin-2020-postponed-art-weekend-takes-place-from-september-11-to-13-2020"
     }
   }


### PR DESCRIPTION
Had an ask to remove the `Munich/Berlin` line from the beginning of this text. 😅 

<img width="901" alt="image" src="https://user-images.githubusercontent.com/2081340/92603616-81c18a80-f27d-11ea-92f7-e8e214344384.png">
