### PR TITLE
fix: image uploading on the submission flow

### DIFF
--- a/src/schema/v2/asset_uploads/create_asset_request_mutation.ts
+++ b/src/schema/v2/asset_uploads/create_asset_request_mutation.ts
@@ -96,7 +96,7 @@ export default mutationWithClientMutationId<any, any, ResolverContext>({
   outputFields: {
     asset: {
       type: CredentialsType,
-      resolve: (asset) => asset,
+      resolve: (asset) => asset.body,
     },
   },
   mutateAndGetPayload: ({ name, acl }, { createNewGeminiAssetLoader }) => {

--- a/src/schema/v2/asset_uploads/finalize_asset_mutation.ts
+++ b/src/schema/v2/asset_uploads/finalize_asset_mutation.ts
@@ -2,7 +2,6 @@ import { GraphQLString, GraphQLNonNull, GraphQLObjectType } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 import GraphQLJSON from "graphql-type-json"
 import { ResolverContext } from "types/graphql"
-import { StaticPathLoader } from "lib/loaders/api/loader_interface"
 
 export const GeminiEntryType = new GraphQLObjectType<any, ResolverContext>({
   name: "GeminiEntry",
@@ -24,7 +23,7 @@ export default mutationWithClientMutationId<
     sourceBucket: string
     metadata: any
   },
-  StaticPathLoader<any> | null,
+  any,
   ResolverContext
 >({
   name: "CreateGeminiEntryForAsset",
@@ -68,7 +67,7 @@ export default mutationWithClientMutationId<
   outputFields: {
     asset: {
       type: GeminiEntryType,
-      resolve: (credentials) => credentials,
+      resolve: (credentials) => credentials.body,
     },
   },
   mutateAndGetPayload: (


### PR DESCRIPTION
This PR fixes image uploading on the submission flow. The error was caused after updating `loader_without_cache_factory` [here](https://github.com/artsy/metaphysics/pull/4141/files), updated loader returns an object that contains `body` field if the loader receives `headers`. Since [Gemini loaders use the headers](https://github.com/artsy/metaphysics/blob/0e7202ed5899e9dee465ddded88950138ee7e5f3/src/lib/loaders/loaders_without_authentication/gemini.ts#L16-L18) we got this error.

Integrity error - https://artsy.slack.com/archives/C02B4Q2TKGW/p1655107547276509