### PR TITLE
feat: fallback image for marketing collection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10839,7 +10839,7 @@ type MarketingCollection {
   relatedCollections(size: Int = 10): [MarketingCollection!]!
 
   # ID of an artwork with highest merchandis ability
-  representativeArtworkId: String
+  representativeArtworkID: String
 
   # Show featured artists section in header. Defaults to true
   showFeaturedArtists: Boolean!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10838,6 +10838,9 @@ type MarketingCollection {
   # Returns collections by the same artist if more than 4 exist, otherwise returns collections from the same category
   relatedCollections(size: Int = 10): [MarketingCollection!]!
 
+  # ID of an artwork with highest merchandis ability
+  representativeArtworkId: String
+
   # Show featured artists section in header. Defaults to true
   showFeaturedArtists: Boolean!
 

--- a/src/data/gravity.graphql
+++ b/src/data/gravity.graphql
@@ -1155,7 +1155,7 @@ type MarketingCollection {
   """
   ID of an artwork with highest merchandis ability
   """
-  representativeArtworkId: String
+  representativeArtworkID: String
 
   """
   Show featured artists section in header. Defaults to true

--- a/src/data/gravity.graphql
+++ b/src/data/gravity.graphql
@@ -1153,6 +1153,11 @@ type MarketingCollection {
   relatedCollections(size: Int = 10): [MarketingCollection!]!
 
   """
+  ID of an artwork with highest merchandis ability
+  """
+  representativeArtworkId: String
+
+  """
   Show featured artists section in header. Defaults to true
   """
   showFeaturedArtists: Boolean!

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -1082,7 +1082,7 @@ describe("gravity/stitching", () => {
       })
     })
 
-    describe("Thumbnail Image", () => {
+    describe("#thumbnailImage", () => {
       it("resolves the thumbnailImage field with a copy of the request context", async () => {
         const { resolvers } = await getGravityStitchedSchema()
         const { thumbnailImage } = resolvers.MarketingCollection
@@ -1119,14 +1119,14 @@ describe("gravity/stitching", () => {
         const args = {}
         const info = { mergeInfo: { delegateToSchema: jest.fn() } }
 
+        const imageData = {
+          image_url: "cat.jpg",
+        }
+
         const artworkLoader = () =>
           Promise.resolve({
-            thumbnailImage: {
-              image_url:
-                "https://www.example.com/representative-artwork-image.jpg",
-            },
+            images: [imageData],
           })
-
         const sharedContext = {
           artworkLoader,
         }
@@ -1135,16 +1135,14 @@ describe("gravity/stitching", () => {
 
         expect(sharedContext).toHaveProperty("artworkLoader")
 
-        expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith(
-          expect.objectContaining({
-            context: {
-              imageData: {
-                image_url:
-                  "https://www.example.com/representative-artwork-image.jpg",
-              },
-            },
-          })
-        )
+        expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
+          args: expect.anything(),
+          operation: "query",
+          fieldName: "_do_not_use_image",
+          schema: expect.anything(),
+          context: expect.objectContaining({ imageData }),
+          info: expect.anything(),
+        })
       })
     })
   })

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -1089,7 +1089,7 @@ describe("gravity/stitching", () => {
 
         const parent = {
           image_url: "https://www.example.com/image.jpg",
-          representativeArtworkID: "representativeArtworkID123",
+          representativeArtworkId: "representativeArtworkID123",
         }
         const args = {}
         const sharedContext = {}
@@ -1114,7 +1114,7 @@ describe("gravity/stitching", () => {
 
         const parent = {
           image_url: null,
-          representativeArtworkID: "representative-artwork-id",
+          representativeArtworkId: "representative-artwork-id",
         }
         const args = {}
         const info = { mergeInfo: { delegateToSchema: jest.fn() } }

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -1089,7 +1089,7 @@ describe("gravity/stitching", () => {
 
         const parent = {
           image_url: "https://www.example.com/image.jpg",
-          representativeArtworkId: "representativeArtworkID123",
+          representativeArtworkID: "representativeArtworkID123",
         }
         const args = {}
         const sharedContext = {}
@@ -1114,7 +1114,7 @@ describe("gravity/stitching", () => {
 
         const parent = {
           image_url: null,
-          representativeArtworkId: "representative-artwork-id",
+          representativeArtworkID: "representative-artwork-id",
         }
         const args = {}
         const info = { mergeInfo: { delegateToSchema: jest.fn() } }
@@ -1132,8 +1132,6 @@ describe("gravity/stitching", () => {
         }
 
         await thumbnailImage.resolve(parent, args, sharedContext, info)
-
-        expect(sharedContext).toHaveProperty("artworkLoader")
 
         expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
           args: expect.anything(),

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -302,11 +302,11 @@ export const gravityStitchingEnvironment = (
           fragment: gql`
           ... on MarketingCollection {
             image_url: thumbnail
-            representativeArtworkId
+            representativeArtworkID
           }
           `,
           resolve: async (
-            { representativeArtworkId, image_url },
+            { representativeArtworkID, image_url },
             args,
             context,
             info
@@ -314,9 +314,9 @@ export const gravityStitchingEnvironment = (
             let imageData: unknown
             if (image_url) {
               imageData = normalizeImageData(image_url)
-            } else if (representativeArtworkId) {
+            } else if (representativeArtworkID) {
               const { artworkLoader } = context
-              const { images } = await artworkLoader(representativeArtworkId)
+              const { images } = await artworkLoader(representativeArtworkID)
               imageData = normalizeImageData(getDefault(images))
             }
             return info.mergeInfo.delegateToSchema({

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -307,12 +307,11 @@ export const gravityStitchingEnvironment = (
           `,
           resolve: async (
             { representativeArtworkId, image_url },
-            _args,
+            args,
             context,
             info
           ) => {
             let imageData: unknown
-
             if (image_url) {
               imageData = normalizeImageData(image_url)
             } else if (representativeArtworkId) {
@@ -321,6 +320,7 @@ export const gravityStitchingEnvironment = (
               imageData = normalizeImageData(getDefault(images))
             }
             return info.mergeInfo.delegateToSchema({
+              args,
               schema: localSchema,
               operation: "query",
               fieldName: "_do_not_use_image",
@@ -824,7 +824,6 @@ export const gravityStitchingEnvironment = (
             }
           `,
           resolve: async (_parent, args, context, info) => {
-            console.log("[debug] :: I am here")
             try {
               return await info.mergeInfo.delegateToSchema({
                 schema: gravitySchema,

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -302,16 +302,33 @@ export const gravityStitchingEnvironment = (
           fragment: gql`
           ... on MarketingCollection {
             image_url: thumbnail
+            representativeArtworkID
           }
           `,
-          resolve: async ({ image_url }, _args, context, info) => {
+          resolve: async (
+            { representativeArtworkID, image_url },
+            _args,
+            context,
+            info
+          ) => {
+            let imageData: unknown
+            if (image_url) {
+              console.log("Coming here ", image_url)
+              imageData = normalizeImageData(image_url)
+            } else if (representativeArtworkID) {
+              console.log(" Not its Coming here ", representativeArtworkID)
+
+              const { artworkLoader } = context
+              const { images } = await artworkLoader(representativeArtworkID)
+              imageData = normalizeImageData(getDefault(images))
+            }
             return info.mergeInfo.delegateToSchema({
               schema: localSchema,
               operation: "query",
               fieldName: "_do_not_use_image",
               context: {
                 ...context,
-                imageData: normalizeImageData(image_url),
+                imageData,
               },
               info,
             })
@@ -809,6 +826,7 @@ export const gravityStitchingEnvironment = (
             }
           `,
           resolve: async (_parent, args, context, info) => {
+            console.log("[debug] :: I am here")
             try {
               return await info.mergeInfo.delegateToSchema({
                 schema: gravitySchema,

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -313,11 +313,8 @@ export const gravityStitchingEnvironment = (
           ) => {
             let imageData: unknown
             if (image_url) {
-              console.log("Coming here ", image_url)
               imageData = normalizeImageData(image_url)
             } else if (representativeArtworkID) {
-              console.log(" Not its Coming here ", representativeArtworkID)
-
               const { artworkLoader } = context
               const { images } = await artworkLoader(representativeArtworkID)
               imageData = normalizeImageData(getDefault(images))

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -302,21 +302,22 @@ export const gravityStitchingEnvironment = (
           fragment: gql`
           ... on MarketingCollection {
             image_url: thumbnail
-            representativeArtworkID
+            representativeArtworkId
           }
           `,
           resolve: async (
-            { representativeArtworkID, image_url },
+            { representativeArtworkId, image_url },
             _args,
             context,
             info
           ) => {
             let imageData: unknown
+
             if (image_url) {
               imageData = normalizeImageData(image_url)
-            } else if (representativeArtworkID) {
+            } else if (representativeArtworkId) {
               const { artworkLoader } = context
-              const { images } = await artworkLoader(representativeArtworkID)
+              const { images } = await artworkLoader(representativeArtworkId)
               imageData = normalizeImageData(getDefault(images))
             }
             return info.mergeInfo.delegateToSchema({


### PR DESCRIPTION
Lots of marketing collections do not have thumbnail images attached. When searching by collection name in the app, a collection without a thumbnail image will have a grey image placeholder instead.

This PR gets the `representativeArtworkId` from gravity and uses its `imageUrl` as the fallback image to display as the thumbnail image of those marketing collections.

for eg:

<img width="1381" alt="image" src="https://user-images.githubusercontent.com/17421923/231715276-1a66439a-aecd-46a4-8a4f-118732ba70ae.png">

