### PR TITLE
chore: add support for a `status` argument to `artworksConnection` under `Sale` type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12923,6 +12923,7 @@ type Sale implements Node {
     exclude: [String]
     first: Int
     last: Int
+    status: SaleArtworkStatus
   ): ArtworkConnection
   associatedSale: Sale
   bidder: Bidder

--- a/src/schema/v2/sale/__tests__/index.test.ts
+++ b/src/schema/v2/sale/__tests__/index.test.ts
@@ -1215,6 +1215,7 @@ describe("Sale type", () => {
                 id: "some-id",
               },
             }),
+            headers: {},
           } as any),
       }
 


### PR DESCRIPTION
Doing [this](https://github.com/artsy/metaphysics/pull/4128) for a different field.

It turns out that the `saleArtworksConnection` under `Sale` is a different type than the root `saleArtworksConnection`, and does _not_ implement the `ArtworkConnectionInterface` needed to use Force's `ArtworkGrid` component.

So!

Decided to use `artworksConnection` field instead, which being an artworks connection already _does_ implement `ArtworkConnectionInterface`.

I probably should have used this field in the first place, but I'm not reverting https://github.com/artsy/metaphysics/pull/4128 as it's an improvement anyhow.