### PR TITLE
feat(article): corrects author

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -684,7 +684,8 @@ input ARImageInput {
 }
 
 type Article implements Node {
-  author: Author
+  author: Author @deprecated(reason: "Use `byline` or `authors` instead")
+  authors: [Author!]
 
   # The byline for the article. Defaults to "Artsy Editorial" if no authors are present.
   byline: String
@@ -695,6 +696,7 @@ type Article implements Node {
   ): [Article!]!
   channelID: String
   contributingAuthors: [Author]
+    @deprecated(reason: "Use `byline` or `authors` instead")
   description: String
   hero: ArticleHero
   href: String
@@ -2567,6 +2569,7 @@ type Author {
   # A globally unique ID.
   id: ID!
   image: Image
+  initials(length: Int = 3): String
 
   # A type-specific ID.
   internalID: ID!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2562,13 +2562,16 @@ type AuthenticationType {
 }
 
 type Author {
+  bio(format: Format): String
+
   # A globally unique ID.
   id: ID!
+  image: Image
 
   # A type-specific ID.
   internalID: ID!
   name: String
-  profileHandle: String
+  twitterHandle: String
 }
 
 # Backup Two-Factor Authentication factor

--- a/src/lib/loaders/loaders_without_authentication/positron.ts
+++ b/src/lib/loaders/loaders_without_authentication/positron.ts
@@ -7,5 +7,7 @@ export default (opts) => {
   return {
     articlesLoader: positronLoader("articles"),
     articleLoader: positronLoader((id) => `articles/${id}`),
+    authorsLoader: positronLoader("authors"),
+    authorLoader: positronLoader((id) => `authors/${id}`),
   }
 }

--- a/src/schema/v2/article/index.ts
+++ b/src/schema/v2/article/index.ts
@@ -32,8 +32,16 @@ export const ArticleType = new GraphQLObjectType<any, ResolverContext>({
   fields: () => ({
     ...IDFields,
     cached,
+    authors: {
+      type: new GraphQLList(new GraphQLNonNull(AuthorType)),
+      resolve: async ({ author_ids }, _args, { authorsLoader }) => {
+        const { results } = await authorsLoader({ ids: author_ids })
+        return results
+      },
+    },
     author: {
       type: AuthorType,
+      deprecationReason: "Use `byline` or `authors` instead",
       resolve: ({ author }) => author,
     },
     byline: {
@@ -77,6 +85,7 @@ export const ArticleType = new GraphQLObjectType<any, ResolverContext>({
       resolve: ({ channel_id }) => channel_id,
     },
     contributingAuthors: {
+      deprecationReason: "Use `byline` or `authors` instead",
       type: new GraphQLList(AuthorType),
       resolve: ({ contributing_authors }) => contributing_authors,
     },

--- a/src/schema/v2/author.ts
+++ b/src/schema/v2/author.ts
@@ -3,6 +3,7 @@ import { GraphQLString, GraphQLObjectType } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { ImageType } from "./image"
 import { markdown } from "schema/v2/fields/markdown"
+import initials from "schema/v2/fields/initials"
 
 const AuthorType = new GraphQLObjectType<any, ResolverContext>({
   name: "Author",
@@ -11,6 +12,7 @@ const AuthorType = new GraphQLObjectType<any, ResolverContext>({
     name: {
       type: GraphQLString,
     },
+    initials: initials("name"),
     image: {
       type: ImageType,
       resolve: ({ image_url }) => {

--- a/src/schema/v2/author.ts
+++ b/src/schema/v2/author.ts
@@ -1,6 +1,8 @@
 import { IDFields } from "./object_identification"
 import { GraphQLString, GraphQLObjectType } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { ImageType } from "./image"
+import { markdown } from "schema/v2/fields/markdown"
 
 const AuthorType = new GraphQLObjectType<any, ResolverContext>({
   name: "Author",
@@ -9,9 +11,17 @@ const AuthorType = new GraphQLObjectType<any, ResolverContext>({
     name: {
       type: GraphQLString,
     },
-    profileHandle: {
+    image: {
+      type: ImageType,
+      resolve: ({ image_url }) => {
+        if (!image_url) return null
+        return { image_url }
+      },
+    },
+    bio: markdown(({ bio }) => bio),
+    twitterHandle: {
       type: GraphQLString,
-      resolve: ({ profile_handle }) => profile_handle,
+      resolve: ({ twitter_handle }) => twitter_handle,
     },
   },
 })


### PR DESCRIPTION
So I'm deprecating two fields which are the denormalized author data; these have IDs that don't actually match up with what's in the database... they appear to just be some stub sub-objects. The `author_ids` has the correct author data in it. We can still use the denormalized data for the `byline` so this PR just adds the `authors` field and loads those (to get the bio + image) in addition to deprecating the old author fields.