### PR TITLE
feat: add isSavedToList to Artwork type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2280,6 +2280,9 @@ type Artwork implements Node & Searchable & Sellable {
   isPriceRange: Boolean
   isSaved: Boolean
 
+  # Checks if artwork is saved to user's lists
+  isSavedToList(default: Boolean = false, saves: Boolean = true): Boolean!
+
   # Should the video be used as the cover image
   isSetVideoAsCover: Boolean
   isShareable: Boolean

--- a/src/lib/stitching/gravity/schema.ts
+++ b/src/lib/stitching/gravity/schema.ts
@@ -8,7 +8,7 @@ import {
 } from "graphql-tools"
 import { readFileSync } from "fs"
 
-const allowList = [
+const rootFieldsAllowList = [
   "agreement",
   "artistSeries",
   "artistSeriesConnection",
@@ -84,7 +84,7 @@ export const executableGravitySchema = () => {
     // We have the same restrictions for root, so let's prefix
     // for now
     new RenameRootFields((type, name, _field) => {
-      if (type === "Query" && !allowList.includes(name)) {
+      if (type === "Query" && !rootFieldsAllowList.includes(name)) {
         return `_unused_gravity_${name}`
       } else {
         return name

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -1679,6 +1679,52 @@ describe("Artwork type", () => {
     })
   })
 
+  describe("#isSavedToList", () => {
+    const query = gql`
+      query {
+        artwork(id: "catty-artwork-slug") {
+          isSavedToList
+        }
+      }
+    `
+
+    const collectionsMock = {
+      headers: {
+        "x-total-count": 1,
+      },
+    }
+
+    beforeEach(() => {
+      context.collectionsLoader = jest.fn(() =>
+        Promise.resolve(collectionsMock)
+      )
+      context.artworkLoader = jest.fn(() =>
+        Promise.resolve({ _id: "catty-artwork-id" })
+      )
+      context.userID = "percy-z"
+    })
+
+    it("passes the correct args and resolves properly", async () => {
+      const response = await runAuthenticatedQuery(query, context)
+
+      expect(context.collectionsLoader).toHaveBeenCalledWith({
+        artwork_id: "catty-artwork-id",
+        user_id: "percy-z",
+        private: true,
+        saves: true,
+        size: 0,
+        default: false,
+        total_count: true,
+      })
+
+      expect(response).toEqual({
+        artwork: {
+          isSavedToList: true,
+        },
+      })
+    })
+  })
+
   describe("#context", () => {
     it("returns either one Fair, Sale, or PartnerShow", () => {
       const relatedSale = assign({}, sale, {

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -1274,6 +1274,20 @@ describe("Artwork type", () => {
         },
       })
     })
+
+    it("returns null if the fetch returned an error (artwork unpublished)", async () => {
+      context.collectionsLoader = jest.fn(() => {
+        throw new Error("Artwork Not Published")
+      })
+
+      const response = await runAuthenticatedQuery(query, context)
+
+      expect(response).toEqual({
+        artwork: {
+          collectionsConnection: null,
+        },
+      })
+    })
   })
 
   describe("#consignmentSubmission", () => {
@@ -1695,9 +1709,6 @@ describe("Artwork type", () => {
     }
 
     beforeEach(() => {
-      context.collectionsLoader = jest.fn(() =>
-        Promise.resolve(collectionsMock)
-      )
       context.artworkLoader = jest.fn(() =>
         Promise.resolve({ _id: "catty-artwork-id" })
       )
@@ -1705,6 +1716,10 @@ describe("Artwork type", () => {
     })
 
     it("passes the correct args and resolves properly", async () => {
+      context.collectionsLoader = jest.fn(() =>
+        Promise.resolve(collectionsMock)
+      )
+
       const response = await runAuthenticatedQuery(query, context)
 
       expect(context.collectionsLoader).toHaveBeenCalledWith({
@@ -1720,6 +1735,20 @@ describe("Artwork type", () => {
       expect(response).toEqual({
         artwork: {
           isSavedToList: true,
+        },
+      })
+    })
+
+    it("returns false if the fetch returned an error (artwork unpublished)", async () => {
+      context.collectionsLoader = jest.fn(() => {
+        throw new Error("Artwork Not Published")
+      })
+
+      const response = await runAuthenticatedQuery(query, context)
+
+      expect(response).toEqual({
+        artwork: {
+          isSavedToList: false,
         },
       })
     })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -90,6 +90,7 @@ import {
 } from "./utilities"
 import { pageable } from "relay-cursor-paging"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { error } from "lib/loggers"
 
 const has_price_range = (price) => {
   return new RegExp(/-/).test(price)
@@ -378,35 +379,40 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           sort: { type: CollectionSorts },
         }),
         resolve: async (parent, args, context, _info) => {
-          const { id: artwork_id } = parent
-          const { collectionsLoader, userID } = context
-          if (!collectionsLoader) return null
+          try {
+            const { id: artwork_id } = parent
+            const { collectionsLoader, userID } = context
+            if (!collectionsLoader) return null
 
-          const { page, size, offset } = convertConnectionArgsToGravityArgs(
-            args
-          )
+            const { page, size, offset } = convertConnectionArgsToGravityArgs(
+              args
+            )
 
-          const { body, headers } = await collectionsLoader({
-            artwork_id,
-            user_id: userID,
-            private: true,
-            default: args.default,
-            saves: args.saves,
-            sort: args.sort,
-            size,
-            offset,
-            total_count: true,
-          })
-          const totalCount = parseInt(headers?.["x-total-count"] || "0", 10)
+            const { body, headers } = await collectionsLoader({
+              artwork_id,
+              user_id: userID,
+              private: true,
+              default: args.default,
+              saves: args.saves,
+              sort: args.sort,
+              size,
+              offset,
+              total_count: true,
+            })
+            const totalCount = parseInt(headers?.["x-total-count"] || "0", 10)
 
-          return paginationResolver({
-            totalCount,
-            offset,
-            page,
-            size,
-            body,
-            args,
-          })
+            return paginationResolver({
+              totalCount,
+              offset,
+              page,
+              size,
+              body,
+              args,
+            })
+          } catch (e) {
+            error(e)
+            return null
+          }
         },
       },
       collectingInstitution: {
@@ -961,30 +967,35 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           args,
           { savedArtworkLoader, collectionsLoader, userID }
         ) => {
-          const { default: isDefault, saves } = args
+          try {
+            const { default: isDefault, saves } = args
 
-          // For the default saved artworks list, we can use a different loader
-          // that is more performant.
-          if (isDefault && saves) {
-            if (!savedArtworkLoader) return false
+            // For the default saved artworks list, we can use a different loader
+            // that is more performant.
+            if (isDefault && saves) {
+              if (!savedArtworkLoader) return false
 
-            const { is_saved: isSaved } = await savedArtworkLoader(_id)
-            return isSaved
+              const { is_saved: isSaved } = await savedArtworkLoader(_id)
+              return isSaved
+            }
+
+            if (!collectionsLoader || !userID) return false
+            const { headers } = await collectionsLoader({
+              artwork_id: _id,
+              user_id: userID,
+              private: true,
+              size: 0,
+              total_count: true,
+              default: isDefault,
+              saves,
+            })
+            const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+            return totalCount > 0
+          } catch (e) {
+            error(e)
+            return false
           }
-
-          if (!collectionsLoader || !userID) return null
-          const { headers } = await collectionsLoader({
-            artwork_id: _id,
-            user_id: userID,
-            private: true,
-            size: 0,
-            total_count: true,
-            default: isDefault,
-            saves,
-          })
-          const totalCount = parseInt(headers["x-total-count"] || "0", 10)
-
-          return totalCount > 0
         },
       },
       isDisliked: {


### PR DESCRIPTION
This adds `isSavedToList`, including support for the default artwork saves list. In practice, this one field may replace `isSaved` and the custom `collectionsConnection`-exist-y check that is being done currently to determine list-inclusion for the current user/artwork.

I think it's a nice schema addition (suggested by @dblandin ) which will slightly simplify the [client fetch](https://github.com/artsy/force/blob/be6754ecf650bafd5a27203dcee2f29e459e23a3/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActionsSaveButtonV2.tsx#L96-L102).

Additionally, it allows us to possibly further optimize this field (via batching) for the list-inclusion check, as there's some indication that might be [increasing](https://artsy.slack.com/archives/C05EQL4R5N0/p1693499825263889) artwork grid load time. This would be easier done than with the `collectionsConnection` field.

Also - fixes an issue that sometimes crops up around unpublished artworks being returned in artwork grids (due to ES caching) - and the `await` call to fetch collections for that artwork, which loudly errors.