### PR TITLE
feat: Add signed_in_plate to ArtworkType

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -2143,6 +2143,7 @@ describe("Artwork type", () => {
       artwork.stamped_by_artist_estate = null
       artwork.sticker_label = null
       artwork.signed_other = null
+      artwork.signed_in_plate = null
       artwork.not_signed = null
 
       return runQuery(query, context).then((data) => {
@@ -2152,6 +2153,7 @@ describe("Artwork type", () => {
     it("is null when all related fields are false", () => {
       artwork.signature = ""
       artwork.signed_by_artist = false
+      artwork.signed_in_plate = false
       artwork.stamped_by_artist_estate = false
       artwork.sticker_label = false
       artwork.signed_other = false
@@ -2163,6 +2165,7 @@ describe("Artwork type", () => {
     it("is set to proper object when signed_other is true", () => {
       artwork.signature = ""
       artwork.signed_by_artist = false
+      artwork.signed_in_plate = false
       artwork.stamped_by_artist_estate = false
       artwork.sticker_label = false
       artwork.signed_other = true
@@ -2191,6 +2194,7 @@ describe("Artwork type", () => {
     it("is set to proper object when several fields are true", () => {
       artwork.signature = "some details about signature"
       artwork.signed_by_artist = true
+      artwork.signed_in_plate = true
       artwork.stamped_by_artist_estate = true
       artwork.sticker_label = true
       artwork.signed_other = true
@@ -2200,7 +2204,7 @@ describe("Artwork type", () => {
             signatureInfo: {
               label: "Signature",
               details:
-                "Hand-signed by artist, stamped by artist's estate, sticker label, some details about signature",
+                "Hand-signed by artist, signed in plate, stamped by artist's estate, sticker label, some details about signature",
             },
           },
         })
@@ -2209,6 +2213,7 @@ describe("Artwork type", () => {
     it("is set to proper object when only signed_other is true", () => {
       artwork.signature = ""
       artwork.signed_by_artist = false
+      artwork.signed_in_plate = false
       artwork.stamped_by_artist_estate = false
       artwork.sticker_label = false
       artwork.signed_other = true

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -920,6 +920,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({
           signature,
           signed_by_artist,
+          signed_in_plate,
           stamped_by_artist_estate,
           sticker_label,
           signed_other,
@@ -928,6 +929,9 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           const detailsParts: string[] = []
           if (signed_by_artist) {
             detailsParts.push("hand-signed by artist")
+          }
+          if (signed_in_plate) {
+            detailsParts.push("signed in plate")
           }
           if (stamped_by_artist_estate) {
             detailsParts.push("stamped by artist's estate")

--- a/src/types/runtime/gravity/Artwork.ts
+++ b/src/types/runtime/gravity/Artwork.ts
@@ -87,6 +87,7 @@ export const Artwork = Record({
   shipping_origin: Array(String).Or(Null),
   signature: String,
   signed_by_artist: Boolean.Or(Null),
+  signed_in_plate: Boolean.Or(Null),
   signed_other: Boolean.Or(Null),
   size_score: Number.Or(Null),
   sold: Boolean,


### PR DESCRIPTION
Adding another option to valid signature fields (`signed_in_plate`). This follows adding the field in Gravity and Kinetic. Making sure Purchase is aware.