### PR TITLE
fix: Reduce number of loaded artists in AuctionResultsByFollowedArtists

### DIFF
--- a/src/lib/loaders/helpers.ts
+++ b/src/lib/loaders/helpers.ts
@@ -2,7 +2,7 @@ import { BodyAndHeaders, ResponseHeaders } from "."
 import { StaticPathLoader } from "./api/loader_interface"
 
 const MAX_FOLLOWED_ARTISTS_PER_STEP = 100
-const MAX_STEPS = 2
+const MAX_STEPS = 1
 
 /**
  * This is a helper function that loads all followed artists for a user.


### PR DESCRIPTION
Addresses [CX-3534]

## Description

Reduce number of loaded artists in AuctionResultsByFollowedArtists. Sending more than 100 artworks to Diffusion could be the reason for these timeouts ([Slack Thread](https://artsy.slack.com/archives/C01B2P6LJUU/p1681324853790219)).

[CX-3534]: https://artsyproduct.atlassian.net/browse/CX-3534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ