### PR TITLE
feat(alerts): add support for new colors

### DIFF
--- a/src/lib/colors.ts
+++ b/src/lib/colors.ts
@@ -1,4 +1,5 @@
-export const COLORS = [
+// TODO: delete after all artworks are reindexed to use new colors only
+export const OLD_COLORS = [
   {
     value: "black-and-white",
     name: "Black and White",
@@ -76,5 +77,62 @@ export const COLORS = [
     name: "Dark Green",
     backgroundColor: "#004600",
     foregroundColor: "#fff",
+  },
+]
+
+export const COLORS = [
+  {
+    value: "red",
+    name: "Red",
+    backgroundColor: "#BB392D",
+    foregroundColor: "#fff",
+  },
+  {
+    value: "orange",
+    name: "Orange",
+    backgroundColor: "#EA6B1F",
+    foregroundColor: "#000",
+  },
+  {
+    value: "yellow",
+    name: "Yellow",
+    backgroundColor: "#E2B929",
+    foregroundColor: "#000",
+  },
+  {
+    value: "green",
+    name: "Green",
+    backgroundColor: "#00674A",
+    foregroundColor: "#fff",
+  },
+  {
+    value: "blue",
+    name: "Blue",
+    backgroundColor: "#0A1AB4",
+    foregroundColor: "#fff",
+  },
+  {
+    value: "purple",
+    name: "Purple",
+    backgroundColor: "#7B3D91",
+    foregroundColor: "#fff",
+  },
+  {
+    value: "black-and-white",
+    name: "Black and White",
+    backgroundColor: "#000",
+    foregroundColor: "#f00",
+  },
+  {
+    value: "gray",
+    name: "Gray",
+    backgroundColor: "#C2C2C2",
+    foregroundColor: "#000",
+  },
+  {
+    value: "pink",
+    name: "Pink",
+    backgroundColor: "#E1ADCD",
+    foregroundColor: "#000",
   },
 ]

--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -455,7 +455,7 @@ describe("resolveSearchCriteriaLabels", () => {
 
   it("formats color criteria", async () => {
     const parent = {
-      colors: ["lightblue", "yellow"],
+      colors: ["blue", "yellow"],
     }
 
     const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
@@ -463,7 +463,7 @@ describe("resolveSearchCriteriaLabels", () => {
     expect(labels).toIncludeAllMembers([
       {
         name: "Color",
-        value: "Light Blue",
+        value: "Blue",
         field: "colors",
       },
       {

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -3,7 +3,7 @@ import { ResolverContext } from "types/graphql"
 import { toTitleCase } from "@artsy/to-title-case"
 
 import allAttributionClasses from "lib/attributionClasses"
-import { COLORS } from "lib/colors"
+import { COLORS, OLD_COLORS } from "lib/colors"
 
 // Taken from Force's SizeFilter component
 export const SIZES = {
@@ -349,7 +349,7 @@ function getColorLabels(colors: string[]) {
   if (!colors?.length) return []
 
   return colors.map((value) => {
-    const color = COLORS.find((c) => value === c.value)
+    const color = [...COLORS, ...OLD_COLORS].find((c) => value === c.value)
     if (!color) throw new Error(`Color not found: ${value}`)
 
     return {


### PR DESCRIPTION
# Description 

Follow-up on https://github.com/artsy/metaphysics/pull/3762

- Adds new colors and keeps old ones as `OLD_COLORS`

more context on this [slack thread](https://artsy.slack.com/archives/C9SATFLUU/p1646316037871739)