### PR TITLE
[Coordinated merge] Update schema to support one time use payment for bank accounts

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -5871,6 +5871,7 @@ input CommerceSetPaymentByStripeIntentInput {
   # A unique identifier for the client performing the mutation.
   clientMutationId: String
   id: ID!
+  oneTimeUse: Boolean = false
   setupIntentId: String!
 }
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5017,6 +5017,7 @@ input CommerceSetPaymentByStripeIntentInput {
   # A unique identifier for the client performing the mutation.
   clientMutationId: String
   id: ID!
+  oneTimeUse: Boolean = false
   setupIntentId: String!
 }
 

--- a/src/data/exchange.graphql
+++ b/src/data/exchange.graphql
@@ -1937,6 +1937,7 @@ input SetPaymentByStripeIntentInput {
   """
   clientMutationId: String
   id: ID!
+  oneTimeUse: Boolean = false
   setupIntentId: String!
 }
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/TX-440

This should be merged after https://github.com/artsy/exchange/pull/1245.

This updates the schema for the new `oneTimeUse` argument added in Exchange.