### PR TITLE
feat: admin note includes creator name when available

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16537,9 +16537,6 @@ type UserAddressEdge {
 union UserAddressOrErrorsUnion = Errors | UserAddress
 
 type UserAdminNotes {
-  # The name of the admin user who created the note
-  adminName: String
-
   # The body of the admin note
   body: String!
   createdAt(
@@ -16550,6 +16547,9 @@ type UserAdminNotes {
     # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String
+
+  # The user who created the note
+  creator: User
 
   # A globally unique ID.
   id: ID!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16537,6 +16537,9 @@ type UserAddressEdge {
 union UserAddressOrErrorsUnion = Errors | UserAddress
 
 type UserAdminNotes {
+  # The name of the admin user who created the note
+  adminName: String
+
   # The body of the admin note
   body: String!
   createdAt(

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -49,7 +49,7 @@ export const UserAdminNoteType = new GraphQLObjectType<any, ResolverContext>({
       resolve: ({ created_by }, _args, { userByIDLoader }) => {
         if (!userByIDLoader) {
           throw new Error(
-            "Loader not found. You must supply an X-Access-Token header."
+            "An X-Access-Token header is required to perform this action."
           )
         }
 
@@ -69,7 +69,7 @@ export const UserAdminNotesField: GraphQLFieldConfig<any, ResolverContext> = {
   resolve: async ({ id }, {}, { userAdminNotesLoader }) => {
     if (!userAdminNotesLoader) {
       throw new Error(
-        "You need to pass a X-Access-Token header to perform this action"
+        "An X-Access-Token header is required to perform this action."
       )
     }
 
@@ -91,7 +91,7 @@ export const PartnerAccessField: GraphQLFieldConfig<any, ResolverContext> = {
   resolve: async ({ id }, {}, { userAccessControlLoader }) => {
     if (!userAccessControlLoader) {
       throw new Error(
-        "You need to pass a X-Access-Token header to perform this action"
+        "An X-Access-Token header is required to perform this action."
       )
     }
 
@@ -110,7 +110,7 @@ export const ProfileAccessField: GraphQLFieldConfig<any, ResolverContext> = {
   resolve: async ({ id }, {}, { userAccessControlLoader }) => {
     if (!userAccessControlLoader) {
       throw new Error(
-        "You need to pass a X-Access-Token header to perform this action"
+        "An X-Access-Token header is required to perform this action."
       )
     }
 
@@ -144,7 +144,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
         ) => {
           if (!userAccessControlLoaderAllProperties) {
             throw new Error(
-              "Loader not found. You must supply an X-Access-Token header."
+              "An X-Access-Token header is required to perform this action."
             )
           }
 
@@ -187,7 +187,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
         resolve: async ({ id: user_id }, {}, { collectorProfilesLoader }) => {
           if (!collectorProfilesLoader)
             throw new Error(
-              "Loader not found. You must supply an X-Access-Token header."
+              "An X-Access-Token header is required to perform this action."
             )
 
           const { body: profiles } = await collectorProfilesLoader({
@@ -262,7 +262,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
         resolve: async ({ id }, args, { userInquiryRequestsLoader }) => {
           if (!userInquiryRequestsLoader) {
             throw new Error(
-              "Loader not found. You must supply an X-Access-Token header."
+              "An X-Access-Token header is required to perform this action."
             )
           }
 
@@ -293,7 +293,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
         resolve: async ({ id }, args, { userInterestsLoader }) => {
           if (!userInterestsLoader) {
             throw new Error(
-              "Loader not found. You must supply an X-Access-Token header."
+              "An X-Access-Token header is required to perform this action."
             )
           }
 
@@ -328,7 +328,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
               resolve: async ({ id }, args, { userArtistFollowsLoader }) => {
                 if (!userArtistFollowsLoader) {
                   throw new Error(
-                    "Loader not found. You must supply an X-Access-Token header."
+                    "An X-Access-Token header is required to perform this action."
                   )
                 }
                 const {
@@ -359,7 +359,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
               resolve: async ({ id }, args, { userGeneFollowsLoader }) => {
                 if (!userGeneFollowsLoader) {
                   throw new Error(
-                    "Loader not found. You must supply an X-Access-Token header."
+                    "An X-Access-Token header is required to perform this action."
                   )
                 }
                 const {
@@ -401,7 +401,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
         resolve: async ({ id }, args, { purchasesLoader }) => {
           if (!purchasesLoader) {
             throw new Error(
-              "Loader not found. You must supply an X-Access-Token header."
+              "An X-Access-Token header is required to perform this action."
             )
           }
 

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -43,6 +43,24 @@ export const UserAdminNoteType = new GraphQLObjectType<any, ResolverContext>({
       type: new GraphQLNonNull(GraphQLString),
     },
     createdAt: date(({ created_at }) => created_at),
+    adminName: {
+      description: "The name of the admin user who created the note",
+      type: GraphQLString,
+      resolve: async ({ created_by }, {}, { userByIDLoader }) => {
+        if (!userByIDLoader) {
+          throw new Error(
+            "Loader not found. You must supply an X-Access-Token header."
+          )
+        }
+
+        if (!created_by) {
+          return null // This is a legacy note, associated user is not available
+        }
+
+        const { name } = await userByIDLoader(created_by)
+        return name
+      },
+    },
   }),
 })
 

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -43,10 +43,10 @@ export const UserAdminNoteType = new GraphQLObjectType<any, ResolverContext>({
       type: new GraphQLNonNull(GraphQLString),
     },
     createdAt: date(({ created_at }) => created_at),
-    adminName: {
-      description: "The name of the admin user who created the note",
-      type: GraphQLString,
-      resolve: async ({ created_by }, {}, { userByIDLoader }) => {
+    creator: {
+      description: "The user who created the note",
+      type: UserType,
+      resolve: ({ created_by }, {}, { userByIDLoader }) => {
         if (!userByIDLoader) {
           throw new Error(
             "Loader not found. You must supply an X-Access-Token header."
@@ -57,8 +57,7 @@ export const UserAdminNoteType = new GraphQLObjectType<any, ResolverContext>({
           return null // This is a legacy note, associated user is not available
         }
 
-        const { name } = await userByIDLoader(created_by)
-        return name
+        return userByIDLoader(created_by)
       },
     },
   }),

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -46,7 +46,7 @@ export const UserAdminNoteType = new GraphQLObjectType<any, ResolverContext>({
     creator: {
       description: "The user who created the note",
       type: UserType,
-      resolve: ({ created_by }, {}, { userByIDLoader }) => {
+      resolve: ({ created_by }, _args, { userByIDLoader }) => {
         if (!userByIDLoader) {
           throw new Error(
             "Loader not found. You must supply an X-Access-Token header."

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -49,7 +49,7 @@ export const UserAdminNoteType = new GraphQLObjectType<any, ResolverContext>({
       resolve: ({ created_by }, _args, { userByIDLoader }) => {
         if (!userByIDLoader) {
           throw new Error(
-            "An X-Access-Token header is required to perform this action."
+            "A X-Access-Token header is required to perform this action."
           )
         }
 
@@ -69,7 +69,7 @@ export const UserAdminNotesField: GraphQLFieldConfig<any, ResolverContext> = {
   resolve: async ({ id }, {}, { userAdminNotesLoader }) => {
     if (!userAdminNotesLoader) {
       throw new Error(
-        "An X-Access-Token header is required to perform this action."
+        "A X-Access-Token header is required to perform this action."
       )
     }
 
@@ -91,7 +91,7 @@ export const PartnerAccessField: GraphQLFieldConfig<any, ResolverContext> = {
   resolve: async ({ id }, {}, { userAccessControlLoader }) => {
     if (!userAccessControlLoader) {
       throw new Error(
-        "An X-Access-Token header is required to perform this action."
+        "A X-Access-Token header is required to perform this action."
       )
     }
 
@@ -110,7 +110,7 @@ export const ProfileAccessField: GraphQLFieldConfig<any, ResolverContext> = {
   resolve: async ({ id }, {}, { userAccessControlLoader }) => {
     if (!userAccessControlLoader) {
       throw new Error(
-        "An X-Access-Token header is required to perform this action."
+        "A X-Access-Token header is required to perform this action."
       )
     }
 
@@ -144,7 +144,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
         ) => {
           if (!userAccessControlLoaderAllProperties) {
             throw new Error(
-              "An X-Access-Token header is required to perform this action."
+              "A X-Access-Token header is required to perform this action."
             )
           }
 
@@ -187,7 +187,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
         resolve: async ({ id: user_id }, {}, { collectorProfilesLoader }) => {
           if (!collectorProfilesLoader)
             throw new Error(
-              "An X-Access-Token header is required to perform this action."
+              "A X-Access-Token header is required to perform this action."
             )
 
           const { body: profiles } = await collectorProfilesLoader({
@@ -262,7 +262,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
         resolve: async ({ id }, args, { userInquiryRequestsLoader }) => {
           if (!userInquiryRequestsLoader) {
             throw new Error(
-              "An X-Access-Token header is required to perform this action."
+              "A X-Access-Token header is required to perform this action."
             )
           }
 
@@ -293,7 +293,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
         resolve: async ({ id }, args, { userInterestsLoader }) => {
           if (!userInterestsLoader) {
             throw new Error(
-              "An X-Access-Token header is required to perform this action."
+              "A X-Access-Token header is required to perform this action."
             )
           }
 
@@ -328,7 +328,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
               resolve: async ({ id }, args, { userArtistFollowsLoader }) => {
                 if (!userArtistFollowsLoader) {
                   throw new Error(
-                    "An X-Access-Token header is required to perform this action."
+                    "A X-Access-Token header is required to perform this action."
                   )
                 }
                 const {
@@ -359,7 +359,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
               resolve: async ({ id }, args, { userGeneFollowsLoader }) => {
                 if (!userGeneFollowsLoader) {
                   throw new Error(
-                    "An X-Access-Token header is required to perform this action."
+                    "A X-Access-Token header is required to perform this action."
                   )
                 }
                 const {
@@ -401,7 +401,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
         resolve: async ({ id }, args, { purchasesLoader }) => {
           if (!purchasesLoader) {
             throw new Error(
-              "An X-Access-Token header is required to perform this action."
+              "A X-Access-Token header is required to perform this action."
             )
           }
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4713

This builds on the [recent change](https://github.com/artsy/gravity/pull/15838) to the admin note API which exposed the `created_by` field (_user ID_) on the note.

As far as this PR, it updates the `UserAdminNoteType` to include a new field `creator` which, using the `created_by` field coming from gravity, _resolves_ using `userByIDLoader` to return the `user` who created the note.

`null` is returned in case of [legacy note](https://github.com/artsy/metaphysics/pull/4515#discussion_r1019651031) where the`created_by` field was never set during note creation:

Example shape of admin notes with `body` and `creator` selecting only the _name_ field would look like so:

![Screen Shot 2022-11-11 at 9 30 02 AM](https://user-images.githubusercontent.com/29984068/201361630-8345775e-1c77-469a-ba26-b0f303185b0c.png)

---

I _could really use some advice_ as far as how to test this change. I have been trying to modify [this realted test](https://github.com/artsy/metaphysics/blob/main/src/schema/v2/__tests__/user.test.ts#L898-L945) to include the new shape but haven't been able to get it to work.