### PR TITLE
feat: add fields controlling artist list rendering

### DIFF
--- a/src/schema/v2/__tests__/partner.test.js
+++ b/src/schema/v2/__tests__/partner.test.js
@@ -13,6 +13,7 @@ describe("Partner type", () => {
       name: "Catty Partner",
       has_full_profile: true,
       profile_banner_display: true,
+      distinguish_represented_artists: true,
       partner_categories: [
         {
           id: "blue-chip",
@@ -28,6 +29,23 @@ describe("Partner type", () => {
         .withArgs(partnerData.id)
         .returns(Promise.resolve(partnerData)),
     }
+  })
+
+  it("returns distinguishRepresentedArtists field", async () => {
+    const query = gql`
+      {
+        partner(id: "catty-partner") {
+          distinguishRepresentedArtists
+        }
+      }
+    `
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      partner: {
+        distinguishRepresentedArtists: true,
+      },
+    })
   })
 
   it("includes the gallery website address in shows", async () => {

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -403,6 +403,11 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLString,
         resolve: ({ name }) => name.trim(),
       },
+      distinguishRepresentedArtists: {
+        type: GraphQLBoolean,
+        resolve: ({ distinguish_represented_artists }) =>
+          distinguish_represented_artists,
+      },
       profile: {
         type: Profile.type,
         resolve: ({ default_profile_id }, _options, { profileLoader }) =>

--- a/src/schema/v2/profile.ts
+++ b/src/schema/v2/profile.ts
@@ -33,6 +33,14 @@ export const ProfileType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
       resolve: ({ id }) => `/${id}`,
     },
+    displayArtistsSection: {
+      type: GraphQLBoolean,
+      resolve: ({ owner }) => owner.display_artists_section,
+    },
+    profileArtistsLayout: {
+      type: GraphQLString,
+      resolve: ({ owner }) => owner.profile_artists_layout,
+    },
     icon: {
       type: Image.type,
       resolve: ({ icon }) => normalizeImageData(icon),


### PR DESCRIPTION
This PR adds `distinguishRepresentedArtists`, `displayArtistsSection` and `profileArtistsLayout` fields that controls rendering process.

JIRA - https://artsyproduct.atlassian.net/browse/PX-3840

![image](https://user-images.githubusercontent.com/79979820/113313202-b1b4a600-9313-11eb-8a99-3af7eb720b3f.png)
