### PR TITLE
feat(messages): Add sentAt and messageSentOnPlatform

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12717,6 +12717,17 @@ type Message implements Node {
       reason: "Payment Request was deprecated. The field was kept for legacy client support. [Will be removed in v2]"
     )
 
+  # True if message was sent on the platform. False if sent via an email client.
+  isMessageSentOnPlatform: Boolean
+  sentAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See
+    # http://www.iana.org/time-zones,
+    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+
   # Masked emails w/ display name of the recipients.
   to: [String!]!
 }

--- a/src/schema/v2/conversation/message.ts
+++ b/src/schema/v2/conversation/message.ts
@@ -133,7 +133,14 @@ export const MessageType = new GraphQLObjectType<any, ResolverContext>({
       }),
       resolve: ({ metadata }) => isInvoiceMessage(metadata),
     },
+    isMessageSentOnPlatform: {
+      description:
+        "True if message was sent on the platform. False if sent via an email client.",
+      type: GraphQLBoolean,
+      resolve: ({ sent_at }) => !!sent_at,
+    },
     createdAt: date(),
+    sentAt: date(),
     to: {
       description: "Masked emails w/ display name of the recipients.",
       type: new GraphQLNonNull(


### PR DESCRIPTION
This updates our schema to account for `sentAt`, so we can distinguish between messages sent on platform or via email. 

This will help us distinguish when we need to make wide conversation bubbles in Convos clients in partner / collector apps.

cc @artsy/amber-devs 