### PR TITLE
chore: remove savedAtLeastOnce arg from partner.artworksConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13989,9 +13989,6 @@ type Partner implements Node {
     # Return artworks published less than x seconds ago.
     publishedWithin: Int
 
-    # Return artworks that were saved by collectors at least one time.
-    savedAtLeastOnce: Boolean
-
     # Only allowed for authorized admin/partner requests. When false fetch :all
     # properties on an artwork, when true or not present fetch artwork :short properties
     shallow: Boolean

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -110,11 +110,6 @@ const artworksArgs: GraphQLFieldConfigArgumentMap = {
     type: GraphQLInt,
     description: "Return artworks published less than x seconds ago.",
   },
-  savedAtLeastOnce: {
-    type: GraphQLBoolean,
-    description:
-      "Return artworks that were saved by collectors at least one time.",
-  },
   shallow: {
     type: GraphQLBoolean,
     description:
@@ -428,7 +423,6 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             page: number
             published?: boolean
             published_within?: number
-            saved_at_least_once?: boolean
             size: number
             sort: string
             total_count: boolean
@@ -442,7 +436,6 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             page,
             published: true,
             published_within: args.publishedWithin,
-            saved_at_least_once: args.savedAtLeastOnce,
             size,
             sort: args.sort,
             total_count: true,


### PR DESCRIPTION
Part of [EMI-1649]

This PR removes the deprecated `savedAtLeastOnce` argument from the `partner.artworksConnection` field. The only usage of this field was removed from [here](https://github.com/artsy/volt-v2/blame/b7ac9d15792ab44d8edd101f685c449efa3afb9d/src/pages/send-offers/components/SavedArtworksTable.tsx#L160) in artsy/volt-v2#117.

[EMI-1649]: https://artsyproduct.atlassian.net/browse/EMI-1649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ