### PR TITLE
feat(EMI-1881): Add offerableActivityCount to artwork

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2622,6 +2622,9 @@ type Artwork implements Node & Searchable & Sellable {
   metric: String
   myLotStanding(live: Boolean = null): [LotStanding!]
 
+  # Count of collectors with eligible offerable activities.
+  offerableActivityCount: Int
+
   # Is this work only available for shipping domestically?
   onlyShipsDomestically: Boolean
   partner(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2623,7 +2623,7 @@ type Artwork implements Node & Searchable & Sellable {
   myLotStanding(live: Boolean = null): [LotStanding!]
 
   # Count of collectors with eligible offerable activities.
-  offerableActivityCount: Int
+  offerableActivity: OfferableActivity
 
   # Is this work only available for shipping domestically?
   onlyShipsDomestically: Boolean
@@ -14042,6 +14042,11 @@ enum NotificationTypesEnum {
   PARTNER_OFFER_CREATED
   PARTNER_SHOW_OPENED
   VIEWING_ROOM_PUBLISHED
+}
+
+type OfferableActivity {
+  # Count of collectors with eligible offerable activities.
+  totalCount: Int
 }
 
 # Consignment Offer Response

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -578,6 +578,15 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    partnerArtworkOfferableActivityLoader: gravityLoader<
+      any,
+      { id: string; artworkId: string }
+    >(
+      ({ id, artworkId }) =>
+        `partner/${id}/artworks/${artworkId}/offerable_activity`,
+      {},
+      { headers: true }
+    ),
     partnerDocumentsLoader: gravityLoader<any, { id: string }>(
       (id) => `partner/${id}/documents`,
       {},

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -4513,6 +4513,28 @@ describe("Artwork type", () => {
     })
   })
 
+  describe("#offerableActivityCount", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          offerableActivityCount
+        }
+      }
+    `
+
+    it("returns count of collectors with eligible offerable activities", () => {
+      const partnerArtworkOfferableActivityLoader = jest.fn(() =>
+        Promise.resolve({ headers: { "x-total-count": 3 } })
+      )
+      context.partnerArtworkOfferableActivityLoader = partnerArtworkOfferableActivityLoader
+      artwork.partner = { id: "123" }
+
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({ artwork: { offerableActivityCount: 3 } })
+      })
+    })
+  })
+
   describe("#listedArtworksConnection", () => {
     const query = `
       {

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -4517,7 +4517,9 @@ describe("Artwork type", () => {
     const query = `
       {
         artwork(id: "richard-prince-untitled-portrait") {
-          offerableActivityCount
+          offerableActivity {
+            totalCount
+          }
         }
       }
     `
@@ -4530,7 +4532,13 @@ describe("Artwork type", () => {
       artwork.partner = { id: "123" }
 
       return runQuery(query, context).then((data) => {
-        expect(data).toEqual({ artwork: { offerableActivityCount: 3 } })
+        expect(data).toEqual({
+          artwork: {
+            offerableActivity: {
+              totalCount: 3,
+            },
+          },
+        })
       })
     })
   })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1920,6 +1920,27 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       lastOfferableActivityAt: date(),
+      offerableActivityCount: {
+        description: "Count of collectors with eligible offerable activities.",
+        type: GraphQLInt,
+        resolve: async (
+          { id, partner },
+          {},
+          { partnerArtworkOfferableActivityLoader }
+        ) => {
+          if (!partnerArtworkOfferableActivityLoader) {
+            throw new Error("You need to be signed in to perform this action")
+          }
+          if (_.isEmpty(partner)) return null
+
+          const { headers } = await partnerArtworkOfferableActivityLoader({
+            artworkId: id,
+            id: partner.id,
+          })
+
+          return parseInt(headers["x-total-count"] || "0", 10)
+        },
+      },
     }
   },
 })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1920,9 +1920,9 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       lastOfferableActivityAt: date(),
-      offerableActivityCount: {
+      offerableActivity: {
         description: "Count of collectors with eligible offerable activities.",
-        type: GraphQLInt,
+        type: offerableActivityType,
         resolve: async (
           { id, partner },
           {},
@@ -1938,7 +1938,9 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             id: partner.id,
           })
 
-          return parseInt(headers["x-total-count"] || "0", 10)
+          const totalCount = parseInt(headers?.["x-total-count"] || "0", 10)
+
+          return { totalCount }
         },
       },
     }
@@ -2020,6 +2022,16 @@ export const artworkConnection = connectionWithCursorInfo({
   nodeType: ArtworkType,
   connectionInterfaces: [ArtworkConnectionInterface],
   edgeInterfaces: [ArtworkEdgeInterface],
+})
+
+const offerableActivityType = new GraphQLObjectType<any, ResolverContext>({
+  name: "OfferableActivity",
+  fields: {
+    totalCount: {
+      type: GraphQLInt,
+      description: "Count of collectors with eligible offerable activities.",
+    },
+  },
 })
 
 export default Artwork


### PR DESCRIPTION
This PR resolves part of [EMI-1881]

### Description
This PR adds a new field to the Artwork type
The new field is called `offerableActivityCount`, and it's the count of collectors who have eligible offerable activity on a the current artwork

#### Example
Request
```graphql
query {
  artwork(id: "XYZ") {
    offerableActivity {
      totalCount
    }
  }
}
```


Response:
```json
{
  "data": {
    "artwork": {
      "offerableActivity": {
        "totalCount": 2
      }
    }
  }
}
```


[EMI-1881]: https://artsyproduct.atlassian.net/browse/EMI-1881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ