### PR TITLE
feat: add user id to comparables query

### DIFF
--- a/src/schema/v2/auction_result.ts
+++ b/src/schema/v2/auction_result.ts
@@ -129,7 +129,7 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
       resolve: async (
         parent,
         options,
-        { auctionResultComparableAuctionResultsLoader }
+        { auctionResultComparableAuctionResultsLoader, userID }
       ) => {
         if (!auctionResultComparableAuctionResultsLoader) {
           return null
@@ -142,7 +142,9 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
         const {
           _embedded: { items },
           total_count,
-        } = await auctionResultComparableAuctionResultsLoader(parent.id)
+        } = await auctionResultComparableAuctionResultsLoader(parent.id, {
+          user_id: userID,
+        })
 
         return merge(
           {


### PR DESCRIPTION
This PR adds current user id to the comparables query. Since the id is added for testing proposes I added it as a query parameter.

JIRA - [DO-692]

[DO-692]: https://artsyproduct.atlassian.net/browse/DO-692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ