### PR TITLE
feat(NX-3441): Expose a formatted first message including questions

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13252,6 +13252,10 @@ type PartnerEdge {
 type PartnerInquiryRequest {
   collectorProfile: InquirerCollectorProfile
 
+  # Returns the first message of an inquiry with the addition of any inquiry
+  # questions submitted by the user, formatted and if present.
+  formattedFirstMessage: String
+
   # A globally unique ID.
   id: ID!
 

--- a/src/schema/v2/conversation/__tests__/__snapshots__/conversation.test.js.snap
+++ b/src/schema/v2/conversation/__tests__/__snapshots__/conversation.test.js.snap
@@ -39,7 +39,12 @@ Object {
 }
 `;
 
-exports[`Me Conversation inquiry request returns the questions and shipping location when present 1`] = `
+exports[`Me Conversation inquiry request returns the formatted first message as just the formatted questions if no message is present 1`] = `
+"I would like to request the following information about this artwork:
+• Condition & Provenance"
+`;
+
+exports[`Me Conversation inquiry request returns the formatted first message, questions, and shipping location when present 1`] = `
 Array [
   Object {
     "internalID": "shipping_quote",
@@ -52,12 +57,20 @@ Array [
 ]
 `;
 
-exports[`Me Conversation inquiry request returns the questions and shipping location when present 2`] = `
+exports[`Me Conversation inquiry request returns the formatted first message, questions, and shipping location when present 2`] = `
 Object {
   "city": "New York City",
   "country": "US",
   "state": "NY",
 }
+`;
+
+exports[`Me Conversation inquiry request returns the formatted first message, questions, and shipping location when present 3`] = `
+"Hello world!,
+
+I would like to request the following information about this artwork:
+• Shipping Quote to New York City, US
+• Condition & Provenance"
 `;
 
 exports[`Me Conversation returns a conversation 1`] = `

--- a/src/schema/v2/conversation/__tests__/conversation.test.js
+++ b/src/schema/v2/conversation/__tests__/conversation.test.js
@@ -575,6 +575,7 @@ describe("Me", () => {
                   state
                   city
                 }
+                formattedFirstMessage
               }
             }
           }
@@ -586,11 +587,12 @@ describe("Me", () => {
           }
         )
       })
-      it("returns the questions and shipping location when present", () => {
+      it("returns the formatted first message, questions, and shipping location when present", () => {
         const newContext = {
           ...context,
           partnerInquiryRequestLoader: () =>
             Promise.resolve({
+              message: "Hello world!",
               inquiry_questions: [
                 { id: "shipping_quote", question: "Shipping" },
                 {
@@ -611,6 +613,47 @@ describe("Me", () => {
             expect(inquiryRequest.questions).toHaveLength(2)
             expect(inquiryRequest.questions).toMatchSnapshot()
             expect(inquiryRequest.shippingLocation).toMatchSnapshot()
+            expect(inquiryRequest.formattedFirstMessage).toMatchSnapshot()
+          }
+        )
+      })
+      it("defaults the formatted first message to just the message if no questions are present", () => {
+        const newContext = {
+          ...context,
+          partnerInquiryRequestLoader: () =>
+            Promise.resolve({
+              message: "Hello world!",
+              inquiry_questions: [],
+              inquiry_shipping_location: null,
+            }),
+        }
+        return runAuthenticatedQuery(query, newContext).then(
+          ({ conversation: { inquiryRequest } }) => {
+            expect(inquiryRequest.questions).toHaveLength(0)
+            expect(inquiryRequest.shippingLocation).toBeNull()
+            expect(inquiryRequest.formattedFirstMessage).toBe("Hello world!")
+          }
+        )
+      })
+      it("returns the formatted first message as just the formatted questions if no message is present", () => {
+        const newContext = {
+          ...context,
+          partnerInquiryRequestLoader: () =>
+            Promise.resolve({
+              message: null,
+              inquiry_questions: [
+                {
+                  id: "condition_and_provenance",
+                  question: "Condition & Provenance",
+                },
+              ],
+            }),
+        }
+        return runAuthenticatedQuery(query, newContext).then(
+          ({ conversation: { inquiryRequest } }) => {
+            expect(inquiryRequest.questions).toHaveLength(1)
+            expect(inquiryRequest.shippingLocation).toBeNull()
+            expect(inquiryRequest.formattedFirstMessage).toMatchSnapshot()
           }
         )
       })

--- a/src/schema/v2/partner/partnerInquiryRequest.ts
+++ b/src/schema/v2/partner/partnerInquiryRequest.ts
@@ -1,4 +1,4 @@
-import { GraphQLList, GraphQLObjectType } from "graphql"
+import { GraphQLList, GraphQLObjectType, GraphQLString } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { InquiryQuestionType } from "../inquiry_question"
 import { LocationType } from "../location"
@@ -16,6 +16,33 @@ export const InquiryRequestType = new GraphQLObjectType<any, ResolverContext>({
     questions: {
       type: new GraphQLList(InquiryQuestionType),
       resolve: ({ inquiry_questions }) => inquiry_questions,
+    },
+    formattedFirstMessage: {
+      type: GraphQLString,
+      description:
+        "Returns the first message of an inquiry with the addition of any inquiry questions submitted by the user, formatted and if present.",
+      resolve: ({ inquiry_shipping_location, inquiry_questions, message }) => {
+        if (!inquiry_questions || !inquiry_questions.length) return message
+        const shippingQuote = () => {
+          if (!inquiry_shipping_location) return "• Shipping Quote"
+          const { city, country, state } = inquiry_shipping_location
+          const stateOrCountry = country === "United States" ? state : country
+          return `• Shipping Quote to ${[city, stateOrCountry].join(", ")}`
+        }
+        const lines = [
+          "I would like to request the following information about this artwork:",
+        ]
+
+        inquiry_questions.forEach((question) => {
+          lines.push(
+            question.id === "shipping_quote"
+              ? shippingQuote()
+              : `• ${question?.question}`
+          )
+        })
+        if (message) lines.unshift([message, "\n"].join())
+        return lines.join("\n")
+      },
     },
     collectorProfile: {
       type: InquirerCollectorProfileType,


### PR DESCRIPTION
Partly resolves [NX-3441]

Exposes a `formattedFirstMessage` field on the `inquiryRequest`, which includes the first message and the formatted inquiry questions and location. If no questions are present, it'll default to the first message and return only the formatted questions if the opposite is true.

Example:
```
{
   conversation (id: "123") {
      inquiryRequest: {
         message: "Hello world!",
         questions: [
             {
                 "internalID": "shipping_quote",
                 "question": "Shipping"
              }, {
                  "internalID": "condition_and_provenance",
                  "question": "Condition & Provenance"
              }
          ],
         shippingLocation: {
            city: "Montevideo",
            country: "Uruguay"
         },
         formattedFirstMessage: "Hello world!\n\nI would like to request the following information about this artwork:\n• Shipping Quote to Montevideo, Uruguay\n• Condition & Provenance"
      }
   }
}

```
Which can be rendered in the frontend as:

> Hello world!
> 
> I would like to request the following information about this artwork:
> • Shipping Quote to Montevideo, Uruguay
> • Condition & Provenance

cc @artsy/negotiate-devs 

[NX-3441]: https://artsyproduct.atlassian.net/browse/NX-3441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ