### PR TITLE
fix: update collectorProfile field on User to reflect that user's profile, vs. the requesting user

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16053,8 +16053,6 @@ type User implements Node {
   adminNotes: [UserAdminNotes]!
   analytics: AnalyticsUserStats
   cached: Int
-
-  # A collector profile.
   collectorProfile: CollectorProfileType
   createdAt(
     format: String

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -65,6 +65,11 @@ export default (accessToken, userID, opts) => {
     collectionLoader: gravityLoader((id) => `collection/${id}`, {
       user_id: userID,
     }),
+    collectorProfilesLoader: gravityLoader(
+      "collector_profiles",
+      {},
+      { headers: true }
+    ),
     createAccountRequestLoader: gravityLoader(
       "account_requests",
       {},

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -65,7 +65,6 @@ export default (accessToken, userID, opts) => {
     collectionLoader: gravityLoader((id) => `collection/${id}`, {
       user_id: userID,
     }),
-    collectorProfileLoader: gravityLoader("me/collector_profile"),
     createAccountRequestLoader: gravityLoader(
       "account_requests",
       {},
@@ -238,6 +237,7 @@ export default (accessToken, userID, opts) => {
     ),
     meBidderPositionsLoader: gravityLoader("me/bidder_positions"),
     meBiddersLoader: gravityLoader("me/bidders"),
+    meCollectorProfileLoader: gravityLoader("me/collector_profile"),
     meCreditCardsLoader: gravityLoader(
       "me/credit_cards",
       {},

--- a/src/schema/v2/CollectorProfile/collectorProfile.ts
+++ b/src/schema/v2/CollectorProfile/collectorProfile.ts
@@ -63,7 +63,7 @@ export const CollectorProfileType = new GraphQLObjectType<any, ResolverContext>(
 export const CollectorProfile: GraphQLFieldConfig<void, ResolverContext> = {
   type: CollectorProfileType,
   description: "A collector profile.",
-  resolve: (_root, _option, { collectorProfileLoader }) => {
-    return collectorProfileLoader?.()
+  resolve: (_root, _option, { meCollectorProfileLoader }) => {
+    return meCollectorProfileLoader?.()
   },
 }

--- a/src/schema/v2/__tests__/user.test.ts
+++ b/src/schema/v2/__tests__/user.test.ts
@@ -446,4 +446,54 @@ describe("User", () => {
       })
     })
   })
+
+  describe("collectorProfile", () => {
+    it("returns the user's collector profile", async () => {
+      const query = `
+        {
+          user(id: "blah") {
+            collectorProfile {
+              companyName
+              companyWebsite
+            }
+          }
+        }
+      `
+
+      const user = {
+        id: "blah",
+      }
+
+      const collectorProfiles = [
+        {
+          company_name: "Nun'ya Business",
+          company_website: "donotcontact.me",
+        },
+      ]
+
+      const context = {
+        userByIDLoader: () => {
+          return Promise.resolve(user)
+        },
+        collectorProfilesLoader: (data) => {
+          if (data.user_id !== "blah") {
+            throw new Error(
+              "Unexpected user ID passed to collector profile loader"
+            )
+          }
+          return Promise.resolve({
+            body: collectorProfiles,
+            headers: { "x-total-count": "1" },
+          })
+        },
+      }
+
+      const {
+        user: { collectorProfile },
+      } = await runAuthenticatedQuery(query, context)
+
+      expect(collectorProfile.companyName).toEqual("Nun'ya Business")
+      expect(collectorProfile.companyWebsite).toEqual("donotcontact.me")
+    })
+  })
 })

--- a/src/schema/v2/me/__tests__/collector_profile.test.js
+++ b/src/schema/v2/me/__tests__/collector_profile.test.js
@@ -38,9 +38,7 @@ describe("Me", () => {
       }
 
       const context = {
-        collectorProfileLoader: sinon
-          .stub()
-          .returns(Promise.resolve(collectorProfile)),
+        meCollectorProfileLoader: () => Promise.resolve(collectorProfile),
       }
 
       return runAuthenticatedQuery(query, context).then(

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -65,13 +65,15 @@ import { WatchedLotConnection } from "./watchedLotConnection"
 const collectorProfileResolver = (field: string) => async (
   _root,
   options,
-  { collectorProfileLoader }: { collectorProfileLoader?: StaticPathLoader<any> }
+  {
+    meCollectorProfileLoader,
+  }: { meCollectorProfileLoader?: StaticPathLoader<any> }
 ) => {
-  if (!collectorProfileLoader) {
+  if (!meCollectorProfileLoader) {
     throw new Error("You need to be signed in to perform this action")
   }
 
-  const result = await collectorProfileLoader(options)
+  const result = await meCollectorProfileLoader(options)
   return result?.[field]
 }
 

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -16,7 +16,7 @@ import {
   paginationResolver,
 } from "./fields/pagination"
 import { date } from "./fields/date"
-import { CollectorProfile } from "./CollectorProfile/collectorProfile"
+import { CollectorProfileType } from "./CollectorProfile/collectorProfile"
 import { UserSaleProfile } from "./userSaleProfile"
 import { UserInterestConnection } from "./userInterests"
 import { pageable } from "relay-cursor-paging"
@@ -100,7 +100,22 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
     ...InternalIDFields,
     cached,
     adminNotes: UserAdminNotesField,
-    collectorProfile: CollectorProfile,
+    collectorProfile: {
+      type: CollectorProfileType,
+      resolve: async ({ id: user_id }, {}, { collectorProfilesLoader }) => {
+        if (!collectorProfilesLoader)
+          throw new Error(
+            "Loader not found. You must supply an X-Access-Token header."
+          )
+
+        const { body: profiles } = await collectorProfilesLoader({
+          user_id,
+        })
+
+        // It's ok if `profiles` is an empty array.
+        return profiles[0]
+      },
+    },
     name: {
       description: "The given name of the user.",
       type: new GraphQLNonNull(GraphQLString),


### PR DESCRIPTION
This addresses the bug where the data for `collectorProfile` reflected a 'me'-style API call, vs. that user's data. This updates the existing `collectorProfileLoader` to be called `meCollectorProfileLoader` (since that's what it does), and adds a new `collectorProfilesLoader`.

The partner-inbox query for an order should be able to get the proper data querying this field.

![Screen Shot 2022-09-09 at 1 04 51 PM](https://user-images.githubusercontent.com/1457859/189404653-296aa274-f326-498a-84a9-01eda03bf093.png)
