### PR TITLE
fix: default to excluding purchased artworks from my collection 

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8436,7 +8436,7 @@ type Me implements Node {
     before: String
 
     # Exclude artworks that have been purchased on Artsy and automatically added to the collection.
-    excludePurchasedArtworks: Boolean
+    excludePurchasedArtworks: Boolean = true
     first: Int
     last: Int
     sort: MyCollectionArtworkSorts

--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -69,7 +69,7 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
     },
     excludePurchasedArtworks: {
       type: GraphQLBoolean,
-      defaultValue: false,
+      defaultValue: true,
       description:
         "Exclude artworks that have been purchased on Artsy and automatically added to the collection.",
     },


### PR DESCRIPTION
This changes the default behavior of metaphysics to ask gravity to exclude users imported purchases from their collection. This is to maintain backwards compatibility with old clients until the feature is ready. 

Conversation here on justification: https://github.com/artsy/gravity/pull/14610