### PR TITLE
chore: stitch savedSearch query field from Gravity

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -9774,6 +9774,7 @@ type Me implements Node {
     sort: SaleSorts
   ): [SaleRegistration]
   saved_artworks: Collection
+  savedSearch(criteria: SearchCriteriaAttributes, id: ID): SearchCriteria
   secondFactors(kinds: [SecondFactorKind]): [SecondFactor]
 
   # A list of the current user’s suggested artists, based on a single artist
@@ -11995,6 +11996,12 @@ type Query {
   # Find partners by IDs
   _unused_gravity_partners(ids: [ID!]!): [DoNotUseThisPartner!]
 
+  # Find a saved search by ID or criteria
+  _unused_gravity_savedSearch(
+    criteria: SearchCriteriaAttributes
+    id: ID
+  ): SearchCriteria
+
   # List enabled Two-Factor Authentication factors
   _unused_gravity_secondFactors(
     kinds: [SecondFactorKind!] = [app, sms, backup]
@@ -13494,6 +13501,16 @@ type SearchCriteria {
   attribution: String
   category: String
   internalID: ID!
+  priceMax: Int
+  priceMin: Int
+  size: String
+}
+
+# Attributes for a search criteria
+input SearchCriteriaAttributes {
+  artistID: String
+  attribution: String
+  category: String
   priceMax: Int
   priceMin: Int
   size: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9231,6 +9231,12 @@ type Query {
   # Find partners by IDs
   _unused_gravity_partners(ids: [ID!]!): [DoNotUseThisPartner!]
 
+  # Find a saved search by ID or criteria
+  _unused_gravity_savedSearch(
+    criteria: SearchCriteriaAttributes
+    id: ID
+  ): SearchCriteria
+
   # List enabled Two-Factor Authentication factors
   _unused_gravity_secondFactors(
     kinds: [SecondFactorKind!] = [app, sms, backup]
@@ -10668,6 +10674,16 @@ type SearchCriteria {
   attribution: String
   category: String
   internalID: ID!
+  priceMax: Int
+  priceMin: Int
+  size: String
+}
+
+# Attributes for a search criteria
+input SearchCriteriaAttributes {
+  artistID: String
+  attribution: String
+  category: String
   priceMax: Int
   priceMin: Int
   size: String

--- a/src/data/gravity.graphql
+++ b/src/data/gravity.graphql
@@ -1396,6 +1396,11 @@ type Query {
   saleArtworks(ids: [ID!]!): [SaleArtwork!]!
 
   """
+  Find a saved search by ID or criteria
+  """
+  savedSearch(criteria: SearchCriteriaAttributes, id: ID): SearchCriteria
+
+  """
   List enabled Two-Factor Authentication factors
   """
   secondFactors(
@@ -1709,6 +1714,18 @@ type SearchCriteria {
   attribution: String
   category: String
   internalID: ID!
+  priceMax: Int
+  priceMin: Int
+  size: String
+}
+
+"""
+Attributes for a search criteria
+"""
+input SearchCriteriaAttributes {
+  artistID: String
+  attribution: String
+  category: String
   priceMax: Int
   priceMin: Int
   size: String

--- a/src/lib/stitching/gravity/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/gravity/__tests__/__snapshots__/schema.test.ts.snap
@@ -693,6 +693,9 @@ type Query {
   # Find partners by IDs
   _unused_gravity_partners(ids: [ID!]!): [DoNotUseThisPartner!]
 
+  # Find a saved search by ID or criteria
+  _unused_gravity_savedSearch(criteria: SearchCriteriaAttributes, id: ID): SearchCriteria
+
   # List enabled Two-Factor Authentication factors
   _unused_gravity_secondFactors(kinds: [SecondFactorKind!] = [app, sms, backup]): [SecondFactor!]!
 
@@ -802,6 +805,16 @@ type SearchCriteria {
   attribution: String
   category: String
   internalID: ID!
+  priceMax: Int
+  priceMin: Int
+  size: String
+}
+
+# Attributes for a search criteria
+input SearchCriteriaAttributes {
+  artistID: String
+  attribution: String
+  category: String
   priceMax: Int
   priceMin: Int
   size: String

--- a/src/lib/stitching/gravity/v1/stitching.ts
+++ b/src/lib/stitching/gravity/v1/stitching.ts
@@ -53,6 +53,7 @@ export const gravityStitchingEnvironment = (
     // The SDL used to declare how to stitch an object
     extensionSchema: gql`
       extend type Me {
+        savedSearch(id: ID, criteria: SearchCriteriaAttributes): SearchCriteria
         secondFactors(kinds: [SecondFactorKind]): [SecondFactor]
         addressConnection(
           first: Int
@@ -133,6 +134,18 @@ export const gravityStitchingEnvironment = (
     `,
     resolvers: {
       Me: {
+        savedSearch: {
+          resolve: (_parent, args, context, info) => {
+            return info.mergeInfo.delegateToSchema({
+              schema: gravitySchema,
+              operation: "query",
+              fieldName: "_unused_gravity_savedSearch",
+              args: args,
+              context,
+              info,
+            })
+          },
+        },
         secondFactors: {
           resolve: (_parent, args, context, info) => {
             return info.mergeInfo.delegateToSchema({


### PR DESCRIPTION
Jira: [FX-2989]

- includes support for `savedSearch` query field

Additionally stitches in the new field under `me`:

```graphql
{
  me {
    savedSearch(criteria: { artistID: "andy-warhol", classification: "unique" }) {
      internalID
    }
  }
}
```

[FX-2989]: https://artsyproduct.atlassian.net/browse/FX-2989