### PR TITLE
feat: Add artistIDs param to myCollectionConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11648,7 +11648,7 @@ type Me implements Node {
     after: String
 
     # Filter by artist IDs
-    artistIDs: [String]
+    artistIDs: [String!]
     before: String
 
     # Exclude artworks that have been purchased on Artsy and automatically added to the collection.

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11646,6 +11646,9 @@ type Me implements Node {
   ): AuctionResultConnection
   myCollectionConnection(
     after: String
+
+    # Filter by artist IDs
+    artistIDs: [String]
     before: String
 
     # Exclude artworks that have been purchased on Artsy and automatically added to the collection.

--- a/src/lib/__tests__/helpers.test.ts
+++ b/src/lib/__tests__/helpers.test.ts
@@ -7,6 +7,7 @@ import {
   removeEmptyValues,
   removeNulls,
   resolveBlueGreen,
+  snakeCaseKeys,
   stripTags,
   toKey,
   toQueryString,
@@ -323,5 +324,41 @@ describe("isInteger", () => {
     expect(isInteger("2023, 4, 23")).toEqual(false)
     expect(isInteger("4th-5th Century AD")).toEqual(false)
     expect(isInteger("2000s")).toEqual(false)
+  })
+})
+
+describe("snakeCaseKeys", () => {
+  it("converts all object keys to snake case", () => {
+    const object = {
+      firstName: "John",
+      lastName: "Doe",
+      age: 42,
+      favorite_plant: "cactus",
+    }
+
+    expect(snakeCaseKeys(object)).toMatchInlineSnapshot(`
+      Object {
+        "age": 42,
+        "favorite_plant": "cactus",
+        "first_name": "John",
+        "last_name": "Doe",
+      }
+    `)
+  })
+
+  it("converts ID correctly to id", () => {
+    const object = {
+      ID: "123",
+      artistIDs: ["123"],
+    }
+
+    expect(snakeCaseKeys(object)).toMatchInlineSnapshot(`
+      Object {
+        "artist_ids": Array [
+          "123",
+        ],
+        "id": "123",
+      }
+    `)
   })
 })

--- a/src/lib/__tests__/helpers.test.ts
+++ b/src/lib/__tests__/helpers.test.ts
@@ -334,6 +334,7 @@ describe("snakeCaseKeys", () => {
       lastName: "Doe",
       age: 42,
       favorite_plant: "cactus",
+      ID: "123",
     }
 
     expect(snakeCaseKeys(object)).toMatchInlineSnapshot(`
@@ -341,6 +342,7 @@ describe("snakeCaseKeys", () => {
         "age": 42,
         "favorite_plant": "cactus",
         "first_name": "John",
+        "id": "123",
         "last_name": "Doe",
       }
     `)

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -9,9 +9,11 @@ import {
   isEmpty,
   isObject,
   isString,
+  mapKeys,
   omit,
   pick,
   reject,
+  snakeCase,
   trim,
   values,
 } from "lodash"
@@ -218,7 +220,7 @@ export const defineCustomLocale = (
 /**
  * Extracts nodes from a GraphQL connection.
  */
-export const extractNodes = <Node extends object, T = Node>(
+export const extractNodes = <Node extends Record<string, unknown>, T = Node>(
   connection:
     | {
         readonly edges?: ReadonlyArray<{
@@ -227,11 +229,11 @@ export const extractNodes = <Node extends object, T = Node>(
       }
     | undefined
     | null,
-  mapper?: (node: Node) => T
+  mapper?: (node?: Node | null) => T
 ): T[] => {
   return (
     connection?.edges
-      ?.map((edge) => (mapper ? (mapper(edge?.node!) as any) : edge?.node!))
+      ?.map((edge) => (mapper ? (mapper(edge?.node) as any) : edge?.node))
       .filter((x) => x != null) ?? []
   )
 }
@@ -248,4 +250,22 @@ export const CatchCollectionNotFoundException = (error) => {
   if (error.statusCode === 404) return emptyConnection
 
   throw error
+}
+
+/**
+ * Converts all object keys to snake case.
+ * @param object — The object to convert.
+ * @return — Returns the object with converted keys.
+ */
+export const snakeCaseKeys = (
+  obj: Record<string, any>
+): Record<string, any> => {
+  return mapKeys(obj, (_, key) => {
+    // Special case for ID to not be converted to I_D
+    if (key.includes("ID")) {
+      return snakeCase(key.replace(/ID/g, "_id"))
+    }
+
+    return snakeCase(key)
+  })
 }

--- a/src/schema/v2/me/__tests__/myCollection.test.ts
+++ b/src/schema/v2/me/__tests__/myCollection.test.ts
@@ -74,14 +74,12 @@ describe("me.myCollection", () => {
     )
 
     expect(meMyCollectionArtworksLoader).toHaveBeenCalledWith({
-      artistIDs: ["artist-id"],
       artist_ids: ["artist-id"],
-      excludePurchasedArtworks: false,
       exclude_purchased_artworks: false,
       offset: 0,
       size: 10,
-      sortByLastAuctionResultDate: false,
       total_count: true,
+      sort_by_last_auction_result_date: false,
     })
   })
 

--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -4,6 +4,7 @@ import {
   GraphQLFieldConfig,
   GraphQLInt,
   GraphQLList,
+  GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
   GraphQLUnionType,
@@ -61,7 +62,7 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
       }),
     },
     artistIDs: {
-      type: new GraphQLList(GraphQLString),
+      type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
       description: "Filter by artist IDs",
     },
 

--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -3,7 +3,9 @@ import {
   GraphQLEnumType,
   GraphQLFieldConfig,
   GraphQLInt,
+  GraphQLList,
   GraphQLObjectType,
+  GraphQLString,
   GraphQLUnionType,
 } from "graphql"
 import { connectionFromArray, cursorForObjectInConnection } from "graphql-relay"
@@ -58,6 +60,11 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
         },
       }),
     },
+    artistIDs: {
+      type: new GraphQLList(GraphQLString),
+      description: "Filter by artist IDs",
+    },
+
     excludePurchasedArtworks: {
       type: GraphQLBoolean,
       defaultValue: false,
@@ -95,6 +102,7 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
       : convertConnectionArgsToGravityArgs(options)
 
     const gravityOptions = {
+      artist_ids: options.artistIDs,
       exclude_purchased_artworks: options.excludePurchasedArtworks,
       total_count: true,
       ...paginationArgs,

--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -11,7 +11,7 @@ import {
 import { connectionFromArray, cursorForObjectInConnection } from "graphql-relay"
 import { enrichArtworksWithPriceInsights } from "lib/fillers/enrichArtworksWithPriceInsights"
 import { GravityMutationErrorType } from "lib/gravityErrorHandler"
-import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { convertConnectionArgsToGravityArgs, snakeCaseKeys } from "lib/helpers"
 import { compact, reverse, sortBy, uniqWith } from "lodash"
 import { pageable } from "relay-cursor-paging"
 import { ResolverContext } from "types/graphql"
@@ -97,15 +97,13 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
 
     // We're setting the size to 100 here because we're going to filter and sort these artworks later manualy.
     // The idea is to fetch (almost) all artworks and then filter/sort them in memory.
-    const paginationArgs = options.sortByLastAuctionResultDate
-      ? { size: MAX_COLLECTION_SIZE }
+    const optionsAndPaginationArgs = options.sortByLastAuctionResultDate
+      ? { size: MAX_COLLECTION_SIZE, ...options }
       : convertConnectionArgsToGravityArgs(options)
 
     const gravityOptions = {
-      artist_ids: options.artistIDs,
-      exclude_purchased_artworks: options.excludePurchasedArtworks,
       total_count: true,
-      ...paginationArgs,
+      ...snakeCaseKeys(optionsAndPaginationArgs),
     }
 
     // This can't also be used with the offset in gravity

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -10,8 +10,8 @@ import {
 import { mutationWithClientMutationId } from "graphql-relay"
 import { GraphQLLong } from "lib/customTypes/GraphQLLong"
 import { formatGravityError } from "lib/gravityErrorHandler"
+import { snakeCaseKeys } from "lib/helpers"
 import { StaticPathLoader } from "lib/loaders/api/loader_interface"
-import { mapKeys, snakeCase } from "lodash"
 import { ResolverContext } from "types/graphql"
 import { ArtworkImportSourceEnum } from "../artwork"
 import { MyCollectionArtworkMutationType } from "./myCollection"
@@ -260,7 +260,7 @@ const createArtists = async (
   const responses = await Promise.all(
     artists.map((artist) =>
       createArtistLoader({
-        ...mapKeys(artist, (_v, k) => snakeCase(k)),
+        ...snakeCaseKeys(artist),
         is_personal_artist: true,
       })
     )


### PR DESCRIPTION
Addresses [ONYX-140]

- Related Gravity PR: https://github.com/artsy/gravity/pull/16558

## Description

This PR adds an `artistIDs` param to the connection `me.myCollectionConnection` to filter artworks by artist ID.

[ONYX-140]: https://artsyproduct.atlassian.net/browse/ONYX-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ