### PR TITLE
chore:add visibility level to artwork

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2172,7 +2172,7 @@ type Artwork implements Node & Searchable & Sellable {
   vatRequirementComplete: Boolean
 
   # The visibility level of the artwork
-  visibilityLevel: String
+  visibilityLevel: Visibility
 
   # If the category is video, then it returns the href for the (youtube/vimeo) video, otherwise returns the website from CMS
   website: String
@@ -17563,6 +17563,12 @@ input ViewingRoomSubsectionInput {
   delete: Boolean = false
   image: ARImageInput
   internalID: ID
+}
+
+enum Visibility {
+  DRAFT
+  LISTED
+  UNLISTED
 }
 
 type WireTransfer {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2171,6 +2171,9 @@ type Artwork implements Node & Searchable & Sellable {
   # Based on artwork location verify that VAT info for the partner is complete.
   vatRequirementComplete: Boolean
 
+  # The visibility level of the artwork
+  visibilityLevel: String
+
   # If the category is video, then it returns the href for the (youtube/vimeo) video, otherwise returns the website from CMS
   website: String
 

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -445,6 +445,53 @@ describe("Artwork type", () => {
     })
   })
 
+  describe("visibility_level", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          visibilityLevel
+        }
+      }
+    `
+
+    it("returns valid visibility level", async () => {
+      artwork = {
+        ...artwork,
+        visibility_level: "draft",
+      }
+
+      context = {
+        artworkLoader: () => Promise.resolve(artwork),
+      }
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          visibilityLevel: "DRAFT",
+        },
+      })
+    })
+
+    it("returns null if visibility level is empty", async () => {
+      artwork = {
+        ...artwork,
+      }
+
+      context = {
+        artworkLoader: () => Promise.resolve(artwork),
+      }
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          visibilityLevel: null,
+        },
+      })
+    })
+  })
+
   describe("#pricePaid", () => {
     const query = `
     {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1446,6 +1446,11 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           }
         },
       },
+      visibilityLevel: {
+        description: "The visibility level of the artwork",
+        type: GraphQLString,
+        resolve: ({ visibility_level }) => visibility_level,
+      },
       width: {
         description: "The width as expressed by the original input metric",
         type: GraphQLString,

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -217,6 +217,15 @@ const ArtworkPriceInsightsType = new GraphQLObjectType<any, ResolverContext>({
   },
 })
 
+export const VisibilityEnum = new GraphQLEnumType({
+  name: "Visibility",
+  values: {
+    DRAFT: { value: "draft" },
+    UNLISTED: { value: "unlisted" },
+    LISTED: { value: "listed" },
+  },
+})
+
 export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
   name: "Artwork",
   interfaces: [NodeInterface, Searchable, Sellable],
@@ -1448,7 +1457,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       },
       visibilityLevel: {
         description: "The visibility level of the artwork",
-        type: GraphQLString,
+        type: VisibilityEnum,
         resolve: ({ visibility_level }) => visibility_level,
       },
       width: {


### PR DESCRIPTION
This PR adds visibility level to artwork per [PX-5249]. It also has a related [gravity ticket ](https://github.com/artsy/gravity/pull/15693)that needs to be merged first.

[PX-5249]: https://artsyproduct.atlassian.net/browse/PX-5249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ