### PR TITLE
fix(schema-sync): Update schema sync to also push .json format

### DIFF
--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -77,6 +77,9 @@ async function main() {
       { repo: "volt-v2" },
       { repo: "pulse", dest: "vendor/graphql/schema/metaphysics.json" },
       { repo: "volt", dest: "vendor/graphql/schema/schema.graphql" },
+      // We're pushing two changes to volt; one for Relay and one for Artemis,
+      // our server-side GraphQL client. They take different schema formats.
+      { repo: "volt", dest: "vendor/graphql/schema/metaphysics.json" },
     ]
 
     const updatePromises = reposToUpdate.map((repo) => updateSchemaFile(repo))


### PR DESCRIPTION
This fixes a regression that was introduced in https://github.com/artsy/metaphysics/pull/5502, where we were simplified how we handle graphql schema syncing over in Volt. Unfortunately, this doesn't account for artemis, our server-side graphql client. So now we're restoring the old command (while retaining the new addition from #5502, since we need both types. 