### PR TITLE
fix: pass partner id, not user id, when querying by seller

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4775,7 +4775,8 @@ type Conversation implements Node {
     before: String
     first: Int
     last: Int
-    participantType: CommerceOrderParticipantEnum!
+    participantType: CommerceOrderParticipantEnum
+    sellerId: ID
     state: CommerceOrderStateEnum
   ): CommerceOrderConnectionWithTotalCount
 

--- a/src/lib/stitching/exchange/__tests__/stitching.test.ts
+++ b/src/lib/stitching/exchange/__tests__/stitching.test.ts
@@ -296,7 +296,7 @@ describe("Conversation with orders", () => {
 
     orderConnectionResolver(
       { internalID: "conversation-id" },
-      { participantType: "BUYER" },
+      {},
       { userID: "user-id" },
       { mergeInfo }
     )
@@ -319,13 +319,16 @@ describe("Conversation with orders", () => {
 
     orderConnectionResolver(
       { internalID: "conversation-id" },
-      { participantType: "SELLER" },
+      { sellerId: "partner-id" },
       { userID: "user-id" },
       { mergeInfo }
     )
 
     expect(mergeInfo.delegateToSchema).toHaveBeenCalledWith({
-      args: { sellerId: "user-id", impulseConversationId: "conversation-id" },
+      args: {
+        sellerId: "partner-id",
+        impulseConversationId: "conversation-id",
+      },
       fieldName: "commerceOrders",
       operation: "query",
       schema: expect.anything(),
@@ -342,7 +345,7 @@ describe("Conversation with orders", () => {
 
     orderConnectionResolver(
       { internalID: "conversation-id" },
-      { participantType: "BUYER", state: "SUBMITTED" },
+      { state: "SUBMITTED" },
       { userID: "user-id" },
       { mergeInfo }
     )

--- a/src/lib/stitching/exchange/v2/stitching.ts
+++ b/src/lib/stitching/exchange/v2/stitching.ts
@@ -192,7 +192,8 @@ export const exchangeStitchingEnvironment = ({
 
     extend type Conversation {
       orderConnection(
-        participantType: CommerceOrderParticipantEnum!
+        sellerId: ID
+        participantType: CommerceOrderParticipantEnum
         state: CommerceOrderStateEnum
         after: String
         before: String
@@ -262,18 +263,31 @@ export const exchangeStitchingEnvironment = ({
           `,
           resolve: (
             { internalID: conversationId },
-            { participantType, ...requestArgs },
+            {
+              sellerId,
+              ...requestArgs
+            }: {
+              /* Deprecated - use sellerId */
+              participantType?: any
+              /* Overrides buyer_id in request */
+              sellerId?: string
+              first?: number
+              last?: number
+              after?: string
+              before?: string
+              state?: string
+            },
             context,
             info
           ) => {
-            const viewerKey =
-              participantType === "BUYER" ? "buyerId" : "sellerId"
-            const { userID } = context
+            const viewerKey = sellerId
+              ? { sellerId: sellerId }
+              : { buyerId: context.userID }
 
             const exchangeArgs = {
               ...requestArgs,
+              ...viewerKey,
               impulseConversationId: conversationId,
-              [viewerKey]: userID,
             }
 
             return info.mergeInfo.delegateToSchema({


### PR DESCRIPTION
cc @artsy/purchase-devs - We went over this together this morning so this should be a relatively uncontroversial fix. To avoid a bad dev experience I will wait to remove `participantType` completely until lily & I's args have switched to use it.