### PR TITLE
fix: Remove duplicated "/api" from vortexGraphqlLoader path

### DIFF
--- a/src/lib/loaders/loaders_without_authentication/vortex.ts
+++ b/src/lib/loaders/loaders_without_authentication/vortex.ts
@@ -6,7 +6,7 @@ export const vortexLoaders = (opts) => {
 
   return {
     vortexGraphqlLoader: (body) =>
-      vortexLoader("/api/graphql", body, {
+      vortexLoader("/graphql", body, {
         method: "POST",
       }),
     vortexUserLoader: vortexLoader((userId) => `/api/users/${userId}`),


### PR DESCRIPTION
Addresses [CX-1891]

## Description

Removes duplicated `/api` from `vortexGraphqlLoader` path.

[CX-1891]: https://artsyproduct.atlassian.net/browse/CX-1891