### PR TITLE
feat: Add maxDistance param to partnersConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13583,6 +13583,9 @@ type PartnerCategory {
     # If true, will only return partners that list artists that the user follows
     includePartnersWithFollowedArtists: Boolean
 
+    # Max distance to use when geo-locating partners, defaults to 75km.
+    maxDistance: Int
+
     # Coordinates to find partners closest to
     near: String
     page: Int
@@ -14903,6 +14906,9 @@ type Query {
     # If true, will only return partners that list artists that the user follows
     includePartnersWithFollowedArtists: Boolean
 
+    # Max distance to use when geo-locating partners, defaults to 75km.
+    maxDistance: Int
+
     # Coordinates to find partners closest to
     near: String
     page: Int
@@ -15207,6 +15213,9 @@ type Query {
     # If true, will only return partners that list artists that the user follows
     includePartnersWithFollowedArtists: Boolean
     last: Int
+
+    # Max distance to use when geo-locating partners, defaults to 75km.
+    maxDistance: Int
 
     # Coordinates to find partners closest to
     near: String
@@ -19336,6 +19345,9 @@ type Viewer {
     # If true, will only return partners that list artists that the user follows
     includePartnersWithFollowedArtists: Boolean
 
+    # Max distance to use when geo-locating partners, defaults to 75km.
+    maxDistance: Int
+
     # Coordinates to find partners closest to
     near: String
     page: Int
@@ -19600,6 +19612,9 @@ type Viewer {
     # If true, will only return partners that list artists that the user follows
     includePartnersWithFollowedArtists: Boolean
     last: Int
+
+    # Max distance to use when geo-locating partners, defaults to 75km.
+    maxDistance: Int
 
     # Coordinates to find partners closest to
     near: String

--- a/src/schema/v2/partner/partners.ts
+++ b/src/schema/v2/partner/partners.ts
@@ -63,6 +63,11 @@ export const Partners: GraphQLFieldConfig<void, ResolverContext> = {
     hasFullProfile: {
       type: GraphQLBoolean,
     },
+    maxDistance: {
+      type: GraphQLInt,
+      description:
+        "Max distance to use when geo-locating partners, defaults to 75km.",
+    },
     near: {
       type: GraphQLString,
       description: "Coordinates to find partners closest to",
@@ -134,6 +139,7 @@ export const Partners: GraphQLFieldConfig<void, ResolverContext> = {
       excludeFollowedPartners,
       hasFullProfile,
       includePartnersWithFollowedArtists,
+      maxDistance,
       near,
       partnerCategories,
       ..._options
@@ -161,6 +167,7 @@ export const Partners: GraphQLFieldConfig<void, ResolverContext> = {
       exclude_followed_partners: excludeFollowedPartners,
       has_full_profile: hasFullProfile,
       include_partners_with_followed_artists: includePartnersWithFollowedArtists,
+      max_distance: maxDistance,
       partner_categories: partnerCategories,
       ...locationArgs,
       ..._options,
@@ -195,6 +202,7 @@ export const PartnersConnection: GraphQLFieldConfig<void, ResolverContext> = {
       "includePartnersWithFollowedArtists",
       "includePartnersNearIpBasedLocation",
       "near",
+      "maxDistance",
       "partnerCategories",
       "sort",
       "type"
@@ -227,6 +235,7 @@ export const PartnersConnection: GraphQLFieldConfig<void, ResolverContext> = {
       exclude_followed_partners: args.excludeFollowedPartners,
       include_partners_with_followed_artists:
         args.includePartnersWithFollowedArtists,
+      max_distance: args.maxDistance,
       default_profile_public: args.defaultProfilePublic,
       sort: args.sort,
       partner_categories: args.partnerCategories,


### PR DESCRIPTION

## Description

This PR adds the param `maxDistance` to `partnersConnection` to be able to pass it to Gravity. This is needed to not default to 75 when sorting by distance on the new "Galleries for You" screen in the app.