### PR TITLE
feat: add isLotsClosing to Sale, and also let an uncached loader be used to fetch sale artworks

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12936,6 +12936,9 @@ type Sale implements Node {
     after: String
     before: String
 
+    # When this is true and there is no access token present, allow a loader that caches to be used.
+    cached: Boolean = true
+
     # List of artwork IDs to exclude from the response (irrespective of size)
     exclude: [String]
     first: Int
@@ -13018,6 +13021,9 @@ type Sale implements Node {
   isGalleryAuction: Boolean
   isLiveOpen: Boolean
   isLotConditionsReportEnabled: Boolean
+
+  # True for a cascading-end-time enabled sale where lots have started closing
+  isLotsClosing: Boolean!
   isOpen: Boolean
   isPreliminary: Boolean
   isPreview: Boolean

--- a/src/lib/loaders/api/loader_without_cache_factory.ts
+++ b/src/lib/loaders/api/loader_without_cache_factory.ts
@@ -13,7 +13,7 @@ import { DataLoaderKey } from "./index"
 
 export const uncachedLoaderFactory = (
   api: (route: string, params) => Promise<any>,
-  _apiName: string
+  apiName: string
 ) => {
   const apiLoaderFactory = (path, options: any | null) => {
     // If you use gravity as the api here, then options will get interpreted as
@@ -25,7 +25,13 @@ export const uncachedLoaderFactory = (
             if (apiOptions) {
               throw new Error("A uncachedLoader does not accept API options.")
             }
-            return Promise.resolve(api(key, options).then((r) => r.body))
+
+            const reduceData = ({ body, headers }) =>
+              options && options.headers ? { body, headers } : body
+
+            return Promise.resolve(
+              api(key, apiName === "gravity" ? null : options).then(reduceData)
+            )
           })
         ),
       { cache: false, batch: false }

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -207,6 +207,10 @@ export default (opts) => {
       null
     ),
     saleArtworksFilterLoader: gravityLoader("filter/sale_artworks"),
+    uncachedSaleArtworksLoader: gravityUncachedLoader(
+      (id) => `sale/${id}/sale_artworks`,
+      { headers: true }
+    ),
     saleArtworksLoader: gravityLoader(
       (id) => `sale/${id}/sale_artworks`,
       {},


### PR DESCRIPTION
This adds `isLotsClosing` , which is an attribute that is nice to have since we will be forking based on this in the UI (when true, leads to a different exp. on the auction page), it's pretty self-explanatory + tests.

This also adds an uncached loader, which is opt-in to use, in order to fetch sale artworks. Logged-in users automatically use the same-named loader which skips the cache, this is more for logged-out users.

I added it as a new loader with opt-in functionality to still keep the benefit of MP throttling of backend requests for logged-out users, which _might_ be an over-optimization, but why not!

