### PR TITLE
feat(NX-3163): createInquiryOrder mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9946,6 +9946,11 @@ type Mutation {
   createInquiryOfferOrder(
     input: CommerceCreateInquiryOfferOrderWithArtworkInput!
   ): CommerceCreateInquiryOfferOrderWithArtworkPayload
+
+  # Creates an order and links the conversation to it
+  createInquiryOrder(
+    input: CommerceCreateInquiryOrderWithArtworkInput!
+  ): CommerceCreateInquiryOrderWithArtworkPayload
   createSavedSearch(input: CreateSavedSearchInput!): CreateSavedSearchPayload
   createSmsSecondFactor(
     input: CreateSmsSecondFactorInput!


### PR DESCRIPTION
[NX-3163]

Adds a new mutation `createInquiryOrder` that pretty much does the same as `createInquiryOfferOrder` but stitches to another mutation in Exchange.

Reasoning about why stitching again, Exchange doesn't support Rest API, has no Grape or other utility tool, we already use stitching here and the AST complexity was quite simple but happy and open to discuss if someone wants to 🙂 

cc @artsy/negotiate-devs 

[NX-3163]: https://artsyproduct.atlassian.net/browse/NX-3163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ