### PR TITLE
fix: make format arg not required

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6520,7 +6520,7 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
   # A formatted description of the start to end dates
   exhibitionPeriod(
     # Formatting option to apply to exhibition period
-    format: ExhibitionPeriodFormat!
+    format: ExhibitionPeriodFormat
   ): String
 
   # The exhibitors with booths in this fair with letter.
@@ -12019,7 +12019,7 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
   # A formatted description of the start to end dates
   exhibitionPeriod(
     # Formatting option to apply to exhibition period
-    format: ExhibitionPeriodFormat!
+    format: ExhibitionPeriodFormat
   ): String
 
   # If the show is in a Fair, then that fair
@@ -12266,7 +12266,7 @@ type ShowEventType {
   # A formatted description of the start to end dates
   exhibitionPeriod(
     # Formatting option to apply to exhibition period
-    format: ExhibitionPeriodFormat!
+    format: ExhibitionPeriodFormat
   ): String
   startAt(
     format: String

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -142,7 +142,7 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
         description: "A formatted description of the start to end dates",
         args: {
           format: {
-            type: new GraphQLNonNull(ExhibitionPeriodFormatEnum),
+            type: ExhibitionPeriodFormatEnum,
             description: "Formatting option to apply to exhibition period",
             defaultValue: ExhibitionPeriodFormatEnum.getValue("LONG"),
           },

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -341,7 +341,7 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
         description: "A formatted description of the start to end dates",
         args: {
           format: {
-            type: new GraphQLNonNull(ExhibitionPeriodFormatEnum),
+            type: ExhibitionPeriodFormatEnum,
             description: "Formatting option to apply to exhibition period",
             defaultValue: ExhibitionPeriodFormatEnum.getValue("LONG"),
           },

--- a/src/schema/v2/show_event.ts
+++ b/src/schema/v2/show_event.ts
@@ -1,5 +1,5 @@
 import dateField from "./fields/date"
-import { GraphQLString, GraphQLObjectType, GraphQLNonNull } from "graphql"
+import { GraphQLString, GraphQLObjectType } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { dateRange, dateTimeRange } from "lib/date"
 import { ExhibitionPeriodFormatEnum } from "./types/exhibitonPeriod"
@@ -32,7 +32,7 @@ const ShowEventType = new GraphQLObjectType<any, ResolverContext>({
       description: "A formatted description of the start to end dates",
       args: {
         format: {
-          type: new GraphQLNonNull(ExhibitionPeriodFormatEnum),
+          type: ExhibitionPeriodFormatEnum,
           description: "Formatting option to apply to exhibition period",
           defaultValue: ExhibitionPeriodFormatEnum.getValue("LONG"),
         },


### PR DESCRIPTION
former PR made the format arg required which was incompatible with Eigen's existing schema. This makes the arg not required but we still have a default. 