### PR TITLE
feat: add recent_show for managing artist insights

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1858,6 +1858,9 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     partnerCategory: [String]
     representedBy: Boolean
   ): PartnerArtistConnection
+
+  # The most recent show for an artist
+  recentShow: String
   related: ArtistRelatedData
   sales(
     isAuction: Boolean
@@ -18957,6 +18960,7 @@ input UpdateArtistMutationInput {
   middle: String
   nationality: String
   public: Boolean
+  recentShow: String
   targetSupplyPriority: ArtistTargetSupplyPriority
   targetSupplyType: ArtistTargetSupplyType
   vanguardYear: String

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -860,6 +860,11 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       related: Related,
+      recentShow: {
+        type: GraphQLString,
+        description: "The most recent show for an artist",
+        resolve: ({ recent_show }) => recent_show,
+      },
       sales: {
         type: new GraphQLList(Sale.type),
         args: {

--- a/src/schema/v2/artist/updateArtistMutation.ts
+++ b/src/schema/v2/artist/updateArtistMutation.ts
@@ -44,6 +44,7 @@ interface Input {
   middle?: string
   nationality?: string
   public?: boolean
+  recentShow?: string
   targetSupplyPriority?: ArtistTargetSupplyPriority
   targetSupplyType?: ArtistTargetSupplyType
   vanguardYear?: string
@@ -68,6 +69,7 @@ const inputFields = {
   middle: { type: GraphQLString },
   nationality: { type: GraphQLString },
   public: { type: GraphQLBoolean },
+  recentShow: { type: GraphQLString },
   targetSupplyPriority: { type: ArtistTargetSupplyPriorityEnum },
   targetSupplyType: { type: ArtistTargetSupplyTypeEnum },
   vanguardYear: { type: GraphQLString },
@@ -92,6 +94,7 @@ interface GravityInput {
   middle?: string
   nationality?: string
   public?: boolean
+  recent_show?: string
   target_supply_priority?: string
   target_supply_type?: string
   vanguard_year?: string


### PR DESCRIPTION
This PR resolves and enables the `recent_show` field to be used as input for updateArtist mutation.

[Gravity PR](https://github.com/artsy/gravity/pull/17602)