### PR TITLE
feat: recognize ViewingRoomPublishedActivity events

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11415,6 +11415,7 @@ input NotificationPreferenceInput {
 enum NotificationTypesEnum {
   ARTWORK_ALERT
   ARTWORK_PUBLISHED
+  VIEWING_ROOM_PUBLISHED
 }
 
 # Consignment Offer Response

--- a/src/schema/v2/notifications/index.ts
+++ b/src/schema/v2/notifications/index.ts
@@ -26,6 +26,7 @@ const NotificationTypesEnum = new GraphQLEnumType({
   values: {
     ARTWORK_ALERT: { value: "SavedSearchHitActivity" },
     ARTWORK_PUBLISHED: { value: "ArtworkPublishedActivity" },
+    VIEWING_ROOM_PUBLISHED: { value: "ViewingRoomPublishedActivity" },
   },
 })
 
@@ -49,14 +50,25 @@ export const NotificationType = new GraphQLObjectType<any, ResolverContext>({
     createdAt: date(({ date }) => date),
     targetHref: {
       type: new GraphQLNonNull(GraphQLString),
-      resolve: ({ object }) => `/artist/${object.artist.id}/works-for-sale`,
+      resolve: ({ object, message }) => {
+        if (message.includes("Viewing Room")) {
+          return `/viewing-room/${object.id}`
+        } else {
+          return `/artist/${object.artist.id}/works-for-sale`
+        }
+      },
     },
     notificationType: {
       type: new GraphQLNonNull(NotificationTypesEnum),
-      resolve: ({ actors }) =>
-        actors.startsWith("Works by")
-          ? "SavedSearchHitActivity"
-          : "ArtworkPublishedActivity",
+      resolve: ({ actors, message }) => {
+        if (actors.startsWith("Works by")) {
+          return "SavedSearchHitActivity"
+        } else if (message.includes("Viewing Room")) {
+          return "ViewingRoomPublishedActivity"
+        } else {
+          return "ArtworkPublishedActivity"
+        }
+      },
     },
     artworksConnection: {
       type: artworkConnection.connectionType,


### PR DESCRIPTION
Adds some rough support to recognize ViewingRoomPublishedActivity events separate from the other two currently recognized.

We should move the type and targetHref awareness over to the modeling in Gravity and stop doing this in Metaphysics though.

Example of the notification payload via Gravity's API:

```json
{
  "feed": [
    {
      "actors": "Commerce Test Partner",
      "message": "1 Viewing Room Published",
      "status": "unread",
      "date": "2022-09-16T12:45:53.000Z",
      "object": {
        "id": "cbf1888e-47f6-40e0-ac9d-162041004045",
        "start_at": "2022-09-15T14:30:00.000Z",
        "end_at": "2022-10-14T14:30:00.000Z",
        "title": "Matt tests image uploads"
      },
      "object_ids": [
        "cbf1888e-47f6-40e0-ac9d-162041004045"
      ],
      "id": "6324700153b5930007e6c0eb"
    }
  ],
  "total_unread": 1,
  "total": 1
}
```