### PR TITLE
fix: use en-dash for estimate

### DIFF
--- a/src/schema/v2/__tests__/auction_result.test.ts
+++ b/src/schema/v2/__tests__/auction_result.test.ts
@@ -28,9 +28,6 @@ const mockAuctionResult = {
     centsUSD: 200000,
     display: "€200.000",
   },
-  estimate: {
-    display: "€200,000 - 500,000",
-  },
 }
 
 describe("AuctionResult type", () => {
@@ -43,6 +40,9 @@ describe("AuctionResult type", () => {
           location
           performance {
             mid
+          }
+          estimate {
+            display
           }
         }
       }
@@ -59,6 +59,9 @@ describe("AuctionResult type", () => {
         location: "Berlin",
         performance: {
           mid: "-50%",
+        },
+        estimate: {
+          display: "€1,000 – 3,000",
         },
       })
     })

--- a/src/schema/v2/__tests__/auction_results.test.js
+++ b/src/schema/v2/__tests__/auction_results.test.js
@@ -103,7 +103,7 @@ describe("Artist type", () => {
                     display: "JPY ¥420k",
                   },
                   estimate: {
-                    display: "JPY ¥200,000 - 500,000",
+                    display: "JPY ¥200,000 – 500,000",
                   },
                 },
               },

--- a/src/schema/v2/auction_result.ts
+++ b/src/schema/v2/auction_result.ts
@@ -212,7 +212,7 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
                 display += numeral(amount).format("")
               } else {
                 amount = Math.round(low_estimate_cents / subunit_to_unit)
-                display += numeral(amount).format("") + " - "
+                display += numeral(amount).format("") + " – "
                 amount = Math.round(high_estimate_cents / subunit_to_unit)
                 display += numeral(amount).format("")
               }


### PR DESCRIPTION
**Description:**
Use **en-dash** (&ndash;) on auction results estimate range