### PR TITLE
Additional type change on Artwork editionNumber field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7399,7 +7399,7 @@ input MyCollectionCreateArtworkInput {
   costMinor: Int
   date: String
   depth: String
-  editionNumber: Int
+  editionNumber: String
   editionSize: String
   height: String
   medium: String!

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -11,7 +11,7 @@ describe("myCollectionCreateArtworkMutation", () => {
           costCurrencyCode: "USD"
           costMinor: 200
           editionSize: "10x10x10"
-          editionNumber: 1
+          editionNumber: "1"
           date: "1990"
           depth: "20"
           height: "20"

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -37,7 +37,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
       type: GraphQLString,
     },
     editionNumber: {
-      type: GraphQLInt,
+      type: GraphQLString,
     },
     editionSize: {
       type: GraphQLString,


### PR DESCRIPTION
Follow up to #2721. `editionNumber` should be a string, rather than an integer.