### PR TITLE
When creating an inquiry-offer-order, associate the offer and order in the mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7652,6 +7652,9 @@ type Mutation {
     input: CreateGeminiEntryForAssetInput!
   ): CreateGeminiEntryForAssetPayload
   createImage(input: CreateImageInput!): CreateImagePayload
+  createInquiryOffer(
+    input: CommerceCreateInquiryOfferOrderWithArtworkInput!
+  ): CommerceCreateInquiryOfferOrderWithArtworkPayload
   createSmsSecondFactor(
     input: CreateSmsSecondFactorInput!
   ): CreateSmsSecondFactorPayload

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7652,7 +7652,7 @@ type Mutation {
     input: CreateGeminiEntryForAssetInput!
   ): CreateGeminiEntryForAssetPayload
   createImage(input: CreateImageInput!): CreateImagePayload
-  createInquiryOffer(
+  createInquiryOfferOrder(
     input: CommerceCreateInquiryOfferOrderWithArtworkInput!
   ): CommerceCreateInquiryOfferOrderWithArtworkPayload
   createSmsSecondFactor(

--- a/src/lib/loaders/loaders_with_authentication/impulse.ts
+++ b/src/lib/loaders/loaders_with_authentication/impulse.ts
@@ -50,5 +50,10 @@ export default (accessToken, userID, opts) => {
       },
       { method: "POST" }
     ),
+    conversationCreateConversationOrderLoader: impulseLoader(
+      `conversation_orders`,
+      {},
+      { method: "POST" }
+    ),
   }
 }

--- a/src/lib/stitching/exchange/__tests__/stitching.test.ts
+++ b/src/lib/stitching/exchange/__tests__/stitching.test.ts
@@ -137,7 +137,7 @@ it("delegates to the local schema for an Order's creditCard", async () => {
 
   expect(mergeInfo.delegateToSchema).toHaveBeenCalledWith({
     args: { id: "CC-1" },
-    fieldName: "credit_card",
+    fieldName: "creditCard",
     ...restOfResolveArgs,
   })
 })
@@ -151,7 +151,7 @@ it("doesn't delegate to the local schema for an Order's creditCard if creditCard
 
   expect(mergeInfo.delegateToSchema).not.toHaveBeenCalledWith({
     args: { id: null },
-    fieldName: "credit_card",
+    fieldName: "creditCard",
     ...restOfResolveArgs,
   })
 })

--- a/src/lib/stitching/exchange/__tests__/stitching.test.ts
+++ b/src/lib/stitching/exchange/__tests__/stitching.test.ts
@@ -37,7 +37,7 @@ it("extends the Me object", async () => {
 it("extends the Mutation object", async () => {
   const mergedSchema = await getExchangeMergedSchema()
   const meFields = await getFieldsForTypeFromSchema("Mutation", mergedSchema)
-  expect(meFields).toContain("createInquiryOffer")
+  expect(meFields).toContain("createInquiryOfferOrder")
 })
 
 it("resolves amount fields on CommerceOrder", async () => {
@@ -162,7 +162,7 @@ it("doesn't delegate to the local schema for an Order's creditCard if creditCard
   })
 })
 
-describe("commerceCreateInquiryOfferOrderWithArtwork", () => {
+describe("createInquiryOfferOrder", () => {
   const context = {
     conversationLoader: jest.fn(),
     conversationCreateConversationOrderLoader: jest.fn(),
@@ -175,7 +175,7 @@ describe("commerceCreateInquiryOfferOrderWithArtwork", () => {
 
   it("calls impulse after creating the order", async () => {
     const { resolvers } = await getExchangeStitchedSchema()
-    const resolver = resolvers.Mutation.createInquiryOffer.resolve
+    const resolver = resolvers.Mutation.createInquiryOfferOrder.resolve
 
     const args = {
       input: {
@@ -213,7 +213,7 @@ describe("commerceCreateInquiryOfferOrderWithArtwork", () => {
 
   it("returns an error from exchange", async () => {
     const { resolvers } = await getExchangeStitchedSchema()
-    const resolver = resolvers.Mutation.createInquiryOffer.resolve
+    const resolver = resolvers.Mutation.createInquiryOfferOrder.resolve
     const args = {
       input: {
         artworkId: "artwork-id",
@@ -234,7 +234,7 @@ describe("commerceCreateInquiryOfferOrderWithArtwork", () => {
 
   it("returns an error if the conversationLoader does not return a conversation", async () => {
     const { resolvers } = await getExchangeStitchedSchema()
-    const resolver = resolvers.Mutation.createInquiryOffer.resolve
+    const resolver = resolvers.Mutation.createInquiryOfferOrder.resolve
     const args = {
       input: {
         artworkId: "artwork-id",
@@ -250,7 +250,7 @@ describe("commerceCreateInquiryOfferOrderWithArtwork", () => {
   })
   it("returns an error if the conversationCreateConversationOrderLoader fails", async () => {
     const { resolvers } = await getExchangeStitchedSchema()
-    const resolver = resolvers.Mutation.createInquiryOffer.resolve
+    const resolver = resolvers.Mutation.createInquiryOfferOrder.resolve
     const args = {
       input: {
         artworkId: "artwork-id",

--- a/src/lib/stitching/exchange/__tests__/stitching.test.ts
+++ b/src/lib/stitching/exchange/__tests__/stitching.test.ts
@@ -155,3 +155,115 @@ it("doesn't delegate to the local schema for an Order's creditCard if creditCard
     ...restOfResolveArgs,
   })
 })
+
+describe("commerceCreateInquiryOfferOrderWithArtwork", () => {
+  const context = {
+    conversationLoader: jest.fn(),
+    conversationCreateConversationOrderLoader: jest.fn(),
+  }
+  const mergeInfo = { delegateToSchema: jest.fn() }
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it("calls impulse after creating the order", async () => {
+    const { resolvers } = await getExchangeStitchedSchema()
+    const resolver =
+      resolvers.Mutation.commerceCreateInquiryOfferOrderWithArtwork.resolve
+
+    const args = {
+      input: {
+        artworkId: "artwork-id",
+        impulseConversationId: "conversation-id",
+      },
+    }
+    const orderResult = { orderOrError: { order: { internalID: "order-id" } } }
+    context.conversationLoader.mockResolvedValue({})
+    mergeInfo.delegateToSchema.mockResolvedValue(orderResult)
+    context.conversationCreateConversationOrderLoader.mockResolvedValue({
+      conversation_id: "it worked",
+    })
+
+    const result = await resolver({}, args, context, { mergeInfo })
+
+    expect(mergeInfo.delegateToSchema).toHaveBeenCalledWith({
+      args,
+      fieldName: "commerceCreateInquiryOfferOrderWithArtwork",
+      operation: "mutation",
+      schema: expect.anything(),
+      context: expect.anything(),
+      info: expect.anything(),
+    })
+    expect(result).toEqual(orderResult)
+    expect(context.conversationLoader).toHaveBeenCalledWith("conversation-id")
+    expect(
+      context.conversationCreateConversationOrderLoader
+    ).toHaveBeenCalledWith({
+      conversation_id: "conversation-id",
+      exchange_order_id: "order-id",
+    })
+  })
+
+  it("returns an error from exchange", async () => {
+    const { resolvers } = await getExchangeStitchedSchema()
+    const resolver =
+      resolvers.Mutation.commerceCreateInquiryOfferOrderWithArtwork.resolve
+    const args = {
+      input: {
+        artworkId: "artwork-id",
+        impulseConversationId: "conversation-id",
+      },
+    }
+    const orderResult = { orderOrError: { error: { message: "who cares" } } }
+
+    context.conversationLoader.mockResolvedValue({})
+    mergeInfo.delegateToSchema.mockResolvedValue(orderResult)
+    const result = await resolver({}, args, context, { mergeInfo })
+
+    expect(result).toEqual(orderResult)
+    expect(
+      context.conversationCreateConversationOrderLoader
+    ).not.toHaveBeenCalled()
+  })
+
+  it("returns an error if the conversationLoader does not return a conversation", async () => {
+    const { resolvers } = await getExchangeStitchedSchema()
+    const resolver =
+      resolvers.Mutation.commerceCreateInquiryOfferOrderWithArtwork.resolve
+    const args = {
+      input: {
+        artworkId: "artwork-id",
+        impulseConversationId: "conversation-id",
+      },
+    }
+
+    context.conversationLoader.mockRejectedValue({})
+
+    await expect(resolver({}, args, context, { mergeInfo })).rejects.toThrow(
+      "Bad Request"
+    )
+  })
+  it("returns an error if the conversationCreateConversationOrderLoader fails", async () => {
+    const { resolvers } = await getExchangeStitchedSchema()
+    const resolver =
+      resolvers.Mutation.commerceCreateInquiryOfferOrderWithArtwork.resolve
+    const args = {
+      input: {
+        artworkId: "artwork-id",
+        impulseConversationId: "conversation-id",
+      },
+    }
+    const orderResult = { orderOrError: { order: { internalID: "order-id" } } }
+
+    context.conversationLoader.mockResolvedValue({})
+    mergeInfo.delegateToSchema.mockResolvedValue(orderResult)
+    context.conversationCreateConversationOrderLoader.mockRejectedValue({
+      message: "bad stuff",
+    })
+
+    await expect(resolver({}, args, context, { mergeInfo })).rejects.toThrow(
+      "Impulse: request to associate offer with conversation failed"
+    )
+  })
+})

--- a/src/lib/stitching/exchange/__tests__/stitching.test.ts
+++ b/src/lib/stitching/exchange/__tests__/stitching.test.ts
@@ -34,6 +34,12 @@ it("extends the Me object", async () => {
   expect(meFields).toContain("orders")
 })
 
+it("extends the Mutation object", async () => {
+  const mergedSchema = await getExchangeMergedSchema()
+  const meFields = await getFieldsForTypeFromSchema("Mutation", mergedSchema)
+  expect(meFields).toContain("createInquiryOffer")
+})
+
 it("resolves amount fields on CommerceOrder", async () => {
   const { resolvers } = await getExchangeStitchedSchema()
   const totalListPriceResolver = resolvers.CommerceOrder.totalListPrice.resolve
@@ -169,8 +175,7 @@ describe("commerceCreateInquiryOfferOrderWithArtwork", () => {
 
   it("calls impulse after creating the order", async () => {
     const { resolvers } = await getExchangeStitchedSchema()
-    const resolver =
-      resolvers.Mutation.commerceCreateInquiryOfferOrderWithArtwork.resolve
+    const resolver = resolvers.Mutation.createInquiryOffer.resolve
 
     const args = {
       input: {
@@ -194,6 +199,7 @@ describe("commerceCreateInquiryOfferOrderWithArtwork", () => {
       schema: expect.anything(),
       context: expect.anything(),
       info: expect.anything(),
+      transforms: [expect.anything()],
     })
     expect(result).toEqual(orderResult)
     expect(context.conversationLoader).toHaveBeenCalledWith("conversation-id")
@@ -207,8 +213,7 @@ describe("commerceCreateInquiryOfferOrderWithArtwork", () => {
 
   it("returns an error from exchange", async () => {
     const { resolvers } = await getExchangeStitchedSchema()
-    const resolver =
-      resolvers.Mutation.commerceCreateInquiryOfferOrderWithArtwork.resolve
+    const resolver = resolvers.Mutation.createInquiryOffer.resolve
     const args = {
       input: {
         artworkId: "artwork-id",
@@ -229,8 +234,7 @@ describe("commerceCreateInquiryOfferOrderWithArtwork", () => {
 
   it("returns an error if the conversationLoader does not return a conversation", async () => {
     const { resolvers } = await getExchangeStitchedSchema()
-    const resolver =
-      resolvers.Mutation.commerceCreateInquiryOfferOrderWithArtwork.resolve
+    const resolver = resolvers.Mutation.createInquiryOffer.resolve
     const args = {
       input: {
         artworkId: "artwork-id",
@@ -241,13 +245,12 @@ describe("commerceCreateInquiryOfferOrderWithArtwork", () => {
     context.conversationLoader.mockRejectedValue({})
 
     await expect(resolver({}, args, context, { mergeInfo })).rejects.toThrow(
-      "Bad Request"
+      "[metaphysics @ exchange/v2/stitching] Conversation not found"
     )
   })
   it("returns an error if the conversationCreateConversationOrderLoader fails", async () => {
     const { resolvers } = await getExchangeStitchedSchema()
-    const resolver =
-      resolvers.Mutation.commerceCreateInquiryOfferOrderWithArtwork.resolve
+    const resolver = resolvers.Mutation.createInquiryOffer.resolve
     const args = {
       input: {
         artworkId: "artwork-id",

--- a/src/lib/stitching/exchange/__tests__/testingUtils.ts
+++ b/src/lib/stitching/exchange/__tests__/testingUtils.ts
@@ -1,8 +1,8 @@
 import { mergeSchemas } from "graphql-tools"
-import { exchangeStitchingEnvironment } from "../v1/stitching"
+import { exchangeStitchingEnvironment } from "../v2/stitching"
 import { GraphQLSchema } from "graphql"
 import { executableExchangeSchema, transformsForExchange } from "../schema"
-import localSchema from "schema/v1/schema"
+import localSchema from "schema/v2/schema"
 
 let cachedSchema: GraphQLSchema & { transforms: any }
 let stitchedSchema: ReturnType<typeof exchangeStitchingEnvironment>

--- a/src/lib/stitching/exchange/v2/stitching.ts
+++ b/src/lib/stitching/exchange/v2/stitching.ts
@@ -197,7 +197,7 @@ export const exchangeStitchingEnvironment = ({
     }
 
     extend type Mutation {
-      createInquiryOffer(
+      createInquiryOfferOrder(
         input: CommerceCreateInquiryOfferOrderWithArtworkInput!
       ): CommerceCreateInquiryOfferOrderWithArtworkPayload
     }
@@ -357,7 +357,7 @@ export const exchangeStitchingEnvironment = ({
         },
       },
       Mutation: {
-        createInquiryOffer: {
+        createInquiryOfferOrder: {
           resolve: async (_source, args, context, info) => {
             const {
               conversationLoader,

--- a/src/lib/stitching/exchange/v2/stitching.ts
+++ b/src/lib/stitching/exchange/v2/stitching.ts
@@ -366,8 +366,9 @@ export const exchangeStitchingEnvironment = ({
             try {
               await conversationLoader(impulseConversationId)
             } catch (e) {
-              // be more elegant?
-              throw new GraphQLError(`Bad Request`)
+              throw new GraphQLError(
+                `[metaphysics @ exchange/v2/stitching] Conversation not found`
+              )
             }
 
             const offerResult = await info.mergeInfo.delegateToSchema({
@@ -415,7 +416,9 @@ export const exchangeStitchingEnvironment = ({
               } = orderOrError
 
               if (!orderId) {
-                throw new GraphQLError("Bad request (no order id)")
+                throw new GraphQLError(
+                  "[metaphysics @ exchange/v2/stitching] Order.orderID field must be selected"
+                )
               }
 
               try {
@@ -425,7 +428,7 @@ export const exchangeStitchingEnvironment = ({
                 })
               } catch (e) {
                 throw new GraphQLError(
-                  "Impulse: request to associate offer with conversation failed"
+                  "[metaphysics @ exchange/v2/stitching] Impulse: request to associate offer with conversation failed"
                 )
               }
             }


### PR DESCRIPTION
completes [PURCHASE-2381]

This pr updates our exchange `commerceCreateInquiryOfferOrderWithArtwork` mutation resolver to make additional calls to impulse before and after the exchange call, failing if any request along the way fails. This could mean returning a `data...orderOrError.error` from exchange or no data but an `errors` key in the graphql response. 

<strike>It relies on `order.internalID` being selected in the query - we currently have some commented-out code where we tried and failed to use a `WrapQuery` transform to achieve this automatically but it didn't work so far. So for now just make sure you request the `order.internalID`.</strike> *We got this working with `WrapQuery` 🎉*

Consumers will have to handle a rejected request, a success with `errors`, and a success with `data.commerceCreateInquiryOfferOrderWithArtwork.orderOrError.error`.

Co-authored-by: sepans <sepans@sepans.com> and also part of a mob session with @artsy/purchase-devs.

[PURCHASE-2381]: https://artsyproduct.atlassian.net/browse/PURCHASE-2381