### PR TITLE
fix(article): filters out unsupported section types

### DIFF
--- a/src/schema/v2/article/index.ts
+++ b/src/schema/v2/article/index.ts
@@ -283,7 +283,21 @@ export const ArticleType = new GraphQLObjectType<any, ResolverContext>({
           )
         )
       ),
-      resolve: ({ sections }) => (sections ? sections : []),
+      resolve: ({ sections }) =>
+        sections
+          ? // Filter out any unsupported sections
+            sections.filter((section) => {
+              return [
+                "callout",
+                "embed",
+                "image_collection",
+                "image_set",
+                "social_embed",
+                "text",
+                "video",
+              ].includes(section.type)
+            })
+          : [],
     },
     series: {
       type: new GraphQLObjectType({


### PR DESCRIPTION
Apparently a few legacy articles have unsupported section types like "slideshow" — this filters those out (which is what the front end is currently doing)