### PR TITLE
feat: add trim option to strip away lot label past first alphanumeric chunk

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14513,7 +14513,10 @@ type SaleArtwork implements ArtworkEdgeInterface & Node {
   isWatching: Boolean
   isWithReserve: Boolean
   lotID: String
-  lotLabel: String
+  lotLabel(
+    # Whether to trim anything past the first alphanumeric chunk
+    trim: Boolean = false
+  ): String
   lotState: CausalityLotState
   lowEstimate: SaleArtworkLowEstimate
   minimumNextBid: SaleArtworkMinimumNextBid

--- a/src/schema/v2/__tests__/sale_artwork.test.js
+++ b/src/schema/v2/__tests__/sale_artwork.test.js
@@ -624,6 +624,39 @@ describe("SaleArtwork type", () => {
     })
   })
 
+  describe("lotLabel", () => {
+    const query = ({ trim }) =>
+      gql`
+        {
+          node(id: "${toGlobalId("SaleArtwork", "54c7ed2a7261692bfa910200")}") {
+            ... on SaleArtwork {
+              lotLabel(trim: ${trim})
+            }
+          }
+        }
+      `
+
+    beforeEach(() => {
+      saleArtwork.lot_label = "123456b - Curated by Cereus Art"
+    })
+
+    it("returns the lot label", async () => {
+      expect(await execute(query({ trim: false }), saleArtwork)).toEqual({
+        node: {
+          lotLabel: "123456b - Curated by Cereus Art",
+        },
+      })
+    })
+
+    it("trims away anything past the first alphanumeric chunk if trim option is enabled", async () => {
+      expect(await execute(query({ trim: true }), saleArtwork)).toEqual({
+        node: {
+          lotLabel: "123456b",
+        },
+      })
+    })
+  })
+
   describe("formattedStartDateTime", () => {
     const query = gql`
       {

--- a/src/schema/v2/sale_artwork.ts
+++ b/src/schema/v2/sale_artwork.ts
@@ -315,7 +315,16 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
       },
       lotLabel: {
         type: GraphQLString,
-        resolve: ({ lot_label }) => lot_label,
+        args: {
+          trim: {
+            type: GraphQLBoolean,
+            description:
+              "Whether to trim anything past the first alphanumeric chunk",
+            defaultValue: false,
+          },
+        },
+        resolve: ({ lot_label }, { trim }) =>
+          trim ? lot_label?.match(/\S+/)?.shift() : lot_label,
       },
       lotID: {
         type: GraphQLString,


### PR DESCRIPTION
We've encountered cases where sale artworks in Gravity have non-numeric characters to store metadata related to the lot. This isn't a recommended use of the lot label field. As an alternative, we've recommended that colleagues use the `blurb` field which is also exposed on the same surfaces across web and app ([Slack](https://artsy.slack.com/archives/C02RAMW9QQJ/p1664364783118159)).

This PR updates the lotLabel resolver to accept an optional `trim` argument (default=false) to strip away anything past the first alphanumeric chunk from the Gravity-backed input. We'll use this in clients that need a shorter display string but we might consider adding this formatting and perhaps validation upstream in Gravity.

**Desired design**:

<img width="376" alt="Screenshot 2022-12-07 at 19 33 36" src="https://user-images.githubusercontent.com/123595/206267323-f7f8039c-2e6f-40f7-8d29-e6ab96150645.png">

**Example of undesired use of the `lotLabel` field**:

<img src="https://user-images.githubusercontent.com/123595/206267415-04fb4955-fd31-402b-af78-de25115e813d.png" width=300 />