### PR TITLE
[PX-4946] Remove fallbacks + deprecated arta related fields

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1666,10 +1666,6 @@ type ArtistTargetSupplyMicrofunnel {
 
 type Artwork implements Node & Searchable & Sellable {
   additionalInformation(format: Format): String
-  artaShippingEnabled: Boolean
-    @deprecated(
-      reason: "Prefer to use `processWithArtsyShippingDomestic`. [Will be removed in v2]"
-    )
   articles(size: Int): [Article]
   artist(
     # Use whatever is in the original response instead of making a request
@@ -1875,12 +1871,6 @@ type Artwork implements Node & Searchable & Sellable {
   # The price paid for the artwork in a user's 'my collection'
   pricePaid: Money
   pricingContext: AnalyticsPricingContext
-
-  # Returns true if this work is eligible to be automatically opted into Artsy Domestic Shipping
-  processWithArtaShipping: Boolean
-    @deprecated(
-      reason: "Prefer to use `processWithArtsyShippingDomestic`. [Will be removed in v2]"
-    )
 
   # Returns true if this work is eligible to be automatically opted into Artsy Domestic Shipping
   processWithArtsyShippingDomestic: Boolean

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -643,60 +643,15 @@ describe("Artwork type", () => {
       }
     `
 
-    describe("when process_with_artsy_shipping is null", () => {
-      beforeEach(() => {
-        artwork.process_with_artsy_shipping_domestic = null
-      })
+    it("returns the correct value", () => {
+      artwork.process_with_artsy_shipping_domestic = true
 
-      describe("when fallback is null", () => {
-        beforeEach(() => {
-          artwork.process_with_arta_shipping = null
-        })
-
-        it("returns false", () => {
-          return runQuery(query, context).then((data) => {
-            expect(data).toEqual({
-              artwork: {
-                slug: "richard-prince-untitled-portrait",
-                processWithArtsyShippingDomestic: false,
-              },
-            })
-          })
-        })
-
-        describe("when fallback is true", () => {
-          beforeEach(() => {
-            artwork.process_with_arta_shipping = true
-          })
-
-          it("returns the fallback value for process_with_arta_shipping", () => {
-            return runQuery(query, context).then((data) => {
-              expect(data).toEqual({
-                artwork: {
-                  slug: "richard-prince-untitled-portrait",
-                  processWithArtsyShippingDomestic: true,
-                },
-              })
-            })
-          })
-        })
-      })
-    })
-
-    describe("when process_with_artsy_shipping is true", () => {
-      beforeEach(() => {
-        artwork.process_with_artsy_shipping_domestic = true
-        artwork.process_with_arta_shipping = null
-      })
-
-      it("returns the correct value", () => {
-        return runQuery(query, context).then((data) => {
-          expect(data).toEqual({
-            artwork: {
-              slug: "richard-prince-untitled-portrait",
-              processWithArtsyShippingDomestic: true,
-            },
-          })
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            slug: "richard-prince-untitled-portrait",
+            processWithArtsyShippingDomestic: true,
+          },
         })
       })
     })
@@ -2367,8 +2322,8 @@ describe("Artwork type", () => {
       })
     })
 
-    it("is set to calculated at checkout when artwork will be processed with Arta shipping", () => {
-      artwork.process_with_arta_shipping = true
+    it("is set to calculated at checkout when artwork will be processed with Artsy domestic shipping", () => {
+      artwork.process_with_artsy_shipping_domestic = true
 
       return runQuery(query, context).then((data) => {
         expect(data).toEqual({

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -49,7 +49,7 @@ describe("Artwork type", () => {
       metric: "in",
       unlisted: true,
       category: "Painting",
-      arta_enabled: false,
+      process_with_artsy_shipping_domestic: false,
     }
 
     context = {
@@ -651,54 +651,6 @@ describe("Artwork type", () => {
           artwork: {
             slug: "richard-prince-untitled-portrait",
             processWithArtsyShippingDomestic: true,
-          },
-        })
-      })
-    })
-  })
-
-  describe("#artaShippingEnabled", () => {
-    const query = `
-      {
-        artwork(id: "richard-prince-untitled-portrait") {
-          slug
-          artaShippingEnabled
-        }
-      }
-    `
-
-    it("passes true from gravity", () => {
-      artwork.arta_enabled = true
-
-      return runQuery(query, context).then((data) => {
-        expect(data).toEqual({
-          artwork: {
-            slug: "richard-prince-untitled-portrait",
-            artaShippingEnabled: true,
-          },
-        })
-      })
-    })
-  })
-
-  describe("#processWithArtaShipping", () => {
-    const query = `
-      {
-        artwork(id: "richard-prince-untitled-portrait") {
-          slug
-          processWithArtaShipping
-        }
-      }
-    `
-
-    it("passes true from gravity", () => {
-      artwork.process_with_arta_shipping = true
-
-      return runQuery(query, context).then((data) => {
-        expect(data).toEqual({
-          artwork: {
-            slug: "richard-prince-untitled-portrait",
-            processWithArtaShipping: true,
           },
         })
       })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -764,12 +764,8 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLBoolean,
         description:
           "Returns true if this work is eligible to be automatically opted into Artsy Domestic Shipping",
-        resolve: (artwork) => {
-          return Boolean(
-            artwork.process_with_artsy_shipping_domestic ||
-              artwork.process_with_arta_shipping
-          )
-        },
+        resolve: ({ process_with_artsy_shipping_domestic }) =>
+          process_with_artsy_shipping_domestic,
       },
       processWithArtaShipping: {
         type: GraphQLBoolean,
@@ -837,7 +833,6 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         resolve: (artwork) => {
           if (
             artwork.process_with_artsy_shipping_domestic ||
-            artwork.process_with_arta_shipping ||
             artwork.artsy_shipping_international
           ) {
             return "Shipping: Calculated in checkout"

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -747,14 +747,6 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           return price_includes_tax ? "VAT included in price" : null
         },
       },
-      artaShippingEnabled: {
-        type: GraphQLBoolean,
-        deprecationReason: deprecate({
-          inVersion: 2,
-          preferUsageOf: "processWithArtsyShippingDomestic",
-        }),
-        resolve: ({ arta_enabled }) => arta_enabled,
-      },
       artsyShippingInternational: {
         type: GraphQLBoolean,
         resolve: ({ artsy_shipping_international }) =>
@@ -766,16 +758,6 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           "Returns true if this work is eligible to be automatically opted into Artsy Domestic Shipping",
         resolve: ({ process_with_artsy_shipping_domestic }) =>
           process_with_artsy_shipping_domestic,
-      },
-      processWithArtaShipping: {
-        type: GraphQLBoolean,
-        description:
-          "Returns true if this work is eligible to be automatically opted into Artsy Domestic Shipping",
-        deprecationReason: deprecate({
-          inVersion: 2,
-          preferUsageOf: "processWithArtsyShippingDomestic",
-        }),
-        resolve: ({ process_with_arta_shipping }) => process_with_arta_shipping,
       },
       shipsToContinentalUSOnly: {
         type: GraphQLBoolean,


### PR DESCRIPTION
After deploying the final renaming of JSON fields `process_with_arta_shipping` to `process_with_artsy_shipping` in gravity: https://github.com/artsy/gravity/pull/15206 we can remove the fallbacks that check for `process_with_arta_shipping` in metaphysics and clean out all the fields we marked for deprecation last time.

Q: 
- Force is updated and deployed using the new fields, is it cool to remove the deprecated fields here altogether? 