### PR TITLE
feat(artwork lists): support 'saves' and 'default' args

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10975,9 +10975,11 @@ type Me implements Node {
   collectionsConnection(
     after: String
     before: String
+    default: Boolean
     first: Int
     last: Int
     page: Int
+    saves: Boolean
     size: Int
   ): CollectionsConnection
   collectorLevel: Int

--- a/src/schema/v2/me/__tests__/collectionsConnection.test.ts
+++ b/src/schema/v2/me/__tests__/collectionsConnection.test.ts
@@ -5,10 +5,10 @@ import { ResolverContext } from "types/graphql"
 let context: Partial<ResolverContext>
 
 describe("collectionsConnection", () => {
-  let query = gql`
+  const query = gql`
     query {
       me {
-        collectionsConnection(first: 1) {
+        collectionsConnection(first: 1, saves: true) {
           edges {
             node {
               internalID
@@ -51,6 +51,7 @@ describe("collectionsConnection", () => {
     expect(context.collectionsLoader as jest.Mock).toHaveBeenCalledWith({
       user_id: "user-42",
       private: true,
+      saves: true,
       offset: 0,
       size: 1,
       total_count: true,
@@ -81,7 +82,7 @@ describe("collectionsConnection", () => {
 })
 
 describe("collectionsConnection with artworksConnection", () => {
-  let query = gql`
+  const query = gql`
     query {
       me {
         collectionsConnection(first: 1) {

--- a/src/schema/v2/me/collectionsConnection.ts
+++ b/src/schema/v2/me/collectionsConnection.ts
@@ -5,7 +5,7 @@ import {
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { CollectionType } from "./collection"
 import { pageable } from "relay-cursor-paging"
-import { GraphQLFieldConfig, GraphQLInt } from "graphql"
+import { GraphQLBoolean, GraphQLFieldConfig, GraphQLInt } from "graphql"
 import { ResolverContext } from "types/graphql"
 
 export const CollectionsConnectionType = connectionWithCursorInfo({
@@ -18,6 +18,8 @@ export const CollectionsConnection: GraphQLFieldConfig<any, ResolverContext> = {
   args: pageable({
     page: { type: GraphQLInt },
     size: { type: GraphQLInt },
+    default: { type: GraphQLBoolean },
+    saves: { type: GraphQLBoolean },
   }),
   resolve: async (parent, args, context, _info) => {
     const { id: meID } = parent
@@ -25,9 +27,13 @@ export const CollectionsConnection: GraphQLFieldConfig<any, ResolverContext> = {
     if (!collectionsLoader) return null
 
     const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+    const { default: default_, saves } = args // 'default' is a reserved word in JS
+
     const { body, headers } = await collectionsLoader({
       user_id: meID,
       private: true,
+      default: default_,
+      saves,
       size,
       offset,
       total_count: true,

--- a/src/schema/v2/me/collectionsConnection.ts
+++ b/src/schema/v2/me/collectionsConnection.ts
@@ -27,13 +27,12 @@ export const CollectionsConnection: GraphQLFieldConfig<any, ResolverContext> = {
     if (!collectionsLoader) return null
 
     const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
-    const { default: default_, saves } = args // 'default' is a reserved word in JS
 
     const { body, headers } = await collectionsLoader({
       user_id: meID,
       private: true,
-      default: default_,
-      saves,
+      default: args.default,
+      saves: args.saves,
       size,
       offset,
       total_count: true,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-4596

Adds support for `default` and `saves` fields, which are already support at the upstream Gravity endpoint, e.g.:

```graphql
{
  me {
    defaultSaves: collection(id: "saved-artwork") {
      name
      artworksCount
    }

    #                                                👇🏽              👇🏽 
    artworkLists: collectionsConnection(first: 10, default: false, saves: true) {
      edges {
        node {
          name
          artworksCount
        }
      }
    }
  }
}
```

This would return every collection that is a user-defined saves collection, but not the default saved-artworks collection:

```json
{
  "data": {
    "me": {
      "defaultSaves": {
        "name": "Saved Artwork",
        "artworksCount": 19
      },
      "artworkLists": {
        "edges": [
          {
            "node": {
              "name": "For the kitchen",
              "artworksCount": 3
            }
          },
          {
            "node": {
              "name": "For the living room",
              "artworksCount": 7
            }
          }
        ]
      }
    }
  }
}
```