### PR TITLE
fix(ONYX-72): use authenticatedArtistLoader to return custom artist data

### DIFF
--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -759,11 +759,15 @@ const Artist: GraphQLFieldConfig<void, ResolverContext> = {
       type: new GraphQLNonNull(GraphQLString),
     },
   },
-  resolve: (_root, { id }, { artistLoader }) => {
+  resolve: (_root, { id }, { authenticatedArtistLoader, artistLoader }) => {
     if (id.length === 0) {
       return null
     }
-    return artistLoader(id)
+
+    // use the authenticated artist loader to get custom artist data
+    const loader = authenticatedArtistLoader || artistLoader
+
+    return loader(id)
   },
 }
 export default Artist


### PR DESCRIPTION
Co-authored-by: Sultan Al-Maari <sultan.al-maari@artsymail.com>

This PR resolves [ONYX-72]

| custom artist with the authenticatedArtistLoader | custom artist without the authenticatedArtistLoader | public artist |
| --- | --- | --- |
|  <img width="963" alt="image" src="https://github.com/artsy/metaphysics/assets/36167539/03f9f2c6-141c-4658-9d1c-89ce733ce753"> | <img width="947" alt="image" src="https://github.com/artsy/metaphysics/assets/36167539/ac92c4ba-e889-49d4-a3f3-6d6dabfbb93e"> | <img width="963" alt="image" src="https://github.com/artsy/metaphysics/assets/36167539/5223fc09-c5ab-4eae-aa8b-ba61cbe52723"> |

[ONYX-72]: https://artsyproduct.atlassian.net/browse/ONYX-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ