### PR TITLE
fix: Pin TS version 4.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "sinon": "1.17.7",
     "superagent": "3.8.3",
     "supertest": "3.1.0",
-    "typescript": "4.3.2"
+    "typescript": "4.2.4"
   },
   "prettier": {
     "semi": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9984,10 +9984,10 @@ type-is@~1.6.15:
     media-typer "0.3.0"
     mime-types "~2.1.15"
 
-typescript@4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
-  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
+typescript@4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 ua-parser-js@^0.7.18, ua-parser-js@^0.7.9:
   version "0.7.28"


### PR DESCRIPTION
Looks like TS 4.3.2 has some issues 😢 This pins things to 4.2.4, the last good known version. See [this thread](https://artsy.slack.com/archives/CP9P4KR35/p1622232236226000) for some context. 

Related force PR: https://github.com/artsy/force/pull/7658

