### PR TITLE
feat(partner): exposes filter artworks connection; deprecates old connection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8059,7 +8059,7 @@ type Partner implements Node {
     forSale: Boolean
     last: Int
     sort: ArtworkSorts
-  ): ArtworkConnection
+  ): ArtworkConnection @deprecated(reason: "Use `filterArtworksConnection`")
   cached: Int
   categories: [PartnerCategory]
 
@@ -8068,6 +8068,60 @@ type Partner implements Node {
   collectingInstitution: String
   counts: PartnerCounts
   defaultProfileID: String
+
+  # Artworks Elastic Search results
+  filterArtworksConnection(
+    acquireable: Boolean
+    after: String
+    aggregationPartnerCities: [String]
+    aggregations: [ArtworkAggregation]
+    artistID: String
+    artistIDs: [String]
+    artistNationalities: [String]
+    artistSeriesID: String
+    atAuction: Boolean
+    attributionClass: [String]
+    before: String
+    color: String
+    dimensionRange: String
+    excludeArtworkIDs: [String]
+    extraAggregationGeneIDs: [String]
+    first: Int
+    forSale: Boolean
+    geneID: String
+    geneIDs: [String]
+    height: String
+    includeArtworksByFollowedArtists: Boolean
+    includeMediumFilterInAggregation: Boolean
+    inquireableOnly: Boolean
+    keyword: String
+
+    # When true, will only return exact keyword match
+    keywordMatchExact: Boolean
+    last: Int
+    majorPeriods: [String]
+
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
+
+    # A string from the list of allocations, or * to denote all mediums
+    medium: String
+    offerable: Boolean
+    page: Int
+    partnerCities: [String]
+    partnerID: ID
+    period: String
+    periods: [String]
+    priceRange: String
+    saleID: ID
+    size: Int
+
+    # Filter results by Artwork sizes
+    sizes: [ArtworkSizes]
+    sort: String
+    tagID: String
+    width: String
+  ): FilterArtworksConnection
   hasFairPartnership: Boolean
   href: String
 

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -53,6 +53,8 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       edgeFields: partnerArtistFields,
     }).connectionType
 
+    const { filterArtworksConnection } = require("./filterArtworksConnection")
+
     return {
       ...SlugAndInternalIDFields,
       cached,
@@ -98,6 +100,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       },
       artworksConnection: {
         description: "A connection of artworks from a Partner.",
+        deprecationReason: "Use `filterArtworksConnection`",
         type: artworkConnection.connectionType,
         args: pageable(artworksArgs),
         resolve: ({ id }, args, { partnerArtworksLoader }) => {
@@ -218,6 +221,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLString,
         resolve: ({ default_profile_id }) => default_profile_id,
       },
+      filterArtworksConnection: filterArtworksConnection("partner_id"),
       hasFairPartnership: {
         type: GraphQLBoolean,
         resolve: ({ has_fair_partnership }) => has_fair_partnership,


### PR DESCRIPTION
Took me a moment to realize we supported this and how it worked... but there ya go.

![](https://static.damonzucconi.com/_capture/8YgnQ3v8YM8p.png)
