### PR TITLE
feature: SSL Termination

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,11 +78,6 @@ xapp.init(xappConfig, (_unused, token) => {
 }) // eslint-disable-line
 
 function bootApp() {
-  if (PRODUCTION_ENV) {
-    app.set("forceSSLOptions", { trustXFPHeader: true }).use(forceSSL)
-    app.set("trust proxy", 1)
-  }
-
   if (IP_DENYLIST) {
     app.use(
       ipfilter(IP_DENYLIST.split(","), {


### PR DESCRIPTION
This change removes the built in ssl enforcement added back when
communication was done over the web.

By removing ssl enforcement here we can leverage standard http
connections for internal communication on the overlay network while
ensuring that all public connections are using ssl at the ingress
controller.

This is also necessary to simplify running the full artsy stack locally.

See conversation here: [secure link](https://artsy.slack.com/archives/CA8SANW3W/p1646325030995449)