### PR TITLE
feat(FX-4313): Add the ability to query a formatted date for notification

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11453,8 +11453,8 @@ type Notification implements Node {
   message: String!
   notificationType: NotificationTypesEnum!
   publishedAt(
-    # The human-friendly date (e.g. "Today", "Yesterday", "5 days ago")
-    formatted: Boolean
+    # pass `RELATIVE` to display the human-friendly date (e.g. "Today", "Yesterday", "5 days ago")
+    format: String
   ): String!
   targetHref: String!
   title: String!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11443,6 +11443,7 @@ type Notification implements Node {
     # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String
+  formattedCreatedAt: String!
 
   # A globally unique ID.
   id: ID!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11442,7 +11442,7 @@ type Notification implements Node {
     # http://www.iana.org/time-zones,
     # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
-  ): String
+  ): String @deprecated(reason: "Please use `publishedAt` instead")
 
   # A globally unique ID.
   id: ID!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11443,7 +11443,6 @@ type Notification implements Node {
     # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String
-  formattedCreatedAt: String!
 
   # A globally unique ID.
   id: ID!
@@ -11453,6 +11452,7 @@ type Notification implements Node {
   isUnread: Boolean!
   message: String!
   notificationType: NotificationTypesEnum!
+  publishedAt: String!
   targetHref: String!
   title: String!
 }

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11452,7 +11452,10 @@ type Notification implements Node {
   isUnread: Boolean!
   message: String!
   notificationType: NotificationTypesEnum!
-  publishedAt: String!
+  publishedAt(
+    # The human-friendly date (e.g. "Today", "Yesterday", "5 days ago")
+    formatted: Boolean
+  ): String!
   targetHref: String!
   title: String!
 }

--- a/src/schema/v2/notifications/__tests__/index.test.ts
+++ b/src/schema/v2/notifications/__tests__/index.test.ts
@@ -99,7 +99,7 @@ describe("notificationsConnection", () => {
         notificationsConnection(first: 1) {
           edges {
             node {
-              formattedCreatedAt
+              publishedAt
             }
           }
         }
@@ -120,7 +120,7 @@ describe("notificationsConnection", () => {
       const edges = data.notificationsConnection.edges
       const item = edges[0].node
 
-      expect(item.formattedCreatedAt).toEqual("Today")
+      expect(item.publishedAt).toEqual("Today")
     })
 
     it("should return `Yesterday` label", async () => {
@@ -143,7 +143,7 @@ describe("notificationsConnection", () => {
       const edges = data.notificationsConnection.edges
       const item = edges[0].node
 
-      expect(item.formattedCreatedAt).toEqual("Yesterday")
+      expect(item.publishedAt).toEqual("Yesterday")
     })
 
     it("should return `x days ago` label", async () => {
@@ -165,7 +165,7 @@ describe("notificationsConnection", () => {
       const edges = data.notificationsConnection.edges
       const item = edges[0].node
 
-      expect(item.formattedCreatedAt).toEqual("5 days ago")
+      expect(item.publishedAt).toEqual("5 days ago")
     })
   })
 })

--- a/src/schema/v2/notifications/__tests__/index.test.ts
+++ b/src/schema/v2/notifications/__tests__/index.test.ts
@@ -93,14 +93,14 @@ describe("notificationsConnection", () => {
     })
   })
 
-  describe("with formatted publication date", () => {
+  describe("with publication date", () => {
     describe("the human-friendly date", () => {
       const query = gql`
         {
           notificationsConnection(first: 1) {
             edges {
               node {
-                publishedAt(formatted: true)
+                publishedAt(format: "RELATIVE")
               }
             }
           }
@@ -190,6 +190,28 @@ describe("notificationsConnection", () => {
       const item = edges[0].node
 
       expect(item.publishedAt).toEqual("2022-08-22T21:15:49Z")
+    })
+
+    it("should return date in the specified format", async () => {
+      const query = gql`
+        {
+          notificationsConnection(first: 1) {
+            edges {
+              node {
+                publishedAt(format: "YYYY-MM-DD")
+              }
+            }
+          }
+        }
+      `
+
+      const data = await runAuthenticatedQuery(query, {
+        notificationsFeedLoader,
+      })
+      const edges = data.notificationsConnection.edges
+      const item = edges[0].node
+
+      expect(item.publishedAt).toEqual("2022-08-22")
     })
   })
 })

--- a/src/schema/v2/notifications/__tests__/index.test.ts
+++ b/src/schema/v2/notifications/__tests__/index.test.ts
@@ -1,24 +1,11 @@
 import gql from "lib/gql"
 import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import moment from "moment-timezone"
 
 describe("notificationsConnection", () => {
   const notificationsFeedLoader = jest.fn(() =>
     Promise.resolve({
-      feed: [
-        {
-          id: "6303f205b54941000843419a",
-          actors: "Works by Damien Hirst",
-          message: "8 Works Added",
-          status: "unread",
-          date: "2022-08-22T21:15:49.000Z",
-          object_ids: ["63036fafbe5cfc000cf358e3", "630392514f13a5000b55ecec"],
-          object: {
-            artist: { id: "damien-hirst", _id: "4d8b926a4eb68a1b2c0000ae" },
-          },
-          activity_type: "ArtworkPublishedActivity",
-          target_href: "/artist/damien-hirst/works-for-sale",
-        },
-      ],
+      feed: [notificationFeedItem],
       total: 100,
       total_unread: 10,
     })
@@ -105,7 +92,97 @@ describe("notificationsConnection", () => {
       expect(data).toEqual(expectedData)
     })
   })
+
+  describe("with formatted creation date", () => {
+    const query = gql`
+      {
+        notificationsConnection(first: 1) {
+          edges {
+            node {
+              formattedCreatedAt
+            }
+          }
+        }
+      }
+    `
+
+    it("should return `Today` label", async () => {
+      const loader = () => {
+        return Promise.resolve({
+          feed: [{ ...notificationFeedItem, date: moment() }],
+          total: 1,
+          total_unread: 1,
+        })
+      }
+      const data = await runAuthenticatedQuery(query, {
+        notificationsFeedLoader: loader,
+      })
+      const edges = data.notificationsConnection.edges
+      const item = edges[0].node
+
+      expect(item.formattedCreatedAt).toEqual("Today")
+    })
+
+    it("should return `Yesterday` label", async () => {
+      const loader = () => {
+        return Promise.resolve({
+          feed: [
+            {
+              ...notificationFeedItem,
+              // 23:59:59 yesterday
+              date: moment().endOf("day").subtract(1, "days"),
+            },
+          ],
+          total: 1,
+          total_unread: 1,
+        })
+      }
+      const data = await runAuthenticatedQuery(query, {
+        notificationsFeedLoader: loader,
+      })
+      const edges = data.notificationsConnection.edges
+      const item = edges[0].node
+
+      expect(item.formattedCreatedAt).toEqual("Yesterday")
+    })
+
+    it("should return `x days ago` label", async () => {
+      const loader = () => {
+        return Promise.resolve({
+          feed: [
+            {
+              ...notificationFeedItem,
+              date: moment().subtract(5, "days"),
+            },
+          ],
+          total: 1,
+          total_unread: 1,
+        })
+      }
+      const data = await runAuthenticatedQuery(query, {
+        notificationsFeedLoader: loader,
+      })
+      const edges = data.notificationsConnection.edges
+      const item = edges[0].node
+
+      expect(item.formattedCreatedAt).toEqual("5 days ago")
+    })
+  })
 })
+
+const notificationFeedItem = {
+  id: "6303f205b54941000843419a",
+  actors: "Works by Damien Hirst",
+  message: "8 Works Added",
+  status: "unread",
+  date: "2022-08-22T21:15:49.000Z",
+  object_ids: ["63036fafbe5cfc000cf358e3", "630392514f13a5000b55ecec"],
+  object: {
+    artist: { id: "damien-hirst", _id: "4d8b926a4eb68a1b2c0000ae" },
+  },
+  activity_type: "ArtworkPublishedActivity",
+  target_href: "/artist/damien-hirst/works-for-sale",
+}
 
 const expectedData = {
   notificationsConnection: {

--- a/src/schema/v2/notifications/__tests__/index.test.ts
+++ b/src/schema/v2/notifications/__tests__/index.test.ts
@@ -94,78 +94,102 @@ describe("notificationsConnection", () => {
   })
 
   describe("with formatted publication date", () => {
-    const query = gql`
-      {
-        notificationsConnection(first: 1) {
-          edges {
-            node {
-              publishedAt
+    describe("the human-friendly date", () => {
+      const query = gql`
+        {
+          notificationsConnection(first: 1) {
+            edges {
+              node {
+                publishedAt(formatted: true)
+              }
             }
           }
         }
-      }
-    `
+      `
 
-    it("should return `Today` label", async () => {
-      const loader = () => {
-        return Promise.resolve({
-          feed: [{ ...notificationFeedItem, date: moment() }],
-          total: 1,
-          total_unread: 1,
+      it("should return `Today` label", async () => {
+        const loader = () => {
+          return Promise.resolve({
+            feed: [{ ...notificationFeedItem, date: moment() }],
+            total: 1,
+            total_unread: 1,
+          })
+        }
+        const data = await runAuthenticatedQuery(query, {
+          notificationsFeedLoader: loader,
         })
-      }
-      const data = await runAuthenticatedQuery(query, {
-        notificationsFeedLoader: loader,
-      })
-      const edges = data.notificationsConnection.edges
-      const item = edges[0].node
+        const edges = data.notificationsConnection.edges
+        const item = edges[0].node
 
-      expect(item.publishedAt).toEqual("Today")
+        expect(item.publishedAt).toEqual("Today")
+      })
+
+      it("should return `Yesterday` label", async () => {
+        const loader = () => {
+          return Promise.resolve({
+            feed: [
+              {
+                ...notificationFeedItem,
+                // 23:59:59 yesterday
+                date: moment().endOf("day").subtract(1, "days"),
+              },
+            ],
+            total: 1,
+            total_unread: 1,
+          })
+        }
+        const data = await runAuthenticatedQuery(query, {
+          notificationsFeedLoader: loader,
+        })
+        const edges = data.notificationsConnection.edges
+        const item = edges[0].node
+
+        expect(item.publishedAt).toEqual("Yesterday")
+      })
+
+      it("should return `x days ago` label", async () => {
+        const loader = () => {
+          return Promise.resolve({
+            feed: [
+              {
+                ...notificationFeedItem,
+                date: moment().subtract(5, "days"),
+              },
+            ],
+            total: 1,
+            total_unread: 1,
+          })
+        }
+        const data = await runAuthenticatedQuery(query, {
+          notificationsFeedLoader: loader,
+        })
+        const edges = data.notificationsConnection.edges
+        const item = edges[0].node
+
+        expect(item.publishedAt).toEqual("5 days ago")
+      })
     })
 
-    it("should return `Yesterday` label", async () => {
-      const loader = () => {
-        return Promise.resolve({
-          feed: [
-            {
-              ...notificationFeedItem,
-              // 23:59:59 yesterday
-              date: moment().endOf("day").subtract(1, "days"),
-            },
-          ],
-          total: 1,
-          total_unread: 1,
-        })
-      }
+    it("should return raw date", async () => {
+      const query = gql`
+        {
+          notificationsConnection(first: 1) {
+            edges {
+              node {
+                publishedAt
+              }
+            }
+          }
+        }
+      `
+
       const data = await runAuthenticatedQuery(query, {
-        notificationsFeedLoader: loader,
+        notificationsFeedLoader,
       })
       const edges = data.notificationsConnection.edges
       const item = edges[0].node
 
-      expect(item.publishedAt).toEqual("Yesterday")
-    })
-
-    it("should return `x days ago` label", async () => {
-      const loader = () => {
-        return Promise.resolve({
-          feed: [
-            {
-              ...notificationFeedItem,
-              date: moment().subtract(5, "days"),
-            },
-          ],
-          total: 1,
-          total_unread: 1,
-        })
-      }
-      const data = await runAuthenticatedQuery(query, {
-        notificationsFeedLoader: loader,
-      })
-      const edges = data.notificationsConnection.edges
-      const item = edges[0].node
-
-      expect(item.publishedAt).toEqual("5 days ago")
+      expect(item.publishedAt).toEqual("2022-08-22T21:15:49Z")
     })
   })
 })

--- a/src/schema/v2/notifications/__tests__/index.test.ts
+++ b/src/schema/v2/notifications/__tests__/index.test.ts
@@ -93,7 +93,7 @@ describe("notificationsConnection", () => {
     })
   })
 
-  describe("with formatted creation date", () => {
+  describe("with formatted publication date", () => {
     const query = gql`
       {
         notificationsConnection(first: 1) {

--- a/src/schema/v2/notifications/index.ts
+++ b/src/schema/v2/notifications/index.ts
@@ -56,16 +56,17 @@ export const NotificationType = new GraphQLObjectType<any, ResolverContext>({
     publishedAt: {
       type: new GraphQLNonNull(GraphQLString),
       args: {
-        formatted: {
-          type: GraphQLBoolean,
+        format: {
+          type: GraphQLString,
           description:
-            'The human-friendly date (e.g. "Today", "Yesterday", "5 days ago")',
+            'pass `RELATIVE` to display the human-friendly date (e.g. "Today", "Yesterday", "5 days ago")',
         },
       },
-      resolve: ({ date }, { formatted }, { defaultTimezone }) => {
+      resolve: ({ date }, { format }, { defaultTimezone }) => {
         const timezone = defaultTimezone ?? DEFAULT_TZ
+        const dateFormat = format ?? "YYYY-MM-DDTHH:mm:ss[Z]"
 
-        if (formatted) {
+        if (format === "RELATIVE") {
           const today = moment.tz(moment(), timezone).startOf("day")
           const createdAt = moment.tz(date, timezone).startOf("day")
           const days = today.diff(createdAt, "days")
@@ -81,7 +82,7 @@ export const NotificationType = new GraphQLObjectType<any, ResolverContext>({
           return `${days} days ago`
         }
 
-        return formatDate(date, "YYYY-MM-DDTHH:mm:ss[Z]", timezone)
+        return formatDate(date, dateFormat, timezone)
       },
     },
     targetHref: {

--- a/src/schema/v2/notifications/index.ts
+++ b/src/schema/v2/notifications/index.ts
@@ -48,7 +48,10 @@ export const NotificationType = new GraphQLObjectType<any, ResolverContext>({
       type: new GraphQLNonNull(GraphQLBoolean),
       resolve: ({ status }) => status === "unread",
     },
-    createdAt: date(({ date }) => date),
+    createdAt: {
+      ...date(({ date }) => date),
+      deprecationReason: "Please use `publishedAt` instead",
+    },
     publishedAt: {
       type: new GraphQLNonNull(GraphQLString),
       resolve: ({ date }, {}, { defaultTimezone }) => {

--- a/src/schema/v2/notifications/index.ts
+++ b/src/schema/v2/notifications/index.ts
@@ -49,7 +49,7 @@ export const NotificationType = new GraphQLObjectType<any, ResolverContext>({
       resolve: ({ status }) => status === "unread",
     },
     createdAt: date(({ date }) => date),
-    formattedCreatedAt: {
+    publishedAt: {
       type: new GraphQLNonNull(GraphQLString),
       resolve: ({ date }, {}, { defaultTimezone }) => {
         const today = moment.tz(moment(), defaultTimezone!).startOf("day")

--- a/src/schema/v2/notifications/index.ts
+++ b/src/schema/v2/notifications/index.ts
@@ -21,6 +21,7 @@ import { artworkConnection } from "../artwork"
 import numeral from "../fields/numeral"
 import { IDFields, NodeInterface } from "../object_identification"
 import moment from "moment-timezone"
+import { DEFAULT_TZ } from "lib/date"
 
 const NotificationTypesEnum = new GraphQLEnumType({
   name: "NotificationTypesEnum",
@@ -55,8 +56,9 @@ export const NotificationType = new GraphQLObjectType<any, ResolverContext>({
     publishedAt: {
       type: new GraphQLNonNull(GraphQLString),
       resolve: ({ date }, {}, { defaultTimezone }) => {
-        const today = moment.tz(moment(), defaultTimezone!).startOf("day")
-        const createdAt = moment.tz(date, defaultTimezone!).startOf("day")
+        const timezone = defaultTimezone ?? DEFAULT_TZ
+        const today = moment.tz(moment(), timezone).startOf("day")
+        const createdAt = moment.tz(date, timezone).startOf("day")
         const days = today.diff(createdAt, "days")
 
         if (days === 0) {

--- a/src/schema/v2/notifications/index.ts
+++ b/src/schema/v2/notifications/index.ts
@@ -20,6 +20,7 @@ import { ResolverContext } from "types/graphql"
 import { artworkConnection } from "../artwork"
 import numeral from "../fields/numeral"
 import { IDFields, NodeInterface } from "../object_identification"
+import moment from "moment-timezone"
 
 const NotificationTypesEnum = new GraphQLEnumType({
   name: "NotificationTypesEnum",
@@ -48,6 +49,24 @@ export const NotificationType = new GraphQLObjectType<any, ResolverContext>({
       resolve: ({ status }) => status === "unread",
     },
     createdAt: date(({ date }) => date),
+    formattedCreatedAt: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ date }, {}, { defaultTimezone }) => {
+        const today = moment.tz(moment(), defaultTimezone!).startOf("day")
+        const createdAt = moment.tz(date, defaultTimezone!).startOf("day")
+        const days = today.diff(createdAt, "days")
+
+        if (days === 0) {
+          return "Today"
+        }
+
+        if (days === 1) {
+          return "Yesterday"
+        }
+
+        return `${days} days ago`
+      },
+    },
     targetHref: {
       type: new GraphQLNonNull(GraphQLString),
       resolve: ({ target_href }) => target_href,

--- a/src/schema/v2/notifications/index.ts
+++ b/src/schema/v2/notifications/index.ts
@@ -81,7 +81,7 @@ export const NotificationType = new GraphQLObjectType<any, ResolverContext>({
           return `${days} days ago`
         }
 
-        return formatDate(date, null, timezone)
+        return formatDate(date, "YYYY-MM-DDTHH:mm:ss[Z]", timezone)
       },
     },
     targetHref: {


### PR DESCRIPTION
Jira ticket: [FX-4313]

### Description
Add a new field for [Notification](https://github.com/artsy/metaphysics/blob/main/src/schema/v2/notifications/index.ts#L34) type to be able to query a formatted date

### Acceptance Criteria
* Formatted date labels
  * `Today` when notification was published today
  * `Yesterday` when notification was published yesterday
  * `x days ago` when the notification was published 2 or more days ago
* It is necessary to take into account the user's time zone

[FX-4313]: https://artsyproduct.atlassian.net/browse/FX-4313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ