### PR TITLE
feat(me): exposes followed profiles count

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12601,6 +12601,9 @@ type Me implements Node {
 
 type MeCounts {
   followedArtists: Int!
+
+  # Returns the total count of followed profiles. There is currently no way to filter this count by `owner_type`.
+  followedProfiles: Int!
   savedArtworks: Int!
   savedSearches: Int!
 }

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -250,6 +250,27 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
               }
             },
           },
+          followedProfiles: {
+            type: new GraphQLNonNull(GraphQLInt),
+            description:
+              "Returns the total count of followed profiles. There is currently no way to filter this count by `owner_type`.",
+            resolve: async (_me, { followedPartnersLoader }) => {
+              if (!followedPartnersLoader) return 0
+
+              try {
+                const { headers } = await followedPartnersLoader({
+                  page: 1,
+                  size: 1,
+                  total_count: true,
+                })
+
+                return headers["x-total-count"] ?? 0
+              } catch (error) {
+                console.error(error)
+                return 0
+              }
+            },
+          },
           savedArtworks: {
             type: new GraphQLNonNull(GraphQLInt),
             resolve: async (_me, _args, { collectionArtworksLoader }) => {


### PR DESCRIPTION
Closes [DIA-513](https://artsyproduct.atlassian.net/browse/DIA-513)

This endpoint filters items post-query so it doesn't affect the total count: https://github.com/artsy/gravity/blob/72e34e75f2b6f05ba0e97873300220176e7173eb/app/api/v1/me_follow_profiles_endpoint.rb#L32

This seems like a bug to me but, in practice I don't think it matters much for our purposes at the moment.