### PR TITLE
Revert "feat(onyx-886): exclude disliked artworks from artworksForUser recommendations (#5673)"

### DIFF
--- a/src/schema/v2/artworksForUser/__tests__/helpers.test.ts
+++ b/src/schema/v2/artworksForUser/__tests__/helpers.test.ts
@@ -63,11 +63,6 @@ describe("getNewForYouArtworks", () => {
       context
     )
     expect(artworks.length).toEqual(1)
-    expect(mockArtworksLoader).toBeCalledWith({
-      availability: "for sale",
-      exclude_disliked_artworks: true,
-      ids: artworkIds,
-    })
   })
 })
 
@@ -125,7 +120,7 @@ describe("getBackfillArtworks", () => {
     const context = {
       setsLoader: mockSetsLoader,
       setItemsLoader: mockSetItemsLoader,
-      authenticatedLoaders: {},
+      unauthenticatedLoaders: {},
     } as any
 
     const backfillArtworks = await getBackfillArtworks(
@@ -134,9 +129,6 @@ describe("getBackfillArtworks", () => {
       context
     )
 
-    expect(mockSetItemsLoader).toBeCalledWith("valid_id", {
-      exclude_disliked_artworks: true,
-    })
     expect(backfillArtworks.length).toEqual(1)
   })
 
@@ -147,7 +139,7 @@ describe("getBackfillArtworks", () => {
     const remainingSize = 1
     const includeBackfill = true
     const context = {
-      authenticatedLoaders: {
+      unauthenticatedLoaders: {
         filterArtworksLoader: mockFilterArtworksLoader,
       },
     } as any
@@ -159,12 +151,6 @@ describe("getBackfillArtworks", () => {
       true
     )
 
-    expect(mockFilterArtworksLoader).toBeCalledWith({
-      exclude_disliked_artworks: true,
-      size: 1,
-      sort: "-decayed_merch",
-      marketing_collection_id: "top-auction-lots",
-    })
     expect(backfillArtworks.map((artwork) => artwork.id)).toEqual([
       "backfill-artwork-id",
     ])
@@ -178,7 +164,7 @@ describe("getBackfillArtworks", () => {
     const context = {
       setsLoader: mockSetsLoader,
       setItemsLoader: mockSetItemsLoader,
-      authenticatedLoaders: {},
+      unauthenticatedLoaders: {},
     } as any
 
     const backfillArtworks = await getBackfillArtworks(

--- a/src/schema/v2/artworksForUser/helpers.ts
+++ b/src/schema/v2/artworksForUser/helpers.ts
@@ -95,7 +95,6 @@ export const getNewForYouArtworks = async (
 
   const artworkParams = {
     availability: "for sale",
-    exclude_disliked_artworks: true,
     ids: ids,
     offset,
     size,
@@ -121,12 +120,11 @@ export const getBackfillArtworks = async (
   const {
     setItemsLoader,
     setsLoader,
-    authenticatedLoaders: { filterArtworksLoader },
+    unauthenticatedLoaders: { filterArtworksLoader }, // Not personalized
   } = context
 
-  if (filterArtworksLoader && onlyAtAuction) {
+  if (onlyAtAuction) {
     const { hits } = await filterArtworksLoader({
-      exclude_disliked_artworks: true,
       size: remainingSize,
       sort: "-decayed_merch",
       marketing_collection_id: "top-auction-lots",
@@ -143,9 +141,7 @@ export const getBackfillArtworks = async (
 
   if (!backfillSetId) return []
 
-  const { body: itemsBody } = await setItemsLoader(backfillSetId, {
-    exclude_disliked_artworks: true,
-  })
+  const { body: itemsBody } = await setItemsLoader(backfillSetId)
 
   return (itemsBody || []).slice(0, remainingSize)
 }


### PR DESCRIPTION
This [slack thread](https://artsy.slack.com/archives/C05EQL4R5N0/p1713443386902879) explains the issue. Fix is on the way, but I want to unblock MP deployments today.