### PR TITLE
fix(partnersConnection): corrects hasNextPage calculation

### DIFF
--- a/src/schema/v2/partners.ts
+++ b/src/schema/v2/partners.ts
@@ -158,35 +158,39 @@ export const PartnersConnection: GraphQLFieldConfig<void, ResolverContext> = {
       "type"
     ),
   }),
-  resolve: async (_root, options, { partnersLoader }) => {
-    const { page, size, offset } = convertConnectionArgsToGravityArgs(options)
+  resolve: async (_root, args, { partnersLoader }) => {
+    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
 
-    const gravityArgs: any = {
-      id: options.ids,
+    const options = {
+      id: args.ids,
       page,
       size,
-      near: options.near,
-      eligible_for_listing: options.eligibleForListing,
-      default_profile_public: options.defaultProfilePublic,
-      sort: options.sort,
-      partner_categories: options.partnerCategories,
-      type: options.type,
+      near: args.near,
+      eligible_for_listing: args.eligibleForListing,
+      default_profile_public: args.defaultProfilePublic,
+      sort: args.sort,
+      partner_categories: args.partnerCategories,
+      type: args.type,
       total_count: true,
     }
 
     // Removes null/undefined values from options
-    const cleanedGravityArgs = pickBy(clone(gravityArgs), identity)
+    const cleanedOptions = pickBy(clone(options), identity)
 
-    const { body, headers } = await partnersLoader(cleanedGravityArgs)
+    const { body, headers } = await partnersLoader(cleanedOptions)
     const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 
     return {
       totalCount,
       pageCursors: createPageCursors({ page, size }, totalCount),
-      ...connectionFromArraySlice(body, gravityArgs, {
-        sliceStart: offset ?? 0,
-        arrayLength: totalCount,
-      }),
+      ...connectionFromArraySlice(
+        body,
+        pick(args, "before", "after", "first", "last"),
+        {
+          sliceStart: offset ?? 0,
+          arrayLength: totalCount,
+        }
+      ),
     }
   },
 }


### PR DESCRIPTION
OK, a quick read of the source of [connectionFromArraySlice](https://github.com/graphql/graphql-relay-js/blob/17231860ee64431009c193be2e6ac444936a88ea/src/connection/arrayConnection.js#L49-L111) and it seems like we were passing the gravity args rather than the connection pagination args. This PR fixes that and cleans up a bit.