### PR TITLE
feat: Add count to artist insights

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1601,6 +1601,8 @@ type ArtistHighlights {
 }
 
 type ArtistInsight {
+  # Number of entities relevant to the insight.
+  count: Int!
   description: String
 
   # List of entities relevant to the insight.

--- a/src/schema/v2/artist/insights.ts
+++ b/src/schema/v2/artist/insights.ts
@@ -1,12 +1,13 @@
-import { compact } from "lodash"
 import {
-  GraphQLObjectType,
-  GraphQLList,
   GraphQLEnumType,
-  GraphQLString,
   GraphQLFieldConfig,
+  GraphQLInt,
+  GraphQLList,
   GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
 } from "graphql"
+import { compact } from "lodash"
 import { ResolverContext } from "types/graphql"
 
 const ARTIST_INSIGHT_KINDS = {
@@ -83,6 +84,10 @@ const ArtistInsight = new GraphQLObjectType<any, ResolverContext>({
       type: new GraphQLNonNull(GraphQLList(new GraphQLNonNull(GraphQLString))),
       description: "List of entities relevant to the insight.",
     },
+    count: {
+      type: new GraphQLNonNull(GraphQLInt),
+      description: "Number of entities relevant to the insight.",
+    },
     kind: {
       type: ArtistInsightKind,
       description: "The type of insight.",
@@ -120,10 +125,12 @@ export const ArtistInsights: GraphQLFieldConfig<any, ResolverContext> = {
 
             if (!trimmed) return null
 
+            const entities = trimmed
+              .split(delimiter ?? "|")
+              .map((entity) => entity.trim())
             return {
-              entities: trimmed
-                .split(delimiter ?? "|")
-                .map((entity) => entity.trim()),
+              entities,
+              count: entities.length,
               label,
               type: kind,
               kind,
@@ -137,10 +144,11 @@ export const ArtistInsights: GraphQLFieldConfig<any, ResolverContext> = {
               type: kind,
               kind,
               description,
+              count: value ? 1 : 0,
             }
 
           default:
-            return null
+            return { count: 0 }
         }
       })
     )


### PR DESCRIPTION
Addresses [CX-2644]

## Description

Adds a `count` field to artist insights to be able to check which artist has which insights without loading all the insights when fetching My Collection insights

--------

We'll be able to fetch artist insights like this:

```
{
  me {
    myCollectionInfo {
      collectedArtistsConnection(first: $first) {
        edges {
          node {
            name
            insights(
              kind: [SOLO_SHOW, GROUP_SHOW, COLLECTED, REVIEWED, BIENNIAL]
            ) {
              kind
              count
            }
          }
        }
      }
    }
  }
}

```

[CX-2644]: https://artsyproduct.atlassian.net/browse/CX-2644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ