### PR TITLE
feat(EMI-1564): add saved_at_least_once filter to partner query

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13772,6 +13772,9 @@ type Partner implements Node {
     # Return artworks published less than x seconds ago.
     publishedWithin: Int
 
+    # Return artworks that were saved by collectors at least one time.
+    savedAtLeastOnce: Boolean
+
     # Only allowed for authorized admin/partner requests. When false fetch :all
     # properties on an artwork, when true or not present fetch artwork :short properties
     shallow: Boolean

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -106,6 +106,11 @@ const artworksArgs: GraphQLFieldConfigArgumentMap = {
     description:
       "If true return both published and unpublished artworks, requires auth",
   },
+  savedAtLeastOnce: {
+    type: GraphQLBoolean,
+    description:
+      "Return artworks that were saved by collectors at least one time.",
+  },
   sort: ArtworkSorts,
   shallow: {
     type: GraphQLBoolean,
@@ -392,6 +397,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             page: number
             published?: boolean
             published_within?: number
+            saved_at_least_once?: boolean
             size: number
             sort: string
             total_count: boolean
@@ -404,6 +410,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             page,
             published: true,
             published_within: args.publishedWithin,
+            saved_at_least_once: args.savedAtLeastOnce,
             size,
             sort: args.sort,
             total_count: true,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/EMI-1564

Followup for: https://github.com/artsy/gravity/pull/17133

left: with filter - right: no filter
![SCR-20231129-mxi](https://github.com/artsy/metaphysics/assets/554507/459b46d0-107d-4a04-9c5f-4980af893fb9)
