### PR TITLE
feat: add all partner artists connection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8275,6 +8275,13 @@ type PageInfo {
 }
 
 type Partner implements Node {
+  # A connection of all artists from a Partner.
+  allArtistsConnection(
+    displayOnPartnerProfile: Boolean
+    hasNotRepresentedArtistWithPublishedArtworks: Boolean
+    hasPublishedArtworks: Boolean
+    representedBy: Boolean
+  ): ArtistPartnerConnection
   analytics: AnalyticsPartnerStats
 
   # A connection of articles related to a partner.

--- a/src/schema/v2/__tests__/partner.test.js
+++ b/src/schema/v2/__tests__/partner.test.js
@@ -1011,6 +1011,220 @@ describe("Partner type", () => {
     })
   })
 
+  describe("#allArtistsConnection", () => {
+    let artistsResponse
+
+    beforeEach(() => {
+      artistsResponse = [
+        {
+          published_artworks_count: 0,
+          represented_by: true,
+          artist: {
+            id: "jessica-lichtenstein",
+          },
+        },
+        {
+          published_artworks_count: 12,
+          represented_by: true,
+          artist: {
+            id: "yves-klein",
+          },
+        },
+        {
+          published_artworks_count: 10,
+          represented_by: false,
+          artist: {
+            id: "carol-rama",
+          },
+        },
+        {
+          published_artworks_count: 0,
+          represented_by: false,
+          artist: {
+            id: "edozie-anedu",
+          },
+        },
+      ]
+      context = {
+        partnerArtistsForPartnerLoader: () =>
+          Promise.resolve({
+            body: artistsResponse,
+            headers: {
+              "x-total-count": artistsResponse.length,
+            },
+          }),
+        partnerLoader: () => Promise.resolve(partnerData),
+      }
+    })
+
+    it("returns all artists", async () => {
+      const query = gql`
+        {
+          partner(id: "catty-partner") {
+            allArtistsConnection {
+              edges {
+                counts {
+                  artworks
+                }
+                representedBy
+                node {
+                  slug
+                }
+              }
+            }
+          }
+        }
+      `
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        partner: {
+          allArtistsConnection: {
+            edges: [
+              {
+                counts: {
+                  artworks: 0,
+                },
+                representedBy: true,
+                node: {
+                  slug: "jessica-lichtenstein",
+                },
+              },
+              {
+                counts: {
+                  artworks: 12,
+                },
+                representedBy: true,
+                node: {
+                  slug: "yves-klein",
+                },
+              },
+              {
+                counts: {
+                  artworks: 10,
+                },
+                representedBy: false,
+                node: {
+                  slug: "carol-rama",
+                },
+              },
+              {
+                counts: {
+                  artworks: 0,
+                },
+                representedBy: false,
+                node: {
+                  slug: "edozie-anedu",
+                },
+              },
+            ],
+          },
+        },
+      })
+    })
+
+    it("returns all represented artists and not represented artists with published artworks", async () => {
+      const query = gql`
+        {
+          partner(id: "catty-partner") {
+            allArtistsConnection(
+              hasNotRepresentedArtistWithPublishedArtworks: true
+            ) {
+              edges {
+                node {
+                  slug
+                }
+              }
+            }
+          }
+        }
+      `
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        partner: {
+          allArtistsConnection: {
+            edges: [
+              {
+                node: {
+                  slug: "jessica-lichtenstein",
+                },
+              },
+              {
+                node: {
+                  slug: "yves-klein",
+                },
+              },
+              {
+                node: {
+                  slug: "carol-rama",
+                },
+              },
+            ],
+          },
+        },
+      })
+    })
+
+    it("returns artists with published artworks", async () => {
+      const query = gql`
+        {
+          partner(id: "catty-partner") {
+            allArtistsConnection(hasPublishedArtworks: true) {
+              edges {
+                node {
+                  slug
+                }
+              }
+            }
+          }
+        }
+      `
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        partner: {
+          allArtistsConnection: {
+            edges: [
+              {
+                node: {
+                  slug: "yves-klein",
+                },
+              },
+              {
+                node: {
+                  slug: "carol-rama",
+                },
+              },
+            ],
+          },
+        },
+      })
+    })
+
+    it("loads the total count", async () => {
+      const query = gql`
+        {
+          partner(id: "bau-xi-gallery") {
+            allArtistsConnection {
+              totalCount
+            }
+          }
+        }
+      `
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        partner: {
+          allArtistsConnection: {
+            totalCount: 4,
+          },
+        },
+      })
+    })
+  })
+
   describe("#articlesConnection", () => {
     let articlesResponse
 


### PR DESCRIPTION
This PR adds `allArtistsConnection` to the `partner` type. Since we load all artists for the artist list on the client-side we decided with @sweir27  to move the loading logic to the server-side.

![image](https://user-images.githubusercontent.com/79979820/116382768-ef2b2700-a81e-11eb-8681-3c9f829b2293.png)
