### PR TITLE
feat: enable more artist insight fields for update

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1668,7 +1668,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     # State of the returned auction results (can be past, upcoming, or all)
     state: AuctionResultsState
   ): AuctionResultConnection
-  awards: String!
+  awards: String
 
   # In applicable contexts, this is what the artist (as a suggestion) is based on.
   basedOn: Artist
@@ -1703,7 +1703,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String
-  criticallyAcclaimed: Boolean
+  criticallyAcclaimed: Boolean!
   currentEvent: CurrentEvent
   deathday: String
   disablePriceContext: Boolean
@@ -1893,7 +1893,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   sortableID: String
   statuses: ArtistStatuses
   targetSupply: ArtistTargetSupply!
-  vanguardYear: String!
+  vanguardYear: String
   verifiedRepresentatives: [VerifiedRepresentative!]!
   years: String
 }

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1668,6 +1668,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     # State of the returned auction results (can be past, upcoming, or all)
     state: AuctionResultsState
   ): AuctionResultConnection
+  awards: String!
 
   # In applicable contexts, this is what the artist (as a suggestion) is based on.
   basedOn: Artist
@@ -1892,7 +1893,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   sortableID: String
   statuses: ArtistStatuses
   targetSupply: ArtistTargetSupply!
-  vanguardYear: String
+  vanguardYear: String!
   verifiedRepresentatives: [VerifiedRepresentative!]!
   years: String
 }
@@ -18937,10 +18938,12 @@ type UpdateArtistFailure {
 
 input UpdateArtistMutationInput {
   alternateNames: [String!]
+  awards: String
   birthday: String
   blurb: String
   clientMutationId: String
   coverArtworkId: String
+  criticallyAcclaimed: Boolean
   deathday: String
   displayName: String
   first: String
@@ -18955,6 +18958,7 @@ input UpdateArtistMutationInput {
   public: Boolean
   targetSupplyPriority: ArtistTargetSupplyPriority
   targetSupplyType: ArtistTargetSupplyType
+  vanguardYear: String
 }
 
 type UpdateArtistMutationPayload {

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -241,7 +241,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       awards: {
-        type: GraphQLNonNull(GraphQLString),
+        type: GraphQLString,
         resolve: ({ awards }) => awards || "",
       },
       auctionResultsConnection: {
@@ -658,8 +658,8 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
       },
       createdAt: date(),
       criticallyAcclaimed: {
-        type: GraphQLBoolean,
-        resolve: ({ critically_acclaimed }) => critically_acclaimed,
+        type: new GraphQLNonNull(GraphQLBoolean),
+        resolve: ({ critically_acclaimed }) => !!critically_acclaimed,
       },
       currentEvent: CurrentEvent,
       deathday: { type: GraphQLString },
@@ -898,8 +898,8 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
       statuses: ArtistStatuses,
       targetSupply: ArtistTargetSupply,
       vanguardYear: {
-        type: GraphQLNonNull(GraphQLString),
-        resolve: ({ vanguard_year }) => vanguard_year || "",
+        type: GraphQLString,
+        resolve: ({ vanguard_year }) => vanguard_year,
       },
       verifiedRepresentatives: VerifiedRepresentatives,
       years: { type: GraphQLString },

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -240,6 +240,10 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
           )
         },
       },
+      awards: {
+        type: GraphQLNonNull(GraphQLString),
+        resolve: ({ awards }) => awards || "",
+      },
       auctionResultsConnection: {
         type: auctionResultConnection.connectionType,
         args: pageable({
@@ -894,8 +898,8 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
       statuses: ArtistStatuses,
       targetSupply: ArtistTargetSupply,
       vanguardYear: {
-        type: GraphQLString,
-        resolve: ({ vanguard_year }) => vanguard_year,
+        type: GraphQLNonNull(GraphQLString),
+        resolve: ({ vanguard_year }) => vanguard_year || "",
       },
       verifiedRepresentatives: VerifiedRepresentatives,
       years: { type: GraphQLString },

--- a/src/schema/v2/artist/updateArtistMutation.ts
+++ b/src/schema/v2/artist/updateArtistMutation.ts
@@ -27,8 +27,10 @@ import {
 
 interface Input {
   alternateNames: string[]
+  awards?: string
   birthday?: string
   blurb?: string
+  criticallyAcclaimed?: boolean
   coverArtworkId?: string
   deathday?: string
   displayName?: string
@@ -44,12 +46,15 @@ interface Input {
   public?: boolean
   targetSupplyPriority?: ArtistTargetSupplyPriority
   targetSupplyType?: ArtistTargetSupplyType
+  vanguardYear?: string
 }
 
 const inputFields = {
   alternateNames: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) },
+  awards: { type: GraphQLString },
   birthday: { type: GraphQLString },
   blurb: { type: GraphQLString },
+  criticallyAcclaimed: { type: GraphQLBoolean },
   coverArtworkId: { type: GraphQLString },
   deathday: { type: GraphQLString },
   displayName: { type: GraphQLString },
@@ -65,13 +70,16 @@ const inputFields = {
   public: { type: GraphQLBoolean },
   targetSupplyPriority: { type: ArtistTargetSupplyPriorityEnum },
   targetSupplyType: { type: ArtistTargetSupplyTypeEnum },
+  vanguardYear: { type: GraphQLString },
 }
 
 interface GravityInput {
   alternate_names: string[]
+  awards?: string
   birthday?: string
   blurb?: string
   cover_artwork_id?: string
+  critically_acclaimed?: boolean
   deathday?: string
   display_name?: string
   first?: string
@@ -86,6 +94,7 @@ interface GravityInput {
   public?: boolean
   target_supply_priority?: string
   target_supply_type?: string
+  vanguard_year?: string
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({


### PR DESCRIPTION
This PR enables the `criticallyAcclaimed`, `vanguardYear`, and `awards` fields to be used as input for updateArtist mutation.

[Gravity PR](https://github.com/artsy/gravity/pull/17582)