### PR TITLE
Ensure we don't try to parse details if they don't exist

### DIFF
--- a/src/schema/v2/me/conversation/submit_inquiry_request_mutation.ts
+++ b/src/schema/v2/me/conversation/submit_inquiry_request_mutation.ts
@@ -116,7 +116,7 @@ export const submitInquiryRequestMutation = mutationWithClientMutationId<
         (question) => question.questionID === "shipping_quote"
       )
       let inquiryShippingLocation
-      if (locationQuestion) {
+      if (locationQuestion && locationQuestion.details) {
         try {
           inquiryShippingLocation = JSON.parse(locationQuestion.details)
         } catch (e) {


### PR DESCRIPTION
Tiny bug fix that we noticed when reviewing some of the functionality of the inquiry request mutation. 