### PR TITLE
Add `active` arg to Me.bidders

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6910,6 +6910,9 @@ type Me implements Node {
 
   # A list of the current user’s bidder registrations
   bidders(
+    # Limit results to bidders in active auctions
+    active: Boolean
+
     # The slug or ID of a Sale
     saleID: String
   ): [Bidder]

--- a/src/schema/v2/me/__tests__/bidders.test.js
+++ b/src/schema/v2/me/__tests__/bidders.test.js
@@ -52,5 +52,32 @@ describe("Me", () => {
         }
       )
     })
+
+    it("calls the gravity endpoint with the `filter` param if included", () => {
+      const query = `
+        {
+          me {
+            bidders(active: true) {
+              internalID
+            }
+          }
+        }
+      `
+      const response = () =>
+        Promise.resolve([{ id: "Foo ID" }, { id: "Bar ID" }])
+      const meBiddersLoader = jest.fn(response)
+
+      return runAuthenticatedQuery(query, { meBiddersLoader }).then(
+        ({ me: { bidders } }) => {
+          expect(meBiddersLoader).toBeCalledWith(
+            expect.objectContaining({ active: true })
+          )
+          expect(bidders).toEqual([
+            { internalID: "Foo ID" },
+            { internalID: "Bar ID" },
+          ])
+        }
+      )
+    })
   })
 })

--- a/src/schema/v2/me/__tests__/bidders.test.js
+++ b/src/schema/v2/me/__tests__/bidders.test.js
@@ -63,8 +63,7 @@ describe("Me", () => {
           }
         }
       `
-      const response = () =>
-        Promise.resolve([{ id: "Foo ID" }, { id: "Bar ID" }])
+      const response = () => Promise.resolve([])
       const meBiddersLoader = jest.fn(response)
 
       return runAuthenticatedQuery(query, { meBiddersLoader }).then(
@@ -72,10 +71,6 @@ describe("Me", () => {
           expect(meBiddersLoader).toBeCalledWith(
             expect.objectContaining({ active: true })
           )
-          expect(bidders).toEqual([
-            { internalID: "Foo ID" },
-            { internalID: "Bar ID" },
-          ])
         }
       )
     })

--- a/src/schema/v2/me/bidders.ts
+++ b/src/schema/v2/me/bidders.ts
@@ -1,5 +1,10 @@
 import Bidder from "schema/v2/bidder"
-import { GraphQLList, GraphQLString, GraphQLFieldConfig } from "graphql"
+import {
+  GraphQLList,
+  GraphQLString,
+  GraphQLFieldConfig,
+  GraphQLBoolean,
+} from "graphql"
 import { ResolverContext } from "types/graphql"
 
 const Bidders: GraphQLFieldConfig<void, ResolverContext> = {
@@ -10,10 +15,15 @@ const Bidders: GraphQLFieldConfig<void, ResolverContext> = {
       type: GraphQLString,
       description: "The slug or ID of a Sale",
     },
+    active: {
+      type: GraphQLBoolean,
+      description: "Limit results to bidders in active auctions",
+    },
   },
-  resolve: (_root, { saleID }, { meBiddersLoader }) => {
+  resolve: (_root, { saleID, active }, { meBiddersLoader }) => {
     const options: any = {
       sale_id: saleID,
+      active,
     }
     if (!meBiddersLoader) return null
     return meBiddersLoader(options)


### PR DESCRIPTION
Not blocked by, but depends on https://github.com/artsy/gravity/pull/13571 to work.
Completes PURCHASE-2194

This PR adds an optional `active: Boolean` arg to the Me.bidders field, allowing a user to query her bidders limiting them to only active (published, unended) sales. Omitting it or setting `active: false` would match today's behavior and `active: true` opts into the filter.