### PR TITLE
feat: add priceListedDisplay to Artwork that always returns display for price if it's publicly available)

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2621,6 +2621,7 @@ type Artwork implements Node & Searchable & Sellable {
   priceIncludesTax: Boolean
   priceIncludesTaxDisplay: String
   priceListed: Money
+  priceListedDisplay: String
 
   # The price paid for the artwork in a user's 'my collection'
   pricePaid: Money

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -1194,6 +1194,90 @@ describe("Artwork type", () => {
     })
   })
 
+  describe("#priceListedDisplay", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          slug
+          priceListedDisplay
+        }
+      }
+    `
+
+    it("returns 'Not publicly listed' if work is on hold with no price", () => {
+      artwork.price_cents = null
+      artwork.availability = "on hold"
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            slug: "richard-prince-untitled-portrait",
+            priceListedDisplay: "Not publicly listed",
+          },
+        })
+      })
+    })
+
+    it("returns 'Not publicly listed' if work is for sale with no price", () => {
+      artwork.price_cents = null
+      artwork.availability = "for sale"
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            slug: "richard-prince-untitled-portrait",
+            priceListedDisplay: "Not publicly listed",
+          },
+        })
+      })
+    })
+
+    it("returns '[Price]' if work is on hold with a price", () => {
+      artwork.price_cents = [42000000]
+      artwork.price_currency = "USD"
+      artwork.availability = "on hold"
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            slug: "richard-prince-untitled-portrait",
+            priceListedDisplay: "US$420,000",
+          },
+        })
+      })
+    })
+
+    it("returns '[Price]' if work is sold", () => {
+      artwork.price_cents = [42000000]
+      artwork.price_currency = "USD"
+      artwork.availability = "sold"
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            slug: "richard-prince-untitled-portrait",
+            priceListedDisplay: "US$420,000",
+          },
+        })
+      })
+    })
+
+    it("returns '[Price]' if work is not for sale", () => {
+      artwork.price_cents = [42000000]
+      artwork.price_currency = "USD"
+      artwork.availability = "not for sale"
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            slug: "richard-prince-untitled-portrait",
+            priceListedDisplay: "US$420,000",
+          },
+        })
+      })
+    })
+  })
+
   describe("#collectionsConnection", () => {
     const query = gql`
       query {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1574,6 +1574,28 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           return formatted
         },
       },
+      priceListedDisplay: {
+        type: GraphQLString,
+        resolve: ({ price_cents, price_currency }) => {
+          let formatted
+
+          if (price_cents) {
+            formatted =
+              price_cents.length === 1
+                ? priceDisplayText(price_cents[0], price_currency, "")
+                : priceRangeDisplayText(
+                    price_cents[0],
+                    price_cents[1],
+                    price_currency,
+                    ""
+                  )
+          } else {
+            formatted = "Not publicly listed"
+          }
+
+          return formatted
+        },
+      },
       series: markdown(),
       isSetVideoAsCover: {
         type: GraphQLBoolean,


### PR DESCRIPTION
This to follow up on discussion from https://github.com/artsy/eigen/pull/10008 as I'm about to add this display to Artwork page with offer.

I also followed the logic of price display from saleMessage as that is what we want I believe to match how the artwork price is displayed on the Artwork page when offer is not present except that we always want to return the price if it's available if the work has a publicly available price.