### PR TITLE
feat: add `alert` and `alertsConnection` under `Me`

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -269,24 +269,50 @@ type Agreement {
 }
 
 type Alert {
+  acquireable: Boolean
+  additionalGeneIDs: [String]
   additionalGeneNames: [String]
+  artistIDs: [String]
   artists: [Artist!]!
+  artistsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtistConnection!
+  artistSeriesIDs: [String]
+  atAuction: Boolean
   attributionClass: [String]
+  colors: [String]
+  dimensionRange: String
   formattedPriceRange: String
+  forSale: Boolean
   hasRecentlyEnabledUserSearchCriteria: Boolean
+  height: String
+  href: String
 
   # A globally unique ID.
   id: ID!
+  inquireableOnly: Boolean
 
   # A type-specific ID.
   internalID: ID!
+  keyword: String
 
   # Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity
   labels: [SearchCriteriaLabel]!
+  locationCities: [String]
+  majorPeriods: [String]
   materialsTerms: [String]
+  offerable: Boolean
+  partnerIDs: [String]
+  priceArray: [Int]
   priceRange: String
+  settings: AlertSettings
+  sizes: [String]
   summary: JSON
   totalUserSearchCriteriaCount: Int
+  width: String
 }
 
 # A connection to a list of items.
@@ -324,6 +350,19 @@ type AlertNotificationItem {
 
 type AlertsCounts {
   totalUserSearchCriteriaCount: Int
+}
+
+type AlertSettings {
+  details: String
+  email: Boolean
+  frequency: AlertSettingsFrequency
+  name: String
+  push: Boolean
+}
+
+enum AlertSettingsFrequency {
+  DAILY
+  INSTANT
 }
 
 input AlertSource {
@@ -11744,6 +11783,13 @@ type Me implements Node {
     first: Int
     last: Int
   ): UserAddressConnection
+  alert(id: String!): Alert
+  alertsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AlertConnection!
 
   # A connection of artist recommendations for the current user.
   artistRecommendations(

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -434,6 +434,8 @@ export default (accessToken, userID, opts) => {
     ),
     matchUsersLoader: gravityLoader("match/users", {}, { headers: true }),
     mergeArtistLoader: gravityLoader("artists/merge", {}, { method: "POST" }),
+    meAlertLoader: gravityLoader((id) => `me/alert/${id}`),
+    meAlertsLoader: gravityLoader("me/alerts", {}, { headers: true }),
     meBankAccountsLoader: gravityLoader(
       "me/bank_accounts",
       {},

--- a/src/schema/v2/alerts.ts
+++ b/src/schema/v2/alerts.ts
@@ -1,20 +1,66 @@
 import {
   GraphQLBoolean,
+  GraphQLEnumType,
   GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
 } from "graphql"
-import { connectionWithCursorInfo } from "schema/v2/fields/pagination"
+import {
+  connectionWithCursorInfo,
+  createPageCursors,
+  emptyConnection,
+} from "schema/v2/fields/pagination"
 import { ResolverContext } from "types/graphql"
 import { IDFields } from "./object_identification"
 import GraphQLJSON from "graphql-type-json"
-import { ArtistType } from "./artist"
 import {
   SearchCriteriaLabel,
   resolveSearchCriteriaLabels,
 } from "./previewSavedSearch/searchCriteriaLabel"
+import { ArtistType, artistConnection } from "./artist"
+import { pageable } from "relay-cursor-paging"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { connectionFromArray } from "graphql-relay"
+
+type GravityAlertSettingsJSON = {
+  name: string
+  email: boolean
+  push: boolean
+  details: string
+  frequency: string
+}
+
+const AlertSettingsType = new GraphQLObjectType<
+  GravityAlertSettingsJSON,
+  ResolverContext
+>({
+  name: "AlertSettings",
+  fields: {
+    name: {
+      type: GraphQLString,
+    },
+    email: {
+      type: GraphQLBoolean,
+    },
+    push: {
+      type: GraphQLBoolean,
+    },
+    details: {
+      type: GraphQLString,
+    },
+    frequency: {
+      type: new GraphQLEnumType({
+        name: "AlertSettingsFrequency",
+        values: {
+          DAILY: { value: "daily" },
+          INSTANT: { value: "instant" },
+        },
+      }),
+    },
+  },
+})
 
 type GravitySearchCriteriaJSON = {
   id: string
@@ -24,9 +70,20 @@ type GravitySearchCriteriaJSON = {
   attribution_class: string[]
   additional_gene_names: string[]
   summary: JSON
-  count_30d: number
-  count_7d: number
+  count_30d?: number // only present when data is returned from ElasticSearch
+  count_7d?: number // only present when data is returned from ElasticSearch
   artist_ids: string[]
+  artist_series_ids: string[]
+  partner_ids: string[]
+  location_cities: string[]
+  major_periods: string[]
+  additional_gene_ids: string[]
+  price_array: number[]
+  dimension_range: string
+  for_sale: boolean
+  inquireable_only: boolean
+  at_auction: boolean
+  offerable: boolean
 }
 
 export const AlertType = new GraphQLObjectType<
@@ -36,29 +93,12 @@ export const AlertType = new GraphQLObjectType<
   name: "Alert",
   fields: () => ({
     ...IDFields,
-    priceRange: {
-      type: GraphQLString,
-      resolve: ({ price_range }) => price_range,
-    },
-    formattedPriceRange: {
-      type: GraphQLString,
-      resolve: ({ formatted_price_range }) => formatted_price_range,
-    },
-    totalUserSearchCriteriaCount: {
-      type: GraphQLInt,
-      resolve: ({ count_30d }) => count_30d,
-    },
-    materialsTerms: {
-      type: new GraphQLList(GraphQLString),
-      resolve: ({ materials_terms }) => materials_terms,
-    },
-    attributionClass: {
-      type: new GraphQLList(GraphQLString),
-      resolve: ({ attribution_class }) => attribution_class,
-    },
-    hasRecentlyEnabledUserSearchCriteria: {
+    acquireable: {
       type: GraphQLBoolean,
-      resolve: ({ count_7d }) => count_7d > 0,
+    },
+    additionalGeneIDs: {
+      type: new GraphQLList(GraphQLString),
+      resolve: ({ additional_gene_ids }) => additional_gene_ids,
     },
     additionalGeneNames: {
       type: new GraphQLList(GraphQLString),
@@ -70,10 +110,9 @@ export const AlertType = new GraphQLObjectType<
       description:
         "Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity",
     },
-    // Summary is a generic/dynamic JSON object.
-    // TODO: This should probably be structured.
-    summary: {
-      type: GraphQLJSON,
+    artistIDs: {
+      type: new GraphQLList(GraphQLString),
+      resolve: ({ artist_ids }) => artist_ids,
     },
     artists: {
       type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ArtistType))),
@@ -83,6 +122,118 @@ export const AlertType = new GraphQLObjectType<
         const { body } = await artistsLoader({ ids: artist_ids })
         return body ?? []
       },
+    },
+    artistsConnection: {
+      type: new GraphQLNonNull(artistConnection.connectionType),
+      args: pageable(),
+      resolve: async ({ artist_ids }, args, { artistsLoader }) => {
+        if (!artist_ids || artist_ids.length === 0) return emptyConnection
+
+        const { page, size } = convertConnectionArgsToGravityArgs(args)
+        const { body } = await artistsLoader({ ids: artist_ids })
+
+        const totalCount = body.length
+        return {
+          totalCount,
+          pageCursors: createPageCursors({ page, size }, totalCount),
+          ...connectionFromArray(body, args),
+        }
+      },
+    },
+    artistSeriesIDs: {
+      type: new GraphQLList(GraphQLString),
+      resolve: ({ artist_series_ids }) => artist_series_ids,
+    },
+    atAuction: {
+      type: GraphQLBoolean,
+      resolve: ({ at_auction }) => at_auction,
+    },
+    attributionClass: {
+      type: new GraphQLList(GraphQLString),
+      resolve: ({ attribution_class }) => attribution_class,
+    },
+    colors: {
+      type: new GraphQLList(GraphQLString),
+    },
+    dimensionRange: {
+      type: GraphQLString,
+      resolve: ({ dimension_range }) => dimension_range,
+    },
+    forSale: {
+      type: GraphQLBoolean,
+      resolve: ({ for_sale }) => for_sale,
+    },
+    formattedPriceRange: {
+      type: GraphQLString,
+      resolve: ({ formatted_price_range }) => formatted_price_range,
+    },
+    height: {
+      type: GraphQLString,
+    },
+    href: {
+      type: GraphQLString,
+    },
+    inquireableOnly: {
+      type: GraphQLBoolean,
+      resolve: ({ inquireable_only }) => inquireable_only,
+    },
+    keyword: {
+      type: GraphQLString,
+    },
+    locationCities: {
+      type: new GraphQLList(GraphQLString),
+      resolve: ({ location_cities }) => location_cities,
+    },
+    majorPeriods: {
+      type: new GraphQLList(GraphQLString),
+      resolve: ({ major_periods }) => major_periods,
+    },
+    materialsTerms: {
+      type: new GraphQLList(GraphQLString),
+      resolve: ({ materials_terms }) => materials_terms,
+    },
+    offerable: {
+      type: GraphQLBoolean,
+    },
+    partnerIDs: {
+      type: new GraphQLList(GraphQLString),
+      resolve: ({ partner_ids }) => partner_ids,
+    },
+    priceArray: {
+      type: new GraphQLList(GraphQLInt),
+      resolve: ({ price_array }) => price_array,
+    },
+    priceRange: {
+      type: GraphQLString,
+      resolve: ({ price_range }) => price_range,
+    },
+    sizes: {
+      type: new GraphQLList(GraphQLString),
+    },
+    // Summary is a generic/dynamic JSON object.
+    // TODO: This should probably be structured.
+    summary: {
+      type: GraphQLJSON,
+    },
+    width: {
+      type: GraphQLString,
+    },
+    settings: {
+      type: AlertSettingsType,
+    },
+
+    // Below fields are injected in the JSON when the alert data is being returned
+    // from ElasticSearch - currently when queried from the following places:
+    //
+    // - `alertsConnection` under `Artist`
+    // - `alertsSummaryArtistsConnection` under `Partner`.
+    totalUserSearchCriteriaCount: {
+      type: GraphQLInt,
+      resolve: ({ count_30d }) => count_30d,
+    },
+    hasRecentlyEnabledUserSearchCriteria: {
+      type: GraphQLBoolean,
+      resolve: ({ count_7d }) => count_7d && count_7d > 0,
     },
   }),
 })

--- a/src/schema/v2/me/__tests__/index.test.ts
+++ b/src/schema/v2/me/__tests__/index.test.ts
@@ -387,4 +387,137 @@ describe("me/index", () => {
       })
     })
   })
+
+  describe("alertsConnection", () => {
+    const query = gql`
+      query {
+        me {
+          alertsConnection(first: 1) {
+            totalCount
+            edges {
+              node {
+                internalID
+                keyword
+                artistIDs
+                settings {
+                  email
+                  name
+                  frequency
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+
+    it("returns the alerts connection", async () => {
+      const meLoader = () => Promise.resolve({})
+      const meAlertsLoader = () =>
+        Promise.resolve({
+          body: [
+            {
+              id: "123",
+              search_criteria: {
+                keyword: "cats",
+                artist_ids: ["andy-warhol"],
+              },
+              frequency: "daily",
+              name: "My Alert",
+              email: true,
+            },
+          ],
+          headers: { "x-total-count": "1" },
+        })
+
+      const data = await runAuthenticatedQuery(query, {
+        meLoader,
+        meAlertsLoader,
+      })
+
+      expect(data).toMatchInlineSnapshot(`
+        Object {
+          "me": Object {
+            "alertsConnection": Object {
+              "edges": Array [
+                Object {
+                  "node": Object {
+                    "artistIDs": Array [
+                      "andy-warhol",
+                    ],
+                    "internalID": "123",
+                    "keyword": "cats",
+                    "settings": Object {
+                      "email": true,
+                      "frequency": "DAILY",
+                      "name": "My Alert",
+                    },
+                  },
+                },
+              ],
+              "totalCount": 1,
+            },
+          },
+        }
+      `)
+    })
+  })
+
+  describe("alert", () => {
+    const query = gql`
+      query {
+        me {
+          alert(id: "123") {
+            internalID
+            keyword
+            artistIDs
+            settings {
+              email
+              name
+              frequency
+            }
+          }
+        }
+      }
+    `
+
+    it("returns the alert", async () => {
+      const meLoader = () => Promise.resolve({})
+      const meAlertLoader = () =>
+        Promise.resolve({
+          id: "123",
+          search_criteria: {
+            keyword: "cats",
+            artist_ids: ["andy-warhol"],
+          },
+          frequency: "daily",
+          name: "My Alert",
+          email: true,
+        })
+
+      const data = await runAuthenticatedQuery(query, {
+        meLoader,
+        meAlertLoader,
+      })
+
+      expect(data).toMatchInlineSnapshot(`
+        Object {
+          "me": Object {
+            "alert": Object {
+              "artistIDs": Array [
+                "andy-warhol",
+              ],
+              "internalID": "123",
+              "keyword": "cats",
+              "settings": Object {
+                "email": true,
+                "frequency": "DAILY",
+                "name": "My Alert",
+              },
+            },
+          },
+        }
+      `)
+    })
+  })
 })


### PR DESCRIPTION
Opening this a tad early, still need to add some specs.

Looks like:

![Screen Shot 2024-01-04 at 5 14 25 PM](https://github.com/artsy/metaphysics/assets/1457859/e9803a0d-f453-41c3-9190-e042f3596043)

![Screen Shot 2024-01-04 at 4 41 41 PM](https://github.com/artsy/metaphysics/assets/1457859/2fb41823-dc13-44d0-af13-71fb2a27a92e)

This adds `alert` and `alertsConnection` under `Me` -> corresponding to the following currently being stitched in: https://github.com/artsy/metaphysics/blob/edc18163c18e5d83f3281987078da791318ba521/src/lib/stitching/gravity/v2/stitching.ts#L130-L131

This also adds `artistsConnection` to `Alert` -> corresponding to the following currently being stitched in: https://github.com/artsy/metaphysics/blob/edc18163c18e5d83f3281987078da791318ba521/src/lib/stitching/gravity/v2/stitching.ts#L160

Still to do:
  - Need to add the CRUD mutations. This _should_ be relatively straightforward.
  - Need to support the following fields on `Alert`, currently being stitched in to `SearchCriteria`: https://github.com/artsy/metaphysics/blob/edc18163c18e5d83f3281987078da791318ba521/src/lib/stitching/gravity/v2/stitching.ts#L169-L172
 
And I think that's it! That should be what's needed to fully duplicate the stitched-in 'Saved Search + SearchCriteria' schema, and so clients should be able to then be updated to use this new schema (which itself could be piecemeal but we'll see how that goes).