### PR TITLE
MyC mutations support 'framed' fields

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2463,6 +2463,11 @@ type Artwork implements Node & Searchable & Sellable {
   # Formatted artwork metadata, including artist, title, date and partner; e.g., 'Andy Warhol, Truck, 1980, Westward Gallery'.
   formattedMetadata: String
   framed: ArtworkInfoRow
+    @deprecated(reason: "Consider using isFramed field (boolean) instead")
+  framedDepth: String
+  framedHeight: String
+  framedMetric: String
+  framedWidth: String
 
   # Returns true when artwork has a certificate of authenticity
   hasCertificateOfAuthenticity: Boolean
@@ -2538,6 +2543,7 @@ type Artwork implements Node & Searchable & Sellable {
   isEligibleToCreateAlert: Boolean!
   isEmbeddableVideo: Boolean
   isForSale: Boolean
+  isFramed: Boolean
   isHangable: Boolean
 
   # Is this artwork part of an auction?
@@ -13818,9 +13824,14 @@ input MyCollectionCreateArtworkInput {
   editionNumber: String
   editionSize: String
   externalImageUrls: [String]
+  framedDepth: String
+  framedHeight: String
+  framedMetric: String
+  framedWidth: String
   height: String
   importSource: ArtworkImportSource
   isEdition: Boolean
+  isFramed: Boolean
   medium: String
   metric: String
 
@@ -13909,8 +13920,13 @@ input MyCollectionUpdateArtworkInput {
   editionNumber: String
   editionSize: String
   externalImageUrls: [String]
+  framedDepth: String
+  framedHeight: String
+  framedMetric: String
+  framedWidth: String
   height: String
   isEdition: Boolean
+  isFramed: Boolean
   medium: String
   metric: String
   pricePaidCents: Long

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1740,8 +1740,15 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         resolve: (artwork) =>
           isEmbeddedVideo(artwork) ? null : artwork.website,
       },
+      isFramed: {
+        type: GraphQLBoolean,
+        resolve: ({ framed }) => {
+          return framed
+        },
+      },
       framed: {
         type: ArtworkInfoRowType,
+        deprecationReason: "Consider using isFramed field (boolean) instead",
         resolve: ({ framed }) => {
           if (framed) {
             return { label: "Framed", details: "Included" }
@@ -1751,6 +1758,22 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             return null
           }
         },
+      },
+      framedDepth: {
+        type: GraphQLString,
+        resolve: ({ framed_depth }) => framed_depth,
+      },
+      framedHeight: {
+        type: GraphQLString,
+        resolve: ({ framed_height }) => framed_height,
+      },
+      framedMetric: {
+        type: GraphQLString,
+        resolve: ({ framed_metric }) => framed_metric,
+      },
+      framedWidth: {
+        type: GraphQLString,
+        resolve: ({ framed_width }) => framed_width,
       },
       signatureInfo: {
         type: ArtworkInfoRowType,

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -22,6 +22,11 @@ const artworkDetails = {
   ],
   signature: "artist initials",
   signed_other: true,
+  framed: true,
+  framed_metric: "in",
+  framed_depth: "1",
+  framed_height: "21",
+  framed_width: "21",
 }
 
 const createArtworkLoader = jest.fn().mockResolvedValue(newArtwork)
@@ -60,9 +65,14 @@ const computeMutationInput = ({
           date: "1990"
           depth: "20"
           isEdition: ${JSON.stringify(isEdition)}
+          isFramed: true,
           editionNumber: ${JSON.stringify(editionNumber)}
           editionSize: ${JSON.stringify(editionSize)}
           externalImageUrls: ${JSON.stringify(externalImageUrls)}
+          framedMetric: "in",
+          framedDepth: "1",
+          framedHeight: "21",
+          framedWidth: "21",
           height: "20"
           artworkLocation: "Berlin, Germany"
           collectorLocation: {country: "Germany", city: "Berlin"}
@@ -98,6 +108,11 @@ const computeMutationInput = ({
                 details
                 label
               }
+              isFramed
+              framedMetric
+              framedDepth
+              framedHeight
+              framedWidth
             }
             artworkEdge {
               node {
@@ -173,11 +188,16 @@ describe("myCollectionCreateArtworkMutation", () => {
               "city": "Berlin",
               "country": "Germany",
             },
+            "framedDepth": "1",
+            "framedHeight": "21",
+            "framedMetric": "cm",
+            "framedWidth": "21",
             "images": Array [
               Object {
                 "imageURL": null,
               },
             ],
+            "isFramed": true,
             "medium": "Painting",
             "pricePaid": Object {
               "display": "$100",
@@ -242,6 +262,11 @@ describe("myCollectionCreateArtworkMutation", () => {
         cost_minor: 200,
         date: "1990",
         depth: "20",
+        framed: true,
+        framed_depth: "1",
+        framed_height: "21",
+        framed_metric: "in",
+        framed_width: "21",
         height: "20",
         import_source: "convection",
         medium: "Painting",
@@ -282,11 +307,16 @@ describe("myCollectionCreateArtworkMutation", () => {
               "city": "Berlin",
               "country": "Germany",
             },
+            "framedDepth": "1",
+            "framedHeight": "21",
+            "framedMetric": "in",
+            "framedWidth": "21",
             "images": Array [
               Object {
                 "imageURL": null,
               },
             ],
+            "isFramed": true,
             "medium": "Painting",
             "pricePaid": Object {
               "display": "$100",

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -190,7 +190,7 @@ describe("myCollectionCreateArtworkMutation", () => {
             },
             "framedDepth": "1",
             "framedHeight": "21",
-            "framedMetric": "cm",
+            "framedMetric": "in",
             "framedWidth": "21",
             "images": Array [
               Object {

--- a/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
@@ -30,6 +30,11 @@ const defaultArtworkDetails = ({
   edition_number: JSON.stringify(editionNumber),
   edition_size: JSON.stringify(editionSize),
   external_image_urls: JSON.stringify(externalImageUrls),
+  framed: true,
+  framed_depth: "1",
+  framed_height: "21",
+  framed_metric: "in",
+  framed_width: "21",
   height: "20",
   medium: "Updated",
   metric: "in",
@@ -76,6 +81,11 @@ const computeMutationInput = ({
           date: "1990"
           depth: "20"
           isEdition: ${JSON.stringify(isEdition)}
+          isFramed: true
+          framedDepth: "1"
+          framedHeight: "21"
+          framedMetric: "in"
+          framedWidth: "21"
           editionNumber: ${JSON.stringify(editionNumber)}
           editionSize: ${JSON.stringify(editionSize)}
           externalImageUrls: ${JSON.stringify(externalImageUrls)}
@@ -110,9 +120,14 @@ const computeMutationInput = ({
                 city
                 country
               }
+              framedDepth
+              framedHeight
+              framedMetric
+              framedWidth
               images(includeAll: true) {
                 imageURL
               }
+              isFramed
               metric
               provenance
               title
@@ -212,6 +227,10 @@ describe("myCollectionUpdateArtworkMutation", () => {
             "depth": "20",
             "editionNumber": null,
             "editionSize": null,
+            "framedDepth": "1",
+            "framedHeight": "21",
+            "framedMetric": "in",
+            "framedWidth": "21",
             "height": "20",
             "images": Array [
               Object {
@@ -219,6 +238,7 @@ describe("myCollectionUpdateArtworkMutation", () => {
               },
             ],
             "isEdition": null,
+            "isFramed": true,
             "medium": "Updated",
             "metric": "in",
             "pricePaid": Object {
@@ -269,6 +289,10 @@ describe("myCollectionUpdateArtworkMutation", () => {
             "depth": "20",
             "editionNumber": null,
             "editionSize": null,
+            "framedDepth": "1",
+            "framedHeight": "21",
+            "framedMetric": "in",
+            "framedWidth": "21",
             "height": "20",
             "images": Array [
               Object {
@@ -276,6 +300,7 @@ describe("myCollectionUpdateArtworkMutation", () => {
               },
             ],
             "isEdition": null,
+            "isFramed": true,
             "medium": "Updated",
             "metric": "in",
             "pricePaid": Object {

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -75,6 +75,21 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
     importSource: {
       type: ArtworkImportSourceEnum,
     },
+    isFramed: {
+      type: GraphQLBoolean,
+    },
+    framedDepth: {
+      type: GraphQLString,
+    },
+    framedHeight: {
+      type: GraphQLString,
+    },
+    framedMetric: {
+      type: GraphQLString,
+    },
+    framedWidth: {
+      type: GraphQLString,
+    },
     submissionId: {
       type: GraphQLString,
     },
@@ -170,6 +185,11 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
       externalImageUrls = [],
       importSource,
       isEdition,
+      isFramed,
+      framedDepth,
+      framedHeight,
+      framedMetric,
+      framedWidth,
       pricePaidCents,
       pricePaidCurrency,
       signatureDetails,
@@ -220,6 +240,11 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
         confidential_notes: confidentialNotes,
         cost_currency_code: costCurrencyCode,
         cost_minor: costMinor,
+        framed: isFramed,
+        framed_depth: framedDepth,
+        framed_height: framedHeight,
+        framed_metric: framedMetric,
+        framed_width: framedWidth,
         price_paid_cents: transformedPricePaidCents,
         price_paid_currency: pricePaidCurrency,
         artwork_location: artworkLocation,

--- a/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
@@ -33,6 +33,11 @@ interface MyCollectionArtworkUpdateMutationInput {
   date?: string
   depth?: string
   isEdition?: boolean
+  isFramed?: boolean
+  framedDepth?: string
+  framedHeight?: string
+  framedMetric?: string
+  framedWidth?: string
   editionNumber?: string
   editionSize?: string
   externalImageUrls?: [string]
@@ -94,6 +99,21 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
     },
     externalImageUrls: {
       type: new GraphQLList(GraphQLString),
+    },
+    isFramed: {
+      type: GraphQLBoolean,
+    },
+    framedDepth: {
+      type: GraphQLString,
+    },
+    framedHeight: {
+      type: GraphQLString,
+    },
+    framedMetric: {
+      type: GraphQLString,
+    },
+    framedWidth: {
+      type: GraphQLString,
     },
     height: {
       type: GraphQLString,
@@ -157,6 +177,11 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
       editionSize,
       externalImageUrls = [],
       isEdition,
+      isFramed,
+      framedDepth,
+      framedHeight,
+      framedMetric,
+      framedWidth,
       pricePaidCents,
       pricePaidCurrency,
       signatureDetails,
@@ -198,6 +223,11 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
         cost_minor: costMinor,
         artwork_location: artworkLocation,
         collector_location: collectorLocation,
+        framed: isFramed,
+        framed_depth: framedDepth,
+        framed_height: framedHeight,
+        framed_metric: framedMetric,
+        framed_width: framedWidth,
         price_paid_cents: transformedPricePaidCents,
         price_paid_currency: pricePaidCurrency,
         attribution_class: attributionClass,


### PR DESCRIPTION
Add `isFramed`, `framedMetric`, `framedDepth`, `framedWidth`, `framedHeight` fields to MyCollection create / update artwork mutations.

I can add `framedDimensions` later, it requires Gravity changes

Example request:

```graphql
mutation {
  myCollectionCreateArtwork(input: { title: "test nikita", artistIds: ["banksy"], isFramed: true, framedMetric: "cm", framedDepth: "1", framedHeight: "10", framedWidth: "10" }) {
    artworkOrError {
      ... on MyCollectionArtworkMutationSuccess {
        artwork {
          title 
          isFramed
          framedMetric
          framedDepth
          framedHeight
          framedWidth
        }
      }
    }
  }
}
```

Response

```json
{
  "data": {
    "myCollectionCreateArtwork": {
      "artworkOrError": {
        "artwork": {
          "title": "test nikita",
          "isFramed": true,
          "framedMetric": "cm",
          "framedDepth": "1",
          "framedHeight": "10",
          "framedWidth": "10"
        }
      }
    }
  }
}
```