### PR TITLE
chore: expose `totalCount` field for `notificationsConnection`

### DIFF
--- a/src/schema/v2/notifications/__tests__/index.test.ts
+++ b/src/schema/v2/notifications/__tests__/index.test.ts
@@ -28,6 +28,7 @@ describe("notificationsConnection", () => {
     const query = gql`
       {
         notificationsConnection(first: 10, notificationTypes: [ARTWORK_ALERT]) {
+          totalCount
           counts {
             total
             unread
@@ -56,6 +57,7 @@ describe("notificationsConnection", () => {
 
     expect(data).toEqual({
       notificationsConnection: {
+        totalCount: 100,
         counts: {
           total: 100,
           unread: 10,

--- a/src/schema/v2/notifications/index.ts
+++ b/src/schema/v2/notifications/index.ts
@@ -111,6 +111,7 @@ export const NotificationsConnection: GraphQLFieldConfig<
 
     return {
       counts: { total: body.total, unread: body.total_unread },
+      totalCount: body.total,
       pageCursors: createPageCursors({ page, size }, body.total),
       ...connectionFromArraySlice(
         body.feed,


### PR DESCRIPTION
Initial PR: artsy/metaphysics#4316

### Description
Small changes that allow to return the correct value of `totalCount`

### Demo
#### Before
<img width="1029" alt="before" src="https://user-images.githubusercontent.com/3513494/186889508-15439859-4c35-414b-a9f7-13459c1ee59f.png">

#### After
<img width="1029" alt="after" src="https://user-images.githubusercontent.com/3513494/186889527-07846d4f-a2f1-41c9-afc7-edeb54c4c6d6.png">
