### PR TITLE
feat: support marketable flag for artworksForUser

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14251,6 +14251,7 @@ type Query {
     first: Int
     includeBackfill: Boolean!
     last: Int
+    marketable: Boolean
     maxWorksPerArtist: Int
     page: Int
     userId: String
@@ -18690,6 +18691,7 @@ type Viewer {
     first: Int
     includeBackfill: Boolean!
     last: Int
+    marketable: Boolean
     maxWorksPerArtist: Int
     page: Int
     userId: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14251,7 +14251,7 @@ type Query {
     first: Int
     includeBackfill: Boolean!
     last: Int
-    marketable: Boolean
+    marketable: Boolean = false
     maxWorksPerArtist: Int
     page: Int
     userId: String
@@ -18691,7 +18691,7 @@ type Viewer {
     first: Int
     includeBackfill: Boolean!
     last: Int
-    marketable: Boolean
+    marketable: Boolean = false
     maxWorksPerArtist: Int
     page: Int
     userId: String

--- a/src/schema/v2/artworksForUser/artworksForUser.ts
+++ b/src/schema/v2/artworksForUser/artworksForUser.ts
@@ -28,6 +28,7 @@ export const artworksForUser: GraphQLFieldConfig<void, ResolverContext> = {
     userId: { type: GraphQLString },
     version: { type: GraphQLString },
     maxWorksPerArtist: { type: GraphQLInt },
+    marketable: { type: GraphQLBoolean },
   }),
   resolve: async (_root, args: CursorPageable, context) => {
     if (!context.artworksLoader) return

--- a/src/schema/v2/artworksForUser/helpers.ts
+++ b/src/schema/v2/artworksForUser/helpers.ts
@@ -52,19 +52,20 @@ export const getNewForYouArtworks = async (
 ): Promise<any[]> => {
   if (artworkIds.length === 0) return []
 
-  const { size, offset } = gravityArgs
-  const { artworksLoader } = context
+  const { size, offset, marketable } = gravityArgs
+  const { filterArtworksLoader } = context
 
   const artworkParams = {
     availability: "for sale",
     ids: artworkIds,
+    marketable,
     offset,
     size,
   }
 
-  const body = await artworksLoader(artworkParams)
+  const { hits } = await filterArtworksLoader(artworkParams)
 
-  return body
+  return hits
 }
 
 export const getBackfillArtworks = async (

--- a/src/schema/v2/artworksForUser/helpers.ts
+++ b/src/schema/v2/artworksForUser/helpers.ts
@@ -52,20 +52,19 @@ export const getNewForYouArtworks = async (
 ): Promise<any[]> => {
   if (artworkIds.length === 0) return []
 
-  const { size, offset, marketable } = gravityArgs
-  const { filterArtworksLoader } = context
+  const { size, offset } = gravityArgs
+  const { artworksLoader } = context
 
   const artworkParams = {
     availability: "for sale",
     ids: artworkIds,
-    marketable,
     offset,
     size,
   }
 
-  const { hits } = await filterArtworksLoader(artworkParams)
+  const body = await artworksLoader(artworkParams)
 
-  return hits
+  return body
 }
 
 export const getBackfillArtworks = async (
@@ -88,4 +87,17 @@ export const getBackfillArtworks = async (
   const { body: itemsBody } = await setItemsLoader(backfillSetId)
 
   return (itemsBody || []).slice(0, remainingSize)
+}
+
+export const getMarketableArtworks = async (
+  artworkIds: string[],
+  context: ResolverContext
+): Promise<any[]> => {
+  const { filterArtworksLoader } = context
+  const { hits } = await filterArtworksLoader({
+    ids: artworkIds,
+    marketable: true,
+  })
+
+  return hits
 }


### PR DESCRIPTION
This PR makes the following changes:

- Support `marketable` arg in order to only return marketable artworks inside `artworksForUser` interface.
- Updates loader used for artworksForUser to be the using filter artworks endpoint:
  - Why? The latter not only supports `marketable` filtering  but also uses ES for filtering and should allow, if we want to, better filtering

| Condition                          | Screenshot                                                                                                                                                             |
|------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| When `marketable` is `true`        | <img width="1363" alt="Screenshot 2023-04-24 at 15 26 37" src="https://user-images.githubusercontent.com/11945712/234012688-1800f393-ba52-407f-89db-352a40fa5d8a.png"> |
| When `marketable` is `false`       | <img width="1364" alt="Screenshot 2023-04-24 at 15 26 45" src="https://user-images.githubusercontent.com/11945712/234012524-d6990f01-917a-4552-a682-7462f61ad3cd.png"> |
| When `marketable` is not specified | <img width="1727" alt="Screenshot 2023-04-24 at 15 34 36" src="https://user-images.githubusercontent.com/11945712/234012502-ec81ff2d-7c87-42a7-82e4-4daada4f8a91.png"> |