### PR TITLE
chore: fix artist interface inside auction result

### DIFF
--- a/src/schema/v2/__tests__/auction_result.test.ts
+++ b/src/schema/v2/__tests__/auction_result.test.ts
@@ -246,6 +246,33 @@ describe("AuctionResult type", () => {
       })
     })
   })
+
+  describe("artist", () => {
+    it("returns the artist name when requested", () => {
+      const auctionResult = {
+        ...mockAuctionResult,
+      }
+
+      const context = {
+        auctionLotLoader: jest.fn(() => Promise.resolve(auctionResult)),
+        artistLoader: jest.fn(() => Promise.resolve({ name: "Andy Warhol" })),
+      }
+
+      const query = `
+        {
+          auctionResult(id: "foo-bar") {
+            artist {
+              name
+            }
+          }
+        }
+      `
+
+      return runQuery(query, context).then((data) => {
+        expect(data.auctionResult.artist.name).toEqual("Andy Warhol")
+      })
+    })
+  })
 })
 
 const mockComparableAuctionResults = {

--- a/src/schema/v2/auction_result.ts
+++ b/src/schema/v2/auction_result.ts
@@ -81,7 +81,15 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
     },
     artist: {
       type: ArtistType,
-      resolve: ({ artist }) => artist,
+      resolve: async (res, _, { artistLoader }) => {
+        // In case we get artist already resolved from the main connection
+        if (res.artist) {
+          return res.artist
+        }
+
+        const artist = await artistLoader(res.artist_id)
+        return artist
+      },
     },
     date,
     dateText: {


### PR DESCRIPTION
<img width="1282" alt="Screenshot 2023-03-17 at 13 12 13" src="https://user-images.githubusercontent.com/11945712/225900940-07fd578d-6daa-4492-8d06-175538c8967b.png">

**Note:**
This change might lead to performance issues in case we query for different artists from different lots but given that we are not doing this in any surface, we won't do the optimisation unless needed.
