### PR TITLE
chore: update schema for diffusion medianSaleOverEstimatePercentage field

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -9318,11 +9318,13 @@ type MarketPriceInsights {
   demandRank: Float
   demandTrend: Float
   highRangeCents: BigInt
+  id: ID!
   largeHighRangeCents: BigInt
   largeLowRangeCents: BigInt
   largeMidRangeCents: BigInt
   liquidityRank: Float
   lowRangeCents: BigInt
+  medianSaleOverEstimatePercentage: Int
   medianSaleToEstimateRatio: Float
   medium: String
   mediumHighRangeCents: BigInt

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7075,11 +7075,13 @@ type MarketPriceInsights {
   demandRank: Float
   demandTrend: Float
   highRangeCents: BigInt
+  id: ID!
   largeHighRangeCents: BigInt
   largeLowRangeCents: BigInt
   largeMidRangeCents: BigInt
   liquidityRank: Float
   lowRangeCents: BigInt
+  medianSaleOverEstimatePercentage: Int
   medianSaleToEstimateRatio: Float
   medium: String
   mediumHighRangeCents: BigInt

--- a/src/data/diffusion.graphql
+++ b/src/data/diffusion.graphql
@@ -22,11 +22,13 @@ type MarketPriceInsights {
   demandRank: Float
   demandTrend: Float
   highRangeCents: BigInt
+  id: ID!
   largeHighRangeCents: BigInt
   largeLowRangeCents: BigInt
   largeMidRangeCents: BigInt
   liquidityRank: Float
   lowRangeCents: BigInt
+  medianSaleOverEstimatePercentage: Int
   medianSaleToEstimateRatio: Float
   medium: String
   mediumHighRangeCents: BigInt


### PR DESCRIPTION
Partially addresses https://artsyproduct.atlassian.net/browse/CX-738.

Stitches in a new field named `medianSaleOverEstimatePercentage`, which we'll be using in Eigen for displaying market stats for an artist.