### PR TITLE
feat: [OrderedSet] Add additional Profile type

### DIFF
--- a/src/schema/v2/item.ts
+++ b/src/schema/v2/item.ts
@@ -7,6 +7,7 @@ import { connectionWithCursorInfo } from "schema/v2/fields/pagination"
 import { Gravity } from "types/runtime"
 import { SaleType } from "./sale"
 import { ShowType } from "./show"
+import { ProfileType } from "./profile"
 
 export const OrderedSetItemType = new GraphQLUnionType({
   name: "OrderedSetItem",
@@ -15,6 +16,7 @@ export const OrderedSetItemType = new GraphQLUnionType({
     ArtworkType,
     FeaturedLinkType,
     GeneType,
+    ProfileType,
     SaleType,
     ShowType,
   ],
@@ -32,6 +34,8 @@ export const OrderedSetItemType = new GraphQLUnionType({
         return GeneType
       case "PartnerShow":
         return ShowType
+      case "Profile":
+        return ProfileType
       case "Sale":
         return SaleType
       default:

--- a/src/types/runtime/gravity/OrderedSet.ts
+++ b/src/types/runtime/gravity/OrderedSet.ts
@@ -8,15 +8,15 @@ export const OrderedSet = Record({
   name: String.Or(Null),
   internal_name: String.Or(Null),
   description: String.Or(Null),
-  item_type: Literal("Profile")
-    .Or(Literal("FeaturedLink"))
-    .Or(Literal("Sale"))
-    .Or(Literal("Gene"))
-    .Or(Literal("User"))
+  item_type: Literal("Artist")
     .Or(Literal("Artwork"))
-    .Or(Literal("PartnerShow"))
+    .Or(Literal("FeaturedLink"))
+    .Or(Literal("Gene"))
     .Or(Literal("OrderedSet"))
-    .Or(Literal("Artist")),
+    .Or(Literal("PartnerShow"))
+    .Or(Literal("Profile"))
+    .Or(Literal("Sale"))
+    .Or(Literal("User")),
   owner_type: Literal("Fair")
     .Or(Literal("Feature"))
     .Or(Literal("Post"))


### PR DESCRIPTION
This updates `OrderedSet` to support a new `Profile` type. 

```graphql
{
  orderedSet(id: "5638fdfb7261690296000031") {
    description
    itemType
    orderedItemsConnection(first: 10) {
      edges {
        node {
          __typename
          ... on Profile {
            slug
            internalID
          }
        }
      }
    }
  }
}
```