### PR TITLE
feat: add CRUD and listings for FeaturedLink

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7036,6 +7036,33 @@ union CreateConsignmentInquiryMutationType =
     ConsignmentInquiryMutationFailure
   | ConsignmentInquiryMutationSuccess
 
+type CreateFeaturedLinkFailure {
+  mutationError: GravityMutationError
+}
+
+input CreateFeaturedLinkMutationInput {
+  clientMutationId: String
+  description: String!
+  href: String!
+  sourceBucket: String
+  sourceKey: String
+  subtitle: String
+  title: String!
+}
+
+type CreateFeaturedLinkMutationPayload {
+  clientMutationId: String
+  featuredLinkOrError: CreateFeaturedLinkResponseOrError
+}
+
+union CreateFeaturedLinkResponseOrError =
+    CreateFeaturedLinkFailure
+  | CreateFeaturedLinkSuccess
+
+type CreateFeaturedLinkSuccess {
+  featuredLink: FeaturedLink
+}
+
 type CreateFeatureFailure {
   mutationError: GravityMutationError
 }
@@ -7661,6 +7688,28 @@ type DeleteCreditCardPayload {
   clientMutationId: String
   creditCardOrError: CreditCardMutationType
   me: Me
+}
+
+type DeleteFeaturedLinkFailure {
+  mutationError: GravityMutationError
+}
+
+input DeleteFeaturedLinkMutationInput {
+  clientMutationId: String
+  id: String!
+}
+
+type DeleteFeaturedLinkMutationPayload {
+  clientMutationId: String
+  featuredLinkOrError: DeleteFeaturedLinkResponseOrError
+}
+
+union DeleteFeaturedLinkResponseOrError =
+    DeleteFeaturedLinkFailure
+  | DeleteFeaturedLinkSuccess
+
+type DeleteFeaturedLinkSuccess {
+  featuredLink: FeaturedLink
 }
 
 type DeleteFeatureFailure {
@@ -8667,6 +8716,26 @@ type FeaturedLink {
   internalID: ID!
   subtitle(format: Format): String
   title: String
+}
+
+# A connection to a list of items.
+type FeaturedLinkConnection {
+  # A list of edges.
+  edges: [FeaturedLinkEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type FeaturedLinkEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: FeaturedLink
 }
 
 union FeaturedLinkEntity = Artist | Gene | Partner
@@ -11481,6 +11550,11 @@ type Mutation {
     input: CreateFeatureMutationInput!
   ): CreateFeatureMutationPayload
 
+  # Creates a featured link.
+  createFeaturedLink(
+    input: CreateFeaturedLinkMutationInput!
+  ): CreateFeaturedLinkMutationPayload
+
   # Attach an gemini asset to a consignment submission
   createGeminiEntryForAsset(
     input: CreateGeminiEntryForAssetInput!
@@ -11544,6 +11618,11 @@ type Mutation {
   deleteFeature(
     input: DeleteFeatureMutationInput!
   ): DeleteFeatureMutationPayload
+
+  # deletes a featured link.
+  deleteFeaturedLink(
+    input: DeleteFeaturedLinkMutationInput!
+  ): DeleteFeaturedLinkMutationPayload
 
   # Delete User Artsy Account
   deleteMyAccountMutation(input: DeleteAccountInput!): DeleteAccountPayload
@@ -11748,6 +11827,11 @@ type Mutation {
   updateFeature(
     input: UpdateFeatureMutationInput!
   ): UpdateFeatureMutationPayload
+
+  # updates a featured link.
+  updateFeaturedLink(
+    input: UpdateFeaturedLinkMutationInput!
+  ): UpdateFeaturedLinkMutationPayload
 
   # Update a message.
   updateMessage(
@@ -13969,6 +14053,15 @@ type Query {
     # The slug or ID of the Feature
     id: ID
   ): Feature
+  featuredLinksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+
+    # If present, will search by term
+    term: String
+  ): FeaturedLinkConnection
   featuresConnection(
     after: String
     before: String
@@ -16744,6 +16837,36 @@ type UpdateConversationMutationPayload {
   conversation: Conversation
 }
 
+type UpdateFeaturedLinkFailure {
+  mutationError: GravityMutationError
+}
+
+input UpdateFeaturedLinkMutationInput {
+  clientMutationId: String
+  description: String
+  href: String
+  id: String!
+  sourceBucket: String
+  sourceKey: String
+  subtitle: String
+  title: String
+}
+
+type UpdateFeaturedLinkMutationPayload {
+  clientMutationId: String
+
+  # On success: featured link updated.
+  featuredLinkOrError: UpdateFeaturedLinkResponseOrError
+}
+
+union UpdateFeaturedLinkResponseOrError =
+    UpdateFeaturedLinkFailure
+  | UpdateFeaturedLinkSuccess
+
+type UpdateFeaturedLinkSuccess {
+  featuredLink: FeaturedLink
+}
+
 type UpdateFeatureFailure {
   mutationError: GravityMutationError
 }
@@ -18130,6 +18253,15 @@ type Viewer {
     # The slug or ID of the Feature
     id: ID
   ): Feature
+  featuredLinksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+
+    # If present, will search by term
+    term: String
+  ): FeaturedLinkConnection
   featuresConnection(
     after: String
     before: String

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -195,6 +195,28 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" }
     ),
+    featuredLinkLoader: gravityLoader((id) => `featured_link/${id}`),
+    featuredLinksLoader: gravityLoader("featured_links", {}, { headers: true }),
+    createFeaturedLinkLoader: gravityLoader(
+      "featured_link",
+      {},
+      { method: "POST" }
+    ),
+    deleteFeaturedLinkLoader: gravityLoader(
+      (id) => `featured_link/${id}`,
+      {},
+      { method: "DELETE" }
+    ),
+    updateFeaturedLinkLoader: gravityLoader(
+      (id) => `featured_link/${id}`,
+      {},
+      { method: "PUT" }
+    ),
+    matchFeaturedLinksLoader: gravityLoader(
+      "match/featured_links",
+      {},
+      { headers: true }
+    ),
     featureLoader: gravityLoader((id) => `feature/${id}`),
     featuresLoader: gravityLoader("features", {}, { headers: true }),
     createFeatureLoader: gravityLoader("feature", {}, { method: "POST" }),

--- a/src/schema/v2/FeaturedLink/__tests__/createFeaturedLinkMutation.test.ts
+++ b/src/schema/v2/FeaturedLink/__tests__/createFeaturedLinkMutation.test.ts
@@ -1,0 +1,106 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+const mutation = gql`
+  mutation {
+    createFeaturedLink(
+      input: { description: "link to cats", title: "Cat Link", href: "/percy" }
+    ) {
+      featuredLinkOrError {
+        __typename
+        ... on CreateFeaturedLinkSuccess {
+          featuredLink {
+            description
+            title
+            href
+          }
+        }
+        ... on CreateFeaturedLinkFailure {
+          mutationError {
+            type
+            message
+            detail
+          }
+        }
+      }
+    }
+  }
+`
+
+describe("CreateFeaturedLinkMutation", () => {
+  describe("on success", () => {
+    const featuredLink = {
+      description: "link to cats",
+      title: "Cat Link",
+      href: "/percy",
+      id: "featured-link-id",
+    }
+
+    const mockCreateFeaturedLinkLoader = jest.fn()
+
+    const context = {
+      createFeaturedLinkLoader: mockCreateFeaturedLinkLoader,
+    }
+
+    beforeEach(() => {
+      mockCreateFeaturedLinkLoader.mockResolvedValue(
+        Promise.resolve(featuredLink)
+      )
+    })
+
+    afterEach(() => {
+      mockCreateFeaturedLinkLoader.mockReset()
+    })
+
+    it("returns a featuredLink", async () => {
+      const res = await runAuthenticatedQuery(mutation, context)
+
+      expect(mockCreateFeaturedLinkLoader).toBeCalledWith({
+        description: "link to cats",
+        title: "Cat Link",
+        href: "/percy",
+      })
+
+      expect(res).toEqual({
+        createFeaturedLink: {
+          featuredLinkOrError: {
+            __typename: "CreateFeaturedLinkSuccess",
+            featuredLink: {
+              description: "link to cats",
+              title: "Cat Link",
+              href: "/percy",
+            },
+          },
+        },
+      })
+    })
+  })
+
+  describe("on failure", () => {
+    const context = {
+      createFeaturedLinkLoader: () =>
+        Promise.reject(
+          new Error(
+            `https://stagingapi.artsy.net/api/v1/featured_link - {"type": "error","message":"example message","detail":"example detail"}`
+          )
+        ),
+    }
+
+    it("returns a mutation error", async () => {
+      const res = await runAuthenticatedQuery(mutation, context)
+
+      expect(res).toEqual({
+        createFeaturedLink: {
+          featuredLinkOrError: {
+            __typename: "CreateFeaturedLinkFailure",
+            mutationError: {
+              type: "error",
+              message: "example message",
+              detail: "example detail",
+            },
+          },
+        },
+      })
+    })
+  })
+})

--- a/src/schema/v2/FeaturedLink/__tests__/deleteFeaturedLinkMutation.test.ts
+++ b/src/schema/v2/FeaturedLink/__tests__/deleteFeaturedLinkMutation.test.ts
@@ -1,0 +1,94 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+const mutation = gql`
+  mutation {
+    deleteFeaturedLink(input: { id: "abc123" }) {
+      featuredLinkOrError {
+        __typename
+        ... on DeleteFeaturedLinkSuccess {
+          featuredLink {
+            href
+          }
+        }
+        ... on DeleteFeaturedLinkFailure {
+          mutationError {
+            type
+            message
+            detail
+          }
+        }
+      }
+    }
+  }
+`
+
+describe("deleteFeaturedLinkMutation", () => {
+  describe("on success", () => {
+    const featuredLink = {
+      href: "/percy",
+      id: "abc123",
+    }
+
+    const mockDeleteFeaturedLinkLoader = jest.fn()
+
+    const context = {
+      deleteFeaturedLinkLoader: mockDeleteFeaturedLinkLoader,
+    }
+
+    beforeEach(() => {
+      mockDeleteFeaturedLinkLoader.mockResolvedValue(
+        Promise.resolve(featuredLink)
+      )
+    })
+
+    afterEach(() => {
+      mockDeleteFeaturedLinkLoader.mockReset()
+    })
+
+    it("returns the deleted featured link", async () => {
+      const res = await runAuthenticatedQuery(mutation, context)
+
+      expect(mockDeleteFeaturedLinkLoader).toBeCalledWith("abc123")
+
+      expect(res).toEqual({
+        deleteFeaturedLink: {
+          featuredLinkOrError: {
+            __typename: "DeleteFeaturedLinkSuccess",
+            featuredLink: {
+              href: "/percy",
+            },
+          },
+        },
+      })
+    })
+  })
+
+  describe("on failure", () => {
+    const context = {
+      deleteFeaturedLinkLoader: () =>
+        Promise.reject(
+          new Error(
+            `https://stagingapi.artsy.net/api/v1/featured_link - {"type": "error","message":"example message","detail":"example detail"}`
+          )
+        ),
+    }
+
+    it("returns a mutation error", async () => {
+      const res = await runAuthenticatedQuery(mutation, context)
+
+      expect(res).toEqual({
+        deleteFeaturedLink: {
+          featuredLinkOrError: {
+            __typename: "DeleteFeaturedLinkFailure",
+            mutationError: {
+              type: "error",
+              message: "example message",
+              detail: "example detail",
+            },
+          },
+        },
+      })
+    })
+  })
+})

--- a/src/schema/v2/FeaturedLink/__tests__/featuredLinksConnection.test.ts
+++ b/src/schema/v2/FeaturedLink/__tests__/featuredLinksConnection.test.ts
@@ -1,0 +1,75 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("featuredLinksConnection", () => {
+  it("uses the match loader when searching by term", async () => {
+    const matchFeaturedLinksLoader = jest.fn().mockReturnValue(
+      Promise.resolve({
+        body: [{ href: "/bitty" }, { href: "/percy" }],
+        headers: { "x-total-count": "2" },
+      })
+    )
+
+    const query = gql`
+      {
+        featuredLinksConnection(term: "foo", first: 5) {
+          totalCount
+          edges {
+            node {
+              href
+            }
+          }
+        }
+      }
+    `
+    const { featuredLinksConnection } = await runAuthenticatedQuery(query, {
+      matchFeaturedLinksLoader,
+    })
+
+    expect(matchFeaturedLinksLoader).toBeCalledWith({
+      term: "foo",
+      page: 1,
+      size: 5,
+      total_count: true,
+    })
+
+    expect(featuredLinksConnection.totalCount).toBe(2)
+    expect(featuredLinksConnection.edges[0].node.href).toEqual("/bitty")
+    expect(featuredLinksConnection.edges[1].node.href).toEqual("/percy")
+  })
+
+  it("uses the features loader when not searching by term", async () => {
+    const featuredLinksLoader = jest.fn().mockReturnValue(
+      Promise.resolve({
+        body: [{ href: "/bitty" }, { href: "/percy" }],
+        headers: { "x-total-count": "2" },
+      })
+    )
+
+    const query = gql`
+      {
+        featuredLinksConnection(first: 5) {
+          totalCount
+          edges {
+            node {
+              href
+            }
+          }
+        }
+      }
+    `
+    const { featuredLinksConnection } = await runAuthenticatedQuery(query, {
+      featuredLinksLoader,
+    })
+
+    expect(featuredLinksLoader).toBeCalledWith({
+      page: 1,
+      size: 5,
+      total_count: true,
+    })
+
+    expect(featuredLinksConnection.totalCount).toBe(2)
+    expect(featuredLinksConnection.edges[0].node.href).toEqual("/bitty")
+    expect(featuredLinksConnection.edges[1].node.href).toEqual("/percy")
+  })
+})

--- a/src/schema/v2/FeaturedLink/__tests__/updateFeaturedLinkMutation.test.ts
+++ b/src/schema/v2/FeaturedLink/__tests__/updateFeaturedLinkMutation.test.ts
@@ -1,0 +1,96 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+const mutation = gql`
+  mutation {
+    updateFeaturedLink(input: { href: "/percy", id: "xyz789" }) {
+      featuredLinkOrError {
+        __typename
+        ... on UpdateFeaturedLinkSuccess {
+          featuredLink {
+            href
+          }
+        }
+        ... on UpdateFeaturedLinkFailure {
+          mutationError {
+            type
+            message
+            detail
+          }
+        }
+      }
+    }
+  }
+`
+
+describe("UpdateFeaturedLinkMutation", () => {
+  describe("on success", () => {
+    const featuredLink = {
+      id: "xyz789",
+      href: "/percy",
+    }
+
+    const mockUpdateFeaturedLinkLoader = jest.fn()
+
+    const context = {
+      updateFeaturedLinkLoader: mockUpdateFeaturedLinkLoader,
+    }
+
+    beforeEach(() => {
+      mockUpdateFeaturedLinkLoader.mockResolvedValue(
+        Promise.resolve(featuredLink)
+      )
+    })
+
+    afterEach(() => {
+      mockUpdateFeaturedLinkLoader.mockReset()
+    })
+
+    it("returns the updated featured link", async () => {
+      const res = await runAuthenticatedQuery(mutation, context)
+
+      expect(mockUpdateFeaturedLinkLoader).toBeCalledWith("xyz789", {
+        href: "/percy",
+      })
+
+      expect(res).toEqual({
+        updateFeaturedLink: {
+          featuredLinkOrError: {
+            __typename: "UpdateFeaturedLinkSuccess",
+            featuredLink: {
+              href: "/percy",
+            },
+          },
+        },
+      })
+    })
+  })
+
+  describe("on failure", () => {
+    const context = {
+      updateFeaturedLinkLoader: () =>
+        Promise.reject(
+          new Error(
+            `https://stagingapi.artsy.net/api/v1/featured_link - {"type": "error","message":"example message","detail":"example detail"}`
+          )
+        ),
+    }
+
+    it("returns a mutation error", async () => {
+      const res = await runAuthenticatedQuery(mutation, context)
+
+      expect(res).toEqual({
+        updateFeaturedLink: {
+          featuredLinkOrError: {
+            __typename: "UpdateFeaturedLinkFailure",
+            mutationError: {
+              type: "error",
+              message: "example message",
+              detail: "example detail",
+            },
+          },
+        },
+      })
+    })
+  })
+})

--- a/src/schema/v2/FeaturedLink/createFeaturedLinkMutation.ts
+++ b/src/schema/v2/FeaturedLink/createFeaturedLinkMutation.ts
@@ -1,0 +1,104 @@
+import { GraphQLString, GraphQLUnionType, GraphQLObjectType } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { GraphQLNonNull } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { FeaturedLinkType } from "./featuredLink"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+
+interface Input {
+  description: string
+  title: string
+  href: string
+  subtitle?: string
+  sourceBucket?: string
+  sourceKey?: string
+}
+
+interface GravityInput {
+  description: string
+  title: string
+  href: string
+  subtitle?: string
+  source_bucket?: string
+  source_key?: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreateFeaturedLinkSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    featuredLink: {
+      type: FeaturedLinkType,
+      resolve: (featuredLink) => featuredLink,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreateFeaturedLinkFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "CreateFeaturedLinkResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const CreateFeaturedLinkMutation = mutationWithClientMutationId<
+  Input,
+  any | null,
+  ResolverContext
+>({
+  name: "CreateFeaturedLinkMutation",
+  description: "Creates a featured link.",
+  inputFields: {
+    description: { type: new GraphQLNonNull(GraphQLString) },
+    title: { type: new GraphQLNonNull(GraphQLString) },
+    href: { type: new GraphQLNonNull(GraphQLString) },
+    subtitle: { type: GraphQLString },
+    sourceBucket: { type: GraphQLString },
+    sourceKey: { type: GraphQLString },
+  },
+  outputFields: {
+    featuredLinkOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (args, { createFeaturedLinkLoader }) => {
+    if (!createFeaturedLinkLoader) {
+      throw new Error(
+        "You need to pass a X-Access-Token header to perform this action"
+      )
+    }
+
+    const gravityArgs: GravityInput = {
+      description: args.description,
+      title: args.title,
+      href: args.href,
+      subtitle: args.subtitle,
+      source_bucket: args.sourceBucket,
+      source_key: args.sourceKey,
+    }
+
+    try {
+      return await createFeaturedLinkLoader(gravityArgs)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/FeaturedLink/deleteFeaturedLinkMutation.ts
+++ b/src/schema/v2/FeaturedLink/deleteFeaturedLinkMutation.ts
@@ -1,0 +1,76 @@
+import { GraphQLString, GraphQLUnionType, GraphQLObjectType } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { GraphQLNonNull } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { FeaturedLinkType } from "./featuredLink"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+
+interface Input {
+  id: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DeleteFeaturedLinkSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    featuredLink: {
+      type: FeaturedLinkType,
+      resolve: (featuredLink) => featuredLink,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DeleteFeaturedLinkFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "DeleteFeaturedLinkResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const DeleteFeaturedLinkMutation = mutationWithClientMutationId<
+  Input,
+  any | null,
+  ResolverContext
+>({
+  name: "DeleteFeaturedLinkMutation",
+  description: "deletes a featured link.",
+  inputFields: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+  },
+  outputFields: {
+    featuredLinkOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async ({ id }, { deleteFeaturedLinkLoader }) => {
+    if (!deleteFeaturedLinkLoader) {
+      throw new Error(
+        "You need to pass a X-Access-Token header to perform this action"
+      )
+    }
+
+    try {
+      return await deleteFeaturedLinkLoader(id)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/FeaturedLink/featuredLink.ts
+++ b/src/schema/v2/FeaturedLink/featuredLink.ts
@@ -1,5 +1,5 @@
-import initials from "./fields/initials"
-import Image from "./image"
+import initials from "../fields/initials"
+import Image from "../image"
 import {
   GraphQLString,
   GraphQLObjectType,
@@ -7,12 +7,13 @@ import {
   GraphQLUnionType,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
-import { InternalIDFields } from "./object_identification"
-import { markdown } from "./fields/markdown"
-import { ArtistType } from "./artist"
+import { InternalIDFields } from "../object_identification"
+import { markdown } from "../fields/markdown"
+import { ArtistType } from "../artist"
 import { PartnerType } from "schema/v2/partner/partner"
-import { GeneType } from "./gene"
+import { GeneType } from "../gene"
 import { URL } from "url"
+import { connectionWithCursorInfo } from "../fields/pagination"
 
 export const FeaturedLinkType = new GraphQLObjectType<any, ResolverContext>({
   name: "FeaturedLink",
@@ -74,6 +75,10 @@ export const FeaturedLinkType = new GraphQLObjectType<any, ResolverContext>({
     title: { type: GraphQLString },
   },
 })
+
+export const FeaturedLinkConnectionType = connectionWithCursorInfo({
+  nodeType: FeaturedLinkType,
+}).connectionType
 
 const FeaturedLink: GraphQLFieldConfig<void, ResolverContext> = {
   type: FeaturedLinkType,

--- a/src/schema/v2/FeaturedLink/featuredLinksConnection.ts
+++ b/src/schema/v2/FeaturedLink/featuredLinksConnection.ts
@@ -1,0 +1,60 @@
+import { GraphQLFieldConfig, GraphQLString } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { paginationResolver } from "schema/v2/fields/pagination"
+import { pageable } from "relay-cursor-paging"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { FeaturedLinkConnectionType } from "./featuredLink"
+
+export const FeaturedLinksConnection: GraphQLFieldConfig<
+  void,
+  ResolverContext
+> = {
+  type: FeaturedLinkConnectionType,
+  args: pageable({
+    term: {
+      type: GraphQLString,
+      description: "If present, will search by term",
+    },
+  }),
+  resolve: async (
+    _root,
+    args,
+    { featuredLinksLoader, matchFeaturedLinksLoader }
+  ) => {
+    if (!matchFeaturedLinksLoader || !featuredLinksLoader)
+      throw new Error(
+        "You need to pass a X-Access-Token header to perform this action"
+      )
+
+    const { term } = args
+    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+
+    const gravityArgs: {
+      page: number
+      size: number
+      total_count: boolean
+      term?: string
+    } = {
+      page,
+      size,
+      total_count: true,
+    }
+
+    if (term) gravityArgs.term = term
+
+    const loader = term ? matchFeaturedLinksLoader : featuredLinksLoader
+
+    const { body, headers } = await loader(gravityArgs)
+
+    const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+    return paginationResolver({
+      args,
+      body,
+      offset,
+      page,
+      size,
+      totalCount,
+    })
+  },
+}

--- a/src/schema/v2/FeaturedLink/updateFeaturedLinkMutation.ts
+++ b/src/schema/v2/FeaturedLink/updateFeaturedLinkMutation.ts
@@ -1,0 +1,108 @@
+import { GraphQLString, GraphQLUnionType, GraphQLObjectType } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { GraphQLNonNull } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { FeaturedLinkType } from "./featuredLink"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+
+interface Input {
+  description?: string
+  title?: string
+  href?: string
+  subtitle?: string
+  sourceBucket?: string
+  sourceKey?: string
+}
+
+interface GravityInput {
+  description?: string
+  title?: string
+  href?: string
+  subtitle?: string
+  source_bucket?: string
+  source_key?: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateFeaturedLinkSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    featuredLink: {
+      type: FeaturedLinkType,
+      resolve: (featuredLink) => featuredLink,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateFeaturedLinkFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdateFeaturedLinkResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const UpdateFeaturedLinkMutation = mutationWithClientMutationId<
+  Input & { id: string },
+  any | null,
+  ResolverContext
+>({
+  name: "UpdateFeaturedLinkMutation",
+  description: "updates a featured link.",
+  inputFields: {
+    description: { type: GraphQLString },
+    title: { type: GraphQLString },
+    href: { type: GraphQLString },
+    subtitle: { type: GraphQLString },
+    id: { type: new GraphQLNonNull(GraphQLString) },
+    sourceBucket: { type: GraphQLString },
+    sourceKey: { type: GraphQLString },
+  },
+  outputFields: {
+    featuredLinkOrError: {
+      type: ResponseOrErrorType,
+      description: "On success: featured link updated.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (args, { updateFeaturedLinkLoader }) => {
+    if (!updateFeaturedLinkLoader) {
+      throw new Error(
+        "You need to pass a X-Access-Token header to perform this action"
+      )
+    }
+
+    const { id, ...rest } = args
+
+    const gravityArgs: GravityInput = {
+      description: rest.description,
+      title: rest.title,
+      href: rest.href,
+      subtitle: rest.subtitle,
+      source_bucket: rest.sourceBucket,
+      source_key: rest.sourceKey,
+    }
+
+    try {
+      return await updateFeaturedLinkLoader(id, gravityArgs)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/item.ts
+++ b/src/schema/v2/item.ts
@@ -1,7 +1,7 @@
 import { GraphQLUnionType } from "graphql"
 import { ArtistType } from "./artist"
 import { ArtworkType } from "./artwork"
-import { FeaturedLinkType } from "./featured_link"
+import { FeaturedLinkType } from "./FeaturedLink/featuredLink"
 import { GeneType } from "./gene"
 import { connectionWithCursorInfo } from "schema/v2/fields/pagination"
 import { Gravity } from "types/runtime"

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -178,6 +178,10 @@ import { FeaturesConnection } from "./Feature/FeaturesConnection"
 import { CreateFeatureMutation } from "./Feature/CreateFeatureMutation"
 import { UpdateFeatureMutation } from "./Feature/UpdateFeatureMutation"
 import { DeleteFeatureMutation } from "./Feature/DeleteFeatureMutation"
+import { FeaturedLinksConnection } from "./FeaturedLink/featuredLinksConnection"
+import { CreateFeaturedLinkMutation } from "./FeaturedLink/createFeaturedLinkMutation"
+import { UpdateFeaturedLinkMutation } from "./FeaturedLink/updateFeaturedLinkMutation"
+import { DeleteFeaturedLinkMutation } from "./FeaturedLink/deleteFeaturedLinkMutation"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -238,6 +242,7 @@ const rootFields = {
   fairs: Fairs,
   fairsConnection,
   feature: Feature,
+  featuredLinksConnection: FeaturedLinksConnection,
   featuresConnection: FeaturesConnection,
   filterPartners: FilterPartners,
   gene: Gene,
@@ -320,6 +325,7 @@ export default new GraphQLSchema({
       createCreditCard: createCreditCardMutation,
       createGeminiEntryForAsset: CreateGeminiEntryForAsset,
       createFeature: CreateFeatureMutation,
+      createFeaturedLink: CreateFeaturedLinkMutation,
       createIdentityVerificationOverride: createIdentityVerificationOverrideMutation,
       createOrderedSet: createOrderedSetMutation,
       createUserAdminNote: createUserAdminNoteMutation,
@@ -330,6 +336,7 @@ export default new GraphQLSchema({
       deleteConversation: deleteConversationMutation,
       deleteCreditCard: deleteCreditCardMutation,
       deleteFeature: DeleteFeatureMutation,
+      deleteFeaturedLink: DeleteFeaturedLinkMutation,
       deleteMyAccountMutation: deleteUserAccountMutation,
       deleteMyUserProfileIcon: deleteCollectorProfileIconMutation,
       deleteOrderedSet: deleteOrderedSetMutation,
@@ -368,6 +375,7 @@ export default new GraphQLSchema({
       updateCollectorProfileWithID: UpdateCollectorProfileWithID,
       updateConversation: UpdateConversationMutation,
       updateFeature: UpdateFeatureMutation,
+      updateFeaturedLink: UpdateFeaturedLinkMutation,
       updateMessage: updateMessageMutation,
       updateMyPassword: updateMyPasswordMutation,
       updateMyUserProfile: UpdateMyUserProfileMutation,


### PR DESCRIPTION
Opening this in draft mode b/c I still need to add some tests.

But! This adds the usual CRUD mutations, plus a listings root field `featuredLinksConnection` which supports the match-querying as well (as per usual).