### PR TITLE
chore: docker development changes

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,4 @@
-GRAVITY_API_BASE=http://localhost:3000/api/v1
-GRAVITY_GRAPHQL_ENDPOINT=http://localhost:3000/api
-GRAVITY_API_URL=http://localhost:3000
-#GRAVITY_ID=
-#GRAVITY_SECRET=
-MEMCACHED_URL=localhost:11211
+GRAVITY_API_BASE=http://gravity:3000/api/v1
+GRAVITY_GRAPHQL_ENDPOINT=http://gravity:3000/api
+GRAVITY_API_URL=http://gravity:3000
+MEMCACHED_URL=metaphysics-memcached:11211

--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,6 @@
 GRAVITY_API_BASE=http://gravity:3000/api/v1
 GRAVITY_GRAPHQL_ENDPOINT=http://gravity:3000/api
 GRAVITY_API_URL=http://gravity:3000
+#GRAVITY_ID=metaphysics-client-id
+#GRAVITY_SECRET=metaphysics-client-secret
 MEMCACHED_URL=metaphysics-memcached:11211

--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -4,8 +4,8 @@ services:
 {% include 'templates/docker-compose-service-dev.yml.j2' %}
     command: ["yarn", "start"]
     env_file:
-      - ../.env.development
       - ../.env.shared
+      - ../.env.development
       - ../.env
     depends_on:
       - metaphysics-memcached
@@ -16,4 +16,4 @@ services:
   metaphysics-memcached:
     image: memcached:1.4.34-alpine
     ports:
-      - 11211:11211
+      - 11212:11211

--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -15,5 +15,3 @@ services:
       - ../:/app
   metaphysics-memcached:
     image: memcached:1.4.34-alpine
-    ports:
-      - 11212:11211


### PR DESCRIPTION
Supports https://artsyproduct.atlassian.net/browse/PHIRE-293

This tweaks the `.env.development` to use docker service name when connecting to gravity and also increments the Memcached port exposed on the host to prevent port collision when `gravity-memcached` service is already running as part of gravity local dev stack.

If needed to use `localhost`, those overrides can go into `.env`.