### PR TITLE
Fix incorrect args sent to sales endpoint for auctions filtering

### DIFF
--- a/src/schema/v2/sales.ts
+++ b/src/schema/v2/sales.ts
@@ -27,13 +27,13 @@ export const SalesConnectionField: GraphQLFieldConfig<void, ResolverContext> = {
         name: "AuctionState",
         values: {
           OPEN: {
-            value: "Open",
+            value: "open",
           },
           UPCOMING: {
-            value: "Upcoming",
+            value: "upcoming",
           },
           CLOSED: {
-            value: "Closed",
+            value: "closed",
           },
         },
       }),
@@ -93,7 +93,7 @@ export const SalesConnectionField: GraphQLFieldConfig<void, ResolverContext> = {
       typeof registered === "boolean" ? loaderWithoutCache : loaderWithCache
     const { body: sales, headers } = ((await loader!(
       {
-        auctionState,
+        auction_state: auctionState,
         id: ids,
         is_auction: isAuction,
         live,


### PR DESCRIPTION
Slight issue when calling the API. The Enum wasn't matching the upstream case that was expected by gravity and the param needed to be passed as snake case to gravity instead of camel case. 