### PR TITLE
fix(CX-3459): Update collector profile resolvers

### DIFF
--- a/src/schema/v2/CollectorProfile/__tests__/updateCollectorProfileWithID.test.ts
+++ b/src/schema/v2/CollectorProfile/__tests__/updateCollectorProfileWithID.test.ts
@@ -52,6 +52,10 @@ describe("UpdateCollectorProfileWithID", () => {
       email: "percy@cat.com",
       self_reported_purchases: "treats",
       intents: ["buy art & design"],
+      owner: {
+        name: "Percy",
+        email: "percy@cat.com",
+      },
     }
 
     const context = {

--- a/src/schema/v2/CollectorProfile/collectorProfile.ts
+++ b/src/schema/v2/CollectorProfile/collectorProfile.ts
@@ -35,14 +35,14 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
     resolve: ({ company_website }) => company_website,
   },
   confirmedBuyerAt: date,
-  email: { type: GraphQLString },
+  email: { type: GraphQLString, resolve: ({ owner: { email } }) => email },
   institutionalAffiliations: {
     type: GraphQLString,
     resolve: ({ institutional_affiliations }) => institutional_affiliations,
   },
   intents: { type: new GraphQLList(GraphQLString) },
   loyaltyApplicantAt: date,
-  name: { type: GraphQLString },
+  name: { type: GraphQLString, resolve: ({ owner: { name } }) => name },
   privacy: { type: GraphQLString },
   professionalBuyerAppliedAt: date,
   professionalBuyerAt: date,
@@ -58,7 +58,7 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
   },
 
   // moved InquirerCollectorProfileFields here
-  location: { type: myLocationType },
+  location: { type: myLocationType, resolve: ({ owner }) => owner.location },
   artsyUserSince: dateFormatter(({ artsy_user_since }) => artsy_user_since),
   ownerID: {
     type: new GraphQLNonNull(GraphQLID),
@@ -72,7 +72,10 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
   bio: {
     type: GraphQLString,
   },
-  profession: { type: GraphQLString },
+  profession: {
+    type: GraphQLString,
+    resolve: ({ owner: { profession } }) => profession,
+  },
   otherRelevantPositions: {
     type: GraphQLString,
     description: "Collector's position with relevant institutions",

--- a/src/schema/v2/me/__tests__/collector_profile.test.js
+++ b/src/schema/v2/me/__tests__/collector_profile.test.js
@@ -35,6 +35,9 @@ describe("Me", () => {
         intents: ["buy art & design"],
         privacy: "public",
         owner: {
+          name: "Percy",
+          email: "percy@cat.com",
+          profession: "typer",
           location: {
             display: "Germany",
           },

--- a/src/schema/v2/me/__tests__/update_collector_profile.test.js
+++ b/src/schema/v2/me/__tests__/update_collector_profile.test.js
@@ -28,6 +28,10 @@ describe("UpdateCollectorProfile", () => {
         email: "percy@cat.com",
         self_reported_purchases: "treats",
         intents: ["buy art & design"],
+        owner: {
+          name: "Percy",
+          email: "percy@cat.com",
+        },
       })
     )
 

--- a/src/schema/v2/partner/__tests__/partnerInquirerCollectorProfile.test.ts
+++ b/src/schema/v2/partner/__tests__/partnerInquirerCollectorProfile.test.ts
@@ -16,6 +16,14 @@ describe("partnerInquirerCollectorProfile", () => {
     },
     profession: "Superhuman",
     bio: "I got snacks to the roof",
+    owner: {
+      name: "Some Collector",
+      location: {
+        city: "Around",
+        country: "The Globe",
+      },
+      profession: "Superhuman",
+    },
   }
 
   const context = {


### PR DESCRIPTION
This PR resolves [CX-3459]

### Description
This PR is a follow-up on artsy/gravity#16149 🔒

This PR updates the collector profile fields (`email`, `name`, `location`, `profession`) to use the `owner` property in the JSON response to eliminate the caching issue with the collector profile



[CX-3459]: https://artsyproduct.atlassian.net/browse/CX-3459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ