### PR TITLE
Change saleMessage price formatting

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1520,7 +1520,7 @@ type Artwork implements Node & Searchable & Sellable {
   # Minimal location information describing from where artwork will be shipped.
   shippingOrigin: String
 
-  # Is this work available for shipping only within the Contenental US?
+  # Is this work available for shipping only within the Continental US?
   shipsToContinentalUSOnly: Boolean
     @deprecated(
       reason: "Prefer to use `onlyShipsDomestically`. [Will be removed in v2]"

--- a/src/lib/__tests__/moneyHelpers.test.ts
+++ b/src/lib/__tests__/moneyHelpers.test.ts
@@ -8,11 +8,11 @@ describe("currencyPrefix", () => {
   it("returns the currency symbol if in symbol only list", () => {
     expect(currencyPrefix("EUR")).toBe("€")
     expect(currencyPrefix("GBP")).toBe("£")
-    expect(currencyPrefix("USD")).toBe("$")
     expect(currencyPrefix("MYR")).toBe("RM")
   })
 
   it("returns symbol with prefix if disambiguate_symbol exists", () => {
+    expect(currencyPrefix("USD")).toBe("US$")
     expect(currencyPrefix("HKD")).toBe("HK$")
     expect(currencyPrefix("CAD")).toBe("C$")
     expect(currencyPrefix("AUD")).toBe("A$")

--- a/src/lib/moneyHelpers.ts
+++ b/src/lib/moneyHelpers.ts
@@ -1,7 +1,7 @@
 import currencyCodes from "lib/currency_codes.json"
 import numeral from "numeral"
 
-const symbolOnly = ["USD", "GBP", "EUR", "MYR"]
+const symbolOnly = ["GBP", "EUR", "MYR"]
 
 /**
  * Adds the currency to a price and returns the display text.
@@ -42,11 +42,14 @@ export const isCurrencySupported = (currency: string): boolean => {
  * Builds price display text (e.g. "$100").
  */
 export const priceDisplayText = (
-  priceCents: number,
+  priceCents: number | [number, number],
   currency: string,
   format: string
 ): string => {
-  return currencyPrefix(currency) + priceAmount(priceCents, currency, format)
+  if (typeof priceCents === "number") {
+    return currencyPrefix(currency) + priceAmount(priceCents, currency, format)
+  }
+  return priceRangeDisplayText(priceCents[0], priceCents[1], currency, format)
 }
 
 /**

--- a/src/schema/v2/__tests__/auction_results.test.js
+++ b/src/schema/v2/__tests__/auction_results.test.js
@@ -102,7 +102,7 @@ describe("Artist type", () => {
                     cents: 420000,
                     centsUSD: 100000,
                     display: "JPY ¥420k",
-                    displayUSD: "$1k",
+                    displayUSD: "US$1k",
                   },
                   estimate: {
                     display: "JPY ¥200,000–¥500,000",
@@ -309,7 +309,7 @@ describe("Artist type", () => {
                       display: "JPY ¥0",
                       cents: 0,
                       centsUSD: 0,
-                      displayUSD: "$0",
+                      displayUSD: "US$0",
                     },
                   },
                 },

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -824,13 +824,15 @@ describe("Artwork type", () => {
     it("returns '[Price], on hold' if work is on hold with a price", () => {
       artwork.sale_message = "Not for sale"
       artwork.price = "$420,000"
+      artwork.price_cents = [42000000]
+      artwork.price_currency = "USD"
       artwork.availability = "on hold"
 
       return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
             slug: "richard-prince-untitled-portrait",
-            saleMessage: "$420,000, on hold",
+            saleMessage: "US$420,000, on hold",
           },
         })
       })
@@ -905,7 +907,7 @@ describe("Artwork type", () => {
       })
     })
 
-    it("returns the gravity sale_message if for sale", () => {
+    it("returns the gravity sale_message if for sale but there is no price", () => {
       artwork.availability = "for sale"
       artwork.sale_message = "something from gravity"
 
@@ -914,6 +916,37 @@ describe("Artwork type", () => {
           artwork: {
             slug: "richard-prince-untitled-portrait",
             saleMessage: "something from gravity",
+          },
+        })
+      })
+    })
+
+    it("returns the formatted price if for sale", () => {
+      artwork.availability = "for sale"
+      artwork.price_cents = [42000]
+      artwork.price_currency = "USD"
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            slug: "richard-prince-untitled-portrait",
+            saleMessage: "US$420",
+          },
+        })
+      })
+    })
+
+    it("returns the formatted price range if sale is a price range", () => {
+      artwork.availability = "for sale"
+      artwork.sale_message = "something from gravity"
+      artwork.price_cents = [6900, 42000]
+      artwork.price_currency = "USD"
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            slug: "richard-prince-untitled-portrait",
+            saleMessage: "US$69–US$420",
           },
         })
       })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -57,10 +57,11 @@ import { ArtworkContextGrids } from "./artworkContextGrids"
 import { PageInfoType } from "graphql-relay"
 import { getMicrofunnelDataByArtworkInternalID } from "../artist/targetSupply/utils/getMicrofunnelData"
 import { InquiryQuestionType } from "../inquiry_question"
+import { priceDisplayText } from "lib/moneyHelpers"
 import { LocationType } from "schema/v2/location"
 
 const has_price_range = (price) => {
-  return new RegExp(/\-/).test(price)
+  return new RegExp(/-/).test(price)
 }
 
 const has_multiple_editions = (edition_sets) => {
@@ -666,7 +667,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       shipsToContinentalUSOnly: {
         type: GraphQLBoolean,
         description:
-          "Is this work available for shipping only within the Contenental US?",
+          "Is this work available for shipping only within the Continental US?",
         deprecationReason: deprecate({
           inVersion: 2,
           preferUsageOf: "onlyShipsDomestically",
@@ -897,7 +898,8 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           sale_message,
           availability,
           availability_hidden,
-          price,
+          price_cents,
+          price_currency,
         }) => {
           // Don't display anything if availability is hidden, or artwork is not for sale.
           if (availability_hidden || availability === "not for sale") {
@@ -915,15 +917,18 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             return "Sold"
           }
 
+          const price =
+            price_cents && priceDisplayText(price_cents, price_currency, "")
+
           // If on hold, prepend the price (if there is one).
           if (availability === "on hold") {
-            if (price) {
+            if (price_cents) {
               return `${price}, on hold`
             }
             return "On hold"
           }
 
-          return sale_message
+          return price || sale_message
         },
       },
       series: markdown(),


### PR DESCRIPTION
solves [https://artsyproduct.atlassian.net/browse/PURCHASE-2824]
might solve [https://artsyproduct.atlassian.net/browse/PURCHASE-2404]

Change saleMessage field to display price formatted at metaphysics instead of gravity 
Results: (as is => to be)
AUD $420 => A$420
HKD $420 => HK$420
$420 => US$420
AUD $400-420 => AU$400-AU$420

It affected only saleMessage field, but in other places similar approach could be taken. 
It could affect some tests in other projects as well as integrity tests. 