### PR TITLE
fix: update master to main in force schema url

### DIFF
--- a/peril/compareForceSchema.ts
+++ b/peril/compareForceSchema.ts
@@ -7,21 +7,23 @@ import { warn, danger } from "danger"
 // and the current Force one, warn.
 export default async () => {
   const forceSchemaUrl =
-    "https://github.com/artsy/force/raw/master/data/schema.graphql"
+    "https://github.com/artsy/force/raw/main/data/schema.graphql"
 
   const forceSchema = await (await fetch(forceSchemaUrl)).text()
   const repo = danger.github.pr.head.repo.full_name
   const sha = danger.github.pr.head.sha
-  const localSchema = await (await fetch(
-    `https://raw.githubusercontent.com/${repo}/${sha}/_schemaV2.graphql`
-  )).text()
+  const localSchema = await (
+    await fetch(
+      `https://raw.githubusercontent.com/${repo}/${sha}/_schemaV2.graphql`
+    )
+  ).text()
 
   const allChanges = schemaDiff(
     buildSchema(forceSchema),
     buildSchema(localSchema)
   )
-  const breakings = allChanges.filter(c => c.criticality.level === "BREAKING")
-  const messages = breakings.map(c => c.message)
+  const breakings = allChanges.filter((c) => c.criticality.level === "BREAKING")
+  const messages = breakings.map((c) => c.message)
   if (messages.length) {
     warn(
       `The V2 schema in this PR has breaking changes with Force. Remember to update the Force schema if necessary.


### PR DESCRIPTION
Updating the branch reference from `master` to `main` in `ForceSchemaUrl` after the [adoption of inclusive language](https://github.com/artsy/force/pull/9041). 

This should resolve an issue that surfaced in #3618, due to Peril not being able to fetch the GraphQL schema as https://github.com/artsy/force/raw/master/data/schema.graphql 404s. Per [GitHub docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch), “Although file URLs are automatically redirected, raw file URLs are not redirected”
