### PR TITLE
[PX-3747] Add data loader for PartnerArtworksAll + add custom handling for additional artwork data

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8140,7 +8140,7 @@ type Partner implements Node {
     imageCountLessThan: Int
     last: Int
 
-    # Returns artworks with less than 2 images and/or missing visible price info
+    # Return artworks that are missing priority metadata
     missingPriorityMetadata: Boolean
 
     # Return artworks published less than x seconds ago.

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8145,6 +8145,10 @@ type Partner implements Node {
 
     # Return artworks published less than x seconds ago.
     publishedWithin: Int
+
+    # Only allowed for authorized admin/partner requests. When false fetch :all
+    # properties on an artwork, when true or not present fetch artwork :short properties
+    shallow: Boolean
     sort: ArtworkSorts
   ): ArtworkConnection
   cached: Int

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8140,6 +8140,9 @@ type Partner implements Node {
     imageCountLessThan: Int
     last: Int
 
+    # Returns artworks with less than 2 images and/or missing visible price info
+    missingPriorityMetadata: Boolean
+
     # Return artworks published less than x seconds ago.
     publishedWithin: Int
     sort: ArtworkSorts

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -220,6 +220,11 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    partnerArtworksAllLoader: gravityLoader(
+      (id) => `partner/${id}/artworks/all`,
+      {},
+      { headers: true }
+    ),
     popularArtistsLoader: gravityLoader("artists/popular"),
     recordArtworkViewLoader: gravityLoader(
       "me/recently_viewed_artworks",

--- a/src/schema/v2/__tests__/partner.test.js
+++ b/src/schema/v2/__tests__/partner.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable promise/always-return */
-import { runQuery } from "schema/v2/test/utils"
+import { runQuery, runAuthenticatedQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
 
 describe("Partner type", () => {
@@ -204,6 +204,27 @@ describe("Partner type", () => {
 
   describe("#artworksConnection", () => {
     let artworksResponse
+    const partnerArtworksLoader = jest.fn(() => {
+      return Promise.resolve({
+        body: artworksResponse,
+        headers: {
+          "x-total-count": artworksResponse.length,
+        },
+      })
+    })
+
+    const partnerArtworksAllLoader = jest.fn(() => {
+      return Promise.resolve({
+        body: artworksResponse,
+        headers: {
+          "x-total-count": artworksResponse.length,
+        },
+      })
+    })
+
+    const partnerLoader = jest.fn(() => {
+      return Promise.resolve(partnerData)
+    })
 
     beforeEach(() => {
       artworksResponse = [
@@ -218,108 +239,236 @@ describe("Partner type", () => {
         },
       ]
       context = {
-        partnerArtworksLoader: () =>
-          Promise.resolve({
-            body: artworksResponse,
-            headers: {
-              "x-total-count": artworksResponse.length,
-            },
-          }),
-        partnerLoader: () => Promise.resolve(partnerData),
+        partnerArtworksAllLoader,
+        partnerArtworksLoader,
+        partnerLoader,
       }
     })
 
-    it("returns artworks", async () => {
-      const query = `
-        {
-          partner(id:"bau-xi-gallery") {
-            artworksConnection(first:3) {
-              edges {
-                node {
-                  slug
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    describe("when query is authenticated", () => {
+      describe("when shallow is false", () => {
+        it("calls partnerArtworksAllLoader", async () => {
+          const query = gql`
+            {
+              partner(id: "bau-xi-gallery") {
+                artworksConnection(first: 3, shallow: false) {
+                  edges {
+                    node {
+                      slug
+                    }
+                  }
+                }
+              }
+            }
+          `
+          await runAuthenticatedQuery(query, context)
+          expect(partnerArtworksAllLoader).toHaveBeenCalled()
+        })
+      })
+      describe("when shallow is true", () => {
+        it("does not call partnerArtworksAllLoader", async () => {
+          const query = gql`
+            {
+              partner(id: "bau-xi-gallery") {
+                artworksConnection(first: 3, shallow: true) {
+                  edges {
+                    node {
+                      slug
+                    }
+                  }
+                }
+              }
+            }
+          `
+          await runAuthenticatedQuery(query, context)
+          expect(partnerArtworksAllLoader).not.toHaveBeenCalled()
+        })
+      })
+    })
+
+    describe("when query is not authenticated", () => {
+      it("returns artworks", async () => {
+        const query = gql`
+          {
+            partner(id: "bau-xi-gallery") {
+              artworksConnection(first: 3) {
+                edges {
+                  node {
+                    slug
+                  }
                 }
               }
             }
           }
-        }
-      `
+        `
 
-      const data = await runQuery(query, context)
+        const data = await runQuery(query, context)
 
-      expect(data).toEqual({
-        partner: {
-          artworksConnection: {
-            edges: [
-              {
-                node: {
-                  slug: "cara-barer-iceberg",
+        expect(data).toEqual({
+          partner: {
+            artworksConnection: {
+              edges: [
+                {
+                  node: {
+                    slug: "cara-barer-iceberg",
+                  },
                 },
-              },
-              {
-                node: {
-                  slug: "david-leventi-rezzonico",
+                {
+                  node: {
+                    slug: "david-leventi-rezzonico",
+                  },
                 },
-              },
-              {
-                node: {
-                  slug: "virginia-mak-hidden-nature-08",
+                {
+                  node: {
+                    slug: "virginia-mak-hidden-nature-08",
+                  },
                 },
-              },
-            ],
+              ],
+            },
           },
-        },
+        })
       })
-    })
 
-    it("returns hasNextPage=true when first is below total", async () => {
-      const query = `
-        {
-          partner(id:"bau-xi-gallery") {
-            artworksConnection(first:1) {
-              pageInfo {
-                hasNextPage
+      it("returns hasNextPage=true when first is below total", async () => {
+        const query = gql`
+          {
+            partner(id: "bau-xi-gallery") {
+              artworksConnection(first: 1) {
+                pageInfo {
+                  hasNextPage
+                }
               }
             }
           }
-        }
-      `
+        `
 
-      const data = await runQuery(query, context)
+        const data = await runQuery(query, context)
 
-      expect(data).toEqual({
-        partner: {
-          artworksConnection: {
-            pageInfo: {
-              hasNextPage: true,
+        expect(data).toEqual({
+          partner: {
+            artworksConnection: {
+              pageInfo: {
+                hasNextPage: true,
+              },
             },
           },
-        },
+        })
       })
-    })
 
-    it("returns hasNextPage=false when first is above total", async () => {
-      const query = `
-        {
-          partner(id:"bau-xi-gallery") {
-            artworksConnection(first:3) {
-              pageInfo {
-                hasNextPage
+      it("returns hasNextPage=false when first is above total", async () => {
+        const query = gql`
+          {
+            partner(id: "bau-xi-gallery") {
+              artworksConnection(first: 3) {
+                pageInfo {
+                  hasNextPage
+                }
               }
             }
           }
-        }
-      `
+        `
 
-      const data = await runQuery(query, context)
+        const data = await runQuery(query, context)
 
-      expect(data).toEqual({
-        partner: {
-          artworksConnection: {
-            pageInfo: {
-              hasNextPage: false,
+        expect(data).toEqual({
+          partner: {
+            artworksConnection: {
+              pageInfo: {
+                hasNextPage: false,
+              },
             },
           },
-        },
+        })
+      })
+
+      describe("when shallow is false", () => {
+        it("does not return deep artwork data", async () => {
+          const query = gql`
+            {
+              partner(id: "bau-xi-gallery") {
+                artworksConnection(first: 3, shallow: false) {
+                  edges {
+                    node {
+                      slug
+                    }
+                  }
+                }
+              }
+            }
+          `
+          const data = await runQuery(query, context)
+
+          expect(data).toEqual({
+            partner: {
+              artworksConnection: {
+                edges: [
+                  {
+                    node: {
+                      slug: "cara-barer-iceberg",
+                    },
+                  },
+                  {
+                    node: {
+                      slug: "david-leventi-rezzonico",
+                    },
+                  },
+                  {
+                    node: {
+                      slug: "virginia-mak-hidden-nature-08",
+                    },
+                  },
+                ],
+              },
+            },
+          })
+        })
+      })
+      describe("when shallow is true", () => {
+        it("does not return deep artwork data", async () => {
+          const query = gql`
+            {
+              partner(id: "bau-xi-gallery") {
+                artworksConnection(first: 3, shallow: true) {
+                  edges {
+                    node {
+                      slug
+                    }
+                  }
+                }
+              }
+            }
+          `
+
+          const data = await runQuery(query, context)
+
+          expect(data).toEqual({
+            partner: {
+              artworksConnection: {
+                edges: [
+                  {
+                    node: {
+                      slug: "cara-barer-iceberg",
+                    },
+                  },
+                  {
+                    node: {
+                      slug: "david-leventi-rezzonico",
+                    },
+                  },
+                  {
+                    node: {
+                      slug: "virginia-mak-hidden-nature-08",
+                    },
+                  },
+                ],
+              },
+            },
+          })
+        })
       })
     })
   })

--- a/src/schema/v2/__tests__/partner.test.js
+++ b/src/schema/v2/__tests__/partner.test.js
@@ -238,11 +238,6 @@ describe("Partner type", () => {
           id: "virginia-mak-hidden-nature-08",
         },
       ]
-      context = {
-        partnerArtworksAllLoader,
-        partnerArtworksLoader,
-        partnerLoader,
-      }
     })
 
     afterEach(() => {
@@ -250,6 +245,13 @@ describe("Partner type", () => {
     })
 
     describe("when query is authenticated", () => {
+      beforeEach(() => {
+        context = {
+          partnerArtworksAllLoader,
+          partnerArtworksLoader,
+          partnerLoader,
+        }
+      })
       describe("when shallow is false", () => {
         it("calls partnerArtworksAllLoader", async () => {
           const query = gql`
@@ -291,6 +293,9 @@ describe("Partner type", () => {
     })
 
     describe("when query is not authenticated", () => {
+      beforeEach(() => {
+        context = { partnerLoader, partnerArtworksLoader }
+      })
       it("returns artworks", async () => {
         const query = gql`
           {
@@ -386,7 +391,7 @@ describe("Partner type", () => {
       })
 
       describe("when shallow is false", () => {
-        it("does not return deep artwork data", async () => {
+        it("does not call partnerArtworksAllLoader", async () => {
           const query = gql`
             {
               partner(id: "bau-xi-gallery") {
@@ -400,35 +405,13 @@ describe("Partner type", () => {
               }
             }
           `
-          const data = await runQuery(query, context)
+          await runQuery(query, context)
 
-          expect(data).toEqual({
-            partner: {
-              artworksConnection: {
-                edges: [
-                  {
-                    node: {
-                      slug: "cara-barer-iceberg",
-                    },
-                  },
-                  {
-                    node: {
-                      slug: "david-leventi-rezzonico",
-                    },
-                  },
-                  {
-                    node: {
-                      slug: "virginia-mak-hidden-nature-08",
-                    },
-                  },
-                ],
-              },
-            },
-          })
+          expect(partnerArtworksAllLoader).not.toHaveBeenCalled()
         })
       })
       describe("when shallow is true", () => {
-        it("does not return deep artwork data", async () => {
+        it("does not call partnerArtworksAllLoader", async () => {
           const query = gql`
             {
               partner(id: "bau-xi-gallery") {
@@ -443,31 +426,9 @@ describe("Partner type", () => {
             }
           `
 
-          const data = await runQuery(query, context)
+          await runQuery(query, context)
 
-          expect(data).toEqual({
-            partner: {
-              artworksConnection: {
-                edges: [
-                  {
-                    node: {
-                      slug: "cara-barer-iceberg",
-                    },
-                  },
-                  {
-                    node: {
-                      slug: "david-leventi-rezzonico",
-                    },
-                  },
-                  {
-                    node: {
-                      slug: "virginia-mak-hidden-nature-08",
-                    },
-                  },
-                ],
-              },
-            },
-          })
+          expect(partnerArtworksAllLoader).not.toHaveBeenCalled()
         })
       })
     })

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -47,6 +47,11 @@ const artworksArgs: GraphQLFieldConfigArgumentMap = {
     type: GraphQLInt,
     description: "Return artworks with less than x additional_images.",
   },
+  missingPriorityMetadata: {
+    type: GraphQLBoolean,
+    description:
+      "Returns artworks with less than 2 images and/or missing visible price info",
+  },
   publishedWithin: {
     type: GraphQLInt,
     description: "Return artworks published less than x seconds ago.",
@@ -124,6 +129,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             exclude_ids?: string[]
             for_sale: boolean
             image_count_less_than?: number
+            missing_priority_metadata?: boolean
             page: number
             published: boolean
             published_within?: number
@@ -135,6 +141,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           const gravityArgs: GravityArgs = {
             for_sale: args.forSale,
             image_count_less_than: args.imageCountLessThan,
+            missing_priority_metadata: args.missingPriorityMetadata,
             page,
             published: true,
             published_within: args.publishedWithin,

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -49,8 +49,7 @@ const artworksArgs: GraphQLFieldConfigArgumentMap = {
   },
   missingPriorityMetadata: {
     type: GraphQLBoolean,
-    description:
-      "Returns artworks with less than 2 images and/or missing visible price info",
+    description: "Return artworks that are missing priority metadata",
   },
   publishedWithin: {
     type: GraphQLInt,


### PR DESCRIPTION
Have partner artworks connection accept new `shallow` argument to fetch additional artwork information.


If `shallow: false` make an additional request to the `partnerArtworksAllLoader` to fetch more data on the artwork (note the `isPriceHidden: false`)

<img width="800" alt="Screen Shot 2021-02-26 at 12 01 15 PM" src="https://user-images.githubusercontent.com/12748344/109335848-99db9500-7830-11eb-942e-df2c89027efe.png">


If `shallow:true` or not present in the parameters, fall back on default `partnerArtworksLoader` behavior (note the `isPriceHidden: null`)
<img width="800" alt="Screen Shot 2021-02-26 at 12 01 25 PM" src="https://user-images.githubusercontent.com/12748344/109335945-b8da2700-7830-11eb-9648-a5548a7cc4e6.png">

Also encaptulates @annacarey's new work to support a new MP filter: https://github.com/artsy/metaphysics/pull/3020

Mobbing with @sweir27 @annacarey  @mdole @oxaudo 