### PR TITLE
add stitched sellingPrice field

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -3092,14 +3092,16 @@ type AuctionsLotStandingEdge {
 
 # The state of a lot
 type AuctionsLotState {
-  # total number of bids placed on the lot
+  # total number of actual bids placed by users on the lot
   bidCount: Int!
+
+  # current high bid recognized on the live auction floor
   floorSellingPrice: Money
 
   # selling price, in minor unit, on the live auction floor
   floorSellingPriceCents: Long
 
-  # The bidder currently winning the online portion of the auction
+  # The bidder currently winning the live floor portion of the auction
   floorWinningBidder: AuctionsBidder
 
   # The Gravity Lot ID.
@@ -3120,6 +3122,12 @@ type AuctionsLotState {
 
   # The Gravity Sale ID.
   saleId: ID!
+
+  # current high bid
+  sellingPrice: Money
+
+  # current bid amount in minor unit, whether reserve is met or not
+  sellingPriceCents: Long!
 
   # Whether the lot is sold, for sale or passed
   soldStatus: AuctionsSoldStatus!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1876,14 +1876,16 @@ type AuctionsLotStandingEdge {
 
 # The state of a lot
 type AuctionsLotState {
-  # total number of bids placed on the lot
+  # total number of actual bids placed by users on the lot
   bidCount: Int!
+
+  # current high bid recognized on the live auction floor
   floorSellingPrice: Money
 
   # selling price, in minor unit, on the live auction floor
   floorSellingPriceCents: Long
 
-  # The bidder currently winning the online portion of the auction
+  # The bidder currently winning the live floor portion of the auction
   floorWinningBidder: AuctionsBidder
 
   # The Gravity Lot ID.
@@ -1904,6 +1906,12 @@ type AuctionsLotState {
 
   # The Gravity Sale ID.
   saleId: ID!
+
+  # current high bid
+  sellingPrice: Money
+
+  # current bid amount in minor unit, whether reserve is met or not
+  sellingPriceCents: Long!
 
   # Whether the lot is sold, for sale or passed
   soldStatus: AuctionsSoldStatus!

--- a/src/data/causality.graphql
+++ b/src/data/causality.graphql
@@ -70,13 +70,16 @@ type Lot {
   "The Gravity Sale ID."
   saleId: ID!
 
-  "total number of bids placed on the lot"
+  "total number of actual bids placed by users on the lot"
   bidCount: Int!
+
+  "current bid amount in minor unit, whether reserve is met or not"
+  sellingPriceCents: Long!
 
   "selling price, in minor unit, on the live auction floor"
   floorSellingPriceCents: Long
 
-  "The bidder currently winning the online portion of the auction"
+  "The bidder currently winning the live floor portion of the auction"
   floorWinningBidder: Bidder
 
   "asking price, in minor unit, for online bidders"
@@ -267,8 +270,8 @@ type Query {
 
 enum ReserveStatus {
   NoReserve
-  ReserveMet
   ReserveNotMet
+  ReserveMet
 }
 
 "The state of a sale"
@@ -312,8 +315,8 @@ type Sale {
 
 enum SoldStatus {
   ForSale
-  Passed
   Sold
+  Passed
 }
 
 "An Artsy User"

--- a/src/lib/stitching/causality/__tests__/stitching.test.ts
+++ b/src/lib/stitching/causality/__tests__/stitching.test.ts
@@ -33,6 +33,26 @@ describe("causality/stitching", () => {
       expect(await getFields("AuctionsLotState")).toContain("onlineAskingPrice")
     })
 
+    it("resolves sellingPrice field as a Money type", async () => {
+      const { resolvers } = await useCausalityStitching()
+      const saleArtworkRootLoader = jest.fn(() => {
+        return { currency: "USD" }
+      })
+      const sellingPrice = await resolvers.AuctionsLotState.sellingPrice.resolve(
+        { internalID: "123", sellingPriceCents: 10000 },
+        {},
+        { saleArtworkRootLoader },
+        {}
+      )
+
+      expect(sellingPrice).toEqual({
+        major: 100,
+        minor: 10000,
+        currencyCode: "USD",
+        display: "$100",
+      })
+    })
+
     it("resolves floorSellingPrice field as a Money type", async () => {
       const { resolvers } = await useCausalityStitching()
       const saleArtworkRootLoader = jest.fn(() => {

--- a/src/lib/stitching/causality/stitching.ts
+++ b/src/lib/stitching/causality/stitching.ts
@@ -44,7 +44,10 @@ export const causalityStitchingEnvironment = ({
       }
 
       extend type AuctionsLotState {
+        "current high bid recognized on the live auction floor"
         floorSellingPrice: Money
+        "current high bid"
+        sellingPrice: Money
         onlineAskingPrice: Money
       }
     `,
@@ -80,6 +83,15 @@ export const causalityStitchingEnvironment = ({
             }
           `,
           resolve: resolveLotCentsFieldToMoney("floorSellingPriceCents"),
+        },
+        sellingPrice: {
+          fragment: gql`
+            ... on AuctionsLotState {
+              internalID
+              sellingPriceCents
+            }
+          `,
+          resolve: resolveLotCentsFieldToMoney("sellingPriceCents"),
         },
         onlineAskingPrice: {
           fragment: gql`


### PR DESCRIPTION
Part of [PURCHASE-2294]
#minor
This PR updates our stitched causality schema to include the `sellingPrice` field, which is the primary field we want for representing the selling price of an auction lot.


[PURCHASE-2294]: https://artsyproduct.atlassian.net/browse/PURCHASE-2294