### PR TITLE
feat(TX-148): relax vat requirements and add exempt approval flag

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1574,8 +1574,8 @@ type Artwork implements Node & Searchable & Sellable {
   # Whether this artwork is unlisted or not
   unlisted: Boolean
 
-  # Based on artwork location and status, verify that VAT exempt partners are approved.
-  vatExemptApprovalComplete: Boolean
+  # Based on artwork location and status, verify that partner needs VAT exemption approval from Artsy.
+  vatExemptApprovalRequired: Boolean
 
   # Based on artwork location verify that VAT info for the partner is complete.
   vatRequirementComplete: Boolean

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1574,6 +1574,9 @@ type Artwork implements Node & Searchable & Sellable {
   # Whether this artwork is unlisted or not
   unlisted: Boolean
 
+  # Based on artwork location and status, verify that VAT exempt partners are approved.
+  vatExemptApprovalComplete: Boolean
+
   # Based on artwork location verify that VAT info for the partner is complete.
   vatRequirementComplete: Boolean
 

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -2451,6 +2451,103 @@ describe("Artwork type", () => {
     })
   })
 
+  describe("#vatExemptApprovalRequired", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          vatExemptApprovalRequired
+        }
+      }
+    `
+
+    it("returns null when vat_required is not present", () => {
+      delete artwork.vat_required
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({ artwork: { vatExemptApprovalRequired: null } })
+      })
+    })
+
+    it("returns null when partner is empty", () => {
+      artwork.vat_required = false
+      artwork.partner = null
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({ artwork: { vatExemptApprovalRequired: null } })
+      })
+    })
+
+    it("returns null when partnerAllLoader is not present", () => {
+      artwork.vat_required = false
+      artwork.partner = { id: "123" }
+      delete context.partnerAllLoader
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({ artwork: { vatExemptApprovalRequired: null } })
+      })
+    })
+
+    it("returns false when artwork does not require vat", () => {
+      artwork.vat_required = false
+      artwork.partner = { id: "123" }
+      context.partnerAllLoader = jest.fn(() => Promise.resolve({}))
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({ artwork: { vatExemptApprovalRequired: false } })
+        expect(context.partnerAllLoader).not.toHaveBeenCalled()
+      })
+    })
+
+    it("returns false when artwork requires VAT and partner has the VAT status 'registered'", () => {
+      artwork.vat_required = true
+      artwork.partner = { id: "123" }
+      context.partnerAllLoader = jest.fn(() =>
+        Promise.resolve({ vat_status: "registered" })
+      )
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({ artwork: { vatExemptApprovalRequired: false } })
+        expect(context.partnerAllLoader).toHaveBeenCalledWith("123")
+      })
+    })
+
+    it("returns false when artwork requires VAT and partner does not have a VAT status", () => {
+      artwork.vat_required = true
+      artwork.partner = { id: "123" }
+      context.partnerAllLoader = jest.fn(() =>
+        Promise.resolve({ vat_status: null })
+      )
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({ artwork: { vatExemptApprovalRequired: false } })
+        expect(context.partnerAllLoader).toHaveBeenCalledWith("123")
+      })
+    })
+
+    it("returns true when artwork requires VAT, partner has an exempt VAT status, and has not been approved by Artsy", () => {
+      artwork.vat_required = true
+      artwork.partner = { id: "123" }
+      context.partnerAllLoader = jest.fn(() =>
+        Promise.resolve({ vat_status: "exempt", vat_exempt_approved: false })
+      )
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({ artwork: { vatExemptApprovalRequired: true } })
+        expect(context.partnerAllLoader).toHaveBeenCalledWith("123")
+      })
+    })
+
+    it("returns false when artwork requires VAT, partner has an exempt VAT status, and has been approved by Artsy", () => {
+      artwork.vat_required = true
+      artwork.partner = { id: "123" }
+      context.partnerAllLoader = jest.fn(() =>
+        Promise.resolve({ vat_status: "exempt", vat_exempt_approved: true })
+      )
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({ artwork: { vatExemptApprovalRequired: false } })
+        expect(context.partnerAllLoader).toHaveBeenCalledWith("123")
+      })
+    })
+  })
+
   describe("#euShippingOrigin", () => {
     const query = `
       {

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -2424,11 +2424,11 @@ describe("Artwork type", () => {
       })
     })
 
-    it("returns true when artwork requires vat and partner is vat registered", () => {
+    it("returns true when artwork requires VAT and partner has any VAT status", () => {
       artwork.vat_required = true
       artwork.partner = { id: "123" }
       context.partnerAllLoader = jest.fn(() =>
-        Promise.resolve({ vat_registered: true })
+        Promise.resolve({ vat_status: "anything" })
       )
 
       return runQuery(query, context).then((data) => {
@@ -2437,11 +2437,11 @@ describe("Artwork type", () => {
       })
     })
 
-    it("returns false when artwork requires vat and partner is not vat registered", () => {
+    it("returns false when artwork requires VAT and partner does not have a VAT status", () => {
       artwork.vat_required = true
       artwork.partner = { id: "123" }
       context.partnerAllLoader = jest.fn(() =>
-        Promise.resolve({ vat_registered: false })
+        Promise.resolve({ vat_status: null })
       )
 
       return runQuery(query, context).then((data) => {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -836,9 +836,32 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
 
           if (!vat_required) return true
 
-          const { vat_registered } = await partnerAllLoader(partner.id)
+          const { vat_status } = await partnerAllLoader(partner.id)
 
-          return vat_registered
+          return !!vat_status
+        },
+      },
+      vatExemptApprovalComplete: {
+        type: GraphQLBoolean,
+        description:
+          "Based on artwork location and status, verify that VAT exempt partners are approved.",
+        resolve: async (
+          { vat_required, partner },
+          {},
+          { partnerAllLoader }
+        ) => {
+          if (vat_required == null || _.isEmpty(partner) || !partnerAllLoader)
+            return null
+
+          if (!vat_required) return true
+
+          const { vat_status, vat_exempt_approved } = await partnerAllLoader(
+            partner.id
+          )
+
+          if (vat_status === "registered") return true
+
+          return vat_exempt_approved
         },
       },
       pricePaid: {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -841,10 +841,10 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           return !!vat_status
         },
       },
-      vatExemptApprovalComplete: {
+      vatExemptApprovalRequired: {
         type: GraphQLBoolean,
         description:
-          "Based on artwork location and status, verify that VAT exempt partners are approved.",
+          "Based on artwork location and status, verify that partner needs VAT exemption approval from Artsy.",
         resolve: async (
           { vat_required, partner },
           {},
@@ -853,15 +853,15 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           if (vat_required == null || _.isEmpty(partner) || !partnerAllLoader)
             return null
 
-          if (!vat_required) return true
+          if (!vat_required) return false
 
           const { vat_status, vat_exempt_approved } = await partnerAllLoader(
             partner.id
           )
 
-          if (vat_status === "registered") return true
+          if (vat_status == null || vat_status === "registered") return false
 
-          return vat_exempt_approved
+          return !vat_exempt_approved
         },
       },
       pricePaid: {


### PR DESCRIPTION
[TX-148](https://artsyproduct.atlassian.net/browse/TX-148)

We want to enable BNMO (including Make Offer in Inquiries) for artworks located in relevant countries as long as partners have provided a VAT status (and necessary exemption documentation for us to review), regardless of the selected status.

With this, clients (i.e. Volt) will not block taking actions on MOI orders as long as there is a VAT status set.

Currently, VAT-exempted partners cannot take actions (e.g. accepting) on MOI orders in CMS. This PR will add a new flag to enable it once the partner’s VAT exempt status has been approved by Artsy. 