### PR TITLE
feat: add alertsSummaryArtistsConnection under Partner

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -269,8 +269,8 @@ type Agreement {
 }
 
 type Alert {
-  additionalGeneNames: String
-  attributionClass: String
+  additionalGeneNames: [String]
+  attributionClass: [String]
   formattedPriceRange: String
   hasRecentlyEnabledUserSearchCriteria: Boolean
 
@@ -279,7 +279,7 @@ type Alert {
 
   # A type-specific ID.
   internalID: ID!
-  materialsTerms: String
+  materialsTerms: [String]
   priceRange: String
   summary: JSON
   totalUserSearchCriteriaCount: Int

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -305,6 +305,38 @@ type AlertEdge {
   node: Alert
 }
 
+# A connection to a list of items.
+type AlertsSummaryArtistConnection {
+  # A list of edges.
+  edges: [AlertsSummaryArtistEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type AlertsSummaryArtistEdge {
+  counts: AlertsSummaryCounts
+
+  # A cursor for use in pagination
+  cursor: String!
+  isRecentlyEnabled: Boolean
+
+  # The item at the end of the edge
+  node: Artist
+  topHit: Alert
+}
+
+type AlertsSummaryCounts {
+  totalUserSearchCriteriaCount: Int
+  totalWithAdditionalGeneIdsCount: Int
+  totalWithAttributionClassCount: Int
+  totalWithOtherMetadataCount: Int
+  totalWithPriceRangeCount: Int
+}
+
 type Algolia {
   apiKey: String! @deprecated(reason: "Algolia search is no longer supported")
   appID: String! @deprecated(reason: "Algolia search is no longer supported")
@@ -13587,6 +13619,13 @@ type PageInfo {
 }
 
 type Partner implements Node {
+  alertsSummaryArtistsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AlertsSummaryArtistConnection
+
   # A connection of all artists from a Partner.
   allArtistsConnection(
     displayOnPartnerProfile: Boolean

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -268,6 +268,43 @@ type Agreement {
   updatedAt: ISO8601DateTime!
 }
 
+type Alert {
+  additionalGeneNames: String
+  attributionClass: String
+  formattedPriceRange: String
+  hasRecentlyEnabledUserSearchCriteria: Boolean
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID.
+  internalID: ID!
+  materialsTerms: String
+  priceRange: String
+  summary: JSON
+  totalUserSearchCriteriaCount: Int
+}
+
+# A connection to a list of items.
+type AlertConnection {
+  # A list of edges.
+  edges: [AlertEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type AlertEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: Alert
+}
+
 type Algolia {
   apiKey: String! @deprecated(reason: "Algolia search is no longer supported")
   appID: String! @deprecated(reason: "Algolia search is no longer supported")
@@ -1319,6 +1356,13 @@ type ArticleUnpublishedArtworkPartner {
 }
 
 type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Searchable {
+  alertsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    sort: String
+  ): AlertConnection
   alternateNames: [String]
   articlesConnection(
     after: String

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -504,6 +504,9 @@ export default (accessToken, userID, opts) => {
       { method: "PUT" }
     ),
     matchPagesLoader: gravityLoader("match/pages", {}, { headers: true }),
+    partnerAlertsSummaryLoader: gravityLoader(
+      (id) => `partner/${id}/alerts_summary`
+    ),
     partnerAllLoader: gravityLoader((id) => `partner/${id}/all`),
     partnerArtistDocumentsLoader: gravityLoader<
       any,

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -20,6 +20,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    artistAlertsLoader: gravityLoader(
+      (id) => `artist/${id}/alerts`,
+      {},
+      { headers: true }
+    ),
     artistDuplicatesLoader: gravityLoader(
       (id) => `artist/${id}/duplicates`,
       {},

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -20,11 +20,7 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
-    artistAlertsLoader: gravityLoader(
-      (id) => `artist/${id}/alerts`,
-      {},
-      { headers: true }
-    ),
+    artistAlertsLoader: gravityLoader((id) => `artist/${id}/alerts`),
     artistDuplicatesLoader: gravityLoader(
       (id) => `artist/${id}/duplicates`,
       {},

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -505,7 +505,7 @@ export default (accessToken, userID, opts) => {
     ),
     matchPagesLoader: gravityLoader("match/pages", {}, { headers: true }),
     partnerAlertsSummaryLoader: gravityLoader(
-      (id) => `partner/${id}/alerts_summary`
+      (id) => `partner/${id}/alert_summary`
     ),
     partnerAllLoader: gravityLoader((id) => `partner/${id}/all`),
     partnerArtistDocumentsLoader: gravityLoader<

--- a/src/schema/v2/alerts.ts
+++ b/src/schema/v2/alerts.ts
@@ -111,5 +111,6 @@ export const AlertsSummaryFields = {
         },
       },
     }),
+    resolve: (resp) => resp,
   },
 }

--- a/src/schema/v2/alerts.ts
+++ b/src/schema/v2/alerts.ts
@@ -69,3 +69,47 @@ export const AlertsConnectionType = connectionWithCursorInfo({
   name: "Alert",
   nodeType: AlertType,
 }).connectionType
+
+export const AlertsSummaryFields = {
+  topHit: {
+    type: AlertType,
+    resolve: ({ top_hit }) => top_hit,
+  },
+  isRecentlyEnabled: {
+    type: GraphQLBoolean,
+    resolve: ({ total_user_search_criteria_enabled_within_last_7d }) =>
+      total_user_search_criteria_enabled_within_last_7d > 0,
+  },
+  counts: {
+    type: new GraphQLObjectType({
+      name: "AlertsSummaryCounts",
+      fields: {
+        totalUserSearchCriteriaCount: {
+          type: GraphQLInt,
+          resolve: ({ total_user_search_criteria_count }) =>
+            total_user_search_criteria_count,
+        },
+        totalWithAdditionalGeneIdsCount: {
+          type: GraphQLInt,
+          resolve: ({ total_with_additional_gene_ids_count }) =>
+            total_with_additional_gene_ids_count,
+        },
+        totalWithAttributionClassCount: {
+          type: GraphQLInt,
+          resolve: ({ total_with_attribution_class_count }) =>
+            total_with_attribution_class_count,
+        },
+        totalWithPriceRangeCount: {
+          type: GraphQLInt,
+          resolve: ({ total_with_price_range_count }) =>
+            total_with_price_range_count,
+        },
+        totalWithOtherMetadataCount: {
+          type: GraphQLInt,
+          resolve: ({ total_with_other_metadata_count }) =>
+            total_with_other_metadata_count,
+        },
+      },
+    }),
+  },
+}

--- a/src/schema/v2/alerts.ts
+++ b/src/schema/v2/alerts.ts
@@ -1,6 +1,7 @@
 import {
   GraphQLBoolean,
   GraphQLInt,
+  GraphQLList,
   GraphQLObjectType,
   GraphQLString,
 } from "graphql"
@@ -9,7 +10,22 @@ import { ResolverContext } from "types/graphql"
 import { IDFields } from "./object_identification"
 import GraphQLJSON from "graphql-type-json"
 
-export const AlertType = new GraphQLObjectType<any, ResolverContext>({
+type GravitySearchCriteriaJSON = {
+  id: string
+  price_range: string
+  formatted_price_range: string
+  materials_terms: string[]
+  attribution_class: string[]
+  additional_gene_names: string[]
+  summary: JSON
+  count_30d: number
+  count_7d: number
+}
+
+const AlertType = new GraphQLObjectType<
+  GravitySearchCriteriaJSON,
+  ResolverContext
+>({
   name: "Alert",
   fields: {
     ...IDFields,
@@ -23,24 +39,22 @@ export const AlertType = new GraphQLObjectType<any, ResolverContext>({
     },
     totalUserSearchCriteriaCount: {
       type: GraphQLInt,
-      resolve: ({ total_user_search_criteria_count }) =>
-        total_user_search_criteria_count,
+      resolve: ({ count_30d }) => count_30d,
     },
     materialsTerms: {
-      type: GraphQLString,
+      type: new GraphQLList(GraphQLString),
       resolve: ({ materials_terms }) => materials_terms,
     },
     attributionClass: {
-      type: GraphQLString,
+      type: new GraphQLList(GraphQLString),
       resolve: ({ attribution_class }) => attribution_class,
     },
     hasRecentlyEnabledUserSearchCriteria: {
       type: GraphQLBoolean,
-      resolve: ({ has_recently_enabled_user_search_criteria }) =>
-        has_recently_enabled_user_search_criteria,
+      resolve: ({ count_7d }) => count_7d > 0,
     },
     additionalGeneNames: {
-      type: GraphQLString,
+      type: new GraphQLList(GraphQLString),
       resolve: ({ additional_gene_names }) => additional_gene_names,
     },
     // Summary is a generic/dynamic JSON object.

--- a/src/schema/v2/alerts.ts
+++ b/src/schema/v2/alerts.ts
@@ -1,0 +1,57 @@
+import {
+  GraphQLBoolean,
+  GraphQLInt,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { connectionWithCursorInfo } from "schema/v2/fields/pagination"
+import { ResolverContext } from "types/graphql"
+import { IDFields } from "./object_identification"
+import GraphQLJSON from "graphql-type-json"
+
+export const AlertType = new GraphQLObjectType<any, ResolverContext>({
+  name: "Alert",
+  fields: {
+    ...IDFields,
+    priceRange: {
+      type: GraphQLString,
+      resolve: ({ price_range }) => price_range,
+    },
+    formattedPriceRange: {
+      type: GraphQLString,
+      resolve: ({ formatted_price_range }) => formatted_price_range,
+    },
+    totalUserSearchCriteriaCount: {
+      type: GraphQLInt,
+      resolve: ({ total_user_search_criteria_count }) =>
+        total_user_search_criteria_count,
+    },
+    materialsTerms: {
+      type: GraphQLString,
+      resolve: ({ materials_terms }) => materials_terms,
+    },
+    attributionClass: {
+      type: GraphQLString,
+      resolve: ({ attribution_class }) => attribution_class,
+    },
+    hasRecentlyEnabledUserSearchCriteria: {
+      type: GraphQLBoolean,
+      resolve: ({ has_recently_enabled_user_search_criteria }) =>
+        has_recently_enabled_user_search_criteria,
+    },
+    additionalGeneNames: {
+      type: GraphQLString,
+      resolve: ({ additional_gene_names }) => additional_gene_names,
+    },
+    // Summary is a generic/dynamic JSON object.
+    // TODO: This should probably be structured.
+    summary: {
+      type: GraphQLJSON,
+    },
+  },
+})
+
+export const AlertsConnectionType = connectionWithCursorInfo({
+  name: "Alert",
+  nodeType: AlertType,
+}).connectionType

--- a/src/schema/v2/artist/__tests__/index.test.js
+++ b/src/schema/v2/artist/__tests__/index.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable promise/always-return */
-import { runQuery } from "schema/v2/test/utils"
+import { runAuthenticatedQuery, runQuery } from "schema/v2/test/utils"
 
 describe("Artist type", () => {
   let artist = null
@@ -737,6 +737,41 @@ describe("Artist type", () => {
         expect(data).toEqual({
           artist: {
             formattedArtworksCount: "1 work",
+          },
+        })
+      })
+    })
+  })
+
+  describe("alertsConnection", () => {
+    const artistAlertsLoader = () =>
+      Promise.resolve({
+        total_count: 1,
+        alerts: [{ id: "percy-z-alert", count_7d: 1 }],
+      })
+    it("returns a connection of the artist's alerts", () => {
+      const query = `
+        {
+          artist(id: "percy-z") {
+            alertsConnection(first: 10) {
+              edges {
+                node {
+                  hasRecentlyEnabledUserSearchCriteria
+                }
+              }
+            }
+          }
+        }
+      `
+      return runAuthenticatedQuery(query, {
+        ...context,
+        artistAlertsLoader,
+      }).then((data) => {
+        expect(data).toEqual({
+          artist: {
+            alertsConnection: {
+              edges: [{ node: { hasRecentlyEnabledUserSearchCriteria: true } }],
+            },
           },
         })
       })

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -123,7 +123,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
           )
 
           const {
-            alerts_json: body,
+            alerts: body,
             total_count: totalCount,
           } = await artistAlertsLoader(_id, {
             page,

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -61,6 +61,7 @@ import VerifiedRepresentatives from "./verifiedRepresentatives"
 import { AuctionResultsAggregation } from "../aggregations/filterAuctionResultsAggregation"
 import { parsePriceRangeValues } from "lib/moneyHelper"
 import { ArtistGroupIndicatorEnum } from "schema/v2/artist/groupIndicator"
+import { AlertsConnectionType } from "../alerts"
 
 // Manually curated list of artist id's who has verified auction lots that can be
 // returned, when queried for via `recordsTrusted: true`.
@@ -106,6 +107,37 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
       alternateNames: {
         type: new GraphQLList(GraphQLString),
         resolve: ({ alternate_names }) => alternate_names,
+      },
+      alertsConnection: {
+        args: pageable({
+          sort: {
+            type: GraphQLString,
+          },
+        }),
+        type: AlertsConnectionType,
+        resolve: async ({ _id }, args, { artistAlertsLoader }) => {
+          if (!artistAlertsLoader) throw new Error("You need to be signed in.")
+
+          const { page, size, offset } = convertConnectionArgsToGravityArgs(
+            args
+          )
+
+          const { body, headers } = await artistAlertsLoader(_id, {
+            page,
+            size,
+            sort: args.sort,
+          })
+          const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+          return paginationResolver({
+            totalCount,
+            offset,
+            page,
+            size,
+            body,
+            args,
+          })
+        },
       },
       articlesConnection: {
         args: pageable({

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -122,12 +122,14 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
             args
           )
 
-          const { body, headers } = await artistAlertsLoader(_id, {
+          const {
+            alerts_json: body,
+            total_count: totalCount,
+          } = await artistAlertsLoader(_id, {
             page,
             size,
             sort: args.sort,
           })
-          const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 
           return paginationResolver({
             totalCount,

--- a/src/schema/v2/partner/__tests__/partner.test.js
+++ b/src/schema/v2/partner/__tests__/partner.test.js
@@ -1328,6 +1328,85 @@ describe("Partner type", () => {
     })
   })
 
+  describe("#alertsSummaryArtistsConnection", () => {
+    it("returns the summary of artists with recently enabled user search criteria", async () => {
+      const summaryResponse = {
+        summary: [
+          {
+            artist: { name: "Percy Z" },
+            top_hit: {
+              formatted_price_range: "Under $1,000,000",
+              count_7d: 1,
+            },
+            total_user_search_criteria_enabled_within_last_7d: 3,
+            total_user_search_criteria_count: 59,
+            total_with_additional_gene_ids_count: 55,
+            total_with_attribution_class_count: 33,
+            total_with_price_range_count: 31,
+            total_with_other_metadata_count: 0,
+          },
+        ],
+        total_count: 1,
+      }
+      const query = gql`
+        {
+          partner(id: "catty-partner") {
+            alertsSummaryArtistsConnection(first: 10) {
+              edges {
+                isRecentlyEnabled
+                counts {
+                  totalWithAdditionalGeneIdsCount
+                  totalWithPriceRangeCount
+                  totalWithAttributionClassCount
+                  totalWithOtherMetadataCount
+                  totalUserSearchCriteriaCount
+                }
+                topHit {
+                  formattedPriceRange
+                  hasRecentlyEnabledUserSearchCriteria
+                }
+                node {
+                  name
+                }
+              }
+            }
+          }
+        }
+      `
+      const partnerAlertsSummaryLoader = () => Promise.resolve(summaryResponse)
+      const data = await runAuthenticatedQuery(query, {
+        ...context,
+        partnerAlertsSummaryLoader,
+      })
+
+      expect(data).toEqual({
+        partner: {
+          alertsSummaryArtistsConnection: {
+            edges: [
+              {
+                isRecentlyEnabled: true,
+                counts: {
+                  totalWithAdditionalGeneIdsCount: 55,
+                  totalWithAttributionClassCount: 33,
+                  totalWithOtherMetadataCount: 0,
+                  totalWithPriceRangeCount: 31,
+                  totalUserSearchCriteriaCount: 59,
+                },
+                topHit: {
+                  formattedPriceRange: "Under $1,000,000",
+                  hasRecentlyEnabledUserSearchCriteria: true,
+                },
+                node: {
+                  name: "Percy Z",
+                },
+              },
+            ],
+          },
+        },
+      })
+    })
+  })
+
   describe("#articlesConnection", () => {
     let articlesResponse
 

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -155,9 +155,12 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           )
 
           const {
-            summary_json: body,
+            summary: body,
             total_count: totalCount,
-          } = await partnerAlertsSummaryLoader(_id)
+          } = await partnerAlertsSummaryLoader(_id, {
+            page,
+            size,
+          })
 
           return paginationResolver({
             totalCount,

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -47,6 +47,7 @@ import { setVersion } from "schema/v2/image/normalize"
 import { compact } from "lodash"
 import { InquiryRequestType } from "./partnerInquiryRequest"
 import { PartnerDocumentsConnection } from "./partnerDocumentsConnection"
+import { AlertsSummaryFields } from "../alerts"
 
 const isFairOrganizer = (type) => type === "FairOrganizer"
 const isGallery = (type) => type === "PartnerGallery"
@@ -117,7 +118,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
   name: "Partner",
   interfaces: [NodeInterface],
   fields: () => {
-    // This avoids a circular require
+    // These avoids a circular require
     const ArtistPartnerConnection = connectionWithCursorInfo({
       name: "ArtistPartner",
       nodeType: ArtistType,
@@ -134,9 +135,41 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       partnerShowsMatchConnection,
     } = require("./PartnerMatch")
 
+    const AlertsSummaryArtistConnectionType = connectionWithCursorInfo({
+      name: "AlertsSummaryArtist",
+      edgeFields: AlertsSummaryFields,
+      nodeType: ArtistType,
+    }).connectionType
+
     return {
       ...SlugAndInternalIDFields,
       cached,
+      alertsSummaryArtistsConnection: {
+        type: AlertsSummaryArtistConnectionType,
+        args: pageable({}),
+        resolve: async ({ _id }, args, { partnerAlertsSummaryLoader }) => {
+          if (!partnerAlertsSummaryLoader) return null
+
+          const { page, size, offset } = convertConnectionArgsToGravityArgs(
+            args
+          )
+
+          const {
+            summary_json: body,
+            total_count: totalCount,
+          } = await partnerAlertsSummaryLoader(_id)
+
+          return paginationResolver({
+            totalCount,
+            offset,
+            page,
+            size,
+            body,
+            args,
+            resolveNode: ({ artist }) => artist,
+          })
+        },
+      },
       articlesConnection: {
         description: "A connection of articles related to a partner.",
         type: articleConnection.connectionType,


### PR DESCRIPTION
This is built on top of https://github.com/artsy/metaphysics/pull/5409 , so can look at the latest commit for just these changes. It consumes a summary endpoint added in https://github.com/artsy/gravity/pull/17066.

It adds a schema of the form:

```
partner(id: "test-partner") {
  alertsSummaryArtistsConnection(first: 10, represented: true) {
    edges {
      counts {
        # various counts
      }
      isRecentlyEnabled
      topHit {
        # This is an Alert
        # ... other alert fields
      }
    }
    node {
      name
      # This is an Artist
      # ... other artist fields
    }
  }
}
```

which feels good and can power the summary-view in Volt-V2.