### PR TITLE
feat(onyx-886): exclude disliked artworks from artworksForUser recommendations

### DIFF
--- a/src/schema/v2/artworksForUser/__tests__/helpers.test.ts
+++ b/src/schema/v2/artworksForUser/__tests__/helpers.test.ts
@@ -63,6 +63,11 @@ describe("getNewForYouArtworks", () => {
       context
     )
     expect(artworks.length).toEqual(1)
+    expect(mockArtworksLoader).toBeCalledWith({
+      availability: "for sale",
+      exclude_disliked_artworks: true,
+      ids: artworkIds,
+    })
   })
 })
 
@@ -129,6 +134,9 @@ describe("getBackfillArtworks", () => {
       context
     )
 
+    expect(mockSetItemsLoader).toBeCalledWith("valid_id", {
+      exclude_disliked_artworks: true,
+    })
     expect(backfillArtworks.length).toEqual(1)
   })
 
@@ -151,6 +159,12 @@ describe("getBackfillArtworks", () => {
       true
     )
 
+    expect(mockFilterArtworksLoader).toBeCalledWith({
+      exclude_disliked_artworks: true,
+      size: 1,
+      sort: "-decayed_merch",
+      marketing_collection_id: "top-auction-lots",
+    })
     expect(backfillArtworks.map((artwork) => artwork.id)).toEqual([
       "backfill-artwork-id",
     ])

--- a/src/schema/v2/artworksForUser/__tests__/helpers.test.ts
+++ b/src/schema/v2/artworksForUser/__tests__/helpers.test.ts
@@ -125,7 +125,7 @@ describe("getBackfillArtworks", () => {
     const context = {
       setsLoader: mockSetsLoader,
       setItemsLoader: mockSetItemsLoader,
-      unauthenticatedLoaders: {},
+      authenticatedLoaders: {},
     } as any
 
     const backfillArtworks = await getBackfillArtworks(
@@ -147,7 +147,7 @@ describe("getBackfillArtworks", () => {
     const remainingSize = 1
     const includeBackfill = true
     const context = {
-      unauthenticatedLoaders: {
+      authenticatedLoaders: {
         filterArtworksLoader: mockFilterArtworksLoader,
       },
     } as any
@@ -178,7 +178,7 @@ describe("getBackfillArtworks", () => {
     const context = {
       setsLoader: mockSetsLoader,
       setItemsLoader: mockSetItemsLoader,
-      unauthenticatedLoaders: {},
+      authenticatedLoaders: {},
     } as any
 
     const backfillArtworks = await getBackfillArtworks(

--- a/src/schema/v2/artworksForUser/helpers.ts
+++ b/src/schema/v2/artworksForUser/helpers.ts
@@ -121,10 +121,10 @@ export const getBackfillArtworks = async (
   const {
     setItemsLoader,
     setsLoader,
-    unauthenticatedLoaders: { filterArtworksLoader }, // Not personalized
+    authenticatedLoaders: { filterArtworksLoader },
   } = context
 
-  if (onlyAtAuction) {
+  if (filterArtworksLoader && onlyAtAuction) {
     const { hits } = await filterArtworksLoader({
       exclude_disliked_artworks: true,
       size: remainingSize,

--- a/src/schema/v2/artworksForUser/helpers.ts
+++ b/src/schema/v2/artworksForUser/helpers.ts
@@ -95,6 +95,7 @@ export const getNewForYouArtworks = async (
 
   const artworkParams = {
     availability: "for sale",
+    exclude_disliked_artworks: true,
     ids: ids,
     offset,
     size,
@@ -125,6 +126,7 @@ export const getBackfillArtworks = async (
 
   if (onlyAtAuction) {
     const { hits } = await filterArtworksLoader({
+      exclude_disliked_artworks: true,
       size: remainingSize,
       sort: "-decayed_merch",
       marketing_collection_id: "top-auction-lots",
@@ -141,7 +143,9 @@ export const getBackfillArtworks = async (
 
   if (!backfillSetId) return []
 
-  const { body: itemsBody } = await setItemsLoader(backfillSetId)
+  const { body: itemsBody } = await setItemsLoader(backfillSetId, {
+    exclude_disliked_artworks: true,
+  })
 
   return (itemsBody || []).slice(0, remainingSize)
 }


### PR DESCRIPTION
Initial description of a problem is here: https://github.com/artsy/metaphysics/pull/5658

After releasing ☝️ we discovered a bug - metaphysics was sending a non-authenticated request to `/filter/artworks` endpoint with a new `exclude_disliked_artworks=true` parameter. Earlier, thanks to @joeyAghion's suggestion, I made this parameter `user_only` in Gravity, which makes Gravity fail with `Can not access user-only field` error when it's requested without a user. The fact that Gravity crashes was very fortunate - otherwise I would probably not spot that artworks returned by `filter/artworks` endpoint contain disliked artworks.

This PR reverts a revert (https://github.com/artsy/metaphysics/pull/5668) and also switches to authenticated requests.