### PR TITLE
chore: switch from nvm to asdf

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -14,10 +14,11 @@ if ! which memcached > /dev/null; then
   brew install memcached
 fi
 
-if [[ ! -z $NVM_DIR ]]; then # skip if nvm is not available
-  echo "Installing Node..."
-  source ~/.nvm/nvm.sh
-  nvm install
+if command -v asdf >/dev/null; then
+  echo "Installing language dependencies with asdf"
+  asdf install
+else
+  echo "Skipping language dependencies installation (asdf not found)"
 fi
 
 echo "Installing dependencies..."


### PR DESCRIPTION
This switches to `asdf` as the default version manager for node, as per https://github.com/artsy/README/pull/505.

Like in https://github.com/artsy/force/pull/13834, I left the `.nvmrc` file in place as a convenience for developers that haven't yet made the switch.