### PR TITLE
bug:ensure auctions detail formatted start date time works with live auction integrations

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2895,6 +2895,10 @@ type CaptureHoldPayload {
   holdOrError: InventoryHoldOrErrorUnion!
 }
 
+type CascadingEndTime {
+  formattedStartDateTime: String
+}
+
 type CausalityLotState {
   bidCount: Int
   floorSellingPrice: Money
@@ -12202,12 +12206,6 @@ type Sale implements Node {
     last: Int
   ): ArtworkConnection
   associatedSale: Sale
-
-  # A label indicating the interval in minutes in which lots close
-  auctionsDetailCascadingIntervalLabel: String
-
-  # A more granular formatted description of when the auction starts or ends or if it has ended
-  auctionsDetailFormattedStartDateTime: String
   bidder: Bidder
 
   # A bid increment policy that explains minimum bids in ranges.
@@ -12216,6 +12214,7 @@ type Sale implements Node {
   # Auction's buyer's premium policy.
   buyersPremium: [BuyersPremium]
   cached: Int
+  cascadingEndTime: CascadingEndTime
 
   # Amount of seconds in between each lot closing.
   cascadingEndTimeInterval: Int

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2895,10 +2895,6 @@ type CaptureHoldPayload {
   holdOrError: InventoryHoldOrErrorUnion!
 }
 
-type CascadingEndTime {
-  formattedStartDateTime: String
-}
-
 type CausalityLotState {
   bidCount: Int
   floorSellingPrice: Money
@@ -12214,7 +12210,7 @@ type Sale implements Node {
   # Auction's buyer's premium policy.
   buyersPremium: [BuyersPremium]
   cached: Int
-  cascadingEndTime: CascadingEndTime
+  cascadingEndTime: SaleCascadingEndTime
 
   # Amount of seconds in between each lot closing.
   cascadingEndTimeInterval: Int
@@ -12626,6 +12622,14 @@ type SaleArtworksConnection implements ArtworkConnectionInterface {
   # Information to aid in pagination.
   pageInfo: PageInfo!
   totalCount: Int
+}
+
+type SaleCascadingEndTime {
+  # A more granular formatted description of when the auction starts or ends if it has ended
+  formattedStartDateTime: String
+
+  # A label indicating the interval in minutes in which lots close
+  intervalLabel: String
 }
 
 # A connection to a list of items.

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -273,10 +273,6 @@ export function auctionsDetailFormattedStartDateTime(
   const saleEndMoment = moment.tz(endedAt, "GMT")
   const liveStartMoment = moment.tz(liveStartAt, "GMT")
 
-  // return `${saleStartMoment.format("MMM D, YYYY")} • ${saleStartMoment.format(
-  //   "h:mma z"
-  // )}`
-
   if (!!endedAt)
     return `Closed ${saleEndMoment.format(
       "MMM D, YYYY"

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -261,11 +261,21 @@ export function cascadingFormattedStartDateTime(
   return dateRange(startAt, endAt, timezone, "long")
 }
 
-export function auctionsDetailFormattedStartDateTime(startAt, endAt, endedAt) {
+export function auctionsDetailFormattedStartDateTime(
+  startAt,
+  endAt,
+  endedAt,
+  liveStartAt
+) {
   const thisMoment = moment.tz(moment(), "GMT")
   const saleStartMoment = moment.tz(startAt, "GMT")
   const lotsClosingMoment = moment.tz(endAt, "GMT")
   const saleEndMoment = moment.tz(endedAt, "GMT")
+  const liveStartMoment = moment.tz(liveStartAt, "GMT")
+
+  // return `${saleStartMoment.format("MMM D, YYYY")} • ${saleStartMoment.format(
+  //   "h:mma z"
+  // )}`
 
   if (!!endedAt)
     return `Closed ${saleEndMoment.format(
@@ -276,6 +286,18 @@ export function auctionsDetailFormattedStartDateTime(startAt, endAt, endedAt) {
     return `${saleStartMoment.format("MMM D, YYYY")} • ${saleStartMoment.format(
       "h:mma z"
     )}`
+  if (liveStartAt) {
+    if (thisMoment.isBefore(liveStartMoment)) {
+      return `Live ${liveStartMoment.format(
+        "MMM D, YYYY"
+      )} • ${liveStartMoment.format("h:mma z")}`
+    } else if (
+      thisMoment.isAfter(liveStartMoment) &&
+      (thisMoment.isBefore(lotsClosingMoment) || !endAt)
+    ) {
+      return `In progress`
+    }
+  }
   return `${lotsClosingMoment.format(
     "MMM D, YYYY"
   )} • ${lotsClosingMoment.format("h:mma z")}`

--- a/src/schema/v2/sale/__tests__/index.test.ts
+++ b/src/schema/v2/sale/__tests__/index.test.ts
@@ -895,11 +895,10 @@ describe("Sale type", () => {
       }
     `
 
-    it.only("returns a string including the correctly formatted start time when we the auction has not started", async () => {
+    it("returns a string including the correctly formatted start time when we the auction has not started", async () => {
       const response = await execute(query, {
         start_at: moment().add(3, "days"),
       })
-      console.log(response.sale)
       expect(response.sale.cascadingEndTime.formattedStartDateTime).toEqual(
         "Mar 11, 2022 • 12:33pm GMT"
       )
@@ -909,7 +908,7 @@ describe("Sale type", () => {
       const response = await execute(query, {
         ended_at: moment().subtract(1, "days"),
       })
-      expect(response.sale.auctionsDetailFormattedStartDateTime).toEqual(
+      expect(response.sale.cascadingEndTime.formattedStartDateTime).toEqual(
         "Closed Mar 7, 2022 • 12:33pm GMT"
       )
     })
@@ -918,7 +917,7 @@ describe("Sale type", () => {
       const response = await execute(query, {
         end_at: moment().subtract(1, "days"),
       })
-      expect(response.sale.auctionsDetailFormattedStartDateTime).toEqual(
+      expect(response.sale.cascadingEndTime.formattedStartDateTime).toEqual(
         "Mar 7, 2022 • 12:33pm GMT"
       )
     })
@@ -927,7 +926,7 @@ describe("Sale type", () => {
       const response = await execute(query, {
         live_start_at: moment().add(1, "days"),
       })
-      expect(response.sale.auctionsDetailFormattedStartDateTime).toEqual(
+      expect(response.sale.cascadingEndTime.formattedStartDateTime).toEqual(
         "Live Mar 9, 2022 • 12:33pm GMT"
       )
     })
@@ -936,7 +935,7 @@ describe("Sale type", () => {
       const response = await execute(query, {
         live_start_at: moment().subtract(1, "days"),
       })
-      expect(response.sale.auctionsDetailFormattedStartDateTime).toEqual(
+      expect(response.sale.cascadingEndTime.formattedStartDateTime).toEqual(
         "In progress"
       )
     })
@@ -960,7 +959,7 @@ describe("Sale type", () => {
       const response = await execute(query, {
         cascading_end_time_interval: 120,
       })
-      expect(response.sale.auctionsDetailCascadingIntervalLabel).toEqual(
+      expect(response.sale.cascadingEndTime.intervalLabel).toEqual(
         "Lots close at 2-minute intervals"
       )
     })
@@ -970,7 +969,7 @@ describe("Sale type", () => {
         ended_at: moment().subtract(30, "minutes"),
         cascading_end_time_interval: 120,
       })
-      expect(response.sale.auctionsDetailCascadingIntervalLabel).toEqual(null)
+      expect(response.sale.cascadingEndTime.intervalLabel).toEqual(null)
     })
   })
 

--- a/src/schema/v2/sale/__tests__/index.test.ts
+++ b/src/schema/v2/sale/__tests__/index.test.ts
@@ -881,23 +881,26 @@ describe("Sale type", () => {
     })
   })
 
-  describe("auctionsDetailFormattedStartDateTime", () => {
+  describe("cascadingEndTimeFormattedStartDateTime", () => {
     beforeEach(() => {
       Date.now = jest.fn(() => new Date("2022-03-08T12:33:37.000Z"))
     })
     const query = `
       {
         sale(id: "foo-foo") {
-          auctionsDetailFormattedStartDateTime
+          cascadingEndTime {
+            formattedStartDateTime
+          }
         }
       }
     `
 
-    it("returns a string including the correctly formatted start time when we the auction has not started", async () => {
+    it.only("returns a string including the correctly formatted start time when we the auction has not started", async () => {
       const response = await execute(query, {
         start_at: moment().add(3, "days"),
       })
-      expect(response.sale.auctionsDetailFormattedStartDateTime).toEqual(
+      console.log(response.sale)
+      expect(response.sale.cascadingEndTime.formattedStartDateTime).toEqual(
         "Mar 11, 2022 • 12:33pm GMT"
       )
     })
@@ -939,14 +942,16 @@ describe("Sale type", () => {
     })
   })
 
-  describe("auctionsDetailCascadingIntervalLabel", () => {
+  describe("cascadingIntervalLabel", () => {
     beforeEach(() => {
       Date.now = jest.fn(() => new Date("2022-03-08T12:33:37.000Z"))
     })
     const query = `
       {
         sale(id: "foo-foo") {
-          auctionsDetailCascadingIntervalLabel
+          cascadingEndTime {
+            intervalLabel
+          }
         }
       }
     `

--- a/src/schema/v2/sale/__tests__/index.test.ts
+++ b/src/schema/v2/sale/__tests__/index.test.ts
@@ -919,6 +919,24 @@ describe("Sale type", () => {
         "Mar 7, 2022 • 12:33pm GMT"
       )
     })
+
+    it("returns a string including the correctly formatted date when the live start at has yet to start and is a LAI", async () => {
+      const response = await execute(query, {
+        live_start_at: moment().add(1, "days"),
+      })
+      expect(response.sale.auctionsDetailFormattedStartDateTime).toEqual(
+        "Live Mar 9, 2022 • 12:33pm GMT"
+      )
+    })
+
+    it("returns a in progress when the auction has started and is a LAI", async () => {
+      const response = await execute(query, {
+        live_start_at: moment().subtract(1, "days"),
+      })
+      expect(response.sale.auctionsDetailFormattedStartDateTime).toEqual(
+        "In progress"
+      )
+    })
   })
 
   describe("auctionsDetailCascadingIntervalLabel", () => {
@@ -938,7 +956,7 @@ describe("Sale type", () => {
         cascading_end_time_interval: 120,
       })
       expect(response.sale.auctionsDetailCascadingIntervalLabel).toEqual(
-        "Lots close in 2 minute intervals"
+        "Lots close at 2-minute intervals"
       )
     })
 

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -240,11 +240,12 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLString,
         description:
           "A more granular formatted description of when the auction starts or ends or if it has ended",
-        resolve: ({ start_at, end_at, ended_at }, _options) => {
+        resolve: ({ start_at, end_at, ended_at, live_start_at }, _options) => {
           return auctionsDetailFormattedStartDateTime(
             start_at,
             end_at,
-            ended_at
+            ended_at,
+            live_start_at
           )
         },
       },
@@ -257,9 +258,9 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
           if (ended_at) {
             return null
           } else {
-            return `Lots close in ${
+            return `Lots close at ${
               cascading_end_time_interval / 60
-            } minute intervals`
+            }-minute intervals`
           }
         },
       },

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -236,32 +236,52 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
           }
         },
       },
-      auctionsDetailFormattedStartDateTime: {
-        type: GraphQLString,
-        description:
-          "A more granular formatted description of when the auction starts or ends or if it has ended",
-        resolve: ({ start_at, end_at, ended_at, live_start_at }, _options) => {
-          return auctionsDetailFormattedStartDateTime(
-            start_at,
-            end_at,
-            ended_at,
-            live_start_at
-          )
-        },
-      },
-      auctionsDetailCascadingIntervalLabel: {
-        type: GraphQLString,
-        description:
-          "A label indicating the interval in minutes in which lots close",
-        resolve: ({ ended_at, cascading_end_time_interval }, _options) => {
-          if (cascading_end_time_interval === null) return null
-          if (ended_at) {
-            return null
-          } else {
-            return `Lots close at ${
-              cascading_end_time_interval / 60
-            }-minute intervals`
-          }
+      cascadingEndTime: {
+        type: new GraphQLObjectType({
+          name: "CascadingEndTime",
+          fields: {
+            formattedStartDateTime: {
+              type: GraphQLString,
+              // description:
+              //   "A more granular formatted description of when the auction starts or ends or if it has ended",
+              resolve: (
+                // { start_at, end_at, ended_at, live_start_at },
+                _options
+              ) => {
+                // return auctionsDetailFormattedStartDateTime(
+                //   start_at,
+                //   end_at,
+                //   ended_at,
+                //   live_start_at
+                // )
+                return "hello"
+              },
+            },
+            // intervalLabel: {
+            //   type: GraphQLString,
+            //   description:
+            //     "A label indicating the interval in minutes in which lots close",
+            //   resolve: (
+            //     { ended_at, cascading_end_time_interval },
+            //     _options
+            //   ) => {
+            //     if (cascading_end_time_interval === null) return null
+            //     if (ended_at) {
+            //       return null
+            //     } else {
+            //       return `Lots close at ${
+            //         cascading_end_time_interval / 60
+            //       }-minute intervals`
+            //     }
+            //   },
+            // },
+          },
+        }),
+        resolve: (sale, { cascading_end_time }) => {
+          console.log("TEST", sale, cascading_end_time)
+          if (!sale) return null
+
+          return cascading_end_time
         },
       },
       href: { type: GraphQLString, resolve: ({ id }) => `/auction/${id}` },

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -238,50 +238,52 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
       },
       cascadingEndTime: {
         type: new GraphQLObjectType({
-          name: "CascadingEndTime",
+          name: "SaleCascadingEndTime",
           fields: {
             formattedStartDateTime: {
               type: GraphQLString,
-              // description:
-              //   "A more granular formatted description of when the auction starts or ends or if it has ended",
+              description:
+                "A more granular formatted description of when the auction starts or ends if it has ended",
               resolve: (
-                // { start_at, end_at, ended_at, live_start_at },
+                { start_at, end_at, ended_at, live_start_at },
                 _options
               ) => {
-                // return auctionsDetailFormattedStartDateTime(
-                //   start_at,
-                //   end_at,
-                //   ended_at,
-                //   live_start_at
-                // )
-                return "hello"
+                return auctionsDetailFormattedStartDateTime(
+                  start_at,
+                  end_at,
+                  ended_at,
+                  live_start_at
+                )
               },
             },
-            // intervalLabel: {
-            //   type: GraphQLString,
-            //   description:
-            //     "A label indicating the interval in minutes in which lots close",
-            //   resolve: (
-            //     { ended_at, cascading_end_time_interval },
-            //     _options
-            //   ) => {
-            //     if (cascading_end_time_interval === null) return null
-            //     if (ended_at) {
-            //       return null
-            //     } else {
-            //       return `Lots close at ${
-            //         cascading_end_time_interval / 60
-            //       }-minute intervals`
-            //     }
-            //   },
-            // },
+            intervalLabel: {
+              type: GraphQLString,
+              description:
+                "A label indicating the interval in minutes in which lots close",
+              resolve: (
+                { ended_at, cascading_end_time_interval },
+                _options
+              ) => {
+                if (!cascading_end_time_interval) return null
+                if (ended_at) {
+                  return null
+                } else {
+                  return `Lots close at ${
+                    cascading_end_time_interval / 60
+                  }-minute intervals`
+                }
+              },
+            },
           },
         }),
-        resolve: (sale, { cascading_end_time }) => {
-          console.log("TEST", sale, cascading_end_time)
-          if (!sale) return null
-
-          return cascading_end_time
+        resolve: (sale) => {
+          return {
+            start_at: sale.start_at,
+            end_at: sale.end_at,
+            ended_at: sale.ended_at,
+            live_start_at: sale.live_start_at,
+            cascading_end_time_interval: sale.cascading_end_time_interval,
+          }
         },
       },
       href: { type: GraphQLString, resolve: ({ id }) => `/auction/${id}` },


### PR DESCRIPTION
This PR addresses an [issue brought up in slack](https://artsy.slack.com/archives/C01PBEBRB0V/p1647482514904939) where the date in force was displaying invalid date to invalid date. This was caused by auctionsDetailFormattedStartDateTime not accounting for live sale integrations. 