### PR TITLE
chore: Update gravity graphql schema with latest gravity changes

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14622,6 +14622,9 @@ type Query {
     partnerID: ID
     previewByArtist: Boolean
     since: Int
+
+    # Returns search criteria sorted by input (default: by high quality and count desc)
+    sort: [SearchCriteriaSortEnum!] = [HIGH_QUALITY_DESC, COUNT_DESC]
   ): SearchCriteriaConnection
 
   # List enabled Two-Factor Authentication factors
@@ -16941,6 +16944,14 @@ type SearchCriteriaLabel {
 
 # A search criteria or errors object
 union SearchCriteriaOrErrorsUnion = Errors | SearchCriteria
+
+enum SearchCriteriaSortEnum {
+  # Sort by most popular search criteria in descending order
+  COUNT_DESC
+
+  # Sort by high quality priority listed first
+  HIGH_QUALITY_DESC
+}
 
 enum SearchEntity {
   ARTICLE

--- a/src/data/gravity.graphql
+++ b/src/data/gravity.graphql
@@ -1698,6 +1698,11 @@ type Query {
     partnerID: ID
     previewByArtist: Boolean
     since: Int
+
+    """
+    Returns search criteria sorted by input (default: by high quality and count desc)
+    """
+    sort: [SearchCriteriaSortEnum!] = [HIGH_QUALITY_DESC, COUNT_DESC]
   ): SearchCriteriaConnection
 
   """
@@ -2189,6 +2194,18 @@ type SearchCriteriaEdge {
 A search criteria or errors object
 """
 union SearchCriteriaOrErrorsUnion = Errors | SearchCriteria
+
+enum SearchCriteriaSortEnum {
+  """
+  Sort by most popular search criteria in descending order
+  """
+  COUNT_DESC
+
+  """
+  Sort by high quality priority listed first
+  """
+  HIGH_QUALITY_DESC
+}
 
 interface SecondFactor {
   createdAt: ISO8601DateTime!


### PR DESCRIPTION
Ran 
```
# in grav
rake graphql:schema:idl
```

and copied to MP
```
cp _schema.graphql path_to_your_local_metaphysics/src/data/gravity.graphql
```
to update gravity graphql schema with latest gravity changes