### PR TITLE
feat(CX-3280): Add lotNumber to Auction Results type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2676,6 +2676,7 @@ type AuctionResult implements Node {
   internalID: ID!
   isUpcoming: Boolean
   location: String
+  lotNumber: String
   mediumText: String
   organization: String
   performance: AuctionLotPerformance

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2749,6 +2749,7 @@ type AuctionResultsByArtists {
   highEstimateCentsUsd: BigInt
   id: ID!
   location: String
+  lotNumber: String
   lowEstimateCents: BigInt
   lowEstimateCentsUsd: BigInt
   mediumText: String

--- a/src/data/diffusion.graphql
+++ b/src/data/diffusion.graphql
@@ -20,6 +20,7 @@ type AuctionResultsByArtists {
   highEstimateCentsUsd: BigInt
   id: ID!
   location: String
+  lotNumber: String
   lowEstimateCents: BigInt
   lowEstimateCentsUsd: BigInt
   mediumText: String

--- a/src/schema/v2/__tests__/auction_result.test.ts
+++ b/src/schema/v2/__tests__/auction_result.test.ts
@@ -151,6 +151,7 @@ describe("AuctionResult type", () => {
       })
     })
   })
+
   describe("isUpcoming", () => {
     it("returns true when the sale date is in the future", () => {
       const auctionResult = {
@@ -194,6 +195,54 @@ describe("AuctionResult type", () => {
 
       return runQuery(query, context!).then((data) => {
         expect(data.auctionResult.isUpcoming).toEqual(false)
+      })
+    })
+  })
+
+  describe("lotNumber", () => {
+    it("returns the lot number when it is present", () => {
+      const auctionResult = {
+        ...mockAuctionResult,
+        lot_number: "123",
+      }
+
+      const context = {
+        auctionLotLoader: jest.fn(() => Promise.resolve(auctionResult)),
+      }
+
+      const query = `
+        {
+          auctionResult(id: "foo-bar") {
+            lotNumber
+          }
+        }
+      `
+
+      return runQuery(query, context).then((data) => {
+        expect(data.auctionResult.lotNumber).toEqual("123")
+      })
+    })
+
+    it("returns null when the lot number is not present", () => {
+      const auctionResult = {
+        ...mockAuctionResult,
+        lot_number: null,
+      }
+
+      const context = {
+        auctionLotLoader: jest.fn(() => Promise.resolve(auctionResult)),
+      }
+
+      const query = `
+          {
+            auctionResult(id: "foo-bar") {
+              lotNumber
+            }
+          }
+        `
+
+      return runQuery(query, context).then((data) => {
+        expect(data.auctionResult.lotNumber).toEqual(null)
       })
     })
   })

--- a/src/schema/v2/auction_result.ts
+++ b/src/schema/v2/auction_result.ts
@@ -104,6 +104,10 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
         return isSameOrAfterToday(sale_date)
       },
     },
+    lotNumber: {
+      type: GraphQLString,
+      resolve: ({ lot_number }) => lot_number,
+    },
     comparableAuctionResults: {
       type: auctionResultConnection.connectionType,
       description: "Comparable auction results ",


### PR DESCRIPTION
This PR adds `lotNumber` to the auction results type to be used by the new design for the auction results on Force

**Query**
```graphql
query {
  artist (id: "andy-warhol") {
    name
    auctionResultsConnection (first: 1) { 
      edges {
        node {
          lotNumber
        }
      }
    }
  }
}
```

**Result**
```json
{
  "data": {
    "artist": {
      "name": "Andy Warhol",
      "auctionResultsConnection": {
        "edges": [
          {
            "node": {
              "title": "Jean Cocteau",
              "lotNumber": null
            }
          }
        ]
      }
    }
  }
}
```