### PR TITLE
feat: [Artwork] Expand formattedMetadata output for SEO

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -59,6 +59,66 @@ describe("Artwork type", () => {
     }
   })
 
+  describe("#formattedMetadata", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          formattedMetadata
+        }
+      }
+    `
+
+    it("returns properly formatted metadata", async () => {
+      artwork = {
+        ...artwork,
+        artist: { name: "Name" },
+        title: "Title",
+        date: "Date",
+        category: "Category",
+        medium: "Medium",
+        partner: { name: "Partner" },
+      }
+
+      context = {
+        artworkLoader: () => Promise.resolve(artwork),
+      }
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          formattedMetadata:
+            "Name, ‘Title’, Date, Category, Medium, Partner",
+        },
+      })
+    })
+
+    it("excludes null values", async () => {
+      artwork = {
+        ...artwork,
+        artist: { name: "Name" },
+        title: "Title",
+        date: "Date",
+        category: null,
+        medium: null,
+        partner: { name: "Partner" },
+      }
+
+      context = {
+        artworkLoader: () => Promise.resolve(artwork),
+      }
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          formattedMetadata:
+            "Name, ‘Title’, Date, Partner",
+        },
+      })
+    })
+  })
+
   describe("dimensions", () => {
     const query = `
       {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -281,11 +281,13 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLString,
         description:
           "Formatted artwork metadata, including artist, title, date and partner; e.g., 'Andy Warhol, Truck, 1980, Westward Gallery'.",
-        resolve: ({ artist, title, date, partner }) => {
+        resolve: ({ artist, title, date, category, medium, partner }) => {
           return _.compact([
             artist && artist.name,
             title && `‘${title}’`,
             date,
+            category && category,
+            medium && medium,
             partner && partner.name,
           ]).join(", ")
         },


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/GRO-164 

Updates our Artwork meta data to include more info for SEO purposes. 

<img width="1053" alt="Screen Shot 2021-02-01 at 3 14 19 PM" src="https://user-images.githubusercontent.com/236943/106531238-b808dc00-64a2-11eb-8f92-d782b9230fe5.png">

cc @artsy/grow-devs 