### PR TITLE
chore (app home screen): update curated collections

### DIFF
--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -272,11 +272,11 @@ export const gravityStitchingEnvironment = (
                 fieldName: "marketingCollections",
                 args: {
                   slugs: [
+                    "trending-now",
                     "top-auction-lots",
-                    "artists-on-the-rise",
-                    "iconic-prints",
-                    "finds-under-1000-dollars",
-                    "trending-this-week",
+                    "new-this-week",
+                    "curators-picks-blue-chip",
+                    "curators-picks-emerging",
                   ],
                 },
                 context,


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1582]

### Description
This is an update to the collections populating the home screen of the app. It took me a while to find where the curated collections slugs for the home feed were coming from, but thanks to these PRs by @mdole & @jonallured I think I might have found the right place to make the change: 
https://github.com/artsy/metaphysics/pull/4399/
https://github.com/artsy/metaphysics/pull/4677


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1582]: https://artsyproduct.atlassian.net/browse/GRO-1582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ