### PR TITLE
chore: use Squash on Green label when pushing schema updates to client repos

### DIFF
--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -31,7 +31,7 @@ async function updateSchemaFile({
     commitMessage: "Update metaphysics schema",
     body,
     assignees: ["artsyit"],
-    labels: ["Merge On Green"],
+    labels: ["Squash On Green"],
     update: (repoDir) => {
       const repoDest = path.join(repoDir, dest)
       execSync("yarn config set ignore-engines true", { cwd: repoDir })


### PR DESCRIPTION
Follow up after https://artsy.slack.com/archives/C02BAQ5K7/p1639509813109500.

We tend to prefer a squash-merge to avoid the merge commit these days.