### PR TITLE
fix: reverts profile loaders change

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -306,11 +306,7 @@ export default (accessToken, userID, opts) => {
       { headers: true }
     ),
     followedProfileLoader: trackedEntityLoaderFactory(
-      gravityLoader(
-        "me/follow/profiles",
-        { total_count: true },
-        { headers: true }
-      ),
+      gravityLoader("me/follow/profiles"),
       {
         paramKey: "profiles",
         trackingKey: "is_followed",


### PR DESCRIPTION
This reverts the one irrelevant change from https://github.com/artsy/metaphysics/pull/4854

I'm assuming this didn't actually intend to be committed but in the future if one ever updates loaders to return headers, you need to find every call site and update it accordingly.