### PR TITLE
feat: Add CRUD and listings for Feature management

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8565,6 +8565,17 @@ type Feature {
   subheadline(format: Format): String
 }
 
+# A connection to a list of items.
+type FeatureConnection {
+  # A list of edges.
+  edges: [FeatureEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
 # An illustrated link chosen to highlight a Gene from a given GeneFamily
 type FeaturedGeneLink {
   href: String!
@@ -8592,6 +8603,15 @@ type FeaturedLink {
 }
 
 union FeaturedLinkEntity = Artist | Gene | Partner
+
+# An edge in a connection.
+type FeatureEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: Feature
+}
 
 type FeatureFlag {
   createdAt(
@@ -8680,6 +8700,13 @@ type FeatureMeta {
   description: String!
   image: String
   name: String!
+}
+
+enum FeatureSorts {
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  NAME_ASC
+  NAME_DESC
 }
 
 type Feedback {
@@ -13824,6 +13851,16 @@ type Query {
     # The slug or ID of the Feature
     id: ID
   ): Feature
+  featuresConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    sort: FeatureSorts
+
+    # If present, will search by term
+    term: String
+  ): FeatureConnection
 
   # Partners Elastic Search results
   filterPartners(
@@ -17947,6 +17984,16 @@ type Viewer {
     # The slug or ID of the Feature
     id: ID
   ): Feature
+  featuresConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    sort: FeatureSorts
+
+    # If present, will search by term
+    term: String
+  ): FeatureConnection
 
   # Partners Elastic Search results
   filterPartners(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7014,6 +7014,31 @@ union CreateConsignmentInquiryMutationType =
     ConsignmentInquiryMutationFailure
   | ConsignmentInquiryMutationSuccess
 
+type CreateFeatureFailure {
+  mutationError: GravityMutationError
+}
+
+input CreateFeatureMutationInput {
+  active: Boolean!
+  callout: String
+  clientMutationId: String
+  description: String
+  layout: FeatureLayouts
+  name: String!
+  subheadline: String
+}
+
+type CreateFeatureMutationPayload {
+  clientMutationId: String
+  featureOrError: createFeatureResponseOrError
+}
+
+union createFeatureResponseOrError = CreateFeatureFailure | CreateFeatureSuccess
+
+type CreateFeatureSuccess {
+  feature: Feature
+}
+
 input CreateGeminiEntryForAssetInput {
   clientMutationId: String
 
@@ -7614,6 +7639,26 @@ type DeleteCreditCardPayload {
   clientMutationId: String
   creditCardOrError: CreditCardMutationType
   me: Me
+}
+
+type DeleteFeatureFailure {
+  mutationError: GravityMutationError
+}
+
+input DeleteFeatureMutationInput {
+  clientMutationId: String
+  id: String!
+}
+
+type DeleteFeatureMutationPayload {
+  clientMutationId: String
+  featureOrError: DeleteFeatureResponseOrError
+}
+
+union DeleteFeatureResponseOrError = DeleteFeatureFailure | DeleteFeatureSuccess
+
+type DeleteFeatureSuccess {
+  feature: Feature
 }
 
 type deleteOrderedSetFailure {
@@ -11378,6 +11423,11 @@ type Mutation {
   # Create a credit card
   createCreditCard(input: CreditCardInput!): CreditCardPayload
 
+  # Creates a feature.
+  createFeature(
+    input: CreateFeatureMutationInput!
+  ): CreateFeatureMutationPayload
+
   # Attach an gemini asset to a consignment submission
   createGeminiEntryForAsset(
     input: CreateGeminiEntryForAssetInput!
@@ -11436,6 +11486,11 @@ type Mutation {
 
   # Remove a credit card
   deleteCreditCard(input: DeleteCreditCardInput!): DeleteCreditCardPayload
+
+  # deletes a feature.
+  deleteFeature(
+    input: DeleteFeatureMutationInput!
+  ): DeleteFeatureMutationPayload
 
   # Delete User Artsy Account
   deleteMyAccountMutation(input: DeleteAccountInput!): DeleteAccountPayload
@@ -11630,6 +11685,11 @@ type Mutation {
   updateConversation(
     input: UpdateConversationMutationInput!
   ): UpdateConversationMutationPayload
+
+  # updates a feature.
+  updateFeature(
+    input: UpdateFeatureMutationInput!
+  ): UpdateFeatureMutationPayload
 
   # Update a message.
   updateMessage(
@@ -16624,6 +16684,34 @@ input UpdateConversationMutationInput {
 type UpdateConversationMutationPayload {
   clientMutationId: String
   conversation: Conversation
+}
+
+type UpdateFeatureFailure {
+  mutationError: GravityMutationError
+}
+
+input UpdateFeatureMutationInput {
+  active: Boolean!
+  callout: String
+  clientMutationId: String
+  description: String
+  id: String!
+  layout: FeatureLayouts
+  name: String!
+  subheadline: String
+}
+
+type UpdateFeatureMutationPayload {
+  clientMutationId: String
+
+  # On success: the ordered set updated.
+  featureOrError: UpdateFeatureResponseOrError
+}
+
+union UpdateFeatureResponseOrError = UpdateFeatureFailure | UpdateFeatureSuccess
+
+type UpdateFeatureSuccess {
+  feature: Feature
 }
 
 type UpdateMessageFailure {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -195,6 +195,20 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" }
     ),
+    featureLoader: gravityLoader((id) => `feature/${id}`),
+    featuresLoader: gravityLoader("features", {}, { headers: true }),
+    createFeatureLoader: gravityLoader("feature", {}, { method: "POST" }),
+    deleteFeatureLoader: gravityLoader(
+      (id) => `feature/${id}`,
+      {},
+      { method: "DELETE" }
+    ),
+    updateFeatureLoader: gravityLoader(
+      (id) => `feature/${id}`,
+      {},
+      { method: "PUT" }
+    ),
+    matchFeaturesLoader: gravityLoader("match/features", {}, { headers: true }),
     filterArtworksLoader: gravityLoader("filter/artworks"),
     followArtistLoader: gravityLoader(
       "me/follow/artist",

--- a/src/schema/v2/Feature/CreateFeatureMutation.ts
+++ b/src/schema/v2/Feature/CreateFeatureMutation.ts
@@ -1,0 +1,92 @@
+import {
+  GraphQLString,
+  GraphQLUnionType,
+  GraphQLObjectType,
+  GraphQLBoolean,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { GraphQLNonNull } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { FeatureType } from "./FeatureType"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { FeatureLayoutsEnum } from "./FeatureLayoutsEnum"
+
+interface Input {
+  description: string
+  name: string
+  active: boolean
+  callout: string
+  subheadline: string
+  layout: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreateFeatureSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    feature: {
+      type: FeatureType,
+      resolve: (feature) => feature,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreateFeatureFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "createFeatureResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const CreateFeatureMutation = mutationWithClientMutationId<
+  Input,
+  any | null,
+  ResolverContext
+>({
+  name: "CreateFeatureMutation",
+  description: "Creates a feature.",
+  inputFields: {
+    description: { type: GraphQLString },
+    layout: { type: FeatureLayoutsEnum },
+    name: { type: new GraphQLNonNull(GraphQLString) },
+    active: { type: new GraphQLNonNull(GraphQLBoolean) },
+    callout: { type: GraphQLString },
+    subheadline: { type: GraphQLString },
+  },
+  outputFields: {
+    featureOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (args, { createFeatureLoader }) => {
+    if (!createFeatureLoader) {
+      throw new Error(
+        "You need to pass a X-Access-Token header to perform this action"
+      )
+    }
+
+    try {
+      return await createFeatureLoader(args)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/Feature/DeleteFeatureMutation.ts
+++ b/src/schema/v2/Feature/DeleteFeatureMutation.ts
@@ -1,0 +1,76 @@
+import { GraphQLString, GraphQLUnionType, GraphQLObjectType } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { GraphQLNonNull } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { FeatureType } from "./FeatureType"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+
+interface Input {
+  id: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DeleteFeatureSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    feature: {
+      type: FeatureType,
+      resolve: (feature) => feature,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DeleteFeatureFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "DeleteFeatureResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const DeleteFeatureMutation = mutationWithClientMutationId<
+  Input,
+  any | null,
+  ResolverContext
+>({
+  name: "DeleteFeatureMutation",
+  description: "deletes a feature.",
+  inputFields: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+  },
+  outputFields: {
+    featureOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async ({ id }, { deleteFeatureLoader }) => {
+    if (!deleteFeatureLoader) {
+      throw new Error(
+        "You need to pass a X-Access-Token header to perform this action"
+      )
+    }
+
+    try {
+      return await deleteFeatureLoader(id)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/Feature/Feature.ts
+++ b/src/schema/v2/Feature/Feature.ts
@@ -1,5 +1,6 @@
 import { GraphQLID, GraphQLFieldConfig } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { connectionWithCursorInfo } from "../fields/pagination"
 import { FeatureType } from "./FeatureType"
 
 export const Feature: GraphQLFieldConfig<void, ResolverContext> = {
@@ -13,3 +14,7 @@ export const Feature: GraphQLFieldConfig<void, ResolverContext> = {
   },
   resolve: (_root, { id }, { featureLoader }) => featureLoader(id),
 }
+
+export const FeatureConnection = connectionWithCursorInfo({
+  nodeType: FeatureType,
+})

--- a/src/schema/v2/Feature/FeaturesConnection.ts
+++ b/src/schema/v2/Feature/FeaturesConnection.ts
@@ -1,0 +1,83 @@
+import { GraphQLFieldConfig, GraphQLString } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { paginationResolver } from "schema/v2/fields/pagination"
+import { pageable } from "relay-cursor-paging"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { FeatureConnection } from "./Feature"
+
+import { GraphQLEnumType } from "graphql"
+
+const FeatureSortsType = new GraphQLEnumType({
+  name: "FeatureSorts",
+  values: {
+    CREATED_AT_ASC: {
+      value: "created_at",
+    },
+    CREATED_AT_DESC: {
+      value: "-created_at",
+    },
+    NAME_ASC: {
+      value: "name",
+    },
+    NAME_DESC: {
+      value: "-name",
+    },
+  },
+})
+
+export const FeaturesConnection: GraphQLFieldConfig<void, ResolverContext> = {
+  type: FeatureConnection.connectionType,
+  args: pageable({
+    term: {
+      type: GraphQLString,
+      description: "If present, will search by term",
+    },
+    sort: {
+      type: FeatureSortsType,
+    },
+  }),
+  resolve: async (_root, args, { featuresLoader, matchFeaturesLoader }) => {
+    if (!matchFeaturesLoader || !featuresLoader)
+      throw new Error(
+        "You need to pass a X-Access-Token header to perform this action"
+      )
+
+    const { term } = args
+    const { page, size, offset, sort } = convertConnectionArgsToGravityArgs(
+      args
+    )
+
+    if (term && sort)
+      throw new Error("`sort` and `term` are mutually exclusive parameters.")
+
+    const gravityArgs: {
+      page: number
+      size: number
+      total_count: boolean
+      term?: string
+      sort?: string
+    } = {
+      page,
+      size,
+      total_count: true,
+    }
+
+    if (term) gravityArgs.term = term
+    if (sort) gravityArgs.sort = sort
+
+    const loader = term ? matchFeaturesLoader : featuresLoader
+
+    const { body, headers } = await loader(gravityArgs)
+
+    const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+    return paginationResolver({
+      args,
+      body,
+      offset,
+      page,
+      size,
+      totalCount,
+    })
+  },
+}

--- a/src/schema/v2/Feature/UpdateFeatureMutation.ts
+++ b/src/schema/v2/Feature/UpdateFeatureMutation.ts
@@ -1,0 +1,97 @@
+import {
+  GraphQLString,
+  GraphQLUnionType,
+  GraphQLObjectType,
+  GraphQLBoolean,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { GraphQLNonNull } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { FeatureType } from "./FeatureType"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { FeatureLayoutsEnum } from "./FeatureLayoutsEnum"
+
+interface Input {
+  description: string
+  name: string
+  active: boolean
+  callout: string
+  subheadline: string
+  layout: string
+  id: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateFeatureSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    feature: {
+      type: FeatureType,
+      resolve: (feature) => feature,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateFeatureFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdateFeatureResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const UpdateFeatureMutation = mutationWithClientMutationId<
+  Input,
+  any | null,
+  ResolverContext
+>({
+  name: "UpdateFeatureMutation",
+  description: "updates a feature.",
+  inputFields: {
+    description: { type: GraphQLString },
+    layout: { type: FeatureLayoutsEnum },
+    name: { type: new GraphQLNonNull(GraphQLString) },
+    active: { type: new GraphQLNonNull(GraphQLBoolean) },
+    callout: { type: GraphQLString },
+    subheadline: { type: GraphQLString },
+    id: { type: new GraphQLNonNull(GraphQLString) },
+  },
+  outputFields: {
+    featureOrError: {
+      type: ResponseOrErrorType,
+      description: "On success: the ordered set updated.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (args, { updateFeatureLoader }) => {
+    if (!updateFeatureLoader) {
+      throw new Error(
+        "You need to pass a X-Access-Token header to perform this action"
+      )
+    }
+
+    const { id, ...rest } = args
+
+    try {
+      return await updateFeatureLoader(id, rest)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/Feature/__tests__/CreateFeatureMutation.test.ts
+++ b/src/schema/v2/Feature/__tests__/CreateFeatureMutation.test.ts
@@ -1,0 +1,98 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+const mutation = gql`
+  mutation {
+    createFeature(input: { name: "Catty Feature", active: true }) {
+      featureOrError {
+        __typename
+        ... on CreateFeatureSuccess {
+          feature {
+            name
+            isActive
+          }
+        }
+        ... on CreateFeatureFailure {
+          mutationError {
+            type
+            message
+            detail
+          }
+        }
+      }
+    }
+  }
+`
+
+describe("CreateFeatureMutation", () => {
+  describe("on success", () => {
+    const set = {
+      name: "Catty Feature",
+      active: true,
+      id: "feature-id",
+    }
+
+    const mockCreateFeatureLoader = jest.fn()
+
+    const context = {
+      createFeatureLoader: mockCreateFeatureLoader,
+    }
+
+    beforeEach(() => {
+      mockCreateFeatureLoader.mockResolvedValue(Promise.resolve(set))
+    })
+
+    afterEach(() => {
+      mockCreateFeatureLoader.mockReset()
+    })
+
+    it("returns a feature", async () => {
+      const res = await runAuthenticatedQuery(mutation, context)
+
+      expect(mockCreateFeatureLoader).toBeCalledWith({
+        name: "Catty Feature",
+        active: true,
+      })
+
+      expect(res).toEqual({
+        createFeature: {
+          featureOrError: {
+            __typename: "CreateFeatureSuccess",
+            feature: {
+              name: "Catty Feature",
+              isActive: true,
+            },
+          },
+        },
+      })
+    })
+  })
+
+  describe("on failure", () => {
+    const context = {
+      createFeatureLoader: () =>
+        Promise.reject(
+          new Error(
+            `https://stagingapi.artsy.net/api/v1/feature - {"type": "error","message":"example message","detail":"example detail"}`
+          )
+        ),
+    }
+
+    it("returns a mutation error", async () => {
+      const res = await runAuthenticatedQuery(mutation, context)
+
+      expect(res).toEqual({
+        createFeature: {
+          featureOrError: {
+            __typename: "CreateFeatureFailure",
+            mutationError: {
+              type: "error",
+              message: "example message",
+              detail: "example detail",
+            },
+          },
+        },
+      })
+    })
+  })
+})

--- a/src/schema/v2/Feature/__tests__/DeleteFeatureMutation.test.ts
+++ b/src/schema/v2/Feature/__tests__/DeleteFeatureMutation.test.ts
@@ -1,0 +1,95 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+const mutation = gql`
+  mutation {
+    deleteFeature(input: { id: "abc123" }) {
+      featureOrError {
+        __typename
+        ... on DeleteFeatureSuccess {
+          feature {
+            name
+            isActive
+          }
+        }
+        ... on DeleteFeatureFailure {
+          mutationError {
+            type
+            message
+            detail
+          }
+        }
+      }
+    }
+  }
+`
+
+describe("deleteFeatureMutation", () => {
+  describe("on success", () => {
+    const feature = {
+      name: "Catty Feature",
+      id: "abc123",
+      active: true,
+    }
+
+    const mockDeleteFeatureLoader = jest.fn()
+
+    const context = {
+      deleteFeatureLoader: mockDeleteFeatureLoader,
+    }
+
+    beforeEach(() => {
+      mockDeleteFeatureLoader.mockResolvedValue(Promise.resolve(feature))
+    })
+
+    afterEach(() => {
+      mockDeleteFeatureLoader.mockReset()
+    })
+
+    it("returns the deleted feature", async () => {
+      const res = await runAuthenticatedQuery(mutation, context)
+
+      expect(mockDeleteFeatureLoader).toBeCalledWith("abc123")
+
+      expect(res).toEqual({
+        deleteFeature: {
+          featureOrError: {
+            __typename: "DeleteFeatureSuccess",
+            feature: {
+              name: "Catty Feature",
+              isActive: true,
+            },
+          },
+        },
+      })
+    })
+  })
+
+  describe("on failure", () => {
+    const context = {
+      deleteFeatureLoader: () =>
+        Promise.reject(
+          new Error(
+            `https://stagingapi.artsy.net/api/v1/feature - {"type": "error","message":"example message","detail":"example detail"}`
+          )
+        ),
+    }
+
+    it("returns a mutation error", async () => {
+      const res = await runAuthenticatedQuery(mutation, context)
+
+      expect(res).toEqual({
+        deleteFeature: {
+          featureOrError: {
+            __typename: "DeleteFeatureFailure",
+            mutationError: {
+              type: "error",
+              message: "example message",
+              detail: "example detail",
+            },
+          },
+        },
+      })
+    })
+  })
+})

--- a/src/schema/v2/Feature/__tests__/FeaturesConnection.test.ts
+++ b/src/schema/v2/Feature/__tests__/FeaturesConnection.test.ts
@@ -1,0 +1,80 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("FeaturesConnection", () => {
+  it("uses the match loader when searching by term", async () => {
+    const matchFeaturesLoader = jest.fn().mockReturnValue(
+      Promise.resolve({
+        body: [{ description: "Foo fair" }, { description: "Foo bar fair" }],
+        headers: { "x-total-count": "2" },
+      })
+    )
+
+    const query = gql`
+      {
+        featuresConnection(term: "foo", first: 5) {
+          totalCount
+          edges {
+            node {
+              description
+            }
+          }
+        }
+      }
+    `
+    const { featuresConnection } = await runAuthenticatedQuery(query, {
+      matchFeaturesLoader,
+    })
+
+    expect(matchFeaturesLoader).toBeCalledWith({
+      term: "foo",
+      page: 1,
+      size: 5,
+      total_count: true,
+    })
+
+    expect(featuresConnection.totalCount).toBe(2)
+    expect(featuresConnection.edges[0].node.description).toEqual("Foo fair")
+    expect(featuresConnection.edges[1].node.description).toEqual("Foo bar fair")
+  })
+
+  it("uses the features loader when not searching by term", async () => {
+    const featuresLoader = jest.fn().mockReturnValue(
+      Promise.resolve({
+        body: [
+          { description: "Foo feature" },
+          { description: "Foo bar feature" },
+        ],
+        headers: { "x-total-count": "2" },
+      })
+    )
+
+    const query = gql`
+      {
+        featuresConnection(first: 5) {
+          totalCount
+          edges {
+            node {
+              description
+            }
+          }
+        }
+      }
+    `
+    const { featuresConnection } = await runAuthenticatedQuery(query, {
+      featuresLoader,
+    })
+
+    expect(featuresLoader).toBeCalledWith({
+      page: 1,
+      size: 5,
+      total_count: true,
+    })
+
+    expect(featuresConnection.totalCount).toBe(2)
+    expect(featuresConnection.edges[0].node.description).toEqual("Foo feature")
+    expect(featuresConnection.edges[1].node.description).toEqual(
+      "Foo bar feature"
+    )
+  })
+})

--- a/src/schema/v2/Feature/__tests__/UpdateFeatureMutation.test.ts
+++ b/src/schema/v2/Feature/__tests__/UpdateFeatureMutation.test.ts
@@ -1,0 +1,100 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+const mutation = gql`
+  mutation {
+    updateFeature(
+      input: { name: "Catty Feature", id: "xyz789", active: true }
+    ) {
+      featureOrError {
+        __typename
+        ... on UpdateFeatureSuccess {
+          feature {
+            name
+            isActive
+          }
+        }
+        ... on UpdateFeatureFailure {
+          mutationError {
+            type
+            message
+            detail
+          }
+        }
+      }
+    }
+  }
+`
+
+describe("UpdateFeatureMutation", () => {
+  describe("on success", () => {
+    const feature = {
+      id: "xyz789",
+      name: "Catty Feature",
+      active: true,
+    }
+
+    const mockUpdateFeatureLoader = jest.fn()
+
+    const context = {
+      updateFeatureLoader: mockUpdateFeatureLoader,
+    }
+
+    beforeEach(() => {
+      mockUpdateFeatureLoader.mockResolvedValue(Promise.resolve(feature))
+    })
+
+    afterEach(() => {
+      mockUpdateFeatureLoader.mockReset()
+    })
+
+    it("returns the updated feature", async () => {
+      const res = await runAuthenticatedQuery(mutation, context)
+
+      expect(mockUpdateFeatureLoader).toBeCalledWith("xyz789", {
+        name: "Catty Feature",
+        active: true,
+      })
+
+      expect(res).toEqual({
+        updateFeature: {
+          featureOrError: {
+            __typename: "UpdateFeatureSuccess",
+            feature: {
+              name: "Catty Feature",
+              isActive: true,
+            },
+          },
+        },
+      })
+    })
+  })
+
+  describe("on failure", () => {
+    const context = {
+      updateFeatureLoader: () =>
+        Promise.reject(
+          new Error(
+            `https://stagingapi.artsy.net/api/v1/feature - {"type": "error","message":"example message","detail":"example detail"}`
+          )
+        ),
+    }
+
+    it("returns a mutation error", async () => {
+      const res = await runAuthenticatedQuery(mutation, context)
+
+      expect(res).toEqual({
+        updateFeature: {
+          featureOrError: {
+            __typename: "UpdateFeatureFailure",
+            mutationError: {
+              type: "error",
+              message: "example message",
+              detail: "example detail",
+            },
+          },
+        },
+      })
+    })
+  })
+})

--- a/src/schema/v2/OrderedSet/orderedSetsConnection.ts
+++ b/src/schema/v2/OrderedSet/orderedSetsConnection.ts
@@ -42,12 +42,9 @@ export const OrderedSetsConnection: GraphQLFieldConfig<
 
     const loader = term ? matchSetsLoader : setsLoader
 
-    const { body } = await loader(gravityArgs)
+    const { body, headers } = await loader(gravityArgs)
 
-    // NOTE: the api/v1/match/sets doesn't currently support pagination
-    // so we need manually declare the totalCount since we can't
-    // count on it being returned as a header.
-    const totalCount = body.length
+    const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 
     return paginationResolver({
       args,

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -174,6 +174,9 @@ import { updateQuizMutation } from "schema/v2/updateQuizMutation"
 import { OrderedSetsConnection } from "./OrderedSet/orderedSetsConnection"
 import { triggerCampaignMutation } from "./me/triggerCampaignMutation"
 import { FeaturesConnection } from "./Feature/FeaturesConnection"
+import { CreateFeatureMutation } from "./Feature/CreateFeatureMutation"
+import { UpdateFeatureMutation } from "./Feature/UpdateFeatureMutation"
+import { DeleteFeatureMutation } from "./Feature/DeleteFeatureMutation"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -315,6 +318,7 @@ export default new GraphQLSchema({
       createConsignmentInquiry: createConsignmentInquiryMutation,
       createCreditCard: createCreditCardMutation,
       createGeminiEntryForAsset: CreateGeminiEntryForAsset,
+      createFeature: CreateFeatureMutation,
       createIdentityVerificationOverride: createIdentityVerificationOverrideMutation,
       createOrderedSet: createOrderedSetMutation,
       createUserAdminNote: createUserAdminNoteMutation,
@@ -324,6 +328,7 @@ export default new GraphQLSchema({
       deleteBankAccount: deleteBankAccountMutation,
       deleteConversation: deleteConversationMutation,
       deleteCreditCard: deleteCreditCardMutation,
+      deleteFeature: DeleteFeatureMutation,
       deleteMyAccountMutation: deleteUserAccountMutation,
       deleteMyUserProfileIcon: deleteCollectorProfileIconMutation,
       deleteOrderedSet: deleteOrderedSetMutation,
@@ -360,6 +365,7 @@ export default new GraphQLSchema({
       updateCollectorProfile: UpdateCollectorProfile,
       updateCollectorProfileWithID: UpdateCollectorProfileWithID,
       updateConversation: UpdateConversationMutation,
+      updateFeature: UpdateFeatureMutation,
       updateMessage: updateMessageMutation,
       updateMyPassword: updateMyPasswordMutation,
       updateMyUserProfile: UpdateMyUserProfileMutation,

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -173,6 +173,7 @@ import Conversations from "./conversation/conversations"
 import { updateQuizMutation } from "schema/v2/updateQuizMutation"
 import { OrderedSetsConnection } from "./OrderedSet/orderedSetsConnection"
 import { triggerCampaignMutation } from "./me/triggerCampaignMutation"
+import { FeaturesConnection } from "./Feature/FeaturesConnection"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -233,6 +234,7 @@ const rootFields = {
   fairs: Fairs,
   fairsConnection,
   feature: Feature,
+  featuresConnection: FeaturesConnection,
   filterPartners: FilterPartners,
   gene: Gene,
   geneFamiliesConnection: GeneFamilies,


### PR DESCRIPTION
This adds the CRUD mutations to manage a `Feature`, as well as the `featuresConnection` listings root field.