### PR TITLE
feat: update some gravity error parsing code to be more accurate

### DIFF
--- a/src/lib/HTTPError.ts
+++ b/src/lib/HTTPError.ts
@@ -1,8 +1,10 @@
+type Body = { [key: string]: any }
+
 export class HTTPError extends Error {
   public statusCode: number
-  public body?: string
+  public body?: Body | string
 
-  constructor(message: string, statusCode: number, body?: string) {
+  constructor(message: string, statusCode: number, body?: Body | string) {
     super(message)
     this.statusCode = statusCode
     this.body = body

--- a/src/lib/__tests__/gravityErrorHandler.test.ts
+++ b/src/lib/__tests__/gravityErrorHandler.test.ts
@@ -28,8 +28,13 @@ describe("gravityErrorHandler", () => {
 
     it("returns a parsed error with a field error array", () => {
       const expectedErrorFormat = {
-        message: `https://stagingapi.artsy.net/api/v1/me/credit_cards?provider=stripe&token=tok_chargeDeclinedExpiredCard - {"type":"param_error","message":"Email foo@artsymail.com is not an @artsy address.","detail":{"email":["foo@artsymail.com is not an @artsy address"]}}`,
-        statusCode: 404,
+        message: `https://stagingapi.artsy.net/api/v1/me/credit_cards?provider=stripe&token=tok_chargeDeclinedExpiredCard - 400`,
+        statusCode: 400,
+        body: {
+          type: "param_error",
+          message: "Email foo@artsymail.com is not an @artsy address.",
+          detail: { email: ["foo@artsymail.com is not an @artsy address"] },
+        },
       }
       expect(formatGravityError(expectedErrorFormat)).toEqual({
         detail: undefined,
@@ -41,6 +46,7 @@ describe("gravityErrorHandler", () => {
         ],
         message: "Email foo@artsymail.com is not an @artsy address.",
         type: "param_error",
+        statusCode: 400,
       })
     })
     it("returns an unparsed error if the format is different", () => {

--- a/src/lib/apis/fetch.ts
+++ b/src/lib/apis/fetch.ts
@@ -78,10 +78,15 @@ export default (url, options = {}) => {
         response.statusCode &&
         (response.statusCode < 200 || response.statusCode >= 300)
       ) {
-        const message = compact([
-          get(response, "request.uri.href"),
-          response.body,
-        ]).join(" - ")
+        // If `request.body` is a string, we can include it in the message.
+        const body =
+          typeof response.body === "string"
+            ? response.body
+            : response.statusMessage
+
+        const message = compact([get(response, "request.uri.href"), body]).join(
+          " - "
+        )
         return reject(
           new HTTPError(message, response.statusCode || 500, response.body)
         )

--- a/src/schema/v2/__tests__/deleteUserMutation.test.ts
+++ b/src/schema/v2/__tests__/deleteUserMutation.test.ts
@@ -56,7 +56,7 @@ describe("Delete a user", () => {
             new HTTPError(
               `https://stagingapi.artsy.net/api/v1/user/bats? - {"error":"User Not Found"}`,
               404,
-              `{"error":"User Not Found"}`
+              { error: "User Not Found" }
             )
           ),
       }
@@ -85,7 +85,7 @@ describe("Delete a user", () => {
             new HTTPError(
               `https://stagingapi.artsy.net/api/v1/user/bats? - {"type":"illegal_operation","message":"Some Op Error"}`,
               400,
-              `{"type":"illegal_operation","message":"Some Op Error"}`
+              { type: "illegal_operation", message: "Some Op Error" }
             )
           ),
       }

--- a/src/schema/v2/me/__tests__/createCollectionMutation.test.ts
+++ b/src/schema/v2/me/__tests__/createCollectionMutation.test.ts
@@ -80,7 +80,7 @@ describe("createCollection", () => {
     const error = new HTTPError(
       "http://artsy.net - {}",
       400,
-      JSON.stringify(gravityResponseBody)
+      gravityResponseBody
     )
     const context = {
       createCollectionLoader: jest.fn().mockRejectedValue(error),

--- a/src/schema/v2/me/__tests__/updateCollectionMutation.test.ts
+++ b/src/schema/v2/me/__tests__/updateCollectionMutation.test.ts
@@ -80,9 +80,9 @@ describe("updateCollection", () => {
       type: "param_error",
     }
     const error = new HTTPError(
-      "http://artsy.net - {}",
+      "http://artsy.net - Bad Request",
       400,
-      JSON.stringify(gravityResponseBody)
+      gravityResponseBody
     )
     const context = {
       updateCollectionLoader: jest.fn().mockRejectedValue(error),

--- a/src/schema/v2/me/createCollectionMutation.ts
+++ b/src/schema/v2/me/createCollectionMutation.ts
@@ -7,7 +7,7 @@ import {
 import { mutationWithClientMutationId } from "graphql-relay"
 import {
   GravityMutationErrorType,
-  formatGravityErrorDetails,
+  formatGravityError,
 } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
 import { CollectionType } from "./collection"
@@ -77,7 +77,7 @@ export const createCollectionMutation = mutationWithClientMutationId<
 
       return response
     } catch (error) {
-      const formattedErr = formatGravityHttpError(error)
+      const formattedErr = formatGravityError(error)
 
       if (formattedErr) {
         return { ...formattedErr, _type: "GravityMutationError" }
@@ -87,24 +87,3 @@ export const createCollectionMutation = mutationWithClientMutationId<
     }
   },
 })
-
-const formatGravityHttpError = (error) => {
-  const errorBody =
-    typeof error.body === "string" ? JSON.parse(error.body) : error.body
-  const errorType = errorBody?.type || "error"
-  const message = errorBody?.message || errorBody?.error
-  // confusing part: gravity returns field errors in the body.detail, but in some cases (PaymentError for instance),
-  // body.detail includes a string message. GravityMutationErrorType#fieldErrors hold the actual field errors
-  // and GravityMutationErrorType#detail - the string message
-  const fieldErrors = formatGravityErrorDetails(errorBody?.detail || {})
-  const detail =
-    typeof errorBody?.detail === "object" ? null : errorBody?.detail
-
-  return {
-    type: errorType,
-    statusCode: error.statusCode,
-    message,
-    fieldErrors,
-    detail,
-  }
-}

--- a/src/schema/v2/me/updateCollectionMutation.ts
+++ b/src/schema/v2/me/updateCollectionMutation.ts
@@ -7,7 +7,7 @@ import {
 import { mutationWithClientMutationId } from "graphql-relay"
 import {
   GravityMutationErrorType,
-  formatGravityErrorDetails,
+  formatGravityError,
 } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
 import { CollectionType } from "./collection"
@@ -81,7 +81,7 @@ export const updateCollectionMutation = mutationWithClientMutationId<
 
       return response
     } catch (error) {
-      const formattedErr = formatGravityHttpError(error)
+      const formattedErr = formatGravityError(error)
 
       if (formattedErr) {
         return { ...formattedErr, _type: "GravityMutationError" }
@@ -91,24 +91,3 @@ export const updateCollectionMutation = mutationWithClientMutationId<
     }
   },
 })
-
-const formatGravityHttpError = (error) => {
-  const errorBody =
-    typeof error.body === "string" ? JSON.parse(error.body) : error.body
-  const errorType = errorBody?.type || "error"
-  const message = errorBody?.message || errorBody?.error
-  // confusing part: gravity returns field errors in the body.detail, but in some cases (PaymentError for instance),
-  // body.detail includes a string message. GravityMutationErrorType#fieldErrors hold the actual field errors
-  // and GravityMutationErrorType#detail - the string message
-  const fieldErrors = formatGravityErrorDetails(errorBody?.detail || {})
-  const detail =
-    typeof errorBody?.detail === "object" ? null : errorBody?.detail
-
-  return {
-    type: errorType,
-    statusCode: error.statusCode,
-    message,
-    fieldErrors,
-    detail,
-  }
-}


### PR DESCRIPTION
I tweaked the Gravity error parsing code to work with the formats from https://github.com/artsy/gravity/blob/04a76103bcf26516a656537a3e98e45248127aa6/app/api/util/error_handlers.rb

namely:

```
error: not always present, can be contents of entire error, or `error` property
message: human-readable, should be always present
detail: array of field-level errors
type: more short-hand 'type' of error
```

This works with the common errors from Gravity, and obviates the fix added in https://github.com/artsy/metaphysics/pull/5076 for collections.