### PR TITLE
feat(EMI-1641): expose EditionSet#priceListed for offer discount calculations

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9165,6 +9165,7 @@ type EditionSet implements Sellable {
   isSold: Boolean
   listPrice: ListPrice
   price: String
+  priceListed: Money
   saleMessage: String
 
   # size bucket assigned to an artwork based on its dimensions

--- a/src/schema/v2/edition_set.ts
+++ b/src/schema/v2/edition_set.ts
@@ -13,6 +13,8 @@ import { capitalizeFirstCharacter } from "lib/helpers"
 import { Sellable } from "./sellable"
 import { ResolverContext } from "types/graphql"
 import { listPrice } from "./fields/listPrice"
+import { Money } from "./fields/money"
+import currencyCodes from "lib/currency_codes.json"
 
 export const EditionSetSorts = {
   type: new GraphQLEnumType({
@@ -75,6 +77,15 @@ export const EditionSetType = new GraphQLObjectType<any, ResolverContext>({
     },
     price: {
       type: GraphQLString,
+    },
+    priceListed: {
+      type: Money,
+      resolve: ({ price_listed: price_listed, price_currency: currency }) => {
+        const factor =
+          currencyCodes[currency?.toLowerCase()]?.subunit_to_unit ?? 100
+        const cents = price_listed * factor
+        return { cents, currency }
+      },
     },
     sizeScore: {
       description: "score assigned to an artwork based on its dimensions",


### PR DESCRIPTION
The current price fields in the EditionSet type (`listPrice`, `internalDisplayPrice` and `price`)  can't be used for integer calculations without too much trouble converting them.

Similar to https://github.com/artsy/metaphysics/pull/5497 where we exposed the `Artwork#price_listed` field, which is more reliable for discount calculations and https://github.com/artsy/pulse/pull/1827, which used the `EditionSet#price_listed` field to display the price in emails, we need to expose this in the EditionSet Type so we can use it in volt-v2 for discount calculations for artworks with edition sets.

<details><summary>Example payload</summary>
<p>

```
# QUERY
query ArtworksConnection($partnerId: String!, $first: Int,$sort: ArtworkSorts, $shallow: Boolean, $partnerOfferable: Boolean) {
  partner(id: $partnerId) {
    artworksConnection(first: $first, sort: $sort, shallow: $shallow, partnerOfferable: $partnerOfferable) {
      edges {
        node {
          editionSets {
            priceListed {
              currencyCode
              display
              major
            	minor
            }
          }
        }
      }
    }
  }
}

# RESPONSE
{
  "data": {
    "partner": {
      "artworksConnection": {
        "edges": [
          {
            "node": {
              "editionSets": []
            }
          },
          {
            "node": {
              "editionSets": [
                {
                  "priceListed": {
                    "currencyCode": "USD",
                    "display": null,
                    "major": 12345,
                    "minor": 1234500
                  }
                }
              ]
            }
          },
          {
            "node": {
              "editionSets": [
                {
                  "priceListed": {
                    "currencyCode": "USD",
                    "display": null,
                    "major": 12345,
                    "minor": 1234500
                  }
                }
              ]
            }
          },
          {
            "node": {
              "editionSets": []
            }
          },
          {
            "node": {
              "editionSets": [
                {
                  "priceListed": {
                    "currencyCode": "USD",
                    "display": null,
                    "major": 1400,
                    "minor": 140000
                  }
                }
              ]
            }
          },
          {
            "node": {
              "editionSets": []
            }
          },
          {
            "node": {
              "editionSets": []
            }
          },
          {
            "node": {
              "editionSets": []
            }
          },
          {
            "node": {
              "editionSets": []
            }
          },
          {
            "node": {
              "editionSets": [
                {
                  "priceListed": {
                    "currencyCode": "USD",
                    "display": null,
                    "major": 200,
                    "minor": 20000
                  }
                }
              ]
            }
          }
        ]
      }
    }
  },
}
``` 

</p>
</details> 