### PR TITLE
chore: removing some private mentions from artwork

### DIFF
--- a/src/schema/v2/me/__tests__/newWorksByInterestingArtists.test.ts
+++ b/src/schema/v2/me/__tests__/newWorksByInterestingArtists.test.ts
@@ -256,7 +256,6 @@ const mockArtworksResponse = [
     price_hidden: false,
     edition_sets_count: 0,
     published: true,
-    private: false,
     feature_eligible: false,
     price_currency: "USD",
     price_includes_tax: false,

--- a/src/test/fixtures/gravity/order.json
+++ b/src/test/fixtures/gravity/order.json
@@ -146,7 +146,6 @@
         "blurb": "",
         "edition_sets_count": 1,
         "published": true,
-        "private": false,
         "price_currency": "USD",
         "sale_message": "Not for sale",
         "inquireable": false,

--- a/src/types/runtime/gravity/Artwork.ts
+++ b/src/types/runtime/gravity/Artwork.ts
@@ -75,7 +75,6 @@ export const Artwork = Record({
   price_hidden: Boolean,
   price_includes_tax: Boolean,
   price: String,
-  private: Boolean,
   provenance: String,
   published_at: String,
   published: Boolean,


### PR DESCRIPTION
This is the references I could find to Artwork `private` field here.

A bit confusing one is the one on `collectionsConnection`. Those are requesting artworks but I believe `private` in those requests refers to `private` collection vs `private` artwork...