### PR TITLE
feat: support blurhashDataURI for Image

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11083,6 +11083,7 @@ type Image {
 
   # Blurhash code for the image
   blurhash: String
+  blurhashDataURI(width: Int = 64): String
   caption: String
   cropped(
     height: Int!

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
     "apollo-link": "1.2.1",
     "apollo-link-context": "1.0.8",
     "apollo-link-http": "1.5.4",
+    "base64-arraybuffer": "^1.0.2",
     "basic-auth": "1.1.0",
+    "blurhash": "^2.0.5",
     "body-parser": "1.18.2",
     "chalk": "^4.1.2",
     "compression": "1.7.2",
@@ -94,6 +96,7 @@
     "relay-runtime": "10.0.1",
     "request": "2.88.2",
     "runtypes": "4.2.0",
+    "upng-js": "^2.1.0",
     "url-join": "4.0.0",
     "uuid": "3.1.0"
   },

--- a/src/schema/v2/image/__tests__/index.test.js
+++ b/src/schema/v2/image/__tests__/index.test.js
@@ -64,6 +64,24 @@ describe("Image type", () => {
     }
   })
 
+  describe("blurhashDataURI", () => {
+    it("returns a data URI for a given blurhash", () => {
+      const query = `{
+        artwork(id: "richard-prince-untitled-portrait") {
+          image {
+            blurhashDataURI
+          }
+        }
+      }`
+      assign(image, { blurhash: "LGHLe$4oIU-;_3%MbHRj~pIo%MM{" })
+      return runQuery(query, context).then((data) => {
+        expect(data.artwork.image.blurhashDataURI).toStartWith(
+          "data:image/png;base64,"
+        )
+      })
+    })
+  })
+
   describe("#aspect_ratio", () => {
     const query = `{
       artwork(id: "richard-prince-untitled-portrait") {

--- a/src/schema/v2/image/index.ts
+++ b/src/schema/v2/image/index.ts
@@ -16,6 +16,9 @@ import DeepZoom, { isZoomable } from "./deep_zoom"
 import { ImageData, normalize } from "./normalize"
 import ResizedUrl from "./resized"
 import VersionedUrl from "./versioned"
+import { decode as decodeBlurHash } from "blurhash"
+import UPNG from "upng-js"
+import { encode } from "base64-arraybuffer"
 
 export type OriginalImage = {
   original_width?: number
@@ -57,6 +60,30 @@ export const ImageType = new GraphQLObjectType<any, ResolverContext>({
     blurhash: {
       type: GraphQLString,
       description: "Blurhash code for the image",
+    },
+    blurhashDataURI: {
+      type: GraphQLString,
+      args: {
+        width: {
+          type: GraphQLInt,
+          defaultValue: 64,
+        },
+      },
+      resolve: ({ blurhash, aspect_ratio }, { width }) => {
+        if (!blurhash) return null
+
+        try {
+          const aspectRatio = aspect_ratio || 1
+          const height = Math.round(width / aspectRatio)
+          const pixels = decodeBlurHash(blurhash, width, height)
+          const png = UPNG.encode([pixels], width, height, 256)
+
+          return `data:image/png;base64,${encode(png)}`
+        } catch (error) {
+          console.error("[schema/v2/image/blurhashDataURI] Error:", error)
+          return null
+        }
+      },
     },
     caption: {
       type: GraphQLString,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2840,6 +2840,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-arraybuffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#1c37589a7c4b0746e34bd1feb951da2df01c1bdc"
+  integrity sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==
+
 base64-js@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
@@ -2903,6 +2908,11 @@ bindings@^1.5.0:
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
+
+blurhash@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/blurhash/-/blurhash-2.0.5.tgz#efde729fc14a2f03571a6aa91b49cba80d1abe4b"
+  integrity sha512-cRygWd7kGBQO3VEhPiTgq4Wc43ctsM+o46urrmPOiuAe+07fzlSB9OJVdpgDL0jPqXUVQ9ht7aq7kxOeJHRK+w==
 
 body-parser@1.18.2:
   version "1.18.2"
@@ -7577,7 +7587,7 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
   integrity sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==
 
-pako@^1.0.3:
+pako@^1.0.3, pako@^1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
@@ -9507,6 +9517,13 @@ upath@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
+
+upng-js@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/upng-js/-/upng-js-2.1.0.tgz#7176e73973db361ca95d0fa14f958385db6b9dd2"
+  integrity sha512-d3xzZzpMP64YkjP5pr8gNyvBt7dLk/uGI67EctzDuVp4lCZyVMo0aJO6l/VDlgbInJYDY6cnClLoBp29eKWI6g==
+  dependencies:
+    pako "^1.0.5"
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
This supports returning a `blurhashDataURI` for an image where a `blurhash` is available.

I'm not sure about the right parameters re: what kind of dimensions the blurred image should be - presumably we can have a 'small' blurred placeholder (like 64px wide as the default for instance), which will look acceptable when scaled 'up' in the artwork grid. But, for the artwork page we might want a larger placeholder blurred image, so left `width` as an argument.

We can probably iterate on those exact settings (esp if we wind up going with a Force review app or feature flag for the front-end expression of this).