### PR TITLE
fix: short show exhibition period as a format arg

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6392,6 +6392,11 @@ enum EventStatus {
   UPCOMING
 }
 
+enum ExhibitionPeriodFormat {
+  LONG
+  SHORT
+}
+
 type External {
   auctionHouses(size: Int, term: String): [ExternalAuctionHouse!]!
   fairs(size: Int, term: String): [ExternalFair!]!
@@ -6511,8 +6516,8 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
 
   # A formatted description of the start to end dates
   exhibitionPeriod(
-    # SHORT or LONG, SHORT returns a shorter exhbition period description, LONG returns a longer description, defaults to LONG
-    format: String
+    # SHORT or LONG, SHORT returns a shorter exhbition period description with months abbreviated, defaults to LONG
+    format: ExhibitionPeriodFormat
   ): String
 
   # The exhibitors with booths in this fair with letter.
@@ -11967,8 +11972,8 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
 
   # A formatted description of the start to end dates
   exhibitionPeriod(
-    # SHORT or LONG, SHORT returns a shorter exhbition period description, LONG returns a longer description, defaults to LONG
-    format: String
+    # SHORT or LONG, SHORT returns a shorter exhbition period description with months abbreviated, defaults to LONG
+    format: ExhibitionPeriodFormat
   ): String
 
   # If the show is in a Fair, then that fair

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12221,10 +12221,10 @@ type ShowEventType {
   eventType: String
 
   # A formatted description of the start to end dates
-  exhibitionPeriod: String
-
-  # A formatted description of the start to end dates with abbreviated months
-  shortExhibitionPeriod: String
+  exhibitionPeriod(
+    # Formatting option to apply to exhibition period
+    format: ExhibitionPeriodFormat!
+  ): String
   startAt(
     format: String
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6393,7 +6393,10 @@ enum EventStatus {
 }
 
 enum ExhibitionPeriodFormat {
+  # Long formatted period e.g. February 25 – May 24, 2015
   LONG
+
+  # Short formatted period e.g. Feb 25 - May 24, 2015
   SHORT
 }
 
@@ -6516,8 +6519,8 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
 
   # A formatted description of the start to end dates
   exhibitionPeriod(
-    # SHORT or LONG, SHORT returns a shorter exhbition period description with months abbreviated, defaults to LONG
-    format: ExhibitionPeriodFormat
+    # Formatting option to apply to exhibition period
+    format: ExhibitionPeriodFormat!
   ): String
 
   # The exhibitors with booths in this fair with letter.
@@ -11972,8 +11975,8 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
 
   # A formatted description of the start to end dates
   exhibitionPeriod(
-    # SHORT or LONG, SHORT returns a shorter exhbition period description with months abbreviated, defaults to LONG
-    format: ExhibitionPeriodFormat
+    # Formatting option to apply to exhibition period
+    format: ExhibitionPeriodFormat!
   ): String
 
   # If the show is in a Fair, then that fair

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6510,7 +6510,10 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
   ): String
 
   # A formatted description of the start to end dates
-  exhibitionPeriod: String
+  exhibitionPeriod(
+    # SHORT or LONG, SHORT returns a shorter exhbition period description, LONG returns a longer description, defaults to LONG
+    format: String
+  ): String
 
   # The exhibitors with booths in this fair with letter.
   exhibitorsGroupedByName: [FairExhibitorsGroup]
@@ -6603,9 +6606,6 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
   name: String
   organizer: FairOrganizer
   profile: Profile
-
-  # A formatted description of the start to end dates with abbreviated months
-  shortExhibitionPeriod: String
 
   # This connection only supports forward pagination. We're replacing Relay's default cursor with one from Gravity.
   showsConnection(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11966,7 +11966,10 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
   events: [ShowEventType]
 
   # A formatted description of the start to end dates
-  exhibitionPeriod: String
+  exhibitionPeriod(
+    # SHORT or LONG, SHORT returns a shorter exhbition period description, LONG returns a longer description, defaults to LONG
+    format: String
+  ): String
 
   # If the show is in a Fair, then that fair
   fair: Fair
@@ -12121,9 +12124,6 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
 
   # Link to the press release for this show
   pressReleaseUrl: String
-
-  # A formatted description of the start to end dates with abbreviated months
-  shortExhibitionPeriod: String
 
   # A slug ID.
   slug: ID!

--- a/src/lib/__tests__/date.test.ts
+++ b/src/lib/__tests__/date.test.ts
@@ -422,7 +422,7 @@ describe("date formatting", () => {
     })
 
     it("abbreviates months when specified", () => {
-      const period = dateRange("2011-01-01", "2011-04-19", "UTC", true)
+      const period = dateRange("2011-01-01", "2011-04-19", "UTC", "short")
       expect(period).toBe("Jan 1 – Apr 19, 2011")
     })
   })

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -154,10 +154,10 @@ export function dateTimeRange(
  * Nov 1 – 4, 2018
  * Nov 1, 2018 – Jan 4, 2019
  */
-export function dateRange(startAt, endAt, timezone, abbreviateMonths = false) {
+export function dateRange(startAt, endAt, timezone, format = "long") {
   const startMoment = moment.tz(startAt, timezone)
   const endMoment = moment.tz(endAt, timezone)
-  const monthFormat = abbreviateMonths ? "MMM" : "MMMM"
+  const monthFormat = format === "short" ? "MMM" : "MMMM"
   let startFormat = monthFormat + " D"
   let endFormat = "D, YYYY"
   const singleDateFormat = monthFormat + " D, YYYY"

--- a/src/schema/v2/__tests__/fair.test.js
+++ b/src/schema/v2/__tests__/fair.test.js
@@ -683,7 +683,7 @@ describe("Fair", () => {
     const query = gql`
       {
         fair(id: "aqua-art-miami-2018") {
-          exhibitionPeriod(format: "SHORT")
+          exhibitionPeriod(format: SHORT)
         }
       }
     `

--- a/src/schema/v2/__tests__/fair.test.js
+++ b/src/schema/v2/__tests__/fair.test.js
@@ -683,7 +683,7 @@ describe("Fair", () => {
     const query = gql`
       {
         fair(id: "aqua-art-miami-2018") {
-          shortExhibitionPeriod
+          exhibitionPeriod(format: "SHORT")
         }
       }
     `
@@ -691,11 +691,10 @@ describe("Fair", () => {
     const data = await runQuery(query, context)
     expect(data).toEqual({
       fair: {
-        shortExhibitionPeriod: "Feb 15 – 17, 2019",
+        exhibitionPeriod: "Feb 15 – 17, 2019",
       },
     })
   })
-
 
   it("includes artists associated with the fair", async () => {
     const query = gql`

--- a/src/schema/v2/__tests__/show.test.js
+++ b/src/schema/v2/__tests__/show.test.js
@@ -619,7 +619,7 @@ describe("Show type", () => {
     const query = gql`
       {
         show(id: "new-museum-1-2015-triennial-surround-audience") {
-          exhibitionPeriod(format: "SHORT")
+          exhibitionPeriod(format: SHORT)
         }
       }
     `

--- a/src/schema/v2/__tests__/show.test.js
+++ b/src/schema/v2/__tests__/show.test.js
@@ -619,7 +619,7 @@ describe("Show type", () => {
     const query = gql`
       {
         show(id: "new-museum-1-2015-triennial-surround-audience") {
-          shortExhibitionPeriod
+          exhibitionPeriod(format: "SHORT")
         }
       }
     `
@@ -627,7 +627,7 @@ describe("Show type", () => {
     const data = await runQuery(query, context)
     expect(data).toEqual({
       show: {
-        shortExhibitionPeriod: "Feb 25 – May 24, 2015",
+        exhibitionPeriod: "Feb 25 – May 24, 2015",
       },
     })
   })

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -139,14 +139,18 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
       exhibitionPeriod: {
         type: GraphQLString,
         description: "A formatted description of the start to end dates",
-        resolve: ({ start_at, end_at }) => dateRange(start_at, end_at, "UTC"),
-      },
-      shortExhibitionPeriod: {
-        type: GraphQLString,
-        description:
-          "A formatted description of the start to end dates with abbreviated months",
-        resolve: ({ start_at, end_at }) =>
-          dateRange(start_at, end_at, "UTC", true),
+        args: {
+          format: {
+            type: GraphQLString,
+            description:
+              "SHORT or LONG, SHORT returns a shorter exhbition period description, LONG returns a longer description, defaults to LONG",
+          },
+        },
+        resolve: ({ start_at, end_at }, args) => {
+          const { format } = args
+          const useShortFormat = format === "SHORT"
+          return dateRange(start_at, end_at, "UTC", useShortFormat)
+        },
       },
       formattedOpeningHours: {
         type: GraphQLString,

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -12,7 +12,7 @@ import Profile from "./profile"
 import Image from "./image"
 import Artist from "./artist"
 import Partner, { PartnerType } from "./partner"
-import { ShowsConnection } from "./show"
+import { ExhibitionPeriodFormatType, ShowsConnection } from "./show"
 import { LocationType } from "./location"
 import {
   SlugAndInternalIDFields,
@@ -141,9 +141,9 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
         description: "A formatted description of the start to end dates",
         args: {
           format: {
-            type: GraphQLString,
+            type: ExhibitionPeriodFormatType,
             description:
-              "SHORT or LONG, SHORT returns a shorter exhbition period description, LONG returns a longer description, defaults to LONG",
+              "SHORT or LONG, SHORT returns a shorter exhbition period description with months abbreviated, defaults to LONG",
           },
         },
         resolve: ({ start_at, end_at }, args) => {

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -148,8 +148,7 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
         },
         resolve: ({ start_at, end_at }, args) => {
           const { format } = args
-          const useShortFormat = format === "short"
-          return dateRange(start_at, end_at, "UTC", useShortFormat)
+          return dateRange(start_at, end_at, "UTC", format)
         },
       },
       formattedOpeningHours: {

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -12,7 +12,7 @@ import Profile from "./profile"
 import Image from "./image"
 import Artist from "./artist"
 import Partner, { PartnerType } from "./partner"
-import { ExhibitionPeriodFormatType, ShowsConnection } from "./show"
+import { ExhibitionPeriodFormatEnum, ShowsConnection } from "./show"
 import { LocationType } from "./location"
 import {
   SlugAndInternalIDFields,
@@ -141,14 +141,14 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
         description: "A formatted description of the start to end dates",
         args: {
           format: {
-            type: ExhibitionPeriodFormatType,
-            description:
-              "SHORT or LONG, SHORT returns a shorter exhbition period description with months abbreviated, defaults to LONG",
+            type: new GraphQLNonNull(ExhibitionPeriodFormatEnum),
+            description: "Formatting option to apply to exhibition period",
+            defaultValue: ExhibitionPeriodFormatEnum.getValue("LONG"),
           },
         },
         resolve: ({ start_at, end_at }, args) => {
           const { format } = args
-          const useShortFormat = format === "SHORT"
+          const useShortFormat = format === "short"
           return dateRange(start_at, end_at, "UTC", useShortFormat)
         },
       },

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -12,7 +12,7 @@ import Profile from "./profile"
 import Image from "./image"
 import Artist from "./artist"
 import Partner, { PartnerType } from "./partner"
-import { ExhibitionPeriodFormatEnum, ShowsConnection } from "./show"
+import { ShowsConnection } from "./show"
 import { LocationType } from "./location"
 import {
   SlugAndInternalIDFields,
@@ -41,6 +41,7 @@ import {
   createPageCursors,
 } from "./fields/pagination"
 import { FairOrganizerType } from "./fair_organizer"
+import { ExhibitionPeriodFormatEnum } from "./types/exhibitonPeriod"
 
 const FollowedContentType = new GraphQLObjectType<any, ResolverContext>({
   name: "FollowedContent",

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -57,14 +57,16 @@ const FollowArtistType = new GraphQLObjectType<any, ResolverContext>({
   }),
 })
 
-export const ExhibitionPeriodFormatType = new GraphQLEnumType({
+export const ExhibitionPeriodFormatEnum = new GraphQLEnumType({
   name: "ExhibitionPeriodFormat",
   values: {
     SHORT: {
-      value: "SHORT",
+      value: "short",
+      description: "Short formatted period e.g. Feb 25 - May 24, 2015",
     },
     LONG: {
-      value: "LONG",
+      value: "long",
+      description: "Long formatted period e.g. February 25 – May 24, 2015",
     },
   },
 })
@@ -353,14 +355,14 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
         description: "A formatted description of the start to end dates",
         args: {
           format: {
-            type: ExhibitionPeriodFormatType,
-            description:
-              "SHORT or LONG, SHORT returns a shorter exhbition period description with months abbreviated, defaults to LONG",
+            type: new GraphQLNonNull(ExhibitionPeriodFormatEnum),
+            description: "Formatting option to apply to exhibition period",
+            defaultValue: ExhibitionPeriodFormatEnum.getValue("LONG"),
           },
         },
         resolve: ({ start_at, end_at }, args) => {
           const { format } = args
-          const useShortFormat = format === "SHORT"
+          const useShortFormat = format === "short"
           return dateRange(start_at, end_at, "UTC", useShortFormat)
         },
       },

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -362,8 +362,7 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
         },
         resolve: ({ start_at, end_at }, args) => {
           const { format } = args
-          const useShortFormat = format === "short"
-          return dateRange(start_at, end_at, "UTC", useShortFormat)
+          return dateRange(start_at, end_at, "UTC", format)
         },
       },
       fair: {

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -37,7 +37,6 @@ import {
   GraphQLUnionType,
   GraphQLFieldConfig,
   GraphQLFieldConfigArgumentMap,
-  GraphQLEnumType,
 } from "graphql"
 import { totalViaLoader } from "lib/total"
 import { find, flatten } from "lodash"
@@ -47,6 +46,7 @@ import EventStatus from "./input_fields/event_status"
 import { LOCAL_DISCOVERY_RADIUS_KM } from "./city/constants"
 import { ResolverContext } from "types/graphql"
 import followArtistsResolver from "lib/shared_resolvers/followedArtistsResolver"
+import { ExhibitionPeriodFormatEnum } from "./types/exhibitonPeriod"
 
 const FollowArtistType = new GraphQLObjectType<any, ResolverContext>({
   name: "ShowFollowArtist",
@@ -55,20 +55,6 @@ const FollowArtistType = new GraphQLObjectType<any, ResolverContext>({
       type: Artist.type,
     },
   }),
-})
-
-export const ExhibitionPeriodFormatEnum = new GraphQLEnumType({
-  name: "ExhibitionPeriodFormat",
-  values: {
-    SHORT: {
-      value: "short",
-      description: "Short formatted period e.g. Feb 25 - May 24, 2015",
-    },
-    LONG: {
-      value: "long",
-      description: "Long formatted period e.g. February 25 – May 24, 2015",
-    },
-  },
 })
 
 const kind = ({ artists, fair, artists_without_artworks, group }) => {

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -37,6 +37,7 @@ import {
   GraphQLUnionType,
   GraphQLFieldConfig,
   GraphQLFieldConfigArgumentMap,
+  GraphQLEnumType,
 } from "graphql"
 import { totalViaLoader } from "lib/total"
 import { find, flatten } from "lodash"
@@ -54,6 +55,18 @@ const FollowArtistType = new GraphQLObjectType<any, ResolverContext>({
       type: Artist.type,
     },
   }),
+})
+
+export const ExhibitionPeriodFormatType = new GraphQLEnumType({
+  name: "ExhibitionPeriodFormat",
+  values: {
+    SHORT: {
+      value: "SHORT",
+    },
+    LONG: {
+      value: "LONG",
+    },
+  },
 })
 
 const kind = ({ artists, fair, artists_without_artworks, group }) => {
@@ -340,9 +353,9 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
         description: "A formatted description of the start to end dates",
         args: {
           format: {
-            type: GraphQLString,
+            type: ExhibitionPeriodFormatType,
             description:
-              "SHORT or LONG, SHORT returns a shorter exhbition period description, LONG returns a longer description, defaults to LONG",
+              "SHORT or LONG, SHORT returns a shorter exhbition period description with months abbreviated, defaults to LONG",
           },
         },
         resolve: ({ start_at, end_at }, args) => {

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -338,14 +338,18 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
       exhibitionPeriod: {
         type: GraphQLString,
         description: "A formatted description of the start to end dates",
-        resolve: ({ start_at, end_at }) => dateRange(start_at, end_at, "UTC"),
-      },
-      shortExhibitionPeriod: {
-        type: GraphQLString,
-        description:
-          "A formatted description of the start to end dates with abbreviated months",
-        resolve: ({ start_at, end_at }) =>
-          dateRange(start_at, end_at, "UTC", true),
+        args: {
+          format: {
+            type: GraphQLString,
+            description:
+              "SHORT or LONG, SHORT returns a shorter exhbition period description, LONG returns a longer description, defaults to LONG",
+          },
+        },
+        resolve: ({ start_at, end_at }, args) => {
+          const { format } = args
+          const useShortFormat = format === "SHORT"
+          return dateRange(start_at, end_at, "UTC", useShortFormat)
+        },
       },
       fair: {
         description: "If the show is in a Fair, then that fair",

--- a/src/schema/v2/show_event.ts
+++ b/src/schema/v2/show_event.ts
@@ -1,7 +1,8 @@
 import dateField from "./fields/date"
-import { GraphQLString, GraphQLObjectType } from "graphql"
+import { GraphQLString, GraphQLObjectType, GraphQLNonNull } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { dateRange, dateTimeRange } from "lib/date"
+import { ExhibitionPeriodFormatEnum } from "./types/exhibitonPeriod"
 
 const ShowEventType = new GraphQLObjectType<any, ResolverContext>({
   name: "ShowEventType",
@@ -29,14 +30,17 @@ const ShowEventType = new GraphQLObjectType<any, ResolverContext>({
     exhibitionPeriod: {
       type: GraphQLString,
       description: "A formatted description of the start to end dates",
-      resolve: ({ start_at, end_at }) => dateRange(start_at, end_at, "UTC"),
-    },
-    shortExhibitionPeriod: {
-      type: GraphQLString,
-      description:
-        "A formatted description of the start to end dates with abbreviated months",
-      resolve: ({ start_at, end_at }) =>
-        dateRange(start_at, end_at, "UTC", true),
+      args: {
+        format: {
+          type: new GraphQLNonNull(ExhibitionPeriodFormatEnum),
+          description: "Formatting option to apply to exhibition period",
+          defaultValue: ExhibitionPeriodFormatEnum.getValue("LONG"),
+        },
+      },
+      resolve: ({ start_at, end_at }, args) => {
+        const { format } = args
+        return dateRange(start_at, end_at, "UTC", format)
+      },
     },
   },
 })

--- a/src/schema/v2/types/exhibitonPeriod.ts
+++ b/src/schema/v2/types/exhibitonPeriod.ts
@@ -1,0 +1,15 @@
+import { GraphQLEnumType } from "graphql"
+
+export const ExhibitionPeriodFormatEnum = new GraphQLEnumType({
+  name: "ExhibitionPeriodFormat",
+  values: {
+    SHORT: {
+      value: "short",
+      description: "Short formatted period e.g. Feb 25 - May 24, 2015",
+    },
+    LONG: {
+      value: "long",
+      description: "Long formatted period e.g. February 25 – May 24, 2015",
+    },
+  },
+})


### PR DESCRIPTION
some PR review follow up from https://github.com/artsy/metaphysics/pull/3550

Instead of having a separate field add a format arg to the existing exhibitionPeriod field, right now just `LONG` and `SHORT` supported. 