### PR TITLE
fix: check if artist exists in AuctionResultsByFollowedArtists resolver

### DIFF
--- a/src/schema/v2/me/auction_results_by_followed_artists.ts
+++ b/src/schema/v2/me/auction_results_by_followed_artists.ts
@@ -106,9 +106,9 @@ const AuctionResultsByFollowedArtists: GraphQLFieldConfig<
           // enrich result with artist data
           const items = _embedded.items.map((auctionResult) => {
             const artist = followedArtists.find(
-              (artist) => artist.artist?._id == auctionResult.artist_id
+              (artist) => artist?.artist?._id == auctionResult.artist_id
             )
-            auctionResult.artist = artist.artist
+            auctionResult.artist = artist?.artist
             return auctionResult
           })
 

--- a/src/schema/v2/me/auction_results_by_followed_artists.ts
+++ b/src/schema/v2/me/auction_results_by_followed_artists.ts
@@ -74,7 +74,7 @@ const AuctionResultsByFollowedArtists: GraphQLFieldConfig<
       const { body: followedArtists } = await followedArtistsLoader(gravityArgs)
 
       const followedArtistIds = compact(
-        followedArtists.map((artist) => artist.artist._id)
+        followedArtists.map((artist) => artist?.artist?._id)
       )
 
       const {


### PR DESCRIPTION
Addresses a bug discussed [here](https://artsy.slack.com/archives/C02BAQ5K7/p1624982653469000).