### PR TITLE
fix: avoid format if description not present

### DIFF
--- a/src/schema/v2/artist/insights.ts
+++ b/src/schema/v2/artist/insights.ts
@@ -45,6 +45,7 @@ export const ArtistInsight = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       resolve: ({ description }, { format }) => {
+        if (!description) return null
         return formatMarkdownValue(description, format).trim()
       },
     },


### PR DESCRIPTION
@MounirDhahri noticed that we are experiencing an issue when trying to obtain insights without specifying the kind. This problem was introduced on the staging environment with [this PR](https://github.com/artsy/metaphysics/pull/5312).

This PR adds the ability to skip the "marked" function call if we don't have a description.