### PR TITLE
fix(trending artists): handle invalid/empty response more defensively

### DIFF
--- a/src/schema/v2/artists/__tests__/curatedTrending.test.ts
+++ b/src/schema/v2/artists/__tests__/curatedTrending.test.ts
@@ -45,61 +45,63 @@ const mockArtistRecords = [
 
 let context: Partial<ResolverContext>
 
-beforeEach(() => {
-  context = {
-    filterArtworksLoader: jest.fn(() =>
-      Promise.resolve(mockFilterArtworksResponse)
-    ),
-    artistsLoader: jest.fn(
-      // mock implementation to filter over the array of artists above
-      ({ ids }) => {
-        const matchedRecords = mockArtistRecords.filter(({ _id }) =>
-          ids.includes(_id)
-        )
-        const sortedRecords = ids.map((id) =>
-          matchedRecords.find((a) => a._id === id)
-        )
-        const artistsLoaderResponse = {
-          body: sortedRecords,
-          headers: {},
+describe("when trending artists are present", () => {
+  beforeEach(() => {
+    context = {
+      filterArtworksLoader: jest.fn(() =>
+        Promise.resolve(mockFilterArtworksResponse)
+      ),
+      artistsLoader: jest.fn(
+        // mock implementation to filter over the array of artists above
+        ({ ids }) => {
+          const matchedRecords = mockArtistRecords.filter(({ _id }) =>
+            ids.includes(_id)
+          )
+          const sortedRecords = ids.map((id) =>
+            matchedRecords.find((a) => a._id === id)
+          )
+          const artistsLoaderResponse = {
+            body: sortedRecords,
+            headers: {},
+          }
+
+          return Promise.resolve(artistsLoaderResponse)
         }
+      ),
+    }
+  })
 
-        return Promise.resolve(artistsLoaderResponse)
-      }
-    ),
-  }
-})
+  describe("with no timezone provided", () => {
+    it("returns a sample of artists, shuffled according to UTC", async () => {
+      const response = await runQuery(query, context)
 
-describe("with no timezone provided", () => {
-  it("returns a sample of artists, shuffled according to UTC", async () => {
-    const response = await runQuery(query, context)
-
-    expect(response).toEqual({
-      curatedTrendingArtists: {
-        edges: [
-          { node: { slug: "david-hockney", name: "David Hockney" } },
-          { node: { slug: "chloe-wise", name: "Chloe Wise" } },
-          { node: { slug: "marc-chagall", name: "Marc Chagall" } },
-        ],
-      },
+      expect(response).toEqual({
+        curatedTrendingArtists: {
+          edges: [
+            { node: { slug: "david-hockney", name: "David Hockney" } },
+            { node: { slug: "chloe-wise", name: "Chloe Wise" } },
+            { node: { slug: "marc-chagall", name: "Marc Chagall" } },
+          ],
+        },
+      })
     })
   })
-})
 
-describe("with a user timezone provided", () => {
-  it("returns a sample of artists, shuffled for that timezone", async () => {
-    context.defaultTimezone = "America/New_York"
+  describe("with a user timezone provided", () => {
+    it("returns a sample of artists, shuffled for that timezone", async () => {
+      context.defaultTimezone = "America/New_York"
 
-    const response = await runQuery(query, context)
+      const response = await runQuery(query, context)
 
-    expect(response).toEqual({
-      curatedTrendingArtists: {
-        edges: [
-          { node: { slug: "chloe-wise", name: "Chloe Wise" } },
-          { node: { slug: "david-hockney", name: "David Hockney" } },
-          { node: { slug: "marc-chagall", name: "Marc Chagall" } },
-        ],
-      },
+      expect(response).toEqual({
+        curatedTrendingArtists: {
+          edges: [
+            { node: { slug: "chloe-wise", name: "Chloe Wise" } },
+            { node: { slug: "david-hockney", name: "David Hockney" } },
+            { node: { slug: "marc-chagall", name: "Marc Chagall" } },
+          ],
+        },
+      })
     })
   })
 })

--- a/src/schema/v2/artists/__tests__/curatedTrending.test.ts
+++ b/src/schema/v2/artists/__tests__/curatedTrending.test.ts
@@ -105,3 +105,29 @@ describe("when trending artists are present", () => {
     })
   })
 })
+
+describe("when trending artists are missing", () => {
+  beforeEach(() => {
+    context = {
+      filterArtworksLoader: jest.fn(() =>
+        Promise.resolve({
+          hits: [],
+          aggregations: {
+            merchandisable_artists: {},
+          },
+        })
+      ),
+      artistsLoader: jest.fn(),
+    }
+  })
+
+  it("just returns an empty list", async () => {
+    const response = await runQuery(query, context)
+
+    expect(response).toEqual({
+      curatedTrendingArtists: {
+        edges: [],
+      },
+    })
+  })
+})

--- a/src/schema/v2/artists/curatedTrending.ts
+++ b/src/schema/v2/artists/curatedTrending.ts
@@ -18,6 +18,9 @@ export const getCuratedArtists = async (context): Promise<[typeof Artist]> => {
 
   const artists = artworks.aggregations.merchandisable_artists
   const artistIDs = Object.keys(artists)
+  if (artistIDs.length === 0) {
+    return [] as any
+  }
   const shuffledIDs = dailyShuffle(artistIDs, defaultTimezone)
   const { body: artistRecords } = await artistsLoader({
     ids: shuffledIDs,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-4782

Related to [this Slack thread](https://artsy.slack.com/archives/C02BAQ5K7/p1683551869036359) and maybe [this one too](https://artsy.slack.com/archives/C02BAQ5K7/p1683640885033599).

When data for the [curated trending collection](https://www.artsy.net/collection/trending-this-week?metric=in) is invalid — e.g in the staging environment after a failed prod→staging weekend copy — then the response for the `curatedTrendingArtists` field might under certain circumstances be unusable, i.e. data that is both incorrect and invalid. See the ticket^ for sleuthing details.

This addresses that by doing an early return if it appears that the trending collection is itself empty.

The relevant change is in f916a4ca0c2dc372cdb3f78bf4f2d9a27f431574

### Example of good data in prod

<img width="500" alt="prod" src="https://github.com/artsy/metaphysics/assets/140521/4b701baa-5b11-4496-b46f-fab221bfa555">

### Example of bad data in staging

<img width="500" alt="stage" src="https://github.com/artsy/metaphysics/assets/140521/74bb8ccc-4354-4745-832a-e32ad50f8caf">

### Example of early return with `[]` after this change

<img width="500" alt="dev" src="https://github.com/artsy/metaphysics/assets/140521/f9b269e7-d19d-4c28-9f81-462a35ab76c4">
