### PR TITLE
feat: allow prod to run on spot

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -92,14 +92,6 @@ spec:
                 values:
                 - foreground
                 - foreground-spot
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: tier
-                    operator: In
-                    values:
-                      - foreground
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -90,8 +90,16 @@ spec:
               - key: tier
                 operator: In
                 values:
-                - api
                 - foreground
+                - foreground-spot
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: tier
+                    operator: In
+                    values:
+                      - foreground
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -97,14 +97,6 @@ spec:
                 values:
                 - foreground
                 - foreground-spot
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: tier
-                    operator: In
-                    values:
-                      - foreground
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -97,15 +97,14 @@ spec:
                 values:
                 - foreground
                 - foreground-spot
-      topologySpreadConstraints:
-      - maxSkew: 1
-        topologyKey: tier
-        whenUnsatisfiable: ScheduleAnyway
-        labelSelector:
-          matchLabels:
-            app: metaphysics
-            layer: application
-            component: web
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: tier
+                    operator: In
+                    values:
+                      - foreground
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler


### PR DESCRIPTION
[PLATFORM-4571]

### Description

Staging [has been partly run on Spot nodes](https://github.com/artsy/metaphysics/pull/4341) for a while. I haven't heard of any problems. This PR spikes Prod on Spot.

- Allow pods in Prod to run on Spot nodes.
- Don't let pods run in `api` tier anymore. (as having affinity for 3 tiers, including spot, seems too complicated.)

And (as [done for Gravity](https://github.com/artsy/gravity/pull/15646)):

- Remove topologySpreadConstraints in Staging.

[PLATFORM-4571]: https://artsyproduct.atlassian.net/browse/PLATFORM-4571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ