### PR TITLE
feat: allow optional identity verification emails (PRO-79)

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16165,6 +16165,9 @@ input SendIdentityVerificationEmailMutationInput {
   # The name to be used for the user undergoing identity verification
   name: String
 
+  # Whether an automated identity verification is sent or not
+  sendEmail: Boolean
+
   # The user Id for the user undergoing identity verification
   userID: String
 }

--- a/src/schema/v2/me/sendIdentityVerficationEmailMutation.ts
+++ b/src/schema/v2/me/sendIdentityVerficationEmailMutation.ts
@@ -1,4 +1,5 @@
 import {
+  GraphQLBoolean,
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
@@ -109,6 +110,10 @@ export const sendIdentityVerificationEmailMutation = mutationWithClientMutationI
         "The name to be used for the user undergoing identity verification",
       type: GraphQLString,
     },
+    sendEmail: {
+      description: "Whether an automated identity verification is sent or not",
+      type: GraphQLBoolean,
+    },
   },
   outputFields: {
     confirmationOrError: {
@@ -117,7 +122,7 @@ export const sendIdentityVerificationEmailMutation = mutationWithClientMutationI
     },
   },
   mutateAndGetPayload: async (
-    { userID, email, name },
+    { userID, email, name, sendEmail },
     { sendIdentityVerificationEmailLoader }
   ) => {
     if (!sendIdentityVerificationEmailLoader) {
@@ -129,6 +134,7 @@ export const sendIdentityVerificationEmailMutation = mutationWithClientMutationI
         user_id: userID,
         email,
         name,
+        send_email: sendEmail,
       })
 
       return response


### PR DESCRIPTION
This PR introduces `sendEmail` as a field that can be included in a mutation to request an IDV (identity verification) creation. It will instruct downstream services to not send an automated email after the IDV record has been created. Its purpose is to allow admins to send custom-made emails to collectors who need a more hands-on experience.