### PR TITLE
fix: use layout enum when creating or updating orderedSet

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7341,7 +7341,7 @@ input CreateOrderedSetMutationInput {
   itemIds: [String]
   itemType: String!
   key: String!
-  layout: String
+  layout: OrderedSetLayouts
   name: String
   ownerType: String
   published: Boolean
@@ -17440,7 +17440,7 @@ input UpdateOrderedSetMutationInput {
   itemIds: [String]
   itemType: String
   key: String
-  layout: String
+  layout: OrderedSetLayouts
   name: String
   ownerId: String
   ownerType: String

--- a/src/schema/v2/OrderedSet/__tests__/createOrderedSetMutation.test.ts
+++ b/src/schema/v2/OrderedSet/__tests__/createOrderedSetMutation.test.ts
@@ -10,7 +10,7 @@ const mutation = gql`
         itemIds: ["def456", "ghi789"]
         itemType: "Artist"
         key: "a"
-        layout: "default"
+        layout: DEFAULT
         name: "Example set"
         ownerType: "Feature"
         published: true

--- a/src/schema/v2/OrderedSet/__tests__/updateOrderedSetMutation.test.ts
+++ b/src/schema/v2/OrderedSet/__tests__/updateOrderedSetMutation.test.ts
@@ -10,7 +10,7 @@ const mutation = gql`
         itemId: "abc123"
         itemType: "Artist"
         key: "a"
-        layout: "default"
+        layout: DEFAULT
         name: "Example set"
         ownerId: "feature-id"
         ownerType: "Feature"

--- a/src/schema/v2/OrderedSet/createOrderedSetMutation.ts
+++ b/src/schema/v2/OrderedSet/createOrderedSetMutation.ts
@@ -13,6 +13,7 @@ import {
   formatGravityError,
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
+import { OrderedSetLayoutsEnum } from "./OrderedSetLayoutsEnum"
 
 type ItemType =
   | "Artist"
@@ -27,8 +28,6 @@ type ItemType =
 
 type OwnerType = "Fair" | "Feature" | "Sale"
 
-type LayoutType = "default" | "full"
-
 interface Input {
   description: string
   internalName: string
@@ -36,7 +35,7 @@ interface Input {
   itemIds: string[]
   itemType: ItemType
   key: string
-  layout: LayoutType
+  layout: string
   name: string
   ownerType: OwnerType
   published: boolean
@@ -83,7 +82,7 @@ export const createOrderedSetMutation = mutationWithClientMutationId<
     itemIds: { type: GraphQLList(GraphQLString) },
     itemType: { type: new GraphQLNonNull(GraphQLString) },
     key: { type: new GraphQLNonNull(GraphQLString) },
-    layout: { type: GraphQLString },
+    layout: { type: OrderedSetLayoutsEnum },
     name: { type: GraphQLString },
     ownerType: { type: GraphQLString },
     published: { type: GraphQLBoolean },

--- a/src/schema/v2/OrderedSet/updateOrderedSetMutation.ts
+++ b/src/schema/v2/OrderedSet/updateOrderedSetMutation.ts
@@ -14,6 +14,7 @@ import {
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
 import { FeatureType } from "../Feature"
+import { OrderedSetLayoutsEnum } from "./OrderedSetLayoutsEnum"
 
 type ItemType =
   | "Artist"
@@ -28,8 +29,6 @@ type ItemType =
 
 type OwnerType = "Fair" | "Feature" | "Sale"
 
-type LayoutType = "default" | "full"
-
 interface Input {
   description: string
   id: string
@@ -38,7 +37,7 @@ interface Input {
   itemIds: string
   itemType: ItemType
   key: string
-  layout: LayoutType
+  layout: string
   name: string
   ownerType: OwnerType
   ownerId: string
@@ -98,7 +97,7 @@ export const updateOrderedSetMutation = mutationWithClientMutationId<
     },
     itemType: { type: GraphQLString },
     key: { type: GraphQLString },
-    layout: { type: GraphQLString },
+    layout: { type: OrderedSetLayoutsEnum },
     name: { type: GraphQLString },
     ownerId: { type: GraphQLString },
     ownerType: { type: GraphQLString },


### PR DESCRIPTION
This PR updates the `OrderedSet` create and update mutations to use the  `OrderedSetLayoutEnum` ([here](https://github.com/artsy/metaphysics/blob/main/src/schema/v2/OrderedSet/OrderedSetLayoutsEnum.ts)) for the `layout` input. 

[PLATFORM-4981]