### PR TITLE
chore: Add end at to saleArtwork

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12173,6 +12173,14 @@ type SaleArtwork implements ArtworkEdgeInterface & Node {
   currency: String
   currentBid: SaleArtworkCurrentBid
   cursor: String
+  endAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See
+    # http://www.iana.org/time-zones,
+    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
   estimate: String
 
   # Singular estimate field, if specified

--- a/src/schema/v2/sale_artwork.ts
+++ b/src/schema/v2/sale_artwork.ts
@@ -1,7 +1,7 @@
 import { isExisty } from "lib/helpers"
 import { assign, compact, get } from "lodash"
 import cached from "./fields/cached"
-import date from "./fields/date"
+import { date } from "./fields/date"
 import money, { amount } from "./fields/money"
 import { formatMoney } from "accounting"
 import numeral from "./fields/numeral"
@@ -123,6 +123,7 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
             saleArtwork.display_opening_bid_dollars,
         }),
       }),
+      endAt: date(({ end_at }) => end_at),
       estimate: {
         type: GraphQLString,
         resolve: ({
@@ -154,7 +155,7 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: new GraphQLObjectType<any, ResolverContext>({
           name: "SaleArtworkHighestBid",
           fields: {
-            createdAt: date,
+            createdAt: date(),
             isCancelled: {
               type: GraphQLBoolean,
               resolve: ({ cancelled }) => cancelled,


### PR DESCRIPTION
Adding `end_at` to the `SaleArtwork` type in Metaphysics:

Query running locally:
<img width="833" alt="Screen Shot 2022-03-03 at 11 21 23 AM" src="https://user-images.githubusercontent.com/9466631/156606609-4a3d770e-18ea-4654-afa4-47badb8246d2.png">

