### PR TITLE
chore(fx-2514): enables jest eslint plugin

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,4 @@
 node_modules/*
 build/*
 scripts/*
-**/__tests__/*
+

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,12 +6,13 @@
     "jasmine": true,
     "es6": true
   },
-  "plugins": ["promise", "@typescript-eslint"],
+  "plugins": ["promise", "@typescript-eslint", "jest"],
   "extends": [
     "plugin:promise/recommended",
     "plugin:import/errors",
     "plugin:import/typescript",
-    "plugin:@typescript-eslint/recommended"
+    "plugin:@typescript-eslint/recommended",
+    "plugin:jest/recommended"
   ],
   "parser": "@typescript-eslint/parser",
   "rules": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,7 +38,18 @@
     ],
     "@typescript-eslint/no-use-before-define": 0,
     "@typescript-eslint/explicit-module-boundary-types": 0,
-    "prefer-const": ["error", { "ignoreReadBeforeAssign": true }]
+    "prefer-const": ["error", { "ignoreReadBeforeAssign": true }],
+    "jest/expect-expect": [
+      "warn",
+      {
+        "assertFunctionNames": [
+          "expect",
+          "expectPromiseRejectionToMatch",
+          "assertStatusSupported",
+          "assertInvalidStatusFails"
+        ]
+      }
+    ]
   },
   "globals": {
     "expect": false,

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "eslint": "6.7.2",
     "eslint-import-resolver-typescript": "2.0.0",
     "eslint-plugin-import": "2.18.2",
+    "eslint-plugin-jest": "^24.1.3",
     "eslint-plugin-promise": "4.0.1",
     "expect.js": "0.3.1",
     "husky": "3.1.0",

--- a/src/integration/__tests__/integration.test.ts
+++ b/src/integration/__tests__/integration.test.ts
@@ -13,7 +13,7 @@ describe("integration tests", () => {
     mockFetch.mockReset()
   })
 
-  it("It should bail for an unknown GET request", async () => {
+  it("should bail for an unknown GET request", async () => {
     const response = await request(app).get("/")
     expect(response.statusCode).toBe(400)
   })

--- a/src/integration/index.js
+++ b/src/integration/index.js
@@ -24,7 +24,7 @@ const staging = metaphysics(METAPHYSICS_STAGING_ENDPOINT)
 const production = metaphysics(METAPHYSICS_PRODUCTION_ENDPOINT)
 
 describe("Integration specs", () => {
-  xdescribe("/artwork", () => {
+  describe.skip("/artwork", () => {
     const query = `
       query artwork($id: String!) {
         artwork(id: $id) {

--- a/src/lib/__tests__/apis/fetch.test.ts
+++ b/src/lib/__tests__/apis/fetch.test.ts
@@ -7,7 +7,7 @@ import fetch from "../../apis/fetch"
 declare const expectPromiseRejectionToMatch: any
 
 it("tries to parse the response when there is a String and resolves with it", async () => {
-  let reqResponse = {
+  const reqResponse = {
     statusCode: 200,
     body: `{ "foo": "bar" }`,
   }
@@ -29,8 +29,8 @@ it("rejects request errors", async () => {
   expectPromiseRejectionToMatch(fetch("foo/bar"), /bad/)
 })
 
-it("tries to parse the response when there is a String and resolves with it", async () => {
-  let reqResponse = {
+it("tries to parse the response when there is a String and resolves with it (2)", async () => {
+  const reqResponse = {
     statusCode: 200,
     body: `{ not json }`,
   }
@@ -42,8 +42,8 @@ it("tries to parse the response when there is a String and resolves with it", as
   return expectPromiseRejectionToMatch(fetch("foo/bar"), /Unexpected token/)
 })
 
-it("tries to parse the response when there is a String and resolves with it", (done) => {
-  let reqResponse = {
+it("tries to parse the response when there is a String and resolves with it (3)", () => {
+  const reqResponse = {
     statusCode: 400,
     request: {
       uri: {
@@ -57,7 +57,9 @@ it("tries to parse the response when there is a String and resolves with it", (d
     callback(null, reqResponse)
   )
 
-  fetch("foo/bar").catch((error) => {
+  expect.assertions(3)
+
+  return fetch("foo/bar").catch((error) => {
     expect(error.message).toEqual(
       `http://api.artsy.net/api/v1/me - { "type": "other_error", "message": "undefined method \`[]' for nil:NilClass" }`
     )
@@ -65,6 +67,5 @@ it("tries to parse the response when there is a String and resolves with it", (d
     expect(error.body).toEqual(
       `{ "type": "other_error", "message": "undefined method \`[]' for nil:NilClass" }`
     )
-    done()
   })
 })

--- a/src/lib/__tests__/date.test.ts
+++ b/src/lib/__tests__/date.test.ts
@@ -15,7 +15,7 @@ import {
 } from "lib/date"
 
 describe("date formatting", () => {
-  describe(timeRange, () => {
+  describe("timeRange", () => {
     it("includes only one am or pm if within same am/pm", () => {
       const period = timeRange(
         "2022-12-30T08:00:00+00:00",
@@ -44,7 +44,7 @@ describe("date formatting", () => {
     })
   })
 
-  describe(datesAreSameDay, () => {
+  describe("datesAreSameDay", () => {
     it("returns true if dates are the same day", () => {
       const period = datesAreSameDay(
         "2022-12-30T20:00:00+00:00",
@@ -82,7 +82,7 @@ describe("date formatting", () => {
     })
   })
 
-  describe(formattedStartDateTime, () => {
+  describe("formattedStartDateTime", () => {
     const realNow = Date.now
     beforeEach(() => {
       Date.now = () => new Date("2018-01-30T03:24:00") as any
@@ -121,7 +121,7 @@ describe("date formatting", () => {
       expect(period).toBe("Ended Dec 30, 2016")
     })
 
-    it("includes 'Starts' when event starts in the future", () => {
+    it("includes 'Starts' when event starts in the future (2)", () => {
       const period = formattedStartDateTime(
         "2045-12-05T20:00:00+00:00",
         "2050-12-30T17:00:00+00:00",
@@ -148,7 +148,7 @@ describe("date formatting", () => {
     })
   })
 
-  describe(formattedOpeningHours, () => {
+  describe("formattedOpeningHours", () => {
     const realNow = Date.now
     beforeEach(() => {
       Date.now = () => new Date("2018-01-30T03:24:00") as any
@@ -185,7 +185,7 @@ describe("date formatting", () => {
     })
   })
 
-  describe(singleTime, () => {
+  describe("singleTime", () => {
     it("includes hour using default UTC timezone", () => {
       const period = singleTime("2018-12-05T20:00:00+00:00", "UTC")
       expect(period).toBe("8:00pm UTC")
@@ -197,7 +197,7 @@ describe("date formatting", () => {
     })
   })
 
-  describe(singleDateTime, () => {
+  describe("singleDateTime", () => {
     const realNow = Date.now
     beforeEach(() => {
       Date.now = () => new Date("2018-01-30T03:24:00") as any
@@ -225,7 +225,7 @@ describe("date formatting", () => {
     })
   })
 
-  describe(singleDate, () => {
+  describe("singleDate", () => {
     const realNow = Date.now
     beforeEach(() => {
       Date.now = () => new Date("2018-01-30T03:24:00") as any
@@ -245,7 +245,7 @@ describe("date formatting", () => {
     })
   })
 
-  describe(singleDateWithDay, () => {
+  describe("singleDateWithDay", () => {
     const realNow = Date.now
     beforeEach(() => {
       Date.now = () => new Date("2018-01-30T03:24:00") as any
@@ -265,7 +265,7 @@ describe("date formatting", () => {
     })
   })
 
-  describe(dateTimeRange, () => {
+  describe("dateTimeRange", () => {
     const realNow = Date.now
     beforeEach(() => {
       Date.now = () => new Date("2018-01-30T03:24:00") as any
@@ -391,7 +391,7 @@ describe("date formatting", () => {
     })
   })
 
-  describe(dateRange, () => {
+  describe("dateRange", () => {
     it("includes month day and both years when years are different years", () => {
       const period = dateRange("2011-01-01", "2014-04-19", "UTC")
       expect(period).toBe("Jan 1, 2011 – Apr 19, 2014")
@@ -422,7 +422,7 @@ describe("date formatting", () => {
     })
   })
 
-  describe(exhibitionStatus, () => {
+  describe("exhibitionStatus", () => {
     let today: Moment = null as any
 
     beforeEach(() => {

--- a/src/lib/__tests__/deprecate.test.ts
+++ b/src/lib/__tests__/deprecate.test.ts
@@ -2,7 +2,7 @@ import { deprecate, shouldBeRemoved, deprecateType } from "../deprecation"
 import { GraphQLObjectType, GraphQLString } from "graphql"
 
 describe("deprecation", () => {
-  describe(deprecate, () => {
+  describe("deprecate", () => {
     it("generates a deprecation reason that encodes the version from whence the field will be removed", () => {
       expect(
         deprecate({ inVersion: 2, preferUsageOf: "foo" })
@@ -18,7 +18,7 @@ describe("deprecation", () => {
     })
   })
 
-  describe(deprecateType, () => {
+  describe("deprecateType", () => {
     it("marks all fields of a type as deprecated", () => {
       const type = deprecateType(
         { inVersion: 2, preferUsageOf: "AnotherType" },
@@ -77,7 +77,7 @@ describe("deprecation", () => {
     })
   })
 
-  describe(shouldBeRemoved, () => {
+  describe("shouldBeRemoved", () => {
     it("should not be removed if there is no deprecation reason", () => {
       expect(
         shouldBeRemoved({

--- a/src/lib/__tests__/errorHandler.test.ts
+++ b/src/lib/__tests__/errorHandler.test.ts
@@ -2,8 +2,14 @@ import { errorHandler } from "lib/errorHandler"
 import { IpDeniedError } from "express-ipfilter"
 
 describe("errorHandler", () => {
-  const statusMock = jest.fn().mockReturnValueOnce({ end: () => {} })
+  const statusMock = jest.fn().mockReturnValueOnce({
+    end: () => {
+      // noop
+    },
+  })
+
   const res = { status: statusMock } as any
+
   it("returns a 401 for an IpDenied error", () => {
     errorHandler(
       new IpDeniedError("denied"),
@@ -13,6 +19,7 @@ describe("errorHandler", () => {
     )
     expect(statusMock).toBeCalledWith(401)
   })
+
   it("calls next otherwise", () => {
     const next = jest.fn()
     errorHandler(new Error("error"), jest.fn() as any, res, next)

--- a/src/lib/__tests__/getPrincipalFieldDirectivePath.test.ts
+++ b/src/lib/__tests__/getPrincipalFieldDirectivePath.test.ts
@@ -3,7 +3,7 @@ import { Source, parse } from "graphql"
 
 const queryToAst = (query) => parse(new Source(query))
 
-describe(getPrincipalFieldDirectivePath, () => {
+describe("getPrincipalFieldDirectivePath", () => {
   it("returns an empty array when the directive is not used", () => {
     const query = `
       {

--- a/src/lib/__tests__/graphqlErrorHandler.test.ts
+++ b/src/lib/__tests__/graphqlErrorHandler.test.ts
@@ -9,7 +9,7 @@ import config from "config"
 import { ServerError } from "apollo-link-http-common"
 
 describe("graphqlErrorHandler", () => {
-  describe(shouldReportError, () => {
+  describe("shouldReportError", () => {
     it("reports when the error is null", () => {
       expect(shouldReportError(null)).toBeTruthy()
     })
@@ -59,7 +59,7 @@ describe("graphqlErrorHandler", () => {
     })
   })
 
-  describe(formattedGraphQLError, () => {
+  describe("formattedGraphQLError", () => {
     describe("stack traces", () => {
       it("are not present in production", () => {
         config.PRODUCTION_ENV = true

--- a/src/lib/__tests__/graphqlTimeoutMiddleware.test.ts
+++ b/src/lib/__tests__/graphqlTimeoutMiddleware.test.ts
@@ -58,7 +58,7 @@ describe("graphQLTimeoutMiddleware", () => {
   })
 
   describe("timeoutForField", () => {
-    function timeoutField(timeout: object | null) {
+    function timeoutField(timeout: Record<string, unknown> | null) {
       const args =
         timeout &&
         Object.keys(timeout)
@@ -80,17 +80,17 @@ describe("graphQLTimeoutMiddleware", () => {
       expect(timeoutForField(timeoutField(null))).toEqual(null)
     })
 
-    xit("returns the specified timeout", () => {
+    it.skip("returns the specified timeout", () => {
       expect(timeoutForField(timeoutField({ ms: 42 }))).toEqual(42)
     })
 
-    xit("throws an error if the directive is specified but no ms argument is given", () => {
+    it.skip("throws an error if the directive is specified but no ms argument is given", () => {
       expect(() => timeoutForField(timeoutField({ sec: 42 }))).toThrowError(
         /argument is required/
       )
     })
 
-    xit("throws an error if the directive is specified but no integer argument is given", () => {
+    it.skip("throws an error if the directive is specified but no integer argument is given", () => {
       expect(() => timeoutForField(timeoutField({ ms: `"42"` }))).toThrowError(
         /Expected.+IntValue.+got.+StringValue/
       )

--- a/src/lib/__tests__/modifyOldEigenQueries.test.ts
+++ b/src/lib/__tests__/modifyOldEigenQueries.test.ts
@@ -1,5 +1,4 @@
 import {
-  nameOldEigenQueries,
   rewriteEcommerceMutations,
   shouldRewriteEcommerceMutations,
   shouldAddQueryToMutations,
@@ -8,7 +7,7 @@ import gql from "lib/gql"
 
 let beforeOffer: string
 let beforeOrder: string
-let savedArtworksQuery = gql`
+const savedArtworksQuery = gql`
   {
     me {
       saved_artworks {
@@ -23,7 +22,7 @@ let savedArtworksQuery = gql`
   }
 `
 
-describe(nameOldEigenQueries, () => {
+describe("nameOldEigenQueries", () => {
   beforeAll(() => {
     beforeOffer = gql`
       mutation createOfferOrder($artworkId: String!, $quantity: Int) {
@@ -122,13 +121,13 @@ describe(nameOldEigenQueries, () => {
   })
 })
 
-describe(shouldRewriteEcommerceMutations, () => {
+describe("shouldRewriteEcommerceMutations", () => {
   it("shoud re-write", () => {
     expect(shouldRewriteEcommerceMutations(beforeOffer)).toBeTruthy()
   })
 })
 
-describe(shouldAddQueryToMutations, () => {
+describe("shouldAddQueryToMutations", () => {
   it("doesn't do it on an offer mutation", () => {
     expect(shouldAddQueryToMutations(beforeOffer)).toBeFalsy()
   })

--- a/src/lib/loaders/__tests__/api.test.ts
+++ b/src/lib/loaders/__tests__/api.test.ts
@@ -109,6 +109,7 @@ describe("API loaders", () => {
           })
           .catch(() => {
             // swallow the error, because this is the expected code-path
+            expect(true).toBe(true)
           })
       })
     })
@@ -143,6 +144,7 @@ describe("API loaders", () => {
           })
           .catch(() => {
             // swallow the error, because this is the expected code-path
+            expect(true).toBe(true)
           })
       })
     })

--- a/src/lib/loaders/__tests__/batchLoader.test.ts
+++ b/src/lib/loaders/__tests__/batchLoader.test.ts
@@ -13,14 +13,18 @@ describe("batchLoader", () => {
     })
 
     it("should return a single loader if one is provided", () => {
-      const singleLoader = () => {}
+      const singleLoader = () => {
+        // noop
+      }
       expect(batchLoader({ singleLoader, multipleLoader: null })).toBe(
         singleLoader
       )
     })
 
     it("should return a multipleLoader if no singleLoader provided", () => {
-      const multipleLoader = () => {}
+      const multipleLoader = () => {
+        // noop
+      }
       expect(batchLoader({ multipleLoader })).toBe(multipleLoader)
     })
   })

--- a/src/lib/stitching/convection/__tests__/link.test.ts
+++ b/src/lib/stitching/convection/__tests__/link.test.ts
@@ -19,8 +19,8 @@ const runLinkChain = (link, op, complete) =>
   link.request(op).subscribe({ complete })
 
 // FIXME: This seems to be hitting the actual network and thus fails without it.
-xdescribe("convection link", () => {
-  it("passes request ID headers to the fetch", (done) => {
+describe.skip("convection link", () => {
+  it("passes request ID headers to the fetch", () => {
     expect.assertions(1)
 
     const link = createConvectionLink()
@@ -37,7 +37,7 @@ xdescribe("convection link", () => {
       getContext: () => defaultContext,
     }
 
-    runLinkChain(link, op, () => {
+    return runLinkChain(link, op, () => {
       expect(op.setContext).toBeCalledWith({
         headers: {
           "x-request-id": "req123",
@@ -45,12 +45,11 @@ xdescribe("convection link", () => {
           "x-datadog-trace-id": "trace123",
         },
       })
-      done()
     })
   })
 
   describe("when authenticated", () => {
-    it("also gravity auth HTTP headers to the fetch", (done) => {
+    it("also gravity auth HTTP headers to the fetch", () => {
       expect.assertions(1)
 
       // The difference here is that locals will now include a dataloader named convectionTokenLoader
@@ -70,7 +69,7 @@ xdescribe("convection link", () => {
         getContext: () => defaultContext,
       }
 
-      runLinkChain(link, op, () => {
+      return runLinkChain(link, op, () => {
         expect(op.setContext).toBeCalledWith({
           headers: {
             Authorization: "Bearer token_123",
@@ -79,7 +78,6 @@ xdescribe("convection link", () => {
             "x-datadog-trace-id": "trace123",
           },
         })
-        done()
       })
     })
   })

--- a/src/lib/stitching/exchange/__tests__/link.test.ts
+++ b/src/lib/stitching/exchange/__tests__/link.test.ts
@@ -19,8 +19,8 @@ const runLinkChain = (link, op, complete) =>
   link.request(op).subscribe({ complete })
 
 // FIXME: This seems to be hitting the actual network and thus fails without it.
-xdescribe("exchange link", () => {
-  it("passes request ID headers to the fetch", (done) => {
+describe.skip("exchange link", () => {
+  it("passes request ID headers to the fetch", () => {
     expect.assertions(1)
 
     const link = createExchangeLink()
@@ -37,7 +37,7 @@ xdescribe("exchange link", () => {
       getContext: () => defaultContext,
     }
 
-    runLinkChain(link, op, () => {
+    return runLinkChain(link, op, () => {
       expect(op.setContext).toBeCalledWith({
         headers: {
           "x-request-id": "req123",
@@ -45,12 +45,11 @@ xdescribe("exchange link", () => {
           "x-datadog-trace-id": "trace123",
         },
       })
-      done()
     })
   })
 
   describe("when authenticated", () => {
-    it("also gravity auth HTTP headers to the fetch", (done) => {
+    it("also gravity auth HTTP headers to the fetch", () => {
       expect.assertions(1)
 
       // The difference here is that locals will now include a dataloader named exchangeTokenLoader
@@ -69,7 +68,7 @@ xdescribe("exchange link", () => {
         setContext: jest.fn(),
         getContext: () => defaultContext,
       }
-      runLinkChain(link, op, () => {
+      return runLinkChain(link, op, () => {
         expect(op.setContext).toBeCalledWith({
           headers: {
             Authorization: "Bearer token_123",
@@ -78,7 +77,6 @@ xdescribe("exchange link", () => {
             "x-datadog-trace-id": "trace123",
           },
         })
-        done()
       })
     })
   })

--- a/src/lib/stitching/exchange/__tests__/replaceComerceDateTime.test.ts
+++ b/src/lib/stitching/exchange/__tests__/replaceComerceDateTime.test.ts
@@ -29,7 +29,7 @@ const schema = transformSchema(originalSchema, [
   new ReplaceCommerceDateTimeType(),
 ])
 
-describe(ReplaceCommerceDateTimeType, () => {
+describe("ReplaceCommerceDateTimeType", () => {
   it("replaces CommerceDateTime fields", async () => {
     const data = await runQueryOrThrow({
       schema,

--- a/src/lib/stitching/exchange/__tests__/stitching.test.ts
+++ b/src/lib/stitching/exchange/__tests__/stitching.test.ts
@@ -70,7 +70,7 @@ describe("when handling resolver delegation", () => {
     })
   })
 
-  it("calls a user or partner when looking up party details ", async () => {
+  it("calls a user or partner when looking up party details", async () => {
     const { resolvers } = await getExchangeStitchedSchema()
     const { buyerDetails } = resolvers.CommerceBuyOrder
     const info = { mergeInfo: { delegateToSchema: jest.fn() } }

--- a/src/lib/stitching/vortex/__tests__/pricingContext.test.ts
+++ b/src/lib/stitching/vortex/__tests__/pricingContext.test.ts
@@ -233,7 +233,7 @@ describe("PricingContext type", () => {
     expect(result.artwork.pricingContext).toBeNull()
   })
 
-  it("it works when the user is not authenticated", async () => {
+  it("works when the user is not authenticated", async () => {
     const { meLoader, ...others } = context
     const result = (await runQuery(query, others)) as any
     expect(result).toMatchInlineSnapshot(`

--- a/src/lib/stitching/vortex/__tests__/pricingContextv1.test.ts
+++ b/src/lib/stitching/vortex/__tests__/pricingContextv1.test.ts
@@ -233,7 +233,7 @@ describe("PricingContext type", () => {
     expect(result.artwork.pricingContext).toBeNull()
   })
 
-  it("it works when the user is not authenticated", async () => {
+  it("works when the user is not authenticated", async () => {
     const { meLoader, ...others } = context
     const result = (await runQuery(query, others)) as any
     expect(result).toMatchInlineSnapshot(`

--- a/src/schema/v1/SearchableItem/__tests__/SearchableItemPresenter.test.ts
+++ b/src/schema/v1/SearchableItem/__tests__/SearchableItemPresenter.test.ts
@@ -155,12 +155,12 @@ describe("SearchableItemPresenter", () => {
       })
 
       it("prefers live_start_at to start_at date", () => {
-        let presenter = new SearchableItemPresenter({
+        const presenter = new SearchableItemPresenter({
           ...buildSearchableItem("Auction"),
           live_start_at: "2018-05-30T12:00:00.000Z",
           end_at: "",
         })
-        let description = presenter.formattedDescription()
+        const description = presenter.formattedDescription()
 
         expect(description).toBe("Sale opening May 30th, 2018 (at 8:00am EDT)")
       })

--- a/src/schema/v1/__tests__/city.test.ts
+++ b/src/schema/v1/__tests__/city.test.ts
@@ -38,7 +38,7 @@ describe("City", () => {
   })
 
   describe("finding by slug", () => {
-    it("finds a city by its slug", () => {
+    it("finds a city by its slug", async () => {
       const query = gql`
         {
           city(slug: "sacramende-ca-usa") {
@@ -47,15 +47,15 @@ describe("City", () => {
         }
       `
 
-      return runQuery(query).then((result) => {
-        expect(result!.city).toEqual({
-          name: "Sacramende",
-        })
+      const result = await runQuery(query)
+      expect(result!.city).toEqual({
+        name: "Sacramende",
       })
     })
 
-    it("returns a helpful error for unknown slugs", () => {
+    it("returns a helpful error for unknown slugs", async () => {
       expect.assertions(1)
+
       const query = gql`
         {
           city(slug: "sacramundo") {
@@ -63,14 +63,15 @@ describe("City", () => {
           }
         }
       `
-      return runQuery(query).catch((e) =>
-        expect(e.message).toMatch(/City sacramundo not found in:/)
+
+      await expect(runQuery(query)).rejects.toThrow(
+        /City sacramundo not found in:/
       )
     })
   })
 
   describe("finding by lat/lng", () => {
-    it("finds the city nearest to a supplied point", () => {
+    it("finds the city nearest to a supplied point", async () => {
       const pointNearSmallville = "{ lat: 40, lng: -100 }"
       const query = `
         {
@@ -80,14 +81,13 @@ describe("City", () => {
         }
       `
 
-      return runQuery(query).then((result) => {
-        expect(result!.city).toEqual({
-          name: "Smallville",
-        })
+      const result = await runQuery(query)
+      expect(result!.city).toEqual({
+        name: "Smallville",
       })
     })
 
-    it("returns null if no cities are within a defined threshold", () => {
+    it("returns null if no cities are within a defined threshold", async () => {
       const veryRemotePoint = "{ lat: 90, lng: 0 }"
       const query = gql`
         {
@@ -97,9 +97,8 @@ describe("City", () => {
         }
       `
 
-      return runQuery(query).then((result) => {
-        expect(result!.city).toBeNull()
-      })
+      const result = await runQuery(query)
+      expect(result!.city).toBeNull()
     })
   })
 
@@ -133,26 +132,24 @@ describe("City", () => {
       }
     })
 
-    it("resolves nearby shows", () => {
-      return runQuery(query, context).then((result) => {
-        expect(result!.city).toEqual({
-          name: "Sacramende",
-          shows: {
-            edges: [
-              {
-                node: mockShows[0],
-              },
-            ],
-          },
-        })
-
-        expect(mockShowsLoader).toHaveBeenCalledWith(
-          expect.objectContaining({
-            near: "38.5,-121.8",
-            total_count: true,
-          })
-        )
+    it("resolves nearby shows", async () => {
+      const result = await runQuery(query, context)
+      expect(result!.city).toEqual({
+        name: "Sacramende",
+        shows: {
+          edges: [
+            {
+              node: mockShows[0],
+            },
+          ],
+        },
       })
+      expect(mockShowsLoader).toHaveBeenCalledWith(
+        expect.objectContaining({
+          near: "38.5,-121.8",
+          total_count: true,
+        })
+      )
     })
 
     it("requests displayable shows, by default", async () => {
@@ -387,7 +384,7 @@ describe("City", () => {
       }
     })
 
-    it("resolves nearby fairs", () => {
+    it("resolves nearby fairs", async () => {
       const query = gql`
         {
           city(slug: "sacramende-ca-usa") {
@@ -403,21 +400,19 @@ describe("City", () => {
         }
       `
 
-      return runQuery(query, context).then((result) => {
-        expect(result!.city).toEqual({
-          name: "Sacramende",
-          fairs: {
-            edges: [{ node: { id: "first-fair" } }],
-          },
-        })
-
-        expect(mockFairsLoader).toHaveBeenCalledWith(
-          expect.objectContaining({
-            near: "38.5,-121.8",
-            total_count: true,
-          })
-        )
+      const result = await runQuery(query, context)
+      expect(result!.city).toEqual({
+        name: "Sacramende",
+        fairs: {
+          edges: [{ node: { id: "first-fair" } }],
+        },
       })
+      expect(mockFairsLoader).toHaveBeenCalledWith(
+        expect.objectContaining({
+          near: "38.5,-121.8",
+          total_count: true,
+        })
+      )
     })
 
     it("can request all shows [that match other filter parameters]", async () => {

--- a/src/schema/v1/__tests__/ecommerce/buyer_accept_offer_mutation.test.ts
+++ b/src/schema/v1/__tests__/ecommerce/buyer_accept_offer_mutation.test.ts
@@ -29,7 +29,7 @@ describe("BuyerAcceptOffer Mutation", () => {
     }
   `
 
-  it("accepts the seller offer", () => {
+  it("accepts the seller offer", async () => {
     const resolvers = {
       Mutation: {
         buyerAcceptOffer: () => ({
@@ -40,14 +40,14 @@ describe("BuyerAcceptOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceBuyerAcceptOffer.orderOrError.order).toEqual(
-        sampleOrder()
-      )
-    })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceBuyerAcceptOffer.orderOrError.order).toEqual(
+      sampleOrder()
+    )
   })
 
-  it("returns an error if there is one", () => {
+  it("returns an error if there is one", async () => {
     const resolvers = {
       Mutation: {
         buyerAcceptOffer: () => ({
@@ -63,12 +63,12 @@ describe("BuyerAcceptOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceBuyerAcceptOffer.orderOrError.error).toEqual({
-        type: "application_error",
-        code: "404",
-        data: null,
-      })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceBuyerAcceptOffer.orderOrError.error).toEqual({
+      type: "application_error",
+      code: "404",
+      data: null,
     })
   })
 })

--- a/src/schema/v1/__tests__/ecommerce/buyer_counter_offer_mutation.test.ts
+++ b/src/schema/v1/__tests__/ecommerce/buyer_counter_offer_mutation.test.ts
@@ -29,7 +29,7 @@ describe("BuyerCounterOffer Mutation", () => {
     }
   `
 
-  it("counters sellers offer", () => {
+  it("counters sellers offer", async () => {
     const resolvers = {
       Mutation: {
         buyerCounterOffer: () => ({
@@ -40,18 +40,18 @@ describe("BuyerCounterOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceBuyerCounterOffer.orderOrError.order).toEqual(
-        sampleOrder({
-          mode: "OFFER",
-          includeOfferFields: true,
-          includeCreditCard: true,
-        })
-      )
-    })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceBuyerCounterOffer.orderOrError.order).toEqual(
+      sampleOrder({
+        mode: "OFFER",
+        includeOfferFields: true,
+        includeCreditCard: true,
+      })
+    )
   })
 
-  it("returns an error if there is one", () => {
+  it("returns an error if there is one", async () => {
     const resolvers = {
       Mutation: {
         buyerCounterOffer: () => ({
@@ -67,12 +67,12 @@ describe("BuyerCounterOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceBuyerCounterOffer.orderOrError.error).toEqual({
-        type: "application_error",
-        code: "404",
-        data: null,
-      })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceBuyerCounterOffer.orderOrError.error).toEqual({
+      type: "application_error",
+      code: "404",
+      data: null,
     })
   })
 })

--- a/src/schema/v1/__tests__/ecommerce/buyer_reject_offer_mutation.test.ts
+++ b/src/schema/v1/__tests__/ecommerce/buyer_reject_offer_mutation.test.ts
@@ -50,7 +50,7 @@ describe("BuyerRejectOffer Mutation", () => {
     }
   `
 
-  it("rejects the seller offer with a reason", () => {
+  it("rejects the seller offer with a reason", async () => {
     const resolvers = {
       Mutation: {
         buyerRejectOffer: () => ({
@@ -61,14 +61,14 @@ describe("BuyerRejectOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutationWithRejectReason, context).then((data) => {
-      expect(data!.ecommerceBuyerRejectOffer.orderOrError.order).toEqual(
-        sampleOrder()
-      )
-    })
+    const data = await runQuery(mutationWithRejectReason, context)
+
+    expect(data!.ecommerceBuyerRejectOffer.orderOrError.order).toEqual(
+      sampleOrder()
+    )
   })
 
-  it("rejects the seller offer without a reason", () => {
+  it("rejects the seller offer without a reason", async () => {
     const resolvers = {
       Mutation: {
         buyerRejectOffer: () => ({
@@ -79,14 +79,14 @@ describe("BuyerRejectOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutationWithoutRejectReason, context).then((data) => {
-      expect(data!.ecommerceBuyerRejectOffer.orderOrError.order).toEqual(
-        sampleOrder()
-      )
-    })
+    const data = await runQuery(mutationWithoutRejectReason, context)
+
+    expect(data!.ecommerceBuyerRejectOffer.orderOrError.order).toEqual(
+      sampleOrder()
+    )
   })
 
-  it("returns an error if an error occurs", () => {
+  it("returns an error if an error occurs", async () => {
     const resolvers = {
       Mutation: {
         buyerRejectOffer: () => ({
@@ -102,12 +102,12 @@ describe("BuyerRejectOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutationWithoutRejectReason, context).then((data) => {
-      expect(data!.ecommerceBuyerRejectOffer.orderOrError.error).toEqual({
-        type: "application_error",
-        code: "404",
-        data: null,
-      })
+    const data = await runQuery(mutationWithoutRejectReason, context)
+
+    expect(data!.ecommerceBuyerRejectOffer.orderOrError.error).toEqual({
+      type: "application_error",
+      code: "404",
+      data: null,
     })
   })
 })

--- a/src/schema/v1/__tests__/ecommerce/fix_failed_payment.test.ts
+++ b/src/schema/v1/__tests__/ecommerce/fix_failed_payment.test.ts
@@ -29,7 +29,7 @@ describe("FixFailedPayment Mutation", () => {
     }
   `
 
-  it("does not fail", () => {
+  it("does not fail", async () => {
     const resolvers = {
       Mutation: {
         fixFailedPayment: () => ({
@@ -40,14 +40,14 @@ describe("FixFailedPayment Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceFixFailedPayment.orderOrError.order).toEqual(
-        sampleOrder({ includeCreditCard: true })
-      )
-    })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceFixFailedPayment.orderOrError.order).toEqual(
+      sampleOrder({ includeCreditCard: true })
+    )
   })
 
-  it("returns an error if there is one", () => {
+  it("returns an error if there is one", async () => {
     const resolvers = {
       Mutation: {
         fixFailedPayment: () => ({
@@ -63,12 +63,12 @@ describe("FixFailedPayment Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceFixFailedPayment.orderOrError.error).toEqual({
-        type: "application_error",
-        code: "404",
-        data: null,
-      })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceFixFailedPayment.orderOrError.error).toEqual({
+      type: "application_error",
+      code: "404",
+      data: null,
     })
   })
 })

--- a/src/schema/v1/__tests__/ecommerce/orders.test.ts
+++ b/src/schema/v1/__tests__/ecommerce/orders.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable promise/always-return */
-
 import { runQuery } from "schema/v1/test/utils"
 import { mockxchange } from "test/fixtures/exchange/mockxchange"
 import { sampleOrder } from "test/fixtures/results/sample_order"
@@ -14,7 +12,7 @@ describe("Orders query", () => {
     const resolvers = { Query: { orders: () => exchangeOrdersJSON } }
     context = mockxchange(resolvers)
   })
-  it("fetches orders by seller id", () => {
+  it("fetches orders by seller id", async () => {
     const query = gql`
       {
         orders(sellerId: "581b45e4cd530e658b000124") {
@@ -51,16 +49,16 @@ describe("Orders query", () => {
       }
     `
 
-    return runQuery(query, context).then((data) => {
-      expect(data!.orders.totalCount).toEqual(100)
-      expect(data!.orders.totalPages).toEqual(10)
-      expect(data!.orders.pageCursors).not.toBeNull
-      expect(data!.orders.pageCursors.first.page).toEqual(1)
-      expect(data!.orders.pageCursors.last.page).toEqual(10)
-      expect(data!.orders.pageCursors.around.length).toEqual(3)
-      expect(data!.orders.pageCursors.previous.page).toEqual(4)
-      expect(data!.orders.totalPages).toEqual(10)
-      expect(data!.orders.edges[0].node).toEqual(sampleOrder())
-    })
+    const data = await runQuery(query, context)
+
+    expect(data!.orders.totalCount).toEqual(100)
+    expect(data!.orders.totalPages).toEqual(10)
+    expect(data!.orders.pageCursors).not.toBeNull()
+    expect(data!.orders.pageCursors.first.page).toEqual(1)
+    expect(data!.orders.pageCursors.last.page).toEqual(10)
+    expect(data!.orders.pageCursors.around.length).toEqual(3)
+    expect(data!.orders.pageCursors.previous.page).toEqual(4)
+    expect(data!.orders.totalPages).toEqual(10)
+    expect(data!.orders.edges[0].node).toEqual(sampleOrder())
   })
 })

--- a/src/schema/v1/__tests__/ecommerce/seller_accept_offer_mutation.test.ts
+++ b/src/schema/v1/__tests__/ecommerce/seller_accept_offer_mutation.test.ts
@@ -29,7 +29,7 @@ describe("SellerAcceptOffer Mutation", () => {
     }
   `
 
-  it("approves the order of the offer", () => {
+  it("approves the order of the offer", async () => {
     const resolvers = {
       Mutation: {
         sellerAcceptOffer: () => ({
@@ -40,14 +40,14 @@ describe("SellerAcceptOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceSellerAcceptOffer.orderOrError.order).toEqual(
-        sampleOrder()
-      )
-    })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceSellerAcceptOffer.orderOrError.order).toEqual(
+      sampleOrder()
+    )
   })
 
-  it("returns an error if there is one", () => {
+  it("returns an error if there is one", async () => {
     const resolvers = {
       Mutation: {
         sellerAcceptOffer: () => ({
@@ -63,12 +63,12 @@ describe("SellerAcceptOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceSellerAcceptOffer.orderOrError.error).toEqual({
-        type: "application_error",
-        code: "404",
-        data: null,
-      })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceSellerAcceptOffer.orderOrError.error).toEqual({
+      type: "application_error",
+      code: "404",
+      data: null,
     })
   })
 })

--- a/src/schema/v1/__tests__/ecommerce/seller_counter_offer_mutation.test.ts
+++ b/src/schema/v1/__tests__/ecommerce/seller_counter_offer_mutation.test.ts
@@ -29,7 +29,7 @@ describe("SellerCounterOffer Mutation", () => {
     }
   `
 
-  it("counters buyers offer", () => {
+  it("counters buyers offer", async () => {
     const resolvers = {
       Mutation: {
         sellerCounterOffer: () => ({
@@ -40,14 +40,14 @@ describe("SellerCounterOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceSellerCounterOffer.orderOrError.order).toEqual(
-        sampleOrder({ mode: "OFFER", includeOfferFields: true })
-      )
-    })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceSellerCounterOffer.orderOrError.order).toEqual(
+      sampleOrder({ mode: "OFFER", includeOfferFields: true })
+    )
   })
 
-  it("returns an error if there is one", () => {
+  it("returns an error if there is one", async () => {
     const resolvers = {
       Mutation: {
         sellerCounterOffer: () => ({
@@ -63,12 +63,12 @@ describe("SellerCounterOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceSellerCounterOffer.orderOrError.error).toEqual({
-        type: "application_error",
-        code: "404",
-        data: null,
-      })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceSellerCounterOffer.orderOrError.error).toEqual({
+      type: "application_error",
+      code: "404",
+      data: null,
     })
   })
 })

--- a/src/schema/v1/__tests__/ecommerce/seller_reject_offer_mutation.test.ts
+++ b/src/schema/v1/__tests__/ecommerce/seller_reject_offer_mutation.test.ts
@@ -29,7 +29,7 @@ describe("SellerRejectOffer Mutation", () => {
     }
   `
 
-  it("rejects the order of the offer", () => {
+  it("rejects the order of the offer", async () => {
     const resolvers = {
       Mutation: {
         sellerRejectOffer: () => ({
@@ -40,14 +40,14 @@ describe("SellerRejectOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceSellerRejectOffer.orderOrError.order).toEqual(
-        sampleOrder()
-      )
-    })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceSellerRejectOffer.orderOrError.order).toEqual(
+      sampleOrder()
+    )
   })
 
-  it("returns an error if there is one", () => {
+  it("returns an error if there is one", async () => {
     const resolvers = {
       Mutation: {
         sellerRejectOffer: () => ({
@@ -63,12 +63,12 @@ describe("SellerRejectOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceSellerRejectOffer.orderOrError.error).toEqual({
-        type: "application_error",
-        code: "404",
-        data: null,
-      })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceSellerRejectOffer.orderOrError.error).toEqual({
+      type: "application_error",
+      code: "404",
+      data: null,
     })
   })
 })

--- a/src/schema/v1/__tests__/ecommerce/submit_pending_offer_mutation.test.ts
+++ b/src/schema/v1/__tests__/ecommerce/submit_pending_offer_mutation.test.ts
@@ -29,7 +29,7 @@ describe("SubmitPendingOffer Mutation", () => {
     }
   `
 
-  it("submits offer", () => {
+  it("submits offer", async () => {
     const resolvers = {
       Mutation: {
         submitPendingOffer: () => ({
@@ -40,14 +40,14 @@ describe("SubmitPendingOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceSubmitPendingOffer.orderOrError.order).toEqual(
-        sampleOrder()
-      )
-    })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceSubmitPendingOffer.orderOrError.order).toEqual(
+      sampleOrder()
+    )
   })
 
-  it("returns an error if there is one", () => {
+  it("returns an error if there is one", async () => {
     const resolvers = {
       Mutation: {
         submitPendingOffer: () => ({
@@ -63,12 +63,12 @@ describe("SubmitPendingOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceSubmitPendingOffer.orderOrError.error).toEqual({
-        type: "application_error",
-        code: "404",
-        data: null,
-      })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceSubmitPendingOffer.orderOrError.error).toEqual({
+      type: "application_error",
+      code: "404",
+      data: null,
     })
   })
 })

--- a/src/schema/v1/__tests__/principalFieldDirective.test.ts
+++ b/src/schema/v1/__tests__/principalFieldDirective.test.ts
@@ -5,7 +5,7 @@ import { principalFieldDirectiveExtension } from "extensions/principalFieldDirec
 const schema = require("schema/v1").default
 const queryToAst = (query) => parse(new Source(query))
 
-describe(principalFieldDirectiveExtension, () => {
+describe("principalFieldDirectiveExtension", () => {
   it("returns the underlying error when occurring on a tagged field", async () => {
     const query = `
       {

--- a/src/schema/v1/artwork/artworkContextGrids/__tests__/auctionContext.test.ts
+++ b/src/schema/v1/artwork/artworkContextGrids/__tests__/auctionContext.test.ts
@@ -4,7 +4,7 @@ import { assign } from "lodash"
 
 describe("Default Context", () => {
   let context: any
-  let parentArtwork = {}
+  const parentArtwork = {}
 
   const query = gql`
     {
@@ -91,7 +91,7 @@ describe("Default Context", () => {
     }
   })
 
-  it("Does not return auction-related grids for a non-auction sale", () => {
+  it("Does not return auction-related grids for a non-auction sale", async () => {
     expect.assertions(1)
     context.saleLoader = () =>
       Promise.resolve({
@@ -100,33 +100,25 @@ describe("Default Context", () => {
         auction_state: "closed",
       })
 
-    return runAuthenticatedQuery(query, context).then((data) => {
-      // Returns the default grid
-      expect(data.artwork.contextGrids.length).toEqual(3)
-    })
+    const data = await runAuthenticatedQuery(query, context)
+    // Returns the default grid
+    expect(data.artwork.contextGrids.length).toEqual(3)
   })
 
-  it("Returns the correct values for metadata fields for an open auction", () => {
+  it("Returns the correct values for metadata fields for an open auction", async () => {
     expect.assertions(5)
 
-    return runAuthenticatedQuery(query, context).then((data) => {
-      // Should have one artist grid and one related grid with 0 works
-      expect(data.artwork.contextGrids.length).toEqual(1)
-      const {
-        title,
-        ctaTitle,
-        ctaHref,
-        artworks,
-      } = data.artwork.contextGrids[0]
-
-      expect(title).toEqual("Other works from Phillips Auction")
-      expect(ctaTitle).toEqual("View all works from the auction")
-      expect(ctaHref).toEqual("/auction/phillips-auction")
-      expect(artworks.edges.length).toEqual(2)
-    })
+    const data = await runAuthenticatedQuery(query, context)
+    // Should have one artist grid and one related grid with 0 works
+    expect(data.artwork.contextGrids.length).toEqual(1)
+    const { title, ctaTitle, ctaHref, artworks } = data.artwork.contextGrids[0]
+    expect(title).toEqual("Other works from Phillips Auction")
+    expect(ctaTitle).toEqual("View all works from the auction")
+    expect(ctaHref).toEqual("/auction/phillips-auction")
+    expect(artworks.edges.length).toEqual(2)
   })
 
-  it("Returns the correct values for metadata fields for a closed auction", () => {
+  it("Returns the correct values for metadata fields for a closed auction", async () => {
     expect.assertions(6)
 
     context.saleLoader = () =>
@@ -136,26 +128,18 @@ describe("Default Context", () => {
         auction_state: "closed",
       })
 
-    return runAuthenticatedQuery(query, context).then((data) => {
-      // Should have one partner grid and one related grid with 0 works
-      expect(data.artwork.contextGrids.length).toEqual(2)
-      const {
-        title,
-        ctaTitle,
-        ctaHref,
-        artworks,
-      } = data.artwork.contextGrids[0]
-
-      expect(title).toEqual("Other works by Andy Warhol")
-      expect(ctaTitle).toEqual("View all works by Andy Warhol")
-      expect(ctaHref).toEqual("/artist/andy-warhol")
-      expect(artworks.edges.map(({ node }) => node.id)).toEqual([
-        "artwork1",
-        "artwork2",
-      ])
-
-      // Related artworks grid should have no artworks
-      expect(data.artwork.contextGrids[1].artworks).toEqual(null)
-    })
+    const data = await runAuthenticatedQuery(query, context)
+    // Should have one partner grid and one related grid with 0 works
+    expect(data.artwork.contextGrids.length).toEqual(2)
+    const { title, ctaTitle, ctaHref, artworks } = data.artwork.contextGrids[0]
+    expect(title).toEqual("Other works by Andy Warhol")
+    expect(ctaTitle).toEqual("View all works by Andy Warhol")
+    expect(ctaHref).toEqual("/artist/andy-warhol")
+    expect(artworks.edges.map(({ node }) => node.id)).toEqual([
+      "artwork1",
+      "artwork2",
+    ])
+    // Related artworks grid should have no artworks
+    expect(data.artwork.contextGrids[1].artworks).toEqual(null)
   })
 })

--- a/src/schema/v1/artwork/artworkContextGrids/__tests__/defaultContext.test.ts
+++ b/src/schema/v1/artwork/artworkContextGrids/__tests__/defaultContext.test.ts
@@ -4,7 +4,7 @@ import { assign } from "lodash"
 
 describe("Default Context", () => {
   let context: any
-  let parentArtwork = {} as any
+  const parentArtwork = {} as any
 
   const query = gql`
     {
@@ -71,59 +71,43 @@ describe("Default Context", () => {
     }
   })
 
-  it("Returns the correct values for metadata fields when there is just artist data", () => {
+  it("Returns the correct values for metadata fields when there is just artist data", async () => {
     expect.assertions(6)
 
     parentArtwork.partner = null
     context.partnerArtworksLoader = Promise.resolve(null)
 
-    return runAuthenticatedQuery(query, context).then((data) => {
-      // Should have one artist grid and one related grid with 0 works
-      expect(data.artwork.contextGrids.length).toEqual(2)
-      const {
-        title,
-        ctaTitle,
-        ctaHref,
-        artworks,
-      } = data.artwork.contextGrids[0]
-
-      expect(title).toEqual("Other works by Andy Warhol")
-      expect(ctaTitle).toEqual("View all works by Andy Warhol")
-      expect(ctaHref).toEqual("/artist/andy-warhol")
-      expect(artworks.edges.length).toEqual(2)
-
-      // Related artworks grid should have no artworks
-      expect(data.artwork.contextGrids[1].artworks).toEqual(null)
-    })
+    const data = await runAuthenticatedQuery(query, context)
+    // Should have one artist grid and one related grid with 0 works
+    expect(data.artwork.contextGrids.length).toEqual(2)
+    const { title, ctaTitle, ctaHref, artworks } = data.artwork.contextGrids[0]
+    expect(title).toEqual("Other works by Andy Warhol")
+    expect(ctaTitle).toEqual("View all works by Andy Warhol")
+    expect(ctaHref).toEqual("/artist/andy-warhol")
+    expect(artworks.edges.length).toEqual(2)
+    // Related artworks grid should have no artworks
+    expect(data.artwork.contextGrids[1].artworks).toEqual(null)
   })
 
-  it("Returns the correct values for metadata fields when there is just partner data", () => {
+  it("Returns the correct values for metadata fields when there is just partner data", async () => {
     expect.assertions(6)
 
     parentArtwork.artist = null
     context.artistArtworksLoader = Promise.resolve(null)
 
-    return runAuthenticatedQuery(query, context).then((data) => {
-      // Should have one partner grid and one related grid with 0 works
-      expect(data.artwork.contextGrids.length).toEqual(2)
-      const {
-        title,
-        ctaTitle,
-        ctaHref,
-        artworks,
-      } = data.artwork.contextGrids[0]
-
-      expect(title).toEqual("Other works from CAMA Gallery")
-      expect(ctaTitle).toEqual("View all works from CAMA Gallery")
-      expect(ctaHref).toEqual("/cama-gallery")
-      expect(artworks.edges.length).toEqual(2)
-
-      // Related artworks grid should have no artworks
-      expect(data.artwork.contextGrids[1].artworks).toEqual(null)
-    })
+    const data = await runAuthenticatedQuery(query, context)
+    // Should have one partner grid and one related grid with 0 works
+    expect(data.artwork.contextGrids.length).toEqual(2)
+    const { title, ctaTitle, ctaHref, artworks } = data.artwork.contextGrids[0]
+    expect(title).toEqual("Other works from CAMA Gallery")
+    expect(ctaTitle).toEqual("View all works from CAMA Gallery")
+    expect(ctaHref).toEqual("/cama-gallery")
+    expect(artworks.edges.length).toEqual(2)
+    // Related artworks grid should have no artworks
+    expect(data.artwork.contextGrids[1].artworks).toEqual(null)
   })
 
-  it("Returns the correct values for metadata fields when there is all data", () => {
+  it("Returns the correct values for metadata fields when there is all data", async () => {
     expect.assertions(13)
 
     context.relatedLayersLoader = () => Promise.resolve([{ id: "main" }])
@@ -134,57 +118,50 @@ describe("Default Context", () => {
         { id: "relatedArtwork3", title: "Related Artwork 3" },
       ])
 
-    return runAuthenticatedQuery(query, context).then((data) => {
-      // Should have one artist grid and one related grid with 0 works
-      expect(data.artwork.contextGrids.length).toEqual(3)
-
-      // The first grid should include artist-related metadata
-      const {
-        title: artistTitle,
-        ctaTitle: artistCtaTitle,
-        ctaHref: artistctaHref,
-        artworks: artistArtworks,
-      } = data.artwork.contextGrids[0]
-
-      expect(artistTitle).toEqual("Other works by Andy Warhol")
-      expect(artistCtaTitle).toEqual("View all works by Andy Warhol")
-      expect(artistctaHref).toEqual("/artist/andy-warhol")
-      expect(artistArtworks.edges.map(({ node }) => node.id)).toEqual([
-        "artwork1",
-        "artwork2",
-      ])
-
-      // The second grid should include partner-related metadata
-      const {
-        title: partnerTitle,
-        ctaTitle: partnerCtaTitle,
-        ctaHref: partnerctaHref,
-        artworks: partnerArtworks,
-      } = data.artwork.contextGrids[1]
-
-      expect(partnerTitle).toEqual("Other works from CAMA Gallery")
-      expect(partnerCtaTitle).toEqual("View all works from CAMA Gallery")
-      expect(partnerctaHref).toEqual("/cama-gallery")
-      expect(partnerArtworks.edges.map(({ node }) => node.id)).toEqual([
-        "partnerArtwork1",
-        "partnerArtwork2",
-      ])
-
-      // The third grid should include related artworks
-      const {
-        title: relatedTitle,
-        ctaTitle: relatedCtaTitle,
-        ctaHref: relatedctaHref,
-        artworks: relatedArtworks,
-      } = data.artwork.contextGrids[2]
-
-      expect(relatedTitle).toEqual("Related works")
-      expect(relatedCtaTitle).toEqual(null)
-      expect(relatedctaHref).toEqual(null)
-      expect(relatedArtworks.edges.map(({ node }) => node.id)).toEqual([
-        "relatedArtwork1",
-        "relatedArtwork2",
-      ])
-    })
+    const data = await runAuthenticatedQuery(query, context)
+    // Should have one artist grid and one related grid with 0 works
+    expect(data.artwork.contextGrids.length).toEqual(3)
+    // The first grid should include artist-related metadata
+    const {
+      title: artistTitle,
+      ctaTitle: artistCtaTitle,
+      ctaHref: artistctaHref,
+      artworks: artistArtworks,
+    } = data.artwork.contextGrids[0]
+    expect(artistTitle).toEqual("Other works by Andy Warhol")
+    expect(artistCtaTitle).toEqual("View all works by Andy Warhol")
+    expect(artistctaHref).toEqual("/artist/andy-warhol")
+    expect(artistArtworks.edges.map(({ node }) => node.id)).toEqual([
+      "artwork1",
+      "artwork2",
+    ])
+    // The second grid should include partner-related metadata
+    const {
+      title: partnerTitle,
+      ctaTitle: partnerCtaTitle,
+      ctaHref: partnerctaHref,
+      artworks: partnerArtworks,
+    } = data.artwork.contextGrids[1]
+    expect(partnerTitle).toEqual("Other works from CAMA Gallery")
+    expect(partnerCtaTitle).toEqual("View all works from CAMA Gallery")
+    expect(partnerctaHref).toEqual("/cama-gallery")
+    expect(partnerArtworks.edges.map(({ node: node_1 }) => node_1.id)).toEqual([
+      "partnerArtwork1",
+      "partnerArtwork2",
+    ])
+    // The third grid should include related artworks
+    const {
+      title: relatedTitle,
+      ctaTitle: relatedCtaTitle,
+      ctaHref: relatedctaHref,
+      artworks: relatedArtworks,
+    } = data.artwork.contextGrids[2]
+    expect(relatedTitle).toEqual("Related works")
+    expect(relatedCtaTitle).toEqual(null)
+    expect(relatedctaHref).toEqual(null)
+    expect(relatedArtworks.edges.map(({ node: node_2 }) => node_2.id)).toEqual([
+      "relatedArtwork1",
+      "relatedArtwork2",
+    ])
   })
 })

--- a/src/schema/v1/artwork/artworkContextGrids/__tests__/fairContext.test.ts
+++ b/src/schema/v1/artwork/artworkContextGrids/__tests__/fairContext.test.ts
@@ -4,7 +4,7 @@ import { assign } from "lodash"
 
 describe("Show Context", () => {
   let context: any
-  let parentArtwork = {} as any
+  const parentArtwork = {} as any
 
   const query = gql`
     {
@@ -90,33 +90,25 @@ describe("Show Context", () => {
     }
   })
 
-  it("Returns the correct values for metadata fields when there is just show data", () => {
+  it("Returns the correct values for metadata fields when there is just show data", async () => {
     expect.assertions(6)
 
     parentArtwork.artist = null
     context.artistArtworksLoader = () => Promise.resolve(null)
 
-    return runAuthenticatedQuery(query, context).then((data) => {
-      // Should have one artist grid and one related grid with 0 works
-      expect(data.artwork.contextGrids.length).toEqual(2)
-      const {
-        title,
-        ctaTitle,
-        ctaHref,
-        artworks,
-      } = data.artwork.contextGrids[0]
-
-      expect(title).toEqual("Other works from Cool Show")
-      expect(ctaTitle).toEqual("View all works from the booth")
-      expect(ctaHref).toEqual("/show/cool-show")
-      expect(artworks.edges.length).toEqual(2)
-
-      // Related artworks grid should have no artworks
-      expect(data.artwork.contextGrids[1].artworks).toEqual(null)
-    })
+    const data = await runAuthenticatedQuery(query, context)
+    // Should have one artist grid and one related grid with 0 works
+    expect(data.artwork.contextGrids.length).toEqual(2)
+    const { title, ctaTitle, ctaHref, artworks } = data.artwork.contextGrids[0]
+    expect(title).toEqual("Other works from Cool Show")
+    expect(ctaTitle).toEqual("View all works from the booth")
+    expect(ctaHref).toEqual("/show/cool-show")
+    expect(artworks.edges.length).toEqual(2)
+    // Related artworks grid should have no artworks
+    expect(data.artwork.contextGrids[1].artworks).toEqual(null)
   })
 
-  it("Returns the correct values for metadata fields when there is all data", () => {
+  it("Returns the correct values for metadata fields when there is all data", async () => {
     expect.assertions(13)
 
     context.relatedLayersLoader = () => Promise.resolve([{ id: "main" }])
@@ -127,57 +119,50 @@ describe("Show Context", () => {
         { id: "relatedArtwork3", title: "Related Artwork 3" },
       ])
 
-    return runAuthenticatedQuery(query, context).then((data) => {
-      // Should have one artist grid and one related grid with 0 works
-      expect(data.artwork.contextGrids.length).toEqual(3)
-
-      // The first grid should include show-related metadata
-      const {
-        title: showTitle,
-        ctaTitle: showCtaTitle,
-        ctaHref: showctaHref,
-        artworks: showArtworks,
-      } = data.artwork.contextGrids[0]
-
-      expect(showTitle).toEqual("Other works from Cool Show")
-      expect(showCtaTitle).toEqual("View all works from the booth")
-      expect(showctaHref).toEqual("/show/cool-show")
-      expect(showArtworks.edges.map(({ node }) => node.id)).toEqual([
-        "showArtwork1",
-        "showArtwork2",
-      ])
-
-      // The second grid should include artist-related metadata
-      const {
-        title: artistTitle,
-        ctaTitle: artistCtaTitle,
-        ctaHref: artistctaHref,
-        artworks: artistArtworks,
-      } = data.artwork.contextGrids[1]
-
-      expect(artistTitle).toEqual("Other works by Andy Warhol")
-      expect(artistCtaTitle).toEqual("View all works by Andy Warhol")
-      expect(artistctaHref).toEqual("/artist/andy-warhol")
-      expect(artistArtworks.edges.map(({ node }) => node.id)).toEqual([
-        "artwork1",
-        "artwork2",
-      ])
-
-      // The third grid should include related artworks
-      const {
-        title: relatedTitle,
-        ctaTitle: relatedCtaTitle,
-        ctaHref: relatedctaHref,
-        artworks: relatedArtworks,
-      } = data.artwork.contextGrids[2]
-
-      expect(relatedTitle).toEqual("Related works")
-      expect(relatedCtaTitle).toEqual(null)
-      expect(relatedctaHref).toEqual(null)
-      expect(relatedArtworks.edges.map(({ node }) => node.id)).toEqual([
-        "relatedArtwork1",
-        "relatedArtwork2",
-      ])
-    })
+    const data = await runAuthenticatedQuery(query, context)
+    // Should have one artist grid and one related grid with 0 works
+    expect(data.artwork.contextGrids.length).toEqual(3)
+    // The first grid should include show-related metadata
+    const {
+      title: showTitle,
+      ctaTitle: showCtaTitle,
+      ctaHref: showctaHref,
+      artworks: showArtworks,
+    } = data.artwork.contextGrids[0]
+    expect(showTitle).toEqual("Other works from Cool Show")
+    expect(showCtaTitle).toEqual("View all works from the booth")
+    expect(showctaHref).toEqual("/show/cool-show")
+    expect(showArtworks.edges.map(({ node }) => node.id)).toEqual([
+      "showArtwork1",
+      "showArtwork2",
+    ])
+    // The second grid should include artist-related metadata
+    const {
+      title: artistTitle,
+      ctaTitle: artistCtaTitle,
+      ctaHref: artistctaHref,
+      artworks: artistArtworks,
+    } = data.artwork.contextGrids[1]
+    expect(artistTitle).toEqual("Other works by Andy Warhol")
+    expect(artistCtaTitle).toEqual("View all works by Andy Warhol")
+    expect(artistctaHref).toEqual("/artist/andy-warhol")
+    expect(artistArtworks.edges.map(({ node: node_1 }) => node_1.id)).toEqual([
+      "artwork1",
+      "artwork2",
+    ])
+    // The third grid should include related artworks
+    const {
+      title: relatedTitle,
+      ctaTitle: relatedCtaTitle,
+      ctaHref: relatedctaHref,
+      artworks: relatedArtworks,
+    } = data.artwork.contextGrids[2]
+    expect(relatedTitle).toEqual("Related works")
+    expect(relatedCtaTitle).toEqual(null)
+    expect(relatedctaHref).toEqual(null)
+    expect(relatedArtworks.edges.map(({ node: node_2 }) => node_2.id)).toEqual([
+      "relatedArtwork1",
+      "relatedArtwork2",
+    ])
   })
 })

--- a/src/schema/v1/artwork/artworkContextGrids/__tests__/showContext.test.ts
+++ b/src/schema/v1/artwork/artworkContextGrids/__tests__/showContext.test.ts
@@ -4,7 +4,7 @@ import { assign } from "lodash"
 
 describe("Show Context", () => {
   let context: any
-  let parentArtwork = {} as any
+  const parentArtwork = {} as any
 
   const query = gql`
     {
@@ -90,7 +90,7 @@ describe("Show Context", () => {
     }
   })
 
-  it("Returns the correct values for metadata fields when there is just show data", () => {
+  it("Returns the correct values for metadata fields when there is just show data", async () => {
     expect.assertions(6)
 
     parentArtwork.partner = null
@@ -99,54 +99,38 @@ describe("Show Context", () => {
     parentArtwork.artist = null
     context.artistArtworksLoader = () => Promise.resolve(null)
 
-    return runAuthenticatedQuery(query, context).then((data) => {
-      // Should have one artist grid and one related grid with 0 works
-      expect(data.artwork.contextGrids.length).toEqual(2)
-      const {
-        title,
-        ctaTitle,
-        ctaHref,
-        artworks,
-      } = data.artwork.contextGrids[0]
-
-      expect(title).toEqual("Other works from Cool Show")
-      expect(ctaTitle).toEqual("View all works from the show")
-      expect(ctaHref).toEqual("/show/cool-show")
-      expect(artworks.edges.length).toEqual(2)
-
-      // Related artworks grid should have no artworks
-      expect(data.artwork.contextGrids[1].artworks).toEqual(null)
-    })
+    const data = await runAuthenticatedQuery(query, context)
+    // Should have one artist grid and one related grid with 0 works
+    expect(data.artwork.contextGrids.length).toEqual(2)
+    const { title, ctaTitle, ctaHref, artworks } = data.artwork.contextGrids[0]
+    expect(title).toEqual("Other works from Cool Show")
+    expect(ctaTitle).toEqual("View all works from the show")
+    expect(ctaHref).toEqual("/show/cool-show")
+    expect(artworks.edges.length).toEqual(2)
+    // Related artworks grid should have no artworks
+    expect(data.artwork.contextGrids[1].artworks).toEqual(null)
   })
 
-  it("Returns the correct values for metadata fields when there is just partner data", () => {
+  it("Returns the correct values for metadata fields when there is just partner data", async () => {
     expect.assertions(6)
 
     parentArtwork.artist = null
     context.artistArtworksLoader = () => Promise.resolve(null)
     context.relatedShowsLoader = () => Promise.resolve(null)
 
-    return runAuthenticatedQuery(query, context).then((data) => {
-      // Should have one partner grid and one related grid with 0 works
-      expect(data.artwork.contextGrids.length).toEqual(2)
-      const {
-        title,
-        ctaTitle,
-        ctaHref,
-        artworks,
-      } = data.artwork.contextGrids[0]
-
-      expect(title).toEqual("Other works from CAMA Gallery")
-      expect(ctaTitle).toEqual("View all works from CAMA Gallery")
-      expect(ctaHref).toEqual("/cama-gallery")
-      expect(artworks.edges.length).toEqual(2)
-
-      // Related artworks grid should have no artworks
-      expect(data.artwork.contextGrids[1].artworks).toEqual(null)
-    })
+    const data = await runAuthenticatedQuery(query, context)
+    // Should have one partner grid and one related grid with 0 works
+    expect(data.artwork.contextGrids.length).toEqual(2)
+    const { title, ctaTitle, ctaHref, artworks } = data.artwork.contextGrids[0]
+    expect(title).toEqual("Other works from CAMA Gallery")
+    expect(ctaTitle).toEqual("View all works from CAMA Gallery")
+    expect(ctaHref).toEqual("/cama-gallery")
+    expect(artworks.edges.length).toEqual(2)
+    // Related artworks grid should have no artworks
+    expect(data.artwork.contextGrids[1].artworks).toEqual(null)
   })
 
-  it("Returns the correct values for metadata fields when there is all data", () => {
+  it("Returns the correct values for metadata fields when there is all data", async () => {
     expect.assertions(17)
 
     context.relatedLayersLoader = () => Promise.resolve([{ id: "main" }])
@@ -157,73 +141,64 @@ describe("Show Context", () => {
         { id: "relatedArtwork3", title: "Related Artwork 3" },
       ])
 
-    return runAuthenticatedQuery(query, context).then((data) => {
-      // Should have one artist grid and one related grid with 0 works
-      expect(data.artwork.contextGrids.length).toEqual(4)
-
-      // The first grid should include show-related metadata
-      const {
-        title: showTitle,
-        ctaTitle: showCtaTitle,
-        ctaHref: showctaHref,
-        artworks: showArtworks,
-      } = data.artwork.contextGrids[0]
-
-      expect(showTitle).toEqual("Other works from Cool Show")
-      expect(showCtaTitle).toEqual("View all works from the show")
-      expect(showctaHref).toEqual("/show/cool-show")
-      expect(showArtworks.edges.map(({ node }) => node.id)).toEqual([
-        "showArtwork1",
-        "showArtwork2",
-      ])
-
-      // The second grid should include artist-related metadata
-      const {
-        title: artistTitle,
-        ctaTitle: artistCtaTitle,
-        ctaHref: artistctaHref,
-        artworks: artistArtworks,
-      } = data.artwork.contextGrids[1]
-
-      expect(artistTitle).toEqual("Other works by Andy Warhol")
-      expect(artistCtaTitle).toEqual("View all works by Andy Warhol")
-      expect(artistctaHref).toEqual("/artist/andy-warhol")
-      expect(artistArtworks.edges.map(({ node }) => node.id)).toEqual([
-        "artwork1",
-        "artwork2",
-      ])
-
-      // The third grid should include partner-related metadata
-      const {
-        title: partnerTitle,
-        ctaTitle: partnerCtaTitle,
-        ctaHref: partnerctaHref,
-        artworks: partnerArtworks,
-      } = data.artwork.contextGrids[2]
-
-      expect(partnerTitle).toEqual("Other works from CAMA Gallery")
-      expect(partnerCtaTitle).toEqual("View all works from CAMA Gallery")
-      expect(partnerctaHref).toEqual("/cama-gallery")
-      expect(partnerArtworks.edges.map(({ node }) => node.id)).toEqual([
-        "partnerArtwork1",
-        "partnerArtwork2",
-      ])
-
-      // The fourth grid should include related artworks
-      const {
-        title: relatedTitle,
-        ctaTitle: relatedCtaTitle,
-        ctaHref: relatedctaHref,
-        artworks: relatedArtworks,
-      } = data.artwork.contextGrids[3]
-
-      expect(relatedTitle).toEqual("Related works")
-      expect(relatedCtaTitle).toEqual(null)
-      expect(relatedctaHref).toEqual(null)
-      expect(relatedArtworks.edges.map(({ node }) => node.id)).toEqual([
-        "relatedArtwork1",
-        "relatedArtwork2",
-      ])
-    })
+    const data = await runAuthenticatedQuery(query, context)
+    // Should have one artist grid and one related grid with 0 works
+    expect(data.artwork.contextGrids.length).toEqual(4)
+    // The first grid should include show-related metadata
+    const {
+      title: showTitle,
+      ctaTitle: showCtaTitle,
+      ctaHref: showctaHref,
+      artworks: showArtworks,
+    } = data.artwork.contextGrids[0]
+    expect(showTitle).toEqual("Other works from Cool Show")
+    expect(showCtaTitle).toEqual("View all works from the show")
+    expect(showctaHref).toEqual("/show/cool-show")
+    expect(showArtworks.edges.map(({ node }) => node.id)).toEqual([
+      "showArtwork1",
+      "showArtwork2",
+    ])
+    // The second grid should include artist-related metadata
+    const {
+      title: artistTitle,
+      ctaTitle: artistCtaTitle,
+      ctaHref: artistctaHref,
+      artworks: artistArtworks,
+    } = data.artwork.contextGrids[1]
+    expect(artistTitle).toEqual("Other works by Andy Warhol")
+    expect(artistCtaTitle).toEqual("View all works by Andy Warhol")
+    expect(artistctaHref).toEqual("/artist/andy-warhol")
+    expect(artistArtworks.edges.map(({ node: node_1 }) => node_1.id)).toEqual([
+      "artwork1",
+      "artwork2",
+    ])
+    // The third grid should include partner-related metadata
+    const {
+      title: partnerTitle,
+      ctaTitle: partnerCtaTitle,
+      ctaHref: partnerctaHref,
+      artworks: partnerArtworks,
+    } = data.artwork.contextGrids[2]
+    expect(partnerTitle).toEqual("Other works from CAMA Gallery")
+    expect(partnerCtaTitle).toEqual("View all works from CAMA Gallery")
+    expect(partnerctaHref).toEqual("/cama-gallery")
+    expect(partnerArtworks.edges.map(({ node: node_2 }) => node_2.id)).toEqual([
+      "partnerArtwork1",
+      "partnerArtwork2",
+    ])
+    // The fourth grid should include related artworks
+    const {
+      title: relatedTitle,
+      ctaTitle: relatedCtaTitle,
+      ctaHref: relatedctaHref,
+      artworks: relatedArtworks,
+    } = data.artwork.contextGrids[3]
+    expect(relatedTitle).toEqual("Related works")
+    expect(relatedCtaTitle).toEqual(null)
+    expect(relatedctaHref).toEqual(null)
+    expect(relatedArtworks.edges.map(({ node: node_3 }) => node_3.id)).toEqual([
+      "relatedArtwork1",
+      "relatedArtwork2",
+    ])
   })
 })

--- a/src/schema/v1/fields/__tests__/money.test.ts
+++ b/src/schema/v1/fields/__tests__/money.test.ts
@@ -1,9 +1,9 @@
 import { amount } from "../money"
 
-describe(amount, () => {
+describe("amount", () => {
   const getResult = ({
     obj = {},
-    args = { symbol: "$" } as object,
+    args = { symbol: "$" } as Record<string, unknown>,
     amountCents = 1234 as any,
   }) => amount(() => amountCents).resolve(obj, args)
 

--- a/src/schema/v1/me/__tests__/delete_credit_card_mutation.test.ts
+++ b/src/schema/v1/me/__tests__/delete_credit_card_mutation.test.ts
@@ -60,14 +60,17 @@ describe("Delete card mutation", () => {
   })
 
   it("throws an error if there is one we don't recognize", async () => {
+    expect.assertions(1)
+
     const errorRootValue = {
       deleteCreditCardLoader: () => {
         throw new Error("ETIMEOUT service unreachable")
       },
     }
-    runAuthenticatedQuery(query, errorRootValue).catch((error) => {
-      expect(error.message).toEqual("ETIMEOUT service unreachable")
-    })
+
+    await expect(runAuthenticatedQuery(query, errorRootValue)).rejects.toThrow(
+      "ETIMEOUT service unreachable"
+    )
   })
 
   it("deletes a credit card successfully", async () => {

--- a/src/schema/v1/me/__tests__/follow_show.test.ts
+++ b/src/schema/v1/me/__tests__/follow_show.test.ts
@@ -15,8 +15,8 @@ describe("FollowShow", () => {
     `
     interface Props {
       followShow: {
-        id: String
-        name: String
+        id: string
+        name: string
       }
     }
 
@@ -73,10 +73,10 @@ describe("FollowShow", () => {
 
     interface Props {
       followShow: {
-        id: String
-        name: String
+        id: string
+        name: string
         show: {
-          id: String
+          id: string
         }
       }
     }

--- a/src/schema/v1/me/__tests__/followed_shows.test.ts
+++ b/src/schema/v1/me/__tests__/followed_shows.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable promise/always-return */
 import { runAuthenticatedQuery } from "schema/v1/test/utils"
 import gql from "lib/gql"
 import cityData from "schema/v1/city/cityDataSortedByDisplayPreference.json"
@@ -41,7 +40,7 @@ describe("returns followed shows for a user", () => {
   })
 
   describe("filter by status", () => {
-    const assert_status_supported = async (status) => {
+    const assertStatusSupported = async (status) => {
       const query = generate_query(
         `(first: 10, status: ${status.toUpperCase()})`
       )
@@ -54,7 +53,7 @@ describe("returns followed shows for a user", () => {
       })
     }
 
-    const assert_invalid_status_fails = async (status) => {
+    const assertInvalidStatusFails = async (status) => {
       const query = generate_query(
         `(first: 10, status: ${status.toUpperCase()})`
       )
@@ -66,15 +65,15 @@ describe("returns followed shows for a user", () => {
     }
 
     it("handles all supported status definitions", async () => {
-      await assert_status_supported("closed")
-      await assert_status_supported("running")
-      await assert_status_supported("upcoming")
-      await assert_status_supported("closing_soon")
-      await assert_status_supported("running_and_upcoming")
+      await assertStatusSupported("closed")
+      await assertStatusSupported("running")
+      await assertStatusSupported("upcoming")
+      await assertStatusSupported("closing_soon")
+      await assertStatusSupported("running_and_upcoming")
     })
 
     it("throws an error if an unsupported status is supplied", async () => {
-      await assert_invalid_status_fails("random_invalid_status")
+      await assertInvalidStatusFails("random_invalid_status")
     })
   })
 

--- a/src/schema/v2/SearchableItem/__tests__/SearchableItemPresenter.test.ts
+++ b/src/schema/v2/SearchableItem/__tests__/SearchableItemPresenter.test.ts
@@ -155,12 +155,12 @@ describe("SearchableItemPresenter", () => {
       })
 
       it("prefers live_start_at to start_at date", () => {
-        let presenter = new SearchableItemPresenter({
+        const presenter = new SearchableItemPresenter({
           ...buildSearchableItem("Auction"),
           live_start_at: "2018-05-30T12:00:00.000Z",
           end_at: "",
         })
-        let description = presenter.formattedDescription()
+        const description = presenter.formattedDescription()
 
         expect(description).toBe("Sale opening May 30th, 2018 (at 8:00am EDT)")
       })

--- a/src/schema/v2/__tests__/article.test.js
+++ b/src/schema/v2/__tests__/article.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable promise/always-return */
 import { runQuery } from "schema/v2/test/utils"
 
-xdescribe("Article type", () => {
+describe.skip("Article type", () => {
   let article = null
   let context = null
 

--- a/src/schema/v2/__tests__/city.test.ts
+++ b/src/schema/v2/__tests__/city.test.ts
@@ -38,7 +38,7 @@ describe("City", () => {
   })
 
   describe("finding by slug", () => {
-    it("finds a city by its slug", () => {
+    it("finds a city by its slug", async () => {
       const query = gql`
         {
           city(slug: "sacramende-ca-usa") {
@@ -47,15 +47,15 @@ describe("City", () => {
         }
       `
 
-      return runQuery(query).then((result) => {
-        expect(result!.city).toEqual({
-          name: "Sacramende",
-        })
+      const result = await runQuery(query)
+      expect(result!.city).toEqual({
+        name: "Sacramende",
       })
     })
 
-    it("returns a helpful error for unknown slugs", () => {
+    it("returns a helpful error for unknown slugs", async () => {
       expect.assertions(1)
+
       const query = gql`
         {
           city(slug: "sacramundo") {
@@ -63,14 +63,14 @@ describe("City", () => {
           }
         }
       `
-      return runQuery(query).catch((e) =>
-        expect(e.message).toMatch(/City sacramundo not found in:/)
+      await expect(runQuery(query)).rejects.toThrow(
+        /City sacramundo not found in:/
       )
     })
   })
 
   describe("finding by lat/lng", () => {
-    it("finds the city nearest to a supplied point", () => {
+    it("finds the city nearest to a supplied point", async () => {
       const pointNearSmallville = "{ lat: 40, lng: -100 }"
       const query = `
         {
@@ -80,14 +80,13 @@ describe("City", () => {
         }
       `
 
-      return runQuery(query).then((result) => {
-        expect(result!.city).toEqual({
-          name: "Smallville",
-        })
+      const result = await runQuery(query)
+      expect(result!.city).toEqual({
+        name: "Smallville",
       })
     })
 
-    it("returns null if no cities are within a defined threshold", () => {
+    it("returns null if no cities are within a defined threshold", async () => {
       const veryRemotePoint = "{ lat: 90, lng: 0 }"
       const query = gql`
         {
@@ -97,9 +96,8 @@ describe("City", () => {
         }
       `
 
-      return runQuery(query).then((result) => {
-        expect(result!.city).toBeNull()
-      })
+      const result = await runQuery(query)
+      expect(result!.city).toBeNull()
     })
   })
 
@@ -133,28 +131,26 @@ describe("City", () => {
       }
     })
 
-    it("resolves nearby shows", () => {
-      return runQuery(query, context).then((result) => {
-        expect(result!.city).toEqual({
-          name: "Sacramende",
-          showsConnection: {
-            edges: [
-              {
-                node: {
-                  slug: "first-show",
-                },
+    it("resolves nearby shows", async () => {
+      const result = await runQuery(query, context)
+      expect(result!.city).toEqual({
+        name: "Sacramende",
+        showsConnection: {
+          edges: [
+            {
+              node: {
+                slug: "first-show",
               },
-            ],
-          },
-        })
-
-        expect(mockShowsLoader).toHaveBeenCalledWith(
-          expect.objectContaining({
-            near: "38.5,-121.8",
-            total_count: true,
-          })
-        )
+            },
+          ],
+        },
       })
+      expect(mockShowsLoader).toHaveBeenCalledWith(
+        expect.objectContaining({
+          near: "38.5,-121.8",
+          total_count: true,
+        })
+      )
     })
 
     it("requests displayable shows, by default", async () => {
@@ -390,7 +386,7 @@ describe("City", () => {
       }
     })
 
-    it("resolves nearby fairs", () => {
+    it("resolves nearby fairs", async () => {
       const query = gql`
         {
           city(slug: "sacramende-ca-usa") {
@@ -406,21 +402,19 @@ describe("City", () => {
         }
       `
 
-      return runQuery(query, context).then((result) => {
-        expect(result!.city).toEqual({
-          name: "Sacramende",
-          fairsConnection: {
-            edges: [{ node: { slug: "first-fair" } }],
-          },
-        })
-
-        expect(mockFairsLoader).toHaveBeenCalledWith(
-          expect.objectContaining({
-            near: "38.5,-121.8",
-            total_count: true,
-          })
-        )
+      const result = await runQuery(query, context)
+      expect(result!.city).toEqual({
+        name: "Sacramende",
+        fairsConnection: {
+          edges: [{ node: { slug: "first-fair" } }],
+        },
       })
+      expect(mockFairsLoader).toHaveBeenCalledWith(
+        expect.objectContaining({
+          near: "38.5,-121.8",
+          total_count: true,
+        })
+      )
     })
 
     it("can request all shows [that match other filter parameters]", async () => {

--- a/src/schema/v2/__tests__/collection.test.js
+++ b/src/schema/v2/__tests__/collection.test.js
@@ -14,7 +14,7 @@ const gravityData = {
   private: false,
 }
 
-xdescribe("Collections", () => {
+describe.skip("Collections", () => {
   describe("Handles getting collection metadata", () => {
     it("returns collection metadata", async () => {
       const query = `

--- a/src/schema/v2/__tests__/credit_card.test.ts
+++ b/src/schema/v2/__tests__/credit_card.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable promise/always-return */
 import { runQuery } from "schema/v2/test/utils"
 
-xdescribe("CreditCard type", () => {
+describe.skip("CreditCard type", () => {
   let creditCard: any
   let context: any
 

--- a/src/schema/v2/__tests__/ecommerce/buyer_accept_offer_mutation.test.ts
+++ b/src/schema/v2/__tests__/ecommerce/buyer_accept_offer_mutation.test.ts
@@ -29,7 +29,7 @@ describe("BuyerAcceptOffer Mutation", () => {
     }
   `
 
-  it("accepts the seller offer", () => {
+  it("accepts the seller offer", async () => {
     const resolvers = {
       Mutation: {
         buyerAcceptOffer: () => ({
@@ -40,14 +40,14 @@ describe("BuyerAcceptOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceBuyerAcceptOffer.orderOrError.order).toEqual(
-        sampleOrder()
-      )
-    })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceBuyerAcceptOffer.orderOrError.order).toEqual(
+      sampleOrder()
+    )
   })
 
-  it("returns an error if there is one", () => {
+  it("returns an error if there is one", async () => {
     const resolvers = {
       Mutation: {
         buyerAcceptOffer: () => ({
@@ -63,12 +63,12 @@ describe("BuyerAcceptOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceBuyerAcceptOffer.orderOrError.error).toEqual({
-        type: "application_error",
-        code: "404",
-        data: null,
-      })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceBuyerAcceptOffer.orderOrError.error).toEqual({
+      type: "application_error",
+      code: "404",
+      data: null,
     })
   })
 })

--- a/src/schema/v2/__tests__/ecommerce/buyer_counter_offer_mutation.test.ts
+++ b/src/schema/v2/__tests__/ecommerce/buyer_counter_offer_mutation.test.ts
@@ -29,7 +29,7 @@ describe("BuyerCounterOffer Mutation", () => {
     }
   `
 
-  it("counters sellers offer", () => {
+  it("counters sellers offer", async () => {
     const resolvers = {
       Mutation: {
         buyerCounterOffer: () => ({
@@ -40,18 +40,18 @@ describe("BuyerCounterOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceBuyerCounterOffer.orderOrError.order).toEqual(
-        sampleOrder({
-          mode: "OFFER",
-          includeOfferFields: true,
-          includeCreditCard: true,
-        })
-      )
-    })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceBuyerCounterOffer.orderOrError.order).toEqual(
+      sampleOrder({
+        mode: "OFFER",
+        includeOfferFields: true,
+        includeCreditCard: true,
+      })
+    )
   })
 
-  it("returns an error if there is one", () => {
+  it("returns an error if there is one", async () => {
     const resolvers = {
       Mutation: {
         buyerCounterOffer: () => ({
@@ -67,12 +67,12 @@ describe("BuyerCounterOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceBuyerCounterOffer.orderOrError.error).toEqual({
-        type: "application_error",
-        code: "404",
-        data: null,
-      })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceBuyerCounterOffer.orderOrError.error).toEqual({
+      type: "application_error",
+      code: "404",
+      data: null,
     })
   })
 })

--- a/src/schema/v2/__tests__/ecommerce/buyer_reject_offer_mutation.test.ts
+++ b/src/schema/v2/__tests__/ecommerce/buyer_reject_offer_mutation.test.ts
@@ -50,7 +50,7 @@ describe("BuyerRejectOffer Mutation", () => {
     }
   `
 
-  it("rejects the seller offer with a reason", () => {
+  it("rejects the seller offer with a reason", async () => {
     const resolvers = {
       Mutation: {
         buyerRejectOffer: () => ({
@@ -61,14 +61,13 @@ describe("BuyerRejectOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutationWithRejectReason, context).then((data) => {
-      expect(data!.ecommerceBuyerRejectOffer.orderOrError.order).toEqual(
-        sampleOrder()
-      )
-    })
+    const data = await runQuery(mutationWithRejectReason, context)
+    expect(data!.ecommerceBuyerRejectOffer.orderOrError.order).toEqual(
+      sampleOrder()
+    )
   })
 
-  it("rejects the seller offer without a reason", () => {
+  it("rejects the seller offer without a reason", async () => {
     const resolvers = {
       Mutation: {
         buyerRejectOffer: () => ({
@@ -79,14 +78,13 @@ describe("BuyerRejectOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutationWithoutRejectReason, context).then((data) => {
-      expect(data!.ecommerceBuyerRejectOffer.orderOrError.order).toEqual(
-        sampleOrder()
-      )
-    })
+    const data = await runQuery(mutationWithoutRejectReason, context)
+    expect(data!.ecommerceBuyerRejectOffer.orderOrError.order).toEqual(
+      sampleOrder()
+    )
   })
 
-  it("returns an error if an error occurs", () => {
+  it("returns an error if an error occurs", async () => {
     const resolvers = {
       Mutation: {
         buyerRejectOffer: () => ({
@@ -102,12 +100,11 @@ describe("BuyerRejectOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutationWithoutRejectReason, context).then((data) => {
-      expect(data!.ecommerceBuyerRejectOffer.orderOrError.error).toEqual({
-        type: "application_error",
-        code: "404",
-        data: null,
-      })
+    const data = await runQuery(mutationWithoutRejectReason, context)
+    expect(data!.ecommerceBuyerRejectOffer.orderOrError.error).toEqual({
+      type: "applicaxtion_error",
+      code: "404",
+      data: null,
     })
   })
 })

--- a/src/schema/v2/__tests__/ecommerce/fix_failed_payment.test.ts
+++ b/src/schema/v2/__tests__/ecommerce/fix_failed_payment.test.ts
@@ -29,7 +29,7 @@ describe("FixFailedPayment Mutation", () => {
     }
   `
 
-  it("does not fail", () => {
+  it("does not fail", async () => {
     const resolvers = {
       Mutation: {
         fixFailedPayment: () => ({
@@ -40,14 +40,14 @@ describe("FixFailedPayment Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceFixFailedPayment.orderOrError.order).toEqual(
-        sampleOrder({ includeCreditCard: true })
-      )
-    })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceFixFailedPayment.orderOrError.order).toEqual(
+      sampleOrder({ includeCreditCard: true })
+    )
   })
 
-  it("returns an error if there is one", () => {
+  it("returns an error if there is one", async () => {
     const resolvers = {
       Mutation: {
         fixFailedPayment: () => ({
@@ -63,12 +63,12 @@ describe("FixFailedPayment Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceFixFailedPayment.orderOrError.error).toEqual({
-        type: "application_error",
-        code: "404",
-        data: null,
-      })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceFixFailedPayment.orderOrError.error).toEqual({
+      type: "application_error",
+      code: "404",
+      data: null,
     })
   })
 })

--- a/src/schema/v2/__tests__/ecommerce/orders.test.ts
+++ b/src/schema/v2/__tests__/ecommerce/orders.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable promise/always-return */
-
 import { runQuery } from "schema/v2/test/utils"
 import { mockxchange } from "test/fixtures/exchange/mockxchange"
 import { sampleOrder } from "test/fixtures/results/sample_order"
@@ -14,7 +12,7 @@ describe("Orders query", () => {
     const resolvers = { Query: { orders: () => exchangeOrdersJSON } }
     context = mockxchange(resolvers)
   })
-  it("fetches orders by seller id", () => {
+  it("fetches orders by seller id", async () => {
     const query = gql`
       {
         orders(sellerId: "581b45e4cd530e658b000124") {
@@ -51,16 +49,16 @@ describe("Orders query", () => {
       }
     `
 
-    return runQuery(query, context).then((data) => {
-      expect(data!.orders.totalCount).toEqual(100)
-      expect(data!.orders.totalPages).toEqual(10)
-      expect(data!.orders.pageCursors).not.toBeNull
-      expect(data!.orders.pageCursors.first.page).toEqual(1)
-      expect(data!.orders.pageCursors.last.page).toEqual(10)
-      expect(data!.orders.pageCursors.around.length).toEqual(3)
-      expect(data!.orders.pageCursors.previous.page).toEqual(4)
-      expect(data!.orders.totalPages).toEqual(10)
-      expect(data!.orders.edges[0].node).toEqual(sampleOrder())
-    })
+    const data = await runQuery(query, context)
+
+    expect(data!.orders.totalCount).toEqual(100)
+    expect(data!.orders.totalPages).toEqual(10)
+    expect(data!.orders.pageCursors).not.toBeNull()
+    expect(data!.orders.pageCursors.first.page).toEqual(1)
+    expect(data!.orders.pageCursors.last.page).toEqual(10)
+    expect(data!.orders.pageCursors.around.length).toEqual(3)
+    expect(data!.orders.pageCursors.previous.page).toEqual(4)
+    expect(data!.orders.totalPages).toEqual(10)
+    expect(data!.orders.edges[0].node).toEqual(sampleOrder())
   })
 })

--- a/src/schema/v2/__tests__/ecommerce/seller_accept_offer_mutation.test.ts
+++ b/src/schema/v2/__tests__/ecommerce/seller_accept_offer_mutation.test.ts
@@ -29,7 +29,7 @@ describe("SellerAcceptOffer Mutation", () => {
     }
   `
 
-  it("approves the order of the offer", () => {
+  it("approves the order of the offer", async () => {
     const resolvers = {
       Mutation: {
         sellerAcceptOffer: () => ({
@@ -40,14 +40,14 @@ describe("SellerAcceptOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceSellerAcceptOffer.orderOrError.order).toEqual(
-        sampleOrder()
-      )
-    })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceSellerAcceptOffer.orderOrError.order).toEqual(
+      sampleOrder()
+    )
   })
 
-  it("returns an error if there is one", () => {
+  it("returns an error if there is one", async () => {
     const resolvers = {
       Mutation: {
         sellerAcceptOffer: () => ({
@@ -63,12 +63,12 @@ describe("SellerAcceptOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceSellerAcceptOffer.orderOrError.error).toEqual({
-        type: "application_error",
-        code: "404",
-        data: null,
-      })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceSellerAcceptOffer.orderOrError.error).toEqual({
+      type: "application_error",
+      code: "404",
+      data: null,
     })
   })
 })

--- a/src/schema/v2/__tests__/ecommerce/seller_counter_offer_mutation.test.ts
+++ b/src/schema/v2/__tests__/ecommerce/seller_counter_offer_mutation.test.ts
@@ -29,7 +29,7 @@ describe("SellerCounterOffer Mutation", () => {
     }
   `
 
-  it("counters buyers offer", () => {
+  it("counters buyers offer", async () => {
     const resolvers = {
       Mutation: {
         sellerCounterOffer: () => ({
@@ -40,14 +40,14 @@ describe("SellerCounterOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceSellerCounterOffer.orderOrError.order).toEqual(
-        sampleOrder({ mode: "OFFER", includeOfferFields: true })
-      )
-    })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceSellerCounterOffer.orderOrError.order).toEqual(
+      sampleOrder({ mode: "OFFER", includeOfferFields: true })
+    )
   })
 
-  it("returns an error if there is one", () => {
+  it("returns an error if there is one", async () => {
     const resolvers = {
       Mutation: {
         sellerCounterOffer: () => ({
@@ -63,12 +63,12 @@ describe("SellerCounterOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceSellerCounterOffer.orderOrError.error).toEqual({
-        type: "application_error",
-        code: "404",
-        data: null,
-      })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceSellerCounterOffer.orderOrError.error).toEqual({
+      type: "application_error",
+      code: "404",
+      data: null,
     })
   })
 })

--- a/src/schema/v2/__tests__/ecommerce/seller_reject_offer_mutation.test.ts
+++ b/src/schema/v2/__tests__/ecommerce/seller_reject_offer_mutation.test.ts
@@ -29,7 +29,7 @@ describe("SellerRejectOffer Mutation", () => {
     }
   `
 
-  it("rejects the order of the offer", () => {
+  it("rejects the order of the offer", async () => {
     const resolvers = {
       Mutation: {
         sellerRejectOffer: () => ({
@@ -40,14 +40,14 @@ describe("SellerRejectOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceSellerRejectOffer.orderOrError.order).toEqual(
-        sampleOrder()
-      )
-    })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceSellerRejectOffer.orderOrError.order).toEqual(
+      sampleOrder()
+    )
   })
 
-  it("returns an error if there is one", () => {
+  it("returns an error if there is one", async () => {
     const resolvers = {
       Mutation: {
         sellerRejectOffer: () => ({
@@ -63,12 +63,12 @@ describe("SellerRejectOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceSellerRejectOffer.orderOrError.error).toEqual({
-        type: "application_error",
-        code: "404",
-        data: null,
-      })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceSellerRejectOffer.orderOrError.error).toEqual({
+      type: "application_error",
+      code: "404",
+      data: null,
     })
   })
 })

--- a/src/schema/v2/__tests__/ecommerce/submit_pending_offer_mutation.test.ts
+++ b/src/schema/v2/__tests__/ecommerce/submit_pending_offer_mutation.test.ts
@@ -29,7 +29,7 @@ describe("SubmitPendingOffer Mutation", () => {
     }
   `
 
-  it("submits offer", () => {
+  it("submits offer", async () => {
     const resolvers = {
       Mutation: {
         submitPendingOffer: () => ({
@@ -40,14 +40,14 @@ describe("SubmitPendingOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceSubmitPendingOffer.orderOrError.order).toEqual(
-        sampleOrder()
-      )
-    })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceSubmitPendingOffer.orderOrError.order).toEqual(
+      sampleOrder()
+    )
   })
 
-  it("returns an error if there is one", () => {
+  it("returns an error if there is one", async () => {
     const resolvers = {
       Mutation: {
         submitPendingOffer: () => ({
@@ -63,12 +63,12 @@ describe("SubmitPendingOffer Mutation", () => {
 
     context = mockxchange(resolvers)
 
-    return runQuery(mutation, context).then((data) => {
-      expect(data!.ecommerceSubmitPendingOffer.orderOrError.error).toEqual({
-        type: "application_error",
-        code: "404",
-        data: null,
-      })
+    const data = await runQuery(mutation, context)
+
+    expect(data!.ecommerceSubmitPendingOffer.orderOrError.error).toEqual({
+      type: "application_error",
+      code: "404",
+      data: null,
     })
   })
 })

--- a/src/schema/v2/__tests__/filterArtworksConnection.test.ts
+++ b/src/schema/v2/__tests__/filterArtworksConnection.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable promise/always-return */
 import { runQuery } from "schema/v2/test/utils"
 import { toGlobalId } from "graphql-relay"
 import gql from "lib/gql"
@@ -348,6 +347,8 @@ describe("artworksConnection", () => {
     })
 
     it("throws an error when `first`, `last` and `size` are missing", async () => {
+      expect.assertions(1)
+
       const query = gql`
         {
           artworksConnection(aggregations: [TOTAL]) {
@@ -358,14 +359,9 @@ describe("artworksConnection", () => {
         }
       `
 
-      expect.assertions(1)
-      try {
-        await runQuery(query, context)
-      } catch (e) {
-        expect(e.message).toMatch(
-          "You must pass either `first`, `last` or `size`."
-        )
-      }
+      await expect(runQuery(query, context)).rejects.toThrow(
+        "You must pass either `first`, `last` or `size`."
+      )
     })
   })
 

--- a/src/schema/v2/__tests__/object_identification.test.js
+++ b/src/schema/v2/__tests__/object_identification.test.js
@@ -68,11 +68,11 @@ describe("Object Identification", () => {
     }
 
     describe(`for a ${typeName}`, () => {
-      xit("generates a Global ID", () => {
+      it.skip("generates a Global ID", () => {
         const query = `
           {
             ${fieldName}(id: "foo-bar") {
-              id 
+              id
             }
           }
         `
@@ -92,7 +92,7 @@ describe("Object Identification", () => {
             node(id: "${toGlobalId(typeName, "foo-bar")}") {
               __typename
               ... on ${typeName} {
-                slug 
+                slug
               }
             }
           }

--- a/src/schema/v2/__tests__/partners.test.js
+++ b/src/schema/v2/__tests__/partners.test.js
@@ -32,7 +32,7 @@ describe("PartnersConnection", () => {
   })
 })
 
-xdescribe("Partners", () => {
+describe.skip("Partners", () => {
   it("returns a list of partners matching array of ids", async () => {
     const partnersLoader = ({ id }) => {
       if (id) {

--- a/src/schema/v2/__tests__/profile.test.js
+++ b/src/schema/v2/__tests__/profile.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable promise/always-return */
 import { runQuery } from "schema/v2/test/utils"
 
-xdescribe("Profile type", () => {
+describe.skip("Profile type", () => {
   let profileData = null
   let context = null
 

--- a/src/schema/v2/__tests__/startIdentityVerificationMutation.test.ts
+++ b/src/schema/v2/__tests__/startIdentityVerificationMutation.test.ts
@@ -23,11 +23,9 @@ mutation {
 
 describe("starting an identity verification", () => {
   it("requires an access token", async () => {
-    runQuery(mutation).catch((error) => {
-      expect(error.message).toEqual(
-        "You need to be signed in to perform this action"
-      )
-    })
+    await expect(runQuery(mutation)).rejects.toThrow(
+      "You need to be signed in to perform this action"
+    )
   })
 
   it("returns the given identity verification ID and flow URL from Gravity", async () => {
@@ -78,15 +76,15 @@ describe("starting an identity verification", () => {
     })
   })
 
-  it("throws an error if there is an unrecognizable error", () => {
+  it("throws an error if there is an unrecognizable error", async () => {
     const errorRootValue = {
       startIdentityVerificationLoader: () => {
         throw new Error("ETIMEOUT service unreachable")
       },
     }
 
-    runAuthenticatedQuery(mutation, errorRootValue).catch((error) => {
-      expect(error.message).toEqual("ETIMEOUT service unreachable")
-    })
+    await expect(
+      runAuthenticatedQuery(mutation, errorRootValue)
+    ).rejects.toThrow("ETIMEOUT service unreachable")
   })
 })

--- a/src/schema/v2/__tests__/vanityURLEntity.test.ts
+++ b/src/schema/v2/__tests__/vanityURLEntity.test.ts
@@ -146,14 +146,13 @@ describe("vanityURLEntity", () => {
       }
     `
     expect.assertions(1)
-    try {
-      await runAuthenticatedQuery(query, {
+
+    await expect(
+      runAuthenticatedQuery(query, {
         profileLoader,
         partnerLoader,
         fairLoader,
       })
-    } catch (e) {
-      expect(e.message).toMatch("Unrecognized profile type: UnknownType")
-    }
+    ).rejects.toThrow("Unrecognized profile type: UnknownType")
   })
 })

--- a/src/schema/v2/artists/__tests__/trending.test.js
+++ b/src/schema/v2/artists/__tests__/trending.test.js
@@ -1,7 +1,7 @@
 import gql from "lib/gql"
 import { runQuery } from "schema/v2/test/utils"
 
-xdescribe("Trending Artists", () => {
+describe.skip("Trending Artists", () => {
   it("makes a call for trending artists", async () => {
     const query = gql`
       {

--- a/src/schema/v2/artwork/artworkContextGrids/__tests__/auctionContext.test.ts
+++ b/src/schema/v2/artwork/artworkContextGrids/__tests__/auctionContext.test.ts
@@ -4,7 +4,7 @@ import { assign } from "lodash"
 
 describe("Default Context", () => {
   let context: any
-  let parentArtwork = {}
+  const parentArtwork = {}
 
   const query = gql`
     {
@@ -100,28 +100,25 @@ describe("Default Context", () => {
         auction_state: "closed",
       })
 
-    await runAuthenticatedQuery(query, context).then((data) => {
-      // Returns the default grid
-      expect(data.artwork.contextGrids.length).toEqual(3)
-    })
+    const data = await runAuthenticatedQuery(query, context)
+    // Returns the default grid
+    expect(data.artwork.contextGrids.length).toEqual(3)
   })
 
   it("Returns the correct values for metadata fields for an open auction", async () => {
-    await runAuthenticatedQuery(query, context).then((data) => {
-      // Should have one artist grid and one related grid with 0 works
-      expect(data.artwork.contextGrids.length).toEqual(1)
-      const {
-        title,
-        ctaTitle,
-        ctaHref,
-        artworksConnection,
-      } = data.artwork.contextGrids[0]
-
-      expect(title).toEqual("Other works from Phillips Auction")
-      expect(ctaTitle).toEqual("View all works from the auction")
-      expect(ctaHref).toEqual("/auction/phillips-auction")
-      expect(artworksConnection.edges.length).toEqual(2)
-    })
+    const data = await runAuthenticatedQuery(query, context)
+    // Should have one artist grid and one related grid with 0 works
+    expect(data.artwork.contextGrids.length).toEqual(1)
+    const {
+      title,
+      ctaTitle,
+      ctaHref,
+      artworksConnection,
+    } = data.artwork.contextGrids[0]
+    expect(title).toEqual("Other works from Phillips Auction")
+    expect(ctaTitle).toEqual("View all works from the auction")
+    expect(ctaHref).toEqual("/auction/phillips-auction")
+    expect(artworksConnection.edges.length).toEqual(2)
   })
 
   it("Returns the correct values for metadata fields for a closed auction", async () => {
@@ -132,26 +129,23 @@ describe("Default Context", () => {
         auction_state: "closed",
       })
 
-    await runAuthenticatedQuery(query, context).then((data) => {
-      // Should have one partner grid and one related grid with 0 works
-      expect(data.artwork.contextGrids.length).toEqual(2)
-      const {
-        title,
-        ctaTitle,
-        ctaHref,
-        artworksConnection,
-      } = data.artwork.contextGrids[0]
-
-      expect(title).toEqual("Other works by Andy Warhol")
-      expect(ctaTitle).toEqual("View all works by Andy Warhol")
-      expect(ctaHref).toEqual("/artist/andy-warhol")
-      expect(artworksConnection.edges.map(({ node }) => node.slug)).toEqual([
-        "artwork1",
-        "artwork2",
-      ])
-
-      // Related artworks grid should have no artworks
-      expect(data.artwork.contextGrids[1].artworksConnection).toEqual(null)
-    })
+    const data = await runAuthenticatedQuery(query, context)
+    // Should have one partner grid and one related grid with 0 works
+    expect(data.artwork.contextGrids.length).toEqual(2)
+    const {
+      title,
+      ctaTitle,
+      ctaHref,
+      artworksConnection,
+    } = data.artwork.contextGrids[0]
+    expect(title).toEqual("Other works by Andy Warhol")
+    expect(ctaTitle).toEqual("View all works by Andy Warhol")
+    expect(ctaHref).toEqual("/artist/andy-warhol")
+    expect(artworksConnection.edges.map(({ node }) => node.slug)).toEqual([
+      "artwork1",
+      "artwork2",
+    ])
+    // Related artworks grid should have no artworks
+    expect(data.artwork.contextGrids[1].artworksConnection).toEqual(null)
   })
 })

--- a/src/schema/v2/artwork/artworkContextGrids/__tests__/defaultContext.test.ts
+++ b/src/schema/v2/artwork/artworkContextGrids/__tests__/defaultContext.test.ts
@@ -4,7 +4,7 @@ import { assign } from "lodash"
 
 describe("Default Context", () => {
   let context: any
-  let parentArtwork = {} as any
+  const parentArtwork = {} as any
 
   const query = gql`
     {
@@ -81,14 +81,13 @@ describe("Default Context", () => {
       Promise.resolve(artistArtworks)
     )
 
-    await runAuthenticatedQuery(query, context).then((data) => {
-      expect(data.artwork.contextGrids.length).toEqual(3)
-      expect(context.artistArtworksLoader).toHaveBeenCalledWith("andy-warhol", {
-        exclude_ids: ["abc123"],
-        page: 1,
-        size: 2,
-        sort: "-merchandisability",
-      })
+    const data = await runAuthenticatedQuery(query, context)
+    expect(data.artwork.contextGrids.length).toEqual(3)
+    expect(context.artistArtworksLoader).toHaveBeenCalledWith("andy-warhol", {
+      exclude_ids: ["abc123"],
+      page: 1,
+      size: 2,
+      sort: "-merchandisability",
     })
     expect.assertions(2)
   })
@@ -97,24 +96,21 @@ describe("Default Context", () => {
     parentArtwork.partner = null
     context.partnerArtworksLoader = Promise.resolve(null)
 
-    await runAuthenticatedQuery(query, context).then((data) => {
-      // Should have one artist grid and one related grid with 0 works
-      expect(data.artwork.contextGrids.length).toEqual(2)
-      const {
-        title,
-        ctaTitle,
-        ctaHref,
-        artworksConnection,
-      } = data.artwork.contextGrids[0]
-
-      expect(title).toEqual("Other works by Andy Warhol")
-      expect(ctaTitle).toEqual("View all works by Andy Warhol")
-      expect(ctaHref).toEqual("/artist/andy-warhol")
-      expect(artworksConnection.edges.length).toEqual(2)
-
-      // Related artworks grid should have no artworks
-      expect(data.artwork.contextGrids[1].artworksConnection).toEqual(null)
-    })
+    const data = await runAuthenticatedQuery(query, context)
+    // Should have one artist grid and one related grid with 0 works
+    expect(data.artwork.contextGrids.length).toEqual(2)
+    const {
+      title,
+      ctaTitle,
+      ctaHref,
+      artworksConnection,
+    } = data.artwork.contextGrids[0]
+    expect(title).toEqual("Other works by Andy Warhol")
+    expect(ctaTitle).toEqual("View all works by Andy Warhol")
+    expect(ctaHref).toEqual("/artist/andy-warhol")
+    expect(artworksConnection.edges.length).toEqual(2)
+    // Related artworks grid should have no artworks
+    expect(data.artwork.contextGrids[1].artworksConnection).toEqual(null)
     expect.assertions(6)
   })
 
@@ -122,23 +118,21 @@ describe("Default Context", () => {
     parentArtwork.artist = null
     context.artistArtworksLoader = Promise.resolve(null)
 
-    await runAuthenticatedQuery(query, context).then((data) => {
-      // Should have one partner grid and one related grid with 0 works
-      expect(data.artwork.contextGrids.length).toEqual(2)
-      const {
-        title,
-        ctaTitle,
-        ctaHref,
-        artworksConnection,
-      } = data.artwork.contextGrids[0]
-      expect(title).toEqual("Other works from CAMA Gallery")
-      expect(ctaTitle).toEqual("View all works from CAMA Gallery")
-      expect(ctaHref).toEqual("/cama-gallery")
-      expect(artworksConnection.edges.length).toEqual(2)
-
-      // Related artworks grid should have no artworks
-      expect(data.artwork.contextGrids[1].artworksConnection).toEqual(null)
-    })
+    const data = await runAuthenticatedQuery(query, context)
+    // Should have one partner grid and one related grid with 0 works
+    expect(data.artwork.contextGrids.length).toEqual(2)
+    const {
+      title,
+      ctaTitle,
+      ctaHref,
+      artworksConnection,
+    } = data.artwork.contextGrids[0]
+    expect(title).toEqual("Other works from CAMA Gallery")
+    expect(ctaTitle).toEqual("View all works from CAMA Gallery")
+    expect(ctaHref).toEqual("/cama-gallery")
+    expect(artworksConnection.edges.length).toEqual(2)
+    // Related artworks grid should have no artworks
+    expect(data.artwork.contextGrids[1].artworksConnection).toEqual(null)
     expect.assertions(6)
   })
 
@@ -151,58 +145,49 @@ describe("Default Context", () => {
         { id: "relatedArtwork3", title: "Related Artwork 3" },
       ])
 
-    await runAuthenticatedQuery(query, context).then((data) => {
-      // Should have one artist grid and one related grid with 0 works
-      expect(data.artwork.contextGrids.length).toEqual(3)
-
-      // The first grid should include artist-related metadata
-      const {
-        title: artistTitle,
-        ctaTitle: artistCtaTitle,
-        ctaHref: artistctaHref,
-        artworksConnection: artistArtworks,
-      } = data.artwork.contextGrids[0]
-
-      expect(artistTitle).toEqual("Other works by Andy Warhol")
-      expect(artistCtaTitle).toEqual("View all works by Andy Warhol")
-      expect(artistctaHref).toEqual("/artist/andy-warhol")
-      expect(artistArtworks.edges.map(({ node }) => node.slug)).toEqual([
-        "artwork1",
-        "artwork2",
-      ])
-
-      // The second grid should include partner-related metadata
-      const {
-        title: partnerTitle,
-        ctaTitle: partnerCtaTitle,
-        ctaHref: partnerctaHref,
-        artworksConnection: partnerArtworks,
-      } = data.artwork.contextGrids[1]
-
-      expect(partnerTitle).toEqual("Other works from CAMA Gallery")
-      expect(partnerCtaTitle).toEqual("View all works from CAMA Gallery")
-      expect(partnerctaHref).toEqual("/cama-gallery")
-      expect(partnerArtworks.edges.map(({ node }) => node.slug)).toEqual([
-        "partnerArtwork1",
-        "partnerArtwork2",
-      ])
-
-      // The third grid should include related artworks
-      const {
-        title: relatedTitle,
-        ctaTitle: relatedCtaTitle,
-        ctaHref: relatedctaHref,
-        artworksConnection: relatedArtworks,
-      } = data.artwork.contextGrids[2]
-
-      expect(relatedTitle).toEqual("Related works")
-      expect(relatedCtaTitle).toEqual(null)
-      expect(relatedctaHref).toEqual(null)
-      expect(relatedArtworks.edges.map(({ node }) => node.slug)).toEqual([
-        "relatedArtwork1",
-        "relatedArtwork2",
-      ])
-    })
+    const data = await runAuthenticatedQuery(query, context)
+    // Should have one artist grid and one related grid with 0 works
+    expect(data.artwork.contextGrids.length).toEqual(3)
+    // The first grid should include artist-related metadata
+    const {
+      title: artistTitle,
+      ctaTitle: artistCtaTitle,
+      ctaHref: artistctaHref,
+      artworksConnection: artistArtworks,
+    } = data.artwork.contextGrids[0]
+    expect(artistTitle).toEqual("Other works by Andy Warhol")
+    expect(artistCtaTitle).toEqual("View all works by Andy Warhol")
+    expect(artistctaHref).toEqual("/artist/andy-warhol")
+    expect(artistArtworks.edges.map(({ node }) => node.slug)).toEqual([
+      "artwork1",
+      "artwork2",
+    ])
+    // The second grid should include partner-related metadata
+    const {
+      title: partnerTitle,
+      ctaTitle: partnerCtaTitle,
+      ctaHref: partnerctaHref,
+      artworksConnection: partnerArtworks,
+    } = data.artwork.contextGrids[1]
+    expect(partnerTitle).toEqual("Other works from CAMA Gallery")
+    expect(partnerCtaTitle).toEqual("View all works from CAMA Gallery")
+    expect(partnerctaHref).toEqual("/cama-gallery")
+    expect(
+      partnerArtworks.edges.map(({ node: node_1 }) => node_1.slug)
+    ).toEqual(["partnerArtwork1", "partnerArtwork2"])
+    // The third grid should include related artworks
+    const {
+      title: relatedTitle,
+      ctaTitle: relatedCtaTitle,
+      ctaHref: relatedctaHref,
+      artworksConnection: relatedArtworks,
+    } = data.artwork.contextGrids[2]
+    expect(relatedTitle).toEqual("Related works")
+    expect(relatedCtaTitle).toEqual(null)
+    expect(relatedctaHref).toEqual(null)
+    expect(
+      relatedArtworks.edges.map(({ node: node_2 }) => node_2.slug)
+    ).toEqual(["relatedArtwork1", "relatedArtwork2"])
     expect.assertions(13)
   })
 })

--- a/src/schema/v2/artwork/artworkContextGrids/__tests__/fairContext.test.ts
+++ b/src/schema/v2/artwork/artworkContextGrids/__tests__/fairContext.test.ts
@@ -4,7 +4,7 @@ import { assign } from "lodash"
 
 describe("Show Context", () => {
   let context: any
-  let parentArtwork = {} as any
+  const parentArtwork = {} as any
 
   const query = gql`
     {
@@ -90,30 +90,27 @@ describe("Show Context", () => {
     }
   })
 
-  it("Returns the correct values for metadata fields when there is just show data", () => {
+  it("Returns the correct values for metadata fields when there is just show data", async () => {
     expect.assertions(6)
 
     parentArtwork.artist = null
     context.artistArtworksLoader = () => Promise.resolve(null)
 
-    return runAuthenticatedQuery(query, context).then((data) => {
-      // Should have one artist grid and one related grid with 0 works
-      expect(data.artwork.contextGrids.length).toEqual(2)
-      const {
-        title,
-        ctaTitle,
-        ctaHref,
-        artworksConnection,
-      } = data.artwork.contextGrids[0]
-
-      expect(title).toEqual("Other works from Cool Show")
-      expect(ctaTitle).toEqual("View all works from the booth")
-      expect(ctaHref).toEqual("/show/cool-show")
-      expect(artworksConnection.edges.length).toEqual(2)
-
-      // Related artworks grid should have no artworks
-      expect(data.artwork.contextGrids[1].artworksConnection).toEqual(null)
-    })
+    const data = await runAuthenticatedQuery(query, context)
+    // Should have one artist grid and one related grid with 0 works
+    expect(data.artwork.contextGrids.length).toEqual(2)
+    const {
+      title,
+      ctaTitle,
+      ctaHref,
+      artworksConnection,
+    } = data.artwork.contextGrids[0]
+    expect(title).toEqual("Other works from Cool Show")
+    expect(ctaTitle).toEqual("View all works from the booth")
+    expect(ctaHref).toEqual("/show/cool-show")
+    expect(artworksConnection.edges.length).toEqual(2)
+    // Related artworks grid should have no artworks
+    expect(data.artwork.contextGrids[1].artworksConnection).toEqual(null)
   })
 
   it("Returns the correct values for metadata fields when there is all data", async () => {
@@ -125,58 +122,49 @@ describe("Show Context", () => {
         { id: "relatedArtwork3", title: "Related Artwork 3" },
       ])
 
-    await runAuthenticatedQuery(query, context).then((data) => {
-      // Should have one artist grid and one related grid with 0 works
-      expect(data.artwork.contextGrids.length).toEqual(3)
-
-      // The first grid should include show-related metadata
-      const {
-        title: showTitle,
-        ctaTitle: showCtaTitle,
-        ctaHref: showctaHref,
-        artworksConnection: showArtworks,
-      } = data.artwork.contextGrids[0]
-
-      expect(showTitle).toEqual("Other works from Cool Show")
-      expect(showCtaTitle).toEqual("View all works from the booth")
-      expect(showctaHref).toEqual("/show/cool-show")
-      expect(showArtworks.edges.map(({ node }) => node.slug)).toEqual([
-        "showArtwork1",
-        "showArtwork2",
-      ])
-
-      // The second grid should include artist-related metadata
-      const {
-        title: artistTitle,
-        ctaTitle: artistCtaTitle,
-        ctaHref: artistctaHref,
-        artworksConnection: artistArtworks,
-      } = data.artwork.contextGrids[1]
-
-      expect(artistTitle).toEqual("Other works by Andy Warhol")
-      expect(artistCtaTitle).toEqual("View all works by Andy Warhol")
-      expect(artistctaHref).toEqual("/artist/andy-warhol")
-      expect(artistArtworks.edges.map(({ node }) => node.slug)).toEqual([
-        "artwork1",
-        "artwork2",
-      ])
-
-      // The third grid should include related artworks
-      const {
-        title: relatedTitle,
-        ctaTitle: relatedCtaTitle,
-        ctaHref: relatedctaHref,
-        artworksConnection: relatedArtworks,
-      } = data.artwork.contextGrids[2]
-
-      expect(relatedTitle).toEqual("Related works")
-      expect(relatedCtaTitle).toEqual(null)
-      expect(relatedctaHref).toEqual(null)
-      expect(relatedArtworks.edges.map(({ node }) => node.slug)).toEqual([
-        "relatedArtwork1",
-        "relatedArtwork2",
-      ])
-    })
+    const data = await runAuthenticatedQuery(query, context)
+    // Should have one artist grid and one related grid with 0 works
+    expect(data.artwork.contextGrids.length).toEqual(3)
+    // The first grid should include show-related metadata
+    const {
+      title: showTitle,
+      ctaTitle: showCtaTitle,
+      ctaHref: showctaHref,
+      artworksConnection: showArtworks,
+    } = data.artwork.contextGrids[0]
+    expect(showTitle).toEqual("Other works from Cool Show")
+    expect(showCtaTitle).toEqual("View all works from the booth")
+    expect(showctaHref).toEqual("/show/cool-show")
+    expect(showArtworks.edges.map(({ node }) => node.slug)).toEqual([
+      "showArtwork1",
+      "showArtwork2",
+    ])
+    // The second grid should include artist-related metadata
+    const {
+      title: artistTitle,
+      ctaTitle: artistCtaTitle,
+      ctaHref: artistctaHref,
+      artworksConnection: artistArtworks,
+    } = data.artwork.contextGrids[1]
+    expect(artistTitle).toEqual("Other works by Andy Warhol")
+    expect(artistCtaTitle).toEqual("View all works by Andy Warhol")
+    expect(artistctaHref).toEqual("/artist/andy-warhol")
+    expect(
+      artistArtworks.edges.map(({ node: node_1 }) => node_1.slug)
+    ).toEqual(["artwork1", "artwork2"])
+    // The third grid should include related artworks
+    const {
+      title: relatedTitle,
+      ctaTitle: relatedCtaTitle,
+      ctaHref: relatedctaHref,
+      artworksConnection: relatedArtworks,
+    } = data.artwork.contextGrids[2]
+    expect(relatedTitle).toEqual("Related works")
+    expect(relatedCtaTitle).toEqual(null)
+    expect(relatedctaHref).toEqual(null)
+    expect(
+      relatedArtworks.edges.map(({ node: node_2 }) => node_2.slug)
+    ).toEqual(["relatedArtwork1", "relatedArtwork2"])
     expect.assertions(13)
   })
 })

--- a/src/schema/v2/artwork/artworkContextGrids/__tests__/showContext.test.ts
+++ b/src/schema/v2/artwork/artworkContextGrids/__tests__/showContext.test.ts
@@ -4,7 +4,7 @@ import { assign } from "lodash"
 
 describe("Show Context", () => {
   let context: any
-  let parentArtwork = {} as any
+  const parentArtwork = {} as any
 
   const query = gql`
     {
@@ -97,24 +97,21 @@ describe("Show Context", () => {
     parentArtwork.artist = null
     context.artistArtworksLoader = () => Promise.resolve(null)
 
-    await runAuthenticatedQuery(query, context).then((data) => {
-      // Should have one artist grid and one related grid with 0 works
-      expect(data.artwork.contextGrids.length).toEqual(2)
-      const {
-        title,
-        ctaTitle,
-        ctaHref,
-        artworksConnection,
-      } = data.artwork.contextGrids[0]
-
-      expect(title).toEqual("Other works from Cool Show")
-      expect(ctaTitle).toEqual("View all works from the show")
-      expect(ctaHref).toEqual("/show/cool-show")
-      expect(artworksConnection.edges.length).toEqual(2)
-
-      // Related artworks grid should have no artworks
-      expect(data.artwork.contextGrids[1].artworksConnection).toEqual(null)
-    })
+    const data = await runAuthenticatedQuery(query, context)
+    // Should have one artist grid and one related grid with 0 works
+    expect(data.artwork.contextGrids.length).toEqual(2)
+    const {
+      title,
+      ctaTitle,
+      ctaHref,
+      artworksConnection,
+    } = data.artwork.contextGrids[0]
+    expect(title).toEqual("Other works from Cool Show")
+    expect(ctaTitle).toEqual("View all works from the show")
+    expect(ctaHref).toEqual("/show/cool-show")
+    expect(artworksConnection.edges.length).toEqual(2)
+    // Related artworks grid should have no artworks
+    expect(data.artwork.contextGrids[1].artworksConnection).toEqual(null)
     expect.assertions(6)
   })
 
@@ -123,24 +120,21 @@ describe("Show Context", () => {
     context.artistArtworksLoader = () => Promise.resolve(null)
     context.relatedShowsLoader = () => Promise.resolve(null)
 
-    await runAuthenticatedQuery(query, context).then((data) => {
-      // Should have one partner grid and one related grid with 0 works
-      expect(data.artwork.contextGrids.length).toEqual(2)
-      const {
-        title,
-        ctaTitle,
-        ctaHref,
-        artworksConnection,
-      } = data.artwork.contextGrids[0]
-
-      expect(title).toEqual("Other works from CAMA Gallery")
-      expect(ctaTitle).toEqual("View all works from CAMA Gallery")
-      expect(ctaHref).toEqual("/cama-gallery")
-      expect(artworksConnection.edges.length).toEqual(2)
-
-      // Related artworks grid should have no artworks
-      expect(data.artwork.contextGrids[1].artworksConnection).toEqual(null)
-    })
+    const data = await runAuthenticatedQuery(query, context)
+    // Should have one partner grid and one related grid with 0 works
+    expect(data.artwork.contextGrids.length).toEqual(2)
+    const {
+      title,
+      ctaTitle,
+      ctaHref,
+      artworksConnection,
+    } = data.artwork.contextGrids[0]
+    expect(title).toEqual("Other works from CAMA Gallery")
+    expect(ctaTitle).toEqual("View all works from CAMA Gallery")
+    expect(ctaHref).toEqual("/cama-gallery")
+    expect(artworksConnection.edges.length).toEqual(2)
+    // Related artworks grid should have no artworks
+    expect(data.artwork.contextGrids[1].artworksConnection).toEqual(null)
     expect.assertions(6)
   })
 
@@ -153,74 +147,62 @@ describe("Show Context", () => {
         { id: "relatedArtwork3", title: "Related Artwork 3" },
       ])
 
-    await runAuthenticatedQuery(query, context).then((data) => {
-      // Should have one artist grid and one related grid with 0 works
-      expect(data.artwork.contextGrids.length).toEqual(4)
-
-      // The first grid should include show-related metadata
-      const {
-        title: showTitle,
-        ctaTitle: showCtaTitle,
-        ctaHref: showctaHref,
-        artworksConnection: showArtworks,
-      } = data.artwork.contextGrids[0]
-
-      expect(showTitle).toEqual("Other works from Cool Show")
-      expect(showCtaTitle).toEqual("View all works from the show")
-      expect(showctaHref).toEqual("/show/cool-show")
-      expect(showArtworks.edges.map(({ node }) => node.slug)).toEqual([
-        "showArtwork1",
-        "showArtwork2",
-      ])
-
-      // The second grid should include artist-related metadata
-      const {
-        title: artistTitle,
-        ctaTitle: artistCtaTitle,
-        ctaHref: artistctaHref,
-        artworksConnection: artistArtworks,
-      } = data.artwork.contextGrids[1]
-
-      expect(artistTitle).toEqual("Other works by Andy Warhol")
-      expect(artistCtaTitle).toEqual("View all works by Andy Warhol")
-      expect(artistctaHref).toEqual("/artist/andy-warhol")
-      expect(artistArtworks.edges.map(({ node }) => node.slug)).toEqual([
-        "artwork1",
-        "artwork2",
-      ])
-
-      // The third grid should include partner-related metadata
-      const {
-        title: partnerTitle,
-        ctaTitle: partnerCtaTitle,
-        ctaHref: partnerctaHref,
-        artworksConnection: partnerArtworks,
-      } = data.artwork.contextGrids[2]
-
-      expect(partnerTitle).toEqual("Other works from CAMA Gallery")
-      expect(partnerCtaTitle).toEqual("View all works from CAMA Gallery")
-      expect(partnerctaHref).toEqual("/cama-gallery")
-      expect(partnerArtworks.edges.map(({ node }) => node.slug)).toEqual([
-        "partnerArtwork1",
-        "partnerArtwork2",
-      ])
-
-      // The fourth grid should include related artworks
-      const {
-        title: relatedTitle,
-        ctaTitle: relatedCtaTitle,
-        ctaHref: relatedctaHref,
-        artworksConnection: relatedArtworks,
-      } = data.artwork.contextGrids[3]
-
-      expect(relatedTitle).toEqual("Related works")
-      expect(relatedCtaTitle).toEqual(null)
-      expect(relatedctaHref).toEqual(null)
-      expect(relatedArtworks.edges.map(({ node }) => node.slug)).toEqual([
-        "relatedArtwork1",
-        "relatedArtwork2",
-      ])
-    })
+    const data = await runAuthenticatedQuery(query, context)
+    // Should have one artist grid and one related grid with 0 works
+    expect(data.artwork.contextGrids.length).toEqual(4)
+    // The first grid should include show-related metadata
+    const {
+      title: showTitle,
+      ctaTitle: showCtaTitle,
+      ctaHref: showctaHref,
+      artworksConnection: showArtworks,
+    } = data.artwork.contextGrids[0]
+    expect(showTitle).toEqual("Other works from Cool Show")
+    expect(showCtaTitle).toEqual("View all works from the show")
+    expect(showctaHref).toEqual("/show/cool-show")
+    expect(showArtworks.edges.map(({ node }) => node.slug)).toEqual([
+      "showArtwork1",
+      "showArtwork2",
+    ])
+    // The second grid should include artist-related metadata
+    const {
+      title: artistTitle,
+      ctaTitle: artistCtaTitle,
+      ctaHref: artistctaHref,
+      artworksConnection: artistArtworks,
+    } = data.artwork.contextGrids[1]
+    expect(artistTitle).toEqual("Other works by Andy Warhol")
+    expect(artistCtaTitle).toEqual("View all works by Andy Warhol")
+    expect(artistctaHref).toEqual("/artist/andy-warhol")
+    expect(
+      artistArtworks.edges.map(({ node: node_1 }) => node_1.slug)
+    ).toEqual(["artwork1", "artwork2"])
+    // The third grid should include partner-related metadata
+    const {
+      title: partnerTitle,
+      ctaTitle: partnerCtaTitle,
+      ctaHref: partnerctaHref,
+      artworksConnection: partnerArtworks,
+    } = data.artwork.contextGrids[2]
+    expect(partnerTitle).toEqual("Other works from CAMA Gallery")
+    expect(partnerCtaTitle).toEqual("View all works from CAMA Gallery")
+    expect(partnerctaHref).toEqual("/cama-gallery")
+    expect(
+      partnerArtworks.edges.map(({ node: node_2 }) => node_2.slug)
+    ).toEqual(["partnerArtwork1", "partnerArtwork2"])
+    // The fourth grid should include related artworks
+    const {
+      title: relatedTitle,
+      ctaTitle: relatedCtaTitle,
+      ctaHref: relatedctaHref,
+      artworksConnection: relatedArtworks,
+    } = data.artwork.contextGrids[3]
+    expect(relatedTitle).toEqual("Related works")
+    expect(relatedCtaTitle).toEqual(null)
+    expect(relatedctaHref).toEqual(null)
+    expect(
+      relatedArtworks.edges.map(({ node: node_3 }) => node_3.slug)
+    ).toEqual(["relatedArtwork1", "relatedArtwork2"])
     expect.assertions(17)
   })
 })

--- a/src/schema/v2/asset_uploads/__tests__/create_asset_request_mutation.test.js
+++ b/src/schema/v2/asset_uploads/__tests__/create_asset_request_mutation.test.js
@@ -2,7 +2,7 @@
 import { runAuthenticatedQuery } from "schema/v2/test/utils"
 
 // FIXME: We're now stitching. Remove these files once this work settles
-xdescribe("addAssetToConsignmentSubmission", () => {
+describe.skip("addAssetToConsignmentSubmission", () => {
   it("creates a submission and returns its new data payload", async () => {
     const mutation = `
       mutation {

--- a/src/schema/v2/asset_uploads/__tests__/finalize_asset_mutation.test.js
+++ b/src/schema/v2/asset_uploads/__tests__/finalize_asset_mutation.test.js
@@ -3,7 +3,7 @@ import { runAuthenticatedQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
 
 // FIXME: We're now stitching. Remove these files once this work settles
-xdescribe("CreateGeminiEntryForAsset", () => {
+describe.skip("CreateGeminiEntryForAsset", () => {
   it("creates a submission and returns its new data payload", () => {
     const mutation = gql`
       mutation {

--- a/src/schema/v2/fields/__tests__/markdown.test.ts
+++ b/src/schema/v2/fields/__tests__/markdown.test.ts
@@ -1,6 +1,6 @@
 import { formatMarkdownValue, markdown } from "../markdown"
 
-describe(formatMarkdownValue, () => {
+describe("formatMarkdownValue", () => {
   it("formats markdown as html", () => {
     expect(formatMarkdownValue("Here's some *emphasis* !", "html"))
       .toMatchInlineSnapshot(`
@@ -15,7 +15,7 @@ describe(formatMarkdownValue, () => {
   })
 })
 
-describe(markdown, () => {
+describe("markdown", () => {
   it("resolves markdown as html", () => {
     expect(
       markdown().resolve?.(

--- a/src/schema/v2/fields/__tests__/money.test.ts
+++ b/src/schema/v2/fields/__tests__/money.test.ts
@@ -2,10 +2,10 @@ import { amount } from "../money"
 import { runQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
 
-describe(amount, () => {
+describe("amount", () => {
   const getResult = ({
     obj = {},
-    args = { symbol: "$" } as object,
+    args = { symbol: "$" } as Record<string, unknown>,
     amountCents = 1234 as any,
   }) => amount(() => amountCents).resolve(obj, args)
 
@@ -94,7 +94,7 @@ describe("major(convertTo:)", () => {
     }
   }
 
-  it("converts an exact price from native currency to USD dollars", () => {
+  it("converts an exact price from native currency to USD dollars", async () => {
     const context = mockArtworkContext({
       id: "some-european-artwork",
       price_currency: "EUR",
@@ -114,15 +114,14 @@ describe("major(convertTo:)", () => {
       }
     `
 
-    return runQuery(query, context).then((result) => {
-      expect(result!.artwork.listPrice).toEqual({
-        original: 10.0,
-        converted: 2.0,
-      })
+    const result = await runQuery(query, context)
+    expect(result!.artwork.listPrice).toEqual({
+      original: 10,
+      converted: 2,
     })
   })
 
-  it("converts a price range from native currency to USD dollars", () => {
+  it("converts a price range from native currency to USD dollars", async () => {
     const context = mockArtworkContext({
       id: "some-european-artwork",
       price_currency: "EUR",
@@ -148,19 +147,20 @@ describe("major(convertTo:)", () => {
       }
     `
 
-    return runQuery(query, context).then((result) => {
-      expect(result!.artwork.listPrice.minPrice).toEqual({
-        original: 10.0,
-        converted: 2.0,
-      })
-      expect(result!.artwork.listPrice.maxPrice).toEqual({
-        original: 20.0,
-        converted: 4.0,
-      })
+    const result = await runQuery(query, context)
+    expect(result!.artwork.listPrice.minPrice).toEqual({
+      original: 10,
+      converted: 2,
+    })
+    expect(result!.artwork.listPrice.maxPrice).toEqual({
+      original: 20,
+      converted: 4,
     })
   })
 
-  xit("only supports USD", () => {
+  it.skip("only supports USD", async () => {
+    expect.assertions(1)
+
     const context = mockArtworkContext({
       id: "some-european-artwork",
       price_currency: "EUR",
@@ -179,10 +179,10 @@ describe("major(convertTo:)", () => {
       }
     `
 
-    expect(runQuery(query, context)).rejects.toThrowError(/Only USD/)
+    await expect(runQuery(query, context)).rejects.toThrowError(/Only USD/)
   })
 
-  it("returns null for missing prices", () => {
+  it("returns null for missing prices", async () => {
     const context = mockArtworkContext({
       id: "some-european-artwork",
       price_currency: "EUR",
@@ -209,12 +209,11 @@ describe("major(convertTo:)", () => {
       }
     `
 
-    return runQuery(query, context).then((result) => {
-      expect(result!.artwork.listPrice).toBeNull()
-    })
+    const result = await runQuery(query, context)
+    expect(result!.artwork.listPrice).toBeNull()
   })
 
-  it("truncates returned dollar value to cents (two decimal places) precision", () => {
+  it("truncates returned dollar value to cents (two decimal places) precision", async () => {
     const context = mockArtworkContext({
       id: "some-european-artwork",
       price_currency: "EUR",
@@ -233,11 +232,10 @@ describe("major(convertTo:)", () => {
       }
     `
 
-    return runQuery(query, context).then((result) => {
-      const expectedPriceAfterConversion = 2.47 // i.e. not 2.4691199...
-      expect(result!.artwork.listPrice.major).toEqual(
-        expectedPriceAfterConversion
-      )
-    })
+    const result = await runQuery(query, context)
+    const expectedPriceAfterConversion = 2.47 // i.e. not 2.4691199...
+    expect(result!.artwork.listPrice.major).toEqual(
+      expectedPriceAfterConversion
+    )
   })
 })

--- a/src/schema/v2/home/__tests__/home_page_fairs_module.test.js
+++ b/src/schema/v2/home/__tests__/home_page_fairs_module.test.js
@@ -2,9 +2,8 @@
 import { runQuery } from "schema/v2/test/utils"
 
 // FIXME: These tests seem to be failing in CI. Revisit and investigate why.
-
 describe("HomePageFairsModule", () => {
-  xit("works", () => {
+  it.skip("works", () => {
     const runningFairs = [
       {
         id: "artissima-2017",
@@ -59,7 +58,7 @@ describe("HomePageFairsModule", () => {
     })
   })
 
-  xit("puts fairs that haven't started yet at the end of the results", async () => {
+  it.skip("puts fairs that haven't started yet at the end of the results", async () => {
     const fairs = [
       {
         id: "future-fair",
@@ -88,14 +87,14 @@ describe("HomePageFairsModule", () => {
     `
 
     const fairModule = await runQuery(query, {
-      fairsLoader: (options) => Promise.resolve({ body: fairs }),
+      fairsLoader: () => Promise.resolve({ body: fairs }),
     })
     const results = fairModule.homePage.fairsModule.results
     expect(results[0].slug).toEqual("current-fair")
     expect(results[1].slug).toEqual("future-fair")
   })
 
-  xit("does not request past fairs if it has 8 running ones", () => {
+  it.skip("does not request past fairs if it has 8 running ones", () => {
     const aFair = {
       id: "artissima-2017",
       name: "Artissima 2017",

--- a/src/schema/v2/match/__tests__/artist.test.js
+++ b/src/schema/v2/match/__tests__/artist.test.js
@@ -2,7 +2,7 @@
 import { runQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
 
-xdescribe("MatchArtist", () => {
+describe.skip("MatchArtist", () => {
   it("queries match/artist for the term 'ok'", () => {
     const query = gql`
       {

--- a/src/schema/v2/match/__tests__/gene.test.js
+++ b/src/schema/v2/match/__tests__/gene.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable promise/always-return */
 import { runQuery } from "schema/v2/test/utils"
 
-xdescribe("MatchGene", () => {
+describe.skip("MatchGene", () => {
   it("queries match/genes for the term 'pop'", () => {
     const query = `
       {

--- a/src/schema/v2/me/__tests__/conversation/submit_inquiry_request_mutation.test.ts
+++ b/src/schema/v2/me/__tests__/conversation/submit_inquiry_request_mutation.test.ts
@@ -19,7 +19,7 @@ describe("SubmitInquiryRequestMutation", () => {
   })
 
   describe("when question is present", () => {
-    it("calls gravity loader with questions and address", () => {
+    it("calls gravity loader with questions and address", async () => {
       const mutation = gql`
         mutation {
           submitInquiryRequestMutation(
@@ -86,24 +86,24 @@ describe("SubmitInquiryRequestMutation", () => {
       }
 
       expect.assertions(4)
-      return runAuthenticatedQuery(mutation, context).then(
-        ({ submitInquiryRequestMutation }) => {
-          expect(submitArtworkInquiryRequestLoader).toHaveBeenCalledWith({
-            artwork: "artwork-id",
-            inquiry_questions: ["price_and_availability", "shipping_quote"],
-            inquiry_shipping_location: {
-              address: "112 Main st Brooklyn NY 11211",
-            },
-          })
-          expect(userByIDLoader).toHaveBeenCalledWith("rob-ross")
-          expect(artistLoader).toHaveBeenCalledWith("bob-ross")
-          expect(submitInquiryRequestMutation).toMatchSnapshot()
-        }
+      const { submitInquiryRequestMutation } = await runAuthenticatedQuery(
+        mutation,
+        context
       )
+      expect(submitArtworkInquiryRequestLoader).toHaveBeenCalledWith({
+        artwork: "artwork-id",
+        inquiry_questions: ["price_and_availability", "shipping_quote"],
+        inquiry_shipping_location: {
+          address: "112 Main st Brooklyn NY 11211",
+        },
+      })
+      expect(userByIDLoader).toHaveBeenCalledWith("rob-ross")
+      expect(artistLoader).toHaveBeenCalledWith("bob-ross")
+      expect(submitInquiryRequestMutation).toMatchSnapshot()
     })
   })
   describe("when only message is present", () => {
-    it("calls gravity loader with only message", () => {
+    it("calls gravity loader with only message", async () => {
       const mutation = gql`
         mutation {
           submitInquiryRequestMutation(
@@ -160,17 +160,17 @@ describe("SubmitInquiryRequestMutation", () => {
       }
 
       expect.assertions(4)
-      return runAuthenticatedQuery(mutation, context).then(
-        ({ submitInquiryRequestMutation }) => {
-          expect(submitArtworkInquiryRequestLoader).toHaveBeenCalledWith({
-            artwork: "artwork-id",
-            message: "do you have sunset paintings?",
-          })
-          expect(userByIDLoader).toHaveBeenCalledWith("rob-ross")
-          expect(artistLoader).toHaveBeenCalledWith("bob-ross")
-          expect(submitInquiryRequestMutation).toMatchSnapshot()
-        }
+      const { submitInquiryRequestMutation } = await runAuthenticatedQuery(
+        mutation,
+        context
       )
+      expect(submitArtworkInquiryRequestLoader).toHaveBeenCalledWith({
+        artwork: "artwork-id",
+        message: "do you have sunset paintings?",
+      })
+      expect(userByIDLoader).toHaveBeenCalledWith("rob-ross")
+      expect(artistLoader).toHaveBeenCalledWith("bob-ross")
+      expect(submitInquiryRequestMutation).toMatchSnapshot()
     })
   })
 })

--- a/src/schema/v2/me/__tests__/delete_credit_card_mutation.test.ts
+++ b/src/schema/v2/me/__tests__/delete_credit_card_mutation.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable promise/always-return */
 import { runAuthenticatedQuery } from "schema/v2/test/utils"
 
 describe("Delete card mutation", () => {
@@ -64,9 +63,12 @@ describe("Delete card mutation", () => {
         throw new Error("ETIMEOUT service unreachable")
       },
     }
-    runAuthenticatedQuery(query, errorRootValue).catch((error) => {
-      expect(error.message).toEqual("ETIMEOUT service unreachable")
-    })
+
+    expect.assertions(1)
+
+    await expect(runAuthenticatedQuery(query, errorRootValue)).rejects.toThrow(
+      "ETIMEOUT service unreachable"
+    )
   })
 
   it("deletes a credit card successfully", async () => {

--- a/src/schema/v2/me/__tests__/follow_show.test.ts
+++ b/src/schema/v2/me/__tests__/follow_show.test.ts
@@ -16,8 +16,8 @@ describe("FollowShow", () => {
     interface Props {
       followShow: {
         show: {
-          slug: String
-          name: String
+          slug: string
+          name: string
         }
       }
     }
@@ -75,10 +75,10 @@ describe("FollowShow", () => {
 
     interface Props {
       followShow: {
-        id: String
-        name: String
+        id: string
+        name: string
         show: {
-          slug: String
+          slug: string
         }
       }
     }

--- a/src/schema/v2/me/__tests__/followed_shows.test.ts
+++ b/src/schema/v2/me/__tests__/followed_shows.test.ts
@@ -41,7 +41,7 @@ describe("returns followed shows for a user", () => {
   })
 
   describe("filter by status", () => {
-    const assert_status_supported = async (status) => {
+    const assertStatusSupported = async (status) => {
       const query = generate_query(
         `(first: 10, status: ${status.toUpperCase()})`
       )
@@ -54,7 +54,7 @@ describe("returns followed shows for a user", () => {
       })
     }
 
-    const assert_invalid_status_fails = async (status) => {
+    const assertInvalidStatusFails = async (status) => {
       const query = generate_query(
         `(first: 10, status: ${status.toUpperCase()})`
       )
@@ -66,15 +66,15 @@ describe("returns followed shows for a user", () => {
     }
 
     it("handles all supported status definitions", async () => {
-      await assert_status_supported("closed")
-      await assert_status_supported("running")
-      await assert_status_supported("upcoming")
-      await assert_status_supported("closing_soon")
-      await assert_status_supported("running_and_upcoming")
+      await assertStatusSupported("closed")
+      await assertStatusSupported("running")
+      await assertStatusSupported("upcoming")
+      await assertStatusSupported("closing_soon")
+      await assertStatusSupported("running_and_upcoming")
     })
 
     it("throws an error if an unsupported status is supplied", async () => {
-      await assert_invalid_status_fails("random_invalid_status")
+      await assertInvalidStatusFails("random_invalid_status")
     })
   })
 

--- a/src/schema/v2/me/__tests__/myCollection.test.ts
+++ b/src/schema/v2/me/__tests__/myCollection.test.ts
@@ -98,10 +98,9 @@ describe("me.myCollection", () => {
     }
 
     expect.assertions(1)
-    try {
-      await runAuthenticatedQuery(query, context)
-    } catch (e) {
-      expect(e.message).toMatch("Some other error")
-    }
+
+    await expect(runAuthenticatedQuery(query, context)).rejects.toThrow(
+      "Some other error"
+    )
   })
 })

--- a/src/schema/v2/me/__tests__/sale_registrations.test.js
+++ b/src/schema/v2/me/__tests__/sale_registrations.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable promise/always-return */
 import { runAuthenticatedQuery } from "schema/v2/test/utils"
 
-xdescribe("Me", () => {
+describe.skip("Me", () => {
   describe("SaleRegistrations", () => {
     it("returns the sales along with the registration status", () => {
       const query = `

--- a/src/schema/v2/sale/__tests__/index.test.ts
+++ b/src/schema/v2/sale/__tests__/index.test.ts
@@ -780,7 +780,7 @@ describe("Sale type", () => {
       expect(response.sale.formattedStartDateTime).toContain("Ended")
     })
 
-    it("returns End time when end_at is in the past", async () => {
+    it("returns End time when end_at is in the past (2)", async () => {
       const response = await execute(query, {
         start_at: moment().subtract(2, "hours"),
         end_at: null,
@@ -883,7 +883,7 @@ describe("Sale type", () => {
 
   describe("userNeedsIdentityVerification", () => {
     describe("when the sale doesn't requires identity verification", () => {
-      let sale = {
+      const sale = {
         id: "foo-foo",
         _id: "123",
         currency: "$",
@@ -913,7 +913,7 @@ describe("Sale type", () => {
     })
 
     describe("when the sale does require identity verification", () => {
-      let sale = {
+      const sale = {
         id: "foo-foo",
         _id: "123",
         currency: "$",

--- a/src/schema/v2/system/__tests__/time.test.js
+++ b/src/schema/v2/system/__tests__/time.test.js
@@ -2,7 +2,7 @@ import { runQuery } from "schema/v2/test/utils"
 
 jest.mock("lib/apis/fetch", () => jest.fn())
 
-xdescribe("SystemTime type", () => {
+describe.skip("SystemTime type", () => {
   const systemTimeData = {
     time: "2018-07-02 20:58:58 UTC",
     day: 2,

--- a/src/validations/__tests__/principalFieldDirectiveValidation.test.ts
+++ b/src/validations/__tests__/principalFieldDirectiveValidation.test.ts
@@ -5,7 +5,7 @@ const schema = require("schema/v1").default
 
 const queryToAst = (query) => parse(new Source(query))
 
-describe(principalFieldDirectiveValidation, () => {
+describe("principalFieldDirectiveValidation", () => {
   it("errors when used more than once", () => {
     const query = `
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1766,6 +1766,18 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
+"@typescript-eslint/experimental-utils@^4.0.1":
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.9.0.tgz#23a296b85d243afba24e75a43fd55aceda5141f0"
+  integrity sha512-0p8GnDWB3R2oGhmRXlEnCvYOtaBCijtA5uBfH5GxQKsukdSQyI4opC4NGTUb88CagsoNQ4rb/hId2JuMbzWKFQ==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/scope-manager" "4.9.0"
+    "@typescript-eslint/types" "4.9.0"
+    "@typescript-eslint/typescript-estree" "4.9.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
 "@typescript-eslint/parser@4.8.1":
   version "4.8.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.8.1.tgz#4fe2fbdbb67485bafc4320b3ae91e34efe1219d1"
@@ -1784,10 +1796,23 @@
     "@typescript-eslint/types" "4.8.1"
     "@typescript-eslint/visitor-keys" "4.8.1"
 
+"@typescript-eslint/scope-manager@4.9.0":
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.9.0.tgz#5eefe305d6b71d1c85af6587b048426bfd4d3708"
+  integrity sha512-q/81jtmcDtMRE+nfFt5pWqO0R41k46gpVLnuefqVOXl4QV1GdQoBWfk5REcipoJNQH9+F5l+dwa9Li5fbALjzg==
+  dependencies:
+    "@typescript-eslint/types" "4.9.0"
+    "@typescript-eslint/visitor-keys" "4.9.0"
+
 "@typescript-eslint/types@4.8.1":
   version "4.8.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.8.1.tgz#23829c73c5fc6f4fcd5346a7780b274f72fee222"
   integrity sha512-ave2a18x2Y25q5K05K/U3JQIe2Av4+TNi/2YuzyaXLAsDx6UZkz1boZ7nR/N6Wwae2PpudTZmHFXqu7faXfHmA==
+
+"@typescript-eslint/types@4.9.0":
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.9.0.tgz#3fe8c3632abd07095c7458f7451bd14c85d0033c"
+  integrity sha512-luzLKmowfiM/IoJL/rus1K9iZpSJK6GlOS/1ezKplb7MkORt2dDcfi8g9B0bsF6JoRGhqn0D3Va55b+vredFHA==
 
 "@typescript-eslint/typescript-estree@4.8.1":
   version "4.8.1"
@@ -1803,12 +1828,34 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
+"@typescript-eslint/typescript-estree@4.9.0":
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.9.0.tgz#38a98df6ee281cfd6164d6f9d91795b37d9e508c"
+  integrity sha512-rmDR++PGrIyQzAtt3pPcmKWLr7MA+u/Cmq9b/rON3//t5WofNR4m/Ybft2vOLj0WtUzjn018ekHjTsnIyBsQug==
+  dependencies:
+    "@typescript-eslint/types" "4.9.0"
+    "@typescript-eslint/visitor-keys" "4.9.0"
+    debug "^4.1.1"
+    globby "^11.0.1"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
 "@typescript-eslint/visitor-keys@4.8.1":
   version "4.8.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.8.1.tgz#794f68ee292d1b2e3aa9690ebedfcb3a8c90e3c3"
   integrity sha512-3nrwXFdEYALQh/zW8rFwP4QltqsanCDz4CwWMPiIZmwlk9GlvBeueEIbq05SEq4ganqM0g9nh02xXgv5XI3PeQ==
   dependencies:
     "@typescript-eslint/types" "4.8.1"
+    eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@4.9.0":
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.9.0.tgz#f284e9fac43f2d6d35094ce137473ee321f266c8"
+  integrity sha512-sV45zfdRqQo1A97pOSx3fsjR+3blmwtdCt8LDrXgCX36v4Vmz4KHrhpV6Fo2cRdXmyumxx11AHw0pNJqCNpDyg==
+  dependencies:
+    "@typescript-eslint/types" "4.9.0"
     eslint-visitor-keys "^2.0.0"
 
 "@wry/equality@^0.1.2":
@@ -3819,6 +3866,13 @@ eslint-plugin-import@2.18.2:
     object.values "^1.1.0"
     read-pkg-up "^2.0.0"
     resolve "^1.11.0"
+
+eslint-plugin-jest@^24.1.3:
+  version "24.1.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-24.1.3.tgz#fa3db864f06c5623ff43485ca6c0e8fc5fe8ba0c"
+  integrity sha512-dNGGjzuEzCE3d5EPZQ/QGtmlMotqnYWD/QpCZ1UuZlrMAdhG5rldh0N0haCvhGnUkSeuORS5VNROwF9Hrgn3Lg==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^4.0.1"
 
 eslint-plugin-promise@4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Closes: [FX-2514](https://artsyproduct.atlassian.net/browse/FX-2514)

OK, so I tend to use focused specs quite a bit when working, and frequently forget to unfocus them (and thanks to @damassi for always catching me). The jest plugin takes care of this with the recommended settings and will error.

We had eslint disabled over the specs — I think because of how common the `promise/always-return` rule was in violation. But, this is an easy automated refactoring: just use an async function. It's still disabled file-wide in a lot of places and I just left those alone. The rest of the errors I dealt with. Some much more valid/problematic. In general I think having eslint enabled over specs will help catch a lot of things.

Right now the only things that are coming up as warns are disabled specs with skip. It's nice to have those highlighted in your editor as well.

I'd like to enable this in Force as well, unsure what will be involved with that.