### PR TITLE
feat: update fair organizer about field to take format argument

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6338,7 +6338,7 @@ type FairExhibitorsGroup {
 }
 
 type FairOrganizer {
-  about: String
+  about(format: Format): String
 
   # A connection of articles related to a partner.
   articlesConnection(

--- a/src/schema/v2/fair_organizer.ts
+++ b/src/schema/v2/fair_organizer.ts
@@ -18,6 +18,7 @@ import { pick } from "lodash"
 import { fairConnection } from "./fair"
 import { articleConnection } from "./article"
 import ArticleSorts, { ArticleSort } from "./sorts/article_sorts"
+import { formatMarkdownValue, markdown } from "./fields/markdown"
 
 export const FairOrganizerType = new GraphQLObjectType<any, ResolverContext>({
   name: "FairOrganizer",
@@ -26,6 +27,12 @@ export const FairOrganizerType = new GraphQLObjectType<any, ResolverContext>({
       ...SlugAndInternalIDFields,
       about: {
         type: GraphQLString,
+        args: {
+          ...markdown().args,
+        },
+        resolve: ({ about }, { format }) => {
+          return formatMarkdownValue(about, format)
+        },
       },
       articlesConnection: {
         description: "A connection of articles related to a partner.",


### PR DESCRIPTION
- The about property from Gravity is stored in markdown. This update allows the client to render the text in html, markdown, or plaintext.


cc/ @anastasiapyzhik 

## Example

**Request**

```graphql
{
  fairOrganizer(id: "the-armory-show") {
    about(format: HTML)
  }
}
```

**Response**

```json
{
  "data": {
    "fairOrganizer": {
      "about": "<p>The Armory Show is New York City’s premier art fair and a leading cultural destination for discovering and collecting the world’s most important 20th- and 21st-century art. The Armory Show features presentations by leading international galleries, innovative artist commissions, and dynamic public programs. Since its founding in 1994, The Armory Show has served as a nexus for the art world, inspiring dialogue, discovery, and patronage in the visual arts.</p>\n<p><strong>More Information:</strong><br><a href=\"http://www.thearmoryshow.com/\">http://www.thearmoryshow.com/</a>  </p>\n<p><strong>Location:</strong><br>711 12th Avenue<br>Piers 90 and 94<br>New York, NY 10019</p>\n<p><strong>Contacts:</strong><br>The Armory Show<br>+1 212.645.6440<br><a href=\"mailto:info@thearmoryshow.com\">info@thearmoryshow.com</a></p>\n<p><strong>Follow:</strong><br><a href=\"https://www.facebook.com/ArmoryShow\">Facebook</a><br><a href=\"https://twitter.com/thearmoryshow\">Twitter</a><br><a href=\"https://instagram.com/thearmoryshow/\">Instagram</a>  </p>\n<p><em>Pascale Marthine Tayou. Photo by Teddy Wolff.</em></p>\n"
    }
  }
}
```