### PR TITLE
chore: Bring back me.saleRegistrations as a connection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7259,6 +7259,31 @@ type Me implements Node {
     first: Int
     last: Int
   ): ArtworkConnection
+  saleRegistrationsConnection(
+    after: String
+    before: String
+    first: Int
+
+    #
+    #         Only return sales matching specified ids.
+    #         Accepts list of ids.
+    #
+    ids: [String]
+
+    # Limit by auction.
+    isAuction: Boolean = true
+    last: Int
+
+    # Limit by live status.
+    live: Boolean = true
+
+    # Limit by published status.
+    published: Boolean = true
+
+    # Returns sales the user has registered for if true, returns sales the user has not registered for if false.
+    registered: Boolean
+    sort: SaleSorts
+  ): SaleRegistrationConnection
   secondFactors(kinds: [SecondFactorKind]): [SecondFactor]
   type: String
 
@@ -9650,6 +9675,36 @@ type SaleEdge {
 
   # The item at the end of the edge
   node: Sale
+}
+
+type SaleRegistration {
+  bidder: Bidder
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+  isRegistered: Boolean
+  sale: Sale
+}
+
+# A connection to a list of items.
+type SaleRegistrationConnection {
+  # A list of edges.
+  edges: [SaleRegistrationEdge]
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+}
+
+# An edge in a connection.
+type SaleRegistrationEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: SaleRegistration
 }
 
 enum SaleSorts {

--- a/src/schema/v2/me/__tests__/sale_registrations.test.js
+++ b/src/schema/v2/me/__tests__/sale_registrations.test.js
@@ -1,16 +1,20 @@
 /* eslint-disable promise/always-return */
 import { runAuthenticatedQuery } from "schema/v2/test/utils"
 
-describe.skip("Me", () => {
-  describe("SaleRegistrations", () => {
+describe("Me", () => {
+  describe("SaleRegistrationsConnection", () => {
     it("returns the sales along with the registration status", () => {
       const query = `
         {
           me {
-            saleRegistrations {
-              isRegistered
-              sale {
-                name
+            saleRegistrationsConnection(first: 10) {
+              edges {
+                node {
+                  isRegistered
+                  sale {
+                    name
+                  }
+                }
               }
             }
           }
@@ -23,28 +27,37 @@ describe.skip("Me", () => {
 
       const context = {
         salesLoader: sinon.stub().returns(
-          Promise.resolve([
-            {
-              name: "Foo Sale",
-              currency: "$",
-              is_auction: true,
+          Promise.resolve({
+            body: [
+              {
+                name: "Foo Sale",
+                currency: "$",
+                is_auction: true,
+              },
+              {
+                name: "Bar Sale",
+                currency: "$",
+                is_auction: true,
+              },
+            ],
+            headers: {
+              "x-total-count": "10",
             },
-            {
-              name: "Bar Sale",
-              currency: "$",
-              is_auction: true,
-            },
-          ])
+          })
         ),
         meBiddersLoader,
       }
 
       return runAuthenticatedQuery(query, context).then(
-        ({ me: { saleRegistrations } }) => {
-          expect(saleRegistrations).toEqual([
-            { isRegistered: false, sale: { name: "Foo Sale" } },
-            { isRegistered: true, sale: { name: "Bar Sale" } },
-          ])
+        ({ me: { saleRegistrationsConnection } }) => {
+          expect(saleRegistrationsConnection.edges[0].node).toEqual({
+            isRegistered: false,
+            sale: { name: "Foo Sale" },
+          })
+          expect(saleRegistrationsConnection.edges[1].node).toEqual({
+            isRegistered: true,
+            sale: { name: "Bar Sale" },
+          })
         }
       )
     })

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -32,7 +32,7 @@ import Invoice from "./conversation/invoice"
 import LotStanding from "./lot_standing"
 import LotStandings from "./lot_standings"
 import { RecentlyViewedArtworks } from "./recently_viewed_artworks"
-// import SaleRegistrations from "./sale_registrations"
+import SaleRegistrations from "./sale_registrations"
 import { SavedArtworks } from "./savedArtworks"
 import { ResolverContext } from "types/graphql"
 import { SaleArtworksConnectionField } from "../sale_artworks"
@@ -184,7 +184,7 @@ const Me = new GraphQLObjectType<any, ResolverContext>({
       resolve: ({ recently_viewed_artwork_ids }) => recently_viewed_artwork_ids,
     },
     recentlyViewedArtworksConnection: RecentlyViewedArtworks,
-    // saleRegistrations: SaleRegistrations,
+    saleRegistrations: SaleRegistrations,
     type: {
       type: GraphQLString,
     },

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -32,7 +32,7 @@ import Invoice from "./conversation/invoice"
 import LotStanding from "./lot_standing"
 import LotStandings from "./lot_standings"
 import { RecentlyViewedArtworks } from "./recently_viewed_artworks"
-import SaleRegistrations from "./sale_registrations"
+import SaleRegistrationsConnection from "./sale_registrations"
 import { SavedArtworks } from "./savedArtworks"
 import { ResolverContext } from "types/graphql"
 import { SaleArtworksConnectionField } from "../sale_artworks"
@@ -184,7 +184,7 @@ const Me = new GraphQLObjectType<any, ResolverContext>({
       resolve: ({ recently_viewed_artwork_ids }) => recently_viewed_artwork_ids,
     },
     recentlyViewedArtworksConnection: RecentlyViewedArtworks,
-    saleRegistrations: SaleRegistrations,
+    saleRegistrationsConnection: SaleRegistrationsConnection,
     type: {
       type: GraphQLString,
     },
@@ -230,7 +230,7 @@ const MeField: GraphQLFieldConfig<void, ResolverContext> = {
       "bidderStatus",
       "lotStanding",
       "lotStandings",
-      "saleRegistrations",
+      "saleRegistrationsConnection",
       "conversation",
       "conversations",
       "collectorProfile",

--- a/src/schema/v2/me/sale_registrations.ts
+++ b/src/schema/v2/me/sale_registrations.ts
@@ -20,7 +20,6 @@ export const SaleRegistrationType = new GraphQLObjectType<any, ResolverContext>(
       },
       isRegistered: {
         type: GraphQLBoolean,
-        resolve: ({ is_registered }) => is_registered,
       },
       sale: {
         type: Sale.type,
@@ -64,6 +63,7 @@ const SaleRegistrationConnection: GraphQLFieldConfig<void, ResolverContext> = {
         }
       })
     )
+
     return connectionFromArraySlice(saleRegistrations, paginationArgs, {
       arrayLength: parseInt(headers["x-total-count"] || "0", 10),
       sliceStart: offset,

--- a/src/schema/v2/me/sale_registrations.ts
+++ b/src/schema/v2/me/sale_registrations.ts
@@ -1,19 +1,20 @@
 import { first } from "lodash"
+import { pageable } from "relay-cursor-paging"
 import Sale from "schema/v2/sale/index"
+import { connectionDefinitions, connectionFromArraySlice } from "graphql-relay"
 import { SalesConnectionField } from "schema/v2/sales"
 import Bidder from "schema/v2/bidder"
-import {
-  GraphQLList,
-  GraphQLBoolean,
-  GraphQLObjectType,
-  GraphQLFieldConfig,
-} from "graphql"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { BodyAndHeaders } from "lib/loaders"
+import { GraphQLBoolean, GraphQLObjectType, GraphQLFieldConfig } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { InternalIDFields } from "schema/v2/object_identification"
 
 export const SaleRegistrationType = new GraphQLObjectType<any, ResolverContext>(
   {
     name: "SaleRegistration",
     fields: () => ({
+      ...InternalIDFields,
       bidder: {
         type: Bidder.type,
       },
@@ -28,26 +29,46 @@ export const SaleRegistrationType = new GraphQLObjectType<any, ResolverContext>(
   }
 )
 
-// TODO: If this is needed by Reaction, it should become a connection
-const SaleRegistration: GraphQLFieldConfig<void, ResolverContext> = {
-  type: new GraphQLList(SaleRegistrationType),
-  args: SalesConnectionField.args,
-  resolve: (_root, options, { meBiddersLoader, salesLoader }) => {
+const SaleRegistrationConnection: GraphQLFieldConfig<void, ResolverContext> = {
+  type: connectionDefinitions({ nodeType: SaleRegistrationType })
+    .connectionType,
+  args: pageable(SalesConnectionField.args),
+  resolve: async (
+    _root,
+    { isAuction: is_auction, live, published, sort, ...paginationArgs },
+    { meBiddersLoader, salesLoader }
+  ) => {
     if (!meBiddersLoader) return null
-    return salesLoader(options).then((sales) => {
-      return Promise.all(
-        sales.map((sale) => {
-          return meBiddersLoader({ sale_id: sale.id }).then((bidders) => {
-            return {
-              sale,
-              bidder: first(bidders),
-              is_registered: bidders.length > 0,
-            }
-          })
-        })
-      )
+    const { page, size, offset } = convertConnectionArgsToGravityArgs(
+      paginationArgs
+    )
+    const { body: sales, headers } = (await (salesLoader(
+      {
+        is_auction,
+        live,
+        published,
+        sort,
+        page,
+        size,
+        total_count: true,
+      },
+      { headers: true }
+    ) as any)) as BodyAndHeaders
+    const saleRegistrations = await Promise.all(
+      sales.map(async (sale) => {
+        const bidders = await meBiddersLoader({ sale_id: sale.id })
+        return {
+          sale,
+          bidder: first(bidders),
+          isRegistered: bidders.length > 0,
+        }
+      })
+    )
+    return connectionFromArraySlice(saleRegistrations, paginationArgs, {
+      arrayLength: parseInt(headers["x-total-count"] || "0", 10),
+      sliceStart: offset,
     })
   },
 }
 
-export default SaleRegistration
+export default SaleRegistrationConnection


### PR DESCRIPTION
Part 1 of 2 for resolving [PURCHASE-2185](https://artsyproduct.atlassian.net/browse/PURCHASE-2185).

Commenting `me.saleRegistrations` field back in to allow for move from `v1` to `v2` on `force`, and turning it into a connection.

Follow up on [this](https://github.com/artsy/force/pull/6810) PR.