### PR TITLE
feat: Use IP address from header for location request

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15730,6 +15730,7 @@ type RequestCredentialsForAssetUploadPayload {
 
 type RequestLocation {
   cached: Int
+  coordinates: LatLng
   country: String
   countryCode: String
   id: ID!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15324,7 +15324,7 @@ type Query {
   ): RecentlySoldArtworkTypeConnection
 
   # A requested location
-  requestLocation(ip: String!): RequestLocation
+  requestLocation(ip: String): RequestLocation
 
   # Search for matching artworks by image
   reverseImageSearch(
@@ -19704,7 +19704,7 @@ type Viewer {
   ): RecentlySoldArtworkTypeConnection
 
   # A requested location
-  requestLocation(ip: String!): RequestLocation
+  requestLocation(ip: String): RequestLocation
 
   # Search for matching artworks by image
   reverseImageSearch(

--- a/src/schema/v2/__tests__/requestLocation.test.ts
+++ b/src/schema/v2/__tests__/requestLocation.test.ts
@@ -12,6 +12,10 @@ describe("requestLocation", () => {
             id
             country
             countryCode
+            coordinates {
+              lat
+              lng
+            }
           }
         }
       `
@@ -29,8 +33,12 @@ describe("requestLocation", () => {
 
       expect(requestLocation).toMatchInlineSnapshot(`
         Object {
+          "coordinates": Object {
+            "lat": 50.11207962036133,
+            "lng": 8.683409690856934,
+          },
           "country": "Germany",
-          "countryCode": "de",
+          "countryCode": "DE",
           "id": "cmVxdWVzdC1pcA==",
         }
       `)
@@ -45,6 +53,10 @@ describe("requestLocation", () => {
             id
             country
             countryCode
+            coordinates {
+              lat
+              lng
+            }
           }
         }
       `
@@ -62,8 +74,12 @@ describe("requestLocation", () => {
 
       expect(requestLocation).toMatchInlineSnapshot(`
         Object {
+          "coordinates": Object {
+            "lat": 50.11207962036133,
+            "lng": 8.683409690856934,
+          },
           "country": "Germany",
-          "countryCode": "de",
+          "countryCode": "DE",
           "id": "cGFyYW0taXA=",
         }
       `)
@@ -73,12 +89,132 @@ describe("requestLocation", () => {
 
 const locationResponse = {
   body: {
+    header: {
+      date: "Tue, 20 Jun 2023 09:11:05 GMT",
+      "content-type": "application/json; charset=UTF-8",
+      "transfer-encoding": "chunked",
+      connection: "close",
+      "www-authenticate": 'Key realm="kong"',
+      "ratelimit-remaining": "9",
+      "ratelimit-limit": "10",
+      "x-ratelimit-limit-hour": "10",
+      "x-ratelimit-remaining-hour": "9",
+      "ratelimit-reset": "2935",
+      charset: "utf-8",
+      "x-limit": "1",
+      "x-execution-time": "7.32",
+      "cache-control": "no-cache, private",
+      "x-forwarded-proto": "https",
+      "x-forwarded-port": "443",
+      "access-control-allow-origin": "*",
+      "cf-cache-status": "DYNAMIC",
+      "report-to":
+        '{"endpoints":[{"url":"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=B8ar4N5KR9Nh%2FmuNXDnRZkVnZjjtrfIyUnZHudQ%2BDHZB%2FRMPaUBkU9N9hYQkaAdguPILrC3ntvrlfMnArfSpXrihOtXckUTHZnFzncemzKS3VSN0XxPLJX8V33cmxAc5dA%3D%3D"}],"group":"cf-nel","max_age":604800}',
+      nel: '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}',
+      server: "cloudflare",
+      "cf-ray": "7da2e1e26ac6161f-DUS",
+      "alt-svc": 'h3=":443"; ma=86400',
+    },
     data: {
+      ip: "85.239.36.119",
+      hostname: null,
+      type: "v4",
+      range_type: {
+        type: "PUBLIC",
+        description: "Public address",
+      },
+      connection: {
+        asn: 52000,
+        organization: "MIRholding B.V.",
+        isp: "TrafficTransitSolution LLC",
+        range: "85.239.36.0/24",
+      },
       location: {
-        country: {
-          alpha2: "de",
-          name: "Germany",
+        geonames_id: 6463469,
+        latitude: 50.11207962036133,
+        longitude: 8.683409690856934,
+        zip: "60311",
+        continent: {
+          code: "EU",
+          name: "Europe",
+          name_translated: "Europe",
         },
+        country: {
+          alpha2: "DE",
+          alpha3: "DEU",
+          calling_codes: ["+49"],
+          currencies: [
+            {
+              symbol: "€",
+              name: "Euro",
+              symbol_native: "€",
+              decimal_digits: 2,
+              rounding: 0,
+              code: "EUR",
+              name_plural: "Euros",
+            },
+          ],
+          emoji: "🇩🇪",
+          ioc: "GER",
+          languages: [
+            {
+              name: "German",
+              name_native: "Deutsch",
+            },
+          ],
+          name: "Germany",
+          name_translated: "Germany",
+          timezones: ["Europe/Berlin", "Europe/Busingen"],
+          is_in_european_union: true,
+          fips: "GM",
+          geonames_id: 2921044,
+          hasc_id: "DE",
+          wikidata_id: "Q183",
+        },
+        city: {
+          fips: null,
+          alpha2: null,
+          geonames_id: 2925533,
+          hasc_id: null,
+          wikidata_id: "Q1794",
+          name: "Frankfurt",
+          name_translated: "Frankfurt",
+        },
+        region: {
+          fips: "GM05",
+          alpha2: "DE-HE",
+          geonames_id: 2905330,
+          hasc_id: "DE.HE",
+          wikidata_id: "Q1199",
+          name: "Hesse",
+          name_translated: "Hesse",
+        },
+      },
+      tlds: [".de"],
+      timezone: {
+        id: "Europe/Berlin",
+        current_time: "2023-06-20T11:11:05+02:00",
+        code: "CEST",
+        is_daylight_saving: true,
+        gmt_offset: 7200,
+      },
+      security: {
+        is_anonymous: null,
+        is_datacenter: null,
+        is_vpn: null,
+        is_bot: null,
+        is_abuser: null,
+        is_known_attacker: null,
+        is_proxy: null,
+        is_spam: null,
+        is_tor: null,
+        proxy_type: null,
+        is_icloud_relay: null,
+        threat_score: null,
+      },
+      domains: {
+        count: null,
+        domains: [],
       },
     },
   },

--- a/src/schema/v2/__tests__/requestLocation.test.ts
+++ b/src/schema/v2/__tests__/requestLocation.test.ts
@@ -1,11 +1,9 @@
-/* eslint-disable promise/always-return */
-
 import gql from "lib/gql"
 import { runAuthenticatedQuery } from "schema/v2/test/utils"
 
 describe("requestLocation", () => {
   describe("when ip param is not provided", () => {
-    it("returns location based request header IP", async () => {
+    it("returns location based on the IP address from the request", async () => {
       const query = gql`
         {
           requestLocation {
@@ -46,7 +44,7 @@ describe("requestLocation", () => {
   })
 
   describe("when `ip` param is provided", () => {
-    it("returns location based param IP", async () => {
+    it("returns location based on the `ip` param", async () => {
       const query = gql`
         {
           requestLocation(ip: "param-ip") {

--- a/src/schema/v2/__tests__/requestLocation.test.ts
+++ b/src/schema/v2/__tests__/requestLocation.test.ts
@@ -1,0 +1,85 @@
+/* eslint-disable promise/always-return */
+
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("requestLocation", () => {
+  describe("when ip param is not provided", () => {
+    it("returns location based request header IP", async () => {
+      const query = gql`
+        {
+          requestLocation {
+            id
+            country
+            countryCode
+          }
+        }
+      `
+
+      const requestLocationLoader = jest.fn(async () => locationResponse)
+
+      const context = {
+        requestLocationLoader,
+        ipAddress: "request-ip",
+      }
+
+      const { requestLocation } = await runAuthenticatedQuery(query, context)
+
+      expect(requestLocationLoader).toHaveBeenCalledWith({ ip: "request-ip" })
+
+      expect(requestLocation).toMatchInlineSnapshot(`
+        Object {
+          "country": "Germany",
+          "countryCode": "de",
+          "id": "cmVxdWVzdC1pcA==",
+        }
+      `)
+    })
+  })
+
+  describe("when `ip` param is provided", () => {
+    it("returns location based param IP", async () => {
+      const query = gql`
+        {
+          requestLocation(ip: "param-ip") {
+            id
+            country
+            countryCode
+          }
+        }
+      `
+
+      const requestLocationLoader = jest.fn(async () => locationResponse)
+
+      const context = {
+        requestLocationLoader,
+        ipAddress: "request-ip",
+      }
+
+      const { requestLocation } = await runAuthenticatedQuery(query, context)
+
+      expect(requestLocationLoader).toHaveBeenCalledWith({ ip: "param-ip" })
+
+      expect(requestLocation).toMatchInlineSnapshot(`
+        Object {
+          "country": "Germany",
+          "countryCode": "de",
+          "id": "cGFyYW0taXA=",
+        }
+      `)
+    })
+  })
+})
+
+const locationResponse = {
+  body: {
+    data: {
+      location: {
+        country: {
+          alpha2: "de",
+          name: "Germany",
+        },
+      },
+    },
+  },
+}

--- a/src/schema/v2/requestLocation.ts
+++ b/src/schema/v2/requestLocation.ts
@@ -50,7 +50,7 @@ export const RequestLocationField: GraphQLFieldConfig<void, ResolverContext> = {
         body: { data },
         headers,
         cached,
-      } = await requestLocationLoader({ ip: args.ip || ipAddress })
+      } = await requestLocationLoader({ ip })
 
       if (config.ENABLE_GEOLOCATION_LOGGING) {
         logRateHeaders(headers)

--- a/src/schema/v2/requestLocation.ts
+++ b/src/schema/v2/requestLocation.ts
@@ -9,6 +9,7 @@ import {
 import { base64 } from "lib/base64"
 import cached from "schema/v2/fields/cached"
 import { ResolverContext } from "types/graphql"
+import { LatLngType } from "./location"
 
 const logRateHeaders = (headers) => {
   const headerKeys = [...Object.keys(headers)]
@@ -27,6 +28,9 @@ export const RequestLocationType = new GraphQLObjectType<any, ResolverContext>({
     id: { type: new GraphQLNonNull(GraphQLID) },
     country: { type: GraphQLString },
     countryCode: { type: GraphQLString },
+    coordinates: {
+      type: LatLngType,
+    },
   }),
 })
 
@@ -52,16 +56,21 @@ export const RequestLocationField: GraphQLFieldConfig<void, ResolverContext> = {
         logRateHeaders(headers)
       }
 
-      debugger
-
       // Unspecified/unknown address
       if (!("location" in data)) {
         return { id: base64(ip), cached }
       }
 
       const { alpha2: countryCode, name: country } = data.location.country
+      const { latitude: lat, longitude: lng } = data.location
 
-      return { id: base64(ip), country, countryCode, cached }
+      return {
+        id: base64(ip),
+        country,
+        countryCode,
+        cached,
+        coordinates: { lat, lng },
+      }
     } catch (error) {
       // Likely, an invalid IP address
       console.error(error)


### PR DESCRIPTION
This PR modifies the `requestLocation` field as follows:

-  Making the `ip` parameter optional and adjusting the resolver to use the IP address from the context (obtained from the request headers).
-  Adding field coordinates to the `requestLocation` type.

---

The location lookup request should be cached, so the following query should only do one request:

```graphql
{
  requestLocation {
    country
    coordinates {
      lat
      lng
  }
  me {
    showsConnection(includeShowsNearIpBasedLocation: true) {
      totalCount
    }
  }
}
```

---

These changes enable us to use the user's location in the app when retrieving content based on the user's (IP-based) location (https://github.com/artsy/eigen/pull/8902, https://github.com/artsy/eigen/pull/8901).