### PR TITLE
feat: remove the old created year aggregation for auction results

### DIFF
--- a/src/lib/loaders/loaders_without_authentication/diffusion.ts
+++ b/src/lib/loaders/loaders_without_authentication/diffusion.ts
@@ -7,7 +7,6 @@ export default (opts) => {
   return {
     auctionLotsLoader: diffusionLoader("lots"),
     auctionLotLoader: diffusionLoader((id) => `lots/${id}`),
-    auctionCreatedYearRangeLoader: diffusionLoader("lots/created_dates"),
     auctionResultFilterLoader: diffusionLoader(
       "filters/lots",
       {},

--- a/src/schema/v2/__tests__/auction_results.test.js
+++ b/src/schema/v2/__tests__/auction_results.test.js
@@ -332,6 +332,111 @@ describe("Artist type", () => {
     )
   })
 
+  it("returns created date range", () => {
+    context.auctionResultFilterLoader = jest
+      .fn()
+      .mockReturnValueOnce(Promise.resolve(lotsByCreatedYearResponse))
+
+    const query = `
+      {
+        artist(id: "percy-z") {
+          auctionResultsConnection {
+            createdYearRange {
+              startAt
+              endAt
+            }
+          }
+        }
+      }
+    `
+
+    return runQuery(query, context).then(
+      ({
+        artist: {
+          auctionResultsConnection: { createdYearRange },
+        },
+      }) => {
+        expect(createdYearRange).toEqual({
+          startAt: 1900,
+          endAt: 2023,
+        })
+      }
+    )
+  })
+
+  it("does not return the created date range", () => {
+    const lotsByCreatedYearResponse = {
+      lots_by_created_year: {},
+    }
+    context.auctionResultFilterLoader = jest
+      .fn()
+      .mockReturnValueOnce(Promise.resolve(lotsByCreatedYearResponse))
+
+    const query = `
+      {
+        artist(id: "percy-z") {
+          auctionResultsConnection {
+            createdYearRange {
+              startAt
+              endAt
+            }
+          }
+        }
+      }
+    `
+
+    return runQuery(query, context).then(
+      ({
+        artist: {
+          auctionResultsConnection: { createdYearRange },
+        },
+      }) => {
+        expect(createdYearRange).toEqual({
+          startAt: null,
+          endAt: null,
+        })
+      }
+    )
+  })
+
+  it("returns empty created date range", () => {
+    const lotsByCreatedYearResponse = {
+      lots_by_created_year: {
+        2002: { name: "2002", count: 10 },
+      },
+    }
+
+    context.auctionResultFilterLoader = jest
+      .fn()
+      .mockReturnValueOnce(Promise.resolve(lotsByCreatedYearResponse))
+
+    const query = `
+      {
+        artist(id: "percy-z") {
+          auctionResultsConnection {
+            createdYearRange {
+              startAt
+              endAt
+            }
+          }
+        }
+      }
+    `
+
+    return runQuery(query, context).then(
+      ({
+        artist: {
+          auctionResultsConnection: { createdYearRange },
+        },
+      }) => {
+        expect(createdYearRange).toEqual({
+          startAt: 2002,
+          endAt: 2002,
+        })
+      }
+    )
+  })
+
   it("returns correct page info", () => {
     const query = `
       {

--- a/src/schema/v2/auction_result.ts
+++ b/src/schema/v2/auction_result.ts
@@ -442,13 +442,12 @@ export const auctionResultConnection = connectionWithCursorInfo({
               }
             }
           }
+          return {
+            startAt: null,
+            endAt: null,
+          }
         } catch (error) {
           throw new GraphQLError(`createdYearRange resolver error: ${error}`)
-        }
-
-        return {
-          startAt: null,
-          endAt: null,
         }
       },
       type: YearRange,


### PR DESCRIPTION
This PR removes the old loader for created dates.

Currently, this query is only used in [Eigen](https://github.com/artsy/eigen/blob/a031acc72df3314723456c9523500cd9dbdb7e18/src/app/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tsx#L93). 
We can create a follow-up ticket to replace the Eigen aggregation and then remove `createdYearRange` completely from the schema. @MounirDhahri 

[Metaphysics - the new aggregations](https://github.com/artsy/metaphysics/pull/5255/files)
[Diffusion PR](https://github.com/artsy/diffusion/pull/780)
[DIA-133]

@artsy/diamond-devs 


[DIA-133]: https://artsyproduct.atlassian.net/browse/DIA-133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ