### PR TITLE
chore: connect to diffusion using internal hostname

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,11 +1,11 @@
 # Services
 CONVECTION_API_BASE=https://convection-staging.artsy.net/api
 CONVECTION_APP_ID=123412341
-DIFFUSION_API_BASE=https://diffusion-staging.artsy.net/api
+DIFFUSION_API_BASE=https://diffusion.stg.artsy.systems/api
 DIFFUSION_TOKEN=REPLACE
 DELTA_API_BASE=http://delta.artsy.test
 EMBEDLY_ENDPOINT=https://i.embed.ly.test/1/display
-GALAXY_API_BASE=https://galaxy-staging-herokuapp.com
+GALAXY_API_BASE=https://galaxy.stg.artsy.systems
 GEMINI_API_BASE=https://media.artsy.net
 GEMINI_ENDPOINT=https://gemini.cloudfront.test
 GEODATA_API_BASE=http://artsy-geodata.s3-website-us-east-1.amazonaws.com

--- a/src/lib/__tests__/apis/galaxy.test.js
+++ b/src/lib/__tests__/apis/galaxy.test.js
@@ -8,7 +8,7 @@ describe("APIs", () => {
     it("makes a correct request to Gravity", async () => {
       await galaxy("foo/bar", null, { userAgent: "catty browser" })
 
-      const url = "https://galaxy-staging-herokuapp.com/foo/bar"
+      const url = "https://galaxy.stg.artsy.systems/foo/bar"
       const requestConfig = {
         headers: {
           Accept: "application/vnd.galaxy-public+json",


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4041

As part of making diffusion internal only Metaphysics, a consumer of diffusion, will now use `artsy.systems` domain to reach diffusion. 

The environments (and `.env.shared`) have already been updated to use internal hostname:
```
➜  metaphysics git:(ovasdi/PLATFORM-4041/diffusion-internal-routing) hokusai staging env get | grep -i diffusion
DIFFUSION_API_BASE=https://diffusion.stg.artsy.systems/api
➜  metaphysics git:(ovasdi/PLATFORM-4041/diffusion-internal-routing) hokusai production env get | grep -i diffusion
DIFFUSION_API_BASE=https://diffusion.prd.artsy.systems/api
```

I noticed that galaxy URL is out of date so that was also updated as part of this PR.

