### PR TITLE
Fix failed lotStandingConnection queries when a sale artwork is unpublished

### DIFF
--- a/src/lib/stitching/causality/stitching.ts
+++ b/src/lib/stitching/causality/stitching.ts
@@ -130,8 +130,6 @@ export const causalityStitchingEnvironment = ({
                 info,
               })
               .then(async (lotStandingsConnection) => {
-                throw new Error("BAD!")
-                console.log("standing connection", lotStandingsConnection)
                 const promisedSaleArtworks = lotStandingsConnection.edges.map(
                   ({ node: { lot } }) => {
                     return context
@@ -143,7 +141,7 @@ export const causalityStitchingEnvironment = ({
                 const availableSaleArtworks = (
                   await Promise.all(promisedSaleArtworks)
                 ).filter((sa) => sa !== null)
-
+                // FIXME: this depends on the presence of edge->node->lot->internalID in the query. see https://github.com/artsy/metaphysics/pull/2885#discussion_r543693841
                 const availableEdges = lotStandingsConnection.edges.reduce(
                   (acc: any, edge: any) => {
                     const saleArtwork = availableSaleArtworks.find(

--- a/src/lib/stitching/causality/stitching.ts
+++ b/src/lib/stitching/causality/stitching.ts
@@ -130,6 +130,7 @@ export const causalityStitchingEnvironment = ({
                 info,
               })
               .then(async (lotStandingsConnection) => {
+                throw new Error("BAD!")
                 console.log("standing connection", lotStandingsConnection)
                 const promisedSaleArtworks = lotStandingsConnection.edges.map(
                   ({ node: { lot } }) => {


### PR DESCRIPTION
The Causality LotStanding type needs to be stitched and assembled using data from Gravity. This PR fixes a bug where unpublished gravity data ruins a graphql query, when really it just means that the lot should be treated as nonexistent.

Causality's part is really just the calculated state portion of a gravity sale artwork, and the `saleArtwork` field is stitched into the underlying type in order to make a query like `auctionsLotStandingConnection.edges[0].node.saleArtwork.sale.name`. This works fine unless the sale artwork is unpublished; additionally the sale artwork is implicitly queried for currency-related fields in order to resolve the `display` values. If a sale artwork is unpublished, the entire query fails.

WIP solution: 
- get a list of lot standings (lotStandingConnection) as before but then 
  - fetch the sale artwork for each (currently we have to do this one by one), 
  - catching errors (currently, all errors) and returning `null` for that sale artwork,
  - filter the list for not-nullness,
  - filter the lotStandingConnection `edges` for presence of a matching sale artwork
  - and map the edge to a new edge that includes the sale artwork on its node,
  - return the original connection with our new, filtered + sale-artwork-enhanced edges

If this method works for us we may want to do something similar from the other direction for [PURCHASE-2200]. It would be nice to get some outside buy-in since i'm not sure if this is a new approach or what gotchas might exist.
(mobbed with @lilyfromseattle , @zephraph , @sepans , @starsirius )


[PURCHASE-2200]: https://artsyproduct.atlassian.net/browse/PURCHASE-2200