### PR TITLE
[Artwork] Add metric field to artwork, as well as individual dimensions

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1207,6 +1207,9 @@ type Artwork implements Node & Searchable & Sellable {
   contextGrids: [ArtworkContextGrid]
   culturalMaker: String
   date: String
+
+  # The depth as expressed by the original input metric
+  depth: String
   description(format: Format): String
   dimensions: dimensions
   displayLabel: String
@@ -1227,6 +1230,9 @@ type Artwork implements Node & Searchable & Sellable {
 
   # Returns true when artwork has a certificate of authenticity
   hasCertificateOfAuthenticity: Boolean
+
+  # The height as expressed by the original input metric
+  height: String
 
   # If you need to render artwork dimensions as a string, prefer the `Artwork#dimensions` field
   heightCm: Float
@@ -1289,6 +1295,7 @@ type Artwork implements Node & Searchable & Sellable {
   manufacturer(format: Format): String
   medium: String
   meta: ArtworkMeta
+  metric: String
   myLotStanding(live: Boolean = null): [LotStanding!]
 
   # Is this work only available for shipping domestically?
@@ -1349,6 +1356,9 @@ type Artwork implements Node & Searchable & Sellable {
 
   # If the category is video, then it returns the href for the (youtube/vimeo) video, otherwise returns the website from CMS
   website: String
+
+  # The width as expressed by the original input metric
+  width: String
 
   # If you need to render artwork dimensions as a string, prefer the `Artwork#dimensions` field
   widthCm: Float

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -173,6 +173,10 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ cultural_maker }) => cultural_maker,
       },
       date: { type: GraphQLString },
+      depth: {
+        description: "The depth as expressed by the original input metric",
+        type: GraphQLString,
+      },
       description: markdown(({ blurb }) => blurb),
       dimensions: Dimensions,
       embed: {
@@ -244,6 +248,10 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             partner && partner.name,
           ]).join(", ")
         },
+      },
+      height: {
+        description: "The height as expressed by the original input metric",
+        type: GraphQLString,
       },
       highlights: {
         type: new GraphQLList(ArtworkHighlightType),
@@ -477,6 +485,11 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       manufacturer: markdown(),
       medium: { type: GraphQLString },
       meta: Meta,
+      metric: {
+        description:
+          "The unit of length of the artwork, expressed in `in` or `cm`",
+        type: GraphQLString,
+      },
       myLotStanding: {
         type: new GraphQLList(new GraphQLNonNull(LotStandingType)),
         args: { live: { type: GraphQLBoolean, defaultValue: null } },
@@ -865,6 +878,10 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             return null
           }
         },
+      },
+      width: {
+        description: "The width as expressed by the original input metric",
+        type: GraphQLString,
       },
       widthCm: {
         description:

--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -82,6 +82,8 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
 
     return myCollectionArtworksLoader(gravityOptions)
       .then(({ body, headers }) => {
+        console.log(body)
+
         return connectionFromArraySlice(body, options, {
           arrayLength: parseInt(headers["x-total-count"] || "0", 10),
           sliceStart: gravityOptions.offset,


### PR DESCRIPTION
Related https://github.com/artsy/gravity/pull/13468

Adds `metric`, `height`, `width` and `depth` fields to the Artwork type. 

<img width="783" alt="Screen Shot 2020-09-15 at 1 06 30 PM" src="https://user-images.githubusercontent.com/236943/93259223-598dcc00-f754-11ea-882e-d9eadf5d006a.png">
