### PR TITLE
feat: include totalUnreadCount when a partner requests a list of conversations

### DIFF
--- a/src/schema/v2/conversation/conversations.ts
+++ b/src/schema/v2/conversation/conversations.ts
@@ -97,6 +97,7 @@ const Conversations: GraphQLFieldConfig<
       }
 
       params = {
+        expand,
         deleted: false,
         intercepted: false,
         to_id: args.partnerId,

--- a/src/schema/v2/me/__tests__/conversations.test.js
+++ b/src/schema/v2/me/__tests__/conversations.test.js
@@ -36,6 +36,8 @@ describe("Conversations", () => {
         {
           me {
             conversationsConnection(first: 10, type: PARTNER, partnerId: "foo") {
+              totalCount
+              totalUnreadCount
               edges {
                 node {
                   internalID
@@ -62,6 +64,8 @@ describe("Conversations", () => {
       }
 
       const expectedConversationData = {
+        totalCount: 2,
+        totalUnreadCount: 1,
         edges: [
           {
             node: {


### PR DESCRIPTION
This work was motivated by artsy/volt#7560, in which the total count of unread conversations was being fetched separately from the list of conversations. I believe that those should be done in one single query since the Metaphysics schema supports it.

It seems like two separate queries were needed because Metaphysics was returning `null` for `totalUnreadCount` when requested by a partner. It turns out that we were not including the `expand=["total_unread_count"]` param when a partner requests a list of their conversations.

It makes sense to expose the total unread count to partners, so I think that including it in the request params is OK.