### PR TITLE
feat: add isUpcoming to auction result interface

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2668,6 +2668,7 @@ type AuctionResult implements Node {
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
+  isUpcoming: Boolean
   location: String
   mediumText: String
   organization: String

--- a/src/schema/v2/__tests__/auction_result.test.ts
+++ b/src/schema/v2/__tests__/auction_result.test.ts
@@ -9,7 +9,7 @@ const mockAuctionResult = {
   dimension_text: "20 x 20",
   organization: "Christie's",
   category_text: "an old guitar",
-  sale_date: "yesterday",
+  sale_date: "2022-01-19T20:00:00.000Z",
   images: [
     {
       thumbnail: "https://path.to.thumbnail.jpg",
@@ -148,6 +148,52 @@ describe("AuctionResult type", () => {
             display: null,
           },
         })
+      })
+    })
+  })
+  describe("isUpcoming", () => {
+    it("returns true when the sale date is in the future", () => {
+      const auctionResult = {
+        ...mockAuctionResult,
+        sale_date: "2050-01-19T20:00:00.000Z",
+      }
+
+      const context = {
+        auctionLotLoader: jest.fn(() => Promise.resolve(auctionResult)),
+      }
+
+      const query = `
+        {
+          auctionResult(id: "foo-bar") {
+            isUpcoming
+          }
+        }
+      `
+
+      return runQuery(query, context!).then((data) => {
+        expect(data.auctionResult.isUpcoming).toEqual(true)
+      })
+    })
+    it("returns false when the sale date is in the past", () => {
+      const auctionResult = {
+        ...mockAuctionResult,
+        sale_date: "2000-01-19T20:00:00.000Z",
+      }
+
+      const context = {
+        auctionLotLoader: jest.fn(() => Promise.resolve(auctionResult)),
+      }
+
+      const query = `
+          {
+            auctionResult(id: "foo-bar") {
+              isUpcoming
+            }
+          }
+        `
+
+      return runQuery(query, context!).then((data) => {
+        expect(data.auctionResult.isUpcoming).toEqual(false)
       })
     })
   })

--- a/src/schema/v2/auction_result.ts
+++ b/src/schema/v2/auction_result.ts
@@ -96,6 +96,15 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
       resolve: ({ category_text }) => category_text,
     },
+    isUpcoming: {
+      type: GraphQLBoolean,
+      resolve: ({ sale_date }) => {
+        if (!sale_date) return null
+        const utc = new Date().toJSON().slice(0, 10).replace(/-/g, "/")
+
+        return new Date(sale_date) >= new Date(utc)
+      },
+    },
     comparableAuctionResults: {
       type: auctionResultConnection.connectionType,
       description: "Comparable auction results ",

--- a/src/schema/v2/auction_result.ts
+++ b/src/schema/v2/auction_result.ts
@@ -100,9 +100,8 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLBoolean,
       resolve: ({ sale_date }) => {
         if (!sale_date) return null
-        const utc = new Date().toJSON().slice(0, 10).replace(/-/g, "/")
 
-        return new Date(sale_date) >= new Date(utc)
+        return isSameOrAfterToday(sale_date)
       },
     },
     comparableAuctionResults: {
@@ -387,3 +386,9 @@ export const auctionResultConnection = connectionWithCursorInfo({
     },
   },
 })
+
+// Compare two dates and return true if the first date is after todoy's date (00:00:00)
+const isSameOrAfterToday = (date: string | number | Date): boolean => {
+  const utc = new Date().toJSON().slice(0, 10).replace(/-/g, "/")
+  return new Date(date) >= new Date(utc)
+}


### PR DESCRIPTION
This PR adds `isUpcoming` to the auction result interface. 
**Notes:** 
- ⭐️This is important to avoid doing this computation on the frontend side.
- ⭐️⭐️ We intentionally compare to the beginning of the day instead of the exact moments 

<img width="1456" alt="Screenshot 2022-12-23 at 12 02 37" src="https://user-images.githubusercontent.com/11945712/209326048-d6fced68-d3f5-445d-b0c1-6c31264c940f.png">
