### PR TITLE
feat: use responseOrError pattern for createUserAdminNoteMutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7049,6 +7049,10 @@ type CreateUserAddressPayload {
   userAddressOrErrors: UserAddressOrErrorsUnion!
 }
 
+type createUserAdminNoteFailure {
+  mutationError: GravityMutationError
+}
+
 input createUserAdminNoteMutationInput {
   body: String!
   clientMutationId: String
@@ -7056,10 +7060,17 @@ input createUserAdminNoteMutationInput {
 }
 
 type createUserAdminNoteMutationPayload {
+  # On success: the admin note created.
+  adminNoteOrError: createUserAdminNoteResponseOrError
   clientMutationId: String
+}
 
-  # On success: an identity verification with overrides
-  userAdminNote: UserAdminNotes!
+union createUserAdminNoteResponseOrError =
+    createUserAdminNoteFailure
+  | createUserAdminNoteSuccess
+
+type createUserAdminNoteSuccess {
+  adminNote: UserAdminNotes
 }
 
 input CreateUserInterestMutationInput {

--- a/src/schema/v2/__tests__/createUserAdminNoteMutation.test.ts
+++ b/src/schema/v2/__tests__/createUserAdminNoteMutation.test.ts
@@ -1,0 +1,81 @@
+/* eslint-disable promise/always-return */
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+const mutation = gql`
+  mutation {
+    createUserAdminNote(
+      input: { id: "xyz321", body: "Still a great collector" }
+    ) {
+      adminNoteOrError {
+        __typename
+        ... on createUserAdminNoteSuccess {
+          adminNote {
+            body
+            createdAt
+          }
+        }
+        ... on createUserAdminNoteFailure {
+          mutationError {
+            message
+          }
+        }
+      }
+    }
+  }
+`
+
+describe("Create a admin note for a user", () => {
+  describe("when succesfull", () => {
+    const adminNote = {
+      id: "xyz321",
+      body: "Still a great collector",
+      created_at: "2022-09-30T12:00:00+00:00",
+    }
+
+    const context = {
+      createUserAdminNoteLoader: () => Promise.resolve(adminNote),
+    }
+
+    it("creates an account request", async () => {
+      const data = await runAuthenticatedQuery(mutation, context)
+      expect(data).toEqual({
+        createUserAdminNote: {
+          adminNoteOrError: {
+            __typename: "createUserAdminNoteSuccess",
+            adminNote: {
+              body: "Still a great collector",
+              createdAt: "2022-09-30T12:00:00+00:00",
+            },
+          },
+        },
+      })
+    })
+  })
+
+  describe("when failure", () => {
+    it("return an error", async () => {
+      const context = {
+        createUserAdminNoteLoader: () =>
+          Promise.reject(
+            new Error(
+              `https://stagingapi.artsy.net/api/v1/user/abc123/admin_notes - {"type":"error","message":"User not found"}`
+            )
+          ),
+      }
+
+      const response = await runAuthenticatedQuery(mutation, context)
+
+      expect(response).toEqual({
+        createUserAdminNote: {
+          adminNoteOrError: {
+            __typename: "createUserAdminNoteFailure",
+            mutationError: {
+              message: "User not found",
+            },
+          },
+        },
+      })
+    })
+  })
+})

--- a/src/schema/v2/__tests__/user.test.ts
+++ b/src/schema/v2/__tests__/user.test.ts
@@ -722,4 +722,54 @@ describe("User", () => {
       })
     })
   })
+  describe("adminNotes", () => {
+    it("returns the admin notes associated with a user in descending order", async () => {
+      const query = `
+        {
+          user(id: "abc123") {
+            adminNotes {
+              body
+              createdAt
+            }
+          }
+        }
+      `
+
+      const user = {
+        id: "abc123",
+      }
+
+      const userAdminNotes = [
+        {
+          body: "A Good collector",
+          created_at: "2022-04-24T09:00:00+00:00",
+        },
+        {
+          body: "Now a great collector",
+          created_at: "2022-06-15T10:00:00+00:00",
+        },
+        {
+          body: "The best collector",
+          created_at: "2022-09-30T12:00:00+00:00",
+        },
+      ]
+
+      const context = {
+        userByIDLoader: () => {
+          return Promise.resolve(user)
+        },
+        userAdminNotesLoader: () => {
+          return Promise.resolve(userAdminNotes)
+        },
+      }
+
+      const {
+        user: { adminNotes },
+      } = await runAuthenticatedQuery(query, context)
+
+      expect(adminNotes[0].body).toEqual("The best collector")
+      expect(adminNotes[1].body).toEqual("Now a great collector")
+      expect(adminNotes[2].body).toEqual("A Good collector")
+    })
+  })
 })

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -52,7 +52,15 @@ export const UserAdminNotesField: GraphQLFieldConfig<any, ResolverContext> = {
       )
     }
 
-    return await userAdminNotesLoader(id)
+    const adminNotes = await userAdminNotesLoader(id)
+
+    const sortedAdminNotes = adminNotes.sort((objA, objB) => {
+      const dateA = new Date(objA.created_at).getTime()
+      const dateB = new Date(objB.created_at).getTime()
+      return dateB - dateA
+    })
+
+    return sortedAdminNotes
   },
 }
 


### PR DESCRIPTION
This PR does two things in support of [PLATFORM-4594]. 

1. It updates `createUserAdminNoteMutation` to use our `responseOrError` pattern.
2. It [sorts](https://github.com/artsy/metaphysics/compare/mc-jones/admin-note?expand=1#diff-53a08671c7ab0c03c56b68075478ab8b4b79e04a1c3f946e29aed49569a66abcR57) the admin notes in descending order.

TO-DO:

- [x] Add specs



[PLATFORM-4594]: https://artsyproduct.atlassian.net/browse/PLATFORM-4594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ