### PR TITLE
Fix typos in bulk update mutation

### DIFF
--- a/src/schema/v2/bulkUpdatePartnerArtworksMutation.ts
+++ b/src/schema/v2/bulkUpdatePartnerArtworksMutation.ts
@@ -13,6 +13,7 @@ import {
 } from "lib/gravityErrorHandler"
 import { GraphQLObjectType } from "graphql"
 import { GraphQLUnionType } from "graphql"
+import { isExisty } from "lib/helpers"
 
 interface Input {
   id: string
@@ -26,10 +27,10 @@ const BulkUpdatePartnerArtworksResponseType = new GraphQLObjectType<
   ResolverContext
 >({
   name: "BulkUpdatePartnerArtworksResponse",
-  fields: {
+  fields: () => ({
     count: { type: GraphQLInt },
     ids: { type: GraphQLList(GraphQLString) },
-  },
+  }),
 })
 
 const BulkUpdatePartnerArtworksMutationSuccessType = new GraphQLObjectType<
@@ -37,6 +38,7 @@ const BulkUpdatePartnerArtworksMutationSuccessType = new GraphQLObjectType<
   ResolverContext
 >({
   name: "BulkUpdatePartnerArtworksMutationSuccess",
+  isTypeOf: (data) => isExisty(data.success),
   fields: () => ({
     updatedPartnerArtworks: { type: BulkUpdatePartnerArtworksResponseType },
     skippedPartnerArtworks: { type: BulkUpdatePartnerArtworksResponseType },

--- a/src/schema/v2/bulkUpdatePartnerArtworksMutation.ts
+++ b/src/schema/v2/bulkUpdatePartnerArtworksMutation.ts
@@ -67,6 +67,11 @@ const BulkUpdatePartnerArtworksMutationType = new GraphQLUnionType({
     BulkUpdatePartnerArtworksMutationSuccessType,
     BulkUpdatePartnerArtworksMutationFailureType,
   ],
+  resolveType: (object) => {
+    if (object.skippedPartnerArtworks) {
+      return BulkUpdatePartnerArtworksMutationSuccessType
+    } else return BulkUpdatePartnerArtworksMutationFailureType
+  },
 })
 
 export const bulkUpdatePartnerArtworksMutation = mutationWithClientMutationId<

--- a/src/schema/v2/bulkUpdatePartnerArtworksMutation.ts
+++ b/src/schema/v2/bulkUpdatePartnerArtworksMutation.ts
@@ -66,9 +66,10 @@ const BulkUpdatePartnerArtworksMutationType = new GraphQLUnionType({
     BulkUpdatePartnerArtworksMutationFailureType,
   ],
   resolveType: (object) => {
-    if (object.skippedPartnerArtworks) {
-      return BulkUpdatePartnerArtworksMutationSuccessType
-    } else return BulkUpdatePartnerArtworksMutationFailureType
+    if (object.mutationError) {
+      return BulkUpdatePartnerArtworksMutationFailureType
+    }
+    return BulkUpdatePartnerArtworksMutationSuccessType
   },
 })
 

--- a/src/schema/v2/bulkUpdatePartnerArtworksMutation.ts
+++ b/src/schema/v2/bulkUpdatePartnerArtworksMutation.ts
@@ -123,8 +123,8 @@ export const bulkUpdatePartnerArtworksMutation = mutationWithClientMutationId<
       const formattedReturn = {
         updatedPartnerArtworks: { count: gravityResponse.success, ids: [] },
         skippedPartnerArtworks: {
-          count: gravityResponse.error.count,
-          ids: gravityResponse.error.ids,
+          count: gravityResponse.errors.count,
+          ids: gravityResponse.errors.ids,
         },
       }
 

--- a/src/schema/v2/bulkUpdatePartnerArtworksMutation.ts
+++ b/src/schema/v2/bulkUpdatePartnerArtworksMutation.ts
@@ -103,14 +103,13 @@ export const bulkUpdatePartnerArtworksMutation = mutationWithClientMutationId<
       type: BulkUpdatePartnerArtworksMutationType,
       resolve: (result) => {
         // In the future it could be helpful to have a list of successfully opted in ids, can add this to gravity at a later date
-        const formattedReturn = {
+        return {
           updatedPartnerArtworks: { count: result.success, ids: [] },
           skippedPartnerArtworks: {
             count: result.errors.count,
             ids: result.errors.ids,
           },
         }
-        return formattedReturn
       },
     },
   },
@@ -129,12 +128,7 @@ export const bulkUpdatePartnerArtworksMutation = mutationWithClientMutationId<
     }
 
     try {
-      const gravityResponse = await updatePartnerArtworksLoader(
-        id,
-        gravityOptions
-      )
-
-      return gravityResponse
+      return await updatePartnerArtworksLoader(id, gravityOptions)
     } catch (error) {
       const formattedErr = formatGravityError(error)
       if (formattedErr) {

--- a/src/schema/v2/bulkUpdatePartnerArtworksMutation.ts
+++ b/src/schema/v2/bulkUpdatePartnerArtworksMutation.ts
@@ -66,7 +66,6 @@ const BulkUpdatePartnerArtworksMutationType = new GraphQLUnionType({
     BulkUpdatePartnerArtworksMutationFailureType,
   ],
   resolveType: (object) => {
-    console.log("OBJECT IN RESOLVE TYPE", object)
     if (object.skippedPartnerArtworks) {
       return BulkUpdatePartnerArtworksMutationSuccessType
     } else return BulkUpdatePartnerArtworksMutationFailureType


### PR DESCRIPTION
I introduced a breaking typo ("error" instead of "errors") when making changes requested in PR comments. My bad!

I also decided along with @ansor4 to mov the response formatting to the resolver.