### PR TITLE
feat: use cost Major for price paid in MyC

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11285,6 +11285,7 @@ input MyCollectionCreateArtworkInput {
   # The given location of the user as structured data
   collectorLocation: EditableLocation
   costCurrencyCode: String
+  costMajor: Int
   costMinor: Int
   date: String
   depth: String
@@ -11296,6 +11297,8 @@ input MyCollectionCreateArtworkInput {
   isEdition: Boolean
   medium: String
   metric: String
+
+  # @deprecated use the cost major and cost minor fields instead
   pricePaidCents: Int
   pricePaidCurrency: String
   provenance: String
@@ -11366,6 +11369,7 @@ input MyCollectionUpdateArtworkInput {
   # The given location of the user as structured data
   collectorLocation: EditableLocation
   costCurrencyCode: String
+  costMajor: Int
   costMinor: Int
   date: String
   depth: String

--- a/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
@@ -12,6 +12,7 @@ import { MyCollectionArtworkMutationType } from "./myCollection"
 import {
   ArtworkAttributionClassEnum,
   computeImageSources,
+  transformToPricePaidCents,
 } from "./myCollectionCreateArtworkMutation"
 import { EditableLocationFields } from "./update_me_mutation"
 
@@ -21,6 +22,7 @@ interface MyCollectionArtworkUpdateMutationInput {
   attributionClass?: string
   category?: string
   costCurrencyCode?: string
+  costMajor?: number
   costMinor?: number
   date?: string
   depth?: string
@@ -57,6 +59,9 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
     },
     costCurrencyCode: {
       type: GraphQLString,
+    },
+    costMajor: {
+      type: GraphQLInt,
     },
     costMinor: {
       type: GraphQLInt,
@@ -122,20 +127,21 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
   },
   mutateAndGetPayload: async (
     {
-      artworkId,
       artistIds,
+      artworkId,
+      artworkLocation,
+      attributionClass,
+      collectorLocation,
       costCurrencyCode,
+      costMajor,
       costMinor,
-      isEdition,
       editionNumber,
       editionSize,
       externalImageUrls = [],
-      artworkLocation,
-      collectorLocation,
+      isEdition,
       pricePaidCents,
       pricePaidCurrency,
       submissionId,
-      attributionClass,
       ...rest
     },
     {
@@ -156,6 +162,12 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
       return new Error("You need to be signed in to perform this action")
     }
 
+    const transformedPricePaidCents = transformToPricePaidCents({
+      costMajor,
+      costMinor,
+      pricePaidCents,
+    })
+
     try {
       const response = await updateArtworkLoader(artworkId, {
         artists: artistIds,
@@ -163,7 +175,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
         cost_minor: costMinor,
         artwork_location: artworkLocation,
         collector_location: collectorLocation,
-        price_paid_cents: pricePaidCents,
+        price_paid_cents: transformedPricePaidCents,
         price_paid_currency: pricePaidCurrency,
         attribution_class: attributionClass,
         submission_id: submissionId,


### PR DESCRIPTION
This PR resolves: [CX-2847]


This PR allows us to send the price paid for my collection artwork in the more common way we do it in MP by specifying the cost major and cost minor separately.

Co-authored-by: Daria Kozlova <daria.kozlova@artsymail.com>
Co-authored-by: Kizito Egeonu <kizito.egeonu@gmail.com>
Co-authored-by: Sultan Al-Maari <sultan.al-maari@artsymail.com>

[CX-2847]: https://artsyproduct.atlassian.net/browse/CX-2847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ