### PR TITLE
feat: Add support for remote images to MyC artwork mutations

### DIFF
--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -258,6 +258,7 @@ describe("myCollectionCreateArtworkMutation", () => {
           "https://d2v80f5yrouhh2.cloudfront.net/kKRlZGUZU6qHYbsHWV_0ig/large.jpg",
       })
     })
+
     it("returns an error when the additional image can't be created", async () => {
       const externalImageUrls = [
         "https://test-upload-bucket.s3.amazonaws.com/path/to/image.jpg",

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -242,6 +242,22 @@ describe("myCollectionCreateArtworkMutation", () => {
       })
     })
 
+    it("creates an additional image from a valid remote image url", async () => {
+      const externalImageUrls = [
+        "https://d2v80f5yrouhh2.cloudfront.net/kKRlZGUZU6qHYbsHWV_0ig/large.jpg",
+      ]
+      const mutation = computeMutationInput({ externalImageUrls })
+
+      const data = await runAuthenticatedQuery(mutation, defaultContext)
+      const { artworkOrError } = data.myCollectionCreateArtwork
+
+      expect(artworkOrError).toHaveProperty("artwork")
+      expect(artworkOrError).not.toHaveProperty("error")
+      expect(createImageLoader).toBeCalledWith(newArtwork.id, {
+        remote_image_url:
+          "https://d2v80f5yrouhh2.cloudfront.net/kKRlZGUZU6qHYbsHWV_0ig/large.jpg",
+      })
+    })
     it("returns an error when the additional image can't be created", async () => {
       const externalImageUrls = [
         "https://test-upload-bucket.s3.amazonaws.com/path/to/image.jpg",
@@ -385,8 +401,8 @@ describe("computeImageSources", () => {
     expect(imageSources).toEqual([])
   })
 
-  it("filters out urls that don't match the regex", () => {
-    const externalImageUrls = ["http://example.com/path/to/image.jpg"]
+  it("filters out urls that don't match the regex and are not valid urls", () => {
+    const externalImageUrls = ["example.com/path/to/image.jpg"]
     const imageSources = computeImageSources(externalImageUrls)
     expect(imageSources).toEqual([])
   })
@@ -407,6 +423,6 @@ describe("computeImageSources", () => {
       "https://test-upload-bucket.s3.amazonaws.com/path/to/image.jpg",
     ]
     const imageSources = computeImageSources(externalImageUrls)
-    expect(imageSources.length).toEqual(1)
+    expect(imageSources.length).toEqual(2)
   })
 })

--- a/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
@@ -226,6 +226,23 @@ describe("myCollectionUpdateArtworkMutation", () => {
       })
     })
 
+    it("creates an additional image from a valid remote image url", async () => {
+      const externalImageUrls = [
+        "https://d2v80f5yrouhh2.cloudfront.net/kKRlZGUZU6qHYbsHWV_0ig/large.jpg",
+      ]
+      const mutation = computeMutationInput({ externalImageUrls })
+
+      const data = await runAuthenticatedQuery(mutation, defaultContext)
+      const { artworkOrError } = data.myCollectionUpdateArtwork
+
+      expect(artworkOrError).toHaveProperty("artwork")
+      expect(artworkOrError).not.toHaveProperty("error")
+      expect(createImageLoader).toBeCalledWith(updatedArtwork.id, {
+        remote_image_url:
+          "https://d2v80f5yrouhh2.cloudfront.net/kKRlZGUZU6qHYbsHWV_0ig/large.jpg",
+      })
+    })
+
     it("returns an error when the additional image can't be created", async () => {
       const externalImageUrls = [
         "https://test-upload-bucket.s3.amazonaws.com/path/to/image.jpg",

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -255,7 +255,15 @@ export const computeImageSources = (externalImageUrls) => {
   const imageSources = externalImageUrls.map((url) => {
     const match = url.match(externalUrlRegex)
 
-    if (!match) return
+    if (!match) {
+      if (url.startsWith("http")) {
+        return {
+          remote_image_url: url,
+        }
+      } else {
+        return
+      }
+    }
 
     const { sourceBucket, sourceKey } = match.groups
 

--- a/src/schema/v2/notifications/index.ts
+++ b/src/schema/v2/notifications/index.ts
@@ -21,16 +21,11 @@ import { artworkConnection } from "../artwork"
 import numeral from "../fields/numeral"
 import { IDFields, NodeInterface } from "../object_identification"
 
-const GRAVITY_NOTIFICATION_TYPE_MAPPING = {
-  artwork_alert: "SavedSearchHitActivity",
-  artwork_published: "ArtworkPublishedActivity",
-}
-
 const NotificationTypesEnum = new GraphQLEnumType({
   name: "NotificationTypesEnum",
   values: {
-    ARTWORK_ALERT: { value: "artwork_alert" },
-    ARTWORK_PUBLISHED: { value: "artwork_published" },
+    ARTWORK_ALERT: { value: "SavedSearchHitActivity" },
+    ARTWORK_PUBLISHED: { value: "ArtworkPublishedActivity" },
   },
 })
 
@@ -59,7 +54,9 @@ export const NotificationType = new GraphQLObjectType<any, ResolverContext>({
     notificationType: {
       type: new GraphQLNonNull(NotificationTypesEnum),
       resolve: ({ actors }) =>
-        actors.startsWith("Works by") ? "artwork_alert" : "artwork_published",
+        actors.startsWith("Works by")
+          ? "SavedSearchHitActivity"
+          : "ArtworkPublishedActivity",
     },
     artworksConnection: {
       type: artworkConnection.connectionType,
@@ -110,10 +107,8 @@ export const NotificationsConnection: GraphQLFieldConfig<
 
     const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
 
-    const activityTypes = getGravityActivityTypes(args.notificationTypes)
-
     const body = await notificationsFeedLoader({
-      activity_types: activityTypes,
+      activity_types: args.notificationTypes,
       size,
       page,
     })
@@ -133,6 +128,3 @@ export const NotificationsConnection: GraphQLFieldConfig<
     }
   },
 }
-
-const getGravityActivityTypes = (notificationTypes: [string]) =>
-  notificationTypes?.map((type) => GRAVITY_NOTIFICATION_TYPE_MAPPING[type])


### PR DESCRIPTION
Addresses [CX-2983]

## Description

In order to support adding images from a remote URL (not S3) to a My Collection artwork, this PR adds the functionality to the function that computes the image source. 

This PR prepares the endpoint for https://github.com/artsy/convection/pull/1348 and uses Gravity's optional parameter [remote_image_url](https://github.com/artsy/gravity/blob/bcf19fd80bc908a802191e80366685c346bc3f53/app/api/v1/artworks_images_endpoint.rb#L49) (`POST /api/v1/artwork/:artwork_id/image`)



[CX-2983]: https://artsyproduct.atlassian.net/browse/CX-2983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ