### PR TITLE
feat: support adding country code to address field

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -15087,6 +15087,9 @@ type UserAddress {
   # Phone number
   phoneNumber: String
 
+  # Phone number country code
+  phoneNumberCountryCode: String
+
   # Postal Code
   postalCode: String
 
@@ -15116,6 +15119,9 @@ input UserAddressAttributes {
 
   # Phone number
   phoneNumber: String
+
+  # ISO Phone number country code
+  phoneNumberCountryCode: String
 
   # Postal code
   postalCode: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9025,7 +9025,14 @@ type OrderedSetEdge {
   node: OrderedSet
 }
 
-union OrderedSetItem = Artist | Artwork | FeaturedLink | Gene | Sale | Show
+union OrderedSetItem =
+    Artist
+  | Artwork
+  | FeaturedLink
+  | Gene
+  | Profile
+  | Sale
+  | Show
 
 # A connection to a list of items.
 type OrderedSetItemConnection {
@@ -12707,6 +12714,9 @@ type UserAddress {
   # Phone number
   phoneNumber: String
 
+  # Phone number country code
+  phoneNumberCountryCode: String
+
   # Postal Code
   postalCode: String
 
@@ -12736,6 +12746,9 @@ input UserAddressAttributes {
 
   # Phone number
   phoneNumber: String
+
+  # ISO Phone number country code
+  phoneNumberCountryCode: String
 
   # Postal code
   postalCode: String

--- a/src/data/gravity.graphql
+++ b/src/data/gravity.graphql
@@ -2179,6 +2179,11 @@ type UserAddress {
   phoneNumber: String
 
   """
+  Phone number country code
+  """
+  phoneNumberCountryCode: String
+
+  """
   Postal Code
   """
   postalCode: String
@@ -2227,6 +2232,11 @@ input UserAddressAttributes {
   Phone number
   """
   phoneNumber: String
+
+  """
+  ISO Phone number country code
+  """
+  phoneNumberCountryCode: String
 
   """
   Postal code

--- a/src/lib/stitching/gravity/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/gravity/__tests__/__snapshots__/schema.test.ts.snap
@@ -1121,6 +1121,9 @@ type UserAddress {
   # Phone number
   phoneNumber: String
 
+  # Phone number country code
+  phoneNumberCountryCode: String
+
   # Postal Code
   postalCode: String
 
@@ -1150,6 +1153,9 @@ input UserAddressAttributes {
 
   # Phone number
   phoneNumber: String
+
+  # ISO Phone number country code
+  phoneNumberCountryCode: String
 
   # Postal code
   postalCode: String


### PR DESCRIPTION
To support phone number validation, we need to add a  phone number country code field to the Address model in [Gravity](https://github.com/artsy/gravity/pull/14447) and enable storing values in the db via MP mutations. This PR introduces the necessary schema updates to support this ch.

https://artsyproduct.atlassian.net/browse/PURCHASE-2938

