### PR TITLE
fix: allow listPrice to be queried on CommerceOrder line items

### DIFF
--- a/src/lib/stitching/exchange/__tests__/stitching.test.ts
+++ b/src/lib/stitching/exchange/__tests__/stitching.test.ts
@@ -66,7 +66,10 @@ describe("when handling resolver delegation", () => {
     expect(mergeInfo.delegateToSchema).toHaveBeenCalledWith({
       args: { id: "ARTWORK-ID" },
       fieldName: "artwork",
-      ...restOfResolveArgs,
+      operation: "query",
+      schema: expect.anything(),
+      context: expect.anything(),
+      info: expect.anything(),
     })
   })
 
@@ -118,7 +121,10 @@ it("delegates to the local schema for an LineItem's artwork", async () => {
   expect(mergeInfo.delegateToSchema).toHaveBeenCalledWith({
     args: { id: "ARTWORK-ID" },
     fieldName: "artwork",
-    ...restOfResolveArgs,
+    operation: "query",
+    schema: expect.anything(),
+    context: expect.anything(),
+    info: expect.anything(),
   })
 })
 

--- a/src/lib/stitching/exchange/stitching.ts
+++ b/src/lib/stitching/exchange/stitching.ts
@@ -227,7 +227,6 @@ export const exchangeStitchingEnvironment = ({
               },
               context,
               info,
-              transforms: exchangeSchema.transforms,
             })
           },
         },


### PR DESCRIPTION
**Description:**
This PR allows us to query the `listPrice` field on an artwork when that artwork is a line item on a `CommerceOrder` from the stitched Exchange schema like so:

```graphql
{
  commerceOrder(id: "2e8c7a62-37fe-4702-9e58-2227dd45e295") {
    lineItems {
      edges {
        node {
          artwork {
            listPrice {
              ... on PriceRange {
                display
              }
            }
          }
        }
      }
    }
  }
}
```

Before this change, the above query threw the following error because the `PriceRange` type was being transformed as part of the Exchange schema:

```
__typename did not match an object type: CommercePriceRange
```

**See also:** 
- #1878 