### PR TITLE
fix(resized): correctly handles situations where we pass both a width and a height

### DIFF
--- a/src/schema/v2/image/__tests__/resized.test.ts
+++ b/src/schema/v2/image/__tests__/resized.test.ts
@@ -2,74 +2,161 @@ import { resizedImageUrl } from "schema/v2/image/resized"
 
 describe("Image", () => {
   describe("resizedImageUrl", () => {
-    const image = {
-      original_height: 2333,
-      original_width: 3500,
-      image_url: "https://xxx.cloudfront.net/xxx/:version.jpg",
-      image_versions: ["large"],
-    }
+    describe("landscape input", () => {
+      const LANDSCAPE_IMAGE = {
+        original_height: 2333,
+        original_width: 3500,
+        image_url: "https://xxx.cloudfront.net/xxx/:version.jpg",
+        image_versions: ["large"],
+      }
 
-    it("takes an image response with options and resizes it to fit (landscape)", () => {
-      const url1x =
-        "https://gemini.cloudfront.test?resize_to=fit&width=500&height=333&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
-      const url2x =
-        "https://gemini.cloudfront.test?resize_to=fit&width=1000&height=666&quality=50&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
+      it("takes an image response with options and resizes it to fit (landscape)", () => {
+        const url1x =
+          "https://gemini.cloudfront.test?resize_to=fit&width=500&height=333&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
+        const url2x =
+          "https://gemini.cloudfront.test?resize_to=fit&width=1000&height=666&quality=50&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
 
-      expect(resizedImageUrl(image, { width: 500, height: 500 })).toEqual({
-        factor: 0.14285714285714285,
-        height: 333,
-        width: 500,
-        url: url1x,
-        src: url1x,
-        srcSet: `${url1x} 1x, ${url2x} 2x`,
+        expect(
+          resizedImageUrl(LANDSCAPE_IMAGE, { width: 500, height: 500 })
+        ).toEqual({
+          factor: 0.14285714285714285,
+          height: 333,
+          width: 500,
+          url: url1x,
+          src: url1x,
+          srcSet: `${url1x} 1x, ${url2x} 2x`,
+        })
+      })
+
+      it("takes an image response with options and resizes it to fit (portrait)", () => {
+        const url1x =
+          "https://gemini.cloudfront.test?resize_to=fit&width=500&height=333&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
+        const url2x =
+          "https://gemini.cloudfront.test?resize_to=fit&width=1000&height=666&quality=50&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
+
+        expect(
+          resizedImageUrl(LANDSCAPE_IMAGE, { width: 500, height: 500 })
+        ).toEqual({
+          factor: 0.14285714285714285,
+          height: 333,
+          width: 500,
+          url: url1x,
+          src: url1x,
+          srcSet: `${url1x} 1x, ${url2x} 2x`,
+        })
+      })
+
+      it("takes an image response with options and resizes it to fit (square)", () => {
+        const url1x =
+          "https://gemini.cloudfront.test?resize_to=fit&width=300&height=199&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
+        const url2x =
+          "https://gemini.cloudfront.test?resize_to=fit&width=600&height=398&quality=50&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
+
+        expect(
+          resizedImageUrl(LANDSCAPE_IMAGE, { width: 300, height: 300 })
+        ).toEqual({
+          factor: 0.08571428571428572,
+          height: 199,
+          width: 300,
+          url: url1x,
+          src: url1x,
+          srcSet: `${url1x} 1x, ${url2x} 2x`,
+        })
+      })
+
+      it("takes an image response with options (just one dimension) and resizes it to fit", () => {
+        const url1x =
+          "https://gemini.cloudfront.test?resize_to=fit&width=500&height=333&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
+        const url2x =
+          "https://gemini.cloudfront.test?resize_to=fit&width=1000&height=666&quality=50&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
+
+        expect(resizedImageUrl(LANDSCAPE_IMAGE, { width: 500 })).toEqual({
+          factor: 0.14285714285714285,
+          height: 333,
+          width: 500,
+          url: url1x,
+          src: url1x,
+          srcSet: `${url1x} 1x, ${url2x} 2x`,
+        })
       })
     })
 
-    it("takes an image response with options and resizes it to fit (portrait)", () => {
-      const url1x =
-        "https://gemini.cloudfront.test?resize_to=fit&width=500&height=333&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
-      const url2x =
-        "https://gemini.cloudfront.test?resize_to=fit&width=1000&height=666&quality=50&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
+    describe("portrait input", () => {
+      const PORTRAIT_IMAGE = {
+        original_height: 3500,
+        original_width: 2333,
+        image_url: "https://xxx.cloudfront.net/xxx/:version.jpg",
+        image_versions: ["large"],
+      }
 
-      expect(resizedImageUrl(image, { width: 500, height: 500 })).toEqual({
-        factor: 0.14285714285714285,
-        height: 333,
-        width: 500,
-        url: url1x,
-        src: url1x,
-        srcSet: `${url1x} 1x, ${url2x} 2x`,
+      it("takes an image response with options and resizes it to fit (landscape)", () => {
+        const url1x =
+          "https://gemini.cloudfront.test?resize_to=fit&width=333&height=500&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
+        const url2x =
+          "https://gemini.cloudfront.test?resize_to=fit&width=666&height=1000&quality=50&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
+
+        expect(
+          resizedImageUrl(PORTRAIT_IMAGE, { width: 500, height: 500 })
+        ).toEqual({
+          factor: 0.14285714285714285,
+          height: 500,
+          width: 333,
+          url: url1x,
+          src: url1x,
+          srcSet: `${url1x} 1x, ${url2x} 2x`,
+        })
       })
-    })
 
-    it("takes an image response with options and resizes it to fit (square)", () => {
-      const url1x =
-        "https://gemini.cloudfront.test?resize_to=fit&width=300&height=199&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
-      const url2x =
-        "https://gemini.cloudfront.test?resize_to=fit&width=600&height=398&quality=50&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
+      it("takes an image response with options and resizes it to fit (portrait)", () => {
+        const url1x =
+          "https://gemini.cloudfront.test?resize_to=fit&width=333&height=500&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
+        const url2x =
+          "https://gemini.cloudfront.test?resize_to=fit&width=666&height=1000&quality=50&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
 
-      expect(resizedImageUrl(image, { width: 300, height: 300 })).toEqual({
-        factor: 0.08571428571428572,
-        height: 199,
-        width: 300,
-        url: url1x,
-        src: url1x,
-        srcSet: `${url1x} 1x, ${url2x} 2x`,
+        expect(
+          resizedImageUrl(PORTRAIT_IMAGE, { width: 500, height: 500 })
+        ).toEqual({
+          factor: 0.14285714285714285,
+          height: 500,
+          width: 333,
+          url: url1x,
+          src: url1x,
+          srcSet: `${url1x} 1x, ${url2x} 2x`,
+        })
       })
-    })
 
-    it("takes an image response with options (just one dimension) and resizes it to fit", () => {
-      const url1x =
-        "https://gemini.cloudfront.test?resize_to=fit&width=500&height=333&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
-      const url2x =
-        "https://gemini.cloudfront.test?resize_to=fit&width=1000&height=666&quality=50&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
+      it("takes an image response with options and resizes it to fit (square)", () => {
+        const url1x =
+          "https://gemini.cloudfront.test?resize_to=fit&width=199&height=300&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
+        const url2x =
+          "https://gemini.cloudfront.test?resize_to=fit&width=398&height=600&quality=50&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
 
-      expect(resizedImageUrl(image, { width: 500 })).toEqual({
-        factor: 0.14285714285714285,
-        height: 333,
-        width: 500,
-        url: url1x,
-        src: url1x,
-        srcSet: `${url1x} 1x, ${url2x} 2x`,
+        expect(
+          resizedImageUrl(PORTRAIT_IMAGE, { width: 300, height: 300 })
+        ).toEqual({
+          factor: 0.08571428571428572,
+          height: 300,
+          width: 199,
+          url: url1x,
+          src: url1x,
+          srcSet: `${url1x} 1x, ${url2x} 2x`,
+        })
+      })
+
+      it("takes an image response with options (just one dimension) and resizes it to fit", () => {
+        const url1x =
+          "https://gemini.cloudfront.test?resize_to=fit&width=499&height=750&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
+        const url2x =
+          "https://gemini.cloudfront.test?resize_to=fit&width=998&height=1500&quality=50&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
+
+        expect(resizedImageUrl(PORTRAIT_IMAGE, { width: 500 })).toEqual({
+          factor: 0.2143163309044149,
+          height: 750,
+          width: 499,
+          url: url1x,
+          src: url1x,
+          srcSet: `${url1x} 1x, ${url2x} 2x`,
+        })
       })
     })
 

--- a/src/schema/v2/image/resized.ts
+++ b/src/schema/v2/image/resized.ts
@@ -1,4 +1,4 @@
-import { scale } from "proportional-scale"
+import { MaxDimensions, scale } from "proportional-scale"
 import proxy from "./proxies"
 import { setVersion } from "./normalize"
 import {
@@ -55,9 +55,19 @@ export const resizedImageUrl = (
     }
   }
 
-  const scaleTo = !!targetWidth
-    ? { maxWidth: targetWidth! }
-    : { maxHeight: targetHeight! }
+  // This will always have either a width, height or both — the incoming
+  // types are slightly incorrect.
+  // @ts-ignore
+  const scaleTo: MaxDimensions = (() => {
+    switch (true) {
+      case targetWidth !== undefined && targetHeight !== undefined:
+        return { maxWidth: targetWidth, maxHeight: targetHeight }
+      case targetWidth !== undefined:
+        return { maxWidth: targetWidth }
+      case targetHeight !== undefined:
+        return { maxHeight: targetHeight }
+    }
+  })()
 
   const scaled = scale({
     width: originalWidth ?? 0,


### PR DESCRIPTION
Going to add a spec here before merging.

I'm really weirded out this is the first time I'm running into this bug.

I noticed that passing both a width and a height was returning images resized favoring width:
![](https://static.damonzucconi.com/_capture/JtBHwE3f.png)

Specifying both a width and a height should return an image resized proportionally within those max dimensions:
![](https://static.damonzucconi.com/_capture/Wk6nNQS5.png)

Now, for the most part we should be OK in terms of what this breaks. This is definitely the correct and desired behavior, and there's no real way to tell other than let issues shake out if they present themselves. I say we make the change and I can just run through staging and adjust any values that we run into.