### PR TITLE
chore: support page/size for arbitrary paging in alert connections

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1400,6 +1400,8 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     before: String
     first: Int
     last: Int
+    page: Int
+    size: Int
     sort: String
   ): AlertConnection
   alternateNames: [String]
@@ -13702,7 +13704,9 @@ type Partner implements Node {
     before: String
     first: Int
     last: Int
+    page: Int
     represented: Boolean
+    size: Int
   ): AlertsSummaryArtistConnection
 
   # A connection of all artists from a Partner.

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -113,6 +113,12 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
           sort: {
             type: GraphQLString,
           },
+          page: {
+            type: GraphQLInt,
+          },
+          size: {
+            type: GraphQLInt,
+          },
         }),
         type: AlertsConnectionType,
         resolve: async ({ _id }, args, { artistAlertsLoader }) => {

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -158,6 +158,12 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           activeInventory: {
             type: GraphQLBoolean,
           },
+          page: {
+            type: GraphQLInt,
+          },
+          size: {
+            type: GraphQLInt,
+          },
         }),
         resolve: async ({ _id }, args, { partnerAlertsSummaryLoader }) => {
           if (!partnerAlertsSummaryLoader) return null


### PR DESCRIPTION
Our standard pagination controls in the connection resolver already do the right thing (ie- prefer `page/size` if specified over connection arguments). This is needed, typically, to let a client UI arbitrarily load any URL of the form `?page=4` (so helps with deep-linking).