### PR TITLE
fix(EMI-1623): force an empty return if there are no artwork IDs

### DIFF
--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -455,21 +455,14 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
 
           const { body, headers } = await partnerArtworksLoader(id, gravityArgs)
           const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+          const artworkIds = body.map((artwork) => artwork._id)
 
           // Only accept shallow = false argument if requesting user is authorized admin/partner
-          if (args.shallow === false && partnerArtworksAllLoader) {
-            const artworkIds = body.map((artwork) => artwork._id)
-            if (artworkIds.length === 0) {
-              return paginationResolver({
-                totalCount,
-                offset,
-                page,
-                size,
-                body: [],
-                args,
-              })
-            }
-
+          if (
+            args.shallow === false &&
+            artworkIds.length > 0 &&
+            partnerArtworksAllLoader
+          ) {
             const gravityArtworkArgs = {
               artwork_id: artworkIds,
               sort: args.sort,

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -459,10 +459,23 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           // Only accept shallow = false argument if requesting user is authorized admin/partner
           if (args.shallow === false && partnerArtworksAllLoader) {
             const artworkIds = body.map((artwork) => artwork._id)
+            if (artworkIds.length === 0) {
+              return paginationResolver({
+                totalCount,
+                offset,
+                page,
+                size,
+                body: [],
+                args,
+              })
+            }
+
             const gravityArtworkArgs = {
               artwork_id: artworkIds,
               sort: args.sort,
+              page: page,
             }
+
             const { body: artworks } = await partnerArtworksAllLoader(
               id,
               gravityArtworkArgs

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -466,7 +466,6 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             const gravityArtworkArgs = {
               artwork_id: artworkIds,
               sort: args.sort,
-              page: page,
             }
 
             const { body: artworks } = await partnerArtworksAllLoader(


### PR DESCRIPTION
While doing https://github.com/artsy/volt-v2/pull/1141, I noticed that if a page number that is 1 more than the maximum page number is given, it would still return some data when it should return an empty array.

I am not sure why this is happening but forcing a return when the `artworkIds` is empty solved the issue.

I've checked Gravity and it is returning the expected empty array, so there's is something wrong with Metaphysics pagination helpers.

Check slack thread for more context: https://artsy.slack.com/archives/CP9P4KR35/p1706528000848069
Relates to: https://github.com/artsy/volt-v2/pull/1141