### PR TITLE
fix(article): fallback to author field before editors default

### DIFF
--- a/src/schema/v2/article/__tests__/article.test.ts
+++ b/src/schema/v2/article/__tests__/article.test.ts
@@ -61,4 +61,28 @@ describe("Article", () => {
       authors: [],
     })
   })
+
+  it("first fallsback to the author when there are no author_ids", async () => {
+    const query = gql`
+      {
+        article(id: "example") {
+          byline
+          authors {
+            name
+          }
+        }
+      }
+    `
+
+    const articleLoader = jest.fn(() =>
+      Promise.resolve({ author_ids: [], author: { name: "John Smith" } })
+    )
+
+    const { article } = await runQuery(query, { articleLoader })
+
+    expect(article).toEqual({
+      byline: "John Smith",
+      authors: [],
+    })
+  })
 })

--- a/src/schema/v2/article/index.ts
+++ b/src/schema/v2/article/index.ts
@@ -52,8 +52,11 @@ export const ArticleType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
       description:
         'The byline for the article. Defaults to "Artsy Editors" if no authors are present.',
-      resolve: async ({ author_ids }, _args, { authorsLoader }) => {
-        if (!author_ids || author_ids.length === 0) return "Artsy Editors"
+      resolve: async ({ author_ids, author }, _args, { authorsLoader }) => {
+        if (!author_ids || author_ids.length === 0) {
+          // Attempt to fallback to the `author`. Classic layout articles, for instance, use this.
+          return author?.name || "Artsy Editors"
+        }
 
         const { results } = await authorsLoader({ ids: author_ids })
 


### PR DESCRIPTION
Discovered that classic layout articles will utilize the `author` field, which is otherwise only used to control the article slug (lol).