### PR TITLE
Revert "feat: update prediction mp schema"

### DIFF
--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -71,7 +71,6 @@ async function main() {
     const reposToUpdate = [
       { repo: "eigen", body: `${defaultBody} #nochangelog` },
       { repo: "energy" },
-      { repo: "prediction" },
       { repo: "force" },
       { repo: "forque" },
       { repo: "volt-v2" },


### PR DESCRIPTION
Reverts artsy/metaphysics#5360

Prediction _does_ need an updated copy of Metaphysics' schema, but this automatic push failed with errors like:

```
Error: Command failed: yarn relay
Watchman:  spawn watchman ENOENT
...
error Command failed with exit code 100.

    at checkExecSyncError (node:child_process:885:11)
    at execSync (node:child_process:957:15)
...
```

`yarn relay` also fails locally with slightly different errors. Until that can be fixed, let's exclude Prediction from this step so Metaphysics can build successfully.