### PR TITLE
Fix price range display when price is in the lowest or highest bucket (PURCHASE-2970)

### DIFF
--- a/src/lib/__tests__/moneyHelpers.test.ts
+++ b/src/lib/__tests__/moneyHelpers.test.ts
@@ -27,6 +27,7 @@ describe("currencyPrefix", () => {
 
 describe("priceDisplayText", () => {
   it("builds display text", () => {
+    expect(priceDisplayText(100, "USD", "")).toBe("US$1")
     expect(priceDisplayText(100, "EUR", "")).toBe("€1")
     expect(priceDisplayText(100, "CAD", "")).toBe("C$1")
     expect(priceDisplayText(100, "VUV", "")).toBe("VUV Vt100")
@@ -35,6 +36,7 @@ describe("priceDisplayText", () => {
 
 describe("priceRangeDisplayText", () => {
   it("builds display text with range", () => {
+    expect(priceRangeDisplayText(10000, 20000, "USD", "")).toBe("US$100–US$200")
     expect(priceRangeDisplayText(10000, 20000, "EUR", "")).toBe("€100–€200")
     expect(priceRangeDisplayText(100, 200, "MXN", "")).toBe("MX$1–MX$2")
     expect(priceRangeDisplayText(100, 200, "VUV", "")).toBe("VUV Vt100–Vt200")

--- a/src/lib/__tests__/moneyHelpers.test.ts
+++ b/src/lib/__tests__/moneyHelpers.test.ts
@@ -40,11 +40,22 @@ describe("priceRangeDisplayText", () => {
     expect(priceRangeDisplayText(100, 200, "VUV", "")).toBe("VUV Vt100–Vt200")
   })
 
-  it("builds display text with lowest", () => {
-    expect(priceRangeDisplayText(10000, 0, "EUR", "")).toBe("€100")
+  it("doesn't care if low and high prices passed in are out of order", () => {
+    expect(priceRangeDisplayText(10000, 0, "EUR", "")).toBe("€100–€0")
+    expect(priceRangeDisplayText(10000, 100, "EUR", "")).toBe("€100–€1")
   })
 
-  it("builds display text with highest", () => {
-    expect(priceRangeDisplayText(0, 20000, "EUR", "")).toBe("€200")
+  it("returns an empty string when both low and high prices are empty", () => {
+    expect(priceRangeDisplayText(null, null, "EUR", "")).toBe("")
+  })
+
+  it("prepends text 'Under' when low price is not given", () => {
+    expect(priceRangeDisplayText(null, 10000, "EUR", "")).toBe("Under €100")
+    expect(priceRangeDisplayText(null, 100, "VUV", "")).toBe("Under VUV Vt100")
+  })
+
+  it("appends text 'and up' when high price is not given", () => {
+    expect(priceRangeDisplayText(10000, null, "EUR", "")).toBe("€100 and up")
+    expect(priceRangeDisplayText(100, null, "VUV", "")).toBe("VUV Vt100 and up")
   })
 })

--- a/src/lib/moneyHelpers.ts
+++ b/src/lib/moneyHelpers.ts
@@ -39,21 +39,18 @@ export const isCurrencySupported = (currency: string): boolean => {
 }
 
 /**
- * Builds price display text (e.g. "$100").
+ * Builds price display text (e.g. "US$100").
  */
 export const priceDisplayText = (
-  priceCents: number | [number, number],
+  priceCents: number,
   currency: string,
   format: string
 ): string => {
-  if (typeof priceCents === "number") {
-    return currencyPrefix(currency) + priceAmount(priceCents, currency, format)
-  }
-  return priceRangeDisplayText(priceCents[0], priceCents[1], currency, format)
+  return currencyPrefix(currency) + priceAmount(priceCents, currency, format)
 }
 
 /**
- * Builds price range display text (e.g. "$100–$200" or "VUV Vt100–Vt200")..
+ * Builds price range display text (e.g. "US$100–US$200" or "VUV Vt100–Vt200")..
  */
 export const priceRangeDisplayText = (
   lowerPriceCents: number | null,

--- a/src/lib/moneyHelpers.ts
+++ b/src/lib/moneyHelpers.ts
@@ -56,32 +56,32 @@ export const priceDisplayText = (
  * Builds price range display text (e.g. "$100–$200" or "VUV Vt100–Vt200")..
  */
 export const priceRangeDisplayText = (
-  lowerPriceCents: number,
-  higherPriceCents: number,
+  lowerPriceCents: number | null,
+  higherPriceCents: number | null,
   currency: string,
   format: string
 ): string => {
-  if (!lowerPriceCents || !higherPriceCents) {
-    return priceDisplayText(
-      lowerPriceCents || higherPriceCents,
-      currency,
-      format
-    )
+  if (lowerPriceCents == null && higherPriceCents == null) {
+    return ""
   }
 
-  const lowerCurrencyPrefix = currencyPrefix(currency)
-  const higherCurrencyPrefix = lowerCurrencyPrefix.includes(" ")
-    ? lowerCurrencyPrefix.split(" ")[1]
-    : lowerCurrencyPrefix
+  const fullPrefix = currencyPrefix(currency)
+  const shortPrefix = fullPrefix.includes(" ")
+    ? fullPrefix.split(" ")[1]
+    : fullPrefix
 
-  const lowerPriceAmount = priceAmount(lowerPriceCents, currency, format)
-  const higherPriceAmount = priceAmount(higherPriceCents, currency, format)
+  if (lowerPriceCents == null) {
+    const amount = priceAmount(higherPriceCents as number, currency, format)
+    return `Under ${fullPrefix}${amount}`
+  }
 
-  return (
-    lowerCurrencyPrefix +
-    lowerPriceAmount +
-    "–" +
-    higherCurrencyPrefix +
-    higherPriceAmount
-  )
+  if (higherPriceCents == null) {
+    const amount = priceAmount(lowerPriceCents as number, currency, format)
+    return `${fullPrefix}${amount} and up`
+  }
+
+  const low = priceAmount(lowerPriceCents, currency, format)
+  const high = priceAmount(higherPriceCents, currency, format)
+
+  return `${fullPrefix}${low}–${shortPrefix}${high}`
 }

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -57,7 +57,7 @@ import { ArtworkContextGrids } from "./artworkContextGrids"
 import { PageInfoType } from "graphql-relay"
 import { getMicrofunnelDataByArtworkInternalID } from "../artist/targetSupply/utils/getMicrofunnelData"
 import { InquiryQuestionType } from "../inquiry_question"
-import { priceDisplayText } from "lib/moneyHelpers"
+import { priceDisplayText, priceRangeDisplayText } from "lib/moneyHelpers"
 import { LocationType } from "schema/v2/location"
 
 const has_price_range = (price) => {
@@ -916,18 +916,31 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             return "Sold"
           }
 
-          const price =
-            price_cents && priceDisplayText(price_cents, price_currency, "")
+          let formatted
+
+          if (price_cents) {
+            formatted =
+              price_cents.length === 1
+                ? priceDisplayText(price_cents[0], price_currency, "")
+                : priceRangeDisplayText(
+                    price_cents[0],
+                    price_cents[1],
+                    price_currency,
+                    ""
+                  )
+          } else {
+            formatted = sale_message
+          }
 
           // If on hold, prepend the price (if there is one).
           if (availability === "on hold") {
             if (price_cents) {
-              return `${price}, on hold`
+              return `${formatted}, on hold`
             }
             return "On hold"
           }
 
-          return price || sale_message
+          return formatted
         },
       },
       series: markdown(),


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/PURCHASE-2970

When an artwork is set as displaying price range and is in the lowest (`[nil, 1000]`) or highest (`[10_000_000, nil]`) bucket, the price is displayed incorrectly with an exact price, rather than the "Under [price]" or "[price] and up" language.

This fixes it by updating the `priceRangeDisplayText` logic and the `saleMessage` resolver. More details inline.

It's not ideal there if duplicate and inconsistent formatting logic in MP and Gravity that deserves a bigger discussion. This only fixes the immediate issue.

### Before and after
#### Price in the lowest bucket
![Screen Shot 2021-09-30 at 11 46 45 PM](https://user-images.githubusercontent.com/796573/135566836-35d4ae4f-367e-42db-9421-5a7a9897a30b.png)
![Screen Shot 2021-09-30 at 11 47 05 PM](https://user-images.githubusercontent.com/796573/135566837-754cd047-6d06-4c23-8015-cef3c3fc117a.png)

#### Price in the highest bucket
![Screen Shot 2021-10-01 at 12 36 03 AM](https://user-images.githubusercontent.com/796573/135566856-5de04b04-bc35-4c07-999f-8d96c24c9aaa.png)
![Screen Shot 2021-10-01 at 12 36 22 AM](https://user-images.githubusercontent.com/796573/135566857-0148ce48-f680-409a-ade0-21e9854ea0ba.png)


