### PR TITLE
feat(schema): re-enables profiles

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13026,6 +13026,12 @@ type Query {
     sort: PriceInsightSort
   ): PriceInsightConnection
 
+  # A Profile
+  profile(
+    # The slug or ID of the Profile
+    id: String!
+  ): Profile
+
   # Static set of recently sold artworks for the SWA landing page
   recentlySoldArtworks(
     after: String
@@ -16311,6 +16317,12 @@ type Viewer {
   previewSavedSearch(
     attributes: PreviewSavedSearchAttributes
   ): PreviewSavedSearch
+
+  # A Profile
+  profile(
+    # The slug or ID of the Profile
+    id: String!
+  ): Profile
 
   # Static set of recently sold artworks for the SWA landing page
   recentlySoldArtworks(

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -86,7 +86,7 @@ import { OrderedSet } from "./OrderedSet"
 import OrderedSets from "./ordered_sets"
 import Partner from "./partner"
 import PartnerArtworks from "./partnerArtworks"
-// import Profile from "./profile"
+import Profile from "./profile"
 // import Partner from "./partner"
 import { PartnersConnection } from "./partners"
 import { RequestLocationField } from "./requestLocation"
@@ -224,7 +224,7 @@ const rootFields = {
   partnerCategory: PartnerCategory,
   partnersConnection: PartnersConnection,
   phoneNumber: PhoneNumber,
-  // profile: Profile,
+  profile: Profile,
   previewSavedSearch: PreviewSavedSearchField,
   requestLocation: RequestLocationField,
   reverseImageSearch: ReverseImageSearch,


### PR DESCRIPTION
This re-enables profile as a top-level field, which is needed in Force to handle the legacy top-level path redirects.