### PR TITLE
fix: filter out auction results without artist id

### DIFF
--- a/src/schema/v2/me/__tests__/auction_results_by_followed_artists.test.ts
+++ b/src/schema/v2/me/__tests__/auction_results_by_followed_artists.test.ts
@@ -57,6 +57,9 @@ describe("Me", () => {
               title: "Auction Result 2",
               artist_id: "artist-2",
             },
+            {
+              title: "Auction Result Without Artist ID",
+            },
           ],
         },
       }))

--- a/src/schema/v2/me/auction_results_by_followed_artists.ts
+++ b/src/schema/v2/me/auction_results_by_followed_artists.ts
@@ -103,14 +103,21 @@ const AuctionResultsByFollowedArtists: GraphQLFieldConfig<
         ({ total_count, _embedded }) => {
           const totalPages = Math.ceil(total_count / size)
 
+          // filter items without artist id
+          const filteredAuctionResults = _embedded.items.filter(
+            (auctionResult) => auctionResult.artist_id
+          )
+
           // enrich result with artist data
-          const items = _embedded.items.map((auctionResult) => {
-            const artist = followedArtists.find(
-              (artist) => artist?.artist?._id == auctionResult.artist_id
-            )
-            auctionResult.artist = artist?.artist
-            return auctionResult
-          })
+          const enrichedAuctionResults = filteredAuctionResults.map(
+            (auctionResult) => {
+              const artist = followedArtists.find(
+                (artist) => artist?.artist?._id == auctionResult.artist_id
+              )
+              auctionResult.artist = artist?.artist
+              return auctionResult
+            }
+          )
 
           return merge(
             {
@@ -125,7 +132,7 @@ const AuctionResultsByFollowedArtists: GraphQLFieldConfig<
             {
               totalCount: total_count,
             },
-            connectionFromArraySlice(items, options, {
+            connectionFromArraySlice(enrichedAuctionResults, options, {
               arrayLength: total_count,
               sliceStart: offset,
             }),


### PR DESCRIPTION
Addresses [CX-1676]

This PR filters out auction results without an artist id in the auctionResultsByFollowedArtists resolver.

[CX-1676]: https://artsyproduct.atlassian.net/browse/CX-1676