### PR TITLE
feat(NX-3537): add artistId filter to conversationConnection query

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11192,6 +11192,7 @@ type Me implements Node {
   # Conversations, usually between a user and partner.
   conversationsConnection(
     after: String
+    artistId: String
     before: String
     dismissed: Boolean
     first: Int
@@ -14448,6 +14449,7 @@ type Query {
   # Conversations, usually between a user and partner.
   conversationsConnection(
     after: String
+    artistId: String
     before: String
     dismissed: Boolean
     first: Int
@@ -18776,6 +18778,7 @@ type Viewer {
   # Conversations, usually between a user and partner.
   conversationsConnection(
     after: String
+    artistId: String
     before: String
     dismissed: Boolean
     first: Int

--- a/src/schema/v2/conversation/conversations.ts
+++ b/src/schema/v2/conversation/conversations.ts
@@ -20,6 +20,7 @@ interface ConversationsArguments extends CursorPageable {
   hasReply?: boolean
   partnerId?: string
   fromId?: string
+  artistId?: string
   type?: "Partner" | "User"
 }
 
@@ -66,6 +67,9 @@ const Conversations: GraphQLFieldConfig<
     fromId: {
       type: GraphQLString,
     },
+    artistId: {
+      type: GraphQLString,
+    },
     type: {
       type: ConversationsInputModeEnum,
       defaultValue: "USER",
@@ -95,6 +99,7 @@ const Conversations: GraphQLFieldConfig<
         from_id: args.fromId ?? undefined,
         from_type: args.fromId ? "User" : undefined,
         to_type: "Partner",
+        artistId: args.artistId,
         has_reply: args.hasReply ?? undefined,
         has_message: args.hasMessage ?? undefined,
         dismissed: !!args.dismissed,


### PR DESCRIPTION
[NX-3537]

Adds the `artistId` option when filtering `ConversationsConnection`.

cc @artsy/negotiate-devs 

[NX-3537]: https://artsyproduct.atlassian.net/browse/NX-3537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ