### PR TITLE
chore: refining isHangable logic to enable View in Room for more works with depth

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -1322,16 +1322,16 @@ describe("Artwork type", () => {
       `
 
       describe("if the artwork is able to be used with View in Room", () => {
-        it("is hangable if ink artwork is 2d and has reasonable dimensions", () => {
+        it("is hangable if print artwork is 2D and has reasonable dimensions", () => {
           artwork.width = 100
           artwork.height = 100
-          artwork.category = "ink"
+          artwork.category = "print"
           return runQuery(query, context).then((data) => {
             expect(data.artwork.isHangable).toBe(true)
           })
         })
 
-        it("is hangable if artwork is 2d with a reasonable dimensions + tiny depth", () => {
+        it("is hangable if artwork is not 3D category with a reasonable dimensions + tiny depth", () => {
           artwork.width = 100
           artwork.height = 100
           artwork.depth = 0.5
@@ -1341,7 +1341,17 @@ describe("Artwork type", () => {
           })
         })
 
-        it("is hangable if painting artwork is 2d and has reasonable dimensions", () => {
+        it("is hangable if artwork is not in the 3D category or 2D category but has a depth of less than 3", () => {
+          artwork.width = 100
+          artwork.height = 100
+          artwork.depth = 2
+          artwork.category = "ink"
+          return runQuery(query, context).then((data) => {
+            expect(data.artwork.isHangable).toBe(true)
+          })
+        })
+
+        it("is hangable if painting artwork is in 2d category and has reasonable dimensions", () => {
           artwork.width = 100
           artwork.height = 100
           artwork.category = "painting"
@@ -1352,8 +1362,8 @@ describe("Artwork type", () => {
       })
 
       describe("if the artwork is not able to be used with View in Room", () => {
-        it("is not hangable if the category is not applicable to wall display like sculpture", () => {
-          artwork.category = "sculpture"
+        it("is not hangable if the artwork is in a 3D category", () => {
+          artwork.category = "fashion"
           artwork.width = 100
           artwork.height = 100
           return runQuery(query, context).then((data) => {
@@ -1361,8 +1371,8 @@ describe("Artwork type", () => {
           })
         })
 
-        it("is not hangable if the category is not applicable to wall display like installations", () => {
-          artwork.category = "installation"
+        it("is not hangable if the artwork is in a 3D category like sound", () => {
+          artwork.category = "sound"
           artwork.width = 100
           artwork.height = 100
           return runQuery(query, context).then((data) => {
@@ -1370,7 +1380,7 @@ describe("Artwork type", () => {
           })
         })
 
-        it("is not hangable if the work is 3d", () => {
+        it("is not hangable if the work has a large depth", () => {
           artwork.width = 100
           artwork.height = 100
           artwork.depth = 100

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -471,12 +471,36 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       isHangable: {
         type: GraphQLBoolean,
         resolve: (artwork) => {
-          const is3D =
-            _.includes(artwork.category, "sculpture") ||
-            _.includes(artwork.category, "installation") ||
-            _.includes(artwork.category, "design")
+          const categories3D = [
+            "installation",
+            "design",
+            "performance",
+            "sound",
+            "fashion",
+            "architecture",
+            "books_and_portfolios",
+            "jewelry",
+            "other",
+          ]
+          const categories2D = [
+            "print",
+            "drawing_collage_other_work_on_paper",
+            "painting",
+            "photography",
+            "posters",
+            "work_on_paper",
+          ]
 
-          return !is3D && isTwoDimensional(artwork) && !isTooBig(artwork)
+          const areIncluded = (category) =>
+            _.includes(artwork.category, category)
+
+          const is3DCategory = categories3D.some(areIncluded)
+          const is2DCategory = categories2D.some(areIncluded)
+
+          return (
+            (is2DCategory || (!is3DCategory && isTwoDimensional(artwork))) &&
+            !isTooBig(artwork)
+          )
         },
       },
       isInquireable: {

--- a/src/schema/v2/artwork/utilities.ts
+++ b/src/schema/v2/artwork/utilities.ts
@@ -1,7 +1,7 @@
 import { parse } from "url"
 
 export const isDimensional = (value) => parseFloat(value) > 0
-export const isTinyDimensional = (value) => parseFloat(value) > 1
+export const isTinyDimensional = (value) => parseFloat(value) > 3
 
 export const isTwoDimensional = ({ width, height, depth, diameter }) => {
   return (


### PR DESCRIPTION
# PURCHASE-2719
User can still see view 2D works on wall that now have Depth

While looking into this story, I realized we were already enabling VIR for works with a depth of >1. Based on [this discussion](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=41&projectKey=PURCHASE&modal=detail&selectedIssue=PURCHASE-2719&quickFilter=61) with stakeholders, I refined the logic to make `isHangable` always true and thus enable VIR for all works in certain categories (like "painting"), always false for all works in other categories (like "sound"), and for all other works, it is true if the depth of the work is less than 3.