### PR TITLE
fix: Set excludePurchasedArtworks to false

### DIFF
--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -98,7 +98,7 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
     },
     excludePurchasedArtworks: {
       type: GraphQLBoolean,
-      defaultValue: true,
+      defaultValue: false,
       description:
         "Exclude artworks that have been purchased on Artsy and automatically added to the collection.",
     },


### PR DESCRIPTION
Addresses [CX-2269]

## Description

There is no need anymore to exclude purchased artworks from "My Collection". Therefore we can default `excludePurchasedArtworks` to false so clients don't have to send the param anymore.

Relates to https://github.com/artsy/eigen/pull/6036

[CX-2269]: https://artsyproduct.atlassian.net/browse/CX-2269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ