### PR TITLE
feature: Set 2x Images to Use 50 Quality

### DIFF
--- a/src/schema/v2/image/__tests__/cropped.test.ts
+++ b/src/schema/v2/image/__tests__/cropped.test.ts
@@ -12,7 +12,7 @@ describe("Image", () => {
       const url1x =
         "https://gemini.cloudfront.test?resize_to=fill&width=500&height=500&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
       const url2x =
-        "https://gemini.cloudfront.test?resize_to=fill&width=1000&height=1000&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
+        "https://gemini.cloudfront.test?resize_to=fill&width=1000&height=1000&quality=50&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
 
       expect(croppedImageUrl(image, { width: 500, height: 500 })).toEqual({
         width: 500,
@@ -27,7 +27,7 @@ describe("Image", () => {
       const url1x =
         "https://gemini.cloudfront.test?resize_to=fill&width=500&height=500&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Fcat.jpg"
       const url2x =
-        "https://gemini.cloudfront.test?resize_to=fill&width=1000&height=1000&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Fcat.jpg"
+        "https://gemini.cloudfront.test?resize_to=fill&width=1000&height=1000&quality=50&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Fcat.jpg"
       const bareImageUrl = normalize("https://xxx.cloudfront.net/xxx/cat.jpg")
 
       expect(

--- a/src/schema/v2/image/__tests__/resized.test.ts
+++ b/src/schema/v2/image/__tests__/resized.test.ts
@@ -13,7 +13,7 @@ describe("Image", () => {
       const url1x =
         "https://gemini.cloudfront.test?resize_to=fit&width=500&height=333&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
       const url2x =
-        "https://gemini.cloudfront.test?resize_to=fit&width=1000&height=666&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
+        "https://gemini.cloudfront.test?resize_to=fit&width=1000&height=666&quality=50&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
 
       expect(resizedImageUrl(image, { width: 500, height: 500 })).toEqual({
         factor: 0.14285714285714285,
@@ -29,7 +29,7 @@ describe("Image", () => {
       const url1x =
         "https://gemini.cloudfront.test?resize_to=fit&width=500&height=333&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
       const url2x =
-        "https://gemini.cloudfront.test?resize_to=fit&width=1000&height=666&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
+        "https://gemini.cloudfront.test?resize_to=fit&width=1000&height=666&quality=50&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
 
       expect(resizedImageUrl(image, { width: 500, height: 500 })).toEqual({
         factor: 0.14285714285714285,
@@ -45,7 +45,7 @@ describe("Image", () => {
       const url1x =
         "https://gemini.cloudfront.test?resize_to=fit&width=300&height=199&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
       const url2x =
-        "https://gemini.cloudfront.test?resize_to=fit&width=600&height=398&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
+        "https://gemini.cloudfront.test?resize_to=fit&width=600&height=398&quality=50&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
 
       expect(resizedImageUrl(image, { width: 300, height: 300 })).toEqual({
         factor: 0.08571428571428572,
@@ -61,7 +61,7 @@ describe("Image", () => {
       const url1x =
         "https://gemini.cloudfront.test?resize_to=fit&width=500&height=333&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
       const url2x =
-        "https://gemini.cloudfront.test?resize_to=fit&width=1000&height=666&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
+        "https://gemini.cloudfront.test?resize_to=fit&width=1000&height=666&quality=50&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
 
       expect(resizedImageUrl(image, { width: 500 })).toEqual({
         factor: 0.14285714285714285,
@@ -77,7 +77,7 @@ describe("Image", () => {
       const url1x =
         "https://gemini.cloudfront.test?resize_to=fit&width=500&height=500&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
       const url2x =
-        "https://gemini.cloudfront.test?resize_to=fit&width=1000&height=1000&quality=80&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
+        "https://gemini.cloudfront.test?resize_to=fit&width=1000&height=1000&quality=50&src=https%3A%2F%2Fxxx.cloudfront.net%2Fxxx%2Flarge.jpg"
 
       expect(
         resizedImageUrl(

--- a/src/schema/v2/image/cropped.ts
+++ b/src/schema/v2/image/cropped.ts
@@ -32,7 +32,7 @@ export const croppedImageUrl = (
   const src = setVersion(image as any, version)
 
   const url1x = proxy(src, "crop", width, height)
-  const url2x = proxy(src, "crop", width * 2, height * 2)
+  const url2x = proxy(src, "crop", width * 2, height * 2, 50)
 
   return {
     width,

--- a/src/schema/v2/image/resized.ts
+++ b/src/schema/v2/image/resized.ts
@@ -73,7 +73,8 @@ export const resizedImageUrl = (
     src,
     "resize",
     (proxiedWidth || 0) * 2 || undefined,
-    (proxiedHeight || 0) * 2 || undefined
+    (proxiedHeight || 0) * 2 || undefined,
+    50
   )
 
   return {


### PR DESCRIPTION
This change should brings the 2x image urls that are generated in
metaphysics in line with the recent changes to force.