### PR TITLE
feat: Add medianSalePriceDisplayText to artwork price insights

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2358,6 +2358,10 @@ type ArtworkPriceInsights {
   ): String
   demandRank: Float
   lastAuctionResultDate: String
+  medianSalePriceDisplayText(
+    # Passes in to numeral, such as `'0.00'`
+    format: String = ""
+  ): String
   medium: String
 }
 

--- a/src/lib/loaders/loaders_with_authentication/vortex.ts
+++ b/src/lib/loaders/loaders_with_authentication/vortex.ts
@@ -64,12 +64,13 @@ export default (accessToken, opts) => {
             totalCount
             edges {
               node {
-                artistId
-                medium
-                demandRank
                 annualLotsSold
                 annualValueSoldCents
+                artistId
+                demandRank
                 lastAuctionResultDate
+                medianSalePriceLast36Months
+                medium
               }
             }
           }

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -130,6 +130,23 @@ const ArtworkPriceInsightsType = new GraphQLObjectType<any, ResolverContext>({
         )
       },
     },
+    medianSalePriceDisplayText: {
+      type: GraphQLString,
+      args: {
+        format: {
+          type: GraphQLString,
+          description: "Passes in to numeral, such as `'0.00'`",
+          defaultValue: "",
+        },
+      },
+      resolve: ({ medianSalePriceLast36Months }, { format }) => {
+        if (!medianSalePriceLast36Months) {
+          return null
+        }
+
+        return priceDisplayText(medianSalePriceLast36Months, "USD", format)
+      },
+    },
     lastAuctionResultDate: {
       type: GraphQLString,
     },

--- a/src/schema/v2/me/__tests__/myCollection.test.ts
+++ b/src/schema/v2/me/__tests__/myCollection.test.ts
@@ -340,6 +340,7 @@ describe("me.myCollection", () => {
                 marketPriceInsights {
                   demandRank
                   averageSalePriceDisplayText
+                  medianSalePriceDisplayText
                 }
               }
             }
@@ -393,6 +394,7 @@ describe("me.myCollection", () => {
                   "marketPriceInsights": Object {
                     "averageSalePriceDisplayText": "US$2,176,421",
                     "demandRank": 0.64,
+                    "medianSalePriceDisplayText": "US$5,776,622,000",
                   },
                   "medium": "Painting",
                   "title": "some title",
@@ -509,6 +511,7 @@ const mockVortexResponse = [
     annualLotsSold: 25,
     annualValueSoldCents: 577662200012,
     lastAuctionResultDate: "2022-06-15T00:00:00Z",
+    medianSalePriceLast36Months: 577662200012,
   },
   {
     artistId: "artist-id",
@@ -517,5 +520,6 @@ const mockVortexResponse = [
     annualLotsSold: 10,
     annualValueSoldCents: 2176421231,
     lastAuctionResultDate: "2023-06-15T00:00:00Z",
+    medianSalePriceLast36Months: 577662200012,
   },
 ]


### PR DESCRIPTION
Addresses [CX-2688]

## Description

Add `medianSalePriceDisplayText` to artwork price insights.

[CX-2688]: https://artsyproduct.atlassian.net/browse/CX-2688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ