### PR TITLE
feat: add slug for auction result type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2788,6 +2788,7 @@ type AuctionResult implements Node {
   ): String
   saleDateText: String
   saleTitle: String
+  slug: String
   title: String
 }
 
@@ -14633,7 +14634,7 @@ type Query {
 
   # An auction result
   auctionResult(
-    # The ID of the auction result
+    # The ID or slug of the auction result
     id: String!
   ): AuctionResult
 
@@ -19231,7 +19232,7 @@ type Viewer {
 
   # An auction result
   auctionResult(
-    # The ID of the auction result
+    # The ID or slug of the auction result
     id: String!
   ): AuctionResult
 

--- a/src/schema/v2/__tests__/auction_result.test.ts
+++ b/src/schema/v2/__tests__/auction_result.test.ts
@@ -321,6 +321,31 @@ describe("AuctionResult type", () => {
       })
     })
   })
+
+  describe("slug", () => {
+    it("returns the slug", () => {
+      const auctionResult = {
+        ...mockAuctionResult,
+        slug: "artist-title",
+      }
+
+      const context = {
+        auctionLotLoader: jest.fn(() => Promise.resolve(auctionResult)),
+      }
+
+      const query = `
+        {
+          auctionResult(id: "foo-bar") {
+            slug
+          }
+        }
+      `
+
+      return runQuery(query, context).then((data) => {
+        expect(data.auctionResult.slug).toEqual("artist-title")
+      })
+    })
+  })
 })
 
 const mockComparableAuctionResults = {

--- a/src/schema/v2/auction_result.ts
+++ b/src/schema/v2/auction_result.ts
@@ -76,6 +76,9 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
   interfaces: [NodeInterface],
   fields: () => ({
     ...InternalIDFields,
+    slug: {
+      type: GraphQLString,
+    },
     title: {
       type: GraphQLString,
     },
@@ -387,7 +390,7 @@ export const AuctionResult: GraphQLFieldConfig<void, ResolverContext> = {
   description: "An auction result",
   args: {
     id: {
-      description: "The ID of the auction result",
+      description: "The ID or slug of the auction result",
       type: new GraphQLNonNull(GraphQLString),
     },
   },


### PR DESCRIPTION
This PR adds slug for the auction result type.

JIRA - [PLATFORM-5231]

![Screenshot from 2023-06-21 14-02-46](https://github.com/artsy/metaphysics/assets/79979820/951736b6-3324-4555-86f1-5da42dc40d28)


[PLATFORM-5231]: https://artsyproduct.atlassian.net/browse/PLATFORM-5231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ