### PR TITLE
feat: support signature information for MyC artworks

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2681,6 +2681,7 @@ type Artwork implements Node & Searchable & Sellable {
   show(active: Boolean, atAFair: Boolean, sort: ShowSorts): Show
   shows(active: Boolean, atAFair: Boolean, size: Int, sort: ShowSorts): [Show]
   signature(format: Format): String
+  signatureDetails: String
   signatureInfo: ArtworkInfoRow
 
   # size bucket assigned to an artwork based on its dimensions
@@ -3023,6 +3024,26 @@ type ArtworksCollectionsBatchUpdateSuccess {
   addedToCollections: [Collection]
   counts: ArtworksCollectionsBatchUpdateCounts
   removedFromCollections: [Collection]
+}
+
+enum ArtworkSignatureTypeEnum {
+  # The artwork is hand signed by the artist
+  HAND_SIGNED_BY_ARTIST
+
+  # The artwork is not signed
+  NOT_SIGNED
+
+  # The artwork has another type of signature
+  OTHER
+
+  # The artwork is signed in the plate
+  SIGNED_IN_PLATE
+
+  # The artwork is stamped by the artist's estate
+  STAMPED_BY_ARTIST_ESTATE
+
+  # The artwork has a sticker label
+  STICKER_LABEL
 }
 
 enum ArtworkSizes {
@@ -13710,6 +13731,8 @@ input MyCollectionCreateArtworkInput {
   pricePaidCents: Long
   pricePaidCurrency: String
   provenance: String
+  signatureDetails: String
+  signatureTypes: [ArtworkSignatureTypeEnum]
   submissionId: String
   title: String!
   width: String
@@ -13796,6 +13819,8 @@ input MyCollectionUpdateArtworkInput {
   pricePaidCents: Long
   pricePaidCurrency: String
   provenance: String
+  signatureDetails: String
+  signatureTypes: [ArtworkSignatureTypeEnum]
   submissionId: String
   title: String
   width: String

--- a/src/schema/v2/artwork/artworkSignatureTypes.ts
+++ b/src/schema/v2/artwork/artworkSignatureTypes.ts
@@ -1,0 +1,50 @@
+import { GraphQLEnumType } from "graphql"
+
+export const ArtworkSignatureTypeEnum = new GraphQLEnumType({
+  name: "ArtworkSignatureTypeEnum",
+  values: {
+    NOT_SIGNED: {
+      value: "not_signed",
+      description: "The artwork is not signed",
+    },
+    HAND_SIGNED_BY_ARTIST: {
+      value: "signed_by_artist",
+      description: "The artwork is hand signed by the artist",
+    },
+    SIGNED_IN_PLATE: {
+      value: "signed_in_plate",
+      description: "The artwork is signed in the plate",
+    },
+    STAMPED_BY_ARTIST_ESTATE: {
+      value: "stamped_by_artist_estate",
+      description: "The artwork is stamped by the artist's estate",
+    },
+    STICKER_LABEL: {
+      value: "sticker_label",
+      description: "The artwork has a sticker label",
+    },
+    OTHER: {
+      value: "signed_other",
+      description: "The artwork has another type of signature",
+    },
+  },
+})
+
+export const transformSignatureFieldsToGravityFields = (
+  signatureTypes: undefined | string[]
+) => {
+  if (!signatureTypes) return {}
+
+  const defaults = ArtworkSignatureTypeEnum.getValues().reduce(
+    (acc, { value }) => {
+      acc[value] = false
+      return acc
+    },
+    {}
+  )
+
+  return signatureTypes.reduce((acc, name) => {
+    acc[name] = true
+    return acc
+  }, defaults)
+}

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1653,6 +1653,10 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       signature: markdown(({ signature }) =>
         signature.replace(/^signature:\s+/i, "")
       ),
+      signatureDetails: {
+        type: GraphQLString,
+        resolve: ({ signature }) => signature,
+      },
       savedSearch: {
         description: "Schema related to saved searches based on this artwork",
         type: new GraphQLObjectType({

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -20,6 +20,8 @@ const artworkDetails = {
       aspect_ratio: 1,
     },
   ],
+  signature: "artist initials",
+  signed_other: true,
 }
 
 const createArtworkLoader = jest.fn().mockResolvedValue(newArtwork)
@@ -69,6 +71,8 @@ const computeMutationInput = ({
           pricePaidCents: 10000
           pricePaidCurrency: "USD"
           provenance: "Pat Hearn Gallery"
+          signatureDetails: "artist initials"
+          signatureTypes: [OTHER]
           title: "hey now"
           width: "20"
           importSource: CONVECTION
@@ -88,6 +92,11 @@ const computeMutationInput = ({
               }
               images(includeAll: true) {
                 imageURL
+              }
+              signature
+              signatureInfo {
+                details
+                label
               }
             }
             artworkEdge {
@@ -173,6 +182,11 @@ describe("myCollectionCreateArtworkMutation", () => {
             "pricePaid": Object {
               "display": "$100",
             },
+            "signature": "artist initials",
+            "signatureInfo": Object {
+              "details": "Artist initials",
+              "label": "Signature",
+            },
           },
           "artworkEdge": Object {
             "node": Object {
@@ -223,6 +237,7 @@ describe("myCollectionCreateArtworkMutation", () => {
         category: "some strange category",
         collection_id: "my-collection",
         collector_location: { city: "Berlin", country: "Germany" },
+        confidential_notes: undefined,
         cost_currency_code: "USD",
         cost_minor: 200,
         date: "1990",
@@ -231,9 +246,16 @@ describe("myCollectionCreateArtworkMutation", () => {
         import_source: "convection",
         medium: "Painting",
         metric: "in",
+        not_signed: false,
         price_paid_cents: 10000,
         price_paid_currency: "USD",
         provenance: "Pat Hearn Gallery",
+        signature: "artist initials",
+        signed_by_artist: false,
+        signed_in_plate: false,
+        signed_other: true,
+        stamped_by_artist_estate: false,
+        sticker_label: false,
         submission_id: undefined,
         title: "hey now",
         width: "20",
@@ -268,6 +290,11 @@ describe("myCollectionCreateArtworkMutation", () => {
             "medium": "Painting",
             "pricePaid": Object {
               "display": "$100",
+            },
+            "signature": "artist initials",
+            "signatureInfo": Object {
+              "details": "Artist initials",
+              "label": "Signature",
             },
           },
           "artworkEdge": Object {

--- a/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
@@ -41,6 +41,8 @@ const defaultArtworkDetails = ({
   title: "hey now",
   width: "20",
   attribution_class: "open edition",
+  signature: "artist initials",
+  signed_other: true,
   submissionId: "submission-id",
 })
 
@@ -85,6 +87,8 @@ const computeMutationInput = ({
           pricePaidCents: 10000
           pricePaidCurrency: "USD"
           provenance: "Pat Hearn Gallery"
+          signatureDetails: "artist initials"
+          signatureTypes: [OTHER]
           title: "hey now"
           width: "20"
           submissionId: "submission-id"
@@ -118,6 +122,11 @@ const computeMutationInput = ({
               }
               attributionClass{
                 name
+              }
+              signature
+              signatureInfo {
+                details
+                label
               }
             }
             artworkEdge {
@@ -216,6 +225,11 @@ describe("myCollectionUpdateArtworkMutation", () => {
               "display": "$100",
             },
             "provenance": "Pat Hearn Gallery",
+            "signature": "artist initials",
+            "signatureInfo": Object {
+              "details": "Artist initials",
+              "label": "Signature",
+            },
             "title": "hey now",
             "width": "20",
           },
@@ -268,6 +282,11 @@ describe("myCollectionUpdateArtworkMutation", () => {
               "display": "$100",
             },
             "provenance": "Pat Hearn Gallery",
+            "signature": "artist initials",
+            "signatureInfo": Object {
+              "details": "Artist initials",
+              "label": "Signature",
+            },
             "title": "hey now",
             "width": "20",
           },

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -16,6 +16,10 @@ import { ResolverContext } from "types/graphql"
 import { ArtworkImportSourceEnum } from "../artwork"
 import { MyCollectionArtworkMutationType } from "./myCollection"
 import { EditableLocationFields } from "./update_me_mutation"
+import {
+  ArtworkSignatureTypeEnum,
+  transformSignatureFieldsToGravityFields,
+} from "../artwork/artworkSignatureTypes"
 
 export const externalUrlRegex = /https:\/\/(?<sourceBucket>.*).s3.amazonaws.com\/(?<sourceKey>.*)/
 
@@ -131,6 +135,12 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
     provenance: {
       type: GraphQLString,
     },
+    signatureDetails: {
+      type: GraphQLString,
+    },
+    signatureTypes: {
+      type: new GraphQLList(ArtworkSignatureTypeEnum),
+    },
     width: {
       type: GraphQLString,
     },
@@ -162,6 +172,8 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
       isEdition,
       pricePaidCents,
       pricePaidCurrency,
+      signatureDetails,
+      signatureTypes,
       submissionId,
       ...rest
     },
@@ -214,6 +226,8 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
         collector_location: collectorLocation,
         attribution_class: attributionClass,
         import_source: importSource,
+        signature: signatureDetails,
+        ...transformSignatureFieldsToGravityFields(signatureTypes),
         ...rest,
       })
 

--- a/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
@@ -16,6 +16,10 @@ import {
   transformToPricePaidCents,
 } from "./myCollectionCreateArtworkMutation"
 import { EditableLocationFields } from "./update_me_mutation"
+import {
+  ArtworkSignatureTypeEnum,
+  transformSignatureFieldsToGravityFields,
+} from "../artwork/artworkSignatureTypes"
 
 interface MyCollectionArtworkUpdateMutationInput {
   artworkId: string
@@ -36,6 +40,8 @@ interface MyCollectionArtworkUpdateMutationInput {
   collectorLocation?: Record<string, string>
   pricePaidCents?: number
   pricePaidCurrency?: string
+  signatureDetails?: string
+  signatureTypes?: [string]
   submissionId?: string
 }
 
@@ -114,6 +120,12 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
     provenance: {
       type: GraphQLString,
     },
+    signatureDetails: {
+      type: GraphQLString,
+    },
+    signatureTypes: {
+      type: new GraphQLList(ArtworkSignatureTypeEnum),
+    },
     submissionId: {
       type: GraphQLString,
     },
@@ -147,6 +159,8 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
       isEdition,
       pricePaidCents,
       pricePaidCurrency,
+      signatureDetails,
+      signatureTypes,
       submissionId,
       ...rest
     },
@@ -188,6 +202,8 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
         price_paid_currency: pricePaidCurrency,
         attribution_class: attributionClass,
         submission_id: submissionId,
+        signature: signatureDetails,
+        ...transformSignatureFieldsToGravityFields(signatureTypes),
         ...rest,
       })
 


### PR DESCRIPTION
- Specifiy signature details (as open text input)
- Specify signature types (via structured enum)

**Request**

```graphql
mutation {
  myCollectionUpdateArtwork(input: {
    signatureDetails: "artist initials",
    signatureTypes: [HAND_SIGNED_BY_ARTIST]
  }) {
    artworkOrError {
      ... on MyCollectionArtworkMutationSuccess {
        artwork {
          internalID
          signature
          signatureInfo {
	    details
	    label
          }
        }
      }
    }
  }
}
```

**Response**

```json
{
  "data": {
    "myCollectionCreateArtwork": {
      "artworkOrError": {
        "artwork": {
          "internalID": "64de2e913850ca000dd2b967",
          "signature": "artist initials",
          "signatureInfo": {
            "details": "Hand-signed by artist, artist initials",
            "label": "Signature"
          }
        }
     }
  }
}
```