### PR TITLE
feat(mutation): adds me field to create saved search payload

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7401,6 +7401,7 @@ input CreateSavedSearchInput {
 type CreateSavedSearchPayload {
   # A unique identifier for the client performing the mutation.
   clientMutationId: String
+  me: Me
   savedSearchOrErrors: SearchCriteriaOrErrorsUnion!
 }
 

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -177,20 +177,25 @@ export const gravityStitchingEnvironment = (
         algolia: Algolia
       }
 
+
       extend type CreateUserAddressPayload {
-        me : Me
+        me: Me
+      }
+
+      extend type CreateSavedSearchPayload {
+        me: Me
       }
 
       extend type UpdateUserAddressPayload {
-        me : Me
+        me: Me
       }
 
       extend type DeleteUserAddressPayload {
-        me : Me
+        me: Me
       }
 
       extend type UpdateUserDefaultAddressPayload {
-        me : Me
+        me: Me
       }
 
       extend type Fair {
@@ -960,6 +965,20 @@ export const gravityStitchingEnvironment = (
         },
       },
       CreateUserAddressPayload: {
+        me: {
+          resolve: (_parent, args, context, info) => {
+            return info.mergeInfo.delegateToSchema({
+              schema: localSchema,
+              operation: "query",
+              fieldName: "me",
+              args,
+              context,
+              info,
+            })
+          },
+        },
+      },
+      CreateSavedSearchPayload: {
         me: {
           resolve: (_parent, args, context, info) => {
             return info.mergeInfo.delegateToSchema({


### PR DESCRIPTION
This stitches in the `me` field to the payload for creating a saved search. We need it to access the updated counts object.