### PR TITLE
fix: correctly thread maxWorksPerArtist arg to newForYouRecommendations

### DIFF
--- a/src/schema/v2/artworksForUser/helpers.ts
+++ b/src/schema/v2/artworksForUser/helpers.ts
@@ -14,8 +14,8 @@ export const getNewForYouRecs = async (
 
   const userIdArgument = args.userId ? `userId: "${args.userId}"` : ""
   const versionArgument = args.version ? `version: "${args.version}"` : ""
-  const maxWorksPerUserArgument = args.maxWorksPerUser
-    ? `maxWorksPerUser: "${args.maxWorksPerUser}"`
+  const maxWorksPerArtistArgument = args.maxWorksPerArtist
+    ? `maxWorksPerArtist: ${args.maxWorksPerArtist}`
     : ""
 
   const vortexResult = await graphqlLoader({
@@ -25,7 +25,7 @@ export const getNewForYouRecs = async (
             first: ${args.first}
             ${userIdArgument}
             ${versionArgument}
-            ${maxWorksPerUserArgument}
+            ${maxWorksPerArtistArgument}
           ) {
             totalCount
             edges {


### PR DESCRIPTION
The first iteration had a couple problems:

- Name was mistyped as `maxWorksPerUser`
- The integer value was incorrectly quoted

Testing this against staging was difficult but I was eventually able to generate the appropriate `VORTEX_TOKEN` to test against production data which helped surface these issues.

```ruby
subject = ClientApplication.find_by(name: "Metaphysics")
app = ClientApplication.find_by(name: "vortex-production")
ApplicationTrust.create_for_token_authentication(mp, subject_application: app)
```