### PR TITLE
feat: add root-level markdown field for use in live previews

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10601,6 +10601,10 @@ type MarkAllNotificationsAsReadSuccess {
   success: Boolean
 }
 
+type MarkdownContent {
+  content(format: Format): String
+}
+
 type MarketingCollection {
   artworksConnection(
     acquireable: Boolean
@@ -14357,6 +14361,7 @@ type Query {
   ): IdentityVerificationConnection
   job(id: ID!): Job!
   jobs: [Job!]!
+  markdown(content: String!): MarkdownContent
   marketingCategories: [MarketingCollectionCategory!]!
 
   # Find a marketing collection by ID or slug
@@ -18597,6 +18602,7 @@ type Viewer {
   ): IdentityVerificationConnection
   job(id: ID!): Job!
   jobs: [Job!]!
+  markdown(content: String!): MarkdownContent
   marketingCollections(
     artistID: String
     category: String

--- a/src/schema/v2/__tests__/markdownContent.test.ts
+++ b/src/schema/v2/__tests__/markdownContent.test.ts
@@ -1,0 +1,41 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery, runQuery } from "schema/v2/test/utils"
+
+describe("markdownContent", () => {
+  const query = gql`
+    {
+      markdown(content: "**cats**") {
+        content(format: HTML)
+      }
+    }
+  `
+
+  it("without a token, errors", async () => {
+    expect.assertions(1)
+    await expect(runQuery(query)).rejects.toThrow(
+      "You need to be signed in to perform this action"
+    )
+  })
+
+  it("with an invalid token, errors", async () => {
+    const meLoader = () => Promise.reject(new Error("Invalid token"))
+    expect.assertions(1)
+    await expect(runAuthenticatedQuery(query, { meLoader })).rejects.toThrow(
+      "You need to be signed in to perform this action"
+    )
+  })
+
+  it("with a valid token w/o the `content_manager` role, errors", async () => {
+    const meLoader = () => Promise.resolve({ roles: [] })
+    expect.assertions(1)
+    await expect(runAuthenticatedQuery(query, { meLoader })).rejects.toThrow(
+      "You need to have the `content_manager` role to perform this action"
+    )
+  })
+
+  it("with the `content_manager` role, returns data", async () => {
+    const meLoader = () => Promise.resolve({ roles: ["content_manager"] })
+    const data = await runAuthenticatedQuery(query, { meLoader })
+    expect(data.markdown.content).toInclude("<strong>cats</strong>")
+  })
+})

--- a/src/schema/v2/markdownContent.ts
+++ b/src/schema/v2/markdownContent.ts
@@ -1,0 +1,41 @@
+import {
+  GraphQLFieldConfig,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import { markdown } from "schema/v2/fields/markdown"
+
+const MarkdownContentType = new GraphQLObjectType<any, ResolverContext>({
+  name: "MarkdownContent",
+  fields: {
+    content: markdown(({ content }) => content),
+  },
+})
+
+class RoleRequiredError extends Error {}
+
+export const MarkdownContent: GraphQLFieldConfig<void, ResolverContext> = {
+  type: MarkdownContentType,
+  args: {
+    content: { type: new GraphQLNonNull(GraphQLString) },
+  },
+  resolve: async (_source, { content }, { meLoader }) => {
+    if (!meLoader)
+      throw new Error("You need to be signed in to perform this action")
+
+    try {
+      const { roles } = await meLoader()
+      if (!roles.includes("content_manager"))
+        throw new RoleRequiredError(
+          "You need to have the `content_manager` role to perform this action"
+        )
+    } catch (err) {
+      if (err instanceof RoleRequiredError) throw err
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    return { content }
+  },
+}

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -187,6 +187,7 @@ import { CreateFeaturedLinkMutation } from "./FeaturedLink/createFeaturedLinkMut
 import { UpdateFeaturedLinkMutation } from "./FeaturedLink/updateFeaturedLinkMutation"
 import { DeleteFeaturedLinkMutation } from "./FeaturedLink/deleteFeaturedLinkMutation"
 import { createUserSaleProfileMutation } from "./users/createUserSaleProfileMutation"
+import { MarkdownContent } from "./markdownContent"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -259,6 +260,7 @@ const rootFields = {
   identityVerificationsConnection,
   job,
   jobs,
+  markdown: MarkdownContent,
   matchArtist: MatchArtist,
   matchConnection: MatchConnection,
   me: Me,


### PR DESCRIPTION
<img width="1088" alt="Screen Shot 2023-02-14 at 12 43 24 PM" src="https://user-images.githubusercontent.com/1457859/218817665-dc5037c5-54ea-44cf-bf6b-1c7f24a4e10f.png">

This is going to be used to generate live previews for entered text in Markdown fields in Forque!