### PR TITLE
fix(image): marks image width/height as non-nullable

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9495,7 +9495,7 @@ type Image {
     width: Int!
   ): CroppedImageUrl
   deepZoom: DeepZoom
-  height: Int
+  height: Int!
   href: String
   imageURL: String
   imageVersions: [String]
@@ -9531,7 +9531,7 @@ type Image {
   title: String
   url(version: [String]): String
   versions: [String]
-  width: Int
+  width: Int!
 }
 
 type ImageSearch {

--- a/src/schema/v2/image/index.ts
+++ b/src/schema/v2/image/index.ts
@@ -61,8 +61,8 @@ export const ImageType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
     },
     height: {
-      type: GraphQLInt,
-      resolve: ({ original_height }) => original_height,
+      type: new GraphQLNonNull(GraphQLInt),
+      resolve: ({ original_height }) => original_height || 0,
     },
     imageURL: {
       type: GraphQLString,
@@ -137,8 +137,8 @@ export const ImageType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
     },
     width: {
-      type: GraphQLInt,
-      resolve: ({ original_width }) => original_width,
+      type: new GraphQLNonNull(GraphQLInt),
+      resolve: ({ original_width }) => original_width || 0,
     },
     url: VersionedUrl,
     versions: {


### PR DESCRIPTION
I think we need to mark these as non-nullable and just fallback to 0. It's a little weird since: _sometimes_ images might be missing geometry. We want to be able to query for a `figure`'s dimensions without the types conflicting.

I believe nothing of consequence should happen here. There's a few minor places in Force where we use a `??` fallback. What we'll have to do is just switch those to `||`, which I'll do now before converting off draft.