### PR TITLE
feat[FX-3451]: human-readable size labels for SearchCriteria

### DIFF
--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -189,17 +189,17 @@ describe("resolveSearchCriteriaLabels", () => {
     expect(labels).toIncludeAllMembers([
       {
         name: "Size",
-        value: "Large", // TODO: fix this placeholder formatting
+        value: "Large (over 100cm)",
         field: "sizes",
       },
       {
         name: "Size",
-        value: "Medium", // TODO: fix this placeholder formatting
+        value: "Medium (40 – 100cm)",
         field: "sizes",
       },
       {
         name: "Size",
-        value: "Small", // TODO: fix this placeholder formatting
+        value: "Small (under 40cm)",
         field: "sizes",
       },
     ])

--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -307,7 +307,7 @@ describe("resolveSearchCriteriaLabels", () => {
       expect(labels).toIncludeAllMembers([
         {
           name: "Size",
-          value: "w: from 50 cm",
+          value: "w: to 51 cm",
           field: "width",
         },
         {

--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -205,26 +205,118 @@ describe("resolveSearchCriteriaLabels", () => {
     ])
   })
 
-  it("formats custom size criteria", async () => {
-    const parent = {
-      height: "1-10",
-      width: "2-20",
-    }
+  describe("formatting size criteria", () => {
+    it("handles range with min for height", async () => {
+      const parent = {
+        height: "0.39370078740157477-*",
+      }
 
-    const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+      const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
 
-    expect(labels).toIncludeAllMembers([
-      {
-        name: "Size",
-        value: "w: 5–51 cm", // TODO: fix this placeholder formatting
-        field: "width",
-      },
-      {
-        name: "Size",
-        value: "h: 3–25 cm", // TODO: fix this placeholder formatting
-        field: "height",
-      },
-    ])
+      expect(labels).toIncludeAllMembers([
+        {
+          name: "Size",
+          value: "h: from 1 cm",
+          field: "height",
+        },
+      ])
+    })
+    it("handles range with max for height", async () => {
+      const parent = {
+        height: "*-3.937007874015748",
+      }
+
+      const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+
+      expect(labels).toIncludeAllMembers([
+        {
+          name: "Size",
+          value: "h: to 10 cm",
+          field: "height",
+        },
+      ])
+    })
+    it("handles range with min and max for height", async () => {
+      const parent = {
+        height: "0.39370078740157477-3.937007874015748",
+      }
+
+      const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+
+      expect(labels).toIncludeAllMembers([
+        {
+          name: "Size",
+          value: "h: 1–10 cm",
+          field: "height",
+        },
+      ])
+    })
+    it("handles range with min for width", async () => {
+      const parent = {
+        width: "0.39370078740157477-*",
+      }
+
+      const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+
+      expect(labels).toIncludeAllMembers([
+        {
+          name: "Size",
+          value: "w: from 1 cm",
+          field: "width",
+        },
+      ])
+    })
+    it("handles range with max for width", async () => {
+      const parent = {
+        width: "*-3.937007874015748",
+      }
+
+      const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+
+      expect(labels).toIncludeAllMembers([
+        {
+          name: "Size",
+          value: "w: to 10 cm",
+          field: "width",
+        },
+      ])
+    })
+    it("handles range with min and max for width", async () => {
+      const parent = {
+        width: "0.39370078740157477-3.937007874015748",
+      }
+
+      const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+
+      expect(labels).toIncludeAllMembers([
+        {
+          name: "Size",
+          value: "w: 1–10 cm",
+          field: "width",
+        },
+      ])
+    })
+    it("handles range with min and max for height and width", async () => {
+      const parent = {
+        height: "0.39370078740157477-3.937007874015748",
+        width: "*-20",
+      }
+
+      const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+
+      expect(labels).toIncludeAllMembers([
+        {
+          name: "Size",
+          value: "w: from 50 cm",
+          field: "width",
+        },
+        {
+          name: "Size",
+          value: "h: 1–10 cm",
+          field: "height",
+        },
+      ])
+    })
   })
 
   it("formats ways-to-buy criteria", async () => {

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -12,6 +12,8 @@ export const SIZES = {
   LARGE: "Large (over 100cm)",
 }
 
+const ONE_IN_TO_CM = 2.54
+
 type SearchCriteriaLabel = {
   /** The GraphQL field name of the filter facet */
   field: string
@@ -186,6 +188,32 @@ function getSizeLabels(sizes: string[]) {
   }))
 }
 
+const convertToCentimeters = (element: number) => {
+  return Math.round(element * ONE_IN_TO_CM)
+}
+
+const parseRange = (range = ""): (number | "*")[] => {
+  return range.split("-").map((s) => {
+    if (s === "*") return s
+    return convertToCentimeters(parseFloat(s))
+  })
+}
+
+const extractSizeLabel = (prefix: string, value: string) => {
+  const [min, max] = parseRange(value)
+
+  let label
+  if (max === "*") {
+    label = `from ${min}`
+  } else if (min === "*") {
+    label = `to ${max}`
+  } else {
+    label = `${min}–${max}`
+  }
+
+  return `${prefix}: ${label} cm`
+}
+
 function getCustomSizeLabels({
   height,
   width,
@@ -195,32 +223,18 @@ function getCustomSizeLabels({
 }) {
   const labels: SearchCriteriaLabel[] = []
 
-  // TODO: this a placeholder, we need to format these properly
-
   if (width) {
-    const [wmin, wmax] = width
-      .split(/-/)
-      .map(parseFloat)
-      .map((n) => n * 2.54)
-      .map(Math.round)
-
     labels.push({
       name: "Size",
-      value: `w: ${wmin}–${wmax} cm`,
+      value: extractSizeLabel("w", width),
       field: "width",
     })
   }
 
   if (height) {
-    const [hmin, hmax] = height
-      .split(/-/)
-      .map(parseFloat)
-      .map((n) => n * 2.54)
-      .map(Math.round)
-
     labels.push({
       name: "Size",
-      value: `h: ${hmin}–${hmax} cm`,
+      value: extractSizeLabel("h", height),
       field: "height",
     })
   }

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -5,6 +5,13 @@ import { toTitleCase } from "@artsy/to-title-case"
 import allAttributionClasses from "lib/attributionClasses"
 import { COLORS } from "lib/colors"
 
+// Taken from Force's SizeFilter component
+export const SIZES = {
+  SMALL: "Small (under 40cm)",
+  MEDIUM: "Medium (40 – 100cm)",
+  LARGE: "Large (over 100cm)",
+}
+
 type SearchCriteriaLabel = {
   /** The GraphQL field name of the filter facet */
   field: string
@@ -174,7 +181,7 @@ function getSizeLabels(sizes: string[]) {
 
   return sizes.map((size) => ({
     name: "Size",
-    value: toTitleCase(size.toLowerCase()), // TODO: this a placeholder, we need to format these properly
+    value: SIZES[`${size}`],
     field: "sizes",
   }))
 }


### PR DESCRIPTION
~~WIP: planning to move some of the parsing and formatting of size values to a util package so that they can be shared between Force, Eigen, and Metaphysics, per [this conversation](https://artsy.slack.com/archives/C9SATFLUU/p1645445717561499) on Slack.~~

~~We should also consider if there's any logic for other filter formatting that could be moved to this util! Prices perhaps? Planning on creating that package tomorrow~~

We ended up having more conversations about this and deciding that we want to store in/cm units on SearchCriteria in Gravity, which means we'll need to update this parsing anyway. For now, we'll go with the copy/paste approach to unblock displaying these labels.

Jira ticket: https://artsyproduct.atlassian.net/browse/FX-3451