### PR TITLE
Feat: un-deprecate and add params to partner artworksConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8106,11 +8106,20 @@ type Partner implements Node {
   # A connection of artworks from a Partner.
   artworksConnection(
     after: String
+
+    # Return only artwork(s) included in this list of IDs.
+    artworkIDs: [String]
     before: String
     exclude: [String]
     first: Int
     forSale: Boolean
+
+    # Return artworks with less than x additional_images.
+    imageCountLessThan: Int
     last: Int
+
+    # Return artworks published less than x seconds ago.
+    publishedWithin: Int
     sort: ArtworkSorts
   ): ArtworkConnection
   cached: Int

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8112,7 +8112,7 @@ type Partner implements Node {
     forSale: Boolean
     last: Int
     sort: ArtworkSorts
-  ): ArtworkConnection @deprecated(reason: "Use `filterArtworksConnection`")
+  ): ArtworkConnection
   cached: Int
   categories: [PartnerCategory]
 

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -33,13 +33,25 @@ import { connectionWithCursorInfo } from "./fields/pagination"
 import { deprecate } from "lib/deprecation"
 
 const artworksArgs: GraphQLFieldConfigArgumentMap = {
-  forSale: {
-    type: GraphQLBoolean,
+  artworkIDs: {
+    type: new GraphQLList(GraphQLString),
+    description: "Return only artwork(s) included in this list of IDs.",
   },
-  sort: ArtworkSorts,
   exclude: {
     type: new GraphQLList(GraphQLString),
   },
+  forSale: {
+    type: GraphQLBoolean,
+  },
+  imageCountLessThan: {
+    type: GraphQLInt,
+    description: "Return artworks with less than x additional_images.",
+  },
+  publishedWithin: {
+    type: GraphQLInt,
+    description: "Return artworks published less than x seconds ago.",
+  },
+  sort: ArtworkSorts,
 }
 
 export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
@@ -108,26 +120,34 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           )
 
           interface GravityArgs {
+            artwork_id?: string[]
             exclude_ids?: string[]
+            for_sale: boolean
+            image_count_less_than?: number
             page: number
             published: boolean
+            published_within?: number
             size: number
-            total_count: boolean
             sort: string
-            for_sale: boolean
+            total_count: boolean
           }
 
           const gravityArgs: GravityArgs = {
-            published: true,
-            total_count: true,
+            for_sale: args.forSale,
+            image_count_less_than: args.imageCountLessThan,
             page,
+            published: true,
+            published_within: args.publishedWithin,
             size,
             sort: args.sort,
-            for_sale: args.forSale,
+            total_count: true,
           }
 
           if (args.exclude) {
             gravityArgs.exclude_ids = flatten([args.exclude])
+          }
+          if (args.artworkIDs) {
+            gravityArgs.artwork_id = flatten([args.artworkIDs])
           }
 
           return partnerArtworksLoader(id, gravityArgs).then(

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -100,7 +100,6 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       },
       artworksConnection: {
         description: "A connection of artworks from a Partner.",
-        deprecationReason: "Use `filterArtworksConnection`",
         type: artworkConnection.connectionType,
         args: pageable(artworksArgs),
         resolve: ({ id }, args, { partnerArtworksLoader }) => {


### PR DESCRIPTION
Following up on https://github.com/artsy/gravity/pull/13790, this PR allows us to use the new `imageCountLessThan`, `publishedWithin` (seconds) and `artworkID`. We can thus execute a query like this:

```graphql
{ 
  partner(id: "commerce-test-partner") {
    artworkMetadataChecklistItems: artworksConnection(first: 5 publishedWithin: 7776000 imageCountLessThan:2 artworkID:["5fadb09499a3f8000e1c8afe","5fcfef6acdefca0012db87b2"] exclude:"5fcfef6acdefca0012db87b2") {
      edges {
        node {
          internalID
          title
          image {
            href
          }
          artistNames
          slug
        }
      }
    }
  }
}
```

...and get back artworks that meet all of the criteria in the params. Woohoo!