### PR TITLE
chore: add new fields for popcorn bidding to sale and sale artwork

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12475,6 +12475,12 @@ type Sale implements Node {
     timezone: String
   ): String
 
+  # Amount of time added when a late bid comes in.
+  extendedBiddingIntervalMinutes: Int
+
+  # Duration before lot closes that a late bid would extend the end time.
+  extendedBiddingPeriodMinutes: Int
+
   # A formatted description of when the auction starts or ends or if it has ended
   formattedStartDateTime: String
   href: String
@@ -12600,6 +12606,14 @@ type SaleArtwork implements ArtworkEdgeInterface & Node {
 
   # Singular estimate field, if specified
   estimateCents: Int
+  extendedBiddingEndAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See
+    # http://www.iana.org/time-zones,
+    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
 
   # A formatted description of the lot end date and time
   formattedEndDateTime: String

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -212,6 +212,19 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
       endedAt: date,
       eventStartAt: date,
       eventEndAt: date,
+      extendedBiddingIntervalMinutes: {
+        type: GraphQLInt,
+        description: "Amount of time added when a late bid comes in.",
+        resolve: ({ extended_bidding_interval_minutes }) =>
+          extended_bidding_interval_minutes,
+      },
+      extendedBiddingPeriodMinutes: {
+        type: GraphQLInt,
+        description:
+          "Duration before lot closes that a late bid would extend the end time.",
+        resolve: ({ extended_bidding_period_minutes }) =>
+          extended_bidding_period_minutes,
+      },
       formattedStartDateTime: {
         type: GraphQLString,
         description:

--- a/src/schema/v2/sale_artwork.ts
+++ b/src/schema/v2/sale_artwork.ts
@@ -126,6 +126,9 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
       }),
       endAt: date(({ end_at }) => end_at),
       endedAt: date(({ ended_at }) => ended_at),
+      extendedBiddingEndAt: date(
+        ({ extended_bidding_end_at }) => extended_bidding_end_at
+      ),
       estimate: {
         type: GraphQLString,
         resolve: ({


### PR DESCRIPTION
Adds the fields for popcorn bidding, this lets the front-end start using them.