### PR TITLE
fix: incorrect & inconsistent address validation fields

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -106,6 +106,15 @@ type addOrderedSetItemSuccess {
   setItem: OrderedSetItem
 }
 
+input AddressInput {
+  addressLine1: String!
+  addressLine2: String
+  city: String
+  country: String!
+  postalCode: String!
+  region: String
+}
+
 type addUserRoleFailure {
   mutationError: GravityMutationError
 }
@@ -10572,8 +10581,8 @@ type ImageURLs {
 }
 
 type InputAddress {
-  address_line1: String!
-  address_line2: String!
+  address_line_1: String!
+  address_line_2: String!
   city: String!
   country: String!
   postal_code: String!
@@ -15556,14 +15565,7 @@ type Query {
   ): VanityURLEntityType
 
   # Verify a given address.
-  verifyAddress(
-    addressLine1: String!
-    addressLine2: String
-    city: String!
-    country: String!
-    postalCode: String!
-    region: String
-  ): VerifyAddressType
+  verifyAddress(address: AddressInput!): VerifyAddressType
 
   # A wildcard used to support complex root queries in Relay
   viewer: Viewer
@@ -19953,14 +19955,7 @@ type Viewer {
   ): VanityURLEntityType
 
   # Verify a given address.
-  verifyAddress(
-    addressLine1: String!
-    addressLine2: String
-    city: String!
-    country: String!
-    postalCode: String!
-    region: String
-  ): VerifyAddressType
+  verifyAddress(address: AddressInput!): VerifyAddressType
   viewingRoomsConnection(
     after: String
     first: Int

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10581,11 +10581,11 @@ type ImageURLs {
 }
 
 type InputAddress {
-  address_line_1: String!
-  address_line_2: String!
+  addressLine1: String!
+  addressLine2: String!
   city: String!
   country: String!
-  postal_code: String!
+  postalCode: String!
   region: String
 }
 
@@ -17330,11 +17330,11 @@ type SubmittedPriceEstimateParams {
 }
 
 type SuggestedAddress {
-  address_line_1: String!
-  address_line_2: String!
+  addressLine1: String!
+  addressLine2: String!
   city: String!
   country: String!
-  postal_code: String!
+  postalCode: String!
   region: String
 }
 

--- a/src/schema/v2/__tests__/verify_address.test.ts
+++ b/src/schema/v2/__tests__/verify_address.test.ts
@@ -20,9 +20,9 @@ describe("verifyAddressQuery", () => {
               city
               country
               region
-              postal_code
-              address_line_1
-              address_line_2
+              postalCode
+              addressLine1
+              addressLine2
             }
             lines
           }
@@ -31,9 +31,9 @@ describe("verifyAddressQuery", () => {
               city
               country
               region
-              postal_code
-              address_line_1
-              address_line_2
+              postalCode
+              addressLine1
+              addressLine2
             }
             lines
           }
@@ -53,10 +53,10 @@ describe("verifyAddressQuery", () => {
       verificationStatus: "VERIFIED_WITH_CHANGES",
       inputAddress: {
         address: {
-          address_line_1: "Lausitzer Straße 46",
+          addressLine1: "Lausitzer Straße 46",
           city: "Berlin",
           region: "Berlin",
-          postal_code: "10999",
+          postalCode: "10999",
           country: "DE",
         },
         lines: [
@@ -69,11 +69,11 @@ describe("verifyAddressQuery", () => {
       suggestedAddresses: [
         {
           address: {
-            address_line_1: "Lausitzer Straße 46",
-            address_line_2: "Kreuzberg",
+            addressLine1: "Lausitzer Straße 46",
+            addressLine2: "Kreuzberg",
             city: "Berlin",
             region: "Berlin",
-            postal_code: "10999",
+            postalCode: "10999",
             country: "DE",
           },
           lines: [
@@ -114,9 +114,9 @@ describe("verifyAddressQuery", () => {
               city
               country
               region
-              postal_code
-              address_line_1
-              address_line_2
+              postalCode
+              addressLine1
+              addressLine2
             }
             lines
           }
@@ -125,9 +125,9 @@ describe("verifyAddressQuery", () => {
               city
               country
               region
-              postal_code
-              address_line_1
-              address_line_2
+              postalCode
+              addressLine1
+              addressLine2
             }
             lines
           }

--- a/src/schema/v2/__tests__/verify_address.test.ts
+++ b/src/schema/v2/__tests__/verify_address.test.ts
@@ -6,11 +6,13 @@ describe("verifyAddressQuery", () => {
     const query = gql`
       {
         verifyAddress(
-          addressLine1: "Lausitzer Str. 46"
-          city: "Berlin"
-          country: "DE"
-          postalCode: "10999"
-          region: "Berlin"
+          address: {
+            addressLine1: "Lausitzer Str. 46"
+            city: "Berlin"
+            country: "DE"
+            postalCode: "10999"
+            region: "Berlin"
+          }
         ) {
           verificationStatus
           inputAddress {
@@ -19,8 +21,8 @@ describe("verifyAddressQuery", () => {
               country
               region
               postal_code
-              address_line1
-              address_line2
+              address_line_1
+              address_line_2
             }
             lines
           }
@@ -67,8 +69,8 @@ describe("verifyAddressQuery", () => {
       suggestedAddresses: [
         {
           address: {
-            address_line1: "Lausitzer Straße 46",
-            address_line2: "Kreuzberg",
+            address_line_1: "Lausitzer Straße 46",
+            address_line_2: "Kreuzberg",
             city: "Berlin",
             region: "Berlin",
             postal_code: "10999",
@@ -98,11 +100,13 @@ describe("verifyAddressQuery", () => {
     const query = gql`
       {
         verifyAddress(
-          addressLine1: "1251 John Calvin Drive"
-          city: "Harvey"
-          country: "US"
-          postalCode: "60426"
-          region: "Illinois"
+          address: {
+            addressLine1: "1251 John Calvin Drive"
+            city: "Harvey"
+            country: "US"
+            postalCode: "60426"
+            region: "Illinois"
+          }
         ) {
           verificationStatus
           inputAddress {
@@ -111,8 +115,8 @@ describe("verifyAddressQuery", () => {
               country
               region
               postal_code
-              address_line1
-              address_line2
+              address_line_1
+              address_line_2
             }
             lines
           }
@@ -158,7 +162,7 @@ describe("verifyAddressQuery", () => {
       suggestedAddresses: [
         {
           address: {
-            address_line1: "1251 John Calvin Drive",
+            address_line_1: "1251 John Calvin Drive",
             city: "Harvey",
             region: "Illinois",
             postal_code: "60426",

--- a/src/schema/v2/verifyAddress.ts
+++ b/src/schema/v2/verifyAddress.ts
@@ -1,3 +1,4 @@
+import { GraphQLFieldConfigArgumentMap, GraphQLInputObjectType } from "graphql"
 import {
   GraphQLEnumType,
   GraphQLFieldConfig,
@@ -16,14 +17,34 @@ type VerifyAddressTypeSource = {
 
 type AddressTypeSource = {
   address: {
-    address_line1: string
-    address_line2: string
+    address_line_1: string
+    address_line_2: string
     city: string
     region: string
     postal_code: string
     country: string
   }
   lines: string[]
+}
+
+const addressFields = {
+  addressLine1: { type: new GraphQLNonNull(GraphQLString) },
+  addressLine2: { type: GraphQLString },
+  city: { type: GraphQLString },
+  country: { type: new GraphQLNonNull(GraphQLString) },
+  postalCode: { type: new GraphQLNonNull(GraphQLString) },
+  region: { type: GraphQLString },
+}
+
+const AddressVerificationInput: GraphQLFieldConfigArgumentMap = {
+  address: {
+    type: new GraphQLNonNull(
+      new GraphQLInputObjectType({
+        name: "AddressInput",
+        fields: addressFields,
+      })
+    ),
+  },
 }
 
 const VerificationStatuses = {
@@ -55,8 +76,8 @@ const VerifyAddressType: GraphQLObjectType<
             type: new GraphQLObjectType<any, ResolverContext>({
               name: "InputAddress",
               fields: {
-                address_line1: { type: new GraphQLNonNull(GraphQLString) },
-                address_line2: { type: new GraphQLNonNull(GraphQLString) },
+                address_line_1: { type: new GraphQLNonNull(GraphQLString) },
+                address_line_2: { type: new GraphQLNonNull(GraphQLString) },
                 city: { type: new GraphQLNonNull(GraphQLString) },
                 country: { type: new GraphQLNonNull(GraphQLString) },
                 postal_code: { type: new GraphQLNonNull(GraphQLString) },
@@ -103,17 +124,19 @@ const VerifyAddressType: GraphQLObjectType<
 export const VerifyAddress: GraphQLFieldConfig<any, ResolverContext> = {
   type: VerifyAddressType,
   description: "Verify a given address.",
-  args: {
-    addressLine1: { type: new GraphQLNonNull(GraphQLString) },
-    addressLine2: { type: GraphQLString },
-    city: { type: new GraphQLNonNull(GraphQLString) },
-    country: { type: new GraphQLNonNull(GraphQLString) },
-    postalCode: { type: new GraphQLNonNull(GraphQLString) },
-    region: { type: GraphQLString },
-  },
+  args: AddressVerificationInput,
   resolve: async (
     _,
-    { addressLine1, addressLine2, city, country, postalCode, region },
+    {
+      address: {
+        addressLine1,
+        addressLine2,
+        city,
+        country,
+        postalCode,
+        region,
+      },
+    },
     { verifyAddressLoader }
   ) => {
     if (!verifyAddressLoader) {

--- a/src/schema/v2/verifyAddress.ts
+++ b/src/schema/v2/verifyAddress.ts
@@ -45,6 +45,21 @@ const AddressVerificationInput: GraphQLFieldConfigArgumentMap = {
   },
 }
 
+const addressFieldsFromGravity = {
+  addressLine1: {
+    type: new GraphQLNonNull(GraphQLString),
+    resolve: (source) => source.address_line_1,
+  },
+  addressLine2: {
+    type: new GraphQLNonNull(GraphQLString),
+    resolve: (source) => source.address_line_2,
+  },
+  city: { type: new GraphQLNonNull(GraphQLString) },
+  country: { type: new GraphQLNonNull(GraphQLString) },
+  postalCode: { type: new GraphQLNonNull(GraphQLString) },
+  region: { type: GraphQLString },
+}
+
 const VerificationStatuses = {
   VERIFIED_NO_CHANGE: { value: "VERIFIED_NO_CHANGE" },
   VERIFIED_WITH_CHANGES: { value: "VERIFIED_WITH_CHANGES" },
@@ -73,20 +88,7 @@ const VerifyAddressType: GraphQLObjectType<
           address: {
             type: new GraphQLObjectType<any, ResolverContext>({
               name: "InputAddress",
-              fields: {
-                addressLine1: {
-                  type: new GraphQLNonNull(GraphQLString),
-                  resolve: (source) => source.address_line_1,
-                },
-                addressLine2: {
-                  type: new GraphQLNonNull(GraphQLString),
-                  resolve: (source) => source.address_line_2,
-                },
-                city: { type: new GraphQLNonNull(GraphQLString) },
-                country: { type: new GraphQLNonNull(GraphQLString) },
-                postalCode: { type: new GraphQLNonNull(GraphQLString) },
-                region: { type: GraphQLString },
-              },
+              fields: addressFieldsFromGravity,
             }),
           },
           lines: {
@@ -104,20 +106,7 @@ const VerifyAddressType: GraphQLObjectType<
             address: {
               type: new GraphQLObjectType<any, ResolverContext>({
                 name: "SuggestedAddress",
-                fields: {
-                  addressLine1: {
-                    type: new GraphQLNonNull(GraphQLString),
-                    resolve: (source) => source.address_line_1,
-                  },
-                  addressLine2: {
-                    type: new GraphQLNonNull(GraphQLString),
-                    resolve: (source) => source.address_line_2,
-                  },
-                  city: { type: new GraphQLNonNull(GraphQLString) },
-                  country: { type: new GraphQLNonNull(GraphQLString) },
-                  postalCode: { type: new GraphQLNonNull(GraphQLString) },
-                  region: { type: GraphQLString },
-                },
+                fields: addressFieldsFromGravity,
               }),
             },
             lines: {

--- a/src/schema/v2/verifyAddress.ts
+++ b/src/schema/v2/verifyAddress.ts
@@ -27,21 +27,19 @@ type AddressTypeSource = {
   lines: string[]
 }
 
-const addressFields = {
-  addressLine1: { type: new GraphQLNonNull(GraphQLString) },
-  addressLine2: { type: GraphQLString },
-  city: { type: GraphQLString },
-  country: { type: new GraphQLNonNull(GraphQLString) },
-  postalCode: { type: new GraphQLNonNull(GraphQLString) },
-  region: { type: GraphQLString },
-}
-
 const AddressVerificationInput: GraphQLFieldConfigArgumentMap = {
   address: {
     type: new GraphQLNonNull(
       new GraphQLInputObjectType({
         name: "AddressInput",
-        fields: addressFields,
+        fields: {
+          addressLine1: { type: new GraphQLNonNull(GraphQLString) },
+          addressLine2: { type: GraphQLString },
+          city: { type: GraphQLString },
+          country: { type: new GraphQLNonNull(GraphQLString) },
+          postalCode: { type: new GraphQLNonNull(GraphQLString) },
+          region: { type: GraphQLString },
+        },
       })
     ),
   },
@@ -76,11 +74,17 @@ const VerifyAddressType: GraphQLObjectType<
             type: new GraphQLObjectType<any, ResolverContext>({
               name: "InputAddress",
               fields: {
-                address_line_1: { type: new GraphQLNonNull(GraphQLString) },
-                address_line_2: { type: new GraphQLNonNull(GraphQLString) },
+                addressLine1: {
+                  type: new GraphQLNonNull(GraphQLString),
+                  resolve: (source) => source.address_line_1,
+                },
+                addressLine2: {
+                  type: new GraphQLNonNull(GraphQLString),
+                  resolve: (source) => source.address_line_2,
+                },
                 city: { type: new GraphQLNonNull(GraphQLString) },
                 country: { type: new GraphQLNonNull(GraphQLString) },
-                postal_code: { type: new GraphQLNonNull(GraphQLString) },
+                postalCode: { type: new GraphQLNonNull(GraphQLString) },
                 region: { type: GraphQLString },
               },
             }),
@@ -101,11 +105,17 @@ const VerifyAddressType: GraphQLObjectType<
               type: new GraphQLObjectType<any, ResolverContext>({
                 name: "SuggestedAddress",
                 fields: {
-                  address_line_1: { type: new GraphQLNonNull(GraphQLString) },
-                  address_line_2: { type: new GraphQLNonNull(GraphQLString) },
+                  addressLine1: {
+                    type: new GraphQLNonNull(GraphQLString),
+                    resolve: (source) => source.address_line_1,
+                  },
+                  addressLine2: {
+                    type: new GraphQLNonNull(GraphQLString),
+                    resolve: (source) => source.address_line_2,
+                  },
                   city: { type: new GraphQLNonNull(GraphQLString) },
                   country: { type: new GraphQLNonNull(GraphQLString) },
-                  postal_code: { type: new GraphQLNonNull(GraphQLString) },
+                  postalCode: { type: new GraphQLNonNull(GraphQLString) },
                   region: { type: GraphQLString },
                 },
               }),


### PR DESCRIPTION
This PR fixes some issues with our address verification fields which was causing our `verifyAddress` query to not work. It also includes a **breaking change** to move all address field arguments under a single `address:` argument, allowing for more flexibility in the future. This field is not yet used by any client.

completes [EMI-1278](https://artsyproduct.atlassian.net/browse/EMI-1278)

cc @artsy/emerald-devs 

[EMI-1278]: https://artsyproduct.atlassian.net/browse/EMI-1278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ