### PR TITLE
feat: expose identityVerified field on User type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16317,6 +16317,9 @@ type User implements Node {
 
   # A globally unique ID.
   id: ID!
+
+  # Has the users identity been verified.
+  identityVerified: Boolean
   inquiredArtworksConnection(
     after: String
     before: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16319,7 +16319,7 @@ type User implements Node {
   id: ID!
 
   # Has the users identity been verified.
-  identityVerified: Boolean
+  identityVerified: Boolean!
   inquiredArtworksConnection(
     after: String
     before: String

--- a/src/schema/v2/__tests__/user.test.ts
+++ b/src/schema/v2/__tests__/user.test.ts
@@ -106,6 +106,26 @@ describe("User", () => {
     expect(result.name).toEqual("Artsy User")
   })
 
+  it("returns identity verification status", async () => {
+    const query = `
+      {
+        user(id: "percy-z") {
+          identityVerified
+        }
+      }
+    `
+
+    const context = {
+      userByIDLoader: () => {
+        return Promise.resolve({ identity_verified: true })
+      },
+    }
+
+    const { user: result } = await runAuthenticatedQuery(query, context)
+
+    expect(result.identityVerified).toEqual(true)
+  })
+
   describe("userAlreadyExists", () => {
     it("returns true if a user exists", async () => {
       const foundUser = {

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -256,6 +256,11 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLBoolean,
         resolve: async ({ data_transfer_opt_out }) => data_transfer_opt_out,
       },
+      identityVerified: {
+        description: "Has the users identity been verified.",
+        type: GraphQLBoolean,
+        resolve: async ({ identity_verified }) => identity_verified,
+      },
       inquiredArtworksConnection: {
         type: UserInquiredArtworksConnection,
         args: pageable({}),

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -258,7 +258,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
       },
       identityVerified: {
         description: "Has the users identity been verified.",
-        type: GraphQLBoolean,
+        type: new GraphQLNonNull(GraphQLBoolean),
         resolve: async ({ identity_verified }) => identity_verified,
       },
       inquiredArtworksConnection: {


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4714

This PR exposes `identityVerified` field on the `User` type by mapping [this](https://github.com/artsy/gravity/blob/90621a2e3234f7f94e56e4f736055dc453af7642/app/models/domain/user.rb#L785) gravity field.