### PR TITLE
[PX-4996] Removes deprecated fields and fallback to arta_enabled and process_wi…

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1689,6 +1689,7 @@ type Artwork implements Node & Searchable & Sellable {
     first: Int
     last: Int
   ): ArtistSeriesConnection
+  artsyShippingDomestic: Boolean
   artsyShippingInternational: Boolean
 
   # Represents the location of the artwork for "My Collection" artworks
@@ -1881,12 +1882,6 @@ type Artwork implements Node & Searchable & Sellable {
   # The price paid for the artwork in a user's 'my collection'
   pricePaid: Money
   pricingContext: AnalyticsPricingContext
-
-  # Returns true if this work is eligible to be automatically opted into Artsy Domestic Shipping
-  processWithArtaShipping: Boolean
-    @deprecated(
-      reason: "Prefer to use `processWithArtsyShippingDomestic`. [Will be removed in v2]"
-    )
 
   # Returns true if this work is eligible to be automatically opted into Artsy Domestic Shipping
   processWithArtsyShippingDomestic: Boolean

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -49,7 +49,7 @@ describe("Artwork type", () => {
       metric: "in",
       unlisted: true,
       category: "Painting",
-      arta_enabled: false,
+      artsy_shipping_domestic: false,
     }
 
     context = {
@@ -609,6 +609,54 @@ describe("Artwork type", () => {
     })
   })
 
+  describe("#artaShippingEnabled", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          slug
+          artaShippingEnabled
+        }
+      }
+    `
+
+    it("passes true from gravity", () => {
+      artwork.arta_enabled = true
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            slug: "richard-prince-untitled-portrait",
+            artaShippingEnabled: true,
+          },
+        })
+      })
+    })
+  })
+
+  describe("#artsyShippingDomestic", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          slug
+          artsyShippingDomestic
+        }
+      }
+    `
+
+    it("passes true from gravity", () => {
+      artwork.artsy_shipping_domestic = true
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            slug: "richard-prince-untitled-portrait",
+            artsyShippingDomestic: true,
+          },
+        })
+      })
+    })
+  })
+
   describe("#artsyShippingInternational", () => {
     const query = `
       {
@@ -643,50 +691,9 @@ describe("Artwork type", () => {
       }
     `
 
-    describe("when process_with_artsy_shipping is null", () => {
-      beforeEach(() => {
-        artwork.process_with_artsy_shipping_domestic = null
-      })
-
-      describe("when fallback is null", () => {
-        beforeEach(() => {
-          artwork.process_with_arta_shipping = null
-        })
-
-        it("returns false", () => {
-          return runQuery(query, context).then((data) => {
-            expect(data).toEqual({
-              artwork: {
-                slug: "richard-prince-untitled-portrait",
-                processWithArtsyShippingDomestic: false,
-              },
-            })
-          })
-        })
-
-        describe("when fallback is true", () => {
-          beforeEach(() => {
-            artwork.process_with_arta_shipping = true
-          })
-
-          it("returns the fallback value for process_with_arta_shipping", () => {
-            return runQuery(query, context).then((data) => {
-              expect(data).toEqual({
-                artwork: {
-                  slug: "richard-prince-untitled-portrait",
-                  processWithArtsyShippingDomestic: true,
-                },
-              })
-            })
-          })
-        })
-      })
-    })
-
     describe("when process_with_artsy_shipping is true", () => {
       beforeEach(() => {
         artwork.process_with_artsy_shipping_domestic = true
-        artwork.process_with_arta_shipping = null
       })
 
       it("returns the correct value", () => {
@@ -697,54 +704,6 @@ describe("Artwork type", () => {
               processWithArtsyShippingDomestic: true,
             },
           })
-        })
-      })
-    })
-  })
-
-  describe("#artaShippingEnabled", () => {
-    const query = `
-      {
-        artwork(id: "richard-prince-untitled-portrait") {
-          slug
-          artaShippingEnabled
-        }
-      }
-    `
-
-    it("passes true from gravity", () => {
-      artwork.arta_enabled = true
-
-      return runQuery(query, context).then((data) => {
-        expect(data).toEqual({
-          artwork: {
-            slug: "richard-prince-untitled-portrait",
-            artaShippingEnabled: true,
-          },
-        })
-      })
-    })
-  })
-
-  describe("#processWithArtaShipping", () => {
-    const query = `
-      {
-        artwork(id: "richard-prince-untitled-portrait") {
-          slug
-          processWithArtaShipping
-        }
-      }
-    `
-
-    it("passes true from gravity", () => {
-      artwork.process_with_arta_shipping = true
-
-      return runQuery(query, context).then((data) => {
-        expect(data).toEqual({
-          artwork: {
-            slug: "richard-prince-untitled-portrait",
-            processWithArtaShipping: true,
-          },
         })
       })
     })
@@ -2368,7 +2327,7 @@ describe("Artwork type", () => {
     })
 
     it("is set to calculated at checkout when artwork will be processed with Arta shipping", () => {
-      artwork.process_with_arta_shipping = true
+      artwork.process_with_artsy_shipping_domestic = true
 
       return runQuery(query, context).then((data) => {
         expect(data).toEqual({

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -762,6 +762,10 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         }),
         resolve: ({ arta_enabled }) => arta_enabled,
       },
+      artsyShippingDomestic: {
+        type: GraphQLBoolean,
+        resolve: ({ artsy_shipping_domestic }) => artsy_shipping_domestic,
+      },
       artsyShippingInternational: {
         type: GraphQLBoolean,
         resolve: ({ artsy_shipping_international }) =>
@@ -771,22 +775,8 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLBoolean,
         description:
           "Returns true if this work is eligible to be automatically opted into Artsy Domestic Shipping",
-        resolve: (artwork) => {
-          return Boolean(
-            artwork.process_with_artsy_shipping_domestic ||
-              artwork.process_with_arta_shipping
-          )
-        },
-      },
-      processWithArtaShipping: {
-        type: GraphQLBoolean,
-        description:
-          "Returns true if this work is eligible to be automatically opted into Artsy Domestic Shipping",
-        deprecationReason: deprecate({
-          inVersion: 2,
-          preferUsageOf: "processWithArtsyShippingDomestic",
-        }),
-        resolve: ({ process_with_arta_shipping }) => process_with_arta_shipping,
+        resolve: ({ process_with_artsy_shipping_domestic }) =>
+          process_with_artsy_shipping_domestic,
       },
       shipsToContinentalUSOnly: {
         type: GraphQLBoolean,
@@ -844,7 +834,6 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         resolve: (artwork) => {
           if (
             artwork.process_with_artsy_shipping_domestic ||
-            artwork.process_with_arta_shipping ||
             artwork.artsy_shipping_international
           ) {
             return "Shipping: Calculated in checkout"

--- a/src/schema/v2/me/__tests__/newWorksByInterestingArtists.test.ts
+++ b/src/schema/v2/me/__tests__/newWorksByInterestingArtists.test.ts
@@ -296,6 +296,6 @@ const mockArtworksResponse = [
     current_version_id: null,
     unlisted: false,
     featured_slot: null,
-    arta_enabled: false,
+    artsy_shipping_domestic: false,
   },
 ]


### PR DESCRIPTION
…th_arta_shipping

Co-authored-by: lilyfromseattle <lilyfpace@gmail.com>


Addresses: https://artsyproduct.atlassian.net/browse/PX-4996
A revert of the revert of: https://github.com/artsy/metaphysics/pull/3978/files because we discovered volt orders was pulling in deprecated fields still
Also adds `artsyShippingDomestic` to MP schema (which Volt needs and was missing!)

TO NOTE the corresponding Volt PR should be deployed first before merging this in:
https://github.com/artsy/volt/pull/5891