### PR TITLE
fix: propagate a requests xapp token when using stitching

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -224,6 +224,7 @@ function startApp(appSchema, path: string) {
         exchangeSchema,
         requestIDs,
         userAgent,
+        appToken,
       }
 
       const validationRules = [

--- a/src/lib/stitching/gravity/link.ts
+++ b/src/lib/stitching/gravity/link.ts
@@ -22,7 +22,8 @@ export const createGravityLink = () => {
       const headers = {
         ...(graphqlContext && requestIDHeaders(graphqlContext.requestIDs)),
       }
-      Object.assign(headers, { "X-XAPP-TOKEN": config.GRAVITY_XAPP_TOKEN })
+      const xappToken = graphqlContext.appToken || config.GRAVITY_XAPP_TOKEN
+      Object.assign(headers, { "X-XAPP-TOKEN": xappToken })
       if (graphqlContext.accessToken) {
         Object.assign(headers, { "X-ACCESS-TOKEN": graphqlContext.accessToken })
       }

--- a/src/types/graphql.d.ts
+++ b/src/types/graphql.d.ts
@@ -3,6 +3,7 @@ import { createLoaders } from "../lib/loaders"
 import { ImageData } from "schema/v2/image/normalize"
 
 export interface ResolverContextValues {
+  appToken?: string
   /** Optionally you can include an access token for a logged in user */
   accessToken?: string
   /** Optionally you can include a user token for a logged in user */


### PR DESCRIPTION
This should fix the behavior you were seeing. Namely, Pulse was passing an `X-XAPP-TOKEN` to Metaphysics, which wasn't being propagated when a stitching request occurs. Metaphysics' own token is used instead, and it is not a trusted app.

This switches the behavior for gravity stitching to match the behavior for data loaders: namely, if the request passes an `X-XAPP-TOKEN`, pass that through to Gravity instead of using Metaphysics' own.