### PR TITLE
fix: unconfirmedEmail field on User

### DIFF
--- a/src/schema/v2/__tests__/user.test.ts
+++ b/src/schema/v2/__tests__/user.test.ts
@@ -67,7 +67,7 @@ describe("User", () => {
     const user = {
       name: "Percy Z",
       email: "percy-z@catmail.com",
-      unconfirmedEmail: "percy-z@purr.me",
+      unconfirmed_email: "percy-z@purr.me",
       confirmed_at: "2020-01-01T01:00:00.000Z",
       confirmation_sent_at: "2022-01-01T00:00:00.000Z",
     }

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -192,6 +192,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
       unconfirmedEmail: {
         description: "The unconfirmed email of the user.",
         type: GraphQLString,
+        resolve: ({ unconfirmed_email }) => unconfirmed_email,
       },
       phone: {
         description: "The given phone number of the user.",


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4647

This fixes an oversight when resolving `unconfirmedEmail` field which was exposed on the `User` schema in https://github.com/artsy/metaphysics/pull/4435