### PR TITLE
fix: Fixes collection.artworksConnection pagination

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3635,7 +3635,7 @@ type Collection {
     before: String
     first: Int
     last: Int
-    page: Int = 1
+    page: Int
     sort: CollectionArtworkSorts
   ): ArtworkConnection
 

--- a/src/schema/v2/me/collection.ts
+++ b/src/schema/v2/me/collection.ts
@@ -31,7 +31,7 @@ export const CollectionType = new GraphQLObjectType<any, ResolverContext>({
             defaultValue: CollectionArtworkSorts.getValue("SAVED_AT_DESC")!
               .value,
           },
-          page: { type: GraphQLInt, defaultValue: 1 },
+          page: { type: GraphQLInt },
         }),
       },
       resolve: async (parent, args, context, _info) => {


### PR DESCRIPTION
Because of [this condition](https://github.com/artsy/metaphysics/blob/dc017e9c7a1418f11fbcb8e183f935c3f29edf51/src/lib/helpers.ts#L142-L149) cursor-based pagination appears to be broken. It is impossible to make such query, wrong parameters get passed to gravity:

```
{
	me {
		collection(id: "2fc5f80e-759f-4fbf-90a1-5a7f58785921") {
			name
			
			artworksConnection(first: 1, after: "YXJyYXljb25uZWN0aW9uOjE") {
				edges {
					cursor

					node {
						id
						title
					}
				}
			}
		}
	}
}
```