### PR TITLE
feat(onyx-911): consignment submission state info

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2759,10 +2759,19 @@ interface ArtworkConnectionInterface {
 }
 
 type ArtworkConsignmentSubmission {
-  displayText: String
+  displayText: String @deprecated(reason: "Prefer `stateLabel` field.")
   inProgress: Boolean
   internalID: String
   isSold: Boolean
+
+  # Submission state.
+  state: String
+
+  # More information about the submission state.
+  stateHelpMessage: String
+
+  # Submission state label visible to the user.
+  stateLabel: String
 }
 
 union ArtworkContext = Fair | Sale | Show

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2765,13 +2765,23 @@ type ArtworkConsignmentSubmission {
   isSold: Boolean
 
   # Submission state.
-  state: String
+  state: ArtworkConsignmentSubmissionState!
 
   # More information about the submission state.
   stateHelpMessage: String
 
   # Submission state label visible to the user.
   stateLabel: String
+}
+
+enum ArtworkConsignmentSubmissionState {
+  APPROVED
+  CLOSED
+  DRAFT
+  HOLD
+  PUBLISHED
+  REJECTED
+  SUBMITTED
 }
 
 union ArtworkContext = Fair | Sale | Show

--- a/src/schema/v2/artwork/__tests__/artworkConsignmentSubmissionType.test.ts
+++ b/src/schema/v2/artwork/__tests__/artworkConsignmentSubmissionType.test.ts
@@ -268,4 +268,143 @@ describe("ArtworkConsignmentSubmissionType", () => {
       expect(data.artwork.consignmentSubmission.isSold).toBeFalse()
     })
   })
+
+  describe("#state", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          consignmentSubmission {
+            state
+          }
+        }
+      }
+    `
+
+    it("returns correct state", async () => {
+      artwork.consignmentSubmission.state = "DRAFT"
+      let data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.state).toEqual("draft")
+
+      artwork.consignmentSubmission.state = "APPROVED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.state).toEqual("approved")
+    })
+  })
+
+  describe("#stateLabel", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          consignmentSubmission {
+            stateLabel
+          }
+        }
+      }
+    `
+
+    it("returns correct state label", async () => {
+      artwork.consignmentSubmission.state = "DRAFT"
+      let data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateLabel).toEqual(
+        "In Progress"
+      )
+
+      artwork.consignmentSubmission.state = "SUBMITTED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateLabel).toEqual(
+        "In Progress"
+      )
+
+      artwork.consignmentSubmission.state = "APPROVED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateLabel).toEqual(
+        "Evaluation Complete"
+      )
+
+      artwork.consignmentSubmission.state = "PUBLISHED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateLabel).toEqual(
+        "Evaluation Complete"
+      )
+
+      artwork.consignmentSubmission.state = "REJECTED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateLabel).toEqual(
+        "Evaluation Complete"
+      )
+
+      artwork.consignmentSubmission.state = "HOLD"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateLabel).toEqual(
+        "In Progress"
+      )
+
+      artwork.consignmentSubmission.state = "CLOSED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateLabel).toEqual(
+        "Evaluation Complete"
+      )
+    })
+  })
+
+  describe("#stateHelpMessage", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          consignmentSubmission {
+            stateHelpMessage
+          }
+        }
+      }
+    `
+
+    const IN_PROGRESS_MESSAGE =
+      "The artwork is being reviewed or is in the sale process."
+    const SUBMISSION_EVALUATED_MESSAGE =
+      "Our specialists have reviewed this submission and determined that we do not currently have a market for it."
+
+    it("returns correct help message", async () => {
+      artwork.consignmentSubmission.state = "DRAFT"
+      let data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateHelpMessage).toEqual(
+        IN_PROGRESS_MESSAGE
+      )
+
+      artwork.consignmentSubmission.state = "SUBMITTED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateHelpMessage).toEqual(
+        IN_PROGRESS_MESSAGE
+      )
+
+      artwork.consignmentSubmission.state = "APPROVED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateHelpMessage).toEqual(
+        SUBMISSION_EVALUATED_MESSAGE
+      )
+
+      artwork.consignmentSubmission.state = "PUBLISHED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateHelpMessage).toEqual(
+        SUBMISSION_EVALUATED_MESSAGE
+      )
+
+      artwork.consignmentSubmission.state = "REJECTED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateHelpMessage).toEqual(
+        SUBMISSION_EVALUATED_MESSAGE
+      )
+
+      artwork.consignmentSubmission.state = "HOLD"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateHelpMessage).toEqual(
+        IN_PROGRESS_MESSAGE
+      )
+
+      artwork.consignmentSubmission.state = "CLOSED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateHelpMessage).toEqual(
+        SUBMISSION_EVALUATED_MESSAGE
+      )
+    })
+  })
 })

--- a/src/schema/v2/artwork/__tests__/artworkConsignmentSubmissionType.test.ts
+++ b/src/schema/v2/artwork/__tests__/artworkConsignmentSubmissionType.test.ts
@@ -283,11 +283,11 @@ describe("ArtworkConsignmentSubmissionType", () => {
     it("returns correct state", async () => {
       artwork.consignmentSubmission.state = "DRAFT"
       let data = await runQuery(query, context)
-      expect(data.artwork.consignmentSubmission.state).toEqual("draft")
+      expect(data.artwork.consignmentSubmission.state).toEqual("DRAFT")
 
       artwork.consignmentSubmission.state = "APPROVED"
       data = await runQuery(query, context)
-      expect(data.artwork.consignmentSubmission.state).toEqual("approved")
+      expect(data.artwork.consignmentSubmission.state).toEqual("APPROVED")
     })
   })
 

--- a/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
+++ b/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
@@ -14,6 +14,7 @@ const ArtworkConsignmentSubmissionType = new GraphQLObjectType<
       },
       displayText: {
         type: GraphQLString,
+        deprecationReason: "Prefer `stateLabel` field.",
         resolve: (consignmentSubmission) => {
           const state =
             consignmentSubmission.saleState || consignmentSubmission.state
@@ -51,6 +52,41 @@ const ArtworkConsignmentSubmissionType = new GraphQLObjectType<
             consignmentSubmission.saleState || consignmentSubmission.state
 
           return ["submitted", "hold", "open"].includes(state?.toLowerCase())
+        },
+      },
+      state: {
+        type: GraphQLString,
+        description: "Submission state.",
+        resolve: ({ state }) => state.toLowerCase(),
+      },
+      stateLabel: {
+        type: GraphQLString,
+        description: "Submission state label visible to the user.",
+        resolve: ({ state }) => {
+          switch (state.toLowerCase()) {
+            case "approved":
+            case "rejected":
+            case "closed":
+            case "published":
+              return "Evaluation Complete"
+            default:
+              return "In Progress"
+          }
+        },
+      },
+      stateHelpMessage: {
+        type: GraphQLString,
+        description: "More information about the submission state.",
+        resolve: ({ state }) => {
+          switch (state.toLowerCase()) {
+            case "approved":
+            case "rejected":
+            case "closed":
+            case "published":
+              return "Our specialists have reviewed this submission and determined that we do not currently have a market for it."
+            default:
+              return "The artwork is being reviewed or is in the sale process."
+          }
         },
       },
     }

--- a/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
+++ b/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
@@ -1,5 +1,25 @@
-import { GraphQLBoolean, GraphQLObjectType, GraphQLString } from "graphql"
+import {
+  GraphQLBoolean,
+  GraphQLEnumType,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
 import { ResolverContext } from "types/graphql"
+
+// Based directly on Convection Submission#state: https://github.com/artsy/convection/blob/main/app/models/submission.rb
+const ArtworkConsignmentSubmissionStateType = new GraphQLEnumType({
+  name: "ArtworkConsignmentSubmissionState",
+  values: {
+    DRAFT: { value: "draft" },
+    SUBMITTED: { value: "submitted" },
+    APPROVED: { value: "approved" },
+    PUBLISHED: { value: "published" },
+    REJECTED: { value: "rejected" },
+    HOLD: { value: "hold" },
+    CLOSED: { value: "closed" },
+  },
+})
 
 const ArtworkConsignmentSubmissionType = new GraphQLObjectType<
   any,
@@ -55,9 +75,11 @@ const ArtworkConsignmentSubmissionType = new GraphQLObjectType<
         },
       },
       state: {
-        type: GraphQLString,
+        type: new GraphQLNonNull(ArtworkConsignmentSubmissionStateType),
         description: "Submission state.",
-        resolve: ({ state }) => state,
+        resolve: ({ state }) => {
+          return state.toLowerCase()
+        },
       },
       stateLabel: {
         type: GraphQLString,

--- a/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
+++ b/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
@@ -57,7 +57,7 @@ const ArtworkConsignmentSubmissionType = new GraphQLObjectType<
       state: {
         type: GraphQLString,
         description: "Submission state.",
-        resolve: ({ state }) => state.toLowerCase(),
+        resolve: ({ state }) => state,
       },
       stateLabel: {
         type: GraphQLString,


### PR DESCRIPTION
[Jira ticket](https://artsyproduct.atlassian.net/browse/ONYX-897).

From the ticket:

> [Force](https://github.com/artsy/force/blob/e64ac8ce6881c2200aa56cc1d32c72d0cbbdfbb8/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSWASectionSubmitted.tsx) and [Eigen](https://github.com/artsy/eigen/blob/addcd491a72c01cf41458b81929d993a48b21711/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus.tsx) display a colorful description of the submission state, along with some help text. There’s some duplication, and in the case of “approved” submissions, the help text is misleading (“determined that we do not currently have a market for it”).

When pairing with @joeyAghion we agreed that it feel awkward to specify palette colors in Metaphysics - instead we are going to expose raw Convection state (draft, approved, rejected, etc.) based on which Force / Eigen can compute colors.

> and in the case of “approved” submissions, the help text is misleading (“determined that we do not currently have a market for it”

In current state of PR I haven't change the copy - how would you communicate to a user that their submission was approved?

## New schema

```graphql
query X {
  me {
    myCollectionConnection(first: 1, sort: CREATED_AT_DESC) {
      edges {
        node {
          consignmentSubmission {
            state # 'approved'
            stateLabel # 'Evaluation Complete'
            stateHelpMessage # 'Our specialists have reviewed...'
          }
        }
      }
    }
  }
}
```