### PR TITLE
feat: add a curated trending artists connection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13249,6 +13249,14 @@ type Query {
     id: String!
   ): CreditCard
   curatedMarketingCollections(size: Int): [MarketingCollection]
+
+  # A list of trending artists. Inferred from a manually curated collection of trending artworks.
+  curatedTrendingArtists(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtistConnection
   departments: [Department!]!
 
   # Get an image info
@@ -17057,6 +17065,14 @@ type Viewer {
     # The ID of the Credit Card
     id: String!
   ): CreditCard
+
+  # A list of trending artists. Inferred from a manually curated collection of trending artworks.
+  curatedTrendingArtists(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtistConnection
   departments: [Department!]!
 
   # Get an image info

--- a/src/lib/__tests__/shuffle.test.ts
+++ b/src/lib/__tests__/shuffle.test.ts
@@ -53,3 +53,57 @@ describe("seededShuffle", () => {
     })
   })
 })
+
+describe("dailyShuffle", () => {
+  describe("with no time zone specified", () => {
+    it("produces a stable shuffle for an entire UTC day", () => {
+      const veryEarly = new Date("2022-11-15T01:00:00Z").valueOf()
+      const veryLate = new Date("2022-11-15T23:00:00Z").valueOf()
+      const nextDay = new Date("2022-11-16T01:00:00Z").valueOf()
+
+      // early in the day - same
+      jest.spyOn(global.Date, "now").mockImplementation(() => veryEarly)
+      expect(dailyShuffle([1, 2, 3, 4, 5])).toEqual([4, 2, 5, 3, 1])
+
+      // late in the day - same
+      jest.spyOn(global.Date, "now").mockImplementation(() => veryLate)
+      expect(dailyShuffle([1, 2, 3, 4, 5])).toEqual([4, 2, 5, 3, 1])
+
+      // next day - different
+      jest.spyOn(global.Date, "now").mockImplementation(() => nextDay)
+      expect(dailyShuffle([1, 2, 3, 4, 5])).toEqual([3, 4, 1, 5, 2])
+    })
+  })
+
+  describe("with a valid time zone specified", () => {
+    it("produces a stable shuffle for an entire day in that time zone", () => {
+      const veryEarly = new Date("2022-11-15T01:00:00-05:00").valueOf()
+      const veryLate = new Date("2022-11-15T23:00:00-05:00").valueOf()
+      const nextDay = new Date("2022-11-16T01:00:00-05:00").valueOf()
+      const nycTime = "America/New_York"
+
+      // early in the day - same
+      jest.spyOn(global.Date, "now").mockImplementation(() => veryEarly)
+      expect(dailyShuffle([1, 2, 3, 4, 5], nycTime)).toEqual([4, 2, 5, 3, 1])
+
+      // late in the day - same
+      jest.spyOn(global.Date, "now").mockImplementation(() => veryLate)
+      expect(dailyShuffle([1, 2, 3, 4, 5], nycTime)).toEqual([4, 2, 5, 3, 1])
+
+      // next day - different
+      jest.spyOn(global.Date, "now").mockImplementation(() => nextDay)
+      expect(dailyShuffle([1, 2, 3, 4, 5], nycTime)).toEqual([3, 4, 1, 5, 2])
+    })
+  })
+
+  describe("with an invalid time zone", () => {
+    it("does not error", () => {
+      expect(() => dailyShuffle([1, 2, 3, 4, 5], "lol/jk")).not.toThrow()
+    })
+    it("falls back to default UTC behavior", () => {
+      const veryEarly = new Date("2022-11-15T01:00:00Z").valueOf()
+      jest.spyOn(global.Date, "now").mockImplementation(() => veryEarly)
+      expect(dailyShuffle([1, 2, 3, 4, 5], "lol/jk")).toEqual([4, 2, 5, 3, 1])
+    })
+  })
+})

--- a/src/lib/__tests__/shuffle.test.ts
+++ b/src/lib/__tests__/shuffle.test.ts
@@ -1,0 +1,55 @@
+// Adapted from https://github.com/artsy/force/blob/9fb0f70c7abda2db06a79d80d4a77dea68c53334/src/Utils/Hooks/__tests__/useStableShuffle.jest.tsx
+
+import { dailyShuffle, mulberry32, seededShuffle, xmur3 } from "../shuffle"
+
+describe("xmur3", () => {
+  it("returns a deterministic, hashed sequence", () => {
+    const hashA = xmur3("hello world")
+
+    expect(hashA()).toEqual(2225606010)
+    expect(hashA()).toEqual(2106958649)
+
+    const hashB = xmur3("goodbye world")
+
+    expect(hashB()).toEqual(534649177)
+    expect(hashB()).toEqual(1317567859)
+  })
+})
+
+describe("mulberry32", () => {
+  it("returns a deterministic number sequence between 0 and 1", () => {
+    const randomA = mulberry32(1)
+
+    expect(randomA()).toEqual(0.6270739405881613)
+    expect(randomA()).toEqual(0.002735721180215478)
+
+    const randomB = mulberry32(99)
+
+    expect(randomB()).toEqual(0.2604658124037087)
+    expect(randomB()).toEqual(0.8048227655235678)
+  })
+})
+
+describe("seededShuffle", () => {
+  it("returns a function", () => {
+    const { shuffle } = seededShuffle("a seed")
+    expect(shuffle).toBeFunction()
+  })
+
+  describe("the returned shuffle() function", () => {
+    it("shuffles an array deterministically", () => {
+      const { shuffle } = seededShuffle("any seed will do")
+      const result = shuffle([1, 2, 3, 4, 5])
+      expect(result).toEqual([3, 5, 4, 1, 2])
+    })
+
+    it("produces a stable sequence of shuffles", () => {
+      const { shuffle } = seededShuffle("very stable genius ordering")
+      expect(shuffle([1, 2, 3, 4, 5])).toEqual([2, 1, 4, 5, 3])
+      expect(shuffle([1, 2, 3, 4, 5])).toEqual([4, 5, 2, 1, 3])
+      expect(shuffle([1, 2, 3, 4, 5])).toEqual([2, 1, 4, 3, 5])
+      expect(shuffle([1, 2, 3, 4, 5])).toEqual([4, 3, 5, 2, 1])
+      expect(shuffle([1, 2, 3, 4, 5])).toEqual([2, 3, 5, 1, 4])
+    })
+  })
+})

--- a/src/lib/shuffle.ts
+++ b/src/lib/shuffle.ts
@@ -1,0 +1,63 @@
+// Adapted from https://github.com/artsy/force/blob/c3fe1f217e5572f8098fbfac2e975dae027b876f/src/Utils/Hooks/useStableShuffle.ts
+
+/**
+ * Each subsequent call to the return function of xmur3 produces a new "random"
+ * 32-bit hash value to be used as a seed in a PRNG.
+ * https://github.com/bryc/code/blob/master/jshash/PRNGs.md#addendum-a-seed-generating-functions
+ */
+export const xmur3 = (str: string) => {
+  let h = 1779033703 ^ str.length
+
+  for (let i = 0; i < str.length; i++) {
+    h = Math.imul(h ^ str.charCodeAt(i), 3432918353)
+    h = (h << 13) | (h >>> 19)
+  }
+
+  return () => {
+    h = Math.imul(h ^ (h >>> 16), 2246822507)
+    h = Math.imul(h ^ (h >>> 13), 3266489909)
+    return (h ^= h >>> 16) >>> 0
+  }
+}
+
+/**
+ * https://github.com/bryc/code/blob/master/jshash/PRNGs.md#mulberry32
+ */
+export const mulberry32 = (a: number) => {
+  return () => {
+    let t = (a += 0x6d2b79f5)
+
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/**
+ * Returns a Fisher-Yates shuffle function seeded with seed value
+ * https://stackoverflow.com/a/53758827/160937
+ */
+export const seededShuffle = (seed: string) => {
+  const hash = xmur3(seed)
+  const random = mulberry32(hash())
+
+  const shuffle = <T>(xs: T[]) => {
+    const array = xs.slice()
+
+    let m = array.length,
+      t: T,
+      i: number
+
+    while (m) {
+      i = Math.floor(random() * m--)
+      t = array[m]
+      array[m] = array[i]
+      array[i] = t
+    }
+
+    return array
+  }
+
+  return { shuffle }
+}

--- a/src/schema/v2/artists/__tests__/curatedTrending.test.ts
+++ b/src/schema/v2/artists/__tests__/curatedTrending.test.ts
@@ -1,0 +1,105 @@
+import gql from "lib/gql"
+import { runQuery } from "schema/v2/test/utils"
+import { ResolverContext } from "types/graphql"
+
+const query = gql`
+  query {
+    curatedTrendingArtists(first: 3) {
+      edges {
+        node {
+          slug
+          name
+        }
+      }
+    }
+  }
+`
+
+/*
+ * Because there is a date-seeded shuffle involved, we must
+ * lock in a specific date here for deterministic test results
+ */
+const timeOfQuery = new Date("2022-11-15T01:00:00Z").valueOf()
+jest.spyOn(global.Date, "now").mockImplementation(() => timeOfQuery)
+
+const mockFilterArtworksResponse = {
+  hits: [],
+  aggregations: {
+    merchandisable_artists: {
+      "id-1": { name: "Daniel Heidkamp", count: 1 },
+      "id-2": { name: "Chloe Wise", count: 1 },
+      "id-3": { name: "Mari Kuroda", count: 1 },
+      "id-4": { name: "David Hockney", count: 1 },
+      "id-5": { name: "Marc Chagall", count: 1 },
+    },
+  },
+}
+
+const mockArtistRecords = [
+  { _id: "id-1", id: "daniel-heidkamp", name: "Daniel Heidkamp" },
+  { _id: "id-2", id: "chloe-wise", name: "Chloe Wise" },
+  { _id: "id-3", id: "mari-kuroda", name: "Mari Kuroda" },
+  { _id: "id-4", id: "david-hockney", name: "David Hockney" },
+  { _id: "id-5", id: "marc-chagall", name: "Marc Chagall" },
+]
+
+let context: Partial<ResolverContext>
+
+beforeEach(() => {
+  context = {
+    filterArtworksLoader: jest.fn(() =>
+      Promise.resolve(mockFilterArtworksResponse)
+    ),
+    artistsLoader: jest.fn(
+      // mock implementation to filter over the array of artists above
+      ({ ids }) => {
+        const matchedRecords = mockArtistRecords.filter(({ _id }) =>
+          ids.includes(_id)
+        )
+        const sortedRecords = ids.map((id) =>
+          matchedRecords.find((a) => a._id === id)
+        )
+        const artistsLoaderResponse = {
+          body: sortedRecords,
+          headers: {},
+        }
+
+        return Promise.resolve(artistsLoaderResponse)
+      }
+    ),
+  }
+})
+
+describe("with no timezone provided", () => {
+  it("returns a sample of artists, shuffled according to UTC", async () => {
+    const response = await runQuery(query, context)
+
+    expect(response).toEqual({
+      curatedTrendingArtists: {
+        edges: [
+          { node: { slug: "david-hockney", name: "David Hockney" } },
+          { node: { slug: "chloe-wise", name: "Chloe Wise" } },
+          { node: { slug: "marc-chagall", name: "Marc Chagall" } },
+        ],
+      },
+    })
+  })
+})
+
+describe("with a user timezone provided", () => {
+  it("returns a sample of artists, shuffled for that timezone", async () => {
+    context.defaultTimezone = "America/New_York"
+
+    const response = await runQuery(query, context)
+
+    expect(response).toEqual({
+      curatedTrendingArtists: {
+        edges: [
+          { node: { slug: "chloe-wise", name: "Chloe Wise" } },
+          { node: { slug: "david-hockney", name: "David Hockney" } },
+          { node: { slug: "marc-chagall", name: "Marc Chagall" } },
+        ],
+      },
+    })
+  })
+})

--- a/src/schema/v2/artists/curatedTrending.ts
+++ b/src/schema/v2/artists/curatedTrending.ts
@@ -1,0 +1,36 @@
+import { GraphQLFieldConfig } from "graphql"
+import type { ResolverContext } from "types/graphql"
+import { connectionArgs, connectionFromArray } from "graphql-relay"
+
+import { dailyShuffle } from "lib/shuffle"
+import { ArtworksAggregation } from "../aggregations/filter_artworks_aggregation"
+import { artistConnection } from "../artist"
+
+export const CuratedTrendingArtists: GraphQLFieldConfig<
+  void,
+  ResolverContext
+> = {
+  type: artistConnection.connectionType,
+  description:
+    "A list of trending artists. Inferred from a manually curated collection of trending artworks.",
+  args: connectionArgs,
+  resolve: async (_parent, args, context) => {
+    const { artistsLoader, filterArtworksLoader, defaultTimezone } = context
+    const artworks = await filterArtworksLoader({
+      size: 0,
+      marketing_collection_id: "trending-this-week",
+      aggregations: [
+        ArtworksAggregation.getValue("MERCHANDISABLE_ARTISTS")!.value,
+      ],
+    })
+
+    const artists = artworks.aggregations.merchandisable_artists
+    const artistIDs = Object.keys(artists)
+    const shuffledIDs = dailyShuffle(artistIDs, defaultTimezone)
+    const { body: artistRecords } = await artistsLoader({
+      ids: shuffledIDs,
+    })
+
+    return connectionFromArray(artistRecords, args)
+  },
+}

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -13,6 +13,7 @@ import Articles from "./articles"
 import ArticlesConnection from "./articlesConnection"
 import Artist from "./artist"
 import Artists, { artistsConnection } from "./artists"
+import { CuratedTrendingArtists } from "./artists/curatedTrending"
 import { mergeArtistsMutation } from "./artists/mergeArtistsMutation"
 import Artwork from "./artwork"
 import { ArtistArtworkGridType } from "./artwork/artworkContextGrids/ArtistArtworkGrid"
@@ -195,6 +196,7 @@ const rootFields = {
   },
   bankAccount: BankAccount,
   creditCard: CreditCard,
+  curatedTrendingArtists: CuratedTrendingArtists,
   departments,
   // externalPartner: ExternalPartner,
   fair: Fair,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-4451

This adds a new `curatedTrendingArtists` root-level field in order to expose a timely list of Artsy-suggested artists for use in various client-side contexts — starting with search suggestions in Eigen.

The list of artists:

- is sourced from the [Trending This Week](https://www.artsy.net/collection/trending-this-week) marketing collection
  - for an idea of what that would feel like, see [here](https://artsy.slack.com/archives/C9SATFLUU/p1668542926931289)
- is exposed as a GraphQL connection
- has a built-in daily shuffle, such that each user will get a different sampling of artists every day
  - the shuffle attempts to be time zone aware, so that the shuffle happens at midnight in the user's time zone

Since seeded random numbers are [not a thing](https://artsy.slack.com/archives/CP9P4KR35/p1668534209604179) in vanilla JS, this PR borrows some patterns from Force to do stabled seeded random number generation and shuffling (https://github.com/artsy/metaphysics/pull/4522/commits/90a996401f797b47acc009970a6c6d4156878c38)

It adds on top of that a date-stable, timezone-aware shuffling method for convenience (https://github.com/artsy/metaphysics/pull/4522/commits/d6ea35ff672c4b3f551255dcc520161454a7c1ce)

### Request

```graphql
{
  curatedTrendingArtists(first: 3) {
    edges {
      node {
        slug
        name
      }
    }
  }
}
```

### Response

```json
{
  "data": {
    "curatedTrendingArtists": {
      "edges": [
        {
          "node": {
            "slug": "devin-troy-strother",
            "name": "Devin Troy Strother"
          }
        },
        {
          "node": {
            "slug": "andy-warhol",
            "name": "Andy Warhol"
          }
        },
        {
          "node": {
            "slug": "damien-hirst",
            "name": "Damien Hirst"
          }
        }
      ]
    }
  }
}
```

<details>
  <summary>
    <strong>See here (and hidden comments below) for earlier discussion about alternative fields, schema design etc</strong>
  </summary>

*Very WIP-y at the moment for the reasons outlined below.*

Adds a new root-level `trendingArtists` field.

This new field implements the proposed strategy of sourcing a list of trending artists from the [Trending This Week collection](https://www.artsy.net/collection/trending-this-week), which is actively curated on a weekly basis.

In doing this I discovered that there are several different versions of a "trending artist" concept floating around in Metaphysics.

<details>
  <summary>
    <strong>Open me up for a tour of the ~4 such existing fields…</strong>
  </summary>

### 1. An obsolete root-level `trendingArtists` field

- Looks like it dates back to the v1 schema, 
- Commented out in the v2 schema (which is why the root-level `trendingArtists` field name was available for me to squat on)
- Data is/was sourced directly from Delta via a `deltaLoader` (not to be confused with [beltalowdas](https://expanse.fandom.com/wiki/Beltalowda))


### 2. A home page module at `homePage.artistModule(key: TRENDING)`

- Data is sourced via the `trendingArtistsLoader`, which hits Gravity's `artist/trending` endpoint

### 3. A gene-specific  `gene.trendingArtists` 

- Data is also sourced via the `trendingArtistsLoader`, which hits Gravity's `/artists/trending` endpoint, and passes a `gene` param into that endpoint

### 4. A `-trending` sort on the root-level `artists` and `artistsConnection` fields

- Data is sourced via the `artistsLoader`, which hits Gravity's `/artists` endpoint with a custom `-trending` sort

</details>

…So we've got four fields kinda named "trending artists," sourced in four somewhat different ways (though I think they all back up onto [artsy/delta](https://github.com/artsy/metaphysics/pull/4522))

And we are going to add a fifth, sourced differently 😅

### Questions

- What is the **best name** for this new field? We've been calling it "trending artists" so far, but that name seems a bit overloaded? Are there good alternatives? "Curated trending artists"?

- What is the **best location** in the graph for this new field? At the root? I'm not sure if any other existing nesting would make sense e.g. `{ trending { artists } }`

- Wild left-field thought — should we consider actually leaning into the existing trending artist microservice (https://github.com/artsy/delta) but add more signals to it, such as the fact that an artist is in Trending This Week (which we might favor with a huge boost)?

</details>

### TODO

- [x] settle field name
- [x] settle field location
- [x] add date-stable shuffling ([a tip](https://artsy.slack.com/archives/CP9P4KR35/p1668534209604179))
- [x] specs
