### PR TITLE
fix: Replace Continental Europe with European Union

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -2459,7 +2459,7 @@ describe("Artwork type", () => {
         return runQuery(query, context).then((data) => {
           expect(data).toEqual({
             artwork: {
-              shippingInfo: "Free shipping within Continental Europe only",
+              shippingInfo: "Free shipping within European Union only",
             },
           })
         })
@@ -2483,7 +2483,7 @@ describe("Artwork type", () => {
         return runQuery(query, context).then((data) => {
           expect(data).toEqual({
             artwork: {
-              shippingInfo: "Shipping: $10 within Continental Europe only",
+              shippingInfo: "Shipping: $10 within European Union only",
             },
           })
         })
@@ -2496,7 +2496,7 @@ describe("Artwork type", () => {
           expect(data).toEqual({
             artwork: {
               shippingInfo:
-                "Shipping: $10 within Continental Europe, free rest of world",
+                "Shipping: $10 within European Union, free rest of world",
             },
           })
         })
@@ -2509,7 +2509,7 @@ describe("Artwork type", () => {
           expect(data).toEqual({
             artwork: {
               shippingInfo:
-                "Shipping: Free within Continental Europe, $100 rest of world",
+                "Shipping: Free within European Union, $100 rest of world",
             },
           })
         })
@@ -2522,7 +2522,7 @@ describe("Artwork type", () => {
           expect(data).toEqual({
             artwork: {
               shippingInfo:
-                "Shipping: $10 within Continental Europe, $20 rest of world",
+                "Shipping: $10 within European Union, $20 rest of world",
             },
           })
         })
@@ -2536,7 +2536,7 @@ describe("Artwork type", () => {
           expect(data).toEqual({
             artwork: {
               shippingInfo:
-                "Shipping: €10 within Continental Europe, €20 rest of world",
+                "Shipping: €10 within European Union, €20 rest of world",
             },
           })
         })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -947,7 +947,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             artwork.international_shipping_fee_cents == null
           )
             return artwork.eu_shipping_origin
-              ? "Free shipping within Continental Europe only"
+              ? "Free shipping within European Union only"
               : "Free domestic shipping only"
 
           if (
@@ -973,7 +973,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           })
 
           const shippingRegion = artwork.eu_shipping_origin
-            ? "within Continental Europe"
+            ? "within European Union"
             : "domestic"
 
           if (


### PR DESCRIPTION
Following up with the European Union shipping zone after the release of Artsy Shipping