### PR TITLE
feat: Add high auction record to artist insights GRO-841

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1434,6 +1434,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
       REVIEWED
       BIENNIAL
       ACTIVE_SECONDARY_MARKET
+      HIGH_AUCTION_RECORD
     ]
   ): [ArtistInsight!]!
 
@@ -1641,6 +1642,7 @@ enum ArtistInsightKind {
   BIENNIAL
   COLLECTED
   GROUP_SHOW
+  HIGH_AUCTION_RECORD
   REVIEWED
   SOLO_SHOW
 }

--- a/src/schema/v2/artist/__tests__/helpers.test.ts
+++ b/src/schema/v2/artist/__tests__/helpers.test.ts
@@ -123,4 +123,40 @@ describe("getArtistInsights", () => {
       })
     })
   })
+
+  describe("string insight fields", () => {
+    const fields = [
+      {
+        key: "highAuctionRecord",
+        kind: "HIGH_AUCTION_RECORD",
+        value: "£18.6m, Sotheby's, 2021",
+      } as any,
+    ]
+
+    fields.forEach((field) => {
+      it(`returns an empty array of entities when the ${field.key} has a value and sets the description`, () => {
+        const artist = {
+          [field.key]: field.value,
+        }
+
+        const insights = getArtistInsights(artist)
+        const insight = insights.find((insight) => insight.kind === field.kind)!
+
+        expect(insight.count).toEqual(0)
+        expect(insight.entities).toEqual([])
+        expect(insight.description).toEqual(field.value)
+      })
+
+      it(`returns an empty artist object when the ${field.key} has no value`, () => {
+        field.value = null
+        const artist = {
+          [field.key]: field.value,
+        }
+
+        const insights = getArtistInsights(artist)
+        const insight = insights.find((insight) => insight.kind === field.kind)
+        expect(insight).toBeUndefined()
+      })
+    })
+  })
 })

--- a/src/schema/v2/artist/__tests__/helpers.test.ts
+++ b/src/schema/v2/artist/__tests__/helpers.test.ts
@@ -11,13 +11,6 @@ describe("getArtistInsights", () => {
     })
   })
 
-  it("returns a fallback shape when the value isn't a string or boolean", () => {
-    const artist = { solo_show_institutions: 7 }
-    const insights = getArtistInsights(artist)
-    const insight = insights[0]
-    expect(insight).toEqual({ artist, count: 0 })
-  })
-
   describe("pipe delimited insight fields", () => {
     const value =
       "Art Institute of Chicago |Brooklyn Museum |       Hamburger Bahnhof"

--- a/src/schema/v2/artist/__tests__/helpers.test.ts
+++ b/src/schema/v2/artist/__tests__/helpers.test.ts
@@ -98,7 +98,7 @@ describe("getArtistInsights", () => {
     ]
 
     fields.forEach((field) => {
-      it(`returns an empty array of entities but a count of 1 when the ${field.key} value is true`, () => {
+      it(`returns an empty array of entities when the ${field.key} value is true`, () => {
         field.value = true
         const artist = {
           [field.key]: field.value,
@@ -107,7 +107,7 @@ describe("getArtistInsights", () => {
         const insights = getArtistInsights(artist)
         const insight = insights.find((insight) => insight.kind === field.kind)!
 
-        expect(insight.count).toEqual(1)
+        expect(insight.count).toEqual(0)
         expect(insight.entities).toEqual([])
       })
 

--- a/src/schema/v2/artist/__tests__/helpers.test.ts
+++ b/src/schema/v2/artist/__tests__/helpers.test.ts
@@ -1,0 +1,133 @@
+import { ARTIST_INSIGHT_MAPPING, getArtistInsights } from "../helpers"
+
+describe("getArtistInsights", () => {
+  it("returns artist objects with no other information for each insight kind", () => {
+    const artist = {}
+    const insights = getArtistInsights(artist)
+    const mappingLength = Object.entries(ARTIST_INSIGHT_MAPPING).length
+    expect(insights.length).toEqual(mappingLength)
+    insights.forEach((insight) => {
+      expect(insight).toMatchObject({ artist })
+    })
+  })
+
+  it("returns a fallback shape when the value isn't a string or boolean", () => {
+    const artist = { solo_show_institutions: 7 }
+    const insights = getArtistInsights(artist)
+    const insight = insights[0]
+    expect(insight).toEqual({ artist, count: 0 })
+  })
+
+  describe("pipe delimited insight fields", () => {
+    const value =
+      "Art Institute of Chicago |Brooklyn Museum |       Hamburger Bahnhof"
+
+    const fields = [
+      {
+        key: "solo_show_institutions",
+        kind: "SOLO_SHOW",
+        value,
+      },
+      {
+        key: "group_show_institutions",
+        kind: "GROUP_SHOW",
+        value,
+      },
+      {
+        key: "review_sources",
+        kind: "REVIEWED",
+        value,
+      },
+      {
+        key: "biennials",
+        kind: "BIENNIAL",
+        value,
+      },
+    ]
+
+    fields.forEach((field) => {
+      it(`returns an array of ${field.key} entities split by pipe`, () => {
+        const artist = {
+          [field.key]: field.value,
+        }
+
+        const insights = getArtistInsights(artist)
+        const insight = insights.find((insight) => insight.kind === field.kind)!
+
+        expect(insight.count).toEqual(3)
+        expect(insight.entities).toEqual([
+          "Art Institute of Chicago",
+          "Brooklyn Museum",
+          "Hamburger Bahnhof",
+        ])
+      })
+    })
+  })
+
+  describe("newline delimited insight fields", () => {
+    const value =
+      "Art Institute of Chicago \nBrooklyn Museum \n       Hamburger Bahnhof"
+
+    const fields = [
+      {
+        key: "collections",
+        kind: "COLLECTED",
+        value,
+      },
+    ]
+
+    fields.forEach((field) => {
+      it(`returns an array of ${field.key} entities split by newline`, () => {
+        const artist = {
+          [field.key]: field.value,
+        }
+
+        const insights = getArtistInsights(artist)
+        const insight = insights.find((insight) => insight.kind === field.kind)!
+
+        expect(insight.count).toEqual(3)
+        expect(insight.entities).toEqual([
+          "Art Institute of Chicago",
+          "Brooklyn Museum",
+          "Hamburger Bahnhof",
+        ])
+      })
+    })
+  })
+
+  describe("boolean insight fields", () => {
+    const fields = [
+      {
+        key: "active_secondary_market",
+        kind: "ACTIVE_SECONDARY_MARKET",
+        value: true,
+      },
+    ]
+
+    fields.forEach((field) => {
+      it(`returns an empty array of entities but a count of 1 when the ${field.key} value is true`, () => {
+        field.value = true
+        const artist = {
+          [field.key]: field.value,
+        }
+
+        const insights = getArtistInsights(artist)
+        const insight = insights.find((insight) => insight.kind === field.kind)!
+
+        expect(insight.count).toEqual(1)
+        expect(insight.entities).toEqual([])
+      })
+
+      it(`returns an empty artist object when the ${field.key} value is false`, () => {
+        field.value = false
+        const artist = {
+          [field.key]: field.value,
+        }
+
+        const insights = getArtistInsights(artist)
+        const insight = insights.find((insight) => insight.kind === field.kind)
+        expect(insight).toBeUndefined()
+      })
+    })
+  })
+})

--- a/src/schema/v2/artist/helpers.ts
+++ b/src/schema/v2/artist/helpers.ts
@@ -51,47 +51,51 @@ export const ARTIST_INSIGHT_MAPPING = {
 } as const
 
 export const getArtistInsights = (artist) => {
-  const insights = (Object.entries(ARTIST_INSIGHT_MAPPING) as [
+  const mappings = Object.entries(ARTIST_INSIGHT_MAPPING) as [
     ArtistInsightKind,
     typeof ARTIST_INSIGHT_MAPPING[ArtistInsightKind]
-  ][]).map(([kind, { label, description, fieldName, delimiter }]) => {
-    const value = artist[fieldName]
+  ][]
 
-    if (!value) {
-      return { artist }
+  const insights = mappings.map(
+    ([kind, { label, description, fieldName, delimiter }]) => {
+      const value = artist[fieldName]
+
+      if (!value) {
+        return { artist }
+      }
+
+      switch (typeof value) {
+        case "string":
+          const trimmed = value.trim()
+
+          if (!trimmed) return null
+
+          const entities = trimmed
+            .split(delimiter ?? "|")
+            .map((entity) => entity.trim())
+          return {
+            entities,
+            count: entities.length,
+            label,
+            type: kind,
+            kind,
+            description,
+            artist,
+          }
+
+        case "boolean":
+          return {
+            entities: [],
+            label,
+            type: kind,
+            kind,
+            description,
+            count: value ? 1 : 0,
+            artist,
+          }
+      }
     }
-
-    switch (typeof value) {
-      case "string":
-        const trimmed = value.trim()
-
-        if (!trimmed) return null
-
-        const entities = trimmed
-          .split(delimiter ?? "|")
-          .map((entity) => entity.trim())
-        return {
-          entities,
-          count: entities.length,
-          label,
-          type: kind,
-          kind,
-          description,
-          artist,
-        }
-
-      case "boolean":
-        return {
-          entities: [],
-          label,
-          type: kind,
-          kind,
-          description,
-          count: value ? 1 : 0,
-          artist,
-        }
-    }
-  })
+  )
 
   return compact(insights)
 }

--- a/src/schema/v2/artist/helpers.ts
+++ b/src/schema/v2/artist/helpers.ts
@@ -1,0 +1,99 @@
+import { compact } from "lodash"
+
+export const ARTIST_INSIGHT_KINDS = {
+  SOLO_SHOW: { value: "SOLO_SHOW" },
+  GROUP_SHOW: { value: "GROUP_SHOW" },
+  COLLECTED: { value: "COLLECTED" },
+  REVIEWED: { value: "REVIEWED" },
+  BIENNIAL: { value: "BIENNIAL" },
+  ACTIVE_SECONDARY_MARKET: { value: "ACTIVE_SECONDARY_MARKET" },
+} as const
+
+type ArtistInsightKind = keyof typeof ARTIST_INSIGHT_KINDS
+
+export const ARTIST_INSIGHT_MAPPING = {
+  SOLO_SHOW: {
+    label: "Solo show at a major institution",
+    description: null,
+    fieldName: "solo_show_institutions",
+    delimiter: "|",
+  },
+  GROUP_SHOW: {
+    label: "Group show at a major institution",
+    description: null,
+    fieldName: "group_show_institutions",
+    delimiter: "|",
+  },
+  COLLECTED: {
+    label: "Collected by a major institution",
+    description: null,
+    fieldName: "collections",
+    delimiter: "\n",
+  },
+  REVIEWED: {
+    label: "Reviewed by a major art publication",
+    description: null,
+    fieldName: "review_sources",
+    delimiter: "|",
+  },
+  BIENNIAL: {
+    label: "Included in a major biennial",
+    description: null,
+    fieldName: "biennials",
+    delimiter: "|",
+  },
+  ACTIVE_SECONDARY_MARKET: {
+    label: "Active Secondary Market",
+    description: "Recent auction results in the Artsy Price Database",
+    fieldName: "active_secondary_market",
+    delimiter: null,
+  },
+} as const
+
+export const getArtistInsights = (artist) =>
+  compact(
+    (Object.entries(ARTIST_INSIGHT_MAPPING) as [
+      ArtistInsightKind,
+      typeof ARTIST_INSIGHT_MAPPING[ArtistInsightKind]
+    ][]).map(([kind, { label, description, fieldName, delimiter }]) => {
+      const value = artist[fieldName]
+
+      if (!value) {
+        return { artist }
+      }
+
+      switch (typeof value) {
+        case "string":
+          const trimmed = value.trim()
+
+          if (!trimmed) return null
+
+          const entities = trimmed
+            .split(delimiter ?? "|")
+            .map((entity) => entity.trim())
+          return {
+            entities,
+            count: entities.length,
+            label,
+            type: kind,
+            kind,
+            description,
+            artist,
+          }
+
+        case "boolean":
+          return {
+            entities: [],
+            label,
+            type: kind,
+            kind,
+            description,
+            count: value ? 1 : 0,
+            artist,
+          }
+
+        default:
+          return { count: 0, artist }
+      }
+    })
+  )

--- a/src/schema/v2/artist/helpers.ts
+++ b/src/schema/v2/artist/helpers.ts
@@ -94,7 +94,7 @@ export const getArtistInsights = (artist) => {
           type: kind,
           kind,
           description,
-          count: value ? 1 : 0,
+          count: 0,
           artist,
         }
     }

--- a/src/schema/v2/artist/helpers.ts
+++ b/src/schema/v2/artist/helpers.ts
@@ -13,45 +13,39 @@ type ArtistInsightKind = keyof typeof ARTIST_INSIGHT_KINDS
 
 export const ARTIST_INSIGHT_MAPPING = {
   SOLO_SHOW: {
-    label: "Solo show at a major institution",
     description: null,
-    fieldName: "solo_show_institutions",
-    delimiter: "|",
+    getEntities: (artist) => splitEntities(artist.solo_show_institutions),
+    label: "Solo show at a major institution",
   },
   GROUP_SHOW: {
-    label: "Group show at a major institution",
     description: null,
-    fieldName: "group_show_institutions",
-    delimiter: "|",
+    getEntities: (artist) => splitEntities(artist.group_show_institutions),
+    label: "Group show at a major institution",
   },
   COLLECTED: {
-    label: "Collected by a major institution",
     description: null,
-    fieldName: "collections",
-    delimiter: "\n",
+    getEntities: (artist) => splitEntities(artist.collections, "\n"),
+    label: "Collected by a major institution",
   },
   REVIEWED: {
-    label: "Reviewed by a major art publication",
     description: null,
-    fieldName: "review_sources",
-    delimiter: "|",
+    getEntities: (artist) => splitEntities(artist.review_sources),
+    label: "Reviewed by a major art publication",
   },
   BIENNIAL: {
-    label: "Included in a major biennial",
     description: null,
-    fieldName: "biennials",
-    delimiter: "|",
+    getEntities: (artist) => splitEntities(artist.biennials),
+    label: "Included in a major biennial",
   },
   ACTIVE_SECONDARY_MARKET: {
-    label: "Active Secondary Market",
     description: "Recent auction results in the Artsy Price Database",
-    fieldName: "active_secondary_market",
-    delimiter: null,
+    getEntities: (artist) => artist.active_secondary_market && [],
+    label: "Active Secondary Market",
   },
 } as const
 
-const getEntities = (value, delimiter) => {
-  if (typeof value !== "string") return []
+const splitEntities = (value, delimiter = "|") => {
+  if (!value) return null
 
   const entities = value
     .trim()
@@ -68,14 +62,10 @@ export const getArtistInsights = (artist) => {
   ][]
 
   const insights = mappings.map((mapping) => {
-    const [kind, { label, description, fieldName, delimiter }] = mapping
-    const value = artist[fieldName]
+    const [kind, { description, getEntities, label }] = mapping
 
-    if (!value) {
-      return { artist }
-    }
-
-    const entities = getEntities(value, delimiter ?? "|")
+    const entities = getEntities(artist)
+    if (!entities) return { artist }
 
     return {
       artist,

--- a/src/schema/v2/artist/helpers.ts
+++ b/src/schema/v2/artist/helpers.ts
@@ -13,32 +13,32 @@ type ArtistInsightKind = keyof typeof ARTIST_INSIGHT_KINDS
 
 export const ARTIST_INSIGHT_MAPPING = {
   SOLO_SHOW: {
-    description: null,
+    getDescription: () => null,
     getEntities: (artist) => splitEntities(artist.solo_show_institutions),
     label: "Solo show at a major institution",
   },
   GROUP_SHOW: {
-    description: null,
+    getDescription: () => null,
     getEntities: (artist) => splitEntities(artist.group_show_institutions),
     label: "Group show at a major institution",
   },
   COLLECTED: {
-    description: null,
+    getDescription: () => null,
     getEntities: (artist) => splitEntities(artist.collections, "\n"),
     label: "Collected by a major institution",
   },
   REVIEWED: {
-    description: null,
+    getDescription: () => null,
     getEntities: (artist) => splitEntities(artist.review_sources),
     label: "Reviewed by a major art publication",
   },
   BIENNIAL: {
-    description: null,
+    getDescription: () => null,
     getEntities: (artist) => splitEntities(artist.biennials),
     label: "Included in a major biennial",
   },
   ACTIVE_SECONDARY_MARKET: {
-    description: "Recent auction results in the Artsy Price Database",
+    getDescription: () => "Recent auction results in the Artsy Price Database",
     getEntities: (artist) => artist.active_secondary_market && [],
     label: "Active Secondary Market",
   },
@@ -62,10 +62,12 @@ export const getArtistInsights = (artist) => {
   ][]
 
   const insights = mappings.map((mapping) => {
-    const [kind, { description, getEntities, label }] = mapping
+    const [kind, { getDescription, getEntities, label }] = mapping
 
     const entities = getEntities(artist)
     if (!entities) return { artist }
+
+    const description = getDescription()
 
     return {
       artist,

--- a/src/schema/v2/artist/helpers.ts
+++ b/src/schema/v2/artist/helpers.ts
@@ -50,6 +50,15 @@ export const ARTIST_INSIGHT_MAPPING = {
   },
 } as const
 
+const getEntities = (value, delimiter) => {
+  const entities = value
+    .trim()
+    .split(delimiter)
+    .map((entity) => entity.trim())
+
+  return entities
+}
+
 export const getArtistInsights = (artist) => {
   const mappings = Object.entries(ARTIST_INSIGHT_MAPPING) as [
     ArtistInsightKind,
@@ -66,13 +75,8 @@ export const getArtistInsights = (artist) => {
 
     switch (typeof value) {
       case "string":
-        const trimmed = value.trim()
+        const entities = getEntities(value, delimiter ?? "|")
 
-        if (!trimmed) return null
-
-        const entities = trimmed
-          .split(delimiter ?? "|")
-          .map((entity) => entity.trim())
         return {
           entities,
           count: entities.length,

--- a/src/schema/v2/artist/helpers.ts
+++ b/src/schema/v2/artist/helpers.ts
@@ -50,47 +50,48 @@ export const ARTIST_INSIGHT_MAPPING = {
   },
 } as const
 
-export const getArtistInsights = (artist) =>
-  compact(
-    (Object.entries(ARTIST_INSIGHT_MAPPING) as [
-      ArtistInsightKind,
-      typeof ARTIST_INSIGHT_MAPPING[ArtistInsightKind]
-    ][]).map(([kind, { label, description, fieldName, delimiter }]) => {
-      const value = artist[fieldName]
+export const getArtistInsights = (artist) => {
+  const insights = (Object.entries(ARTIST_INSIGHT_MAPPING) as [
+    ArtistInsightKind,
+    typeof ARTIST_INSIGHT_MAPPING[ArtistInsightKind]
+  ][]).map(([kind, { label, description, fieldName, delimiter }]) => {
+    const value = artist[fieldName]
 
-      if (!value) {
-        return { artist }
-      }
+    if (!value) {
+      return { artist }
+    }
 
-      switch (typeof value) {
-        case "string":
-          const trimmed = value.trim()
+    switch (typeof value) {
+      case "string":
+        const trimmed = value.trim()
 
-          if (!trimmed) return null
+        if (!trimmed) return null
 
-          const entities = trimmed
-            .split(delimiter ?? "|")
-            .map((entity) => entity.trim())
-          return {
-            entities,
-            count: entities.length,
-            label,
-            type: kind,
-            kind,
-            description,
-            artist,
-          }
+        const entities = trimmed
+          .split(delimiter ?? "|")
+          .map((entity) => entity.trim())
+        return {
+          entities,
+          count: entities.length,
+          label,
+          type: kind,
+          kind,
+          description,
+          artist,
+        }
 
-        case "boolean":
-          return {
-            entities: [],
-            label,
-            type: kind,
-            kind,
-            description,
-            count: value ? 1 : 0,
-            artist,
-          }
-      }
-    })
-  )
+      case "boolean":
+        return {
+          entities: [],
+          label,
+          type: kind,
+          kind,
+          description,
+          count: value ? 1 : 0,
+          artist,
+        }
+    }
+  })
+
+  return compact(insights)
+}

--- a/src/schema/v2/artist/helpers.ts
+++ b/src/schema/v2/artist/helpers.ts
@@ -51,6 +51,8 @@ export const ARTIST_INSIGHT_MAPPING = {
 } as const
 
 const getEntities = (value, delimiter) => {
+  if (typeof value !== "string") return []
+
   const entities = value
     .trim()
     .split(delimiter)
@@ -73,30 +75,16 @@ export const getArtistInsights = (artist) => {
       return { artist }
     }
 
-    switch (typeof value) {
-      case "string":
-        const entities = getEntities(value, delimiter ?? "|")
+    const entities = getEntities(value, delimiter ?? "|")
 
-        return {
-          entities,
-          count: entities.length,
-          label,
-          type: kind,
-          kind,
-          description,
-          artist,
-        }
-
-      case "boolean":
-        return {
-          entities: [],
-          label,
-          type: kind,
-          kind,
-          description,
-          count: 0,
-          artist,
-        }
+    return {
+      artist,
+      count: entities.length,
+      description,
+      entities,
+      kind,
+      label,
+      type: kind,
     }
   })
 

--- a/src/schema/v2/artist/helpers.ts
+++ b/src/schema/v2/artist/helpers.ts
@@ -91,9 +91,6 @@ export const getArtistInsights = (artist) =>
             count: value ? 1 : 0,
             artist,
           }
-
-        default:
-          return { count: 0, artist }
       }
     })
   )

--- a/src/schema/v2/artist/helpers.ts
+++ b/src/schema/v2/artist/helpers.ts
@@ -56,46 +56,45 @@ export const getArtistInsights = (artist) => {
     typeof ARTIST_INSIGHT_MAPPING[ArtistInsightKind]
   ][]
 
-  const insights = mappings.map(
-    ([kind, { label, description, fieldName, delimiter }]) => {
-      const value = artist[fieldName]
+  const insights = mappings.map((mapping) => {
+    const [kind, { label, description, fieldName, delimiter }] = mapping
+    const value = artist[fieldName]
 
-      if (!value) {
-        return { artist }
-      }
-
-      switch (typeof value) {
-        case "string":
-          const trimmed = value.trim()
-
-          if (!trimmed) return null
-
-          const entities = trimmed
-            .split(delimiter ?? "|")
-            .map((entity) => entity.trim())
-          return {
-            entities,
-            count: entities.length,
-            label,
-            type: kind,
-            kind,
-            description,
-            artist,
-          }
-
-        case "boolean":
-          return {
-            entities: [],
-            label,
-            type: kind,
-            kind,
-            description,
-            count: value ? 1 : 0,
-            artist,
-          }
-      }
+    if (!value) {
+      return { artist }
     }
-  )
+
+    switch (typeof value) {
+      case "string":
+        const trimmed = value.trim()
+
+        if (!trimmed) return null
+
+        const entities = trimmed
+          .split(delimiter ?? "|")
+          .map((entity) => entity.trim())
+        return {
+          entities,
+          count: entities.length,
+          label,
+          type: kind,
+          kind,
+          description,
+          artist,
+        }
+
+      case "boolean":
+        return {
+          entities: [],
+          label,
+          type: kind,
+          kind,
+          description,
+          count: value ? 1 : 0,
+          artist,
+        }
+    }
+  })
 
   return compact(insights)
 }

--- a/src/schema/v2/artist/insights.ts
+++ b/src/schema/v2/artist/insights.ts
@@ -9,7 +9,11 @@ import {
 } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { ArtistType } from "../artist"
-import { getArtistInsights, ARTIST_INSIGHT_KINDS } from "./helpers"
+import {
+  ARTIST_INSIGHT_KINDS,
+  getArtistInsights,
+  getAuctionRecord,
+} from "./helpers"
 
 export const ArtistInsightKind = new GraphQLEnumType({
   name: "ArtistInsightKind",
@@ -61,7 +65,15 @@ export const ArtistInsights: GraphQLFieldConfig<any, ResolverContext> = {
       defaultValue: Object.keys(ARTIST_INSIGHT_KINDS),
     },
   },
-  resolve: (artist, { kind }) => {
+  resolve: async (artist, { kind }, { auctionLotsLoader }) => {
+    if (kind.includes("HIGH_AUCTION_RECORD")) {
+      const highAuctionRecord = await getAuctionRecord(
+        artist,
+        auctionLotsLoader
+      )
+      artist.highAuctionRecord = highAuctionRecord
+    }
+
     const insights = getArtistInsights(artist)
 
     return insights.filter((insight) => kind.includes(insight.type))

--- a/src/schema/v2/artist/insights.ts
+++ b/src/schema/v2/artist/insights.ts
@@ -7,59 +7,9 @@ import {
   GraphQLObjectType,
   GraphQLString,
 } from "graphql"
-import { compact } from "lodash"
 import { ResolverContext } from "types/graphql"
 import { ArtistType } from "../artist"
-
-const ARTIST_INSIGHT_KINDS = {
-  SOLO_SHOW: { value: "SOLO_SHOW" },
-  GROUP_SHOW: { value: "GROUP_SHOW" },
-  COLLECTED: { value: "COLLECTED" },
-  REVIEWED: { value: "REVIEWED" },
-  BIENNIAL: { value: "BIENNIAL" },
-  ACTIVE_SECONDARY_MARKET: { value: "ACTIVE_SECONDARY_MARKET" },
-} as const
-
-type ArtistInsightKind = keyof typeof ARTIST_INSIGHT_KINDS
-
-const ARTIST_INSIGHT_MAPPING = {
-  SOLO_SHOW: {
-    label: "Solo show at a major institution",
-    description: null,
-    fieldName: "solo_show_institutions",
-    delimiter: "|",
-  },
-  GROUP_SHOW: {
-    label: "Group show at a major institution",
-    description: null,
-    fieldName: "group_show_institutions",
-    delimiter: "|",
-  },
-  COLLECTED: {
-    label: "Collected by a major institution",
-    description: null,
-    fieldName: "collections",
-    delimiter: "\n",
-  },
-  REVIEWED: {
-    label: "Reviewed by a major art publication",
-    description: null,
-    fieldName: "review_sources",
-    delimiter: "|",
-  },
-  BIENNIAL: {
-    label: "Included in a major biennial",
-    description: null,
-    fieldName: "biennials",
-    delimiter: "|",
-  },
-  ACTIVE_SECONDARY_MARKET: {
-    label: "Active Secondary Market",
-    description: "Recent auction results in the Artsy Price Database",
-    fieldName: "active_secondary_market",
-    delimiter: null,
-  },
-} as const
+import { getArtistInsights, ARTIST_INSIGHT_KINDS } from "./helpers"
 
 export const ArtistInsightKind = new GraphQLEnumType({
   name: "ArtistInsightKind",
@@ -117,51 +67,3 @@ export const ArtistInsights: GraphQLFieldConfig<any, ResolverContext> = {
     return insights.filter((insight) => kind.includes(insight.type))
   },
 }
-
-export const getArtistInsights = (artist) =>
-  compact(
-    (Object.entries(ARTIST_INSIGHT_MAPPING) as [
-      ArtistInsightKind,
-      typeof ARTIST_INSIGHT_MAPPING[ArtistInsightKind]
-    ][]).map(([kind, { label, description, fieldName, delimiter }]) => {
-      const value = artist[fieldName]
-
-      if (!value) {
-        return { artist }
-      }
-
-      switch (typeof value) {
-        case "string":
-          const trimmed = value.trim()
-
-          if (!trimmed) return null
-
-          const entities = trimmed
-            .split(delimiter ?? "|")
-            .map((entity) => entity.trim())
-          return {
-            entities,
-            count: entities.length,
-            label,
-            type: kind,
-            kind,
-            description,
-            artist,
-          }
-
-        case "boolean":
-          return {
-            entities: [],
-            label,
-            type: kind,
-            kind,
-            description,
-            count: value ? 1 : 0,
-            artist,
-          }
-
-        default:
-          return { count: 0, artist }
-      }
-    })
-  )

--- a/src/schema/v2/me/myCollectionInfo.ts
+++ b/src/schema/v2/me/myCollectionInfo.ts
@@ -11,11 +11,8 @@ import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { pageable } from "relay-cursor-paging"
 import { artistConnection } from "schema/v2/artist"
 import { ResolverContext } from "types/graphql"
-import {
-  ArtistInsight,
-  ArtistInsightKind,
-  getArtistInsights,
-} from "../artist/insights"
+import { ArtistInsight, ArtistInsightKind } from "../artist/insights"
+import { getArtistInsights } from "../artist/helpers"
 import { paginationResolver } from "../fields/pagination"
 import ArtistSorts from "../sorts/artist_sorts"
 


### PR DESCRIPTION
This PR moves calculating an artist's high auction record up into MP from Force. Right now this is done like here:

https://github.com/artsy/force/blob/9fb0f70c7abda2db06a79d80d4a77dea68c53334/src/Apps/Artist/Components/ArtistInsights/ArtistInsightBadges.tsx#L75

I think this is better because it pulls logic out of the client which is always a win but it also makes the mental model easier: if you want insights they are on the `artist.insights` field full stop. No more having to think about where they are.

And so then this sets me up to add both critically acclaimed and Artsy vanguard as the next two artist insights. I'll follow up with that work as I get things in place.

https://artsyproduct.atlassian.net/browse/GRO-841

/cc @artsy/grow-devs