### PR TITLE
feature: Add displayUSD to auction results realized price

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1898,6 +1898,10 @@ type AuctionResultPriceRealized {
     # Passes in to numeral, such as `'0.00'`
     format: String = ""
   ): String
+  displayUSD(
+    # Passes in to numeral, such as `'0.00'`
+    format: String = ""
+  ): String
 }
 
 # An auction lot result

--- a/src/schema/v2/__tests__/auction_results.test.js
+++ b/src/schema/v2/__tests__/auction_results.test.js
@@ -67,6 +67,7 @@ describe("Artist type", () => {
                 currency
                 priceRealized {
                   display(format: "0a")
+                  displayUSD(format: "0a")
                   cents
                   centsUSD
                 }
@@ -101,6 +102,7 @@ describe("Artist type", () => {
                     cents: 420000,
                     centsUSD: 100000,
                     display: "JPY ¥420k",
+                    displayUSD: "$1k",
                   },
                   estimate: {
                     display: "JPY ¥200,000–¥500,000",
@@ -281,6 +283,7 @@ describe("Artist type", () => {
                   display(format: "0a")
                   cents
                   centsUSD
+                  displayUSD
                 }
               }
             }
@@ -306,6 +309,7 @@ describe("Artist type", () => {
                       display: "JPY ¥0",
                       cents: 0,
                       centsUSD: 0,
+                      displayUSD: "$0",
                     },
                   },
                 },

--- a/src/schema/v2/auction_result.ts
+++ b/src/schema/v2/auction_result.ts
@@ -253,6 +253,23 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
               return priceDisplayText(price_realized_cents, currency, format)
             },
           },
+          displayUSD: {
+            type: GraphQLString,
+            args: {
+              format: {
+                type: GraphQLString,
+                description: "Passes in to numeral, such as `'0.00'`",
+                defaultValue: "",
+              },
+            },
+            resolve: ({ price_realized_cents_usd }, { format }) => {
+              if (isNil(price_realized_cents_usd)) {
+                return null
+              }
+
+              return priceDisplayText(price_realized_cents_usd, "USD", format)
+            },
+          },
         },
       }),
       resolve: (lot) => lot,


### PR DESCRIPTION
Contributes towards [CX-1707]

## Description

Adds a `displayUSD` field to auction results `prizeRealized` (returns e.g. "$100.00").

<img width="1135" alt="Screenshot 2021-08-23 at 21 53 50" src="https://user-images.githubusercontent.com/4691889/130510753-de40b718-42aa-425f-a6c6-16642c6a1e3b.png">

[CX-1707]: https://artsyproduct.atlassian.net/browse/CX-1707

