### PR TITLE
feat(NX-3129): add shortArrayDescription to attributionClass of artwork

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2315,6 +2315,9 @@ type AttributionClass {
   # Shortest form of attribution class display
   name: String
 
+  # Short descriptive phrase for attribution class without punctuation as array of strings
+  shortArrayDescription: [String]
+
   # Short descriptive phrase for attribution class without punctuation
   shortDescription: String
 }

--- a/src/lib/attributionClasses.ts
+++ b/src/lib/attributionClasses.ts
@@ -4,6 +4,7 @@ export default {
     name: "Unique",
     info: null,
     short_description: "This is a unique work",
+    short_array_description: ["This is", "a unique work"],
     long_description: "One-of-a-kind piece.",
   },
   "limited edition": {
@@ -11,6 +12,7 @@ export default {
     name: "Limited edition",
     info: null,
     short_description: "This work is part of a limited edition set",
+    short_array_description: ["This work is part of", "a limited edition set"],
     long_description:
       "The edition run has ended; the number of works produced is known and included in the listing.",
   },
@@ -19,6 +21,7 @@ export default {
     name: "Open edition",
     info: null,
     short_description: "This work is from an open edition",
+    short_array_description: ["This work is from", "an open edition"],
     long_description: [
       "The edition run is ongoing.",
       "New works are still being produced, which may be numbered.",
@@ -30,6 +33,10 @@ export default {
     name: "Unknown edition",
     info: null,
     short_description: "This work is from an edition of unknown size",
+    short_array_description: [
+      "This work is from",
+      "an edition of unknown size",
+    ],
     long_description:
       "The edition run has ended; it is unclear how many works were produced.",
   },

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -2025,6 +2025,27 @@ describe("Artwork type", () => {
       })
     })
 
+    it(`returns proper attribution class short_array_description for unique artwork`, () => {
+      const query = `
+        {
+          artwork(id: "richard-prince-untitled-portrait") {
+            attributionClass {
+              shortArrayDescription
+            }
+          }
+        }
+      `
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            attributionClass: {
+              shortArrayDescription: ["This is", "a unique work"],
+            },
+          },
+        })
+      })
+    })
+
     it(`returns proper attribution class long_description for unique artwork`, () => {
       const query = `
         {

--- a/src/schema/v2/artwork/attributionClass.ts
+++ b/src/schema/v2/artwork/attributionClass.ts
@@ -1,4 +1,4 @@
-import { GraphQLObjectType, GraphQLString } from "graphql"
+import { GraphQLObjectType, GraphQLString, GraphQLList } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { InternalIDFields } from "schema/v2/object_identification"
 
@@ -21,6 +21,14 @@ const AttributionClass = new GraphQLObjectType<any, ResolverContext>({
         "Short descriptive phrase for attribution class without punctuation",
       resolve: ({ short_description }) => {
         return short_description
+      },
+    },
+    shortArrayDescription: {
+      type: new GraphQLList(GraphQLString),
+      description:
+        "Short descriptive phrase for attribution class without punctuation as array of strings",
+      resolve: ({ short_array_description }) => {
+        return short_array_description
       },
     },
     longDescription: {


### PR DESCRIPTION
[NX-3129]

Adds `shortArrayDescription` to the `attributionClass` of the `Artwork`.
The same info as `shortDescription` but broken down as an array.

cc @artsy/negotiate-devs 

[NX-3129]: https://artsyproduct.atlassian.net/browse/NX-3129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ