### PR TITLE
feat: Add showsByFollowedArtists

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8412,6 +8412,18 @@ type Me implements Node {
   ): SearchCriteriaConnection
   secondFactors(kinds: [SecondFactorKind]): [SecondFactor]
   shareFollows: Boolean!
+
+  # A list of shows by followed artists
+  showsByFollowedArtists(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    sort: ShowSorts
+
+    # Filter shows by chronological event status
+    status: EventStatus
+  ): ShowConnection
   type: String
 
   # The count of conversations with unread messages.

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -78,6 +78,11 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    followedArtistsShowsLoader: gravityLoader(
+      "me/follow/artists/shows",
+      {},
+      { headers: true }
+    ),
     followedArtistsLoader: gravityLoader(
       "me/follow/artists",
       {},

--- a/src/schema/v2/me/__tests__/showsByFollowedArtists.test.ts
+++ b/src/schema/v2/me/__tests__/showsByFollowedArtists.test.ts
@@ -1,0 +1,75 @@
+/* eslint-disable promise/always-return */
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("Me", () => {
+  describe("ShowsByFollowedArtists", () => {
+    it("returns shows by followed artists", async () => {
+      const query = gql`
+        {
+          me {
+            showsByFollowedArtists(
+              first: 100
+              sort: NAME_ASC
+              status: UPCOMING
+            ) {
+              totalCount
+              edges {
+                node {
+                  name
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const expectedConnectionData = {
+        totalCount: 2,
+        edges: [
+          {
+            node: {
+              name: "Show 1",
+            },
+          },
+          {
+            node: {
+              name: "Show 2",
+            },
+          },
+        ],
+      }
+
+      const followedArtistsShowsLoader = jest.fn(async () => ({
+        headers: { "x-total-count": 2 },
+        body: [
+          {
+            name: "Show 1",
+          },
+          {
+            name: "Show 2",
+          },
+        ],
+      }))
+
+      const context = {
+        meLoader: () => Promise.resolve({}),
+        followedArtistsShowsLoader,
+      }
+
+      const {
+        me: { showsByFollowedArtists },
+      } = await runAuthenticatedQuery(query, context)
+
+      expect(showsByFollowedArtists).toEqual(expectedConnectionData)
+
+      expect(followedArtistsShowsLoader).toHaveBeenCalledWith({
+        offset: 0,
+        size: 100,
+        sort: "name",
+        status: "upcoming",
+        total_count: true,
+      })
+    })
+  })
+})

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -44,6 +44,7 @@ import { RecentlyViewedArtworks } from "./recently_viewed_artworks"
 import { SaleRegistrationConnection } from "./sale_registrations"
 import { SavedArtworks } from "./savedArtworks"
 import { WatchedLotConnection } from "./watchedLotConnection"
+import { ShowsByFollowedArtists } from "./showsByFollowedArtists"
 
 const Me = new GraphQLObjectType<any, ResolverContext>({
   name: "Me",
@@ -220,6 +221,7 @@ const Me = new GraphQLObjectType<any, ResolverContext>({
     type: {
       type: GraphQLString,
     },
+    showsByFollowedArtists: ShowsByFollowedArtists,
     unreadNotificationsCount: {
       type: new GraphQLNonNull(GraphQLInt),
       description: "A count of unread notifications.",

--- a/src/schema/v2/me/showsByFollowedArtists.ts
+++ b/src/schema/v2/me/showsByFollowedArtists.ts
@@ -1,0 +1,53 @@
+import { GraphQLFieldConfig } from "graphql"
+import { getPagingParameters, pageable } from "relay-cursor-paging"
+import { ResolverContext } from "types/graphql"
+import { connectionFromArraySlice } from "graphql-relay"
+import EventStatus from "../input_fields/event_status"
+import ShowSorts from "../sorts/show_sorts"
+import { ShowsConnection } from "../show"
+
+export const ShowsByFollowedArtists: GraphQLFieldConfig<
+  void,
+  ResolverContext
+> = {
+  type: ShowsConnection.connectionType,
+  args: pageable({
+    sort: {
+      type: ShowSorts,
+    },
+    status: {
+      type: EventStatus.type,
+      defaultValue: "current",
+      description: "Filter shows by chronological event status",
+    },
+  }),
+  description: "A list of shows by followed artists",
+  resolve: async (_root, options, { followedArtistsShowsLoader }) => {
+    if (!followedArtistsShowsLoader) return null
+
+    const { limit: size, offset } = getPagingParameters(options)
+    const { sort, status } = options
+
+    const gravityArgs = {
+      size,
+      offset,
+      total_count: true,
+      sort,
+      status,
+    }
+
+    const { body: shows, headers } = await followedArtistsShowsLoader(
+      gravityArgs
+    )
+
+    const count = parseInt(headers["x-total-count"] || "0", 10)
+
+    return {
+      totalCount: count,
+      ...connectionFromArraySlice(shows, options, {
+        arrayLength: count,
+        sliceStart: offset,
+      }),
+    }
+  },
+}


### PR DESCRIPTION

Addresses [CX-1957]

## Description

Adds showsByFollowedArtists field under me that returns all shows including artists the user follows.

Depends on https://github.com/artsy/gravity/pull/14458

### Example Query

```
query ShowsByFollowedArtistsQuery {
  me {
    showsByFollowedArtists(first: 100, sort: NAME_ASC, status: UPCOMING) {
      totalCount
      edges {
        node {
          name
        }
      }
    }
  }
}

```

[CX-1957]: https://artsyproduct.atlassian.net/browse/CX-1957