### PR TITLE
feat(EMI-1710, EMI-1711): add shareableWithPartners to Collections

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4076,6 +4076,7 @@ type Collection {
 
   # True if this collection represents artworks explicitly saved by the user, false otherwise.
   saves: Boolean!
+  shareableWithPartners: Boolean!
 }
 
 enum CollectionArtworkSorts {
@@ -7806,6 +7807,7 @@ type CreateCollectionFailure {
 input createCollectionInput {
   clientMutationId: String
   name: String!
+  shareableWithPartners: Boolean
 }
 
 type createCollectionPayload {

--- a/src/schema/v2/me/__tests__/createCollectionMutation.test.ts
+++ b/src/schema/v2/me/__tests__/createCollectionMutation.test.ts
@@ -4,11 +4,12 @@ import { HTTPError } from "lib/HTTPError"
 
 const mutation = `
   mutation {
-    createCollection(input: { name: "Dining room" }) {
+    createCollection(input: { name: "Dining room", shareableWithPartners: false }) {
       responseOrError {
         ... on CreateCollectionSuccess {
           collection {
             name
+            shareableWithPartners
           }
         }
 
@@ -30,6 +31,7 @@ describe("createCollection", () => {
     const mockGravityResponse = {
       id: "id",
       name: "Dining room",
+      shareable_with_partners: false,
     }
 
     let context: Partial<ResolverContext>
@@ -49,6 +51,7 @@ describe("createCollection", () => {
         user_id: "user-42",
         name: "Dining room",
         saves: true,
+        shareable_with_partners: false,
       })
     })
 
@@ -61,6 +64,7 @@ describe("createCollection", () => {
             "responseOrError": Object {
               "collection": Object {
                 "name": "Dining room",
+                "shareableWithPartners": false,
               },
             },
           },

--- a/src/schema/v2/me/collection.ts
+++ b/src/schema/v2/me/collection.ts
@@ -139,6 +139,12 @@ export const CollectionType = new GraphQLObjectType<any, ResolverContext>({
         return totalCount > 0
       },
     },
+    shareableWithPartners: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      resolve: (collection) => {
+        return collection.shareable_with_partners
+      },
+    },
   }),
 })
 

--- a/src/schema/v2/me/createCollectionMutation.ts
+++ b/src/schema/v2/me/createCollectionMutation.ts
@@ -3,6 +3,7 @@ import {
   GraphQLUnionType,
   GraphQLNonNull,
   GraphQLString,
+  GraphQLBoolean,
 } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 import {
@@ -45,6 +46,7 @@ const ResponseOrErrorType = new GraphQLUnionType({
 
 interface InputProps {
   name: string
+  shareableWithPartners: boolean
 }
 
 export const createCollectionMutation = mutationWithClientMutationId<
@@ -56,6 +58,7 @@ export const createCollectionMutation = mutationWithClientMutationId<
   description: "Create a collection",
   inputFields: {
     name: { type: new GraphQLNonNull(GraphQLString) },
+    shareableWithPartners: { type: GraphQLBoolean },
   },
   outputFields: {
     responseOrError: {
@@ -73,6 +76,7 @@ export const createCollectionMutation = mutationWithClientMutationId<
         name: args.name,
         user_id: context.userID,
         saves: true,
+        shareable_with_partners: args.shareableWithPartners,
       })
 
       return response


### PR DESCRIPTION
Make `shareable_with_partners` available as a not required param for Collections creation. 

Followup from https://github.com/artsy/gravity/pull/17388

![image](https://github.com/artsy/metaphysics/assets/554507/489c20eb-0beb-4100-b717-5427ae979af1)

**Param not given**
![image](https://github.com/artsy/metaphysics/assets/554507/405fbc69-3605-486f-9ed4-6d4fe43dd7ab)
