### PR TITLE
feat: add inquiredArtworksConnection to User

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16098,6 +16098,12 @@ type User implements Node {
 
   # A globally unique ID.
   id: ID!
+  inquiredArtworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): UserInquiredArtworksConnection
   interestsConnection(
     after: String
     before: String
@@ -16369,6 +16375,47 @@ type UserIconDeleteSuccessType {
 union UserIconDeletionMutationType =
     UserIconDeleteFailureType
   | UserIconDeleteSuccessType
+
+# A connection to a list of items.
+type UserInquiredArtworksConnection {
+  # A list of edges.
+  edges: [UserInquiredArtworksEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type UserInquiredArtworksEdge {
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See
+    # http://www.iana.org/time-zones,
+    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+
+  # A cursor for use in pagination
+  cursor: String!
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID.
+  internalID: ID!
+  isSentToGallery: Boolean
+
+  # The item at the end of the edge
+  node: Artwork
+  note: String
+  outcome: String
+
+  # This reflects the `title` attribute of the most recent embedded object in `statuses`
+  status: String
+}
 
 type UserInterest {
   body: String

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -459,6 +459,11 @@ export default (accessToken, userID, opts) => {
       { method: "PUT" }
     ),
     usersLoader: gravityLoader("users", {}, { headers: true }),
+    userInquiryRequestsLoader: gravityLoader(
+      (id) => `user/${id}/artwork_inquiry_requests`,
+      {},
+      { headers: true }
+    ),
     userSaleProfileLoader: gravityLoader((id) => `user_sale_profile/${id}`),
     userAdminNotesLoader: gravityLoader((id) => `user/${id}/admin_notes`),
     createUserAdminNoteLoader: gravityLoader(

--- a/src/schema/v2/userInquiredArtworks.ts
+++ b/src/schema/v2/userInquiredArtworks.ts
@@ -1,0 +1,47 @@
+import { connectionWithCursorInfo } from "schema/v2/fields/pagination"
+import { ResolverContext } from "types/graphql"
+import {
+  GraphQLString,
+  Thunk,
+  GraphQLFieldConfigMap,
+  GraphQLBoolean,
+} from "graphql"
+import { IDFields } from "./object_identification"
+import { ArtworkType } from "./artwork"
+import { date } from "./fields/date"
+
+export const edgeFields: Thunk<GraphQLFieldConfigMap<
+  any,
+  ResolverContext
+>> = () => ({
+  ...IDFields,
+  status: {
+    type: GraphQLString,
+    description:
+      "This reflects the `title` attribute of the most recent embedded object in `statuses`",
+    resolve: ({ statuses }) => {
+      const statusesWithDates = statuses.map((obj) => {
+        return { ...obj, createdAt: new Date(obj.created_at) }
+      })
+
+      const sortedStatusesReverseChronological = [...statusesWithDates].sort(
+        (objA, objB) => objB.createdAt.getTime() - objA.createdAt.getTime()
+      )
+
+      return sortedStatusesReverseChronological[0]?.title
+    },
+  },
+  outcome: { type: GraphQLString },
+  note: { type: GraphQLString },
+  createdAt: date(({ created_at }) => created_at),
+  isSentToGallery: {
+    type: GraphQLBoolean,
+    resolve: ({ contact_gallery }) => !!contact_gallery,
+  },
+})
+
+export const UserInquiredArtworksConnection = connectionWithCursorInfo({
+  name: "UserInquiredArtworks",
+  nodeType: ArtworkType,
+  edgeFields: edgeFields,
+}).connectionType


### PR DESCRIPTION
![Screen Shot 2022-09-12 at 1 24 25 PM](https://user-images.githubusercontent.com/1457859/189718865-b13c7505-c149-4638-bc6e-d0f584ad1a57.png)

Exposes a connection of artworks, with inquiry data along the edge (pretty much like lots of these other connections we've been adding). This should be enough to power the Forque UI ('Inquiries' tab for user management) and can be built upon further if needed.