### PR TITLE
feat: update user schema and mutations for order notifications

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9437,6 +9437,9 @@ type Me implements Node {
   # This user should receive new works notifications
   receiveNewWorksNotification: Boolean
 
+  # This user should receive order notifications
+  receiveOrderNotification: Boolean
+
   # This user should receive outbid notifications
   receiveOutbidNotification: Boolean
 
@@ -13992,6 +13995,9 @@ input UpdateMyProfileInput {
   # This user should receive new works notifications
   receiveNewWorksNotification: Boolean
 
+  # This user should receive order notifications
+  receiveOrderNotification: Boolean
+
   # This user should receive outbid notifications
   receiveOutbidNotification: Boolean
 
@@ -14261,6 +14267,9 @@ type User {
 
   # This user should receive new works notifications
   receiveNewWorksNotification: Boolean
+
+  # This user should receive order notifications
+  receiveOrderNotification: Boolean
 
   # This user should receive outbid notifications
   receiveOutbidNotification: Boolean

--- a/src/schema/v2/__tests__/user.test.ts
+++ b/src/schema/v2/__tests__/user.test.ts
@@ -125,6 +125,7 @@ describe("User", () => {
       receive_new_works_notification: true,
       receive_new_sales_notification: false,
       receive_promotion_notification: false,
+      receive_order_notification: true,
     }
 
     const userByEmailLoader = (data) => {
@@ -147,6 +148,7 @@ describe("User", () => {
           receiveNewWorksNotification
           receiveNewSalesNotification
           receivePromotionNotification
+          receiveOrderNotification
         }
       }
     `
@@ -162,5 +164,6 @@ describe("User", () => {
     expect(user.receiveNewWorksNotification).toEqual(true)
     expect(user.receiveNewSalesNotification).toEqual(false)
     expect(user.receivePromotionNotification).toEqual(false)
+    expect(user.receiveOrderNotification).toEqual(true)
   })
 })

--- a/src/schema/v2/me/__tests__/__snapshots__/update_me_mutation.test.js.snap
+++ b/src/schema/v2/me/__tests__/__snapshots__/update_me_mutation.test.js.snap
@@ -36,6 +36,7 @@ Object {
       "receiveLotOpeningSoonNotification": false,
       "receiveNewSalesNotification": false,
       "receiveNewWorksNotification": true,
+      "receiveOrderNotification": false,
       "receiveOutbidNotification": false,
       "receivePromotionNotification": false,
       "receivePurchaseNotification": false,

--- a/src/schema/v2/me/__tests__/index.test.ts
+++ b/src/schema/v2/me/__tests__/index.test.ts
@@ -20,6 +20,7 @@ describe("me/index", () => {
         receiveNewWorksNotification
         receiveNewSalesNotification
         receivePromotionNotification
+        receiveOrderNotification
         currencyPreference
         lengthUnitPreference
       }
@@ -74,6 +75,7 @@ describe("me/index", () => {
       receive_new_works_notification: false,
       receive_new_sales_notification: true,
       receive_promotion_notification: false,
+      receive_order_notification: false,
       currency_preference: "USD",
       length_unit_preference: "in",
     }
@@ -98,6 +100,7 @@ describe("me/index", () => {
           receiveNewWorksNotification: false,
           receiveNewSalesNotification: true,
           receivePromotionNotification: false,
+          receiveOrderNotification: false,
           currencyPreference: "USD",
           lengthUnitPreference: "IN",
         },

--- a/src/schema/v2/me/__tests__/update_me_mutation.test.js
+++ b/src/schema/v2/me/__tests__/update_me_mutation.test.js
@@ -25,6 +25,7 @@ describe("UpdateMeMutation", () => {
             receivePromotionNotification: false
             receivePurchaseNotification: false
             receiveSaleOpeningClosingNotification: false
+            receiveOrderNotification: false
             shareFollows: false
             currencyPreference: EUR
             lengthUnitPreference: CM
@@ -45,6 +46,7 @@ describe("UpdateMeMutation", () => {
             receiveNewWorksNotification
             receiveNewSalesNotification
             receivePromotionNotification
+            receiveOrderNotification
           }
           userOrError {
             ... on UpdateMyProfileMutationSuccess {
@@ -83,6 +85,7 @@ describe("UpdateMeMutation", () => {
         receive_promotion_notification: false,
         receive_purchase_notification: false,
         receive_sale_opening_closing_notification: false,
+        receive_order_notification: false,
         currency_preference: "EUR",
         length_unit_preference: "cm",
       })
@@ -105,6 +108,7 @@ describe("UpdateMeMutation", () => {
           receive_promotion_notification: true,
           receive_purchase_notification: true,
           receive_sale_opening_closing_notification: true,
+          receive_order_notification: true,
           currency_preference: "EUR",
           length_unit_preference: "cm",
         }),
@@ -133,6 +137,7 @@ describe("UpdateMeMutation", () => {
       receive_promotion_notification: false,
       receive_purchase_notification: false,
       receive_sale_opening_closing_notification: false,
+      receive_order_notification: false,
       share_follows: false,
       currency_preference: "EUR",
       length_unit_preference: "cm",
@@ -199,6 +204,7 @@ describe("UpdateMeMutation", () => {
         receive_promotion_notification: false,
         receive_purchase_notification: false,
         receive_sale_opening_closing_notification: false,
+        receive_order_notification: false,
       })
     )
 

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -335,6 +335,11 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
       resolve: ({ receive_promotion_notification }) =>
         receive_promotion_notification,
     },
+    receiveOrderNotification: {
+      description: "This user should receive order notifications",
+      type: GraphQLBoolean,
+      resolve: ({ receive_order_notification }) => receive_order_notification,
+    },
     recentlyViewedArtworkIds: {
       type: new GraphQLNonNull(new GraphQLList(GraphQLString)),
       resolve: ({ recently_viewed_artwork_ids }) => recently_viewed_artwork_ids,

--- a/src/schema/v2/me/update_me_mutation.ts
+++ b/src/schema/v2/me/update_me_mutation.ts
@@ -198,6 +198,10 @@ export default mutationWithClientMutationId<any, any, ResolverContext>({
         "This user should receive sale opening/closing notifications",
       type: GraphQLBoolean,
     },
+    receiveOrderNotification: {
+      description: "This user should receive order notifications",
+      type: GraphQLBoolean,
+    },
     shareFollows: {
       description:
         "Shares FollowArtists, FollowGenes, and FollowProfiles with partners.",

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -94,6 +94,11 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
       resolve: ({ receive_promotion_notification }) =>
         receive_promotion_notification,
     },
+    receiveOrderNotification: {
+      description: "This user should receive order notifications",
+      type: GraphQLBoolean,
+      resolve: ({ receive_order_notification }) => receive_order_notification,
+    },
     userAlreadyExists: {
       description:
         "Check whether a user exists by email address before creating an account.",


### PR DESCRIPTION
Updates the user and associated update mutations to add access to the new order notification preference in gravity.

This PR should not be merged until gravity is updated!

https://github.com/artsy/gravity/pull/15186