### PR TITLE
feat(quiz): exposes a (cached) recommended artworks field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14713,6 +14713,7 @@ type Quiz {
     page: Int
     size: Int
   ): QuizArtworkConnection
+  recommendedArtworks: [Artwork!]!
   savedArtworks: [Artwork!]!
 }
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2439,6 +2439,7 @@ type ArtworkLayer {
     first: Int
     last: Int
   ): ArtworkConnection
+  cached: Int
   description: String
   href: String
 

--- a/src/schema/v2/artwork/layer.ts
+++ b/src/schema/v2/artwork/layer.ts
@@ -5,11 +5,13 @@ import { pageable } from "relay-cursor-paging"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { connectionFromArraySlice } from "graphql-relay"
 import { ResolverContext } from "types/graphql"
+import cached from "../fields/cached"
 
 const ArtworkLayerType = new GraphQLObjectType<any, ResolverContext>({
   name: "ArtworkLayer",
   fields: () => ({
     ...IDFields,
+    cached,
     // NOTE: pagination is not truly supported here.
     // The GraphQL connection spec is observed, but only
     // the number of items to return is respected.

--- a/src/schema/v2/quizArtworkConnection.ts
+++ b/src/schema/v2/quizArtworkConnection.ts
@@ -31,14 +31,19 @@ export const quizArtworkConnection: GraphQLFieldConfig<any, ResolverContext> = {
   }),
   resolve: ({ quiz_artworks }, args) => {
     const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+
     const totalCount = quiz_artworks.length
+
+    const sorted = quiz_artworks.sort((a, b) => {
+      return a.position - b.position
+    })
 
     const quizArtworks = paginationResolver({
       totalCount,
       offset,
       page,
       size,
-      body: quiz_artworks,
+      body: sorted,
       args,
       resolveNode: (node) => {
         return node.artwork


### PR DESCRIPTION
So, primarily what this does is expose a new `recommendedArtworks` field to the `Quiz`. It looks for your saved artworks, then uses those to directly request the `main` layer and caches it for 24 hours.