### PR TITLE
feat(onyx-730): add alert.artworksConnection field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -281,6 +281,68 @@ type Alert {
     last: Int
   ): ArtistConnection!
   artistSeriesIDs: [String]
+
+  # Artworks Elastic Search results
+  artworksConnection(
+    acquireable: Boolean
+    additionalGeneIDs: [String]
+    after: String
+    aggregationPartnerCities: [String]
+    aggregations: [ArtworkAggregation]
+    artistID: String
+    artistIDs: [String]
+    artistNationalities: [String]
+    artistSeriesID: String
+    artistSeriesIDs: [String]
+    atAuction: Boolean
+    attributionClass: [String]
+    before: String
+    color: String
+    colors: [String]
+    dimensionRange: String
+    excludeArtworkIDs: [String]
+    extraAggregationGeneIDs: [String]
+    first: Int
+    forSale: Boolean
+    geneID: String
+    geneIDs: [String]
+    height: String
+    includeArtworksByFollowedArtists: Boolean
+    includeMediumFilterInAggregation: Boolean
+    input: FilterArtworksInput
+    inquireableOnly: Boolean
+    keyword: String
+
+    # When true, will only return exact keyword match
+    keywordMatchExact: Boolean
+    last: Int
+    locationCities: [String]
+    majorPeriods: [String]
+
+    # When true, will only return `marketable` works (not nude or provocative).
+    marketable: Boolean
+    marketingCollectionID: String
+    materialsTerms: [String]
+
+    # A string from the list of allocations, or * to denote all mediums
+    medium: String
+    offerable: Boolean
+    page: Int
+    partnerCities: [String]
+    partnerID: ID
+    partnerIDs: [String]
+    period: String
+    periods: [String]
+    priceRange: String
+    saleID: ID
+    size: Int
+
+    # Filter results by Artwork sizes
+    sizes: [ArtworkSizes]
+    sort: String
+    tagID: String
+    width: String
+  ): FilterArtworksConnection
   atAuction: Boolean
   attributionClass: [String]
   colors: [String]

--- a/src/schema/v2/Alerts/index.ts
+++ b/src/schema/v2/Alerts/index.ts
@@ -177,157 +177,190 @@ export const AlertType = new GraphQLObjectType<
   ResolverContext
 >({
   name: "Alert",
-  fields: () => ({
-    ...IDFields,
-    acquireable: {
-      type: GraphQLBoolean,
-    },
-    additionalGeneIDs: {
-      type: new GraphQLList(GraphQLString),
-      resolve: ({ additional_gene_ids }) => additional_gene_ids,
-    },
-    additionalGeneNames: {
-      type: new GraphQLList(GraphQLString),
-      resolve: ({ additional_gene_names }) => additional_gene_names,
-    },
-    artistIDs: {
-      type: new GraphQLList(GraphQLString),
-      resolve: ({ artist_ids }) => artist_ids,
-    },
-    artists: {
-      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ArtistType))),
-      resolve: async ({ artist_ids }, _args, { artistsLoader }) => {
-        if (!artist_ids) return []
+  fields: () => {
+    const {
+      filterArtworksConnectionWithParams,
+    } = require("../filterArtworksConnection")
 
-        const { body } = await artistsLoader({ ids: artist_ids })
-        return body ?? []
+    return {
+      ...IDFields,
+      acquireable: {
+        type: GraphQLBoolean,
       },
-    },
-    artistsConnection: {
-      type: new GraphQLNonNull(artistConnection.connectionType),
-      args: pageable(),
-      resolve: async ({ artist_ids }, args, { artistsLoader }) => {
-        if (!artist_ids || artist_ids.length === 0) return emptyConnection
+      additionalGeneIDs: {
+        type: new GraphQLList(GraphQLString),
+        resolve: ({ additional_gene_ids }) => additional_gene_ids,
+      },
+      additionalGeneNames: {
+        type: new GraphQLList(GraphQLString),
+        resolve: ({ additional_gene_names }) => additional_gene_names,
+      },
+      artistIDs: {
+        type: new GraphQLList(GraphQLString),
+        resolve: ({ artist_ids }) => artist_ids,
+      },
+      artists: {
+        type: new GraphQLNonNull(
+          new GraphQLList(new GraphQLNonNull(ArtistType))
+        ),
+        resolve: async ({ artist_ids }, _args, { artistsLoader }) => {
+          if (!artist_ids) return []
 
-        const { page, size } = convertConnectionArgsToGravityArgs(args)
-        const { body } = await artistsLoader({ ids: artist_ids })
+          const { body } = await artistsLoader({ ids: artist_ids })
+          return body ?? []
+        },
+      },
+      artistsConnection: {
+        type: new GraphQLNonNull(artistConnection.connectionType),
+        args: pageable(),
+        resolve: async ({ artist_ids }, args, { artistsLoader }) => {
+          if (!artist_ids || artist_ids.length === 0) return emptyConnection
 
-        const totalCount = body.length
-        return {
-          totalCount,
-          pageCursors: createPageCursors({ page, size }, totalCount),
-          ...connectionFromArray(body, args),
+          const { page, size } = convertConnectionArgsToGravityArgs(args)
+          const { body } = await artistsLoader({ ids: artist_ids })
+
+          const totalCount = body.length
+          return {
+            totalCount,
+            pageCursors: createPageCursors({ page, size }, totalCount),
+            ...connectionFromArray(body, args),
+          }
+        },
+      },
+      artworksConnection: filterArtworksConnectionWithParams((args) => {
+        const filterArtworksArgs = {
+          acquireable: args.acquireable,
+          additional_gene_ids: args.additional_gene_ids,
+          artist_ids: args.artist_ids,
+          artist_series_ids: args.artist_series_ids,
+          at_auction: args.at_auction,
+          attribution_class: args.attribution_class,
+          colors: args.colors,
+          dimension_range: args.dimension_range,
+          height: args.height,
+          inquireable_only: args.inquireable_only,
+          keyword: args.keyword,
+          location_cities: args.location_cities,
+          major_periods: args.major_periods,
+          materials_terms: args.materials_terms,
+          offerable: args.offerable,
+          partner_ids: args.partner_ids,
+          price_range: args.price_range,
+          sizes: args.sizes,
+          width: args.width,
         }
-      },
-    },
-    artistSeriesIDs: {
-      type: new GraphQLList(GraphQLString),
-      resolve: ({ artist_series_ids }) => artist_series_ids,
-    },
-    atAuction: {
-      type: GraphQLBoolean,
-      resolve: ({ at_auction }) => at_auction,
-    },
-    attributionClass: {
-      type: new GraphQLList(GraphQLString),
-      resolve: ({ attribution_class }) => attribution_class,
-    },
-    colors: {
-      type: new GraphQLList(GraphQLString),
-    },
-    dimensionRange: {
-      type: GraphQLString,
-      resolve: ({ dimension_range }) => dimension_range,
-    },
-    displayName: {
-      type: new GraphQLNonNull(GraphQLString),
-      resolve: generateDisplayName,
-      description:
-        "A suggestion for a name that describes a set of saved search criteria in a conventional format",
-    },
-    forSale: {
-      type: GraphQLBoolean,
-      resolve: ({ for_sale }) => for_sale,
-    },
-    formattedPriceRange: {
-      type: GraphQLString,
-      resolve: ({ formatted_price_range }) => formatted_price_range,
-    },
-    height: {
-      type: GraphQLString,
-    },
-    href: {
-      type: GraphQLString,
-    },
-    inquireableOnly: {
-      type: GraphQLBoolean,
-      resolve: ({ inquireable_only }) => inquireable_only,
-    },
-    keyword: {
-      type: GraphQLString,
-    },
-    labels: {
-      type: new GraphQLNonNull(new GraphQLList(SearchCriteriaLabel)),
-      resolve: resolveSearchCriteriaLabels,
-      description:
-        "Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity",
-    },
-    locationCities: {
-      type: new GraphQLList(GraphQLString),
-      resolve: ({ location_cities }) => location_cities,
-    },
-    majorPeriods: {
-      type: new GraphQLList(GraphQLString),
-      resolve: ({ major_periods }) => major_periods,
-    },
-    materialsTerms: {
-      type: new GraphQLList(GraphQLString),
-      resolve: ({ materials_terms }) => materials_terms,
-    },
-    offerable: {
-      type: GraphQLBoolean,
-    },
-    partnerIDs: {
-      type: new GraphQLList(GraphQLString),
-      resolve: ({ partner_ids }) => partner_ids,
-    },
-    priceArray: {
-      type: new GraphQLList(GraphQLInt),
-      resolve: ({ price_array }) => price_array,
-    },
-    priceRange: {
-      type: GraphQLString,
-      resolve: ({ price_range }) => price_range,
-    },
-    sizes: {
-      type: new GraphQLList(GraphQLString),
-    },
-    // Summary is a generic/dynamic JSON object.
-    // TODO: This should probably be structured.
-    summary: {
-      type: GraphQLJSON,
-    },
-    width: {
-      type: GraphQLString,
-    },
-    settings: {
-      type: AlertSettingsType,
-    },
 
-    // Below fields are injected in the JSON when the alert data is being returned
-    // from ElasticSearch - currently when queried from the following places:
-    //
-    // - `alertsConnection` under `Artist`
-    // - `alertsSummaryArtistsConnection` under `Partner`.
-    totalUserSearchCriteriaCount: {
-      type: GraphQLInt,
-      resolve: ({ count_30d }) => count_30d,
-    },
-    hasRecentlyEnabledUserSearchCriteria: {
-      type: GraphQLBoolean,
-      resolve: ({ count_7d }) => count_7d && count_7d > 0,
-    },
-  }),
+        return filterArtworksArgs
+      }),
+      artistSeriesIDs: {
+        type: new GraphQLList(GraphQLString),
+        resolve: ({ artist_series_ids }) => artist_series_ids,
+      },
+      atAuction: {
+        type: GraphQLBoolean,
+        resolve: ({ at_auction }) => at_auction,
+      },
+      attributionClass: {
+        type: new GraphQLList(GraphQLString),
+        resolve: ({ attribution_class }) => attribution_class,
+      },
+      colors: {
+        type: new GraphQLList(GraphQLString),
+      },
+      dimensionRange: {
+        type: GraphQLString,
+        resolve: ({ dimension_range }) => dimension_range,
+      },
+      displayName: {
+        type: new GraphQLNonNull(GraphQLString),
+        resolve: generateDisplayName,
+        description:
+          "A suggestion for a name that describes a set of saved search criteria in a conventional format",
+      },
+      forSale: {
+        type: GraphQLBoolean,
+        resolve: ({ for_sale }) => for_sale,
+      },
+      formattedPriceRange: {
+        type: GraphQLString,
+        resolve: ({ formatted_price_range }) => formatted_price_range,
+      },
+      height: {
+        type: GraphQLString,
+      },
+      href: {
+        type: GraphQLString,
+      },
+      inquireableOnly: {
+        type: GraphQLBoolean,
+        resolve: ({ inquireable_only }) => inquireable_only,
+      },
+      keyword: {
+        type: GraphQLString,
+      },
+      labels: {
+        type: new GraphQLNonNull(new GraphQLList(SearchCriteriaLabel)),
+        resolve: resolveSearchCriteriaLabels,
+        description:
+          "Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity",
+      },
+      locationCities: {
+        type: new GraphQLList(GraphQLString),
+        resolve: ({ location_cities }) => location_cities,
+      },
+      majorPeriods: {
+        type: new GraphQLList(GraphQLString),
+        resolve: ({ major_periods }) => major_periods,
+      },
+      materialsTerms: {
+        type: new GraphQLList(GraphQLString),
+        resolve: ({ materials_terms }) => materials_terms,
+      },
+      offerable: {
+        type: GraphQLBoolean,
+      },
+      partnerIDs: {
+        type: new GraphQLList(GraphQLString),
+        resolve: ({ partner_ids }) => partner_ids,
+      },
+      priceArray: {
+        type: new GraphQLList(GraphQLInt),
+        resolve: ({ price_array }) => price_array,
+      },
+      priceRange: {
+        type: GraphQLString,
+        resolve: ({ price_range }) => price_range,
+      },
+      sizes: {
+        type: new GraphQLList(GraphQLString),
+      },
+      // Summary is a generic/dynamic JSON object.
+      // TODO: This should probably be structured.
+      summary: {
+        type: GraphQLJSON,
+      },
+      width: {
+        type: GraphQLString,
+      },
+      settings: {
+        type: AlertSettingsType,
+      },
+
+      // Below fields are injected in the JSON when the alert data is being returned
+      // from ElasticSearch - currently when queried from the following places:
+      //
+      // - `alertsConnection` under `Artist`
+      // - `alertsSummaryArtistsConnection` under `Partner`.
+      totalUserSearchCriteriaCount: {
+        type: GraphQLInt,
+        resolve: ({ count_30d }) => count_30d,
+      },
+      hasRecentlyEnabledUserSearchCriteria: {
+        type: GraphQLBoolean,
+        resolve: ({ count_7d }) => count_7d && count_7d > 0,
+      },
+    }
+  },
 })
 
 const AlertsEdgeFields = {


### PR DESCRIPTION
[Ticket](https://artsyproduct.atlassian.net/browse/ONYX-730)

We need to query alert's artworks in a few placed. Currently, we fetch search criteria first and then pass them to `filterArtworksConnection` as arguments. This PR adds support to query artworks easier, via `alert.artworksConnection`.

## Demo

```graphql
query X {
  me {
    alert(id: "143292") {
      artworksConnection(first: 1) {
        counts {
          total
        }
        
        edges {
          node {
            title
          }
        }
      }
    }
  }
}
```

produces:

```json
{
  "data": {
    "me": {
      "alert": {
        "artworksConnection": {
          "counts": {
            "total": 1
          },
          "edges": [
            {
              "node": {
                "title": "The Hours Spin Skull"
              }
            }
          ]
        }
      }
    }
  }
}
```