### PR TITLE
fix: Updates causality stub data to include id on watchedLotConnection

### DIFF
--- a/src/lib/stitching/causality/stitching.ts
+++ b/src/lib/stitching/causality/stitching.ts
@@ -219,6 +219,7 @@ export const causalityStitchingEnvironment = ({
               saleArtwork: sa,
               // TODO: fetch actual lot states
               lot: {
+                id: "12346789",
                 bidCount: 4,
                 reserveStatus: "NoReserve",
                 sellingPrice: {


### PR DESCRIPTION
Update to #2925 's stub data on Causality's 'watchedLotConnection' to also stub out `id`.

cc @artsy/purchase-devs 