### PR TITLE
feat: align alert labels with known artwork medium types

### DIFF
--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -73,114 +73,125 @@ describe("resolveSearchCriteriaLabels", () => {
     ])
   })
 
-  it("formats medium criteria", async () => {
-    const parent = {
-      additionalGeneIDs: [
-        "painting",
-        "photography",
-        "sculpture",
-        "prints",
-        "work-on-paper",
-        "nft",
-        "design",
-        "drawing",
-        "installation",
-        "film-slash-video",
-        "jewelry",
-        "performance-art",
-        "reproduction",
-        "ephemera-or-merchandise",
-      ],
-    }
+  describe("medium criteria", () => {
+    it("formats medium criteria", async () => {
+      const parent = {
+        additionalGeneIDs: [
+          "painting",
+          "photography",
+          "sculpture",
+          "prints",
+          "work-on-paper",
+          "nft",
+          "design",
+          "installation",
+          "film-slash-video",
+          "jewelry",
+          "performance-art",
+          "reproduction",
+          "ephemera-or-merchandise",
+        ],
+      }
 
-    const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+      const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
 
-    expect(labels).toIncludeAllMembers([
-      {
-        name: "Medium",
-        displayValue: "Painting",
-        value: "painting",
-        field: "additionalGeneIDs",
-      },
-      {
-        name: "Medium",
-        displayValue: "Photography",
-        value: "photography",
-        field: "additionalGeneIDs",
-      },
-      {
-        name: "Medium",
-        displayValue: "Sculpture",
-        value: "sculpture",
-        field: "additionalGeneIDs",
-      },
-      {
-        name: "Medium",
-        displayValue: "Prints",
-        value: "prints",
-        field: "additionalGeneIDs",
-      },
-      {
-        name: "Medium",
-        displayValue: "Work on Paper",
-        value: "work-on-paper",
-        field: "additionalGeneIDs",
-      },
-      {
-        name: "Medium",
-        displayValue: "NFT",
-        value: "nft",
-        field: "additionalGeneIDs",
-      },
-      {
-        name: "Medium",
-        displayValue: "Design",
-        value: "design",
-        field: "additionalGeneIDs",
-      },
-      {
-        name: "Medium",
-        displayValue: "Drawing",
-        value: "drawing",
-        field: "additionalGeneIDs",
-      },
-      {
-        name: "Medium",
-        displayValue: "Installation",
-        value: "installation",
-        field: "additionalGeneIDs",
-      },
-      {
-        name: "Medium",
-        displayValue: "Film/Video",
-        value: "film-slash-video",
-        field: "additionalGeneIDs",
-      },
-      {
-        name: "Medium",
-        displayValue: "Jewelry",
-        value: "jewelry",
-        field: "additionalGeneIDs",
-      },
-      {
-        name: "Medium",
-        displayValue: "Performance Art",
-        value: "performance-art",
-        field: "additionalGeneIDs",
-      },
-      {
-        name: "Medium",
-        displayValue: "Reproduction",
-        value: "reproduction",
-        field: "additionalGeneIDs",
-      },
-      {
-        name: "Medium",
-        displayValue: "Ephemera or Merchandise",
-        value: "ephemera-or-merchandise",
-        field: "additionalGeneIDs",
-      },
-    ])
+      expect(labels).toIncludeAllMembers([
+        {
+          name: "Medium",
+          displayValue: "Painting",
+          value: "painting",
+          field: "additionalGeneIDs",
+        },
+        {
+          name: "Medium",
+          displayValue: "Photography",
+          value: "photography",
+          field: "additionalGeneIDs",
+        },
+        {
+          name: "Medium",
+          displayValue: "Sculpture",
+          value: "sculpture",
+          field: "additionalGeneIDs",
+        },
+        {
+          name: "Medium",
+          displayValue: "Print",
+          value: "prints",
+          field: "additionalGeneIDs",
+        },
+        {
+          name: "Medium",
+          displayValue: "Drawing, Collage or other Work on Paper",
+          value: "work-on-paper",
+          field: "additionalGeneIDs",
+        },
+        {
+          name: "Medium",
+          displayValue: "NFT",
+          value: "nft",
+          field: "additionalGeneIDs",
+        },
+        {
+          name: "Medium",
+          displayValue: "Design/Decorative Art",
+          value: "design",
+          field: "additionalGeneIDs",
+        },
+        {
+          name: "Medium",
+          displayValue: "Installation",
+          value: "installation",
+          field: "additionalGeneIDs",
+        },
+        {
+          name: "Medium",
+          displayValue: "Video/Film/Animation",
+          value: "film-slash-video",
+          field: "additionalGeneIDs",
+        },
+        {
+          name: "Medium",
+          displayValue: "Jewelry",
+          value: "jewelry",
+          field: "additionalGeneIDs",
+        },
+        {
+          name: "Medium",
+          displayValue: "Performance Art",
+          value: "performance-art",
+          field: "additionalGeneIDs",
+        },
+        {
+          name: "Medium",
+          displayValue: "Reproduction",
+          value: "reproduction",
+          field: "additionalGeneIDs",
+        },
+        {
+          name: "Medium",
+          displayValue: "Ephemera or Merchandise",
+          value: "ephemera-or-merchandise",
+          field: "additionalGeneIDs",
+        },
+      ])
+    })
+    it("formats medium criteria when medium type is unknown", async () => {
+      const parent = {
+        additionalGeneIDs: ["drawing"],
+      }
+
+      const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+
+      expect(labels).toIncludeAllMembers([
+        {
+          name: "Medium",
+          displayValue: "Other (drawing)",
+          value: "drawing",
+          field: "additionalGeneIDs",
+        },
+      ])
+    })
   })
 
   describe("price criteria", () => {

--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -81,6 +81,7 @@ describe("resolveSearchCriteriaLabels", () => {
           "photography",
           "sculpture",
           "prints",
+          "drawing",
           "work-on-paper",
           "nft",
           "design",
@@ -118,6 +119,12 @@ describe("resolveSearchCriteriaLabels", () => {
           name: "Medium",
           displayValue: "Print",
           value: "prints",
+          field: "additionalGeneIDs",
+        },
+        {
+          name: "Medium",
+          displayValue: "Drawing",
+          value: "drawing",
           field: "additionalGeneIDs",
         },
         {
@@ -178,7 +185,7 @@ describe("resolveSearchCriteriaLabels", () => {
     })
     it("formats medium criteria when medium type is unknown", async () => {
       const parent = {
-        additionalGeneIDs: ["drawing"],
+        additionalGeneIDs: ["watercolor"],
       }
 
       const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
@@ -186,8 +193,8 @@ describe("resolveSearchCriteriaLabels", () => {
       expect(labels).toIncludeAllMembers([
         {
           name: "Medium",
-          displayValue: "Other (drawing)",
-          value: "drawing",
+          displayValue: "Other (watercolor)",
+          value: "watercolor",
           field: "additionalGeneIDs",
         },
       ])

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -144,18 +144,28 @@ function getRarityLabels(attributionClasses: string[]) {
   }))
 }
 
+function getArtworkMediumByGene(geneID: string) {
+  const mediums = Object.assign(
+    {
+      drawing: { name: "Drawing", mediumFilterGeneSlug: "drawing" },
+    },
+    artworkMediums
+  )
+  const fallbackMedium = { name: `Other (${geneID})` }
+  const artworkMedium = Object.values(mediums).find(
+    (entry) => entry.mediumFilterGeneSlug === geneID
+  )
+
+  return artworkMedium ?? fallbackMedium
+}
+
 function getMediumLabels(additionalGeneIDs: string[]) {
   if (!additionalGeneIDs?.length) return []
 
   return additionalGeneIDs.map((geneID) => {
-    const fallbackMedium = { name: `Other (${geneID})` }
-    const artworkMedium = Object.values(artworkMediums).find(
-      (entry) => entry.mediumFilterGeneSlug === geneID
-    )
-
     return {
       name: "Medium",
-      displayValue: (artworkMedium ?? fallbackMedium).name,
+      displayValue: getArtworkMediumByGene(geneID).name,
       value: geneID,
       field: "additionalGeneIDs",
     }

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -148,13 +148,14 @@ function getMediumLabels(additionalGeneIDs: string[]) {
   if (!additionalGeneIDs?.length) return []
 
   return additionalGeneIDs.map((geneID) => {
-    const medium = Object.values(artworkMediums).find(
+    const fallbackMedium = { name: `Other (${geneID})` }
+    const artworkMedium = Object.values(artworkMediums).find(
       (entry) => entry.mediumFilterGeneSlug === geneID
-    ) || { name: `Other (${geneID})` }
+    )
 
     return {
       name: "Medium",
-      displayValue: medium.name,
+      displayValue: (artworkMedium ?? fallbackMedium).name,
       value: geneID,
       field: "additionalGeneIDs",
     }

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -2,6 +2,7 @@ import { GraphQLNonNull, GraphQLObjectType, GraphQLString } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { toTitleCase } from "@artsy/to-title-case"
 
+import artworkMediums from "lib/artworkMediums"
 import allAttributionClasses from "lib/attributionClasses"
 import { COLORS, OLD_COLORS } from "lib/colors"
 
@@ -146,35 +147,18 @@ function getRarityLabels(attributionClasses: string[]) {
 function getMediumLabels(additionalGeneIDs: string[]) {
   if (!additionalGeneIDs?.length) return []
 
-  // Corresponds to the list of options under
-  // the Medium facet on an artwork grid.
-  //
-  // Being a list of genes, this is related to,
-  // but not the same as, the list of artwork medium types.
+  return additionalGeneIDs.map((geneID) => {
+    const medium = Object.values(artworkMediums).find(
+      (entry) => entry.mediumFilterGeneSlug === geneID
+    ) || { name: `Other (${geneID})` }
 
-  const MEDIUM_GENES = {
-    painting: "Painting",
-    photography: "Photography",
-    sculpture: "Sculpture",
-    prints: "Prints",
-    "work-on-paper": "Work on Paper",
-    nft: "NFT",
-    design: "Design",
-    drawing: "Drawing",
-    installation: "Installation",
-    "film-slash-video": "Film/Video",
-    jewelry: "Jewelry",
-    "performance-art": "Performance Art",
-    reproduction: "Reproduction",
-    "ephemera-or-merchandise": "Ephemera or Merchandise",
-  }
-
-  return additionalGeneIDs.map((geneID) => ({
-    name: "Medium",
-    displayValue: MEDIUM_GENES[geneID],
-    value: geneID,
-    field: "additionalGeneIDs",
-  }))
+    return {
+      name: "Medium",
+      displayValue: medium.name,
+      value: geneID,
+      field: "additionalGeneIDs",
+    }
+  })
 }
 
 function getPriceLabel(priceRange: string): SearchCriteriaLabel | undefined {


### PR DESCRIPTION
Find corresponding medium type via gene slug and use the defined name. When a corresponding medium type is not found, use `Other (<slug>)` as the display name.

Jira: [FX-4578](https://artsyproduct.atlassian.net/browse/FX-4578) 🔒 

[FX-4578]: https://artsyproduct.atlassian.net/browse/FX-4578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ