### PR TITLE
fix(artist): correctly passes size argument

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1290,6 +1290,8 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     # Get only articles with 'standard', 'feature', 'series' or 'video' layouts.
     inEditorialFeed: Boolean
     last: Int
+
+    # DEPRECATION REASON: Use `size` instead
     limit: Int
     page: Int
     size: Int

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -105,6 +105,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
           sort: ArticleSorts,
           limit: {
             type: GraphQLInt,
+            description: "DEPRECATION REASON: Use `size` instead",
           },
           inEditorialFeed: {
             type: GraphQLBoolean,
@@ -125,9 +126,8 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
             published: true,
             artist_id: _id,
             in_editorial_feed: args.inEditorialFeed,
-            limit: args.limit,
+            limit: size,
             offset,
-            size,
             sort: args.sort,
           })
 


### PR DESCRIPTION
* Positron apparently supports BOTH `size` and `limit` params, but `size` is capped at `10` because of a bug where there's a default `limit` of `10`
* Someone exposed `limit` as an argument here which is Positron-specific and we should strive for a consistent pagination interface on Metaphysics' side of things. I'm not removing limit because I don't want to break the schema, but it won't work. I wish there was a proper way to deprecate arguments.