### PR TITLE
feat(artwork): Update figure with new video

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2194,6 +2194,9 @@ type Artwork implements Node & Searchable & Sellable {
   saleMessage: String
   series(format: Format): String
 
+  # Should the video be used as the cover image
+  setVideoAsCover: Boolean
+
   # The country an artwork will be shipped from.
   shippingCountry: String
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2131,6 +2131,9 @@ type Artwork implements Node & Searchable & Sellable {
   isPriceHidden: Boolean
   isPriceRange: Boolean
   isSaved: Boolean
+
+  # Should the video be used as the cover image
+  isSetVideoAsCover: Boolean
   isShareable: Boolean
   isSold: Boolean
   isUnique: Boolean
@@ -2193,9 +2196,6 @@ type Artwork implements Node & Searchable & Sellable {
   saleArtwork(saleID: String = null): SaleArtwork
   saleMessage: String
   series(format: Format): String
-
-  # Should the video be used as the cover image
-  setVideoAsCover: Boolean
 
   # The country an artwork will be shipped from.
   shippingCountry: String

--- a/src/schema/v2/artwork/__tests__/utilities.test.ts
+++ b/src/schema/v2/artwork/__tests__/utilities.test.ts
@@ -1,5 +1,5 @@
 import { Artwork } from "types/runtime/gravity"
-import { isTooBig, isTwoDimensional } from "../utilities"
+import { getFigures, isTooBig, isTwoDimensional } from "../utilities"
 
 describe("isTwoDimensional", () => {
   let artwork: Artwork
@@ -153,5 +153,79 @@ describe("isTooBig", () => {
 
       expect(isTooBig(artwork)).toBe(false)
     })
+  })
+})
+
+describe("getFigures", () => {
+  it("returns an array of images", () => {
+    const data = getFigures({
+      images: [
+        {
+          image_url: "foo",
+        },
+        {
+          image_url: "bar",
+        },
+      ],
+      external_video_id: null,
+      set_video_as_cover: null,
+    })
+
+    expect(data).toEqual([
+      { image_url: "foo", type: "Image" },
+      { image_url: "bar", type: "Image" },
+    ])
+  })
+
+  it("returns images with video appended at end by default", () => {
+    const data = getFigures({
+      images: [
+        {
+          image_url: "foo",
+        },
+        {
+          image_url: "bar",
+        },
+      ],
+      external_video_id: "video-id",
+      set_video_as_cover: null,
+    })
+
+    expect(data).toEqual([
+      { image_url: "foo", type: "Image" },
+      { image_url: "bar", type: "Image" },
+      {
+        type: "Video",
+        url: "video-id",
+        width: 360,
+        height: 360,
+      },
+    ])
+  })
+
+  it("returns a video at the front with images at the end if set_video_as_cover=true", () => {
+    const data = getFigures({
+      images: [
+        {
+          image_url: "foo",
+        },
+        {
+          image_url: "bar",
+        },
+      ],
+      external_video_id: "video-id",
+      set_video_as_cover: true,
+    })
+
+    expect(data).toEqual([
+      {
+        type: "Video",
+        url: "video-id",
+        width: 360,
+        height: 360,
+      },
+      { image_url: "foo", type: "Image" },
+      { image_url: "bar", type: "Image" },
+    ])
   })
 })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -74,7 +74,13 @@ import { ArtworkHighlightType } from "./highlight"
 import ArtworkLayer from "./layer"
 import ArtworkLayers, { artworkLayers } from "./layers"
 import Meta, { artistNames } from "./meta"
-import { embed, isEmbeddedVideo, isTooBig, isTwoDimensional } from "./utilities"
+import {
+  embed,
+  getFigures,
+  isEmbeddedVideo,
+  isTooBig,
+  isTwoDimensional,
+} from "./utilities"
 
 const has_price_range = (price) => {
   return new RegExp(/-/).test(price)
@@ -1327,7 +1333,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       series: markdown(),
-      setVideoAsCover: {
+      isSetVideoAsCover: {
         type: GraphQLBoolean,
         description: "Should the video be used as the cover image",
         resolve: ({ set_video_as_cover }) => set_video_as_cover,
@@ -1544,32 +1550,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             )
           )
         ),
-        resolve: ({ images, external_video_id, set_video_as_cover }) => {
-          const typedImages = images.map((image) => ({
-            ...image,
-            type: "Image",
-          }))
-          const sortedTypedImages = normalizeImageData(
-            _.sortBy(typedImages, "position")
-          )
-
-          const typedVideos = external_video_id
-            ? [
-                {
-                  type: "Video",
-                  url: external_video_id,
-                  width: 360,
-                  height: 360,
-                },
-              ]
-            : []
-
-          if (set_video_as_cover) {
-            return [...typedVideos, ...sortedTypedImages]
-          } else {
-            return [...sortedTypedImages, ...typedVideos]
-          }
-        },
+        resolve: getFigures,
       },
     }
   },

--- a/src/schema/v2/artwork/utilities.ts
+++ b/src/schema/v2/artwork/utilities.ts
@@ -1,5 +1,7 @@
 import { Artwork } from "types/runtime/gravity"
 import { parse } from "url"
+import { normalizeImageData } from "../image"
+import _ from "lodash"
 
 export const isTwoDimensional = ({
   width_cm,
@@ -68,5 +70,34 @@ export const embed = (website, { width, height, autoplay }) => {
 
     default:
       return null
+  }
+}
+
+export const getFigures = ({
+  images,
+  external_video_id,
+  set_video_as_cover,
+}) => {
+  const _images = images.map((image) => ({
+    ...image,
+    type: "Image",
+  }))
+  const sortedImages = normalizeImageData(_.sortBy(_images, "position"))
+
+  const videos = external_video_id
+    ? [
+        {
+          type: "Video",
+          url: external_video_id,
+          width: 360,
+          height: 360,
+        },
+      ]
+    : []
+
+  if (set_video_as_cover) {
+    return [...videos, ...sortedImages]
+  } else {
+    return [...sortedImages, ...videos]
   }
 }


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GRO-1306

This updates video support in the artwork type in support of the `setVideoAsCover` prop, which will push the video to the front. 

cc @artsy/grow-devs 