### PR TITLE
feat(static-content): Add markdown formatter to field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12844,7 +12844,7 @@ type StartIdentityVerificationSuccess {
 }
 
 type StaticContent {
-  content: String
+  content(format: Format): String
 
   # A globally unique ID.
   id: ID!

--- a/src/schema/v2/static_content.ts
+++ b/src/schema/v2/static_content.ts
@@ -5,6 +5,7 @@ import {
   GraphQLString,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { markdown } from "./fields/markdown"
 import { SlugAndInternalIDFields } from "./object_identification"
 
 const StaticContentType = new GraphQLObjectType<any, ResolverContext>({
@@ -14,9 +15,7 @@ const StaticContentType = new GraphQLObjectType<any, ResolverContext>({
     name: {
       type: GraphQLString,
     },
-    content: {
-      type: GraphQLString,
-    },
+    content: markdown(),
   },
 })
 


### PR DESCRIPTION
This updates the staticContent.content field to use `markdown()` helper, which can convert to regular html on the fly 