### PR TITLE
feat(CX-3524): Add isPriceEstimateRequestable field to artwork type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2203,6 +2203,7 @@ type Artwork implements Node & Searchable & Sellable {
   # Whether a user can make an offer on the work through inquiry
   isOfferableFromInquiry: Boolean
   isOnHold: String
+  isPriceEstimateRequestable: Boolean
   isPriceHidden: Boolean
   isPriceRange: Boolean
   isSaved: Boolean

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -3982,4 +3982,79 @@ describe("Artwork type", () => {
       })
     })
   })
+
+  describe("isPriceEstimateRequestable", () => {
+    beforeEach(() => {
+      artwork.artist.target_supply_priority = 1
+      artwork.category = "Painting"
+    })
+
+    const query = `
+      {
+        artwork(id: "foo-bar") {
+          isPriceEstimateRequestable
+        }
+      }
+    `
+
+    it("returns true if the artist is P1 artist", async () => {
+      artwork.artist.target_supply_priority = 1
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          isPriceEstimateRequestable: true,
+        },
+      })
+    })
+
+    it("returns false if the artwork category is Posters", async () => {
+      artwork.category = "Posters"
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          isPriceEstimateRequestable: false,
+        },
+      })
+    })
+
+    it("returns false if the artist is Salvador Dali", async () => {
+      artwork.artist.id = "salvador-dali"
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          isPriceEstimateRequestable: false,
+        },
+      })
+    })
+
+    it("returns false if the artwork has a submission", async () => {
+      artwork.submission_id = "submission_id"
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          isPriceEstimateRequestable: false,
+        },
+      })
+    })
+
+    it("returns false if the artist is not P1 artist", async () => {
+      artwork.artist.target_supply_priority = 2
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          isPriceEstimateRequestable: false,
+        },
+      })
+    })
+  })
 })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -106,6 +106,9 @@ const IMPORT_SOURCES = {
 
 const ARTIST_IN_HIGH_DEMAND_RANK = 9
 
+const NON_REQUESTABLE_CATEGORIES = [artworkMediums.Posters.name]
+const NON_REQUESTABLE_ARTIST_IDS = ["salvador-dali"]
+
 export const ArtworkImportSourceEnum = new GraphQLEnumType({
   name: "ArtworkImportSource",
   values: IMPORT_SOURCES,
@@ -942,8 +945,8 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             artist.target_supply_priority === 1 &&
             !submission_id &&
             !consignmentSubmission?.id &&
-            category !== artworkMediums.Posters.name &&
-            artist.id !== "salvador-dali"
+            !NON_REQUESTABLE_CATEGORIES.includes(category) &&
+            !NON_REQUESTABLE_ARTIST_IDS.includes(artist.id)
 
           return isRequestable
         },

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -930,6 +930,24 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ price, edition_sets }) =>
           has_price_range(price) && !has_multiple_editions(edition_sets),
       },
+      isPriceEstimateRequestable: {
+        type: GraphQLBoolean,
+        resolve: ({
+          artist,
+          submission_id,
+          consignmentSubmission,
+          category,
+        }) => {
+          const isRequestable =
+            artist.target_supply_priority === 1 &&
+            !submission_id &&
+            !consignmentSubmission?.id &&
+            category !== artworkMediums.Posters.name &&
+            artist.id !== "salvador-dali"
+
+          return isRequestable
+        },
+      },
       isSaved: {
         type: GraphQLBoolean,
         resolve: ({ _id }, {}, { savedArtworkLoader }) => {


### PR DESCRIPTION
This resolves [CX-3524]

This PR adds the Request Price Estimate requirements to the artwork type as a boolean field called `isPriceEstimateRequestable`

#### Query
```graphql
{
  artwork(id: "foo-bar") {
    isPriceEstimateRequestable
  }
}
```

#### Response
```json
{
  "data": {
    "artwork": {
      "isPriceEstimateRequestable": false
    }
  }
}
```

[CX-3524]: https://artsyproduct.atlassian.net/browse/CX-3524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ