### PR TITLE
Revert "feat(PX-4058): partner transition part 3"

### DIFF
--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -523,10 +523,10 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       },
       href: {
         type: GraphQLString,
-        resolve: ({ type, default_profile_id, id }) =>
+        resolve: ({ type, default_profile_id }) =>
           type === "Auction"
             ? `/auction/${default_profile_id}`
-            : `/partner/${id}`,
+            : `/${default_profile_id}`,
       },
       initials: initials("name"),
       isDefaultProfilePublic: {


### PR DESCRIPTION
Reverts artsy/metaphysics#3193

Reverting this because there are a few places in force that are incorrectly already adding a /partner at the front of the URL. Will update those and then re-merge this in!