### PR TITLE
Update tool versions file

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 18.15
+nodejs 18.15.0


### PR DESCRIPTION
I'm not totally sure what happened here but at least for me this way of specifying a node version does not work with asdf:

```
jon@sabretooth:~/code/temp/metaphysics(main)% asdf current
java            zulu-11.58.15   /Users/jon/.tool-versions
nodejs          18.15           Not installed. Run "asdf install nodejs 18.15"
python          3.9.13          /Users/jon/.tool-versions
ruby            3.1.0           /Users/jon/.tool-versions
rust            1.55.0          /Users/jon/.tool-versions
15:25:17
jon@sabretooth:~/code/temp/metaphysics(main)% asdf install nodejs 18.15
Trying to update node-build... ok
node-build: definition not found: 18.15
```

So all I did here was specify down to the patch level. I assume this is fine but lmk if I'm missing something!