### PR TITLE
Add shipping fees to artwork type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1292,6 +1292,9 @@ type Artwork implements Node & Searchable & Sellable {
   dimensions: dimensions
   displayLabel: String
   displayPriceRange: Boolean
+
+  # Domestic shipping fee.
+  domesticShippingFee: Money
   editionNumber: String
   editionOf: String
   editionSet(id: String!): EditionSet
@@ -1336,6 +1339,9 @@ type Artwork implements Node & Searchable & Sellable {
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
+
+  # International shipping fee.
+  internationalShippingFee: Money
 
   # Private text field for partner use
   inventoryId: String

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -1766,6 +1766,178 @@ describe("Artwork type", () => {
     })
   })
 
+  describe("#domesticShippingFee", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          domesticShippingFee {
+            major
+            minor
+            currencyCode
+          }
+        }
+      }
+    `
+
+    it("returns domestic shipping fee as a Money type", () => {
+      artwork.domestic_shipping_fee_cents = 10000
+      artwork.price_currency = "USD"
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            domesticShippingFee: {
+              currencyCode: "USD",
+              major: 100,
+              minor: 10000,
+            },
+          },
+        })
+      })
+    })
+
+    it("supports 0", () => {
+      artwork.domestic_shipping_fee_cents = 0
+      artwork.price_currency = "USD"
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            domesticShippingFee: {
+              currencyCode: "USD",
+              major: 0,
+              minor: 0,
+            },
+          },
+        })
+      })
+    })
+
+    it("supports non-fractional currency", () => {
+      artwork.domestic_shipping_fee_cents = 10000
+      artwork.price_currency = "JPY"
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            domesticShippingFee: {
+              currencyCode: "JPY",
+              major: 10000,
+              minor: 10000,
+            },
+          },
+        })
+      })
+    })
+
+    it("returns null with no domestic_shipping_fee_cents", () => {
+      artwork.domestic_shipping_fee_cents = null
+      artwork.price_currency = "USD"
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            domesticShippingFee: null,
+          },
+        })
+      })
+    })
+
+    it("returns null with no price_currency", () => {
+      artwork.domestic_shipping_fee_cents = 10000
+      artwork.price_currency = null
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            domesticShippingFee: null,
+          },
+        })
+      })
+    })
+  })
+
+  describe("#internationalShippingFee", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          internationalShippingFee {
+            major
+            minor
+            currencyCode
+          }
+        }
+      }
+    `
+
+    it("returns international shipping fee as a Money type", () => {
+      artwork.international_shipping_fee_cents = 10000
+      artwork.price_currency = "USD"
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            internationalShippingFee: {
+              currencyCode: "USD",
+              major: 100,
+              minor: 10000,
+            },
+          },
+        })
+      })
+    })
+
+    it("supports 0", () => {
+      artwork.international_shipping_fee_cents = 0
+      artwork.price_currency = "USD"
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            internationalShippingFee: {
+              currencyCode: "USD",
+              major: 0,
+              minor: 0,
+            },
+          },
+        })
+      })
+    })
+
+    it("supports non-fractional currency", () => {
+      artwork.international_shipping_fee_cents = 10000
+      artwork.price_currency = "JPY"
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            internationalShippingFee: {
+              currencyCode: "JPY",
+              major: 10000,
+              minor: 10000,
+            },
+          },
+        })
+      })
+    })
+
+    it("returns null with no international_shipping_fee_cents", () => {
+      artwork.international_shipping_fee_cents = null
+      artwork.price_currency = "USD"
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            internationalShippingFee: null,
+          },
+        })
+      })
+    })
+
+    it("returns null with no price_currency", () => {
+      artwork.international_shipping_fee_cents = 10000
+      artwork.price_currency = null
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            internationalShippingFee: null,
+          },
+        })
+      })
+    })
+  })
+
   describe("#shippingInfo", () => {
     const query = `
       {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -655,6 +655,30 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           )
         },
       },
+      domesticShippingFee: {
+        type: Money,
+        description: "Domestic shipping fee.",
+        resolve: ({
+          domestic_shipping_fee_cents: cents,
+          price_currency: currency,
+        }) => {
+          if (typeof cents !== "number" || !currency) return null
+
+          return { cents, currency }
+        },
+      },
+      internationalShippingFee: {
+        type: Money,
+        description: "International shipping fee.",
+        resolve: ({
+          international_shipping_fee_cents: cents,
+          price_currency: currency,
+        }) => {
+          if (typeof cents !== "number" || !currency) return null
+
+          return { cents, currency }
+        },
+      },
       shippingInfo: {
         type: GraphQLString,
         description:


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PURCHASE-2573

This exposes `domesticShippingFee` and `internationalShippingFee` on `Artwork` type as `Money` type. CMS can use it to determine if the artwork of an inquiry order has sufficient metadata for partners to "counter" an offer that'd be transactable.

For artwork location, I think we can rely on the existing [`shippingOrigin`](https://github.com/artsy/gravity/blob/0a9e0da15053c7935d9f9051b9175ec34f34dbd6/app/models/domain/artwork.rb#L1223) field.

![Screen Shot 2021-04-21 at 5 42 37 PM](https://user-images.githubusercontent.com/796573/115624695-fb682f00-a2c8-11eb-978d-855b2ff8bc49.png)

