### PR TITLE
feat: add profilesConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14146,12 +14146,32 @@ type Profile {
   slug: ID!
 }
 
+# A connection to a list of items.
+type ProfileConnection {
+  # A list of edges.
+  edges: [ProfileEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
 type ProfileCounts {
   follows(
     # Returns a `String` when format is specified. e.g.`'0,0.0000''`
     format: String
     label: String
   ): FormattedNumber
+}
+
+# An edge in a connection.
+type ProfileEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: Profile
 }
 
 union ProfileOwnerType = Fair | FairOrganizer | Partner
@@ -15241,6 +15261,18 @@ type Query {
     # The slug or ID of the Profile
     id: String!
   ): Profile
+
+  # A list of Profiles
+  profilesConnection(
+    after: String
+    before: String
+    first: Int
+    ids: [String]
+    last: Int
+
+    # If present, will search by term
+    term: String
+  ): ProfileConnection
 
   # Static set of recently sold artworks for the SWA landing page
   recentlySoldArtworks(
@@ -19600,6 +19632,18 @@ type Viewer {
     # The slug or ID of the Profile
     id: String!
   ): Profile
+
+  # A list of Profiles
+  profilesConnection(
+    after: String
+    before: String
+    first: Int
+    ids: [String]
+    last: Int
+
+    # If present, will search by term
+    term: String
+  ): ProfileConnection
 
   # Static set of recently sold artworks for the SWA landing page
   recentlySoldArtworks(

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -378,14 +378,11 @@ export default (accessToken, userID, opts) => {
       { method: "POST" }
     ),
     lotStandingLoader: gravityLoader("me/lot_standings", { size: 100 }),
-    matchSalesLoader: gravityLoader("match/sales", {}, { headers: true }),
     markNotificationsAsSeenLoader: gravityLoader(
       "me/notifications/mark_as_seen",
       {},
       { method: "PUT" }
     ),
-    matchUsersLoader: gravityLoader("match/users", {}, { headers: true }),
-    matchSetsLoader: gravityLoader("match/sets", {}, { headers: true }),
     authenticatedHeroUnitsLoader: gravityLoader(
       "hero_units",
       {},
@@ -401,11 +398,15 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    matchProfilesLoader: gravityLoader("match/profiles", {}, { headers: true }),
+    matchSalesLoader: gravityLoader("match/sales", {}, { headers: true }),
+    matchSetsLoader: gravityLoader("match/sets", {}, { headers: true }),
     matchShowsLoader: gravityLoader(
       "match/partner_shows",
       {},
       { headers: true }
     ),
+    matchUsersLoader: gravityLoader("match/users", {}, { headers: true }),
     mergeArtistLoader: gravityLoader("artists/merge", {}, { method: "POST" }),
     meBankAccountsLoader: gravityLoader(
       "me/bank_accounts",
@@ -545,6 +546,7 @@ export default (accessToken, userID, opts) => {
     ),
     partnersLoader: gravityLoader("partners", {}, { headers: true }),
     popularArtistsLoader: gravityLoader("artists/popular"),
+    profilesLoader: gravityLoader("profiles", {}, { headers: true }),
     purchasesLoader: gravityLoader("purchases", {}, { headers: true }),
     recordArtworkViewLoader: gravityLoader(
       "me/Recently_viewed_artworks",

--- a/src/schema/v2/__tests__/profiles.test.ts
+++ b/src/schema/v2/__tests__/profiles.test.ts
@@ -1,0 +1,93 @@
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+const PROFILES_FIXTURE = [
+  {
+    _id: "2",
+    owner: { name: "cat gallery" },
+  },
+  {
+    _id: "3",
+    owner: { name: "dog gallery" },
+  },
+]
+
+describe("profilesConnection", () => {
+  it("returns a list of profiles", async () => {
+    const query = gql`
+      {
+        profilesConnection(first: 2) {
+          totalCount
+          edges {
+            node {
+              internalID
+              name
+            }
+          }
+        }
+      }
+    `
+
+    const profilesLoader = jest.fn().mockReturnValue(
+      Promise.resolve({
+        body: PROFILES_FIXTURE,
+        headers: {
+          "x-total-count": "2",
+        },
+      })
+    )
+
+    const { profilesConnection } = await runAuthenticatedQuery(query, {
+      profilesLoader,
+    })
+
+    expect(profilesConnection).toEqual({
+      totalCount: 2,
+      edges: [
+        { node: { internalID: "2", name: "cat gallery" } },
+        { node: { internalID: "3", name: "dog gallery" } },
+      ],
+    })
+
+    expect(profilesLoader).toBeCalledWith({
+      page: 1,
+      size: 2,
+      total_count: true,
+    })
+  })
+
+  it("returns a list of profiles matching array of ids", async () => {
+    const profilesLoader = jest.fn().mockReturnValue(
+      Promise.resolve({
+        body: [{ _id: "example" }],
+        headers: { "x-total-count": "1" },
+      })
+    )
+
+    const query = gql`
+      {
+        profilesConnection(ids: ["example"], first: 5) {
+          totalCount
+          edges {
+            node {
+              internalID
+            }
+          }
+        }
+      }
+    `
+    const { profilesConnection } = await runAuthenticatedQuery(query, {
+      profilesLoader,
+    })
+
+    expect(profilesLoader).toBeCalledWith({
+      id: ["example"],
+      page: 1,
+      size: 5,
+      total_count: true,
+    })
+
+    expect(profilesConnection.totalCount).toBe(1)
+    expect(profilesConnection.edges[0].node.internalID).toEqual("example")
+  })
+})

--- a/src/schema/v2/__tests__/profiles.test.ts
+++ b/src/schema/v2/__tests__/profiles.test.ts
@@ -127,7 +127,7 @@ describe("profilesConnection", () => {
     expect(profilesConnection.edges[1].node.name).toEqual("dog gallery")
   })
 
-  it("uses the features loader when not searching by term", async () => {
+  it("uses the profiles loader when not searching by term", async () => {
     const profilesLoader = jest.fn().mockReturnValue(
       Promise.resolve({
         body: PROFILES_FIXTURE,

--- a/src/schema/v2/profiles.ts
+++ b/src/schema/v2/profiles.ts
@@ -51,8 +51,6 @@ export const Profiles: GraphQLFieldConfig<
 
       const { body, headers } = await matchProfilesLoader(gravityArgs)
 
-      console.log("body", body)
-
       const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 
       return paginationResolver({

--- a/src/schema/v2/profiles.ts
+++ b/src/schema/v2/profiles.ts
@@ -1,0 +1,90 @@
+import { GraphQLFieldConfig, GraphQLList, GraphQLString } from "graphql"
+import { ResolverContext } from "types/graphql"
+import {
+  connectionWithCursorInfo,
+  createPageCursors,
+  paginationResolver,
+} from "schema/v2/fields/pagination"
+import { ProfileType } from "./profile"
+import { CursorPageable, pageable } from "relay-cursor-paging"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { connectionFromArraySlice } from "graphql-relay"
+import { pick } from "lodash"
+
+export const Profiles: GraphQLFieldConfig<
+  void,
+  ResolverContext,
+  {
+    ids?: string[]
+    term?: string
+  } & CursorPageable
+> = {
+  type: connectionWithCursorInfo({ nodeType: ProfileType }).connectionType,
+  description: "A list of Profiles",
+  args: pageable({
+    ids: {
+      type: new GraphQLList(GraphQLString),
+    },
+    term: {
+      description: "If present, will search by term",
+      type: GraphQLString,
+    },
+  }),
+  resolve: async (_root, args, { profilesLoader, matchProfilesLoader }) => {
+    const { term } = args
+
+    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+
+    if (!matchProfilesLoader || !profilesLoader) {
+      throw new Error(
+        "You need to pass a X-Access-Token header to perform this action"
+      )
+    }
+
+    if (term) {
+      const gravityArgs: {
+        page: number
+        size: number
+        total_count: boolean
+        term?: string
+      } = { page, size, term, total_count: true }
+
+      const { body, headers } = await matchProfilesLoader(gravityArgs)
+
+      console.log("body", body)
+
+      const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+      return paginationResolver({
+        args,
+        body,
+        offset,
+        page,
+        size,
+        totalCount,
+      })
+    }
+
+    const { body, headers } = await profilesLoader({
+      total_count: true,
+      page,
+      size,
+      id: args.ids,
+    })
+
+    const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+    return {
+      totalCount,
+      pageCursors: createPageCursors({ page, size }, totalCount),
+      ...connectionFromArraySlice(
+        body,
+        pick(args, "before", "after", "first", "last"),
+        {
+          arrayLength: totalCount,
+          sliceStart: offset,
+        }
+      ),
+    }
+  },
+}

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -203,6 +203,7 @@ import { DeletePageMutation } from "./Page/DeletePageMutation"
 import { UpdatePageMutation } from "./Page/UpdatePageMutation"
 import { createArtistMutation } from "./artist/createArtistMutation"
 import { CollectorProfilesConnection } from "./CollectorProfile/collectorProfiles"
+import { Profiles } from "./profiles"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -301,6 +302,7 @@ const rootFields = {
   phoneNumber: PhoneNumber,
   previewSavedSearch: PreviewSavedSearchField,
   profile: Profile,
+  profilesConnection: Profiles,
   recentlySoldArtworks: RecentlySoldArtworks,
   requestLocation: RequestLocationField,
   reverseImageSearch: ReverseImageSearch,


### PR DESCRIPTION
### Problem 
<!-- the original problem or rationale -->
Our initial migration of the sets editor from `torque` did not include the `profile` item type as part of its scope. Once we cut over it was [surfaced](https://artsy.slack.com/archives/C0376CFU527/p1683046933073749) that this is blocking the retirement of the `torque` implementation. 

### Solution
<!-- the solution eventually agreed upon -->
Support managing sets with the `profile` item type. In support of that this PR: 

- Adds a `profilesLoader`
- Adds a `profiles` type (queryable with `profilesConnection`), which uses the `matchLoader` if a `term` argument is provider, otherwise it falls back to the `profilesLoader`. It also supports passing an array of `ids`. 

<details>
  <summary>Search without term</summary>
  
<img width="2254" alt="Screenshot 2023-06-09 at 11 15 12 AM" src="https://github.com/artsy/metaphysics/assets/38149304/9cafeb23-97a4-4b3c-b3a1-6da3f63292b3">
</details>

<details>
  <summary>Search with term</summary>
<img width="1862" alt="Screenshot 2023-06-09 at 11 16 56 AM" src="https://github.com/artsy/metaphysics/assets/38149304/6cca7a20-f976-4c02-b466-fa1175ba9af2">
</details>

<details>
  <summary>Search with array of ids</summary> 
<img width="1860" alt="Screenshot 2023-06-09 at 1 28 46 PM" src="https://github.com/artsy/metaphysics/assets/38149304/b2a30740-73d4-49ad-8f9a-5c15352b00ea">

</details>

### Related PR
- https://github.com/artsy/forque/pull/861


[PLATFORM-5152]

[PLATFORM-5152]: https://artsyproduct.atlassian.net/browse/PLATFORM-5152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ