### PR TITLE
feat: support name param in sendIdentityVerificationEmailMutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14169,6 +14169,9 @@ input SendIdentityVerificationEmailMutationInput {
   # The email for the user undergoing identity verificaiton
   email: String
 
+  # The name to be used for the user undergoing identity verification
+  name: String
+
   # The user Id for the user undergoing identity verificaiton
   userID: String
 }

--- a/src/schema/v2/me/sendIdentityVerficationEmailMutation.ts
+++ b/src/schema/v2/me/sendIdentityVerficationEmailMutation.ts
@@ -98,6 +98,11 @@ export const sendIdentityVerificationEmailMutation = mutationWithClientMutationI
       description: "The email for the user undergoing identity verificaiton",
       type: GraphQLString,
     },
+    name: {
+      description:
+        "The name to be used for the user undergoing identity verification",
+      type: GraphQLString,
+    },
   },
   outputFields: {
     confirmationOrError: {
@@ -106,14 +111,14 @@ export const sendIdentityVerificationEmailMutation = mutationWithClientMutationI
     },
   },
   mutateAndGetPayload: (
-    { userID, email },
+    { userID, email, name },
     { sendIdentityVerificationEmailLoader }
   ) => {
     if (!sendIdentityVerificationEmailLoader) {
       throw new Error("You need to be signed in to perform this action")
     }
 
-    return sendIdentityVerificationEmailLoader({ user_id: userID, email })
+    return sendIdentityVerificationEmailLoader({ user_id: userID, email, name })
       .then((result) => result)
       .catch((error) => {
         const formattedErr = formatGravityError(error)


### PR DESCRIPTION
This PR extenda MP to send the `name` param to the `v1/identity_verificaiton` endpoint. (https://artsy.slack.com/archives/CTZA5NBB9/p1655488507521359)). 

### Considerations
Where and `IdentityVerificaiton` is initiated with `name` and `email` params , the `IdentityVerificaiton` record will default the name param  instead of the name associated with the `User` record (relevant slack [thread](https://artsy.slack.com/archives/CTZA5NBB9/p1655488507521359) with trust and safety).

### Related PRs
- #4124
- https://github.com/artsy/gravity/pull/15452


