### PR TITLE
feat: Allow trusted clients to fetch sale artworks by user ID

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11301,6 +11301,7 @@ type Me implements Node {
     saleSlug: String
     size: Int
     sort: String
+    userId: String
   ): SaleArtworksConnection
 
   # The current user's status relating to bids on artworks
@@ -14940,6 +14941,7 @@ type Query {
     saleSlug: String
     size: Int
     sort: String
+    userId: String
   ): SaleArtworksConnection
 
   # A list of Sales
@@ -19200,6 +19202,7 @@ type Viewer {
     saleSlug: String
     size: Int
     sort: String
+    userId: String
   ): SaleArtworksConnection
 
   # A list of Sales

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -211,6 +211,11 @@ export default (opts) => {
       (id) => `sale/${id}/sale_artworks`,
       { headers: true }
     ),
+    saleArtworksAllLoader: gravityLoader(
+      "sale_artworks",
+      {},
+      { headers: true }
+    ),
     saleArtworksLoader: gravityLoader(
       (id) => `sale/${id}/sale_artworks`,
       {},

--- a/src/schema/v2/__tests__/sale_artworks.test.ts
+++ b/src/schema/v2/__tests__/sale_artworks.test.ts
@@ -10,7 +10,7 @@ describe("Sale Artworks", () => {
     })
   }
 
-  it("pulls from /sale_artworks if `live_sale, include_lots_by_followed_artists, is_auction to true` ", async () => {
+  it("pulls from /sale_artworks if `live_sale, include_lots_by_followed_artists, is_auction to true`", async () => {
     const hits = _.fill(Array(10), { id: "foo" })
     const totalCount = hits.length * 2
     const gravityResponse = {
@@ -22,7 +22,11 @@ describe("Sale Artworks", () => {
     const query = gql`
       {
         me {
-          lotsByFollowedArtistsConnection(liveSale: true, isAuction: true) {
+          lotsByFollowedArtistsConnection(
+            liveSale: true
+            isAuction: true
+            userId: "test-user-id"
+          ) {
             counts {
               total
             }
@@ -161,7 +165,7 @@ describe("Sale Artworks", () => {
         },
       },
     } = await execute(gravityResponse, query)
-    const [first, last] = [_.first(edges), _.last(edges)]
+    const [first, last] = [_.first(edges), _.last(edges)] as any
     expect(first.cursor).toEqual(startCursor)
     expect(last.cursor).toEqual(endCursor)
     expect(hasNextPage).toEqual(true)
@@ -304,9 +308,7 @@ describe("Sale Artworks", () => {
       }
     `
     expect.hasAssertions()
-    const {
-      saleArtworksConnection: { edges },
-    } = await execute(gravityResponse, query, {
+    await execute(gravityResponse, query, {
       saleArtworksFilterLoader: ({
         include_artworks_by_followed_artists,
         sale_id,

--- a/src/schema/v2/sale_artworks.ts
+++ b/src/schema/v2/sale_artworks.ts
@@ -96,6 +96,7 @@ export const SaleArtworksConnectionField: GraphQLFieldConfig<
     },
     size: { type: GraphQLInt },
     sort: { type: GraphQLString },
+    userId: { type: GraphQLString },
   }),
   description: "Sale Artworks search results",
   type: SaleArtworksConnectionType,
@@ -111,6 +112,7 @@ export const SaleArtworksConnectionField: GraphQLFieldConfig<
       liveSale,
       saleID,
       saleSlug,
+      userId,
       ..._args
     },
     { saleArtworksFilterLoader, saleArtworksAllLoader },
@@ -140,6 +142,7 @@ export const SaleArtworksConnectionField: GraphQLFieldConfig<
       is_auction: isAuction,
       live_sale: liveSale,
       sale_id: saleID || saleSlug,
+      user_id: userId,
       ..._args,
     }
 
@@ -150,6 +153,7 @@ export const SaleArtworksConnectionField: GraphQLFieldConfig<
     if (saleArtworksAllLoader && args.live_sale) {
       // @ts-expect-error FIXME: Make `page` an optional parameter on `params`
       delete params.page
+
       const { body, headers } = await saleArtworksAllLoader({
         ...params,
         total_count: true,


### PR DESCRIPTION
Addresses [CX-3621]

## Description

This PR allows trusted clients to fetch sale artworks by user ID as a param by passing the user ID to Gravity.


Related Gravity PR: https://github.com/artsy/gravity/pull/16258

---

**Query:**

```
{
    viewer {
        saleArtworksConnection(
            first: 10
            includeArtworksByFollowedArtists: true
            isAuction: true
            liveSale: true
            userId: "a-user-id"
        ) {
            pageInfo {
                hasNextPage
                startCursor
                endCursor
            }
            edges {
                node {
                    id
                    href
                    slug
                }
            }
        }
    }
}
```

[CX-3621]: https://artsyproduct.atlassian.net/browse/CX-3621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ