### PR TITLE
docs: describe artwork's medium, category, and attribution_class fields

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1448,6 +1448,10 @@ type Artwork implements Node & Searchable & Sellable {
   cached: Int
   can_share_image: Boolean
     @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
+
+  # Represents the "**medium type**", such as _Painting_. (This field is also
+  # commonly referred to as just "medium", but should not be confused with the
+  # artwork attribute called `medium`.)
   category: String
 
   # Returns the display label and detail for artwork certificate of authenticity
@@ -1554,6 +1558,10 @@ type Artwork implements Node & Searchable & Sellable {
   listPrice: ListPrice
   literature(format: Format): String
   manufacturer(format: Format): String
+
+  # Represents the **materials** used in this work, such as _oil and acrylic on
+  # canvas_. (This should not be confused with the artwork attribute called
+  # `category`, which is commonly referred to as "medium" or "medium type")
   medium: String
   meta: ArtworkMeta
   metric: String
@@ -2509,6 +2517,10 @@ type ArtworkItem implements Node & Searchable & Sellable {
   cached: Int
   can_share_image: Boolean
     @deprecated(reason: "Prefer to use `is_*`. [Will be removed in v2]")
+
+  # Represents the "**medium type**", such as _Painting_. (This field is also
+  # commonly referred to as just "medium", but should not be confused with the
+  # artwork attribute called `medium`.)
   category: String
 
   # Returns the display label and detail for artwork certificate of authenticity
@@ -2615,6 +2627,10 @@ type ArtworkItem implements Node & Searchable & Sellable {
   listPrice: ListPrice
   literature(format: Format): String
   manufacturer(format: Format): String
+
+  # Represents the **materials** used in this work, such as _oil and acrylic on
+  # canvas_. (This should not be confused with the artwork attribute called
+  # `category`, which is commonly referred to as "medium" or "medium type")
   medium: String
   meta: ArtworkMeta
   metric: String

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1442,7 +1442,7 @@ type Artwork implements Node & Searchable & Sellable {
     last: Int
   ): ArtistSeriesConnection
 
-  # Attribution class object
+  # Represents the "**classification**" of an artwork, such as _limited edition_
   attribution_class: AttributionClass
   availability: String
   cached: Int
@@ -2511,7 +2511,7 @@ type ArtworkItem implements Node & Searchable & Sellable {
     shallow: Boolean
   ): [Artist]
 
-  # Attribution class object
+  # Represents the "**classification**" of an artwork, such as _limited edition_
   attribution_class: AttributionClass
   availability: String
   cached: Int

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1251,6 +1251,10 @@ type Artwork implements Node & Searchable & Sellable {
 
   # Can a user request a lot conditions report for this artwork?
   canRequestLotConditionsReport: Boolean
+
+  # Represents the "**medium type**", such as _Painting_. (This field is also
+  # commonly referred to as just "medium", but should not be confused with the
+  # artwork attribute called `medium`.)
   category: String
 
   # Returns the display label and detail for artwork certificate of authenticity
@@ -1366,6 +1370,10 @@ type Artwork implements Node & Searchable & Sellable {
   listPrice: ListPrice
   literature(format: Format): String
   manufacturer(format: Format): String
+
+  # Represents the **materials** used in this work, such as _oil and acrylic on
+  # canvas_. (This should not be confused with the artwork attribute called
+  # `category`, which is commonly referred to as "medium" or "medium type")
   medium: String
   meta: ArtworkMeta
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1244,7 +1244,7 @@ type Artwork implements Node & Searchable & Sellable {
     last: Int
   ): ArtistSeriesConnection
 
-  # Attribution class object
+  # Represents the "**classification**" of an artwork, such as _limited edition_
   attributionClass: AttributionClass
   availability: String
   cached: Int

--- a/src/schema/v1/artwork/index.ts
+++ b/src/schema/v1/artwork/index.ts
@@ -141,7 +141,8 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       },
       attribution_class: {
         type: AttributionClass,
-        description: "Attribution class object",
+        description:
+          'Represents the "**classification**" of an artwork, such as _limited edition_',
         resolve: ({ attribution_class }) => {
           if (attribution_class) {
             return attributionClasses[attribution_class]

--- a/src/schema/v1/artwork/index.ts
+++ b/src/schema/v1/artwork/index.ts
@@ -134,7 +134,11 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           preferUsageOf: "is_*",
         }),
       },
-      category: { type: GraphQLString },
+      category: {
+        type: GraphQLString,
+        description:
+          'Represents the "**medium type**", such as _Painting_. (This field is also commonly referred to as just "medium", but should not be confused with the artwork attribute called `medium`.)',
+      },
       attribution_class: {
         type: AttributionClass,
         description: "Attribution class object",
@@ -497,7 +501,11 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         literature.replace(/^literature:\s+/i, "")
       ),
       manufacturer: markdown(),
-      medium: { type: GraphQLString },
+      medium: {
+        type: GraphQLString,
+        description:
+          'Represents the **materials** used in this work, such as _oil and acrylic on canvas_. (This should not be confused with the artwork attribute called `category`, which is commonly referred to as "medium" or "medium type")',
+      },
       metric: {
         type: GraphQLString, // Used for Eigen compatibility, see conversation at: https://github.com/artsy/metaphysics/pull/1350
         deprecationReason: deprecate({

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -120,7 +120,8 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       },
       attributionClass: {
         type: AttributionClass,
-        description: "Attribution class object",
+        description:
+          'Represents the "**classification**" of an artwork, such as _limited edition_',
         resolve: ({ attribution_class }) => {
           if (attribution_class) {
             return attributionClasses[attribution_class]

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -128,7 +128,11 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       availability: { type: GraphQLString },
-      category: { type: GraphQLString },
+      category: {
+        type: GraphQLString,
+        description:
+          'Represents the "**medium type**", such as _Painting_. (This field is also commonly referred to as just "medium", but should not be confused with the artwork attribute called `medium`.)',
+      },
       collectingInstitution: {
         type: GraphQLString,
         resolve: ({ collecting_institution }) =>
@@ -532,7 +536,11 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         literature.replace(/^literature:\s+/i, "")
       ),
       manufacturer: markdown(),
-      medium: { type: GraphQLString },
+      medium: {
+        type: GraphQLString,
+        description:
+          'Represents the **materials** used in this work, such as _oil and acrylic on canvas_. (This should not be confused with the artwork attribute called `category`, which is commonly referred to as "medium" or "medium type")',
+      },
       meta: Meta,
       metric: {
         description:


### PR DESCRIPTION
It has come to light that our [always](https://artsy.slack.com/archives/C04KVDZU6/p1607107159063800?thread_ts=1607106319.063200&cid=C04KVDZU6), [always](https://artsy.slack.com/archives/C01B2P6LJUU/p1606928260015100?thread_ts=1606927746.014400&cid=C01B2P6LJUU), [always](https://artsy.slack.com/archives/C9SATFLUU/p1603390117262300?thread_ts=1603303917.232100&cid=C9SATFLUU), [always](https://github.com/artsy/reaction/pull/3121#issuecomment-581450001), [always](https://artsy.slack.com/archives/C9SATFLUU/p1560978400046700) [confusing](https://github.com/artsy/candela/pull/123) naming of `artwork.category` and `artwork.medium` has tripped up the team a couple of more times recently.

Adding some documentation at the point where devs are likely to encounter these fields seemed like a good incremental step. It's a little verbose, but deservedly so imho.

If people have better ideas of where and how to spread this knowledge please chime in 😄 

![Screen Shot 2020-12-04 at 4 06 09 PM](https://user-images.githubusercontent.com/140521/101215244-7ba83380-364b-11eb-9a62-7439feeed4f9.png)

![Screen Shot 2020-12-04 at 4 06 19 PM](https://user-images.githubusercontent.com/140521/101215246-7ba83380-364b-11eb-99fd-726990f598ba.png)

I threw in `artwork.attribution_class` for free here too.

![Screen Shot 2020-12-04 at 4 12 02 PM](https://user-images.githubusercontent.com/140521/101215247-7ba83380-364b-11eb-98b3-a995e6c2b2cb.png)
