### PR TITLE
remove SlugAndInternalIDFields from sale.buyersPremium

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2204,16 +2204,7 @@ type BuyersPremium {
     thousand: String = ","
   ): String
   cents: Int
-
-  # A globally unique ID.
-  id: ID!
-
-  # A type-specific ID likely used as a database ID.
-  internalID: ID!
   percent: Float
-
-  # A slug ID.
-  slug: ID!
 }
 
 type CalculatedCost {

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -61,7 +61,6 @@ const BidIncrement = new GraphQLObjectType<any, ResolverContext>({
 const BuyersPremium = new GraphQLObjectType<any, ResolverContext>({
   name: "BuyersPremium",
   fields: {
-    ...SlugAndInternalIDFields,
     amount: amount(({ cents }) => cents),
     cents: {
       type: GraphQLInt,


### PR DESCRIPTION
Because it will alway be null. The current implementation returns an array, not an object.

related Slack discussion: 

https://artsy.slack.com/archives/CP9P4KR35/p1604430180080000

Without this change, the relay-generated queries in Eigen will fail with 

> Cannot return null for non-nullable field BuyersPremium.id


