### PR TITLE
feat: stitch in money-typed price fields in AuctionsLotState type (PURCHASE-2171)

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3048,7 +3048,10 @@ type AuctionsLotStanding implements AuctionsNode {
   leadingBidAmount: AuctionsMoney!
 
   # whether this user has the leading bid
-  lotState: AuctionsLotState!
+  lot: AuctionsLotState!
+
+  # whether this user has the leading bid
+  lotState: AuctionsLotState! @deprecated(reason: "prefer `lot`")
   rawId: String!
   saleArtwork: SaleArtwork
 }
@@ -3071,13 +3074,14 @@ type AuctionsLotStandingEdge {
   node: AuctionsLotStanding!
 }
 
-# A lot in a sale
+# The state of a lot
 type AuctionsLotState {
   # total number of bids placed on the lot
   bidCount: Int!
+  floorSellingPrice: Money
 
-  # selling price on the live auction floor
-  floorSellingPrice: AuctionsMoney
+  # selling price, in minor unit, on the live auction floor
+  floorSellingPriceCents: Long
 
   # The bidder currently winning the online portion of the auction
   floorWinningBidder: AuctionsBidder
@@ -3087,9 +3091,10 @@ type AuctionsLotState {
 
   # The Gravity Lot ID.
   internalID: ID!
+  onlineAskingPrice: Money
 
-  # asking price for online bidders
-  onlineAskingPrice: AuctionsMoney!
+  # asking price, in minor unit, for online bidders
+  onlineAskingPriceCents: Long!
 
   # The bidder currently winning the online portion of the auction
   onlineSellingToBidder: AuctionsBidder
@@ -3195,7 +3200,7 @@ enum AuctionsReserveStatus {
   ReserveNotMet
 }
 
-# A collection of lots.
+# The state of a sale
 type AuctionsSaleState {
   # Users not allowed to participate in the sale
   bannedUsers: [AuctionsUser!]!
@@ -3206,7 +3211,7 @@ type AuctionsSaleState {
   # The Gravity Sale ID.
   id: ID!
 
-  # The Gravity Lot ID.
+  # The Gravity Sale ID.
   internalID: ID!
 
   # Lot ids that had an Artsy bid that was the highest bid on the lot but did not win

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1840,7 +1840,10 @@ type AuctionsLotStanding implements AuctionsNode {
   leadingBidAmount: AuctionsMoney!
 
   # whether this user has the leading bid
-  lotState: AuctionsLotState!
+  lot: AuctionsLotState!
+
+  # whether this user has the leading bid
+  lotState: AuctionsLotState! @deprecated(reason: "prefer `lot`")
   rawId: String!
   saleArtwork: SaleArtwork
 }
@@ -1863,13 +1866,14 @@ type AuctionsLotStandingEdge {
   node: AuctionsLotStanding!
 }
 
-# A lot in a sale
+# The state of a lot
 type AuctionsLotState {
   # total number of bids placed on the lot
   bidCount: Int!
+  floorSellingPrice: Money
 
-  # selling price on the live auction floor
-  floorSellingPrice: AuctionsMoney
+  # selling price, in minor unit, on the live auction floor
+  floorSellingPriceCents: Long
 
   # The bidder currently winning the online portion of the auction
   floorWinningBidder: AuctionsBidder
@@ -1879,9 +1883,10 @@ type AuctionsLotState {
 
   # The Gravity Lot ID.
   internalID: ID!
+  onlineAskingPrice: Money
 
-  # asking price for online bidders
-  onlineAskingPrice: AuctionsMoney!
+  # asking price, in minor unit, for online bidders
+  onlineAskingPriceCents: Long!
 
   # The bidder currently winning the online portion of the auction
   onlineSellingToBidder: AuctionsBidder
@@ -1987,7 +1992,7 @@ enum AuctionsReserveStatus {
   ReserveNotMet
 }
 
-# A collection of lots.
+# The state of a sale
 type AuctionsSaleState {
   # Users not allowed to participate in the sale
   bannedUsers: [AuctionsUser!]!
@@ -1998,7 +2003,7 @@ type AuctionsSaleState {
   # The Gravity Sale ID.
   id: ID!
 
-  # The Gravity Lot ID.
+  # The Gravity Sale ID.
   internalID: ID!
 
   # Lot ids that had an Artsy bid that was the highest bid on the lot but did not win

--- a/src/data/causality.graphql
+++ b/src/data/causality.graphql
@@ -59,7 +59,7 @@ type IncrementPolicySubgroup {
   revisions: [IncrementPolicy!]!
 }
 
-"A lot in a sale"
+"The state of a lot"
 type Lot {
   "The Gravity Lot ID."
   id: ID!
@@ -73,14 +73,14 @@ type Lot {
   "total number of bids placed on the lot"
   bidCount: Int!
 
-  "selling price on the live auction floor"
-  floorSellingPrice: Money
+  "selling price, in minor unit, on the live auction floor"
+  floorSellingPriceCents: Long
 
   "The bidder currently winning the online portion of the auction"
   floorWinningBidder: Bidder
 
-  "asking price for online bidders"
-  onlineAskingPrice: Money!
+  "asking price, in minor unit, for online bidders"
+  onlineAskingPriceCents: Long!
 
   "The bidder currently winning the online portion of the auction"
   onlineSellingToBidder: Bidder
@@ -105,7 +105,10 @@ type LotStanding implements Node {
   isHighestBidder: Boolean!
 
   "whether this user has the leading bid"
-  lotState: Lot!
+  lotState: Lot! @deprecated(reason: "prefer `lot`")
+
+  "whether this user has the leading bid"
+  lot: Lot!
 }
 
 "A connection to a list of items."
@@ -151,7 +154,7 @@ type Mutation {
   addIncrementPolicy(
     newIncrementPolicy: NewIncrementPolicyInput!
   ): IncrementPolicy
-  addSale(id: ID!): Sale
+  addSale(id: String!): Sale
   banUserFromSale(saleId: ID!, userId: ID!): Sale
   unbanUserFromSale(userId: ID!, saleId: ID!): Sale
 }
@@ -233,7 +236,7 @@ type Query {
   ): LotStandingConnection!
 
   "Returns an increment policy with specific `id`."
-  incrementPolicy(id: ID!): IncrementPolicy
+  incrementPolicy(id: String!): IncrementPolicy
 
   "Previews a draft of a new increment policy."
   previewIncrementPolicy(
@@ -247,10 +250,13 @@ type Query {
   incrementPolicyGroups: [IncrementPolicyGroup!]!
 
   "Returns a lot with specific `id`."
-  lot(id: ID!): Lot
+  lot(id: String!): Lot
+
+  "Returns a list of lots"
+  lots(ids: [String!]!): [Lot!]!
 
   "Returns a sale with specific `id`."
-  sale(id: ID!): Sale
+  sale(id: String!): Sale
 
   "Fetches an object given its ID"
   node("The ID of an object" id: ID!): Node
@@ -265,7 +271,7 @@ enum ReserveStatus {
   ReserveNotMet
 }
 
-"A collection of lots."
+"The state of a sale"
 type Sale {
   "Users not allowed to participate in the sale"
   bannedUsers: [User!]!
@@ -276,7 +282,7 @@ type Sale {
   "The Gravity Sale ID."
   id: ID!
 
-  "The Gravity Lot ID."
+  "The Gravity Sale ID."
   internalID: ID!
 
   "The lots belonging to this sale."

--- a/src/integration/__tests__/__fixtures__/knownV2Failures.json
+++ b/src/integration/__tests__/__fixtures__/knownV2Failures.json
@@ -948,5 +948,12 @@
   "ebb240b91abb54dde55e46da86a0a885": null,
   "acf634b76c571c63c354f9203e7757f1": null,
   "e435b0066fae9cdb0cddd2146c1e383f": null,
-  "810fe4219c35f8c1198fcbd6bdbed29e": null
+  "810fe4219c35f8c1198fcbd6bdbed29e": null,
+  "042c99463b706a2a8a35d4b0a5337c71": null,
+  "7114b24c69da6fdf8a952cc998dded17": null,
+  "5feb6d845487b8b8d696e0cce082eb2b": null,
+  "491575e8d9b9f682de1cb678fd351c4b": null,
+  "e089beca2667c383e7e2c99c42e8750f": null,
+  "bd37ef982226143b0d68d972b5fee276": null,
+  "5d6a47112815cab926fb8f2036b94039": null
 }

--- a/src/lib/stitching/causality/__tests__/stitching.test.ts
+++ b/src/lib/stitching/causality/__tests__/stitching.test.ts
@@ -22,6 +22,58 @@ describe("causality/stitching", () => {
     })
   })
 
+  describe("AuctionsLotState", () => {
+    it("extends the AuctionsLotState type with a floorSellingPrice field", async () => {
+      const { getFields } = await useCausalityStitching()
+      expect(await getFields("AuctionsLotState")).toContain("floorSellingPrice")
+    })
+
+    it("extends the AuctionsLotState type with a onlineAskingPrice field", async () => {
+      const { getFields } = await useCausalityStitching()
+      expect(await getFields("AuctionsLotState")).toContain("onlineAskingPrice")
+    })
+
+    it("resolves floorSellingPrice field as a Money type", async () => {
+      const { resolvers } = await useCausalityStitching()
+      const saleArtworkRootLoader = jest.fn(() => {
+        return { currency: "USD" }
+      })
+      const floorSellingPrice = await resolvers.AuctionsLotState.floorSellingPrice.resolve(
+        { internalID: "123", floorSellingPriceCents: 10000 },
+        {},
+        { saleArtworkRootLoader },
+        {}
+      )
+
+      expect(floorSellingPrice).toEqual({
+        major: 100,
+        minor: 10000,
+        currencyCode: "USD",
+        display: "$100.00",
+      })
+    })
+
+    it("resolves onlineAskingPrice field as a Money type", async () => {
+      const { resolvers } = await useCausalityStitching()
+      const saleArtworkRootLoader = jest.fn(() => {
+        return { currency: "JPY" }
+      })
+      const onlineAskingPrice = await resolvers.AuctionsLotState.onlineAskingPrice.resolve(
+        { internalID: "123", onlineAskingPriceCents: 10000 },
+        {},
+        { saleArtworkRootLoader },
+        {}
+      )
+
+      expect(onlineAskingPrice).toEqual({
+        major: 10000,
+        minor: 10000,
+        currencyCode: "JPY",
+        display: "¥10,000.00",
+      })
+    })
+  })
+
   it("resolves a SaleArtwork on an AuctionsLotStanding", async () => {
     const allMergedSchemas = await incrementalMergeSchemas(schema, 1)
 

--- a/src/lib/stitching/causality/__tests__/testingUtils.ts
+++ b/src/lib/stitching/causality/__tests__/testingUtils.ts
@@ -32,7 +32,7 @@ export async function useCausalityStitching() {
 }
 
 /**
- * The following is used for internal setup, initializing convection's schema /
+ * The following is used for internal setup, initializing causality's schema /
  * stitching environment and then caching the results.
  */
 
@@ -41,7 +41,7 @@ let stitchedSchema: ReturnType<typeof causalityStitchingEnvironment>
 let mergedSchema: GraphQLSchema & { transforms: any }
 
 /**
- * Gets a cached copy of the transformed convection schema
+ * Gets a cached copy of the transformed causality schema
  */
 const getCausalityTransformedSchema = async () => {
   if (!cachedSchema) {
@@ -66,7 +66,7 @@ const getCausalityStitchedSchema = async () => {
 }
 
 /**
- * Gets a cached fully setup schema with convection and the localSchema
+ * Gets a cached fully setup schema with causality and the localSchema
  */
 const getCausalityMergedSchema = async () => {
   if (!stitchedSchema) {


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PURCHASE-2171

This stitches in `floorSellingPrice` and `onlineAskingPrice` fields in `AcutionsLotState` type, and uses the recommended Metaphysics `Money` type. The field names were removed in https://github.com/artsy/causality/pull/852 so we can reuse them here.

Migration steps:

- [x] (artsy/causality#848) Add the new raw cents fields (e.g. `floorSellingPriceCents`) and deprecate the Causality `Money` type fields (e.g. `floorSellingPrice`).
- [x] (https://github.com/artsy/ohm/pull/707) Migrate Ohm to use the new cents fields.
- [x] (https://github.com/artsy/causality/pull/852) Remove the Causality `Money` type fields (e.g. `floorSellingPrice`).
- [x] (This PR) Update MP to stitch in MP `Money` type fields.
- [ ] Update Eigen to use the new fields.

![Screen Shot 2020-11-30 at 10 06 18 PM](https://user-images.githubusercontent.com/796573/100692540-14436880-3359-11eb-9cdc-979df46e27f9.png)
