### PR TITLE
feat(article): detect and supports embeds

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -769,6 +769,8 @@ type ArticleEdge {
 }
 
 type ArticleFeatureSection {
+  # Only YouTube and Vimeo are supported
+  embed(autoPlay: Boolean = false): String
   image: Image
   layout: ArticleFeatureSectionType!
   title: String

--- a/src/schema/v2/article/lib/extractEmbed.ts
+++ b/src/schema/v2/article/lib/extractEmbed.ts
@@ -59,3 +59,8 @@ export const extractEmbed = (url: string, options: Options = {}) => {
 
   return `<iframe src="${src}" width="100%" height="100%" frameborder="0" allowfullscreen></iframe>`
 }
+
+export const isEmbed = (url: string) => {
+  const uri = new URL(url)
+  return !(detectProvider(uri) === null)
+}


### PR DESCRIPTION
So, Positron seems to have some layouts that are more or less just implemented via convention in the UI rather than modeled explicitly. In this case: if there's a hero unit in the "basic" layout; then you can have a URL associated with it; that URL isn't an image as in the other layouts; but is an embed.