### PR TITLE
feat(artist): biography blurb status; types

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1591,7 +1591,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
 
   # Use this attribute to sort by when sorting a collection of Artists
   sortableID: String
-  statuses: ArtistStatuses
+  statuses: ArtistStatuses!
   targetSupply: ArtistTargetSupply
   vanguardYear: String
   years: String
@@ -1948,17 +1948,23 @@ enum ArtistSorts {
 }
 
 type ArtistStatuses {
-  articles: Boolean
-  artists: Boolean
-  artworks: Boolean
-  auctionLots: Boolean
-  biography: Boolean
-  contemporary: Boolean
+  articles: Boolean!
+  artists: Boolean!
+  artworks: Boolean!
+  auctionLots: Boolean!
+  biography: Boolean!
+  biographyBlurb(
+    format: Format
+
+    # If true, will return featured bio over Artsy one.
+    partnerBio: Boolean = false
+  ): Boolean!
+  contemporary: Boolean!
   cv(
     # Suppress the cv tab when artist show count is less than this.
     minShowCount: Int = 15
-  ): Boolean
-  shows: Boolean
+  ): Boolean!
+  shows: Boolean!
 }
 
 type ArtistTargetSupply {

--- a/src/schema/v2/artist/biographyBlurb.ts
+++ b/src/schema/v2/artist/biographyBlurb.ts
@@ -1,0 +1,51 @@
+import { GraphQLBoolean, GraphQLFieldResolver } from "graphql"
+import { first } from "lodash"
+import { ResolverContext } from "types/graphql"
+import { formatMarkdownValue, markdown } from "../fields/markdown"
+
+export const biographyBlurbResolver: GraphQLFieldResolver<
+  { blurb?: string | null; id: string },
+  ResolverContext
+> = async (
+  { blurb, id },
+  { format, partnerBio },
+  { partnerArtistsForArtistLoader }
+) => {
+  if (!blurb) return null
+
+  if (!partnerBio && blurb && blurb.length) {
+    return { text: formatMarkdownValue(blurb, format) }
+  }
+
+  try {
+    const partnerArtists = await partnerArtistsForArtistLoader(id, {
+      size: 1,
+      featured: true,
+    })
+
+    if (partnerArtists && partnerArtists.length) {
+      const { biography, partner } = first(partnerArtists) as any
+
+      return {
+        text: formatMarkdownValue(biography, format),
+        credit: `Submitted by ${partner.name}`,
+        partner_id: partner.id,
+        partner: partner,
+      }
+    }
+
+    return { text: formatMarkdownValue(blurb, format) }
+  } catch (error) {
+    console.error(error)
+    return { text: formatMarkdownValue(blurb, format) }
+  }
+}
+
+export const biographyBlurbArgs = {
+  partnerBio: {
+    type: GraphQLBoolean,
+    description: "If true, will return featured bio over Artsy one.",
+    defaultValue: false,
+  },
+  ...markdown().args,
+}

--- a/src/schema/v2/artist/statuses.ts
+++ b/src/schema/v2/artist/statuses.ts
@@ -3,69 +3,109 @@ import {
   GraphQLBoolean,
   GraphQLInt,
   GraphQLFieldConfig,
+  GraphQLNonNull,
 } from "graphql"
 import { totalViaLoader } from "lib/total"
 import { ResolverContext } from "types/graphql"
+import { biographyBlurbArgs, biographyBlurbResolver } from "./biographyBlurb"
 
 const ArtistStatusesType = new GraphQLObjectType<any, ResolverContext>({
   name: "ArtistStatuses",
   fields: {
     artists: {
-      type: GraphQLBoolean,
-      resolve: ({ id }, _options, { relatedMainArtistsLoader }) =>
-        totalViaLoader(
-          relatedMainArtistsLoader,
-          {},
-          { exclude_artists_without_artworks: true, artist: [id] }
-        ).then((count) => count > 0),
+      type: new GraphQLNonNull(GraphQLBoolean),
+      resolve: async ({ id }, _options, { relatedMainArtistsLoader }) => {
+        try {
+          const count = totalViaLoader(
+            relatedMainArtistsLoader,
+            {},
+            { exclude_artists_without_artworks: true, artist: [id] }
+          )
+
+          return count > 0
+        } catch (error) {
+          return false
+        }
+      },
     },
     articles: {
-      type: GraphQLBoolean,
-      resolve: ({ _id }, _options, { articlesLoader }) =>
-        articlesLoader({
-          artist_id: _id,
-          published: true,
-          in_editorial_feed: true,
-          limit: 0,
-          count: true,
-        }).then(({ count }) => {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      resolve: async ({ _id }, _options, { articlesLoader }) => {
+        try {
+          const { count } = await articlesLoader({
+            artist_id: _id,
+            published: true,
+            in_editorial_feed: true,
+            limit: 0,
+            count: true,
+          })
+
           return count > 0
-        }),
+        } catch (error) {
+          return false
+        }
+      },
     },
     artworks: {
-      type: GraphQLBoolean,
+      type: new GraphQLNonNull(GraphQLBoolean),
       resolve: ({ published_artworks_count }) => published_artworks_count > 0,
     },
     auctionLots: {
-      type: GraphQLBoolean,
-      resolve: ({ display_auction_link, hide_auction_link }) => {
-        return display_auction_link && !hide_auction_link
+      type: new GraphQLNonNull(GraphQLBoolean),
+      resolve: ({ display_auction_link }) => {
+        return !!display_auction_link
       },
     },
     biography: {
-      type: GraphQLBoolean,
-      resolve: ({ _id }, _options, { articlesLoader }) =>
-        articlesLoader({
-          published: true,
-          biography_for_artist_id: _id,
-          limit: 0,
-        }).then(({ count }) => count > 0),
+      type: new GraphQLNonNull(GraphQLBoolean),
+      resolve: async ({ _id }, _options, { articlesLoader }) => {
+        try {
+          const { count } = await articlesLoader({
+            published: true,
+            biography_for_artist_id: _id,
+            limit: 0,
+          })
+
+          return count > 0
+        } catch (error) {
+          return false
+        }
+      },
+    },
+    biographyBlurb: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      args: biographyBlurbArgs,
+      resolve: async (...props) => {
+        try {
+          const res = await biographyBlurbResolver(...props)
+          return res.text.length > 0
+        } catch (error) {
+          return false
+        }
+      },
     },
     contemporary: {
-      type: GraphQLBoolean,
-      resolve: ({ id }, _options, { relatedContemporaryArtistsLoader }) => {
-        return totalViaLoader(
-          relatedContemporaryArtistsLoader,
-          {},
-          {
-            exclude_artists_without_artworks: true,
-            artist: [id],
-          }
-        ).then((total) => total > 0)
+      type: new GraphQLNonNull(GraphQLBoolean),
+      resolve: async (
+        { id },
+        _options,
+        { relatedContemporaryArtistsLoader }
+      ) => {
+        try {
+          const count = await totalViaLoader(
+            relatedContemporaryArtistsLoader,
+            {},
+            { exclude_artists_without_artworks: true, artist: [id] }
+          )
+
+          return count > 0
+        } catch (error) {
+          return false
+        }
       },
     },
     cv: {
-      type: GraphQLBoolean,
+      type: new GraphQLNonNull(GraphQLBoolean),
       args: {
         minShowCount: {
           type: GraphQLInt,
@@ -74,19 +114,21 @@ const ArtistStatusesType = new GraphQLObjectType<any, ResolverContext>({
           defaultValue: 15,
         },
       },
-      resolve: ({ partner_shows_count }, { minShowCount }) =>
-        partner_shows_count > minShowCount,
+      resolve: ({ partner_shows_count }, { minShowCount }) => {
+        return partner_shows_count > minShowCount
+      },
     },
     shows: {
-      type: GraphQLBoolean,
-      resolve: ({ displayable_partner_shows_count }) =>
-        displayable_partner_shows_count > 0,
+      type: new GraphQLNonNull(GraphQLBoolean),
+      resolve: ({ displayable_partner_shows_count }) => {
+        return displayable_partner_shows_count > 0
+      },
     },
   },
 })
 
 const ArtistStatuses: GraphQLFieldConfig<any, ResolverContext> = {
-  type: ArtistStatusesType,
+  type: new GraphQLNonNull(ArtistStatusesType),
   resolve: (artist) => artist,
 }
 


### PR DESCRIPTION
* Added a `biographyBlurb` resolver to statuses
* Fixed the types to better reflect their non-nullability (all boolean fields should always be non-nullable IMO)
* Added some error handling to all statuses.

I was going to add the rest of these but it looks like the tabs on the artist page are changing with the upcoming redesign so backing off until we know more.