### PR TITLE
fix: admin notes can be null, because the requester may be unauthorized (PLATFORM-4901)

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17500,7 +17500,7 @@ type User implements Node {
   ): UserAccessiblePropertyConnection
 
   # The admin notes associated with the user
-  adminNotes: [UserAdminNotes]!
+  adminNotes: [UserAdminNotes]
   analytics: AnalyticsUserStats
   cached: Int
   collectorProfile: CollectorProfileType
@@ -17576,7 +17576,7 @@ type User implements Node {
   # The paddle number of the user
   paddleNumber: String
 
-  # The Parnter or Profile access granted to the user
+  # The Partner or Profile access granted to the user
   partnerAccess: [String]!
 
   # The given phone number of the user.
@@ -17588,7 +17588,7 @@ type User implements Node {
   # The price range the collector has selected
   priceRange: String
 
-  # The Parnter or Profile access granted to the user
+  # The Partner or Profile access granted to the user
   profileAccess: [String]!
   purchasedArtworksConnection(
     after: String

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -66,7 +66,7 @@ export const UserAdminNoteType = new GraphQLObjectType<any, ResolverContext>({
 
 export const UserAdminNotesField: GraphQLFieldConfig<any, ResolverContext> = {
   description: "The admin notes associated with the user",
-  type: new GraphQLNonNull(new GraphQLList(UserAdminNoteType)),
+  type: new GraphQLList(UserAdminNoteType),
   resolve: async ({ id }, {}, { userAdminNotesLoader }) => {
     if (!userAdminNotesLoader) {
       throw new Error(
@@ -87,7 +87,7 @@ export const UserAdminNotesField: GraphQLFieldConfig<any, ResolverContext> = {
 }
 
 export const PartnerAccessField: GraphQLFieldConfig<any, ResolverContext> = {
-  description: "The Parnter or Profile access granted to the user",
+  description: "The Partner or Profile access granted to the user",
   type: new GraphQLNonNull(new GraphQLList(GraphQLString)),
   resolve: async ({ id }, {}, { userAccessControlLoader }) => {
     if (!userAccessControlLoader) {
@@ -106,7 +106,7 @@ export const PartnerAccessField: GraphQLFieldConfig<any, ResolverContext> = {
 }
 
 export const ProfileAccessField: GraphQLFieldConfig<any, ResolverContext> = {
-  description: "The Parnter or Profile access granted to the user",
+  description: "The Partner or Profile access granted to the user",
   type: new GraphQLNonNull(new GraphQLList(GraphQLString)),
   resolve: async ({ id }, {}, { userAccessControlLoader }) => {
     if (!userAccessControlLoader) {


### PR DESCRIPTION
Now that access to user data depends on more fine-grained privileges (such as `role_manager` for roles and `customer_support` for account details), certain schema properties may not be accessible to the authenticated administrator. Currently, querying any of these results in the top-level `user` being `null` (confusingly), even though most other properties _are_ accessible.

This PR adjusts the `adminNotes` to anticipate `null`s, which is enough in my tests for role management to function without the `customer_support` privilege. I think it would be even better for clients to avoid querying for inaccessible data (maybe via `@include` directives), but that is left as a separate improvement.

https://artsyproduct.atlassian.net/browse/PLATFORM-4901