### PR TITLE
fix: Pass partners connection arguments correctly

### DIFF
--- a/src/lib/locationHelpers.ts
+++ b/src/lib/locationHelpers.ts
@@ -8,11 +8,17 @@ interface Location {
 
 const DEFAULT_MAX_DISTANCE_KM = 75
 
-export const getLocationArgs = async (
-  near: Location | undefined,
-  ip: string | undefined,
+export const getLocationArgs = async ({
+  ip,
+  maxDistance,
+  near,
+  requestLocationLoader,
+}: {
+  ip?: string
+  maxDistance?: number
+  near?: Location
   requestLocationLoader: any
-) => {
+}) => {
   let location = near
 
   if (!location && ip) {
@@ -32,6 +38,7 @@ export const getLocationArgs = async (
 
   return {
     near: isString(near) ? near : `${location.lat},${location.lng}`,
-    max_distance: location.maxDistance || DEFAULT_MAX_DISTANCE_KM,
+    max_distance:
+      maxDistance || location.maxDistance || DEFAULT_MAX_DISTANCE_KM,
   }
 }

--- a/src/schema/v2/me/showsConnection.ts
+++ b/src/schema/v2/me/showsConnection.ts
@@ -65,11 +65,11 @@ export const ShowsConnection: GraphQLFieldConfig<void, ResolverContext> = {
     // TODO: Only include shows by IP if `includeShowsNearIpBasedLocation` is set to true.
     const userIP = ip || (includeShowsNearIpBasedLocation && ipAddress) || null
 
-    const locationArgs = await getLocationArgs(
+    const locationArgs = await getLocationArgs({
       near,
-      userIP,
-      requestLocationLoader
-    )
+      ip: userIP,
+      requestLocationLoader,
+    })
 
     const gravityArgs = {
       size,

--- a/src/schema/v2/partner/__tests__/partners.test.js
+++ b/src/schema/v2/partner/__tests__/partners.test.js
@@ -1,9 +1,9 @@
-import { runQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
+import { runQuery } from "schema/v2/test/utils"
 
 describe("PartnersConnection", () => {
-  it("returns a list of partners matching array of ids", async () => {
-    const partnersLoader = ({ id }) => {
+  it("returns a list of partners matching array of ids and passes correct arguments", async () => {
+    const partnersLoader = jest.fn(({ id }) => {
       if (id) {
         return Promise.resolve({
           body: id.map((id) => ({ _id: id })),
@@ -12,11 +12,20 @@ describe("PartnersConnection", () => {
       }
 
       throw new Error("Unexpected invocation")
-    }
+    })
 
     const query = gql`
       {
-        partnersConnection(ids: ["5a958e8e7622dd49f4f4176d"]) {
+        partnersConnection(
+          ids: ["5a958e8e7622dd49f4f4176d"]
+          maxDistance: 10
+          near: "40.0,-70.0"
+          type: GALLERY
+          eligibleForListing: true
+          excludeFollowedPartners: false
+          defaultProfilePublic: false
+          sort: CREATED_AT_ASC
+        ) {
           edges {
             node {
               internalID
@@ -29,35 +38,21 @@ describe("PartnersConnection", () => {
       partnersLoader,
     })
 
+    expect(partnersLoader).toHaveBeenCalledWith({
+      id: ["5a958e8e7622dd49f4f4176d"],
+      default_profile_public: false,
+      max_distance: 10,
+      near: "40.0,-70.0",
+      page: 1,
+      total_count: true,
+      eligible_for_listing: true,
+      exclude_followed_partners: false,
+      sort: "created_at",
+      type: ["PartnerGallery"],
+    })
+
     expect(partnersConnection.edges[0].node.internalID).toEqual(
       "5a958e8e7622dd49f4f4176d"
     )
-  })
-})
-
-describe.skip("Partners", () => {
-  it("returns a list of partners matching array of ids", async () => {
-    const partnersLoader = ({ id }) => {
-      if (id) {
-        return Promise.resolve(
-          id.map((id) => ({
-            _id: id,
-            has_full_profile: true,
-            profile_banner_display: true,
-          }))
-        )
-      }
-      throw new Error("Unexpected invocation")
-    }
-
-    const query = gql`
-      {
-        partners(ids: ["5a958e8e7622dd49f4f4176d"]) {
-          internalID
-        }
-      }
-    `
-    const { partners } = await runQuery(query, { partnersLoader })
-    expect(partners[0].internalID).toEqual("5a958e8e7622dd49f4f4176d")
   })
 })

--- a/src/schema/v2/partner/partners.ts
+++ b/src/schema/v2/partner/partners.ts
@@ -152,11 +152,12 @@ export const Partners: GraphQLFieldConfig<void, ResolverContext> = {
       )
     }
 
-    const locationArgs = await getLocationArgs(
+    const locationArgs = await getLocationArgs({
+      maxDistance,
       near,
-      includePartnersNearIpBasedLocation && ipAddress,
-      requestLocationLoader
-    )
+      ip: includePartnersNearIpBasedLocation && ipAddress,
+      requestLocationLoader,
+    })
 
     const options: any = {
       default_profile_public: defaultProfilePublic,
@@ -167,7 +168,6 @@ export const Partners: GraphQLFieldConfig<void, ResolverContext> = {
       exclude_followed_partners: excludeFollowedPartners,
       has_full_profile: hasFullProfile,
       include_partners_with_followed_artists: includePartnersWithFollowedArtists,
-      max_distance: maxDistance,
       partner_categories: partnerCategories,
       ...locationArgs,
       ..._options,
@@ -221,11 +221,12 @@ export const PartnersConnection: GraphQLFieldConfig<void, ResolverContext> = {
       )
     }
 
-    const locationArgs = await getLocationArgs(
-      args.near,
-      args.includePartnersNearIpBasedLocation && ipAddress,
-      requestLocationLoader
-    )
+    const locationArgs = await getLocationArgs({
+      ip: args.includePartnersNearIpBasedLocation && ipAddress,
+      maxDistance: args.maxDistance,
+      near: args.near,
+      requestLocationLoader,
+    })
 
     const options = {
       id: args.ids,
@@ -235,7 +236,6 @@ export const PartnersConnection: GraphQLFieldConfig<void, ResolverContext> = {
       exclude_followed_partners: args.excludeFollowedPartners,
       include_partners_with_followed_artists:
         args.includePartnersWithFollowedArtists,
-      max_distance: args.maxDistance,
       default_profile_public: args.defaultProfilePublic,
       sort: args.sort,
       partner_categories: args.partnerCategories,
@@ -245,7 +245,10 @@ export const PartnersConnection: GraphQLFieldConfig<void, ResolverContext> = {
     }
 
     // Removes null/undefined values from options
-    const cleanedOptions = pickBy(clone(options), identity)
+    const cleanedOptions = pickBy(
+      clone(options),
+      (option) => option !== null && option !== undefined
+    )
 
     const { body, headers } = await partnersLoader(cleanedOptions)
     const totalCount = parseInt(headers["x-total-count"] || "0", 10)


### PR DESCRIPTION
[Jira Ticket](https://artsyproduct.atlassian.net/browse/CX-3809)

## Description

The `partnerConnection`'s `maxDistance` parameter is currently not passed on to Gravity if the `near` parameter is set. This pull request fixes the issue and adds some tests. 

It also fixed a bug where Boolean parameters aren't passed to Gravity if they are set to `false`.
