### PR TITLE
fix: return isForSale=false if artwork is sold

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -3896,4 +3896,36 @@ describe("Artwork type", () => {
       })
     })
   })
+
+  describe("isForSale", () => {
+    const query = `
+      {
+        artwork(id: "foo-bar") {
+          isForSale
+        }
+      }
+    `
+
+    //
+    // FIXME: We've seen cases on the backend, especially when edition sets are
+    // involved, where the availability of the partent artwork is not aligned
+    // with overall availability of its edition sets and the `sold` attribute.
+    // When all of an artwork's edition sets have sold, the parent artwork
+    // _should_ transition to a "not for sale" availability. While we look into
+    // why that isn't reliably happening, this patch ensures that we return
+    // false if the artwork is considered sold.
+    //
+    it("should return false if the artwork is marked as sold", async () => {
+      artwork.forsale = true
+      artwork.sold = true
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          isForSale: false,
+        },
+      })
+    })
+  })
 })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -760,7 +760,10 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ images }) => !!(_.first(images) && images[0].downloadable),
       },
       isEmbeddableVideo: { type: GraphQLBoolean, resolve: isEmbeddedVideo },
-      isForSale: { type: GraphQLBoolean, resolve: ({ forsale }) => forsale },
+      isForSale: {
+        type: GraphQLBoolean,
+        resolve: ({ forsale, sold }) => forsale && !sold,
+      },
       isHangable: {
         type: GraphQLBoolean,
         resolve: (artwork) => {


### PR DESCRIPTION
Patches a backend data issue for which an artwork can be both available for sale _and_ sold at the same time.

See [this Slack thread](https://artsy.slack.com/archives/CP9P4KR35/p1669977785252689) for more context.