### PR TITLE
Add artwork medium type fields

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1359,6 +1359,9 @@ type Artwork implements Node & Searchable & Sellable {
   # canvas_. (This should not be confused with the artwork attribute called
   # `category`, which is commonly referred to as "medium" or "medium type")
   medium: String
+
+  # Represents the "**medium**" of an artwork, such as painting_
+  mediumType: MediumType
   meta: ArtworkMeta
 
   # The unit of length of the artwork, expressed in `in` or `cm`

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7263,6 +7263,23 @@ type Me implements Node {
   unreadNotificationsCount: Int!
 }
 
+# Collection of fields that describe medium type, such as _Painting_. (This field
+# is also commonly referred to as just "medium", but should not be confused with
+# the artwork attribute called `medium`.)
+type MediumType {
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+
+  # Long descriptive phrase
+  longDescription: String
+
+  # Shortest form of medium type display
+  name: String
+}
+
 # A message in a conversation.
 type Message implements Node {
   attachments: [Attachment]
@@ -8604,6 +8621,9 @@ type Query {
 
   # List of all artwork attribution classes
   artworkAttributionClasses: [AttributionClass]
+
+  # List of all artwork medium types
+  artworkMediumTypes: [MediumType]
 
   # A list of Artworks
   artworks(
@@ -10900,6 +10920,9 @@ type Viewer {
 
   # List of all artwork attribution classes
   artworkAttributionClasses: [AttributionClass]
+
+  # List of all artwork medium types
+  artworkMediumTypes: [MediumType]
 
   # A list of Artworks
   artworks(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1239,7 +1239,7 @@ type Artwork implements Node & Searchable & Sellable {
   # Represents the "**medium type**", such as _Painting_. (This field is also
   # commonly referred to as just "medium", but should not be confused with the
   # artwork attribute called `medium`.)
-  category: String
+  category: String @deprecated(reason: "Prefer to use `mediumType`.")
 
   # Returns the display label and detail for artwork certificate of authenticity
   certificateOfAuthenticity: ArtworkInfoRow
@@ -1360,7 +1360,9 @@ type Artwork implements Node & Searchable & Sellable {
   # `category`, which is commonly referred to as "medium" or "medium type")
   medium: String
 
-  # Represents the "**medium**" of an artwork, such as painting_
+  # Represents the "**medium type**", such as _Painting_. (This field is also
+  # commonly referred to as just "medium", but should not be confused with the
+  # artwork attribute called `medium`.)
   mediumType: MediumType
   meta: ArtworkMeta
 

--- a/src/lib/mediumTypes.ts
+++ b/src/lib/mediumTypes.ts
@@ -1,0 +1,126 @@
+export default {
+  Architecture: {
+    id: "Architecture",
+    long_description:
+      "Includes architectural models; buildings (e.g. house, temple).",
+    name: "Architecture",
+  },
+  "Books and Portfolios": {
+    id: "Books and Portfolios",
+    long_description:
+      "Includes albums; artist books; illustrated manuscripts; portfolios (i.e. group of works such as photographs or prints).",
+    name: "Books and Portfolios",
+  },
+  "Design/Decorative Art": {
+    id: "Design/Decorative Art",
+    long_description: [
+      "Objects that are primarily functional.",
+      "Includes such items as containers (e.g. basket, bowl, box, vase); furniture (e.g. cabinet, chair, table); lighting; mirrors; tableware (e.g. flatware, plates).",
+    ].join(" "),
+    name: "Design/Decorative Art",
+  },
+  "Drawing, Collage or Other Work on Paper": {
+    id: "Drawing, Collage or Other Work on Paper",
+    long_description: [
+      "Includes collages; drawings; figure drawing; pen and ink; sketch.",
+      "This medium type also includes paintings where paper is the support.",
+    ].join(" "),
+    name: "Drawing, Collage or Other Work on Paper",
+  },
+  "Ephemera or Merchandise": {
+    id: "Ephemera or Merchandise",
+    long_description: [
+      "Items related to the artist, created or manufactured for a specific or limited use.",
+      "This also includes exhibition materials, memorabilia, autographs, skateboards, toys, and other items made with branded collaborators, etc.",
+    ].join(" "),
+    name: "Ephemera or Merchandise",
+  },
+  "Fashion Design and Wearable Art": {
+    id: "Fashion Design and Wearable Art",
+    long_description: "Includes costumes; garments (e.g. dress, jacket).",
+    name: "Fashion Design and Wearable Art",
+  },
+  Installation: {
+    id: "Installation",
+    long_description: "Includes land art; installation art; site-specific art.",
+    name: "Installation",
+  },
+  Jewelry: {
+    id: "Jewelry",
+    long_description:
+      "Includes costume accessories; bracelets; brooches; earrings; necklaces; rings.",
+    name: "Jewelry",
+  },
+  "Mixed Media": {
+    id: "Mixed Media",
+    long_description:
+      "Intermedia; Multimedia work that does not fall into another medium type category (ex: Drawing, Collage, or Other work on paper).",
+    name: "Mixed Media",
+  },
+  Other: {
+    id: "Other",
+    long_description:
+      "Includes armor; musical instruments; tools; weapons; items that do not fall into any of the other categories.",
+    name: "Other",
+  },
+  Painting: {
+    id: "Painting",
+    long_description:
+      "Includes gouache; fresco; ink and wash; oil painting; screen painting; scroll painting; tempera; watercolor.",
+    name: "Painting",
+  },
+  "Performance Art": {
+    id: "Performance Art",
+    long_description: "Includes body art; endurance art; live performance.",
+    name: "Performance Art",
+  },
+  Photography: {
+    id: "Photography",
+    long_description:
+      "Includes chromogenic color prints (i.e. c-print); polaroids; silver gelatin prints; photograms.",
+    name: "Photography",
+  },
+  Posters: {
+    id: "Posters",
+    long_description: [
+      "Includes advertisements; offset lithograph posters.",
+      "Please note that this does not include exhibition posters (see Merchandise and Ephemera).",
+    ].join(" "),
+    name: "Posters",
+  },
+  Print: {
+    id: "Print",
+    long_description:
+      "Includes etchings; engravings; lithographs; monoprints; screen prints; woodcuts.",
+    name: "Print",
+  },
+  Reproduction: {
+    id: "Reproduction",
+    long_description: [
+      "Reproduction of an original work authorized by the artist, the artist's studio or estate.",
+      "Artist involvement is not implicit.",
+      "This includes plates from illustrated books, museum replicas, etc.",
+    ].join(" "),
+    name: "Reproduction",
+  },
+  Sculpture: {
+    id: "Sculpture",
+    long_description: [
+      "Includes assemblage; bas-relief; carvings; figurines; masks; mosaics; statues; wall pieces.",
+      "For figurines made with branded collaborators (ex: BE@RBRICK, Medicom), please see “Ephemera or Merchandise.”",
+    ].join(" "),
+    name: "Sculpture",
+  },
+  "Textile Arts": {
+    id: "Textile Arts",
+    long_description:
+      "Includes banners; carpets; rugs; samplers; tapestries; weavings.",
+    name: "Textile Arts",
+  },
+  "Video/Film/Animation": {
+    id: "Video/Film/Animation",
+    long_description:
+      "Includes 16mm film; computer animation; video recordings.",
+    name: "Video/Film/Animation",
+  },
+}

--- a/src/schema/v2/__tests__/artworkMediumTypes.test.ts
+++ b/src/schema/v2/__tests__/artworkMediumTypes.test.ts
@@ -1,0 +1,24 @@
+/* eslint-disable promise/always-return */
+import { runQuery } from "schema/v2/test/utils"
+
+describe("ArtworkMediumTypes type", () => {
+  it("fetches artworkMediumTypes", () => {
+    const query = `
+      {
+        artworkMediumTypes {
+          internalID
+          name
+          longDescription
+        }
+      }
+    `
+
+    return runQuery(query).then((data) => {
+      expect(data!.artworkMediumTypes[0].internalID).toBe("Architecture")
+      expect(data!.artworkMediumTypes[0].name).toBe("Architecture")
+      expect(data!.artworkMediumTypes[0].longDescription).toBe(
+        "Includes architectural models; buildings (e.g. house, temple)."
+      )
+    })
+  })
+})

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -9,7 +9,6 @@ import { getMicrofunnelDataByArtworkInternalID } from "schema/v2/artist/targetSu
 jest.mock("schema/v2/artist/targetSupply/utils/getMicrofunnelData")
 
 describe("Artwork type", () => {
-  const partner = { id: "existy" }
   const sale = { id: "existy" }
 
   let artwork = null
@@ -50,6 +49,7 @@ describe("Artwork type", () => {
       dimensions: { in: "2 x 3in." },
       metric: "in",
       unlisted: true,
+      category: "Painting",
     }
     context = {
       artworkLoader: sinon
@@ -2428,6 +2428,35 @@ describe("Artwork type", () => {
         "richard-prince-untitled-portrait",
         {}
       )
+    })
+  })
+
+  describe("mediumType", () => {
+    it(`returns proper medium type for artwork`, () => {
+      const query = `
+        {
+          artwork(id: "richard-prince-untitled-portrait") {
+            mediumType {
+              internalID
+              name
+              longDescription
+            }
+          }
+        }
+      `
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            mediumType: {
+              internalID: "Painting",
+              name: "Painting",
+              longDescription:
+                "Includes gouache; fresco; ink and wash; oil painting; screen painting; scroll painting; tempera; watercolor.",
+            },
+          },
+        })
+      })
     })
   })
 })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -44,6 +44,9 @@ import {
 import AttributionClass from "schema/v2/artwork/attributionClass"
 // Mapping of attribution_class ids to AttributionClass values
 import attributionClasses from "lib/attributionClasses"
+import MediumType from "schema/v2/artwork/mediumType"
+// Mapping of category ids to MediumType values
+import mediumTypes from "lib/mediumTypes"
 import { LotStandingType } from "../me/lot_standing"
 import { amount, symbolFromCurrencyCode } from "schema/v2/fields/money"
 import { capitalizeFirstCharacter } from "lib/helpers"
@@ -541,6 +544,16 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLString,
         description:
           'Represents the **materials** used in this work, such as _oil and acrylic on canvas_. (This should not be confused with the artwork attribute called `category`, which is commonly referred to as "medium" or "medium type")',
+      },
+      mediumType: {
+        type: MediumType,
+        description:
+          'Represents the "**medium type**", such as _Painting_. (This field is also commonly referred to as just "medium", but should not be confused with the artwork attribute called `medium`.)',
+        resolve: ({ category }) => {
+          if (category) {
+            return mediumTypes[category]
+          }
+        },
       },
       meta: Meta,
       metric: {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -134,6 +134,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       availability: { type: GraphQLString },
       category: {
         type: GraphQLString,
+        deprecationReason: "Prefer to use `mediumType`.",
         description:
           'Represents the "**medium type**", such as _Painting_. (This field is also commonly referred to as just "medium", but should not be confused with the artwork attribute called `medium`.)',
       },

--- a/src/schema/v2/artwork/mediumType.ts
+++ b/src/schema/v2/artwork/mediumType.ts
@@ -1,0 +1,25 @@
+import { GraphQLObjectType, GraphQLString } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { InternalIDFields } from "schema/v2/object_identification"
+
+const MediumType = new GraphQLObjectType<any, ResolverContext>({
+  name: "MediumType",
+  description:
+    'Collection of fields that describe medium type, such as _Painting_. (This field is also commonly referred to as just "medium", but should not be confused with the artwork attribute called `medium`.)',
+  fields: {
+    ...InternalIDFields,
+    name: {
+      type: GraphQLString,
+      description: "Shortest form of medium type display",
+    },
+    longDescription: {
+      type: GraphQLString,
+      description: "Long descriptive phrase",
+      resolve: ({ long_description }) => {
+        return long_description
+      },
+    },
+  },
+})
+
+export default MediumType

--- a/src/schema/v2/artworkMediumTypes.ts
+++ b/src/schema/v2/artworkMediumTypes.ts
@@ -1,0 +1,12 @@
+import { GraphQLList, GraphQLFieldConfig } from "graphql"
+import { ResolverContext } from "types/graphql"
+import AttributionClass from "./artwork/mediumType"
+import mediumTypes from "lib/mediumTypes"
+
+const ArtworkMediumTypes: GraphQLFieldConfig<void, ResolverContext> = {
+  type: new GraphQLList(AttributionClass),
+  description: "List of all artwork medium types",
+  resolve: (_root, _args, _context) => Object.values(mediumTypes),
+}
+
+export default ArtworkMediumTypes

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -102,6 +102,7 @@ import { DeleteArtworkImageMutation } from "./deleteArtworkImageMutation"
 
 import { ArtworkOrEditionSetType } from "schema/v2/artworkOrEditionSet"
 import { AuctionResult } from "./auction_result"
+import ArtworkMediumTypes from "./artworkMediumTypes"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -110,6 +111,7 @@ const PrincipalFieldDirective = new GraphQLDirective({
 
 const rootFields = {
   artworkAttributionClasses: ArtworkAttributionClasses,
+  artworkMediumTypes: ArtworkMediumTypes,
   auctionResult: AuctionResult,
   article: Article,
   articles: Articles,


### PR DESCRIPTION
- feat: add `artworkMediumTypes` root field
    Add `artworkMediumTypes` root field to list known artwork medium types and corresponding documentation.

- feat: add `mediumType` field to Artwork type
    Add `mediumType` field on Artwork type to expose medium type documentation.

- chore(artwork): Deprecate Artwork category field in favor of mediumType
    In addition to `name`, we now support documentation copy within the `mediumType` field.

Jira 🔒 : https://artsyproduct.atlassian.net/browse/FX-2556

Rebase and merge please!

<img width="2001" alt="Screen Shot 2020-12-16 at 6 28 48 PM" src="https://user-images.githubusercontent.com/123595/102419014-e69f2600-3fcc-11eb-9fe7-0e3d60711ac4.png">
