### PR TITLE
fix(NX-3412): gracefully handle errors from fromUser

### DIFF
--- a/src/schema/v2/conversation/index.ts
+++ b/src/schema/v2/conversation/index.ts
@@ -272,12 +272,17 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
     fromUser: {
       description: "The user who initiated the conversation",
       type: UserType,
-      resolve: ({ from_id }, _options, { userByIDLoader }) => {
+      resolve: async ({ from_id }, _options, { userByIDLoader }) => {
         if (!userByIDLoader) {
           return null
         }
-
-        return userByIDLoader(from_id)
+        try {
+          const user = await userByIDLoader(from_id)
+          return user
+        } catch (error) {
+          console.error("[schema/v2/conversation/fromUser] Error:", error)
+          return null
+        }
       },
     },
     to: {


### PR DESCRIPTION
[NX-3421]

When we soft remove user data the field `fromUser` throws an error from the `conversations` domain. This PR gracefully handles the error; no changes within the returned data, only does not pollute the client logs with the error anymore.

@artsy/negotiate-devs 

[NX-3421]: https://artsyproduct.atlassian.net/browse/NX-3421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ