### PR TITLE
Add conversation to Order type (with new root conversation field)

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8728,6 +8728,9 @@ type PublishViewingRoomPayload {
 
 type Query {
   # Do not use (only used internally for stitching)
+  _do_not_use_conversation: Conversation
+
+  # Do not use (only used internally for stitching)
   _do_not_use_image: Image
 
   # Lot standings for a user
@@ -11318,6 +11321,9 @@ union VanityURLEntityType = Fair | Partner
 
 # A wildcard used to support complex root queries in Relay
 type Viewer {
+  # Do not use (only used internally for stitching)
+  _do_not_use_conversation: Conversation
+
   # Do not use (only used internally for stitching)
   _do_not_use_image: Image
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2522,6 +2522,7 @@ type CommerceBuyOrder implements CommerceOrder {
   ): String
   commissionFeeCents: Int
   commissionRate: Float
+  conversation: Conversation
   createdAt(
     format: String
 
@@ -3098,6 +3099,7 @@ type CommerceOfferOrder implements CommerceOrder {
   ): String
   commissionFeeCents: Int
   commissionRate: Float
+  conversation: Conversation
   createdAt(
     format: String
 
@@ -3281,6 +3283,7 @@ interface CommerceOrder {
   ): String
   commissionFeeCents: Int
   commissionRate: Float
+  conversation: Conversation
   createdAt(
     format: String
 

--- a/src/lib/stitching/exchange/v2/stitching.ts
+++ b/src/lib/stitching/exchange/v2/stitching.ts
@@ -202,6 +202,7 @@ export const exchangeStitchingEnvironment = ({
       creditCard: CreditCard
       isInquiryOrder: Boolean!
       conversation: Conversation
+      
       ${orderTotalsSDL.join("\n")}
     }
 

--- a/src/lib/stitching/exchange/v2/stitching.ts
+++ b/src/lib/stitching/exchange/v2/stitching.ts
@@ -159,44 +159,10 @@ export const exchangeStitchingEnvironment = ({
         return info.mergeInfo.delegateToSchema({
           schema: localSchema,
           operation: "query",
-          fieldName: "conversation",
+          fieldName: "_do_not_use_conversation",
           args: { id: impulseConversationId },
           context,
           info,
-          transforms: [],
-          //   // Wrap document takes a subtree as an AST node
-          //   new WrapQuery(
-          //     // path at which to apply wrapping and extracting
-          //     ["conversation"],
-          //     (subtree: SelectionSetNode) => ({
-          //       // we create a wrapping AST Field
-          //       kind: Kind.FIELD,
-          //       name: {
-          //         kind: Kind.NAME,
-          //         value: "conversation",
-          //       },
-          //       arguments: [
-          //         {
-          //           kind: Kind.ARGUMENT,
-          //           name: {
-          //             kind: Kind.NAME,
-          //             value: "id",
-          //           },
-          //           value: {
-          //             kind: Kind.STRING,
-          //             value: impulseConversationId,
-          //           },
-          //         },
-          //       ],
-          //       // Inside the field selection
-          //       selectionSet: subtree,
-          //     }),
-          //     // how to process the data result at path
-          //     (result) => {
-          //       return result.conversation
-          //     }
-          //   ),
-          // ],
         })
       },
     },

--- a/src/lib/stitching/exchange/v2/stitching.ts
+++ b/src/lib/stitching/exchange/v2/stitching.ts
@@ -159,43 +159,44 @@ export const exchangeStitchingEnvironment = ({
         return info.mergeInfo.delegateToSchema({
           schema: localSchema,
           operation: "query",
-          fieldName: "me",
+          fieldName: "conversation",
+          args: { id: impulseConversationId },
           context,
           info,
-          transforms: [
-            // Wrap document takes a subtree as an AST node
-            new WrapQuery(
-              // path at which to apply wrapping and extracting
-              ["me"],
-              (subtree: SelectionSetNode) => ({
-                // we create a wrapping AST Field
-                kind: Kind.FIELD,
-                name: {
-                  kind: Kind.NAME,
-                  value: "conversation",
-                },
-                arguments: [
-                  {
-                    kind: Kind.ARGUMENT,
-                    name: {
-                      kind: Kind.NAME,
-                      value: "id",
-                    },
-                    value: {
-                      kind: Kind.STRING,
-                      value: impulseConversationId,
-                    },
-                  },
-                ],
-                // Inside the field selection
-                selectionSet: subtree,
-              }),
-              // how to process the data result at path
-              (result) => {
-                return result.conversation
-              }
-            ),
-          ],
+          transforms: [],
+          //   // Wrap document takes a subtree as an AST node
+          //   new WrapQuery(
+          //     // path at which to apply wrapping and extracting
+          //     ["conversation"],
+          //     (subtree: SelectionSetNode) => ({
+          //       // we create a wrapping AST Field
+          //       kind: Kind.FIELD,
+          //       name: {
+          //         kind: Kind.NAME,
+          //         value: "conversation",
+          //       },
+          //       arguments: [
+          //         {
+          //           kind: Kind.ARGUMENT,
+          //           name: {
+          //             kind: Kind.NAME,
+          //             value: "id",
+          //           },
+          //           value: {
+          //             kind: Kind.STRING,
+          //             value: impulseConversationId,
+          //           },
+          //         },
+          //       ],
+          //       // Inside the field selection
+          //       selectionSet: subtree,
+          //     }),
+          //     // how to process the data result at path
+          //     (result) => {
+          //       return result.conversation
+          //     }
+          //   ),
+          // ],
         })
       },
     },
@@ -255,6 +256,7 @@ export const exchangeStitchingEnvironment = ({
       creditCard: CreditCard
       isInquiryOrder: Boolean!
       conversation: Conversation
+
       ${orderTotalsSDL.join("\n")}
     }
 

--- a/src/lib/stitching/exchange/v2/stitching.ts
+++ b/src/lib/stitching/exchange/v2/stitching.ts
@@ -146,6 +146,59 @@ export const exchangeStitchingEnvironment = ({
         return Boolean(impulseConversationId)
       },
     },
+    conversation: {
+      fragment: gql`
+        fragment CommerceOrderConversation on CommerceOfferOrder {
+          impulseConversationId
+        }
+      `,
+      resolve: async (order, _args, context, info) => {
+        const { impulseConversationId } = order
+        if (!impulseConversationId) return null
+
+        return info.mergeInfo.delegateToSchema({
+          schema: localSchema,
+          operation: "query",
+          fieldName: "me",
+          context,
+          info,
+          transforms: [
+            // Wrap document takes a subtree as an AST node
+            new WrapQuery(
+              // path at which to apply wrapping and extracting
+              ["me"],
+              (subtree: SelectionSetNode) => ({
+                // we create a wrapping AST Field
+                kind: Kind.FIELD,
+                name: {
+                  kind: Kind.NAME,
+                  value: "conversation",
+                },
+                arguments: [
+                  {
+                    kind: Kind.ARGUMENT,
+                    name: {
+                      kind: Kind.NAME,
+                      value: "id",
+                    },
+                    value: {
+                      kind: Kind.STRING,
+                      value: impulseConversationId,
+                    },
+                  },
+                ],
+                // Inside the field selection
+                selectionSet: subtree,
+              }),
+              // how to process the data result at path
+              (result) => {
+                return result.conversation
+              }
+            ),
+          ],
+        })
+      },
+    },
   }
 
   // Map the totals array to a set of resolvers that call the amount function
@@ -181,7 +234,7 @@ export const exchangeStitchingEnvironment = ({
       sellerDetails: OrderParty
       creditCard: CreditCard
       isInquiryOrder: Boolean!
-
+      conversation: Conversation
       ${orderTotalsSDL.join("\n")}
     }
 
@@ -190,6 +243,7 @@ export const exchangeStitchingEnvironment = ({
       sellerDetails: OrderParty
       creditCard: CreditCard
       isInquiryOrder: Boolean!
+      conversation: Conversation
 
       ${orderTotalsSDL.join("\n")}
       ${amountSDL("offerTotal")}
@@ -200,7 +254,7 @@ export const exchangeStitchingEnvironment = ({
       sellerDetails: OrderParty
       creditCard: CreditCard
       isInquiryOrder: Boolean!
-
+      conversation: Conversation
       ${orderTotalsSDL.join("\n")}
     }
 

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -55,6 +55,7 @@ import { UserField } from "./user"
 // import MatchArtist from "./match/artist"
 // import { SaleArtworksConnectionField } from "./sale_artworks"
 
+import Conversation from "./me/conversation"
 import UpdateConversationMutation from "./me/conversation/update_conversation_mutation"
 import SendConversationMessageMutation from "./me/conversation/send_message_mutation"
 import { submitInquiryRequestMutation } from "./me/conversation/submit_inquiry_request_mutation"
@@ -104,7 +105,6 @@ import { DeleteArtworkImageMutation } from "./deleteArtworkImageMutation"
 import { ArtworkOrEditionSetType } from "schema/v2/artworkOrEditionSet"
 import { AuctionResult } from "./auction_result"
 import ArtworkMediums from "./artworkMediums"
-import Conversation from "./me/conversation"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -127,7 +127,11 @@ const rootFields = {
   city: City,
   cities,
   // collection: Collection,
-  conversation: Conversation,
+  _do_not_use_conversation: {
+    type: Conversation.type,
+    resolve: Conversation.resolve,
+    description: "Do not use (only used internally for stitching)",
+  },
   creditCard: CreditCard,
   // externalPartner: ExternalPartner,
   fair: Fair,

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -104,6 +104,7 @@ import { DeleteArtworkImageMutation } from "./deleteArtworkImageMutation"
 import { ArtworkOrEditionSetType } from "schema/v2/artworkOrEditionSet"
 import { AuctionResult } from "./auction_result"
 import ArtworkMediums from "./artworkMediums"
+import Conversation from "./me/conversation"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -126,6 +127,7 @@ const rootFields = {
   city: City,
   cities,
   // collection: Collection,
+  conversation: Conversation,
   creditCard: CreditCard,
   // externalPartner: ExternalPartner,
   fair: Fair,


### PR DESCRIPTION
This PR follows up on https://github.com/artsy/metaphysics/pull/2990 by stitching in `conversation` under a `CommerceOrder` and delegating it to a new root `conversation` field. The previous PR used `me.conversation` but we realized this field would not work for queries from volt which do not use `me`. Still WIP, but if we like this approach it should also hopefully be easier to test.

[PURCHASE-2375]

cc @artsy/purchase-devs 

[PURCHASE-2375]: https://artsyproduct.atlassian.net/browse/PURCHASE-2375