### PR TITLE
feat(FX-3850): Add ArtworksConnection under MarketingCollection

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1046,7 +1046,6 @@ type Artist implements Node & Searchable {
   is_public: Boolean
   is_shareable: Boolean
   location: String
-  marketingCollections(size: Int): [MarketingCollection]
   meta: ArtistMeta
   name: String
   nationality: String
@@ -10088,105 +10087,27 @@ type LotStanding {
   sale_artwork: SaleArtwork
 }
 
-# Object representing a collection page
 type MarketingCollection {
-  artworks(
-    acquireable: Boolean
-    aggregation_partner_cities: [String]
-    aggregations: [ArtworkAggregation]
-    artist_id: String
-    artist_ids: [String]
-    at_auction: Boolean
-    attribution_class: [String]
-    color: String
-    dimension_range: String
-    extra_aggregation_gene_ids: [String]
-    for_sale: Boolean
-    gene_id: String
-    gene_ids: [String]
-    height: String
-    include_artworks_by_followed_artists: Boolean
-    include_medium_filter_in_aggregation: Boolean
-    inquireable_only: Boolean
-    keyword: String
-    keyword_match_exact: Boolean
-    major_periods: [String]
-    marketable: Boolean
-    medium: String
-    offerable: Boolean
-    page: Int
-    partner_cities: [String]
-    partner_id: ID
-    period: String
-    periods: [String]
-    price_range: String
-    sale_id: ID
-    size: Int
-    sort: String
-    tag_id: String
-    width: String
-  ): FilterArtworks
-
-  # Category of the collection
   category: String!
-  createdAt: MarketingDateTime!
-
-  # Image credit for the header image
+  createdAt: ISO8601DateTime!
   credit: String
-
-  # Description of the collection which can include links to other collections
   description: String
-
-  # Markdown alternate of description field contents.
   descriptionMarkdown: String
-
-  # IDs of artists that should be excluded from Featured Artists for this collection
-  featuredArtistExclusionIds: [String!]
-
-  # Background image for the header of the collection page
+  featuredArtistExclusionIds: [String!]!
   headerImage: String
+
+  # Unique ID for this marketing collection
   id: ID!
+
+  # Unique ID for this marketing collection
   internalID: ID!
-
-  # Collection has prioritized connection to artist
-  is_featured_artist_content: Boolean!
-    @deprecated(reason: "Prefer isFeaturedArtistContent")
-  isDepartment: Boolean!
-
-  # Collection has prioritized connection to artist
   isFeaturedArtistContent: Boolean!
-
-  # Set of keywords used for SEO purposes
-  keywords: String!
-
-  # CollectionGroups of this collection
-  linkedCollections: [MarketingCollectionGroup!]!
-
-  # Suggested average price for included works
-  price_guidance: Float @deprecated(reason: "Prefer priceGuidance")
-
-  # Suggested average price for included works
   priceGuidance: Float
-
-  # Structured object used to build filtered artworks query
   query: MarketingCollectionQuery!
-  relatedCollections(size: Int = 10): [MarketingCollection!]!
-
-  # Collection can be surfaced on editorial pages
-  show_on_editorial: Boolean! @deprecated(reason: "Prefer showOnEditorial")
-
-  # Collection can be surfaced on editorial pages
-  showOnEditorial: Boolean!
-
-  # slug version of title, used for pretty URLs (e.g. `kaws-prints` for Kaws Prints
   slug: String!
-
-  # URL for Thumbnail image to be used when this collection is displayed.
   thumbnail: String
-
-  # Name of the collection
   title: String!
-  updatedAt: MarketingDateTime!
+  updatedAt: ISO8601DateTime!
 }
 
 type MarketingCollectionCategory {
@@ -10194,74 +10115,11 @@ type MarketingCollectionCategory {
   name: String!
 }
 
-type MarketingCollectionGroup {
-  groupType: MarketingGroupTypes!
-  internalID: ID
-  members: [MarketingCollection!]!
-  name: String!
-}
-
 type MarketingCollectionQuery {
-  acquireable: Boolean
-  aggregations: [String!]
-  artist_id: String @deprecated(reason: "Prefer artistID")
-  artist_ids: [String!] @deprecated(reason: "Prefer artistIDs")
-  artistID: String
   artistIDs: [String!]
-  at_auction: Boolean @deprecated(reason: "Prefer atAuction")
-  atAuction: Boolean
-  color: String
-  dimension_range: String @deprecated(reason: "Prefer dimensionRange")
-  dimensionRange: String
-  extra_aggregation_gene_ids: [String!]
-    @deprecated(reason: "prefer extraAggregationGeneIDs")
-  extraAggregationGeneIDs: [String!]
-  for_sale: Boolean @deprecated(reason: "Prefer forSale")
-  forSale: Boolean
-  gene_id: String @deprecated(reason: "Prefer geneID")
-  gene_ids: [String!] @deprecated(reason: "Prefer geneIDs")
-  geneID: String
   geneIDs: [String!]
-  height: String
-  id: ID
-  include_artworks_by_followed_artists: Boolean
-    @deprecated(reason: "Prefer includeArtworksByFollowedArtists")
-  include_medium_filter_in_aggregation: Boolean
-    @deprecated(reason: "Prefer includeMediumFilterInAggregation")
-  includeArtworksByFollowedArtists: Boolean
-  includeMediumFilterInAggregation: Boolean
-  inquireable_only: Boolean @deprecated(reason: "Prefer inquireableOnly")
-  inquireableOnly: Boolean
-  internalID: ID
   keyword: String
-  major_periods: [String!] @deprecated(reason: "Prefer majorPeriods")
-  majorPeriods: [String!]
-  medium: String
-  page: Int
-  partner_cities: [String!] @deprecated(reason: "Prefer partnerCities")
-  partner_id: ID @deprecated(reason: "Prefer partnerID")
-  partnerCities: [String!]
-  partnerID: ID
-  period: String
-  periods: [String!]
-  price_range: String @deprecated(reason: "Prefer priceRange")
-  priceRange: String
-  sale_id: ID @deprecated(reason: "Prefer saleID")
-  saleID: ID
-  size: Int
-  sort: String
-  tag_id: String @deprecated(reason: "Prefer tagID")
   tagID: String
-  width: String
-}
-
-scalar MarketingDateTime
-
-# Available types of CollectionGroup
-enum MarketingGroupTypes {
-  ArtistSeries
-  FeaturedCollections
-  OtherCollections
 }
 
 # Market Price Insights
@@ -12760,18 +12618,6 @@ type Query {
   _unused_gravity_categories: [MarketingCollectionCategory!]!
   _unused_gravity_devices(userId: ID!): [Device!]!
 
-  # Find a marketing collection by ID or slug
-  _unused_gravity_marketingCollection(id: ID!): MarketingCollection
-
-  # An array of marketing collections. Defaults to returning all available collections if no args are passed
-  _unused_gravity_marketingCollections(
-    artistID: ID
-    category: String
-    isFeaturedArtistContent: Boolean
-    size: Int
-    slugs: [String!]
-  ): [MarketingCollection!]
-
   # Autocomplete resolvers.
   _unused_gravity_match_partners(
     match_type: String
@@ -13282,18 +13128,18 @@ type Query {
 
   # Home screen content
   home_page: HomePage
-  marketingCategories: [MarketingCollectionCategory!]!
-  marketingCollection(slug: String!): MarketingCollection
+
+  # Find a marketing collection by ID or slug
+  marketingCollection(id: ID!): MarketingCollection
+
+  # An array of marketing collections. Defaults to returning all available collections if no args are passed
   marketingCollections(
-    artistID: String
+    artistID: ID
     category: String
     isFeaturedArtistContent: Boolean
-    randomizationSeed: String
-    showOnEditorial: Boolean
     size: Int
     slugs: [String!]
-  ): [MarketingCollection!]!
-  marketingHubCollections: [MarketingCollection!]!
+  ): [MarketingCollection!]
 
   # Get price insights for a market.
   marketPriceInsights(artistId: ID!, medium: String!): MarketPriceInsights

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1046,6 +1046,7 @@ type Artist implements Node & Searchable {
   is_public: Boolean
   is_shareable: Boolean
   location: String
+  marketingCollections(size: Int): [MarketingCollection]
   meta: ArtistMeta
   name: String
   nationality: String
@@ -10087,27 +10088,105 @@ type LotStanding {
   sale_artwork: SaleArtwork
 }
 
+# Object representing a collection page
 type MarketingCollection {
+  artworks(
+    acquireable: Boolean
+    aggregation_partner_cities: [String]
+    aggregations: [ArtworkAggregation]
+    artist_id: String
+    artist_ids: [String]
+    at_auction: Boolean
+    attribution_class: [String]
+    color: String
+    dimension_range: String
+    extra_aggregation_gene_ids: [String]
+    for_sale: Boolean
+    gene_id: String
+    gene_ids: [String]
+    height: String
+    include_artworks_by_followed_artists: Boolean
+    include_medium_filter_in_aggregation: Boolean
+    inquireable_only: Boolean
+    keyword: String
+    keyword_match_exact: Boolean
+    major_periods: [String]
+    marketable: Boolean
+    medium: String
+    offerable: Boolean
+    page: Int
+    partner_cities: [String]
+    partner_id: ID
+    period: String
+    periods: [String]
+    price_range: String
+    sale_id: ID
+    size: Int
+    sort: String
+    tag_id: String
+    width: String
+  ): FilterArtworks
+
+  # Category of the collection
   category: String!
-  createdAt: ISO8601DateTime!
+  createdAt: MarketingDateTime!
+
+  # Image credit for the header image
   credit: String
+
+  # Description of the collection which can include links to other collections
   description: String
+
+  # Markdown alternate of description field contents.
   descriptionMarkdown: String
-  featuredArtistExclusionIds: [String!]!
+
+  # IDs of artists that should be excluded from Featured Artists for this collection
+  featuredArtistExclusionIds: [String!]
+
+  # Background image for the header of the collection page
   headerImage: String
-
-  # Unique ID for this marketing collection
   id: ID!
-
-  # Unique ID for this marketing collection
   internalID: ID!
+
+  # Collection has prioritized connection to artist
+  is_featured_artist_content: Boolean!
+    @deprecated(reason: "Prefer isFeaturedArtistContent")
+  isDepartment: Boolean!
+
+  # Collection has prioritized connection to artist
   isFeaturedArtistContent: Boolean!
+
+  # Set of keywords used for SEO purposes
+  keywords: String!
+
+  # CollectionGroups of this collection
+  linkedCollections: [MarketingCollectionGroup!]!
+
+  # Suggested average price for included works
+  price_guidance: Float @deprecated(reason: "Prefer priceGuidance")
+
+  # Suggested average price for included works
   priceGuidance: Float
+
+  # Structured object used to build filtered artworks query
   query: MarketingCollectionQuery!
+  relatedCollections(size: Int = 10): [MarketingCollection!]!
+
+  # Collection can be surfaced on editorial pages
+  show_on_editorial: Boolean! @deprecated(reason: "Prefer showOnEditorial")
+
+  # Collection can be surfaced on editorial pages
+  showOnEditorial: Boolean!
+
+  # slug version of title, used for pretty URLs (e.g. `kaws-prints` for Kaws Prints
   slug: String!
+
+  # URL for Thumbnail image to be used when this collection is displayed.
   thumbnail: String
+
+  # Name of the collection
   title: String!
-  updatedAt: ISO8601DateTime!
+  updatedAt: MarketingDateTime!
 }
 
 type MarketingCollectionCategory {
@@ -10115,11 +10194,74 @@ type MarketingCollectionCategory {
   name: String!
 }
 
+type MarketingCollectionGroup {
+  groupType: MarketingGroupTypes!
+  internalID: ID
+  members: [MarketingCollection!]!
+  name: String!
+}
+
 type MarketingCollectionQuery {
+  acquireable: Boolean
+  aggregations: [String!]
+  artist_id: String @deprecated(reason: "Prefer artistID")
+  artist_ids: [String!] @deprecated(reason: "Prefer artistIDs")
+  artistID: String
   artistIDs: [String!]
+  at_auction: Boolean @deprecated(reason: "Prefer atAuction")
+  atAuction: Boolean
+  color: String
+  dimension_range: String @deprecated(reason: "Prefer dimensionRange")
+  dimensionRange: String
+  extra_aggregation_gene_ids: [String!]
+    @deprecated(reason: "prefer extraAggregationGeneIDs")
+  extraAggregationGeneIDs: [String!]
+  for_sale: Boolean @deprecated(reason: "Prefer forSale")
+  forSale: Boolean
+  gene_id: String @deprecated(reason: "Prefer geneID")
+  gene_ids: [String!] @deprecated(reason: "Prefer geneIDs")
+  geneID: String
   geneIDs: [String!]
+  height: String
+  id: ID
+  include_artworks_by_followed_artists: Boolean
+    @deprecated(reason: "Prefer includeArtworksByFollowedArtists")
+  include_medium_filter_in_aggregation: Boolean
+    @deprecated(reason: "Prefer includeMediumFilterInAggregation")
+  includeArtworksByFollowedArtists: Boolean
+  includeMediumFilterInAggregation: Boolean
+  inquireable_only: Boolean @deprecated(reason: "Prefer inquireableOnly")
+  inquireableOnly: Boolean
+  internalID: ID
   keyword: String
+  major_periods: [String!] @deprecated(reason: "Prefer majorPeriods")
+  majorPeriods: [String!]
+  medium: String
+  page: Int
+  partner_cities: [String!] @deprecated(reason: "Prefer partnerCities")
+  partner_id: ID @deprecated(reason: "Prefer partnerID")
+  partnerCities: [String!]
+  partnerID: ID
+  period: String
+  periods: [String!]
+  price_range: String @deprecated(reason: "Prefer priceRange")
+  priceRange: String
+  sale_id: ID @deprecated(reason: "Prefer saleID")
+  saleID: ID
+  size: Int
+  sort: String
+  tag_id: String @deprecated(reason: "Prefer tagID")
   tagID: String
+  width: String
+}
+
+scalar MarketingDateTime
+
+# Available types of CollectionGroup
+enum MarketingGroupTypes {
+  ArtistSeries
+  FeaturedCollections
+  OtherCollections
 }
 
 # Market Price Insights
@@ -12618,6 +12760,18 @@ type Query {
   _unused_gravity_categories: [MarketingCollectionCategory!]!
   _unused_gravity_devices(userId: ID!): [Device!]!
 
+  # Find a marketing collection by ID or slug
+  _unused_gravity_marketingCollection(id: ID!): MarketingCollection
+
+  # An array of marketing collections. Defaults to returning all available collections if no args are passed
+  _unused_gravity_marketingCollections(
+    artistID: ID
+    category: String
+    isFeaturedArtistContent: Boolean
+    size: Int
+    slugs: [String!]
+  ): [MarketingCollection!]
+
   # Autocomplete resolvers.
   _unused_gravity_match_partners(
     match_type: String
@@ -13128,18 +13282,18 @@ type Query {
 
   # Home screen content
   home_page: HomePage
-
-  # Find a marketing collection by ID or slug
-  marketingCollection(id: ID!): MarketingCollection
-
-  # An array of marketing collections. Defaults to returning all available collections if no args are passed
+  marketingCategories: [MarketingCollectionCategory!]!
+  marketingCollection(slug: String!): MarketingCollection
   marketingCollections(
-    artistID: ID
+    artistID: String
     category: String
     isFeaturedArtistContent: Boolean
+    randomizationSeed: String
+    showOnEditorial: Boolean
     size: Int
     slugs: [String!]
-  ): [MarketingCollection!]
+  ): [MarketingCollection!]!
+  marketingHubCollections: [MarketingCollection!]!
 
   # Get price insights for a market.
   marketPriceInsights(artistId: ID!, medium: String!): MarketPriceInsights

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1198,6 +1198,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
 
     # When true, will only return `marketable` works (not nude or provocative).
     marketable: Boolean
+    marketingCollectionID: String
     materialsTerms: [String]
 
     # A string from the list of allocations, or * to denote all mediums
@@ -1559,6 +1560,7 @@ type ArtistSeries {
     locationCities: [String]
     majorPeriods: [String]
     marketable: Boolean
+    marketingCollectionID: String
     materialsTerms: [String]
     medium: String
     offerable: Boolean
@@ -7027,6 +7029,7 @@ interface EntityWithFilterArtworksConnectionInterface {
 
     # When true, will only return `marketable` works (not nude or provocative).
     marketable: Boolean
+    marketingCollectionID: String
     materialsTerms: [String]
 
     # A string from the list of allocations, or * to denote all mediums
@@ -7269,6 +7272,7 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
 
     # When true, will only return `marketable` works (not nude or provocative).
     marketable: Boolean
+    marketingCollectionID: String
     materialsTerms: [String]
 
     # A string from the list of allocations, or * to denote all mediums
@@ -7651,6 +7655,7 @@ input FilterArtworksInput {
 
   # When true, will only return `marketable` works (not nude or provocative).
   marketable: Boolean
+  marketingCollectionID: String
   materialsTerms: [String]
 
   # A string from the list of allocations, or * to denote all mediums
@@ -8103,6 +8108,7 @@ type Gene implements Node & Searchable {
 
     # When true, will only return `marketable` works (not nude or provocative).
     marketable: Boolean
+    marketingCollectionID: String
     materialsTerms: [String]
 
     # A string from the list of allocations, or * to denote all mediums
@@ -8996,6 +9002,7 @@ type MarketingCollection {
     locationCities: [String]
     majorPeriods: [String]
     marketable: Boolean
+    marketingCollectionID: String
     materialsTerms: [String]
     medium: String
     offerable: Boolean
@@ -10395,6 +10402,7 @@ type Partner implements Node {
 
     # When true, will only return `marketable` works (not nude or provocative).
     marketable: Boolean
+    marketingCollectionID: String
     materialsTerms: [String]
 
     # A string from the list of allocations, or * to denote all mediums
@@ -11427,6 +11435,7 @@ type Query {
 
     # When true, will only return `marketable` works (not nude or provocative).
     marketable: Boolean
+    marketingCollectionID: String
     materialsTerms: [String]
 
     # A string from the list of allocations, or * to denote all mediums
@@ -13207,6 +13216,7 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
 
     # When true, will only return `marketable` works (not nude or provocative).
     marketable: Boolean
+    marketingCollectionID: String
     materialsTerms: [String]
 
     # A string from the list of allocations, or * to denote all mediums
@@ -13672,6 +13682,7 @@ type Tag implements Node {
 
     # When true, will only return `marketable` works (not nude or provocative).
     marketable: Boolean
+    marketingCollectionID: String
     materialsTerms: [String]
 
     # A string from the list of allocations, or * to denote all mediums
@@ -14650,6 +14661,7 @@ type Viewer {
 
     # When true, will only return `marketable` works (not nude or provocative).
     marketable: Boolean
+    marketingCollectionID: String
     materialsTerms: [String]
 
     # A string from the list of allocations, or * to denote all mediums

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1255,6 +1255,8 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   marketingCollections(
     category: String
     isFeaturedArtistContent: Boolean
+    randomizationSeed: String
+    showOnEditorial: Boolean
     size: Int
     slugs: [String!]
   ): [MarketingCollection]
@@ -8968,6 +8970,7 @@ type LotStanding {
   saleArtwork: SaleArtwork
 }
 
+# Object representing a collection page
 type MarketingCollection {
   artworksConnection(
     acquireable: Boolean
@@ -9020,26 +9023,67 @@ type MarketingCollection {
     tagID: String
     width: String
   ): FilterArtworksConnection
+
+  # Category of the collection
   category: String!
-  createdAt: ISO8601DateTime!
+  createdAt: MarketingDateTime!
+
+  # Image credit for the header image
   credit: String
+
+  # Description of the collection which can include links to other collections
   description: String
+
+  # Markdown alternate of description field contents.
   descriptionMarkdown: String
-  featuredArtistExclusionIds: [String!]!
+
+  # IDs of artists that should be excluded from Featured Artists for this collection
+  featuredArtistExclusionIds: [String!]
+
+  # Background image for the header of the collection page
   headerImage: String
-
-  # Unique ID for this marketing collection
   id: ID!
-
-  # Unique ID for this marketing collection
   internalID: ID!
+
+  # Collection has prioritized connection to artist
+  is_featured_artist_content: Boolean!
+    @deprecated(reason: "Prefer isFeaturedArtistContent")
+  isDepartment: Boolean!
+
+  # Collection has prioritized connection to artist
   isFeaturedArtistContent: Boolean!
+
+  # Set of keywords used for SEO purposes
+  keywords: String!
+
+  # CollectionGroups of this collection
+  linkedCollections: [MarketingCollectionGroup!]!
+
+  # Suggested average price for included works
+  price_guidance: Float @deprecated(reason: "Prefer priceGuidance")
+
+  # Suggested average price for included works
   priceGuidance: Float
+
+  # Structured object used to build filtered artworks query
   query: MarketingCollectionQuery!
+  relatedCollections(size: Int = 10): [MarketingCollection!]!
+
+  # Collection can be surfaced on editorial pages
+  show_on_editorial: Boolean! @deprecated(reason: "Prefer showOnEditorial")
+
+  # Collection can be surfaced on editorial pages
+  showOnEditorial: Boolean!
+
+  # slug version of title, used for pretty URLs (e.g. `kaws-prints` for Kaws Prints
   slug: String!
+
+  # URL for Thumbnail image to be used when this collection is displayed.
   thumbnail: String
+
+  # Name of the collection
   title: String!
-  updatedAt: ISO8601DateTime!
+  updatedAt: MarketingDateTime!
 }
 
 type MarketingCollectionCategory {
@@ -9047,11 +9091,74 @@ type MarketingCollectionCategory {
   name: String!
 }
 
+type MarketingCollectionGroup {
+  groupType: MarketingGroupTypes!
+  internalID: ID
+  members: [MarketingCollection!]!
+  name: String!
+}
+
 type MarketingCollectionQuery {
+  acquireable: Boolean
+  aggregations: [String!]
+  artist_id: String @deprecated(reason: "Prefer artistID")
+  artist_ids: [String!] @deprecated(reason: "Prefer artistIDs")
+  artistID: String
   artistIDs: [String!]
+  at_auction: Boolean @deprecated(reason: "Prefer atAuction")
+  atAuction: Boolean
+  color: String
+  dimension_range: String @deprecated(reason: "Prefer dimensionRange")
+  dimensionRange: String
+  extra_aggregation_gene_ids: [String!]
+    @deprecated(reason: "prefer extraAggregationGeneIDs")
+  extraAggregationGeneIDs: [String!]
+  for_sale: Boolean @deprecated(reason: "Prefer forSale")
+  forSale: Boolean
+  gene_id: String @deprecated(reason: "Prefer geneID")
+  gene_ids: [String!] @deprecated(reason: "Prefer geneIDs")
+  geneID: String
   geneIDs: [String!]
+  height: String
+  id: ID
+  include_artworks_by_followed_artists: Boolean
+    @deprecated(reason: "Prefer includeArtworksByFollowedArtists")
+  include_medium_filter_in_aggregation: Boolean
+    @deprecated(reason: "Prefer includeMediumFilterInAggregation")
+  includeArtworksByFollowedArtists: Boolean
+  includeMediumFilterInAggregation: Boolean
+  inquireable_only: Boolean @deprecated(reason: "Prefer inquireableOnly")
+  inquireableOnly: Boolean
+  internalID: ID
   keyword: String
+  major_periods: [String!] @deprecated(reason: "Prefer majorPeriods")
+  majorPeriods: [String!]
+  medium: String
+  page: Int
+  partner_cities: [String!] @deprecated(reason: "Prefer partnerCities")
+  partner_id: ID @deprecated(reason: "Prefer partnerID")
+  partnerCities: [String!]
+  partnerID: ID
+  period: String
+  periods: [String!]
+  price_range: String @deprecated(reason: "Prefer priceRange")
+  priceRange: String
+  sale_id: ID @deprecated(reason: "Prefer saleID")
+  saleID: ID
+  size: Int
+  sort: String
+  tag_id: String @deprecated(reason: "Prefer tagID")
   tagID: String
+  width: String
+}
+
+scalar MarketingDateTime
+
+# Available types of CollectionGroup
+enum MarketingGroupTypes {
+  ArtistSeries
+  FeaturedCollections
+  OtherCollections
 }
 
 # Market Price Insights
@@ -11135,6 +11242,18 @@ type Query {
   _unused_gravity_categories: [MarketingCollectionCategory!]!
   _unused_gravity_devices(userId: ID!): [Device!]!
 
+  # Find a marketing collection by ID or slug
+  _unused_gravity_marketingCollection(id: ID!): MarketingCollection
+
+  # An array of marketing collections. Defaults to returning all available collections if no args are passed
+  _unused_gravity_marketingCollections(
+    artistID: ID
+    category: String
+    isFeaturedArtistContent: Boolean
+    size: Int
+    slugs: [String!]
+  ): [MarketingCollection!]
+
   # Autocomplete resolvers.
   _unused_gravity_match_partners(
     match_type: String
@@ -11720,18 +11839,18 @@ type Query {
 
   # Home screen content
   homePage: HomePage
-
-  # Find a marketing collection by ID or slug
-  marketingCollection(id: ID!): MarketingCollection
-
-  # An array of marketing collections. Defaults to returning all available collections if no args are passed
+  marketingCategories: [MarketingCollectionCategory!]!
+  marketingCollection(slug: String!): MarketingCollection
   marketingCollections(
-    artistID: ID
+    artistID: String
     category: String
     isFeaturedArtistContent: Boolean
+    randomizationSeed: String
+    showOnEditorial: Boolean
     size: Int
     slugs: [String!]
-  ): [MarketingCollection!]
+  ): [MarketingCollection!]!
+  marketingHubCollections: [MarketingCollection!]!
 
   # Get price insights for a market.
   marketPriceInsights(artistId: ID!, medium: String!): MarketPriceInsights
@@ -14837,6 +14956,8 @@ type Viewer {
     artistID: String
     category: String
     isFeaturedArtistContent: Boolean
+    randomizationSeed: String
+    showOnEditorial: Boolean
     size: Int
     slugs: [String!]
   ): [MarketingCollection]

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1254,8 +1254,6 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   marketingCollections(
     category: String
     isFeaturedArtistContent: Boolean
-    randomizationSeed: String
-    showOnEditorial: Boolean
     size: Int
     slugs: [String!]
   ): [MarketingCollection]
@@ -8964,7 +8962,6 @@ type LotStanding {
   saleArtwork: SaleArtwork
 }
 
-# Object representing a collection page
 type MarketingCollection {
   artworksConnection(
     acquireable: Boolean
@@ -9016,67 +9013,26 @@ type MarketingCollection {
     tagID: String
     width: String
   ): FilterArtworksConnection
-
-  # Category of the collection
   category: String!
-  createdAt: MarketingDateTime!
-
-  # Image credit for the header image
+  createdAt: ISO8601DateTime!
   credit: String
-
-  # Description of the collection which can include links to other collections
   description: String
-
-  # Markdown alternate of description field contents.
   descriptionMarkdown: String
-
-  # IDs of artists that should be excluded from Featured Artists for this collection
-  featuredArtistExclusionIds: [String!]
-
-  # Background image for the header of the collection page
+  featuredArtistExclusionIds: [String!]!
   headerImage: String
+
+  # Unique ID for this marketing collection
   id: ID!
+
+  # Unique ID for this marketing collection
   internalID: ID!
-
-  # Collection has prioritized connection to artist
-  is_featured_artist_content: Boolean!
-    @deprecated(reason: "Prefer isFeaturedArtistContent")
-  isDepartment: Boolean!
-
-  # Collection has prioritized connection to artist
   isFeaturedArtistContent: Boolean!
-
-  # Set of keywords used for SEO purposes
-  keywords: String!
-
-  # CollectionGroups of this collection
-  linkedCollections: [MarketingCollectionGroup!]!
-
-  # Suggested average price for included works
-  price_guidance: Float @deprecated(reason: "Prefer priceGuidance")
-
-  # Suggested average price for included works
   priceGuidance: Float
-
-  # Structured object used to build filtered artworks query
   query: MarketingCollectionQuery!
-  relatedCollections(size: Int = 10): [MarketingCollection!]!
-
-  # Collection can be surfaced on editorial pages
-  show_on_editorial: Boolean! @deprecated(reason: "Prefer showOnEditorial")
-
-  # Collection can be surfaced on editorial pages
-  showOnEditorial: Boolean!
-
-  # slug version of title, used for pretty URLs (e.g. `kaws-prints` for Kaws Prints
   slug: String!
-
-  # URL for Thumbnail image to be used when this collection is displayed.
   thumbnail: String
-
-  # Name of the collection
   title: String!
-  updatedAt: MarketingDateTime!
+  updatedAt: ISO8601DateTime!
 }
 
 type MarketingCollectionCategory {
@@ -9084,74 +9040,11 @@ type MarketingCollectionCategory {
   name: String!
 }
 
-type MarketingCollectionGroup {
-  groupType: MarketingGroupTypes!
-  internalID: ID
-  members: [MarketingCollection!]!
-  name: String!
-}
-
 type MarketingCollectionQuery {
-  acquireable: Boolean
-  aggregations: [String!]
-  artist_id: String @deprecated(reason: "Prefer artistID")
-  artist_ids: [String!] @deprecated(reason: "Prefer artistIDs")
-  artistID: String
   artistIDs: [String!]
-  at_auction: Boolean @deprecated(reason: "Prefer atAuction")
-  atAuction: Boolean
-  color: String
-  dimension_range: String @deprecated(reason: "Prefer dimensionRange")
-  dimensionRange: String
-  extra_aggregation_gene_ids: [String!]
-    @deprecated(reason: "prefer extraAggregationGeneIDs")
-  extraAggregationGeneIDs: [String!]
-  for_sale: Boolean @deprecated(reason: "Prefer forSale")
-  forSale: Boolean
-  gene_id: String @deprecated(reason: "Prefer geneID")
-  gene_ids: [String!] @deprecated(reason: "Prefer geneIDs")
-  geneID: String
   geneIDs: [String!]
-  height: String
-  id: ID
-  include_artworks_by_followed_artists: Boolean
-    @deprecated(reason: "Prefer includeArtworksByFollowedArtists")
-  include_medium_filter_in_aggregation: Boolean
-    @deprecated(reason: "Prefer includeMediumFilterInAggregation")
-  includeArtworksByFollowedArtists: Boolean
-  includeMediumFilterInAggregation: Boolean
-  inquireable_only: Boolean @deprecated(reason: "Prefer inquireableOnly")
-  inquireableOnly: Boolean
-  internalID: ID
   keyword: String
-  major_periods: [String!] @deprecated(reason: "Prefer majorPeriods")
-  majorPeriods: [String!]
-  medium: String
-  page: Int
-  partner_cities: [String!] @deprecated(reason: "Prefer partnerCities")
-  partner_id: ID @deprecated(reason: "Prefer partnerID")
-  partnerCities: [String!]
-  partnerID: ID
-  period: String
-  periods: [String!]
-  price_range: String @deprecated(reason: "Prefer priceRange")
-  priceRange: String
-  sale_id: ID @deprecated(reason: "Prefer saleID")
-  saleID: ID
-  size: Int
-  sort: String
-  tag_id: String @deprecated(reason: "Prefer tagID")
   tagID: String
-  width: String
-}
-
-scalar MarketingDateTime
-
-# Available types of CollectionGroup
-enum MarketingGroupTypes {
-  ArtistSeries
-  FeaturedCollections
-  OtherCollections
 }
 
 # Market Price Insights
@@ -11234,18 +11127,6 @@ type Query {
   _unused_gravity_categories: [MarketingCollectionCategory!]!
   _unused_gravity_devices(userId: ID!): [Device!]!
 
-  # Find a marketing collection by ID or slug
-  _unused_gravity_marketingCollection(id: ID!): MarketingCollection
-
-  # An array of marketing collections. Defaults to returning all available collections if no args are passed
-  _unused_gravity_marketingCollections(
-    artistID: ID
-    category: String
-    isFeaturedArtistContent: Boolean
-    size: Int
-    slugs: [String!]
-  ): [MarketingCollection!]
-
   # Autocomplete resolvers.
   _unused_gravity_match_partners(
     match_type: String
@@ -11830,18 +11711,18 @@ type Query {
 
   # Home screen content
   homePage: HomePage
-  marketingCategories: [MarketingCollectionCategory!]!
-  marketingCollection(slug: String!): MarketingCollection
+
+  # Find a marketing collection by ID or slug
+  marketingCollection(id: ID!): MarketingCollection
+
+  # An array of marketing collections. Defaults to returning all available collections if no args are passed
   marketingCollections(
-    artistID: String
+    artistID: ID
     category: String
     isFeaturedArtistContent: Boolean
-    randomizationSeed: String
-    showOnEditorial: Boolean
     size: Int
     slugs: [String!]
-  ): [MarketingCollection!]!
-  marketingHubCollections: [MarketingCollection!]!
+  ): [MarketingCollection!]
 
   # Get price insights for a market.
   marketPriceInsights(artistId: ID!, medium: String!): MarketPriceInsights
@@ -14944,8 +14825,6 @@ type Viewer {
     artistID: String
     category: String
     isFeaturedArtistContent: Boolean
-    randomizationSeed: String
-    showOnEditorial: Boolean
     size: Int
     slugs: [String!]
   ): [MarketingCollection]

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -1033,4 +1033,47 @@ describe("gravity/stitching", () => {
       })
     })
   })
+
+  describe("MarketingCollection", () => {
+    describe("artworksConnection", () => {
+      it("extends the MarketingCollection type with an artworksConnection field for the V2 schema", async () => {
+        config.ENABLE_GRAVITY_MARKETING_COLLECTIONS = true
+
+        const mergedSchema = await getGravityMergedSchema()
+        const marketingCollectionFields = await getFieldsForTypeFromSchema(
+          "MarketingCollection",
+          mergedSchema
+        )
+        expect(marketingCollectionFields).toContain("artworksConnection")
+      })
+
+      it("resolves the artworksConnection field on MarketingCollection for the V2 schema", async () => {
+        config.ENABLE_GRAVITY_MARKETING_COLLECTIONS = true
+
+        const { resolvers } = await getGravityStitchedSchema()
+        const { artworksConnection } = resolvers.MarketingCollection
+        const info = { mergeInfo: { delegateToSchema: jest.fn() } }
+
+        artworksConnection.resolve(
+          { internalID: "abc123" },
+          { first: 2 },
+          { currentArtworkID: "catty-artwork" },
+          info
+        )
+
+        expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
+          args: {
+            marketingCollectionID: "abc123",
+            first: 2,
+            excludeArtworkIDs: ["catty-artwork"],
+          },
+          operation: "query",
+          fieldName: "artworksConnection",
+          schema: expect.anything(),
+          context: expect.anything(),
+          info: expect.anything(),
+        })
+      })
+    })
+  })
 })

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -87,9 +87,14 @@ const gravityMarketingCollectionsExtensions = gql`
   extend type HomePage {
     marketingCollectionsModule: HomePageMarketingCollectionsModule
   }
+  extend type MarketingCollection {
+    artworksConnection(${argsToSDL(pageableFilterArtworksArgsWithInput).join(
+      "\n"
+    )}): FilterArtworksConnection
+  }
 `
 
-const gravityMarketingCollectionsResolvers = (gravitySchema) => {
+const gravityMarketingCollectionsResolvers = (gravitySchema, localSchema) => {
   return {
     Artist: {
       marketingCollections: {
@@ -205,17 +210,51 @@ const gravityMarketingCollectionsResolvers = (gravitySchema) => {
         },
       },
     },
+    MarketingCollection: {
+      artworksConnection: {
+        fragment: `
+          ... on MarketingCollection {
+            internalID
+          }
+        `,
+        resolve: (
+          { internalID: marketingCollectionID },
+          args,
+          context,
+          info
+        ) => {
+          return info.mergeInfo.delegateToSchema({
+            schema: localSchema,
+            operation: "query",
+            fieldName: "artworksConnection",
+            args: {
+              marketingCollectionID,
+              ...(!!context.currentArtworkID && {
+                excludeArtworkIDs: [context.currentArtworkID],
+              }),
+              ...args,
+            },
+            context,
+            info,
+          })
+        },
+      },
+    },
   }
 }
 
 const mergeGravityMarketingCollectionsResolvers = (
   gravitySchema,
+  localSchema,
   resolvers
 ) => {
   const { ENABLE_GRAVITY_MARKETING_COLLECTIONS } = config
 
   if (ENABLE_GRAVITY_MARKETING_COLLECTIONS) {
-    return merge(gravityMarketingCollectionsResolvers(gravitySchema), resolvers)
+    return merge(
+      gravityMarketingCollectionsResolvers(gravitySchema, localSchema),
+      resolvers
+    )
   } else {
     return resolvers
   }
@@ -347,161 +386,164 @@ export const gravityStitchingEnvironment = (
         me : Me
       }
     `,
-    resolvers: mergeGravityMarketingCollectionsResolvers(gravitySchema, {
-      Me: {
-        savedSearch: {
-          resolve: (_parent, args, context, info) => {
-            return info.mergeInfo.delegateToSchema({
-              schema: gravitySchema,
-              operation: "query",
-              fieldName: "_unused_gravity_savedSearch",
-              args: args,
-              context,
-              info,
-            })
+    resolvers: mergeGravityMarketingCollectionsResolvers(
+      gravitySchema,
+      localSchema,
+      {
+        Me: {
+          savedSearch: {
+            resolve: (_parent, args, context, info) => {
+              return info.mergeInfo.delegateToSchema({
+                schema: gravitySchema,
+                operation: "query",
+                fieldName: "_unused_gravity_savedSearch",
+                args: args,
+                context,
+                info,
+              })
+            },
           },
-        },
-        savedSearchesConnection: {
-          resolve: (_parent, args, context, info) => {
-            return info.mergeInfo.delegateToSchema({
-              schema: gravitySchema,
-              operation: "query",
-              fieldName: "_unused_gravity_savedSearchesConnection",
-              args: args,
-              context,
-              info,
-            })
+          savedSearchesConnection: {
+            resolve: (_parent, args, context, info) => {
+              return info.mergeInfo.delegateToSchema({
+                schema: gravitySchema,
+                operation: "query",
+                fieldName: "_unused_gravity_savedSearchesConnection",
+                args: args,
+                context,
+                info,
+              })
+            },
           },
-        },
-        secondFactors: {
-          resolve: (_parent, args, context, info) => {
-            return info.mergeInfo.delegateToSchema({
-              schema: gravitySchema,
-              operation: "query",
-              fieldName: "_unused_gravity_secondFactors",
-              args: args,
-              context,
-              info,
-            })
+          secondFactors: {
+            resolve: (_parent, args, context, info) => {
+              return info.mergeInfo.delegateToSchema({
+                schema: gravitySchema,
+                operation: "query",
+                fieldName: "_unused_gravity_secondFactors",
+                args: args,
+                context,
+                info,
+              })
+            },
           },
-        },
-        addressConnection: {
-          fragment: gql`
+          addressConnection: {
+            fragment: gql`
           ... on Me {
             __typename
           }
           `,
-          resolve: (_parent, args, context, info) => {
-            return info.mergeInfo.delegateToSchema({
-              schema: gravitySchema,
-              operation: "query",
-              fieldName: "_unused_gravity_userAddressConnection",
-              args: { ...args, userId: context.userID },
-              context,
-              info,
-            })
+            resolve: (_parent, args, context, info) => {
+              return info.mergeInfo.delegateToSchema({
+                schema: gravitySchema,
+                operation: "query",
+                fieldName: "_unused_gravity_userAddressConnection",
+                args: { ...args, userId: context.userID },
+                context,
+                info,
+              })
+            },
           },
         },
-      },
-      User: {
-        devices: {
-          fragment: gql`
+        User: {
+          devices: {
+            fragment: gql`
             ... on User {
             internalID
           }
           `,
-          resolve: ({ internalID: userId }, _args, context, info) => {
-            return info.mergeInfo.delegateToSchema({
-              schema: gravitySchema,
-              operation: "query",
-              fieldName: "_unused_gravity_devices",
-              args: { userId },
-              context,
-              info,
-            })
+            resolve: ({ internalID: userId }, _args, context, info) => {
+              return info.mergeInfo.delegateToSchema({
+                schema: gravitySchema,
+                operation: "query",
+                fieldName: "_unused_gravity_devices",
+                args: { userId },
+                context,
+                info,
+              })
+            },
           },
         },
-      },
-      UserAddress: {
-        id: {
-          fragment: gql`
+        UserAddress: {
+          id: {
+            fragment: gql`
           ... on UserAddress {
           internalID
           }
           `,
-          resolve: (parent, _args, _context, _info) => {
-            const internalID = parent.internalID
-            return toGlobalId("UserAddress", internalID)
+            resolve: (parent, _args, _context, _info) => {
+              const internalID = parent.internalID
+              return toGlobalId("UserAddress", internalID)
+            },
           },
         },
-      },
-      ArtistSeries: {
-        artworksConnection: {
-          fragment: gql`
+        ArtistSeries: {
+          artworksConnection: {
+            fragment: gql`
           ... on ArtistSeries {
             artworkIDs
           }
           `,
-          resolve: async ({ artworkIDs: ids }, _args, context, info) => {
-            // Exclude the current artwork in a series so that lists of
-            // other artworks in the same series don't show the artwork.
-            const filteredIDs = context.currentArtworkID
-              ? ids.filter((id) => id !== context.currentArtworkID)
-              : ids
-            return await info.mergeInfo.delegateToSchema({
-              args: {
-                ids: filteredIDs,
-                ..._args,
-              },
-              schema: localSchema,
-              operation: "query",
-              fieldName: "artworks",
-              context,
-              info,
-            })
+            resolve: async ({ artworkIDs: ids }, _args, context, info) => {
+              // Exclude the current artwork in a series so that lists of
+              // other artworks in the same series don't show the artwork.
+              const filteredIDs = context.currentArtworkID
+                ? ids.filter((id) => id !== context.currentArtworkID)
+                : ids
+              return await info.mergeInfo.delegateToSchema({
+                args: {
+                  ids: filteredIDs,
+                  ..._args,
+                },
+                schema: localSchema,
+                operation: "query",
+                fieldName: "artworks",
+                context,
+                info,
+              })
+            },
           },
-        },
-        descriptionFormatted: {
-          fragment: gql`
+          descriptionFormatted: {
+            fragment: gql`
             ... on ArtistSeries {
               description
             }
           `,
-          resolve: async ({ description }, { format }) => {
-            if (!isExisty(description) || typeof description !== "string")
-              return null
+            resolve: async ({ description }, { format }) => {
+              if (!isExisty(description) || typeof description !== "string")
+                return null
 
-            const { type: formatType } = Format
-            const desiredFormat = formatType
-              ?.getValues()
-              ?.find((e) => e.name === format)?.value
+              const { type: formatType } = Format
+              const desiredFormat = formatType
+                ?.getValues()
+                ?.find((e) => e.name === format)?.value
 
-            return formatMarkdownValue(description, desiredFormat)
+              return formatMarkdownValue(description, desiredFormat)
+            },
           },
-        },
-        artworksCountMessage: {
-          fragment: gql`
+          artworksCountMessage: {
+            fragment: gql`
             ... on ArtistSeries {
               forSaleArtworksCount
               artworksCount
             }
           `,
-          resolve: async ({ forSaleArtworksCount, artworksCount }) => {
-            let artworksCountMessage
+            resolve: async ({ forSaleArtworksCount, artworksCount }) => {
+              let artworksCountMessage
 
-            if (forSaleArtworksCount) {
-              artworksCountMessage = `${forSaleArtworksCount} available`
-            } else {
-              artworksCountMessage = `${artworksCount} ${
-                artworksCount === 1 ? "work" : "works"
-              }`
-            }
+              if (forSaleArtworksCount) {
+                artworksCountMessage = `${forSaleArtworksCount} available`
+              } else {
+                artworksCountMessage = `${artworksCount} ${
+                  artworksCount === 1 ? "work" : "works"
+                }`
+              }
 
-            return artworksCountMessage
+              return artworksCountMessage
+            },
           },
-        },
-        image: {
-          fragment: gql`
+          image: {
+            fragment: gql`
           ... on ArtistSeries {
             image_url: imageURL
             original_height: imageHeight
@@ -509,451 +551,451 @@ export const gravityStitchingEnvironment = (
             representativeArtworkID
           }
           `,
-          resolve: async (
-            {
-              representativeArtworkID,
-              image_url,
-              original_height,
-              original_width,
-            },
-            args,
-            context,
-            info
-          ) => {
-            if (image_url) {
-              context.imageData = {
+            resolve: async (
+              {
+                representativeArtworkID,
                 image_url,
-                original_width,
                 original_height,
-              }
-            } else if (representativeArtworkID) {
-              const { artworkLoader } = context
-              const { images } = await artworkLoader(representativeArtworkID)
-              context.imageData = normalizeImageData(getDefault(images))
-            }
-
-            return info.mergeInfo.delegateToSchema({
+                original_width,
+              },
               args,
-              schema: localSchema,
-              operation: "query",
-              fieldName: "_do_not_use_image",
               context,
-              info,
-            })
+              info
+            ) => {
+              if (image_url) {
+                context.imageData = {
+                  image_url,
+                  original_width,
+                  original_height,
+                }
+              } else if (representativeArtworkID) {
+                const { artworkLoader } = context
+                const { images } = await artworkLoader(representativeArtworkID)
+                context.imageData = normalizeImageData(getDefault(images))
+              }
+
+              return info.mergeInfo.delegateToSchema({
+                args,
+                schema: localSchema,
+                operation: "query",
+                fieldName: "_do_not_use_image",
+                context,
+                info,
+              })
+            },
           },
-        },
-        artists: {
-          fragment: gql`
+          artists: {
+            fragment: gql`
           ... on ArtistSeries {
             artistIDs
             internalID
           }
         `,
-          resolve: ({ artistIDs: ids, internalID }, args, context, info) => {
-            if (ids.length === 0) {
-              return []
-            }
+            resolve: ({ artistIDs: ids, internalID }, args, context, info) => {
+              if (ids.length === 0) {
+                return []
+              }
 
-            context.currentArtistSeriesInternalID = internalID
+              context.currentArtistSeriesInternalID = internalID
 
-            return info.mergeInfo.delegateToSchema({
-              schema: localSchema,
-              operation: "query",
-              fieldName: "artists",
-              args: {
-                ids,
-                ...args,
-              },
-              context,
-              info,
-            })
+              return info.mergeInfo.delegateToSchema({
+                schema: localSchema,
+                operation: "query",
+                fieldName: "artists",
+                args: {
+                  ids,
+                  ...args,
+                },
+                context,
+                info,
+              })
+            },
           },
-        },
 
-        filterArtworksConnection: {
-          fragment: `
+          filterArtworksConnection: {
+            fragment: `
           ... on ArtistSeries {
             internalID
           }
         `,
-          resolve: ({ internalID: artistSeriesID }, args, context, info) => {
-            return info.mergeInfo.delegateToSchema({
-              schema: localSchema,
-              operation: "query",
-              fieldName: "artworksConnection",
-              args: {
-                artistSeriesID,
-                ...(!!context.currentArtworkID && {
-                  excludeArtworkIDs: [context.currentArtworkID],
-                }),
-                ...args,
-              },
-              context,
-              info,
-            })
+            resolve: ({ internalID: artistSeriesID }, args, context, info) => {
+              return info.mergeInfo.delegateToSchema({
+                schema: localSchema,
+                operation: "query",
+                fieldName: "artworksConnection",
+                args: {
+                  artistSeriesID,
+                  ...(!!context.currentArtworkID && {
+                    excludeArtworkIDs: [context.currentArtworkID],
+                  }),
+                  ...args,
+                },
+                context,
+                info,
+              })
+            },
           },
         },
-      },
-      ViewingRoom: {
-        artworksConnection: {
-          fragment: gql`
+        ViewingRoom: {
+          artworksConnection: {
+            fragment: gql`
             ... on ViewingRoom {
               artworkIDs
             }
           `,
-          resolve: ({ artworkIDs: ids }, args, context, info) => {
-            // qs ignores empty array/object and prevents us from sending `?array[]=`.
-            // This is a workaround to map an empty array to `[null]` so it gets treated
-            // as an empty string.
-            // https://github.com/ljharb/qs/issues/362
-            //
-            // Note that we can't easily change this globally as there are multiple places
-            // clients are sending params of empty array but expecting Gravity to return
-            // non-empty data. This only fixes the issue for viewing room artworks.
-            if (ids.length === 0) {
-              ids = [null]
-            }
+            resolve: ({ artworkIDs: ids }, args, context, info) => {
+              // qs ignores empty array/object and prevents us from sending `?array[]=`.
+              // This is a workaround to map an empty array to `[null]` so it gets treated
+              // as an empty string.
+              // https://github.com/ljharb/qs/issues/362
+              //
+              // Note that we can't easily change this globally as there are multiple places
+              // clients are sending params of empty array but expecting Gravity to return
+              // non-empty data. This only fixes the issue for viewing room artworks.
+              if (ids.length === 0) {
+                ids = [null]
+              }
 
-            return info.mergeInfo.delegateToSchema({
-              schema: localSchema,
-              operation: "query",
-              fieldName: "artworks",
-              args: {
-                ids,
-                respectParamsOrder: true,
-                ...args,
-              },
-              context,
-              info,
-            })
+              return info.mergeInfo.delegateToSchema({
+                schema: localSchema,
+                operation: "query",
+                fieldName: "artworks",
+                args: {
+                  ids,
+                  respectParamsOrder: true,
+                  ...args,
+                },
+                context,
+                info,
+              })
+            },
           },
-        },
-        partnerArtworksConnection: {
-          fragment: gql`
+          partnerArtworksConnection: {
+            fragment: gql`
             ... on ViewingRoom {
               internalID
               partnerID
             }
           `,
-          resolve: (
-            { internalID: viewingRoomID, partnerID },
-            args,
-            context,
-            info
-          ) => {
-            return info.mergeInfo.delegateToSchema({
-              schema: localSchema,
-              operation: "query",
-              fieldName: "partnerArtworks",
-              args: {
-                viewingRoomID,
-                partnerID,
-                ...args,
-              },
+            resolve: (
+              { internalID: viewingRoomID, partnerID },
+              args,
               context,
-              info,
-            })
+              info
+            ) => {
+              return info.mergeInfo.delegateToSchema({
+                schema: localSchema,
+                operation: "query",
+                fieldName: "partnerArtworks",
+                args: {
+                  viewingRoomID,
+                  partnerID,
+                  ...args,
+                },
+                context,
+                info,
+              })
+            },
           },
-        },
-        distanceToOpen: {
-          fragment: gql`
+          distanceToOpen: {
+            fragment: gql`
             ... on ViewingRoom {
               startAt
             }
 		  `,
-          resolve: (
-            { startAt: _startAt }: { startAt: string | null },
-            { short = false }: { short?: boolean }
-          ) => {
-            if (_startAt === null) {
-              return null
-            }
+            resolve: (
+              { startAt: _startAt }: { startAt: string | null },
+              { short = false }: { short?: boolean }
+            ) => {
+              if (_startAt === null) {
+                return null
+              }
 
-            const startAt = moment(_startAt)
-            const now = moment()
+              const startAt = moment(_startAt)
+              const now = moment()
 
-            if (startAt < now) {
-              return null
-            }
+              if (startAt < now) {
+                return null
+              }
 
-            if (!short && startAt > now.clone().add(30, "days")) {
-              return null
-            }
+              if (!short && startAt > now.clone().add(30, "days")) {
+                return null
+              }
 
-            const distance = moment.duration(startAt.diff(now))
-            return distance
-              .locale(
-                short
-                  ? LocaleEnViewingRoomRelativeShort
-                  : LocaleEnViewingRoomRelativeLong
-              )
-              .humanize(short, { ss: 1, d: 31 })
+              const distance = moment.duration(startAt.diff(now))
+              return distance
+                .locale(
+                  short
+                    ? LocaleEnViewingRoomRelativeShort
+                    : LocaleEnViewingRoomRelativeLong
+                )
+                .humanize(short, { ss: 1, d: 31 })
+            },
           },
-        },
-        distanceToClose: {
-          fragment: gql`
+          distanceToClose: {
+            fragment: gql`
             ... on ViewingRoom {
               startAt
               endAt
             }
           `,
-          resolve: (
-            {
-              startAt: _startAt,
-              endAt: _endAt,
-            }: { startAt: string | null; endAt: string | null },
-            { short = false }: { short?: boolean }
-          ) => {
-            if (_startAt === null || _endAt === null) {
-              return null
-            }
-
-            const startAt = moment(_startAt)
-            const endAt = moment(_endAt)
-            const now = moment()
-
-            if (startAt > now) {
-              return null
-            }
-
-            if (endAt < now) {
-              return null
-            }
-
-            if (short) {
-              if (endAt > now.clone().add(5, "days")) {
+            resolve: (
+              {
+                startAt: _startAt,
+                endAt: _endAt,
+              }: { startAt: string | null; endAt: string | null },
+              { short = false }: { short?: boolean }
+            ) => {
+              if (_startAt === null || _endAt === null) {
                 return null
               }
-            } else {
-              if (endAt > now.clone().add(30, "days")) {
+
+              const startAt = moment(_startAt)
+              const endAt = moment(_endAt)
+              const now = moment()
+
+              if (startAt > now) {
                 return null
               }
-            }
 
-            return `${moment
-              .duration(endAt.diff(now))
-              .locale(LocaleEnViewingRoomRelativeLong)
-              .humanize(false, { ss: 1, d: 31 })}`
+              if (endAt < now) {
+                return null
+              }
+
+              if (short) {
+                if (endAt > now.clone().add(5, "days")) {
+                  return null
+                }
+              } else {
+                if (endAt > now.clone().add(30, "days")) {
+                  return null
+                }
+              }
+
+              return `${moment
+                .duration(endAt.diff(now))
+                .locale(LocaleEnViewingRoomRelativeLong)
+                .humanize(false, { ss: 1, d: 31 })}`
+            },
           },
-        },
-        partner: {
-          fragment: gql`
+          partner: {
+            fragment: gql`
             ... on ViewingRoom {
               partnerID
             }
           `,
-          resolve: ({ partnerID: id }, _args, context, info) => {
-            return info.mergeInfo.delegateToSchema({
-              schema: localSchema,
-              operation: "query",
-              fieldName: "partner",
-              args: {
-                id,
-              },
-              context,
-              info,
-            })
+            resolve: ({ partnerID: id }, _args, context, info) => {
+              return info.mergeInfo.delegateToSchema({
+                schema: localSchema,
+                operation: "query",
+                fieldName: "partner",
+                args: {
+                  id,
+                },
+                context,
+                info,
+              })
+            },
           },
-        },
-        exhibitionPeriod: {
-          fragment: gql`
+          exhibitionPeriod: {
+            fragment: gql`
           ... on ViewingRoom {
             startAt
             endAt
           }
         `,
-          resolve: ({ startAt: _startAt, endAt: _endAt }) =>
-            dateRange(_startAt, _endAt, "UTC"),
+            resolve: ({ startAt: _startAt, endAt: _endAt }) =>
+              dateRange(_startAt, _endAt, "UTC"),
+          },
         },
-      },
-      Viewer: {
-        viewingRoomsConnection: {
-          fragment: `
+        Viewer: {
+          viewingRoomsConnection: {
+            fragment: `
           ... on Viewer {
             __typename
           }`,
-          resolve: (_parent, args, context, info) => {
-            return info.mergeInfo.delegateToSchema({
-              schema: gravitySchema,
-              operation: "query",
-              fieldName: "_unused_gravity_viewingRoomsConnection",
-              args,
-              context,
-              info,
-            })
+            resolve: (_parent, args, context, info) => {
+              return info.mergeInfo.delegateToSchema({
+                schema: gravitySchema,
+                operation: "query",
+                fieldName: "_unused_gravity_viewingRoomsConnection",
+                args,
+                context,
+                info,
+              })
+            },
           },
         },
-      },
-      Partner: {
-        viewingRoomsConnection: {
-          fragment: gql`
+        Partner: {
+          viewingRoomsConnection: {
+            fragment: gql`
             ... on Partner {
               internalID
             }
           `,
-          resolve: ({ internalID: partnerID }, args, context, info) => {
-            return info.mergeInfo.delegateToSchema({
-              schema: gravitySchema,
-              operation: "query",
-              fieldName: "_unused_gravity_viewingRoomsConnection",
-              args: {
-                partnerID,
-                ...args,
-              },
-              context,
-              info,
-            })
+            resolve: ({ internalID: partnerID }, args, context, info) => {
+              return info.mergeInfo.delegateToSchema({
+                schema: gravitySchema,
+                operation: "query",
+                fieldName: "_unused_gravity_viewingRoomsConnection",
+                args: {
+                  partnerID,
+                  ...args,
+                },
+                context,
+                info,
+              })
+            },
           },
         },
-      },
-      Show: {
-        viewingRoomsConnection: {
-          fragment: gql`
+        Show: {
+          viewingRoomsConnection: {
+            fragment: gql`
             ... on Show {
               viewingRoomIDs
             }
           `,
-          resolve: ({ viewingRoomIDs: ids }, _args, context, info) => {
-            if (ids.length === 0) return null
+            resolve: ({ viewingRoomIDs: ids }, _args, context, info) => {
+              if (ids.length === 0) return null
 
-            return info.mergeInfo.delegateToSchema({
-              schema: gravitySchema,
-              operation: "query",
-              fieldName: "_unused_gravity_viewingRoomsConnection",
-              args: {
-                ids,
-              },
-              context,
-              info,
-            })
+              return info.mergeInfo.delegateToSchema({
+                schema: gravitySchema,
+                operation: "query",
+                fieldName: "_unused_gravity_viewingRoomsConnection",
+                args: {
+                  ids,
+                },
+                context,
+                info,
+              })
+            },
           },
         },
-      },
-      Artist: {
-        artistSeriesConnection: {
-          fragment: gql`
+        Artist: {
+          artistSeriesConnection: {
+            fragment: gql`
             ... on Artist {
               internalID
             }
           `,
-          resolve: ({ internalID: artistID }, args, context, info) => {
-            return info.mergeInfo.delegateToSchema({
-              schema: gravitySchema,
-              operation: "query",
-              fieldName: "artistSeriesConnection",
-              args: {
-                artistID,
-                ...args,
-                // Exclude the current artist series so that lists of
-                // artist series by the artist don't include the current series
-                // if there is one.
-                ...(!!context.currentArtistSeriesInternalID && {
-                  excludeIDs: [context.currentArtistSeriesInternalID],
-                }),
-              },
-              context,
-              info,
-            })
+            resolve: ({ internalID: artistID }, args, context, info) => {
+              return info.mergeInfo.delegateToSchema({
+                schema: gravitySchema,
+                operation: "query",
+                fieldName: "artistSeriesConnection",
+                args: {
+                  artistID,
+                  ...args,
+                  // Exclude the current artist series so that lists of
+                  // artist series by the artist don't include the current series
+                  // if there is one.
+                  ...(!!context.currentArtistSeriesInternalID && {
+                    excludeIDs: [context.currentArtistSeriesInternalID],
+                  }),
+                },
+                context,
+                info,
+              })
+            },
           },
         },
-      },
-      Artwork: {
-        artistSeriesConnection: {
-          fragment: gql`
+        Artwork: {
+          artistSeriesConnection: {
+            fragment: gql`
             ... on Artwork {
               internalID
             }
             `,
-          resolve: ({ internalID: artworkID }, args, context, info) => {
-            context.currentArtworkID = artworkID
-            return info.mergeInfo.delegateToSchema({
-              schema: gravitySchema,
-              operation: "query",
-              fieldName: "artistSeriesConnection",
-              args: {
-                artworkID,
-                ...args,
-              },
-              context,
-              info,
-            })
+            resolve: ({ internalID: artworkID }, args, context, info) => {
+              context.currentArtworkID = artworkID
+              return info.mergeInfo.delegateToSchema({
+                schema: gravitySchema,
+                operation: "query",
+                fieldName: "artistSeriesConnection",
+                args: {
+                  artworkID,
+                  ...args,
+                },
+                context,
+                info,
+              })
+            },
           },
         },
-      },
-      System: {
-        algolia: {
-          resolve: (_parent, args, context, info) => {
-            return info.mergeInfo.delegateToSchema({
-              schema: gravitySchema,
-              operation: "query",
-              fieldName: "_unused_gravity_algolia",
-              args: args,
-              context,
-              info,
-            })
+        System: {
+          algolia: {
+            resolve: (_parent, args, context, info) => {
+              return info.mergeInfo.delegateToSchema({
+                schema: gravitySchema,
+                operation: "query",
+                fieldName: "_unused_gravity_algolia",
+                args: args,
+                context,
+                info,
+              })
+            },
           },
         },
-      },
-      CreateUserAddressPayload: {
-        me: {
-          resolve: (_parent, args, context, info) => {
-            return info.mergeInfo.delegateToSchema({
-              schema: localSchema,
-              operation: "query",
-              fieldName: "me",
-              args,
-              context,
-              info,
-            })
+        CreateUserAddressPayload: {
+          me: {
+            resolve: (_parent, args, context, info) => {
+              return info.mergeInfo.delegateToSchema({
+                schema: localSchema,
+                operation: "query",
+                fieldName: "me",
+                args,
+                context,
+                info,
+              })
+            },
           },
         },
-      },
-      UpdateUserAddressPayload: {
-        me: {
-          resolve: (_parent, args, context, info) => {
-            return info.mergeInfo.delegateToSchema({
-              schema: localSchema,
-              operation: "query",
-              fieldName: "me",
-              args,
-              context,
-              info,
-            })
+        UpdateUserAddressPayload: {
+          me: {
+            resolve: (_parent, args, context, info) => {
+              return info.mergeInfo.delegateToSchema({
+                schema: localSchema,
+                operation: "query",
+                fieldName: "me",
+                args,
+                context,
+                info,
+              })
+            },
           },
         },
-      },
-      DeleteUserAddressPayload: {
-        me: {
-          resolve: (_parent, args, context, info) => {
-            console.log("DELETE: DeleteUserAddressPayload")
-            return info.mergeInfo.delegateToSchema({
-              schema: localSchema,
-              operation: "query",
-              fieldName: "me",
-              args,
-              context,
-              info,
-            })
+        DeleteUserAddressPayload: {
+          me: {
+            resolve: (_parent, args, context, info) => {
+              console.log("DELETE: DeleteUserAddressPayload")
+              return info.mergeInfo.delegateToSchema({
+                schema: localSchema,
+                operation: "query",
+                fieldName: "me",
+                args,
+                context,
+                info,
+              })
+            },
           },
         },
-      },
-      UpdateUserDefaultAddressPayload: {
-        me: {
-          resolve: (_parent, args, context, info) => {
-            return info.mergeInfo.delegateToSchema({
-              schema: localSchema,
-              operation: "query",
-              fieldName: "me",
-              args,
-              context,
-              info,
-            })
+        UpdateUserDefaultAddressPayload: {
+          me: {
+            resolve: (_parent, args, context, info) => {
+              return info.mergeInfo.delegateToSchema({
+                schema: localSchema,
+                operation: "query",
+                fieldName: "me",
+                args,
+                context,
+                info,
+              })
+            },
           },
         },
-      },
-      SearchCriteria: {
-        labels: {
-          fragment: gql`
+        SearchCriteria: {
+          labels: {
+            fragment: gql`
             ... on SearchCriteria {
               artistIDs
               attributionClass
@@ -973,11 +1015,12 @@ export const gravityStitchingEnvironment = (
               partnerIDs
             }
             `,
-          resolve: resolveSearchCriteriaLabels,
-          description:
-            "Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity",
+            resolve: resolveSearchCriteriaLabels,
+            description:
+              "Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity",
+          },
         },
-      },
-    }),
+      }
+    ),
   }
 }

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -230,6 +230,9 @@ export const filterArtworksArgs: GraphQLFieldConfigArgumentMap = {
   locationCities: {
     type: new GraphQLList(GraphQLString),
   },
+  marketingCollectionID: {
+    type: GraphQLString,
+  },
 }
 
 const pageableFilterArtworksArgs = pageable(filterArtworksArgs)
@@ -416,6 +419,7 @@ const convertFilterArgs = ({
   geneID,
   geneIDs,
   majorPeriods,
+  marketingCollectionID,
   materialsTerms,
   partnerID,
   partnerIDs,
@@ -447,6 +451,7 @@ const convertFilterArgs = ({
     gene_id: geneID,
     gene_ids: geneIDs,
     major_periods: majorPeriods,
+    marketing_collection_id: marketingCollectionID,
     materials_terms: materialsTerms,
     partner_id: partnerID,
     partner_ids: partnerIDs,


### PR DESCRIPTION
Jira: https://artsyproduct.atlassian.net/browse/FX-3850

This PR is a part of [Kaws deprecation](https://www.notion.so/artsy/Deprecating-Kaws-7be8b8b764534ea7838224f06252b99a) story

Adds `artworksConnection` under gravity-backed `marketingCollection` type.

<img width="1256" alt="Screenshot 2022-04-12 at 19 51 23" src="https://user-images.githubusercontent.com/3934579/163023790-06ea317a-bfcc-4eac-8bd8-02127b088e2f.png">
