### PR TITLE
fix: add saleAgreementLoader to gravity auth loaders

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -660,6 +660,7 @@ export default (accessToken, userID, opts) => {
       { headers: true }
     ),
     salesLoaderWithHeaders: gravityLoader("sales", {}, { headers: true }),
+    saleAgreementLoader: gravityLoader((id) => `sale_agreements/${id}`),
     saleSaleAgreementLoader: gravityLoader((id) => `sale/${id}/sale_agreement`),
     saveArtworkLoader: gravityLoader(
       (id) => `collection/saved-artwork/artwork/${id}`,


### PR DESCRIPTION
patches #5642. The `saleAgreementLoader` needs to pass an `X-ACCESS-TOKEN` to authorize access to unpublished agreements. This was mistakenly removed from a previous [revert](https://github.com/artsy/metaphysics/pull/5642/commits/5711a2351957f2e20ccd25cd2f0b04ec50043794).