### PR TITLE
feat: add partnerEngagement to CollectorProfile

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4203,6 +4203,12 @@ type CollectorProfileType implements Node {
 
   # User ID of the collector profile's owner
   ownerID: ID!
+
+  # Holds information about the engagement a collector profile has with a given partner
+  partnerEngagement(
+    # The ID of the partner to check for engagement
+    partnerID: ID!
+  ): PartnerEngagement
   privacy: String
   profession: String
   professionalBuyerAppliedAt(
@@ -11403,6 +11409,12 @@ type InquirerCollectorProfile {
 
   # User ID of the collector profile's owner
   ownerID: ID!
+
+  # Holds information about the engagement a collector profile has with a given partner
+  partnerEngagement(
+    # The ID of the partner to check for engagement
+    partnerID: ID!
+  ): PartnerEngagement
   privacy: String
   profession: String
   professionalBuyerAppliedAt(
@@ -14785,6 +14797,21 @@ type PartnerEdge {
 
   # The item at the end of the edge
   node: Partner
+}
+
+type PartnerEngagement {
+  counts: PartnerEngagementCounts
+}
+
+# Counts relating to a collector's interest in the gallery program
+type PartnerEngagementCounts {
+  alerts: Int!
+  artworkInquiries(
+    # When present, returns the inquiry count for the artist (across partners).
+    artistID: String
+  ): Int!
+  followedArtists: Int!
+  savedArtworks: Int!
 }
 
 type PartnerInquiryRequest {
@@ -19151,6 +19178,12 @@ type UpdateCollectorProfilePayload {
 
   # User ID of the collector profile's owner
   ownerID: ID!
+
+  # Holds information about the engagement a collector profile has with a given partner
+  partnerEngagement(
+    # The ID of the partner to check for engagement
+    partnerID: ID!
+  ): PartnerEngagement
   privacy: String
   profession: String
   professionalBuyerAppliedAt(

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -577,6 +577,20 @@ export default (accessToken, userID, opts) => {
       ({ partnerId, userId }) =>
         `partner_collector_profile?partner_id=${partnerId}&user_id=${userId}`
     ),
+    partnerCollectorProfileArtworkInquiryCountLoader: gravityLoader<
+      any,
+      { partnerID: string; collectorProfileID: string }
+    >(
+      ({ partnerID, collectorProfileID }) =>
+        `partner_collector_profile/${collectorProfileID}/artwork_inquiry_requests_count?partner_id=${partnerID}`
+    ),
+    partnerCollectorProfileEngagementLoader: gravityLoader<
+      any,
+      { partnerID: string; collectorProfileID: string }
+    >(
+      ({ partnerID, collectorProfileID }) =>
+        `partner_collector_profile/${collectorProfileID}/partner_engagement?partner_id=${partnerID}`
+    ),
     partnerCollectorProfileUserInterestsLoader: gravityLoader<
       any,
       { collectorProfileId: string; partnerId: string }

--- a/src/schema/v2/CollectorProfile/collectorProfile.ts
+++ b/src/schema/v2/CollectorProfile/collectorProfile.ts
@@ -26,6 +26,7 @@ import { pageable } from "relay-cursor-paging"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { createPageCursors } from "../fields/pagination"
 import { connectionFromArraySlice } from "graphql-relay"
+import { PartnerEngagementType } from "./partnerEngagement"
 
 export const CollectorProfileFields: GraphQLFieldConfigMap<
   any,
@@ -57,6 +58,21 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
   firstNameLastInitial: {
     type: GraphQLString,
     resolve: ({ first_name_last_initial }) => first_name_last_initial,
+  },
+  partnerEngagement: {
+    type: PartnerEngagementType,
+    description:
+      "Holds information about the engagement a collector profile has with a given partner",
+    args: {
+      partnerID: {
+        type: new GraphQLNonNull(GraphQLID),
+        description: "The ID of the partner to check for engagement",
+      },
+    },
+    resolve: ({ id: collectorProfileID }, { partnerID }) => {
+      // Inject data needed for fields within this type to resolve
+      return { collectorProfileID, partnerID }
+    },
   },
   privacy: { type: GraphQLString },
   professionalBuyerAppliedAt: date,

--- a/src/schema/v2/CollectorProfile/partnerEngagement.ts
+++ b/src/schema/v2/CollectorProfile/partnerEngagement.ts
@@ -1,0 +1,91 @@
+import { GraphQLString } from "graphql"
+import { GraphQLInt, GraphQLNonNull, GraphQLObjectType } from "graphql"
+import { includesFieldsOtherThanSelectionSet } from "lib/hasFieldSelection"
+import { ResolverContext } from "types/graphql"
+
+export const PartnerEngagementType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "PartnerEngagement",
+  fields: {
+    counts: {
+      type: new GraphQLObjectType({
+        name: "PartnerEngagementCounts",
+        description:
+          "Counts relating to a collector's interest in the gallery program",
+        fields: {
+          artworkInquiries: {
+            type: new GraphQLNonNull(GraphQLInt),
+            args: {
+              artistID: {
+                type: GraphQLString,
+                description:
+                  "When present, returns the inquiry count for the artist (across partners).",
+              },
+            },
+            resolve: async (
+              { collectorProfileID, partnerID },
+              { artistID },
+              { partnerCollectorProfileArtworkInquiryCountLoader }
+            ) => {
+              if (!partnerCollectorProfileArtworkInquiryCountLoader) {
+                throw new Error(
+                  "You need to be signed in to perform this action"
+                )
+              }
+
+              const {
+                artwork_inquiry_requests_count,
+              } = await partnerCollectorProfileArtworkInquiryCountLoader(
+                { partnerID, collectorProfileID },
+                { artist_id: artistID }
+              )
+
+              return artwork_inquiry_requests_count
+            },
+          },
+          followedArtists: {
+            type: new GraphQLNonNull(GraphQLInt),
+            resolve: ({ artist_follows_count }) => artist_follows_count,
+          },
+          savedArtworks: {
+            type: new GraphQLNonNull(GraphQLInt),
+            resolve: ({ saved_artworks_count }) => saved_artworks_count,
+          },
+          alerts: {
+            type: new GraphQLNonNull(GraphQLInt),
+            resolve: ({ alerts_count }) => alerts_count,
+          },
+        },
+      }),
+      resolve: async (
+        { collectorProfileID, partnerID },
+        _args,
+        { partnerCollectorProfileEngagementLoader },
+        info
+      ) => {
+        const fieldsNotRequireLoader = ["artworkInquiries"]
+        const defaultResolvedData = { collectorProfileID, partnerID }
+
+        if (includesFieldsOtherThanSelectionSet(info, fieldsNotRequireLoader)) {
+          if (!partnerCollectorProfileEngagementLoader) {
+            throw new Error("You need to be signed in to perform this action")
+          }
+
+          const data = await partnerCollectorProfileEngagementLoader({
+            partnerID,
+            collectorProfileID,
+          })
+
+          return {
+            ...data,
+            ...defaultResolvedData,
+          }
+        } else {
+          return defaultResolvedData
+        }
+      },
+    },
+  },
+})


### PR DESCRIPTION
Now that we have some newer data points in https://github.com/artsy/gravity/pull/17626 and https://github.com/artsy/gravity/pull/17625 , I decided to get a stake in the ground on trying to add these concepts to `CollectorProfile`. I decided to go with `partnerEngagement(partnerID: ID!): PartnerEngagement` (as these are partner-specific) and include all these properties.

For now just these counts are being exposed, and it's very much a WIP (for instance - maybe we should just combine all of these into a single API call, they're arbitrarily split up now). This `PartnerEngagement` type is where we could also add the `userIntroduction` natural-language sentence, although in the designs I saw there was still room to present some of these headline counts.

Looks like-

![Screen Shot 2024-04-23 at 3 28 52 PM](https://github.com/artsy/metaphysics/assets/1457859/e6182587-e0cb-49e9-9956-c985d84c0015)

What do we think?