### PR TITLE
chore: add activeInventory filter argument on alertsSummaryArtistsConn…

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13697,6 +13697,7 @@ type PageInfo {
 
 type Partner implements Node {
   alertsSummaryArtistsConnection(
+    activeInventory: Boolean
     after: String
     before: String
     first: Int

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -155,6 +155,9 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           represented: {
             type: GraphQLBoolean,
           },
+          activeInventory: {
+            type: GraphQLBoolean,
+          },
         }),
         resolve: async ({ _id }, args, { partnerAlertsSummaryLoader }) => {
           if (!partnerAlertsSummaryLoader) return null
@@ -167,10 +170,12 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             page: number
             size: number
             represented?: boolean
+            active_inventory?: boolean
           }
 
           const gravityArgs: GravityArgs = { page, size }
           if (args.represented) gravityArgs.represented = true
+          if (args.activeInventory) gravityArgs.active_inventory = true
 
           const {
             summary: body,


### PR DESCRIPTION
…ection

Expose a new `activeInventory` bool argument on `alertsSummaryArtistsConnection`
This will allow clients to pass in the new active inventory filter down [to gravity layer](https://github.com/artsy/gravity/pull/17140)

