### PR TITLE
fix(admin): remove unnecessary global id

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -99,9 +99,6 @@ type Admin {
     # The sort order of the results
     sortBy: FeatureFlagsSortBy
   ): [FeatureFlag]
-
-  # A globally unique ID.
-  id: ID!
 }
 
 input AdminCreateFeatureFlagInput {

--- a/src/schema/v2/admin/index.ts
+++ b/src/schema/v2/admin/index.ts
@@ -1,13 +1,11 @@
 import { GraphQLFieldConfig, GraphQLObjectType } from "graphql"
 import { ResolverContext } from "types/graphql"
-import { GlobalIDField } from "../object_identification"
 import { FeatureFlags } from "./featureFlags"
 
 export const AdminField: GraphQLFieldConfig<void, ResolverContext> = {
   type: new GraphQLObjectType<any, ResolverContext>({
     name: "Admin",
     fields: {
-      id: GlobalIDField,
       featureFlags: FeatureFlags,
     },
   }),


### PR DESCRIPTION
No need to assign an `id` to admin field. 