### PR TITLE
feat: allow X-Image-Service header to specify backend image service

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -142,6 +142,7 @@ const graphqlServer = graphqlHTTP((req, res, params) => {
   const userID = req.headers["x-user-id"] as string | undefined
   const timezone = req.headers["x-timezone"] as string | undefined
   const userAgent = req.headers["user-agent"]
+  const imageService = req.headers["x-image-service"] as string | undefined
 
   const { requestIDs } = res.locals
   const requestID = requestIDs.requestID
@@ -173,6 +174,7 @@ const graphqlServer = graphqlHTTP((req, res, params) => {
     requestIDs,
     userAgent,
     appToken,
+    imageService,
   }
 
   const validationRules = [

--- a/src/schema/v2/image/cropped.ts
+++ b/src/schema/v2/image/cropped.ts
@@ -1,4 +1,5 @@
-import { DEFAULT_SRCSET_QUALITY, gemini } from "./services"
+import { getImageService } from "./services"
+import { DEFAULT_SRCSET_QUALITY } from "./services/config"
 import { normalizeQuality, setVersion } from "./normalize"
 import {
   GraphQLObjectType,
@@ -33,13 +34,16 @@ export const croppedImageUrl = (
     width,
     height,
     quality = DEFAULT_SRCSET_QUALITY,
-  }: CroppedImageArguments
+  }: CroppedImageArguments,
+  { imageService = "gemini" } = {}
 ): CroppedImageUrl => {
   const src = setVersion(image as any, version)
 
   const [quality1x, quality2x] = normalizeQuality(quality)
 
-  const url1x = gemini({
+  const loader = getImageService(imageService)
+
+  const url1x = loader({
     src,
     mode: "crop",
     width,
@@ -47,7 +51,7 @@ export const croppedImageUrl = (
     quality: quality1x,
   })
 
-  const url2x = gemini({
+  const url2x = loader({
     src,
     mode: "crop",
     width: width * 2,

--- a/src/schema/v2/image/normalize.ts
+++ b/src/schema/v2/image/normalize.ts
@@ -12,7 +12,7 @@ import {
   find,
   curry,
 } from "lodash"
-import { DEFAULT_SRCSET_QUALITY } from "./services"
+import { DEFAULT_SRCSET_QUALITY } from "./services/config"
 
 export const grab: any = flow(pick, values, first)
 

--- a/src/schema/v2/image/resized.ts
+++ b/src/schema/v2/image/resized.ts
@@ -1,5 +1,6 @@
 import { MaxDimensions, scale } from "proportional-scale"
-import { DEFAULT_SRCSET_QUALITY, gemini } from "./services"
+import { getImageService } from "./services"
+import { DEFAULT_SRCSET_QUALITY } from "./services/config"
 import { normalizeQuality, setVersion } from "./normalize"
 import {
   GraphQLObjectType,
@@ -36,7 +37,8 @@ export const resizedImageUrl = (
     width: targetWidth,
     height: targetHeight,
     quality = DEFAULT_SRCSET_QUALITY,
-  }: ResizedImageArguments = {}
+  }: ResizedImageArguments = {},
+  { imageService = "gemini" } = {}
 ): ResizedImageUrl => {
   const src = setVersion(image as any, version)
 
@@ -81,7 +83,9 @@ export const resizedImageUrl = (
   const proxiedHeight = scaled.height || targetHeight
   const [quality1x, quality2x] = normalizeQuality(quality)
 
-  const url1x = gemini({
+  const loader = getImageService(imageService)
+
+  const url1x = loader({
     src,
     mode: "resize",
     width: proxiedWidth,
@@ -89,7 +93,7 @@ export const resizedImageUrl = (
     quality: quality1x,
   })
 
-  const url2x = gemini({
+  const url2x = loader({
     src,
     mode: "resize",
     width: (proxiedWidth || 0) * 2 || undefined,

--- a/src/schema/v2/image/services/config.ts
+++ b/src/schema/v2/image/services/config.ts
@@ -1,0 +1,28 @@
+import config from "config"
+import { configureImageServices } from "@artsy/img"
+
+export const DEFAULT_1X_QUALITY = 80
+const DEFAULT_2X_QUALITY = 50
+export const DEFAULT_SRCSET_QUALITY = [DEFAULT_1X_QUALITY, DEFAULT_2X_QUALITY]
+
+const { GEMINI_ENDPOINT } = config
+
+export const services = configureImageServices({
+  gemini: {
+    endpoint: GEMINI_ENDPOINT!,
+  },
+  // TODO: The below should be ENV-ified and have separate staging values?
+  lambda: {
+    endpoint: "https://d1j88w5k23s1nr.cloudfront.net",
+    sources: [
+      {
+        source: "https://d32dm0rphc51dk.cloudfront.net",
+        bucket: "artsy-media-assets",
+      },
+      {
+        source: "https://files.artsy.net",
+        bucket: "artsy-vanity-files-production",
+      },
+    ],
+  },
+})

--- a/src/schema/v2/image/services/index.ts
+++ b/src/schema/v2/image/services/index.ts
@@ -1,1 +1,14 @@
-export * from "./gemini"
+import { gemini } from "./gemini"
+import { lambda } from "./lambda"
+
+export const getImageService = (service: string) => {
+  if (service === "gemini") {
+    return gemini
+  }
+
+  if (service === "lambda") {
+    return lambda
+  }
+
+  return gemini
+}

--- a/src/schema/v2/image/services/lambda.ts
+++ b/src/schema/v2/image/services/lambda.ts
@@ -1,7 +1,7 @@
 import { ResizeMode } from "@artsy/img"
 import { services, DEFAULT_1X_QUALITY } from "./config"
 
-interface Gemini {
+interface Lambda {
   src: string
   mode: ResizeMode
   width?: number
@@ -9,12 +9,12 @@ interface Gemini {
   quality?: number
 }
 
-export const gemini = ({
+export const lambda = ({
   src,
   mode,
   width,
   height,
   quality = DEFAULT_1X_QUALITY,
-}: Gemini): string => {
-  return services.gemini.exec(mode, src, { width, height, quality })
+}: Lambda): string => {
+  return services.lambda.exec(mode, src, { width, height, quality })
 }

--- a/src/types/graphql.d.ts
+++ b/src/types/graphql.d.ts
@@ -29,6 +29,10 @@ export interface ResolverContextValues {
    * to the MP `Image` type
    */
   imageData?: ImageData
+
+  /** Sent as a X-Image-Service header from Force, when a specific
+   * image service is desired to be used. */
+  imageService?: string
 }
 
 export type ResolverContext = ResolverContextValues &


### PR DESCRIPTION
This supports `X-Image-Service` to be set (or not), and if set will support "gemini" and "lambda" as possible values (which will switch support for which image service provides resized and cropped URL's). The default fallback is "gemini".