### PR TITLE
Fix: Update price insights type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1840,7 +1840,7 @@ type Artwork implements Node & Searchable & Sellable {
   # Represents partner's location
   location: Location
   manufacturer(format: Format): String
-  marketPriceInsights: MarketPriceInsights
+  marketPriceInsights: PriceInsights
 
   # Represents the **materials** used in this work, such as _oil and acrylic on
   # canvas_. (This should not be confused with the artwork attribute called
@@ -10959,6 +10959,12 @@ type PriceInsightEdge {
 
   # The item at the end of the edge.
   node: MarketPriceInsights
+}
+
+type PriceInsights {
+  artistId: String
+  demandRank: Float
+  medium: String
 }
 
 enum PriceInsightSort {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -82,8 +82,8 @@ export const ArtworkImportSourceEnum = new GraphQLEnumType({
   values: IMPORT_SOURCES,
 })
 
-const MarketPriceInsightsType = new GraphQLObjectType<any, ResolverContext>({
-  name: "MarketPriceInsights",
+const PriceInsightsType = new GraphQLObjectType<any, ResolverContext>({
+  name: "PriceInsights",
   fields: {
     artistId: {
       type: GraphQLString,
@@ -123,7 +123,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       marketPriceInsights: {
-        type: MarketPriceInsightsType,
+        type: PriceInsightsType,
       },
       artists: {
         type: new GraphQLList(Artist.type),


### PR DESCRIPTION
This is a follow up on #3882

## Description
This PR changes the type of the Market Price Insights inside My Collection Artwork type, since the current one uses the `MarketPriceInsights` from Vortex, which has the ID, a non-nullable field, that is returned as `null` in Metaphysics