### PR TITLE
fix: parse error for sizes in `previewSavedSearch`

### DIFF
--- a/src/schema/v2/__tests__/previewSavedSearch.test.ts
+++ b/src/schema/v2/__tests__/previewSavedSearch.test.ts
@@ -27,4 +27,41 @@ describe("previewSavedSearch", () => {
       },
     ])
   })
+
+  it("returns a previewed saved search for sizes", async () => {
+    const query = gql`
+      {
+        previewSavedSearch(attributes: { sizes: [SMALL, MEDIUM, LARGE] }) {
+          labels {
+            field
+            name
+            displayValue
+            value
+          }
+        }
+      }
+    `
+    const { previewSavedSearch } = await runQuery(query)
+
+    expect(previewSavedSearch.labels).toEqual([
+      {
+        field: "sizes",
+        name: "Size",
+        displayValue: "Small (under 40cm)",
+        value: "SMALL",
+      },
+      {
+        field: "sizes",
+        name: "Size",
+        displayValue: "Medium (40 – 100cm)",
+        value: "MEDIUM",
+      },
+      {
+        field: "sizes",
+        name: "Size",
+        displayValue: "Large (over 100cm)",
+        value: "LARGE",
+      },
+    ])
+  })
 })

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -205,12 +205,16 @@ function getPriceLabel(priceRange: string): SearchCriteriaLabel | undefined {
 function getSizeLabels(sizes: string[]) {
   if (!sizes?.length) return []
 
-  return sizes.map((size) => ({
-    name: "Size",
-    displayValue: SIZES[`${size}`],
-    value: size,
-    field: "sizes",
-  }))
+  return sizes.map((size) => {
+    const sizeInUppercase = size.toUpperCase()
+
+    return {
+      name: "Size",
+      displayValue: SIZES[sizeInUppercase],
+      value: sizeInUppercase,
+      field: "sizes",
+    }
+  })
 }
 
 const convertToCentimeters = (element: number) => {


### PR DESCRIPTION
Type: **Fix**

### Description
[ArtworkSizes](https://github.com/artsy/metaphysics/blob/main/src/schema/v2/artwork/artworkSizes.ts#L3-L16) values are stored in lowercase and for this reason we received an error when [parsing values](https://github.com/artsy/metaphysics/blob/main/src/schema/v2/searchCriteriaLabel.ts#L210) in [getSizeLabels](https://github.com/artsy/metaphysics/blob/main/src/schema/v2/searchCriteriaLabel.ts#L205-L214)

### Before
<img width="1631" alt="error" src="https://user-images.githubusercontent.com/3513494/161316394-42fc3060-7533-4517-b61e-423c0689226f.png">

### After
<img width="1631" alt="fixed-error" src="https://user-images.githubusercontent.com/3513494/161316477-e909de14-6bf9-45f8-9fd2-38ea3f8bddba.png">
