### PR TITLE
feat: pass through the app token for exchange

### DIFF
--- a/src/lib/stitching/exchange/link.ts
+++ b/src/lib/stitching/exchange/link.ts
@@ -23,8 +23,17 @@ export const createExchangeLink = () => {
       const headers = {
         ...(graphqlContext && requestIDHeaders(graphqlContext.requestIDs)),
       }
+      // Use the app token when application is trying to reach the exchange eg. Impulse calling Metaphysics to get data from Exchange
+      if (graphqlContext.appToken) {
+        return {
+          headers: Object.assign(headers, {
+            Authorization: `Bearer ${graphqlContext.appToken}`,
+          }),
+        }
+      }
       // If a token loader exists for Exchange (i.e. this is an authenticated request), use that token to make
       // authenticated requests to Exchange.
+
       if (tokenLoader) {
         return tokenLoader().then(({ token }) => {
           return {
@@ -35,7 +44,9 @@ export const createExchangeLink = () => {
         })
       }
       // Exchange uses no authentication for now
-      return { headers }
+      return {
+        headers,
+      }
     }
   )
 

--- a/src/lib/stitching/exchange/link.ts
+++ b/src/lib/stitching/exchange/link.ts
@@ -23,17 +23,9 @@ export const createExchangeLink = () => {
       const headers = {
         ...(graphqlContext && requestIDHeaders(graphqlContext.requestIDs)),
       }
-      // Use the app token when application is trying to reach the exchange eg. Impulse calling Metaphysics to get data from Exchange
-      if (graphqlContext.appToken) {
-        return {
-          headers: Object.assign(headers, {
-            Authorization: `Bearer ${graphqlContext.appToken}`,
-          }),
-        }
-      }
+
       // If a token loader exists for Exchange (i.e. this is an authenticated request), use that token to make
       // authenticated requests to Exchange.
-
       if (tokenLoader) {
         return tokenLoader().then(({ token }) => {
           return {
@@ -43,6 +35,16 @@ export const createExchangeLink = () => {
           }
         })
       }
+
+      // Use the app token when an application is trying to reach Exchange eg. Impulse calling Metaphysics
+      if (graphqlContext.appToken) {
+        return {
+          headers: Object.assign(headers, {
+            Authorization: `Bearer ${graphqlContext.appToken}`,
+          }),
+        }
+      }
+
       // Exchange uses no authentication for now
       return {
         headers,


### PR DESCRIPTION
This PR enables request [from Impulse](https://github.com/artsy/impulse/pull/1110) to be proxied to Exchange.