### PR TITLE
feat(alerts): expose displayName under stitched SearchCriteria GraphQL type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16721,6 +16721,7 @@ type SearchCriteria {
   attributionClass: [String!]!
   colors: [String!]!
   dimensionRange: String
+  displayName: String
   height: String
   href: String!
   inquireableOnly: Boolean

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16721,7 +16721,7 @@ type SearchCriteria {
   attributionClass: [String!]!
   colors: [String!]!
   dimensionRange: String
-  displayName: String
+  displayName: String!
   height: String
   href: String!
   inquireableOnly: Boolean

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -10,6 +10,7 @@ import { toGlobalId } from "graphql-relay"
 import { printType } from "lib/stitching/lib/printType"
 import { dateRange } from "lib/date"
 import { resolveSearchCriteriaLabels } from "schema/v2/searchCriteriaLabel"
+import { generateDisplayName } from "schema/v2/previewSavedSearch"
 
 const LocaleEnViewingRoomRelativeShort = "en-viewing-room-relative-short"
 defineCustomLocale(LocaleEnViewingRoomRelativeShort, {
@@ -83,6 +84,7 @@ export const gravityStitchingEnvironment = (
         ): UserAddressConnection
       }
       extend type SearchCriteria {
+        displayName: String!
         labels: [SearchCriteriaLabel!]!
       }
       extend type UserAddress {
@@ -1033,6 +1035,34 @@ export const gravityStitchingEnvironment = (
         },
       },
       SearchCriteria: {
+        displayName: {
+          fragment: gql`
+            ... on SearchCriteria {
+              ... on SearchCriteria {
+                artistIDs
+                attributionClass
+                additionalGeneIDs
+                priceRange
+                sizes
+                width
+                height
+                acquireable
+                atAuction
+                inquireableOnly
+                offerable
+                materialsTerms
+                locationCities
+                majorPeriods
+                colors
+                partnerIDs
+              }
+              userAlertSettings {
+                name
+              }
+            }
+          `,
+          resolve: generateDisplayName,
+        },
         labels: {
           fragment: gql`
             ... on SearchCriteria {

--- a/src/schema/v2/__tests__/previewSavedSearch.test.ts
+++ b/src/schema/v2/__tests__/previewSavedSearch.test.ts
@@ -255,6 +255,26 @@ describe("previewSavedSearch", () => {
           "KAWS — New York, NY, USA, Foo Bar Gallery"
         )
       })
+
+      it("generates a name with only artist specified in the alert criteria", async () => {
+        const query = gql`
+          {
+            previewSavedSearch(attributes: { artistIDs: ["kaws"] }) {
+              displayName
+            }
+          }
+        `
+
+        const artistLoader = jest
+          .fn()
+          .mockReturnValueOnce(Promise.resolve({ name: "KAWS" }))
+
+        const { previewSavedSearch } = await runQuery(query, {
+          artistLoader,
+        })
+
+        expect(previewSavedSearch.displayName).toEqual("KAWS")
+      })
     })
   })
 })

--- a/src/schema/v2/previewSavedSearch.ts
+++ b/src/schema/v2/previewSavedSearch.ts
@@ -107,6 +107,8 @@ export const PreviewSavedSearchField: GraphQLFieldConfig<
 }
 
 export const generateDisplayName = async (parent, args, context, info) => {
+  if (parent?.userAlertSettings?.name) return parent?.userAlertSettings?.name
+
   const labels = await resolveSearchCriteriaLabels(parent, args, context, info)
 
   // artist always

--- a/src/schema/v2/previewSavedSearch.ts
+++ b/src/schema/v2/previewSavedSearch.ts
@@ -106,7 +106,7 @@ export const PreviewSavedSearchField: GraphQLFieldConfig<
   },
 }
 
-const generateDisplayName = async (parent, args, context, info) => {
+export const generateDisplayName = async (parent, args, context, info) => {
   const labels = await resolveSearchCriteriaLabels(parent, args, context, info)
 
   // artist always
@@ -167,7 +167,7 @@ const generateDisplayName = async (parent, args, context, info) => {
     return labels.map((label) => label.displayValue).join(" or ")
   })
   const [artist, ...others] = displayValues
-  let result = [artist, others.join(", ")].join(" — ")
+  let result = [artist, others.join(", ")].join(others.length > 0 ? " — " : "")
 
   const remainingCount = allLabels.length - useableLabels.length
   if (remainingCount > 0) result += ` + ${remainingCount} more`


### PR DESCRIPTION
Repurposes the generated display name used for previewSavedSearch for additional use under the existing SearchCriteria type, currently stitched from Gravity's GraphQL schema.

This will allow us to render this generated default/fallback name when the user has not supplied their own custom name for the alert.

Follow-up to #5186.

Jira: [ONYX-234](https://artsyproduct.atlassian.net/browse/ONYX-234)

## Example

```graphql
{
  previewSavedSearch(attributes: { artistIDs: ["andy-warhol"], priceRange: "0-50000", attributionClass: ["unique"] }) {
    displayName
  }
  me {
    email // quirk to get the following stitched query to execute
    savedSearchesConnection(first: 5) {
      edges {
        node {
          displayName
        }
      }
    }
  }
}
```

```json
{
  "data": {
    "previewSavedSearch": {
      "displayName": "Andy Warhol — $0–$50,000, Unique"
    },
    "me": {
      "email": "devon@example.com",
      "savedSearchesConnection": {
        "edges": [
          {
            "node": {
              "displayName": "Andy Warhol — $0-50,000, Unique"
            }
          }
        ]
      }
    }
  },
```

[ONYX-234]: https://artsyproduct.atlassian.net/browse/ONYX-234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ