### PR TITLE
feat(featuredlink): exposes entities

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7296,6 +7296,9 @@ type FeaturedGeneLink {
 
 type FeaturedLink {
   description(format: Format): String
+
+  # Parses the `href` to get the underlying entity
+  entity: FeaturedLinkEntity
   href: String
 
   # A globally unique ID.
@@ -7304,10 +7307,12 @@ type FeaturedLink {
   initials(length: Int = 3): String
 
   # A type-specific ID likely used as a database ID.
-  internalID: String
+  internalID: ID!
   subtitle(format: Format): String
   title: String
 }
+
+union FeaturedLinkEntity = Artist | Gene | Partner
 
 enum FeatureLayouts {
   DEFAULT

--- a/src/schema/v2/featured_link.ts
+++ b/src/schema/v2/featured_link.ts
@@ -1,29 +1,77 @@
 import initials from "./fields/initials"
 import Image from "./image"
-import { GraphQLString, GraphQLObjectType, GraphQLFieldConfig } from "graphql"
+import {
+  GraphQLString,
+  GraphQLObjectType,
+  GraphQLFieldConfig,
+  GraphQLUnionType,
+} from "graphql"
 import { ResolverContext } from "types/graphql"
 import { InternalIDFields } from "./object_identification"
 import { markdown } from "./fields/markdown"
+import { ArtistType } from "./artist"
+import { PartnerType } from "./partner"
+import { GeneType } from "./gene"
+import { URL } from "url"
 
 export const FeaturedLinkType = new GraphQLObjectType<any, ResolverContext>({
   name: "FeaturedLink",
   fields: {
     ...InternalIDFields,
-    internalID: {
-      type: GraphQLString,
-      description: InternalIDFields.internalID.description,
-      resolve: ({ href }) => href.split("/").pop().split("?")[0],
+    entity: {
+      description: "Parses the `href` to get the underlying entity",
+      type: new GraphQLUnionType({
+        name: "FeaturedLinkEntity",
+        types: [ArtistType, PartnerType, GeneType],
+        resolveType: ({ __typename }) => {
+          switch (__typename) {
+            case "Artist":
+              return ArtistType
+            case "Partner":
+              return PartnerType
+            case "Gene":
+              return GeneType
+            default:
+              return null
+          }
+        },
+      }),
+      resolve: async (
+        { href },
+        _args,
+        { artistLoader, partnerLoader, geneLoader }
+      ) => {
+        if (!href) return null
+
+        const uri = new URL(href)
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const [_, kind, slug] = uri.pathname.split("/")
+
+        switch (kind) {
+          case "artist": {
+            const res = await artistLoader(slug)
+            return { __typename: "Artist", ...res }
+          }
+          case "partner": {
+            const res = await partnerLoader(slug)
+            return { __typename: "Partner", ...res }
+          }
+          case "gene": {
+            const res = await geneLoader(slug)
+            return { __typename: "Gene", ...res }
+          }
+          default:
+            return null
+        }
+      },
     },
-    href: {
-      type: GraphQLString,
-    },
+    description: markdown(),
+    href: { type: GraphQLString },
     image: Image,
     initials: initials("title"),
     subtitle: markdown(),
-    description: markdown(),
-    title: {
-      type: GraphQLString,
-    },
+    title: { type: GraphQLString },
   },
 })
 


### PR DESCRIPTION
Adds a proper `entity` union type to the featured link; wherein we try to load the thing that is being linked to.

I'm also removing this crazy `internalID` overwrite that apparently I introduced many, many years ago.