### PR TITLE
feat: add artist career highlights mutations

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1688,7 +1688,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
 
     # Filter by solo shows.
     solo: Boolean
-  ): [CareerHighlight!]
+  ): [CareerHighlight!]!
   carousel: ArtistCarousel
   collections: [String]
   contemporary(
@@ -4001,8 +4001,8 @@ type CaptureHoldPayload {
 
 type CareerHighlight implements Node {
   artist: Artist!
-  collected: Boolean
-  group: Boolean
+  collected: Boolean!
+  group: Boolean!
 
   # A globally unique ID.
   id: ID!
@@ -4010,7 +4010,7 @@ type CareerHighlight implements Node {
   # A type-specific ID.
   internalID: ID!
   partner: Partner!
-  solo: Boolean
+  solo: Boolean!
   venue: String!
 }
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1676,6 +1676,19 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   birthday: String
   blurb(format: Format): String
   cached: Int
+  careerHighlights(
+    # Filter by collected shows.
+    collected: Boolean
+
+    # Filter by group shows.
+    group: Boolean
+
+    # The slug or ID of the Partner
+    partnerId: String
+
+    # Filter by solo shows.
+    solo: Boolean
+  ): [CareerHighlight!]
   carousel: ArtistCarousel
   collections: [String]
   contemporary(
@@ -3984,6 +3997,21 @@ type CaptureHoldPayload {
   # A unique identifier for the client performing the mutation.
   clientMutationId: String
   holdOrError: InventoryHoldOrErrorUnion!
+}
+
+type CareerHighlight implements Node {
+  artist: Artist!
+  collected: Boolean
+  group: Boolean
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID.
+  internalID: ID!
+  partner: Partner!
+  solo: Boolean
+  venue: String!
 }
 
 type CausalityLotState {
@@ -7836,6 +7864,33 @@ type CreateBidderPayload {
   clientMutationId: String
 }
 
+type CreateCareerHighlightFailure {
+  mutationError: GravityMutationError
+}
+
+input CreateCareerHighlightInput {
+  artistId: String!
+  clientMutationId: String
+  collected: Boolean
+  group: Boolean
+  partnerId: String!
+  solo: Boolean
+}
+
+type CreateCareerHighlightPayload {
+  # On success: the created Artist Career Highlight.
+  careerHighlightOrError: CreateCareerHighlightSuccessResponseOrError
+  clientMutationId: String
+}
+
+type CreateCareerHighlightSuccess {
+  careerHighlight: CareerHighlight
+}
+
+union CreateCareerHighlightSuccessResponseOrError =
+    CreateCareerHighlightFailure
+  | CreateCareerHighlightSuccess
+
 type CreateCollectionFailure {
   mutationError: GravityMutationError
 }
@@ -8724,6 +8779,29 @@ type DeleteBankAccountPayload {
   clientMutationId: String
   me: Me
 }
+
+type DeleteCareerHighlightFailure {
+  mutationError: GravityMutationError
+}
+
+input DeleteCareerHighlightInput {
+  clientMutationId: String
+  id: String!
+}
+
+type DeleteCareerHighlightPayload {
+  # On success: the deleted Artist Career Highlight is returned
+  careerHighlightOrError: DeleteCareerHighlightSuccessOrErrorType
+  clientMutationId: String
+}
+
+type DeleteCareerHighlightSuccess {
+  careerHighlight: CareerHighlight
+}
+
+union DeleteCareerHighlightSuccessOrErrorType =
+    DeleteCareerHighlightFailure
+  | DeleteCareerHighlightSuccess
 
 type DeleteCollectionFailure {
   mutationError: GravityMutationError
@@ -13135,6 +13213,11 @@ type Mutation {
   # Creates a bidder position
   createBidderPosition(input: BidderPositionInput!): BidderPositionPayload
 
+  # Creates Artist Career Highlight.
+  createCareerHighlight(
+    input: CreateCareerHighlightInput!
+  ): CreateCareerHighlightPayload
+
   # Create a collection
   createCollection(input: createCollectionInput!): createCollectionPayload
 
@@ -13257,6 +13340,11 @@ type Mutation {
 
   # Remove a bank account
   deleteBankAccount(input: DeleteBankAccountInput!): DeleteBankAccountPayload
+
+  # Delete an artist career highlight
+  deleteCareerHighlight(
+    input: DeleteCareerHighlightInput!
+  ): DeleteCareerHighlightPayload
 
   # Delete a collection
   deleteCollection(input: deleteCollectionInput!): deleteCollectionPayload
@@ -13485,6 +13573,11 @@ type Mutation {
   updateArtwork(
     input: UpdateArtworkMutationInput!
   ): UpdateArtworkMutationPayload
+
+  # Updates Artist Career Highlight.
+  updateCareerHighlight(
+    input: UpdateCareerHighlightInput!
+  ): UpdateCareerHighlightPayload
 
   # Updates the flags on a partner.
   updateCMSLastAccessTimestamp(
@@ -19045,6 +19138,32 @@ union updateArtworkResponseOrError = updateArtworkFailure | updateArtworkSuccess
 
 type updateArtworkSuccess {
   artwork: Artwork
+}
+
+type UpdateCareerHighlightFailure {
+  mutationError: GravityMutationError
+}
+
+input UpdateCareerHighlightInput {
+  clientMutationId: String
+  collected: Boolean
+  group: Boolean
+  id: String!
+  solo: Boolean
+}
+
+type UpdateCareerHighlightPayload {
+  # On success: updated Artist Career Highlight.
+  careerHighlightOrError: UpdateCareerHighlightsSuccessResponseOrError
+  clientMutationId: String
+}
+
+union UpdateCareerHighlightsSuccessResponseOrError =
+    UpdateCareerHighlightFailure
+  | UpdateCareerHighlightSuccess
+
+type UpdateCareerHighlightSuccess {
+  careerHighlight: CareerHighlight
 }
 
 type UpdateCMSLastAccessTimestampFailure {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -67,6 +67,21 @@ export default (accessToken, userID, opts) => {
       { method: "POST" }
     ),
     createArtistLoader: gravityLoader("artist", {}, { method: "POST" }),
+    createArtistCareerHighlightLoader: gravityLoader(
+      "artist_career_highlight",
+      {},
+      { method: "POST" }
+    ),
+    updateArtistCareerHighlightLoader: gravityLoader(
+      (id) => `artist_career_highlight/${id}`,
+      {},
+      { method: "PUT" }
+    ),
+    deleteArtistCareerHighlightLoader: gravityLoader(
+      (id) => `artist_career_highlight/${id}`,
+      {},
+      { method: "DELETE" }
+    ),
     createVerifiedRepresentativeLoader: gravityLoader(
       "verified_representatives",
       {},

--- a/src/schema/v2/artist/__tests__/careerHighlights.test.ts
+++ b/src/schema/v2/artist/__tests__/careerHighlights.test.ts
@@ -1,0 +1,87 @@
+/* eslint-disable promise/always-return */
+import { runQuery } from "schema/v2/test/utils"
+
+describe("Artist careerHighlights", () => {
+  const artist = {
+    _id: "123456",
+  }
+
+  const artistLoader = () => Promise.resolve(artist)
+
+  const artistCareerHighlightsResponse = [
+    {
+      id: 1,
+      venue: "Moma",
+      solo: true,
+      group: false,
+      collected: false,
+    },
+    {
+      id: 2,
+      venue: "Guggenheim",
+      solo: false,
+      group: true,
+      collected: false,
+    },
+  ]
+
+  const artistCareerHighlightsLoader = jest
+    .fn()
+    .mockReturnValue(Promise.resolve(artistCareerHighlightsResponse))
+
+  const artistCareerHighlightsWithoutResponse = jest
+    .fn()
+    .mockReturnValue(Promise.resolve([]))
+
+  const context = {
+    artistLoader,
+    artistCareerHighlightsLoader,
+  }
+
+  const contextWithEmptyResponse = {
+    artistLoader,
+    artistCareerHighlightsLoader: artistCareerHighlightsWithoutResponse,
+  }
+
+  describe("with an artist_id", () => {
+    it("returns artist career highlights for an artist", () => {
+      const query = `
+      {
+        artist(id: "xyz") {
+          careerHighlights {
+            venue
+            solo
+            group
+            collected
+          }
+        }
+      }
+    `
+
+      return runQuery(query, context).then(({ artist: { ...response } }) => {
+        const careerHighlights = response.careerHighlights
+        expect(careerHighlights[0].venue).toBe("Moma")
+        expect(careerHighlights[1].venue).toBe("Guggenheim")
+      })
+    })
+
+    it("returns empty list when there are no highlights", () => {
+      const query = `
+      {
+        artist(id: "xyz") {
+          careerHighlights {
+            venue
+            solo
+            group
+            collected
+          }
+        }
+      }
+    `
+
+      return runQuery(query, contextWithEmptyResponse).then((data) => {
+        expect(data.artist.careerHighlights).toEqual([])
+      })
+    })
+  })
+})

--- a/src/schema/v2/artist/careerHighlights.ts
+++ b/src/schema/v2/artist/careerHighlights.ts
@@ -9,7 +9,9 @@ import { ResolverContext } from "types/graphql"
 import { CareerHighlightType } from "../careerHighlight/careerHighlight"
 
 const CareerHighlights: GraphQLFieldConfig<{ _id: string }, ResolverContext> = {
-  type: new GraphQLList(new GraphQLNonNull(CareerHighlightType)),
+  type: new GraphQLNonNull(
+    new GraphQLList(new GraphQLNonNull(CareerHighlightType))
+  ),
   args: {
     partnerId: {
       type: GraphQLString,
@@ -36,16 +38,16 @@ const CareerHighlights: GraphQLFieldConfig<{ _id: string }, ResolverContext> = {
       )
 
       if (!response || !Array.isArray(response)) {
-        console.log(
+        console.error(
           "[schema/v2/artist/careerHighlights.ts] Error: response is not an array or is null."
         )
-        return null
+        return []
       }
 
       return response
     } catch (error) {
       console.error(error)
-      return null
+      return []
     }
   },
 }

--- a/src/schema/v2/artist/careerHighlights.ts
+++ b/src/schema/v2/artist/careerHighlights.ts
@@ -1,0 +1,53 @@
+import {
+  GraphQLFieldConfig,
+  GraphQLBoolean,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLString,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import { CareerHighlightType } from "../careerHighlight/careerHighlight"
+
+const CareerHighlights: GraphQLFieldConfig<{ _id: string }, ResolverContext> = {
+  type: new GraphQLList(new GraphQLNonNull(CareerHighlightType)),
+  args: {
+    partnerId: {
+      type: GraphQLString,
+      description: "The slug or ID of the Partner",
+    },
+    solo: {
+      type: GraphQLBoolean,
+      description: "Filter by solo shows.",
+    },
+    group: {
+      type: GraphQLBoolean,
+      description: "Filter by group shows.",
+    },
+    collected: {
+      type: GraphQLBoolean,
+      description: "Filter by collected shows.",
+    },
+  },
+  resolve: async ({ _id }, options, { artistCareerHighlightsLoader }) => {
+    try {
+      const response = await artistCareerHighlightsLoader(
+        { artist_id: _id, ...options },
+        options
+      )
+
+      if (!response || !Array.isArray(response)) {
+        console.log(
+          "[schema/v2/artist/careerHighlights.ts] Error: response is not an array or is null."
+        )
+        return null
+      }
+
+      return response
+    } catch (error) {
+      console.error(error)
+      return null
+    }
+  },
+}
+
+export default CareerHighlights

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -62,6 +62,7 @@ import { AuctionResultsAggregation } from "../aggregations/filterAuctionResultsA
 import { parsePriceRangeValues } from "lib/moneyHelper"
 import { ArtistGroupIndicatorEnum } from "schema/v2/artist/groupIndicator"
 import { AlertsConnectionType } from "../Alerts"
+import CareerHighlights from "./careerHighlights"
 
 // Manually curated list of artist id's who has verified auction lots that can be
 // returned, when queried for via `recordsTrusted: true`.
@@ -958,6 +959,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ vanguard_year }) => vanguard_year,
       },
       verifiedRepresentatives: VerifiedRepresentatives,
+      careerHighlights: CareerHighlights,
       years: { type: GraphQLString },
     }
   },

--- a/src/schema/v2/careerHighlight/__tests__/createCareerHighlightMutation.test.ts
+++ b/src/schema/v2/careerHighlight/__tests__/createCareerHighlightMutation.test.ts
@@ -1,0 +1,107 @@
+import gql from "lib/gql"
+import { HTTPError } from "lib/HTTPError"
+import { runAuthenticatedQuery, runQuery } from "schema/v2/test/utils"
+
+describe("createCareerHighlightMutation", () => {
+  const mutation = gql`
+    mutation {
+      createCareerHighlight(
+        input: {
+          artistId: "andy-warhol"
+          partnerId: "artsy-hq"
+          solo: true
+          collected: false
+          group: false
+        }
+      ) {
+        careerHighlightOrError {
+          __typename
+          ... on CreateCareerHighlightSuccess {
+            careerHighlight {
+              venue
+            }
+          }
+          ... on CreateCareerHighlightFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  const artistCareerHighlight = {
+    artistId: "xyz",
+    partnerId: "artsy-hq",
+    solo: true,
+    group: false,
+    collected: false,
+    venue: "Artsy HQ",
+    id: "xyz",
+  }
+
+  const context = {
+    createArtistCareerHighlightLoader: jest.fn(() =>
+      Promise.resolve(artistCareerHighlight)
+    ),
+  }
+
+  it("calls the right loader with artist id", async () => {
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(context.createArtistCareerHighlightLoader).toBeCalledWith({
+      artist_id: "andy-warhol",
+      partner_id: "artsy-hq",
+      solo: true,
+      collected: false,
+      group: false,
+    })
+
+    expect(result).toEqual({
+      createCareerHighlight: {
+        careerHighlightOrError: {
+          __typename: "CreateCareerHighlightSuccess",
+          careerHighlight: {
+            venue: "Artsy HQ",
+          },
+        },
+      },
+    })
+  })
+
+  it("throws error when data loader is missing", async () => {
+    const errorResponse =
+      "You need to pass a X-Access-Token header to perform this action"
+
+    try {
+      await runQuery(mutation)
+      throw new Error(
+        "You need to pass a X-Access-Token header to perform this action."
+      )
+    } catch (error) {
+      // eslint-disable-next-line jest/no-conditional-expect, jest/no-try-expect
+      expect(error.message).toEqual(errorResponse)
+    }
+  })
+
+  it("returns gravity errors", async () => {
+    const context = {
+      createArtistCareerHighlightLoader: () =>
+        Promise.reject(new HTTPError(`Forbidden`, 403, "Gravity Error")),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      createCareerHighlight: {
+        careerHighlightOrError: {
+          __typename: "CreateCareerHighlightFailure",
+          mutationError: {
+            message: "Gravity Error",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/careerHighlight/__tests__/deleteCareerHighlightMutation.test.ts
+++ b/src/schema/v2/careerHighlight/__tests__/deleteCareerHighlightMutation.test.ts
@@ -1,0 +1,52 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("deleteCareerHighlightMutation", () => {
+  const mutation = gql`
+    mutation {
+      deleteCareerHighlight(input: { id: "xyz" }) {
+        careerHighlightOrError {
+          __typename
+          ... on DeleteCareerHighlightSuccess {
+            careerHighlight {
+              venue
+            }
+          }
+          ... on DeleteCareerHighlightFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  const artistCareerHighlight = {
+    id: "xyz",
+    venue: "Artsy HQ",
+  }
+
+  const context = {
+    deleteArtistCareerHighlightLoader: jest.fn(() =>
+      Promise.resolve(artistCareerHighlight)
+    ),
+  }
+
+  it("calls the right loader with artist id", async () => {
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(context.deleteArtistCareerHighlightLoader).toBeCalledWith("xyz")
+
+    expect(result).toEqual({
+      deleteCareerHighlight: {
+        careerHighlightOrError: {
+          __typename: "DeleteCareerHighlightSuccess",
+          careerHighlight: {
+            venue: "Artsy HQ",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/careerHighlight/__tests__/updateCareerHighlightMutation.test.ts
+++ b/src/schema/v2/careerHighlight/__tests__/updateCareerHighlightMutation.test.ts
@@ -1,0 +1,57 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("updateCareerHighlightMutation", () => {
+  const mutation = gql`
+    mutation {
+      updateCareerHighlight(input: { id: "xyz", solo: true }) {
+        careerHighlightOrError {
+          __typename
+          ... on UpdateCareerHighlightSuccess {
+            careerHighlight {
+              venue
+              solo
+            }
+          }
+          ... on UpdateCareerHighlightFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  const artistCareerHighlight = {
+    id: "xyz",
+    venue: "Artsy HQ",
+    solo: true,
+  }
+
+  const context = {
+    updateArtistCareerHighlightLoader: jest.fn(() =>
+      Promise.resolve(artistCareerHighlight)
+    ),
+  }
+
+  it("calls the right loader with artist id", async () => {
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(context.updateArtistCareerHighlightLoader).toBeCalledWith("xyz", {
+      solo: true,
+    })
+
+    expect(result).toEqual({
+      updateCareerHighlight: {
+        careerHighlightOrError: {
+          __typename: "UpdateCareerHighlightSuccess",
+          careerHighlight: {
+            venue: "Artsy HQ",
+            solo: true,
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/careerHighlight/careerHighlight.ts
+++ b/src/schema/v2/careerHighlight/careerHighlight.ts
@@ -27,19 +27,19 @@ export const CareerHighlightType = new GraphQLObjectType<any, any>({
         },
       },
       solo: {
-        type: GraphQLBoolean,
+        type: GraphQLNonNull(GraphQLBoolean),
         resolve: ({ solo }) => {
           return solo
         },
       },
       group: {
-        type: GraphQLBoolean,
+        type: GraphQLNonNull(GraphQLBoolean),
         resolve: ({ group }) => {
           return group
         },
       },
       collected: {
-        type: GraphQLBoolean,
+        type: GraphQLNonNull(GraphQLBoolean),
         resolve: ({ collected }) => {
           return collected
         },

--- a/src/schema/v2/careerHighlight/careerHighlight.ts
+++ b/src/schema/v2/careerHighlight/careerHighlight.ts
@@ -1,0 +1,55 @@
+import {
+  GraphQLString,
+  GraphQLBoolean,
+  GraphQLNonNull,
+  GraphQLObjectType,
+} from "graphql"
+import { IDFields, NodeInterface } from "schema/v2/object_identification"
+import { ArtistType } from "schema/v2/artist"
+import { PartnerType } from "schema/v2/partner/partner"
+
+export const CareerHighlightType = new GraphQLObjectType<any, any>({
+  name: "CareerHighlight",
+  interfaces: [NodeInterface],
+  fields: () => {
+    return {
+      ...IDFields,
+      artist: {
+        type: new GraphQLNonNull(ArtistType),
+        resolve: ({ artist_id }, {}, { artistLoader }) => {
+          return artistLoader(artist_id)
+        },
+      },
+      partner: {
+        type: new GraphQLNonNull(PartnerType),
+        resolve: ({ partner_id }, {}, { partnerLoader }) => {
+          return partnerLoader(partner_id)
+        },
+      },
+      solo: {
+        type: GraphQLBoolean,
+        resolve: ({ solo }) => {
+          return solo
+        },
+      },
+      group: {
+        type: GraphQLBoolean,
+        resolve: ({ group }) => {
+          return group
+        },
+      },
+      collected: {
+        type: GraphQLBoolean,
+        resolve: ({ collected }) => {
+          return collected
+        },
+      },
+      venue: {
+        type: GraphQLNonNull(GraphQLString),
+        resolve: ({ venue }) => {
+          return venue
+        },
+      },
+    }
+  },
+})

--- a/src/schema/v2/careerHighlight/createCareerHighlightMutation.ts
+++ b/src/schema/v2/careerHighlight/createCareerHighlightMutation.ts
@@ -1,0 +1,111 @@
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  GraphQLBoolean,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import { CareerHighlightType } from "schema/v2/careerHighlight/careerHighlight"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { snakeCase } from "lodash"
+
+interface Input {
+  artistId: string
+  partnerId: string
+  solo: boolean
+  group: boolean
+  collected: boolean
+}
+
+const inputFields = {
+  artistId: { type: new GraphQLNonNull(GraphQLString) },
+  partnerId: { type: new GraphQLNonNull(GraphQLString) },
+  solo: { type: GraphQLBoolean },
+  group: { type: GraphQLBoolean },
+  collected: { type: GraphQLBoolean },
+}
+
+interface GravityInput {
+  artist_id: string
+  partner_id: string
+  solo: boolean
+  group: boolean
+  collected: boolean
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreateCareerHighlightSuccess",
+  isTypeOf: (data) => data.id,
+  fields: {
+    careerHighlight: {
+      type: CareerHighlightType,
+      resolve: (careerHighlight) => careerHighlight,
+    },
+  },
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreateCareerHighlightFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "CreateCareerHighlightSuccessResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const createCareerHighlightMutation = mutationWithClientMutationId<
+  Input,
+  any,
+  ResolverContext
+>({
+  name: "CreateCareerHighlight",
+  description: "Creates Artist Career Highlight.",
+  inputFields,
+  outputFields: {
+    careerHighlightOrError: {
+      type: ResponseOrErrorType,
+      description: "On success: the created Artist Career Highlight.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (args, { createArtistCareerHighlightLoader }) => {
+    if (!createArtistCareerHighlightLoader) {
+      throw new Error(
+        "You need to pass a X-Access-Token header to perform this action"
+      )
+    }
+
+    const createArtistCareerHighlightLoaderPayload = Object.keys(args)
+      .filter((key) => key !== "id")
+      .reduce(
+        (acc, key) => ({ ...acc, [snakeCase(key)]: args[key] }),
+        {} as GravityInput
+      )
+
+    try {
+      return await createArtistCareerHighlightLoader(
+        createArtistCareerHighlightLoaderPayload
+      )
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/careerHighlight/deleteCareerHighlightMutation.ts
+++ b/src/schema/v2/careerHighlight/deleteCareerHighlightMutation.ts
@@ -1,0 +1,90 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { CareerHighlightType } from "./careerHighlight"
+
+interface Input {
+  id: string
+}
+
+const inputFields = {
+  id: { type: new GraphQLNonNull(GraphQLString) },
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DeleteCareerHighlightSuccess",
+  isTypeOf: (data) => {
+    return data.id
+  },
+  fields: () => ({
+    careerHighlight: {
+      type: CareerHighlightType,
+      resolve: (careerHighlight) => {
+        console.log("careerHighlight")
+        console.log(careerHighlight)
+        return careerHighlight
+      },
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DeleteCareerHighlightFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "DeleteCareerHighlightSuccessOrErrorType",
+  types: [SuccessType, FailureType],
+})
+
+export const deleteCareerHighlightMutation = mutationWithClientMutationId<
+  Input,
+  any | null,
+  ResolverContext
+>({
+  name: "DeleteCareerHighlight",
+  description: "Delete an artist career highlight",
+  inputFields,
+  outputFields: {
+    careerHighlightOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the deleted Artist Career Highlight is returned",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { id },
+    { deleteArtistCareerHighlightLoader }
+  ) => {
+    if (!deleteArtistCareerHighlightLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+    try {
+      return await deleteArtistCareerHighlightLoader(id)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/careerHighlight/updateCareerHighlightMutation.ts
+++ b/src/schema/v2/careerHighlight/updateCareerHighlightMutation.ts
@@ -1,0 +1,109 @@
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  GraphQLBoolean,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import { CareerHighlightType } from "schema/v2/careerHighlight/careerHighlight"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { snakeCase } from "lodash"
+
+interface Input {
+  solo: boolean
+  group: boolean
+  collected: boolean
+  id: string
+}
+
+const inputFields = {
+  solo: { type: GraphQLBoolean },
+  group: { type: GraphQLBoolean },
+  collected: { type: GraphQLBoolean },
+  id: { type: new GraphQLNonNull(GraphQLString) },
+}
+
+interface GravityInput {
+  solo: boolean
+  group: boolean
+  collected: boolean
+  id: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateCareerHighlightSuccess",
+  isTypeOf: (data) => data.id,
+  fields: {
+    careerHighlight: {
+      type: CareerHighlightType,
+      resolve: (careerHighlight) => careerHighlight,
+    },
+  },
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateCareerHighlightFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdateCareerHighlightsSuccessResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const updateCareerHighlightMutation = mutationWithClientMutationId<
+  Input,
+  any,
+  ResolverContext
+>({
+  name: "UpdateCareerHighlight",
+  description: "Updates Artist Career Highlight.",
+  inputFields,
+  outputFields: {
+    careerHighlightOrError: {
+      type: ResponseOrErrorType,
+      description: "On success: updated Artist Career Highlight.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (args, { updateArtistCareerHighlightLoader }) => {
+    if (!updateArtistCareerHighlightLoader) {
+      throw new Error(
+        "You need to pass a X-Access-Token header to perform this action"
+      )
+    }
+
+    const updateArtistCareerHighlightLoaderPayload = Object.keys(args)
+      .filter((key) => key !== "id")
+      .reduce(
+        (acc, key) => ({ ...acc, [snakeCase(key)]: args[key] }),
+        {} as GravityInput
+      )
+
+    try {
+      return await updateArtistCareerHighlightLoader(
+        args.id,
+        updateArtistCareerHighlightLoaderPayload
+      )
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -220,6 +220,9 @@ import { CreateSaleAgreementMutation } from "./SaleAgreements/createSaleAgreemen
 import { UpdateSaleAgreementMutation } from "./SaleAgreements/updateSaleAgreementMutation"
 import { SaleAgreementsConnection } from "./SaleAgreements/saleAgreementsConnection"
 import { SaleAgreement } from "./SaleAgreements/SaleAgreement"
+import { createCareerHighlightMutation } from "./careerHighlight/createCareerHighlightMutation"
+import { deleteCareerHighlightMutation } from "./careerHighlight/deleteCareerHighlightMutation"
+import { updateCareerHighlightMutation } from "./careerHighlight/updateCareerHighlightMutation"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -370,6 +373,9 @@ export default new GraphQLSchema({
       createAlert: createAlertMutation,
       createVerifiedRepresentative: createVerifiedRepresentativeMutation,
       deleteVerifiedRepresentative: deleteVerifiedRepresentativeMutation,
+      createCareerHighlight: createCareerHighlightMutation,
+      updateCareerHighlight: updateCareerHighlightMutation,
+      deleteCareerHighlight: deleteCareerHighlightMutation,
       createArtist: createArtistMutation,
       createBidder: createBidderMutation,
       createBidderPosition: BidderPositionMutation,


### PR DESCRIPTION
[DIA-632](https://artsyproduct.atlassian.net/browse/DIA-632)

This PR adds the mutation for managing artist career highlights.

[Forque PR](https://github.com/artsy/forque/pull/1187)

[DIA-632]: https://artsyproduct.atlassian.net/browse/DIA-632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ