### PR TITLE
feat: add alertsConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -269,8 +269,8 @@ type Agreement {
 }
 
 type Alert {
-  additionalGeneNames: String
-  attributionClass: String
+  additionalGeneNames: [String]
+  attributionClass: [String]
   formattedPriceRange: String
   hasRecentlyEnabledUserSearchCriteria: Boolean
 
@@ -279,7 +279,7 @@ type Alert {
 
   # A type-specific ID.
   internalID: ID!
-  materialsTerms: String
+  materialsTerms: [String]
   priceRange: String
   summary: JSON
   totalUserSearchCriteriaCount: Int

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -268,6 +268,43 @@ type Agreement {
   updatedAt: ISO8601DateTime!
 }
 
+type Alert {
+  additionalGeneNames: String
+  attributionClass: String
+  formattedPriceRange: String
+  hasRecentlyEnabledUserSearchCriteria: Boolean
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID.
+  internalID: ID!
+  materialsTerms: String
+  priceRange: String
+  summary: JSON
+  totalUserSearchCriteriaCount: Int
+}
+
+# A connection to a list of items.
+type AlertConnection {
+  # A list of edges.
+  edges: [AlertEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type AlertEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: Alert
+}
+
 type Algolia {
   apiKey: String! @deprecated(reason: "Algolia search is no longer supported")
   appID: String! @deprecated(reason: "Algolia search is no longer supported")
@@ -1319,6 +1356,13 @@ type ArticleUnpublishedArtworkPartner {
 }
 
 type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Searchable {
+  alertsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    sort: String
+  ): AlertConnection
   alternateNames: [String]
   articlesConnection(
     after: String

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -20,6 +20,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    artistAlertsLoader: gravityLoader(
+      (id) => `artist/${id}/alerts`,
+      {},
+      { headers: true }
+    ),
     artistDuplicatesLoader: gravityLoader(
       (id) => `artist/${id}/duplicates`,
       {},

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -20,11 +20,7 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
-    artistAlertsLoader: gravityLoader(
-      (id) => `artist/${id}/alerts`,
-      {},
-      { headers: true }
-    ),
+    artistAlertsLoader: gravityLoader((id) => `artist/${id}/alerts`),
     artistDuplicatesLoader: gravityLoader(
       (id) => `artist/${id}/duplicates`,
       {},

--- a/src/schema/v2/alerts.ts
+++ b/src/schema/v2/alerts.ts
@@ -1,6 +1,7 @@
 import {
   GraphQLBoolean,
   GraphQLInt,
+  GraphQLList,
   GraphQLObjectType,
   GraphQLString,
 } from "graphql"
@@ -9,7 +10,22 @@ import { ResolverContext } from "types/graphql"
 import { IDFields } from "./object_identification"
 import GraphQLJSON from "graphql-type-json"
 
-export const AlertType = new GraphQLObjectType<any, ResolverContext>({
+type GravitySearchCriteriaJSON = {
+  id: string
+  price_range: string
+  formatted_price_range: string
+  materials_terms: string[]
+  attribution_class: string[]
+  additional_gene_names: string[]
+  summary: JSON
+  count_30d: number
+  count_7d: number
+}
+
+const AlertType = new GraphQLObjectType<
+  GravitySearchCriteriaJSON,
+  ResolverContext
+>({
   name: "Alert",
   fields: {
     ...IDFields,
@@ -23,24 +39,22 @@ export const AlertType = new GraphQLObjectType<any, ResolverContext>({
     },
     totalUserSearchCriteriaCount: {
       type: GraphQLInt,
-      resolve: ({ total_user_search_criteria_count }) =>
-        total_user_search_criteria_count,
+      resolve: ({ count_30d }) => count_30d,
     },
     materialsTerms: {
-      type: GraphQLString,
+      type: new GraphQLList(GraphQLString),
       resolve: ({ materials_terms }) => materials_terms,
     },
     attributionClass: {
-      type: GraphQLString,
+      type: new GraphQLList(GraphQLString),
       resolve: ({ attribution_class }) => attribution_class,
     },
     hasRecentlyEnabledUserSearchCriteria: {
       type: GraphQLBoolean,
-      resolve: ({ has_recently_enabled_user_search_criteria }) =>
-        has_recently_enabled_user_search_criteria,
+      resolve: ({ count_7d }) => count_7d > 0,
     },
     additionalGeneNames: {
-      type: GraphQLString,
+      type: new GraphQLList(GraphQLString),
       resolve: ({ additional_gene_names }) => additional_gene_names,
     },
     // Summary is a generic/dynamic JSON object.

--- a/src/schema/v2/alerts.ts
+++ b/src/schema/v2/alerts.ts
@@ -1,0 +1,57 @@
+import {
+  GraphQLBoolean,
+  GraphQLInt,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { connectionWithCursorInfo } from "schema/v2/fields/pagination"
+import { ResolverContext } from "types/graphql"
+import { IDFields } from "./object_identification"
+import GraphQLJSON from "graphql-type-json"
+
+export const AlertType = new GraphQLObjectType<any, ResolverContext>({
+  name: "Alert",
+  fields: {
+    ...IDFields,
+    priceRange: {
+      type: GraphQLString,
+      resolve: ({ price_range }) => price_range,
+    },
+    formattedPriceRange: {
+      type: GraphQLString,
+      resolve: ({ formatted_price_range }) => formatted_price_range,
+    },
+    totalUserSearchCriteriaCount: {
+      type: GraphQLInt,
+      resolve: ({ total_user_search_criteria_count }) =>
+        total_user_search_criteria_count,
+    },
+    materialsTerms: {
+      type: GraphQLString,
+      resolve: ({ materials_terms }) => materials_terms,
+    },
+    attributionClass: {
+      type: GraphQLString,
+      resolve: ({ attribution_class }) => attribution_class,
+    },
+    hasRecentlyEnabledUserSearchCriteria: {
+      type: GraphQLBoolean,
+      resolve: ({ has_recently_enabled_user_search_criteria }) =>
+        has_recently_enabled_user_search_criteria,
+    },
+    additionalGeneNames: {
+      type: GraphQLString,
+      resolve: ({ additional_gene_names }) => additional_gene_names,
+    },
+    // Summary is a generic/dynamic JSON object.
+    // TODO: This should probably be structured.
+    summary: {
+      type: GraphQLJSON,
+    },
+  },
+})
+
+export const AlertsConnectionType = connectionWithCursorInfo({
+  name: "Alert",
+  nodeType: AlertType,
+}).connectionType

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -61,6 +61,7 @@ import VerifiedRepresentatives from "./verifiedRepresentatives"
 import { AuctionResultsAggregation } from "../aggregations/filterAuctionResultsAggregation"
 import { parsePriceRangeValues } from "lib/moneyHelper"
 import { ArtistGroupIndicatorEnum } from "schema/v2/artist/groupIndicator"
+import { AlertsConnectionType } from "../alerts"
 
 // Manually curated list of artist id's who has verified auction lots that can be
 // returned, when queried for via `recordsTrusted: true`.
@@ -106,6 +107,37 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
       alternateNames: {
         type: new GraphQLList(GraphQLString),
         resolve: ({ alternate_names }) => alternate_names,
+      },
+      alertsConnection: {
+        args: pageable({
+          sort: {
+            type: GraphQLString,
+          },
+        }),
+        type: AlertsConnectionType,
+        resolve: async ({ _id }, args, { artistAlertsLoader }) => {
+          if (!artistAlertsLoader) throw new Error("You need to be signed in.")
+
+          const { page, size, offset } = convertConnectionArgsToGravityArgs(
+            args
+          )
+
+          const { body, headers } = await artistAlertsLoader(_id, {
+            page,
+            size,
+            sort: args.sort,
+          })
+          const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+          return paginationResolver({
+            totalCount,
+            offset,
+            page,
+            size,
+            body,
+            args,
+          })
+        },
       },
       articlesConnection: {
         args: pageable({

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -122,12 +122,14 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
             args
           )
 
-          const { body, headers } = await artistAlertsLoader(_id, {
+          const {
+            alerts_json: body,
+            total_count: totalCount,
+          } = await artistAlertsLoader(_id, {
             page,
             size,
             sort: args.sort,
           })
-          const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 
           return paginationResolver({
             totalCount,


### PR DESCRIPTION
(for discussion/buy-in, plus need to add specs)

## What is this

This is the companion PR to https://github.com/artsy/gravity/pull/17065 , which added a new endpoint. This PR consumes that endpoint.

This demonstrates how, for a specific artist, a proper connection of alerts can be fetched using the new endpoint, properly paginated and all that.

```
{
  artist(id: "...") {
    alertsConnection(first: 5) {
      priceRange
      formattedPriceRange
      # ... all other fields for artist-scoped view
    }
  }
}
```

So vanilla!

This should be able to be plugged into the Volt-V2 artist-scoped view with a straightforward lift as it's essentially the same schema as the stitched-in version.