### PR TITLE
[CX-2328]: adds inProgress to artworkConsignmentSubmission

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1800,6 +1800,7 @@ interface ArtworkConnectionInterface {
 
 type ArtworkConsignmentSubmission {
   displayText: String
+  inProgress: Boolean
 }
 
 union ArtworkContext = Fair | Sale | Show

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -977,6 +977,36 @@ describe("Artwork type", () => {
     })
   })
 
+  describe("#consignmentSubmission", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          slug
+          consignmentSubmission {
+            displayText
+            inProgress
+          }
+        }
+      }
+    `
+
+    it("returns artwork's submission", () => {
+      artwork.consignmentSubmission = { state: "submitted" }
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            slug: "richard-prince-untitled-portrait",
+            consignmentSubmission: {
+              displayText: "Submission in progress",
+              inProgress: true,
+            },
+          },
+        })
+      })
+    })
+  })
+
   describe("#contactMessage", () => {
     const query = `
       {

--- a/src/schema/v2/artwork/__tests__/artworkConsignmentSubmissionType.test.ts
+++ b/src/schema/v2/artwork/__tests__/artworkConsignmentSubmissionType.test.ts
@@ -1,0 +1,112 @@
+import { runQuery } from "schema/v2/test/utils"
+import sinon from "sinon"
+
+describe("ArtworkConsignmentSubmissionType", () => {
+  const artwork = {
+    id: "richard-prince-untitled-portrait",
+    consignmentSubmission: {
+      state: "draft",
+    },
+  }
+
+  let context = {}
+
+  beforeEach(() => {
+    context = {
+      artworkLoader: sinon
+        .stub()
+        .withArgs(artwork.id)
+        .returns(Promise.resolve(artwork)),
+    }
+  })
+
+  describe("#displayText", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          slug
+          consignmentSubmission {
+            displayText
+          }
+        }
+      }
+    `
+
+    it("returns correct displayText", async () => {
+      artwork.consignmentSubmission.state = "submitted"
+      let data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.displayText).toEqual(
+        "Submission in progress"
+      )
+
+      artwork.consignmentSubmission.state = "approved"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.displayText).toEqual(
+        "Submission in progress"
+      )
+
+      artwork.consignmentSubmission.state = "published"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.displayText).toEqual(
+        "Submission in progress"
+      )
+
+      artwork.consignmentSubmission.state = "rejected"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.displayText).toEqual(
+        "Submission in progress"
+      )
+
+      artwork.consignmentSubmission.state = "hold"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.displayText).toEqual(
+        "Submission in progress"
+      )
+
+      artwork.consignmentSubmission.state = "closed"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.displayText).toEqual(
+        "Submission evaluated"
+      )
+    })
+  })
+
+  describe("#inProgress", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          slug
+          consignmentSubmission {
+            inProgress
+          }
+        }
+      }
+    `
+
+    it("returns correct inProgress", async () => {
+      artwork.consignmentSubmission.state = "submitted"
+      let data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.inProgress).toBeTrue()
+
+      artwork.consignmentSubmission.state = "approved"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.inProgress).toBeTrue()
+
+      artwork.consignmentSubmission.state = "published"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.inProgress).toBeTrue()
+
+      artwork.consignmentSubmission.state = "rejected"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.inProgress).toBeFalse()
+
+      artwork.consignmentSubmission.state = "hold"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.inProgress).toBeTrue()
+
+      artwork.consignmentSubmission.state = "closed"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.inProgress).toBeFalse()
+    })
+  })
+})

--- a/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
+++ b/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
@@ -1,4 +1,4 @@
-import { GraphQLObjectType, GraphQLString } from "graphql"
+import { GraphQLObjectType, GraphQLString, GraphQLBoolean } from "graphql"
 import { ResolverContext } from "types/graphql"
 
 const ArtworkConsignmentSubmissionType = new GraphQLObjectType<
@@ -21,6 +21,24 @@ const ArtworkConsignmentSubmissionType = new GraphQLObjectType<
           }
 
           return statusDisplayTexts[consignmentSubmission.state]
+        },
+      },
+      inProgress: {
+        type: GraphQLBoolean,
+        resolve: (consignmentSubmission) => {
+          const inProgressSubmissionStates = [
+            "submitted",
+            "published",
+            "approved",
+            "hold",
+            "open",
+          ]
+
+          return inProgressSubmissionStates.includes(
+            consignmentSubmission.state
+          )
+            ? true
+            : false
         },
       },
     }

--- a/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
+++ b/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
@@ -37,8 +37,6 @@ const ArtworkConsignmentSubmissionType = new GraphQLObjectType<
           return inProgressSubmissionStates.includes(
             consignmentSubmission.state
           )
-            ? true
-            : false
         },
       },
     }

--- a/src/schema/v2/me/__tests__/myCollection.test.ts
+++ b/src/schema/v2/me/__tests__/myCollection.test.ts
@@ -72,7 +72,7 @@ describe("me.myCollection", () => {
     )
   })
 
-  it("enriches artwork with consingment submissions data", async () => {
+  it("enriches artwork with consignment submissions data", async () => {
     const query = gql`
       {
         me {


### PR DESCRIPTION
The goal is to hide Artwork Edit Button when the submission is in progress. This is a BE part of the story: adds inProgress field to artworkConsignmentSubmission type

Jira - https://artsyproduct.atlassian.net/browse/CX-2328