### PR TITLE
Revert "fix: dont use query params for PUT/POST requests"

### DIFF
--- a/src/lib/apis/fetch.ts
+++ b/src/lib/apis/fetch.ts
@@ -23,11 +23,6 @@ export default (url, options = {}) => {
     delete opts.userAgent
     opts.headers = assign({}, { "User-Agent": userAgent }, opts.headers)
 
-    if (opts.method === "GET") {
-      delete opts.body
-      delete opts.json
-    }
-
     request(url, opts, (err, response) => {
       if (err) return reject(err)
       // If there is a non-200 status code, reject.

--- a/src/lib/loaders/__tests__/request_id.test.js
+++ b/src/lib/loaders/__tests__/request_id.test.js
@@ -23,13 +23,9 @@ describe("requestID (with the real data loaders)", () => {
 
     await runQuery(query, context)
 
-    expect(gravity).toBeCalledWith(
-      "artist/andy-warhol?",
-      null,
-      expect.objectContaining({
-        requestIDs,
-      })
-    )
+    expect(gravity).toBeCalledWith("artist/andy-warhol?", null, {
+      requestIDs,
+    })
   })
 
   it("(authenticated request) resolves to add the initial request ID to a gravity header", async () => {
@@ -48,13 +44,9 @@ describe("requestID (with the real data loaders)", () => {
     expect.assertions(1)
     await runAuthenticatedQuery(query, context)
 
-    expect(gravity).toBeCalledWith(
-      "me/lot_standings?size=100",
-      "secret",
-      expect.objectContaining({
-        requestIDs,
-      })
-    )
+    expect(gravity).toBeCalledWith("me/lot_standings?size=100", "secret", {
+      requestIDs,
+    })
   })
 })
 

--- a/src/lib/loaders/__tests__/user_agent.test.js
+++ b/src/lib/loaders/__tests__/user_agent.test.js
@@ -23,13 +23,9 @@ describe("User-Agent (with the real data loaders)", () => {
     expect.assertions(1)
     await runQuery(query, context)
 
-    expect(gravity).toBeCalledWith(
-      "artist/andy-warhol?",
-      null,
-      expect.objectContaining({
-        userAgent,
-      })
-    )
+    expect(gravity).toBeCalledWith("artist/andy-warhol?", null, {
+      userAgent,
+    })
   })
 
   it("(authenticated request) resolves to add the initial request ID to a gravity header", async () => {
@@ -48,12 +44,8 @@ describe("User-Agent (with the real data loaders)", () => {
     expect.assertions(1)
     await runAuthenticatedQuery(query, context)
 
-    expect(gravity).toBeCalledWith(
-      "me/lot_standings?size=100",
-      "secret",
-      expect.objectContaining({
-        userAgent,
-      })
-    )
+    expect(gravity).toBeCalledWith("me/lot_standings?size=100", "secret", {
+      userAgent,
+    })
   })
 })

--- a/src/lib/loaders/api/index.ts
+++ b/src/lib/loaders/api/index.ts
@@ -35,7 +35,6 @@ export interface APIOptions {
 export interface DataLoaderKey {
   key: string
   apiOptions?: APIOptions
-  method?: string
 }
 
 export default (opts) => ({

--- a/src/lib/loaders/api/loader_with_authentication_factory.ts
+++ b/src/lib/loaders/api/loader_with_authentication_factory.ts
@@ -27,11 +27,7 @@ export const apiLoaderWithAuthenticationFactory = <T = any>(
   globalAPIOptions: any
 ) => {
   return (accessTokenLoader) => {
-    const apiLoaderFactory = (
-      path,
-      globalParams = {},
-      pathAPIOptions: { method: string } = { method: "GET" }
-    ) => {
+    const apiLoaderFactory = (path, globalParams = {}, pathAPIOptions = {}) => {
       const loader = new DataLoader<
         DataLoaderKey,
         T | { body: T; headers: any }
@@ -84,7 +80,7 @@ export const apiLoaderWithAuthenticationFactory = <T = any>(
           cacheKeyFn: (input) => JSON.stringify(input),
         }
       )
-      return loaderInterface(pathAPIOptions.method, loader, path, globalParams)
+      return loaderInterface(loader, path, globalParams)
     }
     return apiLoaderFactory as LoaderFactory
   }

--- a/src/lib/loaders/api/loader_without_authentication_factory.ts
+++ b/src/lib/loaders/api/loader_without_authentication_factory.ts
@@ -40,11 +40,7 @@ export const apiLoaderWithoutAuthenticationFactory = <T = any>(
   apiName: string,
   globalAPIOptions: APIOptions = {}
 ) => {
-  const apiLoaderFactory = (
-    path,
-    globalParams = {},
-    pathAPIOptions = { method: "GET" }
-  ) => {
+  const apiLoaderFactory = (path, globalParams = {}, pathAPIOptions = {}) => {
     const loader = new DataLoader<DataLoaderKey, T | { body: T; headers: any }>(
       (keys) =>
         Promise.all<any>(
@@ -164,7 +160,7 @@ export const apiLoaderWithoutAuthenticationFactory = <T = any>(
         cacheKeyFn: (input) => JSON.stringify(input),
       }
     )
-    return loaderInterface(pathAPIOptions.method, loader, path, globalParams)
+    return loaderInterface(loader, path, globalParams)
   }
   return apiLoaderFactory as LoaderFactory
 }

--- a/src/lib/loaders/api/loader_without_cache_factory.ts
+++ b/src/lib/loaders/api/loader_without_cache_factory.ts
@@ -30,7 +30,7 @@ export const uncachedLoaderFactory = (
         ),
       { cache: false, batch: false }
     )
-    return loaderInterface(options?.method, loader, path, options)
+    return loaderInterface(loader, path, options)
   }
   return apiLoaderFactory as LoaderFactory
 }


### PR DESCRIPTION
Reverts artsy/metaphysics#3001

See if this solves the new Integrity failures discussed in https://artsy.slack.com/archives/C9YNS4X32/p1613569288257200.