### PR TITLE
Feat(CX-3574): Support Lots ASC param

### DIFF
--- a/src/schema/v2/auction_result.ts
+++ b/src/schema/v2/auction_result.ts
@@ -39,7 +39,7 @@ export const AuctionResultSorts = {
         value: "-sale_date",
       },
       DATE_ASC: {
-        value: "-sale_date_asc",
+        value: "sale_date",
       },
       PRICE_AND_DATE_DESC: {
         value: "-price_realized_cents_usd,-sale_date",


### PR DESCRIPTION
This PR addresses [CX-3574]

### Description
- Enables passing `sale_date` (note: Not `-sale_date`) as sort param in order to receive results in ASC order

Related to https://github.com/artsy/diffusion/pull/710

[CX-3574]: https://artsyproduct.atlassian.net/browse/CX-3574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ