### PR TITLE
feat(artist): adds support for updating target supply and group indicator

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2027,8 +2027,8 @@ type ArtistTargetSupply {
   # True if artist is in target supply list.
   isTargetSupply: Boolean
   microfunnel: ArtistTargetSupplyMicrofunnel
-  priority: ArtistTargetSupplyPriorityEnum
-  type: ArtistTargetSupplyTypeEnum
+  priority: ArtistTargetSupplyPriority
+  type: ArtistTargetSupplyType
 }
 
 type ArtistTargetSupplyMicrofunnel {
@@ -2045,12 +2045,12 @@ type ArtistTargetSupplyMicrofunnel {
   metadata: TargetSupplyMicrofunnelMetadata
 }
 
-enum ArtistTargetSupplyPriorityEnum {
+enum ArtistTargetSupplyPriority {
   P1
   P2
 }
 
-enum ArtistTargetSupplyTypeEnum {
+enum ArtistTargetSupplyType {
   BLUE_CHIP
   CRITICALLY_ACCLAIMED
   NEW_AND_NOTEWORTHY
@@ -17992,8 +17992,8 @@ input UpdateArtistMutationInput {
   location: String
   middle: String
   nationality: String
-  targetSupplyPriority: ArtistTargetSupplyPriorityEnum
-  targetSupplyType: ArtistTargetSupplyTypeEnum
+  targetSupplyPriority: ArtistTargetSupplyPriority
+  targetSupplyType: ArtistTargetSupplyType
 }
 
 type UpdateArtistMutationPayload {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17985,12 +17985,15 @@ input UpdateArtistMutationInput {
   displayName: String
   first: String
   gender: String
+  groupIndicator: ArtistGroupIndicator
   hometown: String
   id: String!
   last: String
   location: String
   middle: String
   nationality: String
+  targetSupplyPriority: ArtistTargetSupplyPriorityEnum
+  targetSupplyType: ArtistTargetSupplyTypeEnum
 }
 
 type UpdateArtistMutationPayload {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2014,11 +2014,13 @@ type ArtistTargetSupply {
   isInMicrofunnel: Boolean
 
   # True if an artist is a P1 artist.
-  isP1: Boolean
+  isP1: Boolean @deprecated(reason: "Use \"priority\" field instead.")
 
   # True if artist is in target supply list.
   isTargetSupply: Boolean
   microfunnel: ArtistTargetSupplyMicrofunnel
+  priority: ArtistTargetSupplyPriorityEnum
+  type: ArtistTargetSupplyTypeEnum
 }
 
 type ArtistTargetSupplyMicrofunnel {
@@ -2033,6 +2035,20 @@ type ArtistTargetSupplyMicrofunnel {
     randomize: Boolean
   ): ArtworkConnection
   metadata: TargetSupplyMicrofunnelMetadata
+}
+
+enum ArtistTargetSupplyPriorityEnum {
+  P1
+  P2
+}
+
+enum ArtistTargetSupplyTypeEnum {
+  BLUE_CHIP
+  CRITICALLY_ACCLAIMED
+  NEW_AND_NOTEWORTHY
+  STREET_AND_URBAN
+  TRENDING_EMERGING
+  ULTRA_HIGH_DEMAND
 }
 
 type Artwork implements Node & Searchable & Sellable {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1523,6 +1523,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
 
   # A list of genes associated with an artist
   genes: [Gene]
+  groupIndicator: ArtistGroupIndicator
   hasMetadata: Boolean
   highlights: ArtistHighlights
   hometown: String
@@ -1731,6 +1732,13 @@ type ArtistGroup {
 
   # Letter artists group belongs to
   letter: String
+}
+
+enum ArtistGroupIndicator {
+  DUO
+  GROUP
+  INDIVIDUAL
+  N_A
 }
 
 type ArtistHighlights {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1626,7 +1626,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   # Use this attribute to sort by when sorting a collection of Artists
   sortableID: String
   statuses: ArtistStatuses
-  targetSupply: ArtistTargetSupply
+  targetSupply: ArtistTargetSupply!
   vanguardYear: String
   verifiedRepresentatives: [VerifiedRepresentative!]!
   years: String

--- a/src/schema/v2/artist/groupIndicator.ts
+++ b/src/schema/v2/artist/groupIndicator.ts
@@ -1,0 +1,15 @@
+import { GraphQLEnumType } from "graphql"
+
+const ARTIST_GROUP_INDICATORS = {
+  INDIVIDUAL: { value: "individual" },
+  DUO: { value: "duo" },
+  GROUP: { value: "group" },
+  N_A: { value: "n/a" },
+} as const
+
+export type ArtistGroupIndicator = typeof ARTIST_GROUP_INDICATORS[keyof typeof ARTIST_GROUP_INDICATORS]["value"]
+
+export const ArtistGroupIndicatorEnum = new GraphQLEnumType({
+  name: "ArtistGroupIndicator",
+  values: ARTIST_GROUP_INDICATORS,
+})

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -60,7 +60,6 @@ import { ArtistTargetSupply } from "./targetSupply"
 import VerifiedRepresentatives from "./verifiedRepresentatives"
 import { AuctionResultsAggregation } from "../aggregations/filterAuctionResultsAggregation"
 import { parsePriceRangeValues } from "lib/moneyHelper"
-import { GraphQLEnumType } from "graphql"
 import { ArtistGroupIndicatorEnum } from "schema/v2/artist/groupIndicator"
 
 // Manually curated list of artist id's who has verified auction lots that can be

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -60,6 +60,7 @@ import { ArtistTargetSupply } from "./targetSupply"
 import VerifiedRepresentatives from "./verifiedRepresentatives"
 import { AuctionResultsAggregation } from "../aggregations/filterAuctionResultsAggregation"
 import { parsePriceRangeValues } from "lib/moneyHelper"
+import { GraphQLEnumType } from "graphql"
 
 // Manually curated list of artist id's who has verified auction lots that can be
 // returned, when queried for via `recordsTrusted: true`.
@@ -687,6 +688,18 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       gender: { type: GraphQLString },
+      groupIndicator: {
+        type: new GraphQLEnumType({
+          name: "ArtistGroupIndicator",
+          values: {
+            INDIVIDUAL: { value: "individual" },
+            DUO: { value: "duo" },
+            GROUP: { value: "group" },
+            N_A: { value: "n/a" },
+          },
+        }),
+        resolve: ({ group_indicator }) => group_indicator,
+      },
       hasMetadata: {
         type: GraphQLBoolean,
         resolve: ({ blurb, nationality, years, hometown, location }) => {

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -61,6 +61,7 @@ import VerifiedRepresentatives from "./verifiedRepresentatives"
 import { AuctionResultsAggregation } from "../aggregations/filterAuctionResultsAggregation"
 import { parsePriceRangeValues } from "lib/moneyHelper"
 import { GraphQLEnumType } from "graphql"
+import { ArtistGroupIndicatorEnum } from "schema/v2/artist/groupIndicator"
 
 // Manually curated list of artist id's who has verified auction lots that can be
 // returned, when queried for via `recordsTrusted: true`.
@@ -689,15 +690,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
       },
       gender: { type: GraphQLString },
       groupIndicator: {
-        type: new GraphQLEnumType({
-          name: "ArtistGroupIndicator",
-          values: {
-            INDIVIDUAL: { value: "individual" },
-            DUO: { value: "duo" },
-            GROUP: { value: "group" },
-            N_A: { value: "n/a" },
-          },
-        }),
+        type: ArtistGroupIndicatorEnum,
         resolve: ({ group_indicator }) => group_indicator,
       },
       hasMetadata: {

--- a/src/schema/v2/artist/targetSupply/index.ts
+++ b/src/schema/v2/artist/targetSupply/index.ts
@@ -1,18 +1,52 @@
-import { GraphQLBoolean, GraphQLFieldConfig, GraphQLObjectType } from "graphql"
+import {
+  GraphQLBoolean,
+  GraphQLEnumType,
+  GraphQLFieldConfig,
+  GraphQLObjectType,
+} from "graphql"
 import { getRecentlySoldArtworksConnection } from "schema/v2/types/targetSupply/recentlySoldArtworksConnection"
 import { TargetSupplyMicrofunnelMetadata } from "schema/v2/types/targetSupply/targetSupplyMicrofunnelMetadata"
 import { ResolverContext } from "types/graphql"
 import { getArtistMicrofunnelMetadata } from "./utils/getMicrofunnelData"
 
+export const ArtistTargetSupplyPriorityEnum = new GraphQLEnumType({
+  name: "ArtistTargetSupplyPriorityEnum",
+  values: {
+    P1: { value: 1 },
+    P2: { value: 2 },
+  },
+})
+
+export const ArtistTargetSupplyTypeEnum = new GraphQLEnumType({
+  name: "ArtistTargetSupplyTypeEnum",
+  values: {
+    BLUE_CHIP: { value: "Blue-Chip" },
+    CRITICALLY_ACCLAIMED: { value: "Critically-Acclaimed" },
+    NEW_AND_NOTEWORTHY: { value: "New & Noteworthy" },
+    STREET_AND_URBAN: { value: "Street & Urban" },
+    TRENDING_EMERGING: { value: "Trending Emerging" },
+    ULTRA_HIGH_DEMAND: { value: "Ultra High Demand" },
+  },
+})
+
 const ArtistTargetSupplyType = new GraphQLObjectType<any, ResolverContext>({
   name: "ArtistTargetSupply",
   fields: {
+    priority: {
+      type: ArtistTargetSupplyPriorityEnum,
+      resolve: (artist) => artist.target_supply_priority,
+    },
+    type: {
+      type: ArtistTargetSupplyTypeEnum,
+      resolve: (artist) => artist.target_supply_type,
+    },
     isTargetSupply: {
       description: "True if artist is in target supply list.",
       type: GraphQLBoolean,
       resolve: (artist) => artist.target_supply,
     },
     isP1: {
+      deprecationReason: 'Use "priority" field instead.',
       description: "True if an artist is a P1 artist.",
       type: GraphQLBoolean,
       resolve: (artist) => artist.target_supply_priority === 1,

--- a/src/schema/v2/artist/targetSupply/index.ts
+++ b/src/schema/v2/artist/targetSupply/index.ts
@@ -18,7 +18,7 @@ const ARTIST_TARGET_SUPPLY_PRIORITIES = {
 export type ArtistTargetSupplyPriority = typeof ARTIST_TARGET_SUPPLY_PRIORITIES[keyof typeof ARTIST_TARGET_SUPPLY_PRIORITIES]["value"]
 
 export const ArtistTargetSupplyPriorityEnum = new GraphQLEnumType({
-  name: "ArtistTargetSupplyPriorityEnum",
+  name: "ArtistTargetSupplyPriority",
   values: ARTIST_TARGET_SUPPLY_PRIORITIES,
 })
 
@@ -34,7 +34,7 @@ const ARTIST_TARGET_SUPPLY_TYPES = {
 export type ArtistTargetSupplyType = typeof ARTIST_TARGET_SUPPLY_TYPES[keyof typeof ARTIST_TARGET_SUPPLY_TYPES]["value"]
 
 export const ArtistTargetSupplyTypeEnum = new GraphQLEnumType({
-  name: "ArtistTargetSupplyTypeEnum",
+  name: "ArtistTargetSupplyType",
   values: ARTIST_TARGET_SUPPLY_TYPES,
 })
 

--- a/src/schema/v2/artist/targetSupply/index.ts
+++ b/src/schema/v2/artist/targetSupply/index.ts
@@ -2,6 +2,7 @@ import {
   GraphQLBoolean,
   GraphQLEnumType,
   GraphQLFieldConfig,
+  GraphQLNonNull,
   GraphQLObjectType,
 } from "graphql"
 import { getRecentlySoldArtworksConnection } from "schema/v2/types/targetSupply/recentlySoldArtworksConnection"
@@ -91,6 +92,6 @@ const ArtistTargetSupplyType = new GraphQLObjectType<any, ResolverContext>({
 })
 
 export const ArtistTargetSupply: GraphQLFieldConfig<void, ResolverContext> = {
-  type: ArtistTargetSupplyType,
+  type: new GraphQLNonNull(ArtistTargetSupplyType),
   resolve: (artist) => artist,
 }

--- a/src/schema/v2/artist/targetSupply/index.ts
+++ b/src/schema/v2/artist/targetSupply/index.ts
@@ -9,24 +9,32 @@ import { TargetSupplyMicrofunnelMetadata } from "schema/v2/types/targetSupply/ta
 import { ResolverContext } from "types/graphql"
 import { getArtistMicrofunnelMetadata } from "./utils/getMicrofunnelData"
 
+const ARTIST_TARGET_SUPPLY_PRIORITIES = {
+  P1: { value: 1 },
+  P2: { value: 2 },
+} as const
+
+export type ArtistTargetSupplyPriority = typeof ARTIST_TARGET_SUPPLY_PRIORITIES[keyof typeof ARTIST_TARGET_SUPPLY_PRIORITIES]["value"]
+
 export const ArtistTargetSupplyPriorityEnum = new GraphQLEnumType({
   name: "ArtistTargetSupplyPriorityEnum",
-  values: {
-    P1: { value: 1 },
-    P2: { value: 2 },
-  },
+  values: ARTIST_TARGET_SUPPLY_PRIORITIES,
 })
+
+const ARTIST_TARGET_SUPPLY_TYPES = {
+  BLUE_CHIP: { value: "Blue-Chip" },
+  CRITICALLY_ACCLAIMED: { value: "Critically-Acclaimed" },
+  NEW_AND_NOTEWORTHY: { value: "New & Noteworthy" },
+  STREET_AND_URBAN: { value: "Street & Urban" },
+  TRENDING_EMERGING: { value: "Trending Emerging" },
+  ULTRA_HIGH_DEMAND: { value: "Ultra High Demand" },
+} as const
+
+export type ArtistTargetSupplyType = typeof ARTIST_TARGET_SUPPLY_TYPES[keyof typeof ARTIST_TARGET_SUPPLY_TYPES]["value"]
 
 export const ArtistTargetSupplyTypeEnum = new GraphQLEnumType({
   name: "ArtistTargetSupplyTypeEnum",
-  values: {
-    BLUE_CHIP: { value: "Blue-Chip" },
-    CRITICALLY_ACCLAIMED: { value: "Critically-Acclaimed" },
-    NEW_AND_NOTEWORTHY: { value: "New & Noteworthy" },
-    STREET_AND_URBAN: { value: "Street & Urban" },
-    TRENDING_EMERGING: { value: "Trending Emerging" },
-    ULTRA_HIGH_DEMAND: { value: "Ultra High Demand" },
-  },
+  values: ARTIST_TARGET_SUPPLY_TYPES,
 })
 
 const ArtistTargetSupplyType = new GraphQLObjectType<any, ResolverContext>({

--- a/src/schema/v2/artist/updateArtistMutation.ts
+++ b/src/schema/v2/artist/updateArtistMutation.ts
@@ -13,6 +13,16 @@ import {
   formatGravityError,
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
+import {
+  ArtistTargetSupplyPriorityEnum,
+  ArtistTargetSupplyPriority,
+  ArtistTargetSupplyType,
+  ArtistTargetSupplyTypeEnum,
+} from "./targetSupply/index"
+import {
+  ArtistGroupIndicator,
+  ArtistGroupIndicatorEnum,
+} from "schema/v2/artist/groupIndicator"
 
 interface Input {
   alternateNames: string[]
@@ -22,12 +32,15 @@ interface Input {
   displayName?: string
   first?: string
   gender?: string
+  groupIndicator?: ArtistGroupIndicator
   hometown?: string
   id: string
   last?: string
   location?: string
   middle?: string
   nationality?: string
+  targetSupplyPriority?: ArtistTargetSupplyPriority
+  targetSupplyType?: ArtistTargetSupplyType
 }
 
 const inputFields = {
@@ -38,12 +51,15 @@ const inputFields = {
   displayName: { type: GraphQLString },
   first: { type: GraphQLString },
   gender: { type: GraphQLString },
+  groupIndicator: { type: ArtistGroupIndicatorEnum },
   hometown: { type: GraphQLString },
   id: { type: new GraphQLNonNull(GraphQLString) },
   last: { type: GraphQLString },
   location: { type: GraphQLString },
   middle: { type: GraphQLString },
   nationality: { type: GraphQLString },
+  targetSupplyPriority: { type: ArtistTargetSupplyPriorityEnum },
+  targetSupplyType: { type: ArtistTargetSupplyTypeEnum },
 }
 
 interface GravityInput {
@@ -54,12 +70,15 @@ interface GravityInput {
   display_name?: string
   first?: string
   gender?: string
+  group_indicator?: string
   hometown?: string
   id: string
   last?: string
   location?: string
   middle?: string
   nationality?: string
+  target_supply_priority?: string
+  target_supply_type?: string
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({


### PR DESCRIPTION
Working through [the list](https://www.notion.so/artsy/5128c372c8e744a28a2accc758b8a480?v=b7d7ce2c8b184dd7834920e1f47fd02d).

This PR adds support for the few remaining enum fields on artists.