### PR TITLE
Revert "fix:fallback to email if user.name is null"

### DIFF
--- a/src/schema/v2/__tests__/user.test.ts
+++ b/src/schema/v2/__tests__/user.test.ts
@@ -55,62 +55,6 @@ describe("User", () => {
     expect(user.userAlreadyExists).toEqual(false)
   })
 
-  it("falls back to email for name if name is blank", async () => {
-    const foundUser = {
-      id: "123456",
-      _id: "000012345",
-      name: null,
-      email: "foo@bar.org",
-      pin: "3141",
-      paddle_number: "314159",
-    }
-
-    const userByEmailLoader = (data) => {
-      if (data) {
-        return Promise.resolve(foundUser)
-      }
-      throw new Error("Unexpected invocation")
-    }
-
-    const query = gql`
-      {
-        user(email: "foo@bar.com") {
-          name
-        }
-      }
-    `
-
-    const { user } = await runAuthenticatedQuery(query, { userByEmailLoader })
-    expect(user.name).toEqual("foo@bar.org")
-  })
-
-  it("falls back to empty string for name if name and e-mail are blank", async () => {
-    // This is what returned from Gravity when a non-admin user hits /v1/user/:id
-    const foundUser = {
-      id: "123456",
-      _id: "000012345",
-      name: null,
-    }
-
-    const userByEmailLoader = (data) => {
-      if (data) {
-        return Promise.resolve(foundUser)
-      }
-      throw new Error("Unexpected invocation")
-    }
-
-    const query = gql`
-      {
-        user(email: "foo@bar.com") {
-          name
-        }
-      }
-    `
-
-    const { user } = await runAuthenticatedQuery(query, { userByEmailLoader })
-    expect(user.name).toEqual("")
-  })
-
   it("returns push notification settings for a user", async () => {
     const foundUser = {
       id: "123456",

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -70,7 +70,6 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
     name: {
       description: "The given name of the user.",
       type: new GraphQLNonNull(GraphQLString),
-      resolve: ({ name, email }) => name || email || "",
     },
     email: {
       description: "The given email of the user.",


### PR DESCRIPTION
This reverts commit a1cd5718b5cb69595f796f421dcb2f4e912687c7.

We have backfilled the null names to the string `collector`, so this workaround is not necessary at the moment.