### PR TITLE
fix:fallback to email if user.name is null

### DIFF
--- a/src/schema/v2/__tests__/user.test.ts
+++ b/src/schema/v2/__tests__/user.test.ts
@@ -55,6 +55,35 @@ describe("User", () => {
     expect(user.userAlreadyExists).toEqual(false)
   })
 
+  it("falls back to email for name if name is blank", async () => {
+    const foundUser = {
+      id: "123456",
+      _id: "000012345",
+      name: null,
+      email: "foo@bar.org",
+      pin: "3141",
+      paddle_number: "314159",
+    }
+
+    const userByEmailLoader = (data) => {
+      if (data) {
+        return Promise.resolve(foundUser)
+      }
+      throw new Error("Unexpected invocation")
+    }
+
+    const query = gql`
+      {
+        user(email: "foo@bar.com") {
+          name
+        }
+      }
+    `
+
+    const { user } = await runAuthenticatedQuery(query, { userByEmailLoader })
+    expect(user.name).toEqual("foo@bar.org")
+  })
+
   it("returns push notification settings for a user", async () => {
     const foundUser = {
       id: "123456",

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -19,6 +19,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
     name: {
       description: "The given name of the user.",
       type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ name, email }) => name || email,
     },
     email: {
       description: "The given email of the user.",


### PR DESCRIPTION
Fix for users that were created without names, which is breaking MP queries, since name is supposed to be non-nullable.

https://artsyproduct.atlassian.net/browse/BID-220