### PR TITLE
feat(materials filter): add materialsTerms to artwork filtering and aggregation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -783,6 +783,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
 
     # When true, will only return `marketable` works (not nude or provocative).
     marketable: Boolean
+    materialsTerms: [String]
 
     # A string from the list of allocations, or * to denote all mediums
     medium: String
@@ -1130,6 +1131,7 @@ type ArtistSeries {
     locationCities: [String]
     majorPeriods: [String]
     marketable: Boolean
+    materialsTerms: [String]
     medium: String
     offerable: Boolean
     page: Int
@@ -1477,6 +1479,7 @@ enum ArtworkAggregation {
   INSTITUTION
   LOCATION_CITY
   MAJOR_PERIOD
+  MATERIALS_TERMS
   MEDIUM
   MERCHANDISABLE_ARTISTS
   PARTNER
@@ -5531,6 +5534,7 @@ interface EntityWithFilterArtworksConnectionInterface {
 
     # When true, will only return `marketable` works (not nude or provocative).
     marketable: Boolean
+    materialsTerms: [String]
 
     # A string from the list of allocations, or * to denote all mediums
     medium: String
@@ -5686,6 +5690,7 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
 
     # When true, will only return `marketable` works (not nude or provocative).
     marketable: Boolean
+    materialsTerms: [String]
 
     # A string from the list of allocations, or * to denote all mediums
     medium: String
@@ -6352,6 +6357,7 @@ type Gene implements Node & Searchable {
 
     # When true, will only return `marketable` works (not nude or provocative).
     marketable: Boolean
+    materialsTerms: [String]
 
     # A string from the list of allocations, or * to denote all mediums
     medium: String
@@ -7077,6 +7083,7 @@ type MarketingCollection {
     locationCities: [String]
     majorPeriods: [String]
     marketable: Boolean
+    materialsTerms: [String]
     medium: String
     offerable: Boolean
     page: Int
@@ -8237,6 +8244,7 @@ type Partner implements Node {
 
     # When true, will only return `marketable` works (not nude or provocative).
     marketable: Boolean
+    materialsTerms: [String]
 
     # A string from the list of allocations, or * to denote all mediums
     medium: String
@@ -9039,6 +9047,7 @@ type Query {
 
     # When true, will only return `marketable` works (not nude or provocative).
     marketable: Boolean
+    materialsTerms: [String]
 
     # A string from the list of allocations, or * to denote all mediums
     medium: String
@@ -10446,6 +10455,7 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
 
     # When true, will only return `marketable` works (not nude or provocative).
     marketable: Boolean
+    materialsTerms: [String]
 
     # A string from the list of allocations, or * to denote all mediums
     medium: String
@@ -10869,6 +10879,7 @@ type Tag implements Node {
 
     # When true, will only return `marketable` works (not nude or provocative).
     marketable: Boolean
+    materialsTerms: [String]
 
     # A string from the list of allocations, or * to denote all mediums
     medium: String
@@ -11554,6 +11565,7 @@ type Viewer {
 
     # When true, will only return `marketable` works (not nude or provocative).
     marketable: Boolean
+    materialsTerms: [String]
 
     # A string from the list of allocations, or * to denote all mediums
     medium: String

--- a/src/schema/v2/aggregations/filter_artworks_aggregation.ts
+++ b/src/schema/v2/aggregations/filter_artworks_aggregation.ts
@@ -27,6 +27,9 @@ export const ArtworksAggregation = new GraphQLEnumType({
     MAJOR_PERIOD: {
       value: "major_period",
     },
+    MATERIALS_TERMS: {
+      value: "materials_terms",
+    },
     MEDIUM: {
       value: "medium",
     },

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -171,6 +171,9 @@ export const filterArtworksArgs: GraphQLFieldConfigArgumentMap = {
     description:
       "When true, will only return `marketable` works (not nude or provocative).",
   },
+  materialsTerms: {
+    type: GraphQLList(GraphQLString),
+  },
   medium: {
     type: GraphQLString,
     description:
@@ -407,6 +410,7 @@ const filterArtworksConnectionTypeFactory = (
       geneID,
       geneIDs,
       majorPeriods,
+      materialsTerms,
       partnerID,
       partnerIDs,
       partnerCities,
@@ -443,6 +447,7 @@ const filterArtworksConnectionTypeFactory = (
       gene_id: geneID,
       gene_ids: geneIDs,
       major_periods: majorPeriods,
+      materials_terms: materialsTerms,
       partner_id: partnerID,
       partner_ids: partnerIDs,
       partner_cities: partnerCities,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2665
https://artsyproduct.atlassian.net/browse/FX-2667

Wires up the new **materials terms** field for artwork filtering and aggregating.

### Request

```graphql
{
  artworksConnection(
    first: 5, 
    materialsTerms: ["watercolor", "paper"], 
    aggregations: [MATERIALS_TERMS]
  ) {
    edges {
      node {
        slug
        medium
      }
    }
    aggregations {
      slice
      counts {
      	value  
        count
      }
    }
  }
  
}
```


### Response

```json
{
  "data": {
    "artworksConnection": {
      "edges": [
        {
          "node": {
            "slug": "alfred-figueras-sanmarti-circ",
            "medium": "Watercolor on paper"
          }
        },
        {
          "node": {
            "slug": "bernard-buffet-assiette-de-fruits-2",
            "medium": "Watercolor and pastel on paper"
          }
        },
        {
          "node": {
            "slug": "javier-perez-non-melancholic-scenes-dot-4",
            "medium": "Watercolour on paper"
          }
        },
        {
          "node": {
            "slug": "javier-perez-non-melancholic-scenes-dot-6",
            "medium": "Oil, tempera & watercolour on paper"
          }
        },
        {
          "node": {
            "slug": "javier-perez-design-for-tapestries-dot-2",
            "medium": "Watercolour on paper"
          }
        }
      ],
      "aggregations": [
        {
          "slice": "MATERIALS_TERMS",
          "counts": [
            {
              "count": 33553,
              "name": "paper",
              "value": "paper"
            },
            {
              "count": 33553,
              "name": "watercolor",
              "value": "watercolor"
            },
            {
              "count": 6925,
              "name": "ink",
              "value": "ink"
            },
            {
              "count": 3884,
              "name": "pencil",
              "value": "pencil"
            },
            {
              "count": 3388,
              "name": "gouache",
              "value": "gouache"
            },

            /* etc */

          ]
        }
      ]
    }
  }
}
```