### PR TITLE
chore: remove unneeded ids from attribution class

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3110,12 +3110,7 @@ type Attachment {
 
 # Collection of fields that describe attribution class
 type AttributionClass {
-  # A globally unique ID.
-  id: ID!
   info: String @deprecated(reason: "Prefer `shortDescription`")
-
-  # A type-specific ID likely used as a database ID.
-  internalID: ID!
 
   # Long description (can include multiple sentences) for attribution class
   longDescription: String

--- a/src/lib/attributionClasses.ts
+++ b/src/lib/attributionClasses.ts
@@ -1,6 +1,5 @@
 export default {
   unique: {
-    id: "unique",
     name: "Unique",
     info: null,
     short_description: "Unique work",
@@ -8,7 +7,6 @@ export default {
     long_description: "One-of-a-kind piece.",
   },
   "limited edition": {
-    id: "limited edition",
     name: "Limited edition",
     info: null,
     short_description: "Part of a limited edition set",
@@ -17,7 +15,6 @@ export default {
       "The edition run has ended; the number of works produced is known and included in the listing.",
   },
   "open edition": {
-    id: "open edition",
     name: "Open edition",
     info: null,
     short_description: "From an open edition",
@@ -29,7 +26,6 @@ export default {
     ].join(" "),
   },
   "unknown edition": {
-    id: "unknown edition",
     name: "Unknown edition",
     info: null,
     short_description: "From an unknown edition",

--- a/src/schema/v2/artwork/attributionClass.ts
+++ b/src/schema/v2/artwork/attributionClass.ts
@@ -1,12 +1,10 @@
 import { GraphQLObjectType, GraphQLString, GraphQLList } from "graphql"
 import { ResolverContext } from "types/graphql"
-import { InternalIDFields } from "schema/v2/object_identification"
 
 const AttributionClass = new GraphQLObjectType<any, ResolverContext>({
   name: "AttributionClass",
   description: "Collection of fields that describe attribution class",
   fields: {
-    ...InternalIDFields,
     name: {
       type: GraphQLString,
       description: "Shortest form of attribution class display",


### PR DESCRIPTION
This may or may not have any effect, but taking a random look at this, and it _feels_ wrong. There are no id's associated with these records? We have 'rich' objects in our schema all the time (like `counts`, etc.) that _don't_ have id's. I _think_ id's are good if there are actual database id's backing it, _or_ you need to implement the `Node` interface to allow this object to be refetched via id - neither of which is the case for attribution class.