### PR TITLE
feat: add verified representatives to Artist schema

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1608,7 +1608,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   statuses: ArtistStatuses
   targetSupply: ArtistTargetSupply
   vanguardYear: String
-  verifiedRepresentatives: [Partner]
+  verifiedRepresentatives: [Partner!]!
   years: String
 }
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1608,6 +1608,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   statuses: ArtistStatuses
   targetSupply: ArtistTargetSupply
   vanguardYear: String
+  verifiedRepresentatives: [Partner]
   years: String
 }
 

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -780,10 +780,5 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
-    verifiedRepresentativesLoader: gravityLoader<any, { artist_id: string }>(
-      ({ artist_id }) => `verified_representatives?artist_id=${artist_id}`,
-      {},
-      { method: "GET" }
-    ),
   }
 }

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -780,5 +780,10 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    verifiedRepresentativesLoader: gravityLoader<any, { artist_id: string }>(
+      ({ artist_id }) => `verified_representatives?artist_id=${artist_id}`,
+      {},
+      { method: "GET" }
+    ),
   }
 }

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -275,5 +275,10 @@ export default (opts) => {
     trendingArtistsLoader: gravityLoader("artists/trending"),
     userByEmailLoader: gravityLoader("user", {}, { method: "GET" }),
     userByIDLoader: gravityLoader((id) => `user/${id}`, {}, { method: "GET" }),
+    verifiedRepresentativesLoader: gravityLoader<any, { artist_id: string }>(
+      ({ artist_id }) => `verified_representatives?artist_id=${artist_id}`,
+      {},
+      { method: "GET" }
+    ),
   }
 }

--- a/src/schema/v2/artist/__tests__/verifiedRepresentatives.test.ts
+++ b/src/schema/v2/artist/__tests__/verifiedRepresentatives.test.ts
@@ -68,7 +68,7 @@ describe("Artist verifiedRepresentatives", () => {
       })
     })
 
-    it("returns null when there are no partners", () => {
+    it("returns empty list when there are no partners", () => {
       const query = `
       {
         artist(id: "123456") {

--- a/src/schema/v2/artist/__tests__/verifiedRepresentatives.test.ts
+++ b/src/schema/v2/artist/__tests__/verifiedRepresentatives.test.ts
@@ -1,0 +1,61 @@
+/* eslint-disable promise/always-return */
+import { runQuery } from "schema/v2/test/utils"
+
+describe("Artist verifiedRepresentatives", () => {
+  const artist = {
+    _id: "123456",
+  }
+
+  const artistLoader = () => Promise.resolve(artist)
+
+  const verifiedRepresentativesResponse = [
+    {
+      partner_id: "123456",
+    },
+  ]
+
+  const partnerDataResponse = {
+    body: [
+      {
+        name: "Catty Partner",
+      },
+      {
+        name: "Yttac Partner",
+      },
+    ],
+  }
+
+  const verifiedRepresentativesLoader = jest
+    .fn()
+    .mockReturnValue(Promise.resolve(verifiedRepresentativesResponse))
+
+  const partnersLoader = jest
+    .fn()
+    .mockReturnValue(Promise.resolve(partnerDataResponse))
+
+  const context = {
+    artistLoader,
+    verifiedRepresentativesLoader,
+    partnersLoader,
+  }
+
+  describe("with a artist_id", () => {
+    it("returns a verifiedRepresentatives partners", () => {
+      const query = `
+      {
+        artist(id: "123456") {
+          verifiedRepresentatives {
+            name
+          }
+        }
+      }
+    `
+
+      return runQuery(query, context).then(({ artist: { ...response } }) => {
+        const verifiedRepresentatives = response.verifiedRepresentatives
+        expect(verifiedRepresentatives[0].name).toBe("Catty Partner")
+        expect(verifiedRepresentatives[1].name).toBe("Yttac Partner")
+      })
+    })
+  })
+})

--- a/src/schema/v2/artist/__tests__/verifiedRepresentatives.test.ts
+++ b/src/schema/v2/artist/__tests__/verifiedRepresentatives.test.ts
@@ -10,7 +10,7 @@ describe("Artist verifiedRepresentatives", () => {
 
   const verifiedRepresentativesResponse = [
     {
-      partner_id: "123456",
+      partner_id: "654321",
     },
   ]
 
@@ -29,6 +29,10 @@ describe("Artist verifiedRepresentatives", () => {
     .fn()
     .mockReturnValue(Promise.resolve(verifiedRepresentativesResponse))
 
+  const verifiedRepresentativesWithoutResponseLoader = jest
+    .fn()
+    .mockReturnValue(Promise.resolve([]))
+
   const partnersLoader = jest
     .fn()
     .mockReturnValue(Promise.resolve(partnerDataResponse))
@@ -36,6 +40,12 @@ describe("Artist verifiedRepresentatives", () => {
   const context = {
     artistLoader,
     verifiedRepresentativesLoader,
+    partnersLoader,
+  }
+
+  const contextWithNotResponse = {
+    artistLoader,
+    verifiedRepresentativesLoader: verifiedRepresentativesWithoutResponseLoader,
     partnersLoader,
   }
 
@@ -55,6 +65,22 @@ describe("Artist verifiedRepresentatives", () => {
         const verifiedRepresentatives = response.verifiedRepresentatives
         expect(verifiedRepresentatives[0].name).toBe("Catty Partner")
         expect(verifiedRepresentatives[1].name).toBe("Yttac Partner")
+      })
+    })
+
+    it("returns null when there is no artist", () => {
+      const query = `
+      {
+        artist(id: "123456") {
+          verifiedRepresentatives {
+            name
+          }
+        }
+      }
+    `
+
+      return runQuery(query, contextWithNotResponse).then((data) => {
+        expect(data.artist.verifiedRepresentatives).toEqual([])
       })
     })
   })

--- a/src/schema/v2/artist/__tests__/verifiedRepresentatives.test.ts
+++ b/src/schema/v2/artist/__tests__/verifiedRepresentatives.test.ts
@@ -43,7 +43,7 @@ describe("Artist verifiedRepresentatives", () => {
     partnersLoader,
   }
 
-  const contextWithNotResponse = {
+  const contextWithEmptyResponse = {
     artistLoader,
     verifiedRepresentativesLoader: verifiedRepresentativesWithoutResponseLoader,
     partnersLoader,
@@ -79,7 +79,7 @@ describe("Artist verifiedRepresentatives", () => {
       }
     `
 
-      return runQuery(query, contextWithNotResponse).then((data) => {
+      return runQuery(query, contextWithEmptyResponse).then((data) => {
         expect(data.artist.verifiedRepresentatives).toEqual([])
       })
     })

--- a/src/schema/v2/artist/__tests__/verifiedRepresentatives.test.ts
+++ b/src/schema/v2/artist/__tests__/verifiedRepresentatives.test.ts
@@ -68,7 +68,7 @@ describe("Artist verifiedRepresentatives", () => {
       })
     })
 
-    it("returns null when there is no artist", () => {
+    it("returns null when there are no partners", () => {
       const query = `
       {
         artist(id: "123456") {

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -57,6 +57,7 @@ import {
 } from "./shows"
 import ArtistStatuses from "./statuses"
 import { ArtistTargetSupply } from "./targetSupply"
+import VerifiedRepresentatives from "./verifiedRepresentatives"
 
 // Manually curated list of artist id's who has verified auction lots that can be
 // returned, when queried for via `recordsTrusted: true`.
@@ -770,6 +771,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLString,
         resolve: ({ vanguard_year }) => vanguard_year,
       },
+      verifiedRepresentatives: VerifiedRepresentatives,
       years: { type: GraphQLString },
     }
   },

--- a/src/schema/v2/artist/verifiedRepresentatives.ts
+++ b/src/schema/v2/artist/verifiedRepresentatives.ts
@@ -12,9 +12,6 @@ const VerifiedRepresentatives: GraphQLFieldConfig<
     options,
     { verifiedRepresentativesLoader, partnersLoader }
   ) => {
-    if (!verifiedRepresentativesLoader) {
-      throw new Error("You are not authorized to perform this action.")
-    }
     try {
       const verifiedRepresentatives = await verifiedRepresentativesLoader(
         { artist_id: _id },
@@ -33,7 +30,7 @@ const VerifiedRepresentatives: GraphQLFieldConfig<
         return []
       }
 
-      const response = await partnersLoader({ ids: partnerIds })
+      const response = await partnersLoader({ id: partnerIds })
 
       if (!response || !response.body || !Array.isArray(response.body)) {
         throw new Error("Invalid response from partnersLoader.")

--- a/src/schema/v2/artist/verifiedRepresentatives.ts
+++ b/src/schema/v2/artist/verifiedRepresentatives.ts
@@ -1,0 +1,51 @@
+import { GraphQLFieldConfig, GraphQLList } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { PartnerType } from "schema/v2/partner/partner"
+
+const VerifiedRepresentatives: GraphQLFieldConfig<
+  { _id: string },
+  ResolverContext
+> = {
+  type: GraphQLList(PartnerType),
+  resolve: async (
+    { _id },
+    options,
+    { verifiedRepresentativesLoader, partnersLoader }
+  ) => {
+    if (!verifiedRepresentativesLoader) {
+      throw new Error("You are not authorized to perform this action.")
+    }
+    try {
+      const verifiedRepresentatives = await verifiedRepresentativesLoader(
+        { artist_id: _id },
+        options
+      )
+
+      if (!verifiedRepresentatives || !Array.isArray(verifiedRepresentatives)) {
+        throw new Error("Invalid response from verifiedRepresentativesLoader.")
+      }
+
+      const partnerIds = verifiedRepresentatives.map(
+        ({ partner_id }) => partner_id
+      )
+
+      if (!Array.isArray(partnerIds) || partnerIds.length === 0) {
+        return []
+      }
+
+      const response = await partnersLoader({ ids: partnerIds })
+
+      if (!response || !response.body || !Array.isArray(response.body)) {
+        throw new Error("Invalid response from partnersLoader.")
+      }
+
+      return response.body
+    } catch (error) {
+      throw new Error(
+        `Error retrieving verified representatives: ${error.message}`
+      )
+    }
+  },
+}
+
+export default VerifiedRepresentatives

--- a/src/schema/v2/artist/verifiedRepresentatives.ts
+++ b/src/schema/v2/artist/verifiedRepresentatives.ts
@@ -1,4 +1,4 @@
-import { GraphQLFieldConfig, GraphQLList } from "graphql"
+import { GraphQLFieldConfig, GraphQLList, GraphQLNonNull } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { PartnerType } from "schema/v2/partner/partner"
 
@@ -6,7 +6,7 @@ const VerifiedRepresentatives: GraphQLFieldConfig<
   { _id: string },
   ResolverContext
 > = {
-  type: GraphQLList(PartnerType),
+  type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(PartnerType))),
   resolve: async (
     { _id },
     options,


### PR DESCRIPTION
We are introducing the VerifiedRepresentative field[] to the Artist schema. This addition will be as the definitive source for information on galleries representing artists.

[DIA-43]
https://artsy.slack.com/archives/C05EEBNEF71/p1689862876720839


[DIA-43]: https://artsyproduct.atlassian.net/browse/DIA-43?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ