### PR TITLE
Remove unused Codecov orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@3.2.2
   hokusai: artsy/hokusai@0.10.0
   horizon: artsy/release@0.0.1
   node: circleci/node@4.9.0


### PR DESCRIPTION
Similar to https://github.com/artsy/force/pull/9533, this PR removes the unused Codecov orb.

