### PR TITLE
WIP: Add an orderEvents history to commerce orders

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8059,9 +8059,16 @@ enum OrderedSetSorts {
 }
 
 type OrderEvent {
-  amount: String
+  amount(
+    decimal: String
+
+    # Allows control of symbol position (%v = value, %s = symbol)
+    format: String
+    precision: Int
+    symbol: String
+    thousand: String
+  ): String
   createdAt: String!
-  json: String
   kind: OrderEventKind!
   message: String!
 }

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3182,6 +3182,7 @@ type CommerceOfferOrder implements CommerceOrder {
     symbol: String
     thousand: String = ","
   ): String
+  orderEvents: [OrderEvent]!
   requestedFulfillment: CommerceRequestedFulfillmentUnion
   seller: CommerceOrderPartyUnion!
   sellerDetails: OrderParty
@@ -8055,6 +8056,19 @@ enum OrderedSetSorts {
   OWNER_ID_DESC
   OWNER_TYPE_ASC
   OWNER_TYPE_DESC
+}
+
+type OrderEvent {
+  amount: String
+  createdAt: String!
+  json: String
+  kind: OrderEventKind!
+  message: String!
+}
+
+enum OrderEventKind {
+  OFFER_RECEIVED
+  OFFER_SENT
 }
 
 union OrderParty = Partner | User

--- a/src/lib/stitching/exchange/v2/stitching.ts
+++ b/src/lib/stitching/exchange/v2/stitching.ts
@@ -1,19 +1,10 @@
 import { GraphQLError, GraphQLSchema, Kind, SelectionSetNode } from "graphql"
 import { amountSDL, amount } from "schema/v1/fields/money"
 import gql from "lib/gql"
-import {
-  connectionFromArray,
-  connectionFromArraySlice,
-  toGlobalId,
-} from "graphql-relay"
+import { toGlobalId } from "graphql-relay"
 import { delegateToSchema } from "@graphql-tools/delegate"
 import { ArtworkVersionType } from "schema/v2/artwork_version"
 import { WrapQuery } from "graphql-tools"
-import { convertConnectionArgsToGravityArgs } from "lib/helpers"
-import { MessageConnection } from "schema/v2/me/conversation"
-import { resolve } from "url"
-import { MessageType } from "schema/v1/me/conversation/message"
-import { access } from "fs"
 
 const orderTotals = [
   "itemsTotal",
@@ -193,46 +184,11 @@ export const exchangeStitchingEnvironment = ({
 
   // Used to convert an array of `key: resolvers` to a single obj
   const reduceToResolvers = (arr) => arr.reduce((a, b) => ({ ...a, ...b }))
-  /*
 
-resolve events:
-- get impulse message loader from context and load correct page of messages
-- get all offers for conversation order(s)
-- iterate over messages and insert offers by timestamp
-
-## New type mixed in with messages
-
-type ConversationOrderEvent implements Node {
-
-}
-
-
-
-*/
   return {
     // The SDL used to declare how to stitch an object
     extensionSchema: gql`
 
-    type ConversationEvent implements Node{
-      id: ID!
-      message: String
-    }
-
-    union ConversationEventKind = Message | ConversationEvent
-
-    type ConversationEventEdge {
-      cursor: String!
-      node: ConversationEventKind!
-    }
-
-    type ConversationEventConnection {
-      # A list of edges.
-      edges: [ConversationEventEdge]
-
-      # Information to aid in pagination.
-      pageInfo: PageInfo!
-      totalCount: Int
-    }
 
     extend type Conversation {
       orderConnection(
@@ -242,15 +198,6 @@ type ConversationOrderEvent implements Node {
         first: Int
         last: Int
       ): CommerceOrderConnectionWithTotalCount
-
-      eventConnection(
-        participantType: CommerceOrderParticipantEnum!
-        after: String
-        before: String
-        first: Int
-        last: Int
-      ): ConversationEventConnection!
-
     }
 
     extend type CommerceLineItem {
@@ -302,157 +249,17 @@ type ConversationOrderEvent implements Node {
       ): CommerceCreateInquiryOfferOrderWithArtworkPayload
     }
   `,
-    /*
 
-conversation(id: sdaf) {
-
-  eventConnection() { edges { node {
-    # message: Message
-    message {
-      id
-      internalID
-      isFromUser
-      isFirstMessage
-      body
-      createdAt
-      ...
-    }
-    # commerceEvent: CommerceEvent
-    commerceEvent {
-      kind 
-      message
-    }
-  }}}
-}
-
-*/
     // Resolvers for the above
     resolvers: {
       Conversation: {
-        eventConnection: {
-          fragment: gql`
-            fragment Conversation_eventConnection on Conversation {
-              internalID
-              from {
-                email
-                name
-              }
-              initialMessage: messagesConnection(first: 1) {
-                edges {
-                  node {
-                    body
-                    internalID
-                  }
-                }
-              }
-              lastMessage: messagesConnection(last: 1) {
-                edges {
-                  node {
-                    body
-                    internalID
-                  }
-                }
-              }
-              messagesConnection {
-                edges
-              }
-            }
-          `,
-          resolve: async (root, args, context, info) => {
-            const { internalID, from, initialMessage, lastMessage } = root
-            const { conversationMessagesLoader } = context
-            const lastMessageId = lastMessage?.edges?.node?.internalID
-            const initialMessageBody = initialMessage?.edges?.node?.body
-
-            if (!conversationMessagesLoader) return null
-            const argKeys = Object.keys(args)
-            if (argKeys.includes("last") && !argKeys.includes("before")) {
-              args.before = lastMessageId
-            }
-            const { page, size, offset } = convertConnectionArgsToGravityArgs(
-              args
-            )
-            const {
-              total_count,
-              message_details,
-            } = await conversationMessagesLoader({
-              page,
-              size,
-              conversation_id: internalID,
-              "expand[]": "deliveries",
-              sort: args.sort || "asc",
-            })
-            // Inject the convesation initiator's email into each message payload
-            // so we can tell if the user sent a particular message.
-            // Also inject the conversation id, since we need it in some message
-            // resolvers (invoices).
-            /* eslint-disable no-param-reassign */
-            const messageResult = message_details.map((message) => {
-              console.log(message)
-              const messageFields = MessageType.getFields()
-              return Object.entries(messageFields).reduce(
-                (acc, [key, field]) => {
-                  return {
-                    ...acc,
-                    [key]: field.resolve!(
-                      message,
-                      {
-                        /* how to get args? */
-                      },
-                      context,
-                      info
-                    ),
-                  }
-                },
-                { __typename: "Message" } as any
-              )
-              // return {
-              //   ...message,
-              //   __typename: "Message",
-              //   conversation_initial_message: initialMessageBody,
-              //   conversation_from_name: from.name,
-              //   conversation_from_address: from?.email,
-              //   conversation_id: internalID,
-              // }
-            })
-            const fullResult = [...messageResult]
-            console.log({ total_count, fullResult })
-            /*
-            context.conversationLoader
-            const messageResult = info.mergeInfo.delegateToSchema({
-              schema: localSchema,
-              operation: "query",
-              fieldName: "messageConnection",
-              args: {},
-              context,
-              info,
-            })
-            // alternativeley message loader
-            const messageResult = messageLoader()
-            const eventResults = info.mergeInfo.delegateToSchema({
-              schema: exchangeSchema,
-              operation: "query",
-              fieldName: "commerceOffers",
-              args: {},
-              context,
-              info,
-            })
-            // alternatively fetch from exchange
-            return connectionFromArray(messageResult + eventResults, args)
-      */
-            return connectionFromArraySlice(fullResult, args, {
-              arrayLength: total_count,
-              sliceStart: offset,
-            })
-          },
-        },
         orderConnection: {
           fragment: gql`
             fragment Conversation_orderConnection on Conversation {
               internalID
             }
           `,
-          resolve: async (
+          resolve: (
             { internalID: conversationId },
             { participantType, ...requestArgs },
             context,
@@ -468,7 +275,7 @@ conversation(id: sdaf) {
               [viewerKey]: userID,
             }
 
-            const os = await info.mergeInfo.delegateToSchema({
+            return info.mergeInfo.delegateToSchema({
               schema: exchangeSchema,
               operation: "query",
               fieldName: "commerceOrders",
@@ -476,8 +283,6 @@ conversation(id: sdaf) {
               context,
               info,
             })
-            console.warn(os)
-            return os
           },
         },
       },

--- a/src/schema/v2/me/conversation/index.ts
+++ b/src/schema/v2/me/conversation/index.ts
@@ -176,10 +176,17 @@ const messagesConnection = {
     },
   }),
   resolve: (
-    { id, from_email, initial_message, from_name, _embedded },
+    root,
     options,
     { conversationMessagesLoader }: { conversationMessagesLoader?: any }
   ) => {
+    const {
+      internalID: id,
+      from_email,
+      initial_message,
+      from_name,
+      _embedded,
+    } = root
     if (!conversationMessagesLoader) return null
     const optionKeys = Object.keys(options)
     if (optionKeys.includes("last") && !optionKeys.includes("before")) {

--- a/src/schema/v2/me/conversation/index.ts
+++ b/src/schema/v2/me/conversation/index.ts
@@ -176,17 +176,10 @@ const messagesConnection = {
     },
   }),
   resolve: (
-    root,
+    { id, from_email, initial_message, from_name, _embedded },
     options,
     { conversationMessagesLoader }: { conversationMessagesLoader?: any }
   ) => {
-    const {
-      internalID: id,
-      from_email,
-      initial_message,
-      from_name,
-      _embedded,
-    } = root
     if (!conversationMessagesLoader) return null
     const optionKeys = Object.keys(options)
     if (optionKeys.includes("last") && !optionKeys.includes("before")) {


### PR DESCRIPTION
Very WIP/proof of concept for now, putting it up for early comments:

This PR creates a new `OrderEvent` type in our exchange stitching layer that converts an order's offers into a list of events. This is mostly an intermediate step as all of the data is already available on `Order.offers` (a relay connection), but soon we will want to add certain order changes as events as well - for example transitions of `state` when an order is accepted or declined, which are currently not exposed by exchange and only available via the `state_history` property.

paired with @sepans and @starsirius, cc @artsy/purchase-devs 

![image](https://user-images.githubusercontent.com/9088720/109725582-57db8780-7b7f-11eb-9fd6-ef0281ede072.png)
