### PR TITLE
feat: Add sorting by most recent insight update to My Collection artwork connection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2312,8 +2312,11 @@ union ArtworkMutationType =
 union ArtworkOrEditionSetType = Artwork | EditionSet
 
 type ArtworkPriceInsights {
+  annualLotsSold: Int
+  annualValueSoldCents: FormattedNumber
   artistId: String
   demandRank: Float
+  lastAuctionResultDate: String
   medium: String
 }
 
@@ -10002,8 +10005,8 @@ type Me implements Node {
     size: Int
     sort: MyCollectionArtworkSorts
 
-    # Sort by most recent insight updates.
-    sortedByMostRecentInsightUpdates: Boolean = false
+    # Sort by most recent price insight updates and filter out artworks without insights.
+    sortByMostRecentPriceInsightUpdates: Boolean = false
   ): MyCollectionConnection
 
   # Info about the current user's my-collection

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10006,7 +10006,7 @@ type Me implements Node {
     sort: MyCollectionArtworkSorts
 
     # Sort by most recent price insight updates and filter out artworks without insights.
-    sortByMostRecentPriceInsightUpdates: Boolean = false
+    sortByLastAuctionResultDate: Boolean = false
   ): MyCollectionConnection
 
   # Info about the current user's my-collection

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10001,6 +10001,9 @@ type Me implements Node {
     page: Int
     size: Int
     sort: MyCollectionArtworkSorts
+
+    # Sort by most recent insight updates.
+    sortedByMostRecentInsightUpdates: Boolean = false
   ): MyCollectionConnection
 
   # Info about the current user's my-collection

--- a/src/lib/loadBatchPriceInsights.ts
+++ b/src/lib/loadBatchPriceInsights.ts
@@ -32,6 +32,7 @@ export const loadBatchPriceInsights = async (
                 demandRank
                 annualLotsSold
                 annualValueSoldCents
+                lastAuctionResultDate
               }
             }
           }

--- a/src/lib/loadBatchPriceInsights.ts
+++ b/src/lib/loadBatchPriceInsights.ts
@@ -18,9 +18,7 @@ export const loadBatchPriceInsights = async (
   vortexGraphQLLoader: ({ query, variables }) => StaticPathLoader<any>
 ) => {
   try {
-    // TODO: Add lastAuctionResultDate
-
-    const vortexResult: any = await vortexGraphQLLoader({
+    const vortexResult = await vortexGraphQLLoader({
       query: gql`
         query MarketPriceInsightsBatchQuery($artistIDMediumTuples: [ArtistIdMediumTupleType!]!) {
           marketPriceInsightsBatch(input: $artistIDMediumTuples, first: ${MAX_MARKET_PRICE_INSIGHTS}) {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -73,6 +73,7 @@ import Meta, { artistNames } from "./meta"
 import { embed, isEmbeddedVideo, isTooBig, isTwoDimensional } from "./utilities"
 import gql from "lib/gql"
 import { extractNodes } from "../../../lib/helpers"
+import FormattedNumber from "../types/formatted_number"
 
 const has_price_range = (price) => {
   return new RegExp(/-/).test(price)
@@ -98,10 +99,19 @@ const ArtworkPriceInsightsType = new GraphQLObjectType<any, ResolverContext>({
     artistId: {
       type: GraphQLString,
     },
+    medium: {
+      type: GraphQLString,
+    },
     demandRank: {
       type: GraphQLFloat,
     },
-    medium: {
+    annualValueSoldCents: {
+      type: FormattedNumber,
+    },
+    annualLotsSold: {
+      type: GraphQLInt,
+    },
+    lastAuctionResultDate: {
       type: GraphQLString,
     },
   },

--- a/src/schema/v2/me/__tests__/myCollection.test.ts
+++ b/src/schema/v2/me/__tests__/myCollection.test.ts
@@ -49,27 +49,14 @@ describe("me.myCollection", () => {
         }
       }
     `
+
     const context: Partial<ResolverContext> = {
       meLoader: () =>
         Promise.resolve({
           id: "some-user-id",
         }),
 
-      collectionArtworksLoader: () =>
-        Promise.resolve({
-          body: [
-            {
-              _id: "58e3e54aa09a6708282022f6",
-              title: "some title",
-              artist: {
-                _id: "artist-id",
-              },
-            },
-          ],
-          headers: {
-            "x-total-count": "10",
-          },
-        }),
+      collectionArtworksLoader: async () => mockCollectionArtworksResponse,
       vortexGraphqlLoader,
       authenticatedArtistLoader: () =>
         Promise.resolve({
@@ -81,6 +68,64 @@ describe("me.myCollection", () => {
     expect(data.me.myCollectionConnection.edges[0].node.title).toBe(
       "some title"
     )
+  })
+
+  describe("when passing the argument sortByMostRecentPriceInsightUpdates", () => {
+    it("sort by most recent price insight updates and filter out artworks without insights.", async () => {
+      const query = gql`
+        {
+          me {
+            myCollectionConnection(
+              first: 10
+              sortByMostRecentPriceInsightUpdates: true
+            ) {
+              edges {
+                node {
+                  marketPriceInsights {
+                    lastAuctionResultDate
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const context: Partial<ResolverContext> = {
+        meLoader: () =>
+          Promise.resolve({
+            id: "some-user-id",
+          }),
+
+        collectionArtworksLoader: async () => mockCollectionArtworksResponse,
+        vortexGraphqlLoader: jest.fn(() => async () => mockVortexResponse),
+        authenticatedArtistLoader: () =>
+          Promise.resolve({
+            _id: "artist-id",
+          }),
+      }
+
+      const data = await runAuthenticatedQuery(query, context)
+
+      expect(data.me.myCollectionConnection.edges).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "node": Object {
+              "marketPriceInsights": Object {
+                "lastAuctionResultDate": "2023-06-15T00:00:00Z",
+              },
+            },
+          },
+          Object {
+            "node": Object {
+              "marketPriceInsights": Object {
+                "lastAuctionResultDate": "2022-06-15T00:00:00Z",
+              },
+            },
+          },
+        ]
+      `)
+    })
   })
 
   it("enriches artwork with consignment submissions data", async () => {
@@ -407,6 +452,30 @@ describe("me.myCollection", () => {
   })
 })
 
+const mockCollectionArtworksResponse = {
+  body: [
+    {
+      _id: "58e3e54aa09a6708282022f6",
+      title: "some title",
+      medium: "Print",
+      artist: {
+        _id: "artist-id",
+      },
+    },
+    {
+      _id: "58e3e54aa09a6708282022f6",
+      title: "some title",
+      medium: "Painting",
+      artist: {
+        _id: "artist-id",
+      },
+    },
+  ],
+  headers: {
+    "x-total-count": "10",
+  },
+}
+
 const mockVortexResponse = {
   data: {
     marketPriceInsightsBatch: {
@@ -416,7 +485,16 @@ const mockVortexResponse = {
           node: {
             artistId: "artist-id",
             demandRank: 0.64,
+            medium: "Print",
+            lastAuctionResultDate: "2022-06-15T00:00:00Z",
+          },
+        },
+        {
+          node: {
+            artistId: "artist-id",
+            demandRank: 0.64,
             medium: "Painting",
+            lastAuctionResultDate: "2023-06-15T00:00:00Z",
           },
         },
       ],

--- a/src/schema/v2/me/__tests__/myCollection.test.ts
+++ b/src/schema/v2/me/__tests__/myCollection.test.ts
@@ -70,14 +70,14 @@ describe("me.myCollection", () => {
     )
   })
 
-  describe("when passing the argument sortByMostRecentPriceInsightUpdates", () => {
+  describe("when passing the argument sortByLastAuctionResultDate", () => {
     it("sort by most recent price insight updates and filter out artworks without insights.", async () => {
       const query = gql`
         {
           me {
             myCollectionConnection(
               first: 10
-              sortByMostRecentPriceInsightUpdates: true
+              sortByLastAuctionResultDate: true
             ) {
               edges {
                 node {

--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -63,10 +63,11 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
       description:
         "Exclude artworks that have been purchased on Artsy and automatically added to the collection.",
     },
-    sortedByMostRecentInsightUpdates: {
+    sortByMostRecentPriceInsightUpdates: {
       type: GraphQLBoolean,
       defaultValue: false,
-      description: "Sort by most recent insight updates.",
+      description:
+        "Sort by most recent price insight updates and filter out artworks without insights.",
     },
   }),
   resolve: async (
@@ -82,7 +83,7 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
       return null
     }
 
-    const paginationArgs = options.sortedByMostRecentInsightUpdates
+    const paginationArgs = options.sortByMostRecentPriceInsightUpdates
       ? { size: 100 }
       : convertConnectionArgsToGravityArgs(options)
 
@@ -125,12 +126,11 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
 
       // Sort by most recent market price update if requested
 
-      if (options.sortedByMostRecentInsightUpdates) {
+      if (options.sortByMostRecentPriceInsightUpdates) {
         enrichedArtworks = sortBy(
           enrichedArtworks,
-          // TODO: sort by most recent insight update
-          (artwork) => -artwork.marketPriceInsights?.demandRank
-        )
+          (artwork) => -artwork.marketPriceInsights?.lastAuctionResultDate
+        ).filter((artwork) => artwork.marketPriceInsights)
       }
 
       // Return connection

--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -63,7 +63,7 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
       description:
         "Exclude artworks that have been purchased on Artsy and automatically added to the collection.",
     },
-    sortByMostRecentPriceInsightUpdates: {
+    sortByLastAuctionResultDate: {
       type: GraphQLBoolean,
       defaultValue: false,
       description:
@@ -83,7 +83,7 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
       return null
     }
 
-    const paginationArgs = options.sortByMostRecentPriceInsightUpdates
+    const paginationArgs = options.sortByLastAuctionResultDate
       ? { size: 100 }
       : convertConnectionArgsToGravityArgs(options)
 
@@ -126,7 +126,7 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
 
       // sort by most recent price insight updates and filter out artworks without insights if requested
 
-      if (options.sortByMostRecentPriceInsightUpdates) {
+      if (options.sortByLastAuctionResultDate) {
         enrichedArtworks = reverse(
           sortBy(
             enrichedArtworks.filter((artwork) => artwork.marketPriceInsights),

--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -9,7 +9,7 @@ import {
 import { connectionFromArray, cursorForObjectInConnection } from "graphql-relay"
 import { GravityMutationErrorType } from "lib/gravityErrorHandler"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
-import { compact, isEqual, sortBy, uniqWith } from "lodash"
+import { compact, isEqual, reverse, sortBy, uniqWith } from "lodash"
 import { pageable } from "relay-cursor-paging"
 import { ResolverContext } from "types/graphql"
 import { ArtworkType } from "../artwork"
@@ -124,13 +124,15 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
         vortexGraphqlLoader
       )
 
-      // Sort by most recent market price update if requested
+      // sort by most recent price insight updates and filter out artworks without insights if requested
 
       if (options.sortByMostRecentPriceInsightUpdates) {
-        enrichedArtworks = sortBy(
-          enrichedArtworks,
-          (artwork) => -artwork.marketPriceInsights?.lastAuctionResultDate
-        ).filter((artwork) => artwork.marketPriceInsights)
+        enrichedArtworks = reverse(
+          sortBy(
+            enrichedArtworks.filter((artwork) => artwork.marketPriceInsights),
+            (artwork) => artwork.marketPriceInsights?.lastAuctionResultDate
+          )
+        )
       }
 
       // Return connection

--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -9,7 +9,7 @@ import {
 import { connectionFromArray, cursorForObjectInConnection } from "graphql-relay"
 import { GravityMutationErrorType } from "lib/gravityErrorHandler"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
-import { compact, isEqual, uniqWith } from "lodash"
+import { compact, isEqual, sortBy, uniqWith } from "lodash"
 import { pageable } from "relay-cursor-paging"
 import { ResolverContext } from "types/graphql"
 import { ArtworkType } from "../artwork"
@@ -20,14 +20,7 @@ import {
 import { loadBatchPriceInsights } from "lib/loadBatchPriceInsights"
 import { loadSubmissions } from "./loadSubmissions"
 import { myCollectionInfoFields } from "./myCollectionInfo"
-
-type PriceInsight = {
-  artistId: string
-  demandRank: number
-  medium: string
-}
-
-type MarketPriceInsightsType = Record<string, Record<string, PriceInsight>>
+import { StaticPathLoader } from "lib/loaders/api/loader_interface"
 
 const MyCollectionConnection = connectionWithCursorInfo({
   name: "MyCollection",
@@ -70,6 +63,11 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
       description:
         "Exclude artworks that have been purchased on Artsy and automatically added to the collection.",
     },
+    sortedByMostRecentInsightUpdates: {
+      type: GraphQLBoolean,
+      defaultValue: false,
+      description: "Sort by most recent insight updates.",
+    },
   }),
   resolve: async (
     { id: userId },
@@ -84,25 +82,31 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
       return null
     }
 
-    const gravityOptions = Object.assign(
-      {
-        exclude_purchased_artworks: options.excludePurchasedArtworks,
-        private: true,
-        total_count: true,
-        user_id: userId,
-      },
-      convertConnectionArgsToGravityArgs(options)
-    )
+    const paginationArgs = options.sortedByMostRecentInsightUpdates
+      ? { size: 100 }
+      : convertConnectionArgsToGravityArgs(options)
+
+    const gravityOptions = {
+      exclude_purchased_artworks: options.excludePurchasedArtworks,
+      private: true,
+      total_count: true,
+      user_id: userId,
+      ...paginationArgs,
+    }
 
     // This can't also be used with the offset in gravity
     // @ts-expect-error FIXME: Make `page` is an optional param of `gravityOptions`
     delete gravityOptions.page
 
     try {
+      // Fetch artworks from Gravity
+
       const { body: artworks, headers } = await collectionArtworksLoader(
         "my-collection",
         gravityOptions
       )
+
+      // Fetch submission statues for artworks
 
       const submissionIds = compact([...artworks.map((c) => c.submission_id)])
       const submissions = await loadSubmissions(
@@ -110,25 +114,27 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
         convectionGraphQLLoader
       )
 
-      let artistIdMediumTuples = artworks.map((artwork: any) => ({
-        artistId: artwork.artist?._id,
-        medium: artwork.medium,
-      }))
+      enrichArtworksWithSubmissions(artworks, submissions)
 
-      // remove duplicates
-      artistIdMediumTuples = uniqWith(artistIdMediumTuples, isEqual)
+      // Fetch market price insights for artworks
 
-      const marketPriceInsights = await loadBatchPriceInsights(
-        artistIdMediumTuples,
+      let enrichedArtworks = await enrichArtworksWithPriceInsights(
+        artworks,
         vortexGraphqlLoader
       )
 
-      enrichArtworksWithSubmissions(artworks, submissions)
+      // Sort by most recent market price update if requested
 
-      const artworksWithInsights = enrichArtworksWithPriceInsights(
-        artworks,
-        marketPriceInsights
-      )
+      if (options.sortedByMostRecentInsightUpdates) {
+        enrichedArtworks = sortBy(
+          enrichedArtworks,
+          // TODO: sort by most recent insight update
+          (artwork) => -artwork.marketPriceInsights?.demandRank
+        )
+      }
+
+      // Return connection
+
       const { page, size, offset } = convertConnectionArgsToGravityArgs(options)
       const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 
@@ -137,7 +143,7 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
         offset,
         page,
         size,
-        body: artworksWithInsights,
+        body: enrichedArtworks,
         args: options,
       })
     } catch (error) {
@@ -250,10 +256,23 @@ const enrichArtworksWithSubmissions = async (
   }
 }
 
-const enrichArtworksWithPriceInsights = (
+const enrichArtworksWithPriceInsights = async (
   artworks: Array<any>,
-  marketPriceInsights: MarketPriceInsightsType
+  vortexGraphqlLoader: ({ query, variables }) => StaticPathLoader<any>
 ) => {
+  const artistIdMediumTuples = uniqWith(
+    artworks.map((artwork: any) => ({
+      artistId: artwork.artist?._id,
+      medium: artwork.medium,
+    })),
+    isEqual
+  )
+
+  const marketPriceInsights = await loadBatchPriceInsights(
+    artistIdMediumTuples,
+    vortexGraphqlLoader
+  )
+
   return artworks.map((artwork: any) => {
     const insights =
       marketPriceInsights[artwork.artist?._id]?.[artwork.medium] ?? null


### PR DESCRIPTION
Addresses [CX-2503]

🔴 Depends on https://github.com/artsy/vortex/pull/473

## Description

In order to get the most recent price insight updates for My Collection artworks, this PR adds the argument `sortedByMostRecentInsightUpdates` to `myCollectionConnection`. If this argument is provided, the resolver fetches all (limited to 100) artworks from the user's collection and sorts them by the most recent price insight update (which comes from **Vortex**).

```graphql
{ 
  me {
    myCollectionConnection(first: 18, sortByLastAuctionResultDate: true) {
      edges {
        node {
          medium
          artist {
            name
          }
          marketPriceInsights {
            demandRank
	    annualValueSoldCents
	    annualLotsSold
            lastAuctionResultDate
          }
        }
      }
    }
  }
}
```

[CX-2503]: https://artsyproduct.atlassian.net/browse/CX-2503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ