### PR TITLE
feat(FX-3940): query for an artwork within a tineye match

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12497,6 +12497,8 @@ type ResizedImageUrl {
 }
 
 type ReverseImageSearchResult {
+  artwork: Artwork
+
   # The matching collection image’s file path
   filepath: String!
 

--- a/src/schema/v2/__tests__/reverseImageSearch.test.ts
+++ b/src/schema/v2/__tests__/reverseImageSearch.test.ts
@@ -78,6 +78,47 @@ describe("reverseImageSearch", () => {
       "Error message"
     )
   })
+
+  it("should return info about artwork", async () => {
+    const artworkQuery = gql`
+      query($file: Upload!) {
+        reverseImageSearch(image: $file) {
+          results {
+            filepath
+            artwork {
+              title
+            }
+          }
+        }
+      }
+    `
+    const context = {
+      meLoader: jest.fn().mockResolvedValue({}),
+      artworkLoader: jest.fn().mockResolvedValue({
+        title: "Artwork Title",
+        _id: "artwork-id",
+      }),
+    }
+
+    mockTineyeSearch.mockResolvedValue(TinEyeSuccessResponse)
+
+    const result = await runQuery(artworkQuery, context, { file: upload })
+
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "reverseImageSearch": Object {
+          "results": Array [
+            Object {
+              "artwork": Object {
+                "title": "Artwork Title",
+              },
+              "filepath": "artwork/artwork-id/image/image-id",
+            },
+          ],
+        },
+      }
+    `)
+  })
 })
 
 const query = gql`

--- a/src/schema/v2/__tests__/reverseImageSearch.test.ts
+++ b/src/schema/v2/__tests__/reverseImageSearch.test.ts
@@ -94,10 +94,12 @@ describe("reverseImageSearch", () => {
     `
     const context = {
       meLoader: jest.fn().mockResolvedValue({}),
-      artworkLoader: jest.fn().mockResolvedValue({
-        title: "Artwork Title",
-        _id: "artwork-id",
-      }),
+      unauthenticatedLoaders: {
+        artworkLoader: jest.fn().mockResolvedValue({
+          title: "Artwork Title",
+          _id: "artwork-id",
+        }),
+      },
     }
 
     mockTineyeSearch.mockResolvedValue(TinEyeSuccessResponse)

--- a/src/schema/v2/reverseImageSearch.ts
+++ b/src/schema/v2/reverseImageSearch.ts
@@ -72,8 +72,12 @@ export const ReverseImageSearchResult = new GraphQLObjectType({
     },
     artwork: {
       type: ArtworkType,
-      resolve: ({ filepath }, _args, { artworkLoader }) => {
-        if (filepath && artworkLoader) {
+      resolve: (
+        { filepath },
+        _args,
+        { unauthenticatedLoaders: { artworkLoader } }
+      ) => {
+        if (filepath) {
           const parts = filepath.split("/")
           const artworkId = parts[1]
 

--- a/src/schema/v2/reverseImageSearch.ts
+++ b/src/schema/v2/reverseImageSearch.ts
@@ -11,6 +11,7 @@ import {
 import { GraphQLUpload } from "graphql-upload"
 import { tineyeSearch } from "lib/apis/tineye"
 import { ResolverContext } from "types/graphql"
+import { ArtworkType } from "./artwork"
 
 export const ReverseImageSearchResultMatchRect = new GraphQLObjectType({
   name: "ReverseImageSearchResultMatchRect",
@@ -68,6 +69,19 @@ export const ReverseImageSearchResult = new GraphQLObjectType({
       description: "Location of the matching area in the first image",
       type: new GraphQLNonNull(ReverseImageSearchResultMatchRect),
       resolve: ({ query_match_rect }) => query_match_rect,
+    },
+    artwork: {
+      type: ArtworkType,
+      resolve: ({ filepath }, _args, { artworkLoader }) => {
+        if (filepath && artworkLoader) {
+          const parts = filepath.split("/")
+          const artworkId = parts[1]
+
+          return artworkLoader(artworkId)
+        }
+
+        return null
+      },
     },
   }),
 })


### PR DESCRIPTION
Jira ticket [FX-3940]

### Description
Define an artwork subfield under each result, backed by a Gravity loader to fetch artwork details.

```graphql
{
  reverseImageSearch(image: $file) {
    results {
      artwork {
        href
        internalID
      }
    }
  }
}
```

### Acceptance Criteria
* Given an image is indexed to TinEye
* When I query for the image using what should be a match
* Then I get back some results
* And I can fetch the corresponding artwork for each match

### Demo
https://user-images.githubusercontent.com/3513494/168045437-505ca98c-de49-4917-b7d7-f9942cb498a2.mp4

[FX-3940]: https://artsyproduct.atlassian.net/browse/FX-3940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ