### PR TITLE
feat: expose created_at for IdentityVerification types.

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8758,6 +8758,15 @@ type HomePageSalesModule {
 }
 
 type IdentityVerification {
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See
+    # http://www.iana.org/time-zones,
+    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+
   # A globally unique ID.
   id: ID!
 
@@ -8882,6 +8891,14 @@ type IdentityVerificationOverride {
 }
 
 type IdentityVerificationScanReference {
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See
+    # http://www.iana.org/time-zones,
+    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
   extractedFirstName: String
   extractedIdFailReason: String
   extractedLastName: String

--- a/src/schema/v2/__tests__/identityVerification.test.ts
+++ b/src/schema/v2/__tests__/identityVerification.test.ts
@@ -15,6 +15,7 @@ describe("IdentityVerification type", () => {
       invitation_expires_at:
         "Mon Feb 10 2020 00:00:00 GMT-0500 (Eastern Standard Time)",
       user_id: "user1",
+      created_at: "",
     }
 
     const query = `
@@ -53,6 +54,7 @@ describe("IdentityVerification type", () => {
       invitation_expires_at:
         "Mon Feb 10 2020 00:00:00 GMT-0500 (Eastern Standard Time)",
       user_id: "user1",
+      created_at: "",
     }
 
     const gravityScanReference: IdentityVerificationScanReferenceGravityResponse = {
@@ -64,6 +66,7 @@ describe("IdentityVerification type", () => {
       finished_at: "",
       extracted_id_fail_reason: "",
       extracted_similarity_fail_reason: "",
+      created_at: "",
     }
 
     const gravityOverride: IdentityVerificationOverrideGravityResponse = {
@@ -122,6 +125,7 @@ describe("IdentityVerification type", () => {
       invitation_expires_at:
         "Mon Feb 10 2020 00:00:00 GMT-0500 (Eastern Standard Time)",
       user_id: "user1",
+      created_at: "",
     }
 
     const query = gql`

--- a/src/schema/v2/identityVerification.ts
+++ b/src/schema/v2/identityVerification.ts
@@ -115,6 +115,7 @@ export const IdentityVerificationScanReferenceType = new GraphQLObjectType<
       resolve: ({ extracted_similarity_fail_reason }) =>
         extracted_similarity_fail_reason,
     },
+    createdAt: date(({ created_at }) => created_at),
   },
 })
 
@@ -162,6 +163,7 @@ export const IdentityVerificationType = new GraphQLObjectType<
         return identityVerificationScanReferencesLoader(id)
       },
     },
+    createdAt: date(({ created_at }) => created_at),
   },
 })
 

--- a/src/schema/v2/identityVerification.ts
+++ b/src/schema/v2/identityVerification.ts
@@ -21,6 +21,7 @@ export type IdentityVerificationGravityResponse = {
   state: string
   invitation_expires_at: string
   user_id: string
+  created_at: string
 }
 
 export type IdentityVerificationOverrideGravityResponse = {
@@ -41,6 +42,7 @@ export type IdentityVerificationScanReferenceGravityResponse = {
   result: string
   extracted_id_fail_reason: string
   extracted_similarity_fail_reason: string
+  created_at: string
 }
 
 const dateFieldForVerificationExpiresAt: GraphQLFieldConfig<


### PR DESCRIPTION
https://artsy.slack.com/archives/CA8SANW3W/p1654889772383309

Expose `created_at` for these types:

- `IdentityVerification`
- `IdentityVerificationScanReference`

So the info can be displayed in Forque.