### PR TITLE
fix: remove description for some insights

### DIFF
--- a/src/schema/v2/artist/helpers.ts
+++ b/src/schema/v2/artist/helpers.ts
@@ -136,7 +136,7 @@ export const ARTIST_INSIGHT_MAPPING: Record<
     getLabel: () => "Recent career event",
   },
   RESIDENCIES: {
-    getDescription: () => "Established artist residencies",
+    getDescription: () => null,
     getEntities: (artist) => splitEntities(artist.residencies),
     getLabel: (_artist, count: number) =>
       `Participated in ${
@@ -146,7 +146,7 @@ export const ARTIST_INSIGHT_MAPPING: Record<
       }`,
   },
   PRIVATE_COLLECTIONS: {
-    getDescription: () => "A list of collections they are part of",
+    getDescription: () => null,
     getEntities: (artist) => splitEntities(artist.private_collections),
     getLabel: (_artist, count: number) =>
       `Collected by ${
@@ -156,7 +156,7 @@ export const ARTIST_INSIGHT_MAPPING: Record<
       }`,
   },
   AWARDS: {
-    getDescription: () => "Awards and prizes the artist has won",
+    getDescription: () => null,
     getEntities: (artist) => splitEntities(artist.awards),
     getLabel: (_artist, count: number) =>
       `Winner of ${


### PR DESCRIPTION
Remove the descriptions so we use the entities instead.

![image](https://github.com/artsy/metaphysics/assets/1176374/c0701eb9-3337-48a0-bdfd-b16887f9d27c)


[Slack](https://artsy.slack.com/archives/C05EEBNEF71/p1696869404116629)