### PR TITLE
feat(H13): Add blurhash field to Image type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11063,6 +11063,9 @@ type IdentityVerificationScanReference {
 
 type Image {
   aspectRatio: Float!
+
+  # Blurhash code for the image
+  blurhash: String
   caption: String
   cropped(
     height: Int!

--- a/src/schema/v2/image/index.ts
+++ b/src/schema/v2/image/index.ts
@@ -54,6 +54,10 @@ export const ImageType = new GraphQLObjectType<any, ResolverContext>({
         return aspect_ratio || 1
       },
     },
+    blurhash: {
+      type: GraphQLString,
+      description: "Blurhash code for the image",
+    },
     caption: {
       type: GraphQLString,
     },


### PR DESCRIPTION
> [!NOTE]
> This PR is part of [#hack13-blurhash](https://artsy.slack.com/archives/C06E4ND6EBV) 🔒

### Description
This PR adds the blurhash field into the Image type


### Example
Query:
```graphql
query() {
  artwork(id: "xyz") {
    image {
      blurhash
    }
  }
}
```

Result:
```json
{
  "data": {
    "artwork": {
      "image": {
        "blurhash": "xxxxx"
      }
    }
  }
}
```