### PR TITLE
feat: Add artworksForUser root level query

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11681,6 +11681,16 @@ type Query {
     width: String
   ): FilterArtworksConnection
 
+  # A connection of artworks for a user.
+  artworksForUser(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    page: Int
+    userId: String
+  ): ArtworkConnection
+
   # An auction result
   auctionResult(
     # The ID of the auction result
@@ -14997,6 +15007,16 @@ type Viewer {
     tagID: String
     width: String
   ): FilterArtworksConnection
+
+  # A connection of artworks for a user.
+  artworksForUser(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    page: Int
+    userId: String
+  ): ArtworkConnection
 
   # An auction result
   auctionResult(

--- a/src/lib/loaders/loaders_without_authentication/index.ts
+++ b/src/lib/loaders/loaders_without_authentication/index.ts
@@ -6,6 +6,7 @@ import geodataLoaders from "./geodata"
 import gravityLoaders from "./gravity"
 import positronLoaders from "./positron"
 import greenhouseLoaders from "./greenhouse"
+import vortexLoaders from "./vortex"
 
 export const createLoadersWithoutAuthentication = (opts) => ({
   ...deltaLoaders(opts),
@@ -16,6 +17,7 @@ export const createLoadersWithoutAuthentication = (opts) => ({
   ...positronLoaders(opts),
   ...geodataLoaders(opts),
   ...greenhouseLoaders(opts),
+  ...vortexLoaders(opts),
 })
 
 export type LoadersWithoutAuthentication = ReturnType<

--- a/src/lib/loaders/loaders_without_authentication/vortex.ts
+++ b/src/lib/loaders/loaders_without_authentication/vortex.ts
@@ -1,0 +1,30 @@
+import factories from "../api"
+
+interface LoaderArgs {
+  query: string
+  variables?: any
+}
+
+export default (opts) => {
+  const { vortexLoaderWithAuthenticationFactory } = factories(opts)
+
+  const setup = (appToken) => {
+    return vortexLoaderWithAuthenticationFactory(() =>
+      Promise.resolve(appToken)
+    )
+  }
+
+  return {
+    vortexGraphqlLoaderFactory: (appToken) => {
+      return ({ query, variables }: LoaderArgs) => {
+        return setup(appToken)(
+          "/graphql",
+          { query, variables: JSON.stringify(variables) },
+          {
+            method: "POST",
+          }
+        )
+      }
+    },
+  }
+}

--- a/src/schema/v2/__tests__/artworksForUser.test.ts
+++ b/src/schema/v2/__tests__/artworksForUser.test.ts
@@ -1,0 +1,39 @@
+import { getArtistAffinities } from "../artworksForUser"
+
+const mockLoaderFactory = (affinities) => {
+  const edges = affinities.map((affinity) => {
+    return { node: { ...affinity } }
+  })
+
+  const data = { artistAffinities: { edges } }
+  const loader = jest.fn(() => ({ data }))
+
+  return loader
+}
+
+describe("getArtistAffinities", () => {
+  const userLoader = mockLoaderFactory([{ artistId: "banksy", score: "7.77" }])
+  const appLoader = mockLoaderFactory([{ artistId: "warhol", score: "9.99" }])
+
+  it("prefers the user loader when available", async () => {
+    const context = {
+      vortexGraphqlLoader: () => userLoader,
+      vortexGraphqlLoaderFactory: () => () => appLoader,
+    } as any
+
+    const artistIds = await getArtistAffinities({}, context)
+
+    expect(artistIds).toEqual(["banksy"])
+  })
+
+  it("falls back to the app loader when there is no user loader", async () => {
+    const context = {
+      vortexGraphqlLoader: null,
+      vortexGraphqlLoaderFactory: () => () => appLoader,
+    } as any
+
+    const artistIds = await getArtistAffinities({}, context)
+
+    expect(artistIds).toEqual(["warhol"])
+  })
+})

--- a/src/schema/v2/artworksForUser.ts
+++ b/src/schema/v2/artworksForUser.ts
@@ -1,0 +1,86 @@
+import { GraphQLString, GraphQLFieldConfig, GraphQLInt } from "graphql"
+import { connectionFromArraySlice } from "graphql-relay"
+import { convertConnectionArgsToGravityArgs, extractNodes } from "lib/helpers"
+import { CursorPageable, pageable } from "relay-cursor-paging"
+import { createPageCursors } from "schema/v1/fields/pagination"
+import { ResolverContext } from "types/graphql"
+import { artworkConnection } from "schema/v2/artwork"
+import gql from "lib/gql"
+
+const MAX_ARTISTS = 50
+const MAX_ARTWORKS = 100
+const MIN_AFFINITY_SCORE = 0.5
+
+export const artworksForUser: GraphQLFieldConfig<void, ResolverContext> = {
+  description: "A connection of artworks for a user.",
+  type: artworkConnection.connectionType,
+  args: pageable({
+    page: { type: GraphQLInt },
+    userId: { type: GraphQLString },
+  }),
+  resolve: async (
+    _root,
+    args: CursorPageable,
+    {
+      vortexGraphqlLoader,
+      vortexGraphqlLoaderFactory,
+      artworksLoader,
+      appToken,
+    }
+  ) => {
+    if (!artworksLoader) return
+
+    const graphqlLoader =
+      vortexGraphqlLoader || vortexGraphqlLoaderFactory(appToken)
+
+    const vortexResult = await graphqlLoader({
+      query: gql`
+        query artistAffinitiesQuery {
+          artistAffinities(
+            first: ${MAX_ARTISTS}
+            minScore: ${MIN_AFFINITY_SCORE}
+            userId: "${args.userId}"
+          ) {
+            totalCount
+            edges {
+              node {
+                artistId
+                score
+              }
+            }
+          }
+        }
+      `,
+    })()
+
+    const artistIds = extractNodes(vortexResult.data?.artistAffinities).map(
+      (node: any) => node?.artistId
+    )
+
+    let artworks = []
+
+    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+
+    if (artistIds?.length) {
+      artworks = await artworksLoader({
+        artist_ids: artistIds,
+        sort: "-published_at",
+        availability: "for sale",
+        size,
+        offset,
+      })
+    }
+
+    // TODO: get count from artworks loader to optimize pagination
+    const count = artworks.length === 0 ? 0 : MAX_ARTWORKS
+
+    return {
+      totalCount: count,
+      pageCursors: createPageCursors({ ...args, page, size }, count),
+      ...connectionFromArraySlice(artworks, args, {
+        arrayLength: count,
+        sliceStart: offset ?? 0,
+      }),
+    }
+  },
+}

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -128,6 +128,7 @@ import { shortcut } from "./shortcut"
 import { channel } from "./article/channel"
 import { departments, job, jobs } from "./jobs"
 import { RecentlySoldArtworks } from "./recentlySoldArtworks"
+import { artworksForUser } from "./artworksForUser"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -140,6 +141,7 @@ const OptionalFieldDirective = new GraphQLDirective({
 })
 
 const rootFields = {
+  artworksForUser,
   artworkAttributionClasses: ArtworkAttributionClasses,
   artworkMediums: ArtworkMediums,
   auctionResult: AuctionResult,


### PR DESCRIPTION
This PR adds a new root query that can be used like so:

```gql
query ArtworksForUserAccessToken {
  artworksForUser {
    edges {
      node {
        title
      }
    }
  }
}
```

Or:

```gql
query ArtworksForUserSignedAppToken {
  artworksForUser(userId:"587aef0ea09a67787600115b") {
    edges {
      node {
        title
      }
    }
  }
}
```

Note that attempting to use it without either a user token or a signed app token will result in an error.

In terms of what this is doing - it moves the `newWorksByInterestingArtists` query up out of the `me` namespace and allows for two kinds of graphql loaders to hit vortex:

* one that uses the existing access token
* one that falls back to the app token being sent in

Note: depends on this one https://github.com/artsy/vortex/pull/446.

/cc @artsy/grow-devs