### PR TITLE
feat: expose userRoles at root

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11153,6 +11153,11 @@ type LinkAuthenticationMutationPayload {
 
 union ListPrice = Money | PriceRange
 
+enum LiveAuctionRole {
+  OPERATOR
+  PARTICIPANT
+}
+
 type Location {
   address: String
   address2: String
@@ -16249,11 +16254,6 @@ type ReverseImageSearchResults {
   results: [ReverseImageSearchResult]!
 }
 
-enum Role {
-  OPERATOR
-  PARTICIPANT
-}
-
 # The conditions for uploading assets to media.artsy.net
 type S3PolicyConditionsType {
   # The assigned access control
@@ -17820,7 +17820,7 @@ type System {
 
   # Creates, and authorizes, a JWT custom for Causality
   causalityJWT(
-    role: Role
+    role: LiveAuctionRole
 
     # The id of the auction to participate in
     saleID: String!
@@ -17832,6 +17832,9 @@ type System {
 
   # Gravity system time, necessary for synchronizing device clocks.
   time: SystemTime
+
+  # List of all available product privileges
+  userRoles: [UserRole]
 }
 
 type SystemTime {
@@ -19494,6 +19497,12 @@ type UserPurchasesEdge {
   ): String
   salePrice: Float
   source: String
+}
+
+# Fields corresponding to a given product privilege
+type UserRole {
+  # unique label for this role
+  name: String
 }
 
 type UserSaleProfile {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -594,6 +594,7 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    userRolesLoader: gravityLoader("system/roles"),
     saleArtworksAllLoader: gravityLoader(
       "sale_artworks",
       {},

--- a/src/schema/v2/system/__tests__/userRoles.test.ts
+++ b/src/schema/v2/system/__tests__/userRoles.test.ts
@@ -1,0 +1,36 @@
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+const ROLES_FIXTURE = [
+  {
+    name: "content_manager",
+  },
+  {
+    name: "sales_observer",
+  },
+]
+
+describe("userRoles", () => {
+  it("returns a list of roles", async () => {
+    const userRolesLoader = jest
+      .fn()
+      .mockReturnValue(Promise.resolve(ROLES_FIXTURE))
+
+    const query = gql`
+      {
+        system {
+          userRoles {
+            name
+          }
+        }
+      }
+    `
+    const {
+      system: { userRoles },
+    } = await runAuthenticatedQuery(query, {
+      userRolesLoader,
+    })
+
+    expect(userRoles[0].name).toEqual("content_manager")
+  })
+})

--- a/src/schema/v2/system/causality_jwt.ts
+++ b/src/schema/v2/system/causality_jwt.ts
@@ -29,7 +29,7 @@ const CausalityJWT: GraphQLFieldConfig<void, ResolverContext> = {
   args: {
     role: {
       type: new GraphQLEnumType({
-        name: "Role",
+        name: "LiveAuctionRole",
         values: {
           PARTICIPANT: { value: "PARTICIPANT" },
           OPERATOR: { value: "OPERATOR" },
@@ -53,7 +53,7 @@ const CausalityJWT: GraphQLFieldConfig<void, ResolverContext> = {
     }
     // Observer role for logged out users
     if (!meLoader || !meBiddersLoader || !mePartnersLoader) {
-      return saleLoader(options.sale_id).then(sale =>
+      return saleLoader(options.sale_id).then((sale) =>
         causalityJwt({
           role: "observer",
           userId: null,
@@ -99,7 +99,7 @@ const CausalityJWT: GraphQLFieldConfig<void, ResolverContext> = {
 
           if (sale.partner) {
             return mePartnersLoader({ "partner_ids[]": sale.partner._id }).then(
-              mePartners => {
+              (mePartners) => {
                 // Check if current user has access to partner running the sale
                 if (mePartners.length === 0) {
                   throw new Error("Unauthorized to be operator")

--- a/src/schema/v2/system/index.ts
+++ b/src/schema/v2/system/index.ts
@@ -9,6 +9,7 @@ import SystemTime from "./time"
 import Services from "./services"
 import { ResolverContext } from "types/graphql"
 import { Algolia } from "../algolia"
+import { UserRoles } from "./userRoles"
 
 const SystemType = new GraphQLObjectType<any, ResolverContext>({
   name: "System",
@@ -31,6 +32,7 @@ const SystemType = new GraphQLObjectType<any, ResolverContext>({
       }),
       resolve: () => ({}),
     },
+    userRoles: UserRoles,
   },
 })
 

--- a/src/schema/v2/system/userRoles.ts
+++ b/src/schema/v2/system/userRoles.ts
@@ -1,0 +1,32 @@
+import {
+  GraphQLList,
+  GraphQLFieldConfig,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+
+const UserRoleType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UserRole",
+  description: "Fields corresponding to a given product privilege",
+  fields: {
+    name: {
+      type: GraphQLString,
+      description: "unique label for this role",
+    },
+  },
+})
+
+export const UserRoles: GraphQLFieldConfig<void, ResolverContext> = {
+  type: new GraphQLList(UserRoleType),
+  description: "List of all available product privileges",
+  resolve: async (_root, _args, { userRolesLoader }) => {
+    if (!userRolesLoader) {
+      throw new Error(
+        "You need to pass a X-Access-Token header to perform this action"
+      )
+    }
+
+    return userRolesLoader()
+  },
+}


### PR DESCRIPTION
This is the partner to https://github.com/artsy/gravity/pull/16963. I was able to copy+paste my way to a working response. Feedback welcome.

Unfortunately Causality already exposes a `Role` enum, so I called the new type `UserRole` which sort of matches the few mutations in this area.