### PR TITLE
fix(article): filters out unpublished artworks

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8909,6 +8909,9 @@ type Me implements Node {
     sort: CommerceOrderConnectionSortEnum
     states: [CommerceOrderStateEnum!]
   ): CommerceOrderConnectionWithTotalCount
+
+  # Collector's position with relevant institutions
+  otherRelevantPosition: String
   paddleNumber: String
 
   # A list of the current user’s managed partners
@@ -13188,6 +13191,9 @@ input UpdateMyProfileInput {
 
   # Additional personal notes.
   notes: String
+
+  # Collector's position with relevant institutions
+  otherRelevantPosition: String
 
   # The user's password, required to change email address.
   password: String

--- a/src/schema/v2/article/sections/ArticleSectionImageCollection.ts
+++ b/src/schema/v2/article/sections/ArticleSectionImageCollection.ts
@@ -52,12 +52,14 @@ export const ArticleSectionImageCollection = new GraphQLObjectType<
         return Promise.all(
           section.images.map((image) => {
             if (image.type === "artwork") {
-              return artworkLoader(image.slug)
+              // Articles may have unpublished artworks
+              return artworkLoader(image.slug).catch(() => null)
             }
 
             return Promise.resolve(image)
           })
-        )
+          // Filter out any null (unpublished) figures
+        ).then((figures) => figures.filter(Boolean))
       },
     },
   }),

--- a/src/schema/v2/article/sections/ArticleSectionImageSet.ts
+++ b/src/schema/v2/article/sections/ArticleSectionImageSet.ts
@@ -55,7 +55,7 @@ export const ArticleSectionImageSet = new GraphQLObjectType<
           const figure = images[0]
 
           if (figure.type === "artwork") {
-            return artworkLoader(figure.slug)
+            return artworkLoader(figure.slug).catch(() => null)
           }
         },
       },
@@ -67,12 +67,14 @@ export const ArticleSectionImageSet = new GraphQLObjectType<
           return Promise.all(
             section.images.map((figure) => {
               if (figure.type === "artwork") {
-                return artworkLoader(figure.slug)
+                // Articles may have unpublished artworks
+                return artworkLoader(figure.slug).catch(() => null)
               }
 
               return Promise.resolve(figure)
             })
-          )
+            // Filter out any null (unpublished) figures
+          ).then((figures) => figures.filter(Boolean))
         },
       },
       counts: {


### PR DESCRIPTION
So articles may have unpublished works and since we are loading the actual artwork now we need to catch and filter them out.