### PR TITLE
fix(mutations): success for unlink auth

### DIFF
--- a/src/lib/apis/fetch.ts
+++ b/src/lib/apis/fetch.ts
@@ -71,7 +71,8 @@ export default (url, options = {}) => {
       }
 
       try {
-        const shouldParse = typeof response.body === "string"
+        const shouldParse =
+          typeof response.body === "string" && response.body !== ""
         const parsed = shouldParse ? JSON.parse(response.body) : response.body
 
         resolve({

--- a/src/schema/v2/me/unlinkAuthenticationMutation.ts
+++ b/src/schema/v2/me/unlinkAuthenticationMutation.ts
@@ -37,7 +37,8 @@ export const unlinkAuthenticationMutation = mutationWithClientMutationId<
     }
 
     try {
-      return await unlinkAuthenticationLoader(provider)
+      await unlinkAuthenticationLoader(provider)
+      return {}
     } catch (err) {
       if ("body" in (err as any)) {
         const e = err as GravityError


### PR DESCRIPTION
So, for whatever reason: https://github.com/artsy/gravity/blob/31ced403829a5b4b4f3618075345a2f5cef0730f/app/api/v1/me_authentications_endpoint.rb#L26 is returning a successful but empty response.

This PR both prevents us from parsing empty string, which is correct. And just returns empty object on the mutation, which is fine since we don't actually use the response, the only output field on this mutation is `me`.