### PR TITLE
fix: return descriptions for viewing rooms

### DIFF
--- a/src/schema/v2/SearchableItem/SearchableItemPresenter.ts
+++ b/src/schema/v2/SearchableItem/SearchableItemPresenter.ts
@@ -34,7 +34,7 @@ export class SearchableItemPresenter {
         return `Browse current exhibitions in ${display}`
       case "Collection":
       case "ArtistSeries":
-      case "ViewingRoom":
+      case "Viewing Room":
         return stripTags(description)
       default:
         return undefined

--- a/src/schema/v2/SearchableItem/__tests__/SearchableItemPresenter.test.ts
+++ b/src/schema/v2/SearchableItem/__tests__/SearchableItemPresenter.test.ts
@@ -342,6 +342,22 @@ describe("SearchableItemPresenter", () => {
         )
       })
     })
+
+    describe("for a ViewingRoom type", () => {
+      it("returns a formatted description for a past show", () => {
+        const searchableItem = {
+          ...BASE_ITEM,
+          label: "ViewingRoom",
+          description: "A pretty neat viewing room with some sweet artworks",
+        }
+
+        const presenter = new SearchableItemPresenter(searchableItem)
+        const description = presenter.formattedDescription()
+        expect(description).toBe(
+          "A pretty neat viewing room with some sweet artworks"
+        )
+      })
+    })
   })
 
   describe("#imageUrl", () => {


### PR DESCRIPTION
Because of a missing space in the `case` statement, we weren't returning descriptions for viewing rooms in calls to Metaphysics. Fixes the issue and adds a test for it! 

More context here: https://github.com/artsy/gravity/pull/13596#issuecomment-724387229