### PR TITLE
fix(partners): fixes connection; adds args

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8436,7 +8436,7 @@ type Me implements Node {
     before: String
 
     # Exclude artworks that have been purchased on Artsy and automatically added to the collection.
-    excludePurchasedArtworks: Boolean
+    excludePurchasedArtworks: Boolean = false
     first: Int
     last: Int
     sort: MyCollectionArtworkSorts
@@ -10722,7 +10722,14 @@ type Query {
 
     # Coordinates to find partners closest to
     near: String
+
+    #
+    #         Only return partners of the specified partner categories.
+    #         Accepts list of slugs.
+    #
+    partnerCategories: [String]
     sort: PartnersSortType
+    type: [PartnerClassification]
   ): PartnerConnection
 
   # Get all price insights for an artist.
@@ -13429,7 +13436,14 @@ type Viewer {
 
     # Coordinates to find partners closest to
     near: String
+
+    #
+    #         Only return partners of the specified partner categories.
+    #         Accepts list of slugs.
+    #
+    partnerCategories: [String]
     sort: PartnersSortType
+    type: [PartnerClassification]
   ): PartnerConnection
 
   # A requested location

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -158,7 +158,7 @@ export default (opts) => {
       {},
       { headers: true }
     ),
-    partnersLoader: gravityLoader("partners"),
+    partnersLoader: gravityLoader("partners", {}, { headers: true }),
     popularArtistsLoader: gravityLoader(`artists/popular`),
     profileLoader: gravityLoader((id) => `profile/${id}`),
     relatedArtworksLoader: gravityLoader("related/artworks"),

--- a/src/schema/v1/__tests__/partners.test.js
+++ b/src/schema/v1/__tests__/partners.test.js
@@ -5,13 +5,13 @@ describe("Partners", () => {
   it("returns a list of partners matching array of ids", async () => {
     const partnersLoader = ({ id }) => {
       if (id) {
-        return Promise.resolve(
-          id.map((_id) => ({
+        return Promise.resolve({
+          body: id.map((_id) => ({
             _id,
             has_full_profile: true,
             profile_banner_display: true,
-          }))
-        )
+          })),
+        })
       }
       throw new Error("Unexpected invocation")
     }

--- a/src/schema/v1/partners.ts
+++ b/src/schema/v1/partners.ts
@@ -95,14 +95,16 @@ const Partners: GraphQLFieldConfig<void, ResolverContext> = {
       type: new GraphQLList(PartnerTypeType),
     },
   },
-  resolve: (_root, options, { partnersLoader }) => {
+  resolve: async (_root, options, { partnersLoader }) => {
     const cleanedOptions = clone(options)
     // make ids singular to match gravity :id
     if (options.ids) {
       cleanedOptions.id = options.ids
       delete cleanedOptions.ids
     }
-    return partnersLoader(cleanedOptions)
+    const { body } = await partnersLoader(cleanedOptions)
+
+    return body
   },
 }
 

--- a/src/schema/v2/__tests__/partners.test.js
+++ b/src/schema/v2/__tests__/partners.test.js
@@ -5,12 +5,12 @@ describe("PartnersConnection", () => {
   it("returns a list of partners matching array of ids", async () => {
     const partnersLoader = ({ id }) => {
       if (id) {
-        return Promise.resolve(
-          id.map((id) => ({
-            _id: id,
-          }))
-        )
+        return Promise.resolve({
+          body: id.map((id) => ({ _id: id })),
+          headers: { "x-total-count": 1 },
+        })
       }
+
       throw new Error("Unexpected invocation")
     }
 
@@ -25,7 +25,10 @@ describe("PartnersConnection", () => {
         }
       }
     `
-    const { partnersConnection } = await runQuery(query, { partnersLoader })
+    const { partnersConnection } = await runQuery(query, {
+      partnersLoader,
+    })
+
     expect(partnersConnection.edges[0].node.internalID).toEqual(
       "5a958e8e7622dd49f4f4176d"
     )


### PR DESCRIPTION
Closes [GRO-646](https://artsyproduct.atlassian.net/browse/GRO-646)

Thankfully we already have a partners connection; it just didn't correctly implement total count and is missing some params. This also doesn't expose the aggregations which we'll probably want to do and then deprecate `filterPartners` entirely.