### PR TITLE
feat: support filtering conversation.orderConnection by order state (PURCHASE-2463)

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4735,6 +4735,7 @@ type Conversation implements Node {
     first: Int
     last: Int
     participantType: CommerceOrderParticipantEnum!
+    state: CommerceOrderStateEnum
   ): CommerceOrderConnectionWithTotalCount
 
   # The participant(s) responding to the conversation

--- a/src/lib/stitching/exchange/__tests__/stitching.test.ts
+++ b/src/lib/stitching/exchange/__tests__/stitching.test.ts
@@ -333,6 +333,33 @@ describe("Conversation with orders", () => {
       info: expect.anything(),
     })
   })
+
+  it("supports filtering orders by state", async () => {
+    const { resolvers } = await getExchangeStitchedSchema()
+    const orderConnectionResolver =
+      resolvers.Conversation.orderConnection.resolve
+    const mergeInfo = { delegateToSchema: jest.fn() }
+
+    orderConnectionResolver(
+      { internalID: "conversation-id" },
+      { participantType: "BUYER", state: "SUBMITTED" },
+      { userID: "user-id" },
+      { mergeInfo }
+    )
+
+    expect(mergeInfo.delegateToSchema).toHaveBeenCalledWith({
+      args: {
+        buyerId: "user-id",
+        impulseConversationId: "conversation-id",
+        state: "SUBMITTED",
+      },
+      fieldName: "commerceOrders",
+      operation: "query",
+      schema: expect.anything(),
+      context: expect.anything(),
+      info: expect.anything(),
+    })
+  })
 })
 
 // FIXME: These tests don't work

--- a/src/lib/stitching/exchange/v2/stitching.ts
+++ b/src/lib/stitching/exchange/v2/stitching.ts
@@ -193,6 +193,7 @@ export const exchangeStitchingEnvironment = ({
     extend type Conversation {
       orderConnection(
         participantType: CommerceOrderParticipantEnum!
+        state: CommerceOrderStateEnum
         after: String
         before: String
         first: Int


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PURCHASE-2463

We want to hide the "Make Offer" button when there is an active/submitted order associated with a conversation. To support that, we want to filter the orders by state. This adds it as an argument in `orderConnection` and it's already [supported in Exchange](https://github.com/artsy/exchange/blob/1cd7df5d875e6a04b5a22a3c6585df71af25b304/app/graphql/types/query_type.rb#L18).

![Screen Shot 2021-03-05 at 5 52 17 PM](https://user-images.githubusercontent.com/796573/110182826-8f467000-7ddb-11eb-9fa1-d84e37aba287.png)
