### PR TITLE
Update exchange schema

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4835,6 +4835,9 @@ input CommerceCreatePartnerOfferOrderInput {
   # EditionSet Id
   editionSetId: String
 
+  # Impulse conversation id corresponding to an order.
+  impulseConversationId: String
+
   # PartnerOffer Id
   partnerOfferId: String!
 
@@ -15923,7 +15926,10 @@ type Query {
   ): CommerceBankAccountBalance
 
   # Buyer Activity Data for Collector Resume
-  commerceBuyerActivity(buyerId: String!): CommerceBuyerActivity
+  commerceBuyerActivity(
+    buyerId: String!
+    sellerId: String
+  ): CommerceBuyerActivity
 
   # Find list of competing orders
   commerceCompetingOrders(

--- a/src/data/exchange.graphql
+++ b/src/data/exchange.graphql
@@ -630,6 +630,11 @@ input CreatePartnerOfferOrderInput {
   editionSetId: String
 
   """
+  Impulse conversation id corresponding to an order.
+  """
+  impulseConversationId: String
+
+  """
   PartnerOffer Id
   """
   partnerOfferId: String!
@@ -1853,7 +1858,7 @@ type Query {
   """
   Buyer Activity Data for Collector Resume
   """
-  buyerActivity(buyerId: String!): BuyerActivity
+  buyerActivity(buyerId: String!, sellerId: String): BuyerActivity
 
   """
   Find list of competing orders


### PR DESCRIPTION
This PR updates the stitched exchange schema. It removes the [@specifiedBy directive included in the exchange schema](https://github.com/artsy/exchange/blob/dce6ba4cbdf6cae02b893dd9e9d39c4a7833f486/_schema.graphql#L671) because that directive is not supported. 

Related to [EMI-1866], blocks artsy/force#13872

[EMI-1866]: https://artsyproduct.atlassian.net/browse/EMI-1866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ