### PR TITLE
Feat(CX-3410): Introduce optional recipient_email to ConsignmentInquiryMutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5809,6 +5809,9 @@ type ConsignmentInquiry {
   # Phone number of the inquirer
   phoneNumber: String
 
+  # an optional Collector services team memeber email who was sent the Inquiry
+  recipientEmail: String
+
   # gravity user id if user is logged in
   userId: String
 }
@@ -7159,6 +7162,7 @@ input CreateConsignmentInquiryMutationInput {
   message: String!
   name: String!
   phoneNumber: String
+  recipientEmail: String
   userId: String
 }
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5809,7 +5809,7 @@ type ConsignmentInquiry {
   # Phone number of the inquirer
   phoneNumber: String
 
-  # an optional Collector services team memeber email who was sent the Inquiry
+  # An optional email from a member of the Collector Services team to whom the request was sent
   recipientEmail: String
 
   # gravity user id if user is logged in

--- a/src/schema/v2/consignments/createConsignmentInquiryMutation.ts
+++ b/src/schema/v2/consignments/createConsignmentInquiryMutation.ts
@@ -32,7 +32,7 @@ const ConsignmentInquiryType = new GraphQLObjectType<any, ResolverContext>({
     recipientEmail: {
       type: GraphQLString,
       description:
-        "an optional Collector services team memeber email who was sent the Inquiry",
+        "An optional email from a member of the Collector Services team to whom the request was sent",
     },
     name: {
       type: new GraphQLNonNull(GraphQLString),

--- a/src/schema/v2/consignments/createConsignmentInquiryMutation.ts
+++ b/src/schema/v2/consignments/createConsignmentInquiryMutation.ts
@@ -29,6 +29,11 @@ const ConsignmentInquiryType = new GraphQLObjectType<any, ResolverContext>({
       type: new GraphQLNonNull(GraphQLString),
       description: "Email of inquirer",
     },
+    recipientEmail: {
+      type: GraphQLString,
+      description:
+        "an optional Collector services team memeber email who was sent the Inquiry",
+    },
     name: {
       type: new GraphQLNonNull(GraphQLString),
       description: "Name of the inquirer",
@@ -102,6 +107,9 @@ export const createConsignmentInquiryMutation = mutationWithClientMutationId<
     email: {
       type: new GraphQLNonNull(GraphQLString),
     },
+    recipientEmail: {
+      type: GraphQLString,
+    },
     message: {
       type: new GraphQLNonNull(GraphQLString),
     },
@@ -116,7 +124,7 @@ export const createConsignmentInquiryMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: (
-    { name, email, userId, phoneNumber, message },
+    { name, email, recipientEmail, userId, phoneNumber, message },
     { createConsignmentInquiryLoader }
   ) => {
     if (!createConsignmentInquiryLoader) {
@@ -126,6 +134,7 @@ export const createConsignmentInquiryMutation = mutationWithClientMutationId<
     return createConsignmentInquiryLoader({
       name,
       email,
+      recipient_email: recipientEmail,
       gravity_user_id: userId,
       message,
       phone_number: phoneNumber,


### PR DESCRIPTION

co-authored-by: Daria Kozlova <daria.kozlova@artsymail.com>

### Description
This PR enables optionally specify specify recipient_email in the ConsignmentInquiryMutation.
The recipient_email is the email of any of the collector services team member for whom an Inquiry is specific for.