### PR TITLE
feat: Add formattedStartDateTime to MP

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12311,6 +12311,9 @@ type SaleArtwork implements ArtworkEdgeInterface & Node {
 
   # Singular estimate field, if specified
   estimateCents: Int
+
+  # A formatted description of when the lot starts or ends or if it has ended
+  formattedStartDateTime: String
   highestBid: SaleArtworkHighestBid
   highEstimate: SaleArtworkHighEstimate
 

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -267,22 +267,23 @@ export function cascadingFormattedStartDateTime(
  * Ended Apr 3 2017
  */
 export function formattedStartDateTime(startAt, endAt, liveStartAt, timezone) {
-  const thisMoment = moment.tz(moment(), timezone)
-  const startMoment = moment.tz(startAt, timezone)
-  const endMoment = moment.tz(endAt, timezone)
-  const liveStartMoment = moment.tz(liveStartAt, timezone)
+  const tz = timezone || DEFAULT_TZ
+  const thisMoment = moment.tz(moment(), tz)
+  const startMoment = moment.tz(startAt, tz)
+  const endMoment = moment.tz(endAt, tz)
+  const liveStartMoment = moment.tz(liveStartAt, tz)
 
   if (thisMoment.isBefore(startMoment)) {
-    return `Starts ${singleDateTime(startAt, timezone)}`
+    return `Starts ${singleDateTime(startAt, tz)}`
   }
 
   if (thisMoment.isAfter(endMoment)) {
-    return `Ended ${singleDate(endAt, timezone)}`
+    return `Ended ${singleDate(endAt, tz)}`
   }
 
   if (liveStartAt) {
     if (thisMoment.isBefore(liveStartMoment)) {
-      return `Live ${singleDateTime(liveStartAt, timezone)}`
+      return `Live ${singleDateTime(liveStartAt, tz)}`
     } else if (
       thisMoment.isAfter(liveStartMoment) &&
       (thisMoment.isBefore(endMoment) || !endAt)
@@ -290,7 +291,7 @@ export function formattedStartDateTime(startAt, endAt, liveStartAt, timezone) {
       return `In progress`
     }
   } else if (thisMoment.isBefore(endMoment)) {
-    return `Ends ${singleDateTime(endAt, timezone)}`
+    return `Ends ${singleDateTime(endAt, tz)}`
   } else {
     return null
   }

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,5 +1,7 @@
 import moment from "moment-timezone"
 
+export const DEFAULT_TZ = "UTC"
+
 /**
  * Returns true if dates are on same day, timezone must be the same for both timestamps
  */

--- a/src/schema/v2/__tests__/sale_artwork.test.js
+++ b/src/schema/v2/__tests__/sale_artwork.test.js
@@ -25,8 +25,6 @@ describe("SaleArtwork type", () => {
     reserve_status: "reserve_met",
     currency: "EUR",
     symbol: "€",
-    end_at: "2022-03-08T04:00:00+00:00",
-    ended_at: "2022-03-08T04:00:03+00:00",
   }
 
   const execute = async (
@@ -534,7 +532,97 @@ describe("SaleArtwork type", () => {
     })
   })
 
+  describe("formattedStartDateTime", () => {
+    const query = gql`
+      {
+        node(id: "${toGlobalId("SaleArtwork", "54c7ed2a7261692bfa910200")}") {
+          ... on SaleArtwork {
+            formattedStartDateTime
+          }
+        }
+      }
+    `
+
+    const context = {
+      saleLoader: () => {
+        return Promise.resolve({ start_at: "2019-02-17T11:00:00+00:00" })
+      },
+    }
+
+    it("returns 'Starts date/time' when the sale's start time is in the future", async () => {
+      const context = {
+        saleLoader: () => {
+          return Promise.resolve({ start_at: "2029-02-17T11:00:00+00:00" })
+        },
+      }
+      saleArtwork.ended_at = null
+      saleArtwork.end_at = "2029-02-19T11:00:00+00:00"
+
+      expect(await execute(query, saleArtwork, context)).toEqual({
+        node: {
+          formattedStartDateTime: "Starts Feb 17, 2029 at 11:00am UTC",
+        },
+      })
+    })
+
+    it("returns 'Ends date/time' when the sale has started and the lot's close time is in the future", async () => {
+      saleArtwork.ended_at = null
+      saleArtwork.end_at = "2029-02-17T11:00:00+00:00"
+
+      expect(await execute(query, saleArtwork, context)).toEqual({
+        node: {
+          formattedStartDateTime: "Ends Feb 17, 2029 at 11:00am UTC",
+        },
+      })
+    })
+
+    it("returns 'Ended date/time' when the sale has started and the lot's end_at time has passed", async () => {
+      saleArtwork.ended_at = null
+      saleArtwork.end_at = "2020-02-17T11:00:00+00:00"
+
+      expect(await execute(query, saleArtwork, context)).toEqual({
+        node: {
+          formattedStartDateTime: "Ended Feb 17, 2020",
+        },
+      })
+    })
+
+    it("returns 'Ended date/time' when the sale has started and the lot's ended_at time has passed", async () => {
+      saleArtwork.ended_at = "2019-02-17T11:00:00+00:00"
+      saleArtwork.end_at = "2020-02-17T11:00:00+00:00"
+
+      expect(await execute(query, saleArtwork, context)).toEqual({
+        node: {
+          formattedStartDateTime: "Ended Feb 17, 2019",
+        },
+      })
+    })
+
+    it("returns 'Ended date/time' when the sale has started and the sale's end_at time has passed", async () => {
+      saleArtwork.ended_at = null
+      saleArtwork.end_at = null
+
+      const context = {
+        saleLoader: () => {
+          return Promise.resolve({
+            start_at: "2019-02-17T11:00:00+00:00",
+            end_at: "2020-02-17T11:00:00+00:00",
+          })
+        },
+      }
+
+      expect(await execute(query, saleArtwork, context)).toEqual({
+        node: {
+          formattedStartDateTime: "Ended Feb 17, 2020",
+        },
+      })
+    })
+  })
+
   it("formats dates correctly", async () => {
+    saleArtwork.end_at = "2022-03-08T04:00:00+00:00"
+    saleArtwork.ended_at = "2022-03-08T04:00:03+00:00"
+
     const query = gql`
       {
         node(id: "${toGlobalId("SaleArtwork", "54c7ed2a7261692bfa910200")}") {

--- a/src/schema/v2/__tests__/sale_artwork.test.js
+++ b/src/schema/v2/__tests__/sale_artwork.test.js
@@ -545,14 +545,20 @@ describe("SaleArtwork type", () => {
 
     const context = {
       saleLoader: () => {
-        return Promise.resolve({ start_at: "2019-02-17T11:00:00+00:00" })
+        return Promise.resolve({
+          start_at: "2019-02-17T11:00:00+00:00",
+          cascading_end_time_interval: 120,
+        })
       },
     }
 
     it("returns 'Starts date/time' when the sale's start time is in the future", async () => {
       const context = {
         saleLoader: () => {
-          return Promise.resolve({ start_at: "2029-02-17T11:00:00+00:00" })
+          return Promise.resolve({
+            start_at: "2029-02-17T11:00:00+00:00",
+            cascading_end_time_interval: 120,
+          })
         },
       }
       saleArtwork.ended_at = null
@@ -594,6 +600,22 @@ describe("SaleArtwork type", () => {
       expect(await execute(query, saleArtwork, context)).toEqual({
         node: {
           formattedStartDateTime: "Ended Feb 17, 2019",
+        },
+      })
+    })
+
+    it("returns null if cascading_end_time_interval is not present on the sale", async () => {
+      const context = {
+        saleLoader: () => {
+          return Promise.resolve({
+            start_at: "2020-02-17T11:00:00+00:00",
+          })
+        },
+      }
+
+      expect(await execute(query, saleArtwork, context)).toEqual({
+        node: {
+          formattedStartDateTime: null,
         },
       })
     })

--- a/src/schema/v2/__tests__/sale_artwork.test.js
+++ b/src/schema/v2/__tests__/sale_artwork.test.js
@@ -597,26 +597,6 @@ describe("SaleArtwork type", () => {
         },
       })
     })
-
-    it("returns 'Ended date/time' when the sale has started and the sale's end_at time has passed", async () => {
-      saleArtwork.ended_at = null
-      saleArtwork.end_at = null
-
-      const context = {
-        saleLoader: () => {
-          return Promise.resolve({
-            start_at: "2019-02-17T11:00:00+00:00",
-            end_at: "2020-02-17T11:00:00+00:00",
-          })
-        },
-      }
-
-      expect(await execute(query, saleArtwork, context)).toEqual({
-        node: {
-          formattedStartDateTime: "Ended Feb 17, 2020",
-        },
-      })
-    })
   })
 
   it("formats dates correctly", async () => {

--- a/src/schema/v2/sale/__tests__/index.test.ts
+++ b/src/schema/v2/sale/__tests__/index.test.ts
@@ -746,7 +746,6 @@ describe("Sale type", () => {
             },
             {
               meBiddersLoader: () => Promise.resolve(bidders),
-              defaultTimezone: "UTC",
             }
           )
         })

--- a/src/schema/v2/sale/__tests__/index.test.ts
+++ b/src/schema/v2/sale/__tests__/index.test.ts
@@ -744,7 +744,10 @@ describe("Sale type", () => {
               is_auction: true,
               ...(input as any),
             },
-            { meBiddersLoader: () => Promise.resolve(bidders) }
+            {
+              meBiddersLoader: () => Promise.resolve(bidders),
+              defaultTimezone: "UTC",
+            }
           )
         })
       )

--- a/src/schema/v2/sale/display.ts
+++ b/src/schema/v2/sale/display.ts
@@ -1,6 +1,5 @@
 import moment from "moment-timezone"
 import { defineCustomLocale } from "lib/helpers"
-import { DEFAULT_TZ } from "lib/date"
 
 const LocaleEnAuctionRelative = "en-auction-relative"
 defineCustomLocale(LocaleEnAuctionRelative, {
@@ -58,7 +57,7 @@ export async function displayTimelyAt({ sale, meBiddersLoader, timeZone }) {
       const diff = moment().diff(moment(registration_ends_at), "hours")
       const format = diff > -24 ? "ha" : "MMM D, ha"
       const label = `register by\n${moment(registration_ends_at)
-        .tz(timeZone || DEFAULT_TZ)
+        .tz(timeZone)
         .locale(LocaleEnAuctionRelative)
         .format(format)}`
       return label

--- a/src/schema/v2/sale/display.ts
+++ b/src/schema/v2/sale/display.ts
@@ -1,5 +1,6 @@
 import moment from "moment-timezone"
 import { defineCustomLocale } from "lib/helpers"
+import { DEFAULT_TZ } from "lib/date"
 
 const LocaleEnAuctionRelative = "en-auction-relative"
 defineCustomLocale(LocaleEnAuctionRelative, {
@@ -57,7 +58,7 @@ export async function displayTimelyAt({ sale, meBiddersLoader, timeZone }) {
       const diff = moment().diff(moment(registration_ends_at), "hours")
       const format = diff > -24 ? "ha" : "MMM D, ha"
       const label = `register by\n${moment(registration_ends_at)
-        .tz(timeZone)
+        .tz(timeZone || DEFAULT_TZ)
         .locale(LocaleEnAuctionRelative)
         .format(format)}`
       return label

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -45,8 +45,6 @@ import { markdown } from "../fields/markdown"
 
 const { PREDICTION_ENDPOINT } = config
 
-const DEFAULT_TZ = "UTC"
-
 const BidIncrement = new GraphQLObjectType<any, ResolverContext>({
   name: "BidIncrement",
   fields: {
@@ -188,8 +186,6 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
       displayTimelyAt: {
         type: GraphQLString,
         resolve: (sale, _options, { meBiddersLoader, defaultTimezone }) => {
-          const DEFAULT_TZ = "UTC"
-
           return displayTimelyAt({
             sale,
             meBiddersLoader,

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -189,7 +189,7 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
           return displayTimelyAt({
             sale,
             meBiddersLoader,
-            timeZone: defaultTimezone || DEFAULT_TZ,
+            timeZone: defaultTimezone,
           })
         },
       },
@@ -221,14 +221,14 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
               start_at,
               end_at,
               ended_at,
-              defaultTimezone || DEFAULT_TZ
+              defaultTimezone
             )
           } else {
             return formattedStartDateTime(
               start_at,
               ended_at || end_at,
               live_start_at,
-              defaultTimezone || DEFAULT_TZ
+              defaultTimezone
             )
           }
         },

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -12,6 +12,7 @@ import { SlugAndInternalIDFields } from "schema/v2/object_identification"
 import {
   formattedStartDateTime,
   cascadingFormattedStartDateTime,
+  DEFAULT_TZ,
 } from "lib/date"
 import { pageable, getPagingParameters } from "relay-cursor-paging"
 import {
@@ -189,7 +190,7 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
           return displayTimelyAt({
             sale,
             meBiddersLoader,
-            timeZone: defaultTimezone,
+            timeZone: defaultTimezone || DEFAULT_TZ,
           })
         },
       },

--- a/src/schema/v2/sale_artwork.ts
+++ b/src/schema/v2/sale_artwork.ts
@@ -150,17 +150,26 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLString,
         description:
           "A formatted description of when the lot starts or ends or if it has ended",
-        resolve: (
-          { sale, ended_at, end_at },
-          _options,
-          { defaultTimezone }
-        ) => {
-          return formattedStartDateTime(
-            sale.start_at,
-            ended_at || end_at,
-            null,
-            defaultTimezone || DEFAULT_TZ
-          )
+        resolve: (saleArtwork, _options, { defaultTimezone, saleLoader }) => {
+          if (!!saleArtwork.sale) {
+            return formattedStartDateTime(
+              saleArtwork.sale.start_at,
+              saleArtwork.endedAt ||
+                saleArtwork.endAt ||
+                saleArtwork.sale.end_at,
+              null,
+              defaultTimezone || DEFAULT_TZ
+            )
+          } else {
+            return saleLoader(saleArtwork.sale_id).then((sale) => {
+              return formattedStartDateTime(
+                sale.start_at,
+                saleArtwork.endedAt || saleArtwork.endAt || sale.end_at,
+                null,
+                defaultTimezone || DEFAULT_TZ
+              )
+            })
+          }
         },
       },
       highEstimate: money({

--- a/src/schema/v2/sale_artwork.ts
+++ b/src/schema/v2/sale_artwork.ts
@@ -152,12 +152,16 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
           "A formatted description of when the lot starts or ends or if it has ended",
         resolve: (saleArtwork, _options, { defaultTimezone, saleLoader }) =>
           saleLoader(saleArtwork.sale_id).then((sale) => {
-            return formattedStartDateTime(
-              sale.start_at,
-              saleArtwork.ended_at || saleArtwork.end_at,
-              null,
-              defaultTimezone
-            )
+            if (!sale.cascading_end_time_interval) {
+              return null
+            } else {
+              return formattedStartDateTime(
+                sale.start_at,
+                saleArtwork.ended_at || saleArtwork.end_at,
+                null,
+                defaultTimezone
+              )
+            }
           }),
       },
       highEstimate: money({

--- a/src/schema/v2/sale_artwork.ts
+++ b/src/schema/v2/sale_artwork.ts
@@ -164,7 +164,7 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
             return saleLoader(saleArtwork.sale_id).then((sale) => {
               return formattedStartDateTime(
                 sale.start_at,
-                saleArtwork.endedAt || saleArtwork.endAt || sale.end_at,
+                saleArtwork.ended_at || saleArtwork.end_at || sale.end_at,
                 null,
                 defaultTimezone || DEFAULT_TZ
               )

--- a/src/schema/v2/sale_artwork.ts
+++ b/src/schema/v2/sale_artwork.ts
@@ -154,7 +154,7 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
           saleLoader(saleArtwork.sale_id).then((sale) => {
             return formattedStartDateTime(
               sale.start_at,
-              saleArtwork.ended_at || saleArtwork.end_at || sale.end_at,
+              saleArtwork.ended_at || saleArtwork.end_at,
               null,
               defaultTimezone
             )

--- a/src/schema/v2/sale_artwork.ts
+++ b/src/schema/v2/sale_artwork.ts
@@ -27,7 +27,7 @@ import { ResolverContext } from "types/graphql"
 import { LoadersWithoutAuthentication } from "lib/loaders/loaders_without_authentication"
 import { NodeInterface } from "schema/v2/object_identification"
 import { CausalityLotState } from "./lot"
-import { DEFAULT_TZ, formattedStartDateTime } from "lib/date"
+import { formattedStartDateTime } from "lib/date"
 
 const { BIDDER_POSITION_MAX_BID_AMOUNT_CENTS_LIMIT } = config
 
@@ -150,27 +150,15 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLString,
         description:
           "A formatted description of when the lot starts or ends or if it has ended",
-        resolve: (saleArtwork, _options, { defaultTimezone, saleLoader }) => {
-          if (!!saleArtwork.sale) {
+        resolve: (saleArtwork, _options, { defaultTimezone, saleLoader }) =>
+          saleLoader(saleArtwork.sale_id).then((sale) => {
             return formattedStartDateTime(
-              saleArtwork.sale.start_at,
-              saleArtwork.endedAt ||
-                saleArtwork.endAt ||
-                saleArtwork.sale.end_at,
+              sale.start_at,
+              saleArtwork.ended_at || saleArtwork.end_at || sale.end_at,
               null,
-              defaultTimezone || DEFAULT_TZ
+              defaultTimezone
             )
-          } else {
-            return saleLoader(saleArtwork.sale_id).then((sale) => {
-              return formattedStartDateTime(
-                sale.start_at,
-                saleArtwork.ended_at || saleArtwork.end_at || sale.end_at,
-                null,
-                defaultTimezone || DEFAULT_TZ
-              )
-            })
-          }
-        },
+          }),
       },
       highEstimate: money({
         name: "SaleArtworkHighEstimate",

--- a/src/schema/v2/sale_artwork.ts
+++ b/src/schema/v2/sale_artwork.ts
@@ -27,6 +27,7 @@ import { ResolverContext } from "types/graphql"
 import { LoadersWithoutAuthentication } from "lib/loaders/loaders_without_authentication"
 import { NodeInterface } from "schema/v2/object_identification"
 import { CausalityLotState } from "./lot"
+import { DEFAULT_TZ, formattedStartDateTime } from "lib/date"
 
 const { BIDDER_POSITION_MAX_BID_AMOUNT_CENTS_LIMIT } = config
 
@@ -144,6 +145,23 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLInt,
         description: "Singular estimate field, if specified",
         resolve: ({ estimate_cents }) => estimate_cents,
+      },
+      formattedStartDateTime: {
+        type: GraphQLString,
+        description:
+          "A formatted description of when the lot starts or ends or if it has ended",
+        resolve: (
+          { sale, ended_at, end_at },
+          _options,
+          { defaultTimezone }
+        ) => {
+          return formattedStartDateTime(
+            sale.start_at,
+            ended_at || end_at,
+            null,
+            defaultTimezone || DEFAULT_TZ
+          )
+        },
       },
       highEstimate: money({
         name: "SaleArtworkHighEstimate",


### PR DESCRIPTION
Add `formattedStartDateTime` to `SaleArtwork` type so I can use it in [my PR](https://github.com/artsy/force/pull/9550) to add a label under the timer on the lot page. We need to show the correct copy depending on whether the sale has started and whether the lot itself has closed. 