### PR TITLE
Add a placeholder response for inquiry questions to unblock ui work

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1257,6 +1257,9 @@ type Artwork implements Node & Searchable & Sellable {
   imageTitle: String
   imageUrl: String
 
+  # Structured questions a collector can inquire on about this work
+  inquiryQuestions: [InquiryQuestion]
+
   # A type-specific ID likely used as a database ID.
   internalID: ID!
 
@@ -6400,6 +6403,15 @@ type Image {
 
 type ImageURLs {
   normalized: String
+}
+
+type InquiryQuestion {
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID.
+  internalID: ID!
+  question: String!
 }
 
 enum Intents {

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -1250,6 +1250,42 @@ describe("Artwork type", () => {
       })
     })
   })
+  describe("#inquiryQuestions", () => {
+    const query = `
+        {
+          artwork(id: "richard-prince-untitled-portrait") {
+            isInquireable
+            inquiryQuestions {
+              internalID
+              question
+            }
+          }
+        }
+      `
+    beforeEach(() => {
+      artwork.inquireable = true
+      artwork.ecommerce = false
+    })
+
+    it("returns available inquiry questions", () => {
+      return runQuery(query, context).then((data) => {
+        expect(data.artwork.inquiryQuestions).toEqual([
+          {
+            internalID: "price_and_availability",
+            question: "Price & Availability",
+          },
+          {
+            internalID: "shipping",
+            question: "Shipping",
+          },
+          {
+            internalID: "condition_and_provenance",
+            question: "Condition & Provenance",
+          },
+        ])
+      })
+    })
+  })
   describe("markdown fields", () => {
     describe("#signature", () => {
       const query = `

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -53,6 +53,7 @@ import Show from "schema/v2/show"
 import { ArtworkContextGrids } from "./artworkContextGrids"
 import { PageInfoType } from "graphql-relay"
 import { getMicrofunnelDataByArtworkInternalID } from "../artist/targetSupply/utils/getMicrofunnelData"
+import InquiryQuestionType from "../inquiry_question"
 
 const has_price_range = (price) => {
   return new RegExp(/\-/).test(price)
@@ -332,6 +333,30 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ images }, { size }) => {
           const sorted = _.sortBy(images, "position")
           return normalizeImageData(size ? _.take(sorted, size) : sorted)
+        },
+      },
+      inquiryQuestions: {
+        type: new GraphQLList(InquiryQuestionType),
+        description:
+          "Structured questions a collector can inquire on about this work",
+        resolve: ({ ecommerce, inquireable }) => {
+          if (!ecommerce && inquireable) {
+            return [
+              {
+                id: "price_and_availability",
+                question: "Price & Availability",
+              },
+              {
+                id: "shipping",
+                question: "Shipping",
+              },
+              {
+                id: "condition_and_provenance",
+                question: "Condition & Provenance",
+              },
+            ]
+          }
+          return null
         },
       },
       inventoryId: {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -341,6 +341,12 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           "Structured questions a collector can inquire on about this work",
         resolve: ({ ecommerce, inquireable }) => {
           if (!ecommerce && inquireable) {
+            /**
+             * TODO: This is temporary, fixture data hardcoded to enable the
+             * first inquiry project to be broken down into parallel tasks. Will
+             * be followed w/ a PR to hook it up to a soon to be built gravity
+             * hook.
+             */
             return [
               {
                 id: "price_and_availability",

--- a/src/schema/v2/inquiry_question.ts
+++ b/src/schema/v2/inquiry_question.ts
@@ -1,0 +1,15 @@
+import { IDFields } from "./object_identification"
+import { GraphQLNonNull, GraphQLString, GraphQLObjectType } from "graphql"
+import { ResolverContext } from "types/graphql"
+
+const InquiryQuestionType = new GraphQLObjectType<any, ResolverContext>({
+  name: "InquiryQuestion",
+  fields: {
+    ...IDFields,
+    question: {
+      type: GraphQLNonNull(GraphQLString),
+    },
+  },
+})
+
+export default InquiryQuestionType


### PR DESCRIPTION
This is a pretty critical piece of pre-work to quickly unblock UI work for the first inquiry project so that we can begin parallelizing asap.

This adds a `inquiryQuestions` field to the `Artwork` type. This field will be used to power a modal after the user taps contact gallery that will send structured questions to gravity (and ultimately to our partners) so that they can provide more consistent, faster responses (all while reducing the overhead for collectors in deciding how to ask about basic questions). 

We'll follow up on hooking this up to gravity soon.