### PR TITLE
feat(video): adds id

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16794,6 +16794,7 @@ union VanityURLEntityType = Fair | Partner
 type Video {
   # The height of the video
   height: Int!
+  id: ID!
 
   # The url of the video
   url: String!

--- a/src/schema/v2/types/Video.ts
+++ b/src/schema/v2/types/Video.ts
@@ -1,15 +1,23 @@
 import {
+  GraphQLID,
   GraphQLInt,
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
 } from "graphql"
+import uuid from "uuid/v5"
 import { ResolverContext } from "types/graphql"
 
 export const VideoType = new GraphQLObjectType<any, ResolverContext>({
   name: "Video",
   description: "An object containing video metadata",
   fields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLID),
+      resolve: ({ url }) => {
+        return uuid(url, uuid.URL)
+      },
+    },
     url: {
       description: "The url of the video",
       type: GraphQLNonNull(GraphQLString),


### PR DESCRIPTION
So this just encodes the URL as an ID. I realize we can parse the ID out but that makes an assumption about the service. Then again, the way we're doing width/height also makes an assumption about the underlying service.

I do very much wish we had a real underlying model with more metadata here. It makes it hard to do the union type of Image/Video since fields conflict. Anyway: we _always_ need IDs or the Relay cache is gonna break.