### PR TITLE
chore: move savedSearch query field entirely to V2

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -9764,7 +9764,6 @@ type Me implements Node {
     sort: SaleSorts
   ): [SaleRegistration]
   saved_artworks: Collection
-  savedSearch(criteria: SearchCriteriaAttributes, id: ID): SearchCriteria
   secondFactors(kinds: [SecondFactorKind]): [SecondFactor]
 
   # A list of the current user’s suggested artists, based on a single artist

--- a/src/lib/stitching/gravity/v1/stitching.ts
+++ b/src/lib/stitching/gravity/v1/stitching.ts
@@ -53,7 +53,6 @@ export const gravityStitchingEnvironment = (
     // The SDL used to declare how to stitch an object
     extensionSchema: gql`
       extend type Me {
-        savedSearch(id: ID, criteria: SearchCriteriaAttributes): SearchCriteria
         secondFactors(kinds: [SecondFactorKind]): [SecondFactor]
         addressConnection(
           first: Int
@@ -134,18 +133,6 @@ export const gravityStitchingEnvironment = (
     `,
     resolvers: {
       Me: {
-        savedSearch: {
-          resolve: (_parent, args, context, info) => {
-            return info.mergeInfo.delegateToSchema({
-              schema: gravitySchema,
-              operation: "query",
-              fieldName: "_unused_gravity_savedSearch",
-              args: args,
-              context,
-              info,
-            })
-          },
-        },
         secondFactors: {
           resolve: (_parent, args, context, info) => {
             return info.mergeInfo.delegateToSchema({

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -142,6 +142,18 @@ export const gravityStitchingEnvironment = (
     `,
     resolvers: {
       Me: {
+        savedSearch: {
+          resolve: (_parent, args, context, info) => {
+            return info.mergeInfo.delegateToSchema({
+              schema: gravitySchema,
+              operation: "query",
+              fieldName: "_unused_gravity_savedSearch",
+              args: args,
+              context,
+              info,
+            })
+          },
+        },
         secondFactors: {
           resolve: (_parent, args, context, info) => {
             return info.mergeInfo.delegateToSchema({


### PR DESCRIPTION
- No V1 clients need access to the savedSearch query field so make it V2 only