### PR TITLE
feat(PX-4128): arta shipping costs for the artwork

### DIFF
--- a/src/schema/v2/articlesConnection.ts
+++ b/src/schema/v2/articlesConnection.ts
@@ -22,7 +22,7 @@ const ArticlesConnection: GraphQLFieldConfig<void, ResolverContext> = {
   resolve: async (
     _root,
     args: {
-      inEditorialFeed?: Boolean
+      inEditorialFeed?: boolean
       sort?: ArticleSort
     } & CursorPageable,
     { articlesLoader }

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -50,6 +50,7 @@ describe("Artwork type", () => {
       metric: "in",
       unlisted: true,
       category: "Painting",
+      arta_enabled: false,
     }
     context = {
       artworkLoader: sinon
@@ -2171,6 +2172,89 @@ describe("Artwork type", () => {
             artwork: {
               shippingInfo:
                 "Shipping: €10 within Continental Europe, €20 rest of world",
+            },
+          })
+        })
+      })
+    })
+
+    describe("for Arta shipping", () => {
+      beforeEach(() => {
+        artwork.arta_enabled = true
+      })
+
+      it("is set to domestic calculated at checkout only when its domestic_shipping_fee_cents is null and international_shipping_fee_cents is null", () => {
+        artwork.domestic_shipping_fee_cents = null
+        artwork.international_shipping_fee_cents = null
+
+        return runQuery(query, context).then((data) => {
+          expect(data).toEqual({
+            artwork: {
+              shippingInfo: "Shipping: domestic calculated at checkout only",
+            },
+          })
+        })
+      })
+
+      it("is set to domestic calculated at checkout when its domestic_shipping_fee_cents is 0 and international_shipping_fee_cents is 0", () => {
+        artwork.domestic_shipping_fee_cents = 0
+        artwork.international_shipping_fee_cents = 0
+        return runQuery(query, context).then((data) => {
+          expect(data).toEqual({
+            artwork: {
+              shippingInfo:
+                "Shipping: domestic calculated at checkout, free rest of world",
+            },
+          })
+        })
+      })
+
+      it("is set to domestic calculated at checkout only when its domestic_shipping_fee_cents is present and international_shipping_fee_cents is null", () => {
+        artwork.domestic_shipping_fee_cents = 1000
+        artwork.international_shipping_fee_cents = null
+        return runQuery(query, context).then((data) => {
+          expect(data).toEqual({
+            artwork: {
+              shippingInfo: "Shipping: domestic calculated at checkout only",
+            },
+          })
+        })
+      })
+
+      it("is set to domestic calculated at checkout and free international shipping when domestic_shipping_fee_cents is 0 and domestic_shipping_fee_cents is present", () => {
+        artwork.domestic_shipping_fee_cents = 1000
+        artwork.international_shipping_fee_cents = 0
+        return runQuery(query, context).then((data) => {
+          expect(data).toEqual({
+            artwork: {
+              shippingInfo:
+                "Shipping: domestic calculated at checkout, free rest of world",
+            },
+          })
+        })
+      })
+
+      it("is set to domestic calculated at checkout and intermational shipping when domestic_shipping_fee_cents is 0 and international_shipping_fee_cents is present", () => {
+        artwork.domestic_shipping_fee_cents = 0
+        artwork.international_shipping_fee_cents = 10000
+        return runQuery(query, context).then((data) => {
+          expect(data).toEqual({
+            artwork: {
+              shippingInfo:
+                "Shipping: domestic calculated at checkout, $100 rest of world",
+            },
+          })
+        })
+      })
+
+      it("is set to domestic calculated at checkout and intermational shipping when both domestic_shipping_fee_cents and present and international_shipping_fee_cents are set", () => {
+        artwork.domestic_shipping_fee_cents = 1000
+        artwork.international_shipping_fee_cents = 2000
+        return runQuery(query, context).then((data) => {
+          expect(data).toEqual({
+            artwork: {
+              shippingInfo:
+                "Shipping: domestic calculated at checkout, $20 rest of world",
             },
           })
         })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -689,11 +689,13 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           "The string that describes domestic and international shipping.",
         resolve: (artwork) => {
           if (
+            !artwork.arta_enabled &&
             artwork.domestic_shipping_fee_cents == null &&
             artwork.international_shipping_fee_cents == null
           )
             return "Shipping, tax, and additional fees quoted by seller"
           if (
+            !artwork.arta_enabled &&
             artwork.domestic_shipping_fee_cents === 0 &&
             artwork.international_shipping_fee_cents == null
           )
@@ -702,6 +704,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
               : "Free domestic shipping only"
 
           if (
+            !artwork.arta_enabled &&
             artwork.domestic_shipping_fee_cents === 0 &&
             artwork.international_shipping_fee_cents === 0
           )
@@ -727,18 +730,20 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             ? "within Continental Europe"
             : "domestic"
 
-          if (
-            domesticShipping &&
-            artwork.international_shipping_fee_cents == null
-          )
-            return `Shipping: ${domesticShipping} ${shippingRegion} only`
-
           if (artwork.domestic_shipping_fee_cents === 0)
             domesticShipping = "Free"
           if (artwork.international_shipping_fee_cents === 0)
             internationalShipping = "free"
 
-          return `Shipping: ${domesticShipping} ${shippingRegion}, ${internationalShipping} rest of world`
+          const domesticShippingMessage = artwork.arta_enabled
+            ? "domestic calculated at checkout"
+            : `${domesticShipping} ${shippingRegion}`
+
+          if (artwork.international_shipping_fee_cents == null) {
+            return `Shipping: ${domesticShippingMessage} only`
+          }
+
+          return `Shipping: ${domesticShippingMessage}, ${internationalShipping} rest of world`
         },
       },
       shippingOrigin: {

--- a/src/schema/v2/fair_organizer.ts
+++ b/src/schema/v2/fair_organizer.ts
@@ -49,7 +49,7 @@ export const FairOrganizerType = new GraphQLObjectType<any, ResolverContext>({
         resolve: async (
           { profile_id },
           args: {
-            inEditorialFeed?: Boolean
+            inEditorialFeed?: boolean
             sort?: ArticleSort
           } & CursorPageable,
           { articlesLoader, fairsLoader }
@@ -72,7 +72,7 @@ export const FairOrganizerType = new GraphQLObjectType<any, ResolverContext>({
             count: boolean
             offset: number
             sort?: ArticleSort
-            in_editorial_feed?: Boolean
+            in_editorial_feed?: boolean
           }
 
           const articleArgs: ArticleArgs = {

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -126,7 +126,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         resolve: async (
           { _id },
           args: {
-            inEditorialFeed?: Boolean
+            inEditorialFeed?: boolean
             sort?: ArticleSort
           } & CursorPageable,
           { articlesLoader }
@@ -142,7 +142,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             count: boolean
             offset: number
             sort?: ArticleSort
-            in_editorial_feed?: Boolean
+            in_editorial_feed?: boolean
           }
 
           const articleArgs: ArticleArgs = {

--- a/src/schema/v2/partner_category.ts
+++ b/src/schema/v2/partner_category.ts
@@ -1,4 +1,3 @@
-import _ from "lodash"
 import cached from "./fields/cached"
 import PartnerCategoryTypeEnum from "./input_fields/partner_category_type"
 import { SlugAndInternalIDFields } from "./object_identification"
@@ -28,7 +27,7 @@ export const PartnerCategoryType = new GraphQLObjectType<any, ResolverContext>({
       partners: {
         type: Partners.type,
         args: Partners.args,
-        resolve: Partners.resolve
+        resolve: Partners.resolve,
       },
     }
   },


### PR DESCRIPTION
This PR updates `shippingInfo` field to inform users that the shipping price is calculated at checkout if ARTA shipping enabled.

JIRA - https://artsyproduct.atlassian.net/browse/PX-4446 

international_shipping = $200
![image](https://user-images.githubusercontent.com/79979820/129176434-ec8a3a37-e2de-4374-959a-fac722602f2b.png)
international_shipping = free
![image](https://user-images.githubusercontent.com/79979820/129176519-261e179a-1485-4d5c-aa0b-1de2ae77add1.png)
no international_shipping
![image](https://user-images.githubusercontent.com/79979820/129176607-1bc5b283-3ec5-4268-9fb2-d11ba5d0ba17.png)

Let me know if you want to change the messages.