### PR TITLE
fix(FX-3421): pass fair id instead of profile id

### DIFF
--- a/src/schema/v2/fair_organizer.ts
+++ b/src/schema/v2/fair_organizer.ts
@@ -49,7 +49,7 @@ export const FairOrganizerType = new GraphQLObjectType<any, ResolverContext>({
           },
         }),
         resolve: async (
-          { profile_id },
+          { id },
           args: {
             inEditorialFeed?: boolean
             sort?: ArticleSort
@@ -61,7 +61,7 @@ export const FairOrganizerType = new GraphQLObjectType<any, ResolverContext>({
           )
 
           const gravityOptions = {
-            fair_organizer_id: profile_id,
+            fair_organizer_id: id,
             size: 100,
           }
 


### PR DESCRIPTION
Jira ticket: [FX-3421]

### Description
We passed `profileID` instead of `fair ID`. As a result, we received an error message `Fair Organizer Not Found`

<img width="1261" alt="GraphiQL 2021-10-04 17-33-50" src="https://user-images.githubusercontent.com/3513494/135873336-3a70a3d3-1b91-4d58-8abd-8e0c3d304bc3.png">


