### PR TITLE
chore(NX-3438): Allow updateConversation mutation to update toLastViewedMessageId

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17357,7 +17357,7 @@ input UpdateConversationMutationInput {
   # Mark the conversation as dismissed
   dismissed: Boolean
 
-  # The message id to mark as read.
+  # The message id to mark as read as a collector (from).
   fromLastViewedMessageId: String
 
   # The seller outcome for the conversation. Options include `already_contacted`, `dont_trust`, `other`, `work_unavailable`.
@@ -17365,6 +17365,9 @@ input UpdateConversationMutationInput {
 
   # The seller outcome comment for the conversation.
   sellerOutcomeComment: String
+
+  # The message id to mark as read as a partner (to).
+  toLastViewedMessageId: String
 }
 
 type UpdateConversationMutationPayload {

--- a/src/schema/v2/conversation/__tests__/update_conversation_mutation.test.js
+++ b/src/schema/v2/conversation/__tests__/update_conversation_mutation.test.js
@@ -5,7 +5,7 @@ describe("UpdateConversationMutation", () => {
   it("sets from_last_viewed_message_id", async () => {
     const mutation = `
       mutation {
-        updateConversation(input: { conversationId: "25", fromLastViewedMessageId: "35", dismissed: true, sellerOutcome: "already_contacted", sellerOutcomeComment: "Outcome comment" }) {
+        updateConversation(input: { conversationId: "25", fromLastViewedMessageId: "35", toLastViewedMessageId: "36" dismissed: true, sellerOutcome: "already_contacted", sellerOutcomeComment: "Outcome comment" }) {
           conversation {
             initialMessage
           }

--- a/src/schema/v2/conversation/update_conversation_mutation.ts
+++ b/src/schema/v2/conversation/update_conversation_mutation.ts
@@ -8,6 +8,7 @@ interface UpdateMessageMutationInputProps {
   conversationId: string
   dismissed: boolean
   fromLastViewedMessageId: string
+  toLastViewedMessageId: string
   sellerOutcome: string
   sellerOutcomeComment: string
 }
@@ -34,7 +35,11 @@ export default mutationWithClientMutationId<
     },
     fromLastViewedMessageId: {
       type: GraphQLString,
-      description: "The message id to mark as read.",
+      description: "The message id to mark as read as a collector (from).",
+    },
+    toLastViewedMessageId: {
+      type: GraphQLString,
+      description: "The message id to mark as read as a partner (to).",
     },
     sellerOutcome: {
       type: GraphQLString,
@@ -66,6 +71,7 @@ export default mutationWithClientMutationId<
         {
           dismissed: args.dismissed,
           from_last_viewed_message_id: args.fromLastViewedMessageId,
+          to_last_viewed_message_id: args.toLastViewedMessageId,
           seller_outcome: args.sellerOutcome,
           seller_outcome_comment: args.sellerOutcomeComment,
         }


### PR DESCRIPTION
Resolves [NX-3438](https://artsyproduct.atlassian.net/browse/NX-3438)

The `updateConversation` mutation now takes a `toLastViewedMessageId` that updates the `to_last_viewed_message_id` field on Impulse.

cc @artsy/negotiate-devs 

[NX-3438]: https://artsyproduct.atlassian.net/browse/NX-3438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ