### PR TITLE
feat: support condition details for MyC artworks

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13815,6 +13815,7 @@ input MyCollectionCreateArtworkInput {
 
   # The given location of the user as structured data
   collectorLocation: EditableLocation
+  conditionDescription: String
   confidentialNotes: String
   costCurrencyCode: String
   costMajor: Int
@@ -13911,6 +13912,7 @@ input MyCollectionUpdateArtworkInput {
 
   # The given location of the user as structured data
   collectorLocation: EditableLocation
+  conditionDescription: String
   confidentialNotes: String
   costCurrencyCode: String
   costMajor: Int

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -14,6 +14,7 @@ const artworkDetails = {
   price_paid_currency: "USD",
   artwork_location: "Berlin, Germany",
   collector_location: { country: "Germany", city: "Berlin" },
+  condition_description: "like a new!",
   attribution_class: "open edition",
   images: [
     {
@@ -60,6 +61,7 @@ const computeMutationInput = ({
               : null
           }],
           category: "some strange category"
+          conditionDescription: "like a new!"
           costCurrencyCode: "USD"
           costMinor: 200
           date: "1990"
@@ -96,6 +98,10 @@ const computeMutationInput = ({
               collectorLocation {
                 city
                 country
+              }
+              conditionDescription {
+                label
+                details
               }
               pricePaid {
                 display
@@ -188,6 +194,10 @@ describe("myCollectionCreateArtworkMutation", () => {
               "city": "Berlin",
               "country": "Germany",
             },
+            "conditionDescription": Object {
+              "details": "Like a new!",
+              "label": "Condition details",
+            },
             "framedDepth": "1",
             "framedHeight": "21",
             "framedMetric": "in",
@@ -257,6 +267,7 @@ describe("myCollectionCreateArtworkMutation", () => {
         category: "some strange category",
         collection_id: "my-collection",
         collector_location: { city: "Berlin", country: "Germany" },
+        condition_description: "like a new!",
         confidential_notes: undefined,
         cost_currency_code: "USD",
         cost_minor: 200,
@@ -306,6 +317,10 @@ describe("myCollectionCreateArtworkMutation", () => {
             "collectorLocation": Object {
               "city": "Berlin",
               "country": "Germany",
+            },
+            "conditionDescription": Object {
+              "details": "Like a new!",
+              "label": "Condition details",
             },
             "framedDepth": "1",
             "framedHeight": "21",

--- a/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
@@ -42,6 +42,7 @@ const defaultArtworkDetails = ({
   price_paid_currency: "USD",
   artwork_location: "Berlin, Germany",
   collector_location: { city: "Berlin", country: "Germany" },
+  condition_description: "like a new!",
   provenance: "Pat Hearn Gallery",
   title: "hey now",
   width: "20",
@@ -94,6 +95,7 @@ const computeMutationInput = ({
           metric: "in"
           artworkLocation: "Berlin, Germany"
           collectorLocation: {country: "Germany", city: "Berlin"}
+          conditionDescription: "like a new!"
           pricePaidCents: 10000
           pricePaidCurrency: "USD"
           provenance: "Pat Hearn Gallery"
@@ -119,6 +121,10 @@ const computeMutationInput = ({
               collectorLocation {
                 city
                 country
+              }
+              conditionDescription {
+                label
+                details
               }
               framedDepth
               framedHeight
@@ -223,6 +229,10 @@ describe("myCollectionUpdateArtworkMutation", () => {
               "city": "Berlin",
               "country": "Germany",
             },
+            "conditionDescription": Object {
+              "details": "Like a new!",
+              "label": "Condition details",
+            },
             "date": "1990",
             "depth": "20",
             "editionNumber": null,
@@ -284,6 +294,10 @@ describe("myCollectionUpdateArtworkMutation", () => {
             "collectorLocation": Object {
               "city": "Berlin",
               "country": "Germany",
+            },
+            "conditionDescription": Object {
+              "details": "Like a new!",
+              "label": "Condition details",
             },
             "date": "1990",
             "depth": "20",

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -136,6 +136,9 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
       description: "The given location of the user as structured data",
       type: EditableLocationFields,
     },
+    conditionDescription: {
+      type: GraphQLString,
+    },
     metric: {
       type: GraphQLString,
     },
@@ -176,6 +179,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
       artworkLocation,
       attributionClass,
       collectorLocation,
+      conditionDescription,
       confidentialNotes,
       costCurrencyCode,
       costMajor,
@@ -237,6 +241,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
         artists: artistIds,
         submission_id: submissionId,
         collection_id: "my-collection",
+        condition_description: conditionDescription,
         confidential_notes: confidentialNotes,
         cost_currency_code: costCurrencyCode,
         cost_minor: costMinor,

--- a/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
@@ -26,6 +26,7 @@ interface MyCollectionArtworkUpdateMutationInput {
   artistIds?: [string]
   attributionClass?: string
   category?: string
+  conditionDescription?: string
   confidentialNotes?: string
   costCurrencyCode?: string
   costMajor?: number
@@ -68,6 +69,9 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
       type: ArtworkAttributionClassEnum,
     },
     category: {
+      type: GraphQLString,
+    },
+    conditionDescription: {
       type: GraphQLString,
     },
     confidentialNotes: {
@@ -169,6 +173,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
       artworkLocation,
       attributionClass,
       collectorLocation,
+      conditionDescription,
       confidentialNotes,
       costCurrencyCode,
       costMajor,
@@ -218,6 +223,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
     try {
       const response = await updateArtworkLoader(artworkId, {
         artists: artistIds,
+        condition_description: conditionDescription,
         confidential_notes: confidentialNotes,
         cost_currency_code: costCurrencyCode,
         cost_minor: costMinor,


### PR DESCRIPTION
Adds `conditionDetails` field to MyC artwork mutations.

Example request:

```graphql
mutation {
  myCollectionUpdateArtwork(input: { artworkId: "6655fcce28a249000f872965", conditionDescription: "very good condition" }) {
    artworkOrError {
      ... on MyCollectionArtworkMutationSuccess {
        artwork {
          title
          conditionDescription {
            label
            details
          }
        }
      }
    }
  }
}
```

Response:

```json
{
  "data": {
    "myCollectionUpdateArtwork": {
      "artworkOrError": {
        "artwork": {
          "title": "Napalm - Unsigned",
          "conditionDescription": {
            "label": "Condition details",
            "details": "Very good condition"
          }
        }
      }
    }
  }
}
```