### PR TITLE
feat(NX-3538): add filter by from_id in ConversationsConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11194,6 +11194,7 @@ type Me implements Node {
     before: String
     dismissed: Boolean
     first: Int
+    fromId: String
     hasMessage: Boolean
     hasReply: Boolean
     last: Int
@@ -14449,6 +14450,7 @@ type Query {
     before: String
     dismissed: Boolean
     first: Int
+    fromId: String
     hasMessage: Boolean
     hasReply: Boolean
     last: Int
@@ -18776,6 +18778,7 @@ type Viewer {
     before: String
     dismissed: Boolean
     first: Int
+    fromId: String
     hasMessage: Boolean
     hasReply: Boolean
     last: Int

--- a/src/schema/v2/conversation/conversations.ts
+++ b/src/schema/v2/conversation/conversations.ts
@@ -19,6 +19,7 @@ interface ConversationsArguments extends CursorPageable {
   toBeReplied?: boolean
   hasReply?: boolean
   partnerId?: string
+  fromId?: string
   type?: "Partner" | "User"
 }
 
@@ -62,6 +63,9 @@ const Conversations: GraphQLFieldConfig<
     partnerId: {
       type: GraphQLString,
     },
+    fromId: {
+      type: GraphQLString,
+    },
     type: {
       type: ConversationsInputModeEnum,
       defaultValue: "USER",
@@ -88,6 +92,8 @@ const Conversations: GraphQLFieldConfig<
         deleted: false,
         intercepted: false,
         to_id: args.partnerId,
+        from_id: args.fromId ?? undefined,
+        from_type: args.fromId ? "User" : undefined,
         to_type: "Partner",
         has_reply: args.hasReply ?? undefined,
         has_message: args.hasMessage ?? undefined,


### PR DESCRIPTION
[NX-3538]

Adds the `fromId` option when filtering conversations as a `Partner`.

cc @artsy/negotiate-devs 

[NX-3538]: https://artsyproduct.atlassian.net/browse/NX-3538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ