### PR TITLE
feature CORS Preflight Caching

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,9 @@ function startApp(appSchema, path: string) {
 
   app.use(
     path,
-    cors(),
+    cors({
+      maxAge: 600,
+    }),
     morgan,
     // Gotta parse the JSON body before passing it to logQueryDetails/fetchPersistedQuery
     bodyParser.json(),


### PR DESCRIPTION
Adds the `Access-Control-Max-Age` header to allow caching CORS preflight
headers for 10 minutes.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age