### PR TITLE
feat(PX-4286): Users can see viewing rooms on the gallery profile page

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13014,6 +13014,7 @@ type ViewingRoom {
 
   # Datetime after which the viewing room is no longer viewable
   endAt: ISO8601DateTime
+  exhibitionPeriod: String
   heroImageURL: String @deprecated(reason: "Use image field instead")
   href: String
   image: ARImage

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -470,6 +470,62 @@ describe("gravity/stitching", () => {
     })
   })
 
+  describe("#exhibitionPeriod", () => {
+    it("extends the ViewingRoom type with a exhibitionPeriod field", async () => {
+      const mergedSchema = await getGravityMergedSchema()
+      const artworkConnectionFields = await getFieldsForTypeFromSchema(
+        "ViewingRoom",
+        mergedSchema
+      )
+
+      expect(artworkConnectionFields).toContain("exhibitionPeriod")
+    })
+
+    it("resolves the exhibitionPeriod field on ViewingRoom", async () => {
+      const { resolvers } = await getGravityStitchedSchema()
+      const { exhibitionPeriod } = resolvers.ViewingRoom
+      const startAt = moment().add(1, "days").format("MMM D")
+      const endAt = moment().add(30, "days").format("MMM D")
+
+      expect(
+        exhibitionPeriod.resolve({
+          startAt: momentAdd(1, "days"),
+          endAt: momentAdd(30, "days"),
+        })
+      ).toEqual(`${startAt} – ${endAt}`)
+    })
+
+    it("returns Invalid dates if dates are missing", async () => {
+      const { resolvers } = await getGravityStitchedSchema()
+      const { exhibitionPeriod } = resolvers.ViewingRoom
+      const startAt = moment().add(1, "days").format("MMM D")
+      const endAt = moment().add(30, "days").format("MMM D")
+      const startAtYear = moment().format("YYYY")
+      const endAtAtYear = moment().format("YYYY")
+
+      expect(
+        exhibitionPeriod.resolve({
+          startAt: null,
+          endAt: momentAdd(30, "days"),
+        })
+      ).toEqual(`${"Invalid date"} – ${endAt}, ${endAtAtYear}`)
+
+      expect(
+        exhibitionPeriod.resolve({
+          startAt: momentAdd(1, "days"),
+          endAt: null,
+        })
+      ).toEqual(`${startAt}, ${startAtYear} – ${"Invalid date"}`)
+
+      expect(
+        exhibitionPeriod.resolve({
+          startAt: null,
+          endAt: null,
+        })
+      ).toEqual("Invalid date – Invalid date")
+    })
+  })
+
   describe("#viewingRoomsConnection in Partner", () => {
     it("extends the Partner type with a viewingRoomsConnection field", async () => {
       const mergedSchema = await getGravityMergedSchema()

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -8,6 +8,7 @@ import { formatMarkdownValue } from "schema/v2/fields/markdown"
 import Format from "schema/v2/input_fields/format"
 import { toGlobalId } from "graphql-relay"
 import { printType } from "lib/stitching/lib/printType"
+import { dateRange } from "lib/date"
 
 const LocaleEnViewingRoomRelativeShort = "en-viewing-room-relative-short"
 defineCustomLocale(LocaleEnViewingRoomRelativeShort, {
@@ -98,6 +99,7 @@ export const gravityStitchingEnvironment = (
         distanceToOpen(short: Boolean! = false): String
         distanceToClose(short: Boolean! = false): String
         partner: Partner
+        exhibitionPeriod: String
       }
 
       extend type ArtistSeries {
@@ -534,6 +536,16 @@ export const gravityStitchingEnvironment = (
               info,
             })
           },
+        },
+        exhibitionPeriod: {
+          fragment: gql`
+          ... on ViewingRoom {
+            startAt
+            endAt
+          }
+        `,
+          resolve: ({ startAt: _startAt, endAt: _endAt }) =>
+            dateRange(_startAt, _endAt, "UTC"),
         },
       },
       Viewer: {


### PR DESCRIPTION
Jira Ticket: https://artsyproduct.atlassian.net/browse/PX-4286

This PR expands `ViewingRoom` with the `exhibitionPeriod` field
Related PR for Force: https://github.com/artsy/force/pull/8224

![image](https://user-images.githubusercontent.com/55637696/129737296-4206cb95-872d-4f27-9026-8c42981b97d7.png)
