### PR TITLE
Feature: Expose additional price fields on artwork

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1379,8 +1379,8 @@ type Artwork implements Node & Searchable & Sellable {
     shallow: Boolean
   ): Partner
   pickupAvailable: Boolean
+  price: String
   priceCurrency: String
-  priceDisplay: String
   priceIncludesTax: Boolean
   priceIncludesTaxDisplay: String
   pricingContext: AnalyticsPricingContext

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1279,6 +1279,7 @@ type Artwork implements Node & Searchable & Sellable {
   description(format: Format): String
   dimensions: dimensions
   displayLabel: String
+  displayPriceRange: Boolean
   editionNumber: String
   editionOf: String
   editionSets(sort: EditionSetSorts): [EditionSet]
@@ -1379,6 +1380,7 @@ type Artwork implements Node & Searchable & Sellable {
   ): Partner
   pickupAvailable: Boolean
   priceCurrency: String
+  priceDisplay: String
   priceIncludesTax: Boolean
   priceIncludesTaxDisplay: String
   pricingContext: AnalyticsPricingContext

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -561,13 +561,13 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ pickup_available }) => pickup_available,
       },
       listPrice,
+      price: {
+        type: GraphQLString,
+        resolve: ({ price }) => price,
+      },
       priceCurrency: {
         type: GraphQLString,
         resolve: ({ price_currency }) => price_currency,
-      },
-      priceDisplay: {
-        type: GraphQLString,
-        resolve: ({ price }) => price,
       },
       priceIncludesTax: {
         type: GraphQLBoolean,

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -407,6 +407,10 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           return false
         },
       },
+      displayPriceRange: {
+        type: GraphQLBoolean,
+        resolve: ({ display_price_range }) => display_price_range,
+      },
       isBuyNowable: {
         type: GraphQLBoolean,
         description: "When in an auction, can the work be bought immediately",
@@ -560,6 +564,10 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       priceCurrency: {
         type: GraphQLString,
         resolve: ({ price_currency }) => price_currency,
+      },
+      priceDisplay: {
+        type: GraphQLString,
+        resolve: ({ price }) => price,
       },
       priceIncludesTax: {
         type: GraphQLBoolean,


### PR DESCRIPTION
This PR exposes `displayPriceRange` and `priceDisplay` on the artwork-level, which previously were not available.

These fields will be used to enable a user to make an offer on a work with a visible _price range_, but no exact list price.

As we intend to use the `priceDisplay` field to show users what the "List price" is when they are making an offer, it needs to always display the _price_, and not adjust to reconcile the artwork's _availability_, as the `saleMessage` does.

Note that we can include these fields on the `artwork` _or_ the `artworkVersion`. Here's my reasoning for putting it on `artwork`, but it is not a strong opinion and I look forward to others 😄:
- While the user is filling out the form, we explicitly validate that the artwork version is the same as when they started. So, for all intents and purposes, the artwork version should match the artwork for a successful order/offer to be submitted.
- After the initial submission, if the partner changes the price range (we _may_ actually have validation preventing this, I'm not sure), we can choose to either:
  - Display the price range from the original version (which might not match what's on the artwork view)
  - Display the price range from the artwork (which might not match the original one that the user used to offer on)
- Given the case in which users will _see_ this range is when they're accepting/rejecting an offer, it seems best to let them see the most up-to-date range vs. the original one.