### PR TITLE
refactor: make CollectorProfile#privacy String

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2733,7 +2733,7 @@ type CollectorProfileType {
     timezone: String
   ): String
   name: String
-  privacy: Int
+  privacy: String
   professionalBuyerAppliedAt(
     format: String
 
@@ -8851,7 +8851,7 @@ type Me implements Node {
   priceRange: String
   priceRangeMax: Float
   priceRangeMin: Float
-  privacy: Int
+  privacy: String
   profession: String
 
   # This user should receive lot opening notifications
@@ -13030,7 +13030,7 @@ type UpdateCollectorProfilePayload {
     timezone: String
   ): String
   name: String
-  privacy: Int
+  privacy: String
   professionalBuyerAppliedAt(
     format: String
 
@@ -13132,7 +13132,7 @@ input UpdateMyProfileInput {
   priceRangeMin: Int
 
   # Wheter or not the collector shares detailed profile information with galleries.
-  privacy: Int
+  privacy: String
 
   # Profession.
   profession: String

--- a/src/schema/v2/me/__tests__/collector_profile.test.js
+++ b/src/schema/v2/me/__tests__/collector_profile.test.js
@@ -25,7 +25,7 @@ describe("Me", () => {
         email: "percy@cat.com",
         self_reported_purchases: "treats",
         intents: ["buy art & design"],
-        privacy: 1,
+        privacy: "public",
       }
 
       const expectedProfileData = {
@@ -34,7 +34,7 @@ describe("Me", () => {
         email: "percy@cat.com",
         selfReportedPurchases: "treats",
         intents: ["buy art & design"],
-        privacy: 1,
+        privacy: "public",
       }
 
       const context = {

--- a/src/schema/v2/me/__tests__/update_me_mutation.test.js
+++ b/src/schema/v2/me/__tests__/update_me_mutation.test.js
@@ -16,7 +16,7 @@ describe("UpdateMeMutation", () => {
             phone: "1234890"
             priceRangeMax: 1000000000000
             priceRangeMin: -1
-            privacy: 1
+            privacy: "public"
             profession: "Juggler"
             receiveLotOpeningSoonNotification: false
             receiveNewSalesNotification: false
@@ -118,7 +118,7 @@ describe("UpdateMeMutation", () => {
       phone: "1234890",
       price_range_max: 1000000000000,
       price_range_min: -1,
-      privacy: 1,
+      privacy: "public",
       profession: "Juggler",
       receive_lot_opening_soon_notification: false,
       receive_new_sales_notification: false,
@@ -147,7 +147,7 @@ describe("UpdateMeMutation", () => {
             collectorLevel: 1
             bio: "A very long story"
             iconUrl: "https://gggg.notS3.com/thekey"
-            privacy: 1
+            privacy: "public"
           }
         ) {
           user {
@@ -214,7 +214,7 @@ describe("UpdateMeMutation", () => {
       client_mutation_id: "1232",
       collector_level: 1,
       bio: "A very long story",
-      privacy: 1,
+      privacy: "public",
     })
 
     expect(mockUpdateCollectorProfileIconLoader).not.toHaveBeenCalled()

--- a/src/schema/v2/me/collector_profile.ts
+++ b/src/schema/v2/me/collector_profile.ts
@@ -30,7 +30,7 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
   intents: { type: new GraphQLList(GraphQLString) },
   loyaltyApplicantAt: date,
   name: { type: GraphQLString },
-  privacy: { type: GraphQLInt },
+  privacy: { type: GraphQLString },
   professionalBuyerAppliedAt: date,
   professionalBuyerAt: date,
   selfReportedPurchases: {

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -217,7 +217,7 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLFloat,
       resolve: ({ price_range }) => price_range?.split(":")[1],
     },
-    privacy: { type: GraphQLInt },
+    privacy: { type: GraphQLString },
     profession: {
       type: GraphQLString,
     },

--- a/src/schema/v2/me/update_me_mutation.ts
+++ b/src/schema/v2/me/update_me_mutation.ts
@@ -155,7 +155,7 @@ export default mutationWithClientMutationId<any, any, ResolverContext>({
     privacy: {
       description:
         "Wheter or not the collector shares detailed profile information with galleries.",
-      type: GraphQLInt,
+      type: GraphQLString,
     },
     profession: { type: GraphQLString, description: "Profession." },
     receiveLotOpeningSoonNotification: {


### PR DESCRIPTION
Relates to #3640

After some discussion, we decided to have the privacy field as String in Gravity, so we needed to reflect the changes here as well.

See https://github.com/artsy/gravity/pull/14815 for more context.