### PR TITLE
fix(types): disables use unknown in catch

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,11 +10,12 @@
     "noImplicitAny": false,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "resolveJsonModule": true,
     "pretty": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "es5"
+    "target": "es5",
+    "useUnknownInCatchVariables": false
   },
   "include": ["index.js", "src/**/*"],
   "exclude": ["build", "node_modules", "**/node_modules/*", "dangerfile.ts"]


### PR DESCRIPTION
Re: https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables

Not sure why this passed and merged: https://github.com/artsy/metaphysics/pull/3368