### PR TITLE
feat(ONYX-259): Allow admins to query a user's My Collection artworks

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -18739,6 +18739,12 @@ type User implements Node {
 
   # The given location of the user as structured data
   location: Location
+  myCollectionArtworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
 
   # The given name of the user.
   name: String!

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -466,6 +466,11 @@ export default (accessToken, userID, opts) => {
       { headers: true }
     ),
     meShowsLoader: gravityLoader("me/shows", {}, { headers: true }),
+    myCollectionArtworksLoader: gravityLoader(
+      "collection/my-collection/artworks",
+      {},
+      { headers: true }
+    ),
     notificationPreferencesLoader: gravityLoader("notification_preferences"),
     notificationsFeedLoader: gravityLoader("me/notifications/feed"),
     pageLoader: gravityLoader((id) => `page/${id}`),


### PR DESCRIPTION
This PR resolves [ONYX-259]

- Related Forque PR: https://github.com/artsy/forque/pull/956
- Slack Thread for context: https://artsy.slack.com/archives/C05EQL4R5N0/p1692288587491529

## Description


This PR exposes a user's My Collection artworks under `user` ([similar to `savedArtworksConnection`](https://github.com/artsy/metaphysics/pull/4363)).

The new connection will be used to display a user's My Collection artworks in in Forque (for user's with the role `customer_support` only).

```graphql
{
  user(id: "blah") {
    myCollectionArtworksConnection(first: 10) {
      totalCount
      edges {
        node {
          title
        }
      }
    }
  }
}
```

[ONYX-259]: https://artsyproduct.atlassian.net/browse/ONYX-259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ