### PR TITLE
feat(TX-947): add medium and attribution class to artwork version type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2542,6 +2542,9 @@ type ArtworkVersion implements Node {
   # The artists related to this Artwork Version
   artists: [Artist]
 
+  # The Artwork Version attribution class
+  attribution_class: String
+
   # The Image id
   defaultImageID: String
 
@@ -2553,6 +2556,9 @@ type ArtworkVersion implements Node {
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
+
+  # The Artwork Version medium
+  medium: String
 
   # Artwork title
   title: String

--- a/src/schema/v2/artwork_version.ts
+++ b/src/schema/v2/artwork_version.ts
@@ -55,6 +55,16 @@ export const ArtworkVersionType = new GraphQLObjectType<any, ResolverContext>({
           image_id: version.default_image_id,
         }),
     },
+
+    medium: {
+      type: GraphQLString,
+      description: "The Artwork Version medium",
+    },
+
+    attribution_class: {
+      type: GraphQLString,
+      description: "The Artwork Version attribution class",
+    },
   }),
 })
 


### PR DESCRIPTION
[TX-947](https://artsyproduct.atlassian.net/browse/TX-947)

This PR adds medium and attribution class to the artwork version type in preparation for private sales. 

<img width="1196" alt="Screenshot 2023-01-06 at 12 18 56 PM" src="https://user-images.githubusercontent.com/50849237/211003523-4d325013-0872-439a-9aff-76c6da5f50be.png">


[TX-947]: https://artsyproduct.atlassian.net/browse/TX-947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ