### PR TITLE
chore(NX-3537): Fix name of param passed as artist id to conversations

### DIFF
--- a/src/schema/v2/conversation/conversations.ts
+++ b/src/schema/v2/conversation/conversations.ts
@@ -99,7 +99,7 @@ const Conversations: GraphQLFieldConfig<
         from_id: args.fromId ?? undefined,
         from_type: args.fromId ? "User" : undefined,
         to_type: "Partner",
-        artistId: args.artistId,
+        artist_id: args.artistId,
         has_reply: args.hasReply ?? undefined,
         has_message: args.hasMessage ?? undefined,
         dismissed: !!args.dismissed,


### PR DESCRIPTION
[NX-3537]

Param name on the endpoint must be `artist_id` (and not `artistId`)

[NX-3537]: https://artsyproduct.atlassian.net/browse/NX-3537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ