### PR TITLE
Fix(CX-2303): fix appleuid typos

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8312,7 +8312,7 @@ type LatLng {
 
 input LinkAuthenticationMutationInput {
   # Unique Apple user id. **Required** for Apple authentication.
-  applieUid: String
+  appleUid: String
   clientMutationId: String
 
   # User email, only used for Apple authentication.

--- a/src/schema/v2/me/linkAuthenticationMutation.ts
+++ b/src/schema/v2/me/linkAuthenticationMutation.ts
@@ -9,7 +9,7 @@ import { snakeCase } from "lodash"
 interface Input {
   provider: Provider
   oauthToken: string
-  applieUid?: string
+  appleUid?: string
   idToken?: string
   name?: string
   email?: string
@@ -36,7 +36,7 @@ export const linkAuthenticationMutation = mutationWithClientMutationId<
       type: new GraphQLNonNull(GraphQLString),
       description: "An OAuth token.",
     },
-    applieUid: {
+    appleUid: {
       type: GraphQLString,
       description:
         "Unique Apple user id. **Required** for Apple authentication.",


### PR DESCRIPTION
This PR resolves [CX-2303]

Fixes Typo in AppleUid params sent to gravity from Metaphysics

[CX-2303]: https://artsyproduct.atlassian.net/browse/CX-2303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ