### PR TITLE
GRO-350: Updated to allow the partner.href property to be used for Artist Bio links

### DIFF
--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -58,7 +58,7 @@ import { totalViaLoader } from "lib/total"
 import { ResolverContext } from "types/graphql"
 import ArtworkSizes from "../artwork/artworkSizes"
 import { ArtistTargetSupply } from "./targetSupply"
-import Partner, { PartnerType } from "../partner"
+import { PartnerType } from "../partner"
 
 // Manually curated list of artist id's who has verified auction lots that can be
 // returned, when queried for via `recordsTrusted: true`.

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -58,6 +58,7 @@ import { totalViaLoader } from "lib/total"
 import { ResolverContext } from "types/graphql"
 import ArtworkSizes from "../artwork/artworkSizes"
 import { ArtistTargetSupply } from "./targetSupply"
+import Partner, { PartnerType } from "../partner"
 
 // Manually curated list of artist id's who has verified auction lots that can be
 // returned, when queried for via `recordsTrusted: true`.
@@ -348,8 +349,14 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
             partnerID: {
               type: GraphQLString,
               resolve: ({ partner_id }) => partner_id,
+              deprecationReason:
+                "No longer used as the partner field contains the partner.id",
               description:
                 "The partner id of the partner who submitted the featured bio.",
+            },
+            partner: {
+              type: PartnerType,
+              resolve: ({ partner }) => partner,
             },
           },
         }),
@@ -371,6 +378,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
                 text: formatMarkdownValue(biography, format),
                 credit: `Submitted by ${partner.name}`,
                 partner_id: partner.id,
+                partner: partner,
               }
             }
             return { text: formatMarkdownValue(blurb, format) }


### PR DESCRIPTION
This is an update in MP to allow us to access the partner href that is used to create slugs. 

We are seeing issues with certain slugs not being updated to accurately reflect Partner name changes. This is because we are creating our associated partner hrefs using partnerID `const partnerHref = `${sd.APP_URL}/${partnerID}``

This update will allow us to pull in the correct href value for slug creation.