### PR TITLE
Order of artworks should match what's passed in

### DIFF
--- a/src/schema/v2/artworksForUser/helpers.ts
+++ b/src/schema/v2/artworksForUser/helpers.ts
@@ -52,8 +52,9 @@ export const getNewForYouArtworks = async (
   const { artworksLoader } = context
 
   const artworkParams = {
-    ids: artworkIds,
     availability: "for sale",
+    batched: true,
+    ids: artworkIds,
     offset,
     size,
   }


### PR DESCRIPTION
Without this `batched` flag the list of artwork ids will get shuffled - not sure why! Anyway this fixes the ordering problem we saw yesterday!

/cc @artsy/grow-devs @joeyAghion