### PR TITLE
Revert "Revert "feat: update prediction mp schema""

### DIFF
--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -71,6 +71,7 @@ async function main() {
     const reposToUpdate = [
       { repo: "eigen", body: `${defaultBody} #nochangelog` },
       { repo: "energy" },
+      { repo: "prediction" },
       { repo: "force" },
       { repo: "forque" },
       { repo: "volt-v2" },


### PR DESCRIPTION
This reverts https://github.com/artsy/metaphysics/pull/5360 and re-adds https://github.com/artsy/metaphysics/pull/5363.

It should only be merged after https://github.com/artsy/prediction/pull/1224, which fixes Prediction's `yarn relay` command.