### PR TITLE
chore: update route handling of /v2 to be more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ _If you're new to GraphQL, you can checkout [Artsy's GraphQL Workshop](https://g
 
 For `GraphQL Endpoint`, set it to `http://localhost:3000/v2`.
 
-**Note that `/v2` is the default** and `/v1` has been fully deprecated and removed..
+**Note that `/v2` is the default** and `/v1` has been fully deprecated and removed.
 
 ### Introspection Setup
 

--- a/src/test/supportedV2Routes.test.ts
+++ b/src/test/supportedV2Routes.test.ts
@@ -1,0 +1,56 @@
+import { supportedV2RouteHandler } from "index"
+
+describe("supportedV2RouteHandler", () => {
+  describe("not allowing GraphQL requests", () => {
+    it("calls next for a POST not on the root of /v2", () => {
+      const req = { method: "POST", url: "/foo" }
+      const next = jest.fn()
+      supportedV2RouteHandler(req, null, next)
+      expect(next).toHaveBeenCalled()
+    })
+
+    it("calls next for a GET not on the root of /v2", () => {
+      const req = { method: "GET", url: "/foo" }
+      const next = jest.fn()
+      supportedV2RouteHandler(req, null, next)
+      expect(next).toHaveBeenCalled()
+    })
+
+    it("calls next for a GET on the root of /v2 with unknown query params", () => {
+      const req = { method: "GET", url: "/?", query: { unknown: true } }
+      const next = jest.fn()
+      supportedV2RouteHandler(req, null, next)
+      expect(next).toHaveBeenCalled()
+    })
+
+    it("calls next for a PUT", () => {
+      const req = { method: "PUT", url: "/" }
+      const next = jest.fn()
+      supportedV2RouteHandler(req, null, next)
+      expect(next).toHaveBeenCalled()
+    })
+  })
+
+  describe("allowing GraphQL requests", () => {
+    it("allows a GraphQL request to a POST on the root of /v2", () => {
+      const req = { method: "POST", url: "/" }
+      const next = jest.fn()
+      supportedV2RouteHandler(req, null, next)
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it("allows a GraphQL request to a GET on the root of /v2 w/o query params", () => {
+      const req = { method: "GET", url: "/" }
+      const next = jest.fn()
+      supportedV2RouteHandler(req, null, next)
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it("allows a GraphQL request to a GET on the root of /v2 with proper query params", () => {
+      const req = { method: "GET", url: "/?", query: { query: true } }
+      const next = jest.fn()
+      supportedV2RouteHandler(req, null, next)
+      expect(next).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
Wanted to be a bit more explicit about how routes are handled for /v2.

This was prompted by a recent #dev-help question where someone was hitting "/api/v2" in Metaphysics, which matched the catch-all V1 route (!), and thus was actually running V1 with no complaints, which was of course quite confusing.

This tries to be a bit more explicit about the very limited set of valid paths we accept.