### PR TITLE
feat: use uncached filterArtworksLoader when filtering by price within a sale

### DIFF
--- a/src/schema/v2/__tests__/filterArtworksConnection.test.ts
+++ b/src/schema/v2/__tests__/filterArtworksConnection.test.ts
@@ -413,7 +413,7 @@ describe("artworksConnection", () => {
     })
   })
 
-  describe(`When filtering on a sale and sorting by price`, () => {
+  describe(`When filtering on a sale and filtering/sorting by price`, () => {
     beforeEach(() => {
       context = {
         authenticatedLoaders: {},
@@ -448,10 +448,34 @@ describe("artworksConnection", () => {
       }
     })
 
-    it("returns results using the uncached loader", async () => {
+    it("returns results using the uncached loader when sorting", async () => {
       const query = gql`
         {
           artworksConnection(first: 1, saleID: "sale-id", sort: "prices") {
+            edges {
+              node {
+                slug
+              }
+            }
+          }
+        }
+      `
+
+      const { artworksConnection } = await runQuery(query, context)
+
+      expect(artworksConnection.edges).toEqual([
+        { node: { slug: "uncached-loader-artwork-id" } },
+      ])
+    })
+
+    it("returns results using the uncached loader when filtering", async () => {
+      const query = gql`
+        {
+          artworksConnection(
+            first: 1
+            saleID: "sale-id"
+            priceRange: "*-1000"
+          ) {
             edges {
               node {
                 slug

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -543,13 +543,14 @@ const filterArtworksConnectionTypeFactory = (
       }
       loader = filterArtworksAuthenticatedLoader
     } else {
-      // If filtering by sale and sorting by price,
+      // If filtering by sale and filtering/sorting by price,
       // use the uncached loader to avoid stale data.
       const isSortingByPrice = ["-prices", "prices"].includes(
         gravityOptions.sort
       )
+      const isFilteringByPrice = !!gravityOptions.price_range
       const isFilteringBySale = !!gravityOptions.sale_id
-      if (isSortingByPrice && isFilteringBySale) {
+      if ((isSortingByPrice || isFilteringByPrice) && isFilteringBySale) {
         loader = filterArtworksUncachedLoader
       } else {
         loader = filterArtworksUnauthenticatedLoader


### PR DESCRIPTION
Following up on https://github.com/artsy/metaphysics/pull/5191#discussion_r1283779732 , the real-time behavior of sorting by a price looks to be good - so let's add the filtering by price behavior as well - that was still stale in mocktion-ing.