### PR TITLE
[GRO-849] add active_secondary_market type to Artist

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1130,6 +1130,7 @@ type ArticleSponsor {
 }
 
 type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Searchable {
+  activeSecondaryMarket: Boolean
   alternateNames: [String]
   articlesConnection(
     after: String

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -624,6 +624,10 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
       },
       initials: initials("name"),
       insights: ArtistInsights,
+      activeSecondaryMarket: {
+        type: GraphQLBoolean,
+        resolve: ({ active_secondary_market }) => active_secondary_market,
+      },
       isConsignable: {
         type: GraphQLBoolean,
         resolve: ({ consignable }) => consignable,


### PR DESCRIPTION
This PR solves [GRO-849](https://artsyproduct.atlassian.net/browse/GRO-849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

Goal is to automate imports of new artist metadata from multiple CSV files in a folder in an S3 bucket to be added to the Artist and then funneled to the front end.

A rake task is hooked up to a jenkins job that is supposed to run at everyday intervals but is currently disabled while I am prepping the back end for real CSV imports:

https://joe.artsy.net/view/All/job/gravity-artist-updates/

Part of that prep is adding `active_secondary_market` type to the Artist in metaphysics here. 