### PR TITLE
feat(PX-3603): do not return certificate of authenticity data if certificate is false

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -2260,13 +2260,10 @@ describe("Artwork type", () => {
         expect(data.artwork.hasCertificateOfAuthenticity).toBe(true)
       })
     })
-    it("is set to proper object when certificate_of_authenticity is false", () => {
+    it("is null when certificate_of_authenticity is false", () => {
       artwork.certificate_of_authenticity = false
       return runQuery(query, context).then((data) => {
-        expect(data.artwork.certificateOfAuthenticity).toEqual({
-          label: "Certificate of authenticity",
-          details: "Not included",
-        })
+        expect(data.artwork.certificateOfAuthenticity).toBe(null)
         expect(data.artwork.hasCertificateOfAuthenticity).toBe(false)
       })
     })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -955,15 +955,10 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       certificateOfAuthenticity: {
         type: ArtworkInfoRowType,
         description:
-          "Returns the display label and detail for artwork certificate of authenticity",
+          "Returns the display label and detail when artwork has a certificate of authenticity",
         resolve: ({ certificate_of_authenticity }) => {
           if (certificate_of_authenticity) {
             return { label: "Certificate of authenticity", details: "Included" }
-          } else if (certificate_of_authenticity === false) {
-            return {
-              label: "Certificate of authenticity",
-              details: "Not included",
-            }
           } else {
             return null
           }


### PR DESCRIPTION
There is a request not to display the note that COA is not included when it's marked as false. I think this will solve that for all clients.

We are still waiting for confirmation from Product that there is no additional concerns with that removal hence the WIP message here. 