### PR TITLE
feat: add accessiblePropertiesConnection to User

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16192,6 +16192,14 @@ type UpdateViewingRoomSubsectionsPayload {
 scalar Upload
 
 type User implements Node {
+  accessiblePropertiesConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    model: UserAccessiblePropertyInput
+  ): UserAccessiblePropertyConnection
+
   # The admin notes associated with the user
   adminNotes: [UserAdminNotes]!
   analytics: AnalyticsUserStats
@@ -16325,6 +16333,35 @@ type User implements Node {
 
   # Check whether a user exists by email address before creating an account.
   userAlreadyExists: Boolean
+}
+
+union UserAccessibleProperty = Artist | Artwork | Partner | Profile
+
+# A connection to a list of items.
+type UserAccessiblePropertyConnection {
+  # A list of edges.
+  edges: [UserAccessiblePropertyEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type UserAccessiblePropertyEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: UserAccessibleProperty
+}
+
+enum UserAccessiblePropertyInput {
+  ARTIST
+  ARTWORK
+  PARTNER
+  PROFILE
 }
 
 # User saved address

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -543,5 +543,10 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "GET" }
     ),
+    userAccessControlLoaderAllProperties: gravityLoader<any, { id: string }>(
+      (id) => `user/${id}/access_controls`,
+      {},
+      { headers: true }
+    ),
   }
 }

--- a/src/schema/v2/userAccessibleProperties.ts
+++ b/src/schema/v2/userAccessibleProperties.ts
@@ -1,0 +1,49 @@
+import { GraphQLEnumType, GraphQLUnionType } from "graphql"
+import { connectionWithCursorInfo } from "./fields/pagination"
+import { ArtworkType } from "./artwork"
+import { ProfileType } from "./profile"
+import { PartnerType } from "./partner"
+import { ArtistType } from "./artist"
+
+const userAccessControlPropertiesType = new GraphQLUnionType({
+  name: "UserAccessibleProperty",
+  types: () => [ArtistType, ArtworkType, ProfileType, PartnerType],
+  resolveType: ({ propertyType }) => {
+    switch (propertyType) {
+      case "Artist":
+        return ArtistType
+      case "Artwork":
+        return ArtworkType
+      case "Partner":
+        return PartnerType
+      case "Profile":
+        return ProfileType
+      default:
+        throw new Error(`Unknown context type: ${propertyType}`)
+    }
+  },
+})
+
+export const UserAccessiblePropertiesConnectionType = connectionWithCursorInfo({
+  nodeType: userAccessControlPropertiesType,
+}).connectionType
+
+export const UserAccessiblePropertiesModelInputType = {
+  type: new GraphQLEnumType({
+    name: "UserAccessiblePropertyInput",
+    values: {
+      PARTNER: {
+        value: "partner",
+      },
+      ARTWORK: {
+        value: "artwork",
+      },
+      PROFILE: {
+        value: "profile",
+      },
+      ARTIST: {
+        value: "artist",
+      },
+    },
+  }),
+}


### PR DESCRIPTION
This depends on https://github.com/artsy/gravity/pull/15722 in order to properly resolve the data re: counts and all the cursor/pagination stuff.

Posted a screenshot in Slack (private data) to show the example schema.

This is in response to https://github.com/artsy/metaphysics/pull/4428

Essentially, rather than worrying about specifics of the current UI (wanting to link to a partner - which might change, now we want to show partner name, etc.), this adds support for a connection of accessible properties to `User`.

There isn't much info on the `edge`, and then the `node` is a union of the possible types that are currently in use:

```
> AccessControl.distinct(:property_type)
=> ["Artist", "Artwork", "Partner", "Profile"]
```

