### PR TITLE
feat(alerts): render human-friendly criteria labels

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12388,6 +12388,9 @@ type SearchCriteria {
   href: String!
   inquireableOnly: Boolean
   internalID: ID!
+
+  # Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity
+  labels: [SearchCriteriaLabel]
   locationCities: [String!]!
   majorPeriods: [String!]!
   materialsTerms: [String!]!
@@ -12445,6 +12448,18 @@ type SearchCriteriaEdge {
 
   # The item at the end of the edge.
   node: SearchCriteria
+}
+
+# Human-friendly representation of a single SearchCriteria filter
+type SearchCriteriaLabel {
+  # The GraphQL field name of the filter facet
+  field: String
+
+  # The human-friendly name of the filter facet
+  name: String
+
+  # The human-friendly value of the filter facet
+  value: String
 }
 
 # A search criteria or errors object

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12390,7 +12390,7 @@ type SearchCriteria {
   internalID: ID!
 
   # Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity
-  labels: [SearchCriteriaLabel]
+  labels: [SearchCriteriaLabel!]!
   locationCities: [String!]!
   majorPeriods: [String!]!
   materialsTerms: [String!]!
@@ -12453,13 +12453,13 @@ type SearchCriteriaEdge {
 # Human-friendly representation of a single SearchCriteria filter
 type SearchCriteriaLabel {
   # The GraphQL field name of the filter facet
-  field: String
+  field: String!
 
   # The human-friendly name of the filter facet
-  name: String
+  name: String!
 
   # The human-friendly value of the filter facet
-  value: String
+  value: String!
 }
 
 # A search criteria or errors object

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@artsy/morgan": "^1.0.2",
     "@artsy/multienv": "^1.2.0",
+    "@artsy/to-title-case": "^1.1.0",
     "@artsy/xapp": "1.0.6",
     "@graphql-tools/delegate": "6.0.10",
     "@sentry/node": "5.18.1",

--- a/src/lib/colors.ts
+++ b/src/lib/colors.ts
@@ -1,0 +1,80 @@
+export const COLORS = [
+  {
+    value: "black-and-white",
+    name: "Black and White",
+    backgroundColor: "#000",
+    foregroundColor: "#fff",
+  },
+  {
+    value: "red",
+    name: "Red",
+    backgroundColor: "#FF0000",
+    foregroundColor: "#fff",
+  },
+  {
+    value: "yellow",
+    name: "Yellow",
+    backgroundColor: "#FBE854",
+    foregroundColor: "#000",
+  },
+  {
+    value: "pink",
+    name: "Pink",
+    backgroundColor: "#FB81CD",
+    foregroundColor: "#000",
+  },
+  {
+    value: "violet",
+    name: "Violet",
+    backgroundColor: "#B82C83",
+    foregroundColor: "#fff",
+  },
+  {
+    value: "gold",
+    name: "Gold",
+    backgroundColor: "#DAA520",
+    foregroundColor: "#000",
+  },
+  {
+    value: "orange",
+    name: "Orange",
+    backgroundColor: "#F7923A",
+    foregroundColor: "#000",
+  },
+  {
+    value: "darkviolet",
+    name: "Dark Violet",
+    backgroundColor: "#642B7F",
+    foregroundColor: "#fff",
+  },
+  {
+    value: "lightgreen",
+    name: "Light Green",
+    backgroundColor: "#BCCC46",
+    foregroundColor: "#000",
+  },
+  {
+    value: "lightblue",
+    name: "Light Blue",
+    backgroundColor: "#C2D5F1",
+    foregroundColor: "#000",
+  },
+  {
+    value: "darkblue",
+    name: "Dark Blue",
+    backgroundColor: "#0A1AB4",
+    foregroundColor: "#fff",
+  },
+  {
+    value: "darkorange",
+    name: "Dark Orange",
+    backgroundColor: "#612A00",
+    foregroundColor: "#fff",
+  },
+  {
+    value: "darkgreen",
+    name: "Dark Green",
+    backgroundColor: "#004600",
+    foregroundColor: "#fff",
+  },
+]

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -796,6 +796,7 @@ export const gravityStitchingEnvironment = (
               offerable
               materialsTerms
               locationCities
+              majorPeriods
             }
             `,
           resolve: resolveSearchCriteriaLabels,

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -798,6 +798,7 @@ export const gravityStitchingEnvironment = (
               locationCities
               majorPeriods
               colors
+              partnerIDs
             }
             `,
           resolve: resolveSearchCriteriaLabels,

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -82,7 +82,7 @@ export const gravityStitchingEnvironment = (
         ): UserAddressConnection
       }
       extend type SearchCriteria {
-        labels: [SearchCriteriaLabel]
+        labels: [SearchCriteriaLabel!]!
       }
       extend type UserAddress {
         id: ID!

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -785,6 +785,7 @@ export const gravityStitchingEnvironment = (
             ... on SearchCriteria {
               artistIDs
               attributionClass
+              additionalGeneIDs
             }
             `,
           resolve: resolveSearchCriteriaLabels,

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -797,6 +797,7 @@ export const gravityStitchingEnvironment = (
               materialsTerms
               locationCities
               majorPeriods
+              colors
             }
             `,
           resolve: resolveSearchCriteriaLabels,

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -787,6 +787,7 @@ export const gravityStitchingEnvironment = (
               attributionClass
               additionalGeneIDs
               priceRange
+              sizes
             }
             `,
           resolve: resolveSearchCriteriaLabels,

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -795,6 +795,7 @@ export const gravityStitchingEnvironment = (
               inquireableOnly
               offerable
               materialsTerms
+              locationCities
             }
             `,
           resolve: resolveSearchCriteriaLabels,

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -786,6 +786,7 @@ export const gravityStitchingEnvironment = (
               artistIDs
               attributionClass
               additionalGeneIDs
+              priceRange
             }
             `,
           resolve: resolveSearchCriteriaLabels,

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -794,6 +794,7 @@ export const gravityStitchingEnvironment = (
               atAuction
               inquireableOnly
               offerable
+              materialsTerms
             }
             `,
           resolve: resolveSearchCriteriaLabels,

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -9,6 +9,7 @@ import Format from "schema/v2/input_fields/format"
 import { toGlobalId } from "graphql-relay"
 import { printType } from "lib/stitching/lib/printType"
 import { dateRange } from "lib/date"
+import { resolveSearchCriteriaLabels } from "schema/v2/searchCriteriaLabel"
 
 const LocaleEnViewingRoomRelativeShort = "en-viewing-room-relative-short"
 defineCustomLocale(LocaleEnViewingRoomRelativeShort, {
@@ -79,6 +80,9 @@ export const gravityStitchingEnvironment = (
           after: String
           before: String
         ): UserAddressConnection
+      }
+      extend type SearchCriteria {
+        labels: [SearchCriteriaLabel]
       }
       extend type UserAddress {
         id: ID!
@@ -773,6 +777,18 @@ export const gravityStitchingEnvironment = (
               info,
             })
           },
+        },
+      },
+      SearchCriteria: {
+        labels: {
+          fragment: gql`
+            ... on SearchCriteria {
+              artistIDs
+            }
+            `,
+          resolve: resolveSearchCriteriaLabels,
+          description:
+            "Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity",
         },
       },
     },

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -790,6 +790,10 @@ export const gravityStitchingEnvironment = (
               sizes
               width
               height
+              acquireable
+              atAuction
+              inquireableOnly
+              offerable
             }
             `,
           resolve: resolveSearchCriteriaLabels,

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -784,6 +784,7 @@ export const gravityStitchingEnvironment = (
           fragment: gql`
             ... on SearchCriteria {
               artistIDs
+              attributionClass
             }
             `,
           resolve: resolveSearchCriteriaLabels,

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -788,6 +788,8 @@ export const gravityStitchingEnvironment = (
               additionalGeneIDs
               priceRange
               sizes
+              width
+              height
             }
             `,
           resolve: resolveSearchCriteriaLabels,

--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -302,4 +302,25 @@ describe("resolveSearchCriteriaLabels", () => {
       },
     ])
   })
+
+  it("formats time period criteria", async () => {
+    const parent = {
+      majorPeriods: ["1990", "Early 19th Century"],
+    }
+
+    const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+
+    expect(labels).toIncludeAllMembers([
+      {
+        name: "Time Period",
+        value: "1990–1999",
+        field: "majorPeriods",
+      },
+      {
+        name: "Time Period",
+        value: "Early 19th Century",
+        field: "majorPeriods",
+      },
+    ])
+  })
 })

--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -1,0 +1,69 @@
+import { resolveSearchCriteriaLabels } from "../searchCriteriaLabel"
+
+const _ = {}
+
+describe("resolveSearchCriteriaLabels", () => {
+  it("formats artist criteria", async () => {
+    const parent = {
+      artistIDs: ["foo-bar", "baz-qux"],
+    }
+
+    const context = {
+      artistLoader: jest
+        .fn()
+        .mockReturnValueOnce(Promise.resolve({ name: "Foo Bar" }))
+        .mockReturnValueOnce(Promise.resolve({ name: "Baz Qux" })),
+    }
+
+    const labels = await resolveSearchCriteriaLabels(parent, _, context, _)
+
+    expect(labels).toIncludeAllMembers([
+      {
+        name: "Artist",
+        value: "Foo Bar",
+        field: "artistIDs",
+      },
+      {
+        name: "Artist",
+        value: "Baz Qux",
+        field: "artistIDs",
+      },
+    ])
+  })
+
+  it("formats rarity criteria", async () => {
+    const parent = {
+      attributionClass: [
+        "unique",
+        "limited edition",
+        "open edition",
+        "unknown edition",
+      ],
+    }
+
+    const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+
+    expect(labels).toIncludeAllMembers([
+      {
+        name: "Rarity",
+        value: "Unique",
+        field: "attributionClass",
+      },
+      {
+        name: "Rarity",
+        value: "Limited edition",
+        field: "attributionClass",
+      },
+      {
+        name: "Rarity",
+        value: "Open edition",
+        field: "attributionClass",
+      },
+      {
+        name: "Rarity",
+        value: "Unknown edition",
+        field: "attributionClass",
+      },
+    ])
+  })
+})

--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -178,4 +178,30 @@ describe("resolveSearchCriteriaLabels", () => {
       },
     ])
   })
+
+  it("formats size bucket criteria", async () => {
+    const parent = {
+      sizes: ["LARGE", "MEDIUM", "SMALL"],
+    }
+
+    const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+
+    expect(labels).toIncludeAllMembers([
+      {
+        name: "Size",
+        value: "Large", // TODO: fix this placeholder formatting
+        field: "sizes",
+      },
+      {
+        name: "Size",
+        value: "Medium", // TODO: fix this placeholder formatting
+        field: "sizes",
+      },
+      {
+        name: "Size",
+        value: "Small", // TODO: fix this placeholder formatting
+        field: "sizes",
+      },
+    ])
+  })
 })

--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -204,4 +204,26 @@ describe("resolveSearchCriteriaLabels", () => {
       },
     ])
   })
+
+  it("formats custom size criteria", async () => {
+    const parent = {
+      height: "1-10",
+      width: "2-20",
+    }
+
+    const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+
+    expect(labels).toIncludeAllMembers([
+      {
+        name: "Size",
+        value: "w: 5–51 cm", // TODO: fix this placeholder formatting
+        field: "width",
+      },
+      {
+        name: "Size",
+        value: "h: 3–25 cm", // TODO: fix this placeholder formatting
+        field: "height",
+      },
+    ])
+  })
 })

--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -344,4 +344,32 @@ describe("resolveSearchCriteriaLabels", () => {
       },
     ])
   })
+
+  it("formats partner criteria", async () => {
+    const parent = {
+      partnerIDs: ["foo-bar-gallery", "baz-qux-gallery"],
+    }
+
+    const context = {
+      partnerLoader: jest
+        .fn()
+        .mockReturnValueOnce(Promise.resolve({ name: "Foo Bar Gallery" }))
+        .mockReturnValueOnce(Promise.resolve({ name: "Baz Qux Gallery" })),
+    }
+
+    const labels = await resolveSearchCriteriaLabels(parent, _, context, _)
+
+    expect(labels).toIncludeAllMembers([
+      {
+        name: "Galleries and Institutions",
+        value: "Foo Bar Gallery",
+        field: "partnerIDs",
+      },
+      {
+        name: "Galleries and Institutions",
+        value: "Baz Qux Gallery",
+        field: "partnerIDs",
+      },
+    ])
+  })
 })

--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -260,4 +260,25 @@ describe("resolveSearchCriteriaLabels", () => {
       },
     ])
   })
+
+  it("formats material criteria", async () => {
+    const parent = {
+      materialsTerms: ["acrylic", "c-print"],
+    }
+
+    const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+
+    expect(labels).toIncludeAllMembers([
+      {
+        name: "Material",
+        value: "Acrylic",
+        field: "materialsTerms",
+      },
+      {
+        name: "Material",
+        value: "C-Print",
+        field: "materialsTerms",
+      },
+    ])
+  })
 })

--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -281,4 +281,25 @@ describe("resolveSearchCriteriaLabels", () => {
       },
     ])
   })
+
+  it("formats artwork location criteria", async () => {
+    const parent = {
+      locationCities: ["Durham, PA, USA", "New York, NY, USA"],
+    }
+
+    const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+
+    expect(labels).toIncludeAllMembers([
+      {
+        name: "Artwork Location",
+        value: "Durham, PA, USA",
+        field: "locationCities",
+      },
+      {
+        name: "Artwork Location",
+        value: "New York, NY, USA",
+        field: "locationCities",
+      },
+    ])
+  })
 })

--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -226,4 +226,38 @@ describe("resolveSearchCriteriaLabels", () => {
       },
     ])
   })
+
+  it("formats ways-to-buy criteria", async () => {
+    const parent = {
+      acquireable: true,
+      atAuction: true,
+      inquireableOnly: true,
+      offerable: true,
+    }
+
+    const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+
+    expect(labels).toIncludeAllMembers([
+      {
+        name: "Ways to Buy",
+        value: "Buy Now",
+        field: "acquireable",
+      },
+      {
+        name: "Ways to Buy",
+        value: "Bid",
+        field: "atAuction",
+      },
+      {
+        name: "Ways to Buy",
+        value: "Inquire",
+        field: "inquireableOnly",
+      },
+      {
+        name: "Ways to Buy",
+        value: "Make Offer",
+        field: "offerable",
+      },
+    ])
+  })
 })

--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -66,4 +66,100 @@ describe("resolveSearchCriteriaLabels", () => {
       },
     ])
   })
+
+  it("formats medium criteria", async () => {
+    const parent = {
+      additionalGeneIDs: [
+        "painting",
+        "photography",
+        "sculpture",
+        "prints",
+        "work-on-paper",
+        "nft",
+        "design",
+        "drawing",
+        "installation",
+        "film-slash-video",
+        "jewelry",
+        "performance-art",
+        "reproduction",
+        "ephemera-or-merchandise",
+      ],
+    }
+
+    const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+
+    expect(labels).toIncludeAllMembers([
+      {
+        name: "Medium",
+        value: "Painting",
+        field: "additionalGeneIDs",
+      },
+      {
+        name: "Medium",
+        value: "Photography",
+        field: "additionalGeneIDs",
+      },
+      {
+        name: "Medium",
+        value: "Sculpture",
+        field: "additionalGeneIDs",
+      },
+      {
+        name: "Medium",
+        value: "Prints",
+        field: "additionalGeneIDs",
+      },
+      {
+        name: "Medium",
+        value: "Work on Paper",
+        field: "additionalGeneIDs",
+      },
+      {
+        name: "Medium",
+        value: "NFT",
+        field: "additionalGeneIDs",
+      },
+      {
+        name: "Medium",
+        value: "Design",
+        field: "additionalGeneIDs",
+      },
+      {
+        name: "Medium",
+        value: "Drawing",
+        field: "additionalGeneIDs",
+      },
+      {
+        name: "Medium",
+        value: "Installation",
+        field: "additionalGeneIDs",
+      },
+      {
+        name: "Medium",
+        value: "Film/Video",
+        field: "additionalGeneIDs",
+      },
+      {
+        name: "Medium",
+        value: "Jewelry",
+        field: "additionalGeneIDs",
+      },
+      {
+        name: "Medium",
+        value: "Performance Art",
+        field: "additionalGeneIDs",
+      },
+      {
+        name: "Medium",
+        value: "Reproduction",
+        field: "additionalGeneIDs",
+      },
+      {
+        name: "Medium",
+        value: "Ephemera or Merchandise",
+        field: "additionalGeneIDs",
+      },
+    ])
+  })
 })

--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -162,4 +162,20 @@ describe("resolveSearchCriteriaLabels", () => {
       },
     ])
   })
+
+  it("formats price criteria", async () => {
+    const parent = {
+      priceRange: "42-420",
+    }
+
+    const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+
+    expect(labels).toIncludeAllMembers([
+      {
+        name: "Price",
+        value: expect.anything(), // TODO: fix this placeholder formatting
+        field: "priceRange",
+      },
+    ])
+  })
 })

--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -323,4 +323,25 @@ describe("resolveSearchCriteriaLabels", () => {
       },
     ])
   })
+
+  it("formats color criteria", async () => {
+    const parent = {
+      colors: ["lightblue", "yellow"],
+    }
+
+    const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+
+    expect(labels).toIncludeAllMembers([
+      {
+        name: "Color",
+        value: "Light Blue",
+        field: "colors",
+      },
+      {
+        name: "Color",
+        value: "Yellow",
+        field: "colors",
+      },
+    ])
+  })
 })

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -117,6 +117,7 @@ import { unlinkAuthenticationMutation } from "./me/unlinkAuthenticationMutation"
 import { linkAuthenticationMutation } from "./me/linkAuthenticationMutation"
 import { authenticationStatus } from "./authenticationStatus"
 import { deleteUserAccountMutation } from "./me/delete_account_mutation"
+import { SearchCriteriaLabel } from "./searchCriteriaLabel"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -278,6 +279,7 @@ export default new GraphQLSchema({
     RelatedArtworkGridType,
     ShowArtworkGridType,
     ArtworkOrEditionSetType,
+    SearchCriteriaLabel,
   ],
   directives: specifiedDirectives.concat([
     PrincipalFieldDirective,

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -52,7 +52,7 @@ export const resolveSearchCriteriaLabels = async (
   context,
   _info
 ) => {
-  const { artistIDs, attributionClass, additionalGeneIDs } = parent
+  const { artistIDs, attributionClass, additionalGeneIDs, priceRange } = parent
 
   const { artistLoader } = context
 
@@ -61,6 +61,7 @@ export const resolveSearchCriteriaLabels = async (
   labels.push(await getArtistLabels(artistIDs, artistLoader))
   labels.push(getRarityLabels(attributionClass))
   labels.push(getMediumLabels(additionalGeneIDs))
+  labels.push(getPriceLabel(priceRange))
 
   return labels.flat().filter((x) => x !== undefined) as SearchCriteriaLabel[]
 }
@@ -121,4 +122,15 @@ function getMediumLabels(additionalGeneIDs: string[]) {
     value: MEDIUM_GENES[geneID],
     field: "additionalGeneIDs",
   }))
+}
+
+function getPriceLabel(priceRange: string): SearchCriteriaLabel | undefined {
+  if (!priceRange) return
+
+  const [min, max] = priceRange.split(/-/)
+  return {
+    name: "Price",
+    value: `USD ${min}–${max}`, // TODO: this a placeholder, we need to format these properly
+    field: "priceRange",
+  }
 }

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -3,6 +3,7 @@ import { ResolverContext } from "types/graphql"
 import { startCase } from "lodash"
 
 import allAttributionClasses from "lib/attributionClasses"
+import { COLORS } from "lib/colors"
 
 type SearchCriteriaLabel = {
   /** The GraphQL field name of the filter facet */
@@ -68,6 +69,7 @@ export const resolveSearchCriteriaLabels = async (
     materialsTerms,
     locationCities,
     majorPeriods,
+    colors,
   } = parent
 
   const { artistLoader } = context
@@ -91,6 +93,7 @@ export const resolveSearchCriteriaLabels = async (
   labels.push(getMaterialLabels(materialsTerms))
   labels.push(getLocationLabels(locationCities))
   labels.push(getPeriodLabels(majorPeriods))
+  labels.push(getColorLabels(colors))
 
   return labels.flat().filter((x) => x !== undefined) as SearchCriteriaLabel[]
 }
@@ -302,6 +305,21 @@ function getPeriodLabels(majorPeriods: string[]) {
       name: "Time Period",
       value: DISPLAY_TEXT[period] ?? period,
       field: "majorPeriods",
+    }
+  })
+}
+
+function getColorLabels(colors: string[]) {
+  if (!colors?.length) return []
+
+  return colors.map((value) => {
+    const color = COLORS.find((c) => value === c.value)
+    if (!color) throw new Error(`Color not found: ${value}`)
+
+    return {
+      name: "Color",
+      value: color.name,
+      field: "colors",
     }
   })
 }

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -61,6 +61,10 @@ export const resolveSearchCriteriaLabels = async (
     sizes,
     width,
     height,
+    acquireable,
+    atAuction,
+    inquireableOnly,
+    offerable,
   } = parent
 
   const { artistLoader } = context
@@ -73,6 +77,14 @@ export const resolveSearchCriteriaLabels = async (
   labels.push(getPriceLabel(priceRange))
   labels.push(getSizeLabels(sizes))
   labels.push(getCustomSizeLabels({ width, height }))
+  labels.push(
+    getWaysToBuyLabels({
+      acquireable,
+      atAuction,
+      inquireableOnly,
+      offerable,
+    })
+  )
 
   return labels.flat().filter((x) => x !== undefined) as SearchCriteriaLabel[]
 }
@@ -194,6 +206,46 @@ function getCustomSizeLabels({
       field: "height",
     })
   }
+
+  return labels
+}
+
+function getWaysToBuyLabels(waysToBuy: {
+  acquireable: boolean
+  atAuction: boolean
+  inquireableOnly: boolean
+  offerable: boolean
+}) {
+  const { acquireable, atAuction, inquireableOnly, offerable } = waysToBuy
+  const labels: SearchCriteriaLabel[] = []
+
+  if (acquireable)
+    labels.push({
+      name: "Ways to Buy",
+      value: "Buy Now",
+      field: "acquireable",
+    })
+
+  if (atAuction)
+    labels.push({
+      name: "Ways to Buy",
+      value: "Bid",
+      field: "atAuction",
+    })
+
+  if (inquireableOnly)
+    labels.push({
+      name: "Ways to Buy",
+      value: "Inquire",
+      field: "inquireableOnly",
+    })
+
+  if (offerable)
+    labels.push({
+      name: "Ways to Buy",
+      value: "Make Offer",
+      field: "offerable",
+    })
 
   return labels
 }

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -1,6 +1,6 @@
 import { GraphQLNonNull, GraphQLObjectType, GraphQLString } from "graphql"
 import { ResolverContext } from "types/graphql"
-import { startCase } from "lodash"
+import { toTitleCase } from "@artsy/to-title-case"
 
 import allAttributionClasses from "lib/attributionClasses"
 import { COLORS } from "lib/colors"
@@ -174,7 +174,7 @@ function getSizeLabels(sizes: string[]) {
 
   return sizes.map((size) => ({
     name: "Size",
-    value: startCase(size.toLowerCase()), // TODO: this a placeholder, we need to format these properly
+    value: toTitleCase(size.toLowerCase()), // TODO: this a placeholder, we need to format these properly
     field: "sizes",
   }))
 }
@@ -267,7 +267,7 @@ function getMaterialLabels(materialsTerms: string[]) {
   return materialsTerms.map((term) => {
     return {
       name: "Material",
-      value: capitalizeWords(term),
+      value: toTitleCase(term),
       field: "materialsTerms",
     }
   })
@@ -339,8 +339,4 @@ async function getPartnerLabels(partnerIDs: string[], partnerLoader) {
       }
     })
   )
-}
-
-function capitalizeWords(str: string) {
-  return str.replace(/\b([a-z])/g, (_match, p1) => p1.toUpperCase())
 }

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -67,6 +67,7 @@ export const resolveSearchCriteriaLabels = async (
     offerable,
     materialsTerms,
     locationCities,
+    majorPeriods,
   } = parent
 
   const { artistLoader } = context
@@ -89,6 +90,7 @@ export const resolveSearchCriteriaLabels = async (
   )
   labels.push(getMaterialLabels(materialsTerms))
   labels.push(getLocationLabels(locationCities))
+  labels.push(getPeriodLabels(majorPeriods))
 
   return labels.flat().filter((x) => x !== undefined) as SearchCriteriaLabel[]
 }
@@ -274,6 +276,34 @@ function getLocationLabels(locationCities: string[]): SearchCriteriaLabel[] {
     value: city,
     field: "locationCities",
   }))
+}
+
+function getPeriodLabels(majorPeriods: string[]) {
+  if (!majorPeriods?.length) return []
+
+  const DISPLAY_TEXT: Record<string, string> = {
+    "2020": "2020–Today",
+    "2010": "2010–2019",
+    "2000": "2000–2009",
+    "1990": "1990–1999",
+    "1980": "1980–1989",
+    "1970": "1970–1979",
+    "1960": "1960–1969",
+    "1950": "1950–1959",
+    "1940": "1940–1949",
+    "1930": "1930–1939",
+    "1920": "1920–1929",
+    "1910": "1910–1919",
+    "1900": "1900–1909",
+  }
+
+  return majorPeriods.map((period) => {
+    return {
+      name: "Time Period",
+      value: DISPLAY_TEXT[period] ?? period,
+      field: "majorPeriods",
+    }
+  })
 }
 
 function capitalizeWords(str: string) {

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -70,9 +70,10 @@ export const resolveSearchCriteriaLabels = async (
     locationCities,
     majorPeriods,
     colors,
+    partnerIDs,
   } = parent
 
-  const { artistLoader } = context
+  const { artistLoader, partnerLoader } = context
 
   const labels: any[] = []
 
@@ -94,6 +95,7 @@ export const resolveSearchCriteriaLabels = async (
   labels.push(getLocationLabels(locationCities))
   labels.push(getPeriodLabels(majorPeriods))
   labels.push(getColorLabels(colors))
+  labels.push(await getPartnerLabels(partnerIDs, partnerLoader))
 
   return labels.flat().filter((x) => x !== undefined) as SearchCriteriaLabel[]
 }
@@ -322,6 +324,21 @@ function getColorLabels(colors: string[]) {
       field: "colors",
     }
   })
+}
+
+async function getPartnerLabels(partnerIDs: string[], partnerLoader) {
+  if (!partnerIDs?.length) return []
+
+  return Promise.all(
+    partnerIDs.map(async (id) => {
+      const partner = await partnerLoader(id)
+      return {
+        name: "Galleries and Institutions",
+        value: partner.name,
+        field: "partnerIDs",
+      }
+    })
+  )
 }
 
 function capitalizeWords(str: string) {

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -1,4 +1,4 @@
-import { GraphQLObjectType, GraphQLString } from "graphql"
+import { GraphQLNonNull, GraphQLObjectType, GraphQLString } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { startCase } from "lodash"
 
@@ -30,15 +30,15 @@ export const SearchCriteriaLabel = new GraphQLObjectType<
     "Human-friendly representation of a single SearchCriteria filter",
   fields: {
     field: {
-      type: GraphQLString,
+      type: GraphQLNonNull(GraphQLString),
       description: "The GraphQL field name of the filter facet",
     },
     name: {
-      type: GraphQLString,
+      type: GraphQLNonNull(GraphQLString),
       description: "The human-friendly name of the filter facet",
     },
     value: {
-      type: GraphQLString,
+      type: GraphQLNonNull(GraphQLString),
       description: "The human-friendly value of the filter facet",
     },
   },

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -59,6 +59,8 @@ export const resolveSearchCriteriaLabels = async (
     additionalGeneIDs,
     priceRange,
     sizes,
+    width,
+    height,
   } = parent
 
   const { artistLoader } = context
@@ -70,6 +72,7 @@ export const resolveSearchCriteriaLabels = async (
   labels.push(getMediumLabels(additionalGeneIDs))
   labels.push(getPriceLabel(priceRange))
   labels.push(getSizeLabels(sizes))
+  labels.push(getCustomSizeLabels({ width, height }))
 
   return labels.flat().filter((x) => x !== undefined) as SearchCriteriaLabel[]
 }
@@ -151,4 +154,46 @@ function getSizeLabels(sizes: string[]) {
     value: startCase(size.toLowerCase()), // TODO: this a placeholder, we need to format these properly
     field: "sizes",
   }))
+}
+
+function getCustomSizeLabels({
+  height,
+  width,
+}: {
+  height: string
+  width: string
+}) {
+  const labels: SearchCriteriaLabel[] = []
+
+  // TODO: this a placeholder, we need to format these properly
+
+  if (width) {
+    const [wmin, wmax] = width
+      .split(/-/)
+      .map(parseFloat)
+      .map((n) => n * 2.54)
+      .map(Math.round)
+
+    labels.push({
+      name: "Size",
+      value: `w: ${wmin}–${wmax} cm`,
+      field: "width",
+    })
+  }
+
+  if (height) {
+    const [hmin, hmax] = height
+      .split(/-/)
+      .map(parseFloat)
+      .map((n) => n * 2.54)
+      .map(Math.round)
+
+    labels.push({
+      name: "Size",
+      value: `h: ${hmin}–${hmax} cm`,
+      field: "height",
+    })
+  }
+
+  return labels
 }

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -65,6 +65,7 @@ export const resolveSearchCriteriaLabels = async (
     atAuction,
     inquireableOnly,
     offerable,
+    materialsTerms,
   } = parent
 
   const { artistLoader } = context
@@ -85,6 +86,7 @@ export const resolveSearchCriteriaLabels = async (
       offerable,
     })
   )
+  labels.push(getMaterialLabels(materialsTerms))
 
   return labels.flat().filter((x) => x !== undefined) as SearchCriteriaLabel[]
 }
@@ -248,4 +250,20 @@ function getWaysToBuyLabels(waysToBuy: {
     })
 
   return labels
+}
+
+function getMaterialLabels(materialsTerms: string[]) {
+  if (!materialsTerms?.length) return []
+
+  return materialsTerms.map((term) => {
+    return {
+      name: "Material",
+      value: capitalizeWords(term),
+      field: "materialsTerms",
+    }
+  })
+}
+
+function capitalizeWords(str: string) {
+  return str.replace(/\b([a-z])/g, (_match, p1) => p1.toUpperCase())
 }

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -66,6 +66,7 @@ export const resolveSearchCriteriaLabels = async (
     inquireableOnly,
     offerable,
     materialsTerms,
+    locationCities,
   } = parent
 
   const { artistLoader } = context
@@ -87,6 +88,7 @@ export const resolveSearchCriteriaLabels = async (
     })
   )
   labels.push(getMaterialLabels(materialsTerms))
+  labels.push(getLocationLabels(locationCities))
 
   return labels.flat().filter((x) => x !== undefined) as SearchCriteriaLabel[]
 }
@@ -262,6 +264,16 @@ function getMaterialLabels(materialsTerms: string[]) {
       field: "materialsTerms",
     }
   })
+}
+
+function getLocationLabels(locationCities: string[]): SearchCriteriaLabel[] {
+  if (!locationCities?.length) return []
+
+  return locationCities.map((city) => ({
+    name: "Artwork Location",
+    value: city,
+    field: "locationCities",
+  }))
 }
 
 function capitalizeWords(str: string) {

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -52,7 +52,7 @@ export const resolveSearchCriteriaLabels = async (
   context,
   _info
 ) => {
-  const { artistIDs, attributionClass } = parent
+  const { artistIDs, attributionClass, additionalGeneIDs } = parent
 
   const { artistLoader } = context
 
@@ -60,6 +60,7 @@ export const resolveSearchCriteriaLabels = async (
 
   labels.push(await getArtistLabels(artistIDs, artistLoader))
   labels.push(getRarityLabels(attributionClass))
+  labels.push(getMediumLabels(additionalGeneIDs))
 
   return labels.flat().filter((x) => x !== undefined) as SearchCriteriaLabel[]
 }
@@ -86,5 +87,38 @@ function getRarityLabels(attributionClasses: string[]) {
     name: "Rarity",
     value: allAttributionClasses[attributionClass].name,
     field: "attributionClass",
+  }))
+}
+
+function getMediumLabels(additionalGeneIDs: string[]) {
+  if (!additionalGeneIDs?.length) return []
+
+  // Corresponds to the list of options under
+  // the Medium facet on an artwork grid.
+  //
+  // Being a list of genes, this is related to,
+  // but not the same as, the list of artwork medium types.
+
+  const MEDIUM_GENES = {
+    painting: "Painting",
+    photography: "Photography",
+    sculpture: "Sculpture",
+    prints: "Prints",
+    "work-on-paper": "Work on Paper",
+    nft: "NFT",
+    design: "Design",
+    drawing: "Drawing",
+    installation: "Installation",
+    "film-slash-video": "Film/Video",
+    jewelry: "Jewelry",
+    "performance-art": "Performance Art",
+    reproduction: "Reproduction",
+    "ephemera-or-merchandise": "Ephemera or Merchandise",
+  }
+
+  return additionalGeneIDs.map((geneID) => ({
+    name: "Medium",
+    value: MEDIUM_GENES[geneID],
+    field: "additionalGeneIDs",
   }))
 }

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -1,6 +1,8 @@
 import { GraphQLObjectType, GraphQLString } from "graphql"
 import { ResolverContext } from "types/graphql"
 
+import allAttributionClasses from "lib/attributionClasses"
+
 type SearchCriteriaLabel = {
   /** The GraphQL field name of the filter facet */
   field: string
@@ -50,13 +52,14 @@ export const resolveSearchCriteriaLabels = async (
   context,
   _info
 ) => {
-  const { artistIDs } = parent
+  const { artistIDs, attributionClass } = parent
 
   const { artistLoader } = context
 
   const labels: any[] = []
 
   labels.push(await getArtistLabels(artistIDs, artistLoader))
+  labels.push(getRarityLabels(attributionClass))
 
   return labels.flat().filter((x) => x !== undefined) as SearchCriteriaLabel[]
 }
@@ -74,4 +77,14 @@ async function getArtistLabels(artistIDs: string[], artistLoader) {
       }
     })
   )
+}
+
+function getRarityLabels(attributionClasses: string[]) {
+  if (!attributionClasses?.length) return []
+
+  return attributionClasses.map((attributionClass) => ({
+    name: "Rarity",
+    value: allAttributionClasses[attributionClass].name,
+    field: "attributionClass",
+  }))
 }

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -1,0 +1,77 @@
+import { GraphQLObjectType, GraphQLString } from "graphql"
+import { ResolverContext } from "types/graphql"
+
+type SearchCriteriaLabel = {
+  /** The GraphQL field name of the filter facet */
+  field: string
+
+  /** The human-friendly name of the filter facet */
+  name: string
+
+  /** The human-friendly value of the filter facet */
+  value: string
+}
+
+/**
+ * A type, derived here in Metaphysics from the upstream Gravity response,
+ * that represents a SearchCriteria's filter in a human-friendly label,
+ * suitable for use in a pill UI, for example.
+ */
+export const SearchCriteriaLabel = new GraphQLObjectType<
+  SearchCriteriaLabel,
+  ResolverContext
+>({
+  name: "SearchCriteriaLabel",
+  description:
+    "Human-friendly representation of a single SearchCriteria filter",
+  fields: {
+    field: {
+      type: GraphQLString,
+      description: "The GraphQL field name of the filter facet",
+    },
+    name: {
+      type: GraphQLString,
+      description: "The human-friendly name of the filter facet",
+    },
+    value: {
+      type: GraphQLString,
+      description: "The human-friendly value of the filter facet",
+    },
+  },
+})
+
+/**
+ * A resolver that takes the current SearchCriteria and returns a list of
+ * SearchCriteriaLabels representing that SearchCriteria in human-friendly form
+ */
+export const resolveSearchCriteriaLabels = async (
+  parent,
+  _args,
+  context,
+  _info
+) => {
+  const { artistIDs } = parent
+
+  const { artistLoader } = context
+
+  const labels: any[] = []
+
+  labels.push(await getArtistLabels(artistIDs, artistLoader))
+
+  return labels.flat().filter((x) => x !== undefined) as SearchCriteriaLabel[]
+}
+
+async function getArtistLabels(artistIDs: string[], artistLoader) {
+  if (!artistIDs?.length) return []
+
+  return Promise.all(
+    artistIDs.map(async (id) => {
+      const artist = await artistLoader(id)
+      return {
+        name: "Artist",
+        value: artist.name,
+        field: "artistIDs",
+      }
+    })
+  )
+}

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -1,5 +1,6 @@
 import { GraphQLObjectType, GraphQLString } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { startCase } from "lodash"
 
 import allAttributionClasses from "lib/attributionClasses"
 
@@ -52,7 +53,13 @@ export const resolveSearchCriteriaLabels = async (
   context,
   _info
 ) => {
-  const { artistIDs, attributionClass, additionalGeneIDs, priceRange } = parent
+  const {
+    artistIDs,
+    attributionClass,
+    additionalGeneIDs,
+    priceRange,
+    sizes,
+  } = parent
 
   const { artistLoader } = context
 
@@ -62,6 +69,7 @@ export const resolveSearchCriteriaLabels = async (
   labels.push(getRarityLabels(attributionClass))
   labels.push(getMediumLabels(additionalGeneIDs))
   labels.push(getPriceLabel(priceRange))
+  labels.push(getSizeLabels(sizes))
 
   return labels.flat().filter((x) => x !== undefined) as SearchCriteriaLabel[]
 }
@@ -133,4 +141,14 @@ function getPriceLabel(priceRange: string): SearchCriteriaLabel | undefined {
     value: `USD ${min}–${max}`, // TODO: this a placeholder, we need to format these properly
     field: "priceRange",
   }
+}
+
+function getSizeLabels(sizes: string[]) {
+  if (!sizes?.length) return []
+
+  return sizes.map((size) => ({
+    name: "Size",
+    value: startCase(size.toLowerCase()), // TODO: this a placeholder, we need to format these properly
+    field: "sizes",
+  }))
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,6 +26,15 @@
   dependencies:
     dotenv "^10.0.0"
 
+"@artsy/to-title-case@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@artsy/to-title-case/-/to-title-case-1.1.0.tgz#ed22a9d926d88edc7b3833900c6c6cef9d5bc282"
+  integrity sha512-n2GISILNv3X9xVjkUC1thoOl7rVKPeDskobQJsC5G8poFpF4HNxxSJD97NjvCK3Ai1RplSMsN2MCmMAy7plx9Q==
+  dependencies:
+    lodash.deburr "^4.1.0"
+    lodash.isnumber "^3.0.3"
+    lodash.upperfirst "^4.3.1"
+
 "@artsy/update-repo@0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@artsy/update-repo/-/update-repo-0.5.0.tgz#9beb3fb574a2e039e8912fde3309a564e3f8270a"
@@ -6432,6 +6441,11 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
+lodash.deburr@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.deburr/-/lodash.deburr-4.1.0.tgz#ddb1bbb3ef07458c0177ba07de14422cb033ff9b"
+  integrity sha1-3bG7s+8HRYwBd7oH3hRCLLAz/5s=
+
 lodash.find@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
@@ -6540,6 +6554,11 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
+
+lodash.upperfirst@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
+  integrity sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984=
 
 lodash@4.17.21, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5:
   version "4.17.21"


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-3216

Supersedes:  ~https://github.com/artsy/gravity/pull/14926~

This gives Metaphysics the ability to add human-readable search criteria into the `SearchCriteria` response coming from upstream in Gravity.

So, whereas Gravity's GraphQL API might produce a response like this…

<img width="1980" alt="grav" src="https://user-images.githubusercontent.com/140521/153657013-99399ea7-6121-4fa9-9e81-d294639beac2.png">

Metaphysics can now additionally fulfill a new `labels` field on `SearchCriteria`…

<img width="1980" alt="mp" src="https://user-images.githubusercontent.com/140521/153657026-e4f86902-8372-4272-821d-8a8960bfe152.png">

See the first commit (https://github.com/artsy/metaphysics/pull/3762/commits/7fec9bda1e4f078903c1566c95fd61580c596147) where the basic plumbing is laid down. Subsequent commits add the various facets, one at a time.