### PR TITLE
feat(FX-4675): Rename every “Saved Artwork” collection to “All Saves” 

### DIFF
--- a/src/schema/v2/me/__tests__/collection.test.ts
+++ b/src/schema/v2/me/__tests__/collection.test.ts
@@ -61,6 +61,27 @@ it("returns collection attributes", async () => {
   })
 })
 
+describe("name field", () => {
+  it("should return `All Saves` when collection has `Saved Artwork` name", async () => {
+    context.collectionLoader = jest.fn(() => {
+      return Promise.resolve({
+        ...mockGravityCollection,
+        name: "Saved Artwork",
+      })
+    })
+
+    const response = await runAuthenticatedQuery(query, context)
+
+    expect(response.me.collection.name).toBe("All Saves")
+  })
+
+  it("should return name received from gravity", async () => {
+    const response = await runAuthenticatedQuery(query, context)
+
+    expect(response.me.collection.name).toBe("Works for dining room")
+  })
+})
+
 describe("isSavedArtwork field", () => {
   beforeEach(() => {
     query = gql`

--- a/src/schema/v2/me/collection.ts
+++ b/src/schema/v2/me/collection.ts
@@ -85,6 +85,13 @@ export const CollectionType = new GraphQLObjectType<any, ResolverContext>({
       type: new GraphQLNonNull(GraphQLString),
       description:
         "Name of the collection. Has a predictable value for 'standard' collections such as Saved Artwork, My Collection, etc. Can be provided by user otherwise.",
+      resolve: ({ name }) => {
+        if (name === "Saved Artwork") {
+          return "All Saves"
+        }
+
+        return name
+      },
     },
     saves: {
       type: new GraphQLNonNull(GraphQLBoolean),


### PR DESCRIPTION
### Demo
| Before | After |
| ------------- | ------------- |
| <img width="1307" alt="before" src="https://user-images.githubusercontent.com/3513494/225416717-c16e7e18-99b1-438e-9e5d-4bf2bbed53a9.png"> | <img width="1307" alt="after" src="https://user-images.githubusercontent.com/3513494/225416739-cc505249-9a17-43f4-9d75-8f84023a0b4c.png"> | 