### PR TITLE
Feat: add my collection artist insights count endpoint

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1629,6 +1629,15 @@ enum ArtistInsightKind {
   SOLO_SHOW
 }
 
+type ArtistInsightsCount {
+  activeSecondaryMarketCount: Int!
+  biennialCount: Int!
+  collectedCount: Int!
+  groupShowCount: Int!
+  reviewedCount: Int!
+  soloShowCount: Int!
+}
+
 type ArtistMeta {
   description: String
   title: String
@@ -10956,6 +10965,7 @@ type MyCollectionConnection {
     # The type of insight.
     kind: ArtistInsightKind
   ): [ArtistInsight!]!
+  artistInsightsCount: ArtistInsightsCount
   artistsCount: Int!
   artworksCount: Int!
 
@@ -11044,6 +11054,7 @@ type MyCollectionInfo {
     # The type of insight.
     kind: ArtistInsightKind
   ): [ArtistInsight!]!
+  artistInsightsCount: ArtistInsightsCount
   artistsCount: Int!
   artworksCount: Int!
 

--- a/src/schema/v2/me/__tests__/myCollectionInfo.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionInfo.test.ts
@@ -40,6 +40,94 @@ describe("me.myCollectionInfo", () => {
     `)
   })
 
+  describe("artistInsightsCount", () => {
+    it("returns the correct count", async () => {
+      const query = gql`
+        {
+          me {
+            myCollectionInfo {
+              artistInsightsCount {
+                activeSecondaryMarketCount
+                biennialCount
+                groupShowCount
+                collectedCount
+                soloShowCount
+                reviewedCount
+              }
+            }
+          }
+        }
+      `
+
+      const context: Partial<ResolverContext> = {
+        collectionLoader: async () => ({}),
+        meLoader: async () => ({ id: "some-user-id" }),
+        collectionArtistsLoader: async () => ({
+          headers: {},
+          body: [
+            {
+              name: "Artist 1",
+              collections: "Collected by a major art publication",
+              review_sources: "Reviewed by a major art publication",
+            },
+            {
+              name: "Artist 2",
+              group_show_institutions: "Group show at a major institution",
+              review_sources: "Reviewed by a major art publication",
+              solo_show_institutions: "Solo show at a major institution",
+            },
+            {
+              name: "Artist 3",
+              active_secondary_market: "Active Secondary Market",
+              biennials: "Included in a major biennial",
+              collections: "Collected by a major art publication",
+            },
+            {
+              name: "Artist 4",
+              active_secondary_market: "Active Secondary Market",
+              collections: "Collected by a major art publication",
+            },
+          ],
+        }),
+      }
+
+      const data = await runAuthenticatedQuery(query, context)
+
+      const {
+        activeSecondaryMarketCount,
+        biennialCount,
+        collectedCount,
+        groupShowCount,
+        soloShowCount,
+        reviewedCount,
+      } = data.me.myCollectionInfo.artistInsightsCount
+
+      expect(activeSecondaryMarketCount).toBe(2)
+      expect(biennialCount).toBe(1)
+      expect(groupShowCount).toBe(1)
+      expect(collectedCount).toBe(3)
+      expect(reviewedCount).toBe(2)
+      expect(soloShowCount).toBe(1)
+
+      expect(data).toMatchInlineSnapshot(`
+        Object {
+          "me": Object {
+            "myCollectionInfo": Object {
+              "artistInsightsCount": Object {
+                "activeSecondaryMarketCount": 2,
+                "biennialCount": 1,
+                "collectedCount": 3,
+                "groupShowCount": 1,
+                "reviewedCount": 2,
+                "soloShowCount": 1,
+              },
+            },
+          },
+        }
+      `)
+    })
+  })
+
   describe("artistInsights", () => {
     it("returns insights for all collected artist by kind", async () => {
       const query = gql`

--- a/src/schema/v2/me/myCollectionInfo.ts
+++ b/src/schema/v2/me/myCollectionInfo.ts
@@ -115,7 +115,7 @@ export const myCollectionInfoFields = {
         }
       }
 
-      artists.map((artist) => {
+      artists.forEach((artist) => {
         getArtistInsights(artist).map((insight) => {
           if (!!insight.kind) countInsights(insight)
         })

--- a/src/schema/v2/me/myCollectionInfo.ts
+++ b/src/schema/v2/me/myCollectionInfo.ts
@@ -116,7 +116,7 @@ export const myCollectionInfoFields = {
       }
 
       artists.forEach((artist) => {
-        getArtistInsights(artist).map((insight) => {
+        getArtistInsights(artist).forEach((insight) => {
           if (!!insight.kind) countInsights(insight)
         })
       })

--- a/src/schema/v2/me/myCollectionInfo.ts
+++ b/src/schema/v2/me/myCollectionInfo.ts
@@ -21,6 +21,30 @@ import ArtistSorts from "../sorts/artist_sorts"
 
 export const MAX_ARTISTS = 100
 
+const artistInsightsCountType = new GraphQLObjectType({
+  name: "ArtistInsightsCount",
+  fields: {
+    soloShowCount: {
+      type: new GraphQLNonNull(GraphQLInt),
+    },
+    groupShowCount: {
+      type: new GraphQLNonNull(GraphQLInt),
+    },
+    collectedCount: {
+      type: new GraphQLNonNull(GraphQLInt),
+    },
+    reviewedCount: {
+      type: new GraphQLNonNull(GraphQLInt),
+    },
+    biennialCount: {
+      type: new GraphQLNonNull(GraphQLInt),
+    },
+    activeSecondaryMarketCount: {
+      type: new GraphQLNonNull(GraphQLInt),
+    },
+  },
+})
+
 export const myCollectionInfoFields = {
   description: {
     type: new GraphQLNonNull(GraphQLString),
@@ -45,6 +69,67 @@ export const myCollectionInfoFields = {
   artistsCount: {
     type: new GraphQLNonNull(GraphQLInt),
     resolve: ({ artists_count }) => artists_count,
+  },
+  artistInsightsCount: {
+    type: artistInsightsCountType,
+    resolve: async (_root, _args, context) => {
+      const { collectionArtistsLoader, userID } = context
+
+      if (!collectionArtistsLoader) return
+
+      const { body: artists } = await collectionArtistsLoader("my-collection", {
+        size: MAX_ARTISTS,
+        user_id: userID,
+        all: true,
+      })
+
+      let soloShowCount = 0
+      let groupShowCount = 0
+      let collectedCount = 0
+      let reviewedCount = 0
+      let biennialCount = 0
+      let activeSecondaryMarketCount = 0
+
+      const countInsights = (
+        insight: ReturnType<typeof getArtistInsights>[0]
+      ) => {
+        switch (insight.kind) {
+          case "SOLO_SHOW":
+            soloShowCount += 1
+            break
+          case "GROUP_SHOW":
+            groupShowCount += 1
+            break
+          case "REVIEWED":
+            reviewedCount += 1
+            break
+          case "COLLECTED":
+            collectedCount += 1
+            break
+          case "BIENNIAL":
+            biennialCount += 1
+            break
+          case "ACTIVE_SECONDARY_MARKET":
+            activeSecondaryMarketCount += 1
+            break
+        }
+      }
+
+      artists.map((artist) => {
+        getArtistInsights(artist).map((insight) => {
+          if (!!insight.kind) countInsights(insight)
+        })
+      })
+
+      return {
+        soloShowCount,
+        groupShowCount,
+        collectedCount,
+        reviewedCount,
+        biennialCount,
+        activeSecondaryMarketCount,
+      }
+    },
   },
   artistInsights: {
     description: "Insights for all collected artists",


### PR DESCRIPTION
This PR resolves [CX-2670]

### Description

This PR adds a count for the insights kinds for the artists inside my collection

### Example

- Query:
```graphql
query {
  me {
    myCollectionInfo {
      artistInsightsCount {
        activeSecondaryMarketCount
        biennialCount
        groupShowCount
        collectedCount
        soloShowCount
        reviewedCount
      }
    }
  }
}
```

- Response
```json
{
  "data": {
    "me": {
      "myCollectionInfo": {
        "artistInsightsCount": {
          "activeSecondaryMarketCount": 5,
          "biennialCount": 1,
          "groupShowCount": 0,
          "collectedCount": 2,
          "soloShowCount": 0,
          "reviewedCount": 2
        }
      }
    }
  }
}
```


[CX-2670]: https://artsyproduct.atlassian.net/browse/CX-2670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ