### PR TITLE
refactor: allow opt-out for related works in artwork context grids

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2017,7 +2017,7 @@ type Artwork implements Node & Searchable & Sellable {
   context: ArtworkContext
   contextGrids(
     # Whether to include the `RelatedArtworksGrid` module. Defaults to `true`; preferred behavior is to opt out with `false`.
-    includeRelatedArtworks: Boolean = true
+    includeRelatedArtworks: Boolean! = true
   ): [ArtworkContextGrid]
 
   # The currency code used to pay for the artwork

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2015,7 +2015,10 @@ type Artwork implements Node & Searchable & Sellable {
 
   # Returns the associated Fair/Sale/Show
   context: ArtworkContext
-  contextGrids: [ArtworkContextGrid]
+  contextGrids(
+    # Whether to include the `RelatedArtworksGrid` module. Defaults to `true`; preferred behavior is to opt out with `false`.
+    includeRelatedArtworks: Boolean = true
+  ): [ArtworkContextGrid]
 
   # The currency code used to pay for the artwork
   costCurrencyCode: String

--- a/src/schema/v2/artwork/artworkContextGrids/__tests__/defaultContext.test.ts
+++ b/src/schema/v2/artwork/artworkContextGrids/__tests__/defaultContext.test.ts
@@ -191,4 +191,37 @@ describe("Default Context", () => {
     ).toEqual(["relatedArtwork1", "relatedArtwork2"])
     expect.assertions(13)
   })
+
+  it("allows related artworks to be excluded", async () => {
+    context.relatedLayersLoader = () => Promise.resolve([{ id: "main" }])
+    context.relatedLayerArtworksLoader = jest.fn()
+
+    const response = await runAuthenticatedQuery(
+      gql`
+        {
+          artwork(id: "donn-delson-space-invader") {
+            contextGrids(includeRelatedArtworks: false) {
+              title
+              artworksConnection(first: 2) {
+                edges {
+                  node {
+                    slug
+                    title
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+      context
+    )
+
+    const grids = response.artwork.contextGrids
+    const gridTitles = grids.map((grid) => grid.title)
+
+    expect(grids.length).toEqual(2)
+    expect(gridTitles).not.toInclude("Related works")
+    expect(context.relatedLayerArtworksLoader).not.toHaveBeenCalled()
+  })
 })

--- a/src/schema/v2/artwork/artworkContextGrids/__tests__/showContext.test.ts
+++ b/src/schema/v2/artwork/artworkContextGrids/__tests__/showContext.test.ts
@@ -205,4 +205,37 @@ describe("Show Context", () => {
     ).toEqual(["relatedArtwork1", "relatedArtwork2"])
     expect.assertions(17)
   })
+
+  it("allows related artworks to be excluded", async () => {
+    context.relatedLayersLoader = () => Promise.resolve([{ id: "main" }])
+    context.relatedLayerArtworksLoader = jest.fn()
+
+    const response = await runAuthenticatedQuery(
+      gql`
+        {
+          artwork(id: "donn-delson-space-invader") {
+            contextGrids(includeRelatedArtworks: false) {
+              title
+              artworksConnection(first: 2) {
+                edges {
+                  node {
+                    slug
+                    title
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+      context
+    )
+
+    const grids = response.artwork.contextGrids
+    const gridTitles = grids.map((grid) => grid.title)
+
+    expect(grids.length).toEqual(3)
+    expect(gridTitles).not.toInclude("Related works")
+    expect(context.relatedLayerArtworksLoader).not.toHaveBeenCalled()
+  })
 })

--- a/src/schema/v2/artwork/artworkContextGrids/index.ts
+++ b/src/schema/v2/artwork/artworkContextGrids/index.ts
@@ -4,6 +4,7 @@ import {
   GraphQLFieldConfig,
   GraphQLList,
   GraphQLBoolean,
+  GraphQLNonNull,
 } from "graphql"
 import { artworkConnection } from "schema/v2/artwork"
 import { pageable } from "relay-cursor-paging"
@@ -65,7 +66,7 @@ export const ArtworkContextGrids: GraphQLFieldConfig<any, ResolverContext> = {
   type: new GraphQLList(ArtworkContextGridType),
   args: {
     includeRelatedArtworks: {
-      type: GraphQLBoolean,
+      type: new GraphQLNonNull(GraphQLBoolean),
       defaultValue: true,
       description:
         "Whether to include the `RelatedArtworksGrid` module. Defaults to `true`; preferred behavior is to opt out with `false`.",

--- a/src/schema/v2/artwork/artworkContextGrids/index.ts
+++ b/src/schema/v2/artwork/artworkContextGrids/index.ts
@@ -3,6 +3,7 @@ import {
   GraphQLString,
   GraphQLFieldConfig,
   GraphQLList,
+  GraphQLBoolean,
 } from "graphql"
 import { artworkConnection } from "schema/v2/artwork"
 import { pageable } from "relay-cursor-paging"
@@ -62,12 +63,21 @@ export const ArtworkContextGridType = new GraphQLInterfaceType({
 
 export const ArtworkContextGrids: GraphQLFieldConfig<any, ResolverContext> = {
   type: new GraphQLList(ArtworkContextGridType),
+  args: {
+    includeRelatedArtworks: {
+      type: GraphQLBoolean,
+      defaultValue: true,
+      description:
+        "Whether to include the `RelatedArtworksGrid` module. Defaults to `true`; preferred behavior is to opt out with `false`.",
+    },
+  },
   resolve: async (
     artwork,
-    _options,
+    args,
     { saleLoader, relatedFairsLoader, relatedShowsLoader }
   ) => {
     const { id, artist, partner, sale_ids } = artwork
+    const { includeRelatedArtworks } = args
 
     // If the artwork is in an auction, return a context that includes the auction
     if (sale_ids && sale_ids.length > 0) {
@@ -78,11 +88,9 @@ export const ArtworkContextGrids: GraphQLFieldConfig<any, ResolverContext> = {
             ...(artist
               ? [{ gridType: "ArtistArtworkGrid", artist, artwork }]
               : []),
-            {
-              gridType: "RelatedArtworkGrid",
-              artist,
-              artwork,
-            },
+            ...(includeRelatedArtworks
+              ? [{ gridType: "RelatedArtworkGrid", artist, artwork }]
+              : []),
           ]
         } else {
           return [
@@ -122,7 +130,9 @@ export const ArtworkContextGrids: GraphQLFieldConfig<any, ResolverContext> = {
             ...(artist
               ? [{ gridType: "ArtistArtworkGrid", artist, artwork }]
               : []),
-            { gridType: "RelatedArtworkGrid", artwork },
+            ...(includeRelatedArtworks
+              ? [{ gridType: "RelatedArtworkGrid", artwork }]
+              : []),
           ]
         }
       }
@@ -148,7 +158,9 @@ export const ArtworkContextGrids: GraphQLFieldConfig<any, ResolverContext> = {
         ...(partner
           ? [{ gridType: "PartnerArtworkGrid", partner, artwork }]
           : []),
-        { gridType: "RelatedArtworkGrid", artwork },
+        ...(includeRelatedArtworks
+          ? [{ gridType: "RelatedArtworkGrid", artwork }]
+          : []),
       ]
     }
 
@@ -158,7 +170,9 @@ export const ArtworkContextGrids: GraphQLFieldConfig<any, ResolverContext> = {
       ...(partner
         ? [{ gridType: "PartnerArtworkGrid", partner, artwork }]
         : []),
-      { gridType: "RelatedArtworkGrid", artwork },
+      ...(includeRelatedArtworks
+        ? [{ gridType: "RelatedArtworkGrid", artwork }]
+        : []),
     ]
   },
 }


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-4454

This partially addresses some potentially expensive over-fetching currently affecting the artwork page.

The Artwork page in Force currently does some lazy loading of other artworks’ data, e.g. artworks from the same show, fair, auction — _or_ artworks related by our similarity algorithm.

The last one, the "related artworks" grid, currently backs up onto a sometimes expensive ES query. Therefore we'd like to defer and minimize it as much as possible.

Funny thing is, although this can be addressed from the client side, there is a whole server-side orchestration of these artwork grid fetches that needs to be addressed at the Metaphysics layer.

So this PR makes the most expensive fetch _optional_ by:

- adding a new `includeRelatedArtworks` arg on the `artwork.contextGrids` field
- defaulting that to `includeRelatedArtworks: true`, so that current behavior is preserved

The expectation is that clients (basically just Force) can get smart and opt out of this fetch when the returned data is not needed. This change forthcoming in https://github.com/artsy/force/pull/11432.

### Default behavior, same as before

<img width="2627" alt="before" src="https://user-images.githubusercontent.com/140521/203432717-f73007a2-ba5a-46d8-ac55-6c8db4f4856d.png">

### Opt-out behavior, preferred now for Force

<img width="2621" alt="after" src="https://user-images.githubusercontent.com/140521/203432737-d5da3958-4117-47ef-9002-341b11f9eca8.png">

cc @artsy/velocity-engineers 