### PR TITLE
feat(NX-3371): Expose message's to and cc

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11176,6 +11176,9 @@ type Message implements Node {
 
   # Unaltered text if possible, otherwise `body`: a parsed/sanitized version from Sendgrid.
   body: String
+
+  # Masked emails w/ display name of the recipients in copy.
+  cc: [String]
   createdAt(
     format: String
 
@@ -11211,6 +11214,9 @@ type Message implements Node {
     @deprecated(
       reason: "Payment Request was deprecated. The field was kept for legacy client support. [Will be removed in v2]"
     )
+
+  # Masked emails w/ display name of the recipients.
+  to: [String]
 }
 
 # A connection to a list of items.

--- a/src/schema/v2/conversation/__tests__/__snapshots__/message.test.js.snap
+++ b/src/schema/v2/conversation/__tests__/__snapshots__/message.test.js.snap
@@ -64,23 +64,31 @@ Object {
         Object {
           "node": Object {
             "body": "Loved some of the works at your fair booth!",
+            "cc": Array [],
             "from": Object {
               "email": "fancy_german_person@posteo.de",
               "name": "Percy Z",
             },
             "internalID": "222",
             "isFirstMessage": true,
+            "to": Array [],
           },
         },
         Object {
           "node": Object {
             "body": "I'm a cat oh yea!",
+            "cc": Array [
+              "\\"Another Recipient\\" <another_recipient_in_cc@cat.com>",
+            ],
             "from": Object {
               "email": "fancy_german_person@posteo.de",
               "name": "Percy Z",
             },
             "internalID": "222",
             "isFirstMessage": false,
+            "to": Array [
+              "\\"Recipient Name\\" <recipient@cat.com>",
+            ],
           },
         },
       ],

--- a/src/schema/v2/conversation/__tests__/message.test.js
+++ b/src/schema/v2/conversation/__tests__/message.test.js
@@ -30,6 +30,8 @@ describe("Me", () => {
                 original_text:
                   "Loved some of the works at your fair booth! ABOUT THIS COLLECTOR: blah, blah",
                 body: "I'm a cat",
+                to: [],
+                cc: [],
               },
               {
                 id: "222",
@@ -45,6 +47,8 @@ describe("Me", () => {
                 from_principal: true,
                 original_text: "I'm a cat oh yea!",
                 body: "I'm a cat",
+                to: ['"Recipient Name" <recipient@cat.com>'],
+                cc: ['"Another Recipient" <another_recipient_in_cc@cat.com>'],
               },
             ],
           }),
@@ -71,6 +75,8 @@ describe("Me", () => {
                         email
                         name
                       }
+                      to
+                      cc
                     }
                   }
                 }

--- a/src/schema/v2/conversation/message.ts
+++ b/src/schema/v2/conversation/message.ts
@@ -134,5 +134,13 @@ export const MessageType = new GraphQLObjectType<any, ResolverContext>({
       resolve: ({ metadata }) => isInvoiceMessage(metadata),
     },
     createdAt: date(),
+    to: {
+      description: "Masked emails w/ display name of the recipients.",
+      type: new GraphQLList(GraphQLString),
+    },
+    cc: {
+      description: "Masked emails w/ display name of the recipients in copy.",
+      type: new GraphQLList(GraphQLString),
+    },
   },
 })


### PR DESCRIPTION
This PR solves part of [NX-3371](https://artsyproduct.atlassian.net/browse/NX-3371)

# Description

Expose `message` recipients on `to` and `cc`, so we can determine who has opened an email on Volt's Conversations.

cc @artsy/negotiate-devs 

[NX-3371]: https://artsyproduct.atlassian.net/browse/NX-3371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ