### PR TITLE
Add mutation to edit an artist

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1414,6 +1414,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   deathday: String
   disablePriceContext: Boolean
   displayLabel: String
+  displayName: String
   duplicates: [Artist]
 
   # Custom-sorted list of shows for an artist, in order of significance.
@@ -1482,6 +1483,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     tagID: String
     width: String
   ): FilterArtworksConnection
+  first: String
 
   # A string showing the total number of works and those for sale
   formattedArtworksCount: String
@@ -1529,6 +1531,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   isPersonalArtist: Boolean
   isPublic: Boolean
   isShareable: Boolean
+  last: String
   location: String
   marketingCollections(
     category: String
@@ -1537,6 +1540,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     slugs: [String!]
   ): [MarketingCollection]
   meta: ArtistMeta
+  middle: String
   name: String
   nationality: String
   partnerArtists(
@@ -12027,6 +12031,9 @@ type Mutation {
     input: UpdateAppSecondFactorInput!
   ): UpdateAppSecondFactorPayload
 
+  # Update the artist
+  updateArtist(input: UpdateArtistMutationInput!): UpdateArtistMutationPayload
+
   # Updates an artwork.
   updateArtwork(
     input: UpdateArtworkMutationInput!
@@ -16867,6 +16874,31 @@ type UpdateAppSecondFactorPayload {
   # A unique identifier for the client performing the mutation.
   clientMutationId: String
   secondFactorOrErrors: AppSecondFactorOrErrorsUnion!
+}
+
+type UpdateArtistFailure {
+  mutationError: GravityMutationError
+}
+
+input UpdateArtistMutationInput {
+  clientMutationId: String
+  displayName: String
+  first: String
+  id: String!
+  last: String
+  middle: String
+}
+
+type UpdateArtistMutationPayload {
+  # On success: the updated artist
+  artistOrError: UpdateArtistResponseOrError
+  clientMutationId: String
+}
+
+union UpdateArtistResponseOrError = UpdateArtistFailure | UpdateArtistSuccess
+
+type UpdateArtistSuccess {
+  artist: Artist
 }
 
 type updateArtworkFailure {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -693,5 +693,10 @@ export default (accessToken, userID, opts) => {
     usersLoader: gravityLoader("users", {}, { headers: true }),
     quizLoader: gravityLoader(`user_art_quiz`, {}, { method: "GET" }),
     updateQuizLoader: gravityLoader(`user_art_quiz`, {}, { method: "PUT" }),
+    updateArtistLoader: gravityLoader(
+      (id) => `artist/${id}`,
+      {},
+      { method: "PUT" }
+    ),
   }
 }

--- a/src/schema/v2/artist/__tests__/updateArtistMutation.test.ts
+++ b/src/schema/v2/artist/__tests__/updateArtistMutation.test.ts
@@ -1,0 +1,85 @@
+import gql from "lib/gql"
+import { HTTPError } from "lib/HTTPError"
+import { runAuthenticatedQuery, runQuery } from "schema/v2/test/utils"
+
+describe("updateArtistMutation", () => {
+  const mutation = gql`
+    mutation {
+      updateArtist(input: { displayName: "Polly Painter", id: "3" }) {
+        artistOrError {
+          __typename
+          ... on UpdateArtistSuccess {
+            artist {
+              displayName
+            }
+          }
+          ... on UpdateArtistFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("calls the expected loader with correctly formatted params", async () => {
+    const mockUpdateArtistLoader = jest.fn(() =>
+      Promise.resolve({
+        id: "foo",
+        display_name: "Polly Painter",
+      })
+    )
+
+    const context = { updateArtistLoader: mockUpdateArtistLoader }
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(mockUpdateArtistLoader).toBeCalledWith("3", {
+      display_name: "Polly Painter",
+    })
+
+    expect(result).toEqual({
+      updateArtist: {
+        artistOrError: {
+          __typename: "UpdateArtistSuccess",
+          artist: {
+            displayName: "Polly Painter",
+          },
+        },
+      },
+    })
+  })
+
+  it("throws error when data loader is missing", async () => {
+    const errorResponse =
+      "You need to pass a X-Access-Token header to perform this action"
+
+    try {
+      await runQuery(mutation)
+      throw new Error("An error was not thrown but was expected.")
+    } catch (error) {
+      // eslint-disable-next-line jest/no-conditional-expect, jest/no-try-expect
+      expect(error.message).toEqual(errorResponse)
+    }
+  })
+
+  it("returns gravity errors", async () => {
+    const context = {
+      updateArtistLoader: () =>
+        Promise.reject(new HTTPError(`Oops`, 500, "Error from API")),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      updateArtist: {
+        artistOrError: {
+          __typename: "UpdateArtistFailure",
+          mutationError: {
+            message: "Error from API",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -651,6 +651,13 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
       meta: Meta,
       nationality: { type: GraphQLString },
       name: { type: GraphQLString },
+      first: { type: GraphQLString },
+      last: { type: GraphQLString },
+      displayName: {
+        type: GraphQLString,
+        resolve: ({ display_name }) => display_name,
+      },
+      middle: { type: GraphQLString },
       partnersConnection: {
         type: PartnerArtistConnection,
         args: pageable({

--- a/src/schema/v2/artist/updateArtistMutation.ts
+++ b/src/schema/v2/artist/updateArtistMutation.ts
@@ -1,0 +1,106 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import { snakeCase } from "lodash"
+import { ArtistType } from "./index"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+
+interface Input {
+  displayName: string
+  first: string
+  id: string
+  last: string
+  middle: string
+}
+
+interface GravityInput {
+  display_name: string
+  first: string
+  id: string
+  last: string
+  middle: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateArtistSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    artist: {
+      type: ArtistType,
+      resolve: (response) => response,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateArtistFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdateArtistResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const updateArtistMutation = mutationWithClientMutationId<
+  Input,
+  any | null,
+  ResolverContext
+>({
+  name: "UpdateArtistMutation",
+  description: "Update the artist",
+  inputFields: {
+    displayName: { type: GraphQLString },
+    first: { type: GraphQLString },
+    id: { type: new GraphQLNonNull(GraphQLString) },
+    last: { type: GraphQLString },
+    middle: { type: GraphQLString },
+  },
+  outputFields: {
+    artistOrError: {
+      type: ResponseOrErrorType,
+      description: "On success: the updated artist",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (args, { updateArtistLoader }) => {
+    if (!updateArtistLoader) {
+      throw new Error(
+        "You need to pass a X-Access-Token header to perform this action"
+      )
+    }
+
+    const updateArtistLoaderPayload = Object.keys(args)
+      .filter((key) => key !== "id")
+      .reduce(
+        (acc, key) => ({ ...acc, [snakeCase(key)]: args[key] }),
+        {} as GravityInput
+      )
+
+    try {
+      return await updateArtistLoader(args.id, updateArtistLoaderPayload)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -86,6 +86,7 @@ import UpdateCollectorProfile from "./me/update_collector_profile"
 import UpdateCollectorProfileWithID from "./CollectorProfile/mutations/updateCollectorProfileWithID"
 import UpdateMyUserProfileMutation from "./me/update_me_mutation"
 import { updateMyPasswordMutation } from "./me/updateMyPasswordMutation"
+import { updateArtistMutation } from "./artist/updateArtistMutation"
 import { updateUserMutation } from "./users/updateUserMutation"
 import { addUserRoleMutation } from "./users/addUserRoleMutation"
 import { createUserAdminNoteMutation } from "./users/createUserAdminNoteMutation"
@@ -396,6 +397,7 @@ export default new GraphQLSchema({
       updateNotificationPreferences: updateNotificationPreferencesMutation,
       updateOrderedSet: updateOrderedSetMutation,
       updateUser: updateUserMutation,
+      updateArtist: updateArtistMutation,
       updateUserSaleProfile: updateUserSaleProfileMutation,
       updateQuiz: updateQuizMutation,
     },


### PR DESCRIPTION
This PR adds a new top-level mutation called `updateArtist`. It's a copy/paste/update job from the other user update mutation I made before on https://github.com/artsy/metaphysics/pull/3918 and https://github.com/artsy/metaphysics/pull/3926. At this point all it supports is managing this list of data about an artist:

* displayName
* first
* id
* last
* middle

And my intention here is to lay down the basics but we'll ultimately be adding a bunch of fields here as we migrate over the artist edit page.