### PR TITLE
fix: Fix total count partner endpoints

### DIFF
--- a/src/schema/v2/__tests__/partner.test.js
+++ b/src/schema/v2/__tests__/partner.test.js
@@ -252,6 +252,29 @@ describe("Partner type", () => {
           partnerLoader,
         }
       })
+
+      it("loads the total count", async () => {
+        const query = gql`
+          {
+            partner(id: "bau-xi-gallery") {
+              artworksConnection(first: 3) {
+                totalCount
+              }
+            }
+          }
+        `
+
+        const data = await runAuthenticatedQuery(query, context)
+
+        expect(data).toEqual({
+          partner: {
+            artworksConnection: {
+              totalCount: 3,
+            },
+          },
+        })
+      })
+
       describe("when shallow is false", () => {
         it("calls partnerArtworksAllLoader", async () => {
           const query = gql`
@@ -390,6 +413,28 @@ describe("Partner type", () => {
         })
       })
 
+      it("loads the total count", async () => {
+        const query = gql`
+          {
+            partner(id: "bau-xi-gallery") {
+              artworksConnection(first: 3) {
+                totalCount
+              }
+            }
+          }
+        `
+
+        const data = await runQuery(query, context)
+
+        expect(data).toEqual({
+          partner: {
+            artworksConnection: {
+              totalCount: 3,
+            },
+          },
+        })
+      })
+
       describe("when shallow is false", () => {
         it("does not call partnerArtworksAllLoader", async () => {
           const query = gql`
@@ -462,10 +507,10 @@ describe("Partner type", () => {
     })
 
     it("returns shows", async () => {
-      const query = `
+      const query = gql`
         {
-          partner(id:"levy-gorvy") {
-            showsConnection(first:3) {
+          partner(id: "levy-gorvy") {
+            showsConnection(first: 3) {
               edges {
                 node {
                   slug
@@ -504,10 +549,10 @@ describe("Partner type", () => {
     })
 
     it("returns hasNextPage=true when first is below total", async () => {
-      const query = `
+      const query = gql`
         {
-          partner(id:"bau-xi-gallery") {
-            showsConnection(first:1) {
+          partner(id: "bau-xi-gallery") {
+            showsConnection(first: 1) {
               pageInfo {
                 hasNextPage
               }
@@ -530,10 +575,10 @@ describe("Partner type", () => {
     })
 
     it("returns hasNextPage=false when first is above total", async () => {
-      const query = `
+      const query = gql`
         {
-          partner(id:"bau-xi-gallery") {
-            showsConnection(first:3) {
+          partner(id: "bau-xi-gallery") {
+            showsConnection(first: 3) {
               pageInfo {
                 hasNextPage
               }
@@ -550,6 +595,27 @@ describe("Partner type", () => {
             pageInfo: {
               hasNextPage: false,
             },
+          },
+        },
+      })
+    })
+
+    it("loads the total count", async () => {
+      const query = gql`
+        {
+          partner(id: "levy-gorvy") {
+            showsConnection(first: 3) {
+              totalCount
+            }
+          }
+        }
+      `
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        partner: {
+          showsConnection: {
+            totalCount: 3,
           },
         },
       })

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -221,10 +221,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
                     return {
                       totalCount,
                       ...connectionFromArraySlice(body, args, {
-                        arrayLength: parseInt(
-                          headers["x-total-count"] || "0",
-                          10
-                        ),
+                        arrayLength: totalCount,
                         sliceStart: offset,
                       }),
                     }
@@ -236,10 +233,15 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
 
           return partnerArtworksLoader(id, gravityArgs).then(
             ({ body, headers }) => {
-              return connectionFromArraySlice(body, args, {
-                arrayLength: parseInt(headers["x-total-count"] || "0", 10),
-                sliceStart: offset,
-              })
+              const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+              return {
+                totalCount,
+                ...connectionFromArraySlice(body, args, {
+                  arrayLength: totalCount,
+                  sliceStart: offset,
+                }),
+              }
             }
           )
         },
@@ -460,7 +462,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
               return {
                 totalCount,
                 ...connectionFromArraySlice(body, args, {
-                  arrayLength: parseInt(headers["x-total-count"] || "0", 10),
+                  arrayLength: totalCount,
                   sliceStart: offset,
                 }),
               }

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -214,15 +214,20 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
                   artwork_id: artworkIds,
                 }
 
+                const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
                 return partnerArtworksAllLoader(id, gravityArtworkArgs).then(
                   ({ body }) => {
-                    return connectionFromArraySlice(body, args, {
-                      arrayLength: parseInt(
-                        headers["x-total-count"] || "0",
-                        10
-                      ),
-                      sliceStart: offset,
-                    })
+                    return {
+                      totalCount,
+                      ...connectionFromArraySlice(body, args, {
+                        arrayLength: parseInt(
+                          headers["x-total-count"] || "0",
+                          10
+                        ),
+                        sliceStart: offset,
+                      }),
+                    }
                   }
                 )
               }
@@ -450,10 +455,15 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
 
           return partnerShowsLoader(id, gravityArgs).then(
             ({ body, headers }) => {
-              return connectionFromArraySlice(body, args, {
-                arrayLength: parseInt(headers["x-total-count"] || "0", 10),
-                sliceStart: offset,
-              })
+              const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+              return {
+                totalCount,
+                ...connectionFromArraySlice(body, args, {
+                  arrayLength: parseInt(headers["x-total-count"] || "0", 10),
+                  sliceStart: offset,
+                }),
+              }
             }
           )
         },


### PR DESCRIPTION
Implemented `totalCount` for `artworksConnection` and `showsConnection` on the partner by calculating the count from the `total-count` header and adding to the result returned from MP. For the case with `artworksConnection`, I calculated `totalCount` twice for each case (when authenticated and `shallow=false` and for our default case).

```gql
{
  partner(id: "commerce-test-partner") {
     artworksConnection(first: 25) {
      totalCount
    }
    showsConnection(first: 30) {
      totalCount
    }
  }
}
```

<img width="379" alt="Screen Shot 2021-03-24 at 12 44 10 PM" src="https://user-images.githubusercontent.com/9466631/112366672-b5ef1c80-8c9e-11eb-91ea-e943d9b862c3.png">
