### PR TITLE
feat(collectorInterestsConnection): move collectorInterestsConnection to the Conversation type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7386,6 +7386,12 @@ type Conversation implements Node {
     # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String
+  collectorInterestsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): UserInterestConnection
 
   # The collector profile of the user who initiated the conversation. Do not use this field for Partners
   collectorResume: CollectorResume


### PR DESCRIPTION
`interetsConnection` is not fully working with Relay pagination when under `CollectorProfileType`, this PR moves it and renames it for better understanding to the `Conversation` type.