### PR TITLE
fix(PURCHASE-2928): Add disambiguate symbol to swiss frank

### DIFF
--- a/src/lib/currency_codes.json
+++ b/src/lib/currency_codes.json
@@ -436,6 +436,7 @@
     "iso_code": "CHF",
     "name": "Swiss Franc",
     "symbol": "CHF",
+    "disambiguate_symbol": "CHF",
     "alternate_symbols": ["SFr", "Fr"],
     "subunit": "Rappen",
     "subunit_to_unit": 100,


### PR DESCRIPTION
solves [PURCHASE-2928] 

Change swiss frank formatting from **CHF CHF1,000** to **CHF1,000** by setting **CHF** as disambiguate symbol

[PURCHASE-2928]: https://artsyproduct.atlassian.net/browse/PURCHASE-2928