### PR TITLE
chore: Update gravity graphql schema to retire some fields off SearchCriteri…

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17115,7 +17115,6 @@ type SearchCriteria {
 
   # Human readable price range value
   formattedPriceRange: String
-  hasRecentlyEnabledUserSearchCriteria: Boolean!
   height: String
   highPriceAmount(
     decimal: String = "."
@@ -17147,17 +17146,11 @@ type SearchCriteria {
   materialsTerms: [String!]!
   offerable: Boolean
   partnerIDs: [String!]!
-  priceArray: [Float]
   priceRange: String
   sizes: [String!]!
 
   # Summary of the fields selected
   summary: JSON
-  totalUserSearchCriteriaCount: Int
-  totalWithAdditionalGeneIdsCount: Int
-  totalWithAttributionClassCount: Int
-  totalWithOtherMetadataCount: Int
-  totalWithPriceRangeCount: Int
   userAlertSettings: SavedSearchUserAlertSettings!
   userSearchCriteriaCount: Int!
   width: String

--- a/src/data/gravity.graphql
+++ b/src/data/gravity.graphql
@@ -2085,7 +2085,6 @@ type SearchCriteria {
   Human readable price range value
   """
   formattedPriceRange: String
-  hasRecentlyEnabledUserSearchCriteria: Boolean!
   height: String
   href: String!
   inquireableOnly: Boolean
@@ -2096,7 +2095,6 @@ type SearchCriteria {
   materialsTerms: [String!]!
   offerable: Boolean
   partnerIDs: [String!]!
-  priceArray: [Float]
   priceRange: String
   sizes: [String!]!
 
@@ -2104,11 +2102,6 @@ type SearchCriteria {
   Summary of the fields selected
   """
   summary: JSON
-  totalUserSearchCriteriaCount: Int
-  totalWithAdditionalGeneIdsCount: Int
-  totalWithAttributionClassCount: Int
-  totalWithOtherMetadataCount: Int
-  totalWithPriceRangeCount: Int
   userAlertSettings: SavedSearchUserAlertSettings!
   userSearchCriteriaCount: Int!
   width: String


### PR DESCRIPTION
…aType

Retiring some "partner" facing fields off of Gravity GraphQL Search criteria type: https://github.com/artsy/gravity/pull/17141

We have moved from stitching <> gravity graphQL to rest <> [gravity data loaders pattern](https://github.com/artsy/metaphysics/pull/5410/files#diff-70e0feb2c514e16a36a1bd6637730c639ce2000af9719951f9894504591e2444R507-R509
), to note these deleted fields are not used in the client anymore