### PR TITLE
fix(feature-flags): fix feature flag creation responses

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -144,6 +144,8 @@ type AddUserToSubmissionMutationPayload {
 }
 
 type Admin {
+  featureFlag(id: String): FeatureFlag
+
   # A list of feature flags
   featureFlags(
     # The sort order of the results

--- a/src/lib/loaders/loaders_with_authentication/unleash.ts
+++ b/src/lib/loaders/loaders_with_authentication/unleash.ts
@@ -85,8 +85,10 @@ export const unleashLoaders = (accessToken, opts) => {
       { method: "POST" }
     ),
 
-    adminFeatureFlagsLoader: unleashLoader("features"),
-    adminFeatureFlagLoader: unleashLoader((id) => `features/${id}`),
+    adminFeatureFlagsLoader: unleashLoader("projects/default/features"),
+    adminFeatureFlagLoader: unleashLoader(
+      (id) => `projects/default/features/${id}`
+    ),
     adminProjectsLoader: unleashLoader("projects"),
     adminProjectLoader: unleashLoader((id) => `projects/${id}`),
   }

--- a/src/schema/v2/admin/index.ts
+++ b/src/schema/v2/admin/index.ts
@@ -1,12 +1,32 @@
-import { GraphQLFieldConfig, GraphQLObjectType } from "graphql"
+import { GraphQLFieldConfig, GraphQLObjectType, GraphQLString } from "graphql"
 import { ResolverContext } from "types/graphql"
-import { FeatureFlags } from "./featureFlags"
+import { FeatureFlagType, FeatureFlags } from "./featureFlags"
 
 export const AdminField: GraphQLFieldConfig<void, ResolverContext> = {
   type: new GraphQLObjectType<any, ResolverContext>({
     name: "Admin",
     fields: {
       featureFlags: FeatureFlags,
+      featureFlag: {
+        type: FeatureFlagType,
+        args: {
+          id: {
+            type: GraphQLString,
+          },
+        },
+        resolve: async (_args, { id }, { adminFeatureFlagLoader }) => {
+          if (!adminFeatureFlagLoader) {
+            return new Error("You need to be signed in to perform this action")
+          }
+
+          try {
+            const featureFlag = await adminFeatureFlagLoader(id)
+            return featureFlag
+          } catch (error) {
+            throw new Error(JSON.stringify(error))
+          }
+        },
+      },
     },
   }),
   resolve: (x) => x,

--- a/src/schema/v2/admin/mutations/createFeatureFlagMutation.ts
+++ b/src/schema/v2/admin/mutations/createFeatureFlagMutation.ts
@@ -172,8 +172,7 @@ export const createFeatureFlagMutation = mutationWithClientMutationId<
         await addFeatureFlagVariant(args.name, args.variants)
       }
 
-      const featureFlag = await adminFeatureFlagLoader(args.name)
-      return featureFlag
+      return {}
     } catch (error) {
       throw new Error(JSON.stringify(error))
     }


### PR DESCRIPTION
Noticed that creating feature flags was (kinda) broken in forque (would create, but on create it couldnt find the flag), and we needed to update the api path slightly. 