### PR TITLE
feat: newWorksFromGalleriesYouFollow artworks connection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11271,6 +11271,14 @@ type Me implements Node {
     last: Int
     page: Int
   ): ArtworkConnection
+
+  # A list of artworks from galleries the user follows.
+  newWorksFromGalleriesYouFollowConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
   orders(
     after: String
     before: String

--- a/src/schema/v2/me/__tests__/newWorksFromGalleriesYouFollow.test.ts
+++ b/src/schema/v2/me/__tests__/newWorksFromGalleriesYouFollow.test.ts
@@ -1,0 +1,113 @@
+/* eslint-disable promise/always-return */
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import me from ".."
+
+jest.mock("node-fetch", () => jest.fn())
+
+describe("NewWorksFromGalleriesYouFollow", () => {
+  let context
+  beforeEach(() => {
+    const me = {}
+    const artworks = [
+      { id: "percy", title: "Percy the Cat" },
+      { id: "matt", title: "Matt the Person" },
+      { id: "paul", title: "Paul the snail" },
+      { id: "paula", title: "Paula the butterfly" },
+    ]
+    context = {
+      meLoader: async () => me,
+      followedProfilesArtworksLoader: async () => ({
+        body: artworks,
+        headers: { "x-total-count": 4 },
+      }),
+    }
+  })
+
+  it("returns an artwork connection", async () => {
+    const query = gql`
+      {
+        me {
+          newWorksFromGalleriesYouFollowConnection(first: 2) {
+            edges {
+              node {
+                slug
+                title
+              }
+            }
+            pageInfo {
+              hasNextPage
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runAuthenticatedQuery(query, context)
+    const newWorksFromGalleriesYouFollow = data!.me
+      .newWorksFromGalleriesYouFollowConnection
+
+    expect(newWorksFromGalleriesYouFollow).toMatchInlineSnapshot(`
+      Object {
+        "edges": Array [
+          Object {
+            "node": Object {
+              "slug": "percy",
+              "title": "Percy the Cat",
+            },
+          },
+          Object {
+            "node": Object {
+              "slug": "matt",
+              "title": "Matt the Person",
+            },
+          },
+        ],
+        "pageInfo": Object {
+          "hasNextPage": true,
+        },
+      }
+    `)
+  })
+
+  it("can return an empty connection", async () => {
+    const query = gql`
+      {
+        me {
+          newWorksFromGalleriesYouFollowConnection(first: 1) {
+            edges {
+              node {
+                id
+                title
+              }
+            }
+            pageInfo {
+              hasNextPage
+            }
+          }
+        }
+      }
+    `
+    context = {
+      meLoader: async () => me,
+      followedProfilesArtworksLoader: async () => ({
+        body: [],
+        headers: { "x-total-count": 4 },
+      }),
+    }
+
+    const data = await runAuthenticatedQuery(query, context)
+    const newWorksFromGalleriesYouFollow = data!.me
+      .newWorksFromGalleriesYouFollowConnection
+
+    expect(newWorksFromGalleriesYouFollow).toMatchInlineSnapshot(`
+      Object {
+        "edges": Array [],
+        "pageInfo": Object {
+          "hasNextPage": true,
+        },
+      }
+    `)
+    expect.assertions(1)
+  })
+})

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -11,12 +11,22 @@ import {
 } from "graphql"
 import { includesFieldsOtherThanSelectionSet } from "lib/hasFieldSelection"
 import { StaticPathLoader } from "lib/loaders/api/loader_interface"
+import moment from "moment"
+import Conversation from "schema/v2/conversation"
+import Conversations from "schema/v2/conversation/conversations"
+import Invoice from "schema/v2/conversation/invoice"
 import date from "schema/v2/fields/date"
 import initials from "schema/v2/fields/initials"
 import { IDFields, NodeInterface } from "schema/v2/object_identification"
 import { ResolverContext } from "types/graphql"
+import { CollectorProfile } from "../CollectorProfile/collectorProfile"
+import {
+  IdentityVerification,
+  PendingIdentityVerification,
+} from "../identityVerification"
 import Image from "../image"
 import { PhoneNumber } from "../phoneNumber"
+import { quiz } from "../quiz"
 import { SaleArtworksConnectionField } from "../sale_artworks"
 import { ArtistRecommendations } from "./artistRecommendations"
 import { ArtworkRecommendations } from "./artworkRecommendations"
@@ -28,10 +38,8 @@ import Bidders from "./bidders"
 import { BidderPosition } from "./bidder_position"
 import BidderPositions from "./bidder_positions"
 import BidderStatus from "./bidder_status"
-import { CollectorProfile } from "../CollectorProfile/collectorProfile"
-import Conversation from "schema/v2/conversation"
-import Invoice from "schema/v2/conversation/invoice"
-import Conversations from "schema/v2/conversation/conversations"
+import { Collection } from "./collection"
+import { CollectionsConnection } from "./collectionsConnection"
 import { CreditCards } from "./credit_cards"
 import { followedProfiles } from "./followedProfiles"
 import FollowedArtists from "./followed_artists"
@@ -40,10 +48,6 @@ import FollowedFairs from "./followed_fairs"
 import FollowedGalleries from "./followed_galleries"
 import FollowedGenes from "./followed_genes"
 import FollowedShows from "./followed_shows"
-import {
-  IdentityVerification,
-  PendingIdentityVerification,
-} from "../identityVerification"
 import LotStanding from "./lot_standing"
 import LotStandings from "./lot_standings"
 import { MyBids } from "./myBids"
@@ -52,16 +56,13 @@ import MyCollectionAuctionResults from "./myCollectionAuctionResults"
 import { MyCollectionInfo } from "./myCollectionInfo"
 import { myLocationType } from "./myLocation"
 import { NewWorksByInterestingArtists } from "./newWorksByInterestingArtists"
+import { newWorksFromGalleriesYouFollow } from "./newWorksFromGalleriesYouFollow"
 import { ManagedPartners } from "./partners"
 import { RecentlyViewedArtworks } from "./recentlyViewedArtworks"
 import { SaleRegistrationConnection } from "./sale_registrations"
 import { COLLECTION_ID, SavedArtworks } from "./savedArtworks"
 import { ShowsByFollowedArtists } from "./showsByFollowedArtists"
 import { WatchedLotConnection } from "./watchedLotConnection"
-import { quiz } from "../quiz"
-import moment from "moment"
-import { Collection } from "./collection"
-import { CollectionsConnection } from "./collectionsConnection"
 
 /**
  * @deprecated: Please use the CollectorProfile type instead of adding fields to me directly.
@@ -442,6 +443,7 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
       resolve: ({ recently_viewed_artwork_ids }) => recently_viewed_artwork_ids,
     },
     recentlyViewedArtworksConnection: RecentlyViewedArtworks,
+    newWorksFromGalleriesYouFollowConnection: newWorksFromGalleriesYouFollow,
     saleRegistrationsConnection: SaleRegistrationConnection,
     shareFollows: {
       type: new GraphQLNonNull(GraphQLBoolean),

--- a/src/schema/v2/me/newWorksFromGalleriesYouFollow.ts
+++ b/src/schema/v2/me/newWorksFromGalleriesYouFollow.ts
@@ -1,0 +1,46 @@
+import { GraphQLFieldConfig } from "graphql"
+import { connectionFromArraySlice } from "graphql-relay"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { pageable } from "relay-cursor-paging"
+import { artworkConnection } from "schema/v2/artwork"
+import { ResolverContext } from "types/graphql"
+import { createPageCursors } from "../fields/pagination"
+
+export const newWorksFromGalleriesYouFollow: GraphQLFieldConfig<
+  {},
+  ResolverContext
+> = {
+  type: artworkConnection.connectionType,
+  args: pageable({}),
+  description: "A list of artworks from galleries the user follows.",
+  resolve: async ({}, args, { followedProfilesArtworksLoader }) => {
+    if (!followedProfilesArtworksLoader) return null
+
+    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+
+    const { body: artworks, headers } = await followedProfilesArtworksLoader({
+      size,
+      offset,
+    })
+
+    const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+    const connection = connectionFromArraySlice(artworks, args, {
+      arrayLength: totalCount,
+      sliceStart: offset,
+    })
+
+    const totalPages = Math.ceil(totalCount / size)
+
+    return {
+      totalCount,
+      pageCursors: createPageCursors({ ...args, page, size }, totalCount),
+      ...connection,
+      pageInfo: {
+        ...connection.pageInfo,
+        hasPreviousPage: page > 1,
+        hasNextPage: page < totalPages,
+      },
+    }
+  },
+}


### PR DESCRIPTION
Addresses [CX-3411]

## Description

Introduce new `newWorksFromGalleriesYouFollow` artworks connection under `me`.


### GraphQL Query

```graphql
{
  me {
    newWorksFromGalleriesYouFollowConnection(
      first: 20
    ) {
      pageInfo {
        endCursor
        hasNextPage
        hasPreviousPage
      }
      edges {
        cursor
        node {
          title
        }
      }
    }
  }
}

```


[CX-3411]: https://artsyproduct.atlassian.net/browse/CX-3411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ