### PR TITLE
feat: Add includePersonalArtists param to collectedArtistsConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11672,6 +11672,9 @@ type MyCollectionConnection {
     after: String
     before: String
     first: Int
+
+    # Include artists that have been created by the user.
+    includePersonalArtists: Boolean = true
     last: Int
     page: Int
     size: Int
@@ -11764,6 +11767,9 @@ type MyCollectionInfo {
     after: String
     before: String
     first: Int
+
+    # Include artists that have been created by the user.
+    includePersonalArtists: Boolean = true
     last: Int
     page: Int
     size: Int

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11674,7 +11674,7 @@ type MyCollectionConnection {
     first: Int
 
     # Include artists that have been created by the user.
-    includePersonalArtists: Boolean = true
+    includePersonalArtists: Boolean = false
     last: Int
     page: Int
     size: Int
@@ -11769,7 +11769,7 @@ type MyCollectionInfo {
     first: Int
 
     # Include artists that have been created by the user.
-    includePersonalArtists: Boolean = true
+    includePersonalArtists: Boolean = false
     last: Int
     page: Int
     size: Int

--- a/src/schema/v2/me/myCollectionInfo.ts
+++ b/src/schema/v2/me/myCollectionInfo.ts
@@ -168,7 +168,7 @@ export const myCollectionInfoFields = {
       size: { type: GraphQLInt },
       includePersonalArtists: {
         type: GraphQLBoolean,
-        defaultValue: true,
+        defaultValue: false,
         description: "Include artists that have been created by the user.",
       },
     }),
@@ -176,6 +176,11 @@ export const myCollectionInfoFields = {
       const { collectionArtistsLoader, userID } = context
 
       if (!collectionArtistsLoader) return
+
+      // TODO: Remove this once all clients pass includePersonalArtists correctly
+      // This is a hack and currently we are defaulting to true if the query comes from the artwork form (passing a size of 100)
+      const includePersonalArtists =
+        args.size === 100 ? true : args.includePersonalArtists
 
       const { page, offset, size, sort } = convertConnectionArgsToGravityArgs(
         args
@@ -188,7 +193,7 @@ export const myCollectionInfoFields = {
         all: true,
         total_count: true,
         user_id: userID,
-        include_personal_artists: args.includePersonalArtists,
+        include_personal_artists: includePersonalArtists,
       })
       const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 

--- a/src/schema/v2/me/myCollectionInfo.ts
+++ b/src/schema/v2/me/myCollectionInfo.ts
@@ -166,6 +166,11 @@ export const myCollectionInfoFields = {
       sort: ArtistSorts,
       page: { type: GraphQLInt },
       size: { type: GraphQLInt },
+      includePersonalArtists: {
+        type: GraphQLBoolean,
+        defaultValue: true,
+        description: "Include artists that have been created by the user.",
+      },
     }),
     resolve: async (_root, args, context) => {
       const { collectionArtistsLoader, userID } = context
@@ -183,6 +188,7 @@ export const myCollectionInfoFields = {
         all: true,
         total_count: true,
         user_id: userID,
+        include_personal_artists: args.includePersonalArtists,
       })
       const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 

--- a/src/schema/v2/me/myCollectionInfo.ts
+++ b/src/schema/v2/me/myCollectionInfo.ts
@@ -177,11 +177,6 @@ export const myCollectionInfoFields = {
 
       if (!collectionArtistsLoader) return
 
-      // TODO: Remove this once all clients pass includePersonalArtists correctly
-      // This is a hack and currently we are defaulting to true if the query comes from the artwork form (passing a size of 100)
-      const includePersonalArtists =
-        args.size === 100 ? true : args.includePersonalArtists
-
       const { page, offset, size, sort } = convertConnectionArgsToGravityArgs(
         args
       )
@@ -193,7 +188,7 @@ export const myCollectionInfoFields = {
         all: true,
         total_count: true,
         user_id: userID,
-        include_personal_artists: includePersonalArtists,
+        include_personal_artists: args.includePersonalArtists,
       })
       const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 


### PR DESCRIPTION
Addresses [CX-3285]

🔴  Depends on https://github.com/artsy/gravity/pull/15975

## Description

Adding includePersonalArtists param to the collection artist endpoint. This param will be used to make sure personal artists don't show up when fetching artists to show insights.

[CX-3285]: https://artsyproduct.atlassian.net/browse/CX-3285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ