### PR TITLE
fix: auction results by followed artists, bail out early when user has no follows

### DIFF
--- a/src/schema/v2/me/auction_results_by_followed_artists.ts
+++ b/src/schema/v2/me/auction_results_by_followed_artists.ts
@@ -77,6 +77,10 @@ const AuctionResultsByFollowedArtists: GraphQLFieldConfig<
         followedArtists.map((artist) => artist?.artist?._id)
       )
 
+      if (!followedArtistIds || followedArtistIds.length === 0) {
+        return null
+      }
+
       const {
         page,
         size,


### PR DESCRIPTION
We are seeing expensive queries to diffusion coming through from the new "Auction Lots by Artists you Follow" rail for users with no followed artists. Since the intention of the rail is to show auction lots by the artists the user follows I believe it should be okay to return empty in this case and not call diffusion.