### PR TITLE
chore(GRO-1671): update meta tags based on the selected tab on the Artist page

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1544,7 +1544,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     size: Int
     slugs: [String!]
   ): [MarketingCollection]
-  meta: ArtistMeta
+  meta(tab: ArtistTab): ArtistMeta
   middle: String
   name: String
   nationality: String
@@ -1964,6 +1964,12 @@ type ArtistStatuses {
     minShowCount: Int = 15
   ): Boolean
   shows: Boolean
+}
+
+enum ArtistTab {
+  ABOUT
+  ARTWORKS
+  AUCTION_RESULTS
 }
 
 type ArtistTargetSupply {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1544,7 +1544,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     size: Int
     slugs: [String!]
   ): [MarketingCollection]
-  meta(page: ArtistPage): ArtistMeta
+  meta(page: ArtistPage = ABOUT): ArtistMeta
   middle: String
   name: String
   nationality: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1544,7 +1544,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     size: Int
     slugs: [String!]
   ): [MarketingCollection]
-  meta(tab: ArtistTab): ArtistMeta
+  meta(page: ArtistPage): ArtistMeta
   middle: String
   name: String
   nationality: String
@@ -1762,6 +1762,12 @@ type ArtistMeta {
   title: String
 }
 
+enum ArtistPage {
+  ABOUT
+  ARTWORKS
+  AUCTION_RESULTS
+}
+
 # A connection to a list of items.
 type ArtistPartnerConnection {
   # A list of edges.
@@ -1964,12 +1970,6 @@ type ArtistStatuses {
     minShowCount: Int = 15
   ): Boolean
   shows: Boolean
-}
-
-enum ArtistTab {
-  ABOUT
-  ARTWORKS
-  AUCTION_RESULTS
 }
 
 type ArtistTargetSupply {

--- a/src/schema/v2/artist/__tests__/meta.test.js
+++ b/src/schema/v2/artist/__tests__/meta.test.js
@@ -1,0 +1,144 @@
+/* eslint-disable promise/always-return */
+import { runQuery } from "schema/v2/test/utils"
+
+describe("ArtistMeta type", () => {
+  let context
+  const artist = {
+    id: "foo-bar",
+    name: "Foo Bar",
+    blurb:
+      "Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit.",
+  }
+
+  beforeEach(() => {
+    context = {
+      artistLoader: () => artist,
+    }
+  })
+
+  it("returns the default title and description", () => {
+    const query = `
+      {
+        artist(id: "foo-bar") {
+          meta {
+            title
+            description
+          }
+        }
+      }
+    `
+
+    return runQuery(query, context).then((data) => {
+      expect(data).toEqual({
+        artist: {
+          meta: {
+            title: "Foo Bar - Biography, Shows, Articles & More | Artsy",
+            description:
+              "Explore Foo Bar’s biography, achievements, artworks, auction results, and shows on Artsy. Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit.",
+          },
+        },
+      })
+    })
+  })
+
+  describe("using the enum values", () => {
+    it("returns the correct value for ABOUT", () => {
+      const query = `
+        {
+          artist(id: "foo-bar") {
+            meta(page: ABOUT) {
+              title
+              description
+            }
+          }
+        }
+      `
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artist: {
+            meta: {
+              title: "Foo Bar - Biography, Shows, Articles & More | Artsy",
+              description:
+                "Explore Foo Bar’s biography, achievements, artworks, auction results, and shows on Artsy. Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit.",
+            },
+          },
+        })
+      })
+    })
+
+    it("returns the correct value for ARTWORKS", () => {
+      const query = `
+        {
+          artist(id: "foo-bar") {
+            meta(page: ARTWORKS) {
+              title
+              description
+            }
+          }
+        }
+      `
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artist: {
+            meta: {
+              title: "Foo Bar - Artworks for Sale & More | Artsy",
+              description:
+                "Discover and purchase Foo Bar’s artworks, available for sale. Browse our selection of paintings, prints, and sculptures by the artist, and find art you love. Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit.",
+            },
+          },
+        })
+      })
+    })
+
+    it("returns the correct value for AUCTION_RESULTS", () => {
+      const query = `
+        {
+          artist(id: "foo-bar") {
+            meta(page: AUCTION_RESULTS) {
+              title
+              description
+            }
+          }
+        }
+      `
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artist: {
+            meta: {
+              title: "Foo Bar - Auction Results and Sales Data | Artsy",
+              description:
+                "Find out about Foo Bar’s auction history, past sales, and current market value. Browse Artsy’s Price Database for recent auction results from the artist.",
+            },
+          },
+        })
+      })
+    })
+  })
+
+  it("returns the description without a blurb when it is absent", () => {
+    artist.blurb = null
+    const query = `
+    {
+      artist(id: "foo-bar") {
+        meta(page: ARTWORKS) {
+          description
+        }
+      }
+    }
+  `
+
+    return runQuery(query, context).then((data) => {
+      expect(data).toEqual({
+        artist: {
+          meta: {
+            description:
+              "Discover and purchase Foo Bar’s artworks, available for sale. Browse our selection of paintings, prints, and sculptures by the artist, and find art you love.",
+          },
+        },
+      })
+    })
+  })
+})

--- a/src/schema/v2/artist/__tests__/meta.test.js
+++ b/src/schema/v2/artist/__tests__/meta.test.js
@@ -2,7 +2,7 @@
 import { runQuery } from "schema/v2/test/utils"
 
 describe("ArtistMeta type", () => {
-  let context
+  let context, blurb
   const artist = {
     id: "foo-bar",
     name: "Foo Bar",
@@ -14,9 +14,11 @@ describe("ArtistMeta type", () => {
     context = {
       artistLoader: () => artist,
     }
+
+    blurb = artist.blurb.slice(0, 70)
   })
 
-  it("returns the default title and description", () => {
+  it("returns the default title and description when the page is not specified", () => {
     const query = `
       {
         artist(id: "foo-bar") {
@@ -33,8 +35,7 @@ describe("ArtistMeta type", () => {
         artist: {
           meta: {
             title: "Foo Bar - Biography, Shows, Articles & More | Artsy",
-            description:
-              "Explore Foo Bar’s biography, achievements, artworks, auction results, and shows on Artsy. Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit.",
+            description: `Explore Foo Bar’s biography, achievements, artworks, auction results, and shows on Artsy. ${blurb}`,
           },
         },
       })
@@ -59,8 +60,7 @@ describe("ArtistMeta type", () => {
           artist: {
             meta: {
               title: "Foo Bar - Biography, Shows, Articles & More | Artsy",
-              description:
-                "Explore Foo Bar’s biography, achievements, artworks, auction results, and shows on Artsy. Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit.",
+              description: `Explore Foo Bar’s biography, achievements, artworks, auction results, and shows on Artsy. ${blurb}`,
             },
           },
         })
@@ -85,7 +85,7 @@ describe("ArtistMeta type", () => {
             meta: {
               title: "Foo Bar - Artworks for Sale & More | Artsy",
               description:
-                "Discover and purchase Foo Bar’s artworks, available for sale. Browse our selection of paintings, prints, and sculptures by the artist, and find art you love. Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit.",
+                "Discover and purchase Foo Bar’s artworks, available for sale. Browse our selection of paintings, prints, and sculptures by the artist, and find art you love.",
             },
           },
         })

--- a/src/schema/v2/artist/meta.ts
+++ b/src/schema/v2/artist/meta.ts
@@ -28,7 +28,7 @@ const ArtistMetaType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
       resolve: ({ artist, page }) => {
         const blurb = artist.blurb?.length
-          ? ` ${markdownToText(artist.blurb)}`
+          ? ` ${markdownToText(artist.blurb).slice(0, 70)}`
           : ""
 
         switch (page) {
@@ -39,7 +39,7 @@ const ArtistMetaType = new GraphQLObjectType<any, ResolverContext>({
           case "ARTWORKS":
             return `Discover and purchase ${metaName(
               artist
-            )}’s artworks, available for sale. Browse our selection of paintings, prints, and sculptures by the artist, and find art you love.${blurb}`
+            )}’s artworks, available for sale. Browse our selection of paintings, prints, and sculptures by the artist, and find art you love.`
           case "AUCTION_RESULTS":
             return `Find out about ${metaName(
               artist

--- a/src/schema/v2/artist/meta.ts
+++ b/src/schema/v2/artist/meta.ts
@@ -8,9 +8,48 @@ export const metaName = (artist) => {
   return "Unnamed Artist"
 }
 
+export const formatDescription = (description: string, blurb?: string) => {
+  return truncate(compact([description, blurb]).join("."), 157)
+}
+
 const ArtistMetaType = new GraphQLObjectType<any, ResolverContext>({
   name: "ArtistMeta",
   fields: {
+    artworksDescription: {
+      type: GraphQLString,
+      resolve: (artist) => {
+        const blurb = artist.blurb.length
+          ? markdownToText(artist.blurb)
+          : undefined
+
+        return formatDescription(
+          `Discover and purchase ${metaName(
+            artist
+          )}’s artworks, available for sale. Browse our selection of paintings, prints, and sculptures by the artist, and find art you love.`,
+          blurb
+        )
+      },
+    },
+    artworksTitle: {
+      type: GraphQLString,
+      resolve: (artist) => {
+        return `${metaName(artist)} - Artworks for Sale & More | Artsy`
+      },
+    },
+    auctionDescription: {
+      type: GraphQLString,
+      resolve: (artist) => {
+        return `Find out about ${metaName(
+          artist
+        )}’s auction history, past sales, and current market value. Browse Artsy’s Price Database for recent auction results from the artist.`
+      },
+    },
+    auctionTitle: {
+      type: GraphQLString,
+      resolve: (artist) => {
+        return `${metaName(artist)} - Auction Results and Sales Data | Artsy`
+      },
+    },
     description: {
       type: GraphQLString,
       resolve: (artist) => {
@@ -18,20 +57,18 @@ const ArtistMetaType = new GraphQLObjectType<any, ResolverContext>({
           ? markdownToText(artist.blurb)
           : undefined
 
-        const description = compact([
-          `Find the latest shows, biography, and artworks for sale by ${metaName(
+        return formatDescription(
+          `Explore ${metaName(
             artist
-          )}`,
-          blurb,
-        ]).join(". ")
-        return truncate(description, 157)
+          )}'s biography, achievements, artworks, auction results, and shows on Artsy.`,
+          blurb
+        )
       },
     },
     title: {
       type: GraphQLString,
       resolve: (artist) => {
-        const count = artist.published_artworks_count
-        return `${metaName(artist)} - ${count} Artworks, Bio & Shows on Artsy`
+        return `${metaName(artist)} - Biography, Shows, Articles & More | Artsy`
       },
     },
   },

--- a/src/schema/v2/artist/meta.ts
+++ b/src/schema/v2/artist/meta.ts
@@ -1,4 +1,4 @@
-import { stripTags, truncate, markdownToText } from "lib/helpers"
+import { stripTags, markdownToText } from "lib/helpers"
 import {
   GraphQLString,
   GraphQLObjectType,
@@ -27,25 +27,19 @@ const ArtistMetaType = new GraphQLObjectType<any, ResolverContext>({
     description: {
       type: GraphQLString,
       resolve: ({ artist, page }) => {
-        const blurb = artist.blurb.length
-          ? markdownToText(artist.blurb)
-          : undefined
+        const blurb = artist.blurb?.length
+          ? ` ${markdownToText(artist.blurb)}`
+          : ""
 
         switch (page) {
           case "ABOUT":
-            return truncate(
-              `Explore ${metaName(
-                artist
-              )}'s biography, achievements, artworks, auction results, and shows on Artsy. ${blurb}`,
-              157
-            )
+            return `Explore ${metaName(
+              artist
+            )}’s biography, achievements, artworks, auction results, and shows on Artsy.${blurb}`
           case "ARTWORKS":
-            return truncate(
-              `Discover and purchase ${metaName(
-                artist
-              )}’s artworks, available for sale. Browse our selection of paintings, prints, and sculptures by the artist, and find art you love. ${blurb}`,
-              157
-            )
+            return `Discover and purchase ${metaName(
+              artist
+            )}’s artworks, available for sale. Browse our selection of paintings, prints, and sculptures by the artist, and find art you love.${blurb}`
           case "AUCTION_RESULTS":
             return `Find out about ${metaName(
               artist

--- a/src/schema/v2/artist/meta.ts
+++ b/src/schema/v2/artist/meta.ts
@@ -1,6 +1,11 @@
 import { stripTags, truncate, markdownToText } from "lib/helpers"
 import { compact } from "lodash"
-import { GraphQLString, GraphQLObjectType, GraphQLFieldConfig } from "graphql"
+import {
+  GraphQLString,
+  GraphQLObjectType,
+  GraphQLFieldConfig,
+  GraphQLEnumType,
+} from "graphql"
 import { ResolverContext } from "types/graphql"
 
 export const metaName = (artist) => {
@@ -12,63 +17,62 @@ export const formatDescription = (description: string, blurb?: string) => {
   return truncate(compact([description, blurb]).join("."), 157)
 }
 
+const ArtistTabEnumType = new GraphQLEnumType({
+  name: "ArtistTab",
+  values: {
+    ABOUT: { value: "ABOUT" },
+    ARTWORKS: { value: "ARTWORKS" },
+    AUCTION_RESULTS: { value: "AUCTION_RESULTS" },
+  },
+})
+
 const ArtistMetaType = new GraphQLObjectType<any, ResolverContext>({
   name: "ArtistMeta",
   fields: {
-    artworksDescription: {
-      type: GraphQLString,
-      resolve: (artist) => {
-        const blurb = artist.blurb.length
-          ? markdownToText(artist.blurb)
-          : undefined
-
-        return formatDescription(
-          `Discover and purchase ${metaName(
-            artist
-          )}’s artworks, available for sale. Browse our selection of paintings, prints, and sculptures by the artist, and find art you love.`,
-          blurb
-        )
-      },
-    },
-    artworksTitle: {
-      type: GraphQLString,
-      resolve: (artist) => {
-        return `${metaName(artist)} - Artworks for Sale & More | Artsy`
-      },
-    },
-    auctionDescription: {
-      type: GraphQLString,
-      resolve: (artist) => {
-        return `Find out about ${metaName(
-          artist
-        )}’s auction history, past sales, and current market value. Browse Artsy’s Price Database for recent auction results from the artist.`
-      },
-    },
-    auctionTitle: {
-      type: GraphQLString,
-      resolve: (artist) => {
-        return `${metaName(artist)} - Auction Results and Sales Data | Artsy`
-      },
-    },
     description: {
       type: GraphQLString,
-      resolve: (artist) => {
+      resolve: ({ artist, tab }) => {
         const blurb = artist.blurb.length
           ? markdownToText(artist.blurb)
           : undefined
 
-        return formatDescription(
-          `Explore ${metaName(
-            artist
-          )}'s biography, achievements, artworks, auction results, and shows on Artsy.`,
-          blurb
-        )
+        switch (tab) {
+          case "ABOUT":
+            return formatDescription(
+              `Explore ${metaName(
+                artist
+              )}'s biography, achievements, artworks, auction results, and shows on Artsy.`,
+              blurb
+            )
+          case "ARTWORKS":
+            return formatDescription(
+              `Discover and purchase ${metaName(
+                artist
+              )}’s artworks, available for sale. Browse our selection of paintings, prints, and sculptures by the artist, and find art you love.`,
+              blurb
+            )
+          case "AUCTION_RESULTS":
+            return `Find out about ${metaName(
+              artist
+            )}’s auction history, past sales, and current market value. Browse Artsy’s Price Database for recent auction results from the artist.`
+        }
       },
     },
     title: {
       type: GraphQLString,
-      resolve: (artist) => {
-        return `${metaName(artist)} - Biography, Shows, Articles & More | Artsy`
+      resolve: ({ artist, tab }) => {
+        switch (tab) {
+          case "ABOUT":
+            return `${metaName(
+              artist
+            )} - Biography, Shows, Articles & More | Artsy`
+          case "ARTWORKS":
+            return `${metaName(artist)} - Artworks for Sale & More | Artsy`
+          case "AUCTION_RESULTS":
+            return `${metaName(
+              artist
+            )} - Auction Results and Sales Data | Artsy`
+        }
       },
     },
   },
@@ -76,7 +80,12 @@ const ArtistMetaType = new GraphQLObjectType<any, ResolverContext>({
 
 const Meta: GraphQLFieldConfig<void, ResolverContext> = {
   type: ArtistMetaType,
-  resolve: (x) => x,
+  args: {
+    tab: { type: ArtistTabEnumType },
+  },
+  resolve: (artist, { tab }) => {
+    return { artist, tab }
+  },
 }
 
 export default Meta

--- a/src/schema/v2/artist/meta.ts
+++ b/src/schema/v2/artist/meta.ts
@@ -17,8 +17,8 @@ export const formatDescription = (description: string, blurb?: string) => {
   return truncate(compact([description, blurb]).join("."), 157)
 }
 
-const ArtistTabEnumType = new GraphQLEnumType({
-  name: "ArtistTab",
+const ArtistPageEnumType = new GraphQLEnumType({
+  name: "ArtistPage",
   values: {
     ABOUT: { value: "ABOUT" },
     ARTWORKS: { value: "ARTWORKS" },
@@ -31,12 +31,12 @@ const ArtistMetaType = new GraphQLObjectType<any, ResolverContext>({
   fields: {
     description: {
       type: GraphQLString,
-      resolve: ({ artist, tab }) => {
+      resolve: ({ artist, page }) => {
         const blurb = artist.blurb.length
           ? markdownToText(artist.blurb)
           : undefined
 
-        switch (tab) {
+        switch (page) {
           case "ABOUT":
             return formatDescription(
               `Explore ${metaName(
@@ -60,8 +60,8 @@ const ArtistMetaType = new GraphQLObjectType<any, ResolverContext>({
     },
     title: {
       type: GraphQLString,
-      resolve: ({ artist, tab }) => {
-        switch (tab) {
+      resolve: ({ artist, page }) => {
+        switch (page) {
           case "ABOUT":
             return `${metaName(
               artist
@@ -81,10 +81,10 @@ const ArtistMetaType = new GraphQLObjectType<any, ResolverContext>({
 const Meta: GraphQLFieldConfig<void, ResolverContext> = {
   type: ArtistMetaType,
   args: {
-    tab: { type: ArtistTabEnumType },
+    page: { type: ArtistPageEnumType },
   },
-  resolve: (artist, { tab }) => {
-    return { artist, tab }
+  resolve: (artist, { page }) => {
+    return { artist, page }
   },
 }
 

--- a/src/schema/v2/artist/meta.ts
+++ b/src/schema/v2/artist/meta.ts
@@ -1,5 +1,4 @@
 import { stripTags, truncate, markdownToText } from "lib/helpers"
-import { compact } from "lodash"
 import {
   GraphQLString,
   GraphQLObjectType,
@@ -11,10 +10,6 @@ import { ResolverContext } from "types/graphql"
 export const metaName = (artist) => {
   if (artist.name) return stripTags(artist.name)
   return "Unnamed Artist"
-}
-
-export const formatDescription = (description: string, blurb?: string) => {
-  return truncate(compact([description, blurb]).join("."), 157)
 }
 
 const ArtistPageEnumType = new GraphQLEnumType({
@@ -38,18 +33,18 @@ const ArtistMetaType = new GraphQLObjectType<any, ResolverContext>({
 
         switch (page) {
           case "ABOUT":
-            return formatDescription(
+            return truncate(
               `Explore ${metaName(
                 artist
-              )}'s biography, achievements, artworks, auction results, and shows on Artsy.`,
-              blurb
+              )}'s biography, achievements, artworks, auction results, and shows on Artsy. ${blurb}`,
+              157
             )
           case "ARTWORKS":
-            return formatDescription(
+            return truncate(
               `Discover and purchase ${metaName(
                 artist
-              )}’s artworks, available for sale. Browse our selection of paintings, prints, and sculptures by the artist, and find art you love.`,
-              blurb
+              )}’s artworks, available for sale. Browse our selection of paintings, prints, and sculptures by the artist, and find art you love. ${blurb}`,
+              157
             )
           case "AUCTION_RESULTS":
             return `Find out about ${metaName(
@@ -81,7 +76,7 @@ const ArtistMetaType = new GraphQLObjectType<any, ResolverContext>({
 const Meta: GraphQLFieldConfig<void, ResolverContext> = {
   type: ArtistMetaType,
   args: {
-    page: { type: ArtistPageEnumType },
+    page: { type: ArtistPageEnumType, defaultValue: "ABOUT" },
   },
   resolve: (artist, { page }) => {
     return { artist, page }


### PR DESCRIPTION
The type of this PR is: **Chore**

This PR solves [GRO-1671]

### Description

* adds `ArtistPageEnumType` to `ArtistMeta` to make it easier to get the tag's content depending on the Artist page tab

This is 🤝 with https://github.com/artsy/force/pull/12430


[GRO-1671]: https://artsyproduct.atlassian.net/browse/GRO-1671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ