### PR TITLE
feat: Boost licensed sales on the home screen GRO-904

### DIFF
--- a/src/schema/v2/home/home_page_sales_module.ts
+++ b/src/schema/v2/home/home_page_sales_module.ts
@@ -16,7 +16,7 @@ export const HomePageSalesModuleType = new GraphQLObjectType<
           live: true,
           is_auction: true,
           size: 10,
-          sort: "timely_at,name",
+          sort: "-is_artsy_licensed,timely_at,name",
         }
         return salesLoader(gravityOptions)
       },


### PR DESCRIPTION
A small PR to update the sort on the sales that are shown on the home screen. This aligns what a user sees in the app with what they see on the auctions landing page per this one: https://github.com/artsy/force/pull/9557.

https://artsyproduct.atlassian.net/browse/GRO-904

/cc @artsy/grow-devs