### PR TITLE
fix(artwork lists): collection artworks pagination

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3567,7 +3567,6 @@ type Collection {
     first: Int
     last: Int
     page: Int = 1
-    size: Int = 10
     sort: CollectionArtworkSorts
   ): ArtworkConnection
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3566,6 +3566,8 @@ type Collection {
     before: String
     first: Int
     last: Int
+    page: Int = 1
+    size: Int = 10
     sort: CollectionArtworkSorts
   ): ArtworkConnection
 

--- a/src/schema/v2/me/__tests__/collection.test.ts
+++ b/src/schema/v2/me/__tests__/collection.test.ts
@@ -151,7 +151,7 @@ describe("artworksConnection", () => {
         query {
           me {
             collection(id: "123-abc") {
-              artworksConnection(page: 2, size: 3, sort: SAVED_AT_DESC) {
+              artworksConnection(page: 2, sort: SAVED_AT_DESC) {
                 totalCount
                 edges {
                   node {
@@ -170,7 +170,6 @@ describe("artworksConnection", () => {
         context.collectionArtworksLoader as jest.Mock
       ).toHaveBeenCalledWith(mockGravityCollection.id, {
         page: 2,
-        size: 3,
         sort: "-created_at",
         user_id: "user-42",
         private: true,

--- a/src/schema/v2/me/__tests__/collection.test.ts
+++ b/src/schema/v2/me/__tests__/collection.test.ts
@@ -144,4 +144,38 @@ describe("artworksConnection", () => {
       },
     })
   })
+
+  describe("pagination", () => {
+    it("supports page and size params", async () => {
+      query = gql`
+        query {
+          me {
+            collection(id: "123-abc") {
+              artworksConnection(page: 2, size: 3, sort: SAVED_AT_DESC) {
+                totalCount
+                edges {
+                  node {
+                    slug
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      await runAuthenticatedQuery(query, context)
+
+      expect(
+        context.collectionArtworksLoader as jest.Mock
+      ).toHaveBeenCalledWith(mockGravityCollection.id, {
+        page: 2,
+        size: 3,
+        sort: "-created_at",
+        user_id: "user-42",
+        private: true,
+        total_count: true,
+      })
+    })
+  })
 })

--- a/src/schema/v2/me/collection.ts
+++ b/src/schema/v2/me/collection.ts
@@ -31,7 +31,6 @@ export const CollectionType = new GraphQLObjectType<any, ResolverContext>({
             defaultValue: CollectionArtworkSorts.getValue("SAVED_AT_DESC")!
               .value,
           },
-          size: { type: GraphQLInt, defaultValue: 10 },
           page: { type: GraphQLInt, defaultValue: 1 },
         }),
       },

--- a/src/schema/v2/me/collection.ts
+++ b/src/schema/v2/me/collection.ts
@@ -31,6 +31,8 @@ export const CollectionType = new GraphQLObjectType<any, ResolverContext>({
             defaultValue: CollectionArtworkSorts.getValue("SAVED_AT_DESC")!
               .value,
           },
+          size: { type: GraphQLInt, defaultValue: 10 },
+          page: { type: GraphQLInt, defaultValue: 1 },
         }),
       },
       resolve: async (parent, args, context, _info) => {


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-4593

Adds missing `page` arg for `collection.artworksConnection`

```graphql
{
  me {
    collection(id: "42427e8172616975e8004242") {
                         👇🏽
      artworksConnection(page: 2) {
        edges {
          node {
            slug
          }
        }
      }
    }
  }
}
```