### PR TITLE
feat(artist): supports cover artworks

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1414,6 +1414,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     size: Int
   ): [Artist]
   counts: ArtistCounts
+  coverArtwork: Artwork
   createdAt(
     format: String
 
@@ -17612,6 +17613,7 @@ type UpdateArtistFailure {
 
 input UpdateArtistMutationInput {
   clientMutationId: String
+  coverArtworkId: String
   displayName: String
   first: String
   id: String!

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -13,7 +13,7 @@ import { totalViaLoader } from "lib/total"
 import { compact, defaults, first, flatten, includes, merge } from "lodash"
 import { getPagingParameters, pageable } from "relay-cursor-paging"
 import Article, { articleConnection } from "schema/v2/article"
-import { artworkConnection } from "schema/v2/artwork"
+import { ArtworkType, artworkConnection } from "schema/v2/artwork"
 import {
   auctionResultConnection,
   AuctionResultSorts,
@@ -506,6 +506,31 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
           },
         }),
         resolve: (artist) => artist,
+      },
+      coverArtwork: {
+        type: ArtworkType,
+        resolve: async (
+          { id, cover_artwork_id },
+          _options,
+          { artistArtworksLoader, artworkLoader }
+        ) => {
+          try {
+            if (cover_artwork_id) {
+              return artworkLoader(cover_artwork_id)
+            }
+
+            const [fallbackArtwork] = await artistArtworksLoader(id, {
+              offset: 0,
+              size: 1,
+              sort: "-iconicity",
+              published: true,
+            })
+
+            return fallbackArtwork
+          } catch (error) {
+            return null
+          }
+        },
       },
       createdAt: date(),
       criticallyAcclaimed: {

--- a/src/schema/v2/artist/updateArtistMutation.ts
+++ b/src/schema/v2/artist/updateArtistMutation.ts
@@ -14,19 +14,21 @@ import {
 } from "lib/gravityErrorHandler"
 
 interface Input {
-  displayName: string
-  first: string
+  coverArtworkId?: string
+  displayName?: string
+  first?: string
   id: string
-  last: string
-  middle: string
+  last?: string
+  middle?: string
 }
 
 interface GravityInput {
-  display_name: string
-  first: string
+  cover_artwork_id?: string
+  display_name?: string
+  first?: string
   id: string
-  last: string
-  middle: string
+  last?: string
+  middle?: string
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
@@ -64,6 +66,7 @@ export const updateArtistMutation = mutationWithClientMutationId<
   name: "UpdateArtistMutation",
   description: "Update the artist",
   inputFields: {
+    coverArtworkId: { type: GraphQLString },
     displayName: { type: GraphQLString },
     first: { type: GraphQLString },
     id: { type: new GraphQLNonNull(GraphQLString) },


### PR DESCRIPTION
Very simple change here. Just exposes the `coverArtwork` field on an artist, falls back to the most iconic work, and adds the support to update it in the mutation.