### PR TITLE
feat: allow querying alerts by search criteria

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12031,6 +12031,7 @@ type Me implements Node {
   alert(id: String!): Alert
   alertsConnection(
     after: String
+    attributes: PreviewSavedSearchAttributes
     before: String
     first: Int
     last: Int

--- a/src/schema/v2/me/__tests__/index.test.ts
+++ b/src/schema/v2/me/__tests__/index.test.ts
@@ -465,6 +465,84 @@ describe("me/index", () => {
         }
       `)
     })
+
+    it("calls gravity with the correct params", async () => {
+      const query = gql`
+        query {
+          me {
+            alertsConnection(
+              first: 1
+              sort: ENABLED_AT_DESC
+              attributes: {
+                acquireable: true
+                additionalGeneIDs: ["gene1", "gene2"]
+                artistIDs: ["kaws", "banksy"]
+                artistSeriesIDs: ["series1", "series2"]
+                atAuction: true
+                attributionClass: ["unique", "limited edition"]
+                colors: ["blue", "red"]
+                height: "10"
+                inquireableOnly: true
+                locationCities: ["New York", "Los Angeles"]
+                majorPeriods: ["period1", "period2"]
+                materialsTerms: ["oil", "canvas"]
+                offerable: true
+                partnerIDs: ["partner1", "partner2"]
+                priceRange: "*-1000"
+                sizes: [SMALL, MEDIUM]
+                width: "10"
+              }
+            ) {
+              totalCount
+              edges {
+                node {
+                  internalID
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const meLoader = () => Promise.resolve({})
+      const meAlertsLoader = jest.fn().mockReturnValue(
+        Promise.resolve({
+          body: [],
+          headers: { "x-total-count": "0" },
+        })
+      )
+
+      await runAuthenticatedQuery(query, {
+        meLoader,
+        meAlertsLoader,
+      })
+
+      expect(meAlertsLoader).toHaveBeenCalledWith({
+        page: 1,
+        search_criteria: {
+          acquireable: true,
+          additional_gene_ids: ["gene1", "gene2"],
+          artist_ids: ["kaws", "banksy"],
+          artist_series_ids: ["series1", "series2"],
+          at_auction: true,
+          attribution_class: ["unique", "limited edition"],
+          colors: ["blue", "red"],
+          height: "10",
+          inquireable_only: true,
+          location_cities: ["New York", "Los Angeles"],
+          major_periods: ["period1", "period2"],
+          materials_terms: ["oil", "canvas"],
+          offerable: true,
+          partner_ids: ["partner1", "partner2"],
+          price_range: "*-1000",
+          sizes: ["small", "medium"],
+          width: "10",
+        },
+        size: 1,
+        sort: "-enabled_at",
+        total_count: true,
+      })
+    })
   })
 
   describe("alert", () => {

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -72,6 +72,7 @@ import { NotificationType } from "../notifications"
 import {
   DEFAULT_CURRENCY_PREFERENCE,
   DEFAULT_LENGTH_UNIT_PREFERENCE,
+  snakeCaseKeys,
 } from "lib/helpers"
 import {
   AlertType,
@@ -82,6 +83,7 @@ import {
 import { emptyConnection, paginationResolver } from "../fields/pagination"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { pageable } from "relay-cursor-paging"
+import { PreviewSavedSearchAttributesType } from "../previewSavedSearch"
 
 /**
  * @deprecated: Please use the CollectorProfile type instead of adding fields to me directly.
@@ -152,6 +154,9 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
         sort: {
           type: AlertsConnectionSortEnum,
         },
+        attributes: {
+          type: PreviewSavedSearchAttributesType,
+        },
       }),
       type: new GraphQLNonNull(AlertsConnectionType),
       resolve: async (_parent, args, { meAlertsLoader }) => {
@@ -159,11 +164,18 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
         const { page, size, offset, sort } = convertConnectionArgsToGravityArgs(
           args
         )
+
+        // Convert artistIDs to artist_ids, etc.
+        const gravitySearchCriteriaAttributes = snakeCaseKeys(
+          args.attributes
+        ) as any
+
         const { body, headers } = await meAlertsLoader({
           page,
           size,
           sort,
           total_count: true,
+          search_criteria: gravitySearchCriteriaAttributes,
         })
         const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 

--- a/src/schema/v2/previewSavedSearch/previewSavedSearch.ts
+++ b/src/schema/v2/previewSavedSearch/previewSavedSearch.ts
@@ -113,7 +113,7 @@ const PreviewSavedSearchType = new GraphQLObjectType<any, ResolverContext>({
   }),
 })
 
-const PreviewSavedSearchAttributesType = new GraphQLInputObjectType({
+export const PreviewSavedSearchAttributesType = new GraphQLInputObjectType({
   name: "PreviewSavedSearchAttributes",
   fields: previewSavedSearchArgs,
 })


### PR DESCRIPTION
[Context for this PR](https://github.com/artsy/gravity/pull/17398)

Adds support for filtering alerts by search criteria attributes:

```graphql
query X {
  me {
    email
    
    alertsConnection(first: 1, attributes: { artistIDs: ["kaws"], acquireable: true }) {
      edges {
        node {
          displayName
        }
      }
    }
  }
}
```