### PR TITLE
feat: add vortex schema and regenerate stitched schema

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -195,6 +195,8 @@ type AnalyticsPartnerInquiryCountTimeSeriesStats {
 # Inquiry stats of a partner
 type AnalyticsPartnerInquiryStats {
   inquiryCount: Int!
+
+  # Inquiry response time in seconds
   inquiryResponseTime: Int
   partnerId: String!
   period: AnalyticsQueryPeriodEnum!
@@ -208,6 +210,8 @@ type AnalyticsPartnerInquiryStats {
 # Sales stats of a partner
 type AnalyticsPartnerSalesStats {
   orderCount: Int!
+
+  # Order response time in seconds
   orderResponseTime: Int
   partnerId: String!
   period: AnalyticsQueryPeriodEnum!
@@ -244,9 +248,17 @@ type AnalyticsPartnerSalesTimeSeriesStats {
 # Partner Stats
 type AnalyticsPartnerStats {
   # Time series data on number of artworks published
+  artworkPublished(
+    period: AnalyticsQueryPeriodEnum!
+  ): AnalyticsPartnerStatsArtworksPublished
+
+  # Time series data on number of artworks published
   artworksPublished(
     period: AnalyticsQueryPeriodEnum!
   ): AnalyticsArtworksPublishedStats
+    @deprecated(
+      reason: "Use artworkPublished for refactored time series bucket code"
+    )
 
   # Audience stats
   audience(period: AnalyticsQueryPeriodEnum!): AnalyticsPartnerAudienceStats
@@ -273,7 +285,11 @@ type AnalyticsPartnerStats {
   inquiry(period: AnalyticsQueryPeriodEnum!): AnalyticsPartnerInquiryStats
 
   # Different types of partner pageviews
+  pageview(period: AnalyticsQueryPeriodEnum!): AnalyticsPartnerStatsPageviews
+
+  # Different types of partner pageviews
   pageviews(period: AnalyticsQueryPeriodEnum!): AnalyticsPageviewStats
+    @deprecated(reason: "Use pageview for refactored time series bucket code")
   partnerId: String!
 
   # Artworks, shows, or artists ranked by views. Capped at 20 by the underlying sql query.
@@ -315,6 +331,50 @@ type AnalyticsPartnerStats {
   # Number of unique visitors
   uniqueVisitors(period: AnalyticsQueryPeriodEnum!): Int
     @deprecated(reason: "Use audience() { uniqueVisitors } instead")
+}
+
+# Publish artwork Series Stats
+type AnalyticsPartnerStatsArtworksPublished {
+  partnerId: String!
+  percentageChanged: Int!
+  period: AnalyticsQueryPeriodEnum!
+
+  # Partner artworks published count time series
+  timeSeries(
+    cumulative: Boolean = false
+  ): [AnalyticsPartnerStatsArtworksPublishedTimeSeries!]!
+  totalCount: Int!
+}
+
+# Artworks published time series data of a partner
+type AnalyticsPartnerStatsArtworksPublishedTimeSeries {
+  count: Int
+  endTime: AnalyticsDateTime
+  startTime: AnalyticsDateTime
+}
+
+# Stats for pageviews of partner content
+type AnalyticsPartnerStatsPageviews {
+  artworkViews: Int!
+  galleryViews: Int!
+  partnerId: String!
+  percentageChanged: Int!
+  period: AnalyticsQueryPeriodEnum!
+  showViews: Int!
+
+  # Pageviews time series
+  timeSeries(
+    cumulative: Boolean = false
+  ): [AnalyticsPartnerStatsPageviewsTimeSeries!]
+  totalCount: Int!
+  uniqueVisitors: Int!
+}
+
+# Pageviews time series data of a partner
+type AnalyticsPartnerStatsPageviewsTimeSeries {
+  count: Int
+  endTime: AnalyticsDateTime
+  startTime: AnalyticsDateTime
 }
 
 # Partner Time Series Stats
@@ -11361,6 +11421,9 @@ type Query {
     # Returns only viewing rooms with these statuses
     statuses: [ViewingRoomStatusEnum!] = [live]
   ): ViewingRoomsConnection
+
+  # Last updated timestamp
+  analyticsLastUpdatedAt: AnalyticsDateTime
 
   # Find PartnerStats
   analyticsPartnerStats(partnerId: String!): AnalyticsPartnerStats

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -181,6 +181,8 @@ type AnalyticsPartnerInquiryCountTimeSeriesStats {
 # Inquiry stats of a partner
 type AnalyticsPartnerInquiryStats {
   inquiryCount: Int!
+
+  # Inquiry response time in seconds
   inquiryResponseTime: Int
   partnerId: String!
   period: AnalyticsQueryPeriodEnum!
@@ -194,6 +196,8 @@ type AnalyticsPartnerInquiryStats {
 # Sales stats of a partner
 type AnalyticsPartnerSalesStats {
   orderCount: Int!
+
+  # Order response time in seconds
   orderResponseTime: Int
   partnerId: String!
   period: AnalyticsQueryPeriodEnum!
@@ -230,9 +234,17 @@ type AnalyticsPartnerSalesTimeSeriesStats {
 # Partner Stats
 type AnalyticsPartnerStats {
   # Time series data on number of artworks published
+  artworkPublished(
+    period: AnalyticsQueryPeriodEnum!
+  ): AnalyticsPartnerStatsArtworksPublished
+
+  # Time series data on number of artworks published
   artworksPublished(
     period: AnalyticsQueryPeriodEnum!
   ): AnalyticsArtworksPublishedStats
+    @deprecated(
+      reason: "Use artworkPublished for refactored time series bucket code"
+    )
 
   # Audience stats
   audience(period: AnalyticsQueryPeriodEnum!): AnalyticsPartnerAudienceStats
@@ -259,7 +271,11 @@ type AnalyticsPartnerStats {
   inquiry(period: AnalyticsQueryPeriodEnum!): AnalyticsPartnerInquiryStats
 
   # Different types of partner pageviews
+  pageview(period: AnalyticsQueryPeriodEnum!): AnalyticsPartnerStatsPageviews
+
+  # Different types of partner pageviews
   pageviews(period: AnalyticsQueryPeriodEnum!): AnalyticsPageviewStats
+    @deprecated(reason: "Use pageview for refactored time series bucket code")
   partnerId: String!
 
   # Artworks, shows, or artists ranked by views. Capped at 20 by the underlying sql query.
@@ -301,6 +317,50 @@ type AnalyticsPartnerStats {
   # Number of unique visitors
   uniqueVisitors(period: AnalyticsQueryPeriodEnum!): Int
     @deprecated(reason: "Use audience() { uniqueVisitors } instead")
+}
+
+# Publish artwork Series Stats
+type AnalyticsPartnerStatsArtworksPublished {
+  partnerId: String!
+  percentageChanged: Int!
+  period: AnalyticsQueryPeriodEnum!
+
+  # Partner artworks published count time series
+  timeSeries(
+    cumulative: Boolean = false
+  ): [AnalyticsPartnerStatsArtworksPublishedTimeSeries!]!
+  totalCount: Int!
+}
+
+# Artworks published time series data of a partner
+type AnalyticsPartnerStatsArtworksPublishedTimeSeries {
+  count: Int
+  endTime: AnalyticsDateTime
+  startTime: AnalyticsDateTime
+}
+
+# Stats for pageviews of partner content
+type AnalyticsPartnerStatsPageviews {
+  artworkViews: Int!
+  galleryViews: Int!
+  partnerId: String!
+  percentageChanged: Int!
+  period: AnalyticsQueryPeriodEnum!
+  showViews: Int!
+
+  # Pageviews time series
+  timeSeries(
+    cumulative: Boolean = false
+  ): [AnalyticsPartnerStatsPageviewsTimeSeries!]
+  totalCount: Int!
+  uniqueVisitors: Int!
+}
+
+# Pageviews time series data of a partner
+type AnalyticsPartnerStatsPageviewsTimeSeries {
+  count: Int
+  endTime: AnalyticsDateTime
+  startTime: AnalyticsDateTime
 }
 
 # Partner Time Series Stats
@@ -8115,6 +8175,9 @@ type Query {
     # Returns only viewing rooms with these statuses
     statuses: [ViewingRoomStatusEnum!] = [live]
   ): ViewingRoomsConnection
+
+  # Last updated timestamp
+  analyticsLastUpdatedAt: AnalyticsDateTime
 
   # Find PartnerStats
   analyticsPartnerStats(partnerId: String!): AnalyticsPartnerStats

--- a/src/data/vortex.graphql
+++ b/src/data/vortex.graphql
@@ -189,6 +189,10 @@ Inquiry stats of a partner
 """
 type PartnerInquiryStats {
   inquiryCount: Int!
+
+  """
+  Inquiry response time in seconds
+  """
   inquiryResponseTime: Int
   partnerId: String!
   period: QueryPeriodEnum!
@@ -204,6 +208,10 @@ Sales stats of a partner
 """
 type PartnerSalesStats {
   orderCount: Int!
+
+  """
+  Order response time in seconds
+  """
   orderResponseTime: Int
   partnerId: String!
   period: QueryPeriodEnum!
@@ -232,7 +240,15 @@ type PartnerStats {
   """
   Time series data on number of artworks published
   """
+  artworkPublished(period: QueryPeriodEnum!): PartnerStatsArtworksPublished
+
+  """
+  Time series data on number of artworks published
+  """
   artworksPublished(period: QueryPeriodEnum!): ArtworksPublishedStats
+    @deprecated(
+      reason: "Use artworkPublished for refactored time series bucket code"
+    )
 
   """
   Audience stats
@@ -275,7 +291,13 @@ type PartnerStats {
   """
   Different types of partner pageviews
   """
+  pageview(period: QueryPeriodEnum!): PartnerStatsPageviews
+
+  """
+  Different types of partner pageviews
+  """
   pageviews(period: QueryPeriodEnum!): PageviewStats
+    @deprecated(reason: "Use pageview for refactored time series bucket code")
   partnerId: String!
 
   """
@@ -341,6 +363,60 @@ type PartnerStats {
   """
   uniqueVisitors(period: QueryPeriodEnum!): Int
     @deprecated(reason: "Use audience() { uniqueVisitors } instead")
+}
+
+"""
+Publish artwork Series Stats
+"""
+type PartnerStatsArtworksPublished {
+  partnerId: String!
+  percentageChanged: Int!
+  period: QueryPeriodEnum!
+
+  """
+  Partner artworks published count time series
+  """
+  timeSeries(
+    cumulative: Boolean = false
+  ): [PartnerStatsArtworksPublishedTimeSeries!]!
+  totalCount: Int!
+}
+
+"""
+Artworks published time series data of a partner
+"""
+type PartnerStatsArtworksPublishedTimeSeries {
+  count: Int
+  endTime: DateTime
+  startTime: DateTime
+}
+
+"""
+Stats for pageviews of partner content
+"""
+type PartnerStatsPageviews {
+  artworkViews: Int!
+  galleryViews: Int!
+  partnerId: String!
+  percentageChanged: Int!
+  period: QueryPeriodEnum!
+  showViews: Int!
+
+  """
+  Pageviews time series
+  """
+  timeSeries(cumulative: Boolean = false): [PartnerStatsPageviewsTimeSeries!]
+  totalCount: Int!
+  uniqueVisitors: Int!
+}
+
+"""
+Pageviews time series data of a partner
+"""
+type PartnerStatsPageviewsTimeSeries {
+  count: Int
+  endTime: DateTime
+  startTime: DateTime
 }
 
 """
@@ -483,6 +559,11 @@ enum PricingContextDimensionEnum {
 }
 
 type Query {
+  """
+  Last updated timestamp
+  """
+  lastUpdatedAt: DateTime
+
   """
   Find PartnerStats
   """


### PR DESCRIPTION
Bump MP schema for new field in vortex. It looks like it's been awhile since vortex's schema has been updated, but all of the changes are additions of new fields, deprecation reasons, or comments.

Relevant code for lastUpdatedAt all the way at the bottom!