### PR TITLE
fix: Don't filter out auction results without sale_end_date

### DIFF
--- a/src/schema/v2/artist/__tests__/index.test.js
+++ b/src/schema/v2/artist/__tests__/index.test.js
@@ -21,6 +21,11 @@ describe("Artist type", () => {
               },
               {
                 id: "lot-id",
+                title: "Lot without sale end date",
+                sale_end_date: null,
+              },
+              {
+                id: "lot-id",
                 title: "Lot in the future 1",
                 sale_end_date: "3012-07-04T00:00:00.000Z",
               },
@@ -152,6 +157,11 @@ describe("Artist type", () => {
                 Object {
                   "node": Object {
                     "title": "Lot in the past 1",
+                  },
+                },
+                Object {
+                  "node": Object {
+                    "title": "Lot without sale end date",
                   },
                 },
               ],

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -285,6 +285,9 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
           // TODO: Filter upcoming auction results (sale_end_date > today) in Diffusion.
           const filteredAuctionResults = _embedded.items.filter(
             (auctionResult) => {
+              // Don't filter out auction results with no sale end date.
+              if (!auctionResult.sale_end_date) return true
+
               const now = moment.utc()
 
               return moment.utc(auctionResult.sale_end_date).isBefore(now)


### PR DESCRIPTION
Addresses [CX-2654]

## Description

Follow-Up PR for https://github.com/artsy/metaphysics/pull/4205


Don't filter out auction results without `sale_end_date.`

[CX-2654]: https://artsyproduct.atlassian.net/browse/CX-2654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ