### PR TITLE
feat: expose algolia app id under system>algolia query field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -76,6 +76,7 @@ type Agreement {
 
 type Algolia {
   apiKey: String
+  appID: String
 }
 
 type AnalyticsArtist {

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ require("dotenv").config({
 })
 
 const {
+  ALGOLIA_APP_ID,
   ALGOLIA_RESTRICT_INDICES,
   ALGOLIA_SEARCH_API_KEY,
   ARTICLE_REQUEST_THROTTLE_MS,
@@ -129,6 +130,7 @@ function IntWithDefault(value: any | undefined, defaultValue: number): number {
 }
 
 export default {
+  ALGOLIA_APP_ID,
   ALGOLIA_RESTRICT_INDICES,
   ALGOLIA_SEARCH_API_KEY,
   ARTICLE_REQUEST_THROTTLE_MS: Number(ARTICLE_REQUEST_THROTTLE_MS) || 600000,

--- a/src/schema/v2/system/algolia/index.ts
+++ b/src/schema/v2/system/algolia/index.ts
@@ -9,6 +9,12 @@ import config from "config"
 export const AlgoliaType = new GraphQLObjectType<any, ResolverContext>({
   name: "Algolia",
   fields: () => ({
+    appID: {
+      type: GraphQLString,
+      resolve: () => {
+        config.ALGOLIA_APP_ID
+      },
+    },
     apiKey: {
       type: GraphQLString,
       resolve: async (_root, _options, { meLoader }, _info) => {


### PR DESCRIPTION
Clients need both an app ID and API key to initialize an API client.