### PR TITLE
fix: minor bugs in [still unused] hybrid conversation/order event connection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5958,7 +5958,6 @@ type ConversationOfferSubmitted implements Node {
   id: ID!
   isCounter: Boolean
   offerAmountChanged: Boolean
-  respondsTo: ConversationOfferSubmitted
 }
 
 # A conversation order state change

--- a/src/schema/v2/fields/hybridConnection/hybridConnectionFromArraySlice.ts
+++ b/src/schema/v2/fields/hybridConnection/hybridConnectionFromArraySlice.ts
@@ -55,6 +55,7 @@ export function hybridConnectionFromArraySlice<
   const lastEdge = edges[edges.length - 1]
 
   const result = {
+    totalCount,
     edges,
     pageInfo: {
       startCursor: firstEdge?.cursor ?? null,

--- a/src/schema/v2/me/conversation/eventConnection/orderEvents.ts
+++ b/src/schema/v2/me/conversation/eventConnection/orderEvents.ts
@@ -24,26 +24,24 @@ export const fetchOrderEventsForPagination = (
   userID: string,
   exchangeGraphQLLoader: any
 ): FetcherForLimitAndOffset<ReturnedNodeShape> => async ({
-  limit,
-  offset,
-  sort,
+  // We don't care about these because we return the entire collection and let
+  // the fetchHybridConnection worry about coalating and handling the result
+  limit: _limit,
+  offset: _offset,
+  sort: _sort,
 }) => {
   const orderEvents: Array<any> = await fetchOrderEvents(conversationId, {
     exchangeGraphQLLoader,
     userID,
   })
-  const sortedNodes = orderEvents.sort((event) => {
-    const date: number = Date.parse(event.createdAt)
-
-    return sort === "DESC" ? -date : date
-  })
 
   return {
-    totalCount: sortedNodes.length,
-    nodes: sortedNodes.slice(offset, limit + offset),
+    totalCount: orderEvents.length,
+    nodes: orderEvents,
   }
 }
 
+// TODO: implement this in exchange instead of making it up.
 const fakeEventId = (prefix, index, orderIndex) =>
   `${prefix}-event-${index}-${orderIndex}`
 

--- a/src/schema/v2/me/conversation/eventConnection/orderEvents.ts
+++ b/src/schema/v2/me/conversation/eventConnection/orderEvents.ts
@@ -30,20 +30,23 @@ export const fetchOrderEventsForPagination = (
   offset: _offset,
   sort: _sort,
 }) => {
-  const orderEvents: Array<any> = await fetchOrderEvents(conversationId, {
+  const orderEvents = await fetchOrderEvents(conversationId, {
     exchangeGraphQLLoader,
     userID,
   })
+
+  if (!orderEvents) {
+    return {
+      totalCount: 0,
+      nodes: [],
+    }
+  }
 
   return {
     totalCount: orderEvents.length,
     nodes: orderEvents,
   }
 }
-
-// TODO: implement this in exchange instead of making it up.
-const fakeEventId = (prefix, index, orderIndex) =>
-  `${prefix}-event-${index}-${orderIndex}`
 
 /**
  * fetch all order events for a conversation from exchange
@@ -57,7 +60,7 @@ const fetchOrderEvents = async (
   }: { exchangeGraphQLLoader: any; userID: string },
   // from args - presence of sellerId overrides buyer mode
   sellerId?: string
-) => {
+): Promise<Array<any> | null> => {
   if (!exchangeGraphQLLoader) return null
   // this id key depends on whether the requester the buyer or seller
   const viewerKey = sellerId
@@ -87,7 +90,7 @@ const fetchOrderEvents = async (
                     definesTotal
                     offerAmountChanged
                     respondsTo {
-                      fromParticipant
+                      id
                     }
                   }
                 }
@@ -100,11 +103,21 @@ const fetchOrderEvents = async (
       conversationId: String(conversationId),
     },
   })
-  const orderEvents = exchangeData.orders.nodes.flatMap((node, orderIndex) =>
-    node.orderHistory.map((event, index) => {
-      return { ...event, id: fakeEventId(conversationId, index, orderIndex) }
-    })
-  )
+  // Extract events and sort them descending from latest
+  const orderEvents: Array<any> =
+    exchangeData.orders.nodes
+      .flatMap((node) => node.orderHistory.map((event) => event))
+      .sort((e1, e2) => Date.parse(e2.createdAt) - Date.parse(e1.createdAt)) ||
+    []
+
+  // apply a synthetic id (for the relay node interface) to each event,
+  // working back to earliest. This is to guarantee the id
+  // will be as stable as possible as new events are added to the collection
+  const count = orderEvents.length
+  orderEvents.forEach((event, index) => {
+    event["id"] = `fake-id-${conversationId}-${count - index}`
+  })
+
   return orderEvents
 }
 
@@ -138,10 +151,6 @@ const ConversationOfferSubmittedEventType = new GraphQLObjectType<
     offerAmountChanged: {
       type: GraphQLBoolean,
       resolve: ({ offer }) => Boolean(offer.offerAmountChanged),
-    },
-    respondsTo: {
-      type: ConversationOfferSubmittedEventType,
-      resolve: ({ offer }) => offer.respondsTo,
     },
   }),
 })


### PR DESCRIPTION
This is a PR to fix some bugs I discovered with @lilyfromseattle during implementation of this new hybrid relay connection in force. So far we've identified:
- a nasty bug due to a bad sorting method which led to us not giving the correct subset of order events on long conversations
- totalCount was missing in the result
- bad typing on our `offerEvent.offer.respondsTo` object - this wasn't needed since we only have to determine whether it is present for the `isCounter` property. **This is a breaking change to our schema, but the field has never been used in production.**

This has been really difficult to test in development, so we aren't yet 100% certain the current changes are enough to render conversations.