### PR TITLE
chore: Use user tz for cascade end time timing fields

### DIFF
--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -250,28 +250,31 @@ export function cascadingFormattedStartDateTime(
   endedAt,
   timezone
 ) {
-  const thisMoment = moment.tz(moment(), timezone)
-  const lotsClosingMoment = moment.tz(endAt, timezone)
-  const saleEndMoment = moment.tz(endedAt, timezone) // only used for formatting
+  const tz = timezone || DEFAULT_TZ
+  const thisMoment = moment.tz(moment(), tz)
+  const lotsClosingMoment = moment.tz(endAt, tz)
+  const saleEndMoment = moment.tz(endedAt, tz) // only used for formatting
 
   if (!!endedAt) return `Closed ${saleEndMoment.format("MMM D, YYYY")}`
 
   if (thisMoment.isAfter(lotsClosingMoment)) return "Closing soon"
 
-  return dateRange(startAt, endAt, timezone, "long")
+  return dateRange(startAt, endAt, tz, "long")
 }
 
 export function auctionsDetailFormattedStartDateTime(
   startAt,
   endAt,
   endedAt,
-  liveStartAt
+  liveStartAt,
+  timezone
 ) {
-  const thisMoment = moment.tz(moment(), "GMT")
-  const saleStartMoment = moment.tz(startAt, "GMT")
-  const lotsClosingMoment = moment.tz(endAt, "GMT")
-  const saleEndMoment = moment.tz(endedAt, "GMT")
-  const liveStartMoment = moment.tz(liveStartAt, "GMT")
+  const tz = timezone || DEFAULT_TZ
+  const thisMoment = moment.tz(moment(), tz)
+  const saleStartMoment = moment.tz(startAt, tz)
+  const lotsClosingMoment = moment.tz(endAt, tz)
+  const saleEndMoment = moment.tz(endedAt, tz)
+  const liveStartMoment = moment.tz(liveStartAt, tz)
 
   if (!!endedAt)
     return `Closed ${saleEndMoment.format(
@@ -299,8 +302,9 @@ export function auctionsDetailFormattedStartDateTime(
   )} • ${lotsClosingMoment.format("h:mma z")}`
 }
 
-export function formattedEndDateTime(endAt) {
-  const lotEndMoment = moment.tz(endAt, "GMT")
+export function formattedEndDateTime(endAt, timezone) {
+  const tz = timezone || DEFAULT_TZ
+  const lotEndMoment = moment.tz(endAt, tz)
   return `Closes, ${lotEndMoment.format("MMM D")} • ${lotEndMoment.format(
     "h:mma z"
   )}`

--- a/src/schema/v2/__tests__/sale_artwork.test.js
+++ b/src/schema/v2/__tests__/sale_artwork.test.js
@@ -557,7 +557,7 @@ describe("SaleArtwork type", () => {
 
       expect(await execute(query, saleArtwork, context)).toEqual({
         node: {
-          formattedEndDateTime: "Closes, Feb 19 • 11:00am GMT",
+          formattedEndDateTime: "Closes, Feb 19 • 11:00am UTC",
         },
       })
     })

--- a/src/schema/v2/sale/__tests__/index.test.ts
+++ b/src/schema/v2/sale/__tests__/index.test.ts
@@ -900,7 +900,7 @@ describe("Sale type", () => {
         start_at: moment().add(3, "days"),
       })
       expect(response.sale.cascadingEndTime.formattedStartDateTime).toEqual(
-        "Mar 11, 2022 • 12:33pm GMT"
+        "Mar 11, 2022 • 12:33pm UTC"
       )
     })
 
@@ -909,7 +909,7 @@ describe("Sale type", () => {
         ended_at: moment().subtract(1, "days"),
       })
       expect(response.sale.cascadingEndTime.formattedStartDateTime).toEqual(
-        "Closed Mar 7, 2022 • 12:33pm GMT"
+        "Closed Mar 7, 2022 • 12:33pm UTC"
       )
     })
 
@@ -918,7 +918,7 @@ describe("Sale type", () => {
         end_at: moment().subtract(1, "days"),
       })
       expect(response.sale.cascadingEndTime.formattedStartDateTime).toEqual(
-        "Mar 7, 2022 • 12:33pm GMT"
+        "Mar 7, 2022 • 12:33pm UTC"
       )
     })
 
@@ -927,7 +927,7 @@ describe("Sale type", () => {
         live_start_at: moment().add(1, "days"),
       })
       expect(response.sale.cascadingEndTime.formattedStartDateTime).toEqual(
-        "Live Mar 9, 2022 • 12:33pm GMT"
+        "Live Mar 9, 2022 • 12:33pm UTC"
       )
     })
 

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -246,13 +246,15 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
                 "A more granular formatted description of when the auction starts or ends if it has ended",
               resolve: (
                 { start_at, end_at, ended_at, live_start_at },
-                _options
+                _options,
+                { defaultTimezone }
               ) => {
                 return auctionsDetailFormattedStartDateTime(
                   start_at,
                   end_at,
                   ended_at,
-                  live_start_at
+                  live_start_at,
+                  defaultTimezone
                 )
               },
             },

--- a/src/schema/v2/sale_artwork.ts
+++ b/src/schema/v2/sale_artwork.ts
@@ -167,7 +167,7 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
       formattedEndDateTime: {
         type: GraphQLString,
         description: "A formatted description of the lot end date and time",
-        resolve: (saleArtwork, _options, { saleLoader }) =>
+        resolve: (saleArtwork, _options, { defaultTimezone, saleLoader }) =>
           saleLoader(saleArtwork.sale_id).then((sale) => {
             if (
               !sale.cascading_end_time_interval ||
@@ -176,7 +176,7 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
             ) {
               return null
             } else {
-              return formattedEndDateTime(saleArtwork.end_at)
+              return formattedEndDateTime(saleArtwork.end_at, defaultTimezone)
             }
           }),
       },


### PR DESCRIPTION
[BX-309](https://artsyproduct.atlassian.net/browse/BID-309)

Update cascading-end-time-relevant time fields to show local timezone or if not present, UTC.

Lot grid:
<img width="970" alt="Screen Shot 2022-03-30 at 2 56 34 PM" src="https://user-images.githubusercontent.com/9466631/160912305-ccfed1eb-22ef-43c7-ab97-b4e2b8d3c584.png">

Sale details:
<img width="615" alt="Screen Shot 2022-03-30 at 2 56 39 PM" src="https://user-images.githubusercontent.com/9466631/160912278-294c2e9c-20fb-4e02-b7d3-8dc72ff56529.png">

Lot page (date/time below timer):
<img width="1265" alt="Screen Shot 2022-03-30 at 2 57 14 PM" src="https://user-images.githubusercontent.com/9466631/160912234-e1c42705-7b95-41db-ac04-71162ed6b9ec.png">

