### PR TITLE
refactor: return all item in an orderedSet

### DIFF
--- a/src/schema/v2/OrderedSet/OrderedSet.ts
+++ b/src/schema/v2/OrderedSet/OrderedSet.ts
@@ -21,6 +21,7 @@ import { markdown } from "../fields/markdown"
 import { OrderedSetLayoutsEnum } from "./OrderedSetLayoutsEnum"
 import { date } from "../fields/date"
 import { UserType } from "../user"
+import { allViaLoader } from "lib/all"
 
 export const OrderedSetType = new GraphQLObjectType<
   Gravity.OrderedSet & { cached: number; created_by: any },
@@ -63,7 +64,7 @@ export const OrderedSetType = new GraphQLObjectType<
     items: {
       type: new GraphQLList(OrderedSetItemType),
       resolve: ({ id, item_type }, _options, { setItemsLoader }) => {
-        return setItemsLoader(id).then(({ body: items }) => {
+        return allViaLoader(setItemsLoader, { path: id }).then((items) => {
           return items.map((item) => {
             return { ...item, item_type }
           })

--- a/src/schema/v2/__tests__/ordered_set.test.js
+++ b/src/schema/v2/__tests__/ordered_set.test.js
@@ -39,7 +39,7 @@ describe("OrderedSet type", () => {
               title: "Another Artwork",
             },
           ],
-          headers: {},
+          headers: { "x-total-count": 2 },
         })
       ),
     }

--- a/src/schema/v2/__tests__/ordered_sets.test.js
+++ b/src/schema/v2/__tests__/ordered_sets.test.js
@@ -38,6 +38,7 @@ describe("OrderedSets type", () => {
             name: "Painting",
           },
         ],
+        headers: { "x-total-count": 1 },
       })
     ),
   }


### PR DESCRIPTION
This PR refactors the `orderedSet` field `items` to return _all_ of the set's items instead of just `10`. 

![2023-05-02 15 53 25](https://user-images.githubusercontent.com/38149304/235774692-c969a6c6-1bec-4703-acca-38a193f0a31f.gif)

### Motivation
- See https://github.com/artsy/forque/pull/810

### TODO

- [ ] Validate that no [use](https://github.com/search?q=org%3Aartsy%20orderedSet(&type=code)) of `orderedSet` implicitly relies on the current return 1-page limit of `10`. 

[PLATFORM-5147](https://artsyproduct.atlassian.net/browse/PLATFORM-5147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

[PLATFORM-5147]: https://artsyproduct.atlassian.net/browse/PLATFORM-5147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ