### PR TITLE
Revert "Only return all active hero units"

### DIFF
--- a/src/schema/v2/HeroUnit/heroUnitsConnection.ts
+++ b/src/schema/v2/HeroUnit/heroUnitsConnection.ts
@@ -19,7 +19,22 @@ export const heroUnitsConnection: GraphQLFieldConfig<void, ResolverContext> = {
     },
   }),
   resolve: async (_root, args, context) => {
-    const { heroUnitsLoader } = context
+    const {
+      authenticatedHeroUnitsLoader,
+      heroUnitsLoader,
+      matchHeroUnitsLoader,
+    } = context
+
+    const { term } = args
+
+    if (term && !matchHeroUnitsLoader)
+      throw new Error(
+        "You need to pass a X-Access-Token header to perform this action"
+      )
+
+    const loader =
+      (term && matchHeroUnitsLoader) ||
+      (authenticatedHeroUnitsLoader ?? heroUnitsLoader)
 
     const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
 
@@ -32,9 +47,10 @@ export const heroUnitsConnection: GraphQLFieldConfig<void, ResolverContext> = {
       page,
       size,
       total_count: true,
+      ...(term ? { term } : {}),
     }
 
-    const { body, headers } = await heroUnitsLoader(gravityArgs)
+    const { body, headers } = await loader(gravityArgs)
 
     const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 


### PR DESCRIPTION
This reverts commit ac5aa40277eb896ea8f436b170911e9ef605c82a.

https://github.com/artsy/metaphysics/pull/5059

This experiment didn't fix anything so I'm going back to the way it was.