### PR TITLE
feat: add comparable auction results

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1844,6 +1844,14 @@ type AuctionResult implements Node {
   artistID: String!
   boughtIn: Boolean
   categoryText: String
+
+  # Comparable auction results
+  comparableAuctionResults(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AuctionResultConnection
   currency: String
   date(
     format: String

--- a/src/lib/loaders/loaders_without_authentication/diffusion.ts
+++ b/src/lib/loaders/loaders_without_authentication/diffusion.ts
@@ -8,5 +8,8 @@ export default (opts) => {
     auctionLotsLoader: diffusionLoader("lots"),
     auctionLotLoader: diffusionLoader((id) => `lots/${id}`),
     auctionCreatedYearRangeLoader: diffusionLoader("lots/created_dates"),
+    comparableAuctionResultsLoader: diffusionLoader(
+      (id) => `lots/${id}/comparable_lots`
+    ),
   }
 }

--- a/src/schema/v2/__tests__/auction_result.test.ts
+++ b/src/schema/v2/__tests__/auction_result.test.ts
@@ -152,3 +152,97 @@ describe("AuctionResult type", () => {
     })
   })
 })
+
+const mockComparableComparableAuctionResults = {
+  total_count: 2,
+  _embedded: {
+    items: [
+      {
+        sale_date_text: "10-12-2020",
+        currency: "EUR",
+        images: [
+          {
+            thumbnail: {
+              image_url: "https://path.to.1.jpg",
+            },
+          },
+        ],
+      },
+      {
+        sale_date_text: "10-10-2021",
+        currency: "EUR",
+        images: [
+          {
+            thumbnail: {
+              image_url: "https://path.to.2.jpg",
+            },
+          },
+        ],
+      },
+    ],
+  },
+}
+
+describe("Comparable Auction Results", () => {
+  it("fetches comparable auction results", () => {
+    const query = `
+    {
+      auctionResult(id: "foo-bar") {
+        saleDateText
+        saleTitle
+        comparableAuctionResults(first:25) {
+          totalCount
+          edges {
+            node {
+              saleDateText
+              currency
+              images {
+                thumbnail {
+                  imageURL
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    `
+
+    const context = {
+      auctionLotLoader: jest.fn(() => Promise.resolve(mockAuctionResult)),
+      comparableAuctionResultsLoader: jest.fn(() =>
+        Promise.resolve(mockComparableComparableAuctionResults)
+      ),
+    }
+
+    return runQuery(query, context!).then((data) => {
+      expect(data.auctionResult.comparableAuctionResults).toEqual({
+        totalCount: 2,
+        edges: [
+          {
+            node: {
+              saleDateText: "10-12-2020",
+              currency: "EUR",
+              images: {
+                thumbnail: {
+                  imageURL: "https://path.to.1.jpg",
+                },
+              },
+            },
+          },
+          {
+            node: {
+              saleDateText: "10-10-2021",
+              currency: "EUR",
+              images: {
+                thumbnail: {
+                  imageURL: "https://path.to.2.jpg",
+                },
+              },
+            },
+          },
+        ],
+      })
+    })
+  })
+})


### PR DESCRIPTION
Addresses: [CX-940]
Use `lot_comparable` from diffusion and add to MP.

[CX-940]: https://artsyproduct.atlassian.net/browse/CX-940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ