### PR TITLE
feat(EMI-1584): add page cursor info to partner artworks

### DIFF
--- a/src/schema/v2/partner/__tests__/partner.test.js
+++ b/src/schema/v2/partner/__tests__/partner.test.js
@@ -647,6 +647,40 @@ describe("Partner type", () => {
         })
       })
 
+      it("returns cursor info", async () => {
+        const query = gql`
+          {
+            partner(id: "bau-xi-gallery") {
+              artworksConnection(first: 3) {
+                totalCount
+                pageCursors {
+                  around {
+                    page
+                  }
+                }
+              }
+            }
+          }
+        `
+
+        const data = await runAuthenticatedQuery(query, context)
+
+        expect(data).toEqual({
+          partner: {
+            artworksConnection: {
+              totalCount: 3,
+              pageCursors: {
+                around: [
+                  {
+                    page: 1,
+                  },
+                ],
+              },
+            },
+          },
+        })
+      })
+
       describe("when shallow is false", () => {
         it("calls partnerArtworksAllLoader", async () => {
           const query = gql`

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -470,6 +470,10 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
 
               return {
                 totalCount,
+                pageCursors: createPageCursors(
+                  { ...args, page, size },
+                  totalCount
+                ),
                 ...connectionFromArraySlice(body, args, {
                   arrayLength: totalCount,
                   sliceStart: offset,


### PR DESCRIPTION
Related to [EMI-1584](https://artsyproduct.atlassian.net/browse/EMI-1584)

This adds cursor info to partner artworks to our partner artworks connection so we can paginate the new saved artworks table in Volt V2. 
