### PR TITLE
Revert "Revert "feat(PX-4058): partner transition part 3""

### DIFF
--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -523,10 +523,10 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       },
       href: {
         type: GraphQLString,
-        resolve: ({ type, default_profile_id }) =>
+        resolve: ({ type, default_profile_id, id }) =>
           type === "Auction"
             ? `/auction/${default_profile_id}`
-            : `/${default_profile_id}`,
+            : `/partner/${id}`,
       },
       initials: initials("name"),
       isDefaultProfilePublic: {


### PR DESCRIPTION
Reverts artsy/metaphysics#3641

A double-revert!

This gets us back to the original state, and effectively re-merges in [this PR](https://github.com/artsy/metaphysics/pull/3193). The end-result is that metaphysics will serve our new URL-style `/partner/:partner_slug` for the partner `href` field. We updated the URL from `/:profile_id` -> `/partner/:partner_slug` back when we rebuilt the partner profile page. This is one of the lingering changes from that effort.

The first revert was because we noticed a few broken links on the homepage. [This PR](https://github.com/artsy/force/pull/9137) has fixed those, so now we're good to merge in this change!