### PR TITLE
chore(FX-3753): update description for inEditorialFeed field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -941,7 +941,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     before: String
     first: Int
 
-    # Articles that are ready to be publicly viewed in the feed by everyone.
+    # Get only articles with 'standard', 'feature', 'series' or 'video' layouts.
     inEditorialFeed: Boolean
     last: Int
     limit: Int
@@ -6897,7 +6897,7 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
     before: String
     first: Int
 
-    # Articles that are ready to be publicly viewed in the feed by everyone.
+    # Get only articles with 'standard', 'feature', 'series' or 'video' layouts.
     inEditorialFeed: Boolean
     last: Int
     sort: ArticleSorts
@@ -7135,7 +7135,7 @@ type FairOrganizer {
     before: String
     first: Int
 
-    # Articles that are ready to be publicly viewed in the feed by everyone.
+    # Get only articles with with 'standard', 'feature', 'series' or 'video' layouts.
     inEditorialFeed: Boolean
     last: Int
     page: Int
@@ -10018,7 +10018,7 @@ type Partner implements Node {
     before: String
     first: Int
 
-    # Articles that are ready to be publicly viewed in the feed by everyone.
+    # Get only articles with 'standard', 'feature', 'series' or 'video' layouts.
     inEditorialFeed: Boolean
     last: Int
     page: Int
@@ -10948,7 +10948,7 @@ type Query {
     featured: Boolean
     first: Int
 
-    # Articles that are ready to be publicly viewed in the feed by everyone.
+    # Get only articles with 'standard', 'feature', 'series' or 'video' layouts.
     inEditorialFeed: Boolean
     last: Int
     page: Int
@@ -13980,7 +13980,7 @@ type Viewer {
     featured: Boolean
     first: Int
 
-    # Articles that are ready to be publicly viewed in the feed by everyone.
+    # Get only articles with 'standard', 'feature', 'series' or 'video' layouts.
     inEditorialFeed: Boolean
     last: Int
     page: Int

--- a/src/schema/v2/articlesConnection.ts
+++ b/src/schema/v2/articlesConnection.ts
@@ -21,7 +21,7 @@ const ArticlesConnection: GraphQLFieldConfig<void, ResolverContext> = {
     inEditorialFeed: {
       type: GraphQLBoolean,
       description:
-        "Articles that are ready to be publicly viewed in the feed by everyone.",
+        "Get only articles with 'standard', 'feature', 'series' or 'video' layouts.",
     },
     page: { type: GraphQLInt },
     sort: ArticleSorts,

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -115,7 +115,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
           inEditorialFeed: {
             type: GraphQLBoolean,
             description:
-              "Articles that are ready to be publicly viewed in the feed by everyone.",
+              "Get only articles with 'standard', 'feature', 'series' or 'video' layouts.",
           },
         }),
         type: articleConnection.connectionType,

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -478,7 +478,7 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
           inEditorialFeed: {
             type: GraphQLBoolean,
             description:
-              "Articles that are ready to be publicly viewed in the feed by everyone.",
+              "Get only articles with 'standard', 'feature', 'series' or 'video' layouts.",
           },
         }),
         resolve: async ({ _id }, args, { articlesLoader }) => {

--- a/src/schema/v2/fair_organizer.ts
+++ b/src/schema/v2/fair_organizer.ts
@@ -45,7 +45,7 @@ export const FairOrganizerType = new GraphQLObjectType<any, ResolverContext>({
           inEditorialFeed: {
             type: GraphQLBoolean,
             description:
-              "Articles that are ready to be publicly viewed in the feed by everyone.",
+              "Get only articles with with 'standard', 'feature', 'series' or 'video' layouts.",
           },
         }),
         resolve: async (

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -121,7 +121,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           inEditorialFeed: {
             type: GraphQLBoolean,
             description:
-              "Articles that are ready to be publicly viewed in the feed by everyone.",
+              "Get only articles with 'standard', 'feature', 'series' or 'video' layouts.",
           },
         }),
         resolve: async (


### PR DESCRIPTION
Type: **Chore**
Jira ticket: [FX-3753]

### Description
Update description for `inEditorialFeed` field based on artsy/positron#1669 and [this code](https://github.com/artsy/positron/blob/80d34bcc17b47c9d80f95e5a8187565a9e51740b/src/api/apps/articles/model/retrieve.js#L142)

[FX-3753]: https://artsyproduct.atlassian.net/browse/FX-3753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ