### PR TITLE
feat(searchCriteriaConnection): Connect stitched field to artists and fix bug in artistsConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13664,6 +13664,17 @@ type Partner implements Node {
   profile: Profile
   profileArtistsLayout: String
   profileBannerDisplay: String
+  searchCriteriaConnection(
+    after: String
+    artistID: ID
+    before: String
+    first: Int
+    highQuality: Boolean
+    last: Int
+    partnerID: String
+    previewByArtist: Boolean
+    since: Int
+  ): SearchCriteriaConnection
   showPromoted: Boolean
 
   # A connection of shows from a Partner.
@@ -14578,26 +14589,6 @@ type Query {
 
     # Returns saved searches sorted by input (default: by created date in descending order)
     sort: SavedSearchesSortEnum
-  ): SearchCriteriaConnection
-
-  # List of more general partner facing search criteria data
-  _unused_gravity_searchCriteriaConnection(
-    # Returns the elements in the list that come after the specified cursor.
-    after: String
-    artistID: ID
-
-    # Returns the elements in the list that come before the specified cursor.
-    before: String
-
-    # Returns the first _n_ elements from the list.
-    first: Int
-    highQuality: Boolean
-
-    # Returns the last _n_ elements from the list.
-    last: Int
-    partnerID: ID
-    previewByArtist: Boolean
-    since: Int
   ): SearchCriteriaConnection
 
   # List enabled Two-Factor Authentication factors
@@ -15731,6 +15722,26 @@ type Query {
     # Search query to perform. Required.
     query: String!
   ): SearchableConnection
+
+  # List of more general partner facing search criteria data
+  searchCriteriaConnection(
+    # Returns the elements in the list that come after the specified cursor.
+    after: String
+    artistID: ID
+
+    # Returns the elements in the list that come before the specified cursor.
+    before: String
+
+    # Returns the first _n_ elements from the list.
+    first: Int
+    highQuality: Boolean
+
+    # Returns the last _n_ elements from the list.
+    last: Int
+    partnerID: ID
+    previewByArtist: Boolean
+    since: Int
+  ): SearchCriteriaConnection
   shortcut(id: ID!): Shortcut
 
   # A Show

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14591,6 +14591,26 @@ type Query {
     sort: SavedSearchesSortEnum
   ): SearchCriteriaConnection
 
+  # List of more general partner facing search criteria data
+  _unused_gravity_searchCriteriaConnection(
+    # Returns the elements in the list that come after the specified cursor.
+    after: String
+    artistID: ID
+
+    # Returns the elements in the list that come before the specified cursor.
+    before: String
+
+    # Returns the first _n_ elements from the list.
+    first: Int
+    highQuality: Boolean
+
+    # Returns the last _n_ elements from the list.
+    last: Int
+    partnerID: ID
+    previewByArtist: Boolean
+    since: Int
+  ): SearchCriteriaConnection
+
   # List enabled Two-Factor Authentication factors
   _unused_gravity_secondFactors(
     kinds: [SecondFactorKind!] = [app, sms, backup]
@@ -15722,26 +15742,6 @@ type Query {
     # Search query to perform. Required.
     query: String!
   ): SearchableConnection
-
-  # List of more general partner facing search criteria data
-  searchCriteriaConnection(
-    # Returns the elements in the list that come after the specified cursor.
-    after: String
-    artistID: ID
-
-    # Returns the elements in the list that come before the specified cursor.
-    before: String
-
-    # Returns the first _n_ elements from the list.
-    first: Int
-    highQuality: Boolean
-
-    # Returns the last _n_ elements from the list.
-    last: Int
-    partnerID: ID
-    previewByArtist: Boolean
-    since: Int
-  ): SearchCriteriaConnection
   shortcut(id: ID!): Shortcut
 
   # A Show
@@ -16812,6 +16812,15 @@ type SearchCriteria {
   additionalGeneIDs: [String!]!
   artistID: String @deprecated(reason: "Deprecated in favor of artistIDs array")
   artistIDs: [String!]
+  artistsConnection(
+    after: String
+    before: String
+    first: Int
+    ids: [String]
+    last: Int
+    sort: ArtistSorts
+    term: String
+  ): ArtistConnection
   atAuction: Boolean
   attributionClass: [String!]!
   colors: [String!]!

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -1045,6 +1045,44 @@ describe("gravity/stitching", () => {
     })
   })
 
+  describe("SearchCriteria", () => {
+    it("extends the SearchCriteria type with an artistsConnection field", async () => {
+      const mergedSchema = await getGravityMergedSchema()
+      const searchCriteriaFields = await getFieldsForTypeFromSchema(
+        "SearchCriteria",
+        mergedSchema
+      )
+      expect(searchCriteriaFields).toContain("artistsConnection")
+    })
+
+    it("resolves the artistsConnection field", async () => {
+      const { resolvers } = await getGravityStitchedSchema()
+      const { artistsConnection } = resolvers.SearchCriteria
+      const info = { mergeInfo: { delegateToSchema: jest.fn() } }
+
+      artistsConnection.resolve(
+        { artistIDs: ["abc123", "foo"] },
+        { first: 2 },
+        {},
+        info
+      )
+
+      expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith(
+        expect.objectContaining({
+          args: {
+            ids: ["abc123", "foo"],
+            first: 2,
+          },
+          operation: "query",
+          fieldName: "artistsConnection",
+          schema: expect.anything(),
+          context: expect.anything(),
+          info: expect.anything(),
+        })
+      )
+    })
+  })
+
   describe("MarketingCollection", () => {
     describe("artworksConnection", () => {
       it("extends the MarketingCollection type with an artworksConnection field for the V2 schema", async () => {

--- a/src/lib/stitching/gravity/schema.ts
+++ b/src/lib/stitching/gravity/schema.ts
@@ -10,14 +10,14 @@ import { readFileSync } from "fs"
 
 const allowList = [
   "agreement",
-  "curatedMarketingCollections",
-  "viewingRoom",
-  "viewingRooms",
   "artistSeries",
   "artistSeriesConnection",
+  "curatedMarketingCollections",
+  "marketingCategories",
   "marketingCollection",
   "marketingCollections",
-  "marketingCategories",
+  "viewingRoom",
+  "viewingRooms",
 ]
 
 export const executableGravitySchema = () => {

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -164,6 +164,15 @@ export const gravityStitchingEnvironment = (
       }
 
       extend type SearchCriteria {
+        artistsConnection(
+          first: Int,
+          last: Int,
+          before: String,
+          after: String,
+          ids: [String],
+          sort: ArtistSorts,
+          term: String
+        ): ArtistConnection
         displayName: String!
         labels: [SearchCriteriaLabel!]!
       }
@@ -739,6 +748,26 @@ export const gravityStitchingEnvironment = (
         },
       },
       SearchCriteria: {
+        artistsConnection: {
+          fragment: gql`
+            ... on SearchCriteria {
+              artistIDs
+            }
+          `,
+          resolve: ({ artistIDs }, args, context, info) => {
+            return info.mergeInfo.delegateToSchema({
+              schema: localSchema,
+              operation: "query",
+              fieldName: "artistsConnection",
+              args: {
+                ids: artistIDs,
+                ...args,
+              },
+              context,
+              info,
+            })
+          },
+        },
         displayName: {
           fragment: gql`
             ... on SearchCriteria {

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -144,6 +144,18 @@ export const gravityStitchingEnvironment = (
       }
 
       extend type Partner {
+        searchCriteriaConnection(
+          first: Int,
+          last: Int,
+          before: String,
+          after: String,
+          artistID: ID,
+          highQuality: Boolean,
+          partnerID: String,
+          previewByArtist: Boolean
+          since: Int
+        ): SearchCriteriaConnection
+
         viewingRoomsConnection(first: Int, after: String, statuses: [ViewingRoomStatusEnum!]): ViewingRoomsConnection
       }
 
@@ -653,6 +665,26 @@ export const gravityStitchingEnvironment = (
         },
       },
       Partner: {
+        searchCriteriaConnection: {
+          fragment: gql`
+          ... on Partner {
+            internalID
+          }
+        `,
+          resolve: ({ internalID: partnerID }, args, context, info) => {
+            return info.mergeInfo.delegateToSchema({
+              schema: gravitySchema,
+              operation: "query",
+              fieldName: "_unused_gravity_searchCriteriaConnection",
+              args: {
+                partnerID,
+                ...args,
+              },
+              context,
+              info,
+            })
+          },
+        },
         viewingRoomsConnection: {
           fragment: gql`
             ... on Partner {

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -66,76 +66,6 @@ export const gravityStitchingEnvironment = (
   return {
     // The SDL used to declare how to stitch an object
     extensionSchema: gql`
-      extend type Me {
-        savedSearch(id: ID, criteria: SearchCriteriaAttributes): SearchCriteria
-        savedSearchesConnection(
-          first: Int
-          last: Int
-          after: String
-          before: String
-          sort: SavedSearchesSortEnum
-        ): SearchCriteriaConnection
-        secondFactors(kinds: [SecondFactorKind]): [SecondFactor]
-        addressConnection(
-          first: Int
-          last: Int
-          after: String
-          before: String
-        ): UserAddressConnection
-      }
-      extend type SearchCriteria {
-        displayName: String!
-        labels: [SearchCriteriaLabel!]!
-      }
-      extend type UserAddress {
-        id: ID!
-      }
-      extend type User {
-        devices: [Device!]!
-      }
-      extend type ViewingRoom {
-        artworksConnection(
-          first: Int
-          last: Int
-          after: String
-          before: String
-        ): ArtworkConnection
-        partnerArtworksConnection(
-          first: Int
-          last: Int
-          after: String
-          before: String
-        ): ArtworkConnection
-        distanceToOpen(short: Boolean! = false): String
-        distanceToClose(short: Boolean! = false): String
-        partner: Partner
-        exhibitionPeriod: String
-      }
-
-      extend type ArtistSeries {
-        artists(page: Int, size: Int): [Artist]
-        image: Image
-        artworksConnection(first: Int, after: String): ArtworkConnection
-        filterArtworksConnection(${argsToSDL(
-          pageableFilterArtworksArgsWithInput
-        ).join("\n")}): FilterArtworksConnection
-
-        descriptionFormatted(format: Format): String
-        """
-        A formatted string that shows the number of available works or
-        (as a fallback) the number of works in general.
-        """
-        artworksCountMessage: String
-      }
-
-      extend type Partner {
-        viewingRoomsConnection(first: Int, after: String, statuses: [ViewingRoomStatusEnum!]): ViewingRoomsConnection
-      }
-
-      extend type Show {
-        viewingRoomsConnection: ViewingRoomsConnection
-      }
-
       extend type Artist {
         artistSeriesConnection(
           first: Int
@@ -160,6 +90,103 @@ export const gravityStitchingEnvironment = (
           ): ArtistSeriesConnection
       }
 
+      extend type ArtistSeries {
+        artists(page: Int, size: Int): [Artist]
+        image: Image
+        artworksConnection(first: Int, after: String): ArtworkConnection
+        filterArtworksConnection(${argsToSDL(
+          pageableFilterArtworksArgsWithInput
+        ).join("\n")}): FilterArtworksConnection
+
+        descriptionFormatted(format: Format): String
+        """
+        A formatted string that shows the number of available works or
+        (as a fallback) the number of works in general.
+        """
+        artworksCountMessage: String
+      }
+
+      extend type Fair {
+        marketingCollections(size: Int): [MarketingCollection]!
+      }
+
+      extend type HomePage {
+        marketingCollectionsModule: HomePageMarketingCollectionsModule
+      }
+
+      type HomePageMarketingCollectionsModule {
+        results: [MarketingCollection]!
+      }
+
+      extend type MarketingCollection {
+        thumbnailImage: Image
+        artworksConnection(${argsToSDL(
+          pageableFilterArtworksArgsWithInput
+        ).join("\n")}): FilterArtworksConnection
+      }
+
+      extend type Me {
+        savedSearch(id: ID, criteria: SearchCriteriaAttributes): SearchCriteria
+        savedSearchesConnection(
+          first: Int
+          last: Int
+          after: String
+          before: String
+          sort: SavedSearchesSortEnum
+        ): SearchCriteriaConnection
+        secondFactors(kinds: [SecondFactorKind]): [SecondFactor]
+        addressConnection(
+          first: Int
+          last: Int
+          after: String
+          before: String
+        ): UserAddressConnection
+      }
+
+      extend type Partner {
+        viewingRoomsConnection(first: Int, after: String, statuses: [ViewingRoomStatusEnum!]): ViewingRoomsConnection
+      }
+
+      extend type Query {
+        curatedMarketingCollections(size: Int): [MarketingCollection]
+      }
+
+      extend type SearchCriteria {
+        displayName: String!
+        labels: [SearchCriteriaLabel!]!
+      }
+
+      extend type Show {
+        viewingRoomsConnection: ViewingRoomsConnection
+      }
+
+      extend type UserAddress {
+        id: ID!
+      }
+
+      extend type User {
+        devices: [Device!]!
+      }
+
+      extend type ViewingRoom {
+        artworksConnection(
+          first: Int
+          last: Int
+          after: String
+          before: String
+        ): ArtworkConnection
+        partnerArtworksConnection(
+          first: Int
+          last: Int
+          after: String
+          before: String
+        ): ArtworkConnection
+        distanceToOpen(short: Boolean! = false): String
+        distanceToClose(short: Boolean! = false): String
+        partner: Partner
+        exhibitionPeriod: String
+      }
+
       extend type Viewer {
         viewingRoomsConnection(first: Int, after: String, statuses: [ViewingRoomStatusEnum!], partnerID: ID): ViewingRoomsConnection
         marketingCollections(
@@ -171,10 +198,7 @@ export const gravityStitchingEnvironment = (
         ): [MarketingCollection]
       }
 
-      extend type Query {
-        curatedMarketingCollections(size: Int): [MarketingCollection]
-      }
-
+      # Mutation Payloads
       extend type CreateUserAddressPayload {
         me: Me
       }
@@ -194,27 +218,245 @@ export const gravityStitchingEnvironment = (
       extend type UpdateUserDefaultAddressPayload {
         me: Me
       }
-
-      extend type Fair {
-        marketingCollections(size: Int): [MarketingCollection]!
-      }
-
-      type HomePageMarketingCollectionsModule {
-        results: [MarketingCollection]!
-      }
-
-      extend type HomePage {
-        marketingCollectionsModule: HomePageMarketingCollectionsModule
-      }
-
-      extend type MarketingCollection {
-        thumbnailImage: Image
-        artworksConnection(${argsToSDL(
-          pageableFilterArtworksArgsWithInput
-        ).join("\n")}): FilterArtworksConnection
-      }
     `,
     resolvers: {
+      Artist: {
+        artistSeriesConnection: {
+          fragment: gql`
+            ... on Artist {
+              internalID
+            }
+          `,
+          resolve: ({ internalID: artistID }, args, context, info) => {
+            return info.mergeInfo.delegateToSchema({
+              schema: gravitySchema,
+              operation: "query",
+              fieldName: "artistSeriesConnection",
+              args: {
+                artistID,
+                ...args,
+                // Exclude the current artist series so that lists of
+                // artist series by the artist don't include the current series
+                // if there is one.
+                ...(!!context.currentArtistSeriesInternalID && {
+                  excludeIDs: [context.currentArtistSeriesInternalID],
+                }),
+              },
+              context,
+              info,
+            })
+          },
+        },
+        marketingCollections: {
+          fragment: `
+              ... on Artist {
+                internalID
+              }
+            `,
+          resolve: ({ internalID: artistID }, args, context, info) => {
+            return info.mergeInfo.delegateToSchema({
+              schema: gravitySchema,
+              operation: "query",
+              fieldName: "marketingCollections",
+              args: {
+                artistID,
+                ...args,
+              },
+              context,
+              info,
+            })
+          },
+        },
+      },
+      Artwork: {
+        artistSeriesConnection: {
+          fragment: gql`
+            ... on Artwork {
+              internalID
+            }
+            `,
+          resolve: ({ internalID: artworkID }, args, context, info) => {
+            return info.mergeInfo.delegateToSchema({
+              schema: gravitySchema,
+              operation: "query",
+              fieldName: "artistSeriesConnection",
+              args: {
+                artworkID,
+                ...args,
+              },
+              context: {
+                ...context,
+                currentArtworkID: artworkID,
+              },
+              info,
+            })
+          },
+        },
+      },
+      ArtistSeries: {
+        artworksConnection: {
+          fragment: gql`
+          ... on ArtistSeries {
+            artworkIDs
+          }
+          `,
+          resolve: async ({ artworkIDs: ids }, _args, context, info) => {
+            // Exclude the current artwork in a series so that lists of
+            // other artworks in the same series don't show the artwork.
+            const filteredIDs = context.currentArtworkID
+              ? ids.filter((id) => id !== context.currentArtworkID)
+              : ids
+            return await info.mergeInfo.delegateToSchema({
+              args: {
+                ids: filteredIDs,
+                ..._args,
+              },
+              schema: localSchema,
+              operation: "query",
+              fieldName: "artworks",
+              context,
+              info,
+            })
+          },
+        },
+        descriptionFormatted: {
+          fragment: gql`
+            ... on ArtistSeries {
+              description
+            }
+          `,
+          resolve: async ({ description }, { format }) => {
+            if (!isExisty(description) || typeof description !== "string")
+              return null
+
+            const { type: formatType } = Format
+            const desiredFormat = formatType
+              ?.getValues()
+              ?.find((e) => e.name === format)?.value
+
+            return formatMarkdownValue(description, desiredFormat)
+          },
+        },
+        artworksCountMessage: {
+          fragment: gql`
+            ... on ArtistSeries {
+              forSaleArtworksCount
+              artworksCount
+            }
+          `,
+          resolve: async ({ forSaleArtworksCount, artworksCount }) => {
+            let artworksCountMessage
+
+            if (forSaleArtworksCount) {
+              artworksCountMessage = `${forSaleArtworksCount} available`
+            } else {
+              artworksCountMessage = `${artworksCount} ${
+                artworksCount === 1 ? "work" : "works"
+              }`
+            }
+
+            return artworksCountMessage
+          },
+        },
+        image: {
+          fragment: gql`
+          ... on ArtistSeries {
+            image_url: imageURL
+            original_height: imageHeight
+            original_width: imageWidth
+            representativeArtworkID
+          }
+          `,
+          resolve: async (
+            {
+              representativeArtworkID,
+              image_url,
+              original_height,
+              original_width,
+            },
+            args,
+            context,
+            info
+          ) => {
+            let imageData: unknown
+            if (image_url) {
+              imageData = {
+                image_url,
+                original_width,
+                original_height,
+              }
+            } else if (representativeArtworkID) {
+              const { artworkLoader } = context
+              const { images } = await artworkLoader(representativeArtworkID)
+              imageData = normalizeImageData(getDefault(images))
+            }
+
+            return info.mergeInfo.delegateToSchema({
+              args,
+              schema: localSchema,
+              operation: "query",
+              fieldName: "_do_not_use_image",
+              context: {
+                ...context,
+                imageData,
+              },
+              info,
+            })
+          },
+        },
+        artists: {
+          fragment: gql`
+          ... on ArtistSeries {
+            artistIDs
+            internalID
+          }
+        `,
+          resolve: ({ artistIDs: ids, internalID }, args, context, info) => {
+            if (ids.length === 0) {
+              return []
+            }
+
+            return info.mergeInfo.delegateToSchema({
+              schema: localSchema,
+              operation: "query",
+              fieldName: "artists",
+              args: {
+                ids,
+                ...args,
+              },
+              context: {
+                ...context,
+                currentArtistSeriesInternalID: internalID,
+              },
+              info,
+            })
+          },
+        },
+
+        filterArtworksConnection: {
+          fragment: `
+          ... on ArtistSeries {
+            internalID
+          }
+        `,
+          resolve: ({ internalID: artistSeriesID }, args, context, info) => {
+            return info.mergeInfo.delegateToSchema({
+              schema: localSchema,
+              operation: "query",
+              fieldName: "artworksConnection",
+              args: {
+                artistSeriesID,
+                ...(!!context.currentArtworkID && {
+                  excludeArtworkIDs: [context.currentArtworkID],
+                }),
+                ...args,
+              },
+              context,
+              info,
+            })
+          },
+        },
+      },
       Fair: {
         marketingCollections: {
           fragment: `
@@ -410,6 +652,137 @@ export const gravityStitchingEnvironment = (
           },
         },
       },
+      Partner: {
+        viewingRoomsConnection: {
+          fragment: gql`
+            ... on Partner {
+              internalID
+            }
+          `,
+          resolve: ({ internalID: partnerID }, args, context, info) => {
+            return info.mergeInfo.delegateToSchema({
+              schema: gravitySchema,
+              operation: "query",
+              fieldName: "_unused_gravity_viewingRoomsConnection",
+              args: {
+                partnerID,
+                ...args,
+              },
+              context,
+              info,
+            })
+          },
+        },
+      },
+      Query: {
+        curatedMarketingCollections: {
+          fragment: gql`
+            ...on Query {
+              __typename
+            }
+          `,
+          resolve: async (_parent, args, context, info) => {
+            try {
+              return await info.mergeInfo.delegateToSchema({
+                schema: gravitySchema,
+                operation: "query",
+                fieldName: "marketingCollections",
+                args: {
+                  slugs: [
+                    "trending-now",
+                    "top-auction-lots",
+                    "new-this-week",
+                    "curators-picks-blue-chip",
+                    "curators-picks-emerging",
+                  ],
+                  ...args,
+                },
+                context,
+                info,
+              })
+            } catch (error) {
+              return []
+            }
+          },
+        },
+      },
+      SearchCriteria: {
+        displayName: {
+          fragment: gql`
+            ... on SearchCriteria {
+              artistIDs
+              attributionClass
+              additionalGeneIDs
+              priceRange
+              sizes
+              width
+              height
+              acquireable
+              atAuction
+              inquireableOnly
+              offerable
+              materialsTerms
+              locationCities
+              majorPeriods
+              colors
+              partnerIDs
+
+              userAlertSettings {
+                name
+              }
+            }
+          `,
+          resolve: generateDisplayName,
+        },
+        labels: {
+          fragment: gql`
+            ... on SearchCriteria {
+              artistIDs
+              attributionClass
+              additionalGeneIDs
+              priceRange
+              sizes
+              width
+              height
+              acquireable
+              atAuction
+              inquireableOnly
+              offerable
+              materialsTerms
+              locationCities
+              majorPeriods
+              colors
+              partnerIDs
+            }
+            `,
+          resolve: resolveSearchCriteriaLabels,
+          description:
+            "Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity",
+        },
+      },
+      Show: {
+        viewingRoomsConnection: {
+          fragment: gql`
+            ... on Show {
+              viewingRoomIDs
+            }
+          `,
+          resolve: ({ viewingRoomIDs: ids }, _args, context, info) => {
+            if (ids.length === 0) return null
+
+            return info.mergeInfo.delegateToSchema({
+              schema: gravitySchema,
+              operation: "query",
+              fieldName: "_unused_gravity_viewingRoomsConnection",
+              args: {
+                ids,
+              },
+              context,
+              info,
+            })
+          },
+        },
+      },
       User: {
         devices: {
           fragment: gql`
@@ -439,170 +812,6 @@ export const gravityStitchingEnvironment = (
           resolve: (parent, _args, _context, _info) => {
             const internalID = parent.internalID
             return toGlobalId("UserAddress", internalID)
-          },
-        },
-      },
-      ArtistSeries: {
-        artworksConnection: {
-          fragment: gql`
-          ... on ArtistSeries {
-            artworkIDs
-          }
-          `,
-          resolve: async ({ artworkIDs: ids }, _args, context, info) => {
-            // Exclude the current artwork in a series so that lists of
-            // other artworks in the same series don't show the artwork.
-            const filteredIDs = context.currentArtworkID
-              ? ids.filter((id) => id !== context.currentArtworkID)
-              : ids
-            return await info.mergeInfo.delegateToSchema({
-              args: {
-                ids: filteredIDs,
-                ..._args,
-              },
-              schema: localSchema,
-              operation: "query",
-              fieldName: "artworks",
-              context,
-              info,
-            })
-          },
-        },
-        descriptionFormatted: {
-          fragment: gql`
-            ... on ArtistSeries {
-              description
-            }
-          `,
-          resolve: async ({ description }, { format }) => {
-            if (!isExisty(description) || typeof description !== "string")
-              return null
-
-            const { type: formatType } = Format
-            const desiredFormat = formatType
-              ?.getValues()
-              ?.find((e) => e.name === format)?.value
-
-            return formatMarkdownValue(description, desiredFormat)
-          },
-        },
-        artworksCountMessage: {
-          fragment: gql`
-            ... on ArtistSeries {
-              forSaleArtworksCount
-              artworksCount
-            }
-          `,
-          resolve: async ({ forSaleArtworksCount, artworksCount }) => {
-            let artworksCountMessage
-
-            if (forSaleArtworksCount) {
-              artworksCountMessage = `${forSaleArtworksCount} available`
-            } else {
-              artworksCountMessage = `${artworksCount} ${
-                artworksCount === 1 ? "work" : "works"
-              }`
-            }
-
-            return artworksCountMessage
-          },
-        },
-        image: {
-          fragment: gql`
-          ... on ArtistSeries {
-            image_url: imageURL
-            original_height: imageHeight
-            original_width: imageWidth
-            representativeArtworkID
-          }
-          `,
-          resolve: async (
-            {
-              representativeArtworkID,
-              image_url,
-              original_height,
-              original_width,
-            },
-            args,
-            context,
-            info
-          ) => {
-            let imageData: unknown
-            if (image_url) {
-              imageData = {
-                image_url,
-                original_width,
-                original_height,
-              }
-            } else if (representativeArtworkID) {
-              const { artworkLoader } = context
-              const { images } = await artworkLoader(representativeArtworkID)
-              imageData = normalizeImageData(getDefault(images))
-            }
-
-            return info.mergeInfo.delegateToSchema({
-              args,
-              schema: localSchema,
-              operation: "query",
-              fieldName: "_do_not_use_image",
-              context: {
-                ...context,
-                imageData,
-              },
-              info,
-            })
-          },
-        },
-        artists: {
-          fragment: gql`
-          ... on ArtistSeries {
-            artistIDs
-            internalID
-          }
-        `,
-          resolve: ({ artistIDs: ids, internalID }, args, context, info) => {
-            if (ids.length === 0) {
-              return []
-            }
-
-            return info.mergeInfo.delegateToSchema({
-              schema: localSchema,
-              operation: "query",
-              fieldName: "artists",
-              args: {
-                ids,
-                ...args,
-              },
-              context: {
-                ...context,
-                currentArtistSeriesInternalID: internalID,
-              },
-              info,
-            })
-          },
-        },
-
-        filterArtworksConnection: {
-          fragment: `
-          ... on ArtistSeries {
-            internalID
-          }
-        `,
-          resolve: ({ internalID: artistSeriesID }, args, context, info) => {
-            return info.mergeInfo.delegateToSchema({
-              schema: localSchema,
-              operation: "query",
-              fieldName: "artworksConnection",
-              args: {
-                artistSeriesID,
-                ...(!!context.currentArtworkID && {
-                  excludeArtworkIDs: [context.currentArtworkID],
-                }),
-                ...args,
-              },
-              context,
-              info,
-            })
           },
         },
       },
@@ -813,156 +1022,8 @@ export const gravityStitchingEnvironment = (
           },
         },
       },
-      Query: {
-        curatedMarketingCollections: {
-          fragment: gql`
-            ...on Query {
-              __typename
-            }
-          `,
-          resolve: async (_parent, args, context, info) => {
-            try {
-              return await info.mergeInfo.delegateToSchema({
-                schema: gravitySchema,
-                operation: "query",
-                fieldName: "marketingCollections",
-                args: {
-                  slugs: [
-                    "trending-now",
-                    "top-auction-lots",
-                    "new-this-week",
-                    "curators-picks-blue-chip",
-                    "curators-picks-emerging",
-                  ],
-                  ...args,
-                },
-                context,
-                info,
-              })
-            } catch (error) {
-              return []
-            }
-          },
-        },
-      },
-      Partner: {
-        viewingRoomsConnection: {
-          fragment: gql`
-            ... on Partner {
-              internalID
-            }
-          `,
-          resolve: ({ internalID: partnerID }, args, context, info) => {
-            return info.mergeInfo.delegateToSchema({
-              schema: gravitySchema,
-              operation: "query",
-              fieldName: "_unused_gravity_viewingRoomsConnection",
-              args: {
-                partnerID,
-                ...args,
-              },
-              context,
-              info,
-            })
-          },
-        },
-      },
-      Show: {
-        viewingRoomsConnection: {
-          fragment: gql`
-            ... on Show {
-              viewingRoomIDs
-            }
-          `,
-          resolve: ({ viewingRoomIDs: ids }, _args, context, info) => {
-            if (ids.length === 0) return null
 
-            return info.mergeInfo.delegateToSchema({
-              schema: gravitySchema,
-              operation: "query",
-              fieldName: "_unused_gravity_viewingRoomsConnection",
-              args: {
-                ids,
-              },
-              context,
-              info,
-            })
-          },
-        },
-      },
-      Artist: {
-        artistSeriesConnection: {
-          fragment: gql`
-            ... on Artist {
-              internalID
-            }
-          `,
-          resolve: ({ internalID: artistID }, args, context, info) => {
-            return info.mergeInfo.delegateToSchema({
-              schema: gravitySchema,
-              operation: "query",
-              fieldName: "artistSeriesConnection",
-              args: {
-                artistID,
-                ...args,
-                // Exclude the current artist series so that lists of
-                // artist series by the artist don't include the current series
-                // if there is one.
-                ...(!!context.currentArtistSeriesInternalID && {
-                  excludeIDs: [context.currentArtistSeriesInternalID],
-                }),
-              },
-              context,
-              info,
-            })
-          },
-        },
-        marketingCollections: {
-          fragment: `
-              ... on Artist {
-                internalID
-              }
-            `,
-          resolve: ({ internalID: artistID }, args, context, info) => {
-            return info.mergeInfo.delegateToSchema({
-              schema: gravitySchema,
-              operation: "query",
-              fieldName: "marketingCollections",
-              args: {
-                artistID,
-                ...args,
-              },
-              context,
-              info,
-            })
-          },
-        },
-      },
-      Artwork: {
-        artistSeriesConnection: {
-          fragment: gql`
-            ... on Artwork {
-              internalID
-            }
-            `,
-          resolve: ({ internalID: artworkID }, args, context, info) => {
-            return info.mergeInfo.delegateToSchema({
-              schema: gravitySchema,
-              operation: "query",
-              fieldName: "artistSeriesConnection",
-              args: {
-                artworkID,
-                ...args,
-              },
-              context: {
-                ...context,
-                currentArtworkID: artworkID,
-              },
-              info,
-            })
-          },
-        },
-      },
+      // Mutations
       CreateUserAddressPayload: {
         me: {
           resolve: (_parent, args, context, info) => {
@@ -1032,60 +1093,6 @@ export const gravityStitchingEnvironment = (
               info,
             })
           },
-        },
-      },
-      SearchCriteria: {
-        displayName: {
-          fragment: gql`
-            ... on SearchCriteria {
-              artistIDs
-              attributionClass
-              additionalGeneIDs
-              priceRange
-              sizes
-              width
-              height
-              acquireable
-              atAuction
-              inquireableOnly
-              offerable
-              materialsTerms
-              locationCities
-              majorPeriods
-              colors
-              partnerIDs
-
-              userAlertSettings {
-                name
-              }
-            }
-          `,
-          resolve: generateDisplayName,
-        },
-        labels: {
-          fragment: gql`
-            ... on SearchCriteria {
-              artistIDs
-              attributionClass
-              additionalGeneIDs
-              priceRange
-              sizes
-              width
-              height
-              acquireable
-              atAuction
-              inquireableOnly
-              offerable
-              materialsTerms
-              locationCities
-              majorPeriods
-              colors
-              partnerIDs
-            }
-            `,
-          resolve: resolveSearchCriteriaLabels,
-          description:
-            "Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity",
         },
       },
     },


### PR DESCRIPTION
This is part two of the stitching work to get things read into MP, where we decorate a gravity graphql type and "connect" it to mp-backed fields -- in this case, transforming `artistIDs` into an `artistsConnection` and attaching the `searchCriteriaConnection` to `partner`. 

Along the way discovered a bug in the `artistsConnection` resolver, where anytime we used the argument `ids` it wouldn't return a connection. Fixed that, and also added some tests. 

Additionally cleaned up the gravity stitching file, mostly through alphabetization (its a large and sprawling file and was getting kinda crazy). GH automatically collapsed things, but i've left comments at the areas that have actually changed!

**Query**:

```graphql
{
  partner(id: "gagosian") {
    searchCriteriaConnection(first: 1) {
      edges {
        node {
          artistIDs
          artistsConnection(first: 20) {
            edges {
              node {
                name
                internalID
              }
            }
          }
        }
      }
    }
  }
}
```

**Response**:
```json
{
  "data": {
    "partner": {
      "searchCriteriaConnection": {
        "edges": [
          {
            "node": {
              "artistIDs": [
                "4db441cc2a7e0b78df000450"
              ],
              "artistsConnection": {
                "edges": [
                  {
                    "node": {
                      "name": "Robert Rauschenberg",
                      "internalID": "4db441cc2a7e0b78df000450"
                    }
                  }
                ]
              }
            }
          }
        ]
      }
    }
  },
}
```