### PR TITLE
Feat(PX-3768): add atAFair param & artworksCount to show type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8238,6 +8238,9 @@ type Partner implements Node {
   # A connection of shows from a Partner.
   showsConnection(
     after: String
+
+    # True for only shows that are part of a fair, false for only shows not part of a fair, blank for all shows
+    atAFair: Boolean
     before: String
 
     # Only used when status is CLOSING_SOON or UPCOMING. Number of days used to filter upcoming and closing soon shows

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10313,6 +10313,9 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
     last: Int
     published: Boolean = true
   ): ArtworkConnection
+
+  # The total count of artworks, both unpublished and published, in a show
+  artworksCount: Int
   cached: Int
 
   # The general city, derived from a fair location, a show location or a potential city

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -326,6 +326,16 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         description: "A connection of shows from a Partner.",
         type: ShowsConnection.connectionType,
         args: pageable({
+          atAFair: {
+            type: GraphQLBoolean,
+            description:
+              "True for only shows that are part of a fair, false for only shows not part of a fair, blank for all shows",
+          },
+          dayThreshold: {
+            type: GraphQLInt,
+            description:
+              "Only used when status is CLOSING_SOON or UPCOMING. Number of days used to filter upcoming and closing soon shows",
+          },
           sort: {
             type: ShowSorts,
           },
@@ -334,26 +344,23 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             defaultValue: "current",
             description: "Filter shows by chronological event status",
           },
-          dayThreshold: {
-            type: GraphQLInt,
-            description:
-              "Only used when status is CLOSING_SOON or UPCOMING. Number of days used to filter upcoming and closing soon shows",
-          },
         }),
         resolve: ({ id }, args, { partnerShowsLoader }) => {
           const pageOptions = convertConnectionArgsToGravityArgs(args)
           const { page, size, offset } = pageOptions
 
           interface GravityArgs {
+            at_a_fair: boolean
+            day_threshold: number
             page: number
             size: number
-            total_count: boolean
             sort: string
             status: string
-            day_threshold: number
+            total_count: boolean
           }
 
           const gravityArgs: GravityArgs = {
+            at_a_fair: args.atAFair,
             total_count: true,
             page,
             size,

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -147,6 +147,12 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
           )
         },
       },
+      artworksCount: {
+        description:
+          "The total count of artworks, both unpublished and published, in a show",
+        type: GraphQLInt,
+        resolve: ({ artworks_count }) => artworks_count,
+      },
       artistsWithoutArtworks: {
         description: "Artists inside the show who do not have artworks present",
         type: new GraphQLList(Artist.type),


### PR DESCRIPTION
This PR enables us to fetch only shows that are part of fairs using the `atAFair` param, and it allows us to fetch counts of ALL artworks (published or unpublished) that are in a show. These attributes will be used for the CMS homepage checklist, allowing us to display shows that the partner needs to upload artworks to.

```graphql
{
  partner(id: "xavier-hufkens") {
    showsConnection(first: 5, atAFair: true) {
      edges {
        node {
          artworksCount
          name
          isFairBooth
        }
      }
    }
  }
}

```

Jira ticket: https://artsyproduct.atlassian.net/browse/PX-3768