### PR TITLE
feat: add marketPriceInsights to the artwork interface

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2354,6 +2354,9 @@ union ArtworkOrEditionSetType = Artwork | EditionSet
 type ArtworkPriceInsights {
   annualLotsSold: Int
   annualValueSoldCents: FormattedNumber
+
+  # The annual value of the work sold "in USD "
+  annualValueSoldDisplayText: String
   artistId: String
   averageSalePriceDisplayText(
     # Passes in to numeral, such as `'0.00'`
@@ -2361,6 +2364,10 @@ type ArtworkPriceInsights {
   ): String
   demandRank: Float
   lastAuctionResultDate: String
+  liquidityRankDisplayText(
+    # Return the liquidity rank in a formatted way (Low, medium, high or very high)
+    format: String = ""
+  ): String
   medianSalePriceDisplayText(
     # Passes in to numeral, such as `'0.00'`
     format: String = ""

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "graphql": "14.5.4",
     "graphql-depth-limit": "1.1.0",
     "graphql-middleware": "1.2.6",
+    "graphql-parse-resolve-info": "^4.12.3",
     "graphql-relay": "0.5.4",
     "graphql-tools": "4.0.5",
     "graphql-type-json": "0.1.4",

--- a/src/lib/__tests__/formatLargeNumber.test.ts
+++ b/src/lib/__tests__/formatLargeNumber.test.ts
@@ -1,0 +1,27 @@
+import { formatLargeNumber } from "../formatLargeNumber"
+
+describe("formatLargeNumber", () => {
+  describe("no decimal places specified", () => {
+    it("returns the number when less than 1000", () => {
+      expect(formatLargeNumber(132)).toEqual("132")
+    })
+
+    it("returns the number of thousands when less than 1m", () => {
+      expect(formatLargeNumber(123456)).toEqual("123k")
+    })
+
+    it("returns the number of millions when less than 1b", () => {
+      expect(formatLargeNumber(987654321)).toEqual("988M")
+    })
+
+    it("returns the number of billions when less than 1t which is totally going to happen soon", () => {
+      expect(formatLargeNumber(543235234432)).toEqual("543B")
+    })
+  })
+
+  describe("decimal places specified", () => {
+    it("includes specified decimal places", () => {
+      expect(formatLargeNumber(123456, 2)).toEqual("123.46k")
+    })
+  })
+})

--- a/src/lib/fillers/enrichArtworksWithPriceInsights.ts
+++ b/src/lib/fillers/enrichArtworksWithPriceInsights.ts
@@ -1,0 +1,49 @@
+import { MarketPriceInsight } from "lib/loaders/loaders_with_authentication/vortex"
+import { uniqWith, isEqual } from "lodash"
+import * as Sentry from "@sentry/node"
+export const enrichArtworksWithPriceInsights = async (
+  artworks: Array<any>,
+  marketPriceInsightsBatchLoader: (
+    params: {
+      artistId: string
+      medium: string
+      category: string
+    }[]
+  ) => Promise<MarketPriceInsight[]>
+) => {
+  try {
+    const marketPriceInsightParams = uniqWith(
+      artworks.map((artwork: any) => ({
+        artistId: artwork.artist?._id,
+        medium: artwork.medium,
+        category: artwork.category,
+      })),
+      isEqual
+    )
+
+    const priceInsightNodes =
+      (await marketPriceInsightsBatchLoader(marketPriceInsightParams)) || []
+
+    return artworks.map((artwork: any) => {
+      const insights = priceInsightNodes.find(
+        (insight: MarketPriceInsight) =>
+          insight.artistId === artwork.artist?._id &&
+          // TODO: Fix this logic once we only need category to fetch insights
+          (insight.medium === artwork.medium ||
+            insight.medium === artwork.category)
+      )
+
+      artwork.marketPriceInsights = insights
+
+      return artwork
+    })
+  } catch (error) {
+    console.error("error")
+    Sentry.captureException(
+      "Failed to load price insights for My Collection",
+      error
+    )
+
+    return artworks
+  }
+}

--- a/src/lib/formatLargeNumber.ts
+++ b/src/lib/formatLargeNumber.ts
@@ -1,0 +1,19 @@
+/**
+ *
+ * @param number
+ * @param decimalPlaces
+ * @returns the number formatted with the specified decimal places
+ * @example formatLargeNumber(123456, 2) => "123.46k"
+ * @example formatLargeNumber(123456, 0) => "123k"
+ */
+export function formatLargeNumber(number: number, decimalPlaces = 0) {
+  if (number < 1000) {
+    return number.toString()
+  } else if (number < 1000000) {
+    return `${(number / 1000).toFixed(decimalPlaces)}k`
+  } else if (number < 1000000000) {
+    return `${(number / 1000000).toFixed(decimalPlaces)}M`
+  } else {
+    return `${(number / 1000000000).toFixed(decimalPlaces)}B`
+  }
+}

--- a/src/lib/ifFieldRequested.ts
+++ b/src/lib/ifFieldRequested.ts
@@ -1,0 +1,26 @@
+import { GraphQLResolveInfo } from "graphql"
+import {
+  parseResolveInfo,
+  ResolveTree,
+  simplifyParsedResolveInfoFragmentWithType,
+} from "graphql-parse-resolve-info"
+
+export const isFieldRequested = (
+  field: string,
+  resolveInfo: GraphQLResolveInfo
+) => {
+  const parsedResolveInfoFragment = parseResolveInfo(resolveInfo)
+  if (parsedResolveInfoFragment) {
+    const {
+      fields: requestedFields,
+    } = simplifyParsedResolveInfoFragmentWithType(
+      parsedResolveInfoFragment as any,
+      resolveInfo.returnType
+    )
+
+    return !!Object.values(requestedFields).find(
+      (requestedField) => (requestedField as ResolveTree).name === field
+    )
+  }
+  return false
+}

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -17,7 +17,7 @@ describe("Artwork type", () => {
     {
       artistId: "artist-id",
       demandRank: 0.64,
-      medium: "Print",
+      medium: "print",
       annualLotsSold: 25,
       annualValueSoldCents: 577662200012,
       lastAuctionResultDate: "2022-06-15T00:00:00Z",

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -13,6 +13,19 @@ describe("Artwork type", () => {
   let artwork = null
   let context = null
 
+  const artworkInsights = [
+    {
+      artistId: "artist-id",
+      demandRank: 0.64,
+      medium: "Print",
+      annualLotsSold: 25,
+      annualValueSoldCents: 577662200012,
+      lastAuctionResultDate: "2022-06-15T00:00:00Z",
+      medianSalePriceLast36Months: 577662200012,
+      liquidityRank: 0.9,
+    },
+  ]
+
   const artworkImages = [
     {
       position: 2,
@@ -3563,6 +3576,59 @@ describe("Artwork type", () => {
       expect(data).toEqual({
         artwork: {
           hasMarketPriceInsights: false,
+        },
+      })
+    })
+  })
+
+  it("queries for marketPriceInsights when they are requested", () => {
+    const query = `
+        {
+          artwork(id: "foo-bar") {
+            title
+            marketPriceInsights   {
+              liquidityRankDisplayText
+            }
+          }
+        }
+      `
+
+    const marketPriceInsightsBatchLoader = jest.fn(async () => artworkInsights)
+
+    context.marketPriceInsightsBatchLoader = marketPriceInsightsBatchLoader
+
+    return runQuery(query, context).then((data) => {
+      expect(marketPriceInsightsBatchLoader).toHaveBeenCalled()
+
+      expect(data).toEqual({
+        artwork: {
+          title: "Untitled (Portrait)",
+          marketPriceInsights: {
+            liquidityRankDisplayText: "Very High",
+          },
+        },
+      })
+    })
+  })
+
+  it("does not query for marketPriceInsights when they're not requested", () => {
+    const query = `
+        {
+          artwork(id: "foo-bar") {
+            title
+          }
+        }
+      `
+
+    const marketPriceInsightsBatchLoader = jest.fn(async () => artworkInsights)
+
+    context.marketPriceInsightsBatchLoader = marketPriceInsightsBatchLoader
+
+    return runQuery(query, context).then((data) => {
+      expect(marketPriceInsightsBatchLoader).not.toHaveBeenCalled()
+      expect(data).toEqual({
+        artwork: {
+          title: "Untitled (Portrait)",
         },
       })
     })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -18,7 +18,9 @@ import artworkMediums from "lib/artworkMediums"
 // Mapping of attribution_class ids to AttributionClass values
 import attributionClasses from "lib/attributionClasses"
 import { deprecate } from "lib/deprecation"
+import { formatLargeNumber } from "lib/formatLargeNumber"
 import { capitalizeFirstCharacter, enhance, existyValue } from "lib/helpers"
+import { isFieldRequested } from "lib/ifFieldRequested"
 import { priceDisplayText, priceRangeDisplayText } from "lib/moneyHelpers"
 import _ from "lodash"
 import Article from "schema/v2/article"
@@ -106,6 +108,13 @@ const ArtworkPriceInsightsType = new GraphQLObjectType<any, ResolverContext>({
     annualValueSoldCents: {
       type: FormattedNumber,
     },
+    annualValueSoldDisplayText: {
+      type: GraphQLString,
+      description: 'The annual value of the work sold "in USD "',
+      resolve: ({ annualValueSoldCents }) => {
+        return `$${formatLargeNumber(annualValueSoldCents)}`
+      },
+    },
     annualLotsSold: {
       type: GraphQLInt,
     },
@@ -128,6 +137,35 @@ const ArtworkPriceInsightsType = new GraphQLObjectType<any, ResolverContext>({
           "USD",
           format
         )
+      },
+    },
+    liquidityRankDisplayText: {
+      type: GraphQLString,
+      args: {
+        format: {
+          type: GraphQLString,
+          description:
+            "Return the liquidity rank in a formatted way (Low, medium, high or very high)",
+          defaultValue: "",
+        },
+      },
+      resolve: ({ liquidityRank }) => {
+        if (liquidityRank === null) {
+          return ""
+        }
+
+        switch (true) {
+          case liquidityRank < 0.25:
+            return "Low"
+          case liquidityRank >= 0.25 && liquidityRank < 0.7:
+            return "Medium"
+          case liquidityRank >= 0.7 && liquidityRank < 0.85:
+            return "High"
+          case liquidityRank >= 0.85:
+            return "Very High"
+        }
+
+        return ""
       },
     },
     medianSalePriceDisplayText: {
@@ -1451,13 +1489,51 @@ const Artwork: GraphQLFieldConfig<void, ResolverContext> = {
       description: "Include unlisted artwork or not",
     },
   },
-  resolve: (_source, args, { artworkLoader }) => {
+  resolve: async (
+    _source,
+    args,
+    { artworkLoader, marketPriceInsightsBatchLoader },
+    resolveInfo
+  ) => {
     const { id } = args
     const gravityParams = _.mapKeys(
       _.pick(args, ["includeUnlisted"]),
       (_v, k) => _.snakeCase(k)
     )
-    return artworkLoader(id, gravityParams)
+
+    const hasRequestedPriceInsights = isFieldRequested(
+      "marketPriceInsights",
+      resolveInfo
+    )
+
+    const gravityArtworkRes = await artworkLoader(id, gravityParams)
+
+    const enrichedArtwork = {
+      ...gravityArtworkRes,
+    }
+
+    // We don't want to query for the price insights unless the user has requested them
+    if (
+      marketPriceInsightsBatchLoader &&
+      gravityArtworkRes &&
+      hasRequestedPriceInsights
+    ) {
+      const marketPriceInsight = await marketPriceInsightsBatchLoader([
+        {
+          artistId: gravityArtworkRes.artist._id,
+          medium: gravityArtworkRes.medium,
+          category: gravityArtworkRes.category,
+        },
+      ])
+
+      if (marketPriceInsight.length > 0) {
+        enrichedArtwork.marketPriceInsights = marketPriceInsight[0]
+      } else {
+        enrichedArtwork.marketPriceInsights = null
+      }
+    }
+
+    return enrichedArtwork
   },
 }
 

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1520,7 +1520,7 @@ const Artwork: GraphQLFieldConfig<void, ResolverContext> = {
         marketPriceInsightsBatchLoader
       )
 
-      return enrichedArtworks && enrichedArtworks[0]
+      return enrichedArtworks?.[0]
     }
 
     return artwork

--- a/src/schema/v2/me/__tests__/myCollection.test.ts
+++ b/src/schema/v2/me/__tests__/myCollection.test.ts
@@ -338,8 +338,10 @@ describe("me.myCollection", () => {
                   internalID
                 }
                 marketPriceInsights {
-                  demandRank
+                  annualValueSoldDisplayText
                   averageSalePriceDisplayText
+                  demandRank
+                  liquidityRankDisplayText
                   medianSalePriceDisplayText
                 }
               }
@@ -392,8 +394,10 @@ describe("me.myCollection", () => {
                   },
                   "internalID": "artwork_id_with_market_price_insights",
                   "marketPriceInsights": Object {
+                    "annualValueSoldDisplayText": "$2B",
                     "averageSalePriceDisplayText": "US$2,176,421",
                     "demandRank": 0.64,
+                    "liquidityRankDisplayText": "Medium",
                     "medianSalePriceDisplayText": "US$5,776,622,000",
                   },
                   "medium": "Painting",
@@ -515,6 +519,7 @@ const mockVortexResponse = [
     annualValueSoldCents: 577662200012,
     lastAuctionResultDate: "2022-06-15T00:00:00Z",
     medianSalePriceLast36Months: 577662200012,
+    liquidityRank: 0.9,
   },
   {
     artistId: "artist-id",
@@ -524,5 +529,6 @@ const mockVortexResponse = [
     annualValueSoldCents: 2176421231,
     lastAuctionResultDate: "2023-06-15T00:00:00Z",
     medianSalePriceLast36Months: 577662200012,
+    liquidityRank: 0.5,
   },
 ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -4912,6 +4912,14 @@ graphql-middleware@1.2.6:
   dependencies:
     graphql-tools "^3.0.2"
 
+graphql-parse-resolve-info@^4.12.3:
+  version "4.12.3"
+  resolved "https://registry.yarnpkg.com/graphql-parse-resolve-info/-/graphql-parse-resolve-info-4.12.3.tgz#89df645f72c068760eed9176806009107b6c6ed5"
+  integrity sha512-Lxb+v+SCxzBZHKohK4xje3CBQ1iZ968DiKuFtmwzSaI45oP8FgPJjJv35TOzgv73QLijEdgH4NDZGwIvwJM7Kw==
+  dependencies:
+    debug "^4.1.1"
+    tslib "^2.0.1"
+
 graphql-relay@0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/graphql-relay/-/graphql-relay-0.5.4.tgz#58050cfe16118595f82ab3aabfc974546ce755a8"
@@ -9409,6 +9417,11 @@ tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+tslib@^2.0.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tslib@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
**Description:**

The `marketPriceInsights` interface was broken for artwork and was always returning `null`. The problem was that there was no resolver supplied to it.

I also added some of the logic of the display that we need for the artist insights inside Force. The next step will be to use those new field in Eigen since Eigen is now doing that logic locally.

**Jira ticket:** https://artsyproduct.atlassian.net/browse/CX-2768