### PR TITLE
fix: [Causality Stitching] Make `lot` private

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -11726,6 +11726,9 @@ type PublishViewingRoomPayload {
 }
 
 type Query {
+  # Returns a lot with specific `id`.
+  _unused_auctionsLot(id: ID!): AuctionsLotState
+
   # Lot standings for a user
   _unused_auctionsLotStandingConnection(
     after: String
@@ -11887,9 +11890,6 @@ type Query {
     # The ID of the ArtworkVersion
     id: String!
   ): ArtworkVersion
-
-  # Returns a lot with specific `id`.
-  auctionsLot(id: ID!): AuctionsLotState
 
   # Creates, and authorizes, a JWT custom for Causality
   causality_jwt(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8748,6 +8748,9 @@ type Query {
   # Do not use (only used internally for stitching)
   _do_not_use_image: Image
 
+  # Returns a lot with specific `id`.
+  _unused_auctionsLot(id: ID!): AuctionsLotState
+
   # Lot standings for a user
   _unused_auctionsLotStandingConnection(
     after: String
@@ -9013,9 +9016,6 @@ type Query {
     # The ID of the auction result
     id: String!
   ): AuctionResult
-
-  # Returns a lot with specific `id`.
-  auctionsLot(id: ID!): AuctionsLotState
 
   # A list of cities
   cities(featured: Boolean = false): [City!]!

--- a/src/lib/stitching/causality/schema.ts
+++ b/src/lib/stitching/causality/schema.ts
@@ -10,8 +10,8 @@ import {
 import { readFileSync } from "fs"
 
 const blacklistedTypes: string[] = []
-const whitelistedRootFields: string[] = ["lot"]
-const privateFields: string[] = ["lotStandingConnection"]
+const whitelistedRootFields: string[] = []
+const privateFields: string[] = ["lot", "lotStandingConnection"]
 const permittedRootFields = [...whitelistedRootFields, ...privateFields]
 
 export const executableCausalitySchema = () => {

--- a/src/lib/stitching/causality/v2/stitching.ts
+++ b/src/lib/stitching/causality/v2/stitching.ts
@@ -121,7 +121,7 @@ export const causalityStitchingEnvironment = ({
             return info.mergeInfo.delegateToSchema({
               schema: causalitySchema,
               operation: "query",
-              fieldName: "auctionsLot",
+              fieldName: "_unused_auctionsLot",
               args: { id: parent.saleArtwork.internalID },
               context,
               info,


### PR DESCRIPTION
I just realized we could make `auctionsLot` private, since we're simply pointing at causality now. 