### PR TITLE
feat(article): exposes social embeds

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -846,8 +846,8 @@ union ArticleSections =
   | ArticleSectionVideo
 
 type ArticleSectionSocialEmbed {
-  layout: String
-  type: String
+  # oEmbed HTML response. Only Twitter is currently supported.
+  embed: String
   url: String
 }
 

--- a/src/schema/v2/article/__tests__/extractOEmbed.test.ts
+++ b/src/schema/v2/article/__tests__/extractOEmbed.test.ts
@@ -1,0 +1,35 @@
+import { extractOEmbed } from "../lib/extractOEmbed"
+import fetch from "node-fetch"
+
+jest.mock("node-fetch")
+
+describe("extractOEmbed", () => {
+  const mockFetch = (fetch as unknown) as jest.Mock<any>
+
+  beforeEach(() => {
+    mockFetch.mockImplementation(() => {
+      return Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            html: '<iframe src="https://example.com"></iframe>',
+          }),
+      })
+    })
+  })
+
+  afterEach(() => {
+    mockFetch.mockReset()
+  })
+
+  it("makes the appropriate fetch", async () => {
+    const res = await extractOEmbed(
+      "https://twitter.com/kanyewest/status/1277964735887978499"
+    )
+
+    expect(res.html).toEqual('<iframe src="https://example.com"></iframe>')
+
+    expect(mockFetch).toBeCalledWith(
+      "https://publish.twitter.com/oembed?url=https%3A%2F%2Ftwitter.com%2Fkanyewest%2Fstatus%2F1277964735887978499"
+    )
+  })
+})

--- a/src/schema/v2/article/lib/extractEmbed.ts
+++ b/src/schema/v2/article/lib/extractEmbed.ts
@@ -26,15 +26,14 @@ const OPTIONS: Record<Provider, Options> = {
 }
 
 const detectProvider = ({ hostname }: URL): Provider | null => {
-  if (hostname.indexOf("vimeo.com") > -1) {
-    return "vimeo"
+  switch (true) {
+    case hostname.includes("vimeo.com"):
+      return "vimeo"
+    case hostname.includes("youtu"):
+      return "youtube"
+    default:
+      return null
   }
-
-  if (hostname.indexOf("youtu") > -1) {
-    return "youtube"
-  }
-
-  return null
 }
 
 const detectId = ({ pathname, search }: URL, provider: Provider): string => {

--- a/src/schema/v2/article/lib/extractOEmbed.ts
+++ b/src/schema/v2/article/lib/extractOEmbed.ts
@@ -1,0 +1,43 @@
+import fetch from "node-fetch"
+import { URL } from "url"
+
+/**
+ * * Instagram turned off their old oEmbed endpoint:
+ * https://developers.facebook.com/docs/instagram/oembed/
+ * which has been replaced with:
+ * https://developers.facebook.com/docs/features-reference/oembed-read
+ * To use this we need to submit our app for review then sign
+ * requests with an access token. Disabled for now.
+ */
+
+const PROVIDERS = {
+  // instagram: "https://api.instagram.com/oembed",
+  twitter: "https://publish.twitter.com/oembed",
+} as const
+
+type Provider = keyof typeof PROVIDERS
+
+export const extractOEmbed = async (url: string) => {
+  const uri = new URL(url)
+
+  const provider = detectProvider(uri)
+
+  if (!provider) return null
+
+  const res = await fetch(
+    `${PROVIDERS[provider]}?url=${encodeURIComponent(url)}`
+  )
+
+  return await res.json()
+}
+
+const detectProvider = ({ hostname }: URL): Provider | null => {
+  switch (true) {
+    case hostname.includes("twitter"):
+      return "twitter"
+    // case hostname.includes("insta"):
+    //   return "instagram"
+    default:
+      return null
+  }
+}

--- a/src/schema/v2/article/sections/ArticleSectionSocialEmbed.ts
+++ b/src/schema/v2/article/sections/ArticleSectionSocialEmbed.ts
@@ -1,23 +1,31 @@
 import { GraphQLObjectType, GraphQLString } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { extractOEmbed } from "../lib/extractOEmbed"
 
 export const ArticleSectionSocialEmbed = new GraphQLObjectType<
   any,
   ResolverContext
 >({
   name: "ArticleSectionSocialEmbed",
-  isTypeOf: (data) => {
-    return data.type === "social_embed"
+  isTypeOf: (section) => {
+    return section.type === "social_embed"
   },
   fields: () => ({
-    type: {
-      type: GraphQLString,
-    },
     url: {
       type: GraphQLString,
     },
-    layout: {
+    embed: {
+      description: "oEmbed HTML response. Only Twitter is currently supported.",
       type: GraphQLString,
+      resolve: async ({ url }) => {
+        if (!url) return null
+        try {
+          const embed = await extractOEmbed(url)
+          return embed.html
+        } catch (err) {
+          return null
+        }
+      },
     },
   }),
 })

--- a/src/schema/v2/article/sections/ArticleSectionVideo.ts
+++ b/src/schema/v2/article/sections/ArticleSectionVideo.ts
@@ -32,7 +32,6 @@ export const ArticleSectionVideo = new GraphQLObjectType<any, ResolverContext>({
         }
       },
     },
-
     layout: {
       type: new GraphQLEnumType({
         name: "ArticleSectionVideoLayout",
@@ -57,6 +56,7 @@ export const ArticleSectionVideo = new GraphQLObjectType<any, ResolverContext>({
       },
       type: GraphQLString,
       resolve: ({ url }, { autoPlay }) => {
+        if (!url) return null
         const options = { autoplay: autoPlay ? 1 : 0 }
         return extractEmbed(url, options)
       },


### PR DESCRIPTION
Fleshes out the social embed sections.

Previously we only supported Instagram and Twitter (despite the fact that we're using oEmbed here and we _could_ just support oEmbed more broadly...). But: Instagram turned off their oEmbed endpoint last year and replaced it with a permission on the Graph API: https://developers.facebook.com/docs/instagram/oembed/ & https://developers.facebook.com/docs/features-reference/oembed-read — which... is deeply annoying. So at the moment Instagram embeds are broken in Positron as well as Force. This does nothing to fix them but I'll make a ticket for this. It doesn't appear that this is a much used feature anyway. There's some articles that have Instagram embeds in them but they use the... odd... method of embedding them in an HTML file which is uploaded and then embedded as an iframe using the generic embed feature. So... there's that.