### PR TITLE
feat: add buyerActivity to collectorResume

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4136,10 +4136,14 @@ type CollectorProfileTypeEdge {
 }
 
 type CollectorResume {
+  buyerActivity: CommerceBuyerActivity
   collectorProfile: CollectorProfileType!
 
   # The Collector follows the Gallery profile
   isCollectorFollowingPartner: Boolean!
+
+  # The Collector's id
+  userId: String!
 }
 
 # Represents either an action or a potential failure

--- a/src/lib/stitching/exchange/__tests__/stitching.test.ts
+++ b/src/lib/stitching/exchange/__tests__/stitching.test.ts
@@ -40,6 +40,15 @@ it("extends the Me object", async () => {
   expect(meFields).toContain("orders")
 })
 
+it("extends the CollectorResume", async () => {
+  const mergedSchema = await getExchangeMergedSchema()
+  const collectorResumeFields = await getFieldsForTypeFromSchema(
+    "CollectorResume",
+    mergedSchema
+  )
+  expect(collectorResumeFields).toContain("buyerActivity")
+})
+
 it("extends the Conversation type", async () => {
   const mergedSchema = await getExchangeMergedSchema()
   const conversationFields = await getFieldsForTypeFromSchema(

--- a/src/lib/stitching/exchange/v2/stitching.ts
+++ b/src/lib/stitching/exchange/v2/stitching.ts
@@ -331,6 +331,10 @@ export const exchangeStitchingEnvironment = ({
       orders(first: Int, last: Int, after: String, before: String, mode: CommerceOrderModeEnum, sellerId: String, sort: CommerceOrderConnectionSortEnum, states: [CommerceOrderStateEnum!]): CommerceOrderConnectionWithTotalCount
     }
 
+    extend type CollectorResume {
+      buyerActivity: CommerceBuyerActivity
+    }
+
     extend type Mutation {
       # Creates an order and links the conversation to it
       createInquiryOrder(
@@ -348,6 +352,29 @@ export const exchangeStitchingEnvironment = ({
 
     // Resolvers for the above
     resolvers: {
+      CollectorResume: {
+        buyerActivity: {
+          fragment: gql`
+            ... on CollectorResume {
+             userId
+            }
+          `,
+          resolve: async (parent, _args, context, info) => {
+            const exchangeArgs = {
+              buyerId: parent.userId,
+            }
+
+            return await info.mergeInfo.delegateToSchema({
+              schema: exchangeSchema,
+              operation: "query",
+              fieldName: "commerceBuyerActivity",
+              args: exchangeArgs,
+              context,
+              info,
+            })
+          },
+        },
+      },
       Conversation: {
         orderConnection: {
           fragment: gql`

--- a/src/schema/v2/conversation/collectorResume.ts
+++ b/src/schema/v2/conversation/collectorResume.ts
@@ -1,4 +1,9 @@
-import { GraphQLObjectType, GraphQLNonNull, GraphQLBoolean } from "graphql"
+import {
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLBoolean,
+} from "graphql"
 import { CollectorProfileType } from "schema/v2/CollectorProfile/collectorProfile"
 import { ResolverContext } from "types/graphql"
 
@@ -13,6 +18,11 @@ export const CollectorResume = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLNonNull(GraphQLBoolean),
       description: "The Collector follows the Gallery profile",
       resolve: ({ isCollectorFollowingPartner }) => isCollectorFollowingPartner,
+    },
+    userId: {
+      type: GraphQLNonNull(GraphQLString),
+      description: "The Collector's id",
+      resolve: ({ userId }) => userId,
     },
   }),
 })

--- a/src/schema/v2/conversation/index.ts
+++ b/src/schema/v2/conversation/index.ts
@@ -324,6 +324,7 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
           return {
             collectorProfile: data.collector_profile,
             isCollectorFollowingPartner: data.follows_profile,
+            userId: from_id,
           }
         } catch (error) {
           console.error(


### PR DESCRIPTION
This PR stitches the Exchange's buyerActivity to collectorResume.

![image](https://github.com/artsy/metaphysics/assets/1176374/c6214adf-7e33-4201-8969-972912355d46)

Follow-up to: 
- https://github.com/artsy/exchange/pull/1995 
- https://github.com/artsy/metaphysics/pull/5539

Ticket [DIA-368]

[DIA-368]: https://artsyproduct.atlassian.net/browse/DIA-368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ