### PR TITLE
chore: add support for a `status` argument for sale artworks and tigthen up pagination

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12969,6 +12969,7 @@ type Sale implements Node {
     # List of sale artwork internal IDs to fetch
     internalIDs: [ID]
     last: Int
+    status: SaleArtworkStatus
   ): SaleArtworkConnection
   saleType: String
 
@@ -13289,6 +13290,11 @@ type SaleArtworksConnection implements ArtworkConnectionInterface {
   # Information to aid in pagination.
   pageInfo: PageInfo!
   totalCount: Int
+}
+
+enum SaleArtworkStatus {
+  CLOSED
+  OPEN
 }
 
 type SaleCascadingEndTime {

--- a/src/schema/v2/sale/__tests__/index.test.ts
+++ b/src/schema/v2/sale/__tests__/index.test.ts
@@ -259,6 +259,7 @@ describe("Sale type", () => {
             body: fill(Array(sale.eligible_sale_artworks_count), {
               id: "some-id",
             }),
+            headers: {},
           })
         ),
       }


### PR DESCRIPTION
This adds a new `status` argument that can be passed down when fetching sale artworks.

Additionally, the existing pagination used `sale.eigible_sale_artworks_count` as the 'total count' to construct pagination options. I decided to leave that alone (gremlins may be there?!), and add in the more typical 'total count for that particular API request from the "x-total-count" header' only when the `status` argument is present.