### PR TITLE
fix: correct shape for lot standings to properly return sold status after sale is closed

### DIFF
--- a/src/schema/v2/me/__tests__/myBids.test.ts
+++ b/src/schema/v2/me/__tests__/myBids.test.ts
@@ -190,6 +190,7 @@ describe("myBids", () => {
               isHighestBidder: true,
               lotState: expect.objectContaining({
                 saleId: "sale-2",
+                soldStatus: "Sold",
               }),
               slug:
                 "mario-giacomelli-io-non-ho-mani-che-mi-accarezzino-il-volto-22",
@@ -252,7 +253,7 @@ function getContext(props: { auctionState: "open" | "closed" }) {
       bidder: {
         sale: {
           _id: "sale-2",
-          auction_state: "open",
+          auction_state: "closed",
         },
       },
       sale_artwork: {

--- a/src/schema/v2/me/myBids.ts
+++ b/src/schema/v2/me/myBids.ts
@@ -420,8 +420,10 @@ function formatGravityLotStandingsToMatchCausalityLotStandings(
 
 function getSoldStatus(lotStanding): string | undefined {
   const {
-    bidder: { sale, sale_artwork },
+    bidder: { sale },
+    sale_artwork,
   } = lotStanding
+
   if (sale.auction_state === "open") {
     return "ForSale"
   } else if (sale.auction_state == "closed") {


### PR DESCRIPTION
This was a bug from a large refactor of this schema back in https://github.com/artsy/metaphysics/pull/3714

The shape of the `lotStanding` being destructured in the function is slightly different than what it was doing, and so `sale_artwork` was always `null`. That is the `null` that winds up being evaluated (`sale_artwork.reserve_status`) a few lines down only when the sale is closed.

[This](https://github.com/artsy/gravity/blob/0c998ec21a4f373dbc042159d0ff7f6b41349735/app/services/lot_standing_service.rb#L37-L42) is the object from Gravity that is being used for `lotStanding` here.

Closes [BID-395]



[BID-395]: https://artsyproduct.atlassian.net/browse/BID-395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ