### PR TITLE
Fix Artworks not enriched with insights

### DIFF
--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -86,9 +86,7 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
       return null
     }
 
-    const paginationArgs = options.sortByLastAuctionResultDate
-      ? { size: 100 }
-      : convertConnectionArgsToGravityArgs(options)
+    const paginationArgs = convertConnectionArgsToGravityArgs(options)
 
     const gravityOptions = {
       exclude_purchased_artworks: options.excludePurchasedArtworks,


### PR DESCRIPTION
### Description
This PR removes the redundant forcing of `size: 100` when using the `sortByLastAuctionResultDate`, which when used populates marketInsights on artworks with nulls.

<table>
  <tr>
    <td>Before</td>
     <td>After</td>
  </tr>
  <tr>
    <td valign="top"><img src="https://user-images.githubusercontent.com/18648835/220130939-3a215886-2dfc-4196-9023-173e6d0cde95.png"></td>
<td valign="top"><img src="https://user-images.githubusercontent.com/18648835/220130943-059977ed-c78a-49fd-bf6e-f27f593e578f.png"></td>
  </tr>
 </table>
