### PR TITLE
fix(DIA-577): does throw an error when term is ''

### DIFF
--- a/src/schema/v2/CollectorProfile/collectorProfiles.ts
+++ b/src/schema/v2/CollectorProfile/collectorProfiles.ts
@@ -31,13 +31,16 @@ export const CollectorProfilesConnection: GraphQLFieldConfig<
     { term, partnerID, ...args },
     { collectorProfilesLoader }
   ) => {
-    if (!collectorProfilesLoader)
+    if (!collectorProfilesLoader) {
       throw new Error(
         "A X-Access-Token header is required to perform this action."
       )
-
-    if (!partnerID || !term) {
-      throw new Error("Arguments `partnerID` and `term` are required.")
+    }
+    if (!partnerID) {
+      throw new Error("Argument `partnerID` is required.")
+    }
+    if (term == undefined) {
+      throw new Error("Argument `term` is required.")
     }
 
     const { page, size, offset } = convertConnectionArgsToGravityArgs(args)

--- a/src/schema/v2/__tests__/collectorProfiles.test.ts
+++ b/src/schema/v2/__tests__/collectorProfiles.test.ts
@@ -57,31 +57,57 @@ describe("collectorProfilesConnection", () => {
     })
   })
 
-  it("returns an error if the partnerID or term arguments are missing", async () => {
+  it("returns an error partnerID argument is missing", async () => {
     const missingArgsQuery = gql`
       {
         collectorProfilesConnection(first: 5) {
           totalCount
-          edges {
-            node {
-              name
-            }
-          }
         }
       }
     `
 
     try {
-      await runQuery(missingArgsQuery, {
-        collectorProfilesLoader,
-      })
+      await runQuery(missingArgsQuery, { collectorProfilesLoader })
       throw new Error("An error was not thrown but was expected.")
     } catch (error) {
       /* eslint-disable jest/no-conditional-expect */
       /* eslint-disable jest/no-try-expect */
-      expect(error.message).toEqual(
-        "Arguments `partnerID` and `term` are required."
-      )
+      expect(error.message).toEqual("Argument `partnerID` is required.")
     }
+  })
+
+  it("returns an error term argument is missing", async () => {
+    const missingArgsQuery = gql`
+      {
+        collectorProfilesConnection(first: 5, partnerID: "test-id") {
+          totalCount
+        }
+      }
+    `
+
+    try {
+      await runQuery(missingArgsQuery, { collectorProfilesLoader })
+      throw new Error("An error was not thrown but was expected.")
+    } catch (error) {
+      /* eslint-disable jest/no-conditional-expect */
+      /* eslint-disable jest/no-try-expect */
+      expect(error.message).toEqual("Argument `term` is required.")
+    }
+  })
+
+  it("returns the data when term is ''", async () => {
+    const query = gql`
+      {
+        collectorProfilesConnection(first: 5, partnerID: "test-id", term: "") {
+          totalCount
+        }
+      }
+    `
+
+    const { collectorProfilesConnection } = await runQuery(query, {
+      collectorProfilesLoader,
+    })
+
+    expect(collectorProfilesConnection.totalCount).toBe(2)
   })
 })


### PR DESCRIPTION
[DIA-577]

Fixes the annoying error we see on volt-v2 when the term is an empty string. That's harmless and it is how it works by default in gravity, it accepts an empty string in the `name_contains` filter field.

<img width="385" alt="image" src="https://github.com/artsy/metaphysics/assets/15792853/e97389c9-0e72-4b31-9ab6-76a3f475d2cf">
