### PR TITLE
feat: add marketable arg to artworksForUser query field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14255,6 +14255,7 @@ type Query {
     first: Int
     includeBackfill: Boolean!
     last: Int
+    marketable: Boolean
     maxWorksPerArtist: Int
     page: Int
     userId: String
@@ -18698,6 +18699,7 @@ type Viewer {
     first: Int
     includeBackfill: Boolean!
     last: Int
+    marketable: Boolean
     maxWorksPerArtist: Int
     page: Int
     userId: String

--- a/src/schema/v2/artworksForUser/__tests__/helpers.test.ts
+++ b/src/schema/v2/artworksForUser/__tests__/helpers.test.ts
@@ -49,7 +49,7 @@ describe("getNewForYouArtworks", () => {
     const context = {} as any
 
     const artworks = await getNewForYouArtworks(
-      artworkIds,
+      { ids: artworkIds },
       gravityArgs,
       context
     )
@@ -65,7 +65,7 @@ describe("getNewForYouArtworks", () => {
     } as any
 
     const artworks = await getNewForYouArtworks(
-      artworkIds,
+      { ids: artworkIds },
       gravityArgs,
       context
     )

--- a/src/schema/v2/artworksForUser/artworksForUser.ts
+++ b/src/schema/v2/artworksForUser/artworksForUser.ts
@@ -28,6 +28,7 @@ export const artworksForUser: GraphQLFieldConfig<void, ResolverContext> = {
     userId: { type: GraphQLString },
     version: { type: GraphQLString },
     maxWorksPerArtist: { type: GraphQLInt },
+    marketable: { type: GraphQLBoolean },
   }),
   resolve: async (_root, args: CursorPageable, context) => {
     if (!context.artworksLoader) return
@@ -38,7 +39,10 @@ export const artworksForUser: GraphQLFieldConfig<void, ResolverContext> = {
     const { page, size, offset } = gravityArgs
 
     const newForYouArtworks = await getNewForYouArtworks(
-      newForYouArtworkIds,
+      {
+        ids: newForYouArtworkIds,
+        marketable: args.marketable,
+      },
       gravityArgs,
       context
     )

--- a/src/schema/v2/artworksForUser/helpers.ts
+++ b/src/schema/v2/artworksForUser/helpers.ts
@@ -46,20 +46,24 @@ export const getNewForYouRecs = async (
 }
 
 export const getNewForYouArtworks = async (
-  artworkIds: string[],
+  { ids, marketable }: { ids: string[]; marketable?: boolean },
   gravityArgs,
   context: ResolverContext
 ): Promise<any[]> => {
-  if (artworkIds.length === 0) return []
+  if (ids.length === 0) return []
 
   const { size, offset } = gravityArgs
   const { artworksLoader } = context
 
   const artworkParams = {
     availability: "for sale",
-    ids: artworkIds,
+    ids: ids,
     offset,
     size,
+  }
+
+  if (marketable) {
+    artworkParams["marketable"] = true
   }
 
   const body = await artworksLoader(artworkParams)


### PR DESCRIPTION
Allow clients to pass `marketable: true` arg for `artworksForUser` query field to filter to only marketable artworks.

Jira: [FX-4768](https://artsyproduct.atlassian.net/browse/FX-4768)