### PR TITLE
[PURCHASE-2747] - enable fetching a live artwork instead of the snapshot

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5211,7 +5211,7 @@ type ConversationInitiator {
 
 type ConversationItem {
   item: ConversationItemType
-  liveArtworkItem: ConversationItemType
+  liveArtwork: ConversationItemType
   permalink: String
   title: String
 }

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5211,6 +5211,7 @@ type ConversationInitiator {
 
 type ConversationItem {
   item: ConversationItemType
+  liveArtworkItem: ConversationItemType
   permalink: String
   title: String
 }

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5211,6 +5211,8 @@ type ConversationInitiator {
 
 type ConversationItem {
   item: ConversationItemType
+
+  # The actual, non-snapshotted artwork
   liveArtwork: ConversationItemType
   permalink: String
   title: String

--- a/src/schema/v2/me/__tests__/conversation/conversation.test.js
+++ b/src/schema/v2/me/__tests__/conversation/conversation.test.js
@@ -294,6 +294,7 @@ describe("Me", () => {
                         id: "artist-42",
                       },
                     ],
+                    published: true,
                   },
                   liveArtworkItem: {
                     slug: "artwork-42",
@@ -311,6 +312,7 @@ describe("Me", () => {
               forsale: true,
               offerable_from_inquiry: true,
               artists: [],
+              published: true,
             })
           },
         }
@@ -344,6 +346,92 @@ describe("Me", () => {
             expect(artwork.liveArtworkItem.isOfferableFromInquiry).toBe(true)
             expect(artwork.liveArtworkItem.isForSale).toBe(true)
             expect(artwork.liveArtworkItem.slug).toBe("artwork-42")
+          }
+        )
+      })
+
+      it("returns null when the artwork is not published", () => {
+        const newContext = {
+          conversationLoader: () => {
+            return Promise.resolve({
+              id: "420",
+              initial_message: "Loved some of the works at your fair booth!",
+              from_email: "collector@example.com",
+              from_name: "Percy",
+              _embedded: {
+                last_message: {
+                  snippet:
+                    "Loved some of the works at your fair booth! About this collector: Percy is a good cat",
+                  from_email_address: "other-collector@example.com",
+                  id: "25",
+                  order: 1,
+                },
+              },
+              from_last_viewed_message_id: "20",
+              items: [
+                {
+                  item_type: "Artwork",
+                  item_id: "artwork-42",
+                  title: "Pwetty Cats",
+                  properties: {
+                    id: "artwork-42",
+                    title: "Pwetty Cats",
+                    acquireable: true,
+                    artists: [
+                      {
+                        id: "artist-42",
+                      },
+                    ],
+                    published: true,
+                  },
+                  liveArtworkItem: {
+                    slug: "artwork-42",
+                    isOfferableFromInquiry: true,
+                  },
+                },
+              ],
+            })
+          },
+
+          artworkLoader: () => {
+            return Promise.resolve({
+              id: "artwork-42",
+              title: "Untitled (Portrait)",
+              forsale: true,
+              offerable_from_inquiry: true,
+              artists: [],
+              published: false,
+            })
+          },
+        }
+
+        const query = `
+          {
+            me {
+              conversation(id: "420") {
+                items {
+                  title
+                  liveArtworkItem {
+                    ... on Artwork {
+                      slug
+                      isForSale
+                      isOfferableFromInquiry
+                    }
+                  }
+                }
+              }
+            }
+          }
+        `
+
+        return runAuthenticatedQuery(query, newContext).then(
+          ({
+            me: {
+              conversation: { items },
+            },
+          }) => {
+            const artworkItem = items[0]
+            expect(artworkItem.liveArtworkItem).toBe(null)
           }
         )
       })

--- a/src/schema/v2/me/__tests__/conversation/conversation.test.js
+++ b/src/schema/v2/me/__tests__/conversation/conversation.test.js
@@ -35,7 +35,7 @@ describe("Me", () => {
                   },
                 ],
               },
-              liveArtworkItem: {
+              liveArtwork: {
                 slug: "artwork-42",
                 isOfferableFromInquiry: true,
               },
@@ -296,7 +296,7 @@ describe("Me", () => {
                     ],
                     published: true,
                   },
-                  liveArtworkItem: {
+                  liveArtwork: {
                     slug: "artwork-42",
                     isOfferableFromInquiry: true,
                   },
@@ -323,7 +323,7 @@ describe("Me", () => {
               conversation(id: "420") {
                 items {
                   title
-                  liveArtworkItem {
+                  liveArtwork {
                     ... on Artwork {
                       slug
                       isForSale
@@ -343,9 +343,9 @@ describe("Me", () => {
             },
           }) => {
             const artwork = items[0]
-            expect(artwork.liveArtworkItem.isOfferableFromInquiry).toBe(true)
-            expect(artwork.liveArtworkItem.isForSale).toBe(true)
-            expect(artwork.liveArtworkItem.slug).toBe("artwork-42")
+            expect(artwork.liveArtwork.isOfferableFromInquiry).toBe(true)
+            expect(artwork.liveArtwork.isForSale).toBe(true)
+            expect(artwork.liveArtwork.slug).toBe("artwork-42")
           }
         )
       })
@@ -384,25 +384,13 @@ describe("Me", () => {
                     ],
                     published: true,
                   },
-                  liveArtworkItem: {
-                    slug: "artwork-42",
-                    isOfferableFromInquiry: true,
-                  },
+                  liveArtwork: null,
                 },
               ],
             })
           },
 
-          artworkLoader: () => {
-            return Promise.resolve({
-              id: "artwork-42",
-              title: "Untitled (Portrait)",
-              forsale: true,
-              offerable_from_inquiry: true,
-              artists: [],
-              published: false,
-            })
-          },
+          artworkLoader: () => Promise.reject({ error: "Artwork Not Found" }),
         }
 
         const query = `
@@ -411,7 +399,7 @@ describe("Me", () => {
               conversation(id: "420") {
                 items {
                   title
-                  liveArtworkItem {
+                  liveArtwork {
                     ... on Artwork {
                       slug
                       isForSale
@@ -430,13 +418,13 @@ describe("Me", () => {
               conversation: { items },
             },
           }) => {
-            const artworkItem = items[0]
-            expect(artworkItem.liveArtworkItem).toBe(null)
+            const artwork = items[0]
+            expect(artwork.liveArtwork).toBe(null)
           }
         )
       })
 
-      it("throws error when liveArtworkItem is a partner show", () => {
+      it("throws error when liveArtwork is a partner show", () => {
         const newContext = {
           conversationLoader: () => {
             return Promise.resolve({
@@ -463,7 +451,7 @@ describe("Me", () => {
                     is_reference: true,
                     display_on_partner_profile: true,
                   },
-                  liveArtworkItem: {
+                  liveArtwork: {
                     slug: "artwork-42",
                     isOfferableFromInquiry: true,
                   },
@@ -483,7 +471,7 @@ describe("Me", () => {
               conversation(id: "420") {
                 items {
                   title
-                  liveArtworkItem {
+                  liveArtwork {
                     ... on Artwork {
                       slug
                       isForSale

--- a/src/schema/v2/me/__tests__/conversation/conversation.test.js
+++ b/src/schema/v2/me/__tests__/conversation/conversation.test.js
@@ -424,7 +424,7 @@ describe("Me", () => {
         )
       })
 
-      it("throws error when liveArtwork is a partner show", () => {
+      it("returns null when item is a partner show", () => {
         const newContext = {
           conversationLoader: () => {
             return Promise.resolve({
@@ -451,17 +451,9 @@ describe("Me", () => {
                     is_reference: true,
                     display_on_partner_profile: true,
                   },
-                  liveArtwork: {
-                    slug: "artwork-42",
-                    isOfferableFromInquiry: true,
-                  },
                 },
               ],
             })
-          },
-
-          artworkLoader: () => {
-            return Promise.resolve({})
           },
         }
 
@@ -484,13 +476,16 @@ describe("Me", () => {
           }
         `
 
-        return runAuthenticatedQuery(query, newContext)
-          .then((result) => {
-            expect(result).toBe(null)
-          })
-          .catch((e) => {
-            expect(e.message).toBe("PartnerShow not supported.")
-          })
+        return runAuthenticatedQuery(query, newContext).then(
+          ({
+            me: {
+              conversation: { items },
+            },
+          }) => {
+            const artwork = items[0]
+            expect(artwork.liveArtwork).toBe(null)
+          }
+        )
       })
     })
 

--- a/src/schema/v2/me/conversation/index.ts
+++ b/src/schema/v2/me/conversation/index.ts
@@ -134,16 +134,19 @@ const ConversationItem = new GraphQLObjectType<any, ResolverContext>({
     permalink: {
       type: GraphQLString,
     },
-    liveItem: {
+    liveArtworkItem: {
       type: ConversationItemType,
-      resolve: (parent, _args, { artworkLoader }) => {
-        if (parent.item_type === "Artwork") {
-          return artworkLoader(parent.properties.id).then((artwork) => ({
-            ...artwork,
-            __typename: "Artwork",
-          }))
+      resolve: (artworkItem, _args, { artworkLoader }) => {
+        if (artworkItem.item_type === "Artwork") {
+          return artworkLoader(artworkItem.properties.id).then((artwork) => {
+            return {
+              ...artwork,
+              __typename: "Artwork",
+            }
+          })
+        } else {
+          throw new Error("PartnerShow not supported.")
         }
-        throw new Error("Only artworks are supported.")
       },
     },
   },
@@ -364,17 +367,10 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
     },
 
     items: {
-      args: {
-        live: {
-          type: GraphQLBoolean,
-          description: "When true fetches an actual items instead of snapshots",
-          defaultValue: false,
-        },
-      },
       type: new GraphQLList(ConversationItem),
       description:
         "The artworks and/or partner shows discussed in the conversation.",
-      resolve: async (conversation, args, { artworkLoader }, _info) => {
+      resolve: async (conversation) => {
         const results = []
 
         for (const item of conversation.items) {
@@ -382,23 +378,9 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
             isExisty(item.properties) &&
             (item.item_type === "Artwork" || item.item_type === "PartnerShow")
           ) {
-            if (args.live && item.item_type === "Artwork") {
-              const artwork = await artworkLoader(item.properties.id)
-
-              const updatedArtwork = {
-                properties: artwork,
-                item_type: "Artwork",
-                title: artwork.title,
-                permalink: `https://www.artsy.net/artwork/${item.properties.id}`,
-              }
-
-              // @ts-ignore
-              results.push(updatedArtwork) // figure out how to type this as an artwork
-            } else {
-              // FIXME: Argument of type 'any' is not assignable to parameter of type 'never'.
-              // @ts-ignore
-              results.push(item)
-            }
+            // FIXME: Argument of type 'any' is not assignable to parameter of type 'never'.
+            // @ts-ignore
+            results.push(item)
           }
         }
         return results

--- a/src/schema/v2/me/conversation/index.ts
+++ b/src/schema/v2/me/conversation/index.ts
@@ -136,6 +136,7 @@ const ConversationItem = new GraphQLObjectType<any, ResolverContext>({
     },
     liveArtwork: {
       type: ConversationItemType,
+      description: "The actual, non-snapshotted artwork",
       resolve: async (conversationItem, _args, { artworkLoader }) => {
         if (conversationItem.item_type === "Artwork") {
           try {

--- a/src/schema/v2/me/conversation/index.ts
+++ b/src/schema/v2/me/conversation/index.ts
@@ -152,7 +152,8 @@ const ConversationItem = new GraphQLObjectType<any, ResolverContext>({
             return null
           }
         } else if (conversationItem.item_type === "PartnerShow") {
-          throw new Error("PartnerShow not supported.")
+          console.warn("PartnerShow not supported")
+          return null
         } else {
           return null
         }

--- a/src/schema/v2/me/conversation/index.ts
+++ b/src/schema/v2/me/conversation/index.ts
@@ -136,16 +136,21 @@ const ConversationItem = new GraphQLObjectType<any, ResolverContext>({
     },
     liveArtworkItem: {
       type: ConversationItemType,
-      resolve: (artworkItem, _args, { artworkLoader }) => {
-        if (artworkItem.item_type === "Artwork") {
-          return artworkLoader(artworkItem.properties.id).then((artwork) => {
-            return {
-              ...artwork,
-              __typename: "Artwork",
+      resolve: (conversationItem, _args, { artworkLoader }) => {
+        if (conversationItem.item_type === "Artwork") {
+          return artworkLoader(conversationItem.properties.id).then(
+            (artwork) => {
+              const updatedArtwork = {
+                ...artwork,
+                __typename: "Artwork",
+              }
+              return artwork.published ? updatedArtwork : null
             }
-          })
-        } else {
+          )
+        } else if (conversationItem.item_type === "PartnerShow") {
           throw new Error("PartnerShow not supported.")
+        } else {
+          return null
         }
       },
     },
@@ -370,7 +375,7 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
       type: new GraphQLList(ConversationItem),
       description:
         "The artworks and/or partner shows discussed in the conversation.",
-      resolve: async (conversation) => {
+      resolve: (conversation) => {
         const results = []
 
         for (const item of conversation.items) {

--- a/src/schema/v2/me/conversation/index.ts
+++ b/src/schema/v2/me/conversation/index.ts
@@ -134,19 +134,22 @@ const ConversationItem = new GraphQLObjectType<any, ResolverContext>({
     permalink: {
       type: GraphQLString,
     },
-    liveArtworkItem: {
+    liveArtwork: {
       type: ConversationItemType,
-      resolve: (conversationItem, _args, { artworkLoader }) => {
+      resolve: async (conversationItem, _args, { artworkLoader }) => {
         if (conversationItem.item_type === "Artwork") {
-          return artworkLoader(conversationItem.properties.id).then(
-            (artwork) => {
-              const updatedArtwork = {
-                ...artwork,
-                __typename: "Artwork",
-              }
-              return artwork.published ? updatedArtwork : null
+          try {
+            const artworkData = await artworkLoader(
+              conversationItem.properties.id
+            )
+            return {
+              ...artworkData,
+              __typename: "Artwork",
             }
-          )
+          } catch (error) {
+            console.error(error)
+            return null
+          }
         } else if (conversationItem.item_type === "PartnerShow") {
           throw new Error("PartnerShow not supported.")
         } else {


### PR DESCRIPTION
Addresses: [PURCHASE-2747](https://artsyproduct.atlassian.net/browse/PURCHASE-2747)

**Issue:**
When we fetch items _(a collection of artworks or partner shows a user has inquired on)_, we are fetching a [snapshot version](https://github.com/artsy/impulse/blob/master/app/services/item_service.rb#L17-L46) of these items from impulse. This is particularly beneficial in the event a partner deletes or un-publishes an artwork or show. The conversation still maintains relevant context. However, when we need actual (not a snapshot) and up-to-date information from the artwork object (as is the case for the `isOfferableFromInquiry` property), this presents a problem.

Previously we got around this by creating a [new query renderer](https://github.com/artsy/eigen/pull/4637) and just fetching the artwork directly from gravity through metaphysics. This worked fine initially but introduces other [complexities](https://github.com/artsy/eigen/pull/4814#pullrequestreview-674613779). For example, when we refetch the conversation we also have to trigger a refetch to get the artwork, otherwise the `isOfferableFromInquiry` will be stale and show the "Make Offer" button when we shouldn't.

**Proposed solution:**
The proposed solution is to move the fetch of an up-to-date artwork to metaphysics as part of the conversation query. This is a WIP pull requests with two solutions:
1. Add an optional boolean argument that determines whether to get the snapshot or actual artwork.
2. A new `liveItem` field in the `ConversationItem`

**Screenshot of query:**
<img width="1233" alt="Screen Shot 2021-06-29 at 5 10 20 PM" src="https://user-images.githubusercontent.com/5201004/123868476-bcc0a780-d8fd-11eb-9ff1-bbc088a4df98.png">

Opening this WIP for purpose of discussion. More context about this issue in a [slack thread](https://artsy.slack.com/archives/C9YNS4X32/p1623442687199400).

Shout out to @erikdstock, our resident purchase graphql/metaphysics expert 😜 for helping me with some of the typing.

cc: @artsy/purchase-devs 

**Screenshot:**
<img width="691" alt="Screen Shot 2021-07-07 at 5 13 56 PM" src="https://user-images.githubusercontent.com/5201004/125123041-2ee67880-e0c4-11eb-8274-c77b34594973.png">
