### PR TITLE
Revert "fix: Sort recently viewed artworks correctly"

### DIFF
--- a/src/schema/v2/home/results.ts
+++ b/src/schema/v2/home/results.ts
@@ -157,23 +157,14 @@ const moduleResults: HomePageArtworkModuleResolvers<any> = {
       })
     })
   },
-  recently_viewed_works: async ({ meLoader, artworksLoader }) => {
+  recently_viewed_works: ({ meLoader, artworksLoader }) => {
     if (!meLoader) return null
-    return meLoader().then(async ({ recently_viewed_artwork_ids }) => {
+    return meLoader().then(({ recently_viewed_artwork_ids }) => {
       if (recently_viewed_artwork_ids.length === 0) {
         return []
       }
       const ids = recently_viewed_artwork_ids.slice(0, RESULTS_SIZE)
-      const artworks = await artworksLoader({
-        ids,
-      })
-
-      // sort artworks because artworksLoader does not guarantee order
-      const orderedArtworks = recently_viewed_artwork_ids.map((id) =>
-        artworks.find((a) => a?._id === id)
-      )
-
-      return orderedArtworks
+      return artworksLoader({ ids })
     })
   },
 }

--- a/src/schema/v2/me/__tests__/recentlyViewedArtworks.test.ts
+++ b/src/schema/v2/me/__tests__/recentlyViewedArtworks.test.ts
@@ -12,10 +12,10 @@ describe("RecentlyViewedArtworks", () => {
       recently_viewed_artwork_ids: ["percy", "matt", "paul"],
     }
     const artworks = [
-      { id: "percy", title: "Percy the Cat", _id: "percy" },
-      { id: "matt", title: "Matt the Person", _id: "matt" },
-      { id: "paul", title: "Paul the snail", _id: "paul" },
-      { id: "paula", title: "Paula the butterfly", _id: "paula" },
+      { id: "percy", title: "Percy the Cat" },
+      { id: "matt", title: "Matt the Person" },
+      { id: "paul", title: "Paul the snail" },
+      { id: "paula", title: "Paula the butterfly" },
     ]
     context = {
       meLoader: async () => me,

--- a/src/schema/v2/me/recentlyViewedArtworks.ts
+++ b/src/schema/v2/me/recentlyViewedArtworks.ts
@@ -29,14 +29,9 @@ export const RecentlyViewedArtworks: GraphQLFieldConfig<
       ? await artworksLoader({ ids: pageArtworkIDs })
       : []
 
-    // sort artworks because artworksLoader does not guarantee order
-    const orderedArtworks = pageArtworkIDs.map((id) =>
-      artworks.find((a) => a?._id === id)
-    )
-
     const totalCount = recently_viewed_artwork_ids.length
 
-    const connection = connectionFromArraySlice(orderedArtworks, args, {
+    const connection = connectionFromArraySlice(artworks, args, {
       arrayLength: totalCount,
       sliceStart: offset,
     })


### PR DESCRIPTION
Reverts artsy/metaphysics#4867

Reverting rather than fixing because we should just fix this in Gravity if it's actually a problem. @mzikherman states that Gravity should be returning artworks in the order they are requested in.

That said: the reason this is causing a problem is because you'd want to just use a sort function not a map + find. Gravity might not return all the artworks, so where an ID might be missing this is returning a `null`.