### PR TITLE
feat: if query body contains the string "mutation", skip cache for gravity loaders

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -171,6 +171,7 @@ const graphqlServer = graphqlHTTP((req, res, params) => {
     userAgent,
     appToken,
     xOriginalSessionID,
+    isMutation: !!req.body?.query?.includes("mutation"),
   })
 
   const context: ResolverContext = {

--- a/src/lib/loaders/api/index.ts
+++ b/src/lib/loaders/api/index.ts
@@ -34,6 +34,11 @@ export interface APIOptions {
 
   /** This only applies to caching loaders */
   requestThrottleMs?: number
+
+  // Is this loader being used during a request that includes a mutation?
+  // If so, loaders can skip the cache (even if they typically would cache).
+  // This is to ensure any fetched data in the mutation response is fresh.
+  isMutation?: boolean
 }
 
 export interface DataLoaderKey {
@@ -121,6 +126,7 @@ export default (opts) => ({
       requestIDs: opts.requestIDs,
       userAgent: opts.userAgent,
       appToken: opts.appToken,
+      isMutation: opts.isMutation,
     }
   ),
 

--- a/src/lib/loaders/api/loader_without_authentication_factory.ts
+++ b/src/lib/loaders/api/loader_without_authentication_factory.ts
@@ -110,7 +110,8 @@ export const apiLoaderWithoutAuthenticationFactory = <T = any>(
             const skipCache =
               CACHE_DISABLED ||
               (apiOptions.method &&
-                ["PUT", "POST", "DELETE"].includes(apiOptions.method))
+                ["PUT", "POST", "DELETE"].includes(apiOptions.method)) ||
+              apiOptions.isMutation
 
             if (skipCache) {
               return callApi()


### PR DESCRIPTION
This is what we were discussing in Slack - that the mutation schema for a response can sometimes resolve with the changed data (when it's literally the response of the upstream POST/PUT/DELETE) - but sometimes there's a mutation schema which includes fields which make other fetches, and in that mutation context we'd likely always want to skip the cache.

Thus far, this has probably not ever come up b/c any loaders being invoked in the mutation response skip the cache already (authenticated loaders), _or_ that the mutation response schema returns just the changed object directly, sometimes the parent (which might be ok to cache), or some variation of this.

This might altogether be too clever, and perhaps better served by a `X-Skip-Cache` header that can be added by clients for mutations as needed.

Figured I'd PR for fun - this isn't really that great, mostly b/c of the naive way of checking if there's a mutation happening.