### PR TITLE
feat(my collection): allow marking works as editions without requiring extra fields

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1326,6 +1326,7 @@ type Artwork implements Node & Searchable & Sellable {
   isBuyNowable: Boolean
   isComparableWithAuctionResults: Boolean
   isDownloadable: Boolean
+  isEdition: Boolean
   isEmbeddableVideo: Boolean
   isForSale: Boolean
   isHangable: Boolean
@@ -7650,6 +7651,7 @@ input MyCollectionCreateArtworkInput {
   editionSize: String
   externalImageUrls: [String]
   height: String
+  isEdition: Boolean
   medium: String!
   metric: String
   provenance: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7696,6 +7696,7 @@ input MyCollectionUpdateArtworkInput {
   editionSize: String
   externalImageUrls: [String]
   height: String
+  isEdition: Boolean
   medium: String
   metric: String
   provenance: String

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -205,6 +205,15 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" }
     ),
+    deleteArtworkEditionSetLoader: gravityLoader<
+      any,
+      { artworkId: string; editionSetId: string }
+    >(
+      ({ artworkId, editionSetId }) =>
+        `artwork/${artworkId}/edition_set/${editionSetId}`,
+      {},
+      { method: "DELETE" }
+    ),
     notificationsFeedLoader: gravityLoader("me/notifications/feed"),
     partnerArtworksLoader: gravityLoader(
       (id) => `partner/${id}/artworks`,

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -223,6 +223,12 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           }
         },
       },
+      isEdition: {
+        type: GraphQLBoolean,
+        resolve: ({ edition_sets }) => {
+          return edition_sets && edition_sets.length >= 1
+        },
+      },
       editionSize: {
         type: GraphQLString,
         resolve: ({ edition_sets }) => edition_sets?.[0]?.edition_size,

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -14,10 +14,12 @@ const computeMutationInput = ({
   externalImageUrls = [],
   editionSize = null,
   editionNumber = null,
+  isEdition = null,
 }: {
   externalImageUrls?: string[]
   editionSize?: string | null
   editionNumber?: string | null
+  isEdition?: boolean | null
 } = {}): string => {
   const mutation = gql`
     mutation {
@@ -29,6 +31,7 @@ const computeMutationInput = ({
           costMinor: 200
           date: "1990"
           depth: "20"
+          isEdition: ${JSON.stringify(isEdition)}
           editionNumber: ${JSON.stringify(editionNumber)}
           editionSize: ${JSON.stringify(editionSize)}
           externalImageUrls: ${JSON.stringify(externalImageUrls)}
@@ -228,7 +231,6 @@ describe("myCollectionCreateArtworkMutation", () => {
       expect(createArtworkEditionSetLoader).toHaveBeenCalledWith(
         newArtwork.id,
         {
-          edition_size: null,
           available_editions: ["50"],
         }
       )
@@ -245,7 +247,6 @@ describe("myCollectionCreateArtworkMutation", () => {
         newArtwork.id,
         {
           edition_size: "50",
-          available_editions: null,
         }
       )
     })
@@ -259,6 +260,19 @@ describe("myCollectionCreateArtworkMutation", () => {
       await runAuthenticatedQuery(mutation, defaultContext)
 
       expect(createArtworkEditionSetLoader).not.toHaveBeenCalled()
+    })
+
+    it("does create an edition set if you pass `isEdition`", async () => {
+      const mutation = computeMutationInput({
+        isEdition: true,
+      })
+
+      await runAuthenticatedQuery(mutation, defaultContext)
+
+      expect(createArtworkEditionSetLoader).toHaveBeenCalledWith(
+        newArtwork.id,
+        {}
+      )
     })
   })
 })

--- a/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
@@ -267,7 +267,7 @@ describe("myCollectionUpdateArtworkMutation", () => {
       expect(createArtworkEditionSetLoader).not.toHaveBeenCalled()
     })
 
-    it("creates an edition set if you specify `isEdition` true ", async () => {
+    it("creates an edition set if you specify `isEdition` true", async () => {
       const mutation = computeMutationInput({
         isEdition: true,
       })

--- a/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
@@ -1,6 +1,5 @@
 import { runAuthenticatedQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
-import { Partner } from "types/runtime/gravity"
 
 const updatedArtwork = { id: "some-artwork-id" }
 const updateArtworkLoader = jest.fn().mockResolvedValue(updatedArtwork)

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -1,4 +1,4 @@
-import { GraphQLString, GraphQLList, GraphQLInt } from "graphql"
+import { GraphQLString, GraphQLList, GraphQLInt, GraphQLBoolean } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 import { ResolverContext } from "types/graphql"
 import { GraphQLNonNull } from "graphql"
@@ -56,6 +56,9 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
     depth: {
       type: GraphQLString,
     },
+    isEdition: {
+      type: GraphQLBoolean,
+    },
     editionNumber: {
       type: GraphQLString,
     },
@@ -92,6 +95,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
       artistIds,
       costCurrencyCode,
       costMinor,
+      isEdition,
       editionSize,
       editionNumber,
       externalImageUrls = [],
@@ -122,12 +126,18 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
 
       const artworkId = response.id
 
-      if (editionNumber || editionSize) {
+      if (isEdition) {
         // create edition set for artwork
-        await createArtworkEditionSetLoader(artworkId, {
-          edition_size: editionSize,
-          available_editions: editionNumber ? [editionNumber] : null,
-        })
+        let payload = {}
+        if (editionSize) {
+          payload["edition_size"] = editionSize
+        }
+
+        if (editionNumber) {
+          payload["available_editions"] = [editionNumber]
+        }
+
+        await createArtworkEditionSetLoader(artworkId, payload)
       }
 
       const imageSources = computeImageSources(externalImageUrls)

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -126,8 +126,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
 
       const artworkId = response.id
 
-      const providedEditionField = editionNumber || editionSize
-      if (isEdition === true || providedEditionField) {
+      if (isEdition === true || editionNumber || editionSize) {
         // create edition set for artwork
         const payload = {}
         if (editionSize) {

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -127,7 +127,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
       const artworkId = response.id
 
       const providedEditionField = editionNumber || editionSize
-      if (isEdition || providedEditionField) {
+      if (isEdition === true || providedEditionField) {
         // create edition set for artwork
         let payload = {}
         if (editionSize) {

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -126,7 +126,8 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
 
       const artworkId = response.id
 
-      if (isEdition) {
+      const providedEditionField = editionNumber || editionSize
+      if (isEdition || providedEditionField) {
         // create edition set for artwork
         let payload = {}
         if (editionSize) {

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -129,7 +129,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
       const providedEditionField = editionNumber || editionSize
       if (isEdition === true || providedEditionField) {
         // create edition set for artwork
-        let payload = {}
+        const payload = {}
         if (editionSize) {
           payload["edition_size"] = editionSize
         }

--- a/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
@@ -1,12 +1,32 @@
-import { GraphQLString, GraphQLList, GraphQLNonNull, GraphQLInt } from "graphql"
+import {
+  GraphQLString,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLInt,
+  GraphQLBoolean,
+} from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 import { ResolverContext } from "types/graphql"
 import { MyCollectionArtworkMutationType } from "./myCollection"
 import { formatGravityError } from "lib/gravityErrorHandler"
 import { computeImageSources } from "./myCollectionCreateArtworkMutation"
 
+interface MyCollectionArtworkUpdateMutationInput {
+  artworkId: string
+  artistIds?: [string]
+  category?: string
+  costCurrencyCode?: string
+  costMinor?: number
+  date?: string
+  depth?: string
+  isEdition?: boolean
+  editionNumber?: string
+  editionSize?: string
+  externalImageUrls?: [string]
+}
+
 export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
-  any,
+  MyCollectionArtworkUpdateMutationInput,
   any,
   ResolverContext
 >({
@@ -33,6 +53,9 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
     },
     depth: {
       type: GraphQLString,
+    },
+    isEdition: {
+      type: GraphQLBoolean,
     },
     editionNumber: {
       type: GraphQLString,
@@ -74,6 +97,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
       artistIds,
       costCurrencyCode,
       costMinor,
+      isEdition,
       editionNumber,
       editionSize,
       externalImageUrls = [],
@@ -83,6 +107,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
       updateArtworkLoader,
       createArtworkImageLoader,
       createArtworkEditionSetLoader,
+      deleteArtworkEditionSetLoader,
       updateArtworkEditionSetLoader,
     }
   ) => {
@@ -90,6 +115,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
       !updateArtworkLoader ||
       !createArtworkImageLoader ||
       !createArtworkEditionSetLoader ||
+      !deleteArtworkEditionSetLoader ||
       !updateArtworkEditionSetLoader
     ) {
       return new Error("You need to be signed in to perform this action")
@@ -104,22 +130,36 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
       })
 
       if (!response.edition_sets?.length) {
-        if (editionSize || editionNumber) {
-          // create new edition set when none existed previously
-          await createArtworkEditionSetLoader(artworkId, {
-            edition_size: editionSize,
-            available_editions: editionNumber ? [editionNumber] : null,
-          })
+        const providedEditionField = editionNumber || editionSize
+        if (isEdition === true || providedEditionField) {
+          // create edition set for artwork
+          let payload = {}
+          if (editionSize) {
+            payload["edition_size"] = editionSize
+          }
+
+          if (editionNumber) {
+            payload["available_editions"] = [editionNumber]
+          }
+          await createArtworkEditionSetLoader(artworkId, payload)
         }
       } else {
         const editionSetId = response.edition_sets[0].id
-        await updateArtworkEditionSetLoader(
-          { artworkId, editionSetId },
-          {
-            edition_size: editionSize,
-            available_editions: editionNumber ? [editionNumber] : null,
+
+        if (isEdition === false) {
+          await deleteArtworkEditionSetLoader({ artworkId, editionSetId })
+        } else {
+          const payload = {
+            edition_size: editionSize ? editionSize : null,
+            // TODO: Is there a better way to clear out edition number?
+            available_editions: editionNumber ? [editionNumber] : [""],
           }
-        )
+
+          await updateArtworkEditionSetLoader(
+            { artworkId, editionSetId },
+            payload
+          )
+        }
       }
 
       const imageSources = computeImageSources(externalImageUrls)

--- a/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
@@ -133,7 +133,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
         const providedEditionField = editionNumber || editionSize
         if (isEdition === true || providedEditionField) {
           // create edition set for artwork
-          let payload = {}
+          const payload = {}
           if (editionSize) {
             payload["edition_size"] = editionSize
           }

--- a/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
@@ -130,8 +130,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
       })
 
       if (!response.edition_sets?.length) {
-        const providedEditionField = editionNumber || editionSize
-        if (isEdition === true || providedEditionField) {
+        if (isEdition === true || editionNumber || editionSize) {
           // create edition set for artwork
           const payload = {}
           if (editionSize) {


### PR DESCRIPTION
**New behavior:** We are hoping to support users creating artworks marked as editions without requiring them to provide **editionSize** or **editionNumber**

**Old behavior:** Editions were only created when a user passed either editionSize or editionNumber. There was a small bug here where if only editionSize was passed creation would fail validation because of explicit null being passed in the field. This instead doesn't provide the field when it isn't present.

To support the new behavior this PR:
- adds a new field to the `myCollectionCreateArtworkMutation` `isEdition` to explicitly ask for an edition to be created. 
- only passes provided fields to edition creation to prevent validation error from explicit null
- To stay backwards compatible this also keeps logic to create an edition if either **editionSize** or **editionNumber** is passed. 
-  adds a helper field on artwork `isEdition` 
- adds similar fields and logic to `myCollectionUpdateArtworkMutation`, slight difference in that this mutation needs to be able to set individual fields to empty values

TODO:
- [x] Similar logic in update mutation