### PR TITLE
feat: let User type implement NodeInterface in order for refetchability

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16048,7 +16048,7 @@ type UpdateViewingRoomSubsectionsPayload {
 # The `Upload` scalar type represents a file upload.
 scalar Upload
 
-type User {
+type User implements Node {
   # The admin notes associated with the user
   adminNotes: [UserAdminNotes]!
   analytics: AnalyticsUserStats

--- a/src/schema/v2/object_identification.ts
+++ b/src/schema/v2/object_identification.ts
@@ -57,6 +57,7 @@ const SupportedTypes: any = {
     "./sale",
     "./collection",
     "./sale_artwork",
+    "./user",
   ],
 }
 

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -8,7 +8,7 @@ import {
   GraphQLInt,
 } from "graphql"
 import cached from "./fields/cached"
-import { InternalIDFields } from "./object_identification"
+import { InternalIDFields, NodeInterface } from "./object_identification"
 import { LocationType } from "schema/v2/location"
 import { ResolverContext } from "types/graphql"
 import {
@@ -95,6 +95,7 @@ export const ProfileAccessField: GraphQLFieldConfig<any, ResolverContext> = {
 
 export const UserType = new GraphQLObjectType<any, ResolverContext>({
   name: "User",
+  interfaces: [NodeInterface],
   fields: () => ({
     ...InternalIDFields,
     cached,
@@ -380,3 +381,5 @@ export const UserField: GraphQLFieldConfig<void, ResolverContext> = {
 }
 
 export const UsersConnection = connectionWithCursorInfo({ nodeType: UserType })
+
+export default UserField


### PR DESCRIPTION
This lets some conventional refetching within `User` (of a particular tab showing Forque data in https://github.com/artsy/forque/pull/375#discussion_r965208250) start happening.

> The @refetchable directive can only be added to fragments that are "refetchable", that is, on fragments that are declared on Viewer or Query types, or on a type that implements Node (i.e. a type that has an id).

from https://relay.dev/docs/api-reference/use-refetchable-fragment/

On my machine, running Forque pointing to my local Metaphysics running this code, and everything is 👌 