### PR TITLE
Revert "feat(onyx-886): exclude disliked artworks from artworksForUser recommendations (#5658)"

### DIFF
--- a/src/schema/v2/artworksForUser/__tests__/helpers.test.ts
+++ b/src/schema/v2/artworksForUser/__tests__/helpers.test.ts
@@ -63,11 +63,6 @@ describe("getNewForYouArtworks", () => {
       context
     )
     expect(artworks.length).toEqual(1)
-    expect(mockArtworksLoader).toBeCalledWith({
-      availability: "for sale",
-      exclude_disliked_artworks: true,
-      ids: artworkIds,
-    })
   })
 })
 
@@ -134,9 +129,6 @@ describe("getBackfillArtworks", () => {
       context
     )
 
-    expect(mockSetItemsLoader).toBeCalledWith("valid_id", {
-      exclude_disliked_artworks: true,
-    })
     expect(backfillArtworks.length).toEqual(1)
   })
 
@@ -159,12 +151,6 @@ describe("getBackfillArtworks", () => {
       true
     )
 
-    expect(mockFilterArtworksLoader).toBeCalledWith({
-      exclude_disliked_artworks: true,
-      size: 1,
-      sort: "-decayed_merch",
-      marketing_collection_id: "top-auction-lots",
-    })
     expect(backfillArtworks.map((artwork) => artwork.id)).toEqual([
       "backfill-artwork-id",
     ])

--- a/src/schema/v2/artworksForUser/helpers.ts
+++ b/src/schema/v2/artworksForUser/helpers.ts
@@ -95,7 +95,6 @@ export const getNewForYouArtworks = async (
 
   const artworkParams = {
     availability: "for sale",
-    exclude_disliked_artworks: true,
     ids: ids,
     offset,
     size,
@@ -126,7 +125,6 @@ export const getBackfillArtworks = async (
 
   if (onlyAtAuction) {
     const { hits } = await filterArtworksLoader({
-      exclude_disliked_artworks: true,
       size: remainingSize,
       sort: "-decayed_merch",
       marketing_collection_id: "top-auction-lots",
@@ -143,9 +141,7 @@ export const getBackfillArtworks = async (
 
   if (!backfillSetId) return []
 
-  const { body: itemsBody } = await setItemsLoader(backfillSetId, {
-    exclude_disliked_artworks: true,
-  })
+  const { body: itemsBody } = await setItemsLoader(backfillSetId)
 
   return (itemsBody || []).slice(0, remainingSize)
 }


### PR DESCRIPTION
This reverts commit 0a2016c6415cc65ebd9ad40272257cc874611a39.

This should solve this [bug feedback](https://artsy.slack.com/archives/C03N12SR0RK/p1713280359576229)

I've executed this query (key part is `onlyAtAuction: true`):

```graphql
artworksForUser(includeBackfill: true, first: 20, onlyAtAuction: true) {
    edges {
      node {
        slug
      }
    }
  }
```

and get:

```
"message": "https://stagingapi.artsy.net/api/v1/filter/artworks?exclude_disliked_artworks=true&marketing_collection_id=top-auction-lots&size=20&sort=-decayed_merch - {\"type\":\"access_error\",\"message\":\"Can not access user-only field.\",\"detail\":{\"exclude_disliked_artworks\":[\"Can not access user-only field.\"]}}",
```

I will look for a proper fix later, for now simply reverting this change because no client relies on new `exclude_disliked_artworks` behaviour