### PR TITLE
feat(wishlists): add deleteCollection mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7710,6 +7710,30 @@ type DeleteBankAccountPayload {
   me: Me
 }
 
+type DeleteCollectionFailure {
+  mutationError: GravityMutationError
+}
+
+input deleteCollectionInput {
+  clientMutationId: String
+  id: String!
+}
+
+type deleteCollectionPayload {
+  clientMutationId: String
+
+  # On success: the deleted collection
+  responseOrError: DeleteCollectionResponseOrError
+}
+
+union DeleteCollectionResponseOrError =
+    DeleteCollectionFailure
+  | DeleteCollectionSuccess
+
+type DeleteCollectionSuccess {
+  collection: Collection
+}
+
 type DeleteConversationFailure {
   mutationError: GravityMutationError
 }
@@ -11674,6 +11698,9 @@ type Mutation {
 
   # Remove a bank account
   deleteBankAccount(input: DeleteBankAccountInput!): DeleteBankAccountPayload
+
+  # Delete a collection
+  deleteCollection(input: deleteCollectionInput!): deleteCollectionPayload
 
   # Soft-delete a conversation.
   deleteConversation(

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -127,6 +127,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "DELETE" }
     ),
+    deleteCollectionLoader: gravityLoader(
+      (id) => `collection/${id}`,
+      { user_id: userID },
+      { method: "DELETE" }
+    ),
     deleteCollectorProfileIconLoader: gravityLoader(
       "me/collector_profile/icon",
       {},

--- a/src/schema/v2/me/__tests__/deleteCollectionMutation.test.ts
+++ b/src/schema/v2/me/__tests__/deleteCollectionMutation.test.ts
@@ -1,0 +1,89 @@
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import { ResolverContext } from "types/graphql"
+
+const mutation = `
+  mutation {
+    deleteCollection(input: { id: "123-abc" }) {
+      responseOrError {
+        ... on DeleteCollectionSuccess {
+          collection {
+            internalID
+            name
+          }
+        }
+
+        ... on DeleteCollectionFailure {
+          mutationError {
+            message
+          }
+        }
+      }
+    }
+  }
+`
+
+describe("deleteCollection", () => {
+  describe("valid query", () => {
+    const mockGravityResponse = {
+      id: "123-abc",
+      name: "Dining room",
+    }
+
+    let context: Partial<ResolverContext>
+
+    beforeEach(() => {
+      context = {
+        deleteCollectionLoader: jest
+          .fn()
+          .mockResolvedValue(mockGravityResponse),
+      }
+    })
+
+    it("passes correct args to Gravity", async () => {
+      await runAuthenticatedQuery(mutation, context)
+
+      expect(context.deleteCollectionLoader as jest.Mock).toHaveBeenCalledWith(
+        "123-abc"
+      )
+    })
+
+    it("returns success response", async () => {
+      const result = await runAuthenticatedQuery(mutation, context)
+
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "deleteCollection": Object {
+            "responseOrError": Object {
+              "collection": Object {
+                "internalID": "123-abc",
+                "name": "Dining room",
+              },
+            },
+          },
+        }
+      `)
+    })
+  })
+
+  it("returns failure when something went wrong", async () => {
+    const message = `https://stagingapi.artsy.net/api/v1/collection - {"error":"Collection Not Found"}`
+    const error = new Error(message)
+    const context = {
+      deleteCollectionLoader: jest.fn().mockRejectedValue(error),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "deleteCollection": Object {
+          "responseOrError": Object {
+            "mutationError": Object {
+              "message": "Collection Not Found",
+            },
+          },
+        },
+      }
+    `)
+  })
+})

--- a/src/schema/v2/me/deleteCollectionMutation.ts
+++ b/src/schema/v2/me/deleteCollectionMutation.ts
@@ -1,0 +1,87 @@
+import {
+  GraphQLObjectType,
+  GraphQLUnionType,
+  GraphQLNonNull,
+  GraphQLString,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { CollectionType } from "./collection"
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DeleteCollectionSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    collection: {
+      type: CollectionType,
+      resolve: async (response) => {
+        return response
+      },
+    },
+  }),
+})
+
+const ErrorType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DeleteCollectionFailure",
+  isTypeOf: (data) => {
+    return data._type === "GravityMutationError"
+  },
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => (typeof err.message === "object" ? err.message : err),
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "DeleteCollectionResponseOrError",
+  types: [SuccessType, ErrorType],
+})
+
+interface InputProps {
+  id: string
+}
+
+export const deleteCollectionMutation = mutationWithClientMutationId<
+  InputProps,
+  any,
+  ResolverContext
+>({
+  name: "deleteCollection",
+  description: "Delete a collection",
+  inputFields: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+  },
+  outputFields: {
+    responseOrError: {
+      type: ResponseOrErrorType,
+      description: "On success: the deleted collection",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (args, context) => {
+    if (!context.deleteCollectionLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const response = await context.deleteCollectionLoader(args.id)
+
+      return response
+    } catch (error) {
+      console.log(error)
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -36,6 +36,7 @@ import {
 import { City } from "./city"
 import { createAccountRequestMutation } from "./createAccountRequestMutation"
 import { createCollectionMutation } from "./me/createCollectionMutation"
+import { deleteCollectionMutation } from "./me/deleteCollectionMutation"
 // import Collection from "./collection"
 import { CreditCard } from "./credit_card"
 import { DeleteArtworkImageMutation } from "./deleteArtworkImageMutation"
@@ -335,6 +336,7 @@ export default new GraphQLSchema({
       createUserInterestForUser: createUserInterestForUser,
       deleteArtworkImage: DeleteArtworkImageMutation,
       deleteBankAccount: deleteBankAccountMutation,
+      deleteCollection: deleteCollectionMutation,
       deleteConversation: deleteConversationMutation,
       deleteCreditCard: deleteCreditCardMutation,
       deleteFeature: DeleteFeatureMutation,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-4530

Adds a mutation to delete the current user's collection by id.

### Mutation

```graphql
mutation DeleteCollection {
  deleteCollection(input: { id: "ee941f42-9d1e-41e2-ad47-6f5b53315fc9" }) {
    responseOrError {
      ... on DeleteCollectionSuccess {
        collection {
          internalID
          name
        }
      }
      ... on DeleteCollectionFailure {
        mutationError {
          statusCode
          message
        }
      }
    }
  }
}
```

### Success Response

```json
{
  "data": {
    "deleteCollection": {
      "responseOrError": {
        "collection": {
          "internalID": "dc24d286-4621-4613-bb63-c709e97ee789",
          "name": "Delete me"
        }
      }
    }
  }
}
```

### Error Response 

If there is a mismatch between the collection owner and the user associated with the current access token

```json
{
 "data": {
    "deleteCollection": {
      "responseOrError": {
        "mutationError": {
          "message": "Collection Not Found"
        }
      }
    }
  }
}
```