### PR TITLE
feat(DIA-561): use icon to check collector profile completion and remove bio from it

### DIFF
--- a/src/schema/v2/CollectorProfile/collectorProfile.ts
+++ b/src/schema/v2/CollectorProfile/collectorProfile.ts
@@ -212,12 +212,12 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
   },
   isProfileComplete: {
     type: GraphQLBoolean,
-    resolve: ({ name, location, profession, other_relevant_positions, bio }) =>
+    resolve: ({ icon, name, location, profession, other_relevant_positions }) =>
+      !!icon &&
       !!name &&
       !!location?.display &&
       !!profession &&
-      !!other_relevant_positions &&
-      !!bio,
+      !!other_relevant_positions,
   },
   summarySentence: {
     type: new GraphQLNonNull(GraphQLString),

--- a/src/schema/v2/me/__tests__/collector_profile.test.js
+++ b/src/schema/v2/me/__tests__/collector_profile.test.js
@@ -84,12 +84,12 @@ describe("Me", () => {
           id: "3",
           name: "Johnathan Storm",
           email: "johnathan@storm.com",
+          icon: { url: "http://image.com" },
           location: {
             display: "Berlin",
           },
           profession: "coder",
           other_relevant_positions: "other typer",
-          bio: "J. Storm",
         }
 
         const context = {


### PR DESCRIPTION
Related to [DIA-561]

This PR is related to `CollectorProfile#isProfileComplete` and changes:
- removes `bio` from the gauge
- adds `icon` to the gauge

So far this prop has been used by Eigen, so with this change, we don't expect any super weird stuff in the current Edit profile screen.

[DIA-561]: https://artsyproduct.atlassian.net/browse/DIA-561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ