### PR TITLE
fix: (PX-5094) account for artsy shipping logic in onlyShipsDomestically function

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -2574,50 +2574,204 @@ describe("Artwork type", () => {
         }
       }
     `
-    it("is true when domestic_shipping_fee_cents is present and international_shipping_fee_cents is null", () => {
-      artwork.domestic_shipping_fee_cents = 1000
-      artwork.international_shipping_fee_cents = null
-      return runQuery(query, context).then((data) => {
-        expect(data).toEqual({
-          artwork: {
-            onlyShipsDomestically: true,
-          },
+    describe("when artsy domestic shipping enabled", () => {
+      beforeEach(() => {
+        artwork.process_with_artsy_shipping_domestic = true
+      })
+
+      describe("when domestic_shipping_fee_cents and international_shipping_fee is null", () => {
+        beforeEach(() => {
+          artwork.domestic_shipping_fee_cents = null
+          artwork.international_shipping_fee_cents = null
+        })
+
+        it("returns true", () => {
+          return runQuery(query, context).then((data) => {
+            expect(data).toEqual({
+              artwork: {
+                onlyShipsDomestically: true,
+              },
+            })
+          })
+        })
+      })
+
+      describe("when domestic_shipping_fee_cents is present", () => {
+        beforeEach(() => {
+          artwork.domestic_shipping_fee_cents = 100
+          artwork.international_shipping_fee_cents = null
+        })
+
+        it("returns true", () => {
+          return runQuery(query, context).then((data) => {
+            expect(data).toEqual({
+              artwork: {
+                onlyShipsDomestically: true,
+              },
+            })
+          })
+        })
+      })
+
+      describe("when only international_shipping_fee_cents is present", () => {
+        beforeEach(() => {
+          artwork.domestic_shipping_fee_cents = null
+          artwork.international_shipping_fee_cents = 100
+        })
+
+        it("returns false", () => {
+          return runQuery(query, context).then((data) => {
+            expect(data).toEqual({
+              artwork: {
+                onlyShipsDomestically: false,
+              },
+            })
+          })
+        })
+
+        describe("when only artsy international shipping is present", () => {
+          beforeEach(() => {
+            artwork.domestic_shipping_fee_cents = null
+            artwork.international_shipping_fee_cents = null
+            artwork.artsy_shipping_international = true
+          })
+
+          it("returns false", () => {
+            return runQuery(query, context).then((data) => {
+              expect(data).toEqual({
+                artwork: {
+                  onlyShipsDomestically: false,
+                },
+              })
+            })
+          })
+        })
+
+        describe("when free shipping worldwide", () => {
+          beforeEach(() => {
+            artwork.domestic_shipping_fee_cents = 0
+            artwork.international_shipping_fee_cents = 0
+          })
+
+          it("returns false", () => {
+            return runQuery(query, context).then((data) => {
+              expect(data).toEqual({
+                artwork: {
+                  onlyShipsDomestically: false,
+                },
+              })
+            })
+          })
         })
       })
     })
 
-    it("is false when work ships free internationally", () => {
-      artwork.domestic_shipping_fee_cents = 1000
-      artwork.international_shipping_fee_cents = 0
-      return runQuery(query, context).then((data) => {
-        expect(data).toEqual({
-          artwork: {
-            onlyShipsDomestically: false,
-          },
+    describe("when artsy domestic shipping disabled", () => {
+      beforeEach(() => {
+        artwork.process_with_artsy_shipping_domestic = false
+        artwork.artsy_shipping_international = false
+      })
+
+      describe("when domestic_shipping_fee_cents and international_shipping_fee is null", () => {
+        beforeEach(() => {
+          artwork.domestic_shipping_fee_cents = null
+          artwork.international_shipping_fee_cents = null
+        })
+
+        it("returns false", () => {
+          return runQuery(query, context).then((data) => {
+            expect(data).toEqual({
+              artwork: {
+                onlyShipsDomestically: false,
+              },
+            })
+          })
         })
       })
-    })
 
-    it("is false when work ships free worldwide", () => {
-      artwork.domestic_shipping_fee_cents = 0
-      artwork.international_shipping_fee_cents = 0
-      return runQuery(query, context).then((data) => {
-        expect(data).toEqual({
-          artwork: {
-            onlyShipsDomestically: false,
-          },
+      describe("when domestic_shipping_fee_cents is present", () => {
+        beforeEach(() => {
+          artwork.domestic_shipping_fee_cents = 100
+          artwork.international_shipping_fee_cents = null
+        })
+
+        it("returns true", () => {
+          return runQuery(query, context).then((data) => {
+            expect(data).toEqual({
+              artwork: {
+                onlyShipsDomestically: true,
+              },
+            })
+          })
         })
       })
-    })
 
-    it("is false when work ships worldwide", () => {
-      artwork.domestic_shipping_fee_cents = 1000
-      artwork.international_shipping_fee_cents = 1000
-      return runQuery(query, context).then((data) => {
-        expect(data).toEqual({
-          artwork: {
-            onlyShipsDomestically: false,
-          },
+      describe("when only international_shipping_fee_cents is present", () => {
+        beforeEach(() => {
+          artwork.domestic_shipping_fee_cents = null
+          artwork.international_shipping_fee_cents = 100
+        })
+
+        it("returns false", () => {
+          return runQuery(query, context).then((data) => {
+            expect(data).toEqual({
+              artwork: {
+                onlyShipsDomestically: false,
+              },
+            })
+          })
+        })
+
+        describe("when only artsy international shipping is present", () => {
+          beforeEach(() => {
+            artwork.domestic_shipping_fee_cents = null
+            artwork.international_shipping_fee_cents = null
+            artwork.artsy_shipping_international = true
+          })
+
+          it("returns false", () => {
+            return runQuery(query, context).then((data) => {
+              expect(data).toEqual({
+                artwork: {
+                  onlyShipsDomestically: false,
+                },
+              })
+            })
+          })
+        })
+
+        describe("when free shipping worldwide", () => {
+          beforeEach(() => {
+            artwork.domestic_shipping_fee_cents = 0
+            artwork.international_shipping_fee_cents = 0
+          })
+
+          it("returns false", () => {
+            return runQuery(query, context).then((data) => {
+              expect(data).toEqual({
+                artwork: {
+                  onlyShipsDomestically: false,
+                },
+              })
+            })
+          })
+        })
+
+        describe("when free domestic shipping", () => {
+          beforeEach(() => {
+            artwork.domestic_shipping_fee_cents = 0
+            artwork.international_shipping_fee_cents = null
+          })
+
+          it("returns true", () => {
+            return runQuery(query, context).then((data) => {
+              expect(data).toEqual({
+                artwork: {
+                  onlyShipsDomestically: true,
+                },
+              })
+            })
+          })
         })
       })
     })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -892,9 +892,15 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLBoolean,
         description: "Is this work only available for shipping domestically?",
         resolve: (artwork) => {
+          const domesticShippingSupported =
+            artwork.domestic_shipping_fee_cents != null ||
+            artwork.process_with_artsy_shipping_domestic
+          const internationalShippingSupported =
+            artwork.international_shipping_fee_cents != null ||
+            artwork.artsy_shipping_international
+
           return Boolean(
-            artwork.domestic_shipping_fee_cents &&
-              artwork.international_shipping_fee_cents == null
+            domesticShippingSupported && !internationalShippingSupported
           )
         },
       },


### PR DESCRIPTION
Addresses this bug: https://artsyproduct.atlassian.net/browse/PX-5094

MP's `onlyShipsDomestically` field was only checking flat rate shipping fees to determine if an artwork could be shipping domestically vs internationally.

This was causing users to not be able to check out adding a new `NEW` address if the work was international artsy shipping enabled but had a domestic shipping fee cent value

The form would lock and not allow international addresses to be added by collectors:
<img width="1918" alt="Screen Shot 2022-06-22 at 12 50 30 PM" src="https://user-images.githubusercontent.com/12748344/175313296-93105e53-f3c3-4040-8349-d012489b7a46.png">

