### PR TITLE
feat: add root-level fairOrganizer field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6232,7 +6232,7 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
   marketingCollections(size: Int): [MarketingCollection]!
   mobileImage: Image
   name: String
-  organizer: organizer
+  organizer: FairOrganizer
   profile: Profile
 
   # This connection only supports forward pagination. We're replacing Relay's default cursor with one from Gravity.
@@ -6334,6 +6334,23 @@ type FairExhibitorsGroup {
 
   # Letter exhibitors group belongs to
   letter: String
+}
+
+type FairOrganizer {
+  about: String
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+  name: String
+  profile: Profile
+  profileID: ID
+
+  # A slug ID.
+  slug: ID!
+  website: String
 }
 
 enum FairSorts {
@@ -8760,20 +8777,6 @@ enum OrderedSetSorts {
 
 union OrderParty = Partner | User
 
-type organizer {
-  # A globally unique ID.
-  id: ID!
-
-  # A type-specific ID likely used as a database ID.
-  internalID: ID!
-  profile: Profile
-  profileID: ID
-
-  # A slug ID.
-  slug: ID!
-  website: String
-}
-
 type PageCursor {
   # first cursor on the page
   cursor: String!
@@ -9996,6 +9999,12 @@ type Query {
     # The slug or ID of the Fair
     id: String!
   ): Fair
+
+  # A fair organizer, e.g. The Armory Show
+  fairOrganizer(
+    # The slug or ID of the Fair organizer
+    id: String!
+  ): FairOrganizer
 
   # A list of Fairs
   fairs(
@@ -12551,6 +12560,12 @@ type Viewer {
     # The slug or ID of the Fair
     id: String!
   ): Fair
+
+  # A fair organizer, e.g. The Armory Show
+  fairOrganizer(
+    # The slug or ID of the Fair organizer
+    id: String!
+  ): FairOrganizer
 
   # A list of Fairs
   fairs(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6338,6 +6338,12 @@ type FairExhibitorsGroup {
 
 type FairOrganizer {
   about: String
+  fairsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): FairConnection
 
   # A globally unique ID.
   id: ID!

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -72,6 +72,7 @@ export default (opts) => {
       { headers: true }
     ),
     fairLoader: gravityLoader((id) => `fair/${id}`),
+    fairOrganizerLoader: gravityLoader((id) => `fair_organizer/${id}`),
     fairsLoader: gravityLoader("fairs", {}, { headers: true }),
     filterArtworksLoader: gravityLoader(
       "filter/artworks",

--- a/src/schema/v2/__tests__/fair_organizer.test.ts
+++ b/src/schema/v2/__tests__/fair_organizer.test.ts
@@ -1,0 +1,59 @@
+import gql from "lib/gql"
+import { runQuery } from "schema/v2/test/utils"
+
+describe("fairOrganizer", () => {
+  const query = gql`
+    {
+      fairOrganizer(id: "the-armory-show") {
+        name
+        website
+        profile {
+          href
+        }
+      }
+    }
+  `
+  const fairOrganizerLoader = jest.fn().mockResolvedValue(
+    Promise.resolve({
+      id: "the-armory-show",
+      name: "The Armory Show",
+      website: "https://www.thearmoryshow.com/",
+      profile_id: "the-armory-show",
+    })
+  )
+  const profileLoader = jest.fn().mockResolvedValue(
+    Promise.resolve({
+      id: "the-armory-show",
+      href: "/the-armory-show",
+    })
+  )
+
+  const context = {
+    fairOrganizerLoader: fairOrganizerLoader,
+    profileLoader: profileLoader,
+  }
+
+  afterEach(() => {
+    fairOrganizerLoader.mockClear()
+    profileLoader.mockClear()
+  })
+
+  it("returns a fair organizer", async () => {
+    const result = await runQuery(query, context)
+
+    expect(result.fairOrganizer).toEqual({
+      name: "The Armory Show",
+      website: "https://www.thearmoryshow.com/",
+      profile: { href: "/the-armory-show" },
+    })
+  })
+
+  it("passes args to gravity", async () => {
+    await runQuery(query, context)
+
+    expect(fairOrganizerLoader).toBeCalledTimes(1)
+    expect(profileLoader).toBeCalledTimes(1)
+    expect(fairOrganizerLoader).toBeCalledWith("the-armory-show")
+    expect(profileLoader).toBeCalledWith("the-armory-show")
+  })
+})

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -21,7 +21,6 @@ import {
 } from "./object_identification"
 import {
   GraphQLObjectType,
-  GraphQLID,
   GraphQLString,
   GraphQLBoolean,
   GraphQLNonNull,
@@ -41,6 +40,7 @@ import {
   connectionWithCursorInfo,
   createPageCursors,
 } from "./fields/pagination"
+import { FairOrganizerType } from "./fair_organizer"
 
 const FollowedContentType = new GraphQLObjectType<any, ResolverContext>({
   name: "FollowedContent",
@@ -52,26 +52,6 @@ const FollowedContentType = new GraphQLObjectType<any, ResolverContext>({
       type: new GraphQLList(Partner.type),
     },
   }),
-})
-
-const FairOrganizerType = new GraphQLObjectType<any, ResolverContext>({
-  name: "organizer",
-  fields: {
-    ...SlugAndInternalIDFields,
-    profileID: {
-      type: GraphQLID,
-      resolve: ({ profile_id }) => profile_id,
-    },
-    profile: {
-      type: Profile.type,
-      resolve: ({ profile_id }, _options, { profileLoader }) => {
-        return profileLoader(profile_id).catch(() => null)
-      },
-    },
-    website: {
-      type: GraphQLString,
-    },
-  },
 })
 
 export const FairType = new GraphQLObjectType<any, ResolverContext>({

--- a/src/schema/v2/fair_organizer.ts
+++ b/src/schema/v2/fair_organizer.ts
@@ -1,0 +1,54 @@
+import {
+  GraphQLObjectType,
+  GraphQLID,
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLFieldConfig,
+} from "graphql"
+import { SlugAndInternalIDFields } from "./object_identification"
+import Profile from "./profile"
+import { ResolverContext } from "types/graphql"
+
+export const FairOrganizerType = new GraphQLObjectType<any, ResolverContext>({
+  name: "FairOrganizer",
+  fields: () => {
+    return {
+      ...SlugAndInternalIDFields,
+      about: {
+        type: GraphQLString,
+      },
+      name: {
+        type: GraphQLString,
+      },
+      profileID: {
+        type: GraphQLID,
+        resolve: ({ profile_id }) => profile_id,
+      },
+      profile: {
+        type: Profile.type,
+        resolve: ({ profile_id }, _options, { profileLoader }) => {
+          return profileLoader(profile_id).catch(() => null)
+        },
+      },
+      website: {
+        type: GraphQLString,
+      },
+    }
+  },
+})
+
+const FairOrganizer: GraphQLFieldConfig<void, ResolverContext> = {
+  type: FairOrganizerType,
+  description: "A fair organizer, e.g. The Armory Show",
+  args: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The slug or ID of the Fair organizer",
+    },
+  },
+  resolve: (_root, { id }, { fairOrganizerLoader }) => {
+    return fairOrganizerLoader(id)
+  },
+}
+
+export default FairOrganizer

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -101,6 +101,7 @@ import { UserField } from "./user"
 // import TrendingArtists from "./artists/trending"
 import { Users } from "./users"
 import VanityURLEntity from "./vanityURLEntity"
+import FairOrganizer from "./fair_organizer"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -136,6 +137,7 @@ const rootFields = {
   creditCard: CreditCard,
   // externalPartner: ExternalPartner,
   fair: Fair,
+  fairOrganizer: FairOrganizer,
   fairs: Fairs,
   fairsConnection,
   feature: Feature,


### PR DESCRIPTION
In our quest to update Force's fair organizer app, we realized that we don't have a good way of fetching a fair organizer from Metaphysics when it's not nested inside of something else.

In the "old" [implementation of the fair organizer app in Force](https://github.com/artsy/force/blob/bb0564b88c7aa06f407fd8e9a75577c3ad0f8f0f/src/desktop/apps/fair_organizer/index.coffee#L22), we hit Gravity's `/fair_organizer/:id` route, e.g. `/fair_organizer/the-armory-show`, which gives us back a very limited amount of information about the fair organizer - including the `profile_id`. We then use that ID as a param and pass it to Gravity's `/fairs` endpoint: `/fairs?fair_organizer_id=the-armory-show`. This gets us a paginated list of fairs associated with the fair organizer, which we can then display.

In Metaphysics right now, we [support](https://github.com/artsy/metaphysics/blob/629ff9048de8f497bafc168da1f434199c757bc9/src/schema/v2/fair.ts#L317-L319) fetching a fair organizer as a nested field inside a fair edition, but as far as I can tell, there's no way to just fetch a fair organizer based on a fair organizer ID or slug. There _is_ [a bit of code](https://github.com/artsy/metaphysics/blob/629ff9048de8f497bafc168da1f434199c757bc9/src/schema/v2/partner.ts#L45) in the `partner` endpoint that seems to indicate that you can fetch a `partner` with type `FairOrganizer`, but I believe this is actually incorrect - I have been unable to find anything in Gravity to indicate that a `Partner` can be a fair organizer. Let me know if I missed something though!

So: this PR adds a root-level `fairOrganizer` field and adds a nested `fairsConnection`, so that we can do it all in one go.

Last note: currently, our `get /fair_organizer` endpoint in Gravity [enforces](https://github.com/artsy/gravity/blob/889a590fe3d4109038c269b39acc4fa858487269/app/api/v1/fair_organizers_endpoint.rb#L62) an `admin true` block. I'm frankly not sure how Force deals with this and whether or not it would cause problems with this new field in production, but it was definitely stopping me from fetching results while testing. I got around it by removing the block and running MP against local grav, which worked fine. I'm opening a [separate PR in Gravity](https://github.com/artsy/gravity/pull/14326) to remove that requirement, because it seems strange/unnecessary for `get` requests. Leave a comment there if I'm wrong/it's unnecessary :)

After this PR, you can run something like this:
```graphql
{
  fairOrganizer(id:"the-armory-show") {
    name
    profileID
    website
    profile {
      id
      href
      isPubliclyVisible
    }
    fairsConnection(first: 5) {
      totalCount
      edges {
        cursor
        node {
         name
        }
      }
    }
  }
}
```

...and get back something like this:
```graphql
{
  "data": {
    "fairOrganizer": {
      "name": "The Armory Show",
      "profileID": "the-armory-show",
      "website": "https://www.thearmoryshow.com/",
      "profile": {
        "id": "UHJvZmlsZTo1NTFiMWE2OTcyNjE2OTJiNTJlMTBlMDA=",
        "href": "/the-armory-show",
        "isPubliclyVisible": true
      },
      "fairsConnection": {
        "totalCount": 8,
        "edges": [
          {
            "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
            "node": {
              "name": "The Armory Show 2020"
            }
          },
          {
            "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
            "node": {
              "name": "The Armory Show 2019"
            }
          },
          {
            "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
            "node": {
              "name": "The Armory Show 2018"
            }
          },
          {
            "cursor": "YXJyYXljb25uZWN0aW9uOjM=",
            "node": {
              "name": "The Armory Show 2017"
            }
          },
          {
            "cursor": "YXJyYXljb25uZWN0aW9uOjQ=",
            "node": {
              "name": "The Armory Show 2016"
            }
          }
        ]
      }
    }
  },
  "extensions": {
    "requests": {
      "gravity": {
        "requests": {
          "fair_organizer/the-armory-show": {
            "time": "0s 1.923ms",
            "cache": true,
            "length": "N/A"
          },
          "profile/the-armory-show": {
            "time": "0s 1.129ms",
            "cache": true,
            "length": "N/A"
          },
          "fairs?fair_organizer_id=the-armory-show&page=1&size=5&total_count=true": {
            "time": "0s 1.136ms",
            "cache": true,
            "length": "N/A"
          }
        }
      }
    },
    "requestID": "d5492be0-f07e-11eb-ac59-1bb61fb25790"
  }
}
```