### PR TITLE
feat(pref center): update metaphysics to support channel field for push

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12561,6 +12561,16 @@ type Notification implements Node {
   title: String!
 }
 
+enum NotificationChannel {
+  EMAIL
+  PUSH
+}
+
+enum NotificationChannelInput {
+  EMAIL
+  PUSH
+}
+
 # A connection to a list of items.
 type NotificationConnection {
   counts: NotificationCounts
@@ -12602,13 +12612,14 @@ type NotificationEdge {
 }
 
 type NotificationPreference {
-  channel: String!
+  channel: NotificationChannel!
   id: String!
   name: String!
   status: SubGroupStatus!
 }
 
 input NotificationPreferenceInput {
+  channel: NotificationChannelInput!
   name: String!
   status: SubGroupInputStatus!
 }

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12602,7 +12602,7 @@ type NotificationEdge {
 }
 
 type NotificationPreference {
-  #  email | push
+  # email | push
   channel: String!
   id: String!
   name: String!
@@ -12610,8 +12610,8 @@ type NotificationPreference {
 }
 
 input NotificationPreferenceInput {
-  #  email | push
-  channel: String!
+  # email | push
+  channel: String
   name: String!
   status: SubGroupInputStatus!
 }

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12561,16 +12561,6 @@ type Notification implements Node {
   title: String!
 }
 
-enum NotificationChannel {
-  EMAIL
-  PUSH
-}
-
-enum NotificationChannelInput {
-  EMAIL
-  PUSH
-}
-
 # A connection to a list of items.
 type NotificationConnection {
   counts: NotificationCounts
@@ -12612,14 +12602,16 @@ type NotificationEdge {
 }
 
 type NotificationPreference {
-  channel: NotificationChannel!
+  #  email | push
+  channel: String!
   id: String!
   name: String!
   status: SubGroupStatus!
 }
 
 input NotificationPreferenceInput {
-  channel: NotificationChannelInput!
+  #  email | push
+  channel: String!
   name: String!
   status: SubGroupInputStatus!
 }

--- a/src/schema/v2/__tests__/notification_preferences.test.ts
+++ b/src/schema/v2/__tests__/notification_preferences.test.ts
@@ -1,15 +1,122 @@
+import gql from "lib/gql"
 import { convertSubGroups } from "../notification_preferences"
+import { runQuery } from "../test/utils"
 
 describe("convertSubGroups", () => {
-  it("converts to params for gravity", () => {
+  it("converts subGroups to params for gravity loader", () => {
     const subGroups = [
-      { id: "abc", name: "daily", channel: "email", status: "Subscribed" },
+      { id: "abc", name: "GroupA", status: "Subscribed", channel: "Email" },
+      { id: "abc", name: "GroupB", status: "Unsubscribed", channel: "Push" },
     ]
 
     const params = convertSubGroups(subGroups)
 
     expect(params).toEqual({
-      subscription_groups: { daily: "subscribed" },
+      subscription_groups: [
+        { name: "GroupA", status: "subscribed", channel: "email" },
+        { name: "GroupB", status: "unsubscribed", channel: "push" },
+      ],
     })
+  })
+})
+
+describe("notificationPreferences", () => {
+  it("returns notification preferences for authenticated user", async () => {
+    const query = gql`
+      {
+        notificationPreferences {
+          id
+          name
+          channel
+          status
+        }
+      }
+    `
+
+    const notificationPreferences = [
+      {
+        id: "abc",
+        name: "GroupA",
+        channel: "EMAIL",
+        status: "SUBSCRIBED",
+      },
+      {
+        id: "abc",
+        name: "GroupB",
+        channel: "PUSH",
+        status: "UNSUBSCRIBED",
+      },
+    ]
+
+    const context = {
+      notificationPreferencesLoader: () =>
+        Promise.resolve(notificationPreferences),
+    }
+
+    const data = await runQuery(query, context)
+    expect(data!.notificationPreferences).toEqual(notificationPreferences)
+  })
+
+  it("returns notification preferences for unathenticated user", async () => {
+    const query = gql`
+      {
+        notificationPreferences {
+          id
+          name
+          channel
+          status
+        }
+      }
+    `
+
+    const notificationPreferences = [
+      {
+        id: "abc",
+        name: "GroupA",
+        channel: "EMAIL",
+        status: "SUBSCRIBED",
+      },
+      {
+        id: "abc",
+        name: "GroupB",
+        channel: "PUSH",
+        status: "UNSUBSCRIBED",
+      },
+    ]
+
+    const context = {
+      anonNotificationPreferencesLoader: () =>
+        Promise.resolve(notificationPreferences),
+    }
+
+    const data = await runQuery(query, context)
+    expect(data!.notificationPreferences).toEqual(notificationPreferences)
+  })
+
+  it.skip("returns an error when there is a problem returning notification preferences", async () => {
+    // add error handling or is this backend?
+  })
+})
+
+describe("Update notificationPreferences", () => {
+  it.skip("updates notification preferences when input is valid", async () => {})
+  it.skip("updates email notification preferences to 'Subscribed' when input is valid", async () => {})
+
+  it.skip("updates email notification preferences to 'Unsubscribed' when input is valid", async () => {})
+
+  it.skip("updates push notification preferences to 'Subscribed' when input is valid", async () => {})
+
+  it.skip("updates push notification preferences to 'Unsubscribed' when input is valid", async () => {})
+
+  it.skip("returns an error when input value is invalid", async () => {
+    // Invalid name
+    // Invalid status
+    // Invalid channel
+  })
+
+  it.skip("returns an error when input value is missing", async () => {
+    //Missing name
+    // Missing status
+    // Missing channel
   })
 })

--- a/src/schema/v2/notification_preferences.ts
+++ b/src/schema/v2/notification_preferences.ts
@@ -32,7 +32,7 @@ const subGroupFields = {
   // Using an enum will cause type errors on the frontend.
   channel: {
     type: new GraphQLNonNull(GraphQLString),
-    description: " email | push ",
+    description: "email | push",
   },
   status: {
     type: new GraphQLNonNull(
@@ -54,8 +54,8 @@ const subGroupInputFields = {
   // NOTE: The 'channel' property is defined as a string instead of an enum because some frontend code relies on it being a string.
   // Using an enum will cause type errors on the frontend.
   channel: {
-    type: new GraphQLNonNull(GraphQLString),
-    description: " email | push ",
+    type: GraphQLString,
+    description: "email | push",
   },
   status: {
     type: new GraphQLNonNull(

--- a/src/schema/v2/notification_preferences.ts
+++ b/src/schema/v2/notification_preferences.ts
@@ -11,11 +11,10 @@ import { mutationWithClientMutationId } from "graphql-relay"
 import { ResolverContext } from "types/graphql"
 
 export const convertSubGroups = (subGroups) => {
-  const gravityGroups = subGroups.map((group) => ({
-    name: group.name,
-    status: group.status.toLowerCase(),
-    channel: group.channel.toLowerCase(),
-  }))
+  const gravityGroups = subGroups.reduce((previous, current) => {
+    previous[current.name] = current.status.toLowerCase()
+    return previous
+  }, {})
 
   const params = { subscription_groups: gravityGroups }
 
@@ -29,24 +28,19 @@ const subGroupFields = {
   name: {
     type: new GraphQLNonNull(GraphQLString),
   },
+  // NOTE: The 'channel' property is defined as a string instead of an enum because some frontend code relies on it being a string.
+  // Using an enum will cause type errors on the frontend.
   channel: {
-    type: new GraphQLNonNull(
-      new GraphQLEnumType({
-        name: "NotificationChannel",
-        values: {
-          EMAIL: { value: "EMAIL" },
-          PUSH: { value: "PUSH" },
-        },
-      })
-    ),
+    type: new GraphQLNonNull(GraphQLString),
+    description: " email | push ",
   },
   status: {
     type: new GraphQLNonNull(
       new GraphQLEnumType({
         name: "SubGroupStatus",
         values: {
-          SUBSCRIBED: { value: "SUBSCRIBED" },
-          UNSUBSCRIBED: { value: "UNSUBSCRIBED" },
+          SUBSCRIBED: { value: "Subscribed" },
+          UNSUBSCRIBED: { value: "Unsubscribed" },
         },
       })
     ),
@@ -57,16 +51,11 @@ const subGroupInputFields = {
   name: {
     type: new GraphQLNonNull(GraphQLString),
   },
+  // NOTE: The 'channel' property is defined as a string instead of an enum because some frontend code relies on it being a string.
+  // Using an enum will cause type errors on the frontend.
   channel: {
-    type: new GraphQLNonNull(
-      new GraphQLEnumType({
-        name: "NotificationChannelInput",
-        values: {
-          EMAIL: { value: "Email" },
-          PUSH: { value: "Push" },
-        },
-      })
-    ),
+    type: new GraphQLNonNull(GraphQLString),
+    description: " email | push ",
   },
   status: {
     type: new GraphQLNonNull(
@@ -147,7 +136,6 @@ export const updateNotificationPreferencesMutation = mutationWithClientMutationI
     const subGroups = args.subscriptionGroups
     const params = convertSubGroups(subGroups)
 
-    // add error handling??
     if (updateNotificationPreferencesLoader) {
       return updateNotificationPreferencesLoader(params)
     }

--- a/src/schema/v2/notification_preferences.ts
+++ b/src/schema/v2/notification_preferences.ts
@@ -11,10 +11,11 @@ import { mutationWithClientMutationId } from "graphql-relay"
 import { ResolverContext } from "types/graphql"
 
 export const convertSubGroups = (subGroups) => {
-  const gravityGroups = subGroups.reduce((previous, current) => {
-    previous[current.name] = current.status.toLowerCase()
-    return previous
-  }, {})
+  const gravityGroups = subGroups.map((group) => ({
+    name: group.name,
+    status: group.status.toLowerCase(),
+    channel: group.channel.toLowerCase(),
+  }))
 
   const params = { subscription_groups: gravityGroups }
 
@@ -29,15 +30,23 @@ const subGroupFields = {
     type: new GraphQLNonNull(GraphQLString),
   },
   channel: {
-    type: new GraphQLNonNull(GraphQLString),
+    type: new GraphQLNonNull(
+      new GraphQLEnumType({
+        name: "NotificationChannel",
+        values: {
+          EMAIL: { value: "EMAIL" },
+          PUSH: { value: "PUSH" },
+        },
+      })
+    ),
   },
   status: {
     type: new GraphQLNonNull(
       new GraphQLEnumType({
         name: "SubGroupStatus",
         values: {
-          SUBSCRIBED: { value: "Subscribed" },
-          UNSUBSCRIBED: { value: "Unsubscribed" },
+          SUBSCRIBED: { value: "SUBSCRIBED" },
+          UNSUBSCRIBED: { value: "UNSUBSCRIBED" },
         },
       })
     ),
@@ -47,6 +56,17 @@ const subGroupFields = {
 const subGroupInputFields = {
   name: {
     type: new GraphQLNonNull(GraphQLString),
+  },
+  channel: {
+    type: new GraphQLNonNull(
+      new GraphQLEnumType({
+        name: "NotificationChannelInput",
+        values: {
+          EMAIL: { value: "Email" },
+          PUSH: { value: "Push" },
+        },
+      })
+    ),
   },
   status: {
     type: new GraphQLNonNull(
@@ -127,6 +147,7 @@ export const updateNotificationPreferencesMutation = mutationWithClientMutationI
     const subGroups = args.subscriptionGroups
     const params = convertSubGroups(subGroups)
 
+    // add error handling??
     if (updateNotificationPreferencesLoader) {
       return updateNotificationPreferencesLoader(params)
     }


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [GRO-1650]

### Description
The goal of this PR is to update `notificationPreferences` to support a channel field to be passed to Gravity as part of a first step towards rebuilding the user preference center to include push notifications.

Tech plan: https://www.notion.so/artsy/Notification-Preference-Center-Mobile-Web-294c4c1967e9491984048cef8c91893a 

TODO

- [x] Wrap up tests
- [x] Match Eigen and Force to local MP schema to test SavedSearchAlerts query for breaking changes
- [x] Double check case sensitivity in specs

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRO-1650]: https://artsyproduct.atlassian.net/browse/GRO-1650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ