### PR TITLE
chore(price filter): support new histogram aggregation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1936,6 +1936,7 @@ enum ArtworkAggregation {
   PARTNER_CITY
   PERIOD
   PRICE_RANGE
+  SIMPLE_PRICE_HISTOGRAM
   TOTAL
 }
 

--- a/src/schema/v2/aggregations/filter_artworks_aggregation.ts
+++ b/src/schema/v2/aggregations/filter_artworks_aggregation.ts
@@ -57,6 +57,9 @@ export const ArtworksAggregation = new GraphQLEnumType({
     PRICE_RANGE: {
       value: "price_range",
     },
+    SIMPLE_PRICE_HISTOGRAM: {
+      value: "simple_price_histogram",
+    },
     TOTAL: {
       value: "total",
     },


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-3801

Follow-up to https://github.com/artsy/gravity/pull/15118

Simply exposes the `simple_price_histogram` aggregation that's now available in Gravity's `api/v1/filter/artworks` endpoint.

This new aggregation is currently only supported only on _artist_ artwork grids, a constraint that is not modeled here but enforced by Gravity instead.