### PR TITLE
fix: Adjust logic to get the default artwork images to not return broken images without URL

### DIFF
--- a/src/schema/v2/image/__tests__/index.test.js
+++ b/src/schema/v2/image/__tests__/index.test.js
@@ -8,17 +8,31 @@ describe("getDefault", () => {
   it("returns the default image", () => {
     expect(
       getDefault([
-        { id: "foo", is_default: false },
-        { id: "bar", is_default: true },
-        { id: "baz", is_default: false },
+        { id: "foo", image_url: "a-url", is_default: false },
+        { id: "bar", image_url: "a-url", is_default: true },
+        { id: "baz", image_url: "a-url", is_default: false },
       ]).id
     ).toBe("bar")
   })
 
   it("returns the first object if there is no default", () => {
-    expect(getDefault([{ id: "foo" }, { id: "bar" }, { id: "baz" }]).id).toBe(
-      "foo"
-    )
+    expect(
+      getDefault([
+        { id: "foo", image_url: "a-url" },
+        { id: "bar", image_url: "a-url" },
+        { id: "baz", image_url: "a-url" },
+      ]).id
+    ).toBe("foo")
+  })
+
+  it("filters out broken images without a URL", () => {
+    expect(
+      getDefault([
+        { id: "foo", image_url: "a-url", is_default: false },
+        { id: "bar", is_default: true },
+        { id: "baz", image_url: "a-url", is_default: false },
+      ]).id
+    ).toBe("foo")
   })
 })
 

--- a/src/schema/v2/image/index.ts
+++ b/src/schema/v2/image/index.ts
@@ -29,9 +29,14 @@ export { normalize as normalizeImageData } from "./normalize"
 
 export const getDefault = (images) => {
   if (isArray(images)) {
+    // filter out broken images that don't have a URL
+    const filteredImages = images.filter((image) => image.image_url)
+
     return (
-      find(images, (img) => img.is_default === true || img.default === true) ||
-      first(images)
+      find(
+        filteredImages,
+        (img) => img.is_default === true || img.default === true
+      ) || first(filteredImages)
     )
   }
   return images


### PR DESCRIPTION
Addresses [CX-3058]

## Description

This PR adjusts the logic to get the default artwork images to not return broken images without URL which happened in the case described in the Jira ticket. 


[CX-3058]: https://artsyproduct.atlassian.net/browse/CX-3058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ