### PR TITLE
feat: optionally return the set when adding or removing a set item

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -92,7 +92,7 @@ input addOrderedSetItemMutationInput {
 }
 
 type addOrderedSetItemMutationPayload {
-  # On success: the ordered set item added.
+  # On success: the updated parent set or the set item added.
   addOrderedSetItemResponseOrError: addOrderedSetItemResponseOrError
   clientMutationId: String
 }
@@ -8005,7 +8005,7 @@ input deleteOrderedSetItemMutationInput {
 type deleteOrderedSetItemMutationPayload {
   clientMutationId: String
 
-  # On success: the ordered set item deleted.
+  # On success: the updated parent set or the set item deleted.
   deleteOrderedSetItemResponseOrError: deleteOrderedSetItemResponseOrError
 }
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -92,10 +92,9 @@ input addOrderedSetItemMutationInput {
 }
 
 type addOrderedSetItemMutationPayload {
-  clientMutationId: String
-
   # On success: the ordered set item added.
-  orderedSetItemOrError: addOrderedSetItemResponseOrError
+  addOrderedSetItemResponseOrError: addOrderedSetItemResponseOrError
+  clientMutationId: String
 }
 
 union addOrderedSetItemResponseOrError =
@@ -103,6 +102,7 @@ union addOrderedSetItemResponseOrError =
   | addOrderedSetItemSuccess
 
 type addOrderedSetItemSuccess {
+  set: OrderedSet
   setItem: OrderedSetItem
 }
 
@@ -8006,7 +8006,7 @@ type deleteOrderedSetItemMutationPayload {
   clientMutationId: String
 
   # On success: the ordered set item deleted.
-  orderedSetItemOrError: deleteOrderedSetItemResponseOrError
+  deleteOrderedSetItemResponseOrError: deleteOrderedSetItemResponseOrError
 }
 
 union deleteOrderedSetItemResponseOrError =
@@ -8014,6 +8014,7 @@ union deleteOrderedSetItemResponseOrError =
   | deleteOrderedSetItemSuccess
 
 type deleteOrderedSetItemSuccess {
+  set: OrderedSet
   setItem: OrderedSetItem
 }
 

--- a/src/schema/v2/OrderedSet/__tests__/addOrderedSetItemMutation.test.ts
+++ b/src/schema/v2/OrderedSet/__tests__/addOrderedSetItemMutation.test.ts
@@ -11,7 +11,7 @@ const mutation = gql`
         position: 1
       }
     ) {
-      orderedSetItemOrError {
+      addOrderedSetItemResponseOrError {
         __typename
         ... on addOrderedSetItemSuccess {
           setItem {
@@ -19,6 +19,10 @@ const mutation = gql`
               name
               hometown
             }
+          }
+          set {
+            internalID
+            itemType
           }
         }
         ... on addOrderedSetItemFailure {
@@ -63,7 +67,7 @@ describe("addOrderedSetItemMutation", () => {
       mockAddSetItemLoader.mockReset()
     })
 
-    it("returns a Artist", async () => {
+    it("returns the set and item", async () => {
       const res = await runAuthenticatedQuery(mutation, context)
 
       expect(mockAddSetItemLoader).toBeCalledWith("abc123", {
@@ -74,11 +78,15 @@ describe("addOrderedSetItemMutation", () => {
 
       expect(res).toEqual({
         addOrderedSetItem: {
-          orderedSetItemOrError: {
+          addOrderedSetItemResponseOrError: {
             __typename: "addOrderedSetItemSuccess",
             setItem: {
               name: "percy-z",
               hometown: "catville",
+            },
+            set: {
+              internalID: "fgh456",
+              itemType: "Artist",
             },
           },
         },
@@ -101,7 +109,7 @@ describe("addOrderedSetItemMutation", () => {
 
       expect(res).toEqual({
         addOrderedSetItem: {
-          orderedSetItemOrError: {
+          addOrderedSetItemResponseOrError: {
             __typename: "addOrderedSetItemFailure",
             mutationError: {
               type: "error",

--- a/src/schema/v2/OrderedSet/__tests__/deleteOrderedSetItemMutation.test.ts
+++ b/src/schema/v2/OrderedSet/__tests__/deleteOrderedSetItemMutation.test.ts
@@ -4,7 +4,7 @@ import { runAuthenticatedQuery } from "schema/v2/test/utils"
 const mutation = gql`
   mutation {
     deleteOrderedSetItem(input: { id: "abc123", itemId: "xyz789" }) {
-      orderedSetItemOrError {
+      deleteOrderedSetItemResponseOrError {
         __typename
         ... on deleteOrderedSetItemSuccess {
           setItem {
@@ -12,6 +12,10 @@ const mutation = gql`
               name
               hometown
             }
+          }
+          set {
+            internalID
+            itemType
           }
         }
         ... on deleteOrderedSetItemFailure {
@@ -56,7 +60,7 @@ describe("deleteOrderedSetItemMutation", () => {
       mockDeleteSetItemLoader.mockReset()
     })
 
-    it("returns a Artist", async () => {
+    it("returns the set and item", async () => {
       const res = await runAuthenticatedQuery(mutation, context)
 
       expect(mockDeleteSetItemLoader).toBeCalledWith({
@@ -66,11 +70,15 @@ describe("deleteOrderedSetItemMutation", () => {
 
       expect(res).toEqual({
         deleteOrderedSetItem: {
-          orderedSetItemOrError: {
+          deleteOrderedSetItemResponseOrError: {
             __typename: "deleteOrderedSetItemSuccess",
             setItem: {
               name: "percy-z",
               hometown: "catville",
+            },
+            set: {
+              internalID: "abc123",
+              itemType: "Artist",
             },
           },
         },
@@ -93,7 +101,7 @@ describe("deleteOrderedSetItemMutation", () => {
 
       expect(res).toEqual({
         deleteOrderedSetItem: {
-          orderedSetItemOrError: {
+          deleteOrderedSetItemResponseOrError: {
             __typename: "deleteOrderedSetItemFailure",
             mutationError: {
               type: "error",

--- a/src/schema/v2/OrderedSet/addOrderedSetItemMutation.ts
+++ b/src/schema/v2/OrderedSet/addOrderedSetItemMutation.ts
@@ -27,7 +27,6 @@ const SuccessType = new GraphQLObjectType<any, ResolverContext>({
   fields: () => ({
     set: {
       type: OrderedSetType,
-      resolve: ({ setId }, _options, { setLoader }) => setLoader(setId),
     },
     setItem: {
       type: OrderedSetItemType,
@@ -89,9 +88,9 @@ export const addOrderedSetItemMutation = mutationWithClientMutationId<
         position,
       })
 
-      const { item_type } = await setLoader(id)
+      const set = await setLoader(id)
 
-      return { item_type, setId: id, ...res }
+      return { item_type: set.item_type, set, ...res }
     } catch (error) {
       const formattedErr = formatGravityError(error)
       if (formattedErr) {

--- a/src/schema/v2/OrderedSet/addOrderedSetItemMutation.ts
+++ b/src/schema/v2/OrderedSet/addOrderedSetItemMutation.ts
@@ -67,7 +67,7 @@ export const addOrderedSetItemMutation = mutationWithClientMutationId<
   outputFields: {
     addOrderedSetItemResponseOrError: {
       type: ResponseOrErrorType,
-      description: "On success: the ordered set item added.",
+      description: "On success: the updated parent set or the set item added.",
       resolve: (result) => result,
     },
   },

--- a/src/schema/v2/OrderedSet/addOrderedSetItemMutation.ts
+++ b/src/schema/v2/OrderedSet/addOrderedSetItemMutation.ts
@@ -12,6 +12,7 @@ import {
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
 import { OrderedSetItemType } from "../item"
+import { OrderedSetType } from "./OrderedSet"
 
 interface Input {
   geminiToken: string
@@ -24,6 +25,10 @@ const SuccessType = new GraphQLObjectType<any, ResolverContext>({
   name: "addOrderedSetItemSuccess",
   isTypeOf: (data) => data.id,
   fields: () => ({
+    set: {
+      type: OrderedSetType,
+      resolve: ({ setId }, _options, { setLoader }) => setLoader(setId),
+    },
     setItem: {
       type: OrderedSetItemType,
       resolve: (orderedSetItem) => orderedSetItem,
@@ -61,7 +66,7 @@ export const addOrderedSetItemMutation = mutationWithClientMutationId<
     position: { type: GraphQLInt },
   },
   outputFields: {
-    orderedSetItemOrError: {
+    addOrderedSetItemResponseOrError: {
       type: ResponseOrErrorType,
       description: "On success: the ordered set item added.",
       resolve: (result) => result,
@@ -86,7 +91,7 @@ export const addOrderedSetItemMutation = mutationWithClientMutationId<
 
       const { item_type } = await setLoader(id)
 
-      return { item_type, ...res }
+      return { item_type, setId: id, ...res }
     } catch (error) {
       const formattedErr = formatGravityError(error)
       if (formattedErr) {

--- a/src/schema/v2/OrderedSet/deleteOrderedSetItemMutation.ts
+++ b/src/schema/v2/OrderedSet/deleteOrderedSetItemMutation.ts
@@ -7,16 +7,22 @@ import {
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
 import { OrderedSetItemType } from "../item"
+import { OrderedSetType } from "./OrderedSet"
 
 interface Input {
   id: string
   itemId: string
+  setId: string
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
   name: "deleteOrderedSetItemSuccess",
   isTypeOf: (data) => data.id,
   fields: () => ({
+    set: {
+      type: OrderedSetType,
+      resolve: ({ setId }, _options, { setLoader }) => setLoader(setId),
+    },
     setItem: {
       type: OrderedSetItemType,
       resolve: (orderedSetItem) => orderedSetItem,
@@ -52,7 +58,7 @@ export const deleteOrderedSetItemMutation = mutationWithClientMutationId<
     itemId: { type: new GraphQLNonNull(GraphQLString) },
   },
   outputFields: {
-    orderedSetItemOrError: {
+    deleteOrderedSetItemResponseOrError: {
       type: ResponseOrErrorType,
       description: "On success: the ordered set item deleted.",
       resolve: (result) => result,
@@ -73,7 +79,7 @@ export const deleteOrderedSetItemMutation = mutationWithClientMutationId<
 
       const { item_type } = await setLoader(id)
 
-      return { item_type, ...res }
+      return { item_type, setId: id, ...res }
     } catch (error) {
       const formattedErr = formatGravityError(error)
       if (formattedErr) {

--- a/src/schema/v2/OrderedSet/deleteOrderedSetItemMutation.ts
+++ b/src/schema/v2/OrderedSet/deleteOrderedSetItemMutation.ts
@@ -59,7 +59,8 @@ export const deleteOrderedSetItemMutation = mutationWithClientMutationId<
   outputFields: {
     deleteOrderedSetItemResponseOrError: {
       type: ResponseOrErrorType,
-      description: "On success: the ordered set item deleted.",
+      description:
+        "On success: the updated parent set or the set item deleted.",
       resolve: (result) => result,
     },
   },

--- a/src/schema/v2/OrderedSet/deleteOrderedSetItemMutation.ts
+++ b/src/schema/v2/OrderedSet/deleteOrderedSetItemMutation.ts
@@ -21,7 +21,6 @@ const SuccessType = new GraphQLObjectType<any, ResolverContext>({
   fields: () => ({
     set: {
       type: OrderedSetType,
-      resolve: ({ setId }, _options, { setLoader }) => setLoader(setId),
     },
     setItem: {
       type: OrderedSetItemType,
@@ -77,9 +76,9 @@ export const deleteOrderedSetItemMutation = mutationWithClientMutationId<
     try {
       const res = await deleteSetItemLoader({ id, itemId })
 
-      const { item_type } = await setLoader(id)
+      const set = await setLoader(id)
 
-      return { item_type, setId: id, ...res }
+      return { item_type: set.item_type, set, ...res }
     } catch (error) {
       const formattedErr = formatGravityError(error)
       if (formattedErr) {


### PR DESCRIPTION
This PR extends the `deleteOrderedSetItemMutation` and the `addOrderedSetItemMutation`s to support returning the parent `OrderedSet`. It directly supports the `sets` page refactor in `forque`: https://github.com/artsy/forque/pull/827.


TODO:
- [x] Confirm this doesn't introduce breaking changes to clients other than `forque`. 

[PLATFORM-5151]

[PLATFORM-5151]: https://artsyproduct.atlassian.net/browse/PLATFORM-5151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ