### PR TITLE
chore: switch savedArtworks count to return the value from the Collection

### DIFF
--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -281,21 +281,14 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
           },
           savedArtworks: {
             type: new GraphQLNonNull(GraphQLInt),
-            resolve: async (_me, _args, { collectionArtworksLoader }) => {
-              if (!collectionArtworksLoader) return 0
+            resolve: async (_me, _args, { collectionLoader }) => {
+              if (!collectionLoader) return 0
 
               try {
-                const { headers } = await collectionArtworksLoader(
-                  COLLECTION_ID,
-                  {
-                    page: 1,
-                    private: true,
-                    size: 1,
-                    total_count: true,
-                  }
+                const { visible_artworks_count } = await collectionLoader(
+                  COLLECTION_ID
                 )
-
-                return headers["x-total-count"] ?? 0
+                return visible_artworks_count
               } catch (error) {
                 console.error(error)
                 return 0


### PR DESCRIPTION
This count is used during onboarding, and so can be requested on many different pages. We've seen some evidence that fetching the total count and paginating the collection w/ `total_count: true` can be slow for power users.

Rather than un-pack some of the complexity involved there - let's isolate our attention to _just_ this count field, which as part of onboarding gets queried often, and so might give us some bang for our buck here, even if we aren't touching any _other_ places `savedArtworks` are paginated w/ `total_count: true`.

Since fetching the collection already returns a `visible_artworks_count` 'live' query - https://github.com/artsy/gravity/blob/42969a41ba98a3b8adc860677be5ab05d62a21b1/app/models/domain/collection.rb#L242 - let's use it here. It should be faster than the current implementation, which essentially does this step, but then also plucks the resulting id's and passes them _back_ to Postgres - https://github.com/artsy/gravity/blob/42969a41ba98a3b8adc860677be5ab05d62a21b1/app/services/collected_artwork_service.rb#L22

This saves that last step, so this should be an improvement from the current implementation. Whether that's 'enough', we'll have to keep monitoring (I'm never fully confident if some slow transaction logs might be red herrings, but nevertheless we've seen slow counts of saves specifically come up more than once -I believe tying back to progressive onboarding usage, which itself is [relatively] new).