### PR TITLE
chore: resolve a `partner`in PartialArtwork

### DIFF
--- a/src/schema/v2/artworkResult/__tests__/index.test.ts
+++ b/src/schema/v2/artworkResult/__tests__/index.test.ts
@@ -5,6 +5,7 @@ describe("Artwork type", () => {
   describe("when throwing an error", () => {
     const artwork = {
       artist_ids: ["artist-id"],
+      partner_id: "partner-id",
       id: "artwork-slug",
       _id: "artwork-id",
     }
@@ -33,6 +34,7 @@ describe("Artwork type", () => {
       relatedLayerArtworksLoader: () =>
         Promise.resolve(relatedArtworksResponse),
       artistLoader: () => Promise.resolve({ name: "Catty Artist" }),
+      partnerLoader: () => Promise.resolve({ name: "Catty Partner" }),
     }
     const query = `
       {

--- a/src/schema/v2/artworkResult/index.ts
+++ b/src/schema/v2/artworkResult/index.ts
@@ -45,19 +45,20 @@ const ArtworkErrorType = new GraphQLObjectType<any, ResolverContext>({
           },
         },
       }),
-      resolve: async ({ artwork }, _, { artistLoader }) => {
+      resolve: async ({ artwork }, _, { artistLoader, partnerLoader }) => {
         if (!artwork) return null
 
-        const { artist_ids } = artwork
+        const { artist_ids, partner_id: partnerID } = artwork
         const artistID = artist_ids[0]
         return {
           ...artwork,
 
-          // Inject a resolved `artist`, in order to better match `Artwork` shape.
+          // Inject resolved data, in order to better match `Artwork` shape.
           //
-          // TODO: Move this upstream to Gravity, where a partial artwork 404 response
-          // should better match the shape of a full artwork response.
+          // TODO: Consider moving this upstream to Gravity, where a partial
+          // artwork 404 response should better match the shape of the full one.
           artist: !!artistID ? await artistLoader(artistID) : null,
+          partner: !!partnerID ? await partnerLoader(partnerID) : null,
         }
       },
     },


### PR DESCRIPTION
After https://github.com/artsy/gravity/pull/17300 added `partner_id`, we can inject that in and have access to the 'Other Works by Partner' section.