### PR TITLE
refactor(conversations): Migrate static conversation props to resolvers

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/impulse.ts
+++ b/src/lib/loaders/loaders_with_authentication/impulse.ts
@@ -3,7 +3,7 @@ import config from "config"
 
 const { IMPULSE_APPLICATION_ID } = config
 
-export default (accessToken, userID, opts) => {
+export default (accessToken, _userID, opts) => {
   let impulseTokenLoader
   const gravityAccessTokenLoader = () => Promise.resolve(accessToken)
   const impulseAccessTokenLoader = () =>
@@ -28,11 +28,7 @@ export default (accessToken, userID, opts) => {
   )
 
   return {
-    conversationsLoader: impulseLoader("conversations", {
-      from_id: userID,
-      from_type: "User",
-      has_message: true,
-    }),
+    conversationsLoader: impulseLoader("conversations"),
     conversationLoader: impulseLoader((id) => `conversations/${id}`),
     conversationUpdateLoader: impulseLoader(
       (id) => `conversations/${id}`,
@@ -44,10 +40,7 @@ export default (accessToken, userID, opts) => {
     }),
     conversationCreateMessageLoader: impulseLoader(
       (id) => `conversations/${id}/messages`,
-      {
-        reply_all: true,
-        from_id: userID,
-      },
+      {},
       { method: "POST" }
     ),
     conversationCreateConversationOrderLoader: impulseLoader(

--- a/src/schema/v2/conversation/conversations.ts
+++ b/src/schema/v2/conversation/conversations.ts
@@ -19,21 +19,26 @@ const Conversations: GraphQLFieldConfig<void, ResolverContext> = {
   }).connectionType,
   description: "Conversations, usually between a user and partner.",
   args: pageable(),
-  resolve: (_root, options, { conversationsLoader }) => {
+  resolve: (_root, options, { conversationsLoader, userID }) => {
     if (!conversationsLoader) return null
     const { page, size, offset } = convertConnectionArgsToGravityArgs(options)
     const expand = ["total_unread_count"]
-    return conversationsLoader({ page, size, expand }).then(
-      ({ total_count, total_unread_count, conversations }) => {
-        return assign(
-          { total_unread_count },
-          connectionFromArraySlice(conversations, options, {
-            arrayLength: total_count,
-            sliceStart: offset,
-          })
-        )
-      }
-    )
+    return conversationsLoader({
+      page,
+      size,
+      expand,
+      from_id: userID,
+      from_type: "User",
+      has_message: true,
+    }).then(({ total_count, total_unread_count, conversations }) => {
+      return assign(
+        { total_unread_count },
+        connectionFromArraySlice(conversations, options, {
+          arrayLength: total_count,
+          sliceStart: offset,
+        })
+      )
+    })
   },
 }
 

--- a/src/schema/v2/conversation/send_message_mutation.ts
+++ b/src/schema/v2/conversation/send_message_mutation.ts
@@ -68,6 +68,8 @@ export default mutationWithClientMutationId<any, any, ResolverContext>({
       from,
       reply_to_message_id,
       body_text,
+      reply_all: true,
+      from_id: userID,
     }).then(({ id: newMessageID }) => {
       return conversationLoader(id).then((updatedConversation) => {
         return {

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -390,12 +390,17 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
     unreadConversationCount: {
       type: new GraphQLNonNull(GraphQLInt),
       description: "The count of conversations with unread messages.",
-      resolve: (_root, _options, { conversationsLoader }) => {
+      resolve: (_root, _options, { conversationsLoader, userID }) => {
         if (!conversationsLoader) return 0
         const expand = ["total_unread_count"]
-        return conversationsLoader({ page: 1, size: 0, expand }).then(
-          ({ total_unread_count }) => total_unread_count
-        )
+        return conversationsLoader({
+          page: 1,
+          size: 0,
+          expand,
+          from_id: userID,
+          from_type: "User",
+          has_message: true,
+        }).then(({ total_unread_count }) => total_unread_count)
       },
     },
     watchedLotConnection: WatchedLotConnection,


### PR DESCRIPTION
Currently we have a number of static props defined in our loaders that are very specific to the client and aren't configurable. This makes it so that we can dynamically pass in values to our resolvers to keep them generic. Step PR for wiring up partner-specific convo work in follow-up. 

cc @artsy/negotiate-devs 