### PR TITLE
fix: add set loader to gravity with authentication

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -547,6 +547,7 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    setLoader: gravityLoader((id) => `set/${id}`),
     setsLoader: gravityLoader("sets", {}, { headers: true }),
     showLoader: gravityLoader((id) => `show/${id}`),
     submitArtworkInquiryRequestLoader: gravityLoader(


### PR DESCRIPTION
This PR fixes the issue spotted in [sets/features QA](https://www.notion.so/artsy/QA-Forque-Sets-Features-Manager-3d25adcb9fd9460cb5aba22aee2e36c6), which spotted that unpublished sets were being returned as `null` when a user navigated to `sets/:id` with a `403 - Forbidden` error. This fixes this by adding the`setLoader` to `loaders_with_authentication/gravity.ts`. 