### PR TITLE
fix: add improvements for recently viewed artwork ids queries

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -193,6 +193,7 @@ const graphqlServer = graphqlHTTP((req, res, params) => {
     userAgent,
     appToken,
     ipAddress,
+    xImpersonateUserID,
   }
 
   const validationRules = [

--- a/src/schema/v2/me/__tests__/recentlyViewedArtworks.test.ts
+++ b/src/schema/v2/me/__tests__/recentlyViewedArtworks.test.ts
@@ -20,10 +20,8 @@ describe("RecentlyViewedArtworks", () => {
     ]
 
     context = {
-      meLoader: async () => me,
       artworksLoader: async () => artworks,
       recordArtworkViewLoader: jest.fn(async () => me),
-      xImpersonateUserID: () => undefined,
       recentlyViewedArtworkIdsLoader: async () =>
         Promise.resolve({ body: me.recently_viewed_artwork_ids }),
     }
@@ -73,7 +71,7 @@ describe("RecentlyViewedArtworks", () => {
     `)
   })
 
-  it("returns impersonated artwork connection", async () => {
+  it("does not return artwork connection without userID", async () => {
     const query = gql`
       {
         me {
@@ -91,34 +89,11 @@ describe("RecentlyViewedArtworks", () => {
         }
       }
     `
-    context.xImpersonateUserID = () => "some-user-id"
-    context.recentlyViewedArtworkIdsLoader = () =>
-      Promise.resolve({ body: ["percy", "matt"] })
 
     const data = await runQuery(query, context)
-    const recentlyViewedArtworks = data!.me.recentlyViewedArtworksConnection
+    const recentlyViewedArtworks = data!.me?.recentlyViewedArtworksConnection
 
-    expect(recentlyViewedArtworks).toMatchInlineSnapshot(`
-      Object {
-        "edges": Array [
-          Object {
-            "node": Object {
-              "slug": "percy",
-              "title": "Percy the Cat",
-            },
-          },
-          Object {
-            "node": Object {
-              "slug": "matt",
-              "title": "Matt the Person",
-            },
-          },
-        ],
-        "pageInfo": Object {
-          "hasNextPage": false,
-        },
-      }
-    `)
+    expect(recentlyViewedArtworks).toBeUndefined()
   })
 
   it("can return an empty connection", async () => {

--- a/src/schema/v2/me/__tests__/similarToRecentlyViewed.test.ts
+++ b/src/schema/v2/me/__tests__/similarToRecentlyViewed.test.ts
@@ -129,7 +129,7 @@ describe("SimilarToRecentlyViewed", () => {
 
     context.recentlyViewedArtworkIdsLoader = async () => ids
     context.similarArtworksLoader = async () => artworks
-    context.userID = "user-200"
+    context.xImpersonateUserID = "some-user-id"
 
     const data = await runQuery(query, context)
     const similarToRecentlyViewed = data!.me.similarToRecentlyViewedConnection

--- a/src/schema/v2/me/__tests__/similarToRecentlyViewed.test.ts
+++ b/src/schema/v2/me/__tests__/similarToRecentlyViewed.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable promise/always-return */
-import { runAuthenticatedQuery, runQuery } from "schema/v2/test/utils"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
 
 jest.mock("node-fetch", () => jest.fn())
@@ -17,7 +17,6 @@ describe("SimilarToRecentlyViewed", () => {
       { id: "paula", title: "Paula the butterfly" },
     ]
     context = {
-      meLoader: async () => me,
       similarArtworksLoader: async () => artworks,
       recordArtworkViewLoader: jest.fn(async () => me),
       recentlyViewedArtworkIdsLoader: async () => null,
@@ -90,7 +89,7 @@ describe("SimilarToRecentlyViewed", () => {
     context.similarArtworksLoader = async () => []
 
     const data = await runAuthenticatedQuery(query, context)
-    const similarToRecentlyViewed = data!.me.similarToRecentlyViewedConnection
+    const similarToRecentlyViewed = data!.me?.similarToRecentlyViewedConnection
 
     expect(similarToRecentlyViewed).toEqual({
       edges: [],
@@ -99,61 +98,5 @@ describe("SimilarToRecentlyViewed", () => {
       },
     })
     expect.assertions(1)
-  })
-
-  it("when using an impersonated call", async () => {
-    const query = gql`
-      {
-        me {
-          similarToRecentlyViewedConnection(first: 2) {
-            edges {
-              node {
-                slug
-                title
-              }
-            }
-            pageInfo {
-              hasNextPage
-            }
-          }
-        }
-      }
-    `
-    const artworks = [
-      { id: "x", title: "X the snail" },
-      { id: "y", title: "Y the Person" },
-      { id: "z", title: "Z the butterfly" },
-    ]
-
-    const ids = ["x", "y", "z"]
-
-    context.recentlyViewedArtworkIdsLoader = async () => ids
-    context.similarArtworksLoader = async () => artworks
-    context.xImpersonateUserID = "some-user-id"
-
-    const data = await runQuery(query, context)
-    const similarToRecentlyViewed = data!.me.similarToRecentlyViewedConnection
-
-    expect(similarToRecentlyViewed).toMatchInlineSnapshot(`
-      Object {
-        "edges": Array [
-          Object {
-            "node": Object {
-              "slug": "x",
-              "title": "X the snail",
-            },
-          },
-          Object {
-            "node": Object {
-              "slug": "y",
-              "title": "Y the Person",
-            },
-          },
-        ],
-        "pageInfo": Object {
-          "hasNextPage": true,
-        },
-      }
-    `)
   })
 })

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -550,7 +550,12 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
 
 const MeField: GraphQLFieldConfig<void, ResolverContext> = {
   type: meType,
-  resolve: (_root, _options, { userID, meLoader }, info) => {
+  resolve: (
+    _root,
+    _options,
+    { userID, meLoader, xImpersonateUserID },
+    info
+  ) => {
     if (!meLoader) return null
     const fieldsNotRequireLoader = [
       "id",
@@ -574,13 +579,11 @@ const MeField: GraphQLFieldConfig<void, ResolverContext> = {
       "identityVerification",
       "unreadNotificationsCount",
       "unseenNotificationsCount",
-      "similarToRecentlyViewedConnection",
       "showsByFollowedArtists",
       "newWorksFromGalleriesYouFollowConnection",
       "myCollectionInfo",
       "watchedLotConnection",
       "userInterestsConnection",
-      "recentlyViewedArtworksConnection",
       "myCollectionConnection",
       "artworkInquiriesConnection",
       "collectionsConnection",
@@ -588,6 +591,11 @@ const MeField: GraphQLFieldConfig<void, ResolverContext> = {
       "myCollectionAuctionResults",
       "newWorksByInterestingArtists",
     ]
+
+    if (xImpersonateUserID) {
+      return {}
+    }
+
     if (includesFieldsOtherThanSelectionSet(info, fieldsNotRequireLoader)) {
       return meLoader()
     }

--- a/src/schema/v2/me/recentlyViewedArtworks.ts
+++ b/src/schema/v2/me/recentlyViewedArtworks.ts
@@ -17,22 +17,21 @@ export const RecentlyViewedArtworks: GraphQLFieldConfig<
   resolve: async (
     { recently_viewed_artwork_ids },
     args,
-    { artworksLoader, recentlyViewedArtworkIdsLoader, userID }
+    { artworksLoader, recentlyViewedArtworkIdsLoader, xImpersonateUserID }
   ) => {
-    if (!userID) return null
     const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
 
     try {
       let recentlyViewedIds = recently_viewed_artwork_ids || []
-      if (!recentlyViewedIds.length) {
+
+      if (xImpersonateUserID) {
         const recentlyViewedArtworksBody = (
-          await recentlyViewedArtworkIdsLoader(userID)
+          await recentlyViewedArtworkIdsLoader(xImpersonateUserID)
         )?.body
         recentlyViewedIds = recentlyViewedArtworksBody || []
       }
 
       const pageArtworkIDs = recentlyViewedIds.slice(offset, offset + size)
-
       const artworks = recentlyViewedIds?.length
         ? await artworksLoader({ ids: pageArtworkIDs })
         : []

--- a/src/schema/v2/me/similarToRecentlyViewed.ts
+++ b/src/schema/v2/me/similarToRecentlyViewed.ts
@@ -17,28 +17,44 @@ export const SimilarToRecentlyViewed: GraphQLFieldConfig<
   args: pageable({}),
   description: "A list of artworks similar to recently viewed artworks.",
   resolve: async (
-    _me,
+    { recently_viewed_artwork_ids },
     args,
-    { similarArtworksLoader, recentlyViewedArtworkIdsLoader, userID }
+    {
+      similarArtworksLoader,
+      recentlyViewedArtworkIdsLoader,
+      userID,
+      xImpersonateUserID,
+    }
   ) => {
-    if (!userID) return null
+    if (!userID && !xImpersonateUserID) return null
+
     const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
 
     // Fetching all artworks until the current page because `offset` isn't working for similarArtworksLoader
     const numberOfArtworksToFetch = Math.min(size + offset, MAX_ARTWORKS)
 
     try {
-      const recentlyViewedArtworksBody = (
-        await recentlyViewedArtworkIdsLoader(userID)
-      )?.body
+      let artworkIDs
 
-      const recentlyViewedIds = (recentlyViewedArtworksBody || []).slice(0, 7)
+      // If `recently_viewed_artwork_ids` exists, use those
+      if (!!recently_viewed_artwork_ids) {
+        artworkIDs = recently_viewed_artwork_ids
+      } else if (!!xImpersonateUserID) {
+        // Otherwise, we are impersonating and use special loader to fetch
+        const {
+          body: recentlyViewedArtworkIds,
+        } = await recentlyViewedArtworkIdsLoader(xImpersonateUserID)
+        artworkIDs = recentlyViewedArtworkIds
+      }
 
-      const artworks = await similarArtworksLoader({
-        artwork_id: recentlyViewedIds,
-        for_sale: true,
-        size: numberOfArtworksToFetch,
-      })
+      const artworks =
+        artworkIDs?.length > 0
+          ? await similarArtworksLoader({
+              artwork_id: artworkIDs,
+              for_sale: true,
+              size: numberOfArtworksToFetch,
+            })
+          : []
 
       const totalCount = artworks.length
 

--- a/src/schema/v2/me/similarToRecentlyViewed.ts
+++ b/src/schema/v2/me/similarToRecentlyViewed.ts
@@ -19,9 +19,12 @@ export const SimilarToRecentlyViewed: GraphQLFieldConfig<
   resolve: async (
     { recently_viewed_artwork_ids },
     args,
-    { similarArtworksLoader, recentlyViewedArtworkIdsLoader, userID }
+    {
+      similarArtworksLoader,
+      recentlyViewedArtworkIdsLoader,
+      xImpersonateUserID,
+    }
   ) => {
-    if (!userID) return null
     const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
 
     // Fetching all artworks until the current page because `offset` isn't working for similarArtworksLoader
@@ -30,9 +33,9 @@ export const SimilarToRecentlyViewed: GraphQLFieldConfig<
     try {
       let recentlyViewedIds = (recently_viewed_artwork_ids || []).slice(0, 7)
 
-      if (!recentlyViewedIds.length) {
+      if (xImpersonateUserID) {
         const recentlyViewedArtworksBody = (
-          await recentlyViewedArtworkIdsLoader(userID)
+          await recentlyViewedArtworkIdsLoader(xImpersonateUserID)
         )?.body
         recentlyViewedIds = (recentlyViewedArtworksBody || []).slice(0, 7)
       }

--- a/src/types/graphql.d.ts
+++ b/src/types/graphql.d.ts
@@ -29,6 +29,7 @@ export interface ResolverContextValues {
   imageData?: ImageData
 
   ipAddress: string
+  xImpersonateUserID?: string
 }
 
 export type ResolverContext = ResolverContextValues &


### PR DESCRIPTION
This PR is addressing the issues caused by recent changes for braze impersonations.