### PR TITLE
fix: check for *-* priceRange filters, as thats not really filtering

### DIFF
--- a/src/schema/v2/__tests__/filterArtworksConnection.test.ts
+++ b/src/schema/v2/__tests__/filterArtworksConnection.test.ts
@@ -492,6 +492,26 @@ describe("artworksConnection", () => {
       ])
     })
 
+    it("uses the unauthenticated loader when filtering with *-*", async () => {
+      const query = gql`
+        {
+          artworksConnection(first: 1, priceRange: "*-*") {
+            edges {
+              node {
+                slug
+              }
+            }
+          }
+        }
+      `
+
+      const { artworksConnection } = await runQuery(query, context)
+
+      expect(artworksConnection.edges).toEqual([
+        { node: { slug: "unauthenticated-loader-artwork-id" } },
+      ])
+    })
+
     it("uses the unauthenticated loader otherwise", async () => {
       const query = gql`
         {

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -548,7 +548,8 @@ const filterArtworksConnectionTypeFactory = (
       const isSortingByPrice = ["-prices", "prices"].includes(
         gravityOptions.sort
       )
-      const isFilteringByPrice = !!gravityOptions.price_range
+      const isFilteringByPrice =
+        !!gravityOptions.price_range && gravityOptions.priceRange !== "*-*"
       const isFilteringBySale = !!gravityOptions.sale_id
       if ((isSortingByPrice || isFilteringByPrice) && isFilteringBySale) {
         loader = filterArtworksUncachedLoader


### PR DESCRIPTION
As a follow-up to https://github.com/artsy/metaphysics/pull/5194 , let's require a `priceRange` which is truthy and _not_ `*-*` (as that's not really filtering by price at all and so we don't need to skip the cache for 'real-time' results).