### PR TITLE
fix: use split helper for new fields string

### DIFF
--- a/src/schema/v2/artist/helpers.ts
+++ b/src/schema/v2/artist/helpers.ts
@@ -70,17 +70,17 @@ export const ARTIST_INSIGHT_MAPPING = {
   },
   RESIDENCIES: {
     getDescription: () => "Established artist residencies.",
-    getEntities: (artist) => artist.residencies && [],
+    getEntities: (artist) => splitEntities(artist.residencies),
     getLabel: () => "Residencies",
   },
   PRIVATE_COLLECTIONS: {
     getDescription: () => "A list of collections they are part of.",
-    getEntities: (artist) => artist.private_collections && [],
+    getEntities: (artist) => splitEntities(artist.private_collections),
     getLabel: () => "Private Collections",
   },
   AWARDS: {
     getDescription: () => "Awards and prizes the artist has won.",
-    getEntities: (artist) => artist.awards && [],
+    getEntities: (artist) => splitEntities(artist.awards),
     getLabel: () => "Awards",
   },
 } as const


### PR DESCRIPTION
The entities on the new fields returned empty arrays before. I tested this with the the `splitEntities` helper and got back the actual data:
<img width="730" alt="Bildschirmfoto 2023-02-27 um 12 42 19" src="https://user-images.githubusercontent.com/15628617/221554974-dd313046-eedc-44e6-96d2-f7841474045a.png">

Resolves [GROW-1563](https://artsyproduct.atlassian.net/browse/GRO-1563)
Related to: #4815 and https://github.com/artsy/force/pull/11966