### PR TITLE
Update home screen titles

### DIFF
--- a/src/schema/v2/home/__tests__/home_page_artwork_module.test.js
+++ b/src/schema/v2/home/__tests__/home_page_artwork_module.test.js
@@ -121,7 +121,7 @@ describe("HomePageArtworkModule", () => {
         }
       `
       return runQuery(query).then(({ homePage }) => {
-        expect(homePage.artworkModule.title).toEqual("Works by popular artists")
+        expect(homePage.artworkModule.title).toEqual("Works by Popular Artists")
       })
     })
   })

--- a/src/schema/v2/home/title.ts
+++ b/src/schema/v2/home/title.ts
@@ -11,7 +11,7 @@ import {
 import { ResolverContext } from "types/graphql"
 
 const moduleTitle: HomePageArtworkModuleResolvers<string> = {
-  active_bids: () => "Your active bids",
+  active_bids: () => "Your Active Bids",
   current_fairs: ({ fairsLoader }) => {
     return featuredFair(fairsLoader).then((fair) => fair && fair.name)
   },
@@ -21,8 +21,8 @@ const moduleTitle: HomePageArtworkModuleResolvers<string> = {
       (artist) => artist && artist.name
     )
   },
-  followed_artists: () => "New works by artists you follow",
-  followed_galleries: () => "Works from galleries you follow",
+  followed_artists: () => "New Works by Artists You Follow",
+  followed_galleries: () => "Works from Galleries You Follow",
   generic_gene: (_context, params) => {
     if (isGenericGeneArtworkModuleParams(params)) {
       return params.title
@@ -46,18 +46,18 @@ const moduleTitle: HomePageArtworkModuleResolvers<string> = {
       (auction) => auction && auction.name
     )
   },
-  popular_artists: () => "Works by popular artists",
-  recommended_works: () => "Recommended works for you",
+  popular_artists: () => "Works by Popular Artists",
+  recommended_works: () => "Recommended Works for You",
   related_artists: ({ artistLoader }, params) => {
     if (!isRelatedArtistArtworkModuleParams(params)) return null
     return artistLoader(params.related_artist_id).then(
       (artist) => artist && artist.name
     )
   },
-  saved_works: () => "Recently saved",
-  similar_to_saved_works: () => "Similar to works you’ve saved",
-  recently_viewed_works: () => "Recently viewed",
-  similar_to_recently_viewed: () => "Similar to works you’ve viewed",
+  saved_works: () => "Recently Saved",
+  similar_to_saved_works: () => "Similar to Works You’ve Saved",
+  recently_viewed_works: () => "Recently Viewed",
+  similar_to_recently_viewed: () => "Similar to Works You’ve Viewed",
 }
 
 const Title: GraphQLFieldConfig<


### PR DESCRIPTION
The type of this PR is: **Update**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1602]

### Description

Artsy is moving away from Sentence Case across Titles and CTAs throughout the UI. I'm starting this change by updating all titles in the App Home Feed.

<!-- Implementation description -->

### Screenshots

_Home screen_
<img width="417" alt="Screen Shot 2021-07-07 at 12 32 35 PM" src="https://user-images.githubusercontent.com/23108927/124827071-988b4900-df43-11eb-8fff-cd5ef9359d10.png">

[CX-1347]: https://artsyproduct.atlassian.net/browse/CX-1347

[CX-1602]: https://artsyproduct.atlassian.net/browse/CX-1602