### PR TITLE
fix(FX-3300): return only running fairs

### DIFF
--- a/src/schema/v2/home/__tests__/home_page_artwork_modules.test.js
+++ b/src/schema/v2/home/__tests__/home_page_artwork_modules.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable promise/always-return */
 import { map, find } from "lodash"
+import moment from "moment"
 import { runAuthenticatedQuery } from "schema/v2/test/utils"
 
 describe("HomePageArtworkModules", () => {
@@ -354,5 +355,42 @@ describe("HomePageArtworkModules", () => {
 
       expect(keys).toEqual(["followed_galleries"])
     })
+  })
+
+  it("returns first running fair", async () => {
+    const query = `
+    {
+      homePage {
+        artworkModules(
+          maxFollowedGeneRails: -1
+          include: [CURRENT_FAIRS]
+        ) {
+          key
+          title
+        }
+      }
+    }`
+
+    context.fairsLoader = () =>
+      Promise.resolve({
+        body: [
+          {
+            start_at: moment().add(1, "day"),
+            end_at: moment().add(10, "day"),
+            has_homepage_section: true,
+            name: "fair-1",
+          },
+          {
+            start_at: moment().subtract(2, "day"),
+            end_at: moment().add(2, "day"),
+            has_homepage_section: true,
+            name: "fair-2",
+          },
+        ],
+      })
+
+    const { homePage } = await runAuthenticatedQuery(query, context)
+
+    expect(homePage.artworkModules[0].title).toBe("fair-1")
   })
 })

--- a/src/schema/v2/home/fetch.ts
+++ b/src/schema/v2/home/fetch.ts
@@ -19,6 +19,8 @@ export const featuredFair = (
   return fairsLoader({
     size: 5,
     active: true,
+    sort: "-start_at",
+    status: "running",
     has_homepage_section: true,
   }).then(({ body: fairs }) => {
     if (fairs.length) {


### PR DESCRIPTION
The type of this PR is: **Fix**
Solves: [FX-3300]

### Description
* Art Fair rail is appearing on the homepage, even though the fair has not yet launched. Clicking into the fair leads to a 404 error.
* Fairs should not be appearing on homepage rail ahead of start date.

### Demo
It's now **September 13**
```javascript
{
  "data": {
    "homePage": {
      "artworkModules": [
        {
          "key": "current_fairs",
          "context": {
            "name": "The Armory Show 2021",
            "exhibitionPeriod": "Sep 9 – 30"
          }
        }
      ]
    }
  }
}
```

<img width="1280" alt="GraphiQL 2021-09-13 15-30-05" src="https://user-images.githubusercontent.com/3513494/133083927-baf2d88b-d9ab-41bc-a7f1-6049893e4651.png">

[FX-3300]: https://artsyproduct.atlassian.net/browse/FX-3300