### PR TITLE
feat: Add metric support to Saved Search display name and labels

### DIFF
--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -3,6 +3,8 @@ import { resolveSearchCriteriaLabels } from "../searchCriteriaLabel"
 const _ = {}
 
 describe("resolveSearchCriteriaLabels", () => {
+  const meLoader = async () => ({ length_unit_preference: "cm" })
+
   it("formats artist criteria", async () => {
     const parent = {
       artistIDs: ["foo-bar", "baz-qux"],
@@ -13,6 +15,7 @@ describe("resolveSearchCriteriaLabels", () => {
         .fn()
         .mockReturnValueOnce(Promise.resolve({ name: "Foo Bar" }))
         .mockReturnValueOnce(Promise.resolve({ name: "Baz Qux" })),
+      meLoader,
     }
 
     const labels = await resolveSearchCriteriaLabels(parent, _, context, _)
@@ -43,7 +46,7 @@ describe("resolveSearchCriteriaLabels", () => {
       ],
     }
 
-    const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+    const labels = await resolveSearchCriteriaLabels(parent, _, { meLoader }, _)
 
     expect(labels).toIncludeAllMembers([
       {
@@ -94,7 +97,12 @@ describe("resolveSearchCriteriaLabels", () => {
         ],
       }
 
-      const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+      const labels = await resolveSearchCriteriaLabels(
+        parent,
+        _,
+        { meLoader },
+        _
+      )
 
       expect(labels).toIncludeAllMembers([
         {
@@ -188,7 +196,12 @@ describe("resolveSearchCriteriaLabels", () => {
         additionalGeneIDs: ["watercolor"],
       }
 
-      const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+      const labels = await resolveSearchCriteriaLabels(
+        parent,
+        _,
+        { meLoader },
+        _
+      )
 
       expect(labels).toIncludeAllMembers([
         {
@@ -204,7 +217,12 @@ describe("resolveSearchCriteriaLabels", () => {
         additionalGeneIDs: ["4d90d18edcdd5f44a5000010"],
       }
 
-      const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+      const labels = await resolveSearchCriteriaLabels(
+        parent,
+        _,
+        { meLoader },
+        _
+      )
 
       expect(labels).toIncludeAllMembers([
         {
@@ -223,7 +241,12 @@ describe("resolveSearchCriteriaLabels", () => {
         const parent = {
           priceRange: "42-420",
         }
-        const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+        const labels = await resolveSearchCriteriaLabels(
+          parent,
+          _,
+          { meLoader },
+          _
+        )
 
         expect(labels).toIncludeAllMembers([
           {
@@ -241,7 +264,12 @@ describe("resolveSearchCriteriaLabels", () => {
         const parent = {
           priceRange: "42-*",
         }
-        const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+        const labels = await resolveSearchCriteriaLabels(
+          parent,
+          _,
+          { meLoader },
+          _
+        )
 
         expect(labels).toIncludeAllMembers([
           {
@@ -259,7 +287,12 @@ describe("resolveSearchCriteriaLabels", () => {
         const parent = {
           priceRange: "*-420",
         }
-        const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+        const labels = await resolveSearchCriteriaLabels(
+          parent,
+          _,
+          { meLoader },
+          _
+        )
 
         expect(labels).toIncludeAllMembers([
           {
@@ -278,7 +311,7 @@ describe("resolveSearchCriteriaLabels", () => {
       sizes: ["LARGE", "MEDIUM", "SMALL"],
     }
 
-    const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+    const labels = await resolveSearchCriteriaLabels(parent, _, { meLoader }, _)
 
     expect(labels).toIncludeAllMembers([
       {
@@ -308,7 +341,12 @@ describe("resolveSearchCriteriaLabels", () => {
         height: "0.39370078740157477-*",
       }
 
-      const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+      const labels = await resolveSearchCriteriaLabels(
+        parent,
+        _,
+        { meLoader },
+        _
+      )
 
       expect(labels).toIncludeAllMembers([
         {
@@ -324,7 +362,12 @@ describe("resolveSearchCriteriaLabels", () => {
         height: "*-3.937007874015748",
       }
 
-      const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+      const labels = await resolveSearchCriteriaLabels(
+        parent,
+        _,
+        { meLoader },
+        _
+      )
 
       expect(labels).toIncludeAllMembers([
         {
@@ -340,7 +383,12 @@ describe("resolveSearchCriteriaLabels", () => {
         height: "0.39370078740157477-3.937007874015748",
       }
 
-      const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+      const labels = await resolveSearchCriteriaLabels(
+        parent,
+        _,
+        { meLoader },
+        _
+      )
 
       expect(labels).toIncludeAllMembers([
         {
@@ -356,7 +404,12 @@ describe("resolveSearchCriteriaLabels", () => {
         width: "0.39370078740157477-*",
       }
 
-      const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+      const labels = await resolveSearchCriteriaLabels(
+        parent,
+        _,
+        { meLoader },
+        _
+      )
 
       expect(labels).toIncludeAllMembers([
         {
@@ -372,7 +425,12 @@ describe("resolveSearchCriteriaLabels", () => {
         width: "*-3.937007874015748",
       }
 
-      const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+      const labels = await resolveSearchCriteriaLabels(
+        parent,
+        _,
+        { meLoader },
+        _
+      )
 
       expect(labels).toIncludeAllMembers([
         {
@@ -388,7 +446,12 @@ describe("resolveSearchCriteriaLabels", () => {
         width: "0.39370078740157477-3.937007874015748",
       }
 
-      const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+      const labels = await resolveSearchCriteriaLabels(
+        parent,
+        _,
+        { meLoader },
+        _
+      )
 
       expect(labels).toIncludeAllMembers([
         {
@@ -405,7 +468,12 @@ describe("resolveSearchCriteriaLabels", () => {
         width: "*-20",
       }
 
-      const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+      const labels = await resolveSearchCriteriaLabels(
+        parent,
+        _,
+        { meLoader },
+        _
+      )
 
       expect(labels).toIncludeAllMembers([
         {
@@ -432,7 +500,7 @@ describe("resolveSearchCriteriaLabels", () => {
       offerable: true,
     }
 
-    const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+    const labels = await resolveSearchCriteriaLabels(parent, _, { meLoader }, _)
 
     expect(labels).toIncludeAllMembers([
       {
@@ -467,7 +535,7 @@ describe("resolveSearchCriteriaLabels", () => {
       materialsTerms: ["acrylic", "c-print"],
     }
 
-    const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+    const labels = await resolveSearchCriteriaLabels(parent, _, { meLoader }, _)
 
     expect(labels).toIncludeAllMembers([
       {
@@ -490,7 +558,7 @@ describe("resolveSearchCriteriaLabels", () => {
       locationCities: ["Durham, PA, USA", "New York, NY, USA"],
     }
 
-    const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+    const labels = await resolveSearchCriteriaLabels(parent, _, { meLoader }, _)
 
     expect(labels).toIncludeAllMembers([
       {
@@ -513,7 +581,7 @@ describe("resolveSearchCriteriaLabels", () => {
       majorPeriods: ["1990", "Early 19th Century"],
     }
 
-    const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+    const labels = await resolveSearchCriteriaLabels(parent, _, { meLoader }, _)
 
     expect(labels).toIncludeAllMembers([
       {
@@ -536,7 +604,7 @@ describe("resolveSearchCriteriaLabels", () => {
       colors: ["blue", "yellow"],
     }
 
-    const labels = await resolveSearchCriteriaLabels(parent, _, _, _)
+    const labels = await resolveSearchCriteriaLabels(parent, _, { meLoader }, _)
 
     expect(labels).toIncludeAllMembers([
       {
@@ -564,6 +632,7 @@ describe("resolveSearchCriteriaLabels", () => {
         .fn()
         .mockReturnValueOnce(Promise.resolve({ name: "Foo Bar Gallery" }))
         .mockReturnValueOnce(Promise.resolve({ name: "Baz Qux Gallery" })),
+      meLoader,
     }
 
     const labels = await resolveSearchCriteriaLabels(parent, _, context, _)

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -91,7 +91,7 @@ const collectorProfileResolver = (field: string) => async (
 // These default values are only necessary due to caching issues in Gravity.
 // Normally Gravity should always send values for these preferences.
 const DEFAULT_CURRENCY_PREFERENCE = "USD"
-const DEFAULT_LENGTH_UNIT_PREFERENCE = "in"
+export const DEFAULT_LENGTH_UNIT_PREFERENCE = "in"
 
 export const CurrencyPreference = new GraphQLEnumType({
   name: "CurrencyPreference",

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -7,13 +7,11 @@ import allAttributionClasses from "lib/attributionClasses"
 import { COLORS } from "lib/colors"
 import { round } from "lodash"
 
-// Taken from Force's SizeFilter component
 export const SIZES_IN_CM = {
   SMALL: "Small (under 40cm)",
   MEDIUM: "Medium (40 – 100cm)",
   LARGE: "Large (over 100cm)",
 }
-
 export const SIZES_IN_INCHES = {
   SMALL: "Small (under 16in)",
   MEDIUM: "Medium (16in – 40in)",
@@ -21,6 +19,8 @@ export const SIZES_IN_INCHES = {
 }
 
 const ONE_IN_TO_CM = 2.54
+
+const DEFAULT_METRIC = "in"
 
 export type SearchCriteriaLabel = {
   /** The GraphQL field name of the filter facet */
@@ -110,7 +110,7 @@ export const resolveSearchCriteriaLabels = async (
 
   const { artistLoader, meLoader, partnerLoader } = context
 
-  const { length_unit_preference: metric } = await meLoader()
+  const metric = await getPreferredMetric(meLoader)
 
   const labels: any[] = []
 
@@ -411,6 +411,14 @@ function getColorLabels(colors: string[]) {
       field: "colors",
     }
   })
+}
+
+const getPreferredMetric = async (meLoader) => {
+  if (!meLoader) return DEFAULT_METRIC
+
+  const { length_unit_preference } = await meLoader()
+
+  return length_unit_preference
 }
 
 async function getPartnerLabels(partnerIDs: string[], partnerLoader) {

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -8,10 +8,16 @@ import { COLORS } from "lib/colors"
 import { round } from "lodash"
 
 // Taken from Force's SizeFilter component
-export const SIZES = {
+export const SIZES_IN_CM = {
   SMALL: "Small (under 40cm)",
   MEDIUM: "Medium (40 – 100cm)",
   LARGE: "Large (over 100cm)",
+}
+
+export const SIZES_IN_INCHES = {
+  SMALL: "Small (under 16in)",
+  MEDIUM: "Medium (16in – 40in)",
+  LARGE: "Large (over 40in)",
 }
 
 const ONE_IN_TO_CM = 2.54
@@ -104,7 +110,7 @@ export const resolveSearchCriteriaLabels = async (
 
   const { artistLoader, meLoader, partnerLoader } = context
 
-  const { length_unit_preference } = await meLoader()
+  const { length_unit_preference: metric } = await meLoader()
 
   const labels: any[] = []
 
@@ -112,10 +118,8 @@ export const resolveSearchCriteriaLabels = async (
   labels.push(getRarityLabels(attributionClass))
   labels.push(getMediumLabels(additionalGeneIDs))
   labels.push(getPriceLabel(priceRange))
-  labels.push(getSizeLabels(sizes))
-  labels.push(
-    getCustomSizeLabels({ height, metric: length_unit_preference, width })
-  )
+  labels.push(getSizeLabels(sizes, metric))
+  labels.push(getCustomSizeLabels({ height, metric, width }))
   labels.push(
     getWaysToBuyLabels({
       acquireable,
@@ -218,7 +222,7 @@ function getPriceLabel(priceRange: string): SearchCriteriaLabel | undefined {
   }
 }
 
-function getSizeLabels(sizes: string[]) {
+function getSizeLabels(sizes: string[], metric) {
   if (!sizes?.length) return []
 
   return sizes.map((size) => {
@@ -226,7 +230,10 @@ function getSizeLabels(sizes: string[]) {
 
     return {
       name: "Size",
-      displayValue: SIZES[sizeInUppercase],
+      displayValue:
+        metric === "cm"
+          ? SIZES_IN_CM[sizeInUppercase]
+          : SIZES_IN_INCHES[sizeInUppercase],
       value: sizeInUppercase,
       field: "sizes",
     }

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -6,6 +6,7 @@ import artworkMediums from "lib/artworkMediums"
 import allAttributionClasses from "lib/attributionClasses"
 import { COLORS } from "lib/colors"
 import { round } from "lodash"
+import { DEFAULT_LENGTH_UNIT_PREFERENCE } from "./me"
 
 export const SIZES_IN_CM = {
   SMALL: "Small (under 40cm)",
@@ -19,8 +20,6 @@ export const SIZES_IN_INCHES = {
 }
 
 const ONE_IN_TO_CM = 2.54
-
-const DEFAULT_METRIC = "in"
 
 export type SearchCriteriaLabel = {
   /** The GraphQL field name of the filter facet */
@@ -414,11 +413,11 @@ function getColorLabels(colors: string[]) {
 }
 
 const getPreferredMetric = async (meLoader) => {
-  if (!meLoader) return DEFAULT_METRIC
+  if (!meLoader) return DEFAULT_LENGTH_UNIT_PREFERENCE
 
   const { length_unit_preference } = await meLoader()
 
-  return length_unit_preference
+  return length_unit_preference || DEFAULT_LENGTH_UNIT_PREFERENCE
 }
 
 async function getPartnerLabels(partnerIDs: string[], partnerLoader) {

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -249,7 +249,7 @@ const parseRange = (range = "", metric: string): (number | "*")[] => {
     if (s === "*") return s
     return metric === "cm"
       ? convertToCentimeters(parseFloat(s))
-      : round(parseFloat(s), 2)
+      : round(parseFloat(s), 1)
   })
 }
 


### PR DESCRIPTION
Addresses [ONYX-472]


## Description

This PR adds metric support for the saved search `displayName` and `size` (+ custom size) labels. The metric is retrieved from the user's preferred metric (`me.length_unit_preference`) and defaults to inches.

- This change will apply to [previewSavedSearch](https://github.com/artsy/metaphysics/blob/eb7038505ce95d8d2ad2e69314a7ba016e669da1/src/schema/v2/previewSavedSearch.ts#L1), [savedSearch](https://github.com/artsy/metaphysics/blob/eb7038505ce95d8d2ad2e69314a7ba016e669da1/src/lib/stitching/gravity/v2/stitching.ts#L655) and [savedSearchesConnection](https://github.com/artsy/metaphysics/blob/eb7038505ce95d8d2ad2e69314a7ba016e669da1/src/lib/stitching/gravity/v2/stitching.ts#L667).

- When querying `previewSavedSearch` without a logged-in user, the metric falls back to the default value (inches).

**Next Steps:**

This would be the first step towards making size value dynamic. The next step would involve reading the metric value from the search criteria and falling back to the user's preference.


### Example Query

```graphql
{
  previewSavedSearch(
    attributes: {
      artistIDs: ["kaws"]
      sizes: [SMALL]
      height: "10-20"
      width: "5-10"
    }
  ) {
    displayName
    labels {
      name
      displayValue
    }
  }
}
```

**Inches (Default)**

```json
"previewSavedSearch": {
  "displayName": "KAWS — Small (under 16in) or w: 5–10 in or h: 10–20 in",
  "labels": [
    {
      "name": "Artist",
      "displayValue": "KAWS"
    },
    {
      "name": "Size",
      "displayValue": "Small (under 16in)"
    },
    {
      "name": "Size",
      "displayValue": "w: 5–10 in"
    },
    {
      "name": "Size",
      "displayValue": "h: 10–20 in"
    }
  ]
}
```

**Centimeters**

```json
{
    "previewSavedSearch": {
      "displayName": "KAWS — Small (under 40cm) or w: 13–25 cm or h: 25–51 cm",
      "labels": [
        {
          "name": "Artist",
          "displayValue": "KAWS"
        },
        {
          "name": "Size",
          "displayValue": "Small (under 40cm)"
        },
        {
          "name": "Size",
          "displayValue": "w: 13–25 cm"
        },
        {
          "name": "Size",
          "displayValue": "h: 25–51 cm"
        }
      ]
    }
```

[ONYX-472]: https://artsyproduct.atlassian.net/browse/ONYX-472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ