### PR TITLE
[GRO-861] add include_fallback_artists param to related artists schema

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1511,6 +1511,9 @@ type ArtistRelatedData {
     # Exclude artists the user already follows
     excludeFollowedArtists: Boolean
     first: Int
+
+    # Include featured artists if no results are found
+    includeFallbackArtists: Boolean
     last: Int
   ): ArtistConnection
 }

--- a/src/schema/v2/artist/related.ts
+++ b/src/schema/v2/artist/related.ts
@@ -123,6 +123,10 @@ export const Related = {
             description:
               "Exclude these ids from results, may result in all artists being excluded.",
           },
+          includeFallbackArtists: {
+            type: GraphQLBoolean,
+            description: "Include featured artists if no results are found",
+          },
         }),
         description:
           "A list of the current user’s suggested artists, based on a single artist",
@@ -133,6 +137,7 @@ export const Related = {
             excludeArtistsWithoutArtworks,
             excludeFollowedArtists,
             excludeArtistIDs,
+            includeFallbackArtists,
             ..._args
           },
           { suggestedArtistsLoader }
@@ -144,6 +149,7 @@ export const Related = {
             exclude_artists_without_artworks: excludeArtistsWithoutArtworks,
             exclude_followed_artists: excludeFollowedArtists,
             exclude_artist_ids: excludeArtistIDs,
+            include_fallback_artists: includeFallbackArtists,
             ..._args,
           } as any
 


### PR DESCRIPTION
This PR solves [GRO-861] to backfill featured artists if no artists are followed by user

[GRO-861]: https://artsyproduct.atlassian.net/browse/GRO-861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ