### PR TITLE
fix(bidder-position): Fix error status handling

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2700,6 +2700,7 @@ type BidderPositionResult {
   messageDescriptionMD: String
   messageHeader: String
   position: BidderPosition
+  rawError: String
   status: String!
 }
 

--- a/src/schema/v2/me/__tests__/bidder_position.test.js
+++ b/src/schema/v2/me/__tests__/bidder_position.test.js
@@ -124,7 +124,7 @@ describe("BidderPosition", () => {
         bidderPosition: {
           status: "OUTBID",
           messageHeader: "Your bid wasn’t high enough",
-          messageDescriptionMD: `Another bidder placed a higher max bid\nor the same max bid before you did.`,
+          messageDescriptionMD: `Another bidder placed a higher max bid or the same max bid before you did.`,
           position: {
             processedAt: "2018-04-26T14:15:52+00:00",
           },
@@ -138,7 +138,7 @@ describe("BidderPosition", () => {
         bidderPosition: {
           status: "SALE_CLOSED",
           messageHeader: "Lot closed",
-          messageDescriptionMD: `Sorry, your bid wasn’t received\nbefore the lot closed.`,
+          messageDescriptionMD: `Sorry, your bid wasn’t received before the lot closed.`,
           position: {
             processedAt: "2018-04-26T14:15:52+00:00",
           },

--- a/src/schema/v2/me/bidder_position_messages.ts
+++ b/src/schema/v2/me/bidder_position_messages.ts
@@ -1,59 +1,59 @@
 // the description_md must be a function to delay interpolation of string literal
 
 interface BiddingMessage {
-  id:
+  status:
     | "OUTBID"
     | "RESERVE_NOT_MET"
     | "SALE_CLOSED"
     | "LIVE_BIDDING_STARTED"
     | "BIDDER_NOT_QUALIFIED"
     | "ERROR"
-  gravity_key: string
+  message: string
   header: string
-  description_md: (opts: any) => string
+  getDescription: (props?: { liveAuctionUrl: string }) => string
 }
 
-export const BiddingMessages: BiddingMessage[] = [
+export const bidderPositionMessages: BiddingMessage[] = [
   {
-    id: "OUTBID",
-    gravity_key: "Please enter a bid higher than",
+    status: "OUTBID",
+    message: "Please enter a bid higher than",
     header: "Your bid wasn’t high enough",
-    description_md: () =>
-      `Another bidder placed a higher max bid\nor the same max bid before you did.`,
+    getDescription: () =>
+      `Another bidder placed a higher max bid or the same max bid before you did.`,
   },
   {
-    id: "RESERVE_NOT_MET",
-    gravity_key: "Please enter a bid higher than",
+    status: "RESERVE_NOT_MET",
+    message: "Please enter a bid higher than",
     header: "Your bid wasn’t high enough",
-    description_md: () =>
+    getDescription: () =>
       `Your bid is below the reserve price. Please select a higher bid.`,
   },
   {
-    id: "SALE_CLOSED",
-    gravity_key: "Sale Closed to Bids",
+    status: "SALE_CLOSED",
+    message: "Sale Closed to Bids",
     header: "Lot closed",
-    description_md: () =>
-      "Sorry, your bid wasn’t received\nbefore the lot closed.",
+    getDescription: () =>
+      "Sorry, your bid wasn’t received before the lot closed.",
   },
   {
-    id: "LIVE_BIDDING_STARTED",
-    gravity_key: "Live Bidding has Started",
+    status: "LIVE_BIDDING_STARTED",
+    message: "Live Bidding has Started",
     header: "Live bidding has started",
-    description_md: (params) =>
-      `Sorry, your bid wasn’t received before\nlive bidding started. To continue\nbidding, please [join the live auction](${params.liveAuctionUrl}).`,
+    getDescription: (props) =>
+      `Sorry, your bid wasn’t received before live bidding started. To continue bidding, please [join the live auction](${props?.liveAuctionUrl}).`,
   },
   {
-    id: "BIDDER_NOT_QUALIFIED",
-    gravity_key: "Bidder not qualified to bid on this auction.",
+    status: "BIDDER_NOT_QUALIFIED",
+    message: "Bidder not qualified to bid on this auction.",
     header: "Bid not placed",
-    description_md: () =>
-      `Your bid can’t be placed at this time.\nPlease contact [support@artsy.net](mailto:support@artsy.net) for\nmore information.`,
+    getDescription: () =>
+      `Your bid can't be placed at this time. Please contact [support@artsy.net](mailto:support@artsy.net) for more information.`,
   },
   {
-    id: "ERROR",
-    gravity_key: "unknown error",
+    status: "ERROR",
+    message: "unknown error",
     header: "Bid not placed",
-    description_md: () =>
-      `Your bid can’t be placed at this time.\nPlease contact [support@artsy.net](mailto:support@artsy.net) for\nmore information.`,
+    getDescription: () =>
+      `Your bid can't be placed at this time. Please contact [support@artsy.net](mailto:support@artsy.net) for more information.`,
   },
 ]

--- a/src/schema/v2/types/bidder_position_result.ts
+++ b/src/schema/v2/types/bidder_position_result.ts
@@ -13,14 +13,15 @@ export const BidderPositionResultType = new GraphQLObjectType<
     },
     messageHeader: {
       type: GraphQLString,
-      resolve: ({ message_header }) => message_header,
     },
     messageDescriptionMD: {
       type: GraphQLString,
-      resolve: ({ message_description_md }) => message_description_md,
     },
     position: {
       type: BidderPosition.type,
+    },
+    rawError: {
+      type: GraphQLString,
     },
   }),
 })


### PR DESCRIPTION
This fixes some error handling issues we were seeing with the bidder position. I'm not sure how it worked before, unless we changed the structure of our error response in Gravity? In any case this works:

From grav: 
<img width="411" alt="Screen Shot 2022-02-25 at 11 27 09 AM" src="https://user-images.githubusercontent.com/236943/155794323-509fb476-e790-4717-b097-ab2413310a9c.png">

In MP: 
<img width="689" alt="Screen Shot 2022-02-25 at 12 10 54 PM" src="https://user-images.githubusercontent.com/236943/155794390-a219b61f-6d59-4f54-ade0-be0b6524a702.png">

<img width="655" alt="Screen Shot 2022-02-25 at 12 11 26 PM" src="https://user-images.githubusercontent.com/236943/155794425-a6c38b4e-7cc3-46e7-944a-1c6c310645a5.png">

Additionally, added a new field, `rawError`, which returns the error as it originates from gravity. I have no clue why we aren't using this in the UI? It's quite informative (as one would expect). 

cc @artsy/grow-devs 
 