### PR TITLE
feat(saleArtworksConnection): Add saleSlug input arg

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9142,6 +9142,9 @@ type Me implements Node {
     liveSale: Boolean
     page: Int
     saleID: ID
+
+    # Same as saleID argument, but matches the argument type of `sale(id: 'foo')` root field
+    saleSlug: String
     size: Int
     sort: String
   ): SaleArtworksConnection
@@ -11680,6 +11683,9 @@ type Query {
     liveSale: Boolean
     page: Int
     saleID: ID
+
+    # Same as saleID argument, but matches the argument type of `sale(id: 'foo')` root field
+    saleSlug: String
     size: Int
     sort: String
   ): SaleArtworksConnection
@@ -14529,6 +14535,9 @@ type Viewer {
     liveSale: Boolean
     page: Int
     saleID: ID
+
+    # Same as saleID argument, but matches the argument type of `sale(id: 'foo')` root field
+    saleSlug: String
     size: Int
     sort: String
   ): SaleArtworksConnection

--- a/src/schema/v2/sale_artworks.ts
+++ b/src/schema/v2/sale_artworks.ts
@@ -89,6 +89,11 @@ export const SaleArtworksConnectionField: GraphQLFieldConfig<
     liveSale: { type: GraphQLBoolean },
     page: { type: GraphQLInt },
     saleID: { type: GraphQLID },
+    saleSlug: {
+      description:
+        "Same as saleID argument, but matches the argument type of `sale(id: 'foo')` root field",
+      type: GraphQLString,
+    },
     size: { type: GraphQLInt },
     sort: { type: GraphQLString },
   }),
@@ -105,6 +110,7 @@ export const SaleArtworksConnectionField: GraphQLFieldConfig<
       isAuction,
       liveSale,
       saleID,
+      saleSlug,
       ..._args
     },
     { saleArtworksFilterLoader, saleArtworksAllLoader },
@@ -133,7 +139,7 @@ export const SaleArtworksConnectionField: GraphQLFieldConfig<
       include_artworks_by_followed_artists: includeArtworksByFollowedArtists,
       is_auction: isAuction,
       live_sale: liveSale,
-      sale_id: saleID,
+      sale_id: saleID || saleSlug,
       ..._args,
     }
 


### PR DESCRIPTION
This is a somewhat hacky fix to get around arg type mismatches in Relay, which causes problems as args are often passed down at the top of the app to various parts of the sub tree. 

Since `sale(id: "foo")` expects `String!` one would expect the other field to accept the same too. Not a pleasing situation but not sure what else to do. 