### PR TITLE
feat(EMI-1727): create updateCollectionsMutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4108,6 +4108,11 @@ type CollectionsEdge {
   node: Collection
 }
 
+input CollectionsInput {
+  id: String!
+  shareableWithPartners: Boolean!
+}
+
 enum CollectionSorts {
   CREATED_AT_ASC
   CREATED_AT_DESC
@@ -13423,6 +13428,11 @@ type Mutation {
   # Update a collection
   updateCollection(input: updateCollectionInput!): updateCollectionPayload
 
+  # Updates the user's collections in batch.
+  updateCollectionsMutation(
+    input: updateCollectionsMutationInput!
+  ): updateCollectionsMutationPayload
+
   # Updating a collector profile (loyalty applicant status).
   updateCollectorProfile(
     input: UpdateCollectorProfileInput!
@@ -18878,6 +18888,28 @@ type updateCollectionPayload {
 union UpdateCollectionResponseOrError =
     UpdateCollectionFailure
   | UpdateCollectionSuccess
+
+type UpdateCollectionsFailure {
+  mutationError: GravityMutationError
+}
+
+input updateCollectionsMutationInput {
+  attributes: [CollectionsInput!]!
+  clientMutationId: String
+}
+
+type updateCollectionsMutationPayload {
+  clientMutationId: String
+  collectionsOrErrors: [UpdateCollectionsResponseOrError!]!
+}
+
+union UpdateCollectionsResponseOrError =
+    UpdateCollectionsFailure
+  | UpdateCollectionsSuccess
+
+type UpdateCollectionsSuccess {
+  collection: Collection
+}
 
 type UpdateCollectionSuccess {
   collection: Collection

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4108,11 +4108,6 @@ type CollectionsEdge {
   node: Collection
 }
 
-input CollectionsInput {
-  id: String!
-  shareableWithPartners: Boolean!
-}
-
 enum CollectionSorts {
   CREATED_AT_ASC
   CREATED_AT_DESC
@@ -13428,11 +13423,6 @@ type Mutation {
   # Update a collection
   updateCollection(input: updateCollectionInput!): updateCollectionPayload
 
-  # Updates the user's collections in batch.
-  updateCollectionsMutation(
-    input: updateCollectionsMutationInput!
-  ): updateCollectionsMutationPayload
-
   # Updating a collector profile (loyalty applicant status).
   updateCollectorProfile(
     input: UpdateCollectorProfileInput!
@@ -13466,6 +13456,11 @@ type Mutation {
   updateHeroUnit(
     input: UpdateHeroUnitMutationInput!
   ): UpdateHeroUnitMutationPayload
+
+  # Updates the user's collections in batch.
+  updateMeCollectionsMutation(
+    input: updateMeCollectionsMutationInput!
+  ): updateMeCollectionsMutationPayload
 
   # Update a message.
   updateMessage(
@@ -18889,28 +18884,6 @@ union UpdateCollectionResponseOrError =
     UpdateCollectionFailure
   | UpdateCollectionSuccess
 
-type UpdateCollectionsFailure {
-  mutationError: GravityMutationError
-}
-
-input updateCollectionsMutationInput {
-  attributes: [CollectionsInput!]!
-  clientMutationId: String
-}
-
-type updateCollectionsMutationPayload {
-  clientMutationId: String
-  collectionsOrErrors: [UpdateCollectionsResponseOrError!]!
-}
-
-union UpdateCollectionsResponseOrError =
-    UpdateCollectionsFailure
-  | UpdateCollectionsSuccess
-
-type UpdateCollectionsSuccess {
-  collection: Collection
-}
-
 type UpdateCollectionSuccess {
   collection: Collection
 }
@@ -19201,6 +19174,33 @@ union updateHeroUnitResponseOrError =
 
 type updateHeroUnitSuccess {
   heroUnit: HeroUnit
+}
+
+input UpdateMeCollectionInput {
+  id: String!
+  shareableWithPartners: Boolean!
+}
+
+type UpdateMeCollectionsFailure {
+  mutationError: GravityMutationError
+}
+
+input updateMeCollectionsMutationInput {
+  attributes: [UpdateMeCollectionInput!]!
+  clientMutationId: String
+}
+
+type updateMeCollectionsMutationPayload {
+  clientMutationId: String
+  meCollectionsOrErrors: [UpdateMeCollectionsResponseOrError!]!
+}
+
+union UpdateMeCollectionsResponseOrError =
+    UpdateMeCollectionsFailure
+  | UpdateMeCollectionsSuccess
+
+type UpdateMeCollectionsSuccess {
+  collection: Collection
 }
 
 type UpdateMessageFailure {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -448,6 +448,11 @@ export default (accessToken, userID, opts) => {
     ),
     meBidderPositionsLoader: gravityLoader("me/bidder_positions"),
     meBiddersLoader: gravityLoader("me/bidders"),
+    meUpdateCollectionsLoader: gravityLoader(
+      "me/collections",
+      {},
+      { method: "PUT" }
+    ),
     meCollectorProfileLoader: gravityLoader("me/collector_profile"),
     meCreateAlertLoader: gravityLoader("me/alert", {}, { method: "POST" }),
     meCreateUserInterestLoader: gravityLoader(

--- a/src/schema/v2/me/__tests__/updateCollectionsMutation.test.ts
+++ b/src/schema/v2/me/__tests__/updateCollectionsMutation.test.ts
@@ -1,0 +1,103 @@
+import gql from "lib/gql"
+import { HTTPError } from "lib/HTTPError"
+import { runAuthenticatedQuery, runQuery } from "schema/v2/test/utils"
+
+describe("updateMeCollectionsMutation", () => {
+  const mutation = gql`
+    mutation {
+      updateMeCollectionsMutation(
+        input: {
+          attributes: [
+            { id: "collection-id-1", shareableWithPartners: true }
+            { id: "collection-id-2", shareableWithPartners: false }
+          ]
+        }
+      ) {
+        meCollectionsOrErrors {
+          ... on UpdateMeCollectionsSuccess {
+            collection {
+              shareableWithPartners
+            }
+          }
+          ... on UpdateMeCollectionsFailure {
+            mutationError {
+              type
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  const mockCollections = [
+    { id: "collection-id-1", shareable_with_partners: true },
+    { id: "collection-id-2", shareable_with_partners: false },
+  ]
+
+  it("calls the expected loader with correctly formatted params", async () => {
+    const mockUpdateMeCollectionsLoader = jest.fn(() =>
+      Promise.resolve(mockCollections)
+    )
+
+    const context = { meUpdateCollectionsLoader: mockUpdateMeCollectionsLoader }
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(mockUpdateMeCollectionsLoader).toBeCalledWith({
+      attributes: JSON.stringify(mockCollections),
+    })
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        updateMeCollectionsMutation: {
+          meCollectionsOrErrors: [
+            {
+              collection: {
+                shareableWithPartners: true,
+              },
+            },
+            {
+              collection: {
+                shareableWithPartners: false,
+              },
+            },
+          ],
+        },
+      })
+    )
+  })
+
+  it("throws error when data loader is missing", async () => {
+    const errorResponse = "You need to be signed in to perform this action"
+
+    try {
+      await runQuery(mutation)
+      throw new Error("An error was not thrown but was expected.")
+    } catch (error) {
+      // eslint-disable-next-line jest/no-conditional-expect, jest/no-try-expect
+      expect(error.message).toEqual(errorResponse)
+    }
+  })
+
+  it("returns gravity errors", async () => {
+    const context = {
+      meUpdateCollectionsLoader: () =>
+        Promise.reject(new HTTPError(`Oops`, 500, "Error from API")),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      updateMeCollectionsMutation: {
+        meCollectionsOrErrors: [
+          {
+            mutationError: {
+              message: "Error from API",
+              type: "error",
+            },
+          },
+        ],
+      },
+    })
+  })
+})

--- a/src/schema/v2/me/updateCollectionsMutation.ts
+++ b/src/schema/v2/me/updateCollectionsMutation.ts
@@ -17,7 +17,7 @@ import {
 import { snakeCase } from "lodash"
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
-  name: "UpdateCollectionsSuccess",
+  name: "UpdateMeCollectionsSuccess",
   isTypeOf: (data) => data.id,
   fields: () => ({
     collection: {
@@ -28,7 +28,7 @@ const SuccessType = new GraphQLObjectType<any, ResolverContext>({
 })
 
 const FailureType = new GraphQLObjectType<any, ResolverContext>({
-  name: "UpdateCollectionsFailure",
+  name: "UpdateMeCollectionsFailure",
   isTypeOf: (data) => data._type === "GravityMutationError",
   fields: () => ({
     mutationError: {
@@ -39,12 +39,12 @@ const FailureType = new GraphQLObjectType<any, ResolverContext>({
 })
 
 const ResponseOrErrorType = new GraphQLUnionType({
-  name: "UpdateCollectionsResponseOrError",
+  name: "UpdateMeCollectionsResponseOrError",
   types: [SuccessType, FailureType],
 })
 
-export const CollectionsInputType = new GraphQLInputObjectType({
-  name: "CollectionsInput",
+export const UpdateMeCollectionInput = new GraphQLInputObjectType({
+  name: "UpdateMeCollectionInput",
   fields: {
     id: {
       type: new GraphQLNonNull(GraphQLString),
@@ -55,22 +55,22 @@ export const CollectionsInputType = new GraphQLInputObjectType({
   },
 })
 
-export const updateCollectionsMutation = mutationWithClientMutationId<
+export const updateMeCollectionsMutation = mutationWithClientMutationId<
   any,
   any | null,
   ResolverContext
 >({
-  name: "updateCollectionsMutation",
+  name: "updateMeCollectionsMutation",
   description: "Updates the user's collections in batch.",
   inputFields: {
     attributes: {
       type: new GraphQLNonNull(
-        new GraphQLList(new GraphQLNonNull(CollectionsInputType))
+        new GraphQLList(new GraphQLNonNull(UpdateMeCollectionInput))
       ),
     },
   },
   outputFields: {
-    collectionsOrErrors: {
+    meCollectionsOrErrors: {
       type: new GraphQLNonNull(
         new GraphQLList(new GraphQLNonNull(ResponseOrErrorType))
       ),

--- a/src/schema/v2/me/updateCollectionsMutation.ts
+++ b/src/schema/v2/me/updateCollectionsMutation.ts
@@ -1,0 +1,105 @@
+import {
+  GraphQLNonNull,
+  GraphQLList,
+  GraphQLString,
+  GraphQLBoolean,
+  GraphQLInputObjectType,
+  GraphQLObjectType,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import { CollectionType } from "./collection"
+import {
+  GravityMutationErrorType,
+  formatGravityError,
+} from "lib/gravityErrorHandler"
+import { snakeCase } from "lodash"
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateCollectionsSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    collection: {
+      type: CollectionType,
+      resolve: (response) => response,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateCollectionsFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdateCollectionsResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const CollectionsInputType = new GraphQLInputObjectType({
+  name: "CollectionsInput",
+  fields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    shareableWithPartners: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+    },
+  },
+})
+
+export const updateCollectionsMutation = mutationWithClientMutationId<
+  any,
+  any | null,
+  ResolverContext
+>({
+  name: "updateCollectionsMutation",
+  description: "Updates the user's collections in batch.",
+  inputFields: {
+    attributes: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(CollectionsInputType))
+      ),
+    },
+  },
+  outputFields: {
+    collectionsOrErrors: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(ResponseOrErrorType))
+      ),
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (args, { meUpdateCollectionsLoader }) => {
+    if (!meUpdateCollectionsLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    const gravityPayload = args.attributes.map((collection) => {
+      return Object.keys(collection).reduce(
+        (acc, key) => ({ ...acc, [snakeCase(key)]: collection[key] }),
+        {}
+      )
+    })
+
+    try {
+      return await meUpdateCollectionsLoader({
+        attributes: JSON.stringify(gravityPayload),
+      })
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return [{ ...formattedErr, _type: "GravityMutationError" }]
+      } else {
+        return [{ message: error.message, _type: "GravityMutationError" }]
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -216,7 +216,7 @@ import { createAlertMutation } from "./Alerts/createAlertMutation"
 import { updateAlertMutation } from "./Alerts/updateAlertMutation"
 import { deleteAlertMutation } from "./Alerts/deleteAlertMutation"
 import { ArtworkResult } from "./artworkResult"
-import { updateCollectionsMutation } from "./me/updateCollectionsMutation"
+import { updateMeCollectionsMutation } from "./me/updateCollectionsMutation"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -436,7 +436,7 @@ export default new GraphQLSchema({
       updateArtwork: updateArtworkMutation,
       updateCMSLastAccessTimestamp: updateCMSLastAccessTimestampMutation,
       updateCollection: updateCollectionMutation,
-      updateCollectionsMutation: updateCollectionsMutation,
+      updateMeCollectionsMutation: updateMeCollectionsMutation,
       updateCollectorProfile: UpdateCollectorProfile,
       updateCollectorProfileWithID: UpdateCollectorProfileWithID,
       updateConversation: UpdateConversationMutation,

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -216,6 +216,7 @@ import { createAlertMutation } from "./Alerts/createAlertMutation"
 import { updateAlertMutation } from "./Alerts/updateAlertMutation"
 import { deleteAlertMutation } from "./Alerts/deleteAlertMutation"
 import { ArtworkResult } from "./artworkResult"
+import { updateCollectionsMutation } from "./me/updateCollectionsMutation"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -435,6 +436,7 @@ export default new GraphQLSchema({
       updateArtwork: updateArtworkMutation,
       updateCMSLastAccessTimestamp: updateCMSLastAccessTimestampMutation,
       updateCollection: updateCollectionMutation,
+      updateCollectionsMutation: updateCollectionsMutation,
       updateCollectorProfile: UpdateCollectorProfile,
       updateCollectorProfileWithID: UpdateCollectorProfileWithID,
       updateConversation: UpdateConversationMutation,


### PR DESCRIPTION
Port the work done at https://github.com/artsy/gravity/pull/17431 to metaphysics.

Example request for reference:
```
  mutation {
    updateMeCollectionsMutation(
      input: {
        attributes: [
          {
            id: ""
            shareableWithPartners: false
          },
          {
            id: ""
            shareableWithPartners: true
          },
        ]
      }
    ) {
      meCollectionsOrErrors {
        ... on UpdateMeCollectionsSuccess {
          collection {
            id
          	shareableWithPartners
            name
            artworksCount
          }
        }
        ... on UpdateMeCollectionsFailure {
          mutationError {
            type
            message
          }
        }
      }
    }
  }
```

Successful request
![SCR-20240325-owt](https://github.com/artsy/metaphysics/assets/554507/5219a374-a6d7-4f5b-be0f-6860c88a7ff8)

Failed request
![SCR-20240325-ox2](https://github.com/artsy/metaphysics/assets/554507/b705af80-7fd2-4bdf-948f-774014f7a472)

@artsy/emerald-devs 