### PR TITLE
feat: add interestsConnection under User

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16081,6 +16081,12 @@ type User {
 
   # A globally unique ID.
   id: ID!
+  interestsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): UserInterestConnection
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
@@ -16335,6 +16341,34 @@ type UserInterest {
 enum UserInterestCategory {
   COLLECTED_BEFORE
   INTERESTED_IN_COLLECTING
+}
+
+# A connection to a list of items.
+type UserInterestConnection {
+  # A list of edges.
+  edges: [UserInterestEdge]
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+}
+
+# An edge in a connection.
+type UserInterestEdge {
+  body: String
+  category: UserInterestCategory!
+  createdByAdmin: Boolean!
+
+  # A cursor for use in pagination
+  cursor: String!
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID.
+  internalID: ID!
+
+  # The item at the end of the edge
+  node: UserInterestInterest
 }
 
 union UserInterestInterest = Artist | Gene

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -452,7 +452,12 @@ export default (accessToken, userID, opts) => {
     ),
     userByEmailLoader: gravityLoader("user", {}, { method: "GET" }),
     userByIDLoader: gravityLoader((id) => `user/${id}`, {}, { method: "GET" }),
-    userInterestsLoader: gravityLoader("me/user_interests"),
+    meUserInterestsLoader: gravityLoader("me/user_interests"),
+    userInterestsLoader: gravityLoader(
+      (id) => `user_interests?user_id=${id}`,
+      {},
+      { headers: true }
+    ),
     deleteUserRole: gravityLoader<any, { id: string; role_type: string }>(
       ({ id, role_type }) => `user/${id}/roles/${role_type}`,
       {},

--- a/src/schema/v2/CollectorProfile/collectorProfile.ts
+++ b/src/schema/v2/CollectorProfile/collectorProfile.ts
@@ -47,8 +47,8 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
   },
   userInterests: {
     type: new GraphQLNonNull(new GraphQLList(userInterestType)),
-    resolve: (_collectorProfile, _args, { userInterestsLoader }) => {
-      return userInterestsLoader?.()
+    resolve: (_collectorProfile, _args, { meUserInterestsLoader }) => {
+      return meUserInterestsLoader?.()
     },
   },
 }

--- a/src/schema/v2/__tests__/user.test.ts
+++ b/src/schema/v2/__tests__/user.test.ts
@@ -3,114 +3,210 @@ import gql from "lib/gql"
 import { HTTPError } from "lib/HTTPError"
 
 describe("User", () => {
-  it("returns true if a user exists", async () => {
-    const foundUser = {
-      id: "123456",
-      _id: "000012345",
-      name: "foo bar",
-      pin: "3141",
-      paddle_number: "314159",
-    }
-
-    const userByEmailLoader = (data) => {
-      if (data) {
-        return Promise.resolve(foundUser)
+  describe("userAlreadyExists", () => {
+    it("returns true if a user exists", async () => {
+      const foundUser = {
+        id: "123456",
+        _id: "000012345",
+        name: "foo bar",
+        pin: "3141",
+        paddle_number: "314159",
       }
-      throw new Error("Unexpected invocation")
-    }
 
-    const query = gql`
-      {
-        user(email: "foo@bar.com") {
-          pin
-          paddleNumber
-          userAlreadyExists
+      const userByEmailLoader = (data) => {
+        if (data) {
+          return Promise.resolve(foundUser)
         }
+        throw new Error("Unexpected invocation")
       }
-    `
 
-    const { user } = await runAuthenticatedQuery(query, { userByEmailLoader })
-    expect(user.pin).toEqual("3141")
-    expect(user.paddleNumber).toEqual("314159")
-    expect(user.userAlreadyExists).toEqual(true)
+      const query = gql`
+        {
+          user(email: "foo@bar.com") {
+            pin
+            paddleNumber
+            userAlreadyExists
+          }
+        }
+      `
+
+      const { user } = await runAuthenticatedQuery(query, { userByEmailLoader })
+      expect(user.pin).toEqual("3141")
+      expect(user.paddleNumber).toEqual("314159")
+      expect(user.userAlreadyExists).toEqual(true)
+    })
+
+    it("returns false if user is not found by email", async () => {
+      const notFoundUser = { error: "User Not Found" }
+      const error = new HTTPError(notFoundUser.error, 404)
+      const userByEmailLoader = (data) => {
+        if (data) {
+          return Promise.resolve(notFoundUser)
+        }
+        throw error
+      }
+      const query = gql`
+        {
+          user(email: "nonexistentuser@bar.com") {
+            userAlreadyExists
+          }
+        }
+      `
+      const { user } = await runAuthenticatedQuery(query, { userByEmailLoader })
+      expect(user.userAlreadyExists).toEqual(false)
+    })
   })
 
-  it("returns false if user is not found by email", async () => {
-    const notFoundUser = { error: "User Not Found" }
-    const error = new HTTPError(notFoundUser.error, 404)
-    const userByEmailLoader = (data) => {
-      if (data) {
-        return Promise.resolve(notFoundUser)
+  describe("push notification settings", () => {
+    it("returns push notification settings for a user", async () => {
+      const foundUser = {
+        id: "123456",
+        _id: "000012345",
+        name: "foo bar",
+        pin: "3141",
+        paddle_number: "314159",
+        receive_purchase_notification: false,
+        receive_outbid_notification: false,
+        receive_lot_opening_soon_notification: false,
+        receive_sale_opening_closing_notification: false,
+        receive_new_works_notification: true,
+        receive_new_sales_notification: false,
+        receive_promotion_notification: false,
+        receive_order_notification: true,
+        receive_viewing_room_notification: true,
       }
-      throw error
-    }
-    const query = gql`
-      {
-        user(email: "nonexistentuser@bar.com") {
-          userAlreadyExists
+
+      const userByEmailLoader = (data) => {
+        if (data) {
+          return Promise.resolve(foundUser)
         }
+        throw new Error("Unexpected invocation")
       }
-    `
-    const { user } = await runAuthenticatedQuery(query, { userByEmailLoader })
-    expect(user.userAlreadyExists).toEqual(false)
+
+      const query = gql`
+        {
+          user(email: "foo@bar.com") {
+            pin
+            paddleNumber
+            userAlreadyExists
+            receivePurchaseNotification
+            receiveOutbidNotification
+            receiveLotOpeningSoonNotification
+            receiveSaleOpeningClosingNotification
+            receiveNewWorksNotification
+            receiveNewSalesNotification
+            receivePromotionNotification
+            receiveOrderNotification
+            receiveViewingRoomNotification
+          }
+        }
+      `
+
+      const { user } = await runAuthenticatedQuery(query, { userByEmailLoader })
+      expect(user.pin).toEqual("3141")
+      expect(user.paddleNumber).toEqual("314159")
+      expect(user.userAlreadyExists).toEqual(true)
+      expect(user.receivePurchaseNotification).toEqual(false)
+      expect(user.receiveOutbidNotification).toEqual(false)
+      expect(user.receiveLotOpeningSoonNotification).toEqual(false)
+      expect(user.receiveSaleOpeningClosingNotification).toEqual(false)
+      expect(user.receiveNewWorksNotification).toEqual(true)
+      expect(user.receiveNewSalesNotification).toEqual(false)
+      expect(user.receivePromotionNotification).toEqual(false)
+      expect(user.receiveOrderNotification).toEqual(true)
+      expect(user.receiveViewingRoomNotification).toEqual(true)
+    })
   })
 
-  it("returns push notification settings for a user", async () => {
-    const foundUser = {
-      id: "123456",
-      _id: "000012345",
-      name: "foo bar",
-      pin: "3141",
-      paddle_number: "314159",
-      receive_purchase_notification: false,
-      receive_outbid_notification: false,
-      receive_lot_opening_soon_notification: false,
-      receive_sale_opening_closing_notification: false,
-      receive_new_works_notification: true,
-      receive_new_sales_notification: false,
-      receive_promotion_notification: false,
-      receive_order_notification: true,
-      receive_viewing_room_notification: true,
-    }
-
-    const userByEmailLoader = (data) => {
-      if (data) {
-        return Promise.resolve(foundUser)
-      }
-      throw new Error("Unexpected invocation")
-    }
-
-    const query = gql`
-      {
-        user(email: "foo@bar.com") {
-          pin
-          paddleNumber
-          userAlreadyExists
-          receivePurchaseNotification
-          receiveOutbidNotification
-          receiveLotOpeningSoonNotification
-          receiveSaleOpeningClosingNotification
-          receiveNewWorksNotification
-          receiveNewSalesNotification
-          receivePromotionNotification
-          receiveOrderNotification
-          receiveViewingRoomNotification
+  describe("interestsConnection", () => {
+    it("returns user interests", async () => {
+      const query = `
+        {
+          user(id: "blah") {
+            interestsConnection(first: 10) {
+              edges {
+                body
+                category
+                createdByAdmin
+                node {
+                  __typename
+                  ... on Gene {
+                    name
+                  }
+                  ... on Artist {
+                    name
+                  }
+                }
+              }
+            }
+          }
         }
-      }
-    `
+      
+      `
 
-    const { user } = await runAuthenticatedQuery(query, { userByEmailLoader })
-    expect(user.pin).toEqual("3141")
-    expect(user.paddleNumber).toEqual("314159")
-    expect(user.userAlreadyExists).toEqual(true)
-    expect(user.receivePurchaseNotification).toEqual(false)
-    expect(user.receiveOutbidNotification).toEqual(false)
-    expect(user.receiveLotOpeningSoonNotification).toEqual(false)
-    expect(user.receiveSaleOpeningClosingNotification).toEqual(false)
-    expect(user.receiveNewWorksNotification).toEqual(true)
-    expect(user.receiveNewSalesNotification).toEqual(false)
-    expect(user.receivePromotionNotification).toEqual(false)
-    expect(user.receiveOrderNotification).toEqual(true)
-    expect(user.receiveViewingRoomNotification).toEqual(true)
+      const user = {
+        id: "blah",
+      }
+
+      const interests = [
+        {
+          body: "Told an admin they collected",
+          owner_type: "UserSaleProfile",
+          category: "collected_before",
+          interest: {
+            birthday: 2001,
+            name: "Catty Artist",
+          },
+        },
+        {
+          body: null,
+          owner_type: "CollectorProfile",
+          category: "interested_in_collecting",
+          interest: {
+            name: "Catty Gene",
+          },
+        },
+      ]
+
+      const context = {
+        userByIDLoader: () => {
+          return Promise.resolve(user)
+        },
+        userInterestsLoader: () => {
+          return Promise.resolve({
+            body: interests,
+            headers: { "x-total-count": "2" },
+          })
+        },
+      }
+
+      const {
+        user: {
+          interestsConnection: { edges },
+        },
+      } = await runAuthenticatedQuery(query, context)
+
+      expect(edges.length).toEqual(2)
+
+      expect(edges[0]).toEqual({
+        body: "Told an admin they collected",
+        category: "COLLECTED_BEFORE",
+        createdByAdmin: true,
+        node: {
+          __typename: "Artist",
+          name: "Catty Artist",
+        },
+      })
+
+      expect(edges[1]).toEqual({
+        body: null,
+        category: "INTERESTED_IN_COLLECTING",
+        createdByAdmin: false,
+        node: {
+          __typename: "Gene",
+          name: "Catty Gene",
+        },
+      })
+    })
   })
 })

--- a/src/schema/v2/me/userInterests.ts
+++ b/src/schema/v2/me/userInterests.ts
@@ -19,8 +19,9 @@ export interface UserInterest {
   category: UserInterestCategory
   created_at: string
   id: number
-  interest: unknown // Artist | Gene
-  owner: unknown // CollectorProfile | UserSaleProfile
+  interest: unknown // object which is one of Artist | Gene
+  owner: unknown // object which is one of CollectorProfile | UserSaleProfile
+  owner_type: string // CollectorProfile | UserSaleProfile
   updated_at: string
 }
 

--- a/src/schema/v2/userInterests.ts
+++ b/src/schema/v2/userInterests.ts
@@ -1,0 +1,34 @@
+import { connectionDefinitions } from "graphql-relay"
+import {
+  userInterestInterestUnion,
+  UserInterest,
+  userInterestCategoryEnum,
+} from "./me/userInterests"
+import { ResolverContext } from "types/graphql"
+import {
+  GraphQLString,
+  Thunk,
+  GraphQLFieldConfigMap,
+  GraphQLNonNull,
+  GraphQLBoolean,
+} from "graphql"
+import { IDFields } from "./object_identification"
+
+export const edgeFields: Thunk<GraphQLFieldConfigMap<
+  UserInterest,
+  ResolverContext
+>> = () => ({
+  ...IDFields,
+  body: { type: GraphQLString },
+  category: { type: new GraphQLNonNull(userInterestCategoryEnum) },
+  createdByAdmin: {
+    type: new GraphQLNonNull(GraphQLBoolean),
+    resolve: ({ owner_type }) => owner_type === "UserSaleProfile",
+  },
+})
+
+export const UserInterestConnection = connectionDefinitions({
+  name: "UserInterest",
+  nodeType: userInterestInterestUnion,
+  edgeFields: edgeFields,
+}).connectionType


### PR DESCRIPTION
<img width="936" alt="Screen Shot 2022-08-29 at 4 28 13 PM" src="https://user-images.githubusercontent.com/1457859/187292339-acf0059b-fcf5-4892-bb56-e35ef8706544.png">

This adds a new `interestsConnection` field under a `User`, without being scoped to `me` and using the admin endpoint.

It also adjusts the schema to store some of the 'join' data between a user and the interest on the edge, so the nodes stay as meaningful entities. 