### PR TITLE
feat(conversation): add fromUser field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6591,6 +6591,9 @@ type Conversation implements Node {
   from: ConversationInitiator!
   fromLastViewedMessageID: String
 
+  # The user who initiated the conversation
+  fromUser: User
+
   # A globally unique ID.
   id: ID!
   initialMessage: String!

--- a/src/schema/v2/conversation/__tests__/__snapshots__/conversation.test.js.snap
+++ b/src/schema/v2/conversation/__tests__/__snapshots__/conversation.test.js.snap
@@ -45,6 +45,9 @@ Object {
     "from": Object {
       "email": "collector@example.com",
     },
+    "fromUser": Object {
+      "email": "collector@example.com",
+    },
     "initialMessage": "Loved some of the works at your fair booth!",
     "internalID": "420",
     "lastMessage": "Loved some of the works at your fair booth!",

--- a/src/schema/v2/conversation/__tests__/conversation.test.js
+++ b/src/schema/v2/conversation/__tests__/conversation.test.js
@@ -4,6 +4,8 @@ import { runAuthenticatedQuery } from "schema/v2/test/utils"
 describe("Me", () => {
   describe("Conversation", () => {
     const context = {
+      userByIDLoader: () =>
+        Promise.resolve({ id: "user-id", email: "collector@example.com" }),
       conversationLoader: () => {
         return Promise.resolve({
           id: "420",
@@ -124,6 +126,9 @@ describe("Me", () => {
               internalID
               initialMessage
               from {
+                email
+              }
+              fromUser {
                 email
               }
               lastMessage

--- a/src/schema/v2/conversation/index.ts
+++ b/src/schema/v2/conversation/index.ts
@@ -26,6 +26,7 @@ import {
 } from "schema/v2/object_identification"
 import { MessageType } from "./message"
 import { ResolverContext } from "types/graphql"
+import { UserType } from "../user"
 
 export const BuyerOutcomeTypes = new GraphQLEnumType({
   name: "BuyerOutcomeTypes",
@@ -265,6 +266,17 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
           name: conversation.from_name,
           email: conversation.from_email,
         }
+      },
+    },
+    fromUser: {
+      description: "The user who initiated the conversation",
+      type: UserType,
+      resolve: ({ from_id }, _options, { userByIDLoader }) => {
+        if (!userByIDLoader) {
+          return null
+        }
+
+        return userByIDLoader(from_id)
       },
     },
     to: {


### PR DESCRIPTION
This updates the `conversation` type with a new `fromUser` field which will return a full user object from a conversation query:

```graphql
{
  converstion(id: "foo") {
    fromUser {
      email
    }
  }
}
```

Previously we were just returning a slice of JSON from the impulse response which omitted a lot of needed data around the Collector Profile area of the new convo UI. 

cc @artsy/negotiate-devs 
