### PR TITLE
fix: Missing Post-Deploy Script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 *
 !__mocks__/
+!.circleci/
 !patches/
 !peril/
 !scripts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN chown deploy:deploy $(pwd)
 # Switch to deploy user
 USER deploy
 
+COPY --chown=deploy:deploy --from=builder-base /app/.circleci ./.circleci
 COPY --chown=deploy:deploy --from=builder-base /app/build ./build
 COPY --chown=deploy:deploy --from=builder-base /app/src/data ./src/data
 COPY --chown=deploy:deploy --from=builder-base /opt/node_modules.prod ./node_modules


### PR DESCRIPTION
The hokusai post-deploy script was being excluded from the docker image, this brings it back.