### PR TITLE
chore(schema): makes external non-nullable

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10268,7 +10268,7 @@ type Query {
   ): CreditCard
 
   # A namespace external partners (provided by Galaxy)
-  external: External
+  external: External!
 
   # A Fair
   fair(
@@ -12948,7 +12948,7 @@ type Viewer {
   ): CreditCard
 
   # A namespace external partners (provided by Galaxy)
-  external: External
+  external: External!
 
   # A Fair
   fair(

--- a/src/schema/v2/External/External.ts
+++ b/src/schema/v2/External/External.ts
@@ -95,7 +95,7 @@ const externalType = new GraphQLObjectType<
 })
 
 export const externalField: GraphQLFieldConfig<void, ResolverContext> = {
-  type: externalType,
+  type: new GraphQLNonNull(externalType),
   description: "A namespace external partners (provided by Galaxy)",
   resolve: (_root, _options, _context) => {
     return {}


### PR DESCRIPTION
Minor thing to clean up the types. Longing for the day when we could do this for other parts of the schema.