### PR TITLE
[Release on 4/18] Update the help center URL for Zendesk to Salesforce transition # Summary

### DIFF
--- a/src/schema/v2/artwork/taxInfo.ts
+++ b/src/schema/v2/artwork/taxInfo.ts
@@ -2,7 +2,7 @@ import { GraphQLNonNull, GraphQLObjectType, GraphQLString } from "graphql"
 import { isEligibleForOnPlatformTransaction } from "./utilities"
 
 export const CHECKOUT_TAXES_DOC_URL =
-  "https://support.artsy.net/hc/en-us/articles/360047294733-How-is-sales-tax-and-VAT-handled-on-works-listed-with-secure-checkout-"
+  "https://support.artsy.net/s/article/How-are-taxes-customs-VAT-and-import-fees-handled-on-works-listed-with-secure-checkout"
 
 const TaxMoreInfoType = new GraphQLObjectType({
   name: "TaxMoreInfo",


### PR DESCRIPTION
The PR updates one help center URL for Zendesk to Salesforce transition.

# Ticket
https://artsyproduct.atlassian.net/browse/TX-1097