### PR TITLE
fix: proper schema for pagination on GenesConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8877,9 +8877,11 @@ type Gene implements Node & Searchable {
 type GeneConnection {
   # A list of edges.
   edges: [GeneEdge]
+  pageCursors: PageCursors!
 
   # Information to aid in pagination.
   pageInfo: PageInfo!
+  totalCount: Int
 }
 
 # An edge in a connection.

--- a/src/schema/v2/gene.ts
+++ b/src/schema/v2/gene.ts
@@ -1,5 +1,5 @@
 import { getPagingParameters, pageable } from "relay-cursor-paging"
-import { connectionDefinitions, connectionFromArraySlice } from "graphql-relay"
+import { connectionFromArraySlice } from "graphql-relay"
 import _ from "lodash"
 import cached from "./fields/cached"
 import Artist, { artistConnection } from "./artist"
@@ -24,6 +24,7 @@ import { Searchable } from "./searchable"
 import { setVersion } from "./image/normalize"
 import { getDefault } from "./image"
 import { markdown } from "schema/v2/fields/markdown"
+import { connectionWithCursorInfo } from "./fields/pagination"
 
 const SUBJECT_MATTER_MATCHES = [
   "content",
@@ -248,6 +249,6 @@ const Gene: GraphQLFieldConfig<void, ResolverContext> = {
 
 export default Gene
 
-export const geneConnection = connectionDefinitions({
+export const geneConnection = connectionWithCursorInfo({
   nodeType: GeneType,
 }).connectionType


### PR DESCRIPTION
This was using the proper resolver (so I assumed pagination was working with a genes connection), but the type definition didn't have the right schema.