### PR TITLE
Revert "fix: Return all saved artworks from quiz GRO-1547"

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -528,7 +528,6 @@ export default (accessToken, userID, opts) => {
         paramKey: "artworks",
         trackingKey: "is_saved",
         entityIDKeyPath: "_id",
-        batchSize: 10,
       }
     ),
     savedArtworksLoader: gravityLoader(


### PR DESCRIPTION
Reverts https://github.com/artsy/metaphysics/pull/4746

While investigating [this](https://artsy.slack.com/archives/C02BAQ5K7/p1676982560961129) earlier I noticed that it broke the onboarding on app for, af as I can tell, all users who signed u and didn't skip it the onboarding and have a collection with over 10 artworks (a bit over  1k). I had to sign out early for a personal issue and ask others who were pairing with me to urgently investigate this and revert it but found out it wasn't reverted yet so I'm creating a PR to revert it on my phone while bowling 🎳😁