### PR TITLE
feat: Add status for LOT_CLOSED when bidder position is on a sale that is open but a lot that is closed

### DIFF
--- a/src/schema/v2/me/__tests__/bidder_position.test.js
+++ b/src/schema/v2/me/__tests__/bidder_position.test.js
@@ -55,6 +55,28 @@ describe("BidderPosition", () => {
             processed_at: "2018-04-26T14:15:52+00:00",
             active: false,
             errors: ["Lot must be open"],
+            bidder: {
+              sale: {
+                auction_state: "closed",
+              },
+            },
+            sale_artwork: {
+              reserve_status: "reserve_met",
+            },
+          },
+        })
+      )
+      .mockReturnValueOnce(
+        Promise.resolve({
+          body: {
+            processed_at: "2018-04-26T14:15:52+00:00",
+            active: false,
+            errors: ["Lot must be open"],
+            bidder: {
+              sale: {
+                auction_state: "open",
+              },
+            },
             sale_artwork: {
               reserve_status: "reserve_met",
             },
@@ -137,6 +159,20 @@ describe("BidderPosition", () => {
       expect(me).toEqual({
         bidderPosition: {
           status: "SALE_CLOSED",
+          messageHeader: "Lot closed",
+          messageDescriptionMD: `Sorry, your bid wasn’t received before the lot closed.`,
+          position: {
+            processedAt: "2018-04-26T14:15:52+00:00",
+          },
+        },
+      })
+    })
+  })
+  it("returns lot closed when the lot is closed and sale is still open", () => {
+    return runAuthenticatedQuery(query, context).then(({ me }) => {
+      expect(me).toEqual({
+        bidderPosition: {
+          status: "LOT_CLOSED",
           messageHeader: "Lot closed",
           messageDescriptionMD: `Sorry, your bid wasn’t received before the lot closed.`,
           position: {

--- a/src/schema/v2/me/bidder_position.ts
+++ b/src/schema/v2/me/bidder_position.ts
@@ -39,7 +39,11 @@ export const BidderPosition: GraphQLFieldConfig<void, ResolverContext> = {
             position.errors &&
             position.errors.includes("Lot must be open")
           ) {
-            status = "SALE_CLOSED"
+            if (position.bidder.sale.auction_state === "open") {
+              status = "LOT_CLOSED"
+            } else {
+              status = "SALE_CLOSED"
+            }
           } else if (!position.processed_at) {
             return {
               status: "PENDING",

--- a/src/schema/v2/me/bidder_position_messages.ts
+++ b/src/schema/v2/me/bidder_position_messages.ts
@@ -5,6 +5,7 @@ interface BiddingMessage {
     | "OUTBID"
     | "RESERVE_NOT_MET"
     | "SALE_CLOSED"
+    | "LOT_CLOSED"
     | "LIVE_BIDDING_STARTED"
     | "BIDDER_NOT_QUALIFIED"
     | "ERROR"
@@ -31,6 +32,13 @@ export const bidderPositionMessages: BiddingMessage[] = [
   {
     status: "SALE_CLOSED",
     message: "Sale Closed to Bids",
+    header: "Lot closed",
+    getDescription: () =>
+      "Sorry, your bid wasn’t received before the lot closed.",
+  },
+  {
+    status: "LOT_CLOSED",
+    message: "Lot Closed to Bids",
     header: "Lot closed",
     getDescription: () =>
       "Sorry, your bid wasn’t received before the lot closed.",


### PR DESCRIPTION
This PR adds a new error state for bidder positions when a lot is closed but the sale is still open.

[BID-257](https://artsyproduct.atlassian.net/browse/BID-257)

I chose to do this in MP because we append the error "Lot must be open" in Gravity ([here](https://github.com/artsy/gravity/blob/1d339c53d3482b522952b9534b31ae774e70c50a/app/models/lot_events/max_bid_placed.rb#L217)) so even the `SALE_CLOSED` case checks for that error. Interested in feedback on doing this extra check the position's sale's auction state. 

Here's what it looks like in Force w/ [corresponding Force PR](https://github.com/artsy/force/pull/9721):
<img width="442" alt="Screen Shot 2022-03-23 at 1 09 02 PM" src="https://user-images.githubusercontent.com/9466631/159759293-cbc6cb92-2232-4c93-a209-7b8707276e92.png">

Example: Must be run on a bidder position that was placed on a lot that was closed but when the sale was open:
example from staging that will work for a few days: `{
	"bidderPositionID": "94964"
}`
```graphql
query useBidderPositionQuery($bidderPositionID: String!) {
          me {
            bidderPosition(id: $bidderPositionID) {
              status
              messageHeader
              position {
                internalID
                suggestedNextBid {
                  cents
                  display
                }
                saleArtwork {
                  artwork {
                    title
                  }
                }
              }
            }
          }
        }
```