### PR TITLE
Remove unneeded conditionals from inquireable

### DIFF
--- a/src/schema/v1/artwork/__tests__/artwork.test.js
+++ b/src/schema/v1/artwork/__tests__/artwork.test.js
@@ -1252,25 +1252,15 @@ describe("Artwork type", () => {
         }
       `
 
-      it("returns false for ecommerce works regardless of work inquireable status", () => {
+      it("returns true for inquireable works", () => {
         artwork.inquireable = true
-        artwork.ecommerce = true
-        return runQuery(query, context).then((data) => {
-          expect(data.artwork.is_inquireable).toBe(false)
-        })
-      })
-
-      it("returns true for inquireable non ecommerce works", () => {
-        artwork.inquireable = true
-        artwork.ecommerce = false
         return runQuery(query, context).then((data) => {
           expect(data.artwork.is_inquireable).toBe(true)
         })
       })
 
-      it("returns false for non inquireable non ecommerce works", () => {
+      it("returns false for non inquireable works", () => {
         artwork.inquireable = false
-        artwork.ecommerce = false
         return runQuery(query, context).then((data) => {
           expect(data.artwork.is_inquireable).toBe(false)
         })

--- a/src/schema/v1/artwork/index.ts
+++ b/src/schema/v1/artwork/index.ts
@@ -421,7 +421,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       is_inquireable: {
         type: GraphQLBoolean,
         description: "Do we want to encourage inquiries on this work?",
-        resolve: ({ ecommerce, inquireable }) => !ecommerce && inquireable,
+        resolve: ({ inquireable }) => inquireable,
       },
       is_in_auction: {
         type: GraphQLBoolean,

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -1504,25 +1504,15 @@ describe("Artwork type", () => {
         }
       `
 
-      it("returns false for ecommerce works regardless of work inquireable status", () => {
+      it("returns true for inquireable works", () => {
         artwork.inquireable = true
-        artwork.ecommerce = true
-        return runQuery(query, context).then((data) => {
-          expect(data.artwork.isInquireable).toBe(false)
-        })
-      })
-
-      it("returns true for inquireable non ecommerce works", () => {
-        artwork.inquireable = true
-        artwork.ecommerce = false
         return runQuery(query, context).then((data) => {
           expect(data.artwork.isInquireable).toBe(true)
         })
       })
 
-      it("returns false for non inquireable non ecommerce works", () => {
+      it("returns false for non inquireable works", () => {
         artwork.inquireable = false
-        artwork.ecommerce = false
         return runQuery(query, context).then((data) => {
           expect(data.artwork.isInquireable).toBe(false)
         })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -531,7 +531,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       isInquireable: {
         type: GraphQLBoolean,
         description: "Do we want to encourage inquiries on this work?",
-        resolve: ({ ecommerce, inquireable }) => !ecommerce && inquireable,
+        resolve: ({ inquireable }) => inquireable,
       },
       isInAuction: {
         type: GraphQLBoolean,


### PR DESCRIPTION
[NX-3081] We don't need to check here if an artwork is not `ecommerce` in order to determine if it's `inquireable`. This is Gravity responsibility.

See: https://github.com/artsy/gravity/pull/14971

[NX-3081]: https://artsyproduct.atlassian.net/browse/NX-3081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ