### PR TITLE
chore: Use SearchCriterianSinceEnum as part of SearchCriteriaConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13710,7 +13710,7 @@ type Partner implements Node {
     highQuality: Boolean
     last: Int
     partnerID: String
-    since: Int
+    since: SearchCriteriaSinceEnum
   ): SearchCriteriaConnection
   showPromoted: Boolean
 
@@ -15789,7 +15789,7 @@ type Query {
     highQuality: Boolean
     last: Int
     partnerID: String
-    since: Int
+    since: SearchCriteriaSinceEnum
   ): SearchCriteriaConnection
   shortcut(id: ID!): Shortcut
 
@@ -20401,7 +20401,7 @@ type Viewer {
     highQuality: Boolean
     last: Int
     partnerID: String
-    since: Int
+    since: SearchCriteriaSinceEnum
   ): SearchCriteriaConnection
   shortcut(id: ID!): Shortcut
 

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -154,7 +154,7 @@ export const gravityStitchingEnvironment = (
           artistID: ID,
           highQuality: Boolean,
           partnerID: String,
-          since: Int
+          since: SearchCriteriaSinceEnum
         ): SearchCriteriaConnection
 
         viewingRoomsConnection(first: Int, after: String, statuses: [ViewingRoomStatusEnum!]): ViewingRoomsConnection
@@ -171,7 +171,7 @@ export const gravityStitchingEnvironment = (
           artistID: ID,
           highQuality: Boolean,
           partnerID: String,
-          since: Int
+          since: SearchCriteriaSinceEnum
         ): SearchCriteriaConnection
       }
 
@@ -231,7 +231,7 @@ export const gravityStitchingEnvironment = (
           artistID: ID,
           highQuality: Boolean,
           partnerID: String,
-          since: Int
+          since: SearchCriteriaSinceEnum
         ): SearchCriteriaConnection
         viewingRoomsConnection(first: Int, after: String, statuses: [ViewingRoomStatusEnum!], partnerID: ID): ViewingRoomsConnection
         marketingCollections(


### PR DESCRIPTION
Previously clients were expected to pass in an integer, now allow clients to pass in an Enum value to reduce date parsing/converting

And will also fix this hidden error from GravityGraphQL
<img width="1343" alt="Screen Shot 2023-09-11 at 11 54 33 AM" src="https://github.com/artsy/metaphysics/assets/12748344/9e4f4640-3ac8-4e72-9e59-f64640be3b57">

---

Example use
```
{
  partner(id: "commerce-test-partner") {
    searchCriteriaConnection(first: 500, highQuality: true, since: LAST_30_DAYS) {
      totalCount
      edges {
        node {
          priceArray
          internalID
        }
      }
    }
  }
}
``` 

Eg:
<img width="1287" alt="Screen Shot 2023-09-11 at 11 50 18 AM" src="https://github.com/artsy/metaphysics/assets/12748344/d3b178f7-9225-4cad-85f7-acf819c38f25">
