### PR TITLE
feat: staging to tolerate spot instance taint.

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -82,6 +82,11 @@ spec:
         options:
         - name: ndots
           value: '1'
+      tolerations:
+        - key: reserved
+          operator: Equal
+          value: spot
+          effect: NoSchedule
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
The type of this PR is: Feat

This PR solves PLATFORM-4514

### Description

Part of spike on using AWS Spot instances.
Follows https://github.com/artsy/metaphysics/pull/4341

Spot tiers were [tainted](https://github.com/artsy/substance/pull/285) with `reserved=spot:NoSchedule`. Now for any deployment we want to run on Spot, we must add a [toleration](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/). Adding that for `web` deployment.