### PR TITLE
chore(FX-2340): Add sponsored content for Frieze London

### DIFF
--- a/src/lib/sponsoredContent/data.json
+++ b/src/lib/sponsoredContent/data.json
@@ -92,6 +92,10 @@
     "gallery-weekend-berlin-2020": {
       "activationText": "From September 11 to 13, 2020, the Gallery Weekend Berlin presents its 16th edition with productions by emerging artists alongside more established positions at 48 participating galleries. BMW supports the Gallery Weekend as main partner from the beginning and will again provide the traditional VIP shuttle service for the galleries.",
       "pressReleaseUrl": "https://www.press.bmwgroup.com/global/article/detail/T0315631EN/bmw-is-main-partner-of-the-gallery-weekend-berlin-2020-postponed-art-weekend-takes-place-from-september-11-to-13-2020"
+    },
+    "frieze-london-2020": {
+      "activationText": "For the fourth consecutive year BMW and Frieze continue their long-term partnership with the major art initiative BMW Open Work by Frieze. The artist selected by the curator Attilia Fattori Franchini is the New York-based Madeline Hollander, who will present the commission in two phases, as an interactive digital platform and livery intervention during Frieze Week in London 2020, and as a live, site-specific installation at Frieze Los Angeles in 2021.",
+      "pressReleaseUrl": "https://www.press.bmwgroup.com/global/article/detail/T0318107EN/madeline-hollander-premiers-%E2%80%9Csunrise/sunset%E2%80%9D-for-bmw-open-work-by-frieze-bmw-i3-electric-vehicles-as-part-of-the-commission-during-frieze-week-in-london"
     }
   }
 }


### PR DESCRIPTION
Include activation text and press release URL for Frieze London sponsorship content.