### PR TITLE
fix(FX-3294): Group fair exhibitors by numeric or special character within `#` group

### DIFF
--- a/src/schema/v2/__tests__/fair.test.js
+++ b/src/schema/v2/__tests__/fair.test.js
@@ -267,6 +267,187 @@ describe("Fair", () => {
     })
   })
 
+  it("fair exhibitors with special characters or numbers should be within '#'", async () => {
+    const query = gql`
+      {
+        fair(id: "aqua-art-miami-2018") {
+          slug
+          name
+          exhibitorsGroupedByName {
+            letter
+            exhibitors {
+              name
+              slug
+              partnerID
+              profileID
+            }
+          }
+        }
+      }
+    `
+
+    context.fairPartnersLoader = sinon.stub().returns(
+      Promise.resolve({
+        body: [
+          {
+            name: "ArtHelix Gallery",
+            id: "arthelix-gallery",
+            partner_id: "1234567890",
+            partner_show_ids: ["arthelix-gallery"],
+          },
+          {
+            name: "192 Gallery",
+            id: "192-gallery",
+            partner_id: "192-partner-id",
+            partner_show_ids: ["192-gallery"],
+          },
+          {
+            name: "{Suit}",
+            id: "suit-gallery",
+            partner_id: "suit-partner-id",
+            partner_show_ids: ["suit-gallery"],
+          },
+        ],
+        headers: {
+          "x-total-count": 3,
+        },
+      })
+    )
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      fair: {
+        slug: "aqua-art-miami-2018",
+        name: "Aqua Art Miami 2018",
+        exhibitorsGroupedByName: [
+          {
+            letter: "#",
+            exhibitors: [
+              {
+                name: "{Suit}",
+                slug: "suit-gallery",
+                partnerID: "suit-partner-id",
+                profileID: "suit-gallery",
+              },
+              {
+                name: "192 Gallery",
+                slug: "192-gallery",
+                partnerID: "192-partner-id",
+                profileID: "192-gallery",
+              },
+            ],
+          },
+          {
+            letter: "A",
+            exhibitors: [
+              {
+                name: "ArtHelix Gallery",
+                slug: "arthelix-gallery",
+                partnerID: "1234567890",
+                profileID: "arthelix-gallery",
+              },
+            ],
+          },
+        ],
+      },
+    })
+  })
+
+  it("in the '#' group would go special characters first, then numbers", async () => {
+    const query = gql`
+      {
+        fair(id: "aqua-art-miami-2018") {
+          slug
+          name
+          exhibitorsGroupedByName {
+            letter
+            exhibitors {
+              name
+              slug
+              partnerID
+              profileID
+            }
+          }
+        }
+      }
+    `
+
+    context.fairPartnersLoader = sinon.stub().returns(
+      Promise.resolve({
+        body: [
+          {
+            name: "192 Gallery",
+            id: "192-gallery",
+            partner_id: "192-gallery-partner-id",
+            partner_show_ids: ["192-gallery"],
+          },
+          {
+            name: "{Suit}",
+            id: "suit-gallery",
+            partner_id: "suit-gallery-partner-id",
+            partner_show_ids: ["suit-gallery"],
+          },
+          {
+            name: "313 Art Project",
+            id: "313-art-project",
+            partner_id: "313-art-project-partner-id",
+            partner_show_ids: ["313-art-project"],
+          },
+          {
+            name: "#hashtag",
+            id: "hashtag-gallery",
+            partner_id: "hashtag-gallery-partner-id",
+            partner_show_ids: ["hashtag-gallery"],
+          },
+        ],
+        headers: {
+          "x-total-count": 4,
+        },
+      })
+    )
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      fair: {
+        slug: "aqua-art-miami-2018",
+        name: "Aqua Art Miami 2018",
+        exhibitorsGroupedByName: [
+          {
+            letter: "#",
+            exhibitors: [
+              {
+                name: "#hashtag",
+                slug: "hashtag-gallery",
+                partnerID: "hashtag-gallery-partner-id",
+                profileID: "hashtag-gallery",
+              },
+              {
+                name: "{Suit}",
+                slug: "suit-gallery",
+                partnerID: "suit-gallery-partner-id",
+                profileID: "suit-gallery",
+              },
+              {
+                name: "192 Gallery",
+                slug: "192-gallery",
+                partnerID: "192-gallery-partner-id",
+                profileID: "192-gallery",
+              },
+              {
+                name: "313 Art Project",
+                slug: "313-art-project",
+                partnerID: "313-art-project-partner-id",
+                profileID: "313-art-project",
+              },
+            ],
+          },
+        ],
+      },
+    })
+  })
+
   it("exposes the partner type when grouping exhibitors alphanumerically", async () => {
     const query = gql`
       {

--- a/src/schema/v2/__tests__/fair.test.js
+++ b/src/schema/v2/__tests__/fair.test.js
@@ -354,6 +354,93 @@ describe("Fair", () => {
     })
   })
 
+  it("group correctly exhibitors whose names start with accented characters", async () => {
+    const query = gql`
+      {
+        fair(id: "aqua-art-miami-2018") {
+          slug
+          name
+          exhibitorsGroupedByName {
+            letter
+            exhibitors {
+              name
+              slug
+              partnerID
+              profileID
+            }
+          }
+        }
+      }
+    `
+
+    context.fairPartnersLoader = sinon.stub().returns(
+      Promise.resolve({
+        body: [
+          {
+            name: "Ánother Gallery",
+            id: "another-gallery",
+            partner_id: "another-partner-id",
+            partner_show_ids: ["another-gallery"],
+          },
+          {
+            name: "Öther name",
+            id: "other-name",
+            partner_id: "other-partner-id",
+            partner_show_ids: ["other-name"],
+          },
+          {
+            name: "ArtHelix Gallery",
+            id: "arthelix-gallery",
+            partner_id: "1234567890",
+            partner_show_ids: ["arthelix-gallery"],
+          },
+        ],
+        headers: {
+          "x-total-count": 3,
+        },
+      })
+    )
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      fair: {
+        slug: "aqua-art-miami-2018",
+        name: "Aqua Art Miami 2018",
+        exhibitorsGroupedByName: [
+          {
+            letter: "A",
+            exhibitors: [
+              {
+                name: "ArtHelix Gallery",
+                slug: "arthelix-gallery",
+                partnerID: "1234567890",
+                profileID: "arthelix-gallery",
+              },
+              {
+                name: "Ánother Gallery",
+                slug: "another-gallery",
+                partnerID: "another-partner-id",
+                profileID: "another-gallery",
+              },
+            ],
+          },
+          {
+            letter: "O",
+            exhibitors: [
+              {
+                name: "Öther name",
+                slug: "other-name",
+                partnerID: "other-partner-id",
+                profileID: "other-name",
+              },
+            ],
+          },
+        ],
+      },
+    })
+  })
+
   it("in the '#' group would go special characters first, then numbers", async () => {
     const query = gql`
       {

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -356,17 +356,16 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
           if (!root._id) {
             return []
           }
+          interface Exhibitor {
+            name: string
+            profile_id: string
+            id: string
+            partner_id: string
+          }
           const exhibitor_groups: {
             [letter: string]: {
               letter: string
-              exhibitors: [
-                {
-                  name: string
-                  profile_id: string
-                  id: string
-                  partner_id: string
-                }
-              ]
+              exhibitors: Exhibitor[]
             }
           } = {}
           const fetch = allViaLoader(fairPartnersLoader, { path: root._id })
@@ -409,6 +408,29 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
                 }
               }
             }
+
+            // Special characters first, then numbers
+            if (exhibitor_groups["#"]) {
+              const numericExhibitors: Exhibitor[] = []
+              const specialCharacterExhibitors: Exhibitor[] = []
+
+              for (const exhibitor of exhibitor_groups["#"].exhibitors) {
+                const letter = exhibitor.name.charAt(0)
+
+                // Numeric letter
+                if (/[0-9]/.test(letter)) {
+                  numericExhibitors.push(exhibitor)
+                } else {
+                  specialCharacterExhibitors.push(exhibitor)
+                }
+              }
+
+              exhibitor_groups["#"].exhibitors = [
+                ...specialCharacterExhibitors,
+                ...numericExhibitors,
+              ]
+            }
+
             return Object.values(exhibitor_groups)
           })
         },

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -1,4 +1,4 @@
-import { omit, map } from "lodash"
+import { omit, map, deburr } from "lodash"
 import { pageable } from "relay-cursor-paging"
 import { connectionFromArraySlice } from "graphql-relay"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
@@ -381,7 +381,7 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
             for (const fairExhibitor of fairExhibitors) {
               const names = fairExhibitor.name.split(" ")
               const firstName = names[0]
-              let letter = firstName.charAt(0).toUpperCase()
+              let letter = deburr(firstName.charAt(0).toUpperCase())
 
               // Numeric or special symbol
               if (/[^A-Z]/i.test(letter)) {

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -381,7 +381,13 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
             for (const fairExhibitor of fairExhibitors) {
               const names = fairExhibitor.name.split(" ")
               const firstName = names[0]
-              const letter = firstName.charAt(0).toUpperCase()
+              let letter = firstName.charAt(0).toUpperCase()
+
+              // Numeric or special symbol
+              if (/[^A-Z]/i.test(letter)) {
+                letter = "#"
+              }
+
               if (exhibitor_groups[letter]) {
                 exhibitor_groups[letter].exhibitors.push({
                   name: fairExhibitor.name,

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -362,6 +362,7 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
             id: string
             partner_id: string
           }
+          const SPECIAL_GROUP_KEY = "#"
           const exhibitor_groups: {
             [letter: string]: {
               letter: string
@@ -384,7 +385,7 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
 
               // Numeric or special symbol
               if (/[^A-Z]/i.test(letter)) {
-                letter = "#"
+                letter = SPECIAL_GROUP_KEY
               }
 
               if (exhibitor_groups[letter]) {
@@ -410,11 +411,12 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
             }
 
             // Special characters first, then numbers
-            if (exhibitor_groups["#"]) {
+            if (exhibitor_groups[SPECIAL_GROUP_KEY]) {
               const numericExhibitors: Exhibitor[] = []
               const specialCharacterExhibitors: Exhibitor[] = []
+              const exhibitors = exhibitor_groups[SPECIAL_GROUP_KEY].exhibitors
 
-              for (const exhibitor of exhibitor_groups["#"].exhibitors) {
+              for (const exhibitor of exhibitors) {
                 const letter = exhibitor.name.charAt(0)
 
                 // Numeric letter
@@ -425,7 +427,7 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
                 }
               }
 
-              exhibitor_groups["#"].exhibitors = [
+              exhibitor_groups[SPECIAL_GROUP_KEY].exhibitors = [
                 ...specialCharacterExhibitors,
                 ...numericExhibitors,
               ]


### PR DESCRIPTION
solves [FX-3294] 

### Acceptance criteria
- Special characters will go first, then numbers

### Response
```javascript
{
  "data": {
    "fair": {
      "exhibitorsGroupedByName": [
        {
          "letter": "#",
          "exhibitors": [
            {
              "partner": {
                "name": "{Suit}"
              }
            },
            {
              "partner": {
                "name": "193 Gallery"
              }
            },
            {
              "partner": {
                "name": "313 Art Project"
              }
            },
          ]
        },
        {
          "letter": "A",
          "exhibitors": [
            {
              "partner": {
                "name": "A2Z Art Gallery"
              }
            },
          ]
        },
      ]
    }
  }
}
```

[FX-3294]: https://artsyproduct.atlassian.net/browse/FX-3294