### PR TITLE
Add href field to previewSavedSearch

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14206,6 +14206,9 @@ type PreviewSavedSearch {
   # A suggestion for a name that describes a set of saved search criteria in a conventional format
   displayName: String!
 
+  # The URL for the user to view the search results
+  href: String
+
   # Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity
   labels: [SearchCriteriaLabel]!
 }

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14206,7 +14206,7 @@ type PreviewSavedSearch {
   # A suggestion for a name that describes a set of saved search criteria in a conventional format
   displayName: String!
 
-  # The URL for the user to view the search results
+  # URL for a user to view the artwork grid with applied filters matching saved search criteria attributes
   href: String
 
   # Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity

--- a/src/schema/v2/__tests__/previewSavedSearch.test.ts
+++ b/src/schema/v2/__tests__/previewSavedSearch.test.ts
@@ -277,4 +277,63 @@ describe("previewSavedSearch", () => {
       })
     })
   })
+
+  describe("href", () => {
+    describe("when no artistIDs are present", () => {
+      it("returns null", async () => {
+        const query = gql`
+          {
+            previewSavedSearch(
+              attributes: {
+                additionalGeneIDs: "prints"
+                attributionClass: "limited edition"
+                priceRange: "100-1000"
+              }
+            ) {
+              href
+            }
+          }
+        `
+
+        const { previewSavedSearch } = await runQuery(query)
+
+        expect(previewSavedSearch.href).toEqual(null)
+      })
+    })
+
+    describe("when artistIDs are present", () => {
+      it("builds correct href based on passed attributes", async () => {
+        const query = gql`
+          {
+            previewSavedSearch(
+              attributes: {
+                acquireable: true
+                additionalGeneIDs: "prints"
+                artistIDs: ["kaws"]
+                atAuction: true
+                attributionClass: ["limited edition", "unique"]
+                colors: ["yellow", "red"]
+                inquireableOnly: true
+                locationCities: ["New York, NY, USA"]
+                majorPeriods: ["1990", "2000"]
+                materialsTerms: ["acrylic", "aluminium"]
+                offerable: true
+                partnerIDs: ["foo-bar-gallery"]
+                priceRange: "100-1000"
+                sizes: [SMALL, MEDIUM]
+              }
+            ) {
+              href
+            }
+          }
+        `
+
+        const { previewSavedSearch } = await runQuery(query)
+
+        expect(previewSavedSearch.href).toEqual(
+          "/artist/kaws?acquireable=true&additional_gene_ids%5B0%5D=prints&at_auction=true&attribution_class%5B0%5D=limited%20edition&attribution_class%5B1%5D=unique&colors%5B0%5D=yellow&colors%5B1%5D=red&inquireable_only=true&location_cities%5B0%5D=New%20York%2C%20NY%2C%20USA&major_periods%5B0%5D=1990&major_periods%5B1%5D=2000&materials_terms%5B0%5D=acrylic&materials_terms%5B1%5D=aluminium&offerable=true&partner_ids%5B0%5D=foo-bar-gallery&price_range=100-1000&sizes%5B0%5D=small&sizes%5B1%5D=medium&for_sale=true"
+        )
+      })
+    })
+  })
 })

--- a/src/schema/v2/previewSavedSearch.ts
+++ b/src/schema/v2/previewSavedSearch.ts
@@ -86,7 +86,8 @@ const PreviewSavedSearchType = new GraphQLObjectType<any, ResolverContext>({
     },
     href: {
       type: GraphQLString,
-      description: "The URL for the user to view the search results",
+      description:
+        "URL for a user to view the artwork grid with applied filters matching saved search criteria attributes",
       resolve: resolveHref,
     },
   }),

--- a/src/schema/v2/previewSavedSearch.ts
+++ b/src/schema/v2/previewSavedSearch.ts
@@ -14,6 +14,8 @@ import {
   resolveSearchCriteriaLabels,
   SearchCriteriaLabel,
 } from "./searchCriteriaLabel"
+import { snakeCaseKeys } from "lib/helpers"
+import { stringify } from "qs"
 
 const previewSavedSearchArgs: GraphQLFieldConfigArgumentMap = {
   acquireable: {
@@ -81,6 +83,11 @@ const PreviewSavedSearchType = new GraphQLObjectType<any, ResolverContext>({
       resolve: resolveSearchCriteriaLabels,
       description:
         "Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity",
+    },
+    href: {
+      type: GraphQLString,
+      description: "The URL for the user to view the search results",
+      resolve: resolveHref,
     },
   }),
 })
@@ -175,4 +182,17 @@ export const generateDisplayName = async (parent, args, context, info) => {
   if (remainingCount > 0) result += ` + ${remainingCount} more`
 
   return result
+}
+
+const resolveHref = async (parent, _args, _context, _info) => {
+  const primaryArtist = parent.artistIDs?.[0]
+
+  if (!primaryArtist) return null
+
+  // Filter out artistIDs and snake_case the rest of the attributes
+  const criteriaAttributesWithoutArtistIds = (({ artistIDs, ...o }) =>
+    snakeCaseKeys(o))(parent)
+  const queryParams = stringify(criteriaAttributesWithoutArtistIds)
+
+  return `/artist/${primaryArtist}?${queryParams}&for_sale=true`
 }


### PR DESCRIPTION
- [Jira ticket](https://artsyproduct.atlassian.net/browse/ONYX-317) (forked from [this one](https://artsyproduct.atlassian.net/browse/ONYX-254))

We need to add a button that leads to artist artworks grid based on saved alerts attributes. Currently Force computes `href` on frontend side ([link](https://github.com/artsy/force/blob/4331d87e14354f15419e682ec609f9e897d65d8f/src/Components/SavedSearchAlert/SavedSearchAlertContext.tsx#L109)). In order to avoid duplicating such logic in Eigen we've decided to encapsulate `href` calculation in Metaphysics.

Such request:

```graphql
query MyQuery {
	previewSavedSearch(
		attributes: {
			acquireable: true
			additionalGeneIDs: "prints"
			artistIDs: ["kaws"]
			atAuction: true
			attributionClass: ["limited edition", "unique"]
			colors: ["yellow", "red"]
			inquireableOnly: true
			locationCities: ["New York, NY, USA"]
			majorPeriods: ["1990", "2000"]
			materialsTerms: ["acrylic", "aluminium"]
			offerable: true
			partnerIDs: ["10-art-and-design"]
			priceRange: "100-1000"
			sizes: [SMALL, MEDIUM]
		}
	) {
		href
	}
}
```

Is going to  produce such href:

```json
{
	"data": {
		"previewSavedSearch": {
			"href": "/artist/kaws?acquireable=true&additional_gene_ids%5B0%5D=prints&at_auction=true&attribution_class%5B0%5D=limited%20edition&attribution_class%5B1%5D=unique&colors%5B0%5D=yellow&colors%5B1%5D=red&inquireable_only=true&location_cities%5B0%5D=New%20York%2C%20NY%2C%20USA&major_periods%5B0%5D=1990&major_periods%5B1%5D=2000&materials_terms%5B0%5D=acrylic&materials_terms%5B1%5D=aluminium&offerable=true&partner_ids%5B0%5D=10-art-and-design&price_range=100-1000&sizes%5B0%5D=small&sizes%5B1%5D=medium&for_sale=true"
		}
	}
}
```