### PR TITLE
feat(FX-3301): return sorted letters in order for `exhibitorsGroupedByName`

### DIFF
--- a/src/schema/v2/__tests__/fair.test.js
+++ b/src/schema/v2/__tests__/fair.test.js
@@ -322,6 +322,17 @@ describe("Fair", () => {
         name: "Aqua Art Miami 2018",
         exhibitorsGroupedByName: [
           {
+            letter: "A",
+            exhibitors: [
+              {
+                name: "ArtHelix Gallery",
+                slug: "arthelix-gallery",
+                partnerID: "1234567890",
+                profileID: "arthelix-gallery",
+              },
+            ],
+          },
+          {
             letter: "#",
             exhibitors: [
               {
@@ -335,17 +346,6 @@ describe("Fair", () => {
                 slug: "192-gallery",
                 partnerID: "192-partner-id",
                 profileID: "192-gallery",
-              },
-            ],
-          },
-          {
-            letter: "A",
-            exhibitors: [
-              {
-                name: "ArtHelix Gallery",
-                slug: "arthelix-gallery",
-                partnerID: "1234567890",
-                profileID: "arthelix-gallery",
               },
             ],
           },

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -363,6 +363,7 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
             partner_id: string
           }
           const SPECIAL_GROUP_KEY = "#"
+          const LETTERS_ORDER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ#"
           const exhibitor_groups: {
             [letter: string]: {
               letter: string
@@ -433,7 +434,14 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
               ]
             }
 
-            return Object.values(exhibitor_groups)
+            const values = Object.values(exhibitor_groups).sort((asc, desc) => {
+              return (
+                LETTERS_ORDER.indexOf(asc.letter) -
+                LETTERS_ORDER.indexOf(desc.letter)
+              )
+            })
+
+            return values
           })
         },
       },


### PR DESCRIPTION
The type of this PR is: **Feature**
This PR resolves [FX-3301]

### Expected response
```javascript
{
  "data": {
    "fair": {
      "exhibitorsGroupedByName": [
        {
          "letter": "A"
        },
        {
          "letter": "B"
        },
        {
          "letter": "C"
        },
        {
          "letter": "D"
        },

        ...
        
        {
          "letter": "#"
        }
      ]
    }
  }
}
```

[FX-3301]: https://artsyproduct.atlassian.net/browse/FX-3301