### PR TITLE
feat: add setItemsLoader to authenticated loaders

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -575,6 +575,11 @@ export default (accessToken, userID, opts) => {
       { method: "POST" }
     ),
     setLoader: gravityLoader((id) => `set/${id}`),
+    setItemsLoader: gravityLoader(
+      (id) => `set/${id}/items`,
+      {},
+      { headers: true }
+    ),
     setsLoader: gravityLoader("sets", {}, { headers: true }),
     showLoader: gravityLoader((id) => `show/${id}`),
     submitArtworkInquiryRequestLoader: gravityLoader(


### PR DESCRIPTION
Missed a commit on #5012. We need to include the `setItemsLoader` in `loaders_with_authentication` to avoid cached data being returned with the mutation. 
