### PR TITLE
fix: remove cache availability check from health-check endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ import compression from "compression"
 import bodyParser from "body-parser"
 import { info, error } from "./src/lib/loggers"
 import config from "./src/config"
-import cache from "./src/lib/cache"
 import { init as initTracer } from "./src/lib/tracer"
 import { IpFilter as ipfilter } from "express-ipfilter"
 import { errorHandler } from "./src/lib/errorHandler"
@@ -96,14 +95,8 @@ function bootApp() {
     if (isShuttingDown) {
       return res.status(503).end()
     }
-    cache
-      .isAvailable()
-      .then((_stats) => {
-        return res.status(200).end()
-      })
-      .catch((_err) => {
-        return res.status(503).end()
-      })
+
+    return res.status(200).end()
   })
 
   app.all("/graphql", (_req, res) => res.redirect("/v2"))

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -193,17 +193,4 @@ export default {
   delete: (key: string) => {
     return cacheTracer.delete(_delete(key))
   },
-
-  isAvailable: () => {
-    return new Promise((resolve, reject) => {
-      client.stats((err, resp) => {
-        if (err) {
-          error(err)
-          reject(err)
-        } else {
-          resolve(resp)
-        }
-      })
-    })
-  },
 }


### PR DESCRIPTION
We had an incident today when all MP pods were removed, presumably failing a health-check. We also observed some logs and metrics that were pointing to increased cache latency.

At first, it seemed like MP should be resilient to this, as all the `get` calls are wrapped in a way that will time them out fairly aggressively.

However, we were actually making a call to the cache for health-checks, which would likely hang. Let's just remove it! With this call, MP is not very resilient to a slowly-responding cache server, and I think our goal is to be as resilient as possible (while not masking real issues, which I believe to be caught by more dedicated monitoring for the cache, which we already have via datadog, Elasticache metrics, etc.)