### PR TITLE
feat(onyx-349): update gravity schema to support hear from an artsy advisor fields

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7671,6 +7671,7 @@ input CreateSavedSearchInput {
 
   # A unique identifier for the client performing the mutation.
   clientMutationId: String
+  contactRequest: SavedSearchContactRequestInput
   userAlertSettings: UserAlertSettingsInput
 }
 
@@ -16801,6 +16802,21 @@ type SavedArtworksEdge {
   node: Artwork
 }
 
+# Saved search contact request details
+type SavedSearchContactRequest {
+  message: String
+  phoneNumber: String!
+}
+
+# Contact request details
+input SavedSearchContactRequestInput {
+  # Message to an advisor.
+  message: String
+
+  # Phone number.
+  phoneNumber: String!
+}
+
 enum SavedSearchesSortEnum {
   # Sort by created date in descending order
   CREATED_AT_DESC
@@ -16897,6 +16913,7 @@ type SearchCriteria {
   atAuction: Boolean
   attributionClass: [String!]!
   colors: [String!]!
+  contactRequest: SavedSearchContactRequest
   dimensionRange: String
   displayName: String!
   hasRecentlyEnabledUserSearchCriteria: Boolean!

--- a/src/data/gravity.graphql
+++ b/src/data/gravity.graphql
@@ -545,6 +545,7 @@ input CreateSavedSearchInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  contactRequest: SavedSearchContactRequestInput
   userAlertSettings: UserAlertSettingsInput
 }
 
@@ -2070,6 +2071,29 @@ type SaleArtworkEdge {
 }
 
 """
+Saved search contact request details
+"""
+type SavedSearchContactRequest {
+  message: String
+  phoneNumber: String!
+}
+
+"""
+Contact request details
+"""
+input SavedSearchContactRequestInput {
+  """
+  Message to an advisor.
+  """
+  message: String
+
+  """
+  Phone number.
+  """
+  phoneNumber: String!
+}
+
+"""
 Saved Search User Alert Settings
 """
 type SavedSearchUserAlertSettings {
@@ -2111,6 +2135,7 @@ type SearchCriteria {
   atAuction: Boolean
   attributionClass: [String!]!
   colors: [String!]!
+  contactRequest: SavedSearchContactRequest
   dimensionRange: String
   hasRecentlyEnabledUserSearchCriteria: Boolean!
   height: String


### PR DESCRIPTION
Update Gravity GraphQL schema to support `createSaveSearch(input: { contactRequest: {...}})` input field. 

> [!WARNING]
> Do not merge until this [Gravity PR](https://github.com/artsy/gravity/pull/16858) is deployed on production!

Example GraphQL request:

```graphql
mutation CreateSavedSearch {
  createSavedSearch(input: {
    attributes: { artistIDs: ["andy-warhol"] },
    userAlertSettings: {
      push: true,
      email: true
    },
    contactRequest: {
      phoneNumber: "+11 111 111 1111",
      message: "I'm looking for cool warhol prints."
    }
  }) {
    savedSearchOrErrors {
      ... on SearchCriteria {
        contactRequest {
          phoneNumber
          message
        }
      }
      
      ... on Errors {
        errors {
          message
        }
      }
    }
  }
}
```

Response:

```
{
  "data": {
    "createSavedSearch": {
      "savedSearchOrErrors": {
        "contactRequest": {
          "phoneNumber": "+11 111 111 1111",
          "message": "I'm looking for cool warhol prints."
        }
      }
    }
  }
}
```