### PR TITLE
Compare order payment method with triple equals

### DIFF
--- a/src/lib/stitching/exchange/v2/stitching.ts
+++ b/src/lib/stitching/exchange/v2/stitching.ts
@@ -817,7 +817,7 @@ export const exchangeStitchingEnvironment = ({
               // is implemented in Exchange.
               // See https://www.notion.so/artsy/2023-02-09-Platform-Practice-Meeting-Notes-87f4cc9987a7436c9c4b207847e318db?pvs=4
               // orderOrError.order.state === "IN_REVIEW"
-              orderOrError.order.paymentMethod == "WIRE_TRANSFER"
+              orderOrError.order.paymentMethod === "WIRE_TRANSFER"
             ) {
               return submitOrderWithOffer
             }


### PR DESCRIPTION
I am trying to understand why a conversation is being created for an order that ends up in the review queue. I realized that we're comparing the payment method with `==` instead of `===`.