### PR TITLE
fix: alert.artworksConnection shows only for sale artworks

### DIFF
--- a/src/schema/v2/Alerts/index.ts
+++ b/src/schema/v2/Alerts/index.ts
@@ -250,7 +250,7 @@ export const AlertType = new GraphQLObjectType<
           price_range: args.price_range,
           sizes: args.sizes,
           width: args.width,
-          for_sale: true,
+          for_sale: args.for_sale,
         }
 
         return filterArtworksArgs

--- a/src/schema/v2/Alerts/index.ts
+++ b/src/schema/v2/Alerts/index.ts
@@ -250,6 +250,7 @@ export const AlertType = new GraphQLObjectType<
           price_range: args.price_range,
           sizes: args.sizes,
           width: args.width,
+          for_sale: true,
         }
 
         return filterArtworksArgs

--- a/src/schema/v2/me/__tests__/index.test.ts
+++ b/src/schema/v2/me/__tests__/index.test.ts
@@ -587,6 +587,7 @@ describe("me/index", () => {
             price_range: "*-1000",
             additional_gene_ids: ["painting"],
             id: "search-criteria-id",
+            for_sale: true,
           },
           frequency: "daily",
           email: true,

--- a/src/schema/v2/me/__tests__/index.test.ts
+++ b/src/schema/v2/me/__tests__/index.test.ts
@@ -628,6 +628,7 @@ describe("me/index", () => {
           artist_ids: ["andy-warhol"],
           price_range: "*-1000",
           aggregations: ["total"],
+          for_sale: true,
         })
       )
 


### PR DESCRIPTION
There is a mismatch between the artworks user sees in the new "View artworks" screen and when navigating to the artworks grid when clicking "See all matching works" button. This happens because "View artworks" screen uses `alert.artworksConnection` field witch lacks `for_sale` attribute. This PR adds the missing attribute.

Demo of the bug (notice 22 artworks before and 11 after):

<video src="https://github.com/artsy/metaphysics/assets/3934579/bc62a8ec-7262-444e-af67-8557cfcabf8f" />


