### PR TITLE
Add more images to my collection artworks

### DIFF
--- a/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
@@ -1,22 +1,31 @@
 import { runAuthenticatedQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
 
-describe("myCollectionUpdateArtworkMutation", () => {
+const updatedArtwork = { id: "some-artwork-id" }
+const updateArtworkLoader = jest.fn().mockResolvedValue(updatedArtwork)
+
+const artworkDetails = { medium: "Updated" }
+const artworkLoader = jest.fn().mockResolvedValue(artworkDetails)
+
+const createImageLoader = jest.fn()
+
+const computeMutationInput = (externalImageUrls: string[] = []): string => {
   const mutation = gql`
     mutation {
       myCollectionUpdateArtwork(
         input: {
           artistIds: ["4d8b92b34eb68a1b2c0003f4"]
-          artworkId: "foo"
+          artworkId: "some-artwork-id"
           category: "some strange category"
           costCurrencyCode: "USD"
           costMinor: 200
-          editionNumber: "5"
-          editionSize: "100x100x100"
           date: "1990"
           depth: "20"
+          editionNumber: "5"
+          editionSize: "100x100x100"
+          externalImageUrls: ${JSON.stringify(externalImageUrls)}
           height: "20"
-          medium: "Painting"
+          medium: "Updated"
           metric: "in"
           title: "hey now"
           width: "20"
@@ -43,51 +52,103 @@ describe("myCollectionUpdateArtworkMutation", () => {
     }
   `
 
-  it("returns an error", async () => {
-    const context = {
-      myCollectionUpdateArtworkLoader: () =>
-        Promise.reject(
-          new Error(
-            `https://stagingapi.artsy.net/api/v1/my_collection/artworks/foo - {"error":"Error updating artwork"}`
-          )
-        ),
-    }
+  return mutation
+}
 
-    const data = await runAuthenticatedQuery(mutation, context)
-    expect(data).toEqual({
-      myCollectionUpdateArtwork: {
-        artworkOrError: {
-          mutationError: {
-            message: "Error updating artwork",
-          },
-        },
-      },
+const defaultContext = {
+  myCollectionUpdateArtworkLoader: updateArtworkLoader,
+  myCollectionArtworkLoader: artworkLoader,
+  myCollectionCreateImageLoader: createImageLoader,
+}
+
+describe("myCollectionUpdateArtworkMutation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("when the server responds with an error", () => {
+    it("returns an error", async () => {
+      const mutation = computeMutationInput()
+
+      const serverError = "Error updating artwork"
+      const url =
+        "https://stagingapi.artsy.net/api/v1/my_collection?id=some-artwork-id"
+      const error = new Error(`${url} - {"error":"${serverError}"}`)
+      const failureLoader = jest.fn().mockRejectedValue(error)
+
+      const context = {
+        ...defaultContext,
+        myCollectionUpdateArtworkLoader: failureLoader,
+      }
+
+      const data = await runAuthenticatedQuery(mutation, context)
+      const { artworkOrError } = data.myCollectionUpdateArtwork
+      const { message } = artworkOrError.mutationError
+
+      expect(message).toEqual(serverError)
     })
   })
 
-  it("updates an artwork", async () => {
-    const context = {
-      myCollectionUpdateArtworkLoader: () => Promise.resolve({ id: "foo" }),
-      myCollectionArtworkLoader: () =>
-        Promise.resolve({
-          medium: "Updated",
-        }),
-    }
+  describe("when the server response is successful", () => {
+    it("returns details of the new artwork", async () => {
+      const mutation = computeMutationInput()
 
-    const data = await runAuthenticatedQuery(mutation, context)
-    expect(data).toEqual({
-      myCollectionUpdateArtwork: {
-        artworkOrError: {
-          artwork: {
+      const data = await runAuthenticatedQuery(mutation, defaultContext)
+      const { artworkOrError } = data.myCollectionUpdateArtwork
+
+      expect(artworkOrError).toEqual({
+        artwork: {
+          medium: "Updated",
+        },
+        artworkEdge: {
+          node: {
             medium: "Updated",
           },
-          artworkEdge: {
-            node: {
-              medium: "Updated",
-            },
-          },
         },
-      },
+      })
+    })
+  })
+
+  describe("creating additional images", () => {
+    it("creates an additional image with bucket and key with a valid image url", async () => {
+      const externalImageUrls = [
+        "https://test-upload-bucket.s3.amazonaws.com/path/to/image.jpg",
+      ]
+      const mutation = computeMutationInput(externalImageUrls)
+
+      const data = await runAuthenticatedQuery(mutation, defaultContext)
+      const { artworkOrError } = data.myCollectionUpdateArtwork
+
+      expect(artworkOrError).toHaveProperty("artwork")
+      expect(artworkOrError).not.toHaveProperty("error")
+      expect(createImageLoader).toBeCalledWith(updatedArtwork.id, {
+        source_bucket: "test-upload-bucket",
+        source_key: "path/to/image.jpg",
+      })
+    })
+
+    it("returns an error when the additional image can't be created", async () => {
+      const externalImageUrls = [
+        "https://test-upload-bucket.s3.amazonaws.com/path/to/image.jpg",
+      ]
+      const mutation = computeMutationInput(externalImageUrls)
+
+      const serverError = "Error creating image"
+      const url =
+        "https://stagingapi.artsy.net/api/v1/artwork/some-artwork-id/images"
+      const error = new Error(`${url} - {"error":"${serverError}"}`)
+      const failureLoader = jest.fn().mockRejectedValue(error)
+
+      const context = {
+        ...defaultContext,
+        myCollectionCreateImageLoader: failureLoader,
+      }
+
+      const data = await runAuthenticatedQuery(mutation, context)
+      const { artworkOrError } = data.myCollectionUpdateArtwork
+      const { message } = artworkOrError.mutationError
+
+      expect(message).toEqual(serverError)
     })
   })
 })


### PR DESCRIPTION
This PR follows on #2742 and adds support for adding additional images when editing a My Collection artwork.

After some chatter here:

https://artsy.slack.com/archives/C01B2P6LJUU/p1602188267269900

I set out to add the `externalImageUrls` prop to the `myCollectionUpdateArtworkMutation` and did extract a func to compute the image sources so that the business logic around matching and parsing these URLs could be encapsulated. Then I updated both mutations to use the func.

Then I updated the tests like so:

* leave some of the tests right where they were for the create mutation - these serve as integration tests
* extract some of the existing tests to focus on the newly extracted helper func
* copy/paste those integration tests into the update mutation test file - more integration coverage

So now the business logic of this helper func can evolve but the outer context doesn't have to care and is just focused on how mutations behave in certain situations. 😎 