### PR TITLE
chore: resolve a feature when updating a set

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17336,6 +17336,7 @@ union updateOrderedSetResponseOrError =
   | updateOrderedSetSuccess
 
 type updateOrderedSetSuccess {
+  feature: Feature
   set: OrderedSet
 }
 

--- a/src/schema/v2/OrderedSet/updateOrderedSetMutation.ts
+++ b/src/schema/v2/OrderedSet/updateOrderedSetMutation.ts
@@ -12,6 +12,7 @@ import {
   formatGravityError,
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
+import { FeatureType } from "../Feature"
 
 type ItemType =
   | "Artist"
@@ -48,6 +49,13 @@ const SuccessType = new GraphQLObjectType<any, ResolverContext>({
     set: {
       type: OrderedSetType,
       resolve: (orderedSet) => orderedSet,
+    },
+    feature: {
+      type: FeatureType,
+      resolve: ({ owner, owner_type }) => {
+        if (owner_type !== "Feature") return null
+        return owner
+      },
     },
   }),
 })


### PR DESCRIPTION
It's nice to be able to resolve the feature owner (when updating a set), such as re-fetching the sets belonging to that owner!