### PR TITLE
chore(PX-5236): remove unlisted and includeUnlisted

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2165,9 +2165,6 @@ type Artwork implements Node & Searchable & Sellable {
   submissionId: String
   title: String
 
-  # Whether this artwork is unlisted or not
-  unlisted: Boolean
-
   # Based on artwork location and status, verify that partner needs VAT exemption approval from Artsy.
   vatExemptApprovalRequired: Boolean
 
@@ -12862,9 +12859,6 @@ type Query {
   artwork(
     # The slug or ID of the Artwork
     id: String!
-
-    # Include unlisted artwork or not
-    includeUnlisted: Boolean
   ): Artwork
 
   # List of all artwork attribution classes
@@ -16735,9 +16729,6 @@ type Viewer {
   artwork(
     # The slug or ID of the Artwork
     id: String!
-
-    # Include unlisted artwork or not
-    includeUnlisted: Boolean
   ): Artwork
 
   # List of all artwork attribution classes

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -80,7 +80,6 @@ describe("Artwork type", () => {
       attribution_class: "unique",
       dimensions: { in: "2 x 3in." },
       metric: "in",
-      unlisted: true,
       category: "Painting",
       artsy_shipping_domestic: false,
     }
@@ -3469,64 +3468,6 @@ describe("Artwork type", () => {
       }
       const data = await runQuery(query, context)
       expect(data.artwork.realizedToEstimate).toBe("2.2")
-    })
-  })
-
-  describe("#unlisted", () => {
-    const query = `
-      {
-        artwork(id: "richard-prince-untitled-portrait") {
-          unlisted
-        }
-      }
-    `
-    it("returns unlisted", async () => {
-      let data = await runQuery(query, context)
-      expect(data.artwork.unlisted).toBe(true)
-      artwork.unlisted = false
-
-      data = await runQuery(query, context)
-      expect(data.artwork.unlisted).toBe(false)
-    })
-  })
-
-  describe("includeUnlisted argument", () => {
-    beforeEach(() => {
-      context = {
-        artworkLoader: jest.fn(() => Promise.resolve(artwork)),
-      }
-    })
-
-    it("passes includeUnlisted to artworkLoader when with the argument", async () => {
-      const query = `
-        {
-          artwork(id: "richard-prince-untitled-portrait", includeUnlisted: true) {
-            unlisted
-          }
-        }
-      `
-      await runQuery(query, context)
-      expect(context.artworkLoader).toBeCalledWith(
-        "richard-prince-untitled-portrait",
-        {
-          include_unlisted: true,
-        }
-      )
-    })
-
-    it("does not pass includeUnlisted to artworkLoader when without the argument", async () => {
-      const query = `
-        {
-          artwork(id: "richard-prince-untitled-portrait") {
-            unlisted
-          }
-        }
-      `
-      await runQuery(query, context)
-      expect(context.artworkLoader).toBeCalledWith(
-        "richard-prince-untitled-portrait",
-        {}
-      )
     })
   })
 

--- a/src/schema/v2/artwork/__tests__/comparableAuctionResults.test.ts
+++ b/src/schema/v2/artwork/__tests__/comparableAuctionResults.test.ts
@@ -37,7 +37,7 @@ describe("ComparableAuctionResults", () => {
       artwork: { comparableAuctionResults },
     } = await runQuery(query, context)
 
-    expect(artworkLoader).toHaveBeenCalledWith(mockArtwork.id, {})
+    expect(artworkLoader).toHaveBeenCalledWith(mockArtwork.id)
     expect(comparableAuctionResultsLoader).toHaveBeenCalledWith({
       artist_id: mockArtwork.artist._id,
       date: mockArtwork.date,

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1340,10 +1340,6 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: new GraphQLNonNull(GraphQLBoolean),
         description: "Whether this artwork is published or not",
       },
-      unlisted: {
-        type: GraphQLBoolean,
-        description: "Whether this artwork is unlisted or not",
-      },
       website: {
         type: GraphQLString,
         description:
@@ -1537,10 +1533,6 @@ const Artwork: GraphQLFieldConfig<void, ResolverContext> = {
       type: new GraphQLNonNull(GraphQLString),
       description: "The slug or ID of the Artwork",
     },
-    includeUnlisted: {
-      type: GraphQLBoolean,
-      description: "Include unlisted artwork or not",
-    },
   },
   resolve: async (
     _source,
@@ -1549,17 +1541,13 @@ const Artwork: GraphQLFieldConfig<void, ResolverContext> = {
     resolveInfo
   ) => {
     const { id } = args
-    const gravityParams = _.mapKeys(
-      _.pick(args, ["includeUnlisted"]),
-      (_v, k) => _.snakeCase(k)
-    )
 
     const hasRequestedPriceInsights = isFieldRequested(
       "marketPriceInsights",
       resolveInfo
     )
 
-    const artwork = await artworkLoader(id, gravityParams)
+    const artwork = await artworkLoader(id)
 
     // // We don't want to query for the price insights unless the user has requested them
     if (

--- a/src/schema/v2/me/__tests__/newWorksByInterestingArtists.test.ts
+++ b/src/schema/v2/me/__tests__/newWorksByInterestingArtists.test.ts
@@ -293,7 +293,6 @@ const mockArtworksResponse = [
     shipping_origin: null,
     eu_shipping_origin: false,
     current_version_id: null,
-    unlisted: false,
     featured_slot: null,
     artsy_shipping_domestic: false,
   },


### PR DESCRIPTION
Removing `unlisted` field on `artwork` and the `includeUnlisted` argument on the `artwork` field.

Basically reverting [this PR](https://github.com/artsy/metaphysics/pull/2428)

-----------------------------

Expected failure when querying with`includeUnlisted` param

<img width="884" alt=" 2022-09-19 at 1 35 01 PM" src="https://user-images.githubusercontent.com/1389948/191111646-557d3af3-afb2-45c0-8620-e132f13815b3.png">

Expected failure when querying for `unlisted` field

<img width="921" alt=" 2022-09-19 at 1 34 17 PM" src="https://user-images.githubusercontent.com/1389948/191111661-db4b89fc-a0fd-40ba-953f-305eb5a81bb3.png">

A successful query

<img width="717" alt=" 2022-09-19 at 1 34 39 PM" src="https://user-images.githubusercontent.com/1389948/191111670-bfc01b9a-00b3-499f-89d0-b18dd94fc156.png">
