### PR TITLE
fix: Prevent sorting partners by distance without provided location param

### DIFF
--- a/src/schema/v2/partner/partners.ts
+++ b/src/schema/v2/partner/partners.ts
@@ -19,6 +19,8 @@ import PartnerTypeType from "schema/v2/input_fields/partner_type_type"
 import Partner, { PartnerType } from "schema/v2/partner/partner"
 import { ResolverContext } from "types/graphql"
 
+const DISTANCE_FALLBACK_SORT = "-created_at"
+
 export const Partners: GraphQLFieldConfig<void, ResolverContext> = {
   type: new GraphQLList(Partner.type),
   description: "A list of Partners",
@@ -230,7 +232,9 @@ export const PartnersConnection: GraphQLFieldConfig<void, ResolverContext> = {
 
     // Do not sort by distance if a location is not provided because it's not supported by Gravity
     const sort =
-      args.sort == "distance" && !locationArgs.near ? "-created_at" : args.sort
+      args.sort == "distance" && !locationArgs.near
+        ? DISTANCE_FALLBACK_SORT
+        : args.sort
 
     const options = {
       id: args.ids,

--- a/src/schema/v2/partner/partners.ts
+++ b/src/schema/v2/partner/partners.ts
@@ -228,6 +228,10 @@ export const PartnersConnection: GraphQLFieldConfig<void, ResolverContext> = {
       requestLocationLoader,
     })
 
+    // Do not sort by distance if a location is not provided because it's not supported by Gravity
+    const sort =
+      args.sort == "distance" && !locationArgs.near ? "-created_at" : args.sort
+
     const options = {
       id: args.ids,
       page,
@@ -237,7 +241,7 @@ export const PartnersConnection: GraphQLFieldConfig<void, ResolverContext> = {
       include_partners_with_followed_artists:
         args.includePartnersWithFollowedArtists,
       default_profile_public: args.defaultProfilePublic,
-      sort: args.sort,
+      sort,
       partner_categories: args.partnerCategories,
       type: args.type,
       total_count: true,


### PR DESCRIPTION
## Description

We need to prevent sorting partners by distance when no location is provided in the following query (because Gravity expects the `near` param when sorting by distance). This case can happen when the IP-based location lookup fails ([Slack Thread](https://artsy.slack.com/archives/C02BAQ5K7/p1691567528217389)).

```graphql
{
  partnersConnection(
    maxDistance: 10
    type: GALLERY
    eligibleForListing: true
    excludeFollowedPartners: false
    defaultProfilePublic: false
    sort: DISTANCE
  ) {
    edges {
      node {
        internalID
      }
    }
  }
}
```

Gravity returns the following error when sorting by `location` without providing `near`:

```
 when `near` param is not provided and ip based location lookup fails › returns a list of partners without sending `distance` param
 ```
 
 **Open Question:**

This could also be fixed in Gravity by defaulting to another sorting when `near` is not provided, but I think Metaphysics is the right place to fix this because it's where the IP-based location lookup happens (which can fail).