### PR TITLE
feat: Adds offerable_from_inquiry flag for Inquiry Checkout

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1351,6 +1351,9 @@ type Artwork implements Node & Searchable & Sellable {
 
   # Whether a user can make an offer on a work
   isOfferable: Boolean
+
+  # Whether a user can make an offer on the work through inquiry
+  isOfferableFromInquiry: Boolean
   isOnHold: String
   isPriceHidden: Boolean
   isPriceRange: Boolean
@@ -5313,6 +5316,7 @@ type EditionSet implements Sellable {
   isAcquireable: Boolean
   isForSale: Boolean
   isOfferable: Boolean
+  isOfferableFromInquiry: Boolean
   isSold: Boolean
   listPrice: ListPrice
   price: String
@@ -9997,6 +10001,9 @@ interface Sellable {
 
   # Whether a user can make an offer on the work
   isOfferable: Boolean
+
+  # Whether a user can make an offer on the work through inquiry
+  isOfferableFromInquiry: Boolean
   isSold: Boolean
   saleMessage: String
 }

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -264,6 +264,30 @@ describe("Artwork type", () => {
     })
   })
 
+  describe("#isOfferableFromInquiry", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          slug
+          isOfferableFromInquiry
+        }
+      }
+    `
+
+    it("will return the value of offerable_from_inquiry", () => {
+      artwork.offerable_from_inquiry = true
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            slug: "richard-prince-untitled-portrait",
+            isOfferableFromInquiry: true,
+          },
+        })
+      })
+    })
+  })
+
   describe("#pricePaid", () => {
     const query = `
     {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -390,6 +390,12 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         description: "Whether a user can make an offer on a work",
         resolve: ({ offerable }) => offerable,
       },
+      isOfferableFromInquiry: {
+        type: GraphQLBoolean,
+        description:
+          "Whether a user can make an offer on the work through inquiry",
+        resolve: ({ offerable_from_inquiry }) => offerable_from_inquiry,
+      },
       isBiddable: {
         type: GraphQLBoolean,
         description:

--- a/src/schema/v2/edition_set.ts
+++ b/src/schema/v2/edition_set.ts
@@ -54,6 +54,10 @@ export const EditionSetType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLBoolean,
       resolve: ({ offerable }) => offerable,
     },
+    isOfferableFromInquiry: {
+      type: GraphQLBoolean,
+      resolve: ({ offerable_from_inquiry }) => offerable_from_inquiry,
+    },
     isForSale: {
       type: GraphQLBoolean,
       resolve: ({ forsale }) => forsale,

--- a/src/schema/v2/sellable.ts
+++ b/src/schema/v2/sellable.ts
@@ -21,6 +21,12 @@ export const Sellable = new GraphQLInterfaceType({
       description: "Whether a user can make an offer on the work",
       resolve: ({ is_offerable }) => is_offerable,
     },
+    isOfferableFromInquiry: {
+      type: GraphQLBoolean,
+      description:
+        "Whether a user can make an offer on the work through inquiry",
+      resolve: ({ is_offerable_from_inquiry }) => is_offerable_from_inquiry,
+    },
     isForSale: {
       type: GraphQLBoolean,
       resolve: ({ is_for_sale }) => is_for_sale,

--- a/src/types/gravity/artworkResponse.d.ts
+++ b/src/types/gravity/artworkResponse.d.ts
@@ -39,6 +39,7 @@ export interface GravityArtwork {
   inquireable: boolean
   acquireable: boolean
   offerable: boolean
+  offerable_from_inquiry: boolean
   published_at: string
   can_share: boolean
   can_share_image: boolean

--- a/src/types/runtime/gravity/Artwork.ts
+++ b/src/types/runtime/gravity/Artwork.ts
@@ -68,6 +68,7 @@ export const Artwork = Record({
   not_signed: Boolean.Or(Null),
   offer: Boolean,
   offerable: Boolean,
+  offerable_from_inquiry: Boolean,
   partner: Partner,
   pickup_available: Boolean.Or(Null),
   price_cents: Array(Number.Or(Null)).Or(Null),

--- a/src/types/runtime/gravity/EditionSet.ts
+++ b/src/types/runtime/gravity/EditionSet.ts
@@ -9,6 +9,7 @@ export const EditionSet = Record({
   price_cents: Array(Number.Or(Null)).Or(Null),
   acquireable: Boolean,
   offerable: Boolean,
+  offerable_from_inquiry: Boolean,
   dimensions: Record({ in: String.Or(Null), cm: String.Or(Null) }),
   editions: String,
   display_price_currency: String,


### PR DESCRIPTION
This PR resolves [\[PURCHASE-2413\]](https://artsyproduct.atlassian.net/browse/PURCHASE-2413)

Adds `offerable_from_inquiry` flag for `EditionSet` and `Artwork` to be used with Inquiry Checkout. Relates to [this](https://github.com/artsy/gravity/pull/13786) gravity PR.

[PURCHASE-2413]: https://artsyproduct.atlassian.net/browse/PURCHASE-2413