### PR TITLE
ci: add node version for test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,6 @@ orbs:
   node: circleci/node@5.1.0
   yarn: artsy/yarn@6.5.0
 
-executors:
-  node-default:
-    docker:
-      - image: cimg/node:18.15.0
-
 not_staging_or_release: &not_staging_or_release
   filters:
     branches:
@@ -62,33 +57,19 @@ commands:
       - yarn/save_dependencies
 
 jobs:
-  node/test:
-    executor: node-default
-    steps:
-      - checkout
-      - setup_hokusai
-      - yarn_install
-      - run:
-          name: test-jest
-          command: yarn test-jest
-  node/run:
-    executor: node-default
-    steps:
-      - checkout
-      - setup_hokusai
-      - yarn_install
-      - run:
-          name: test-jest
-          command: yarn test-jest
   ensure-schema-update:
-    executor: node-default
+    executor:
+      name: node/default
+      tag: "18.15"
     steps:
       - checkout
       - setup_hokusai
       - yarn_install
       - run: scripts/ensure-schema-update.sh
   push-schema-changes:
-    executor: node-default
+    executor:
+      name: node/default
+      tag: "18.15"
     steps:
       - checkout
       - setup_hokusai
@@ -105,6 +86,7 @@ workflows:
           name: test-jest
           pkg-manager: yarn
           test-results-for: jest
+          version: "18.15"
 
       - node/run:
           <<: *not_staging_or_release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,8 @@ not_staging_or_release: &not_staging_or_release
       ignore:
         - staging
         - release
+  docker:
+    - image: circleci/node:18.15.0
 
 only_main: &only_main
   context: hokusai

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ orbs:
 executors:
   node-default:
     docker:
-      - image: circleci/node:18.15
+      - image: cimg/node:18.15.0
 
 not_staging_or_release: &not_staging_or_release
   filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,14 +6,17 @@ orbs:
   node: circleci/node@5.1.0
   yarn: artsy/yarn@6.5.0
 
+executors:
+  node-default:
+    docker:
+      - image: circleci/node:18.15
+
 not_staging_or_release: &not_staging_or_release
   filters:
     branches:
       ignore:
         - staging
         - release
-  docker:
-    - image: circleci/node:18.15.0
 
 only_main: &only_main
   context: hokusai
@@ -59,19 +62,33 @@ commands:
       - yarn/save_dependencies
 
 jobs:
+  node/test:
+    executor: node-default
+    steps:
+      - checkout
+      - setup_hokusai
+      - yarn_install
+      - run:
+          name: test-jest
+          command: yarn test-jest
+  node/run:
+    executor: node-default
+    steps:
+      - checkout
+      - setup_hokusai
+      - yarn_install
+      - run:
+          name: test-jest
+          command: yarn test-jest
   ensure-schema-update:
-    executor:
-      name: node/default
-      tag: "18.15"
+    executor: node-default
     steps:
       - checkout
       - setup_hokusai
       - yarn_install
       - run: scripts/ensure-schema-update.sh
   push-schema-changes:
-    executor:
-      name: node/default
-      tag: "18.15"
+    executor: node-default
     steps:
       - checkout
       - setup_hokusai


### PR DESCRIPTION
Not sure how this failure suddenly emerged, but it seems the last LTS version introduced this issue.
[Docs here](https://circleci.com/developer/orbs/orb/circleci/node#jobs-test)

![image](https://github.com/artsy/metaphysics/assets/1176374/e16fb823-b726-4293-81cd-82405f9d97f6)


[Before Spin up Environment](https://app.circleci.com/pipelines/github/artsy/metaphysics/19818/workflows/926dd583-8616-48c9-a78b-16fe984c9d12/jobs/41689/parallel-runs/0/steps/0-0)
[After Spin up Environment](https://app.circleci.com/pipelines/github/artsy/metaphysics/19819/workflows/3f164445-1632-47f9-b8fc-745d75143c57/jobs/41694/parallel-runs/0/steps/0-0)
