### PR TITLE
fix: incorporate -dev compose template

### DIFF
--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   metaphysics:
-{% include 'templates/docker-compose-service.yml.j2' %}
+{% include 'templates/docker-compose-service-dev.yml.j2' %}
     command: ["yarn", "start"]
     env_file:
       - ../.env.development

--- a/hokusai/templates/docker-compose-service-dev.yml.j2
+++ b/hokusai/templates/docker-compose-service-dev.yml.j2
@@ -1,2 +1,3 @@
     build:
       context: ../
+      target: builder-base


### PR DESCRIPTION
Follow-up to https://github.com/artsy/metaphysics/pull/5341

Fixes broken [builds](https://app.circleci.com/pipelines/github/artsy/metaphysics/19542/workflows/f5a03efe-b092-402c-a818-b05997961431/jobs/41167?invite=true#step-106-1555_25) as a result of `docker-compose` template change.