### PR TITLE
feat: raise staging min pod count to 2.

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -94,7 +94,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: metaphysics-web
-  minReplicas: 1
+  minReplicas: 2
   maxReplicas: 3
   targetCPUUtilizationPercentage: 80
 


### PR DESCRIPTION
https://artsy.slack.com/archives/CA8SANW3W/p1620140319056400

So that the service does not go down when cluster-autoscaler evicts one pod (when removing a k8s node for cluster scale-down).

For most apps we are okay with min pod count of 1 and once in a while service down. But MP is important so let's up it.