### PR TITLE
feat: add user coordinates for user location

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7650,6 +7650,9 @@ input EditableLocation {
   # The city the location is based in
   city: String
 
+  # The optional location coordinates. [lat, lng]
+  coordinates: [Float!]
+
   # The county the location is based in
   country: String
 

--- a/src/schema/v2/me/update_me_mutation.ts
+++ b/src/schema/v2/me/update_me_mutation.ts
@@ -3,6 +3,8 @@ import {
   GraphQLFloat,
   GraphQLInputObjectType,
   GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
   GraphQLUnionType,
@@ -56,6 +58,10 @@ export const EditableLocationFields = new GraphQLInputObjectType({
     stateCode: {
       description: "The (optional) state code of the state for location",
       type: GraphQLString,
+    },
+    coordinates: {
+      description: "The optional location coordinates. [lat, lng]",
+      type: GraphQLList(GraphQLNonNull(GraphQLFloat)),
     },
   },
 })


### PR DESCRIPTION
This PR adds new field `coordinates` for `updateMyUserProfile` mutation to set correct user's timezone after address update.

JIRA - [TX-926]

[TX-926]: https://artsyproduct.atlassian.net/browse/TX-926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ