### PR TITLE
chore: better formatted logs in MP

### DIFF
--- a/src/lib/timer.ts
+++ b/src/lib/timer.ts
@@ -7,7 +7,7 @@ export default (key) => {
   return {
     start: () => {
       time = process.hrtime()
-      info(`Loading: ${key}`)
+      info(`Loading: ${decodeURIComponent(key)}`)
       return time
     },
 
@@ -17,7 +17,7 @@ export default (key) => {
       const end = process.hrtime(time)
       time = null
       const interval = `${end[0]}s ${round(end[1] / 1000000, 3)}ms`
-      info(`Elapsed: ${interval} - ${key}`)
+      info(`Elapsed: ${interval} - ${decodeURIComponent(key)}`)
       return interval
     },
   }


### PR DESCRIPTION
While checking the logs printed in MP, I noticed that the logs printed are pretty hard to read and spent some time to see if I can make them a bit prettier.

**Before**
<img width="2556" alt="Screenshot 2023-07-12 at 16 39 20" src="https://github.com/artsy/metaphysics/assets/11945712/0551d286-3369-4c34-821b-86beb917194b">

___
**After**
<img width="2560" alt="Screenshot 2023-07-12 at 16 40 54" src="https://github.com/artsy/metaphysics/assets/11945712/7e75ae3f-5ea1-46d5-8f8a-4fceeb7c7dd9">
