### PR TITLE
fix: doubled inquiries from Exchange stitching

### DIFF
--- a/src/lib/stitching/exchange/__tests__/stitching.test.ts
+++ b/src/lib/stitching/exchange/__tests__/stitching.test.ts
@@ -313,6 +313,7 @@ describe("submitOfferOrderWithConversation", () => {
   const validOrderResult = {
     orderOrError: {
       order: {
+        source: "artwork_page",
         internalID: "order-id",
         myLastOffer: {
           note: "test note",
@@ -365,6 +366,42 @@ describe("submitOfferOrderWithConversation", () => {
       message: "test note",
       order_id: "order-id",
     })
+  })
+
+  it("does not call submitArtworkInquiryRequestLoader given inquiry offer", async () => {
+    const { resolvers } = await getExchangeStitchedSchema()
+    const resolver = resolvers.Mutation.submitOfferOrderWithConversation.resolve
+    const args = {
+      input: {
+        offerId: "offer-id",
+      },
+    }
+    const order = {
+      orderOrError: {
+        order: {
+          source: "inquiry",
+        },
+      },
+    }
+    mergeInfo.delegateToSchema.mockResolvedValue(order)
+
+    const result = await resolver({}, args, context, { mergeInfo })
+
+    expect(mergeInfo.delegateToSchema).toHaveBeenCalledWith({
+      args: {
+        input: {
+          offerId: "offer-id",
+        },
+      },
+      fieldName: "commerceSubmitOrderWithOffer",
+      operation: "mutation",
+      schema: expect.anything(),
+      context: expect.anything(),
+      info: expect.anything(),
+      transforms: [expect.anything()],
+    })
+    expect(result).toEqual(order)
+    expect(context.submitArtworkInquiryRequestLoader).not.toHaveBeenCalled()
   })
 
   it("returns an error from exchange", async () => {

--- a/src/lib/stitching/exchange/v2/stitching.ts
+++ b/src/lib/stitching/exchange/v2/stitching.ts
@@ -577,6 +577,13 @@ export const exchangeStitchingEnvironment = ({
                         },
                       },
                       {
+                        kind: Kind.FIELD,
+                        name: {
+                          kind: Kind.NAME,
+                          value: "source",
+                        },
+                      },
+                      {
                         kind: Kind.INLINE_FRAGMENT,
                         typeCondition: {
                           kind: Kind.NAMED_TYPE,
@@ -665,7 +672,11 @@ export const exchangeStitchingEnvironment = ({
 
             const { orderOrError } = submitOrderWithOffer
 
-            if (orderOrError.error || !orderOrError.order) {
+            if (
+              orderOrError.error ||
+              !orderOrError.order ||
+              orderOrError.order.source === "inquiry"
+            ) {
               return submitOrderWithOffer
             }
 
@@ -678,6 +689,7 @@ export const exchangeStitchingEnvironment = ({
                 order_id: order.internalID,
               })
             } catch (e) {
+              console.error(e)
               throw new GraphQLError(
                 `[metaphysics @ exchange/v2/stitching] Gravity: request to create inquiry failed`
               )


### PR DESCRIPTION
Fixes a doubled inquiry from the mutation `submitOfferOrderWithConversation` when the `source` of the offer is `inquiry`. For these cases, we don't need to create another `inquiry`.