### PR TITLE
feat(NX-3437): add unread fields for Partner and Collector

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6976,9 +6976,16 @@ type Conversation implements Node {
 
   # The participant(s) responding to the conversation
   to: ConversationResponder!
+  toLastViewedMessageID: String
 
-  # True if there is an unread message by the user.
-  unread: Boolean
+  # True if there is an unread message by the Collector(from).
+  unread: Boolean @deprecated(reason: "Use `unreadByCollector` instead")
+
+  # True if there is an unread message by the Collector(from).
+  unreadByCollector: Boolean
+
+  # True if there is an unread message by the Partner(to).
+  unreadByPartner: Boolean
 }
 
 # A connection to a list of items.

--- a/src/schema/v2/conversation/__tests__/__snapshots__/conversation.test.js.snap
+++ b/src/schema/v2/conversation/__tests__/__snapshots__/conversation.test.js.snap
@@ -36,6 +36,8 @@ Object {
   "isLastMessageToUser": true,
   "lastMessageDeliveryID": "2",
   "unread": true,
+  "unreadByCollector": true,
+  "unreadByPartner": false,
 }
 `;
 

--- a/src/schema/v2/conversation/__tests__/conversation.test.js
+++ b/src/schema/v2/conversation/__tests__/conversation.test.js
@@ -25,6 +25,7 @@ describe("Me", () => {
             },
           },
           from_last_viewed_message_id: "20",
+          to_last_viewed_message_id: "20",
           items: [
             {
               item_type: "Artwork",
@@ -288,6 +289,7 @@ describe("Me", () => {
                 },
               },
               from_last_viewed_message_id: "20",
+              to_last_viewed_message_id: "20",
               items: [
                 {
                   item_type: "Artwork",
@@ -376,6 +378,7 @@ describe("Me", () => {
                 },
               },
               from_last_viewed_message_id: "20",
+              to_last_viewed_message_id: "20",
               items: [
                 {
                   item_type: "Artwork",
@@ -450,6 +453,7 @@ describe("Me", () => {
                 },
               },
               from_last_viewed_message_id: "20",
+              to_last_viewed_message_id: "20",
               items: [
                 {
                   item_type: "PartnerShow",

--- a/src/schema/v2/conversation/__tests__/conversation.test.js
+++ b/src/schema/v2/conversation/__tests__/conversation.test.js
@@ -25,7 +25,7 @@ describe("Me", () => {
             },
           },
           from_last_viewed_message_id: "20",
-          to_last_viewed_message_id: "20",
+          to_last_viewed_message_id: "25",
           items: [
             {
               item_type: "Artwork",
@@ -181,6 +181,8 @@ describe("Me", () => {
               conversation(id: "420") {
                 isLastMessageToUser
                 unread
+                unreadByCollector
+                unreadByPartner
                 lastMessageDeliveryID
               }
             }
@@ -208,6 +210,8 @@ describe("Me", () => {
         return runAuthenticatedQuery(query, customRootValue).then(
           ({ me: { conversation } }) => {
             expect(conversation).toMatchSnapshot()
+            expect(conversation.unreadByCollector).toBe(true)
+            expect(conversation.unreadByPartner).toBe(false)
           }
         )
       })

--- a/src/schema/v2/conversation/index.ts
+++ b/src/schema/v2/conversation/index.ts
@@ -329,6 +329,13 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
       resolve: ({ from_last_viewed_message_id }) => from_last_viewed_message_id,
     },
+    toLastViewedMessageID: {
+      type: GraphQLString,
+      resolve: ({ from_last_viewed_message_id, ...rest }) => {
+        console.log("### rest", rest)
+        return from_last_viewed_message_id
+      },
+    },
     initialMessage: {
       deprecationReason:
         "This field is no longer required. Prefer the first message from the MessageConnection.",
@@ -463,7 +470,8 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
     messagesConnection,
     unread: {
       type: GraphQLBoolean,
-      description: "True if there is an unread message by the user.",
+      description: "True if there is an unread message by the Collector(from).",
+      deprecationReason: "Use `unreadByCollector` instead",
       resolve: (conversation) => {
         const memoizedLastMessageId = lastMessageId(conversation)
         const { from_last_viewed_message_id } = conversation
@@ -471,6 +479,32 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
           !!from_last_viewed_message_id &&
           !!memoizedLastMessageId &&
           from_last_viewed_message_id < memoizedLastMessageId
+        )
+      },
+    },
+    unreadByCollector: {
+      type: GraphQLBoolean,
+      description: "True if there is an unread message by the Collector(from).",
+      resolve: (conversation) => {
+        const memoizedLastMessageId = lastMessageId(conversation)
+        const { from_last_viewed_message_id } = conversation
+        return (
+          !!from_last_viewed_message_id &&
+          !!memoizedLastMessageId &&
+          from_last_viewed_message_id < memoizedLastMessageId
+        )
+      },
+    },
+    unreadByPartner: {
+      type: GraphQLBoolean,
+      description: "True if there is an unread message by the Partner(to).",
+      resolve: (conversation) => {
+        const memoizedLastMessageId = lastMessageId(conversation)
+        const { to_last_viewed_message_id } = conversation
+        return (
+          !!to_last_viewed_message_id &&
+          !!memoizedLastMessageId &&
+          to_last_viewed_message_id < memoizedLastMessageId
         )
       },
     },

--- a/src/schema/v2/conversation/index.ts
+++ b/src/schema/v2/conversation/index.ts
@@ -331,9 +331,8 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
     },
     toLastViewedMessageID: {
       type: GraphQLString,
-      resolve: ({ from_last_viewed_message_id, ...rest }) => {
-        console.log("### rest", rest)
-        return from_last_viewed_message_id
+      resolve: ({ to_last_viewed_message_id }) => {
+        return to_last_viewed_message_id
       },
     },
     initialMessage: {

--- a/src/schema/v2/conversation/index.ts
+++ b/src/schema/v2/conversation/index.ts
@@ -189,6 +189,18 @@ const lastMessageId = (conversation) => {
   return get(conversation, "_embedded.last_message.id")
 }
 
+const unreadConversation = (
+  conversation: any,
+  lastViewedMessageId?: number
+) => {
+  const memoizedLastMessageId = lastMessageId(conversation)
+  return (
+    !!lastViewedMessageId &&
+    !!memoizedLastMessageId &&
+    lastViewedMessageId < memoizedLastMessageId
+  )
+}
+
 // TODO: Move back inside ConversationType after messages is removed
 const messagesConnection = {
   type: MessageConnection,
@@ -472,39 +484,24 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
       description: "True if there is an unread message by the Collector(from).",
       deprecationReason: "Use `unreadByCollector` instead",
       resolve: (conversation) => {
-        const memoizedLastMessageId = lastMessageId(conversation)
         const { from_last_viewed_message_id } = conversation
-        return (
-          !!from_last_viewed_message_id &&
-          !!memoizedLastMessageId &&
-          from_last_viewed_message_id < memoizedLastMessageId
-        )
+        return unreadConversation(conversation, from_last_viewed_message_id)
       },
     },
     unreadByCollector: {
       type: GraphQLBoolean,
       description: "True if there is an unread message by the Collector(from).",
       resolve: (conversation) => {
-        const memoizedLastMessageId = lastMessageId(conversation)
         const { from_last_viewed_message_id } = conversation
-        return (
-          !!from_last_viewed_message_id &&
-          !!memoizedLastMessageId &&
-          from_last_viewed_message_id < memoizedLastMessageId
-        )
+        return unreadConversation(conversation, from_last_viewed_message_id)
       },
     },
     unreadByPartner: {
       type: GraphQLBoolean,
       description: "True if there is an unread message by the Partner(to).",
       resolve: (conversation) => {
-        const memoizedLastMessageId = lastMessageId(conversation)
         const { to_last_viewed_message_id } = conversation
-        return (
-          !!to_last_viewed_message_id &&
-          !!memoizedLastMessageId &&
-          to_last_viewed_message_id < memoizedLastMessageId
-        )
+        return unreadConversation(conversation, to_last_viewed_message_id)
       },
     },
   },


### PR DESCRIPTION
[NX-3437]

- Adds unreadByPartner and unreadByCollector fields to the conversation
- deprecates `unread` in favor of `unreadByCollector` to improve the general understanding of it

[NX-3437]: https://artsyproduct.atlassian.net/browse/NX-3437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ