### PR TITLE
fix: don't suppress all myCollectionArtwork errors

### DIFF
--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -90,11 +90,15 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
       .catch((error) => {
         console.error("[schema/v2/me/my_collection] Error:", error)
 
-        // For some users with no items, Gravity produces an error of
-        // "Collection Not Found". This can cause the Gravity endpoint to
-        // produce a 404, so we will intercept the error and return an empty
-        // list instead.
-        return connectionFromArray([], options)
+        if (error.message == "Collection Not Found") {
+          // For some users with no items, Gravity produces an error of
+          // "Collection Not Found". This can cause the Gravity endpoint to
+          // produce a 404, so we will intercept the error and return an empty
+          // list instead.
+          return connectionFromArray([], options)
+        } else {
+          throw error
+        }
       })
   },
 }


### PR DESCRIPTION
I was looking into why myCollection calls were failing in Eigen and saw an error in gravity logs for an improper sort type that wasn't showing up in metaphysics. It looks like we were suppressing all errors because the myCollectionArtwork loader in some circumstances can return a 404 when a user does not have a collection. This PR instead checks for that particular error and throws for all other errors for hopefully a bit easier debugging. 