### PR TITLE
feat(NX-3505): conversation dismissed is false by default on query

### DIFF
--- a/src/schema/v2/conversation/conversations.ts
+++ b/src/schema/v2/conversation/conversations.ts
@@ -91,7 +91,7 @@ const Conversations: GraphQLFieldConfig<
         to_type: "Partner",
         has_reply: args.hasReply ?? undefined,
         has_message: args.hasMessage ?? undefined,
-        dismissed: args.dismissed ?? undefined,
+        dismissed: !!args.dismissed,
         to_be_replied: args.toBeReplied ?? undefined,
       }
       // User


### PR DESCRIPTION
[NX-3505]

Makes dismissed param false by default querying Conversations.


[NX-3505]: https://artsyproduct.atlassian.net/browse/NX-3505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ