### PR TITLE
feat: Artwork recommendations

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8974,6 +8974,15 @@ type Me implements Node {
     last: Int
   ): ArtworkInquiryConnection
 
+  # A connection of artwork recommendations for the current user.
+  artworkRecommendations(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    page: Int
+  ): ArtworkConnection
+
   # A list of the auction results by followed artists
   auctionResultsByFollowedArtists(
     after: String

--- a/src/schema/v2/me/__tests__/artworkRecommendations.test.ts
+++ b/src/schema/v2/me/__tests__/artworkRecommendations.test.ts
@@ -20,9 +20,9 @@ describe("artworkRecommendations", () => {
   `
 
   it("returns artwork recommendations from Vortex", async () => {
-    const vortexGraphqlLoader = jest.fn(() => async () => mockVortexResponse)
+    const vortexGraphqlLoader = jest.fn(() => async () => vortexResponse)
 
-    const artworksLoader = jest.fn(async () => mockArtworksResponse)
+    const artworksLoader = jest.fn(async () => artworksResponse)
 
     const context = {
       meLoader: () => Promise.resolve({}),
@@ -84,7 +84,7 @@ describe("artworkRecommendations", () => {
       },
     }))
 
-    const artworksLoader = jest.fn(async () => mockArtworksResponse)
+    const artworksLoader = jest.fn(async () => artworksResponse)
 
     const context = {
       meLoader: () => Promise.resolve({}),
@@ -108,7 +108,7 @@ describe("artworkRecommendations", () => {
   })
 })
 
-const mockVortexResponse = {
+const vortexResponse = {
   data: {
     artworkRecommendations: {
       totalCount: 2,
@@ -130,17 +130,15 @@ const mockVortexResponse = {
   },
 }
 
-const mockArtworksResponse = {
-  body: [
-    {
-      _id: "608a7416bdfbd1a789ba0911",
-      id: "gerhard-richter-abendstimmung-evening-calm-2",
-      slug: "gerhard-richter-abendstimmung-evening-calm-2",
-    },
-    {
-      _id: "608a7417bdfbd1a789ba092a",
-      id: "pablo-picasso-deux-femmes-nues-dans-un-arbre-2",
-      slug: "pablo-picasso-deux-femmes-nues-dans-un-arbre-2",
-    },
-  ],
-}
+const artworksResponse = [
+  {
+    _id: "608a7416bdfbd1a789ba0911",
+    id: "gerhard-richter-abendstimmung-evening-calm-2",
+    slug: "gerhard-richter-abendstimmung-evening-calm-2",
+  },
+  {
+    _id: "608a7417bdfbd1a789ba092a",
+    id: "pablo-picasso-deux-femmes-nues-dans-un-arbre-2",
+    slug: "pablo-picasso-deux-femmes-nues-dans-un-arbre-2",
+  },
+]

--- a/src/schema/v2/me/__tests__/artworkRecommendations.test.ts
+++ b/src/schema/v2/me/__tests__/artworkRecommendations.test.ts
@@ -1,0 +1,208 @@
+/* eslint-disable promise/always-return */
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("artworkRecommendations", () => {
+  const query = gql`
+    {
+      me {
+        artworkRecommendations(first: 100) {
+          totalCount
+          edges {
+            node {
+              internalID
+              slug
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("returns artwork recommendations from Vortex", async () => {
+    const vortexGraphqlLoader = jest.fn(() => async () => mockVortexResponse)
+
+    const artworksLoader = jest.fn(async () => mockArtworksResponse)
+
+    const context = {
+      meLoader: () => Promise.resolve({}),
+      vortexGraphqlLoader,
+      artworksLoader,
+    }
+
+    const {
+      me: { artworkRecommendations },
+    } = await runAuthenticatedQuery(query, context)
+
+    expect(artworkRecommendations).toMatchInlineSnapshot(`
+      Object {
+        "edges": Array [
+          Object {
+            "node": Object {
+              "internalID": "608a7417bdfbd1a789ba092a",
+              "slug": "1-plus-1-plus-1",
+            },
+          },
+          Object {
+            "node": Object {
+              "internalID": "608a7416bdfbd1a789ba0911",
+              "slug": "banksy",
+            },
+          },
+        ],
+        "totalCount": 2,
+      }
+    `)
+
+    expect(vortexGraphqlLoader).toHaveBeenCalledWith({
+      query: gql`
+        query artworkRecommendationsQuery {
+          artworkRecommendations(first: 50) {
+            totalCount
+            edges {
+              node {
+                artworkId
+                score
+              }
+            }
+          }
+        }
+      `,
+    })
+    expect(artworksLoader).toHaveBeenCalledWith({
+      ids: ["608a7417bdfbd1a789ba092a", "608a7416bdfbd1a789ba0911"],
+    })
+  })
+
+  it("doesn't return artworks if no artwork recommendations are present", async () => {
+    const vortexGraphqlLoader = jest.fn(() => async () => ({
+      data: {
+        artworkRecommendations: {
+          totalCount: 0,
+          edges: [],
+        },
+      },
+    }))
+
+    const artworksLoader = jest.fn(async () => mockArtworksResponse)
+
+    const context = {
+      meLoader: () => Promise.resolve({}),
+      vortexGraphqlLoader,
+      artworksLoader,
+    }
+
+    const {
+      me: { artworkRecommendations },
+    } = await runAuthenticatedQuery(query, context)
+
+    expect(artworkRecommendations).toMatchInlineSnapshot(`
+      Object {
+        "edges": Array [],
+        "totalCount": 0,
+      }
+    `)
+
+    expect(vortexGraphqlLoader).toHaveBeenCalled()
+    expect(artworksLoader).not.toHaveBeenCalled()
+  })
+})
+
+const mockVortexResponse = {
+  data: {
+    artworkRecommendations: {
+      totalCount: 2,
+      edges: [
+        {
+          node: {
+            artworkId: "608a7417bdfbd1a789ba092a",
+            score: 3.422242962512335,
+          },
+        },
+        {
+          node: {
+            artworkId: "608a7416bdfbd1a789ba0911",
+            score: 3.2225049587839654,
+          },
+        },
+      ],
+    },
+  },
+}
+
+const mockArtworksResponse = {
+  body: [
+    {
+      _id: "608a7416bdfbd1a789ba0911",
+      artworks_count: 1,
+      birthday: "",
+      blurb: "",
+      consignable: false,
+      deathday: "",
+      forsale_artworks_count: 0,
+      group_indicator: "individual",
+      id: "banksy",
+      image_url:
+        "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/:version.jpg",
+      image_urls: {
+        square:
+          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/square.jpg",
+        four_thirds:
+          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/four_thirds.jpg",
+        large:
+          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/large.jpg",
+        tall:
+          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/tall.jpg",
+      },
+      image_versions: ["square", "four_thirds", "large", "tall"],
+      medium_known_for: null,
+      name: "1+1+1",
+      nationality: "Swedish Icelandic Finnish",
+      original_height: 5237,
+      original_width: 3491,
+      public: true,
+      published_artworks_count: 0,
+      sortable_id: "banksy",
+      target_supply: false,
+      target_supply_priority: null,
+      target_supply_type: null,
+      years: "",
+    },
+    {
+      _id: "608a7417bdfbd1a789ba092a",
+      artworks_count: 1,
+      birthday: "",
+      blurb: "",
+      consignable: false,
+      deathday: "",
+      forsale_artworks_count: 0,
+      group_indicator: "individual",
+      id: "1-plus-1-plus-1",
+      image_url:
+        "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/:version.jpg",
+      image_urls: {
+        square:
+          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/square.jpg",
+        four_thirds:
+          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/four_thirds.jpg",
+        large:
+          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/large.jpg",
+        tall:
+          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/tall.jpg",
+      },
+      image_versions: ["square", "four_thirds", "large", "tall"],
+      medium_known_for: null,
+      name: "1+1+1",
+      nationality: "Swedish Icelandic Finnish",
+      original_height: 5237,
+      original_width: 3491,
+      public: true,
+      published_artworks_count: 0,
+      sortable_id: "1-plus-1-plus-1",
+      target_supply: false,
+      target_supply_priority: null,
+      target_supply_type: null,
+      years: "",
+    },
+  ],
+}

--- a/src/schema/v2/me/__tests__/artworkRecommendations.test.ts
+++ b/src/schema/v2/me/__tests__/artworkRecommendations.test.ts
@@ -19,7 +19,7 @@ describe("artworkRecommendations", () => {
     }
   `
 
-  it("returns artwork recommendations from Vortex", async () => {
+  it("returns artwork recommendations with order from Vortex", async () => {
     const vortexGraphqlLoader = jest.fn(() => async () => vortexResponse)
 
     const artworksLoader = jest.fn(async () => artworksResponse)

--- a/src/schema/v2/me/__tests__/artworkRecommendations.test.ts
+++ b/src/schema/v2/me/__tests__/artworkRecommendations.test.ts
@@ -40,13 +40,13 @@ describe("artworkRecommendations", () => {
           Object {
             "node": Object {
               "internalID": "608a7417bdfbd1a789ba092a",
-              "slug": "1-plus-1-plus-1",
+              "slug": "pablo-picasso-deux-femmes-nues-dans-un-arbre-2",
             },
           },
           Object {
             "node": Object {
               "internalID": "608a7416bdfbd1a789ba0911",
-              "slug": "banksy",
+              "slug": "gerhard-richter-abendstimmung-evening-calm-2",
             },
           },
         ],
@@ -134,75 +134,13 @@ const mockArtworksResponse = {
   body: [
     {
       _id: "608a7416bdfbd1a789ba0911",
-      artworks_count: 1,
-      birthday: "",
-      blurb: "",
-      consignable: false,
-      deathday: "",
-      forsale_artworks_count: 0,
-      group_indicator: "individual",
-      id: "banksy",
-      image_url:
-        "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/:version.jpg",
-      image_urls: {
-        square:
-          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/square.jpg",
-        four_thirds:
-          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/four_thirds.jpg",
-        large:
-          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/large.jpg",
-        tall:
-          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/tall.jpg",
-      },
-      image_versions: ["square", "four_thirds", "large", "tall"],
-      medium_known_for: null,
-      name: "1+1+1",
-      nationality: "Swedish Icelandic Finnish",
-      original_height: 5237,
-      original_width: 3491,
-      public: true,
-      published_artworks_count: 0,
-      sortable_id: "banksy",
-      target_supply: false,
-      target_supply_priority: null,
-      target_supply_type: null,
-      years: "",
+      id: "gerhard-richter-abendstimmung-evening-calm-2",
+      slug: "gerhard-richter-abendstimmung-evening-calm-2",
     },
     {
       _id: "608a7417bdfbd1a789ba092a",
-      artworks_count: 1,
-      birthday: "",
-      blurb: "",
-      consignable: false,
-      deathday: "",
-      forsale_artworks_count: 0,
-      group_indicator: "individual",
-      id: "1-plus-1-plus-1",
-      image_url:
-        "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/:version.jpg",
-      image_urls: {
-        square:
-          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/square.jpg",
-        four_thirds:
-          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/four_thirds.jpg",
-        large:
-          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/large.jpg",
-        tall:
-          "https://d32dm0rphc51dk.cloudfront.net/jS7hjyXq3OKxNqWZPJeLPg/tall.jpg",
-      },
-      image_versions: ["square", "four_thirds", "large", "tall"],
-      medium_known_for: null,
-      name: "1+1+1",
-      nationality: "Swedish Icelandic Finnish",
-      original_height: 5237,
-      original_width: 3491,
-      public: true,
-      published_artworks_count: 0,
-      sortable_id: "1-plus-1-plus-1",
-      target_supply: false,
-      target_supply_priority: null,
-      target_supply_type: null,
-      years: "",
+      id: "pablo-picasso-deux-femmes-nues-dans-un-arbre-2",
+      slug: "pablo-picasso-deux-femmes-nues-dans-un-arbre-2",
     },
   ],
 }

--- a/src/schema/v2/me/artworkRecommendations.ts
+++ b/src/schema/v2/me/artworkRecommendations.ts
@@ -1,0 +1,85 @@
+import { GraphQLFieldConfig, GraphQLInt } from "graphql"
+import { connectionFromArray } from "graphql-relay"
+import gql from "lib/gql"
+import { convertConnectionArgsToGravityArgs, extractNodes } from "lib/helpers"
+import { compact, find } from "lodash"
+import { CursorPageable, pageable } from "relay-cursor-paging"
+import { createPageCursors } from "schema/v1/fields/pagination"
+import { artworkConnection } from "schema/v2/artwork"
+import { ResolverContext } from "types/graphql"
+
+// This limits the maximum number of artworks we receive from Vortex and is related to how we implement the Connection in this resolver.
+const MAX_ARTWORKS = 50
+
+export const ArtworkRecommendations: GraphQLFieldConfig<
+  void,
+  ResolverContext
+> = {
+  description: "A connection of artwork recommendations for the current user.",
+  type: artworkConnection.connectionType,
+  args: pageable({
+    page: { type: GraphQLInt },
+  }),
+  resolve: async (
+    _root,
+    args: CursorPageable,
+    { vortexGraphqlLoader, artworksLoader }
+  ) => {
+    if (!vortexGraphqlLoader || !artworksLoader) return
+
+    const { page, size } = convertConnectionArgsToGravityArgs(args)
+
+    // Fetch artwork IDs from Vortex
+
+    const vortexResult = await vortexGraphqlLoader({
+      query: gql`
+        query artworkRecommendationsQuery {
+          artworkRecommendations(first: ${MAX_ARTWORKS}) {
+            totalCount
+            edges {
+              node {
+                artworkId
+                score
+              }
+            }
+          }
+        }
+      `,
+    })()
+
+    const artworkRecommendations = extractNodes(
+      vortexResult.data?.artworkRecommendations
+    )
+    const artworkIds = artworkRecommendations.map(
+      (node: any) => node?.artworkId
+    )
+
+    // Fetch artwork details from Gravity
+
+    let artworks: any = []
+
+    if (artworkIds?.length) {
+      artworks = (
+        await artworksLoader({
+          ids: artworkIds,
+        })
+      ).body
+
+      // Apply order from Vortex result (score ASC)
+
+      artworks = compact(
+        artworkIds.map((artworkId) => {
+          return find(artworks, { _id: artworkId })
+        })
+      )
+    }
+
+    const count = artworks.length
+
+    return {
+      totalCount: count,
+      pageCursors: createPageCursors({ ...args, page, size }, count),
+      ...connectionFromArray(artworks, args),
+    }
+  },
+}

--- a/src/schema/v2/me/artworkRecommendations.ts
+++ b/src/schema/v2/me/artworkRecommendations.ts
@@ -56,17 +56,14 @@ export const ArtworkRecommendations: GraphQLFieldConfig<
 
     // Fetch artwork details from Gravity
 
-    let artworks: any = []
+    let artworks: any[] = []
 
     if (artworkIds?.length) {
-      artworks = (
-        await artworksLoader({
-          ids: artworkIds,
-        })
-      ).body
+      artworks = await artworksLoader({
+        ids: artworkIds,
+      })
 
       // Apply order from Vortex result (score ASC)
-
       artworks = compact(
         artworkIds.map((artworkId) => {
           return find(artworks, { _id: artworkId })

--- a/src/schema/v2/me/artworkRecommendations.ts
+++ b/src/schema/v2/me/artworkRecommendations.ts
@@ -29,7 +29,7 @@ export const ArtworkRecommendations: GraphQLFieldConfig<
 
     const { page, size } = convertConnectionArgsToGravityArgs(args)
 
-    // Fetch artwork IDs from Vortex
+    // Fetching artwork IDs from Vortex
 
     const vortexResult = await vortexGraphqlLoader({
       query: gql`
@@ -54,7 +54,7 @@ export const ArtworkRecommendations: GraphQLFieldConfig<
       (node: any) => node?.artworkId
     )
 
-    // Fetch artwork details from Gravity
+    // Fetching artwork details from Gravity
 
     let artworks: any[] = []
 
@@ -63,7 +63,8 @@ export const ArtworkRecommendations: GraphQLFieldConfig<
         ids: artworkIds,
       })
 
-      // Apply order from Vortex result (score ASC)
+      // Applying order from Vortex result (score ASC)
+
       artworks = compact(
         artworkIds.map((artworkId) => {
           return find(artworks, { _id: artworkId })

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -19,6 +19,7 @@ import Image from "../image"
 import { PhoneNumber } from "../phoneNumber"
 import { SaleArtworksConnectionField } from "../sale_artworks"
 import { ArtistRecommendations } from "./artistRecommendations"
+import { ArtworkRecommendations } from "./artworkRecommendations"
 import ArtworkInquiries from "./artwork_inquiries"
 import AuctionResultsByFollowedArtists from "./auction_results_by_followed_artists"
 import { authentications } from "./authentications"
@@ -109,6 +110,7 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
   fields: {
     ...IDFields,
     artistRecommendations: ArtistRecommendations,
+    artworkRecommendations: ArtworkRecommendations,
     artworkInquiriesConnection: ArtworkInquiries,
     auctionResultsByFollowedArtists: AuctionResultsByFollowedArtists,
     authentications: authentications,


### PR DESCRIPTION
Addresses [CX-2371]

## Description

This PR adds the new `artworkRecommendations` connection to `me`. The connection fetches artwork recommendations for the current user from **Vortex** and the artwork details from **Gravity**.

### Query

```graphql
query ArtworkRecommendationsQuery {
  me {
    artworkRecommendations(first: 10) {
      totalCount
      edges {
        node {
          artistId
          score
        }
      }
    }
 }
}
```

[CX-2371]: https://artsyproduct.atlassian.net/browse/CX-2371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ