### PR TITLE
fix(PX-4576): use "Shipping: Сalculated in checkout" for artworks with arta shipping

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -2118,7 +2118,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
-            shippingInfo: "Shipping: calculated at checkout",
+            shippingInfo: "Shipping: Calculated in checkout",
           },
         })
       })

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -2112,6 +2112,18 @@ describe("Artwork type", () => {
       })
     })
 
+    it("is set to calculated at checkout when Arta shipping", () => {
+      artwork.arta_enabled = true
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            shippingInfo: "Shipping: calculated at checkout",
+          },
+        })
+      })
+    })
+
     describe("for artworks that is located within continental EU", () => {
       beforeEach(() => {
         artwork.eu_shipping_origin = true
@@ -2215,89 +2227,6 @@ describe("Artwork type", () => {
             artwork: {
               shippingInfo:
                 "Shipping: €10 within Continental Europe, €20 rest of world",
-            },
-          })
-        })
-      })
-    })
-
-    describe("for Arta shipping", () => {
-      beforeEach(() => {
-        artwork.arta_enabled = true
-      })
-
-      it("is set to domestic calculated at checkout only when its domestic_shipping_fee_cents is null and international_shipping_fee_cents is null", () => {
-        artwork.domestic_shipping_fee_cents = null
-        artwork.international_shipping_fee_cents = null
-
-        return runQuery(query, context).then((data) => {
-          expect(data).toEqual({
-            artwork: {
-              shippingInfo: "Shipping: domestic calculated at checkout only",
-            },
-          })
-        })
-      })
-
-      it("is set to domestic calculated at checkout when its domestic_shipping_fee_cents is 0 and international_shipping_fee_cents is 0", () => {
-        artwork.domestic_shipping_fee_cents = 0
-        artwork.international_shipping_fee_cents = 0
-        return runQuery(query, context).then((data) => {
-          expect(data).toEqual({
-            artwork: {
-              shippingInfo:
-                "Shipping: domestic calculated at checkout, free rest of world",
-            },
-          })
-        })
-      })
-
-      it("is set to domestic calculated at checkout only when its domestic_shipping_fee_cents is present and international_shipping_fee_cents is null", () => {
-        artwork.domestic_shipping_fee_cents = 1000
-        artwork.international_shipping_fee_cents = null
-        return runQuery(query, context).then((data) => {
-          expect(data).toEqual({
-            artwork: {
-              shippingInfo: "Shipping: domestic calculated at checkout only",
-            },
-          })
-        })
-      })
-
-      it("is set to domestic calculated at checkout and free international shipping when domestic_shipping_fee_cents is 0 and domestic_shipping_fee_cents is present", () => {
-        artwork.domestic_shipping_fee_cents = 1000
-        artwork.international_shipping_fee_cents = 0
-        return runQuery(query, context).then((data) => {
-          expect(data).toEqual({
-            artwork: {
-              shippingInfo:
-                "Shipping: domestic calculated at checkout, free rest of world",
-            },
-          })
-        })
-      })
-
-      it("is set to domestic calculated at checkout and intermational shipping when domestic_shipping_fee_cents is 0 and international_shipping_fee_cents is present", () => {
-        artwork.domestic_shipping_fee_cents = 0
-        artwork.international_shipping_fee_cents = 10000
-        return runQuery(query, context).then((data) => {
-          expect(data).toEqual({
-            artwork: {
-              shippingInfo:
-                "Shipping: domestic calculated at checkout, $100 rest of world",
-            },
-          })
-        })
-      })
-
-      it("is set to domestic calculated at checkout and intermational shipping when both domestic_shipping_fee_cents and present and international_shipping_fee_cents are set", () => {
-        artwork.domestic_shipping_fee_cents = 1000
-        artwork.international_shipping_fee_cents = 2000
-        return runQuery(query, context).then((data) => {
-          expect(data).toEqual({
-            artwork: {
-              shippingInfo:
-                "Shipping: domestic calculated at checkout, $20 rest of world",
             },
           })
         })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -719,7 +719,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           "The string that describes domestic and international shipping.",
         resolve: (artwork) => {
           if (artwork.arta_enabled) {
-            return "Shipping: calculated at checkout"
+            return "Shipping: Calculated in checkout"
           }
 
           if (

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -718,14 +718,16 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         description:
           "The string that describes domestic and international shipping.",
         resolve: (artwork) => {
+          if (artwork.arta_enabled) {
+            return "Shipping: calculated at checkout"
+          }
+
           if (
-            !artwork.arta_enabled &&
             artwork.domestic_shipping_fee_cents == null &&
             artwork.international_shipping_fee_cents == null
           )
             return "Shipping, tax, and additional fees quoted by seller"
           if (
-            !artwork.arta_enabled &&
             artwork.domestic_shipping_fee_cents === 0 &&
             artwork.international_shipping_fee_cents == null
           )
@@ -734,7 +736,6 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
               : "Free domestic shipping only"
 
           if (
-            !artwork.arta_enabled &&
             artwork.domestic_shipping_fee_cents === 0 &&
             artwork.international_shipping_fee_cents === 0
           )
@@ -760,20 +761,18 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             ? "within Continental Europe"
             : "domestic"
 
+          if (
+            domesticShipping &&
+            artwork.international_shipping_fee_cents == null
+          )
+            return `Shipping: ${domesticShipping} ${shippingRegion} only`
+
           if (artwork.domestic_shipping_fee_cents === 0)
             domesticShipping = "Free"
           if (artwork.international_shipping_fee_cents === 0)
             internationalShipping = "free"
 
-          const domesticShippingMessage = artwork.arta_enabled
-            ? "domestic calculated at checkout"
-            : `${domesticShipping} ${shippingRegion}`
-
-          if (artwork.international_shipping_fee_cents == null) {
-            return `Shipping: ${domesticShippingMessage} only`
-          }
-
-          return `Shipping: ${domesticShippingMessage}, ${internationalShipping} rest of world`
+          return `Shipping: ${domesticShipping} ${shippingRegion}, ${internationalShipping} rest of world`
         },
       },
       shippingOrigin: {


### PR DESCRIPTION
This PR fixes shipping label for artworks with Arta shipping.

Discussed here - https://artsy.slack.com/archives/C9ZJYFDNF/p1629972053009400
JIRA - https://artsyproduct.atlassian.net/browse/PX-4576

![image](https://user-images.githubusercontent.com/79979820/133736925-e0ae6c06-d357-492f-8dcb-d5f03fe17050.png)

