### PR TITLE
chore(counts): Move `totalUserSearchCriteriaCount` to counts

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -298,12 +298,17 @@ type AlertConnection {
 
 # An edge in a connection.
 type AlertEdge {
+  counts: AlertsCounts
+
   # A cursor for use in pagination
   cursor: String!
   isRecentlyEnabled: Boolean
 
   # The item at the end of the edge
   node: Alert
+}
+
+type AlertsCounts {
   totalUserSearchCriteriaCount: Int
 }
 

--- a/src/schema/v2/alerts.ts
+++ b/src/schema/v2/alerts.ts
@@ -66,9 +66,17 @@ const AlertType = new GraphQLObjectType<
 })
 
 const AlertsEdgeFields = {
-  totalUserSearchCriteriaCount: {
-    type: GraphQLInt,
-    resolve: ({ count_30d }) => count_30d,
+  counts: {
+    type: new GraphQLObjectType({
+      name: "AlertsCounts",
+      fields: {
+        totalUserSearchCriteriaCount: {
+          type: GraphQLInt,
+          resolve: ({ count_30d }) => count_30d,
+        },
+      },
+    }),
+    resolve: (x) => x,
   },
   isRecentlyEnabled: {
     type: GraphQLBoolean,

--- a/src/schema/v2/artist/__tests__/index.test.js
+++ b/src/schema/v2/artist/__tests__/index.test.js
@@ -749,14 +749,17 @@ describe("Artist type", () => {
         total_count: 1,
         alerts: [{ id: "percy-z-alert", count_7d: 1, count_30d: 420 }],
       })
+
     it("returns a connection of the artist's alerts", () => {
       const query = `
         {
           artist(id: "percy-z") {
             alertsConnection(first: 10) {
               edges {
-                totalUserSearchCriteriaCount
                 isRecentlyEnabled
+                counts {
+                  totalUserSearchCriteriaCount
+                }
                 node {
                   hasRecentlyEnabledUserSearchCriteria
                 }
@@ -775,11 +778,13 @@ describe("Artist type", () => {
               "alertsConnection": Object {
                 "edges": Array [
                   Object {
+                    "counts": Object {
+                      "totalUserSearchCriteriaCount": 420,
+                    },
                     "isRecentlyEnabled": true,
                     "node": Object {
                       "hasRecentlyEnabledUserSearchCriteria": true,
                     },
-                    "totalUserSearchCriteriaCount": 420,
                   },
                 ],
               },


### PR DESCRIPTION
Missed this! Update to https://github.com/artsy/metaphysics/pull/5422, which moves count info into `counts`, so that things are aligned with the summary query structure. As future counts are needed, we can continue populating this subfield (also similar to the summary page) 