### PR TITLE
fix: Filter out sold artworks for newWorksByInterestingArtists

### DIFF
--- a/src/schema/v2/me/__tests__/newWorksByInterestingArtists.test.ts
+++ b/src/schema/v2/me/__tests__/newWorksByInterestingArtists.test.ts
@@ -51,7 +51,13 @@ describe("newWorksByInterestingArtists", () => {
     `)
 
     expect(vortexGraphqlLoader).toHaveBeenCalled()
-    expect(artworksLoader).toHaveBeenCalled()
+    expect(artworksLoader).toHaveBeenCalledWith({
+      artist_ids: ["608a7417bdfbd1a789ba092a", "608a7416bdfbd1a789ba0911"],
+      availability: "for sale",
+      offset: 0,
+      size: 100,
+      sort: "-published_at",
+    })
   })
 
   it("doesn't return works if user hasn't interacted with any artists", async () => {

--- a/src/schema/v2/me/newWorksByInterestingArtists.ts
+++ b/src/schema/v2/me/newWorksByInterestingArtists.ts
@@ -59,6 +59,7 @@ export const NewWorksByInterestingArtists: GraphQLFieldConfig<
       artworks = await artworksLoader({
         artist_ids: artistIds,
         sort: "-published_at",
+        availability: "for sale",
         size,
         offset,
       })


### PR DESCRIPTION
Addresses [CX-1891]

Changes the `newWorksByInterestingArtists` resolver in order to filter out sold artworks for.

[CX-1891]: https://artsyproduct.atlassian.net/browse/CX-1891