### PR TITLE
feat: web deployment to prefer spot tier

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -97,6 +97,14 @@ spec:
                 values:
                 - foreground
                 - foreground-spot
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: tier
+                operator: In
+                values:
+                - foreground-spot
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -97,6 +97,14 @@ spec:
                 values:
                 - foreground
                 - foreground-spot
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: tier
+                operator: In
+                values:
+                - foreground-spot
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler


### PR DESCRIPTION
[PLATFORM-4614]
Follows https://github.com/artsy/metaphysics/pull/4389

Make web deployment prefer Spot tier, to maximize Spot usage. [Dashboard](https://app.datadoghq.com/dashboard/2n5-6tr-ypp/kubernetes-deployments?tpl_var_deployment%5B0%5D=metaphysics-web&tpl_var_hpa%5B0%5D=metaphysics-web&from_ts=1665066550292&to_ts=1665671350292&live=true) shows spot/on-demand distribution.

[PLATFORM-4614]: https://artsyproduct.atlassian.net/browse/PLATFORM-4614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ