### PR TITLE
chore: format sale date string into date

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17058,7 +17058,14 @@ type UserPurchasesEdge {
   # The item at the end of the edge
   node: Artwork
   ownerType: String
-  saleDate: String
+  saleDate(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See
+    # http://www.iana.org/time-zones,
+    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
   salePrice: Float
   source: String
 }

--- a/src/schema/v2/userPurchases.ts
+++ b/src/schema/v2/userPurchases.ts
@@ -8,6 +8,7 @@ import {
 import { IDFields } from "./object_identification"
 import { ArtworkType } from "./artwork"
 import { connectionWithCursorInfo } from "schema/v2/fields/pagination"
+import { date } from "./fields/date"
 
 export const edgeFields: Thunk<GraphQLFieldConfigMap<
   any,
@@ -16,7 +17,7 @@ export const edgeFields: Thunk<GraphQLFieldConfigMap<
   ...IDFields,
   ownerType: { type: GraphQLString, resolve: ({ owner_type }) => owner_type },
   salePrice: { type: GraphQLFloat, resolve: ({ sale_price }) => sale_price },
-  saleDate: { type: GraphQLString, resolve: ({ sale_date }) => sale_date },
+  saleDate: date(({ sale_date }) => sale_date),
   source: { type: GraphQLString },
 })
 


### PR DESCRIPTION
I used the helper `date` to send a better formated version of the sale date to forque, because over in forque we don't have moment.js and formatting there would mean creating a new helper in forque.