### PR TITLE
fix: Use correct geolocation url GRO-784

### DIFF
--- a/src/schema/v2/requestLocation.ts
+++ b/src/schema/v2/requestLocation.ts
@@ -31,7 +31,7 @@ export const RequestLocationField: GraphQLFieldConfig<void, ResolverContext> = {
     },
   },
   resolve: (_root, args) => {
-    const url = `https://freegeoip.app/json/${args.ip}?apikey=${config.FREEGEOIP_API_KEY}`
+    const url = `https://api.freegeoip.app/json/${args.ip}?apikey=${config.FREEGEOIP_API_KEY}`
     return fetch(url)
       .then((response) => {
         if (config.ENABLE_GEOLOCATION_LOGGING) {


### PR DESCRIPTION
Turn out the api key only works if you are hitting the api subdomain. Nothing is easy folks.

https://artsyproduct.atlassian.net/browse/GRO-784

/cc @artsy/grow-devs