### PR TITLE
feat(partner): exposes featured show

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9283,6 +9283,7 @@ type Partner implements Node {
   displayFullPartnerPage: Boolean
   displayWorksSection: Boolean
   distinguishRepresentedArtists: Boolean
+  featuredShow: Show
 
   # Artworks Elastic Search results
   filterArtworksConnection(

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -20,7 +20,7 @@ import EventStatus from "schema/v2/input_fields/event_status"
 import { NodeInterface, SlugAndInternalIDFields } from "./object_identification"
 import { artworkConnection } from "./artwork"
 import numeral from "./fields/numeral"
-import { ShowsConnection } from "./show"
+import { ShowsConnection, ShowType } from "./show"
 import { ArtistType } from "./artist"
 import ArtworkSorts from "./sorts/artwork_sorts"
 import { includesFieldsOtherThanSelectionSet } from "lib/hasFieldSelection"
@@ -447,6 +447,22 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       defaultProfileID: {
         type: GraphQLString,
         resolve: ({ default_profile_id }) => default_profile_id,
+      },
+      featuredShow: {
+        type: ShowType,
+        resolve: async ({ id }, _args, { partnerShowsLoader }) => {
+          const { body: shows }: { body: any[] } = await partnerShowsLoader(
+            id,
+            {
+              page: 1,
+              size: 1,
+              sort: "-featured,-end_at",
+              displayable: true,
+            }
+          )
+
+          return shows[0]
+        },
       },
       filterArtworksConnection: filterArtworksConnection("partner_id"),
       vatNumber: {


### PR DESCRIPTION
Rather than [re-implement this: ](https://github.com/artsy/force/blob/4424bb8690c08a0d5cb873124c73de2418151595/src/desktop/collections/partner_shows.coffee#L20-L49)

```coffeescript
  current: (exclude = []) ->
    new PartnerShows _.filter @models, (show) ->
      show.running() and show.get('displayable') and show not in exclude

  upcoming: (exclude = []) ->
    new PartnerShows _.filter @models, (show) ->
      show.upcoming() and show.get('displayable') and show not in exclude

  past: (exclude = []) ->
    new PartnerShows _.filter @models, (show) ->
      show.closed() and show.get('displayable') and show not in exclude

  featured: ->
    # If there is a featured show (should only be one), this wins
    featured = @findWhere featured: true
    return featured if featured?

    # Next in line is the first current show that ends closest to now
    featurables = @current().filter (show) -> show.get('displayable')
    featurables = _.sortBy featurables, (show) -> moment(show.get('end_at')).unix()
    return featurables[0] if featurables.length

    # Then the first upcoming show by start date
    featurables = @upcoming().filter (show) -> show.get('displayable')
    featurables = _.sortBy featurables, (show) -> moment(show.get('start_at')).unix()
    return featurables[0] if featurables.length

    # Finally, we'll take a past show ordered by the default
    featurables = @past().filter (show) -> show.get('displayable')
    return featurables[0] if featurables.length
```

We can get most of the way there by simply sorting shows `-featured,-end_at` and grabbing the first one.

In practice — for instance in the featured partners carousels — all the partners have a featured show, so we generally don't have to do the other footwork.