### PR TITLE
chore(NX-3371): make message's to and cc non-nullable

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11178,7 +11178,7 @@ type Message implements Node {
   body: String
 
   # Masked emails w/ display name of the recipients in copy.
-  cc: [String]
+  cc: [String!]!
   createdAt(
     format: String
 
@@ -11216,7 +11216,7 @@ type Message implements Node {
     )
 
   # Masked emails w/ display name of the recipients.
-  to: [String]
+  to: [String!]!
 }
 
 # A connection to a list of items.

--- a/src/schema/v2/conversation/message.ts
+++ b/src/schema/v2/conversation/message.ts
@@ -136,11 +136,15 @@ export const MessageType = new GraphQLObjectType<any, ResolverContext>({
     createdAt: date(),
     to: {
       description: "Masked emails w/ display name of the recipients.",
-      type: new GraphQLList(GraphQLString),
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(GraphQLString))
+      ),
     },
     cc: {
       description: "Masked emails w/ display name of the recipients in copy.",
-      type: new GraphQLList(GraphQLString),
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(GraphQLString))
+      ),
     },
   },
 })


### PR DESCRIPTION
Solves part of [NX-3371](https://artsyproduct.atlassian.net/browse/NX-3371)

## Description

As a follow-up of https://github.com/artsy/metaphysics/pull/4698, define `message`'s `to` and `cc` as non-nullable since they can be empty arrays. More context [here](https://github.com/artsy/metaphysics/pull/4698#discussion_r1081643489).

cc @artsy/negotiate-devs 

[NX-3371]: https://artsyproduct.atlassian.net/browse/NX-3371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ