### PR TITLE
feat(type): expose types from InquirerCollectorProfile on CollectorProfileType

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3536,7 +3536,19 @@ type CollectorProfileArtists {
 }
 
 type CollectorProfileType {
+  artsyUserSince(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See
+    # http://www.iana.org/time-zones,
+    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+  bio: String
   collectorLevel: Int
+
+  # List of artists the Collector is interested in.
+  collectorProfileArtists: [CollectorProfileArtists]
   companyName: String
   companyWebsite: String
   confirmedBuyerAt(
@@ -3548,14 +3560,20 @@ type CollectorProfileType {
     timezone: String
   ): String
   email: String
+  emailConfirmed: Boolean
+  icon: Image
 
   # A globally unique ID.
   id: ID!
+  identityVerified: Boolean
   institutionalAffiliations: String
   intents: [String]
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
+  isActiveBidder: Boolean
+  isActiveInquirer: Boolean
+  location: MyLocation
   loyaltyApplicantAt(
     format: String
 
@@ -3565,7 +3583,14 @@ type CollectorProfileType {
     timezone: String
   ): String
   name: String
+
+  # Collector's position with relevant institutions
+  otherRelevantPositions: String
+
+  # User ID of the collector profile's owner
+  ownerID: ID!
   privacy: String
+  profession: String
   professionalBuyerAppliedAt(
     format: String
 
@@ -16266,8 +16291,20 @@ input UpdateCollectorProfileInput {
 }
 
 type UpdateCollectorProfilePayload {
+  artsyUserSince(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See
+    # http://www.iana.org/time-zones,
+    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+  bio: String
   clientMutationId: String
   collectorLevel: Int
+
+  # List of artists the Collector is interested in.
+  collectorProfileArtists: [CollectorProfileArtists]
   companyName: String
   companyWebsite: String
   confirmedBuyerAt(
@@ -16279,14 +16316,20 @@ type UpdateCollectorProfilePayload {
     timezone: String
   ): String
   email: String
+  emailConfirmed: Boolean
+  icon: Image
 
   # A globally unique ID.
   id: ID!
+  identityVerified: Boolean
   institutionalAffiliations: String
   intents: [String]
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
+  isActiveBidder: Boolean
+  isActiveInquirer: Boolean
+  location: MyLocation
   loyaltyApplicantAt(
     format: String
 
@@ -16296,7 +16339,14 @@ type UpdateCollectorProfilePayload {
     timezone: String
   ): String
   name: String
+
+  # Collector's position with relevant institutions
+  otherRelevantPositions: String
+
+  # User ID of the collector profile's owner
+  ownerID: ID!
   privacy: String
+  profession: String
   professionalBuyerAppliedAt(
     format: String
 

--- a/src/schema/v2/CollectorProfile/collectorProfile.ts
+++ b/src/schema/v2/CollectorProfile/collectorProfile.ts
@@ -1,16 +1,21 @@
 import date from "schema/v2/fields/date"
 import { InternalIDFields } from "schema/v2/object_identification"
 import {
+  GraphQLID,
   GraphQLObjectType,
   GraphQLString,
   GraphQLInt,
+  GraphQLBoolean,
   GraphQLList,
   GraphQLFieldConfigMap,
   GraphQLNonNull,
   GraphQLFieldConfig,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
+import Image, { normalizeImageData } from "schema/v2/image"
+
 import { userInterestType } from "../userInterests"
+import { myLocationType } from "../me/myLocation"
 
 export const CollectorProfileFields: GraphQLFieldConfigMap<
   any,
@@ -50,6 +55,58 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
     resolve: (_collectorProfile, _args, { meUserInterestsLoader }) => {
       return meUserInterestsLoader?.()
     },
+  },
+
+  // moved InquirerCollectorProfileFields here
+  location: { type: myLocationType },
+  artsyUserSince: date,
+  ownerID: {
+    type: new GraphQLNonNull(GraphQLID),
+    description: "User ID of the collector profile's owner",
+    resolve: ({ owner: { id } }) => id,
+  },
+  icon: {
+    type: Image.type,
+    resolve: ({ icon }) => normalizeImageData(icon),
+  },
+  bio: {
+    type: GraphQLString,
+  },
+  profession: { type: GraphQLString },
+  otherRelevantPositions: {
+    type: GraphQLString,
+    description: "Collector's position with relevant institutions",
+    resolve: ({ other_relevant_positions }) => other_relevant_positions,
+  },
+  emailConfirmed: {
+    type: GraphQLBoolean,
+    resolve: ({ owner }) => !!owner.confirmed_at,
+  },
+  identityVerified: {
+    type: GraphQLBoolean,
+    resolve: ({ owner }) => owner.identity_verified,
+  },
+  isActiveInquirer: {
+    type: GraphQLBoolean,
+    resolve: ({ artwork_inquiry_requests_count }) =>
+      artwork_inquiry_requests_count >= 25,
+  },
+  isActiveBidder: {
+    type: GraphQLBoolean,
+    resolve: ({ previously_registered_for_auction }) =>
+      previously_registered_for_auction ?? false,
+  },
+  collectorProfileArtists: {
+    type: new GraphQLList(
+      new GraphQLObjectType<any, ResolverContext>({
+        name: "CollectorProfileArtists",
+        fields: {
+          name: { type: GraphQLString },
+        },
+      })
+    ),
+    description: "List of artists the Collector is interested in.",
+    resolve: ({ collected_artist_names }) => collected_artist_names,
   },
 }
 

--- a/src/schema/v2/me/__tests__/collector_profile.test.js
+++ b/src/schema/v2/me/__tests__/collector_profile.test.js
@@ -14,6 +14,14 @@ describe("Me", () => {
               selfReportedPurchases
               intents
               privacy
+              profession
+              emailConfirmed
+              identityVerified 
+              isActiveInquirer
+              isActiveBidder
+              collectorProfileArtists {
+                name
+              }
             }
           }
         }
@@ -26,6 +34,17 @@ describe("Me", () => {
         self_reported_purchases: "treats",
         intents: ["buy art & design"],
         privacy: "public",
+        owner: {
+          location: {
+            display: "Germany",
+          },
+          confirmed_at: "2022-12-19",
+          identity_verified: true,
+        },
+        profession: "typer",
+        artwork_inquiry_requests_count: 25,
+        previously_registered_for_auction: false,
+        collected_artist_names: [{ name: "Gumball" }, { name: "Edgar" }],
       }
 
       const expectedProfileData = {
@@ -35,6 +54,12 @@ describe("Me", () => {
         selfReportedPurchases: "treats",
         intents: ["buy art & design"],
         privacy: "public",
+        profession: "typer",
+        emailConfirmed: true,
+        identityVerified: true,
+        isActiveInquirer: true,
+        isActiveBidder: false,
+        collectorProfileArtists: [{ name: "Gumball" }, { name: "Edgar" }],
       }
 
       const context = {

--- a/src/schema/v2/partner/partnerInquirerCollectorProfile.ts
+++ b/src/schema/v2/partner/partnerInquirerCollectorProfile.ts
@@ -1,80 +1,19 @@
 import {
-  GraphQLBoolean,
   GraphQLFieldConfig,
   GraphQLFieldConfigMap,
-  GraphQLID,
-  GraphQLList,
-  GraphQLNonNull,
   GraphQLObjectType,
-  GraphQLString,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
-import date from "schema/v2/fields/date"
-import Image, { normalizeImageData } from "schema/v2/image"
 import { CollectorProfileFields } from "schema/v2/CollectorProfile/collectorProfile"
-import { myLocationType } from "schema/v2/me/myLocation"
-
-export const CollectorProfileArtists = new GraphQLObjectType<
-  any,
-  ResolverContext
->({
-  name: "CollectorProfileArtists",
-  fields: {
-    name: { type: GraphQLString },
-  },
-})
 
 const InquirerCollectorProfileFields: GraphQLFieldConfigMap<
   any,
   ResolverContext
 > = {
   ...CollectorProfileFields,
-  location: { type: myLocationType },
-  artsyUserSince: date,
-  ownerID: {
-    type: new GraphQLNonNull(GraphQLID),
-    description: "User ID of the collector profile's owner",
-    resolve: ({ owner: { id } }) => id,
-  },
-  icon: {
-    type: Image.type,
-    resolve: ({ icon }) => normalizeImageData(icon),
-  },
-  bio: {
-    type: GraphQLString,
-  },
-  profession: { type: GraphQLString },
-  otherRelevantPositions: {
-    type: GraphQLString,
-    description: "Collector's position with relevant institutions",
-    resolve: ({ other_relevant_positions }) => other_relevant_positions,
-  },
-  emailConfirmed: {
-    type: GraphQLBoolean,
-    resolve: ({ owner }) => !!owner.confirmed_at,
-  },
-  identityVerified: {
-    type: GraphQLBoolean,
-    resolve: ({ owner }) => owner.identity_verified,
-  },
-  isActiveInquirer: {
-    type: GraphQLBoolean,
-    resolve: ({ artwork_inquiry_requests_count }) =>
-      artwork_inquiry_requests_count >= 25,
-  },
-  isActiveBidder: {
-    type: GraphQLBoolean,
-    resolve: ({ previously_registered_for_auction }) =>
-      previously_registered_for_auction ?? false,
-  },
-  collectorProfileArtists: {
-    type: new GraphQLList(CollectorProfileArtists),
-    description: "List of artists the Collector is interested in.",
-    resolve: ({ collected_artist_names }) => collected_artist_names,
-  },
 }
 
-const InquirerCollectorProfileType = new GraphQLObjectType<
+export const InquirerCollectorProfileType = new GraphQLObjectType<
   any,
   ResolverContext
 >({


### PR DESCRIPTION
[NX-3395]

Some fields we use to query on Volt V1 like [here](https://github.com/artsy/volt/blob/d2a043a7f249c27116fd8c8c0407a20cfaf67acc/app/javascript/v2/apps/CollectorProfile/CollectorProfile.tsx#L111) but they were not fully exposed to the `collectorProfile` on the `Conversation` level. 

We have the data already, we just don't expose it, this PR expands the fields expositions under `Conversation.fromUser.collectorProfile`.

cc @artsy/negotiate-devs 

[NX-3395]: https://artsyproduct.atlassian.net/browse/NX-3395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ