### PR TITLE
chore: add `represented` filter to `alertsSummaryArtistsConnection`

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13624,6 +13624,7 @@ type Partner implements Node {
     before: String
     first: Int
     last: Int
+    represented: Boolean
   ): AlertsSummaryArtistConnection
 
   # A connection of all artists from a Partner.

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -146,7 +146,11 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       cached,
       alertsSummaryArtistsConnection: {
         type: AlertsSummaryArtistConnectionType,
-        args: pageable({}),
+        args: pageable({
+          represented: {
+            type: GraphQLBoolean,
+          },
+        }),
         resolve: async ({ _id }, args, { partnerAlertsSummaryLoader }) => {
           if (!partnerAlertsSummaryLoader) return null
 
@@ -154,13 +158,19 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             args
           )
 
+          type GravityArgs = {
+            page: number
+            size: number
+            represented?: boolean
+          }
+
+          const gravityArgs: GravityArgs = { page, size }
+          if (args.represented) gravityArgs.represented = true
+
           const {
             summary: body,
             total_count: totalCount,
-          } = await partnerAlertsSummaryLoader(_id, {
-            page,
-            size,
-          })
+          } = await partnerAlertsSummaryLoader(_id, gravityArgs)
 
           return paginationResolver({
             totalCount,


### PR DESCRIPTION
Realized we need this truth-y filter for /demand (Gravity already supports this, forgot to include here).