### PR TITLE
feat(alerts): expose a medium type's corresponding filter gene

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2091,6 +2091,9 @@ type ArtworkLayer {
 # is also commonly referred to as just "medium", but should not be confused with
 # the artwork attribute called `medium`.)
 type ArtworkMedium {
+  # The medium gene that corresponds to this medium type. Used for filtering purposes on our frontend, e.g. in artwork grids.
+  filterGene: Gene
+
   # Long descriptive phrase
   longDescription: String
 

--- a/src/lib/artworkMediums.ts
+++ b/src/lib/artworkMediums.ts
@@ -4,12 +4,14 @@ export default {
     long_description:
       "Includes architectural models; buildings (e.g., house, temple).",
     name: "Architecture",
+    mediumFilterGeneSlug: "architecture-1",
   },
   "Books and Portfolios": {
     id: "Books and Portfolios",
     long_description:
       "Includes albums; artist books; illustrated manuscripts; portfolios (i.e., a group of works such as photographs or prints).",
     name: "Books and Portfolios",
+    mediumFilterGeneSlug: "books-and-portfolios",
   },
   "Design/Decorative Art": {
     id: "Design/Decorative Art",
@@ -18,6 +20,7 @@ export default {
       "Includes containers (e.g., basket, bowl, box, vase); furniture (e.g., cabinet, chair, table); lighting; mirrors; tableware (e.g., flatware, plates).",
     ].join(" "),
     name: "Design/Decorative Art",
+    mediumFilterGeneSlug: "design",
   },
   "Drawing, Collage or other Work on Paper": {
     id: "Drawing, Collage or other Work on Paper",
@@ -26,6 +29,7 @@ export default {
       "This also includes paintings where paper is the support.",
     ].join(" "),
     name: "Drawing, Collage or other Work on Paper",
+    mediumFilterGeneSlug: "work-on-paper",
   },
   "Ephemera or Merchandise": {
     id: "Ephemera or Merchandise",
@@ -34,57 +38,67 @@ export default {
       "This includes exhibition materials, memorabilia, autographs, skateboards, toys, and other items made with branded collaborators.",
     ].join(" "),
     name: "Ephemera or Merchandise",
+    mediumFilterGeneSlug: "ephemera-or-merchandise",
   },
   "Fashion Design and Wearable Art": {
     id: "Fashion Design and Wearable Art",
     long_description: "Includes costumes; garments (e.g., dress, jacket).",
     name: "Fashion Design and Wearable Art",
+    mediumFilterGeneSlug: "fashion-design-and-wearable-art",
   },
   Installation: {
     id: "Installation",
     long_description: "Includes land art; installation art; site-specific art.",
     name: "Installation",
+    mediumFilterGeneSlug: "installation",
   },
   Jewelry: {
     id: "Jewelry",
     long_description:
       "Includes bracelets; brooches; earrings; necklaces; rings; costume accessories.",
     name: "Jewelry",
+    mediumFilterGeneSlug: "jewelry",
   },
   "Mixed Media": {
     id: "Mixed Media",
     long_description:
       "Intermedia; Multimedia work that does not fall into another category.",
     name: "Mixed Media",
+    mediumFilterGeneSlug: "mixed-media",
   },
   NFT: {
     id: "NFT",
     long_description:
       "Non-fungible token. Indicates that the primary medium of the work is the NFT.",
     name: "NFT",
+    mediumFilterGeneSlug: "nft",
   },
   Other: {
     id: "Other",
     long_description:
       "Includes items that do not fall into any other categories (e.g., armor; musical instruments; tools).",
     name: "Other",
+    mediumFilterGeneSlug: null,
   },
   Painting: {
     id: "Painting",
     long_description:
       "Includes gouache; fresco; ink and wash; oil painting; screen painting; scroll painting; tempera; watercolor.",
     name: "Painting",
+    mediumFilterGeneSlug: "painting",
   },
   "Performance Art": {
     id: "Performance Art",
     long_description: "Includes body art; endurance art; live performance.",
     name: "Performance Art",
+    mediumFilterGeneSlug: "performance-art",
   },
   Photography: {
     id: "Photography",
     long_description:
       "Includes chromogenic color prints (c-prints); polaroids; silver gelatin prints; photograms.",
     name: "Photography",
+    mediumFilterGeneSlug: "photography",
   },
   Posters: {
     id: "Posters",
@@ -93,12 +107,14 @@ export default {
       "Please note that this does not include exhibition posters (see “Ephemera or Merchandise”).",
     ].join(" "),
     name: "Posters",
+    mediumFilterGeneSlug: "poster",
   },
   Print: {
     id: "Print",
     long_description:
       "Includes etchings; engravings; lithographs; monoprints; screen prints; woodcuts.",
     name: "Print",
+    mediumFilterGeneSlug: "prints",
   },
   Reproduction: {
     id: "Reproduction",
@@ -108,6 +124,7 @@ export default {
       "Please note that the artist may not have been directly involved in the work’s production.",
     ].join(" "),
     name: "Reproduction",
+    mediumFilterGeneSlug: "reproduction",
   },
   Sculpture: {
     id: "Sculpture",
@@ -116,17 +133,20 @@ export default {
       "For figurines made with branded collaborators (e.g., BE@RBRICK, Medicom), please see “Ephemera or Merchandise.”",
     ].join(" "),
     name: "Sculpture",
+    mediumFilterGeneSlug: "sculpture",
   },
   "Textile Arts": {
     id: "Textile Arts",
     long_description:
       "Includes banners; carpets; rugs; samplers; tapestries; weavings.",
     name: "Textile Arts",
+    mediumFilterGeneSlug: "textile-arts",
   },
   "Video/Film/Animation": {
     id: "Video/Film/Animation",
     long_description:
       "Includes 16mm film; computer animation; video recordings.",
     name: "Video/Film/Animation",
+    mediumFilterGeneSlug: "film-slash-video",
   },
 }

--- a/src/schema/v2/__tests__/artworkMediums.test.ts
+++ b/src/schema/v2/__tests__/artworkMediums.test.ts
@@ -1,9 +1,10 @@
 /* eslint-disable promise/always-return */
+import gql from "lib/gql"
 import { runQuery } from "schema/v2/test/utils"
 
 describe("ArtworkMediums type", () => {
   it("fetches artworkMediums", () => {
-    const query = `
+    const query = gql`
       {
         artworkMediums {
           name
@@ -17,6 +18,39 @@ describe("ArtworkMediums type", () => {
       expect(data!.artworkMediums[0].longDescription).toBe(
         "Includes architectural models; buildings (e.g., house, temple)."
       )
+    })
+  })
+
+  it("returns the associated filter gene", async () => {
+    const context = {
+      geneLoader: jest.fn(() =>
+        Promise.resolve({
+          id: "architecture-1",
+          name: "Architecture",
+        })
+      ),
+    }
+
+    const query = gql`
+      {
+        artworkMediums {
+          name
+          longDescription
+          filterGene {
+            slug
+            name
+          }
+        }
+      }
+    `
+
+    const result = await runQuery(query, context)
+
+    expect(context.geneLoader).toHaveBeenCalledTimes(19)
+
+    expect(result.artworkMediums[0].filterGene).toEqual({
+      slug: "architecture-1",
+      name: "Architecture",
     })
   })
 })

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -3195,12 +3195,18 @@ describe("Artwork type", () => {
 
   describe("mediumType", () => {
     it(`returns proper medium type for artwork`, () => {
+      context.geneLoader = () =>
+        Promise.resolve({ name: "Painting", id: "painting" })
       const query = `
         {
           artwork(id: "richard-prince-untitled-portrait") {
             mediumType {
               name
               longDescription
+              filterGene {
+                slug
+                name
+              }
             }
           }
         }
@@ -3213,6 +3219,10 @@ describe("Artwork type", () => {
               name: "Painting",
               longDescription:
                 "Includes gouache; fresco; ink and wash; oil painting; screen painting; scroll painting; tempera; watercolor.",
+              filterGene: {
+                slug: "painting",
+                name: "Painting",
+              },
             },
           },
         })

--- a/src/schema/v2/artwork/artworkMedium.ts
+++ b/src/schema/v2/artwork/artworkMedium.ts
@@ -1,5 +1,6 @@
 import { GraphQLObjectType, GraphQLString } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { GeneType } from "schema/v2/gene"
 
 const ArtworkMedium = new GraphQLObjectType<any, ResolverContext>({
   name: "ArtworkMedium",
@@ -15,6 +16,16 @@ const ArtworkMedium = new GraphQLObjectType<any, ResolverContext>({
       description: "Long descriptive phrase",
       resolve: ({ long_description }) => {
         return long_description
+      },
+    },
+    filterGene: {
+      type: GeneType,
+      description:
+        "The medium gene that corresponds to this medium type. Used for filtering purposes on our frontend, e.g. in artwork grids.",
+      resolve: async (parent, _args, { geneLoader }) => {
+        const { mediumFilterGeneSlug } = parent
+        if (!mediumFilterGeneSlug) return null
+        return await geneLoader(mediumFilterGeneSlug)
       },
     },
   },


### PR DESCRIPTION
_Leaving this as a DRAFT until we can answer the question below_

https://artsyproduct.atlassian.net/browse/FX-3820

This allows artworks' medium types to be associated with their corresponding genes — which is what we actually use for filtering on the frontend in our artwork grids.

## Context

- Every artwork has a medium type field, which is exposed in Metaphysics as `{ artwork { mediumType { name … } } }`

- This ultimately derives from `Artwork#category` in the corresponding Gravity record; this value is originally supplied by the partner in CMS

- But that medium type is not sufficient for our desired Alerts functionality, because alerts are based on our artworks grids' filter facets — and the medium facet actually filters on the artworks' _genes_, through [a bit of indirection that is described more fully in this Notion document](https://www.notion.so/artsy/Medium-types-vs-medium-filters-39310c0278d64675b755e6db46fec363).

- We therefore expose that corresponding `filterGene` now, which can be accessed from the root…

  ```graphql
  {
    artworkMediums {
      name
      filterGene { # NEW
        slug
        name
      }
    }
  }
  ```

  … Or from an artwork…

  ```graphql
  {
    artwork(id: "pablo-picasso-guernica") {
      slug
      mediumType {
        name
        filterGene { # NEW
          slug
          name
        }
      }
    }
  }
  ```

It's that last query that will be useful in the Artwork Alerts context.

## Questions

- As of now, three of these associated Genes — **Ephemera or Merchandise**; **Reproduction**; **NFT** — are actually _unpublished_, which means that they don't return a proper name, slug etc. Can we publish these, and who's the DRI who could tell us so?

  <img width="1892" alt="Screen Shot 2022-04-06 at 6 23 20 PM" src="https://user-images.githubusercontent.com/140521/162082361-48266cf1-4742-499e-8770-bf7da0235d9f.png">

