### PR TITLE
fix: add handler for not qualified comparable lots

### DIFF
--- a/src/schema/v2/__tests__/auction_result.test.ts
+++ b/src/schema/v2/__tests__/auction_result.test.ts
@@ -377,6 +377,9 @@ const mockComparableAuctionResults = {
     ],
   },
 }
+const mockEmptyComparableAuctionResults = {
+  error: "Lot not comparable",
+}
 
 describe("Comparable Auction Results", () => {
   it("fetches comparable auction results", () => {
@@ -438,6 +441,42 @@ describe("Comparable Auction Results", () => {
           },
         ],
       })
+    })
+  })
+
+  it("fetches not comparable auction results", () => {
+    const query = `
+    {
+      auctionResult(id: "foo-bar") {
+        saleDateText
+        saleTitle
+        comparableAuctionResults(first:25) {
+          totalCount
+          edges {
+            node {
+              saleDateText
+              currency
+              images {
+                thumbnail {
+                  imageURL
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    `
+
+    const context = {
+      auctionLotLoader: jest.fn(() => Promise.resolve(mockAuctionResult)),
+      auctionResultComparableAuctionResultsLoader: jest.fn(() =>
+        Promise.resolve(mockEmptyComparableAuctionResults)
+      ),
+    }
+
+    return runQuery(query, context!).then((data) => {
+      expect(data.auctionResult.comparableAuctionResults).toEqual(null)
     })
   })
 })

--- a/src/schema/v2/auction_result.ts
+++ b/src/schema/v2/auction_result.ts
@@ -144,10 +144,18 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
           options
         )
 
+        const response = await auctionResultComparableAuctionResultsLoader(
+          parent.id
+        )
+
+        if (response.error) {
+          return null
+        }
+
         const {
           _embedded: { items },
           total_count,
-        } = await auctionResultComparableAuctionResultsLoader(parent.id)
+        } = response
 
         return merge(
           {


### PR DESCRIPTION
This PR is followup for Diffusion improvements for lots/comparable_lots endpoint.
[Diffusion PR](https://github.com/artsy/diffusion/pull/788)