### PR TITLE
chore: userRoles.name should never be null

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -19507,7 +19507,7 @@ type UserPurchasesEdge {
 # Fields corresponding to a given product privilege
 type UserRole {
   # unique label for this role
-  name: String
+  name: String!
 }
 
 type UserSaleProfile {

--- a/src/schema/v2/system/userRoles.ts
+++ b/src/schema/v2/system/userRoles.ts
@@ -3,6 +3,7 @@ import {
   GraphQLFieldConfig,
   GraphQLObjectType,
   GraphQLString,
+  GraphQLNonNull,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
 
@@ -11,7 +12,7 @@ const UserRoleType = new GraphQLObjectType<any, ResolverContext>({
   description: "Fields corresponding to a given product privilege",
   fields: {
     name: {
-      type: GraphQLString,
+      type: new GraphQLNonNull(GraphQLString),
       description: "unique label for this role",
     },
   },


### PR DESCRIPTION
It was suggested around [this downstream change](https://github.com/artsy/forque/pull/1064) that `userRoles`' `name`s should never be `null`.