### PR TITLE
feat(EMI-1286) Handle gravity errors in metaphysics verifyAddress query resolver

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -106,15 +106,6 @@ type addOrderedSetItemSuccess {
   setItem: OrderedSetItem
 }
 
-input AddressInput {
-  addressLine1: String!
-  addressLine2: String
-  city: String
-  country: String!
-  postalCode: String!
-  region: String
-}
-
 type addUserRoleFailure {
   mutationError: GravityMutationError
 }
@@ -15749,7 +15740,7 @@ type Query {
   ): VanityURLEntityType
 
   # Verify a given address.
-  verifyAddress(address: AddressInput!): VerifyAddressType
+  verifyAddress(input: VerifyAddressInput!): VerifyAddressPayload
 
   # A wildcard used to support complex root queries in Relay
   viewer: Viewer
@@ -19284,6 +19275,27 @@ enum VerificationStatuses {
   VERIFIED_WITH_CHANGES
 }
 
+type VerifyAddressFailureType {
+  mutationError: GravityMutationError
+}
+
+input VerifyAddressInput {
+  addressLine1: String!
+  addressLine2: String
+  city: String
+  clientMutationId: String
+  country: String!
+  postalCode: String!
+  region: String
+}
+
+union VerifyAddressMutationType = VerifyAddressFailureType | VerifyAddressType
+
+type VerifyAddressPayload {
+  clientMutationId: String
+  verifyAddressOrError: VerifyAddressMutationType
+}
+
 type VerifyAddressType {
   inputAddress: InputAddressFields!
   suggestedAddresses: [SuggestedAddressFields]!
@@ -20203,7 +20215,7 @@ type Viewer {
   ): VanityURLEntityType
 
   # Verify a given address.
-  verifyAddress(address: AddressInput!): VerifyAddressType
+  verifyAddress(input: VerifyAddressInput!): VerifyAddressPayload
   viewingRoomsConnection(
     after: String
     first: Int


### PR DESCRIPTION
The current `verifyAddress` error handling approach is not in pair with what we usually have for other queries and mutations, which is preventing us to handle errors correctly client side.

This updates the resolver to be more in pair with the pattern we use across Gravity queries, i.e., using the `...OrError` and `Success` or `Failure` types.

**After**

_successful response_
![SCR-20230731-g72](https://github.com/artsy/metaphysics/assets/554507/21a0598f-4ac2-44d2-a479-0ad84aff6d97)

_failed response_
![SCR-20230731-g79](https://github.com/artsy/metaphysics/assets/554507/ab23696d-fdd0-4a5b-a68c-b183b37ab996)

