### PR TITLE
Shows all fairs on home, regardles of mobile image

### DIFF
--- a/src/schema/v2/home/__tests__/__snapshots__/home_page_fairs_module.test.js.snap
+++ b/src/schema/v2/home/__tests__/__snapshots__/home_page_fairs_module.test.js.snap
@@ -4,13 +4,54 @@ exports[`HomePageFairsModule does not request past fairs if it has 8 running one
 Object {
   "homePage": Object {
     "fairsModule": Object {
-      "results": Array [],
+      "results": Array [
+        Object {
+          "isActive": false,
+          "name": "Artissima 2017",
+          "slug": "artissima-2017",
+        },
+        Object {
+          "isActive": false,
+          "name": "Artissima 2017",
+          "slug": "artissima-2017",
+        },
+        Object {
+          "isActive": false,
+          "name": "Artissima 2017",
+          "slug": "artissima-2017",
+        },
+        Object {
+          "isActive": false,
+          "name": "Artissima 2017",
+          "slug": "artissima-2017",
+        },
+        Object {
+          "isActive": false,
+          "name": "Artissima 2017",
+          "slug": "artissima-2017",
+        },
+        Object {
+          "isActive": false,
+          "name": "Artissima 2017",
+          "slug": "artissima-2017",
+        },
+        Object {
+          "isActive": false,
+          "name": "Artissima 2017",
+          "slug": "artissima-2017",
+        },
+        Object {
+          "isActive": false,
+          "name": "Artissima 2017",
+          "slug": "artissima-2017",
+        },
+      ],
     },
   },
 }
 `;
 
-exports[`HomePageFairsModule does not return fairs that do not have mobile images 1`] = `
+exports[`HomePageFairsModule works 1`] = `
 Object {
   "homePage": Object {
     "fairsModule": Object {
@@ -26,16 +67,6 @@ Object {
           "slug": "zonamaco-foto-and-sal-n-del-anticuario-2017",
         },
       ],
-    },
-  },
-}
-`;
-
-exports[`HomePageFairsModule works 1`] = `
-Object {
-  "homePage": Object {
-    "fairsModule": Object {
-      "results": Array [],
     },
   },
 }

--- a/src/schema/v2/home/__tests__/home_page_fairs_module.test.js
+++ b/src/schema/v2/home/__tests__/home_page_fairs_module.test.js
@@ -5,7 +5,6 @@ describe("HomePageFairsModule", () => {
   it("works", () => {
     const runningFairs = [
       {
-        mobile_image: null,
         id: "artissima-2017",
         default_profile_id: "artissima-2017",
         start_at: "2017-11-03T10:00:00+00:00",
@@ -22,7 +21,6 @@ describe("HomePageFairsModule", () => {
 
     const pastFairs = [
       {
-        mobile_image: null,
         id: "zonamaco-foto-and-sal-n-del-anticuario-2017",
         default_profile_id: "zsonamaco-foto-2017",
         start_at: "2017-09-20T13:45:00+00:00",
@@ -62,13 +60,11 @@ describe("HomePageFairsModule", () => {
   it("puts fairs that haven't started yet at the end of the results", async () => {
     const fairs = [
       {
-        mobile_image: {},
         id: "future-fair",
         start_at: "2027-11-03T10:00:00+00:00",
         name: "Future Fair",
       },
       {
-        mobile_image: {},
         id: "current-fair",
         start_at: "2017-11-03T10:00:00+00:00",
         name: "Current Fair",
@@ -137,54 +133,6 @@ describe("HomePageFairsModule", () => {
       fairsLoader: (options) =>
         Promise.resolve({ body: options.active ? runningFairs : pastFairs }),
     }).then((fairsModule) => {
-      expect(fairsModule).toMatchSnapshot()
-    })
-  })
-
-  // FIXME: Snapshot seems to change
-  it.skip("does not return fairs that do not have mobile images", () => {
-    const aFair = [
-      {
-        id: "artissima-2017",
-        name: "Artissima 2017",
-        mobile_image: "circle-image.jpg",
-      },
-    ]
-
-    const pastFairs = [
-      {
-        id: "zonamaco-foto-and-sal-n-del-anticuario-2017",
-        name: "Zâ“ˆONAMACO FOTO & SALÃ“N DEL ANTICUARIO 2017",
-        mobile_image: {
-          image_url: "circle-image.jpg",
-        },
-      },
-      {
-        id: "past-fair-2017",
-        name: "I Should Not Show Up in the Snapshot",
-        mobile_image: null,
-      },
-    ]
-
-    const query = `
-      {
-        homePage {
-          fairsModule {
-            results {
-              slug
-              name
-              isActive
-            }
-          }
-        }
-      }
-    `
-
-    return runQuery(query, {
-      fairsLoader: (options) =>
-        Promise.resolve({ body: options.active ? aFair : pastFairs }),
-    }).then((fairsModule) => {
-      // FIXME: isActive flipped from true to false here and I'm not sure why
       expect(fairsModule).toMatchSnapshot()
     })
   })

--- a/src/schema/v2/home/home_page_fairs_module.ts
+++ b/src/schema/v2/home/home_page_fairs_module.ts
@@ -34,19 +34,18 @@ export const HomePageFairsModuleType = new GraphQLObjectType<
             )
 
             // If there are less than 8, get the most recent closed fairs
-            if (runningFairs.length < 8) {
-              const newOptions = {
-                ...gravityOptions,
-                status: "closed",
-                active: false,
-                size: 8 - runningFairs.length,
-              }
-              return fairsLoader(newOptions).then(({ body: closedFairs }) => {
-                const allFairs = runningFairs.concat(closedFairs)
-                return allFairs.filter((fair) => fair.mobile_image)
-              })
+            if (runningFairs.length >= 8) {
+              return runningFairs
             }
-            return runningFairs.filter((fair) => fair.mobile_image)
+            const newOptions = {
+              ...gravityOptions,
+              status: "closed",
+              active: false,
+              size: 8 - runningFairs.length,
+            }
+            return fairsLoader(newOptions).then(({ body: closedFairs }) =>
+              runningFairs.concat(closedFairs)
+            )
           }
         )
       },


### PR DESCRIPTION
We were previously only showing fairs on the home page when they had a `mobile_image` set, but this is causing issues (see: [Slack thread](https://artsy.slack.com/archives/CN8S32FJR/p1600876254022800) and a [recent waves change](https://github.com/artsy/waves/pull/275)).

Since we launched a new home feed early this spring, the app doesn't actually use this `mobile_image`. Making this change will affect older versions of the app, which will now show a grey circle on the old home screen (not a huge UX problem but wanted to bring it up).

Tested this locally:

![Screen Shot 2020-09-23 at 16 41 03](https://user-images.githubusercontent.com/498212/94067246-97759a80-fdbb-11ea-8c23-ab1c428f1229.png)
