### PR TITLE
feat: Adds partnerProvidedBiography field to Artist

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1850,6 +1850,9 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     # The number of PartnerArtists to return
     size: Int
   ): [PartnerArtist]
+
+  # The Partner's provided biography for the artist
+  partnerBiographyBlurb(format: Format): partnerBiographyBlurb
   partnersConnection(
     after: String
     before: String
@@ -14595,6 +14598,10 @@ type PartnerArtworkGrid implements ArtworkContextGrid {
   ctaHref: String
   ctaTitle: String
   title: String
+}
+
+type partnerBiographyBlurb {
+  text: String
 }
 
 type PartnerCategory {

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -868,6 +868,38 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ id }, options, { partnerArtistsForArtistLoader }) =>
           partnerArtistsForArtistLoader(id, options),
       },
+      partnerBiographyBlurb: {
+        description: "The Partner's provided biography for the artist",
+        args: {
+          ...markdown().args,
+        },
+        type: new GraphQLObjectType<any, ResolverContext>({
+          name: "partnerBiographyBlurb",
+          fields: {
+            text: {
+              type: GraphQLString,
+              resolve: ({ text }) => text,
+            },
+          },
+        }),
+        resolve: async (
+          { id },
+          { format },
+          { partnerArtistsForArtistLoader }
+        ) => {
+          const partnerArtists = await partnerArtistsForArtistLoader(id, {
+            size: 1,
+          })
+
+          if (partnerArtists && partnerArtists.length) {
+            const { biography } = first(partnerArtists) as any
+
+            return {
+              text: formatMarkdownValue(biography, format),
+            }
+          }
+        },
+      },
       duplicates: {
         type: new GraphQLList(Artist.type),
         resolve: ({ id }, _args, { artistDuplicatesLoader }, _info) => {


### PR DESCRIPTION
Adds partnerProvidedBiography field to Artist, originally we wanted to use `biographyBlurb` provided function but it only returns the partner provided bio for `featured` partner artists, see [here](https://github.com/artsy/metaphysics/blob/bf5f37c86646adbbe2c68c464bf69e9add480ad9/src/schema/v2/artist/index.ts#L495)

We need a more flexible solution for our new private artworks experience

```graphql
{
  artist(id: "662664897e9e2b00073fae7d") {
    partnerBiographyBlurb {
      text
    }
    biographyBlurb {
      text
    }
  }
}
```


<img width="700" alt="Screenshot 2024-04-24 at 6 16 26 PM" src="https://github.com/artsy/metaphysics/assets/12748344/dd7965a4-133a-42ac-8a90-e869950a32f1">