### PR TITLE
feat: expose notificationsConnection using existing /feed structure

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11300,6 +11300,69 @@ interface Node {
   id: ID!
 }
 
+type Notification implements Node {
+  artworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See
+    # http://www.iana.org/time-zones,
+    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID.
+  internalID: ID!
+  isUnread: Boolean!
+  message: String!
+  notificationType: NotificationTypesEnum!
+  targetHref: String!
+  title: String!
+}
+
+# A connection to a list of items.
+type NotificationConnection {
+  counts: NotificationCounts
+
+  # A list of edges.
+  edges: [NotificationEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+type NotificationCounts {
+  total(
+    # Returns a `String` when format is specified. e.g.`'0,0.0000''`
+    format: String
+    label: String
+  ): FormattedNumber
+  unread(
+    # Returns a `String` when format is specified. e.g.`'0,0.0000''`
+    format: String
+    label: String
+  ): FormattedNumber
+}
+
+# An edge in a connection.
+type NotificationEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: Notification
+}
+
 type NotificationPreference {
   channel: String!
   id: String!
@@ -11310,6 +11373,11 @@ type NotificationPreference {
 input NotificationPreferenceInput {
   name: String!
   status: SubGroupInputStatus!
+}
+
+enum NotificationTypesEnum {
+  ARTWORK_ALERT
+  ARTWORK_PUBLISHED
 }
 
 # Consignment Offer Response
@@ -13210,6 +13278,17 @@ type Query {
   notificationPreferences(
     authenticationToken: String
   ): [NotificationPreference!]!
+
+  # A feed of notifications
+  notificationsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+
+    # Notification types to return
+    notificationTypes: [NotificationTypesEnum]
+  ): NotificationConnection
 
   # Get an Offer
   offer(
@@ -16751,6 +16830,17 @@ type Viewer {
   notificationPreferences(
     authenticationToken: String
   ): [NotificationPreference!]!
+
+  # A feed of notifications
+  notificationsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+
+    # Notification types to return
+    notificationTypes: [NotificationTypesEnum]
+  ): NotificationConnection
 
   # An OrderedSet
   orderedSet(

--- a/src/schema/v2/notifications/__tests__/index.test.ts
+++ b/src/schema/v2/notifications/__tests__/index.test.ts
@@ -1,0 +1,79 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("notificationsConnection", () => {
+  const notificationsFeedLoader = jest.fn(() =>
+    Promise.resolve({
+      feed: [
+        {
+          id: "6303f205b54941000843419a",
+          actors: "Works by Damien Hirst",
+          message: "8 Works Added",
+          status: "unread",
+          date: "2022-08-22T21:15:49.000Z",
+          object_ids: ["63036fafbe5cfc000cf358e3", "630392514f13a5000b55ecec"],
+          object: { artist: { id: "damien-hirst" } },
+        },
+      ],
+      total: 100,
+      total_unread: 10,
+    })
+  )
+
+  afterEach(() => {
+    notificationsFeedLoader.mockClear()
+  })
+
+  it("returns data", async () => {
+    const query = gql`
+      {
+        notificationsConnection(first: 10, notificationTypes: [ARTWORK_ALERT]) {
+          counts {
+            total
+            unread
+          }
+          edges {
+            node {
+              internalID
+              isUnread
+              createdAt(format: "YYYY")
+              notificationType
+              title
+              message
+              targetHref
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runAuthenticatedQuery(query, { notificationsFeedLoader })
+
+    expect(notificationsFeedLoader).toHaveBeenCalledWith({
+      size: 10,
+      page: 1,
+    })
+
+    expect(data).toEqual({
+      notificationsConnection: {
+        counts: {
+          total: 100,
+          unread: 10,
+        },
+        edges: [
+          {
+            node: {
+              internalID: "6303f205b54941000843419a",
+              isUnread: true,
+              createdAt: "2022",
+              notificationType: "ARTWORK_ALERT",
+              title: "Works by Damien Hirst",
+              message: "8 works added",
+              targetHref: "/artist/damien-hirst/works-for-sale",
+            },
+          },
+        ],
+      },
+    })
+  })
+})

--- a/src/schema/v2/notifications/index.ts
+++ b/src/schema/v2/notifications/index.ts
@@ -1,0 +1,125 @@
+import {
+  GraphQLBoolean,
+  GraphQLEnumType,
+  GraphQLFieldConfig,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { pageable } from "relay-cursor-paging"
+import {
+  connectionWithCursorInfo,
+  createPageCursors,
+} from "schema/v2/fields/pagination"
+import { ResolverContext } from "types/graphql"
+import { IDFields, NodeInterface } from "../object_identification"
+import { date } from "schema/v2/fields/date"
+import { artworkConnection } from "../artwork"
+import { connectionFromArray, connectionFromArraySlice } from "graphql-relay"
+import numeral from "../fields/numeral"
+import { pick } from "lodash"
+
+const NotificationTypesEnum = new GraphQLEnumType({
+  name: "NotificationTypesEnum",
+  values: {
+    ARTWORK_ALERT: { value: "artwork_alert" },
+    ARTWORK_PUBLISHED: { value: "artwork_published" },
+  },
+})
+
+export const NotificationType = new GraphQLObjectType<any, ResolverContext>({
+  name: "Notification",
+  interfaces: [NodeInterface],
+  fields: () => ({
+    ...IDFields,
+    title: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ actors }) => actors,
+    },
+    message: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ message }) => message.toLowerCase(),
+    },
+    isUnread: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      resolve: ({ status }) => status === "unread",
+    },
+    createdAt: date(({ date }) => date),
+    targetHref: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ object }) => `/artist/${object.artist.id}/works-for-sale`,
+    },
+    notificationType: {
+      type: new GraphQLNonNull(NotificationTypesEnum),
+      resolve: ({ actors }) =>
+        actors.startsWith("Works by") ? "artwork_alert" : "artwork_published",
+    },
+    artworksConnection: {
+      type: artworkConnection.connectionType,
+      args: pageable(),
+      resolve: async ({ object_ids: ids }, args, { artworksLoader }) => {
+        const { page, size } = convertConnectionArgsToGravityArgs(args)
+        return artworksLoader({ ids, batched: true }).then((body) => {
+          const totalCount = body.length
+          return {
+            totalCount,
+            pageCursors: createPageCursors({ page, size }, totalCount),
+            ...connectionFromArray(body, args),
+          }
+        })
+      },
+    },
+  }),
+})
+
+const NotificationCounts = {
+  type: new GraphQLObjectType<any, ResolverContext>({
+    name: "NotificationCounts",
+    fields: {
+      total: numeral(({ total }) => total),
+      unread: numeral(({ unread }) => unread),
+    },
+  }),
+  resolve: (data) => data.counts,
+}
+
+export const NotificationsConnection: GraphQLFieldConfig<
+  void,
+  ResolverContext
+> = {
+  type: connectionWithCursorInfo({
+    nodeType: NotificationType,
+    connectionFields: { counts: NotificationCounts },
+  }).connectionType,
+  description: "A feed of notifications",
+  args: pageable({
+    notificationTypes: {
+      type: new GraphQLList(NotificationTypesEnum),
+      description: "Notification types to return",
+    },
+  }),
+  resolve: async (_root, args, { notificationsFeedLoader }) => {
+    if (!notificationsFeedLoader) return null
+
+    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+    const body = await notificationsFeedLoader({
+      size,
+      page,
+    })
+
+    return {
+      counts: { total: body.total, unread: body.total_unread },
+      pageCursors: createPageCursors({ page, size }, body.total),
+      ...connectionFromArraySlice(
+        body.feed,
+        pick(args, "before", "after", "first", "last"),
+        {
+          arrayLength: body.total,
+          sliceStart: offset,
+        }
+      ),
+    }
+  },
+}

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -152,6 +152,7 @@ import { MatchConnection } from "./Match"
 import { PartnerArtistDocumentsConnection } from "./partnerArtistDocumentsConnection"
 import { PartnerShowDocumentsConnection } from "./partnerShowDocumentsConnection"
 import { bulkUpdatePartnerArtworksMutation } from "./bulkUpdatePartnerArtworksMutation"
+import { NotificationsConnection } from "./notifications"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -222,6 +223,7 @@ const rootFields = {
   matchConnection: MatchConnection,
   me: Me,
   node: ObjectIdentification.NodeField,
+  notificationsConnection: NotificationsConnection,
   orderedSet: OrderedSet,
   orderedSets: OrderedSets,
   page,


### PR DESCRIPTION
Spike on exposing notifications via notificationsConnection query field.

cc/ @evaschilken @nickskalkin 

**Query**

```graphql
{
  notificationsConnection(first: 1) {
    edges {
      node {
        internalID
        title
        message
        createdAt
        isUnread
        targetHref
        artworksConnection(first: 5) {
          edges {
            node {
              title
            }
          }
        }
      }
    }
  }
}
```

**Response**

```json
{
  "data": {
    "notificationsConnection": {
      "edges": [
        {
          "node": {
            "internalID": "62fe270e071fb90007594c12",
            "title": "Gina Beavers",
            "message": "1 Work Added",
            "createdAt": "2022-08-18T11:48:30.000Z",
            "isUnread": true,
            "targetHref": "/artist/damien-hirst/works-for-sale",
            "artworksConnection": {
              "edges": [
                {
                  "node": {
                    "title": "Florescent Lip"
                  }
                }
              ]
            }
          }
        }
      ]
    }
  }
}
```
```