### PR TITLE
Refactor: Use of reserved word ID in ConsignmentInquiry type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5560,7 +5560,7 @@ type ConsignmentInquiry {
   email: String!
 
   # id of the ConsignmentInquiry
-  id: Int!
+  internalID: Int!
 
   # Message of the inquirer
   message: String!

--- a/src/schema/v2/consignments/__tests__/createConsignmentInquiryMutation.test.js
+++ b/src/schema/v2/consignments/__tests__/createConsignmentInquiryMutation.test.js
@@ -27,7 +27,7 @@ describe("CreateConsignmentInquiryMutation", () => {
       consignmentInquiryOrError {
         ... on ConsignmentInquiryMutationSuccess {
           consignmentInquiry {
-            id
+            internalID
             name
             email
             message
@@ -51,7 +51,7 @@ describe("CreateConsignmentInquiryMutation", () => {
         consignmentInquiryOrError: {
           consignmentInquiry: {
             email: "user@art.com",
-            id: 1,
+            internalID: 1,
             message: "This is my message to you",
             name: "User",
             userId: "1234gravity",

--- a/src/schema/v2/consignments/createConsignmentInquiryMutation.ts
+++ b/src/schema/v2/consignments/createConsignmentInquiryMutation.ts
@@ -16,7 +16,7 @@ import { ResolverContext } from "types/graphql"
 const ConsignmentInquiryType = new GraphQLObjectType<any, ResolverContext>({
   name: "ConsignmentInquiry",
   fields: () => ({
-    id: {
+    internalID: {
       type: new GraphQLNonNull(GraphQLInt),
       description: "id of the ConsignmentInquiry",
     },
@@ -53,11 +53,12 @@ const MutationSuccessType = new GraphQLObjectType<any, ResolverContext>({
       type: ConsignmentInquiryType,
       resolve: (consignmentInquiry) => {
         const result = {}
-        const { gravity_user_id, ...otherFields } = consignmentInquiry
+        const { gravity_user_id, id, ...otherFields } = consignmentInquiry
         const keys = Object.keys(otherFields)
         keys.forEach((key) => {
           result[camelCase(key)] = consignmentInquiry[key]
         })
+        result["internalID"] = id
         result["userId"] = consignmentInquiry.gravity_user_id ?? null
         return result
       },


### PR DESCRIPTION
### Description
- Refactor to use internalID as the key for id in ConsignmentInquiry type since id is a reserved word in Relay. Clients using Relay such as Eigen are unable to query for the field id of a consignment inquiry.