### PR TITLE
chore: remove double fragment spread in gravity stitching

### DIFF
--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -1038,24 +1038,23 @@ export const gravityStitchingEnvironment = (
         displayName: {
           fragment: gql`
             ... on SearchCriteria {
-              ... on SearchCriteria {
-                artistIDs
-                attributionClass
-                additionalGeneIDs
-                priceRange
-                sizes
-                width
-                height
-                acquireable
-                atAuction
-                inquireableOnly
-                offerable
-                materialsTerms
-                locationCities
-                majorPeriods
-                colors
-                partnerIDs
-              }
+              artistIDs
+              attributionClass
+              additionalGeneIDs
+              priceRange
+              sizes
+              width
+              height
+              acquireable
+              atAuction
+              inquireableOnly
+              offerable
+              materialsTerms
+              locationCities
+              majorPeriods
+              colors
+              partnerIDs
+
               userAlertSettings {
                 name
               }


### PR DESCRIPTION
I unintentionally doubled the fragment spread in [#5201][pr]. This removes that extra weirdness, beyond the standard GraphQL stitching weirdness!

> Why the double ... on SearchCriteria?

Caught by @mzikherman via https://github.com/artsy/gravity/pull/16660#issuecomment-1679035552.

[pr]: https://github.com/artsy/metaphysics/pull/5201

cc/ @anandaroop  @mzikherman 