### PR TITLE
Limit number of works able to be fetched by VR to 100, via gravity's limit [WIP]

### DIFF
--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -343,6 +343,17 @@ export const gravityStitchingEnvironment = (
               ids = [null]
             }
 
+            // We can't send more than 100 artwork ids to /api/v1/artworks
+            let limit = 100
+            // Allow override of "first" and "last", but not if it's greater than 100
+            const arg_limit = args["first"] || args["last"]
+            if (arg_limit < limit) {
+              limit = arg_limit
+            }
+            if (limit < ids.length) {
+              ids = ids.slice(0, limit)
+            }
+
             return info.mergeInfo.delegateToSchema({
               schema: localSchema,
               operation: "query",

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -344,14 +344,8 @@ export const gravityStitchingEnvironment = (
             }
 
             // We can't send more than 100 artwork ids to /api/v1/artworks
-            let limit = 100
-            // Allow override of "first" and "last", but not if it's greater than 100
-            const arg_limit = args["first"] || args["last"]
-            if (arg_limit < limit) {
-              limit = arg_limit
-            }
-            if (limit < ids.length) {
-              ids = ids.slice(0, limit)
+            if (ids.length > 100) {
+              ids = ids.slice(0, 100)
             }
 
             return info.mergeInfo.delegateToSchema({


### PR DESCRIPTION
Not sure if we should be doing this in the artworks dataloader, seems like any field that stitches in artworksConnection will run into this problem. The only issue there is that the `totalCount` field is calculated after the dataloader get the response back from gravity, although the query will fail if `ids.length > 100`