### PR TITLE
My bids - remove cents from formatted currencies

### DIFF
--- a/src/lib/stitching/causality/__tests__/stitching.test.ts
+++ b/src/lib/stitching/causality/__tests__/stitching.test.ts
@@ -49,7 +49,7 @@ describe("causality/stitching", () => {
         major: 100,
         minor: 10000,
         currencyCode: "USD",
-        display: "$100.00",
+        display: "$100",
       })
     })
 
@@ -69,7 +69,7 @@ describe("causality/stitching", () => {
         major: 10000,
         minor: 10000,
         currencyCode: "JPY",
-        display: "¥10,000.00",
+        display: "¥10,000",
       })
     })
   })

--- a/src/lib/stitching/causality/stitching.ts
+++ b/src/lib/stitching/causality/stitching.ts
@@ -16,7 +16,7 @@ const resolveLotCentsFieldToMoney = (centsField) => {
       major,
       minor: cents,
       currencyCode: currency,
-      display: formatMoney(major, symbolFromCurrencyCode(currency)),
+      display: formatMoney(major, symbolFromCurrencyCode(currency), 0),
     }
   }
 }


### PR DESCRIPTION
# [PURCHASE-2295]

__Before:__
<img width="1015" alt="Screen Shot 2020-12-09 at 5 12 49 PM" src="https://user-images.githubusercontent.com/5643895/101694999-f6a18d80-3a41-11eb-91a8-bc83c5b8ab01.png">
__After:__
<img width="950" alt="Screen Shot 2020-12-09 at 5 13 37 PM" src="https://user-images.githubusercontent.com/5643895/101695031-00c38c00-3a42-11eb-8246-3324e612e3eb.png">


[PURCHASE-2295]: https://artsyproduct.atlassian.net/browse/PURCHASE-2295