### PR TITLE
feat: Add hero unit operations GRO-1683

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7286,6 +7286,43 @@ type CreateGeminiEntryForAssetPayload {
   clientMutationId: String
 }
 
+type createHeroUnitFailure {
+  mutationError: GravityMutationError
+}
+
+input CreateHeroUnitLinkInput {
+  text: String!
+  url: String!
+}
+
+input CreateHeroUnitMutationInput {
+  body: String!
+  clientMutationId: String
+  credit: String
+  endAt: String
+  imageUrl: String
+  label: String
+  link: CreateHeroUnitLinkInput!
+  position: Int
+  startAt: String
+  title: String!
+}
+
+type CreateHeroUnitMutationPayload {
+  clientMutationId: String
+
+  # On success: the hero unit created.
+  heroUnitOrError: createHeroUnitResponseOrError
+}
+
+union createHeroUnitResponseOrError =
+    createHeroUnitFailure
+  | createHeroUnitSuccess
+
+type createHeroUnitSuccess {
+  heroUnit: HeroUnit
+}
+
 input CreateIdentityVerificationOverrideMutationInput {
   clientMutationId: String
 
@@ -7986,6 +8023,30 @@ union DeleteFeatureResponseOrError = DeleteFeatureFailure | DeleteFeatureSuccess
 
 type DeleteFeatureSuccess {
   feature: Feature
+}
+
+type deleteHeroUnitFailure {
+  mutationError: GravityMutationError
+}
+
+input deleteHeroUnitMutationInput {
+  clientMutationId: String
+  id: String!
+}
+
+type deleteHeroUnitMutationPayload {
+  clientMutationId: String
+
+  # On success: the deleted hero unit.
+  heroUnitOrError: deleteHeroUnitResponseOrError
+}
+
+union deleteHeroUnitResponseOrError =
+    deleteHeroUnitFailure
+  | deleteHeroUnitSuccess
+
+type deleteHeroUnitSuccess {
+  heroUnit: HeroUnit
 }
 
 type deleteOrderedSetFailure {
@@ -9819,6 +9880,86 @@ type GravityMutationError {
   message: String!
   statusCode: Int
   type: String
+}
+
+# A Hero Unit
+type HeroUnit {
+  # Main Hero Unit content.
+  body: String!
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See
+    # http://www.iana.org/time-zones,
+    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+
+  # Optional image credit line.
+  credit: String
+  endAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See
+    # http://www.iana.org/time-zones,
+    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+
+  # A globally unique ID.
+  id: ID!
+
+  # The main image for the Hero Unit.
+  image: Image
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+
+  # Optional label for above the title.
+  label: String
+  link: HeroUnitLink!
+
+  # Dictates the order of the Hero Units.
+  position: Int
+  startAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See
+    # http://www.iana.org/time-zones,
+    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+
+  # The main headline for the Hero Unit.
+  title: String!
+}
+
+# A connection to a list of items.
+type HeroUnitConnection {
+  # A list of edges.
+  edges: [HeroUnitEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type HeroUnitEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: HeroUnit
+}
+
+type HeroUnitLink {
+  # Text for the CTA of the Hero Unit.
+  text: String!
+
+  # URL for the CTA of the Hero Unit.
+  url: String!
 }
 
 type HighestBid {
@@ -12017,6 +12158,11 @@ type Mutation {
     input: CreateGeminiEntryForAssetInput!
   ): CreateGeminiEntryForAssetPayload
 
+  # Creates a hero unit.
+  createHeroUnit(
+    input: CreateHeroUnitMutationInput!
+  ): CreateHeroUnitMutationPayload
+
   # Create an identity verification override
   createIdentityVerificationOverride(
     input: CreateIdentityVerificationOverrideMutationInput!
@@ -12091,6 +12237,11 @@ type Mutation {
   deleteFeaturedLink(
     input: DeleteFeaturedLinkMutationInput!
   ): DeleteFeaturedLinkMutationPayload
+
+  # deletes a hero unit.
+  deleteHeroUnit(
+    input: deleteHeroUnitMutationInput!
+  ): deleteHeroUnitMutationPayload
 
   # Delete User Artsy Account
   deleteMyAccountMutation(input: DeleteAccountInput!): DeleteAccountPayload
@@ -12317,6 +12468,11 @@ type Mutation {
   updateFeaturedLink(
     input: UpdateFeaturedLinkMutationInput!
   ): UpdateFeaturedLinkMutationPayload
+
+  # updates a hero unit.
+  updateHeroUnit(
+    input: UpdateHeroUnitMutationInput!
+  ): UpdateHeroUnitMutationPayload
 
   # Update a message.
   updateMessage(
@@ -14672,6 +14828,21 @@ type Query {
     #
     slugs: [String]
   ): [Gene]
+
+  # A Hero Unit.
+  heroUnit(
+    # The ID of the Hero Unit
+    id: String!
+  ): HeroUnit
+  heroUnitsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+
+    # If present, will search by term
+    term: String
+  ): HeroUnitConnection
   highlights: Highlights
 
   # Home screen content
@@ -17524,6 +17695,44 @@ type UpdateFeatureSuccess {
   feature: Feature
 }
 
+type updateHeroUnitFailure {
+  mutationError: GravityMutationError
+}
+
+input UpdateHeroUnitLinkInput {
+  text: String!
+  url: String!
+}
+
+input UpdateHeroUnitMutationInput {
+  body: String!
+  clientMutationId: String
+  credit: String
+  endAt: String
+  id: String!
+  imageUrl: String
+  label: String
+  link: UpdateHeroUnitLinkInput!
+  position: Int
+  startAt: String
+  title: String!
+}
+
+type UpdateHeroUnitMutationPayload {
+  clientMutationId: String
+
+  # On success: the hero unit updated.
+  heroUnitOrError: updateHeroUnitResponseOrError
+}
+
+union updateHeroUnitResponseOrError =
+    updateHeroUnitFailure
+  | updateHeroUnitSuccess
+
+type updateHeroUnitSuccess {
+  heroUnit: HeroUnit
+}
+
 type UpdateMessageFailure {
   mutationError: GravityMutationError
 }
@@ -19000,6 +19209,21 @@ type Viewer {
     #
     slugs: [String]
   ): [Gene]
+
+  # A Hero Unit.
+  heroUnit(
+    # The ID of the Hero Unit
+    id: String!
+  ): HeroUnit
+  heroUnitsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+
+    # If present, will search by term
+    term: String
+  ): HeroUnitConnection
   highlights: Highlights
 
   # Home screen content

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -168,6 +168,17 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "DELETE" }
     ),
+    createHeroUnitLoader: gravityLoader("hero_units", {}, { method: "POST" }),
+    updateHeroUnitLoader: gravityLoader(
+      (id) => `hero_units/${id}`,
+      {},
+      { method: "PUT" }
+    ),
+    deleteHeroUnitLoader: gravityLoader(
+      (id) => `hero_units/${id}`,
+      {},
+      { method: "DELETE" }
+    ),
     deleteSetItemLoader: gravityLoader<any, { id: string; itemId: string }>(
       ({ id, itemId }) => `set/${id}/item/${itemId}`,
       {},
@@ -375,6 +386,21 @@ export default (accessToken, userID, opts) => {
     ),
     matchUsersLoader: gravityLoader("match/users", {}, { headers: true }),
     matchSetsLoader: gravityLoader("match/sets", {}, { headers: true }),
+    authenticatedHeroUnitsLoader: gravityLoader(
+      "hero_units",
+      {},
+      { headers: true }
+    ),
+    authenticatedHeroUnitLoader: gravityLoader(
+      (id) => `hero_units/${id}`,
+      {},
+      { headers: true }
+    ),
+    matchHeroUnitsLoader: gravityLoader(
+      "match/hero_units",
+      {},
+      { headers: true }
+    ),
     matchShowsLoader: gravityLoader(
       "match/partner_shows",
       {},

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -89,7 +89,13 @@ export default (opts) => {
     geneFamiliesLoader: gravityLoader("gene_families"),
     geneLoader: gravityLoader((id) => `gene/${id}`),
     genesLoader: gravityLoader("genes"),
-    heroUnitsLoader: gravityLoader("site_hero_units"),
+    siteHeroUnitsLoader: gravityLoader("site_hero_units"),
+    heroUnitsLoader: gravityLoader("hero_units", {}, { headers: true }),
+    heroUnitLoader: gravityLoader(
+      (id) => `hero_units/${id}`,
+      {},
+      { headers: true }
+    ),
     identityVerificationLoader: gravityUncachedLoader(
       (id) => `identity_verification/${id}`
     ),

--- a/src/schema/v2/HeroUnit/HeroUnitType.ts
+++ b/src/schema/v2/HeroUnit/HeroUnitType.ts
@@ -1,0 +1,92 @@
+import {
+  GraphQLInt,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { InternalIDFields } from "../object_identification"
+import { ResolverContext } from "types/graphql"
+import Image, { normalizeImageData } from "../image"
+import date from "schema/v2/fields/date"
+
+interface HeroUnitGravityResponse {
+  body: string
+  created_at: string
+  credit?: string
+  end_at?: string
+  image?: {
+    image_url?: string
+    image_urls?: string[]
+    image_versions?: string[]
+    original_height?: string
+    original_width?: string
+  }
+  label?: string
+  link_text: string
+  link_url: string
+  position?: number
+  start_at?: string
+  title: string
+}
+
+export const HeroUnitType = new GraphQLObjectType<
+  HeroUnitGravityResponse,
+  ResolverContext
+>({
+  name: "HeroUnit",
+  description: "A Hero Unit",
+  fields: {
+    ...InternalIDFields,
+    body: {
+      description: "Main Hero Unit content.",
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    createdAt: date,
+    credit: {
+      description: "Optional image credit line.",
+      type: GraphQLString,
+    },
+    endAt: date,
+    image: {
+      description: "The main image for the Hero Unit.",
+      type: Image.type,
+      resolve: ({ image }) => {
+        if (!image) return null
+        return normalizeImageData(image)
+      },
+    },
+    label: {
+      description: "Optional label for above the title.",
+      type: GraphQLString,
+    },
+    link: {
+      resolve: (response) => response,
+      type: new GraphQLNonNull(
+        new GraphQLObjectType<HeroUnitGravityResponse, ResolverContext>({
+          name: "HeroUnitLink",
+          fields: {
+            text: {
+              description: "Text for the CTA of the Hero Unit.",
+              resolve: ({ link_text }) => link_text,
+              type: new GraphQLNonNull(GraphQLString),
+            },
+            url: {
+              description: "URL for the CTA of the Hero Unit.",
+              resolve: ({ link_url }) => link_url,
+              type: new GraphQLNonNull(GraphQLString),
+            },
+          },
+        })
+      ),
+    },
+    position: {
+      description: "Dictates the order of the Hero Units.",
+      type: GraphQLInt,
+    },
+    startAt: date,
+    title: {
+      description: "The main headline for the Hero Unit.",
+      type: new GraphQLNonNull(GraphQLString),
+    },
+  },
+})

--- a/src/schema/v2/HeroUnit/createHeroUnitMutation.ts
+++ b/src/schema/v2/HeroUnit/createHeroUnitMutation.ts
@@ -1,0 +1,126 @@
+import {
+  GraphQLInputObjectType,
+  GraphQLInt,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { GraphQLNonNull } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { HeroUnitType } from "./HeroUnitType"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+
+interface Input {
+  body: string
+  credit?: string
+  endAt?: string
+  imageUrl?: string
+  label?: string
+  link: {
+    text: string
+    url: string
+  }
+  position?: number
+  startAt?: string
+  title: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "createHeroUnitSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    heroUnit: {
+      type: HeroUnitType,
+      resolve: (heroUnit) => heroUnit,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "createHeroUnitFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "createHeroUnitResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const createHeroUnitMutation = mutationWithClientMutationId<
+  Input,
+  any | null,
+  ResolverContext
+>({
+  name: "CreateHeroUnitMutation",
+  description: "Creates a hero unit.",
+  inputFields: {
+    body: { type: new GraphQLNonNull(GraphQLString) },
+    credit: { type: GraphQLString },
+    endAt: { type: GraphQLString },
+    imageUrl: { type: GraphQLString },
+    label: { type: GraphQLString },
+    link: {
+      type: new GraphQLNonNull(
+        new GraphQLInputObjectType({
+          name: "CreateHeroUnitLinkInput",
+          fields: {
+            text: { type: new GraphQLNonNull(GraphQLString) },
+            url: { type: new GraphQLNonNull(GraphQLString) },
+          },
+        })
+      ),
+    },
+    position: { type: GraphQLInt },
+    startAt: { type: GraphQLString },
+    title: { type: new GraphQLNonNull(GraphQLString) },
+  },
+  outputFields: {
+    heroUnitOrError: {
+      type: ResponseOrErrorType,
+      description: "On success: the hero unit created.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { body, credit, endAt, imageUrl, label, link, position, startAt, title },
+    { createHeroUnitLoader }
+  ) => {
+    if (!createHeroUnitLoader) {
+      throw new Error(
+        "You need to pass a X-Access-Token header to perform this action"
+      )
+    }
+
+    try {
+      return await createHeroUnitLoader({
+        body,
+        credit,
+        end_at: endAt,
+        image_attributes: { image_url: imageUrl },
+        label,
+        link_text: link.text,
+        link_url: link.url,
+        position,
+        start_at: startAt,
+        title,
+      })
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/HeroUnit/deleteHeroUnitMutation.ts
+++ b/src/schema/v2/HeroUnit/deleteHeroUnitMutation.ts
@@ -1,0 +1,77 @@
+import { GraphQLString, GraphQLUnionType, GraphQLObjectType } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { GraphQLNonNull } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { HeroUnitType } from "./HeroUnitType"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+
+interface Input {
+  id: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "deleteHeroUnitSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    heroUnit: {
+      type: HeroUnitType,
+      resolve: (heroUnit) => heroUnit,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "deleteHeroUnitFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "deleteHeroUnitResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const deleteHeroUnitMutation = mutationWithClientMutationId<
+  Input,
+  any | null,
+  ResolverContext
+>({
+  name: "deleteHeroUnitMutation",
+  description: "deletes a hero unit.",
+  inputFields: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+  },
+  outputFields: {
+    heroUnitOrError: {
+      type: ResponseOrErrorType,
+      description: "On success: the deleted hero unit.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async ({ id }, { deleteHeroUnitLoader }) => {
+    if (!deleteHeroUnitLoader) {
+      throw new Error(
+        "You need to pass a X-Access-Token header to perform this action"
+      )
+    }
+
+    try {
+      return await deleteHeroUnitLoader(id)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/HeroUnit/heroUnit.ts
+++ b/src/schema/v2/HeroUnit/heroUnit.ts
@@ -1,0 +1,20 @@
+import { HeroUnitType } from "./HeroUnitType"
+import { GraphQLString, GraphQLNonNull, GraphQLFieldConfig } from "graphql"
+import { ResolverContext } from "types/graphql"
+
+export const heroUnit: GraphQLFieldConfig<void, ResolverContext> = {
+  type: HeroUnitType,
+  description: "A Hero Unit.",
+  args: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the Hero Unit",
+    },
+  },
+  resolve: async (_root, { id }, context) => {
+    const { authenticatedHeroUnitLoader, heroUnitLoader } = context
+    const loader = authenticatedHeroUnitLoader ?? heroUnitLoader
+    const { body } = await loader(id)
+    return body
+  },
+}

--- a/src/schema/v2/HeroUnit/heroUnitsConnection.ts
+++ b/src/schema/v2/HeroUnit/heroUnitsConnection.ts
@@ -1,0 +1,66 @@
+import { connectionWithCursorInfo } from "../fields/pagination"
+import { HeroUnitType } from "./HeroUnitType"
+import { GraphQLString, GraphQLFieldConfig } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { pageable } from "relay-cursor-paging"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { paginationResolver } from "schema/v2/fields/pagination"
+
+const HeroUnitConnection = connectionWithCursorInfo({
+  nodeType: HeroUnitType,
+})
+
+export const heroUnitsConnection: GraphQLFieldConfig<void, ResolverContext> = {
+  type: HeroUnitConnection.connectionType,
+  args: pageable({
+    term: {
+      type: GraphQLString,
+      description: "If present, will search by term",
+    },
+  }),
+  resolve: async (_root, args, context) => {
+    const {
+      authenticatedHeroUnitsLoader,
+      heroUnitsLoader,
+      matchHeroUnitsLoader,
+    } = context
+
+    const { term } = args
+
+    if (term && !matchHeroUnitsLoader)
+      throw new Error(
+        "You need to pass a X-Access-Token header to perform this action"
+      )
+
+    const loader =
+      (term && matchHeroUnitsLoader) ||
+      (authenticatedHeroUnitsLoader ?? heroUnitsLoader)
+
+    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+
+    const gravityArgs: {
+      page: number
+      size: number
+      total_count: boolean
+      term?: string
+    } = {
+      page,
+      size,
+      total_count: true,
+      ...(term ? { term } : {}),
+    }
+
+    const { body, headers } = await loader(gravityArgs)
+
+    const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+    return paginationResolver({
+      args,
+      body,
+      offset,
+      page,
+      size,
+      totalCount,
+    })
+  },
+}

--- a/src/schema/v2/HeroUnit/updateHeroUnitMutation.ts
+++ b/src/schema/v2/HeroUnit/updateHeroUnitMutation.ts
@@ -1,0 +1,139 @@
+import {
+  GraphQLInputObjectType,
+  GraphQLInt,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { GraphQLNonNull } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { HeroUnitType } from "./HeroUnitType"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+
+interface Input {
+  body: string
+  credit?: string
+  endAt?: string
+  id: string
+  imageUrl?: string
+  label?: string
+  link: {
+    text: string
+    url: string
+  }
+  position?: number
+  startAt?: string
+  title: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "updateHeroUnitSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    heroUnit: {
+      type: HeroUnitType,
+      resolve: (heroUnit) => heroUnit,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "updateHeroUnitFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "updateHeroUnitResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const updateHeroUnitMutation = mutationWithClientMutationId<
+  Input,
+  any | null,
+  ResolverContext
+>({
+  name: "UpdateHeroUnitMutation",
+  description: "updates a hero unit.",
+  inputFields: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+    body: { type: new GraphQLNonNull(GraphQLString) },
+    credit: { type: GraphQLString },
+    endAt: { type: GraphQLString },
+    imageUrl: { type: GraphQLString },
+    label: { type: GraphQLString },
+    link: {
+      type: new GraphQLNonNull(
+        new GraphQLInputObjectType({
+          name: "UpdateHeroUnitLinkInput",
+          fields: {
+            text: { type: new GraphQLNonNull(GraphQLString) },
+            url: { type: new GraphQLNonNull(GraphQLString) },
+          },
+        })
+      ),
+    },
+    position: { type: GraphQLInt },
+    startAt: { type: GraphQLString },
+    title: { type: new GraphQLNonNull(GraphQLString) },
+  },
+  outputFields: {
+    heroUnitOrError: {
+      type: ResponseOrErrorType,
+      description: "On success: the hero unit updated.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    {
+      body,
+      credit,
+      endAt,
+      id,
+      imageUrl,
+      label,
+      link,
+      position,
+      startAt,
+      title,
+    },
+    { updateHeroUnitLoader }
+  ) => {
+    if (!updateHeroUnitLoader) {
+      throw new Error(
+        "You need to pass a X-Access-Token header to perform this action"
+      )
+    }
+
+    try {
+      return await updateHeroUnitLoader(id, {
+        body,
+        credit,
+        end_at: endAt,
+        image_attributes: { image_url: imageUrl },
+        label,
+        link_text: link.text,
+        link_url: link.url,
+        position,
+        start_at: startAt,
+        title,
+      })
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/home/__tests__/home_page_hero_units.test.js
+++ b/src/schema/v2/home/__tests__/home_page_hero_units.test.js
@@ -25,7 +25,7 @@ describe("HomePageHeroUnits", () => {
       const params = { enabled: true }
       params[platform] = true
       const context = {
-        heroUnitsLoader: sinon
+        siteHeroUnitsLoader: sinon
           .stub()
           .withArgs("site_hero_units", params)
           .returns(Promise.resolve(payload)),
@@ -54,7 +54,7 @@ describe("HomePageHeroUnits", () => {
       const params = { enabled: true }
       params[platform] = true
       const context = {
-        heroUnitsLoader: sinon
+        siteHeroUnitsLoader: sinon
           .stub()
           .withArgs("site_hero_units", params)
           .returns(Promise.resolve(payload)),
@@ -93,7 +93,7 @@ describe("HomePageHeroUnits", () => {
 
   it("returns a specific background image version", () => {
     const context = {
-      heroUnitsLoader: sinon.stub().returns(Promise.resolve(payload)),
+      siteHeroUnitsLoader: sinon.stub().returns(Promise.resolve(payload)),
     }
 
     const query = `
@@ -117,7 +117,7 @@ describe("HomePageHeroUnits", () => {
 
   it("returns the correct wide image on 'mobile'", async () => {
     const context = {
-      heroUnitsLoader: sinon.stub().returns(Promise.resolve(payload)),
+      siteHeroUnitsLoader: sinon.stub().returns(Promise.resolve(payload)),
     }
 
     const backgroundImageWideResult = await runQuery(
@@ -140,7 +140,7 @@ describe("HomePageHeroUnits", () => {
 
   it("returns the correct narrow image on 'mobile'", async () => {
     const context = {
-      heroUnitsLoader: sinon.stub().returns(Promise.resolve(payload)),
+      siteHeroUnitsLoader: sinon.stub().returns(Promise.resolve(payload)),
     }
 
     const backgroundImageNarrowResult = await runQuery(
@@ -162,7 +162,7 @@ describe("HomePageHeroUnits", () => {
   })
   it("returns the correct title and subtitle on 'mobile'", async () => {
     const context = {
-      heroUnitsLoader: sinon.stub().returns(Promise.resolve(payload)),
+      siteHeroUnitsLoader: sinon.stub().returns(Promise.resolve(payload)),
     }
 
     const result = await runQuery(

--- a/src/schema/v2/home/home_page_hero_units.ts
+++ b/src/schema/v2/home/home_page_hero_units.ts
@@ -171,9 +171,9 @@ const HomePageHeroUnits: GraphQLFieldConfig<void, ResolverContext> = {
       ),
     },
   },
-  resolve: (_, { platform }, { heroUnitsLoader }) => {
+  resolve: (_, { platform }, { siteHeroUnitsLoader }) => {
     const params = { enabled: true, [platform]: true }
-    return heroUnitsLoader(params).then((units) => {
+    return siteHeroUnitsLoader(params).then((units) => {
       return units.map((unit) => Object.assign({ platform }, unit))
     })
   },

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -38,6 +38,11 @@ import { City } from "./city"
 import { createAccountRequestMutation } from "./createAccountRequestMutation"
 import { createCollectionMutation } from "./me/createCollectionMutation"
 import { deleteCollectionMutation } from "./me/deleteCollectionMutation"
+import { deleteHeroUnitMutation } from "./HeroUnit/deleteHeroUnitMutation"
+import { createHeroUnitMutation } from "./HeroUnit/createHeroUnitMutation"
+import { updateHeroUnitMutation } from "./HeroUnit/updateHeroUnitMutation"
+import { heroUnitsConnection } from "./HeroUnit/heroUnitsConnection"
+import { heroUnit } from "./HeroUnit/heroUnit"
 // import Collection from "./collection"
 import { CreditCard } from "./credit_card"
 import { DeleteArtworkImageMutation } from "./deleteArtworkImageMutation"
@@ -263,6 +268,8 @@ const rootFields = {
   gene: Gene,
   geneFamiliesConnection: GeneFamilies,
   genes: Genes,
+  heroUnitsConnection,
+  heroUnit,
   highlights: HighlightsField,
   homePage: HomePage,
   identityVerification: IdentityVerification,
@@ -359,6 +366,9 @@ export default new GraphQLSchema({
       deleteCreditCard: deleteCreditCardMutation,
       deleteFeature: DeleteFeatureMutation,
       deleteFeaturedLink: DeleteFeaturedLinkMutation,
+      deleteHeroUnit: deleteHeroUnitMutation,
+      createHeroUnit: createHeroUnitMutation,
+      updateHeroUnit: updateHeroUnitMutation,
       deleteMyAccountMutation: deleteUserAccountMutation,
       deleteMyUserProfileIcon: deleteCollectorProfileIconMutation,
       deleteOrderedSet: deleteOrderedSetMutation,


### PR DESCRIPTION
This PR adds a set of operations for hero units:

* heroUnitsConnection - list of hero units
* heroUnit - a particular hero unit
* createHeroUnit - to create
* deleteHeroUnit - to delete
* updateHeroUnit - to update

This is in service of force wanting to display hero units and forque that wants to manage them. I stole things from a few places to put this all together so lmk if anything look wonky! I'm especially interested to know if anybody sees missing tests.

https://artsyproduct.atlassian.net/browse/GRO-1683

/cc @artsy/grow-devs