### PR TITLE
Adds Fair#isVisible field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5482,6 +5482,10 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
   # Are we currently in the fair's active period?
   isActive: Boolean
   isPublished: Boolean
+
+  # All fairs have profiles. If the profile 403s, then the entire fair shouldn't
+  # be publicly visible on the frontend. This is only "enforced" on the frontend.
+  isVisible: Boolean!
   kawsCollectionSlugs: [String]!
   links(format: Format): String
   location: Location

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -215,6 +215,28 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLBoolean,
         resolve: ({ published }) => published,
       },
+      isVisible: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        description: `All fairs have profiles. If the profile 403s, then the entire fair shouldn't be publicly visible on the frontend. This is only "enforced" on the frontend.`,
+        resolve: async (
+          { default_profile_id, organizer },
+          _options,
+          { profileLoader }
+        ) => {
+          const id = default_profile_id ?? organizer?.profile_id
+
+          if (!id) {
+            return false
+          }
+
+          try {
+            await profileLoader(id)
+            return true
+          } catch {
+            return false
+          }
+        },
+      },
       location: {
         type: LocationType,
         resolve: ({ id, location, published }, options, { fairLoader }) => {


### PR DESCRIPTION
Re: [FX-2395](https://artsyproduct.atlassian.net/browse/FX-2395)

So draft because I have no idea if this makes any sense at all.

* We have a `Fair#published` flag, which according to Waves: "should basically always be checked". OK. (What happens if it's not?)
* **All** fairs (?) have a profile, if they have a profile it might be `private`. We have an `isPubliclyVisible` field which resolves to `profile && profile.published && !profile.private`, except if you're not an admin, this 403s. If you are an admin, then by default, if you can see the profile, it's "visible".
* We should maybe check this in the root fair resolver and return `null`, but it's unclear if that will break anything else.
* `Fair#organizer#profile` isn't relevant — or is it? What about if that profile is private?
* In general, it seems like Gravity should control all visibility and the API should just not return the fair if the profile is private? If so should we add that to the `Fair#published` scope?

![](http://static.damonzucconi.com/_capture/OplzFVlzA7hc.png)