### PR TITLE
chore: update artistIDs param to match the one Gravity requests

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11978,7 +11978,7 @@ type Me implements Node {
     after: String
 
     # Returns saved searches associated with the provided artist IDs
-    artistIDs: [ID!]
+    artistIDs: [String!]
     before: String
     first: Int
     last: Int

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -138,7 +138,7 @@ export const gravityStitchingEnvironment = (
           """
           Returns saved searches associated with the provided artist IDs
           """
-          artistIDs: [ID!]
+          artistIDs: [String!]
         ): SearchCriteriaConnection
         secondFactors(kinds: [SecondFactorKind]): [SecondFactor]
         addressConnection(


### PR DESCRIPTION
This PR comes as follow up on https://github.com/artsy/metaphysics/pull/5287

Although we're stitching the schema, we need to update the list of params specified in `stitching.ts` to match the gravity changes.

**Note:** The changes from the previous PR only had an impact on the `_unused_gravity_savedSearchesConnection`
![Screenshot 2023-09-14 at 12 40 17](https://github.com/artsy/metaphysics/assets/11945712/c67b6580-987b-440b-a882-a709e8dde272)
