### PR TITLE
feat: add deleteUserAdminNote mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7357,6 +7357,30 @@ type DeleteUserAddressPayload {
   userAddressOrErrors: UserAddressOrErrorsUnion!
 }
 
+type deleteUserAdminNoteFailure {
+  mutationError: GravityMutationError
+}
+
+input deleteUserAdminNoteMutationInput {
+  adminNoteId: String!
+  clientMutationId: String
+  id: String!
+}
+
+type deleteUserAdminNoteMutationPayload {
+  # On success: the admin note deleted.
+  adminNoteOrError: deleteUserAdminNoteResponseOrError
+  clientMutationId: String
+}
+
+union deleteUserAdminNoteResponseOrError =
+    deleteUserAdminNoteFailure
+  | deleteUserAdminNoteSuccess
+
+type deleteUserAdminNoteSuccess {
+  adminNote: UserAdminNotes
+}
+
 input DeleteUserIconInput {
   clientMutationId: String
 }
@@ -10932,6 +10956,11 @@ type Mutation {
   # Remove the user icon
   deleteMyUserProfileIcon(input: DeleteUserIconInput!): DeleteUserIconPayload
   deleteUserAddress(input: DeleteUserAddressInput!): DeleteUserAddressPayload
+
+  # delete an admin note for the user
+  deleteUserAdminNote(
+    input: deleteUserAdminNoteMutationInput!
+  ): deleteUserAdminNoteMutationPayload
 
   # Deletes a UserInterest on the logged in User's CollectorProfile.
   deleteUserInterest(

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -471,6 +471,14 @@ export default (accessToken, userID, opts) => {
     ),
     userSaleProfileLoader: gravityLoader((id) => `user_sale_profile/${id}`),
     userAdminNotesLoader: gravityLoader((id) => `user/${id}/admin_notes`),
+    deleteUserAdminNoteLoader: gravityLoader<
+      any,
+      { id: string; admin_note_id: string }
+    >(
+      ({ id, admin_note_id }) => `user/${id}/admin_note/${admin_note_id}`,
+      {},
+      { method: "DELETE" }
+    ),
     createUserAdminNoteLoader: gravityLoader(
       (id) => `/user/${id}/admin_note`,
       {},

--- a/src/schema/v2/__tests__/deleteUserAdminNoteMutation.test.ts
+++ b/src/schema/v2/__tests__/deleteUserAdminNoteMutation.test.ts
@@ -1,0 +1,81 @@
+/* eslint-disable promise/always-return */
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+const mutation = gql`
+  mutation {
+    deleteUserAdminNote(input: { id: "xyz321", adminNoteId: "abc123" }) {
+      adminNoteOrError {
+        __typename
+        ... on deleteUserAdminNoteSuccess {
+          adminNote {
+            internalID
+            body
+            createdAt
+          }
+        }
+        ... on deleteUserAdminNoteFailure {
+          mutationError {
+            message
+          }
+        }
+      }
+    }
+  }
+`
+
+describe("Delete an admin note for a user", () => {
+  describe("when succesfull", () => {
+    const adminNote = {
+      id: "xyz321",
+      body: "Still a great collector",
+      created_at: "2022-09-30T12:00:00+00:00",
+    }
+
+    const context = {
+      deleteUserAdminNoteLoader: () => Promise.resolve(adminNote),
+    }
+
+    it("deletes an account request", async () => {
+      const data = await runAuthenticatedQuery(mutation, context)
+      expect(data).toEqual({
+        deleteUserAdminNote: {
+          adminNoteOrError: {
+            __typename: "deleteUserAdminNoteSuccess",
+            adminNote: {
+              internalID: "xyz321",
+              body: "Still a great collector",
+              createdAt: "2022-09-30T12:00:00+00:00",
+            },
+          },
+        },
+      })
+    })
+  })
+
+  describe("when failure", () => {
+    it("return an error", async () => {
+      const context = {
+        deleteUserAdminNoteLoader: () =>
+          Promise.reject(
+            new Error(
+              `https://stagingapi.artsy.net/api/v1/user/xyz321/admin_note/abc123 - {"type":"error","message":"User not found"}`
+            )
+          ),
+      }
+
+      const response = await runAuthenticatedQuery(mutation, context)
+
+      expect(response).toEqual({
+        deleteUserAdminNote: {
+          adminNoteOrError: {
+            __typename: "deleteUserAdminNoteFailure",
+            mutationError: {
+              message: "User not found",
+            },
+          },
+        },
+      })
+    })
+  })
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -83,6 +83,7 @@ import { updateMyPasswordMutation } from "./me/updateMyPasswordMutation"
 import { updateUserMutation } from "./users/updateUserMutation"
 import { addUserRoleMutation } from "./users/addUserRoleMutation"
 import { createUserAdminNoteMutation } from "./users/createUserAdminNoteMutation"
+import { deleteUserAdminNoteMutation } from "./users/deleteUserAdminNoteMutation"
 import { updateUserSaleProfileMutation } from "./users/updateUserSaleProfileMutation"
 import { deleteCollectorProfileIconMutation } from "./me/deleteCollectorProfileIconMutation"
 import ObjectIdentification from "./object_identification"
@@ -290,6 +291,7 @@ export default new GraphQLSchema({
       createGeminiEntryForAsset: CreateGeminiEntryForAsset,
       createIdentityVerificationOverride: createIdentityVerificationOverrideMutation,
       createUserAdminNote: createUserAdminNoteMutation,
+      deleteUserAdminNote: deleteUserAdminNoteMutation,
       createUserInterest: createUserInterestMutation,
       deleteBankAccount: deleteBankAccountMutation,
       deleteCreditCard: deleteCreditCardMutation,

--- a/src/schema/v2/users/deleteUserAdminNoteMutation.ts
+++ b/src/schema/v2/users/deleteUserAdminNoteMutation.ts
@@ -1,0 +1,86 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { UserAdminNoteType } from "../user"
+
+interface Input {
+  id: string
+  adminNoteId: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "deleteUserAdminNoteSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    adminNote: {
+      type: UserAdminNoteType,
+      resolve: (result) => result,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "deleteUserAdminNoteFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "deleteUserAdminNoteResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const deleteUserAdminNoteMutation = mutationWithClientMutationId<
+  Input,
+  any | null,
+  ResolverContext
+>({
+  name: "deleteUserAdminNoteMutation",
+  description: "delete an admin note for the user",
+  inputFields: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+    adminNoteId: { type: new GraphQLNonNull(GraphQLString) },
+  },
+  outputFields: {
+    adminNoteOrError: {
+      type: ResponseOrErrorType,
+      description: "On success: the admin note deleted.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (args, { deleteUserAdminNoteLoader }) => {
+    if (!deleteUserAdminNoteLoader) {
+      throw new Error(
+        "You need to pass a X-Access-Token header to perform this action"
+      )
+    }
+
+    try {
+      return await deleteUserAdminNoteLoader?.({
+        id: args.id,
+        admin_note_id: args.adminNoteId,
+      })
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})


### PR DESCRIPTION
This PR adds a loader and mutation to delete an admin note associated with a user. This will be used by `Forque` and supports the work to migrate the `User` app over from `Torque`. 

The `Gravity` endpoint is [here](https://github.com/artsy/gravity/blob/ef8cba1c109a005912af21dfdcda899125ba1b08/app/api/v1/users_admin_notes_endpoint.rb#L61).

[PLATFORM-4600]

[PLATFORM-4600]: https://artsyproduct.atlassian.net/browse/PLATFORM-4600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ