### PR TITLE
fix: time zone-sensitive test failures

### DIFF
--- a/src/schema/v2/notifications/__tests__/index.test.ts
+++ b/src/schema/v2/notifications/__tests__/index.test.ts
@@ -1,4 +1,5 @@
 import gql from "lib/gql"
+import { DEFAULT_TZ } from "lib/date"
 import { runAuthenticatedQuery } from "schema/v2/test/utils"
 import moment from "moment-timezone"
 
@@ -165,7 +166,7 @@ describe("notificationsConnection", () => {
       it("should return `Today` label", async () => {
         const loader = () => {
           return Promise.resolve({
-            feed: [{ ...notificationFeedItem, date: moment() }],
+            feed: [{ ...notificationFeedItem, date: moment().tz(DEFAULT_TZ) }],
             total: 1,
             total_unread: 1,
             total_unseen: 1,
@@ -187,7 +188,7 @@ describe("notificationsConnection", () => {
               {
                 ...notificationFeedItem,
                 // 23:59:59 yesterday
-                date: moment().endOf("day").subtract(1, "days"),
+                date: moment().tz(DEFAULT_TZ).endOf("day").subtract(1, "days"),
               },
             ],
             total: 1,


### PR DESCRIPTION
This works to fix the faily test _right now_ locally and in CI. Who knows what tomorrow brings.