### PR TITLE
feature: Remove Bluebird

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 import "moment-timezone"
-import Bluebird from "bluebird"
 import xapp from "@artsy/xapp"
 import compression from "compression"
 import forceSSL from "express-force-ssl"
@@ -22,8 +21,6 @@ const {
   PORT,
   PRODUCTION_ENV,
 } = config
-
-global.Promise = Bluebird
 
 const port = PORT
 const isDevelopment = NODE_ENV === "development"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "apollo-link-http": "1.5.4",
     "apollo-server-express": "2.4.8",
     "basic-auth": "1.1.0",
-    "bluebird": "3.5.1",
     "body-parser": "1.18.2",
     "chalk": "^4.1.2",
     "compression": "1.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2846,11 +2846,6 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
 
-bluebird@3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
-  integrity sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==
-
 body-parser@1.18.2:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.2.tgz#87678a19d84b47d859b83199bd59bce222b10454"


### PR DESCRIPTION
Drop Bluebird in favor of Node.js native promises the native performance is now 
better than Bluebird.