### PR TITLE
fix: adds id to sale registration for relay object identification

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11395,9 +11395,6 @@ type SaleRegistration {
 
   # A globally unique ID.
   id: ID!
-
-  # A type-specific ID likely used as a database ID.
-  internalID: ID!
   isRegistered: Boolean
   sale: Sale
 }

--- a/src/schema/v2/me/sale_registrations.ts
+++ b/src/schema/v2/me/sale_registrations.ts
@@ -8,13 +8,13 @@ import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { BodyAndHeaders } from "lib/loaders"
 import { GraphQLBoolean, GraphQLObjectType, GraphQLFieldConfig } from "graphql"
 import { ResolverContext } from "types/graphql"
-import { InternalIDFields } from "schema/v2/object_identification"
+import { GlobalIDField } from "schema/v2/object_identification"
 
 export const SaleRegistrationType = new GraphQLObjectType<any, ResolverContext>(
   {
     name: "SaleRegistration",
     fields: () => ({
-      ...InternalIDFields,
+      id: GlobalIDField,
       bidder: {
         type: Bidder.type,
       },
@@ -59,7 +59,7 @@ export const SaleRegistrationConnection: GraphQLFieldConfig<
         const bidders = await meBiddersLoader({ sale_id: sale.id })
 
         return {
-          id: `sale-registration-${sale.id}`,
+          id: sale.id,
           sale,
           bidder: first(bidders),
           isRegistered: bidders.length > 0,


### PR DESCRIPTION
So @AlicanAkyuz came across this interesting bug when rebuilding the auction registrations user settings panel. Since previously this was in CoffeeScript, the `id` field was never getting called. Since it's in Relay now, this was being internally requested and would error with a non-nullable error. Just gluing on the sale ID here should be fine since this is scoped to the `Me` object anyway. But let me know if you think I should be sticking something else here @mzikherman 