### PR TITLE
chore: add states filter to Conversation#orderConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4801,6 +4801,7 @@ type Conversation implements Node {
     participantType: CommerceOrderParticipantEnum
     sellerId: ID
     state: CommerceOrderStateEnum
+    states: [CommerceOrderStateEnum!]
   ): CommerceOrderConnectionWithTotalCount
 
   # The participant(s) responding to the conversation

--- a/src/lib/stitching/exchange/v2/stitching.ts
+++ b/src/lib/stitching/exchange/v2/stitching.ts
@@ -195,6 +195,7 @@ export const exchangeStitchingEnvironment = ({
         sellerId: ID
         participantType: CommerceOrderParticipantEnum
         state: CommerceOrderStateEnum
+        states: [CommerceOrderStateEnum!]
         after: String
         before: String
         first: Int
@@ -276,6 +277,7 @@ export const exchangeStitchingEnvironment = ({
               after?: string
               before?: string
               state?: string
+              states?: [string]
             },
             context,
             info


### PR DESCRIPTION
This PR adds the [new order connection `states` filter](https://github.com/artsy/metaphysics/pull/3078/files) to Conversation#orderConnection.

cc @artsy/purchase-devs 