### PR TITLE
feat: add isEligibleForArtsyGuarantee

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2099,6 +2099,9 @@ type Artwork implements Node & Searchable & Sellable {
   isComparableWithAuctionResults: Boolean
   isDownloadable: Boolean
   isEdition: Boolean
+
+  # Artwork is eligible for the Artsy Guarantee
+  isEligibleForArtsyGuarantee: Boolean!
   isEmbeddableVideo: Boolean
   isForSale: Boolean
   isHangable: Boolean

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -3739,5 +3739,67 @@ describe("Artwork type", () => {
         })
       })
     })
+
+    describe("isEligibleForArtsyGuarantee", () => {
+      const query = `
+        {
+          artwork(id: "foo-bar") {
+            isEligibleForArtsyGuarantee
+          }
+        }
+      `
+
+      it("returns false by default", () => {
+        return runQuery(query, context).then((data) => {
+          expect(data).toEqual({
+            artwork: {
+              isEligibleForArtsyGuarantee: false,
+            },
+          })
+        })
+      })
+
+      it("returns true if work is acquirable", () => {
+        artwork.acquireable = true
+        artwork.offerable = false
+        artwork.offerable_from_inquiry = false
+
+        return runQuery(query, context).then((data) => {
+          expect(data).toEqual({
+            artwork: {
+              isEligibleForArtsyGuarantee: true,
+            },
+          })
+        })
+      })
+
+      it("returns true if work is offerable", () => {
+        artwork.acquireable = false
+        artwork.offerable = true
+        artwork.offerable_from_inquiry = false
+
+        return runQuery(query, context).then((data) => {
+          expect(data).toEqual({
+            artwork: {
+              isEligibleForArtsyGuarantee: true,
+            },
+          })
+        })
+      })
+
+      it("returns true if work is offerable from inquiry", () => {
+        artwork.acquireable = false
+        artwork.offerable = false
+        artwork.offerable_from_inquiry = true
+
+        return runQuery(query, context).then((data) => {
+          expect(data).toEqual({
+            artwork: {
+              isEligibleForArtsyGuarantee: true,
+            },
+          })
+        })
+      })
+    })
   })
 })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -668,6 +668,17 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           return false
         },
       },
+      isEligibleForArtsyGuarantee: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        description: "Artwork is eligible for the Artsy Guarantee",
+        resolve: ({ acquireable, offerable, offerable_from_inquiry }) => {
+          if (acquireable || offerable || offerable_from_inquiry) {
+            return true
+          }
+
+          return false
+        },
+      },
       canRequestLotConditionsReport: {
         type: GraphQLBoolean,
         description:


### PR DESCRIPTION
### Description

Adding a property called `isEligibleForArtsyGuarantee`  to encapsulate conditions of eligibility for [Artsy Guarantee](https://www.artsy.net/buyer-guarantee)


```graphql
{
  artwork(id: "foo-bar") {
    isEligibleForArtsyGuarantee
  }
}
```