### PR TITLE
Try to fix CI

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,16 @@
     "strict": true,
     "target": "es5"
   },
-  "exclude": ["build", "node_modules", "**/node_modules/*", "dangerfile.ts"]
+  "exclude": [
+    "build",
+    "scripts",
+    "peril",
+    "__mocks__",
+    "node_modules",
+    "**/node_modules/*",
+    "dangerfile.ts",
+    "index.js",
+    "jest.config*.js",
+    "wallaby.js"
+  ]
 }


### PR DESCRIPTION
Ever since [this upgrade to TS 4.3.5](https://github.com/artsy/metaphysics/pull/3224), Metaphysics builds have been failing on javascript source files that are outside the `src` directory. E.g.:

```
error TS6059: File '/home/circleci/project/index.js' is not under 'rootDir' '/home/circleci/project/src'. 'rootDir' is expected to contain all source files.
  The file is in the program because:
    Matched by include pattern '**/*' in '/home/circleci/project/tsconfig.json'
```

This PR adds all the offending files to `tsconfig.json`'s excludes. There's probably a better solution, in which case we should do that instead. I'm just not sure what's conventional or possible here, and builds have been failing in the meantime.