### PR TITLE
chore: enable blurhashes on Eigen

### DIFF
--- a/src/schema/v2/image/__tests__/index.test.js
+++ b/src/schema/v2/image/__tests__/index.test.js
@@ -66,23 +66,97 @@ describe("Image type", () => {
   })
 
   describe("blurhashDataURL", () => {
-    const mockIsFeatureFlagEnabled = isFeatureFlagEnabled
+    describe("when the feature flag is enabled", () => {
+      const mockIsFeatureFlagEnabled = isFeatureFlagEnabled
 
-    it("returns a data URL for a given blurhash", () => {
-      mockIsFeatureFlagEnabled.mockReturnValue(true)
+      it("returns a data URL when client is not Eigen", () => {
+        mockIsFeatureFlagEnabled.mockReturnValue(true)
 
-      const query = `{
-        artwork(id: "richard-prince-untitled-portrait") {
-          image {
-            blurhashDataURL
+        const query = `{
+          artwork(id: "richard-prince-untitled-portrait") {
+            image {
+              blurhashDataURL
+            }
           }
+        }`
+        assign(image, { blurhash: "LGHLe$4oIU-;_3%MbHRj~pIo%MM{" })
+        return runQuery(query, context).then((data) => {
+          expect(data.artwork.image.blurhashDataURL).toStartWith(
+            "data:image/png;base64,"
+          )
+        })
+      })
+
+      it("returns a data URL when client is Eigen", () => {
+        mockIsFeatureFlagEnabled.mockReturnValue(true)
+
+        const query = `{
+          artwork(id: "richard-prince-untitled-portrait") {
+            image {
+              blurhashDataURL
+            }
+          }
+        }`
+        assign(image, { blurhash: "LGHLe$4oIU-;_3%MbHRj~pIo%MM{" })
+
+        const context = {
+          artworkLoader: sinon
+            .stub()
+            .withArgs(artwork.id)
+            .returns(Promise.resolve(artwork)),
+          userAgent: "Artsy-Mobile/version-Eigen/build-number/app-version",
         }
-      }`
-      assign(image, { blurhash: "LGHLe$4oIU-;_3%MbHRj~pIo%MM{" })
-      return runQuery(query, context).then((data) => {
-        expect(data.artwork.image.blurhashDataURL).toStartWith(
-          "data:image/png;base64,"
-        )
+        return runQuery(query, context).then((data) => {
+          expect(data.artwork.image.blurhashDataURL).toStartWith(
+            "data:image/png;base64,"
+          )
+        })
+      })
+    })
+
+    describe("when the feature flag is disabled", () => {
+      const mockIsFeatureFlagEnabled = isFeatureFlagEnabled
+
+      it("returns data URL as null when client is not Eigen", () => {
+        mockIsFeatureFlagEnabled.mockReturnValue(false)
+
+        const query = `{
+          artwork(id: "richard-prince-untitled-portrait") {
+            image {
+              blurhashDataURL
+            }
+          }
+        }`
+        assign(image, { blurhash: "LGHLe$4oIU-;_3%MbHRj~pIo%MM{" })
+        return runQuery(query, context).then((data) => {
+          expect(data.artwork.image.blurhashDataURL).toBeNull()
+        })
+      })
+
+      it("returns a data URL when client is Eigen", () => {
+        mockIsFeatureFlagEnabled.mockReturnValue(false)
+
+        const query = `{
+          artwork(id: "richard-prince-untitled-portrait") {
+            image {
+              blurhashDataURL
+            }
+          }
+        }`
+        assign(image, { blurhash: "LGHLe$4oIU-;_3%MbHRj~pIo%MM{" })
+
+        const context = {
+          artworkLoader: sinon
+            .stub()
+            .withArgs(artwork.id)
+            .returns(Promise.resolve(artwork)),
+          userAgent: "Artsy-Mobile/version-Eigen/build-number/app-version",
+        }
+        return runQuery(query, context).then((data) => {
+          expect(data.artwork.image.blurhashDataURL).toStartWith(
+            "data:image/png;base64,"
+          )
+        })
       })
     })
   })

--- a/src/schema/v2/image/index.ts
+++ b/src/schema/v2/image/index.ts
@@ -70,10 +70,11 @@ export const ImageType = new GraphQLObjectType<any, ResolverContext>({
           defaultValue: 64,
         },
       },
-      resolve: ({ blurhash, aspect_ratio }, { width }) => {
-        const isBlurhashEnabled = isFeatureFlagEnabled(
-          "diamond_blurhash-enabled-globally"
-        )
+      resolve: ({ blurhash, aspect_ratio }, { width }, { userAgent }) => {
+        const isEigen = userAgent?.match("Artsy-Mobile") != null
+
+        const isBlurhashEnabled =
+          isEigen || isFeatureFlagEnabled("diamond_blurhash-enabled-globally")
 
         if (!isBlurhashEnabled) return null
         if (!blurhash) return null


### PR DESCRIPTION
This PR is a follow-up on https://github.com/artsy/metaphysics/pull/5722

Since the SEO issue is related to Web, I figured out why not keep this enabled on App. Please let me know what you think.