### PR TITLE
feat: me userInterest field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11835,6 +11835,12 @@ type Me implements Node {
   # A count of unseen notifications.
   unseenNotificationsCount: Int!
 
+  # Get a user interest
+  userInterest(
+    # The ID of the UserInterest
+    id: String
+  ): UserInterest
+
   # A list of lots a user is watching.
   watchedLotConnection(
     after: String

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -449,6 +449,7 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" }
     ),
+    meUserInterestLoader: gravityLoader((id) => `me/user_interest/${id}`),
     meUserInterestsLoader: gravityLoader("me/user_interests"),
     meMyCollectionArtworksLoader: gravityLoader(
       "me/my_collection_artworks",

--- a/src/schema/v2/me/__tests__/userInterest.test.ts
+++ b/src/schema/v2/me/__tests__/userInterest.test.ts
@@ -1,0 +1,100 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import { ResolverContext } from "types/graphql"
+
+describe("me.userInterest", () => {
+  it("returns user interest", async () => {
+    const query = gql`
+      {
+        me {
+          userInterest(id: "user-interest-id") {
+            internalID
+            interest {
+              __typename
+              ... on Artist {
+                internalID
+              }
+            }
+          }
+        }
+      }
+    `
+    const meUserInterestLoader = jest.fn(async () => userInterestResponse)
+    const meLoader = jest.fn(async () => ({ id: "some-user-id" }))
+
+    const context: Partial<ResolverContext> = {
+      meUserInterestLoader,
+      meLoader,
+    }
+
+    const data = await runAuthenticatedQuery(query, context)
+
+    expect(meLoader).toHaveBeenCalled()
+    expect(meUserInterestLoader).toHaveBeenCalledWith("user-interest-id")
+
+    expect(data).toMatchInlineSnapshot(`
+      Object {
+        "me": Object {
+          "userInterest": Object {
+            "interest": Object {
+              "__typename": "Artist",
+              "internalID": "artist-id",
+            },
+            "internalID": "user-interest-id",
+          },
+        },
+      }
+    `)
+  })
+})
+
+const userInterestResponse = {
+  interest: {
+    _id: "artist-id",
+    artworks_count: 2844,
+    birthday: "1929",
+    blurb:
+      "Yayoi Kusama dazzles audiences worldwide with her immersive “Infinity Mirror Rooms” and an aesthetic that embraces light, polka dots, and pumpkins. The avant-garde artist first rose to prominence in 1960s New York, where she staged provocative [Happenings](https://www.artsy.net/gene/happenings) and exhibited hallucinatory paintings of loops and [dots](https://www.artsy.net/artist-series/yayoi-kusama-polka-dots) that she called “[Infinity Nets](https://www.artsy.net/artist-series/yayoi-kusama-infinity-nets).” Kusama also influenced [Andy Warhol](https://www.artsy.net/artist/andy-warhol) and augured the rise of feminist and [Pop art](https://www.artsy.net/gene/pop-art). She has been the subject of major exhibitions at the [Museum of Modern Art](https://www.artsy.net/museum-of-modern-art), [Centre Pompidou](https://www.artsy.net/centrepompidou), [Tate Modern](https://www.artsy.net/tate), and the [National Museum of Modern Art in Tokyo](https://www.artsy.net/the-national-museum-of-modern-art-tokyo). In 1993, Kusama represented Japan at the Venice Biennale. Today, her work regularly sells for seven figures on the secondary market. Throughout her disparate practice, Kusama has continued to explore her own obsessive-compulsive disorder, sexuality, freedom, and perception. In 1977, Kusama voluntarily checked herself into a psychiatric hospital in Tokyo, where she continues to live today. ",
+    consignable: true,
+    created_at: "2010-11-15T16:32:38+00:00",
+    critically_acclaimed: true,
+    deathday: "",
+    forsale_artworks_count: 446,
+    group_indicator: "individual",
+    id: "yayoi-kusama",
+    image_url:
+      "https://d32dm0rphc51dk.cloudfront.net/k4jwHwwpU_4Ayulhp8p6qw/:version.jpg",
+    image_urls: {
+      four_thirds:
+        "https://d32dm0rphc51dk.cloudfront.net/k4jwHwwpU_4Ayulhp8p6qw/four_thirds.jpg",
+      large:
+        "https://d32dm0rphc51dk.cloudfront.net/k4jwHwwpU_4Ayulhp8p6qw/large.jpg",
+      square:
+        "https://d32dm0rphc51dk.cloudfront.net/k4jwHwwpU_4Ayulhp8p6qw/square.jpg",
+      tall:
+        "https://d32dm0rphc51dk.cloudfront.net/k4jwHwwpU_4Ayulhp8p6qw/tall.jpg",
+    },
+    image_versions: ["four_thirds", "large", "square", "tall"],
+    is_personal_artist: false,
+    medium_known_for: "",
+    name: "Yayoi Kusama",
+    nationality: "Japanese",
+    original_height: 389,
+    original_width: 389,
+    public: true,
+    published_artworks_count: 1647,
+    sortable_id: "kusama-yayoi",
+    target_supply: true,
+    target_supply_priority: 1,
+    target_supply_type: "Blue-Chip",
+    vanguard_year: null,
+    years: "born 1929",
+  },
+  id: "user-interest-id",
+  created_at: "2023-07-11T09:35:07+00:00",
+  updated_at: "2023-07-11T10:02:24+00:00",
+  owner_type: "CollectorProfile",
+  body: null,
+  category: "collected_before",
+  private: false,
+}

--- a/src/schema/v2/me/__tests__/userInterest.test.ts
+++ b/src/schema/v2/me/__tests__/userInterest.test.ts
@@ -13,13 +13,22 @@ describe("me.userInterest", () => {
               __typename
               ... on Artist {
                 internalID
+                name
               }
             }
           }
         }
       }
     `
-    const meUserInterestLoader = jest.fn(async () => userInterestResponse)
+    const meUserInterestLoader = jest.fn(async () => ({
+      interest: {
+        _id: "artist-id",
+        name: "Artist Name",
+        id: "yayoi-kusama",
+        birthday: "10.10.2002",
+      },
+      id: "user-interest-id",
+    }))
     const meLoader = jest.fn(async () => ({ id: "some-user-id" }))
 
     const context: Partial<ResolverContext> = {
@@ -39,6 +48,7 @@ describe("me.userInterest", () => {
             "interest": Object {
               "__typename": "Artist",
               "internalID": "artist-id",
+              "name": "Artist Name",
             },
             "internalID": "user-interest-id",
           },
@@ -47,54 +57,3 @@ describe("me.userInterest", () => {
     `)
   })
 })
-
-const userInterestResponse = {
-  interest: {
-    _id: "artist-id",
-    artworks_count: 2844,
-    birthday: "1929",
-    blurb:
-      "Yayoi Kusama dazzles audiences worldwide with her immersive “Infinity Mirror Rooms” and an aesthetic that embraces light, polka dots, and pumpkins. The avant-garde artist first rose to prominence in 1960s New York, where she staged provocative [Happenings](https://www.artsy.net/gene/happenings) and exhibited hallucinatory paintings of loops and [dots](https://www.artsy.net/artist-series/yayoi-kusama-polka-dots) that she called “[Infinity Nets](https://www.artsy.net/artist-series/yayoi-kusama-infinity-nets).” Kusama also influenced [Andy Warhol](https://www.artsy.net/artist/andy-warhol) and augured the rise of feminist and [Pop art](https://www.artsy.net/gene/pop-art). She has been the subject of major exhibitions at the [Museum of Modern Art](https://www.artsy.net/museum-of-modern-art), [Centre Pompidou](https://www.artsy.net/centrepompidou), [Tate Modern](https://www.artsy.net/tate), and the [National Museum of Modern Art in Tokyo](https://www.artsy.net/the-national-museum-of-modern-art-tokyo). In 1993, Kusama represented Japan at the Venice Biennale. Today, her work regularly sells for seven figures on the secondary market. Throughout her disparate practice, Kusama has continued to explore her own obsessive-compulsive disorder, sexuality, freedom, and perception. In 1977, Kusama voluntarily checked herself into a psychiatric hospital in Tokyo, where she continues to live today. ",
-    consignable: true,
-    created_at: "2010-11-15T16:32:38+00:00",
-    critically_acclaimed: true,
-    deathday: "",
-    forsale_artworks_count: 446,
-    group_indicator: "individual",
-    id: "yayoi-kusama",
-    image_url:
-      "https://d32dm0rphc51dk.cloudfront.net/k4jwHwwpU_4Ayulhp8p6qw/:version.jpg",
-    image_urls: {
-      four_thirds:
-        "https://d32dm0rphc51dk.cloudfront.net/k4jwHwwpU_4Ayulhp8p6qw/four_thirds.jpg",
-      large:
-        "https://d32dm0rphc51dk.cloudfront.net/k4jwHwwpU_4Ayulhp8p6qw/large.jpg",
-      square:
-        "https://d32dm0rphc51dk.cloudfront.net/k4jwHwwpU_4Ayulhp8p6qw/square.jpg",
-      tall:
-        "https://d32dm0rphc51dk.cloudfront.net/k4jwHwwpU_4Ayulhp8p6qw/tall.jpg",
-    },
-    image_versions: ["four_thirds", "large", "square", "tall"],
-    is_personal_artist: false,
-    medium_known_for: "",
-    name: "Yayoi Kusama",
-    nationality: "Japanese",
-    original_height: 389,
-    original_width: 389,
-    public: true,
-    published_artworks_count: 1647,
-    sortable_id: "kusama-yayoi",
-    target_supply: true,
-    target_supply_priority: 1,
-    target_supply_type: "Blue-Chip",
-    vanguard_year: null,
-    years: "born 1929",
-  },
-  id: "user-interest-id",
-  created_at: "2023-07-11T09:35:07+00:00",
-  updated_at: "2023-07-11T10:02:24+00:00",
-  owner_type: "CollectorProfile",
-  body: null,
-  category: "collected_before",
-  private: false,
-}

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -35,10 +35,10 @@ import ArtworkInquiries from "./artwork_inquiries"
 import AuctionResultsByFollowedArtists from "./auctionResultsByFollowedArtists"
 import { authentications } from "./authentications"
 import { BankAccounts } from "./bank_accounts"
-import Bidders from "./bidders"
 import { BidderPosition } from "./bidder_position"
 import BidderPositions from "./bidder_positions"
 import BidderStatus from "./bidder_status"
+import Bidders from "./bidders"
 import { Collection } from "./collection"
 import { CollectionsConnection } from "./collectionsConnection"
 import { CreditCards } from "./credit_cards"
@@ -63,9 +63,10 @@ import { RecentlyViewedArtworks } from "./recentlyViewedArtworks"
 import { SaleRegistrationConnection } from "./sale_registrations"
 import { COLLECTION_ID, SavedArtworks } from "./savedArtworks"
 import { ShowsByFollowedArtists } from "./showsByFollowedArtists"
-import { SimilarToRecentlyViewed } from "./similarToRecentlyViewed"
-import { WatchedLotConnection } from "./watchedLotConnection"
 import { ShowsConnection } from "./showsConnection"
+import { SimilarToRecentlyViewed } from "./similarToRecentlyViewed"
+import { UserInterest } from "./userInterest"
+import { WatchedLotConnection } from "./watchedLotConnection"
 
 /**
  * @deprecated: Please use the CollectorProfile type instead of adding fields to me directly.
@@ -523,6 +524,7 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
         })
       },
     },
+    userInterest: UserInterest,
     watchedLotConnection: WatchedLotConnection,
   },
 })

--- a/src/schema/v2/me/userInterest.ts
+++ b/src/schema/v2/me/userInterest.ts
@@ -1,0 +1,21 @@
+import { GraphQLFieldConfig, GraphQLString } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { userInterestType } from "../userInterests"
+
+export const UserInterest: GraphQLFieldConfig<any, ResolverContext> = {
+  type: userInterestType,
+  args: {
+    id: {
+      type: GraphQLString,
+      description: "The ID of the UserInterest",
+    },
+  },
+  description: "Get a user interest",
+  resolve: async (_, { id }, { meUserInterestLoader }) => {
+    if (!meUserInterestLoader) {
+      return null
+    }
+
+    return await meUserInterestLoader(id)
+  },
+}

--- a/src/schema/v2/me/userInterest.ts
+++ b/src/schema/v2/me/userInterest.ts
@@ -11,11 +11,11 @@ export const UserInterest: GraphQLFieldConfig<any, ResolverContext> = {
     },
   },
   description: "Get a user interest",
-  resolve: async (_, { id }, { meUserInterestLoader }) => {
+  resolve: (_, { id }, { meUserInterestLoader }) => {
     if (!meUserInterestLoader) {
       return null
     }
 
-    return await meUserInterestLoader(id)
+    return meUserInterestLoader(id)
   },
 }

--- a/src/schema/v2/userInterests.ts
+++ b/src/schema/v2/userInterests.ts
@@ -83,7 +83,7 @@ export const userInterestType = new GraphQLObjectType<
   },
 })
 
-export const edgeFields: Thunk<GraphQLFieldConfigMap<
+export const userInterestFields: Thunk<GraphQLFieldConfigMap<
   UserInterest,
   ResolverContext
 >> = () => ({
@@ -102,5 +102,5 @@ export const edgeFields: Thunk<GraphQLFieldConfigMap<
 export const UserInterestConnection = connectionWithCursorInfo({
   name: "UserInterest",
   nodeType: userInterestInterestUnion,
-  edgeFields: edgeFields,
+  edgeFields: userInterestFields,
 }).connectionType


### PR DESCRIPTION
Addresses [ONYX-118]

## Description

This PR adds a `userInterest` field under `me` to fetch user interests by ID. The new field is needed because we have decided against returning all the necessary data in the `userInterestsConnection`.


**Query:**

```graphql
{
  me {
    userInterest(id: "user-interest-id") {
      internalID
      interest {
        __typename
        ... on Artist {
          internalID
        }
      }
    }
  }
}
```


[ONYX-118]: https://artsyproduct.atlassian.net/browse/ONYX-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ