### PR TITLE
fix(partners): removes null/undefineds from gravity options

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11007,7 +11007,7 @@ type Sale implements Node {
   collectPayments: Boolean!
   coverImage: Image
   currency: String
-  description: String
+  description(format: Format): String
   displayTimelyAt: String
   eligibleSaleArtworksCount: Int
   endAt(

--- a/src/schema/v2/partners.ts
+++ b/src/schema/v2/partners.ts
@@ -1,4 +1,4 @@
-import { clone, pick } from "lodash"
+import { clone, identity, pick, pickBy } from "lodash"
 import Partner, { PartnerType } from "./partner"
 import PartnerTypeType from "./input_fields/partner_type_type"
 import {
@@ -126,8 +126,11 @@ export const Partners: GraphQLFieldConfig<void, ResolverContext> = {
       partner_categories: partnerCategories,
       ..._options,
     }
-    const cleanedOptions = clone(options)
-    // make ids singular to match gravity :id
+
+    // Removes null/undefined values from options
+    const cleanedOptions = pickBy(clone(options), identity)
+
+    // Make `ids` singular to match Gravity `id`
     if (options.ids) {
       cleanedOptions.id = options.ids
       delete cleanedOptions.ids


### PR DESCRIPTION
Previously a query with `near: null` to this field would error. This URL was being hit:

`https://stagingapi.artsy.net/api/v1/partners?aggregations%5B%5D=partner_category&aggregations%5B%5D=total&default_profile_public=true&eligible_for_listing=true&near=&size=0&type%5B%5D=PartnerGallery`

The `near=` in particular here caused a 400: `[400] {"error":{"root_cause":[{"type":"query_shard_exception","reason":"couldn't validate latitude/ longitude values","index_uuid":"2mvq9JW0TRKxwNTRmxXPzg","index":"partners_staging"}],"type":"search_phase_execution_exception","reason":"all shards failed","phase":"query","grouped":true,"failed_shards":[{"shard":0,"index":"partners_staging","node":"8h8RpHnSTve-VFsL_j7V1A","reason":{"type":"query_shard_exception","reason":"couldn't validate latitude/ longitude values","index_uuid":"2mvq9JW0TRKxwNTRmxXPzg","index":"partners_staging","caused_by":{"type":"illegal_argument_exception","reason":"Validation Failed: 1: [geo_distance] center point latitude is invalid: NaN;2: [geo_distance] center point longitude is invalid: NaN;"}}}]},"status":400}`

------

This PR just compacts the Gravity options object to remove any nulls before sending it off.
