### PR TITLE
feat(my collection): create/update edition information

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -191,6 +191,20 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "DELETE" }
     ),
+    createArtworkEditionSetLoader: gravityLoader(
+      (artworkID) => `artwork/${artworkID}/edition_set`,
+      {},
+      { method: "POST" }
+    ),
+    updateArtworkEditionSetLoader: gravityLoader<
+      any,
+      { artworkId: string; editionSetId: string }
+    >(
+      ({ artworkId, editionSetId }) =>
+        `artwork/${artworkId}/edition_set/${editionSetId}`,
+      {},
+      { method: "PUT" }
+    ),
     notificationsFeedLoader: gravityLoader("me/notifications/feed"),
     partnerArtworksLoader: gravityLoader(
       (id) => `partner/${id}/artworks`,

--- a/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
@@ -332,7 +332,7 @@ describe("myCollectionUpdateArtworkMutation", () => {
       )
     })
 
-    it("does not create an edition set if you don't specify either", async () => {
+    it("resets the edition set if you don't specify either", async () => {
       const mutation = computeMutationInput({
         editionNumber: null,
         editionSize: null,
@@ -340,7 +340,16 @@ describe("myCollectionUpdateArtworkMutation", () => {
 
       await runAuthenticatedQuery(mutation, defaultContext)
 
-      expect(updateArtworkEditionSetLoader).not.toHaveBeenCalled()
+      expect(updateArtworkEditionSetLoader).toHaveBeenCalledWith(
+        {
+          artworkId: updatedArtwork.id,
+          editionSetId: editionedArtwork.edition_sets[0].id,
+        },
+        {
+          edition_size: null,
+          available_editions: null,
+        }
+      )
     })
   })
 })

--- a/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
@@ -9,7 +9,15 @@ const artworkLoader = jest.fn().mockResolvedValue(artworkDetails)
 
 const createImageLoader = jest.fn()
 
-const computeMutationInput = (externalImageUrls: string[] = []): string => {
+const computeMutationInput = ({
+  externalImageUrls = [],
+  editionSize = null,
+  editionNumber = null,
+}: {
+  externalImageUrls?: string[]
+  editionSize?: string | null
+  editionNumber?: string | null
+} = {}): string => {
   const mutation = gql`
     mutation {
       myCollectionUpdateArtwork(
@@ -21,8 +29,8 @@ const computeMutationInput = (externalImageUrls: string[] = []): string => {
           costMinor: 200
           date: "1990"
           depth: "20"
-          editionNumber: "5"
-          editionSize: "100x100x100"
+          editionNumber: ${JSON.stringify(editionNumber)}
+          editionSize: ${JSON.stringify(editionSize)}
           externalImageUrls: ${JSON.stringify(externalImageUrls)}
           height: "20"
           medium: "Updated"
@@ -56,10 +64,14 @@ const computeMutationInput = (externalImageUrls: string[] = []): string => {
   return mutation
 }
 
+const createArtworkEditionSetLoader = jest.fn()
+const updateArtworkEditionSetLoader = jest.fn()
 const defaultContext = {
   updateArtworkLoader,
   artworkLoader: artworkLoader,
   createArtworkImageLoader: createImageLoader,
+  createArtworkEditionSetLoader,
+  updateArtworkEditionSetLoader,
 }
 
 describe("myCollectionUpdateArtworkMutation", () => {
@@ -115,7 +127,7 @@ describe("myCollectionUpdateArtworkMutation", () => {
       const externalImageUrls = [
         "https://test-upload-bucket.s3.amazonaws.com/path/to/image.jpg",
       ]
-      const mutation = computeMutationInput(externalImageUrls)
+      const mutation = computeMutationInput({ externalImageUrls })
 
       const data = await runAuthenticatedQuery(mutation, defaultContext)
       const { artworkOrError } = data.myCollectionUpdateArtwork
@@ -132,7 +144,7 @@ describe("myCollectionUpdateArtworkMutation", () => {
       const externalImageUrls = [
         "https://test-upload-bucket.s3.amazonaws.com/path/to/image.jpg",
       ]
-      const mutation = computeMutationInput(externalImageUrls)
+      const mutation = computeMutationInput({ externalImageUrls })
 
       const serverError = "Error creating image"
       const url =
@@ -164,7 +176,7 @@ describe("myCollectionUpdateArtworkMutation", () => {
         "https://test-upload-bucket.s3.amazonaws.com/path/to/image.jpg",
         "https://test-upload-bucket.s3.amazonaws.com/path/to/other/image.jpg",
       ]
-      const mutation = computeMutationInput(externalImageUrls)
+      const mutation = computeMutationInput({ externalImageUrls })
 
       runAuthenticatedQuery(mutation, defaultContext)
 
@@ -187,6 +199,148 @@ describe("myCollectionUpdateArtworkMutation", () => {
         source_bucket: "test-upload-bucket",
         source_key: "path/to/other/image.jpg",
       })
+    })
+  })
+
+  describe("setting edition set info on an artwork with no edition set info", () => {
+    it("creates an edition set on the artwork", async () => {
+      const mutation = computeMutationInput({
+        editionNumber: "50",
+        editionSize: "100",
+      })
+
+      await runAuthenticatedQuery(mutation, defaultContext)
+
+      expect(createArtworkEditionSetLoader).toHaveBeenCalledWith(
+        updatedArtwork.id,
+        {
+          edition_size: "100",
+          available_editions: ["50"],
+        }
+      )
+    })
+
+    it("works if you only specify the edition number", async () => {
+      const mutation = computeMutationInput({
+        editionNumber: "50",
+      })
+
+      await runAuthenticatedQuery(mutation, defaultContext)
+
+      expect(createArtworkEditionSetLoader).toHaveBeenCalledWith(
+        updatedArtwork.id,
+        {
+          edition_size: null,
+          available_editions: ["50"],
+        }
+      )
+    })
+
+    it("works if you only specify the edition size", async () => {
+      const mutation = computeMutationInput({
+        editionSize: "50",
+      })
+
+      await runAuthenticatedQuery(mutation, defaultContext)
+
+      expect(createArtworkEditionSetLoader).toHaveBeenCalledWith(
+        updatedArtwork.id,
+        {
+          edition_size: "50",
+          available_editions: null,
+        }
+      )
+    })
+
+    it("does not create an edition set if you don't specify either", async () => {
+      const mutation = computeMutationInput({
+        editionNumber: null,
+        editionSize: null,
+      })
+
+      await runAuthenticatedQuery(mutation, defaultContext)
+
+      expect(createArtworkEditionSetLoader).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("setting edition set info on an artwork with existing edition set info", () => {
+    const editionedArtwork = {
+      ...updatedArtwork,
+
+      edition_sets: [{ id: "my-edition-set-id" }],
+    }
+    beforeEach(() => {
+      updateArtworkLoader.mockResolvedValueOnce(editionedArtwork)
+    })
+
+    it("updates the edition set on the artwork", async () => {
+      const mutation = computeMutationInput({
+        editionNumber: "50",
+        editionSize: "100",
+      })
+
+      await runAuthenticatedQuery(mutation, defaultContext)
+
+      expect(updateArtworkEditionSetLoader).toHaveBeenCalledWith(
+        {
+          artworkId: updatedArtwork.id,
+          editionSetId: editionedArtwork.edition_sets[0].id,
+        },
+        {
+          edition_size: "100",
+          available_editions: ["50"],
+        }
+      )
+    })
+
+    it("works if you only specify the edition number", async () => {
+      const mutation = computeMutationInput({
+        editionNumber: "50",
+      })
+
+      await runAuthenticatedQuery(mutation, defaultContext)
+
+      expect(updateArtworkEditionSetLoader).toHaveBeenCalledWith(
+        {
+          artworkId: updatedArtwork.id,
+          editionSetId: editionedArtwork.edition_sets[0].id,
+        },
+        {
+          edition_size: null,
+          available_editions: ["50"],
+        }
+      )
+    })
+
+    it("works if you only specify the edition size", async () => {
+      const mutation = computeMutationInput({
+        editionSize: "50",
+      })
+
+      await runAuthenticatedQuery(mutation, defaultContext)
+
+      expect(updateArtworkEditionSetLoader).toHaveBeenCalledWith(
+        {
+          artworkId: updatedArtwork.id,
+          editionSetId: editionedArtwork.edition_sets[0].id,
+        },
+        {
+          edition_size: "50",
+          available_editions: null,
+        }
+      )
+    })
+
+    it("does not create an edition set if you don't specify either", async () => {
+      const mutation = computeMutationInput({
+        editionNumber: null,
+        editionSize: null,
+      })
+
+      await runAuthenticatedQuery(mutation, defaultContext)
+
+      expect(updateArtworkEditionSetLoader).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -126,7 +126,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
         // create edition set for artwork
         await createArtworkEditionSetLoader(artworkId, {
           edition_size: editionSize,
-          available_editions: [editionNumber],
+          available_editions: editionNumber ? [editionNumber] : null,
         })
       }
 

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -97,9 +97,17 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
       externalImageUrls = [],
       ...rest
     },
-    { createArtworkLoader, createArtworkImageLoader }
+    {
+      createArtworkLoader,
+      createArtworkImageLoader,
+      createArtworkEditionSetLoader,
+    }
   ) => {
-    if (!createArtworkLoader || !createArtworkImageLoader) {
+    if (
+      !createArtworkLoader ||
+      !createArtworkImageLoader ||
+      !createArtworkEditionSetLoader
+    ) {
       return new Error("You need to be signed in to perform this action")
     }
 
@@ -109,12 +117,19 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
         collection_id: "my-collection",
         cost_currency_code: costCurrencyCode,
         cost_minor: costMinor,
-        edition_size: editionSize,
-        edition_number: editionNumber,
         ...rest,
       })
 
       const artworkId = response.id
+
+      if (editionNumber || editionSize) {
+        // create edition set for artwork
+        await createArtworkEditionSetLoader(artworkId, {
+          edition_size: editionSize,
+          available_editions: [editionNumber],
+        })
+      }
+
       const imageSources = computeImageSources(externalImageUrls)
 
       for (const imageSource of imageSources) {

--- a/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
@@ -79,9 +79,19 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
       externalImageUrls = [],
       ...rest
     },
-    { updateArtworkLoader, createArtworkImageLoader }
+    {
+      updateArtworkLoader,
+      createArtworkImageLoader,
+      createArtworkEditionSetLoader,
+      updateArtworkEditionSetLoader,
+    }
   ) => {
-    if (!updateArtworkLoader || !createArtworkImageLoader) {
+    if (
+      !updateArtworkLoader ||
+      !createArtworkImageLoader ||
+      !createArtworkEditionSetLoader ||
+      !updateArtworkEditionSetLoader
+    ) {
       return new Error("You need to be signed in to perform this action")
     }
 
@@ -90,10 +100,27 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
         artists: artistIds,
         cost_currency_code: costCurrencyCode,
         cost_minor: costMinor,
-        edition_number: editionNumber,
-        edition_size: editionSize,
         ...rest,
       })
+
+      if (editionNumber || editionSize) {
+        // create edition set for artwork
+        if (response.edition_sets.length === 0) {
+          await createArtworkEditionSetLoader(artworkId, {
+            edition_size: editionSize,
+            available_editions: [editionNumber],
+          })
+        } else {
+          const editionSetId = response.edition_sets[0].id
+          await updateArtworkEditionSetLoader(
+            { artworkId, editionSetId },
+            {
+              edition_size: editionSize,
+              available_editions: [editionNumber],
+            }
+          )
+        }
+      }
 
       const imageSources = computeImageSources(externalImageUrls)
 

--- a/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
@@ -105,10 +105,10 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
 
       if (editionNumber || editionSize) {
         // create edition set for artwork
-        if (response.edition_sets.length === 0) {
+        if (!response.edition_sets?.length) {
           await createArtworkEditionSetLoader(artworkId, {
             edition_size: editionSize,
-            available_editions: [editionNumber],
+            available_editions: editionNumber ? [editionNumber] : null,
           })
         } else {
           const editionSetId = response.edition_sets[0].id
@@ -116,7 +116,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
             { artworkId, editionSetId },
             {
               edition_size: editionSize,
-              available_editions: [editionNumber],
+              available_editions: editionNumber ? [editionNumber] : null,
             }
           )
         }

--- a/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
@@ -103,23 +103,23 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
         ...rest,
       })
 
-      if (editionNumber || editionSize) {
-        // create edition set for artwork
-        if (!response.edition_sets?.length) {
+      if (!response.edition_sets?.length) {
+        if (editionSize || editionNumber) {
+          // create new edition set when none existed previously
           await createArtworkEditionSetLoader(artworkId, {
             edition_size: editionSize,
             available_editions: editionNumber ? [editionNumber] : null,
           })
-        } else {
-          const editionSetId = response.edition_sets[0].id
-          await updateArtworkEditionSetLoader(
-            { artworkId, editionSetId },
-            {
-              edition_size: editionSize,
-              available_editions: editionNumber ? [editionNumber] : null,
-            }
-          )
         }
+      } else {
+        const editionSetId = response.edition_sets[0].id
+        await updateArtworkEditionSetLoader(
+          { artworkId, editionSetId },
+          {
+            edition_size: editionSize,
+            available_editions: editionNumber ? [editionNumber] : null,
+          }
+        )
       }
 
       const imageSources = computeImageSources(externalImageUrls)


### PR DESCRIPTION
This implements the ability for create/update mutations on 'my collection' artworks to set/update edition information.