### PR TITLE
fix: Filter null values in price insights batch loader input

### DIFF
--- a/src/lib/fillers/enrichArtworksWithPriceInsights.ts
+++ b/src/lib/fillers/enrichArtworksWithPriceInsights.ts
@@ -1,18 +1,22 @@
 import * as Sentry from "@sentry/node"
-import { MarketPriceInsight } from "lib/loaders/loaders_with_authentication/vortex"
+import {
+  MarketPriceInsight,
+  MarketPriceInsightsBatchLoaderParams,
+} from "lib/loaders/loaders_with_authentication/vortex"
 import { isEqual, uniqWith } from "lodash"
+
 export const enrichArtworksWithPriceInsights = async (
   artworks: Array<any>,
   marketPriceInsightsBatchLoader: (
-    params: {
-      artistId: string
-      medium: string
-      category: string
-    }[]
+    params: MarketPriceInsightsBatchLoaderParams
   ) => Promise<MarketPriceInsight[]>
 ) => {
   try {
-    const marketPriceInsightParams = uniqWith(
+    const marketPriceInsightParams: {
+      artistId?: string
+      medium?: string
+      category?: string
+    }[] = uniqWith(
       artworks.map((artwork: any) => ({
         artistId: artwork.artist?._id,
         medium: artwork.medium,

--- a/src/lib/loaders/loaders_with_authentication/vortex.ts
+++ b/src/lib/loaders/loaders_with_authentication/vortex.ts
@@ -49,12 +49,14 @@ export default (accessToken, opts) => {
     vortexTokenLoader,
     vortexGraphqlLoader,
     marketPriceInsightsBatchLoader: async (
-      params: { artistId: string; medium: string; category: string }[]
+      params: MarketPriceInsightsBatchLoaderParams
     ) => {
-      const artistIDMediumTuples = params.map((artist) => ({
-        artistId: artist.artistId,
-        medium: artist.category,
-      }))
+      const artistIDMediumTuples = params
+        .map((artist) => ({
+          artistId: artist.artistId,
+          medium: artist.category,
+        }))
+        .filter((tuple) => tuple.artistId && tuple.medium)
 
       const vortexResult = await vortexGraphqlLoader({
         query: gql`
@@ -100,3 +102,9 @@ export type MarketPriceInsight = {
   annualLotsSold: number
   annualValueSold: number
 }
+
+export type MarketPriceInsightsBatchLoaderParams = {
+  artistId?: string
+  medium?: string
+  category?: string
+}[]

--- a/src/lib/loaders/loaders_with_authentication/vortex.ts
+++ b/src/lib/loaders/loaders_with_authentication/vortex.ts
@@ -87,6 +87,10 @@ export default (accessToken, opts) => {
         vortexResult.data?.marketPriceInsightsBatch
       )
 
+      if (vortexResult.errors.length) {
+        console.error(vortexResult.errors)
+      }
+
       return priceInsightNodes
     },
   }


### PR DESCRIPTION
## Description

We need to filter out `null` values in the price insights batch loader input because the params `artistId` and `medium` are [required in Vortex](https://github.com/artsy/vortex/blob/34991742b702d00e697399acce769e64373cc5f9/app/graphql/types/artist_id_medium_tuple_type.rb#L6) and the loader will fail silently when we send null values.

Related issue: https://github.com/artsy/metaphysics/pull/4800