### PR TITLE
feat: expose partner field under FairExhibitor type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6324,6 +6324,7 @@ type FairEdge {
 type FairExhibitor {
   # Exhibitor name
   name: String
+  partner: Partner
 
   # Exhibitors _id
   partnerID: String

--- a/src/schema/v2/__tests__/fair.test.js
+++ b/src/schema/v2/__tests__/fair.test.js
@@ -267,6 +267,48 @@ describe("Fair", () => {
     })
   })
 
+  it("exposes the partner type when grouping exhibitors alphanumerically", async () => {
+    const query = gql`
+      {
+        fair(id: "aqua-art-miami-2018") {
+          exhibitorsGroupedByName {
+            letter
+            exhibitors {
+              partner {
+                name
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const partner = {
+      name: "ArtHelix Gallery",
+    }
+
+    context.partnerLoader = sinon.stub().returns(Promise.resolve(partner))
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      fair: {
+        exhibitorsGroupedByName: [
+          {
+            letter: "A",
+            exhibitors: [
+              {
+                partner: {
+                  name: "ArtHelix Gallery",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    })
+  })
+
   it("Shows connection uses gravity cursor", async () => {
     const query = gql`
       {

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -11,7 +11,7 @@ import numeral from "./fields/numeral"
 import Profile from "./profile"
 import Image from "./image"
 import Artist from "./artist"
-import Partner from "./partner"
+import Partner, { PartnerType } from "./partner"
 import { ShowsConnection } from "./show"
 import { LocationType } from "./location"
 import {
@@ -329,6 +329,16 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
                         type: GraphQLString,
                         description: "Exhibitors _id",
                         resolve: ({ partner_id }) => partner_id,
+                      },
+                      partner: {
+                        type: PartnerType,
+                        resolve: (
+                          { partner_id },
+                          _options,
+                          { partnerLoader }
+                        ) => {
+                          return partnerLoader(partner_id).catch(() => null)
+                        },
                       },
                       profileID: {
                         type: GraphQLString,


### PR DESCRIPTION
We're working on a new fair tab that groups exhibitors alphanumerically. This allows the client to fetch partner data without needing to make separate GraphQL requests to:
    
- Fetch all of the groups including partner IDs
- For all groups, utilizing the IDs, fetch the full partner info

In support of [FX-3077]

cc/ @tr-ann 

[FX-3077]: https://artsyproduct.atlassian.net/browse/FX-3077