### PR TITLE
feat(artwork lists): add sort option to collectionsConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3616,6 +3616,11 @@ type CollectionsEdge {
   node: Collection
 }
 
+enum CollectionSorts {
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+}
+
 type CollectorProfileArtists {
   name: String
 }
@@ -10990,6 +10995,7 @@ type Me implements Node {
     page: Int
     saves: Boolean
     size: Int
+    sort: CollectionSorts
   ): CollectionsConnection
   collectorLevel: Int
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3566,7 +3566,7 @@ type Collection {
     before: String
     first: Int
     last: Int
-    sort: CollectionSorts
+    sort: CollectionArtworkSorts
   ): ArtworkConnection
 
   # Number of artworks associated with this collection.
@@ -3589,6 +3589,13 @@ type Collection {
   saves: Boolean!
 }
 
+enum CollectionArtworkSorts {
+  POSITION_ASC
+  POSITION_DESC
+  SAVED_AT_ASC
+  SAVED_AT_DESC
+}
+
 # A connection to a list of items.
 type CollectionsConnection {
   # A list of edges.
@@ -3607,13 +3614,6 @@ type CollectionsEdge {
 
   # The item at the end of the edge
   node: Collection
-}
-
-enum CollectionSorts {
-  POSITION_ASC
-  POSITION_DESC
-  SAVED_AT_ASC
-  SAVED_AT_DESC
 }
 
 type CollectorProfileArtists {
@@ -9376,7 +9376,7 @@ type FollowsAndSaves {
     page: Int
     private: Boolean = false
     size: Int
-    sort: CollectionSorts
+    sort: CollectionArtworkSorts
   ): SavedArtworksConnection
 
   # A list of published artworks by followed artists (grouped by date and artists).

--- a/src/schema/v2/me/__tests__/collectionsConnection.test.ts
+++ b/src/schema/v2/me/__tests__/collectionsConnection.test.ts
@@ -8,7 +8,7 @@ describe("collectionsConnection", () => {
   const query = gql`
     query {
       me {
-        collectionsConnection(first: 1, saves: true) {
+        collectionsConnection(first: 1, saves: true, sort: CREATED_AT_DESC) {
           edges {
             node {
               internalID
@@ -52,6 +52,7 @@ describe("collectionsConnection", () => {
       user_id: "user-42",
       private: true,
       saves: true,
+      sort: "-created_at",
       offset: 0,
       size: 1,
       total_count: true,

--- a/src/schema/v2/me/collection.ts
+++ b/src/schema/v2/me/collection.ts
@@ -15,7 +15,7 @@ import { ResolverContext } from "types/graphql"
 import { artworkConnection } from "../artwork"
 import { paginationResolver } from "../fields/pagination"
 import { InternalIDFields } from "../object_identification"
-import CollectionSorts from "../sorts/collection_sorts"
+import CollectionArtworkSorts from "../sorts/collection_sorts"
 
 export const CollectionType = new GraphQLObjectType<any, ResolverContext>({
   name: "Collection",
@@ -27,8 +27,9 @@ export const CollectionType = new GraphQLObjectType<any, ResolverContext>({
       args: {
         ...pageable({
           sort: {
-            type: CollectionSorts,
-            defaultValue: CollectionSorts.getValue("SAVED_AT_DESC")!.value,
+            type: CollectionArtworkSorts,
+            defaultValue: CollectionArtworkSorts.getValue("SAVED_AT_DESC")!
+              .value,
           },
         }),
       },

--- a/src/schema/v2/me/collectionsConnection.ts
+++ b/src/schema/v2/me/collectionsConnection.ts
@@ -5,13 +5,30 @@ import {
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { CollectionType } from "./collection"
 import { pageable } from "relay-cursor-paging"
-import { GraphQLBoolean, GraphQLFieldConfig, GraphQLInt } from "graphql"
+import {
+  GraphQLBoolean,
+  GraphQLEnumType,
+  GraphQLFieldConfig,
+  GraphQLInt,
+} from "graphql"
 import { ResolverContext } from "types/graphql"
 
 export const CollectionsConnectionType = connectionWithCursorInfo({
   name: "Collections",
   nodeType: CollectionType,
 }).connectionType
+
+const CollectionSorts = new GraphQLEnumType({
+  name: "CollectionSorts",
+  values: {
+    CREATED_AT_ASC: {
+      value: "created_at",
+    },
+    CREATED_AT_DESC: {
+      value: "-created_at",
+    },
+  },
+})
 
 export const CollectionsConnection: GraphQLFieldConfig<any, ResolverContext> = {
   type: CollectionsConnectionType,
@@ -20,6 +37,7 @@ export const CollectionsConnection: GraphQLFieldConfig<any, ResolverContext> = {
     size: { type: GraphQLInt },
     default: { type: GraphQLBoolean },
     saves: { type: GraphQLBoolean },
+    sort: { type: CollectionSorts },
   }),
   resolve: async (parent, args, context, _info) => {
     const { id: meID } = parent
@@ -33,6 +51,7 @@ export const CollectionsConnection: GraphQLFieldConfig<any, ResolverContext> = {
       private: true,
       default: args.default,
       saves: args.saves,
+      sort: args.sort,
       size,
       offset,
       total_count: true,

--- a/src/schema/v2/me/savedArtworks.ts
+++ b/src/schema/v2/me/savedArtworks.ts
@@ -12,7 +12,7 @@ import {
 } from "../fields/pagination"
 import { ArtworkType } from "../artwork"
 import { pageable } from "relay-cursor-paging"
-import CollectionSorts from "../sorts/collection_sorts"
+import CollectionArtworkSorts from "../sorts/collection_sorts"
 import {
   CatchCollectionNotFoundException,
   convertConnectionArgsToGravityArgs,
@@ -47,7 +47,7 @@ export const SavedArtworks: GraphQLFieldConfig<any, ResolverContext> = {
       defaultValue: false,
     },
     sort: {
-      type: CollectionSorts,
+      type: CollectionArtworkSorts,
       defaultValue: "-position",
     },
     page: { type: GraphQLInt },
@@ -74,7 +74,14 @@ export const SavedArtworks: GraphQLFieldConfig<any, ResolverContext> = {
 
       const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 
-      return paginationResolver({ totalCount, offset, page, size, body, args })
+      return paginationResolver({
+        totalCount,
+        offset,
+        page,
+        size,
+        body,
+        args,
+      })
     } catch (error) {
       return CatchCollectionNotFoundException(error)
     }

--- a/src/schema/v2/sorts/collection_sorts.ts
+++ b/src/schema/v2/sorts/collection_sorts.ts
@@ -1,7 +1,7 @@
 import { GraphQLEnumType } from "graphql"
 
-const CollectionSorts = new GraphQLEnumType({
-  name: "CollectionSorts",
+const CollectionArtworkSorts = new GraphQLEnumType({
+  name: "CollectionArtworkSorts",
   values: {
     POSITION_ASC: {
       value: "position",
@@ -18,4 +18,4 @@ const CollectionSorts = new GraphQLEnumType({
   },
 })
 
-export default CollectionSorts
+export default CollectionArtworkSorts


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-4598

(And follow-up to https://github.com/artsy/gravity/pull/16058)

Supports a new sort param on collectionsConnection, e.g. 

```graphql
{
  me {
    #                                 👇🏽      👇🏽
    collectionsConnection(first: 10, sort: CREATED_AT_DESC) {
      edges {
        node {
          internalID
          name
        }
      }
    }
  }
}
```

Note: before introducing `CollectionSorts` I wanted to rename the already-existing `CollectionSorts` to the more apt `CollectionArtworkSorts`. I think this is a non-breaking change at least in terms of the _data_ being passed around. Though I'm not sure if any Relay compilers in other projects might complain about the types having changed names, before this schema update makes the rounds.

