### PR TITLE
feat: add initial user activity sentence to collector profile summary

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4242,9 +4242,7 @@ type CollectorProfileType implements Node {
   ): String
   savedArtworksCount: Int!
   selfReportedPurchases: String
-
-  # A partner-specific sentence describing the collector.
-  summarySentence(partnerID: String!): String!
+  summarySentence: String
   totalBidsCount: Int!
   userInterests: [UserInterest]!
     @deprecated(reason: "Use \"owner#interestsConnection\" field instead.")
@@ -11422,9 +11420,7 @@ type InquirerCollectorProfile {
   ): String
   savedArtworksCount: Int!
   selfReportedPurchases: String
-
-  # A partner-specific sentence describing the collector.
-  summarySentence(partnerID: String!): String!
+  summarySentence: String
   totalBidsCount: Int!
   userInterests: [UserInterest]!
     @deprecated(reason: "Use \"owner#interestsConnection\" field instead.")
@@ -19192,9 +19188,7 @@ type UpdateCollectorProfilePayload {
   ): String
   savedArtworksCount: Int!
   selfReportedPurchases: String
-
-  # A partner-specific sentence describing the collector.
-  summarySentence(partnerID: String!): String!
+  summarySentence: String
   totalBidsCount: Int!
   userInterests: [UserInterest]!
     @deprecated(reason: "Use \"owner#interestsConnection\" field instead.")

--- a/src/schema/v2/CollectorProfile/collectorProfile.ts
+++ b/src/schema/v2/CollectorProfile/collectorProfile.ts
@@ -27,6 +27,9 @@ import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { createPageCursors } from "../fields/pagination"
 import { connectionFromArraySlice } from "graphql-relay"
 import { PartnerEngagementType } from "./partnerEngagement"
+import { SummarySentenceField } from "./summarySentence"
+
+// TODO: Add typing based on Gravity JSON
 
 export const CollectorProfileFields: GraphQLFieldConfigMap<
   any,
@@ -219,18 +222,7 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
       !!profession &&
       !!other_relevant_positions,
   },
-  summarySentence: {
-    type: new GraphQLNonNull(GraphQLString),
-    description: "A partner-specific sentence describing the collector.",
-    args: {
-      partnerID: {
-        type: new GraphQLNonNull(GraphQLString),
-      },
-    },
-    resolve: () => {
-      return "This collector exists."
-    },
-  },
+  summarySentence: SummarySentenceField,
 }
 
 export const CollectorProfileType = new GraphQLObjectType<any, ResolverContext>(

--- a/src/schema/v2/CollectorProfile/summarySentence.ts
+++ b/src/schema/v2/CollectorProfile/summarySentence.ts
@@ -1,0 +1,33 @@
+import { GraphQLString } from "graphql"
+
+const userActivitySentence = ({
+  artsy_user_since,
+  confirmed_buyer_at,
+  first_name_last_initial,
+}) => {
+  let userActivityFragment = `${first_name_last_initial} is `
+  if (confirmed_buyer_at) {
+    userActivityFragment += "a Confirmed Artsy Buyer."
+  } else if (artsy_user_since) {
+    const thirtyDaysAgo = new Date(Date.now() - 1000 * 60 * 60 * 24 * 30)
+    const signedUpWithin30Days = new Date(artsy_user_since) > thirtyDaysAgo
+
+    userActivityFragment += signedUpWithin30Days ? "a New" : "an Active"
+
+    userActivityFragment += " Artsy user."
+  }
+
+  return userActivityFragment
+}
+
+export const SummarySentenceField = {
+  type: GraphQLString,
+  resolve: (collectorProfile) => {
+    const { artsy_user_since } = collectorProfile
+
+    // If anon. session owner (old conversations), return nothing.
+    if (!artsy_user_since) return null
+
+    return userActivitySentence(collectorProfile)
+  },
+}


### PR DESCRIPTION
Getting started with generating the first part of the summary: "Matt Z is a Confirmed Artsy Buyer / New Artsy user / Active Artsy user".

This wound up being really simple b/c the data points needed to generate this sentence are already available on the collector profile. Subsequent parts of the summary (my collection info cross-referenced with partner inventory, etc.) might be more challenging - not sure if these can wholly be constructed in MP, or we might need some new API's (an API for my collection that accepts a partner id and returns partner-specific relevant info from my collection, that sort of thing).

But for now...it's something!