### PR TITLE
feat(sync-schema): Update schema sync to also account for Artemis - Take 2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -44,5 +44,6 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
-  }
+  },
+  "circleci.persistedProjectSelection": ["gh/artsy/metaphysics"]
 }

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15692,7 +15692,7 @@ type Query {
 
     #
     #         Only return artists matching specified slugs.
-    #         Accepts list of slugs. (e.g. 'andy-warhol', 'banksy')
+    #         Accepts list of slugs (e.g. 'andy-warhol', 'banksy').
     #
     slugs: [String]
     sort: ArtistSorts
@@ -20711,7 +20711,7 @@ type Viewer {
 
     #
     #         Only return artists matching specified slugs.
-    #         Accepts list of slugs. (e.g. 'andy-warhol', 'banksy')
+    #         Accepts list of slugs (e.g. 'andy-warhol', 'banksy').
     #
     slugs: [String]
     sort: ArtistSorts

--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -74,6 +74,10 @@ async function main() {
       { repo: "prediction" },
       { repo: "force" },
       { repo: "forque" },
+      // We're pushing two changes to volt; one for Relay and one for Artemis,
+      // our server-side GraphQL client. They take different schema formats.
+      // Keeping this entry separate from the other volt to avoid race condition.
+      { repo: "volt", dest: "vendor/graphql/schema/metaphysics.json" },
       { repo: "volt-v2" },
       { repo: "pulse", dest: "vendor/graphql/schema/metaphysics.json" },
       { repo: "volt", dest: "vendor/graphql/schema/schema.graphql" },

--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -14,11 +14,11 @@ const defaultBody =
  * @param {Object} input
  * @param {string} input.repo - repo: name of the artsy repo to update
  * @param {string} [input.body] - body: The PR body descrption
- * @param {string} [input.dest] - dest: Path to schema file in target repo
+ * @param {Array<string>} [input.destinations] - destinations: Paths to schema files in target repo
  */
 async function updateSchemaFile({
   repo,
-  dest = "data/schema.graphql",
+  destinations = ["data/schema.graphql"],
   body = defaultBody,
 }) {
   await updateRepo({
@@ -34,30 +34,34 @@ async function updateSchemaFile({
     assignees: ["artsyit"],
     labels: ["Squash On Green"],
     update: (repoDir) => {
-      const repoDest = path.join(repoDir, dest)
       execSync("yarn config set ignore-engines true", { cwd: repoDir })
       execSync("yarn install", { cwd: repoDir })
-      if (dest.endsWith(".json")) {
-        const sdl = readFileSync("_schemaV2.graphql", "utf8").toString()
-        const schema = buildSchema(sdl, { commentDescriptions: true })
-        const gql = graphqlSync(schema, introspectionQuery)
-        writeFileSync(repoDest, JSON.stringify(gql, null, 2))
-      } else {
-        execSync(`cp _schemaV2.graphql '${repoDest}'`)
 
-        // Running the compiler directly for Rails projects
-        const relayCompilerCommand = ["pulse", "volt"].includes(repo)
-          ? "./node_modules/.bin/relay-compiler"
-          : "yarn relay"
+      destinations.forEach((dest) => {
+        const repoDest = path.join(repoDir, dest)
+        if (dest.endsWith(".json")) {
+          const sdl = readFileSync("_schemaV2.graphql", "utf8").toString()
+          const schema = buildSchema(sdl, { commentDescriptions: true })
+          const gql = graphqlSync(schema, introspectionQuery)
+          writeFileSync(repoDest, JSON.stringify(gql, null, 2))
+        } else {
+          execSync(`cp _schemaV2.graphql '${repoDest}'`)
 
-        execSync(relayCompilerCommand, { cwd: repoDir })
-      }
-      execSync(
-        `[ ! -f ./node_modules/.bin/prettier ] || ./node_modules/.bin/prettier --write ${dest}`,
-        {
-          cwd: repoDir,
+          // Running the compiler directly for Rails projects
+          const relayCompilerCommand = ["pulse", "volt"].includes(repo)
+            ? "./node_modules/.bin/relay-compiler"
+            : "yarn relay"
+
+          execSync(relayCompilerCommand, { cwd: repoDir })
         }
-      )
+
+        execSync(
+          `[ ! -f ./node_modules/.bin/prettier ] || ./node_modules/.bin/prettier --write ${dest}`,
+          {
+            cwd: repoDir,
+          }
+        )
+      })
     },
   })
 }
@@ -74,13 +78,18 @@ async function main() {
       { repo: "prediction" },
       { repo: "force" },
       { repo: "forque" },
-      // We're pushing two changes to volt; one for Relay and one for Artemis,
-      // our server-side GraphQL client. They take different schema formats.
-      // Keeping this entry separate from the other volt to avoid race condition.
-      { repo: "volt", dest: "vendor/graphql/schema/metaphysics.json" },
+      {
+        repo: "pulse",
+        destinations: ["vendor/graphql/schema/metaphysics.json"],
+      },
+      {
+        repo: "volt",
+        destinations: [
+          "vendor/graphql/schema/schema.graphql",
+          "vendor/graphql/schema/metaphysics.json",
+        ],
+      },
       { repo: "volt-v2" },
-      { repo: "pulse", dest: "vendor/graphql/schema/metaphysics.json" },
-      { repo: "volt", dest: "vendor/graphql/schema/schema.graphql" },
     ]
 
     const updatePromises = reposToUpdate.map((repo) => updateSchemaFile(repo))

--- a/src/schema/v2/artists.ts
+++ b/src/schema/v2/artists.ts
@@ -82,7 +82,7 @@ export const artistsConnection = {
       type: new GraphQLList(GraphQLString),
       description: `
         Only return artists matching specified slugs.
-        Accepts list of slugs. (e.g. 'andy-warhol', 'banksy')
+        Accepts list of slugs (e.g. 'andy-warhol', 'banksy').
       `,
     },
     letter: { type: GraphQLString },


### PR DESCRIPTION
Attempting to fix issue noted in this [revert PR here](https://github.com/artsy/metaphysics/pull/5713). 

The fix is converting the `dest` argument to an array rather than a string, and then allowing the ability to pass multiple output destinations _per repo_. With this in place we no longer clobber the previous git push in the array of repos, but rather perform two operations if necessary (as is the case with volt, where we need to output two different schema types).

cc @artsy/amber-devs 