### PR TITLE
feat: add percentage performance over mid estimate to auction result

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1726,6 +1726,11 @@ type AuctionLotImages {
   thumbnail: Image
 }
 
+type AuctionLotPerformance {
+  # Percentage performance over mid-estimate
+  mid: String
+}
+
 type AuctionResult implements Node {
   artistID: String!
   boughtIn: Boolean
@@ -1753,6 +1758,7 @@ type AuctionResult implements Node {
   location: String
   mediumText: String
   organization: String
+  performance: AuctionLotPerformance
   priceRealized: AuctionResultPriceRealized
   saleDate(
     format: String

--- a/src/schema/v2/__tests__/auction_result.test.ts
+++ b/src/schema/v2/__tests__/auction_result.test.ts
@@ -18,17 +18,18 @@ const mockAuctionResult = {
   ],
   currency: "EUR",
   location: "Berlin",
-  priceRealized_cents: 420000,
-  priceRealized_cents_usd: 100000,
+  price_realized_cents: 420000,
+  price_realized_cents_usd: 100000,
   low_estimate_cents: 200000,
-  high_estimate_cents: 500000,
+  hammer_price_cents: 350000,
+  high_estimate_cents: 400000,
   price_realized: {
-    cents: 420000,
-    centsUSD: 100000,
-    display: "JPY ¥420k",
+    cents: 200000,
+    centsUSD: 200000,
+    display: "€200.000",
   },
   estimate: {
-    display: "JPY ¥200,000 - 500,000",
+    display: "€200,000 - 500,000",
   },
 }
 
@@ -40,6 +41,9 @@ describe("AuctionResult type", () => {
           currency
           saleDateText
           location
+          performance {
+            mid
+          }
         }
       }
     `
@@ -49,9 +53,14 @@ describe("AuctionResult type", () => {
     }
 
     return runQuery(query, context!).then((data) => {
-      expect(data.auctionResult.currency).toBe("EUR")
-      expect(data.auctionResult.saleDateText).toEqual("10-12-2020")
-      expect(data.auctionResult.location).toEqual("Berlin")
+      expect(data.auctionResult).toEqual({
+        currency: "EUR",
+        saleDateText: "10-12-2020",
+        location: "Berlin",
+        performance: {
+          mid: "14%",
+        },
+      })
     })
   })
 })

--- a/src/schema/v2/__tests__/auction_result.test.ts
+++ b/src/schema/v2/__tests__/auction_result.test.ts
@@ -18,11 +18,11 @@ const mockAuctionResult = {
   ],
   currency: "EUR",
   location: "Berlin",
-  price_realized_cents: 420000,
-  price_realized_cents_usd: 100000,
-  low_estimate_cents: 200000,
-  hammer_price_cents: 350000,
-  high_estimate_cents: 400000,
+  price_realized_cents: 200000,
+  price_realized_cents_usd: 200000,
+  low_estimate_cents: 100000,
+  hammer_price_cents: 100000,
+  high_estimate_cents: 300000,
   price_realized: {
     cents: 200000,
     centsUSD: 200000,
@@ -58,7 +58,7 @@ describe("AuctionResult type", () => {
         saleDateText: "10-12-2020",
         location: "Berlin",
         performance: {
-          mid: "14%",
+          mid: "-50%",
         },
       })
     })

--- a/src/schema/v2/__tests__/auction_result.test.ts
+++ b/src/schema/v2/__tests__/auction_result.test.ts
@@ -18,10 +18,10 @@ const mockAuctionResult = {
   ],
   currency: "EUR",
   location: "Berlin",
-  price_realized_cents: 200000,
+  price_realized_cents: 100000,
   price_realized_cents_usd: 200000,
-  low_estimate_cents: 100000,
   hammer_price_cents: 100000,
+  low_estimate_cents: 100000,
   high_estimate_cents: 300000,
   price_realized: {
     cents: 200000,

--- a/src/schema/v2/auction_result.ts
+++ b/src/schema/v2/auction_result.ts
@@ -141,6 +141,39 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
         }
       },
     },
+    performance: {
+      type: new GraphQLObjectType({
+        name: "AuctionLotPerformance",
+        fields: {
+          mid: {
+            type: GraphQLString,
+            description: "Percentage performance over mid-estimate",
+            resolve: ({
+              hammer_price_cents,
+              high_estimate_cents,
+              low_estimate_cents,
+            }) => {
+              if (
+                hammer_price_cents &&
+                high_estimate_cents &&
+                low_estimate_cents
+              ) {
+                return (
+                  Math.round(
+                    ((hammer_price_cents -
+                      (low_estimate_cents + high_estimate_cents) / 2) /
+                      hammer_price_cents) *
+                      100
+                  ) + "%"
+                )
+              }
+              return null
+            },
+          },
+        },
+      }),
+      resolve: (lot) => lot,
+    },
     estimate: {
       type: new GraphQLObjectType<any, ResolverContext>({
         name: "AuctionLotEstimate",
@@ -153,6 +186,7 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
             type: GraphQLFloat,
             resolve: ({ high_estimate_cents }) => high_estimate_cents,
           },
+
           display: {
             type: GraphQLString,
             resolve: ({

--- a/src/schema/v2/auction_result.ts
+++ b/src/schema/v2/auction_result.ts
@@ -158,11 +158,11 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
                 high_estimate_cents &&
                 low_estimate_cents
               ) {
+                const midEstimate = (low_estimate_cents + high_estimate_cents) / 2)
+                const delta = hammer_price_cents - midEstimate
                 return (
                   Math.round(
-                    ((hammer_price_cents -
-                      (low_estimate_cents + high_estimate_cents) / 2) /
-                      hammer_price_cents) *
+                    (delta / midEstimate) *
                       100
                   ) + "%"
                 )

--- a/src/schema/v2/auction_result.ts
+++ b/src/schema/v2/auction_result.ts
@@ -149,18 +149,18 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
             type: GraphQLString,
             description: "Percentage performance over mid-estimate",
             resolve: ({
-              hammer_price_cents,
+              price_realized_cents,
               high_estimate_cents,
               low_estimate_cents,
             }) => {
               if (
-                hammer_price_cents &&
+                price_realized_cents &&
                 high_estimate_cents &&
                 low_estimate_cents
               ) {
                 const midEstimate =
                   (low_estimate_cents + high_estimate_cents) / 2
-                const delta = hammer_price_cents - midEstimate
+                const delta = price_realized_cents - midEstimate
                 return Math.round((delta / midEstimate) * 100) + "%"
               }
               return null

--- a/src/schema/v2/auction_result.ts
+++ b/src/schema/v2/auction_result.ts
@@ -158,14 +158,10 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
                 high_estimate_cents &&
                 low_estimate_cents
               ) {
-                const midEstimate = (low_estimate_cents + high_estimate_cents) / 2)
+                const midEstimate =
+                  (low_estimate_cents + high_estimate_cents) / 2
                 const delta = hammer_price_cents - midEstimate
-                return (
-                  Math.round(
-                    (delta / midEstimate) *
-                      100
-                  ) + "%"
-                )
+                return Math.round((delta / midEstimate) * 100) + "%"
               }
               return null
             },


### PR DESCRIPTION
This PR resolves: https://artsyproduct.atlassian.net/browse/CX-955

**Description:**
- Add percentage performance over mid estimate to auction result


TODO: 
- [x] Make sure the formula is correct