### PR TITLE
feat: add previewSavedSearch query field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10814,6 +10814,32 @@ type PhoneNumberType {
   regionCode: String
 }
 
+type PreviewSavedSearch {
+  # Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity
+  labels: [SearchCriteriaLabel]!
+}
+
+input PreviewSavedSearchAttributes {
+  acquireable: Boolean
+  additionalGeneIDs: [String]
+  artistIDs: [String]
+  atAuction: Boolean
+  attributionClass: [String]
+  colors: [String]
+  height: String
+  inquireableOnly: Boolean
+  locationCities: [String]
+  majorPeriods: [String]
+  materialsTerms: [String]
+  offerable: Boolean
+  partnerIDs: [String]
+  priceRange: String
+
+  # Filter results by Artwork sizes
+  sizes: [ArtworkSizes]
+  width: String
+}
+
 # The connection type for MarketPriceInsights.
 type PriceInsightConnection {
   # A list of edges.
@@ -11800,6 +11826,11 @@ type Query {
 
   # Phone number information
   phoneNumber(phoneNumber: String!, regionCode: String): PhoneNumberType
+
+  # A previewed saved search
+  previewSavedSearch(
+    attributes: PreviewSavedSearchAttributes
+  ): PreviewSavedSearch
 
   # Get all price insights for an artist.
   priceInsights(
@@ -14704,6 +14735,11 @@ type Viewer {
 
   # Phone number information
   phoneNumber(phoneNumber: String!, regionCode: String): PhoneNumberType
+
+  # A previewed saved search
+  previewSavedSearch(
+    attributes: PreviewSavedSearchAttributes
+  ): PreviewSavedSearch
 
   # A requested location
   requestLocation(ip: String!): RequestLocation

--- a/src/schema/v2/__tests__/previewSavedSearch.test.ts
+++ b/src/schema/v2/__tests__/previewSavedSearch.test.ts
@@ -1,0 +1,24 @@
+import { runQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("previewSavedSearch", () => {
+  const query = gql`
+    {
+      previewSavedSearch(attributes: { acquireable: true }) {
+        labels {
+          field
+          name
+          value
+        }
+      }
+    }
+  `
+
+  it("returns a previewed saved search", async () => {
+    const { previewSavedSearch } = await runQuery(query)
+
+    expect(previewSavedSearch.labels).toEqual([
+      { field: "acquireable", name: "Ways to Buy", value: "Buy Now" },
+    ])
+  })
+})

--- a/src/schema/v2/previewSavedSearch.ts
+++ b/src/schema/v2/previewSavedSearch.ts
@@ -1,0 +1,101 @@
+import {
+  GraphQLBoolean,
+  GraphQLFieldConfig,
+  GraphQLFieldConfigArgumentMap,
+  GraphQLInputObjectType,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import ArtworkSizes from "./artwork/artworkSizes"
+import {
+  resolveSearchCriteriaLabels,
+  SearchCriteriaLabel,
+} from "./searchCriteriaLabel"
+
+const previewSavedSearchArgs: GraphQLFieldConfigArgumentMap = {
+  acquireable: {
+    type: GraphQLBoolean,
+  },
+  additionalGeneIDs: {
+    type: new GraphQLList(GraphQLString),
+  },
+  artistIDs: {
+    type: new GraphQLList(GraphQLString),
+  },
+  atAuction: {
+    type: GraphQLBoolean,
+  },
+  attributionClass: {
+    type: new GraphQLList(GraphQLString),
+  },
+  colors: {
+    type: new GraphQLList(GraphQLString),
+  },
+  height: {
+    type: GraphQLString,
+  },
+  inquireableOnly: {
+    type: GraphQLBoolean,
+  },
+  locationCities: {
+    type: new GraphQLList(GraphQLString),
+  },
+  majorPeriods: {
+    type: new GraphQLList(GraphQLString),
+  },
+  materialsTerms: {
+    type: GraphQLList(GraphQLString),
+  },
+  offerable: {
+    type: GraphQLBoolean,
+  },
+  partnerIDs: {
+    type: new GraphQLList(GraphQLString),
+  },
+  priceRange: {
+    type: GraphQLString,
+  },
+  sizes: {
+    type: new GraphQLList(ArtworkSizes),
+    description: "Filter results by Artwork sizes",
+  },
+  width: {
+    type: GraphQLString,
+  },
+}
+
+const PreviewSavedSearchType = new GraphQLObjectType<any, ResolverContext>({
+  name: "PreviewSavedSearch",
+  fields: () => ({
+    labels: {
+      type: new GraphQLNonNull(new GraphQLList(SearchCriteriaLabel)),
+      resolve: resolveSearchCriteriaLabels,
+      description:
+        "Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity",
+    },
+  }),
+})
+
+const PreviewSavedSearchAttributesType = new GraphQLInputObjectType({
+  name: "PreviewSavedSearchAttributes",
+  fields: previewSavedSearchArgs,
+})
+
+export const PreviewSavedSearchField: GraphQLFieldConfig<
+  void,
+  ResolverContext
+> = {
+  type: PreviewSavedSearchType,
+  description: "A previewed saved search",
+  args: {
+    attributes: {
+      type: PreviewSavedSearchAttributesType,
+    },
+  },
+  resolve: (_parent, args, _context, _info) => {
+    return args.attributes
+  },
+}

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -119,6 +119,7 @@ import { authenticationStatus } from "./authenticationStatus"
 import { deleteUserAccountMutation } from "./me/delete_account_mutation"
 import { SearchCriteriaLabel } from "./searchCriteriaLabel"
 import { sendIdentityVerificationEmailMutation } from "./me/sendIdentityVerficationEmailMutation"
+import { PreviewSavedSearchField } from "./previewSavedSearch"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -188,6 +189,7 @@ const rootFields = {
   partnersConnection: PartnersConnection,
   phoneNumber: PhoneNumber,
   // profile: Profile,
+  previewSavedSearch: PreviewSavedSearchField,
   requestLocation: RequestLocationField,
   sale: Sale,
   saleArtwork: SaleArtwork,


### PR DESCRIPTION
Allows a client to preview the formatted labels for an unpersisted alert criteria.

Jira: [FX-3819](https://artsyproduct.atlassian.net/browse/FX-3819)

**Request**

```graphql
{
  previewSavedSearch(attributes: { attributionClass: ["unique"], artistIDs: ["4e934002e340fa0001005336"], acquireable: true }) {
    labels {
      field
      name
      value
    }
  }
}
```

**Response**

```json
{
  "data": {
    "previewSavedSearch": {
      "labels": [
        {
          "field": "artistIDs",
          "name": "Artist",
          "value": "KAWS"
        },
        {
          "field": "attributionClass",
          "name": "Rarity",
          "value": "Unique"
        },
        {
          "field": "acquireable",
          "name": "Ways to Buy",
          "value": "Buy Now"
        }
      ]
    }
  }
}
```