### PR TITLE
fix(pagination): returns correct offset when using page based pagination

### DIFF
--- a/src/lib/__tests__/helpers.test.ts
+++ b/src/lib/__tests__/helpers.test.ts
@@ -9,6 +9,7 @@ import {
   toKey,
   toQueryString,
   unescapeEntities,
+  convertConnectionArgsToGravityArgs,
 } from "lib/helpers"
 
 describe("exclude", () => {
@@ -214,5 +215,62 @@ describe("unescapeEntities", () => {
     expect(unescapeEntities(input)).toEqual(
       "i daren't; i'm is 42\" tall & the hoop is 10' high"
     )
+  })
+})
+
+describe("convertConnectionArgsToGravityArgs", () => {
+  it("works with page-based pagination", () => {
+    expect(convertConnectionArgsToGravityArgs({ page: 1, first: 30 })).toEqual({
+      page: 1,
+      offset: 0,
+      size: 30,
+    })
+
+    expect(convertConnectionArgsToGravityArgs({ page: 2, first: 30 })).toEqual({
+      page: 2,
+      offset: 30,
+      size: 30,
+    })
+
+    expect(convertConnectionArgsToGravityArgs({ page: 3, first: 30 })).toEqual({
+      page: 3,
+      offset: 60,
+      size: 30,
+    })
+  })
+
+  it("works with cursor-based pagination", () => {
+    expect(
+      convertConnectionArgsToGravityArgs({
+        after: "YXJyYXljb25uZWN0aW9uOi0x",
+        first: 30,
+      })
+    ).toEqual({
+      page: 1,
+      offset: 0,
+      size: 30,
+    })
+
+    expect(
+      convertConnectionArgsToGravityArgs({
+        after: "YXJyYXljb25uZWN0aW9uOjI5",
+        first: 30,
+      })
+    ).toEqual({
+      page: 2,
+      offset: 30,
+      size: 30,
+    })
+
+    expect(
+      convertConnectionArgsToGravityArgs({
+        after: "YXJyYXljb25uZWN0aW9uOjU5",
+        first: 30,
+      })
+    ).toEqual({
+      page: 3,
+      offset: 60,
+      size: 30,
+    })
   })
 })

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -514,8 +514,6 @@ const filterArtworksConnectionTypeFactory = (
       aggregations,
     }
 
-    if (!!options.page) gravityOptions.page = options.page
-
     // Support queries that show all mediums using the medium param.
     // If you specify "*" it results in metaphysics removing the query option
     // making the graphQL queries between all and a subset of mediums the same shape.


### PR DESCRIPTION
Draft because this is sort of incorrect but I'm a little unsure about alternatives.

The problem here is that where ever we use `page=n` based pagination we're never getting a correct offset back from this function. We throw away most of the object and just use that `offset` for the `sliceStart` which is then always zero. The result is that `hasNextPage` is never `false` (unless `first` happens to be more than the total amount of items on the first page).

The alternative would be to manually investigate every place we're using this function (~80) and correctly calculate the offset in place.

I'm more or less fine with this — add a spec or two and this fixes the root issue. It's just ugly.

------

You can replicate this issue by querying pretty much anything that has pagination and switching between page based/cursor based.

Should not have a next page:

```graphql
{
  show(id: "galeria-miguel-nabinho-pinturas-de-paisagem") {
    filterArtworksConnection(first: 10, page: 7) {
      counts {
        total
      }
      pageInfo {
        hasNextPage
      }
      edges {
        node {
          title
        }
      }
    }
  }
}
```

```json
{
  "data": {
    "show": {
      "filterArtworksConnection": {
        "counts": {
          "total": 64
        },
        "pageInfo": {
          "hasNextPage": true
        }
      }
    }
  }
}
```

However:

```graphql
{
  show(id: "galeria-miguel-nabinho-pinturas-de-paisagem") {
    filterArtworksConnection(first: 10, after: "YXJyYXljb25uZWN0aW9uOjU5") {
      counts {
        total
      }
      pageInfo {
        hasNextPage
      }
      pageCursors {
        last {
          cursor
        }
      }
      edges {
        node {
          title
        }
      }
    }
  }
}
```

```json
{
  "data": {
    "show": {
      "filterArtworksConnection": {
        "counts": {
          "total": 64
        },
        "pageInfo": {
          "hasNextPage": false
        },
        "pageCursors": {
          "last": null
        }
      }
    }
  }
}
```