### PR TITLE
feat(me): adds quiz field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10676,6 +10676,9 @@ type Me implements Node {
   privacy: String
   profession: String
 
+  # The art quiz of a logged-in user
+  quiz: Quiz!
+
   # This user should receive lot opening notifications
   receiveLotOpeningSoonNotification: Boolean
 

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -58,6 +58,7 @@ import { SaleRegistrationConnection } from "./sale_registrations"
 import { SavedArtworks } from "./savedArtworks"
 import { ShowsByFollowedArtists } from "./showsByFollowedArtists"
 import { WatchedLotConnection } from "./watchedLotConnection"
+import { quiz } from "../quiz"
 
 /**
  * @deprecated: Please use the CollectorProfile type instead of adding fields to me directly.
@@ -300,6 +301,7 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
       description: "Collector's position with relevant institutions",
       resolve: collectorProfileResolver("other_relevant_positions"),
     },
+    quiz,
     receivePurchaseNotification: {
       description: "This user should receive purchase notifications",
       type: GraphQLBoolean,


### PR DESCRIPTION
Generally anything the `UserType` has the `MeType` should have as well. And easy to add. It's simpler and more consistent to be querying for things from the logged in user rather than having to pull the ID out of the current user and querying for it that way.