### PR TITLE
chore: AMBER-361 - remove draft from visibility enum

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -20882,7 +20882,6 @@ input ViewingRoomSubsectionInput {
 }
 
 enum Visibility {
-  DRAFT
   LISTED
   UNLISTED
 }

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -459,7 +459,7 @@ describe("Artwork type", () => {
     it("returns valid visibility level", async () => {
       artwork = {
         ...artwork,
-        visibility_level: "draft",
+        visibility_level: "listed",
       }
 
       context = {
@@ -470,7 +470,7 @@ describe("Artwork type", () => {
 
       expect(data).toEqual({
         artwork: {
-          visibilityLevel: "DRAFT",
+          visibilityLevel: "LISTED",
         },
       })
     })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -241,7 +241,6 @@ const ArtworkPriceInsightsType = new GraphQLObjectType<any, ResolverContext>({
 export const VisibilityEnum = new GraphQLEnumType({
   name: "Visibility",
   values: {
-    DRAFT: { value: "draft" },
     UNLISTED: { value: "unlisted" },
     LISTED: { value: "listed" },
   },


### PR DESCRIPTION
Partially solves [AMBER-361]

This PR undoes some of the work done in a previous Metaphysics PR: https://github.com/artsy/metaphysics/pull/4412. This is because the `draft` `visibility_level` is being deprecated in Gravity. Moving forward, only the `published` attribute will be the deciding factor of whether an artwork is in draft form or not. `visibility` is only relevant to published works and details how accessible it is, whether it is indexed in Elasticsearch or externally etc.

There are currently no artworks with a visibility_level of `draft` at the moment, however this Gravity PR: https://github.com/artsy/gravity/pull/17175 should be merged first to ensure that it will no longer be possible to avoid any weird states. This PR is also blocked by the following Force PR: https://github.com/artsy/force/pull/13258

cc: @artsy/amber-devs 

[AMBER-361]: https://artsyproduct.atlassian.net/browse/AMBER-361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ