### PR TITLE
fix: Check if ComparableAuctionResults date is a valid integer

### DIFF
--- a/src/lib/__tests__/helpers.test.ts
+++ b/src/lib/__tests__/helpers.test.ts
@@ -2,7 +2,7 @@ import {
   convertConnectionArgsToGravityArgs,
   exclude,
   isExisty,
-  isPositiveInteger,
+  isInteger,
   markdownToText,
   removeEmptyValues,
   removeNulls,
@@ -276,14 +276,14 @@ describe("convertConnectionArgsToGravityArgs", () => {
   })
 })
 
-describe("isPositiveInteger", () => {
-  it("only returns true if the input is a positive integer", () => {
-    expect(isPositiveInteger("0")).toEqual(false)
-    expect(isPositiveInteger("1")).toEqual(true)
-    expect(isPositiveInteger("-1")).toEqual(false)
-    expect(isPositiveInteger("1.5")).toEqual(false)
-    expect(isPositiveInteger("test")).toEqual(false)
-    expect(isPositiveInteger("")).toEqual(false)
-    expect(isPositiveInteger("   ")).toEqual(false)
+describe("isInteger", () => {
+  it("only returns true if the input string is a valid integer", () => {
+    expect(isInteger("0")).toEqual(true)
+    expect(isInteger("1")).toEqual(true)
+    expect(isInteger("-1")).toEqual(true)
+    expect(isInteger("1.5")).toEqual(false)
+    expect(isInteger("test")).toEqual(false)
+    expect(isInteger("")).toEqual(false)
+    expect(isInteger("   ")).toEqual(false)
   })
 })

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -226,10 +226,12 @@ export const extractNodes = <Node extends object, T = Node>(
   )
 }
 
-export const isPositiveInteger = (str: string) => {
+export const isInteger = (str: string) => {
+  return Number.isInteger(parseFloat(str))
+
   const num = Number(str)
 
-  if (Number.isInteger(num) && num > 0) {
+  if (Number.isInteger(num)) {
     return true
   }
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -228,12 +228,4 @@ export const extractNodes = <Node extends object, T = Node>(
 
 export const isInteger = (str: string) => {
   return Number.isInteger(parseFloat(str))
-
-  const num = Number(str)
-
-  if (Number.isInteger(num)) {
-    return true
-  }
-
-  return false
 }

--- a/src/schema/v2/artwork/comparableAuctionResults.ts
+++ b/src/schema/v2/artwork/comparableAuctionResults.ts
@@ -1,9 +1,6 @@
 import { GraphQLFieldConfig } from "graphql"
 import { connectionFromArraySlice } from "graphql-relay"
-import {
-  convertConnectionArgsToGravityArgs,
-  isPositiveInteger,
-} from "lib/helpers"
+import { convertConnectionArgsToGravityArgs, isInteger } from "lib/helpers"
 import { isNull, merge, omitBy } from "lodash"
 import { pageable } from "relay-cursor-paging"
 import { ResolverContext } from "types/graphql"
@@ -26,7 +23,7 @@ export const ComparableAuctionResults: GraphQLFieldConfig<
 
     const comparableAuctionResultsParams = {
       artist_id: artwork.artist._id,
-      date: isPositiveInteger(artwork.date) ? artwork.date : undefined,
+      date: isInteger(artwork.date) ? artwork.date : undefined,
       height_cm: artwork.height_cm,
       width_cm: artwork.width_cm,
       depth_cm: artwork.depth_cm,


### PR DESCRIPTION
Addresses [CX-2467]

## Description

Check if ComparableAuctionResults date is a valid integer to allow negative dates like `-200`.

Follow up for https://github.com/artsy/metaphysics/pull/3907

[CX-2467]: https://artsyproduct.atlassian.net/browse/CX-2467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ