### PR TITLE
[GRO-849] Co-locate active_secondary_market with insights

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1130,7 +1130,6 @@ type ArticleSponsor {
 }
 
 type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Searchable {
-  activeSecondaryMarket: Boolean
   alternateNames: [String]
   articlesConnection(
     after: String
@@ -1500,13 +1499,13 @@ type ArtistHighlights {
 
 type ArtistInsight {
   # List of entities relevant to the insight.
-  entities: [String]
+  entities: [String!]!
 
   # Label to use when displaying the insight.
-  label: String
+  label: String!
 
   # The type of insight.
-  type: String
+  type: String!
 }
 
 type ArtistMeta {

--- a/src/schema/v2/artist/__tests__/insights.test.ts
+++ b/src/schema/v2/artist/__tests__/insights.test.ts
@@ -61,6 +61,7 @@ describe("ArtistInsights type", () => {
     artist.collections = "Museum of Modern Art (MoMA)"
     artist.review_sources = "Artforum International Magazine"
     artist.biennials = "frieze"
+    artist.active_secondary_market = true
 
     const query = `
           {
@@ -102,6 +103,11 @@ describe("ArtistInsights type", () => {
           label: "Included in a major biennial",
           entities: ["frieze"],
         },
+        {
+          type: "ACTIVE_SECONDARY_MARKET",
+          label: "Recent auction results in the Artsy Price Database",
+          entities: [],
+        },
       ])
     })
   })
@@ -130,6 +136,27 @@ describe("ArtistInsights type", () => {
           entities: ["MoMA PS1", "Museum of Modern Art (MoMA)"],
         },
       ])
+    })
+  })
+
+  it("does not build an insight if boolean value is false", () => {
+    artist.active_secondary_market = false
+
+    const query = `
+        {
+          artist(id: "foo-bar") {
+            id
+            insights {
+              type
+              label
+              entities
+            }
+          }
+        }
+      `
+
+    return runQuery(query, context).then((data) => {
+      expect(data!.artist.insights).toEqual([])
     })
   })
 })

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -624,10 +624,6 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
       },
       initials: initials("name"),
       insights: ArtistInsights,
-      activeSecondaryMarket: {
-        type: GraphQLBoolean,
-        resolve: ({ active_secondary_market }) => active_secondary_market,
-      },
       isConsignable: {
         type: GraphQLBoolean,
         resolve: ({ consignable }) => consignable,


### PR DESCRIPTION
This PR solves [GRO-849](https://artsyproduct.atlassian.net/browse/GRO-849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

After some thought, it simply made sense to try to co-locate the active_secondary_market insight type with the others so that future efforts to add new artist metadata can live in & be tested together the same place in metaphysics. 