### PR TITLE
fix: Change ShowsByFollowedArtists default sorting to created_at desc

### DIFF
--- a/src/schema/v2/me/showsByFollowedArtists.ts
+++ b/src/schema/v2/me/showsByFollowedArtists.ts
@@ -14,6 +14,7 @@ export const ShowsByFollowedArtists: GraphQLFieldConfig<
   args: pageable({
     sort: {
       type: ShowSorts,
+      defaultValue: "-created_at",
     },
     status: {
       type: EventStatus.type,
@@ -42,6 +43,7 @@ export const ShowsByFollowedArtists: GraphQLFieldConfig<
 
     const count = parseInt(headers["x-total-count"] || "0", 10)
 
+    debugger
     return {
       totalCount: count,
       ...connectionFromArraySlice(shows, options, {

--- a/src/schema/v2/me/showsByFollowedArtists.ts
+++ b/src/schema/v2/me/showsByFollowedArtists.ts
@@ -43,7 +43,6 @@ export const ShowsByFollowedArtists: GraphQLFieldConfig<
 
     const count = parseInt(headers["x-total-count"] || "0", 10)
 
-    debugger
     return {
       totalCount: count,
       ...connectionFromArraySlice(shows, options, {


### PR DESCRIPTION
Addresses [CX-3475]

## Description

Change ShowsByFollowedArtists default sorting to `-created_at` to show the most recently published shows first. Before the sorting defaulted to [start_at](https://github.com/artsy/gravity/blob/main/app/api/v1/me_follow_shows_endpoint.rb#L36)

[CX-3475]: https://artsyproduct.atlassian.net/browse/CX-3475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ