### PR TITLE
fix: previewSavedSearch returns artist series slugs instead of IDs

### DIFF
--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -664,16 +664,16 @@ describe("resolveSearchCriteriaLabels", () => {
         .mockReturnValueOnce(
           Promise.resolve({
             artistSeries: {
-              internalID: "abc-123",
               title: "Astroboy",
+              slug: "kaws-astroboy",
             },
           })
         )
         .mockReturnValueOnce(
           Promise.resolve({
             artistSeries: {
-              internalID: "def-456",
               title: "Companions",
+              slug: "kaws-companions",
             },
           })
         ),
@@ -686,13 +686,13 @@ describe("resolveSearchCriteriaLabels", () => {
       {
         name: "Artist Series",
         field: "artistSeriesIDs",
-        value: "abc-123",
+        value: "kaws-astroboy",
         displayValue: "Astroboy",
       },
       {
         name: "Artist Series",
         field: "artistSeriesIDs",
-        value: "def-456",
+        value: "kaws-companions",
         displayValue: "Companions",
       },
     ])

--- a/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
+++ b/src/schema/v2/__tests__/searchCriteriaLabel.test.ts
@@ -665,7 +665,6 @@ describe("resolveSearchCriteriaLabels", () => {
           Promise.resolve({
             artistSeries: {
               title: "Astroboy",
-              slug: "kaws-astroboy",
             },
           })
         )
@@ -673,7 +672,6 @@ describe("resolveSearchCriteriaLabels", () => {
           Promise.resolve({
             artistSeries: {
               title: "Companions",
-              slug: "kaws-companions",
             },
           })
         ),

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -460,21 +460,20 @@ async function getArtistSeriesLabels(
           query GetArtistSeriesLabelsQuery($id: ID!) {
             artistSeries(id: $id) {
               title
-              slug
             }
           }
         `,
         variables: { id },
       })
       const {
-        artistSeries: { title, slug },
+        artistSeries: { title },
       } = data
 
       return {
         name: "Artist Series",
         displayValue: title,
         field: "artistSeriesIDs",
-        value: slug,
+        value: id,
       }
     })
   )

--- a/src/schema/v2/searchCriteriaLabel.ts
+++ b/src/schema/v2/searchCriteriaLabel.ts
@@ -459,22 +459,22 @@ async function getArtistSeriesLabels(
         query: gql`
           query GetArtistSeriesLabelsQuery($id: ID!) {
             artistSeries(id: $id) {
-              internalID
               title
+              slug
             }
           }
         `,
         variables: { id },
       })
       const {
-        artistSeries: { internalID, title },
+        artistSeries: { title, slug },
       } = data
 
       return {
         name: "Artist Series",
         displayValue: title,
         field: "artistSeriesIDs",
-        value: internalID,
+        value: slug,
       }
     })
   )


### PR DESCRIPTION
Frontends works with `slugs` instead of `IDs`: when a user filters artworks grid by artist series - `slug` is being added to the filters / alert context. `previewSavedSearch` returns `IDs`, and because of this the logic to remove a pill doesn't work.

