### PR TITLE
Revert "chore(NX-3485): Enable delivery pending flag to be passed as an arg to messages"

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6935,7 +6935,6 @@ type Conversation implements Node {
     after: String
     before: String
     first: Int
-    includeDeliveryPending: Boolean
     last: Int
     sort: sort
   ): MessageConnection @deprecated(reason: "Prefer messagesConnection")
@@ -6945,7 +6944,6 @@ type Conversation implements Node {
     after: String
     before: String
     first: Int
-    includeDeliveryPending: Boolean
     last: Int
     sort: sort
   ): MessageConnection

--- a/src/schema/v2/conversation/__tests__/message.test.js
+++ b/src/schema/v2/conversation/__tests__/message.test.js
@@ -64,7 +64,7 @@ describe("Me", () => {
                 from {
                   email
                 }
-                messagesConnection(first: 10, includeDeliveryPending: true) {
+                messagesConnection(first: 10) {
                   totalCount
                   edges {
                     node {

--- a/src/schema/v2/conversation/index.ts
+++ b/src/schema/v2/conversation/index.ts
@@ -193,9 +193,6 @@ const messagesConnection = {
   type: MessageConnection,
   description: "A connection for all messages in a single conversation",
   args: pageable({
-    includeDeliveryPending: {
-      type: GraphQLBoolean,
-    },
     sort: {
       type: new GraphQLEnumType({
         name: "sort",
@@ -223,7 +220,6 @@ const messagesConnection = {
       conversation_id: id,
       "expand[]": "deliveries",
       sort: options.sort || "asc",
-      include_delivery_pending: options.includeDeliveryPending || false,
     }).then(({ total_count, message_details }) => {
       // Inject the convesation initiator's email into each message payload
       // so we can tell if the user sent a particular message.


### PR DESCRIPTION
Reverts artsy/metaphysics#4875 because of issues observed in Force conversations after deploying artsy/impulse#900 (reverted in artsy/impulse#902).