### PR TITLE
fix: use symbol for sale.buyersPremium not currency

### DIFF
--- a/src/schema/v2/sale/__tests__/index.test.ts
+++ b/src/schema/v2/sale/__tests__/index.test.ts
@@ -15,7 +15,7 @@ describe("Sale type", () => {
     id: "foo-foo",
     _id: "123",
     collect_payments: true,
-    currency: "$",
+    currency: "USD",
     is_artsy_licensed: false,
     is_auction: true,
     is_preliminary: false,

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -151,7 +151,7 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
 
           return map(sale.buyers_premium.schedule, (item: any) => ({
             cents: item.min_amount_cents,
-            symbol: sale.currency,
+            symbol: sale.symbol,
             percent: item.percent,
           }))
         },


### PR DESCRIPTION
Metaphysics is returning this:

```json
{
  "data": {
    "sale": {
      "isWithBuyersPremium": true,
      "buyersPremium": [
        {
          "amount": "USD0",
          "percent": 0.25
        },
        {
          "amount": "USD250,000",
          "percent": 0.2
        },
        {
          "amount": "USD4,000,000",
          "percent": 0.125
        }
      ]
    }
  }
```

when it should be returning:

```json
{
  "data": {
    "sale": {
      "isWithBuyersPremium": true,
      "buyersPremium": [
        {
          "amount": "$0",
          "percent": 0.25
        },
        {
          "amount": "$250,000",
          "percent": 0.2
        },
        {
          "amount": "$4,000,000",
          "percent": 0.125
        }
      ]
    }
  }