### PR TITLE
feat: expose maxWorksPerArtist arg for artworksForUser

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12908,6 +12908,7 @@ type Query {
     first: Int
     includeBackfill: Boolean!
     last: Int
+    maxWorksPerArtist: Int
     page: Int
     userId: String
     version: String
@@ -16676,6 +16677,7 @@ type Viewer {
     first: Int
     includeBackfill: Boolean!
     last: Int
+    maxWorksPerArtist: Int
     page: Int
     userId: String
     version: String

--- a/src/data/vortex.graphql
+++ b/src/data/vortex.graphql
@@ -1581,6 +1581,7 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+    maxWorksPerArtist: Int = 1
     userId: String
     version: String
   ): NewForYouRecommendationConnection

--- a/src/schema/v2/artworksForUser/artworksForUser.ts
+++ b/src/schema/v2/artworksForUser/artworksForUser.ts
@@ -27,6 +27,7 @@ export const artworksForUser: GraphQLFieldConfig<void, ResolverContext> = {
     page: { type: GraphQLInt },
     userId: { type: GraphQLString },
     version: { type: GraphQLString },
+    maxWorksPerArtist: { type: GraphQLInt },
   }),
   resolve: async (_root, args: CursorPageable, context) => {
     if (!context.artworksLoader) return

--- a/src/schema/v2/artworksForUser/helpers.ts
+++ b/src/schema/v2/artworksForUser/helpers.ts
@@ -14,6 +14,9 @@ export const getNewForYouRecs = async (
 
   const userIdArgument = args.userId ? `userId: "${args.userId}"` : ""
   const versionArgument = args.version ? `version: "${args.version}"` : ""
+  const maxWorksPerUserArgument = args.maxWorksPerUser
+    ? `maxWorksPerUser: "${args.maxWorksPerUser}"`
+    : ""
 
   const vortexResult = await graphqlLoader({
     query: gql`
@@ -22,6 +25,7 @@ export const getNewForYouRecs = async (
             first: ${args.first}
             ${userIdArgument}
             ${versionArgument}
+            ${maxWorksPerUserArgument}
           ) {
             totalCount
             edges {


### PR DESCRIPTION
This commit threads a new argument to an underlying Vortex query field. The backfill logic doesn't currently respect this argument.

cc/ @olerichter00 @jonallured 