### PR TITLE
feat(artist): sorts insights by rank

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1509,18 +1509,18 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   insights(
     # The specific insights to return.
     kind: [ArtistInsightKind] = [
+      HIGH_AUCTION_RECORD
+      ACTIVE_SECONDARY_MARKET
+      CRITICALLY_ACCLAIMED
+      ARTSY_VANGUARD_YEAR
       SOLO_SHOW
       GROUP_SHOW
+      BIENNIAL
+      PRIVATE_COLLECTIONS
       COLLECTED
       REVIEWED
-      BIENNIAL
-      ACTIVE_SECONDARY_MARKET
-      HIGH_AUCTION_RECORD
-      ARTSY_VANGUARD_YEAR
-      CRITICALLY_ACCLAIMED
-      RESIDENCIES
-      PRIVATE_COLLECTIONS
       AWARDS
+      RESIDENCIES
     ]
   ): [ArtistInsight!]!
 

--- a/src/schema/v2/artist/__tests__/insights.test.ts
+++ b/src/schema/v2/artist/__tests__/insights.test.ts
@@ -58,6 +58,11 @@ describe("ArtistInsights type", () => {
     return runQuery(query, context).then((data) => {
       expect(data!.artist.insights).toEqual([
         {
+          type: "ACTIVE_SECONDARY_MARKET",
+          label: "Active Secondary Market",
+          entities: [],
+        },
+        {
           type: "SOLO_SHOW",
           label: "Solo show at 2 major institutions",
           entities: ["MoMA PS1", "Museum of Modern Art (MoMA)"],
@@ -68,6 +73,11 @@ describe("ArtistInsights type", () => {
           entities: ["Metropolitan Museum of Art"],
         },
         {
+          type: "BIENNIAL",
+          label: "Included in a major biennial",
+          entities: ["frieze"],
+        },
+        {
           type: "COLLECTED",
           label: "Collected by a major institution",
           entities: ["Museum of Modern Art (MoMA)"],
@@ -76,16 +86,6 @@ describe("ArtistInsights type", () => {
           type: "REVIEWED",
           label: "Reviewed by a major art publication",
           entities: ["Artforum International Magazine"],
-        },
-        {
-          type: "BIENNIAL",
-          label: "Included in a major biennial",
-          entities: ["frieze"],
-        },
-        {
-          type: "ACTIVE_SECONDARY_MARKET",
-          label: "Active Secondary Market",
-          entities: [],
         },
       ])
     })
@@ -135,7 +135,7 @@ describe("ArtistInsights type", () => {
           {
             artist(id: "foo-bar") {
               id
-              insights(kind: [SOLO_SHOW, GROUP_SHOW, REVIEWED]) {
+              insights(kind: [GROUP_SHOW, REVIEWED, SOLO_SHOW]) {
                 type
                 label
                 entities

--- a/src/schema/v2/artist/insights.ts
+++ b/src/schema/v2/artist/insights.ts
@@ -17,7 +17,9 @@ import {
 
 export const ArtistInsightKind = new GraphQLEnumType({
   name: "ArtistInsightKind",
-  values: ARTIST_INSIGHT_KINDS,
+  values: ARTIST_INSIGHT_KINDS.reduce((acc, kind) => {
+    return { ...acc, [kind]: { value: kind } }
+  }, {}),
 })
 
 export const ArtistInsight = new GraphQLObjectType<any, ResolverContext>({
@@ -53,16 +55,13 @@ export const ArtistInsight = new GraphQLObjectType<any, ResolverContext>({
   }),
 })
 
-// TODO:
-// return partnerArtistsLoader({ artist_id: artist.id, partner_category: ['blue-chip'], size: 1})
-
 export const ArtistInsights: GraphQLFieldConfig<any, ResolverContext> = {
   type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ArtistInsight))),
   args: {
     kind: {
       type: new GraphQLList(ArtistInsightKind),
       description: "The specific insights to return.",
-      defaultValue: Object.keys(ARTIST_INSIGHT_KINDS),
+      defaultValue: ARTIST_INSIGHT_KINDS,
     },
   },
   resolve: async (artist, { kind }, { auctionLotsLoader }) => {


### PR DESCRIPTION
@TMcMeans and I paired through this just now.

This PR ensures we sort the insights in a consistent fashion. I don't think there's a ticket for this explicitly.

Also, now we know which insights are missing and there's two which were not ranked (added to the end). Will make tickets for each of those.