### PR TITLE
fix: preserve sorting when requesting non-shallow partner.artworkConnection properties

### DIFF
--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -467,6 +467,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             const artworkIds = body.map((artwork) => artwork._id)
             const gravityArtworkArgs = {
               artwork_id: artworkIds,
+              sort: args.sort,
             }
             const { body: artworks } = await partnerArtworksAllLoader(
               id,


### PR DESCRIPTION
This PR adds the incoming `sort` param to the `partner/:id/artworks/all` query when a query on Partner.artworksConnection includes `shallow: false`.
