### PR TITLE
feat(EMI-1589): expose Artwork#price_listed field as Float

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2458,7 +2458,7 @@ type Artwork implements Node & Searchable & Sellable {
   priceCurrency: String
   priceIncludesTax: Boolean
   priceIncludesTaxDisplay: String
-  priceListed: Money
+  priceListed: Float
 
   # The price paid for the artwork in a user's 'my collection'
   pricePaid: Money

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2458,6 +2458,7 @@ type Artwork implements Node & Searchable & Sellable {
   priceCurrency: String
   priceIncludesTax: Boolean
   priceIncludesTaxDisplay: String
+  priceListed: Money
 
   # The price paid for the artwork in a user's 'my collection'
   pricePaid: Money

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -4269,4 +4269,26 @@ describe("Artwork type", () => {
       })
     })
   })
+
+  describe("#priceListed", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          priceListed{
+            display
+          }
+        }
+      }
+    `
+
+    it("returns artworks price_listed", () => {
+      artwork.price_listed = 123
+      artwork.price_currency = "USD"
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: { priceListed: { display: "US$123" } },
+        })
+      })
+    })
+  })
 })

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -4274,9 +4274,7 @@ describe("Artwork type", () => {
     const query = `
       {
         artwork(id: "richard-prince-untitled-portrait") {
-          priceListed{
-            display
-          }
+          priceListed
         }
       }
     `
@@ -4286,7 +4284,7 @@ describe("Artwork type", () => {
       artwork.price_currency = "USD"
       return runQuery(query, context).then((data) => {
         expect(data).toEqual({
-          artwork: { priceListed: { display: "US$123" } },
+          artwork: { priceListed: 123 },
         })
       })
     })

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -4281,7 +4281,6 @@ describe("Artwork type", () => {
 
     it("returns artworks price_listed", () => {
       artwork.price_listed = 123
-      artwork.price_currency = "USD"
       return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: { priceListed: 123 },

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1124,12 +1124,8 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       priceListed: {
-        type: Money,
-        resolve: ({ price_listed, price_currency }) => {
-          return {
-            display: priceDisplayText(price_listed * 100, price_currency, ""),
-          }
-        },
+        type: GraphQLFloat,
+        resolve: ({ price_listed }) => price_listed,
       },
       taxInfo: TaxInfo,
       artaShippingEnabled: {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1123,6 +1123,14 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           return price_includes_tax ? "VAT included in price" : null
         },
       },
+      priceListed: {
+        type: Money,
+        resolve: ({ price_listed, price_currency }) => {
+          return {
+            display: priceDisplayText(price_listed * 100, price_currency, ""),
+          }
+        },
+      },
       taxInfo: TaxInfo,
       artaShippingEnabled: {
         type: GraphQLBoolean,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/EMI-1589

When an Artwork has the price hidden, the `listPrice` field is not reliable, so we need to expose the actual `price_listed`.

This field will be used for discount calculations, so we need it as Float, for displaying the price, we already have `internalDisplayPrice` doing the formatting.

Example where the artwork has the price hidden:
```
{
  "node": {
    "internalDisplayPrice": "$123",
    "priceListed": 123,
    "listPrice": null
  }
}
```

Note: you may need to set `"shallow": false` for it to appear on certain endpoints.
