### PR TITLE
feat: add suggestedArtworksConnection for a saved search on Artwork type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2319,6 +2319,9 @@ type Artwork implements Node & Searchable & Sellable {
   sale: Sale
   saleArtwork(saleID: String = null): SaleArtwork
   saleMessage: String
+
+  # Schema related to saved searches based on this artwork
+  savedSearch: ArtworkSavedSearch
   series(format: Format): String
 
   # The country an artwork will be shipped from.
@@ -2595,6 +2598,16 @@ type ArtworkPriceInsights {
 type ArtworksAggregationResults {
   counts: [AggregationCount]
   slice: ArtworkAggregation
+}
+
+type ArtworkSavedSearch {
+  # Based on the artworks attributes (usually considered for saved searches).
+  suggestedArtworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
 }
 
 type ArtworksCollectionsBatchUpdateCounts {


### PR DESCRIPTION
[Jira ticket](https://artsyproduct.atlassian.net/browse/ONYX-264)

<img width="1203" alt="Screen Shot 2023-08-24 at 1 16 17 PM" src="https://github.com/artsy/metaphysics/assets/1457859/a7eb7f44-863a-4034-bdca-ba972faa2a41">

Enables queries like this - which I think should be helpful to Force/Eigen in order to get the suggested artworks shelf (as well as the count, to know whether or not to even include it at all).