### PR TITLE
chore: update @artsy/update-repo package to v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   },
   "devDependencies": {
     "@artsy/express-reloadable": "1.6.0",
-    "@artsy/update-repo": "0.4.0",
+    "@artsy/update-repo": "0.5.0",
     "@babel/cli": "7.14.8",
     "@babel/core": "7.15.0",
     "@babel/node": "7.14.9",

--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -65,7 +65,6 @@ async function main() {
       repo: "eigen",
       body:
         "Greetings human :robot: this PR was automatically created as part of metaphysics' deploy process. #nochangelog",
-      targetBranch: "main",
     })
     await updateSchemaFile({ repo: "force" })
     await updateSchemaFile({

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,10 +38,10 @@
   dependencies:
     dotenv "^10.0.0"
 
-"@artsy/update-repo@0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@artsy/update-repo/-/update-repo-0.4.0.tgz#97a00e5cf4bf847214e75d06336c0fb22a7c59b0"
-  integrity sha512-GHSF/oUdIvNW1SE89NTC3NtohYvLeue/uD7JLsUbbdGBqUfzrtB1kM5JcSzTnr7izTlbiaEtMDmh9YfUvBixVA==
+"@artsy/update-repo@0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@artsy/update-repo/-/update-repo-0.5.0.tgz#9beb3fb574a2e039e8912fde3309a564e3f8270a"
+  integrity sha512-DaKQAfcnUtAH4cQabm7gBJEJFAImESRQBoKaNyiH/z1jX7XL1x81NO6iLVeHX7RQbfQJ7hC+VjF+JHR/kM949g==
   dependencies:
     "@octokit/rest" "^17.2.0"
     kleur "^3.0.3"


### PR DESCRIPTION
https://github.com/artsy/update-repo/releases/tag/v0.5.0

Update the @artsy/update-repo package to address the failing CI step in #3596. Our push-schema-changes step is failing due to recent default branch updates across other repositories to `main`. The recently released @artsy/update-repo version should fix the targetBranch behavior.

cc/ @mc-jones 