### PR TITLE
chore: allow partnerID to be specified for artist alerts

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1400,7 +1400,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     before: String
     first: Int
     last: Int
-    sort: String
+    partnerID: String
   ): AlertConnection
   alternateNames: [String]
   articlesConnection(

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -110,7 +110,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
       },
       alertsConnection: {
         args: pageable({
-          sort: {
+          partnerID: {
             type: GraphQLString,
           },
         }),
@@ -128,7 +128,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
           } = await artistAlertsLoader(_id, {
             page,
             size,
-            sort: args.sort,
+            partner_id: args.partnerID,
           })
 
           return paginationResolver({


### PR DESCRIPTION
Companion to https://github.com/artsy/gravity/pull/17098 , allowing a `partnerID` to be specified when requesting an artist's alerts. Also removed an unused `sort` argument