### PR TITLE
feat: relax typing when shortcuts dont exist

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13572,7 +13572,7 @@ type Query {
     # Search query to perform. Required.
     query: String!
   ): SearchableConnection
-  shortcut(id: ID!): Shortcut!
+  shortcut(id: ID!): Shortcut
 
   # A Show
   show(
@@ -17128,7 +17128,7 @@ type Viewer {
     # Search query to perform. Required.
     query: String!
   ): SearchableConnection
-  shortcut(id: ID!): Shortcut!
+  shortcut(id: ID!): Shortcut
 
   # A Show
   show(

--- a/src/schema/v2/shortcut.ts
+++ b/src/schema/v2/shortcut.ts
@@ -27,7 +27,7 @@ export const shortcut: GraphQLFieldConfig<void, ResolverContext> = {
   args: {
     id: { type: new GraphQLNonNull(GraphQLID) },
   },
-  type: new GraphQLNonNull(shortcutType),
+  type: shortcutType,
   resolve: (_source, { id }, { shortcutLoader }) => {
     return shortcutLoader(id)
   },


### PR DESCRIPTION
Currently, if you query MP for a shortcut that doesn't exist, MP actually returns a 500 status code! However, GraphiQL kind of looks correct w an `errors` body (which is somewhat confusing!)
<img width="1000" alt="Screen Shot 2022-08-25 at 5 50 23 PM" src="https://user-images.githubusercontent.com/1457859/186775259-e286a040-d173-4d5f-ad7e-3d94b0dce7da.png">. It's easily verified locally that MP returns a 500 error code in such cases.

Additionally, there's a middleware to handle redirects in Force which makes this query, can cause a 500 behind a `try/catch` (so this wasn't affecting users or an unhandled exception within Force). That's in https://github.com/artsy/force/blob/d61e77ee76e7847f7168f921b2fa2808deeb20c6/src/Apps/Redirects/redirectsServerRoutes.tsx#L30-L39

This redirect is mounted fairly high in our middleware stack, and based on functionality, seems like it could actually move to the bottom of our middleware (saving lots of 'shortcut not found' requests) - that's a separate Force update. Adding it fairly high in the middleware stack has caused a spike in 500 errors in Metaphysics (which sadly doesn't have Sentry error tracking enabled).

Here, the typing of `non GraphQLNonNull` breaks whenever a shortcut isn't found (or any other error encountered), so I think the fix is to remove the constraint.

