### PR TITLE
feat(ONYX-159): support interest id filtering within userInterestsConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11893,6 +11893,9 @@ type Me implements Node {
     category: UserInterestCategory
     first: Int
 
+    # Ids of the user interests to return if found. Can be an 'Artist' Id or a 'Gene' Id
+    interestsIDs: [String!]
+
     # UserInterest InterestType to select. 'Artist' or 'Gene' type
     interestType: UserInterestInterestType
     last: Int

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11893,8 +11893,8 @@ type Me implements Node {
     category: UserInterestCategory
     first: Int
 
-    # Ids of the user interests to return if found. Can be an 'Artist' Id or a 'Gene' Id
-    interestsIDs: [String!]
+    # Id of the user interests to return if found. Can be an 'Artist' Id or a 'Gene' Id
+    interestID: String
 
     # UserInterest InterestType to select. 'Artist' or 'Gene' type
     interestType: UserInterestInterestType

--- a/src/schema/v2/me/__tests__/userInterestsConnection.test.ts
+++ b/src/schema/v2/me/__tests__/userInterestsConnection.test.ts
@@ -96,7 +96,7 @@ describe("Me", () => {
       })
     })
 
-    it("uses interest ids when provided", async () => {
+    it("sends interest id when provided", async () => {
       const query = gql`
         {
           me {
@@ -105,7 +105,7 @@ describe("Me", () => {
               category: COLLECTED_BEFORE
               interestType: ARTIST
               first: 10
-              interestsIDs: ["artist-id-1", "artist-id-2"]
+              interestID: "artist-id-1"
             ) {
               edges {
                 internalID
@@ -136,15 +136,6 @@ describe("Me", () => {
             },
             id: "user-interest-id-1",
           },
-          {
-            interest: {
-              _id: "artist-id-2",
-              name: "Artist Name 2",
-              id: "yayoi-kusama",
-              birthday: "10.10.2002",
-            },
-            id: "user-interest-id-2",
-          },
         ],
       }))
 
@@ -153,38 +144,12 @@ describe("Me", () => {
         meUserInterestsLoader,
       }
 
-      const result = await runAuthenticatedQuery(query, context)
-
-      expect(result).toMatchInlineSnapshot(`
-        Object {
-          "me": Object {
-            "name": "Long John",
-            "userInterestsConnection": Object {
-              "edges": Array [
-                Object {
-                  "internalID": "user-interest-id-1",
-                  "node": Object {
-                    "internalID": "artist-id-1",
-                    "name": "Artist Name 1",
-                  },
-                },
-                Object {
-                  "internalID": "user-interest-id-2",
-                  "node": Object {
-                    "internalID": "artist-id-2",
-                    "name": "Artist Name 2",
-                  },
-                },
-              ],
-            },
-          },
-        }
-      `)
+      await runAuthenticatedQuery(query, context)
 
       expect(meUserInterestsLoader).toHaveBeenCalledWith({
         category: "collected_before",
         interest_type: "Artist",
-        interests_ids: ["artist-id-1", "artist-id-2"],
+        interest_id: "artist-id-1",
         page: 1,
         size: 10,
         total_count: true,

--- a/src/schema/v2/me/__tests__/userInterestsConnection.test.ts
+++ b/src/schema/v2/me/__tests__/userInterestsConnection.test.ts
@@ -3,62 +3,62 @@ import { runAuthenticatedQuery } from "schema/v2/test/utils"
 
 describe("Me", () => {
   describe("UserInterestsConnection", () => {
-    const query = gql`
-      {
-        me {
-          name
-          userInterestsConnection(
-            category: COLLECTED_BEFORE
-            interestType: ARTIST
-            first: 10
-          ) {
-            edges {
-              internalID
-              node {
-                ... on Artist {
-                  internalID
-                  name
+    it("returns user's artist user_interests", async () => {
+      const query = gql`
+        {
+          me {
+            name
+            userInterestsConnection(
+              category: COLLECTED_BEFORE
+              interestType: ARTIST
+              first: 10
+            ) {
+              edges {
+                internalID
+                node {
+                  ... on Artist {
+                    internalID
+                    name
+                  }
                 }
               }
             }
           }
         }
+      `
+
+      const meLoader = jest.fn(() => ({
+        name: "Long John",
+      }))
+      const meUserInterestsLoader = jest.fn(async () => ({
+        headers: { "x-total-count": 30 },
+        body: [
+          {
+            interest: {
+              _id: "artist-id-1",
+              name: "Artist Name 1",
+              id: "yayoi-kusama",
+              birthday: "10.10.2002",
+            },
+            id: "user-interest-id-1",
+          },
+          {
+            interest: {
+              _id: "artist-id-2",
+              name: "Artist Name 2",
+              id: "yayoi-kusama",
+              birthday: "10.10.2002",
+            },
+            id: "user-interest-id-2",
+          },
+        ],
+      }))
+
+      const context = {
+        meLoader,
+        meUserInterestsLoader,
       }
-    `
 
-    const meLoader = jest.fn(() => ({
-      name: "Long John",
-    }))
-    const meUserInterestsLoader = jest.fn(async () => ({
-      headers: { "x-total-count": 30 },
-      body: [
-        {
-          interest: {
-            _id: "artist-id-1",
-            name: "Artist Name 1",
-            id: "yayoi-kusama",
-            birthday: "10.10.2002",
-          },
-          id: "user-interest-id-1",
-        },
-        {
-          interest: {
-            _id: "artist-id-2",
-            name: "Artist Name 2",
-            id: "yayoi-kusama",
-            birthday: "10.10.2002",
-          },
-          id: "user-interest-id-2",
-        },
-      ],
-    }))
-
-    const context = {
-      meLoader,
-      meUserInterestsLoader,
-    }
-
-    it("returns user's artist user_interests", async () => {
       const result = await runAuthenticatedQuery(query, context)
 
       expect(result).toMatchInlineSnapshot(`
@@ -90,6 +90,101 @@ describe("Me", () => {
       expect(meUserInterestsLoader).toHaveBeenCalledWith({
         category: "collected_before",
         interest_type: "Artist",
+        page: 1,
+        size: 10,
+        total_count: true,
+      })
+    })
+
+    it("uses interest ids when provided", async () => {
+      const query = gql`
+        {
+          me {
+            name
+            userInterestsConnection(
+              category: COLLECTED_BEFORE
+              interestType: ARTIST
+              first: 10
+              interestsIDs: ["artist-id-1", "artist-id-2"]
+            ) {
+              edges {
+                internalID
+                node {
+                  ... on Artist {
+                    internalID
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const meLoader = jest.fn(() => ({
+        name: "Long John",
+      }))
+      const meUserInterestsLoader = jest.fn(async () => ({
+        headers: { "x-total-count": 30 },
+        body: [
+          {
+            interest: {
+              _id: "artist-id-1",
+              name: "Artist Name 1",
+              id: "yayoi-kusama",
+              birthday: "10.10.2002",
+            },
+            id: "user-interest-id-1",
+          },
+          {
+            interest: {
+              _id: "artist-id-2",
+              name: "Artist Name 2",
+              id: "yayoi-kusama",
+              birthday: "10.10.2002",
+            },
+            id: "user-interest-id-2",
+          },
+        ],
+      }))
+
+      const context = {
+        meLoader,
+        meUserInterestsLoader,
+      }
+
+      const result = await runAuthenticatedQuery(query, context)
+
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "me": Object {
+            "name": "Long John",
+            "userInterestsConnection": Object {
+              "edges": Array [
+                Object {
+                  "internalID": "user-interest-id-1",
+                  "node": Object {
+                    "internalID": "artist-id-1",
+                    "name": "Artist Name 1",
+                  },
+                },
+                Object {
+                  "internalID": "user-interest-id-2",
+                  "node": Object {
+                    "internalID": "artist-id-2",
+                    "name": "Artist Name 2",
+                  },
+                },
+              ],
+            },
+          },
+        }
+      `)
+
+      expect(meUserInterestsLoader).toHaveBeenCalledWith({
+        category: "collected_before",
+        interest_type: "Artist",
+        interests_ids: ["artist-id-1", "artist-id-2"],
         page: 1,
         size: 10,
         total_count: true,

--- a/src/schema/v2/me/userInterestsConnection.ts
+++ b/src/schema/v2/me/userInterestsConnection.ts
@@ -1,4 +1,9 @@
-import { GraphQLFieldConfig } from "graphql"
+import {
+  GraphQLFieldConfig,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLString,
+} from "graphql"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { pageable } from "relay-cursor-paging"
 import { ResolverContext } from "types/graphql"
@@ -25,6 +30,11 @@ export const UserInterestsConnection: GraphQLFieldConfig<
       description:
         "UserInterest InterestType to select. 'Artist' or 'Gene' type",
     },
+    interestsIDs: {
+      type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
+      description:
+        "Ids of the user interests to return if found. Can be an 'Artist' Id or a 'Gene' Id",
+    },
   }),
   resolve: async (_, args, { meUserInterestsLoader }) => {
     if (!meUserInterestsLoader) {
@@ -36,6 +46,7 @@ export const UserInterestsConnection: GraphQLFieldConfig<
     const { body, headers } = await meUserInterestsLoader({
       category: args.category,
       interest_type: args.interestType,
+      interests_ids: args.interestsIDs,
       page,
       size,
       total_count: true,

--- a/src/schema/v2/me/userInterestsConnection.ts
+++ b/src/schema/v2/me/userInterestsConnection.ts
@@ -1,9 +1,4 @@
-import {
-  GraphQLFieldConfig,
-  GraphQLList,
-  GraphQLNonNull,
-  GraphQLString,
-} from "graphql"
+import { GraphQLFieldConfig, GraphQLString } from "graphql"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { pageable } from "relay-cursor-paging"
 import { ResolverContext } from "types/graphql"
@@ -30,10 +25,10 @@ export const UserInterestsConnection: GraphQLFieldConfig<
       description:
         "UserInterest InterestType to select. 'Artist' or 'Gene' type",
     },
-    interestsIDs: {
-      type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
+    interestID: {
+      type: GraphQLString,
       description:
-        "Ids of the user interests to return if found. Can be an 'Artist' Id or a 'Gene' Id",
+        "Id of the user interests to return if found. Can be an 'Artist' Id or a 'Gene' Id",
     },
   }),
   resolve: async (_, args, { meUserInterestsLoader }) => {
@@ -46,7 +41,7 @@ export const UserInterestsConnection: GraphQLFieldConfig<
     const { body, headers } = await meUserInterestsLoader({
       category: args.category,
       interest_type: args.interestType,
-      interests_ids: args.interestsIDs,
+      interest_id: args.interestID,
       page,
       size,
       total_count: true,


### PR DESCRIPTION
This PR resolves: [ONYX-159]


This PR adds support to interest ids filtering within `userInterestsConnection`.

**The PR is reviewable in its current state / Gravity changes are needed though before it's ready to be merged**

[ONYX-159]: https://artsyproduct.atlassian.net/browse/ONYX-159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ