### PR TITLE
feat(DIA-345): wire Inquiry new data loader and expose hasPartnerFollow

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11005,6 +11005,9 @@ type InquirerCollectorProfile {
     @deprecated(
       reason: "emailConfirmed is going to be removed, use isEmailConfirmed instead"
     )
+
+  # The Collector follows the Gallery profile
+  hasPartnerFollow: Boolean
   icon: Image
 
   # A globally unique ID.

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -542,12 +542,9 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
-    partnerInquirerCollectorProfileLoader: gravityLoader<
-      any,
-      { partnerId: string; inquiryId: string }
-    >(
-      ({ partnerId, inquiryId }) =>
-        `partner/${partnerId}/inquiry_request/${inquiryId}/collector_profile`
+    partnerCollectorProfileLoader: gravityLoader<any, { partnerId; userId }>(
+      ({ partnerId, userId }) =>
+        `partner_collector_profile?partner_id=${partnerId}&user_id=${userId}`
     ),
     partnerInquiryRequestLoader: gravityLoader<
       any,

--- a/src/schema/v2/partner/__tests__/partnerInquirerCollectorProfile.test.ts
+++ b/src/schema/v2/partner/__tests__/partnerInquirerCollectorProfile.test.ts
@@ -7,6 +7,7 @@ describe("partnerInquirerCollectorProfile", () => {
     slug: "catty-partner",
     name: "Catty Partner",
   }
+  const inquirer = { id: "inquirer-id" }
 
   const collectorProfile = {
     name: "Some Collector",
@@ -19,8 +20,13 @@ describe("partnerInquirerCollectorProfile", () => {
   }
 
   const context = {
+    partnerCollectorProfileLoader: () =>
+      Promise.resolve({
+        collector_profile: collectorProfile,
+        follows_profile: true,
+      }),
     partnerInquiryRequestLoader: () =>
-      Promise.resolve({ id: "123", partnerId: "catty-partner" }),
+      Promise.resolve({ id: "123", partnerId: "catty-partner", inquirer }),
     partnerInquirerCollectorProfileLoader: () =>
       Promise.resolve(collectorProfile),
     partnerLoader: () => Promise.resolve(partnerData),
@@ -41,6 +47,7 @@ describe("partnerInquirerCollectorProfile", () => {
               bio
               isActiveInquirer
               isActiveBidder
+              hasPartnerFollow
             }
           }
         }
@@ -57,6 +64,7 @@ describe("partnerInquirerCollectorProfile", () => {
             location: { city: "Around", country: "The Globe" },
             profession: "Superhuman",
             bio: "I got snacks to the roof",
+            hasPartnerFollow: true,
             isActiveInquirer: false,
             isActiveBidder: false,
           },

--- a/src/schema/v2/partner/partnerInquirerCollectorProfile.ts
+++ b/src/schema/v2/partner/partnerInquirerCollectorProfile.ts
@@ -1,4 +1,5 @@
 import {
+  GraphQLBoolean,
   GraphQLFieldConfig,
   GraphQLFieldConfigMap,
   GraphQLObjectType,
@@ -11,6 +12,11 @@ const InquirerCollectorProfileFields: GraphQLFieldConfigMap<
   ResolverContext
 > = {
   ...CollectorProfileFields,
+  hasPartnerFollow: {
+    type: GraphQLBoolean,
+    description: "The Collector follows the Gallery profile",
+    resolve: ({ follows_profile }) => follows_profile,
+  },
 }
 
 export const InquirerCollectorProfileType = new GraphQLObjectType<

--- a/src/schema/v2/partner/partnerInquiryRequest.ts
+++ b/src/schema/v2/partner/partnerInquiryRequest.ts
@@ -46,17 +46,22 @@ export const InquiryRequestType = new GraphQLObjectType<any, ResolverContext>({
     },
     collectorProfile: {
       type: InquirerCollectorProfileType,
-      resolve: (
-        { id: inquiryId, partnerId },
+      resolve: async (
+        { partnerId, inquirer },
         _args,
-        { partnerInquirerCollectorProfileLoader }
+        { partnerCollectorProfileLoader }
       ) => {
-        if (!partnerInquirerCollectorProfileLoader) return
+        if (!partnerCollectorProfileLoader) return
 
-        return partnerInquirerCollectorProfileLoader({
+        const data = await partnerCollectorProfileLoader({
           partnerId,
-          inquiryId,
+          userId: inquirer.id,
         })
+
+        return {
+          ...data.collector_profile,
+          follows_profile: data.follows_profile,
+        }
       },
     },
   }),


### PR DESCRIPTION
This PR unwires the old data loader `partner/${partnerId}/inquiry_request/${inquiryId}/collector_profile` in favor of the new `partner_collector_profile?partner_id=${partnerId}&user_id=${userId}` data loader.
We also expose the new field `hasPartnerFollow`.