### PR TITLE
Allow for query of partner top viewed viewing room data

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -292,7 +292,7 @@ type AnalyticsPartnerStats {
     @deprecated(reason: "Use pageview for refactored time series bucket code")
   partnerId: String!
 
-  # Artworks, shows, or artists ranked by views. Capped at 20 by the underlying sql query.
+  # Artworks, shows, viewing rooms, or artists ranked by views. Capped at 20 by the underlying sql query.
   rankedStats(
     # Returns the elements in the list that come after the specified cursor.
     after: String
@@ -478,9 +478,9 @@ enum AnalyticsQueryPeriodEnum {
   SIXTEEN_WEEKS
 }
 
-union AnalyticsRankedEntityUnion = Artist | Artwork | Show
+union AnalyticsRankedEntityUnion = Artist | Artwork | Show | ViewingRoom
 
-# Top artworks, shows, or artists from a partner
+# Top artworks, shows, viewing rooms, or artists from a partner
 type AnalyticsRankedStats {
   entity: AnalyticsRankedEntityUnion
   period: AnalyticsQueryPeriodEnum!
@@ -518,13 +518,17 @@ enum AnalyticsRankedStatsObjectTypeEnum {
 
   # Show
   SHOW
+
+  # ViewingRoom
+  VIEWING_ROOM
 }
 
-# An artwork, artist, or show
+# An artwork, artist, show, or viewing room
 union AnalyticsRankedStatsUnion =
     AnalyticsArtist
   | AnalyticsArtwork
   | AnalyticsShow
+  | AnalyticsViewingRoom
 
 type AnalyticsShow {
   entityId: String!
@@ -534,6 +538,10 @@ type AnalyticsShow {
 type AnalyticsUserStats {
   totalPurchaseCount: Int!
   userId: String!
+}
+
+type AnalyticsViewingRoom {
+  entityId: String!
 }
 
 type AnalyticsVisitorsByCountry {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -278,7 +278,7 @@ type AnalyticsPartnerStats {
     @deprecated(reason: "Use pageview for refactored time series bucket code")
   partnerId: String!
 
-  # Artworks, shows, or artists ranked by views. Capped at 20 by the underlying sql query.
+  # Artworks, shows, viewing rooms, or artists ranked by views. Capped at 20 by the underlying sql query.
   rankedStats(
     # Returns the elements in the list that come after the specified cursor.
     after: String
@@ -464,9 +464,9 @@ enum AnalyticsQueryPeriodEnum {
   SIXTEEN_WEEKS
 }
 
-union AnalyticsRankedEntityUnion = Artist | Artwork | Show
+union AnalyticsRankedEntityUnion = Artist | Artwork | Show | ViewingRoom
 
-# Top artworks, shows, or artists from a partner
+# Top artworks, shows, viewing rooms, or artists from a partner
 type AnalyticsRankedStats {
   entity: AnalyticsRankedEntityUnion
   period: AnalyticsQueryPeriodEnum!
@@ -504,13 +504,17 @@ enum AnalyticsRankedStatsObjectTypeEnum {
 
   # Show
   SHOW
+
+  # ViewingRoom
+  VIEWING_ROOM
 }
 
-# An artwork, artist, or show
+# An artwork, artist, show, or viewing room
 union AnalyticsRankedStatsUnion =
     AnalyticsArtist
   | AnalyticsArtwork
   | AnalyticsShow
+  | AnalyticsViewingRoom
 
 type AnalyticsShow {
   entityId: String!
@@ -520,6 +524,10 @@ type AnalyticsShow {
 type AnalyticsUserStats {
   totalPurchaseCount: Int!
   userId: String!
+}
+
+type AnalyticsViewingRoom {
+  entityId: String!
 }
 
 type AnalyticsVisitorsByCountry {

--- a/src/data/vortex.graphql
+++ b/src/data/vortex.graphql
@@ -301,7 +301,7 @@ type PartnerStats {
   partnerId: String!
 
   """
-  Artworks, shows, or artists ranked by views. Capped at 20 by the underlying sql query.
+  Artworks, shows, viewing rooms, or artists ranked by views. Capped at 20 by the underlying sql query.
   """
   rankedStats(
     """
@@ -602,7 +602,7 @@ enum QueryPeriodEnum {
 }
 
 """
-Top artworks, shows, or artists from a partner
+Top artworks, shows, viewing rooms, or artists from a partner
 """
 type RankedStats {
   period: QueryPeriodEnum!
@@ -660,12 +660,17 @@ enum RankedStatsObjectTypeEnum {
   Show
   """
   SHOW
+
+  """
+  ViewingRoom
+  """
+  VIEWING_ROOM
 }
 
 """
-An artwork, artist, or show
+An artwork, artist, show, or viewing room
 """
-union RankedStatsUnion = Artist | Artwork | Show
+union RankedStatsUnion = Artist | Artwork | Show | ViewingRoom
 
 type Show {
   entityId: String!
@@ -677,6 +682,10 @@ Statistics for users
 type UserStats {
   totalPurchaseCount: Int!
   userId: String!
+}
+
+type ViewingRoom {
+  entityId: String!
 }
 
 type VisitorsByCountry {

--- a/src/lib/stitching/mergeSchemas.ts
+++ b/src/lib/stitching/mergeSchemas.ts
@@ -80,7 +80,9 @@ export const incrementalMergeSchemas = (localSchema, version: 1 | 2) => {
   if (version === 1) {
     useStitchingEnvironment(vortexStitchingEnvironmentv1(localSchema))
   } else {
-    useStitchingEnvironment(vortexStitchingEnvironmentv2(localSchema))
+    useStitchingEnvironment(
+      vortexStitchingEnvironmentv2(localSchema, gravitySchema)
+    )
   }
 
   // Always stitch kaws

--- a/src/lib/stitching/vortex/stitchingv1.ts
+++ b/src/lib/stitching/vortex/stitchingv1.ts
@@ -16,7 +16,7 @@ const getMaxPrice = (thing: { listPrice: any }) => {
 export const vortexStitchingEnvironment = (localSchema: GraphQLSchema) => ({
   // The SDL used to declare how to stitch an object
   extensionSchema: gql`
-    union AnalyticsRankedEntityUnion = Artwork | Show | Artist
+    union AnalyticsRankedEntityUnion = Artwork | Show | Artist | ViewingRoom
     extend type AnalyticsPricingContext {
       appliedFiltersDisplay: String
     }


### PR DESCRIPTION
Builds out the Metaphysics interface to allow for querying of the new Vortex partner analytics of a partner's most viewed viewing rooms.

Associated Vortex changes: https://github.com/artsy/vortex/pull/291 


Takes a partner id, period, and the new viewing room query enum (defined in vortex) and returns a list of Viewing Rooms with the number of user views it has received during the given time period. Also allows us to pull additional viewing room attributes from Gravity's GraphQL schema.

<img width="1665" alt="Screen Shot 2021-01-13 at 2 50 42 PM" src="https://user-images.githubusercontent.com/12748344/104503209-c607c300-55ae-11eb-8ec7-51cb467611f2.png">


This data will drive Most Viewed VR in CMS partner analytics 
<img width="1643" alt="Screen Shot 2021-01-13 at 2 01 04 PM" src="https://user-images.githubusercontent.com/12748344/104516288-0e7cac00-55c2-11eb-9527-d03eceb04a6e.png">




Paired with some cool friends on this - shoutout to Sarah, Matt, and Justin for the help here! 🎉 
