### PR TITLE
feat: Increase number of considered artists for AuctionResultsByFollowedArtists to 200

### DIFF
--- a/src/schema/v2/me/auction_results_by_followed_artists.ts
+++ b/src/schema/v2/me/auction_results_by_followed_artists.ts
@@ -1,21 +1,21 @@
 import {
-  GraphQLFieldConfig,
   GraphQLBoolean,
-  GraphQLString,
-  GraphQLList,
+  GraphQLFieldConfig,
   GraphQLInt,
+  GraphQLList,
+  GraphQLString,
 } from "graphql"
-import { pageable } from "relay-cursor-paging"
-import { params } from "schema/v1/home/add_generic_genes"
-import { ResolverContext } from "types/graphql"
-import { auctionResultConnection, AuctionResultSorts } from "../auction_result"
+import { connectionFromArraySlice } from "graphql-relay"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { compact, merge } from "lodash"
+import { pageable } from "relay-cursor-paging"
+import { params } from "schema/v1/home/add_generic_genes"
 import { createPageCursors } from "schema/v2/fields/pagination"
-import { connectionFromArraySlice } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
 import ArtworkSizes from "../artwork/artworkSizes"
+import { auctionResultConnection, AuctionResultSorts } from "../auction_result"
 
-const MAX_FOLLOWED_ARTISTS = 50
+const MAX_FOLLOWED_ARTISTS = 100
 
 const AuctionResultsByFollowedArtists: GraphQLFieldConfig<
   void,

--- a/src/schema/v2/me/auction_results_by_followed_artists.ts
+++ b/src/schema/v2/me/auction_results_by_followed_artists.ts
@@ -15,7 +15,7 @@ import { ResolverContext } from "types/graphql"
 import ArtworkSizes from "../artwork/artworkSizes"
 import { auctionResultConnection, AuctionResultSorts } from "../auction_result"
 
-const MAX_FOLLOWED_ARTISTS = 100
+const MAX_FOLLOWED_ARTISTS_PER_STEP = 100
 const MAX_STEPS = 2
 
 const AuctionResultsByFollowedArtists: GraphQLFieldConfig<
@@ -71,7 +71,7 @@ const AuctionResultsByFollowedArtists: GraphQLFieldConfig<
       // Since we cannot query more than 100  artists at a time, we have to do this in several steps.
       for (let step = 0; step < MAX_STEPS; step++) {
         const gravityArgs = {
-          size: MAX_FOLLOWED_ARTISTS,
+          size: MAX_FOLLOWED_ARTISTS_PER_STEP,
           offset: step,
           total_count: false,
           ...params,
@@ -80,7 +80,7 @@ const AuctionResultsByFollowedArtists: GraphQLFieldConfig<
 
         followedArtists = [...followedArtists, ...body]
 
-        if (body.followedArtists < MAX_FOLLOWED_ARTISTS) {
+        if (body.followedArtists < MAX_FOLLOWED_ARTISTS_PER_STEP) {
           break
         }
       }


### PR DESCRIPTION
Addresses [CX-2423]

## Description

This PR increases the number of considered followed artists for AuctionResultsByFollowedArtists from 50 to 200.

This change will affect the performance of the query for users with more than 100 followed artists slightly which is expected.

[CX-2423]: https://artsyproduct.atlassian.net/browse/CX-2423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ