### PR TITLE
feat(onyx-210): add me.notification query field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11871,6 +11871,12 @@ type Me implements Node {
     first: Int
     last: Int
   ): ArtworkConnection
+
+  # Retrieve one user's notification by notification ID
+  notification(
+    # The ID of the Notification
+    id: String!
+  ): Notification
   orders(
     after: String
     before: String

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -457,6 +457,7 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" }
     ),
+    meNotificationLoader: gravityLoader((id) => `me/notifications/${id}`),
     meLoader: gravityLoader("me"),
     mePartnersLoader: gravityLoader("me/partners"),
     meUpdateCollectorProfileLoader: gravityLoader(

--- a/src/schema/v2/me/__tests__/notification.test.ts
+++ b/src/schema/v2/me/__tests__/notification.test.ts
@@ -30,9 +30,6 @@ describe("me.notification", () => {
     expect(meLoader).toHaveBeenCalled()
     expect(meNotificationLoader).toHaveBeenCalledWith("user-notification-id")
 
-    console.log("[Debug] data")
-    console.log(data)
-
     expect(data).toMatchInlineSnapshot(`
       Object {
         "me": Object {

--- a/src/schema/v2/me/__tests__/notification.test.ts
+++ b/src/schema/v2/me/__tests__/notification.test.ts
@@ -1,0 +1,47 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import { ResolverContext } from "types/graphql"
+
+describe("me.notification", () => {
+  it("returns a notification", async () => {
+    const query = gql`
+      {
+        me {
+          notification(id: "user-notification-id") {
+            internalID
+            message
+          }
+        }
+      }
+    `
+    const meNotificationLoader = jest.fn(async () => ({
+      id: "user-notification-id",
+      message: "6 works added",
+    }))
+    const meLoader = jest.fn(async () => ({ id: "some-user-id" }))
+
+    const context: Partial<ResolverContext> = {
+      meNotificationLoader,
+      meLoader,
+    }
+
+    const data = await runAuthenticatedQuery(query, context)
+
+    expect(meLoader).toHaveBeenCalled()
+    expect(meNotificationLoader).toHaveBeenCalledWith("user-notification-id")
+
+    console.log("[Debug] data")
+    console.log(data)
+
+    expect(data).toMatchInlineSnapshot(`
+      Object {
+        "me": Object {
+          "notification": Object {
+            "internalID": "user-notification-id",
+            "message": "6 works added",
+          },
+        },
+      }
+    `)
+  })
+})

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -68,6 +68,7 @@ import { SimilarToRecentlyViewed } from "./similarToRecentlyViewed"
 import { UserInterest } from "./userInterest"
 import { UserInterestsConnection } from "./userInterestsConnection"
 import { WatchedLotConnection } from "./watchedLotConnection"
+import { NotificationType } from "../notifications"
 
 /**
  * @deprecated: Please use the CollectorProfile type instead of adding fields to me directly.
@@ -367,6 +368,22 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
     },
     newWorksByInterestingArtists: NewWorksByInterestingArtists,
+    notification: {
+      type: NotificationType,
+      description: "Retrieve one user's notification by notification ID",
+      args: {
+        id: {
+          type: new GraphQLNonNull(GraphQLString),
+          description: "The ID of the Notification",
+        },
+      },
+      resolve: (_root, { id }, { meNotificationLoader }) => {
+        if (!meNotificationLoader)
+          throw new Error("You need to be signed in to perform this action")
+
+        return meNotificationLoader(id)
+      },
+    },
     initials: initials("name"),
     paddleNumber: {
       type: GraphQLString,


### PR DESCRIPTION
[Jira ticket](https://artsyproduct.atlassian.net/browse/ONYX-210)

Adds `me.notification` query field, backed by Gravity's `/notifications/:id` endpoint ([PR](https://github.com/artsy/gravity/pull/16823)).

Example request:

```graphql
query MyQuery {
	me {
		notification(id: "6507d7d60cc903ed2ec2b7f4") {
			internalID
			title
			message
			
			artworksConnection(first: 4) {
				edges {
					node {
						title
					}
				}
		  }
		}
	}
}
```

Response:

```json
{
	"data": {
		"me": {
			"notification": {
				"internalID": "6507d7d60cc903ed2ec2b7f4",
				"title": "Works by Banksy $50,000 - 50",
				"message": "6 works added",
				"artworksConnection": {
					"edges": [
						{
							"node": {
								"title": "Integrity Can Buy with Fraud Review"
							}
						},
						{
							"node": {
								"title": "Integrity Can Buy with Fraud Review"
							}
						},
						{
							"node": {
								"title": "Integrity Can Buy with Fraud Review"
							}
						},
						{
							"node": {
								"title": "Integrity Can Buy with Fraud Review"
							}
						}
					]
				}
			}
		}
	},
}
```