### PR TITLE
chore(push-schema): Update path name to volt

### DIFF
--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -76,7 +76,7 @@ async function main() {
       { repo: "forque" },
       { repo: "volt-v2" },
       { repo: "pulse", dest: "vendor/graphql/schema/metaphysics.json" },
-      { repo: "volt", dest: "vendor/graphql/schema/metaphysics.json" },
+      { repo: "volt", dest: "vendor/graphql/schema/schema.graphql" },
     ]
 
     const updatePromises = reposToUpdate.map((repo) => updateSchemaFile(repo))


### PR DESCRIPTION
This [Volt PR standardizes](https://github.com/artsy/volt/pull/7226) some of our graphql stack, and as such the name of the graphql file needs to be updated here. 