### PR TITLE
chore: dont create duplicate connection types, some tweaks to partner search naming

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11670,6 +11670,15 @@ type Partner implements Node {
     representedBy: Boolean
     sort: ArtistSorts
   ): ArtistPartnerConnection
+  artistsSearchConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    page: Int = 1
+    query: String!
+    size: Int = 10
+  ): ArtistConnection
 
   # A connection of artworks from a Partner.
   artworksConnection(
@@ -11699,6 +11708,15 @@ type Partner implements Node {
     # properties on an artwork, when true or not present fetch artwork :short properties
     shallow: Boolean
     sort: ArtworkSorts
+  ): ArtworkConnection
+  artworksSearchConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    page: Int = 1
+    query: String!
+    size: Int = 10
   ): ArtworkConnection
   cached: Int
   categories: [PartnerCategory]
@@ -11814,34 +11832,7 @@ type Partner implements Node {
   ): LocationConnection
   meta: PartnerMeta
   name: String
-  partnerArtistsSearchConnection(
-    after: String
-    before: String
-    first: Int
-    last: Int
-    page: Int = 1
-    query: String!
-    size: Int = 10
-  ): partnerArtistsSearchConnection
-  partnerArtworksSearchConnection(
-    after: String
-    before: String
-    first: Int
-    last: Int
-    page: Int = 1
-    query: String!
-    size: Int = 10
-  ): partnerArtworksSearchConnection
   partnerPageEligible: Boolean
-  partnerShowsSearchConnection(
-    after: String
-    before: String
-    first: Int
-    last: Int
-    page: Int = 1
-    query: String!
-    size: Int = 10
-  ): partnerShowsSearchConnection
   partnerType: String
   profile: Profile
   profileArtistsLayout: String
@@ -11871,6 +11862,15 @@ type Partner implements Node {
 
     # Filter shows by chronological event status
     status: EventStatus
+  ): ShowConnection
+  showsSearchConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    page: Int = 1
+    query: String!
+    size: Int = 10
   ): ShowConnection
 
   # A slug ID.
@@ -12033,26 +12033,6 @@ type PartnerArtistEdge {
   sortableID: String
 }
 
-# A connection to a list of items.
-type partnerArtistsSearchConnection {
-  # A list of edges.
-  edges: [partnerArtistsSearchEdge]
-  pageCursors: PageCursors!
-
-  # Information to aid in pagination.
-  pageInfo: PageInfo!
-  totalCount: Int
-}
-
-# An edge in a connection.
-type partnerArtistsSearchEdge {
-  # A cursor for use in pagination
-  cursor: String!
-
-  # The item at the end of the edge
-  node: Artist
-}
-
 type PartnerArtworkGrid implements ArtworkContextGrid {
   artworksConnection(
     after: String
@@ -12063,26 +12043,6 @@ type PartnerArtworkGrid implements ArtworkContextGrid {
   ctaHref: String
   ctaTitle: String
   title: String
-}
-
-# A connection to a list of items.
-type partnerArtworksSearchConnection {
-  # A list of edges.
-  edges: [partnerArtworksSearchEdge]
-  pageCursors: PageCursors!
-
-  # Information to aid in pagination.
-  pageInfo: PageInfo!
-  totalCount: Int
-}
-
-# An edge in a connection.
-type partnerArtworksSearchEdge {
-  # A cursor for use in pagination
-  cursor: String!
-
-  # The item at the end of the edge
-  node: Artwork
 }
 
 type PartnerCategory {
@@ -12296,26 +12256,6 @@ type PartnerShowDocumentEdge {
 enum PartnerShowPartnerType {
   GALLERY
   MUSEUM
-}
-
-# A connection to a list of items.
-type partnerShowsSearchConnection {
-  # A list of edges.
-  edges: [partnerShowsSearchEdge]
-  pageCursors: PageCursors!
-
-  # Information to aid in pagination.
-  pageInfo: PageInfo!
-  totalCount: Int
-}
-
-# An edge in a connection.
-type partnerShowsSearchEdge {
-  # A cursor for use in pagination
-  cursor: String!
-
-  # The item at the end of the edge
-  node: Show
 }
 
 enum PartnersSortType {

--- a/src/schema/v2/PartnerMatch.ts
+++ b/src/schema/v2/PartnerMatch.ts
@@ -1,25 +1,18 @@
 import { GraphQLInt, GraphQLNonNull, GraphQLString } from "graphql"
 import { GraphQLFieldConfig } from "graphql"
-import { connectionFromArraySlice } from "graphql-relay"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { pageable } from "relay-cursor-paging"
 import { ResolverContext } from "types/graphql"
-import { ArtistType } from "./artist"
-import { ArtworkType } from "./artwork"
-import {
-  connectionWithCursorInfo,
-  createPageCursors,
-} from "./fields/pagination"
-import { ShowType } from "./show"
+import { artistConnection } from "./artist"
+import { artworkConnection } from "./artwork"
+import { paginationResolver } from "./fields/pagination"
+import { ShowsConnection } from "./show"
 
 export const partnerShowsMatchConnection: GraphQLFieldConfig<
   { id: string },
   ResolverContext
 > = {
-  type: connectionWithCursorInfo({
-    nodeType: ShowType,
-    name: "partnerShowsSearch",
-  }).connectionType,
+  type: ShowsConnection.connectionType,
   args: pageable({
     query: {
       type: new GraphQLNonNull(GraphQLString),
@@ -41,14 +34,14 @@ export const partnerShowsMatchConnection: GraphQLFieldConfig<
 
     const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 
-    return {
+    return paginationResolver({
+      args,
+      body,
+      offset,
+      page,
+      size,
       totalCount,
-      pageCursors: createPageCursors({ ...args, page, size }, totalCount),
-      ...connectionFromArraySlice(body, args, {
-        arrayLength: totalCount,
-        sliceStart: offset,
-      }),
-    }
+    })
   },
 }
 
@@ -56,10 +49,7 @@ export const partnerArtworksMatchConnection: GraphQLFieldConfig<
   { id: string },
   ResolverContext
 > = {
-  type: connectionWithCursorInfo({
-    nodeType: ArtworkType,
-    name: "partnerArtworksSearch",
-  }).connectionType,
+  type: artworkConnection.connectionType,
   args: pageable({
     query: {
       type: new GraphQLNonNull(GraphQLString),
@@ -85,14 +75,14 @@ export const partnerArtworksMatchConnection: GraphQLFieldConfig<
 
     const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 
-    return {
+    return paginationResolver({
+      args,
+      body,
+      offset,
+      page,
+      size,
       totalCount,
-      pageCursors: createPageCursors({ ...args, page, size }, totalCount),
-      ...connectionFromArraySlice(body, args, {
-        arrayLength: totalCount,
-        sliceStart: offset,
-      }),
-    }
+    })
   },
 }
 
@@ -100,10 +90,7 @@ export const partnerArtistsMatchConnection: GraphQLFieldConfig<
   { id: string },
   ResolverContext
 > = {
-  type: connectionWithCursorInfo({
-    nodeType: ArtistType,
-    name: "partnerArtistsSearch",
-  }).connectionType,
+  type: artistConnection.connectionType,
   args: pageable({
     query: {
       type: new GraphQLNonNull(GraphQLString),
@@ -129,13 +116,13 @@ export const partnerArtistsMatchConnection: GraphQLFieldConfig<
 
     const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 
-    return {
+    return paginationResolver({
+      args,
+      body,
+      offset,
+      page,
+      size,
       totalCount,
-      pageCursors: createPageCursors({ ...args, page, size }, totalCount),
-      ...connectionFromArraySlice(body, args, {
-        arrayLength: totalCount,
-        sliceStart: offset,
-      }),
-    }
+    })
   },
 }

--- a/src/schema/v2/__tests__/partner.test.js
+++ b/src/schema/v2/__tests__/partner.test.js
@@ -1379,7 +1379,7 @@ describe("Partner type", () => {
     })
   })
 
-  describe("#partnerShowsSearchConnection", () => {
+  describe("#showsSearchConnection", () => {
     let showsResponse
 
     beforeEach(() => {
@@ -1410,7 +1410,7 @@ describe("Partner type", () => {
       const query = gql`
         {
           partner(id: "levy-gorvy") {
-            partnerShowsSearchConnection(query: "levy") {
+            showsSearchConnection(query: "levy") {
               edges {
                 node {
                   slug
@@ -1424,7 +1424,7 @@ describe("Partner type", () => {
 
       expect(data).toEqual({
         partner: {
-          partnerShowsSearchConnection: {
+          showsSearchConnection: {
             edges: [
               {
                 node: {
@@ -1449,7 +1449,7 @@ describe("Partner type", () => {
     })
   })
 
-  describe("#partnerArtistsSearchConnection", () => {
+  describe("#artistsSearchConnection", () => {
     let artistsResponse
 
     beforeEach(() => {
@@ -1480,7 +1480,7 @@ describe("Partner type", () => {
       const query = gql`
         {
           partner(id: "levy-gorvy") {
-            partnerArtistsSearchConnection(query: "some-query") {
+            artistsSearchConnection(query: "some-query") {
               edges {
                 node {
                   slug
@@ -1494,7 +1494,7 @@ describe("Partner type", () => {
 
       expect(data).toEqual({
         partner: {
-          partnerArtistsSearchConnection: {
+          artistsSearchConnection: {
             edges: [
               {
                 node: {
@@ -1518,7 +1518,7 @@ describe("Partner type", () => {
     })
   })
 
-  describe("#partnerArtworksSearchConnection", () => {
+  describe("#artworksSearchConnection", () => {
     let artworksResponse
 
     beforeEach(() => {
@@ -1549,7 +1549,7 @@ describe("Partner type", () => {
       const query = gql`
         {
           partner(id: "levy-gorvy") {
-            partnerArtworksSearchConnection(query: "some-query") {
+            artworksSearchConnection(query: "some-query") {
               edges {
                 node {
                   slug
@@ -1563,7 +1563,7 @@ describe("Partner type", () => {
 
       expect(data).toEqual({
         partner: {
-          partnerArtworksSearchConnection: {
+          artworksSearchConnection: {
             edges: [
               {
                 node: {

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -313,6 +313,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           )
         },
       },
+      artistsSearchConnection: partnerArtistsMatchConnection,
       artworksConnection: {
         description: "A connection of artworks from a Partner.",
         type: artworkConnection.connectionType,
@@ -400,6 +401,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           )
         },
       },
+      artworksSearchConnection: partnerArtworksMatchConnection,
       categories: {
         type: new GraphQLList(PartnerCategoryType),
         resolve: ({ partner_categories }) => partner_categories,
@@ -501,9 +503,6 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLString,
         resolve: ({ vat_number }) => vat_number,
       },
-      partnerArtistsSearchConnection: partnerArtistsMatchConnection,
-      partnerArtworksSearchConnection: partnerArtworksMatchConnection,
-      partnerShowsSearchConnection: partnerShowsMatchConnection,
       hasFairPartnership: {
         type: GraphQLBoolean,
         resolve: ({ has_fair_partnership }) => has_fair_partnership,
@@ -762,6 +761,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           )
         },
       },
+      showsSearchConnection: partnerShowsMatchConnection,
       type: {
         type: GraphQLString,
         resolve: ({ name, type }) => {


### PR DESCRIPTION
As discussed, I re-used the existing artist/artwork/show connection types for match purposes, rather than creating new types.

Also, can use `paginationResolver` helper instead of having to do the weird dance of creating the proper paginated structure w/ cursor stuff.

Also, renamed the fields under `Partner` to get rid of the redundant `partner` prefix (this might be a breaking change to current development of Folio).

In terms of whether these fields need to even exist (or we can re-use the existing artist/artworks/shows connection that already exist under `Partner`) -> I'll leave that up to you to decide! I would be happy either way, just want to support y'all.