### PR TITLE
feat(artist) update artist data insight labels to include count

### DIFF
--- a/src/schema/v2/artist/__tests__/insights.test.ts
+++ b/src/schema/v2/artist/__tests__/insights.test.ts
@@ -59,7 +59,7 @@ describe("ArtistInsights type", () => {
       expect(data!.artist.insights).toEqual([
         {
           type: "SOLO_SHOW",
-          label: "Solo show at a major institution",
+          label: "Solo show at 2 major institutions",
           entities: ["MoMA PS1", "Museum of Modern Art (MoMA)"],
         },
         {
@@ -116,7 +116,7 @@ describe("ArtistInsights type", () => {
       expect(data!.artist.insights).toEqual([
         {
           type: "SOLO_SHOW",
-          label: "Solo show at a major institution",
+          label: "Solo show at 2 major institutions",
           entities: ["MoMA PS1", "Museum of Modern Art (MoMA)"],
         },
       ])
@@ -148,7 +148,7 @@ describe("ArtistInsights type", () => {
       expect(data!.artist.insights).toEqual([
         {
           type: "SOLO_SHOW",
-          label: "Solo show at a major institution",
+          label: "Solo show at 2 major institutions",
           entities: ["MoMA PS1", "Museum of Modern Art (MoMA)"],
         },
         {

--- a/src/schema/v2/artist/helpers.ts
+++ b/src/schema/v2/artist/helpers.ts
@@ -25,27 +25,44 @@ export const ARTIST_INSIGHT_MAPPING = {
   SOLO_SHOW: {
     getDescription: () => null,
     getEntities: (artist) => splitEntities(artist.solo_show_institutions),
-    getLabel: () => "Solo show at a major institution",
+    getLabel: (_artist, count: number) =>
+      `Solo show at ${
+        count === 1 ? "a major institution" : `${count} major institutions`
+      }`,
   },
   GROUP_SHOW: {
     getDescription: () => null,
     getEntities: (artist) => splitEntities(artist.group_show_institutions),
-    getLabel: () => "Group show at a major institution",
+    getLabel: (_artist, count: number) =>
+      `Group show at ${
+        count === 1 ? "a major institution" : `${count} major institutions`
+      }`,
   },
   COLLECTED: {
     getDescription: () => null,
     getEntities: (artist) => splitEntities(artist.collections),
-    getLabel: () => "Collected by a major institution",
+    getLabel: (_artist, count: number) =>
+      `Collected by ${
+        count === 1 ? "a major institution" : `${count} major institutions`
+      }`,
   },
   REVIEWED: {
     getDescription: () => null,
     getEntities: (artist) => splitEntities(artist.review_sources),
-    getLabel: () => "Reviewed by a major art publication",
+    getLabel: (_artist, count: number) =>
+      `Reviewed by ${
+        count === 1
+          ? "a major art publication"
+          : `${count} major art publications`
+      }`,
   },
   BIENNIAL: {
     getDescription: () => null,
     getEntities: (artist) => splitEntities(artist.biennials),
-    getLabel: () => "Included in a major biennial",
+    getLabel: (_artist, count: number) =>
+      `Included in ${
+        count === 1 ? "a major biennial" : `${count} major biennials`
+      }`,
   },
   ACTIVE_SECONDARY_MARKET: {
     getDescription: () => "Recent auction results in the Artsy Price Database.",
@@ -71,17 +88,30 @@ export const ARTIST_INSIGHT_MAPPING = {
   RESIDENCIES: {
     getDescription: () => "Established artist residencies.",
     getEntities: (artist) => splitEntities(artist.residencies),
-    getLabel: () => "Participated in a notable artist residency",
+    getLabel: (_artist, count: number) =>
+      `Participated in ${
+        count === 1
+          ? "a notable artist residency"
+          : `${count} notable artist residencies`
+      }`,
   },
   PRIVATE_COLLECTIONS: {
     getDescription: () => "A list of collections they are part of.",
     getEntities: (artist) => splitEntities(artist.private_collections),
-    getLabel: () => "Collected by a notable private collector",
+    getLabel: (_artist, count: number) =>
+      `Collected by ${
+        count === 1
+          ? "a notable private collector"
+          : `${count} notable private collectors`
+      }`,
   },
   AWARDS: {
     getDescription: () => "Awards and prizes the artist has won.",
     getEntities: (artist) => splitEntities(artist.awards),
-    getLabel: () => "Winner of top industry award",
+    getLabel: (_artist, count: number) =>
+      `Winner of ${
+        count === 1 ? "a top industry award" : `${count} top industry awards`
+      }`,
   },
 } as const
 
@@ -109,7 +139,7 @@ export const getArtistInsights = (artist) => {
     if (!entities) return { artist }
 
     const description = getDescription(artist)
-    const label = getLabel(artist)
+    const label = getLabel(artist, entities.length)
 
     return {
       artist,


### PR DESCRIPTION
This goal of this PR is to move any counting of entities in an artist's insight data to MP to be funneled to the frontend. 