### PR TITLE
feat(AMBER-28): create messages and conversation events query

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7020,6 +7020,14 @@ type Conversation implements Node {
     sort: sort
   ): MessageConnection @deprecated(reason: "Prefer messagesConnection")
 
+  # A connection for all messages and events in a single conversation
+  messagesAndConversationEventsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): MessageOrConversationEventTypeConnection
+
   # A connection for all messages in a single conversation
   messagesConnection(
     after: String
@@ -7070,6 +7078,22 @@ type ConversationEdge {
 
   # The item at the end of the edge
   node: Conversation
+}
+
+# An event (such as a submitted offer) in a conversation.
+type ConversationEvent implements Node {
+  # Text for this event, formatted for the seller.
+  buyerBody: String
+  eventKey: String!
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+
+  # Text for this event, formatted for the seller.
+  sellerBody: String
 }
 
 # The participant who started the conversation, currently always a User
@@ -12047,6 +12071,27 @@ type MessageInitiator {
   name: String
 }
 
+union MessageOrConversationEventType = ConversationEvent | Message
+
+# A connection to a list of items.
+type MessageOrConversationEventTypeConnection {
+  # A list of edges.
+  edges: [MessageOrConversationEventTypeEdge]
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type MessageOrConversationEventTypeEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: MessageOrConversationEventType
+}
+
 type MetaphysicsService {
   environment: String!
   queryTracing: Boolean!
@@ -13509,6 +13554,8 @@ type Partner implements Node {
     before: String
     first: Int
     last: Int
+    page: Int
+    size: Int
   ): LocationConnection
   meta: PartnerMeta
   name: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7082,7 +7082,7 @@ type ConversationEdge {
 
 # An event (such as a submitted offer) in a conversation.
 type ConversationEvent implements Node {
-  # Text for this event, formatted for the seller.
+  # Text for this event, formatted for the buyer.
   buyerBody: String
   eventKey: String!
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7026,6 +7026,8 @@ type Conversation implements Node {
     before: String
     first: Int
     last: Int
+    page: Int
+    size: Int
   ): MessageOrConversationEventTypeConnection
 
   # A connection for all messages in a single conversation
@@ -12077,6 +12079,7 @@ union MessageOrConversationEventType = ConversationEvent | Message
 type MessageOrConversationEventTypeConnection {
   # A list of edges.
   edges: [MessageOrConversationEventTypeEdge]
+  pageCursors: PageCursors!
 
   # Information to aid in pagination.
   pageInfo: PageInfo!

--- a/src/lib/loaders/loaders_with_authentication/impulse.ts
+++ b/src/lib/loaders/loaders_with_authentication/impulse.ts
@@ -30,6 +30,10 @@ export default (accessToken, _userID, opts) => {
   return {
     conversationsLoader: impulseLoader("conversations"),
     conversationLoader: impulseLoader((id) => `conversations/${id}`),
+    conversationWithEventsLoader: impulseLoader(
+      (id) => `conversations/${id}/messages_and_conversation_events`,
+      { include_delivery_pending: true }
+    ),
     conversationUpdateLoader: impulseLoader(
       (id) => `conversations/${id}`,
       {},

--- a/src/lib/loaders/loaders_with_authentication/impulse.ts
+++ b/src/lib/loaders/loaders_with_authentication/impulse.ts
@@ -32,7 +32,8 @@ export default (accessToken, _userID, opts) => {
     conversationLoader: impulseLoader((id) => `conversations/${id}`),
     conversationWithEventsLoader: impulseLoader(
       (id) => `conversations/${id}/messages_and_conversation_events`,
-      { include_delivery_pending: true }
+      { include_delivery_pending: true },
+      { headers: true }
     ),
     conversationUpdateLoader: impulseLoader(
       (id) => `conversations/${id}`,

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -151,10 +151,11 @@ export default (opts) => {
     partnerCategoryLoader: gravityLoader((id) => `partner_category/${id}`),
     partnerLoader: gravityLoader((id) => `partner/${id}`),
     partnerLocationsLoader: gravityLoader((id) => `partner/${id}/locations`),
-    partnerLocationsConnectionLoader: gravityLoader<
-      any,
-      { page: number; published: boolean; size: number; total_count: boolean }
-    >((id) => `partner/${id}/locations`, {}, { headers: true }),
+    partnerLocationsConnectionLoader: gravityLoader(
+      (id) => `partner/${id}/locations`,
+      {},
+      { headers: true }
+    ),
     partnerShowArtworksLoader: gravityLoader<
       any,
       { partner_id: string; show_id: string }

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -70,7 +70,7 @@ export const gravityStitchingEnvironment = (
         savedSearchesConnection(
           first: Int
           last: Int
-      after: String
+          after: String
           before: String
           sort: SavedSearchesSortEnum
         ): SearchCriteriaConnection

--- a/src/schema/v2/conversation/__tests__/conversation.test.js
+++ b/src/schema/v2/conversation/__tests__/conversation.test.js
@@ -175,8 +175,10 @@ describe("Me", () => {
         ]
 
         return Promise.resolve({
-          total_count: 4,
-          messages_and_conversation_events: messagesAndEvents,
+          body: {
+            total_count: 4,
+            messages_and_conversation_events: messagesAndEvents,
+          },
         })
       },
     }

--- a/src/schema/v2/conversation/conversationEvent.ts
+++ b/src/schema/v2/conversation/conversationEvent.ts
@@ -1,0 +1,29 @@
+import { GraphQLNonNull, GraphQLObjectType, GraphQLString } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { NodeInterface, InternalIDFields } from "../object_identification"
+
+export const ConversationEventType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "ConversationEvent",
+  description: "An event (such as a submitted offer) in a conversation.",
+  interfaces: [NodeInterface],
+  fields: {
+    ...InternalIDFields,
+    sellerBody: {
+      description: "Text for this event, formatted for the seller.",
+      type: GraphQLString,
+      resolve: ({ seller_body }) => seller_body,
+    },
+    buyerBody: {
+      description: "Text for this event, formatted for the buyer.",
+      type: GraphQLString,
+      resolve: ({ buyer_body }) => buyer_body,
+    },
+    eventKey: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ event_key }) => event_key,
+    },
+  },
+})


### PR DESCRIPTION
Companion to https://github.com/artsy/impulse/pull/956.

This PR introduces a new `messagesAndConversationEventsConnection` field inside a `conversation`, which fetches messages and events (like an offer being submitted or rejected) together in a single chronologically-ordered connection.

Sample query (note that to run this, you'll need to change the ID to be a conversation you're part of):
```graphql
query {
	me {
		conversation(id: "208433") {
			messagesAndConversationEventsConnection(first: 50) {
				edges {
					node {
						__typename
						... on Message {
							internalID
							isFromUser
							body
						}
						... on ConversationEvent {
							buyerBody
							sellerBody
							eventKey
						}
					}
				}
			}
		}
	}
}
```

Jira ticket: https://artsyproduct.atlassian.net/browse/AMBER-28