### PR TITLE
chore: allow passing in phone number attributes when creating an advisory opportunity

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7286,6 +7286,8 @@ type createAdvisoryOpportunityFailure {
 input createAdvisoryOpportunityMutationInput {
   clientMutationId: String
   message: String
+  phoneCountryCode: String
+  phoneNumber: String
   searchCriteriaID: String!
 }
 

--- a/src/schema/v2/__tests__/createAdvisoryOpportunity.test.ts
+++ b/src/schema/v2/__tests__/createAdvisoryOpportunity.test.ts
@@ -4,7 +4,12 @@ import { runAuthenticatedQuery } from "schema/v2/test/utils"
 const mutation = gql`
   mutation {
     createAdvisoryOpportunity(
-      input: { message: "im a cat", searchCriteriaID: "search-criteria-id" }
+      input: {
+        message: "im a cat"
+        searchCriteriaID: "search-criteria-id"
+        phoneCountryCode: "DE"
+        phoneNumber: "123456789"
+      }
     ) {
       advisoryOpportunityOrError {
         __typename
@@ -46,6 +51,8 @@ describe("createAdvisoryOpportunityMutation", () => {
     expect(mockCreateAdvisoryOpportunityLoader).toBeCalledWith({
       message: "im a cat",
       search_criteria_id: "search-criteria-id",
+      phone_country_code: "DE",
+      phone_number: "123456789",
     })
 
     expect(res).toEqual({

--- a/src/schema/v2/createAdvisoryOpportunity.ts
+++ b/src/schema/v2/createAdvisoryOpportunity.ts
@@ -43,6 +43,8 @@ export const createAdvisoryOpportunityMutation = mutationWithClientMutationId<
   {
     message: string
     searchCriteriaID: string
+    phoneCountryCode?: string
+    phoneNumber?: string
   },
   any | null,
   ResolverContext
@@ -52,6 +54,8 @@ export const createAdvisoryOpportunityMutation = mutationWithClientMutationId<
   inputFields: {
     searchCriteriaID: { type: new GraphQLNonNull(GraphQLString) },
     message: { type: GraphQLString },
+    phoneCountryCode: { type: GraphQLString },
+    phoneNumber: { type: GraphQLString },
   },
   outputFields: {
     advisoryOpportunityOrError: {
@@ -61,7 +65,12 @@ export const createAdvisoryOpportunityMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    { message, searchCriteriaID: search_criteria_id },
+    {
+      message,
+      searchCriteriaID: search_criteria_id,
+      phoneCountryCode: phone_country_code,
+      phoneNumber: phone_number,
+    },
     { createAdvisoryOpportunityLoader, userID }
   ) => {
     if (!createAdvisoryOpportunityLoader) {
@@ -80,6 +89,8 @@ export const createAdvisoryOpportunityMutation = mutationWithClientMutationId<
       return await createAdvisoryOpportunityLoader?.({
         message,
         search_criteria_id,
+        phone_country_code,
+        phone_number,
       })
     } catch (error) {
       const formattedErr = formatGravityError(error)


### PR DESCRIPTION
The mutation can optionally accept these fields and pass them through to the backend, which will set the phone number on the user if provided - https://github.com/artsy/gravity/pull/16901