### PR TITLE
feat: add creator email field to identity verification overrides type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8926,6 +8926,9 @@ type IdentityVerification {
     timezone: String
   ): String
 
+  # Email of the identity verification's owner
+  email: String
+
   # A globally unique ID.
   id: ID!
 
@@ -8939,6 +8942,9 @@ type IdentityVerification {
     # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String
+
+  # Name of the identity verification's owner
+  name: String
 
   # The overrides associated with an identity verification
   overrides: [IdentityVerificationOverride]

--- a/src/schema/v2/__tests__/identityVerification.test.ts
+++ b/src/schema/v2/__tests__/identityVerification.test.ts
@@ -16,6 +16,8 @@ describe("IdentityVerification type", () => {
         "Mon Feb 10 2020 00:00:00 GMT-0500 (Eastern Standard Time)",
       user_id: "user1",
       created_at: "",
+      name: "",
+      email: "",
     }
 
     const query = `
@@ -55,6 +57,8 @@ describe("IdentityVerification type", () => {
         "Mon Feb 10 2020 00:00:00 GMT-0500 (Eastern Standard Time)",
       user_id: "user1",
       created_at: "",
+      name: "",
+      email: "",
     }
 
     const gravityScanReference: IdentityVerificationScanReferenceGravityResponse = {
@@ -126,6 +130,8 @@ describe("IdentityVerification type", () => {
         "Mon Feb 10 2020 00:00:00 GMT-0500 (Eastern Standard Time)",
       user_id: "user1",
       created_at: "",
+      name: "",
+      email: "",
     }
 
     const query = gql`

--- a/src/schema/v2/identityVerification.ts
+++ b/src/schema/v2/identityVerification.ts
@@ -22,6 +22,8 @@ export type IdentityVerificationGravityResponse = {
   invitation_expires_at: string
   user_id: string
   created_at: string
+  name: string
+  email: string
 }
 
 export type IdentityVerificationOverrideGravityResponse = {
@@ -136,6 +138,16 @@ export const IdentityVerificationType = new GraphQLObjectType<
       description: "User ID of the identity verification's owner",
       type: GraphQLString,
       resolve: ({ user_id }) => user_id,
+    },
+    name: {
+      description: "Name of the identity verification's owner",
+      type: GraphQLString,
+      resolve: ({ name }) => name,
+    },
+    email: {
+      description: "Email of the identity verification's owner",
+      type: GraphQLString,
+      resolve: ({ email }) => email,
     },
     invitationExpiresAt: dateFieldForVerificationExpiresAt,
     overrides: {


### PR DESCRIPTION
Supports https://artsyproduct.atlassian.net/browse/PLATFORM-4199

Forque's List view [shall show](https://excalidraw.com/#room=f29b1c531adfce1cee60,o1Kx52ea3VotetP6dsal6A) `name` and `email` columns in top-level row.