### PR TITLE
refactor: use `process.getActiveResourcesInfo()` instead of deprecated APIs

### DIFF
--- a/src/lib/stats.js
+++ b/src/lib/stats.js
@@ -27,14 +27,21 @@ export function createStatsClient() {
 
   if (enableMetrics && isProd) {
     setInterval(() => {
-      statsClient.gauge(
-        "process.active_handles",
-        process._getActiveHandles().length
-      )
-      statsClient.gauge(
-        "process.active_requests",
-        process._getActiveRequests().length
-      )
+      if (process.getActiveResourcesInfo) {
+        statsClient.gauge(
+          "process.active_resources",
+          process.getActiveResourcesInfo().length
+        )
+      } else {
+        statsClient.gauge(
+          "process.active_handles",
+          process._getActiveHandles().length
+        )
+        statsClient.gauge(
+          "process.active_requests",
+          process._getActiveRequests().length
+        )
+      }
     }, 5000)
   }
 


### PR DESCRIPTION
`process._getActiveRequests()` and `process._getActiveHandles()` have been deprecated: https://nodejs.org/api/deprecations.html#dep0161-process_getactiverequests-and-process_getactivehandles, so this change refactors the code to use the newer `process.getActiveResourcesInfo()` API: https://nodejs.org/api/process.html#processgetactiveresourcesinfo instead.

Signed-off-by: Darshan Sen <raisinten@gmail.com>