### PR TITLE
feat(alerts): add `isEligibleToCreateAlert` to Artwork type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2255,6 +2255,9 @@ type Artwork implements Node & Searchable & Sellable {
 
   # Artwork is eligible for on-platform transaction
   isEligibleForOnPlatformTransaction: Boolean!
+
+  # Artwork meets minimum metadata criteria to have an alert created from it
+  isEligibleToCreateAlert: Boolean!
   isEmbeddableVideo: Boolean
   isForSale: Boolean
   isHangable: Boolean

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -4215,4 +4215,41 @@ describe("Artwork type", () => {
       })
     })
   })
+
+  describe("isEligibleToCreateAlert", () => {
+    beforeEach(() => {
+      artwork.artists = [{ id: "foo" }]
+      artwork.category = "Painting"
+    })
+
+    const query = `
+      {
+        artwork(id: "foo-bar") {
+          isEligibleToCreateAlert
+        }
+      }
+    `
+
+    it("returns true if criteria are met", async () => {
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          isEligibleToCreateAlert: true,
+        },
+      })
+    })
+
+    it("returns false if any criteria are not met", async () => {
+      artwork.category = null
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          isEligibleToCreateAlert: false,
+        },
+      })
+    })
+  })
 })

--- a/src/schema/v2/artwork/__tests__/utilities.test.ts
+++ b/src/schema/v2/artwork/__tests__/utilities.test.ts
@@ -1,5 +1,10 @@
 import { Artwork } from "types/runtime/gravity"
-import { getFigures, isTooBig, isTwoDimensional } from "../utilities"
+import {
+  getFigures,
+  isTooBig,
+  isTwoDimensional,
+  isEligibleToCreateAlert,
+} from "../utilities"
 
 describe("isTwoDimensional", () => {
   let artwork: Artwork
@@ -236,5 +241,31 @@ describe("getFigures", () => {
       { image_url: "foo", type: "Image" },
       { image_url: "bar", type: "Image" },
     ])
+  })
+})
+
+describe("isEligibleToCreateAlert", () => {
+  const artwork = {
+    artists: [{ id: "foo" }],
+    category: "Painting",
+    attribution_class: "unique",
+  }
+
+  it("returns true if basic criteria are met", () => {
+    expect(isEligibleToCreateAlert(artwork)).toBe(true)
+  })
+
+  it("returns false if artwork has no artists", () => {
+    expect(isEligibleToCreateAlert({ ...artwork, artists: [] })).toBe(false)
+  })
+
+  it("returns false if artwork has no medium", () => {
+    expect(isEligibleToCreateAlert({ ...artwork, category: null })).toBe(false)
+  })
+
+  it("returns false if artwork has medium 'Other'", () => {
+    expect(isEligibleToCreateAlert({ ...artwork, category: "Other" })).toBe(
+      false
+    )
   })
 })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -83,6 +83,7 @@ import { TaxInfo } from "./taxInfo"
 import {
   embed,
   getFigures,
+  isEligibleToCreateAlert,
   isEligibleForOnPlatformTransaction,
   isEmbeddedVideo,
   isTooBig,
@@ -751,6 +752,12 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           }
           return false
         },
+      },
+      isEligibleToCreateAlert: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        description:
+          "Artwork meets minimum metadata criteria to have an alert created from it",
+        resolve: isEligibleToCreateAlert,
       },
       isEligibleForArtsyGuarantee: {
         type: new GraphQLNonNull(GraphQLBoolean),

--- a/src/schema/v2/artwork/utilities.ts
+++ b/src/schema/v2/artwork/utilities.ts
@@ -3,6 +3,7 @@ import qs from "querystring"
 import { Artwork } from "types/runtime/gravity"
 import { parse } from "url"
 import { normalizeImageData } from "../image"
+import mediums from "lib/artworkMediums"
 
 export const isTwoDimensional = ({
   width_cm,
@@ -124,4 +125,20 @@ export const isEligibleForOnPlatformTransaction = ({
   }
 
   return false
+}
+
+export const isEligibleToCreateAlert = (artwork: {
+  artists: { id: string }[]
+  category: string | null
+}) => {
+  const { artists, category } = artwork
+
+  // an alert must be associated with at least one valid artist
+  if (artists.length == 0) return false
+
+  // an alert should be associated with a real medium, and not just "Other"
+  if (!category) return false
+  if (category == mediums.Other.name) return false
+
+  return true
 }


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-363

This moves the responsibility for determining _whether an artwork is eligible to have an alert created from it_ up into Metaphysics, instead of being scattered across client code paths in a divergent or error-prone way, e.g.:

- Force: [ArtworkSidebarCreateArtworkAlert.tsx ](https://github.com/artsy/force/blob/e0118180edc02645e595100177e67453e8acfdfa/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCreateArtworkAlert.tsx#L79C1-L79C1)
- Force: [ArtworkSidebarBiddingClosedMessage.tsx](https://github.com/artsy/force/blob/156b302c328600c704360e4998168c1a72186d44/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarBiddingClosedMessage.tsx#L24)
- Eigen: [ArtworkScreenHeaderCreateAlert.tsx](https://github.com/artsy/eigen/blob/090a826251e0e796dc3904f5f0fa7a35df122cf9/src/app/Scenes/Artwork/Components/ArtworkScreenHeaderCreateAlert.tsx#L22)
- Eigen: [ArtworkAuctionCreateAlertHeader.tsx](https://github.com/artsy/eigen/blob/a68106cb6f6a15fd93f43302cca6b36873f642ef/src/app/Scenes/Artwork/ArtworkAuctionCreateAlertHeader.tsx#L34)
- etc…

Will need to be followed by PRs to update the above paths

#### Some real-world examples…

<img width="2445" alt="Screenshot 2023-09-18 at 6 32 48 PM" src="https://github.com/artsy/metaphysics/assets/140521/dd65691f-d69f-4ab0-a93c-af7a2b7745e5">
