### PR TITLE
fix: Use internal IDs for MyCollectionAuctionResults artist matching

### DIFF
--- a/src/schema/v2/me/__tests__/myCollectionAuctionResults.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionAuctionResults.test.ts
@@ -45,6 +45,22 @@ describe("Me", () => {
         ],
       }
 
+      const collectionArtistsLoader = jest.fn(async () => ({
+        headers: { "x-total-count": 2 },
+        body: [
+          {
+            id: "an-artist-1",
+            _id: "artist-1",
+            name: "Artist 1",
+          },
+          {
+            id: "an-artist-2",
+            _id: "artist-2",
+            name: "Artist 2",
+          },
+        ],
+      }))
+
       const auctionLotsLoader = jest.fn(async () => ({
         total_count: 2,
         _embedded: {
@@ -62,22 +78,6 @@ describe("Me", () => {
             },
           ],
         },
-      }))
-
-      const collectionArtistsLoader = jest.fn(async () => ({
-        headers: { "x-total-count": 2 },
-        body: [
-          {
-            id: "an-artist-1",
-            _id: "artist-1",
-            name: "Artist 1",
-          },
-          {
-            id: "an-artist-2",
-            _id: "artist-2",
-            name: "Artist 2",
-          },
-        ],
       }))
 
       const context = {

--- a/src/schema/v2/me/myCollectionAuctionResults.ts
+++ b/src/schema/v2/me/myCollectionAuctionResults.ts
@@ -64,7 +64,7 @@ const MyCollectionAuctionResults: GraphQLFieldConfig<any, ResolverContext> = {
         size: 100,
       })
 
-      const artistIds = artists.map(({ id }) => id)
+      const artistIds = artists.map(({ _id }) => _id)
 
       if (!artistIds || artistIds.length === 0) {
         return null


### PR DESCRIPTION
Addresses [CX-2512]

## Description

Use internal IDs for `MyCollectionAuctionResults` artist matching.

[CX-2512]: https://artsyproduct.atlassian.net/browse/CX-2512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ