### PR TITLE
[My Collection]: Add edition number + size to my collection mutation params

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7382,6 +7382,8 @@ input MyCollectionCreateArtworkInput {
   costMinor: Int
   date: String
   depth: String
+  editionNumber: Int
+  editionSize: String
   height: String
   medium: String!
   metric: String
@@ -7422,6 +7424,8 @@ input MyCollectionUpdateArtworkInput {
   costMinor: Int
   date: String
   depth: String
+  editionNumber: Int
+  editionSize: String
   height: String
   medium: String
   metric: String

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -10,6 +10,8 @@ describe("myCollectionCreateArtworkMutation", () => {
           category: "some strange category"
           costCurrencyCode: "USD"
           costMinor: 200
+          editionSize: "10x10x10"
+          editionNumber: 1
           date: "1990"
           depth: "20"
           height: "20"

--- a/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
@@ -11,6 +11,8 @@ describe("myCollectionUpdateArtworkMutation", () => {
           category: "some strange category"
           costCurrencyCode: "USD"
           costMinor: 200
+          editionNumber: 5
+          editionSize: "100x100x100"
           date: "1990"
           depth: "20"
           height: "20"

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -36,6 +36,12 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
     depth: {
       type: GraphQLString,
     },
+    editionNumber: {
+      type: GraphQLInt,
+    },
+    editionSize: {
+      type: GraphQLString,
+    },
     height: {
       type: GraphQLString,
     },
@@ -56,7 +62,14 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    { artistIds, costCurrencyCode, costMinor, ...rest },
+    {
+      artistIds,
+      costCurrencyCode,
+      costMinor,
+      editionSize,
+      editionNumber,
+      ...rest
+    },
     { myCollectionCreateArtworkLoader }
   ) => {
     if (!myCollectionCreateArtworkLoader) {
@@ -68,6 +81,8 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
         artist_ids: artistIds,
         cost_currency_code: costCurrencyCode,
         cost_minor: costMinor,
+        edition_size: editionSize,
+        edition_number: editionNumber,
         ...rest,
       })
 

--- a/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
@@ -33,6 +33,12 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
     depth: {
       type: GraphQLString,
     },
+    editionNumber: {
+      type: GraphQLInt,
+    },
+    editionSize: {
+      type: GraphQLString,
+    },
     height: {
       type: GraphQLString,
     },
@@ -56,7 +62,15 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    { artworkId, artistIds, costCurrencyCode, costMinor, ...rest },
+    {
+      artworkId,
+      artistIds,
+      costCurrencyCode,
+      costMinor,
+      editionNumber,
+      editionSize,
+      ...rest
+    },
     { myCollectionUpdateArtworkLoader }
   ) => {
     if (!myCollectionUpdateArtworkLoader) {
@@ -68,6 +82,8 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
         artist_ids: artistIds,
         cost_currency_code: costCurrencyCode,
         cost_minor: costMinor,
+        edition_number: editionNumber,
+        edition_size: editionSize,
         ...rest,
       })
 


### PR DESCRIPTION
Adds the parameters `editionSize` and `editionNumber` to myCollection's create and update mutations.

https://artsyproduct.atlassian.net/browse/CSGN-379

<img width="1146" alt="Screen Shot 2020-09-24 at 4 36 12 PM" src="https://user-images.githubusercontent.com/10385964/94198359-28fd0f00-fe85-11ea-8b09-3420d7255e9a.png">
<img width="1150" alt="Screen Shot 2020-09-24 at 4 36 58 PM" src="https://user-images.githubusercontent.com/10385964/94198360-2995a580-fe85-11ea-9cd8-b83ce1dd0069.png">
