### PR TITLE
Fix partner category query by properly passing category ID to partners endpoint

### DIFF
--- a/src/schema/v2/__tests__/partner_categories.test.ts
+++ b/src/schema/v2/__tests__/partner_categories.test.ts
@@ -1,0 +1,49 @@
+import { runQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("partnerCategories", () => {
+  it("passes the correct arguments to gravity", async () => {
+    const query = gql`
+      {
+        partnerCategories(categoryType: GALLERY, size: 10, internal: false) {
+          partners(
+            eligibleForListing: true
+            eligibleForPrimaryBucket: true
+            sort: RANDOM_SCORE_DESC
+            defaultProfilePublic: true
+          ) {
+            name
+          }
+        }
+      }
+    `
+
+    const partnerCategoriesLoader = jest.fn(() =>
+      Promise.resolve([
+        {
+          _id: "55f0d1ec776f72193900000b",
+          id: "19th-century-art",
+          category_type: "Gallery",
+          name: "19th Century Art",
+          internal: false,
+        },
+      ])
+    )
+    const partnersLoader = jest.fn(() => Promise.resolve([]))
+
+    await runQuery(query, {
+      partnerCategoriesLoader,
+      partnersLoader,
+    })
+
+    expect(partnersLoader).toBeCalledWith(
+      expect.objectContaining({
+        default_profile_public: true,
+        eligible_for_listing: true,
+        eligible_for_primary_bucket: true,
+        partner_categories: ["19th-century-art"],
+        sort: "-random_score",
+      })
+    )
+  })
+})

--- a/src/schema/v2/partner_category.ts
+++ b/src/schema/v2/partner_category.ts
@@ -9,6 +9,7 @@ import {
   GraphQLBoolean,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { clone } from "lodash"
 
 export const PartnerCategoryType = new GraphQLObjectType<any, ResolverContext>({
   name: "PartnerCategory",
@@ -27,7 +28,37 @@ export const PartnerCategoryType = new GraphQLObjectType<any, ResolverContext>({
       partners: {
         type: Partners.type,
         args: Partners.args,
-        resolve: Partners.resolve,
+        resolve: (
+          { id },
+          {
+            defaultProfilePublic,
+            eligibleForCarousel,
+            eligibleForListing,
+            eligibleForPrimaryBucket,
+            eligibleForSecondaryBucket,
+            hasFullProfile,
+            ..._options
+          },
+          { partnersLoader }
+        ) => {
+          const options: any = {
+            default_profile_public: defaultProfilePublic,
+            eligible_for_carousel: eligibleForCarousel,
+            eligible_for_listing: eligibleForListing,
+            eligible_for_primary_bucket: eligibleForPrimaryBucket,
+            eligible_for_secondary_bucket: eligibleForSecondaryBucket,
+            has_full_profile: hasFullProfile,
+            partner_categories: [id],
+            ..._options,
+          }
+          const cleanedOptions = clone(options)
+          // make ids singular to match gravity :id
+          if (options.ids) {
+            cleanedOptions.id = options.ids
+            delete cleanedOptions.ids
+          }
+          return partnersLoader(cleanedOptions)
+        },
       },
     }
   },

--- a/src/schema/v2/partner_category.ts
+++ b/src/schema/v2/partner_category.ts
@@ -9,7 +9,6 @@ import {
   GraphQLBoolean,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
-import { clone } from "lodash"
 
 export const PartnerCategoryType = new GraphQLObjectType<any, ResolverContext>({
   name: "PartnerCategory",
@@ -28,36 +27,12 @@ export const PartnerCategoryType = new GraphQLObjectType<any, ResolverContext>({
       partners: {
         type: Partners.type,
         args: Partners.args,
-        resolve: (
-          { id },
-          {
-            defaultProfilePublic,
-            eligibleForCarousel,
-            eligibleForListing,
-            eligibleForPrimaryBucket,
-            eligibleForSecondaryBucket,
-            hasFullProfile,
-            ..._options
-          },
-          { partnersLoader }
-        ) => {
-          const options: any = {
-            default_profile_public: defaultProfilePublic,
-            eligible_for_carousel: eligibleForCarousel,
-            eligible_for_listing: eligibleForListing,
-            eligible_for_primary_bucket: eligibleForPrimaryBucket,
-            eligible_for_secondary_bucket: eligibleForSecondaryBucket,
-            has_full_profile: hasFullProfile,
-            partner_categories: [id],
-            ..._options,
-          }
-          const cleanedOptions = clone(options)
-          // make ids singular to match gravity :id
-          if (options.ids) {
-            cleanedOptions.id = options.ids
-            delete cleanedOptions.ids
-          }
-          return partnersLoader(cleanedOptions)
+        resolve: (parent, args, context) => {
+          return Partners.resolve(
+            parent,
+            { ...args, partner_categories: [parent.id] },
+            context
+          )
         },
       },
     }


### PR DESCRIPTION
This PR fixes the bug reported in #product-find-explore, where all of the category-based carousels on the /galleries page were returning the same set of galleries.

I tracked this down to a bug in [this PR](https://github.com/artsy/metaphysics/pull/3259). When exposing the `partnerCategories` field in the v2 schema, I realized that we weren't properly converting camelCase to snake_case for all of the arguments under the sub-`partners` field. I saw an opportunity to simplify this resolver, but in doing so missed [a crucial piece of logic](https://github.com/artsy/metaphysics/pull/3259/files#diff-8e9b07cef48b76d0559107831dc93046d531c35b68dc8c9154052ab3d9b9e2a3L34)! (Where we explicitly pass the parent partner category as an argument).

This PR does the more verbose, but correct, thing and pulls in the full logic from the `partners` resolver (slightly modified). If you see a way to simplify, let me know!