### PR TITLE
fix: protect against lots that don't have a realized price

### DIFF
--- a/src/schema/v2/__tests__/auction_results.test.js
+++ b/src/schema/v2/__tests__/auction_results.test.js
@@ -263,4 +263,84 @@ describe("Artist type", () => {
       })
     })
   })
+
+  describe("priceRealized", () => {
+    function givenAnAuctionResultResponseWith(specs) {
+      context.auctionLotLoader = jest
+        .fn()
+        .mockReturnValueOnce(Promise.resolve(auctionResultResponse(specs)))
+    }
+
+    const query = `
+      {
+        artist(id: "percy-z") {
+          auctionResultsConnection(recordsTrusted: true, first: 1) {
+            edges {
+              node {
+                priceRealized {
+                  display(format: "0a")
+                  cents
+                  centsUSD
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+
+    it("returns 0 for all priceRealized fields when price is 0", () => {
+      givenAnAuctionResultResponseWith({
+        price_realized_cents: 0,
+        price_realized_cents_usd: 0,
+      })
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toMatchObject({
+          artist: {
+            auctionResultsConnection: {
+              edges: [
+                {
+                  node: {
+                    priceRealized: {
+                      display: "JPY ¥0",
+                      cents: 0,
+                      centsUSD: 0,
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        })
+      })
+    })
+
+    it("returns null for all priceRealized fields when price is undefined", () => {
+      givenAnAuctionResultResponseWith({
+        price_realized_cents: undefined,
+        price_realized_cents_usd: undefined,
+      })
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toMatchObject({
+          artist: {
+            auctionResultsConnection: {
+              edges: [
+                {
+                  node: {
+                    priceRealized: {
+                      display: null,
+                      cents: null,
+                      centsUSD: null,
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        })
+      })
+    })
+  })
 })

--- a/src/schema/v2/auction_result.ts
+++ b/src/schema/v2/auction_result.ts
@@ -9,7 +9,7 @@ import {
   GraphQLEnumType,
   GraphQLBoolean,
 } from "graphql"
-import { indexOf } from "lodash"
+import { indexOf, isNil } from "lodash"
 import { connectionWithCursorInfo } from "schema/v2/fields/pagination"
 import Image, { normalizeImageData } from "schema/v2/image"
 import { ResolverContext } from "types/graphql"
@@ -212,6 +212,10 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
               },
             },
             resolve: ({ currency, price_realized_cents }, { format }) => {
+              if (isNil(price_realized_cents)) {
+                return null
+              }
+
               const { symbol, subunit_to_unit } = currencyCodes[
                 currency.toLowerCase()
               ]


### PR DESCRIPTION
(CX-761) https://artsyproduct.atlassian.net/browse/CX-761

With changes to the diffusion collectoriq import, lots can now have a null `realized_price`. This was resulting in force displaying `$NaN` for some newly imported lots. 

This PR adds a guard to the function that resolves the `display` property of the `realizedPrice`. MP will return `null` instead of `$NaN` when there is no realized price. On force's end, a null `priceRealized.display` will be treated as if the realized price was 0.

Note that I've verified that force has the appropriate check to handle null values from here properly. [It determines which property to use here](https://github.com/artsy/force/blob/9ae2d6722d189d1313ae2f423e43cbbecd392601/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx#L297), and then [it renders the appropriate message here](https://github.com/artsy/force/blob/9ae2d6722d189d1313ae2f423e43cbbecd392601/src/v2/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultItem.tsx#L355).