### PR TITLE
add password to updateMeMutation input

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10516,6 +10516,9 @@ input UpdateMyProfileInput {
   # The given name of the user.
   name: String
 
+  # The user's password, required to change email address.
+  password: String
+
   # The given phone number of the user.
   phone: String
 

--- a/src/schema/v2/me/update_me_mutation.ts
+++ b/src/schema/v2/me/update_me_mutation.ts
@@ -122,6 +122,10 @@ export default mutationWithClientMutationId<any, any, ResolverContext>({
       description: "The given email of the user.",
       type: GraphQLString,
     },
+    password: {
+      description: "The user's password, required to change email address.",
+      type: GraphQLString,
+    },
     phone: {
       description: "The given phone number of the user.",
       type: GraphQLString,


### PR DESCRIPTION
Add `password` to allowed `input` fields for `updateMeMutation`.
Gravity will soon require a password for this mutation when changing user email addresses.

Follow up to #2845 and https://github.com/artsy/gravity/pull/13675