### PR TITLE
fix: Return image square placeholder when no geometry is provided

### DIFF
--- a/src/schema/v2/image/__tests__/index.test.js
+++ b/src/schema/v2/image/__tests__/index.test.js
@@ -74,6 +74,24 @@ describe("Image type", () => {
     })
   })
 
+  describe("#placeholder", () => {
+    const query = `{
+      artwork(id: "richard-prince-untitled-portrait") {
+        image {
+          placeholder
+        }
+      }
+    }`
+
+    it("is square by default (when there is no image geometry)", () => {
+      assign(image, { original_width: null, original_height: null })
+
+      return runQuery(query, context).then((data) => {
+        expect(data.artwork.image.placeholder).toBe("100%")
+      })
+    })
+  })
+
   describe("#orientation", () => {
     const query = `{
       artwork(id: "richard-prince-untitled-portrait") {

--- a/src/schema/v2/image/index.ts
+++ b/src/schema/v2/image/index.ts
@@ -1,6 +1,6 @@
 import {
-  GraphQLFieldConfig,
   GraphQLBoolean,
+  GraphQLFieldConfig,
   GraphQLFloat,
   GraphQLInt,
   GraphQLList,
@@ -9,13 +9,13 @@ import {
   GraphQLString,
 } from "graphql"
 import { find, first, isArray } from "lodash"
+import { NullableIDField } from "schema/v2/object_identification"
 import { ResolverContext } from "types/graphql"
 import CroppedUrl from "./cropped"
 import DeepZoom, { isZoomable } from "./deep_zoom"
 import { ImageData, normalize } from "./normalize"
 import ResizedUrl from "./resized"
 import VersionedUrl from "./versioned"
-import { NullableIDField } from "schema/v2/object_identification"
 
 export type OriginalImage = {
   original_width?: number
@@ -102,8 +102,13 @@ export const ImageType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
       description:
         "Value to use when `padding-bottom` for fluid image placeholders",
-      resolve: ({ original_height, original_width }) =>
-        `${(original_height / original_width) * 100}%`,
+      resolve: ({ original_height, original_width }) => {
+        // To avoid returning "NaN%" if original_width and original_height are 0.
+        // The image is a square by default (when there is no image geometry).
+        if (original_width === original_height) return "100%"
+
+        return `${(original_height / original_width) * 100}%`
+      },
     },
     position: {
       type: GraphQLInt,


### PR DESCRIPTION
Addresses [CX-2854]

## Description

In cases when no geometry is provided for an image, we return a square image by default. This PR fixes the placeholder field that was returning "NaN%" instead of "100%" if the original image width and height are `0`.

The placeholder is important to correctly display the images in the frontend. Without this value being set correctly, My Collection images are not displayed correctly shortly after an artwork has been created.

[CX-2854]: https://artsyproduct.atlassian.net/browse/CX-2854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ