### PR TITLE
chore: Removes usage of previewByArtist from grav graphql and related stitching

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13685,7 +13685,6 @@ type Partner implements Node {
     highQuality: Boolean
     last: Int
     partnerID: String
-    previewByArtist: Boolean
     since: Int
   ): SearchCriteriaConnection
   showPromoted: Boolean
@@ -14620,7 +14619,6 @@ type Query {
     # Returns the last _n_ elements from the list.
     last: Int
     partnerID: ID
-    previewByArtist: Boolean
     since: SearchCriteriaSinceEnum
 
     # Returns search criteria sorted by input (default: by high quality and count desc)
@@ -15766,7 +15764,6 @@ type Query {
     highQuality: Boolean
     last: Int
     partnerID: String
-    previewByArtist: Boolean
     since: Int
   ): SearchCriteriaConnection
   shortcut(id: ID!): Shortcut
@@ -20350,7 +20347,6 @@ type Viewer {
     highQuality: Boolean
     last: Int
     partnerID: String
-    previewByArtist: Boolean
     since: Int
   ): SearchCriteriaConnection
   shortcut(id: ID!): Shortcut

--- a/src/data/gravity.graphql
+++ b/src/data/gravity.graphql
@@ -1696,7 +1696,6 @@ type Query {
     """
     last: Int
     partnerID: ID
-    previewByArtist: Boolean
     since: SearchCriteriaSinceEnum
 
     """

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -152,7 +152,6 @@ export const gravityStitchingEnvironment = (
           artistID: ID,
           highQuality: Boolean,
           partnerID: String,
-          previewByArtist: Boolean
           since: Int
         ): SearchCriteriaConnection
 
@@ -170,7 +169,6 @@ export const gravityStitchingEnvironment = (
           artistID: ID,
           highQuality: Boolean,
           partnerID: String,
-          previewByArtist: Boolean
           since: Int
         ): SearchCriteriaConnection
       }
@@ -229,7 +227,6 @@ export const gravityStitchingEnvironment = (
           artistID: ID,
           highQuality: Boolean,
           partnerID: String,
-          previewByArtist: Boolean
           since: Int
         ): SearchCriteriaConnection
         viewingRoomsConnection(first: Int, after: String, statuses: [ViewingRoomStatusEnum!], partnerID: ID): ViewingRoomsConnection


### PR DESCRIPTION
Removes usage of previewByArtist from grav graphql and related stitching as it is not needed

Grav PR: https://github.com/artsy/gravity/pull/16746
VoltV2 PR: https://github.com/artsy/volt-v2/pull/629