### PR TITLE
feat: add a single `input` arg to filter artworks

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -772,6 +772,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     height: String
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
+    input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
 
@@ -1124,6 +1125,7 @@ type ArtistSeries {
     height: String
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
+    input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
     keywordMatchExact: Boolean
@@ -5679,6 +5681,7 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
     height: String
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
+    input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
 
@@ -5984,6 +5987,64 @@ type FilterArtworksEdge implements ArtworkEdgeInterface {
 
   # The item at the end of the edge
   node: Artwork
+}
+
+input FilterArtworksInput {
+  acquireable: Boolean
+  additionalGeneIDs: [String]
+  after: String
+  aggregationPartnerCities: [String]
+  aggregations: [ArtworkAggregation]
+  artistID: String
+  artistIDs: [String]
+  artistNationalities: [String]
+  artistSeriesID: String
+  atAuction: Boolean
+  attributionClass: [String]
+  before: String
+  color: String
+  colors: [String]
+  dimensionRange: String
+  excludeArtworkIDs: [String]
+  extraAggregationGeneIDs: [String]
+  first: Int
+  forSale: Boolean
+  geneID: String
+  geneIDs: [String]
+  height: String
+  includeArtworksByFollowedArtists: Boolean
+  includeMediumFilterInAggregation: Boolean
+  inquireableOnly: Boolean
+  keyword: String
+
+  # When true, will only return exact keyword match
+  keywordMatchExact: Boolean
+  last: Int
+  locationCities: [String]
+  majorPeriods: [String]
+
+  # When true, will only return `marketable` works (not nude or provocative).
+  marketable: Boolean
+  materialsTerms: [String]
+
+  # A string from the list of allocations, or * to denote all mediums
+  medium: String
+  offerable: Boolean
+  page: Int
+  partnerCities: [String]
+  partnerID: ID
+  partnerIDs: [String]
+  period: String
+  periods: [String]
+  priceRange: String
+  saleID: ID
+  size: Int
+
+  # Filter results by Artwork sizes
+  sizes: [ArtworkSizes]
+  sort: String
+  tagID: String
+  width: String
 }
 
 type FilterSaleArtworksCounts {
@@ -6346,6 +6407,7 @@ type Gene implements Node & Searchable {
     height: String
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
+    input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
 
@@ -7076,6 +7138,7 @@ type MarketingCollection {
     height: String
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
+    input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
     keywordMatchExact: Boolean
@@ -8233,6 +8296,7 @@ type Partner implements Node {
     height: String
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
+    input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
 
@@ -9036,6 +9100,7 @@ type Query {
     height: String
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
+    input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
 
@@ -10444,6 +10509,7 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
     height: String
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
+    input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
 
@@ -10868,6 +10934,7 @@ type Tag implements Node {
     height: String
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
+    input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
 
@@ -11554,6 +11621,7 @@ type Viewer {
     height: String
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
+    input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
 

--- a/src/lib/__tests__/helpers.test.ts
+++ b/src/lib/__tests__/helpers.test.ts
@@ -2,6 +2,7 @@ import {
   exclude,
   isExisty,
   removeNulls,
+  removeEmptyValues,
   resolveBlueGreen,
   stripTags,
   toKey,
@@ -159,6 +160,25 @@ describe("removeNulls", () => {
     expect(objWithNulls).toHaveProperty("a", "percy")
     expect(objWithNulls).not.toHaveProperty("b")
     expect(objWithNulls).not.toHaveProperty("c")
+  })
+})
+
+describe("removeEmptyValues", () => {
+  const obj = {
+    a: "percy",
+    b: null,
+    c: undefined,
+    d: [],
+    e: ["cat"],
+  }
+
+  it("removes null and undefined properties from an object", () => {
+    removeEmptyValues(obj)
+    expect(obj).toHaveProperty("a", "percy")
+    expect(obj).toHaveProperty("e", ["cat"])
+    expect(obj).not.toHaveProperty("b")
+    expect(obj).not.toHaveProperty("c")
+    expect(obj).not.toHaveProperty("d")
   })
 })
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -123,6 +123,15 @@ export const removeNulls = (object) => {
   ) // eslint-disable-line eqeqeq, no-param-reassign, max-len
 }
 
+export const removeEmptyValues = (object) => {
+  Object.keys(object).forEach(
+    (key) =>
+      (object[key] == null ||
+        (Array.isArray(object[key]) && isEmpty(object[key]))) &&
+      delete object[key]
+  ) // eslint-disable-line eqeqeq, no-param-reassign, max-len
+}
+
 export const resolveBlueGreen = (
   resolveBlue: string,
   resolveGreen?: string,

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -1,19 +1,13 @@
 import gql from "lib/gql"
-import {
-  GraphQLSchema,
-  GraphQLFieldConfigArgumentMap,
-  GraphQLType,
-  isScalarType,
-  isListType,
-  isEnumType,
-} from "graphql"
+import { GraphQLSchema, GraphQLFieldConfigArgumentMap } from "graphql"
 import moment from "moment"
 import { defineCustomLocale, isExisty } from "lib/helpers"
-import { pageableFilterArtworksArgs } from "schema/v2/filterArtworksConnection"
+import { pageableFilterArtworksArgsWithInput } from "schema/v2/filterArtworksConnection"
 import { normalizeImageData, getDefault } from "schema/v2/image"
 import { formatMarkdownValue } from "schema/v2/fields/markdown"
 import Format from "schema/v2/input_fields/format"
 import { toGlobalId } from "graphql-relay"
+import { printType } from "lib/stitching/lib/printType"
 
 const LocaleEnViewingRoomRelativeShort = "en-viewing-room-relative-short"
 defineCustomLocale(LocaleEnViewingRoomRelativeShort, {
@@ -62,18 +56,6 @@ function argsToSDL(args: GraphQLFieldConfigArgumentMap) {
   return result
 }
 
-function printType(type: GraphQLType): string {
-  if (isScalarType(type)) {
-    return type.name
-  } else if (isListType(type)) {
-    return `[${printType(type.ofType)}]`
-  } else if (isEnumType(type)) {
-    return type.name
-  } else {
-    throw new Error(`Unknown type: ${JSON.stringify(type)}`)
-  }
-}
-
 export const gravityStitchingEnvironment = (
   localSchema: GraphQLSchema,
   gravitySchema: GraphQLSchema & { transforms: any }
@@ -115,9 +97,9 @@ export const gravityStitchingEnvironment = (
         artists(page: Int, size: Int): [Artist]
         image: Image
         artworksConnection(first: Int, after: String): ArtworkConnection
-        filterArtworksConnection(${argsToSDL(pageableFilterArtworksArgs).join(
-          "\n"
-        )}): FilterArtworksConnection
+        filterArtworksConnection(${argsToSDL(
+          pageableFilterArtworksArgsWithInput
+        ).join("\n")}): FilterArtworksConnection
 
         descriptionFormatted(format: Format): String
         """

--- a/src/lib/stitching/kaws/v1/stitching.ts
+++ b/src/lib/stitching/kaws/v1/stitching.ts
@@ -1,11 +1,5 @@
-import {
-  GraphQLSchema,
-  GraphQLFieldConfigArgumentMap,
-  GraphQLType,
-  isScalarType,
-  isEnumType,
-  isListType,
-} from "graphql"
+import { GraphQLSchema, GraphQLFieldConfigArgumentMap } from "graphql"
+import { printType } from "lib/stitching/lib/printType"
 import { filterArtworksArgs as filterArtworksArgsV1 } from "schema/v1/filter_artworks"
 
 /**
@@ -113,16 +107,4 @@ function argsToSDL(args: GraphQLFieldConfigArgumentMap) {
     result.push(`${argName}: ${printType(args[argName].type)}`)
   })
   return result
-}
-
-function printType(type: GraphQLType): string {
-  if (isScalarType(type)) {
-    return type.name
-  } else if (isListType(type)) {
-    return `[${printType(type.ofType)}]`
-  } else if (isEnumType(type)) {
-    return type.name
-  } else {
-    throw new Error(`Unknown type: ${JSON.stringify(type)}`)
-  }
 }

--- a/src/lib/stitching/lib/printType.ts
+++ b/src/lib/stitching/lib/printType.ts
@@ -1,0 +1,19 @@
+import {
+  GraphQLType,
+  isEnumType,
+  isInputObjectType,
+  isListType,
+  isScalarType,
+} from "graphql"
+
+export function printType(type: GraphQLType): string {
+  if (isScalarType(type)) {
+    return type.name
+  } else if (isListType(type)) {
+    return `[${printType(type.ofType)}]`
+  } else if (isEnumType(type) || isInputObjectType(type)) {
+    return type.name
+  } else {
+    throw new Error(`Unknown type: ${JSON.stringify(type)}`)
+  }
+}


### PR DESCRIPTION
This adds _yet another_ argument to our filter artworks type (but I swear, this one is for a good cause! In fact, it might be the _last_ argument we ever need...).

Basically, converts all the existing ones into a more proper `input` type. This allows the underlying arguments here to change w/o needing long lists to be maintained alongside the GraphQL query for each page that uses a filter (now, a single `input: $input` and `input: FilterArtworksInput` would be all that's needed).

Leaving this in draft as I have a corresponding Force branch in progress locally with this. Also specs.