### PR TITLE
[DO NOT MERGE] Example hybrid connection implementation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1733,6 +1733,28 @@ union ArtworkMutationType =
     ArtworkMutationDeleteSuccess
   | ArtworkMutationFailure
 
+union ArtworkOrArtist = Artist | Artwork
+
+# A connection to a list of items.
+type ArtworkOrArtistConnection {
+  # A list of edges.
+  edges: [ArtworkOrArtistEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type ArtworkOrArtistEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: ArtworkOrArtist
+}
+
 union ArtworkOrEditionSetType = Artwork | EditionSet
 
 # The results for one of the requested aggregations
@@ -10438,6 +10460,14 @@ type Query {
       reason: "This is only for use in resolving stitched queries, not for first-class client use."
     )
 
+  # A list of Artworks and Artists
+  artworksAndArtistsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkOrArtistConnection
+
   # Artworks Elastic Search results
   artworksConnection(
     acquireable: Boolean
@@ -13308,6 +13338,14 @@ type Viewer {
     @deprecated(
       reason: "This is only for use in resolving stitched queries, not for first-class client use."
     )
+
+  # A list of Artworks and Artists
+  artworksAndArtistsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkOrArtistConnection
 
   # Artworks Elastic Search results
   artworksConnection(

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -50,7 +50,6 @@ export default (opts) => {
     >(({ artwork_id, image_id }) => `artwork/${artwork_id}/image/${image_id}`),
     artworkLoader: gravityLoader((id) => `artwork/${id}`),
     artworksLoader: gravityLoader("artworks"),
-    artworksWithHeadersLoader: gravityLoader("artworks", {}, { headers: true }),
     bidderLoader: gravityLoader((id) => `bidder/${id}`),
     exchangeRatesLoader: gravityLoader(
       "exchange_rates",

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -50,6 +50,7 @@ export default (opts) => {
     >(({ artwork_id, image_id }) => `artwork/${artwork_id}/image/${image_id}`),
     artworkLoader: gravityLoader((id) => `artwork/${id}`),
     artworksLoader: gravityLoader("artworks"),
+    artworksWithHeadersLoader: gravityLoader("artworks", {}, { headers: true }),
     bidderLoader: gravityLoader((id) => `bidder/${id}`),
     exchangeRatesLoader: gravityLoader(
       "exchange_rates",

--- a/src/schema/v2/artworksAndArtistsConnection.ts
+++ b/src/schema/v2/artworksAndArtistsConnection.ts
@@ -59,8 +59,6 @@ const fetchArtistsForPagination = (
   }
 }
 
-///////////////////////////////////////
-
 export const ArtworksAndArtistsUnion = new GraphQLUnionType({
   name: "ArtworkOrArtist",
   types: [ArtworkType, ArtistType],
@@ -105,22 +103,5 @@ export const artworksAndArtistsConnection: GraphQLFieldConfig<
       },
     })
     return result
-
-    // return artworksLoader({ ids, batched: respectParamsOrder }).then((body) => {
-    //   const totalCount = body.length
-    //   return {
-    //     totalCount,
-    //     pageCursors: createPageCursors({ page, size }, totalCount),
-    //     ...connectionFromArray(body, options),
-    //   }
-    // })
-    // return artistsLoader({ ids, batched: respectParamsOrder }).then((body) => {
-    //   const totalCount = body.length
-    //   return {
-    //     totalCount,
-    //     pageCursors: createPageCursors({ page, size }, totalCount),
-    //     ...connectionFromArray(body, options),
-    //   }
-    // })
   },
 }

--- a/src/schema/v2/artworksAndArtistsConnection.ts
+++ b/src/schema/v2/artworksAndArtistsConnection.ts
@@ -1,0 +1,126 @@
+import { ArtworkType } from "./artwork"
+import { GraphQLFieldConfig, GraphQLUnionType } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { pageable } from "relay-cursor-paging"
+import { connectionWithCursorInfo } from "./fields/pagination"
+import { ArtistType } from "./artist"
+import { fetchHybridConnection } from "./fields/hybridConnection"
+import { FetcherForLimitAndOffset } from "./fields/hybridConnection/fetchHybridConnection"
+
+const extractNodeDate = (node) => {
+  return Date.parse(node["createdAt"] || node["created_at"])
+}
+
+const fetchArtworksForPagination = (
+  artworksLoader: any
+): FetcherForLimitAndOffset<any> => async ({ limit, offset, sort }) => {
+  const page = limit ? Math.round((limit + offset) / limit) : 1
+  const { body, headers } = await artworksLoader({
+    page,
+    size: limit,
+    sort: sort == "ASC" ? "created_at" : "-created_at", // double check this is the right place for this arg
+    total_count: true,
+  })
+  const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+  const artworks = body.map((artwork) => {
+    return {
+      ...artwork,
+      context_type: "Artwork",
+    }
+  })
+  console.log({ artworksLength: artworks.length, totalCount })
+  return {
+    totalCount,
+    nodes: artworks,
+  }
+}
+
+const fetchArtistsForPagination = (
+  artistsLoader: any
+): FetcherForLimitAndOffset<any> => async ({ limit, offset, sort }) => {
+  const page = limit ? Math.round((limit + offset) / limit) : 1
+  const { body, headers } = await artistsLoader({
+    page,
+    size: limit,
+    sort: sort == "ASC" ? "sortable_id" : "-sortable_id",
+    total_count: true,
+  })
+  const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+  const artists = body.map((artist) => {
+    return {
+      ...artist,
+      context_type: "Artist",
+    }
+  })
+  console.log({ artistsLength: artists.length, totalCount })
+  return {
+    totalCount,
+    nodes: artists,
+  }
+}
+
+///////////////////////////////////////
+
+export const ArtworksAndArtistsUnion = new GraphQLUnionType({
+  name: "ArtworkOrArtist",
+  types: [ArtworkType, ArtistType],
+  resolveType: (value, ..._args) => {
+    switch (value.context_type) {
+      case "Artist":
+        return ArtistType
+      case "Artwork":
+        return ArtworkType
+      default:
+        throw new Error(`Unknown context type: ${value.context_type}`)
+    }
+  },
+})
+
+export const artworksAndArtistsConnection: GraphQLFieldConfig<
+  void,
+  ResolverContext
+> = {
+  type: connectionWithCursorInfo({
+    nodeType: ArtworksAndArtistsUnion,
+  }).connectionType,
+  description: "A list of Artworks and Artists",
+  args: pageable({}),
+  resolve: async (_root, args, { artworksLoader, artistsLoader }) => {
+    const result = await fetchHybridConnection({
+      args,
+      fetchers: {
+        artworks: fetchArtworksForPagination(artworksLoader),
+        artists: fetchArtistsForPagination(artistsLoader),
+        // artists: fetchArtistsForPagination,
+      },
+      transform: (args, nodes) => {
+        // Sort the nodes before returning the relevant slice
+        const sorter =
+          args.sort === "DESC"
+            ? (a, b) => extractNodeDate(b) - extractNodeDate(a)
+            : (a, b) => extractNodeDate(a) - extractNodeDate(b)
+
+        const sortedNodes = nodes.sort(sorter)
+        return sortedNodes
+      },
+    })
+    return result
+
+    // return artworksLoader({ ids, batched: respectParamsOrder }).then((body) => {
+    //   const totalCount = body.length
+    //   return {
+    //     totalCount,
+    //     pageCursors: createPageCursors({ page, size }, totalCount),
+    //     ...connectionFromArray(body, options),
+    //   }
+    // })
+    // return artistsLoader({ ids, batched: respectParamsOrder }).then((body) => {
+    //   const totalCount = body.length
+    //   return {
+    //     totalCount,
+    //     pageCursors: createPageCursors({ page, size }, totalCount),
+    //     ...connectionFromArray(body, options),
+    //   }
+    // })
+  },
+}

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -107,6 +107,7 @@ import { externalField } from "./External/External"
 import { createUserInterestMutation } from "./me/createUserInterestMutation"
 import { page } from "./page"
 import { deleteUserInterestMutation } from "./me/deleteUserInterestMutation"
+import { artworksAndArtistsConnection } from "./artworksAndArtistsConnection"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -128,6 +129,7 @@ const rootFields = {
   artwork: Artwork,
   // artworkVersion: ArtworkVersionResolver,
   artworksConnection: filterArtworksConnection(),
+  artworksAndArtistsConnection,
   artworks: Artworks,
   artist: Artist,
   artists: Artists,


### PR DESCRIPTION
Paired with @erikdstock on this example implementation of a hybrid connection.

It uses 2 standard gravity endpoints, but the artworkLoader fails/times out due to a quirk in its implementation (can explain in slack). Swapping it out for another generic gravity loader (fairs) does work for a basic query without accessing any of the fields. In order to get a fully working implementation we need 2 objects that:
- Can be queried with their total count
- Can be sorted according to the same criteria for consistent collection ordering (ie created_at)

Our original connection PR: #3214

cc @damassi 

