### PR TITLE
fix(artist): guards against possibly null data

### DIFF
--- a/src/schema/v2/artist/helpers.ts
+++ b/src/schema/v2/artist/helpers.ts
@@ -117,6 +117,9 @@ export const getAuctionRecord = async (artist, auctionLotsLoader) => {
   })
 
   const auctionLot = response._embedded.items[0]
+
+  if (!auctionLot) return null
+
   const { currency, price_realized_cents } = auctionLot
   const price = priceDisplayText(price_realized_cents, currency, "0.0a")
   const year = auctionLot.sale_date.split("-")[0]


### PR DESCRIPTION
For whatever reason it looks like Diffusion sometimes returns bad data — I'm not digging into the root cause here but _someone_ should take a look. Specifically this is able to be reproduced with the artist `robert-mangold`.
