### PR TITLE
Revert "chore: use an authenticated loader for search to be able to use unleash on the backend"

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1,7 +1,6 @@
 import { gravityGraphQL } from "lib/apis/gravityGraphQL"
 import trackedEntityLoaderFactory from "lib/loaders/loaders_with_authentication/tracked_entity"
 import factories from "../api"
-import { searchLoader } from "../searchLoader"
 
 export default (accessToken, userID, opts) => {
   const gravityAccessTokenLoader = () => Promise.resolve(accessToken)
@@ -623,7 +622,6 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
-    searchLoader: searchLoader(gravityLoader),
     sendConfirmationEmailLoader: gravityLoader(
       "me/confirmation_emails",
       {},


### PR DESCRIPTION
Reverts artsy/metaphysics#5225

Now that we rolled out the feature and no longer need `current_user` for the Unleash flag - we can drop the authenticated loader here (which should improve performance as there will be some caching re-instated, altho in practice it likely didn't do much, when breaking the caching w/ this change I didn't see any differences in datadog metrics for the endpoint).