### PR TITLE
feat(me): exposes counts

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11067,6 +11067,7 @@ type Me implements Node {
     toBeReplied: Boolean
     type: ConversationsInputMode = USER
   ): ConversationConnection
+  counts: MeCounts
   createdAt(
     format: String
 
@@ -11399,6 +11400,11 @@ type Me implements Node {
     first: Int
     last: Int
   ): LotConnection
+}
+
+type MeCounts {
+  followedArtists: Int!
+  savedArtworks: Int!
 }
 
 type MergeArtistsFailure {

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -55,7 +55,7 @@ import { NewWorksByInterestingArtists } from "./newWorksByInterestingArtists"
 import { ManagedPartners } from "./partners"
 import { RecentlyViewedArtworks } from "./recently_viewed_artworks"
 import { SaleRegistrationConnection } from "./sale_registrations"
-import { SavedArtworks } from "./savedArtworks"
+import { COLLECTION_ID, SavedArtworks } from "./savedArtworks"
 import { ShowsByFollowedArtists } from "./showsByFollowedArtists"
 import { WatchedLotConnection } from "./watchedLotConnection"
 import { quiz } from "../quiz"
@@ -155,6 +155,46 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
     },
     conversation: Conversation,
     conversationsConnection: Conversations,
+    counts: {
+      type: new GraphQLObjectType<any, ResolverContext>({
+        name: "MeCounts",
+        fields: {
+          followedArtists: {
+            type: new GraphQLNonNull(GraphQLInt),
+            resolve: async (_me, _args, { followedArtistsLoader }) => {
+              if (!followedArtistsLoader) return 0
+
+              const { headers } = await followedArtistsLoader({
+                page: 1,
+                size: 1,
+                total_count: true,
+              })
+
+              return headers["x-total-count"] ?? 0
+            },
+          },
+          savedArtworks: {
+            type: new GraphQLNonNull(GraphQLInt),
+            resolve: async (_me, _args, { collectionArtworksLoader }) => {
+              if (!collectionArtworksLoader) return 0
+
+              const { headers } = await collectionArtworksLoader(
+                COLLECTION_ID,
+                {
+                  page: 1,
+                  private: true,
+                  size: 1,
+                  total_count: true,
+                }
+              )
+
+              return headers["x-total-count"] ?? 0
+            },
+          },
+        },
+      }),
+      resolve: (me) => me,
+    },
     createdAt: date,
     creditCards: CreditCards,
     email: {

--- a/src/schema/v2/me/savedArtworks.ts
+++ b/src/schema/v2/me/savedArtworks.ts
@@ -18,7 +18,7 @@ import {
   convertConnectionArgsToGravityArgs,
 } from "lib/helpers"
 
-const COLLECTION_ID = "saved-artwork"
+export const COLLECTION_ID = "saved-artwork"
 
 export const SavedArtworksConnection = connectionWithCursorInfo({
   name: "SavedArtworks",


### PR DESCRIPTION
We need to be able to update a counts field on follows and saves in order to support progressive onboarding dismissals. Currently you can get these by accessing `totalCount`s on the related connections but we'd have to have identical query params for the optimistic updates to work. This is much simpler.