### PR TITLE
Fix: address bugs with isHangable [FX-3950]

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -1581,39 +1581,33 @@ describe("Artwork type", () => {
       `
 
       describe("if the artwork is able to be used with View in Room", () => {
-        it("is hangable if print artwork is 2D and has reasonable dimensions", () => {
-          artwork.width = 100
-          artwork.height = 100
-          artwork.category = "print"
+        it("is hangable if print artwork has a 2D category and has reasonable dimensions", () => {
+          artwork.width = "100"
+          artwork.height = "100"
+          artwork.depth = "0.1"
+          artwork.diameter = null
+          artwork.width_cm = 100
+          artwork.height_cm = 100
+          artwork.depth_cm = 0.1
+          artwork.diameter_cm = null
+          artwork.metric = "cm"
+          artwork.category = "Print"
           return runQuery(query, context).then((data) => {
             expect(data.artwork.isHangable).toBe(true)
           })
         })
 
-        it("is hangable if artwork is not 3D category with a reasonable dimensions + tiny depth", () => {
-          artwork.width = 100
-          artwork.height = 100
-          artwork.depth = 0.5
-          artwork.category = "ink"
-          return runQuery(query, context).then((data) => {
-            expect(data.artwork.isHangable).toBe(true)
-          })
-        })
-
-        it("is hangable if artwork is not in the 3D category or 2D category but has a depth of less than 3", () => {
-          artwork.width = 100
-          artwork.height = 100
-          artwork.depth = 2
-          artwork.category = "ink"
-          return runQuery(query, context).then((data) => {
-            expect(data.artwork.isHangable).toBe(true)
-          })
-        })
-
-        it("is hangable if painting artwork is in 2d category and has reasonable dimensions", () => {
-          artwork.width = 100
-          artwork.height = 100
-          artwork.category = "painting"
+        it("is hangable if artwork is not in the 3D category or 2D category but has reasonable dimensions", () => {
+          artwork.width = "100"
+          artwork.height = "100"
+          artwork.depth = "0.1"
+          artwork.diameter = null
+          artwork.width_cm = 100
+          artwork.height_cm = 100
+          artwork.depth_cm = 0.1
+          artwork.diameter_cm = null
+          artwork.metric = "cm"
+          artwork.category = "Mixed Media"
           return runQuery(query, context).then((data) => {
             expect(data.artwork.isHangable).toBe(true)
           })
@@ -1622,27 +1616,32 @@ describe("Artwork type", () => {
 
       describe("if the artwork is not able to be used with View in Room", () => {
         it("is not hangable if the artwork is in a 3D category", () => {
-          artwork.category = "fashion"
-          artwork.width = 100
-          artwork.height = 100
+          artwork.category = "Fashion Design and Wearable Art"
+          artwork.width = "100"
+          artwork.height = "100"
+          artwork.depth = "0.1"
+          artwork.diameter = null
+          artwork.width_cm = 100
+          artwork.height_cm = 100
+          artwork.depth_cm = 0.1
+          artwork.diameter_cm = null
+          artwork.metric = "cm"
           return runQuery(query, context).then((data) => {
             expect(data.artwork.isHangable).toBe(false)
           })
         })
 
-        it("is not hangable if the artwork is in a 3D category like sound", () => {
-          artwork.category = "sound"
-          artwork.width = 100
-          artwork.height = 100
-          return runQuery(query, context).then((data) => {
-            expect(data.artwork.isHangable).toBe(false)
-          })
-        })
-
-        it("is not hangable if the work has a large depth", () => {
-          artwork.width = 100
-          artwork.height = 100
-          artwork.depth = 100
+        it("is not hangable if the work has a large depth and is not in a 2D category", () => {
+          artwork.width = "100"
+          artwork.height = "100"
+          artwork.depth = "1000"
+          artwork.diameter = null
+          artwork.width_cm = 100
+          artwork.height_cm = 100
+          artwork.depth_cm = 1000
+          artwork.diameter_cm = null
+          artwork.metric = "cm"
+          artwork.category = "Mixed Media"
           return runQuery(query, context).then((data) => {
             expect(data.artwork.isHangable).toBe(false)
           })
@@ -1651,14 +1650,13 @@ describe("Artwork type", () => {
         it("is not hangable if the dimensions are unreasonably large", () => {
           artwork.width = "10000"
           artwork.height = "10000"
+          artwork.depth = "0.1"
+          artwork.diameter = null
+          artwork.width_cm = 10000
+          artwork.height_cm = 10000
+          artwork.depth_cm = 0.1
+          artwork.diameter_cm = null
           artwork.metric = "cm"
-          return runQuery(query, context).then((data) => {
-            expect(data.artwork.isHangable).toBe(false)
-          })
-        })
-
-        it("is not hangable if there is no dimensions", () => {
-          artwork.dimensions = {}
           return runQuery(query, context).then((data) => {
             expect(data.artwork.isHangable).toBe(false)
           })

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -1581,7 +1581,7 @@ describe("Artwork type", () => {
       `
 
       describe("if the artwork is able to be used with View in Room", () => {
-        it("is hangable if print artwork has a 2D category and has reasonable dimensions", () => {
+        it("is hangable if artwork has a 2D category and height and width are < 50ft", () => {
           artwork.width = "100"
           artwork.height = "100"
           artwork.depth = "0.1"
@@ -1590,6 +1590,32 @@ describe("Artwork type", () => {
           artwork.height_cm = 100
           artwork.depth_cm = 0.1
           artwork.diameter_cm = null
+          artwork.metric = "cm"
+          artwork.category = "Print"
+          return runQuery(query, context).then((data) => {
+            expect(data.artwork.isHangable).toBe(true)
+          })
+        })
+
+        it("is hangable if artwork has a 2D category and height and width are < 50ft, even if depth is large", () => {
+          artwork.width = "100"
+          artwork.height = "100"
+          artwork.depth = "50"
+          artwork.diameter = null
+          artwork.width_cm = 100
+          artwork.height_cm = 100
+          artwork.depth_cm = 50
+          artwork.diameter_cm = null
+          artwork.metric = "cm"
+          artwork.category = "Print"
+          return runQuery(query, context).then((data) => {
+            expect(data.artwork.isHangable).toBe(true)
+          })
+        })
+
+        it("is hangable if artwork has a 2D category, even if is round", () => {
+          artwork.diameter = "15"
+          artwork.diameter_cm = 15
           artwork.metric = "cm"
           artwork.category = "Print"
           return runQuery(query, context).then((data) => {

--- a/src/schema/v2/artwork/__tests__/utilities.test.ts
+++ b/src/schema/v2/artwork/__tests__/utilities.test.ts
@@ -1,0 +1,149 @@
+import { Artwork } from "types/runtime/gravity"
+import { isTooBig, isTwoDimensional } from "../utilities"
+
+describe("isTwoDimensional", () => {
+  let artwork: Artwork
+
+  beforeEach(() => {
+    artwork = {
+      ...artwork,
+      width: null,
+      height: null,
+      diameter: null,
+      depth: null,
+      metric: null,
+      width_cm: null,
+      height_cm: null,
+      depth_cm: null,
+      diameter_cm: null,
+    }
+  })
+
+  describe("artwork has diameter", () => {
+    it("returns false", () => {
+      artwork.diameter_cm = 1
+      artwork.width_cm = 1
+      artwork.height_cm = 1
+      artwork.depth_cm = 1
+
+      expect(isTwoDimensional(artwork)).toBe(false)
+    })
+  })
+
+  describe("artwork has null depth", () => {
+    it("returns false", () => {
+      artwork.width_cm = 1
+      artwork.height_cm = 1
+      artwork.depth_cm = null
+
+      expect(isTwoDimensional(artwork)).toBe(false)
+    })
+  })
+
+  describe("artwork is too deep", () => {
+    it("returns false", () => {
+      artwork.width_cm = 1
+      artwork.height_cm = 1
+      artwork.depth_cm = 30
+
+      expect(isTwoDimensional(artwork)).toBe(false)
+    })
+  })
+
+  describe("artwork has no width", () => {
+    it("returns false", () => {
+      artwork.height_cm = 1
+      artwork.depth_cm = 1
+
+      expect(isTwoDimensional(artwork)).toBe(false)
+    })
+  })
+
+  describe("artwork has no height", () => {
+    it("returns false", () => {
+      artwork.width_cm = 1
+      artwork.depth_cm = 1
+
+      expect(isTwoDimensional(artwork)).toBe(false)
+    })
+  })
+
+  describe("artwork is two-dimensional", () => {
+    it("returns true", () => {
+      artwork.width_cm = 1
+      artwork.height_cm = 1
+      artwork.depth_cm = 1
+      expect(isTwoDimensional(artwork)).toBe(true)
+    })
+  })
+})
+
+describe("isTooBig", () => {
+  let artwork: Artwork
+
+  beforeEach(() => {
+    artwork = {
+      ...artwork,
+      width: null,
+      height: null,
+      metric: null,
+    }
+  })
+
+  describe("artwork has null width", () => {
+    it("returns true", () => {
+      artwork.height = "1"
+      artwork.metric = "cm"
+
+      expect(isTooBig(artwork)).toBe(true)
+    })
+  })
+
+  describe("artwork has null height", () => {
+    it("returns true", () => {
+      artwork.width = "1"
+      artwork.metric = "cm"
+
+      expect(isTooBig(artwork)).toBe(true)
+    })
+  })
+
+  describe("artwork has null metric", () => {
+    it("returns true", () => {
+      artwork.height = "1"
+      artwork.width = "1"
+
+      expect(isTooBig(artwork)).toBe(true)
+    })
+  })
+
+  describe("artwork has oversize width", () => {
+    it("returns true", () => {
+      artwork.height = "1"
+      artwork.width = "2000"
+      artwork.metric = "cm"
+
+      expect(isTooBig(artwork)).toBe(true)
+    })
+  })
+
+  describe("artwork has oversize height", () => {
+    it("returns true", () => {
+      artwork.height = "10000"
+      artwork.width = "2"
+      artwork.metric = "cm"
+
+      expect(isTooBig(artwork)).toBe(true)
+    })
+  })
+
+  describe("artwork is a reasonable size", () => {
+    it("returns false", () => {
+      artwork.height = "100"
+      artwork.width = "20"
+      artwork.metric = "cm"
+
+      expect(isTooBig(artwork)).toBe(false)
+    })
+  })
+})

--- a/src/schema/v2/artwork/__tests__/utilities.test.ts
+++ b/src/schema/v2/artwork/__tests__/utilities.test.ts
@@ -84,34 +84,29 @@ describe("isTooBig", () => {
   beforeEach(() => {
     artwork = {
       ...artwork,
-      width: null,
-      height: null,
-      metric: null,
+      width_cm: null,
+      height_cm: null,
+      diameter_cm: null,
     }
   })
 
-  describe("artwork has null width", () => {
+  describe("artwork has no width, height, or diameter", () => {
     it("returns true", () => {
-      artwork.height = "1"
-      artwork.metric = "cm"
+      expect(isTooBig(artwork)).toBe(true)
+    })
+  })
+
+  describe("artwork has height and null width", () => {
+    it("returns true", () => {
+      artwork.height_cm = 1
 
       expect(isTooBig(artwork)).toBe(true)
     })
   })
 
-  describe("artwork has null height", () => {
+  describe("artwork has width and null height", () => {
     it("returns true", () => {
-      artwork.width = "1"
-      artwork.metric = "cm"
-
-      expect(isTooBig(artwork)).toBe(true)
-    })
-  })
-
-  describe("artwork has null metric", () => {
-    it("returns true", () => {
-      artwork.height = "1"
-      artwork.width = "1"
+      artwork.width_cm = 1
 
       expect(isTooBig(artwork)).toBe(true)
     })
@@ -119,9 +114,8 @@ describe("isTooBig", () => {
 
   describe("artwork has oversize width", () => {
     it("returns true", () => {
-      artwork.height = "1"
-      artwork.width = "2000"
-      artwork.metric = "cm"
+      artwork.height_cm = 1
+      artwork.width_cm = 2000
 
       expect(isTooBig(artwork)).toBe(true)
     })
@@ -129,19 +123,33 @@ describe("isTooBig", () => {
 
   describe("artwork has oversize height", () => {
     it("returns true", () => {
-      artwork.height = "10000"
-      artwork.width = "2"
-      artwork.metric = "cm"
+      artwork.height_cm = 10000
+      artwork.width_cm = 2
 
       expect(isTooBig(artwork)).toBe(true)
     })
   })
 
-  describe("artwork is a reasonable size", () => {
+  describe("artwork has oversize diamater", () => {
+    it("returns true", () => {
+      artwork.diameter_cm = 10000
+
+      expect(isTooBig(artwork)).toBe(true)
+    })
+  })
+
+  describe("artwork has height and width < 1524 cm", () => {
     it("returns false", () => {
-      artwork.height = "100"
-      artwork.width = "20"
-      artwork.metric = "cm"
+      artwork.height_cm = 100
+      artwork.width_cm = 20
+
+      expect(isTooBig(artwork)).toBe(false)
+    })
+  })
+
+  describe("artwork has diameter < 1524 cm", () => {
+    it("returns false", () => {
+      artwork.diameter_cm = 100
 
       expect(isTooBig(artwork)).toBe(false)
     })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -580,31 +580,39 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLBoolean,
         resolve: (artwork) => {
           const categories3D = [
-            "installation",
-            "design",
-            "performance",
-            "sound",
-            "fashion",
-            "architecture",
-            "books_and_portfolios",
-            "jewelry",
-            "other",
+            artworkMediums["Architecture"].id,
+            artworkMediums["Books and Portfolios"].id,
+            artworkMediums["Design/Decorative Art"].id,
+            artworkMediums["Fashion Design and Wearable Art"].id,
+            artworkMediums["Installation"].id,
+            artworkMediums["Jewelry"].id,
+            artworkMediums["NFT"].id,
+            artworkMediums["Performance Art"].id,
+            artworkMediums["Video/Film/Animation"].id,
           ]
           const categories2D = [
-            "print",
-            "drawing_collage_other_work_on_paper",
-            "painting",
-            "photography",
-            "posters",
-            "work_on_paper",
+            artworkMediums["Drawing, Collage or other Work on Paper"].id,
+            artworkMediums["Painting"].id,
+            artworkMediums["Photography"].id,
+            artworkMediums["Posters"].id,
+            artworkMediums["Print"].id,
           ]
 
-          const areIncluded = (category) =>
-            _.includes(artwork.category, category)
+          const is3DCategory = categories3D.includes(artwork.category)
+          const is2DCategory = categories2D.includes(artwork.category)
 
-          const is3DCategory = categories3D.some(areIncluded)
-          const is2DCategory = categories2D.some(areIncluded)
+          // If it's in one of the 2D categories and is not humongous, it's
+          // always hangable. If it's in one of the 3D categories, it's never
+          // hangable. But there are some categories that _might_ be hangable:
 
+          //   "Mixed Media"
+          //   "Ephemera or Merchandise"
+          //   "Sculpture"
+          //   "Reproduction"
+          //   "Textile arts"
+          //   "Other"
+
+          // For those categories, we check if it seems two-dimensional.
           return (
             (is2DCategory || (!is3DCategory && isTwoDimensional(artwork))) &&
             !isTooBig(artwork)

--- a/src/schema/v2/artwork/utilities.ts
+++ b/src/schema/v2/artwork/utilities.ts
@@ -1,23 +1,49 @@
+import { Artwork } from "types/runtime/gravity"
 import { parse } from "url"
 
-export const isDimensional = (value) => parseFloat(value) > 0
-export const isTinyDimensional = (value) => parseFloat(value) > 3
-
-export const isTwoDimensional = ({ width, height, depth, diameter }) => {
-  return (
-    isDimensional(width) &&
-    isDimensional(height) &&
-    !isDimensional(diameter) &&
-    // It's quite reasonable for a gallery to put on a depth of under an
-    // inch for an artwork that we should treat as being something we can
-    // up for view in room.
-    !isTinyDimensional(depth)
-  )
+export const isTwoDimensional = ({
+  width_cm,
+  height_cm,
+  depth_cm,
+  diameter_cm,
+}: Artwork) => {
+  // If depth, width, or height are null, we can't be confident it's
+  // two-dimensional so we return false.
+  if (
+    typeof depth_cm === "number" &&
+    typeof width_cm === "number" &&
+    typeof height_cm === "number"
+  ) {
+    return (
+      // Must have width and height
+      width_cm > 0 &&
+      height_cm > 0 &&
+      // Must not have depth over 10 cm/~4 inches
+      depth_cm <= 10 &&
+      // Must not have diameter
+      (diameter_cm === null || diameter_cm === 0)
+    )
+  } else {
+    return false
+  }
 }
 
-export const isTooBig = ({ width, height, metric }) => {
+export const isTooBig = ({ width, height, metric }: Artwork) => {
   const LIMIT = { in: 600, cm: 1524 } // 50 feet
-  return parseFloat(width) > LIMIT[metric] || parseFloat(height) > LIMIT[metric]
+
+  // It's possible for width/height/metric to be null, so we need to typecheck
+  // before we can parse them
+  if (
+    typeof width === "string" &&
+    typeof height === "string" &&
+    typeof metric === "string"
+  ) {
+    return (
+      parseFloat(width) > LIMIT[metric] || parseFloat(height) > LIMIT[metric]
+    )
+  } else {
+    return true // assume works are too big if they don't have dimensions
+  }
 }
 
 export const isEmbeddedVideo = ({ website, category }) =>

--- a/src/schema/v2/artwork/utilities.ts
+++ b/src/schema/v2/artwork/utilities.ts
@@ -28,21 +28,16 @@ export const isTwoDimensional = ({
   }
 }
 
-export const isTooBig = ({ width, height, metric }: Artwork) => {
-  const LIMIT = { in: 600, cm: 1524 } // 50 feet
+export const isTooBig = ({ width_cm, height_cm, diameter_cm }: Artwork) => {
+  const limit_cm = 1524 // 50 feet
 
-  // It's possible for width/height/metric to be null, so we need to typecheck
-  // before we can parse them
-  if (
-    typeof width === "string" &&
-    typeof height === "string" &&
-    typeof metric === "string"
-  ) {
-    return (
-      parseFloat(width) > LIMIT[metric] || parseFloat(height) > LIMIT[metric]
-    )
+  // If we have a diameter, the work is circular and shouldn't have width/height
+  if (typeof diameter_cm === "number") {
+    return diameter_cm > limit_cm
+  } else if (typeof width_cm === "number" && typeof height_cm === "number") {
+    return width_cm > limit_cm || height_cm > limit_cm
   } else {
-    return true // assume works are too big if they don't have dimensions
+    return true // assume works are too big if they don't have diameter or width/height
   }
 }
 


### PR DESCRIPTION
A gallery partner [asked](https://artsy.slack.com/archives/C7LEJU1QU/p1651828938959449) why one of their works did not have the "view in room" button on the desktop artwork page.

The [only thing](https://github.com/artsy/force/blob/6609be28a4657e9d65f435b74c7de59edbe4fcb0/src/v2/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx#L165) that determines whether we show or hide that button in the Force UI is a computed field `isHangable` in Metaphysics.

Looking into how `isHangable` is computed, I noticed that we were comparing the wrong category names, so we were effectively never making use of a "is2DCategory" and "is3DCategory" check. More digging also uncovered some bugs with how we parsed depth (see below for breakdown of what was happening and what's changing), and with how our specs were set up. I worked on splitting out the specs so that we had more test coverage, and on correcting the surprising behavior.

~In my opinion, this logic could probably be simplified to simply be "This work isHangable if it is not one of these 3D categories that we are confident are never hangable, and it has reasonable height, width, and depth" (basically just combining the existing `isTooBig` and `isTwoDimensional` functions). However, based on the conversation in [this ticket](https://artsyproduct.atlassian.net/browse/NX-2719), the use of category as part of the criteria is quite intentional, and I've already spent enough time on this bug that I don't feel like opening a whole 'nother can of worms 🙃~ Edit: I've come around on this a bit. Seems like it's at least helpful to not require or check `depth` for a lot of the "we're pretty sure this is 2D" categories, since we don't always have perfect information input by partners on artworks. In a perfect world, we'd have exact dimensions and could just rely on those...but requirements in CMS have been updated many times over the years, and we don't always have depth information (or it's wrong because we were forcing partners to enter depth and they would put things like `10cm` for a paper-thin work, just to have _something_ in there). So, seems good to still have the 2D/3D category split for now, though it is still confusing. 

### Criteria for a work to display the "view in room" button, before this PR:
- It did not matter what category the artwork was in because we were comparing the wrong category string, so we treated all artwork categories as if they were neither 2D or 3D categories
- Thus the criteria was:
  - Must have height > 0 and < 50ft/15.23m
  - Must have width > 0 and < 50ft/15.23m
  - Must not have diameter
  - Depth is either **null** (was never entered; I don't think we supported this intentionally but we were indeed supporting it) or must be less than 3 inches or centimeters (Note: we did not differentiate between the two, so a work with metric set to `cm` and `depth: 4` would have failed, while a work with metric `in` and `depth: 2` would have passed even though 2 inches is ~5 cm)
    - Edit: just [came across](https://artsy.slack.com/archives/C02K5KBPG9W/p1651873273193649?thread_ts=1651873072.176499&cid=C02K5KBPG9W) one other interesting `depth` bug: works like [this one](https://www.artsy.net/artwork/macauley-norman-the-great-bambino) that have depth set to something like `7/8in` end up not being eligible for View in Room because `parseFloat("7/8")` is `7` (it hits the / and gives up). This is also solved in this PR by using `depth_cm` instead of just `depth`.

### Criteria for a work to display the "view in room" button, after this PR:
- If artwork is in one of the following "3D categories", we never show the "View in Room" button:
  - "Architecture"
  - "Books and Portfolios"
  - "Design/Decorative Art"
  - "Fashion Design and Wearable Art"
  - "Installation"
  - "Jewelry"
  - "NFT"
  - "Performance Art"
  - "Video/Film/Animation"
- If artwork is in one of the following "2D categories", we will show the "View in Room" button as long as we have a width and height OR a diameter (to cover round + flat works like [this one](https://www.artsy.net/artwork/takashi-murakami-flower-parent-and-child-rum-pum-pum-2)) and the work is no larger than 50ft/15.23m in any dimension. **Note that this means we ignore depth for these categories**! If a partner lists a "Painting" with a depth of 50 cm, we would still allow it to be used with View in Room:
  - "Drawing, Collage or other Work on Paper"
  - "Painting"
  - "Photography"
  - "Posters"
  - "Print"
- If the artwork is in neither of those groups of categories (which means its category is `"Mixed Media", "Ephemera or Merchandise", "Sculpture", "Reproduction", "Textile arts", or "Other"`), our criteria are as follows:
  - width > 0 and < 50ft/15.23m
  - height > 0 and < 50ft/15.23m
  - depth > 0 and <= ~4in/10 cm. Note that this means that **we would no longer support null values, so any works (that are not in one of our 2D categories above) without a depth set will be excluded from "View in Room"**
  - Must not have diameter (it must be null or 0)

~Assigning myself to this PR because I want to make sure we're good with the above changes before shipping!~

Jira ticket: https://artsyproduct.atlassian.net/browse/FX-3950