### PR TITLE
fix: fetch more than the first page

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6238,7 +6238,7 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
     before: String
     first: Int
     last: Int
-    page: Int = 1
+    page: Int
 
     # Number of artworks to return
     section: String

--- a/src/schema/v2/__tests__/fair.test.js
+++ b/src/schema/v2/__tests__/fair.test.js
@@ -321,7 +321,6 @@ describe("Fair", () => {
           shows: showsConnection(first: 1) {
             pageInfo {
               hasNextPage
-              endCursor
             }
             edges {
               node {
@@ -340,47 +339,11 @@ describe("Fair", () => {
         shows: {
           pageInfo: {
             hasNextPage: true,
-            endCursor: "YXJyYXljb25uZWN0aW9uOjA=",
           },
           edges: [
             {
               node: {
                 name: "A",
-              },
-            },
-          ],
-        },
-      },
-    })
-
-    const nextQuery = gql`
-      {
-        fair(id: "aqua-art-miami-2018") {
-          shows: showsConnection(first: 1, after: "YXJyYXljb25uZWN0aW9uOjA=") {
-            pageInfo {
-              hasNextPage
-            }
-            edges {
-              node {
-                name
-              }
-            }
-          }
-        }
-      }
-    `
-    const nextData = await runQuery(nextQuery, context)
-
-    expect(nextData).toEqual({
-      fair: {
-        shows: {
-          pageInfo: {
-            hasNextPage: false,
-          },
-          edges: [
-            {
-              node: {
-                name: "B",
               },
             },
           ],

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -268,7 +268,6 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
           },
           page: {
             type: GraphQLInt,
-            defaultValue: 1,
           },
         }),
         resolve: ({ id }, options, { fairBoothsLoader }) => {


### PR DESCRIPTION
In #3256, we accidentally introduced a bug where we would only ever fetch the first page of results. We introduced a default `page 1` argument, then [in Gravity](https://github.com/artsy/gravity/pull/14273), we introduced behavior that prioritized `page` over `cursor`. End result: we always fetch page 1 and nothing beyond.

This PR removes the default value for page so that we can once again fetch more than 1 page of results. 