### PR TITLE
chore: Update gravity graphql schema with new since enum types

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14621,7 +14621,7 @@ type Query {
     last: Int
     partnerID: ID
     previewByArtist: Boolean
-    since: Int
+    since: SearchCriteriaSinceEnum
 
     # Returns search criteria sorted by input (default: by high quality and count desc)
     sort: [SearchCriteriaSortEnum!] = [HIGH_QUALITY_DESC, COUNT_DESC]
@@ -16944,6 +16944,24 @@ type SearchCriteriaLabel {
 
 # A search criteria or errors object
 union SearchCriteriaOrErrorsUnion = Errors | SearchCriteria
+
+# Time range for the since argument
+enum SearchCriteriaSinceEnum {
+  # Query for search criteria enabled within the last 1 day
+  LAST_1_DAY
+
+  # Query for search criteria enabled within the last 15 days
+  LAST_15_DAYS
+
+  # Query for search criteria enabled within the last 30 days
+  LAST_30_DAYS
+
+  # Query for search criteria enabled within the last 7 days
+  LAST_7_DAYS
+
+  # Query for search criteria enabled within the last 90 days
+  LAST_90_DAYS
+}
 
 enum SearchCriteriaSortEnum {
   # Sort by most popular search criteria in descending order

--- a/src/data/gravity.graphql
+++ b/src/data/gravity.graphql
@@ -1697,7 +1697,7 @@ type Query {
     last: Int
     partnerID: ID
     previewByArtist: Boolean
-    since: Int
+    since: SearchCriteriaSinceEnum
 
     """
     Returns search criteria sorted by input (default: by high quality and count desc)
@@ -2192,6 +2192,36 @@ type SearchCriteriaEdge {
 A search criteria or errors object
 """
 union SearchCriteriaOrErrorsUnion = Errors | SearchCriteria
+
+"""
+Time range for the since argument
+"""
+enum SearchCriteriaSinceEnum {
+  """
+  Query for search criteria enabled within the last 15 days
+  """
+  LAST_15_DAYS
+
+  """
+  Query for search criteria enabled within the last 1 day
+  """
+  LAST_1_DAY
+
+  """
+  Query for search criteria enabled within the last 30 days
+  """
+  LAST_30_DAYS
+
+  """
+  Query for search criteria enabled within the last 7 days
+  """
+  LAST_7_DAYS
+
+  """
+  Query for search criteria enabled within the last 90 days
+  """
+  LAST_90_DAYS
+}
 
 enum SearchCriteriaSortEnum {
   """


### PR DESCRIPTION
Update gravity graphQL schema with new `SearchCriteriaSinceEnum` + surface in MP schema

Ran 
```
# in grav
rake graphql:schema:idl
```

and copied to MP
```
cp _schema.graphql path_to_your_local_metaphysics/src/data/gravity.graphql
```
to update gravity graphql schema with latest gravity changes