### PR TITLE
feat(PX-4016): add profileBannerDisplay field to the partner

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8435,6 +8435,7 @@ type Partner implements Node {
   name: String
   profile: Profile
   profileArtistsLayout: String
+  profileBannerDisplay: String
 
   # A connection of shows from a Partner.
   showsConnection(

--- a/src/schema/v2/__tests__/partner.test.js
+++ b/src/schema/v2/__tests__/partner.test.js
@@ -14,6 +14,7 @@ describe("Partner type", () => {
       has_full_profile: true,
       profile_banner_display: true,
       distinguish_represented_artists: true,
+      profile_banner_display: "Artworks",
       partner_categories: [
         {
           id: "blue-chip",
@@ -44,6 +45,23 @@ describe("Partner type", () => {
     expect(data).toEqual({
       partner: {
         distinguishRepresentedArtists: true,
+      },
+    })
+  })
+
+  it("returns profileBannerDisplay field", async () => {
+    const query = gql`
+      {
+        partner(id: "catty-partner") {
+          profileBannerDisplay
+        }
+      }
+    `
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      partner: {
+        profileBannerDisplay: "Artworks",
       },
     })
   })

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -577,6 +577,10 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLBoolean,
         resolve: ({ display_artists_section }) => display_artists_section,
       },
+      profileBannerDisplay: {
+        type: GraphQLString,
+        resolve: ({ profile_banner_display }) => profile_banner_display,
+      },
       profileArtistsLayout: {
         type: GraphQLString,
         resolve: ({ profile_artists_layout }) => profile_artists_layout,


### PR DESCRIPTION
This PR adds profileBannerDisplay field to the partner. This field indicates what type of banner should be shown on the partner page.

JIRA - https://artsyproduct.atlassian.net/browse/PX-4016

![image](https://user-images.githubusercontent.com/79979820/116978904-fe9dea80-accc-11eb-8d3f-bd6c9701f99c.png)
