### PR TITLE
FX-3277 Send fair organizer id to gravity instead of it's pofile id

### DIFF
--- a/src/schema/v2/fair_organizer.ts
+++ b/src/schema/v2/fair_organizer.ts
@@ -116,7 +116,7 @@ export const FairOrganizerType = new GraphQLObjectType<any, ResolverContext>({
           ...pageable(),
         },
         resolve: async (
-          { profile_id },
+          { id },
           {
             fairOrganizerID,
             hasFullFeature,
@@ -133,7 +133,7 @@ export const FairOrganizerType = new GraphQLObjectType<any, ResolverContext>({
             connectionArgs
           )
           const gravityOptions = {
-            fair_organizer_id: profile_id,
+            fair_organizer_id: id,
             has_full_feature: hasFullFeature,
             has_homepage_section: hasHomepageSection,
             has_listing: hasListing,


### PR DESCRIPTION
[FX-3277]

In the current implementation when requesting fairsConnection of fairOrganizer we send to gravity fairOrganizer's profile id instead of it's own id and thus getting an error in cases those values are not equal 


**Before**

![Screenshot 2021-09-10 at 15 57 04](https://user-images.githubusercontent.com/44819355/132856615-e86074c1-daad-4532-adad-6df830fa6641.png)


**After**

![Screenshot 2021-09-10 at 15 55 41](https://user-images.githubusercontent.com/44819355/132856470-c0106604-5644-4ae0-9955-e78ae6c57f74.png)


[FX-3277]: https://artsyproduct.atlassian.net/browse/FX-3277