### PR TITLE
feat: accept password for account deletion

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6802,6 +6802,9 @@ input DeleteAccountInput {
   # Reason for deleting the account.
   explanation: String
 
+  # Password.
+  password: String
+
   # Referrer location
   url: String
 }

--- a/src/lib/__tests__/apis/fetch.test.ts
+++ b/src/lib/__tests__/apis/fetch.test.ts
@@ -94,11 +94,11 @@ describe("constructUrlAndParams", () => {
     expect(json).toBeUndefined()
   })
 
-  const methods = ["PUT", "POST"]
+  const methods = ["PUT", "POST", "DELETE"]
 
   methods.forEach((method) => {
     describe(`for a ${method} request`, () => {
-      it("removes query params for a POST", () => {
+      it("removes query params", () => {
         const { url, body, json } = constructUrlAndParams(
           method,
           "https://staging.artsy.net/api/v1/me/token?client_application_id=blah"

--- a/src/lib/apis/fetch.ts
+++ b/src/lib/apis/fetch.ts
@@ -17,7 +17,7 @@ interface URLAndRequestBodyParams extends RequestBodyParams {
 export const constructUrlAndParams = (method, url): URLAndRequestBodyParams => {
   const opts: RequestBodyParams = {}
 
-  if (method === "PUT" || method === "POST") {
+  if (method === "PUT" || method === "POST" || method === "DELETE") {
     const [path, queryParams] = url.split("?")
     const parsedParams = parse(queryParams)
 

--- a/src/schema/v2/me/delete_account_mutation.ts
+++ b/src/schema/v2/me/delete_account_mutation.ts
@@ -57,6 +57,10 @@ export const deleteUserAccountMutation = mutationWithClientMutationId<
       description: "Reason for deleting the account.",
       type: GraphQLString,
     },
+    password: {
+      description: "Password.",
+      type: GraphQLString,
+    },
     url: {
       description: "Referrer location",
       type: GraphQLString,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4152

Add an optional `password` field to account deletion mutation.

After this we will update clients (e.g. Force) to require user password when deleting account. After that we will come back here to make `password` field required for the mutation.

(see similar [PR](https://github.com/artsy/gravity/pull/15289) for gravity)
 