### PR TITLE
chore: rename redundantly named authenticatedArtistLoader

### DIFF
--- a/src/lib/loaders/__tests__/request_id.test.js
+++ b/src/lib/loaders/__tests__/request_id.test.js
@@ -23,7 +23,7 @@ describe("requestID (with the real data loaders)", () => {
 
     await runQuery(query, context)
 
-    expect(gravity).toBeCalledWith("artist/andy-warhol?", null, {
+    expect(gravity).toBeCalledWith("artist/andy-warhol?", "access-token", {
       requestIDs,
     })
   })

--- a/src/lib/loaders/__tests__/user_agent.test.js
+++ b/src/lib/loaders/__tests__/user_agent.test.js
@@ -23,7 +23,7 @@ describe("User-Agent (with the real data loaders)", () => {
     expect.assertions(1)
     await runQuery(query, context)
 
-    expect(gravity).toBeCalledWith("artist/andy-warhol?", null, {
+    expect(gravity).toBeCalledWith("artist/andy-warhol?", "access-token", {
       userAgent,
     })
   })

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -31,7 +31,7 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
-    authenticatedArtistLoader: gravityLoader((id) => `artist/${id}`),
+    artistLoader: gravityLoader((id) => `artist/${id}`),
     authenticatedArtworkVersionLoader: gravityLoader(
       (id) => `artwork_version/${id}`
     ),

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -264,16 +264,10 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
               "Use whatever is in the original response instead of making a request",
           },
         },
-        resolve: (
-          { artist },
-          { shallow },
-          { artistLoader, authenticatedArtistLoader }
-        ) => {
-          const loader = authenticatedArtistLoader || artistLoader
-
+        resolve: ({ artist }, { shallow }, { artistLoader }) => {
           if (!artist) return null
           if (shallow) return artist
-          return loader(artist.id).catch(() => null)
+          return artistLoader(artist.id).catch(() => null)
         },
       },
       hasMarketPriceInsights: {
@@ -310,17 +304,11 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
               "Use whatever is in the original response instead of making a request",
           },
         },
-        resolve: (
-          { artists },
-          { shallow },
-          { authenticatedArtistLoader, artistLoader }
-        ) => {
+        resolve: ({ artists }, { shallow }, { artistLoader }) => {
           if (shallow) return artists
 
-          const loader = authenticatedArtistLoader || artistLoader
-
           return Promise.all(
-            artists.map((artist) => loader(artist.id))
+            artists.map((artist) => artistLoader(artist.id))
           ).catch(() => [])
         },
       },

--- a/src/schema/v2/conversation/__tests__/submit_inquiry_request_mutation.test.ts
+++ b/src/schema/v2/conversation/__tests__/submit_inquiry_request_mutation.test.ts
@@ -10,7 +10,7 @@ describe("SubmitInquiryRequestMutation", () => {
     })
   })
 
-  const authenticatedArtistLoader = jest.fn(() => {
+  const artistLoader = jest.fn(() => {
     return Promise.resolve({
       id: "bob-ross",
       name: "Bob Ross",
@@ -82,7 +82,7 @@ describe("SubmitInquiryRequestMutation", () => {
       const context = {
         submitArtworkInquiryRequestLoader,
         userByIDLoader,
-        authenticatedArtistLoader,
+        artistLoader,
       }
 
       expect.assertions(4)
@@ -98,7 +98,7 @@ describe("SubmitInquiryRequestMutation", () => {
         },
       })
       expect(userByIDLoader).toHaveBeenCalledWith("rob-ross")
-      expect(authenticatedArtistLoader).toHaveBeenCalledWith("bob-ross")
+      expect(artistLoader).toHaveBeenCalledWith("bob-ross")
       expect(submitInquiryRequestMutation).toMatchSnapshot()
     })
   })
@@ -156,7 +156,7 @@ describe("SubmitInquiryRequestMutation", () => {
       const context = {
         submitArtworkInquiryRequestLoader,
         userByIDLoader,
-        authenticatedArtistLoader,
+        artistLoader,
       }
 
       expect.assertions(4)
@@ -169,7 +169,7 @@ describe("SubmitInquiryRequestMutation", () => {
         message: "do you have sunset paintings?",
       })
       expect(userByIDLoader).toHaveBeenCalledWith("rob-ross")
-      expect(authenticatedArtistLoader).toHaveBeenCalledWith("bob-ross")
+      expect(artistLoader).toHaveBeenCalledWith("bob-ross")
       expect(submitInquiryRequestMutation).toMatchSnapshot()
     })
   })

--- a/src/schema/v2/me/__tests__/myCollection.test.ts
+++ b/src/schema/v2/me/__tests__/myCollection.test.ts
@@ -58,7 +58,7 @@ describe("me.myCollection", () => {
 
       meMyCollectionArtworksLoader: async () => mockCollectionArtworksResponse,
       marketPriceInsightsBatchLoader,
-      authenticatedArtistLoader: () =>
+      artistLoader: () =>
         Promise.resolve({
           _id: "artist-id",
         }),
@@ -100,7 +100,7 @@ describe("me.myCollection", () => {
         meMyCollectionArtworksLoader: async () =>
           mockCollectionArtworksResponse,
         marketPriceInsightsBatchLoader: jest.fn(async () => mockVortexResponse),
-        authenticatedArtistLoader: () =>
+        artistLoader: () =>
           Promise.resolve({
             _id: "artist-id",
           }),
@@ -204,7 +204,7 @@ describe("me.myCollection", () => {
           } as any,
         }),
       marketPriceInsightsBatchLoader,
-      authenticatedArtistLoader: () =>
+      artistLoader: () =>
         Promise.resolve({
           _id: "artist-id",
         }),
@@ -304,7 +304,7 @@ describe("me.myCollection", () => {
             edges: [],
           } as any,
         }),
-      authenticatedArtistLoader: () =>
+      artistLoader: () =>
         Promise.resolve({
           _id: "artist-id",
         }),
@@ -376,7 +376,7 @@ describe("me.myCollection", () => {
           },
         }),
       marketPriceInsightsBatchLoader,
-      authenticatedArtistLoader: () =>
+      artistLoader: () =>
         Promise.resolve({
           _id: "artist-id",
         }),


### PR DESCRIPTION
We shouldn't name loaders with 'authenticated' or 'unauthenticated' since that's kind of redundant - also, it's by design that we can name them the _same_ between the authenticated and unauthenticated files, and when the user is logged in, the authenticated one is selected.

This should obviate the `authenticatedArtistLoader || artistLoader` pattern, and means this PR - https://github.com/artsy/metaphysics/pull/5134 - can just be closed, it'll work as expected.