### PR TITLE
refactor: UpdateCollectorProfileWithID mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15706,6 +15706,10 @@ type UpdateAppSecondFactorPayload {
   secondFactorOrErrors: AppSecondFactorOrErrorsUnion!
 }
 
+type UpdateCollectorProfileFailure {
+  mutationError: GravityMutationError
+}
+
 input UpdateCollectorProfileInput {
   # List of affiliated auction house ids, referencing Galaxy.
   affiliatedAuctionHouseIds: [String]
@@ -15806,54 +15810,17 @@ input UpdateCollectorProfileWithIDInput {
 
 type UpdateCollectorProfileWithIDPayload {
   clientMutationId: String
-  collectorLevel: Int
-  companyName: String
-  companyWebsite: String
-  confirmedBuyerAt(
-    format: String
 
-    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See
-    # http://www.iana.org/time-zones,
-    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-    timezone: String
-  ): String
-  email: String
+  # On success: the collector profile
+  collectorProfileOrError: UpdateCollectorProfileWithIDResponseOrError
+}
 
-  # A globally unique ID.
-  id: ID!
-  institutionalAffiliations: String
-  intents: [String]
+union UpdateCollectorProfileWithIDResponseOrError =
+    UpdateCollectorProfileFailure
+  | UpdateCollectorProfileWithIDSuccess
 
-  # A type-specific ID likely used as a database ID.
-  internalID: ID!
-  loyaltyApplicantAt(
-    format: String
-
-    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See
-    # http://www.iana.org/time-zones,
-    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-    timezone: String
-  ): String
-  name: String
-  privacy: String
-  professionalBuyerAppliedAt(
-    format: String
-
-    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See
-    # http://www.iana.org/time-zones,
-    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-    timezone: String
-  ): String
-  professionalBuyerAt(
-    format: String
-
-    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See
-    # http://www.iana.org/time-zones,
-    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-    timezone: String
-  ): String
-  selfReportedPurchases: String
-  userInterests: [UserInterest]!
+type UpdateCollectorProfileWithIDSuccess {
+  collectorProfile: CollectorProfileType
 }
 
 input UpdateConversationMutationInput {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15706,10 +15706,6 @@ type UpdateAppSecondFactorPayload {
   secondFactorOrErrors: AppSecondFactorOrErrorsUnion!
 }
 
-type UpdateCollectorProfileFailure {
-  mutationError: GravityMutationError
-}
-
 input UpdateCollectorProfileInput {
   # List of affiliated auction house ids, referencing Galaxy.
   affiliatedAuctionHouseIds: [String]
@@ -15783,6 +15779,10 @@ type UpdateCollectorProfilePayload {
   userInterests: [UserInterest]!
 }
 
+type UpdateCollectorProfileWithIDFailure {
+  mutationError: GravityMutationError
+}
+
 input UpdateCollectorProfileWithIDInput {
   # List of affiliated auction house ids, referencing Galaxy.
   affiliatedAuctionHouseIds: [String]
@@ -15816,7 +15816,7 @@ type UpdateCollectorProfileWithIDPayload {
 }
 
 union UpdateCollectorProfileWithIDResponseOrError =
-    UpdateCollectorProfileFailure
+    UpdateCollectorProfileWithIDFailure
   | UpdateCollectorProfileWithIDSuccess
 
 type UpdateCollectorProfileWithIDSuccess {

--- a/src/schema/v2/CollectorProfile/__tests__/updateCollectorProfileWithID.test.ts
+++ b/src/schema/v2/CollectorProfile/__tests__/updateCollectorProfileWithID.test.ts
@@ -1,72 +1,85 @@
 /* eslint-disable promise/always-return */
+import gql from "lib/gql"
 import { runAuthenticatedQuery, runQuery } from "schema/v2/test/utils"
 
 describe("UpdateCollectorProfileWithID", () => {
   it("calls the expected loader with correctly formatted params", async () => {
-    const mutation = `
-        mutation {
-          updateCollectorProfileWithID(input: { id: "5043b8888b3b8145d7005318", professionalBuyer: true, loyaltyApplicant: true, selfReportedPurchases: "trust me i buy art", intents: [BUY_ART_AND_DESIGN], institutionalAffiliations: "example", companyName: "Cool Art Stuff", companyWebsite: "https://artsy.net" }) {
-            internalID
-            name
-            email
-            selfReportedPurchases
-            intents
-            companyName
-            companyWebsite
-            professionalBuyerAt
+    const mutation = gql`
+      mutation {
+        updateCollectorProfileWithID(
+          input: {
+            companyName: "Cool Art Stuff"
+            companyWebsite: "https://artsy.net"
+            clientMutationId: "123"
+            id: "3"
+            professionalBuyer: true
+            loyaltyApplicant: true
+            selfReportedPurchases: "trust me i buy art"
+            intents: [BUY_ART_AND_DESIGN]
+            institutionalAffiliations: "example"
           }
-        } 
-      `
+        ) {
+          collectorProfileOrError {
+            __typename
+            ... on UpdateCollectorProfileWithIDSuccess {
+              collectorProfile {
+                companyName
+                companyWebsite
+                professionalBuyerAt
+                internalID
+                name
+                email
+                selfReportedPurchases
+                intents
+              }
+            }
+            ... on UpdateCollectorProfileWithIDFailure {
+              mutationError {
+                message
+              }
+            }
+          }
+        }
+      }
+    `
 
-    const mockUpdateCollectorProfileLoader = jest.fn().mockReturnValue(
-      Promise.resolve({
-        company_name: "Cool Art Stuff",
-        company_website: "https://artsy.net",
-        professional_buyer_at: "2022-08-15T11:14:55+00:00",
-        id: "3",
-        name: "Percy",
-        email: "percy@cat.com",
-        self_reported_purchases: "treats",
-        intents: ["buy art & design"],
-      })
-    )
-
-    const context = {
-      updateCollectorProfileLoader: mockUpdateCollectorProfileLoader,
-    }
-
-    const expectedProfileData = {
-      companyName: "Cool Art Stuff",
-      companyWebsite: "https://artsy.net",
-      professionalBuyerAt: "2022-08-15T11:14:55+00:00",
-      internalID: "3",
+    const updateCollectorProfileLoaderResponse = {
+      company_name: "Cool Art Stuff",
+      company_website: "https://artsy.net",
+      professional_buyer_at: "2022-08-15T11:14:55+00:00",
+      id: "3",
       name: "Percy",
       email: "percy@cat.com",
-      selfReportedPurchases: "treats",
+      self_reported_purchases: "treats",
       intents: ["buy art & design"],
     }
 
-    expect.assertions(2)
+    const context = {
+      updateCollectorProfileLoader: () =>
+        Promise.resolve(updateCollectorProfileLoaderResponse),
+    }
 
-    const { updateCollectorProfileWithID } = await runAuthenticatedQuery(
-      mutation,
-      context
-    )
+    expect.assertions(1)
 
-    expect(updateCollectorProfileWithID).toEqual(expectedProfileData)
+    const result = await runAuthenticatedQuery(mutation, context)
 
-    expect(mockUpdateCollectorProfileLoader).toBeCalledWith(
-      "5043b8888b3b8145d7005318",
-      {
-        intents: ["buy art & design"],
-        loyalty_applicant: true,
-        professional_buyer: true,
-        self_reported_purchases: "trust me i buy art",
-        institutional_affiliations: "example",
-        company_name: "Cool Art Stuff",
-        company_website: "https://artsy.net",
-      }
-    )
+    expect(result).toEqual({
+      updateCollectorProfileWithID: {
+        collectorProfileOrError: {
+          __typename: "UpdateCollectorProfileWithIDSuccess",
+          collectorProfile: {
+            companyName: "Cool Art Stuff",
+            companyWebsite: "https://artsy.net",
+            professionalBuyerAt: "2022-08-15T11:14:55+00:00",
+            internalID: "3",
+            name: "Percy",
+            email: "percy@cat.com",
+            selfReportedPurchases: "treats",
+            intents: ["buy art & design"],
+          },
+        },
+      },
+    })
   })
 
   it("throws error when data loader is missing", async () => {
@@ -94,5 +107,51 @@ describe("UpdateCollectorProfileWithID", () => {
       // eslint-disable-next-line jest/no-conditional-expect, jest/no-try-expect
       expect(error.message).toEqual(errorResponse)
     }
+  })
+
+  it("returns a GravityMutationError when invalid param is used", async () => {
+    const mutation = gql`
+      mutation {
+        updateCollectorProfileWithID(input: { companyWebsite: "artsy.net" }) {
+          collectorProfileOrError {
+            __typename
+            ... on UpdateCollectorProfileWithIDSuccess {
+              collectorProfile {
+                companyWebsite
+              }
+            }
+            ... on UpdateCollectorProfileWithIDFailure {
+              mutationError {
+                message
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      updateCollectorProfileLoader: () =>
+        Promise.reject(
+          new Error(
+            `https://stagingapi.artsy.net/api/v1/collector_profile/634d721a15077b000eb7e7cf?company_website=artsy.net - {"type":"param_error","message":"Company website url is not valid"}`
+          )
+        ),
+    }
+
+    expect.assertions(1)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      updateCollectorProfileWithID: {
+        collectorProfileOrError: {
+          __typename: "UpdateCollectorProfileWithIDFailure",
+          mutationError: {
+            message: "Company website url is not valid",
+          },
+        },
+      },
+    })
   })
 })

--- a/src/schema/v2/CollectorProfile/mutations/updateCollectorProfileWithID.ts
+++ b/src/schema/v2/CollectorProfile/mutations/updateCollectorProfileWithID.ts
@@ -1,10 +1,47 @@
-import { GraphQLBoolean, GraphQLString, GraphQLList } from "graphql"
+import {
+  GraphQLBoolean,
+  GraphQLString,
+  GraphQLList,
+  GraphQLObjectType,
+  GraphQLUnionType,
+} from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 import { ResolverContext } from "types/graphql"
 import { snakeCase } from "lodash"
-import { CollectorProfileFields } from "../collectorProfile"
+import { CollectorProfileType } from "../collectorProfile"
 import { IntentsType } from "../types/IntentsType"
 import { omit } from "lodash"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateCollectorProfileWithIDSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    collectorProfile: {
+      type: CollectorProfileType,
+      resolve: (result) => result,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateCollectorProfileFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => (typeof err.message === "object" ? err.message : err),
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdateCollectorProfileWithIDResponseOrError",
+  types: [SuccessType, FailureType],
+})
 
 export default mutationWithClientMutationId<any, any, ResolverContext>({
   name: "UpdateCollectorProfileWithID",
@@ -38,8 +75,14 @@ export default mutationWithClientMutationId<any, any, ResolverContext>({
       type: GraphQLString,
     },
   },
-  outputFields: CollectorProfileFields,
-  mutateAndGetPayload: (args, { updateCollectorProfileLoader }) => {
+  outputFields: {
+    collectorProfileOrError: {
+      type: ResponseOrErrorType,
+      description: "On success: the collector profile",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (args, { updateCollectorProfileLoader }) => {
     // snake_case keys for Gravity (keys are the same otherwise)
     const options = Object.keys(args).reduce(
       (acc, key) => ({ ...acc, [snakeCase(key)]: args[key] }),
@@ -52,6 +95,19 @@ export default mutationWithClientMutationId<any, any, ResolverContext>({
       )
     }
 
-    return updateCollectorProfileLoader(args.id, omit(options, "id"))
+    try {
+      const result = await updateCollectorProfileLoader(
+        args.id,
+        omit(options, "id")
+      )
+      return result
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
   },
 })

--- a/src/schema/v2/CollectorProfile/mutations/updateCollectorProfileWithID.ts
+++ b/src/schema/v2/CollectorProfile/mutations/updateCollectorProfileWithID.ts
@@ -28,7 +28,7 @@ const SuccessType = new GraphQLObjectType<any, ResolverContext>({
 })
 
 const FailureType = new GraphQLObjectType<any, ResolverContext>({
-  name: "UpdateCollectorProfileFailure",
+  name: "UpdateCollectorProfileWithIDFailure",
   isTypeOf: (data) => data._type === "GravityMutationError",
   fields: () => ({
     mutationError: {


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4674

This refactors the `UpdateCollectorProfileWithID` _mutation_ adding in the `ResponseOrErrorType` pattern. The primary reason for this refactor is to expose and handle `GravityMutationError` on the client via response payload.

Code search [shows](https://cs.github.com/?scopeName=All+repos&scope=&q=org%3Aartsy+updateCollectorProfileWithID) that this mutation is used only in _Forque_ and so I am updating in place instead of opting for a more graceful switch. Please let me know if I should instead roll this out differently.

<details>
<summary>Click to expand</summary>

![Screen Shot 2022-10-18 at 4 33 04 PM](https://user-images.githubusercontent.com/29984068/196540420-fe594884-0eae-4e79-a7e5-413706715fc7.png)

</details>

---

The affected Forque change is [here](https://github.com/artsy/forque/pull/459).