### PR TITLE
feat: Add support for remote images to My Collection artwork mutations

### DIFF
--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -242,6 +242,23 @@ describe("myCollectionCreateArtworkMutation", () => {
       })
     })
 
+    it("creates an additional image from a valid remote image url", async () => {
+      const externalImageUrls = [
+        "https://d2v80f5yrouhh2.cloudfront.net/kKRlZGUZU6qHYbsHWV_0ig/large.jpg",
+      ]
+      const mutation = computeMutationInput({ externalImageUrls })
+
+      const data = await runAuthenticatedQuery(mutation, defaultContext)
+      const { artworkOrError } = data.myCollectionCreateArtwork
+
+      expect(artworkOrError).toHaveProperty("artwork")
+      expect(artworkOrError).not.toHaveProperty("error")
+      expect(createImageLoader).toBeCalledWith(newArtwork.id, {
+        remote_image_url:
+          "https://d2v80f5yrouhh2.cloudfront.net/kKRlZGUZU6qHYbsHWV_0ig/large.jpg",
+      })
+    })
+
     it("returns an error when the additional image can't be created", async () => {
       const externalImageUrls = [
         "https://test-upload-bucket.s3.amazonaws.com/path/to/image.jpg",
@@ -385,8 +402,8 @@ describe("computeImageSources", () => {
     expect(imageSources).toEqual([])
   })
 
-  it("filters out urls that don't match the regex", () => {
-    const externalImageUrls = ["http://example.com/path/to/image.jpg"]
+  it("filters out urls that don't match the regex and are not valid urls", () => {
+    const externalImageUrls = ["example.com/path/to/image.jpg"]
     const imageSources = computeImageSources(externalImageUrls)
     expect(imageSources).toEqual([])
   })
@@ -407,6 +424,6 @@ describe("computeImageSources", () => {
       "https://test-upload-bucket.s3.amazonaws.com/path/to/image.jpg",
     ]
     const imageSources = computeImageSources(externalImageUrls)
-    expect(imageSources.length).toEqual(1)
+    expect(imageSources.length).toEqual(2)
   })
 })

--- a/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
@@ -226,6 +226,23 @@ describe("myCollectionUpdateArtworkMutation", () => {
       })
     })
 
+    it("creates an additional image from a valid remote image url", async () => {
+      const externalImageUrls = [
+        "https://d2v80f5yrouhh2.cloudfront.net/kKRlZGUZU6qHYbsHWV_0ig/large.jpg",
+      ]
+      const mutation = computeMutationInput({ externalImageUrls })
+
+      const data = await runAuthenticatedQuery(mutation, defaultContext)
+      const { artworkOrError } = data.myCollectionUpdateArtwork
+
+      expect(artworkOrError).toHaveProperty("artwork")
+      expect(artworkOrError).not.toHaveProperty("error")
+      expect(createImageLoader).toBeCalledWith(updatedArtwork.id, {
+        remote_image_url:
+          "https://d2v80f5yrouhh2.cloudfront.net/kKRlZGUZU6qHYbsHWV_0ig/large.jpg",
+      })
+    })
+
     it("returns an error when the additional image can't be created", async () => {
       const externalImageUrls = [
         "https://test-upload-bucket.s3.amazonaws.com/path/to/image.jpg",

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -255,7 +255,15 @@ export const computeImageSources = (externalImageUrls) => {
   const imageSources = externalImageUrls.map((url) => {
     const match = url.match(externalUrlRegex)
 
-    if (!match) return
+    if (!match) {
+      if (url.startsWith("http")) {
+        return {
+          remote_image_url: url,
+        }
+      } else {
+        return
+      }
+    }
 
     const { sourceBucket, sourceKey } = match.groups
 

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -16,7 +16,7 @@ import { ArtworkImportSourceEnum } from "../artwork"
 import { MyCollectionArtworkMutationType } from "./myCollection"
 import { EditableLocationFields } from "./update_me_mutation"
 
-const externalUrlRegex = /https:\/\/(?<sourceBucket>.*).s3.amazonaws.com\/(?<sourceKey>.*)/
+export const externalUrlRegex = /https:\/\/(?<sourceBucket>.*).s3.amazonaws.com\/(?<sourceKey>.*)/
 
 export const ArtworkAttributionClassEnum = new GraphQLEnumType({
   name: "ArtworkAttributionClassType",

--- a/src/schema/v2/me/update_me_mutation.ts
+++ b/src/schema/v2/me/update_me_mutation.ts
@@ -16,7 +16,7 @@ import { snakeCase } from "lodash"
 import { ResolverContext } from "types/graphql"
 import { UserType } from "../user"
 import Me, { CurrencyPreference, LengthUnitPreference } from "./"
-import { computeImageSources } from "./myCollectionCreateArtworkMutation"
+import { externalUrlRegex } from "./myCollectionCreateArtworkMutation"
 
 export const EditableLocationFields = new GraphQLInputObjectType({
   name: "EditableLocation",
@@ -260,3 +260,21 @@ export default mutationWithClientMutationId<any, any, ResolverContext>({
     }
   },
 })
+
+export const computeImageSources = (externalImageUrls) => {
+  const imageSources = externalImageUrls.map((url) => {
+    const match = url.match(externalUrlRegex)
+
+    if (!match) return
+
+    const { sourceBucket, sourceKey } = match.groups
+
+    return {
+      source_bucket: sourceBucket,
+      source_key: sourceKey,
+    }
+  })
+
+  const filteredImageSources = imageSources.filter(Boolean)
+  return filteredImageSources
+}


### PR DESCRIPTION
Addresses [CX-2983]

## Description

In order to support adding images from a remote URL (not S3) to a My Collection artwork, this PR adds the functionality to the function that computes the image source. 

This PR prepares the endpoint for https://github.com/artsy/convection/pull/1348 and uses Gravity's optional parameter [remote_image_url](https://github.com/artsy/gravity/blob/bcf19fd80bc908a802191e80366685c346bc3f53/app/api/v1/artworks_images_endpoint.rb#L49) (`POST /api/v1/artwork/:artwork_id/image`)



[CX-2983]: https://artsyproduct.atlassian.net/browse/CX-2983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ