### PR TITLE
fix(sendMessageMutation): attachments parsing

### DIFF
--- a/src/schema/v2/conversation/send_message_mutation.ts
+++ b/src/schema/v2/conversation/send_message_mutation.ts
@@ -19,7 +19,7 @@ interface SendConversationMessageMutationProps {
     url: string
     id?: string
     size?: string
-  }
+  }[]
   bodyHTML?: string
   bodyText: string
   from: string
@@ -132,7 +132,7 @@ export default mutationWithClientMutationId<
       args.replyAll === false && args.to ? undefined : args.replyAll
 
     return conversationCreateMessageLoader(args.id, {
-      attachments: args.attachments,
+      attachments: { ...args.attachments },
       body_html: args.bodyHTML,
       body_text: args.bodyText,
       from: args.from,


### PR DESCRIPTION
Related to #4819 

Passing the `headers: true` made the loader return `body` and `header` as response object keys instead of the `body` 
as an object.