### PR TITLE
feat[FX-3981]: update app home marketing collections

### DIFF
--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -267,11 +267,11 @@ export const gravityStitchingEnvironment = (
                 fieldName: "marketingCollections",
                 args: {
                   slugs: [
-                    "highlights-this-month",
-                    "new-from-emerging-artists",
-                    "new-from-established-artists",
-                    "limited-edition-prints-trending-artists",
-                    "auction-highlights",
+                    "top-auction-lots",
+                    "artists-on-the-rise",
+                    "iconic-prints",
+                    "finds-under-1000-dollars",
+                    "trending-this-week",
                   ],
                 },
                 context,


### PR DESCRIPTION
Once curated marketing collections are launched, we can also update the collections in the app rail.

https://artsyproduct.atlassian.net/browse/FX-3981