### PR TITLE
feat(art-quiz) create triggerCampaignMutation and gravity loader

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11525,6 +11525,9 @@ type Mutation {
     input: TransferMyCollectionInput!
   ): TransferMyCollectionPayload
 
+  # Triggers a campaign send.
+  triggerCampaign(input: TriggerCampaignInput!): TriggerCampaignPayload
+
   # Unlinks a 3rd party account
   unlinkAuthentication(
     input: UnlinkAuthenticationMutationInput!
@@ -16242,6 +16245,19 @@ union TransferMyCollectionSuccessOrErrorsUnion =
 
 type TrendingArtists {
   artists: [Artist]
+}
+
+enum TriggerCampaignID {
+  ART_QUIZ
+}
+
+input TriggerCampaignInput {
+  campaignID: TriggerCampaignID!
+  clientMutationId: String
+}
+
+type TriggerCampaignPayload {
+  clientMutationId: String
 }
 
 union UnderlyingCurrentEvent = Sale | Show

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16256,8 +16256,25 @@ input TriggerCampaignInput {
   clientMutationId: String
 }
 
+type TriggerCampaignMutationFailure {
+  message: String!
+  mutationError: GravityMutationError
+  statusCode: Int
+}
+
+type TriggerCampaignMutationSuccess {
+  message: String!
+  statusCode: Int
+  success: Boolean
+}
+
+union TriggerCampaignMutationSuccessOrError =
+    TriggerCampaignMutationFailure
+  | TriggerCampaignMutationSuccess
+
 type TriggerCampaignPayload {
   clientMutationId: String
+  successOrError: TriggerCampaignMutationSuccessOrError
 }
 
 union UnderlyingCurrentEvent = Sale | Show

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -498,6 +498,11 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    triggerCampaignLoader: gravityLoader(
+      "me/trigger_campaign",
+      {},
+      { method: "POST" }
+    ),
     unfollowArtistLoader: gravityLoader(
       (id) => `me/follow/artist/${id}`,
       {},

--- a/src/schema/v2/me/__tests__/triggerCampaignMutation.test.ts
+++ b/src/schema/v2/me/__tests__/triggerCampaignMutation.test.ts
@@ -1,0 +1,26 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("triggerCampaignMutation", () => {
+  const mutation = gql`
+    mutation {
+      triggerCampaign(input: { campaignID: ART_QUIZ }) {
+        clientMutationId
+      }
+    }
+  `
+
+  const mockTriggerCampaignLoader = jest
+    .fn()
+    .mockReturnValue(Promise.resolve({ success: true }))
+
+  it("passes correct values to gravity", async () => {
+    await runAuthenticatedQuery(mutation, {
+      triggerCampaignLoader: mockTriggerCampaignLoader,
+    })
+
+    expect(mockTriggerCampaignLoader).toHaveBeenCalledWith({
+      campaign_id: "art-quiz",
+    })
+  })
+})

--- a/src/schema/v2/me/__tests__/triggerCampaignMutation.test.ts
+++ b/src/schema/v2/me/__tests__/triggerCampaignMutation.test.ts
@@ -1,5 +1,13 @@
 import gql from "lib/gql"
 import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import config from "config"
+
+const CAMPAIGN_IDS = {
+  // New campaign IDs can be added by environment variable here
+  development: { ART_QUIZ: "485a7169-b3d8-4b0e-81f3-5741db0a1361" },
+  staging: { ART_QUIZ: "485a7169-b3d8-4b0e-81f3-5741db0a1361" },
+  production: { ART_QUIZ: "bcc384c0-348f-4449-e4c0-0ad9efa7707f" },
+}
 
 describe("triggerCampaignMutation", () => {
   const mutation = gql`
@@ -16,9 +24,7 @@ describe("triggerCampaignMutation", () => {
     }
   `
 
-  const mockTriggerCampaignLoader = jest
-    .fn()
-    .mockReturnValue(Promise.resolve({ success: true }))
+  const mockTriggerCampaignLoader = jest.fn()
 
   it("passes correct values to gravity", async () => {
     const response = await runAuthenticatedQuery(mutation, {
@@ -26,7 +32,7 @@ describe("triggerCampaignMutation", () => {
     })
 
     expect(mockTriggerCampaignLoader).toHaveBeenCalledWith({
-      campaign_id: "art-quiz",
+      campaign_id: CAMPAIGN_IDS[config.SYSTEM_ENVIRONMENT].ART_QUIZ,
     })
     expect(response.triggerCampaign.successOrError.success).toBe(true)
     expect(response.triggerCampaign.successOrError.statusCode).toBe(200)

--- a/src/schema/v2/me/__tests__/triggerCampaignMutation.test.ts
+++ b/src/schema/v2/me/__tests__/triggerCampaignMutation.test.ts
@@ -6,6 +6,11 @@ describe("triggerCampaignMutation", () => {
     mutation {
       triggerCampaign(input: { campaignID: ART_QUIZ }) {
         clientMutationId
+        successOrError {
+          ... on TriggerCampaignMutationSuccess {
+            success
+          }
+        }
       }
     }
   `
@@ -15,12 +20,13 @@ describe("triggerCampaignMutation", () => {
     .mockReturnValue(Promise.resolve({ success: true }))
 
   it("passes correct values to gravity", async () => {
-    await runAuthenticatedQuery(mutation, {
+    const response = await runAuthenticatedQuery(mutation, {
       triggerCampaignLoader: mockTriggerCampaignLoader,
     })
 
     expect(mockTriggerCampaignLoader).toHaveBeenCalledWith({
       campaign_id: "art-quiz",
     })
+    expect(response.triggerCampaign.successOrError.success).toBe(true)
   })
 })

--- a/src/schema/v2/me/__tests__/triggerCampaignMutation.test.ts
+++ b/src/schema/v2/me/__tests__/triggerCampaignMutation.test.ts
@@ -9,6 +9,7 @@ describe("triggerCampaignMutation", () => {
         successOrError {
           ... on TriggerCampaignMutationSuccess {
             success
+            statusCode
           }
         }
       }
@@ -28,5 +29,6 @@ describe("triggerCampaignMutation", () => {
       campaign_id: "art-quiz",
     })
     expect(response.triggerCampaign.successOrError.success).toBe(true)
+    expect(response.triggerCampaign.successOrError.statusCode).toBe(200)
   })
 })

--- a/src/schema/v2/me/triggerCampaignMutation.ts
+++ b/src/schema/v2/me/triggerCampaignMutation.ts
@@ -16,11 +16,10 @@ import {
 import config from "config"
 
 const CAMPAIGN_IDS = {
-  // TODO: replace w/ actual campaignIDs
-  // New campaign IDs can be added based on environment variable here
-  development: { ART_QUIZ: "art-quiz" },
-  staging: { ART_QUIZ: "art-quiz" },
-  production: { ART_QUIZ: "art-quiz" },
+  // New campaign IDs can be added by environment variable here
+  development: { ART_QUIZ: "485a7169-b3d8-4b0e-81f3-5741db0a1361" },
+  staging: { ART_QUIZ: "485a7169-b3d8-4b0e-81f3-5741db0a1361" },
+  production: { ART_QUIZ: "bcc384c0-348f-4449-e4c0-0ad9efa7707f" },
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
@@ -107,12 +106,17 @@ export const triggerCampaignMutation = mutationWithClientMutationId<
       return {
         success: true,
         statusCode: 200,
+        message: "Campaign successfully triggered",
       }
     } catch (error) {
       const formattedErr = formatGravityError(error)
 
       if (formattedErr) {
-        return { ...formattedErr, _type: "GravityMutationError" }
+        return {
+          ...formattedErr,
+          _type: "GravityMutationError",
+          message: "Campaign failed to trigger",
+        }
       } else {
         throw new Error(error)
       }

--- a/src/schema/v2/me/triggerCampaignMutation.ts
+++ b/src/schema/v2/me/triggerCampaignMutation.ts
@@ -1,7 +1,63 @@
-import { GraphQLEnumType } from "graphql"
+import {
+  GraphQLBoolean,
+  GraphQLEnumType,
+  GraphQLInt,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
 import { GraphQLNonNull } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 import { ResolverContext } from "types/graphql"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "TriggerCampaignMutationSuccess",
+  isTypeOf: (data) => data.success,
+  fields: () => ({
+    success: {
+      type: GraphQLBoolean,
+      resolve: (result) => result.success,
+    },
+    statusCode: {
+      type: GraphQLInt,
+      resolve: (result) => result.statusCode,
+    },
+    message: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: () => "Campaign successfully triggered",
+    },
+  }),
+})
+
+const ErrorType = new GraphQLObjectType<any, ResolverContext>({
+  name: "TriggerCampaignMutationFailure",
+  isTypeOf: (data) => {
+    return data._type === "GravityMutationError"
+  },
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => (typeof err.message === "object" ? err.message : err),
+    },
+    statusCode: {
+      type: GraphQLInt,
+      resolve: (result) => result.statusCode,
+    },
+    message: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: () => "Campaign failed to trigger",
+    },
+  }),
+})
+
+const SuccessOrErrorType = new GraphQLUnionType({
+  name: "TriggerCampaignMutationSuccessOrError",
+  types: [SuccessType, ErrorType],
+})
 
 export const triggerCampaignMutation = mutationWithClientMutationId<
   any,
@@ -25,13 +81,32 @@ export const triggerCampaignMutation = mutationWithClientMutationId<
       ),
     },
   },
-  outputFields: {},
+  outputFields: {
+    successOrError: {
+      type: SuccessOrErrorType,
+      resolve: (result) => result,
+    },
+  },
 
   mutateAndGetPayload: async (args, { triggerCampaignLoader }) => {
     if (!triggerCampaignLoader) {
       throw new Error("You need to be signed in to perform this action")
     }
 
-    return triggerCampaignLoader({ campaign_id: args.campaignID })
+    try {
+      await triggerCampaignLoader({ campaign_id: args.campaignID })
+
+      return {
+        success: true,
+      }
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
   },
 })

--- a/src/schema/v2/me/triggerCampaignMutation.ts
+++ b/src/schema/v2/me/triggerCampaignMutation.ts
@@ -13,6 +13,15 @@ import {
   formatGravityError,
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
+import config from "config"
+
+const CAMPAIGN_IDS = {
+  // TODO: replace w/ actual campaignIDs
+  // New campaign IDs can be added based on environment variable here
+  development: { ART_QUIZ: "art-quiz" },
+  staging: { ART_QUIZ: "art-quiz" },
+  production: { ART_QUIZ: "art-quiz" },
+}
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
   name: "TriggerCampaignMutationSuccess",
@@ -72,9 +81,8 @@ export const triggerCampaignMutation = mutationWithClientMutationId<
         new GraphQLEnumType({
           name: "TriggerCampaignID",
           values: {
-            // TODO: replace value w/ actual campaignID
             ART_QUIZ: {
-              value: "art-quiz",
+              value: CAMPAIGN_IDS[config.SYSTEM_ENVIRONMENT].ART_QUIZ,
             },
           },
         })
@@ -98,6 +106,7 @@ export const triggerCampaignMutation = mutationWithClientMutationId<
 
       return {
         success: true,
+        statusCode: 200,
       }
     } catch (error) {
       const formattedErr = formatGravityError(error)

--- a/src/schema/v2/me/triggerCampaignMutation.ts
+++ b/src/schema/v2/me/triggerCampaignMutation.ts
@@ -1,0 +1,37 @@
+import { GraphQLEnumType } from "graphql"
+import { GraphQLNonNull } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+
+export const triggerCampaignMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "TriggerCampaign",
+  description: "Triggers a campaign send.",
+  inputFields: {
+    campaignID: {
+      type: new GraphQLNonNull(
+        new GraphQLEnumType({
+          name: "TriggerCampaignID",
+          values: {
+            // TODO: replace value w/ actual campaignID
+            ART_QUIZ: {
+              value: "art-quiz",
+            },
+          },
+        })
+      ),
+    },
+  },
+  outputFields: {},
+
+  mutateAndGetPayload: async (args, { triggerCampaignLoader }) => {
+    if (!triggerCampaignLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    return triggerCampaignLoader({ campaign_id: args.campaignID })
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -172,6 +172,7 @@ import { createConsignmentInquiryMutation } from "./consignments/createConsignme
 import Conversations from "./conversation/conversations"
 import { updateQuizMutation } from "schema/v2/updateQuizMutation"
 import { OrderedSetsConnection } from "./OrderedSet/orderedSetsConnection"
+import { triggerCampaignMutation } from "./me/triggerCampaignMutation"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -350,6 +351,7 @@ export default new GraphQLSchema({
       sendIdentityVerificationEmail: sendIdentityVerificationEmailMutation,
       startIdentityVerification: startIdentityVerificationMutation,
       submitInquiryRequestMutation,
+      triggerCampaign: triggerCampaignMutation,
       unlinkAuthentication: unlinkAuthenticationMutation,
       updateArtwork: updateArtworkMutation,
       updateCMSLastAccessTimestamp: updateCMSLastAccessTimestampMutation,


### PR DESCRIPTION
The type of this PR is: feat

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1262]

### Description
The goal of this PR is to add a mutation for a `POST` request that triggers a Braze campaign send for authenticated users taking the art quiz to receive their results via email. 

This mutation is also pretty generalized so that any client making a call to `/me/trigger_campaign` with a new campaign can be mapped w/ an appropriate `campaign_id`. A spec is included to test that the call was made w/ the correct values passed to gravity. 

TODO:
- [x] talk to marketing to replace the current `campaign_id` for art quiz to the correct value from Braze
- [ ] make the mutation call in Force on the art quiz "email me my results" button click w/ the correct `campaign_id`


Note: the `clientMutationId` is returned as a response and returns null but that seems to be a graphql/relay thing and isn't a problem here.

<img width="414" alt="Screen Shot 2022-12-22 at 2 43 37 PM" src="https://user-images.githubusercontent.com/23108927/209223656-dd60b0de-b099-449c-bc31-dd7ed89b122e.png">


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1262]: https://artsyproduct.atlassian.net/browse/GRO-1262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ