### PR TITLE
refactor: identityVerified field on User

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16317,9 +16317,6 @@ type User implements Node {
 
   # A globally unique ID.
   id: ID!
-
-  # Has the users identity been verified.
-  identityVerified: Boolean!
   inquiredArtworksConnection(
     after: String
     before: String
@@ -16335,6 +16332,9 @@ type User implements Node {
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
+
+  # Has the users identity been verified.
+  isIdentityVerified: Boolean!
   lastSignInAt(
     format: String
 

--- a/src/schema/v2/__tests__/user.test.ts
+++ b/src/schema/v2/__tests__/user.test.ts
@@ -110,7 +110,7 @@ describe("User", () => {
     const query = `
       {
         user(id: "percy-z") {
-          identityVerified
+          isIdentityVerified
         }
       }
     `
@@ -123,7 +123,7 @@ describe("User", () => {
 
     const { user: result } = await runAuthenticatedQuery(query, context)
 
-    expect(result.identityVerified).toEqual(true)
+    expect(result.isIdentityVerified).toEqual(true)
   })
 
   describe("userAlreadyExists", () => {

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -256,7 +256,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLBoolean,
         resolve: async ({ data_transfer_opt_out }) => data_transfer_opt_out,
       },
-      identityVerified: {
+      isIdentityVerified: {
         description: "Has the users identity been verified.",
         type: new GraphQLNonNull(GraphQLBoolean),
         resolve: async ({ identity_verified }) => identity_verified,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4714

This renames the field based on [feedback](https://github.com/artsy/metaphysics/pull/4524#discussion_r1024494776) to promote the use of `is[FieldName]` for boolean fields.