### PR TITLE
feat: Display info from new COA checkboxes to user on artwork page

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -2331,7 +2331,8 @@ describe("Artwork type", () => {
       return runQuery(query, context).then((data) => {
         expect(data.artwork.certificateOfAuthenticity).toEqual({
           label: "Certificate of authenticity",
-          details: "Included (issued by authorized authenticating body and gallery)",
+          details:
+            "Included (one issued by gallery; one issued by authorized authenticating body)",
         })
         expect(data.artwork.hasCertificateOfAuthenticity).toBe(true)
       })

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -2297,6 +2297,40 @@ describe("Artwork type", () => {
         expect(data.artwork.hasCertificateOfAuthenticity).toBe(true)
       })
     })
+    it("is set to proper object when ertificate_of_authenticity and coa_from_authenticating_body are true", () => {
+      artwork.certificate_of_authenticity = true
+      artwork.coa_by_authenticating_body = true
+      return runQuery(query, context).then((data) => {
+        expect(data.artwork.certificateOfAuthenticity).toEqual({
+          label: "Certificate of authenticity",
+          details: "Included (issued by authorized authenticating body)",
+        })
+        expect(data.artwork.hasCertificateOfAuthenticity).toBe(true)
+      })
+    })
+    it("is set to proper when object certificate_of_authenticity and coa_from_gallery are true", () => {
+      artwork.certificate_of_authenticity = true
+      artwork.coa_by_gallery = true
+      return runQuery(query, context).then((data) => {
+        expect(data.artwork.certificateOfAuthenticity).toEqual({
+          label: "Certificate of authenticity",
+          details: "Included (issued by gallery)",
+        })
+        expect(data.artwork.hasCertificateOfAuthenticity).toBe(true)
+      })
+    })
+    it("is set to proper when object certificate_of_authenticity, coa_from_authenticating_body, and coa_from_gallery are true", () => {
+      artwork.certificate_of_authenticity = true
+      artwork.coa_by_gallery = true
+      artwork.coa_by_authenticating_body = true
+      return runQuery(query, context).then((data) => {
+        expect(data.artwork.certificateOfAuthenticity).toEqual({
+          label: "Certificate of authenticity",
+          details: "Included (issued by authorized authenticating body and gallery)",
+        })
+        expect(data.artwork.hasCertificateOfAuthenticity).toBe(true)
+      })
+    })
     it("is null when certificate_of_authenticity is false", () => {
       artwork.certificate_of_authenticity = false
       return runQuery(query, context).then((data) => {

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -2280,6 +2280,7 @@ describe("Artwork type", () => {
         }
       }
     `
+
     it("is null when certificate_of_authenticity is null", () => {
       artwork.certificate_of_authenticity = null
       return runQuery(query, context).then((data) => {
@@ -2287,6 +2288,7 @@ describe("Artwork type", () => {
         expect(data.artwork.hasCertificateOfAuthenticity).toBe(false)
       })
     })
+
     it("is set to proper object when certificate_of_authenticity is true", () => {
       artwork.certificate_of_authenticity = true
       return runQuery(query, context).then((data) => {
@@ -2297,7 +2299,8 @@ describe("Artwork type", () => {
         expect(data.artwork.hasCertificateOfAuthenticity).toBe(true)
       })
     })
-    it("is set to proper object when ertificate_of_authenticity and coa_from_authenticating_body are true", () => {
+
+    it("is set to proper object when certificate_of_authenticity and coa_from_authenticating_body are true", () => {
       artwork.certificate_of_authenticity = true
       artwork.coa_by_authenticating_body = true
       return runQuery(query, context).then((data) => {
@@ -2308,6 +2311,7 @@ describe("Artwork type", () => {
         expect(data.artwork.hasCertificateOfAuthenticity).toBe(true)
       })
     })
+
     it("is set to proper when object certificate_of_authenticity and coa_from_gallery are true", () => {
       artwork.certificate_of_authenticity = true
       artwork.coa_by_gallery = true
@@ -2319,6 +2323,7 @@ describe("Artwork type", () => {
         expect(data.artwork.hasCertificateOfAuthenticity).toBe(true)
       })
     })
+
     it("is set to proper when object certificate_of_authenticity, coa_from_authenticating_body, and coa_from_gallery are true", () => {
       artwork.certificate_of_authenticity = true
       artwork.coa_by_gallery = true
@@ -2331,6 +2336,7 @@ describe("Artwork type", () => {
         expect(data.artwork.hasCertificateOfAuthenticity).toBe(true)
       })
     })
+
     it("is null when certificate_of_authenticity is false", () => {
       artwork.certificate_of_authenticity = false
       return runQuery(query, context).then((data) => {

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -2312,7 +2312,7 @@ describe("Artwork type", () => {
       })
     })
 
-    it("is set to proper when object certificate_of_authenticity and coa_from_gallery are true", () => {
+    it("is set to proper object when certificate_of_authenticity and coa_from_gallery are true", () => {
       artwork.certificate_of_authenticity = true
       artwork.coa_by_gallery = true
       return runQuery(query, context).then((data) => {
@@ -2324,7 +2324,7 @@ describe("Artwork type", () => {
       })
     })
 
-    it("is set to proper when object certificate_of_authenticity, coa_from_authenticating_body, and coa_from_gallery are true", () => {
+    it("is set to proper object when certificate_of_authenticity, coa_from_authenticating_body, and coa_from_gallery are true", () => {
       artwork.certificate_of_authenticity = true
       artwork.coa_by_gallery = true
       artwork.coa_by_authenticating_body = true

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -991,7 +991,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
               detailsParts += " (issued by gallery)"
             } else if (coa_by_authenticating_body && coa_by_gallery) {
               detailsParts +=
-                " (issued by authorized authenticating body and gallery)"
+                " (one issued by gallery; one issued by authorized authenticating body)"
             }
             return {
               label: "Certificate of authenticity",

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -977,9 +977,26 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: ArtworkInfoRowType,
         description:
           "Returns the display label and detail when artwork has a certificate of authenticity",
-        resolve: ({ certificate_of_authenticity }) => {
+        resolve: ({
+          certificate_of_authenticity,
+          coa_by_authenticating_body,
+          coa_by_gallery,
+        }) => {
+          let detailsParts = ""
           if (certificate_of_authenticity) {
-            return { label: "Certificate of authenticity", details: "Included" }
+            detailsParts += "Included"
+            if (coa_by_authenticating_body && !coa_by_gallery) {
+              detailsParts += " (issued by authorized authenticating body)"
+            } else if (coa_by_gallery && !coa_by_authenticating_body) {
+              detailsParts += " (issued by gallery)"
+            } else if (coa_by_authenticating_body && coa_by_gallery) {
+              detailsParts +=
+                " (issued by authorized authenticating body and gallery)"
+            }
+            return {
+              label: "Certificate of authenticity",
+              details: detailsParts,
+            }
           } else {
             return null
           }


### PR DESCRIPTION
Added new copy about certificate of authentication to provide more detail around COA—whether the COA was issued by an authorized authenticating body and/or by the gallery. These correspond to new checkbox inputs in the artwork form in CMS that allows galleries to provide this further detail.

Case for w/ issued by gallery checked:
<img width="354" alt="Screen Shot 2021-02-02 at 1 34 55 PM" src="https://user-images.githubusercontent.com/9466631/106659273-bc450000-655b-11eb-9f15-08b8c413471f.png">
Case for w/ issued by authenticating body checked:
<img width="513" alt="Screen Shot 2021-02-02 at 1 29 24 PM" src="https://user-images.githubusercontent.com/9466631/106659278-bd762d00-655b-11eb-9eb8-996a35f4cfe5.png">
Case for w/ both checked:
<img width="482" alt="Screen Shot 2021-02-03 at 2 36 03 PM" src="https://user-images.githubusercontent.com/9466631/106812749-52952680-662d-11eb-8f8c-da8036b843fa.png">

[Jira ticket](https://artsyproduct.atlassian.net/browse/PX-3608)