### PR TITLE
feat: re-add matchArtist to root

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12945,6 +12945,21 @@ type Query {
 
   # Get price insights for a market.
   marketPriceInsights(artistId: ID!, medium: String!): MarketPriceInsights
+
+  # A Search for Artists
+  matchArtist(
+    # Exclude these MongoDB ids from results
+    excludeIDs: [String]
+
+    # Page to retrieve. Default: 1.
+    page: Int
+
+    # Maximum number of items to retrieve. Default: 5.
+    size: Int
+
+    # Your search term
+    term: String!
+  ): [Artist]
   matchConnection(
     after: String
     before: String
@@ -16327,6 +16342,21 @@ type Viewer {
     size: Int
     slugs: [String!]
   ): [MarketingCollection]
+
+  # A Search for Artists
+  matchArtist(
+    # Exclude these MongoDB ids from results
+    excludeIDs: [String]
+
+    # Page to retrieve. Default: 1.
+    page: Int
+
+    # Maximum number of items to retrieve. Default: 5.
+    size: Int
+
+    # Your search term
+    term: String!
+  ): [Artist]
   matchConnection(
     after: String
     before: String

--- a/src/schema/v2/match/__tests__/artist.test.js
+++ b/src/schema/v2/match/__tests__/artist.test.js
@@ -2,7 +2,7 @@
 import { runQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
 
-describe.skip("MatchArtist", () => {
+describe("MatchArtist", () => {
   it("queries match/artist for the term 'ok'", () => {
     const query = gql`
       {

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -56,7 +56,7 @@ import Me from "./me"
 import { BidderPositionMutation } from "./me/bidder_position_mutation"
 // import MatchGene from "./match/gene"
 // import SaleArtwork from "./sale_artwork"
-// import MatchArtist from "./match/artist"
+import MatchArtist from "./match/artist"
 // import { SaleArtworksConnectionField } from "./sale_artworks"
 import Conversation from "./me/conversation"
 import SendConversationMessageMutation from "./me/conversation/send_message_mutation"
@@ -212,7 +212,7 @@ const rootFields = {
     resolve: Image.resolve,
     description: "Do not use (only used internally for stitching)",
   },
-  // matchArtist: MatchArtist,
+  matchArtist: MatchArtist,
   // matchGene: MatchGene,
   matchConnection: MatchConnection,
   me: Me,


### PR DESCRIPTION
This is being used by Currents, so it's time to re-add this!

I recall some discussion about a more proper Relay/Next auto-complete for artist in Forque's dupe tool, but that winds up using Gravity directly (but side-note, the one in Currents seems like a decent auto-complete that uses Relay/GraphQL as an example)?