### PR TITLE
chore: fix typescript compilation

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,9 +47,6 @@ if (enableQueryTracing) {
   initTracer()
 }
 
-// Always load the source on startup so any file level issues surface sooner.
-require("./src")
-
 if (enableAsyncStackTraces) {
   console.warn("[FEATURE] Enabling long async stack traces") // eslint-disable-line
   require("longjohn")

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "metaphysics",
   "version": "0.0.1",
   "description": "",
-  "main": "index.js",
   "repository": "https://github.com/artsy/metaphysics",
   "engines": {
     "node": "12",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,11 +10,12 @@
     "noImplicitAny": false,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "rootDir": "./src",
+    "resolveJsonModule": true,
     "pretty": true,
     "skipLibCheck": true,
     "strict": true,
     "target": "es5"
   },
+  "include": ["index.js", "src/**/*"],
   "exclude": ["build", "node_modules", "**/node_modules/*", "dangerfile.ts"]
 }


### PR DESCRIPTION
Opening a different approach to #3313 for consideration.

- Specify `src/**/*` and `index.js` include pattern in tsconfig (default: `**/*`)
- Enable `resolveJsonModule` compiler option
- Remove rootDir, which we were not using correctly
- Remove early ./src require

Addresses the following compilation errors:

```
error TS6059: File '/Users/devon/code/artsy/metaphysics/wallaby.js' is not under 'rootDir' '/Users/devon/code/artsy/metaphysics/src'. 'rootDir' is expected to contain all source files.
  The file is in the program because:
    Matched by include pattern '**/*' in '/Users/devon/code/artsy/metaphysics/tsconfig.json'
```

```
src/schema/v2/fields/money.ts:14:27 - error TS2732: Cannot find module 'lib/currency_codes.json'. Consider using '--resolveJsonModule' to import module with '.json' extension.
```