### PR TITLE
feat(PX-4027): extend partner connection to support filtering by nearby galleries

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9668,9 +9668,17 @@ type Query {
   partnersConnection(
     after: String
     before: String
+    defaultProfilePublic: Boolean
+
+    # Indicates an active subscription
+    eligibleForListing: Boolean
     first: Int
     ids: [String]
     last: Int
+
+    # Coordinates to find partners closest to
+    near: String
+    sort: PartnersSortType
   ): PartnerConnection
 
   # Get all price insights for an artist.
@@ -12079,9 +12087,17 @@ type Viewer {
   partnersConnection(
     after: String
     before: String
+    defaultProfilePublic: Boolean
+
+    # Indicates an active subscription
+    eligibleForListing: Boolean
     first: Int
     ids: [String]
     last: Int
+
+    # Coordinates to find partners closest to
+    near: String
+    sort: PartnersSortType
   ): PartnerConnection
 
   # A Sale

--- a/src/schema/v2/partners.ts
+++ b/src/schema/v2/partners.ts
@@ -139,40 +139,36 @@ export const Partners: GraphQLFieldConfig<void, ResolverContext> = {
 export const PartnersConnection: GraphQLFieldConfig<void, ResolverContext> = {
   type: connectionWithCursorInfo({ nodeType: PartnerType }).connectionType,
   description: "A list of Partners",
-  args: pageable(
-    Object.assign(
-      {
-        ids: {
-          type: new GraphQLList(GraphQLString),
-        },
-      },
-      pick(
-        Partners.args,
-        "near",
-        "eligibleForListing",
-        "defaultProfilePublic",
-        "sort"
-      )
-    )
-  ),
-  resolve: (_root, { ..._options }, { partnersLoader }) => {
-    const { page, size } = convertConnectionArgsToGravityArgs(_options)
-    const options: any = {
-      id: _options.ids,
+  args: pageable({
+    ids: {
+      type: new GraphQLList(GraphQLString),
+    },
+    ...pick(
+      Partners.args,
+      "near",
+      "eligibleForListing",
+      "defaultProfilePublic",
+      "sort"
+    ),
+  }),
+  resolve: (_root, options, { partnersLoader }) => {
+    const { page, size } = convertConnectionArgsToGravityArgs(options)
+    const gravityArgs: any = {
+      id: options.ids,
       page,
       size,
-      near: _options.near,
-      eligible_for_listing: _options.eligibleForListing,
-      default_profile_public: _options.defaultProfilePublic,
-      sort: _options.sort,
+      near: options.near,
+      eligible_for_listing: options.eligibleForListing,
+      default_profile_public: options.defaultProfilePublic,
+      sort: options.sort,
     }
 
-    return partnersLoader(options).then((body) => {
+    return partnersLoader(gravityArgs).then((body) => {
       const totalCount = body.length
       return {
         totalCount,
         pageCursors: createPageCursors({ page, size }, totalCount),
-        ...connectionFromArray(body, options),
+        ...connectionFromArray(body, gravityArgs),
       }
     })
   },

--- a/src/schema/v2/partners.ts
+++ b/src/schema/v2/partners.ts
@@ -1,4 +1,4 @@
-import { clone } from "lodash"
+import { clone, pick } from "lodash"
 import Partner, { PartnerType } from "./partner"
 import PartnerTypeType from "./input_fields/partner_type_type"
 import {
@@ -139,17 +139,32 @@ export const Partners: GraphQLFieldConfig<void, ResolverContext> = {
 export const PartnersConnection: GraphQLFieldConfig<void, ResolverContext> = {
   type: connectionWithCursorInfo({ nodeType: PartnerType }).connectionType,
   description: "A list of Partners",
-  args: pageable({
-    ids: {
-      type: new GraphQLList(GraphQLString),
-    },
-  }),
+  args: pageable(
+    Object.assign(
+      {
+        ids: {
+          type: new GraphQLList(GraphQLString),
+        },
+      },
+      pick(
+        Partners.args,
+        "near",
+        "eligibleForListing",
+        "defaultProfilePublic",
+        "sort"
+      )
+    )
+  ),
   resolve: (_root, { ..._options }, { partnersLoader }) => {
     const { page, size } = convertConnectionArgsToGravityArgs(_options)
     const options: any = {
       id: _options.ids,
       page,
       size,
+      near: _options.near,
+      eligible_for_listing: _options.eligibleForListing,
+      default_profile_public: _options.defaultProfilePublic,
+      sort: _options.sort,
     }
 
     return partnersLoader(options).then((body) => {


### PR DESCRIPTION
This PR adds new arguments to the `partnersConnection` to support filtering by nearby galleries. V2 schema didn't have any query that I can use to get nearby galleries so I extended partnersConnection and added the same arguments as for [galleries page](https://staging.artsy.net/galleries) ([query](https://github.com/artsy/force/blob/94df9ba495f88bed2b466d682b045c23907f0088/src/desktop/apps/galleries_institutions/queries/partners_filter_query.coffee#L15-L20))

JIRA - https://artsyproduct.atlassian.net/browse/PX-4027

![image](https://user-images.githubusercontent.com/79979820/118525197-9547be00-b747-11eb-982b-9eb126b7e5ec.png)
