### PR TITLE
fix: return all non draft viewing rooms stitched under a show

### DIFF
--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -545,7 +545,10 @@ describe("gravity/stitching", () => {
       )
 
       expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
-        args: { ids: ["view-lots-of-cats-id"] },
+        args: {
+          ids: ["view-lots-of-cats-id"],
+          statuses: ["scheduled", "live", "closed"],
+        },
         operation: "query",
         fieldName: "_unused_gravity_viewingRoomsConnection",
         schema: expect.anything(),

--- a/src/lib/stitching/gravity/stitching.ts
+++ b/src/lib/stitching/gravity/stitching.ts
@@ -545,6 +545,7 @@ export const gravityStitchingEnvironment = (
               fieldName: "_unused_gravity_viewingRoomsConnection",
               args: {
                 ids,
+                statuses: ["scheduled", "live", "closed"],
               },
               context,
               info,


### PR DESCRIPTION
This should fix the crashing issue where shows linked to a viewing room that is not live, don't get returned. This is the proper set of `statuses` to be able to return all non-draft viewing rooms.