### PR TITLE
feat: Add city name to requestLocation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16077,6 +16077,7 @@ type RequestCredentialsForAssetUploadPayload {
 
 type RequestLocation {
   cached: Int
+  city: String
   coordinates: LatLng
   country: String
   countryCode: String

--- a/src/schema/v2/__tests__/requestLocation.test.ts
+++ b/src/schema/v2/__tests__/requestLocation.test.ts
@@ -8,6 +8,7 @@ describe("requestLocation", () => {
         {
           requestLocation {
             id
+            city
             country
             countryCode
             coordinates {
@@ -31,6 +32,7 @@ describe("requestLocation", () => {
 
       expect(requestLocation).toMatchInlineSnapshot(`
         Object {
+          "city": "Frankfurt",
           "coordinates": Object {
             "lat": 50.11207962036133,
             "lng": 8.683409690856934,
@@ -49,6 +51,7 @@ describe("requestLocation", () => {
         {
           requestLocation(ip: "param-ip") {
             id
+            city
             country
             countryCode
             coordinates {
@@ -72,6 +75,7 @@ describe("requestLocation", () => {
 
       expect(requestLocation).toMatchInlineSnapshot(`
         Object {
+          "city": "Frankfurt",
           "coordinates": Object {
             "lat": 50.11207962036133,
             "lng": 8.683409690856934,

--- a/src/schema/v2/requestLocation.ts
+++ b/src/schema/v2/requestLocation.ts
@@ -27,6 +27,7 @@ export const RequestLocationType = new GraphQLObjectType<any, ResolverContext>({
     cached,
     id: { type: new GraphQLNonNull(GraphQLID) },
     country: { type: GraphQLString },
+    city: { type: GraphQLString },
     countryCode: { type: GraphQLString },
     coordinates: {
       type: LatLngType,
@@ -62,6 +63,7 @@ export const RequestLocationField: GraphQLFieldConfig<void, ResolverContext> = {
       }
 
       const { alpha2: countryCode, name: country } = data.location.country
+      const { name: city } = data.location.city
       const { latitude: lat, longitude: lng } = data.location
 
       return {
@@ -69,6 +71,7 @@ export const RequestLocationField: GraphQLFieldConfig<void, ResolverContext> = {
         country,
         countryCode,
         cached,
+        city,
         coordinates: { lat, lng },
       }
     } catch (error) {


### PR DESCRIPTION
Jira Ticket: [ONYX-45]

## Description

This PR adds a city field to `requestLocation` in order to show the name of the city of the user in the new "Galleries Near You" artsy home page rail.

[ONYX-45]: https://artsyproduct.atlassian.net/browse/ONYX-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ