### PR TITLE
feat: add eslint rule sort-keys

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,11 @@
   ],
   "parser": "@typescript-eslint/parser",
   "rules": {
+    "sort-keys": [
+      "warn",
+      "asc",
+      { "caseSensitive": true, "natural": false, "minKeys": 2 }
+    ],
     "import/first": 0,
     "import/named": 0,
     "import/default": 0,

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
       "yarn prettier --write",
       "git add"
     ],
-    "*.@(js)": [
+    "*.@(js|ts)": [
       "eslint --fix",
       "yarn prettier --write",
       "git add"


### PR DESCRIPTION
I was motivated to create this PR after reading this [comment](https://github.com/artsy/metaphysics/pull/5358#discussion_r1370290136). To simplify the linting process for everyone, we could introduce the ESLint rule `sort-keys`. We can begin with 'warn' first before implementing it as an 'error' to avoid any blockers.

<img width="1118" alt="Screenshot 2023-10-25 at 17 43 13" src="https://github.com/artsy/metaphysics/assets/1176374/e8170659-8917-4567-bd18-fd334c365b4d">
