### PR TITLE
feat: use an edge field on an artistsConnection to store some counts

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1342,10 +1342,6 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     published: Boolean = true
     sort: ArtworkSorts
   ): ArtworkConnection
-
-  # The total number of artworks by this artist within the collection (this field
-  # will be `undefined` outside of the context of a collection).
-  artworksCountWithinCollection: Int
   auctionResultsConnection(
     after: String
 
@@ -1687,6 +1683,9 @@ type ArtistCounts {
 
 # An edge in a connection.
 type ArtistEdge {
+  # When a relevant `artworksCount` field exists to augment a connection
+  artworksCount: Int
+
   # A cursor for use in pagination
   cursor: String!
 

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -399,13 +399,6 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       carousel: ArtistCarousel,
-      artworksCountWithinCollection: {
-        type: GraphQLInt,
-        resolve: ({ artworks_count_within_collection }) =>
-          artworks_count_within_collection,
-        description:
-          "The total number of artworks by this artist within the collection (this field will be `undefined` outside of the context of a collection).",
-      },
       collections: {
         type: new GraphQLList(GraphQLString),
         resolve: ({ collections }) => {
@@ -775,6 +768,16 @@ const Artist: GraphQLFieldConfig<void, ResolverContext> = {
 }
 export default Artist
 
+const edgeFields = {
+  artworksCount: {
+    type: GraphQLInt,
+    description:
+      "When a relevant `artworksCount` field exists to augment a connection",
+    resolve: ({ artworksCount }) => artworksCount,
+  },
+}
+
 export const artistConnection = connectionWithCursorInfo({
   nodeType: ArtistType,
+  edgeFields,
 })

--- a/src/schema/v2/me/__tests__/myCollectionInfo.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionInfo.test.ts
@@ -202,9 +202,9 @@ describe("me.myCollectionInfo", () => {
               collectedArtistsConnection(first: 5) {
                 totalCount
                 edges {
+                  artworksCount
                   node {
                     name
-                    artworksCountWithinCollection
                   }
                 }
               }
@@ -246,20 +246,20 @@ describe("me.myCollectionInfo", () => {
               "collectedArtistsConnection": Object {
                 "edges": Array [
                   Object {
+                    "artworksCount": 1,
                     "node": Object {
-                      "artworksCountWithinCollection": 1,
                       "name": "Artist 1",
                     },
                   },
                   Object {
+                    "artworksCount": 2,
                     "node": Object {
-                      "artworksCountWithinCollection": 2,
                       "name": "Artist 2",
                     },
                   },
                   Object {
+                    "artworksCount": 3,
                     "node": Object {
-                      "artworksCountWithinCollection": 3,
                       "name": "Artist 3",
                     },
                   },
@@ -276,20 +276,20 @@ describe("me.myCollectionInfo", () => {
         Object {
           "edges": Array [
             Object {
+              "artworksCount": 1,
               "node": Object {
-                "artworksCountWithinCollection": 1,
                 "name": "Artist 1",
               },
             },
             Object {
+              "artworksCount": 2,
               "node": Object {
-                "artworksCountWithinCollection": 2,
                 "name": "Artist 2",
               },
             },
             Object {
+              "artworksCount": 3,
               "node": Object {
-                "artworksCountWithinCollection": 3,
                 "name": "Artist 3",
               },
             },

--- a/src/schema/v2/me/myCollectionInfo.ts
+++ b/src/schema/v2/me/myCollectionInfo.ts
@@ -200,13 +200,23 @@ export const myCollectionInfoFields = {
       })
       const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 
+      // Augment the Gravity response with an `artworksCount` field
+      // relevant to this connection.
+      const artists = body.map((artist) => {
+        return {
+          ...artist,
+          artworksCount: artist.artworks_count_within_collection,
+        }
+      })
+
       return paginationResolver({
         totalCount,
         offset,
         size,
         page,
-        body,
+        body: artists,
         args,
+        resolveNode: (artist) => artist,
       })
     },
   },


### PR DESCRIPTION
As mentioned in https://github.com/artsy/metaphysics/pull/4997#discussion_r1191597267 , proposing this as an alternate schema design (and possible pattern) for future counts + metadata-type stuff.