### PR TITLE
fix: divide value by 100 vo cut the cents

### DIFF
--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -110,7 +110,7 @@ const ArtworkPriceInsightsType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
       description: 'The annual value of the work sold "in USD "',
       resolve: ({ annualValueSoldCents }) => {
-        return `$${formatLargeNumber(annualValueSoldCents)}`
+        return `$${formatLargeNumber(annualValueSoldCents / 100)}` // dividing by 100 because we don't need the value in cents
       },
     },
     annualLotsSold: {

--- a/src/schema/v2/me/__tests__/myCollection.test.ts
+++ b/src/schema/v2/me/__tests__/myCollection.test.ts
@@ -395,7 +395,7 @@ describe("me.myCollection", () => {
                   },
                   "internalID": "artwork_id_with_market_price_insights",
                   "marketPriceInsights": Object {
-                    "annualValueSoldDisplayText": "$2B",
+                    "annualValueSoldDisplayText": "$22M",
                     "averageSalePriceDisplayText": "US$2,176,421",
                     "demandRank": 0.64,
                     "demandRankDisplayText": "Moderate Demand",


### PR DESCRIPTION
We used cants as if it was dollars, which caused the Annual Value Sold to be 100 times bigger than it should be.