### PR TITLE
feat: expose buyerProfile properties directly on orders, rather than via users

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3924,6 +3924,7 @@ type CommerceBuyOrder implements CommerceOrder {
   buyerDetails: OrderParty
   buyerPhoneNumber: String
   buyerPhoneNumberCountryCode: String
+  buyerProfile: CollectorProfileType
   buyerTotal(
     decimal: String = "."
 
@@ -4658,6 +4659,7 @@ type CommerceOfferOrder implements CommerceOrder {
   buyerDetails: OrderParty
   buyerPhoneNumber: String
   buyerPhoneNumberCountryCode: String
+  buyerProfile: CollectorProfileType
   buyerTotal(
     decimal: String = "."
 
@@ -4892,6 +4894,7 @@ interface CommerceOrder {
   buyerDetails: OrderParty
   buyerPhoneNumber: String
   buyerPhoneNumberCountryCode: String
+  buyerProfile: CollectorProfileType
   buyerTotal(
     decimal: String = "."
 
@@ -11069,7 +11072,7 @@ type Me implements Node {
   ): CollectionsConnection
   collectorLevel: Int
 
-  # A collector profile.
+  # Current user's collector profile.
   collectorProfile: CollectorProfileType
 
   # A conversation, usually between a user and a partner
@@ -14163,6 +14166,9 @@ type Query {
     # A slug for the city, conforming to Gravity's city slug naming conventions
     slug: String
   ): City
+
+  # A collector profile.
+  collectorProfile(userID: String): CollectorProfileType
 
   # Find balance of an account associated with a setup intent
   commerceBankAccountBalance(
@@ -18547,6 +18553,9 @@ type Viewer {
     # A slug for the city, conforming to Gravity's city slug naming conventions
     slug: String
   ): City
+
+  # A collector profile.
+  collectorProfile(userID: String): CollectorProfileType
 
   # A conversation, usually between a user and a partner
   conversation(

--- a/src/lib/stitching/exchange/__tests__/stitching.test.ts
+++ b/src/lib/stitching/exchange/__tests__/stitching.test.ts
@@ -19,7 +19,7 @@ it("extends the Order objects", async () => {
       mergedSchema
     )
 
-    expect(orderableFields).toContain("buyerDetails")
+    expect(orderableFields).toContain("buyerProfile")
     expect(orderableFields).toContain("sellerDetails")
     expect(orderableFields).toContain("creditCard")
     expect(orderableFields).toContain("paymentMethodDetails")
@@ -161,6 +161,23 @@ it("delegates to the local schema for an LineItem's artwork", async () => {
     args: { id: "ARTWORK-ID" },
     fieldName: "artwork",
 
+    operation: "query",
+    schema: expect.anything(),
+    context: expect.anything(),
+    info: expect.anything(),
+  })
+})
+
+it("delegates to the local schema for a CommerceOrder's buyerProfile", async () => {
+  const { resolvers } = await getExchangeStitchedSchema()
+  const buyerProfileResolver = resolvers.CommerceBuyOrder.buyerProfile.resolve
+  const mergeInfo = { delegateToSchema: jest.fn() }
+
+  buyerProfileResolver({ buyer: { id: "userid" } }, {}, {}, { mergeInfo })
+
+  expect(mergeInfo.delegateToSchema).toHaveBeenCalledWith({
+    args: { userID: "userid" },
+    fieldName: "collectorProfile",
     operation: "query",
     schema: expect.anything(),
     context: expect.anything(),

--- a/src/lib/stitching/exchange/v2/stitching.ts
+++ b/src/lib/stitching/exchange/v2/stitching.ts
@@ -235,15 +235,27 @@ export const exchangeStitchingEnvironment = ({
       }))
     )
 
-  const profileResolver = async (parent, _args, context, info) => {
-    return await info.mergeInfo.delegateToSchema({
-      schema: localSchema,
-      operation: "query",
-      fieldName: "collectorProfile",
-      args: { userID: parent.buyer.id },
-      context,
-      info,
-    })
+  const buyerProfileResolver = {
+    fragment: gql`
+        ... on CommerceOrder {
+          buyer {
+            __typename
+            ... on CommerceUser {
+              id
+            }
+          }
+        }
+        `,
+    resolve: async (parent, _args, context, info) => {
+      return await info.mergeInfo.delegateToSchema({
+        schema: localSchema,
+        operation: "query",
+        fieldName: "collectorProfile",
+        args: { userID: parent.buyer.id },
+        context,
+        info,
+      })
+    },
   }
 
   // Used to convert an array of `key: resolvers` to a single obj
@@ -392,17 +404,7 @@ export const exchangeStitchingEnvironment = ({
         // The money helper resolvers
         ...totalsResolvers("CommerceBuyOrder", orderTotals),
         buyerDetails: buyerDetailsResolver,
-        buyerProfile: {
-          fragment: gql`... on CommerceBuyOrder {
-            buyer {
-              __typename
-              ... on CommerceUser {
-                id
-              }
-            }
-          }`,
-          resolve: profileResolver,
-        },
+        buyerProfile: buyerProfileResolver,
         sellerDetails: sellerDetailsResolver,
         creditCard: creditCardResolver,
         paymentMethodDetails: paymentMethodDetailsResolver,
@@ -410,17 +412,7 @@ export const exchangeStitchingEnvironment = ({
       CommerceOfferOrder: {
         ...totalsResolvers("CommerceOfferOrder", orderTotals),
         buyerDetails: buyerDetailsResolver,
-        buyerProfile: {
-          fragment: gql`... on CommerceOfferOrder {
-            buyer {
-              __typename
-              ... on CommerceUser {
-                id
-              }
-            }
-          }`,
-          resolve: profileResolver,
-        },
+        buyerProfile: buyerProfileResolver,
         sellerDetails: sellerDetailsResolver,
         creditCard: creditCardResolver,
         paymentMethodDetails: paymentMethodDetailsResolver,

--- a/src/lib/stitching/exchange/v2/stitching.ts
+++ b/src/lib/stitching/exchange/v2/stitching.ts
@@ -235,6 +235,17 @@ export const exchangeStitchingEnvironment = ({
       }))
     )
 
+  const profileResolver = async (parent, _args, context, info) => {
+    return await info.mergeInfo.delegateToSchema({
+      schema: localSchema,
+      operation: "query",
+      fieldName: "collectorProfile",
+      args: { userID: parent.buyer.id },
+      context,
+      info,
+    })
+  }
+
   // Used to convert an array of `key: resolvers` to a single obj
   const reduceToResolvers = (arr) => arr.reduce((a, b) => ({ ...a, ...b }))
 
@@ -269,6 +280,7 @@ export const exchangeStitchingEnvironment = ({
 
     extend type CommerceBuyOrder {
       buyerDetails: OrderParty
+      buyerProfile: CollectorProfileType
       sellerDetails: OrderParty
       creditCard: CreditCard
       paymentMethodDetails: PaymentMethodUnion
@@ -279,6 +291,7 @@ export const exchangeStitchingEnvironment = ({
 
     extend type CommerceOfferOrder {
       buyerDetails: OrderParty
+      buyerProfile: CollectorProfileType
       sellerDetails: OrderParty
       creditCard: CreditCard
       paymentMethodDetails: PaymentMethodUnion
@@ -291,6 +304,7 @@ export const exchangeStitchingEnvironment = ({
 
     extend interface CommerceOrder {
       buyerDetails: OrderParty
+      buyerProfile: CollectorProfileType
       sellerDetails: OrderParty
       creditCard: CreditCard
       paymentMethodDetails: PaymentMethodUnion
@@ -378,6 +392,17 @@ export const exchangeStitchingEnvironment = ({
         // The money helper resolvers
         ...totalsResolvers("CommerceBuyOrder", orderTotals),
         buyerDetails: buyerDetailsResolver,
+        buyerProfile: {
+          fragment: gql`... on CommerceBuyOrder {
+            buyer {
+              __typename
+              ... on CommerceUser {
+                id
+              }
+            }
+          }`,
+          resolve: profileResolver,
+        },
         sellerDetails: sellerDetailsResolver,
         creditCard: creditCardResolver,
         paymentMethodDetails: paymentMethodDetailsResolver,
@@ -385,6 +410,17 @@ export const exchangeStitchingEnvironment = ({
       CommerceOfferOrder: {
         ...totalsResolvers("CommerceOfferOrder", orderTotals),
         buyerDetails: buyerDetailsResolver,
+        buyerProfile: {
+          fragment: gql`... on CommerceOfferOrder {
+            buyer {
+              __typename
+              ... on CommerceUser {
+                id
+              }
+            }
+          }`,
+          resolve: profileResolver,
+        },
         sellerDetails: sellerDetailsResolver,
         creditCard: creditCardResolver,
         paymentMethodDetails: paymentMethodDetailsResolver,

--- a/src/lib/stitching/exchange/v2/stitching.ts
+++ b/src/lib/stitching/exchange/v2/stitching.ts
@@ -239,7 +239,6 @@ export const exchangeStitchingEnvironment = ({
     fragment: gql`
         ... on CommerceOrder {
           buyer {
-            __typename
             ... on CommerceUser {
               id
             }

--- a/src/schema/v2/CollectorProfile/collectorProfile.ts
+++ b/src/schema/v2/CollectorProfile/collectorProfile.ts
@@ -138,10 +138,31 @@ export const CollectorProfileType = new GraphQLObjectType<any, ResolverContext>(
   }
 )
 
-export const CollectorProfile: GraphQLFieldConfig<void, ResolverContext> = {
+export const MeCollectorProfile: GraphQLFieldConfig<void, ResolverContext> = {
   type: CollectorProfileType,
-  description: "A collector profile.",
+  description: "Current user's collector profile.",
   resolve: (_root, _option, { meCollectorProfileLoader }) => {
     return meCollectorProfileLoader?.()
+  },
+}
+
+export const CollectorProfileForUser: GraphQLFieldConfig<
+  void,
+  ResolverContext
+> = {
+  type: CollectorProfileType,
+  description: "A collector profile.",
+  args: { userID: { type: GraphQLString! } },
+  resolve: async (_root, { userID }, { collectorProfilesLoader }) => {
+    if (!collectorProfilesLoader)
+      throw new Error(
+        "A X-Access-Token header is required to perform this action."
+      )
+
+    const { body: profiles } = await collectorProfilesLoader({
+      user_id: userID,
+    })
+
+    return profiles[0]
   },
 }

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -19,7 +19,7 @@ import date from "schema/v2/fields/date"
 import initials from "schema/v2/fields/initials"
 import { IDFields, NodeInterface } from "schema/v2/object_identification"
 import { ResolverContext } from "types/graphql"
-import { CollectorProfile } from "../CollectorProfile/collectorProfile"
+import { MeCollectorProfile } from "../CollectorProfile/collectorProfile"
 import {
   IdentityVerification,
   PendingIdentityVerification,
@@ -142,7 +142,7 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
         return collector_level
       },
     },
-    collectorProfile: CollectorProfile,
+    collectorProfile: MeCollectorProfile,
     emailConfirmed: {
       type: new GraphQLNonNull(GraphQLBoolean),
       description: "User has confirmed their email address",

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -190,6 +190,7 @@ import { UpdateFeaturedLinkMutation } from "./FeaturedLink/updateFeaturedLinkMut
 import { DeleteFeaturedLinkMutation } from "./FeaturedLink/deleteFeaturedLinkMutation"
 import { createUserSaleProfileMutation } from "./users/createUserSaleProfileMutation"
 import { MarkdownContent } from "./markdownContent"
+import { CollectorProfileForUser } from "./CollectorProfile/collectorProfile"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -238,6 +239,7 @@ const rootFields = {
   channel,
   cities,
   city: City,
+  collectorProfile: CollectorProfileForUser,
   conversation: Conversation,
   conversationsConnection: Conversations,
   creditCard: CreditCard,


### PR DESCRIPTION
**Work-in-progress**, relating to https://artsyproduct.atlassian.net/browse/PX-5448: we'd like to retire partners' usage of user APIs and instead source any buyer attributes from the "collector profile" APIs instead.

Thanks for the pair. This _almost_ works. For example, the following query successfully resolves a `buyerProfile`:

```graphql
query {
  commerceOrder(code:"690747315") {
    buyer {
      ... on CommerceUser {
        id
      }
    }
    buyerProfile {
      name
      email
    }
  }
}
```

However, if the `buyer` is not included in the query, the whole `commerceOrder` ends up being `null`. Feedback or pushes welcome.