### PR TITLE
feat: Add previewImages field to Notification type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13847,7 +13847,7 @@ type Notification implements Node {
   message: String!
   notificationType: NotificationTypesEnum!
   objectsCount: Int!
-  previewImages(size: Int): [Image]
+  previewImages(size: Int): [Image!]!
   publishedAt(
     # pass `RELATIVE` to display the human-friendly date (e.g. "Today", "Yesterday", "5 days ago")
     format: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13847,6 +13847,7 @@ type Notification implements Node {
   message: String!
   notificationType: NotificationTypesEnum!
   objectsCount: Int!
+  previewImages(size: Int): [Image]
   publishedAt(
     # pass `RELATIVE` to display the human-friendly date (e.g. "Today", "Yesterday", "5 days ago")
     format: String

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -289,5 +289,6 @@ export default (opts) => {
       {},
       { method: "GET" }
     ),
+    viewingRoomLoader: gravityLoader((id) => `viewing_room/${id}`),
   }
 }

--- a/src/schema/v2/image/normalize.ts
+++ b/src/schema/v2/image/normalize.ts
@@ -67,7 +67,10 @@ export type ImageData =
       image_versions?: string[]
     }
 
-type NormalizedImageData = { image_url: string; image_versions: string[] }
+export type NormalizedImageData = {
+  image_url: string
+  image_versions: string[]
+}
 
 export function normalize(
   response: ImageData,

--- a/src/schema/v2/me/__tests__/notification.test.ts
+++ b/src/schema/v2/me/__tests__/notification.test.ts
@@ -67,15 +67,8 @@ describe("me.notification", () => {
           object_ids: ["viewing-room-id"],
         })),
         viewingRoomLoader: jest.fn(async () => ({
-          viewingRoom: {
-            image: {
-              imageURLs: {
-                normalized: {
-                  image_url: "http://test.com",
-                },
-              },
-            },
-          },
+          image_versions: ["large"],
+          image_url: "http://test.com",
         })),
       }
 

--- a/src/schema/v2/me/__tests__/notification.test.ts
+++ b/src/schema/v2/me/__tests__/notification.test.ts
@@ -3,6 +3,8 @@ import { runAuthenticatedQuery } from "schema/v2/test/utils"
 import { ResolverContext } from "types/graphql"
 
 describe("me.notification", () => {
+  const meLoader = jest.fn(async () => ({ id: "some-user-id" }))
+
   it("returns a notification", async () => {
     const query = gql`
       {
@@ -20,7 +22,6 @@ describe("me.notification", () => {
       headline: "6 works added by Gerhard Richter",
       message: "6 works added",
     }))
-    const meLoader = jest.fn(async () => ({ id: "some-user-id" }))
 
     const context: Partial<ResolverContext> = {
       meNotificationLoader,
@@ -43,5 +44,158 @@ describe("me.notification", () => {
         },
       }
     `)
+  })
+
+  describe("previewImages", () => {
+    const query = gql`
+      {
+        me {
+          notification(id: "test-id") {
+            notificationType
+            previewImages(size: 5) {
+              imageURL
+            }
+          }
+        }
+      }
+    `
+    it('returns "ViewingRoomPublishedActivity" preview images', async () => {
+      const context: Partial<ResolverContext> = {
+        meLoader,
+        meNotificationLoader: jest.fn(async () => ({
+          activity_type: "ViewingRoomPublishedActivity",
+          object_ids: ["viewing-room-id"],
+        })),
+        viewingRoomLoader: jest.fn(async () => ({
+          viewingRoom: {
+            image: {
+              imageURLs: {
+                normalized: {
+                  image_url: "http://test.com",
+                },
+              },
+            },
+          },
+        })),
+      }
+
+      const data = await runAuthenticatedQuery(query, context)
+
+      expect(data).toMatchInlineSnapshot(`
+        Object {
+          "me": Object {
+            "notification": Object {
+              "notificationType": "VIEWING_ROOM_PUBLISHED",
+              "previewImages": Array [
+                Object {
+                  "imageURL": "http://test.com",
+                },
+              ],
+            },
+          },
+        }
+      `)
+    })
+
+    it('returns "ArticleFeaturedArtistActivity" preview images', async () => {
+      const context: Partial<ResolverContext> = {
+        meLoader,
+        meNotificationLoader: jest.fn(async () => ({
+          activity_type: "ArticleFeaturedArtistActivity",
+          actor_ids: ["article-id"],
+        })),
+        articleLoader: jest.fn(async () => ({
+          thumbnail_image: {
+            image_url: "http://test.com",
+          },
+        })),
+      }
+
+      const data = await runAuthenticatedQuery(query, context)
+
+      expect(data).toMatchInlineSnapshot(`
+        Object {
+          "me": Object {
+            "notification": Object {
+              "notificationType": "ARTICLE_FEATURED_ARTIST",
+              "previewImages": Array [
+                Object {
+                  "imageURL": "http://test.com",
+                },
+              ],
+            },
+          },
+        }
+      `)
+    })
+
+    it('returns "PartnerShowOpenedActivity" preview images', async () => {
+      const context: Partial<ResolverContext> = {
+        meLoader,
+        meNotificationLoader: jest.fn(async () => ({
+          activity_type: "PartnerShowOpenedActivity",
+          object_ids: ["show-id"],
+        })),
+        showsLoader: jest.fn(async () => [
+          {
+            image_versions: ["large"],
+            image_url: "http://test.com",
+          },
+        ]),
+      }
+
+      const data = await runAuthenticatedQuery(query, context)
+
+      expect(data).toMatchInlineSnapshot(`
+        Object {
+          "me": Object {
+            "notification": Object {
+              "notificationType": "PARTNER_SHOW_OPENED",
+              "previewImages": Array [
+                Object {
+                  "imageURL": "http://test.com",
+                },
+              ],
+            },
+          },
+        }
+      `)
+    })
+
+    it("returns default preview images from artworksConnection", async () => {
+      const context: Partial<ResolverContext> = {
+        meLoader,
+        meNotificationLoader: jest.fn(async () => ({
+          activity_type: "ArtworkPublishedActivity",
+          object_ids: ["artwork-id"],
+        })),
+        artworksLoader: jest.fn(async () => [
+          {
+            images: [
+              {
+                image_url: "http://test.com",
+              },
+            ],
+          },
+        ]),
+      }
+
+      const data = await runAuthenticatedQuery(query, context)
+
+      expect(data).toMatchInlineSnapshot(`
+        Object {
+          "me": Object {
+            "notification": Object {
+              "notificationType": "ARTWORK_PUBLISHED",
+              "previewImages": Array [
+                Object {
+                  "imageURL": "http://test.com",
+                },
+              ],
+            },
+          },
+        }
+      `)
+    })
   })
 })

--- a/src/schema/v2/notifications/index.ts
+++ b/src/schema/v2/notifications/index.ts
@@ -10,7 +10,7 @@ import {
 } from "graphql"
 import { connectionFromArray, connectionFromArraySlice } from "graphql-relay"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
-import { pick, size } from "lodash"
+import { pick } from "lodash"
 import { pageable } from "relay-cursor-paging"
 import { date, formatDate } from "schema/v2/fields/date"
 import {
@@ -26,7 +26,6 @@ import { DEFAULT_TZ } from "lib/date"
 import { NotificationItemType } from "./Item"
 import _ from "lodash"
 import Image, { normalizeImageData } from "../image"
-import gql from "lib/gql"
 
 const NotificationTypesEnum = new GraphQLEnumType({
   name: "NotificationTypesEnum",


### PR DESCRIPTION
Resolves [ONYX-780]

## Description

This PR adds a `previewImages` field to the `Notification` type that returns preview images depending on the activity type. The new field is intended to replace [this](https://github.com/artsy/eigen/blob/604593ef797f62c403398d621b5e77202ad8e406/src/app/Scenes/Home/Components/ActivityRailItem.tsx#L178) function in Eigen and be used in Force and Eigen in the Activity Panel.



<img width="1728" alt="Screenshot 2024-04-15 at 17 12 27" src="https://github.com/artsy/metaphysics/assets/4691889/6903bc74-6923-43b5-a4e9-cb010f3ea9e5">

[ONYX-780]: https://artsyproduct.atlassian.net/browse/ONYX-780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ