### PR TITLE
feat: add artworkResult root field for first-class error handling

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2692,6 +2692,12 @@ interface ArtworkEdgeInterface {
   node: Artwork
 }
 
+# An error type, potentially containing a partial artwork response
+type ArtworkError {
+  artwork: PartialArtwork
+  requestError: RequestError
+}
+
 union ArtworkFigures = Image | Video
 
 union ArtworkFilterFacet = Gene | Tag
@@ -2839,6 +2845,8 @@ type ArtworkPublishedNotificationItem {
     last: Int
   ): ArtworkConnection
 }
+
+union ArtworkResult = Artwork | ArtworkError
 
 # The results for one of the requested aggregations
 type ArtworksAggregationResults {
@@ -13917,6 +13925,12 @@ type PageInfo {
   startCursor: String
 }
 
+# An artwork with partial data. useful for rendering an error state
+type PartialArtwork {
+  artists: [Artist]
+  layers: [ArtworkLayer]
+}
+
 type Partner implements Node {
   alertsSummaryArtistsConnection(
     activeInventory: Boolean
@@ -15399,6 +15413,12 @@ type Query {
   # List of all artwork mediums
   artworkMediums: [ArtworkMedium]
 
+  # An artwork result
+  artworkResult(
+    # The slug or ID of the artwork
+    id: String!
+  ): ArtworkResult
+
   # A list of Artworks
   artworks(
     after: String
@@ -16592,6 +16612,10 @@ input RequestCredentialsForAssetUploadInput {
 type RequestCredentialsForAssetUploadPayload {
   asset: Credentials
   clientMutationId: String
+}
+
+type RequestError {
+  statusCode: Int!
 }
 
 type RequestLocation {
@@ -20176,6 +20200,12 @@ type Viewer {
 
   # List of all artwork mediums
   artworkMediums: [ArtworkMedium]
+
+  # An artwork result
+  artworkResult(
+    # The slug or ID of the artwork
+    id: String!
+  ): ArtworkResult
 
   # A list of Artworks
   artworks(

--- a/src/schema/v2/artworkResult/__tests__/index.test.ts
+++ b/src/schema/v2/artworkResult/__tests__/index.test.ts
@@ -1,0 +1,120 @@
+import { HTTPError } from "lib/HTTPError"
+import { runQuery } from "schema/v2/test/utils"
+
+describe("Artwork type", () => {
+  describe("when throwing an error", () => {
+    const artwork = {
+      artist_ids: ["artist-id"],
+    }
+
+    const context = {
+      artworkLoader: () => {
+        throw new HTTPError(
+          "Artwork Not Found",
+          404,
+          JSON.stringify({ artwork })
+        )
+      },
+      artistLoader: () => Promise.resolve({ name: "Catty Artist" }),
+    }
+    const query = `
+      {
+        artworkResult(id: "richard-prince-untitled-portrait") {
+          ... on ArtworkError {
+            __typename
+            requestError {
+              statusCode
+            }
+            artwork {
+              artists {
+                name
+              }
+            }
+          }
+        }
+      }
+    `
+
+    it("returns the proper type", async () => {
+      const data = await runQuery(query, context)
+
+      expect(data).toMatchInlineSnapshot(`
+        Object {
+          "artworkResult": Object {
+            "__typename": "ArtworkError",
+            "artwork": Object {
+              "artists": Array [
+                Object {
+                  "name": "Catty Artist",
+                },
+              ],
+            },
+            "requestError": Object {
+              "statusCode": 404,
+            },
+          },
+        }
+      `)
+    })
+
+    it("resolves on an unknown error w/o a partial artwork response", async () => {
+      context.artworkLoader = () => {
+        throw new Error("Unknown Error")
+      }
+      const data = await runQuery(query, context)
+
+      expect(data).toMatchInlineSnapshot(`
+        Object {
+          "artworkResult": Object {
+            "__typename": "ArtworkError",
+            "artwork": null,
+            "requestError": Object {
+              "statusCode": 500,
+            },
+          },
+        }
+      `)
+    })
+  })
+
+  describe("without any errors", () => {
+    const artwork = {
+      published: true,
+      artists: [{ id: "artist-id" }],
+    }
+
+    const context = {
+      artworkLoader: () => Promise.resolve(artwork),
+      artistLoader: () => Promise.resolve({ name: "Catty Artist" }),
+    }
+    const query = `
+      {
+        artworkResult(id: "richard-prince-untitled-portrait") {
+          ... on Artwork {
+            __typename
+            artists {
+              name
+            }
+          }
+        }
+      }
+    `
+
+    it("returns the proper type", async () => {
+      const data = await runQuery(query, context)
+
+      expect(data).toMatchInlineSnapshot(`
+        Object {
+          "artworkResult": Object {
+            "__typename": "Artwork",
+            "artists": Array [
+              Object {
+                "name": "Catty Artist",
+              },
+            ],
+          },
+        }
+      `)
+    })
+  })
+})

--- a/src/schema/v2/artworkResult/index.ts
+++ b/src/schema/v2/artworkResult/index.ts
@@ -1,0 +1,99 @@
+import {
+  GraphQLFieldConfig,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import Artist from "schema/v2/artist"
+import { ResolverContext } from "types/graphql"
+import { ArtworkType, artworkResolver } from "schema/v2/artwork"
+import ArtworkLayers, { artworkLayers } from "schema/v2/artwork/layers"
+import { RequestErrorType } from "schema/v2/fields/requestError"
+
+const ArtworkErrorType = new GraphQLObjectType<any, ResolverContext>({
+  name: "ArtworkError",
+  description:
+    "An error type, potentially containing a partial artwork response",
+  fields: {
+    artwork: {
+      type: new GraphQLObjectType<any, ResolverContext>({
+        name: "PartialArtwork",
+        description:
+          "An artwork with partial data. useful for rendering an error state",
+        fields: {
+          artists: {
+            type: new GraphQLList(Artist.type),
+            resolve: ({ artist_ids }, _, { artistLoader }) => {
+              if (!artist_ids || !artist_ids.length) return []
+
+              return Promise.all(
+                artist_ids.map((artist_id) => artistLoader(artist_id))
+              ).catch(() => [])
+            },
+          },
+
+          layers: {
+            type: ArtworkLayers.type,
+            resolve: ({ id }, _options, { relatedLayersLoader }) =>
+              artworkLayers(id, relatedLayersLoader),
+          },
+        },
+      }),
+    },
+
+    requestError: {
+      type: RequestErrorType,
+    },
+  },
+})
+
+const ArtworkResultType = new GraphQLUnionType<any, ResolverContext>({
+  name: "ArtworkResult",
+  types: [ArtworkErrorType, ArtworkType],
+  resolveType: (artwork) => {
+    if (artwork?.published) {
+      return ArtworkType
+    }
+
+    return ArtworkErrorType
+  },
+})
+
+const artworkErrorResolver = ({ statusCode, body }) => {
+  const requestError = {
+    statusCode: statusCode ?? 500,
+  }
+
+  try {
+    const { artwork } = JSON.parse(body)
+
+    return {
+      requestError,
+      artwork,
+    }
+  } catch {
+    return {
+      requestError,
+    }
+  }
+}
+
+export const ArtworkResult: GraphQLFieldConfig<void, ResolverContext> = {
+  type: ArtworkResultType,
+  description: "An artwork result",
+  args: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The slug or ID of the artwork",
+    },
+  },
+  resolve: async (...args: Parameters<typeof artworkResolver>) => {
+    try {
+      return await artworkResolver(...args)
+    } catch (error) {
+      return artworkErrorResolver(error)
+    }
+  },
+}

--- a/src/schema/v2/fields/requestError.ts
+++ b/src/schema/v2/fields/requestError.ts
@@ -1,0 +1,11 @@
+import { GraphQLObjectType, GraphQLNonNull, GraphQLInt } from "graphql"
+import { ResolverContext } from "types/graphql"
+
+export const RequestErrorType = new GraphQLObjectType<any, ResolverContext>({
+  name: "RequestError",
+  fields: {
+    statusCode: {
+      type: new GraphQLNonNull(GraphQLInt),
+    },
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -215,6 +215,7 @@ import { createPartnerOfferMutation } from "./createPartnerOfferMutation"
 import { createAlertMutation } from "./Alerts/createAlertMutation"
 import { updateAlertMutation } from "./Alerts/updateAlertMutation"
 import { deleteAlertMutation } from "./Alerts/deleteAlertMutation"
+import { ArtworkResult } from "./artworkResult"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -254,6 +255,7 @@ const rootFields = {
   artwork: Artwork,
   artworkAttributionClasses: ArtworkAttributionClasses,
   artworkMediums: ArtworkMediums,
+  artworkResult: ArtworkResult,
   artworks: Artworks,
   artworksConnection: filterArtworksConnection(),
   artworksForUser,


### PR DESCRIPTION
This is an alternate approach to https://github.com/artsy/metaphysics/pull/5523 , and tbh I like this one a lot better.

This elevates our `orError` pattern (from mutations), to actual fields - better allowing us to handle errors in a first-class way, vs. trying to use the basic `errors` key in the GraphQL response, or custom `extensions`.

This way, the artwork page/screen query can start to look like:

``` graphql
artwork(id: "...") {
  ... on Artwork {
    ...ArtworkApp_artwork
  }

  ... on ArtworkError {
    ...ArtworkErrorApp_artworkError
  }
}
```

with a partial artwork schema being available in the error case (now that https://github.com/artsy/gravity/pull/17283 is merged).

Looks like - 

![Screen Shot 2024-01-26 at 2 04 51 PM](https://github.com/artsy/metaphysics/assets/1457859/a899a9c2-3085-4d8d-a546-9bc396277a29)

What do y'all think?
