### PR TITLE
chore: add is high demand flag to the artwork market price insights

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2379,6 +2379,9 @@ type ArtworkPriceInsights {
 
   # The demand rank display text of the artist and medium
   demandRankDisplayText: String
+
+  # Return weather the artist medium is in high demand
+  isHighDemand: Boolean
   lastAuctionResultDate: String
   liquidityRankDisplayText(
     # Return the liquidity rank in a formatted way (Low, medium, high or very high)

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -13,20 +13,32 @@ describe("Artwork type", () => {
   let artwork = null
   let context = null
 
-  const artworkInsights = [
-    {
-      artistId: "artist-id",
-      demandRank: 0.64,
-      medium: "print",
-      annualLotsSold: 25,
-      annualValueSoldCents: 577662200012,
-      lastAuctionResultDate: "2022-06-15T00:00:00Z",
-      medianSalePriceLast36Months: 577662200012,
-      liquidityRank: 0.9,
-      sellThroughRate: 0.902,
-      medianSaleOverEstimatePercentage: 123,
-    },
-  ]
+  const artworkInLowDemand = {
+    artistId: "artist-id",
+    demandRank: 0.64,
+    medium: "print",
+    annualLotsSold: 25,
+    annualValueSoldCents: 577662200012,
+    lastAuctionResultDate: "2022-06-15T00:00:00Z",
+    medianSalePriceLast36Months: 577662200012,
+    liquidityRank: 0.9,
+    sellThroughRate: 0.902,
+    medianSaleOverEstimatePercentage: 123,
+  }
+  const artworkInHighDemand = {
+    artistId: "artist-id",
+    demandRank: 0.9,
+    medium: "print",
+    annualLotsSold: 25,
+    annualValueSoldCents: 577662200012,
+    lastAuctionResultDate: "2022-06-15T00:00:00Z",
+    medianSalePriceLast36Months: 577662200012,
+    liquidityRank: 0.9,
+    sellThroughRate: 0.902,
+    medianSaleOverEstimatePercentage: 123,
+  }
+
+  const artworkInsights = [artworkInLowDemand, artworkInHighDemand]
 
   const artworkImages = [
     {
@@ -3680,6 +3692,63 @@ describe("Artwork type", () => {
         artwork: {
           title: "Untitled (Portrait)",
         },
+      })
+    })
+  })
+
+  describe("isHighDemand", () => {
+    it("returns true when an artwork is in high demand", () => {
+      const query = `
+        {
+          artwork(id: "foo-bar") {
+            marketPriceInsights {
+              isHighDemand
+            }
+          }
+        }
+      `
+
+      const marketPriceInsightsBatchLoader = jest.fn(async () => [
+        artworkInHighDemand,
+      ])
+
+      context.marketPriceInsightsBatchLoader = marketPriceInsightsBatchLoader
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            marketPriceInsights: {
+              isHighDemand: true,
+            },
+          },
+        })
+      })
+    })
+    it("returns false when an artwork is not in high demand", () => {
+      const query = `
+        {
+          artwork(id: "foo-bar") {
+            marketPriceInsights {
+              isHighDemand
+            }
+          }
+        }
+      `
+
+      const marketPriceInsightsBatchLoader = jest.fn(async () => [
+        artworkInLowDemand,
+      ])
+
+      context.marketPriceInsightsBatchLoader = marketPriceInsightsBatchLoader
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            marketPriceInsights: {
+              isHighDemand: false,
+            },
+          },
+        })
       })
     })
   })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -90,6 +90,8 @@ const IMPORT_SOURCES = {
   MY_COLLECTION: { value: "my collection" },
 } as const
 
+const ARTIST_IN_HIGH_DEMAND_RANK = 9
+
 export const ArtworkImportSourceEnum = new GraphQLEnumType({
   name: "ArtworkImportSource",
   values: IMPORT_SOURCES,
@@ -142,6 +144,16 @@ const ArtworkPriceInsightsType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
       description: "The demand rank display text of the artist and medium",
       resolve: ({ demandRank }) => getDemandRankDisplayText(demandRank),
+    },
+    isHighDemand: {
+      type: GraphQLBoolean,
+      description: "Return weather the artist medium is in high demand",
+      resolve: ({ demandRank }) => {
+        if (demandRank) {
+          return demandRank * 10 >= ARTIST_IN_HIGH_DEMAND_RANK
+        }
+        return null
+      },
     },
     lastAuctionResultDate: {
       type: GraphQLString,

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -101,17 +101,6 @@ const ArtworkPriceInsightsType = new GraphQLObjectType<any, ResolverContext>({
     artistId: {
       type: GraphQLString,
     },
-    medium: {
-      type: GraphQLString,
-    },
-    demandRank: {
-      type: GraphQLFloat,
-    },
-    demandRankDisplayText: {
-      type: GraphQLString,
-      description: "The demand rank display text of the artist and medium",
-      resolve: ({ demandRank }) => getDemandRankDisplayText(demandRank),
-    },
     annualValueSoldCents: {
       type: FormattedNumber,
     },
@@ -146,6 +135,17 @@ const ArtworkPriceInsightsType = new GraphQLObjectType<any, ResolverContext>({
         )
       },
     },
+    demandRank: {
+      type: GraphQLFloat,
+    },
+    demandRankDisplayText: {
+      type: GraphQLString,
+      description: "The demand rank display text of the artist and medium",
+      resolve: ({ demandRank }) => getDemandRankDisplayText(demandRank),
+    },
+    lastAuctionResultDate: {
+      type: GraphQLString,
+    },
     liquidityRankDisplayText: {
       type: GraphQLString,
       args: {
@@ -175,6 +175,9 @@ const ArtworkPriceInsightsType = new GraphQLObjectType<any, ResolverContext>({
         return ""
       },
     },
+    medium: {
+      type: GraphQLString,
+    },
     medianSalePriceDisplayText: {
       type: GraphQLString,
       args: {
@@ -195,9 +198,7 @@ const ArtworkPriceInsightsType = new GraphQLObjectType<any, ResolverContext>({
     medianSaleOverEstimatePercentage: {
       type: GraphQLFloat,
     },
-    lastAuctionResultDate: {
-      type: GraphQLString,
-    },
+
     sellThroughRate: {
       type: GraphQLFloat,
     },


### PR DESCRIPTION
This PR adds `isHighDemand` flag to the market price insights flag. The goal from this PR is to make sure we are safe in case the value for what's in high demand changes in the future.

**Bonus:** I alphabetically sorted the interface before it gets messier.
