### PR TITLE
toolchain: Add `yarn test:debug` for debugger

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
     "prettier-project": "prettier --write 'src/**/*.{js,ts,tsx,md,graphql}'",
     "schema-drift": "babel-node --no-warnings --extensions '.ts,.js' ./scripts/schema-drift.ts",
     "start": "yarn run dev",
-    "test:validQueries": "babel-node --extensions '.ts,.js' src/integration/__tests__/runStoredQueryTests.ts",
     "test": "yarn type-check && yarn lint && jest",
+    "test:debug": "node --inspect node_modules/.bin/jest --runInBand",
+    "test:validQueries": "babel-node --extensions '.ts,.js' src/integration/__tests__/runStoredQueryTests.ts",
     "type-check": "tsc --noEmit --pretty",
     "verbose-dev": "DEBUG=verbose,info,error nf start --procfile Procfile.dev",
     "watch": "jest --watch"


### PR DESCRIPTION
Remembered [this blog post](https://artsy.github.io/blog/2018/08/24/How-to-debug-jest-tests). Didn't realize it wasn't in metaphysics:

```bash
yarn test:debug someTestFile --watch
``` 

![jest-debug](https://user-images.githubusercontent.com/236943/111376848-35f10300-865d-11eb-8afb-d148f2a5b840.gif)
