### PR TITLE
feat: Introduce myCollectionAuctionResults

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9537,7 +9537,7 @@ type Me implements Node {
   ): [LotStanding]
   myBids: MyBids
 
-  # A list of the auction results by followed artists
+  # A list of auction results from artists in My Collection
   myCollectionAuctionResults(
     after: String
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9536,6 +9536,36 @@ type Me implements Node {
     saleID: String
   ): [LotStanding]
   myBids: MyBids
+
+  # A list of the auction results by followed artists
+  myCollectionAuctionResults(
+    after: String
+
+    # Filter auction results by empty artwork created date values
+    allowEmptyCreatedDates: Boolean = true
+    before: String
+
+    # Filter auction results by category (medium)
+    categories: [String]
+
+    # Filter auction results by earliest created at year
+    earliestCreatedYear: Int
+    first: Int
+    last: Int
+
+    # Filter auction results by latest created at year
+    latestCreatedYear: Int
+
+    # Filter auction results by organizations
+    organizations: [String]
+
+    # When true, will only return records for allowed artists.
+    recordsTrusted: Boolean = false
+
+    # Filter auction results by Artwork sizes
+    sizes: [ArtworkSizes]
+    sort: AuctionResultSorts
+  ): AuctionResultConnection
   myCollectionConnection(
     after: String
     before: String

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -47,6 +47,11 @@ export default (accessToken, userID, opts) => {
       { user_id: userID },
       { headers: true }
     ),
+    collectionArtistsLoader: gravityLoader(
+      (id) => `collection/${id}/artists`,
+      { user_id: userID },
+      { headers: true }
+    ),
     collectionLoader: gravityLoader((id) => `collection/${id}`, {
       user_id: userID,
     }),

--- a/src/schema/v2/me/__tests__/myCollectionAuctionResults.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionAuctionResults.test.ts
@@ -1,0 +1,99 @@
+/* eslint-disable promise/always-return */
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("Me", () => {
+  describe("myCollectionAuctionResults", () => {
+    it("returns auction results My Collection artists", async () => {
+      const query = gql`
+        {
+          me {
+            myCollectionAuctionResults(first: 100) {
+              totalCount
+              edges {
+                node {
+                  title
+                  artist {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const expectedConnectionData = {
+        totalCount: 2,
+        edges: [
+          {
+            node: {
+              title: "Auction Result 1",
+              artist: {
+                name: "Artist 1",
+              },
+            },
+          },
+          {
+            node: {
+              title: "Auction Result 2",
+              artist: {
+                name: "Artist 2",
+              },
+            },
+          },
+        ],
+      }
+
+      const auctionLotsLoader = jest.fn(async () => ({
+        total_count: 2,
+        _embedded: {
+          items: [
+            {
+              title: "Auction Result 1",
+              artist_id: "artist-1",
+            },
+            {
+              title: "Auction Result 2",
+              artist_id: "artist-2",
+            },
+            {
+              title: "Auction Result Without Artist ID",
+            },
+          ],
+        },
+      }))
+
+      const collectionArtistsLoader = jest.fn(async () => ({
+        headers: { "x-total-count": 2 },
+        body: [
+          {
+            id: "followartist-1",
+            _id: "artist-1",
+            name: "Artist 1",
+          },
+          {
+            id: "followartist-2",
+            _id: "artist-2",
+            name: "Artist 2",
+          },
+        ],
+      }))
+
+      const context = {
+        meLoader: () => Promise.resolve({}),
+        collectionArtistsLoader,
+        auctionLotsLoader,
+      }
+
+      const {
+        me: { myCollectionAuctionResults },
+      } = await runAuthenticatedQuery(query, context)
+
+      expect(myCollectionAuctionResults).toEqual(expectedConnectionData)
+
+      expect(collectionArtistsLoader).toHaveBeenCalled()
+      expect(auctionLotsLoader).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/schema/v2/me/__tests__/myCollectionAuctionResults.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionAuctionResults.test.ts
@@ -68,12 +68,12 @@ describe("Me", () => {
         headers: { "x-total-count": 2 },
         body: [
           {
-            id: "followartist-1",
+            id: "an-artist-1",
             _id: "artist-1",
             name: "Artist 1",
           },
           {
-            id: "followartist-2",
+            id: "an-artist-2",
             _id: "artist-2",
             name: "Artist 2",
           },

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -47,6 +47,7 @@ import LotStanding from "./lot_standing"
 import LotStandings from "./lot_standings"
 import { MyBids } from "./myBids"
 import { MyCollection, MyCollectionInfo } from "./myCollection"
+import MyCollectionAuctionResults from "./myCollectionAuctionResults"
 import { myLocationType } from "./myLocation"
 import { NewWorksByInterestingArtists } from "./newWorksByInterestingArtists"
 import { ManagedPartners } from "./partners"
@@ -248,6 +249,7 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
     partners: ManagedPartners,
     myCollectionConnection: MyCollection,
     myCollectionInfo: MyCollectionInfo,
+    myCollectionAuctionResults: MyCollectionAuctionResults,
     myBids: MyBids,
     name: {
       type: GraphQLString,

--- a/src/schema/v2/me/myCollectionAuctionResults.ts
+++ b/src/schema/v2/me/myCollectionAuctionResults.ts
@@ -114,18 +114,8 @@ const MyCollectionAuctionResults: GraphQLFieldConfig<any, ResolverContext> = {
       )
 
       return merge(
-        {
-          pageCursors: createPageCursors(
-            {
-              page,
-              size,
-            },
-            total_count
-          ),
-        },
-        {
-          totalCount: total_count,
-        },
+        { pageCursors: createPageCursors({ page, size }, total_count) },
+        { totalCount: total_count },
         connectionFromArraySlice(enrichedAuctionResults, options, {
           arrayLength: total_count,
           sliceStart: offset,

--- a/src/schema/v2/me/myCollectionAuctionResults.ts
+++ b/src/schema/v2/me/myCollectionAuctionResults.ts
@@ -1,0 +1,150 @@
+import {
+  GraphQLBoolean,
+  GraphQLFieldConfig,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLString,
+} from "graphql"
+import { connectionFromArraySlice } from "graphql-relay"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { merge } from "lodash"
+import { pageable } from "relay-cursor-paging"
+import { createPageCursors } from "schema/v2/fields/pagination"
+import { ResolverContext } from "types/graphql"
+import ArtworkSizes from "../artwork/artworkSizes"
+import { auctionResultConnection, AuctionResultSorts } from "../auction_result"
+
+const MyCollectionAuctionResults: GraphQLFieldConfig<any, ResolverContext> = {
+  type: auctionResultConnection.connectionType,
+  args: pageable({
+    sort: AuctionResultSorts,
+    organizations: {
+      type: new GraphQLList(GraphQLString),
+      description: "Filter auction results by organizations",
+    },
+    sizes: {
+      type: new GraphQLList(ArtworkSizes),
+      description: "Filter auction results by Artwork sizes",
+    },
+    categories: {
+      type: new GraphQLList(GraphQLString),
+      description: "Filter auction results by category (medium)",
+    },
+    recordsTrusted: {
+      type: GraphQLBoolean,
+      defaultValue: false,
+      description: "When true, will only return records for allowed artists.",
+    },
+    earliestCreatedYear: {
+      type: GraphQLInt,
+      description: "Filter auction results by earliest created at year",
+    },
+    latestCreatedYear: {
+      type: GraphQLInt,
+      description: "Filter auction results by latest created at year",
+    },
+    allowEmptyCreatedDates: {
+      type: GraphQLBoolean,
+      defaultValue: true,
+      description:
+        "Filter auction results by empty artwork created date values",
+    },
+  }),
+  description: "A list of the auction results by followed artists",
+  resolve: async (
+    { id: userId },
+    options,
+    { collectionArtistsLoader, auctionLotsLoader }
+  ) => {
+    try {
+      if (!collectionArtistsLoader || !auctionLotsLoader) return null
+
+      const { body: artists } = await collectionArtistsLoader("my-collection", {
+        user_id: userId,
+      })
+
+      const artistIds = artists.map(({ id }) => id)
+
+      if (!artistIds || artistIds.length === 0) {
+        return null
+      }
+
+      const {
+        page,
+        size,
+        offset,
+        sizes,
+        organizations,
+        categories,
+      } = convertConnectionArgsToGravityArgs(options)
+
+      const diffusionArgs = {
+        page,
+        size,
+        artist_ids: artistIds,
+        organizations,
+        categories,
+        earliest_created_year: options.earliestCreatedYear,
+        latest_created_year: options.latestCreatedYear,
+        allow_empty_created_dates: options.allowEmptyCreatedDates,
+        sizes,
+        sort: options.sort,
+      }
+
+      return auctionLotsLoader(diffusionArgs).then(
+        ({ total_count, _embedded }) => {
+          const totalPages = Math.ceil(total_count / size)
+
+          // filter items without artist id
+          const filteredAuctionResults = _embedded.items.filter(
+            (auctionResult) => auctionResult.artist_id
+          )
+
+          // enrich result with artist data
+          const enrichedAuctionResults = filteredAuctionResults.map(
+            (auctionResult) => {
+              const artist = artistIds.find(
+                (id) => id == auctionResult.artist_id
+              )
+              auctionResult.artist = artist?.artist
+              return auctionResult
+            }
+          )
+
+          return merge(
+            {
+              pageCursors: createPageCursors(
+                {
+                  page,
+                  size,
+                },
+                total_count
+              ),
+            },
+            {
+              totalCount: total_count,
+            },
+            connectionFromArraySlice(enrichedAuctionResults, options, {
+              arrayLength: total_count,
+              sliceStart: offset,
+            }),
+            {
+              pageInfo: {
+                hasPreviousPage: page > 1,
+                hasNextPage: page < totalPages,
+              },
+            },
+            {
+              artist_ids: artistIds,
+            }
+          )
+        }
+      )
+    } catch (error) {
+      console.error(error)
+      throw new Error(error)
+    }
+  },
+}
+
+export default MyCollectionAuctionResults

--- a/src/schema/v2/me/myCollectionAuctionResults.ts
+++ b/src/schema/v2/me/myCollectionAuctionResults.ts
@@ -16,6 +16,7 @@ import { auctionResultConnection, AuctionResultSorts } from "../auction_result"
 
 const MyCollectionAuctionResults: GraphQLFieldConfig<any, ResolverContext> = {
   type: auctionResultConnection.connectionType,
+  description: "A list of auction results from artists in My Collection",
   args: pageable({
     sort: AuctionResultSorts,
     organizations: {
@@ -50,7 +51,6 @@ const MyCollectionAuctionResults: GraphQLFieldConfig<any, ResolverContext> = {
         "Filter auction results by empty artwork created date values",
     },
   }),
-  description: "A list of the auction results by followed artists",
   resolve: async (
     { id: userId },
     options,
@@ -79,7 +79,7 @@ const MyCollectionAuctionResults: GraphQLFieldConfig<any, ResolverContext> = {
         categories,
       } = convertConnectionArgsToGravityArgs(options)
 
-      const diffusionArgs = {
+      const auctionLotsLoaderArgs = {
         page,
         size,
         artist_ids: artistIds,
@@ -92,7 +92,9 @@ const MyCollectionAuctionResults: GraphQLFieldConfig<any, ResolverContext> = {
         sort: options.sort,
       }
 
-      const { total_count, _embedded } = await auctionLotsLoader(diffusionArgs)
+      const { total_count, _embedded } = await auctionLotsLoader(
+        auctionLotsLoaderArgs
+      )
 
       const totalPages = Math.ceil(total_count / size)
 


### PR DESCRIPTION
Addresses [CX-2512]

## Description

Introduces `myCollectionAuctionResults` endpoint under `me` which returns auction results for artists from a user's "My Collection".

**Query:**


```graphql
{
  me {
    myCollectionAuctionResults(first: 10) {
      edges {
        node {
          id
        }
      }
    }
  }
}

```

[CX-2512]: https://artsyproduct.atlassian.net/browse/CX-2512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ