### PR TITLE
chore: Update exchange schema with artwork details

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3844,6 +3844,7 @@ type CommerceBuyOrder implements CommerceOrder {
     thousand: String = ","
   ): String
   artsyTotalCents: Int
+  artworkDetails: String
   availablePaymentMethods: [CommercePaymentMethodEnum!]!
   bankAccountId: String
   buyer: CommerceOrderPartyUnion!
@@ -4573,6 +4574,7 @@ type CommerceOfferOrder implements CommerceOrder {
     thousand: String = ","
   ): String
   artsyTotalCents: Int
+  artworkDetails: String
   availablePaymentMethods: [CommercePaymentMethodEnum!]!
   awaitingResponseFrom: CommerceOrderParticipantEnum
   bankAccountId: String
@@ -4810,6 +4812,7 @@ interface CommerceOrder {
     thousand: String = ","
   ): String
   artsyTotalCents: Int
+  artworkDetails: String
   availablePaymentMethods: [CommercePaymentMethodEnum!]!
   bankAccountId: String
   buyer: CommerceOrderPartyUnion!

--- a/src/data/exchange.graphql
+++ b/src/data/exchange.graphql
@@ -94,6 +94,7 @@ type BuyOrder implements Order {
   artsyCollectsTaxes: Boolean
   artsyRemitsTaxes: Boolean
   artsyTotalCents: Int
+  artworkDetails: String
   availablePaymentMethods: [PaymentMethodEnum!]!
   bankAccountId: String
   buyer: OrderPartyUnion!
@@ -1095,6 +1096,7 @@ type OfferOrder implements Order {
   artsyCollectsTaxes: Boolean
   artsyRemitsTaxes: Boolean
   artsyTotalCents: Int
+  artworkDetails: String
   availablePaymentMethods: [PaymentMethodEnum!]!
   awaitingResponseFrom: OrderParticipantEnum
   bankAccountId: String
@@ -1213,6 +1215,7 @@ interface Order {
   artsyCollectsTaxes: Boolean
   artsyRemitsTaxes: Boolean
   artsyTotalCents: Int
+  artworkDetails: String
   availablePaymentMethods: [PaymentMethodEnum!]!
   bankAccountId: String
   buyer: OrderPartyUnion!
@@ -1450,7 +1453,10 @@ enum OrderModeEnum {
 """
 Represents either a resolved Order or a potential failure
 """
-union OrderOrFailureUnion = OrderRequiresAction | OrderWithMutationFailure | OrderWithMutationSuccess
+union OrderOrFailureUnion =
+    OrderRequiresAction
+  | OrderWithMutationFailure
+  | OrderWithMutationSuccess
 
 enum OrderParticipantEnum {
   """


### PR DESCRIPTION
#### Description 

This PR updates Exchange schema to provide `artworkDetails` of an order for private sales.