### PR TITLE
CX-678: Use existing delete artwork endpoint for my collection

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -196,12 +196,9 @@ export default (accessToken, userID, opts) => {
       },
       { method: "PUT" }
     ),
-    myCollectionDeleteArtworkLoader: gravityLoader(
-      (id) => `my-collection/artworks/${id}`,
-      {
-        user_id: userID,
-        private: true,
-      },
+    deleteArtworkLoader: gravityLoader(
+      (id) => `artwork/${id}`,
+      {},
       { method: "DELETE" }
     ),
     notificationsFeedLoader: gravityLoader("me/notifications/feed"),

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -47,7 +47,7 @@ export default (accessToken, userID, opts) => {
       { method: "POST" }
     ),
     creditCardLoader: gravityLoader((id) => `credit_card/${id}`),
-    deleteArtworkLoader: gravityLoader(
+    deleteSavedArtworkLoader: gravityLoader(
       (id) => `collection/saved-artwork/artwork/${id}`,
       {},
       { method: "DELETE" }

--- a/src/schema/v1/me/__tests__/save_artwork.test.js
+++ b/src/schema/v1/me/__tests__/save_artwork.test.js
@@ -39,7 +39,7 @@ describe("SaveArtworkMutation", () => {
     return runAuthenticatedQuery(mutation, {
       saveArtworkLoader,
       artworkLoader,
-      deleteArtworkLoader: jest.fn(),
+      deleteSavedArtworkLoader: jest.fn(),
     }).then(({ saveArtwork }) => {
       expect(saveArtwork).toEqual(expectedArtworkData)
     })
@@ -76,12 +76,12 @@ describe("SaveArtworkMutation", () => {
       },
     }
 
-    const deleteArtworkLoader = () => Promise.resolve(mutationResponse)
+    const deleteSavedArtworkLoader = () => Promise.resolve(mutationResponse)
     const artworkLoader = () => Promise.resolve(artwork)
 
     expect.assertions(1)
     return runAuthenticatedQuery(mutation, {
-      deleteArtworkLoader,
+      deleteSavedArtworkLoader,
       artworkLoader,
       saveArtworkLoader: jest.fn(),
     }).then(({ saveArtwork }) => {

--- a/src/schema/v1/me/save_artwork_mutation.ts
+++ b/src/schema/v1/me/save_artwork_mutation.ts
@@ -24,13 +24,13 @@ export default mutationWithClientMutationId<any, any, ResolverContext>({
   },
   mutateAndGetPayload: (
     { artwork_id, remove },
-    { userID, saveArtworkLoader, deleteArtworkLoader }
+    { userID, saveArtworkLoader, deleteSavedArtworkLoader }
   ) => {
-    if (!deleteArtworkLoader || !saveArtworkLoader) {
+    if (!deleteSavedArtworkLoader || !saveArtworkLoader) {
       return new Error("You need to be signed in to perform this action")
     }
 
-    const loader = remove ? deleteArtworkLoader : saveArtworkLoader
+    const loader = remove ? deleteSavedArtworkLoader : saveArtworkLoader
     return loader(artwork_id, { user_id: userID }).then(() => ({ artwork_id }))
   },
 })

--- a/src/schema/v2/me/__tests__/myCollectionDeleteArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionDeleteArtworkMutation.test.ts
@@ -21,7 +21,7 @@ describe("myCollectionDeleteArtworkMutation", () => {
 
   it("returns an error", async () => {
     const context = {
-      myCollectionDeleteArtworkLoader: () =>
+      deleteArtworkLoader: () =>
         Promise.reject(
           new Error(
             `https://stagingapi.artsy.net/api/v1/my_collection/artworks/foo - {"error":"Error deleting artwork"}`
@@ -43,8 +43,7 @@ describe("myCollectionDeleteArtworkMutation", () => {
 
   it("deletes an artwork", async () => {
     const context = {
-      myCollectionDeleteArtworkLoader: () =>
-        Promise.resolve({ name: "My Collection" }),
+      deleteArtworkLoader: () => Promise.resolve({ deleted: true }),
     }
 
     const data = await runAuthenticatedQuery(mutation, context)

--- a/src/schema/v2/me/__tests__/save_artwork.test.js
+++ b/src/schema/v2/me/__tests__/save_artwork.test.js
@@ -39,7 +39,7 @@ describe("SaveArtworkMutation", () => {
     return runAuthenticatedQuery(mutation, {
       saveArtworkLoader,
       artworkLoader,
-      deleteArtworkLoader: jest.fn(),
+      deleteSavedArtworkLoader: jest.fn(),
     }).then(({ saveArtwork }) => {
       expect(saveArtwork).toEqual(expectedArtworkData)
     })
@@ -76,12 +76,12 @@ describe("SaveArtworkMutation", () => {
       },
     }
 
-    const deleteArtworkLoader = () => Promise.resolve(mutationResponse)
+    const deleteSavedArtworkLoader = () => Promise.resolve(mutationResponse)
     const artworkLoader = () => Promise.resolve(artwork)
 
     expect.assertions(1)
     return runAuthenticatedQuery(mutation, {
-      deleteArtworkLoader,
+      deleteSavedArtworkLoader,
       artworkLoader,
       saveArtworkLoader: jest.fn(),
     }).then(({ saveArtwork }) => {

--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -141,7 +141,7 @@ const MyCollectionArtworkMutationDeleteSuccess = new GraphQLObjectType<
 >({
   name: "MyCollectionArtworkMutationDeleteSuccess",
   isTypeOf: (data) => {
-    return data.name === "My Collection"
+    return data.deleted
   },
   fields: () => ({
     success: {

--- a/src/schema/v2/me/myCollectionDeleteArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionDeleteArtworkMutation.ts
@@ -22,16 +22,13 @@ export const myCollectionDeleteArtworkMutation = mutationWithClientMutationId<
       resolve: (result) => result,
     },
   },
-  mutateAndGetPayload: async (
-    { artworkId },
-    { myCollectionDeleteArtworkLoader }
-  ) => {
-    if (!myCollectionDeleteArtworkLoader) {
+  mutateAndGetPayload: async ({ artworkId }, { deleteArtworkLoader }) => {
+    if (!deleteArtworkLoader) {
       return new Error("You need to be signed in to perform this action")
     }
 
     try {
-      const response = await myCollectionDeleteArtworkLoader(artworkId)
+      const response = await deleteArtworkLoader(artworkId)
 
       // Response from DELETE isn't internalID of deleted artwork and as such
       // we don't want to match on the MyCollectionArtworkMutationSuccess  type,

--- a/src/schema/v2/me/saveArtworkMutation.ts
+++ b/src/schema/v2/me/saveArtworkMutation.ts
@@ -37,13 +37,13 @@ export default mutationWithClientMutationId<any, any, ResolverContext>({
   },
   mutateAndGetPayload: (
     { artworkID: artwork_id, remove },
-    { userID, saveArtworkLoader, deleteArtworkLoader }
+    { userID, saveArtworkLoader, deleteSavedArtworkLoader }
   ) => {
-    if (!deleteArtworkLoader || !saveArtworkLoader) {
+    if (!deleteSavedArtworkLoader || !saveArtworkLoader) {
       return new Error("You need to be signed in to perform this action")
     }
 
-    const loader = remove ? deleteArtworkLoader : saveArtworkLoader
+    const loader = remove ? deleteSavedArtworkLoader : saveArtworkLoader
     return loader(artwork_id, { user_id: userID }).then(() => ({ artwork_id }))
   },
 })


### PR DESCRIPTION
This PR updates the mutation that deletes a My Collection artwork to favor the existing REST endpoint rather than the ones I made for this use-case. It is based on this one: https://github.com/artsy/gravity/pull/13547.

To make this change I started by discovering that there was already a `deleteArtworkLoader` but it was for removing an artwork from one's saved artworks collection. So I renamed that and then renamed the My Collection-specific loader to the more general name.

The only other notable change here is that I'm sending these params: `{ permanent: true }` which just helps indicate that for this situation we're not looking for a soft-delete, but a full blown removal of the artwork record.

https://artsyproduct.atlassian.net/browse/CX-678