### PR TITLE
fix(collections): avatar bug caused by shared mutable context

### DIFF
--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -1066,6 +1066,28 @@ describe("gravity/stitching", () => {
           info: expect.anything(),
         })
       })
+
+      it("resolves the thumbnailImage field with a copy of the request context", async () => {
+        const { resolvers } = await getGravityStitchedSchema()
+        const { thumbnailImage } = resolvers.MarketingCollection
+
+        const parent = { image_url: "https://www.example.com/image.jpg" }
+        const args = {}
+        const sharedContext = {}
+        const info = { mergeInfo: { delegateToSchema: jest.fn() } }
+
+        thumbnailImage.resolve(parent, args, sharedContext, info)
+
+        expect(sharedContext).not.toHaveProperty("imageData")
+
+        expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith(
+          expect.objectContaining({
+            context: {
+              imageData: { image_url: "https://www.example.com/image.jpg" },
+            },
+          })
+        )
+      })
     })
   })
 })

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -646,13 +646,16 @@ describe("gravity/stitching", () => {
       const { resolvers } = await getGravityStitchedSchema()
       const { artists } = resolvers.ArtistSeries
       const info = { mergeInfo: { delegateToSchema: jest.fn() } }
+      const sharedContext = {}
 
       artists.resolve(
         { artistIDs: ["fakeid"], internalID: "abc123" },
         {},
-        {},
+        sharedContext,
         info
       )
+
+      expect(sharedContext).not.toHaveProperty("currentArtistSeriesInternalID")
 
       expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
         args: { ids: ["fakeid"] },
@@ -766,13 +769,16 @@ describe("gravity/stitching", () => {
       const { resolvers } = await getGravityStitchedSchema()
       const { artistSeriesConnection } = resolvers.Artwork
       const info = { mergeInfo: { delegateToSchema: jest.fn() } }
+      const sharedContext = {}
 
       artistSeriesConnection.resolve(
         { internalID: "fakeid" },
         { first: 5 },
-        {},
+        sharedContext,
         info
       )
+
+      expect(sharedContext).not.toHaveProperty("currentArtworkID")
 
       expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
         args: { artworkID: "fakeid", first: 5 },
@@ -796,13 +802,18 @@ describe("gravity/stitching", () => {
         original_width: 200,
         representativeArtworkID: "artwork-id",
       }
-      image.resolve(artistSeriesData, {}, {}, info)
+      const sharedContext = {}
+
+      image.resolve(artistSeriesData, {}, sharedContext, info)
 
       const imageData = {
         image_url: "cat.jpg",
         original_height: 200,
         original_width: 200,
       }
+
+      expect(sharedContext).not.toHaveProperty("imageData")
+
       expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
         args: expect.anything(),
         operation: "query",
@@ -833,10 +844,13 @@ describe("gravity/stitching", () => {
         Promise.resolve({
           images: [imageData],
         })
-      const context = {
+      const sharedContext = {
         artworkLoader,
       }
-      await image.resolve(artistSeriesData, {}, context, info)
+
+      await image.resolve(artistSeriesData, {}, sharedContext, info)
+
+      expect(sharedContext).not.toHaveProperty("imageData")
 
       expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
         args: expect.anything(),

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -498,24 +498,24 @@ describe("gravity/stitching", () => {
     it("returns Invalid dates if dates are missing", async () => {
       const { resolvers } = await getGravityStitchedSchema()
       const { exhibitionPeriod } = resolvers.ViewingRoom
-      const startAt = moment().add(1, "days").format("MMMM D")
-      const endAt = moment().add(30, "days").format("MMMM D")
-      const startAtYear = moment().add(1, "days").format("YYYY")
-      const endAtAtYear = moment().add(30, "days").format("YYYY")
+      const startAt = moment.utc().add(1, "days").format("MMMM D")
+      const endAt = moment.utc().add(30, "days").format("MMMM D")
+      const startAtYear = moment.utc().add(1, "days").format("YYYY")
+      const endAtAtYear = moment.utc().add(30, "days").format("YYYY")
 
       expect(
         exhibitionPeriod.resolve({
           startAt: null,
           endAt: momentAdd(30, "days"),
         })
-      ).toEqual(`${"Invalid date"} – ${endAt}, ${endAtAtYear}`)
+      ).toEqual(`Invalid date – ${endAt}, ${endAtAtYear}`)
 
       expect(
         exhibitionPeriod.resolve({
           startAt: momentAdd(1, "days"),
           endAt: null,
         })
-      ).toEqual(`${startAt}, ${startAtYear} – ${"Invalid date"}`)
+      ).toEqual(`${startAt}, ${startAtYear} – Invalid date`)
 
       expect(
         exhibitionPeriod.resolve({

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -509,8 +509,9 @@ export const gravityStitchingEnvironment = (
             context,
             info
           ) => {
+            let imageData: unknown
             if (image_url) {
-              context.imageData = {
+              imageData = {
                 image_url,
                 original_width,
                 original_height,
@@ -518,7 +519,7 @@ export const gravityStitchingEnvironment = (
             } else if (representativeArtworkID) {
               const { artworkLoader } = context
               const { images } = await artworkLoader(representativeArtworkID)
-              context.imageData = normalizeImageData(getDefault(images))
+              imageData = normalizeImageData(getDefault(images))
             }
 
             return info.mergeInfo.delegateToSchema({
@@ -526,7 +527,10 @@ export const gravityStitchingEnvironment = (
               schema: localSchema,
               operation: "query",
               fieldName: "_do_not_use_image",
-              context,
+              context: {
+                ...context,
+                imageData,
+              },
               info,
             })
           },
@@ -543,8 +547,6 @@ export const gravityStitchingEnvironment = (
               return []
             }
 
-            context.currentArtistSeriesInternalID = internalID
-
             return info.mergeInfo.delegateToSchema({
               schema: localSchema,
               operation: "query",
@@ -553,7 +555,10 @@ export const gravityStitchingEnvironment = (
                 ids,
                 ...args,
               },
-              context,
+              context: {
+                ...context,
+                currentArtistSeriesInternalID: internalID,
+              },
               info,
             })
           },
@@ -923,7 +928,6 @@ export const gravityStitchingEnvironment = (
             }
             `,
           resolve: ({ internalID: artworkID }, args, context, info) => {
-            context.currentArtworkID = artworkID
             return info.mergeInfo.delegateToSchema({
               schema: gravitySchema,
               operation: "query",
@@ -932,7 +936,10 @@ export const gravityStitchingEnvironment = (
                 artworkID,
                 ...args,
               },
-              context,
+              context: {
+                ...context,
+                currentArtworkID: artworkID,
+              },
               info,
             })
           },

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -299,13 +299,14 @@ export const gravityStitchingEnvironment = (
           }
           `,
           resolve: async ({ image_url }, _args, context, info) => {
-            context.imageData = normalizeImageData(image_url)
-
             return info.mergeInfo.delegateToSchema({
               schema: localSchema,
               operation: "query",
               fieldName: "_do_not_use_image",
-              context,
+              context: {
+                ...context,
+                imageData: normalizeImageData(image_url),
+              },
               info,
             })
           },


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-4543

Fixes one actual, and several potential, bugs by moving away from the pattern of mutating the global shared `context` object for the current request when fulfilling stitched fields.

(I also tried to automate a Danger check to prevent this from happening again in the future, but [hit some blockers](https://artsy.slack.com/archives/CP9P4KR35/p1675978327622389) there.)

Taking for example the [Street Art collection](https://www.artsy.net/collection/street-art)…

## Before

Starting with the recent refactor https://github.com/artsy/force/pull/11715 — which started using `MarketingCollection.thumbnailImage` — this leaky `context` was being inadvertently read from the [Image resolver](https://github.com/artsy/metaphysics/blob/99a12ac1c449379f128e5ad01794f64437cadb7a/src/schema/v2/image/index.ts#L155-L156):

<img width="1736" alt="Screen Shot 2023-02-10 at 12 35 51 AM" src="https://user-images.githubusercontent.com/140521/218010068-fb6de585-a05c-49e7-805c-d9f4ebf90ab1.png">


## After

The `context` is no longer leaky…

<img width="1876" alt="after" src="https://user-images.githubusercontent.com/140521/218005367-54c06f93-d84a-45dd-9b90-6751197f3255.png">

The fix for that ⤴︎ is in https://github.com/artsy/metaphysics/pull/4769/commits/0e83f9c4ece094df93a36e8e4a33436ced97211a

---


## Other fields 

I fixed similar occurrences in https://github.com/artsy/metaphysics/pull/4769/commits/8a19937daf4d350c1a61bd7e89555c2424d22cdc

For good measure I confirmed these other stitched fields via Insomnia…

<img width="2471" alt="Screen Shot 2023-02-10 at 12 29 18 AM" src="https://user-images.githubusercontent.com/140521/218008648-bd731a30-60d5-45ae-a7e2-8009c20a4c60.png">
