### PR TITLE
Re-dump schema for Convection updates

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -6256,6 +6256,18 @@ enum ConsignmentSubmissionSort {
   # sort by category in descending order
   CATEGORY_DESC
 
+  # sort by coa_by_authenticating_body in ascending order
+  COA_BY_AUTHENTICATING_BODY_ASC
+
+  # sort by coa_by_authenticating_body in descending order
+  COA_BY_AUTHENTICATING_BODY_DESC
+
+  # sort by coa_by_gallery in ascending order
+  COA_BY_GALLERY_ASC
+
+  # sort by coa_by_gallery in descending order
+  COA_BY_GALLERY_DESC
+
   # sort by condition_report in ascending order
   CONDITION_REPORT_ASC
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4774,6 +4774,18 @@ enum ConsignmentSubmissionSort {
   # sort by category in descending order
   CATEGORY_DESC
 
+  # sort by coa_by_authenticating_body in ascending order
+  COA_BY_AUTHENTICATING_BODY_ASC
+
+  # sort by coa_by_authenticating_body in descending order
+  COA_BY_AUTHENTICATING_BODY_DESC
+
+  # sort by coa_by_gallery in ascending order
+  COA_BY_GALLERY_ASC
+
+  # sort by coa_by_gallery in descending order
+  COA_BY_GALLERY_DESC
+
   # sort by condition_report in ascending order
   CONDITION_REPORT_ASC
 


### PR DESCRIPTION
Volt can't be deployed because its schema is incompatible with Metaphysics' production-deployed schema. This was initially confusing, because Metaphysics is fully released and Volt has been getting the usual schema updates. It turns out that https://github.com/artsy/metaphysics/pull/3238 didn't fully update the committed schema file. Running `yarn dump:local` again resulted in these changes, which should hopefully (once released) allow Volt to be released.

Co-authored by: @starsirius 