### PR TITLE
feat(quiz): exposes saved artworks field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14289,6 +14289,7 @@ type Quiz {
     page: Int
     size: Int
   ): QuizArtworkConnection
+  savedArtworks: [Artwork!]!
 }
 
 # A connection to a list of items.

--- a/src/schema/v2/quiz.ts
+++ b/src/schema/v2/quiz.ts
@@ -1,11 +1,12 @@
-import { GraphQLFieldConfig } from "graphql"
+import { GraphQLFieldConfig, GraphQLList } from "graphql"
 import { GraphQLNonNull, GraphQLObjectType } from "graphql"
 import { InternalIDFields } from "schema/v2/object_identification"
 import { quizArtworkConnection } from "./quizArtworkConnection"
 import { ResolverContext } from "types/graphql"
 import { date } from "schema/v2/fields/date"
+import { ArtworkType } from "./artwork"
 
-export const QuizType = new GraphQLObjectType({
+export const QuizType = new GraphQLObjectType<any, ResolverContext>({
   name: "Quiz",
   fields: () => ({
     ...InternalIDFields,
@@ -13,6 +14,26 @@ export const QuizType = new GraphQLObjectType({
     completedAt: date(
       ({ completed_at }: { completed_at: string | null }) => completed_at
     ),
+    savedArtworks: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(ArtworkType))
+      ),
+      resolve: async ({ quiz_artworks }, _, { savedArtworkLoader }) => {
+        if (!savedArtworkLoader) return []
+
+        try {
+          const artworks = await Promise.all(
+            quiz_artworks.map(({ artwork_id }) => {
+              return savedArtworkLoader(artwork_id)
+            })
+          )
+
+          return artworks.filter(({ is_saved }) => is_saved)
+        } catch (error) {
+          return []
+        }
+      },
+    },
   }),
 })
 


### PR DESCRIPTION
Quick little optimization since we're doing it in a few places. Doesn't need to be a connection since it's a bounded list that won't be paginated.