### PR TITLE
chore: sync convection schema changes

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -5560,6 +5560,7 @@ type ConsignmentOffer {
   saleLocation: String
   saleName: String
   shippingInfo: String
+  startingBidCents: Int
   state: String
   submission: ConsignmentSubmission!
 }
@@ -5787,6 +5788,12 @@ enum ConsignmentOfferSort {
   # sort by shipping_info in descending order
   SHIPPING_INFO_DESC
 
+  # sort by starting_bid_cents in ascending order
+  STARTING_BID_CENTS_ASC
+
+  # sort by starting_bid_cents in descending order
+  STARTING_BID_CENTS_DESC
+
   # sort by state in ascending order
   STATE_ASC
 
@@ -5864,6 +5871,12 @@ enum ConsignmentSort {
 
   # sort by id in descending order
   ID_DESC
+
+  # sort by invoice_number in ascending order
+  INVOICE_NUMBER_ASC
+
+  # sort by invoice_number in descending order
+  INVOICE_NUMBER_DESC
 
   # sort by notes in ascending order
   NOTES_ASC
@@ -6000,6 +6013,9 @@ type ConsignmentSubmission {
   title: String
   userAgent: String
   userId: String!
+  utmMedium: String
+  utmSource: String
+  utmTerm: String
   width: String
   year: String
 }
@@ -6085,6 +6101,12 @@ enum ConsignmentSubmissionSort {
   # sort by artist_id in descending order
   ARTIST_ID_DESC
 
+  # sort by artist_proofs in ascending order
+  ARTIST_PROOFS_ASC
+
+  # sort by artist_proofs in descending order
+  ARTIST_PROOFS_DESC
+
   # sort by artist_score in ascending order
   ARTIST_SCORE_ASC
 
@@ -6096,6 +6118,12 @@ enum ConsignmentSubmissionSort {
 
   # sort by assigned_to in descending order
   ASSIGNED_TO_DESC
+
+  # sort by attribution_class in ascending order
+  ATTRIBUTION_CLASS_ASC
+
+  # sort by attribution_class in descending order
+  ATTRIBUTION_CLASS_DESC
 
   # sort by auction_score in ascending order
   AUCTION_SCORE_ASC
@@ -6114,6 +6142,12 @@ enum ConsignmentSubmissionSort {
 
   # sort by category in descending order
   CATEGORY_DESC
+
+  # sort by condition_report in ascending order
+  CONDITION_REPORT_ASC
+
+  # sort by condition_report in descending order
+  CONDITION_REPORT_DESC
 
   # sort by consigned_partner_submission_id in ascending order
   CONSIGNED_PARTNER_SUBMISSION_ID_ASC
@@ -6175,6 +6209,12 @@ enum ConsignmentSubmissionSort {
   # sort by edition_size in descending order
   EDITION_SIZE_DESC
 
+  # sort by exhibition in ascending order
+  EXHIBITION_ASC
+
+  # sort by exhibition in descending order
+  EXHIBITION_DESC
+
   # sort by ext_user_id in ascending order
   EXT_USER_ID_ASC
 
@@ -6192,6 +6232,12 @@ enum ConsignmentSubmissionSort {
 
   # sort by id in descending order
   ID_DESC
+
+  # sort by literature in ascending order
+  LITERATURE_ASC
+
+  # sort by literature in descending order
+  LITERATURE_DESC
 
   # sort by location_city in ascending order
   LOCATION_CITY_ASC
@@ -6247,6 +6293,12 @@ enum ConsignmentSubmissionSort {
   # sort by published_at in descending order
   PUBLISHED_AT_DESC
 
+  # sort by publisher in ascending order
+  PUBLISHER_ASC
+
+  # sort by publisher in descending order
+  PUBLISHER_DESC
+
   # sort by qualified in ascending order
   QUALIFIED_ASC
 
@@ -6282,6 +6334,12 @@ enum ConsignmentSubmissionSort {
 
   # sort by signature in descending order
   SIGNATURE_DESC
+
+  # sort by signature_detail in ascending order
+  SIGNATURE_DETAIL_ASC
+
+  # sort by signature_detail in descending order
+  SIGNATURE_DETAIL_DESC
 
   # sort by source_artwork_id in ascending order
   SOURCE_ARTWORK_ID_ASC
@@ -6324,6 +6382,24 @@ enum ConsignmentSubmissionSort {
 
   # sort by user_id in descending order
   USER_ID_DESC
+
+  # sort by utm_medium in ascending order
+  UTM_MEDIUM_ASC
+
+  # sort by utm_medium in descending order
+  UTM_MEDIUM_DESC
+
+  # sort by utm_source in ascending order
+  UTM_SOURCE_ASC
+
+  # sort by utm_source in descending order
+  UTM_SOURCE_DESC
+
+  # sort by utm_term in ascending order
+  UTM_TERM_ASC
+
+  # sort by utm_term in descending order
+  UTM_TERM_DESC
 
   # sort by width in ascending order
   WIDTH_ASC
@@ -6592,6 +6668,7 @@ input CreateOfferMutationInput {
   saleLocation: String
   saleName: String
   shippingInfo: String
+  startingBidDollars: Int
   state: String
   submissionId: ID!
 }
@@ -6721,6 +6798,9 @@ input CreateSubmissionMutationInput {
   state: ConsignmentSubmissionStateAggregation
   title: String
   userAgent: String
+  utmMedium: String
+  utmSource: String
+  utmTerm: String
   width: String
   year: String
 }
@@ -9897,6 +9977,7 @@ type Mutation {
     input: AcceptPartnerAgreementInput!
   ): AcceptPartnerAgreementPayload
   addAssetToConsignmentSubmission(
+    # Parameters for AddAssetToConsignmentSubmission
     input: AddAssetToConsignmentSubmissionInput!
   ): AddAssetToConsignmentSubmissionPayload
 
@@ -9983,12 +10064,15 @@ type Mutation {
   # Creates a bidder position
   createBidderPosition(input: BidderPositionInput!): BidderPositionPayload
   createConsignmentOffer(
+    # Parameters for CreateOfferMutation
     input: CreateOfferMutationInput!
   ): CreateOfferMutationPayload
   createConsignmentOfferResponse(
+    # Parameters for CreateOfferResponseMutation
     input: CreateOfferResponseMutationInput!
   ): CreateOfferResponseMutationPayload
   createConsignmentSubmission(
+    # Parameters for CreateSubmissionMutation
     input: CreateSubmissionMutationInput!
   ): CreateSubmissionMutationPayload
 
@@ -10173,6 +10257,7 @@ type Mutation {
     input: UpdateCollectorProfileInput!
   ): UpdateCollectorProfilePayload
   updateConsignmentSubmission(
+    # Parameters for UpdateSubmissionMutation
     input: UpdateSubmissionMutationInput!
   ): UpdateSubmissionMutationPayload
 
@@ -14480,6 +14565,9 @@ input UpdateSubmissionMutationInput {
   signature: Boolean
   state: ConsignmentSubmissionStateAggregation
   title: String
+  utmMedium: String
+  utmSource: String
+  utmTerm: String
   width: String
   year: String
 }

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4070,6 +4070,7 @@ type ConsignmentOffer {
   saleLocation: String
   saleName: String
   shippingInfo: String
+  startingBidCents: Int
   state: String
   submission: ConsignmentSubmission!
 }
@@ -4297,6 +4298,12 @@ enum ConsignmentOfferSort {
   # sort by shipping_info in descending order
   SHIPPING_INFO_DESC
 
+  # sort by starting_bid_cents in ascending order
+  STARTING_BID_CENTS_ASC
+
+  # sort by starting_bid_cents in descending order
+  STARTING_BID_CENTS_DESC
+
   # sort by state in ascending order
   STATE_ASC
 
@@ -4374,6 +4381,12 @@ enum ConsignmentSort {
 
   # sort by id in descending order
   ID_DESC
+
+  # sort by invoice_number in ascending order
+  INVOICE_NUMBER_ASC
+
+  # sort by invoice_number in descending order
+  INVOICE_NUMBER_DESC
 
   # sort by notes in ascending order
   NOTES_ASC
@@ -4510,6 +4523,9 @@ type ConsignmentSubmission {
   title: String
   userAgent: String
   userId: String!
+  utmMedium: String
+  utmSource: String
+  utmTerm: String
   width: String
   year: String
 }
@@ -4595,6 +4611,12 @@ enum ConsignmentSubmissionSort {
   # sort by artist_id in descending order
   ARTIST_ID_DESC
 
+  # sort by artist_proofs in ascending order
+  ARTIST_PROOFS_ASC
+
+  # sort by artist_proofs in descending order
+  ARTIST_PROOFS_DESC
+
   # sort by artist_score in ascending order
   ARTIST_SCORE_ASC
 
@@ -4606,6 +4628,12 @@ enum ConsignmentSubmissionSort {
 
   # sort by assigned_to in descending order
   ASSIGNED_TO_DESC
+
+  # sort by attribution_class in ascending order
+  ATTRIBUTION_CLASS_ASC
+
+  # sort by attribution_class in descending order
+  ATTRIBUTION_CLASS_DESC
 
   # sort by auction_score in ascending order
   AUCTION_SCORE_ASC
@@ -4624,6 +4652,12 @@ enum ConsignmentSubmissionSort {
 
   # sort by category in descending order
   CATEGORY_DESC
+
+  # sort by condition_report in ascending order
+  CONDITION_REPORT_ASC
+
+  # sort by condition_report in descending order
+  CONDITION_REPORT_DESC
 
   # sort by consigned_partner_submission_id in ascending order
   CONSIGNED_PARTNER_SUBMISSION_ID_ASC
@@ -4685,6 +4719,12 @@ enum ConsignmentSubmissionSort {
   # sort by edition_size in descending order
   EDITION_SIZE_DESC
 
+  # sort by exhibition in ascending order
+  EXHIBITION_ASC
+
+  # sort by exhibition in descending order
+  EXHIBITION_DESC
+
   # sort by ext_user_id in ascending order
   EXT_USER_ID_ASC
 
@@ -4702,6 +4742,12 @@ enum ConsignmentSubmissionSort {
 
   # sort by id in descending order
   ID_DESC
+
+  # sort by literature in ascending order
+  LITERATURE_ASC
+
+  # sort by literature in descending order
+  LITERATURE_DESC
 
   # sort by location_city in ascending order
   LOCATION_CITY_ASC
@@ -4757,6 +4803,12 @@ enum ConsignmentSubmissionSort {
   # sort by published_at in descending order
   PUBLISHED_AT_DESC
 
+  # sort by publisher in ascending order
+  PUBLISHER_ASC
+
+  # sort by publisher in descending order
+  PUBLISHER_DESC
+
   # sort by qualified in ascending order
   QUALIFIED_ASC
 
@@ -4792,6 +4844,12 @@ enum ConsignmentSubmissionSort {
 
   # sort by signature in descending order
   SIGNATURE_DESC
+
+  # sort by signature_detail in ascending order
+  SIGNATURE_DETAIL_ASC
+
+  # sort by signature_detail in descending order
+  SIGNATURE_DETAIL_DESC
 
   # sort by source_artwork_id in ascending order
   SOURCE_ARTWORK_ID_ASC
@@ -4834,6 +4892,24 @@ enum ConsignmentSubmissionSort {
 
   # sort by user_id in descending order
   USER_ID_DESC
+
+  # sort by utm_medium in ascending order
+  UTM_MEDIUM_ASC
+
+  # sort by utm_medium in descending order
+  UTM_MEDIUM_DESC
+
+  # sort by utm_source in ascending order
+  UTM_SOURCE_ASC
+
+  # sort by utm_source in descending order
+  UTM_SOURCE_DESC
+
+  # sort by utm_term in ascending order
+  UTM_TERM_ASC
+
+  # sort by utm_term in descending order
+  UTM_TERM_DESC
 
   # sort by width in ascending order
   WIDTH_ASC
@@ -5149,6 +5225,7 @@ input CreateOfferMutationInput {
   saleLocation: String
   saleName: String
   shippingInfo: String
+  startingBidDollars: Int
   state: String
   submissionId: ID!
 }
@@ -5239,6 +5316,9 @@ input CreateSubmissionMutationInput {
   state: ConsignmentSubmissionStateAggregation
   title: String
   userAgent: String
+  utmMedium: String
+  utmSource: String
+  utmTerm: String
   width: String
   year: String
 }
@@ -7936,6 +8016,7 @@ type Mutation {
     input: AcceptPartnerAgreementInput!
   ): AcceptPartnerAgreementPayload
   addAssetToConsignmentSubmission(
+    # Parameters for AddAssetToConsignmentSubmission
     input: AddAssetToConsignmentSubmissionInput!
   ): AddAssetToConsignmentSubmissionPayload
   captureHold(input: CaptureHoldInput!): CaptureHoldPayload
@@ -8024,12 +8105,15 @@ type Mutation {
   # Creates a bidder position
   createBidderPosition(input: BidderPositionInput!): BidderPositionPayload
   createConsignmentOffer(
+    # Parameters for CreateOfferMutation
     input: CreateOfferMutationInput!
   ): CreateOfferMutationPayload
   createConsignmentOfferResponse(
+    # Parameters for CreateOfferResponseMutation
     input: CreateOfferResponseMutationInput!
   ): CreateOfferResponseMutationPayload
   createConsignmentSubmission(
+    # Parameters for CreateSubmissionMutation
     input: CreateSubmissionMutationInput!
   ): CreateSubmissionMutationPayload
 
@@ -8145,6 +8229,7 @@ type Mutation {
     input: UpdateCollectorProfileInput!
   ): UpdateCollectorProfilePayload
   updateConsignmentSubmission(
+    # Parameters for UpdateSubmissionMutation
     input: UpdateSubmissionMutationInput!
   ): UpdateSubmissionMutationPayload
 
@@ -11689,6 +11774,9 @@ input UpdateSubmissionMutationInput {
   signature: Boolean
   state: ConsignmentSubmissionStateAggregation
   title: String
+  utmMedium: String
+  utmSource: String
+  utmTerm: String
   width: String
   year: String
 }

--- a/src/data/convection.graphql
+++ b/src/data/convection.graphql
@@ -189,6 +189,16 @@ enum ConsignmentSort {
   ID_DESC
 
   """
+  sort by invoice_number in ascending order
+  """
+  INVOICE_NUMBER_ASC
+
+  """
+  sort by invoice_number in descending order
+  """
+  INVOICE_NUMBER_DESC
+
+  """
   sort by notes in ascending order
   """
   NOTES_ASC
@@ -371,6 +381,7 @@ input CreateOfferMutationInput {
   saleLocation: String
   saleName: String
   shippingInfo: String
+  startingBidDollars: Int
   state: String
   submissionId: ID!
 }
@@ -447,6 +458,9 @@ input CreateSubmissionMutationInput {
   state: State
   title: String
   userAgent: String
+  utmMedium: String
+  utmSource: String
+  utmTerm: String
   width: String
   year: String
 }
@@ -488,18 +502,33 @@ Mutation root for this schema
 """
 type Mutation {
   addAssetToConsignmentSubmission(
+    """
+    Parameters for AddAssetToConsignmentSubmission
+    """
     input: AddAssetToConsignmentSubmissionInput!
   ): AddAssetToConsignmentSubmissionPayload
   createConsignmentOffer(
+    """
+    Parameters for CreateOfferMutation
+    """
     input: CreateOfferMutationInput!
   ): CreateOfferMutationPayload
   createConsignmentOfferResponse(
+    """
+    Parameters for CreateOfferResponseMutation
+    """
     input: CreateOfferResponseMutationInput!
   ): CreateOfferResponseMutationPayload
   createConsignmentSubmission(
+    """
+    Parameters for CreateSubmissionMutation
+    """
     input: CreateSubmissionMutationInput!
   ): CreateSubmissionMutationPayload
   updateConsignmentSubmission(
+    """
+    Parameters for UpdateSubmissionMutation
+    """
     input: UpdateSubmissionMutationInput!
   ): UpdateSubmissionMutationPayload
 }
@@ -530,6 +559,7 @@ type Offer {
   saleLocation: String
   saleName: String
   shippingInfo: String
+  startingBidCents: Int
   state: String
   submission: Submission!
 }
@@ -920,6 +950,16 @@ enum OfferSort {
   SHIPPING_INFO_DESC
 
   """
+  sort by starting_bid_cents in ascending order
+  """
+  STARTING_BID_CENTS_ASC
+
+  """
+  sort by starting_bid_cents in descending order
+  """
+  STARTING_BID_CENTS_DESC
+
+  """
   sort by state in ascending order
   """
   STATE_ASC
@@ -1199,6 +1239,9 @@ type Submission {
   title: String
   userAgent: String
   userId: String!
+  utmMedium: String
+  utmSource: String
+  utmTerm: String
   width: String
   year: String
 }
@@ -1293,6 +1336,16 @@ enum SubmissionSort {
   ARTIST_ID_DESC
 
   """
+  sort by artist_proofs in ascending order
+  """
+  ARTIST_PROOFS_ASC
+
+  """
+  sort by artist_proofs in descending order
+  """
+  ARTIST_PROOFS_DESC
+
+  """
   sort by artist_score in ascending order
   """
   ARTIST_SCORE_ASC
@@ -1311,6 +1364,16 @@ enum SubmissionSort {
   sort by assigned_to in descending order
   """
   ASSIGNED_TO_DESC
+
+  """
+  sort by attribution_class in ascending order
+  """
+  ATTRIBUTION_CLASS_ASC
+
+  """
+  sort by attribution_class in descending order
+  """
+  ATTRIBUTION_CLASS_DESC
 
   """
   sort by auction_score in ascending order
@@ -1341,6 +1404,16 @@ enum SubmissionSort {
   sort by category in descending order
   """
   CATEGORY_DESC
+
+  """
+  sort by condition_report in ascending order
+  """
+  CONDITION_REPORT_ASC
+
+  """
+  sort by condition_report in descending order
+  """
+  CONDITION_REPORT_DESC
 
   """
   sort by consigned_partner_submission_id in ascending order
@@ -1443,6 +1516,16 @@ enum SubmissionSort {
   EDITION_SIZE_DESC
 
   """
+  sort by exhibition in ascending order
+  """
+  EXHIBITION_ASC
+
+  """
+  sort by exhibition in descending order
+  """
+  EXHIBITION_DESC
+
+  """
   sort by ext_user_id in ascending order
   """
   EXT_USER_ID_ASC
@@ -1471,6 +1554,16 @@ enum SubmissionSort {
   sort by id in descending order
   """
   ID_DESC
+
+  """
+  sort by literature in ascending order
+  """
+  LITERATURE_ASC
+
+  """
+  sort by literature in descending order
+  """
+  LITERATURE_DESC
 
   """
   sort by location_city in ascending order
@@ -1563,6 +1656,16 @@ enum SubmissionSort {
   PUBLISHED_AT_DESC
 
   """
+  sort by publisher in ascending order
+  """
+  PUBLISHER_ASC
+
+  """
+  sort by publisher in descending order
+  """
+  PUBLISHER_DESC
+
+  """
   sort by qualified in ascending order
   """
   QUALIFIED_ASC
@@ -1621,6 +1724,16 @@ enum SubmissionSort {
   sort by signature in descending order
   """
   SIGNATURE_DESC
+
+  """
+  sort by signature_detail in ascending order
+  """
+  SIGNATURE_DETAIL_ASC
+
+  """
+  sort by signature_detail in descending order
+  """
+  SIGNATURE_DETAIL_DESC
 
   """
   sort by source_artwork_id in ascending order
@@ -1693,6 +1806,36 @@ enum SubmissionSort {
   USER_ID_DESC
 
   """
+  sort by utm_medium in ascending order
+  """
+  UTM_MEDIUM_ASC
+
+  """
+  sort by utm_medium in descending order
+  """
+  UTM_MEDIUM_DESC
+
+  """
+  sort by utm_source in ascending order
+  """
+  UTM_SOURCE_ASC
+
+  """
+  sort by utm_source in descending order
+  """
+  UTM_SOURCE_DESC
+
+  """
+  sort by utm_term in ascending order
+  """
+  UTM_TERM_ASC
+
+  """
+  sort by utm_term in descending order
+  """
+  UTM_TERM_DESC
+
+  """
   sort by width in ascending order
   """
   WIDTH_ASC
@@ -1743,6 +1886,9 @@ input UpdateSubmissionMutationInput {
   signature: Boolean
   state: State
   title: String
+  utmMedium: String
+  utmSource: String
+  utmTerm: String
   width: String
   year: String
 }


### PR DESCRIPTION
syncs convection schema stitching in order to support utm campaign params in consignment submissions in Eigen:
https://artsyproduct.atlassian.net/browse/CX-1431

companion PRs:
https://github.com/artsy/convection/pull/1087
https://github.com/artsy/convection/pull/1075

