### PR TITLE
refactor(gemini): uses @artsy/img to mint urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "author": "Art.sy Inc",
   "license": "MIT",
   "dependencies": {
+    "@artsy/img": "^1.0.0",
     "@artsy/morgan": "^1.0.2",
     "@artsy/multienv": "^1.2.0",
     "@artsy/to-title-case": "^1.1.0",

--- a/src/schema/v2/image/services/gemini.ts
+++ b/src/schema/v2/image/services/gemini.ts
@@ -1,40 +1,21 @@
-import urljoin from "url-join"
-import { isExisty, toQueryString } from "lib/helpers"
 import config from "config"
+import { configureImageServices, ResizeMode } from "@artsy/img"
 
 const { GEMINI_ENDPOINT } = config
+
+const services = configureImageServices({
+  gemini: {
+    endpoint: GEMINI_ENDPOINT!,
+  },
+})
 
 const DEFAULT_1X_QUALITY = 80
 const DEFAULT_2X_QUALITY = 50
 export const DEFAULT_SRCSET_QUALITY = [DEFAULT_1X_QUALITY, DEFAULT_2X_QUALITY]
 
-type Mode = "resize" | "crop"
-
-interface ResizeTo {
-  mode: Mode
-  width?: number
-  height?: number
-}
-
-const resizeTo = ({ mode, width, height }: ResizeTo) => {
-  if (mode === "crop") {
-    return "fill"
-  }
-
-  if (isExisty(width) && !isExisty(height)) {
-    return "width"
-  }
-
-  if (isExisty(height) && !isExisty(width)) {
-    return "height"
-  }
-
-  return "fit"
-}
-
 interface Gemini {
   src: string
-  mode: Mode
+  mode: ResizeMode
   width?: number
   height?: number
   quality?: number
@@ -47,15 +28,5 @@ export const gemini = ({
   height,
   quality = DEFAULT_1X_QUALITY,
 }: Gemini): string => {
-  const options = {
-    resize_to: resizeTo({ mode, width, height }),
-    width,
-    height,
-    quality,
-    src,
-  }
-
-  const queryParams = toQueryString(options)
-
-  return urljoin(GEMINI_ENDPOINT, `?${queryParams}`)
+  return services.gemini.exec(mode, src, { width, height, quality })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,6 +11,13 @@
     chokidar "^3.0.0"
     decache "^4.4.0"
 
+"@artsy/img@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@artsy/img/-/img-1.0.0.tgz#537162b159085758663e757bdaabba01b1b0d73f"
+  integrity sha512-rtc/vn5rSt3Roo/hVbZBicE/OgNFqc36CMDeqvA/Y4s52Q8omCUw9lTHogiMHziOGubZq9HckDjsUE79mlvnJQ==
+  dependencies:
+    md5 "^2.3.0"
+
 "@artsy/morgan@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@artsy/morgan/-/morgan-1.0.2.tgz#b1e0704bef59bb0329357c0648c22376a92bc5f9"
@@ -3077,6 +3084,11 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+charenc@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+  integrity sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==
+
 chokidar@^3.0.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.0.tgz#b30611423ce376357c765b9b8f904b9fba3c0be8"
@@ -3466,6 +3478,11 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+crypt@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
+  integrity sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==
 
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
@@ -5409,7 +5426,7 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
-is-buffer@^1.1.5:
+is-buffer@^1.1.5, is-buffer@~1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -6807,6 +6824,15 @@ marked@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/marked/-/marked-2.0.1.tgz#5e7ed7009bfa5c95182e4eb696f85e948cefcee3"
   integrity sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==
+
+md5@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
+  integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
+  dependencies:
+    charenc "0.0.2"
+    crypt "0.0.2"
+    is-buffer "~1.1.6"
 
 media-typer@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
With this we shouldn't see any changes to the URL output (so specs should pass) since these were already being alphabetized.