### PR TITLE
[WIP] Allow partners to view collector emails

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3633,6 +3633,7 @@ type CommerceBuyOrder implements CommerceOrder {
   ): String
   buyerTotalCents: Int
   code: String!
+  collectorProfile: CollectorProfileType
   commissionFee(
     decimal: String = "."
 
@@ -4358,6 +4359,7 @@ type CommerceOfferOrder implements CommerceOrder {
   ): String
   buyerTotalCents: Int
   code: String!
+  collectorProfile: CollectorProfileType
   commissionFee(
     decimal: String = "."
 
@@ -4589,6 +4591,7 @@ interface CommerceOrder {
   ): String
   buyerTotalCents: Int
   code: String!
+  collectorProfile: CollectorProfileType
   commissionFee(
     decimal: String = "."
 

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -326,6 +326,11 @@ export default (accessToken, userID, opts) => {
       ({ partnerId, inquiryId }) =>
         `partner/${partnerId}/inquiry_request/${inquiryId}/collector_profile`
     ),
+    collectorProfileByUserIDLoader: gravityLoader<any, { userId: string }>(
+      ({ userId }) => `collector_profiles?user_id=${userId}`,
+      {},
+      { headers: true }
+    ),
     partnerShowDocumentsLoader: gravityLoader<
       any,
       { partnerId: string; showId: string }


### PR DESCRIPTION

To note, this is STILL A WIP! Opening up for general feedback
and thanks so much to Roop, Sarah, and Matt J for all the pairing and help!!

### TODOs
- [ ] Tests
- [ ] move `collectorProfile` under the buyerDetails section
- [ ] More tests with local Volt


Addresses part of: https://artsyproduct.atlassian.net/browse/PX-5183
Allow partner user's to view a collector's email when an order is submitted

So far you can query like this:
```graphql
{
  commerceOrder(id: "04a3c172-2238-4ba7-90ed-a0309004ad83") {
    impulseConversationId
    collectorProfile {
      __typename
      email
      name
    }
    buyer {
	... on CommerceUser {
		id				
	}
   }
    buyerDetails {
      __typename
      ... on User {
        name
        internalID
      }
    }
}
```

and get the collector profile email in the response:
```json
{
  "data": {
    "commerceOrder": {
      "impulseConversationId": "57035",
      "collectorProfile": {
        "__typename": "CollectorProfileType",
        "email": "test.t@artsymail.com",
        "name": "Test T"
      },
      "buyer": {
        "id": "6151e254ef0b81000bc75b7b"
      },
      "buyerDetails": {
        "__typename": "User",
        "name": "Test T",
      },
      "lineItems": {
        "edges": [
          {
            "node": {
              "shipment": null
            }
          }
        ]
      }
    }
  },
```