### PR TITLE
fix(CX-2262): price_paid_cents check for zero value

### DIFF
--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -870,7 +870,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           "The price paid for the artwork in a user's 'my collection'",
         resolve: (artwork) => {
           const { price_paid_cents } = artwork
-          if (!price_paid_cents) return null
+          if (!price_paid_cents && price_paid_cents !== 0) return null
           const price_paid_currency = artwork.price_paid_currency || "USD"
           return {
             cents: price_paid_cents,


### PR DESCRIPTION
Changed condition that handles the price paid for the artwork in a user's 'my collection. With this fixes collectors can enter the price paid for the artwork equal to 0 and it will be displayed in the artwork details. - daria

Before: 
![Simulator Screen Shot - iPhone 12 Pro - 2022-01-28 at 14 09 21](https://user-images.githubusercontent.com/36167539/151552382-d19836a7-cf63-4d60-af19-eafc1f4865da.png)

After:
![Simulator Screen Shot - iPhone 12 Pro - 2022-01-28 at 14 10 19](https://user-images.githubusercontent.com/36167539/151552460-e2218bbc-faf7-4044-88cb-bc428a463480.png)

