### PR TITLE
feat: add available to partner offer notifications

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14582,6 +14582,9 @@ type PartnerOfferCreatedNotificationItem {
     first: Int
     last: Int
   ): ArtworkConnection
+
+  # Whether or not the offer is still available
+  available: Boolean
   expiresAt(
     format: String
 

--- a/src/schema/v2/notifications/Item/PartnerOfferCreatedNotificationItem.ts
+++ b/src/schema/v2/notifications/Item/PartnerOfferCreatedNotificationItem.ts
@@ -1,4 +1,4 @@
-import { GraphQLObjectType } from "graphql"
+import { GraphQLBoolean, GraphQLObjectType } from "graphql"
 import { connectionFromArray } from "graphql-relay"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { pageable } from "relay-cursor-paging"
@@ -26,6 +26,17 @@ export const PartnerOfferCreatedNotificationItemType = new GraphQLObjectType<
           pageCursors: createPageCursors({ page, size }, totalCount),
           ...connectionFromArray(body, args),
         }
+      },
+    },
+    available: {
+      type: GraphQLBoolean,
+      description: "Whether or not the offer is still available",
+      resolve: async ({ actor_ids }, _, { mePartnerOfferLoader }) => {
+        if (!mePartnerOfferLoader) return null
+        if (actor_ids.length === 0) return null
+
+        const { available } = await mePartnerOfferLoader(actor_ids[0])
+        return available
       },
     },
     expiresAt: {

--- a/src/schema/v2/notifications/Item/__tests__/index.test.ts
+++ b/src/schema/v2/notifications/Item/__tests__/index.test.ts
@@ -448,6 +448,7 @@ describe("NotificationItem", () => {
       mePartnerOfferLoader = jest.fn(() =>
         Promise.resolve({
           id: "partner-offer-id",
+          available: true,
           end_at: "2024-01-08T10:10:10+10:00",
         })
       )
@@ -468,6 +469,7 @@ describe("NotificationItem", () => {
               item {
                 __typename
                 ... on PartnerOfferCreatedNotificationItem {
+                  available
                   expiresAt
 
                   artworksConnection(first: 5) {
@@ -506,6 +508,7 @@ describe("NotificationItem", () => {
                     },
                   ],
                 },
+                "available": true,
                 "expiresAt": "2024-01-08T10:10:10+10:00",
               },
             },


### PR DESCRIPTION
Adds `availability` field to partner offer based activity panel notifications. This is needed to support "No longer available message":

<img width="463" alt="Screenshot 2024-01-17 at 10 30 01" src="https://github.com/artsy/metaphysics/assets/3934579/f13f55e3-0909-4662-8828-4db5b41ad96e">
