### PR TITLE
Fix casing to allow for filtering artworks by forSale argument

### DIFF
--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -121,7 +121,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             page,
             size,
             sort: args.sort,
-            for_sale: args.for_sale,
+            for_sale: args.forSale,
           }
 
           if (args.exclude) {


### PR DESCRIPTION
Co-authored-by: mdole <mdole7@gmail.com>


Fixes a bug where we are trying to grab the value of `args.for_sale`, the thing is this will always return `undefined`, and not allow us to properly filter by works that are `forSale=true/false`


Bug - artworks regardless of `isForSale` status are returned in the query response:
<img width="1888" alt="Screen Shot 2021-01-28 at 2 32 58 PM" src="https://user-images.githubusercontent.com/12748344/106189964-f76bbb80-6176-11eb-99be-5bb6cd28a005.png">




Fix - artworks where only `isForSale=true` are returned in the query response:
<img width="1899" alt="Screen Shot 2021-01-28 at 2 33 19 PM" src="https://user-images.githubusercontent.com/12748344/106189934-eb7ff980-6176-11eb-953a-374af1059bda.png">