### PR TITLE
feat(onyx-729): alert.displayName allows querying artist name and the rest of criteria separately

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -287,7 +287,13 @@ type Alert {
   dimensionRange: String
 
   # A suggestion for a name that describes a set of saved search criteria in a conventional format
-  displayName: String!
+  displayName(
+    # An array of fields to exclude from the display name.
+    except: [SearchCriteriaFields]
+
+    # An array of fields to include in the display name.
+    only: [SearchCriteriaFields]
+  ): String!
   formattedPriceRange: String
   forSale: Boolean
   hasRecentlyEnabledUserSearchCriteria: Boolean
@@ -303,7 +309,13 @@ type Alert {
   keyword: String
 
   # Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity
-  labels: [SearchCriteriaLabel]!
+  labels(
+    # An array of fields to exclude from labels array.
+    except: [SearchCriteriaFields]
+
+    # An array of fields to include to labels array.
+    only: [SearchCriteriaFields]
+  ): [SearchCriteriaLabel]!
   locationCities: [String]
   majorPeriods: [String]
   materialsTerms: [String]
@@ -17500,6 +17512,26 @@ type SearchCriteriaEdge {
 
   # The item at the end of the edge.
   node: SearchCriteria
+}
+
+enum SearchCriteriaFields {
+  acquireable
+  additionalGeneIDs
+  artistIDs
+  artistSeriesIDs
+  atAuction
+  attributionClass
+  colors
+  height
+  inquireableOnly
+  locationCities
+  majorPeriods
+  materialsTerms
+  offerable
+  partnerIDs
+  priceRange
+  sizes
+  width
 }
 
 # Human-friendly representation of a single SearchCriteria filter

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -313,7 +313,7 @@ type Alert {
     # An array of fields to exclude from labels array.
     except: [SearchCriteriaFields]
 
-    # An array of fields to include to labels array.
+    # An array of fields to include in labels array.
     only: [SearchCriteriaFields]
   ): [SearchCriteriaLabel]!
   locationCities: [String]

--- a/src/schema/v2/Alerts/index.ts
+++ b/src/schema/v2/Alerts/index.ts
@@ -282,7 +282,7 @@ export const AlertType = new GraphQLObjectType<
       args: {
         only: {
           type: new GraphQLList(SearchCriteriaFields),
-          description: "An array of fields to include to labels array.",
+          description: "An array of fields to include in labels array.",
         },
         except: {
           type: new GraphQLList(SearchCriteriaFields),

--- a/src/schema/v2/Alerts/index.ts
+++ b/src/schema/v2/Alerts/index.ts
@@ -17,6 +17,7 @@ import { ResolverContext } from "types/graphql"
 import { IDFields } from "../object_identification"
 import GraphQLJSON from "graphql-type-json"
 import {
+  SearchCriteriaFields,
   SearchCriteriaLabel,
   resolveSearchCriteriaLabels,
 } from "../previewSavedSearch/searchCriteriaLabel"
@@ -241,6 +242,16 @@ export const AlertType = new GraphQLObjectType<
     },
     displayName: {
       type: new GraphQLNonNull(GraphQLString),
+      args: {
+        only: {
+          type: new GraphQLList(SearchCriteriaFields),
+          description: "An array of fields to include in the display name.",
+        },
+        except: {
+          type: new GraphQLList(SearchCriteriaFields),
+          description: "An array of fields to exclude from the display name.",
+        },
+      },
       resolve: generateDisplayName,
       description:
         "A suggestion for a name that describes a set of saved search criteria in a conventional format",
@@ -268,6 +279,16 @@ export const AlertType = new GraphQLObjectType<
     },
     labels: {
       type: new GraphQLNonNull(new GraphQLList(SearchCriteriaLabel)),
+      args: {
+        only: {
+          type: new GraphQLList(SearchCriteriaFields),
+          description: "An array of fields to include to labels array.",
+        },
+        except: {
+          type: new GraphQLList(SearchCriteriaFields),
+          description: "An array of fields to exclude from labels array.",
+        },
+      },
       resolve: resolveSearchCriteriaLabels,
       description:
         "Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity",

--- a/src/schema/v2/me/__tests__/index.test.ts
+++ b/src/schema/v2/me/__tests__/index.test.ts
@@ -472,6 +472,8 @@ describe("me/index", () => {
             keyword
             artistIDs
             displayName
+            title: displayName(only: [artistIDs])
+            subtitle: displayName(except: [artistIDs])
             settings {
               email
               frequency
@@ -490,6 +492,7 @@ describe("me/index", () => {
             keyword: "cats",
             artist_ids: ["andy-warhol"],
             price_range: "*-1000",
+            additional_gene_ids: ["painting"],
           },
           frequency: "daily",
           email: true,
@@ -508,13 +511,15 @@ describe("me/index", () => {
               "artistIDs": Array [
                 "andy-warhol",
               ],
-              "displayName": "Andy Warhol — $0–$1,000",
+              "displayName": "Andy Warhol — $0–$1,000, Painting",
               "internalID": "123",
               "keyword": "cats",
               "settings": Object {
                 "email": true,
                 "frequency": "DAILY",
               },
+              "subtitle": "$0–$1,000, Painting",
+              "title": "Andy Warhol",
             },
           },
         }

--- a/src/schema/v2/previewSavedSearch/generateDisplayName.ts
+++ b/src/schema/v2/previewSavedSearch/generateDisplayName.ts
@@ -5,7 +5,7 @@ import {
 } from "./searchCriteriaLabel"
 
 export const generateDisplayName = async (parent, args, context, info) => {
-  // if `only` or `except` is provided, we forcefully resolve display name dinamically
+  // if `only` or `except` is provided, we forcefully resolve display name dynamically
   if (!args?.only && !args?.except) {
     if (parent?.userAlertSettings?.name) return parent?.userAlertSettings?.name
     // When being used from the non-stitched schema, the field is called `settings`

--- a/src/schema/v2/previewSavedSearch/generateDisplayName.ts
+++ b/src/schema/v2/previewSavedSearch/generateDisplayName.ts
@@ -1,14 +1,17 @@
 import {
   resolveSearchCriteriaLabels,
   SearchCriteriaLabel,
+  searchCriteriaLabelsToReturn,
 } from "./searchCriteriaLabel"
 
 export const generateDisplayName = async (parent, args, context, info) => {
-  if (parent?.userAlertSettings?.name) return parent?.userAlertSettings?.name
-
-  // When being used from the non-stitched schema, the field is called `settings`
-  // instead of `userAlertSettings`
-  if (parent?.settings?.name) return parent.settings.name
+  // if `only` or `except` is provided, we forcefully resolve display name dinamically
+  if (!args?.only && !args?.except) {
+    if (parent?.userAlertSettings?.name) return parent?.userAlertSettings?.name
+    // When being used from the non-stitched schema, the field is called `settings`
+    // instead of `userAlertSettings`
+    if (parent?.settings?.name) return parent.settings.name
+  }
 
   const labels = await resolveSearchCriteriaLabels(parent, args, context, info)
 
@@ -72,8 +75,16 @@ export const generateDisplayName = async (parent, args, context, info) => {
   const displayValues = useableLabels.map((labels) => {
     return labels.map((label) => label.displayValue).join(" or ")
   })
-  const [artist, ...others] = displayValues
-  let result = [artist, others.join(", ")].join(others.length > 0 ? " — " : "")
+
+  let result = ""
+  if (
+    searchCriteriaLabelsToReturn(args.only, args.except).includes("artistIDs")
+  ) {
+    const [artist, ...others] = displayValues
+    result = [artist, others.join(", ")].join(others.length > 0 ? " — " : "")
+  } else {
+    result = displayValues.join(", ")
+  }
 
   const remainingCount = allLabels.length - useableLabels.length
   if (remainingCount > 0) result += ` + ${remainingCount} more`

--- a/src/schema/v2/previewSavedSearch/previewSavedSearch.ts
+++ b/src/schema/v2/previewSavedSearch/previewSavedSearch.ts
@@ -20,7 +20,7 @@ import { generateDisplayName } from "./generateDisplayName"
 import { resolveHref } from "./resolveHref"
 import { suggestedFilters } from "./suggestedFilters"
 
-const previewSavedSearchArgs: GraphQLFieldConfigArgumentMap = {
+export const previewSavedSearchArgs: GraphQLFieldConfigArgumentMap = {
   acquireable: {
     type: GraphQLBoolean,
   },


### PR DESCRIPTION
[Ticket](https://artsyproduct.atlassian.net/browse/ONYX-729)

We need this PR to support upcoming design changes. Notice that alerts list has artist names as titles and the rest of criteria as subtitles on the next lines:

![Active-20240208-130328](https://github.com/artsy/metaphysics/assets/3934579/b11bee04-0b1f-42d0-bb72-2945d296f888)

## Demo

```graphql
query X {
  me {
    alert(id: "143292") {
      displayName
      title: displayName(only: [artistIDs])
      subtitle: displayName(except: [artistIDs])
    }
}
```

returns

```json
{
  "data": {
    "me": {
      "alert": {
        "displayName": "Damien Hirst — Painting, Limited edition",
        "title": "Damien Hirst",
        "subtitle": "Painting, Limited edition"
      }
    }
  },
}
```