### PR TITLE
fix(feature-flags): Remove non-null on Variants

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9907,7 +9907,6 @@ type FeatureFlag {
     timezone: String
   ): String
   description: String
-  enabled: Boolean!
   environments: [FeatureFlagEnvironments]
 
   # A globally unique ID.
@@ -9925,7 +9924,7 @@ type FeatureFlag {
   project: String!
   stale: Boolean!
   type: String!
-  variants: [FeatureFlagVariantType!]!
+  variants: [FeatureFlagVariantType]
 }
 
 type FeatureFlagEnvironments {
@@ -9964,9 +9963,9 @@ input FeatureFlagVariantInputName {
 }
 
 type FeatureFlagVariantType {
-  name: String!
+  name: String
   stickiness: String
-  weight: Int!
+  weight: Int
   weightType: String
 }
 

--- a/src/schema/v2/admin/featureFlags.ts
+++ b/src/schema/v2/admin/featureFlags.ts
@@ -40,34 +40,27 @@ export const FeatureFlagType = new GraphQLObjectType<any, ResolverContext>({
       type: new GraphQLNonNull(GraphQLString),
     },
     variants: {
-      type: new GraphQLNonNull(
-        new GraphQLList(
-          new GraphQLNonNull(
-            new GraphQLObjectType<any, ResolverContext>({
-              name: "FeatureFlagVariantType",
-              fields: {
-                name: {
-                  type: new GraphQLNonNull(GraphQLString),
-                },
-                weightType: {
-                  type: GraphQLString,
-                },
-                weight: {
-                  type: new GraphQLNonNull(GraphQLInt),
-                },
-                stickiness: {
-                  type: GraphQLString,
-                },
-              },
-            })
-          )
-        )
+      type: new GraphQLList(
+        new GraphQLObjectType<any, ResolverContext>({
+          name: "FeatureFlagVariantType",
+          fields: {
+            name: {
+              type: GraphQLString,
+            },
+            weightType: {
+              type: GraphQLString,
+            },
+            weight: {
+              type: GraphQLInt,
+            },
+            stickiness: {
+              type: GraphQLString,
+            },
+          },
+        })
       ),
     },
     createdAt: date(),
-    enabled: {
-      type: new GraphQLNonNull(GraphQLBoolean),
-    },
     name: {
       type: new GraphQLNonNull(GraphQLString),
     },

--- a/src/schema/v2/admin/index.ts
+++ b/src/schema/v2/admin/index.ts
@@ -1,6 +1,7 @@
 import { GraphQLFieldConfig, GraphQLObjectType, GraphQLString } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { FeatureFlagType, FeatureFlags } from "./featureFlags"
+import { base64 } from "lib/base64"
 
 export const AdminField: GraphQLFieldConfig<void, ResolverContext> = {
   type: new GraphQLObjectType<any, ResolverContext>({
@@ -21,7 +22,11 @@ export const AdminField: GraphQLFieldConfig<void, ResolverContext> = {
 
           try {
             const featureFlag = await adminFeatureFlagLoader(id)
-            return featureFlag
+
+            return {
+              ...featureFlag,
+              id: base64(featureFlag.name), // Relay
+            }
           } catch (error) {
             throw new Error(JSON.stringify(error))
           }


### PR DESCRIPTION
A little more cleanup here, particularly with variants being able to be null. And when fetching an individual FF, we need an ID for relay. 