### PR TITLE
fix: restore access to identity and email verification status via collector profiles

### DIFF
--- a/src/schema/v2/CollectorProfile/collectorProfile.ts
+++ b/src/schema/v2/CollectorProfile/collectorProfile.ts
@@ -85,21 +85,21 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
     type: GraphQLBoolean,
     deprecationReason:
       "emailConfirmed is going to be removed, use isEmailConfirmed instead",
-    resolve: ({ owner }) => !!owner.confirmed_at,
+    resolve: ({ email_confirmed_at }) => !!email_confirmed_at,
   },
   isEmailConfirmed: {
     type: GraphQLBoolean,
-    resolve: ({ owner }) => !!owner.confirmed_at,
+    resolve: ({ email_confirmed_at }) => !!email_confirmed_at,
   },
   identityVerified: {
     type: GraphQLBoolean,
     deprecationReason:
       "identityVerified is going to be removed, use isIdentityVerified instead",
-    resolve: ({ owner }) => owner.identity_verified,
+    resolve: ({ identity_verified }) => identity_verified,
   },
   isIdentityVerified: {
     type: GraphQLBoolean,
-    resolve: ({ owner }) => owner.identity_verified,
+    resolve: ({ identity_verified }) => identity_verified,
   },
   isActiveInquirer: {
     type: GraphQLBoolean,

--- a/src/schema/v2/me/__tests__/collector_profile.test.js
+++ b/src/schema/v2/me/__tests__/collector_profile.test.js
@@ -36,12 +36,10 @@ describe("Me", () => {
         intents: ["buy art & design"],
         privacy: "public",
         owner: {
-          location: {
-            display: "Germany",
-          },
-          confirmed_at: "2022-12-19",
-          identity_verified: true,
+          name: "Percy",
         },
+        email_confirmed_at: "2022-12-19",
+        identity_verified: true,
         profession: "typer",
         artwork_inquiry_requests_count: 25,
         previously_registered_for_auction: false,


### PR DESCRIPTION
Depends on https://github.com/artsy/gravity/pull/16260, so a draft for now.

As described there, these verification statuses are no longer available within the nested `owner`, so they must be resolved from the top-level collector profile properties. Once that's merged, we can validate and release this change.