### PR TITLE
chore: add internalID and slug to PartialArtwork

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13937,7 +13937,16 @@ type PageInfo {
 # An artwork with partial data. useful for rendering an error state
 type PartialArtwork {
   artists: [Artist]
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
   layers: [ArtworkLayer]
+
+  # A slug ID.
+  slug: ID!
 }
 
 type Partner implements Node {

--- a/src/schema/v2/artworkResult/__tests__/index.test.ts
+++ b/src/schema/v2/artworkResult/__tests__/index.test.ts
@@ -5,6 +5,8 @@ describe("Artwork type", () => {
   describe("when throwing an error", () => {
     const artwork = {
       artist_ids: ["artist-id"],
+      id: "artwork-slug",
+      _id: "artwork-id",
     }
 
     const context = {
@@ -26,6 +28,8 @@ describe("Artwork type", () => {
               statusCode
             }
             artwork {
+              internalID
+              slug
               artists {
                 name
               }
@@ -48,6 +52,8 @@ describe("Artwork type", () => {
                   "name": "Catty Artist",
                 },
               ],
+              "internalID": "artwork-id",
+              "slug": "artwork-slug",
             },
             "requestError": Object {
               "statusCode": 404,

--- a/src/schema/v2/artworkResult/index.ts
+++ b/src/schema/v2/artworkResult/index.ts
@@ -11,6 +11,7 @@ import { ResolverContext } from "types/graphql"
 import { ArtworkType, artworkResolver } from "schema/v2/artwork"
 import ArtworkLayers, { artworkLayers } from "schema/v2/artwork/layers"
 import { RequestErrorType } from "schema/v2/fields/requestError"
+import { SlugAndInternalIDFields } from "../object_identification"
 
 const ArtworkErrorType = new GraphQLObjectType<any, ResolverContext>({
   name: "ArtworkError",
@@ -23,6 +24,7 @@ const ArtworkErrorType = new GraphQLObjectType<any, ResolverContext>({
         description:
           "An artwork with partial data. useful for rendering an error state",
         fields: {
+          ...SlugAndInternalIDFields,
           artists: {
             type: new GraphQLList(Artist.type),
             resolve: ({ artist_ids }, _, { artistLoader }) => {


### PR DESCRIPTION
Little one, nice to have these identifiers as first-class on the partial artwork 'error' response.