### PR TITLE
chore(DIA-398): Expose inquiry requests count on collector profile

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4066,6 +4066,7 @@ type CollectorProfileType {
       reason: "identityVerified is going to be removed, use isIdentityVerified instead"
     )
   initials(length: Int = 3): String
+  inquiryRequestsCount: Int
   institutionalAffiliations: String
   intents: [String]
 
@@ -11207,6 +11208,7 @@ type InquirerCollectorProfile {
       reason: "identityVerified is going to be removed, use isIdentityVerified instead"
     )
   initials(length: Int = 3): String
+  inquiryRequestsCount: Int
   institutionalAffiliations: String
   intents: [String]
 
@@ -18652,6 +18654,7 @@ type UpdateCollectorProfilePayload {
       reason: "identityVerified is going to be removed, use isIdentityVerified instead"
     )
   initials(length: Int = 3): String
+  inquiryRequestsCount: Int
   institutionalAffiliations: String
   intents: [String]
 

--- a/src/schema/v2/CollectorProfile/collectorProfile.ts
+++ b/src/schema/v2/CollectorProfile/collectorProfile.ts
@@ -110,6 +110,11 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
     resolve: ({ artwork_inquiry_requests_count }) =>
       artwork_inquiry_requests_count >= 25,
   },
+  inquiryRequestsCount: {
+    type: GraphQLInt,
+    resolve: ({ artwork_inquiry_requests_count }) =>
+      artwork_inquiry_requests_count,
+  },
   isActiveBidder: {
     type: GraphQLBoolean,
     resolve: ({ previously_registered_for_auction }) =>


### PR DESCRIPTION
Resolves [DIA-398]

Exposes inquiry requests count on the collector profile.

[DIA-398]: https://artsyproduct.atlassian.net/browse/DIA-398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ