### PR TITLE
fix: Keep order of arrays when passing them to data loaders

### DIFF
--- a/src/lib/__tests__/helpers.test.ts
+++ b/src/lib/__tests__/helpers.test.ts
@@ -35,7 +35,7 @@ describe("toQueryString", () => {
   it("stringifies regular arraies", () => {
     expect(
       toQueryString({ ids: [13, 27], visible: true, availability: "for sale" })
-    ).toBe("availability=for%20sale&ids%5B%5D=13&ids%5B%5D=27&visible=true")
+    ).toBe("ids%5B%5D=13&ids%5B%5D=27&visible=true&availability=for%20sale")
   })
 
   it("ignores empty arraies", () => {
@@ -47,7 +47,39 @@ describe("toQueryString", () => {
   it("stringifies [null] as an empty array", () => {
     expect(
       toQueryString({ ids: [null], visible: true, availability: "for sale" })
-    ).toBe("availability=for%20sale&ids%5B%5D=&visible=true")
+    ).toBe("ids%5B%5D=&visible=true&availability=for%20sale")
+  })
+
+  it("keeps order when request is batched", () => {
+    expect(
+      toQueryString({
+        visible: true,
+        availability: "for sale",
+        batched: true,
+      })
+    ).toBe("visible=true&availability=for%20sale&batched=true")
+  })
+
+  it("keeps order of non-empty arrays", () => {
+    expect(
+      toQueryString({
+        ids: [
+          "63f115629648b4000c707e37",
+          "63c08f8408c833000db6ef58",
+          "63ffbe494cc6f7000c920e0f",
+          "63fcbacb68aa09000bd2609e",
+          "63e67f5a70b792000b9e57c3",
+          "63f89ccae5957d000c2ed8a3",
+          "63e67f5a9e7407000bec0ec3",
+          "63f89d924cc87a000e474c6e",
+          "63f38b52380b9e000d788778",
+          "63f38510f56dbb000d16e196",
+          "63f5421caff176000c3c9c82",
+        ],
+      })
+    ).toBe(
+      "ids%5B%5D=63f115629648b4000c707e37&ids%5B%5D=63c08f8408c833000db6ef58&ids%5B%5D=63ffbe494cc6f7000c920e0f&ids%5B%5D=63fcbacb68aa09000bd2609e&ids%5B%5D=63e67f5a70b792000b9e57c3&ids%5B%5D=63f89ccae5957d000c2ed8a3&ids%5B%5D=63e67f5a9e7407000bec0ec3&ids%5B%5D=63f89d924cc87a000e474c6e&ids%5B%5D=63f38b52380b9e000d788778&ids%5B%5D=63f38510f56dbb000d16e196&ids%5B%5D=63f5421caff176000c3c9c82"
+    )
   })
 })
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -5,6 +5,7 @@ import {
   compact,
   flow,
   includes,
+  isArray,
   isEmpty,
   isObject,
   isString,
@@ -12,6 +13,7 @@ import {
   pick,
   reject,
   trim,
+  values,
 } from "lodash"
 import moment, { LocaleSpecification } from "moment"
 import { performance } from "perf_hooks"
@@ -60,13 +62,18 @@ export const truncate = (string, length, append = "…") => {
   return x.length > limit ? x.slice(0, limit) + append : x
 }
 
-export const toQueryString = (options = {}) =>
+export const toQueryString = (options = {}) => {
+  const optionsIncludeArray = values(options).some(
+    (value) => isArray(value) && !isEmpty(value)
+  )
+
   /**
-   * In the case of batched requests we want to explicitly _not_ sort the
+   * In the case of batched requests or if the params include an array
+   * we want to explicitly _not_ sort the
    * params because the order matters to dataloader
    */
   // @ts-ignore
-  options.batched
+  return options.batched || optionsIncludeArray
     ? stringify(options, {
         arrayFormat: "brackets",
       })
@@ -74,6 +81,7 @@ export const toQueryString = (options = {}) =>
         arrayFormat: "brackets",
         sort: (a, b) => a.localeCompare(b),
       })
+}
 
 export const toKey = (path, options = {}) => `${path}?${toQueryString(options)}`
 

--- a/src/schema/v2/artworksForUser/helpers.ts
+++ b/src/schema/v2/artworksForUser/helpers.ts
@@ -57,7 +57,6 @@ export const getNewForYouArtworks = async (
 
   const artworkParams = {
     availability: "for sale",
-    batched: true,
     ids: artworkIds,
     offset,
     size,

--- a/src/schema/v2/me/__tests__/artistRecommendations.test.ts
+++ b/src/schema/v2/me/__tests__/artistRecommendations.test.ts
@@ -39,14 +39,14 @@ describe("artistRecommendations", () => {
         "edges": Array [
           Object {
             "node": Object {
-              "internalID": "608a7417bdfbd1a789ba092a",
-              "slug": "1-plus-1-plus-1",
+              "internalID": "608a7416bdfbd1a789ba0911",
+              "slug": "banksy",
             },
           },
           Object {
             "node": Object {
-              "internalID": "608a7416bdfbd1a789ba0911",
-              "slug": "banksy",
+              "internalID": "608a7417bdfbd1a789ba092a",
+              "slug": "1-plus-1-plus-1",
             },
           },
         ],
@@ -70,7 +70,7 @@ describe("artistRecommendations", () => {
       `,
     })
     expect(artistsLoader).toHaveBeenCalledWith({
-      ids: ["608a7417bdfbd1a789ba092a", "608a7416bdfbd1a789ba0911"],
+      ids: ["608a7416bdfbd1a789ba0911", "608a7417bdfbd1a789ba092a"],
     })
   })
 
@@ -115,14 +115,14 @@ const mockVortexResponse = {
       edges: [
         {
           node: {
-            artistId: "608a7417bdfbd1a789ba092a",
-            score: 3.422242962512335,
+            artistId: "608a7416bdfbd1a789ba0911",
+            score: 3.2225049587839654,
           },
         },
         {
           node: {
-            artistId: "608a7416bdfbd1a789ba0911",
-            score: 3.2225049587839654,
+            artistId: "608a7417bdfbd1a789ba092a",
+            score: 3.422242962512335,
           },
         },
       ],

--- a/src/schema/v2/me/artistRecommendations.ts
+++ b/src/schema/v2/me/artistRecommendations.ts
@@ -6,7 +6,6 @@ import { createPageCursors } from "schema/v2/fields/pagination"
 import { ResolverContext } from "types/graphql"
 import gql from "lib/gql"
 import { artistConnection } from "schema/v2/artist"
-import { compact, find } from "lodash"
 
 // This limits the maximum number of artists we receive from Vortex and is related to how we implement the Connection in this resolver.
 const MAX_ARTISTS = 50
@@ -53,23 +52,13 @@ export const ArtistRecommendations: GraphQLFieldConfig<
 
     // Fetch artist details from Gravity
 
-    let artists: any = []
-
-    if (artistIds?.length) {
-      artists = (
-        await artistsLoader({
-          ids: artistIds,
-        })
-      ).body
-
-      // Apply order from Vortex result (score ASC)
-
-      artists = compact(
-        artistIds.map((artistId) => {
-          return find(artists, { _id: artistId })
-        })
-      )
-    }
+    const artists = artistIds?.length
+      ? (
+          await artistsLoader({
+            ids: artistIds,
+          })
+        ).body
+      : []
 
     const count = artists.length
 

--- a/src/schema/v2/me/artworkRecommendations.ts
+++ b/src/schema/v2/me/artworkRecommendations.ts
@@ -2,7 +2,6 @@ import { GraphQLFieldConfig, GraphQLInt } from "graphql"
 import { connectionFromArraySlice } from "graphql-relay"
 import gql from "lib/gql"
 import { convertConnectionArgsToGravityArgs, extractNodes } from "lib/helpers"
-import { compact, find } from "lodash"
 import { CursorPageable, pageable } from "relay-cursor-paging"
 import { artworkConnection } from "schema/v2/artwork"
 import { createPageCursors } from "schema/v2/fields/pagination"
@@ -58,21 +57,11 @@ export const ArtworkRecommendations: GraphQLFieldConfig<
 
     // Fetching artwork details from Gravity
 
-    let artworks: any[] = []
-
-    if (artworkIds?.length) {
-      artworks = await artworksLoader({
-        ids: pageArtworkIDs,
-      })
-
-      // Applying order from Vortex result (score ASC)
-
-      artworks = compact(
-        pageArtworkIDs.map((artworkId) => {
-          return find(artworks, { _id: artworkId })
+    const artworks = artworkIds?.length
+      ? await artworksLoader({
+          ids: pageArtworkIDs,
         })
-      )
-    }
+      : []
 
     const totalCount = artworkRecommendations.length
 

--- a/src/schema/v2/notifications/index.ts
+++ b/src/schema/v2/notifications/index.ts
@@ -101,7 +101,7 @@ export const NotificationType = new GraphQLObjectType<any, ResolverContext>({
       args: pageable(),
       resolve: async ({ object_ids: ids }, args, { artworksLoader }) => {
         const { page, size } = convertConnectionArgsToGravityArgs(args)
-        return artworksLoader({ ids, batched: true }).then((body) => {
+        return artworksLoader({ ids }).then((body) => {
           const totalCount = body.length
           return {
             totalCount,


### PR DESCRIPTION
## Description

This is an attempt to fix issues where artwork IDs passed to the artworks loader get shuffled (https://github.com/artsy/metaphysics/pull/4232, https://github.com/artsy/metaphysics/pull/4867, https://github.com/artsy/metaphysics/pull/2537). 

The root cause is that query params [are sorted to increase cache hits](https://github.com/artsy/metaphysics/blob/c9498007a41dbd9dd402f8a075ac5e867fb9439b/src/lib/helpers.ts#L75). This PR fixes the issue by preventing sorting when a non-empty array is passed as a query param (e.g. `?id[]=one&id[]=two&id[]=three`). 

