### PR TITLE
feat(graphql): deprecate emailConfirmed field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3567,6 +3567,9 @@ type CollectorProfileType {
   ): String
   email: String
   emailConfirmed: Boolean
+    @deprecated(
+      reason: "emailConfirmed is going to be removed, use isEmailConfirmed instead"
+    )
   icon: Image
 
   # A globally unique ID.
@@ -3579,6 +3582,7 @@ type CollectorProfileType {
   internalID: ID!
   isActiveBidder: Boolean
   isActiveInquirer: Boolean
+  isEmailConfirmed: Boolean
   location: MyLocation
   loyaltyApplicantAt(
     format: String
@@ -9856,6 +9860,9 @@ type InquirerCollectorProfile {
   ): String
   email: String
   emailConfirmed: Boolean
+    @deprecated(
+      reason: "emailConfirmed is going to be removed, use isEmailConfirmed instead"
+    )
   icon: Image
 
   # A globally unique ID.
@@ -9868,6 +9875,7 @@ type InquirerCollectorProfile {
   internalID: ID!
   isActiveBidder: Boolean
   isActiveInquirer: Boolean
+  isEmailConfirmed: Boolean
   location: MyLocation
   loyaltyApplicantAt(
     format: String
@@ -16342,6 +16350,9 @@ type UpdateCollectorProfilePayload {
   ): String
   email: String
   emailConfirmed: Boolean
+    @deprecated(
+      reason: "emailConfirmed is going to be removed, use isEmailConfirmed instead"
+    )
   icon: Image
 
   # A globally unique ID.
@@ -16354,6 +16365,7 @@ type UpdateCollectorProfilePayload {
   internalID: ID!
   isActiveBidder: Boolean
   isActiveInquirer: Boolean
+  isEmailConfirmed: Boolean
   location: MyLocation
   loyaltyApplicantAt(
     format: String

--- a/src/schema/v2/CollectorProfile/collectorProfile.ts
+++ b/src/schema/v2/CollectorProfile/collectorProfile.ts
@@ -80,6 +80,12 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
   },
   emailConfirmed: {
     type: GraphQLBoolean,
+    deprecationReason:
+      "emailConfirmed is going to be removed, use isEmailConfirmed instead",
+    resolve: ({ owner }) => !!owner.confirmed_at,
+  },
+  isEmailConfirmed: {
+    type: GraphQLBoolean,
     resolve: ({ owner }) => !!owner.confirmed_at,
   },
   identityVerified: {

--- a/src/schema/v2/me/__tests__/collector_profile.test.js
+++ b/src/schema/v2/me/__tests__/collector_profile.test.js
@@ -15,7 +15,7 @@ describe("Me", () => {
               intents
               privacy
               profession
-              emailConfirmed
+              isEmailConfirmed
               identityVerified 
               isActiveInquirer
               isActiveBidder
@@ -55,7 +55,7 @@ describe("Me", () => {
         intents: ["buy art & design"],
         privacy: "public",
         profession: "typer",
-        emailConfirmed: true,
+        isEmailConfirmed: true,
         identityVerified: true,
         isActiveInquirer: true,
         isActiveBidder: false,


### PR DESCRIPTION
This PR addresses this [request](https://github.com/artsy/metaphysics/pull/4628#discussion_r1053407946) deprecating `emailConfirmed` and adding `isEmailConfirmed` as an option.

We'll have PRs to update the clients to use the new field, then we can retire the field.