### PR TITLE
feat: update stitched `savedSearchesConnection` to support new `sort` input argument

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -12767,6 +12767,9 @@ type Query {
 
     # Returns the last _n_ elements from the list.
     last: Int
+
+    # Returns saved searches sorted by input (default: by created date in descending order)
+    sort: SavedSearchesSortEnum
   ): SearchCriteriaConnection
 
   # List enabled Two-Factor Authentication factors
@@ -14245,6 +14248,11 @@ input SaveArtworkInput {
 type SaveArtworkPayload {
   artwork: Artwork
   clientMutationId: String
+}
+
+enum SavedSearchesSortEnum {
+  CREATED_AT_DESC
+  NAME_ASC
 }
 
 # Saved Search User Alert Settings

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -14251,7 +14251,10 @@ type SaveArtworkPayload {
 }
 
 enum SavedSearchesSortEnum {
+  # Sort by created date in descending order
   CREATED_AT_DESC
+
+  # Sort by name in ascending order
   NAME_ASC
 }
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9489,6 +9489,7 @@ type Me implements Node {
     before: String
     first: Int
     last: Int
+    sort: SavedSearchesSortEnum
   ): SearchCriteriaConnection
   secondFactors(kinds: [SecondFactorKind]): [SecondFactor]
   shareFollows: Boolean!
@@ -11214,6 +11215,9 @@ type Query {
 
     # Returns the last _n_ elements from the list.
     last: Int
+
+    # Returns saved searches sorted by input (default: by created date in descending order)
+    sort: SavedSearchesSortEnum
   ): SearchCriteriaConnection
 
   # List enabled Two-Factor Authentication factors
@@ -12819,6 +12823,11 @@ type SavedArtworksEdge {
 
   # The item at the end of the edge
   node: Artwork
+}
+
+enum SavedSearchesSortEnum {
+  CREATED_AT_DESC
+  NAME_ASC
 }
 
 # Saved Search User Alert Settings

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12826,7 +12826,10 @@ type SavedArtworksEdge {
 }
 
 enum SavedSearchesSortEnum {
+  # Sort by created date in descending order
   CREATED_AT_DESC
+
+  # Sort by name in ascending order
   NAME_ASC
 }
 

--- a/src/data/gravity.graphql
+++ b/src/data/gravity.graphql
@@ -1519,6 +1519,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Returns saved searches sorted by input (default: by created date in descending order)
+    """
+    sort: SavedSearchesSortEnum
   ): SearchCriteriaConnection
 
   """
@@ -1888,6 +1893,11 @@ type SavedSearchUserAlertSettings {
   email: Boolean!
   name: String
   push: Boolean!
+}
+
+enum SavedSearchesSortEnum {
+  CREATED_AT_DESC
+  NAME_ASC
 }
 
 """

--- a/src/data/gravity.graphql
+++ b/src/data/gravity.graphql
@@ -1896,7 +1896,14 @@ type SavedSearchUserAlertSettings {
 }
 
 enum SavedSearchesSortEnum {
+  """
+  Sort by created date in descending order
+  """
   CREATED_AT_DESC
+
+  """
+  Sort by name in ascending order
+  """
   NAME_ASC
 }
 

--- a/src/lib/stitching/gravity/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/gravity/__tests__/__snapshots__/schema.test.ts.snap
@@ -754,6 +754,9 @@ type Query {
 
     # Returns the last _n_ elements from the list.
     last: Int
+
+    # Returns saved searches sorted by input (default: by created date in descending order)
+    sort: SavedSearchesSortEnum
   ): SearchCriteriaConnection
 
   # List enabled Two-Factor Authentication factors
@@ -867,6 +870,14 @@ type SaleAdministrationFields {
   partnerTier: String
   region: String
   status: String
+}
+
+enum SavedSearchesSortEnum {
+  # Sort by created date in descending order
+  CREATED_AT_DESC
+
+  # Sort by name in ascending order
+  NAME_ASC
 }
 
 # Saved Search User Alert Settings

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -72,6 +72,7 @@ export const gravityStitchingEnvironment = (
           last: Int
           after: String
           before: String
+          sort: SavedSearchesSortEnum
         ): SearchCriteriaConnection
         secondFactors(kinds: [SecondFactorKind]): [SecondFactor]
         addressConnection(


### PR DESCRIPTION
Type: **Feature**
Jira ticket: [FX-3831]
Gravity PR: artsy/gravity#15166

### Acceptance Criteria
* `sort` argument must support `CREATED_AT_DESC`
* `sort` argument must support `NAME_ASC`
* As a developer, I can execute the following GraphQL query against Metaphysics (e.g. via Insomnia).
```graphql
{
  me {
    savedSearchesConnection(sort: CREATED_AT_DESC) {
      edges {
        node {
          userAlertSettings {
            name
          }
        }
      }
    }
  }
}
```

[FX-3831]: https://artsyproduct.atlassian.net/browse/FX-3831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ