### PR TITLE
feat: Add cascading_end_time_interval to MP sale type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12034,6 +12034,9 @@ type Sale implements Node {
   # Auction's buyer's premium policy.
   buyersPremium: [BuyersPremium]
   cached: Int
+
+  # Amount of seconds in between each lot closing.
+  cascadingEndTimeInterval: Int
   collectPayments: Boolean!
   coverImage: Image
   currency: String

--- a/src/schema/v2/sale/__tests__/index.test.ts
+++ b/src/schema/v2/sale/__tests__/index.test.ts
@@ -14,6 +14,7 @@ describe("Sale type", () => {
   const sale: any = {
     id: "foo-foo",
     _id: "123",
+    cascading_end_time_interval: 120,
     collect_payments: true,
     currency: "USD",
     is_artsy_licensed: false,

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -169,6 +169,12 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
           }))
         },
       },
+      cascadingEndTimeInterval: {
+        type: GraphQLInt,
+        description: "Amount of seconds in between each lot closing.",
+        resolve: ({ cascading_end_time_interval }) =>
+          cascading_end_time_interval,
+      },
       collectPayments: {
         type: new GraphQLNonNull(GraphQLBoolean),
         resolve: ({ collect_payments }) => !!collect_payments,


### PR DESCRIPTION
[BX-230](https://artsyproduct.atlassian.net/browse/BID-230)

Adding `cascadingEndTimeInterval` to MP so we can access it as a feature flag in Force and Eigen.

MP query in Insomnia hitting local endpoint w/ these changes:
<img width="892" alt="Screen Shot 2022-03-02 at 2 35 29 PM" src="https://user-images.githubusercontent.com/9466631/156436205-92aec9ff-90cb-4e27-bd3b-12afbceca3e1.png">

