### PR TITLE
feat(onyx-170): profile search entities return exect href instead of vanity urls

### DIFF
--- a/src/schema/v2/SearchableItem/SearchItemRawResponse.ts
+++ b/src/schema/v2/SearchableItem/SearchItemRawResponse.ts
@@ -12,6 +12,7 @@ export type SearchItemRawResponse = {
   location: string
   model: string
   owner_type: string
+  owner_slug: string
   profile_id: string
   published_at: string
   start_at: string

--- a/src/schema/v2/SearchableItem/SearchableItemPresenter.ts
+++ b/src/schema/v2/SearchableItem/SearchableItemPresenter.ts
@@ -42,12 +42,36 @@ export class SearchableItemPresenter {
   }
 
   href(): string {
-    const { href, label, id, profile_id, model } = this.item
+    const {
+      href,
+      label,
+      id,
+      profile_id,
+      model,
+      owner_type,
+      owner_slug,
+    } = this.item
 
     if (href) return href
+
     switch (label) {
       case "Profile":
-        return `/${id}`
+        switch (owner_type) {
+          case "Fair":
+          case "FairOrganizer":
+            return `/fair/${owner_slug}`
+          case "PartnerAuction":
+          case "PartnerBrand":
+          case "PartnerDemo":
+          case "PartnerGallery":
+          case "PartnerInstitution":
+          case "PartnerInstitutionalSeller":
+          case "PartnerPrivateCollector":
+          case "PartnerPrivateDealer":
+            return `/partner/${owner_slug}`
+          default:
+            return `/${id}`
+        }
       case "Fair":
         return `/${profile_id}`
       case "Sale":

--- a/src/schema/v2/SearchableItem/__tests__/SearchableItemPresenter.test.ts
+++ b/src/schema/v2/SearchableItem/__tests__/SearchableItemPresenter.test.ts
@@ -18,6 +18,7 @@ describe("SearchableItemPresenter", () => {
     location: "",
     model: "",
     owner_type: "",
+    owner_slug: "",
     profile_id: "",
     published_at: "",
     start_at: "",
@@ -370,6 +371,268 @@ describe("SearchableItemPresenter", () => {
       const presenter = new SearchableItemPresenter(searchableItem)
       const imageUrl = presenter.imageUrl()
       expect(imageUrl).toBe("")
+    })
+  })
+
+  describe("#href", () => {
+    describe("for a Fair or FairOrganizer type", () => {
+      it("returns correct href", () => {
+        let searchableItem = {
+          ...BASE_ITEM,
+          label: "Profile",
+          owner_type: "Fair",
+          owner_slug: "fair-slug",
+        }
+
+        expect(new SearchableItemPresenter(searchableItem).href()).toBe(
+          "/fair/fair-slug"
+        )
+
+        searchableItem = {
+          ...BASE_ITEM,
+          label: "Profile",
+          owner_type: "FairOrganizer",
+          owner_slug: "default-fair-slug",
+        }
+
+        expect(new SearchableItemPresenter(searchableItem).href()).toBe(
+          "/fair/default-fair-slug"
+        )
+      })
+    })
+
+    describe("for Partner's types", () => {
+      it("returns correct href", () => {
+        let searchableItem = {
+          ...BASE_ITEM,
+          label: "Profile",
+          owner_type: "PartnerAuction",
+          owner_slug: "partner-auction-slug",
+        }
+
+        expect(new SearchableItemPresenter(searchableItem).href()).toBe(
+          "/partner/partner-auction-slug"
+        )
+
+        searchableItem = {
+          ...BASE_ITEM,
+          label: "Profile",
+          owner_type: "PartnerBrand",
+          owner_slug: "partner-brand-slug",
+        }
+
+        expect(new SearchableItemPresenter(searchableItem).href()).toBe(
+          "/partner/partner-brand-slug"
+        )
+
+        searchableItem = {
+          ...BASE_ITEM,
+          label: "Profile",
+          owner_type: "PartnerDemo",
+          owner_slug: "partner-demo-slug",
+        }
+
+        expect(new SearchableItemPresenter(searchableItem).href()).toBe(
+          "/partner/partner-demo-slug"
+        )
+
+        searchableItem = {
+          ...BASE_ITEM,
+          label: "Profile",
+          owner_type: "PartnerGallery",
+          owner_slug: "partner-gallery-slug",
+        }
+
+        expect(new SearchableItemPresenter(searchableItem).href()).toBe(
+          "/partner/partner-gallery-slug"
+        )
+
+        searchableItem = {
+          ...BASE_ITEM,
+          label: "Profile",
+          owner_type: "PartnerInstitution",
+          owner_slug: "partner-institution-slug",
+        }
+
+        expect(new SearchableItemPresenter(searchableItem).href()).toBe(
+          "/partner/partner-institution-slug"
+        )
+
+        searchableItem = {
+          ...BASE_ITEM,
+          label: "Profile",
+          owner_type: "PartnerInstitutionalSeller",
+          owner_slug: "partner-institutional-seller-slug",
+        }
+
+        expect(new SearchableItemPresenter(searchableItem).href()).toBe(
+          "/partner/partner-institutional-seller-slug"
+        )
+
+        searchableItem = {
+          ...BASE_ITEM,
+          label: "Profile",
+          owner_type: "PartnerPrivateCollector",
+          owner_slug: "partner-private-collector-slug",
+        }
+
+        expect(new SearchableItemPresenter(searchableItem).href()).toBe(
+          "/partner/partner-private-collector-slug"
+        )
+
+        searchableItem = {
+          ...BASE_ITEM,
+          label: "Profile",
+          owner_type: "PartnerPrivateDealer",
+          owner_slug: "partner-private-dealer-slug",
+        }
+
+        expect(new SearchableItemPresenter(searchableItem).href()).toBe(
+          "/partner/partner-private-dealer-slug"
+        )
+      })
+    })
+
+    describe("for other Profile types", () => {
+      it("returns correct href", () => {
+        const searchableItem = {
+          ...BASE_ITEM,
+          label: "Profile",
+          owner_type: "UnkonwnProfileType",
+          id: "partner-slug",
+        }
+
+        expect(new SearchableItemPresenter(searchableItem).href()).toBe(
+          "/partner-slug"
+        )
+      })
+    })
+
+    describe("for a Fair", () => {
+      it("returns correct href", () => {
+        const searchableItem = {
+          ...BASE_ITEM,
+          label: "Fair",
+          profile_id: "fair-profile-id",
+        }
+
+        expect(new SearchableItemPresenter(searchableItem).href()).toBe(
+          "/fair-profile-id"
+        )
+      })
+    })
+
+    describe("for a Sale", () => {
+      it("returns correct href", () => {
+        const searchableItem = {
+          ...BASE_ITEM,
+          label: "Sale",
+          id: "sale-id",
+        }
+
+        expect(new SearchableItemPresenter(searchableItem).href()).toBe(
+          "/auction/sale-id"
+        )
+      })
+    })
+
+    describe("for a City", () => {
+      it("returns correct href", () => {
+        const searchableItem = {
+          ...BASE_ITEM,
+          label: "City",
+          id: "city-id",
+        }
+
+        expect(new SearchableItemPresenter(searchableItem).href()).toBe(
+          "/shows/city-id"
+        )
+      })
+    })
+
+    describe("for a MarketingCollection", () => {
+      it("returns correct href", () => {
+        const searchableItem = {
+          ...BASE_ITEM,
+          label: "MarketingCollection",
+          id: "collection-id",
+        }
+
+        expect(new SearchableItemPresenter(searchableItem).href()).toBe(
+          "/collection/collection-id"
+        )
+      })
+    })
+
+    describe("for a Booth", () => {
+      it("returns correct href", () => {
+        const searchableItem = {
+          ...BASE_ITEM,
+          label: "Booth",
+          id: "show-id",
+        }
+
+        expect(new SearchableItemPresenter(searchableItem).href()).toBe(
+          "/show/show-id"
+        )
+      })
+    })
+
+    describe("for a PartnerShow", () => {
+      it("returns correct href", () => {
+        const searchableItem = {
+          ...BASE_ITEM,
+          label: "PartnerShow",
+          id: "show-id",
+        }
+
+        expect(new SearchableItemPresenter(searchableItem).href()).toBe(
+          "/show/show-id"
+        )
+      })
+    })
+
+    describe("for an ArtistSeries", () => {
+      it("returns correct href", () => {
+        const searchableItem = {
+          ...BASE_ITEM,
+          label: "ArtistSeries",
+          id: "artist-series-id",
+        }
+
+        expect(new SearchableItemPresenter(searchableItem).href()).toBe(
+          "/artist-series/artist-series-id"
+        )
+      })
+    })
+
+    describe("for a ViewingRoom", () => {
+      it("returns correct href", () => {
+        const searchableItem = {
+          ...BASE_ITEM,
+          label: "ViewingRoom",
+          id: "viewing-room-id",
+        }
+
+        expect(new SearchableItemPresenter(searchableItem).href()).toBe(
+          "/viewing-room/viewing-room-id"
+        )
+      })
+    })
+
+    describe("for other entities", () => {
+      it("returns correct href", () => {
+        const searchableItem = {
+          ...BASE_ITEM,
+          label: "SomeOtherEntityType",
+          model: "model",
+          id: "id",
+        }
+
+        expect(new SearchableItemPresenter(searchableItem).href()).toBe(
+          "/model/id"
+        )
+      })
     })
   })
 })


### PR DESCRIPTION
# Motivation

`SearchableItem` has a `href` field. In current implementation, for `Profile` type this field always returns `/<profile_id>`, which is a vanity URL. When user is redirected to a such URL, Metaphysics redirects user to a corresponding page based on profile's `owner_type` field. For instance, if `owner_type` is `Fair` - user is redirected to `/fair/<fair_slug>`, if `owner_type` is `PartnerGallery` - user is redirected to `/partner/<partner_slug>`.

## Example

- We search for British museum

```graphql
{
	searchConnection(first: 20, mode: SITE, query: "british museum", aggregations: [TYPE], entities: [PROFILE]) {
			edges {
				node {
					href
				}
			}
  }
```

- In response `href` is "/britishmuseum", which is a `Profile` slug.
- User is redirected to this page and vanity URL resolution redirects user to `/partner/british-museum` page. (MP makes request `partnerLoader` request to correctly resolve partner's slug, note that profile's and partner's slugs are different).

Vanity URL resolution is intentional and we want to keep it, it is useful to have a "short" url's like `artsy.net/britishmuseum`.

But there is no reason why we should make an extra "hop" when searching from app or web search input - it's more performant to redirect a user to a correct link right away.

# Implementation notes

In this pull request I wanted to establish a direct mapping between profiles of different types and URLs corresponding to them. I pulled all profile types from Gravity console like that:

```ruby
> Profile.distinct(:owner_type)
=>
["Fair",
 "FairOrganizer",
 "PartnerAuction",
 "PartnerBrand",
 "PartnerDemo",
 "PartnerGallery",
 "PartnerInstitution",
 "PartnerInstitutionalSeller",
 "PartnerPrivateCollector",
 "PartnerPrivateDealer"]
```

I also referred to existing vanity URL [resolution logic](https://github.com/artsy/metaphysics/blob/main/src/schema/v2/vanityURLEntity.ts#L36). It seems like that all types of profiles redirect to `/partner/<partner_id>` pages (where `<partner_id>` is taken from `profile.owner.id`) with some exceptions:

- `Fair` redirects to a `/fair/<fair_slug>` URL
- `FairOrganizer` also redirects to a `/fair/<fair_slug>` URL, but `<fair_slug>` now is a `default_fair_id` taken from `FairOrganizer`

I've added a new `owner_slug` field. It doesn't exist in Gravity yet, but I've drafted a [PR](https://github.com/artsy/gravity/pull/16592) to add it. We can avoid introducing this field, but then we will have to make an extra request to a `profileLoader` to get `owner` data (like VanityURLEntity does [here](https://github.com/artsy/metaphysics/blob/main/src/schema/v2/vanityURLEntity.ts#L36)). I've added this field to improve performance, but we can discuss it.

