### PR TITLE
feat(artwork): exposes downloadableImageUrl

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1397,6 +1397,7 @@ type Artwork implements Node & Searchable & Sellable {
 
   # Domestic shipping fee.
   domesticShippingFee: Money
+  downloadableImageUrl: String
   editionNumber: String
   editionOf: String
   editionSet(id: String!): EditionSet

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -59,6 +59,7 @@ import { getMicrofunnelDataByArtworkInternalID } from "../artist/targetSupply/ut
 import { InquiryQuestionType } from "../inquiry_question"
 import { priceDisplayText, priceRangeDisplayText } from "lib/moneyHelpers"
 import { LocationType } from "schema/v2/location"
+import config from "config"
 
 const has_price_range = (price) => {
   return new RegExp(/-/).test(price)
@@ -447,6 +448,19 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       displayPriceRange: {
         type: GraphQLBoolean,
         resolve: ({ display_price_range }) => display_price_range,
+      },
+      downloadableImageUrl: {
+        type: GraphQLString,
+        resolve: ({ id, images }) => {
+          if (!images || !images.length) return null
+
+          const defaultImage =
+            images.find((image) => image.is_default) || images[0]
+
+          if (!defaultImage) return null
+
+          return `${config.GRAVITY_API_BASE}/artwork/${id}/image/${defaultImage.id}/original.jpg`
+        },
       },
       isBuyNowable: {
         type: GraphQLBoolean,


### PR DESCRIPTION
So: 

Downloadable images for admins are currently broken in Force.

Previously we were constructing this URL with some methods on the old Backbone models and then proxying the download. I don't really see a reason though why we can't just conditionally display this URL directly on the client-side — this will redirect. Let me know if I'm missing something obvious. This endpoint will redirect to the S3 asset with a `X-Amz-Expires=43200` query param.