### PR TITLE
feat: Support setting timestamp on user for onboarding complete GRO-125

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10974,6 +10974,9 @@ input UpdateMyProfileInput {
   # The collector level for the user
   collectorLevel: Int
 
+  # The user completed onboarding.
+  completedOnboarding: Boolean
+
   # The given email of the user.
   email: String
 

--- a/src/schema/v2/me/update_me_mutation.ts
+++ b/src/schema/v2/me/update_me_mutation.ts
@@ -138,6 +138,10 @@ export default mutationWithClientMutationId<any, any, ResolverContext>({
       description: "The given location of the user as structured data",
       type: EditableLocationFields,
     },
+    completedOnboarding: {
+      description: "The user completed onboarding.",
+      type: GraphQLBoolean,
+    },
     collectorLevel: {
       description: "The collector level for the user",
       type: GraphQLInt,
@@ -211,6 +215,7 @@ export default mutationWithClientMutationId<any, any, ResolverContext>({
   mutateAndGetPayload: (
     {
       collectorLevel,
+      completedOnboarding,
       emailFrequency,
       priceRangeMin,
       priceRangeMax,
@@ -227,6 +232,7 @@ export default mutationWithClientMutationId<any, any, ResolverContext>({
   ) => {
     const user: any = {
       collector_level: collectorLevel,
+      completed_onboarding: completedOnboarding,
       email_frequency: emailFrequency,
       price_range_min: priceRangeMin,
       price_range_max: priceRangeMax,


### PR DESCRIPTION
Note: this PR depends on this one: https://github.com/artsy/gravity/pull/13858 so I'm starting this as a draft.

The PR adds support to MP for setting a timestamp on a user for when they have completed onboarding. I'll follow up with a PR in force that sends this over.

https://artsyproduct.atlassian.net/browse/GRO-125

/cc @artsy/grow-devs