### PR TITLE
feat: Return `me` from notification mutations

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11643,6 +11643,7 @@ union MarkAllNotificationsAsReadResponseOrError =
   | MarkAllNotificationsAsReadSuccess
 
 type MarkAllNotificationsAsReadSuccess {
+  me: Me!
   success: Boolean
 }
 
@@ -11862,6 +11863,7 @@ union MarkNotificationAsReadResponseOrError =
   | MarkNotificationAsReadSuccess
 
 type MarkNotificationAsReadSuccess {
+  me: Me!
   success: Boolean
 }
 
@@ -11886,6 +11888,7 @@ union MarkNotificationsAsSeenResponseOrError =
   | MarkNotificationsAsSeenSuccess
 
 type MarkNotificationsAsSeenSuccess {
+  me: Me!
   success: Boolean
 }
 

--- a/src/schema/v2/me/markNotificationsAsSeenMutation.ts
+++ b/src/schema/v2/me/markNotificationsAsSeenMutation.ts
@@ -9,11 +9,18 @@ import {
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
+import { meType } from "../me"
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
   name: "MarkNotificationsAsSeenSuccess",
   isTypeOf: (data) => data.success,
   fields: () => ({
+    me: {
+      type: new GraphQLNonNull(meType),
+      resolve: (_source, _args, { meLoader }) => {
+        return meLoader?.()
+      },
+    },
     success: {
       type: GraphQLBoolean,
       resolve: (result) => result.success,

--- a/src/schema/v2/me/mark_all_notifications_as_read_mutation.ts
+++ b/src/schema/v2/me/mark_all_notifications_as_read_mutation.ts
@@ -16,7 +16,6 @@ const SuccessType = new GraphQLObjectType<any, ResolverContext>({
     me: {
       type: new GraphQLNonNull(meType),
       resolve: (_source, _args, { meLoader }) => {
-        debugger
         return meLoader?.()
       },
     },

--- a/src/schema/v2/me/mark_all_notifications_as_read_mutation.ts
+++ b/src/schema/v2/me/mark_all_notifications_as_read_mutation.ts
@@ -1,4 +1,4 @@
-import { GraphQLObjectType } from "graphql"
+import { GraphQLNonNull, GraphQLObjectType } from "graphql"
 import { GraphQLUnionType } from "graphql"
 import { GraphQLBoolean } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
@@ -7,11 +7,19 @@ import {
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
+import { meType } from "../me"
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
   name: "MarkAllNotificationsAsReadSuccess",
   isTypeOf: (data) => data.success,
   fields: () => ({
+    me: {
+      type: new GraphQLNonNull(meType),
+      resolve: (_source, _args, { meLoader }) => {
+        debugger
+        return meLoader?.()
+      },
+    },
     success: {
       type: GraphQLBoolean,
       resolve: (result) => result.success,

--- a/src/schema/v2/me/mark_notification_as_read_mutation.ts
+++ b/src/schema/v2/me/mark_notification_as_read_mutation.ts
@@ -11,11 +11,18 @@ import {
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
+import { meType } from "../me"
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
   name: "MarkNotificationAsReadSuccess",
   isTypeOf: (data) => data.success,
   fields: () => ({
+    me: {
+      type: new GraphQLNonNull(meType),
+      resolve: (_source, _args, { meLoader }) => {
+        return meLoader?.()
+      },
+    },
     success: {
       type: GraphQLBoolean,
       resolve: (result) => result.success,


### PR DESCRIPTION
* [ONYX-750](https://artsyproduct.atlassian.net/browse/ONYX-750)

## Description

In order to update the notification read count, this PR updates all Notification mutations to return `me`. This should allow us to update `unreadNotificationsCount` automatically in the Relay store when notifications are marked as read without manipulating the store imperatively ([example](https://github.com/artsy/force/blob/29a650d2548a31325e8d507acdfa12d7c27ca425/src/Components/Notifications/Mutations/markNotificationsAsSeen.ts#L11))

```graphql
mutation {
	markNotificationAsRead(input: { id: "feed_id" }) {
		responseOrError {
			... on MarkNotificationAsReadSuccess {
				me {
					unreadNotificationsCount
				}
				success
			}
		}
	}
}
```

[ONYX-750]: https://artsyproduct.atlassian.net/browse/ONYX-750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ