### PR TITLE
chore(PX-5026): Remove references to artwork availability_hidden

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -1134,21 +1134,6 @@ describe("Artwork type", () => {
       })
     })
 
-    it("returns null if work is marked with availability_hidden", () => {
-      artwork.sale_message = "for sale"
-      artwork.availability = "on loan"
-      artwork.availability_hidden = true
-
-      return runQuery(query, context).then((data) => {
-        expect(data).toEqual({
-          artwork: {
-            slug: "richard-prince-untitled-portrait",
-            saleMessage: null,
-          },
-        })
-      })
-    })
-
     it("returns Permanent Collection if work is part of permanent collection", () => {
       artwork.sale_message = "for sale"
       artwork.availability = "permanent collection"
@@ -1393,20 +1378,6 @@ describe("Artwork type", () => {
             slug: "richard-prince-untitled-portrait",
             contactMessage:
               "Hello, I am interested in placing a bid on this work. Please send me more information.", // eslint-disable-line max-len
-          },
-        })
-      })
-    })
-
-    it("returns null if work is marked with availability_hidden", () => {
-      artwork.availability = "sold"
-      artwork.availability_hidden = true
-
-      return runQuery(query, context).then((data) => {
-        expect(data).toEqual({
-          artwork: {
-            slug: "richard-prince-untitled-portrait",
-            contactMessage: null,
           },
         })
       })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -463,15 +463,12 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       contactMessage: {
         type: GraphQLString,
         description: "Pre-filled inquiry text",
-        resolve: ({ partner, availability_hidden, availability }) => {
+        resolve: ({ partner, availability }) => {
           if (partner && partner.type === "Auction") {
             return [
               "Hello, I am interested in placing a bid on this work.",
               "Please send me more information.",
             ].join(" ")
-          }
-          if (availability_hidden) {
-            return null
           }
           if (availability === "sold" || availability === "on loan") {
             return [
@@ -1361,12 +1358,11 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({
           sale_message,
           availability,
-          availability_hidden,
           price_cents,
           price_currency,
         }) => {
-          // Don't display anything if availability is hidden, or artwork is not for sale.
-          if (availability_hidden || availability === "not for sale") {
+          // Don't display anything if artwork is not for sale.
+          if (availability === "not for sale") {
             return null
           }
 

--- a/src/schema/v2/edition_set.ts
+++ b/src/schema/v2/edition_set.ts
@@ -88,12 +88,7 @@ export const EditionSetType = new GraphQLObjectType<any, ResolverContext>({
     },
     saleMessage: {
       type: GraphQLString,
-      resolve: ({ availability, availability_hidden, price, forsale }) => {
-        // Don't display anything if availability is hidden.
-        if (availability_hidden) {
-          return null
-        }
-
+      resolve: ({ availability, price, forsale }) => {
         // If it's a supported availability, just return it (capitalized).
         if (includes(EditionSetAvailabilities, availability)) {
           return capitalizeFirstCharacter(availability)

--- a/src/schema/v2/me/__tests__/newWorksByInterestingArtists.test.ts
+++ b/src/schema/v2/me/__tests__/newWorksByInterestingArtists.test.ts
@@ -227,7 +227,6 @@ const mockArtworksResponse = [
     price: "",
     series: "",
     availability: "sold",
-    availability_hidden: false,
     ecommerce: false,
     offer: false,
     tags: ["Pumpkin"],

--- a/src/test/fixtures/gravity/order.json
+++ b/src/test/fixtures/gravity/order.json
@@ -141,7 +141,6 @@
         },
         "price": "$2,000",
         "availability": "sold",
-        "availability_hidden": false,
         "ecommerce": false,
         "collecting_institution": "",
         "blurb": "",
@@ -172,8 +171,7 @@
         },
         "editions": "Edition 8/10",
         "display_price_currency": "USD (United States Dollar)",
-        "availability": "for sale",
-        "availability_hidden": false
+        "availability": "for sale"
       },
       "price_cents": 200000,
       "tax_cents": 0,

--- a/src/types/runtime/gravity/Artwork.ts
+++ b/src/types/runtime/gravity/Artwork.ts
@@ -23,7 +23,6 @@ export const Artwork = Record({
   attribution_class: String.Or(Null),
   artist: EmbeddedArtist.Or(Null),
   artists: Array(EmbeddedArtist),
-  availability_hidden: Boolean,
   availability: String,
   blurb: String,
   can_share_image: Boolean,

--- a/src/types/runtime/gravity/EditionSet.ts
+++ b/src/types/runtime/gravity/EditionSet.ts
@@ -14,7 +14,6 @@ export const EditionSet = Record({
   editions: String,
   display_price_currency: String,
   availability: String,
-  availability_hidden: Boolean,
 })
 
 export type EditionSet = Static<typeof EditionSet>


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/PX-5026

Removing usage of deprecated concept of `availability_hidden` for artworks and edition sets