### PR TITLE
fix: Expose visibilityLevel argument on partner artworksConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14374,7 +14374,7 @@ type Partner implements Node {
     sort: ArtworkSorts
 
     # Return artworks according to visibility levels. Defaults to ["listed"].
-    visibilityLevels: [VisibilityEnumInput]
+    visibilityLevels: [Visibility]
   ): ArtworkConnection
   artworksSearchConnection(
     after: String
@@ -21915,11 +21915,6 @@ input ViewingRoomSubsectionInput {
 }
 
 enum Visibility {
-  LISTED
-  UNLISTED
-}
-
-enum VisibilityEnumInput {
   LISTED
   UNLISTED
 }

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14372,6 +14372,9 @@ type Partner implements Node {
     # properties on an artwork, when true or not present fetch artwork :short properties
     shallow: Boolean
     sort: ArtworkSorts
+
+    # Return artworks according to visibility levels. Defaults to ["listed"].
+    visibilityLevels: [VisibilityEnumInput]
   ): ArtworkConnection
   artworksSearchConnection(
     after: String
@@ -21912,6 +21915,11 @@ input ViewingRoomSubsectionInput {
 }
 
 enum Visibility {
+  LISTED
+  UNLISTED
+}
+
+enum VisibilityEnumInput {
   LISTED
   UNLISTED
 }

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14373,7 +14373,7 @@ type Partner implements Node {
     shallow: Boolean
     sort: ArtworkSorts
 
-    # Return artworks according to visibility levels. Defaults to ["listed"].
+    # Return artworks according to visibility levels. Defaults to ['listed'].
     visibilityLevels: [Visibility]
   ): ArtworkConnection
   artworksSearchConnection(

--- a/src/schema/v2/artwork/artworkVisibility.ts
+++ b/src/schema/v2/artwork/artworkVisibility.ts
@@ -1,14 +1,14 @@
 import { GraphQLEnumType } from "graphql"
 
-export const ArtworkVisibility = new GraphQLEnumType({
-  name: "Visibility",
-  values: {
-    UNLISTED: { value: "unlisted" },
-    LISTED: { value: "listed" },
-  },
-})
-
 export const ArtworkVisibilityEnumValues = {
   UNLISTED: "unlisted",
   LISTED: "listed",
 }
+
+export const ArtworkVisibility = new GraphQLEnumType({
+  name: "Visibility",
+  values: {
+    UNLISTED: { value: ArtworkVisibilityEnumValues.UNLISTED },
+    LISTED: { value: ArtworkVisibilityEnumValues.LISTED },
+  },
+})

--- a/src/schema/v2/artwork/artworkVisibility.ts
+++ b/src/schema/v2/artwork/artworkVisibility.ts
@@ -1,0 +1,16 @@
+import { GraphQLEnumType } from "graphql"
+
+const ArtworkVisibility = new GraphQLEnumType({
+  name: "Visibility",
+  values: {
+    UNLISTED: { value: "unlisted" },
+    LISTED: { value: "listed" },
+  },
+})
+
+export default ArtworkVisibility
+
+export const ArtworkVisibilityEnumValues = {
+  UNLISTED: "unlisted",
+  LISTED: "listed",
+}

--- a/src/schema/v2/artwork/artworkVisibility.ts
+++ b/src/schema/v2/artwork/artworkVisibility.ts
@@ -1,14 +1,12 @@
 import { GraphQLEnumType } from "graphql"
 
-const ArtworkVisibility = new GraphQLEnumType({
+export const ArtworkVisibility = new GraphQLEnumType({
   name: "Visibility",
   values: {
     UNLISTED: { value: "unlisted" },
     LISTED: { value: "listed" },
   },
 })
-
-export default ArtworkVisibility
 
 export const ArtworkVisibilityEnumValues = {
   UNLISTED: "unlisted",

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -95,6 +95,7 @@ import { error } from "lib/loggers"
 import { PartnerOfferType } from "../partnerOffer"
 import currencyCodes from "lib/currency_codes.json"
 import { date } from "../fields/date"
+import ArtworkVisibility from "./artworkVisibility"
 
 const has_price_range = (price) => {
   return new RegExp(/-/).test(price)
@@ -238,14 +239,6 @@ const ArtworkPriceInsightsType = new GraphQLObjectType<any, ResolverContext>({
     sellThroughRate: {
       type: GraphQLFloat,
     },
-  },
-})
-
-export const VisibilityEnum = new GraphQLEnumType({
-  name: "Visibility",
-  values: {
-    UNLISTED: { value: "unlisted" },
-    LISTED: { value: "listed" },
   },
 })
 
@@ -1844,7 +1837,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       },
       visibilityLevel: {
         description: "The visibility level of the artwork",
-        type: VisibilityEnum,
+        type: ArtworkVisibility,
         resolve: ({ visibility_level }) => visibility_level,
       },
       width: {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -95,7 +95,7 @@ import { error } from "lib/loggers"
 import { PartnerOfferType } from "../partnerOffer"
 import currencyCodes from "lib/currency_codes.json"
 import { date } from "../fields/date"
-import ArtworkVisibility from "./artworkVisibility"
+import { ArtworkVisibility } from "./artworkVisibility"
 
 const has_price_range = (price) => {
   return new RegExp(/-/).test(price)

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -119,9 +119,9 @@ const artworksArgs: GraphQLFieldConfigArgumentMap = {
       "Only allowed for authorized admin/partner requests. When false fetch :all properties on an artwork, when true or not present fetch artwork :short properties",
   },
   visibilityLevels: {
-    type: GraphQLList(ArtworkVisibility),
+    type: new GraphQLList(ArtworkVisibility),
     description:
-      'Return artworks according to visibility levels. Defaults to ["listed"].',
+      "Return artworks according to visibility levels. Defaults to ['listed'].",
   },
   sort: ArtworkSorts,
   page: { type: GraphQLInt },
@@ -435,7 +435,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             size: number
             sort: string
             total_count: boolean
-            visibility_levels: string[]
+            visibility_levels: Array<"listed" | "unlisted">
           }
 
           const gravityArgs: GravityArgs = {

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -47,7 +47,8 @@ import { compact } from "lodash"
 import { InquiryRequestType } from "./partnerInquiryRequest"
 import { PartnerDocumentsConnection } from "./partnerDocumentsConnection"
 import { AlertsSummaryFields } from "../Alerts"
-import ArtworkVisibility, {
+import {
+  ArtworkVisibility,
   ArtworkVisibilityEnumValues,
 } from "schema/v2/artwork/artworkVisibility"
 
@@ -452,6 +453,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
               ArtworkVisibilityEnumValues.LISTED,
             ],
           }
+          console.log("args", args.visibilityLevels)
 
           if (args.includeUnpublished) {
             delete gravityArgs.published

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -449,11 +449,10 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             size,
             sort: args.sort,
             total_count: true,
-            visibility_levels: args.visibilityLevels || [
-              ArtworkVisibilityEnumValues.LISTED,
-            ],
+            visibility_levels: args.visibilityLevels
+              ? args.visibilityLevels
+              : [ArtworkVisibilityEnumValues.LISTED],
           }
-          console.log("args", args.visibilityLevels)
 
           if (args.includeUnpublished) {
             delete gravityArgs.published

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -8,6 +8,7 @@ import {
   GraphQLBoolean,
   GraphQLFieldConfig,
   GraphQLFieldConfigArgumentMap,
+  GraphQLEnumType,
 } from "graphql"
 import { connectionFromArraySlice } from "graphql-relay"
 import { flatten } from "lodash"
@@ -48,7 +49,6 @@ import { compact } from "lodash"
 import { InquiryRequestType } from "./partnerInquiryRequest"
 import { PartnerDocumentsConnection } from "./partnerDocumentsConnection"
 import { AlertsSummaryFields } from "../Alerts"
-
 const isFairOrganizer = (type) => type === "FairOrganizer"
 const isGallery = (type) => type === "PartnerGallery"
 const isPartner = (type) => isGallery(type) || isInstitution(type)
@@ -74,6 +74,17 @@ const partnerTitleContent = (type) => {
 
   return result
 }
+
+// DO NOT MERGE: just testing ---
+// I really want to just use the same as artwork VisibilityEnum thats define in artwork schema
+// but its wrestling with me
+export const VisibilityEnumInput = new GraphQLEnumType({
+  name: "VisibilityEnumInput",
+  values: {
+    UNLISTED: { value: "unlisted" },
+    LISTED: { value: "listed" },
+  },
+})
 
 const isPartnerPageEligible = ({ type }) =>
   ["Gallery", "Institution", "Institutional Seller", "Brand"].includes(type)
@@ -114,6 +125,11 @@ const artworksArgs: GraphQLFieldConfigArgumentMap = {
     type: GraphQLBoolean,
     description:
       "Only allowed for authorized admin/partner requests. When false fetch :all properties on an artwork, when true or not present fetch artwork :short properties",
+  },
+  visibilityLevels: {
+    type: GraphQLList(VisibilityEnumInput),
+    description:
+      'Return artworks according to visibility levels. Defaults to ["listed"].',
   },
   sort: ArtworkSorts,
   page: { type: GraphQLInt },
@@ -427,6 +443,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             size: number
             sort: string
             total_count: boolean
+            visibility_levels: string[]
           }
 
           const gravityArgs: GravityArgs = {
@@ -440,6 +457,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             size,
             sort: args.sort,
             total_count: true,
+            visibility_levels: args.visibilityLevels || ["listed"], //No magic strings, yo
           }
 
           if (args.includeUnpublished) {


### PR DESCRIPTION
Reported internally: private artworks were not being returned in the partner artworksConnection call that powers Folio views

The associated gravity endpoint allows for clients to [request certain visibility levels ](https://github.com/artsy/gravity/blob/main/app/api/v1/partners_artworks_endpoint.rb#L131)and returns the correct artworks if the user has access to view them ([partner user vs collector user for example](https://github.com/artsy/gravity/blob/main/app/api/v1/partners_artworks_endpoint.rb#L173-L175))


### Example (Note the mix of listed and unlisted published artworks):
<details>
  <summary>Query Example</summary>
  
  ```graphql

{
  partner(id: "commerce-test-partner") {
    artworksConnection(first: 100, artistID: "6648c2ecbdb841000701ee77", visibilityLevels: ["listed", "unlisted"]) {
      edges {
        node {
          title
          visibilityLevel
        }
      }
    }
  }
}
```

  
  ```graphql
{
  "data": {
    "partner": {
      "artworksConnection": {
        "edges": [
          {
            "node": {
              "title": "UNIQUE-BN-MO-EUR-JP",
              "visibilityLevel": "LISTED"
            }
          },
          {
            "node": {
              "title": "WOooo",
              "visibilityLevel": "UNLISTED"
            }
          },
          {
            "node": {
              "title": "TITLE",
              "visibilityLevel": "UNLISTED"
            }
          },
          {
            "node": {
              "title": "Blaaaah",
              "visibilityLevel": "UNLISTED"
            }
          },
          {
            "node": {
              "title": "Editioned!",
              "visibilityLevel": "UNLISTED"
            }
          },
          {
            "node": {
              "title": "wooowooo",
              "visibilityLevel": "UNLISTED"
            }
          },
          {
            "node": {
              "title": "lots of artists test",
              "visibilityLevel": "LISTED"
            }
          },
          {
            "node": {
              "title": "testing email price",
              "visibilityLevel": "LISTED"
            }
          },
          {
            "node": {
              "title": "2024",
              "visibilityLevel": "UNLISTED"
            }
          }
        ]
      }
    }
  },
  "extensions": {
    "requests": {
      "gravity": {
        "requests": {
          "partner/commerce-test-partner": {
            "time": "0s 176.83ms",
            "cache": false,
            "length": "N/A"
          },
          "partner/commerce-test-partner/artworks?artist_id=6648c2ecbdb841000701ee77&page=1&published=true&size=100&total_count=true&visibility_levels%5B%5D=listed&visibility_levels%5B%5D=unlisted": {
            "time": "0s 145.562ms",
            "cache": false,
            "length": "0 B"
          }
        }
      }
    },
    "requestID": "c30d8180-19d7-11ef-aa80-ade47a8273fe",
    "userAgent": "graphiql-app"
  }
}
```


</details>


---

This exposed the optional `visibility_level` [argument from the endpoint](https://github.com/artsy/gravity/blob/main/app/api/v1/partners_artworks_endpoint.rb#L131) into the MP level and passes in query params as follows:

<img width="500" alt="Screenshot 2024-05-24 at 10 07 27 AM" src="https://github.com/artsy/metaphysics/assets/12748344/e636d960-845a-4bfe-bd24-b5ecbb540f6e">

---

Before this change, the endpoint defaults to only return listed works

<details>
  <summary>Example</summary>

```graphql
{
  partner(id: "commerce-test-partner") {
    artworksConnection(first: 100, artistID: "6648c2ecbdb841000701ee77") {
      edges {
        node {
          title
          visibilityLevel
        }
      }
    }
  }
}
```

```graphql
{
  "data": {
    "partner": {
      "artworksConnection": {
        "edges": [
          {
            "node": {
              "title": "UNIQUE-BN-MO-EUR-JP",
              "visibilityLevel": "LISTED"
            }
          },
          {
            "node": {
              "title": "lots of artists test",
              "visibilityLevel": "LISTED"
            }
          },
          {
            "node": {
              "title": "testing email price",
              "visibilityLevel": "LISTED"
            }
          }
        ]
      }
    }
  },
  "extensions": {
    "requests": {
      "gravity": {
        "requests": {
          "partner/commerce-test-partner": {
            "time": "0s 168.139ms",
            "cache": false,
            "length": "N/A"
          },
          "partner/commerce-test-partner/artworks?artist_id=6648c2ecbdb841000701ee77&page=1&published=true&size=100&total_count=true": {
            "time": "0s 147.463ms",
            "cache": false,
            "length": "0 B"
          }
        }
      }
    },
    "requestID": "4bcb7f80-19d9-11ef-aa80-ade47a8273fe",
    "userAgent": "graphiql-app"
  }
}
```

</details>

### TODOs:
- [x] Test that only partners can view all their OWN unlisted artworks
- [x] Test that regular collector users cannot view unlisted artworks
