### PR TITLE
fix: Sidestep batch loader to fix SaleRegistrationConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8311,6 +8311,7 @@ type Partner implements Node {
   collectingInstitution: String
   counts: PartnerCounts
   defaultProfileID: String
+  distinguishRepresentedArtists: Boolean
 
   # Artworks Elastic Search results
   filterArtworksConnection(
@@ -8860,6 +8861,7 @@ type Profile {
   bio: String
   cached: Int
   counts: ProfileCounts
+  displayArtistsSection: Boolean
   href: String
   icon: Image
 
@@ -8874,6 +8876,7 @@ type Profile {
   isPubliclyVisible: Boolean
   isPublished: Boolean
   name: String
+  profileArtistsLayout: String
 
   # A slug ID.
   slug: ID!

--- a/src/schema/v2/me/__tests__/sale_registrations.test.js
+++ b/src/schema/v2/me/__tests__/sale_registrations.test.js
@@ -26,7 +26,7 @@ describe("Me", () => {
         .mockReturnValueOnce(Promise.resolve([{ id: "bidder-id" }]))
 
       const context = {
-        salesLoader: sinon.stub().returns(
+        salesLoaderWithHeaders: sinon.stub().returns(
           Promise.resolve({
             body: [
               {

--- a/src/schema/v2/me/sale_registrations.ts
+++ b/src/schema/v2/me/sale_registrations.ts
@@ -44,7 +44,7 @@ export const SaleRegistrationConnection: GraphQLFieldConfig<
     const { page, size, offset } = convertConnectionArgsToGravityArgs(
       paginationArgs
     )
-    const { body: sales, headers } = (await (salesLoaderWithHeaders({
+    const response: BodyAndHeaders = await salesLoaderWithHeaders({
       is_auction,
       live,
       published,
@@ -52,7 +52,8 @@ export const SaleRegistrationConnection: GraphQLFieldConfig<
       page,
       size,
       total_count: true,
-    }) as any)) as BodyAndHeaders
+    })
+    const { body: sales, headers } = response
     const saleRegistrations = await Promise.all(
       sales.map(async (sale) => {
         const bidders = await meBiddersLoader({ sale_id: sale.id })

--- a/src/schema/v2/me/sale_registrations.ts
+++ b/src/schema/v2/me/sale_registrations.ts
@@ -38,24 +38,21 @@ export const SaleRegistrationConnection: GraphQLFieldConfig<
   resolve: async (
     _root,
     { isAuction: is_auction, live, published, sort, ...paginationArgs },
-    { meBiddersLoader, salesLoader }
+    { meBiddersLoader, salesLoaderWithHeaders }
   ) => {
     if (!meBiddersLoader) return null
     const { page, size, offset } = convertConnectionArgsToGravityArgs(
       paginationArgs
     )
-    const { body: sales, headers } = (await (salesLoader(
-      {
-        is_auction,
-        live,
-        published,
-        sort,
-        page,
-        size,
-        total_count: true,
-      },
-      { headers: true }
-    ) as any)) as BodyAndHeaders
+    const { body: sales, headers } = (await (salesLoaderWithHeaders({
+      is_auction,
+      live,
+      published,
+      sort,
+      page,
+      size,
+      total_count: true,
+    }) as any)) as BodyAndHeaders
     const saleRegistrations = await Promise.all(
       sales.map(async (sale) => {
         const bidders = await meBiddersLoader({ sale_id: sale.id })


### PR DESCRIPTION
This PR relates to [PURCHASE-2185].

It sidesteps an issue that was raised after merging [this](https://github.com/artsy/metaphysics/pull/2894) PR in which the batch loader was causing the result to have an unexpected shape. Once merged, the part pertaining to `force` can be brought back.

Note: The PR mentioned above was working locally, but not on Staging due to the `ENABLE_RESOLVER_BATCHING` environment variable not being set locally.

Done alongside @zephraph 

cc @artsy/purchase-devs 

[PURCHASE-2185]: https://artsyproduct.atlassian.net/browse/PURCHASE-2185