### PR TITLE
chore: update schema and stitching after upstream Algolia removal

### DIFF
--- a/src/data/gravity.graphql
+++ b/src/data/gravity.graphql
@@ -71,18 +71,6 @@ type Agreement {
   updatedAt: ISO8601DateTime!
 }
 
-type Algolia {
-  apiKey: String!
-  appID: String!
-  indices: [AlgoliaIndex!]!
-}
-
-type AlgoliaIndex {
-  displayName: String!
-  key: String!
-  name: String!
-}
-
 """
 App Authenticator Two-Factor Authentication factor
 """
@@ -1513,11 +1501,6 @@ type Query {
   Find an agreement by ID
   """
   agreement(id: ID!): Agreement
-
-  """
-  Get Algolia configuration
-  """
-  algolia: Algolia!
 
   """
   Find an artist by ID

--- a/src/lib/stitching/gravity/schema.ts
+++ b/src/lib/stitching/gravity/schema.ts
@@ -53,8 +53,6 @@ export const executableGravitySchema = () => {
   // Types which come from Gravity that are not (yet) needed in MP.
   // In the future, these can be removed from this list as they are needed.
   const unusedTypes = [
-    "Algolia", // TODO: remove after merging https://github.com/artsy/gravity/pull/16457
-    "AlgoliaIndex", // TODO: remove after merging https://github.com/artsy/gravity/pull/16457
     "DebitCommissionExemptionInput",
     "DebitCommissionExemptionPayload",
     "LotEvent",


### PR DESCRIPTION
[FX-4642](https://artsyproduct.atlassian.net/browse/FX-4642) & [FX-4819](https://artsyproduct.atlassian.net/browse/FX-4819)

Follow-up to:
- https://github.com/artsy/metaphysics/pull/5087
- https://github.com/artsy/gravity/pull/16457

Now that the Algolia fields have been [removed](https://github.com/artsy/gravity/pull/16457) from GravQL we update the Gravity schema over here in MP too (and remove references to the stitched types that no longer exist).

[FX-4642]: https://artsyproduct.atlassian.net/browse/FX-4642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4819]: https://artsyproduct.atlassian.net/browse/FX-4819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ