### PR TITLE
[PX-2975] Exposes schema necessary to support the galleries_institutions page on Artsy.net

### DIFF
--- a/src/schema/v2/filter_partners.ts
+++ b/src/schema/v2/filter_partners.ts
@@ -15,7 +15,7 @@ const FilterPartners: GraphQLFieldConfig<void, ResolverContext> = {
       type: new GraphQLNonNull(new GraphQLList(PartnersAggregation)),
     },
   }),
-  resolve: (_root, options, { partnersLoader }) => partnersLoader(options),
+  resolve: Partners.resolve
 }
 
 export default FilterPartners

--- a/src/schema/v2/partner_category.ts
+++ b/src/schema/v2/partner_category.ts
@@ -28,12 +28,7 @@ export const PartnerCategoryType = new GraphQLObjectType<any, ResolverContext>({
       partners: {
         type: Partners.type,
         args: Partners.args,
-        resolve: ({ id }, options, { partnersLoader }) =>
-          partnersLoader(
-            _.defaults(options, {
-              partner_categories: [id],
-            })
-          ),
+        resolve: Partners.resolve
       },
     }
   },

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -36,7 +36,7 @@ import { OrderPartyUnionType } from "./ecommerce/types/order_party_union"
 import Fair from "./fair"
 import Fairs, { fairsConnection } from "./fairs"
 import { Feature } from "./Feature"
-// import FilterPartners from "./filter_partners"
+import FilterPartners from "./filter_partners"
 import { filterArtworksConnection } from "./filterArtworksConnection"
 import Gene from "./gene"
 // import ExternalPartner from "./external_partner"
@@ -93,7 +93,7 @@ import { startIdentityVerificationMutation } from "./startIdentityVerificationMu
 import StaticContent from "./static_content"
 import System from "./system"
 // import PartnerCategory from "./partner_category"
-// import PartnerCategories from "./partner_categories"
+import PartnerCategories from "./partner_categories"
 // import SuggestedGenes from "./suggested_genes"
 import { TagField } from "./tag"
 import { TargetSupply } from "./TargetSupply"
@@ -139,7 +139,7 @@ const rootFields = {
   fairs: Fairs,
   fairsConnection,
   feature: Feature,
-  // filterPartners: FilterPartners,
+  filterPartners: FilterPartners,
   // filterArtworksConnection: filterArtworksConnection(),
   gene: Gene,
   genes: Genes,
@@ -160,7 +160,7 @@ const rootFields = {
   orderedSets: OrderedSets,
   partner: Partner,
   partnerArtworks: PartnerArtworks,
-  // partnerCategories: PartnerCategories,
+  partnerCategories: PartnerCategories,
   // partnerCategory: PartnerCategory,
   partnersConnection: PartnersConnection,
   // profile: Profile,


### PR DESCRIPTION
Jira ticket: https://artsyproduct.atlassian.net/browse/PX-2975

When we created metaphysics v2, we intentionally commented out some fields at the root to avoid unnecessary fields.

It turns out, we do actually need a few of these for the /galleries and /institutions page on Artsy.net!