### PR TITLE
test: use consistent inputs to address spec flakiness

### DIFF
--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -484,15 +484,15 @@ describe("gravity/stitching", () => {
     it("resolves the exhibitionPeriod field on ViewingRoom", async () => {
       const { resolvers } = await getGravityStitchedSchema()
       const { exhibitionPeriod } = resolvers.ViewingRoom
-      const startAt = moment().add(1, "days").format("MMM D")
-      const endAt = moment().add(30, "days").format("MMM D")
+      const startAt = moment("2021-09-01T00:00:00Z")
+      const endAt = moment("2021-09-30T00:00:00Z")
 
       expect(
         exhibitionPeriod.resolve({
-          startAt: momentAdd(1, "days"),
-          endAt: momentAdd(30, "days"),
+          startAt: startAt,
+          endAt: endAt,
         })
-      ).toEqual(`${startAt} – ${endAt}`)
+      ).toEqual("Sep 1 – 30")
     })
 
     it("returns Invalid dates if dates are missing", async () => {


### PR DESCRIPTION
Addresses a flaky test with this failure output:

```
Summary of all failing tests
 FAIL  src/lib/stitching/gravity/__tests__/stitching.test.ts
  ● gravity/stitching › #exhibitionPeriod › resolves the exhibitionPeriod field on ViewingRoom

    expect(received).toEqual(expected) // deep equality

    Expected: "Sep 1 – Sep 30"
    Received: "Sep 1 – 30"

      493 |           endAt: momentAdd(30, "days"),
      494 |         })
    > 495 |       ).toEqual(`${startAt} – ${endAt}`)
          |         ^
      496 |     })
      497 |
      498 |     it("returns Invalid dates if dates are missing", async () => {

      at Object.<anonymous> (src/lib/stitching/gravity/__tests__/stitching.test.ts:495:9)
```