### PR TITLE
fix: replace docker-compose extends keyword with Jinja2 template

### DIFF
--- a/hokusai/build.yml
+++ b/hokusai/build.yml
@@ -2,5 +2,4 @@
 version: '2'
 services:
   metaphysics:
-    build:
-      context: ../
+{% include 'templates/docker-compose-service.yml.j2' %}

--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -1,9 +1,7 @@
 version: "2"
 services:
   metaphysics:
-    extends:
-      file: build.yml
-      service: metaphysics
+{% include 'templates/docker-compose-service.yml.j2' %}
     environment:
       - MEMCACHED_URL=metaphysics-memcached:11211
     env_file:

--- a/hokusai/templates/docker-compose-service.yml.j2
+++ b/hokusai/templates/docker-compose-service.yml.j2
@@ -1,0 +1,2 @@
+    build:
+      context: ../

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -2,9 +2,7 @@ version: "2"
 services:
   metaphysics:
     command: env NODE_OPTIONS=--max_old_space_size=4096 yarn ci
-    extends:
-      file: build.yml
-      service: metaphysics
+{% include 'templates/docker-compose-service.yml.j2' %}
     environment:
       - MEMCACHED_URL=metaphysics-memcached:11211
       - CI_PULL_REQUEST=$CI_PULL_REQUEST


### PR DESCRIPTION
Required for Docker Compose v3 / Hokusai >= v0.5.12 compatibility