### PR TITLE
add excludeDislikedArtworks option to artworksForUser

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15808,6 +15808,7 @@ type Query {
   artworksForUser(
     after: String
     before: String
+    excludeDislikedArtworks: Boolean = false
     first: Int
     includeBackfill: Boolean!
     last: Int
@@ -20791,6 +20792,7 @@ type Viewer {
   artworksForUser(
     after: String
     before: String
+    excludeDislikedArtworks: Boolean = false
     first: Int
     includeBackfill: Boolean!
     last: Int

--- a/src/schema/v2/artworksForUser/artworksForUser.ts
+++ b/src/schema/v2/artworksForUser/artworksForUser.ts
@@ -33,6 +33,10 @@ export const artworksForUser: GraphQLFieldConfig<void, ResolverContext> = {
       type: GraphQLBoolean,
       defaultValue: false,
     },
+    excludeDislikedArtworks: {
+      type: GraphQLBoolean,
+      defaultValue: false,
+    },
   }),
   resolve: async (_root, args: CursorPageable, context) => {
     const newForYouArtworkIds = await getNewForYouArtworkIDs(args, context)
@@ -44,6 +48,7 @@ export const artworksForUser: GraphQLFieldConfig<void, ResolverContext> = {
       {
         ids: newForYouArtworkIds,
         marketable: args.marketable,
+        excludeDislikedArtworks: args.excludeDislikedArtworks,
       },
       gravityArgs,
       context
@@ -54,7 +59,8 @@ export const artworksForUser: GraphQLFieldConfig<void, ResolverContext> = {
       remainingSize,
       args.includeBackfill,
       context,
-      args.onlyAtAuction
+      args.onlyAtAuction,
+      args.excludeDislikedArtworks
     )
 
     const artworks = [...newForYouArtworks, ...backfillArtworks]


### PR DESCRIPTION
This PR adds `excludeDislikedArtworks` option to `artworksForUser`. We have some concerns about performance of non-cached personalised calls to `/filter/artworks` endpoint (to exclude disliked artworks we have to make user-authenticated call to gravity).

When `excludeDislikedArtworks` is `false` - we continue using unauthenticated filter artworks loader - otherwise authenticated one.

New option is `false` by default, and only clients (Force / Eigen) will set it to `true` initially. When (if) we feel confident that `artworksForUser` query can handle Braze's load - we can set this option to true by default.