### PR TITLE
feat: add new NotificationItem schema

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -270,6 +270,7 @@ type Agreement {
 
 type Alert {
   additionalGeneNames: [String]
+  artists: [Artist!]!
   attributionClass: [String]
   formattedPriceRange: String
   hasRecentlyEnabledUserSearchCriteria: Boolean
@@ -306,6 +307,16 @@ type AlertEdge {
 
   # The item at the end of the edge
   node: Alert
+}
+
+type AlertNotificationItem {
+  alert: Alert
+  artworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
 }
 
 type AlertsCounts {
@@ -1193,6 +1204,16 @@ type ArticleEdge {
 
   # The item at the end of the edge
   node: Article
+}
+
+type ArticleFeaturedArtistNotificationItem {
+  article: Article
+  artistsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtistConnection
 }
 
 type ArticleFeatureSection {
@@ -2722,6 +2743,16 @@ type ArtworkPriceInsights {
   ): String
   medium: String
   sellThroughRate: Float
+}
+
+type ArtworkPublishedNotificationItem {
+  artists: [Artist!]!
+  artworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
 }
 
 # The results for one of the requested aggregations
@@ -13417,6 +13448,7 @@ type Notification implements Node {
   # A type-specific ID.
   internalID: ID!
   isUnread: Boolean!
+  item: NotificationItem
   message: String!
   notificationType: NotificationTypesEnum!
   objectsCount: Int!
@@ -13467,6 +13499,13 @@ type NotificationEdge {
   # The item at the end of the edge
   node: Notification
 }
+
+union NotificationItem =
+    AlertNotificationItem
+  | ArticleFeaturedArtistNotificationItem
+  | ArtworkPublishedNotificationItem
+  | ShowOpenedNotificationItem
+  | ViewingRoomPublishedNotificationItem
 
 type NotificationPreference {
   # email | push
@@ -17776,6 +17815,16 @@ type ShowFollowArtistEdge {
   node: ShowFollowArtist
 }
 
+type ShowOpenedNotificationItem {
+  partner: Partner
+  showsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ShowConnection
+}
+
 enum ShowSorts {
   END_AT_ASC
   END_AT_DESC
@@ -20813,6 +20862,19 @@ type ViewingRoomEdge {
 
 # A viewing room or errors object
 union ViewingRoomOrErrorsUnion = Errors | ViewingRoom
+
+type ViewingRoomPublishedNotificationItem {
+  partner: Partner
+
+  # The IDs of the viewing rooms, for use in stitching
+  viewingRoomIDs: [String]
+  viewingRoomsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ViewingRoomsConnection
+}
 
 # The connection type for ViewingRoom.
 type ViewingRoomsConnection {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -487,6 +487,7 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    meSearchCriteriaLoader: gravityLoader((id) => `me/search_criteria/${id}`),
     meShowsLoader: gravityLoader("me/shows", {}, { headers: true }),
     myCollectionArtworksLoader: gravityLoader(
       "collection/my-collection/artworks",

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -203,6 +203,10 @@ export const gravityStitchingEnvironment = (
         exhibitionPeriod: String
       }
 
+      extend type ViewingRoomPublishedNotificationItem {
+        viewingRoomsConnection(first: Int, after: String, last: Int, before: String): ViewingRoomsConnection
+      }
+
       extend type Viewer {
         viewingRoomsConnection(first: Int, after: String, statuses: [ViewingRoomStatusEnum!], partnerID: ID): ViewingRoomsConnection
         marketingCollections(
@@ -1021,6 +1025,28 @@ export const gravityStitchingEnvironment = (
         `,
           resolve: ({ startAt: _startAt, endAt: _endAt }) =>
             dateRange(_startAt, _endAt, "UTC"),
+        },
+      },
+      ViewingRoomPublishedNotificationItem: {
+        viewingRoomsConnection: {
+          fragment: `
+            ... on ViewingRoomPublishedNotificationItem {
+              viewingRoomIDs
+            }
+          `,
+          resolve: ({ viewingRoomIDs: ids }, args, context, info) => {
+            return info.mergeInfo.delegateToSchema({
+              schema: gravitySchema,
+              operation: "query",
+              fieldName: "_unused_gravity_viewingRoomsConnection",
+              args: {
+                ...args,
+                ids,
+              },
+              context,
+              info,
+            })
+          },
         },
       },
       Viewer: {

--- a/src/schema/v2/notifications/Item/AlertNotificationItem.ts
+++ b/src/schema/v2/notifications/Item/AlertNotificationItem.ts
@@ -1,0 +1,47 @@
+import { GraphQLObjectType } from "graphql"
+import { connectionFromArray } from "graphql-relay"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { pageable } from "relay-cursor-paging"
+import { AlertType } from "schema/v2/alerts"
+import { artworkConnection } from "schema/v2/artwork"
+import { createPageCursors } from "schema/v2/fields/pagination"
+import { ResolverContext } from "types/graphql"
+
+export const AlertNotificationItemType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "AlertNotificationItem",
+  fields: {
+    alert: {
+      type: AlertType,
+      resolve: ({ actor_ids }, _args, { meSearchCriteriaLoader }) => {
+        if (!meSearchCriteriaLoader) {
+          throw new Error("You need to be signed in to perform this action")
+        }
+
+        if (!actor_ids) return null
+
+        const searchCriteriaID = actor_ids[0]
+
+        return meSearchCriteriaLoader(searchCriteriaID)
+      },
+    },
+
+    artworksConnection: {
+      type: artworkConnection.connectionType,
+      args: pageable(),
+      resolve: async ({ object_ids }, args, { artworksLoader }) => {
+        const { page, size } = convertConnectionArgsToGravityArgs(args)
+        const body = await artworksLoader({ ids: object_ids })
+        const totalCount = body.length
+
+        return {
+          totalCount,
+          pageCursors: createPageCursors({ page, size }, totalCount),
+          ...connectionFromArray(body, args),
+        }
+      },
+    },
+  },
+})

--- a/src/schema/v2/notifications/Item/ArticleFeaturedArtistNotificationItem.ts
+++ b/src/schema/v2/notifications/Item/ArticleFeaturedArtistNotificationItem.ts
@@ -1,0 +1,46 @@
+import { GraphQLObjectType } from "graphql"
+import { connectionFromArray } from "graphql-relay"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { pageable } from "relay-cursor-paging"
+import { ArticleType } from "schema/v2/article"
+import { artistConnection } from "schema/v2/artist"
+import { createPageCursors } from "schema/v2/fields/pagination"
+import { ResolverContext } from "types/graphql"
+
+export const ArticleFeaturedArtistNotificationItemType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "ArticleFeaturedArtistNotificationItem",
+  fields: {
+    article: {
+      type: ArticleType,
+      resolve: ({ actor_ids }, _args, { articleLoader }) => {
+        if (!actor_ids) return null
+
+        const articleID = actor_ids[0]
+
+        return articleLoader(articleID)
+      },
+    },
+
+    artistsConnection: {
+      type: artistConnection.connectionType,
+      args: pageable(),
+      resolve: async ({ object_ids }, args, { artistsLoader }) => {
+        const { page, size } = convertConnectionArgsToGravityArgs(args)
+
+        const { body: artists } = await artistsLoader({
+          ids: object_ids,
+        })
+        const totalCount = artists.length
+
+        return {
+          totalCount,
+          pageCursors: createPageCursors({ page, size }, totalCount),
+          ...connectionFromArray(artists, args),
+        }
+      },
+    },
+  },
+})

--- a/src/schema/v2/notifications/Item/ArtworkPublishedNotificationItem.ts
+++ b/src/schema/v2/notifications/Item/ArtworkPublishedNotificationItem.ts
@@ -1,0 +1,42 @@
+import { GraphQLObjectType, GraphQLNonNull, GraphQLList } from "graphql"
+import { connectionFromArray } from "graphql-relay"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { pageable } from "relay-cursor-paging"
+import { ArtistType } from "schema/v2/artist"
+import { artworkConnection } from "schema/v2/artwork"
+import { createPageCursors } from "schema/v2/fields/pagination"
+import { ResolverContext } from "types/graphql"
+
+export const ArtworkPublishedNotificationItemType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "ArtworkPublishedNotificationItem",
+  fields: {
+    artists: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ArtistType))),
+      resolve: async ({ actor_ids }, _args, { artistsLoader }) => {
+        if (!actor_ids) return []
+
+        const { body } = await artistsLoader({ ids: actor_ids })
+        return body ?? []
+      },
+    },
+
+    artworksConnection: {
+      type: artworkConnection.connectionType,
+      args: pageable(),
+      resolve: async ({ object_ids }, args, { artworksLoader }) => {
+        const { page, size } = convertConnectionArgsToGravityArgs(args)
+        const body = await artworksLoader({ ids: object_ids })
+        const totalCount = body.length
+
+        return {
+          totalCount,
+          pageCursors: createPageCursors({ page, size }, totalCount),
+          ...connectionFromArray(body, args),
+        }
+      },
+    },
+  },
+})

--- a/src/schema/v2/notifications/Item/ShowOpenedNotificationItem.ts
+++ b/src/schema/v2/notifications/Item/ShowOpenedNotificationItem.ts
@@ -1,0 +1,46 @@
+import { GraphQLObjectType } from "graphql"
+import { connectionFromArray } from "graphql-relay"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { pageable } from "relay-cursor-paging"
+import { createPageCursors } from "schema/v2/fields/pagination"
+import { PartnerType } from "schema/v2/partner/partner"
+import { ShowsConnection } from "schema/v2/show"
+import { ResolverContext } from "types/graphql"
+
+export const ShowOpenedNotificationItemType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "ShowOpenedNotificationItem",
+  fields: {
+    partner: {
+      type: PartnerType,
+      resolve: ({ actor_ids }, _args, { partnerLoader }) => {
+        if (!actor_ids) return null
+
+        const partnerID = actor_ids[0]
+
+        return partnerLoader(partnerID)
+      },
+    },
+
+    showsConnection: {
+      type: ShowsConnection.connectionType,
+      args: pageable(),
+      resolve: async ({ object_ids }, args, { showsLoader }) => {
+        const { page, size } = convertConnectionArgsToGravityArgs(args)
+
+        const shows = await showsLoader({
+          id: object_ids,
+        })
+        const totalCount = shows.length
+
+        return {
+          totalCount,
+          pageCursors: createPageCursors({ page, size }, totalCount),
+          ...connectionFromArray(shows, args),
+        }
+      },
+    },
+  },
+})

--- a/src/schema/v2/notifications/Item/ViewingRoomPublishedNotificationItem.ts
+++ b/src/schema/v2/notifications/Item/ViewingRoomPublishedNotificationItem.ts
@@ -1,0 +1,31 @@
+import { GraphQLList, GraphQLObjectType, GraphQLString } from "graphql"
+import { PartnerType } from "schema/v2/partner/partner"
+import { ResolverContext } from "types/graphql"
+
+// Additionally, there is a `viewingRoomsConnection` field that is stitched in.
+export const ViewingRoomPublishedNotificationItemType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "ViewingRoomPublishedNotificationItem",
+  fields: {
+    partner: {
+      type: PartnerType,
+      resolve: ({ actor_ids }, _args, { partnerLoader }) => {
+        if (!actor_ids) return null
+
+        const partnerID = actor_ids[0]
+
+        return partnerLoader(partnerID)
+      },
+    },
+
+    viewingRoomIDs: {
+      type: new GraphQLList(GraphQLString),
+      description: "The IDs of the viewing rooms, for use in stitching",
+      resolve: ({ object_ids }) => {
+        return object_ids
+      },
+    },
+  },
+})

--- a/src/schema/v2/notifications/Item/__tests__/index.test.ts
+++ b/src/schema/v2/notifications/Item/__tests__/index.test.ts
@@ -1,0 +1,417 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("NotificationItem", () => {
+  const notificationPayload = {
+    id: "user-notification-id",
+    actor_ids: ["actor-id"],
+    object_ids: ["object-id1"],
+  }
+  let meNotificationLoader
+
+  const meLoader = jest.fn(() => Promise.resolve({ id: "user-id" }))
+
+  afterEach(() => {
+    meLoader.mockClear()
+    meNotificationLoader.mockClear()
+  })
+
+  describe('for "ArtworkPublishedNotificationItem"', () => {
+    const artistsLoader = jest.fn(() =>
+      Promise.resolve({
+        body: [
+          {
+            id: "artist-id",
+            name: "Catty Artist",
+          },
+        ],
+      })
+    )
+    const artworksLoader = jest.fn(() =>
+      Promise.resolve([
+        {
+          id: "artwork-id",
+          title: "Catty Artwork",
+        },
+      ])
+    )
+
+    beforeEach(() => {
+      meNotificationLoader = jest.fn(() =>
+        Promise.resolve({
+          ...notificationPayload,
+          activity_type: "ArtworkPublishedActivity",
+        })
+      )
+    })
+
+    it("returns data", async () => {
+      const query = gql`
+        {
+          me {
+            notification(id: "user-notification-id") {
+              item {
+                __typename
+                ... on ArtworkPublishedNotificationItem {
+                  artists {
+                    name
+                  }
+                  artworksConnection(first: 5) {
+                    edges {
+                      node {
+                        title
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const data = await runAuthenticatedQuery(query, {
+        meNotificationLoader,
+        meLoader,
+        artistsLoader,
+        artworksLoader,
+      })
+
+      expect(data).toMatchInlineSnapshot(`
+        Object {
+          "me": Object {
+            "notification": Object {
+              "item": Object {
+                "__typename": "ArtworkPublishedNotificationItem",
+                "artists": Array [
+                  Object {
+                    "name": "Catty Artist",
+                  },
+                ],
+                "artworksConnection": Object {
+                  "edges": Array [
+                    Object {
+                      "node": Object {
+                        "title": "Catty Artwork",
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }
+      `)
+    })
+  })
+
+  describe('for "AlertNotificationItem"', () => {
+    const meSearchCriteriaLoader = jest.fn(() =>
+      Promise.resolve({
+        id: "search-criteria-id",
+      })
+    )
+    const artworksLoader = jest.fn(() =>
+      Promise.resolve([
+        {
+          id: "artwork-id",
+          title: "Catty Artwork",
+        },
+      ])
+    )
+
+    beforeEach(() => {
+      meNotificationLoader = jest.fn(() =>
+        Promise.resolve({
+          ...notificationPayload,
+          activity_type: "SavedSearchHitActivity",
+        })
+      )
+    })
+
+    it("returns data", async () => {
+      const query = gql`
+        {
+          me {
+            notification(id: "user-notification-id") {
+              item {
+                __typename
+                ... on AlertNotificationItem {
+                  alert {
+                    internalID
+                  }
+                  artworksConnection(first: 5) {
+                    edges {
+                      node {
+                        title
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const data = await runAuthenticatedQuery(query, {
+        meNotificationLoader,
+        meLoader,
+        meSearchCriteriaLoader,
+        artworksLoader,
+      })
+
+      expect(data).toMatchInlineSnapshot(`
+        Object {
+          "me": Object {
+            "notification": Object {
+              "item": Object {
+                "__typename": "AlertNotificationItem",
+                "alert": Object {
+                  "internalID": "search-criteria-id",
+                },
+                "artworksConnection": Object {
+                  "edges": Array [
+                    Object {
+                      "node": Object {
+                        "title": "Catty Artwork",
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }
+      `)
+    })
+  })
+
+  describe('for "ArticleFeaturedArtistNotificationItem"', () => {
+    const articleLoader = jest.fn(() =>
+      Promise.resolve({
+        id: "article-id",
+      })
+    )
+    const artistsLoader = jest.fn(() =>
+      Promise.resolve({
+        body: [
+          {
+            id: "artist-id",
+            name: "Catty Artist",
+          },
+        ],
+      })
+    )
+
+    beforeEach(() => {
+      meNotificationLoader = jest.fn(() =>
+        Promise.resolve({
+          ...notificationPayload,
+          activity_type: "ArticleFeaturedArtistActivity",
+        })
+      )
+    })
+
+    it("returns data", async () => {
+      const query = gql`
+        {
+          me {
+            notification(id: "user-notification-id") {
+              item {
+                __typename
+                ... on ArticleFeaturedArtistNotificationItem {
+                  article {
+                    internalID
+                  }
+                  artistsConnection(first: 5) {
+                    edges {
+                      node {
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const data = await runAuthenticatedQuery(query, {
+        meNotificationLoader,
+        meLoader,
+        articleLoader,
+        artistsLoader,
+      })
+
+      expect(data).toMatchInlineSnapshot(`
+        Object {
+          "me": Object {
+            "notification": Object {
+              "item": Object {
+                "__typename": "ArticleFeaturedArtistNotificationItem",
+                "article": Object {
+                  "internalID": "article-id",
+                },
+                "artistsConnection": Object {
+                  "edges": Array [
+                    Object {
+                      "node": Object {
+                        "name": "Catty Artist",
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }
+      `)
+    })
+  })
+
+  describe('for "ShowOpenedNotificationItem"', () => {
+    const partnerLoader = jest.fn(() =>
+      Promise.resolve({
+        _id: "partner-id",
+      })
+    )
+    const showsLoader = jest.fn(() =>
+      Promise.resolve([
+        {
+          id: "artist-id",
+          name: "Catty Artist",
+        },
+      ])
+    )
+
+    beforeEach(() => {
+      meNotificationLoader = jest.fn(() =>
+        Promise.resolve({
+          ...notificationPayload,
+          activity_type: "PartnerShowOpenedActivity",
+        })
+      )
+    })
+
+    it("returns data", async () => {
+      const query = gql`
+        {
+          me {
+            notification(id: "user-notification-id") {
+              item {
+                __typename
+                ... on ShowOpenedNotificationItem {
+                  partner {
+                    internalID
+                  }
+                  showsConnection(first: 5) {
+                    edges {
+                      node {
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const data = await runAuthenticatedQuery(query, {
+        meNotificationLoader,
+        meLoader,
+        partnerLoader,
+        showsLoader,
+      })
+
+      expect(data).toMatchInlineSnapshot(`
+        Object {
+          "me": Object {
+            "notification": Object {
+              "item": Object {
+                "__typename": "ShowOpenedNotificationItem",
+                "partner": Object {
+                  "internalID": "partner-id",
+                },
+                "showsConnection": Object {
+                  "edges": Array [
+                    Object {
+                      "node": Object {
+                        "name": "Catty Artist",
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }
+      `)
+    })
+  })
+
+  describe('for "ViewingRoomPublishedNotificationItem"', () => {
+    const partnerLoader = jest.fn(() =>
+      Promise.resolve({
+        _id: "partner-id",
+      })
+    )
+
+    beforeEach(() => {
+      meNotificationLoader = jest.fn(() =>
+        Promise.resolve({
+          ...notificationPayload,
+          activity_type: "ViewingRoomPublishedActivity",
+          object_ids: ["viewing-room-id"],
+        })
+      )
+    })
+
+    it("returns data", async () => {
+      const query = gql`
+        {
+          me {
+            notification(id: "user-notification-id") {
+              item {
+                __typename
+                ... on ViewingRoomPublishedNotificationItem {
+                  partner {
+                    internalID
+                  }
+                  viewingRoomIDs
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const data = await runAuthenticatedQuery(query, {
+        meNotificationLoader,
+        meLoader,
+        partnerLoader,
+      })
+
+      expect(data).toMatchInlineSnapshot(`
+        Object {
+          "me": Object {
+            "notification": Object {
+              "item": Object {
+                "__typename": "ViewingRoomPublishedNotificationItem",
+                "partner": Object {
+                  "internalID": "partner-id",
+                },
+                "viewingRoomIDs": Array [
+                  "viewing-room-id",
+                ],
+              },
+            },
+          },
+        }
+      `)
+    })
+  })
+})

--- a/src/schema/v2/notifications/Item/index.ts
+++ b/src/schema/v2/notifications/Item/index.ts
@@ -1,0 +1,33 @@
+import { GraphQLUnionType } from "graphql"
+import { AlertNotificationItemType } from "./AlertNotificationItem"
+import { ArticleFeaturedArtistNotificationItemType } from "./ArticleFeaturedArtistNotificationItem"
+import { ArtworkPublishedNotificationItemType } from "./ArtworkPublishedNotificationItem"
+import { ShowOpenedNotificationItemType } from "./ShowOpenedNotificationItem"
+import { ViewingRoomPublishedNotificationItemType } from "./ViewingRoomPublishedNotificationItem"
+
+export const NotificationItemType = new GraphQLUnionType({
+  name: "NotificationItem",
+  types: [
+    ArtworkPublishedNotificationItemType,
+    AlertNotificationItemType,
+    ArticleFeaturedArtistNotificationItemType,
+    ShowOpenedNotificationItemType,
+    ViewingRoomPublishedNotificationItemType,
+  ],
+  resolveType: ({ activity_type }) => {
+    switch (activity_type) {
+      case "SavedSearchHitActivity":
+        return AlertNotificationItemType
+      case "ArtworkPublishedActivity":
+        return ArtworkPublishedNotificationItemType
+      case "ArticleFeaturedArtistActivity":
+        return ArticleFeaturedArtistNotificationItemType
+      case "PartnerShowOpenedActivity":
+        return ShowOpenedNotificationItemType
+      case "ViewingRoomPublishedActivity":
+        return ViewingRoomPublishedNotificationItemType
+      default:
+        throw new Error("Unknown notification content type")
+    }
+  },
+})

--- a/src/schema/v2/notifications/index.ts
+++ b/src/schema/v2/notifications/index.ts
@@ -23,6 +23,7 @@ import numeral from "../fields/numeral"
 import { IDFields, NodeInterface } from "../object_identification"
 import moment from "moment-timezone"
 import { DEFAULT_TZ } from "lib/date"
+import { NotificationItemType } from "./Item"
 
 const NotificationTypesEnum = new GraphQLEnumType({
   name: "NotificationTypesEnum",
@@ -55,6 +56,10 @@ export const NotificationType = new GraphQLObjectType<any, ResolverContext>({
     createdAt: {
       ...date(({ date }) => date),
       deprecationReason: "Please use `publishedAt` instead",
+    },
+    item: {
+      type: NotificationItemType,
+      resolve: (notification) => notification,
     },
     publishedAt: {
       type: new GraphQLNonNull(GraphQLString),


### PR DESCRIPTION
## What to do with this PR

This implements (more or less, some naming tweaks) the suggested schema in the tech plan - https://www.notion.so/artsy/Schema-for-Single-Notification-Page-9716fa45eee245d5b6def139d8c3d407.

There's no specs (yet), and we should discuss the naming and things like that, so please comment here!

## What is this

This introduces the `content: NotificationContent` schema under the `Notification` schema brought up in the [tech plan](https://www.notion.so/artsy/Schema-for-Single-Notification-Page-9716fa45eee245d5b6def139d8c3d407).

It allows a richer schema for each notification type to be specified (using a union type), so we can more easily build out a 'single-notification-landing-page' experience.

For instance, when someone lands/clicks/taps on an individual notification based on a viewing room being published -> you can specify `viewingRoom` (and whatever else we may add that is needed) in the fragment to render that page. When someone lands on a notification based on artworks matching an alert -> you can specify `artworksConnection` and `alert` (and whatever else we may add) in the fragment. And so forth.

I think this sets up development of richer landing pages for individual notifications / richer feeds, by allowing specific fragments for specific notification types to be specified w/ a sensible schema that makes sense for that notification type.

Additionally, it provides a pattern for adding new notification types in the future ('private offer received').

### Screenshots

**Artworks Published by Followed Artists** 
![Screen Shot 2023-12-08 at 3 38 04 PM](https://github.com/artsy/metaphysics/assets/1457859/41bc44ec-6477-40f3-80a3-c13b82749d8c)

**Artworks Matching Alert**
![Screen Shot 2023-12-08 at 3 37 21 PM](https://github.com/artsy/metaphysics/assets/1457859/ca100d7c-9e15-44b8-87c9-9addf052b8c8)

**Artist Featured in Article**
![Screen Shot 2023-12-08 at 3 50 19 PM](https://github.com/artsy/metaphysics/assets/1457859/b9f01f84-6058-4271-990a-b471fef3367b)

**Show Opened**
![Screen Shot 2023-12-08 at 3 55 01 PM](https://github.com/artsy/metaphysics/assets/1457859/04282d4f-4c2a-480e-83b8-ff4d79c71b56)

**Viewing Room Published**
![Screen Shot 2023-12-08 at 4 05 50 PM](https://github.com/artsy/metaphysics/assets/1457859/f94e4fdd-cea8-45df-903d-8c2542174255)

### Sample query

As mentioned in the tech plan, the client UI will likely include a fragment that looks like:

``` graphql
fragment NotificationLandingPage_content on NotificationContent {
  __typename
  ...ArtworkPublished_content
  ...CustomAlert_content
  ...ArticleFeaturedArtist_content
  # and so on for other supported types
}
```

**Here's how the schema in this PR satisfies that (long but this is what we need for all types to be supported!) The below query works for all existing notifications:**

``` graphql
{
  me {
    notification(id:"...") {
      internalID
      publishedAt(format: "RELATIVE")
      objectsCount

      content {
        __typename

        ... on ViewingRoomPublishedNotificationContent {
          viewingRoom {
            title
            partner {
              name
            }
          }
        }
        
        ... on ShowOpenedNotificationContent {
          show {
            name
            partner {
              ... on Partner {
                name
              }
            }
          }
        }
        
        ... on ArticleFeaturedArtistNotificationContent {
          article {
            title
          }
          
          artists {
            name
          }
        }
        
        ... on AlertNotificationContent {
          alert {
            additionalGeneNames
            attributionClass
            artists {
              name
            }
          }
          
          artworksConnection(first: 4) {
            edges {
              node {
                title
              }
            }
          }
        }
        
        ... on ArtworkPublishedNotificationContent {
          artists {
            name
          }

          artworksConnection(first: 4) {
            edges {
              node {
                title
              }
            }
          }
        }
      }
    }
  }
}
```


