### PR TITLE
feat(artist-insights): make metaphysics single source of truth for querying artist insights

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1409,7 +1409,10 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   image: Image
   imageUrl: String
   initials(length: Int = 3): String
-  insights: [ArtistInsight!]!
+  insights(
+    # The specific insights to return.
+    kind: [ArtistInsightKind] = []
+  ): [ArtistInsight!]!
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1409,7 +1409,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   image: Image
   imageUrl: String
   initials(length: Int = 3): String
-  insights: [ArtistInsight]
+  insights: [ArtistInsight!]!
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
@@ -1591,14 +1591,28 @@ type ArtistHighlights {
 }
 
 type ArtistInsight {
+  description: String
+
   # List of entities relevant to the insight.
   entities: [String!]!
+
+  # The type of insight.
+  kind: ArtistInsightKind
 
   # Label to use when displaying the insight.
   label: String!
 
   # The type of insight.
-  type: String!
+  type: String! @deprecated(reason: "Use `kind` instead.")
+}
+
+enum ArtistInsightKind {
+  ACTIVE_SECONDARY_MARKET
+  BIENNIAL
+  COLLECTED
+  GROUP_SHOW
+  REVIEWED
+  SOLO_SHOW
 }
 
 type ArtistMeta {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1411,7 +1411,14 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   initials(length: Int = 3): String
   insights(
     # The specific insights to return.
-    kind: [ArtistInsightKind] = []
+    kind: [ArtistInsightKind] = [
+      SOLO_SHOW
+      GROUP_SHOW
+      COLLECTED
+      REVIEWED
+      BIENNIAL
+      ACTIVE_SECONDARY_MARKET
+    ]
   ): [ArtistInsight!]!
 
   # A type-specific ID likely used as a database ID.

--- a/src/schema/v2/artist/__tests__/insights.test.ts
+++ b/src/schema/v2/artist/__tests__/insights.test.ts
@@ -105,7 +105,7 @@ describe("ArtistInsights type", () => {
         },
         {
           type: "ACTIVE_SECONDARY_MARKET",
-          label: "Recent auction results in the Artsy Price Database",
+          label: "Active Secondary Market",
           entities: [],
         },
       ])
@@ -139,7 +139,7 @@ describe("ArtistInsights type", () => {
     })
   })
 
-  it("does not build an insight if boolean value is false", () => {
+  it("does not build an insight if active_secondary_market is false", () => {
     artist.active_secondary_market = false
 
     const query = `

--- a/src/schema/v2/artist/insights.ts
+++ b/src/schema/v2/artist/insights.ts
@@ -9,89 +9,55 @@ import {
 } from "graphql"
 import { ResolverContext } from "types/graphql"
 
-export const ArtistInsightType = new GraphQLEnumType({
-  name: "ArtistInsightType",
-  values: {
-    SOLO_SHOW: {
-      value: "Solo show at a major institution",
-    },
-    GROUP_SHOW: {
-      value: "Group show at a major institution",
-    },
-    COLLECTED: {
-      value: "Collected by a major institution",
-    },
-    REVIEWED: {
-      value: "Reviewed by a major art publication",
-    },
-    BIENNIAL: {
-      value: "Included in a major biennial",
-    },
-    ACTIVE_SECONDARY_MARKET: {
-      value: "Recent auction results in the Artsy Price Database",
-    },
-  },
-})
+const ARTIST_INSIGHT_KINDS = {
+  SOLO_SHOW: { value: "SOLO_SHOW" },
+  GROUP_SHOW: { value: "GROUP_SHOW" },
+  COLLECTED: { value: "COLLECTED" },
+  REVIEWED: { value: "REVIEWED" },
+  BIENNIAL: { value: "BIENNIAL" },
+  ACTIVE_SECONDARY_MARKET: { value: "ACTIVE_SECONDARY_MARKET" },
+} as const
 
-const ARTIST_INSIGHT_TYPES = {
-  solo_show_institutions: { type: ArtistInsightType.getValue("SOLO_SHOW") },
-  group_show_institutions: { type: ArtistInsightType.getValue("GROUP_SHOW") },
-  collections: {
-    type: ArtistInsightType.getValue("COLLECTED"),
+type ArtistInsightKind = keyof typeof ARTIST_INSIGHT_KINDS
+
+const ARTIST_INSIGHT_MAPPING = {
+  SOLO_SHOW: {
+    label: "Solo show at a major institution",
+    description: null,
+    fieldName: "solo_show_institutions",
+    delimiter: "|",
+  },
+  GROUP_SHOW: {
+    label: "Group show at a major institution",
+    description: null,
+    fieldName: "group_show_institutions",
+    delimiter: "|",
+  },
+  COLLECTED: {
+    label: "Collected by a major institution",
+    description: null,
+    fieldName: "collections",
     delimiter: "\n",
   },
-  review_sources: { type: ArtistInsightType.getValue("REVIEWED") },
-  biennials: { type: ArtistInsightType.getValue("BIENNIAL") },
-  active_secondary_market: {
-    type: ArtistInsightType.getValue("ACTIVE_SECONDARY_MARKET"),
+  REVIEWED: {
+    label: "Reviewed by a major art publication",
+    description: null,
+    fieldName: "review_sources",
+    delimiter: "|",
   },
-}
-
-const buildInsights = (artist) => {
-  const splitEntities = (
-    entitiesString: string,
-    delimiter: string
-  ): Array<string> => {
-    return entitiesString.split(delimiter).map((entity) => {
-      return entity.trim()
-    })
-  }
-
-  return compact(
-    Object.keys(ARTIST_INSIGHT_TYPES).map((key) => {
-      const value = artist[key]
-
-      if (!value) {
-        return
-      }
-
-      const mapping = ARTIST_INSIGHT_TYPES[key]
-
-      switch (typeof value) {
-        case "string":
-          const trimmed = value.trim()
-
-          if (!trimmed) return null
-
-          return {
-            entities: splitEntities(trimmed, mapping.delimiter || "|"),
-            label: mapping.type.value,
-            type: mapping.type.name,
-          }
-
-        case "boolean":
-          return {
-            entities: [],
-            label: mapping.type.value,
-            type: mapping.type.name,
-          }
-
-        default:
-          return null
-      }
-    })
-  )
-}
+  BIENNIAL: {
+    label: "Included in a major biennial",
+    description: null,
+    fieldName: "biennials",
+    delimiter: "|",
+  },
+  ACTIVE_SECONDARY_MARKET: {
+    label: "Active Secondary Market",
+    description: "Recent auction results in the Artsy Price Database",
+    fieldName: "active_secondary_market",
+    delimiter: null,
+  },
+} as const
 
 const ArtistInsight = new GraphQLObjectType<any, ResolverContext>({
   name: "ArtistInsight",
@@ -99,21 +65,72 @@ const ArtistInsight = new GraphQLObjectType<any, ResolverContext>({
     type: {
       type: new GraphQLNonNull(GraphQLString),
       description: "The type of insight.",
+      deprecationReason: "Use `kind` instead.",
     },
     label: {
       type: new GraphQLNonNull(GraphQLString),
       description: "Label to use when displaying the insight.",
     },
+    description: {
+      type: GraphQLString,
+    },
     entities: {
       type: new GraphQLNonNull(GraphQLList(new GraphQLNonNull(GraphQLString))),
       description: "List of entities relevant to the insight.",
+    },
+    kind: {
+      type: new GraphQLEnumType({
+        name: "ArtistInsightKind",
+        values: ARTIST_INSIGHT_KINDS,
+      }),
+      description: "The type of insight.",
     },
   },
 })
 
 export const ArtistInsights: GraphQLFieldConfig<any, ResolverContext> = {
-  type: new GraphQLList(ArtistInsight),
+  type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ArtistInsight))),
   resolve: (artist) => {
-    return buildInsights(artist)
+    return compact(
+      (Object.entries(ARTIST_INSIGHT_MAPPING) as [
+        ArtistInsightKind,
+        typeof ARTIST_INSIGHT_MAPPING[ArtistInsightKind]
+      ][]).map(([kind, { label, description, fieldName, delimiter }]) => {
+        const value = artist[fieldName]
+
+        if (!value) {
+          return
+        }
+
+        switch (typeof value) {
+          case "string":
+            const trimmed = value.trim()
+
+            if (!trimmed) return null
+
+            return {
+              entities: trimmed
+                .split(delimiter ?? "|")
+                .map((entity) => entity.trim()),
+              label,
+              type: kind,
+              kind,
+              description,
+            }
+
+          case "boolean":
+            return {
+              entities: [],
+              label,
+              type: kind,
+              kind,
+              description,
+            }
+
+          default:
+            return null
+        }
+      })
+    )
   },
 }

--- a/src/schema/v2/artist/insights.ts
+++ b/src/schema/v2/artist/insights.ts
@@ -99,7 +99,7 @@ export const ArtistInsights: GraphQLFieldConfig<any, ResolverContext> = {
     kind: {
       type: new GraphQLList(ArtistInsightKind),
       description: "The specific insights to return.",
-      defaultValue: Object.values(ARTIST_INSIGHT_KINDS),
+      defaultValue: Object.keys(ARTIST_INSIGHT_KINDS),
     },
   },
   resolve: (artist, { kind }) => {


### PR DESCRIPTION
The type of PR is: feat (plus a little bit of refactoring)

The goal of this PR is to do some refactoring to the Artist insights schema design to allow for querying on the frontend for insights based on the type that is needed. Overall, we wanna make Force as ignorant as possible of the data pipeline. 

Here's an example of a query for insights based on the new setup: 
<img width="1161" alt="Screen Shot 2022-06-15 at 2 09 31 PM" src="https://user-images.githubusercontent.com/23108927/173906194-9b972595-c18e-4d19-95fe-1fc99e17dcb7.png">

