### PR TITLE
@anandaroop => [Fair] Return an empty list if there are no kawsCollectionSlugs set

### DIFF
--- a/src/lib/stitching/kaws/__tests__/stitching.test.ts
+++ b/src/lib/stitching/kaws/__tests__/stitching.test.ts
@@ -80,5 +80,21 @@ describe("KAWS Stitching", () => {
         })
       )
     })
+
+    it("returns an empty list when there are no kawsCollectionSlugs", async () => {
+      const { resolvers } = await getKawsStitchedSchema()
+      const marketingCollectionsResolver =
+        resolvers.Fair.marketingCollections.resolve
+      const mergeInfo = { delegateToSchema: jest.fn() }
+
+      const result = await marketingCollectionsResolver(
+        { kawsCollectionSlugs: [] },
+        {},
+        {},
+        { mergeInfo }
+      )
+
+      expect(result).toEqual([])
+    })
   })
 })

--- a/src/lib/stitching/kaws/stitching.ts
+++ b/src/lib/stitching/kaws/stitching.ts
@@ -164,6 +164,7 @@ export const kawsStitchingEnvironmentV2 = (
           }
         `,
           resolve: ({ kawsCollectionSlugs: slugs }, args, context, info) => {
+            if (slugs.length === 0) return []
             return info.mergeInfo.delegateToSchema({
               schema: kawsSchema,
               operation: "query",


### PR DESCRIPTION
When there are no slugs set, this winds up performing an empty `where({})` query in KAWS, and thus returning actual collections. Just short-circuit here.