### PR TITLE
fix: Set includePersonalArtists to true for artwork form query

### DIFF
--- a/src/schema/v2/me/myCollectionInfo.ts
+++ b/src/schema/v2/me/myCollectionInfo.ts
@@ -184,8 +184,11 @@ export const myCollectionInfoFields = {
       // TODO: Remove this once all clients pass includePersonalArtists correctly
       // This is a hack we need to return the correct results for older cleints that don't send the param `includePersonalArtists`.
       // With this solution we are defaulting to true if the query comes from the My Collection artwork form (which is the only query that passes `size: 100`)
+      const SIZE_ARG_VALUE_FOR_MY_COLLECTION_ARTWORK_FORM = 100
       const includePersonalArtists =
-        args.size === 100 ? true : args.includePersonalArtists
+        args.size === SIZE_ARG_VALUE_FOR_MY_COLLECTION_ARTWORK_FORM
+          ? true
+          : args.includePersonalArtists
 
       const { body, headers } = await collectionArtistsLoader("my-collection", {
         size,

--- a/src/schema/v2/me/myCollectionInfo.ts
+++ b/src/schema/v2/me/myCollectionInfo.ts
@@ -182,7 +182,8 @@ export const myCollectionInfoFields = {
       )
 
       // TODO: Remove this once all clients pass includePersonalArtists correctly
-      // This is a hack and currently we are defaulting to true if the query comes from the artwork form (passing a size of 100)
+      // This is a hack we need to return the correct results for older cleints that don't send the param `includePersonalArtists`.
+      // With this solution we are defaulting to true if the query comes from the My Collection artwork form (which is the only query that passes `size: 100`)
       const includePersonalArtists =
         args.size === 100 ? true : args.includePersonalArtists
 

--- a/src/schema/v2/me/myCollectionInfo.ts
+++ b/src/schema/v2/me/myCollectionInfo.ts
@@ -181,6 +181,11 @@ export const myCollectionInfoFields = {
         args
       )
 
+      // TODO: Remove this once all clients pass includePersonalArtists correctly
+      // This is a hack and currently we are defaulting to true if the query comes from the artwork form (passing a size of 100)
+      const includePersonalArtists =
+        args.size === 100 ? true : args.includePersonalArtists
+
       const { body, headers } = await collectionArtistsLoader("my-collection", {
         size,
         page,
@@ -188,7 +193,7 @@ export const myCollectionInfoFields = {
         all: true,
         total_count: true,
         user_id: userID,
-        include_personal_artists: args.includePersonalArtists,
+        include_personal_artists: includePersonalArtists,
       })
       const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 


### PR DESCRIPTION
Addresses [CX-3285]

## Description

Because `includePersonalArtists` defaults to `false`, we need to use a hack for older clients that don't send the parameter introduced in https://github.com/artsy/eigen/pull/7904. The only query we need to set the param to true is part of the My Collection artwork form (which sets `size` to `100`). 

[CX-3285]: https://artsyproduct.atlassian.net/browse/CX-3285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ