### PR TITLE
chore (app search screen): update curated collections

### DIFF
--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -810,11 +810,11 @@ export const gravityStitchingEnvironment = (
                 fieldName: "marketingCollections",
                 args: {
                   slugs: [
-                    "curators-picks-emerging",
-                    "trending-this-week",
-                    "artists-on-the-rise",
-                    "blue-chip-artists",
+                    "trending-now",
                     "top-auction-lots",
+                    "new-this-week",
+                    "curators-picks-blue-chip",
+                    "curators-picks-emerging",
                   ],
                   ...args,
                 },

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -272,11 +272,11 @@ export const gravityStitchingEnvironment = (
                 fieldName: "marketingCollections",
                 args: {
                   slugs: [
+                    "trending-now",
                     "top-auction-lots",
-                    "artists-on-the-rise",
-                    "iconic-prints",
-                    "finds-under-1000-dollars",
-                    "trending-this-week",
+                    "new-this-week",
+                    "curators-picks-blue-chip",
+                    "curators-picks-emerging",
                   ],
                 },
                 context,


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1580]

### Description
This is an update to the collections populating the search screen on the app. It took me a while to find where the curated collections slugs for the home feed were coming from, but thanks to this PR by @nickskalkin I believe I found the correct place to make the change: 
https://github.com/artsy/metaphysics/pull/4521

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1580]: https://artsyproduct.atlassian.net/browse/GRO-1580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ