### PR TITLE
feat: Respect timezones for event time ranges GRO-1024

### DIFF
--- a/src/schema/v2/show_event.ts
+++ b/src/schema/v2/show_event.ts
@@ -24,8 +24,10 @@ const ShowEventType = new GraphQLObjectType<any, ResolverContext>({
     dateTimeRange: {
       type: GraphQLString,
       description: "A formatted description of the dates with hours",
-      resolve: ({ start_at, end_at }) =>
-        dateTimeRange(start_at, end_at, "UTC", true),
+      resolve: ({ start_at, end_at }, { timezone }, { defaultTimezone }) => {
+        const timezoneString = timezone ? timezone : defaultTimezone
+        return dateTimeRange(start_at, end_at, timezoneString, true)
+      },
     },
     exhibitionPeriod: {
       type: GraphQLString,


### PR DESCRIPTION
There's a pattern in the way Force and MP work together where times can appear in a user's local timezone when rendered client side. The way this works in MP is via a header called `X-Timezone` - it's value is available to resolver functions and there's also a default.

To complete that thought here's how that's set client side in Force:

https://github.com/artsy/force/blob/22fb4e1451302b0ddf1a009b5fb873110ce0293f/src/System/Relay/createRelaySSREnvironment.ts#L84-L85

So anyway all this PR does is pluck these timezone values out of the arguments passed to the resolver and then sends them down to the date formatting function rather than hard-coding UTC.

https://artsyproduct.atlassian.net/browse/GRO-1024

/cc @artsy/grow-devs