### PR TITLE
update causality schema

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3047,10 +3047,10 @@ type AuctionsLotStanding implements AuctionsNode {
   # The current leading bid on the lot, whether it is winning or not
   leadingBidAmount: AuctionsMoney!
 
-  # whether this user has the leading bid
+  # Current lot state
   lot: AuctionsLotState!
 
-  # whether this user has the leading bid
+  # Current lot state
   lotState: AuctionsLotState! @deprecated(reason: "prefer `lot`")
   rawId: String!
   saleArtwork: SaleArtwork

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1839,10 +1839,10 @@ type AuctionsLotStanding implements AuctionsNode {
   # The current leading bid on the lot, whether it is winning or not
   leadingBidAmount: AuctionsMoney!
 
-  # whether this user has the leading bid
+  # Current lot state
   lot: AuctionsLotState!
 
-  # whether this user has the leading bid
+  # Current lot state
   lotState: AuctionsLotState! @deprecated(reason: "prefer `lot`")
   rawId: String!
   saleArtwork: SaleArtwork

--- a/src/data/causality.graphql
+++ b/src/data/causality.graphql
@@ -104,10 +104,10 @@ type LotStanding implements Node {
   "whether this user has the leading bid"
   isHighestBidder: Boolean!
 
-  "whether this user has the leading bid"
+  "Current lot state"
   lotState: Lot! @deprecated(reason: "prefer `lot`")
 
-  "whether this user has the leading bid"
+  "Current lot state"
   lot: Lot!
 }
 
@@ -154,7 +154,7 @@ type Mutation {
   addIncrementPolicy(
     newIncrementPolicy: NewIncrementPolicyInput!
   ): IncrementPolicy
-  addSale(id: String!): Sale
+  addSale(id: ID!): Sale
   banUserFromSale(saleId: ID!, userId: ID!): Sale
   unbanUserFromSale(userId: ID!, saleId: ID!): Sale
 }
@@ -236,7 +236,7 @@ type Query {
   ): LotStandingConnection!
 
   "Returns an increment policy with specific `id`."
-  incrementPolicy(id: String!): IncrementPolicy
+  incrementPolicy(id: ID!): IncrementPolicy
 
   "Previews a draft of a new increment policy."
   previewIncrementPolicy(
@@ -250,13 +250,13 @@ type Query {
   incrementPolicyGroups: [IncrementPolicyGroup!]!
 
   "Returns a lot with specific `id`."
-  lot(id: String!): Lot
+  lot(id: ID!): Lot
 
   "Returns a list of lots"
-  lots(ids: [String!]!): [Lot!]!
+  lots(ids: [ID!]!): [Lot!]!
 
   "Returns a sale with specific `id`."
-  sale(id: String!): Sale
+  sale(id: ID!): Sale
 
   "Fetches an object given its ID"
   node("The ID of an object" id: ID!): Node


### PR DESCRIPTION
This is a followup to https://github.com/artsy/causality/pull/861 (already in staging, not production) which fixed some `ID`-typed args that had been changed to `Strings`. I don't think we are currently using any of these argument-containing fields in metaphysics.

Please let me know if this isn't the right way to go about this schema upgrade 🤝 