### PR TITLE
chore: adding some additional specs for new Artist field

### DIFF
--- a/src/schema/v2/artist/__tests__/index.test.js
+++ b/src/schema/v2/artist/__tests__/index.test.js
@@ -570,6 +570,55 @@ describe("Artist type", () => {
       })
     })
   })
+
+  describe("partnerBiographyBlurb", () => {
+    const query = `
+      {
+        artist(id: "foo-bar") {
+          partnerBiographyBlurb {
+            text   
+          }
+        }
+      }
+    `
+  
+    it("returns the partners provided biography", () => {
+      const partnerArtists = Promise.resolve([{ biography: "Oh hello, I am a bio" }]);
+      context.partnerArtistsForArtistLoader = sinon
+        .stub()
+        .withArgs(artist.id)
+        .returns(partnerArtists);
+  
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artist: {
+            partnerBiographyBlurb: {
+              text: "Oh hello, I am a bio",
+            },
+          },
+        })
+      })
+    })
+  
+    it("handles null partner artist biography", () => {
+      const partnerArtists = Promise.resolve([{ biography: null }]);
+      context.partnerArtistsForArtistLoader = sinon
+        .stub()
+        .withArgs(artist.id)
+        .returns(partnerArtists);
+  
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artist: {
+            partnerBiographyBlurb: {
+              text: null,
+            },
+          },
+        })
+      })
+    })
+  })
+
   describe("concerning related shows", () => {
     beforeEach(() => {
       const partnerlessShow = {

--- a/src/schema/v2/artist/__tests__/index.test.js
+++ b/src/schema/v2/artist/__tests__/index.test.js
@@ -581,14 +581,17 @@ describe("Artist type", () => {
         }
       }
     `
-  
     it("returns the partners provided biography", () => {
-      const partnerArtists = Promise.resolve([{ biography: "Oh hello, I am a bio" }]);
+      const partnerArtists = Promise.resolve([
+        {
+          biography: "Oh hello, I am a bio",
+        }
+      ])
       context.partnerArtistsForArtistLoader = sinon
         .stub()
         .withArgs(artist.id)
-        .returns(partnerArtists);
-  
+        .returns(partnerArtists)
+
       return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {
@@ -599,14 +602,18 @@ describe("Artist type", () => {
         })
       })
     })
-  
-    it("handles null partner artist biography", () => {
-      const partnerArtists = Promise.resolve([{ biography: null }]);
+
+    it("returns the null if no partners provided biography", () => {
+      const partnerArtists = Promise.resolve([
+        {
+          biography: null,
+        }
+      ])
       context.partnerArtistsForArtistLoader = sinon
         .stub()
         .withArgs(artist.id)
-        .returns(partnerArtists);
-  
+        .returns(partnerArtists)
+
       return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artist: {


### PR DESCRIPTION
Fast follow Just wanted to test the case when PartnerArtist bio is `null` in case of 💥 

https://github.com/artsy/metaphysics/pull/5693