### PR TITLE
feat(CX-1464): add auction results count to the artist interface

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -988,6 +988,7 @@ type ArtistCounts {
     format: String
     label: String
   ): FormattedNumber
+  auctionResults: Int
   ecommerceArtworks(
     # Returns a `String` when format is specified. e.g.`'0,0.0000''`
     format: String

--- a/src/schema/v2/artist/__tests__/index.test.js
+++ b/src/schema/v2/artist/__tests__/index.test.js
@@ -9,6 +9,7 @@ describe("Artist type", () => {
     context = {
       artistLoader: () => artist,
       articlesLoader: () => Promise.resolve({ count: 22 }),
+      auctionLotsLoader: () => Promise.resolve({ total_count: 123 }),
       artistGenesLoader: () => Promise.resolve([{ name: "Foo Bar" }]),
       relatedMainArtistsLoader: () =>
         Promise.resolve({ headers: { "x-total-count": 42 } }),
@@ -101,6 +102,28 @@ describe("Artist type", () => {
         artist: {
           counts: {
             articles: 22,
+          },
+        },
+      })
+    })
+  })
+
+  it("returns the number of auction results for an artist", () => {
+    const query = `
+      {
+        artist(id: "foo-bar") {
+          counts {
+            auctionResults
+          }
+        }
+      }
+    `
+
+    return runQuery(query, context).then((data) => {
+      expect(data).toEqual({
+        artist: {
+          counts: {
+            auctionResults: 123,
           },
         },
       })

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -471,6 +471,15 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
             auctionArtworks: numeral(
               ({ auction_artworks_count }) => auction_artworks_count
             ),
+            auctionResults: {
+              type: GraphQLInt,
+              resolve: ({ _id }, _options, { auctionLotsLoader }) =>
+                auctionLotsLoader({
+                  artist_id: _id,
+                }).then(({ total_count }) => {
+                  return total_count
+                }),
+            },
           },
         }),
         resolve: (artist) => artist,


### PR DESCRIPTION
Jira ticket: https://artsyproduct.atlassian.net/browse/CX-1464

This PR adds the auction results count to the artist interface. This will be useful for us to display the links to the auction results tab for the new price insights feature. @edez1t  The query that we will need to run will look similar to the one in the screenshot below:

<img width="1791" alt="Screenshot 2021-05-26 at 15 30 56" src="https://user-images.githubusercontent.com/11945712/119670911-978dd480-be39-11eb-9bc9-29046e6f134d.png">
