### PR TITLE
feat: allow resolution of Notification#searchCriteria

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13238,6 +13238,8 @@ interface Node {
 }
 
 type Notification implements Node {
+  actorIDs: [String]
+  actorType: String
   artworksConnection(
     after: String
     before: String
@@ -13266,6 +13268,7 @@ type Notification implements Node {
     # pass `RELATIVE` to display the human-friendly date (e.g. "Today", "Yesterday", "5 days ago")
     format: String
   ): String!
+  searchCriteria: SearchCriteria
   targetHref: String!
   title: String!
 }

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -148,6 +148,10 @@ export const gravityStitchingEnvironment = (
         ): UserAddressConnection
       }
 
+      extend type Notification {
+        searchCriteria: SearchCriteria
+      }
+
       extend type Partner {
         searchCriteriaConnection(
           first: Int,
@@ -694,6 +698,32 @@ export const gravityStitchingEnvironment = (
               operation: "query",
               fieldName: "_unused_gravity_userAddressConnection",
               args: { ...args, userId: context.userID },
+              context,
+              info,
+            })
+          },
+        },
+      },
+      Notification: {
+        searchCriteria: {
+          fragment: gql`
+          ... on Notification {
+            actorIDs
+            actorType
+          }
+          `,
+          resolve: ({ actorIDs, actorType }, _args, context, info) => {
+            if (actorType !== "SearchCriteria") {
+              return null
+            }
+
+            return info.mergeInfo.delegateToSchema({
+              schema: gravitySchema,
+              operation: "query",
+              fieldName: "_unused_gravity_savedSearch",
+              args: {
+                id: actorIDs[0],
+              },
               context,
               info,
             })

--- a/src/schema/v2/notifications/index.ts
+++ b/src/schema/v2/notifications/index.ts
@@ -40,6 +40,14 @@ export const NotificationType = new GraphQLObjectType<any, ResolverContext>({
   interfaces: [NodeInterface],
   fields: () => ({
     ...IDFields,
+    actorIDs: {
+      type: new GraphQLList(GraphQLString),
+      resolve: ({ actor_ids }) => actor_ids,
+    },
+    actorType: {
+      type: GraphQLString,
+      resolve: ({ actor_type }) => actor_type,
+    },
     title: {
       type: new GraphQLNonNull(GraphQLString),
       resolve: ({ actors }) => actors,


### PR DESCRIPTION
Allow clients to query for the searchCriteria associated with "artwork alert" notification type.

Dependent upon https://github.com/artsy/gravity/pull/16991

### Screenshot

To support a "Manage Alert" link in this Figma prototype:

<img alt="Screenshot 2023-10-24 at 17 56 35" src="https://github.com/artsy/metaphysics/assets/123595/05d67c33-9569-4af3-9cf8-78cecc86edc4" width=300 />
