### PR TITLE
feat: Update remaining My Collection apis

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -181,7 +181,7 @@ export default (accessToken, userID, opts) => {
       { method: "GET" }
     ),
     createArtworkLoader: gravityLoader("artwork", {}, { method: "POST" }),
-    myCollectionCreateImageLoader: gravityLoader(
+    createArtworkImageLoader: gravityLoader(
       (id) => `artwork/${id}/image`,
       {},
       { method: "POST" }

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -167,11 +167,6 @@ export default (accessToken, userID, opts) => {
     ),
     meLoader: gravityLoader("me"),
     mePartnersLoader: gravityLoader("me/partners"),
-    myCollectionArtworksLoader: gravityLoader(
-      "my-collection/artworks",
-      {},
-      { headers: true }
-    ),
     createArtworkLoader: gravityLoader("artwork", {}, { method: "POST" }),
     createArtworkImageLoader: gravityLoader(
       (id) => `artwork/${id}/image`,

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -172,14 +172,6 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
-    myCollectionArtworkLoader: gravityLoader(
-      (id) => `my-collection/artworks/${id}`,
-      {
-        user_id: userID,
-        private: true,
-      },
-      { method: "GET" }
-    ),
     createArtworkLoader: gravityLoader("artwork", {}, { method: "POST" }),
     createArtworkImageLoader: gravityLoader(
       (id) => `artwork/${id}/image`,

--- a/src/schema/v2/me/__tests__/myCollection.test.ts
+++ b/src/schema/v2/me/__tests__/myCollection.test.ts
@@ -23,7 +23,7 @@ describe("me.myCollection", () => {
         Promise.resolve({
           id: "some-user-id",
         }),
-      myCollectionArtworksLoader: () =>
+      collectionArtworksLoader: () =>
         Promise.resolve({
           body: [
             {

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -57,7 +57,7 @@ const computeMutationInput = (externalImageUrls: string[] = []): string => {
 
 const defaultContext = {
   createArtworkLoader,
-  myCollectionArtworkLoader: artworkLoader,
+  artworkLoader: artworkLoader,
   createArtworkImageLoader: createImageLoader,
 }
 

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -58,7 +58,7 @@ const computeMutationInput = (externalImageUrls: string[] = []): string => {
 const defaultContext = {
   createArtworkLoader,
   myCollectionArtworkLoader: artworkLoader,
-  myCollectionCreateImageLoader: createImageLoader,
+  createArtworkImageLoader: createImageLoader,
 }
 
 describe("myCollectionCreateArtworkMutation", () => {
@@ -141,7 +141,7 @@ describe("myCollectionCreateArtworkMutation", () => {
 
       const context = {
         ...defaultContext,
-        myCollectionCreateImageLoader: failureLoader,
+        createArtworkImageLoader: failureLoader,
       }
 
       const data = await runAuthenticatedQuery(mutation, context)

--- a/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
@@ -57,7 +57,7 @@ const computeMutationInput = (externalImageUrls: string[] = []): string => {
 
 const defaultContext = {
   updateArtworkLoader,
-  myCollectionArtworkLoader: artworkLoader,
+  artworkLoader: artworkLoader,
   createArtworkImageLoader: createImageLoader,
 }
 

--- a/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
@@ -58,7 +58,7 @@ const computeMutationInput = (externalImageUrls: string[] = []): string => {
 const defaultContext = {
   updateArtworkLoader,
   myCollectionArtworkLoader: artworkLoader,
-  myCollectionCreateImageLoader: createImageLoader,
+  createArtworkImageLoader: createImageLoader,
 }
 
 describe("myCollectionUpdateArtworkMutation", () => {
@@ -141,7 +141,7 @@ describe("myCollectionUpdateArtworkMutation", () => {
 
       const context = {
         ...defaultContext,
-        myCollectionCreateImageLoader: failureLoader,
+        createArtworkImageLoader: failureLoader,
       }
 
       const data = await runAuthenticatedQuery(mutation, context)

--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -112,19 +112,19 @@ const MyCollectionArtworkMutationSuccessType = new GraphQLObjectType<
   fields: () => ({
     artwork: {
       type: ArtworkType,
-      resolve: ({ id }, _, { myCollectionArtworkLoader }) => {
-        if (myCollectionArtworkLoader) {
-          return myCollectionArtworkLoader(id)
+      resolve: ({ id }, _, { artworkLoader }) => {
+        if (artworkLoader) {
+          return artworkLoader(id)
         }
       },
     },
     artworkEdge: {
       type: MyCollectionEdgeType,
-      resolve: async ({ id }, _, { myCollectionArtworkLoader }) => {
-        if (!myCollectionArtworkLoader) {
+      resolve: async ({ id }, _, { artworkLoader }) => {
+        if (!artworkLoader) {
           return null
         }
-        const artwork = await myCollectionArtworkLoader(id)
+        const artwork = await artworkLoader(id)
         const edge = {
           cursor: cursorForObjectInConnection([artwork], artwork),
           node: artwork,

--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -68,8 +68,8 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
       }),
     },
   }),
-  resolve: ({ id: userId }, options, { myCollectionArtworksLoader }) => {
-    if (!myCollectionArtworksLoader) {
+  resolve: ({ id: userId }, options, { collectionArtworksLoader }) => {
+    if (!collectionArtworksLoader) {
       return null
     }
     const gravityOptions = Object.assign(
@@ -80,7 +80,7 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
     // This can't also be used with the offset in gravity
     delete gravityOptions.page
 
-    return myCollectionArtworksLoader(gravityOptions)
+    return collectionArtworksLoader("my-collection", gravityOptions)
       .then(({ body, headers }) => {
         return connectionFromArraySlice(body, options, {
           arrayLength: parseInt(headers["x-total-count"] || "0", 10),

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -94,9 +94,9 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
       externalImageUrls = [],
       ...rest
     },
-    { createArtworkLoader, myCollectionCreateImageLoader }
+    { createArtworkLoader, createArtworkImageLoader }
   ) => {
-    if (!createArtworkLoader || !myCollectionCreateImageLoader) {
+    if (!createArtworkLoader || !createArtworkImageLoader) {
       return new Error("You need to be signed in to perform this action")
     }
 
@@ -114,7 +114,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
       const artworkId = response.id
       const imageSources = computeImageSources(externalImageUrls)
       const createImagePromises = imageSources.map((source) => {
-        return myCollectionCreateImageLoader(artworkId, source)
+        return createArtworkImageLoader(artworkId, source)
       })
 
       await Promise.all(createImagePromises)

--- a/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
@@ -76,9 +76,9 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
       externalImageUrls = [],
       ...rest
     },
-    { updateArtworkLoader, myCollectionCreateImageLoader }
+    { updateArtworkLoader, createArtworkImageLoader }
   ) => {
-    if (!updateArtworkLoader || !myCollectionCreateImageLoader) {
+    if (!updateArtworkLoader || !createArtworkImageLoader) {
       return new Error("You need to be signed in to perform this action")
     }
 
@@ -95,7 +95,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
       const imageSources = computeImageSources(externalImageUrls)
 
       const createImagePromises = imageSources.map((source) => {
-        return myCollectionCreateImageLoader(artworkId, source)
+        return createArtworkImageLoader(artworkId, source)
       })
 
       await Promise.all(createImagePromises)


### PR DESCRIPTION
Ok I think this is the last one! I've been on a quest to retire all the My Collection-specific endpoints in favor of leveraging existing Gravity endpoints and unless I'm missing something I believe this wraps it. What this PR does is clean up the artwork image loader, switch calls to use the existing artwork loader and then updates the loader for drawing the list of artworks to use the existing collection artworks loader. It's a lot but I broke it into a commit for each thing.

To ensure this doesn't break anything, I booted MP locally with these changes and then pointed my simulator at it. I verified the My Collection interactions and saw that things were working.

https://artsyproduct.atlassian.net/browse/GRO-70

/cc @artsy/grow-devs @artsy/collector-experience