### PR TITLE
feat: Set artist affinity score threshold to 0.5

### DIFF
--- a/src/schema/v2/me/__tests__/newWorksByInterestingArtists.test.ts
+++ b/src/schema/v2/me/__tests__/newWorksByInterestingArtists.test.ts
@@ -50,7 +50,21 @@ describe("newWorksByInterestingArtists", () => {
       }
     `)
 
-    expect(vortexGraphqlLoader).toHaveBeenCalled()
+    expect(vortexGraphqlLoader).toHaveBeenCalledWith({
+      query: gql`
+        query artistAffinitiesQuery {
+          artistAffinities(first: 50, minScore: 0.5) {
+            totalCount
+            edges {
+              node {
+                artistId
+                score
+              }
+            }
+          }
+        }
+      `,
+    })
     expect(artworksLoader).toHaveBeenCalledWith({
       artist_ids: ["608a7417bdfbd1a789ba092a", "608a7416bdfbd1a789ba0911"],
       availability: "for sale",

--- a/src/schema/v2/me/newWorksByInterestingArtists.ts
+++ b/src/schema/v2/me/newWorksByInterestingArtists.ts
@@ -9,6 +9,7 @@ import gql from "lib/gql"
 
 const MAX_ARTISTS = 50
 const MAX_ARTWORKS = 100
+const MIN_AFFINITY_SCORE = 0.5
 
 export const NewWorksByInterestingArtists: GraphQLFieldConfig<
   void,
@@ -34,7 +35,7 @@ export const NewWorksByInterestingArtists: GraphQLFieldConfig<
     const vortexResult = await vortexGraphqlLoader({
       query: gql`
         query artistAffinitiesQuery {
-          artistAffinities(first: ${MAX_ARTISTS}) {
+          artistAffinities(first: ${MAX_ARTISTS}, minScore: ${MIN_AFFINITY_SCORE}) {
             totalCount
             edges {
               node {


### PR DESCRIPTION
Addresses [CX-2043]

Depends on https://github.com/artsy/vortex/pull/334

## Description

Sets the score threshold for artist affinities to 0.5 for `newWorksByInterestingArtist` in order to filter out artworks by artists the user hasn't interacted with a lot.

[CX-2043]: https://artsyproduct.atlassian.net/browse/CX-2043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ