### PR TITLE
fix: Change formatting of price high/lows

### DIFF
--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -1134,7 +1134,7 @@ describe("gravity/stitching", () => {
           {}
         )
 
-        expect(formattedAmount).toEqual("*")
+        expect(formattedAmount).toEqual(0)
       })
     })
 
@@ -1164,7 +1164,7 @@ describe("gravity/stitching", () => {
           {}
         )
 
-        expect(formattedAmount).toEqual("*")
+        expect(formattedAmount).toEqual("+")
       })
     })
   })

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -864,7 +864,7 @@ export const gravityStitchingEnvironment = (
           `,
           resolve: (parent, args) => {
             if (!isNumber(parent.priceArray?.[0])) {
-              return "*"
+              return 0
             }
 
             const formattedAmount = formatSearchCriteriaAmount(
@@ -882,7 +882,7 @@ export const gravityStitchingEnvironment = (
           `,
           resolve: (parent, args) => {
             if (!isNumber(parent.priceArray?.[1])) {
-              return "*"
+              return "+"
             }
 
             const formattedAmount = formatSearchCriteriaAmount(


### PR DESCRIPTION
Addressing part of this ticket:
https://artsyproduct.atlassian.net/browse/AMBER-191

Convert asterisks to:
$0 if there’s no min specified (e.g. `$0-$1,000` instead of `*-$1000`)
“+” if there’s no max specified (e.g. `$1,000+` instead of `$1000-*`