### PR TITLE
feat: Configure query flag so that news is included by default DIA-291

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1326,7 +1326,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     first: Int
 
     # Get only articles with 'standard', 'feature', 'series' or 'video' layouts.
-    inEditorialFeed: Boolean
+    inEditorialFeed: Boolean = false
     last: Int
 
     # DEPRECATION REASON: Use `size` instead

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -116,6 +116,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
           },
           inEditorialFeed: {
             type: GraphQLBoolean,
+            defaultValue: false,
             description:
               "Get only articles with 'standard', 'feature', 'series' or 'video' layouts.",
           },


### PR DESCRIPTION
This PR works with https://github.com/artsy/force/pull/13095 so that we always return news. It's still possible to provide true for this flag for backwards compat with Eigen but that's the only reason as far as I know!

https://artsyproduct.atlassian.net/browse/DIA-291

/cc @artsy/diamond-devs