### PR TITLE
fix(PX-4044): rename isNonSubscriber to fullProfileEligible

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8488,6 +8488,7 @@ type Partner implements Node {
     tagID: String
     width: String
   ): FilterArtworksConnection
+  fullProfileEligible: Boolean
   hasFairPartnership: Boolean
   href: String
 
@@ -8499,7 +8500,6 @@ type Partner implements Node {
   internalID: ID!
   isDefaultProfilePublic: Boolean
   isLinkable: Boolean
-  isNonSubscriber: Boolean
   isPreQualify: Boolean
 
   # Indicates the partner is a trusted seller on Artsy

--- a/src/schema/v2/__tests__/partner.test.js
+++ b/src/schema/v2/__tests__/partner.test.js
@@ -103,11 +103,11 @@ describe("Partner type", () => {
     })
   })
 
-  it("returns isNonSubscriber field", async () => {
+  it("returns fullProfileEligible field", async () => {
     const query = gql`
       {
         partner(id: "catty-partner") {
-          isNonSubscriber
+          fullProfileEligible
         }
       }
     `
@@ -115,7 +115,7 @@ describe("Partner type", () => {
 
     expect(data).toEqual({
       partner: {
-        isNonSubscriber: true,
+        fullProfileEligible: false,
       },
     })
   })

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -521,10 +521,10 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLBoolean,
         resolve: ({ show_promoted }) => show_promoted,
       },
-      isNonSubscriber: {
+      fullProfileEligible: {
         type: GraphQLBoolean,
-        // TODO: get rid of using profile_layout to determine non-subscriber profile after Gravity API updated
-        resolve: ({ profile_layout }) => profile_layout === "gallery_default",
+        // TODO: get rid of using profile_layout to determine fullProfileEligible after Gravity API updated
+        resolve: ({ profile_layout }) => profile_layout !== "gallery_default",
       },
       locations: {
         type: new GraphQLList(LocationType),


### PR DESCRIPTION
Renamed `isNonSubscriber` field to `fullProfileEligible` according to the comment: https://github.com/artsy/force/pull/7502#discussion_r629800741

![image](https://user-images.githubusercontent.com/79979820/117937152-59a79100-b30e-11eb-9ef0-8eaa54c39cb2.png)
