### PR TITLE
feat: allow filtering bank accounts by the bank account type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3040,6 +3040,9 @@ type BankAccount {
 
   # Last four characters of the account identifier
   last4: String!
+
+  # Bank account type
+  type: BankAccountTypes!
 }
 
 # A connection to a list of items.
@@ -3072,6 +3075,11 @@ type BankAccountMutationSuccess {
 union BankAccountMutationType =
     BankAccountMutationFailure
   | BankAccountMutationSuccess
+
+enum BankAccountTypes {
+  SEPA_DEBIT
+  US_BANK_ACCOUNT
+}
 
 type Bidder implements Node {
   createdAt(
@@ -10167,6 +10175,7 @@ type Me implements Node {
     before: String
     first: Int
     last: Int
+    type: BankAccountTypes
   ): BankAccountConnection
 
   # Returns a single bidder position

--- a/src/schema/v2/bank_account.ts
+++ b/src/schema/v2/bank_account.ts
@@ -12,6 +12,7 @@ import {
 import { GravityMutationErrorType } from "lib/gravityErrorHandler"
 import { InternalIDFields } from "schema/v2/object_identification"
 import { ResolverContext } from "types/graphql"
+import { BankAccountTypes } from "./me/bank_accounts"
 
 // fields: https://github.com/artsy/gravity/blob/main/db/schema.rb
 export const BankAccountType = new GraphQLObjectType<any, ResolverContext>({
@@ -31,6 +32,11 @@ export const BankAccountType = new GraphQLObjectType<any, ResolverContext>({
     last4: {
       type: new GraphQLNonNull(GraphQLString),
       description: "Last four characters of the account identifier",
+    },
+    type: {
+      type: new GraphQLNonNull(BankAccountTypes.type),
+      description: "Bank account type",
+      resolve: ({ type }) => type,
     },
   }),
 })

--- a/src/schema/v2/me/bank_accounts.test.ts
+++ b/src/schema/v2/me/bank_accounts.test.ts
@@ -5,17 +5,16 @@ import gql from "lib/gql"
 describe("BankAccounts", () => {
   it("returns a bank account connection", () => {
     const bankAccounts = [
-      { id: "12345", last4: "4321" },
-      { id: "6789", last4: "9876" },
+      { id: "12345", last4: "4321", type: "us_bank_account" },
+      { id: "6789", last4: "9876", type: "us_bank_account" },
     ]
     const context = {
-      meLoader: () =>
-        Promise.resolve({}),
+      meLoader: () => Promise.resolve({}),
       meBankAccountsLoader: () =>
         Promise.resolve({
           body: bankAccounts,
           headers: { "x-total-count": "2" },
-        })
+        }),
     }
     const query = gql`
       {
@@ -25,6 +24,7 @@ describe("BankAccounts", () => {
               node {
                 internalID
                 last4
+                type
               }
             }
             pageInfo {
@@ -43,12 +43,55 @@ describe("BankAccounts", () => {
             node: {
               internalID: "12345",
               last4: "4321",
+              type: "US_BANK_ACCOUNT",
             },
           },
         ],
         pageInfo: {
           hasNextPage: true,
         },
+      })
+    })
+  })
+
+  it("loader receives bank account type", () => {
+    const bankAccounts = [{ id: "12345", last4: "4321" }]
+
+    const mockMeBankAccountsLoader = jest.fn().mockResolvedValue({
+      body: bankAccounts,
+      headers: { "x-total-count": "1" },
+    })
+
+    const context = {
+      meLoader: () => Promise.resolve({}),
+      meBankAccountsLoader: mockMeBankAccountsLoader,
+    }
+
+    const query = gql`
+      {
+        me {
+          bankAccounts(first: 1, type: US_BANK_ACCOUNT) {
+            edges {
+              node {
+                internalID
+                last4
+              }
+            }
+            pageInfo {
+              hasNextPage
+            }
+          }
+        }
+      }
+    `
+
+    expect.assertions(1)
+    return runAuthenticatedQuery(query, context).then(() => {
+      expect(mockMeBankAccountsLoader).toBeCalledWith({
+        page: 1,
+        size: 1,
+        total_count: true,
+        type: "us_bank_account",
       })
     })
   })

--- a/src/schema/v2/me/bank_accounts.ts
+++ b/src/schema/v2/me/bank_accounts.ts
@@ -2,17 +2,29 @@ import { BankAccountConnection } from "schema/v2/bank_account"
 import { pageable } from "relay-cursor-paging"
 import { connectionFromArraySlice } from "graphql-relay"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
-import { GraphQLFieldConfig } from "graphql/type"
+import { GraphQLEnumType, GraphQLFieldConfig } from "graphql/type"
 import { ResolverContext } from "types/graphql"
+
+export const BankAccountTypes = {
+  type: new GraphQLEnumType({
+    name: "BankAccountTypes",
+    values: {
+      US_BANK_ACCOUNT: { value: "us_bank_account" },
+      SEPA_DEBIT: { value: "sepa_debit" },
+    },
+  }),
+}
 
 export const BankAccounts: GraphQLFieldConfig<void, ResolverContext> = {
   type: BankAccountConnection,
-  args: pageable({}),
+  args: pageable({
+    type: BankAccountTypes,
+  }),
   description: "A list of the current user's bank accounts",
   resolve: (_root, options, { meBankAccountsLoader }) => {
     if (!meBankAccountsLoader) return null
     const { page, size, offset } = convertConnectionArgsToGravityArgs(options)
-    const gravityArgs = { page, size, total_count: true }
+    const gravityArgs = { page, size, total_count: true, type: options.type }
 
     return meBankAccountsLoader(gravityArgs).then(({ body, headers }) => {
       return connectionFromArraySlice(body, options, {


### PR DESCRIPTION
This PR adds `type` field to the bank accounts query(argument and field at response) to filter bank accounts by ACH or SEPA.

JIRA - [TX-555]

[TX-555]: https://artsyproduct.atlassian.net/browse/TX-555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ