### PR TITLE
feat: add creator field to IdentityVerificationOverride type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9027,6 +9027,7 @@ type IdentityVerificationOverride {
     # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String
+  creator: User
 
   # A globally unique ID.
   id: ID!

--- a/src/schema/v2/__tests__/identityVerification.test.ts
+++ b/src/schema/v2/__tests__/identityVerification.test.ts
@@ -78,6 +78,10 @@ describe("IdentityVerification type", () => {
       created_at: "",
     }
 
+    const gravityUser = {
+      email: "user1@foo.com",
+    }
+
     const query = gql`
       {
         identityVerificationsConnection(userId: "user1", page: 1) {
@@ -89,6 +93,9 @@ describe("IdentityVerification type", () => {
               }
               overrides {
                 newState
+                creator {
+                  email
+                }
               }
             }
           }
@@ -108,13 +115,14 @@ describe("IdentityVerification type", () => {
           Promise.resolve([gravityScanReference]),
         identityVerificationOverridesLoader: () =>
           Promise.resolve([gravityOverride]),
+        userByIDLoader: () => Promise.resolve(gravityUser),
       }
     )
 
     expect(identityVerificationsConnection.edges[0].node).toEqual({
       state: "pending",
       scanReferences: [{ result: "failed" }],
-      overrides: [{ newState: "passed" }],
+      overrides: [{ newState: "passed", creator: { email: "user1@foo.com" } }],
     })
   })
 

--- a/src/schema/v2/identityVerification.ts
+++ b/src/schema/v2/identityVerification.ts
@@ -12,6 +12,7 @@ import {
   paginationResolver,
 } from "schema/v2/fields/pagination"
 import { InternalIDFields } from "schema/v2/object_identification"
+import { UserField } from "schema/v2/user"
 import dateField, { date, formatDate } from "./fields/date"
 import { CursorPageable, pageable } from "relay-cursor-paging"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
@@ -84,6 +85,13 @@ export const IdentityVerificationOverrideType = new GraphQLObjectType<
       resolve: ({ user_id }) => user_id,
     },
     createdAt: date(({ created_at }) => created_at),
+    creator: {
+      type: UserField.type,
+      resolve: async ({ user_id }, _args, { userByIDLoader }) => {
+        if (!userByIDLoader) return
+        return userByIDLoader(user_id).catch(() => null)
+      },
+    },
   },
 })
 


### PR DESCRIPTION
Supports https://artsyproduct.atlassian.net/browse/PLATFORM-4199

Forque's Identity Verification UI (being implemented) queries Metaphysics for Identity Verification Overrides. An Override has a `userID` field which contains the ID of the Admin user who created the Override. Forque can display this ID on the UI, but we [would like to](https://excalidraw.com/#room=f29b1c531adfce1cee60,o1Kx52ea3VotetP6dsal6A) display the Admin's email instead, as is [done currently](https://admin-staging.artsy.net/identity_verification/1d4e8ab9-8eff-4d94-a898-f6ee94dfae1f) by Torque (which queries Gravity directly).

So this PR allows Forque to retrieve the Admin's email via graphql.