### PR TITLE
fix [CX-2257]: update  partner inquirer collector profile fields

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8152,6 +8152,11 @@ type ImageURLs {
 }
 
 type InquirerCollectorProfile {
+  # List of affiliated auction house ids, referencing Galaxy.
+  affiliatedAuctionHouseIds: [String]
+
+  # List of affiliated gallery ids, referencing Galaxy.
+  affiliatedGalleryIds: [String]
   artsyUserSince(
     format: String
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8223,6 +8223,9 @@ type InquirerCollectorProfile {
   ): String
   selfReportedPurchases: String
   userInterests: [UserInterest]!
+
+  # Collector's brief introduction
+  userIntroduction: String
 }
 
 union InquiryItemType = Artwork | Show

--- a/src/schema/v2/partnerInquirerCollectorProfile.ts
+++ b/src/schema/v2/partnerInquirerCollectorProfile.ts
@@ -78,6 +78,14 @@ const InquirerCollectorProfileFields: GraphQLFieldConfigMap<
     description: "Collector's brief introduction",
     resolve: ({ user_introduction }) => user_introduction?.introduction,
   },
+  affiliatedAuctionHouseIds: {
+    description: "List of affiliated auction house ids, referencing Galaxy.",
+    type: new GraphQLList(GraphQLString),
+  },
+  affiliatedGalleryIds: {
+    description: "List of affiliated gallery ids, referencing Galaxy.",
+    type: new GraphQLList(GraphQLString),
+  },
 }
 
 const InquirerCollectorProfileType = new GraphQLObjectType<

--- a/src/schema/v2/partnerInquirerCollectorProfile.ts
+++ b/src/schema/v2/partnerInquirerCollectorProfile.ts
@@ -72,6 +72,12 @@ const InquirerCollectorProfileFields: GraphQLFieldConfigMap<
     description: "List of artists the Collector is interested in.",
     resolve: ({ collected_artist_names }) => collected_artist_names,
   },
+  // FIXME: please remove this field after the new profile in CMS is in prod for all partners
+  userIntroduction: {
+    type: GraphQLString,
+    description: "Collector's brief introduction",
+    resolve: ({ user_introduction }) => user_introduction?.introduction,
+  },
 }
 
 const InquirerCollectorProfileType = new GraphQLObjectType<

--- a/src/schema/v2/partnerInquirerCollectorProfile.ts
+++ b/src/schema/v2/partnerInquirerCollectorProfile.ts
@@ -72,7 +72,7 @@ const InquirerCollectorProfileFields: GraphQLFieldConfigMap<
     description: "List of artists the Collector is interested in.",
     resolve: ({ collected_artist_names }) => collected_artist_names,
   },
-  // FIXME: please remove this field after the new profile in CMS is in prod for all partners
+  // FIXME: please remove this field after the new collector profile in CMS is in prod for all partners
   userIntroduction: {
     type: GraphQLString,
     description: "Collector's brief introduction",


### PR DESCRIPTION
This PR resolves [CX-2257](https://artsyproduct.atlassian.net/browse/CX-2257)

This is a follow up on #3710 

## Description
This PR adds `userIntroduction` field into the Partner inquirer collector profile endpoint to be used by the old design of the the collector profile
It also adds `affiliatedGalleryIds` and `affiliatedGalleryIds` fields to be used in the collector profile controller in volt