### PR TITLE
feat: Add formatted lot end time to sale_artwork type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12414,6 +12414,9 @@ type SaleArtwork implements ArtworkEdgeInterface & Node {
   # Singular estimate field, if specified
   estimateCents: Int
 
+  # A formatted description of the lot end date and time
+  formattedEndDateTime: String
+
   # A formatted description of when the lot starts or ends or if it has ended
   formattedStartDateTime: String
   highestBid: SaleArtworkHighestBid

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -281,6 +281,13 @@ export function auctionsDetailFormattedStartDateTime(startAt, endAt, endedAt) {
   )} • ${lotsClosingMoment.format("h:mma z")}`
 }
 
+export function formattedEndDateTime(endAt) {
+  const lotEndMoment = moment.tz(endAt, "GMT")
+  return `Closes, ${lotEndMoment.format("MMM D")} • ${lotEndMoment.format(
+    "h:mma z"
+  )}`
+}
+
 /**
  * Starts Mar 29 at 4:00pm
  * Ends Apr 3 at 12:30pm

--- a/src/schema/v2/__tests__/sale_artwork.test.js
+++ b/src/schema/v2/__tests__/sale_artwork.test.js
@@ -532,6 +532,67 @@ describe("SaleArtwork type", () => {
     })
   })
 
+  describe("formattedEndDateTime", () => {
+    const query = gql`
+      {
+        node(id: "${toGlobalId("SaleArtwork", "54c7ed2a7261692bfa910200")}") {
+          ... on SaleArtwork {
+            formattedEndDateTime
+          }
+        }
+      }
+    `
+
+    const context = {
+      saleLoader: () => {
+        return Promise.resolve({
+          cascading_end_time_interval: 120,
+        })
+      },
+    }
+
+    it("returns a string with formatted end date and time when cascading end time is enabled and the lot has not yet closed", async () => {
+      saleArtwork.ended_at = null
+      saleArtwork.end_at = "2029-02-19T11:00:00+00:00"
+
+      expect(await execute(query, saleArtwork, context)).toEqual({
+        node: {
+          formattedEndDateTime: "Closes, Feb 19 • 11:00am GMT",
+        },
+      })
+    })
+
+    it("returns null if cascading end time is turned off", async () => {
+      saleArtwork.ended_at = null
+      saleArtwork.end_at = "2029-02-19T11:00:00+00:00"
+
+      const context = {
+        saleLoader: () => {
+          return Promise.resolve({
+            cascading_end_time_interval: null,
+          })
+        },
+      }
+
+      expect(await execute(query, saleArtwork, context)).toEqual({
+        node: {
+          formattedEndDateTime: null,
+        },
+      })
+    })
+
+    it("returns null if the lot has closed", async () => {
+      saleArtwork.ended_at = "2022-02-19T11:00:00+00:00"
+      saleArtwork.end_at = "2029-02-19T11:00:00+00:00"
+
+      expect(await execute(query, saleArtwork, context)).toEqual({
+        node: {
+          formattedEndDateTime: null,
+        },
+      })
+    })
+  })
+
   describe("formattedStartDateTime", () => {
     const query = gql`
       {

--- a/src/schema/v2/sale_artwork.ts
+++ b/src/schema/v2/sale_artwork.ts
@@ -27,7 +27,7 @@ import { ResolverContext } from "types/graphql"
 import { LoadersWithoutAuthentication } from "lib/loaders/loaders_without_authentication"
 import { NodeInterface } from "schema/v2/object_identification"
 import { CausalityLotState } from "./lot"
-import { formattedStartDateTime } from "lib/date"
+import { formattedEndDateTime, formattedStartDateTime } from "lib/date"
 
 const { BIDDER_POSITION_MAX_BID_AMOUNT_CENTS_LIMIT } = config
 
@@ -161,6 +161,18 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
                 null,
                 defaultTimezone
               )
+            }
+          }),
+      },
+      formattedEndDateTime: {
+        type: GraphQLString,
+        description: "A formatted description of the lot end date and time",
+        resolve: (saleArtwork, _options, { saleLoader }) =>
+          saleLoader(saleArtwork.sale_id).then((sale) => {
+            if (!sale.cascading_end_time_interval || !saleArtwork.endedAt) {
+              return null
+            } else {
+              return formattedEndDateTime(saleArtwork.end_at)
             }
           }),
       },


### PR DESCRIPTION
Needed for [BX-212](https://artsyproduct.atlassian.net/browse/BID-212).

In the case when the sale is open but the lots have started closing we should show the following format for the end date and time of the `lot`:
<img width="330" alt="Screen Shot 2022-03-17 at 4 56 16 PM" src="https://user-images.githubusercontent.com/9466631/158894029-e48d70d7-3b2b-4a3b-afe8-045f18c830ce.png">

```graphql
query AuctionTimerQuery($saleArtworkID: String!) {

	saleArtwork(id: $saleArtworkID) {
		formattedEndDateTime
	}
}

```

<img width="423" alt="Screen Shot 2022-03-17 at 5 03 55 PM" src="https://user-images.githubusercontent.com/9466631/158894866-250fe43f-94c3-4db9-830e-291ad45df967.png">

