### PR TITLE
feat: allow artwork 404s w/o @principalField to resolve

### DIFF
--- a/src/schema/v2/artwork/meta.ts
+++ b/src/schema/v2/artwork/meta.ts
@@ -19,7 +19,8 @@ export const artistNames = (artwork) =>
 const forSaleIndication = (artwork) =>
   artwork.forsale ? "Available for Sale" : undefined
 
-const dimensions = (artwork) => artwork.dimensions[artwork.metric]
+const dimensions = (artwork) =>
+  artwork.dimensions && artwork.dimensions[artwork.metric]
 
 const partnerDescription = ({ partner, forsale }, expanded = true) => {
   const name = partner && partner.name

--- a/src/types/graphql.d.ts
+++ b/src/types/graphql.d.ts
@@ -30,6 +30,8 @@ export interface ResolverContextValues {
 
   ipAddress: string
   xImpersonateUserID?: string
+
+  principalDirectivePath: string[] | undefined
 }
 
 export type ResolverContext = ResolverContextValues &


### PR DESCRIPTION
This update, I _think_ is the necessary/best way to allow Force (and mobile apps too, presumably), to support a more enhanced 404 artwork page.

The idea is:
  - when `@principalField` is used -> nothing changes. This is to keep that directive behaving as desired - namely, we wouldn't want to _stop_ reporting `errors` + the principal field `extensions` if the artwork indeed returned a 404. Since both Force and mobile apps today use `@principalField` when requesting the root `artwork` field, this PR should be safe to merge -> nothing should change to any clients.
  - however, when `@principalField` is not being used, artworks that are 404'ing will no longer return `errors` w/o any `artwork` information -> instead they will resolve as possible. Force will have an update that removes `@principalField` from the artwork app, in favor of an `ArtworkErrorApp` that can render a rich UI.

## Screenshots to illustrate the new behavior

The artwork in question below is unpublished. The sample query, `layers` -> is what allows the 'Similar For Sale Works', 'Similar Works at the same Fair', etc. to render (which seems like some nice info to show on the new 404 page).

With `@principalField`, same as before-
![Screen Shot 2024-01-23 at 4 43 00 PM](https://github.com/artsy/metaphysics/assets/1457859/7d0619cc-950a-48aa-9e50-3dfa83b1917a)

Without `@principalField`, we get some meaningful data-
![Screen Shot 2024-01-23 at 4 42 46 PM](https://github.com/artsy/metaphysics/assets/1457859/1965a9db-3c16-41d1-bea0-7a940d42ef8e)
