### PR TITLE
fix: improve date validation for comparable artworks

### DIFF
--- a/src/lib/__tests__/helpers.test.ts
+++ b/src/lib/__tests__/helpers.test.ts
@@ -2,7 +2,7 @@ import {
   convertConnectionArgsToGravityArgs,
   exclude,
   isExisty,
-  isInteger,
+  isValidDate,
   markdownToText,
   removeEmptyValues,
   removeNulls,
@@ -308,14 +308,20 @@ describe("convertConnectionArgsToGravityArgs", () => {
   })
 })
 
-describe("isInteger", () => {
+describe("isDateValid", () => {
   it("only returns true if the input string is a valid integer", () => {
-    expect(isInteger("0")).toEqual(true)
-    expect(isInteger("1")).toEqual(true)
-    expect(isInteger("-1")).toEqual(true)
-    expect(isInteger("1.5")).toEqual(false)
-    expect(isInteger("test")).toEqual(false)
-    expect(isInteger("")).toEqual(false)
-    expect(isInteger("   ")).toEqual(false)
+    expect(isValidDate("0")).toEqual(true)
+    expect(isValidDate("1")).toEqual(true)
+    expect(isValidDate("-1")).toEqual(true)
+    expect(isValidDate("1.5")).toEqual(false)
+    expect(isValidDate("test")).toEqual(false)
+    expect(isValidDate("")).toEqual(false)
+    expect(isValidDate("   ")).toEqual(false)
+    expect(isValidDate("1991-1993")).toEqual(false)
+    expect(isValidDate("1963/64")).toEqual(false)
+    expect(isValidDate("19th Century")).toEqual(false)
+    expect(isValidDate("2023, 4, 23")).toEqual(false)
+    expect(isValidDate("4th-5th Century AD")).toEqual(false)
+    expect(isValidDate("2000s")).toEqual(false)
   })
 })

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -236,8 +236,9 @@ export const extractNodes = <Node extends object, T = Node>(
   )
 }
 
-export const isInteger = (str: string) => {
-  return Number.isInteger(parseFloat(str))
+export const isValidDate = (str: string) => {
+  const num = parseInt(str, 10)
+  return !isNaN(num) && str.trim() === num.toString() && Number.isInteger(num)
 }
 
 // For some users with no favourites, Gravity can return a 404 (which reflects the

--- a/src/schema/v2/artwork/comparableAuctionResults.ts
+++ b/src/schema/v2/artwork/comparableAuctionResults.ts
@@ -1,6 +1,6 @@
 import { GraphQLFieldConfig } from "graphql"
 import { connectionFromArraySlice } from "graphql-relay"
-import { convertConnectionArgsToGravityArgs, isInteger } from "lib/helpers"
+import { convertConnectionArgsToGravityArgs, isValidDate } from "lib/helpers"
 import { isNull, merge, omitBy } from "lodash"
 import { pageable } from "relay-cursor-paging"
 import { ResolverContext } from "types/graphql"
@@ -23,7 +23,7 @@ export const ComparableAuctionResults: GraphQLFieldConfig<
 
     const comparableAuctionResultsParams = {
       artist_id: artwork.artist._id,
-      date: isInteger(artwork.date) ? artwork.date : undefined,
+      date: isValidDate(artwork.date) ? artwork.date : undefined,
       height_cm: artwork.height_cm,
       width_cm: artwork.width_cm,
       depth_cm: artwork.depth_cm,


### PR DESCRIPTION
Fix for [dates](https://app.datadoghq.com/apm/services/diffusion.controller/operations/rails.action_controller/traces?query=%40_top_level%3A1%20env%3Aproduction%20service%3Adiffusion.controller%20operation_name%3Arails.action_controller%20-status%3Aok&env=production&graphType=flamegraph&spanID=6280903352830411409&spanType=service-entry&spanViewType=metadata&summary=qson%3A%28data%3A%28visible%3A%21t%2Cerrors%3A%28selected%3Acount%29%2Chits%3A%28selected%3Acount%29%2Clatency%3A%28selected%3Alatency%2Cslot%3A%28agg%3A75%29%2Cdistribution%3A%28isLogScale%3A%21f%29%29%2Csublayer%3A%28slot%3A%28layers%3Aservice%29%2Cselected%3Apercentage%29%29%2Cversion%3A%211%29&topGraphs=latency%3Alatency%2CbreakdownAs%3Apercentage%2Cerrors%3Acount%2Chits%3Aversion_count&traces=qson%3A%28data%3A%28search%3A-status%253Aok%29%2Cversion%3A%210%29&start=1679749842930&end=1682341842930&paused=false) passed to Comparable Lots service.