### PR TITLE
[Draft]feat: Add subject to Notification

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13615,6 +13615,7 @@ type Notification implements Node {
     # pass `RELATIVE` to display the human-friendly date (e.g. "Today", "Yesterday", "5 days ago")
     format: String
   ): String!
+  subject: String!
   targetHref: String!
   title: String!
 }

--- a/src/schema/v2/notifications/Item/__tests__/index.test.ts
+++ b/src/schema/v2/notifications/Item/__tests__/index.test.ts
@@ -6,6 +6,7 @@ describe("NotificationItem", () => {
     id: "user-notification-id",
     actor_ids: ["actor-id"],
     object_ids: ["object-id1"],
+    objects_count: 1,
   }
   let meNotificationLoader
   let mePartnerOfferLoader = jest.fn()
@@ -43,6 +44,7 @@ describe("NotificationItem", () => {
         Promise.resolve({
           ...notificationPayload,
           activity_type: "ArtworkPublishedActivity",
+          actors: "Catty Artist",
         })
       )
     })
@@ -67,6 +69,7 @@ describe("NotificationItem", () => {
                   }
                 }
               }
+              subject
             }
           }
         }
@@ -100,6 +103,7 @@ describe("NotificationItem", () => {
                   ],
                 },
               },
+              "subject": "1 New Work by Catty Artist",
             },
           },
         }
@@ -128,6 +132,7 @@ describe("NotificationItem", () => {
         Promise.resolve({
           ...notificationPayload,
           activity_type: "SavedSearchHitActivity",
+          actors: "Work by Catty Artist",
         })
       )
     })
@@ -156,6 +161,7 @@ describe("NotificationItem", () => {
                   }
                 }
               }
+              subject
             }
           }
         }
@@ -199,6 +205,7 @@ describe("NotificationItem", () => {
                   ],
                 },
               },
+              "subject": "1 New Work by Catty Artist",
             },
           },
         }
@@ -252,6 +259,7 @@ describe("NotificationItem", () => {
                   }
                 }
               }
+              subject
             }
           }
         }
@@ -334,6 +342,7 @@ describe("NotificationItem", () => {
                   }
                 }
               }
+              subject
             }
           }
         }
@@ -403,6 +412,7 @@ describe("NotificationItem", () => {
                   viewingRoomIDs
                 }
               }
+              subject
             }
           }
         }
@@ -481,6 +491,7 @@ describe("NotificationItem", () => {
                   }
                 }
               }
+              subject
             }
           }
         }

--- a/src/schema/v2/notifications/index.ts
+++ b/src/schema/v2/notifications/index.ts
@@ -96,7 +96,11 @@ export const NotificationType = new GraphQLObjectType<any, ResolverContext>({
     },
     subject: {
       type: new GraphQLNonNull(GraphQLString),
-      resolve: async (notification, _args, { artworksLoader }) => {
+      resolve: async (
+        notification,
+        _args,
+        { articleLoader, artworksLoader }
+      ) => {
         switch (notification.activity_type) {
           case "ArtworkPublishedActivity":
             return `${notification.objects_count} New ${
@@ -105,7 +109,9 @@ export const NotificationType = new GraphQLObjectType<any, ResolverContext>({
           case "SavedSearchHitActivity":
             return `${notification.objects_count} New ${notification.actors}`
           case "ArticleFeaturedArtistActivity":
-            return notification.article?.title
+            const article = await articleLoader(notification.actor_ids?.[0])
+
+            return article?.title
           case "PartnerOfferCreatedActivity":
             // TODO: This is a hack to get the artwork's artist name. It's not good because we potentially request the artworks list twice without caching!
             const artworks = await artworksLoader({


### PR DESCRIPTION
Resolves [ONYX-657]

## Description

With the new Activity panel design, the title displayed for each notification type also changes. The new title is different from the existing fields `title` and `message`. I have named the new field `subject` for now because it matches the subject line of the emails we send for some of the notification types.

This is a draft for an implementation in Metaphysics, but probably Gravity would be a better place to generate and store the value 🤔 

<img width="394" alt="Screenshot 2024-01-22 at 09 57 28" src="https://github.com/artsy/metaphysics/assets/4691889/8554f10d-2bb7-4e74-887d-2f516d02ed2c">


[ONYX-657]: https://artsyproduct.atlassian.net/browse/ONYX-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ