### PR TITLE
fix: added missing field that was needed in stitching logic

### DIFF
--- a/src/lib/stitching/exchange/v2/stitching.ts
+++ b/src/lib/stitching/exchange/v2/stitching.ts
@@ -721,6 +721,13 @@ export const exchangeStitchingEnvironment = ({
                         },
                       },
                       {
+                        kind: Kind.FIELD,
+                        name: {
+                          kind: Kind.NAME,
+                          value: "paymentMethod",
+                        },
+                      },
+                      {
                         kind: Kind.INLINE_FRAGMENT,
                         typeCondition: {
                           kind: Kind.NAMED_TYPE,
@@ -808,7 +815,10 @@ export const exchangeStitchingEnvironment = ({
             })
 
             const { orderOrError } = submitOrderWithOffer
-
+            console.log("🐖 🐖 🐖 🐖 🐖 🐖 🐖 🐖 🐖 🐖 🐖 🐖")
+            console.log(orderOrError.order.source)
+            console.log(orderOrError.order.state)
+            console.log(orderOrError.order.paymentMethod)
             if (
               orderOrError.error ||
               !orderOrError.order ||

--- a/src/lib/stitching/exchange/v2/stitching.ts
+++ b/src/lib/stitching/exchange/v2/stitching.ts
@@ -815,10 +815,7 @@ export const exchangeStitchingEnvironment = ({
             })
 
             const { orderOrError } = submitOrderWithOffer
-            console.log("🐖 🐖 🐖 🐖 🐖 🐖 🐖 🐖 🐖 🐖 🐖 🐖")
-            console.log(orderOrError.order.source)
-            console.log(orderOrError.order.state)
-            console.log(orderOrError.order.paymentMethod)
+
             if (
               orderOrError.error ||
               !orderOrError.order ||


### PR DESCRIPTION
When an offer order is submitted, Metaphysics decides whether a Conversation needs to be created for that order. In #4785 we updated this logic, but forgot to request a field from the Exchange schema that is used in the new logic. This PR makes the request for that field.