### PR TITLE
chore: remove post-deploy from hokusai config

### DIFF
--- a/.circleci/deploy_event.sh
+++ b/.circleci/deploy_event.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -ex
-
-echo "_e{24,24}:Metaphysics was deployed|Metaphysics was deployed|#service:metaphysics" > /dev/udp/datadog/8125

--- a/hokusai/config.yml
+++ b/hokusai/config.yml
@@ -1,6 +1,5 @@
 project-name: metaphysics
 git-remote: git@github.com:artsy/metaphysics.git
-post-deploy: .circleci/deploy_event.sh
 hokusai-required-version: ">=0.5.9"
 template-config-files:
   - s3://artsy-citadel/k8s/hokusai-vars.yml


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PHIRE-81

We no longer want to send deploy events to datadog via a custom script and so this removes the script and `post-deploy` configuration in hokusai config.