### PR TITLE
feat: Add missing_priority_metadata to partner type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8133,7 +8133,7 @@ type Partner implements Node {
     imageCountLessThan: Int
     last: Int
 
-    # Returns artworks with less than 2 images and/or missing visible price info
+    # Return artworks that are missing priority metadata
     missingPriorityMetadata: Boolean
 
     # Return artworks published less than x seconds ago.

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8133,6 +8133,9 @@ type Partner implements Node {
     imageCountLessThan: Int
     last: Int
 
+    # Returns artworks with less than 2 images and/or missing visible price info
+    missingPriorityMetadata: Boolean
+
     # Return artworks published less than x seconds ago.
     publishedWithin: Int
     sort: ArtworkSorts

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -47,6 +47,11 @@ const artworksArgs: GraphQLFieldConfigArgumentMap = {
     type: GraphQLInt,
     description: "Return artworks with less than x additional_images.",
   },
+  missingPriorityMetadata: {
+    type: GraphQLBoolean,
+    description:
+      "Returns artworks with less than 2 images and/or missing visible price info",
+  },
   publishedWithin: {
     type: GraphQLInt,
     description: "Return artworks published less than x seconds ago.",
@@ -124,6 +129,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             exclude_ids?: string[]
             for_sale: boolean
             image_count_less_than?: number
+            missing_priority_metadata?: boolean
             page: number
             published: boolean
             published_within?: number
@@ -135,6 +141,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           const gravityArgs: GravityArgs = {
             for_sale: args.forSale,
             image_count_less_than: args.imageCountLessThan,
+            missing_priority_metadata: args.missingPriorityMetadata,
             page,
             published: true,
             published_within: args.publishedWithin,

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -49,8 +49,7 @@ const artworksArgs: GraphQLFieldConfigArgumentMap = {
   },
   missingPriorityMetadata: {
     type: GraphQLBoolean,
-    description:
-      "Returns artworks with less than 2 images and/or missing visible price info",
+    description: "Return artworks that are missing priority metadata",
   },
   publishedWithin: {
     type: GraphQLInt,


### PR DESCRIPTION
Added `missing_priority_metadata` from gravity as a param for `artworksConnection` on `partner`.

Query works as shown below:
```graphql
query missingMetadata {
  partner(id: "david-zwirner") {
    name
     artworksConnection(first: 5 missingPriorityMetadata: true){
        edges {
          node {
            title
            listPrice {
              __typename
            }
            isPriceHidden
            artist {
              name
            }
            images {
              imageURL
            }
        }
      }
    }
  }
}
```
<img width="661" alt="Screen Shot 2021-02-24 at 11 30 51 AM" src="https://user-images.githubusercontent.com/9466631/109048042-cefeb080-7693-11eb-82a8-afa67b3c9e7a.png">

[Jira ticket](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=36&projectKey=PX&modal=detail&selectedIssue=PX-3755)