### PR TITLE
feat: short exhibition dates for shows + fairs

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6603,6 +6603,9 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
   organizer: FairOrganizer
   profile: Profile
 
+  # A formatted description of the start to end dates with abbreviated months
+  shortExhibitionPeriod: String
+
   # This connection only supports forward pagination. We're replacing Relay's default cursor with one from Gravity.
   showsConnection(
     after: String
@@ -12118,6 +12121,9 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
   # Link to the press release for this show
   pressReleaseUrl: String
 
+  # A formatted description of the start to end dates with abbreviated months
+  shortExhibitionPeriod: String
+
   # A slug ID.
   slug: ID!
 
@@ -12207,6 +12213,9 @@ type ShowEventType {
 
   # A formatted description of the start to end dates
   exhibitionPeriod: String
+
+  # A formatted description of the start to end dates with abbreviated months
+  shortExhibitionPeriod: String
   startAt(
     format: String
 

--- a/src/lib/__tests__/date.test.ts
+++ b/src/lib/__tests__/date.test.ts
@@ -420,6 +420,11 @@ describe("date formatting", () => {
       )
       expect(period).toBe("January 1 – 19, 2018")
     })
+
+    it("abbreviates months when specified", () => {
+      const period = dateRange("2011-01-01", "2011-04-19", "UTC", true)
+      expect(period).toBe("Jan 1 – Apr 19, 2011")
+    })
   })
 
   describe("exhibitionStatus", () => {

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -154,12 +154,13 @@ export function dateTimeRange(
  * Nov 1 – 4, 2018
  * Nov 1, 2018 – Jan 4, 2019
  */
-export function dateRange(startAt, endAt, timezone) {
+export function dateRange(startAt, endAt, timezone, abbreviateMonths = false) {
   const startMoment = moment.tz(startAt, timezone)
   const endMoment = moment.tz(endAt, timezone)
-  let startFormat = "MMMM D"
+  const monthFormat = abbreviateMonths ? "MMM" : "MMMM"
+  let startFormat = monthFormat + " D"
   let endFormat = "D, YYYY"
-  const singleDateFormat = "MMMM D, YYYY"
+  const singleDateFormat = monthFormat + " D, YYYY"
 
   if (startMoment.year() !== endMoment.year()) {
     // Adds year to start date if the dates are not the same year
@@ -171,7 +172,7 @@ export function dateRange(startAt, endAt, timezone) {
     startMoment.year() !== endMoment.year()
   ) {
     // Show the end month if the month is different
-    endFormat = "MMMM ".concat(endFormat)
+    endFormat = (monthFormat + " ").concat(endFormat)
   }
 
   // Duration is the same day

--- a/src/schema/v2/__tests__/fair.test.js
+++ b/src/schema/v2/__tests__/fair.test.js
@@ -679,6 +679,24 @@ describe("Fair", () => {
     })
   })
 
+  it("includes a formatted exhibition period with abbreviated months", async () => {
+    const query = gql`
+      {
+        fair(id: "aqua-art-miami-2018") {
+          shortExhibitionPeriod
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+    expect(data).toEqual({
+      fair: {
+        shortExhibitionPeriod: "Feb 15 – 17, 2019",
+      },
+    })
+  })
+
+
   it("includes artists associated with the fair", async () => {
     const query = gql`
       {

--- a/src/schema/v2/__tests__/show.test.js
+++ b/src/schema/v2/__tests__/show.test.js
@@ -615,6 +615,23 @@ describe("Show type", () => {
     })
   })
 
+  it("includes a formatted exhibition period with abbreviated months", async () => {
+    const query = gql`
+      {
+        show(id: "new-museum-1-2015-triennial-surround-audience") {
+          shortExhibitionPeriod
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+    expect(data).toEqual({
+      show: {
+        shortExhibitionPeriod: "Feb 25 – May 24, 2015",
+      },
+    })
+  })
+
   it("includes an update on upcoming status changes", async () => {
     showData.end_at = moment().add(1, "d")
     const query = gql`

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -141,6 +141,13 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
         description: "A formatted description of the start to end dates",
         resolve: ({ start_at, end_at }) => dateRange(start_at, end_at, "UTC"),
       },
+      shortExhibitionPeriod: {
+        type: GraphQLString,
+        description:
+          "A formatted description of the start to end dates with abbreviated months",
+        resolve: ({ start_at, end_at }) =>
+          dateRange(start_at, end_at, "UTC", true),
+      },
       formattedOpeningHours: {
         type: GraphQLString,
         description:

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -340,6 +340,13 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
         description: "A formatted description of the start to end dates",
         resolve: ({ start_at, end_at }) => dateRange(start_at, end_at, "UTC"),
       },
+      shortExhibitionPeriod: {
+        type: GraphQLString,
+        description:
+          "A formatted description of the start to end dates with abbreviated months",
+        resolve: ({ start_at, end_at }) =>
+          dateRange(start_at, end_at, "UTC", true),
+      },
       fair: {
         description: "If the show is in a Fair, then that fair",
         type: Fair.type,

--- a/src/schema/v2/show_event.ts
+++ b/src/schema/v2/show_event.ts
@@ -31,6 +31,13 @@ const ShowEventType = new GraphQLObjectType<any, ResolverContext>({
       description: "A formatted description of the start to end dates",
       resolve: ({ start_at, end_at }) => dateRange(start_at, end_at, "UTC"),
     },
+    shortExhibitionPeriod: {
+      type: GraphQLString,
+      description:
+        "A formatted description of the start to end dates with abbreviated months",
+      resolve: ({ start_at, end_at }) =>
+        dateRange(start_at, end_at, "UTC", true),
+    },
   },
 })
 


### PR DESCRIPTION
Add a `shortExhibitionPeriod` property that shows exhibition period display text in the old style with shortened months. In the app in some places we are displaying these dates we are pretty space constrained so in order to prevent wrapping to next line or cutting off text as much as possible we should use this instead. 

Instead of: `"February 25 – May 24, 2015"` => `"Feb 25 - May 24, 2015"`

Way around my hacky way of fixing this in Eigen: https://github.com/artsy/eigen/pull/5802

This logic was updated here to show longer months and it does look nicer so we should use it still where we can: https://github.com/artsy/metaphysics/pull/3497