### PR TITLE
fix(FX-4681):  `createCollection` mutation returns an error if `artworksConnection` is requested

### DIFF
--- a/src/schema/v2/me/createCollectionMutation.ts
+++ b/src/schema/v2/me/createCollectionMutation.ts
@@ -68,14 +68,19 @@ export const createCollectionMutation = mutationWithClientMutationId<
       throw new Error("You need to be signed in to perform this action")
     }
 
+    const { userID } = context
+
     try {
       const response = await context.createCollectionLoader({
         name: args.name,
-        user_id: context.userID,
+        user_id: userID,
         saves: true,
       })
 
-      return response
+      return {
+        ...response,
+        userID,
+      }
     } catch (error) {
       const formattedErr = formatGravityError(error)
 


### PR DESCRIPTION
Jira ticket: FX-4681

### Demo
#### Before
<img width="1546" alt="before" src="https://user-images.githubusercontent.com/3513494/225901219-db49218f-0641-4b2e-a6a7-0a8c69ab63ae.png">

#### After
<img width="1546" alt="after" src="https://user-images.githubusercontent.com/3513494/225901264-135ae799-2d5e-41b3-9600-d2a87e6268e4.png">
