### PR TITLE
feat: Add includePartnersNearIpBasedLocation param to partnersConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13577,11 +13577,11 @@ type PartnerCategory {
     hasFullProfile: Boolean
     ids: [String]
 
+    # If true, will only return partners that are located near the user's location based on the IP address.
+    includePartnersNearIpBasedLocation: Boolean = false
+
     # If true, will only return partners that list artists that the user follows
     includePartnersWithFollowedArtists: Boolean
-
-    # An IP address, will be used to lookup location
-    ip: String
 
     # Coordinates to find partners closest to
     near: String
@@ -14897,11 +14897,11 @@ type Query {
     hasFullProfile: Boolean
     ids: [String]
 
+    # If true, will only return partners that are located near the user's location based on the IP address.
+    includePartnersNearIpBasedLocation: Boolean = false
+
     # If true, will only return partners that list artists that the user follows
     includePartnersWithFollowedArtists: Boolean
-
-    # An IP address, will be used to lookup location
-    ip: String
 
     # Coordinates to find partners closest to
     near: String
@@ -15201,11 +15201,11 @@ type Query {
     first: Int
     ids: [String]
 
+    # If true, will only return partners that are located near the user's location based on the IP address.
+    includePartnersNearIpBasedLocation: Boolean = false
+
     # If true, will only return partners that list artists that the user follows
     includePartnersWithFollowedArtists: Boolean
-
-    # An IP address, will be used to lookup location
-    ip: String
     last: Int
 
     # Coordinates to find partners closest to
@@ -19330,11 +19330,11 @@ type Viewer {
     hasFullProfile: Boolean
     ids: [String]
 
+    # If true, will only return partners that are located near the user's location based on the IP address.
+    includePartnersNearIpBasedLocation: Boolean = false
+
     # If true, will only return partners that list artists that the user follows
     includePartnersWithFollowedArtists: Boolean
-
-    # An IP address, will be used to lookup location
-    ip: String
 
     # Coordinates to find partners closest to
     near: String
@@ -19594,11 +19594,11 @@ type Viewer {
     first: Int
     ids: [String]
 
+    # If true, will only return partners that are located near the user's location based on the IP address.
+    includePartnersNearIpBasedLocation: Boolean = false
+
     # If true, will only return partners that list artists that the user follows
     includePartnersWithFollowedArtists: Boolean
-
-    # An IP address, will be used to lookup location
-    ip: String
     last: Int
 
     # Coordinates to find partners closest to

--- a/src/lib/locationHelpers.ts
+++ b/src/lib/locationHelpers.ts
@@ -15,7 +15,7 @@ export const getLocationArgs = async (
 ) => {
   let location = near
 
-  if (ip) {
+  if (!location && ip) {
     const {
       body: { data: locationData },
     } = await requestLocationLoader({ ip })

--- a/src/schema/v2/me/showsConnection.ts
+++ b/src/schema/v2/me/showsConnection.ts
@@ -56,7 +56,9 @@ export const ShowsConnection: GraphQLFieldConfig<void, ResolverContext> = {
     } = args
 
     if (near && (includeShowsNearIpBasedLocation || ip)) {
-      throw new Error('The "ip" and "near" arguments are mutually exclusive.')
+      throw new Error(
+        'The "includeShowsNearIpBasedLocation" and "near" arguments are mutually exclusive.'
+      )
     }
 
     // Include shows by IP either if `includeShowsNearIpBasedLocation` is set to true or `ip` is passed as an argument


### PR DESCRIPTION
## Description

Add includePartnersNearIpBasedLocation param to partnersConnection.

This PR adds the parameter `includePartnersNearIpBasedLocation` to partnersConnection. When set to true, the IP address from context is used to do the geo lookup (introduced in https://github.com/artsy/metaphysics/pull/5055).

I removed the param `ip`. It's not used yet by any clients and this breaking change shouldn't break anything.

--- 

**Related PRs:**

- https://github.com/artsy/metaphysics/pull/5079
