### PR TITLE
fix Gene Not Found error when calling artwork.savedSearch.suggestedArtworksConnection

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -3427,6 +3427,86 @@ describe("Artwork type", () => {
           aggregations: ["total"],
         })
       })
+
+      describe("when artwork has 'Other' category", () => {
+        it("does not include additional_gene_ids in the filterArtworksLoader call", async () => {
+          const artwork = {
+            id: "portrait-of-cats",
+            artists: [
+              {
+                id: "bitty",
+              },
+              { id: "percy" },
+            ],
+            attribution_class: "unique",
+            category: "Other",
+          }
+          const filterArtworksLoader = jest.fn().mockReturnValue(
+            Promise.resolve({
+              hits: [
+                {
+                  id: "portrait-of-cats-playing-poker",
+                },
+              ],
+              aggregations: {
+                total: {
+                  value: 1,
+                },
+              },
+            })
+          )
+          const context = {
+            artworkLoader: () => Promise.resolve(artwork),
+            unauthenticatedLoaders: {
+              filterArtworksLoader,
+            },
+          }
+          const query = `
+            {
+              artwork(id: "portrait-of-cats") {
+                savedSearch {
+                  suggestedArtworksConnection(first: 1) {
+                    edges {
+                      node {
+                        slug
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          `
+
+          const data = await runQuery(query, context)
+
+          expect(data).toEqual({
+            artwork: {
+              savedSearch: {
+                suggestedArtworksConnection: {
+                  edges: [
+                    {
+                      node: {
+                        slug: "portrait-of-cats-playing-poker",
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          })
+
+          expect(filterArtworksLoader).toHaveBeenCalledWith({
+            artist_ids: ["bitty", "percy"],
+            attribution_class: "unique",
+            exclude_ids: ["portrait-of-cats"],
+            for_sale: true,
+            size: 1,
+            offset: 0,
+            sort: "-published_at",
+            aggregations: ["total"],
+          })
+        })
+      })
     })
   })
 

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1651,7 +1651,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
                 }
 
                 const mediumGene = artworkMediums[artwork.category]
-                if (mediumGene) {
+                if (mediumGene && mediumGene.mediumFilterGeneSlug) {
                   filterArtworksArgs.additional_gene_ids = [
                     mediumGene.mediumFilterGeneSlug,
                   ]


### PR DESCRIPTION
@gkartalis found [this error](https://app.datadoghq.com/apm/services/metaphysics.graphql/operations/graphql.execute/resources?env=production&fromUser=false&graphType=flamegraph&groupMapByOperation=null&panels=qson%3A%28data%3A%28resource%3A%28resourceName%3Aquery%2520ArtworkAboveTheFoldQuery%2528%2524artworkID%253AString%2521%2529%257Bartwork%2528id%253A%2524artworkID%2529%2540principalField%257Bid...Artwork_artworkAboveTheFold%257Dme%257Bid...Artwork_me%257D%257Dfragment%2520ArtworkActions_artwork%2520on%2520Artwork%257BheightCm%2520id%2520image%257Burl%257DisHangable%2520sale%257Bid%2520isAuction%2520isClosed%257Dslug%2520widthCm...ArtworkSaveButton_artwork%257Dfragment%2520ArtworkAuctionBidInfo_artwork%2520on%2520Artwork%257BmyLotStanding%2528live%253Atrue%2529%257BactiveBid%257Bid%2520isWinning%257DmostRecentBid%257Bid%2520internalID%257D%257DsaleArtwork%257Bcounts%257BbidderPositions%257DcurrentBid%257Bdisplay%257Did%257D%257Dfragment%2520ArtworkAuctionCreateAlertHeader_artwork%2520on%2520Artwork%257BartistNames%2520internalID%2520isEligibleToCreateAlert%2520isInAuction%2520myLotStanding%257BisHighestBidder%257Dsale%257Bid%2520isClosed%2520startAt%257DsaleArtwork%257BendAt%2520endedAt%2520extendedBiddingEndAt%2520id%257DsavedSearch%257BsuggestedArtworksConnection%257BtotalCount%257D%257Dslug%2520title...CreateArtworkAlertModal_artwork%257Dfragment%2520ArtworkCommercialButtons_artwork%2520on%2520Artwork%257BeditionSets%257Bid%2520internalID%257DisAcquireable%2520isBuyNowable%2520isInAuction%2520isInquireable%2520isOfferable%2520sale%257Bid%2520internalID%257D...BidButton_artwork...BuyNowButton_artwork...InquiryButtons_artwork...MakeOfferButton_artwork%257Dfragment%2520ArtworkCommercialButtons_me%2520on%2520Me%257B...BidButton_me%257Dfragment%2520ArtworkDetails_artwork%2520on%2520Artwork%257BattributionClass%257Bid%2520name%257DcanRequestLotConditionsReport%2520certificateOfAuthenticity%257Bdetails%2520label%257DconditionDescription%257Bdetails%2520label%257Ddimensions%257Bcm%2520in%257DeditionOf%2520editionSets%257Bid%2520internalID%257Dframed%257Bdetails%2520label%257DimageRights%2520manufacturer%2520medium%2520mediumType%257Bname%257Dpublisher%2520series%2520signatureInfo%257Bdetails%2520label%257Dslug%257Dfragment%2520ArtworkEditionSetInformation_artwork%2520on%2520Artwork%257B...ArtworkEditionSets_artwork%257Dfragment%2520ArtworkEditionSetItem_item%2520on%2520EditionSet%257Bdimensions%257Bcm%2520in%257DeditionOf%2520internalID%2520saleMessage%257Dfragment%2520ArtworkEditionSets_artwork%2520on%2520Artwork%257BeditionSets%257Bid%2520internalID...ArtworkEditionSetItem_item%257D%257Dfragment%2520ArtworkHeader_artwork%2520on%2520Artwork%257Bartists%257Bid%2520name%257Dfigures%257B__typename...ImageCarousel_figures...on%2520Video%257Bid%257D%257Dfigures%257B__typename...on%2520Image%257BimageURL%257D...on%2520Video%257Bid%257D%257Dhref%2520internalID%2520isSetVideoAsCover%2520partner%257Bid%2520name%257Dslug%2520title%2520visibilityLevel...ArtworkActions_artwork...ArtworkTombstone_artwork%257Dfragment%2520ArtworkLotDetails_artwork%2520on%2520Artwork%257Bartist%257Bid%2520name%257DisForSale%2520sale%257BcascadingEndTimeIntervalMinutes%2520id%2520internalID%2520isBenefit%2520isWithBuyersPremium%2520partner%257Bid%2520name%257D...LotCascadingEndTimesBanner_sale%257DsaleArtwork%257BcurrentBid%257Bdisplay%257Destimate%2520id%257Dtitle...LotCurrentBidInfo_artwork...LotEndDateTime_artwork...LotUpcomingLiveDateTime_artwork%257Dfragment%2520ArtworkLotTimer_artwork%2520on%2520Artwork%257BisForSale%2520isInAuction%2520sale%257BcascadingEndTimeIntervalMinutes%2520endAt%2520extendedBiddingIntervalMinutes%2520extendedBiddingPeriodMinutes%2520id%2520internalID%2520isClosed%2520isPreview%2520liveStartAt%2520startAt%257DsaleArtwork%257BendAt%2520endedAt%2520extendedBiddingEndAt%2520id%2520lotID%2520lotLabel%2528trim%253Atrue%2529%257D%257Dfragment%2520ArtworkMakerTitle_artwork%2520on%2520Artwork%257Bartists%257Bhref%2520id%2520name%257DculturalMaker%257Dfragment%2520ArtworkPrice_artwork%2520on%2520Artwork%257Bavailability%2520editionSets%257Bid%2520internalID%2520saleMessage%257DisEligibleForOnPlatformTransaction%2520isInAuction%2520isPriceHidden%2520saleMessage%2520taxInfo%257BdisplayText%257D...ArtworkAuctionBidInfo_artwork%257Dfragment%2520ArtworkSaveButton_artwork%2520on%2520Artwork%257Bsale%257Bid%2520isAuction%2520isClosed%257D...useSaveArtworkToArtworkLists_artwork%257Dfragment%2520ArtworkScreenHeaderCreateAlert_artwork%2520on%2520Artwork%257Bartists%257Bid%2520internalID%257DisEligibleToCreateAlert%2520isForSale%2520isInAuction%2520sale%257Bid%2520isClosed%2520startAt%257DsaleArtwork%257BendAt%2520endedAt%2520extendedBiddingEndAt%2520id%257D...CreateArtworkAlertModal_artwork%257Dfragment%2520ArtworkScreenHeader_artwork%2520on%2520Artwork%257B...ArtworkScreenHeaderCreateAlert_artwork%257Dfragment%2520ArtworkStickyBottomContent_artwork%2520on%2520Artwork%257BisForSale%2520isSold%2520saleArtwork%257BendAt%2520extendedBiddingEndAt%2520id%257D...ArtworkCommercialButtons_artwork...ArtworkPrice_artwork%257Dfragment%2520ArtworkStickyBottomContent_me%2520on%2520Me%257B...ArtworkCommercialButtons_me%257Dfragment%2520ArtworkTombstone_artwork%2520on%2520Artwork%257Bdate%2520isForSale%2520saleMessage%2520title...ArtworkLotTimer_artwork...ArtworkMakerTitle_artwork%257Dfragment%2520Artwork_artworkAboveTheFold%2520on%2520Artwork%257Bavailability%2520editionSets%257Bid%2520internalID%257DinternalID%2520isAcquireable%2520isBiddable%2520isInAuction%2520isInquireable%2520isOfferable%2520sale%257Bid%2520internalID%2520isClosed%2520isPreview%2520liveStartAt%257DsaleArtwork%257Bid%2520internalID%257Dslug...ArtworkAuctionCreateAlertHeader_artwork...ArtworkDetails_artwork...ArtworkEditionSetInformation_artwork...ArtworkHeader_artwork...ArtworkLotDetails_artwork...ArtworkScreenHeader_artwork...ArtworkStickyBottomContent_artwork%257Dfragment%2520Artwork_me%2520on%2520Me%257B...ArtworkStickyBottomContent_me%257Dfragment%2520BidButton_artwork%2520on%2520Artwork%257BmyLotStanding%2528live%253Atrue%2529%257BmostRecentBid%257Bid%2520maxBid%257Bcents%257D%257D%257Dsale%257Bid%2520isClosed%2520isLiveOpen%2520isPreview%2520isRegistrationClosed%2520registrationStatus%257Bid%2520qualifiedForBidding%257DrequireIdentityVerification%2520slug%257DsaleArtwork%257Bid%2520increments%257Bcents%257D%257Dslug%257Dfragment%2520BidButton_me%2520on%2520Me%257BisIdentityVerified%257Dfragment%2520BuyNowButton_artwork%2520on%2520Artwork%257BinternalID%2520saleMessage%2520slug%257Dfragment%2520CollapsibleArtworkDetails_artwork%2520on%2520Artwork%257BartistNames%2520attributionClass%257Bid%2520name%257Dcategory%2520certificateOfAuthenticity%257Bdetails%257DconditionDescription%257Bdetails%257Ddate%2520dimensions%257Bcm%2520in%257Dframed%257Bdetails%257Dimage%257Bheight%2520url%2520width%257DinternalID%2520manufacturer%2520medium%2520publisher%2520saleMessage%2520signatureInfo%2CresourceID%3Aff52c1818c84a037%29%2Ctrace%3A%28traceID%3A9005280360986548556%2CspanID%3A8951714851845271966%29%2CactivePanelKey%3Atrace%29%2Cversion%3A%210%29&resources=qson%3A%28data%3A%28visible%3A%21t%2Chits%3A%28selected%3Atotal%29%2Cerrors%3A%28selected%3Atotal%29%2Clatency%3A%28selected%3Ap95%29%2CtopN%3A%215%2Csearch%3Aartworkabovethefold%29%2Cversion%3A%211%29&shouldShowLegend=true&sort=time&spanID=8313829176784717610&spanViewType=errors&summary=qson%3A%28data%3A%28visible%3A%21t%2Cerrors%3A%28selected%3Acount%29%2Chits%3A%28selected%3Acount%29%2Clatency%3A%28selected%3Alatency%2Cslot%3A%28agg%3A95%29%2Cdistribution%3A%28isLogScale%3A%21f%29%2CshowTraceOutliers%3A%21t%29%2Csublayer%3A%28slot%3A%28layers%3Aservice%29%2Cselected%3Apercentage%29%29%2Cversion%3A%211%29&topGraphs=latency%3Alatency%2Chits%3Aversion_count%2Cerrors%3Aversion_count%2CbreakdownAs%3Apercentage&view=spans&start=1709204030607&end=1709207630607&paused=true) in Datadog.

When artwork has "Other" category, we make filter artworks request with `additional_gene_ids[]=` parameter (it happens because [here](https://github.com/artsy/metaphysics/blob/main/src/lib/artworkMediums.ts#L86) Other category has `mediumFilterGeneSlug: null`). Gravity doesn't handle such empty parameter well - it returns "Gene Not Found" error. I think we should omit adding addinional_gene_ids in such cases.