### PR TITLE
feat: Add isP1 field to artist target supply

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1526,6 +1526,9 @@ type ArtistTargetSupply {
   # True if an artist is in the microfunnel list.
   isInMicrofunnel: Boolean
 
+  # True if an artist is a P1 artist.
+  isP1: Boolean
+
   # True if artist is in target supply list.
   isTargetSupply: Boolean
   microfunnel: ArtistTargetSupplyMicrofunnel

--- a/src/schema/v2/artist/targetSupply/__tests__/index.test.ts
+++ b/src/schema/v2/artist/targetSupply/__tests__/index.test.ts
@@ -57,6 +57,7 @@ describe("ArtistTargetSupply", () => {
       const response = await runQuery(query, context)
       expect(response.artist.targetSupply.isP1).toEqual(false)
     })
+
     it("returns false if target_supply_priority is null", async () => {
       targetSupplyPriority = null
       const response = await runQuery(query, context)

--- a/src/schema/v2/artist/targetSupply/__tests__/index.test.ts
+++ b/src/schema/v2/artist/targetSupply/__tests__/index.test.ts
@@ -24,6 +24,46 @@ describe("ArtistTargetSupply", () => {
       expect(response.artist.targetSupply.isTargetSupply).toEqual(true)
     })
   })
+
+  describe("isP1", () => {
+    let targetSupplyPriority: number | null
+
+    const query = `
+      {
+        artist(id:"andy-warhol") {
+          targetSupply {
+            isP1
+          }
+        }
+      }
+    `
+    const context = {
+      artistLoader: () => {
+        return Promise.resolve({
+          id: "andy-warhol",
+          target_supply_priority: targetSupplyPriority,
+        })
+      },
+    }
+
+    it("returns true if target_supply_priority is 1", async () => {
+      targetSupplyPriority = 1
+      const response = await runQuery(query, context)
+      expect(response.artist.targetSupply.isP1).toEqual(true)
+    })
+
+    it("returns false if target_supply_priority is 2", async () => {
+      targetSupplyPriority = 2
+      const response = await runQuery(query, context)
+      expect(response.artist.targetSupply.isP1).toEqual(false)
+    })
+    it("returns false if target_supply_priority is null", async () => {
+      targetSupplyPriority = null
+      const response = await runQuery(query, context)
+      expect(response.artist.targetSupply.isP1).toEqual(false)
+    })
+  })
+
   describe("isInMicrofunnel", () => {
     it("returns false if artist not in microfunnel", async () => {
       const query = `

--- a/src/schema/v2/artist/targetSupply/index.ts
+++ b/src/schema/v2/artist/targetSupply/index.ts
@@ -1,9 +1,8 @@
-import { ResolverContext } from "types/graphql"
-import { getArtistMicrofunnelMetadata } from "./utils/getMicrofunnelData"
-
-import { GraphQLObjectType, GraphQLBoolean, GraphQLFieldConfig } from "graphql"
+import { GraphQLBoolean, GraphQLFieldConfig, GraphQLObjectType } from "graphql"
 import { getRecentlySoldArtworksConnection } from "schema/v2/types/targetSupply/recentlySoldArtworksConnection"
 import { TargetSupplyMicrofunnelMetadata } from "schema/v2/types/targetSupply/targetSupplyMicrofunnelMetadata"
+import { ResolverContext } from "types/graphql"
+import { getArtistMicrofunnelMetadata } from "./utils/getMicrofunnelData"
 
 const ArtistTargetSupplyType = new GraphQLObjectType<any, ResolverContext>({
   name: "ArtistTargetSupply",
@@ -12,6 +11,11 @@ const ArtistTargetSupplyType = new GraphQLObjectType<any, ResolverContext>({
       description: "True if artist is in target supply list.",
       type: GraphQLBoolean,
       resolve: (artist) => artist.target_supply,
+    },
+    isP1: {
+      description: "True if an artist is a P1 artist.",
+      type: GraphQLBoolean,
+      resolve: (artist) => artist.target_supply_priority === 1,
     },
     isInMicrofunnel: {
       description: "True if an artist is in the microfunnel list.",


### PR DESCRIPTION
Addresses [CX-2351]

## Description

Adds isP1 field to artist target supply.

This comment explains the data model in Gravity: [FX-3023: Enable admins to update artists' Target Supply Status from admin.artsy.net UIDONE](https://artsyproduct.atlassian.net/browse/FX-3023?focusedCommentId=39537)

[CX-2351]: https://artsyproduct.atlassian.net/browse/CX-2351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ