### PR TITLE
Fix [CX-2257]: CMS Collector Profile 

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8312,11 +8312,6 @@ type ImageURLs {
 }
 
 type InquirerCollectorProfile {
-  # List of affiliated auction house ids, referencing Galaxy.
-  affiliatedAuctionHouseIds: [String]
-
-  # List of affiliated gallery ids, referencing Galaxy.
-  affiliatedGalleryIds: [String]
   artsyUserSince(
     format: String
 
@@ -8388,9 +8383,6 @@ type InquirerCollectorProfile {
   ): String
   selfReportedPurchases: String
   userInterests: [UserInterest]!
-
-  # Collector's brief introduction
-  userIntroduction: String
 }
 
 union InquiryItemType = Artwork | Show

--- a/src/schema/v2/partnerInquirerCollectorProfile.ts
+++ b/src/schema/v2/partnerInquirerCollectorProfile.ts
@@ -51,7 +51,7 @@ const InquirerCollectorProfileFields: GraphQLFieldConfigMap<
   },
   emailConfirmed: {
     type: GraphQLBoolean,
-    resolve: ({ owner }) => owner.confirmed_at ?? false,
+    resolve: ({ owner }) => !!owner.confirmed_at,
   },
   identityVerified: {
     type: GraphQLBoolean,
@@ -71,20 +71,6 @@ const InquirerCollectorProfileFields: GraphQLFieldConfigMap<
     type: new GraphQLList(CollectorProfileArtists),
     description: "List of artists the Collector is interested in.",
     resolve: ({ collected_artist_names }) => collected_artist_names,
-  },
-  // FIXME: please remove this field after the new collector profile in CMS is in prod for all partners
-  userIntroduction: {
-    type: GraphQLString,
-    description: "Collector's brief introduction",
-    resolve: ({ user_introduction }) => user_introduction?.introduction,
-  },
-  affiliatedAuctionHouseIds: {
-    description: "List of affiliated auction house ids, referencing Galaxy.",
-    type: new GraphQLList(GraphQLString),
-  },
-  affiliatedGalleryIds: {
-    description: "List of affiliated gallery ids, referencing Galaxy.",
-    type: new GraphQLList(GraphQLString),
   },
 }
 


### PR DESCRIPTION
This PR is a follow up to #3747

This PR updates the CMS Collector Profile fields to remove unused fields and fixes the `emailConfirmed` resolver