### PR TITLE
fix: Hokusai Deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           name: Install hokusai
           command: |
             sudo apt update
-            sudo apt install --assume-yes python-pip
+            sudo apt install --assume-yes python3-pip
             pip install awscli --upgrade
             pip install hokusai
       - hokusai/configure-hokusai


### PR DESCRIPTION
After upgrading to the CircleCI Node 14 image the python dependency
names changed. This updates the depenedcies that hokusai depends on.