### PR TITLE
feat(schema): exposes match fields

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9881,6 +9881,39 @@ type MarketPriceInsightsEdge {
   node: MarketPriceInsights
 }
 
+union Match =
+    Article
+  | Artist
+  | Artwork
+  | Fair
+  | Feature
+  | Gene
+  | Page
+  | Profile
+  | Sale
+  | Show
+  | Tag
+
+# A connection to a list of items.
+type MatchConnection {
+  # A list of edges.
+  edges: [MatchEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type MatchEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: Match
+}
+
 type Me implements Node {
   addressConnection(
     after: String
@@ -12819,6 +12852,35 @@ type Query {
 
   # Get price insights for a market.
   marketPriceInsights(artistId: ID!, medium: String!): MarketPriceInsights
+  matchConnection(
+    after: String
+    before: String
+
+    # ARTIST_SERIES, CITY, COLLECTION, and VIEWING_ROOM are not yet supported
+    entities: [SearchEntity!] = [
+      ARTICLE
+      ARTIST
+      ARTWORK
+      FAIR
+      FEATURE
+      GALLERY
+      GENE
+      INSTITUTION
+      PAGE
+      PROFILE
+      SALE
+      SHOW
+      TAG
+    ]
+    first: Int
+    last: Int
+
+    # Mode of search to execute
+    mode: SearchMode = SITE
+    page: Int = 1
+    size: Int = 10
+    term: String!
+  ): MatchConnection
   me: Me
 
   # Fetches an object given its globally unique ID.
@@ -16126,6 +16188,35 @@ type Viewer {
     size: Int
     slugs: [String!]
   ): [MarketingCollection]
+  matchConnection(
+    after: String
+    before: String
+
+    # ARTIST_SERIES, CITY, COLLECTION, and VIEWING_ROOM are not yet supported
+    entities: [SearchEntity!] = [
+      ARTICLE
+      ARTIST
+      ARTWORK
+      FAIR
+      FEATURE
+      GALLERY
+      GENE
+      INSTITUTION
+      PAGE
+      PROFILE
+      SALE
+      SHOW
+      TAG
+    ]
+    first: Int
+    last: Int
+
+    # Mode of search to execute
+    mode: SearchMode = SITE
+    page: Int = 1
+    size: Int = 10
+    term: String!
+  ): MatchConnection
   me: Me
 
   # Fetches an object given its globally unique ID.

--- a/src/schema/v2/Match.ts
+++ b/src/schema/v2/Match.ts
@@ -1,0 +1,122 @@
+import {
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { GraphQLFieldConfig } from "graphql"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { pageable } from "relay-cursor-paging"
+import { ResolverContext } from "types/graphql"
+import { ArticleType } from "./article"
+import { ArtistType } from "./artist"
+import { ArtworkType } from "./artwork"
+import { FairType } from "./fair"
+import { FeatureType } from "./Feature"
+import {
+  connectionWithCursorInfo,
+  paginationResolver,
+} from "./fields/pagination"
+import { GeneType } from "./gene"
+import { pageType } from "./page"
+import { ProfileType } from "./profile"
+import { SaleType } from "./sale"
+import { SearchMode } from "./search"
+import { SearchEntity } from "./search/SearchEntity"
+import { ShowType } from "./show"
+import { TagType } from "./tag"
+
+const MODELS = {
+  Article: { loader: "articleLoader", type: ArticleType },
+  Artist: { loader: "artistLoader", type: ArtistType },
+  Artwork: { loader: "artworkLoader", type: ArtworkType },
+  Fair: { loader: "fairLoader", type: FairType },
+  Feature: { loader: "featureLoader", type: FeatureType },
+  Gene: { loader: "geneLoader", type: GeneType },
+  Page: { loader: "pageLoader", type: pageType },
+  Profile: { loader: "profileLoader", type: ProfileType },
+  Sale: { loader: "saleLoader", type: SaleType },
+  PartnerShow: { loader: "showLoader", type: ShowType },
+  Tag: { loader: "tagLoader", type: TagType },
+}
+
+export const MatchType = new GraphQLUnionType({
+  name: "Match",
+  types: Object.values(MODELS).map(({ type }) => type),
+  resolveType: ({ __typename }) => {
+    return MODELS[__typename].type
+  },
+})
+
+export const MatchConnection: GraphQLFieldConfig<void, ResolverContext> = {
+  type: connectionWithCursorInfo({ nodeType: MatchType }).connectionType,
+  args: pageable({
+    term: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    entities: {
+      type: new GraphQLList(new GraphQLNonNull(SearchEntity)),
+      description:
+        "ARTIST_SERIES, CITY, COLLECTION, and VIEWING_ROOM are not yet supported",
+      defaultValue: [
+        "ARTICLE",
+        "ARTIST",
+        "ARTWORK",
+        "FAIR",
+        "FEATURE",
+        "GALLERY",
+        "GENE",
+        "INSTITUTION",
+        "PAGE",
+        "PROFILE",
+        "SALE",
+        "SHOW",
+        "TAG",
+      ],
+    },
+    mode: {
+      type: SearchMode,
+      description: "Mode of search to execute",
+      defaultValue: "SITE",
+    },
+    size: { type: GraphQLInt, defaultValue: 10 },
+    page: { type: GraphQLInt, defaultValue: 1 },
+  }),
+  resolve: async (
+    _root,
+    { term, entities, mode, ...args },
+    { searchLoader, ...loaders }
+  ) => {
+    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+
+    const { body, headers } = await searchLoader({
+      term,
+      entities,
+      mode,
+      size,
+      offset,
+      total_count: true,
+    })
+
+    const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+    const results = await Promise.all(
+      body.map(async ({ id, label }) => {
+        const loader = loaders[MODELS[label].loader]
+        const body = await loader(id)
+
+        return { ...body, __typename: label }
+      })
+    )
+
+    return paginationResolver({
+      totalCount,
+      offset,
+      page,
+      size,
+      body: results,
+      args,
+    })
+  },
+}

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -144,6 +144,7 @@ import { createFeatureFlagMutation } from "./admin/mutations/createFeatureFlagMu
 import { deleteFeatureFlagMutation } from "./admin/mutations/deleteFeatureFlagMutation"
 import { updateFeatureFlagMutation } from "./admin/mutations/updateFeatureFlagMutation"
 import { toggleFeatureFlagMutation } from "./admin/mutations/toggleFeatureFlagMutation"
+import { MatchConnection } from "./Match"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -211,6 +212,7 @@ const rootFields = {
   },
   // matchArtist: MatchArtist,
   // matchGene: MatchGene,
+  matchConnection: MatchConnection,
   me: Me,
   node: ObjectIdentification.NodeField,
   orderedSet: OrderedSet,


### PR DESCRIPTION
So it turns out that the `searchConnection` field has some problems that make it unusable for particular kinds of UI.

It exposes a union on _some_ of its types. But you can't really use those types since named fragments aren't supported. And just using the common interface isn't workable since we can't use existing UI with those.

The solution is to expose a simpler field that just takes the results, loads the records, and simply exposes a union of them. This works as you'd expect it to and makes it simple to use existing pieces of UI. (Let's say you wanted to search for artists and then load one of our standard artist card components: couldn't do that with `searchConnection`, can do that with `match`/`matchConnection`.