### PR TITLE
feat: add support for auction lot new-for-you recommendations

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15755,6 +15755,7 @@ type Query {
     last: Int
     marketable: Boolean
     maxWorksPerArtist: Int
+    onlyAtAuction: Boolean = false
     page: Int
     userId: String
     version: String
@@ -20578,6 +20579,7 @@ type Viewer {
     last: Int
     marketable: Boolean
     maxWorksPerArtist: Int
+    onlyAtAuction: Boolean = false
     page: Int
     userId: String
     version: String

--- a/src/lib/loaders/loaders_with_authentication/vortex.ts
+++ b/src/lib/loaders/loaders_with_authentication/vortex.ts
@@ -95,6 +95,9 @@ export default (accessToken, opts) => {
     vortexTokenLoader,
     vortexGraphqlLoader,
     marketPriceInsightsBatchLoader,
+    auctionLotRecommendationsLoader: vortexLoader(
+      "auction_lot_recommendations"
+    ),
   }
 }
 

--- a/src/lib/loaders/loaders_without_authentication/vortex.ts
+++ b/src/lib/loaders/loaders_without_authentication/vortex.ts
@@ -6,11 +6,13 @@ interface GraphQLArgs {
 }
 
 export default (opts) => {
-  const { vortexLoaderWithoutAuthenticationFactory } = factories(opts)
+  const { vortexLoaderWithoutAuthenticationFactory: vortexLoader } = factories(
+    opts
+  )
 
   return {
     vortexGraphqlLoader: ({ query, variables }: GraphQLArgs) => {
-      return vortexLoaderWithoutAuthenticationFactory(
+      return vortexLoader(
         "/graphql",
         { query, variables: JSON.stringify(variables) },
         {
@@ -18,5 +20,8 @@ export default (opts) => {
         }
       )
     },
+    auctionLotRecommendationsLoader: vortexLoader(
+      "auction_lot_recommendations"
+    ),
   }
 }

--- a/src/schema/v2/artworksForUser/__tests__/artworksForUser.test.ts
+++ b/src/schema/v2/artworksForUser/__tests__/artworksForUser.test.ts
@@ -53,19 +53,6 @@ const buildContext = (responses: any = {}) => {
 }
 
 describe("artworksForUser", () => {
-  describe("with no artworksLoader", () => {
-    it("returns null", async () => {
-      const query = buildQuery()
-      const context = {
-        ...buildContext(),
-        artworksLoader: undefined,
-      }
-
-      const response = await runAuthenticatedQuery(query, context)
-      expect(response.artworksForUser).toBeNull()
-    })
-  })
-
   describe("with no artwork recommendations", () => {
     it("returns an empty array", async () => {
       const query = buildQuery()

--- a/src/schema/v2/artworksForUser/__tests__/helpers.test.ts
+++ b/src/schema/v2/artworksForUser/__tests__/helpers.test.ts
@@ -1,7 +1,7 @@
 import {
   getBackfillArtworks,
   getNewForYouArtworks,
-  getNewForYouRecs,
+  getNewForYouArtworkIDs,
 } from "../helpers"
 
 const mockLoaderFactory = (affinities) => {
@@ -29,7 +29,7 @@ describe("getNewForYouRecs", () => {
       },
     } as any
 
-    const artworkIds = await getNewForYouRecs({}, context)
+    const artworkIds = await getNewForYouArtworkIDs({}, context)
 
     expect(artworkIds).toEqual(["banksy"])
   })
@@ -120,6 +120,7 @@ describe("getBackfillArtworks", () => {
     const context = {
       setsLoader: mockSetsLoader,
       setItemsLoader: mockSetItemsLoader,
+      unauthenticatedLoaders: {},
     } as any
 
     const backfillArtworks = await getBackfillArtworks(
@@ -131,6 +132,30 @@ describe("getBackfillArtworks", () => {
     expect(backfillArtworks.length).toEqual(1)
   })
 
+  it("returns backfilled from a collection for auction artworks", async () => {
+    const mockFilterArtworksLoader = jest.fn(() => ({
+      hits: [{ id: "backfill-artwork-id" }],
+    }))
+    const remainingSize = 1
+    const includeBackfill = true
+    const context = {
+      unauthenticatedLoaders: {
+        filterArtworksLoader: mockFilterArtworksLoader,
+      },
+    } as any
+
+    const backfillArtworks = await getBackfillArtworks(
+      remainingSize,
+      includeBackfill,
+      context,
+      true
+    )
+
+    expect(backfillArtworks.map((artwork) => artwork.id)).toEqual([
+      "backfill-artwork-id",
+    ])
+  })
+
   it("returns no more backfill than the remaining size asks for", async () => {
     const mockSetsLoader = jest.fn(() => ({ body: [{ id: "valid_id" }] }))
     const mockSetItemsLoader = jest.fn(() => ({ body: [{}, {}] }))
@@ -139,6 +164,7 @@ describe("getBackfillArtworks", () => {
     const context = {
       setsLoader: mockSetsLoader,
       setItemsLoader: mockSetItemsLoader,
+      unauthenticatedLoaders: {},
     } as any
 
     const backfillArtworks = await getBackfillArtworks(

--- a/src/schema/v2/artworksForUser/artworksForUser.ts
+++ b/src/schema/v2/artworksForUser/artworksForUser.ts
@@ -14,7 +14,7 @@ import { artworkConnection } from "schema/v2/artwork"
 import {
   getBackfillArtworks,
   getNewForYouArtworks,
-  getNewForYouRecs,
+  getNewForYouArtworkIDs,
 } from "./helpers"
 
 const MAX_ARTWORKS = 100
@@ -29,11 +29,13 @@ export const artworksForUser: GraphQLFieldConfig<void, ResolverContext> = {
     version: { type: GraphQLString },
     maxWorksPerArtist: { type: GraphQLInt },
     marketable: { type: GraphQLBoolean },
+    onlyAtAuction: {
+      type: GraphQLBoolean,
+      defaultValue: false,
+    },
   }),
   resolve: async (_root, args: CursorPageable, context) => {
-    if (!context.artworksLoader) return
-
-    const newForYouArtworkIds = await getNewForYouRecs(args, context)
+    const newForYouArtworkIds = await getNewForYouArtworkIDs(args, context)
 
     const gravityArgs = convertConnectionArgsToGravityArgs(args)
     const { page, size, offset } = gravityArgs
@@ -51,7 +53,8 @@ export const artworksForUser: GraphQLFieldConfig<void, ResolverContext> = {
     const backfillArtworks = await getBackfillArtworks(
       remainingSize,
       args.includeBackfill,
-      context
+      context,
+      args.onlyAtAuction
     )
 
     const artworks = [...newForYouArtworks, ...backfillArtworks]


### PR DESCRIPTION
There is existing code to support the current recs + backfill w/ some helpers. That code generally winds up being pretty different than what we want for auction lot recommendations (different backfill methodology, using Vortex GraphQL instead of REST), so the general approach here was to add the new argument (`includeAuctionArtworks`), and thread it through to the two helpers used (fetching artwork id's from Vortex, and fetching backfill works if required), and branch there.
