### PR TITLE
fix(partner): do not return invalid href

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11867,6 +11867,8 @@ type Partner implements Node {
   fullProfileEligible: Boolean
     @deprecated(reason: "Prefer displayFullPartnerPage")
   hasFairPartnership: Boolean
+
+  # The url for a partner. May be `null` if partner is not eligible for page.
   href: String
 
   # A globally unique ID.

--- a/src/schema/v2/partner/__tests__/partner.test.js
+++ b/src/schema/v2/partner/__tests__/partner.test.js
@@ -1586,4 +1586,44 @@ describe("Partner type", () => {
       })
     })
   })
+
+  describe("#href", () => {
+    it("returns an href when partner type is eligible for a page", async () => {
+      partnerData.type = "Gallery"
+
+      const query = gql`
+        {
+          partner(id: "catty-partner") {
+            href
+          }
+        }
+      `
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        partner: {
+          href: "/partner/catty-partner",
+        },
+      })
+    })
+
+    it("returns null when partner type is not eligible for a page", async () => {
+      partnerData.type = "Auction"
+
+      const query = gql`
+        {
+          partner(id: "catty-partner") {
+            href
+          }
+        }
+      `
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        partner: {
+          href: null,
+        },
+      })
+    })
+  })
 })

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -73,6 +73,9 @@ const partnerTitleContent = (type) => {
   return result
 }
 
+const isPartnerPageEligible = ({ type }) =>
+  ["Gallery", "Institution", "Institutional Seller", "Brand"].includes(type)
+
 const artworksArgs: GraphQLFieldConfigArgumentMap = {
   artworkIDs: {
     type: new GraphQLList(GraphQLString),
@@ -563,10 +566,10 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       },
       href: {
         type: GraphQLString,
-        resolve: ({ type, default_profile_id, id }) =>
-          type === "Auction"
-            ? `/auction/${default_profile_id}`
-            : `/partner/${id}`,
+        description:
+          "The url for a partner. May be `null` if partner is not eligible for page.",
+        resolve: (partner) =>
+          isPartnerPageEligible(partner) ? `/partner/${partner.id}` : null,
       },
       initials: initials("name"),
       isDefaultProfilePublic: {
@@ -592,10 +595,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       },
       partnerPageEligible: {
         type: GraphQLBoolean,
-        resolve: ({ type }) =>
-          ["Gallery", "Institution", "Institutional Seller", "Brand"].includes(
-            type
-          ),
+        resolve: isPartnerPageEligible,
       },
       fullProfileEligible: {
         deprecationReason: "Prefer displayFullPartnerPage",


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-4484

Auction artwork pages were rendering links to auction profile pages that were unreachable and 404-ing

In https://github.com/artsy/force/pull/11465 we addressed that on the client side.

This goes a step further and ensures that we don't return a partner `href` for partner types that are not eligible for public pages in the first place, such as Auction, Demo, Private Dealer, etc.

(Note that CI is failing on some python build step at the moment; tests seem ok.)