### PR TITLE
feat(FX-4623): add `isArtworkSaved` field to `Collection` type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3623,6 +3623,9 @@ type Collection {
   # A type-specific ID likely used as a database ID.
   internalID: ID!
 
+  # Add Description
+  isSavedArtwork(artworkID: String!): Boolean!
+
   # Name of the collection. Has a predictable value for 'standard' collections
   # such as Saved Artwork, My Collection, etc. Can be provided by user otherwise.
   name: String!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3623,7 +3623,7 @@ type Collection {
   # A type-specific ID likely used as a database ID.
   internalID: ID!
 
-  # Add Description
+  # Checking whether artwork is included in collection
   isSavedArtwork(artworkID: String!): Boolean!
 
   # Name of the collection. Has a predictable value for 'standard' collections

--- a/src/schema/v2/me/__tests__/collection.test.ts
+++ b/src/schema/v2/me/__tests__/collection.test.ts
@@ -61,6 +61,59 @@ it("returns collection attributes", async () => {
   })
 })
 
+describe("isSavedArtwork field", () => {
+  beforeEach(() => {
+    query = gql`
+      query {
+        me {
+          collection(id: "123-abc") {
+            isSavedArtwork(artworkID: "artwork-id")
+          }
+        }
+      }
+    `
+  })
+
+  it("should return true if artwork is included in the collection", async () => {
+    context.collectionArtworksLoader = jest.fn(() => {
+      return Promise.resolve({
+        headers: {
+          "x-total-count": 1,
+        },
+      })
+    })
+
+    const response = await runAuthenticatedQuery(query, context)
+
+    expect(response).toEqual({
+      me: {
+        collection: {
+          isSavedArtwork: true,
+        },
+      },
+    })
+  })
+
+  it("should return false if artwork is included in the collection", async () => {
+    context.collectionArtworksLoader = jest.fn(() => {
+      return Promise.resolve({
+        headers: {
+          "x-total-count": 0,
+        },
+      })
+    })
+    const response = await runAuthenticatedQuery(query, context)
+
+    expect(response).toEqual({
+      me: {
+        collection: {
+          isSavedArtwork: false,
+        },
+      },
+    })
+  })
+})
+
 describe("artworksConnection", () => {
   const mockGravityCollectionArtworks = {
     headers: {

--- a/src/schema/v2/me/__tests__/collectionsConnection.test.ts
+++ b/src/schema/v2/me/__tests__/collectionsConnection.test.ts
@@ -23,25 +23,12 @@ describe("collectionsConnection", () => {
     }
   `
 
-  const mockGravityCollections = {
-    body: [
-      {
-        id: "123-abc",
-        name: "Works for dining room",
-        default: false,
-        saves: true,
-        artworks_count: 42,
-      },
-    ],
-    headers: {
-      "x-total-count": 1,
-    },
-  }
-
   beforeEach(() => {
     context = {
-      meLoader: jest.fn(() => Promise.resolve({ id: "user-42" })),
-      collectionsLoader: jest.fn(() => Promise.resolve(mockGravityCollections)),
+      meLoader: jest.fn(() => Promise.resolve(defaultMockUser)),
+      collectionsLoader: jest.fn(() =>
+        Promise.resolve(defaultMockGravityCollections)
+      ),
     }
   })
 
@@ -73,6 +60,82 @@ describe("collectionsConnection", () => {
                 default: false,
                 saves: true,
                 artworksCount: 42,
+              },
+            },
+          ],
+        },
+      },
+    })
+  })
+})
+
+describe("collectionsConnection with isArtworkSaved field", () => {
+  const query = gql`
+    query {
+      me {
+        collectionsConnection(first: 1, saves: true, sort: CREATED_AT_DESC) {
+          edges {
+            node {
+              isSavedArtwork(artworkID: "artwork-id")
+            }
+          }
+        }
+      }
+    }
+  `
+
+  beforeEach(() => {
+    context = {
+      meLoader: jest.fn(() => Promise.resolve(defaultMockUser)),
+      collectionsLoader: jest.fn(() =>
+        Promise.resolve(defaultMockGravityCollections)
+      ),
+    }
+  })
+
+  it("should return true if artwork is included in the collection", async () => {
+    context.collectionArtworksLoader = jest.fn(() => {
+      return Promise.resolve({
+        headers: {
+          "x-total-count": 1,
+        },
+      })
+    })
+
+    const response = await runAuthenticatedQuery(query, context)
+
+    expect(response).toEqual({
+      me: {
+        collectionsConnection: {
+          edges: [
+            {
+              node: {
+                isSavedArtwork: true,
+              },
+            },
+          ],
+        },
+      },
+    })
+  })
+
+  it("should return false if artwork is included in the collection", async () => {
+    context.collectionArtworksLoader = jest.fn(() => {
+      return Promise.resolve({
+        headers: {
+          "x-total-count": 0,
+        },
+      })
+    })
+    const response = await runAuthenticatedQuery(query, context)
+
+    expect(response).toEqual({
+      me: {
+        collectionsConnection: {
+          edges: [
+            {
+              node: {
+                isSavedArtwork: false,
               },
             },
           ],
@@ -137,7 +200,7 @@ describe("collectionsConnection with artworksConnection", () => {
 
   beforeEach(() => {
     context = {
-      meLoader: jest.fn(() => Promise.resolve({ id: "user-42" })),
+      meLoader: jest.fn(() => Promise.resolve(defaultMockUser)),
       collectionsLoader: jest.fn(() => Promise.resolve(mockGravityCollections)),
       collectionArtworksLoader: jest.fn(() =>
         Promise.resolve(mockGravityCollectionArtworks)
@@ -202,3 +265,22 @@ describe("collectionsConnection with artworksConnection", () => {
     })
   })
 })
+
+const defaultMockGravityCollections = {
+  body: [
+    {
+      id: "123-abc",
+      name: "Works for dining room",
+      default: false,
+      saves: true,
+      artworks_count: 42,
+    },
+  ],
+  headers: {
+    "x-total-count": 1,
+  },
+}
+
+const defaultMockUser = {
+  id: "user-42",
+}

--- a/src/schema/v2/me/collection.ts
+++ b/src/schema/v2/me/collection.ts
@@ -91,6 +91,33 @@ export const CollectionType = new GraphQLObjectType<any, ResolverContext>({
       description:
         "True if this collection represents artworks explicitly saved by the user, false otherwise.",
     },
+    isSavedArtwork: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description: "Add Description",
+      args: {
+        artworkID: {
+          type: new GraphQLNonNull(GraphQLString),
+        },
+      },
+      resolve: async (parent, args, context) => {
+        const { collectionArtworksLoader } = context
+
+        if (!collectionArtworksLoader) {
+          throw new Error("You need to be signed in to perform this action")
+        }
+
+        const { headers } = await collectionArtworksLoader(parent.id, {
+          artworks: [args.artworkID],
+          user_id: parent.userID,
+          private: true,
+          size: 0,
+          total_count: true,
+        })
+        const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+        return totalCount > 0
+      },
+    },
   }),
 })
 

--- a/src/schema/v2/me/collection.ts
+++ b/src/schema/v2/me/collection.ts
@@ -93,7 +93,7 @@ export const CollectionType = new GraphQLObjectType<any, ResolverContext>({
     },
     isSavedArtwork: {
       type: new GraphQLNonNull(GraphQLBoolean),
-      description: "Add Description",
+      description: "Checking whether artwork is included in collection",
       args: {
         artworkID: {
           type: new GraphQLNonNull(GraphQLString),


### PR DESCRIPTION
The type of this PR is: **Feat**

Jira ticket: [FX-4623]

#### Query
```graphql
{
  me {
    collection(id: "collection-id") {
      isSavedArtwork(artworkID: "artwork-id")
    }

    collectionsConnection(first: 1) {
      edges {
        node {
          isSavedArtwork(artworkID: "artwork-id")
        }
      }
    }
  }
}
```

### Demo
#### "Success" case
<img width="1286" alt="success" src="https://user-images.githubusercontent.com/3513494/220125962-5725ae6d-e546-44e8-b837-a31a457351a2.png">

#### "Fail" case
<img width="1286" alt="failure" src="https://user-images.githubusercontent.com/3513494/220126016-e3118c94-0eac-4391-b452-70c34cc9ffbc.png">


[FX-4623]: https://artsyproduct.atlassian.net/browse/FX-4623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ