### PR TITLE
chore: Remove collector info from lastMessage and clean up code

### DIFF
--- a/src/schema/v2/me/__tests__/conversation/__snapshots__/conversation.test.js.snap
+++ b/src/schema/v2/me/__tests__/conversation/__snapshots__/conversation.test.js.snap
@@ -47,7 +47,7 @@ Object {
     },
     "initialMessage": "Loved some of the works at your fair booth!",
     "internalID": "420",
-    "lastMessage": "Cool snippet",
+    "lastMessage": "Loved some of the works at your fair booth!",
     "messages": Object {
       "edges": Array [
         Object {

--- a/src/schema/v2/me/__tests__/conversation/conversation.test.js
+++ b/src/schema/v2/me/__tests__/conversation/conversation.test.js
@@ -7,15 +7,16 @@ describe("Me", () => {
       conversationLoader: () => {
         return Promise.resolve({
           id: "420",
-          initial_message:
-            "Buncha secret stuff Message from Percy:\n\nLoved some of the works at your fair booth!",
+          initial_message: "Loved some of the works at your fair booth!",
           from_email: "collector@example.com",
           from_name: "Percy",
           _embedded: {
             last_message: {
-              snippet: "Cool snippet About this collector: Percy is a good cat",
+              snippet:
+                "Loved some of the works at your fair booth! About this collector: Percy is a good cat",
               from_email_address: "other-collector@example.com",
               id: "25",
+              order: 1,
             },
           },
           from_last_viewed_message_id: "20",

--- a/src/schema/v2/me/conversation/index.ts
+++ b/src/schema/v2/me/conversation/index.ts
@@ -266,20 +266,20 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
       deprecationReason:
         "This field is no longer required. Prefer the first message from the MessageConnection.",
       type: new GraphQLNonNull(GraphQLString),
-      resolve: ({ initial_message, from_name }) => {
+      resolve: ({ initial_message }) => {
         if (!initial_message) return ""
-        const parts = initial_message.split(
-          "Message from " + from_name + ":\n\n"
-        )
-        return parts[parts.length - 1]
+        return initial_message
       },
     },
     lastMessage: {
       type: GraphQLString,
       description: "This is a snippet of text from the last message.",
-      resolve: ({ _embedded = {} }) => {
+      resolve: ({ initial_message, _embedded = {} }) => {
         const lastMessage = _embedded.last_message || {}
-        return lastMessage.snippet.split("About this collector")[0].trim()
+        if (lastMessage.order == 1) {
+          return initial_message
+        }
+        return lastMessage.snippet
       },
     },
     lastMessageAt: date,

--- a/src/schema/v2/me/conversation/message.ts
+++ b/src/schema/v2/me/conversation/message.ts
@@ -93,7 +93,6 @@ export const MessageType = new GraphQLObjectType<any, ResolverContext>({
       resolve: ({
         body,
         original_text,
-        conversation_from_name,
         conversation_initial_message,
         is_first_message,
       }) => {
@@ -101,10 +100,7 @@ export const MessageType = new GraphQLObjectType<any, ResolverContext>({
           if (!conversation_initial_message) {
             return null
           }
-          const parts = conversation_initial_message.split(
-            "Message from " + conversation_from_name + ":\n\n"
-          )
-          return parts[parts.length - 1]
+          return conversation_initial_message
         }
         if (original_text) {
           return original_text


### PR DESCRIPTION
[PURCHASE-2211]

Information about the collector meant for the gallery was appended to the `lastMessage` and was thus being displayed to the user in the inbox. This PR resolves `lastMessage` to `initial_message` (which has no collector info) if the last message is the only message. Paired with @zephraph 

Before:

<img width="528" alt="Screen Shot 2020-11-13 at 3 59 14 PM" src="https://user-images.githubusercontent.com/5643895/99122221-ef669b80-25cb-11eb-8e4b-afc8e8b28895.png">

After:

<img width="504" alt="Screen Shot 2020-11-13 at 3 58 43 PM" src="https://user-images.githubusercontent.com/5643895/99122240-f4c3e600-25cb-11eb-9d7e-0762738c7e56.png">


[PURCHASE-2211]: https://artsyproduct.atlassian.net/browse/PURCHASE-2211