### PR TITLE
refactor: Consolidate sale formatted start end time

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8167,17 +8167,6 @@ type FormattedDaySchedules {
 # a formatted String. It does not try to coerce the type.
 scalar FormattedNumber
 
-enum FormattedStartDateTimeEnum {
-  # Formatted date
-  Date
-
-  # Formatted date range
-  DateRange
-
-  # Formatted date including time
-  DateTime
-}
-
 # An entry from gemini
 type GeminiEntry {
   # The token that represents the gemini entry.
@@ -12586,8 +12575,9 @@ type Sale implements Node {
 
   # A formatted description of when the auction starts or ends or if it has ended
   formattedStartDateTime(
-    # Formatting option to apply to the start date
-    format: FormattedStartDateTimeEnum
+    # Formatted date that shows if a date range if a sale is open, Closed {date}
+    # if the sale is closed, and Lots are closing if the sale is ending
+    summary: Boolean = false
   ): String
   href: String
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8167,6 +8167,17 @@ type FormattedDaySchedules {
 # a formatted String. It does not try to coerce the type.
 scalar FormattedNumber
 
+enum FormattedStartDateTimeEnum {
+  # Formatted date
+  Date
+
+  # Formatted date range
+  DateRange
+
+  # Formatted date including time
+  DateTime
+}
+
 # An entry from gemini
 type GeminiEntry {
   # The token that represents the gemini entry.
@@ -12574,7 +12585,10 @@ type Sale implements Node {
   extendedBiddingPeriodMinutes: Int
 
   # A formatted description of when the auction starts or ends or if it has ended
-  formattedStartDateTime: String
+  formattedStartDateTime(
+    # Formatting option to apply to the start date
+    format: FormattedStartDateTimeEnum
+  ): String
   href: String
 
   # A globally unique ID.

--- a/src/lib/__tests__/date.test.ts
+++ b/src/lib/__tests__/date.test.ts
@@ -91,59 +91,87 @@ describe("date formatting", () => {
       Date.now = realNow
     })
 
-    it("includes 'Starts' when event starts in the future", () => {
+    it("includes start date when event starts in the future", () => {
       const period = formattedStartDateTime(
         "2045-12-05T20:00:00+00:00",
         "2050-12-30T17:00:00+00:00",
         null,
-        "UTC"
+        null,
+        null,
+        "UTC",
+        null
       )
-      expect(period).toBe("Starts Dec 5, 2045 at 8:00pm UTC")
+      expect(period).toBe("Dec 5, 2045 • 8:00pm UTC")
     })
 
-    it("includes 'Ends' when event is running and terminates in the future", () => {
+    it("includes end date when event is running and terminates in the future", () => {
       const period = formattedStartDateTime(
         "2017-12-05T20:00:00+00:00",
         "2045-12-30T17:00:00+00:00",
         null,
-        "UTC"
+        null,
+        null,
+        "UTC",
+        null
       )
-      expect(period).toBe("Ends Dec 30, 2045 at 5:00pm UTC")
+      expect(period).toBe("Dec 30, 2045 • 5:00pm UTC")
     })
 
-    it("includes 'Ended on date' when event ended in the past and is now closed", () => {
+    it("includes 'Closed date' when event ended in the past and is now closed", () => {
       const period = formattedStartDateTime(
         "2016-12-05T20:00:00+00:00",
         "2016-12-30T17:00:00+00:00",
         null,
-        "UTC"
+        null,
+        null,
+        "UTC",
+        null
       )
-      expect(period).toBe("Ended Dec 30, 2016")
+      expect(period).toBe("Closed Dec 30, 2016 • 5:00pm UTC")
     })
 
-    it("includes 'Starts' when event starts in the future (2)", () => {
+    it("includes start date when event starts in the future (2)", () => {
       const period = formattedStartDateTime(
         "2045-12-05T20:00:00+00:00",
         "2050-12-30T17:00:00+00:00",
         null,
-        "UTC"
+        null,
+        null,
+        "UTC",
+        null
       )
-      expect(period).toBe("Starts Dec 5, 2045 at 8:00pm UTC")
+      expect(period).toBe("Dec 5, 2045 • 8:00pm UTC")
     })
 
     it("includes 'Live' string when auction has started but live sale has not", () => {
       const startAt = "2012-12-05T20:00:00+00:00"
       const liveStartAt = "2045-12-05T20:00:00+00:00"
       const endAt = "2045-12-05T20:00:00+00:00"
-      const date = formattedStartDateTime(startAt, endAt, liveStartAt, "UTC")
-      expect(date).toEqual("Live Dec 5, 2045 at 8:00pm UTC")
+      const date = formattedStartDateTime(
+        startAt,
+        endAt,
+        null,
+        null,
+        liveStartAt,
+        "UTC",
+        null
+      )
+      expect(date).toEqual("Live Dec 5, 2045 • 8:00pm UTC")
     })
 
     it("includes 'In progress' string when auction is live", () => {
       const startAt = "2012-12-05T20:00:00+00:00"
       const liveStartAt = "2012-12-05T20:00:00+00:00"
       const endAt = "2045-12-05T20:00:00+00:00"
-      const date = formattedStartDateTime(startAt, endAt, liveStartAt, "UTC")
+      const date = formattedStartDateTime(
+        startAt,
+        endAt,
+        null,
+        null,
+        liveStartAt,
+        "UTC",
+        null
+      )
       expect(date).toEqual("In progress")
     })
   })

--- a/src/lib/__tests__/date.test.ts
+++ b/src/lib/__tests__/date.test.ts
@@ -91,16 +91,6 @@ describe("date formatting", () => {
       Date.now = realNow
     })
 
-    it("includes start date when event starts in the future", () => {
-      const period = formattedStartDateTime({
-        startAt: "2045-12-05T20:00:00+00:00",
-        endAt: "2050-12-30T17:00:00+00:00",
-        endedAt: null,
-        timezone: "UTC",
-      })
-      expect(period).toBe("Dec 5, 2045 • 8:00pm UTC")
-    })
-
     it("includes end date when event is running and terminates in the future", () => {
       const period = formattedStartDateTime({
         startAt: "2017-12-05T20:00:00+00:00",
@@ -121,9 +111,20 @@ describe("date formatting", () => {
       expect(period).toBe("Closed Dec 30, 2016 • 5:00pm UTC")
     })
 
-    it("includes start date when event starts in the future (2)", () => {
+    it("includes start date when event starts in the future", () => {
       const period = formattedStartDateTime({
         startAt: "2045-12-05T20:00:00+00:00",
+        endAt: "2050-12-30T17:00:00+00:00",
+        endedAt: null,
+        timezone: "UTC",
+      })
+      expect(period).toBe("Dec 5, 2045 • 8:00pm UTC")
+    })
+
+    it("includes start date when event starts in the future and live start date is in the future", () => {
+      const period = formattedStartDateTime({
+        startAt: "2045-12-05T20:00:00+00:00",
+        liveStartAt: "2045-12-10T20:00:00+00:00",
         endAt: "2050-12-30T17:00:00+00:00",
         endedAt: null,
         timezone: "UTC",

--- a/src/lib/__tests__/date.test.ts
+++ b/src/lib/__tests__/date.test.ts
@@ -92,54 +92,42 @@ describe("date formatting", () => {
     })
 
     it("includes start date when event starts in the future", () => {
-      const period = formattedStartDateTime(
-        "2045-12-05T20:00:00+00:00",
-        "2050-12-30T17:00:00+00:00",
-        null,
-        null,
-        null,
-        "UTC",
-        null
-      )
+      const period = formattedStartDateTime({
+        startAt: "2045-12-05T20:00:00+00:00",
+        endAt: "2050-12-30T17:00:00+00:00",
+        endedAt: null,
+        timezone: "UTC",
+      })
       expect(period).toBe("Dec 5, 2045 • 8:00pm UTC")
     })
 
     it("includes end date when event is running and terminates in the future", () => {
-      const period = formattedStartDateTime(
-        "2017-12-05T20:00:00+00:00",
-        "2045-12-30T17:00:00+00:00",
-        null,
-        null,
-        null,
-        "UTC",
-        null
-      )
+      const period = formattedStartDateTime({
+        startAt: "2017-12-05T20:00:00+00:00",
+        endAt: "2045-12-30T17:00:00+00:00",
+        endedAt: null,
+        timezone: "UTC",
+      })
       expect(period).toBe("Dec 30, 2045 • 5:00pm UTC")
     })
 
     it("includes 'Closed date' when event ended in the past and is now closed", () => {
-      const period = formattedStartDateTime(
-        "2016-12-05T20:00:00+00:00",
-        "2016-12-30T17:00:00+00:00",
-        null,
-        null,
-        null,
-        "UTC",
-        null
-      )
+      const period = formattedStartDateTime({
+        startAt: "2016-12-05T20:00:00+00:00",
+        endAt: "2016-12-30T17:00:00+00:00",
+        endedAt: null,
+        timezone: "UTC",
+      })
       expect(period).toBe("Closed Dec 30, 2016 • 5:00pm UTC")
     })
 
     it("includes start date when event starts in the future (2)", () => {
-      const period = formattedStartDateTime(
-        "2045-12-05T20:00:00+00:00",
-        "2050-12-30T17:00:00+00:00",
-        null,
-        null,
-        null,
-        "UTC",
-        null
-      )
+      const period = formattedStartDateTime({
+        startAt: "2045-12-05T20:00:00+00:00",
+        endAt: "2050-12-30T17:00:00+00:00",
+        endedAt: null,
+        timezone: "UTC",
+      })
       expect(period).toBe("Dec 5, 2045 • 8:00pm UTC")
     })
 
@@ -147,15 +135,13 @@ describe("date formatting", () => {
       const startAt = "2012-12-05T20:00:00+00:00"
       const liveStartAt = "2045-12-05T20:00:00+00:00"
       const endAt = "2045-12-05T20:00:00+00:00"
-      const date = formattedStartDateTime(
+      const date = formattedStartDateTime({
         startAt,
         endAt,
-        null,
-        null,
+        endedAt: null,
         liveStartAt,
-        "UTC",
-        null
-      )
+        timezone: "UTC",
+      })
       expect(date).toEqual("Live Dec 5, 2045 • 8:00pm UTC")
     })
 
@@ -163,15 +149,13 @@ describe("date formatting", () => {
       const startAt = "2012-12-05T20:00:00+00:00"
       const liveStartAt = "2012-12-05T20:00:00+00:00"
       const endAt = "2045-12-05T20:00:00+00:00"
-      const date = formattedStartDateTime(
+      const date = formattedStartDateTime({
         startAt,
         endAt,
-        null,
-        null,
+        endedAt: null,
         liveStartAt,
-        "UTC",
-        null
-      )
+        timezone: "UTC",
+      })
       expect(date).toEqual("In progress")
     })
   })

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -267,6 +267,7 @@ export function formattedStartDateTime(
   startAt,
   endAt,
   endedAt,
+  extendedBiddingEndAt,
   liveStartAt,
   timezone,
   cascading_end_time_interval_minutes
@@ -277,6 +278,7 @@ export function formattedStartDateTime(
   // saleEndMoment is when the lots start closing for sales with cascading end times
   const saleEndMoment = moment.tz(endAt, tz)
   const saleEndedMoment = moment.tz(endedAt, tz)
+  const extendedBiddingEndAtMoment = moment.tz(extendedBiddingEndAt, tz)
   const liveStartMoment = moment.tz(liveStartAt, tz)
 
   if (liveStartAt || thisMoment.isBefore(saleEndedMoment)) {
@@ -297,10 +299,17 @@ export function formattedStartDateTime(
       "MMM D, YYYY"
     )} • ${saleEndedMoment.format("h:mma z")}`
 
+  // When the sale does not have cascading end times and the end date has passed, mark closed
   if (!cascading_end_time_interval_minutes && thisMoment.isAfter(saleEndMoment))
     return `Closed ${saleEndMoment.format(
       "MMM D, YYYY"
     )} • ${saleEndMoment.format("h:mma z")}`
+
+  // When the sale has popcorn bidding and the end date has passed, mark closed
+  if (!extendedBiddingEndAt && thisMoment.isAfter(extendedBiddingEndAtMoment))
+    return `Closed ${extendedBiddingEndAtMoment.format(
+      "MMM D, YYYY"
+    )} • ${extendedBiddingEndAtMoment.format("h:mma z")}`
 
   if (thisMoment.isBefore(saleStartMoment))
     return `${saleStartMoment.format("MMM D, YYYY")} • ${saleStartMoment.format(

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -262,15 +262,24 @@ export function summaryFormattedStartDateTime(
   return dateRange(startAt, endAt, tz, "long")
 }
 
-export function formattedStartDateTime(
-  startAt,
-  endAt,
-  endedAt,
-  extendedBiddingEndAt,
-  liveStartAt,
-  timezone,
-  cascading_end_time_interval_minutes
-) {
+export function formattedStartDateTime(params: {
+  startAt
+  endAt
+  endedAt
+  extendedBiddingEndAt?
+  liveStartAt?
+  timezone
+  cascading_end_time_interval_minutes?
+}) {
+  const {
+    startAt,
+    endAt,
+    endedAt,
+    extendedBiddingEndAt,
+    liveStartAt,
+    timezone,
+    cascading_end_time_interval_minutes,
+  } = params
   const tz = timezone || DEFAULT_TZ
   const thisMoment = moment.tz(moment(), tz)
   const saleStartMoment = moment.tz(startAt, tz)

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -328,3 +328,43 @@ export function formattedEndDateTime(endAt, timezone) {
     "h:mma z"
   )}`
 }
+
+export function auctionsDetailFormattedStartDateTime(
+  startAt,
+  endAt,
+  endedAt,
+  liveStartAt,
+  timezone
+) {
+  const tz = timezone || DEFAULT_TZ
+  const thisMoment = moment.tz(moment(), tz)
+  const saleStartMoment = moment.tz(startAt, tz)
+  const lotsClosingMoment = moment.tz(endAt, tz)
+  const saleEndMoment = moment.tz(endedAt, tz)
+  const liveStartMoment = moment.tz(liveStartAt, tz)
+
+  if (!!endedAt)
+    return `Closed ${saleEndMoment.format(
+      "MMM D, YYYY"
+    )} • ${saleEndMoment.format("h:mma z")}`
+
+  if (thisMoment.isBefore(saleStartMoment))
+    return `${saleStartMoment.format("MMM D, YYYY")} • ${saleStartMoment.format(
+      "h:mma z"
+    )}`
+  if (liveStartAt) {
+    if (thisMoment.isBefore(liveStartMoment)) {
+      return `Live ${liveStartMoment.format(
+        "MMM D, YYYY"
+      )} • ${liveStartMoment.format("h:mma z")}`
+    } else if (
+      thisMoment.isAfter(liveStartMoment) &&
+      (thisMoment.isBefore(lotsClosingMoment) || !endAt)
+    ) {
+      return `In progress`
+    }
+  }
+  return `${lotsClosingMoment.format(
+    "MMM D, YYYY"
+  )} • ${lotsClosingMoment.format("h:mma z")}`
+}

--- a/src/schema/v1/sale/index.ts
+++ b/src/schema/v1/sale/index.ts
@@ -219,9 +219,11 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
         ) =>
           formattedStartDateTime(
             start_at,
-            ended_at || end_at,
+            end_at,
+            ended_at,
             live_start_at,
-            defaultTimezone || DEFAULT_TZ
+            defaultTimezone || DEFAULT_TZ,
+            null
           ),
       },
       href: { type: GraphQLString, resolve: ({ id }) => `/auction/${id}` },

--- a/src/schema/v1/sale/index.ts
+++ b/src/schema/v1/sale/index.ts
@@ -217,15 +217,13 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
           _options,
           { defaultTimezone }
         ) =>
-          formattedStartDateTime(
-            start_at,
-            end_at,
-            ended_at,
-            null,
-            live_start_at,
-            defaultTimezone || DEFAULT_TZ,
-            null
-          ),
+          formattedStartDateTime({
+            startAt: start_at,
+            endAt: end_at,
+            endedAt: ended_at,
+            liveStartAt: live_start_at,
+            timezone: defaultTimezone || DEFAULT_TZ,
+          }),
       },
       href: { type: GraphQLString, resolve: ({ id }) => `/auction/${id}` },
       name: { type: GraphQLString },

--- a/src/schema/v1/sale/index.ts
+++ b/src/schema/v1/sale/index.ts
@@ -221,6 +221,7 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
             start_at,
             end_at,
             ended_at,
+            null,
             live_start_at,
             defaultTimezone || DEFAULT_TZ,
             null

--- a/src/schema/v2/__tests__/sale_artwork.test.js
+++ b/src/schema/v2/__tests__/sale_artwork.test.js
@@ -666,6 +666,7 @@ describe("SaleArtwork type", () => {
     it("returns sale end time when the sale has started and the lot's close time is in the future", async () => {
       saleArtwork.ended_at = null
       saleArtwork.end_at = "2029-02-17T11:00:00+00:00"
+      saleArtwork.extended_bidding_end_at = null
 
       expect(await execute(query, saleArtwork, context)).toEqual({
         node: {
@@ -674,7 +675,7 @@ describe("SaleArtwork type", () => {
       })
     })
 
-    it("returns 'Closed date/time' when the sale has started and the lot's end_at time has passed", async () => {
+    it("returns Closed sale end time when the sale has started and the lot's close time has passed", async () => {
       saleArtwork.ended_at = null
       saleArtwork.end_at = "2020-02-17T11:00:00+00:00"
 
@@ -685,14 +686,14 @@ describe("SaleArtwork type", () => {
       })
     })
 
-    it("returns 'Ends date/time' when the sale has started, end_at has passed but bidding was extended", async () => {
+    it("returns 'Closes date/time' when the sale has started, end_at has passed but bidding was extended", async () => {
       saleArtwork.ended_at = null
       saleArtwork.end_at = "2029-02-17T11:00:00+00:00"
       saleArtwork.extended_bidding_end_at = "2029-02-17T12:00:00+00:00"
 
       expect(await execute(query, saleArtwork, context)).toEqual({
         node: {
-          formattedStartDateTime: "Closed Feb 17, 2029 at 12:00pm UTC",
+          formattedStartDateTime: "Feb 17, 2029 • 12:00pm UTC",
         },
       })
     })

--- a/src/schema/v2/__tests__/sale_artwork.test.js
+++ b/src/schema/v2/__tests__/sale_artwork.test.js
@@ -644,7 +644,7 @@ describe("SaleArtwork type", () => {
       },
     }
 
-    it("returns 'Starts date/time' when the sale's start time is in the future", async () => {
+    it("returns sale start time when the sale's start time is in the future", async () => {
       const context = {
         saleLoader: () => {
           return Promise.resolve({
@@ -658,29 +658,29 @@ describe("SaleArtwork type", () => {
 
       expect(await execute(query, saleArtwork, context)).toEqual({
         node: {
-          formattedStartDateTime: "Starts Feb 17, 2029 at 11:00am UTC",
+          formattedStartDateTime: "Feb 17, 2029 • 11:00am UTC",
         },
       })
     })
 
-    it("returns 'Ends date/time' when the sale has started and the lot's close time is in the future", async () => {
+    it("returns sale end time when the sale has started and the lot's close time is in the future", async () => {
       saleArtwork.ended_at = null
       saleArtwork.end_at = "2029-02-17T11:00:00+00:00"
 
       expect(await execute(query, saleArtwork, context)).toEqual({
         node: {
-          formattedStartDateTime: "Ends Feb 17, 2029 at 11:00am UTC",
+          formattedStartDateTime: "Feb 17, 2029 • 11:00am UTC",
         },
       })
     })
 
-    it("returns 'Ended date/time' when the sale has started and the lot's end_at time has passed", async () => {
+    it("returns 'Closed date/time' when the sale has started and the lot's end_at time has passed", async () => {
       saleArtwork.ended_at = null
       saleArtwork.end_at = "2020-02-17T11:00:00+00:00"
 
       expect(await execute(query, saleArtwork, context)).toEqual({
         node: {
-          formattedStartDateTime: "Ended Feb 17, 2020",
+          formattedStartDateTime: "Closed Feb 17, 2020 • 11:00am UTC",
         },
       })
     })
@@ -692,18 +692,18 @@ describe("SaleArtwork type", () => {
 
       expect(await execute(query, saleArtwork, context)).toEqual({
         node: {
-          formattedStartDateTime: "Ends Feb 17, 2029 at 12:00pm UTC",
+          formattedStartDateTime: "Closed Feb 17, 2029 at 12:00pm UTC",
         },
       })
     })
 
-    it("returns 'Ended date/time' when the sale has started and the lot's ended_at time has passed", async () => {
+    it("returns 'Closed date/time' when the sale has started and the lot's ended_at time has passed", async () => {
       saleArtwork.ended_at = "2019-02-17T11:00:00+00:00"
       saleArtwork.end_at = "2020-02-17T11:00:00+00:00"
 
       expect(await execute(query, saleArtwork, context)).toEqual({
         node: {
-          formattedStartDateTime: "Ended Feb 17, 2019",
+          formattedStartDateTime: "Closed Feb 17, 2019 • 11:00am UTC",
         },
       })
     })

--- a/src/schema/v2/sale/__tests__/index.test.ts
+++ b/src/schema/v2/sale/__tests__/index.test.ts
@@ -863,6 +863,22 @@ describe("Sale type", () => {
       expect(response.sale.formattedStartDateTime).toEqual("March 7 – 12, 2022")
     })
 
+    it("returns date range when range is passed in as argument", async () => {
+      const query = `
+      {
+        sale(id: "foo-foo") {
+          formattedStartDateTime(format: DateRange)
+        }
+      }
+    `
+      const response = await execute(query, {
+        start_at: "2022-03-07 09+07:00",
+        end_at: "2022-03-12 09+07:00",
+        cascading_end_time_interval_minutes: null,
+      })
+      expect(response.sale.formattedStartDateTime).toEqual("March 7 – 12, 2022")
+    })
+
     it("returns the words closing soon when cascading interval is true while the sale is closing soon", async () => {
       const response = await execute(query, {
         start_at: moment().subtract(2, "hours"),
@@ -891,65 +907,61 @@ describe("Sale type", () => {
       expect(response.sale.formattedStartDateTime).toEqual("Ended Mar 8")
       expect(response.sale.cascadingEndTimeIntervalMinutes).toEqual(null)
     })
-  })
 
-  describe("cascadingEndTimeFormattedStartDateTime", () => {
-    beforeEach(() => {
-      Date.now = jest.fn(() => new Date("2022-03-08T12:33:37.000Z"))
-    })
-    const query = `
-      {
-        sale(id: "foo-foo") {
-          cascadingEndTime {
-            formattedStartDateTime
+    describe("when the argument is datetime", () => {
+      beforeEach(() => {
+        Date.now = jest.fn(() => new Date("2022-03-08T12:33:37.000Z"))
+      })
+      const query = `
+        {
+          sale(id: "foo-foo") {
+            formattedStartDateTime(format: DateTime)
           }
         }
-      }
-    `
+      `
 
-    it("returns a string including the correctly formatted start time when we the auction has not started", async () => {
-      const response = await execute(query, {
-        start_at: moment().add(3, "days"),
+      it("returns a string including the correctly formatted start time when we the auction has not started", async () => {
+        const response = await execute(query, {
+          start_at: moment().add(3, "days"),
+        })
+        expect(response.sale.formattedStartDateTime).toEqual(
+          "Mar 11, 2022 • 12:33pm UTC"
+        )
       })
-      expect(response.sale.cascadingEndTime.formattedStartDateTime).toEqual(
-        "Mar 11, 2022 • 12:33pm UTC"
-      )
-    })
 
-    it("returns a string including the correctly formatted end time after the auction has ended", async () => {
-      const response = await execute(query, {
-        ended_at: moment().subtract(1, "days"),
+      it("returns a string including the correctly formatted end time after the auction has ended", async () => {
+        const response = await execute(query, {
+          ended_at: moment().subtract(1, "days"),
+        })
+        expect(response.sale.formattedStartDateTime).toEqual(
+          "Closed Mar 7, 2022 • 12:33pm UTC"
+        )
       })
-      expect(response.sale.cascadingEndTime.formattedStartDateTime).toEqual(
-        "Closed Mar 7, 2022 • 12:33pm UTC"
-      )
-    })
 
-    it("returns a string including the correctly formatted end when the auction has started", async () => {
-      const response = await execute(query, {
-        end_at: moment().subtract(1, "days"),
+      it("returns a string including the correctly formatted end when the auction has started", async () => {
+        const response = await execute(query, {
+          end_at: moment().subtract(1, "days"),
+        })
+        expect(response.sale.formattedStartDateTime).toEqual(
+          "Mar 7, 2022 • 12:33pm UTC"
+        )
       })
-      expect(response.sale.cascadingEndTime.formattedStartDateTime).toEqual(
-        "Mar 7, 2022 • 12:33pm UTC"
-      )
-    })
 
-    it("returns a string including the correctly formatted date when the live start at has yet to start and is a LAI", async () => {
-      const response = await execute(query, {
-        live_start_at: moment().add(1, "days"),
+      it("returns a string including the correctly formatted date when the live start at has yet to start and is a LAI", async () => {
+        const response = await execute(query, {
+          live_start_at: moment().add(1, "days"),
+        })
+        expect(response.sale.formattedStartDateTime).toEqual(
+          "Live Mar 9, 2022 • 12:33pm UTC"
+        )
       })
-      expect(response.sale.cascadingEndTime.formattedStartDateTime).toEqual(
-        "Live Mar 9, 2022 • 12:33pm UTC"
-      )
-    })
 
-    it("returns a in progress when the auction has started and is a LAI", async () => {
-      const response = await execute(query, {
-        live_start_at: moment().subtract(1, "days"),
+      it("returns a in progress when the auction has started and is a LAI", async () => {
+        const response = await execute(query, {
+          live_start_at: moment().subtract(1, "days"),
+        })
+        expect(response.sale.formattedStartDateTime).toEqual("In progress")
       })
-      expect(response.sale.cascadingEndTime.formattedStartDateTime).toEqual(
-        "In progress"
-      )
     })
   })
 

--- a/src/schema/v2/sale/__tests__/index.test.ts
+++ b/src/schema/v2/sale/__tests__/index.test.ts
@@ -791,22 +791,26 @@ describe("Sale type", () => {
       )
     })
 
-    it("returns End time when end_at is in the past (2)", async () => {
+    it("returns Closed time when end_at is in the past (2)", async () => {
       const response = await execute(query, {
         start_at: moment().subtract(2, "hours"),
         end_at: null,
         ended_at: moment().subtract(1, "hours"),
       })
-      expect(response.sale.formattedStartDateTime).toContain("Closed")
+      expect(response.sale.formattedStartDateTime).toEqual(
+        "Closed Mar 8, 2022 • 11:33am UTC"
+      )
     })
 
-    it("returns End time when ended_at is in the past but end_at is in the future", async () => {
+    it("returns Closed time when ended_at is in the past but end_at is in the future", async () => {
       const response = await execute(query, {
         start_at: moment().subtract(2, "hours"),
         end_at: moment().add(1, "hours"),
         ended_at: moment().subtract(1, "hours"),
       })
-      expect(response.sale.formattedStartDateTime).toContain("Closed")
+      expect(response.sale.formattedStartDateTime).toEqual(
+        "Closed Mar 8, 2022 • 11:33am UTC"
+      )
     })
 
     it("returns Live start time if live_start_at is in the future", async () => {
@@ -814,7 +818,9 @@ describe("Sale type", () => {
         start_at: moment().subtract(2, "hours"),
         live_start_at: moment().add(2, "hours"),
       })
-      expect(response.sale.formattedStartDateTime).toContain("Live")
+      expect(response.sale.formattedStartDateTime).toEqual(
+        "Live Mar 8, 2022 • 2:33pm UTC"
+      )
     })
 
     it("returns In Progress when its live and end_at is in the future", async () => {
@@ -824,7 +830,7 @@ describe("Sale type", () => {
         end_at: moment().add(2, "hours"),
         ended_at: null,
       })
-      expect(response.sale.formattedStartDateTime).toContain("In progress")
+      expect(response.sale.formattedStartDateTime).toEqual("In progress")
     })
 
     it("returns In Progress when its live and ended_at is in the future", async () => {
@@ -834,7 +840,7 @@ describe("Sale type", () => {
         ended_at: moment().add(2, "hours"),
         end_at: null,
       })
-      expect(response.sale.formattedStartDateTime).toContain("In progress")
+      expect(response.sale.formattedStartDateTime).toEqual("In progress")
     })
 
     it("returns End time", async () => {

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -249,15 +249,13 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
               defaultTimezone
             )
           } else {
-            return formattedStartDateTime(
-              start_at,
-              end_at,
-              ended_at,
-              null,
-              live_start_at,
-              defaultTimezone,
-              null
-            )
+            return formattedStartDateTime({
+              startAt: start_at,
+              endAt: end_at,
+              endedAt: ended_at,
+              liveStartAt: live_start_at,
+              timezone: defaultTimezone,
+            })
           }
         },
       },

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -11,7 +11,7 @@ import moment from "moment"
 import { SlugAndInternalIDFields } from "schema/v2/object_identification"
 import {
   formattedStartDateTime,
-  cascadingFormattedStartDateTime,
+  summaryFormattedStartDateTime,
   DEFAULT_TZ,
   auctionsDetailFormattedStartDateTime,
 } from "lib/date"
@@ -242,7 +242,7 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
         ) => {
           const { summary } = args
           if (summary || cascading_end_time_interval_minutes) {
-            return cascadingFormattedStartDateTime(
+            return summaryFormattedStartDateTime(
               start_at,
               end_at,
               ended_at,
@@ -253,9 +253,10 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
               start_at,
               end_at,
               ended_at,
+              null,
               live_start_at,
               defaultTimezone,
-              cascading_end_time_interval_minutes
+              null
             )
           }
         },

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -13,6 +13,7 @@ import {
   formattedStartDateTime,
   cascadingFormattedStartDateTime,
   DEFAULT_TZ,
+  auctionsDetailFormattedStartDateTime,
 } from "lib/date"
 import { pageable, getPagingParameters } from "relay-cursor-paging"
 import {

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -259,7 +259,7 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
           { defaultTimezone }
         ) => {
           const { format } = args
-          if (format === "range" || cascading_end_time_interval_minutes) {
+          if (format === "daterange" || cascading_end_time_interval_minutes) {
             return cascadingFormattedStartDateTime(
               start_at,
               end_at,
@@ -267,7 +267,7 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
               defaultTimezone
             )
           } else if (format === "datetime") {
-            auctionsDetailFormattedStartDateTime(
+            return auctionsDetailFormattedStartDateTime(
               start_at,
               end_at,
               ended_at,

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -37,7 +37,6 @@ import {
   GraphQLFloat,
   GraphQLFieldConfig,
   GraphQLID,
-  GraphQLEnumType,
 } from "graphql"
 
 import config from "config"

--- a/src/schema/v2/sale_artwork.ts
+++ b/src/schema/v2/sale_artwork.ts
@@ -158,6 +158,8 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
             if (!sale.cascading_end_time_interval_minutes) {
               return null
             } else {
+              // Do not pass cascading_end_time_interval_minutes in for the last argument here
+              // because the method is already using the sale artwork's end time instead of the sale's
               return formattedStartDateTime(
                 sale.start_at,
                 saleArtwork.end_at,

--- a/src/schema/v2/sale_artwork.ts
+++ b/src/schema/v2/sale_artwork.ts
@@ -158,8 +158,6 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
             if (!sale.cascading_end_time_interval_minutes) {
               return null
             } else {
-              // Do not pass cascading_end_time_interval_minutes in for the last argument here
-              // because the method is already using the sale artwork's end time instead of the sale's
               return formattedStartDateTime({
                 startAt: sale.start_at,
                 endAt: saleArtwork.end_at,

--- a/src/schema/v2/sale_artwork.ts
+++ b/src/schema/v2/sale_artwork.ts
@@ -160,11 +160,12 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
             } else {
               return formattedStartDateTime(
                 sale.start_at,
-                saleArtwork.ended_at ||
-                  saleArtwork.extended_bidding_end_at ||
-                  saleArtwork.end_at,
+                saleArtwork.end_at,
+                saleArtwork.ended_at,
+                saleArtwork.extended_bidding_end_at,
                 null,
-                defaultTimezone
+                defaultTimezone,
+                null
               )
             }
           }),

--- a/src/schema/v2/sale_artwork.ts
+++ b/src/schema/v2/sale_artwork.ts
@@ -160,15 +160,13 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
             } else {
               // Do not pass cascading_end_time_interval_minutes in for the last argument here
               // because the method is already using the sale artwork's end time instead of the sale's
-              return formattedStartDateTime(
-                sale.start_at,
-                saleArtwork.end_at,
-                saleArtwork.ended_at,
-                saleArtwork.extended_bidding_end_at,
-                null,
-                defaultTimezone,
-                null
-              )
+              return formattedStartDateTime({
+                startAt: sale.start_at,
+                endAt: saleArtwork.end_at,
+                endedAt: saleArtwork.ended_at,
+                extendedBiddingEndAt: saleArtwork.extended_bidding_end_at,
+                timezone: defaultTimezone,
+              })
             }
           }),
       },


### PR DESCRIPTION
This PR generalizes the `formattedStartDateTime` on sale and deprecates the `cascadingEndTime` fields on `sale` in order to make these fields more generic and less tied to a specific feature.

Noting that the "format" arg is a bit misleading as the three different cases: `DateRange`, `DateTime`, and `Date` are only returned when sales are open. For example, if a sale is already closed, not cascading end time, and the "DateRange" arg is provided, the return value is `Closed Oct 12, 2021`. If the sale is open, it will return a range. Would love thoughts on how to make this more clear?

I'm considering just a comment for now as this work was relatively lightweight and does accomplish the goal of using one consolidated field for this type of information.

non-cascading sale:
query {
	sale(id: "shared-online-only-mocktion") {
		name
		cascadingEndTimeIntervalMinutes
		cascadingEndTime {
			formattedStartDateTime
		}
		formattedStartDateTime(summary: true)
	}
}
```
<img width="426" alt="Screen Shot 2022-05-06 at 11 12 41 AM" src="https://user-images.githubusercontent.com/9466631/167161637-a869e335-d98e-4217-a003-6299a1486355.png">


non-cascading sale: 
```gql
query {
	sale(id: "shared-online-only-mocktion") {
		name
		cascadingEndTimeIntervalMinutes
		cascadingEndTime {
			formattedStartDateTime
		}
		formattedStartDateTime
	}
```
<img width="433" alt="Screen Shot 2022-05-06 at 11 13 06 AM" src="https://user-images.githubusercontent.com/9466631/167161717-c67c470b-4fa3-488a-9b76-f6f2fd346ec3.png">

cascading sale:
```gql
query {
	sale(id: "fri-mocktion-3") {
		name
		cascadingEndTimeIntervalMinutes
		cascadingEndTime {
			formattedStartDateTime
		}
		formattedStartDateTime
	}
}
```
<img width="442" alt="Screen Shot 2022-05-06 at 11 37 15 AM" src="https://user-images.githubusercontent.com/9466631/167165760-3e8bddfa-335b-46d0-8c2e-3a390c7767f5.png">


Screenshots:
Cascade sale, not yet open 
<img width="364" alt="Screen Shot 2022-04-21 at 11 51 17 AM" src="https://user-images.githubusercontent.com/9466631/164500673-bd3fb4d0-af5c-4419-ae64-3b9ddec6be1f.png">

Non-cascade sale, not yet open:
<img width="676" alt="Screen Shot 2022-04-21 at 11 51 34 AM" src="https://user-images.githubusercontent.com/9466631/164500869-172fea10-2c63-428b-9531-230544f0836d.png">

Live sale, not yet open:
<img width="405" alt="Screen Shot 2022-04-21 at 11 53 07 AM" src="https://user-images.githubusercontent.com/9466631/164501078-725f6024-4721-4ec7-b616-412b314db164.png">

Cascade sale, current:
<img width="602" alt="Screen Shot 2022-04-21 at 11 52 35 AM" src="https://user-images.githubusercontent.com/9466631/164500959-d912b93f-0cab-436b-8641-7a0ca47e3991.png">

noncascade sale, current:
<img width="456" alt="Screen Shot 2022-04-21 at 11 54 18 AM" src="https://user-images.githubusercontent.com/9466631/164501288-ca44154f-f0c3-4e29-a902-9c3773441da6.png">

Live sale, current:
<img width="444" alt="Screen Shot 2022-04-21 at 11 52 48 AM" src="https://user-images.githubusercontent.com/9466631/164500994-7a8e7625-306a-4a07-8af8-29d97ecf8358.png">

Cascade sale, closed:
<img width="511" alt="Screen Shot 2022-04-21 at 11 45 38 AM" src="https://user-images.githubusercontent.com/9466631/164499571-18a7976b-76cb-4269-874d-8ddead90f99d.png">

Non-cascade sale, closed
<img width="588" alt="Screen Shot 2022-04-21 at 11 48 27 AM" src="https://user-images.githubusercontent.com/9466631/164500125-23c52ba3-5e97-4314-8cdf-3ed8ffca8c18.png">

Live sale, closed
<img width="443" alt="Screen Shot 2022-04-21 at 11 49 20 AM" src="https://user-images.githubusercontent.com/9466631/164500295-92f9cbd3-4c08-4ad9-90aa-80ad437c16dd.png">

