### PR TITLE
fix: Return all saved artworks from quiz GRO-1547

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -518,6 +518,7 @@ export default (accessToken, userID, opts) => {
         paramKey: "artworks",
         trackingKey: "is_saved",
         entityIDKeyPath: "_id",
+        batchSize: 10,
       }
     ),
     savedArtworksLoader: gravityLoader(


### PR DESCRIPTION
This PR adds in a `batchSize` of 10 so that saved artwork requests don't send more ids than the endpoint can handle. What we saw prior to this change was that we were sending the 16 artwork ids from the quiz but only getting back accurate liked info on exactly 10 of them.

With this change in place a single Gravity API call to the saved artwork collection turns into 2 and all the liked info comes back accurately. So this solves the bug as outlined in the ticket.

But technically all 16 artwork ids could be sent in a single request - this abstraction is causing us to send 2. So another approach here could be to send a size to gravity based on the number of ids. That type of change would alter the behavior of a few more fields so I'm hesitant to make it:

```
jon@mister-sinister:~/code/metaphysics(jonallured/fix-return-all-saved-artworks-from-quiz)% ag trackedEntityLoaderFactory src/lib/loaders/loaders_with_authentication/gravity.ts
2:import trackedEntityLoaderFactory from "lib/loaders/loaders_with_authentication/tracked_entity"
189:    dislikedArtworkLoader: trackedEntityLoaderFactory(
254:    followedArtistLoader: trackedEntityLoaderFactory(
277:    followedGeneLoader: trackedEntityLoaderFactory(
298:    followedProfileLoader: trackedEntityLoaderFactory(
311:    followedShowLoader: trackedEntityLoaderFactory(
512:    savedArtworkLoader: trackedEntityLoaderFactory(
```

And that change might look something like this:

```diff
-      return dataLoader({ [paramKey]: ids }).then((body) => {
+      return dataLoader({ [paramKey]: ids, size: ids.length }).then((body) => {
```

I'm very open to closing this PR and opening one that does that instead but wanted to start with the most scoped fix first.

https://artsyproduct.atlassian.net/browse/GRO-1547

/cc @artsy/grow-devs