### PR TITLE
feat(searchCriteriaConnection): Add `represented` argument to field

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,8 @@
   "parser": "@typescript-eslint/parser",
   "rules": {
     "sort-keys": [
-      "warn",
+      // TODO: Reenable this with "warn" after we auto-fix whole codebase
+      "off",
       "asc",
       { "caseSensitive": true, "natural": false, "minKeys": 2 }
     ],

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13776,6 +13776,7 @@ type Partner implements Node {
     highQuality: Boolean
     last: Int
     partnerID: String
+    represented: Boolean
     since: SearchCriteriaSinceEnum
     sort: SearchCriteriaSortEnum
   ): SearchCriteriaConnection
@@ -15868,6 +15869,7 @@ type Query {
     highQuality: Boolean
     last: Int
     partnerID: String
+    represented: Boolean
     since: SearchCriteriaSinceEnum
     sort: SearchCriteriaSortEnum
   ): SearchCriteriaConnection
@@ -20501,6 +20503,7 @@ type Viewer {
     highQuality: Boolean
     last: Int
     partnerID: String
+    represented: Boolean
     since: SearchCriteriaSinceEnum
     sort: SearchCriteriaSortEnum
   ): SearchCriteriaConnection

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -157,6 +157,7 @@ export const gravityStitchingEnvironment = (
           artistID: ID,
           highQuality: Boolean,
           partnerID: String,
+          represented: Boolean,
           since: SearchCriteriaSinceEnum
           sort: SearchCriteriaSortEnum
         ): SearchCriteriaConnection
@@ -174,6 +175,7 @@ export const gravityStitchingEnvironment = (
           after: String,
           artistID: ID,
           highQuality: Boolean,
+          represented: Boolean,
           partnerID: String,
           since: SearchCriteriaSinceEnum
           sort: SearchCriteriaSortEnum
@@ -236,6 +238,7 @@ export const gravityStitchingEnvironment = (
           artistID: ID,
           highQuality: Boolean,
           partnerID: String,
+          represented: Boolean,
           since: SearchCriteriaSinceEnum
           sort: SearchCriteriaSortEnum
         ): SearchCriteriaConnection


### PR DESCRIPTION
Trivial update to wire up the stitched argument `represented` through to GravityQL