### PR TITLE
chore: add a `sort` to `alertsConnection` and tighten up some types

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -315,7 +315,7 @@ type Alert {
 
     # An array of fields to include in labels array.
     only: [SearchCriteriaFields]
-  ): [SearchCriteriaLabel]!
+  ): [SearchCriteriaLabel!]!
   locationCities: [String]
   majorPeriods: [String]
   materialsTerms: [String]
@@ -323,7 +323,7 @@ type Alert {
   partnerIDs: [String]
   priceArray: [Int]
   priceRange: String
-  settings: AlertSettings
+  settings: AlertSettings!
   sizes: [String]
   summary: JSON
   totalUserSearchCriteriaCount: Int
@@ -363,16 +363,21 @@ type AlertNotificationItem {
   ): ArtworkConnection
 }
 
+enum AlertsConnectionSortEnum {
+  ENABLED_AT_DESC
+  NAME_ASC
+}
+
 type AlertsCounts {
   totalUserSearchCriteriaCount: Int
 }
 
 type AlertSettings {
   details: String
-  email: Boolean
+  email: Boolean!
   frequency: AlertSettingsFrequency
   name: String
-  push: Boolean
+  push: Boolean!
 }
 
 enum AlertSettingsFrequency {
@@ -11954,6 +11959,7 @@ type Me implements Node {
     before: String
     first: Int
     last: Int
+    sort: AlertsConnectionSortEnum
   ): AlertConnection!
 
   # A connection of artist recommendations for the current user.

--- a/src/schema/v2/Alerts/index.ts
+++ b/src/schema/v2/Alerts/index.ts
@@ -53,10 +53,10 @@ const AlertSettingsType = new GraphQLObjectType<
       type: GraphQLString,
     },
     email: {
-      type: GraphQLBoolean,
+      type: GraphQLNonNull(GraphQLBoolean),
     },
     push: {
-      type: GraphQLBoolean,
+      type: GraphQLNonNull(GraphQLBoolean),
     },
     details: {
       type: GraphQLString,
@@ -278,7 +278,9 @@ export const AlertType = new GraphQLObjectType<
       type: GraphQLString,
     },
     labels: {
-      type: new GraphQLNonNull(new GraphQLList(SearchCriteriaLabel)),
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(SearchCriteriaLabel))
+      ),
       args: {
         only: {
           type: new GraphQLList(SearchCriteriaFields),
@@ -332,7 +334,7 @@ export const AlertType = new GraphQLObjectType<
       type: GraphQLString,
     },
     settings: {
-      type: AlertSettingsType,
+      type: new GraphQLNonNull(AlertSettingsType),
     },
 
     // Below fields are injected in the JSON when the alert data is being returned
@@ -369,6 +371,19 @@ const AlertsEdgeFields = {
     resolve: ({ count_7d }) => count_7d > 0,
   },
 }
+
+export const AlertsConnectionSortEnum = new GraphQLEnumType({
+  name: "AlertsConnectionSortEnum",
+  values: {
+    NAME_ASC: {
+      value: "name",
+    },
+
+    ENABLED_AT_DESC: {
+      value: "-enabled_at",
+    },
+  },
+})
 
 export const AlertsConnectionType = connectionWithCursorInfo({
   name: "Alert",

--- a/src/schema/v2/me/__tests__/index.test.ts
+++ b/src/schema/v2/me/__tests__/index.test.ts
@@ -392,7 +392,7 @@ describe("me/index", () => {
     const query = gql`
       query {
         me {
-          alertsConnection(first: 1) {
+          alertsConnection(first: 1, sort: ENABLED_AT_DESC) {
             totalCount
             edges {
               node {

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -73,7 +73,11 @@ import {
   DEFAULT_CURRENCY_PREFERENCE,
   DEFAULT_LENGTH_UNIT_PREFERENCE,
 } from "lib/helpers"
-import { AlertType, AlertsConnectionType } from "../Alerts"
+import {
+  AlertType,
+  AlertsConnectionSortEnum,
+  AlertsConnectionType,
+} from "../Alerts"
 import { emptyConnection, paginationResolver } from "../fields/pagination"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { pageable } from "relay-cursor-paging"
@@ -148,14 +152,21 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
       },
     },
     alertsConnection: {
-      args: pageable(),
+      args: pageable({
+        sort: {
+          type: AlertsConnectionSortEnum,
+        },
+      }),
       type: new GraphQLNonNull(AlertsConnectionType),
       resolve: async (_parent, args, { meAlertsLoader }) => {
         if (!meAlertsLoader) return emptyConnection
-        const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+        const { page, size, offset, sort } = convertConnectionArgsToGravityArgs(
+          args
+        )
         const { body, headers } = await meAlertsLoader({
           page,
           size,
+          sort,
           total_count: true,
         })
         const totalCount = parseInt(headers["x-total-count"] || "0", 10)


### PR DESCRIPTION
Couple of little updates that made Force non-stitched alerts work more smoothly re: types, plus the sort support