### PR TITLE
chore: remove Eigen date hack now that it is unnecessary

### DIFF
--- a/src/schema/v1/__tests__/partner_show_events.test.ts
+++ b/src/schema/v1/__tests__/partner_show_events.test.ts
@@ -1,22 +1,5 @@
 import { runQuery } from "schema/v1/test/utils"
 import gql from "lib/gql"
-import moment from "moment"
-
-// This time-bomb spec will fail starting at some defined point in the future,
-// indicating that we should consider reverting this behavior of sending
-// different raw date representations to different versions of Eigen
-// (in the hope that usage of older versions has dropped below some minimum threshold).
-
-xit("is not yet time to rethink this UA-sniffing behavior for resolving dates", () => {
-  const today = moment()
-  const deadline = moment("2020-10-01") // about 18 months after adding this behavior
-
-  let itIsTimeToRethinkThis = today.isAfter(deadline)
-
-  expect(itIsTimeToRethinkThis).toBe(false)
-})
-
-// In the meantime, here is the custom date resolving behavior
 
 describe("date resolving", () => {
   const showData = {
@@ -62,98 +45,19 @@ describe("date resolving", () => {
     }
   })
 
-  describe("default behavior", () => {
-    it("returns dates with UTC offset", async () => {
-      context.userAgent = "some browser"
+  it("returns dates with UTC offset", async () => {
+    context.userAgent = "some browser"
 
-      const data = await runQuery(query, context)
-      expect(data).toEqual({
-        show: {
-          events: [
-            {
-              end_at: "2019-03-28T21:00:00+00:00",
-              start_at: "2019-03-28T18:00:00+00:00",
-            },
-          ],
-        },
-      })
-    })
-  })
-
-  describe("with Eigen 4.4.x", () => {
-    it("truncates the UTC offset", async () => {
-      context.userAgent =
-        "iPhone9,1 Mozilla/5.0 Artsy-Mobile/4.4.1 Eigen/2019.03.15.11/4.4.1 (iPhone; iOS 12.1.4; Scale/2.00) AppleWebKit/601.1.46 (KHTML, like Gecko)"
-
-      const data = await runQuery(query, context)
-      expect(data).toEqual({
-        show: {
-          events: [
-            {
-              end_at: "2019-03-28T21:00:00",
-              start_at: "2019-03-28T18:00:00",
-            },
-          ],
-        },
-      })
-    })
-  })
-
-  describe("with Eigen 5.0.0", () => {
-    it("truncates the UTC offset", async () => {
-      context.userAgent =
-        "iPhone11,6 Mozilla/5.0 Artsy-Mobile/5.0.0 Eigen/2019.03.20.14/5.0.0 (iPhone; iOS 12.1.4; Scale/3.00) AppleWebKit/601.1.46 (KHTML, like Gecko)"
-
-      const data = await runQuery(query, context)
-      expect(data).toEqual({
-        show: {
-          events: [
-            {
-              end_at: "2019-03-28T21:00:00",
-              start_at: "2019-03-28T18:00:00",
-            },
-          ],
-        },
-      })
-    })
-  })
-
-  describe("with Eigen 5.0.1", () => {
-    it("truncates the UTC offset", async () => {
-      context.userAgent =
-        "x86_64 Mozilla/5.0 Artsy-Mobile/5.0.1 Eigen/2019.02.28.17/5.0.1 (iPhone; iOS 12.2; Scale/2.00) AppleWebKit/60 1.1.46 (KHTML, like Gecko)"
-
-      const data = await runQuery(query, context)
-      expect(data).toEqual({
-        show: {
-          events: [
-            {
-              end_at: "2019-03-28T21:00:00",
-              start_at: "2019-03-28T18:00:00",
-            },
-          ],
-        },
-      })
-    })
-  })
-
-  describe("When an Eigen user agent is returned as part of an array", () => {
-    it("truncates the UTC offset", async () => {
-      context.userAgent = [
-        "x86_64 Mozilla/5.0 Artsy-Mobile/5.0.1 Eigen/2019.02.28.17/5.0.1 (iPhone; iOS 12.2; Scale/2.00) AppleWebKit/60 1.1.46 (KHTML, like Gecko)",
-      ]
-
-      const data = await runQuery(query, context)
-      expect(data).toEqual({
-        show: {
-          events: [
-            {
-              end_at: "2019-03-28T21:00:00",
-              start_at: "2019-03-28T18:00:00",
-            },
-          ],
-        },
-      })
+    const data = await runQuery(query, context)
+    expect(data).toEqual({
+      show: {
+        events: [
+          {
+            end_at: "2019-03-28T21:00:00+00:00",
+            start_at: "2019-03-28T18:00:00+00:00",
+          },
+        ],
+      },
     })
   })
 })

--- a/src/schema/v1/partner_show_event.ts
+++ b/src/schema/v1/partner_show_event.ts
@@ -1,45 +1,7 @@
-import dateField, { date, DateSource } from "./fields/date"
-import { GraphQLString, GraphQLObjectType, GraphQLFieldConfig } from "graphql"
+import dateField from "./fields/date"
+import { GraphQLString, GraphQLObjectType } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { dateRange, dateTimeRange } from "lib/date"
-
-const hasOldEmissionUserAgentString = (userAgent: string | string[]): boolean =>
-  userAgent!.indexOf("Artsy-Mobile/4.4") > 0 ||
-  userAgent!.indexOf("Artsy-Mobile/5.0.0") > 0 ||
-  userAgent!.indexOf("Artsy-Mobile/5.0.1") > 0
-
-const isOlderEmissionVersion = (userAgent: string | string[]): boolean => {
-  let result = false
-  if (typeof userAgent === "string") {
-    result = hasOldEmissionUserAgentString(userAgent)
-  } else if (Array.isArray(userAgent)) {
-    result = userAgent.some(hasOldEmissionUserAgentString)
-  }
-  return result
-}
-
-const dateFieldForPartnerShowEvent: GraphQLFieldConfig<
-  DateSource,
-  ResolverContext
-> = {
-  ...dateField,
-  resolve: (
-    obj,
-    { format, timezone },
-    { defaultTimezone, userAgent },
-    { fieldName }
-  ) => {
-    const rawDate = obj[fieldName]
-
-    if (userAgent && isOlderEmissionVersion(userAgent)) {
-      const dateWithoutOffset = rawDate.replace(/[-+]\d\d:\d\d$/, "")
-      return dateWithoutOffset
-    }
-
-    const timezoneString = timezone ? timezone : defaultTimezone
-    return date(rawDate, format, timezoneString)
-  },
-}
 
 const PartnerShowEventType = new GraphQLObjectType<any, ResolverContext>({
   name: "PartnerShowEventType",
@@ -56,8 +18,8 @@ const PartnerShowEventType = new GraphQLObjectType<any, ResolverContext>({
     title: {
       type: GraphQLString,
     },
-    start_at: dateFieldForPartnerShowEvent,
-    end_at: dateFieldForPartnerShowEvent,
+    start_at: dateField,
+    end_at: dateField,
     dateTimeRange: {
       type: GraphQLString,
       description: "A formatted description of the dates with hours",

--- a/src/schema/v2/__tests__/show_events.test.ts
+++ b/src/schema/v2/__tests__/show_events.test.ts
@@ -1,23 +1,6 @@
 import { runQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
-import moment from "moment"
 import { ResolverContext } from "types/graphql"
-
-// This time-bomb spec will fail starting at some defined point in the future,
-// indicating that we should consider reverting this behavior of sending
-// different raw date representations to different versions of Eigen
-// (in the hope that usage of older versions has dropped below some minimum threshold).
-
-xit("is not yet time to rethink this UA-sniffing behavior for resolving dates", () => {
-  const today = moment()
-  const deadline = moment("2020-10-01") // about 18 months after adding this behavior
-
-  let itIsTimeToRethinkThis = today.isAfter(deadline)
-
-  expect(itIsTimeToRethinkThis).toBe(false)
-})
-
-// In the meantime, here is the custom date resolving behavior
 
 describe("date resolving", () => {
   const showData = {
@@ -57,98 +40,19 @@ describe("date resolving", () => {
     }
   })
 
-  describe("default behavior", () => {
-    it("returns dates with UTC offset", async () => {
-      context.userAgent = "some browser"
+  it("returns dates with UTC offset", async () => {
+    context.userAgent = "some browser"
 
-      const data = await runQuery(query, context)
-      expect(data).toEqual({
-        show: {
-          events: [
-            {
-              endAt: "2019-03-28T21:00:00+00:00",
-              startAt: "2019-03-28T18:00:00+00:00",
-            },
-          ],
-        },
-      })
-    })
-  })
-
-  describe("with Eigen 4.4.x", () => {
-    it("truncates the UTC offset", async () => {
-      context.userAgent =
-        "iPhone9,1 Mozilla/5.0 Artsy-Mobile/4.4.1 Eigen/2019.03.15.11/4.4.1 (iPhone; iOS 12.1.4; Scale/2.00) AppleWebKit/601.1.46 (KHTML, like Gecko)"
-
-      const data = await runQuery(query, context)
-      expect(data).toEqual({
-        show: {
-          events: [
-            {
-              endAt: "2019-03-28T21:00:00",
-              startAt: "2019-03-28T18:00:00",
-            },
-          ],
-        },
-      })
-    })
-  })
-
-  describe("with Eigen 5.0.0", () => {
-    it("truncates the UTC offset", async () => {
-      context.userAgent =
-        "iPhone11,6 Mozilla/5.0 Artsy-Mobile/5.0.0 Eigen/2019.03.20.14/5.0.0 (iPhone; iOS 12.1.4; Scale/3.00) AppleWebKit/601.1.46 (KHTML, like Gecko)"
-
-      const data = await runQuery(query, context)
-      expect(data).toEqual({
-        show: {
-          events: [
-            {
-              endAt: "2019-03-28T21:00:00",
-              startAt: "2019-03-28T18:00:00",
-            },
-          ],
-        },
-      })
-    })
-  })
-
-  describe("with Eigen 5.0.1", () => {
-    it("truncates the UTC offset", async () => {
-      context.userAgent =
-        "x86_64 Mozilla/5.0 Artsy-Mobile/5.0.1 Eigen/2019.02.28.17/5.0.1 (iPhone; iOS 12.2; Scale/2.00) AppleWebKit/60 1.1.46 (KHTML, like Gecko)"
-
-      const data = await runQuery(query, context)
-      expect(data).toEqual({
-        show: {
-          events: [
-            {
-              endAt: "2019-03-28T21:00:00",
-              startAt: "2019-03-28T18:00:00",
-            },
-          ],
-        },
-      })
-    })
-  })
-
-  describe("When an Eigen user agent is returned as part of an array", () => {
-    it("truncates the UTC offset", async () => {
-      context.userAgent = [
-        "x86_64 Mozilla/5.0 Artsy-Mobile/5.0.1 Eigen/2019.02.28.17/5.0.1 (iPhone; iOS 12.2; Scale/2.00) AppleWebKit/60 1.1.46 (KHTML, like Gecko)",
-      ]
-
-      const data = await runQuery(query, context)
-      expect(data).toEqual({
-        show: {
-          events: [
-            {
-              endAt: "2019-03-28T21:00:00",
-              startAt: "2019-03-28T18:00:00",
-            },
-          ],
-        },
-      })
+    const data = await runQuery(query, context)
+    expect(data).toEqual({
+      show: {
+        events: [
+          {
+            endAt: "2019-03-28T21:00:00+00:00",
+            startAt: "2019-03-28T18:00:00+00:00",
+          },
+        ],
+      },
     })
   })
 })

--- a/src/schema/v2/show_event.ts
+++ b/src/schema/v2/show_event.ts
@@ -1,43 +1,7 @@
-import dateField, { date, DateSource } from "./fields/date"
-import { GraphQLString, GraphQLObjectType, GraphQLFieldConfig } from "graphql"
+import dateField from "./fields/date"
+import { GraphQLString, GraphQLObjectType } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { dateRange, dateTimeRange } from "lib/date"
-import { snakeCase } from "lodash"
-
-const hasOldEmissionUserAgentString = (userAgent: string | string[]): boolean =>
-  userAgent!.indexOf("Artsy-Mobile/4.4") > 0 ||
-  userAgent!.indexOf("Artsy-Mobile/5.0.0") > 0 ||
-  userAgent!.indexOf("Artsy-Mobile/5.0.1") > 0
-
-const isOlderEmissionVersion = (userAgent: string | string[]): boolean => {
-  let result = false
-  if (typeof userAgent === "string") {
-    result = hasOldEmissionUserAgentString(userAgent)
-  } else if (Array.isArray(userAgent)) {
-    result = userAgent.some(hasOldEmissionUserAgentString)
-  }
-  return result
-}
-
-const dateFieldForShowEvent: GraphQLFieldConfig<DateSource, ResolverContext> = {
-  ...dateField,
-  resolve: (
-    obj,
-    { format, timezone },
-    { defaultTimezone, userAgent },
-    { fieldName }
-  ) => {
-    const rawDate = obj[snakeCase(fieldName)]
-
-    if (userAgent && isOlderEmissionVersion(userAgent)) {
-      const dateWithoutOffset = rawDate.replace(/[-+]\d\d:\d\d$/, "")
-      return dateWithoutOffset
-    }
-
-    const timezoneString = timezone ? timezone : defaultTimezone
-    return date(rawDate, format, timezoneString)
-  },
-}
 
 const ShowEventType = new GraphQLObjectType<any, ResolverContext>({
   name: "ShowEventType",
@@ -54,8 +18,8 @@ const ShowEventType = new GraphQLObjectType<any, ResolverContext>({
     title: {
       type: GraphQLString,
     },
-    startAt: dateFieldForShowEvent,
-    endAt: dateFieldForShowEvent,
+    startAt: dateField,
+    endAt: dateField,
     dateTimeRange: {
       type: GraphQLString,
       description: "A formatted description of the dates with hours",


### PR DESCRIPTION
Back in the Before Times...
- we found a nasty date-related City Guide [bug](https://artsyproduct.atlassian.net/browse/LD-561)
- we wrote an expedient UA-sniffing [hack](https://github.com/artsy/metaphysics/pull/1642) to address it
- we added a time-bomb [spec](https://github.com/artsy/metaphysics/blob/5e3587518ea274ef6eed5e046d2eeb0f8d480f31/src/schema/v2/__tests__/show_events.test.ts#L6-L18) to remind us to undo the hack

Now in 2020 AD:
- the bomb [went off](https://artsy.slack.com/archives/C02BC3HEJ/p1601567857100300) 
- our prediction about the fix being obsoleted [panned out](https://artsy.slack.com/archives/CN8S32FJR/p1601657401152400)

And I'll be damned if I'm not going to remove that hack just like we said we would 👼 

