### PR TITLE
feat(artwork): Add isUnlisted to artwork schema

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2558,6 +2558,9 @@ type Artwork implements Node & Searchable & Sellable {
   isShareable: Boolean
   isSold: Boolean
   isUnique: Boolean
+
+  # Artwork is marked as "unlisted" (or private) by the partner
+  isUnlisted: Boolean!
   lastSavedAt(
     format: String
 

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -780,6 +780,14 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           return isEligibleForOnPlatformTransaction(artwork)
         },
       },
+      isUnlisted: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        description:
+          'Artwork is marked as "unlisted" (or private) by the partner',
+        resolve: (artwork) => {
+          return artwork.visibility_level === "unlisted"
+        },
+      },
       canRequestLotConditionsReport: {
         type: GraphQLBoolean,
         description:


### PR DESCRIPTION
This updates our schema with a new `isUnlisted` field on artwork:

```graphql
{
  artwork(id: "foo") {
    isUnlisted
  }
}
```