### PR TITLE
feat(artist dupes): wire up artist merger mutation to Gravity

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10154,6 +10154,34 @@ type Me implements Node {
   ): LotConnection
 }
 
+type MergeArtistsFailure {
+  mutationError: GravityMutationError
+}
+
+input MergeArtistsMutationInput {
+  # The database ID of the "bad" artist record(s), which will be **discarded** after the merge
+  badIds: [String!]!
+  clientMutationId: String
+
+  # The database ID of the "good" artist record, which will be **kept** after the
+  # merge. Relevant fields and associations from the bad records will be merged into this one.
+  goodId: String!
+}
+
+type MergeArtistsMutationPayload {
+  clientMutationId: String
+
+  # On success: the "good" artist record, which was kept after the merge. Upon a
+  # successful merge this record may have been updated.
+  mergeArtistsResponseOrError: MergeArtistsResponseOrError
+}
+
+union MergeArtistsResponseOrError = MergeArtistsFailure | MergeArtistsSuccess
+
+type MergeArtistsSuccess {
+  artist: Artist
+}
+
 # A message in a conversation.
 type Message implements Node {
   attachments: [Attachment]
@@ -10505,6 +10533,9 @@ type Mutation {
   linkAuthentication(
     input: LinkAuthenticationMutationInput!
   ): LinkAuthenticationMutationPayload
+
+  # Merge multiple artist records in order to deduplicate artists
+  mergeArtists(input: MergeArtistsMutationInput!): MergeArtistsMutationPayload
 
   # Create an artwork in my collection
   myCollectionCreateArtwork(

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -30,6 +30,7 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    mergeArtistLoader: gravityLoader("artists/merge", {}, { method: "POST" }),
     artworkLoader: gravityLoader((id) => `artwork/${id}`),
     notificationPreferencesLoader: gravityLoader("notification_preferences"),
     updateNotificationPreferencesLoader: gravityLoader(

--- a/src/schema/v2/artists/__tests__/mergeArtistsMutation.test.ts
+++ b/src/schema/v2/artists/__tests__/mergeArtistsMutation.test.ts
@@ -1,0 +1,84 @@
+import gql from "lib/gql"
+import { runQuery, runAuthenticatedQuery } from "schema/v2/test/utils"
+
+const mutation = gql`
+  mutation {
+    mergeArtists(input: { goodId: "abc123", badIds: ["def456", "ghi789"] }) {
+      mergeArtistsResponseOrError {
+        __typename
+        ... on MergeArtistsSuccess {
+          artist {
+            internalID
+            slug
+          }
+        }
+        ... on MergeArtistsFailure {
+          mutationError {
+            message
+          }
+        }
+      }
+    }
+  }
+`
+
+describe("performing an artist merger", () => {
+  it("requires an access token", async () => {
+    await expect(runQuery(mutation)).rejects.toThrow(
+      "You need to be signed in to perform this action"
+    )
+  })
+
+  describe("upon success", () => {
+    it("returns the merged artist record", async () => {
+      const gravityResponse = {
+        _id: "abc123",
+        id: "some-artist",
+      }
+
+      const context = {
+        mergeArtistLoader: () => Promise.resolve(gravityResponse),
+      }
+
+      const response = await runAuthenticatedQuery(mutation, context)
+
+      expect(response).toEqual({
+        mergeArtists: {
+          mergeArtistsResponseOrError: {
+            __typename: "MergeArtistsSuccess",
+            artist: {
+              internalID: "abc123",
+              slug: "some-artist",
+            },
+          },
+        },
+      })
+    })
+  })
+
+  describe("upon error", () => {
+    it("returns the Gravity error message", async () => {
+      const context = {
+        mergeArtistLoader: () =>
+          Promise.reject(
+            new Error(
+              `https://stagingapi.artsy.net/api/v1/artists/merge - {"type":"error","message":"Artist(s) Not Found"}`
+            )
+          ),
+      }
+
+      const response = await runAuthenticatedQuery(mutation, context)
+
+      expect(response).toEqual({
+        mergeArtists: {
+          mergeArtistsResponseOrError: {
+            __typename: "MergeArtistsFailure",
+            mutationError: {
+              message: "Artist(s) Not Found",
+            },
+          },
+        },
+      })
+    })
+  })
+})

--- a/src/schema/v2/artists/mergeArtistsMutation.ts
+++ b/src/schema/v2/artists/mergeArtistsMutation.ts
@@ -1,0 +1,95 @@
+import {
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { ArtistType } from "../artist"
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "MergeArtistsSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    artist: {
+      type: ArtistType,
+      resolve: (artist) => artist,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "MergeArtistsFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "MergeArtistsResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const mergeArtistsMutation = mutationWithClientMutationId<
+  { goodId: string; badIds: string[] },
+  unknown,
+  ResolverContext
+>({
+  name: "MergeArtistsMutation",
+  description: "Merge multiple artist records in order to deduplicate artists",
+  inputFields: {
+    goodId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description:
+        'The database ID of the "good" artist record, which will be **kept** after the merge. Relevant fields and associations from the bad records will be merged into this one.',
+    },
+    badIds: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(GraphQLString))
+      ),
+      description:
+        'The database ID of the "bad" artist record(s), which will be **discarded** after the merge',
+    },
+  },
+  outputFields: {
+    mergeArtistsResponseOrError: {
+      type: ResponseOrErrorType,
+      description:
+        'On success: the "good" artist record, which was kept after the merge. Upon a successful merge this record may have been updated.',
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (input, context) => {
+    const { goodId, badIds } = input
+    const { mergeArtistLoader } = context
+
+    if (!mergeArtistLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const result = await mergeArtistLoader({
+        good_id: goodId,
+        bad_ids: badIds,
+      })
+      return result
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -13,6 +13,7 @@ import Articles from "./articles"
 import ArticlesConnection from "./articlesConnection"
 import Artist from "./artist"
 import Artists, { artistsConnection } from "./artists"
+import { mergeArtistsMutation } from "./artists/mergeArtistsMutation"
 import Artwork from "./artwork"
 import { ArtistArtworkGridType } from "./artwork/artworkContextGrids/ArtistArtworkGrid"
 import { AuctionArtworkGridType } from "./artwork/artworkContextGrids/AuctionArtworkGrid"
@@ -281,6 +282,7 @@ export default new GraphQLSchema({
       followProfile: FollowProfile,
       followShow: FollowShow,
       linkAuthentication: linkAuthenticationMutation,
+      mergeArtists: mergeArtistsMutation,
       myCollectionCreateArtwork: myCollectionCreateArtworkMutation,
       myCollectionUpdateArtwork: myCollectionUpdateArtworkMutation,
       myCollectionDeleteArtwork: myCollectionDeleteArtworkMutation,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4225

This adds a `mergeArtist` mutation that sends the artist merger request up to Gravity and returns the response

- In the success case, this will be the artist record that was retained and updated

- In the error case, we implement the typical [data-or-errors union pattern](https://artsy.github.io/blog/2018/10/19/where-art-thou-my-error/). (For this to work, we will require a tweak to the `api/v1/artists/merge` endpoint in Gravity, which is in https://github.com/artsy/gravity/pull/15454)

## On success

<img width="2737" alt="Screen Shot 2022-06-15 at 3 41 36 PM" src="https://user-images.githubusercontent.com/140521/173912216-8e596dd2-6d81-48be-aa99-5dcf61872d01.png">


## On error

<img width="2737" alt="Screen Shot 2022-06-15 at 3 42 58 PM" src="https://user-images.githubusercontent.com/140521/173912211-00d2853b-238b-4d4e-a0e4-d0bc90f34756.png">
