### PR TITLE
fix(my collection) Create images synchronously to avoid gravity race condition

### DIFF
--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -151,6 +151,43 @@ describe("myCollectionCreateArtworkMutation", () => {
 
       expect(message).toEqual(serverError)
     })
+
+    it("creates additional images in sequence to avoid a gravity race condition", async () => {
+      // allow us to resolve the createImageLoader mock manually
+      let resolveCreateImageLoader = () => null as any
+      createImageLoader.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => (resolveCreateImageLoader = resolve))
+      )
+
+      const externalImageUrls = [
+        "https://test-upload-bucket.s3.amazonaws.com/path/to/image.jpg",
+        "https://test-upload-bucket.s3.amazonaws.com/path/to/other/image.jpg",
+      ]
+      const mutation = computeMutationInput(externalImageUrls)
+
+      runAuthenticatedQuery(mutation, defaultContext)
+
+      // flush promise queue
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(createImageLoader).toHaveBeenCalledTimes(1)
+      expect(createImageLoader).toBeCalledWith(newArtwork.id, {
+        source_bucket: "test-upload-bucket",
+        source_key: "path/to/image.jpg",
+      })
+
+      resolveCreateImageLoader()
+
+      // flush promise queue
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(createImageLoader).toHaveBeenCalledTimes(2)
+      expect(createImageLoader).toBeCalledWith(newArtwork.id, {
+        source_bucket: "test-upload-bucket",
+        source_key: "path/to/other/image.jpg",
+      })
+    })
   })
 })
 

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -116,11 +116,10 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
 
       const artworkId = response.id
       const imageSources = computeImageSources(externalImageUrls)
-      const createImagePromises = imageSources.map((source) => {
-        return createArtworkImageLoader(artworkId, source)
-      })
 
-      await Promise.all(createImagePromises)
+      for (const imageSource of imageSources) {
+        await createArtworkImageLoader(artworkId, imageSource)
+      }
 
       return response
     } catch (error) {


### PR DESCRIPTION
We have discovered a race condition in the `POST /artwork/:id/image` gravity endpoint that is causing corrupt data. This PR adds a workaround while we track down the root cause in gravity, in order to unblock work in eigen.