### PR TITLE
feat: add partner.documentsConnection query field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11811,13 +11811,13 @@ type Partner implements Node {
   displayWorksSection: Boolean
   distinguishRepresentedArtists: Boolean
 
-  # Retrieve all partner documents for a given partner
+  # Return partner documents if current user has CMS access.
   documentsConnection(
     after: String
     artistID: String
     before: String
 
-    # Return only document(s) included in this list of IDs.
+    # Filter documents by ID.
     documentIDs: [String]
     first: Int
     last: Int
@@ -13571,6 +13571,7 @@ type Query {
     partnerID: String!
     size: Int
   ): PartnerArtistDocumentsConnectionConnection
+    @deprecated(reason: "Prefer `partner.documentsConnection`")
 
   # A list of Artworks for a partner
   partnerArtworks(
@@ -13640,6 +13641,7 @@ type Query {
     showID: String!
     size: Int
   ): PartnerDocumentConnection
+    @deprecated(reason: "Prefer `partner.documentsConnection`")
 
   # Phone number information
   phoneNumber(phoneNumber: String!, regionCode: String): PhoneNumberType
@@ -17318,6 +17320,7 @@ type Viewer {
     partnerID: String!
     size: Int
   ): PartnerArtistDocumentsConnectionConnection
+    @deprecated(reason: "Prefer `partner.documentsConnection`")
 
   # A list of Artworks for a partner
   partnerArtworks(
@@ -17387,6 +17390,7 @@ type Viewer {
     showID: String!
     size: Int
   ): PartnerDocumentConnection
+    @deprecated(reason: "Prefer `partner.documentsConnection`")
 
   # Phone number information
   phoneNumber(phoneNumber: String!, regionCode: String): PhoneNumberType

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11810,6 +11810,19 @@ type Partner implements Node {
   displayFullPartnerPage: Boolean
   displayWorksSection: Boolean
   distinguishRepresentedArtists: Boolean
+
+  # A connection of documents at a partner.
+  documentsConnection(
+    after: String
+    before: String
+
+    # Return only document(s) included in this list of IDs.
+    documentIDs: [String]
+    first: Int
+    last: Int
+    page: Int
+    size: Int
+  ): PartnerDocumentConnection
   featuredShow: Show
 
   # Artworks Elastic Search results
@@ -12254,6 +12267,40 @@ type PartnerCounts {
     format: String
     label: String
   ): FormattedNumber
+}
+
+type PartnerDocument {
+  filename: String!
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+  publicUrl: String!
+  size: Int!
+  title: String!
+  uri: String!
+}
+
+# A connection to a list of items.
+type PartnerDocumentConnection {
+  # A list of edges.
+  edges: [PartnerDocumentEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type PartnerDocumentEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: PartnerDocument
 }
 
 # An edge in a connection.
@@ -13581,6 +13628,19 @@ type Query {
     # The slug or ID of the PartnerCategory
     id: String!
   ): PartnerCategory
+
+  # Retrieve all partner documents for a given partner
+  partnerDocumentsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    page: Int
+
+    # The slug or ID of the Partner
+    partnerID: String!
+    size: Int
+  ): PartnerDocumentConnection
 
   # A list of Partners
   partnersConnection(
@@ -17328,6 +17388,19 @@ type Viewer {
     # The slug or ID of the PartnerCategory
     id: String!
   ): PartnerCategory
+
+  # Retrieve all partner documents for a given partner
+  partnerDocumentsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    page: Int
+
+    # The slug or ID of the Partner
+    partnerID: String!
+    size: Int
+  ): PartnerDocumentConnection
 
   # A list of Partners
   partnersConnection(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11814,12 +11814,14 @@ type Partner implements Node {
   # Retrieve all partner documents for a given partner
   documentsConnection(
     after: String
+    artistID: String
     before: String
 
     # Return only document(s) included in this list of IDs.
     documentIDs: [String]
     first: Int
     last: Int
+    showID: String
   ): PartnerDocumentsConnectionConnection
   featuredShow: Show
 
@@ -12261,7 +12263,9 @@ type PartnerDocument {
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
+  publicUrl: String! @deprecated(reason: "Prefer `publicURL`")
   publicURL: String!
+  size: Int! @deprecated(reason: "Prefer `filesize`")
   title: String!
 }
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11820,8 +11820,6 @@ type Partner implements Node {
     documentIDs: [String]
     first: Int
     last: Int
-    page: Int
-    size: Int
   ): PartnerDocumentsConnectionConnection
   featuredShow: Show
 
@@ -12256,17 +12254,15 @@ type PartnerCounts {
 }
 
 type PartnerDocument {
-  filename: String!
+  filesize: Int!
 
   # A globally unique ID.
   id: ID!
 
   # A type-specific Gravity Mongo Document ID.
   internalID: ID!
-  publicUrl: String!
-  size: Int!
+  publicURL: String!
   title: String!
-  uri: String!
 }
 
 # A connection to a list of items.

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11811,7 +11811,7 @@ type Partner implements Node {
   displayWorksSection: Boolean
   distinguishRepresentedArtists: Boolean
 
-  # A connection of documents at a partner.
+  # Retrieve all partner documents for a given partner
   documentsConnection(
     after: String
     before: String
@@ -11822,7 +11822,7 @@ type Partner implements Node {
     last: Int
     page: Int
     size: Int
-  ): PartnerDocumentConnection
+  ): PartnerDocumentsConnectionConnection
   featuredShow: Show
 
   # Artworks Elastic Search results
@@ -12059,24 +12059,10 @@ type PartnerArtistCounts {
   ): FormattedNumber
 }
 
-type PartnerArtistDocument {
-  filename: String!
-
-  # A globally unique ID.
-  id: ID!
-
-  # A type-specific ID likely used as a database ID.
-  internalID: ID!
-  publicUrl: String!
-  size: Int!
-  title: String!
-  uri: String!
-}
-
 # A connection to a list of items.
-type PartnerArtistDocumentConnection {
+type PartnerArtistDocumentsConnectionConnection {
   # A list of edges.
-  edges: [PartnerArtistDocumentEdge]
+  edges: [PartnerArtistDocumentsConnectionEdge]
   pageCursors: PageCursors!
 
   # Information to aid in pagination.
@@ -12085,12 +12071,12 @@ type PartnerArtistDocumentConnection {
 }
 
 # An edge in a connection.
-type PartnerArtistDocumentEdge {
+type PartnerArtistDocumentsConnectionEdge {
   # A cursor for use in pagination
   cursor: String!
 
   # The item at the end of the edge
-  node: PartnerArtistDocument
+  node: PartnerDocument
 }
 
 # An edge in a connection.
@@ -12275,7 +12261,7 @@ type PartnerDocument {
   # A globally unique ID.
   id: ID!
 
-  # A type-specific ID likely used as a database ID.
+  # A type-specific Gravity Mongo Document ID.
   internalID: ID!
   publicUrl: String!
   size: Int!
@@ -12296,6 +12282,26 @@ type PartnerDocumentConnection {
 
 # An edge in a connection.
 type PartnerDocumentEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: PartnerDocument
+}
+
+# A connection to a list of items.
+type PartnerDocumentsConnectionConnection {
+  # A list of edges.
+  edges: [PartnerDocumentsConnectionEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type PartnerDocumentsConnectionEdge {
   # A cursor for use in pagination
   cursor: String!
 
@@ -12343,40 +12349,6 @@ enum PartnersAggregation {
 type PartnersAggregationResults {
   counts: [AggregationCount]
   slice: PartnersAggregation
-}
-
-type PartnerShowDocument {
-  filename: String!
-
-  # A globally unique ID.
-  id: ID!
-
-  # A type-specific ID likely used as a database ID.
-  internalID: ID!
-  publicUrl: String!
-  size: Int!
-  title: String!
-  uri: String!
-}
-
-# A connection to a list of items.
-type PartnerShowDocumentConnection {
-  # A list of edges.
-  edges: [PartnerShowDocumentEdge]
-  pageCursors: PageCursors!
-
-  # Information to aid in pagination.
-  pageInfo: PageInfo!
-  totalCount: Int
-}
-
-# An edge in a connection.
-type PartnerShowDocumentEdge {
-  # A cursor for use in pagination
-  cursor: String!
-
-  # The item at the end of the edge
-  node: PartnerShowDocument
 }
 
 enum PartnerShowPartnerType {
@@ -13584,7 +13556,7 @@ type Query {
     id: String!
   ): Partner
 
-  # Retrieve all partner artist documents for a given partner and artist
+  # Retrieve all partner documents for a given partner
   partnerArtistDocumentsConnection(
     after: String
 
@@ -13598,7 +13570,7 @@ type Query {
     # The slug or ID of the Partner
     partnerID: String!
     size: Int
-  ): PartnerArtistDocumentConnection
+  ): PartnerArtistDocumentsConnectionConnection
 
   # A list of Artworks for a partner
   partnerArtworks(
@@ -13628,19 +13600,6 @@ type Query {
     # The slug or ID of the PartnerCategory
     id: String!
   ): PartnerCategory
-
-  # Retrieve all partner documents for a given partner
-  partnerDocumentsConnection(
-    after: String
-    before: String
-    first: Int
-    last: Int
-    page: Int
-
-    # The slug or ID of the Partner
-    partnerID: String!
-    size: Int
-  ): PartnerDocumentConnection
 
   # A list of Partners
   partnersConnection(
@@ -13680,7 +13639,7 @@ type Query {
     # The slug or ID of the Show
     showID: String!
     size: Int
-  ): PartnerShowDocumentConnection
+  ): PartnerDocumentConnection
 
   # Phone number information
   phoneNumber(phoneNumber: String!, regionCode: String): PhoneNumberType
@@ -17344,7 +17303,7 @@ type Viewer {
     id: String!
   ): Partner
 
-  # Retrieve all partner artist documents for a given partner and artist
+  # Retrieve all partner documents for a given partner
   partnerArtistDocumentsConnection(
     after: String
 
@@ -17358,7 +17317,7 @@ type Viewer {
     # The slug or ID of the Partner
     partnerID: String!
     size: Int
-  ): PartnerArtistDocumentConnection
+  ): PartnerArtistDocumentsConnectionConnection
 
   # A list of Artworks for a partner
   partnerArtworks(
@@ -17388,19 +17347,6 @@ type Viewer {
     # The slug or ID of the PartnerCategory
     id: String!
   ): PartnerCategory
-
-  # Retrieve all partner documents for a given partner
-  partnerDocumentsConnection(
-    after: String
-    before: String
-    first: Int
-    last: Int
-    page: Int
-
-    # The slug or ID of the Partner
-    partnerID: String!
-    size: Int
-  ): PartnerDocumentConnection
 
   # A list of Partners
   partnersConnection(
@@ -17440,7 +17386,7 @@ type Viewer {
     # The slug or ID of the Show
     showID: String!
     size: Int
-  ): PartnerShowDocumentConnection
+  ): PartnerDocumentConnection
 
   # Phone number information
   phoneNumber(phoneNumber: String!, regionCode: String): PhoneNumberType

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11822,7 +11822,7 @@ type Partner implements Node {
     first: Int
     last: Int
     showID: String
-  ): PartnerDocumentsConnectionConnection
+  ): PartnerDocumentConnection
   featuredShow: Show
 
   # Artworks Elastic Search results
@@ -12060,9 +12060,9 @@ type PartnerArtistCounts {
 }
 
 # A connection to a list of items.
-type PartnerArtistDocumentsConnectionConnection {
+type PartnerArtistDocumentConnection {
   # A list of edges.
-  edges: [PartnerArtistDocumentsConnectionEdge]
+  edges: [PartnerArtistDocumentEdge]
   pageCursors: PageCursors!
 
   # Information to aid in pagination.
@@ -12071,7 +12071,7 @@ type PartnerArtistDocumentsConnectionConnection {
 }
 
 # An edge in a connection.
-type PartnerArtistDocumentsConnectionEdge {
+type PartnerArtistDocumentEdge {
   # A cursor for use in pagination
   cursor: String!
 
@@ -12289,26 +12289,6 @@ type PartnerDocumentEdge {
   node: PartnerDocument
 }
 
-# A connection to a list of items.
-type PartnerDocumentsConnectionConnection {
-  # A list of edges.
-  edges: [PartnerDocumentsConnectionEdge]
-  pageCursors: PageCursors!
-
-  # Information to aid in pagination.
-  pageInfo: PageInfo!
-  totalCount: Int
-}
-
-# An edge in a connection.
-type PartnerDocumentsConnectionEdge {
-  # A cursor for use in pagination
-  cursor: String!
-
-  # The item at the end of the edge
-  node: PartnerDocument
-}
-
 # An edge in a connection.
 type PartnerEdge {
   # A cursor for use in pagination
@@ -12349,6 +12329,26 @@ enum PartnersAggregation {
 type PartnersAggregationResults {
   counts: [AggregationCount]
   slice: PartnersAggregation
+}
+
+# A connection to a list of items.
+type PartnerShowDocumentConnection {
+  # A list of edges.
+  edges: [PartnerShowDocumentEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type PartnerShowDocumentEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: PartnerDocument
 }
 
 enum PartnerShowPartnerType {
@@ -13570,7 +13570,7 @@ type Query {
     # The slug or ID of the Partner
     partnerID: String!
     size: Int
-  ): PartnerArtistDocumentsConnectionConnection
+  ): PartnerArtistDocumentConnection
     @deprecated(reason: "Prefer `partner.documentsConnection`")
 
   # A list of Artworks for a partner
@@ -13640,7 +13640,7 @@ type Query {
     # The slug or ID of the Show
     showID: String!
     size: Int
-  ): PartnerDocumentConnection
+  ): PartnerShowDocumentConnection
     @deprecated(reason: "Prefer `partner.documentsConnection`")
 
   # Phone number information
@@ -17319,7 +17319,7 @@ type Viewer {
     # The slug or ID of the Partner
     partnerID: String!
     size: Int
-  ): PartnerArtistDocumentsConnectionConnection
+  ): PartnerArtistDocumentConnection
     @deprecated(reason: "Prefer `partner.documentsConnection`")
 
   # A list of Artworks for a partner
@@ -17389,7 +17389,7 @@ type Viewer {
     # The slug or ID of the Show
     showID: String!
     size: Int
-  ): PartnerDocumentConnection
+  ): PartnerShowDocumentConnection
     @deprecated(reason: "Prefer `partner.documentsConnection`")
 
   # Phone number information

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -345,6 +345,11 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    partnerDocumentsLoader: gravityLoader<any, { partnerId: string }>(
+      (id) => `partner/${id}/documents`,
+      {},
+      { headers: true }
+    ),
     partnerShowArtworksLoader: gravityLoader<
       any,
       { partner_id: string; show_id: string }

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -323,10 +323,10 @@ export default (accessToken, userID, opts) => {
     partnerAllLoader: gravityLoader((id) => `partner/${id}/all`),
     partnerArtistDocumentsLoader: gravityLoader<
       any,
-      { partnerId: string; artistId: string }
+      { partnerID: string; artistID: string }
     >(
-      ({ partnerId, artistId }) =>
-        `partner/${partnerId}/artist/${artistId}/documents`,
+      ({ partnerID, artistID }) =>
+        `partner/${partnerID}/artist/${artistID}/documents`,
       {},
       { headers: true }
     ),
@@ -345,7 +345,7 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
-    partnerDocumentsLoader: gravityLoader<any, { partnerId: string }>(
+    partnerDocumentsLoader: gravityLoader<any, { id: string }>(
       (id) => `partner/${id}/documents`,
       {},
       { headers: true }
@@ -373,10 +373,10 @@ export default (accessToken, userID, opts) => {
     ),
     partnerShowDocumentsLoader: gravityLoader<
       any,
-      { partnerId: string; showId: string }
+      { partnerID: string; showID: string }
     >(
-      ({ partnerId, showId }) =>
-        `partner/${partnerId}/show/${showId}/documents`,
+      ({ partnerID, showID }) =>
+        `partner/${partnerID}/show/${showID}/documents`,
       {},
       { headers: true }
     ),

--- a/src/schema/v2/__tests__/partnerArtistDocumentsConnection.test.ts
+++ b/src/schema/v2/__tests__/partnerArtistDocumentsConnection.test.ts
@@ -9,17 +9,14 @@ describe("partnerArtistDocumentsConnection", () => {
     response = [
       {
         uri: "partner/name/filename-one.pdf",
-        filename: "filename-one.pdf",
         title: "File One",
       },
       {
         uri: "partner/name/filename-two.pdf",
-        filename: "filename-two.png",
         title: "File Two",
       },
       {
         uri: "partner/name/filename-three.pdf",
-        filename: "filename-three.jpg",
         title: "File Three",
       },
     ]
@@ -46,7 +43,6 @@ describe("partnerArtistDocumentsConnection", () => {
         ) {
           edges {
             node {
-              filename
               title
             }
           }
@@ -61,19 +57,16 @@ describe("partnerArtistDocumentsConnection", () => {
         edges: [
           {
             node: {
-              filename: "filename-one.pdf",
               title: "File One",
             },
           },
           {
             node: {
-              filename: "filename-two.png",
               title: "File Two",
             },
           },
           {
             node: {
-              filename: "filename-three.jpg",
               title: "File Three",
             },
           },

--- a/src/schema/v2/__tests__/partnerDocumentsConnection.test.ts
+++ b/src/schema/v2/__tests__/partnerDocumentsConnection.test.ts
@@ -1,0 +1,169 @@
+import { runQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("partnerDocumentsConnection", () => {
+  let response
+  let context
+
+  beforeEach(() => {
+    response = [
+      {
+        uri: "partner/name/filename-one.pdf",
+        filename: "filename-one.pdf",
+        title: "File One",
+      },
+      {
+        uri: "partner/name/filename-two.pdf",
+        filename: "filename-two.png",
+        title: "File Two",
+      },
+      {
+        uri: "partner/name/filename-three.pdf",
+        filename: "filename-three.jpg",
+        title: "File Three",
+      },
+    ]
+
+    context = {
+      partnerDocumentsLoader: () => {
+        return Promise.resolve({
+          body: response,
+          headers: {
+            "x-total-count": response.length,
+          },
+        })
+      },
+    }
+  })
+
+  it("returns documents", async () => {
+    const query = gql`
+      {
+        partnerDocumentsConnection(partnerID: "partnerID", first: 5) {
+          edges {
+            node {
+              filename
+              title
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      partnerDocumentsConnection: {
+        edges: [
+          {
+            node: {
+              filename: "filename-one.pdf",
+              title: "File One",
+            },
+          },
+          {
+            node: {
+              filename: "filename-two.png",
+              title: "File Two",
+            },
+          },
+          {
+            node: {
+              filename: "filename-three.jpg",
+              title: "File Three",
+            },
+          },
+        ],
+      },
+    })
+  })
+
+  it("returns hasNextPage=true when first is below total", async () => {
+    const query = gql`
+      {
+        partnerDocumentsConnection(partnerID: "partnerID", first: 1) {
+          pageInfo {
+            hasNextPage
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      partnerDocumentsConnection: {
+        pageInfo: {
+          hasNextPage: true,
+        },
+      },
+    })
+  })
+
+  it("returns hasNextPage=false when first is above total", async () => {
+    const query = gql`
+      {
+        partnerDocumentsConnection(partnerID: "partnerID", first: 3) {
+          pageInfo {
+            hasNextPage
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      partnerDocumentsConnection: {
+        pageInfo: {
+          hasNextPage: false,
+        },
+      },
+    })
+  })
+
+  it("loads the total count", async () => {
+    const query = gql`
+      {
+        partnerDocumentsConnection(partnerID: "partnerID", first: 3) {
+          totalCount
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      partnerDocumentsConnection: {
+        totalCount: 3,
+      },
+    })
+  })
+
+  it("returns public links", async () => {
+    const query = gql`
+      {
+        partnerDocumentsConnection(partnerID: "partnerID", first: 3) {
+          edges {
+            node {
+              publicUrl
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+    const edges = data.partnerDocumentsConnection.edges
+
+    expect(edges[0].node.publicUrl).toBe(
+      "https://api.artsy.test/api/v1/partner/name/filename-one.pdf"
+    )
+    expect(edges[1].node.publicUrl).toBe(
+      "https://api.artsy.test/api/v1/partner/name/filename-two.pdf"
+    )
+    expect(edges[2].node.publicUrl).toBe(
+      "https://api.artsy.test/api/v1/partner/name/filename-three.pdf"
+    )
+  })
+})

--- a/src/schema/v2/__tests__/partnerShowDocumentsConnection.test.ts
+++ b/src/schema/v2/__tests__/partnerShowDocumentsConnection.test.ts
@@ -9,17 +9,14 @@ describe("partnerShowDocumentsConnection", () => {
     response = [
       {
         uri: "partner/name/filename-one.pdf",
-        filename: "filename-one.pdf",
         title: "File One",
       },
       {
         uri: "partner/name/filename-two.pdf",
-        filename: "filename-two.png",
         title: "File Two",
       },
       {
         uri: "partner/name/filename-three.pdf",
-        filename: "filename-three.jpg",
         title: "File Three",
       },
     ]
@@ -46,7 +43,6 @@ describe("partnerShowDocumentsConnection", () => {
         ) {
           edges {
             node {
-              filename
               title
             }
           }
@@ -61,19 +57,16 @@ describe("partnerShowDocumentsConnection", () => {
         edges: [
           {
             node: {
-              filename: "filename-one.pdf",
               title: "File One",
             },
           },
           {
             node: {
-              filename: "filename-two.png",
               title: "File Two",
             },
           },
           {
             node: {
-              filename: "filename-three.jpg",
               title: "File Three",
             },
           },

--- a/src/schema/v2/partner.ts
+++ b/src/schema/v2/partner.ts
@@ -32,7 +32,6 @@ import { fields as partnerArtistFields } from "./partner_artist"
 import {
   connectionWithCursorInfo,
   createPageCursors,
-  paginationResolver,
 } from "./fields/pagination"
 import { deprecate } from "lib/deprecation"
 import { articleConnection } from "./article"
@@ -43,7 +42,7 @@ import { truncate } from "lib/helpers"
 import { setVersion } from "./image/normalize"
 import { compact } from "lodash"
 import { InquiryRequestType } from "./partnerInquirerCollectorProfile"
-import { partnerDocumentsConnection } from "./partnerDocumentsConnection"
+import { PartnerDocumentsConnection } from "./partnerDocumentsConnection"
 
 const isFairOrganizer = (type) => type === "FairOrganizer"
 const isGallery = (type) => type === "PartnerGallery"
@@ -484,65 +483,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLString,
         resolve: ({ default_profile_id }) => default_profile_id,
       },
-      documentsConnection: {
-        description: "A connection of documents at a partner.",
-        type: partnerDocumentsConnection.connectionType,
-        args: pageable({
-          documentIDs: {
-            type: new GraphQLList(GraphQLString),
-            description:
-              "Return only document(s) included in this list of IDs.",
-          },
-          page: {
-            type: GraphQLInt,
-          },
-          size: {
-            type: GraphQLInt,
-          },
-        }),
-        resolve: async (_root, args, { partnerDocumentsLoader }) => {
-          if (!partnerDocumentsLoader) {
-            return null
-          }
-
-          const { page, size, offset } = convertConnectionArgsToGravityArgs(
-            args
-          )
-
-          interface GravityArgs {
-            document_ids?: string[]
-            offset: number
-            size: number
-            total_count: boolean
-          }
-
-          const gravityArgs: GravityArgs = {
-            size,
-            offset,
-            total_count: true,
-          }
-
-          if (args.documentIDs) {
-            gravityArgs.document_ids = flatten([args.documentIDs])
-          }
-
-          const { body, headers } = await partnerDocumentsLoader(
-            _root.id,
-            gravityArgs
-          )
-
-          const totalCount = parseInt(headers["x-total-count"] || "0", 10)
-
-          return paginationResolver({
-            totalCount,
-            offset,
-            page,
-            size,
-            body,
-            args,
-          })
-        },
-      },
+      documentsConnection: PartnerDocumentsConnection,
       featuredShow: {
         type: ShowType,
         resolve: async ({ id }, _args, { partnerShowsLoader }) => {

--- a/src/schema/v2/partnerArtistDocumentsConnection.ts
+++ b/src/schema/v2/partnerArtistDocumentsConnection.ts
@@ -1,63 +1,30 @@
-import config from "config"
-import {
-  GraphQLString,
-  GraphQLObjectType,
-  GraphQLNonNull,
-  GraphQLInt,
-} from "graphql"
-import { InternalIDFields } from "./object_identification"
-import { ResolverContext } from "types/graphql"
-import {
-  connectionWithCursorInfo,
-  paginationResolver,
-} from "./fields/pagination"
-import { GraphQLFieldConfig } from "graphql"
 import { pageable } from "relay-cursor-paging"
+import { GraphQLInt, GraphQLNonNull, GraphQLString } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { paginationResolver } from "./fields/pagination"
+import { GraphQLFieldConfig } from "graphql"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { connectionWithCursorInfo } from "schema/v2/fields/pagination"
 
-export const PartnerArtistDocumentType = new GraphQLObjectType<
-  any,
-  ResolverContext
->({
-  name: "PartnerArtistDocument",
-  fields: {
-    ...InternalIDFields,
-    uri: {
-      type: new GraphQLNonNull(GraphQLString),
-    },
-    filename: {
-      type: new GraphQLNonNull(GraphQLString),
-    },
-    title: {
-      type: new GraphQLNonNull(GraphQLString),
-    },
-    size: {
-      type: new GraphQLNonNull(GraphQLInt),
-    },
-    publicUrl: {
-      type: new GraphQLNonNull(GraphQLString),
-      resolve: ({ uri }) => `${config.GRAVITY_API_BASE}/${uri}`,
-    },
-  },
-})
+import { PartnerDocumentType } from "./partnerDocumentsConnection"
 
 export const PartnerArtistDocumentsConnection: GraphQLFieldConfig<
   void,
   ResolverContext
 > = {
+  description: "Retrieve all partner documents for a given partner",
   type: connectionWithCursorInfo({
-    nodeType: PartnerArtistDocumentType,
+    name: "PartnerArtistDocumentsConnection",
+    nodeType: PartnerDocumentType,
   }).connectionType,
-  description:
-    "Retrieve all partner artist documents for a given partner and artist",
   args: pageable({
-    partnerID: {
-      type: new GraphQLNonNull(GraphQLString),
-      description: "The slug or ID of the Partner",
-    },
     artistID: {
       type: new GraphQLNonNull(GraphQLString),
       description: "The slug or ID of the Artist",
+    },
+    partnerID: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The slug or ID of the Partner",
     },
     page: {
       type: GraphQLInt,

--- a/src/schema/v2/partnerArtistDocumentsConnection.ts
+++ b/src/schema/v2/partnerArtistDocumentsConnection.ts
@@ -13,6 +13,7 @@ export const PartnerArtistDocumentsConnection: GraphQLFieldConfig<
   ResolverContext
 > = {
   description: "Retrieve all partner documents for a given partner",
+  deprecationReason: "Prefer `partner.documentsConnection`",
   type: connectionWithCursorInfo({
     name: "PartnerArtistDocumentsConnection",
     nodeType: PartnerDocumentType,
@@ -45,7 +46,7 @@ export const PartnerArtistDocumentsConnection: GraphQLFieldConfig<
       total_count: true,
     }
     const { body, headers } = await partnerArtistDocumentsLoader(
-      { artistId: args.artistID, partnerId: args.partnerID },
+      { artistID: args.artistID, partnerID: args.partnerID },
       gravityOptions
     )
     const totalCount = parseInt(headers["x-total-count"] || "0", 10)

--- a/src/schema/v2/partnerArtistDocumentsConnection.ts
+++ b/src/schema/v2/partnerArtistDocumentsConnection.ts
@@ -15,7 +15,7 @@ export const PartnerArtistDocumentsConnection: GraphQLFieldConfig<
   description: "Retrieve all partner documents for a given partner",
   deprecationReason: "Prefer `partner.documentsConnection`",
   type: connectionWithCursorInfo({
-    name: "PartnerArtistDocumentsConnection",
+    name: "PartnerArtistDocument",
     nodeType: PartnerDocumentType,
   }).connectionType,
   args: pageable({

--- a/src/schema/v2/partnerDocumentsConnection.ts
+++ b/src/schema/v2/partnerDocumentsConnection.ts
@@ -59,7 +59,6 @@ export const PartnerDocumentsConnection: GraphQLFieldConfig<
 > = {
   description: "Return partner documents if current user has CMS access.",
   type: connectionWithCursorInfo({
-    name: "PartnerDocumentsConnection",
     nodeType: PartnerDocumentType,
   }).connectionType,
   args: pageable({

--- a/src/schema/v2/partnerDocumentsConnection.ts
+++ b/src/schema/v2/partnerDocumentsConnection.ts
@@ -1,0 +1,89 @@
+import config from "config"
+import {
+  GraphQLFieldConfig,
+  GraphQLInt,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { pageable } from "relay-cursor-paging"
+import {
+  connectionWithCursorInfo,
+  paginationResolver,
+} from "schema/v2/fields/pagination"
+import { ResolverContext } from "types/graphql"
+import { InternalIDFields } from "./object_identification"
+
+const PartnerDocumentType = new GraphQLObjectType<any, ResolverContext>({
+  name: "PartnerDocument",
+  fields: {
+    ...InternalIDFields,
+    uri: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    filename: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    title: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    size: {
+      type: new GraphQLNonNull(GraphQLInt),
+    },
+    publicUrl: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ uri }) => `${config.GRAVITY_API_BASE}/${uri}`,
+    },
+  },
+})
+
+export const partnerDocumentsConnection = connectionWithCursorInfo({
+  nodeType: PartnerDocumentType,
+})
+
+export const PartnerDocumentsConnection: GraphQLFieldConfig<
+  void,
+  ResolverContext
+> = {
+  description: "Retrieve all partner documents for a given partner",
+  type: partnerDocumentsConnection.connectionType,
+  args: pageable({
+    partnerID: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The slug or ID of the Partner",
+    },
+    page: {
+      type: GraphQLInt,
+    },
+    size: {
+      type: GraphQLInt,
+    },
+  }),
+  resolve: async (_root, args, { partnerDocumentsLoader }) => {
+    if (!partnerDocumentsLoader) {
+      return null
+    }
+
+    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+    const gravityOptions = {
+      size,
+      offset,
+      total_count: true,
+    }
+    const { body, headers } = await partnerDocumentsLoader(
+      { partnerId: args.partnerID },
+      gravityOptions
+    )
+    const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+    return paginationResolver({
+      totalCount,
+      offset,
+      page,
+      size,
+      body,
+      args,
+    })
+  },
+}

--- a/src/schema/v2/partnerShowDocumentsConnection.ts
+++ b/src/schema/v2/partnerShowDocumentsConnection.ts
@@ -1,11 +1,4 @@
-import config from "config"
-import {
-  GraphQLString,
-  GraphQLObjectType,
-  GraphQLNonNull,
-  GraphQLInt,
-} from "graphql"
-import { InternalIDFields } from "./object_identification"
+import { GraphQLString, GraphQLNonNull, GraphQLInt } from "graphql"
 import { ResolverContext } from "types/graphql"
 import {
   connectionWithCursorInfo,
@@ -14,39 +7,14 @@ import {
 import { GraphQLFieldConfig } from "graphql"
 import { pageable } from "relay-cursor-paging"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
-
-export const PartnerShowDocumentType = new GraphQLObjectType<
-  any,
-  ResolverContext
->({
-  name: "PartnerShowDocument",
-  fields: {
-    ...InternalIDFields,
-    uri: {
-      type: new GraphQLNonNull(GraphQLString),
-    },
-    filename: {
-      type: new GraphQLNonNull(GraphQLString),
-    },
-    title: {
-      type: new GraphQLNonNull(GraphQLString),
-    },
-    size: {
-      type: new GraphQLNonNull(GraphQLInt),
-    },
-    publicUrl: {
-      type: new GraphQLNonNull(GraphQLString),
-      resolve: ({ uri }) => `${config.GRAVITY_API_BASE}/${uri}`,
-    },
-  },
-})
+import { PartnerDocumentType } from "./partnerDocumentsConnection"
 
 export const PartnerShowDocumentsConnection: GraphQLFieldConfig<
   void,
   ResolverContext
 > = {
   type: connectionWithCursorInfo({
-    nodeType: PartnerShowDocumentType,
+    nodeType: PartnerDocumentType,
   }).connectionType,
   description:
     "Retrieve all partner show documents for a given partner and show",

--- a/src/schema/v2/partnerShowDocumentsConnection.ts
+++ b/src/schema/v2/partnerShowDocumentsConnection.ts
@@ -14,6 +14,7 @@ export const PartnerShowDocumentsConnection: GraphQLFieldConfig<
   ResolverContext
 > = {
   type: connectionWithCursorInfo({
+    name: "PartnerShowDocument",
     nodeType: PartnerDocumentType,
   }).connectionType,
   description:

--- a/src/schema/v2/partnerShowDocumentsConnection.ts
+++ b/src/schema/v2/partnerShowDocumentsConnection.ts
@@ -18,6 +18,7 @@ export const PartnerShowDocumentsConnection: GraphQLFieldConfig<
   }).connectionType,
   description:
     "Retrieve all partner show documents for a given partner and show",
+  deprecationReason: "Prefer `partner.documentsConnection`",
   args: pageable({
     partnerID: {
       type: new GraphQLNonNull(GraphQLString),
@@ -46,7 +47,7 @@ export const PartnerShowDocumentsConnection: GraphQLFieldConfig<
       total_count: true,
     }
     const { body, headers } = await partnerShowDocumentsLoader(
-      { showId: args.showID, partnerId: args.partnerID },
+      { showID: args.showID, partnerID: args.partnerID },
       gravityOptions
     )
     const totalCount = parseInt(headers["x-total-count"] || "0", 10)

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -155,7 +155,6 @@ import { PartnerShowDocumentsConnection } from "./partnerShowDocumentsConnection
 import { bulkUpdatePartnerArtworksMutation } from "./bulkUpdatePartnerArtworksMutation"
 import { NotificationsConnection } from "./notifications"
 import { markAllNotificationsAsReadMutation } from "./me/mark_all_notifications_as_read_mutation"
-import { PartnerDocumentsConnection } from "./partnerDocumentsConnection"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -235,7 +234,6 @@ const rootFields = {
   partnerArtworks: PartnerArtworks,
   partnerCategories: PartnerCategories,
   partnerCategory: PartnerCategory,
-  partnerDocumentsConnection: PartnerDocumentsConnection,
   partnerShowDocumentsConnection: PartnerShowDocumentsConnection,
   partnersConnection: PartnersConnection,
   phoneNumber: PhoneNumber,

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -155,6 +155,7 @@ import { PartnerShowDocumentsConnection } from "./partnerShowDocumentsConnection
 import { bulkUpdatePartnerArtworksMutation } from "./bulkUpdatePartnerArtworksMutation"
 import { NotificationsConnection } from "./notifications"
 import { markAllNotificationsAsReadMutation } from "./me/mark_all_notifications_as_read_mutation"
+import { PartnerDocumentsConnection } from "./partnerDocumentsConnection"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -234,6 +235,7 @@ const rootFields = {
   partnerArtworks: PartnerArtworks,
   partnerCategories: PartnerCategories,
   partnerCategory: PartnerCategory,
+  partnerDocumentsConnection: PartnerDocumentsConnection,
   partnerShowDocumentsConnection: PartnerShowDocumentsConnection,
   partnersConnection: PartnersConnection,
   phoneNumber: PhoneNumber,


### PR DESCRIPTION
This PR resolves: https://artsyproduct.atlassian.net/browse/MOPLAT-477

To fetch documents of the partner by its ID(s)

- [x] modify endpoint in gravity - https://github.com/artsy/gravity/pull/15808


**Query**

```graphql
{
  partner(id: "partnerID") {
    documentsByID: documentsConnection(first: 10, documentIDs: ["4faae457c056c20001000113", "4fc3b2b06c53ad0001000883"]) {
      edges {
        node {
          title
        }
      }
    }

    documentsByArtist: documentsConnection(first: 10, artistID: "abe-ajax") {
      edges {
        node {
          title
        }
      }
    }

    documentsByShow: documentsConnection(first: 10, showID: "folio-test-partner-mega-show-with-lots-of-artworks") {
      edges {
        node {
          title
        }
      }
    }
  }
}
```

**Response**

```json
{
  "partner": {
    "documentsByID": {
      "edges": [
        {
          "node": {
            "title": "hi"
          }
        },
        {
          "node": {
            "title": "hi"
          }
        }
      ]
    },
    "documentsByArtist": {
      "edges": [
        {
          "node": {
            "title": "Bla bl;a"
          }
        }
      ]
    },
    "documentsByShow": {
      "edges": [
        {
          "node": {
            "title": "test"
          }
        }
      ]
    }
  }
}
```