### PR TITLE
[COORDINATE-DEPLOY] feat: relax VAT requirements for artworks (TX-135)

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -2424,11 +2424,11 @@ describe("Artwork type", () => {
       })
     })
 
-    it("returns true when artwork requires vat and partner is vat registered", () => {
+    it("returns true when artwork requires VAT and partner has any VAT status", () => {
       artwork.vat_required = true
       artwork.partner = { id: "123" }
       context.partnerAllLoader = jest.fn(() =>
-        Promise.resolve({ vat_registered: true })
+        Promise.resolve({ vat_status: "anything" })
       )
 
       return runQuery(query, context).then((data) => {
@@ -2437,11 +2437,24 @@ describe("Artwork type", () => {
       })
     })
 
-    it("returns false when artwork requires vat and partner is not vat registered", () => {
+    it("returns false when artwork requires VAT and partner does not have a VAT status", () => {
       artwork.vat_required = true
       artwork.partner = { id: "123" }
       context.partnerAllLoader = jest.fn(() =>
-        Promise.resolve({ vat_registered: false })
+        Promise.resolve({ vat_status: null })
+      )
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({ artwork: { vatRequirementComplete: false } })
+        expect(context.partnerAllLoader).toHaveBeenCalledWith("123")
+      })
+    })
+
+    it("returns false when artwork requires VAT and partner has an empty VAT status", () => {
+      artwork.vat_required = true
+      artwork.partner = { id: "123" }
+      context.partnerAllLoader = jest.fn(() =>
+        Promise.resolve({ vat_status: "" })
       )
 
       return runQuery(query, context).then((data) => {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -815,9 +815,9 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
 
           if (!vat_required) return true
 
-          const { vat_registered } = await partnerAllLoader(partner.id)
+          const { vat_status } = await partnerAllLoader(partner.id)
 
-          return vat_registered
+          return !!vat_status
         },
       },
       pricePaid: {


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/TX-135

We want to enable BNMO (including Make Offer in Inquiries) for artworks located in relevant countries as long as partners have provided a VAT status (and necessary exemption documentation for us to review), regardless of the selected status.

With this, clients (i.e. Volt) will not block taking actions on MOI orders as long as there is _a_ VAT status set. The recording below shows the flow of selecting exempt and the blocking banner going away. Note that the actions are still disabled because of metadata that's also required by Make Offer in Inquiries.

![vat-moi](https://user-images.githubusercontent.com/796573/143956919-a521e2cf-ff15-4535-a2b2-51ad8b5141ef.gif)