### PR TITLE
fix: Match gravity's snake_case for time_zone in show event resolver

### DIFF
--- a/src/schema/v2/__tests__/show_events.test.ts
+++ b/src/schema/v2/__tests__/show_events.test.ts
@@ -3,56 +3,101 @@ import gql from "lib/gql"
 import { ResolverContext } from "types/graphql"
 
 describe("date resolving", () => {
-  const showData = {
-    id: "helwaser-gallery-anton-ginzburg-views",
-    displayable: true,
-    partner: {
-      id: "helwaser-gallery",
-    },
-    events: [
-      {
-        event_type: "Opening Reception",
-        start_at: "2019-03-28T18:00:00+00:00",
-        end_at: "2019-03-28T21:00:00+00:00",
-      },
-    ],
-  }
-
-  const mockLoader = jest.fn(() => Promise.resolve(showData))
-
+  let context: Partial<ResolverContext>
   const query = gql`
     {
       show(id: "helwaser-gallery-anton-ginzburg-views") {
         events {
           startAt
           endAt
+          dateTimeRange
         }
       }
     }
   `
-
-  let context: Partial<ResolverContext>
-
-  beforeEach(() => {
-    context = {
-      showLoader: mockLoader,
-      partnerShowLoader: mockLoader,
-    }
-  })
-
-  it("returns dates with UTC offset", async () => {
-    context.userAgent = "some browser"
-
-    const data = await runQuery(query, context)
-    expect(data).toEqual({
-      show: {
-        events: [
-          {
-            endAt: "2019-03-28T21:00:00+00:00",
-            startAt: "2019-03-28T18:00:00+00:00",
-          },
-        ],
+  describe("when no time zone present on show", () => {
+    const showData = {
+      id: "helwaser-gallery-anton-ginzburg-views",
+      displayable: true,
+      partner: {
+        id: "helwaser-gallery",
       },
+      events: [
+        {
+          event_type: "Opening Reception",
+          start_at: "2019-03-28T18:00:00+00:00",
+          end_at: "2019-03-28T21:00:00+00:00",
+        },
+      ],
+    }
+
+    const mockLoader = jest.fn(() => Promise.resolve(showData))
+
+    beforeEach(() => {
+      context = {
+        showLoader: mockLoader,
+        partnerShowLoader: mockLoader,
+      }
+    })
+
+    it("returns dates with UTC offset", async () => {
+      context.userAgent = "some browser"
+
+      const data = await runQuery(query, context)
+      expect(data).toEqual({
+        show: {
+          events: [
+            {
+              endAt: "2019-03-28T21:00:00+00:00",
+              startAt: "2019-03-28T18:00:00+00:00",
+              dateTimeRange: "Thu, Mar 28, 2019 from 6:00 – 9:00pm UTC",
+            },
+          ],
+        },
+      })
+    })
+  })
+  describe("when time zone present on show", () => {
+    const showData = {
+      id: "helwaser-gallery-anton-ginzburg-views",
+      displayable: true,
+      partner: {
+        id: "helwaser-gallery",
+      },
+      events: [
+        {
+          event_type: "Opening Reception",
+          start_at: "2019-03-28T18:00:00+00:00",
+          end_at: "2019-03-28T21:00:00+00:00",
+          time_zone: "America/New_York",
+        },
+      ],
+    }
+
+    const mockLoader = jest.fn(() => Promise.resolve(showData))
+
+    beforeEach(() => {
+      context = {
+        showLoader: mockLoader,
+        partnerShowLoader: mockLoader,
+      }
+    })
+
+    it("returns dates with correct timezone offset", async () => {
+      context.userAgent = "some browser"
+
+      const data = await runQuery(query, context)
+      expect(data).toEqual({
+        show: {
+          events: [
+            {
+              endAt: "2019-03-28T21:00:00+00:00",
+              startAt: "2019-03-28T18:00:00+00:00",
+              dateTimeRange: "Thu, Mar 28, 2019 from 2:00 – 5:00pm EDT",
+            },
+          ],
+        },
+      })
     })
   })
 })

--- a/src/schema/v2/show_event.ts
+++ b/src/schema/v2/show_event.ts
@@ -24,8 +24,8 @@ const ShowEventType = new GraphQLObjectType<any, ResolverContext>({
     dateTimeRange: {
       type: GraphQLString,
       description: "A formatted description of the dates with hours",
-      resolve: ({ start_at, end_at }, { timezone }, { defaultTimezone }) => {
-        const timezoneString = timezone ? timezone : defaultTimezone
+      resolve: ({ start_at, end_at, time_zone }, { defaultTimezone }) => {
+        const timezoneString = time_zone ? time_zone : defaultTimezone
         return dateTimeRange(start_at, end_at, timezoneString, true)
       },
     },


### PR DESCRIPTION
While investigating a tangential [bug](https://artsyproduct.atlassian.net/browse/PX-5385), came across an issue here where `timezone` on show events was always returning `undefined` from gravity. If timezone is undefined, we fallback to UTC

That is because we are using the wrong attribute name in the resolver, `timezone` vs `time_zone` (the [ShowEvent](https://github.com/artsy/gravity/blob/main/app/models/domain/partner_show_event.rb#L15) model in gravity is using the snake case)

PS youll notice is gravity we use a mix of the different spellings which makes this interface a little more confusing, both [timezone](https://github.com/artsy/gravity/blob/fa87f2b5a51e01bd3777218b468bb45bb5360ce6/app/models/domain/partner_location.rb#L28) and [time_zone](https://github.com/artsy/gravity/blob/main/app/models/domain/partner_show_event.rb#L15)

🐛 Ex of before this change:
<img width="1283" alt="Screen Shot 2023-02-01 at 4 32 41 PM" src="https://user-images.githubusercontent.com/12748344/216391712-912dc595-8a2c-44e2-8784-d296f3bcd05f.png">


Ex after this change:
<img width="1292" alt="Screen Shot 2023-02-01 at 4 32 13 PM" src="https://user-images.githubusercontent.com/12748344/216391640-bbf19437-bee1-40b8-8965-32f1e02038c9.png">


