### PR TITLE
feat: support marketable arg for saleArtworks connection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11443,6 +11443,7 @@ type Me implements Node {
     isAuction: Boolean
     last: Int
     liveSale: Boolean
+    marketable: Boolean
     page: Int
     saleID: ID
 
@@ -15192,6 +15193,7 @@ type Query {
     isAuction: Boolean
     last: Int
     liveSale: Boolean
+    marketable: Boolean
     page: Int
     saleID: ID
 
@@ -19514,6 +19516,7 @@ type Viewer {
     isAuction: Boolean
     last: Int
     liveSale: Boolean
+    marketable: Boolean
     page: Int
     saleID: ID
 

--- a/src/schema/v2/sale_artworks.ts
+++ b/src/schema/v2/sale_artworks.ts
@@ -88,6 +88,7 @@ export const SaleArtworksConnectionField: GraphQLFieldConfig<
     },
     isAuction: { type: GraphQLBoolean },
     liveSale: { type: GraphQLBoolean },
+    marketable: { type: GraphQLBoolean },
     page: { type: GraphQLInt },
     saleID: { type: GraphQLID },
     saleSlug: {
@@ -112,6 +113,7 @@ export const SaleArtworksConnectionField: GraphQLFieldConfig<
       includeArtworksByFollowedArtists: requestIncludeArtworksByFollowedArtists,
       isAuction,
       liveSale,
+      marketable,
       saleID,
       saleSlug,
       userId,
@@ -144,6 +146,7 @@ export const SaleArtworksConnectionField: GraphQLFieldConfig<
       include_artworks_by_followed_artists: includeArtworksByFollowedArtists,
       is_auction: isAuction,
       live_sale: liveSale,
+      marketable: marketable,
       sale_id: saleID || saleSlug,
       user_id: userId,
       ..._args,


### PR DESCRIPTION
Support a new boolean `marketable` argument for the `saleArtworksConnection` query field, allowing clients to specify the backend should filter to only marketable works.

Jira: [FX-4777](https://artsyproduct.atlassian.net/browse/FX-4777)

[FX-4777]: https://artsyproduct.atlassian.net/browse/FX-4777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ