### PR TITLE
feat: add `publicUrl` field for partner artist and partner show documents

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11630,6 +11630,7 @@ type PartnerArtistDocument {
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
+  publicUrl: String!
   size: Int!
   title: String!
   uri: String!
@@ -11881,6 +11882,7 @@ type PartnerShowDocument {
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
+  publicUrl: String!
   size: Int!
   title: String!
   uri: String!

--- a/src/schema/v2/__tests__/partnerArtistDocumentsConnection.test.ts
+++ b/src/schema/v2/__tests__/partnerArtistDocumentsConnection.test.ts
@@ -8,14 +8,17 @@ describe("partnerArtistDocumentsConnection", () => {
   beforeEach(() => {
     response = [
       {
+        uri: "partner/name/filename-one.pdf",
         filename: "filename-one.pdf",
         title: "File One",
       },
       {
+        uri: "partner/name/filename-two.pdf",
         filename: "filename-two.png",
         title: "File Two",
       },
       {
+        uri: "partner/name/filename-three.pdf",
         filename: "filename-three.jpg",
         title: "File Three",
       },
@@ -151,5 +154,36 @@ describe("partnerArtistDocumentsConnection", () => {
         totalCount: 3,
       },
     })
+  })
+
+  it("returns public links", async () => {
+    const query = gql`
+      {
+        partnerArtistDocumentsConnection(
+          artistID: "artistID"
+          partnerID: "partnerID"
+          first: 3
+        ) {
+          edges {
+            node {
+              publicUrl
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+    const edges = data.partnerArtistDocumentsConnection.edges
+
+    expect(edges[0].node.publicUrl).toBe(
+      "https://api.artsy.test/api/v1/partner/name/filename-one.pdf"
+    )
+    expect(edges[1].node.publicUrl).toBe(
+      "https://api.artsy.test/api/v1/partner/name/filename-two.pdf"
+    )
+    expect(edges[2].node.publicUrl).toBe(
+      "https://api.artsy.test/api/v1/partner/name/filename-three.pdf"
+    )
   })
 })

--- a/src/schema/v2/__tests__/partnerShowDocumentsConnection.test.ts
+++ b/src/schema/v2/__tests__/partnerShowDocumentsConnection.test.ts
@@ -8,14 +8,17 @@ describe("partnerShowDocumentsConnection", () => {
   beforeEach(() => {
     response = [
       {
+        uri: "partner/name/filename-one.pdf",
         filename: "filename-one.pdf",
         title: "File One",
       },
       {
+        uri: "partner/name/filename-two.pdf",
         filename: "filename-two.png",
         title: "File Two",
       },
       {
+        uri: "partner/name/filename-three.pdf",
         filename: "filename-three.jpg",
         title: "File Three",
       },
@@ -151,5 +154,36 @@ describe("partnerShowDocumentsConnection", () => {
         totalCount: 3,
       },
     })
+  })
+
+  it("returns public links", async () => {
+    const query = gql`
+      {
+        partnerShowDocumentsConnection(
+          showID: "showID"
+          partnerID: "partnerID"
+          first: 3
+        ) {
+          edges {
+            node {
+              publicUrl
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+    const edges = data.partnerShowDocumentsConnection.edges
+
+    expect(edges[0].node.publicUrl).toBe(
+      "https://api.artsy.test/api/v1/partner/name/filename-one.pdf"
+    )
+    expect(edges[1].node.publicUrl).toBe(
+      "https://api.artsy.test/api/v1/partner/name/filename-two.pdf"
+    )
+    expect(edges[2].node.publicUrl).toBe(
+      "https://api.artsy.test/api/v1/partner/name/filename-three.pdf"
+    )
   })
 })

--- a/src/schema/v2/partnerArtistDocumentsConnection.ts
+++ b/src/schema/v2/partnerArtistDocumentsConnection.ts
@@ -1,3 +1,4 @@
+import config from "config"
 import {
   GraphQLString,
   GraphQLObjectType,
@@ -32,6 +33,10 @@ export const PartnerArtistDocumentType = new GraphQLObjectType<
     },
     size: {
       type: new GraphQLNonNull(GraphQLInt),
+    },
+    publicUrl: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ uri }) => `${config.GRAVITY_API_BASE}/${uri}`,
     },
   },
 })

--- a/src/schema/v2/partnerShowDocumentsConnection.ts
+++ b/src/schema/v2/partnerShowDocumentsConnection.ts
@@ -1,3 +1,4 @@
+import config from "config"
 import {
   GraphQLString,
   GraphQLObjectType,
@@ -32,6 +33,10 @@ export const PartnerShowDocumentType = new GraphQLObjectType<
     },
     size: {
       type: new GraphQLNonNull(GraphQLInt),
+    },
+    publicUrl: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ uri }) => `${config.GRAVITY_API_BASE}/${uri}`,
     },
   },
 })


### PR DESCRIPTION
Jira ticket: https://artsyproduct.atlassian.net/browse/MOPLAT-305

Related PR: https://github.com/artsy/metaphysics/pull/4227, https://github.com/artsy/metaphysics/pull/4230

More context you can find here: https://artsy.slack.com/archives/C02NAJ2CGLW/p1658411062552889

### Demo
<img width="1609" alt="demo" src="https://user-images.githubusercontent.com/3513494/180255144-22b46d5b-8e8e-4cc8-abd1-e26303142a2e.png">
