### PR TITLE
feat: Introduce My Collection artist insights

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1601,6 +1601,8 @@ type ArtistHighlights {
 }
 
 type ArtistInsight {
+  artist: Artist
+
   # Number of entities relevant to the insight.
   count: Int!
   description: String
@@ -10888,6 +10890,11 @@ enum MyCollectionArtworkSorts {
 
 # A connection to a list of items.
 type MyCollectionConnection {
+  # Insights for all collected artists
+  artistInsights(
+    # The type of insight.
+    kind: ArtistInsightKind
+  ): [ArtistInsight!]!
   artistsCount: Int!
   artworksCount: Int!
 
@@ -10971,6 +10978,11 @@ type MyCollectionEdge {
 }
 
 type MyCollectionInfo {
+  # Insights for all collected artists
+  artistInsights(
+    # The type of insight.
+    kind: ArtistInsightKind
+  ): [ArtistInsight!]!
   artistsCount: Int!
   artworksCount: Int!
 

--- a/src/schema/v2/me/__tests__/myCollectionInfo.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionInfo.test.ts
@@ -40,6 +40,70 @@ describe("me.myCollectionInfo", () => {
     `)
   })
 
+  describe("artistInsights", () => {
+    it("returns insights for all collected artist by kind", async () => {
+      const query = gql`
+        {
+          me {
+            myCollectionInfo {
+              artistInsights(kind: COLLECTED) {
+                artist {
+                  name
+                }
+                kind
+                type
+                label
+                entities
+              }
+            }
+          }
+        }
+      `
+
+      const context: Partial<ResolverContext> = {
+        collectionLoader: async () => ({}),
+        meLoader: async () => ({ id: "some-user-id" }),
+        collectionArtistsLoader: async () => ({
+          headers: { "x-total-count": "2" },
+          body: [
+            {
+              name: "Artist 1",
+              collections: "Collected by a major art publication",
+            },
+            {
+              name: "Artist 2",
+              reviewed: "Reviewed by a major art publication",
+            },
+          ],
+        }),
+      }
+
+      const data = await runAuthenticatedQuery(query, context)
+
+      expect(data).toMatchInlineSnapshot(`
+        Object {
+          "me": Object {
+            "myCollectionInfo": Object {
+              "artistInsights": Array [
+                Object {
+                  "artist": Object {
+                    "name": "Artist 1",
+                  },
+                  "entities": Array [
+                    "Collected by a major art publication",
+                  ],
+                  "kind": "COLLECTED",
+                  "label": "Collected by a major institution",
+                  "type": "COLLECTED",
+                },
+              ],
+            },
+          },
+        }
+      `)
+    })
+  })
+
   describe("collectedArtistsConnection", () => {
     it("returns a connection for the artists in the users' collection", async () => {
       const query = gql`

--- a/src/schema/v2/me/myCollectionAuctionResults.ts
+++ b/src/schema/v2/me/myCollectionAuctionResults.ts
@@ -13,6 +13,7 @@ import { createPageCursors } from "schema/v2/fields/pagination"
 import { ResolverContext } from "types/graphql"
 import ArtworkSizes from "../artwork/artworkSizes"
 import { auctionResultConnection, AuctionResultSorts } from "../auction_result"
+import { MAX_ARTISTS } from "./myCollectionInfo"
 
 const MyCollectionAuctionResults: GraphQLFieldConfig<any, ResolverContext> = {
   type: auctionResultConnection.connectionType,
@@ -61,7 +62,7 @@ const MyCollectionAuctionResults: GraphQLFieldConfig<any, ResolverContext> = {
 
       const { body: artists } = await collectionArtistsLoader("my-collection", {
         user_id: userId,
-        size: 100,
+        size: MAX_ARTISTS,
       })
 
       const artistIds = artists.map(({ _id }) => _id)

--- a/src/schema/v2/me/myCollectionInfo.ts
+++ b/src/schema/v2/me/myCollectionInfo.ts
@@ -63,6 +63,7 @@ export const myCollectionInfoFields = {
       const { body: artists } = await collectionArtistsLoader("my-collection", {
         size: MAX_ARTISTS,
         user_id: userID,
+        all: true,
       })
 
       const insights: ReturnType<typeof getArtistInsights> = []

--- a/src/schema/v2/me/myCollectionInfo.ts
+++ b/src/schema/v2/me/myCollectionInfo.ts
@@ -2,6 +2,7 @@ import {
   GraphQLBoolean,
   GraphQLFieldConfig,
   GraphQLInt,
+  GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
@@ -10,8 +11,15 @@ import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { pageable } from "relay-cursor-paging"
 import { artistConnection } from "schema/v2/artist"
 import { ResolverContext } from "types/graphql"
+import {
+  ArtistInsight,
+  ArtistInsightKind,
+  getArtistInsights,
+} from "../artist/insights"
 import { paginationResolver } from "../fields/pagination"
 import ArtistSorts from "../sorts/artist_sorts"
+
+export const MAX_ARTISTS = 100
 
 export const myCollectionInfoFields = {
   description: {
@@ -37,6 +45,36 @@ export const myCollectionInfoFields = {
   artistsCount: {
     type: new GraphQLNonNull(GraphQLInt),
     resolve: ({ artists_count }) => artists_count,
+  },
+  artistInsights: {
+    description: "Insights for all collected artists",
+    type: new GraphQLNonNull(
+      new GraphQLList(new GraphQLNonNull(ArtistInsight))
+    ),
+    args: {
+      kind: {
+        type: ArtistInsightKind,
+        description: "The type of insight.",
+      },
+    },
+    resolve: async (_root, args, context) => {
+      const { collectionArtistsLoader, userID } = context
+
+      const { body: artists } = await collectionArtistsLoader("my-collection", {
+        size: MAX_ARTISTS,
+        user_id: userID,
+      })
+
+      const insights: ReturnType<typeof getArtistInsights> = []
+
+      artists.map((artist) => {
+        getArtistInsights(artist).map((insight) => {
+          if (insight.kind === args.kind || !args.kind) insights.push(insight)
+        })
+      })
+
+      return insights
+    },
   },
   collectedArtistsConnection: {
     description: "A connection of artists in the users' collection",
@@ -64,7 +102,14 @@ export const myCollectionInfoFields = {
       })
       const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 
-      return paginationResolver({ totalCount, offset, size, page, body, args })
+      return paginationResolver({
+        totalCount,
+        offset,
+        size,
+        page,
+        body,
+        args,
+      })
     },
   },
 }


### PR DESCRIPTION
Addresses [CX-2644]

Depends on https://github.com/artsy/gravity/pull/15493

## Description

Introduces new My Collection artist insights field (`artistInsights`) that returns insights for all collected artists by kind.

### Example Query

```graphql
{
  me {
    myCollectionInfo {
      artistInsights(kind: COLLECTED) {
        artist {
          name
        }
        kind
        type
        label
        entities
      }
    }
  }
}
```

```
{
  "data": {
    "me": {
      "myCollectionInfo": {
        "active_secondary_market": [
          {
            "kind": "ACTIVE_SECONDARY_MARKET",
            "label": "Active Secondary Market",
            "artist": {
              "name": "Banksy"
            }
          },
          {
            "kind": "ACTIVE_SECONDARY_MARKET",
            "label": "Active Secondary Market",
            "artist": {
              "name": "Joan Miró"
            }
          }
        }
      }
    }
  }
}
```



[CX-2644]: https://artsyproduct.atlassian.net/browse/CX-2644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ