### PR TITLE
[WIP- dont merge][GRO-849] add artist badge field to schema

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1116,6 +1116,9 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     sort: AuctionResultSorts
   ): AuctionResultConnection
 
+  # A list of badges
+  badges: [ArtistBadge!]!
+
   # In applicable contexts, this is what the artist (as a suggestion) is based on.
   basedOn: Artist
   bio: String
@@ -1325,6 +1328,17 @@ type ArtistArtworkGrid implements ArtworkContextGrid {
 enum ArtistArtworksFilters {
   IS_FOR_SALE
   IS_NOT_FOR_SALE
+}
+
+type ArtistBadge {
+  entities: [String!]!
+  label: String!
+  type: ArtistBadgeType
+}
+
+enum ArtistBadgeType {
+  ACTIVE_SECONDARY_MARKET
+  HIGH_AUCTION_RECORD
 }
 
 type ArtistBlurb {

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -344,20 +344,21 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
           )
         ),
         description: "A list of badges",
-        resolve: ({ id }, _args, { artistBadgesLoader }) => {
-          return [
-            {
-              label: "Active Secondary Market",
-              type: "ACTIVE_SECONDARY_MARKET",
-              entities: [],
-            },
-            {
-              label: "High Auction Record",
-              type: "HIGH_AUCTION_RECORD",
-              entities: ["US$4.2m, Sotheby's, 2010"],
-            },
-          ]
-        },
+        // resolve: ({ id }, _args, { artistBadgesLoader }) => {
+        //  TODO: artistBadgesLoader func to pull json file from s3 and massage data
+        //   return [
+        //     {
+        //       label: "Active Secondary Market",
+        //       type: "ACTIVE_SECONDARY_MARKET",
+        //       entities: [],
+        //     },
+        //     {
+        //       label: "High Auction Record",
+        //       type: "HIGH_AUCTION_RECORD",
+        //       entities: ["US$4.2m, Sotheby's, 2010"],
+        //     },
+        //   ]
+        // },
       },
       basedOn: {
         type: ArtistType,

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -51,6 +51,7 @@ import {
   GraphQLList,
   GraphQLInt,
   GraphQLFieldConfig,
+  GraphQLEnumType,
 } from "graphql"
 import { connectionFromArraySlice } from "graphql-relay"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
@@ -307,6 +308,55 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
               )
             }
           )
+        },
+      },
+      badges: {
+        type: new GraphQLNonNull(
+          new GraphQLList(
+            new GraphQLNonNull(
+              new GraphQLObjectType({
+                name: "ArtistBadge",
+                fields: {
+                  label: {
+                    type: new GraphQLNonNull(GraphQLString),
+                  },
+                  type: {
+                    type: new GraphQLEnumType({
+                      name: "ArtistBadgeType",
+                      values: {
+                        ACTIVE_SECONDARY_MARKET: {
+                          value: "ACTIVE_SECONDARY_MARKET",
+                        },
+                        HIGH_AUCTION_RECORD: {
+                          value: "HIGH_AUCTION_RECORD",
+                        },
+                      },
+                    }),
+                  },
+                  entities: {
+                    type: new GraphQLNonNull(
+                      new GraphQLList(new GraphQLNonNull(GraphQLString))
+                    ),
+                  },
+                },
+              })
+            )
+          )
+        ),
+        description: "A list of badges",
+        resolve: ({ id }, _args, { artistBadgesLoader }) => {
+          return [
+            {
+              label: "Active Secondary Market",
+              type: "ACTIVE_SECONDARY_MARKET",
+              entities: [],
+            },
+            {
+              label: "High Auction Record",
+              type: "HIGH_AUCTION_RECORD",
+              entities: ["US$4.2m, Sotheby's, 2010"],
+            },
+          ]
         },
       },
       basedOn: {


### PR DESCRIPTION
The intent of this PR is to start the process of adding schema to funnel new Artist insights metadata into the frontend so that it can be visualized as badges on the Artist page. The general schema form for the badges matches the schema design in `artist#insights`

Still a WIP and currently in draft form.