### PR TITLE
chore: Expose collector profile counts

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4045,6 +4045,7 @@ type CollectorProfileType {
     timezone: String
   ): String
   bio: String
+  collectedArtworksCount: Int!
   collectorLevel: Int
 
   # List of artists the Collector is interested in.
@@ -4065,6 +4066,7 @@ type CollectorProfileType {
       reason: "emailConfirmed is going to be removed, use isEmailConfirmed instead"
     )
   firstNameLastInitial: String
+  followedArtistsCount: Int!
   icon: Image
 
   # A globally unique ID.
@@ -4119,7 +4121,9 @@ type CollectorProfileType {
     # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String
+  savedArtworksCount: Int!
   selfReportedPurchases: String
+  totalBidsCount: Int!
   userInterests: [UserInterest]!
 }
 
@@ -11195,6 +11199,7 @@ type InquirerCollectorProfile {
     timezone: String
   ): String
   bio: String
+  collectedArtworksCount: Int!
   collectorLevel: Int
 
   # List of artists the Collector is interested in.
@@ -11215,6 +11220,7 @@ type InquirerCollectorProfile {
       reason: "emailConfirmed is going to be removed, use isEmailConfirmed instead"
     )
   firstNameLastInitial: String
+  followedArtistsCount: Int!
 
   # The Collector follows the Gallery profile
   hasPartnerFollow: Boolean
@@ -11272,7 +11278,9 @@ type InquirerCollectorProfile {
     # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String
+  savedArtworksCount: Int!
   selfReportedPurchases: String
+  totalBidsCount: Int!
   userInterests: [UserInterest]!
 }
 
@@ -18677,6 +18685,7 @@ type UpdateCollectorProfilePayload {
   ): String
   bio: String
   clientMutationId: String
+  collectedArtworksCount: Int!
   collectorLevel: Int
 
   # List of artists the Collector is interested in.
@@ -18697,6 +18706,7 @@ type UpdateCollectorProfilePayload {
       reason: "emailConfirmed is going to be removed, use isEmailConfirmed instead"
     )
   firstNameLastInitial: String
+  followedArtistsCount: Int!
   icon: Image
 
   # A globally unique ID.
@@ -18751,7 +18761,9 @@ type UpdateCollectorProfilePayload {
     # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String
+  savedArtworksCount: Int!
   selfReportedPurchases: String
+  totalBidsCount: Int!
   userInterests: [UserInterest]!
 }
 

--- a/src/schema/v2/CollectorProfile/collectorProfile.ts
+++ b/src/schema/v2/CollectorProfile/collectorProfile.ts
@@ -113,7 +113,23 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
   inquiryRequestsCount: {
     type: new GraphQLNonNull(GraphQLInt),
     resolve: ({ artwork_inquiry_requests_count }) =>
-      artwork_inquiry_requests_count,
+      artwork_inquiry_requests_count || 0,
+  },
+  savedArtworksCount: {
+    type: new GraphQLNonNull(GraphQLInt),
+    resolve: ({ saved_artworks_count }) => saved_artworks_count || 0,
+  },
+  followedArtistsCount: {
+    type: new GraphQLNonNull(GraphQLInt),
+    resolve: ({ followed_artists_count }) => followed_artists_count || 0,
+  },
+  collectedArtworksCount: {
+    type: new GraphQLNonNull(GraphQLInt),
+    resolve: ({ collected_artworks_count }) => collected_artworks_count || 0,
+  },
+  totalBidsCount: {
+    type: new GraphQLNonNull(GraphQLInt),
+    resolve: ({ total_bids_count }) => total_bids_count || 0,
   },
   isActiveBidder: {
     type: GraphQLBoolean,


### PR DESCRIPTION
Exposes the new `saved_artworks_count`, `followed_artists_count`, `collected_artworks_count`, and `total_bids_count` fields on the collector profile.