### PR TITLE
Fixes biography handling for partner artists + exposes additional API parameters

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1034,6 +1034,7 @@ type ArtistPartnerConnection {
 type ArtistPartnerEdge {
   artist: Artist
   biography: String
+  biographyBlurb(format: Format): PartnerArtistBlurb
   counts: PartnerArtistCounts
 
   # A cursor for use in pagination
@@ -8438,6 +8439,7 @@ type Partner implements Node {
 type PartnerArtist {
   artist: Artist
   biography: String
+  biographyBlurb(format: Format): PartnerArtistBlurb
   counts: PartnerArtistCounts
 
   # A globally unique ID.
@@ -8450,6 +8452,11 @@ type PartnerArtist {
   partner: Partner
   representedBy: Boolean
   sortableID: String
+}
+
+type PartnerArtistBlurb {
+  credit: String
+  text: String
 }
 
 # A connection to a list of items.
@@ -8478,6 +8485,7 @@ type PartnerArtistCounts {
 type PartnerArtistEdge {
   artist: Artist
   biography: String
+  biographyBlurb(format: Format): PartnerArtistBlurb
   counts: PartnerArtistCounts
 
   # A cursor for use in pagination

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8404,7 +8404,6 @@ type Partner implements Node {
     last: Int
   ): LocationConnection
   name: String
-  partnerArtist(artistID: String!): PartnerArtist
   profile: Profile
   profileArtistsLayout: String
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8272,7 +8272,9 @@ type Partner implements Node {
   # A connection of artists at a partner.
   artistsConnection(
     after: String
+    artistIDs: [String]
     before: String
+    displayOnPartnerProfile: Boolean
     first: Int
     last: Int
     representedBy: Boolean

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8404,6 +8404,7 @@ type Partner implements Node {
     last: Int
   ): LocationConnection
   name: String
+  partnerArtist(artistID: String!): PartnerArtist
   profile: Profile
   profileArtistsLayout: String
 

--- a/src/schema/v2/__tests__/partner_artist.test.js
+++ b/src/schema/v2/__tests__/partner_artist.test.js
@@ -1,0 +1,177 @@
+import { runQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("partnerArtist", () => {
+  let partnerArtistData = null
+  let partnerData = null
+  let context = null
+
+  beforeEach(() => {
+    partnerData = {
+      id: "catty-partner",
+      slug: "catty-partner",
+      name: "Catty Partner",
+      has_full_profile: true,
+      profile_banner_display: true,
+      distinguish_represented_artists: true,
+      partner_categories: [
+        {
+          id: "blue-chip",
+          name: "Blue Chip",
+        },
+      ],
+      website: "https://www.newmuseum.org/",
+    }
+
+    context = {
+      partnerArtistsForPartnerLoader: () =>
+        Promise.resolve({
+          body: partnerArtistData,
+          headers: {
+            "x-total-count": partnerArtistData.length,
+          },
+        }),
+      partnerLoader: () => Promise.resolve(partnerData),
+    }
+  })
+
+  describe("biographyBlurb", () => {
+    it("handles a default biography", async () => {
+      partnerArtistData = [
+        {
+          use_default_biography: true,
+          biography: "Partner provided biography",
+          artist: {
+            blurb: "Artsy provided biography",
+          },
+          partner: {
+            name: "Catty Gallery",
+          },
+        },
+      ]
+
+      const query = gql`
+        {
+          partner(id: "levy-gorvy") {
+            artistsConnection(first: 3) {
+              edges {
+                biographyBlurb {
+                  credit
+                  text
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        partner: {
+          artistsConnection: {
+            edges: [
+              {
+                biographyBlurb: {
+                  credit: null,
+                  text: "Artsy provided biography",
+                },
+              },
+            ],
+          },
+        },
+      })
+    })
+
+    it("handles a non-default biography", async () => {
+      partnerArtistData = [
+        {
+          use_default_biography: false,
+          biography: "Partner provided biography",
+          artist: {
+            blurb: "Artsy provided biography",
+          },
+          partner: {
+            name: "Catty Gallery",
+          },
+        },
+      ]
+
+      const query = gql`
+        {
+          partner(id: "levy-gorvy") {
+            artistsConnection(first: 3) {
+              edges {
+                biographyBlurb {
+                  credit
+                  text
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        partner: {
+          artistsConnection: {
+            edges: [
+              {
+                biographyBlurb: {
+                  credit: "Submitted by Catty Gallery",
+                  text: "Partner provided biography",
+                },
+              },
+            ],
+          },
+        },
+      })
+    })
+
+    it("handles no biography data", async () => {
+      partnerArtistData = [
+        {
+          use_default_biography: false,
+          biography: "",
+          artist: {
+            blurb: "Artsy provided biography",
+          },
+          partner: {
+            name: "Catty Gallery",
+          },
+        },
+      ]
+
+      const query = gql`
+        {
+          partner(id: "levy-gorvy") {
+            artistsConnection(first: 3) {
+              edges {
+                biographyBlurb {
+                  credit
+                  text
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        partner: {
+          artistsConnection: {
+            edges: [
+              {
+                biographyBlurb: null,
+              },
+            ],
+          },
+        },
+      })
+    })
+  })
+})

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -135,6 +135,12 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           representedBy: {
             type: GraphQLBoolean,
           },
+          displayOnPartnerProfile: {
+            type: GraphQLBoolean,
+          },
+          artistIDs: {
+            type: new GraphQLList(GraphQLString),
+          },
         }),
         resolve: ({ id }, args, { partnerArtistsForPartnerLoader }) => {
           const pageOptions = convertConnectionArgsToGravityArgs(args)
@@ -146,6 +152,8 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             total_count: boolean
             sort: string
             represented_by: boolean
+            display_on_partner_profile: boolean
+            artist_ids: [string]
           }
 
           const gravityArgs: GravityArgs = {
@@ -154,6 +162,8 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             size,
             sort: args.sort,
             represented_by: args.representedBy,
+            display_on_partner_profile: args.displayOnPartnerProfile,
+            artist_ids: args.artistIDs,
           }
 
           return partnerArtistsForPartnerLoader(id, gravityArgs).then(

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -28,7 +28,10 @@ import { ResolverContext } from "types/graphql"
 import { PartnerCategoryType } from "./partner_category"
 import ShowSorts from "./sorts/show_sorts"
 import ArtistSorts from "./sorts/artist_sorts"
-import { fields as partnerArtistFields } from "./partner_artist"
+import {
+  fields as partnerArtistFields,
+  PartnerArtistType,
+} from "./partner_artist"
 import {
   connectionWithCursorInfo,
   createPageCursors,
@@ -432,6 +435,17 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       displayArtistsSection: {
         type: GraphQLBoolean,
         resolve: ({ display_artists_section }) => display_artists_section,
+      },
+      partnerArtist: {
+        type: PartnerArtistType,
+        args: {
+          artistID: {
+            type: new GraphQLNonNull(GraphQLString),
+          },
+        },
+        resolve: ({ id }, { artistID }, { partnerArtistLoader }) => {
+          partnerArtistLoader({ artist_id: artistID, partner_id: id })
+        },
       },
       profileArtistsLayout: {
         type: GraphQLString,

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -28,10 +28,7 @@ import { ResolverContext } from "types/graphql"
 import { PartnerCategoryType } from "./partner_category"
 import ShowSorts from "./sorts/show_sorts"
 import ArtistSorts from "./sorts/artist_sorts"
-import {
-  fields as partnerArtistFields,
-  PartnerArtistType,
-} from "./partner_artist"
+import { fields as partnerArtistFields } from "./partner_artist"
 import {
   connectionWithCursorInfo,
   createPageCursors,
@@ -435,17 +432,6 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       displayArtistsSection: {
         type: GraphQLBoolean,
         resolve: ({ display_artists_section }) => display_artists_section,
-      },
-      partnerArtist: {
-        type: PartnerArtistType,
-        args: {
-          artistID: {
-            type: new GraphQLNonNull(GraphQLString),
-          },
-        },
-        resolve: ({ id }, { artistID }, { partnerArtistLoader }) => {
-          partnerArtistLoader({ artist_id: artistID, partner_id: id })
-        },
       },
       profileArtistsLayout: {
         type: GraphQLString,


### PR DESCRIPTION
This PR fixes a couple of things related to partner artists:
1. Exposes a way to get a partner artist's displayable biography. We either show the partner-provided biography, or the artsy one based on the `use_default_biography` flag.
2. Adds the `artistIDs` and `displayOnPartnerProfile` parameters to the `artistsConnection` under a partner so that we're able to retrieve a single, displayable partner artist edge.
<img width="1337" alt="image" src="https://user-images.githubusercontent.com/2081340/115562097-2c724080-a284-11eb-8ff6-937cbec8ece8.png">
