### PR TITLE
feat(NX-3383): Expose the associated inquiry request with a conversation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6865,6 +6865,9 @@ type Conversation implements Node {
   # Gravity inquiry id.
   inquiryID: String
 
+  # The inquiry request associated with the conversation.
+  inquiryRequest: PartnerInquiryRequest
+
   # An optional type-specific ID.
   internalID: ID
 
@@ -13245,6 +13248,14 @@ type PartnerEdge {
 
 type PartnerInquiryRequest {
   collectorProfile: InquirerCollectorProfile
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+  questions: [InquiryQuestion]
+  shippingLocation: Location
 }
 
 # A location

--- a/src/schema/v2/conversation/__tests__/__snapshots__/conversation.test.js.snap
+++ b/src/schema/v2/conversation/__tests__/__snapshots__/conversation.test.js.snap
@@ -39,27 +39,6 @@ Object {
 }
 `;
 
-exports[`Me Conversation inquiry request returns the inquiry request 1`] = `
-Array [
-  Object {
-    "internalID": "shipping_quote",
-    "question": "Shipping",
-  },
-  Object {
-    "internalID": "condition_and_provenance",
-    "question": "Condition & Provenance",
-  },
-]
-`;
-
-exports[`Me Conversation inquiry request returns the inquiry request 2`] = `
-Object {
-  "city": "New York City",
-  "country": "US",
-  "state": "NY",
-}
-`;
-
 exports[`Me Conversation inquiry request returns the questions and shipping location when present 1`] = `
 Array [
   Object {

--- a/src/schema/v2/conversation/__tests__/__snapshots__/conversation.test.js.snap
+++ b/src/schema/v2/conversation/__tests__/__snapshots__/conversation.test.js.snap
@@ -39,6 +39,48 @@ Object {
 }
 `;
 
+exports[`Me Conversation inquiry request returns the inquiry request 1`] = `
+Array [
+  Object {
+    "internalID": "shipping_quote",
+    "question": "Shipping",
+  },
+  Object {
+    "internalID": "condition_and_provenance",
+    "question": "Condition & Provenance",
+  },
+]
+`;
+
+exports[`Me Conversation inquiry request returns the inquiry request 2`] = `
+Object {
+  "city": "New York City",
+  "country": "US",
+  "state": "NY",
+}
+`;
+
+exports[`Me Conversation inquiry request returns the questions and shipping location when present 1`] = `
+Array [
+  Object {
+    "internalID": "shipping_quote",
+    "question": "Shipping",
+  },
+  Object {
+    "internalID": "condition_and_provenance",
+    "question": "Condition & Provenance",
+  },
+]
+`;
+
+exports[`Me Conversation inquiry request returns the questions and shipping location when present 2`] = `
+Object {
+  "city": "New York City",
+  "country": "US",
+  "state": "NY",
+}
+`;
+
 exports[`Me Conversation returns a conversation 1`] = `
 Object {
   "conversation": Object {

--- a/src/schema/v2/conversation/index.ts
+++ b/src/schema/v2/conversation/index.ts
@@ -27,6 +27,7 @@ import {
 import { MessageType } from "./message"
 import { ResolverContext } from "types/graphql"
 import { UserType } from "../user"
+import { InquiryRequestType } from "../partner/partnerInquiryRequest"
 
 export const BuyerOutcomeTypes = new GraphQLEnumType({
   name: "BuyerOutcomeTypes",
@@ -394,7 +395,25 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
         return results
       },
     },
-
+    inquiryRequest: {
+      type: InquiryRequestType,
+      description: "The inquiry request associated with the conversation.",
+      resolve: async (conversation, _args, { partnerInquiryRequestLoader }) => {
+        if (!partnerInquiryRequestLoader) {
+          return null
+        }
+        try {
+          const data = await partnerInquiryRequestLoader({
+            inquiryId: conversation.inquiry_id,
+            partnerId: conversation.to_id,
+          })
+          return data
+        } catch (error) {
+          console.error("[schema/v2/conversation/inquiryRequest] Error:", error)
+          return null
+        }
+      },
+    },
     items: {
       type: new GraphQLList(ConversationItem),
       description:

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -44,7 +44,7 @@ import { allViaLoader } from "lib/all"
 import { truncate } from "lib/helpers"
 import { setVersion } from "schema/v2/image/normalize"
 import { compact } from "lodash"
-import { InquiryRequestType } from "./partnerInquirerCollectorProfile"
+import { InquiryRequestType } from "./partnerInquiryRequest"
 import { PartnerDocumentsConnection } from "./partnerDocumentsConnection"
 
 const isFairOrganizer = (type) => type === "FairOrganizer"

--- a/src/schema/v2/partner/partnerInquirerCollectorProfile.ts
+++ b/src/schema/v2/partner/partnerInquirerCollectorProfile.ts
@@ -28,24 +28,3 @@ export const PartnerInquirerCollectorProfile: GraphQLFieldConfig<
   type: InquirerCollectorProfileType,
   description: "Inquiry requester's profile",
 }
-
-export const InquiryRequestType = new GraphQLObjectType<any, ResolverContext>({
-  name: "PartnerInquiryRequest",
-  fields: {
-    collectorProfile: {
-      type: InquirerCollectorProfileType,
-      resolve: (
-        { id: inquiryId, partnerId },
-        _args,
-        { partnerInquirerCollectorProfileLoader }
-      ) => {
-        if (!partnerInquirerCollectorProfileLoader) return
-
-        return partnerInquirerCollectorProfileLoader({
-          partnerId,
-          inquiryId,
-        })
-      },
-    },
-  },
-})

--- a/src/schema/v2/partner/partnerInquiryRequest.ts
+++ b/src/schema/v2/partner/partnerInquiryRequest.ts
@@ -1,0 +1,36 @@
+import { GraphQLList, GraphQLObjectType } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { InquiryQuestionType } from "../inquiry_question"
+import { LocationType } from "../location"
+import { InternalIDFields } from "../object_identification"
+import { InquirerCollectorProfileType } from "./partnerInquirerCollectorProfile"
+
+export const InquiryRequestType = new GraphQLObjectType<any, ResolverContext>({
+  name: "PartnerInquiryRequest",
+  fields: () => ({
+    ...InternalIDFields,
+    shippingLocation: {
+      type: LocationType,
+      resolve: ({ inquiry_shipping_location }) => inquiry_shipping_location,
+    },
+    questions: {
+      type: new GraphQLList(InquiryQuestionType),
+      resolve: ({ inquiry_questions }) => inquiry_questions,
+    },
+    collectorProfile: {
+      type: InquirerCollectorProfileType,
+      resolve: (
+        { id: inquiryId, partnerId },
+        _args,
+        { partnerInquirerCollectorProfileLoader }
+      ) => {
+        if (!partnerInquirerCollectorProfileLoader) return
+
+        return partnerInquirerCollectorProfileLoader({
+          partnerId,
+          inquiryId,
+        })
+      },
+    },
+  }),
+})


### PR DESCRIPTION
Addresses [NX-3383]

Exposes the associated `InquiryRequest` as part of the conversation. This allows us to access the questions and shipping locations stored on Gravity, which mobile app users might fill in on initial inquiries.

cc @artsy/negotiate-devs 

[NX-3383]: https://artsyproduct.atlassian.net/browse/NX-3383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ