### PR TITLE
Remove moment warnings about deprecated method

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -154,6 +154,6 @@ export const defineCustomLocale = (
   localeSpec: LocaleSpecification
 ) => {
   const currentLocale = moment.locale()
-  moment.defineLocale(uniqueName, localeSpec)
+  moment.updateLocale(uniqueName, localeSpec)
   moment.locale(currentLocale)
 }


### PR DESCRIPTION
I noticed we had hundreds of warnings spitting out in MP's tests around a moment method deprecation. This update silences all those warnings. 

Here's a build w/ the example of the warning output: https://app.circleci.com/pipelines/github/artsy/metaphysics/7437/workflows/5e5ea152-53bc-4f27-bd3d-7313bb9fcfbc/jobs/14460