### PR TITLE
fix(userinterests): returns edge type to support updating ui

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -19602,6 +19602,7 @@ input UpdateUserInterestMutationInput {
 
 type UpdateUserInterestMutationPayload {
   clientMutationId: String
+  userInterestEdge: UserInterestEdge
 
   # On success: the new state of the UserInterest
   userInterestOrError: UpdateUserInterestResponseOrError

--- a/src/schema/v2/me/updateUserInterestMutation.ts
+++ b/src/schema/v2/me/updateUserInterestMutation.ts
@@ -11,7 +11,11 @@ import {
   formatGravityError,
 } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
-import { UserInterest, userInterestType } from "../userInterests"
+import {
+  UserInterest,
+  UserInterestEdge,
+  userInterestType,
+} from "../userInterests"
 
 interface Input {
   id: string
@@ -62,6 +66,10 @@ export const updateUserInterestMutation = mutationWithClientMutationId<
     private: { type: GraphQLBoolean },
   },
   outputFields: {
+    userInterestEdge: {
+      type: UserInterestEdge,
+      resolve: (result) => result,
+    },
     userInterestOrError: {
       type: ResponseOrErrorType,
       description: "On success: the new state of the UserInterest",

--- a/src/schema/v2/userInterests.ts
+++ b/src/schema/v2/userInterests.ts
@@ -102,8 +102,12 @@ export const userInterestFields: Thunk<GraphQLFieldConfigMap<
   },
 })
 
-export const UserInterestConnection = connectionWithCursorInfo({
+export const {
+  connectionType: UserInterestConnection,
+  edgeType: UserInterestEdge,
+} = connectionWithCursorInfo({
   name: "UserInterest",
   nodeType: userInterestInterestUnion,
   edgeFields: userInterestFields,
-}).connectionType
+  resolveNode: (node) => node.interest,
+})


### PR DESCRIPTION
Because, for reasons that escape me, a `UserInterest` is modeled in two different ways: as a node `UserInterest` and as an edge `UserInterestEdge`, when you perform a mutation you can't update the UI because when you fetch user interests you get the edge type and this mutation returns the node type.

This lead the implementation in Eigen to use a completely separate data store from Relay. We do not want to do that in Force, so here we just return the edge type in addition. This is deeply ugly but works fine.

![](https://capture.static.damonzucconi.com/Screen-Shot-2024-04-05-08-58-27.97-wd0HA29QADi5ts1fpT6PmWLeRNjrzGjtT46sxqlfjwe2OkT8wWcNAXyCJ3vH9X0nSAAO1W9ZYwePOJn1elJRXo7cQMTucUs2R2pD.png)