### PR TITLE
fix: Pass includeAll arg correctly to artwork figures resolver

### DIFF
--- a/src/schema/v2/artwork/__tests__/utilities.test.ts
+++ b/src/schema/v2/artwork/__tests__/utilities.test.ts
@@ -158,18 +158,21 @@ describe("isTooBig", () => {
 
 describe("getFigures", () => {
   it("returns an array of images", () => {
-    const data = getFigures({
-      images: [
-        {
-          image_url: "foo",
-        },
-        {
-          image_url: "bar",
-        },
-      ],
-      external_video_id: null,
-      set_video_as_cover: null,
-    })
+    const data = getFigures(
+      {
+        images: [
+          {
+            image_url: "foo",
+          },
+          {
+            image_url: "bar",
+          },
+        ],
+        external_video_id: null,
+        set_video_as_cover: null,
+      },
+      {}
+    )
 
     expect(data).toEqual([
       { image_url: "foo", type: "Image" },
@@ -178,18 +181,21 @@ describe("getFigures", () => {
   })
 
   it("returns images with video appended at end by default", () => {
-    const data = getFigures({
-      images: [
-        {
-          image_url: "foo",
-        },
-        {
-          image_url: "bar",
-        },
-      ],
-      external_video_id: "video-id?id=foo&width=200&height=300",
-      set_video_as_cover: null,
-    })
+    const data = getFigures(
+      {
+        images: [
+          {
+            image_url: "foo",
+          },
+          {
+            image_url: "bar",
+          },
+        ],
+        external_video_id: "video-id?id=foo&width=200&height=300",
+        set_video_as_cover: null,
+      },
+      {}
+    )
 
     expect(data).toEqual([
       { image_url: "foo", type: "Image" },
@@ -204,18 +210,21 @@ describe("getFigures", () => {
   })
 
   it("returns a video at the front with images at the end if set_video_as_cover=true", () => {
-    const data = getFigures({
-      images: [
-        {
-          image_url: "foo",
-        },
-        {
-          image_url: "bar",
-        },
-      ],
-      external_video_id: "video-id?id=foo&width=200&height=300",
-      set_video_as_cover: true,
-    })
+    const data = getFigures(
+      {
+        images: [
+          {
+            image_url: "foo",
+          },
+          {
+            image_url: "bar",
+          },
+        ],
+        external_video_id: "video-id?id=foo&width=200&height=300",
+        set_video_as_cover: true,
+      },
+      {}
+    )
 
     expect(data).toEqual([
       {

--- a/src/schema/v2/artwork/utilities.ts
+++ b/src/schema/v2/artwork/utilities.ts
@@ -74,12 +74,10 @@ export const embed = (website, { width, height, autoplay }) => {
   }
 }
 
-export const getFigures = ({
-  images,
-  external_video_id,
-  set_video_as_cover,
-  includeAll = false,
-}) => {
+export const getFigures = (
+  { images, external_video_id, set_video_as_cover },
+  { includeAll = false }
+) => {
   const _images = images.map((image) => ({
     ...image,
     type: "Image",


### PR DESCRIPTION
Pass includeAll arg correctly to artwork figures resolver
