### PR TITLE
feat: allow totalCount to be requested for fair booths connection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5494,6 +5494,7 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
 
     # Sorts for shows in a fair
     sort: ShowSorts
+    totalCount: Boolean = false
   ): ShowConnection
 
   # A slug ID.

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -259,6 +259,10 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
             type: ShowSorts,
             description: "Sorts for shows in a fair",
           },
+          totalCount: {
+            type: GraphQLBoolean,
+            defaultValue: false,
+          },
         }),
         resolve: ({ id }, options, { fairBoothsLoader }) => {
           interface GravityOptions {
@@ -267,12 +271,14 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
             cursor?: string
             section: string
             artworks: boolean
+            total_count: boolean
           }
           const gravityOptions: GravityOptions = {
             sort: options.sort || "-featured",
             section: options.section,
             size: options.first,
             artworks: true,
+            total_count: !!options.totalCount,
           }
           if (!!options.after) {
             gravityOptions.cursor = options.after


### PR DESCRIPTION
Allows this param to thread through to the Gravity endpoint (needed as part of https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=FX&modal=detail&selectedIssue=FX-2389)