### PR TITLE
feat(EMI-1618): return partner on createPartnerOfferMutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8018,7 +8018,6 @@ input createPartnerOfferMutationInput {
 
 type createPartnerOfferMutationPayload {
   clientMutationId: String
-  partner: Partner
 
   # On success: the partner offer created.
   partnerOfferOrError: createPartnerOfferResponseOrError
@@ -8029,6 +8028,7 @@ union createPartnerOfferResponseOrError =
   | createPartnerOfferSuccess
 
 type createPartnerOfferSuccess {
+  partner: Partner
   partnerOffer: PartnerOffer
 }
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8018,6 +8018,7 @@ input createPartnerOfferMutationInput {
 
 type createPartnerOfferMutationPayload {
   clientMutationId: String
+  partner: Partner
 
   # On success: the partner offer created.
   partnerOfferOrError: createPartnerOfferResponseOrError

--- a/src/schema/v2/__tests__/createPartnerOfferMutation.test.ts
+++ b/src/schema/v2/__tests__/createPartnerOfferMutation.test.ts
@@ -26,6 +26,9 @@ const mutation = gql`
           }
         }
       }
+      partner {
+        name
+      }
     }
   }
 `
@@ -42,12 +45,18 @@ describe("Create a partner offer for users", () => {
       user_ids: ["user_id1", "user_id2"],
     }
 
+    const partner = {
+      name: "partner_name",
+    }
+
     const context = {
       createPartnerOfferLoader: () => Promise.resolve(partnerOffer),
+      partnerAllLoader: () => Promise.resolve(partner),
     }
 
     it("creates a partner offer request", async () => {
       const data = await runAuthenticatedQuery(mutation, context)
+      console.log(data)
       expect(data).toEqual({
         createPartnerOffer: {
           partnerOfferOrError: {
@@ -61,6 +70,9 @@ describe("Create a partner offer for users", () => {
               partnerId: "partner_id",
               userIds: ["user_id1", "user_id2"],
             },
+          },
+          partner: {
+            name: "partner_name",
           },
         },
       })
@@ -88,6 +100,7 @@ describe("Create a partner offer for users", () => {
               message: "Artwork not found",
             },
           },
+          partner: null,
         },
       })
     })

--- a/src/schema/v2/__tests__/createPartnerOfferMutation.test.ts
+++ b/src/schema/v2/__tests__/createPartnerOfferMutation.test.ts
@@ -56,7 +56,6 @@ describe("Create a partner offer for users", () => {
 
     it("creates a partner offer request", async () => {
       const data = await runAuthenticatedQuery(mutation, context)
-      console.log(data)
       expect(data).toEqual({
         createPartnerOffer: {
           partnerOfferOrError: {

--- a/src/schema/v2/__tests__/createPartnerOfferMutation.test.ts
+++ b/src/schema/v2/__tests__/createPartnerOfferMutation.test.ts
@@ -19,15 +19,15 @@ const mutation = gql`
             discountPercentage
             userIds
           }
+          partner {
+            name
+          }
         }
         ... on createPartnerOfferFailure {
           mutationError {
             message
           }
         }
-      }
-      partner {
-        name
       }
     }
   }
@@ -70,9 +70,9 @@ describe("Create a partner offer for users", () => {
               partnerId: "partner_id",
               userIds: ["user_id1", "user_id2"],
             },
-          },
-          partner: {
-            name: "partner_name",
+            partner: {
+              name: "partner_name",
+            },
           },
         },
       })
@@ -100,7 +100,6 @@ describe("Create a partner offer for users", () => {
               message: "Artwork not found",
             },
           },
-          partner: null,
         },
       })
     })

--- a/src/schema/v2/createPartnerOfferMutation.ts
+++ b/src/schema/v2/createPartnerOfferMutation.ts
@@ -81,8 +81,7 @@ export const createPartnerOfferMutation = mutationWithClientMutationId<
         artwork_id: args.artwork_id,
         discount_percentage: args.discount_percentage,
       })
-
-      const partner = await partnerAllLoader?.(partnerOffer._id)
+      const partner = await partnerAllLoader?.(partnerOffer.partner_id)
 
       return { partnerOffer, partner }
     } catch (error) {


### PR DESCRIPTION
The table in "Send Offers" page in volt-v2 needs to be refreshed when the user performs an action. Instead of hard reloading the page, @damassi suggested to use relay fragments to reload the affected rows. This approach is only possible if we include the `partner` type in the mutation payload.

See slack thread for more context https://artsy.slack.com/archives/C02JHHHKP5K/p1706106297053579

Relates to https://github.com/artsy/volt-v2/pull/1153