### PR TITLE
feat: Respect PORT env var

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:remote-schemas": "cp src/data/*.graphql build/src/data/",
     "build": "yarn build:lib && yarn build:index && yarn build:fixtures && yarn build:remote-schemas",
     "ci": "yarn test",
-    "dev": "DEBUG=info,warn,error PORT=3000 babel-node --extensions '.ts,.js' --inspect index.js",
+    "dev": "DEBUG=info,warn,error babel-node --extensions '.ts,.js' --inspect index.js",
     "dump-schema": "babel-node --extensions '.ts,.js' ./scripts/dump-schema.ts",
     "dump:local": "yarn dump-schema v1 _schema.graphql & yarn dump-schema v2 _schemaV2.graphql & wait",
     "dump:staging": "node scripts/dump-staging-schema.js",


### PR DESCRIPTION
I'm not sure if this is intentional so lmk if I'm missing something but hard-coding the PORT like this means I can't configure it with my .env file. This PR just removes this bit so that the PORT env var is respected:

```
jon@juggernaut:~/code/metaphysics(feat-respect-port-env-var*)% y start
// snip
  info [Metaphysics] Listening on http://localhost:3000/v2 +0ms

jon@juggernaut:~/code/metaphysics(feat-respect-port-env-var*)% PORT=5001 y start
// snip
  info [Metaphysics] Listening on http://localhost:5001/v2 +0ms
```