### PR TITLE
[CX-2343]: Adds consignment submission statuses to artworks

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -991,7 +991,15 @@ describe("Artwork type", () => {
     `
 
     it("returns artwork's submission", () => {
-      artwork.consignmentSubmission = { state: "submitted" }
+      const submissions = [
+        {
+          state: "submitted",
+          my_collection_artwork_id: "richard-prince-untitled-portrait",
+        },
+      ]
+      context.submissionsLoader = sinon
+        .stub()
+        .returns(Promise.resolve(submissions))
 
       return runQuery(query, context).then((data) => {
         expect(data).toEqual({

--- a/src/schema/v2/artwork/__tests__/artworkConsignmentSubmissionType.test.ts
+++ b/src/schema/v2/artwork/__tests__/artworkConsignmentSubmissionType.test.ts
@@ -4,10 +4,14 @@ import sinon from "sinon"
 describe("ArtworkConsignmentSubmissionType", () => {
   const artwork = {
     id: "richard-prince-untitled-portrait",
-    consignmentSubmission: {
-      state: "draft",
-    },
   }
+
+  const consignmentSubmissions = [
+    {
+      state: "draft",
+      my_collection_artwork_id: "richard-prince-untitled-portrait",
+    },
+  ]
 
   let context = {}
 
@@ -17,6 +21,9 @@ describe("ArtworkConsignmentSubmissionType", () => {
         .stub()
         .withArgs(artwork.id)
         .returns(Promise.resolve(artwork)),
+      submissionsLoader: sinon
+        .stub()
+        .returns(Promise.resolve(consignmentSubmissions)),
     }
   })
 
@@ -33,37 +40,69 @@ describe("ArtworkConsignmentSubmissionType", () => {
     `
 
     it("returns correct displayText", async () => {
-      artwork.consignmentSubmission.state = "submitted"
+      consignmentSubmissions[0].state = "submitted"
       let data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.displayText).toEqual(
         "Submission in progress"
       )
 
-      artwork.consignmentSubmission.state = "approved"
+      consignmentSubmissions[0].state = "approved"
       data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.displayText).toEqual(
         "Submission in progress"
       )
 
-      artwork.consignmentSubmission.state = "published"
+      consignmentSubmissions[0].state = "published"
       data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.displayText).toEqual(
         "Submission in progress"
       )
 
-      artwork.consignmentSubmission.state = "rejected"
+      consignmentSubmissions[0].state = "rejected"
       data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.displayText).toEqual(
         "Submission in progress"
       )
 
-      artwork.consignmentSubmission.state = "hold"
+      consignmentSubmissions[0].state = "hold"
       data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.displayText).toEqual(
         "Submission in progress"
       )
 
-      artwork.consignmentSubmission.state = "closed"
+      consignmentSubmissions[0].state = "closed"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.displayText).toEqual(
+        "Submission evaluated"
+      )
+
+      consignmentSubmissions[0].state = "open"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.displayText).toEqual(
+        "Submission in progress"
+      )
+
+      consignmentSubmissions[0].state = "sold"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.displayText).toEqual("Sold")
+
+      consignmentSubmissions[0].state = "bought in"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.displayText).toEqual("Sold")
+
+      consignmentSubmissions[0].state = "canceled"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.displayText).toEqual(
+        "Submission evaluated"
+      )
+
+      consignmentSubmissions[0].state = "withdrawn - pre-launch"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.displayText).toEqual(
+        "Submission evaluated"
+      )
+
+      consignmentSubmissions[0].state = "withdrawn - post-launch"
       data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.displayText).toEqual(
         "Submission evaluated"
@@ -84,27 +123,51 @@ describe("ArtworkConsignmentSubmissionType", () => {
     `
 
     it("returns correct inProgress", async () => {
-      artwork.consignmentSubmission.state = "submitted"
+      consignmentSubmissions[0].state = "submitted"
       let data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.inProgress).toBeTrue()
 
-      artwork.consignmentSubmission.state = "approved"
+      consignmentSubmissions[0].state = "approved"
       data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.inProgress).toBeTrue()
 
-      artwork.consignmentSubmission.state = "published"
+      consignmentSubmissions[0].state = "published"
       data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.inProgress).toBeTrue()
 
-      artwork.consignmentSubmission.state = "rejected"
+      consignmentSubmissions[0].state = "rejected"
       data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.inProgress).toBeFalse()
 
-      artwork.consignmentSubmission.state = "hold"
+      consignmentSubmissions[0].state = "hold"
       data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.inProgress).toBeTrue()
 
-      artwork.consignmentSubmission.state = "closed"
+      consignmentSubmissions[0].state = "closed"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.inProgress).toBeFalse()
+
+      consignmentSubmissions[0].state = "open"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.inProgress).toBeTrue()
+
+      consignmentSubmissions[0].state = "sold"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.inProgress).toBeFalse()
+
+      consignmentSubmissions[0].state = "bought in"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.inProgress).toBeFalse()
+
+      consignmentSubmissions[0].state = "canceled"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.inProgress).toBeFalse()
+
+      consignmentSubmissions[0].state = "withdrawn - pre-launch"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.inProgress).toBeFalse()
+
+      consignmentSubmissions[0].state = "withdrawn - post-launch"
       data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.inProgress).toBeFalse()
     })

--- a/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
+++ b/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
@@ -11,6 +11,9 @@ const ArtworkConsignmentSubmissionType = new GraphQLObjectType<
       displayText: {
         type: GraphQLString,
         resolve: (consignmentSubmission) => {
+          const state =
+            consignmentSubmission.consignment_state ||
+            consignmentSubmission.state
           const statusDisplayTexts = {
             submitted: "Submission in progress",
             approved: "Submission in progress",
@@ -18,14 +21,23 @@ const ArtworkConsignmentSubmissionType = new GraphQLObjectType<
             rejected: "Submission in progress",
             hold: "Submission in progress",
             closed: "Submission evaluated",
+            open: "Submission in progress",
+            sold: "Sold",
+            "bought in": "Sold",
+            canceled: "Submission evaluated",
+            "withdrawn - pre-launch": "Submission evaluated",
+            "withdrawn - post-launch": "Submission evaluated",
           }
 
-          return statusDisplayTexts[consignmentSubmission.state]
+          return statusDisplayTexts[state]
         },
       },
       inProgress: {
         type: GraphQLBoolean,
         resolve: (consignmentSubmission) => {
+          const state =
+            consignmentSubmission.consignment_state ||
+            consignmentSubmission.state
           const inProgressSubmissionStates = [
             "submitted",
             "published",
@@ -34,9 +46,7 @@ const ArtworkConsignmentSubmissionType = new GraphQLObjectType<
             "open",
           ]
 
-          return inProgressSubmissionStates.includes(
-            consignmentSubmission.state
-          )
+          return inProgressSubmissionStates.includes(state)
         },
       },
     }

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -154,6 +154,20 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       },
       consignmentSubmission: {
         type: ArtworkConsignmentSubmissionType,
+        resolve: async ({ id }, _options, { submissionsLoader }) => {
+          if (!submissionsLoader) {
+            return
+          }
+
+          const submissions = await submissionsLoader({ size: 1000 })
+          const filteredSubmissions = submissions.filter(
+            (submission) => submission.state !== "draft"
+          )
+
+          return filteredSubmissions.find((submission) => {
+            return submission.my_collection_artwork_id === id
+          })
+        },
       },
       contactLabel: {
         type: GraphQLString,


### PR DESCRIPTION
Jira: https://artsyproduct.atlassian.net/browse/CX-2343

The task is to add the rest of the statuses from this document: https://www.notion.so/artsy/SWA-My-Collection-integration-8d02370063b444e19036dc19f8e73915#b8d078fc5c064e0592c67da44fd824e8

Another change - now it is possible to query consignmentSubmission directly by artwork:

```
{
        artwork(id: ...) {
		title
		internalID
		consignmentSubmission {
			inProgress
		}
	}
}
```