### PR TITLE
chore: update v2 schema

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8252,6 +8252,15 @@ type PageInfo {
 type Partner implements Node {
   analytics: AnalyticsPartnerStats
 
+  # A connection of articles related to a partner.
+  articlesConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    sort: ArticleSorts
+  ): ArticleConnection
+
   # A connection of artists at a partner.
   artistsConnection(
     after: String


### PR DESCRIPTION
Looks like V2 schema became out-of-sync following #3054.

This is usually updated automatically in a pre-commit hook.

Ran the following command locally to sync things back up:

```
$ node_modules/.bin/nf run --env .env.shared,.env yarn dump:local
```

cc/ @sweir27 