### PR TITLE
fix: Make title unrequired again in myCollectionUpdateArtworkMutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10054,7 +10054,7 @@ input MyCollectionUpdateArtworkInput {
   pricePaidCurrency: String
   provenance: String
   submissionId: String
-  title: String!
+  title: String
   width: String
 }
 

--- a/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
@@ -102,7 +102,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
       type: GraphQLString,
     },
     title: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: GraphQLString,
     },
     width: {
       type: GraphQLString,


### PR DESCRIPTION

## Description

`title` doesn't need to be required when updating an artwork. It's just required when creating an artwork to prevent artworks without a title in My Collection. This change is needed to update the submission_id when a submission gets created for a My Collection artwork.

Context can be found here: https://github.com/artsy/metaphysics/pull/3638