### PR TITLE
wip: fetch partner to determine artwork vat completeness

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -220,6 +220,7 @@ export default (accessToken, userID, opts) => {
       { method: "DELETE" }
     ),
     notificationsFeedLoader: gravityLoader("me/notifications/feed"),
+    partnerAllLoader: gravityLoader((id) => `partner/${id}/all`),
     partnerArtworksLoader: gravityLoader(
       (id) => `partner/${id}/artworks`,
       {},

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -767,8 +767,19 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLBoolean,
         description:
           "Based on artwork location verify that VAT info for the partner is complete.",
-        resolve: (artwork) => {
-          return artwork.vat_requirement_complete
+        resolve: async (
+          { vat_required, partner },
+          {},
+          { partnerAllLoader }
+        ) => {
+          if (vat_required == null || _.isEmpty(partner) || !partnerAllLoader)
+            return null
+
+          if (!vat_required) return true
+
+          const { vat_registered } = await partnerAllLoader(partner.id)
+
+          return vat_registered
         },
       },
       pricePaid: {


### PR DESCRIPTION
Open up PRs early and get feedback. I'll work on tests separately.

In https://github.com/artsy/gravity/pull/13995, we exposed a new `vat_requirement_complete` field on `Artwork` json response, and it relies on some fields on the `Partner` model such as `vat_status`. One issue we noticed was that the artwork json response is cached and is not updated when the partner gets updated.

We could invalidate artworks from the partners when, say, the `vat_status` on the partner was updated. But I wonder if it's better to not keep adding this caching complexity.

So this PR follows https://github.com/artsy/gravity/pull/14019 and updates `vatRequirementComplete` to fetch data individually closer to the source. UI can still use the same `vatRequirementComplete` flag and MP will do the heavy lifting.