### PR TITLE
feat: expose additional email confirmation related fields on user schema

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16180,6 +16180,14 @@ type User implements Node {
 
   # The given email of the user.
   email: String!
+  emailConfirmationSentAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See
+    # http://www.iana.org/time-zones,
+    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
   emailConfirmedAt(
     format: String
 
@@ -16290,6 +16298,9 @@ type User implements Node {
 
   # The number of times a user has signed in
   signInCount: Int!
+
+  # The unconfirmed email of the user.
+  unconfirmedEmail: String
 
   # Check whether a user exists by email address before creating an account.
   userAlreadyExists: Boolean

--- a/src/schema/v2/__tests__/user.test.ts
+++ b/src/schema/v2/__tests__/user.test.ts
@@ -674,6 +674,48 @@ describe("User", () => {
     })
   })
 
+  describe("saleProfile", () => {
+    it("returns the user's sale profile", async () => {
+      const query = `
+        {
+          user(id: "blah") {
+            saleProfile {
+              requireBidderApproval
+              employer
+              jobTitle
+            }
+          }
+        }
+      `
+
+      const user = {
+        id: "blah",
+      }
+
+      const userSaleProfile = {
+        require_bidder_approval: true,
+        employer: "Cats R Us",
+        job_title: "CCO - Chief Cat Officer",
+      }
+
+      const context = {
+        userByIDLoader: () => {
+          return Promise.resolve(user)
+        },
+        userSaleProfileLoader: () => {
+          return Promise.resolve(userSaleProfile)
+        },
+      }
+
+      const {
+        user: { saleProfile },
+      } = await runAuthenticatedQuery(query, context)
+      expect(saleProfile.requireBidderApproval).toEqual(true)
+      expect(saleProfile.employer).toEqual("Cats R Us")
+      expect(saleProfile.jobTitle).toEqual("CCO - Chief Cat Officer")
+    })
+  })
+
   describe("inquiredArtworksConnection", () => {
     const query = `
         {

--- a/src/schema/v2/__tests__/user.test.ts
+++ b/src/schema/v2/__tests__/user.test.ts
@@ -52,6 +52,40 @@ describe("User", () => {
     expect(node.__typename).toEqual("User")
   })
 
+  it("returns expected email fields", async () => {
+    const query = `
+      {
+        user(id: "percy-z") {
+          name
+          email
+          unconfirmedEmail
+          emailConfirmedAt
+          emailConfirmationSentAt
+        }
+      }
+    `
+    const user = {
+      name: "Percy Z",
+      email: "percy-z@catmail.com",
+      unconfirmedEmail: "percy-z@purr.me",
+      confirmed_at: "2020-01-01T01:00:00.000Z",
+      confirmation_sent_at: "2022-01-01T00:00:00.000Z",
+    }
+
+    const context = {
+      userByIDLoader: () => {
+        return Promise.resolve(user)
+      },
+    }
+
+    const { user: result } = await runAuthenticatedQuery(query, context)
+
+    expect(result.email).toEqual("percy-z@catmail.com")
+    expect(result.unconfirmedEmail).toEqual("percy-z@purr.me")
+    expect(result.emailConfirmedAt).toEqual("2020-01-01T01:00:00.000Z")
+    expect(result.emailConfirmationSentAt).toEqual("2022-01-01T00:00:00.000Z")
+  })
+
   describe("userAlreadyExists", () => {
     it("returns true if a user exists", async () => {
       const foundUser = {

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -136,12 +136,19 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
         description: "The given email of the user.",
         type: new GraphQLNonNull(GraphQLString),
       },
+      unconfirmedEmail: {
+        description: "The unconfirmed email of the user.",
+        type: GraphQLString,
+      },
       phone: {
         description: "The given phone number of the user.",
         type: GraphQLString,
       },
       createdAt: date(({ created_at }) => created_at),
-      emailConfirmedAt: date(({ email_confirmed_at }) => email_confirmed_at),
+      emailConfirmedAt: date(({ confirmed_at }) => confirmed_at),
+      emailConfirmationSentAt: date(
+        ({ confirmation_sent_at }) => confirmation_sent_at
+      ),
       secondFactorEnabled: {
         description:
           "If the user has enabled two-factor authentication on their account",

--- a/src/schema/v2/userSaleProfile.ts
+++ b/src/schema/v2/userSaleProfile.ts
@@ -70,7 +70,7 @@ export const UserSaleProfileType = new GraphQLObjectType<any, ResolverContext>({
     jobTitle: {
       description: "The job title for this user",
       type: GraphQLString,
-      resolve: ({ marital_status }) => marital_status,
+      resolve: ({ job_title }) => job_title,
     },
     lastName: {
       description: "The last name  for this user",


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4647

This depends on fields getting exposed in https://github.com/artsy/gravity/pull/15720

In support of ongoing work to improve user account management via https://tools.artsy.net, this PR exposes additional fields around email confirmation states and couple of minor fixes:

* adds `emailConfirmationSentAt` and `unconfirmedEmail` fields on _user schema_
* fixes `emailConfirmedAt` to resolve the correct field on _user schema_
* fixes `jobTitle` to resolve the correct field on _userSaleProfile_