### PR TITLE
feat: add emailConfirmed to me interface

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8792,6 +8792,9 @@ type Me implements Node {
   ): CreditCardConnection
   email: String
 
+  # User has confirmed their email address
+  emailConfirmed: Boolean!
+
   # Frequency of marketing emails.
   emailFrequency: String
   followsAndSaves: FollowsAndSaves

--- a/src/schema/v2/me/__tests__/index.test.ts
+++ b/src/schema/v2/me/__tests__/index.test.ts
@@ -269,4 +269,31 @@ describe("me/index", () => {
       expect(response).toEqual({ me: { canRequestEmailConfirmation: false } })
     })
   })
+
+  describe("emailConfirmed", () => {
+    const emailConfirmedQuery = gql`
+      query {
+        me {
+          emailConfirmed
+        }
+      }
+    `
+
+    it("returns email confirmed when the email is confirmed in gravity", () => {
+      return runAuthenticatedQuery(emailConfirmedQuery, {
+        meLoader: () =>
+          Promise.resolve({ confirmed_at: "2020-10-01T20:21:45+00:00" }),
+      }).then((data) => {
+        expect(data).toEqual({ me: { emailConfirmed: true } })
+      })
+    })
+
+    it("returns email is not confirmed when the email is not confirmed in gravity", () => {
+      return runQuery(emailConfirmedQuery, {
+        meLoader: () => Promise.resolve({ emailConfirmed: false }),
+      }).then((data) => {
+        expect(data).toEqual({ me: { emailConfirmed: false } })
+      })
+    })
+  })
 })

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -82,6 +82,16 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
       },
     },
     collectorProfile: CollectorProfile,
+    emailConfirmed: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description: "User has confirmed their email address",
+      resolve: ({ confirmed_at }) => {
+        if (confirmed_at) {
+          return true
+        }
+        return false
+      },
+    },
     conversation: Conversation,
     conversationsConnection: Conversations,
     createdAt: date,


### PR DESCRIPTION
This PR adds `emailConfirmed` to the me interface.

This PR comes as a follow-up on @lordkiz comment [here](https://github.com/artsy/eigen/pull/6076#issuecomment-1026843273)

![Group 1 (20)](https://user-images.githubusercontent.com/11945712/152145502-51677df3-9d50-435f-a009-1e3aeedc1102.png)

