### PR TITLE
update readme for introspection setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ You will need to set up headers with both:
 
 _If you're new to GraphQL, you can checkout [Artsy's GraphQL Workshop](https://github.com/artsy/graphql-workshop)._
 
+### Introspection Setup
+
+In order to get docs for the schema on MP in your playground of choice (Postman, Insomnia, Altair, etc), you need to send the following header:
+```
+Authorization: Bearer <secret>
+```
+and replace `<secret>` with the contents of `Metaphysics INTROSPECT_TOKEN` from 1Password.
+
 ### Sample Queries
 
 Once you have the GraphiQL client running against your local service,

--- a/README.md
+++ b/README.md
@@ -97,11 +97,22 @@ _If you're new to GraphQL, you can checkout [Artsy's GraphQL Workshop](https://g
 
 ### Introspection Setup
 
-In order to get docs for the schema on MP in your playground of choice (Postman, Insomnia, Altair, etc), you need to send the following header:
+Getting docs for the schema on MP in your playground of choice (Postman, Insomnia, Altair, etc) is called introspection.
+
+Introspection is available by default when developing.
+
+Introspection on staging and production are for internal use only, so artsy devs can use it to make development for MP clients (eigen, force, etc) easier, but it is and should not be used by any of the clients or anyone else.
+
+In order to set this up in your playground of choice (Postman, Insomnia, Altair, etc), you need to send the following header:
 ```
 Authorization: Bearer <secret>
 ```
-and replace `<secret>` with the contents of `Metaphysics INTROSPECT_TOKEN` from 1Password.
+and replace `<secret>` with the value you get from hokusai using
+```
+hokusai staging env get INTROSPECT_TOKEN
+hokusai production env get INTROSPECT_TOKEN
+```
+or the contents of `Metaphysics INTROSPECT_TOKEN` in 1Password.
 
 ### Sample Queries
 


### PR DESCRIPTION
After pairing with @annacarey, I noticed that this is only documented on slack [here](https://artsy.slack.com/archives/C02BC3HEJ/p1599250831072100).

I added this in the readme here so it's fast to find when any artsy dev sets up a new app/machine.