### PR TITLE
feat: add lots by created date aggregation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2880,6 +2880,7 @@ type AuctionResultPriceRealized {
 
 enum AuctionResultsAggregation {
   CURRENCIES_COUNT
+  LOTS_BY_CREATED_YEAR
   LOTS_BY_SALE_YEAR
   SIMPLE_PRICE_HISTOGRAM
 }

--- a/src/schema/v2/__tests__/auction_results.test.js
+++ b/src/schema/v2/__tests__/auction_results.test.js
@@ -62,6 +62,14 @@ const lotsBySaleYearResponse = {
   },
 }
 
+const lotsByCreatedYearResponse = {
+  lots_by_created_year: {
+    1900: { name: "1900", count: 5 },
+    2022: { name: "2022", count: 10 },
+    2023: { name: "2022", count: 15 },
+  },
+}
+
 describe("Artist type", () => {
   beforeEach(() => {
     context.auctionLotsLoader = jest
@@ -285,6 +293,41 @@ describe("Artist type", () => {
         expect(aggregations).toHaveLength(1)
         expect(aggregations[0].slice).toEqual("LOTS_BY_SALE_YEAR")
         expect(aggregations[0].counts).toHaveLength(2)
+      }
+    )
+  })
+
+  it("returns aggregated lots by created year response", () => {
+    context.auctionResultFilterLoader = jest
+      .fn()
+      .mockReturnValueOnce(Promise.resolve(lotsByCreatedYearResponse))
+
+    const query = `
+      {
+        artist(id: "percy-z") {
+          auctionResultsConnection(aggregations: [LOTS_BY_CREATED_YEAR]) {
+            aggregations {
+              slice
+              counts {
+                name
+                value
+                count
+              }
+            }
+          }
+        }
+      }
+    `
+
+    return runQuery(query, context).then(
+      ({
+        artist: {
+          auctionResultsConnection: { aggregations },
+        },
+      }) => {
+        expect(aggregations).toHaveLength(1)
+        expect(aggregations[0].slice).toEqual("LOTS_BY_CREATED_YEAR")
+        expect(aggregations[0].counts).toHaveLength(3)
       }
     )
   })

--- a/src/schema/v2/aggregations/filterAuctionResultsAggregation.ts
+++ b/src/schema/v2/aggregations/filterAuctionResultsAggregation.ts
@@ -15,6 +15,9 @@ export const AuctionResultsAggregation = new GraphQLEnumType({
     LOTS_BY_SALE_YEAR: {
       value: "lots_by_sale_year",
     },
+    LOTS_BY_CREATED_YEAR: {
+      value: "lots_by_created_year",
+    },
   },
 })
 


### PR DESCRIPTION
This PR adds new aggregation for lots by year created, using `lots.date` field in Diffusion.

[Diffusion PR](https://github.com/artsy/diffusion/pull/780)