### PR TITLE
feat(artist dupes): enable field-level overrides when merging

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10282,6 +10282,29 @@ type MergeArtistsFailure {
   mutationError: GravityMutationError
 }
 
+# A map describing the field-level overrides that should be part of this merge.
+# - Each **key** is a field name such as `nationality`
+# - Each **value** is a BSON ID that indicates the artist record from which we will _prefer_ the value for the given field
+input MergeArtistsFieldOverrides {
+  # ID of the artist record that contains the `birthday` value that we want to preserve.
+  birthday: ID
+
+  # ID of the artist record that contains the `deathday` value that we want to preserve.
+  deathday: ID
+
+  # ID of the artist record that contains the `gender` value that we want to preserve.
+  gender: ID
+
+  # ID of the artist record that contains the `hometown` value that we want to preserve.
+  hometown: ID
+
+  # ID of the artist record that contains the `location` value that we want to preserve.
+  location: ID
+
+  # ID of the artist record that contains the `nationality` value that we want to preserve.
+  nationality: ID
+}
+
 input MergeArtistsMutationInput {
   # The database ID of the "bad" artist record(s), which will be **discarded** after the merge
   badIds: [String!]!
@@ -10290,6 +10313,9 @@ input MergeArtistsMutationInput {
   # The database ID of the "good" artist record, which will be **kept** after the
   # merge. Relevant fields and associations from the bad records will be merged into this one.
   goodId: String!
+
+  # A map describing the field-level overrides that should be part of this merge.
+  overrides: MergeArtistsFieldOverrides
 }
 
 type MergeArtistsMutationPayload {

--- a/src/schema/v2/artists/__tests__/mergeArtistsMutation.test.ts
+++ b/src/schema/v2/artists/__tests__/mergeArtistsMutation.test.ts
@@ -3,7 +3,13 @@ import { runQuery, runAuthenticatedQuery } from "schema/v2/test/utils"
 
 const mutation = gql`
   mutation {
-    mergeArtists(input: { goodId: "abc123", badIds: ["def456", "ghi789"] }) {
+    mergeArtists(
+      input: {
+        goodId: "abc123"
+        badIds: ["def456", "ghi789"]
+        overrides: { birthday: "def456", deathday: "ghi789" }
+      }
+    ) {
       mergeArtistsResponseOrError {
         __typename
         ... on MergeArtistsSuccess {


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4228

This is one of three PRs to enable the [field-level overrides](https://user-images.githubusercontent.com/140521/149867535-309f46de-dfe8-4add-99ca-42f59c2869af.gif) that are a feature of the new deduping UI.

Gravity: https://github.com/artsy/gravity/pull/15477 
👉🏽 Metaphysics: https://github.com/artsy/metaphysics/pull/4189
Forque: https://github.com/artsy/forque/pull/256

This mostly just declares the overridable fields that can be passed through to Gravity, in a query such as:

```graphql
mutation {
  mergeArtists(
    input: {
      goodId: "62a89de6bbce14000c2968fc"
      badIds: ["62a89f0647f3e7000ebe9232"]

      # these 👇🏽 are new
      overrides: {
        birthday: "62a89f0647f3e7000ebe9232"
        deathday: "62a89f0647f3e7000ebe9232"
      }
    }
  )
 }
```

And it adds some light inline documentation:

<img width="1094" alt="docs" src="https://user-images.githubusercontent.com/140521/176041549-9cd09440-be45-420a-b248-484f8e4ec200.png">

