### PR TITLE
feat(exchange): Extend viewer with commerceOrders exchange field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -21022,6 +21022,28 @@ type Viewer {
     # Term used for searching collector profiles
     term: String
   ): CollectorProfileTypeConnection
+  commerceOrders(
+    # Returns the elements in the list that come after the specified cursor.
+    after: String
+
+    # Returns the elements in the list that come before the specified cursor.
+    before: String
+    buyerId: String
+    buyerType: String
+
+    # Returns the first _n_ elements from the list.
+    first: Int
+    impulseConversationId: String
+
+    # Returns the last _n_ elements from the list.
+    last: Int
+    mode: CommerceOrderModeEnum
+    sellerId: String
+    sellerType: String
+    sort: CommerceOrderConnectionSortEnum
+    state: CommerceOrderStateEnum
+    states: [CommerceOrderStateEnum!]
+  ): CommerceOrderConnectionWithTotalCount
 
   # A conversation, usually between a user and a partner
   conversation(

--- a/src/lib/stitching/exchange/v2/stitching.ts
+++ b/src/lib/stitching/exchange/v2/stitching.ts
@@ -335,6 +335,31 @@ export const exchangeStitchingEnvironment = ({
       buyerActivity: CommerceBuyerActivity
     }
 
+    extend type Viewer {
+      commerceOrders(
+        # Returns the elements in the list that come after the specified cursor.
+        after: String
+
+        # Returns the elements in the list that come before the specified cursor.
+        before: String
+        buyerId: String
+        buyerType: String
+
+        # Returns the first _n_ elements from the list.
+        first: Int
+        impulseConversationId: String
+
+        # Returns the last _n_ elements from the list.
+        last: Int
+        mode: CommerceOrderModeEnum
+        sellerId: String
+        sellerType: String
+        sort: CommerceOrderConnectionSortEnum
+        state: CommerceOrderStateEnum
+        states: [CommerceOrderStateEnum!]
+      ): CommerceOrderConnectionWithTotalCount
+    }
+
     extend type Mutation {
       # Creates an order and links the conversation to it
       createInquiryOrder(
@@ -597,6 +622,25 @@ export const exchangeStitchingEnvironment = ({
               schema: exchangeSchema,
               operation: "query",
               fieldName: "commerceMyOrders",
+              args,
+              context,
+              info,
+            })
+          },
+        },
+      },
+      Viewer: {
+        commerceOrders: {
+          fragment: gql`
+            ... on Viewer {
+              __typename
+            }
+          `,
+          resolve: (_parent, args, context, info) => {
+            return info.mergeInfo.delegateToSchema({
+              schema: exchangeSchema,
+              operation: "query",
+              fieldName: "commerceOrders",
               args,
               context,
               info,


### PR DESCRIPTION
Intersected this in the orders app rebuild in volt. In order to support our modern relay pagination patterns, we need to be able to access root fields from `Viewer`. Normally this is easy to add (just [add the type](https://github.com/artsy/metaphysics/blob/main/src/schema/v2/schema.ts#L351) to `rootFields`, and `Viewer` automatically picks it up -- no work necesary), however with orders we're stitching from exchange, so one has to do the annoying SDL stitching dance.  

cc @artsy/amber-devs 