### PR TITLE
Chore: update exchange schema

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -4637,6 +4637,7 @@ type CommerceOfferOrder implements CommerceOrder {
   currencyCode: String!
   displayCommissionRate: String
   id: ID!
+  impulseConversationId: String
   internalID: ID!
   itemsTotal(
     decimal: String = "."

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3101,6 +3101,7 @@ type CommerceOfferOrder implements CommerceOrder {
   currencyCode: String!
   displayCommissionRate: String
   id: ID!
+  impulseConversationId: String
   internalID: ID!
   itemsTotal(
     decimal: String = "."

--- a/src/data/exchange.graphql
+++ b/src/data/exchange.graphql
@@ -757,6 +757,7 @@ type OfferOrder implements Order {
   currencyCode: String!
   displayCommissionRate: String
   id: ID!
+  impulseConversationId: String
   internalID: ID!
 
   """


### PR DESCRIPTION
Addresses: [PURCHASE-2418](https://artsyproduct.atlassian.net/browse/PURCHASE-2418)

⚠️ Blocked by https://github.com/artsy/exchange/pull/677 ⚠️ 

This updates the exchange schema to include `impulse_conversation_id` in the `OfferOrderType`.

cc @artsy/purchase-devs 