### PR TITLE
feat: support ordered set internal name field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11978,6 +11978,7 @@ type OrderedSet {
 
   # A type-specific ID.
   internalID: ID!
+  internalName: String
   items: [OrderedSetItem]
 
   # Returns a connection of the items. Only Artwork supported right now.

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7113,6 +7113,7 @@ type createOrderedSetFailure {
 input CreateOrderedSetMutationInput {
   clientMutationId: String
   description: String
+  internalName: String
   itemId: String
   itemType: String!
   key: String!

--- a/src/schema/v2/OrderedSet/OrderedSet.ts
+++ b/src/schema/v2/OrderedSet/OrderedSet.ts
@@ -45,6 +45,10 @@ export const OrderedSetType = new GraphQLObjectType<
     layout: {
       type: new GraphQLNonNull(OrderedSetLayoutsEnum),
     },
+    internalName: {
+      type: GraphQLString,
+      resolve: ({ internal_name }) => internal_name,
+    },
     itemType: {
       type: GraphQLString,
       resolve: ({ item_type }) => item_type,

--- a/src/schema/v2/OrderedSet/createOrderedSetMutation.ts
+++ b/src/schema/v2/OrderedSet/createOrderedSetMutation.ts
@@ -30,6 +30,7 @@ type LayoutType = "default" | "full"
 
 interface Input {
   description: string
+  internalName: string
   itemId: string
   itemType: ItemType
   key: string
@@ -75,6 +76,7 @@ export const createOrderedSetMutation = mutationWithClientMutationId<
   description: "Creates an ordered set.",
   inputFields: {
     description: { type: GraphQLString },
+    internalName: { type: GraphQLString },
     itemId: { type: GraphQLString },
     itemType: { type: new GraphQLNonNull(GraphQLString) },
     key: { type: new GraphQLNonNull(GraphQLString) },
@@ -91,7 +93,17 @@ export const createOrderedSetMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    { description, itemId, itemType, key, layout, name, ownerType, published },
+    {
+      description,
+      internalName,
+      itemId,
+      itemType,
+      key,
+      layout,
+      name,
+      ownerType,
+      published,
+    },
     { createSetLoader }
   ) => {
     if (!createSetLoader) {
@@ -103,6 +115,7 @@ export const createOrderedSetMutation = mutationWithClientMutationId<
     try {
       return await createSetLoader({
         description,
+        internal_name: internalName,
         item_id: itemId,
         item_type: itemType,
         key,


### PR DESCRIPTION
This PR   adds `internalName` as an input in the `createOrderedSet` mutation and to the `OrderedSetType` schema.

This supports having the field available as part of the figma [design](https://www.figma.com/file/RiH2Y6TKOPG1kyEWdkJ0Zw/Forque-Platform-redesign?node-id=169%3A27331&t=bVA0aYK7MkgLvaXA-0). 

[PLATFORM-4810]

[PLATFORM-4810]: https://artsyproduct.atlassian.net/browse/PLATFORM-4810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ