### PR TITLE
fix(my collection): return type check for successful artwork image delete

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1590,15 +1590,9 @@ type ArtworkMutationFailure {
   mutationError: GravityMutationError
 }
 
-type ArtworkMutationSuccess {
-  artwork: Artwork
-  artworkEdge: ArtworkEdgeInterface
-}
-
 union ArtworkMutationType =
     ArtworkMutationDeleteSuccess
   | ArtworkMutationFailure
-  | ArtworkMutationSuccess
 
 union ArtworkOrEditionSetType = Artwork | EditionSet
 

--- a/src/schema/v2/__tests__/deleteArtworkImageMutation.test.ts
+++ b/src/schema/v2/__tests__/deleteArtworkImageMutation.test.ts
@@ -20,6 +20,7 @@ describe("DeleteArtworkImageMutation", () => {
   `
 
   it("returns an error", async () => {
+    console.error = jest.fn() // Suppress error output
     const context = {
       deleteArtworkImageLoader: () =>
         Promise.reject(
@@ -43,7 +44,8 @@ describe("DeleteArtworkImageMutation", () => {
 
   it("deletes an artwork image", async () => {
     const context = {
-      deleteArtworkImageLoader: () => Promise.resolve({ deleted: true }),
+      deleteArtworkImageLoader: () =>
+        Promise.resolve({ image_url: "some-deleted-image-url" }),
     }
 
     const data = await runAuthenticatedQuery(mutation, context)

--- a/src/schema/v2/deleteArtworkImageMutation.ts
+++ b/src/schema/v2/deleteArtworkImageMutation.ts
@@ -5,53 +5,20 @@ import {
   GraphQLNonNull,
   GraphQLUnionType,
 } from "graphql"
-import {
-  cursorForObjectInConnection,
-  mutationWithClientMutationId,
-} from "graphql-relay"
+import { mutationWithClientMutationId } from "graphql-relay"
 import { ResolverContext } from "types/graphql"
 import {
   formatGravityError,
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
-import { ArtworkEdgeInterface, ArtworkType } from "schema/v2/artwork"
 
-const ArtworkMutationSuccessType = new GraphQLObjectType<any, ResolverContext>({
-  name: "ArtworkMutationSuccess",
-  isTypeOf: (data) => data.id,
-  fields: () => ({
-    artwork: {
-      type: ArtworkType,
-      resolve: ({ id }, _, { artworkLoader }) => {
-        if (artworkLoader) {
-          return artworkLoader(id)
-        }
-      },
-    },
-    artworkEdge: {
-      type: ArtworkEdgeInterface,
-      resolve: async ({ id }, _, { artworkLoader }) => {
-        if (!artworkLoader) {
-          return null
-        }
-        const artwork = await artworkLoader(id)
-        const edge = {
-          cursor: cursorForObjectInConnection([artwork], artwork),
-          node: artwork,
-        }
-        return edge
-      },
-    },
-  }),
-})
-
-const ArtworkMutationDeleteSuccess = new GraphQLObjectType<
+const ArtworkMutationDeleteSuccessType = new GraphQLObjectType<
   any,
   ResolverContext
 >({
   name: "ArtworkMutationDeleteSuccess",
   isTypeOf: (data) => {
-    return data.deleted
+    return data.image_url
   },
   fields: () => ({
     success: {
@@ -76,11 +43,7 @@ const ArtworkMutationFailureType = new GraphQLObjectType<any, ResolverContext>({
 
 export const ArtworkMutationType = new GraphQLUnionType({
   name: "ArtworkMutationType",
-  types: [
-    ArtworkMutationSuccessType,
-    ArtworkMutationDeleteSuccess,
-    ArtworkMutationFailureType,
-  ],
+  types: [ArtworkMutationDeleteSuccessType, ArtworkMutationFailureType],
 })
 
 interface DeleteArtworkImageMutationInput {


### PR DESCRIPTION
The deletion mutation added here works but looks like the return type of the loader is actually the deleted image rather than a success boolean. 

- Changes the success type check to look for an image_url property 
- Updates the tests and suppresses some errors output to console
- Removes an extra success return type