### PR TITLE
feat(alerts): add a displayName field for saved search criteria

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14091,6 +14091,9 @@ type PhoneNumberType {
 }
 
 type PreviewSavedSearch {
+  # A suggestion for a name that describes a set of saved search criteria in a conventional format
+  displayName: String!
+
   # Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity
   labels: [SearchCriteriaLabel]!
 }

--- a/src/schema/v2/__tests__/previewSavedSearch.test.ts
+++ b/src/schema/v2/__tests__/previewSavedSearch.test.ts
@@ -64,4 +64,197 @@ describe("previewSavedSearch", () => {
       },
     ])
   })
+
+  describe("displayName", () => {
+    it("prefers artist, price, medium type, rarity in that order", async () => {
+      const query = gql`
+        {
+          previewSavedSearch(
+            attributes: {
+              additionalGeneIDs: "prints"
+              artistIDs: ["kaws-4242"]
+              attributionClass: "limited edition"
+              priceRange: "100-1000"
+            }
+          ) {
+            displayName
+          }
+        }
+      `
+
+      const artistLoader = () => Promise.resolve({ name: "KAWS" })
+
+      const { previewSavedSearch } = await runQuery(query, { artistLoader })
+
+      expect(previewSavedSearch.displayName).toEqual(
+        "KAWS — $100–$1,000, Print, Limited edition"
+      )
+    })
+
+    it("handles array-valued input attributes", async () => {
+      const query = gql`
+        {
+          previewSavedSearch(
+            attributes: {
+              additionalGeneIDs: ["painting", "prints"]
+              artistIDs: ["kaws", "banksy"]
+              attributionClass: ["limited edition", "unique"]
+            }
+          ) {
+            displayName
+          }
+        }
+      `
+
+      const artistLoader = jest
+        .fn()
+        .mockReturnValueOnce(Promise.resolve({ name: "KAWS" }))
+        .mockReturnValueOnce(Promise.resolve({ name: "Banksy" }))
+
+      const { previewSavedSearch } = await runQuery(query, { artistLoader })
+
+      expect(previewSavedSearch.displayName).toEqual(
+        "KAWS or Banksy — Painting or Print, Limited edition or Unique"
+      )
+    })
+
+    describe("when other criteria are available", () => {
+      it("still prefers artist, price, medium, rarity over all others", async () => {
+        const query = gql`
+          {
+            previewSavedSearch(
+              attributes: {
+                acquireable: true
+                additionalGeneIDs: "prints"
+                artistIDs: ["kaws"]
+                atAuction: true
+                attributionClass: ["limited edition"]
+                colors: ["yellow"]
+                inquireableOnly: true
+                locationCities: ["New York, NY, USA"]
+                majorPeriods: ["1990"]
+                materialsTerms: ["acrylic"]
+                offerable: true
+                partnerIDs: ["foo-bar-gallery"]
+                priceRange: "100-1000"
+                sizes: [SMALL, MEDIUM]
+              }
+            ) {
+              displayName
+            }
+          }
+        `
+
+        const artistLoader = jest
+          .fn()
+          .mockReturnValueOnce(Promise.resolve({ name: "KAWS" }))
+
+        const partnerLoader = jest
+          .fn()
+          .mockReturnValueOnce(Promise.resolve({ name: "Foo Bar Gallery" }))
+
+        const { previewSavedSearch } = await runQuery(query, {
+          artistLoader,
+          partnerLoader,
+        })
+
+        expect(previewSavedSearch.displayName).toEqual(
+          "KAWS — $100–$1,000, Print, Limited edition"
+        )
+      })
+
+      it("can use size; ways to buy; material", async () => {
+        const query = gql`
+          {
+            previewSavedSearch(
+              attributes: {
+                acquireable: true
+                artistIDs: ["kaws"]
+                atAuction: true
+                inquireableOnly: true
+                materialsTerms: ["acrylic"]
+                offerable: true
+                sizes: [SMALL]
+              }
+            ) {
+              displayName
+            }
+          }
+        `
+
+        const artistLoader = jest
+          .fn()
+          .mockReturnValueOnce(Promise.resolve({ name: "KAWS" }))
+
+        const { previewSavedSearch } = await runQuery(query, {
+          artistLoader,
+        })
+
+        expect(previewSavedSearch.displayName).toEqual(
+          "KAWS — Small (under 40cm), Buy Now or Bid or Inquire or Make Offer, Acrylic"
+        )
+      })
+
+      it("can use period; color", async () => {
+        const query = gql`
+          {
+            previewSavedSearch(
+              attributes: {
+                artistIDs: ["kaws"]
+                colors: ["yellow"]
+                majorPeriods: ["1990"]
+              }
+            ) {
+              displayName
+            }
+          }
+        `
+
+        const artistLoader = jest
+          .fn()
+          .mockReturnValueOnce(Promise.resolve({ name: "KAWS" }))
+
+        const { previewSavedSearch } = await runQuery(query, {
+          artistLoader,
+        })
+
+        expect(previewSavedSearch.displayName).toEqual(
+          "KAWS — 1990–1999, Yellow"
+        )
+      })
+
+      it("can use location; partner", async () => {
+        const query = gql`
+          {
+            previewSavedSearch(
+              attributes: {
+                artistIDs: ["kaws"]
+                locationCities: ["New York, NY, USA"]
+                partnerIDs: ["foo-bar-gallery"]
+              }
+            ) {
+              displayName
+            }
+          }
+        `
+
+        const artistLoader = jest
+          .fn()
+          .mockReturnValueOnce(Promise.resolve({ name: "KAWS" }))
+
+        const partnerLoader = jest
+          .fn()
+          .mockReturnValueOnce(Promise.resolve({ name: "Foo Bar Gallery" }))
+
+        const { previewSavedSearch } = await runQuery(query, {
+          artistLoader,
+          partnerLoader,
+        })
+
+        expect(previewSavedSearch.displayName).toEqual(
+          "KAWS — New York, NY, USA, Foo Bar Gallery"
+        )
+      })
+    })
+  })
 })

--- a/src/schema/v2/__tests__/previewSavedSearch.test.ts
+++ b/src/schema/v2/__tests__/previewSavedSearch.test.ts
@@ -159,7 +159,7 @@ describe("previewSavedSearch", () => {
         })
 
         expect(previewSavedSearch.displayName).toEqual(
-          "KAWS — $100–$1,000, Print, Limited edition"
+          "KAWS — $100–$1,000, Print, Limited edition + 7 more"
         )
       })
 

--- a/src/schema/v2/previewSavedSearch.ts
+++ b/src/schema/v2/previewSavedSearch.ts
@@ -70,6 +70,12 @@ const previewSavedSearchArgs: GraphQLFieldConfigArgumentMap = {
 const PreviewSavedSearchType = new GraphQLObjectType<any, ResolverContext>({
   name: "PreviewSavedSearch",
   fields: () => ({
+    displayName: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: generateDisplayName,
+      description:
+        "A suggestion for a name that describes a set of saved search criteria in a conventional format",
+    },
     labels: {
       type: new GraphQLNonNull(new GraphQLList(SearchCriteriaLabel)),
       resolve: resolveSearchCriteriaLabels,
@@ -98,4 +104,70 @@ export const PreviewSavedSearchField: GraphQLFieldConfig<
   resolve: (_parent, args, _context, _info) => {
     return args.attributes
   },
+}
+
+const generateDisplayName = async (parent, args, context, info) => {
+  const labels = await resolveSearchCriteriaLabels(parent, args, context, info)
+
+  // artist always
+
+  const artistLabels = labels.filter(({ name }) => name === "Artist")
+
+  // then prioritized criteria
+
+  const prioritizedLabels: SearchCriteriaLabel[][] = []
+
+  const price = labels.filter(({ name }) => name === "Price")
+  if (price) prioritizedLabels.push(price)
+
+  const medium = labels.filter(({ name }) => name === "Medium")
+  if (medium) prioritizedLabels.push(medium)
+
+  const rarity = labels.filter(({ name }) => name === "Rarity")
+  if (rarity) prioritizedLabels.push(rarity)
+
+  // then other criteria
+
+  const otherLabels: SearchCriteriaLabel[][] = []
+
+  const size = labels.filter(({ name }) => name === "Size")
+  if (size) otherLabels.push(size)
+
+  const waysToBuy = labels.filter(({ name }) => name === "Ways to Buy")
+  if (waysToBuy) otherLabels.push(waysToBuy)
+
+  const material = labels.filter(({ name }) => name === "Material")
+  if (material) otherLabels.push(material)
+
+  const location = labels.filter(({ name }) => name === "Artwork Location")
+  if (location) otherLabels.push(location)
+
+  const period = labels.filter(({ name }) => name === "Time Period")
+  if (period) otherLabels.push(period)
+
+  const color = labels.filter(({ name }) => name === "Color")
+  if (color) otherLabels.push(color)
+
+  const partner = labels.filter(
+    ({ name }) => name === "Galleries and Institutions"
+  )
+  if (partner) otherLabels.push(partner)
+
+  // concatenate, compact, and trim
+
+  const allLabels = [artistLabels, ...prioritizedLabels, ...otherLabels].filter(
+    (labels) => labels.length > 0
+  )
+
+  const useableLabels = allLabels.slice(0, 4) // artist + up to 3 others
+
+  // render
+
+  const displayValues = useableLabels.map((labels) => {
+    return labels.map((label) => label.displayValue).join(" or ")
+  })
+  const [artist, ...others] = displayValues
+  const result = [artist, others.join(", ")].join(" — ")
+
+  return result
 }

--- a/src/schema/v2/previewSavedSearch.ts
+++ b/src/schema/v2/previewSavedSearch.ts
@@ -167,7 +167,10 @@ const generateDisplayName = async (parent, args, context, info) => {
     return labels.map((label) => label.displayValue).join(" or ")
   })
   const [artist, ...others] = displayValues
-  const result = [artist, others.join(", ")].join(" — ")
+  let result = [artist, others.join(", ")].join(" — ")
+
+  const remainingCount = allLabels.length - useableLabels.length
+  if (remainingCount > 0) result += ` + ${remainingCount} more`
 
   return result
 }

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -20,7 +20,18 @@ export type SearchCriteriaLabel = {
   field: string
 
   /** The human-friendly name of the filter facet */
-  name: string
+  name:
+    | "Artist"
+    | "Artwork Location"
+    | "Color"
+    | "Galleries and Institutions"
+    | "Material"
+    | "Medium"
+    | "Price"
+    | "Rarity"
+    | "Size"
+    | "Time Period"
+    | "Ways to Buy"
 
   /** The value of the filter facet */
   value: string

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -15,7 +15,7 @@ export const SIZES = {
 
 const ONE_IN_TO_CM = 2.54
 
-type SearchCriteriaLabel = {
+export type SearchCriteriaLabel = {
   /** The GraphQL field name of the filter facet */
   field: string
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-173

This nests a new `displayName` field under the root-level `previewSavedSearch` field.

```graphql
query {
  previewSavedSearch(
    attributes: {
      artistIDs: ["kaws"]
      priceRange: "100-1000"
      additionalGeneIDs: "prints"
      attributionClass: "limited edition"
    }
  ) {
    
    displayName # 👈🏽👈🏽👈🏽

    labels {
      displayValue
    }
  }
}
```

```json
{
  "data": {
    "previewSavedSearch": {

      "displayName": "KAWS — $100–$1,000, Print, Limited edition",  👈🏽👈🏽👈🏽

      "labels": [
        {
          "displayValue": "KAWS"
        },
        {
          "displayValue": "Limited edition"
        },
        {
          "displayValue": "Print"
        },
        {
          "displayValue": "$100–$1,000"
        }
      ]
    }
  }
}
```

- `previewSavedSearch` was added in https://github.com/artsy/metaphysics/pull/3864 so that we could centralize some logic for displaying an unpersisted saved search in human-friendly form

- It [does not appear](https://github.com/search?q=org%3Aartsy%20previewSavedSearch&type=code) to have been wired up yet, though

- Since it is an unauthenticated root-level field that takes search criteria as its input, we saw this as a good place to nest this new `displayName` field

- It follows the logic outlined in the ticket to display these values, in this order, when present: **artist, price, medium, rarity**

---

I wanted to get a sense of what kind of suggested output we would get from real-world alert criteria, so I took the 500 newest SearchCriteria instances in staging Gravity and ran them through this logic (code in this commit https://github.com/artsy/metaphysics/pull/5186/commits/1f2159fdeff6df7105ae9a9cda011c0e5cd10c2a)

<details>
<summary>Previous real world output (outdated now)</summary>
👉🏽 https://docs.google.com/spreadsheets/d/1dLPcKBUGsm1MVmpjeGcHWEy4zmg5700ZmWxM_76ZdiM/edit?usp=sharing

<img width="1324" alt="Screenshot 2023-08-01 at 5 25 43 PM" src="https://github.com/artsy/metaphysics/assets/140521/cffcbf91-c3f0-42e7-b433-d48074a9b82a">

<br/><br/>

You can see from this^ that the output can range from the simple…

```
John Kiki
```
…to the ideal…
```
Tom Blachford, $0–$7,000, Photography, Limited edition
```
…to the very verbose…
```
Pablo Picasso, $250–$1,000, Design/Decorative Art or Drawing or Ephemera or Merchandise or Jewelry or Painting or Photography or Print or Sculpture or Drawing, Collage or other Work on Paper
```

Since these are suggested/default names, this seems fine for a first iteration. And the vast majority of these come out to a reasonable length.
</details>

