### PR TITLE
Fix: add total count to partner artists connection.

### DIFF
--- a/src/schema/v2/__tests__/partner.test.js
+++ b/src/schema/v2/__tests__/partner.test.js
@@ -772,6 +772,28 @@ describe("Partner type", () => {
         },
       })
     })
+
+    it("loads the total count", async () => {
+      const query = gql`
+        {
+          partner(id: "bau-xi-gallery") {
+            artistsConnection(first: 3) {
+              totalCount
+            }
+          }
+        }
+      `
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        partner: {
+          artistsConnection: {
+            totalCount: 3,
+          },
+        },
+      })
+    })
   })
 
   describe("#articlesConnection", () => {

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -162,11 +162,16 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
 
           return partnerArtistsForPartnerLoader(id, gravityArgs).then(
             ({ body, headers }) => {
-              return connectionFromArraySlice(body, args, {
-                arrayLength: parseInt(headers["x-total-count"] || "0", 10),
-                sliceStart: offset,
-                resolveNode: (node) => node.artist,
-              })
+              const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+              return {
+                totalCount,
+                ...connectionFromArraySlice(body, args, {
+                  arrayLength: totalCount,
+                  sliceStart: offset,
+                  resolveNode: (node) => node.artist,
+                }),
+              }
             }
           )
         },


### PR DESCRIPTION
This PR adds the `totalCount` field to the artists connection.

![image](https://user-images.githubusercontent.com/79979820/114365979-a9663180-9b83-11eb-934e-69acedc62cb8.png)
