### PR TITLE
feat(FX-4574): add markNotificationsAsSeen mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11269,6 +11269,9 @@ type Me implements Node {
   # A count of unread notifications.
   unreadNotificationsCount: Int!
 
+  # A count of unseen notifications.
+  unseenNotificationsCount: Int!
+
   # A list of lots a user is watching.
   watchedLotConnection(
     after: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7646,11 +7646,6 @@ type CurrentEvent {
 # Date in YYYY-MM-DD format
 scalar Date
 
-# A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the
-# `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO
-# 8601 standard for representation of dates and times using the Gregorian calendar.
-scalar DateTime
-
 type DaySchedule {
   dayOfWeek: String
   endTime: Int
@@ -10751,7 +10746,9 @@ type MarkNotificationsAsSeenFailure {
 
 input MarkNotificationsAsSeenInput {
   clientMutationId: String
-  until: DateTime!
+
+  # Until what point of time notifications were seen. ISO8601 standard-formatted string.
+  until: String!
 }
 
 type MarkNotificationsAsSeenPayload {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7646,6 +7646,11 @@ type CurrentEvent {
 # Date in YYYY-MM-DD format
 scalar Date
 
+# A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the
+# `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO
+# 8601 standard for representation of dates and times using the Gregorian calendar.
+scalar DateTime
+
 type DaySchedule {
   dayOfWeek: String
   endTime: Int
@@ -10740,6 +10745,28 @@ type MarkNotificationAsReadSuccess {
   success: Boolean
 }
 
+type MarkNotificationsAsSeenFailure {
+  mutationError: GravityMutationError
+}
+
+input MarkNotificationsAsSeenInput {
+  clientMutationId: String
+  until: DateTime!
+}
+
+type MarkNotificationsAsSeenPayload {
+  clientMutationId: String
+  responseOrError: MarkNotificationsAsSeenResponseOrError
+}
+
+union MarkNotificationsAsSeenResponseOrError =
+    MarkNotificationsAsSeenFailure
+  | MarkNotificationsAsSeenSuccess
+
+type MarkNotificationsAsSeenSuccess {
+  success: Boolean
+}
+
 union Match =
     Article
   | Artist
@@ -11773,6 +11800,11 @@ type Mutation {
     input: MarkNotificationAsReadInput!
   ): MarkNotificationAsReadPayload
 
+  # Mark notifications as seen
+  markNotificationsAsSeen(
+    input: MarkNotificationsAsSeenInput!
+  ): MarkNotificationsAsSeenPayload
+
   # Merge multiple artist records in order to deduplicate artists
   mergeArtists(input: MergeArtistsMutationInput!): MergeArtistsMutationPayload
 
@@ -12239,6 +12271,11 @@ type NotificationCounts {
     label: String
   ): FormattedNumber
   unread(
+    # Returns a `String` when format is specified. e.g.`'0,0.0000''`
+    format: String
+    label: String
+  ): FormattedNumber
+  unseen(
     # Returns a `String` when format is specified. e.g.`'0,0.0000''`
     format: String
     label: String

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "graphql-middleware": "1.2.6",
     "graphql-parse-resolve-info": "^4.12.3",
     "graphql-relay": "0.5.4",
+    "graphql-scalars": "^1.20.1",
     "graphql-tools": "4.0.5",
     "graphql-type-json": "0.1.4",
     "graphql-upload": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "graphql-middleware": "1.2.6",
     "graphql-parse-resolve-info": "^4.12.3",
     "graphql-relay": "0.5.4",
-    "graphql-scalars": "^1.20.1",
     "graphql-tools": "4.0.5",
     "graphql-type-json": "0.1.4",
     "graphql-upload": "^13.0.0",

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -346,6 +346,11 @@ export default (accessToken, userID, opts) => {
       { method: "POST" }
     ),
     lotStandingLoader: gravityLoader("me/lot_standings", { size: 100 }),
+    markNotificationsAsSeenLoader: gravityLoader(
+      "me/notifications/mark_as_seen",
+      {},
+      { method: "PUT" }
+    ),
     matchUsersLoader: gravityLoader("match/users", {}, { headers: true }),
     matchSetsLoader: gravityLoader("match/sets", {}, { headers: true }),
     mergeArtistLoader: gravityLoader("artists/merge", {}, { method: "POST" }),

--- a/src/schema/v2/me/__tests__/index.test.ts
+++ b/src/schema/v2/me/__tests__/index.test.ts
@@ -301,6 +301,42 @@ describe("me/index", () => {
     })
   })
 
+  describe("unseenNotificationsCount", () => {
+    const countQuery = gql`
+      query {
+        me {
+          unseenNotificationsCount
+        }
+      }
+    `
+
+    it("returns the number of unseen notifications", () => {
+      return runAuthenticatedQuery(countQuery, {
+        notificationsFeedLoader: () => Promise.resolve({ total_unseen: 12 }),
+      }).then((data) => {
+        expect(data).toEqual({ me: { unseenNotificationsCount: 12 } })
+      })
+    })
+
+    it("handles an unauthorized request", () => {
+      return runQuery(countQuery, {
+        notificationsFeedLoader: () => Promise.resolve({ total_unseen: null }),
+      }).catch((error) => {
+        expect(error.message).toEqual(
+          "You need to be signed in to perform this action"
+        )
+      })
+    })
+
+    it("handles a null from gravity", () => {
+      return runAuthenticatedQuery(countQuery, {
+        notificationsFeedLoader: () => Promise.resolve({ total_unseen: null }),
+      }).then((data) => {
+        expect(data).toEqual({ me: { unseenNotificationsCount: 0 } })
+      })
+    })
+  })
+
   describe("canRequestEmailConfirmation", () => {
     it("returns whatever boolean is returned at `can_request_email_confirmation` in the Gravity response", async () => {
       const minimalMeLoaderResponse = {

--- a/src/schema/v2/me/__tests__/markNotificationsAsSeenMutation.test.ts
+++ b/src/schema/v2/me/__tests__/markNotificationsAsSeenMutation.test.ts
@@ -2,13 +2,13 @@ import { runAuthenticatedQuery } from "schema/v2/test/utils"
 
 const mutation = `
   mutation {
-    markAllNotificationsAsRead(input: {}) {
+    markNotificationsAsSeen(input: { until: "2023-01-30T11:03:19Z" }) {
       responseOrError {
-        ... on MarkAllNotificationsAsReadSuccess {
+        ... on MarkNotificationsAsSeenSuccess {
           success
         }
 
-        ... on MarkAllNotificationsAsReadFailure {
+        ... on MarkNotificationsAsSeenFailure {
           mutationError {
             message
           }
@@ -18,17 +18,17 @@ const mutation = `
   }
 `
 
-describe("markAllNotificationsAsReadMutation", () => {
-  it("should return success response when all unread notifications are marked as read", async () => {
+describe("markNotificationsAsSeenMutation", () => {
+  it("should return success response", async () => {
     const context = {
-      updateNotificationsLoader: jest.fn().mockResolvedValue(true),
+      markNotificationsAsSeenLoader: jest.fn().mockResolvedValue(true),
     }
 
     const result = await runAuthenticatedQuery(mutation, context)
 
     expect(result).toMatchInlineSnapshot(`
       Object {
-        "markAllNotificationsAsRead": Object {
+        "markNotificationsAsSeen": Object {
           "responseOrError": Object {
             "success": true,
           },
@@ -38,17 +38,17 @@ describe("markAllNotificationsAsReadMutation", () => {
   })
 
   it("should return failure response when something went wrong", async () => {
-    const message = `https://stagingapi.artsy.net/api/v1/me/notifications - {"error":"Something went wrong"}`
+    const message = `https://stagingapi.artsy.net/api/v1/me/notifications/mark_as_seen - {"error":"Something went wrong"}`
     const error = new Error(message)
     const context = {
-      updateNotificationsLoader: jest.fn().mockRejectedValue(error),
+      markNotificationsAsSeenLoader: jest.fn().mockRejectedValue(error),
     }
 
     const result = await runAuthenticatedQuery(mutation, context)
 
     expect(result).toMatchInlineSnapshot(`
       Object {
-        "markAllNotificationsAsRead": Object {
+        "markNotificationsAsSeen": Object {
           "responseOrError": Object {
             "mutationError": Object {
               "message": "Something went wrong",

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -431,6 +431,18 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
         }).then(({ total_unread_count }) => total_unread_count)
       },
     },
+    unseenNotificationsCount: {
+      type: new GraphQLNonNull(GraphQLInt),
+      description: "A count of unseen notifications.",
+      resolve: (_root, options, { notificationsFeedLoader }) => {
+        if (!notificationsFeedLoader)
+          throw new Error("You need to be signed in to perform this action")
+
+        return notificationsFeedLoader(options).then(({ total_unseen }) => {
+          return total_unseen || 0
+        })
+      },
+    },
     watchedLotConnection: WatchedLotConnection,
   },
 })
@@ -460,6 +472,7 @@ const MeField: GraphQLFieldConfig<void, ResolverContext> = {
       "lotsByFollowedArtistsConnection",
       "identityVerification",
       "unreadNotificationsCount",
+      "unseenNotificationsCount",
     ]
     if (includesFieldsOtherThanSelectionSet(info, fieldsNotRequireLoader)) {
       return meLoader()

--- a/src/schema/v2/me/markNotificationsAsSeenMutation.ts
+++ b/src/schema/v2/me/markNotificationsAsSeenMutation.ts
@@ -1,0 +1,79 @@
+import { GraphQLObjectType } from "graphql"
+import { GraphQLUnionType } from "graphql"
+import { GraphQLBoolean } from "graphql"
+import { GraphQLNonNull } from "graphql"
+import { GraphQLDateTime } from "graphql-scalars"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "MarkNotificationsAsSeenSuccess",
+  isTypeOf: (data) => data.success,
+  fields: () => ({
+    success: {
+      type: GraphQLBoolean,
+      resolve: (result) => result.success,
+    },
+  }),
+})
+
+const ErrorType = new GraphQLObjectType<any, ResolverContext>({
+  name: "MarkNotificationsAsSeenFailure",
+  isTypeOf: (data) => {
+    return data._type === "GravityMutationError"
+  },
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => (typeof err.message === "object" ? err.message : err),
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "MarkNotificationsAsSeenResponseOrError",
+  types: [SuccessType, ErrorType],
+})
+
+export const markNotificationsAsSeenMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "MarkNotificationsAsSeen",
+  description: "Mark notifications as seen",
+  inputFields: {
+    until: { type: new GraphQLNonNull(GraphQLDateTime) },
+  },
+  outputFields: {
+    responseOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (args, { markNotificationsAsSeenLoader }) => {
+    if (!markNotificationsAsSeenLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      await markNotificationsAsSeenLoader({ seen_at: args.until })
+
+      return {
+        success: true,
+      }
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/me/markNotificationsAsSeenMutation.ts
+++ b/src/schema/v2/me/markNotificationsAsSeenMutation.ts
@@ -2,7 +2,7 @@ import { GraphQLObjectType } from "graphql"
 import { GraphQLUnionType } from "graphql"
 import { GraphQLBoolean } from "graphql"
 import { GraphQLNonNull } from "graphql"
-import { GraphQLDateTime } from "graphql-scalars"
+import { GraphQLString } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 import {
   formatGravityError,
@@ -47,7 +47,11 @@ export const markNotificationsAsSeenMutation = mutationWithClientMutationId<
   name: "MarkNotificationsAsSeen",
   description: "Mark notifications as seen",
   inputFields: {
-    until: { type: new GraphQLNonNull(GraphQLDateTime) },
+    until: {
+      type: new GraphQLNonNull(GraphQLString),
+      description:
+        "Until what point of time notifications were seen. ISO8601 standard-formatted string.",
+    },
   },
   outputFields: {
     responseOrError: {

--- a/src/schema/v2/notifications/__tests__/index.test.ts
+++ b/src/schema/v2/notifications/__tests__/index.test.ts
@@ -8,6 +8,7 @@ describe("notificationsConnection", () => {
       feed: [notificationFeedItem],
       total: 100,
       total_unread: 10,
+      total_unseen: 10,
     })
   )
 
@@ -23,6 +24,7 @@ describe("notificationsConnection", () => {
           counts {
             total
             unread
+            unseen
           }
           edges {
             node {
@@ -64,6 +66,7 @@ describe("notificationsConnection", () => {
             counts {
               total
               unread
+              unseen
             }
             edges {
               node {
@@ -115,6 +118,7 @@ describe("notificationsConnection", () => {
             feed: [{ ...notificationFeedItem, date: moment() }],
             total: 1,
             total_unread: 1,
+            total_unseen: 1,
           })
         }
         const data = await runAuthenticatedQuery(query, {
@@ -138,6 +142,7 @@ describe("notificationsConnection", () => {
             ],
             total: 1,
             total_unread: 1,
+            total_unseen: 1,
           })
         }
         const data = await runAuthenticatedQuery(query, {
@@ -160,6 +165,7 @@ describe("notificationsConnection", () => {
             ],
             total: 1,
             total_unread: 1,
+            total_unseen: 1,
           })
         }
         const data = await runAuthenticatedQuery(query, {
@@ -239,6 +245,7 @@ const expectedData = {
     counts: {
       total: 100,
       unread: 10,
+      unseen: 10,
     },
     edges: [
       {

--- a/src/schema/v2/notifications/index.ts
+++ b/src/schema/v2/notifications/index.ts
@@ -124,6 +124,7 @@ const NotificationCounts = {
     fields: {
       total: numeral(({ total }) => total),
       unread: numeral(({ unread }) => unread),
+      unseen: numeral(({ unseen }) => unseen),
     },
   }),
   resolve: (data) => data.counts,
@@ -156,7 +157,11 @@ export const NotificationsConnection: GraphQLFieldConfig<
     })
 
     return {
-      counts: { total: body.total, unread: body.total_unread },
+      counts: {
+        total: body.total,
+        unread: body.total_unread,
+        unseen: body.total_unseen,
+      },
       totalCount: body.total,
       pageCursors: createPageCursors({ page, size }, body.total),
       ...connectionFromArraySlice(

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -166,6 +166,7 @@ import { bulkUpdatePartnerArtworksMutation } from "./bulkUpdatePartnerArtworksMu
 import { NotificationsConnection } from "./notifications"
 import { markAllNotificationsAsReadMutation } from "./me/mark_all_notifications_as_read_mutation"
 import { markNotificationAsReadMutation } from "./me/mark_notification_as_read_mutation"
+import { markNotificationsAsSeenMutation } from "./me/markNotificationsAsSeenMutation"
 import updateMessageMutation from "./conversation/updateMessageMutation"
 import deleteConversationMutation from "./conversation/deleteConversationMutation"
 import { updateArtworkMutation } from "./artwork/updateArtworkMutation"
@@ -356,6 +357,7 @@ export default new GraphQLSchema({
       linkAuthentication: linkAuthenticationMutation,
       markAllNotificationsAsRead: markAllNotificationsAsReadMutation,
       markNotificationAsRead: markNotificationAsReadMutation,
+      markNotificationsAsSeen: markNotificationsAsSeenMutation,
       mergeArtists: mergeArtistsMutation,
       myCollectionCreateArtwork: myCollectionCreateArtworkMutation,
       myCollectionDeleteArtwork: myCollectionDeleteArtworkMutation,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5054,13 +5054,6 @@ graphql-relay@0.5.4:
   resolved "https://registry.yarnpkg.com/graphql-relay/-/graphql-relay-0.5.4.tgz#58050cfe16118595f82ab3aabfc974546ce755a8"
   integrity sha1-WAUM/hYRhZX4KrOqv8l0VGznVag=
 
-graphql-scalars@^1.20.1:
-  version "1.20.1"
-  resolved "https://registry.yarnpkg.com/graphql-scalars/-/graphql-scalars-1.20.1.tgz#295817deff224ac0562545858e370447b97e7457"
-  integrity sha512-HCSosMh8l/DVYL3/wCesnZOb+gbiaO/XlZQEIKOkWDJUGBrc15xWAs5TCQVmrycT0tbEInii+J8eoOyMwxx8zg==
-  dependencies:
-    tslib "~2.4.0"
-
 graphql-tools@4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-4.0.5.tgz#d2b41ee0a330bfef833e5cdae7e1f0b0d86b1754"
@@ -9580,11 +9573,6 @@ tslib@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
   integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
-
-tslib@~2.4.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
-  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
 
 tsutils@^3.17.1:
   version "3.17.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5054,6 +5054,13 @@ graphql-relay@0.5.4:
   resolved "https://registry.yarnpkg.com/graphql-relay/-/graphql-relay-0.5.4.tgz#58050cfe16118595f82ab3aabfc974546ce755a8"
   integrity sha1-WAUM/hYRhZX4KrOqv8l0VGznVag=
 
+graphql-scalars@^1.20.1:
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/graphql-scalars/-/graphql-scalars-1.20.1.tgz#295817deff224ac0562545858e370447b97e7457"
+  integrity sha512-HCSosMh8l/DVYL3/wCesnZOb+gbiaO/XlZQEIKOkWDJUGBrc15xWAs5TCQVmrycT0tbEInii+J8eoOyMwxx8zg==
+  dependencies:
+    tslib "~2.4.0"
+
 graphql-tools@4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-4.0.5.tgz#d2b41ee0a330bfef833e5cdae7e1f0b0d86b1754"
@@ -9573,6 +9580,11 @@ tslib@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
   integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
+
+tslib@~2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
+  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
 
 tsutils@^3.17.1:
   version "3.17.1"


### PR DESCRIPTION
[Jira ticket](https://artsyproduct.atlassian.net/browse/FX-4574)

- Adds `unseen` counter to the `notificationsConnection`
- Adds `markNotificationsAsSeen` mutation

# Counter

```graphql
{
	notificationsConnection(first: 1){
		counts {
			unseen
		}
	}
}
```

# Mutation

```graphql
mutation {
	markNotificationsAsSeen(input: { until: "2023-01-30T11:05:19Z"}) {
		responseOrError {
			... on MarkNotificationsAsSeenSuccess {
				success
			}
			
			... on MarkNotificationsAsSeenFailure {
				mutationError {
					message
				}
			}
		}
	}
}
```

# Response

```graphql
{
	"data": {
		"markNotificationsAsSeen": {
			"responseOrError": {
				"success": true
			}
		}
	}
}
```