### PR TITLE
feat(FX-4181): Create a mutation to mark all unread notifications as read

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9850,12 +9850,24 @@ type LotStanding {
   saleArtwork: SaleArtwork
 }
 
+type MarkAllNotificationsAsReadFailure {
+  mutationError: GravityMutationError
+}
+
 input MarkAllNotificationsAsReadInput {
   clientMutationId: String
 }
 
 type MarkAllNotificationsAsReadPayload {
   clientMutationId: String
+  responseOrError: MarkAllNotificationsAsReadResponseOrError
+}
+
+union MarkAllNotificationsAsReadResponseOrError =
+    MarkAllNotificationsAsReadFailure
+  | MarkAllNotificationsAsReadSuccess
+
+type MarkAllNotificationsAsReadSuccess {
   success: Boolean
 }
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9850,6 +9850,15 @@ type LotStanding {
   saleArtwork: SaleArtwork
 }
 
+input MarkAllNotificationsAsReadInput {
+  clientMutationId: String
+}
+
+type MarkAllNotificationsAsReadPayload {
+  clientMutationId: String
+  success: Boolean
+}
+
 type MarketingCollection {
   artworksConnection(
     acquireable: Boolean
@@ -10941,6 +10950,11 @@ type Mutation {
   linkAuthentication(
     input: LinkAuthenticationMutationInput!
   ): LinkAuthenticationMutationPayload
+
+  # Mark all unread notifications as read
+  markAllNotificationsAsRead(
+    input: MarkAllNotificationsAsReadInput!
+  ): MarkAllNotificationsAsReadPayload
 
   # Merge multiple artist records in order to deduplicate artists
   mergeArtists(input: MergeArtistsMutationInput!): MergeArtistsMutationPayload

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -298,6 +298,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "DELETE" }
     ),
+    updateNotificationsLoader: gravityLoader(
+      "me/notifications",
+      {},
+      { method: "PUT" }
+    ),
     notificationsFeedLoader: gravityLoader("me/notifications/feed"),
     partnerAllLoader: gravityLoader((id) => `partner/${id}/all`),
     partnerArtistDocumentsLoader: gravityLoader<

--- a/src/schema/v2/me/__tests__/mark_all_notifications_as_read_mutation.test.ts
+++ b/src/schema/v2/me/__tests__/mark_all_notifications_as_read_mutation.test.ts
@@ -1,0 +1,44 @@
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+const mutation = `
+  mutation {
+    markAllNotificationsAsRead(input: {}) {
+      success
+    }
+  }
+`
+
+describe("markAllNotificationsAsReadMutation", () => {
+  it("should return success = true when all unread notifications are marked as read", async () => {
+    const context = {
+      updateNotificationsLoader: jest.fn().mockResolvedValue(true),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "markAllNotificationsAsRead": Object {
+          "success": true,
+        },
+      }
+    `)
+  })
+
+  it("should return success = false when something went wrong", async () => {
+    const error = new Error("Some Error")
+    const context = {
+      updateNotificationsLoader: jest.fn().mockRejectedValue(error),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "markAllNotificationsAsRead": Object {
+          "success": false,
+        },
+      }
+    `)
+  })
+})

--- a/src/schema/v2/me/__tests__/mark_all_notifications_as_read_mutation.test.ts
+++ b/src/schema/v2/me/__tests__/mark_all_notifications_as_read_mutation.test.ts
@@ -3,13 +3,23 @@ import { runAuthenticatedQuery } from "schema/v2/test/utils"
 const mutation = `
   mutation {
     markAllNotificationsAsRead(input: {}) {
-      success
+      responseOrError {
+        ... on MarkAllNotificationsAsReadSuccess {
+          success
+        }
+        
+        ... on MarkAllNotificationsAsReadFailure {
+          mutationError {
+            message
+          }
+        }
+      }
     }
   }
 `
 
 describe("markAllNotificationsAsReadMutation", () => {
-  it("should return success = true when all unread notifications are marked as read", async () => {
+  it("should return success response when all unread notifications are marked as read", async () => {
     const context = {
       updateNotificationsLoader: jest.fn().mockResolvedValue(true),
     }
@@ -19,14 +29,17 @@ describe("markAllNotificationsAsReadMutation", () => {
     expect(result).toMatchInlineSnapshot(`
       Object {
         "markAllNotificationsAsRead": Object {
-          "success": true,
+          "responseOrError": Object {
+            "success": true,
+          },
         },
       }
     `)
   })
 
-  it("should return success = false when something went wrong", async () => {
-    const error = new Error("Some Error")
+  it("should return failure response when something went wrong", async () => {
+    const message = `https://stagingapi.artsy.net/api/v1/me/notifications - {"error":"Something went wrong"}`
+    const error = new Error(message)
     const context = {
       updateNotificationsLoader: jest.fn().mockRejectedValue(error),
     }
@@ -36,7 +49,11 @@ describe("markAllNotificationsAsReadMutation", () => {
     expect(result).toMatchInlineSnapshot(`
       Object {
         "markAllNotificationsAsRead": Object {
-          "success": false,
+          "responseOrError": Object {
+            "mutationError": Object {
+              "message": "Something went wrong",
+            },
+          },
         },
       }
     `)

--- a/src/schema/v2/me/mark_all_notifications_as_read_mutation.ts
+++ b/src/schema/v2/me/mark_all_notifications_as_read_mutation.ts
@@ -1,0 +1,36 @@
+import { GraphQLBoolean } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+
+export const markAllNotificationsAsReadMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "MarkAllNotificationsAsRead",
+  description: "Mark all unread notifications as read",
+  inputFields: {},
+  outputFields: {
+    success: {
+      type: GraphQLBoolean,
+      resolve: (result) => result.success,
+    },
+  },
+  mutateAndGetPayload: async (_, { updateNotificationsLoader }) => {
+    if (!updateNotificationsLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      await updateNotificationsLoader({ status: "read" })
+
+      return {
+        success: true,
+      }
+    } catch {
+      return {
+        success: false,
+      }
+    }
+  },
+})

--- a/src/schema/v2/me/mark_all_notifications_as_read_mutation.ts
+++ b/src/schema/v2/me/mark_all_notifications_as_read_mutation.ts
@@ -1,6 +1,41 @@
+import { GraphQLObjectType } from "graphql"
+import { GraphQLUnionType } from "graphql"
 import { GraphQLBoolean } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "MarkAllNotificationsAsReadSuccess",
+  isTypeOf: (data) => data.success,
+  fields: () => ({
+    success: {
+      type: GraphQLBoolean,
+      resolve: (result) => result.success,
+    },
+  }),
+})
+
+const ErrorType = new GraphQLObjectType<any, ResolverContext>({
+  name: "MarkAllNotificationsAsReadFailure",
+  isTypeOf: (data) => {
+    return data._type === "GravityMutationError"
+  },
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => (typeof err.message === "object" ? err.message : err),
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "MarkAllNotificationsAsReadResponseOrError",
+  types: [SuccessType, ErrorType],
+})
 
 export const markAllNotificationsAsReadMutation = mutationWithClientMutationId<
   any,
@@ -11,9 +46,9 @@ export const markAllNotificationsAsReadMutation = mutationWithClientMutationId<
   description: "Mark all unread notifications as read",
   inputFields: {},
   outputFields: {
-    success: {
-      type: GraphQLBoolean,
-      resolve: (result) => result.success,
+    responseOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
     },
   },
   mutateAndGetPayload: async (_, { updateNotificationsLoader }) => {
@@ -27,9 +62,13 @@ export const markAllNotificationsAsReadMutation = mutationWithClientMutationId<
       return {
         success: true,
       }
-    } catch {
-      return {
-        success: false,
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
       }
     }
   },

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -153,6 +153,7 @@ import { PartnerArtistDocumentsConnection } from "./partnerArtistDocumentsConnec
 import { PartnerShowDocumentsConnection } from "./partnerShowDocumentsConnection"
 import { bulkUpdatePartnerArtworksMutation } from "./bulkUpdatePartnerArtworksMutation"
 import { NotificationsConnection } from "./notifications"
+import { markAllNotificationsAsReadMutation } from "./me/mark_all_notifications_as_read_mutation"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -301,6 +302,7 @@ export default new GraphQLSchema({
       followProfile: FollowProfile,
       followShow: FollowShow,
       linkAuthentication: linkAuthenticationMutation,
+      markAllNotificationsAsRead: markAllNotificationsAsReadMutation,
       mergeArtists: mergeArtistsMutation,
       myCollectionCreateArtwork: myCollectionCreateArtworkMutation,
       myCollectionUpdateArtwork: myCollectionUpdateArtworkMutation,


### PR DESCRIPTION
Jira ticket: [FX-4181]

### Mutation
```graphql
mutation {
  markAllNotificationsAsRead(input: {}) {
    responseOrError {
      ... on MarkAllNotificationsAsReadSuccess {
        success
      }
      
      ... on MarkAllNotificationsAsReadFailure {
        mutationError {
          error
        }
      }
    }
  }
}
```

### Mutation success response
```graphql
markAllNotificationsAsRead: {
  responseOrError: {
    success: true
  }
}
```

### Mutation failure response
```graphql
{
  "responseOrError": {
    "mutationError": {
      "error": "...",
      "message": "..."
      ...
    }
  }
}
```

### Debug info
```javascript
{
  "data": {
    "markAllNotificationsAsRead": {
      "responseOrError": {
        "success": true
      }
    }
  },
  "extensions": {
    "requests": {
      "gravity": {
        "requests": {
          "me/notifications?status=read": {
            "time": "0s 524.472ms",
            "cache": false,
            "length": "0 B"
          }
        }
      }
    },
    "requestID": "6d1956a0-34dc-11ed-94de-1dd82adc179a"
  }
}
```

[FX-4181]: https://artsyproduct.atlassian.net/browse/FX-4181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ