### PR TITLE
fix: display recent shows from the last 3 years only

### DIFF
--- a/src/schema/v2/artist/__tests__/helpers.test.ts
+++ b/src/schema/v2/artist/__tests__/helpers.test.ts
@@ -176,9 +176,9 @@ describe("getArtistInsights", () => {
     const field = {
       kind: "RECENT_CAREER_EVENT",
       artist: {
-        recent_show: "2/2/2021|ai-weiwei|Solo|Gagosian Gallery",
+        recent_show: "2/2/2030|ai-weiwei|Solo|Gagosian Gallery",
       },
-      value: "2021 Gagosian Gallery",
+      value: "2030 Gagosian Gallery",
     }
 
     it("returns recent career event insights", () => {
@@ -210,12 +210,16 @@ describe("getArtistInsights", () => {
 
   describe("getRecentShow", () => {
     it("returns the most recent show", () => {
-      const artist = {
-        recent_show: "2/2/2021|ai-weiwei|Solo|Gagosian Gallery",
+      const artist1 = {
+        recent_show: "2/2/2030|ai-weiwei|Solo|Gagosian Gallery",
       }
 
-      const recentShow = getRecentShow(artist)
-      expect(recentShow).toEqual("2021 Gagosian Gallery")
+      const artist2 = {
+        recent_show: "2/2/2010|ai-weiwei|Solo|Gagosian Gallery",
+      }
+
+      expect(getRecentShow(artist1)).toEqual("2030 Gagosian Gallery")
+      expect(getRecentShow(artist2)).toEqual(null)
     })
 
     it("returns empty array if there empty recent show", () => {

--- a/src/schema/v2/artist/helpers.ts
+++ b/src/schema/v2/artist/helpers.ts
@@ -131,7 +131,7 @@ export const ARTIST_INSIGHT_MAPPING: Record<
   },
   RECENT_CAREER_EVENT: {
     getDescription: (artist) => artist.recent_show && getRecentShow(artist),
-    getEntities: (artist) => artist.recent_show && [],
+    getEntities: (artist) => artist.recent_show && getRecentShow(artist) && [],
     getLabel: () => "Recent Career Event",
   },
   RESIDENCIES: {


### PR DESCRIPTION
Fixes the logic of displaying the recent show and expandable label.
[Slack thread.](https://artsy.slack.com/archives/C03N12SR0RK/p1691579953459749)