### PR TITLE
Feat(CX-2847): Updated GraphQLLong

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12071,7 +12071,7 @@ input MyCollectionUpdateArtworkInput {
   isEdition: Boolean
   medium: String
   metric: String
-  pricePaidCents: Int
+  pricePaidCents: Long
   pricePaidCurrency: String
   provenance: String
   submissionId: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11336,7 +11336,7 @@ type Money {
   ): Float!
 
   # An amount of money expressed in minor units (like cents).
-  minor: Int!
+  minor: Long!
 }
 
 # A money object with amount in minor currency and a currency code, or an error object
@@ -11986,8 +11986,8 @@ input MyCollectionCreateArtworkInput {
   medium: String
   metric: String
 
-  # @deprecated use the cost major and cost minor fields instead
-  pricePaidCents: Int
+  # The price paid for the MyCollection artwork in cents for any given currency
+  pricePaidCents: Long
   pricePaidCurrency: String
   provenance: String
   submissionId: String

--- a/src/lib/customTypes/GraphQLLong.ts
+++ b/src/lib/customTypes/GraphQLLong.ts
@@ -1,0 +1,40 @@
+import { GraphQLScalarType } from "graphql"
+import { Kind } from "graphql/language"
+
+const MAX_LONG = Number.MAX_SAFE_INTEGER
+const MIN_LONG = Number.MIN_SAFE_INTEGER
+
+const serializeLong = (value) => {
+  if (value !== 0 && value !== "0" && !Number(value)) {
+    throw new TypeError(
+      "Long cannot represent non 52-bit signed integer value: (empty string or NaN)"
+    )
+  }
+  const num = Number(value)
+  if (num <= MAX_LONG && num >= MIN_LONG) {
+    if (num < 0) {
+      return Math.ceil(num)
+    }
+    return Math.floor(num)
+  }
+  throw new TypeError(
+    `Long cannot represent non 52-bit signed integer value: ${value}`
+  )
+}
+
+export const GraphQLLong = new GraphQLScalarType({
+  name: "Long",
+  description: "The `Long` scalar type represents 52-bit signed integers",
+  serialize: serializeLong,
+  parseValue: serializeLong,
+  parseLiteral: (ast) => {
+    if (ast.kind == Kind.INT) {
+      const num = parseInt(ast.value, 10)
+      if (num <= MAX_LONG && num >= MIN_LONG) {
+        return num
+      }
+      return null
+    }
+    return null
+  },
+})

--- a/src/schema/v2/fields/money.ts
+++ b/src/schema/v2/fields/money.ts
@@ -13,6 +13,7 @@ import { ResolverContext } from "types/graphql"
 
 // Taken from https://github.com/RubyMoney/money/blob/master/config/currency_iso.json
 import currencyCodes from "lib/currency_codes.json"
+import { GraphQLLong } from "lib/customTypes/GraphQLLong"
 
 export const amountSDL = (name) => `
   ${name}(
@@ -159,7 +160,7 @@ export const Money = new GraphQLObjectType<any, ResolverContext>({
   name: "Money",
   fields: {
     minor: {
-      type: new GraphQLNonNull(GraphQLInt),
+      type: new GraphQLNonNull(GraphQLLong),
       description: "An amount of money expressed in minor units (like cents).",
       resolve: ({ cents }) => cents,
     },

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -8,6 +8,7 @@ import {
   GraphQLString,
 } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
+import { GraphQLLong } from "lib/customTypes/GraphQLLong"
 import { formatGravityError } from "lib/gravityErrorHandler"
 import { StaticPathLoader } from "lib/loaders/api/loader_interface"
 import { mapKeys, snakeCase } from "lodash"
@@ -118,8 +119,8 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
     },
     pricePaidCents: {
       description:
-        "@deprecated use the cost major and cost minor fields instead",
-      type: GraphQLInt,
+        "The price paid for the MyCollection artwork in cents for any given currency",
+      type: GraphQLLong,
     },
     pricePaidCurrency: {
       type: GraphQLString,

--- a/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
@@ -6,6 +6,7 @@ import {
   GraphQLString,
 } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
+import { GraphQLLong } from "lib/customTypes/GraphQLLong"
 import { formatGravityError } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
 import { MyCollectionArtworkMutationType } from "./myCollection"
@@ -101,7 +102,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
       type: GraphQLString,
     },
     pricePaidCents: {
-      type: GraphQLInt,
+      type: GraphQLLong,
     },
     pricePaidCurrency: {
       type: GraphQLString,


### PR DESCRIPTION
This PR resolves [CX-2847]

### Description
- This PR is same as https://github.com/artsy/metaphysics/pull/4702 except for a single line that updates the updateArtworkCollection Mutation pricePaidCents type to use the custom Long type.

#### More:
This PR resolves [CX-2847]

### Description
#### Problem:
 We are unable to create artworks priced above 2**32 $. While we can pass this to gravity, we cannot get past Metaphysics because GraphQLInt will only allow values below a 32 bit signed integer.
This  PR does the following: 
- adds a custom Long type to Metaphysics to allow us pass up to javascript's Number.MAX_SAFE_INTEGER which is 52 bits signed integer.
- Updates the type for pricePaidCents for MyCollection Artwork to use this type.
- Updates the type for `minor` in `Money` to use this type. By updating this, this enables us to be able to read money.minor values of up to our current definition of Long.

#### Before
https://user-images.githubusercontent.com/18648835/213712541-151d2aff-c098-4b11-b7fd-f7115b068162.mov

#### Passing Int values above 32 bits 

https://user-images.githubusercontent.com/18648835/213712825-9f437e43-20bc-43ef-a863-5dde05a0dc02.mov

#### Passing Int Values above 53 bits

https://user-images.githubusercontent.com/18648835/213712943-6b5a324c-0579-4b35-9ffa-e2618be0e065.mov

#### A General Sweep of all the places we display money

https://user-images.githubusercontent.com/18648835/213713075-66b6ba14-75d0-49ce-98d5-ec0ed1928714.mov



[CX-2847]: https://artsyproduct.atlassian.net/browse/CX-2847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ