### PR TITLE
chore: add proper pagination support to user interests

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16438,9 +16438,11 @@ enum UserInterestCategory {
 type UserInterestConnection {
   # A list of edges.
   edges: [UserInterestEdge]
+  pageCursors: PageCursors!
 
   # Information to aid in pagination.
   pageInfo: PageInfo!
+  totalCount: Int
 }
 
 # An edge in a connection.

--- a/src/schema/v2/__tests__/user.test.ts
+++ b/src/schema/v2/__tests__/user.test.ts
@@ -271,6 +271,13 @@ describe("User", () => {
         {
           user(id: "blah") {
             interestsConnection(first: 10) {
+              totalCount
+              pageCursors {
+                around {
+                  page
+                  isCurrent
+                }
+              }
               edges {
                 body
                 category
@@ -328,12 +335,14 @@ describe("User", () => {
 
       const {
         user: {
-          interestsConnection: { edges },
+          interestsConnection: { edges, totalCount, pageCursors },
         },
       } = await runAuthenticatedQuery(query, context)
 
-      expect(edges.length).toEqual(2)
+      expect(totalCount).toEqual(2)
+      expect(pageCursors.around).toEqual([{ page: 1, isCurrent: true }])
 
+      expect(edges.length).toEqual(2)
       expect(edges[0]).toEqual({
         body: "Told an admin they collected",
         category: "COLLECTED_BEFORE",
@@ -343,7 +352,6 @@ describe("User", () => {
           name: "Catty Artist",
         },
       })
-
       expect(edges[1]).toEqual({
         body: null,
         category: "INTERESTED_IN_COLLECTING",

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -222,6 +222,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
 
           return {
             totalCount,
+            pageCursors: createPageCursors({ page, size }, totalCount),
             ...connectionFromArraySlice(body, args, {
               arrayLength: totalCount,
               sliceStart: offset,

--- a/src/schema/v2/userInterests.ts
+++ b/src/schema/v2/userInterests.ts
@@ -1,4 +1,3 @@
-import { connectionDefinitions } from "graphql-relay"
 import {
   userInterestInterestUnion,
   UserInterest,
@@ -13,6 +12,7 @@ import {
   GraphQLBoolean,
 } from "graphql"
 import { IDFields } from "./object_identification"
+import { connectionWithCursorInfo } from "./fields/pagination"
 
 export const edgeFields: Thunk<GraphQLFieldConfigMap<
   UserInterest,
@@ -27,7 +27,7 @@ export const edgeFields: Thunk<GraphQLFieldConfigMap<
   },
 })
 
-export const UserInterestConnection = connectionDefinitions({
+export const UserInterestConnection = connectionWithCursorInfo({
   name: "UserInterest",
   nodeType: userInterestInterestUnion,
   edgeFields: edgeFields,


### PR DESCRIPTION
Easy one! I forgot about this when working on user interests - this adds the proper plumbing for our pagination components.

The other place in Forque to add proper pagination to, user follows, already fully supports the pagination schema (on the MP side).