### PR TITLE
chore: deprecate partnerBiographyBlurb field from artist schema

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1844,6 +1844,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
 
   # The Partner's provided biography for the artist
   partnerBiographyBlurb(format: Format): partnerBiographyBlurb
+    @deprecated(reason: "This field is deprecated. No longer in use")
   partnersConnection(
     after: String
     before: String

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -870,6 +870,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
       },
       partnerBiographyBlurb: {
         description: "The Partner's provided biography for the artist",
+        deprecationReason: "This field is deprecated. No longer in use",
         args: {
           ...markdown().args,
         },


### PR DESCRIPTION
Marks unused partnerBiographyBlurb field as deprecated from artist schema

It was not used and perhaps we need to devise a different solution for our needs as per the discussion https://github.com/artsy/metaphysics/pull/5693#discussion_r1579434764
https://github.com/artsy/metaphysics/pull/5693

As per [here](https://github.com/artsy/metaphysics/pull/5721/files), eigen stores a reference to this field in certain versions so it is not safe to just directly remove