### PR TITLE
chore: thread argument through so a set owner can be unset

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17445,6 +17445,7 @@ input UpdateOrderedSetMutationInput {
   ownerId: String
   ownerType: String
   published: Boolean
+  unsetOwner: Boolean
 }
 
 type UpdateOrderedSetMutationPayload {

--- a/src/schema/v2/OrderedSet/updateOrderedSetMutation.ts
+++ b/src/schema/v2/OrderedSet/updateOrderedSetMutation.ts
@@ -42,6 +42,7 @@ interface Input {
   ownerType: OwnerType
   ownerId: string
   published: boolean
+  unsetOwner: boolean
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
@@ -102,6 +103,7 @@ export const updateOrderedSetMutation = mutationWithClientMutationId<
     ownerId: { type: GraphQLString },
     ownerType: { type: GraphQLString },
     published: { type: GraphQLBoolean },
+    unsetOwner: { type: GraphQLBoolean },
   },
   outputFields: {
     orderedSetOrError: {
@@ -124,6 +126,7 @@ export const updateOrderedSetMutation = mutationWithClientMutationId<
       ownerType,
       published,
       ownerId,
+      unsetOwner,
     },
     { updateSetLoader }
   ) => {
@@ -146,6 +149,7 @@ export const updateOrderedSetMutation = mutationWithClientMutationId<
         owner_id: ownerId,
         owner_type: ownerType,
         published,
+        unset_owner: unsetOwner,
       })
     } catch (error) {
       const formattedErr = formatGravityError(error)


### PR DESCRIPTION
Needed to allow explicit unsetting of an owner from an existing set.