### PR TITLE
fix(NX-3465): attachments array in SendMessageMutation

### DIFF
--- a/src/schema/v2/conversation/send_message_mutation.ts
+++ b/src/schema/v2/conversation/send_message_mutation.ts
@@ -19,7 +19,7 @@ interface SendConversationMessageMutationProps {
     url: string
     id?: string
     size?: string
-  }
+  }[]
   bodyHTML?: string
   bodyText: string
   from: string
@@ -131,16 +131,22 @@ export default mutationWithClientMutationId<
     const replyAll =
       args.replyAll === false && args.to ? undefined : args.replyAll
 
-    return conversationCreateMessageLoader(args.id, {
-      attachments: args.attachments,
-      body_html: args.bodyHTML,
-      body_text: args.bodyText,
-      from: args.from,
-      from_id: args.fromId ?? userID,
-      reply_all: replyAll,
-      reply_to_message_id: args.replyToMessageID,
-      to: args.to,
-    })
+    return conversationCreateMessageLoader(
+      args.id,
+      {
+        attachments: { ...args.attachments },
+        body_html: args.bodyHTML,
+        body_text: args.bodyText,
+        from: args.from,
+        from_id: args.fromId ?? userID,
+        reply_all: replyAll,
+        reply_to_message_id: args.replyToMessageID,
+        to: args.to,
+      },
+      {
+        headers: true,
+      }
+    )
       .then(({ id: newMessageID }) => {
         return conversationLoader(args.id).then((updatedConversation) => {
           return {


### PR DESCRIPTION
[NX-3465]

Attachments were not correctly parsed as`array`, the data loader parses the parameter as query string like `path?attachments[][name]="name.jpg"` instead of providing an index.
Spreading the array inside an object fixes the query string to be like `path?attachments[0][name]="name.jpg"&attachments[1][name]="2nd.png"`.

[NX-3465]: https://artsyproduct.atlassian.net/browse/NX-3465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ