### PR TITLE
chore: remove unused `partnerBiographyBlurb` field from artist schema 

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1841,9 +1841,6 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     # The number of PartnerArtists to return
     size: Int
   ): [PartnerArtist]
-
-  # The Partner's provided biography for the artist
-  partnerBiographyBlurb(format: Format): partnerBiographyBlurb
   partnersConnection(
     after: String
     before: String
@@ -14595,10 +14592,6 @@ type PartnerArtworkGrid implements ArtworkContextGrid {
   ctaHref: String
   ctaTitle: String
   title: String
-}
-
-type partnerBiographyBlurb {
-  text: String
 }
 
 type PartnerCategory {

--- a/src/schema/v2/artist/__tests__/index.test.js
+++ b/src/schema/v2/artist/__tests__/index.test.js
@@ -459,15 +459,17 @@ describe("Artist type", () => {
               }
             }
           `
-          return runQuery(query, context).then((data) => {
-            expect(data).toEqual({
-              artist: {
-                biographyBlurb: {
-                  text: "<p>new catty bio</p>\n",
-                  credit: "Submitted by Catty Partner",
-                  partnerID: "catty-partner",
+          it("returns the correct bio data", () => {
+            return runQuery(query, context).then((data) => {
+              expect(data).toEqual({
+                artist: {
+                  biographyBlurb: {
+                    text: "<p>new catty bio</p>\n",
+                    credit: "Submitted by Catty Partner",
+                    partnerID: "catty-partner",
+                  },
                 },
-              },
+              })
             })
           })
         })

--- a/src/schema/v2/artist/__tests__/index.test.js
+++ b/src/schema/v2/artist/__tests__/index.test.js
@@ -571,61 +571,6 @@ describe("Artist type", () => {
     })
   })
 
-  describe("partnerBiographyBlurb", () => {
-    const query = `
-      {
-        artist(id: "foo-bar") {
-          partnerBiographyBlurb {
-            text   
-          }
-        }
-      }
-    `
-    it("returns the partners provided biography", () => {
-      const partnerArtists = Promise.resolve([
-        {
-          biography: "Oh hello, I am a bio",
-        }
-      ])
-      context.partnerArtistsForArtistLoader = sinon
-        .stub()
-        .withArgs(artist.id)
-        .returns(partnerArtists)
-
-      return runQuery(query, context).then((data) => {
-        expect(data).toEqual({
-          artist: {
-            partnerBiographyBlurb: {
-              text: "Oh hello, I am a bio",
-            },
-          },
-        })
-      })
-    })
-
-    it("returns the null if no partners provided biography", () => {
-      const partnerArtists = Promise.resolve([
-        {
-          biography: null,
-        }
-      ])
-      context.partnerArtistsForArtistLoader = sinon
-        .stub()
-        .withArgs(artist.id)
-        .returns(partnerArtists)
-
-      return runQuery(query, context).then((data) => {
-        expect(data).toEqual({
-          artist: {
-            partnerBiographyBlurb: {
-              text: null,
-            },
-          },
-        })
-      })
-    })
-  })
-
   describe("concerning related shows", () => {
     beforeEach(() => {
       const partnerlessShow = {

--- a/src/schema/v2/artist/__tests__/index.test.js
+++ b/src/schema/v2/artist/__tests__/index.test.js
@@ -410,7 +410,7 @@ describe("Artist type", () => {
       })
     })
   })
-  describe("biographyBlurb", () => {
+  describe("biographyBlurb with artist data", () => {
     it("returns the blurb if present", () => {
       artist.blurb = "catty blurb"
       const query = `
@@ -429,7 +429,7 @@ describe("Artist type", () => {
       })
     })
   })
-  describe("biographyBlurb", () => {
+  describe("biographyBlurb with partner data", () => {
     describe("with partnerBio set to true", () => {
       describe("with a featured partner bio", () => {
         beforeEach(() => {
@@ -470,10 +470,6 @@ describe("Artist type", () => {
               },
             })
           })
-        })
-        it("returns the featured partner bio without an artsy blurb", () => {})
-        it("returns the featured partner bio with an artsy blurb", () => {
-          artist.blurb = "artsy blurb"
         })
       })
       describe("without a featured partner bio", () => {

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -868,38 +868,6 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ id }, options, { partnerArtistsForArtistLoader }) =>
           partnerArtistsForArtistLoader(id, options),
       },
-      partnerBiographyBlurb: {
-        description: "The Partner's provided biography for the artist",
-        args: {
-          ...markdown().args,
-        },
-        type: new GraphQLObjectType<any, ResolverContext>({
-          name: "partnerBiographyBlurb",
-          fields: {
-            text: {
-              type: GraphQLString,
-              resolve: ({ text }) => text,
-            },
-          },
-        }),
-        resolve: async (
-          { id },
-          { format },
-          { partnerArtistsForArtistLoader }
-        ) => {
-          const partnerArtists = await partnerArtistsForArtistLoader(id, {
-            size: 1,
-          })
-
-          if (partnerArtists && partnerArtists.length) {
-            const { biography } = first(partnerArtists) as any
-
-            return {
-              text: formatMarkdownValue(biography, format),
-            }
-          }
-        },
-      },
       duplicates: {
         type: new GraphQLList(Artist.type),
         resolve: ({ id }, _args, { artistDuplicatesLoader }, _info) => {


### PR DESCRIPTION
Removes unused `partnerBiographyBlurb` field from artist schema


It was not used and perhaps we need to devise a different solution for our needs as per the discussion [here](https://github.com/artsy/metaphysics/pull/5693#discussion_r1579434764)
https://github.com/artsy/metaphysics/pull/5693

Additionally cleans up some of the specs to make the linter happy

### Question
- Im always nervous about this, no clients should be using this field, is it ok to just delete from the schema? vs deprecating etc