### PR TITLE
fix: Expose sort argument in gravity stitching for searchCriteriaConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13777,6 +13777,7 @@ type Partner implements Node {
     last: Int
     partnerID: String
     since: SearchCriteriaSinceEnum
+    sort: SearchCriteriaSortEnum
   ): SearchCriteriaConnection
   showPromoted: Boolean
 
@@ -15868,6 +15869,7 @@ type Query {
     last: Int
     partnerID: String
     since: SearchCriteriaSinceEnum
+    sort: SearchCriteriaSortEnum
   ): SearchCriteriaConnection
   shortcut(id: ID!): Shortcut
 
@@ -20499,6 +20501,7 @@ type Viewer {
     last: Int
     partnerID: String
     since: SearchCriteriaSinceEnum
+    sort: SearchCriteriaSortEnum
   ): SearchCriteriaConnection
   shortcut(id: ID!): Shortcut
 

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -158,6 +158,7 @@ export const gravityStitchingEnvironment = (
           highQuality: Boolean,
           partnerID: String,
           since: SearchCriteriaSinceEnum
+          sort: SearchCriteriaSortEnum
         ): SearchCriteriaConnection
 
         viewingRoomsConnection(first: Int, after: String, statuses: [ViewingRoomStatusEnum!]): ViewingRoomsConnection
@@ -175,6 +176,7 @@ export const gravityStitchingEnvironment = (
           highQuality: Boolean,
           partnerID: String,
           since: SearchCriteriaSinceEnum
+          sort: SearchCriteriaSortEnum
         ): SearchCriteriaConnection
       }
 
@@ -235,6 +237,7 @@ export const gravityStitchingEnvironment = (
           highQuality: Boolean,
           partnerID: String,
           since: SearchCriteriaSinceEnum
+          sort: SearchCriteriaSortEnum
         ): SearchCriteriaConnection
         viewingRoomsConnection(first: Int, after: String, statuses: [ViewingRoomStatusEnum!], partnerID: ID): ViewingRoomsConnection
         marketingCollections(


### PR DESCRIPTION
Exposing `sort` argument in gravity stitching for searchCriteriaConnection

Discovered it was missing [here](https://artsy.slack.com/archives/C05F8TNKGAV/p1698172709479449)