### PR TITLE
fix: for prod, add toleration for spot node taint

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -82,6 +82,11 @@ spec:
         options:
         - name: ndots
           value: '1'
+      tolerations:
+        - key: reserved
+          operator: Equal
+          value: spot
+          effect: NoSchedule
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Missed this config in https://github.com/artsy/metaphysics/pull/4383