### PR TITLE
feat(CX-2131): Add artist recommendations

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8278,6 +8278,15 @@ type Me implements Node {
     last: Int
   ): UserAddressConnection
 
+  # A connection of artist recommendations.
+  artistRecommendations(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    page: Int
+  ): ArtistConnection
+
   # A list of the current user’s inquiry requests
   artworkInquiriesConnection(
     after: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8278,7 +8278,7 @@ type Me implements Node {
     last: Int
   ): UserAddressConnection
 
-  # A connection of artist recommendations.
+  # A connection of artist recommendations for the current user.
   artistRecommendations(
     after: String
     before: String

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -204,3 +204,24 @@ export const defineCustomLocale = (
   moment.updateLocale(uniqueName, localeSpec)
   moment.locale(currentLocale)
 }
+
+/**
+ * Extracts nodes from a GraphQL connection.
+ */
+export const extractNodes = <Node extends object, T = Node>(
+  connection:
+    | {
+        readonly edges?: ReadonlyArray<{
+          readonly node?: Node | null
+        } | null> | null
+      }
+    | undefined
+    | null,
+  mapper?: (node: Node) => T
+): T[] => {
+  return (
+    connection?.edges
+      ?.map((edge) => (mapper ? (mapper(edge?.node!) as any) : edge?.node!))
+      .filter((x) => x != null) ?? []
+  )
+}

--- a/src/schema/v2/me/__tests__/artistRecommendations.test.ts
+++ b/src/schema/v2/me/__tests__/artistRecommendations.test.ts
@@ -128,31 +128,43 @@ const mockVortexResponse = {
   },
 }
 
-const mockArtistsResponse = [
-  {
-    _id: "608a7417bdfbd1a789ba092a",
-    artists_count: 3,
-    birthday: "",
-    blurb: "",
-    consignable: false,
-    deathday: "",
-    forsale_artists_count: 2,
-    group_indicator: "individual",
-    id: "yayoi-kusama",
-    image_url: null,
-    image_urls: {},
-    image_versions: [],
-    medium_known_for: null,
-    name: "Yayoi Kusama",
-    nationality: "",
-    original_height: null,
-    original_width: null,
-    public: true,
-    published_artists_count: 3,
-    sortable_id: "kusama-yayoi",
-    target_supply: false,
-    target_supply_priority: null,
-    target_supply_type: null,
-    years: "",
-  },
-]
+const mockArtistsResponse = {
+  body: [
+    {
+      _id: "5d6f9f7e3a583e000e51956d",
+      artworks_count: 1,
+      birthday: "",
+      blurb: "",
+      consignable: false,
+      deathday: "",
+      forsale_artworks_count: 0,
+      group_indicator: "individual",
+      id: "1-plus-1-plus-1",
+      image_url:
+        "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/:version.jpg",
+      image_urls: {
+        square:
+          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/square.jpg",
+        four_thirds:
+          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/four_thirds.jpg",
+        large:
+          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/large.jpg",
+        tall:
+          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/tall.jpg",
+      },
+      image_versions: ["square", "four_thirds", "large", "tall"],
+      medium_known_for: null,
+      name: "1+1+1",
+      nationality: "Swedish Icelandic Finnish",
+      original_height: 5237,
+      original_width: 3491,
+      public: true,
+      published_artworks_count: 0,
+      sortable_id: "1-plus-1-plus-1",
+      target_supply: false,
+      target_supply_priority: null,
+      target_supply_type: null,
+      years: "",
+    },
+  ],
+}

--- a/src/schema/v2/me/__tests__/artistRecommendations.test.ts
+++ b/src/schema/v2/me/__tests__/artistRecommendations.test.ts
@@ -40,9 +40,9 @@ describe("artistRecommendations", () => {
         "edges": Array [
           Object {
             "node": Object {
-              "id": "QXJ0aXN0OjYwOGE3NDE3YmRmYmQxYTc4OWJhMDkyYQ==",
-              "internalID": "608a7417bdfbd1a789ba092a",
-              "slug": "yayoi-kusama",
+              "id": "QXJ0aXN0OjVkNmY5ZjdlM2E1ODNlMDAwZTUxOTU2ZA==",
+              "internalID": "5d6f9f7e3a583e000e51956d",
+              "slug": "1-plus-1-plus-1",
             },
           },
         ],

--- a/src/schema/v2/me/__tests__/artistRecommendations.test.ts
+++ b/src/schema/v2/me/__tests__/artistRecommendations.test.ts
@@ -12,7 +12,6 @@ describe("artistRecommendations", () => {
             node {
               internalID
               slug
-              id
             }
           }
         }
@@ -40,13 +39,18 @@ describe("artistRecommendations", () => {
         "edges": Array [
           Object {
             "node": Object {
-              "id": "QXJ0aXN0OjVkNmY5ZjdlM2E1ODNlMDAwZTUxOTU2ZA==",
-              "internalID": "5d6f9f7e3a583e000e51956d",
+              "internalID": "608a7417bdfbd1a789ba092a",
               "slug": "1-plus-1-plus-1",
             },
           },
+          Object {
+            "node": Object {
+              "internalID": "608a7416bdfbd1a789ba0911",
+              "slug": "banksy",
+            },
+          },
         ],
-        "totalCount": 1,
+        "totalCount": 2,
       }
     `)
 
@@ -131,7 +135,43 @@ const mockVortexResponse = {
 const mockArtistsResponse = {
   body: [
     {
-      _id: "5d6f9f7e3a583e000e51956d",
+      _id: "608a7416bdfbd1a789ba0911",
+      artworks_count: 1,
+      birthday: "",
+      blurb: "",
+      consignable: false,
+      deathday: "",
+      forsale_artworks_count: 0,
+      group_indicator: "individual",
+      id: "banksy",
+      image_url:
+        "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/:version.jpg",
+      image_urls: {
+        square:
+          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/square.jpg",
+        four_thirds:
+          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/four_thirds.jpg",
+        large:
+          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/large.jpg",
+        tall:
+          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/tall.jpg",
+      },
+      image_versions: ["square", "four_thirds", "large", "tall"],
+      medium_known_for: null,
+      name: "1+1+1",
+      nationality: "Swedish Icelandic Finnish",
+      original_height: 5237,
+      original_width: 3491,
+      public: true,
+      published_artworks_count: 0,
+      sortable_id: "banksy",
+      target_supply: false,
+      target_supply_priority: null,
+      target_supply_type: null,
+      years: "",
+    },
+    {
+      _id: "608a7417bdfbd1a789ba092a",
       artworks_count: 1,
       birthday: "",
       blurb: "",

--- a/src/schema/v2/me/__tests__/artistRecommendations.test.ts
+++ b/src/schema/v2/me/__tests__/artistRecommendations.test.ts
@@ -71,8 +71,6 @@ describe("artistRecommendations", () => {
     })
     expect(artistsLoader).toHaveBeenCalledWith({
       ids: ["608a7417bdfbd1a789ba092a", "608a7416bdfbd1a789ba0911"],
-      offset: 0,
-      size: 100,
     })
   })
 

--- a/src/schema/v2/me/__tests__/artistRecommendations.test.ts
+++ b/src/schema/v2/me/__tests__/artistRecommendations.test.ts
@@ -46,7 +46,7 @@ describe("artistRecommendations", () => {
             },
           },
         ],
-        "totalCount": 50,
+        "totalCount": 1,
       }
     `)
 

--- a/src/schema/v2/me/__tests__/artistRecommendations.test.ts
+++ b/src/schema/v2/me/__tests__/artistRecommendations.test.ts
@@ -66,7 +66,7 @@ describe("artistRecommendations", () => {
       `,
     })
     expect(artistsLoader).toHaveBeenCalledWith({
-      artist_ids: ["608a7417bdfbd1a789ba092a", "608a7416bdfbd1a789ba0911"],
+      ids: ["608a7417bdfbd1a789ba092a", "608a7416bdfbd1a789ba0911"],
       offset: 0,
       size: 100,
     })

--- a/src/schema/v2/me/__tests__/artistRecommendations.test.ts
+++ b/src/schema/v2/me/__tests__/artistRecommendations.test.ts
@@ -46,14 +46,14 @@ describe("artistRecommendations", () => {
             },
           },
         ],
-        "totalCount": 20,
+        "totalCount": 50,
       }
     `)
 
     expect(vortexGraphqlLoader).toHaveBeenCalledWith({
       query: gql`
         query artistRecommendationsQuery {
-          artistRecommendations(first: 20) {
+          artistRecommendations(first: 50) {
             totalCount
             edges {
               node {

--- a/src/schema/v2/me/__tests__/artistRecommendations.test.ts
+++ b/src/schema/v2/me/__tests__/artistRecommendations.test.ts
@@ -1,0 +1,158 @@
+/* eslint-disable promise/always-return */
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("artistRecommendations", () => {
+  const query = gql`
+    {
+      me {
+        artistRecommendations(first: 100) {
+          totalCount
+          edges {
+            node {
+              internalID
+              slug
+              id
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("returns artist recommendations from Vortex", async () => {
+    const vortexGraphqlLoader = jest.fn(() => async () => mockVortexResponse)
+
+    const artistsLoader = jest.fn(async () => mockArtistsResponse)
+
+    const context = {
+      meLoader: () => Promise.resolve({}),
+      vortexGraphqlLoader,
+      artistsLoader,
+    }
+
+    const {
+      me: { artistRecommendations },
+    } = await runAuthenticatedQuery(query, context)
+
+    expect(artistRecommendations).toMatchInlineSnapshot(`
+      Object {
+        "edges": Array [
+          Object {
+            "node": Object {
+              "id": "QXJ0aXN0OjYwOGE3NDE3YmRmYmQxYTc4OWJhMDkyYQ==",
+              "internalID": "608a7417bdfbd1a789ba092a",
+              "slug": "yayoi-kusama",
+            },
+          },
+        ],
+        "totalCount": 20,
+      }
+    `)
+
+    expect(vortexGraphqlLoader).toHaveBeenCalledWith({
+      query: gql`
+        query artistRecommendationsQuery {
+          artistRecommendations(first: 20) {
+            totalCount
+            edges {
+              node {
+                artistId
+                score
+              }
+            }
+          }
+        }
+      `,
+    })
+    expect(artistsLoader).toHaveBeenCalledWith({
+      artist_ids: ["608a7417bdfbd1a789ba092a", "608a7416bdfbd1a789ba0911"],
+      offset: 0,
+      size: 100,
+    })
+  })
+
+  it("doesn't return artists if no artist recommendations are present", async () => {
+    const vortexGraphqlLoader = jest.fn(() => async () => ({
+      data: {
+        artistRecommendations: {
+          totalCount: 0,
+          edges: [],
+        },
+      },
+    }))
+
+    const artistsLoader = jest.fn(async () => mockArtistsResponse)
+
+    const context = {
+      meLoader: () => Promise.resolve({}),
+      vortexGraphqlLoader,
+      artistsLoader,
+    }
+
+    const {
+      me: { artistRecommendations },
+    } = await runAuthenticatedQuery(query, context)
+
+    expect(artistRecommendations).toMatchInlineSnapshot(`
+      Object {
+        "edges": Array [],
+        "totalCount": 0,
+      }
+    `)
+
+    expect(vortexGraphqlLoader).toHaveBeenCalled()
+    expect(artistsLoader).not.toHaveBeenCalled()
+  })
+})
+
+const mockVortexResponse = {
+  data: {
+    artistRecommendations: {
+      totalCount: 2,
+      edges: [
+        {
+          node: {
+            artistId: "608a7417bdfbd1a789ba092a",
+            score: 3.422242962512335,
+          },
+        },
+        {
+          node: {
+            artistId: "608a7416bdfbd1a789ba0911",
+            score: 3.2225049587839654,
+          },
+        },
+      ],
+    },
+  },
+}
+
+const mockArtistsResponse = [
+  {
+    _id: "608a7417bdfbd1a789ba092a",
+    artists_count: 3,
+    birthday: "",
+    blurb: "",
+    consignable: false,
+    deathday: "",
+    forsale_artists_count: 2,
+    group_indicator: "individual",
+    id: "yayoi-kusama",
+    image_url: null,
+    image_urls: {},
+    image_versions: [],
+    medium_known_for: null,
+    name: "Yayoi Kusama",
+    nationality: "",
+    original_height: null,
+    original_width: null,
+    public: true,
+    published_artists_count: 3,
+    sortable_id: "kusama-yayoi",
+    target_supply: false,
+    target_supply_priority: null,
+    target_supply_type: null,
+    years: "",
+  },
+]

--- a/src/schema/v2/me/artistRecommendations.ts
+++ b/src/schema/v2/me/artistRecommendations.ts
@@ -13,7 +13,7 @@ export const ArtistRecommendations: GraphQLFieldConfig<
   void,
   ResolverContext
 > = {
-  description: "A connection of artist recommendations.",
+  description: "A connection of artist recommendations for the current user.",
   type: artistConnection.connectionType,
   args: pageable({
     page: { type: GraphQLInt },

--- a/src/schema/v2/me/artistRecommendations.ts
+++ b/src/schema/v2/me/artistRecommendations.ts
@@ -1,6 +1,6 @@
 import { GraphQLFieldConfig, GraphQLInt } from "graphql"
 import { connectionFromArray } from "graphql-relay"
-import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { convertConnectionArgsToGravityArgs, extractNodes } from "lib/helpers"
 import { CursorPageable, pageable } from "relay-cursor-paging"
 import { createPageCursors } from "schema/v1/fields/pagination"
 import { ResolverContext } from "types/graphql"
@@ -46,9 +46,9 @@ export const ArtistRecommendations: GraphQLFieldConfig<
       `,
     })()
 
-    const artistIds: string[] = vortexResult.data?.artistRecommendations?.edges?.map(
-      (edge) => edge?.node?.artistId
-    )
+    const artistIds = extractNodes(
+      vortexResult.data?.artistRecommendations
+    ).map((node: any) => node?.artistId)
 
     // Fetch artist details from Gravity
 

--- a/src/schema/v2/me/artistRecommendations.ts
+++ b/src/schema/v2/me/artistRecommendations.ts
@@ -6,7 +6,7 @@ import { createPageCursors } from "schema/v1/fields/pagination"
 import { ResolverContext } from "types/graphql"
 import gql from "lib/gql"
 import { artistConnection } from "schema/v2/artist"
-import { find } from "lodash"
+import { compact, find } from "lodash"
 
 const MAX_ARTISTS = 50
 
@@ -63,9 +63,11 @@ export const ArtistRecommendations: GraphQLFieldConfig<
 
       // Apply order from Vortex result (score ASC)
 
-      artists = artistIds.map((artistId) => {
-        return find(artists, { _id: artistId })
-      })
+      artists = compact(
+        artistIds.map((artistId) => {
+          return find(artists, { _id: artistId })
+        })
+      )
     }
 
     const count = artists.length

--- a/src/schema/v2/me/artistRecommendations.ts
+++ b/src/schema/v2/me/artistRecommendations.ts
@@ -6,6 +6,7 @@ import { createPageCursors } from "schema/v1/fields/pagination"
 import { ResolverContext } from "types/graphql"
 import gql from "lib/gql"
 import { artistConnection } from "schema/v2/artist"
+import { find } from "lodash"
 
 const MAX_ARTISTS = 50
 
@@ -45,7 +46,7 @@ export const ArtistRecommendations: GraphQLFieldConfig<
       `,
     })()
 
-    const artistIds = vortexResult.data?.artistRecommendations?.edges?.map(
+    const artistIds: string[] = vortexResult.data?.artistRecommendations?.edges?.map(
       (edge) => edge?.node?.artistId
     )
 
@@ -61,6 +62,12 @@ export const ArtistRecommendations: GraphQLFieldConfig<
           offset,
         })
       ).body
+
+      // Apply order from Vortex result (score ASC)
+
+      artists = artistIds.map((artistId) => {
+        return find(artists, { _id: artistId })
+      })
     }
 
     const count = artists.length

--- a/src/schema/v2/me/artistRecommendations.ts
+++ b/src/schema/v2/me/artistRecommendations.ts
@@ -7,7 +7,7 @@ import { ResolverContext } from "types/graphql"
 import gql from "lib/gql"
 import { artistConnection } from "schema/v2/artist"
 
-const MAX_ARTISTS = 20
+const MAX_ARTISTS = 50
 
 export const ArtistRecommendations: GraphQLFieldConfig<
   void,

--- a/src/schema/v2/me/artistRecommendations.ts
+++ b/src/schema/v2/me/artistRecommendations.ts
@@ -52,11 +52,13 @@ export const ArtistRecommendations: GraphQLFieldConfig<
     let artists: any = []
 
     if (artistIds?.length) {
-      artists = await artistsLoader({
-        artist_ids: artistIds,
-        size,
-        offset,
-      })
+      artists = (
+        await artistsLoader({
+          artist_ids: artistIds,
+          size,
+          offset,
+        })
+      ).body
     }
 
     // TODO: get count from artists loader to optimize pagination

--- a/src/schema/v2/me/artistRecommendations.ts
+++ b/src/schema/v2/me/artistRecommendations.ts
@@ -1,0 +1,74 @@
+import { GraphQLFieldConfig, GraphQLInt } from "graphql"
+import { connectionFromArraySlice } from "graphql-relay"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { CursorPageable, pageable } from "relay-cursor-paging"
+import { createPageCursors } from "schema/v1/fields/pagination"
+import { ResolverContext } from "types/graphql"
+import gql from "lib/gql"
+import { artistConnection } from "schema/v2/artist"
+
+const MAX_ARTISTS = 20
+
+export const ArtistRecommendations: GraphQLFieldConfig<
+  void,
+  ResolverContext
+> = {
+  description: "A connection of artist recommendations.",
+  type: artistConnection.connectionType,
+  args: pageable({
+    page: { type: GraphQLInt },
+  }),
+  resolve: async (
+    _root,
+    args: CursorPageable,
+    { vortexGraphqlLoader, artistsLoader }
+  ) => {
+    if (!vortexGraphqlLoader || !artistsLoader) return
+
+    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+
+    // Fetch artist IDs from Vortex
+
+    const vortexResult = await vortexGraphqlLoader({
+      query: gql`
+        query artistRecommendationsQuery {
+          artistRecommendations(first: ${MAX_ARTISTS}) {
+            totalCount
+            edges {
+              node {
+                artistId
+                score
+              }
+            }
+          }
+        }
+      `,
+    })()
+
+    const artistIds = vortexResult.data?.artistRecommendations?.edges?.map(
+      (edge) => edge?.node?.artistId
+    )
+
+    let artists: any = []
+
+    if (artistIds?.length) {
+      artists = await artistsLoader({
+        artist_ids: artistIds,
+        size,
+        offset,
+      })
+    }
+
+    // TODO: get count from artists loader to optimize pagination
+    const count = artists.length === 0 ? 0 : MAX_ARTISTS
+
+    return {
+      totalCount: count,
+      pageCursors: createPageCursors({ ...args, page, size }, count),
+      ...connectionFromArraySlice(artists, args, {
+        arrayLength: count,
+        sliceStart: offset ?? 0,
+      }),
+    }
+  },
+}

--- a/src/schema/v2/me/artistRecommendations.ts
+++ b/src/schema/v2/me/artistRecommendations.ts
@@ -49,6 +49,8 @@ export const ArtistRecommendations: GraphQLFieldConfig<
       (edge) => edge?.node?.artistId
     )
 
+    // Fetch artist details from Gravity
+
     let artists: any = []
 
     if (artistIds?.length) {

--- a/src/schema/v2/me/artistRecommendations.ts
+++ b/src/schema/v2/me/artistRecommendations.ts
@@ -63,8 +63,7 @@ export const ArtistRecommendations: GraphQLFieldConfig<
       ).body
     }
 
-    // TODO: get count from artists loader to optimize pagination
-    const count = artists.length === 0 ? 0 : MAX_ARTISTS
+    const count = artists.length
 
     return {
       totalCount: count,

--- a/src/schema/v2/me/artistRecommendations.ts
+++ b/src/schema/v2/me/artistRecommendations.ts
@@ -1,5 +1,5 @@
 import { GraphQLFieldConfig, GraphQLInt } from "graphql"
-import { connectionFromArraySlice } from "graphql-relay"
+import { connectionFromArray } from "graphql-relay"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { CursorPageable, pageable } from "relay-cursor-paging"
 import { createPageCursors } from "schema/v1/fields/pagination"
@@ -26,7 +26,7 @@ export const ArtistRecommendations: GraphQLFieldConfig<
   ) => {
     if (!vortexGraphqlLoader || !artistsLoader) return
 
-    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+    const { page, size } = convertConnectionArgsToGravityArgs(args)
 
     // Fetch artist IDs from Vortex
 
@@ -58,8 +58,6 @@ export const ArtistRecommendations: GraphQLFieldConfig<
       artists = (
         await artistsLoader({
           ids: artistIds,
-          size,
-          offset,
         })
       ).body
 
@@ -75,10 +73,7 @@ export const ArtistRecommendations: GraphQLFieldConfig<
     return {
       totalCount: count,
       pageCursors: createPageCursors({ ...args, page, size }, count),
-      ...connectionFromArraySlice(artists, args, {
-        arrayLength: count,
-        sliceStart: offset ?? 0,
-      }),
+      ...connectionFromArray(artists, args),
     }
   },
 }

--- a/src/schema/v2/me/artistRecommendations.ts
+++ b/src/schema/v2/me/artistRecommendations.ts
@@ -56,7 +56,7 @@ export const ArtistRecommendations: GraphQLFieldConfig<
     if (artistIds?.length) {
       artists = (
         await artistsLoader({
-          artist_ids: artistIds,
+          ids: artistIds,
           size,
           offset,
         })

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -47,12 +47,14 @@ import { SavedArtworks } from "./savedArtworks"
 import { WatchedLotConnection } from "./watchedLotConnection"
 import { ShowsByFollowedArtists } from "./showsByFollowedArtists"
 import Image, { normalizeImageData } from "../image"
+import { ArtistRecommendations } from "./artistRecommendations"
 
 export const meType = new GraphQLObjectType<any, ResolverContext>({
   name: "Me",
   interfaces: [NodeInterface],
   fields: {
     ...IDFields,
+    artistRecommendations: ArtistRecommendations,
     artworkInquiriesConnection: ArtworkInquiries,
     auctionResultsByFollowedArtists: AuctionResultsByFollowedArtists,
     bidders: Bidders,

--- a/src/schema/v2/me/newWorksByInterestingArtists.ts
+++ b/src/schema/v2/me/newWorksByInterestingArtists.ts
@@ -1,6 +1,6 @@
 import { GraphQLFieldConfig, GraphQLInt } from "graphql"
 import { connectionFromArraySlice } from "graphql-relay"
-import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { convertConnectionArgsToGravityArgs, extractNodes } from "lib/helpers"
 import { CursorPageable, pageable } from "relay-cursor-paging"
 import { createPageCursors } from "schema/v1/fields/pagination"
 import { ResolverContext } from "types/graphql"
@@ -48,8 +48,8 @@ export const NewWorksByInterestingArtists: GraphQLFieldConfig<
       `,
     })()
 
-    const artistIds = vortexResult.data?.artistAffinities?.edges?.map(
-      (edge) => edge?.node?.artistId
+    const artistIds = extractNodes(vortexResult.data?.artistAffinities).map(
+      (node: any) => node?.artistId
     )
 
     // Fetch artworks from ArtworksLoader if the user interacted with any artists


### PR DESCRIPTION
Addresses [CX-2131]

## Description

Adds a new `artistRecommendations` connection to `me`. The connection fetches artist recommendations for the current user from **Vortex** and the artist details from **Gravity**.

### Query

```graphql
query ArtistRecommendationsQuery {
  me {
    artistRecommendations(first: 10) {
      totalCount
      edges {
        node {
          artistId
          score
        }
      }
    }
 }
}
```

[CX-2120]: https://artsyproduct.atlassian.net/browse/CX-2120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CX-2131]: https://artsyproduct.atlassian.net/browse/CX-2131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ