### PR TITLE
feat(FX-3624): Add "sizes" attribute to SearchCriteria and SearchCriteriaAttributes

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -2834,6 +2834,12 @@ type ArtworksAggregationResults {
   slice: ArtworkAggregation
 }
 
+enum ArtworkSizes {
+  LARGE
+  MEDIUM
+  SMALL
+}
+
 enum ArtworkSorts {
   availability_desc
     @deprecated(
@@ -14050,6 +14056,7 @@ type SearchCriteria {
   offerable: Boolean
   partnerIDs: [String!]!
   priceRange: String
+  sizes: [ArtworkSizes]
   userAlertSettings: SavedSearchUserAlertSettings!
   width: String
 }
@@ -14071,6 +14078,7 @@ input SearchCriteriaAttributes {
   offerable: Boolean = null
   partnerIDs: [String!] = []
   priceRange: String = null
+  sizes: [ArtworkSizes] = []
   width: String = null
 }
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11808,6 +11808,7 @@ type SearchCriteria {
   offerable: Boolean
   partnerIDs: [String!]!
   priceRange: String
+  sizes: [ArtworkSizes]
   userAlertSettings: SavedSearchUserAlertSettings!
   width: String
 }
@@ -11829,6 +11830,7 @@ input SearchCriteriaAttributes {
   offerable: Boolean = null
   partnerIDs: [String!] = []
   priceRange: String = null
+  sizes: [ArtworkSizes] = []
   width: String = null
 }
 

--- a/src/data/gravity.graphql
+++ b/src/data/gravity.graphql
@@ -1786,6 +1786,12 @@ type SavedSearchUserAlertSettings {
   push: Boolean!
 }
 
+enum ArtworkSizes {
+  LARGE
+  MEDIUM
+  SMALL
+}
+
 """
 Search criteria
 """
@@ -1808,6 +1814,7 @@ type SearchCriteria {
   priceRange: String
   userAlertSettings: SavedSearchUserAlertSettings!
   width: String
+  sizes: [ArtworkSizes]
 }
 
 """
@@ -1830,6 +1837,7 @@ input SearchCriteriaAttributes {
   partnerIDs: [String!] = []
   priceRange: String = null
   width: String = null
+  sizes: [ArtworkSizes] = []
 }
 
 """

--- a/src/lib/stitching/gravity/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/gravity/__tests__/__snapshots__/schema.test.ts.snap
@@ -128,6 +128,12 @@ type ArtistSeriesEdge {
   node: ArtistSeries
 }
 
+enum ArtworkSizes {
+  LARGE
+  MEDIUM
+  SMALL
+}
+
 # Backup Two-Factor Authentication factor
 type BackupSecondFactor implements SecondFactor {
   code: String!
@@ -873,6 +879,7 @@ type SearchCriteria {
   priceRange: String
   userAlertSettings: SavedSearchUserAlertSettings!
   width: String
+  sizes: [ArtworkSizes]
 }
 
 # Attributes for a search criteria
@@ -893,6 +900,7 @@ input SearchCriteriaAttributes {
   partnerIDs: [String!] = []
   priceRange: String = null
   width: String = null
+  sizes: [ArtworkSizes] = []
 }
 
 # The connection type for SearchCriteria.


### PR DESCRIPTION
[FX-3624]

At the moment, the principle of operation of the Size filter on Force (we can choose several size values) and Eigen (we can choose only one size value) is different and we decided to make the same behavior on the two platforms the same (the user can select multiple filter values). For this reason, we need to add support for the sizes attribute in SearchCriteria, SearchCriteriaAttributes.

[FX-3624]: https://artsyproduct.atlassian.net/browse/FX-3624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ