### PR TITLE
feat(schema): exposes partner category

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10720,6 +10720,12 @@ type Query {
     size: Int
   ): [PartnerCategory]
 
+  # A PartnerCategory
+  partnerCategory(
+    # The slug or ID of the PartnerCategory
+    id: String!
+  ): PartnerCategory
+
   # A list of Partners
   partnersConnection(
     after: String
@@ -13433,6 +13439,12 @@ type Viewer {
     internal: Boolean = false
     size: Int
   ): [PartnerCategory]
+
+  # A PartnerCategory
+  partnerCategory(
+    # The slug or ID of the PartnerCategory
+    id: String!
+  ): PartnerCategory
 
   # A list of Partners
   partnersConnection(

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -93,7 +93,7 @@ import { Shows } from "./shows"
 import { startIdentityVerificationMutation } from "./startIdentityVerificationMutation"
 import StaticContent from "./static_content"
 import System from "./system"
-// import PartnerCategory from "./partner_category"
+import PartnerCategory from "./partner_category"
 import PartnerCategories from "./partner_categories"
 // import SuggestedGenes from "./suggested_genes"
 import { TagField } from "./tag"
@@ -169,7 +169,7 @@ const rootFields = {
   partner: Partner,
   partnerArtworks: PartnerArtworks,
   partnerCategories: PartnerCategories,
-  // partnerCategory: PartnerCategory,
+  partnerCategory: PartnerCategory,
   partnersConnection: PartnersConnection,
   // profile: Profile,
   requestLocation: RequestLocationField,


### PR DESCRIPTION
Closes [GRO-602](https://artsyproduct.atlassian.net/browse/GRO-602)

So this apparently existed but was disabled with [this commit](https://github.com/artsy/metaphysics/commit/dde8efc4b76dcfbeb3bf2d68bbb09ce42bab04ad). This PR re-enables the field `partnerCategory(id)` field.