### PR TITLE
toolchain: Match setup script with force

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,2 +1,0 @@
-brew "memcached", restart_service: true
-brew "yarn"

--- a/README.md
+++ b/README.md
@@ -45,13 +45,12 @@ It is currently used in production all over the place in
 
 To get yourself set up with all the project's dependencies:
 
-```
+```sh
 git clone https://github.com/artsy/metaphysics
 cd metaphysics
 
 # Run the setup script
-
-yarn setup
+./scripts/setup.sh
 ```
 
 This will pull the environment variables from aws into .env.shared.
@@ -161,20 +160,20 @@ this:
 - Install [Docker for Mac](https://github.com/artsy/hokusai#requirements) and
   [Hokusai](https://github.com/artsy/hokusai#setup)
 
-  ```
+  ```sh
   $ brew tap caskroom/cask && brew cask install docker
   $ pip install hokusai
   ```
 
   If you are using your system Python distribution, you may need to run this as:
 
-  ```
+  ```sh
   $ sudo pip install hokusai --ignore-installed
   ```
 
 - Configure Hokusai
 
-  ```
+  ```sh
   export AWS_ACCESS_KEY_ID={{ MY_AWS_ACCESS_KEY_ID }}
   export AWS_SECRET_ACCESS_KEY={{ MY_AWS_SECRET_ACCESS_KEY }}
   hokusai configure --kubectl-version {{ kubectl_version }} --s3-bucket {{ kubectl_config_s3_bucket }} --s3-key {{ kubectl_config_s3_key }}
@@ -184,11 +183,9 @@ this:
   Artsy staff should find follow the instructions in
   https://github.com/artsy/potential/blob/master/platform/Kubernetes.md#hokusai
 
-### Development
-
 - Start the server
 
-  ```
+  ```sh
   hokusai dev start
   ```
 
@@ -196,7 +193,7 @@ this:
 
 - Run tests in the Docker Compose test stack via Hokusai:
 
-  ```
+  ```sh
   hokusai test
   ```
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ cd metaphysics
 
 # Run the setup script
 
-source ./scripts/setup.sh
+yarn setup
 ```
 
-This will pull the environment variables from aws into .env.shared. 
+This will pull the environment variables from aws into .env.shared.
 It will also overwrite .env with the values in .env.example. If you need to override any of these values
 or add new .env values place them in the .env file.
 

--- a/README.md
+++ b/README.md
@@ -63,16 +63,10 @@ or add new .env values place them in the .env file.
 With your dependencies set up, you can run Metaphysics by running:
 
 ```sh
-yarn dev
+yarn start
 ```
 
 Which will start the server on http://localhost:3000
-
-You can also use hokusai by running the below command.
-
-```sh
-hokusai dev start
-```
 
 Be sure that memcached is no longer running before starting hokusai by running
 
@@ -104,14 +98,18 @@ Introspection is available by default when developing.
 Introspection on staging and production are for internal use only, so artsy devs can use it to make development for MP clients (eigen, force, etc) easier, but it is and should not be used by any of the clients or anyone else.
 
 In order to set this up in your playground of choice (Postman, Insomnia, Altair, etc), you need to send the following header:
+
 ```
 Authorization: Bearer <secret>
 ```
+
 and replace `<secret>` with the value you get from hokusai using
+
 ```
 hokusai staging env get INTROSPECT_TOKEN
 hokusai production env get INTROSPECT_TOKEN
 ```
+
 or the contents of `Metaphysics INTROSPECT_TOKEN` in 1Password.
 
 ### Sample Queries
@@ -185,6 +183,14 @@ this:
 
   Artsy staff should find follow the instructions in
   https://github.com/artsy/potential/blob/master/platform/Kubernetes.md#hokusai
+
+### Development
+
+- Start the server
+
+  ```
+  hokusai dev start
+  ```
 
 ### Testing
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "prepare": "patch-package",
     "prettier-project": "prettier --write 'src/**/*.{js,ts,tsx,md,graphql}'",
     "schema-drift": "babel-node --no-warnings --extensions '.ts,.js' ./scripts/schema-drift.ts",
-    "setup": " ./scripts/setup.sh",
     "start": "yarn run dev",
     "sync-env": "aws s3 cp s3://artsy-citadel/dev/.env.metaphysics .env.shared && echo 'ENV sync complete.'",
     "test": "yarn type-check && yarn lint && jest",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "prepare": "patch-package",
     "prettier-project": "prettier --write 'src/**/*.{js,ts,tsx,md,graphql}'",
     "schema-drift": "babel-node --no-warnings --extensions '.ts,.js' ./scripts/schema-drift.ts",
+    "setup": " ./scripts/setup.sh",
     "start": "yarn run dev",
     "test": "yarn type-check && yarn lint && jest",
     "test:jest:v1": "yarn jest --config jest.config.v1.js --maxWorkers 3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "schema-drift": "babel-node --no-warnings --extensions '.ts,.js' ./scripts/schema-drift.ts",
     "setup": " ./scripts/setup.sh",
     "start": "yarn run dev",
+    "sync-env": "aws s3 cp s3://artsy-citadel/dev/.env.metaphysics .env.shared && echo 'ENV sync complete.'",
     "test": "yarn type-check && yarn lint && jest",
     "test:jest:v1": "yarn jest --config jest.config.v1.js --maxWorkers 3",
     "test:jest:v2": "yarn jest --config jest.config.v2.js --maxWorkers 3",

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,7 +7,7 @@ set -e
 # https://github.com/artsy/potential/blob/master/scripts/setup
 #
 # Run like:
-#   source scripts/setup.sh
+#   ./scripts/setup.sh
 #
 
 # Install yarn if it does not exist.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -27,7 +27,7 @@ if [[ ! -z $NVM_DIR ]]; then # skip if nvm is not available
 fi
 
 echo "Installing dependencies..."
-yarn install || echo 'Unable to install dependencies using yarn!'
+yarn install
 
 if [ -e ".env" ]; then
   echo '.env file already exists, so skipping initialization...'

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -39,5 +39,5 @@ fi
 echo 'Updating .env.shared file (for shared configuration)...'
 aws s3 cp s3://artsy-citadel/dev/.env.metaphysics .env.shared || return
 
-echo 'Setup complete! To start the server on localhost:3000, run:
-  yarn dev'
+echo 'Setup complete! To start the server, run:
+  yarn start'

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -37,7 +37,7 @@ else
 fi
 
 echo 'Updating .env.shared file (for shared configuration)...'
-aws s3 cp s3://artsy-citadel/dev/.env.metaphysics .env.shared || return
+aws s3 cp s3://artsy-citadel/dev/.env.metaphysics .env.shared || 'Unable to download shared configuration, ensure you have S3 access!'
 
 echo 'Setup complete! To start the server, run:
   yarn start'

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,7 +7,7 @@
 # Commands that may fail have "|| return" to avoid continuing or interfering with terminal.
 
 # Install yarn if it does not exist.
-if ! yarn versions &> /dev/null; then
+if ! which yarn > /dev/null; then
   echo 'yarn is required for setup, installing...'
   if ! which brew > /dev/null; then
     echo 'brew is required to install yarn, see https://docs.brew.sh/Installation'

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -9,7 +9,7 @@
 # Install yarn if it does not exist.
 if ! yarn versions &> /dev/null; then
   echo 'yarn is required for setup, installing...'
-  if ! brew --version &> /dev/null; then
+  if ! which brew > /dev/null; then
     echo 'brew is required to install yarn, see https://docs.brew.sh/Installation'
     exit 0
   fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,17 +6,28 @@
 #
 # Commands that may fail have "|| return" to avoid continuing or interfering with terminal.
 
-if [ ! -z $NVM_DIR ]; then # skip nvm steps if not available
-  echo 'Configuring node 12...'
-  source ~/.nvm/nvm.sh
-  nvm install || return
+# Install yarn if it does not exist.
+if ! yarn versions &> /dev/null; then
+  echo 'yarn is required for setup, installing...'
+  if ! brew --version &> /dev/null; then
+    echo 'brew is required to install yarn, see https://docs.brew.sh/Installation'
+    exit 0
+  fi
+  brew install yarn
 fi
 
-echo 'Installing yarn and memcached...'
-brew bundle || return
+if ! memcached --version &> /dev/null; then
+  brew install memcached
+fi
 
-echo 'Installing node packages...'
-yarn install || return
+if [[ ! -z $NVM_DIR ]]; then # skip if nvm is not available
+  echo "Installing Node..."
+  source ~/.nvm/nvm.sh
+  nvm install
+fi
+
+echo "Installing dependencies..."
+yarn install || echo 'Unable to install dependencies using yarn!'
 
 if [ -e ".env" ]; then
   echo '.env file already exists, so skipping initialization...'

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,18 +1,18 @@
+#!/bin/bash
+
+# Exit if any subcommand fails
+set -e
+
 # This assumes you have general prerequisites installed as by:
 # https://github.com/artsy/potential/blob/master/scripts/setup
 #
 # Run like:
 #   source scripts/setup.sh
 #
-# Commands that may fail have "|| return" to avoid continuing or interfering with terminal.
 
 # Install yarn if it does not exist.
 if ! which yarn > /dev/null; then
-  echo 'yarn is required for setup, installing...'
-  if ! which brew > /dev/null; then
-    echo 'brew is required to install yarn, see https://docs.brew.sh/Installation'
-    exit 0
-  fi
+  echo 'yarn is required for setup, installing with brew...'
   brew install yarn
 fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -16,7 +16,7 @@ if ! which yarn > /dev/null; then
   brew install yarn
 fi
 
-if ! memcached --version &> /dev/null; then
+if ! which memcached > /dev/null; then
   brew install memcached
 fi
 


### PR DESCRIPTION
Related https://github.com/artsy/force/pull/8031

This updates the setup script to match force, with notable changes being:
- check for `yarn` before trying to install 
- check for `memcached` before trying to install
- add `setup` to `package.json` 
- add `sync-env` to `package.json`