### PR TITLE
feat: add fair sort/filter args to fairOrganizer>fairsConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6375,7 +6375,12 @@ type FairOrganizer {
     after: String
     before: String
     first: Int
+    hasFullFeature: Boolean
+    hasHomepageSection: Boolean
+    hasListing: Boolean
     last: Int
+    sort: FairSorts
+    status: EventStatus
   ): FairConnection
 
   # A globally unique ID.

--- a/src/schema/v2/__tests__/fair_organizer.test.ts
+++ b/src/schema/v2/__tests__/fair_organizer.test.ts
@@ -167,7 +167,7 @@ describe("fairOrganizer", () => {
       gql`
         {
           fairOrganizer(id: "the-armory-show") {
-            fairsConnection(first: 5) {
+            fairsConnection(first: 5, sort: START_AT_DESC) {
               edges {
                 node {
                   internalID
@@ -185,6 +185,7 @@ describe("fairOrganizer", () => {
       page: 1,
       size: 5,
       total_count: true,
+      sort: "-start_at",
     })
 
     expect(result.fairOrganizer.fairsConnection).toEqual({


### PR DESCRIPTION
Includes `hasFullFeature`, `hasHomepageSection`, `hasListing`, `sort`, and `status`.

The default fair sort in Gravity is `-created_at`. When looking for an upcoming fair for an organizer, we currently fetch the first fair and check if the start time is in the future. If a past fair is created after a future fair, we might be checking the wrong entity in the system.

For example:

```
Fair A: created_at=2021-06-30 start_at=2021-08-01 end_at=2021-08-15
Fair B: created_at=2021-06-29 start_at=2021-10-01 end_at=2021-10-31
```

On 2021-09-15, we want to show fair B on the organizer page because it's upcoming but we only check fair A because it was created more recently and returned first due to the default sort.

This gives the client more control over sorting and filtering so that we get the right fairs.

Related to [FX-3241]

[FX-3241]: https://artsyproduct.atlassian.net/browse/FX-3241