### PR TITLE
feat: Add data transfer bool for user

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14158,10 +14158,11 @@ type UpdateUserDefaultAddressPayload {
 
 input UpdateUserMutationInput {
   clientMutationId: String
+  dataTransferOptOut: Boolean
   email: String!
   id: String!
   name: String!
-  phone: String!
+  phone: String
 }
 
 type UpdateUserMutationPayload {
@@ -14220,6 +14221,9 @@ type UpdateViewingRoomSubsectionsPayload {
 type User {
   analytics: AnalyticsUserStats
   cached: Int
+
+  # Has the user opted out of data transfer.
+  dataTransferOptOut: Boolean
   devices: [Device!]!
 
   # The given email of the user.

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -42,6 +42,11 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
       description: "Pin for bidding at an auction",
       type: GraphQLString,
     },
+    dataTransferOptOut: {
+      description: "Has the user opted out of data transfer.",
+      type: GraphQLBoolean,
+      resolve: ({ data_transfer_opt_out }) => data_transfer_opt_out,
+    },
     paddleNumber: {
       description: "The paddle number of the user",
       type: GraphQLString,

--- a/src/schema/v2/users/updateUserMutation.ts
+++ b/src/schema/v2/users/updateUserMutation.ts
@@ -1,20 +1,22 @@
-import { GraphQLNonNull, GraphQLString } from "graphql"
+import { GraphQLBoolean, GraphQLNonNull, GraphQLString } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 import { ResolverContext } from "types/graphql"
 import { snakeCase } from "lodash"
 
 interface Input {
   id: string
+  dataTransferOptOut?: boolean
   email: string
   name: string
-  phone: string
+  phone?: string
 }
 
 interface GravityInput {
   id: string
+  data_transfer_opt_out?: boolean
   email: string
   name: string
-  phone: string
+  phone?: string
 }
 
 interface GravityError {
@@ -31,9 +33,10 @@ export const updateUserMutation = mutationWithClientMutationId<
   description: "Update the user",
   inputFields: {
     id: { type: new GraphQLNonNull(GraphQLString) },
+    dataTransferOptOut: { type: GraphQLBoolean },
     email: { type: new GraphQLNonNull(GraphQLString) },
     name: { type: new GraphQLNonNull(GraphQLString) },
-    phone: { type: new GraphQLNonNull(GraphQLString) },
+    phone: { type: GraphQLString },
   },
   outputFields: {},
   mutateAndGetPayload: async (args, { updateUserLoader }) => {


### PR DESCRIPTION
Small one - turns out there was only one missing field for user data. I wrongly assumed some other fields were on user but they are actually on the SaleProfile model in Gravity. That means all I had to do here was add this flag to the query and mutation in order for Forque to be able to edit it.

While I was working through this I realized that I wrongly typed the phone number is NOT optional - it can def be `nil` in Gravity.