### PR TITLE
chore: add sponsored content for Art Basel Hong Kong 2021

### DIFF
--- a/src/lib/sponsoredContent/data.json
+++ b/src/lib/sponsoredContent/data.json
@@ -100,6 +100,9 @@
     "art-basel-ovr-2020": {
       "activationText": "In collaboration with Acute Art, leading producer of visionary virtual and augmented reality (AR) artworks, and Lu Yang, BMW will present a new AR work where “DOKU”, the artist’s digital avatar, takes over the physical world in the form of a giant dancing superhero. The installation, titled “Gigant DOKU”, is developed by a game engine and incorporates motion capture image data from Tokyo and Bali gathered during the artist’s BMW Art Journey.",
       "pressReleaseUrl": "https://www.press.bmwgroup.com/global/article/detail/T0321554EN/bmw-announces-collaboration-with-acute-art-to-realize-a-project-with-bmw-art-journey-awardee-lu-yang-lu-yang-presents-latest-artworks-in-art-basel-s-%E2%80%9Covr:-miami-beach%E2%80%9D"
+    },
+    "art-basel-hong-kong-2021": {
+      "activationText": "From May 21 to May 23, the Art Basel show in Hong Kong will open its doors offering again extensive insights into the modern and contemporary works by emerging and established artists, presented by 242 of the world’s leading galleries. As an official partner of the show BMW will once again provide the VIP shuttle service. Furthermore, the latest BMW Art Journey awardee Leelee Chan will  present her 2020 journey project ‘Tokens from Time’ tracing material culture from the past, present and future and artworks resulting from it at the BMW Wanchai showroom and the Capsule Shanghai booth at the Discoveries sector. On May 20 the BMW Art Journey shortlist 2021 will be announced. Register here to visit Leelee Chan’s exhibition at the BMW Wanchai showroom: https://art.bmwhk.com/exhibition/en/"
     }
   }
 }


### PR DESCRIPTION
Added the activationText but still wating on the pressReleaseURL.