### PR TITLE
@anandaroop => Allow artist aggregation, and fair filtering in followed artists

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1378,6 +1378,7 @@ type Artwork implements Node & Searchable & Sellable {
 }
 
 enum ArtworkAggregation {
+  ARTIST
   COLOR
   DIMENSION_RANGE
   FOLLOWED_ARTISTS
@@ -5862,6 +5863,7 @@ type FollowsAndSaves {
   artistsConnection(
     after: String
     before: String
+    fairID: String
     first: Int
     last: Int
   ): FollowArtistConnection

--- a/src/lib/shared_resolvers/followedArtistsResolver.ts
+++ b/src/lib/shared_resolvers/followedArtistsResolver.ts
@@ -3,9 +3,10 @@ import { connectionFromArraySlice } from "graphql-relay"
 
 // options are connection related arguments
 // params are params passed into gravity to scope the results
-const followArtistsResolver = (params, options, config) => {
+const followArtistsResolver = (params, connectionOptions, config) => {
   if (!config.followedArtistsLoader) return null
-  const { limit: size, offset } = getPagingParameters(options)
+  const { limit: size, offset } = getPagingParameters(connectionOptions)
+
   const gravityArgs = {
     size,
     offset,
@@ -13,7 +14,7 @@ const followArtistsResolver = (params, options, config) => {
     ...params,
   }
   return config.followedArtistsLoader(gravityArgs).then(({ body, headers }) => {
-    return connectionFromArraySlice(body, options, {
+    return connectionFromArraySlice(body, connectionOptions, {
       arrayLength: parseInt(headers["x-total-count"] || "0", 10),
       sliceStart: offset,
     })

--- a/src/schema/v2/aggregations/filter_artworks_aggregation.ts
+++ b/src/schema/v2/aggregations/filter_artworks_aggregation.ts
@@ -6,6 +6,9 @@ import { ResolverContext } from "types/graphql"
 export const ArtworksAggregation = new GraphQLEnumType({
   name: "ArtworkAggregation",
   values: {
+    ARTIST: {
+      value: "artist",
+    },
     COLOR: {
       value: "color",
     },

--- a/src/schema/v2/me/__tests__/followed_artists.test.js
+++ b/src/schema/v2/me/__tests__/followed_artists.test.js
@@ -16,7 +16,12 @@ it("returns artists for a user", () => {
 
   const followedArtistsLoader = sinon
     .stub()
-    .withArgs("me/follow/artists", { size: 10, offset: 0, total_count: true })
+    .withArgs("me/follow/artists", {
+      size: 10,
+      offset: 0,
+      total_count: true,
+      fair_id: "blah",
+    })
     .returns(
       Promise.resolve({ body: artworks, headers: { "x-total-count": 10 } })
     )
@@ -25,7 +30,7 @@ it("returns artists for a user", () => {
     {
       me {
         followsAndSaves {
-          artistsConnection(first: 10) {
+          artistsConnection(fairID: "blah", first: 10) {
             edges {
               node {
                 artist {

--- a/src/schema/v2/me/followed_artists.ts
+++ b/src/schema/v2/me/followed_artists.ts
@@ -3,7 +3,12 @@ import { InternalIDFields } from "schema/v2/object_identification"
 
 import { pageable } from "relay-cursor-paging"
 import { connectionDefinitions } from "graphql-relay"
-import { GraphQLObjectType, GraphQLBoolean, GraphQLFieldConfig } from "graphql"
+import {
+  GraphQLObjectType,
+  GraphQLBoolean,
+  GraphQLFieldConfig,
+  GraphQLString,
+} from "graphql"
 import { ResolverContext } from "types/graphql"
 import followArtistsResolver from "lib/shared_resolvers/followedArtistsResolver"
 
@@ -22,9 +27,14 @@ const FollowArtistType = new GraphQLObjectType<any, ResolverContext>({
 
 const FollowedArtists: GraphQLFieldConfig<void, ResolverContext> = {
   type: connectionDefinitions({ nodeType: FollowArtistType }).connectionType,
-  args: pageable({}),
+  args: pageable({
+    fairID: {
+      type: GraphQLString,
+    },
+  }),
   description: "A Connection of followed artists by current user",
-  resolve: (_parent, args, context) => followArtistsResolver({}, args, context),
+  resolve: (_parent, { fairID, ...connectionArgs }, context) =>
+    followArtistsResolver({ fair_id: fairID }, connectionArgs, context),
 }
 
 export default FollowedArtists


### PR DESCRIPTION
- MP part of https://github.com/artsy/gravity/pull/13531 (exposing artist as a type of aggregation to request)

- also adds a `fairID` param when fetching follows, so one can fetch all followed artists at the fair directly