### PR TITLE
feat: SimilarToRecentlyViewed connection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11403,6 +11403,14 @@ type Me implements Node {
     # Filter shows by chronological event status
     status: EventStatus
   ): ShowConnection
+
+  # A list of the current user’s recently viewed artworks.
+  similarToRecentlyViewedConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
   type: String
 
   # The count of conversations with unread messages.

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11404,7 +11404,7 @@ type Me implements Node {
     status: EventStatus
   ): ShowConnection
 
-  # A list of the current user’s recently viewed artworks.
+  # A list of artworks similar to recently viewed artworks.
   similarToRecentlyViewedConnection(
     after: String
     before: String

--- a/src/schema/v2/me/__tests__/similarToRecentlyViewed.test.ts
+++ b/src/schema/v2/me/__tests__/similarToRecentlyViewed.test.ts
@@ -1,0 +1,103 @@
+/* eslint-disable promise/always-return */
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+jest.mock("node-fetch", () => jest.fn())
+import fetch from "node-fetch"
+
+describe("SimilarToRecentlyViewed", () => {
+  let context
+  beforeEach(() => {
+    const me = {
+      recently_viewed_artwork_ids: ["percy", "matt", "paul"],
+    }
+    const artworks = [
+      { id: "percy", title: "Percy the Cat" },
+      { id: "matt", title: "Matt the Person" },
+      { id: "paul", title: "Paul the snail" },
+      { id: "paula", title: "Paula the butterfly" },
+    ]
+    context = {
+      meLoader: async () => me,
+      similarArtworksLoader: async () => artworks,
+      recordArtworkViewLoader: jest.fn(async () => me),
+    }
+  })
+
+  it("returns an artwork connection", async () => {
+    const query = gql`
+      {
+        me {
+          similarToRecentlyViewedConnection(first: 2) {
+            edges {
+              node {
+                slug
+                title
+              }
+            }
+            pageInfo {
+              hasNextPage
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runAuthenticatedQuery(query, context)
+    const similarToRecentlyViewed = data!.me.similarToRecentlyViewedConnection
+
+    expect(similarToRecentlyViewed).toMatchInlineSnapshot(`
+      Object {
+        "edges": Array [
+          Object {
+            "node": Object {
+              "slug": "percy",
+              "title": "Percy the Cat",
+            },
+          },
+          Object {
+            "node": Object {
+              "slug": "matt",
+              "title": "Matt the Person",
+            },
+          },
+        ],
+        "pageInfo": Object {
+          "hasNextPage": true,
+        },
+      }
+    `)
+  })
+
+  it("can return an empty connection", async () => {
+    const query = gql`
+      {
+        me {
+          similarToRecentlyViewedConnection(first: 1) {
+            edges {
+              node {
+                id
+                title
+              }
+            }
+            pageInfo {
+              hasNextPage
+            }
+          }
+        }
+      }
+    `
+    context.similarArtworksLoader = async () => []
+
+    const data = await runAuthenticatedQuery(query, context)
+    const similarToRecentlyViewed = data!.me.similarToRecentlyViewedConnection
+
+    expect(similarToRecentlyViewed).toEqual({
+      edges: [],
+      pageInfo: {
+        hasNextPage: false,
+      },
+    })
+    expect.assertions(1)
+  })
+})

--- a/src/schema/v2/me/__tests__/similarToRecentlyViewed.test.ts
+++ b/src/schema/v2/me/__tests__/similarToRecentlyViewed.test.ts
@@ -3,7 +3,6 @@ import { runAuthenticatedQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
 
 jest.mock("node-fetch", () => jest.fn())
-import fetch from "node-fetch"
 
 describe("SimilarToRecentlyViewed", () => {
   let context

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -62,6 +62,7 @@ import { RecentlyViewedArtworks } from "./recentlyViewedArtworks"
 import { SaleRegistrationConnection } from "./sale_registrations"
 import { COLLECTION_ID, SavedArtworks } from "./savedArtworks"
 import { ShowsByFollowedArtists } from "./showsByFollowedArtists"
+import { SimilarToRecentlyViewed } from "./similarToRecentlyViewed"
 import { WatchedLotConnection } from "./watchedLotConnection"
 
 /**
@@ -451,6 +452,7 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
         return !!share_follows
       },
     },
+    similarToRecentlyViewedConnection: SimilarToRecentlyViewed,
     type: {
       type: GraphQLString,
     },

--- a/src/schema/v2/me/similarToRecentlyViewed.ts
+++ b/src/schema/v2/me/similarToRecentlyViewed.ts
@@ -25,6 +25,7 @@ export const SimilarToRecentlyViewed: GraphQLFieldConfig<
     const artworks = await similarArtworksLoader({
       artwork_id: recentlyViewedIds,
       for_sale: true,
+      size: 50,
     })
 
     const totalCount = artworks.length

--- a/src/schema/v2/me/similarToRecentlyViewed.ts
+++ b/src/schema/v2/me/similarToRecentlyViewed.ts
@@ -1,0 +1,52 @@
+import { GraphQLFieldConfig } from "graphql"
+import { connectionFromArraySlice } from "graphql-relay"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { pageable } from "relay-cursor-paging"
+import { artworkConnection } from "schema/v2/artwork"
+import { ResolverContext } from "types/graphql"
+import { createPageCursors } from "../fields/pagination"
+
+export const SimilarToRecentlyViewed: GraphQLFieldConfig<
+  { recently_viewed_artwork_ids: string[] },
+  ResolverContext
+> = {
+  type: artworkConnection.connectionType,
+  args: pageable({}),
+  description: "A list of the current user’s recently viewed artworks.",
+  resolve: async (
+    { recently_viewed_artwork_ids },
+    args,
+    { similarArtworksLoader }
+  ) => {
+    const recentlyViewedIds = recently_viewed_artwork_ids.slice(0, 7)
+
+    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+
+    const artworks = await similarArtworksLoader({
+      artwork_id: recentlyViewedIds,
+      for_sale: true,
+    })
+
+    const totalCount = artworks.length
+
+    const pageArtworks = artworks.slice(offset, offset + size)
+
+    const connection = connectionFromArraySlice(pageArtworks, args, {
+      arrayLength: totalCount,
+      sliceStart: offset,
+    })
+
+    const totalPages = Math.ceil(totalCount / size)
+
+    return {
+      totalCount,
+      pageCursors: createPageCursors({ ...args, page, size }, totalCount),
+      ...connection,
+      pageInfo: {
+        ...connection.pageInfo,
+        hasPreviousPage: page > 1,
+        hasNextPage: page < totalPages,
+      },
+    }
+  },
+}

--- a/src/schema/v2/me/similarToRecentlyViewed.ts
+++ b/src/schema/v2/me/similarToRecentlyViewed.ts
@@ -12,7 +12,7 @@ export const SimilarToRecentlyViewed: GraphQLFieldConfig<
 > = {
   type: artworkConnection.connectionType,
   args: pageable({}),
-  description: "A list of the current user’s recently viewed artworks.",
+  description: "A list of artworks similar to recently viewed artworks.",
   resolve: async (
     { recently_viewed_artwork_ids },
     args,


### PR DESCRIPTION
Addresses [CX-3411]

### Description:

This PR introduces the SimilarToRecentlyViewed connection under `me`.

### GraphQL Query:

```graphql
{
  me {
    similarToRecentlyViewedConnection(
      first: 50 ,
    ) {
      pageInfo {
        endCursor
        hasNextPage
        hasPreviousPage
      }
      edges {
        cursor
        node {
          title
        }
      }
    }
  }
}
```

[CX-3411]: https://artsyproduct.atlassian.net/browse/CX-3411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ