### PR TITLE
fix: CollectedArtistConnectionType

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1685,9 +1685,6 @@ type ArtistCounts {
 
 # An edge in a connection.
 type ArtistEdge {
-  # When a relevant `artworksCount` field exists to augment a connection
-  artworksCount: Int
-
   # A cursor for use in pagination
   cursor: String!
 
@@ -3640,6 +3637,29 @@ type CitySponsoredContent {
     sort: ShowSorts
     status: EventStatus
   ): ShowConnection
+}
+
+# A connection to a list of items.
+type CollectedArtistsConnection {
+  # A list of edges.
+  edges: [CollectedArtistsEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type CollectedArtistsEdge {
+  # When a relevant `artworksCount` field exists to augment a connection
+  artworksCount: Int
+
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: Artist
 }
 
 # A collection of artworks
@@ -12713,7 +12733,7 @@ type MyCollectionConnection {
     page: Int
     size: Int
     sort: ArtistSorts
-  ): ArtistConnection
+  ): CollectedArtistsConnection
   default: Boolean!
   description: String!
 
@@ -12809,7 +12829,7 @@ type MyCollectionInfo {
     page: Int
     size: Int
     sort: ArtistSorts
-  ): ArtistConnection
+  ): CollectedArtistsConnection
   default: Boolean!
   description: String!
   includesPurchasedArtworks: Boolean!

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -15,9 +15,9 @@ import { getPagingParameters, pageable } from "relay-cursor-paging"
 import Article, { articleConnection } from "schema/v2/article"
 import { artworkConnection } from "schema/v2/artwork"
 import {
-  auctionResultConnection,
   AuctionResultSorts,
   AuctionResultsState,
+  auctionResultConnection,
 } from "schema/v2/auction_result"
 import cached from "schema/v2/fields/cached"
 import { date } from "schema/v2/fields/date"
@@ -32,6 +32,7 @@ import {
 import Image, { getDefault } from "schema/v2/image"
 import { setVersion } from "schema/v2/image/normalize"
 import { SlugAndInternalIDFields } from "schema/v2/object_identification"
+import { PartnerType } from "schema/v2/partner/partner"
 import PartnerArtist, {
   partnersForArtist,
 } from "schema/v2/partner/partner_artist"
@@ -43,7 +44,6 @@ import ArtworkSorts from "schema/v2/sorts/artwork_sorts"
 import { ResolverContext } from "types/graphql"
 import ArtworkSizes from "../artwork/artworkSizes"
 import { GeneType } from "../gene"
-import { PartnerType } from "schema/v2/partner/partner"
 import ArtistArtworksFilters from "./artwork_filters"
 import ArtistCarousel from "./carousel"
 import { CurrentEvent } from "./current"
@@ -768,16 +768,6 @@ const Artist: GraphQLFieldConfig<void, ResolverContext> = {
 }
 export default Artist
 
-const edgeFields = {
-  artworksCount: {
-    type: GraphQLInt,
-    description:
-      "When a relevant `artworksCount` field exists to augment a connection",
-    resolve: ({ artworksCount }) => artworksCount,
-  },
-}
-
 export const artistConnection = connectionWithCursorInfo({
   nodeType: ArtistType,
-  edgeFields,
 })

--- a/src/schema/v2/me/myCollectionInfo.ts
+++ b/src/schema/v2/me/myCollectionInfo.ts
@@ -9,14 +9,30 @@ import {
 } from "graphql"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { pageable } from "relay-cursor-paging"
-import { artistConnection } from "schema/v2/artist"
+import { ArtistType } from "schema/v2/artist"
 import { ResolverContext } from "types/graphql"
 import { getArtistInsights } from "../artist/helpers"
 import { ArtistInsight, ArtistInsightKind } from "../artist/insights"
-import { paginationResolver } from "../fields/pagination"
+import {
+  connectionWithCursorInfo,
+  paginationResolver,
+} from "../fields/pagination"
 import ArtistSorts from "../sorts/artist_sorts"
 
 export const MAX_ARTISTS = 100
+
+const CollectedArtistConnectionType = connectionWithCursorInfo({
+  name: "CollectedArtists",
+  nodeType: ArtistType,
+  edgeFields: {
+    artworksCount: {
+      type: GraphQLInt,
+      description:
+        "When a relevant `artworksCount` field exists to augment a connection",
+      resolve: ({ artworksCount }) => artworksCount,
+    },
+  },
+}).connectionType
 
 const artistInsightsCountType = new GraphQLObjectType({
   name: "ArtistInsightsCount",
@@ -161,7 +177,7 @@ export const myCollectionInfoFields = {
   },
   collectedArtistsConnection: {
     description: "A connection of artists in the users' collection",
-    type: artistConnection.connectionType,
+    type: CollectedArtistConnectionType,
     args: pageable({
       sort: ArtistSorts,
       page: { type: GraphQLInt },


### PR DESCRIPTION
## Description

This is a draft PR that creates a `CollectedArtistConnectionType`. The reason behind the new type is to be able to add metadata to the edge field within the scope of My Collection without adding the fields to all artist connections.

This is probably a breaking change but would be a nice change :)