### PR TITLE
feat: support additional information for MyC artworks

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13806,6 +13806,7 @@ type MyCollectionConnection {
 }
 
 input MyCollectionCreateArtworkInput {
+  additionalInformation: String
   artistIds: [String]
   artists: [MyCollectionArtistInput]
   artworkLocation: String
@@ -13902,6 +13903,7 @@ type MyCollectionInfo {
 }
 
 input MyCollectionUpdateArtworkInput {
+  additionalInformation: String
   artistIds: [String]
   artworkId: String!
   artworkLocation: String

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -8,6 +8,7 @@ import {
 const newArtwork = { id: "some-artwork-id" }
 const newArtist = { id: "some-artist-id" }
 const artworkDetails = {
+  additional_information: "additional info",
   id: "some-artwork-id",
   medium: "Painting",
   price_paid_cents: 10000,
@@ -51,6 +52,7 @@ const computeMutationInput = ({
     mutation {
       myCollectionCreateArtwork(
         input: {
+          additionalInformation: "additional info"
           artistIds: ["4d8b92b34eb68a1b2c0003f4"]
           artists: [${
             artists
@@ -91,6 +93,7 @@ const computeMutationInput = ({
         artworkOrError {
           ... on MyCollectionArtworkMutationSuccess {
             artwork {
+              additionalInformation
               medium
               artworkLocation
               collectorLocation {
@@ -183,6 +186,7 @@ describe("myCollectionCreateArtworkMutation", () => {
       expect(artworkOrError).toMatchInlineSnapshot(`
         Object {
           "artwork": Object {
+            "additionalInformation": "additional info",
             "artworkLocation": "Berlin, Germany",
             "collectorLocation": Object {
               "city": "Berlin",
@@ -247,6 +251,7 @@ describe("myCollectionCreateArtworkMutation", () => {
       })
 
       expect(createArtworkLoader).toBeCalledWith({
+        additional_information: "additional info",
         artists: [
           "4d8b92b34eb68a1b2c0003f4",
           "some-artist-id",
@@ -302,6 +307,7 @@ describe("myCollectionCreateArtworkMutation", () => {
       expect(artworkOrError).toMatchInlineSnapshot(`
         Object {
           "artwork": Object {
+            "additionalInformation": "additional info",
             "artworkLocation": "Berlin, Germany",
             "collectorLocation": Object {
               "city": "Berlin",

--- a/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
@@ -15,6 +15,7 @@ const defaultArtworkDetails = ({
   editionNumber?: string | null
   isEdition?: boolean | null
 } = {}) => ({
+  additional_information: "some additional info",
   id: "some-artwork-id",
   artistIds: ["4d8b92b34eb68a1b2c0003f4"],
   artworkId: "some-artwork-id",
@@ -75,6 +76,7 @@ const computeMutationInput = ({
     mutation {
       myCollectionUpdateArtwork(
         input: {
+          additionalInformation: "some additional info"
           artistIds: ["4d8b92b34eb68a1b2c0003f4"]
           artworkId: "some-artwork-id"
           category: "some strange category"
@@ -107,6 +109,7 @@ const computeMutationInput = ({
         artworkOrError {
           ... on MyCollectionArtworkMutationSuccess {
             artwork {
+              additionalInformation
               category
               date
               depth
@@ -214,6 +217,7 @@ describe("myCollectionUpdateArtworkMutation", () => {
       expect(artworkOrError).toMatchInlineSnapshot(`
         Object {
           "artwork": Object {
+            "additionalInformation": "some additional info",
             "artworkLocation": "Berlin, Germany",
             "attributionClass": Object {
               "name": "Open edition",
@@ -276,6 +280,7 @@ describe("myCollectionUpdateArtworkMutation", () => {
       expect(artworkOrError).toMatchInlineSnapshot(`
         Object {
           "artwork": Object {
+            "additionalInformation": "some additional info",
             "artworkLocation": "Berlin, Germany",
             "attributionClass": Object {
               "name": "Open edition",

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -59,6 +59,9 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
   name: "MyCollectionCreateArtwork",
   description: "Create an artwork in my collection",
   inputFields: {
+    additionalInformation: {
+      type: GraphQLString,
+    },
     artistIds: {
       type: new GraphQLList(GraphQLString),
     },
@@ -171,6 +174,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
   },
   mutateAndGetPayload: async (
     {
+      additionalInformation,
       artistIds,
       artists,
       artworkLocation,
@@ -234,6 +238,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
 
     try {
       const response = await createArtworkLoader({
+        additional_information: additionalInformation,
         artists: artistIds,
         submission_id: submissionId,
         collection_id: "my-collection",

--- a/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
@@ -22,6 +22,7 @@ import {
 } from "../artwork/artworkSignatureTypes"
 
 interface MyCollectionArtworkUpdateMutationInput {
+  additionalInformation?: string
   artworkId: string
   artistIds?: [string]
   attributionClass?: string
@@ -58,6 +59,9 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
   name: "MyCollectionUpdateArtwork",
   description: "Update an artwork in my collection",
   inputFields: {
+    additionalInformation: {
+      type: GraphQLString,
+    },
     artworkId: {
       type: new GraphQLNonNull(GraphQLString),
     },
@@ -164,6 +168,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
   },
   mutateAndGetPayload: async (
     {
+      additionalInformation,
       artistIds,
       artworkId,
       artworkLocation,
@@ -217,6 +222,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
 
     try {
       const response = await updateArtworkLoader(artworkId, {
+        additional_information: additionalInformation,
         artists: artistIds,
         confidential_notes: confidentialNotes,
         cost_currency_code: costCurrencyCode,


### PR DESCRIPTION
Adds additional information field to MyC artwork mutations.

Example request:

```graphql
mutation {
  myCollectionCreateArtwork(input: { title: "test nikita", artistIds: ["banksy"], additionalInformation: "hello?" }) {
    artworkOrError {
      ... on MyCollectionArtworkMutationSuccess {
        artwork {
          title 
          additionalInformation
        }
      }
    }
  }
}
```

Response:

```json
{
  "data": {
    "myCollectionCreateArtwork": {
      "artworkOrError": {
        "artwork": {
          "title": "test nikita",
          "additionalInformation": "hello?"
        }
      }
    }
  }
}
```