### PR TITLE
fix: add a fallback name to User if one is not set

### DIFF
--- a/src/schema/v2/__tests__/user.test.ts
+++ b/src/schema/v2/__tests__/user.test.ts
@@ -86,6 +86,26 @@ describe("User", () => {
     expect(result.emailConfirmationSentAt).toEqual("2022-01-01T00:00:00.000Z")
   })
 
+  it("includes a fallback when a name isn't set", async () => {
+    const query = `
+      {
+        user(id: "percy-z") {
+          name
+        }
+      }
+    `
+
+    const context = {
+      userByIDLoader: () => {
+        return Promise.resolve({})
+      },
+    }
+
+    const { user: result } = await runAuthenticatedQuery(query, context)
+
+    expect(result.name).toEqual("Artsy User")
+  })
+
   describe("userAlreadyExists", () => {
     it("returns true if a user exists", async () => {
       const foundUser = {

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -184,7 +184,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
       name: {
         description: "The given name of the user.",
         type: new GraphQLNonNull(GraphQLString),
-        resolve: ({ name }) => name || "Artsy User",
+        resolve: ({ name }) => name || "Artsy User", // users may lack names, so fall back this non-null field
       },
       email: {
         description: "The given email of the user.",

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -184,6 +184,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
       name: {
         description: "The given name of the user.",
         type: new GraphQLNonNull(GraphQLString),
+        resolve: ({ name }) => name || "Artsy User",
       },
       email: {
         description: "The given email of the user.",


### PR DESCRIPTION
This field is typed as non-null, but there is no such constraint on the backend that actually enforces that.

So, there are a few options:
  - migrate data + enforce constraint on backend
  - remove non-null typing
  - add a fallback

The last option (fallback), is the easiest and is what's implemented here. The first option requires further work elsewhere in the stack, and the middle option will cause some disruption to client repos when this schema is updated as it's a breaking change.