### PR TITLE
refactor: allow null description in createFeaturedLinkMutaion

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7271,7 +7271,7 @@ type CreateFeaturedLinkFailure {
 
 input CreateFeaturedLinkMutationInput {
   clientMutationId: String
-  description: String!
+  description: String
   href: String!
   sourceBucket: String
   sourceKey: String

--- a/src/schema/v2/FeaturedLink/createFeaturedLinkMutation.ts
+++ b/src/schema/v2/FeaturedLink/createFeaturedLinkMutation.ts
@@ -61,7 +61,7 @@ export const CreateFeaturedLinkMutation = mutationWithClientMutationId<
   name: "CreateFeaturedLinkMutation",
   description: "Creates a featured link.",
   inputFields: {
-    description: { type: new GraphQLNonNull(GraphQLString) },
+    description: { type: GraphQLString },
     title: { type: new GraphQLNonNull(GraphQLString) },
     href: { type: new GraphQLNonNull(GraphQLString) },
     subtitle: { type: GraphQLString },


### PR DESCRIPTION
We received a request from the curatorial team to not require a description when creating a featured link. This removes that requirement from the `MP` schema. It also matches the current old admin [implementation](https://github.com/artsy/torque/blob/eda88b6919945c5880e6439f797653f50f4457d8/app/templates/frames/featured_link.jade#LL21C6-L21C97). A follow-up will be made in `Forque` to remove the client form validation. 

