### PR TITLE
fix: Return uniq artworks when passing sortByLastAuctionResultDate to My Collection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10127,7 +10127,7 @@ type Me implements Node {
     sort: MyCollectionArtworkSorts
 
     # Sort by most recent price insight updates, filter out artworks without
-    # insights and return artworks uniq by medium/artist.
+    # insights and return artworks uniq by artist & medium.
     sortByLastAuctionResultDate: Boolean = false
   ): MyCollectionConnection
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10126,7 +10126,8 @@ type Me implements Node {
     size: Int
     sort: MyCollectionArtworkSorts
 
-    # Sort by most recent price insight updates and filter out artworks without insights.
+    # Sort by most recent price insight updates, filter out artworks without
+    # insights and return artworks uniq by medium/artist.
     sortByLastAuctionResultDate: Boolean = false
   ): MyCollectionConnection
 

--- a/src/schema/v2/me/__tests__/myCollection.test.ts
+++ b/src/schema/v2/me/__tests__/myCollection.test.ts
@@ -480,6 +480,14 @@ const mockCollectionArtworksResponse = {
       },
     },
     {
+      _id: "58e3e52aa09a6708282022f6",
+      title: "another title",
+      medium: "Print",
+      artist: {
+        _id: "artist-id",
+      },
+    },
+    {
       _id: "58e3e54aa09a6708282022f6",
       title: "some title",
       medium: "Painting",

--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -67,7 +67,7 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
       type: GraphQLBoolean,
       defaultValue: false,
       description:
-        "Sort by most recent price insight updates, filter out artworks without insights and return artworks uniq by medium/artist.",
+        "Sort by most recent price insight updates, filter out artworks without insights and return artworks uniq by artist & medium.",
     },
   }),
   resolve: async (

--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -67,7 +67,7 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
       type: GraphQLBoolean,
       defaultValue: false,
       description:
-        "Sort by most recent price insight updates and filter out artworks without insights.",
+        "Sort by most recent price insight updates, filter out artworks without insights and return artworks uniq by medium/artist.",
     },
   }),
   resolve: async (
@@ -127,11 +127,18 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
       // sort by most recent price insight updates and filter out artworks without insights if requested
 
       if (options.sortByLastAuctionResultDate) {
+        enrichedArtworks = enrichedArtworks.filter(
+          (artwork) => artwork.marketPriceInsights
+        )
         enrichedArtworks = reverse(
           sortBy(
-            enrichedArtworks.filter((artwork) => artwork.marketPriceInsights),
+            enrichedArtworks,
             (artwork) => artwork.marketPriceInsights?.lastAuctionResultDate
           )
+        )
+        enrichedArtworks = uniqWith(
+          enrichedArtworks,
+          (a, b) => a.artist._id === b.artist._id && a.medium === b.medium
         )
       }
 


### PR DESCRIPTION
## Description

Return uniq artworks when passing `sortByLastAuctionResultDate` to the My Collection artwork connection.

[Slack Thread](https://artsy.slack.com/archives/C01B2P6LJUU/p1655801368386259)