### PR TITLE
feat(ONYX-520): add rarity as a suggested filter

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14364,11 +14364,7 @@ type PreviewSavedSearch {
   labels: [SearchCriteriaLabel]!
 
   # Suggested filters for the user to use based on their search criteria
-<<<<<<< HEAD
   suggestedFilters: [SearchCriteriaLabel!]!
-=======
-  suggestedFilters: [SearchCriteriaLabel!]
->>>>>>> 10133ae5 (feat: introduce mock structure for suggested filters)
 }
 
 input PreviewSavedSearchAttributes {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14364,7 +14364,11 @@ type PreviewSavedSearch {
   labels: [SearchCriteriaLabel]!
 
   # Suggested filters for the user to use based on their search criteria
+<<<<<<< HEAD
   suggestedFilters: [SearchCriteriaLabel!]!
+=======
+  suggestedFilters: [SearchCriteriaLabel!]
+>>>>>>> 10133ae5 (feat: introduce mock structure for suggested filters)
 }
 
 input PreviewSavedSearchAttributes {

--- a/src/schema/v2/previewSavedSearch.ts
+++ b/src/schema/v2/previewSavedSearch.ts
@@ -103,12 +103,8 @@ const PreviewSavedSearchType = new GraphQLObjectType<any, ResolverContext>({
       ),
       resolve: async (_root, _args, { filterArtworksLoader }) => {
         const suggestedFiltersByArtist: SearchCriteriaLabel[][] = await Promise.all(
-          _root.artistIDs.map(
-            async (artistSlug) =>
-              await getSuggestedFiltersByArtistSlug(
-                artistSlug,
-                filterArtworksLoader
-              )
+          _root.artistIDs.map((artistSlug) =>
+            getSuggestedFiltersByArtistSlug(artistSlug, filterArtworksLoader)
           )
         )
 

--- a/src/schema/v2/previewSavedSearch.ts
+++ b/src/schema/v2/previewSavedSearch.ts
@@ -8,14 +8,16 @@ import {
   GraphQLObjectType,
   GraphQLString,
 } from "graphql"
+import attributionClasses from "lib/attributionClasses"
+import { snakeCaseKeys } from "lib/helpers"
+import _ from "lodash"
+import { stringify } from "qs"
 import { ResolverContext } from "types/graphql"
 import ArtworkSizes from "./artwork/artworkSizes"
 import {
-  resolveSearchCriteriaLabels,
   SearchCriteriaLabel,
+  resolveSearchCriteriaLabels,
 } from "./searchCriteriaLabel"
-import { snakeCaseKeys } from "lib/helpers"
-import { stringify } from "qs"
 
 const previewSavedSearchArgs: GraphQLFieldConfigArgumentMap = {
   acquireable: {
@@ -99,12 +101,71 @@ const PreviewSavedSearchType = new GraphQLObjectType<any, ResolverContext>({
       type: new GraphQLNonNull(
         new GraphQLList(new GraphQLNonNull(SearchCriteriaLabel))
       ),
-      resolve: (_) => {
-        return mockSuggestedFilters
+      resolve: async (_root, _args, { filterArtworksLoader }) => {
+        const suggestedFiltersByArtist: SearchCriteriaLabel[][] = await Promise.all(
+          _root.artistIDs.map(
+            async (artistSlug) =>
+              await getSuggestedFiltersByArtistSlug(
+                artistSlug,
+                filterArtworksLoader
+              )
+          )
+        )
+
+        return _.chain(suggestedFiltersByArtist)
+          .flatten()
+          .uniqBy((searchCriteria) => JSON.stringify(searchCriteria))
+          .value()
       },
     },
   }),
 })
+
+const getMostPopularField = (aggregation: {
+  [key: string]: { name: string; count: number }
+}): string => {
+  return Object.values(aggregation).reduce((acc, curr) => {
+    return curr.count > acc.count ? curr : acc
+  }).name
+}
+
+const getRaritySearchCriteriaLabel = (
+  name: string | undefined
+): SearchCriteriaLabel => {
+  if (!name) {
+    return {
+      displayValue: "Unique",
+      field: "attributionClass",
+      value: "unique",
+      name: "Rarity",
+    }
+  }
+  return {
+    displayValue: attributionClasses[name].name,
+    field: "attributionClass",
+    value: name,
+    name: "Rarity",
+  }
+}
+
+const getSuggestedFiltersByArtistSlug = async (
+  artistSlug: string,
+  filterArtworksLoader
+): Promise<SearchCriteriaLabel[]> => {
+  const gravityArgs = {
+    published: true,
+    aggregations: ["attribution_class"],
+    artist_id: artistSlug,
+  }
+
+  const { aggregations } = await filterArtworksLoader(gravityArgs)
+
+  const rarity = getRaritySearchCriteriaLabel(
+    getMostPopularField(aggregations["attribution_class"])
+  )
+
+  return [rarity]
+}
 
 const PreviewSavedSearchAttributesType = new GraphQLInputObjectType({
   name: "PreviewSavedSearchAttributes",
@@ -213,24 +274,3 @@ const resolveHref = async (parent, _args, _context, _info) => {
 
   return `/artist/${primaryArtist}?${queryParams}&for_sale=true`
 }
-
-export const mockSuggestedFilters: SearchCriteriaLabel[] = [
-  {
-    displayValue: "Painting",
-    field: "additionalGeneIDs",
-    value: "painting",
-    name: "Medium",
-  },
-  {
-    displayValue: "Unique",
-    field: "attributionClass",
-    value: "unique",
-    name: "Rarity",
-  },
-  {
-    displayValue: "$0-$10,000",
-    field: "priceRange",
-    value: "*-10000",
-    name: "Price",
-  },
-]

--- a/src/schema/v2/previewSavedSearch.ts
+++ b/src/schema/v2/previewSavedSearch.ts
@@ -127,15 +127,11 @@ const getMostPopularField = (aggregation: {
 
 const getRaritySearchCriteriaLabel = (
   name: string | undefined
-): SearchCriteriaLabel => {
-  if (!name) {
-    return {
-      displayValue: "Unique",
-      field: "attributionClass",
-      value: "unique",
-      name: "Rarity",
-    }
+): SearchCriteriaLabel | null => {
+  if (!name || name === "unknown edition") {
+    return null
   }
+
   return {
     displayValue: attributionClasses[name].name,
     field: "attributionClass",
@@ -156,11 +152,17 @@ const getSuggestedFiltersByArtistSlug = async (
 
   const { aggregations } = await filterArtworksLoader(gravityArgs)
 
+  const suggestedFilters: SearchCriteriaLabel[] = []
+
   const rarity = getRaritySearchCriteriaLabel(
     getMostPopularField(aggregations["attribution_class"])
   )
 
-  return [rarity]
+  if (rarity) {
+    suggestedFilters.push(rarity)
+  }
+
+  return suggestedFilters
 }
 
 const PreviewSavedSearchAttributesType = new GraphQLInputObjectType({


### PR DESCRIPTION
Resolves [ONYX-520]

This PR adds rarity as a suggested filter. We are getting the most popular rarity for artists based on aggregations. 

**Open questions:**
1. The above logic considers "unique" and "limited edition" as rarities with the same weight. I do however believe that they're not the same and users might be interested in unique works more if both counts are close. I would suggest here to increase the weight of unique artworks to cover for that. Open to other ideas -> Answer: no need for that now


2. Should we consider "Uknown edition" as a valid rarity suggestion? -> Answer: let's remove it

Both questions answered ✅ 



[ONYX-519]: https://artsyproduct.atlassian.net/browse/ONYX-519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ONYX-520]: https://artsyproduct.atlassian.net/browse/ONYX-520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ