### PR TITLE
fix(requestlocation): includes id and cached fields

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12597,8 +12597,10 @@ type RequestCredentialsForAssetUploadPayload {
 }
 
 type RequestLocation {
+  cached: Int
   country: String
   countryCode: String
+  id: ID!
 }
 
 type RequestPriceEstimatedMutationFailure {

--- a/src/lib/loaders/index.ts
+++ b/src/lib/loaders/index.ts
@@ -18,6 +18,7 @@ export type ResponseHeaders = { [header: string]: string }
 export type BodyAndHeaders<B = any, H = ResponseHeaders> = {
   body: B
   headers: H
+  cached?: number
 }
 
 // Remove the `headers` key here so we can use pattern matching below to


### PR DESCRIPTION
![](https://static.damonzucconi.com/_capture/lHbQhZKu.png)

OK this was a bit confusing but:
* Adds an `id` field that's just the base64 encoded IP address so that Relay can throw it in the cache store
* Exposes the `cached` field (and updates the corresponding type)