### PR TITLE
fix: Fix Python Installation Path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,7 @@ jobs:
           command: |
             sudo apt update
             sudo apt install --assume-yes python3-pip
+            sudo ln -s /usr/bin/python3 /usr/bin/python
             pip install awscli --upgrade
             pip install hokusai
       - hokusai/configure-hokusai


### PR DESCRIPTION
In the latest CircleCI Node image python is installed as python 3, this
sets an alias so that yarn post install hooks execute successfully.