### PR TITLE
feat(alerts): support artist series in previews and labels

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14284,6 +14284,7 @@ input PreviewSavedSearchAttributes {
   acquireable: Boolean
   additionalGeneIDs: [String]
   artistIDs: [String]
+  artistSeriesIDs: [String]
   atAuction: Boolean
   attributionClass: [String]
   colors: [String]

--- a/src/schema/v2/__tests__/previewSavedSearch.test.ts
+++ b/src/schema/v2/__tests__/previewSavedSearch.test.ts
@@ -335,12 +335,49 @@ describe("previewSavedSearch", () => {
         const { previewSavedSearch } = await runQuery(query, {
           artistLoader,
           partnerLoader,
-          meLoader,
         })
 
         expect(previewSavedSearch.displayName).toEqual(
           "KAWS — New York, NY, USA, Foo Bar Gallery"
         )
+      })
+
+      it("can use artist series", async () => {
+        const query = gql`
+          {
+            previewSavedSearch(
+              attributes: {
+                artistIDs: ["kaws"]
+                artistSeriesIDs: ["kaws-astroboy"]
+              }
+            ) {
+              displayName
+            }
+          }
+        `
+
+        const artistLoader = jest
+          .fn()
+          .mockReturnValueOnce(Promise.resolve({ name: "KAWS" }))
+
+        const gravityGraphQLLoader = jest.fn().mockReturnValueOnce(
+          Promise.resolve({
+            artistSeries: {
+              internalID: "abc-123",
+              title: "Astroboy",
+            },
+          })
+        )
+
+        const context = {
+          artistLoader,
+          gravityGraphQLLoader,
+          meLoader,
+        }
+
+        const { previewSavedSearch } = await runQuery(query, context)
+
+        expect(previewSavedSearch.displayName).toEqual("KAWS — Astroboy")
       })
 
       it("generates a name with only artist specified in the alert criteria", async () => {

--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -652,4 +652,49 @@ describe("resolveSearchCriteriaLabels", () => {
       },
     ])
   })
+
+  it("formats artist series criteria", async () => {
+    const parent = {
+      artistSeriesIDs: ["kaws-astroboy", "kaws-companions"],
+    }
+
+    const context = {
+      gravityGraphQLLoader: jest
+        .fn()
+        .mockReturnValueOnce(
+          Promise.resolve({
+            artistSeries: {
+              internalID: "abc-123",
+              title: "Astroboy",
+            },
+          })
+        )
+        .mockReturnValueOnce(
+          Promise.resolve({
+            artistSeries: {
+              internalID: "def-456",
+              title: "Companions",
+            },
+          })
+        ),
+      meLoader,
+    }
+
+    const labels = await resolveSearchCriteriaLabels(parent, _, context, _)
+
+    expect(labels).toIncludeAllMembers([
+      {
+        name: "Artist Series",
+        field: "artistSeriesIDs",
+        value: "abc-123",
+        displayValue: "Astroboy",
+      },
+      {
+        name: "Artist Series",
+        field: "artistSeriesIDs",
+        value: "def-456",
+        displayValue: "Companions",
+      },
+    ])
+  })
 })

--- a/src/schema/v2/previewSavedSearch.ts
+++ b/src/schema/v2/previewSavedSearch.ts
@@ -166,6 +166,9 @@ export const generateDisplayName = async (parent, args, context, info) => {
   )
   if (partner) otherLabels.push(partner)
 
+  const artistSeries = labels.filter(({ name }) => name === "Artist Series")
+  if (artistSeries) otherLabels.push(artistSeries)
+
   // concatenate, compact, and trim
 
   const allLabels = [artistLabels, ...prioritizedLabels, ...otherLabels].filter(

--- a/src/schema/v2/previewSavedSearch.ts
+++ b/src/schema/v2/previewSavedSearch.ts
@@ -27,6 +27,9 @@ const previewSavedSearchArgs: GraphQLFieldConfigArgumentMap = {
   artistIDs: {
     type: new GraphQLList(GraphQLString),
   },
+  artistSeriesIDs: {
+    type: new GraphQLList(GraphQLString),
+  },
   atAuction: {
     type: GraphQLBoolean,
   },


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-487

Allows `previewSavedSearch` to take a new `artistSeriesIDs` argument and:

- derive artist series’ label data via `previewSavedSearch.labels`
- include artist series in the generated default name via `previewSavedSearch.displayName`

### Query

```graphql
{
  previewSavedSearch(
    attributes: {
      artistIDs: ["4e934002e340fa0001005336"], 
      artistSeriesIDs: ["kaws-astroboy"]}
  ) {
    displayName
    labels {
      name
      displayValue
      field
      value
    }
  }
}
```

### Response


```json
{
  "data": {
    "previewSavedSearch": {

      // generated alert name
      "displayName": "KAWS — Astroboy",     

      "labels": [
        {
          "name": "Artist",
          "field": "artistIDs",
          "value": "4e934002e340fa0001005336"
          "displayValue": "KAWS",
        },

        // derived labels with machine and human-friendly data
        {
          "name": "Artist Series",
          "field": "artistSeriesIDs",
          "value": "d6830ac3-fa83-4cf7-98a6-ecfd8a3a90fb"
          "displayValue": "Astroboy",
        }
      ]
    }
  }
}
```