### PR TITLE
fix: avoid duplicates in back-filled recommendations (ONYX-899)

### DIFF
--- a/src/schema/v2/artworksForUser/__tests__/artworksForUser.test.ts
+++ b/src/schema/v2/artworksForUser/__tests__/artworksForUser.test.ts
@@ -148,9 +148,9 @@ describe("artworksForUser", () => {
       const newForYouRecommendations = {
         edges: [{ node: { artworkId: "valid-id" } }],
       }
-      const newForYouArtworks = [{}]
+      const newForYouArtworks = [{ id: "valid-id" }]
       const sets = [{ id: "valid-id" }]
-      const setItems = [{}]
+      const setItems = [{ id: "other-valid-id" }]
       const context = buildContext({
         newForYouRecommendations,
         newForYouArtworks,

--- a/src/schema/v2/artworksForUser/__tests__/helpers.test.ts
+++ b/src/schema/v2/artworksForUser/__tests__/helpers.test.ts
@@ -93,12 +93,12 @@ describe("getNewForYouArtworks", () => {
 
 describe("getBackfillArtworks", () => {
   it("returns an empty array without the backfill flag", async () => {
-    const remainingSize = 6
+    const size = 6
     const includeBackfill = false
     const context = {} as any
 
     const backfillArtworks = await getBackfillArtworks(
-      remainingSize,
+      size,
       includeBackfill,
       context
     )
@@ -107,12 +107,12 @@ describe("getBackfillArtworks", () => {
   })
 
   it("returns an empty array with zero remaining size", async () => {
-    const remainingSize = 0
+    const size = 0
     const includeBackfill = true
     const context = {} as any
 
     const backfillArtworks = await getBackfillArtworks(
-      remainingSize,
+      size,
       includeBackfill,
       context
     )
@@ -122,14 +122,14 @@ describe("getBackfillArtworks", () => {
 
   it("returns an empty array with no backfill id", async () => {
     const mockSetsLoader = jest.fn(() => ({ body: [] }))
-    const remainingSize = 6
+    const size = 6
     const includeBackfill = false
     const context = {
       setsLoader: mockSetsLoader,
     } as any
 
     const backfillArtworks = await getBackfillArtworks(
-      remainingSize,
+      size,
       includeBackfill,
       context
     )
@@ -140,7 +140,7 @@ describe("getBackfillArtworks", () => {
   it("returns backfill with a remaining size", async () => {
     const mockSetsLoader = jest.fn(() => ({ body: [{ id: "valid_id" }] }))
     const mockSetItemsLoader = jest.fn(() => ({ body: [{}] }))
-    const remainingSize = 1
+    const size = 1
     const includeBackfill = true
     const context = {
       setsLoader: mockSetsLoader,
@@ -150,7 +150,7 @@ describe("getBackfillArtworks", () => {
     } as any
 
     const backfillArtworks = await getBackfillArtworks(
-      remainingSize,
+      size,
       includeBackfill,
       context
     )
@@ -190,7 +190,7 @@ describe("getBackfillArtworks", () => {
     const mockFilterArtworksLoader = jest.fn(() => ({
       hits: [{ id: "backfill-artwork-id" }],
     }))
-    const remainingSize = 1
+    const size = 1
     const includeBackfill = true
     const context = {
       authenticatedLoaders: {
@@ -202,7 +202,7 @@ describe("getBackfillArtworks", () => {
     } as any
 
     const backfillArtworks = await getBackfillArtworks(
-      remainingSize,
+      size,
       includeBackfill,
       context,
       true
@@ -256,7 +256,7 @@ describe("getBackfillArtworks", () => {
   it("returns no more backfill than the remaining size asks for", async () => {
     const mockSetsLoader = jest.fn(() => ({ body: [{ id: "valid_id" }] }))
     const mockSetItemsLoader = jest.fn(() => ({ body: [{}, {}] }))
-    const remainingSize = 1
+    const size = 1
     const includeBackfill = true
     const context = {
       setsLoader: mockSetsLoader,
@@ -266,7 +266,7 @@ describe("getBackfillArtworks", () => {
     } as any
 
     const backfillArtworks = await getBackfillArtworks(
-      remainingSize,
+      size,
       includeBackfill,
       context
     )

--- a/src/schema/v2/artworksForUser/artworksForUser.ts
+++ b/src/schema/v2/artworksForUser/artworksForUser.ts
@@ -16,6 +16,7 @@ import {
   getNewForYouArtworks,
   getNewForYouArtworkIDs,
 } from "./helpers"
+import { uniqBy } from "lodash"
 
 const MAX_ARTWORKS = 100
 
@@ -54,16 +55,18 @@ export const artworksForUser: GraphQLFieldConfig<void, ResolverContext> = {
       context
     )
 
-    const remainingSize = (gravityArgs.size || 0) - newForYouArtworks.length
     const backfillArtworks = await getBackfillArtworks(
-      remainingSize,
+      size || 0,
       args.includeBackfill,
       context,
       args.onlyAtAuction,
       args.excludeDislikedArtworks
     )
 
-    const artworks = [...newForYouArtworks, ...backfillArtworks]
+    const artworks = uniqBy(
+      newForYouArtworks.concat(backfillArtworks),
+      "id"
+    ).slice(0, size)
 
     // TODO: get count from artworks loader to optimize pagination
     const count = artworks.length === 0 ? 0 : MAX_ARTWORKS

--- a/src/schema/v2/artworksForUser/helpers.ts
+++ b/src/schema/v2/artworksForUser/helpers.ts
@@ -115,13 +115,13 @@ export const getNewForYouArtworks = async (
 }
 
 export const getBackfillArtworks = async (
-  remainingSize: number,
+  size: number,
   includeBackfill: boolean,
   context: ResolverContext,
   onlyAtAuction = false,
   excludeDislikedArtworks = false
 ): Promise<any[]> => {
-  if (!includeBackfill || remainingSize < 1) return []
+  if (!includeBackfill || size < 1) return []
 
   const {
     setItemsLoader,
@@ -142,7 +142,7 @@ export const getBackfillArtworks = async (
   if (filterArtworksLoader && onlyAtAuction) {
     const { hits } = await filterArtworksLoader({
       exclude_disliked_artworks: excludeDislikedArtworks,
-      size: remainingSize,
+      size: size,
       sort: "-decayed_merch",
       marketing_collection_id: "top-auction-lots",
     })
@@ -162,5 +162,5 @@ export const getBackfillArtworks = async (
     exclude_disliked_artworks: excludeDislikedArtworks,
   })
 
-  return (itemsBody || []).slice(0, remainingSize)
+  return (itemsBody || []).slice(0, size)
 }


### PR DESCRIPTION
It [surfaced](https://artsy.slack.com/archives/C03N12SR0RK/p1713280359576229) that duplicates appear in auction recommendations, where personalized and back-fill items are concatenated together. This is understandably more common among auction lots, where there's a relatively small universe of live auction lots at any time. This PR tries to filter duplicates out.

I made some guesses and have some questions, so I'll ask them inline. Thanks for bearing with me while I get familiar!

https://artsyproduct.atlassian.net/browse/ONYX-899