### PR TITLE
feat: move some metadata onto the edge between Alert and Artist nodes

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -300,6 +300,7 @@ type AlertConnection {
 type AlertEdge {
   # A cursor for use in pagination
   cursor: String!
+  isRecentlyEnabled: Boolean
 
   # The item at the end of the edge
   node: Alert

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -303,6 +303,7 @@ type AlertEdge {
 
   # The item at the end of the edge
   node: Alert
+  totalUserSearchCriteriaCount: Int
 }
 
 # A connection to a list of items.

--- a/src/schema/v2/alerts.ts
+++ b/src/schema/v2/alerts.ts
@@ -65,9 +65,17 @@ const AlertType = new GraphQLObjectType<
   },
 })
 
+const AlertsEdgeFields = {
+  totalUserSearchCriteriaCount: {
+    type: GraphQLInt,
+    resolve: ({ count_30d }) => count_30d,
+  },
+}
+
 export const AlertsConnectionType = connectionWithCursorInfo({
   name: "Alert",
   nodeType: AlertType,
+  edgeFields: AlertsEdgeFields,
 }).connectionType
 
 export const AlertsSummaryFields = {

--- a/src/schema/v2/alerts.ts
+++ b/src/schema/v2/alerts.ts
@@ -70,6 +70,10 @@ const AlertsEdgeFields = {
     type: GraphQLInt,
     resolve: ({ count_30d }) => count_30d,
   },
+  isRecentlyEnabled: {
+    type: GraphQLBoolean,
+    resolve: ({ count_7d }) => count_7d > 0,
+  },
 }
 
 export const AlertsConnectionType = connectionWithCursorInfo({

--- a/src/schema/v2/artist/__tests__/index.test.js
+++ b/src/schema/v2/artist/__tests__/index.test.js
@@ -747,7 +747,7 @@ describe("Artist type", () => {
     const artistAlertsLoader = () =>
       Promise.resolve({
         total_count: 1,
-        alerts: [{ id: "percy-z-alert", count_7d: 1 }],
+        alerts: [{ id: "percy-z-alert", count_7d: 1, count_30d: 420 }],
       })
     it("returns a connection of the artist's alerts", () => {
       const query = `
@@ -755,6 +755,7 @@ describe("Artist type", () => {
           artist(id: "percy-z") {
             alertsConnection(first: 10) {
               edges {
+                totalUserSearchCriteriaCount
                 node {
                   hasRecentlyEnabledUserSearchCriteria
                 }
@@ -767,13 +768,22 @@ describe("Artist type", () => {
         ...context,
         artistAlertsLoader,
       }).then((data) => {
-        expect(data).toEqual({
-          artist: {
-            alertsConnection: {
-              edges: [{ node: { hasRecentlyEnabledUserSearchCriteria: true } }],
+        expect(data).toMatchInlineSnapshot(`
+          Object {
+            "artist": Object {
+              "alertsConnection": Object {
+                "edges": Array [
+                  Object {
+                    "node": Object {
+                      "hasRecentlyEnabledUserSearchCriteria": true,
+                    },
+                    "totalUserSearchCriteriaCount": 420,
+                  },
+                ],
+              },
             },
-          },
-        })
+          }
+        `)
       })
     })
   })

--- a/src/schema/v2/artist/__tests__/index.test.js
+++ b/src/schema/v2/artist/__tests__/index.test.js
@@ -756,6 +756,7 @@ describe("Artist type", () => {
             alertsConnection(first: 10) {
               edges {
                 totalUserSearchCriteriaCount
+                isRecentlyEnabled
                 node {
                   hasRecentlyEnabledUserSearchCriteria
                 }
@@ -774,6 +775,7 @@ describe("Artist type", () => {
               "alertsConnection": Object {
                 "edges": Array [
                   Object {
+                    "isRecentlyEnabled": true,
                     "node": Object {
                       "hasRecentlyEnabledUserSearchCriteria": true,
                     },

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -138,6 +138,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
             size,
             body,
             args,
+            resolveNode: (node) => node,
           })
         },
       },


### PR DESCRIPTION
To make things a bit more consistent with the summary schema which includes metadata on the edge, lets use that here as well. This metadata is a bit less compelling to be on the edge from a very pedantic perspective IMO, but we can add it.