### PR TITLE
feat: add the ability to return value and displayValue fields in SearchCriteriaLabel

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12925,6 +12925,9 @@ type SearchCriteriaLabel {
   # The GraphQL field name of the filter facet
   field: String!
 
+  # The human-friendly label of the filter facet
+  label: String!
+
   # The human-friendly name of the filter facet
   name: String!
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12922,11 +12922,11 @@ type SearchCriteriaEdge {
 
 # Human-friendly representation of a single SearchCriteria filter
 type SearchCriteriaLabel {
+  # The human-friendly label of the filter facet
+  displayValue: String!
+
   # The GraphQL field name of the filter facet
   field: String!
-
-  # The human-friendly label of the filter facet
-  label: String!
 
   # The human-friendly name of the filter facet
   name: String!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12931,7 +12931,7 @@ type SearchCriteriaLabel {
   # The human-friendly name of the filter facet
   name: String!
 
-  # The human-friendly value of the filter facet
+  # The value of the filter facet
   value: String!
 }
 

--- a/src/schema/v2/__tests__/previewSavedSearch.test.ts
+++ b/src/schema/v2/__tests__/previewSavedSearch.test.ts
@@ -23,7 +23,7 @@ describe("previewSavedSearch", () => {
         field: "acquireable",
         name: "Ways to Buy",
         displayValue: "Buy Now",
-        value: "acquireable",
+        value: "true",
       },
     ])
   })

--- a/src/schema/v2/__tests__/previewSavedSearch.test.ts
+++ b/src/schema/v2/__tests__/previewSavedSearch.test.ts
@@ -8,6 +8,7 @@ describe("previewSavedSearch", () => {
         labels {
           field
           name
+          label
           value
         }
       }
@@ -18,7 +19,12 @@ describe("previewSavedSearch", () => {
     const { previewSavedSearch } = await runQuery(query)
 
     expect(previewSavedSearch.labels).toEqual([
-      { field: "acquireable", name: "Ways to Buy", value: "Buy Now" },
+      {
+        field: "acquireable",
+        name: "Ways to Buy",
+        label: "Buy Now",
+        value: "acquireable",
+      },
     ])
   })
 })

--- a/src/schema/v2/__tests__/previewSavedSearch.test.ts
+++ b/src/schema/v2/__tests__/previewSavedSearch.test.ts
@@ -8,7 +8,7 @@ describe("previewSavedSearch", () => {
         labels {
           field
           name
-          label
+          displayValue
           value
         }
       }
@@ -22,7 +22,7 @@ describe("previewSavedSearch", () => {
       {
         field: "acquireable",
         name: "Ways to Buy",
-        label: "Buy Now",
+        displayValue: "Buy Now",
         value: "acquireable",
       },
     ])

--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -20,13 +20,13 @@ describe("resolveSearchCriteriaLabels", () => {
     expect(labels).toIncludeAllMembers([
       {
         name: "Artist",
-        label: "Foo Bar",
+        displayValue: "Foo Bar",
         value: "foo-bar",
         field: "artistIDs",
       },
       {
         name: "Artist",
-        label: "Baz Qux",
+        displayValue: "Baz Qux",
         value: "baz-qux",
         field: "artistIDs",
       },
@@ -48,25 +48,25 @@ describe("resolveSearchCriteriaLabels", () => {
     expect(labels).toIncludeAllMembers([
       {
         name: "Rarity",
-        label: "Unique",
+        displayValue: "Unique",
         value: "unique",
         field: "attributionClass",
       },
       {
         name: "Rarity",
-        label: "Limited edition",
+        displayValue: "Limited edition",
         value: "limited edition",
         field: "attributionClass",
       },
       {
         name: "Rarity",
-        label: "Open edition",
+        displayValue: "Open edition",
         value: "open edition",
         field: "attributionClass",
       },
       {
         name: "Rarity",
-        label: "Unknown edition",
+        displayValue: "Unknown edition",
         value: "unknown edition",
         field: "attributionClass",
       },
@@ -98,85 +98,85 @@ describe("resolveSearchCriteriaLabels", () => {
     expect(labels).toIncludeAllMembers([
       {
         name: "Medium",
-        label: "Painting",
+        displayValue: "Painting",
         value: "painting",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        label: "Photography",
+        displayValue: "Photography",
         value: "photography",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        label: "Sculpture",
+        displayValue: "Sculpture",
         value: "sculpture",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        label: "Prints",
+        displayValue: "Prints",
         value: "prints",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        label: "Work on Paper",
+        displayValue: "Work on Paper",
         value: "work-on-paper",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        label: "NFT",
+        displayValue: "NFT",
         value: "nft",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        label: "Design",
+        displayValue: "Design",
         value: "design",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        label: "Drawing",
+        displayValue: "Drawing",
         value: "drawing",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        label: "Installation",
+        displayValue: "Installation",
         value: "installation",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        label: "Film/Video",
+        displayValue: "Film/Video",
         value: "film-slash-video",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        label: "Jewelry",
+        displayValue: "Jewelry",
         value: "jewelry",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        label: "Performance Art",
+        displayValue: "Performance Art",
         value: "performance-art",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        label: "Reproduction",
+        displayValue: "Reproduction",
         value: "reproduction",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        label: "Ephemera or Merchandise",
+        displayValue: "Ephemera or Merchandise",
         value: "ephemera-or-merchandise",
         field: "additionalGeneIDs",
       },
@@ -194,7 +194,7 @@ describe("resolveSearchCriteriaLabels", () => {
         expect(labels).toIncludeAllMembers([
           {
             name: "Price",
-            label: "$42–$420",
+            displayValue: "$42–$420",
             value: "42-420",
             field: "priceRange",
           },
@@ -212,7 +212,7 @@ describe("resolveSearchCriteriaLabels", () => {
         expect(labels).toIncludeAllMembers([
           {
             name: "Price",
-            label: "$42+",
+            displayValue: "$42+",
             value: "42-*",
             field: "priceRange",
           },
@@ -230,7 +230,7 @@ describe("resolveSearchCriteriaLabels", () => {
         expect(labels).toIncludeAllMembers([
           {
             name: "Price",
-            label: "$0–$420",
+            displayValue: "$0–$420",
             value: "*-420",
             field: "priceRange",
           },
@@ -249,19 +249,19 @@ describe("resolveSearchCriteriaLabels", () => {
     expect(labels).toIncludeAllMembers([
       {
         name: "Size",
-        label: "Large (over 100cm)",
+        displayValue: "Large (over 100cm)",
         value: "LARGE",
         field: "sizes",
       },
       {
         name: "Size",
-        label: "Medium (40 – 100cm)",
+        displayValue: "Medium (40 – 100cm)",
         value: "MEDIUM",
         field: "sizes",
       },
       {
         name: "Size",
-        label: "Small (under 40cm)",
+        displayValue: "Small (under 40cm)",
         value: "SMALL",
         field: "sizes",
       },
@@ -279,7 +279,7 @@ describe("resolveSearchCriteriaLabels", () => {
       expect(labels).toIncludeAllMembers([
         {
           name: "Size",
-          label: "h: from 1 cm",
+          displayValue: "h: from 1 cm",
           value: "0.39370078740157477-*",
           field: "height",
         },
@@ -295,7 +295,7 @@ describe("resolveSearchCriteriaLabels", () => {
       expect(labels).toIncludeAllMembers([
         {
           name: "Size",
-          label: "h: to 10 cm",
+          displayValue: "h: to 10 cm",
           value: "*-3.937007874015748",
           field: "height",
         },
@@ -311,7 +311,7 @@ describe("resolveSearchCriteriaLabels", () => {
       expect(labels).toIncludeAllMembers([
         {
           name: "Size",
-          label: "h: 1–10 cm",
+          displayValue: "h: 1–10 cm",
           value: "0.39370078740157477-3.937007874015748",
           field: "height",
         },
@@ -327,7 +327,7 @@ describe("resolveSearchCriteriaLabels", () => {
       expect(labels).toIncludeAllMembers([
         {
           name: "Size",
-          label: "w: from 1 cm",
+          displayValue: "w: from 1 cm",
           value: "0.39370078740157477-*",
           field: "width",
         },
@@ -343,7 +343,7 @@ describe("resolveSearchCriteriaLabels", () => {
       expect(labels).toIncludeAllMembers([
         {
           name: "Size",
-          label: "w: to 10 cm",
+          displayValue: "w: to 10 cm",
           value: "*-3.937007874015748",
           field: "width",
         },
@@ -359,7 +359,7 @@ describe("resolveSearchCriteriaLabels", () => {
       expect(labels).toIncludeAllMembers([
         {
           name: "Size",
-          label: "w: 1–10 cm",
+          displayValue: "w: 1–10 cm",
           value: "0.39370078740157477-3.937007874015748",
           field: "width",
         },
@@ -376,13 +376,13 @@ describe("resolveSearchCriteriaLabels", () => {
       expect(labels).toIncludeAllMembers([
         {
           name: "Size",
-          label: "w: to 51 cm",
+          displayValue: "w: to 51 cm",
           value: "*-20",
           field: "width",
         },
         {
           name: "Size",
-          label: "h: 1–10 cm",
+          displayValue: "h: 1–10 cm",
           value: "0.39370078740157477-3.937007874015748",
           field: "height",
         },
@@ -403,25 +403,25 @@ describe("resolveSearchCriteriaLabels", () => {
     expect(labels).toIncludeAllMembers([
       {
         name: "Ways to Buy",
-        label: "Buy Now",
+        displayValue: "Buy Now",
         value: "acquireable",
         field: "acquireable",
       },
       {
         name: "Ways to Buy",
-        label: "Bid",
+        displayValue: "Bid",
         value: "atAuction",
         field: "atAuction",
       },
       {
         name: "Ways to Buy",
-        label: "Inquire",
+        displayValue: "Inquire",
         value: "inquireableOnly",
         field: "inquireableOnly",
       },
       {
         name: "Ways to Buy",
-        label: "Make Offer",
+        displayValue: "Make Offer",
         value: "offerable",
         field: "offerable",
       },
@@ -438,13 +438,13 @@ describe("resolveSearchCriteriaLabels", () => {
     expect(labels).toIncludeAllMembers([
       {
         name: "Material",
-        label: "Acrylic",
+        displayValue: "Acrylic",
         value: "acrylic",
         field: "materialsTerms",
       },
       {
         name: "Material",
-        label: "C-Print",
+        displayValue: "C-Print",
         value: "c-print",
         field: "materialsTerms",
       },
@@ -461,13 +461,13 @@ describe("resolveSearchCriteriaLabels", () => {
     expect(labels).toIncludeAllMembers([
       {
         name: "Artwork Location",
-        label: "Durham, PA, USA",
+        displayValue: "Durham, PA, USA",
         value: "Durham, PA, USA",
         field: "locationCities",
       },
       {
         name: "Artwork Location",
-        label: "New York, NY, USA",
+        displayValue: "New York, NY, USA",
         value: "New York, NY, USA",
         field: "locationCities",
       },
@@ -484,13 +484,13 @@ describe("resolveSearchCriteriaLabels", () => {
     expect(labels).toIncludeAllMembers([
       {
         name: "Time Period",
-        label: "1990–1999",
+        displayValue: "1990–1999",
         value: "1990",
         field: "majorPeriods",
       },
       {
         name: "Time Period",
-        label: "Early 19th Century",
+        displayValue: "Early 19th Century",
         value: "Early 19th Century",
         field: "majorPeriods",
       },
@@ -507,13 +507,13 @@ describe("resolveSearchCriteriaLabels", () => {
     expect(labels).toIncludeAllMembers([
       {
         name: "Color",
-        label: "Blue",
+        displayValue: "Blue",
         value: "blue",
         field: "colors",
       },
       {
         name: "Color",
-        label: "Yellow",
+        displayValue: "Yellow",
         value: "yellow",
         field: "colors",
       },
@@ -537,13 +537,13 @@ describe("resolveSearchCriteriaLabels", () => {
     expect(labels).toIncludeAllMembers([
       {
         name: "Galleries and Institutions",
-        label: "Foo Bar Gallery",
+        displayValue: "Foo Bar Gallery",
         value: "foo-bar-gallery",
         field: "partnerIDs",
       },
       {
         name: "Galleries and Institutions",
-        label: "Baz Qux Gallery",
+        displayValue: "Baz Qux Gallery",
         value: "baz-qux-gallery",
         field: "partnerIDs",
       },

--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -404,25 +404,25 @@ describe("resolveSearchCriteriaLabels", () => {
       {
         name: "Ways to Buy",
         displayValue: "Buy Now",
-        value: "acquireable",
+        value: "true",
         field: "acquireable",
       },
       {
         name: "Ways to Buy",
         displayValue: "Bid",
-        value: "atAuction",
+        value: "true",
         field: "atAuction",
       },
       {
         name: "Ways to Buy",
         displayValue: "Inquire",
-        value: "inquireableOnly",
+        value: "true",
         field: "inquireableOnly",
       },
       {
         name: "Ways to Buy",
         displayValue: "Make Offer",
-        value: "offerable",
+        value: "true",
         field: "offerable",
       },
     ])

--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -20,12 +20,14 @@ describe("resolveSearchCriteriaLabels", () => {
     expect(labels).toIncludeAllMembers([
       {
         name: "Artist",
-        value: "Foo Bar",
+        label: "Foo Bar",
+        value: "foo-bar",
         field: "artistIDs",
       },
       {
         name: "Artist",
-        value: "Baz Qux",
+        label: "Baz Qux",
+        value: "baz-qux",
         field: "artistIDs",
       },
     ])
@@ -46,22 +48,26 @@ describe("resolveSearchCriteriaLabels", () => {
     expect(labels).toIncludeAllMembers([
       {
         name: "Rarity",
-        value: "Unique",
+        label: "Unique",
+        value: "unique",
         field: "attributionClass",
       },
       {
         name: "Rarity",
-        value: "Limited edition",
+        label: "Limited edition",
+        value: "limited edition",
         field: "attributionClass",
       },
       {
         name: "Rarity",
-        value: "Open edition",
+        label: "Open edition",
+        value: "open edition",
         field: "attributionClass",
       },
       {
         name: "Rarity",
-        value: "Unknown edition",
+        label: "Unknown edition",
+        value: "unknown edition",
         field: "attributionClass",
       },
     ])
@@ -92,72 +98,86 @@ describe("resolveSearchCriteriaLabels", () => {
     expect(labels).toIncludeAllMembers([
       {
         name: "Medium",
-        value: "Painting",
+        label: "Painting",
+        value: "painting",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        value: "Photography",
+        label: "Photography",
+        value: "photography",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        value: "Sculpture",
+        label: "Sculpture",
+        value: "sculpture",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        value: "Prints",
+        label: "Prints",
+        value: "prints",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        value: "Work on Paper",
+        label: "Work on Paper",
+        value: "work-on-paper",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        value: "NFT",
+        label: "NFT",
+        value: "nft",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        value: "Design",
+        label: "Design",
+        value: "design",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        value: "Drawing",
+        label: "Drawing",
+        value: "drawing",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        value: "Installation",
+        label: "Installation",
+        value: "installation",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        value: "Film/Video",
+        label: "Film/Video",
+        value: "film-slash-video",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        value: "Jewelry",
+        label: "Jewelry",
+        value: "jewelry",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        value: "Performance Art",
+        label: "Performance Art",
+        value: "performance-art",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        value: "Reproduction",
+        label: "Reproduction",
+        value: "reproduction",
         field: "additionalGeneIDs",
       },
       {
         name: "Medium",
-        value: "Ephemera or Merchandise",
+        label: "Ephemera or Merchandise",
+        value: "ephemera-or-merchandise",
         field: "additionalGeneIDs",
       },
     ])
@@ -174,7 +194,8 @@ describe("resolveSearchCriteriaLabels", () => {
         expect(labels).toIncludeAllMembers([
           {
             name: "Price",
-            value: "$42–$420",
+            label: "$42–$420",
+            value: "42-420",
             field: "priceRange",
           },
         ])
@@ -191,7 +212,8 @@ describe("resolveSearchCriteriaLabels", () => {
         expect(labels).toIncludeAllMembers([
           {
             name: "Price",
-            value: "$42+",
+            label: "$42+",
+            value: "42-*",
             field: "priceRange",
           },
         ])
@@ -208,7 +230,8 @@ describe("resolveSearchCriteriaLabels", () => {
         expect(labels).toIncludeAllMembers([
           {
             name: "Price",
-            value: "$0–$420",
+            label: "$0–$420",
+            value: "*-420",
             field: "priceRange",
           },
         ])
@@ -226,17 +249,20 @@ describe("resolveSearchCriteriaLabels", () => {
     expect(labels).toIncludeAllMembers([
       {
         name: "Size",
-        value: "Large (over 100cm)",
+        label: "Large (over 100cm)",
+        value: "LARGE",
         field: "sizes",
       },
       {
         name: "Size",
-        value: "Medium (40 – 100cm)",
+        label: "Medium (40 – 100cm)",
+        value: "MEDIUM",
         field: "sizes",
       },
       {
         name: "Size",
-        value: "Small (under 40cm)",
+        label: "Small (under 40cm)",
+        value: "SMALL",
         field: "sizes",
       },
     ])
@@ -253,7 +279,8 @@ describe("resolveSearchCriteriaLabels", () => {
       expect(labels).toIncludeAllMembers([
         {
           name: "Size",
-          value: "h: from 1 cm",
+          label: "h: from 1 cm",
+          value: "0.39370078740157477-*",
           field: "height",
         },
       ])
@@ -268,7 +295,8 @@ describe("resolveSearchCriteriaLabels", () => {
       expect(labels).toIncludeAllMembers([
         {
           name: "Size",
-          value: "h: to 10 cm",
+          label: "h: to 10 cm",
+          value: "*-3.937007874015748",
           field: "height",
         },
       ])
@@ -283,7 +311,8 @@ describe("resolveSearchCriteriaLabels", () => {
       expect(labels).toIncludeAllMembers([
         {
           name: "Size",
-          value: "h: 1–10 cm",
+          label: "h: 1–10 cm",
+          value: "0.39370078740157477-3.937007874015748",
           field: "height",
         },
       ])
@@ -298,7 +327,8 @@ describe("resolveSearchCriteriaLabels", () => {
       expect(labels).toIncludeAllMembers([
         {
           name: "Size",
-          value: "w: from 1 cm",
+          label: "w: from 1 cm",
+          value: "0.39370078740157477-*",
           field: "width",
         },
       ])
@@ -313,7 +343,8 @@ describe("resolveSearchCriteriaLabels", () => {
       expect(labels).toIncludeAllMembers([
         {
           name: "Size",
-          value: "w: to 10 cm",
+          label: "w: to 10 cm",
+          value: "*-3.937007874015748",
           field: "width",
         },
       ])
@@ -328,7 +359,8 @@ describe("resolveSearchCriteriaLabels", () => {
       expect(labels).toIncludeAllMembers([
         {
           name: "Size",
-          value: "w: 1–10 cm",
+          label: "w: 1–10 cm",
+          value: "0.39370078740157477-3.937007874015748",
           field: "width",
         },
       ])
@@ -344,12 +376,14 @@ describe("resolveSearchCriteriaLabels", () => {
       expect(labels).toIncludeAllMembers([
         {
           name: "Size",
-          value: "w: to 51 cm",
+          label: "w: to 51 cm",
+          value: "*-20",
           field: "width",
         },
         {
           name: "Size",
-          value: "h: 1–10 cm",
+          label: "h: 1–10 cm",
+          value: "0.39370078740157477-3.937007874015748",
           field: "height",
         },
       ])
@@ -369,22 +403,26 @@ describe("resolveSearchCriteriaLabels", () => {
     expect(labels).toIncludeAllMembers([
       {
         name: "Ways to Buy",
-        value: "Buy Now",
+        label: "Buy Now",
+        value: "acquireable",
         field: "acquireable",
       },
       {
         name: "Ways to Buy",
-        value: "Bid",
+        label: "Bid",
+        value: "atAuction",
         field: "atAuction",
       },
       {
         name: "Ways to Buy",
-        value: "Inquire",
+        label: "Inquire",
+        value: "inquireableOnly",
         field: "inquireableOnly",
       },
       {
         name: "Ways to Buy",
-        value: "Make Offer",
+        label: "Make Offer",
+        value: "offerable",
         field: "offerable",
       },
     ])
@@ -400,12 +438,14 @@ describe("resolveSearchCriteriaLabels", () => {
     expect(labels).toIncludeAllMembers([
       {
         name: "Material",
-        value: "Acrylic",
+        label: "Acrylic",
+        value: "acrylic",
         field: "materialsTerms",
       },
       {
         name: "Material",
-        value: "C-Print",
+        label: "C-Print",
+        value: "c-print",
         field: "materialsTerms",
       },
     ])
@@ -421,11 +461,13 @@ describe("resolveSearchCriteriaLabels", () => {
     expect(labels).toIncludeAllMembers([
       {
         name: "Artwork Location",
+        label: "Durham, PA, USA",
         value: "Durham, PA, USA",
         field: "locationCities",
       },
       {
         name: "Artwork Location",
+        label: "New York, NY, USA",
         value: "New York, NY, USA",
         field: "locationCities",
       },
@@ -442,11 +484,13 @@ describe("resolveSearchCriteriaLabels", () => {
     expect(labels).toIncludeAllMembers([
       {
         name: "Time Period",
-        value: "1990–1999",
+        label: "1990–1999",
+        value: "1990",
         field: "majorPeriods",
       },
       {
         name: "Time Period",
+        label: "Early 19th Century",
         value: "Early 19th Century",
         field: "majorPeriods",
       },
@@ -463,12 +507,14 @@ describe("resolveSearchCriteriaLabels", () => {
     expect(labels).toIncludeAllMembers([
       {
         name: "Color",
-        value: "Blue",
+        label: "Blue",
+        value: "blue",
         field: "colors",
       },
       {
         name: "Color",
-        value: "Yellow",
+        label: "Yellow",
+        value: "yellow",
         field: "colors",
       },
     ])
@@ -491,12 +537,14 @@ describe("resolveSearchCriteriaLabels", () => {
     expect(labels).toIncludeAllMembers([
       {
         name: "Galleries and Institutions",
-        value: "Foo Bar Gallery",
+        label: "Foo Bar Gallery",
+        value: "foo-bar-gallery",
         field: "partnerIDs",
       },
       {
         name: "Galleries and Institutions",
-        value: "Baz Qux Gallery",
+        label: "Baz Qux Gallery",
+        value: "baz-qux-gallery",
         field: "partnerIDs",
       },
     ])

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -21,11 +21,11 @@ type SearchCriteriaLabel = {
   /** The human-friendly name of the filter facet */
   name: string
 
-  /** The human-friendly label of the filter facet */
-  label: string
-
   /** The human-friendly value of the filter facet */
   value: string
+
+  /** The human-friendly label of the filter facet */
+  displayValue: string
 }
 
 /**
@@ -49,13 +49,13 @@ export const SearchCriteriaLabel = new GraphQLObjectType<
       type: GraphQLNonNull(GraphQLString),
       description: "The human-friendly name of the filter facet",
     },
-    label: {
-      type: GraphQLNonNull(GraphQLString),
-      description: "The human-friendly label of the filter facet",
-    },
     value: {
       type: GraphQLNonNull(GraphQLString),
       description: "The human-friendly value of the filter facet",
+    },
+    displayValue: {
+      type: GraphQLNonNull(GraphQLString),
+      description: "The human-friendly label of the filter facet",
     },
   },
 })
@@ -124,7 +124,7 @@ async function getArtistLabels(artistIDs: string[], artistLoader) {
       const artist = await artistLoader(id)
       return {
         name: "Artist",
-        label: artist.name,
+        displayValue: artist.name,
         value: id,
         field: "artistIDs",
       }
@@ -137,7 +137,7 @@ function getRarityLabels(attributionClasses: string[]) {
 
   return attributionClasses.map((attributionClass) => ({
     name: "Rarity",
-    label: allAttributionClasses[attributionClass].name,
+    displayValue: allAttributionClasses[attributionClass].name,
     value: attributionClass,
     field: "attributionClass",
   }))
@@ -171,7 +171,7 @@ function getMediumLabels(additionalGeneIDs: string[]) {
 
   return additionalGeneIDs.map((geneID) => ({
     name: "Medium",
-    label: MEDIUM_GENES[geneID],
+    displayValue: MEDIUM_GENES[geneID],
     value: geneID,
     field: "additionalGeneIDs",
   }))
@@ -196,7 +196,7 @@ function getPriceLabel(priceRange: string): SearchCriteriaLabel | undefined {
 
   return {
     name: "Price",
-    label,
+    displayValue: label,
     value: priceRange,
     field: "priceRange",
   }
@@ -207,7 +207,7 @@ function getSizeLabels(sizes: string[]) {
 
   return sizes.map((size) => ({
     name: "Size",
-    label: SIZES[`${size}`],
+    displayValue: SIZES[`${size}`],
     value: size,
     field: "sizes",
   }))
@@ -251,7 +251,7 @@ function getCustomSizeLabels({
   if (width) {
     labels.push({
       name: "Size",
-      label: extractSizeLabel("w", width),
+      displayValue: extractSizeLabel("w", width),
       value: width,
       field: "width",
     })
@@ -260,7 +260,7 @@ function getCustomSizeLabels({
   if (height) {
     labels.push({
       name: "Size",
-      label: extractSizeLabel("h", height),
+      displayValue: extractSizeLabel("h", height),
       value: height,
       field: "height",
     })
@@ -281,7 +281,7 @@ function getWaysToBuyLabels(waysToBuy: {
   if (acquireable)
     labels.push({
       name: "Ways to Buy",
-      label: "Buy Now",
+      displayValue: "Buy Now",
       value: "acquireable",
       field: "acquireable",
     })
@@ -289,7 +289,7 @@ function getWaysToBuyLabels(waysToBuy: {
   if (atAuction)
     labels.push({
       name: "Ways to Buy",
-      label: "Bid",
+      displayValue: "Bid",
       value: "atAuction",
       field: "atAuction",
     })
@@ -297,7 +297,7 @@ function getWaysToBuyLabels(waysToBuy: {
   if (inquireableOnly)
     labels.push({
       name: "Ways to Buy",
-      label: "Inquire",
+      displayValue: "Inquire",
       value: "inquireableOnly",
       field: "inquireableOnly",
     })
@@ -305,7 +305,7 @@ function getWaysToBuyLabels(waysToBuy: {
   if (offerable)
     labels.push({
       name: "Ways to Buy",
-      label: "Make Offer",
+      displayValue: "Make Offer",
       value: "offerable",
       field: "offerable",
     })
@@ -319,7 +319,7 @@ function getMaterialLabels(materialsTerms: string[]) {
   return materialsTerms.map((term) => {
     return {
       name: "Material",
-      label: toTitleCase(term),
+      displayValue: toTitleCase(term),
       value: term,
       field: "materialsTerms",
     }
@@ -331,7 +331,7 @@ function getLocationLabels(locationCities: string[]): SearchCriteriaLabel[] {
 
   return locationCities.map((city) => ({
     name: "Artwork Location",
-    label: city,
+    displayValue: city,
     value: city,
     field: "locationCities",
   }))
@@ -359,7 +359,7 @@ function getPeriodLabels(majorPeriods: string[]) {
   return majorPeriods.map((period) => {
     return {
       name: "Time Period",
-      label: DISPLAY_TEXT[period] ?? period,
+      displayValue: DISPLAY_TEXT[period] ?? period,
       value: period,
       field: "majorPeriods",
     }
@@ -375,7 +375,7 @@ function getColorLabels(colors: string[]) {
 
     return {
       name: "Color",
-      label: color.name,
+      displayValue: color.name,
       value: color.value,
       field: "colors",
     }
@@ -390,7 +390,7 @@ async function getPartnerLabels(partnerIDs: string[], partnerLoader) {
       const partner = await partnerLoader(id)
       return {
         name: "Galleries and Institutions",
-        label: partner.name,
+        displayValue: partner.name,
         value: id,
         field: "partnerIDs",
       }

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -21,6 +21,9 @@ type SearchCriteriaLabel = {
   /** The human-friendly name of the filter facet */
   name: string
 
+  /** The human-friendly label of the filter facet */
+  label: string
+
   /** The human-friendly value of the filter facet */
   value: string
 }
@@ -45,6 +48,10 @@ export const SearchCriteriaLabel = new GraphQLObjectType<
     name: {
       type: GraphQLNonNull(GraphQLString),
       description: "The human-friendly name of the filter facet",
+    },
+    label: {
+      type: GraphQLNonNull(GraphQLString),
+      description: "The human-friendly label of the filter facet",
     },
     value: {
       type: GraphQLNonNull(GraphQLString),
@@ -117,7 +124,8 @@ async function getArtistLabels(artistIDs: string[], artistLoader) {
       const artist = await artistLoader(id)
       return {
         name: "Artist",
-        value: artist.name,
+        label: artist.name,
+        value: id,
         field: "artistIDs",
       }
     })
@@ -129,7 +137,8 @@ function getRarityLabels(attributionClasses: string[]) {
 
   return attributionClasses.map((attributionClass) => ({
     name: "Rarity",
-    value: allAttributionClasses[attributionClass].name,
+    label: allAttributionClasses[attributionClass].name,
+    value: attributionClass,
     field: "attributionClass",
   }))
 }
@@ -162,7 +171,8 @@ function getMediumLabels(additionalGeneIDs: string[]) {
 
   return additionalGeneIDs.map((geneID) => ({
     name: "Medium",
-    value: MEDIUM_GENES[geneID],
+    label: MEDIUM_GENES[geneID],
+    value: geneID,
     field: "additionalGeneIDs",
   }))
 }
@@ -186,7 +196,8 @@ function getPriceLabel(priceRange: string): SearchCriteriaLabel | undefined {
 
   return {
     name: "Price",
-    value: label,
+    label,
+    value: priceRange,
     field: "priceRange",
   }
 }
@@ -196,7 +207,8 @@ function getSizeLabels(sizes: string[]) {
 
   return sizes.map((size) => ({
     name: "Size",
-    value: SIZES[`${size}`],
+    label: SIZES[`${size}`],
+    value: size,
     field: "sizes",
   }))
 }
@@ -239,7 +251,8 @@ function getCustomSizeLabels({
   if (width) {
     labels.push({
       name: "Size",
-      value: extractSizeLabel("w", width),
+      label: extractSizeLabel("w", width),
+      value: width,
       field: "width",
     })
   }
@@ -247,7 +260,8 @@ function getCustomSizeLabels({
   if (height) {
     labels.push({
       name: "Size",
-      value: extractSizeLabel("h", height),
+      label: extractSizeLabel("h", height),
+      value: height,
       field: "height",
     })
   }
@@ -267,28 +281,32 @@ function getWaysToBuyLabels(waysToBuy: {
   if (acquireable)
     labels.push({
       name: "Ways to Buy",
-      value: "Buy Now",
+      label: "Buy Now",
+      value: "acquireable",
       field: "acquireable",
     })
 
   if (atAuction)
     labels.push({
       name: "Ways to Buy",
-      value: "Bid",
+      label: "Bid",
+      value: "atAuction",
       field: "atAuction",
     })
 
   if (inquireableOnly)
     labels.push({
       name: "Ways to Buy",
-      value: "Inquire",
+      label: "Inquire",
+      value: "inquireableOnly",
       field: "inquireableOnly",
     })
 
   if (offerable)
     labels.push({
       name: "Ways to Buy",
-      value: "Make Offer",
+      label: "Make Offer",
+      value: "offerable",
       field: "offerable",
     })
 
@@ -301,7 +319,8 @@ function getMaterialLabels(materialsTerms: string[]) {
   return materialsTerms.map((term) => {
     return {
       name: "Material",
-      value: toTitleCase(term),
+      label: toTitleCase(term),
+      value: term,
       field: "materialsTerms",
     }
   })
@@ -312,6 +331,7 @@ function getLocationLabels(locationCities: string[]): SearchCriteriaLabel[] {
 
   return locationCities.map((city) => ({
     name: "Artwork Location",
+    label: city,
     value: city,
     field: "locationCities",
   }))
@@ -339,7 +359,8 @@ function getPeriodLabels(majorPeriods: string[]) {
   return majorPeriods.map((period) => {
     return {
       name: "Time Period",
-      value: DISPLAY_TEXT[period] ?? period,
+      label: DISPLAY_TEXT[period] ?? period,
+      value: period,
       field: "majorPeriods",
     }
   })
@@ -354,7 +375,8 @@ function getColorLabels(colors: string[]) {
 
     return {
       name: "Color",
-      value: color.name,
+      label: color.name,
+      value: color.value,
       field: "colors",
     }
   })
@@ -368,7 +390,8 @@ async function getPartnerLabels(partnerIDs: string[], partnerLoader) {
       const partner = await partnerLoader(id)
       return {
         name: "Galleries and Institutions",
-        value: partner.name,
+        label: partner.name,
+        value: id,
         field: "partnerIDs",
       }
     })

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -282,7 +282,7 @@ function getWaysToBuyLabels(waysToBuy: {
     labels.push({
       name: "Ways to Buy",
       displayValue: "Buy Now",
-      value: "acquireable",
+      value: "true",
       field: "acquireable",
     })
 
@@ -290,7 +290,7 @@ function getWaysToBuyLabels(waysToBuy: {
     labels.push({
       name: "Ways to Buy",
       displayValue: "Bid",
-      value: "atAuction",
+      value: "true",
       field: "atAuction",
     })
 
@@ -298,7 +298,7 @@ function getWaysToBuyLabels(waysToBuy: {
     labels.push({
       name: "Ways to Buy",
       displayValue: "Inquire",
-      value: "inquireableOnly",
+      value: "true",
       field: "inquireableOnly",
     })
 
@@ -306,7 +306,7 @@ function getWaysToBuyLabels(waysToBuy: {
     labels.push({
       name: "Ways to Buy",
       displayValue: "Make Offer",
-      value: "offerable",
+      value: "true",
       field: "offerable",
     })
 

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -21,7 +21,7 @@ type SearchCriteriaLabel = {
   /** The human-friendly name of the filter facet */
   name: string
 
-  /** The human-friendly value of the filter facet */
+  /** The value of the filter facet */
   value: string
 
   /** The human-friendly label of the filter facet */
@@ -51,7 +51,7 @@ export const SearchCriteriaLabel = new GraphQLObjectType<
     },
     value: {
       type: GraphQLNonNull(GraphQLString),
-      description: "The human-friendly value of the filter facet",
+      description: "The value of the filter facet",
     },
     displayValue: {
       type: GraphQLNonNull(GraphQLString),


### PR DESCRIPTION
### Description
This PR adds the ability to query the initial value of search criteria, not just the human-readable label. This changes will allow us to replace the current implementation of label extraction for pills on Force/Eigen, where aggregations are now needed.

### Response before
```
[
  {
    "field": "attributionClass",
    "name": "Rarity",
    "value": "Unique"
  },
  {
    "field": "additionalGeneIDs",
    "name": "Medium",
    "value": "Prints"
  },
  {
    "field": "sizes",
    "name": "Size",
    "value": "Small (under 40cm)"
  },
  {
    "field": "acquireable",
    "name": "Ways to Buy",
    "value": "Buy Now"
  },
  {
    "field": "partnerIDs",
    "name": "Galleries and Institutions",
    "value": "3 White Dots"
  }
]
```

### Response now
```
[
  {
    "field": "attributionClass",
    "name": "Rarity",
    "value": "unique", // search criteria value
    "displayValue": "Unique" // human-readable label (it used to be a `value` field)
  },
  {
    "field": "additionalGeneIDs",
    "name": "Medium",
    "value": "prints",
    "displayValue": "Prints"
  },
  {
    "field": "sizes",
    "name": "Size",
    "value": "SMALL",
    "displayValue": "Small (under 40cm)"
  },
  {
    "field": "acquireable",
    "name": "Ways to Buy",
    "value": "true",
    "displayValue": "Buy Now"
  },
  {
    "field": "partnerIDs",
    "name": "Galleries and Institutions",
    "value": "3-white-dots",
    "displayValue": "3 White Dots"
  }
]
```