### PR TITLE
feat: allow viewing rooms to be returned from search [GALL-3351]

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9336,6 +9336,7 @@ enum SearchEntity {
   SALE
   SHOW
   TAG
+  VIEWING_ROOM
 }
 
 enum SearchMode {

--- a/src/schema/v2/SearchableItem/SearchableItemPresenter.ts
+++ b/src/schema/v2/SearchableItem/SearchableItemPresenter.ts
@@ -34,6 +34,7 @@ export class SearchableItemPresenter {
         return `Browse current exhibitions in ${display}`
       case "Collection":
       case "ArtistSeries":
+      case "ViewingRoom":
         return stripTags(description)
       default:
         return undefined
@@ -60,6 +61,8 @@ export class SearchableItemPresenter {
         return `/show/${id}`
       case "ArtistSeries":
         return `/artist-series/${id}`
+      case "ViewingRoom":
+        return `/viewing-room/${id}`
       default:
         return `/${model}/${id}`
     }
@@ -94,6 +97,8 @@ export class SearchableItemPresenter {
         return "Collection"
       case "ArtistSeries":
         return "Artist Series"
+      case "ViewingRoom":
+        return "Viewing Room"
       default:
         return label
     }

--- a/src/schema/v2/search/SearchEntity.ts
+++ b/src/schema/v2/search/SearchEntity.ts
@@ -51,6 +51,9 @@ export const SearchEntity = new GraphQLEnumType({
     TAG: {
       value: "Tag",
     },
+    VIEWING_ROOM: {
+      value: "ViewingRoom",
+    },
   },
 })
 


### PR DESCRIPTION
This PR adds VRs to the list of entities that can be returned from search. After this PR is merged, next steps:
- [ ] Update Force's MP schema, at which point we should be showing VRs in autosuggest results ([Jira ticket](https://artsyproduct.atlassian.net/browse/GALL-3352) for that)
- [ ] Figure out how to get image + description for search results (not relevant for autosuggest) - **see comment on file below!**
- [ ] Update Force's search results page to have a VR tab and display results ([Jira ticket](https://artsyproduct.atlassian.net/browse/GALL-3283) for this)

Tested it out locally with Insomnia and successfully returned a VR :tada: this image shows `AUTOSUGGEST` mode, which is what we use when a user starts typing and we want to show suggestions, but we also now return VRs in `SITE` mode, which is when they hit enter and run a search:
![Screen Shot 2020-10-08 at 5 40 03 PM](https://user-images.githubusercontent.com/5361806/95516609-84eb8b80-098d-11eb-8692-ba4d696a6748.png)


Draws from https://github.com/artsy/metaphysics/pull/2574!

Jira ticket: https://artsyproduct.atlassian.net/browse/GALL-3351