### PR TITLE
[PX-4379] Surface selected shipping quote as part of order query

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -4601,6 +4601,7 @@ type CommerceLineItem {
   order: CommerceOrder!
   priceCents: Int! @deprecated(reason: "switch to use listPriceCents")
   quantity: Int!
+  selectedShippingQuote: CommerceShippingQuote
   shipment: CommerceShipment
   shippingQuoteOptions(
     # Returns the elements in the list that come after the specified cursor.

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3136,6 +3136,7 @@ type CommerceLineItem {
   order: CommerceOrder!
   priceCents: Int! @deprecated(reason: "switch to use listPriceCents")
   quantity: Int!
+  selectedShippingQuote: CommerceShippingQuote
   shipment: CommerceShipment
   shippingQuoteOptions(
     # Returns the elements in the list that come after the specified cursor.

--- a/src/data/exchange.graphql
+++ b/src/data/exchange.graphql
@@ -649,6 +649,7 @@ type LineItem {
   order: Order!
   priceCents: Int! @deprecated(reason: "switch to use listPriceCents")
   quantity: Int!
+  selectedShippingQuote: ShippingQuote
   shipment: Shipment
   shippingQuoteOptions(
     """


### PR DESCRIPTION
Exchange changes here: https://github.com/artsy/exchange/pull/831

Part of this ticket: https://artsyproduct.atlassian.net/browse/PX-4379
Allows clients to be able to query for attributes on a collector's selected shipping quote


<img width="1920" alt="Screen Shot 2021-08-13 at 11 48 06 AM" src="https://user-images.githubusercontent.com/12748344/129385965-82492145-4f79-48d4-a17a-4212628bfb41.png">


