### PR TITLE
fix: adjust includePersonalArtists hack

### DIFF
--- a/src/schema/v2/me/myCollectionInfo.ts
+++ b/src/schema/v2/me/myCollectionInfo.ts
@@ -183,10 +183,10 @@ export const myCollectionInfoFields = {
 
       // TODO: Remove this once all clients pass includePersonalArtists correctly
       // This is a hack we need to return the correct results for older cleints that don't send the param `includePersonalArtists`.
-      // With this solution we are defaulting to true if the query comes from the My Collection artwork form (which is the only query that passes `size: 100`)
+      // With this solution we are defaulting to true if the query comes from the My Collection artwork form (which is the only query that passes `first: 100`)
       const SIZE_ARG_VALUE_FOR_MY_COLLECTION_ARTWORK_FORM = 100
       const includePersonalArtists =
-        args.size === SIZE_ARG_VALUE_FOR_MY_COLLECTION_ARTWORK_FORM
+        args.first === SIZE_ARG_VALUE_FOR_MY_COLLECTION_ARTWORK_FORM
           ? true
           : args.includePersonalArtists
 


### PR DESCRIPTION
Addresses [CX-3285]

## Description

Adjust includePersonalArtists hack introduced in https://github.com/artsy/metaphysics/pull/4657 (`size` -> `first`).

[CX-3285]: https://artsyproduct.atlassian.net/browse/CX-3285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ