### PR TITLE
feat: only non-expired credit cards are qualified

### DIFF
--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -219,7 +219,7 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
               } = card
 
               // Moment months are 0-indexed
-              const expirationMoment = moment({
+              const expirationMoment = moment.utc({
                 year: expYear,
                 month: expMonth - 1,
               }).endOf("month")


### PR DESCRIPTION
Completes [TX-854](https://artsyproduct.atlassian.net/jira/software/c/projects/TX/boards/114?modal=detail&selectedIssue=TX-854)

This pr updates our `Me.hasQualifiedCreditCards` field to filter out expired cards, which are not 'qualified.'

I verified that cards are [still good during their expiration month](https://www.americanexpress.com/en-us/credit-cards/credit-intel/what-happens-when-credit-card-expires/), so only check whether the current date is after that.

I tried to take the quickest route to implementation and defaulted to measuring by utc. I considered adding a 1-day buffer to the expiration date to account for time zone weirdness, but that seemed like it might be confusing later, and really whether your card is considered qualified or not in this short period isn't very important since the field isn't currently used to process a charge immediately.