### PR TITLE
feat(searchCriteriaConnection): Stitch in connection to root `Query`

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15755,6 +15755,17 @@ type Query {
     # Search query to perform. Required.
     query: String!
   ): SearchableConnection
+  searchCriteriaConnection(
+    after: String
+    artistID: ID
+    before: String
+    first: Int
+    highQuality: Boolean
+    last: Int
+    partnerID: String
+    previewByArtist: Boolean
+    since: Int
+  ): SearchCriteriaConnection
   shortcut(id: ID!): Shortcut
 
   # A Show

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -629,6 +629,18 @@ describe("gravity/stitching", () => {
         expect(rootFields).toContain("curatedMarketingCollections")
       })
     })
+
+    describe("#searchCriteriaConnection", () => {
+      it("extends the Query type with an searchCriteriaConnection field", async () => {
+        const mergedSchema = await getGravityMergedSchema()
+        const rootFields = await getFieldsForTypeFromSchema(
+          "Query",
+          mergedSchema
+        )
+
+        expect(rootFields).toContain("curatedMarketingCollections")
+      })
+    })
   })
 
   describe("#artists", () => {

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -161,6 +161,18 @@ export const gravityStitchingEnvironment = (
 
       extend type Query {
         curatedMarketingCollections(size: Int): [MarketingCollection]
+
+        searchCriteriaConnection(
+          first: Int,
+          last: Int,
+          before: String,
+          after: String,
+          artistID: ID,
+          highQuality: Boolean,
+          partnerID: String,
+          previewByArtist: Boolean
+          since: Int
+        ): SearchCriteriaConnection
       }
 
       extend type SearchCriteria {
@@ -744,6 +756,18 @@ export const gravityStitchingEnvironment = (
             } catch (error) {
               return []
             }
+          },
+        },
+        searchCriteriaConnection: {
+          resolve: (_fragments, args, context, info) => {
+            return info.mergeInfo.delegateToSchema({
+              schema: gravitySchema,
+              operation: "query",
+              fieldName: "_unused_gravity_searchCriteriaConnection",
+              args,
+              context,
+              info,
+            })
           },
         },
       },


### PR DESCRIPTION
Quick and easy. Stitches things into the root-most `Query` type so that we can write queries like:
```
{ 
  searchCriteriaConnection(...)  { ... } 
}
```
Will evaluate in a bit if its even worth it to stitch it in under `partner`. Seems fine and idiomatic to make the partnerID argument implicit, but still -- less code in stitching the better, and this root query (exclusively) being used is the least number of LOC, at the expense of a single additional argument passed in. Will see. 

(Super straight forward so just gonna merge this and keep going 👀)