### PR TITLE
fix(partnersConnection): removes null/undefined values from gravity args

### DIFF
--- a/src/schema/v2/partners.ts
+++ b/src/schema/v2/partners.ts
@@ -174,7 +174,10 @@ export const PartnersConnection: GraphQLFieldConfig<void, ResolverContext> = {
       total_count: true,
     }
 
-    const { body, headers } = await partnersLoader(gravityArgs)
+    // Removes null/undefined values from options
+    const cleanedGravityArgs = pickBy(clone(gravityArgs), identity)
+
+    const { body, headers } = await partnersLoader(cleanedGravityArgs)
     const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 
     return {


### PR DESCRIPTION
Here we also have to compact the arguments — `near: null` causes a 500. cc @mzikherman — this should likely be fixed in Gravity.