### PR TITLE
feat(searchCriteria): Stitch in connection to root `Viewer`

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -20313,6 +20313,17 @@ type Viewer {
     # Search query to perform. Required.
     query: String!
   ): SearchableConnection
+  searchCriteriaConnection(
+    after: String
+    artistID: ID
+    before: String
+    first: Int
+    highQuality: Boolean
+    last: Int
+    partnerID: String
+    previewByArtist: Boolean
+    since: Int
+  ): SearchCriteriaConnection
   shortcut(id: ID!): Shortcut
 
   # A Show

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -592,6 +592,18 @@ describe("gravity/stitching", () => {
   })
 
   describe("#Viewer", () => {
+    describe("#searchCriteriaConnection", () => {
+      it("extends the Query type with an searchCriteriaConnection field", async () => {
+        const mergedSchema = await getGravityMergedSchema()
+        const rootFields = await getFieldsForTypeFromSchema(
+          "Query",
+          mergedSchema
+        )
+
+        expect(rootFields).toContain("searchCriteriaConnection")
+      })
+    })
+
     describe("#viewingRoomsConnection in Viewer", () => {
       it("extends the Viewer type with a viewingRoomsConnection field", async () => {
         const mergedSchema = await getGravityMergedSchema()
@@ -638,7 +650,7 @@ describe("gravity/stitching", () => {
           mergedSchema
         )
 
-        expect(rootFields).toContain("curatedMarketingCollections")
+        expect(rootFields).toContain("searchCriteriaConnection")
       })
     })
   })

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -221,6 +221,17 @@ export const gravityStitchingEnvironment = (
       }
 
       extend type Viewer {
+        searchCriteriaConnection(
+          first: Int,
+          last: Int,
+          before: String,
+          after: String,
+          artistID: ID,
+          highQuality: Boolean,
+          partnerID: String,
+          previewByArtist: Boolean
+          since: Int
+        ): SearchCriteriaConnection
         viewingRoomsConnection(first: Int, after: String, statuses: [ViewingRoomStatusEnum!], partnerID: ID): ViewingRoomsConnection
         marketingCollections(
           slugs: [String!]
@@ -1073,6 +1084,19 @@ export const gravityStitchingEnvironment = (
         },
       },
       Viewer: {
+        searchCriteriaConnection: {
+          resolve: (_fragments, args, context, info) => {
+            return info.mergeInfo.delegateToSchema({
+              schema: gravitySchema,
+              operation: "query",
+              fieldName: "_unused_gravity_searchCriteriaConnection",
+              args,
+              context,
+              info,
+            })
+          },
+        },
+
         viewingRoomsConnection: {
           fragment: `
           ... on Viewer {


### PR DESCRIPTION
Related: 
- https://github.com/artsy/metaphysics/pull/5244

Need to add this to the `Viewer` type as well, for relay pagination. 