### PR TITLE
feat: increase max pod count to 28.

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -96,7 +96,7 @@ spec:
     kind: Deployment
     name: metaphysics-web
   minReplicas: 10
-  maxReplicas: 25
+  maxReplicas: 28
   targetCPUUtilizationPercentage: 60
 
 ---


### PR DESCRIPTION
https://artsy.slack.com/archives/CA8SANW3W/p1618942835151400

during investigation of high load on metaphysics caused by bot traffic, we see that mp has been at max pod count (25) for most of the day even w/o that bot traffic happening, decided to raise max by 3.