### PR TITLE
Revert "Revert "fix: Filter null values in price insights batch loader input""

### DIFF
--- a/src/lib/fillers/enrichArtworksWithPriceInsights.ts
+++ b/src/lib/fillers/enrichArtworksWithPriceInsights.ts
@@ -1,18 +1,22 @@
 import * as Sentry from "@sentry/node"
-import { MarketPriceInsight } from "lib/loaders/loaders_with_authentication/vortex"
+import {
+  MarketPriceInsight,
+  MarketPriceInsightsBatchLoaderParams,
+} from "lib/loaders/loaders_with_authentication/vortex"
 import { isEqual, uniqWith } from "lodash"
+
 export const enrichArtworksWithPriceInsights = async (
   artworks: Array<any>,
   marketPriceInsightsBatchLoader: (
-    params: {
-      artistId: string
-      medium: string
-      category: string
-    }[]
+    params: MarketPriceInsightsBatchLoaderParams
   ) => Promise<MarketPriceInsight[]>
 ) => {
   try {
-    const marketPriceInsightParams = uniqWith(
+    const marketPriceInsightParams: {
+      artistId?: string
+      medium?: string
+      category?: string
+    }[] = uniqWith(
       artworks.map((artwork: any) => ({
         artistId: artwork.artist?._id,
         medium: artwork.medium,

--- a/src/lib/loaders/loaders_with_authentication/vortex.ts
+++ b/src/lib/loaders/loaders_with_authentication/vortex.ts
@@ -49,12 +49,14 @@ export default (accessToken, opts) => {
     vortexTokenLoader,
     vortexGraphqlLoader,
     marketPriceInsightsBatchLoader: async (
-      params: { artistId: string; medium: string; category: string }[]
+      params: MarketPriceInsightsBatchLoaderParams
     ) => {
-      const artistIDMediumTuples = params.map((artist) => ({
-        artistId: artist.artistId,
-        medium: artist.category,
-      }))
+      const artistIDMediumTuples = params
+        .map((artist) => ({
+          artistId: artist.artistId,
+          medium: artist.category,
+        }))
+        .filter((tuple) => tuple.artistId && tuple.medium)
 
       const vortexResult = await vortexGraphqlLoader({
         query: gql`
@@ -85,6 +87,10 @@ export default (accessToken, opts) => {
         vortexResult.data?.marketPriceInsightsBatch
       )
 
+      if (vortexResult.errors.length) {
+        console.error(vortexResult.errors)
+      }
+
       return priceInsightNodes
     },
   }
@@ -100,3 +106,9 @@ export type MarketPriceInsight = {
   annualLotsSold: number
   annualValueSold: number
 }
+
+export type MarketPriceInsightsBatchLoaderParams = {
+  artistId?: string
+  medium?: string
+  category?: string
+}[]

--- a/src/lib/loaders/loaders_with_authentication/vortex.ts
+++ b/src/lib/loaders/loaders_with_authentication/vortex.ts
@@ -45,21 +45,18 @@ export default (accessToken, opts) => {
       }
     )
 
-  return {
-    vortexTokenLoader,
-    vortexGraphqlLoader,
-    marketPriceInsightsBatchLoader: async (
-      params: MarketPriceInsightsBatchLoaderParams
-    ) => {
-      const artistIDMediumTuples = params
-        .map((artist) => ({
-          artistId: artist.artistId,
-          medium: artist.category,
-        }))
-        .filter((tuple) => tuple.artistId && tuple.medium)
+  const marketPriceInsightsBatchLoader = async (
+    params: MarketPriceInsightsBatchLoaderParams
+  ) => {
+    const artistIDMediumTuples = params
+      .map((artist) => ({
+        artistId: artist.artistId,
+        medium: artist.category,
+      }))
+      .filter((tuple) => tuple.artistId && tuple.medium)
 
-      const vortexResult = await vortexGraphqlLoader({
-        query: gql`
+    const vortexResult = await vortexGraphqlLoader({
+      query: gql`
         query MarketPriceInsightsBatchQuery($artistIDMediumTuples: [ArtistIdMediumTupleType!]!) {
           marketPriceInsightsBatch(input: $artistIDMediumTuples, first: ${MAX_MARKET_PRICE_INSIGHTS}) {
             totalCount
@@ -80,19 +77,24 @@ export default (accessToken, opts) => {
           }
         }
       `,
-        variables: { artistIDMediumTuples },
-      })()
+      variables: { artistIDMediumTuples },
+    })()
 
-      const priceInsightNodes: MarketPriceInsight[] = extractNodes(
-        vortexResult.data?.marketPriceInsightsBatch
-      )
+    const priceInsightNodes: MarketPriceInsight[] = extractNodes(
+      vortexResult.data?.marketPriceInsightsBatch
+    )
 
-      if (vortexResult.errors.length) {
-        console.error(vortexResult.errors)
-      }
+    if (vortexResult?.errors?.length) {
+      console.error(vortexResult.errors)
+    }
 
-      return priceInsightNodes
-    },
+    return priceInsightNodes
+  }
+
+  return {
+    vortexTokenLoader,
+    vortexGraphqlLoader,
+    marketPriceInsightsBatchLoader,
   }
 }
 


### PR DESCRIPTION
Reverts artsy/metaphysics#4811 and fixes the bug:

`vortexResult.errors.length` -> `vortexResult?.errors?.length`.