### PR TITLE
feat: skip InquiryRequest creation for in_review offers

### DIFF
--- a/src/lib/stitching/exchange/__tests__/stitching.test.ts
+++ b/src/lib/stitching/exchange/__tests__/stitching.test.ts
@@ -515,6 +515,56 @@ describe("submitOfferOrderWithConversation", () => {
     expect(context.submitArtworkInquiryRequestLoader).not.toHaveBeenCalled()
   })
 
+  it("does not call submitArtworkInquiryRequestLoader if order is in_review", async () => {
+    const { resolvers } = await getExchangeStitchedSchema()
+    const resolver = resolvers.Mutation.submitOfferOrderWithConversation.resolve
+    const args = {
+      input: {
+        offerId: "offer-id",
+      },
+    }
+    const order = {
+      orderOrError: {
+        order: {
+          state: "IN_REVIEW",
+          source: "artwork_page",
+          internalID: "order-id",
+          myLastOffer: {
+            note: "test note",
+          },
+          lineItems: {
+            edges: [
+              {
+                node: {
+                  artworkId: "artwork-id",
+                },
+              },
+            ],
+          },
+        },
+      },
+    }
+    mergeInfo.delegateToSchema.mockResolvedValue(order)
+
+    const result = await resolver({}, args, context, { mergeInfo })
+
+    expect(mergeInfo.delegateToSchema).toHaveBeenCalledWith({
+      args: {
+        input: {
+          offerId: "offer-id",
+        },
+      },
+      fieldName: "commerceSubmitOrderWithOffer",
+      operation: "mutation",
+      schema: expect.anything(),
+      context: expect.anything(),
+      info: expect.anything(),
+      transforms: [expect.anything()],
+    })
+    expect(result).toEqual(order)
+    expect(context.submitArtworkInquiryRequestLoader).not.toHaveBeenCalled()
+  })
+
   it("returns an error from exchange", async () => {
     const { resolvers } = await getExchangeStitchedSchema()
     const resolver = resolvers.Mutation.submitOfferOrderWithConversation.resolve

--- a/src/lib/stitching/exchange/v2/stitching.ts
+++ b/src/lib/stitching/exchange/v2/stitching.ts
@@ -812,7 +812,8 @@ export const exchangeStitchingEnvironment = ({
             if (
               orderOrError.error ||
               !orderOrError.order ||
-              orderOrError.order.source === "inquiry"
+              orderOrError.order.source === "inquiry" ||
+              orderOrError.order.state === "IN_REVIEW"
             ) {
               return submitOrderWithOffer
             }


### PR DESCRIPTION
Per the [tech plan](https://www.notion.so/artsy/Prevent-sellers-receiving-conversations-associated-with-in_review-offers-9d43b056735f489788a17ce4357cfc08), we'll skip creating conversations at offer creation time when the associated order is held for review.

For the time being, this will never actually trigger (even if we were to launch putting orders with offers `in_review`) because of the changes in [this PR](https://github.com/artsy/exchange/pull/1464). To summarize, when a buyer-facing client (Force, Exchange) requests the `state` field exposed by Exchange's GraphQL API, we return `submitted` whenever the order is `in_review` to maintain the illusion that the order is not being held for review, and to avoid having to update clients to know how to display `in_review` orders.

We're planning to discuss https://github.com/artsy/exchange/pull/1503/files in platform practice this week, which is one direction that might help us solve this problem. Exposing & requesting separate buyer/seller-facing states would obviate the need to change the actual `state` and we could use that internally as needed.

Jira ticket: https://artsyproduct.atlassian.net/browse/PRO-59