### PR TITLE
fix: remove markdown from feature subheadline

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8860,7 +8860,7 @@ type Feature {
 
   # A slug ID.
   slug: ID!
-  subheadline(format: Format): String
+  subheadline: String
 }
 
 # A connection to a list of items.

--- a/src/schema/v2/Feature/FeatureType.ts
+++ b/src/schema/v2/Feature/FeatureType.ts
@@ -37,7 +37,9 @@ export const FeatureType = new GraphQLObjectType<
       resolve: ({ active }) => active,
     },
     description: markdown(),
-    subheadline: markdown(),
+    subheadline: {
+      type: GraphQLString,
+    },
     callout: markdown(),
     layout: {
       type: new GraphQLNonNull(FeatureLayoutsEnum),


### PR DESCRIPTION
Quick PR to remove markdown formatting from the `subheadline` for features. This is a follow up to the set / feature editor [QA session](https://www.notion.so/artsy/QA-Forque-Sets-Features-Manager-3d25adcb9fd9460cb5aba22aee2e36c6?p=45b1fbe1f59e44c19829137d915d4fae&pm=s).

This addresses this [QA card](https://www.notion.so/artsy/Create-Feature-Don-t-support-markdown-for-subheading-45b1fbe1f59e44c19829137d915d4fae?pvs=4). 