### PR TITLE
chore: rename `All Saves` to `Saved Artworks`

### DIFF
--- a/src/schema/v2/me/__tests__/collection.test.ts
+++ b/src/schema/v2/me/__tests__/collection.test.ts
@@ -63,7 +63,7 @@ it("returns collection attributes", async () => {
 })
 
 describe("name field", () => {
-  it("should return `All Saves` when collection has `Saved Artwork` name", async () => {
+  it("should return `Saved Artworks` when collection has `Saved Artwork` name", async () => {
     context.collectionLoader = jest.fn(() => {
       return Promise.resolve({
         ...mockGravityCollection,
@@ -73,7 +73,7 @@ describe("name field", () => {
 
     const response = await runAuthenticatedQuery(query, context)
 
-    expect(response.me.collection.name).toBe("All Saves")
+    expect(response.me.collection.name).toBe("Saved Artworks")
   })
 
   it("should return name received from gravity", async () => {

--- a/src/schema/v2/me/collection.ts
+++ b/src/schema/v2/me/collection.ts
@@ -100,7 +100,7 @@ export const CollectionType = new GraphQLObjectType<any, ResolverContext>({
         "Name of the collection. Has a predictable value for 'standard' collections such as Saved Artwork, My Collection, etc. Can be provided by user otherwise.",
       resolve: ({ name }) => {
         if (name === "Saved Artwork") {
-          return "All Saves"
+          return "Saved Artworks"
         }
 
         return name


### PR DESCRIPTION
### Description
We have to rename `All Saves` to `Saved Artworks`. See this [Figma](https://www.figma.com/file/wSV2KNz97Tyj8HkH2ZYAkB/Save-%2B-Lists?node-id=1961-232743&t=GnSm3kVwUDGayQux-0) file