### PR TITLE
feat: [Home] Use HomePageArtworkModuleTypes enum

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7386,7 +7386,7 @@ type HomePage {
     id: String
 
     # Module key
-    key: String
+    key: HomePageArtworkModuleTypes
 
     # ID of related artist to target for related artist rails
     relatedArtistID: String

--- a/src/schema/v2/__tests__/object_identification.test.js
+++ b/src/schema/v2/__tests__/object_identification.test.js
@@ -158,7 +158,7 @@ describe("Object Identification", () => {
         const query = `
           {
             homePage {
-              artworkModule(key: "popular_artists") {
+              artworkModule(key: POPULAR_ARTISTS) {
                 id
               }
             }
@@ -204,7 +204,7 @@ describe("Object Identification", () => {
         const query = `
           {
             homePage {
-              artworkModule(key: "generic_gene", id: "abstract-art") {
+              artworkModule(key: GENERIC_GENES, id: "abstract-art") {
                 id
               }
             }
@@ -261,7 +261,7 @@ describe("Object Identification", () => {
         const query = `
           {
             homePage {
-              artworkModule(key: "related_artists",
+              artworkModule(key: RELATED_ARTISTS,
                              relatedArtistID: "charles-broskoski",
                              followedArtistID: "pablo-picasso") {
                 id

--- a/src/schema/v2/home/__tests__/home_page_artwork_module.test.js
+++ b/src/schema/v2/home/__tests__/home_page_artwork_module.test.js
@@ -9,7 +9,7 @@ describe("HomePageArtworkModule", () => {
         {
           homePage {
             artworkModule(
-              key: "related_artists"
+              key: RELATED_ARTISTS
               followedArtistID: "banksy"
               relatedArtistID: "rob-pruitt"
             ) {
@@ -40,7 +40,7 @@ describe("HomePageArtworkModule", () => {
       const query = gql`
         {
           homePage {
-            artworkModule(key: "followed_artist", followedArtistID: "banksy") {
+            artworkModule(key: FOLLOWED_ARTIST, followedArtistID: "banksy") {
               context {
                 ... on HomePageFollowedArtistArtworkModule {
                   artist {
@@ -66,7 +66,7 @@ describe("HomePageArtworkModule", () => {
       const query = gql`
         {
           homePage {
-            artworkModule(key: "genes", id: "catty-art") {
+            artworkModule(key: GENERIC_GENES, id: "catty-art") {
               results {
                 slug
               }
@@ -89,7 +89,7 @@ describe("HomePageArtworkModule", () => {
     const query = gql`
       {
         homePage {
-          artworkModule(key: "genes") {
+          artworkModule(key: GENERIC_GENES) {
             results {
               slug
             }
@@ -113,7 +113,7 @@ describe("HomePageArtworkModule", () => {
       const query = gql`
         {
           homePage {
-            artworkModule(key: "popular_artists") {
+            artworkModule(key: POPULAR_ARTISTS) {
               key
               title
             }

--- a/src/schema/v2/home/__tests__/home_page_artwork_modules.test.js
+++ b/src/schema/v2/home/__tests__/home_page_artwork_modules.test.js
@@ -176,7 +176,7 @@ describe("HomePageArtworkModules", () => {
       {
         homePage {
           artworkModule(
-            key: "similar_to_recently_viewed"
+            key: SIMILAR_TO_RECENTLY_VIEWED
           ) {
             results { slug }
           }
@@ -212,7 +212,7 @@ describe("HomePageArtworkModules", () => {
       {
         homePage {
           artworkModule(
-            key: "similar_to_saved_works"
+            key: SIMILAR_TO_SAVED_WORKS
           ) {
             results { slug }
           }

--- a/src/schema/v2/home/home_page_artwork_module.ts
+++ b/src/schema/v2/home/home_page_artwork_module.ts
@@ -15,6 +15,7 @@ import {
   GraphQLFieldConfig,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { HomePageArtworkModuleTypes } from "./types"
 
 let possibleArgs
 
@@ -61,7 +62,7 @@ const HomePageArtworkModule: GraphQLFieldConfig<void, ResolverContext> = {
       description: "ID of generic gene rail to target",
     },
     key: {
-      type: GraphQLString,
+      type: HomePageArtworkModuleTypes,
       description: "Module key",
     },
     relatedArtistID: {


### PR DESCRIPTION
Noticed that we weren't getting proper types / intellisense for requesting home modules, looked, and realized that the enum wasn't being assigned: 

<img width="1323" alt="Screen Shot 2021-09-21 at 4 36 07 PM" src="https://user-images.githubusercontent.com/236943/134261524-9f7e3c8f-996f-40cc-8aa8-d83f6584de89.png">

Have looked through Force and Eigen and it appears this field isn't yet being used, though it might be accessed in some old version of the mobile app. Thoughts?  


