### PR TITLE
feat(ONYX-116): support sorting collections by recency

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3709,6 +3709,8 @@ type CollectionsEdge {
 enum CollectionSorts {
   CREATED_AT_ASC
   CREATED_AT_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
 }
 
 type CollectorProfileArtists {

--- a/src/schema/v2/me/__tests__/collectionsConnection.test.ts
+++ b/src/schema/v2/me/__tests__/collectionsConnection.test.ts
@@ -1,6 +1,7 @@
 import gql from "lib/gql"
 import { runAuthenticatedQuery } from "schema/v2/test/utils"
 import { ResolverContext } from "types/graphql"
+import { CollectionSorts } from "../collectionsConnection"
 
 let context: Partial<ResolverContext>
 
@@ -269,6 +270,23 @@ describe("collectionsConnection with artworksConnection", () => {
         },
       },
     })
+  })
+})
+
+describe("CollectionSorts", () => {
+  it("correctly maps external sort values to sort options", () => {
+    expect(CollectionSorts.getValue("CREATED_AT_ASC")?.value).toEqual(
+      "created_at"
+    )
+    expect(CollectionSorts.getValue("CREATED_AT_DESC")?.value).toEqual(
+      "-created_at"
+    )
+    expect(CollectionSorts.getValue("UPDATED_AT_ASC")?.value).toEqual(
+      "updated_at"
+    )
+    expect(CollectionSorts.getValue("UPDATED_AT_DESC")?.value).toEqual(
+      "-updated_at"
+    )
   })
 })
 

--- a/src/schema/v2/me/collectionsConnection.ts
+++ b/src/schema/v2/me/collectionsConnection.ts
@@ -28,6 +28,12 @@ export const CollectionSorts = new GraphQLEnumType({
     CREATED_AT_DESC: {
       value: "-created_at",
     },
+    UPDATED_AT_ASC: {
+      value: "updated_at",
+    },
+    UPDATED_AT_DESC: {
+      value: "-updated_at",
+    },
   },
 })
 


### PR DESCRIPTION
- [Jira ticket](https://artsyproduct.atlassian.net/browse/ONYX-116)

Add two new sort options to `collectionsConnection`: `UPDATED_AT_ASC` and `UPDATED_AT_DESC`.

Do not merge until https://github.com/artsy/gravity/pull/16523 is on production!