### PR TITLE
chore(video): Migrate url -> playerUrl

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16796,6 +16796,9 @@ type Video {
   height: Int!
   id: ID!
 
+  # Returns a full-qualified, embeddable iframe player for the video
+  playerUrl: String!
+
   # The url of the video
   url: String!
 

--- a/src/schema/v2/artwork/__tests__/utilities.test.ts
+++ b/src/schema/v2/artwork/__tests__/utilities.test.ts
@@ -197,6 +197,7 @@ describe("getFigures", () => {
       {
         type: "Video",
         url: "video-id?id=foo&width=200&height=300",
+        playerUrl: "video-id?id=foo&width=200&height=300",
         width: 200,
         height: 300,
       },
@@ -221,6 +222,7 @@ describe("getFigures", () => {
       {
         type: "Video",
         url: "video-id?id=foo&width=200&height=300",
+        playerUrl: "video-id?id=foo&width=200&height=300",
         width: 200,
         height: 300,
       },

--- a/src/schema/v2/artwork/utilities.ts
+++ b/src/schema/v2/artwork/utilities.ts
@@ -88,6 +88,7 @@ export const getFigures = ({
   let videos = [] as {
     type: string
     url: string
+    playerUrl: string
     width: number
     height: number
   }[]
@@ -99,6 +100,7 @@ export const getFigures = ({
       {
         type: "Video",
         url: external_video_id,
+        playerUrl: external_video_id,
         width: Number(width),
         height: Number(height),
       },

--- a/src/schema/v2/types/Video.ts
+++ b/src/schema/v2/types/Video.ts
@@ -22,6 +22,11 @@ export const VideoType = new GraphQLObjectType<any, ResolverContext>({
       description: "The url of the video",
       type: GraphQLNonNull(GraphQLString),
     },
+    playerUrl: {
+      description:
+        "Returns a full-qualified, embeddable iframe player for the video",
+      type: GraphQLNonNull(GraphQLString),
+    },
     height: {
       description: "The height of the video",
       type: GraphQLNonNull(GraphQLInt),


### PR DESCRIPTION
This migrates `url` to `playerUrl` for clarity. A follow-up PR will remove `url` next, after Force and MP is deployed. 