### PR TITLE
Revert "chore(deps): update dep typescript from 4.3.5 to v4.4.3"

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "sinon": "1.17.7",
     "superagent": "3.8.3",
     "supertest": "3.1.0",
-    "typescript": "4.4.3"
+    "typescript": "4.3.5"
   },
   "prettier": {
     "semi": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10250,10 +10250,10 @@ type-is@~1.6.15:
     media-typer "0.3.0"
     mime-types "~2.1.15"
 
-typescript@4.4.3:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
-  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
+typescript@4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 ua-parser-js@^0.7.18, ua-parser-js@^0.7.9:
   version "0.7.28"


### PR DESCRIPTION
Reverts artsy/metaphysics#3368

This never ran the type-check and is blocking production deploys 🤔 Let's revert since there's an important bugfix to send out (https://github.com/artsy/metaphysics/pull/3449/commits/61f416eb9024db07c07a6aae4e4c8447ed1d8b1f), and then re-update TypeScript later