### PR TITLE
feat: allow create and update feature mutations to accept sourceBucket and key

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7130,6 +7130,8 @@ input CreateFeatureMutationInput {
   description: String
   layout: FeatureLayouts
   name: String!
+  sourceBucket: String
+  sourceKey: String
   subheadline: String
 }
 
@@ -16970,13 +16972,15 @@ type UpdateFeatureFailure {
 }
 
 input UpdateFeatureMutationInput {
-  active: Boolean!
+  active: Boolean
   callout: String
   clientMutationId: String
   description: String
   id: String!
   layout: FeatureLayouts
-  name: String!
+  name: String
+  sourceBucket: String
+  sourceKey: String
   subheadline: String
 }
 

--- a/src/schema/v2/Feature/CreateFeatureMutation.ts
+++ b/src/schema/v2/Feature/CreateFeatureMutation.ts
@@ -15,12 +15,25 @@ import {
 import { FeatureLayoutsEnum } from "./FeatureLayoutsEnum"
 
 interface Input {
-  description: string
+  description?: string
   name: string
   active: boolean
-  callout: string
-  subheadline: string
-  layout: string
+  callout?: string
+  subheadline?: string
+  layout?: string
+  sourceBucket?: string
+  sourceKey?: string
+}
+
+interface GravityInput {
+  description?: string
+  name: string
+  active: boolean
+  callout?: string
+  subheadline?: string
+  layout?: string
+  source_bucket?: string
+  source_key?: string
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
@@ -64,6 +77,8 @@ export const CreateFeatureMutation = mutationWithClientMutationId<
     active: { type: new GraphQLNonNull(GraphQLBoolean) },
     callout: { type: GraphQLString },
     subheadline: { type: GraphQLString },
+    sourceBucket: { type: GraphQLString },
+    sourceKey: { type: GraphQLString },
   },
   outputFields: {
     featureOrError: {
@@ -78,8 +93,19 @@ export const CreateFeatureMutation = mutationWithClientMutationId<
       )
     }
 
+    const gravityArgs: GravityInput = {
+      description: args.description,
+      name: args.name,
+      active: args.active,
+      callout: args.callout,
+      subheadline: args.subheadline,
+      layout: args.layout,
+      source_bucket: args.sourceBucket,
+      source_key: args.sourceKey,
+    }
+
     try {
-      return await createFeatureLoader(args)
+      return await createFeatureLoader(gravityArgs)
     } catch (error) {
       const formattedErr = formatGravityError(error)
       if (formattedErr) {

--- a/src/schema/v2/Feature/UpdateFeatureMutation.ts
+++ b/src/schema/v2/Feature/UpdateFeatureMutation.ts
@@ -15,13 +15,26 @@ import {
 import { FeatureLayoutsEnum } from "./FeatureLayoutsEnum"
 
 interface Input {
-  description: string
-  name: string
-  active: boolean
-  callout: string
-  subheadline: string
-  layout: string
+  description?: string
+  name?: string
+  active?: boolean
+  callout?: string
+  subheadline?: string
+  layout?: string
   id: string
+  sourceBucket?: string
+  sourceKey?: string
+}
+
+interface GravityInput {
+  description?: string
+  name?: string
+  active?: boolean
+  callout?: string
+  subheadline?: string
+  layout?: string
+  source_bucket?: string
+  source_key?: string
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
@@ -61,11 +74,13 @@ export const UpdateFeatureMutation = mutationWithClientMutationId<
   inputFields: {
     description: { type: GraphQLString },
     layout: { type: FeatureLayoutsEnum },
-    name: { type: new GraphQLNonNull(GraphQLString) },
-    active: { type: new GraphQLNonNull(GraphQLBoolean) },
+    name: { type: GraphQLString },
+    active: { type: GraphQLBoolean },
     callout: { type: GraphQLString },
     subheadline: { type: GraphQLString },
     id: { type: new GraphQLNonNull(GraphQLString) },
+    sourceBucket: { type: GraphQLString },
+    sourceKey: { type: GraphQLString },
   },
   outputFields: {
     featureOrError: {
@@ -81,10 +96,21 @@ export const UpdateFeatureMutation = mutationWithClientMutationId<
       )
     }
 
-    const { id, ...rest } = args
+    const { id, description, name, active, callout, subheadline, layout } = args
+
+    const gravityArgs: GravityInput = {
+      description,
+      name,
+      active,
+      callout,
+      subheadline,
+      layout,
+      source_bucket: args.sourceBucket,
+      source_key: args.sourceKey,
+    }
 
     try {
-      return await updateFeatureLoader(id, rest)
+      return await updateFeatureLoader(id, gravityArgs)
     } catch (error) {
       const formattedErr = formatGravityError(error)
       if (formattedErr) {

--- a/src/schema/v2/Feature/__tests__/CreateFeatureMutation.test.ts
+++ b/src/schema/v2/Feature/__tests__/CreateFeatureMutation.test.ts
@@ -3,7 +3,14 @@ import { runAuthenticatedQuery } from "schema/v2/test/utils"
 
 const mutation = gql`
   mutation {
-    createFeature(input: { name: "Catty Feature", active: true }) {
+    createFeature(
+      input: {
+        sourceBucket: "catty-bucket"
+        sourceKey: "catty-key"
+        name: "Catty Feature"
+        active: true
+      }
+    ) {
       featureOrError {
         __typename
         ... on CreateFeatureSuccess {
@@ -30,6 +37,8 @@ describe("CreateFeatureMutation", () => {
       name: "Catty Feature",
       active: true,
       id: "feature-id",
+      source_bucket: "catty-bucket",
+      source_key: "catty-key",
     }
 
     const mockCreateFeatureLoader = jest.fn()
@@ -52,6 +61,8 @@ describe("CreateFeatureMutation", () => {
       expect(mockCreateFeatureLoader).toBeCalledWith({
         name: "Catty Feature",
         active: true,
+        source_bucket: "catty-bucket",
+        source_key: "catty-key",
       })
 
       expect(res).toEqual({

--- a/src/schema/v2/Feature/__tests__/UpdateFeatureMutation.test.ts
+++ b/src/schema/v2/Feature/__tests__/UpdateFeatureMutation.test.ts
@@ -4,7 +4,13 @@ import { runAuthenticatedQuery } from "schema/v2/test/utils"
 const mutation = gql`
   mutation {
     updateFeature(
-      input: { name: "Catty Feature", id: "xyz789", active: true }
+      input: {
+        sourceBucket: "catty-bucket"
+        sourceKey: "catty-key"
+        name: "Catty Feature"
+        id: "xyz789"
+        active: true
+      }
     ) {
       featureOrError {
         __typename
@@ -32,6 +38,8 @@ describe("UpdateFeatureMutation", () => {
       id: "xyz789",
       name: "Catty Feature",
       active: true,
+      source_bucket: "catty-bucket",
+      source_key: "catty-key",
     }
 
     const mockUpdateFeatureLoader = jest.fn()
@@ -54,6 +62,8 @@ describe("UpdateFeatureMutation", () => {
       expect(mockUpdateFeatureLoader).toBeCalledWith("xyz789", {
         name: "Catty Feature",
         active: true,
+        source_bucket: "catty-bucket",
+        source_key: "catty-key",
       })
 
       expect(res).toEqual({


### PR DESCRIPTION
Threads through `sourceBucket` and `sourceKey` to the backing endpoints.