### PR TITLE
chore(AMBER-215): remove lastMessageDeliveryID

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7091,9 +7091,6 @@ type Conversation implements Node {
     timezone: String
   ): String
 
-  # Delivery id if the user is a recipient of the last message, null otherwise.
-  lastMessageDeliveryID: String
-
   # Impulse id of the last message.
   lastMessageID: String
     @deprecated(

--- a/src/schema/v2/conversation/__tests__/__snapshots__/conversation.test.js.snap
+++ b/src/schema/v2/conversation/__tests__/__snapshots__/conversation.test.js.snap
@@ -34,7 +34,6 @@ Array [
 exports[`Me Conversation concerning unread indicator returns the right unread status 1`] = `
 Object {
   "isLastMessageToUser": true,
-  "lastMessageDeliveryID": "2",
   "unread": true,
   "unreadByCollector": true,
   "unreadByPartner": false,

--- a/src/schema/v2/conversation/__tests__/conversation.test.js
+++ b/src/schema/v2/conversation/__tests__/conversation.test.js
@@ -244,7 +244,6 @@ describe("Me", () => {
                 unread
                 unreadByCollector
                 unreadByPartner
-                lastMessageDeliveryID
               }
             }
           }

--- a/src/schema/v2/conversation/index.ts
+++ b/src/schema/v2/conversation/index.ts
@@ -405,39 +405,6 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
       resolve: (conversation) => isLastMessageToUser(conversation),
     },
 
-    // If the user is a recipient of the last message, return the relevant delivery id.
-    // This can be used to mark the message as read, or log other events.
-    lastMessageDeliveryID: {
-      type: GraphQLString,
-      description:
-        "Delivery id if the user is a recipient of the last message, null otherwise.",
-      resolve: (conversation, _options, { conversationMessagesLoader }) => {
-        if (!conversationMessagesLoader || !isLastMessageToUser(conversation)) {
-          return null
-        }
-        const radiationMessageId = get(
-          conversation,
-          "_embedded.last_message.radiation_message_id"
-        )
-        return conversationMessagesLoader({
-          conversation_id: conversation.id,
-          radiation_message_id: radiationMessageId,
-          "expand[]": "deliveries",
-        }).then(({ message_details }) => {
-          if (message_details.length === 0) {
-            return null
-          }
-          const relevantDelivery = message_details[0].deliveries.find(
-            (d) => d.email === conversation.from_email
-          )
-          if (!relevantDelivery) {
-            return null
-          }
-          return relevantDelivery.id
-        })
-      },
-    },
-
     artworks: {
       type: new GraphQLList(ArtworkType),
       description: "Only the artworks discussed in the conversation.",


### PR DESCRIPTION
Sister PR to https://github.com/artsy/impulse/pull/987.

Pretty sure this is safe to remove entirely and not just deprecate; it's not referenced in Eigen and AFAIK conversations haven't been touched there for a while. If folks feel it would be safer to mark as deprecated though, can switch to that.