### PR TITLE
fix(feature-flag): simplify create / update mutations

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -116,7 +116,6 @@ input AdminCreateFeatureFlagInput {
 
 type AdminCreateFeatureFlagPayload {
   clientMutationId: String
-  featureFlag: FeatureFlag
 
   # A list of feature flags
   featureFlags(
@@ -174,7 +173,12 @@ input AdminUpdateFeatureFlagInput {
 
 type AdminUpdateFeatureFlagPayload {
   clientMutationId: String
-  featureFlag: FeatureFlag
+
+  # A list of feature flags
+  featureFlags(
+    # The sort order of the results
+    sortBy: FeatureFlagsSortBy
+  ): [FeatureFlag]
 }
 
 # One item in an aggregation

--- a/src/schema/v2/admin/mutations/createFeatureFlagMutation.ts
+++ b/src/schema/v2/admin/mutations/createFeatureFlagMutation.ts
@@ -10,7 +10,7 @@ import {
 import { mutationWithClientMutationId } from "graphql-relay"
 import { omit } from "lodash"
 import { ResolverContext } from "types/graphql"
-import { FeatureFlags, FeatureFlagType } from "../featureFlags"
+import { FeatureFlags } from "../featureFlags"
 
 export const FeatureFlagInputFields = {
   type: {
@@ -127,10 +127,6 @@ export const createFeatureFlagMutation = mutationWithClientMutationId<
   inputFields: FeatureFlagInputFields,
   outputFields: {
     featureFlags: FeatureFlags,
-    featureFlag: {
-      type: FeatureFlagType,
-      resolve: (x) => x,
-    },
   },
   mutateAndGetPayload: async (
     args,

--- a/src/schema/v2/admin/mutations/updateFeatureFlagMutation.ts
+++ b/src/schema/v2/admin/mutations/updateFeatureFlagMutation.ts
@@ -1,7 +1,7 @@
 import { GraphQLString, GraphQLBoolean, GraphQLNonNull } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 import { ResolverContext } from "types/graphql"
-import { FeatureFlagType } from "../featureFlags"
+import { FeatureFlags } from "../featureFlags"
 
 export interface UpdateFeatureFlagInput {
   name: string
@@ -34,10 +34,7 @@ export const updateFeatureFlagMutation = mutationWithClientMutationId<
     },
   },
   outputFields: {
-    featureFlag: {
-      type: FeatureFlagType,
-      resolve: (x) => x,
-    },
+    featureFlags: FeatureFlags,
   },
   mutateAndGetPayload: async (args, { adminUpdateFeatureFlag }) => {
     if (!adminUpdateFeatureFlag) {


### PR DESCRIPTION
Since all we're doing is creating and updating main list, no need to return individual feature flags on create or edit mutation for now. 