### PR TITLE
chore: use an authenticated loader for search to be able to use unleash on the backend

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1,6 +1,7 @@
 import { gravityGraphQL } from "lib/apis/gravityGraphQL"
 import trackedEntityLoaderFactory from "lib/loaders/loaders_with_authentication/tracked_entity"
 import factories from "../api"
+import { searchLoader } from "../searchLoader"
 
 export default (accessToken, userID, opts) => {
   const gravityAccessTokenLoader = () => Promise.resolve(accessToken)
@@ -612,6 +613,7 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    searchLoader: searchLoader(gravityLoader),
     sendConfirmationEmailLoader: gravityLoader(
       "me/confirmation_emails",
       {},


### PR DESCRIPTION
We want to do some user-specific stuff in Gravity as a result of an auto-suggest query (such as use an Unleash flag that is user-specific / AB test).

This means that we need to use an authenticated loader (and skip caching unfort!) for search.