### PR TITLE
fix(NX-3138): add conversation to CommerceBuyOrder in stitching

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3270,6 +3270,7 @@ type CommerceBuyOrder implements CommerceOrder {
   ): String
   commissionFeeCents: Int
   commissionRate: Float
+  conversation: Conversation
   createdAt(
     format: String
 

--- a/src/lib/stitching/exchange/v2/stitching.ts
+++ b/src/lib/stitching/exchange/v2/stitching.ts
@@ -223,6 +223,7 @@ export const exchangeStitchingEnvironment = ({
       buyerDetails: OrderParty
       sellerDetails: OrderParty
       creditCard: CreditCard
+      conversation: Conversation
       
       ${orderTotalsSDL.join("\n")}
     }


### PR DESCRIPTION
Solves: [NX-3138](https://artsyproduct.atlassian.net/browse/NX-3138)

Added Conversation to CommerceBuyOrder that was causing issues for the "Purchase" cta redirection in Conversations.