### PR TITLE
chore: update grav schema to include MarketingCollectionGroup

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -10201,6 +10201,13 @@ type MarketingCollectionGroup {
   name: String!
 }
 
+enum MarketingCollectionGroupTypeEnum {
+  # Artist-focused collections, not to be confused with actual ArtistSeries
+  ArtistSeries
+  FeaturedCollections
+  OtherCollections
+}
+
 type MarketingCollectionQuery {
   acquireable: Boolean
   aggregations: [String!]

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9098,6 +9098,13 @@ type MarketingCollectionGroup {
   name: String!
 }
 
+enum MarketingCollectionGroupTypeEnum {
+  # Artist-focused collections, not to be confused with actual ArtistSeries
+  ArtistSeries
+  FeaturedCollections
+  OtherCollections
+}
+
 type MarketingCollectionQuery {
   acquireable: Boolean
   aggregations: [String!]

--- a/src/data/gravity.graphql
+++ b/src/data/gravity.graphql
@@ -1115,6 +1115,7 @@ type MarketingCollection {
   """
   internalID: ID!
   isFeaturedArtistContent: Boolean!
+  linkedCollections: [MarketingCollectionGroup!]!
   priceGuidance: Float
   query: MarketingCollectionQuery!
   slug: String!
@@ -1126,6 +1127,22 @@ type MarketingCollection {
 type MarketingCollectionCategory {
   collections: [MarketingCollection!]!
   name: String!
+}
+
+type MarketingCollectionGroup {
+  groupType: MarketingCollectionGroupTypeEnum!
+  internalID: ID!
+  members: [MarketingCollection!]!
+  name: String!
+}
+
+enum MarketingCollectionGroupTypeEnum {
+  """
+  Artist-focused collections, not to be confused with actual ArtistSeries
+  """
+  ArtistSeries
+  FeaturedCollections
+  OtherCollections
 }
 
 type MarketingCollectionQuery {

--- a/src/lib/stitching/gravity/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/lib/stitching/gravity/__tests__/__snapshots__/schema.test.ts.snap
@@ -593,6 +593,7 @@ type MarketingCollection {
   # Unique ID for this marketing collection
   internalID: ID!
   isFeaturedArtistContent: Boolean!
+  linkedCollections: [MarketingCollectionGroup!]!
   priceGuidance: Float
   query: MarketingCollectionQuery!
   slug: String!
@@ -604,6 +605,20 @@ type MarketingCollection {
 type MarketingCollectionCategory {
   collections: [MarketingCollection!]!
   name: String!
+}
+
+type MarketingCollectionGroup {
+  groupType: MarketingCollectionGroupTypeEnum!
+  internalID: ID!
+  members: [MarketingCollection!]!
+  name: String!
+}
+
+enum MarketingCollectionGroupTypeEnum {
+  # Artist-focused collections, not to be confused with actual ArtistSeries
+  ArtistSeries
+  FeaturedCollections
+  OtherCollections
 }
 
 type MarketingCollectionQuery {


### PR DESCRIPTION
Just a schema bump now that we include these groups in Gravity's schema!