### PR TITLE
fix: add savedSearchesConnection arguments first/last/before

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8138,7 +8138,12 @@ type Me implements Node {
     sort: SaleSorts
   ): SaleRegistrationConnection
   savedSearch(criteria: SearchCriteriaAttributes, id: ID): SearchCriteria
-  savedSearchesConnection: SearchCriteriaConnection
+  savedSearchesConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): SearchCriteriaConnection
   secondFactors(kinds: [SecondFactorKind]): [SecondFactor]
   type: String
 

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -65,7 +65,12 @@ export const gravityStitchingEnvironment = (
     extensionSchema: gql`
       extend type Me {
         savedSearch(id: ID, criteria: SearchCriteriaAttributes): SearchCriteria
-        savedSearchesConnection: SearchCriteriaConnection
+        savedSearchesConnection(
+          first: Int
+          last: Int
+          after: String
+          before: String
+        ): SearchCriteriaConnection
         secondFactors(kinds: [SecondFactorKind]): [SecondFactor]
         addressConnection(
           first: Int


### PR DESCRIPTION
# Description

savedSearchesConnection was unable to take args for connection and we needed to explicitly declare them on the gravity/v2/stiching.ts file like that:

` after: String
    before: String
    first: Int
    last: Int`