### PR TITLE
chore(PX-3772): Remove image_count_less_than from MP

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8288,9 +8288,6 @@ type Partner implements Node {
     exclude: [String]
     first: Int
     forSale: Boolean
-
-    # Return artworks with less than x additional_images.
-    imageCountLessThan: Int
     last: Int
 
     # Return artworks that are missing priority metadata

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -48,10 +48,6 @@ const artworksArgs: GraphQLFieldConfigArgumentMap = {
   forSale: {
     type: GraphQLBoolean,
   },
-  imageCountLessThan: {
-    type: GraphQLInt,
-    description: "Return artworks with less than x additional_images.",
-  },
   missingPriorityMetadata: {
     type: GraphQLBoolean,
     description: "Return artworks that are missing priority metadata",
@@ -193,7 +189,6 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             artwork_id?: string[]
             exclude_ids?: string[]
             for_sale: boolean
-            image_count_less_than?: number
             missing_priority_metadata?: boolean
             page: number
             published: boolean
@@ -205,7 +200,6 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
 
           const gravityArgs: GravityArgs = {
             for_sale: args.forSale,
-            image_count_less_than: args.imageCountLessThan,
             missing_priority_metadata: args.missingPriorityMetadata,
             page,
             published: true,


### PR DESCRIPTION
Remoes for `image_count_less_than` from the `partner` object in Metaphysics. The corresponding gravity work is [here](https://github.com/artsy/gravity/pull/13961). I also regenerated the schema so it would not include this attribute.

Let me know if I missed anything!

[Jira ticket](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=36&projectKey=PX&modal=detail&selectedIssue=PX-3772)