### PR TITLE
refactor: deprecate conversation's fromUser in favor of fromProfile

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6889,8 +6889,14 @@ type Conversation implements Node {
   from: ConversationInitiator!
   fromLastViewedMessageID: String
 
+  # The collector profile of the user who initiated the conversation
+  fromProfile: CollectorProfileType
+
   # The user who initiated the conversation
   fromUser: User
+    @deprecated(
+      reason: "Will be inaccessible to partners in future versions. Prefer fromProfile."
+    )
 
   # A globally unique ID.
   id: ID!

--- a/src/schema/v2/conversation/__tests__/__snapshots__/conversation.test.js.snap
+++ b/src/schema/v2/conversation/__tests__/__snapshots__/conversation.test.js.snap
@@ -79,7 +79,7 @@ Object {
     "from": Object {
       "email": "collector@example.com",
     },
-    "fromUser": Object {
+    "fromProfile": Object {
       "email": "collector@example.com",
     },
     "initialMessage": "Loved some of the works at your fair booth!",

--- a/src/schema/v2/conversation/__tests__/conversation.test.js
+++ b/src/schema/v2/conversation/__tests__/conversation.test.js
@@ -4,8 +4,11 @@ import { runAuthenticatedQuery } from "schema/v2/test/utils"
 describe("Me", () => {
   describe("Conversation", () => {
     const context = {
-      userByIDLoader: () =>
-        Promise.resolve({ id: "user-id", email: "collector@example.com" }),
+      collectorProfilesLoader: ({ _user_id }) => {
+        return Promise.resolve({
+          body: [{ id: "profile-id", email: "collector@example.com" }],
+        })
+      },
       conversationLoader: () => {
         return Promise.resolve({
           id: "420",
@@ -128,7 +131,7 @@ describe("Me", () => {
               from {
                 email
               }
-              fromUser {
+              fromProfile {
                 email
               }
               lastMessage

--- a/src/schema/v2/conversation/index.ts
+++ b/src/schema/v2/conversation/index.ts
@@ -28,6 +28,7 @@ import { MessageType } from "./message"
 import { ResolverContext } from "types/graphql"
 import { UserType } from "../user"
 import { InquiryRequestType } from "../partner/partnerInquiryRequest"
+import { CollectorProfileType } from "../CollectorProfile/collectorProfile"
 
 export const BuyerOutcomeTypes = new GraphQLEnumType({
   name: "BuyerOutcomeTypes",
@@ -270,9 +271,28 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
         }
       },
     },
+    fromProfile: {
+      description:
+        "The collector profile of the user who initiated the conversation",
+      type: CollectorProfileType,
+      resolve: async ({ from_id }, _options, { collectorProfilesLoader }) => {
+        if (!collectorProfilesLoader)
+          throw new Error(
+            "A X-Access-Token header is required to perform this action."
+          )
+
+        const { body: profiles } = await collectorProfilesLoader({
+          user_id: from_id,
+        })
+
+        return profiles[0]
+      },
+    },
     fromUser: {
       description: "The user who initiated the conversation",
       type: UserType,
+      deprecationReason:
+        "Will be inaccessible to partners in future versions. Prefer fromProfile.",
       resolve: async ({ from_id }, _options, { userByIDLoader }) => {
         if (!userByIDLoader) {
           return null


### PR DESCRIPTION
Similar to https://github.com/artsy/metaphysics/pull/4856, let's expose the associated collector profile directly on a conversation, rather than nested within a user. The `fromUser` property was added [just a few months ago](https://github.com/artsy/metaphysics/pull/4561) and is [only employed by volt-v2](https://github.com/search?q=org%3Aartsy+fromUser&type=code). No additional user properties are requested. This paves the way to retire partners' access to the user endpoint.