### PR TITLE
feat(user): Add completedOnboardingAt mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5321,6 +5321,17 @@ type CommerceUser {
   id: String!
 }
 
+input CompletedOnboardingMutationInput {
+  clientMutationId: String
+  timestamp: String!
+  userID: String!
+}
+
+type CompletedOnboardingMutationPayload {
+  clientMutationId: String
+  user: User!
+}
+
 type ConditionReportRequest {
   internalID: ID!
   saleArtworkID: ID
@@ -10667,6 +10678,11 @@ type Mutation {
     # Parameters for UpdateImpulseConversationId
     input: CommerceUpdateImpulseConversationIdInput!
   ): CommerceUpdateImpulseConversationIdPayload
+
+  # Sends a timestamp to the server that the user has completed onboarding
+  completedOnboarding(
+    input: CompletedOnboardingMutationInput!
+  ): CompletedOnboardingMutationPayload
   confirmPassword(input: ConfirmPasswordInput!): ConfirmPasswordPayload
 
   # Create an account request
@@ -15649,6 +15665,9 @@ scalar Upload
 type User {
   analytics: AnalyticsUserStats
   cached: Int
+
+  # The date and time that the user has completed onboarding.
+  completedOnboardingAt: String
 
   # Has the user opted out of data transfer.
   dataTransferOptOut: Boolean

--- a/src/schema/v2/me/completedOnboardingMutation.ts
+++ b/src/schema/v2/me/completedOnboardingMutation.ts
@@ -1,0 +1,55 @@
+import { GraphQLString, GraphQLNonNull } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import { UserType } from "../user"
+
+interface GravityError {
+  statusCode: number
+  body: { error?: string; text?: string; message?: string }
+}
+
+interface Input {
+  timestamp: string
+  userID: string
+}
+
+export const completedOnboardingMutation = mutationWithClientMutationId<
+  Input,
+  any,
+  ResolverContext
+>({
+  name: "CompletedOnboardingMutation",
+  description:
+    "Sends a timestamp to the server that the user has completed onboarding",
+  inputFields: {
+    timestamp: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    userID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+  },
+  outputFields: {
+    user: {
+      type: new GraphQLNonNull(UserType),
+      resolve: (user) => user,
+    },
+  },
+  mutateAndGetPayload: async ({ timestamp, userID }, { updateUserLoader }) => {
+    if (!updateUserLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      return await updateUserLoader(userID, {
+        completed_onboarding_at: timestamp,
+      })
+    } catch (error) {
+      if ("body" in (error as any)) {
+        const e = error as GravityError
+        throw new Error(e.body.text ?? e.body.error ?? e.body.message)
+      }
+      throw error
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -147,6 +147,7 @@ import { toggleFeatureFlagMutation } from "./admin/mutations/toggleFeatureFlagMu
 import { MatchConnection } from "./Match"
 import { PartnerArtistDocumentsConnection } from "./partnerArtistDocumentsConnection"
 import { PartnerShowDocumentsConnection } from "./partnerShowDocumentsConnection"
+import { completedOnboardingMutation } from "./me/completedOnboardingMutation"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -282,6 +283,7 @@ export default new GraphQLSchema({
       createGeminiEntryForAsset: CreateGeminiEntryForAsset,
       createIdentityVerificationOverride: createIdentityVerificationOverrideMutation,
       createUserInterest: createUserInterestMutation,
+      completedOnboarding: completedOnboardingMutation,
       deleteBankAccount: deleteBankAccountMutation,
       deleteCreditCard: deleteCreditCardMutation,
       deleteMyAccountMutation: deleteUserAccountMutation,

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -67,6 +67,11 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
   fields: () => ({
     ...InternalIDFields,
     cached,
+    completedOnboardingAt: {
+      description: "The date and time that the user has completed onboarding.",
+      type: GraphQLString,
+      resolve: ({ completed_onboarding_at }) => completed_onboarding_at,
+    },
     name: {
       description: "The given name of the user.",
       type: new GraphQLNonNull(GraphQLString),


### PR DESCRIPTION
This adds a new `completedOnboarding` mutation:

```graphql
mutation {
  completedOnboarding(input:{ userID:"58828b1e9c18db30f3002fba",, timestamp:"222"}) {
    user {
      completedOnboardingAt     
    }
  }
}
```

Related: https://github.com/artsy/gravity/pull/15544 