### PR TITLE
feat: add total count to conversations connection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7578,6 +7578,7 @@ type ConversationConnection {
 
   # Information to aid in pagination.
   pageInfo: PageInfo!
+  totalCount: Int
   totalUnreadCount: Int
 }
 

--- a/src/schema/v2/conversation/conversations.ts
+++ b/src/schema/v2/conversation/conversations.ts
@@ -44,6 +44,10 @@ const Conversations: GraphQLFieldConfig<
   type: connectionDefinitions({
     nodeType: ConversationType,
     connectionFields: {
+      totalCount: {
+        type: GraphQLInt,
+        resolve: ({ total_count }) => total_count,
+      },
       totalUnreadCount: {
         type: GraphQLInt,
         resolve: ({ total_unread_count }) => total_unread_count,
@@ -120,6 +124,7 @@ const Conversations: GraphQLFieldConfig<
       ...params,
     }).then(({ total_count, total_unread_count, conversations }) => {
       return assign(
+        { total_count },
         { total_unread_count },
         connectionFromArraySlice(conversations, args, {
           arrayLength: total_count,

--- a/src/schema/v2/me/__tests__/conversations.test.js
+++ b/src/schema/v2/me/__tests__/conversations.test.js
@@ -108,6 +108,7 @@ describe("Conversations", () => {
         {
           me {
             conversationsConnection(first: 10, type: USER) {
+              totalCount
               totalUnreadCount
               edges {
                 node {
@@ -135,6 +136,7 @@ describe("Conversations", () => {
       }
 
       const expectedConversationData = {
+        totalCount: 2,
         totalUnreadCount: 1,
         edges: [
           {
@@ -180,6 +182,7 @@ describe("Conversations", () => {
         {
           me {
             conversationsConnection(first: 10) {
+              totalCount
               totalUnreadCount
               edges {
                 node {
@@ -207,6 +210,7 @@ describe("Conversations", () => {
       }
 
       const expectedConversationData = {
+        totalCount: 2,
         totalUnreadCount: 1,
         edges: [
           {


### PR DESCRIPTION
This PR adds the `totalCount` field back into the `conversationsConnection` so that the total number of conversations between a collector and a gallery can be displayed in that collector's profile in CMS.