### PR TITLE
feat: add currency filter and currencies aggregation for Auction Results

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1367,7 +1367,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     categories: [String]
 
     # Currency code
-    currency: String!
+    currency: String
 
     # Filter auction results by earliest created at year
     earliestCreatedYear: Int

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1356,7 +1356,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   auctionResultsConnection(
     after: String
 
-    # Lits of aggregations fot auction results
+    # List of aggregations for auction results
     aggregations: [AuctionResultsAggregation]
 
     # Allow auction results with empty created date values
@@ -1365,6 +1365,9 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
 
     # Filter auction results by category (medium)
     categories: [String]
+
+    # Currency code
+    currency: String!
 
     # Filter auction results by earliest created at year
     earliestCreatedYear: Int
@@ -2863,6 +2866,7 @@ type AuctionResultPriceRealized {
 }
 
 enum AuctionResultsAggregation {
+  CURRENCIES_COUNT
   SIMPLE_PRICE_HISTOGRAM
 }
 

--- a/src/schema/v2/aggregations/filterAuctionResultsAggregation.ts
+++ b/src/schema/v2/aggregations/filterAuctionResultsAggregation.ts
@@ -9,6 +9,9 @@ export const AuctionResultsAggregation = new GraphQLEnumType({
     SIMPLE_PRICE_HISTOGRAM: {
       value: "simple_price_histogram",
     },
+    CURRENCIES_COUNT: {
+      value: "currencies_count",
+    },
   },
 })
 

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -242,7 +242,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
           },
           aggregations: {
             type: new GraphQLList(AuctionResultsAggregation),
-            description: "Lits of aggregations fot auction results",
+            description: "List of aggregations for auction results",
           },
           includeEstimateRange: {
             type: GraphQLBoolean,
@@ -254,6 +254,10 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
             type: GraphQLBoolean,
             defaultValue: true,
             description: "Includes auction results without price",
+          },
+          currency: {
+            type: new GraphQLNonNull(GraphQLString),
+            description: "Currency code",
           },
           sort: AuctionResultSorts,
           state: AuctionResultsState,

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -256,7 +256,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
             description: "Includes auction results without price",
           },
           currency: {
-            type: new GraphQLNonNull(GraphQLString),
+            type: GraphQLString,
             description: "Currency code",
           },
           sort: AuctionResultSorts,

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -288,6 +288,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
             allow_empty_created_dates: options.allowEmptyCreatedDates,
             artist_id: _id,
             categories,
+            currency: options.currency,
             earliest_created_year: options.earliestCreatedYear,
             keyword: options.keyword,
             latest_created_year: options.latestCreatedYear,


### PR DESCRIPTION
This PR enhances the Auction Results functionality by adding a currency filtering and aggregations option. This allows users to filter and view auction results specific to certain currencies.

![Screenshot 2023-08-08 at 15 27 12](https://github.com/artsy/metaphysics/assets/1176374/7446c867-ec31-4055-a496-0610e152633a)

[Diffusion PR](https://github.com/artsy/diffusion/pull/772)

cc @artsy/diamond-devs 
