### PR TITLE
fix: Adds back currency formatting for zero values

### DIFF
--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -1134,7 +1134,7 @@ describe("gravity/stitching", () => {
           {}
         )
 
-        expect(formattedAmount).toEqual(0)
+        expect(formattedAmount).toEqual("$0.00")
       })
     })
 

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -867,12 +867,12 @@ export const gravityStitchingEnvironment = (
             }
           `,
           resolve: (parent, args) => {
-            if (!isNumber(parent.priceArray?.[0])) {
-              return 0
-            }
+            const price = !isNumber(parent.priceArray?.[0])
+              ? 0
+              : parent.priceArray[0]
 
             const formattedAmount = formatSearchCriteriaAmount(
-              parent.priceArray[0] * 100,
+              price * 100,
               args
             )
             return formattedAmount


### PR DESCRIPTION
Addressing some money formatting feedback
and [here](https://github.com/artsy/volt-v2/pull/684) too

If lowPrice is null return `0` with currency
$0 if there’s no min specified (e.g. “$0-$1,000” instead of “*-$1000”)