### PR TITLE
feat: support sending and fetching source id on IDV

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10313,6 +10313,9 @@ type IdentityVerification {
   # A globally unique ID.
   id: ID!
 
+  # ID of the admin or user (self) that initiated this IDV request
+  initiatorID: String
+
   # A type-specific ID likely used as a database ID.
   internalID: ID!
   invitationExpiresAt(
@@ -10327,11 +10330,17 @@ type IdentityVerification {
   # Name of the identity verification's owner
   name: String
 
+  # ID of the order the user was placing when this IDV request was created
+  orderID: String
+
   # The overrides associated with an identity verification
   overrides: [IdentityVerificationOverride]
 
   # Page URL sent to the identify verification's owner
   pageURL: String
+
+  # ID of the auction the user was registering for when this IDV request was created
+  saleID: String
 
   # The scan references (i.e., results) associated with an identity verification
   scanReferences: [IdentityVerificationScanReference]
@@ -16747,8 +16756,17 @@ input SendIdentityVerificationEmailMutationInput {
   # The email for the user undergoing identity verification
   email: String
 
+  # The ID of the user (self or admin) who initiated the IDV process
+  initiatorID: String
+
   # The name to be used for the user undergoing identity verification
   name: String
+
+  # The ID of the order where the IDV process was initated
+  orderID: String
+
+  # The ID of the sale where the IDV process was initated
+  saleID: String
 
   # Whether an automated identity verification is sent or not
   sendEmail: Boolean

--- a/src/schema/v2/__tests__/identityVerification.test.ts
+++ b/src/schema/v2/__tests__/identityVerification.test.ts
@@ -18,6 +18,9 @@ describe("IdentityVerification type", () => {
       created_at: "",
       name: "",
       email: "",
+      sale_id: null,
+      initiator_id: null,
+      order_id: "order-123",
     }
 
     const query = `
@@ -28,6 +31,9 @@ describe("IdentityVerification type", () => {
             state
             userID
             invitationExpiresAt
+            saleID
+            orderID
+            initiatorID
           }
         }
       }
@@ -45,6 +51,9 @@ describe("IdentityVerification type", () => {
         userID: "user1",
         invitationExpiresAt:
           "Mon Feb 10 2020 00:00:00 GMT-0500 (Eastern Standard Time)",
+        orderID: "order-123",
+        saleID: null,
+        initiatorID: null,
       },
     })
   })
@@ -59,6 +68,9 @@ describe("IdentityVerification type", () => {
       created_at: "",
       name: "",
       email: "",
+      sale_id: null,
+      initiator_id: "user-123",
+      order_id: null,
     }
 
     const gravityScanReference: IdentityVerificationScanReferenceGravityResponse = {
@@ -92,6 +104,9 @@ describe("IdentityVerification type", () => {
           edges {
             node {
               state
+              saleID
+              initiatorID
+              orderID
               scanReferences {
                 result
               }
@@ -127,6 +142,9 @@ describe("IdentityVerification type", () => {
       state: "pending",
       scanReferences: [{ result: "failed" }],
       overrides: [{ newState: "passed", creator: { email: "user1@foo.com" } }],
+      saleID: null,
+      initiatorID: "user-123",
+      orderID: null,
     })
   })
 
@@ -140,12 +158,18 @@ describe("IdentityVerification type", () => {
       created_at: "",
       name: "",
       email: "",
+      sale_id: "sale-123",
+      initiator_id: null,
+      order_id: null,
     }
 
     const query = gql`
       {
         identityVerification(id: "123") {
           state
+          saleID
+          initiatorID
+          orderID
         }
       }
     `
@@ -157,6 +181,9 @@ describe("IdentityVerification type", () => {
 
     expect(identityVerification).toEqual({
       state: "pending",
+      saleID: "sale-123",
+      initiatorID: null,
+      orderID: null,
     })
   })
 })

--- a/src/schema/v2/identityVerification.ts
+++ b/src/schema/v2/identityVerification.ts
@@ -26,6 +26,9 @@ export type IdentityVerificationGravityResponse = {
   created_at: string
   name: string
   email: string
+  sale_id: string | null
+  initiator_id: string | null
+  order_id: string | null
 }
 
 export type IdentityVerificationOverrideGravityResponse = {
@@ -147,6 +150,24 @@ export const IdentityVerificationType = new GraphQLObjectType<
       description: "User ID of the identity verification's owner",
       type: GraphQLString,
       resolve: ({ user_id }) => user_id,
+    },
+    saleID: {
+      description:
+        "ID of the auction the user was registering for when this IDV request was created",
+      type: GraphQLString,
+      resolve: ({ sale_id }) => sale_id,
+    },
+    initiatorID: {
+      description:
+        "ID of the admin or user (self) that initiated this IDV request",
+      type: GraphQLString,
+      resolve: ({ initiator_id }) => initiator_id,
+    },
+    orderID: {
+      description:
+        "ID of the order the user was placing when this IDV request was created",
+      type: GraphQLString,
+      resolve: ({ order_id }) => order_id,
     },
     name: {
       description: "Name of the identity verification's owner",

--- a/src/schema/v2/me/__tests__/sendIdentityVerficationEmailMutation.test.ts
+++ b/src/schema/v2/me/__tests__/sendIdentityVerficationEmailMutation.test.ts
@@ -5,6 +5,7 @@ const identityVerificationDetails = {
   state: "pending",
   user_id: "id-123",
   id: "106",
+  sale_id: "sale-id",
 }
 
 const sendIdentityVerificationEmailMock = jest.fn().mockReturnValue(
@@ -12,6 +13,7 @@ const sendIdentityVerificationEmailMock = jest.fn().mockReturnValue(
     id: "106",
     state: "pending",
     user_id: "id-123",
+    sale_id: "sale-id",
   })
 )
 
@@ -24,7 +26,8 @@ const computeMutationInput = ({
     mutation {
       sendIdentityVerificationEmail(
         input: {
-          userID: ${JSON.stringify(userID)}
+          userID: ${JSON.stringify(userID)},
+          saleID: "sale-id",
         }
       ) {
         confirmationOrError{
@@ -34,6 +37,7 @@ const computeMutationInput = ({
 									pageURL
 									state
 									userID
+                  saleID
 								}
 							}
 							... on IdentityVerificationEmailMutationFailureType{
@@ -78,6 +82,7 @@ describe("Send identity verification email mutation", () => {
             state: "pending",
             userID: "id-123",
             pageURL: "https://staging.artsy.net/identity-verification/106",
+            saleID: "sale-id",
           },
         },
       },

--- a/src/schema/v2/me/sendIdentityVerficationEmailMutation.ts
+++ b/src/schema/v2/me/sendIdentityVerficationEmailMutation.ts
@@ -114,6 +114,19 @@ export const sendIdentityVerificationEmailMutation = mutationWithClientMutationI
       description: "Whether an automated identity verification is sent or not",
       type: GraphQLBoolean,
     },
+    saleID: {
+      description: "The ID of the sale where the IDV process was initated",
+      type: GraphQLString,
+    },
+    initiatorID: {
+      description:
+        "The ID of the user (self or admin) who initiated the IDV process",
+      type: GraphQLString,
+    },
+    orderID: {
+      description: "The ID of the order where the IDV process was initated",
+      type: GraphQLString,
+    },
   },
   outputFields: {
     confirmationOrError: {
@@ -122,7 +135,7 @@ export const sendIdentityVerificationEmailMutation = mutationWithClientMutationI
     },
   },
   mutateAndGetPayload: async (
-    { userID, email, name, sendEmail },
+    { userID, email, name, sendEmail, saleID, initiatorID, orderID },
     { sendIdentityVerificationEmailLoader }
   ) => {
     if (!sendIdentityVerificationEmailLoader) {
@@ -135,6 +148,9 @@ export const sendIdentityVerificationEmailMutation = mutationWithClientMutationI
         email,
         name,
         send_email: sendEmail,
+        sale_id: saleID,
+        initiator_id: initiatorID,
+        order_id: orderID,
       })
 
       return response


### PR DESCRIPTION
Companion to https://github.com/artsy/gravity/pull/16451. Makes `saleID`, `orderID`, and `initiatorID` settable and fetchable. 