### PR TITLE
feat: add user follows

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16052,6 +16052,12 @@ type User {
   # The admin notes associated with the user
   adminNotes: [UserAdminNotes]!
   analytics: AnalyticsUserStats
+  artistFollowsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtistConnection
   cached: Int
 
   # A collector profile.
@@ -16079,6 +16085,12 @@ type User {
     # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String
+  geneFollowsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): GeneConnection
 
   # A globally unique ID.
   id: ID!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16316,13 +16316,13 @@ type UserEdge {
 }
 
 type UserFollows {
-  artistFollowsConnection(
+  artistsConnection(
     after: String
     before: String
     first: Int
     last: Int
   ): ArtistConnection
-  geneFollowsConnection(
+  genesConnection(
     after: String
     before: String
     first: Int

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16052,12 +16052,6 @@ type User {
   # The admin notes associated with the user
   adminNotes: [UserAdminNotes]!
   analytics: AnalyticsUserStats
-  artistFollowsConnection(
-    after: String
-    before: String
-    first: Int
-    last: Int
-  ): ArtistConnection
   cached: Int
 
   # A collector profile.
@@ -16085,12 +16079,7 @@ type User {
     # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String
-  geneFollowsConnection(
-    after: String
-    before: String
-    first: Int
-    last: Int
-  ): GeneConnection
+  follows: UserFollows
 
   # A globally unique ID.
   id: ID!
@@ -16324,6 +16313,21 @@ type UserEdge {
 
   # The item at the end of the edge
   node: User
+}
+
+type UserFollows {
+  artistFollowsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtistConnection
+  geneFollowsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): GeneConnection
 }
 
 type UserIconDeleteFailureType {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -458,6 +458,16 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    userArtistFollowsLoader: gravityLoader(
+      (id) => `user/${id}/follow/artists`,
+      {},
+      { headers: true }
+    ),
+    userGeneFollowsLoader: gravityLoader(
+      (id) => `user/${id}/follow/genes`,
+      {},
+      { headers: true }
+    ),
     deleteUserRole: gravityLoader<any, { id: string; role_type: string }>(
       ({ id, role_type }) => `user/${id}/roles/${role_type}`,
       {},

--- a/src/schema/v2/__tests__/user.test.ts
+++ b/src/schema/v2/__tests__/user.test.ts
@@ -141,7 +141,6 @@ describe("User", () => {
             }
           }
         }
-      
       `
 
       const user = {
@@ -216,14 +215,14 @@ describe("User", () => {
         {
           user(id: "abc") {
             follows {
-              artistFollowsConnection(first: 10) {
+              artistsConnection(first: 10) {
                 edges {
                   node {
                     name
                   }
                 }
               }
-              geneFollowsConnection(first: 10) {
+              genesConnection(first: 10) {
                 edges {
                   node {
                     name
@@ -233,7 +232,6 @@ describe("User", () => {
             }
           }
         }
-      
       `
 
       const user = {
@@ -275,26 +273,26 @@ describe("User", () => {
 
       const {
         user: {
-          follows: { artistFollowsConnection, geneFollowsConnection },
+          follows: { artistsConnection, genesConnection },
         },
       } = await runAuthenticatedQuery(query, context)
 
-      expect(artistFollowsConnection.edges.length).toEqual(2)
-      expect(geneFollowsConnection.edges.length).toEqual(1)
+      expect(artistsConnection.edges.length).toEqual(2)
+      expect(genesConnection.edges.length).toEqual(1)
 
-      expect(artistFollowsConnection.edges[0]).toEqual({
+      expect(artistsConnection.edges[0]).toEqual({
         node: {
           name: "Frank Stella",
         },
       })
 
-      expect(artistFollowsConnection.edges[1]).toEqual({
+      expect(artistsConnection.edges[1]).toEqual({
         node: {
           name: "Ed Ruscha",
         },
       })
 
-      expect(geneFollowsConnection.edges[0]).toEqual({
+      expect(genesConnection.edges[0]).toEqual({
         node: {
           name: "Emerging Art",
         },

--- a/src/schema/v2/__tests__/user.test.ts
+++ b/src/schema/v2/__tests__/user.test.ts
@@ -209,4 +209,96 @@ describe("User", () => {
       })
     })
   })
+
+  describe("follows", () => {
+    it("returns user follows", async () => {
+      const query = `
+        {
+          user(id: "abc") {
+            follows {
+              artistFollowsConnection(first: 10) {
+                edges {
+                  node {
+                    name
+                  }
+                }
+              }
+              geneFollowsConnection(first: 10) {
+                edges {
+                  node {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      
+      `
+
+      const user = {
+        id: "abc",
+      }
+
+      const artistFollows = [
+        {
+          name: "Frank Stella",
+        },
+        {
+          name: "Ed Ruscha",
+        },
+      ]
+
+      const geneFollows = [
+        {
+          name: "Emerging Art",
+        },
+      ]
+
+      const context = {
+        userByIDLoader: () => {
+          return Promise.resolve(user)
+        },
+        userArtistFollowsLoader: () => {
+          return Promise.resolve({
+            body: artistFollows,
+            headers: { "x-total-count": "2" },
+          })
+        },
+        userGeneFollowsLoader: () => {
+          return Promise.resolve({
+            body: geneFollows,
+            headers: { "x-total-count": "1" },
+          })
+        },
+      }
+
+      const {
+        user: {
+          follows: { artistFollowsConnection, geneFollowsConnection },
+        },
+      } = await runAuthenticatedQuery(query, context)
+
+      expect(artistFollowsConnection.edges.length).toEqual(2)
+      expect(geneFollowsConnection.edges.length).toEqual(1)
+
+      expect(artistFollowsConnection.edges[0]).toEqual({
+        node: {
+          name: "Frank Stella",
+        },
+      })
+
+      expect(artistFollowsConnection.edges[1]).toEqual({
+        node: {
+          name: "Ed Ruscha",
+        },
+      })
+
+      expect(geneFollowsConnection.edges[0]).toEqual({
+        node: {
+          name: "Emerging Art",
+        },
+      })
+    })
+  })
 })

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -173,59 +173,71 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
         }
       },
     },
-    artistFollowsConnection: {
-      type: artistConnection.connectionType,
-      args: pageable({}),
-      resolve: async ({ id }, args, { userArtistFollowsLoader }) => {
-        if (!userArtistFollowsLoader) {
-          throw new Error(
-            "Loader not found. You must supply an X-Access-Token header."
-          )
-        }
-        const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+    follows: {
+      type: new GraphQLObjectType({
+        name: "UserFollows",
+        fields: {
+          artistFollowsConnection: {
+            type: artistConnection.connectionType,
+            args: pageable({}),
+            resolve: async ({ id }, args, { userArtistFollowsLoader }) => {
+              if (!userArtistFollowsLoader) {
+                throw new Error(
+                  "Loader not found. You must supply an X-Access-Token header."
+                )
+              }
+              const { page, size, offset } = convertConnectionArgsToGravityArgs(
+                args
+              )
 
-        const { body, headers } = await userArtistFollowsLoader(id, {
-          page,
-          size,
-          total_count: true,
-        })
-        const totalCount = parseInt(headers["x-total-count"] || "0", 10)
-        return paginationResolver({
-          totalCount,
-          offset,
-          page,
-          size,
-          body,
-          args,
-        })
-      },
-    },
-    geneFollowsConnection: {
-      type: geneConnection,
-      args: pageable({}),
-      resolve: async ({ id }, args, { userGeneFollowsLoader }) => {
-        if (!userGeneFollowsLoader) {
-          throw new Error(
-            "Loader not found. You must supply an X-Access-Token header."
-          )
-        }
-        const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+              const { body, headers } = await userArtistFollowsLoader(id, {
+                page,
+                size,
+                total_count: true,
+              })
+              const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+              return paginationResolver({
+                totalCount,
+                offset,
+                page,
+                size,
+                body,
+                args,
+              })
+            },
+          },
+          geneFollowsConnection: {
+            type: geneConnection,
+            args: pageable({}),
+            resolve: async ({ id }, args, { userGeneFollowsLoader }) => {
+              if (!userGeneFollowsLoader) {
+                throw new Error(
+                  "Loader not found. You must supply an X-Access-Token header."
+                )
+              }
+              const { page, size, offset } = convertConnectionArgsToGravityArgs(
+                args
+              )
 
-        const { body, headers } = await userGeneFollowsLoader(id, {
-          page,
-          size,
-          total_count: true,
-        })
-        const totalCount = parseInt(headers["x-total-count"] || "0", 10)
-        return paginationResolver({
-          totalCount,
-          offset,
-          page,
-          size,
-          body,
-          args,
-        })
-      },
+              const { body, headers } = await userGeneFollowsLoader(id, {
+                page,
+                size,
+                total_count: true,
+              })
+              const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+              return paginationResolver({
+                totalCount,
+                offset,
+                page,
+                size,
+                body,
+                args,
+              })
+            },
+          },
+        },
+      }),
+      resolve: (result) => result,
     },
     paddleNumber: {
       description: "The paddle number of the user",

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -177,7 +177,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
       type: new GraphQLObjectType({
         name: "UserFollows",
         fields: {
-          artistFollowsConnection: {
+          artistsConnection: {
             type: artistConnection.connectionType,
             args: pageable({}),
             resolve: async ({ id }, args, { userArtistFollowsLoader }) => {
@@ -206,7 +206,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
               })
             },
           },
-          geneFollowsConnection: {
+          genesConnection: {
             type: geneConnection,
             args: pageable({}),
             resolve: async ({ id }, args, { userGeneFollowsLoader }) => {


### PR DESCRIPTION
This PR adds a field on the user schema to return `follows` connections. In this PR we expose two `connections` under a `follows` field, which leverage the existing `connection` types of `genesConnection` and `artistsConnection`.

We also add the following loaders:
1. `userArtistFollowsLoader`
2. `userGeneFollowsLoader`

This work supports the migration of the `Users` page of `admin.artsy.net` to `tools.artsy.net`.

[PLATFORM-4434]

[PLATFORM-4434]: https://artsyproduct.atlassian.net/browse/PLATFORM-4434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ