### PR TITLE
chore: Remove custom price formatting stitching in favor of gravity formatte…

### DIFF
--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -1107,66 +1107,6 @@ describe("gravity/stitching", () => {
         )
       })
     })
-
-    describe("#lowPriceAmount", () => {
-      it("extends the SearchCriteria type with a lowPriceAmount field", async () => {
-        const mergedSchema = await getGravityMergedSchema()
-        const searchCriteriaFields = await getFieldsForTypeFromSchema(
-          "SearchCriteria",
-          mergedSchema
-        )
-        expect(searchCriteriaFields).toContain("lowPriceAmount")
-      })
-
-      it("resolves the lowPriceAmount field", async () => {
-        const { resolvers } = await getGravityStitchedSchema()
-        const { lowPriceAmount } = resolvers.SearchCriteria
-
-        let formattedAmount = lowPriceAmount.resolve(
-          { priceArray: [1000, 10000] },
-          {}
-        )
-
-        expect(formattedAmount).toEqual("$1,000.00")
-
-        formattedAmount = lowPriceAmount.resolve(
-          { priceArray: [null, 10000] },
-          {}
-        )
-
-        expect(formattedAmount).toEqual("$0.00")
-      })
-    })
-
-    describe("#highPriceAmount", () => {
-      it("extends the SearchCriteria type with a highPriceAmount field", async () => {
-        const mergedSchema = await getGravityMergedSchema()
-        const searchCriteriaFields = await getFieldsForTypeFromSchema(
-          "SearchCriteria",
-          mergedSchema
-        )
-        expect(searchCriteriaFields).toContain("highPriceAmount")
-      })
-
-      it("resolves the highPriceAmount field", async () => {
-        const { resolvers } = await getGravityStitchedSchema()
-        const { highPriceAmount } = resolvers.SearchCriteria
-
-        let formattedAmount = highPriceAmount.resolve(
-          { priceArray: [1000, 10000] },
-          {}
-        )
-
-        expect(formattedAmount).toEqual("$10,000.00")
-
-        formattedAmount = highPriceAmount.resolve(
-          { priceArray: [1000, null] },
-          {}
-        )
-
-        expect(formattedAmount).toEqual("+")
-      })
-    })
   })
 
   describe("MarketingCollection", () => {

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -12,7 +12,6 @@ import { dateRange } from "lib/date"
 import { resolveSearchCriteriaLabels } from "schema/v2/searchCriteriaLabel"
 import { generateDisplayName } from "schema/v2/previewSavedSearch"
 import { amount, amountSDL } from "schema/v2/fields/money"
-import { isNumber } from "lodash"
 
 const LocaleEnViewingRoomRelativeShort = "en-viewing-room-relative-short"
 defineCustomLocale(LocaleEnViewingRoomRelativeShort, {
@@ -859,42 +858,6 @@ export const gravityStitchingEnvironment = (
           resolve: resolveSearchCriteriaLabels,
           description:
             "Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity",
-        },
-        lowPriceAmount: {
-          fragment: gql`
-            ... on SearchCriteria {
-              priceArray
-            }
-          `,
-          resolve: (parent, args) => {
-            const price = !isNumber(parent.priceArray?.[0])
-              ? 0
-              : parent.priceArray[0]
-
-            const formattedAmount = formatSearchCriteriaAmount(
-              price * 100,
-              args
-            )
-            return formattedAmount
-          },
-        },
-        highPriceAmount: {
-          fragment: gql`
-            ... on SearchCriteria {
-              priceArray
-            }
-          `,
-          resolve: (parent, args) => {
-            if (!isNumber(parent.priceArray?.[1])) {
-              return "+"
-            }
-
-            const formattedAmount = formatSearchCriteriaAmount(
-              parent.priceArray[1] * 100,
-              args
-            )
-            return formattedAmount
-          },
         },
       },
       Show: {


### PR DESCRIPTION
…dPriceRange value

Removing price format stitching from MP as we can now rely on Gravity to handle the price range formatting for SearchCriteria
- Supporting Gravity Changes: https://github.com/artsy/gravity/pull/16865
- Supporting Volt V2 Changes: https://github.com/artsy/volt-v2/pull/742

I've removed the use of this from Volt V2 yesterday so I dont think any other clients are using the `lowPriceAmount`/`highPriceAmount` fields
