### PR TITLE
fix: Only load artworks for sale for newWorksFromGalleriesYouFollow

### DIFF
--- a/src/schema/v2/me/newWorksFromGalleriesYouFollow.ts
+++ b/src/schema/v2/me/newWorksFromGalleriesYouFollow.ts
@@ -21,6 +21,7 @@ export const newWorksFromGalleriesYouFollow: GraphQLFieldConfig<
     const { body: artworks, headers } = await followedProfilesArtworksLoader({
       size,
       offset,
+      for_sale: true,
     })
 
     const totalCount = parseInt(headers["x-total-count"] || "0", 10)


### PR DESCRIPTION

## Description

Only load artworks for sale for newWorksFromGalleriesYouFollow (we do the same on the home screen module resolver).