### PR TITLE
feat(EMI-1557): add receivePartnerOfferNotification

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12114,6 +12114,9 @@ type Me implements Node {
   # This user should receive outbid notifications
   receiveOutbidNotification: Boolean
 
+  # This user should receive partner offer notifications
+  receivePartnerOfferNotification: Boolean
+
   # This user should receive partner show notifications
   receivePartnerShowNotification: Boolean
 
@@ -18713,6 +18716,9 @@ input UpdateMyProfileInput {
   # This user should receive outbid notifications
   receiveOutbidNotification: Boolean
 
+  # This user should receive partner offer notifications
+  receivePartnerOfferNotification: Boolean
+
   # This user should receive partner show notifications
   receivePartnerShowNotification: Boolean
 
@@ -19216,6 +19222,9 @@ type User implements Node {
 
   # This user should receive outbid notifications
   receiveOutbidNotification: Boolean
+
+  # This user should receive partner offer notifications
+  receivePartnerOfferNotification: Boolean
 
   # This user should receive partner show notifications
   receivePartnerShowNotification: Boolean

--- a/src/schema/v2/__tests__/user.test.ts
+++ b/src/schema/v2/__tests__/user.test.ts
@@ -394,6 +394,7 @@ describe("User", () => {
         receive_order_notification: true,
         receive_viewing_room_notification: true,
         receive_partner_show_notification: true,
+        receive_partner_offer_notification: true,
       }
 
       const userByEmailLoader = (data) => {
@@ -419,6 +420,7 @@ describe("User", () => {
             receiveOrderNotification
             receiveViewingRoomNotification
             receivePartnerShowNotification
+            receivePartnerOfferNotification
           }
         }
       `
@@ -437,6 +439,7 @@ describe("User", () => {
       expect(user.receiveOrderNotification).toEqual(true)
       expect(user.receiveViewingRoomNotification).toEqual(true)
       expect(user.receivePartnerShowNotification).toEqual(true)
+      expect(user.receivePartnerOfferNotification).toEqual(true)
     })
   })
 

--- a/src/schema/v2/me/__tests__/__snapshots__/update_me_mutation.test.js.snap
+++ b/src/schema/v2/me/__tests__/__snapshots__/update_me_mutation.test.js.snap
@@ -38,6 +38,7 @@ Object {
       "receiveNewWorksNotification": true,
       "receiveOrderNotification": false,
       "receiveOutbidNotification": false,
+      "receivePartnerOfferNotification": true,
       "receivePartnerShowNotification": true,
       "receivePromotionNotification": false,
       "receivePurchaseNotification": false,

--- a/src/schema/v2/me/__tests__/index.test.ts
+++ b/src/schema/v2/me/__tests__/index.test.ts
@@ -24,6 +24,7 @@ describe("me/index", () => {
         receiveOrderNotification
         receiveViewingRoomNotification
         receivePartnerShowNotification
+        receivePartnerOfferNotification
         currencyPreference
         lengthUnitPreference
       }
@@ -81,6 +82,7 @@ describe("me/index", () => {
       receive_order_notification: false,
       receive_viewing_room_notification: true,
       receive_partner_show_notification: true,
+      receive_partner_offer_notification: true,
       currency_preference: "USD",
       length_unit_preference: "in",
     }
@@ -108,6 +110,7 @@ describe("me/index", () => {
           receiveOrderNotification: false,
           receiveViewingRoomNotification: true,
           receivePartnerShowNotification: true,
+          receivePartnerOfferNotification: true,
           currencyPreference: "USD",
           lengthUnitPreference: "IN",
         },

--- a/src/schema/v2/me/__tests__/update_me_mutation.test.js
+++ b/src/schema/v2/me/__tests__/update_me_mutation.test.js
@@ -28,6 +28,7 @@ describe("UpdateMeMutation", () => {
             receiveOrderNotification: false
             receiveViewingRoomNotification: true
             receivePartnerShowNotification: true
+            receivePartnerOfferNotification: true
             shareFollows: false
             currencyPreference: EUR
             lengthUnitPreference: CM
@@ -51,6 +52,7 @@ describe("UpdateMeMutation", () => {
             receiveOrderNotification
             receiveViewingRoomNotification
             receivePartnerShowNotification
+            receivePartnerOfferNotification
           }
           userOrError {
             ... on UpdateMyProfileMutationSuccess {
@@ -92,6 +94,7 @@ describe("UpdateMeMutation", () => {
         receive_order_notification: false,
         receive_viewing_room_notification: true,
         receive_partner_show_notification: true,
+        receive_partner_offer_notification: true,
         currency_preference: "EUR",
         length_unit_preference: "cm",
       })
@@ -117,6 +120,7 @@ describe("UpdateMeMutation", () => {
           receive_order_notification: true,
           receive_viewing_room_notification: true,
           receive_partner_show_notification: true,
+          receive_partner_offer_notification: true,
           currency_preference: "EUR",
           length_unit_preference: "cm",
         }),
@@ -148,6 +152,7 @@ describe("UpdateMeMutation", () => {
       receive_order_notification: false,
       receive_viewing_room_notification: true,
       receive_partner_show_notification: true,
+      receive_partner_offer_notification: true,
       share_follows: false,
       currency_preference: "EUR",
       length_unit_preference: "cm",
@@ -217,6 +222,7 @@ describe("UpdateMeMutation", () => {
         receive_order_notification: false,
         receive_viewing_room_notification: true,
         receive_partner_show_notification: true,
+        receive_partner_offer_notification: true,
       })
     )
 

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -484,6 +484,12 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
       resolve: ({ receive_partner_show_notification }) =>
         receive_partner_show_notification,
     },
+    receivePartnerOfferNotification: {
+      description: "This user should receive partner offer notifications",
+      type: GraphQLBoolean,
+      resolve: ({ receive_partner_offer_notification }) =>
+        receive_partner_offer_notification,
+    },
     recentlyViewedArtworkIds: {
       type: new GraphQLNonNull(new GraphQLList(GraphQLString)),
       resolve: ({ recently_viewed_artwork_ids }) => recently_viewed_artwork_ids,

--- a/src/schema/v2/me/update_me_mutation.ts
+++ b/src/schema/v2/me/update_me_mutation.ts
@@ -222,6 +222,10 @@ export default mutationWithClientMutationId<any, any, ResolverContext>({
       description: "This user should receive partner show notifications",
       type: GraphQLBoolean,
     },
+    receivePartnerOfferNotification: {
+      description: "This user should receive partner offer notifications",
+      type: GraphQLBoolean,
+    },
     shareFollows: {
       description:
         "Shares FollowArtists, FollowGenes, and FollowProfiles with partners.",

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -534,6 +534,12 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ receive_partner_show_notification }) =>
           receive_partner_show_notification,
       },
+      receivePartnerOfferNotification: {
+        description: "This user should receive partner offer notifications",
+        type: GraphQLBoolean,
+        resolve: ({ receive_partner_offer_notification }) =>
+          receive_partner_offer_notification,
+      },
       savedArtworksConnection: {
         type: artworkConnection.connectionType,
         args: pageable({}),


### PR DESCRIPTION
This PR resolves [EMI-1557]

### Description
This PR is a follow-up on artsy/gravity#17116 🔒

This PR adds `receivePartnerOfferNotification` field to the `user` and `me` namespaces to access user preference for push notifications

### Example
Request:
```graphql
query {
  me {
    receivePartnerOfferNotification
  }
}
```

Response:
```json
{
  "me": {
    "receivePartnerOfferNotification": true,
  }
}
```


[EMI-1557]: https://artsyproduct.atlassian.net/browse/EMI-1557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ