### PR TITLE
fix: bump request body limit to 1mb from 100kb

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import "moment-timezone"
 import xapp from "@artsy/xapp"
 import compression from "compression"
-import bodyParser from "body-parser"
+import { bodyParserMiddleware } from "./src/lib/bodyParserMiddleware"
 import { info, error } from "./src/lib/loggers"
 import config from "./src/config"
 import { init as initTracer } from "./src/lib/tracer"
@@ -85,7 +85,7 @@ function bootApp() {
     )
   }
 
-  app.use(bodyParser.json())
+  app.use(bodyParserMiddleware)
 
   app.get("/favicon.ico", (_req, res) => {
     res.status(200).set({ "Content-Type": "image/x-icon" }).end()

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import { optionalFieldsDirectiveExtension } from "directives/optionalField/optio
 import { principalFieldDirectiveExtension } from "directives/principleField/principalFieldDirectiveExtension"
 import { principalFieldDirectiveValidation } from "directives/principleField/principalFieldDirectiveValidation"
 import * as Sentry from "@sentry/node"
+import { bodyParserMiddleware } from "lib/bodyParserMiddleware"
 
 const {
   ENABLE_GRAPHQL_UPLOAD,
@@ -120,8 +121,9 @@ app.use(
     maxAge: 600,
   }),
   morgan,
-  // Gotta parse the JSON body before passing it to logQueryDetails/fetchPersistedQuery
-  bodyParser.json(),
+  // The body parser middleware is needed for integration tests that use this file directly,
+  // even though it is also included in the root index.js file.
+  bodyParserMiddleware,
   rateLimiterMiddleware,
   // Ensure this divider is logged before both fetchPersistedQuery and graphqlHTTP
   (_req, _res, next) => {

--- a/src/lib/bodyParserMiddleware.ts
+++ b/src/lib/bodyParserMiddleware.ts
@@ -1,0 +1,3 @@
+import bodyParser from "body-parser"
+
+export const bodyParserMiddleware = bodyParser.json({ limit: "1mb" })


### PR DESCRIPTION
Passing in a request body that was > 100kb to Metaphysics (now happening due to page management), led to a 'silent' 404. It turns out that the default for `body-parser` is 100kb. MP would return a 404 (and Chrome complained about a CORS issue in the dev console, likely a red herring due to the 404 not returning some appropriate headers). The 404 was 'silent' b/c there  were no logs from the MP webserver indicating something like 'Request size too large'.

I suppose we shouldn't spam logs with every issue related to an invalid request, but I dunno - it certainly would have been nice to have seen that in this case!

Additionally, looks like there's an extra use of `bodyParser` middleware that's not needed, so removing that too.