### PR TITLE
fix: add saleAgreementsLoader to logged-out gravity loaders

### DIFF
--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -248,6 +248,11 @@ export default (opts) => {
     salesLoader: batchSalesLoader,
     salesLoaderWithHeaders: gravityLoader("sales", {}, { headers: true }),
     saleAgreementLoader: gravityLoader((id) => `sale_agreements/${id}`),
+    saleAgreementsLoader: gravityLoader(
+      "sale_agreements",
+      {},
+      { headers: true }
+    ),
     saleSaleAgreementLoader: gravityLoader((id) => `sale/${id}/sale_agreement`),
     searchLoader: searchLoader(gravityLoader),
     sendFeedbackLoader: gravityLoader("feedback", {}, { method: "POST" }),


### PR DESCRIPTION
This should resolve the reported issue where logged-out users (on Force) weren't able to access the listing of sale agreements.