### PR TITLE
fix: disable inquiryQuestions for non inquirable artworks

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -1265,7 +1265,7 @@ describe("Artwork type", () => {
     it("returns available inquiry questions if an artwork is not inquirable", () => {
       const context = {
         artworkLoader: () => {
-          return Promise.resolve({ id: "blah", inquireable: true })
+          return Promise.resolve({ id: "blah", sale_ids: ["sale_id"] })
         },
         inquiryRequestQuestionsLoader: () => {
           return Promise.reject()
@@ -1280,7 +1280,7 @@ describe("Artwork type", () => {
     it("returns inquiry questions if an artwork is inquirable", () => {
       const context = {
         artworkLoader: () => {
-          return Promise.resolve({ id: "blah", inquireable: false })
+          return Promise.resolve({ id: "blah", sale_ids: [] })
         },
         inquiryRequestQuestionsLoader: () => {
           return Promise.resolve([

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -1262,10 +1262,25 @@ describe("Artwork type", () => {
         }
       `
 
-    it("returns available inquiry questions", () => {
+    it("returns available inquiry questions if an artwork is not inquirable", () => {
       const context = {
         artworkLoader: () => {
-          return Promise.resolve({ id: "blah" })
+          return Promise.resolve({ id: "blah", inquireable: true })
+        },
+        inquiryRequestQuestionsLoader: () => {
+          return Promise.reject()
+        },
+      }
+
+      return runQuery(query, context).then((data) => {
+        expect(data.artwork.inquiryQuestions).toEqual([])
+      })
+    })
+
+    it("returns inquiry questions if an artwork is inquirable", () => {
+      const context = {
+        artworkLoader: () => {
+          return Promise.resolve({ id: "blah", inquireable: false })
         },
         inquiryRequestQuestionsLoader: () => {
           return Promise.resolve([

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -340,12 +340,12 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         description:
           "Structured questions a collector can inquire on about this work",
         resolve: (
-          { inquireable, id },
+          { sale_ids, id },
           _params,
           { inquiryRequestQuestionsLoader }
         ) => {
           // Sale artworks are not inquirable
-          if (!inquireable) {
+          if (!sale_ids.length) {
             return inquiryRequestQuestionsLoader({
               inquireable_id: id,
               inquireable_type: "Artwork",

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -339,11 +339,19 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: new GraphQLList(InquiryQuestionType),
         description:
           "Structured questions a collector can inquire on about this work",
-        resolve: ({ id }, _params, { inquiryRequestQuestionsLoader }) => {
-          return inquiryRequestQuestionsLoader({
-            inquireable_id: id,
-            inquireable_type: "Artwork",
-          })
+        resolve: (
+          { inquireable, id },
+          _params,
+          { inquiryRequestQuestionsLoader }
+        ) => {
+          // Sale artworks are not inquirable
+          if (!inquireable) {
+            return inquiryRequestQuestionsLoader({
+              inquireable_id: id,
+              inquireable_type: "Artwork",
+            })
+          }
+          return []
         },
       },
       inventoryId: {


### PR DESCRIPTION
The type of this PR is: **Chore**

This PR resolves [CX-704]

### Description

- Check if an artwork (sale artwork) is inquirable before calling the gravity loader.

**PS: the artwork used in the picture below is from an auction**
<img width="1711" alt="Group 2 (2)" src="https://user-images.githubusercontent.com/11945712/97030381-f7986180-155e-11eb-9c64-b1693953ee0a.png">

<img width="1792" alt="Screenshot 2020-10-26 at 11 28 31" src="https://user-images.githubusercontent.com/11945712/97162238-360c6700-177f-11eb-851a-cbb10e26ddc7.png">



[CX-704]: https://artsyproduct.atlassian.net/browse/CX-704

Issue: https://artsyproduct.atlassian.net/browse/CX-746

Co-authored-by: David Sheldrick <djsheldrick@gmail.com>