### PR TITLE
Expose `dismissedAt` field from conversations

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7271,6 +7271,14 @@ type Conversation implements Node {
     # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String
+  dismissedAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See
+    # http://www.iana.org/time-zones,
+    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
 
   # The participant who initiated the conversation
   from: ConversationInitiator!

--- a/src/schema/v2/conversation/index.ts
+++ b/src/schema/v2/conversation/index.ts
@@ -357,6 +357,7 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
     buyerOutcomeAt: date,
     createdAt: date,
     deletedAt: date,
+    dismissedAt: date,
     fromLastViewedMessageID: {
       type: GraphQLString,
       resolve: ({ from_last_viewed_message_id }) => from_last_viewed_message_id,


### PR DESCRIPTION
By exposing this field, we can use it in Volt V2 to enable better management of dismissed inquiries by partners. We'll be able to show them inquiries that were dismissed by them in the past (this was possible before convos v2), but we can list those in a separate tab and allow them to "undo dismissal" if they wish (the same mutation used to dismiss inquiries can also be used to undo them).

Today it is not possible to undo dismissal. This is a common request from AEs on #product-bugs-and-feedback and engineers end up handling the update on rails console.