### PR TITLE
chore: add an authenticated setsLoader

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -482,6 +482,7 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    setsLoader: gravityLoader("sets", {}, { headers: true }),
     showLoader: gravityLoader((id) => `show/${id}`),
     submitArtworkInquiryRequestLoader: gravityLoader(
       "me/artwork_inquiry_request",


### PR DESCRIPTION
This should be enough to propagate the user's token (and thus be able to retrieve unpublished sets from Gravity).