### PR TITLE
refactor: Simplify Causality Lot stitching 

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -11888,6 +11888,9 @@ type Query {
     id: String!
   ): ArtworkVersion
 
+  # Returns a lot with specific `id`.
+  auctionsLot(id: ID!): AuctionsLotState
+
   # Creates, and authorizes, a JWT custom for Causality
   causality_jwt(
     role: Role

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6944,18 +6944,16 @@ type LocationEdge {
 
 scalar Long
 
-# A lot in an auction containing merged Sale artwork and Lot state data.
+# A lot in an auction containing merged SaleArtwork and LotState data, stitched from causality.
 type Lot implements Node {
   # A globally unique ID.
   id: ID!
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
+  lot: AuctionsLotState
 
-  # The current auction state of the lot.
-  lot: AuctionsLotState!
-
-  # The saleArtwork object.
+  # The watched saleArtwork object.
   saleArtwork: SaleArtwork
 
   # A slug ID.
@@ -9005,6 +9003,9 @@ type Query {
     # The ID of the auction result
     id: String!
   ): AuctionResult
+
+  # Returns a lot with specific `id`.
+  auctionsLot(id: ID!): AuctionsLotState
 
   # A list of cities
   cities(featured: Boolean = false): [City!]!

--- a/src/lib/stitching/causality/__tests__/stitching.test.ts
+++ b/src/lib/stitching/causality/__tests__/stitching.test.ts
@@ -5,33 +5,212 @@ import { useCausalityStitching } from "./testingUtils"
 import gql from "lib/gql"
 import schema from "schema/v1/schema"
 import v2Schema from "schema/v2/schema"
-import { runAuthenticatedQuery } from "schema/v2/test/utils"
 import { getFieldsForTypeFromSchema } from "lib/stitching/lib/getTypesFromSchema"
 
 describe("causality/stitching", () => {
-  describe("extending types", () => {
+  describe("AuctionLotStanding", () => {
     it("extends AuctionsLotStanding", async () => {
       const { types } = await useCausalityStitching()
       expect(types).toContain("AuctionsLotStanding")
     })
-  })
 
-  describe("fields", () => {
-    describe("Me", () => {
-      it("adds #auctionsLotStandingConnection to me", async () => {
-        const { getFields } = await useCausalityStitching()
-        expect(await getFields("Me")).toContain("auctionsLotStandingConnection")
+    it("resolves a SaleArtwork on an AuctionsLotStanding", async () => {
+      const allMergedSchemas = await incrementalMergeSchemas(schema, 1)
+
+      const query = gql`
+        {
+          _unused_auctionsLotStandingConnection(userId: "123") {
+            edges {
+              node {
+                saleArtwork {
+                  artwork {
+                    title
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      addMockFunctionsToSchema({
+        schema: allMergedSchemas,
+        mocks: {
+          Query: () => ({
+            _unused_auctionsLotStandingConnection: (_root, _params) => {
+              return {
+                edges: [
+                  {
+                    node: {
+                      lotState: {
+                        id: "xxx",
+                      },
+                    },
+                  },
+                ],
+              }
+            },
+          }),
+        },
+      })
+
+      const result = await graphql(allMergedSchemas, query, {
+        accessToken: null,
+        userID: null,
+      })
+
+      expect(result).toEqual({
+        data: {
+          _unused_auctionsLotStandingConnection: {
+            edges: [
+              {
+                node: {
+                  saleArtwork: { artwork: { title: "Hello World" } },
+                },
+              },
+            ],
+          },
+        },
+      })
+    })
+
+    describe("auctionsLotStandingConnection", () => {
+      it("stitches auctionsLotStandingConnection under Me", async () => {
+        const allMergedSchemas = await incrementalMergeSchemas(schema, 1)
+
+        const query = gql`
+          {
+            me {
+              auctionsLotStandingConnection {
+                edges {
+                  node {
+                    rawId
+                  }
+                }
+              }
+            }
+          }
+        `
+
+        addMockFunctionsToSchema({
+          schema: allMergedSchemas,
+          mocks: {
+            Query: () => ({
+              me: () => {
+                return {
+                  internalID: "foo",
+                }
+              },
+            }),
+          },
+        })
+
+        const result = await graphql(allMergedSchemas, query, {}, {})
+
+        expect(result).toEqual({
+          data: {
+            me: {
+              auctionsLotStandingConnection: {
+                edges: [
+                  { node: { rawId: "Hello World" } },
+                  { node: { rawId: "Hello World" } },
+                ],
+              },
+            },
+          },
+        })
+      })
+
+      describe("when sale artworks are missing", () => {
+        let info
+        let auctionsLotStandingConnection
+        beforeEach(async () => {
+          const { resolvers } = await useCausalityStitching()
+
+          // Aka _unused_auctionsLotStandingConnection
+          const causalityLotStandingConnection = {
+            edges: [
+              {
+                node: {
+                  lot: {
+                    internalID: "foo",
+                  },
+                },
+              },
+              {
+                node: {
+                  lot: {
+                    internalID: "bar",
+                  },
+                },
+              },
+            ],
+          }
+
+          info = {
+            mergeInfo: {
+              delegateToSchema: jest.fn(() => {
+                return Promise.resolve(causalityLotStandingConnection)
+              }),
+            },
+          }
+
+          auctionsLotStandingConnection =
+            resolvers.Me.auctionsLotStandingConnection
+        })
+
+        it("gracefully handles missing sale artwork but removes the lot standing from result", async () => {
+          const saleArtworkRootLoader = jest.fn((_id) => {
+            return Promise.reject("Im unpublished")
+          })
+
+          const result = await auctionsLotStandingConnection.resolve(
+            { internalID: "foo" },
+            {},
+            {
+              saleArtworkRootLoader,
+            },
+            info
+          )
+          expect(saleArtworkRootLoader.mock.calls).toEqual([["foo"], ["bar"]])
+          expect(result.edges).toEqual([])
+        })
+
+        it("returns lots with matching sale artwork", async () => {
+          const saleArtworkRootLoader = jest.fn((id) => {
+            if (id === "bar") {
+              return Promise.resolve({ _id: "bar" })
+            }
+            return Promise.reject("I am unpublished")
+          })
+
+          const result = await auctionsLotStandingConnection.resolve(
+            { internalID: "foo" },
+            {},
+            {
+              saleArtworkRootLoader,
+            },
+            info
+          )
+          expect(saleArtworkRootLoader.mock.calls).toEqual([["foo"], ["bar"]])
+          expect(result.edges.map((node) => node.node)).toEqual([
+            {
+              lot: { internalID: "bar" },
+              saleArtwork: { _id: "bar" },
+            },
+          ])
+        })
       })
     })
   })
 
   describe("AuctionsLotState", () => {
-    it("extends the AuctionsLotState type with a floorSellingPrice field", async () => {
+    it("extends AuctionsLotState type with #floorSellingPrice", async () => {
       const { getFields } = await useCausalityStitching()
       expect(await getFields("AuctionsLotState")).toContain("floorSellingPrice")
     })
 
-    it("extends the AuctionsLotState type with a onlineAskingPrice field", async () => {
+    it("extends AuctionsLotState type with #onlineAskingPrice", async () => {
       const { getFields } = await useCausalityStitching()
       expect(await getFields("AuctionsLotState")).toContain("onlineAskingPrice")
     })
@@ -97,360 +276,18 @@ describe("causality/stitching", () => {
     })
   })
 
-  it("resolves a SaleArtwork on an AuctionsLotStanding", async () => {
-    const allMergedSchemas = await incrementalMergeSchemas(schema, 1)
-
-    const query = gql`
-      {
-        _unused_auctionsLotStandingConnection(userId: "123") {
-          edges {
-            node {
-              saleArtwork {
-                artwork {
-                  title
-                }
-              }
-            }
-          }
-        }
-      }
-    `
-
-    // Mock the resolvers for just a user's lot standings so we can see the
-    // stitched SaleArtwork data inside.
-    addMockFunctionsToSchema({
-      schema: allMergedSchemas,
-      mocks: {
-        Query: () => ({
-          _unused_auctionsLotStandingConnection: (_root, _params) => {
-            return {
-              edges: [
-                {
-                  node: {
-                    lotState: {
-                      id: "xxx",
-                    },
-                  },
-                },
-              ],
-            }
-          },
-        }),
-      },
-    })
-
-    const result = await graphql(allMergedSchemas, query, {
-      accessToken: null,
-      userID: null,
-    })
-
-    expect(result).toEqual({
-      data: {
-        _unused_auctionsLotStandingConnection: {
-          edges: [
-            {
-              node: {
-                saleArtwork: { artwork: { title: "Hello World" } },
-              },
-            },
-          ],
-        },
-      },
+  describe("Me", () => {
+    it("extends Me type with #auctionsLotStandingConnection", async () => {
+      const { getFields } = await useCausalityStitching()
+      expect(await getFields("Me")).toContain("auctionsLotStandingConnection")
     })
   })
 
-  it("extends the Lot type with a `lot` (state) field", async () => {
-    const mergedSchema = await incrementalMergeSchemas(v2Schema, 2)
-    const lotFields = await getFieldsForTypeFromSchema("Lot", mergedSchema)
-    expect(lotFields).toContain("lot")
-  })
-
-  describe("watchedLotConnection", () => {
-    it("fulfills the Lot interface using a `AuctionsLotState` and `SaleArtwork`", async () => {
-      const query = gql`
-        {
-          me {
-            watchedLotConnection {
-              edges {
-                node {
-                  lot {
-                    internalID
-                  }
-                  saleArtwork {
-                    internalID
-                  }
-                }
-              }
-            }
-          }
-        }
-      `
-
-      const context = {
-        meLoader: jest.fn(() => Promise.resolve({ internalID: "Baz" })),
-        saleArtworksAllLoader: jest.fn(() =>
-          Promise.resolve({
-            headers: {
-              "x-total-count": 1,
-            },
-            body: [
-              {
-                _id: "foo",
-              },
-            ],
-          })
-        ),
-        causalityLoader: jest.fn(() =>
-          Promise.resolve({
-            lots: [{ internalID: "foo" }],
-          })
-        ),
-      }
-
-      const data = await runAuthenticatedQuery(query, context)
-
-      expect(data).toEqual({
-        me: {
-          watchedLotConnection: {
-            edges: [
-              {
-                node: {
-                  saleArtwork: { internalID: "foo" },
-                  lot: {
-                    internalID: "foo",
-                  },
-                },
-              },
-            ],
-          },
-        },
-      })
-    })
-
-    it("resolves the Lot type with stitched `lot` fields", async () => {
-      const query = gql`
-        {
-          me {
-            watchedLotConnection {
-              edges {
-                node {
-                  lot {
-                    bidCount
-                    onlineAskingPrice {
-                      display
-                    }
-                  }
-                  saleArtwork {
-                    lotLabel
-                  }
-                }
-              }
-            }
-          }
-        }
-      `
-
-      // stub out the loaders necessary to assemble this data
-      const context = {
-        meLoader: jest.fn(() => Promise.resolve({ internalID: "Baz" })),
-        saleArtworksAllLoader: jest.fn(() =>
-          Promise.resolve({
-            headers: {
-              "x-total-count": 2,
-            },
-            body: [
-              {
-                _id: "foo",
-                lot_label: "lot #foo",
-              },
-              {
-                _id: "bar",
-                lot_label: "lot #bar",
-              },
-            ],
-          })
-        ),
-        causalityLoader: jest.fn(() =>
-          Promise.resolve({
-            lots: [
-              { internalID: "foo", bidCount: 2, onlineAskingPriceCents: 2200 },
-              {
-                internalID: "bar",
-                bidCount: 4,
-                onlineAskingPriceCents: 420000,
-              },
-            ],
-          })
-        ),
-        saleArtworkRootLoader: jest.fn(() =>
-          Promise.resolve({ currency: "USD" })
-        ),
-      }
-
-      const data = await runAuthenticatedQuery(query, context)
-
-      expect(data).toEqual({
-        me: {
-          watchedLotConnection: {
-            edges: [
-              {
-                node: {
-                  saleArtwork: { lotLabel: "lot #foo" },
-                  lot: {
-                    bidCount: 2,
-                    onlineAskingPrice: {
-                      display: "$22",
-                    },
-                  },
-                },
-              },
-              {
-                node: {
-                  saleArtwork: { lotLabel: "lot #bar" },
-                  lot: {
-                    bidCount: 4,
-                    onlineAskingPrice: {
-                      display: "$4,200",
-                    },
-                  },
-                },
-              },
-            ],
-          },
-        },
-      })
-    })
-  })
-
-  describe("auctionsLotStandingConnection", () => {
-    it("stitches auctionsLotStandingConnection under Me", async () => {
-      const allMergedSchemas = await incrementalMergeSchemas(schema, 1)
-
-      const query = gql`
-        {
-          me {
-            auctionsLotStandingConnection {
-              edges {
-                node {
-                  rawId
-                }
-              }
-            }
-          }
-        }
-      `
-
-      // Mock the resolvers for just a user's lot standings so we can see the
-      // stitched SaleArtwork data inside.
-      // this is needed without it we get [GraphQLError: Variable "$_v0_userId" got invalid value undefined; Expected non-nullable type ID! not to be null.]
-      addMockFunctionsToSchema({
-        schema: allMergedSchemas,
-        mocks: {
-          Query: () => ({
-            me: () => {
-              return {
-                internalID: "foo",
-              }
-            },
-          }),
-        },
-      })
-
-      const result = await graphql(allMergedSchemas, query, {}, {})
-
-      expect(result).toEqual({
-        data: {
-          me: {
-            auctionsLotStandingConnection: {
-              edges: [
-                { node: { rawId: "Hello World" } },
-                { node: { rawId: "Hello World" } },
-              ],
-            },
-          },
-        },
-      })
-    })
-
-    describe("when sale artworks are missing", () => {
-      let info
-      let auctionsLotStandingConnection
-      beforeEach(async () => {
-        const { resolvers } = await useCausalityStitching()
-
-        // aka _unused_auctionsLotStandingConnection
-        const causalityLotStandingConnection = {
-          edges: [
-            {
-              node: {
-                lot: {
-                  internalID: "foo",
-                },
-              },
-            },
-            {
-              node: {
-                lot: {
-                  internalID: "bar",
-                },
-              },
-            },
-          ],
-        }
-
-        info = {
-          mergeInfo: {
-            delegateToSchema: jest.fn(() => {
-              return Promise.resolve(causalityLotStandingConnection)
-            }),
-          },
-        }
-
-        auctionsLotStandingConnection =
-          resolvers.Me.auctionsLotStandingConnection
-      })
-
-      it("gracefully handles missing sale artwork but removes the lot standing from result", async () => {
-        const saleArtworkRootLoader = jest.fn((_id) => {
-          return Promise.reject("Im unpublished")
-        })
-
-        const result = await auctionsLotStandingConnection.resolve(
-          { internalID: "foo" },
-          {},
-          {
-            saleArtworkRootLoader,
-          },
-          info
-        )
-        expect(saleArtworkRootLoader.mock.calls).toEqual([["foo"], ["bar"]])
-        expect(result.edges).toEqual([])
-      })
-
-      it("returns lots with matching sale artwork", async () => {
-        const saleArtworkRootLoader = jest.fn((id) => {
-          if (id === "bar") {
-            return Promise.resolve({ _id: "bar" })
-          }
-          return Promise.reject("I am unpublished")
-        })
-
-        const result = await auctionsLotStandingConnection.resolve(
-          { internalID: "foo" },
-          {},
-          {
-            saleArtworkRootLoader,
-          },
-          info
-        )
-        expect(saleArtworkRootLoader.mock.calls).toEqual([["foo"], ["bar"]])
-        expect(result.edges.map((node) => node.node)).toEqual([
-          {
-            lot: { internalID: "bar" },
-            saleArtwork: { _id: "bar" },
-          },
-        ])
-      })
+  describe("Lot", () => {
+    it("extends Lot type with #lot", async () => {
+      const mergedSchema = await incrementalMergeSchemas(v2Schema, 2)
+      const lotFields = await getFieldsForTypeFromSchema("Lot", mergedSchema)
+      expect(lotFields).toContain("lot")
     })
   })
 })

--- a/src/lib/stitching/causality/schema.ts
+++ b/src/lib/stitching/causality/schema.ts
@@ -10,7 +10,7 @@ import {
 import { readFileSync } from "fs"
 
 const blacklistedTypes: string[] = []
-const whitelistedRootFields: string[] = []
+const whitelistedRootFields: string[] = ["lot"]
 const privateFields: string[] = ["lotStandingConnection"]
 const permittedRootFields = [...whitelistedRootFields, ...privateFields]
 

--- a/src/lib/stitching/logLinkMiddleware.ts
+++ b/src/lib/stitching/logLinkMiddleware.ts
@@ -4,40 +4,43 @@ import config from "../../config"
 import extensionsLogger from "lib/loaders/api/extensionsLogger"
 import { ResolverContext } from "types/graphql"
 
-const shouldLogLinkTraffic = !!process.env.LOG_HTTP_LINKS
+const shouldLogLinkTraffic =
+  !!process.env.LOG_HTTP_LINKS && typeof jest === "undefined"
 const { ENABLE_REQUEST_LOGGING } = config
 const enableRequestLogging = ENABLE_REQUEST_LOGGING === "true"
 
 /**
  * This acts more like a post-middleware logger, by running the operation
  * waiting until it's done, and then logging out the response.
+ *
+ * To use, set `LOG_HTTP_LINKS=true` in .env file.
  */
-export const responseLoggerLink = (name: string) =>
-  new ApolloLink(
-    (operation, forward) =>
-      // null checks
-      (forward &&
-        operation &&
-        forward(operation).map((response) => {
-          // Log to CLI
-          if (shouldLogLinkTraffic) {
-            console.log(`>\n> Made query to ${name}:`)
-            console.log(">\n" + print(operation.query))
-            console.log(`> Got Response:`)
-            console.log("> " + JSON.stringify(response))
-          }
-          // Log the query/vars sent to the stitched API in the extensions
-          if (enableRequestLogging) {
-            const requestID = (operation.getContext()
-              .graphqlContext as ResolverContext).requestIDs.requestID
-            if (requestID) {
-              extensionsLogger(requestID, "stitching", name.toLowerCase(), {
-                query: print(operation.query),
-                vars: operation.variables,
-              })
-            }
-          }
-          return response
-        })) ||
-      null // if it didn't include forward/operation
-  )
+export const responseLoggerLink = (name: string) => {
+  return new ApolloLink((operation, forward) => {
+    if (!(forward && operation)) {
+      return null
+    }
+
+    return forward(operation).map((response) => {
+      // Log to CLI
+      if (shouldLogLinkTraffic) {
+        console.log(`>\n> Made query to ${name}:`)
+        console.log(">\n" + print(operation.query))
+        console.log(`> Got Response:`)
+        console.log("> " + JSON.stringify(response))
+      }
+      // Log the query/vars sent to the stitched API in the extensions
+      if (enableRequestLogging) {
+        const requestID = (operation.getContext()
+          .graphqlContext as ResolverContext).requestIDs.requestID
+        if (requestID) {
+          extensionsLogger(requestID, "stitching", name.toLowerCase(), {
+            query: print(operation.query),
+            vars: operation.variables,
+          })
+        }
+      }
+      return response
+    })
+  })
+}

--- a/src/schema/v2/lot.ts
+++ b/src/schema/v2/lot.ts
@@ -1,180 +1,26 @@
-import { GraphQLError, GraphQLObjectType } from "graphql"
+import { GraphQLObjectType } from "graphql"
 import { SaleArtworkType } from "schema/v2/sale_artwork"
 import { ResolverContext } from "types/graphql"
 import {
   NodeInterface,
   SlugAndInternalIDFields,
 } from "schema/v2/object_identification"
-import { pageable } from "relay-cursor-paging"
-import { connectionWithCursorInfo } from "./fields/pagination"
-import gql from "lib/gql"
-import { convertConnectionArgsToGravityArgs } from "lib/helpers"
-import { connectionFromArray } from "graphql-relay"
 
-export const LotType = new GraphQLObjectType<any, ResolverContext>({
+export const Lot = new GraphQLObjectType<any, ResolverContext>({
   name: "Lot",
   description:
-    "A lot in an auction containing merged Sale artwork and Lot state data.",
+    "A lot in an auction containing merged SaleArtwork and LotState data, stitched from causality.",
   interfaces: () => {
     return [NodeInterface]
   },
   fields: () => {
     return {
-      // Must place an `id` at the root of the object (next to saleArtwork)
-      // when resolving a lot for this to work (see resolver)
       ...SlugAndInternalIDFields,
       saleArtwork: {
         type: SaleArtworkType,
-        description: "The saleArtwork object.",
-        resolve: ({ saleArtwork }) => {
-          return saleArtwork
-        },
+        description: "The watched saleArtwork object.",
+        resolve: (artwork) => artwork,
       },
     }
   },
 })
-
-/**
- * Fetch relevant sale artworks and use them to fetch lot states
- * from causality. Then pass the lot states through to the stitching layer
- * via the graphql request context.
- */
-const watchedLotConnectionResolver = async (_parent, args, context) => {
-  const { saleArtworksAllLoader, causalityLoader } = context
-  // fetch sale artworks from gravity
-  const { first = 25, ...rest } = args
-
-  const connectionOptions = {
-    include_watched_artworks: true,
-    total_count: true,
-    first,
-    ...rest,
-  }
-  const params = convertConnectionArgsToGravityArgs(connectionOptions)
-  delete params.page
-
-  const { body, headers } = await saleArtworksAllLoader(params)
-  const watchedSaleArtworks: any[] = body
-  const totalCount = parseInt(headers["x-total-count"] || "0", 10)
-  const saleArtworkIds = watchedSaleArtworks.map(
-    (saleArtwork) => saleArtwork._id
-  )
-  // Fetch the all fields of the lot object
-  const causalityData = await causalityLoader({
-    query: gql`
-      query WatchedLotsQuery($ids: [ID!]!) {
-        lots(ids: $ids) {
-          id
-          internalID
-          saleId
-          bidCount
-          reserveStatus
-          sellingPriceCents
-          onlineAskingPriceCents
-          floorSellingPriceCents
-          onlineSellingToBidder {
-            __typename
-            ... on ArtsyBidder {
-              id
-              paddleNumber
-              userId
-            }
-          }
-          floorWinningBidder {
-            __typename
-            ... on ArtsyBidder {
-              id
-              paddleNumber
-              userId
-            }
-          }
-          soldStatus
-        }
-      }
-    `,
-    variables: {
-      ids: saleArtworkIds,
-    },
-  })
-
-  // make a map of lot state data
-  const lotDataMap = causalityData.lots.reduce((acc, lot) => {
-    acc[lot.internalID] = lot
-    return acc
-  }, {})
-
-  // place lotData in context for retrieval at stitching stage
-  context.lotDataMap = lotDataMap
-
-  // create nodes from sale artworks
-  const availableLotDataIds = Object.keys(lotDataMap)
-  const nodes = watchedSaleArtworks.reduce((acc, saleArtwork) => {
-    if (!availableLotDataIds.find((id) => id === saleArtwork._id)) {
-      console.warn(
-        `[metaphysics @ schema/v2/lot] Warning: lot state for ${saleArtwork._id} not found - skipping`
-      )
-      return acc
-    } else {
-      return [...acc, { _id: saleArtwork._id, saleArtwork }]
-    }
-  }, [])
-
-  return {
-    totalCount,
-    ...connectionFromArray(nodes, connectionOptions),
-  }
-}
-
-/**
- * An extension schema to add the lot type at the causality stitching stage.
- */
-export const stitchedCausalityLotExtensionSchema = gql`
-  # A unified auction lot with data from our auctions bidding engine.
-  extend type Lot {
-    # The current auction state of the lot.
-    lot: AuctionsLotState!
-  }
-`
-
-/**
- * A Resolver for use with causality's stitching file, but kept here because
- * it is tied to assumptions about our watchedLotConnection resolver's
- * use of context
- */
-export const stitchedCausalityLotResolver = {
-  Lot: {
-    lot: {
-      fragment: gql`
-        ... on Lot {
-          saleArtwork {
-            internalID
-          }
-        }
-      `,
-      resolve: (root, _args, context, _info) => {
-        const {
-          saleArtwork: { internalID },
-        } = root
-
-        // resolve lot if available via context (eg watchedLotConnection resolver)
-        const lotState = context.lotDataMap?.[internalID]
-        if (lotState) {
-          return lotState
-        }
-
-        throw new GraphQLError(`Lot state for ${internalID} missing`)
-      },
-    },
-  },
-}
-
-export const auctionLotConnection = connectionWithCursorInfo({
-  nodeType: LotType,
-})
-
-export const watchedLotConnection = {
-  description: "A list of lots a user is watching.",
-  type: auctionLotConnection.connectionType,
-  args: pageable(),
-  resolve: watchedLotConnectionResolver,
-}

--- a/src/schema/v2/me/__tests__/watchedLotConnection.test.ts
+++ b/src/schema/v2/me/__tests__/watchedLotConnection.test.ts
@@ -1,0 +1,54 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("watchedLotConnection", () => {
+  it("returns data", async () => {
+    const query = gql`
+      {
+        me {
+          watchedLotConnection {
+            edges {
+              node {
+                saleArtwork {
+                  internalID
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      meLoader: jest.fn(() => Promise.resolve({ internalID: "Baz" })),
+      saleArtworksAllLoader: jest.fn(() =>
+        Promise.resolve({
+          headers: {
+            "x-total-count": 1,
+          },
+          body: [
+            {
+              _id: "foo",
+            },
+          ],
+        })
+      ),
+    }
+
+    const data = await runAuthenticatedQuery(query, context)
+
+    expect(data).toEqual({
+      me: {
+        watchedLotConnection: {
+          edges: [
+            {
+              node: {
+                saleArtwork: { internalID: "foo" },
+              },
+            },
+          ],
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -42,7 +42,7 @@ import {
 } from "./identity_verification"
 import { MyCollection } from "./myCollection"
 import FollowedGalleries from "./followed_galleries"
-import { watchedLotConnection } from "../lot"
+import { WatchedLotConnection } from "./watchedLotConnection"
 
 const Me = new GraphQLObjectType<any, ResolverContext>({
   name: "Me",
@@ -217,7 +217,7 @@ const Me = new GraphQLObjectType<any, ResolverContext>({
         )
       },
     },
-    watchedLotConnection,
+    watchedLotConnection: WatchedLotConnection,
   },
 })
 

--- a/src/schema/v2/me/watchedLotConnection.ts
+++ b/src/schema/v2/me/watchedLotConnection.ts
@@ -1,0 +1,41 @@
+import { pageable } from "relay-cursor-paging"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { connectionFromArraySlice } from "graphql-relay"
+import { connectionWithCursorInfo } from "../fields/pagination"
+import { Lot } from "../lot"
+import { GraphQLFieldConfig } from "graphql"
+import { ResolverContext } from "types/graphql"
+
+export const WatchedLotConnection: GraphQLFieldConfig<void, ResolverContext> = {
+  description: "A list of lots a user is watching.",
+  type: connectionWithCursorInfo({
+    nodeType: Lot,
+  }).connectionType,
+  args: pageable(),
+  resolve: async (_parent, args, { saleArtworksAllLoader }) => {
+    if (!saleArtworksAllLoader) {
+      return null
+    }
+
+    const { first = 25, ...rest } = args
+
+    const gravityArgs = convertConnectionArgsToGravityArgs({
+      include_watched_artworks: true,
+      total_count: true,
+      first,
+      ...rest,
+    })
+
+    // @ts-expect-error FIXME: Make `page` is an optional param of `gravityOptions`
+    delete gravityArgs.page
+
+    const { body, headers } = await saleArtworksAllLoader(gravityArgs)
+
+    const connection = connectionFromArraySlice(body, args, {
+      arrayLength: parseInt(headers["x-total-count"] || "0", 10),
+      sliceStart: gravityArgs.offset,
+    })
+
+    return connection
+  },
+}


### PR DESCRIPTION
As I started working on moving the MyBids logic from Eigen to MP, I noticed some places where we might run into confusion/trouble later and wanted to open a PR up for discussion. 

This refactors a [previous PR](https://github.com/artsy/metaphysics/pull/2928) to simplify our Causality `Lot` stitching code by deferring to more conventional stitching patterns seen throughout MP, removing indirection, and deleting a good amount of code. 

All in all, no breaking changes have been made to the schema, and everything should be backwards compatible; however, as detailed below, we're now returning _all_ `watchedLotConnection` nodes, versus just some. I'll defer to @erikdstock as to whether follow-up work is necessary in Eigen and am happy to tackle that as well.  

```graphql
{
  me {
    watchedLotConnection {
      edges {
        node {
          lot {
            id
          }
          saleArtwork {
            internalID
          }
        }
      }
    }
  }
}
```

<img width="476" alt="Screen Shot 2021-02-26 at 1 50 26 AM" src="https://user-images.githubusercontent.com/236943/109284763-10e34000-77d5-11eb-8f2f-410f8b90c532.png">


#### Changes: 

Previously, we created a new type `Lot` which handles lot state from Causality. In order to add a `lot` field to the `Lot` type (`Lot` being the node on a new `WatchedLotConnection`), we needed to make a request to causality by using a dataloader in our `watchedLotConnection` resolver, and then we added that response to the express req/res cycle `context` in order to pass it to our causality stitching logic, which is in a distant area of the codebase. This then extended the stitched causality `AuctionLotState` type with data fetched from causality via the `causalityLoader`, not from stitching. 

The original assumption behind this was: how do we take a selection of all watched lots and then make one request to causality to get an array of lot state for all arworks, and then interleave the response in with the watched lots in a connection. This isn't exactly easy directly within stitched code. And the `context` solution was a clever one! But I think it might be a case of premature optimization in the sense that for given user who watches artworks, there's only going to be a small number of sales going on at any given time, and so we'd never be dealing with situation where suddenly the watched lots connection gets blown up with like 500 artworks. When we do get to that point and real world performance concerns are observed, we should solve it, but not until then. In meantime keep things as vanilla as we can. 

And so this solution defers exclusively to conventional stitching techniques in that for n number of watched lots, we call causality's `delegateToSchema` and execute the `lot(id: ...)` query with the `internalID` of the artwork, which simplifies the feature substantially. 

Additionally, I broke out the coupling between `me.watchedLotConnection` and `Lot`, since `Lot` is a more general type, where `watchedLotConnection` is a sub-field of `me`, and should be co-located there. 

Another change is, previously if a sale artwork lacked `lot` state, it was excluded completely from the `watchedLotConnection` array, leading to confusion. A user could be watching x number of lots, but hasn't bid yet; those lots should still be represented in the connection ("a users watched lots") and for the purposes of the My Bids component, filtered at the UI level. 

In the tests, indirection was also removed around testing MP-centric fields within causality's stitching code. Meaning: we were testing `watchedLotsConnection` far away from where `watchedLotsConnection` was defined. 

-- 

In a follow-up PR I think some similar refactoring can be done around `auctionsLotStandingConnection` (based on discussions that Erik and I have been having), which will then put us in a good place to formally migrate the MyBids logic out of Eigen and into MP, to be shared with force. 


