### PR TITLE
fix(article): exposes unpublished artworks

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1154,7 +1154,10 @@ type ArticleSectionImageCollection {
   layout: ArticleSectionImageCollectionLayout!
 }
 
-union ArticleSectionImageCollectionFigure = ArticleImageSection | Artwork
+union ArticleSectionImageCollectionFigure =
+    ArticleImageSection
+  | ArticleUnpublishedArtwork
+  | Artwork
 
 enum ArticleSectionImageCollectionLayout {
   COLUMN_WIDTH
@@ -1236,6 +1239,35 @@ type ArticleSponsor {
   partnerLogoLink: String
   pixelTrackingCode: String
   subTitle: String
+}
+
+type ArticleUnpublishedArtwork {
+  artist: ArticleUnpublishedArtworkArtist
+  artists: [ArticleUnpublishedArtworkArtist!]!
+  credit: String
+  date: String
+
+  # A globally unique ID.
+  id: ID!
+  image: Image
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+  partner: ArticleUnpublishedArtworkPartner
+
+  # A slug ID.
+  slug: ID!
+  title: String
+}
+
+type ArticleUnpublishedArtworkArtist {
+  name: String
+  slug: String
+}
+
+type ArticleUnpublishedArtworkPartner {
+  name: String
+  slug: String
 }
 
 type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Searchable {


### PR DESCRIPTION
If we fetch an unpublished artwork, it errors, so we assume it's unpublished and use the response that Writer has stored to display a stub of the artwork. In practice this works OK since all we need is the image and a credit.