### PR TITLE
feat: add listedArtworksConnection on Artwork

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2571,6 +2571,12 @@ type Artwork implements Node & Searchable & Sellable {
   ): String
   layer(id: String): ArtworkLayer
   layers: [ArtworkLayer]
+  listedArtworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection!
   listPrice: ListPrice
   literature(format: Format): String
 

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -4369,6 +4369,47 @@ describe("Artwork type", () => {
     })
   })
 
+  describe("#listedArtworksConnection", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          listedArtworksConnection(first: 3) {
+            edges {
+              node {
+                slug
+              }
+            }
+          }
+        }
+      }
+    `
+
+    it("returns the connection", async () => {
+      const artworks = [{ id: "foo-bar" }, { id: "bar-foo" }]
+      const context = {
+        artworkLoader: () =>
+          Promise.resolve({
+            id: "richard-prince-untitled-portrait",
+            listed_artwork_ids: ["foo-bar", "bar-foo"],
+          }),
+        artworksLoader: () => Promise.resolve(artworks),
+      }
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          listedArtworksConnection: {
+            edges: [
+              { node: { slug: "foo-bar" } },
+              { node: { slug: "bar-foo" } },
+            ],
+          },
+        },
+      })
+    })
+  })
+
   describe("#priceListed", () => {
     const query = `
       {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -12,7 +12,7 @@ import {
   GraphQLString,
   GraphQLUnionType,
 } from "graphql"
-import { PageInfoType } from "graphql-relay"
+import { connectionFromArray, PageInfoType } from "graphql-relay"
 // Mapping of category ids to MediumType values
 import artworkMediums from "lib/artworkMediums"
 // Mapping of attribution_class ids to AttributionClass values
@@ -1048,6 +1048,18 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: ArtworkLayers.type,
         resolve: ({ id }, _options, { relatedLayersLoader }) =>
           artworkLayers(id, relatedLayersLoader),
+      },
+      listedArtworksConnection: {
+        type: GraphQLNonNull(artworkConnection.connectionType),
+        args: pageable(),
+        resolve: async ({ listed_artwork_ids }, args, { artworksLoader }) => {
+          const artworks =
+            listed_artwork_ids?.length > 0
+              ? await artworksLoader({ ids: listed_artwork_ids })
+              : []
+
+          return connectionFromArray(artworks, args)
+        },
       },
       literature: markdown(({ literature }) =>
         literature.replace(/^literature:\s+/i, "")


### PR DESCRIPTION
Fairly vanilla - adds a `listedArtworksConnection` field to `Artwork`, which will return a connection of [commercial] artwork listings based on a given artwork (specifically, a consigned/MyCollection artwork).