### PR TITLE
fix: dont set user id into context when its already there

### DIFF
--- a/src/schema/v2/me/myCollectionInfo.ts
+++ b/src/schema/v2/me/myCollectionInfo.ts
@@ -231,15 +231,13 @@ const MyCollectionInfoType = new GraphQLObjectType<any, ResolverContext>({
 export const MyCollectionInfo: GraphQLFieldConfig<any, ResolverContext> = {
   type: MyCollectionInfoType,
   description: "Info about the current user's my-collection",
-  resolve: async ({ id }, _options, context) => {
-    if (!context.collectionLoader) {
+  resolve: async (_parent, _options, { userID, collectionLoader }) => {
+    if (!(collectionLoader && userID)) {
       return null
     }
 
-    context.userID = id
-
-    const collectionResponse = await context.collectionLoader("my-collection", {
-      user_id: id,
+    const collectionResponse = await collectionLoader("my-collection", {
+      user_id: userID,
       private: true,
     })
 


### PR DESCRIPTION
This came up when reviewing https://github.com/artsy/metaphysics/pull/5337/files#r1355377518 , and I traced it back to where it was introduced - https://github.com/artsy/metaphysics/pull/4200

That PR is pretty much wrong (I don't know how else to put it 😆 ) - the `userID` already will exist in the context, and so plucking it out of the `me` response and _setting_ it into context is unnecessary - it's already there!

Furthermore, writing to `context` in a resolver is an anti-pattern / bug waiting to happen - that will 'leak' to other fields + resolvers that are happening in the same request. Another field accessing `context.userID` later in the request will be reading this same global value. In practice this may not be a bug b/c the `userID` is likely going to be the same, but still. Context should only be written to once per request.