### PR TITLE
chore: Trove Rebranding GRO-1495

### DIFF
--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -804,7 +804,7 @@ export const gravityStitchingEnvironment = (
                 fieldName: "marketingCollections",
                 args: {
                   slugs: [
-                    "trove-editors-picks",
+                    "curators-picks-emerging",
                     "trending-this-week",
                     "artists-on-the-rise",
                     "blue-chip-artists",


### PR DESCRIPTION
Minor update to get the new Trove rebranding in MP.

https://artsyproduct.atlassian.net/browse/GRO-1495

/cc @artsy/grow-devs