### PR TITLE
chore: resolve `formatError` warning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -202,12 +202,6 @@ function startApp(appSchema, path: string) {
       validationRules,
       extensions: ({ document, result }) =>
         createExtensions(document, result, requestID),
-      formatError: (error) => ({
-        // better errors formatting for clients
-        // See errorMiddleware in  https://github.com/relay-tools/react-relay-network-modern/blob/master/README.md#built-in-middlewares
-        message: error.message,
-        stack: !PRODUCTION_ENV ? error.stack.split("\n") : null,
-      }),
     }
   })
 

--- a/src/lib/graphqlErrorHandler.ts
+++ b/src/lib/graphqlErrorHandler.ts
@@ -135,7 +135,7 @@ export const formattedGraphQLError = (
   if (includeStackTrace) {
     // TODO: Is the stack still being included in the response or should this
     //       move to extensions?
-    ;(result as any).stack = topLevelError.stack
+    ;(result as any).stack = topLevelError.stack?.split("\n")
   }
 
   const httpStatusCodes: number[] = []


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4120

Thanks @mc-jones for pairing on this.

---

This CL addresses a warning logged on every request in metaphysics which is polluting our logs. Most recently flagged by @mdole [here](https://artsy.slack.com/archives/CA8SANW3W/p1650641537810109).

<img width="1776" alt="Screen Shot 2022-04-29 at 2 58 04 PM" src="https://user-images.githubusercontent.com/29984068/166009072-418e2931-4042-4166-b2b9-567086e3928f.png">

### Changes

- remove the `formatError` configuration option as it does not get used and is removed in [express-graphql v1.0.0](https://github.com/graphql/express-graphql/blob/92088332c3d81174a82a77abfdea8e4b5fc77100/src/index.ts#L113)
  - The [message option](https://github.com/artsy/metaphysics/blob/main/src/index.ts#L208) `formatError` sets is set [here](https://github.com/artsy/metaphysics/blob/ddb359cd7fe45b21058fead58a4389ad93fee641/src/lib/graphqlErrorHandler.ts#L124) in `formattedGraphQLError`
  - The [stack option](https://github.com/artsy/metaphysics/blob/main/src/index.ts#L209) `formatError` sets is set [here](https://github.com/artsy/metaphysics/blob/ddb359cd7fe45b21058fead58a4389ad93fee641/src/lib/graphqlErrorHandler.ts#L138) in `formattedGraphQLError`
- edit the `formattedGraphQLError` function to split the stack adding new lines for better output (adopted from `formatError`).

### Background

The warning was resolved in [this PR](https://github.com/artsy/metaphysics/pull/1979) and reintroduced in [this one](https://github.com/artsy/metaphysics/pull/3470).

### Examples

Testing done in `development` mode. To trigger an error, the following query is used:

```
{
  artist(id: "4d8b92b34eb68a1b2c0003f4") {
    namess
  }
}
```

When _both_ `customFormatErrorFn` and `formatError` are defined in the [graphqlHTTP express-middleware configuration options](https://github.com/artsy/metaphysics/blob/main/src/index.ts#L191), _only one fires_. It seems that the `customFormatErrorFn` is the one that always take precedence. Perhaps because its [decided here](https://github.com/graphql/express-graphql/blob/v0.9.0/src/index.js#L427)?

`customFormatErrorFn` output (both options configured)
> Notice that stack is printed on one line.
<img width="1077" alt="customFormatErrorFn-output" src="https://user-images.githubusercontent.com/29984068/166038767-8f576c5e-2701-4c71-acec-6e5a9a3cda3d.png">
 
console
<img width="642" alt="Screen Shot 2022-04-29 at 2 40 04 PM" src="https://user-images.githubusercontent.com/29984068/166055447-04eb0a30-dfd4-467f-a9a4-d52ec51379a2.png">

---

`formatError` output (with customFormatErrorFn removed)
<img width="1032" alt="formarError-output" src="https://user-images.githubusercontent.com/29984068/166056063-a9119eb8-13d8-4afe-81b2-c38453f6a963.png">

console
<img width="734" alt="Screen Shot 2022-04-29 at 2 38 18 PM" src="https://user-images.githubusercontent.com/29984068/166056924-294ade87-a608-4643-8fdb-32754a055891.png">

---

Error output with changes in place
<img width="1035" alt="customFormatErrorFn-only-stack-split" src="https://user-images.githubusercontent.com/29984068/166062365-c561cb88-dc06-4e80-a960-a75d06fad784.png">

