### PR TITLE
allow passing preferred metric to previewSavedSearch

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15902,6 +15902,7 @@ type Query {
   # A previewed saved search
   previewSavedSearch(
     attributes: PreviewSavedSearchAttributes
+    metric: String
   ): PreviewSavedSearch
 
   # Get all price insights for an artist.
@@ -20556,6 +20557,7 @@ type Viewer {
   # A previewed saved search
   previewSavedSearch(
     attributes: PreviewSavedSearchAttributes
+    metric: String
   ): PreviewSavedSearch
 
   # A Profile

--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -490,6 +490,39 @@ describe("resolveSearchCriteriaLabels", () => {
         },
       ])
     })
+    it("handles range parsing with provided metric", async () => {
+      let parent = {
+        width: "40-100",
+        metric: "in",
+      }
+
+      let labels = await resolveSearchCriteriaLabels(parent, _, { meLoader }, _)
+
+      expect(labels).toIncludeAllMembers([
+        {
+          name: "Size",
+          displayValue: "w: 40–100 in",
+          value: "40-100",
+          field: "width",
+        },
+      ])
+
+      parent = {
+        width: "40-100",
+        metric: "cm",
+      }
+
+      labels = await resolveSearchCriteriaLabels(parent, _, { meLoader }, _)
+
+      expect(labels).toIncludeAllMembers([
+        {
+          name: "Size",
+          displayValue: "w: 102–254 cm",
+          value: "40-100",
+          field: "width",
+        },
+      ])
+    })
   })
 
   it("formats ways-to-buy criteria", async () => {

--- a/src/schema/v2/previewSavedSearch.ts
+++ b/src/schema/v2/previewSavedSearch.ts
@@ -227,9 +227,12 @@ export const PreviewSavedSearchField: GraphQLFieldConfig<
     attributes: {
       type: PreviewSavedSearchAttributesType,
     },
+    metric: {
+      type: GraphQLString,
+    },
   },
   resolve: (_parent, args, _context, _info) => {
-    return args.attributes
+    return { ...args.attributes, metric: args.metric }
   },
 }
 

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -108,6 +108,7 @@ export const resolveSearchCriteriaLabels = async (
     majorPeriods,
     colors,
     partnerIDs,
+    metric,
   } = parent
 
   const {
@@ -117,7 +118,8 @@ export const resolveSearchCriteriaLabels = async (
     partnerLoader,
   } = context
 
-  const metric = await getPreferredMetric(meLoader)
+  // use metric if provided, otherwise fallback to the user's preferred metric
+  const computedMetric = metric ?? (await getPreferredMetric(meLoader))
 
   const labels: any[] = []
 
@@ -125,8 +127,8 @@ export const resolveSearchCriteriaLabels = async (
   labels.push(getRarityLabels(attributionClass))
   labels.push(getMediumLabels(additionalGeneIDs))
   labels.push(getPriceLabel(priceRange))
-  labels.push(getSizeLabels(sizes, metric))
-  labels.push(getCustomSizeLabels({ height, metric, width }))
+  labels.push(getSizeLabels(sizes, computedMetric))
+  labels.push(getCustomSizeLabels({ height, metric: computedMetric, width }))
   labels.push(
     getWaysToBuyLabels({
       acquireable,


### PR DESCRIPTION
Take a look at this quick demo of the issue:

https://github.com/artsy/metaphysics/assets/3934579/e18c2ead-d541-4fe3-9e50-309e03dcfe34

Currently metaphysics uses only preferred units for displaying pills. I find it weird that when user specifies inches or centimetres explicitly - pils are displayed in other metric units.

I suggest passing `metic` argument to the `previewSavedSearch` query. When metric is not specified - metaphysics fallbacks to the preferred units.

```graphql
query MyQuery {
  previewSavedSearch(attributes: { width: "40-100" }, metric: "in") {
    displayName
    labels {
      displayValue # will be "w: 40–100 in"
    }
  }
}
```

```graphql
query MyQuery {
  previewSavedSearch(attributes: { width: "40-100" }, metric: "cm") {
    displayName
    labels {
      displayValue # will be "w: 102–254 cm"
    }
  }
}
```