### PR TITLE
feat: add has market price insights flag to the artwork model

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1775,6 +1775,7 @@ type Artwork implements Node & Searchable & Sellable {
 
   # Returns true when artwork has a certificate of authenticity
   hasCertificateOfAuthenticity: Boolean
+  hasMarketPriceInsights: Boolean
 
   # The height as expressed by the original input metric
   height: String

--- a/src/lib/loadBatchPriceInsights.ts
+++ b/src/lib/loadBatchPriceInsights.ts
@@ -5,7 +5,7 @@ import { StaticPathLoader } from "./loaders/api/loader_interface"
 const MAX_MARKET_PRICE_INSIGHTS = 50
 
 export const loadBatchPriceInsights = async (
-  artistIDMediumTuples: { artistID: string; medium: string }[],
+  artistIDMediumTuples: { artistId: string; medium: string }[],
   vortexGraphQLLoader: ({ query, variables }) => StaticPathLoader<any>
 ) => {
   try {

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -39,6 +39,10 @@ describe("Artwork type", () => {
   beforeEach(() => {
     artwork = {
       id: "richard-prince-untitled-portrait",
+      artist: {
+        _id: "artist-id",
+      },
+      medium: "print",
       title: "Untitled (Portrait)",
       forsale: true,
       acquireable: false,
@@ -2065,7 +2069,7 @@ describe("Artwork type", () => {
           artwork: {
             partner: null,
             meta: {
-              description: "A Cat, 2 x 3in.",
+              description: "A Cat, print, 2 x 3in.",
             },
           },
         })
@@ -3300,6 +3304,64 @@ describe("Artwork type", () => {
             submissionId: "submission-id",
           },
         })
+      })
+    })
+  })
+
+  describe("hasMarketPriceInsights", () => {
+    it("returns true when an artwork has market price insights", () => {
+      const query = `
+        {
+          artwork(id: "foo-bar") {
+            hasMarketPriceInsights
+          }
+        }
+      `
+
+      const mockVortexGraphqlLoader = jest.fn(() => () =>
+        Promise.resolve({
+          data: {
+            marketPriceInsightsBatch: { edges: null },
+          },
+        })
+      )
+
+      context.vortexGraphqlLoader = mockVortexGraphqlLoader
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            hasMarketPriceInsights: false,
+          },
+        })
+      })
+    })
+  })
+
+  it("returns false when an artwork has no market price insights", () => {
+    const query = `
+        {
+          artwork(id: "foo-bar") {
+            hasMarketPriceInsights
+          }
+        }
+      `
+
+    const mockVortexGraphqlLoader = jest.fn(() => () =>
+      Promise.resolve({
+        data: {
+          marketPriceInsightsBatch: { edges: [{ node: { demandRank: 0.9 } }] },
+        },
+      })
+    )
+
+    context.vortexGraphqlLoader = mockVortexGraphqlLoader
+
+    return runQuery(query, context).then((data) => {
+      expect(data).toEqual({
+        artwork: {
+          hasMarketPriceInsights: true,
+        },
       })
     })
   })

--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -108,16 +108,16 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
         convectionGraphQLLoader
       )
 
-      let artistIDMediumTuples = artworks.map((artwork: any) => ({
+      let artistIdMediumTuples = artworks.map((artwork: any) => ({
         artistId: artwork.artist?._id,
         medium: artwork.medium,
       }))
 
       // remove duplicates
-      artistIDMediumTuples = uniqWith(artistIDMediumTuples, isEqual)
+      artistIdMediumTuples = uniqWith(artistIdMediumTuples, isEqual)
 
       const marketPriceInsights = await loadBatchPriceInsights(
-        artistIDMediumTuples,
+        artistIdMediumTuples,
         vortexGraphqlLoader
       )
 


### PR DESCRIPTION
This PR adds `hasMarketPriceInsights` to the artwork model.

<img width="1774" alt="Screenshot 2022-05-24 at 16 54 32" src="https://user-images.githubusercontent.com/11945712/170066999-c69ff187-1e90-4313-bb60-d4ca5bb857d6.png">