### PR TITLE
feat: introduce mock structure for suggested filters

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14364,7 +14364,7 @@ type PreviewSavedSearch {
   labels: [SearchCriteriaLabel]!
 
   # Suggested filters for the user to use based on their search criteria
-  suggestedFilters: [SearchCriteriaLabel!]
+  suggestedFilters: [SearchCriteriaLabel!]!
 }
 
 input PreviewSavedSearchAttributes {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14362,6 +14362,9 @@ type PreviewSavedSearch {
 
   # Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity
   labels: [SearchCriteriaLabel]!
+
+  # Suggested filters for the user to use based on their search criteria
+  suggestedFilters: [SearchCriteriaLabel!]
 }
 
 input PreviewSavedSearchAttributes {

--- a/src/schema/v2/__tests__/previewSavedSearch.test.ts
+++ b/src/schema/v2/__tests__/previewSavedSearch.test.ts
@@ -1,5 +1,6 @@
 import { runQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
+import { mockSuggestedFilters } from "../previewSavedSearch"
 
 describe("previewSavedSearch", () => {
   const query = gql`
@@ -459,6 +460,32 @@ describe("previewSavedSearch", () => {
           "/artist/kaws?acquireable=true&additional_gene_ids%5B0%5D=prints&at_auction=true&attribution_class%5B0%5D=limited%20edition&attribution_class%5B1%5D=unique&colors%5B0%5D=yellow&colors%5B1%5D=red&inquireable_only=true&location_cities%5B0%5D=New%20York%2C%20NY%2C%20USA&major_periods%5B0%5D=1990&major_periods%5B1%5D=2000&materials_terms%5B0%5D=acrylic&materials_terms%5B1%5D=aluminium&offerable=true&partner_ids%5B0%5D=foo-bar-gallery&price_range=100-1000&sizes%5B0%5D=small&sizes%5B1%5D=medium&for_sale=true"
         )
       })
+    })
+  })
+
+  describe("suggestedFilters", () => {
+    it("returns a list of suggested filters", async () => {
+      const query = gql`
+        {
+          previewSavedSearch(attributes: { artistIDs: ["banksy"] }) {
+            suggestedFilters {
+              displayValue
+              field
+              value
+              name
+            }
+          }
+        }
+      `
+
+      const artistLoader = () => Promise.resolve({})
+
+      const { previewSavedSearch } = await runQuery(query, {
+        artistLoader,
+        meLoader,
+      })
+
+      expect(previewSavedSearch.suggestedFilters).toEqual(mockSuggestedFilters)
     })
   })
 })

--- a/src/schema/v2/previewSavedSearch.ts
+++ b/src/schema/v2/previewSavedSearch.ts
@@ -93,6 +93,14 @@ const PreviewSavedSearchType = new GraphQLObjectType<any, ResolverContext>({
         "URL for a user to view the artwork grid with applied filters matching saved search criteria attributes",
       resolve: resolveHref,
     },
+    suggestedFilters: {
+      description:
+        "Suggested filters for the user to use based on their search criteria",
+      type: new GraphQLList(new GraphQLNonNull(SearchCriteriaLabel)),
+      resolve: (_) => {
+        return mockSuggestedFilters
+      },
+    },
   }),
 })
 
@@ -203,3 +211,24 @@ const resolveHref = async (parent, _args, _context, _info) => {
 
   return `/artist/${primaryArtist}?${queryParams}&for_sale=true`
 }
+
+export const mockSuggestedFilters: SearchCriteriaLabel[] = [
+  {
+    displayValue: "Painting",
+    field: "additionalGeneIDs",
+    value: "painting",
+    name: "Medium",
+  },
+  {
+    displayValue: "Unique",
+    field: "attributionClass",
+    value: "unique",
+    name: "Rarity",
+  },
+  {
+    displayValue: "$0-$10,000",
+    field: "priceRange",
+    value: "*-10000",
+    name: "Price",
+  },
+]

--- a/src/schema/v2/previewSavedSearch.ts
+++ b/src/schema/v2/previewSavedSearch.ts
@@ -96,7 +96,9 @@ const PreviewSavedSearchType = new GraphQLObjectType<any, ResolverContext>({
     suggestedFilters: {
       description:
         "Suggested filters for the user to use based on their search criteria",
-      type: new GraphQLList(new GraphQLNonNull(SearchCriteriaLabel)),
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(SearchCriteriaLabel))
+      ),
       resolve: (_) => {
         return mockSuggestedFilters
       },


### PR DESCRIPTION
Resolves [ONYX-515]

This PR brings a mock structure for the upcoming suggested filters work. We are starting here by returning a mock then we will introduce the logic in the upcoming tickets.

<img width="1728" alt="Screenshot 2023-11-14 at 09 52 49" src="https://github.com/artsy/metaphysics/assets/11945712/56528413-a248-4067-a5ee-44fdae0f85ed">


[ONYX-515]: https://artsyproduct.atlassian.net/browse/ONYX-515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ