### PR TITLE
Only return all active hero units

### DIFF
--- a/src/schema/v2/HeroUnit/heroUnitsConnection.ts
+++ b/src/schema/v2/HeroUnit/heroUnitsConnection.ts
@@ -19,22 +19,7 @@ export const heroUnitsConnection: GraphQLFieldConfig<void, ResolverContext> = {
     },
   }),
   resolve: async (_root, args, context) => {
-    const {
-      authenticatedHeroUnitsLoader,
-      heroUnitsLoader,
-      matchHeroUnitsLoader,
-    } = context
-
-    const { term } = args
-
-    if (term && !matchHeroUnitsLoader)
-      throw new Error(
-        "You need to pass a X-Access-Token header to perform this action"
-      )
-
-    const loader =
-      (term && matchHeroUnitsLoader) ||
-      (authenticatedHeroUnitsLoader ?? heroUnitsLoader)
+    const { heroUnitsLoader } = context
 
     const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
 
@@ -47,10 +32,9 @@ export const heroUnitsConnection: GraphQLFieldConfig<void, ResolverContext> = {
       page,
       size,
       total_count: true,
-      ...(term ? { term } : {}),
     }
 
-    const { body, headers } = await loader(gravityArgs)
+    const { body, headers } = await heroUnitsLoader(gravityArgs)
 
     const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 


### PR DESCRIPTION
This purpose of this PR is to troubleshoot why we can't seem to get hero units to show up over on the Force review app for https://github.com/artsy/force/pull/12459 when signed out. There were some theories that it was something to do with different loaders being used so here I'm eliminating that as a possibility by only using the basic hero units loader all the time.

Note that this does break forque but that's ok since we haven't fully cut anything over and are still WIP on this stuff.

/cc @artsy/grow-devs 