### PR TITLE
feat: Update artist insight label copy GRO-1619

### DIFF
--- a/src/schema/v2/artist/helpers.ts
+++ b/src/schema/v2/artist/helpers.ts
@@ -71,17 +71,17 @@ export const ARTIST_INSIGHT_MAPPING = {
   RESIDENCIES: {
     getDescription: () => "Established artist residencies.",
     getEntities: (artist) => splitEntities(artist.residencies),
-    getLabel: () => "Residencies",
+    getLabel: () => "Participated in a notable artist residency",
   },
   PRIVATE_COLLECTIONS: {
     getDescription: () => "A list of collections they are part of.",
     getEntities: (artist) => splitEntities(artist.private_collections),
-    getLabel: () => "Private Collections",
+    getLabel: () => "Collected by a notable private collector",
   },
   AWARDS: {
     getDescription: () => "Awards and prizes the artist has won.",
     getEntities: (artist) => splitEntities(artist.awards),
-    getLabel: () => "Awards",
+    getLabel: () => "Winner of top industry award",
   },
 } as const
 


### PR DESCRIPTION
Just a minor copy update - looks like this:

<img width="1512" alt="Screenshot 2023-03-14 at 1 05 43 PM" src="https://user-images.githubusercontent.com/79799/225098058-1075d2d7-5d81-4513-8926-5638bc7603c4.png">


https://artsyproduct.atlassian.net/browse/GRO-1619

/cc @artsy/grow-devs @mbransfield 