### PR TITLE
chore: allow sending artistIDs to searchCriteriaConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11976,6 +11976,7 @@ type Me implements Node {
   savedSearch(criteria: SearchCriteriaAttributes, id: ID): SearchCriteria
   savedSearchesConnection(
     after: String
+    artistIDs: [String!]
     before: String
     first: Int
     last: Int

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -135,6 +135,7 @@ export const gravityStitchingEnvironment = (
           after: String
           before: String
           sort: SavedSearchesSortEnum
+          artistIDs: [String!]
         ): SearchCriteriaConnection
         secondFactors(kinds: [SecondFactorKind]): [SecondFactor]
         addressConnection(


### PR DESCRIPTION
[ONYX-347]

This PR adds the missing artistIDs param to `Me.searchCriteriaConnection`.

We already added the param support to Gravity here https://github.com/artsy/gravity/pull/16797

| All My Alerts                                                                                                                                              | ArtistIDs filter Applied                                                                                                                                   |
|------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="1630" alt="Screenshot 2023-09-13 at 13 52 32" src="https://github.com/artsy/metaphysics/assets/11945712/4b851a1b-c249-4607-a10c-8a6a014124a8"> | <img width="1627" alt="Screenshot 2023-09-13 at 13 52 07" src="https://github.com/artsy/metaphysics/assets/11945712/2624234d-2fa6-4e53-8af2-f523abd704e7"> |

[ONYX-347]: https://artsyproduct.atlassian.net/browse/ONYX-347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ