### PR TITLE
chore: deprecate and remove usage of highQuality filtering concept

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13773,7 +13773,6 @@ type Partner implements Node {
     artistID: ID
     before: String
     first: Int
-    highQuality: Boolean
     last: Int
     partnerID: String
     represented: Boolean
@@ -15868,7 +15867,6 @@ type Query {
     artistID: ID
     before: String
     first: Int
-    highQuality: Boolean
     last: Int
     partnerID: String
     represented: Boolean
@@ -20502,7 +20500,6 @@ type Viewer {
     artistID: ID
     before: String
     first: Int
-    highQuality: Boolean
     last: Int
     partnerID: String
     represented: Boolean

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14713,6 +14713,8 @@ type Query {
 
     # Returns the first _n_ elements from the list.
     first: Int
+
+    # (Deprecated) No longer supported
     highQuality: Boolean
 
     # Returns the last _n_ elements from the list.

--- a/src/data/gravity.graphql
+++ b/src/data/gravity.graphql
@@ -1694,6 +1694,10 @@ type Query {
     Returns the first _n_ elements from the list.
     """
     first: Int
+
+    """
+    (Deprecated) No longer supported
+    """
     highQuality: Boolean
 
     """

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -155,7 +155,6 @@ export const gravityStitchingEnvironment = (
           before: String,
           after: String,
           artistID: ID,
-          highQuality: Boolean,
           partnerID: String,
           represented: Boolean,
           since: SearchCriteriaSinceEnum
@@ -174,7 +173,6 @@ export const gravityStitchingEnvironment = (
           before: String,
           after: String,
           artistID: ID,
-          highQuality: Boolean,
           represented: Boolean,
           partnerID: String,
           since: SearchCriteriaSinceEnum
@@ -236,7 +234,6 @@ export const gravityStitchingEnvironment = (
           before: String,
           after: String,
           artistID: ID,
-          highQuality: Boolean,
           partnerID: String,
           represented: Boolean,
           since: SearchCriteriaSinceEnum


### PR DESCRIPTION
MP changes to support deprecation of `high_quality` [concept in Gravity](https://github.com/artsy/gravity/commit/b60db3f2d0b3c345e573d70bb69d15746d773bb9)

This filter is no longer being used by clients and we are marking as deprecated

Assigning myself so I can deploy after gravity goes out