### PR TITLE
feat(FX-4725): allow counting only visible artworks for collections

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3640,7 +3640,10 @@ type Collection {
   ): ArtworkConnection
 
   # Number of artworks associated with this collection.
-  artworksCount: Int!
+  artworksCount(
+    # Only count visible artworks
+    onlyVisible: Boolean = false
+  ): Int!
 
   # True if this is the default collection for this user, i.e. the default Saved Artwork collection.
   default: Boolean!

--- a/src/schema/v2/me/__tests__/collection.test.ts
+++ b/src/schema/v2/me/__tests__/collection.test.ts
@@ -22,6 +22,7 @@ const mockGravityCollection = {
   default: false,
   saves: true,
   artworks_count: 42,
+  visible_artworks_count: 39,
 }
 
 let context: Partial<ResolverContext>
@@ -132,6 +133,55 @@ describe("isSavedArtwork field", () => {
         },
       },
     })
+  })
+})
+
+describe("artworksCount field", () => {
+  it("should return visible_artworks_count if onlyVisible is true", async () => {
+    const countQuery = gql`
+      query {
+        me {
+          collection(id: "123-abc") {
+            artworksCount(onlyVisible: true)
+          }
+        }
+      }
+    `
+    const response = await runAuthenticatedQuery(countQuery, context)
+
+    expect(response.me.collection.artworksCount).toBe(
+      mockGravityCollection.visible_artworks_count
+    )
+  })
+
+  it("should return artworks_count if onlyVisible is false or not passed", async () => {
+    let countQuery = gql`
+      query {
+        me {
+          collection(id: "123-abc") {
+            artworksCount(onlyVisible: false)
+          }
+        }
+      }
+    `
+    let response = await runAuthenticatedQuery(countQuery, context)
+    expect(response.me.collection.artworksCount).toBe(
+      mockGravityCollection.artworks_count
+    )
+
+    countQuery = gql`
+      query {
+        me {
+          collection(id: "123-abc") {
+            artworksCount
+          }
+        }
+      }
+    `
+    response = await runAuthenticatedQuery(countQuery, context)
+    expect(response.me.collection.artworksCount).toBe(
+      mockGravityCollection.artworks_count
+    )
   })
 })
 

--- a/src/schema/v2/me/collection.ts
+++ b/src/schema/v2/me/collection.ts
@@ -75,7 +75,19 @@ export const CollectionType = new GraphQLObjectType<any, ResolverContext>({
     artworksCount: {
       type: new GraphQLNonNull(GraphQLInt),
       description: "Number of artworks associated with this collection.",
-      resolve: ({ artworks_count }) => artworks_count,
+      args: {
+        onlyVisible: {
+          type: GraphQLBoolean,
+          description: "Only count visible artworks",
+          defaultValue: false,
+        },
+      },
+      resolve: (
+        { artworks_count, visible_artworks_count },
+        { onlyVisible }
+      ) => {
+        return onlyVisible ? visible_artworks_count : artworks_count
+      },
     },
     default: {
       type: new GraphQLNonNull(GraphQLBoolean),


### PR DESCRIPTION
- [Jira ticket](https://artsyproduct.atlassian.net/browse/FX-4725)

Add an option to `artworksCount` to count only visible artworks

Request:

```graphql
{
	me {
		collection(id: "2fc5f80e-759f-4fbf-90a1-5a7f58785921") {
			name
			privateArtworksCount: artworksCount
			visibleArtworksCount: artworksCount(onlyVisible: true)			
		}
	}
}
```

Response:

```graphql
{
	"data": {
		"me": {
			"collection": {
				"name": "All Saves",
				"privateArtworksCount": 161,
				"visibleArtworksCount": 157
			}
		}
	}
}
```