### PR TITLE
fix(reverse image search): parsing of TinEye artwork result

### DIFF
--- a/src/schema/v2/__tests__/reverseImageSearch.test.ts
+++ b/src/schema/v2/__tests__/reverseImageSearch.test.ts
@@ -58,7 +58,7 @@ describe("reverseImageSearch", () => {
         "reverseImageSearch": Object {
           "results": Array [
             Object {
-              "filepath": "artwork/artwork-id/image/image-id",
+              "filepath": "current-env/artwork/artwork-id/image/image-id",
               "score": 72.83,
             },
           ],
@@ -106,6 +106,10 @@ describe("reverseImageSearch", () => {
 
     const result = await runQuery(artworkQuery, context, { file: upload })
 
+    expect(context.unauthenticatedLoaders.artworkLoader).toHaveBeenCalledWith(
+      "artwork-id"
+    )
+
     expect(result).toMatchInlineSnapshot(`
       Object {
         "reverseImageSearch": Object {
@@ -114,7 +118,7 @@ describe("reverseImageSearch", () => {
               "artwork": Object {
                 "title": "Artwork Title",
               },
-              "filepath": "artwork/artwork-id/image/image-id",
+              "filepath": "current-env/artwork/artwork-id/image/image-id",
             },
           ],
         },
@@ -142,7 +146,7 @@ const TinEyeSuccessResponse = {
     {
       target_overlap_percent: 99.76,
       query_overlap_percent: 99.95,
-      filepath: "artwork/artwork-id/image/image-id",
+      filepath: "current-env/artwork/artwork-id/image/image-id",
       target_match_rect: {
         top: 29.29,
         bottom: 71.64,

--- a/src/schema/v2/reverseImageSearch.ts
+++ b/src/schema/v2/reverseImageSearch.ts
@@ -79,7 +79,7 @@ export const ReverseImageSearchResult = new GraphQLObjectType({
       ) => {
         if (filepath) {
           const parts = filepath.split("/")
-          const artworkId = parts[1]
+          const artworkId = parts[2]
 
           return artworkLoader(artworkId)
         }


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-4202

Follow-up to https://github.com/artsy/metaphysics/pull/4369

The recent change to the convention for the TinEye filepath that we use as an identifier…

|which version|filepath convention|
|---|---|
|old|`artwork/<artwork id>/image/<image token>`|
|new|`<current env>/artwork/<artwork id>/image/<image token>`|

…means that we need to change the way we parse that identifier in order to extract the artwork id — it's now the third segment in that path, not the second.

There wasn't an existing test to catch that, which is why it slipped through #4369 and resulted in broken image matching.

This PR adds the test and updates the implementation.