### PR TITLE
feat: return the sell through rate and median sale over estimate percentage

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2381,11 +2381,13 @@ type ArtworkPriceInsights {
     # Return the liquidity rank in a formatted way (Low, medium, high or very high)
     format: String = ""
   ): String
+  medianSaleOverEstimatePercentage: Float
   medianSalePriceDisplayText(
     # Passes in to numeral, such as `'0.00'`
     format: String = ""
   ): String
   medium: String
+  sellThroughRate: Float
 }
 
 # The results for one of the requested aggregations

--- a/src/lib/loaders/loaders_with_authentication/vortex.ts
+++ b/src/lib/loaders/loaders_with_authentication/vortex.ts
@@ -71,6 +71,8 @@ export default (accessToken, opts) => {
                 lastAuctionResultDate
                 medianSalePriceLast36Months
                 medium
+                sellThroughRate
+                medianSaleOverEstimatePercentage
               }
             }
           }

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -3654,7 +3654,7 @@ describe("Artwork type", () => {
           marketPriceInsights: {
             liquidityRankDisplayText: "Very High",
             sellThroughRate: 0.902,
-            medianSaleOverEstimatePercentage: "123",
+            medianSaleOverEstimatePercentage: 123,
           },
         },
       })

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -23,6 +23,8 @@ describe("Artwork type", () => {
       lastAuctionResultDate: "2022-06-15T00:00:00Z",
       medianSalePriceLast36Months: 577662200012,
       liquidityRank: 0.9,
+      sellThroughRate: 0.902,
+      medianSaleOverEstimatePercentage: 123,
     },
   ]
 
@@ -3632,6 +3634,8 @@ describe("Artwork type", () => {
             title
             marketPriceInsights   {
               liquidityRankDisplayText
+              medianSaleOverEstimatePercentage
+              sellThroughRate
             }
           }
         }
@@ -3649,6 +3653,8 @@ describe("Artwork type", () => {
           title: "Untitled (Portrait)",
           marketPriceInsights: {
             liquidityRankDisplayText: "Very High",
+            sellThroughRate: 0.902,
+            medianSaleOverEstimatePercentage: "123",
           },
         },
       })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -186,8 +186,14 @@ const ArtworkPriceInsightsType = new GraphQLObjectType<any, ResolverContext>({
         return priceDisplayText(medianSalePriceLast36Months, "USD", format)
       },
     },
+    medianSaleOverEstimatePercentage: {
+      type: GraphQLFloat,
+    },
     lastAuctionResultDate: {
       type: GraphQLString,
+    },
+    sellThroughRate: {
+      type: GraphQLFloat,
     },
   },
 })


### PR DESCRIPTION
This PR adds the missing fields needed for the artist market insights to the artwork market insights interface


<img width="1477" alt="Screenshot 2022-08-19 at 12 29 30" src="https://user-images.githubusercontent.com/11945712/185600004-e1158c26-2600-461a-9401-0bf592dc70bb.png">

