### PR TITLE
CSGN-356: Support creating images for My Collection artworks

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7403,6 +7403,7 @@ input MyCollectionCreateArtworkInput {
   depth: String
   editionNumber: String
   editionSize: String
+  externalImageUrls: [String]
   height: String
   medium: String!
   metric: String

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -183,6 +183,11 @@ export default (accessToken, userID, opts) => {
       },
       { method: "POST" }
     ),
+    myCollectionCreateImageLoader: gravityLoader(
+      (id) => `artwork/${id}/image`,
+      {},
+      { method: "POST" }
+    ),
     myCollectionUpdateArtworkLoader: gravityLoader(
       (id) => `my-collection/artworks/${id}`,
       {

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -152,6 +152,23 @@ describe("myCollectionCreateArtworkMutation", () => {
     })
 
     // it("returns an error when the additional image can't be created")
-    // it("tries to create each image even if some are invalid")
+    it("tries to create each image even if some are invalid", async () => {
+      const externalImageUrls = [
+        "http://example.com/path/to/image.jpg",
+        "https://test-upload-bucket.s3.amazonaws.com/path/to/image.jpg",
+      ]
+      const mutation = computeMutationInput(externalImageUrls)
+
+      const data = await runAuthenticatedQuery(mutation, defaultContext)
+      const { artworkOrError } = data.myCollectionCreateArtwork
+
+      expect(artworkOrError).toHaveProperty("artwork")
+      expect(artworkOrError).not.toHaveProperty("error")
+      expect(mockCreateImageLoader).toBeCalledTimes(1)
+      expect(mockCreateImageLoader).toBeCalledWith(newArtwork.id, {
+        source_bucket: "test-upload-bucket",
+        source_key: "path/to/image.jpg",
+      })
+    })
   })
 })

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -62,6 +62,12 @@ const computeMutationInput = (externalImageUrls: string[] = []): string => {
   return mutation
 }
 
+const defaultContext = {
+  myCollectionCreateArtworkLoader: successfulCreateArtworkLoader,
+  myCollectionArtworkLoader: additionalArtworkDetailsLoader,
+  myCollectionCreateImageLoader: mockCreateImageLoader,
+}
+
 describe("myCollectionCreateArtworkMutation", () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -72,6 +78,7 @@ describe("myCollectionCreateArtworkMutation", () => {
       const mutation = computeMutationInput()
 
       const context = {
+        ...defaultContext,
         myCollectionCreateArtworkLoader: failureCreateArtworkLoader,
       }
 
@@ -87,12 +94,7 @@ describe("myCollectionCreateArtworkMutation", () => {
     it("returns details of the new artwork", async () => {
       const mutation = computeMutationInput()
 
-      const context = {
-        myCollectionCreateArtworkLoader: successfulCreateArtworkLoader,
-        myCollectionArtworkLoader: additionalArtworkDetailsLoader,
-      }
-
-      const data = await runAuthenticatedQuery(mutation, context)
+      const data = await runAuthenticatedQuery(mutation, defaultContext)
       const { artworkOrError } = data.myCollectionCreateArtwork
 
       expect(artworkOrError).toEqual({
@@ -112,13 +114,7 @@ describe("myCollectionCreateArtworkMutation", () => {
     it("does nothing when there are no image urls", async () => {
       const mutation = computeMutationInput([])
 
-      const context = {
-        myCollectionCreateArtworkLoader: successfulCreateArtworkLoader,
-        myCollectionArtworkLoader: additionalArtworkDetailsLoader,
-        myCollectionCreateImageLoader: mockCreateImageLoader,
-      }
-
-      const data = await runAuthenticatedQuery(mutation, context)
+      const data = await runAuthenticatedQuery(mutation, defaultContext)
       const { artworkOrError } = data.myCollectionCreateArtwork
 
       expect(artworkOrError).toHaveProperty("artwork")
@@ -130,13 +126,7 @@ describe("myCollectionCreateArtworkMutation", () => {
       const externalImageUrls = ["http://example.com/path/to/image.jpg"]
       const mutation = computeMutationInput(externalImageUrls)
 
-      const context = {
-        myCollectionCreateArtworkLoader: successfulCreateArtworkLoader,
-        myCollectionArtworkLoader: additionalArtworkDetailsLoader,
-        myCollectionCreateImageLoader: mockCreateImageLoader,
-      }
-
-      const data = await runAuthenticatedQuery(mutation, context)
+      const data = await runAuthenticatedQuery(mutation, defaultContext)
       const { artworkOrError } = data.myCollectionCreateArtwork
 
       expect(artworkOrError).toHaveProperty("artwork")
@@ -150,13 +140,7 @@ describe("myCollectionCreateArtworkMutation", () => {
       ]
       const mutation = computeMutationInput(externalImageUrls)
 
-      const context = {
-        myCollectionCreateArtworkLoader: successfulCreateArtworkLoader,
-        myCollectionArtworkLoader: additionalArtworkDetailsLoader,
-        myCollectionCreateImageLoader: mockCreateImageLoader,
-      }
-
-      const data = await runAuthenticatedQuery(mutation, context)
+      const data = await runAuthenticatedQuery(mutation, defaultContext)
       const { artworkOrError } = data.myCollectionCreateArtwork
 
       expect(artworkOrError).toHaveProperty("artwork")

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -15,6 +15,8 @@ const additionalArtworkDetailsLoader = jest
   .fn()
   .mockResolvedValue(additionalArtworkDetails)
 
+const mockCreateImageLoader = jest.fn()
+
 const computeMutationInput = (externalImageUrls: string[] = []): string => {
   const mutation = gql`
     mutation {
@@ -61,6 +63,10 @@ const computeMutationInput = (externalImageUrls: string[] = []): string => {
 }
 
 describe("myCollectionCreateArtworkMutation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   describe("when the server responds with an error", () => {
     it("returns that error", async () => {
       const mutation = computeMutationInput()
@@ -106,12 +112,10 @@ describe("myCollectionCreateArtworkMutation", () => {
     it("does nothing when there are no image urls", async () => {
       const mutation = computeMutationInput([])
 
-      const yetAnotherMockLoader = jest.fn()
-
       const context = {
         myCollectionCreateArtworkLoader: successfulCreateArtworkLoader,
         myCollectionArtworkLoader: additionalArtworkDetailsLoader,
-        myCollectionCreateImageLoader: yetAnotherMockLoader,
+        myCollectionCreateImageLoader: mockCreateImageLoader,
       }
 
       const data = await runAuthenticatedQuery(mutation, context)
@@ -119,19 +123,17 @@ describe("myCollectionCreateArtworkMutation", () => {
 
       expect(artworkOrError).toHaveProperty("artwork")
       expect(artworkOrError).not.toHaveProperty("error")
-      expect(yetAnotherMockLoader).not.toBeCalled()
+      expect(mockCreateImageLoader).not.toBeCalled()
     })
 
     it("does nothing with an image url that doesn't match", async () => {
       const externalImageUrls = ["http://example.com/path/to/image.jpg"]
       const mutation = computeMutationInput(externalImageUrls)
 
-      const yetAnotherMockLoader = jest.fn()
-
       const context = {
         myCollectionCreateArtworkLoader: successfulCreateArtworkLoader,
         myCollectionArtworkLoader: additionalArtworkDetailsLoader,
-        myCollectionCreateImageLoader: yetAnotherMockLoader,
+        myCollectionCreateImageLoader: mockCreateImageLoader,
       }
 
       const data = await runAuthenticatedQuery(mutation, context)
@@ -139,7 +141,7 @@ describe("myCollectionCreateArtworkMutation", () => {
 
       expect(artworkOrError).toHaveProperty("artwork")
       expect(artworkOrError).not.toHaveProperty("error")
-      expect(yetAnotherMockLoader).not.toBeCalled()
+      expect(mockCreateImageLoader).not.toBeCalled()
     })
 
     it("creates an additional image with bucket and key with a valid image url", async () => {
@@ -148,12 +150,10 @@ describe("myCollectionCreateArtworkMutation", () => {
       ]
       const mutation = computeMutationInput(externalImageUrls)
 
-      const yetAnotherMockLoader = jest.fn()
-
       const context = {
         myCollectionCreateArtworkLoader: successfulCreateArtworkLoader,
         myCollectionArtworkLoader: additionalArtworkDetailsLoader,
-        myCollectionCreateImageLoader: yetAnotherMockLoader,
+        myCollectionCreateImageLoader: mockCreateImageLoader,
       }
 
       const data = await runAuthenticatedQuery(mutation, context)
@@ -161,7 +161,7 @@ describe("myCollectionCreateArtworkMutation", () => {
 
       expect(artworkOrError).toHaveProperty("artwork")
       expect(artworkOrError).not.toHaveProperty("error")
-      expect(yetAnotherMockLoader).toBeCalledWith(newArtwork.id, {
+      expect(mockCreateImageLoader).toBeCalledWith(newArtwork.id, {
         source_bucket: "test-upload-bucket",
         source_key: "path/to/image.jpg",
       })

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -10,6 +10,11 @@ const error = new Error(
 )
 const failureCreateArtworkLoader = jest.fn().mockRejectedValue(error)
 
+const additionalArtworkDetails = { medium: "Painting" }
+const additionalArtworkDetailsLoader = jest
+  .fn()
+  .mockResolvedValue(additionalArtworkDetails)
+
 const computeMutationInput = (externalImageUrls: string[] = []): string => {
   const mutation = gql`
     mutation {
@@ -76,14 +81,9 @@ describe("myCollectionCreateArtworkMutation", () => {
     it("returns details of the new artwork", async () => {
       const mutation = computeMutationInput()
 
-      const additionalArtworkDetails = { medium: "Painting" }
-      const anotherMockLoader = jest
-        .fn()
-        .mockResolvedValue(additionalArtworkDetails)
-
       const context = {
         myCollectionCreateArtworkLoader: successfulCreateArtworkLoader,
-        myCollectionArtworkLoader: anotherMockLoader,
+        myCollectionArtworkLoader: additionalArtworkDetailsLoader,
       }
 
       const data = await runAuthenticatedQuery(mutation, context)
@@ -106,16 +106,11 @@ describe("myCollectionCreateArtworkMutation", () => {
     it("does nothing when there are no image urls", async () => {
       const mutation = computeMutationInput([])
 
-      const additionalArtworkDetails = { medium: "Painting" }
-      const anotherMockLoader = jest
-        .fn()
-        .mockResolvedValue(additionalArtworkDetails)
-
       const yetAnotherMockLoader = jest.fn()
 
       const context = {
         myCollectionCreateArtworkLoader: successfulCreateArtworkLoader,
-        myCollectionArtworkLoader: anotherMockLoader,
+        myCollectionArtworkLoader: additionalArtworkDetailsLoader,
         myCollectionCreateImageLoader: yetAnotherMockLoader,
       }
 
@@ -131,16 +126,11 @@ describe("myCollectionCreateArtworkMutation", () => {
       const externalImageUrls = ["http://example.com/path/to/image.jpg"]
       const mutation = computeMutationInput(externalImageUrls)
 
-      const additionalArtworkDetails = { medium: "Painting" }
-      const anotherMockLoader = jest
-        .fn()
-        .mockResolvedValue(additionalArtworkDetails)
-
       const yetAnotherMockLoader = jest.fn()
 
       const context = {
         myCollectionCreateArtworkLoader: successfulCreateArtworkLoader,
-        myCollectionArtworkLoader: anotherMockLoader,
+        myCollectionArtworkLoader: additionalArtworkDetailsLoader,
         myCollectionCreateImageLoader: yetAnotherMockLoader,
       }
 
@@ -158,16 +148,11 @@ describe("myCollectionCreateArtworkMutation", () => {
       ]
       const mutation = computeMutationInput(externalImageUrls)
 
-      const additionalArtworkDetails = { medium: "Painting" }
-      const anotherMockLoader = jest
-        .fn()
-        .mockResolvedValue(additionalArtworkDetails)
-
       const yetAnotherMockLoader = jest.fn()
 
       const context = {
         myCollectionCreateArtworkLoader: successfulCreateArtworkLoader,
-        myCollectionArtworkLoader: anotherMockLoader,
+        myCollectionArtworkLoader: additionalArtworkDetailsLoader,
         myCollectionCreateImageLoader: yetAnotherMockLoader,
       }
 

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -93,20 +93,24 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
       const artworkId = response.id
       const regex = /https:\/\/(?<sourceBucket>.*).s3.amazonaws.com\/(?<sourceKey>.*)/
 
-      const createImagePromises = externalImageUrls
+      const imageSources = externalImageUrls
         .map((url) => {
           const match = url.match(regex)
 
           if (!match) return
 
-          const { sourceBucket, sourceKey } = url.match(regex).groups
+          const { sourceBucket, sourceKey } = match.groups
 
-          return myCollectionCreateImageLoader(artworkId, {
+          return {
             source_bucket: sourceBucket,
             source_key: sourceKey,
-          })
+          }
         })
         .filter(Boolean)
+
+      const createImagePromises = imageSources.map((source) => {
+        return myCollectionCreateImageLoader(artworkId, source)
+      })
 
       await Promise.all(createImagePromises)
 


### PR DESCRIPTION
This PR uses an update I made over on Gravity here:

https://github.com/artsy/gravity/pull/13512

That PR allows one to pass `source_bucket` and `source_key` when creating an `AdditionalArtwork` record. Those arguments will then be passed to Gemini which will fetch and process the corresponding images.

https://artsyproduct.atlassian.net/browse/CSGN-356

/cc @artsy/csgn-devs 