### PR TITLE
fix(alerts): change order of artist series suggestions

### DIFF
--- a/src/schema/v2/previewSavedSearch/__tests__/previewSavedSearch.test.ts
+++ b/src/schema/v2/previewSavedSearch/__tests__/previewSavedSearch.test.ts
@@ -495,18 +495,6 @@ describe("previewSavedSearch", () => {
 
       expect(previewSavedSearch.suggestedFilters).toEqual([
         {
-          displayValue: "Portraits",
-          field: "artistSeriesIDs",
-          name: "Artist Series",
-          value: "andy-warhol-portraits",
-        },
-        {
-          displayValue: "Lithographs",
-          field: "artistSeriesIDs",
-          name: "Artist Series",
-          value: "pablo-picasso-lithographs",
-        },
-        {
           displayValue: "Limited edition",
           field: "attributionClass",
           name: "Rarity",
@@ -523,6 +511,18 @@ describe("previewSavedSearch", () => {
           field: "additionalGeneIDs",
           name: "Medium",
           value: "photography",
+        },
+        {
+          displayValue: "Portraits",
+          field: "artistSeriesIDs",
+          name: "Artist Series",
+          value: "andy-warhol-portraits",
+        },
+        {
+          displayValue: "Lithographs",
+          field: "artistSeriesIDs",
+          name: "Artist Series",
+          value: "pablo-picasso-lithographs",
         },
       ])
     })
@@ -566,18 +566,6 @@ describe("previewSavedSearch", () => {
 
         expect(previewSavedSearch.suggestedFilters).toEqual([
           {
-            displayValue: "Companions",
-            field: "artistSeriesIDs",
-            name: "Artist Series",
-            value: "kaws-companions",
-          },
-          {
-            displayValue: "Toys",
-            field: "artistSeriesIDs",
-            name: "Artist Series",
-            value: "kaws-toys",
-          },
-          {
             displayValue: "Limited edition",
             field: "attributionClass",
             name: "Rarity",
@@ -594,6 +582,18 @@ describe("previewSavedSearch", () => {
             field: "additionalGeneIDs",
             name: "Medium",
             value: "photography",
+          },
+          {
+            displayValue: "Companions",
+            field: "artistSeriesIDs",
+            name: "Artist Series",
+            value: "kaws-companions",
+          },
+          {
+            displayValue: "Toys",
+            field: "artistSeriesIDs",
+            name: "Artist Series",
+            value: "kaws-toys",
           },
         ])
       })

--- a/src/schema/v2/previewSavedSearch/suggestedFilters.ts
+++ b/src/schema/v2/previewSavedSearch/suggestedFilters.ts
@@ -40,22 +40,6 @@ export const suggestedFilters: GraphQLFieldResolver<
 
   let artistSeriesOptions: SearchCriteriaLabel[] | null
 
-  if (source?.type === "Artwork") {
-    artistSeriesOptions = await getArtistSeriesSearchCriteriaLabelsFromArtwork(
-      source,
-      gravityGraphQLLoader
-    )
-  } else {
-    artistSeriesOptions = getArtistSeriesSearchCriteriaLabelsFromArtist(
-      aggregations["artist_series"],
-      MAX_SUGGESTIONS
-    )
-  }
-
-  if (artistSeriesOptions) {
-    suggestedFilters.push(...artistSeriesOptions)
-  }
-
   const rarityOptions = _.chain(
     getMostPopularOptions(aggregations["attribution_class"])
   )
@@ -75,6 +59,22 @@ export const suggestedFilters: GraphQLFieldResolver<
 
   if (mediumOptions.length) {
     suggestedFilters.push(...mediumOptions)
+  }
+
+  if (source?.type === "Artwork") {
+    artistSeriesOptions = await getArtistSeriesSearchCriteriaLabelsFromArtwork(
+      source,
+      gravityGraphQLLoader
+    )
+  } else {
+    artistSeriesOptions = getArtistSeriesSearchCriteriaLabelsFromArtist(
+      aggregations["artist_series"],
+      MAX_SUGGESTIONS
+    )
+  }
+
+  if (artistSeriesOptions) {
+    suggestedFilters.push(...artistSeriesOptions)
   }
 
   return suggestedFilters


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-604

Based on [this discussion](https://artsy.slack.com/archives/C05EQL4R5N0/p1702548068831999?thread_ts=1702492997.351529&cid=C05EQL4R5N0) we are moving the artist series suggestions to be presented after the rarity/medium suggestions.

|Before|After|
|---|---|
|![beforee](https://github.com/artsy/metaphysics/assets/140521/24814e05-7789-4627-9e17-94a74b136046)|![afterr](https://github.com/artsy/metaphysics/assets/140521/a99089b2-861b-436f-bae5-6234e5ad6824)|



