### PR TITLE
chore: Do not run relay compiler when pushing schema changes to Eigen

### DIFF
--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -44,7 +44,12 @@ async function updateSchemaFile({
         writeFileSync(repoDest, JSON.stringify(gql, null, 2))
       } else {
         execSync(`cp _schemaV2.graphql '${repoDest}'`)
-        execSync("./node_modules/.bin/relay-compiler", { cwd: repoDir })
+        // TODO: Run Relay 14 compiler for Eigen (the old compiler fails).
+        if (repo !== "eigen") {
+          execSync("./node_modules/.bin/relay-compiler", {
+            cwd: repoDir,
+          })
+        }
       }
       execSync(
         `[ ! -f ./node_modules/.bin/prettier ] || ./node_modules/.bin/prettier --write ${dest}`,


### PR DESCRIPTION
## Description

 Do not run relay compiler when pushing schema changes to Eigen for now. The compiler will fail when confronted with the new Relay config in Eigen.

[Slack Thread](https://artsy.slack.com/archives/C02BAQ5K7/p1655121973841039)