### PR TITLE
feat: Artwork#isEligibleForOnPlatformTransaction

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2105,6 +2105,9 @@ type Artwork implements Node & Searchable & Sellable {
 
   # Artwork is eligible for the Artsy Guarantee
   isEligibleForArtsyGuarantee: Boolean!
+
+  # Artwork is eligible for on-platform transaction
+  isEligibleForOnPlatformTransaction: Boolean!
   isEmbeddableVideo: Boolean
   isForSale: Boolean
   isHangable: Boolean

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -3740,11 +3740,12 @@ describe("Artwork type", () => {
       })
     })
 
-    describe("isEligibleForArtsyGuarantee", () => {
+    describe("isEligibleForArtsyGuarantee/isEligbleForOnPlatformTransaction", () => {
       const query = `
         {
           artwork(id: "foo-bar") {
             isEligibleForArtsyGuarantee
+            isEligibleForOnPlatformTransaction
           }
         }
       `
@@ -3754,6 +3755,7 @@ describe("Artwork type", () => {
           expect(data).toEqual({
             artwork: {
               isEligibleForArtsyGuarantee: false,
+              isEligibleForOnPlatformTransaction: false,
             },
           })
         })
@@ -3768,6 +3770,7 @@ describe("Artwork type", () => {
           expect(data).toEqual({
             artwork: {
               isEligibleForArtsyGuarantee: true,
+              isEligibleForOnPlatformTransaction: true,
             },
           })
         })
@@ -3782,6 +3785,7 @@ describe("Artwork type", () => {
           expect(data).toEqual({
             artwork: {
               isEligibleForArtsyGuarantee: true,
+              isEligibleForOnPlatformTransaction: true,
             },
           })
         })
@@ -3796,6 +3800,7 @@ describe("Artwork type", () => {
           expect(data).toEqual({
             artwork: {
               isEligibleForArtsyGuarantee: true,
+              isEligibleForOnPlatformTransaction: true,
             },
           })
         })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -85,6 +85,18 @@ const has_multiple_editions = (edition_sets) => {
   return edition_sets && edition_sets.length > 1
 }
 
+const isEligibleForOnPlatformTransaction = ({
+  acquireable,
+  offerable,
+  offerable_from_inquiry,
+}) => {
+  if (acquireable || offerable || offerable_from_inquiry) {
+    return true
+  }
+
+  return false
+}
+
 const IMPORT_SOURCES = {
   CONVECTION: { value: "convection" },
   MY_COLLECTION: { value: "my collection" },
@@ -677,12 +689,15 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       isEligibleForArtsyGuarantee: {
         type: new GraphQLNonNull(GraphQLBoolean),
         description: "Artwork is eligible for the Artsy Guarantee",
-        resolve: ({ acquireable, offerable, offerable_from_inquiry }) => {
-          if (acquireable || offerable || offerable_from_inquiry) {
-            return true
-          }
-
-          return false
+        resolve: (artwork) => {
+          return isEligibleForOnPlatformTransaction(artwork)
+        },
+      },
+      isEligibleForOnPlatformTransaction: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        description: "Artwork is eligible for on-platform transaction",
+        resolve: (artwork) => {
+          return isEligibleForOnPlatformTransaction(artwork)
         },
       },
       canRequestLotConditionsReport: {


### PR DESCRIPTION
As we continue to work on the artwork page/screen and associated details, we've realized that it would be useful to have a consistent definition for when an artwork is eligble to transact on-platform. We have a lot of checks for `isAcquireable || isOfferable` in clients. We've recently introduced the notion of "offerable by inquiry" which expands the cases for which an artwork supports on-platform commercial action. Beyond simplifying these client conditionals today, this also gives us a single source of truth we can adjust as this definition changes in the future.

cc/ @anandaroop @nickskalkin @dimatretyak @gkartalis 