### PR TITLE
(fix: px-5023) Surface currencyCode field on ShippingQuote interface

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -5969,6 +5969,7 @@ type CommerceShippingQuote {
     # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String!
+  currencyCode: String!
   displayName: String!
   id: ID!
   isSelected: Boolean!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4947,6 +4947,7 @@ type CommerceShippingQuote {
     # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String!
+  currencyCode: String!
   displayName: String!
   id: ID!
   isSelected: Boolean!

--- a/src/data/exchange.graphql
+++ b/src/data/exchange.graphql
@@ -2005,6 +2005,7 @@ A shipping quote
 """
 type ShippingQuote {
   createdAt: DateTime!
+  currencyCode: String!
   displayName: String!
   id: ID!
   isSelected: Boolean!


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/PX-5023

Exposes new field for shipping quotes to map the correct currency from the database to the UI: 
https://github.com/artsy/exchange/pull/1185/files

Additional details in pr above ^