### PR TITLE
fix: use correct recent career event type

### DIFF
--- a/src/schema/v2/artist/__tests__/helpers.test.ts
+++ b/src/schema/v2/artist/__tests__/helpers.test.ts
@@ -178,7 +178,7 @@ describe("getArtistInsights", () => {
       artist: {
         recent_show: "2/2/2021|ai-weiwei|Solo|Gagosian Gallery",
       },
-      value: ["2021 Gagosian Gallery"],
+      value: "2021 Gagosian Gallery",
     }
 
     it("returns recent career event insights", () => {
@@ -215,7 +215,7 @@ describe("getArtistInsights", () => {
       }
 
       const recentShow = getRecentShow(artist)
-      expect(recentShow).toEqual(["2021 Gagosian Gallery"])
+      expect(recentShow).toEqual("2021 Gagosian Gallery")
     })
 
     it("returns empty array if there empty recent show", () => {

--- a/src/schema/v2/artist/helpers.ts
+++ b/src/schema/v2/artist/helpers.ts
@@ -234,7 +234,7 @@ export const getAuctionRecord = async (artist, auctionLotsLoader) => {
   }
 }
 
-export const getRecentShow = (artist): string[] | null => {
+export const getRecentShow = (artist): string | null => {
   // dd/mm/yyy|slug|Group or Solo|Show Title
   const entities = splitEntities(artist.recent_show)
   if (!entities) return null
@@ -252,5 +252,5 @@ export const getRecentShow = (artist): string[] | null => {
   const year = showDate.getFullYear()
   const title = `${year} ${show}`
 
-  return [title]
+  return title
 }


### PR DESCRIPTION
This PR resolves the error caused with recent introduction of recent_career_event. 

<img width="852" alt="image" src="https://github.com/artsy/metaphysics/assets/1176374/5dafe6f3-a786-478f-a9ce-b18b48aa1ec8">


AC: 
There should be value in expandable box.

```
{
   error  {
       message  {
             String cannot represent value: ["2022 New York: 1962 - 1964"]     
       }
   }
}
```
https://app.datadoghq.com/apm/traces?query=env%3Aproduction%20service%3Ametaphysics.graphql%20operation_name%3Agraphql.execute%20%40issue.id%3A%2A%20AND%20resource_name%3A%22query%20ArtistCareerHighlightsQuery%28%24id%3AString%21%29%7Bartist%28id%3A%24id%29%7Bid...ArtistCareerHighlights_artist%7D%7Dfragment%20ArtistCareerHighlights_artist%20on%20Artist%7Bhref%20insights%7Bdescription%20entities%20kind%20label%7Dname%7D%22&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&graphType=flamegraph&historicalData=true&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=time&spanType=all&start=1690541586326&end=1691146386326&paused=false