### PR TITLE
feat: allow clients to query an artwork's last partner offer (EMI-1617)

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2678,6 +2678,7 @@ type ArtworkEdge implements ArtworkEdgeInterface {
     last: Int
     page: Int
     size: Int
+    sort: PartnerOfferSorts
   ): PartnerOfferConnection
 }
 
@@ -14584,6 +14585,13 @@ type PartnerOfferEdge {
 
   # The item at the end of the edge
   node: PartnerOffer
+}
+
+enum PartnerOfferSorts {
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  END_AT_ASC
+  END_AT_DESC
 }
 
 type PartnerOfferCreatedNotificationItem {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2475,9 +2475,6 @@ type Artwork implements Node & Searchable & Sellable {
   isShareable: Boolean
   isSold: Boolean
   isUnique: Boolean
-
-  # Metadata of the last partner offer sent for this artwork
-  lastPartnerOffer: PartnerOffer
   layer(id: String): ArtworkLayer
   layers: [ArtworkLayer]
   listPrice: ListPrice
@@ -14578,22 +14575,6 @@ type PartnerOfferConnection {
   totalCount: Int
 }
 
-# An edge in a connection.
-type PartnerOfferEdge {
-  # A cursor for use in pagination
-  cursor: String!
-
-  # The item at the end of the edge
-  node: PartnerOffer
-}
-
-enum PartnerOfferSorts {
-  CREATED_AT_ASC
-  CREATED_AT_DESC
-  END_AT_ASC
-  END_AT_DESC
-}
-
 type PartnerOfferCreatedNotificationItem {
   artworksConnection(
     after: String
@@ -14609,6 +14590,22 @@ type PartnerOfferCreatedNotificationItem {
     # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String
+}
+
+# An edge in a connection.
+type PartnerOfferEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: PartnerOffer
+}
+
+enum PartnerOfferSorts {
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  END_AT_ASC
+  END_AT_DESC
 }
 
 enum PartnersAggregation {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2509,6 +2509,15 @@ type Artwork implements Node & Searchable & Sellable {
     # Use whatever is in the original response instead of making a request
     shallow: Boolean
   ): Partner
+  partnerOfferConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    page: Int
+    size: Int
+    sort: PartnerOfferSorts
+  ): PartnerOfferConnection
   pickupAvailable: Boolean
   price: String
   priceCurrency: String
@@ -2671,15 +2680,6 @@ type ArtworkEdge implements ArtworkEdgeInterface {
 
   # The item at the end of the edge
   node: Artwork
-  partnerOfferConnection(
-    after: String
-    before: String
-    first: Int
-    last: Int
-    page: Int
-    size: Int
-    sort: PartnerOfferSorts
-  ): PartnerOfferConnection
 }
 
 interface ArtworkEdgeInterface {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2671,7 +2671,7 @@ type ArtworkEdge implements ArtworkEdgeInterface {
 
   # The item at the end of the edge
   node: Artwork
-  partnerOffers(
+  partnerOfferConnection(
     after: String
     before: String
     first: Int

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2475,6 +2475,9 @@ type Artwork implements Node & Searchable & Sellable {
   isShareable: Boolean
   isSold: Boolean
   isUnique: Boolean
+
+  # Metadata of the last partner offer sent for this artwork
+  lastPartnerOffer: PartnerOffer
   layer(id: String): ArtworkLayer
   layers: [ArtworkLayer]
   listPrice: ListPrice
@@ -2668,6 +2671,14 @@ type ArtworkEdge implements ArtworkEdgeInterface {
 
   # The item at the end of the edge
   node: Artwork
+  partnerOffers(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    page: Int
+    size: Int
+  ): PartnerOfferConnection
 }
 
 interface ArtworkEdgeInterface {
@@ -14553,6 +14564,26 @@ type PartnerOffer {
   internalID: ID!
   partnerId: String
   userIds: [String]
+}
+
+# A connection to a list of items.
+type PartnerOfferConnection {
+  # A list of edges.
+  edges: [PartnerOfferEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type PartnerOfferEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: PartnerOffer
 }
 
 type PartnerOfferCreatedNotificationItem {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2509,7 +2509,7 @@ type Artwork implements Node & Searchable & Sellable {
     # Use whatever is in the original response instead of making a request
     shallow: Boolean
   ): Partner
-  partnerOfferConnection(
+  partnerOffersConnection(
     after: String
     before: String
     first: Int

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -568,6 +568,7 @@ export default (accessToken, userID, opts) => {
       ({ partnerId, inquiryId }) =>
         `partner/${partnerId}/inquiry_request/${inquiryId}`
     ),
+    partnerOffersLoader: gravityLoader("partner_offers", {}, { headers: true }),
     partnerSearchArtistsLoader: gravityLoader(
       (id) => `/match/partner/${id}/artists`,
       {},

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1859,13 +1859,6 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           return artwork.recent_saves_count
         },
       },
-      lastPartnerOffer: {
-        description: "Metadata of the last partner offer sent for this artwork",
-        type: PartnerOfferType,
-        resolve: (artwork) => {
-          return artwork.last_partner_offer
-        },
-      },
     }
   },
 })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1914,7 +1914,7 @@ export const artworkConnection = connectionWithCursorInfo({
   connectionInterfaces: [ArtworkConnectionInterface],
   edgeInterfaces: [ArtworkEdgeInterface],
   edgeFields: {
-    partnerOffers: {
+    partnerOfferConnection: {
       type: connectionWithCursorInfo({
         nodeType: PartnerOfferType,
       }).connectionType,

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1889,6 +1889,26 @@ export const ArtworkConnectionInterface = new GraphQLInterfaceType({
   },
 })
 
+const PartnerOfferSorts = {
+  type: new GraphQLEnumType({
+    name: "PartnerOfferSorts",
+    values: {
+      CREATED_AT_ASC: {
+        value: "created_at",
+      },
+      CREATED_AT_DESC: {
+        value: "-created_at",
+      },
+      END_AT_ASC: {
+        value: "end_at",
+      },
+      END_AT_DESC: {
+        value: "-end_at",
+      },
+    },
+  }),
+}
+
 export const artworkConnection = connectionWithCursorInfo({
   nodeType: ArtworkType,
   connectionInterfaces: [ArtworkConnectionInterface],
@@ -1901,6 +1921,7 @@ export const artworkConnection = connectionWithCursorInfo({
       args: pageable({
         page: { type: GraphQLInt },
         size: { type: GraphQLInt },
+        sort: PartnerOfferSorts,
       }),
       resolve: async (root, args: CursorPageable, { partnerOffersLoader }) => {
         if (!partnerOffersLoader) return
@@ -1913,6 +1934,7 @@ export const artworkConnection = connectionWithCursorInfo({
           page,
           size,
           artwork_id: root.node._id,
+          sort: args.sort,
         })
 
         const totalCount = parseInt(headers["x-total-count"] || "0", 10)

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1088,7 +1088,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           return partnerLoader(partner.id).catch(() => null)
         },
       },
-      partnerOfferConnection: {
+      partnerOffersConnection: {
         type: connectionWithCursorInfo({
           nodeType: PartnerOfferType,
         }).connectionType,
@@ -1120,7 +1120,8 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           args: CursorPageable,
           { partnerOffersLoader }
         ) => {
-          if (!partnerOffersLoader) return
+          if (!partnerOffersLoader)
+            throw new Error("You need to be signed in to perform this action")
 
           const gravityArgs = convertConnectionArgsToGravityArgs(args)
           const { page, size, offset } = gravityArgs


### PR DESCRIPTION
This PR adds a new partner offers connection to the artworks connection edge. This will allow partners to query the partner offers that have been made on an artwork.