### PR TITLE
feat: add curated_trending and curated_emerging to artist insights

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1526,6 +1526,8 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
       CRITICALLY_ACCLAIMED
       RECENT_CAREER_EVENT
       ARTSY_VANGUARD_YEAR
+      CURATORS_PICK_EMERGING
+      TRENDING_NOW
       GAINING_FOLLOWERS
       SOLO_SHOW
       GROUP_SHOW
@@ -1755,6 +1757,7 @@ enum ArtistInsightKind {
   BIENNIAL
   COLLECTED
   CRITICALLY_ACCLAIMED
+  CURATORS_PICK_EMERGING
   GAINING_FOLLOWERS
   GROUP_SHOW
   HIGH_AUCTION_RECORD
@@ -1763,6 +1766,7 @@ enum ArtistInsightKind {
   RESIDENCIES
   REVIEWED
   SOLO_SHOW
+  TRENDING_NOW
 }
 
 type ArtistInsightsCount {

--- a/src/schema/v2/artist/__tests__/helpers.test.ts
+++ b/src/schema/v2/artist/__tests__/helpers.test.ts
@@ -73,6 +73,16 @@ describe("getArtistInsights", () => {
         kind: "ACTIVE_SECONDARY_MARKET",
         value: true,
       },
+      {
+        key: "curated_emerging",
+        kind: "CURATORS_PICK_EMERGING",
+        value: true,
+      },
+      {
+        key: "curated_trending_weekly",
+        kind: "TRENDING_NOW",
+        value: true,
+      },
     ]
 
     fields.forEach((field) => {

--- a/src/schema/v2/artist/helpers.ts
+++ b/src/schema/v2/artist/helpers.ts
@@ -13,8 +13,8 @@ export const ARTIST_INSIGHT_KINDS = [
   "CRITICALLY_ACCLAIMED",
   "RECENT_CAREER_EVENT",
   "ARTSY_VANGUARD_YEAR",
-  // "CURATORS_PICK_EMERGING", // Missing
-  // "TRENDING_NOW", // Missing
+  "CURATORS_PICK_EMERGING",
+  "TRENDING_NOW",
   "GAINING_FOLLOWERS",
   "SOLO_SHOW",
   "GROUP_SHOW",
@@ -116,6 +116,18 @@ export const ARTIST_INSIGHT_MAPPING: Record<
     getDescription: () => "Recognized by major institutions and publications",
     getEntities: (artist) => artist.critically_acclaimed && [],
     getLabel: () => "Critically acclaimed",
+  },
+  TRENDING_NOW: {
+    getDescription: () =>
+      "Works by this artist are among the most searched, viewed, and asked-about pieces on Artsy.",
+    getEntities: (artist) => artist.curated_trending_weekly && [],
+    getLabel: () => "Featured in Trending Now",
+  },
+  CURATORS_PICK_EMERGING: {
+    getDescription: () =>
+      "Works by this artist were handpicked for this collection of rising talents to watch.",
+    getEntities: (artist) => artist.curated_emerging && [],
+    getLabel: () => "Featured in Curator’s Pick: Emerging",
   },
   RECENT_CAREER_EVENT: {
     getDescription: (artist) => artist.recent_show && getRecentShow(artist),


### PR DESCRIPTION
[DIA-65]
Description: 
It exposes last two data points for the artist insights. 
Corresponding [Gravity PR](https://github.com/artsy/gravity/pull/16522) 

cc @artsy/diamond-devs 

[DIA-65]: https://artsyproduct.atlassian.net/browse/DIA-65?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ