### PR TITLE
fix: dont use query params for PUT/POST requests

### DIFF
--- a/src/lib/apis/fetch.ts
+++ b/src/lib/apis/fetch.ts
@@ -23,6 +23,11 @@ export default (url, options = {}) => {
     delete opts.userAgent
     opts.headers = assign({}, { "User-Agent": userAgent }, opts.headers)
 
+    if (opts.method === "GET") {
+      delete opts.body
+      delete opts.json
+    }
+
     request(url, opts, (err, response) => {
       if (err) return reject(err)
       // If there is a non-200 status code, reject.

--- a/src/lib/loaders/__tests__/request_id.test.js
+++ b/src/lib/loaders/__tests__/request_id.test.js
@@ -23,9 +23,13 @@ describe("requestID (with the real data loaders)", () => {
 
     await runQuery(query, context)
 
-    expect(gravity).toBeCalledWith("artist/andy-warhol?", null, {
-      requestIDs,
-    })
+    expect(gravity).toBeCalledWith(
+      "artist/andy-warhol?",
+      null,
+      expect.objectContaining({
+        requestIDs,
+      })
+    )
   })
 
   it("(authenticated request) resolves to add the initial request ID to a gravity header", async () => {
@@ -44,9 +48,13 @@ describe("requestID (with the real data loaders)", () => {
     expect.assertions(1)
     await runAuthenticatedQuery(query, context)
 
-    expect(gravity).toBeCalledWith("me/lot_standings?size=100", "secret", {
-      requestIDs,
-    })
+    expect(gravity).toBeCalledWith(
+      "me/lot_standings?size=100",
+      "secret",
+      expect.objectContaining({
+        requestIDs,
+      })
+    )
   })
 })
 

--- a/src/lib/loaders/__tests__/user_agent.test.js
+++ b/src/lib/loaders/__tests__/user_agent.test.js
@@ -23,9 +23,13 @@ describe("User-Agent (with the real data loaders)", () => {
     expect.assertions(1)
     await runQuery(query, context)
 
-    expect(gravity).toBeCalledWith("artist/andy-warhol?", null, {
-      userAgent,
-    })
+    expect(gravity).toBeCalledWith(
+      "artist/andy-warhol?",
+      null,
+      expect.objectContaining({
+        userAgent,
+      })
+    )
   })
 
   it("(authenticated request) resolves to add the initial request ID to a gravity header", async () => {
@@ -44,8 +48,12 @@ describe("User-Agent (with the real data loaders)", () => {
     expect.assertions(1)
     await runAuthenticatedQuery(query, context)
 
-    expect(gravity).toBeCalledWith("me/lot_standings?size=100", "secret", {
-      userAgent,
-    })
+    expect(gravity).toBeCalledWith(
+      "me/lot_standings?size=100",
+      "secret",
+      expect.objectContaining({
+        userAgent,
+      })
+    )
   })
 })

--- a/src/lib/loaders/api/index.ts
+++ b/src/lib/loaders/api/index.ts
@@ -35,6 +35,7 @@ export interface APIOptions {
 export interface DataLoaderKey {
   key: string
   apiOptions?: APIOptions
+  method?: string
 }
 
 export default (opts) => ({

--- a/src/lib/loaders/api/loader_interface.ts
+++ b/src/lib/loaders/api/loader_interface.ts
@@ -19,10 +19,10 @@ export type DynamicPathLoader<T, P = string> = (
 ) => Promise<T>
 
 const encodeStaticPath = (
+  method = "GET",
   path: string,
   globalParams,
-  params,
-  method = "GET"
+  params
 ) => {
   if (method === "GET") {
     return toKey(path, Object.assign({}, globalParams, params))
@@ -32,13 +32,13 @@ const encodeStaticPath = (
 }
 
 const encodeDynamicPath = (
+  method = "GET",
   pathGenerator: (id: string) => string,
   globalParams,
   id,
-  params,
-  method
+  params
 ) => {
-  return encodeStaticPath(pathGenerator(id), globalParams, params, method)
+  return encodeStaticPath(method, pathGenerator(id), globalParams, params)
 }
 
 /**
@@ -60,29 +60,29 @@ const encodeDynamicPath = (
  */
 
 export function loaderInterface<T>(
+  method: string,
   loader: DataLoader<DataLoaderKey, T>,
   pathOrGenerator: string,
-  globalParams: any,
-  method?: string
+  globalParams: any
 ): StaticPathLoader<T>
 
 export function loaderInterface<T, P>(
+  method: string,
   loader: DataLoader<DataLoaderKey, T>,
   pathOrGenerator: PathGenerator<P>,
-  globalParams: any,
-  method?: string
+  globalParams: any
 ): DynamicPathLoader<T>
 
 export function loaderInterface<T, P>(
+  method = "GET",
   loader: DataLoader<DataLoaderKey, T>,
   pathOrGenerator: string | PathGenerator<P>,
-  globalParams: any,
-  method?: string
+  globalParams: any
 ) {
   const dynamicPath = typeof pathOrGenerator === "function"
   const keyGenerator: any = dynamicPath ? encodeDynamicPath : encodeStaticPath
   return (...args) => {
-    const key = keyGenerator(pathOrGenerator, globalParams, ...args, method)
+    const key = keyGenerator(method, pathOrGenerator, globalParams, ...args)
     const apiOptions = dynamicPath ? args[2] : args[1]
 
     // These options are passed to `fetch.ts`, and the keys:

--- a/src/lib/loaders/api/loader_interface.ts
+++ b/src/lib/loaders/api/loader_interface.ts
@@ -18,17 +18,27 @@ export type DynamicPathLoader<T, P = string> = (
   apiOptions?: APIOptions
 ) => Promise<T>
 
-const encodeStaticPath = (path: string, globalParams, params) => {
-  return toKey(path, Object.assign({}, globalParams, params))
+const encodeStaticPath = (
+  path: string,
+  globalParams,
+  params,
+  method = "GET"
+) => {
+  if (method === "GET") {
+    return toKey(path, Object.assign({}, globalParams, params))
+  } else {
+    return path
+  }
 }
 
 const encodeDynamicPath = (
   pathGenerator: (id: string) => string,
   globalParams,
   id,
-  params
+  params,
+  method
 ) => {
-  return encodeStaticPath(pathGenerator(id), globalParams, params)
+  return encodeStaticPath(pathGenerator(id), globalParams, params, method)
 }
 
 /**
@@ -52,25 +62,36 @@ const encodeDynamicPath = (
 export function loaderInterface<T>(
   loader: DataLoader<DataLoaderKey, T>,
   pathOrGenerator: string,
-  globalParams: any
+  globalParams: any,
+  method?: string
 ): StaticPathLoader<T>
 
 export function loaderInterface<T, P>(
   loader: DataLoader<DataLoaderKey, T>,
   pathOrGenerator: PathGenerator<P>,
-  globalParams: any
+  globalParams: any,
+  method?: string
 ): DynamicPathLoader<T>
 
 export function loaderInterface<T, P>(
   loader: DataLoader<DataLoaderKey, T>,
   pathOrGenerator: string | PathGenerator<P>,
-  globalParams: any
+  globalParams: any,
+  method?: string
 ) {
   const dynamicPath = typeof pathOrGenerator === "function"
   const keyGenerator: any = dynamicPath ? encodeDynamicPath : encodeStaticPath
   return (...args) => {
-    const key = keyGenerator(pathOrGenerator, globalParams, ...args)
+    const key = keyGenerator(pathOrGenerator, globalParams, ...args, method)
     const apiOptions = dynamicPath ? args[2] : args[1]
-    return loader.load({ key, apiOptions })
+
+    // These options are passed to `fetch.ts`, and the keys:
+    // `body`, `json` correspond to options to the underlying `request` library.
+    const fetchOptions = { method, body: args[0], json: true }
+
+    return loader.load({
+      key,
+      apiOptions: Object.assign({}, fetchOptions, apiOptions),
+    })
   }
 }

--- a/src/lib/loaders/api/loader_with_authentication_factory.ts
+++ b/src/lib/loaders/api/loader_with_authentication_factory.ts
@@ -27,7 +27,11 @@ export const apiLoaderWithAuthenticationFactory = <T = any>(
   globalAPIOptions: any
 ) => {
   return (accessTokenLoader) => {
-    const apiLoaderFactory = (path, globalParams = {}, pathAPIOptions = {}) => {
+    const apiLoaderFactory = (
+      path,
+      globalParams = {},
+      pathAPIOptions: { method?: string } = {}
+    ) => {
       const loader = new DataLoader<
         DataLoaderKey,
         T | { body: T; headers: any }
@@ -80,7 +84,7 @@ export const apiLoaderWithAuthenticationFactory = <T = any>(
           cacheKeyFn: (input) => JSON.stringify(input),
         }
       )
-      return loaderInterface(loader, path, globalParams)
+      return loaderInterface(loader, path, globalParams, pathAPIOptions.method)
     }
     return apiLoaderFactory as LoaderFactory
   }

--- a/src/lib/loaders/api/loader_with_authentication_factory.ts
+++ b/src/lib/loaders/api/loader_with_authentication_factory.ts
@@ -30,7 +30,7 @@ export const apiLoaderWithAuthenticationFactory = <T = any>(
     const apiLoaderFactory = (
       path,
       globalParams = {},
-      pathAPIOptions: { method?: string } = {}
+      pathAPIOptions: { method: string } = { method: "GET" }
     ) => {
       const loader = new DataLoader<
         DataLoaderKey,
@@ -84,7 +84,7 @@ export const apiLoaderWithAuthenticationFactory = <T = any>(
           cacheKeyFn: (input) => JSON.stringify(input),
         }
       )
-      return loaderInterface(loader, path, globalParams, pathAPIOptions.method)
+      return loaderInterface(pathAPIOptions.method, loader, path, globalParams)
     }
     return apiLoaderFactory as LoaderFactory
   }

--- a/src/lib/loaders/api/loader_without_authentication_factory.ts
+++ b/src/lib/loaders/api/loader_without_authentication_factory.ts
@@ -40,7 +40,11 @@ export const apiLoaderWithoutAuthenticationFactory = <T = any>(
   apiName: string,
   globalAPIOptions: APIOptions = {}
 ) => {
-  const apiLoaderFactory = (path, globalParams = {}, pathAPIOptions = {}) => {
+  const apiLoaderFactory = (
+    path,
+    globalParams = {},
+    pathAPIOptions: { method?: string } = {}
+  ) => {
     const loader = new DataLoader<DataLoaderKey, T | { body: T; headers: any }>(
       (keys) =>
         Promise.all<any>(
@@ -160,7 +164,7 @@ export const apiLoaderWithoutAuthenticationFactory = <T = any>(
         cacheKeyFn: (input) => JSON.stringify(input),
       }
     )
-    return loaderInterface(loader, path, globalParams)
+    return loaderInterface(loader, path, globalParams, pathAPIOptions.method)
   }
   return apiLoaderFactory as LoaderFactory
 }

--- a/src/lib/loaders/api/loader_without_authentication_factory.ts
+++ b/src/lib/loaders/api/loader_without_authentication_factory.ts
@@ -43,7 +43,7 @@ export const apiLoaderWithoutAuthenticationFactory = <T = any>(
   const apiLoaderFactory = (
     path,
     globalParams = {},
-    pathAPIOptions: { method?: string } = {}
+    pathAPIOptions = { method: "GET" }
   ) => {
     const loader = new DataLoader<DataLoaderKey, T | { body: T; headers: any }>(
       (keys) =>
@@ -164,7 +164,7 @@ export const apiLoaderWithoutAuthenticationFactory = <T = any>(
         cacheKeyFn: (input) => JSON.stringify(input),
       }
     )
-    return loaderInterface(loader, path, globalParams, pathAPIOptions.method)
+    return loaderInterface(pathAPIOptions.method, loader, path, globalParams)
   }
   return apiLoaderFactory as LoaderFactory
 }

--- a/src/lib/loaders/api/loader_without_cache_factory.ts
+++ b/src/lib/loaders/api/loader_without_cache_factory.ts
@@ -30,7 +30,7 @@ export const uncachedLoaderFactory = (
         ),
       { cache: false, batch: false }
     )
-    return loaderInterface(loader, path, options)
+    return loaderInterface(options?.method, loader, path, options)
   }
   return apiLoaderFactory as LoaderFactory
 }


### PR DESCRIPTION
This re-reverts, but with a change (https://github.com/artsy/metaphysics/commit/d9536d23e47e8cb05ce540a1bea613cf75a53eab), that threads arguments through properly.