### PR TITLE
chore: make my collection info node

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12382,6 +12382,9 @@ type MyCollectionConnection {
   # A globally unique ID.
   id: ID!
   includesPurchasedArtworks: Boolean!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
   name: String!
   pageCursors: PageCursors!
 
@@ -12478,6 +12481,9 @@ type MyCollectionInfo implements Node {
   # A globally unique ID.
   id: ID!
   includesPurchasedArtworks: Boolean!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
   name: String!
   private: Boolean!
 }

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12446,7 +12446,7 @@ type MyCollectionEdge {
   node: Artwork
 }
 
-type MyCollectionInfo {
+type MyCollectionInfo implements Node {
   # Insights for all collected artists
   artistInsights(
     # The type of insight.

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12378,6 +12378,9 @@ type MyCollectionConnection {
 
   # A list of edges.
   edges: [MyCollectionEdge]
+
+  # A globally unique ID.
+  id: ID!
   includesPurchasedArtworks: Boolean!
   name: String!
   pageCursors: PageCursors!
@@ -12471,6 +12474,9 @@ type MyCollectionInfo implements Node {
   ): ArtistConnection
   default: Boolean!
   description: String!
+
+  # A globally unique ID.
+  id: ID!
   includesPurchasedArtworks: Boolean!
   name: String!
   private: Boolean!

--- a/src/schema/v2/me/myCollectionInfo.ts
+++ b/src/schema/v2/me/myCollectionInfo.ts
@@ -15,6 +15,7 @@ import { getArtistInsights } from "../artist/helpers"
 import { ArtistInsight, ArtistInsightKind } from "../artist/insights"
 import { paginationResolver } from "../fields/pagination"
 import ArtistSorts from "../sorts/artist_sorts"
+import { NodeInterface } from "../object_identification"
 
 export const MAX_ARTISTS = 100
 
@@ -215,6 +216,7 @@ export const myCollectionInfoFields = {
 
 const MyCollectionInfoType = new GraphQLObjectType<any, ResolverContext>({
   name: "MyCollectionInfo",
+  interfaces: [NodeInterface],
   fields: myCollectionInfoFields,
 })
 

--- a/src/schema/v2/me/myCollectionInfo.ts
+++ b/src/schema/v2/me/myCollectionInfo.ts
@@ -15,7 +15,7 @@ import { getArtistInsights } from "../artist/helpers"
 import { ArtistInsight, ArtistInsightKind } from "../artist/insights"
 import { paginationResolver } from "../fields/pagination"
 import ArtistSorts from "../sorts/artist_sorts"
-import { NodeInterface } from "../object_identification"
+import { GlobalIDField, NodeInterface } from "../object_identification"
 
 export const MAX_ARTISTS = 100
 
@@ -44,6 +44,7 @@ const artistInsightsCountType = new GraphQLObjectType({
 })
 
 export const myCollectionInfoFields = {
+  id: GlobalIDField,
   description: {
     type: new GraphQLNonNull(GraphQLString),
   },

--- a/src/schema/v2/me/myCollectionInfo.ts
+++ b/src/schema/v2/me/myCollectionInfo.ts
@@ -14,8 +14,8 @@ import { ResolverContext } from "types/graphql"
 import { getArtistInsights } from "../artist/helpers"
 import { ArtistInsight, ArtistInsightKind } from "../artist/insights"
 import { paginationResolver } from "../fields/pagination"
+import { InternalIDFields, NodeInterface } from "../object_identification"
 import ArtistSorts from "../sorts/artist_sorts"
-import { GlobalIDField, NodeInterface } from "../object_identification"
 
 export const MAX_ARTISTS = 100
 
@@ -44,7 +44,7 @@ const artistInsightsCountType = new GraphQLObjectType({
 })
 
 export const myCollectionInfoFields = {
-  id: GlobalIDField,
+  ...InternalIDFields,
   description: {
     type: new GraphQLNonNull(GraphQLString),
   },


### PR DESCRIPTION
I would like to be able to use a pagination fragment for myCollectionInfo. To support that, we need to make a node out of my collection info.
This will also allow help relay store tell that some fields changed by returning them directly without need to refresh the store

<img width="574" alt="Screenshot 2023-05-09 at 17 07 19" src="https://github.com/artsy/metaphysics/assets/11945712/2d1ab118-2cc9-4722-a5c2-82be9929a148">
