### PR TITLE
feat: update pagination for auction results.

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1365,9 +1365,11 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
 
     # Filter auction results by organizations
     organizations: [String]
+    page: Int
 
     # When true, will only return records for allowed artists.
     recordsTrusted: Boolean = false
+    size: Int
 
     # Filter auction results by Artwork sizes
     sizes: [ArtworkSizes]

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -235,13 +235,14 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
           },
           sort: AuctionResultSorts,
           state: AuctionResultsState,
+          page: { type: GraphQLInt },
+          size: { type: GraphQLInt },
         }),
         resolve: async ({ _id }, options, { auctionLotsLoader }) => {
           if (options.recordsTrusted && !includes(auctionRecordsTrusted, _id)) {
             return null
           }
 
-          // Convert `after` cursors to page params
           const {
             categories,
             offset,
@@ -276,7 +277,9 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
                       page,
                       size,
                     },
-                    total_count
+                    total_count,
+                    5,
+                    null
                   ),
                 },
                 {

--- a/src/schema/v2/fields/__tests__/pagination.test.js
+++ b/src/schema/v2/fields/__tests__/pagination.test.js
@@ -123,4 +123,19 @@ describe("createPageCursors", () => {
 
     expect(pageCursors.last.page).toBe(100)
   })
+
+  it("does not cap the page number if cap number not provided", () => {
+    const size = 10
+    const totalPages = 200
+    const totalRecords = totalPages * size
+
+    const pageCursors = createPageCursors(
+      { page: 1, size },
+      totalRecords,
+      5,
+      null
+    )
+
+    expect(pageCursors.last.page).toBe(totalPages)
+  })
 })

--- a/src/schema/v2/fields/pagination.ts
+++ b/src/schema/v2/fields/pagination.ts
@@ -93,15 +93,21 @@ function pageCursorsToArray(start, end, currentPage, size) {
   return cursors
 }
 
-// Returns the total number of pagination results capped to PAGE_NUMBER_CAP.
-export function computeTotalPages(totalRecords, size) {
-  return Math.min(Math.ceil(totalRecords / size), PAGE_NUMBER_CAP)
+// Returns the total number of pagination results capped to PAGE_NUMBER_CAP if cap value provided.
+export function computeTotalPages(
+  totalRecords,
+  size,
+  pageNumberCap: number | null = PAGE_NUMBER_CAP
+) {
+  const totalPages = Math.ceil(totalRecords / size)
+  return pageNumberCap ? Math.min(totalPages, pageNumberCap) : totalPages
 }
 
 export function createPageCursors(
-  { page: currentPage, size },
-  totalRecords,
-  max = 5
+  { page: currentPage, size }: { page: number; size: number },
+  totalRecords: number,
+  max = 5,
+  pageNumberCap: number | null = PAGE_NUMBER_CAP
 ) {
   // If max is even, bump it up by 1, and log out a warning.
   if (max % 2 === 0) {
@@ -109,7 +115,7 @@ export function createPageCursors(
     max = max + 1
   }
 
-  const totalPages = computeTotalPages(totalRecords, size)
+  const totalPages = computeTotalPages(totalRecords, size, pageNumberCap)
 
   let pageCursors
   // Degenerate case of no records found.


### PR DESCRIPTION
This PR updates page numbers cap logic to be able to load more than 100 pages for auction results. Also added `page` and `size` to use pagination by page for auction results instead of cursor pagination.

JIRA - [DO-675]

[DO-675]: https://artsyproduct.atlassian.net/browse/DO-675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ