### PR TITLE
feat: add a summarySentence on CollectorProfile

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4232,6 +4232,9 @@ type CollectorProfileType implements Node {
   ): String
   savedArtworksCount: Int!
   selfReportedPurchases: String
+
+  # A partner-specific sentence describing the collector.
+  summarySentence(partnerID: String!): String!
   totalBidsCount: Int!
   userInterests: [UserInterest]!
     @deprecated(reason: "Use \"owner#interestsConnection\" field instead.")
@@ -11435,6 +11438,9 @@ type InquirerCollectorProfile {
   ): String
   savedArtworksCount: Int!
   selfReportedPurchases: String
+
+  # A partner-specific sentence describing the collector.
+  summarySentence(partnerID: String!): String!
   totalBidsCount: Int!
   userInterests: [UserInterest]!
     @deprecated(reason: "Use \"owner#interestsConnection\" field instead.")
@@ -19207,6 +19213,9 @@ type UpdateCollectorProfilePayload {
   ): String
   savedArtworksCount: Int!
   selfReportedPurchases: String
+
+  # A partner-specific sentence describing the collector.
+  summarySentence(partnerID: String!): String!
   totalBidsCount: Int!
   userInterests: [UserInterest]!
     @deprecated(reason: "Use \"owner#interestsConnection\" field instead.")

--- a/src/schema/v2/CollectorProfile/collectorProfile.ts
+++ b/src/schema/v2/CollectorProfile/collectorProfile.ts
@@ -219,6 +219,18 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
       !!other_relevant_positions &&
       !!bio,
   },
+  summarySentence: {
+    type: new GraphQLNonNull(GraphQLString),
+    description: "A partner-specific sentence describing the collector.",
+    args: {
+      partnerID: {
+        type: new GraphQLNonNull(GraphQLString),
+      },
+    },
+    resolve: () => {
+      return "This collector exists."
+    },
+  },
 }
 
 export const CollectorProfileType = new GraphQLObjectType<any, ResolverContext>(

--- a/src/schema/v2/me/__tests__/collector_profile.test.js
+++ b/src/schema/v2/me/__tests__/collector_profile.test.js
@@ -137,5 +137,35 @@ describe("Me", () => {
         )
       })
     })
+
+    describe("summarySentence", () => {
+      it("returns a summary sentence", () => {
+        const query = `
+          {
+            me {
+              collectorProfile {
+                summarySentence(partnerID: "foo-partner")
+              }
+            }
+          }
+        `
+
+        const collectorProfile = {
+          id: "3",
+        }
+
+        const context = {
+          meCollectorProfileLoader: () => Promise.resolve(collectorProfile),
+        }
+
+        return runAuthenticatedQuery(query, context).then(
+          ({ me: { collectorProfile } }) => {
+            expect(collectorProfile.summarySentence).toBe(
+              "This collector exists."
+            )
+          }
+        )
+      })
+    })
   })
 })


### PR DESCRIPTION
Just to get something in here to iterate on! It is static and pretty boring to start.

I did add a required `partnerID` argument as it seems as though this sentence will be partner-aware or partner-specific, we can relax this if needed.