### PR TITLE
feat: add lot id and modify formattedStartDateTime to take into account extended time

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12766,6 +12766,7 @@ type SaleArtwork implements ArtworkEdgeInterface & Node {
   # it. (Currently only used on me.myBids and me.watchedLotsConnection.)
   isWatching: Boolean
   isWithReserve: Boolean
+  lotID: String
   lotLabel: String
   lotState: CausalityLotState
   lowEstimate: SaleArtworkLowEstimate

--- a/src/schema/v2/__tests__/sale_artwork.test.js
+++ b/src/schema/v2/__tests__/sale_artwork.test.js
@@ -604,6 +604,26 @@ describe("SaleArtwork type", () => {
     })
   })
 
+  it("includes lot id", async () => {
+    saleArtwork.lot_id = "catty-lot-id"
+
+    const query = gql`
+      {
+        node(id: "${toGlobalId("SaleArtwork", "54c7ed2a7261692bfa910200")}") {
+          ... on SaleArtwork {
+            lotID
+          }
+        }
+      }
+    `
+
+    expect(await execute(query, saleArtwork)).toEqual({
+      node: {
+        lotID: "catty-lot-id",
+      },
+    })
+  })
+
   describe("formattedStartDateTime", () => {
     const query = gql`
       {
@@ -661,6 +681,18 @@ describe("SaleArtwork type", () => {
       expect(await execute(query, saleArtwork, context)).toEqual({
         node: {
           formattedStartDateTime: "Ended Feb 17, 2020",
+        },
+      })
+    })
+
+    it("returns 'Ends date/time' when the sale has started, end_at has passed but bidding was extended", async () => {
+      saleArtwork.ended_at = null
+      saleArtwork.end_at = "2029-02-17T11:00:00+00:00"
+      saleArtwork.extended_bidding_end_at = "2029-02-17T12:00:00+00:00"
+
+      expect(await execute(query, saleArtwork, context)).toEqual({
+        node: {
+          formattedStartDateTime: "Ends Feb 17, 2029 at 12:00pm UTC",
         },
       })
     })

--- a/src/schema/v2/sale_artwork.ts
+++ b/src/schema/v2/sale_artwork.ts
@@ -160,7 +160,9 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
             } else {
               return formattedStartDateTime(
                 sale.start_at,
-                saleArtwork.ended_at || saleArtwork.end_at,
+                saleArtwork.ended_at ||
+                  saleArtwork.extended_bidding_end_at ||
+                  saleArtwork.end_at,
                 null,
                 defaultTimezone
               )
@@ -314,6 +316,10 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
       lotLabel: {
         type: GraphQLString,
         resolve: ({ lot_label }) => lot_label,
+      },
+      lotID: {
+        type: GraphQLString,
+        resolve: ({ lot_id }) => lot_id,
       },
       lowEstimate: money({
         name: "SaleArtworkLowEstimate",


### PR DESCRIPTION
Two semi-related updates here!

  - add `lotID` to the `SaleArtwork` type. The websocket is at the level of a sale, broadcasting messages in the form `{lot_id: ..., extended_bidding_end_at: ...}` , so Force needs to be able to get the `lotID` in order to know what to update when a websocket comes in (on a lot page, it would only care about that specific lot, but on the auction page there might be multiple artworks that are getting extended).
  - testing locally, I noticed that if you reloaded the page after a lot has been extended, the artwork sidebar will say 'Ended May 2...', coming from `formattedStartDateTime`.