### PR TITLE
feat: start identity verification without authenticating

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -353,11 +353,6 @@ export default (accessToken, userID, opts) => {
     ),
     sendFeedbackLoader: gravityLoader("feedback", {}, { method: "POST" }),
     showLoader: gravityLoader((id) => `show/${id}`),
-    startIdentityVerificationLoader: gravityLoader(
-      (id) => `identity_verification/${id}/start`,
-      {},
-      { method: "PUT" }
-    ),
     suggestedArtistsLoader: gravityLoader(
       "me/suggested/artists",
       {},

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -14,9 +14,6 @@ export default (accessToken, userID, opts) => {
   )
 
   return {
-    identityVerificationLoader: gravityLoader(
-      (id) => `identity_verification/${id}`
-    ),
     identityVerificationsLoader: gravityLoader(
       "identity_verifications",
       {},

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1,11 +1,6 @@
 import factories from "../api"
 import trackedEntityLoaderFactory from "lib/loaders/loaders_with_authentication/tracked_entity"
 
-export type StartIdentityVerificationGravityOutput = {
-  identity_verification_id: string
-  identity_verification_flow_url: string
-}
-
 export default (accessToken, userID, opts) => {
   const gravityAccessTokenLoader = () => Promise.resolve(accessToken)
   const { gravityLoaderWithAuthenticationFactory } = factories(opts)

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -244,6 +244,11 @@ export default (opts) => {
       {},
       { headers: true }
     ),
+    startIdentityVerificationLoader: gravityLoader(
+      (id) => `identity_verification/${id}/start`,
+      {},
+      { method: "PUT" }
+    ),
     staticContentLoader: gravityLoader((id) => `page/${id}`),
     systemTimeLoader: gravityUncachedLoader("system/time", null),
     tagLoader: gravityLoader((id) => `tag/${id}`),

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -5,6 +5,11 @@ import gravity from "lib/apis/gravity"
 import { createBatchLoaders } from "../batchLoader"
 import { searchLoader } from "../searchLoader"
 
+export type StartIdentityVerificationGravityOutput = {
+  identity_verification_id: string
+  identity_verification_flow_url: string
+}
+
 export default (opts) => {
   const { gravityLoaderWithoutAuthenticationFactory } = factories(opts)
   const gravityLoader = gravityLoaderWithoutAuthenticationFactory

--- a/src/schema/v2/__tests__/startIdentityVerificationMutation.test.ts
+++ b/src/schema/v2/__tests__/startIdentityVerificationMutation.test.ts
@@ -1,5 +1,5 @@
-import { runQuery, runAuthenticatedQuery } from "schema/v2/test/utils"
-import { StartIdentityVerificationGravityOutput } from "lib/loaders/loaders_with_authentication/gravity"
+import { runQuery } from "schema/v2/test/utils"
+import { StartIdentityVerificationGravityOutput } from "lib/loaders/loaders_without_authentication/gravity"
 
 const mutation = `
 mutation {
@@ -22,12 +22,6 @@ mutation {
 `
 
 describe("starting an identity verification", () => {
-  it("requires an access token", async () => {
-    await expect(runQuery(mutation)).rejects.toThrow(
-      "You need to be signed in to perform this action"
-    )
-  })
-
   it("returns the given identity verification ID and flow URL from Gravity", async () => {
     const gravityResponse: StartIdentityVerificationGravityOutput = {
       identity_verification_id: "idv-123",
@@ -38,7 +32,7 @@ describe("starting an identity verification", () => {
       startIdentityVerificationLoader: () => Promise.resolve(gravityResponse),
     }
 
-    const response = await runAuthenticatedQuery(mutation, context)
+    const response = await runQuery(mutation, context)
 
     expect(response).toEqual({
       startIdentityVerification: {
@@ -61,7 +55,7 @@ describe("starting an identity verification", () => {
         ),
     }
 
-    const response = await runAuthenticatedQuery(mutation, errorRootValue)
+    const response = await runQuery(mutation, errorRootValue)
 
     expect(response).toEqual({
       startIdentityVerification: {
@@ -83,8 +77,8 @@ describe("starting an identity verification", () => {
       },
     }
 
-    await expect(
-      runAuthenticatedQuery(mutation, errorRootValue)
-    ).rejects.toThrow("ETIMEOUT service unreachable")
+    await expect(runQuery(mutation, errorRootValue)).rejects.toThrow(
+      "ETIMEOUT service unreachable"
+    )
   })
 })

--- a/src/schema/v2/startIdentityVerificationMutation.ts
+++ b/src/schema/v2/startIdentityVerificationMutation.ts
@@ -77,10 +77,6 @@ export const startIdentityVerificationMutation = mutationWithClientMutationId<
     { identityVerificationId },
     { startIdentityVerificationLoader }
   ) => {
-    if (!startIdentityVerificationLoader) {
-      throw new Error("You need to be signed in to perform this action")
-    }
-
     return startIdentityVerificationLoader(identityVerificationId).catch(
       (error) => {
         const formattedErr = formatGravityError(error)

--- a/src/schema/v2/startIdentityVerificationMutation.ts
+++ b/src/schema/v2/startIdentityVerificationMutation.ts
@@ -77,6 +77,8 @@ export const startIdentityVerificationMutation = mutationWithClientMutationId<
     { identityVerificationId },
     { startIdentityVerificationLoader }
   ) => {
+    if (!startIdentityVerificationLoader) return null
+
     return startIdentityVerificationLoader(identityVerificationId).catch(
       (error) => {
         const formattedErr = formatGravityError(error)

--- a/src/schema/v2/startIdentityVerificationMutation.ts
+++ b/src/schema/v2/startIdentityVerificationMutation.ts
@@ -77,8 +77,6 @@ export const startIdentityVerificationMutation = mutationWithClientMutationId<
     { identityVerificationId },
     { startIdentityVerificationLoader }
   ) => {
-    if (!startIdentityVerificationLoader) return null
-
     return startIdentityVerificationLoader(identityVerificationId).catch(
       (error) => {
         const formattedErr = formatGravityError(error)


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4203

Similar to https://github.com/artsy/metaphysics/pull/4117, this PR allows unauthenticated mutation to start identity verification. This is in support of [this ticket](https://artsyproduct.atlassian.net/browse/PLATFORM-4165) and this [Force PR](https://github.com/artsy/force/pull/10263) to allow unauthenticated users to start identity verification process. These changes should be merged before the Force changes.

* moves `startIdentityVerificationLoader` into `loaders_without_authentication`
* instead of returning an error when loader not available, return null
* update tests to reflect changes