### PR TITLE
bugfix: Fix duplicate items in MyBids component

### DIFF
--- a/src/schema/v2/me/myBids.ts
+++ b/src/schema/v2/me/myBids.ts
@@ -122,15 +122,15 @@ export const MyBids: GraphQLFieldConfig<void, ResolverContext> = {
     ])
 
     // Map over response to gather all sale IDs
-    const causalityLots = causalityResponse.lotStandingConnection.edges.map(
-      ({ node }) => node
-    )
+    const causalityLots = (
+      causalityResponse?.lotStandingConnection?.edges ?? []
+    ).map(({ node }) => node)
     const causalitySaleIds = causalityLots.map((node) => node.lot.saleId)
     const registeredSaleIds = registeredSalesResponse.body.map(
       (sale) => sale._id
     )
     const watchedSaleIds = watchedSaleArtworksResponse.body.map(
-      (artwork) => artwork.sale_id
+      (artwork) => artwork.artwork.sale_ids[0]
     )
 
     // Combine ids from categories and dedupe


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GRO-455

This fixes an issue where we were seeing duplicate entries in /auctions MyBids components when a user has registered for a sale and watches a lot that's in that sale.

The issue was that we can query for artworks by slug _or_ internalID, and so the `uniq` check was failing to filter out one work that was returned as an internalID and slug. 