### PR TITLE
feat(shows): expands args on top level shows connection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9249,10 +9249,14 @@ type Query {
   # A list of Shows
   showsConnection(
     after: String
+    atAFair: Boolean
     before: String
+    displayable: Boolean = true
     first: Int
+    hasLocation: Boolean
     ids: [String]
     last: Int
+    sort: ShowSorts
   ): ShowConnection
 
   # Content for a specific page or view
@@ -11512,10 +11516,14 @@ type Viewer {
   # A list of Shows
   showsConnection(
     after: String
+    atAFair: Boolean
     before: String
+    displayable: Boolean = true
     first: Int
+    hasLocation: Boolean
     ids: [String]
     last: Int
+    sort: ShowSorts
   ): ShowConnection
 
   # Content for a specific page or view

--- a/src/schema/v2/sorts/show_sorts.ts
+++ b/src/schema/v2/sorts/show_sorts.ts
@@ -1,48 +1,26 @@
 import { GraphQLEnumType } from "graphql"
 
+const SHOW_SORTS = {
+  END_AT_ASC: { value: "end_at" },
+  END_AT_DESC: { value: "-end_at" },
+  FEATURED_ASC: { value: "-featured,-start_at" },
+  FEATURED_DESC: { value: "-featured,-end_at" },
+  NAME_ASC: { value: "name" },
+  NAME_DESC: { value: "-name" },
+  PARTNER_ASC: { value: "fully_qualified_name" },
+  SORTABLE_NAME_ASC: { value: "sortable_name" },
+  SORTABLE_NAME_DESC: { value: "-sortable_name" },
+  START_AT_ASC: { value: "start_at" },
+  START_AT_DESC: { value: "-start_at" },
+  UPDATED_AT_ASC: { value: "updated_at" },
+  UPDATED_AT_DESC: { value: "-updated_at" },
+}
+
 const ShowSorts = new GraphQLEnumType({
   name: "ShowSorts",
-  values: {
-    START_AT_ASC: {
-      value: "start_at",
-    },
-    START_AT_DESC: {
-      value: "-start_at",
-    },
-    END_AT_ASC: {
-      value: "end_at",
-    },
-    END_AT_DESC: {
-      value: "-end_at",
-    },
-    UPDATED_AT_ASC: {
-      value: "updated_at",
-    },
-    UPDATED_AT_DESC: {
-      value: "-updated_at",
-    },
-    NAME_ASC: {
-      value: "name",
-    },
-    NAME_DESC: {
-      value: "-name",
-    },
-    FEATURED_ASC: {
-      value: "featured",
-    },
-    FEATURED_DESC: {
-      value: "-featured",
-    },
-    SORTABLE_NAME_ASC: {
-      value: "sortable_name",
-    },
-    SORTABLE_NAME_DESC: {
-      value: "-sortable_name",
-    },
-    PARTNER_ASC: {
-      value: "fully_qualified_name",
-    },
-  },
+  values: SHOW_SORTS,
 })
+
+export type TShowSorts = keyof typeof SHOW_SORTS
 
 export default ShowSorts


### PR DESCRIPTION
For now this just cleans up the top-level showsConnection and adds some of the supported options.

The query criteria for online exclusives according to Force is:

```
  has_location: false,
  displayable: true,
  at_a_fair: false,
```

------

As an aside it does seem like we might want to actually model this or at least remove the `at_a_fair: false` constraint, considering that we have online exclusive fairs on the site.