### PR TITLE
feat(FX-4437): Add curated marketing collections query field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10075,6 +10075,7 @@ type MarketingCollection {
   showHeaderArtworksRail: Boolean!
   slug: String!
   thumbnail: String
+  thumbnailImage: Image
   title: String!
   updatedAt: ISO8601DateTime!
 }

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13289,12 +13289,7 @@ type Query {
     # The ID of the Credit Card
     id: String!
   ): CreditCard
-  curatedMarketingCollections(
-    after: String
-    before: String
-    first: Int
-    last: Int
-  ): [MarketingCollection]
+  curatedMarketingCollections(size: Int): [MarketingCollection]
   departments: [Department!]!
 
   # Get an image info

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13288,6 +13288,12 @@ type Query {
     # The ID of the Credit Card
     id: String!
   ): CreditCard
+  curatedMarketingCollections(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): [MarketingCollection]
   departments: [Department!]!
 
   # Get an image info

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -617,6 +617,20 @@ describe("gravity/stitching", () => {
     })
   })
 
+  describe("#Query", () => {
+    describe("#curatedMarketingCollections in Query", () => {
+      it("extends the Query type with a curatedMarketingCollections field", async () => {
+        const mergedSchema = await getGravityMergedSchema()
+        const rootFields = await getFieldsForTypeFromSchema(
+          "Query",
+          mergedSchema
+        )
+
+        expect(rootFields).toContain("curatedMarketingCollections")
+      })
+    })
+  })
+
   describe("#artists", () => {
     it("extends the ArtistSeries type with artists field", async () => {
       const mergedSchema = await getGravityMergedSchema()

--- a/src/lib/stitching/gravity/schema.ts
+++ b/src/lib/stitching/gravity/schema.ts
@@ -10,6 +10,7 @@ import { readFileSync } from "fs"
 
 const allowList = [
   "agreement",
+  "curatedMarketingCollections",
   "viewingRoom",
   "viewingRooms",
   "artistSeries",

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -169,6 +169,10 @@ export const gravityStitchingEnvironment = (
         ): [MarketingCollection]
       }
 
+      extend type Query {
+        curatedMarketingCollections(first: Int, last: Int, after: String, before: String): [MarketingCollection]
+      }
+
       extend type System {
         algolia: Algolia
       }
@@ -763,6 +767,37 @@ export const gravityStitchingEnvironment = (
               context,
               info,
             })
+          },
+        },
+      },
+      Query: {
+        curatedMarketingCollections: {
+          fragment: gql`
+            ...on Viewer {
+              __typename
+            }
+          `,
+          resolve: async (_parent, _args, context, info) => {
+            try {
+              return await info.mergeInfo.delegateToSchema({
+                schema: gravitySchema,
+                operation: "query",
+                fieldName: "marketingCollections",
+                args: {
+                  slugs: [
+                    "trending-this-week",
+                    "artists-on-the-rise",
+                    "trove-editors-picks",
+                    "painting",
+                    "photography",
+                  ],
+                },
+                context,
+                info,
+              })
+            } catch (error) {
+              return []
+            }
           },
         },
       },

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -206,6 +206,7 @@ export const gravityStitchingEnvironment = (
       }
 
       extend type MarketingCollection {
+        thumbnailImage: Image
         artworksConnection(${argsToSDL(
           pageableFilterArtworksArgsWithInput
         ).join("\n")}): FilterArtworksConnection
@@ -291,6 +292,31 @@ export const gravityStitchingEnvironment = (
         },
       },
       MarketingCollection: {
+        thumbnailImage: {
+          fragment: gql`
+          ... on MarketingCollection {
+            image_url: thumbnail
+          }
+          `,
+          resolve: async ({ image_url }, args, context, info) => {
+            if (image_url) {
+              context.imageData = {
+                image_url,
+              }
+            } else {
+              context.imageData = null
+            }
+
+            return info.mergeInfo.delegateToSchema({
+              args,
+              schema: localSchema,
+              operation: "query",
+              fieldName: "_do_not_use_image",
+              context,
+              info,
+            })
+          },
+        },
         artworksConnection: {
           fragment: `
               ... on MarketingCollection {

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -299,7 +299,7 @@ export const gravityStitchingEnvironment = (
           }
           `,
           resolve: async ({ image_url }, _args, context, info) => {
-            context.imageData = image_url ? normalizeImageData(image_url) : null
+            context.imageData = normalizeImageData(image_url)
 
             return info.mergeInfo.delegateToSchema({
               schema: localSchema,

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -811,11 +811,11 @@ export const gravityStitchingEnvironment = (
                 fieldName: "marketingCollections",
                 args: {
                   slugs: [
+                    "trove-editors-picks",
                     "trending-this-week",
                     "artists-on-the-rise",
-                    "trove-editors-picks",
-                    "painting",
-                    "photography",
+                    "blue-chip-artists",
+                    "top-auction-lots",
                   ],
                 },
                 context,

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -170,7 +170,7 @@ export const gravityStitchingEnvironment = (
       }
 
       extend type Query {
-        curatedMarketingCollections(first: Int, last: Int, after: String, before: String): [MarketingCollection]
+        curatedMarketingCollections(size: Int): [MarketingCollection]
       }
 
       extend type System {
@@ -298,17 +298,10 @@ export const gravityStitchingEnvironment = (
             image_url: thumbnail
           }
           `,
-          resolve: async ({ image_url }, args, context, info) => {
-            if (image_url) {
-              context.imageData = {
-                image_url,
-              }
-            } else {
-              context.imageData = null
-            }
+          resolve: async ({ image_url }, _args, context, info) => {
+            context.imageData = image_url ? normalizeImageData(image_url) : null
 
             return info.mergeInfo.delegateToSchema({
-              args,
               schema: localSchema,
               operation: "query",
               fieldName: "_do_not_use_image",
@@ -799,11 +792,11 @@ export const gravityStitchingEnvironment = (
       Query: {
         curatedMarketingCollections: {
           fragment: gql`
-            ...on Viewer {
+            ...on Query {
               __typename
             }
           `,
-          resolve: async (_parent, _args, context, info) => {
+          resolve: async (_parent, args, context, info) => {
             try {
               return await info.mergeInfo.delegateToSchema({
                 schema: gravitySchema,
@@ -817,6 +810,7 @@ export const gravityStitchingEnvironment = (
                     "blue-chip-artists",
                     "top-auction-lots",
                   ],
+                  ...args,
                 },
                 context,
                 info,


### PR DESCRIPTION
[Jira](https://artsyproduct.atlassian.net/browse/FX-4437)

Adds query field to for new Artsy curated collection section

![Screenshot 2022-11-16 at 13 39 38](https://user-images.githubusercontent.com/3934579/202183122-ca14f153-9463-401b-949e-e38c623f84f7.png)

# Sample Query

```graphql
{
    curatedMarketingCollections(first: 5) {
        slug
        title
        thumbnailImage {
	    resized(width: 200) {
	        url
	    }
        }
    }
}
```

# Response

```json
{
	"data": {
		"curatedMarketingCollections": [
			{
				"slug": "photography",
				"title": "Photography",
				"thumbnailImage": {
					"resized": {
						"url": "https://d7hftxdivxxvm.cloudfront.net?resize_to=width&width=200&quality=80&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2F_zWRgEXoyJtTVaM6NznROw%2Fnormalized.jpg"
					}
				}
			},
			{
				"slug": "painting",
				"title": "Painting",
				"thumbnailImage": null
			},
			{
				"slug": "artists-on-the-rise",
				"title": "Artists on the Rise",
				"thumbnailImage": null
			},
			{
				"slug": "trending-this-week",
				"title": "Trending This Week",
				"thumbnailImage": null
			},
			{
				"slug": "trove-editors-picks",
				"title": "Trove: Editors' Picks",
				"thumbnailImage": null
			}
		]
	}
}
```
