### PR TITLE
feat(MOPLAT-306): add `partnerShowDocumentsConnection` field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11862,6 +11862,39 @@ type PartnersAggregationResults {
   slice: PartnersAggregation
 }
 
+type PartnerShowDocument {
+  filename: String!
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+  size: Int!
+  title: String!
+  uri: String!
+}
+
+# A connection to a list of items.
+type PartnerShowDocumentConnection {
+  # A list of edges.
+  edges: [PartnerShowDocumentEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type PartnerShowDocumentEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: PartnerShowDocument
+}
+
 enum PartnerShowPartnerType {
   GALLERY
   MUSEUM
@@ -13048,6 +13081,22 @@ type Query {
     sort: PartnersSortType
     type: [PartnerClassification]
   ): PartnerConnection
+
+  # Retrieve all partner show documents for a given partner and show
+  partnerShowDocumentsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    page: Int
+
+    # The slug or ID of the Partner
+    partnerID: String!
+
+    # The slug or ID of the Show
+    showID: String!
+    size: Int
+  ): PartnerShowDocumentConnection
 
   # Phone number information
   phoneNumber(phoneNumber: String!, regionCode: String): PhoneNumberType
@@ -16376,6 +16425,22 @@ type Viewer {
     sort: PartnersSortType
     type: [PartnerClassification]
   ): PartnerConnection
+
+  # Retrieve all partner show documents for a given partner and show
+  partnerShowDocumentsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    page: Int
+
+    # The slug or ID of the Partner
+    partnerID: String!
+
+    # The slug or ID of the Show
+    showID: String!
+    size: Int
+  ): PartnerShowDocumentConnection
 
   # Phone number information
   phoneNumber(phoneNumber: String!, regionCode: String): PhoneNumberType

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -321,6 +321,15 @@ export default (accessToken, userID, opts) => {
       ({ partnerId, inquiryId }) =>
         `partner/${partnerId}/inquiry_request/${inquiryId}/collector_profile`
     ),
+    partnerShowDocumentsLoader: gravityLoader<
+      any,
+      { partnerId: string; showId: string }
+    >(
+      ({ partnerId, showId }) =>
+        `partner/${partnerId}/show/${showId}/documents`,
+      {},
+      { headers: true }
+    ),
     popularArtistsLoader: gravityLoader("artists/popular"),
     recordArtworkViewLoader: gravityLoader(
       "me/recently_viewed_artworks",

--- a/src/schema/v2/__tests__/partnerShowDocumentsConnection.test.ts
+++ b/src/schema/v2/__tests__/partnerShowDocumentsConnection.test.ts
@@ -1,0 +1,155 @@
+import { runQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("partnerShowDocumentsConnection", () => {
+  let response
+  let context
+
+  beforeEach(() => {
+    response = [
+      {
+        filename: "filename-one.pdf",
+        title: "File One",
+      },
+      {
+        filename: "filename-two.png",
+        title: "File Two",
+      },
+      {
+        filename: "filename-three.jpg",
+        title: "File Three",
+      },
+    ]
+
+    context = {
+      partnerShowDocumentsLoader: () => {
+        return Promise.resolve({
+          body: response,
+          headers: {
+            "x-total-count": response.length,
+          },
+        })
+      },
+    }
+  })
+
+  it("returns show documents", async () => {
+    const query = gql`
+      {
+        partnerShowDocumentsConnection(
+          showID: "showID"
+          partnerID: "partnerID"
+          first: 5
+        ) {
+          edges {
+            node {
+              filename
+              title
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      partnerShowDocumentsConnection: {
+        edges: [
+          {
+            node: {
+              filename: "filename-one.pdf",
+              title: "File One",
+            },
+          },
+          {
+            node: {
+              filename: "filename-two.png",
+              title: "File Two",
+            },
+          },
+          {
+            node: {
+              filename: "filename-three.jpg",
+              title: "File Three",
+            },
+          },
+        ],
+      },
+    })
+  })
+
+  it("returns hasNextPage=true when first is below total", async () => {
+    const query = gql`
+      {
+        partnerShowDocumentsConnection(
+          showID: "showID"
+          partnerID: "partnerID"
+          first: 1
+        ) {
+          pageInfo {
+            hasNextPage
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      partnerShowDocumentsConnection: {
+        pageInfo: {
+          hasNextPage: true,
+        },
+      },
+    })
+  })
+
+  it("returns hasNextPage=false when first is above total", async () => {
+    const query = gql`
+      {
+        partnerShowDocumentsConnection(
+          showID: "showID"
+          partnerID: "partnerID"
+          first: 3
+        ) {
+          pageInfo {
+            hasNextPage
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      partnerShowDocumentsConnection: {
+        pageInfo: {
+          hasNextPage: false,
+        },
+      },
+    })
+  })
+
+  it("loads the total count", async () => {
+    const query = gql`
+      {
+        partnerShowDocumentsConnection(
+          showID: "showID"
+          partnerID: "partnerID"
+          first: 3
+        ) {
+          totalCount
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      partnerShowDocumentsConnection: {
+        totalCount: 3,
+      },
+    })
+  })
+})

--- a/src/schema/v2/partnerShowDocumentsConnection.ts
+++ b/src/schema/v2/partnerShowDocumentsConnection.ts
@@ -1,0 +1,90 @@
+import {
+  GraphQLString,
+  GraphQLObjectType,
+  GraphQLNonNull,
+  GraphQLInt,
+} from "graphql"
+import { InternalIDFields } from "./object_identification"
+import { ResolverContext } from "types/graphql"
+import {
+  connectionWithCursorInfo,
+  paginationResolver,
+} from "./fields/pagination"
+import { GraphQLFieldConfig } from "graphql"
+import { pageable } from "relay-cursor-paging"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+
+export const PartnerShowDocumentType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "PartnerShowDocument",
+  fields: {
+    ...InternalIDFields,
+    uri: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    filename: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    title: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    size: {
+      type: new GraphQLNonNull(GraphQLInt),
+    },
+  },
+})
+
+export const PartnerShowDocumentsConnection: GraphQLFieldConfig<
+  void,
+  ResolverContext
+> = {
+  type: connectionWithCursorInfo({
+    nodeType: PartnerShowDocumentType,
+  }).connectionType,
+  description:
+    "Retrieve all partner show documents for a given partner and show",
+  args: pageable({
+    partnerID: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The slug or ID of the Partner",
+    },
+    showID: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The slug or ID of the Show",
+    },
+    page: {
+      type: GraphQLInt,
+    },
+    size: {
+      type: GraphQLInt,
+    },
+  }),
+  resolve: async (_root, args, { partnerShowDocumentsLoader }) => {
+    if (!partnerShowDocumentsLoader) {
+      return null
+    }
+
+    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+    const gravityOptions = {
+      size,
+      offset,
+      total_count: true,
+    }
+    const { body, headers } = await partnerShowDocumentsLoader(
+      { showId: args.showID, partnerId: args.partnerID },
+      gravityOptions
+    )
+    const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+    return paginationResolver({
+      totalCount,
+      offset,
+      page,
+      size,
+      body,
+      args,
+    })
+  },
+}

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -146,6 +146,7 @@ import { updateFeatureFlagMutation } from "./admin/mutations/updateFeatureFlagMu
 import { toggleFeatureFlagMutation } from "./admin/mutations/toggleFeatureFlagMutation"
 import { MatchConnection } from "./Match"
 import { PartnerArtistDocumentsConnection } from "./partnerArtistDocumentsConnection"
+import { PartnerShowDocumentsConnection } from "./partnerShowDocumentsConnection"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -224,6 +225,7 @@ const rootFields = {
   partnerArtworks: PartnerArtworks,
   partnerCategories: PartnerCategories,
   partnerCategory: PartnerCategory,
+  partnerShowDocumentsConnection: PartnerShowDocumentsConnection,
   partnersConnection: PartnersConnection,
   phoneNumber: PhoneNumber,
   profile: Profile,


### PR DESCRIPTION
Jira ticket: https://artsyproduct.atlassian.net/browse/MOPLAT-306

### Demo
<img width="1596" alt="show-demo" src="https://user-images.githubusercontent.com/3513494/178965604-1e54031b-f7b8-47c3-b71e-0ce82355a928.png">

### Query example
```graphql
{
  partnerShowDocumentsConnection(
    showID: "showID"
    partnerID: "partnerID"
    first: 10
  ) {
    edges {
      node {
        title
        filename
        size
      }
    }
  }
}
```

### Response example
```graphql
{
  "partnerShowDocumentsConnection": {
    "edges": [
      {
        "node": {
          "title": "2000",
          "filename": "2000.jpeg",
          "size": 226862
        }
      }
    ]
  }
}
```