### PR TITLE
chore(GRO-844): Remove input values that aren't used by Gravity

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9937,10 +9937,8 @@ type NotificationPreference {
 }
 
 input NotificationPreferenceInput {
-  channel: String!
-  id: String!
   name: String!
-  status: SubGroupStatus!
+  status: SubGroupInputStatus!
 }
 
 # Consignment Offer Response
@@ -13245,6 +13243,11 @@ type StaticContent {
 
   # A slug ID.
   slug: ID!
+}
+
+enum SubGroupInputStatus {
+  SUBSCRIBED
+  UNSUBSCRIBED
 }
 
 enum SubGroupStatus {

--- a/src/schema/v2/notification_preferences.ts
+++ b/src/schema/v2/notification_preferences.ts
@@ -21,7 +21,7 @@ export const convertSubGroups = (subGroups) => {
   return params
 }
 
-const subGroupfields = {
+const subGroupFields = {
   id: {
     type: new GraphQLNonNull(GraphQLString),
   },
@@ -44,14 +44,31 @@ const subGroupfields = {
   },
 }
 
+const subGroupInputFields = {
+  name: {
+    type: new GraphQLNonNull(GraphQLString),
+  },
+  status: {
+    type: new GraphQLNonNull(
+      new GraphQLEnumType({
+        name: "SubGroupInputStatus",
+        values: {
+          SUBSCRIBED: { value: "Subscribed" },
+          UNSUBSCRIBED: { value: "Unsubscribed" },
+        },
+      })
+    ),
+  },
+}
+
 const NotificationPreferenceType = new GraphQLObjectType({
   name: "NotificationPreference",
-  fields: subGroupfields,
+  fields: subGroupFields,
 })
 
 const NotificationPreferenceInputType = new GraphQLInputObjectType({
   name: "NotificationPreferenceInput",
-  fields: subGroupfields,
+  fields: subGroupInputFields,
 })
 
 export const notificationPreferences: GraphQLFieldConfig<


### PR DESCRIPTION
The `channel` and `id` fields aren't used by [Gravity](https://github.com/artsy/gravity/blob/main/app/api/v1/notification_preferences_endpoint.rb), so we can remove them and simplify the component using this data! 