### PR TITLE
chore: allow ownerId to be passed in to the update set mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17319,6 +17319,7 @@ input updateOrderedSetMutationInput {
   key: String
   layout: String
   name: String
+  ownerId: String
   ownerType: String
   published: Boolean
 }

--- a/src/schema/v2/OrderedSet/__tests__/updateOrderedSetMutation.test.ts
+++ b/src/schema/v2/OrderedSet/__tests__/updateOrderedSetMutation.test.ts
@@ -12,6 +12,7 @@ const mutation = gql`
         key: "a"
         layout: "default"
         name: "Example set"
+        ownerId: "feature-id"
         ownerType: "Feature"
         published: true
       }
@@ -72,6 +73,7 @@ describe("updateOrderedSetMutation", () => {
         key: "a",
         layout: "default",
         name: "Example set",
+        owner_id: "feature-id",
         owner_type: "Feature",
         published: true,
       })

--- a/src/schema/v2/OrderedSet/updateOrderedSetMutation.ts
+++ b/src/schema/v2/OrderedSet/updateOrderedSetMutation.ts
@@ -37,6 +37,7 @@ interface Input {
   layout: LayoutType
   name: string
   ownerType: OwnerType
+  ownerId: string
   published: boolean
 }
 
@@ -82,6 +83,7 @@ export const updateOrderedSetMutation = mutationWithClientMutationId<
     key: { type: GraphQLString },
     layout: { type: GraphQLString },
     name: { type: GraphQLString },
+    ownerId: { type: GraphQLString },
     ownerType: { type: GraphQLString },
     published: { type: GraphQLBoolean },
   },
@@ -103,6 +105,7 @@ export const updateOrderedSetMutation = mutationWithClientMutationId<
       name,
       ownerType,
       published,
+      ownerId,
     },
     { updateSetLoader }
   ) => {
@@ -120,6 +123,7 @@ export const updateOrderedSetMutation = mutationWithClientMutationId<
         key,
         layout,
         name,
+        owner_id: ownerId,
         owner_type: ownerType,
         published,
       })


### PR DESCRIPTION
I need this to be able to add sets (ie- update their owner) to a Feature. You may need this as well on the sets side (to assign an owner on the set page).