### PR TITLE
feat: Add flag to exclude purchased artworks from My Collection query

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -4212,7 +4212,7 @@ type CommerceBuyOrder implements CommerceOrder {
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
-  displayState: String
+  displayState: CommerceOrderDisplayStateEnum!
   id: ID!
   internalID: ID!
   itemsTotal(
@@ -4853,7 +4853,7 @@ type CommerceOfferOrder implements CommerceOrder {
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
-  displayState: String
+  displayState: CommerceOrderDisplayStateEnum!
   id: ID!
   impulseConversationId: String
   internalID: ID!
@@ -5062,7 +5062,7 @@ interface CommerceOrder {
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
-  displayState: String
+  displayState: CommerceOrderDisplayStateEnum!
   id: ID!
   internalID: ID!
   itemsTotal(
@@ -5229,6 +5229,35 @@ type CommerceOrderConnectionWithTotalCount {
   pageInfo: CommercePageInfo!
   totalCount: Int
   totalPages: Int
+}
+
+enum CommerceOrderDisplayStateEnum {
+  # order is abandoned by buyer and never submitted
+  ABANDONED
+
+  # order is approved by seller
+  APPROVED
+
+  # order is canceled
+  CANCELED
+
+  # order is fulfilled by seller
+  FULFILLED
+
+  # order has been collected and is with shipper
+  IN_TRANSIT
+
+  # order is still pending submission by buyer
+  PENDING
+
+  # order is approved but not yet sent out
+  PROCESSING
+
+  # order is refunded after being approved or fulfilled
+  REFUNDED
+
+  # order is submitted by buyer
+  SUBMITTED
 }
 
 # An edge in a connection.

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2783,7 +2783,7 @@ type CommerceBuyOrder implements CommerceOrder {
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
-  displayState: String
+  displayState: CommerceOrderDisplayStateEnum!
   id: ID!
   internalID: ID!
   itemsTotal(
@@ -3426,7 +3426,7 @@ type CommerceOfferOrder implements CommerceOrder {
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
-  displayState: String
+  displayState: CommerceOrderDisplayStateEnum!
   id: ID!
   impulseConversationId: String
   internalID: ID!
@@ -3636,7 +3636,7 @@ interface CommerceOrder {
   creditCardId: String
   currencyCode: String!
   displayCommissionRate: String
-  displayState: String
+  displayState: CommerceOrderDisplayStateEnum!
   id: ID!
   internalID: ID!
   itemsTotal(
@@ -3803,6 +3803,35 @@ type CommerceOrderConnectionWithTotalCount {
   pageInfo: CommercePageInfo!
   totalCount: Int
   totalPages: Int
+}
+
+enum CommerceOrderDisplayStateEnum {
+  # order is abandoned by buyer and never submitted
+  ABANDONED
+
+  # order is approved by seller
+  APPROVED
+
+  # order is canceled
+  CANCELED
+
+  # order is fulfilled by seller
+  FULFILLED
+
+  # order has been collected and is with shipper
+  IN_TRANSIT
+
+  # order is still pending submission by buyer
+  PENDING
+
+  # order is approved but not yet sent out
+  PROCESSING
+
+  # order is refunded after being approved or fulfilled
+  REFUNDED
+
+  # order is submitted by buyer
+  SUBMITTED
 }
 
 # An edge in a connection.
@@ -8394,6 +8423,9 @@ type Me implements Node {
   myCollectionConnection(
     after: String
     before: String
+
+    # Exclude artworks that have been purchased on Artsy and automatically added to the collection.
+    excludePurchasedArtworks: Boolean
     first: Int
     last: Int
     sort: MyCollectionArtworkSorts

--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -69,6 +69,7 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
     },
     excludePurchasedArtworks: {
       type: GraphQLBoolean,
+      defaultValue: false,
       description:
         "Exclude artworks that have been purchased on Artsy and automatically added to the collection.",
     },

--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -67,13 +67,23 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
         },
       }),
     },
+    excludePurchasedArtworks: {
+      type: GraphQLBoolean,
+      description:
+        "Exclude artworks that have been purchased on Artsy and automatically added to the collection.",
+    },
   }),
   resolve: ({ id: userId }, options, { collectionArtworksLoader }) => {
     if (!collectionArtworksLoader) {
       return null
     }
     const gravityOptions = Object.assign(
-      { private: true, total_count: true, user_id: userId },
+      {
+        exclude_purchased_artworks: options.excludePurchasedArtworks,
+        private: true,
+        total_count: true,
+        user_id: userId,
+      },
       convertConnectionArgsToGravityArgs(options)
     )
 


### PR DESCRIPTION
Addresses [CX-1868]

## Description

Adds a flag to exclude purchased artworks from "My Collection" query. This is necessary to only show artworks that have been automatically added to "My Collection" to specific users until we release the feature for all users.

[CX-1868]: https://artsyproduct.atlassian.net/browse/CX-1868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ