### PR TITLE
chore(video): Remove `url` field on video

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16799,9 +16799,6 @@ type Video {
   # Returns a full-qualified, embeddable iframe player for the video
   playerUrl: String!
 
-  # The url of the video
-  url: String!
-
   # The width of the video
   width: Int!
 }

--- a/src/schema/v2/artwork/__tests__/utilities.test.ts
+++ b/src/schema/v2/artwork/__tests__/utilities.test.ts
@@ -196,7 +196,6 @@ describe("getFigures", () => {
       { image_url: "bar", type: "Image" },
       {
         type: "Video",
-        url: "video-id?id=foo&width=200&height=300",
         playerUrl: "video-id?id=foo&width=200&height=300",
         width: 200,
         height: 300,
@@ -221,7 +220,6 @@ describe("getFigures", () => {
     expect(data).toEqual([
       {
         type: "Video",
-        url: "video-id?id=foo&width=200&height=300",
         playerUrl: "video-id?id=foo&width=200&height=300",
         width: 200,
         height: 300,

--- a/src/schema/v2/artwork/utilities.ts
+++ b/src/schema/v2/artwork/utilities.ts
@@ -87,7 +87,6 @@ export const getFigures = ({
 
   let videos = [] as {
     type: string
-    url: string
     playerUrl: string
     width: number
     height: number
@@ -99,7 +98,6 @@ export const getFigures = ({
     videos = [
       {
         type: "Video",
-        url: external_video_id,
         playerUrl: external_video_id,
         width: Number(width),
         height: Number(height),

--- a/src/schema/v2/types/Video.ts
+++ b/src/schema/v2/types/Video.ts
@@ -18,10 +18,6 @@ export const VideoType = new GraphQLObjectType<any, ResolverContext>({
         return uuid(url, uuid.URL)
       },
     },
-    url: {
-      description: "The url of the video",
-      type: GraphQLNonNull(GraphQLString),
-    },
     playerUrl: {
       description:
         "Returns a full-qualified, embeddable iframe player for the video",


### PR DESCRIPTION
Follow up to https://github.com/artsy/metaphysics/pull/4501

Removes the `url` field for now. 