### PR TITLE
feat: use artist career highlights for artist insights

### DIFF
--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -41,6 +41,7 @@ export default (opts) => {
       { method: "POST" }
     ),
     artistArtworksLoader: gravityLoader((id) => `artist/${id}/artworks`),
+    artistCareerHighlightsLoader: gravityLoader("artist_career_highlights"),
     artistGenesLoader: gravityLoader((id) => `artist/${id}/genome/genes`),
     artistLoader: gravityLoader((id) => `artist/${id}`),
     artistsLoader: gravityLoader("artists", {}, { headers: true }),

--- a/src/schema/v2/artist/__tests__/helpers.test.ts
+++ b/src/schema/v2/artist/__tests__/helpers.test.ts
@@ -21,16 +21,6 @@ describe("getArtistInsights", () => {
 
     const fields = [
       {
-        key: "solo_show_institutions",
-        kind: "SOLO_SHOW",
-        value,
-      },
-      {
-        key: "group_show_institutions",
-        kind: "GROUP_SHOW",
-        value,
-      },
-      {
         key: "review_sources",
         kind: "REVIEWED",
         value,
@@ -38,11 +28,6 @@ describe("getArtistInsights", () => {
       {
         key: "biennials",
         kind: "BIENNIAL",
-        value,
-      },
-      {
-        key: "collections",
-        kind: "COLLECTED",
         value,
       },
     ]

--- a/src/schema/v2/artist/__tests__/insights.test.ts
+++ b/src/schema/v2/artist/__tests__/insights.test.ts
@@ -5,6 +5,8 @@ describe("ArtistInsights type", () => {
   let artist = null as any
   let context = null as any
 
+  const artistCareerHighlightsLoader = jest.fn(() => Promise.resolve(null))
+
   beforeEach(() => {
     artist = {
       id: "foo-bar",
@@ -12,6 +14,7 @@ describe("ArtistInsights type", () => {
     }
     context = {
       artistLoader: () => Promise.resolve(artist),
+      artistCareerHighlightsLoader,
     }
   })
 
@@ -35,9 +38,14 @@ describe("ArtistInsights type", () => {
   })
 
   it("returns all insights when they are present", () => {
-    artist.solo_show_institutions = "MoMA PS1|Museum of Modern Art (MoMA)"
-    artist.group_show_institutions = "Metropolitan Museum of Art"
-    artist.collections = "Museum of Modern Art (MoMA)"
+    artistCareerHighlightsLoader
+      .mockReturnValueOnce([
+        { venue: "MoMA PS1" },
+        { venue: "Museum of Modern Art (MoMA)" },
+      ])
+      .mockReturnValueOnce([{ venue: "Metropolitan Museum of Art" }])
+      .mockReturnValueOnce([{ venue: "Museum of Modern Art (MoMA)" }])
+
     artist.review_sources = "Artforum International Magazine"
     artist.biennials = "frieze"
     artist.active_secondary_market = true
@@ -92,9 +100,14 @@ describe("ArtistInsights type", () => {
   })
 
   it("returns only matching insights when a kind is specified", () => {
-    artist.solo_show_institutions = "MoMA PS1|Museum of Modern Art (MoMA)"
-    artist.group_show_institutions = "Metropolitan Museum of Art"
-    artist.collections = "Museum of Modern Art (MoMA)"
+    artistCareerHighlightsLoader
+      .mockResolvedValueOnce([
+        { venue: "MoMA PS1" },
+        { venue: "Museum of Modern Art (MoMA)" },
+      ])
+      .mockResolvedValueOnce([{ venue: "Metropolitan Museum of Art" }])
+      .mockResolvedValue([{ venue: "Museum of Modern Art (MoMA)" }])
+
     artist.review_sources = "Artforum International Magazine"
     artist.biennials = "frieze"
     artist.active_secondary_market = true
@@ -124,9 +137,13 @@ describe("ArtistInsights type", () => {
   })
 
   it("returns only matching insights when a few kinds are specified", () => {
-    artist.solo_show_institutions = "MoMA PS1|Museum of Modern Art (MoMA)"
-    artist.group_show_institutions = "Metropolitan Museum of Art"
-    artist.collections = "Museum of Modern Art (MoMA)"
+    artistCareerHighlightsLoader
+      .mockReturnValue([{ venue: "Metropolitan Museum of Art" }])
+      .mockReturnValueOnce([
+        { venue: "MoMA PS1" },
+        { venue: "Museum of Modern Art (MoMA)" },
+      ])
+
     artist.review_sources = "Artforum International Magazine"
     artist.biennials = "frieze"
     artist.active_secondary_market = true
@@ -166,9 +183,8 @@ describe("ArtistInsights type", () => {
   })
 
   it("returns an empty array when there are no matching insights and a kind is specified", () => {
-    artist.solo_show_institutions = undefined
-    artist.group_show_institutions = "Metropolitan Museum of Art"
-    artist.collections = "Museum of Modern Art (MoMA)"
+    artistCareerHighlightsLoader.mockReturnValueOnce(null)
+
     artist.review_sources = "Artforum International Magazine"
     artist.biennials = "frieze"
     artist.active_secondary_market = true

--- a/src/schema/v2/artist/insights.ts
+++ b/src/schema/v2/artist/insights.ts
@@ -13,6 +13,7 @@ import {
   ARTIST_INSIGHT_KINDS,
   getArtistInsights,
   getAuctionRecord,
+  enrichWithArtistCareerHighlights,
 } from "./helpers"
 import { formatMarkdownValue } from "schema/v2/fields/markdown"
 import Format, { FORMATS } from "schema/v2/input_fields/format"
@@ -76,7 +77,11 @@ export const ArtistInsights: GraphQLFieldConfig<any, ResolverContext> = {
       defaultValue: ARTIST_INSIGHT_KINDS,
     },
   },
-  resolve: async (artist, { kind }, { auctionLotsLoader }) => {
+  resolve: async (
+    artist,
+    { kind },
+    { auctionLotsLoader, artistCareerHighlightsLoader }
+  ) => {
     if (kind.includes("HIGH_AUCTION_RECORD")) {
       const highAuctionRecord = await getAuctionRecord(
         artist,
@@ -85,6 +90,12 @@ export const ArtistInsights: GraphQLFieldConfig<any, ResolverContext> = {
       /* eslint-disable require-atomic-updates */
       artist.highAuctionRecord = highAuctionRecord
     }
+
+    await enrichWithArtistCareerHighlights(
+      kind,
+      artist,
+      artistCareerHighlightsLoader
+    )
 
     const insights = getArtistInsights(artist)
 

--- a/src/schema/v2/me/__tests__/myCollectionInfo.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionInfo.test.ts
@@ -67,33 +67,32 @@ describe("me.myCollectionInfo", () => {
           body: [
             {
               name: "Artist 1",
-              collections: "Collected by a major art publication",
+              collected_by_institutions_count: 10,
               review_sources: "Reviewed by a major art publication",
               artworks_count_within_collection: 3,
             },
             {
               name: "Artist 2",
-              group_show_institutions: "Group show at a major institution",
+              group_shows_count: 1,
               review_sources: "Reviewed by a major art publication",
-              solo_show_institutions: "Solo show at a major institution",
+              solo_shows_count: 2,
             },
             {
               name: "Artist 3",
               active_secondary_market: "Active Secondary Market",
               biennials: "Included in a major biennial",
-              collections: "Collected by a major art publication",
+              collected_by_institutions_count: 1,
             },
             {
               name: "Artist 4",
               active_secondary_market: "Active Secondary Market",
-              collections: "Collected by a major art publication",
+              collected_by_institutions_count: 1,
             },
           ],
         }),
       }
 
       const data = await runAuthenticatedQuery(query, context)
-
       const {
         activeSecondaryMarketCount,
         biennialCount,
@@ -148,6 +147,7 @@ describe("me.myCollectionInfo", () => {
           }
         }
       `
+      const artistCareerHighlightsLoader = jest.fn(() => Promise.resolve(null))
 
       const context: Partial<ResolverContext> = {
         collectionLoader: async () => ({}),
@@ -165,7 +165,12 @@ describe("me.myCollectionInfo", () => {
             },
           ],
         }),
+        artistCareerHighlightsLoader: artistCareerHighlightsLoader,
       }
+
+      artistCareerHighlightsLoader
+        .mockResolvedValueOnce([{ venue: "MoMA PS1" }])
+        .mockResolvedValueOnce(null)
 
       const data = await runAuthenticatedQuery(query, context)
 
@@ -179,7 +184,7 @@ describe("me.myCollectionInfo", () => {
                     "name": "Artist 1",
                   },
                   "entities": Array [
-                    "Collected by a major art publication",
+                    "MoMA PS1",
                   ],
                   "kind": "COLLECTED",
                   "label": "Collected by a major institution",


### PR DESCRIPTION
This PR introduces the `artist_career_highlights` endpoint used for retrieving artist insights (institutions) for solo, group, venues collected by major institutions.

[Gravity PR](https://github.com/artsy/gravity/pull/17668)