### PR TITLE
feat(schema): expose conversation query in the root level

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13241,6 +13241,12 @@ type Query {
     sort: ConsignmentSort
   ): ConsignmentConnection
 
+  # A conversation, usually between a user and a partner
+  conversation(
+    # The ID of the Conversation
+    id: String!
+  ): Conversation
+
   # Conversations, usually between a user and partner.
   conversationsConnection(
     after: String
@@ -17073,6 +17079,12 @@ type Viewer {
     # A slug for the city, conforming to Gravity's city slug naming conventions
     slug: String
   ): City
+
+  # A conversation, usually between a user and a partner
+  conversation(
+    # The ID of the Conversation
+    id: String!
+  ): Conversation
 
   # Conversations, usually between a user and partner.
   conversationsConnection(

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -189,6 +189,7 @@ const rootFields = {
   channel,
   city: City,
   cities,
+  conversation: Conversation,
   conversationsConnection: Conversations,
   _do_not_use_conversation: {
     ...Conversation,


### PR DESCRIPTION
We previously exposed `conversationsConnection` from the root level and we want to also expose `conversation` to use in the new Volt workflow.