### PR TITLE
fix(CX-2748): show category instead of medium

### DIFF
--- a/src/schema/v2/me/__tests__/myCollection.test.ts
+++ b/src/schema/v2/me/__tests__/myCollection.test.ts
@@ -477,6 +477,7 @@ const mockCollectionArtworksResponse = {
       _id: "58e3e54aa09a6708282022f6",
       title: "some title",
       medium: "Print",
+      category: "Print",
       artist: {
         _id: "artist-id",
       },
@@ -485,6 +486,7 @@ const mockCollectionArtworksResponse = {
       _id: "58e3e52aa09a6708282022f6",
       title: "another title",
       medium: "Print",
+      category: "Print",
       artist: {
         _id: "artist-id",
       },
@@ -493,6 +495,7 @@ const mockCollectionArtworksResponse = {
       _id: "58e3e54aa09a6708282022f6",
       title: "some title",
       medium: "Painting",
+      category: "Painting",
       artist: {
         _id: "artist-id",
       },

--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -142,7 +142,7 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
         )
         enrichedArtworks = uniqWith(
           enrichedArtworks,
-          (a, b) => a.artist._id === b.artist._id && a.medium === b.medium
+          (a, b) => a.artist._id === b.artist._id && a.category === b.category
         )
       }
 


### PR DESCRIPTION
We are filtering using the medium instead of the category and this results on the mediums displayed in the insights tab. 
![Screenshot_20220811_162442 (2)](https://user-images.githubusercontent.com/11945712/184330761-5ca9f72d-2e1c-4b9f-b7e7-9d0b5c40534a.jpg)


After changes locally 
![Simulator Screen Shot - iPhone 13 Pro - 2022-08-12 at 11 54 45](https://user-images.githubusercontent.com/11945712/184330884-5f0ba2cd-42ee-4592-b7e2-5005c93f2fe7.png)

Note: the category is displayed twice because we run uniqWith also applied to medium, we will need to delete that in few weeks