### PR TITLE
Use safer param for artist ids

### DIFF
--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -78,7 +78,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
 
     try {
       const response = await myCollectionCreateArtworkLoader({
-        artist_ids: artistIds,
+        artists: artistIds,
         cost_currency_code: costCurrencyCode,
         cost_minor: costMinor,
         edition_size: editionSize,


### PR DESCRIPTION
This PR moves the mutation for creating an artwork in a user's My Collection to using `artists` as the attribute name. This is safer because there is code in the API to "upgrade" this param to full BSON objects rather than the strings we'll get by default. You can see this here:

https://github.com/artsy/gravity/blob/ff280189e8f54dd6e5cf70ec17093b320123d7ec/app/api/util/find_by_slug_helpers.rb#L102-L110

So what was happening prior to this change is that we'd set the `artist_ids` field on the artwork model to strings rather than BSON keys:

```
gravity:staging> user.my_collection.artworks.first.artist_ids
=> ["52500dc7139b214dc40004c0"]
```

And then everything would be fine until our data pals did an update to the data pipeline and the type mis-match would show up. More chatter here:

https://artsy.slack.com/archives/CS3H1K4BD/p1599853170274300

/cc @emmadickson @artsy/csgn-devs 