### PR TITLE
fix: disambiguate currency symbols

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2593,6 +2593,7 @@ type BidderPositionMaxBid {
   # A formatted price with various currency formatting options.
   amount(
     decimal: String = "."
+    disambiguate: Boolean = false
 
     # Allows control of symbol position (%v = value, %s = symbol)
     format: String = "%s%v"
@@ -2624,6 +2625,7 @@ type BidderPositionSuggestedNextBid {
   # A formatted price with various currency formatting options.
   amount(
     decimal: String = "."
+    disambiguate: Boolean = false
 
     # Allows control of symbol position (%v = value, %s = symbol)
     format: String = "%s%v"
@@ -2658,6 +2660,7 @@ type BuyersPremium {
   # A formatted price with various currency formatting options.
   amount(
     decimal: String = "."
+    disambiguate: Boolean = false
 
     # Allows control of symbol position (%v = value, %s = symbol)
     format: String = "%s%v"
@@ -7825,6 +7828,7 @@ type HighestBid {
   # A formatted price with various currency formatting options.
   amount(
     decimal: String = "."
+    disambiguate: Boolean = false
 
     # Allows control of symbol position (%v = value, %s = symbol)
     format: String = "%s%v"
@@ -8277,6 +8281,7 @@ type Invoice implements Node {
   # A formatted price with various currency formatting options.
   total(
     decimal: String = "."
+    disambiguate: Boolean = false
 
     # Allows control of symbol position (%v = value, %s = symbol)
     format: String = "%s%v"
@@ -11850,6 +11855,7 @@ type SaleArtworkCurrentBid {
   # A formatted price with various currency formatting options.
   amount(
     decimal: String = "."
+    disambiguate: Boolean = false
 
     # Allows control of symbol position (%v = value, %s = symbol)
     format: String = "%s%v"
@@ -11878,6 +11884,7 @@ type SaleArtworkHighestBid {
   # A formatted price with various currency formatting options.
   amount(
     decimal: String = "."
+    disambiguate: Boolean = false
 
     # Allows control of symbol position (%v = value, %s = symbol)
     format: String = "%s%v"
@@ -11902,6 +11909,7 @@ type SaleArtworkHighEstimate {
   # A formatted price with various currency formatting options.
   amount(
     decimal: String = "."
+    disambiguate: Boolean = false
 
     # Allows control of symbol position (%v = value, %s = symbol)
     format: String = "%s%v"
@@ -11921,6 +11929,7 @@ type SaleArtworkLowEstimate {
   # A formatted price with various currency formatting options.
   amount(
     decimal: String = "."
+    disambiguate: Boolean = false
 
     # Allows control of symbol position (%v = value, %s = symbol)
     format: String = "%s%v"
@@ -11940,6 +11949,7 @@ type SaleArtworkMinimumNextBid {
   # A formatted price with various currency formatting options.
   amount(
     decimal: String = "."
+    disambiguate: Boolean = false
 
     # Allows control of symbol position (%v = value, %s = symbol)
     format: String = "%s%v"
@@ -11959,6 +11969,7 @@ type SaleArtworkOpeningBid {
   # A formatted price with various currency formatting options.
   amount(
     decimal: String = "."
+    disambiguate: Boolean = false
 
     # Allows control of symbol position (%v = value, %s = symbol)
     format: String = "%s%v"
@@ -11978,6 +11989,7 @@ type SaleArtworkReserve {
   # A formatted price with various currency formatting options.
   amount(
     decimal: String = "."
+    disambiguate: Boolean = false
 
     # Allows control of symbol position (%v = value, %s = symbol)
     format: String = "%s%v"

--- a/src/schema/v2/fields/__tests__/money.test.ts
+++ b/src/schema/v2/fields/__tests__/money.test.ts
@@ -62,7 +62,7 @@ describe("amount", () => {
         obj: { symbol: "$", currencyCode: "GBP" },
         args: {},
       })
-    ).toMatchInlineSnapshot(`"$12.34"`)
+    ).toMatchInlineSnapshot(`"£12.34"`)
   })
 
   it("prefers argument symbol over currencyCode", () => {
@@ -70,13 +70,30 @@ describe("amount", () => {
       getResult({
         obj: { symbol: "£", currencyCode: "GBP" },
       })
-    ).toMatchInlineSnapshot(`"$12.34"`)
+    ).toMatchInlineSnapshot(`"£12.34"`)
   })
 
   it("doesn't break when it can't find a currencyCode", () => {
     expect(getResult({ obj: { currencyCode: "BLAH" } })).toMatchInlineSnapshot(
       `"$12.34"`
     )
+  })
+
+  it("returns disambiguate symbol over symbol when optional param passed", () => {
+    expect(
+      getResult({
+        obj: { currencyCode: "USD", symbol: "$" },
+        args: { disambiguate: true },
+      })
+    ).toMatchInlineSnapshot(`"US$12.34"`)
+  })
+
+  it("returns symbol over disambiguate symbol by default", () => {
+    expect(
+      getResult({
+        obj: { currencyCode: "USD", symbol: "$" },
+      })
+    ).toMatchInlineSnapshot(`"$12.34"`)
   })
 })
 


### PR DESCRIPTION
This PR introduces an optional parameter on the amount field that when passed will return the `disambiguate_symbol` subfield if present. 

This should allow us to display `US$XXX` instead of `$XXX` to distinguish US from other dollar-based currencies (e.g. AUD,   HKD) optionally, and without introducing breaking changes in all of the places the money helper is used.

This is a requirement from [NX-2405](https://artsyproduct.atlassian.net/browse/NX-2405) and it fixes this [bug](https://github.com/artsy/force/pull/8963).


[NX-3031](https://artsyproduct.atlassian.net/browse/NX-3031)

Thank you to @starsirius for their help on this!

cc @artsy/negotiate-devs 