### PR TITLE
fix: return null for display and estimate for unsupported currencies

### DIFF
--- a/src/schema/v2/auction_result.ts
+++ b/src/schema/v2/auction_result.ts
@@ -18,6 +18,7 @@ import { ResolverContext } from "types/graphql"
 // Taken from https://github.com/RubyMoney/money/blob/master/config/currency_iso.json
 import currencyCodes from "lib/currency_codes.json"
 import { YearRange } from "./types/yearRange"
+import * as Sentry from "@sentry/node"
 const symbolOnly = ["USD", "GBP", "EUR", "MYR"]
 
 export const AuctionResultSorts = {
@@ -193,15 +194,13 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
               if (!low_estimate_cents && !high_estimate_cents) {
                 return null
               }
+
               const currency_map = currencyCodes[currency.toLowerCase()]
-              let symbol
-              let subunit_to_unit
-              if (currency_map) {
-                symbol = currency_map.symbol
-                subunit_to_unit = currency_map.subunit_to_unit
-              } else {
+              if (!currency_map) {
+                Sentry.captureException(`currency not supported ${currency}}`)
                 return null
               }
+              const { symbol, subunit_to_unit } = currency_map
 
               let display
               let amount
@@ -258,20 +257,15 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
               }
 
               const currency_map = currencyCodes[currency.toLowerCase()]
-              let symbol
-              let subunit_to_unit
-              if (currency_map) {
-                symbol = currency_map.symbol
-                subunit_to_unit = currency_map.subunit_to_unit
-              } else {
+              if (!currency_map) {
+                Sentry.captureException(`currency not supported ${currency}}`)
                 return null
               }
+              const { symbol, subunit_to_unit } = currency_map
 
               let display
               if (indexOf(symbolOnly, currency) === -1) {
                 display = currency
-              } else {
-                return null
               }
 
               if (symbol) {

--- a/src/schema/v2/auction_result.ts
+++ b/src/schema/v2/auction_result.ts
@@ -193,9 +193,16 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
               if (!low_estimate_cents && !high_estimate_cents) {
                 return null
               }
-              const { symbol, subunit_to_unit } = currencyCodes[
-                currency.toLowerCase()
-              ]
+              const currency_map = currencyCodes[currency.toLowerCase()]
+              let symbol
+              let subunit_to_unit
+              if (currency_map) {
+                symbol = currency_map.symbol
+                subunit_to_unit = currency_map.subunit_to_unit
+              } else {
+                return null
+              }
+
               let display
               let amount
               if (indexOf(symbolOnly, currency) === -1) {
@@ -250,13 +257,21 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
                 return null
               }
 
-              const { symbol, subunit_to_unit } = currencyCodes[
-                currency.toLowerCase()
-              ]
-              let display
+              const currency_map = currencyCodes[currency.toLowerCase()]
+              let symbol
+              let subunit_to_unit
+              if (currency_map) {
+                symbol = currency_map.symbol
+                subunit_to_unit = currency_map.subunit_to_unit
+              } else {
+                return null
+              }
 
+              let display
               if (indexOf(symbolOnly, currency) === -1) {
                 display = currency
+              } else {
+                return null
               }
 
               if (symbol) {


### PR DESCRIPTION
Resolves: https://artsyproduct.atlassian.net/browse/CX-1113

An error is currently being thrown when lots with unsupported currencies are returned from the `auctionResultsConnection`. Eigen is treating these errors as fatal right now and since adding the auctionResults to the artist page in Eigen this is causing the Artist page not to load for artists with the problematic lots. This instead returns null for the displayPrice and estimate of auction lots with unsupported currencies and does not throw an error.

# Follow-ups

- Eigen probably should not show the retry page in this case since the query is returning the rest of the data
- Find currencies that we are not currently supporting in our lot data and add them to metaphysics
- Add a test case for this 
