### PR TITLE
Add version to artworks for user

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12536,6 +12536,7 @@ type Query {
     last: Int
     page: Int
     userId: String
+    version: String
   ): ArtworkConnection
 
   # An auction result
@@ -16003,6 +16004,7 @@ type Viewer {
     last: Int
     page: Int
     userId: String
+    version: String
   ): ArtworkConnection
 
   # An auction result

--- a/src/schema/v2/artworksForUser/artworksForUser.ts
+++ b/src/schema/v2/artworksForUser/artworksForUser.ts
@@ -26,6 +26,7 @@ export const artworksForUser: GraphQLFieldConfig<void, ResolverContext> = {
     includeBackfill: { type: new GraphQLNonNull(GraphQLBoolean) },
     page: { type: GraphQLInt },
     userId: { type: GraphQLString },
+    version: { type: GraphQLString },
   }),
   resolve: async (_root, args: CursorPageable, context) => {
     if (!context.artworksLoader) return

--- a/src/schema/v2/artworksForUser/helpers.ts
+++ b/src/schema/v2/artworksForUser/helpers.ts
@@ -12,12 +12,16 @@ export const getNewForYouRecs = async (
   const graphqlLoader =
     vortexGraphqlLoader || vortexGraphqlLoaderFactory(appToken)
 
+  const userIdArgument = args.userId ? `userId: "${args.userId}"` : ""
+  const versionArgument = args.version ? `version: "${args.version}"` : ""
+
   const vortexResult = await graphqlLoader({
     query: gql`
         query newForYouRecommendationsQuery {
           newForYouRecommendations(
             first: ${args.first}
-            userId: "${args.userId}"
+            ${userIdArgument}
+            ${versionArgument}
           ) {
             totalCount
             edges {


### PR DESCRIPTION
This PR updates MP to be in sync with the new field on new for you recs. While I was at it I extracted some locals so that when optional values are not passed then they shouldn't appear in the query at all. (h/t @dzucconi on that one)

/cc @artsy/grow-devs