### PR TITLE
@dzucconi => [Fair] Only request fair booths with artworks

### DIFF
--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -266,11 +266,13 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
             sort: string
             cursor?: string
             section: string
+            artworks: boolean
           }
           const gravityOptions: GravityOptions = {
             sort: options.sort || "-featured",
             section: options.section,
             size: options.first,
+            artworks: true,
           }
           if (!!options.after) {
             gravityOptions.cursor = options.after


### PR DESCRIPTION
Kind of a weird one. Basically this param lets you filter out booths which don't have any published artworks (https://github.com/artsy/gravity/blob/102d637a44124e0901eae52f47d983ad3de6ee28/app/api/v1/fairs_shows_endpoint.rb#L39). This feels like a sensible default here.

Fixes https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=FX&modal=detail&selectedIssue=FX-2312