### PR TITLE
chore: rename blurhashDataURI to blurhashDataURL

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11096,7 +11096,7 @@ type Image {
 
   # Blurhash code for the image
   blurhash: String
-  blurhashDataURI(width: Int = 64): String
+  blurhashDataURL(width: Int = 64): String
   caption: String
   cropped(
     height: Int!

--- a/src/schema/v2/image/__tests__/index.test.js
+++ b/src/schema/v2/image/__tests__/index.test.js
@@ -64,18 +64,18 @@ describe("Image type", () => {
     }
   })
 
-  describe("blurhashDataURI", () => {
-    it("returns a data URI for a given blurhash", () => {
+  describe("blurhashDataURL", () => {
+    it("returns a data URL for a given blurhash", () => {
       const query = `{
         artwork(id: "richard-prince-untitled-portrait") {
           image {
-            blurhashDataURI
+            blurhashDataURL
           }
         }
       }`
       assign(image, { blurhash: "LGHLe$4oIU-;_3%MbHRj~pIo%MM{" })
       return runQuery(query, context).then((data) => {
-        expect(data.artwork.image.blurhashDataURI).toStartWith(
+        expect(data.artwork.image.blurhashDataURL).toStartWith(
           "data:image/png;base64,"
         )
       })

--- a/src/schema/v2/image/index.ts
+++ b/src/schema/v2/image/index.ts
@@ -61,7 +61,7 @@ export const ImageType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
       description: "Blurhash code for the image",
     },
-    blurhashDataURI: {
+    blurhashDataURL: {
       type: GraphQLString,
       args: {
         width: {


### PR DESCRIPTION
As pointed out by @anandaroop we should roll with 'url' naming!