### PR TITLE
feat: expose provenance and condition description in artwork versions

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2615,6 +2615,9 @@ type ArtworkVersion implements Node {
   # The Artwork Version attribution class
   attributionClass: AttributionClass
 
+  # Artwork condition description
+  condition_description: String
+
   # The Artwork Version formatted date
   date: String
 
@@ -2635,6 +2638,9 @@ type ArtworkVersion implements Node {
 
   # The Artwork Version medium
   medium: String
+
+  # Artwork provenance
+  provenance: String
 
   # Artwork title
   title: String

--- a/src/schema/v2/artwork_version.ts
+++ b/src/schema/v2/artwork_version.ts
@@ -84,6 +84,16 @@ export const ArtworkVersionType = new GraphQLObjectType<any, ResolverContext>({
         }
       },
     },
+
+    provenance: {
+      type: GraphQLString,
+      description: "Artwork provenance",
+    },
+
+    condition_description: {
+      type: GraphQLString,
+      description: "Artwork condition description",
+    },
   }),
 })
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/TX-1061

Following the [Gravity work](https://github.com/artsy/gravity/pull/16132/files), this exposes provenance and condition description fields in artwork versions.

Artwork version is only exposed through [stitching](https://github.com/artsy/metaphysics/blob/75106b0c6e05e1543e83a1c0f39feddf3b5965c7/src/lib/stitching/exchange/v2/stitching.ts#L265), and I still want to find a better way of testing it. This PR should unblock UI work first.