### PR TITLE
feat: Add follow and sort args to partnersConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13515,8 +13515,17 @@ type PartnerCategory {
 
     # Indicates tier 3/4 for gallery, 2 for institution
     eligibleForSecondaryBucket: Boolean
+
+    # Exclude partners the user follows (only effective when `include_partners_with_followed_artists` is set to true).
+    excludeFollowedPartners: Boolean
     hasFullProfile: Boolean
     ids: [String]
+
+    # If true, will only return partners that list artists that the user follows
+    includePartnersWithFollowedArtists: Boolean
+
+    # An IP address, will be used to lookup location
+    ip: String
 
     # Coordinates to find partners closest to
     near: String
@@ -13740,6 +13749,7 @@ enum PartnerShowPartnerType {
 enum PartnersSortType {
   CREATED_AT_ASC
   CREATED_AT_DESC
+  DISTANCE
   PUBLISHED_AT_DESC
   RANDOM_SCORE_DESC
   RELATIVE_SIZE_ASC
@@ -14793,8 +14803,17 @@ type Query {
 
     # Indicates tier 3/4 for gallery, 2 for institution
     eligibleForSecondaryBucket: Boolean
+
+    # Exclude partners the user follows (only effective when `include_partners_with_followed_artists` is set to true).
+    excludeFollowedPartners: Boolean
     hasFullProfile: Boolean
     ids: [String]
+
+    # If true, will only return partners that list artists that the user follows
+    includePartnersWithFollowedArtists: Boolean
+
+    # An IP address, will be used to lookup location
+    ip: String
 
     # Coordinates to find partners closest to
     near: String
@@ -15085,8 +15104,17 @@ type Query {
 
     # Indicates an active subscription
     eligibleForListing: Boolean
+
+    # Exclude partners the user follows (only effective when `include_partners_with_followed_artists` is set to true).
+    excludeFollowedPartners: Boolean
     first: Int
     ids: [String]
+
+    # If true, will only return partners that list artists that the user follows
+    includePartnersWithFollowedArtists: Boolean
+
+    # An IP address, will be used to lookup location
+    ip: String
     last: Int
 
     # Coordinates to find partners closest to
@@ -19175,8 +19203,17 @@ type Viewer {
 
     # Indicates tier 3/4 for gallery, 2 for institution
     eligibleForSecondaryBucket: Boolean
+
+    # Exclude partners the user follows (only effective when `include_partners_with_followed_artists` is set to true).
+    excludeFollowedPartners: Boolean
     hasFullProfile: Boolean
     ids: [String]
+
+    # If true, will only return partners that list artists that the user follows
+    includePartnersWithFollowedArtists: Boolean
+
+    # An IP address, will be used to lookup location
+    ip: String
 
     # Coordinates to find partners closest to
     near: String
@@ -19427,8 +19464,17 @@ type Viewer {
 
     # Indicates an active subscription
     eligibleForListing: Boolean
+
+    # Exclude partners the user follows (only effective when `include_partners_with_followed_artists` is set to true).
+    excludeFollowedPartners: Boolean
     first: Int
     ids: [String]
+
+    # If true, will only return partners that list artists that the user follows
+    includePartnersWithFollowedArtists: Boolean
+
+    # An IP address, will be used to lookup location
+    ip: String
     last: Int
 
     # Coordinates to find partners closest to

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -543,6 +543,7 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    partnersLoader: gravityLoader("partners", {}, { headers: true }),
     popularArtistsLoader: gravityLoader("artists/popular"),
     purchasesLoader: gravityLoader("purchases", {}, { headers: true }),
     recordArtworkViewLoader: gravityLoader(

--- a/src/lib/locationHelpers.ts
+++ b/src/lib/locationHelpers.ts
@@ -1,0 +1,37 @@
+import { isString } from "lodash"
+
+interface Location {
+  lat: number
+  lng: number
+  maxDistance?: number
+}
+
+const DEFAULT_MAX_DISTANCE_KM = 75
+
+export const getLocationArgs = async (
+  near: Location | undefined,
+  ip: string | undefined,
+  requestLocationLoader: any
+) => {
+  let location = near
+
+  if (ip) {
+    const {
+      body: { data: locationData },
+    } = await requestLocationLoader({ ip })
+
+    if (locationData.location) {
+      location = {
+        lat: locationData.location.latitude,
+        lng: locationData.location.longitude,
+      }
+    }
+  }
+
+  if (!location) return {}
+
+  return {
+    near: isString(near) ? near : `${location.lat},${location.lng}`,
+    max_distance: location.maxDistance || DEFAULT_MAX_DISTANCE_KM,
+  }
+}

--- a/src/schema/v2/me/showsConnection.ts
+++ b/src/schema/v2/me/showsConnection.ts
@@ -1,19 +1,12 @@
 import { GraphQLFieldConfig, GraphQLString } from "graphql"
+import { getLocationArgs } from "lib/locationHelpers"
 import { getPagingParameters, pageable } from "relay-cursor-paging"
 import { ResolverContext } from "types/graphql"
-import EventStatus from "../input_fields/event_status"
-import ShowSorts from "../sorts/show_sorts"
-import { ShowsConnection as ShowsConnectionType } from "../show"
 import { paginationResolver } from "../fields/pagination"
+import EventStatus from "../input_fields/event_status"
 import Near from "../input_fields/near"
-
-const DEFAULT_MAX_DISTANCE_KM = 75
-
-interface Location {
-  lat: number
-  lng: number
-  maxDistance?: number
-}
+import { ShowsConnection as ShowsConnectionType } from "../show"
+import ShowSorts from "../sorts/show_sorts"
 
 export const ShowsConnection: GraphQLFieldConfig<void, ResolverContext> = {
   type: ShowsConnectionType.connectionType,
@@ -71,32 +64,4 @@ export const ShowsConnection: GraphQLFieldConfig<void, ResolverContext> = {
       totalCount,
     })
   },
-}
-
-const getLocationArgs = async (
-  near: Location | undefined,
-  ip: string | undefined,
-  requestLocationLoader: any
-) => {
-  let location = near
-
-  if (ip) {
-    const {
-      body: { data: locationData },
-    } = await requestLocationLoader({ ip })
-
-    if (locationData.location) {
-      location = {
-        lat: locationData.location.latitude,
-        lng: locationData.location.longitude,
-      }
-    }
-  }
-
-  if (!location) return {}
-
-  return {
-    near: `${location.lat},${location.lng}`,
-    max_distance: location.maxDistance || DEFAULT_MAX_DISTANCE_KM,
-  }
 }

--- a/src/schema/v2/partner/partners.ts
+++ b/src/schema/v2/partner/partners.ts
@@ -128,14 +128,22 @@ export const Partners: GraphQLFieldConfig<void, ResolverContext> = {
       eligibleForListing,
       eligibleForPrimaryBucket,
       eligibleForSecondaryBucket,
+      ip,
       excludeFollowedPartners,
       hasFullProfile,
       includePartnersWithFollowedArtists,
+      near,
       partnerCategories,
       ..._options
     },
-    { partnersLoader }
+    { partnersLoader, requestLocationLoader }
   ) => {
+    if (ip && near) {
+      throw new Error('The "ip" and "near" arguments are mutually exclusive.')
+    }
+
+    const locationArgs = await getLocationArgs(near, ip, requestLocationLoader)
+
     const options: any = {
       default_profile_public: defaultProfilePublic,
       eligible_for_carousel: eligibleForCarousel,
@@ -146,6 +154,7 @@ export const Partners: GraphQLFieldConfig<void, ResolverContext> = {
       has_full_profile: hasFullProfile,
       include_partners_with_followed_artists: includePartnersWithFollowedArtists,
       partner_categories: partnerCategories,
+      ...locationArgs,
       ..._options,
     }
 


### PR DESCRIPTION
Addresses [CX-3688]

## Description

This PR adds all parameters to `partnersConnection` introduced in https://github.com/artsy/gravity/pull/16387.


[CX-3688]: https://artsyproduct.atlassian.net/browse/CX-3688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ