### PR TITLE
feat(CX-2964): add isProfileComplete to Collector Profile

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3594,6 +3594,7 @@ type CollectorProfileType {
   isActiveInquirer: Boolean
   isEmailConfirmed: Boolean
   isIdentityVerified: Boolean
+  isProfileComplete: Boolean
   location: MyLocation
   loyaltyApplicantAt(
     format: String
@@ -9899,6 +9900,7 @@ type InquirerCollectorProfile {
   isActiveInquirer: Boolean
   isEmailConfirmed: Boolean
   isIdentityVerified: Boolean
+  isProfileComplete: Boolean
   location: MyLocation
   loyaltyApplicantAt(
     format: String
@@ -16420,6 +16422,7 @@ type UpdateCollectorProfilePayload {
   isActiveInquirer: Boolean
   isEmailConfirmed: Boolean
   isIdentityVerified: Boolean
+  isProfileComplete: Boolean
   location: MyLocation
   loyaltyApplicantAt(
     format: String

--- a/src/schema/v2/CollectorProfile/collectorProfile.ts
+++ b/src/schema/v2/CollectorProfile/collectorProfile.ts
@@ -120,6 +120,15 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
     description: "List of artists the Collector is interested in.",
     resolve: ({ collected_artist_names }) => collected_artist_names,
   },
+  isProfileComplete: {
+    type: GraphQLBoolean,
+    resolve: ({ name, location, profession, other_relevant_positions, bio }) =>
+      !!name &&
+      !!location?.display &&
+      !!profession &&
+      !!other_relevant_positions &&
+      !!bio,
+  },
 }
 
 export const CollectorProfileType = new GraphQLObjectType<any, ResolverContext>(

--- a/src/schema/v2/me/__tests__/collector_profile.test.js
+++ b/src/schema/v2/me/__tests__/collector_profile.test.js
@@ -72,5 +72,75 @@ describe("Me", () => {
         }
       )
     })
+
+    describe("isProfileComplete", () => {
+      it("returns true if the profile is complete", () => {
+        const query = `
+          {
+            me {
+              collectorProfile {
+                isProfileComplete
+              }
+            }
+          }
+        `
+
+        const collectorProfile = {
+          id: "3",
+          name: "Johnathan Storm",
+          email: "johnathan@storm.com",
+          location: {
+            display: "Berlin",
+          },
+          profession: "coder",
+          other_relevant_positions: "other typer",
+          bio: "J. Storm",
+        }
+
+        const context = {
+          meCollectorProfileLoader: () => Promise.resolve(collectorProfile),
+        }
+
+        return runAuthenticatedQuery(query, context).then(
+          ({ me: { collectorProfile } }) => {
+            expect(collectorProfile.isProfileComplete).toBe(true)
+          }
+        )
+      })
+
+      it("returns false if the profile is incomplete", () => {
+        const query = `
+        {
+          me {
+            collectorProfile {
+              isProfileComplete
+            }
+          }
+        }
+      `
+
+        const collectorProfile = {
+          id: "3",
+          name: "Anonny",
+          email: "anonny@mos.sos",
+          location: {
+            display: "Berlin",
+          },
+          profession: "",
+          other_relevant_positions: "no one knows",
+          bio: "¯\\_(ツ)_//¯",
+        }
+
+        const context = {
+          meCollectorProfileLoader: () => Promise.resolve(collectorProfile),
+        }
+
+        return runAuthenticatedQuery(query, context).then(
+          ({ me: { collectorProfile } }) => {
+            expect(collectorProfile.isProfileComplete).toBe(false)
+          }
+        )
+      })
+    })
   })
 })


### PR DESCRIPTION
This PR resolves [CX-2964]

This PR adds a new field to the collector profile. It's a new boolean field called `isProfileComlete` that returns `true` if the user has a **name**, **location**, **profession**, **other relevant positions**, and a **bio**, and returns `false` otherwise

Query:
```graphql
{
  me {
    collectorProfile {
      isProfileComplete
    }
  }
}
```


Response:
```json
{
  "data": {
    "me": {
      "collectorProfile": {
        "isProfileComplete": false
      }
    }
  }
}

```

[CX-2964]: https://artsyproduct.atlassian.net/browse/CX-2964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ