### PR TITLE
feat: improve sending of sale end date params

### DIFF
--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -316,9 +316,11 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
             sizes,
             sort: options.sort,
             state: options.state,
-            sale_start_year: options.saleStartYear,
-            sale_end_year: options.saleEndYear,
             allow_unspecified_sale_dates: options.allowUnspecifiedSaleDates,
+            ...(options.saleStartYear && {
+              sale_start_year: options.saleStartYear,
+            }),
+            ...(options.saleEndYear && { sale_end_year: options.saleEndYear }),
           }
 
           const requests = [auctionLotsLoader(diffusionArgs)]


### PR DESCRIPTION
This PR addresses an issue where null values were causing parameter exceptions in the diffusion. It has been observed that when nulls are sent, they are being converted to empty strings "", leading to unexpected behavior. 
To resolve this, we've enhanced the parameter handling logic to exclude sending parameters when they are null. 

cc @artsy/diamond-devs 