### PR TITLE
feat: allow x-impersonate-user-id headers to grant access to authenticated loaders and propagate

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -150,6 +150,10 @@ const graphqlServer = graphqlHTTP((req, res, params) => {
     | undefined
   const timezone = req.headers["x-timezone"] as string | undefined
   const userAgent = req.headers["user-agent"]
+  const xImpersonateUserID = req.headers["x-impersonate-user-id"] as
+    | string
+    | undefined
+
   const ipAddress = requestIPAddress(req)
 
   const { requestIDs } = res.locals
@@ -172,6 +176,7 @@ const graphqlServer = graphqlHTTP((req, res, params) => {
     appToken,
     xOriginalSessionID,
     isMutation: !!req.body?.query?.includes("mutation"),
+    xImpersonateUserID,
   })
 
   const context: ResolverContext = {

--- a/src/lib/apis/gravity.ts
+++ b/src/lib/apis/gravity.ts
@@ -29,6 +29,11 @@ export default function gravity(
 
   if (accessToken) assign(headers, { "X-ACCESS-TOKEN": accessToken })
 
+  const xImpersonateUserID = fetchOptions.xImpersonateUserID
+  if (xImpersonateUserID) {
+    assign(headers, { "X-IMPERSONATE-USER-ID": xImpersonateUserID })
+  }
+
   return fetch(
     urljoin(
       resolveBlueGreen(

--- a/src/lib/loaders/api/index.ts
+++ b/src/lib/loaders/api/index.ts
@@ -199,10 +199,7 @@ export default (opts) => ({
   gravityLoaderWithAuthenticationFactory: apiLoaderWithAuthenticationFactory(
     gravity,
     "gravity",
-    {
-      requestIDs: opts.requestIDs,
-      userAgent: opts.userAgent,
-    }
+    opts
   ),
 
   /**

--- a/src/lib/loaders/index.ts
+++ b/src/lib/loaders/index.ts
@@ -80,7 +80,7 @@ interface AvailableLoaders extends AllLoaders {
 export const createLoaders = (accessToken, userID, opts): AvailableLoaders => {
   const unauthenticatedLoaders = createLoadersWithoutAuthentication(opts)
   let authenticatedLoaders = {}
-  if (accessToken) {
+  if (accessToken || opts.xImpersonateUserID) {
     authenticatedLoaders = createLoadersWithAuthentication(
       accessToken,
       userID,


### PR DESCRIPTION
This allows an `X-Impersonate-User-ID` header to be passed in to an MP request. If so, it will propagate to gravity, and it will also allow access to the authenticated loaders.

As a demo, this PR allowed the following query to happen (I just tested a piece of the schema that uses the endpoint that was opted-in to this behavior in https://github.com/artsy/gravity/pull/16856).

I specified an `X-Xapp-Token` header, generating one based on the 'Braze staging' client application (which has the `email_provider` role), and my own user id as the `X-Impersonate-User-Id` header value.

And voila!
<img width="1125" alt="Screen Shot 2023-09-26 at 5 30 35 PM" src="https://github.com/artsy/metaphysics/assets/1457859/462707fc-d20b-4f92-9885-3d1ef3bc00c8">


So I think we might be good - as a POC this proves out that Braze can not only directly query Gravity with that header, but can query MP w/ the header and things work as expected.