### PR TITLE
feat(TX-948): add attribution class fields to artwork version

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2543,7 +2543,7 @@ type ArtworkVersion implements Node {
   artists: [Artist]
 
   # The Artwork Version attribution class
-  attributionClass: String
+  attributionClass: AttributionClass
 
   # The Image id
   defaultImageID: String

--- a/src/schema/v2/artwork_version.ts
+++ b/src/schema/v2/artwork_version.ts
@@ -10,6 +10,8 @@ import Image from "./image"
 import { ResolverContext } from "types/graphql"
 import { InternalIDFields, NodeInterface } from "./object_identification"
 import Artist from "./artist"
+import AttributionClass from "./artwork/attributionClass"
+import attributionClasses from "lib/attributionClasses"
 
 export const ArtworkVersionType = new GraphQLObjectType<any, ResolverContext>({
   name: "ArtworkVersion",
@@ -62,9 +64,13 @@ export const ArtworkVersionType = new GraphQLObjectType<any, ResolverContext>({
     },
 
     attributionClass: {
-      type: GraphQLString,
+      type: AttributionClass,
       description: "The Artwork Version attribution class",
-      resolve: ({ attribution_class }) => attribution_class,
+      resolve: ({ attribution_class }) => {
+        if (attribution_class) {
+          return attributionClasses[attribution_class]
+        }
+      },
     },
   }),
 })


### PR DESCRIPTION
Related to [TX-948](https://artsyproduct.atlassian.net/browse/TX-948)

I realized that we specifically need the "short description" of the attribution class on ArtworkVersion. This allows us to access all of the sub-fields instead of only the name. 

<img width="817" alt="Screenshot 2023-01-17 at 11 01 36 AM" src="https://user-images.githubusercontent.com/50849237/212870356-ca2cf960-0f92-47c1-9703-f9d701e2fe27.png">


[TX-948]: https://artsyproduct.atlassian.net/browse/TX-948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ