### PR TITLE
feat: search Artists, Sales, and Shows by term argument

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11235,6 +11235,7 @@ type Me implements Node {
     # Returns sales the user has registered for if true, returns sales the user has not registered for if false.
     registered: Boolean
     sort: SaleSorts
+    term: String
   ): SaleRegistrationConnection
   savedSearch(criteria: SearchCriteriaAttributes, id: ID): SearchCriteria
   savedSearchesConnection(
@@ -13772,6 +13773,7 @@ type Query {
     #
     slugs: [String]
     sort: ArtistSorts
+    term: String
   ): ArtistConnection
 
   # Find an artist series by ID
@@ -14598,6 +14600,7 @@ type Query {
     # Returns sales the user has registered for if true, returns sales the user has not registered for if false.
     registered: Boolean
     sort: SaleSorts
+    term: String
   ): SaleConnection
 
   # Global search
@@ -14640,6 +14643,7 @@ type Query {
     last: Int
     sort: ShowSorts
     status: EventStatus
+    term: String
   ): ShowConnection
 
   # Content for a specific page or view
@@ -18121,6 +18125,7 @@ type Viewer {
     #
     slugs: [String]
     sort: ArtistSorts
+    term: String
   ): ArtistConnection
 
   # An Artwork
@@ -18741,6 +18746,7 @@ type Viewer {
     # Returns sales the user has registered for if true, returns sales the user has not registered for if false.
     registered: Boolean
     sort: SaleSorts
+    term: String
   ): SaleConnection
 
   # Global search
@@ -18783,6 +18789,7 @@ type Viewer {
     last: Int
     sort: ShowSorts
     status: EventStatus
+    term: String
   ): ShowConnection
 
   # Content for a specific page or view

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11235,6 +11235,8 @@ type Me implements Node {
     # Returns sales the user has registered for if true, returns sales the user has not registered for if false.
     registered: Boolean
     sort: SaleSorts
+
+    # If present, will search by term
     term: String
   ): SaleRegistrationConnection
   savedSearch(criteria: SearchCriteriaAttributes, id: ID): SearchCriteria
@@ -13773,6 +13775,8 @@ type Query {
     #
     slugs: [String]
     sort: ArtistSorts
+
+    # If present, will search by term
     term: String
   ): ArtistConnection
 
@@ -14600,6 +14604,8 @@ type Query {
     # Returns sales the user has registered for if true, returns sales the user has not registered for if false.
     registered: Boolean
     sort: SaleSorts
+
+    # If present, will search by term
     term: String
   ): SaleConnection
 
@@ -14643,6 +14649,8 @@ type Query {
     last: Int
     sort: ShowSorts
     status: EventStatus
+
+    # If present, will search by term
     term: String
   ): ShowConnection
 
@@ -18125,6 +18133,8 @@ type Viewer {
     #
     slugs: [String]
     sort: ArtistSorts
+
+    # If present, will search by term
     term: String
   ): ArtistConnection
 
@@ -18746,6 +18756,8 @@ type Viewer {
     # Returns sales the user has registered for if true, returns sales the user has not registered for if false.
     registered: Boolean
     sort: SaleSorts
+
+    # If present, will search by term
     term: String
   ): SaleConnection
 
@@ -18789,6 +18801,8 @@ type Viewer {
     last: Int
     sort: ShowSorts
     status: EventStatus
+
+    # If present, will search by term
     term: String
   ): ShowConnection
 

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -351,8 +351,14 @@ export default (accessToken, userID, opts) => {
       { method: "POST" }
     ),
     lotStandingLoader: gravityLoader("me/lot_standings", { size: 100 }),
-    matchUsersLoader: gravityLoader("match/users", {}, { headers: true }),
+    matchSalesLoader: gravityLoader("match/sales", {}, { headers: true }),
     matchSetsLoader: gravityLoader("match/sets", {}, { headers: true }),
+    matchShowsLoader: gravityLoader(
+      "match/partner_shows",
+      {},
+      { headers: true }
+    ),
+    matchUsersLoader: gravityLoader("match/users", {}, { headers: true }),
     mergeArtistLoader: gravityLoader("artists/merge", {}, { method: "POST" }),
     meBankAccountsLoader: gravityLoader(
       "me/bank_accounts",

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -96,7 +96,6 @@ export default (opts) => {
     incrementsLoader: gravityLoader("increments"),
     inquiryRequestQuestionsLoader: gravityLoader(`inquiry_request_questions`),
     matchArtistsLoader: gravityLoader("match/artists", {}, { headers: true }),
-    matchArtworksLoader: gravityLoader("match/artworks", {}, { headers: true }),
     matchGenesLoader: gravityLoader("match/genes"),
     anonNotificationPreferencesLoader: gravityLoader(
       (authenticationToken) =>

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -95,7 +95,8 @@ export default (opts) => {
     ),
     incrementsLoader: gravityLoader("increments"),
     inquiryRequestQuestionsLoader: gravityLoader(`inquiry_request_questions`),
-    matchArtistsLoader: gravityLoader("match/artists"),
+    matchArtistsLoader: gravityLoader("match/artists", {}, { headers: true }),
+    matchArtworksLoader: gravityLoader("match/artworks", {}, { headers: true }),
     matchGenesLoader: gravityLoader("match/genes"),
     anonNotificationPreferencesLoader: gravityLoader(
       (authenticationToken) =>

--- a/src/schema/v2/artists.ts
+++ b/src/schema/v2/artists.ts
@@ -87,7 +87,10 @@ export const artistsConnection = {
     page: { type: GraphQLInt },
     size: { type: GraphQLInt },
     sort: ArtistSorts,
-    term: { type: GraphQLString },
+    term: {
+      type: GraphQLString,
+      description: "If present, will search by term",
+    },
   }),
   description: "A list of artists",
   resolve: async (

--- a/src/schema/v2/match/__tests__/artist.test.js
+++ b/src/schema/v2/match/__tests__/artist.test.js
@@ -14,14 +14,16 @@ describe("MatchArtist", () => {
       }
     `
     const matchArtistsLoader = () =>
-      Promise.resolve([
-        {
-          id: "han-myung-ok",
-          name: "Han Myung-Ok",
-          birthday: "1958",
-          artworks_count: 12,
-        },
-      ])
+      Promise.resolve({
+        body: [
+          {
+            id: "han-myung-ok",
+            name: "Han Myung-Ok",
+            birthday: "1958",
+            artworks_count: 12,
+          },
+        ],
+      })
 
     return runQuery(query, { matchArtistsLoader }).then((data) => {
       expect(data).toEqual({

--- a/src/schema/v2/match/artist.ts
+++ b/src/schema/v2/match/artist.ts
@@ -29,12 +29,19 @@ const ArtistMatch: GraphQLFieldConfig<void, ResolverContext> = {
       description: "Exclude these MongoDB ids from results",
     },
   },
-  resolve: (_root, { excludeIDs, ..._options }, { matchArtistsLoader }) => {
+  resolve: async (
+    _root,
+    { excludeIDs, ..._options },
+    { matchArtistsLoader }
+  ) => {
     const options: any = {
       exclude_ids: excludeIDs,
       ..._options,
     }
-    return matchArtistsLoader(options)
+
+    const response = await matchArtistsLoader(options)
+
+    return response.body
   },
 }
 

--- a/src/schema/v2/sales.ts
+++ b/src/schema/v2/sales.ts
@@ -97,7 +97,6 @@ export const SalesConnectionField: GraphQLFieldConfig<void, ResolverContext> = {
       paginationArgs
     )
 
-    //TODO: FIX
     if (term) {
       if (!matchSalesLoader)
         throw new Error(

--- a/src/schema/v2/sales.ts
+++ b/src/schema/v2/sales.ts
@@ -70,7 +70,10 @@ export const SalesConnectionField: GraphQLFieldConfig<void, ResolverContext> = {
       defaultValue: undefined,
     },
     sort: SaleSorts,
-    term: { type: GraphQLString },
+    term: {
+      description: "If present, will search by term",
+      type: GraphQLString,
+    },
   }),
   resolve: async (
     _root,
@@ -102,6 +105,7 @@ export const SalesConnectionField: GraphQLFieldConfig<void, ResolverContext> = {
         throw new Error(
           "You need to pass a X-Access-Token header to perform this action"
         )
+
       const gravityArgs: {
         page: number
         size: number

--- a/src/schema/v2/shows.ts
+++ b/src/schema/v2/shows.ts
@@ -5,7 +5,10 @@ import {
   GraphQLString,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
-import { createPageCursors } from "schema/v2/fields/pagination"
+import {
+  createPageCursors,
+  paginationResolver,
+} from "schema/v2/fields/pagination"
 import { ShowsConnection } from "./show"
 import { CursorPageable, pageable } from "relay-cursor-paging"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
@@ -48,9 +51,47 @@ export const Shows: GraphQLFieldConfig<
     status: {
       type: EventStatus.type,
     },
+    term: {
+      type: GraphQLString,
+    },
   }),
-  resolve: async (_root, args, { showsWithHeadersLoader }) => {
+  resolve: async (
+    _root,
+    args,
+    { showsWithHeadersLoader, matchShowsLoader }
+  ) => {
+    const { term } = args
+
     const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+
+    if (term) {
+      if (!matchShowsLoader) {
+        throw new Error(
+          "You need to pass a X-Access-Token header to perform this action"
+        )
+      }
+
+      const gravityArgs: {
+        page: number
+        size: number
+        total_count: boolean
+        term?: string
+        id?: string[]
+      } = { page, size, term, total_count: true }
+
+      const { body, headers } = await matchShowsLoader(gravityArgs)
+
+      const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+      return paginationResolver({
+        args,
+        body,
+        offset,
+        page,
+        size,
+        totalCount,
+      })
+    }
 
     const { body, headers } = await showsWithHeadersLoader({
       total_count: true,

--- a/src/schema/v2/shows.ts
+++ b/src/schema/v2/shows.ts
@@ -52,6 +52,7 @@ export const Shows: GraphQLFieldConfig<
       type: EventStatus.type,
     },
     term: {
+      description: "If present, will search by term",
       type: GraphQLString,
     },
   }),


### PR DESCRIPTION
This PR adds the ability the search by a `term` to `artistsConnection`, `salesConnection`, and `showsConnection`. When a `term` is not provided the query falls through to the connection's default behavior.

This supports the work in `forque` to add a sets editor. 

[PLATFORM-4927] 

[PLATFORM-4927]: https://artsyproduct.atlassian.net/browse/PLATFORM-4927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ