### PR TITLE
fix(artist): returns null for bio when partner bio is false and we do not have a blurb

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1415,7 +1415,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     format: Format
 
     # If true, will return featured bio over Artsy one.
-    partnerBio: Boolean = false
+    partnerBio: Boolean = true
   ): ArtistBlurb
   birthday: String
   blurb(format: Format): String

--- a/src/schema/v2/artist/__tests__/index.test.js
+++ b/src/schema/v2/artist/__tests__/index.test.js
@@ -512,7 +512,7 @@ describe("Artist type", () => {
       const query = `
         {
           artist(id: "foo-bar") {
-            biographyBlurb {
+            biographyBlurb(partnerBio: false) {
               text
               credit
               partnerID

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -401,7 +401,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
           partnerBio: {
             type: GraphQLBoolean,
             description: "If true, will return featured bio over Artsy one.",
-            defaultValue: false,
+            defaultValue: true,
           },
           ...markdown().args,
         },

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -432,12 +432,17 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
         }),
         resolve: (
           { blurb, id },
-          { format, partnerBio: partner_bio },
+          { format, partnerBio },
           { partnerArtistsForArtistLoader }
         ) => {
-          if (!partner_bio && blurb && blurb.length) {
+          if (!partnerBio && blurb && blurb.length) {
             return { text: formatMarkdownValue(blurb, format) }
           }
+
+          if (!partnerBio) {
+            return null
+          }
+
           return partnerArtistsForArtistLoader(id, {
             size: 1,
             featured: true,


### PR DESCRIPTION
Closes [DIA-171](https://artsyproduct.atlassian.net/browse/DIA-171)

So ultimately this corrects the existing logic and then respects the `partnerBio: false` argument to never return a partner bio.

## Previous logic:
* I want the partner bio and, if none is available, fall back to the Artsy provided bio: `partnerBio: true`
* I want the Artsy provided bio and, if none is available, fall back to the partner bio: `partnerBio: false`
* `defaultValue: false`

## New logic:
* I want the partner bio and, if none is available, fall back to the Artsy provided bio: `partnerBio: true`
* I only want the Artsy provided bio: `partnerBio: false`
* `defaultValue: true`

------

What would make more sense would just be to separate these into different fields. But since these are used in Eigen this is the only way to fix the bug that's present there, currently.

[DIA-171]: https://artsyproduct.atlassian.net/browse/DIA-171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ