### PR TITLE
chore: add comment about the artwork price insights type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2420,6 +2420,7 @@ union ArtworkMutationType =
 
 union ArtworkOrEditionSetType = Artwork | EditionSet
 
+# Insights may not be available for all Artwork Connections due to potential performance issues
 type ArtworkPriceInsights {
   annualLotsSold: Int
   annualValueSoldCents: FormattedNumber

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -99,6 +99,8 @@ export const ArtworkImportSourceEnum = new GraphQLEnumType({
 
 const ArtworkPriceInsightsType = new GraphQLObjectType<any, ResolverContext>({
   name: "ArtworkPriceInsights",
+  description:
+    "Insights may not be available for all Artwork Connections due to potential performance issues",
   fields: {
     artistId: {
       type: GraphQLString,


### PR DESCRIPTION
This PR adds some description to the artwork insights type to mention that it is not available for all artwork connections.
