### PR TITLE
feat: allow `term` argument to `usersConnection` root field, used to match users

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13707,6 +13707,9 @@ type Query {
     first: Int
     ids: [String]
     last: Int
+
+    # If present, will search by term, cannot be combined with `ids`
+    term: String
   ): UserConnection
 
   # A Partner or Fair
@@ -17367,6 +17370,9 @@ type Viewer {
     first: Int
     ids: [String]
     last: Int
+
+    # If present, will search by term, cannot be combined with `ids`
+    term: String
   ): UserConnection
 
   # A Partner or Fair

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -230,6 +230,7 @@ export default (accessToken, userID, opts) => {
       { method: "POST" }
     ),
     lotStandingLoader: gravityLoader("me/lot_standings", { size: 100 }),
+    matchUsersLoader: gravityLoader("match/users", {}, { headers: true }),
     meBankAccountsLoader: gravityLoader(
       "me/bank_accounts",
       {},

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -96,7 +96,7 @@ export default (opts) => {
     incrementsLoader: gravityLoader("increments"),
     inquiryRequestQuestionsLoader: gravityLoader(`inquiry_request_questions`),
     matchArtistsLoader: gravityLoader("match/artists"),
-    matchGeneLoader: gravityLoader("match/genes"),
+    matchGenesLoader: gravityLoader("match/genes"),
     anonNotificationPreferencesLoader: gravityLoader(
       (authenticationToken) =>
         `notification_preferences/?authentication_token=${authenticationToken}`

--- a/src/schema/v2/__tests__/users.test.ts
+++ b/src/schema/v2/__tests__/users.test.ts
@@ -1,0 +1,74 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("usersConnection", () => {
+  it("uses the match loader when searching by term", async () => {
+    const matchUsersLoader = jest.fn().mockReturnValue(
+      Promise.resolve({
+        body: [{ name: "Percy Z" }],
+        headers: { "x-total-count": "1" },
+      })
+    )
+
+    const query = gql`
+      {
+        usersConnection(term: "Percy Artsy Employee", first: 5) {
+          totalCount
+          edges {
+            node {
+              name
+            }
+          }
+        }
+      }
+    `
+    const { usersConnection } = await runAuthenticatedQuery(query, {
+      matchUsersLoader,
+    })
+
+    expect(matchUsersLoader).toBeCalledWith({
+      term: "Percy Artsy Employee",
+      page: 1,
+      size: 5,
+      total_count: true,
+    })
+
+    expect(usersConnection.totalCount).toBe(1)
+    expect(usersConnection.edges[0].node.name).toEqual("Percy Z")
+  })
+
+  it("uses the users loader when not searching by term", async () => {
+    const usersLoader = jest.fn().mockReturnValue(
+      Promise.resolve({
+        body: [{ name: "Percy Z" }],
+        headers: { "x-total-count": "1" },
+      })
+    )
+
+    const query = gql`
+      {
+        usersConnection(ids: ["percy-z"], first: 5) {
+          totalCount
+          edges {
+            node {
+              name
+            }
+          }
+        }
+      }
+    `
+    const { usersConnection } = await runAuthenticatedQuery(query, {
+      usersLoader,
+    })
+
+    expect(usersLoader).toBeCalledWith({
+      id: ["percy-z"],
+      page: 1,
+      size: 5,
+      total_count: true,
+    })
+
+    expect(usersConnection.totalCount).toBe(1)
+    expect(usersConnection.edges[0].node.name).toEqual("Percy Z")
+  })
+})

--- a/src/schema/v2/match/__tests__/gene.test.js
+++ b/src/schema/v2/match/__tests__/gene.test.js
@@ -36,9 +36,9 @@ describe.skip("MatchGene", () => {
       },
     ]
 
-    const matchGeneLoader = () => Promise.resolve(response)
+    const matchGenesLoader = () => Promise.resolve(response)
 
-    return runQuery(query, { matchGeneLoader }).then((data) => {
+    return runQuery(query, { matchGenesLoader }).then((data) => {
       expect(data).toEqual({
         matchGene: [{ slug: "pop-art", name: "Pop Art", internalID: "123456" }],
       })

--- a/src/schema/v2/match/gene.ts
+++ b/src/schema/v2/match/gene.ts
@@ -29,12 +29,12 @@ const GeneMatch: GraphQLFieldConfig<void, ResolverContext> = {
       description: "Exclude these MongoDB ids from results",
     },
   },
-  resolve: (_root, { excludeIDs, ..._options }, { matchGeneLoader }) => {
+  resolve: (_root, { excludeIDs, ..._options }, { matchGenesLoader }) => {
     const options: any = {
       exclude_ids: excludeIDs,
       ..._options,
     }
-    return matchGeneLoader(options)
+    return matchGenesLoader(options)
   },
 }
 


### PR DESCRIPTION
Depends on https://github.com/artsy/gravity/pull/15704 , which properly exposes the total count for a match query on users, so that we can have a properly paginated list of search results in Forque.

Since there's already a `usersConnection` root field, rather than add a separate field (`matchUsersConnection`?), which would likely be of the same type as `usersConnection` (namely, a connection where the `node` is a `User`), figured can add a `term` argument to the existing field, and then branch in the resolver based on that argument (perform a match API request, vs. the regular one).

Looks like:
![Screen Shot 2022-10-03 at 3 38 42 PM](https://user-images.githubusercontent.com/1457859/193664005-2569f350-cc7e-44e3-8395-9299b5037849.png)

