### PR TITLE
chore: Add flag to include private hero units GRO-1755

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14929,7 +14929,10 @@ type Query {
     first: Int
     last: Int
 
-    # If present, will search by term
+    # If true will all hero units.
+    showAll: Boolean = false
+
+    # If present, will search by term.
     term: String
   ): HeroUnitConnection
   highlights: Highlights
@@ -19347,7 +19350,10 @@ type Viewer {
     first: Int
     last: Int
 
-    # If present, will search by term
+    # If true will all hero units.
+    showAll: Boolean = false
+
+    # If present, will search by term.
     term: String
   ): HeroUnitConnection
   highlights: Highlights

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14929,10 +14929,10 @@ type Query {
     first: Int
     last: Int
 
-    # If true will all hero units.
-    showAll: Boolean = false
+    # If true will include inactive hero units.
+    private: Boolean = false
 
-    # If present, will search by term.
+    # If present will search by term.
     term: String
   ): HeroUnitConnection
   highlights: Highlights
@@ -19350,10 +19350,10 @@ type Viewer {
     first: Int
     last: Int
 
-    # If true will all hero units.
-    showAll: Boolean = false
+    # If true will include inactive hero units.
+    private: Boolean = false
 
-    # If present, will search by term.
+    # If present will search by term.
     term: String
   ): HeroUnitConnection
   highlights: Highlights

--- a/src/schema/v2/HeroUnit/__tests__/heroUnitsConnection.test.ts
+++ b/src/schema/v2/HeroUnit/__tests__/heroUnitsConnection.test.ts
@@ -6,7 +6,7 @@ import {
 
 interface TestSetup {
   args: {
-    showAll?: boolean
+    private?: boolean
     term?: string
   }
 
@@ -19,7 +19,7 @@ interface TestSetup {
 
 describe("pickLoader", () => {
   const testSetup = (): TestSetup => {
-    const args = { showAll: false, term: undefined }
+    const args = { private: false, term: undefined }
 
     const context = {
       authenticatedHeroUnitsLoader: jest.fn(),
@@ -31,7 +31,7 @@ describe("pickLoader", () => {
   }
 
   describe("without an authenticated loader", () => {
-    describe("without the show all flag nor a term", () => {
+    describe("without the private flag nor a term", () => {
       it("returns the basic loader", () => {
         const { args, context } = testSetup()
         context.authenticatedHeroUnitsLoader = undefined
@@ -42,10 +42,10 @@ describe("pickLoader", () => {
       })
     })
 
-    describe("with the show all flag", () => {
+    describe("with the priavte flag", () => {
       it("returns the basic loader", () => {
         const { args, context } = testSetup()
-        args.showAll = true
+        args.private = true
         context.authenticatedHeroUnitsLoader = undefined
 
         const loader = pickLoader(args, context)
@@ -66,10 +66,10 @@ describe("pickLoader", () => {
       })
     })
 
-    describe("with the show all flag and a term", () => {
+    describe("with the private flag and a term", () => {
       it("throws an error", () => {
         const { args, context } = testSetup()
-        args.showAll = true
+        args.private = true
         args.term = "trending now"
         context.authenticatedHeroUnitsLoader = undefined
 
@@ -81,7 +81,7 @@ describe("pickLoader", () => {
   })
 
   describe("with an authenticated loader", () => {
-    describe("without the show all flag nor a term", () => {
+    describe("without the private flag nor a term", () => {
       it("returns the basic loader", () => {
         const { args, context } = testSetup()
         context.authenticatedHeroUnitsLoader = undefined
@@ -92,10 +92,10 @@ describe("pickLoader", () => {
       })
     })
 
-    describe("with the show all flag", () => {
+    describe("with the private flag", () => {
       it("returns the authenticated loader", () => {
         const { args, context } = testSetup()
-        args.showAll = true
+        args.private = true
 
         const loader = pickLoader(args, context)
 
@@ -114,10 +114,10 @@ describe("pickLoader", () => {
       })
     })
 
-    describe("with the show all flag and a term", () => {
+    describe("with the private flag and a term", () => {
       it("throws an error", () => {
         const { args, context } = testSetup()
-        args.showAll = true
+        args.private = true
         args.term = "trending now"
 
         expect(() => {

--- a/src/schema/v2/HeroUnit/__tests__/heroUnitsConnection.test.ts
+++ b/src/schema/v2/HeroUnit/__tests__/heroUnitsConnection.test.ts
@@ -1,0 +1,88 @@
+import { pickLoader, tokenRequiredMesage } from "../heroUnitsConnection"
+
+interface TestSetup {
+  args: {
+    term?: string
+  }
+
+  context: {
+    authenticatedHeroUnitsLoader?: () => void
+    heroUnitsLoader?: () => void
+    matchHeroUnitsLoader?: () => void
+  }
+}
+
+describe("pickLoader", () => {
+  const testSetup = (): TestSetup => {
+    const args = { term: "trending now" }
+
+    const context = {
+      authenticatedHeroUnitsLoader: jest.fn(),
+      heroUnitsLoader: jest.fn(),
+      matchHeroUnitsLoader: jest.fn(),
+    }
+
+    return { args, context }
+  }
+
+  describe("without an authenticated loader", () => {
+    describe("without a term", () => {
+      it("returns the basic loader", () => {
+        const { args, context } = testSetup()
+        args.term = undefined
+        context.authenticatedHeroUnitsLoader = undefined
+
+        const loader = pickLoader(args, context)
+
+        expect(loader).toEqual(context.heroUnitsLoader)
+      })
+    })
+
+    describe("with a term", () => {
+      it("returns the match loader", () => {
+        const { args, context } = testSetup()
+        context.authenticatedHeroUnitsLoader = undefined
+
+        const loader = pickLoader(args, context)
+
+        expect(loader).toEqual(context.matchHeroUnitsLoader)
+      })
+    })
+  })
+
+  describe("with an authenticated loader", () => {
+    describe("without a term", () => {
+      it("returns the authenticated loader", () => {
+        const { args, context } = testSetup()
+        args.term = undefined
+
+        const loader = pickLoader(args, context)
+
+        expect(loader).toEqual(context.authenticatedHeroUnitsLoader)
+      })
+    })
+
+    describe("with a term", () => {
+      it("returns the match loader", () => {
+        const { args, context } = testSetup()
+
+        const loader = pickLoader(args, context)
+
+        expect(loader).toEqual(context.matchHeroUnitsLoader)
+      })
+    })
+  })
+
+  describe("without a match loader", () => {
+    describe("with a term", () => {
+      it("throws an error", () => {
+        const { args, context } = testSetup()
+        context.matchHeroUnitsLoader = undefined
+
+        expect(() => {
+          pickLoader(args, context)
+        }).toThrow(tokenRequiredMesage)
+      })
+    })
+  })
+})

--- a/src/schema/v2/HeroUnit/__tests__/heroUnitsConnection.test.ts
+++ b/src/schema/v2/HeroUnit/__tests__/heroUnitsConnection.test.ts
@@ -1,7 +1,12 @@
-import { pickLoader, tokenRequiredMesage } from "../heroUnitsConnection"
+import {
+  invalidArgsMessage,
+  pickLoader,
+  tokenRequiredMesage,
+} from "../heroUnitsConnection"
 
 interface TestSetup {
   args: {
+    showAll?: boolean
     term?: string
   }
 
@@ -14,7 +19,7 @@ interface TestSetup {
 
 describe("pickLoader", () => {
   const testSetup = (): TestSetup => {
-    const args = { term: "trending now" }
+    const args = { showAll: false, term: undefined }
 
     const context = {
       authenticatedHeroUnitsLoader: jest.fn(),
@@ -26,10 +31,21 @@ describe("pickLoader", () => {
   }
 
   describe("without an authenticated loader", () => {
-    describe("without a term", () => {
+    describe("without the show all flag nor a term", () => {
       it("returns the basic loader", () => {
         const { args, context } = testSetup()
-        args.term = undefined
+        context.authenticatedHeroUnitsLoader = undefined
+
+        const loader = pickLoader(args, context)
+
+        expect(loader).toEqual(context.heroUnitsLoader)
+      })
+    })
+
+    describe("with the show all flag", () => {
+      it("returns the basic loader", () => {
+        const { args, context } = testSetup()
+        args.showAll = true
         context.authenticatedHeroUnitsLoader = undefined
 
         const loader = pickLoader(args, context)
@@ -41,6 +57,7 @@ describe("pickLoader", () => {
     describe("with a term", () => {
       it("returns the match loader", () => {
         const { args, context } = testSetup()
+        args.term = "trending now"
         context.authenticatedHeroUnitsLoader = undefined
 
         const loader = pickLoader(args, context)
@@ -48,13 +65,37 @@ describe("pickLoader", () => {
         expect(loader).toEqual(context.matchHeroUnitsLoader)
       })
     })
+
+    describe("with the show all flag and a term", () => {
+      it("throws an error", () => {
+        const { args, context } = testSetup()
+        args.showAll = true
+        args.term = "trending now"
+        context.authenticatedHeroUnitsLoader = undefined
+
+        expect(() => {
+          pickLoader(args, context)
+        }).toThrow(invalidArgsMessage)
+      })
+    })
   })
 
   describe("with an authenticated loader", () => {
-    describe("without a term", () => {
+    describe("without the show all flag nor a term", () => {
+      it("returns the basic loader", () => {
+        const { args, context } = testSetup()
+        context.authenticatedHeroUnitsLoader = undefined
+
+        const loader = pickLoader(args, context)
+
+        expect(loader).toEqual(context.heroUnitsLoader)
+      })
+    })
+
+    describe("with the show all flag", () => {
       it("returns the authenticated loader", () => {
         const { args, context } = testSetup()
-        args.term = undefined
+        args.showAll = true
 
         const loader = pickLoader(args, context)
 
@@ -65,10 +106,23 @@ describe("pickLoader", () => {
     describe("with a term", () => {
       it("returns the match loader", () => {
         const { args, context } = testSetup()
+        args.term = "trending now"
 
         const loader = pickLoader(args, context)
 
         expect(loader).toEqual(context.matchHeroUnitsLoader)
+      })
+    })
+
+    describe("with the show all flag and a term", () => {
+      it("throws an error", () => {
+        const { args, context } = testSetup()
+        args.showAll = true
+        args.term = "trending now"
+
+        expect(() => {
+          pickLoader(args, context)
+        }).toThrow(invalidArgsMessage)
       })
     })
   })
@@ -77,6 +131,7 @@ describe("pickLoader", () => {
     describe("with a term", () => {
       it("throws an error", () => {
         const { args, context } = testSetup()
+        args.term = "trending now"
         context.matchHeroUnitsLoader = undefined
 
         expect(() => {

--- a/src/schema/v2/HeroUnit/heroUnitsConnection.ts
+++ b/src/schema/v2/HeroUnit/heroUnitsConnection.ts
@@ -10,12 +10,12 @@ export const tokenRequiredMesage =
   "You need to pass a X-Access-Token header to perform this action"
 
 export const invalidArgsMessage =
-  "Invalid arguments - can't have both showAll and term"
+  "Invalid arguments - can't have both private and term"
 
 export const pickLoader = (args, context) => {
-  const { showAll, term } = args
+  const { term } = args
 
-  if (showAll && term) throw new Error(invalidArgsMessage)
+  if (args.private && term) throw new Error(invalidArgsMessage)
 
   const {
     authenticatedHeroUnitsLoader,
@@ -27,7 +27,7 @@ export const pickLoader = (args, context) => {
 
   const loader =
     (term && matchHeroUnitsLoader) ||
-    (showAll && authenticatedHeroUnitsLoader) ||
+    (args.private && authenticatedHeroUnitsLoader) ||
     heroUnitsLoader
 
   return loader
@@ -40,14 +40,14 @@ const HeroUnitConnection = connectionWithCursorInfo({
 export const heroUnitsConnection: GraphQLFieldConfig<void, ResolverContext> = {
   type: HeroUnitConnection.connectionType,
   args: pageable({
-    showAll: {
+    private: {
       type: GraphQLBoolean,
-      description: "If true will all hero units.",
+      description: "If true will include inactive hero units.",
       defaultValue: false,
     },
     term: {
       type: GraphQLString,
-      description: "If present, will search by term.",
+      description: "If present will search by term.",
     },
   }),
   resolve: async (_root, args, context) => {


### PR DESCRIPTION
This PR adds some much needed specs around picking which hero units loader to use. Prior to this PR it was not easy enough to understand when which of the three loaders would be used and I wanted to further complicate things so I started by extracting a function and wrapping the existing behavior with tests.

Then I added the complexity - if a flag called `private` is passed then use the authenticated loader and if not use the normal one.

So that's what this PR does - adds a flag to the hero units connection and then improves the resolver function by extracting the business logic to a separate function. That function is now wrapped with tests that help articulate the cases and should clarify when each of the loaders will be used.

This is all in service of changing Force to conditionally send `private` based on whether we want to only show the active hero units or if we want to preview the ones that haven't been marked as active yet. This functionality is something that will help our admins to verify they have their hero units configured correctly before pushing them to active.

Note: this PR can land first and then I will do separate PRs for Force and Forque to begin sending this flag. I've provided a default value so my understanding is that it is not required and will not break anything - do I have that right @dzucconi ?

https://artsyproduct.atlassian.net/browse/GRO-1755

/cc @artsy/grow-devs