### PR TITLE
chore: Expose email frequency reads and writes

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7134,6 +7134,9 @@ type Me implements Node {
     last: Int
   ): CreditCardConnection
   email: String
+
+  # Frequency of marketing emails.
+  emailFrequency: String
   followsAndSaves: FollowsAndSaves
   hasCreditCards: Boolean
   hasPassword: Boolean!
@@ -10593,6 +10596,9 @@ input UpdateMyProfileInput {
 
   # The given email of the user.
   email: String
+
+  # Frequency of marketing emails.
+  emailFrequency: String
 
   # The given location of the user as structured data
   location: EditableLocation

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -61,6 +61,11 @@ const Me = new GraphQLObjectType<any, ResolverContext>({
     email: {
       type: GraphQLString,
     },
+    emailFrequency: {
+      description: "Frequency of marketing emails.",
+      resolve: ({ email_frequency }) => email_frequency,
+      type: GraphQLString,
+    },
     canRequestEmailConfirmation: {
       type: new GraphQLNonNull(GraphQLBoolean),
       description: "Whether user is allowed to request email confirmation",

--- a/src/schema/v2/me/update_me_mutation.ts
+++ b/src/schema/v2/me/update_me_mutation.ts
@@ -122,6 +122,10 @@ export default mutationWithClientMutationId<any, any, ResolverContext>({
       description: "The given email of the user.",
       type: GraphQLString,
     },
+    emailFrequency: {
+      description: "Frequency of marketing emails.",
+      type: GraphQLString,
+    },
     password: {
       description: "The user's password, required to change email address.",
       type: GraphQLString,
@@ -207,6 +211,7 @@ export default mutationWithClientMutationId<any, any, ResolverContext>({
   mutateAndGetPayload: (
     {
       collectorLevel,
+      emailFrequency,
       priceRangeMin,
       priceRangeMax,
       receivePurchaseNotification,
@@ -222,6 +227,7 @@ export default mutationWithClientMutationId<any, any, ResolverContext>({
   ) => {
     const user: any = {
       collector_level: collectorLevel,
+      email_frequency: emailFrequency,
       price_range_min: priceRangeMin,
       price_range_max: priceRangeMax,
       receive_purchase_notification: receivePurchaseNotification,


### PR DESCRIPTION
This builds on https://github.com/artsy/gravity/pull/13723 by adding the email frequency field to the me type for reading and writing. I can then use this over in force to get the value and set it when a user manages this setting.

/cc @zephraph @mdole 