### PR TITLE
feat: request more MyCollection artwork properties from privileged contexts (ONYX-898)

### DIFF
--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -412,6 +412,7 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
             size,
             user_id: id,
             private: true,
+            all: true,
             total_count: true,
             sort: "-position",
           }


### PR DESCRIPTION
Related to: https://github.com/artsy/gravity/pull/17584 and [ONYX-898](https://artsyproduct.atlassian.net/browse/ONYX-898)

I _think_ this is all that's required? Locally, queries such as:

```graphql
query {
  user(email:"joey@example.com") {
    myCollectionArtworksConnection(first: 10) {
      edges {
        node {
          submissionId
        }
      }
    }
  }
}
```

...now include internal properties like `submissionId`. [The only references](https://github.com/search?q=org%3Aartsy%20myCollectionArtworksConnection&type=code) to this `user.myCollectionArtworksConnection` schema are from Forque, which [makes the corresponding view available](https://github.com/artsy/forque/blob/0b5d3129da192dd3dd4901a994329a1fe41d271c/src/system/index.ts#L56) only to `customer_support` users.

[ONYX-898]: https://artsyproduct.atlassian.net/browse/ONYX-898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ