### PR TITLE
feat(searchCriteria): Stitch in lowPriceAmount and highPriceAmount and format via currency 

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16878,6 +16878,15 @@ type SearchCriteria {
   displayName: String!
   hasRecentlyEnabledUserSearchCriteria: Boolean!
   height: String
+  highPriceAmount(
+    decimal: String = "."
+
+    # Allows control of symbol position (%v = value, %s = symbol)
+    format: String = "%s%v"
+    precision: Int = 0
+    symbol: String
+    thousand: String = ","
+  ): String
   href: String!
   inquireableOnly: Boolean
   internalID: ID!
@@ -16886,6 +16895,15 @@ type SearchCriteria {
   # Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity
   labels: [SearchCriteriaLabel!]!
   locationCities: [String!]!
+  lowPriceAmount(
+    decimal: String = "."
+
+    # Allows control of symbol position (%v = value, %s = symbol)
+    format: String = "%s%v"
+    precision: Int = 0
+    symbol: String
+    thousand: String = ","
+  ): String
   majorPeriods: [String!]!
   materialsTerms: [String!]!
   offerable: Boolean

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -1070,40 +1070,102 @@ describe("gravity/stitching", () => {
   })
 
   describe("SearchCriteria", () => {
-    it("extends the SearchCriteria type with an artistsConnection field", async () => {
-      const mergedSchema = await getGravityMergedSchema()
-      const searchCriteriaFields = await getFieldsForTypeFromSchema(
-        "SearchCriteria",
-        mergedSchema
-      )
-      expect(searchCriteriaFields).toContain("artistsConnection")
+    describe("#artistsConnection", () => {
+      it("extends the SearchCriteria type with an artistsConnection field", async () => {
+        const mergedSchema = await getGravityMergedSchema()
+        const searchCriteriaFields = await getFieldsForTypeFromSchema(
+          "SearchCriteria",
+          mergedSchema
+        )
+        expect(searchCriteriaFields).toContain("artistsConnection")
+      })
+
+      it("resolves the artistsConnection field", async () => {
+        const { resolvers } = await getGravityStitchedSchema()
+        const { artistsConnection } = resolvers.SearchCriteria
+        const info = { mergeInfo: { delegateToSchema: jest.fn() } }
+
+        artistsConnection.resolve(
+          { artistIDs: ["abc123", "foo"] },
+          { first: 2 },
+          {},
+          info
+        )
+
+        expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith(
+          expect.objectContaining({
+            args: {
+              ids: ["abc123", "foo"],
+              first: 2,
+            },
+            operation: "query",
+            fieldName: "artistsConnection",
+            schema: expect.anything(),
+            context: expect.anything(),
+            info: expect.anything(),
+          })
+        )
+      })
     })
 
-    it("resolves the artistsConnection field", async () => {
-      const { resolvers } = await getGravityStitchedSchema()
-      const { artistsConnection } = resolvers.SearchCriteria
-      const info = { mergeInfo: { delegateToSchema: jest.fn() } }
+    describe("#lowPriceAmount", () => {
+      it("extends the SearchCriteria type with a lowPriceAmount field", async () => {
+        const mergedSchema = await getGravityMergedSchema()
+        const searchCriteriaFields = await getFieldsForTypeFromSchema(
+          "SearchCriteria",
+          mergedSchema
+        )
+        expect(searchCriteriaFields).toContain("lowPriceAmount")
+      })
 
-      artistsConnection.resolve(
-        { artistIDs: ["abc123", "foo"] },
-        { first: 2 },
-        {},
-        info
-      )
+      it("resolves the lowPriceAmount field", async () => {
+        const { resolvers } = await getGravityStitchedSchema()
+        const { lowPriceAmount } = resolvers.SearchCriteria
 
-      expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith(
-        expect.objectContaining({
-          args: {
-            ids: ["abc123", "foo"],
-            first: 2,
-          },
-          operation: "query",
-          fieldName: "artistsConnection",
-          schema: expect.anything(),
-          context: expect.anything(),
-          info: expect.anything(),
-        })
-      )
+        let formattedAmount = lowPriceAmount.resolve(
+          { priceArray: [1000, 10000] },
+          {}
+        )
+
+        expect(formattedAmount).toEqual("$1,000.00")
+
+        formattedAmount = lowPriceAmount.resolve(
+          { priceArray: [null, 10000] },
+          {}
+        )
+
+        expect(formattedAmount).toEqual("*")
+      })
+    })
+
+    describe("#highPriceAmount", () => {
+      it("extends the SearchCriteria type with a highPriceAmount field", async () => {
+        const mergedSchema = await getGravityMergedSchema()
+        const searchCriteriaFields = await getFieldsForTypeFromSchema(
+          "SearchCriteria",
+          mergedSchema
+        )
+        expect(searchCriteriaFields).toContain("highPriceAmount")
+      })
+
+      it("resolves the highPriceAmount field", async () => {
+        const { resolvers } = await getGravityStitchedSchema()
+        const { highPriceAmount } = resolvers.SearchCriteria
+
+        let formattedAmount = highPriceAmount.resolve(
+          { priceArray: [1000, 10000] },
+          {}
+        )
+
+        expect(formattedAmount).toEqual("$10,000.00")
+
+        formattedAmount = highPriceAmount.resolve(
+          { priceArray: [1000, null] },
+          {}
+        )
+
+        expect(formattedAmount).toEqual("*")
+      })
     })
   })
 


### PR DESCRIPTION
This updates our SearchCriteria type to support two new fields:
- lowPriceAmount
- highPriceAmount

These fields are derived from the `priceArray` field from GravQL and then passed through our metaphysics money helpers. 

#### All artists: 

<img width="1024" alt="Screenshot 2023-09-08 at 3 14 24 PM" src="https://github.com/artsy/metaphysics/assets/236943/6127cd7e-b173-4ad0-97bc-46e727e96955">

#### Individual Artists 

<img width="1205" alt="Screenshot 2023-09-08 at 3 25 08 PM" src="https://github.com/artsy/metaphysics/assets/236943/8613ec15-01e0-4add-9f37-f4c189a69def">
