### PR TITLE
feat(artist dupes): expose new sorts and fields for artists

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1361,6 +1361,8 @@ type ArtistSeriesEdge {
 }
 
 enum ArtistSorts {
+  CREATED_AT_ASC
+  CREATED_AT_DESC
   SORTABLE_ID_ASC
   SORTABLE_ID_DESC
   TRENDING_DESC

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -906,6 +906,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   deathday: String
   disablePriceContext: Boolean
   displayLabel: String
+  duplicates: [Artist]
 
   # Custom-sorted list of shows for an artist, in order of significance.
   exhibitionHighlights(
@@ -1121,6 +1122,7 @@ type ArtistCounts {
     label: String
   ): FormattedNumber
   auctionResults: Int
+  duplicates: Int
   ecommerceArtworks(
     # Returns a `String` when format is specified. e.g.`'0,0.0000''`
     format: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -894,6 +894,14 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     size: Int
   ): [Artist]
   counts: ArtistCounts
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See
+    # http://www.iana.org/time-zones,
+    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
   currentEvent: CurrentEvent
   deathday: String
   disablePriceContext: Boolean

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -17,6 +17,11 @@ export default (accessToken, userID, opts) => {
     identityVerificationLoader: gravityLoader(
       (id) => `identity_verification/${id}`
     ),
+    artistDuplicatesLoader: gravityLoader(
+      (id) => `artist/${id}/duplicates`,
+      {},
+      { headers: true }
+    ),
     artworkLoader: gravityLoader((id) => `artwork/${id}`),
     authenticatedArtworkVersionLoader: gravityLoader(
       (id) => `artwork_version/${id}`

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -59,6 +59,7 @@ import { ResolverContext } from "types/graphql"
 import ArtworkSizes from "../artwork/artworkSizes"
 import { ArtistTargetSupply } from "./targetSupply"
 import { PartnerType } from "../partner"
+import { date } from "schema/v2/fields/date"
 
 // Manually curated list of artist id's who has verified auction lots that can be
 // returned, when queried for via `recordsTrusted: true`.
@@ -500,6 +501,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
         }),
         resolve: (artist) => artist,
       },
+      createdAt: date(),
       currentEvent: CurrentEvent,
       deathday: { type: GraphQLString },
       disablePriceContext: {

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -497,6 +497,18 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
                   return total_count
                 }),
             },
+            duplicates: {
+              type: GraphQLInt,
+              resolve: async ({ id }, _args, { artistDuplicatesLoader }) => {
+                if (!artistDuplicatesLoader) {
+                  throw new Error(
+                    "You need to be signed in to perform this action"
+                  )
+                }
+                const { headers } = await artistDuplicatesLoader(id)
+                return headers["x-total-count"] || 0
+              },
+            },
           },
         }),
         resolve: (artist) => artist,
@@ -671,6 +683,15 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
         },
         resolve: ({ id }, options, { partnerArtistsForArtistLoader }) =>
           partnerArtistsForArtistLoader(id, options),
+      },
+      duplicates: {
+        type: new GraphQLList(Artist.type),
+        resolve: ({ id }, _args, { artistDuplicatesLoader }, _info) => {
+          if (!artistDuplicatesLoader) {
+            throw new Error("You need to be signed in to perform this action")
+          }
+          return artistDuplicatesLoader(id).then(({ body: dupes }) => dupes)
+        },
       },
       related: Related,
       sales: {

--- a/src/schema/v2/sorts/artist_sorts.ts
+++ b/src/schema/v2/sorts/artist_sorts.ts
@@ -1,6 +1,12 @@
 import { GraphQLEnumType } from "graphql"
 
 export const ARTIST_SORTS = {
+  CREATED_AT_ASC: {
+    value: "created_at",
+  },
+  CREATED_AT_DESC: {
+    value: "-created_at",
+  },
   SORTABLE_ID_ASC: {
     value: "sortable_id",
   },


### PR DESCRIPTION
See: [Hackathon card](https://www.notion.so/artsy/37f51b29fb994928bcacd49b17d0ac78?v=20814d7262fe45f4afc46905aa6a6b90&p=3b9274b7b69c4ff789776e765b2403dd)

Follow-up to https://github.com/artsy/gravity/pull/14840, whose new features are served up here:

- exposes the `CREATED_AT_DESC` and `CREATED_AT_ASC` sorts on `artistsConnection`
- exposes the `createdAt` field on the `Artist` type
- exposes the `duplicates` field on the `Artist` type (authenticated users only)