### PR TITLE
feat: add `displayName` to `Alert`

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -285,6 +285,9 @@ type Alert {
   attributionClass: [String]
   colors: [String]
   dimensionRange: String
+
+  # A suggestion for a name that describes a set of saved search criteria in a conventional format
+  displayName: String!
   formattedPriceRange: String
   forSale: Boolean
   hasRecentlyEnabledUserSearchCriteria: Boolean

--- a/src/schema/v2/Alerts/index.ts
+++ b/src/schema/v2/Alerts/index.ts
@@ -24,6 +24,7 @@ import { ArtistType, artistConnection } from "../artist"
 import { pageable } from "relay-cursor-paging"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { connectionFromArray } from "graphql-relay"
+import { generateDisplayName } from "../previewSavedSearch/generateDisplayName"
 
 type GravityAlertSettingsJSON = {
   name: string
@@ -189,12 +190,6 @@ export const AlertType = new GraphQLObjectType<
       type: new GraphQLList(GraphQLString),
       resolve: ({ additional_gene_names }) => additional_gene_names,
     },
-    labels: {
-      type: new GraphQLNonNull(new GraphQLList(SearchCriteriaLabel)),
-      resolve: resolveSearchCriteriaLabels,
-      description:
-        "Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity",
-    },
     artistIDs: {
       type: new GraphQLList(GraphQLString),
       resolve: ({ artist_ids }) => artist_ids,
@@ -244,6 +239,12 @@ export const AlertType = new GraphQLObjectType<
       type: GraphQLString,
       resolve: ({ dimension_range }) => dimension_range,
     },
+    displayName: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: generateDisplayName,
+      description:
+        "A suggestion for a name that describes a set of saved search criteria in a conventional format",
+    },
     forSale: {
       type: GraphQLBoolean,
       resolve: ({ for_sale }) => for_sale,
@@ -264,6 +265,12 @@ export const AlertType = new GraphQLObjectType<
     },
     keyword: {
       type: GraphQLString,
+    },
+    labels: {
+      type: new GraphQLNonNull(new GraphQLList(SearchCriteriaLabel)),
+      resolve: resolveSearchCriteriaLabels,
+      description:
+        "Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity",
     },
     locationCities: {
       type: new GraphQLList(GraphQLString),

--- a/src/schema/v2/me/__tests__/index.test.ts
+++ b/src/schema/v2/me/__tests__/index.test.ts
@@ -471,9 +471,9 @@ describe("me/index", () => {
             internalID
             keyword
             artistIDs
+            displayName
             settings {
               email
-              name
               frequency
             }
           }
@@ -489,15 +489,16 @@ describe("me/index", () => {
           search_criteria: {
             keyword: "cats",
             artist_ids: ["andy-warhol"],
+            price_range: "*-1000",
           },
           frequency: "daily",
-          name: "My Alert",
           email: true,
         })
 
       const data = await runAuthenticatedQuery(query, {
         meLoader,
         meAlertLoader,
+        artistLoader: () => Promise.resolve({ name: "Andy Warhol" }),
       })
 
       expect(data).toMatchInlineSnapshot(`
@@ -507,12 +508,12 @@ describe("me/index", () => {
               "artistIDs": Array [
                 "andy-warhol",
               ],
+              "displayName": "Andy Warhol — $0–$1,000",
               "internalID": "123",
               "keyword": "cats",
               "settings": Object {
                 "email": true,
                 "frequency": "DAILY",
-                "name": "My Alert",
               },
             },
           },

--- a/src/schema/v2/previewSavedSearch/generateDisplayName.ts
+++ b/src/schema/v2/previewSavedSearch/generateDisplayName.ts
@@ -6,6 +6,10 @@ import {
 export const generateDisplayName = async (parent, args, context, info) => {
   if (parent?.userAlertSettings?.name) return parent?.userAlertSettings?.name
 
+  // When being used from the non-stitched schema, the field is called `settings`
+  // instead of `userAlertSettings`
+  if (parent?.settings?.name) return parent.settings.name
+
   const labels = await resolveSearchCriteriaLabels(parent, args, context, info)
 
   // artist always


### PR DESCRIPTION
Was just starting to poke around in Force using the new non-stitched `Alert` schema, and quickly saw that we needed to add `displayName` - currently being stitched-in under `SearchCriteria`.

This winds up benefiting from the camel-casing @olerichter00 added in https://github.com/artsy/metaphysics/pull/5489 for the labels, as the `displayName` is essentially just the labels, properly 'sentence-ified'.