### PR TITLE
feat(EMI-1623): expose page arg for Partner#artworksConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13982,6 +13982,7 @@ type Partner implements Node {
 
     # Return artworks that are missing priority metadata
     missingPriorityMetadata: Boolean
+    page: Int
 
     # Only return artworks that are partner-offerable
     partnerOfferable: Boolean

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -116,6 +116,7 @@ const artworksArgs: GraphQLFieldConfigArgumentMap = {
       "Only allowed for authorized admin/partner requests. When false fetch :all properties on an artwork, when true or not present fetch artwork :short properties",
   },
   sort: ArtworkSorts,
+  page: { type: GraphQLInt },
 }
 
 export const PartnerType = new GraphQLObjectType<any, ResolverContext>({


### PR DESCRIPTION
Pagination of the CMS send offers table only works when navigating client-side (e.g. by clicking on the paginator), but does not work when visiting the URL with params directly (e.g. https://cms-staging.artsy.net/send-offers?page=12 ) or refreshing the page. It seems the page param was ignored and it always fetches the first page.

This will enable pagination using query string and allow volt-v2 to use url params to navigate to the page correctly.