### PR TITLE
Add checklistItem type to partner level

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2285,6 +2285,19 @@ type CaptureHoldPayload {
   holdOrError: InventoryHoldOrErrorUnion!
 }
 
+type ChecklistItemsType {
+  # Artworks missing priority metadata for a partner's checklist
+  artworkItemsConnection(
+    after: String
+    before: String
+    exclude: [String]
+    first: Int
+    forSale: Boolean
+    last: Int
+    sort: ArtworkSorts
+  ): ArtworkConnection
+}
+
 type City {
   coordinates: LatLng
   fairsConnection(
@@ -7995,6 +8008,9 @@ type Partner implements Node {
   ): ArtworkConnection
   cached: Int
   categories: [PartnerCategory]
+
+  # A list of the partners checklist items
+  checklistItems: ChecklistItemsType
 
   # A list of the partners unique city locations
   cities(size: Int = 25): [String]

--- a/src/schema/v2/__tests__/partner.test.js
+++ b/src/schema/v2/__tests__/partner.test.js
@@ -201,6 +201,79 @@ describe("Partner type", () => {
       })
     })
   })
+  describe("#checklistItems", () => {
+    let artworksResponse
+
+    beforeEach(() => {
+      artworksResponse = [
+        {
+          id: "cara-barer-iceberg",
+        },
+        {
+          id: "david-leventi-rezzonico",
+        },
+        {
+          id: "virginia-mak-hidden-nature-08",
+        },
+      ]
+      context = {
+        partnerArtworksLoader: () =>
+          Promise.resolve({
+            body: artworksResponse,
+            headers: {
+              "x-total-count": artworksResponse.length,
+            },
+          }),
+        partnerLoader: () => Promise.resolve(partnerData),
+      }
+    })
+
+    it("returns artworks and such", async () => {
+      const query = `
+        {
+          partner(id:"bau-xi-gallery") {
+            checklistItems {
+              artworkItemsConnection(first:3) {
+                edges {
+                  node {
+                    slug
+                  }
+                }
+              }
+            } 
+          }
+        }
+      `
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        partner: {
+          checklistItems: {
+            artworkItemsConnection: {
+              edges: [
+                {
+                  node: {
+                    slug: "cara-barer-iceberg",
+                  },
+                },
+                {
+                  node: {
+                    slug: "david-leventi-rezzonico",
+                  },
+                },
+                {
+                  node: {
+                    slug: "virginia-mak-hidden-nature-08",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      })
+    })
+  })
 
   describe("#artworksConnection", () => {
     let artworksResponse

--- a/src/schema/v2/checklistItems.ts
+++ b/src/schema/v2/checklistItems.ts
@@ -1,0 +1,20 @@
+import { artworkConnection } from "./artwork"
+import { GraphQLObjectType } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { pageable } from "relay-cursor-paging"
+import { artworksArgs, artworksConnectionResolver } from "./partner"
+
+export const ChecklistItemsType = new GraphQLObjectType<any, ResolverContext>({
+  name: "ChecklistItemsType",
+  fields: () => {
+    return {
+      artworkItemsConnection: {
+        description:
+          "Artworks missing priority metadata for a partner's checklist",
+        type: artworkConnection.connectionType,
+        args: pageable(artworksArgs),
+        resolve: artworksConnectionResolver,
+      },
+    }
+  },
+})

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -66,7 +66,7 @@ export const artworksConnectionResolver = (
     page,
     size,
     sort: args.sort,
-    for_sale: args.for_sale,
+    for_sale: args.forSale,
   }
 
   if (args.exclude) {


### PR DESCRIPTION
Co-authored-by: mdole <mdole7@gmail.com>

Addresses: https://artsyproduct.atlassian.net/browse/PX-3631

Development work to allow us to more easily query for artworks that will eventually populate a partner's home checklist in CMS

Eg of query structure:
<img width="1919" alt="Screen Shot 2021-01-26 at 9 46 16 AM" src="https://user-images.githubusercontent.com/12748344/105860236-5be21b80-5fbb-11eb-8e2b-a9befc263c5d.png">
