### PR TITLE
fix: followed fairs galleries schema errors

### DIFF
--- a/src/schema/v2/me/followed_fairs.ts
+++ b/src/schema/v2/me/followed_fairs.ts
@@ -21,7 +21,7 @@ const FollowedFairs: GraphQLFieldConfig<void, ResolverContext> = {
       size,
       offset,
       total_count: true,
-      ownerType: "FAIR",
+      owner_types: "Fair",
     }
 
     return followedFairsLoader(gravityArgs).then(({ body, headers }) => {

--- a/src/schema/v2/me/followed_galleries.ts
+++ b/src/schema/v2/me/followed_galleries.ts
@@ -9,7 +9,7 @@ export const FollowedGalleryConnection = connectionDefinitions({
   nodeType: PartnerType,
 })
 
-export const GALLERY_OWNER_TYPE = "Gallery"
+export const GALLERY_OWNER_TYPE = "PartnerGallery"
 
 const FollowedGalleries: GraphQLFieldConfig<void, ResolverContext> = {
   type: FollowedGalleryConnection.connectionType,
@@ -24,7 +24,7 @@ const FollowedGalleries: GraphQLFieldConfig<void, ResolverContext> = {
       size,
       offset,
       total_count: true,
-      ownerType: GALLERY_OWNER_TYPE,
+      owner_types: GALLERY_OWNER_TYPE,
     }
 
     return followedPartnersLoader(gravityArgs).then(({ body, headers }) => {


### PR DESCRIPTION
A couple of errors relating to queries for retrieving followed fairs and galleries. Not sure how no-one ever noticed this with the galleries query before, since it means that fairs will also be returned when requesting followed galleries.