### PR TITLE
feat: Add importSource to artworks

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1765,6 +1765,9 @@ type Artwork implements Node & Searchable & Sellable {
   imageTitle: String
   imageUrl: String
 
+  # Represents the import source of the artwork
+  importSource: ArtworkImportSource
+
   # Structured questions a collector can inquire on about this work
   inquiryQuestions: [InquiryQuestion]
 
@@ -2003,6 +2006,15 @@ interface ArtworkEdgeInterface {
 union ArtworkFilterFacet = Gene | Tag
 
 union ArtworkHighlight = Article | Show
+
+enum ArtworkImportSource {
+  CONVECTION
+  UNKNOWN
+}
+
+enum ArtworkImportSourceType {
+  CONVECTION
+}
 
 type ArtworkInfoRow {
   # Additional details about given attribute
@@ -9976,7 +9988,7 @@ input MyCollectionCreateArtworkInput {
   editionSize: String
   externalImageUrls: [String]
   height: String
-  importSource: String
+  importSource: ArtworkImportSourceType
   isEdition: Boolean
   medium: String
   metric: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2010,7 +2010,6 @@ union ArtworkHighlight = Article | Show
 enum ArtworkImportSource {
   CONVECTION
   MY_COLLECTION
-  UNKNOWN
 }
 
 type ArtworkInfoRow {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9976,6 +9976,7 @@ input MyCollectionCreateArtworkInput {
   editionSize: String
   externalImageUrls: [String]
   height: String
+  importSource: String
   isEdition: Boolean
   medium: String
   metric: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2012,10 +2012,6 @@ enum ArtworkImportSource {
   UNKNOWN
 }
 
-enum ArtworkImportSourceType {
-  CONVECTION
-}
-
 type ArtworkInfoRow {
   # Additional details about given attribute
   details: String
@@ -9988,7 +9984,7 @@ input MyCollectionCreateArtworkInput {
   editionSize: String
   externalImageUrls: [String]
   height: String
-  importSource: ArtworkImportSourceType
+  importSource: ArtworkImportSource
   isEdition: Boolean
   medium: String
   metric: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2009,6 +2009,7 @@ union ArtworkHighlight = Article | Show
 
 enum ArtworkImportSource {
   CONVECTION
+  MY_COLLECTION
   UNKNOWN
 }
 

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -88,7 +88,7 @@ describe("Artwork type", () => {
       })
     })
 
-    it("returns UNKNOWN if source is unknown", async () => {
+    it("returns null if source is unknown", async () => {
       artwork = {
         ...artwork,
         import_source: "something-else",
@@ -102,7 +102,7 @@ describe("Artwork type", () => {
 
       expect(data).toEqual({
         artwork: {
-          importSource: "UNKNOWN",
+          importSource: null,
         },
       })
     })

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -1,10 +1,9 @@
 /* eslint-disable promise/always-return */
+import gql from "lib/gql"
 import { assign } from "lodash"
 import moment from "moment"
-
-import { runQuery } from "schema/v2/test/utils"
-import gql from "lib/gql"
 import { getMicrofunnelDataByArtworkInternalID } from "schema/v2/artist/targetSupply/utils/getMicrofunnelData"
+import { runQuery } from "schema/v2/test/utils"
 
 jest.mock("schema/v2/artist/targetSupply/utils/getMicrofunnelData")
 
@@ -59,6 +58,72 @@ describe("Artwork type", () => {
         .withArgs(artwork.id)
         .returns(Promise.resolve(artwork)),
     }
+  })
+
+  describe("#importSource", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          importSource
+        }
+      }
+    `
+
+    it("returns properly import source", async () => {
+      artwork = {
+        ...artwork,
+        import_source: "convection",
+      }
+
+      context = {
+        artworkLoader: () => Promise.resolve(artwork),
+      }
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          importSource: "CONVECTION",
+        },
+      })
+    })
+
+    it("returns UNKNOWN if source is unknown", async () => {
+      artwork = {
+        ...artwork,
+        import_source: "something-else",
+      }
+
+      context = {
+        artworkLoader: () => Promise.resolve(artwork),
+      }
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          importSource: "UNKNOWN",
+        },
+      })
+    })
+
+    it("returns null if source is empty", async () => {
+      artwork = {
+        ...artwork,
+      }
+
+      context = {
+        artworkLoader: () => Promise.resolve(artwork),
+      }
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          importSource: null,
+        },
+      })
+    })
   })
 
   describe("#formattedMetadata", () => {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1,6 +1,7 @@
 import config from "config"
 import {
   GraphQLBoolean,
+  GraphQLEnumType,
   GraphQLFieldConfig,
   GraphQLFloat,
   GraphQLInt,
@@ -71,6 +72,16 @@ const has_multiple_editions = (edition_sets) => {
   return edition_sets && edition_sets.length > 1
 }
 
+const IMPORT_SOURCES = {
+  CONVECTION: { value: "convection" },
+  UNKNOWN: { value: "unknown" },
+} as const
+
+const ArtworkImportSourceEnum = new GraphQLEnumType({
+  name: "ArtworkImportSource",
+  values: IMPORT_SOURCES,
+})
+
 export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
   name: "Artwork",
   interfaces: [NodeInterface, Searchable, Sellable],
@@ -134,6 +145,22 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           if (attribution_class) {
             return attributionClasses[attribution_class]
           }
+        },
+      },
+      importSource: {
+        type: ArtworkImportSourceEnum,
+        description: "Represents the import source of the artwork",
+        resolve: ({ import_source }) => {
+          const knownImportSources = [
+            ...Object.values(IMPORT_SOURCES).map(({ value }) => value),
+            undefined,
+          ]
+
+          if (!knownImportSources.includes(import_source)) {
+            return IMPORT_SOURCES.UNKNOWN.value
+          }
+
+          return import_source
         },
       },
       artworkLocation: {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -74,6 +74,8 @@ const has_multiple_editions = (edition_sets) => {
 
 const IMPORT_SOURCES = {
   CONVECTION: { value: "convection" },
+  MY_COLLECTION: { value: "my collection" },
+
   UNKNOWN: { value: "unknown" },
 } as const
 

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -77,7 +77,7 @@ const IMPORT_SOURCES = {
   UNKNOWN: { value: "unknown" },
 } as const
 
-const ArtworkImportSourceEnum = new GraphQLEnumType({
+export const ArtworkImportSourceEnum = new GraphQLEnumType({
   name: "ArtworkImportSource",
   values: IMPORT_SOURCES,
 })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -75,8 +75,6 @@ const has_multiple_editions = (edition_sets) => {
 const IMPORT_SOURCES = {
   CONVECTION: { value: "convection" },
   MY_COLLECTION: { value: "my collection" },
-
-  UNKNOWN: { value: "unknown" },
 } as const
 
 export const ArtworkImportSourceEnum = new GraphQLEnumType({
@@ -155,14 +153,11 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ import_source }) => {
           const knownImportSources = [
             ...Object.values(IMPORT_SOURCES).map(({ value }) => value),
-            undefined,
           ]
 
-          if (!knownImportSources.includes(import_source)) {
-            return IMPORT_SOURCES.UNKNOWN.value
+          if (knownImportSources.includes(import_source)) {
+            return import_source
           }
-
-          return import_source
         },
       },
       artworkLocation: {

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -1,6 +1,6 @@
-import { computeImageSources } from "../myCollectionCreateArtworkMutation"
-import { runAuthenticatedQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import { computeImageSources } from "../myCollectionCreateArtworkMutation"
 
 const newArtwork = { id: "some-artwork-id" }
 const createArtworkLoader = jest.fn().mockResolvedValue(newArtwork)
@@ -50,6 +50,7 @@ const computeMutationInput = ({
           provenance: "Pat Hearn Gallery"
           title: "hey now"
           width: "20"
+          importSource: "convection"
         }
       ) {
         artworkOrError {

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -50,7 +50,7 @@ const computeMutationInput = ({
           provenance: "Pat Hearn Gallery"
           title: "hey now"
           width: "20"
-          importSource: "convection"
+          importSource: CONVECTION
         }
       ) {
         artworkOrError {

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -49,6 +49,15 @@ export const ArtworkAttributionClassEnum = new GraphQLEnumType({
   },
 })
 
+export const ArtworkImportSourceEnum = new GraphQLEnumType({
+  name: "ArtworkImportSourceType",
+  values: {
+    CONVECTION: {
+      value: "convection",
+    },
+  },
+})
+
 export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
   any,
   any,
@@ -66,7 +75,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
 
     // Optional
     importSource: {
-      type: GraphQLString,
+      type: ArtworkImportSourceEnum,
     },
     submissionId: {
       type: GraphQLString,

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -9,6 +9,7 @@ import {
 import { mutationWithClientMutationId } from "graphql-relay"
 import { formatGravityError } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
+import { ArtworkImportSourceEnum } from "../artwork"
 import { MyCollectionArtworkMutationType } from "./myCollection"
 
 const externalUrlRegex = /https:\/\/(?<sourceBucket>.*).s3.amazonaws.com\/(?<sourceKey>.*)/
@@ -45,15 +46,6 @@ export const ArtworkAttributionClassEnum = new GraphQLEnumType({
     },
     UNKNOWN_EDITION: {
       value: "unknown edition",
-    },
-  },
-})
-
-export const ArtworkImportSourceEnum = new GraphQLEnumType({
-  name: "ArtworkImportSourceType",
-  values: {
-    CONVECTION: {
-      value: "convection",
     },
   },
 })

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -1,15 +1,15 @@
 import {
-  GraphQLString,
-  GraphQLList,
-  GraphQLInt,
   GraphQLBoolean,
   GraphQLEnumType,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLString,
 } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
-import { ResolverContext } from "types/graphql"
-import { GraphQLNonNull } from "graphql"
-import { MyCollectionArtworkMutationType } from "./myCollection"
 import { formatGravityError } from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { MyCollectionArtworkMutationType } from "./myCollection"
 
 const externalUrlRegex = /https:\/\/(?<sourceBucket>.*).s3.amazonaws.com\/(?<sourceKey>.*)/
 
@@ -65,6 +65,9 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
     },
 
     // Optional
+    importSource: {
+      type: GraphQLString,
+    },
     submissionId: {
       type: GraphQLString,
     },
@@ -143,6 +146,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
       pricePaidCents,
       pricePaidCurrency,
       attributionClass,
+      importSource,
       ...rest
     },
     {
@@ -170,6 +174,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
         price_paid_currency: pricePaidCurrency,
         artwork_location: artworkLocation,
         attribution_class: attributionClass,
+        import_source: importSource,
         ...rest,
       })
 


### PR DESCRIPTION
Addresses [CX-2455]

## Description

This PR adds `importSource` as an enum to the artwork type and `myCollectionCreateArtworkMutation`. I've added `UNKNOWN` to it because there are no validations in Gravity and import source can be any string. 

Suggestions for a better solution are very welcome :)

[CX-2455]: https://artsyproduct.atlassian.net/browse/CX-2455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ