### PR TITLE
fix: allow owners accessing unpublished artworks to resolve fully

### DIFF
--- a/src/schema/v2/artworkResult/__tests__/index.test.ts
+++ b/src/schema/v2/artworkResult/__tests__/index.test.ts
@@ -122,7 +122,7 @@ describe("Artwork type", () => {
 
   describe("without any errors", () => {
     const artwork = {
-      published: true,
+      title: "Catty Artwork Title",
       artists: [{ id: "artist-id" }],
     }
 

--- a/src/schema/v2/artworkResult/index.ts
+++ b/src/schema/v2/artworkResult/index.ts
@@ -68,7 +68,11 @@ const ArtworkResultType = new GraphQLUnionType<any, ResolverContext>({
   name: "ArtworkResult",
   types: [ArtworkErrorType, ArtworkType],
   resolveType: (artwork) => {
-    if (artwork?.published) {
+    // Rather than use `artwork?.published`, we still need to support owners
+    // being able to see unpublished works resolve with `ArtworkType`.
+    // Instead, let's check for the presence of a `title` to determine if this
+    // is a full artwork.
+    if ("title" in artwork) {
       return ArtworkType
     }
 


### PR DESCRIPTION
This was an odd one!

Before this change, an owner logged in viewing an unpublished artwork, would still be served the new error page!

Since I think we need to support unpublished artworks resolving properly with a 200 and normal artwork page to owners, instead of checking `published`, let's check if we got a 'full response', which would indicate this is an owner who should resolve the full type.