### PR TITLE
feat: Add artwork_location to artwork

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1349,6 +1349,7 @@ type Artwork implements Node & Searchable & Sellable {
     first: Int
     last: Int
   ): ArtistSeriesConnection
+  artworkLocation: String
 
   # Represents the "**classification**" of an artwork, such as _limited edition_
   attributionClass: AttributionClass
@@ -9143,6 +9144,7 @@ type MyCollectionConnection {
 
 input MyCollectionCreateArtworkInput {
   artistIds: [String]!
+  artworkLocation: String
   category: String
   clientMutationId: String
   costCurrencyCode: String
@@ -9198,6 +9200,7 @@ type MyCollectionInfo {
 input MyCollectionUpdateArtworkInput {
   artistIds: [String]
   artworkId: String!
+  artworkLocation: String
   category: String
   clientMutationId: String
   costCurrencyCode: String

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -133,6 +133,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           }
         },
       },
+      artworkLocation: { type: GraphQLString },
       availability: { type: GraphQLString },
       category: {
         type: GraphQLString,

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -133,7 +133,10 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           }
         },
       },
-      artworkLocation: { type: GraphQLString },
+      artworkLocation: {
+        type: GraphQLString,
+        resolve: (artwork) => artwork.artwork_location,
+      },
       availability: { type: GraphQLString },
       category: {
         type: GraphQLString,

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -9,6 +9,7 @@ const artworkDetails = {
   medium: "Painting",
   price_paid_cents: 10000,
   price_paid_currency: "USD",
+  artwork_location: "Berlin",
 }
 const artworkLoader = jest.fn().mockResolvedValue(artworkDetails)
 
@@ -54,6 +55,7 @@ const computeMutationInput = ({
           ... on MyCollectionArtworkMutationSuccess {
             artwork {
               medium
+              artworkLocation
               pricePaid {
                 display
               }
@@ -126,6 +128,7 @@ describe("myCollectionCreateArtworkMutation", () => {
           pricePaid: {
             display: "$100",
           },
+          artworkLocation: "Berlin",
         },
         artworkEdge: {
           node: {

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -40,7 +40,7 @@ const computeMutationInput = ({
           editionSize: ${JSON.stringify(editionSize)}
           externalImageUrls: ${JSON.stringify(externalImageUrls)}
           height: "20"
-          artwork_location: "Berlin"
+          artworkLocation: "Berlin"
           medium: "Painting"
           metric: "in"
           pricePaidCents: 10000

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -40,6 +40,7 @@ const computeMutationInput = ({
           editionSize: ${JSON.stringify(editionSize)}
           externalImageUrls: ${JSON.stringify(externalImageUrls)}
           height: "20"
+          artwork_location: "Berlin"
           medium: "Painting"
           metric: "in"
           pricePaidCents: 10000

--- a/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
@@ -29,6 +29,7 @@ const defaultArtworkDetails = ({
   metric: "in",
   price_paid_cents: 10000,
   price_paid_currency: "USD",
+  artwork_location: "Berlin",
   provenance: "Pat Hearn Gallery",
   title: "hey now",
   width: "20",
@@ -65,6 +66,7 @@ const computeMutationInput = ({
           height: "20"
           medium: "Updated"
           metric: "in"
+          artworkLocation: "Berlin"
           pricePaidCents: 10000
           pricePaidCurrency: "USD"
           provenance: "Pat Hearn Gallery"
@@ -83,6 +85,7 @@ const computeMutationInput = ({
               editionSize
               height
               medium
+              artworkLocation
               metric
               provenance
               title
@@ -172,6 +175,7 @@ describe("myCollectionUpdateArtworkMutation", () => {
           pricePaid: {
             display: "$100",
           },
+          artworkLocation: "Berlin",
           provenance: "Pat Hearn Gallery",
           title: "hey now",
           width: "20",

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -71,6 +71,9 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
     height: {
       type: GraphQLString,
     },
+    artwork_location: {
+      type: GraphQLString,
+    },
     metric: {
       type: GraphQLString,
     },
@@ -105,6 +108,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
       editionSize,
       editionNumber,
       externalImageUrls = [],
+      artwork_location,
       pricePaidCents,
       pricePaidCurrency,
       ...rest
@@ -131,6 +135,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
         cost_minor: costMinor,
         price_paid_cents: pricePaidCents,
         price_paid_currency: pricePaidCurrency,
+        artwork_artwork_location: artwork_location,
         ...rest,
       })
 

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -71,7 +71,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
     height: {
       type: GraphQLString,
     },
-    artwork_location: {
+    artworkLocation: {
       type: GraphQLString,
     },
     metric: {
@@ -108,7 +108,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
       editionSize,
       editionNumber,
       externalImageUrls = [],
-      artwork_location,
+      artworkLocation,
       pricePaidCents,
       pricePaidCurrency,
       ...rest
@@ -135,7 +135,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
         cost_minor: costMinor,
         price_paid_cents: pricePaidCents,
         price_paid_currency: pricePaidCurrency,
-        artwork_artwork_location: artwork_location,
+        artwork_artwork_location: artworkLocation,
         ...rest,
       })
 

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -135,7 +135,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
         cost_minor: costMinor,
         price_paid_cents: pricePaidCents,
         price_paid_currency: pricePaidCurrency,
-        artwork_artwork_location: artworkLocation,
+        artwork_location: artworkLocation,
         ...rest,
       })
 

--- a/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
@@ -141,7 +141,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
         artists: artistIds,
         cost_currency_code: costCurrencyCode,
         cost_minor: costMinor,
-        artwork_artwork_location: artworkLocation,
+        artwork_location: artworkLocation,
         price_paid_cents: pricePaidCents,
         price_paid_currency: pricePaidCurrency,
         ...rest,

--- a/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
@@ -23,6 +23,7 @@ interface MyCollectionArtworkUpdateMutationInput {
   editionNumber?: string
   editionSize?: string
   externalImageUrls?: [string]
+  artwork_location?: string
   pricePaidCents?: number
   pricePaidCurrency?: string
 }
@@ -71,6 +72,9 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
     height: {
       type: GraphQLString,
     },
+    artwork_location: {
+      type: GraphQLString,
+    },
     medium: {
       type: GraphQLString,
     },
@@ -109,6 +113,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
       editionNumber,
       editionSize,
       externalImageUrls = [],
+      artwork_location,
       pricePaidCents,
       pricePaidCurrency,
       ...rest
@@ -136,6 +141,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
         artists: artistIds,
         cost_currency_code: costCurrencyCode,
         cost_minor: costMinor,
+        artwork_artwork_location: artwork_location,
         price_paid_cents: pricePaidCents,
         price_paid_currency: pricePaidCurrency,
         ...rest,
@@ -158,7 +164,10 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
         const editionSetId = response.edition_sets[0].id
 
         if (isEdition === false) {
-          await deleteArtworkEditionSetLoader({ artworkId, editionSetId })
+          await deleteArtworkEditionSetLoader({
+            artworkId,
+            editionSetId,
+          })
         } else {
           const payload = {
             edition_size: editionSize ? editionSize : null,

--- a/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
@@ -23,7 +23,7 @@ interface MyCollectionArtworkUpdateMutationInput {
   editionNumber?: string
   editionSize?: string
   externalImageUrls?: [string]
-  artwork_location?: string
+  artworkLocation?: string
   pricePaidCents?: number
   pricePaidCurrency?: string
 }
@@ -72,7 +72,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
     height: {
       type: GraphQLString,
     },
-    artwork_location: {
+    artworkLocation: {
       type: GraphQLString,
     },
     medium: {
@@ -113,7 +113,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
       editionNumber,
       editionSize,
       externalImageUrls = [],
-      artwork_location,
+      artworkLocation,
       pricePaidCents,
       pricePaidCurrency,
       ...rest
@@ -141,7 +141,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
         artists: artistIds,
         cost_currency_code: costCurrencyCode,
         cost_minor: costMinor,
-        artwork_artwork_location: artwork_location,
+        artwork_artwork_location: artworkLocation,
         price_paid_cents: pricePaidCents,
         price_paid_currency: pricePaidCurrency,
         ...rest,


### PR DESCRIPTION
Addresses [CX-2218]

## Description

Add artwork_location to artwork

It needs [gravity PR](https://github.com/artsy/gravity/pull/14759) to be deployed first. 

[CX-2218]: https://artsyproduct.atlassian.net/browse/CX-2218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ