### PR TITLE
feat: add initials property to CollectorProfileType (PLATFORM-5094)

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3740,6 +3740,7 @@ type CollectorProfileType {
     @deprecated(
       reason: "identityVerified is going to be removed, use isIdentityVerified instead"
     )
+  initials(length: Int = 3): String
   institutionalAffiliations: String
   intents: [String]
 
@@ -10358,6 +10359,7 @@ type InquirerCollectorProfile {
     @deprecated(
       reason: "identityVerified is going to be removed, use isIdentityVerified instead"
     )
+  initials(length: Int = 3): String
   institutionalAffiliations: String
   intents: [String]
 
@@ -17246,6 +17248,7 @@ type UpdateCollectorProfilePayload {
     @deprecated(
       reason: "identityVerified is going to be removed, use isIdentityVerified instead"
     )
+  initials(length: Int = 3): String
   institutionalAffiliations: String
   intents: [String]
 

--- a/src/schema/v2/CollectorProfile/collectorProfile.ts
+++ b/src/schema/v2/CollectorProfile/collectorProfile.ts
@@ -1,4 +1,5 @@
 import date, { date as dateFormatter } from "schema/v2/fields/date"
+
 import { InternalIDFields } from "schema/v2/object_identification"
 import {
   GraphQLID,
@@ -16,6 +17,7 @@ import Image, { normalizeImageData } from "schema/v2/image"
 
 import { userInterestType } from "../userInterests"
 import { myLocationType } from "../me/myLocation"
+import initials from "schema/v2/fields/initials"
 
 export const CollectorProfileFields: GraphQLFieldConfigMap<
   any,
@@ -43,6 +45,7 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
   intents: { type: new GraphQLList(GraphQLString) },
   loyaltyApplicantAt: date,
   name: { type: GraphQLString },
+  initials: initials("name"),
   privacy: { type: GraphQLString },
   professionalBuyerAppliedAt: date,
   professionalBuyerAt: date,

--- a/src/schema/v2/me/__tests__/collector_profile.test.js
+++ b/src/schema/v2/me/__tests__/collector_profile.test.js
@@ -10,6 +10,7 @@ describe("Me", () => {
             collectorProfile {
               internalID
               name
+              initials
               email
               selfReportedPurchases
               intents
@@ -50,6 +51,7 @@ describe("Me", () => {
       const expectedProfileData = {
         internalID: "3",
         name: "Percy",
+        initials: "P",
         email: "percy@cat.com",
         selfReportedPurchases: "treats",
         intents: ["buy art & design"],


### PR DESCRIPTION
This is a follow-up to https://github.com/artsy/metaphysics/pull/4934, where I tried to expose a `conversation.fromProfile` property that could serve in place of `conversation.fromUser.collectorProfile`. The latter depends on a request to the unprivileged user API that I would like to retire, but doesn't actually _need_ any of the data from that API (as all necessary fields are already available on the collector profile).

This PR adds the `initials` property that volt-v2 requires. It's based on the user name, which is handily available on the collector profile as well.