### PR TITLE
feat(PX-4369): add location to artwork schema

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1461,6 +1461,7 @@ type Artwork implements Node & Searchable & Sellable {
   layers: [ArtworkLayer]
   listPrice: ListPrice
   literature(format: Format): String
+  location: Location
   manufacturer(format: Format): String
 
   # Represents the **materials** used in this work, such as _oil and acrylic on

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -57,6 +57,7 @@ import { ArtworkContextGrids } from "./artworkContextGrids"
 import { PageInfoType } from "graphql-relay"
 import { getMicrofunnelDataByArtworkInternalID } from "../artist/targetSupply/utils/getMicrofunnelData"
 import { InquiryQuestionType } from "../inquiry_question"
+import { LocationType } from "schema/v2/location"
 
 const has_price_range = (price) => {
   return new RegExp(/\-/).test(price)
@@ -554,6 +555,10 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       literature: markdown(({ literature }) =>
         literature.replace(/^literature:\s+/i, "")
       ),
+      location: {
+        type: LocationType,
+        resolve: ({ location }) => location,
+      },
       manufacturer: markdown(),
       medium: {
         type: GraphQLString,


### PR DESCRIPTION
Part of https://artsyproduct.atlassian.net/browse/PX-4369
Add the possibility to query for artwork location, using the REST endpoint in gravity.

<img width="1025" alt="Screenshot 2021-09-06 at 16 16 17" src="https://user-images.githubusercontent.com/7518671/132230550-7267aecd-f45f-492d-ae25-303a01ce1e0e.png">
