### PR TITLE
feat: Add averageSalePriceDisplayText to artwork market price insights

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2339,6 +2339,10 @@ type ArtworkPriceInsights {
   annualLotsSold: Int
   annualValueSoldCents: FormattedNumber
   artistId: String
+  averageSalePriceDisplayText(
+    # Passes in to numeral, such as `'0.00'`
+    format: String = ""
+  ): String
   demandRank: Float
   lastAuctionResultDate: String
   medium: String

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -111,6 +111,27 @@ const ArtworkPriceInsightsType = new GraphQLObjectType<any, ResolverContext>({
     annualLotsSold: {
       type: GraphQLInt,
     },
+    averageSalePriceDisplayText: {
+      type: GraphQLString,
+      args: {
+        format: {
+          type: GraphQLString,
+          description: "Passes in to numeral, such as `'0.00'`",
+          defaultValue: "",
+        },
+      },
+      resolve: ({ annualLotsSold, annualValueSoldCents }, { format }) => {
+        if (!annualLotsSold || !annualValueSoldCents) {
+          return null
+        }
+
+        return priceDisplayText(
+          Math.floor((annualValueSoldCents as number) / 100 / annualLotsSold),
+          "USD",
+          format
+        )
+      },
+    },
     lastAuctionResultDate: {
       type: GraphQLString,
     },

--- a/src/schema/v2/me/__tests__/myCollection.test.ts
+++ b/src/schema/v2/me/__tests__/myCollection.test.ts
@@ -339,6 +339,7 @@ describe("me.myCollection", () => {
                 }
                 marketPriceInsights {
                   demandRank
+                  averageSalePriceDisplayText
                 }
               }
             }
@@ -378,14 +379,30 @@ describe("me.myCollection", () => {
 
     const data = await runAuthenticatedQuery(query, context)
 
-    expect(data.me.myCollectionConnection.edges[0].node.title).toBe(
-      "some title"
-    )
-
-    expect(
-      data.me.myCollectionConnection.edges[0].node.marketPriceInsights
-        .demandRank
-    ).toBe(0.64)
+    expect(data).toMatchInlineSnapshot(`
+      Object {
+        "me": Object {
+          "myCollectionConnection": Object {
+            "edges": Array [
+              Object {
+                "node": Object {
+                  "artist": Object {
+                    "internalID": "artist-id",
+                  },
+                  "internalID": "artwork_id_with_market_price_insights",
+                  "marketPriceInsights": Object {
+                    "averageSalePriceDisplayText": "US$21,764",
+                    "demandRank": 0.64,
+                  },
+                  "medium": "Painting",
+                  "title": "some title",
+                },
+              },
+            ],
+          },
+        },
+      }
+    `)
   })
 
   it("ignores collection not found errors and returns an empty array", async () => {
@@ -486,6 +503,8 @@ const mockVortexResponse = {
             artistId: "artist-id",
             demandRank: 0.64,
             medium: "Print",
+            annualLotsSold: 25,
+            annualValueSoldCents: 577662200012,
             lastAuctionResultDate: "2022-06-15T00:00:00Z",
           },
         },
@@ -494,6 +513,8 @@ const mockVortexResponse = {
             artistId: "artist-id",
             demandRank: 0.64,
             medium: "Painting",
+            annualLotsSold: 10,
+            annualValueSoldCents: 2176421231,
             lastAuctionResultDate: "2023-06-15T00:00:00Z",
           },
         },


### PR DESCRIPTION
## Description

This PR adds `averageSalePriceDisplayText` (display price text in USD) to artwork market price insights.


### Query

```graphql
{
  me {
    myCollectionConnection(first: 10) {
      edges {
        node {
          medium
          artist {
            name
          }
          marketPriceInsights {
            averageSalePriceDisplayText
          }
        }
      }
    }
  }
}
```

### Response

```
{
  "data": {
    "me": {
      "myCollectionConnection": {
        "edges": [
          {
            "node": {
              "marketPriceInsights": {
                "averageSalePriceDisplayText": "US$1,019"
              }
            }
          }
        ]
      }
    }
  }
}
```