### PR TITLE
chore: allow deployment to scale up further, to better handle internal floods of requests

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -117,7 +117,7 @@ spec:
     kind: Deployment
     name: metaphysics-web
   minReplicas: 10
-  maxReplicas: 28
+  maxReplicas: 35
   targetCPUUtilizationPercentage: 60
 ---
 apiVersion: v1


### PR DESCRIPTION
In [this discussion](https://artsy.slack.com/archives/C05EQL4R5N0/p1707146887579779), we determined that Metaphysics capacity is the limiting factor in gracefully handling the high volume of requests sometimes sent by Braze. During these floods, the upstream services like Gravity and Vortex receive a large volume of requests, but seem to handle them fine.

We've identified a few _other_ steps to take (especially: limiting the rate via Braze's configuration, and caching the back-fill artworks that ~half of these queries load), but in the meantime I don't see any harm in increasing Metaphysics' maximum scale. Here, I somewhat arbitrarily raise it by 25%. What do you think?