### PR TITLE
Update copy for artwork classifications

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1669,20 +1669,18 @@ type Attachment {
 type AttributionClass {
   # A globally unique ID.
   id: ID!
-
-  # Descriptive phrase used as companion for attribution class name display
-  info: String
+  info: String @deprecated(reason: "Prefer `shortDescription`")
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
 
-  # Long descriptive phrase used as companion for short_description
+  # Long description (can include multiple sentences) for attribution class
   longDescription: String
 
   # Shortest form of attribution class display
   name: String
 
-  # Longer version of attribution class display
+  # Short descriptive phrase for attribution class without punctuation
   shortDescription: String
 }
 

--- a/src/lib/attributionClasses.ts
+++ b/src/lib/attributionClasses.ts
@@ -4,14 +4,14 @@ export default {
     name: "Unique",
     info: null,
     short_description: "This is a unique work",
-    long_description: "One of a kind piece, created by the artist.",
+    long_description: "One-of-a-kind piece.",
     deprecated: false,
   },
   "limited edition": {
     id: "limited edition",
     name: "Limited edition",
     info: null,
-    short_description: "This is part of a limited edition set",
+    short_description: "This work is part of a limited edition set",
     long_description: [
       "Original works created in multiple with direct involvement of the artist.",
       "Generally, less than 150 pieces total.",
@@ -22,7 +22,7 @@ export default {
     id: "open edition",
     name: "Open edition",
     info: null,
-    short_description: "This edition run is still in production",
+    short_description: "This work is from an open edition",
     long_description: [
       "The edition run is ongoing.",
       "New works are still being produced, which may be numbered.",
@@ -34,7 +34,7 @@ export default {
     id: "unknown edition",
     name: "Unknown edition",
     info: null,
-    short_description: "This edition run has ended",
+    short_description: "This work is from an edition of unknown size",
     long_description:
       "The edition run has ended; it is unclear how many works were produced.",
     deprecated: false,

--- a/src/lib/attributionClasses.ts
+++ b/src/lib/attributionClasses.ts
@@ -2,7 +2,7 @@ export default {
   unique: {
     id: "unique",
     name: "Unique",
-    info: "One of a kind piece",
+    info: null,
     short_description: "This is a unique work",
     long_description: "One of a kind piece, created by the artist.",
     deprecated: false,
@@ -10,7 +10,7 @@ export default {
   "limited edition": {
     id: "limited edition",
     name: "Limited edition",
-    info: "Original works created in multiple",
+    info: null,
     short_description: "This is part of a limited edition set",
     long_description: [
       "Original works created in multiple with direct involvement of the artist.",
@@ -21,7 +21,7 @@ export default {
   "open edition": {
     id: "open edition",
     name: "Open edition",
-    info: "The edition run is ongoing",
+    info: null,
     short_description: "This edition run is still in production",
     long_description: [
       "The edition run is ongoing.",
@@ -33,7 +33,7 @@ export default {
   "unknown edition": {
     id: "unknown edition",
     name: "Unknown edition",
-    info: "The edition run has ended",
+    info: null,
     short_description: "This edition run has ended",
     long_description:
       "The edition run has ended; it is unclear how many works were produced.",
@@ -42,7 +42,7 @@ export default {
   "made-to-order": {
     id: "made-to-order",
     name: "Made-to-order",
-    info: "A made-to-order piece",
+    info: null,
     short_description: "This is a made-to-order piece",
     long_description:
       "A piece that is made-to-order, taking into account the collector’s preferences.",
@@ -51,7 +51,7 @@ export default {
   reproduction: {
     id: "reproduction",
     name: "Reproduction",
-    info: "Reproduction authorized by artist’s studio or estate",
+    info: null,
     short_description: "This work is a reproduction",
     long_description: [
       "Reproduction of an original work authorized by artist’s studio or estate.",
@@ -62,7 +62,7 @@ export default {
   "editioned multiple": {
     id: "editioned multiple",
     name: "Editioned multiple",
-    info: "High quantity editions, without direct artist involvement",
+    info: null,
     short_description: "This is an editioned multiple",
     long_description: [
       "Pieces created in larger limited editions, authorized by the artist’s studio or estate.",
@@ -73,7 +73,7 @@ export default {
   "non-editioned multiple": {
     id: "non-editioned multiple",
     name: "Non-editioned multiple",
-    info: "Works made in unlimited or unknown numbers of copies",
+    info: null,
     short_description: "This is a non-editioned multiple",
     long_description: [
       "Works made in unlimited or unknown numbers of copies, authorized by the artist’s studio or estate.",
@@ -84,7 +84,7 @@ export default {
   ephemera: {
     id: "ephemera",
     name: "Ephemera",
-    info: "Peripheral artifacts related to the artist",
+    info: null,
     short_description: "This is ephemera, an artifact related to the artist",
     long_description: [
       "Items related to the artist, created or manufactured for a specific, limited use.",

--- a/src/schema/v1/__tests__/artworkAttributionClasses.test.ts
+++ b/src/schema/v1/__tests__/artworkAttributionClasses.test.ts
@@ -22,7 +22,7 @@ describe("ArtworkAttributionClasses type", () => {
         "This is a unique work"
       )
       expect(data!.artworkAttributionClasses[0].longDescription).toBe(
-        "One of a kind piece, created by the artist."
+        "One-of-a-kind piece."
       )
     })
   })

--- a/src/schema/v1/artwork/__tests__/artwork.test.js
+++ b/src/schema/v1/artwork/__tests__/artwork.test.js
@@ -1495,27 +1495,6 @@ describe("Artwork type", () => {
       })
     })
 
-    it(`returns proper attribution class info for unique artwork`, () => {
-      const query = `
-        {
-          artwork(id: "richard-prince-untitled-portrait") {
-            attribution_class {
-              info,
-            }
-          }
-        }
-      `
-      return runQuery(query, context).then((data) => {
-        expect(data).toEqual({
-          artwork: {
-            attribution_class: {
-              info: "One of a kind piece",
-            },
-          },
-        })
-      })
-    })
-
     it(`returns proper attribution class short_description for unique artwork`, () => {
       const query = `
         {

--- a/src/schema/v1/artwork/__tests__/artwork.test.js
+++ b/src/schema/v1/artwork/__tests__/artwork.test.js
@@ -1530,7 +1530,7 @@ describe("Artwork type", () => {
         expect(data).toEqual({
           artwork: {
             attribution_class: {
-              long_description: "One of a kind piece, created by the artist.",
+              long_description: "One-of-a-kind piece.",
             },
           },
         })

--- a/src/schema/v2/__tests__/artworkAttributionClasses.test.ts
+++ b/src/schema/v2/__tests__/artworkAttributionClasses.test.ts
@@ -21,7 +21,7 @@ describe("ArtworkAttributionClasses type", () => {
         "This is a unique work"
       )
       expect(data!.artworkAttributionClasses[0].longDescription).toBe(
-        "One of a kind piece, created by the artist."
+        "One-of-a-kind piece."
       )
     })
   })

--- a/src/schema/v2/__tests__/artworkAttributionClasses.test.ts
+++ b/src/schema/v2/__tests__/artworkAttributionClasses.test.ts
@@ -8,7 +8,6 @@ describe("ArtworkAttributionClasses type", () => {
         artworkAttributionClasses {
           internalID
           name
-          info
           shortDescription
           longDescription
         }

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -1606,7 +1606,7 @@ describe("Artwork type", () => {
         expect(data).toEqual({
           artwork: {
             attributionClass: {
-              longDescription: "One of a kind piece, created by the artist.",
+              longDescription: "One-of-a-kind piece.",
             },
           },
         })

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -1571,27 +1571,6 @@ describe("Artwork type", () => {
       })
     })
 
-    it(`returns proper attribution class info for unique artwork`, () => {
-      const query = `
-        {
-          artwork(id: "richard-prince-untitled-portrait") {
-            attributionClass {
-              info
-            }
-          }
-        }
-      `
-      return runQuery(query, context).then((data) => {
-        expect(data).toEqual({
-          artwork: {
-            attributionClass: {
-              info: "One of a kind piece",
-            },
-          },
-        })
-      })
-    })
-
     it(`returns proper attribution class short_description for unique artwork`, () => {
       const query = `
         {

--- a/src/schema/v2/artwork/attributionClass.ts
+++ b/src/schema/v2/artwork/attributionClass.ts
@@ -13,12 +13,12 @@ const AttributionClass = new GraphQLObjectType<any, ResolverContext>({
     },
     info: {
       type: GraphQLString,
-      description:
-        "Descriptive phrase used as companion for attribution class name display",
+      deprecationReason: "Prefer `shortDescription`",
     },
     shortDescription: {
       type: GraphQLString,
-      description: "Longer version of attribution class display",
+      description:
+        "Short descriptive phrase for attribution class without punctuation",
       resolve: ({ short_description }) => {
         return short_description
       },
@@ -26,7 +26,7 @@ const AttributionClass = new GraphQLObjectType<any, ResolverContext>({
     longDescription: {
       type: GraphQLString,
       description:
-        "Long descriptive phrase used as companion for short_description",
+        "Long description (can include multiple sentences) for attribution class",
       resolve: ({ long_description }) => {
         return long_description
       },


### PR DESCRIPTION
- chore: Mark AttributionClass#info as deprecated
    This attribute doesn't seem to be used in any of our clients and came up while we were updating copy for new classification options.
- chore: update copy for artwork classifications
    Introduce minor copy updates for shortDescription.

@oxaudo I couldn't find any client using the `info` field. Think it's alright to deprecate until we're confident in removing it?

Note: Rebase and merge