### PR TITLE
feat: Add demandRankDisplayText to Artwork Price Insights

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2377,7 +2377,7 @@ type ArtworkPriceInsights {
   ): String
   demandRank: Float
 
-  # The demand rank  of the artist and medium
+  # The demand rank display text of the artist and medium
   demandRankDisplayText: String
   lastAuctionResultDate: String
   liquidityRankDisplayText(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2376,6 +2376,9 @@ type ArtworkPriceInsights {
     format: String = ""
   ): String
   demandRank: Float
+
+  # The demand rank  of the artist and medium
+  demandRankDisplayText: String
   lastAuctionResultDate: String
   liquidityRankDisplayText(
     # Return the liquidity rank in a formatted way (Low, medium, high or very high)

--- a/src/lib/__tests__/getDemandRank.test.ts
+++ b/src/lib/__tests__/getDemandRank.test.ts
@@ -1,19 +1,19 @@
-import { getDemandRank } from "../getDemandRank"
+import { getDemandRankDisplayText } from "../getDemandRank"
 
-describe("getDemandRank", () => {
+describe("getDemandRankDisplayText", () => {
   it("returns 'Less Active Demand' when the rank is less than 0.4", () => {
-    expect(getDemandRank(0.3)).toEqual("Less Active Demand")
+    expect(getDemandRankDisplayText(0.3)).toEqual("Less Active Demand")
   })
 
   it("returns 'Moderate Demand' when the rank is less than 0.7", () => {
-    expect(getDemandRank(0.57)).toEqual("Moderate Demand")
+    expect(getDemandRankDisplayText(0.57)).toEqual("Moderate Demand")
   })
 
   it("returns 'Active Demand' when the rank is less than 0.9", () => {
-    expect(getDemandRank(0.88)).toEqual("Active Demand")
+    expect(getDemandRankDisplayText(0.88)).toEqual("Active Demand")
   })
 
   it("returns 'High Demand' when the rank is over 0.9", () => {
-    expect(getDemandRank(0.95)).toEqual("High Demand")
+    expect(getDemandRankDisplayText(0.95)).toEqual("High Demand")
   })
 })

--- a/src/lib/__tests__/getDemandRank.test.ts
+++ b/src/lib/__tests__/getDemandRank.test.ts
@@ -1,0 +1,19 @@
+import { getDemandRank } from "../getDemandRank"
+
+describe("getDemandRank", () => {
+  it("returns 'Less Active Demand' when the rank is less than 0.4", () => {
+    expect(getDemandRank(0.3)).toEqual("Less Active Demand")
+  })
+
+  it("returns 'Moderate Demand' when the rank is less than 0.7", () => {
+    expect(getDemandRank(0.57)).toEqual("Moderate Demand")
+  })
+
+  it("returns 'Active Demand' when the rank is less than 0.9", () => {
+    expect(getDemandRank(0.88)).toEqual("Active Demand")
+  })
+
+  it("returns 'High Demand' when the rank is over 0.9", () => {
+    expect(getDemandRank(0.95)).toEqual("High Demand")
+  })
+})

--- a/src/lib/getDemandRank.ts
+++ b/src/lib/getDemandRank.ts
@@ -2,10 +2,10 @@
  *
  * @param demandRank
  * @returns the demand rank in a textual form
- * @example getDemandRank(0.2) => "Less Active Demand"
- * @example getDemandRank(0.6) => "Active Demand"
+ * @example getDemandRankDisplayText(0.2) => "Less Active Demand"
+ * @example getDemandRankDisplayText(0.6) => "Active Demand"
  */
-export function getDemandRank(demandRank: number): string {
+export function getDemandRankDisplayText(demandRank: number): string {
   const rank = Number(demandRank * 10)
 
   if (rank >= 9) {

--- a/src/lib/getDemandRank.ts
+++ b/src/lib/getDemandRank.ts
@@ -1,0 +1,20 @@
+/**
+ *
+ * @param demandRank
+ * @returns the demand rank in a textual form
+ * @example getDemandRank(0.2) => "Less Active Demand"
+ * @example getDemandRank(0.6) => "Active Demand"
+ */
+export function getDemandRank(demandRank: number): string {
+  const rank = Number(demandRank * 10)
+
+  if (rank >= 9) {
+    return "High Demand"
+  } else if (rank >= 7) {
+    return "Active Demand"
+  } else if (rank >= 4) {
+    return "Moderate Demand"
+  }
+
+  return "Less Active Demand"
+}

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -20,7 +20,7 @@ import attributionClasses from "lib/attributionClasses"
 import { deprecate } from "lib/deprecation"
 import { enrichArtworksWithPriceInsights } from "lib/fillers/enrichArtworksWithPriceInsights"
 import { formatLargeNumber } from "lib/formatLargeNumber"
-import { getDemandRank } from "lib/getDemandRank"
+import { getDemandRankDisplayText } from "lib/getDemandRank"
 import { capitalizeFirstCharacter, enhance, existyValue } from "lib/helpers"
 import { isFieldRequested } from "lib/ifFieldRequested"
 import { priceDisplayText, priceRangeDisplayText } from "lib/moneyHelpers"
@@ -109,8 +109,8 @@ const ArtworkPriceInsightsType = new GraphQLObjectType<any, ResolverContext>({
     },
     demandRankDisplayText: {
       type: GraphQLString,
-      description: "The demand rank  of the artist and medium",
-      resolve: ({ demandRank }) => getDemandRank(demandRank),
+      description: "The demand rank display text of the artist and medium",
+      resolve: ({ demandRank }) => getDemandRankDisplayText(demandRank),
     },
     annualValueSoldCents: {
       type: FormattedNumber,

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -20,6 +20,7 @@ import attributionClasses from "lib/attributionClasses"
 import { deprecate } from "lib/deprecation"
 import { enrichArtworksWithPriceInsights } from "lib/fillers/enrichArtworksWithPriceInsights"
 import { formatLargeNumber } from "lib/formatLargeNumber"
+import { getDemandRank } from "lib/getDemandRank"
 import { capitalizeFirstCharacter, enhance, existyValue } from "lib/helpers"
 import { isFieldRequested } from "lib/ifFieldRequested"
 import { priceDisplayText, priceRangeDisplayText } from "lib/moneyHelpers"
@@ -105,6 +106,11 @@ const ArtworkPriceInsightsType = new GraphQLObjectType<any, ResolverContext>({
     },
     demandRank: {
       type: GraphQLFloat,
+    },
+    demandRankDisplayText: {
+      type: GraphQLString,
+      description: "The demand rank  of the artist and medium",
+      resolve: ({ demandRank }) => getDemandRank(demandRank),
     },
     annualValueSoldCents: {
       type: FormattedNumber,

--- a/src/schema/v2/me/__tests__/myCollection.test.ts
+++ b/src/schema/v2/me/__tests__/myCollection.test.ts
@@ -341,6 +341,7 @@ describe("me.myCollection", () => {
                   annualValueSoldDisplayText
                   averageSalePriceDisplayText
                   demandRank
+                  demandRankDisplayText
                   liquidityRankDisplayText
                   medianSalePriceDisplayText
                 }
@@ -397,6 +398,7 @@ describe("me.myCollection", () => {
                     "annualValueSoldDisplayText": "$2B",
                     "averageSalePriceDisplayText": "US$2,176,421",
                     "demandRank": 0.64,
+                    "demandRankDisplayText": "Moderate Demand",
                     "liquidityRankDisplayText": "Medium",
                     "medianSalePriceDisplayText": "US$5,776,622,000",
                   },


### PR DESCRIPTION
This PR adds `demandRankDisplayText` to the artwork price insights



### Example
- Query 
```graphql
query {
  artwork(id: "artwork-id") {
    artistNames
    title
    marketPriceInsights {
      demandRank
      demandRankDisplayText
    }
  }
}
```

- Result
```json
{
  "data": {
    "artwork": {
      "artistNames": "FamousArtist",
      "title": "CoolWork",
      "marketPriceInsights": {
        "demandRank": 0.877,
        "demandRankDisplayText": "Active Demand"
      }
    }
  }
}
```


