### PR TITLE
Revert "fix(CX-3459): Update collector profile resolvers"

### DIFF
--- a/src/schema/v2/CollectorProfile/__tests__/updateCollectorProfileWithID.test.ts
+++ b/src/schema/v2/CollectorProfile/__tests__/updateCollectorProfileWithID.test.ts
@@ -52,10 +52,6 @@ describe("UpdateCollectorProfileWithID", () => {
       email: "percy@cat.com",
       self_reported_purchases: "treats",
       intents: ["buy art & design"],
-      owner: {
-        name: "Percy",
-        email: "percy@cat.com",
-      },
     }
 
     const context = {

--- a/src/schema/v2/CollectorProfile/collectorProfile.ts
+++ b/src/schema/v2/CollectorProfile/collectorProfile.ts
@@ -35,14 +35,14 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
     resolve: ({ company_website }) => company_website,
   },
   confirmedBuyerAt: date,
-  email: { type: GraphQLString, resolve: ({ owner: { email } }) => email },
+  email: { type: GraphQLString },
   institutionalAffiliations: {
     type: GraphQLString,
     resolve: ({ institutional_affiliations }) => institutional_affiliations,
   },
   intents: { type: new GraphQLList(GraphQLString) },
   loyaltyApplicantAt: date,
-  name: { type: GraphQLString, resolve: ({ owner: { name } }) => name },
+  name: { type: GraphQLString },
   privacy: { type: GraphQLString },
   professionalBuyerAppliedAt: date,
   professionalBuyerAt: date,
@@ -58,7 +58,7 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
   },
 
   // moved InquirerCollectorProfileFields here
-  location: { type: myLocationType, resolve: ({ owner }) => owner.location },
+  location: { type: myLocationType },
   artsyUserSince: dateFormatter(({ artsy_user_since }) => artsy_user_since),
   ownerID: {
     type: new GraphQLNonNull(GraphQLID),
@@ -72,10 +72,7 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
   bio: {
     type: GraphQLString,
   },
-  profession: {
-    type: GraphQLString,
-    resolve: ({ owner: { profession } }) => profession,
-  },
+  profession: { type: GraphQLString },
   otherRelevantPositions: {
     type: GraphQLString,
     description: "Collector's position with relevant institutions",

--- a/src/schema/v2/me/__tests__/collector_profile.test.js
+++ b/src/schema/v2/me/__tests__/collector_profile.test.js
@@ -35,9 +35,6 @@ describe("Me", () => {
         intents: ["buy art & design"],
         privacy: "public",
         owner: {
-          name: "Percy",
-          email: "percy@cat.com",
-          profession: "typer",
           location: {
             display: "Germany",
           },

--- a/src/schema/v2/me/__tests__/update_collector_profile.test.js
+++ b/src/schema/v2/me/__tests__/update_collector_profile.test.js
@@ -28,10 +28,6 @@ describe("UpdateCollectorProfile", () => {
         email: "percy@cat.com",
         self_reported_purchases: "treats",
         intents: ["buy art & design"],
-        owner: {
-          name: "Percy",
-          email: "percy@cat.com",
-        },
       })
     )
 

--- a/src/schema/v2/partner/__tests__/partnerInquirerCollectorProfile.test.ts
+++ b/src/schema/v2/partner/__tests__/partnerInquirerCollectorProfile.test.ts
@@ -16,14 +16,6 @@ describe("partnerInquirerCollectorProfile", () => {
     },
     profession: "Superhuman",
     bio: "I got snacks to the roof",
-    owner: {
-      name: "Some Collector",
-      location: {
-        city: "Around",
-        country: "The Globe",
-      },
-      profession: "Superhuman",
-    },
   }
 
   const context = {


### PR DESCRIPTION
Reverts artsy/metaphysics#4868

Rather than digging in to the `owner` object (which erroneously _exposed_ these properties, which will be removed in https://github.com/artsy/gravity/pull/16228), it's correct + preferred to take them from the root/parent document (the collector profile JSON itself in this case).

Assuming there is a stale/caching issue on Gravity for when owners update their information, and it's not reflected here - (from https://github.com/artsy/gravity/pull/16149), I will take a look at what's going on there - we should be able to get that working as expected.