### PR TITLE
bugfix: User.name to fall back to empty string if name and e-mail aren't available

### DIFF
--- a/src/schema/v2/__tests__/user.test.ts
+++ b/src/schema/v2/__tests__/user.test.ts
@@ -84,6 +84,33 @@ describe("User", () => {
     expect(user.name).toEqual("foo@bar.org")
   })
 
+  it("falls back to empty string for name if name and e-mail are blank", async () => {
+    // This is what returned from Gravity when a non-admin user hits /v1/user/:id
+    const foundUser = {
+      id: "123456",
+      _id: "000012345",
+      name: null,
+    }
+
+    const userByEmailLoader = (data) => {
+      if (data) {
+        return Promise.resolve(foundUser)
+      }
+      throw new Error("Unexpected invocation")
+    }
+
+    const query = gql`
+      {
+        user(email: "foo@bar.com") {
+          name
+        }
+      }
+    `
+
+    const { user } = await runAuthenticatedQuery(query, { userByEmailLoader })
+    expect(user.name).toEqual("")
+  })
+
   it("returns push notification settings for a user", async () => {
     const foundUser = {
       id: "123456",

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -19,7 +19,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
     name: {
       description: "The given name of the user.",
       type: new GraphQLNonNull(GraphQLString),
-      resolve: ({ name, email }) => name || email,
+      resolve: ({ name, email }) => name || email || "",
     },
     email: {
       description: "The given email of the user.",


### PR DESCRIPTION
Due to gravity permissioning, we return different fields from /v1/user/:id depending on the access token. This was causing the orders screen for partners to be blank.

Slack thread: https://artsy.slack.com/archives/C9ZJYFDNF/p1647880485569109