### PR TITLE
fix: sort figures the same way as images

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -15,6 +15,7 @@ describe("Artwork type", () => {
 
   const artworkImages = [
     {
+      position: 2,
       is_default: false,
       id: "56b6311876143f4e82000188",
       image_url: "https://xxx.cloudfront.net/xxx/:version.jpg",
@@ -25,6 +26,7 @@ describe("Artwork type", () => {
       },
     },
     {
+      position: 1,
       is_default: true,
       id: "56b64ed2cd530e670c0000b2",
       image_url: "https://xxx.cloudfront.net/xxx/:version.jpg",
@@ -733,6 +735,39 @@ describe("Artwork type", () => {
             image: {
               internalID: "56b64ed2cd530e670c0000b2",
             },
+          },
+        })
+      })
+    })
+  })
+
+  describe("#figures", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          figures {
+            ...on Image {
+              position
+            }
+          }
+        }
+      }
+    `
+
+    it("returns images sorted by position", () => {
+      artwork.images = artworkImages
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            figures: [
+              {
+                position: 1,
+              },
+              {
+                position: 2,
+              },
+            ],
           },
         })
       })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1407,10 +1407,12 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             ...image,
             type: "Image",
           }))
+          const sortedTypedImages = _.sortBy(typedImages, "position")
+
           const typedVideos = VIDEOS[id]
             ? [{ ...VIDEOS[id], type: "Video" }]
             : []
-          return [...typedImages, ...typedVideos]
+          return [...sortedTypedImages, ...typedVideos]
         },
       },
     }

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1407,7 +1407,9 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             ...image,
             type: "Image",
           }))
-          const sortedTypedImages = _.sortBy(typedImages, "position")
+          const sortedTypedImages = normalizeImageData(
+            _.sortBy(typedImages, "position")
+          )
 
           const typedVideos = VIDEOS[id]
             ? [{ ...VIDEOS[id], type: "Video" }]


### PR DESCRIPTION
Because `figures` and `images` were ordered differently, we were getting some buggy behavior on Force where clicking an image would take you to a different image's deep zoom view.

This PR should fix the problem by introducing the same sorting and normalization to images in `figures` as in `images`.

[Slack context](https://artsy.slack.com/archives/C2TQ4PT8R/p1656063626023679)