### PR TITLE
chore: check schema drift on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,16 +33,12 @@ only_development: &only_development
         - release
         - main
 
-jobs:
-  push-schema-changes:
-    executor:
-      name: node/default
-      tag: "14.17"
+commands:
+  setup_hokusai:
     steps:
       - run:
           name: Let hokusai modify /usr/local/bin
           command: sudo chmod -R 777 /usr/local/bin
-      - checkout
       - hokusai/install-aws-iam-authenticator
       - run:
           name: Install hokusai
@@ -53,9 +49,30 @@ jobs:
             pip install awscli --upgrade
             pip install hokusai
       - hokusai/configure-hokusai
+  yarn_install:
+    steps:
       - yarn/load_dependencies
       - yarn/install
       - yarn/save_dependencies
+
+jobs:
+  ensure-schema-update:
+    executor:
+      name: node/default
+      tag: "14.17"
+    steps:
+      - checkout
+      - setup_hokusai
+      - yarn_install
+      - run: scripts/ensure-schema-update.sh
+  push-schema-changes:
+    executor:
+      name: node/default
+      tag: "14.17"
+    steps:
+      - checkout
+      - setup_hokusai
+      - yarn_install
       - run:
           name: push schema changes
           command: node scripts/push-schema-changes.js
@@ -69,6 +86,10 @@ workflows:
 
       - yarn/type-check:
           <<: *not_staging_or_release
+
+      - ensure-schema-update:
+          context: hokusai
+          <<: *only_development
 
       # pre-staging
       - yarn/run:

--- a/scripts/ensure-schema-update.sh
+++ b/scripts/ensure-schema-update.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NO_COLOR='\033[0m'
+
+MSG_CLEAN="\n${GREEN}Schema is up-to-date.${NO_COLOR}"
+MSG_DRIFT="\n${RED}Schema is outdated. You might want to run \`yarn dump:staging\` and commit the changes.${NO_COLOR}"
+
+yarn dump:staging
+
+if [ -z "$(git status _schemaV2.graphql --porcelain)" ]; then
+  echo "$MSG_CLEAN"
+else
+  echo "$MSG_DRIFT" && exit 1
+fi


### PR DESCRIPTION
Surfaced (but not directly related to) this [thread](https://artsy.slack.com/archives/C02BC3HEJ/p1652989950505809), we currently use a [git pre-commit hook](https://github.com/artsy/metaphysics/blob/21698481018fa8e3b4d7f2df0daf8d8f2d308f72/package.json#L166) to update the schema, but we don't have a corresponding check/block on CI. It's possible the hook is skipped and outdated schema lands in the main branch.

This introduces a new schema check on CI for PRs, and blocks merge when schema is not up-to-date.

![Screen Shot 2022-05-20 at 10 07 11 AM](https://user-images.githubusercontent.com/796573/169545599-947d3dea-cc32-44d2-a3d5-1b65aeef44e5.png)

