### PR TITLE
feat: bring back sorting for submissions

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -6695,6 +6695,12 @@ enum ConsignmentSubmissionSort {
   # sort by reminders_sent_count in descending order
   REMINDERS_SENT_COUNT_DESC
 
+  # sort by session_id in ascending order
+  SESSION_ID_ASC
+
+  # sort by session_id in descending order
+  SESSION_ID_DESC
+
   # sort by signature in ascending order
   SIGNATURE_ASC
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5294,6 +5294,12 @@ enum ConsignmentSubmissionSort {
   # sort by reminders_sent_count in descending order
   REMINDERS_SENT_COUNT_DESC
 
+  # sort by session_id in ascending order
+  SESSION_ID_ASC
+
+  # sort by session_id in descending order
+  SESSION_ID_DESC
+
   # sort by signature in ascending order
   SIGNATURE_ASC
 

--- a/src/data/convection.graphql
+++ b/src/data/convection.graphql
@@ -1868,6 +1868,16 @@ enum SubmissionSort {
   REMINDERS_SENT_COUNT_DESC
 
   """
+  sort by session_id in ascending order
+  """
+  SESSION_ID_ASC
+
+  """
+  sort by session_id in descending order
+  """
+  SESSION_ID_DESC
+
+  """
   sort by signature in ascending order
   """
   SIGNATURE_ASC


### PR DESCRIPTION
### Description 

In a [previous PR](https://github.com/artsy/metaphysics/pull/3628/files), session ID sorting was changed by the auto-schema update. However, running a schema synch in Convection creates the diff with session ID sorting. 

This PR simply brings back the session Id as a sorting param. 

Note that: the actual changes (for removeAsset mutation) has already been merged in the above PR in metaphysics. 