### PR TITLE
chore: return grapqhl error stack when non in production

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -251,6 +251,12 @@ function startApp(appSchema, path: string) {
         validationRules,
         extensions: ({ document, result }) =>
           createExtensions(document, result, requestID),
+        formatError: (error) => ({
+          // better errors formatting for clients
+          // See errorMiddleware in  https://github.com/relay-tools/react-relay-network-modern/blob/master/README.md#built-in-middlewares
+          message: error.message,
+          stack: !PRODUCTION_ENV ? error.stack.split("\n") : null,
+        }),
       }
     })
 


### PR DESCRIPTION
For a long time, we were getting non-useful error messages from metaphysics about what went wrong with the query. We were also getting a hint on how we can solve that by properly returning the stack trace. I followed the `errorMiddleware` docs as recommended here https://github.com/relay-tools/react-relay-network-modern#built-in-middlewares and appended our `graphqlHTTP` wrapper to return the stack inside `formatError` in non-production envs (not sure if we actually should hide it in production builds as well, let me know what you think).


**Error formatting in Eigen Before the changes**
![Simulator Screen Shot - iPhone 12 Pro - 2021-10-11 at 13 22 21](https://user-images.githubusercontent.com/11945712/136784143-763d1a2a-66c9-4676-a96c-dfe2e2f3db44.png)

**Error formatting in Eigen After the changes**
![Simulator Screen Shot - iPhone 12 Pro - 2021-10-11 at 13 32 45](https://user-images.githubusercontent.com/11945712/136784157-23354a3d-0b98-416c-a744-94361b352325.png)

