### PR TITLE
fix(collectorprofile): exposes owner field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4103,6 +4103,7 @@ type CollectorProfileType {
 
   # Collector's position with relevant institutions
   otherRelevantPositions: String
+  owner: User!
 
   # User ID of the collector profile's owner
   ownerID: ID!
@@ -4128,6 +4129,7 @@ type CollectorProfileType {
   selfReportedPurchases: String
   totalBidsCount: Int!
   userInterests: [UserInterest]!
+    @deprecated(reason: "Use \"owner#interestsConnection\" field instead.")
 }
 
 # A connection to a list of items.
@@ -11260,6 +11262,7 @@ type InquirerCollectorProfile {
 
   # Collector's position with relevant institutions
   otherRelevantPositions: String
+  owner: User!
 
   # User ID of the collector profile's owner
   ownerID: ID!
@@ -11285,6 +11288,7 @@ type InquirerCollectorProfile {
   selfReportedPurchases: String
   totalBidsCount: Int!
   userInterests: [UserInterest]!
+    @deprecated(reason: "Use \"owner#interestsConnection\" field instead.")
 }
 
 union InquiryItemType = Artwork | Show
@@ -18749,6 +18753,7 @@ type UpdateCollectorProfilePayload {
 
   # Collector's position with relevant institutions
   otherRelevantPositions: String
+  owner: User!
 
   # User ID of the collector profile's owner
   ownerID: ID!
@@ -18774,6 +18779,7 @@ type UpdateCollectorProfilePayload {
   selfReportedPurchases: String
   totalBidsCount: Int!
   userInterests: [UserInterest]!
+    @deprecated(reason: "Use \"owner#interestsConnection\" field instead.")
 }
 
 type UpdateCollectorProfileWithIDFailure {

--- a/src/schema/v2/CollectorProfile/collectorProfile.ts
+++ b/src/schema/v2/CollectorProfile/collectorProfile.ts
@@ -18,6 +18,7 @@ import Image, { normalizeImageData } from "schema/v2/image"
 import { userInterestType } from "../userInterests"
 import { myLocationType } from "../me/myLocation"
 import initials from "schema/v2/fields/initials"
+import { UserType } from "schema/v2/user"
 
 export const CollectorProfileFields: GraphQLFieldConfigMap<
   any,
@@ -58,19 +59,24 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
     resolve: ({ self_reported_purchases }) => self_reported_purchases,
   },
   userInterests: {
+    deprecationReason: 'Use "owner#interestsConnection" field instead.',
     type: new GraphQLNonNull(new GraphQLList(userInterestType)),
     resolve: (_collectorProfile, _args, { meUserInterestsLoader }) => {
       return meUserInterestsLoader?.().then(({ body }) => body)
     },
   },
-
-  // moved InquirerCollectorProfileFields here
   location: { type: myLocationType },
   artsyUserSince: dateFormatter(({ artsy_user_since }) => artsy_user_since),
   ownerID: {
     type: new GraphQLNonNull(GraphQLID),
     description: "User ID of the collector profile's owner",
     resolve: ({ owner: { id } }) => id,
+  },
+  owner: {
+    type: new GraphQLNonNull(UserType),
+    resolve: ({ owner: { id } }, _args, { userByIDLoader }) => {
+      return userByIDLoader(id)
+    },
   },
   icon: {
     type: Image.type,


### PR DESCRIPTION
This is to get at the `interestsConnection` on the `UserType`.

The existing `userInterests` field on the collector profile only fetches for the logged in user and isn't a connection type anyway.

We'll need to add filtering options to the `interestsConnection` once that's done in Gravity.