### PR TITLE
feat(FX-4534): GraphQL mutation for marking a specific entry in the activity panel as read

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10482,6 +10482,28 @@ type MarketPriceInsightsEdge {
   node: MarketPriceInsights
 }
 
+type MarkNotificationAsReadFailure {
+  mutationError: GravityMutationError
+}
+
+input MarkNotificationAsReadInput {
+  clientMutationId: String
+  id: String!
+}
+
+type MarkNotificationAsReadPayload {
+  clientMutationId: String
+  responseOrError: MarkNotificationAsReadResponseOrError
+}
+
+union MarkNotificationAsReadResponseOrError =
+    MarkNotificationAsReadFailure
+  | MarkNotificationAsReadSuccess
+
+type MarkNotificationAsReadSuccess {
+  success: Boolean
+}
+
 union Match =
     Article
   | Artist
@@ -11468,6 +11490,11 @@ type Mutation {
   markAllNotificationsAsRead(
     input: MarkAllNotificationsAsReadInput!
   ): MarkAllNotificationsAsReadPayload
+
+  # Mark an unread notifications as read
+  markNotificationAsRead(
+    input: MarkNotificationAsReadInput!
+  ): MarkNotificationAsReadPayload
 
   # Merge multiple artist records in order to deduplicate artists
   mergeArtists(input: MergeArtistsMutationInput!): MergeArtistsMutationPayload

--- a/src/schema/v2/me/__tests__/mark_notification_as_read_mutation.test.ts
+++ b/src/schema/v2/me/__tests__/mark_notification_as_read_mutation.test.ts
@@ -1,0 +1,61 @@
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+const mutation = `
+  mutation {
+    markNotificationAsRead(input: { id: "feed_id" }) {
+      responseOrError {
+        ... on MarkNotificationAsReadSuccess {
+          success
+        }
+
+        ... on MarkNotificationAsReadFailure {
+          mutationError {
+            message
+          }
+        }
+      }
+    }
+  }
+`
+
+describe("markNotificationAsReadMutation", () => {
+  it("returns success response", async () => {
+    const context = {
+      updateNotificationsLoader: jest.fn().mockResolvedValue(true),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "markNotificationAsRead": Object {
+          "responseOrError": Object {
+            "success": true,
+          },
+        },
+      }
+    `)
+  })
+
+  it("returns failure when something went wrong", async () => {
+    const message = `https://stagingapi.artsy.net/api/v1/me/notifications - {"error":"Something went wrong"}`
+    const error = new Error(message)
+    const context = {
+      updateNotificationsLoader: jest.fn().mockRejectedValue(error),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "markNotificationAsRead": Object {
+          "responseOrError": Object {
+            "mutationError": Object {
+              "message": "Something went wrong",
+            },
+          },
+        },
+      }
+    `)
+  })
+})

--- a/src/schema/v2/me/mark_notification_as_read_mutation.ts
+++ b/src/schema/v2/me/mark_notification_as_read_mutation.ts
@@ -63,7 +63,7 @@ export const markNotificationAsReadMutation = mutationWithClientMutationId<
     }
 
     try {
-      await updateNotificationsLoader({ feed_ids: [args.id], status: "read" })
+      await updateNotificationsLoader({ ids: [args.id], status: "read" })
 
       return {
         success: true,

--- a/src/schema/v2/me/mark_notification_as_read_mutation.ts
+++ b/src/schema/v2/me/mark_notification_as_read_mutation.ts
@@ -1,0 +1,81 @@
+import {
+  GraphQLObjectType,
+  GraphQLUnionType,
+  GraphQLBoolean,
+  GraphQLNonNull,
+  GraphQLString,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "MarkNotificationAsReadSuccess",
+  isTypeOf: (data) => data.success,
+  fields: () => ({
+    success: {
+      type: GraphQLBoolean,
+      resolve: (result) => result.success,
+    },
+  }),
+})
+
+const ErrorType = new GraphQLObjectType<any, ResolverContext>({
+  name: "MarkNotificationAsReadFailure",
+  isTypeOf: (data) => {
+    return data._type === "GravityMutationError"
+  },
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => (typeof err.message === "object" ? err.message : err),
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "MarkNotificationAsReadResponseOrError",
+  types: [SuccessType, ErrorType],
+})
+
+export const markNotificationAsReadMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "MarkNotificationAsRead",
+  description: "Mark an unread notifications as read",
+  inputFields: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+  },
+  outputFields: {
+    responseOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (args, { updateNotificationsLoader }) => {
+    if (!updateNotificationsLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      await updateNotificationsLoader({ feed_ids: [args.id], status: "read" })
+
+      return {
+        success: true,
+      }
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -164,6 +164,7 @@ import { PartnerShowDocumentsConnection } from "./partner/partnerShowDocumentsCo
 import { bulkUpdatePartnerArtworksMutation } from "./bulkUpdatePartnerArtworksMutation"
 import { NotificationsConnection } from "./notifications"
 import { markAllNotificationsAsReadMutation } from "./me/mark_all_notifications_as_read_mutation"
+import { markNotificationAsReadMutation } from "./me/mark_notification_as_read_mutation"
 import updateMessageMutation from "./conversation/updateMessageMutation"
 import deleteConversationMutation from "./conversation/deleteConversationMutation"
 import { updateArtworkMutation } from "./artwork/updateArtworkMutation"
@@ -338,6 +339,7 @@ export default new GraphQLSchema({
       followShow: FollowShow,
       linkAuthentication: linkAuthenticationMutation,
       markAllNotificationsAsRead: markAllNotificationsAsReadMutation,
+      markNotificationAsRead: markNotificationAsReadMutation,
       mergeArtists: mergeArtistsMutation,
       myCollectionCreateArtwork: myCollectionCreateArtworkMutation,
       myCollectionDeleteArtwork: myCollectionDeleteArtworkMutation,


### PR DESCRIPTION
- Do not merge until https://github.com/artsy/gravity/pull/15999 is merged
- [Jira ticket](https://artsyproduct.atlassian.net/browse/FX-4534)

Adds a mutation to mark a notification as read:

```graphql
mutation {
	markNotificationAsRead(input: { id: "63c55aeacde4edd6cf014d66" }) {
		responseOrError {
			... on MarkNotificationAsReadSuccess {
				success
			}
			... on MarkNotificationAsReadFailure {
				mutationError {
					error
					message
				}
			}
		}
	}
}
```

After that in my feed:

![Screenshot 2023-01-17 at 17 40 05](https://user-images.githubusercontent.com/3934579/212958810-a434bd38-d7e3-4f96-a0df-a98c3705cbb6.png)
