### PR TITLE
fix(filter): force undefined when partners filters are not present

### DIFF
--- a/src/schema/v2/conversation/conversations.ts
+++ b/src/schema/v2/conversation/conversations.ts
@@ -85,11 +85,9 @@ const Conversations: GraphQLFieldConfig<
         intercepted: false,
         to_id: args.partnerId,
         to_type: "Partner",
-
-        // TODO
-        dismissed: args.dismissed,
-        has_message: args.hasMessage,
-        has_reply: args.hasReply,
+        has_reply: args.hasReply ?? undefined,
+        has_message: args.hasMessage ?? undefined,
+        dismissed: args.dismissed ?? undefined,
       }
       // User
     } else {


### PR DESCRIPTION
Related to #4530 

We notice Impulse returning errors when we don't pass these args, now forcing them to `undefined` if they're not present solves the issue.

cc @artsy/negotiate-devs 