### PR TITLE
fix: get principalField working for stitched types

### DIFF
--- a/src/lib/__tests__/graphqlErrorHandler.test.ts
+++ b/src/lib/__tests__/graphqlErrorHandler.test.ts
@@ -152,6 +152,40 @@ describe("graphqlErrorHandler", () => {
           ).extensions
         ).toEqual({ httpStatusCodes: [404, 403] })
       })
+
+      it("propagates HTTP status codes when sent from a stitched backend", () => {
+        const originalError = new GraphQLError("extensions: { code: 404")
+
+        const error = new GraphQLError(
+          "not found",
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          originalError
+        )
+        expect(formattedGraphQLError(error).extensions).toEqual({
+          httpStatusCodes: [404],
+        })
+      })
+
+      it("doesn't propagate status codes when none match", () => {
+        const originalError = new GraphQLError(
+          "something is configured wrong (404)"
+        )
+
+        const error = new GraphQLError(
+          "Unexpected error",
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          originalError
+        )
+        expect(Object.keys(formattedGraphQLError(error))).not.toContain(
+          "extensions"
+        )
+      })
     })
   })
 })


### PR DESCRIPTION
## Main Point

This is not a great or long-term fix. However, it does currently satisfy the issue of getting `@principalField` working (thru proper propagation of HTTP status codes) of stitched backends (collections, artist series, etc.). It also defensive in that it shouldn't cause a crash of its own (famous last words...), but exists as a fallback to parsing status codes from underlying errors.

Once this is merged and deployed, we can add @principalField to collection and artist series pages, and remove any custom (non-working?!) error page/status code handling.

## Details

When querying GravQL directly w/ an unknown artist series:
<img width="981" alt="Screen Shot 2021-05-18 at 4 06 45 PM" src="https://user-images.githubusercontent.com/1457859/118716657-14de9700-b7f3-11eb-9eff-c0f8788d8ad1.png">

When querying KAWS directly w/ an unknown collection:
<img width="879" alt="Screen Shot 2021-05-18 at 4 08 13 PM" src="https://user-images.githubusercontent.com/1457859/118716836-46eff900-b7f3-11eb-95a7-88b86187ca66.png">

Everything looks good!

However, there is some code in `graphql-tools` that incorrectly parses those into a string:

<img width="974" alt="Screen Shot 2021-05-18 at 4 09 07 PM" src="https://user-images.githubusercontent.com/1457859/118716917-6424c780-b7f3-11eb-8157-400667cb6cd1.png">

That's....really bad 😓 

I went thru a bit of a rabbit hole with `graphql-tools`. We are now a total of 4(!) major versions behind current, and we also have a non trivial patch applied at our current version, which prevents any easy updates: https://github.com/artsy/metaphysics/blob/3abb99453c82f253d7e5de354e029d4126f76dcf/patches/graphql-tools%2B4.0.5.patch

I didn't get very far, and I think upgrading our stitching setup and associated tools via the Apollo libs should be brought up at the next web practice.

We have some unit tests that essentially use fixtures and so don't recreate the munging of errors that occurs at a different layer of the stack, I added to those in a basic way for this new fallback, but they're of limited use, generally.