### PR TITLE
chore: Add more fields to artist update mutation DIA-22

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17784,13 +17784,19 @@ type UpdateArtistFailure {
 }
 
 input UpdateArtistMutationInput {
+  alternateNames: [String!]
+  birthday: String
   clientMutationId: String
   coverArtworkId: String
+  deathday: String
   displayName: String
   first: String
+  gender: String
+  hometown: String
   id: String!
   last: String
   middle: String
+  nationality: String
 }
 
 type UpdateArtistMutationPayload {

--- a/src/schema/v2/artist/updateArtistMutation.ts
+++ b/src/schema/v2/artist/updateArtistMutation.ts
@@ -1,4 +1,5 @@
 import {
+  GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
@@ -14,21 +15,50 @@ import {
 } from "lib/gravityErrorHandler"
 
 interface Input {
+  alternateNames: string[]
+  birthday?: string
   coverArtworkId?: string
+  deathday?: string
   displayName?: string
   first?: string
+  gender?: string
+  hometown?: string
   id: string
   last?: string
+  location?: string
   middle?: string
+  nationality?: string
+}
+
+const inputFields = {
+  alternateNames: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) },
+  birthday: { type: GraphQLString },
+  coverArtworkId: { type: GraphQLString },
+  deathday: { type: GraphQLString },
+  displayName: { type: GraphQLString },
+  first: { type: GraphQLString },
+  gender: { type: GraphQLString },
+  hometown: { type: GraphQLString },
+  id: { type: new GraphQLNonNull(GraphQLString) },
+  last: { type: GraphQLString },
+  middle: { type: GraphQLString },
+  nationality: { type: GraphQLString },
 }
 
 interface GravityInput {
+  alternate_names: string[]
+  birthday?: string
   cover_artwork_id?: string
+  deathday?: string
   display_name?: string
   first?: string
+  gender?: string
+  hometown?: string
   id: string
   last?: string
+  location?: string
   middle?: string
+  nationality?: string
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
@@ -65,14 +95,7 @@ export const updateArtistMutation = mutationWithClientMutationId<
 >({
   name: "UpdateArtistMutation",
   description: "Update the artist",
-  inputFields: {
-    coverArtworkId: { type: GraphQLString },
-    displayName: { type: GraphQLString },
-    first: { type: GraphQLString },
-    id: { type: new GraphQLNonNull(GraphQLString) },
-    last: { type: GraphQLString },
-    middle: { type: GraphQLString },
-  },
+  inputFields,
   outputFields: {
     artistOrError: {
       type: ResponseOrErrorType,


### PR DESCRIPTION
In order to support migrating more fields to the Forque artist edit page this PR adds more fields to the input type in the update mutation. Note that I was very confused about why adding the fields to the interfaces wasn't enough so I pulled up the actual `inputFields` too. This makes it even easier to see that when you add a field you have to add it in three places. :hurtrealbad: 

https://artsyproduct.atlassian.net/browse/DIA-22

/cc @artsy/diamond-devs