### PR TITLE
chore: remove flaky test

### DIFF
--- a/src/schema/v2/sale/__tests__/index.test.ts
+++ b/src/schema/v2/sale/__tests__/index.test.ts
@@ -615,14 +615,6 @@ describe("Sale type", () => {
       [
         {
           start_at: now().subtract(10, "days").toISOString(),
-          live_start_at: now().add(1, "minutes").toISOString(),
-          registration_ends_at: now().subtract(2, "days").toISOString(),
-        },
-        "live in a minute",
-      ],
-      [
-        {
-          start_at: now().subtract(10, "days").toISOString(),
           live_start_at: now().add(10, "minutes").toISOString(),
           registration_ends_at: now().subtract(2, "days").toISOString(),
         },


### PR DESCRIPTION
This test flakes a lot (takes enough time to run that even w/ the stubbing, the test sometimes prints "in a few seconds" instead of "in a minute"). Not worth keeping.