### PR TITLE
feat: add batch update user interests mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12732,6 +12732,11 @@ type Mutation {
     input: UpdateUserInterestMutationInput!
   ): UpdateUserInterestMutationPayload
 
+  # Update user interests for multiple artists
+  updateUserInterests(
+    input: UpdateUserInterestsMutationInput!
+  ): UpdateUserInterestsMutationPayload
+
   # Update the user sale profile
   updateUserSaleProfile(
     input: UpdateUserSaleProfileMutationInput!
@@ -18439,6 +18444,11 @@ type UpdateUserInterestFailure {
   mutationError: GravityMutationError
 }
 
+input UpdateUserInterestInput {
+  id: String!
+  private: Boolean
+}
+
 input UpdateUserInterestMutationInput {
   clientMutationId: String
   id: String!
@@ -18452,9 +18462,26 @@ type UpdateUserInterestMutationPayload {
   userInterestOrError: UpdateUserInterestResponseOrError
 }
 
+union UpdateUserInterestOrError = UpdateUserInterestsFailure | UserInterest
+
 union UpdateUserInterestResponseOrError =
     UpdateUserInterestFailure
   | UpdateUserInterestSuccess
+
+type UpdateUserInterestsFailure {
+  mutationError: GravityMutationError
+}
+
+input UpdateUserInterestsMutationInput {
+  clientMutationId: String
+  userInterests: [UpdateUserInterestInput!]!
+}
+
+type UpdateUserInterestsMutationPayload {
+  clientMutationId: String
+  me: Me!
+  userInterestsOrErrors: [UpdateUserInterestOrError!]!
+}
 
 type UpdateUserInterestSuccess {
   userInterest: UserInterest

--- a/src/schema/v2/me/__tests__/updateUserInterestsMutation.test.ts
+++ b/src/schema/v2/me/__tests__/updateUserInterestsMutation.test.ts
@@ -1,0 +1,72 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("updateUserInterestMutation", () => {
+  const mockMeUpdateUserInterestLoader = jest.fn()
+
+  const context = {
+    meUpdateUserInterestLoader: mockMeUpdateUserInterestLoader,
+  }
+
+  it("updates the user interest using the provided input", async () => {
+    mockMeUpdateUserInterestLoader.mockResolvedValueOnce(
+      Promise.resolve({ id: "id-1", private: false })
+    )
+    mockMeUpdateUserInterestLoader.mockResolvedValueOnce(
+      Promise.resolve({ id: "id-2", private: true })
+    )
+    mockMeUpdateUserInterestLoader.mockResolvedValueOnce(
+      Promise.resolve({ id: "id-3", private: false })
+    )
+
+    const mutation = gql`
+      mutation {
+        updateUserInterests(
+          input: {
+            userInterests: [
+              { id: "id-1", private: false }
+              { id: "id-2", private: true }
+              { id: "id-3", private: false }
+            ]
+          }
+        ) {
+          userInterestsOrErrors {
+            ... on UserInterest {
+              private
+            }
+          }
+        }
+      }
+    `
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(mockMeUpdateUserInterestLoader).toHaveBeenNthCalledWith(1, "id-1", {
+      private: false,
+    })
+    expect(mockMeUpdateUserInterestLoader).toHaveBeenNthCalledWith(2, "id-2", {
+      private: true,
+    })
+    expect(mockMeUpdateUserInterestLoader).toHaveBeenNthCalledWith(3, "id-3", {
+      private: false,
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "updateUserInterests": Object {
+          "userInterestsOrErrors": Array [
+            Object {
+              "private": false,
+            },
+            Object {
+              "private": true,
+            },
+            Object {
+              "private": false,
+            },
+          ],
+        },
+      }
+    `)
+  })
+})

--- a/src/schema/v2/me/updateUserInterestsMutation.ts
+++ b/src/schema/v2/me/updateUserInterestsMutation.ts
@@ -1,0 +1,114 @@
+import {
+  GraphQLBoolean,
+  GraphQLInputObjectType,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  GravityMutationErrorType,
+  formatGravityError,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { userInterestType } from "../userInterests"
+import { meType } from "./index"
+
+interface UserInterestInput {
+  id: string
+  private?: boolean
+}
+
+interface Input {
+  userInterests: UserInterestInput[]
+}
+
+export const UpdateUserInterestInputType = new GraphQLInputObjectType({
+  name: "UpdateUserInterestInput",
+  fields: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+    private: { type: GraphQLBoolean },
+  },
+})
+
+const UpdateUserInterestFailureType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "UpdateUserInterestsFailure",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const userInterestOrErrorType = new GraphQLUnionType({
+  name: "UpdateUserInterestOrError",
+  types: [userInterestType, UpdateUserInterestFailureType],
+  resolveType: (data) =>
+    data._type === "GravityMutationError"
+      ? UpdateUserInterestFailureType
+      : userInterestType,
+})
+
+export const updateUserInterestsMutation = mutationWithClientMutationId<
+  Input,
+  typeof userInterestOrErrorType[] | null,
+  ResolverContext
+>({
+  name: "UpdateUserInterestsMutation",
+  description: "Update user interests for multiple artists",
+  inputFields: {
+    userInterests: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(UpdateUserInterestInputType))
+      ),
+    },
+  },
+  outputFields: {
+    userInterestsOrErrors: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(userInterestOrErrorType))
+      ),
+      resolve: (userInterests) => userInterests,
+    },
+    me: {
+      type: new GraphQLNonNull(meType),
+      resolve: (_source, _args, { meLoader }) => {
+        return meLoader?.()
+      },
+    },
+  },
+  mutateAndGetPayload: async (args, { meUpdateUserInterestLoader }) => {
+    if (!meUpdateUserInterestLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    const userInterestResponses = Promise.all(
+      args.userInterests.map(async (userInterest) => {
+        try {
+          return await meUpdateUserInterestLoader(userInterest.id, {
+            private: userInterest.private,
+          })
+        } catch (error) {
+          const formattedErr = formatGravityError(error)
+
+          if (formattedErr) {
+            return { ...formattedErr, _type: "GravityMutationError" }
+          } else {
+            return {
+              message: error.message,
+              _type: "GravityMutationError",
+            }
+          }
+        }
+      })
+    )
+
+    return userInterestResponses
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -209,6 +209,7 @@ import { deleteUserInterestForUser } from "./users/deleteUserInterestForUserMuta
 import VanityURLEntity from "./vanityURLEntity"
 import { VerifyAddress } from "./verifyAddress"
 import { updateUserInterestMutation } from "./me/updateUserInterestMutation"
+import { updateUserInterestsMutation } from "./me/updateUserInterestsMutation"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -437,6 +438,7 @@ export default new GraphQLSchema({
       updateQuiz: updateQuizMutation,
       updateUser: updateUserMutation,
       updateUserInterest: updateUserInterestMutation,
+      updateUserInterests: updateUserInterestsMutation,
       updateUserSaleProfile: updateUserSaleProfileMutation,
     },
   }),


### PR DESCRIPTION
This PR resolves [ONYX-152]

The goal here is to add support for updating multiple user interests at once.

