### PR TITLE
feat: add an uncached loader for filterArtworks, and use when filtering by a sale and sorting by price

### DIFF
--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -13,7 +13,7 @@ export type StartIdentityVerificationGravityOutput = {
 export default (opts) => {
   const { gravityLoaderWithoutAuthenticationFactory } = factories(opts)
   const gravityLoader = gravityLoaderWithoutAuthenticationFactory
-  const gravityUncachedLoader = uncachedLoaderFactory(gravity, "gravity")
+  const gravityUncachedLoader = uncachedLoaderFactory(gravity, "gravity", opts)
 
   const [batchSaleLoader, batchSalesLoader] = createBatchLoaders({
     singleLoader: gravityLoader((id) => `sale/${id}`),
@@ -85,6 +85,7 @@ export default (opts) => {
       {},
       { requestThrottleMs: 1000 * 60 * 60 }
     ),
+    filterArtworksUncachedLoader: gravityUncachedLoader("filter/artworks"),
     geneArtistsLoader: gravityLoader((id) => `gene/${id}/artists`),
     geneFamiliesLoader: gravityLoader("gene_families"),
     geneLoader: gravityLoader((id) => `gene/${id}`),

--- a/src/schema/v2/__tests__/filterArtworksConnection.test.ts
+++ b/src/schema/v2/__tests__/filterArtworksConnection.test.ts
@@ -413,6 +413,82 @@ describe("artworksConnection", () => {
     })
   })
 
+  describe(`When filtering on a sale and sorting by price`, () => {
+    beforeEach(() => {
+      context = {
+        authenticatedLoaders: {},
+        unauthenticatedLoaders: {
+          filterArtworksLoader: () =>
+            Promise.resolve({
+              hits: [
+                {
+                  id: "unauthenticated-loader-artwork-id",
+                },
+              ],
+              aggregations: {
+                total: {
+                  value: 303,
+                },
+              },
+            }),
+        },
+        filterArtworksUncachedLoader: () =>
+          Promise.resolve({
+            hits: [
+              {
+                id: "uncached-loader-artwork-id",
+              },
+            ],
+            aggregations: {
+              total: {
+                value: 303,
+              },
+            },
+          }),
+      }
+    })
+
+    it("returns results using the uncached loader", async () => {
+      const query = gql`
+        {
+          artworksConnection(first: 1, saleID: "sale-id", sort: "prices") {
+            edges {
+              node {
+                slug
+              }
+            }
+          }
+        }
+      `
+
+      const { artworksConnection } = await runQuery(query, context)
+
+      expect(artworksConnection.edges).toEqual([
+        { node: { slug: "uncached-loader-artwork-id" } },
+      ])
+    })
+
+    it("uses the unauthenticated loader otherwise", async () => {
+      const query = gql`
+        {
+          artworksConnection(first: 1, sort: "prices") {
+            edges {
+              node {
+                slug
+              }
+            }
+          }
+        }
+      `
+
+      const { artworksConnection } = await runQuery(query, context)
+
+      expect(artworksConnection.edges).toEqual([
+        { node: { slug: "unauthenticated-loader-artwork-id" } },
+      ])
+    })
+  })
+
   describe("Merchandisable artists aggregation", () => {
     beforeEach(() => {
       const mockArtworkResults = {


### PR DESCRIPTION
On an auction page, when sorting by price - we want those results to start being more real-time and 'live' - and so while there's likely a couple of related PR's for that functionality incoming - we definitely need an uncached loader in Metaphysics for it.

This will be in use whenever any user (logged-in or not) includes the relevant sort and filter. For those requests, irregardless of whether they are logged-in or not, we'd want to make the live request to Gravity.

Fixes https://artsyproduct.atlassian.net/browse/ONYX-199

As a bonus - added logging and the request extension debug information for loaders of this type:

<img width="498" alt="Screen Shot 2023-08-03 at 6 16 18 PM" src="https://github.com/artsy/metaphysics/assets/1457859/744bb6e3-94ed-494e-818a-1d088db25c4e">

and

<img width="1424" alt="Screen Shot 2023-08-03 at 6 16 40 PM" src="https://github.com/artsy/metaphysics/assets/1457859/03b4a7d8-1ec9-4334-bf8c-2f19a46fe143">

