### PR TITLE
Simplify introspection enforcement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,6 @@ GRAVITY_SECRET=REPLACE
 HMAC_SECRET=https://www.youtube.com/watch?v=F5bAa6gFvLs
 IMPULSE_API_BASE=https://impulse-staging.artsy.net/api
 IMPULSE_APPLICATION_ID=REPLACE
-INTROSPECT_TOKEN=REPLACE
 KAWS_API_BASE=https://kaws-staging.artsy.net
 MEMCACHED_URL=localhost:11211
 NODE_ENV=development

--- a/src/index.ts
+++ b/src/index.ts
@@ -226,8 +226,7 @@ function startApp(appSchema, path: string) {
           principalFieldDirectiveValidation,
 
           // require Authorization header for introspection (in production if configured)
-          ...(PRODUCTION_ENV &&
-          INTROSPECT_TOKEN &&
+          ...(INTROSPECT_TOKEN &&
           req.headers["authorization"] !== `Bearer ${INTROSPECT_TOKEN}`
             ? [NoSchemaIntrospectionCustomRule]
             : []),


### PR DESCRIPTION
The introspection authorization is already conditional on the presence of `INTROSPECT_TOKEN`, so it doesn't need to be conditional on `PRODUCTION_ENV`. This makes it more straightforward to test and simulate locally, and removes unnecessary env-specific logic.