### PR TITLE
feat(wishlists): add artworksConnection to me.collection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3551,6 +3551,14 @@ type CitySponsoredContent {
 
 # A collection of artworks
 type Collection {
+  artworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    sort: CollectionSorts
+  ): ArtworkConnection
+
   # Number of artworks associated with this collection.
   artworksCount: Int!
 
@@ -3574,6 +3582,8 @@ type Collection {
 enum CollectionSorts {
   POSITION_ASC
   POSITION_DESC
+  SAVED_AT_ASC
+  SAVED_AT_DESC
 }
 
 type CollectorProfileArtists {

--- a/src/schema/v2/me/collection.ts
+++ b/src/schema/v2/me/collection.ts
@@ -6,8 +6,16 @@ import {
   GraphQLBoolean,
   GraphQLInt,
 } from "graphql"
+import {
+  CatchCollectionNotFoundException,
+  convertConnectionArgsToGravityArgs,
+} from "lib/helpers"
+import { pageable } from "relay-cursor-paging"
 import { ResolverContext } from "types/graphql"
+import { artworkConnection } from "../artwork"
+import { paginationResolver } from "../fields/pagination"
 import { InternalIDFields } from "../object_identification"
+import CollectionSorts from "../sorts/collection_sorts"
 
 export const Collection: GraphQLFieldConfig<any, ResolverContext> = {
   description: "A collection belonging to the current user",
@@ -16,6 +24,54 @@ export const Collection: GraphQLFieldConfig<any, ResolverContext> = {
     description: "A collection of artworks",
     fields: () => ({
       ...InternalIDFields,
+      artworksConnection: {
+        type: artworkConnection.connectionType,
+        args: {
+          ...pageable(),
+          sort: {
+            type: CollectionSorts,
+            defaultValue: CollectionSorts.getValue("SAVED_AT_DESC")!.value,
+          },
+        },
+        resolve: async (parent, args, context, _info) => {
+          const { collectionArtworksLoader } = context
+          if (!collectionArtworksLoader) return null
+
+          const { id, user_id } = parent
+          const { page, size, offset } = convertConnectionArgsToGravityArgs(
+            args
+          )
+
+          const gravityOptions = {
+            page,
+            size,
+            user_id,
+            private: true,
+            sort: args.sort,
+            total_count: true,
+          }
+
+          try {
+            const { headers, body } = await collectionArtworksLoader(
+              id,
+              gravityOptions
+            )
+
+            const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+            return paginationResolver({
+              totalCount,
+              offset,
+              page,
+              size,
+              body,
+              args,
+            })
+          } catch (error) {
+            return CatchCollectionNotFoundException(error)
+          }
+        },
+      },
       artworksCount: {
         type: new GraphQLNonNull(GraphQLInt),
         description: "Number of artworks associated with this collection.",
@@ -55,6 +111,9 @@ export const Collection: GraphQLFieldConfig<any, ResolverContext> = {
       private: true,
     })
 
-    return response
+    return {
+      ...response,
+      user_id: meID,
+    }
   },
 }

--- a/src/schema/v2/me/collection.ts
+++ b/src/schema/v2/me/collection.ts
@@ -27,17 +27,18 @@ export const Collection: GraphQLFieldConfig<any, ResolverContext> = {
       artworksConnection: {
         type: artworkConnection.connectionType,
         args: {
-          ...pageable(),
-          sort: {
-            type: CollectionSorts,
-            defaultValue: CollectionSorts.getValue("SAVED_AT_DESC")!.value,
-          },
+          ...pageable({
+            sort: {
+              type: CollectionSorts,
+              defaultValue: CollectionSorts.getValue("SAVED_AT_DESC")!.value,
+            },
+          }),
         },
         resolve: async (parent, args, context, _info) => {
           const { collectionArtworksLoader } = context
           if (!collectionArtworksLoader) return null
 
-          const { id, user_id } = parent
+          const { id, userID } = parent
           const { page, size, offset } = convertConnectionArgsToGravityArgs(
             args
           )
@@ -45,7 +46,7 @@ export const Collection: GraphQLFieldConfig<any, ResolverContext> = {
           const gravityOptions = {
             page,
             size,
-            user_id,
+            user_id: userID,
             private: true,
             sort: args.sort,
             total_count: true,
@@ -113,7 +114,7 @@ export const Collection: GraphQLFieldConfig<any, ResolverContext> = {
 
     return {
       ...response,
-      user_id: meID,
+      userID: meID,
     }
   },
 }

--- a/src/schema/v2/me/collection.ts
+++ b/src/schema/v2/me/collection.ts
@@ -16,25 +16,25 @@ export const Collection: GraphQLFieldConfig<any, ResolverContext> = {
     description: "A collection of artworks",
     fields: () => ({
       ...InternalIDFields,
-      name: {
-        type: new GraphQLNonNull(GraphQLString),
-        description:
-          "Name of the collection. Has a predictable value for 'standard' collections such as Saved Artwork, My Collection, etc. Can be provided by user otherwise.",
+      artworksCount: {
+        type: new GraphQLNonNull(GraphQLInt),
+        description: "Number of artworks associated with this collection.",
+        resolve: ({ artworks_count }) => artworks_count,
       },
       default: {
         type: new GraphQLNonNull(GraphQLBoolean),
         description:
           "True if this is the default collection for this user, i.e. the default Saved Artwork collection.",
       },
+      name: {
+        type: new GraphQLNonNull(GraphQLString),
+        description:
+          "Name of the collection. Has a predictable value for 'standard' collections such as Saved Artwork, My Collection, etc. Can be provided by user otherwise.",
+      },
       saves: {
         type: new GraphQLNonNull(GraphQLBoolean),
         description:
           "True if this collection represents artworks explicitly saved by the user, false otherwise.",
-      },
-      artworksCount: {
-        type: new GraphQLNonNull(GraphQLInt),
-        description: "Number of artworks associated with this collection.",
-        resolve: ({ artworks_count }) => artworks_count,
       },
     }),
   }),

--- a/src/schema/v2/sorts/collection_sorts.ts
+++ b/src/schema/v2/sorts/collection_sorts.ts
@@ -9,6 +9,12 @@ const CollectionSorts = new GraphQLEnumType({
     POSITION_DESC: {
       value: "-position",
     },
+    SAVED_AT_ASC: {
+      value: "created_at",
+    },
+    SAVED_AT_DESC: {
+      value: "-created_at",
+    },
   },
 })
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-4513

This adds a `me.collection.artworksConnection` field such that the following query for a user's saved artworks can be resolved via an authenticated loader:

### Query

```graphql
query {
  me {
    collection(id: "saved-artwork") { # 👈🏽 pseudo-slug or database ID works here
      artworksConnection(first: 3 sort: SAVED_AT_DESC) {
        totalCount
        edges {
          node {
            slug
          }
        }
      }
    }
  }
}
```

### Success Response

```json
{
  "data": {
    "me": {
      "collection": {
        "artworksConnection": {
          "totalCount": 42,
          "edges": [
            {
              "node": {
                "slug": "a-saved-artwork"
              }
            },
            {
              "node": {
                "slug": "another-saved-artwork"
              }
            },
            {
              "node": {
                "slug": "yet-another-saved-artwork"
              }
            }
          ]
        }
      }
    }
  }
}

```

### Unauthorized Response 

If there is a mismatch between the collection owner and the user associated with the current access token

```json
{
  "data": {
    "me": {
      "collection": null
    }
  },
  "errors": [
    {
      "message": "… {\"error\":\"Collection Not Found\"}",
      "locations": "…",
      "path": "…",
      "stack": "…"
    }
  ]
}
```