### PR TITLE
fix: include private=true param for savedArtworks count

### DIFF
--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -285,9 +285,9 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
               if (!collectionLoader) return 0
 
               try {
-                const { visible_artworks_count } = await collectionLoader(
-                  COLLECTION_ID
-                )
+                const {
+                  visible_artworks_count,
+                } = await collectionLoader(COLLECTION_ID, { private: true })
                 return visible_artworks_count
               } catch (error) {
                 console.error(error)


### PR DESCRIPTION
For the count to come back if the collection is private, we need to always include this param.