### PR TITLE
feat: hook up summaryParagraph on CollectorProfile to DataLoader

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4314,8 +4314,11 @@ type CollectorProfileType implements Node {
   savedArtworksCount: Int!
   selfReportedPurchases: String
 
-  # A partner-specific sentence describing the collector.
-  summarySentence(partnerID: String!): String!
+  # An artwork-specific paragraph describing the collector.
+  summaryParagraph(
+    # This can be specified, and is injected in a conversation context for convenience.
+    artworkID: String
+  ): String
   totalBidsCount: Int!
   userInterests: [UserInterest]!
     @deprecated(reason: "Use \"owner#interestsConnection\" field instead.")
@@ -11549,8 +11552,11 @@ type InquirerCollectorProfile {
   savedArtworksCount: Int!
   selfReportedPurchases: String
 
-  # A partner-specific sentence describing the collector.
-  summarySentence(partnerID: String!): String!
+  # An artwork-specific paragraph describing the collector.
+  summaryParagraph(
+    # This can be specified, and is injected in a conversation context for convenience.
+    artworkID: String
+  ): String
   totalBidsCount: Int!
   userInterests: [UserInterest]!
     @deprecated(reason: "Use \"owner#interestsConnection\" field instead.")
@@ -19392,8 +19398,11 @@ type UpdateCollectorProfilePayload {
   savedArtworksCount: Int!
   selfReportedPurchases: String
 
-  # A partner-specific sentence describing the collector.
-  summarySentence(partnerID: String!): String!
+  # An artwork-specific paragraph describing the collector.
+  summaryParagraph(
+    # This can be specified, and is injected in a conversation context for convenience.
+    artworkID: String
+  ): String
   totalBidsCount: Int!
   userInterests: [UserInterest]!
     @deprecated(reason: "Use \"owner#interestsConnection\" field instead.")

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -61,6 +61,7 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    collectorProfileSummaryLoader: gravityLoader("collector_profile_summary"),
     createAccountRequestLoader: gravityLoader(
       "account_requests",
       {},

--- a/src/schema/v2/CollectorProfile/collectorProfile.ts
+++ b/src/schema/v2/CollectorProfile/collectorProfile.ts
@@ -219,16 +219,31 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
       !!profession &&
       !!other_relevant_positions,
   },
-  summarySentence: {
-    type: new GraphQLNonNull(GraphQLString),
-    description: "A partner-specific sentence describing the collector.",
+  summaryParagraph: {
+    type: GraphQLString,
+    description: "An artwork-specific paragraph describing the collector.",
     args: {
-      partnerID: {
-        type: new GraphQLNonNull(GraphQLString),
+      artworkID: {
+        type: GraphQLString,
+        description:
+          "This can be specified, and is injected in a conversation context for convenience.",
       },
     },
-    resolve: () => {
-      return "This collector exists."
+    resolve: async (
+      { id: collector_profile_id, artworkID },
+      { artworkID: artworkIDFromArgs },
+      { collectorProfileSummaryLoader }
+    ) => {
+      if (!collectorProfileSummaryLoader) {
+        throw new Error("You must be signed in to perform this action.")
+      }
+
+      const { paragraph } = await collectorProfileSummaryLoader({
+        artwork_id: artworkIDFromArgs || artworkID,
+        collector_profile_id,
+      })
+
+      return paragraph
     },
   },
 }

--- a/src/schema/v2/conversation/index.ts
+++ b/src/schema/v2/conversation/index.ts
@@ -311,7 +311,7 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
         "The collector profile of the user who initiated the conversation. Do not use this field for Partners",
       type: CollectorResume,
       resolve: async (
-        { from_id, to_id },
+        { from_id, to_id, items },
         _args,
         { partnerCollectorProfileLoader }
       ) => {
@@ -323,11 +323,17 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
             userId: from_id,
           })
 
+          // Assume a conversation only has one item
+          const artwork = items.find((item) => item.item_type === "Artwork")
+          const artworkID = artwork ? artwork.properties.id : null
+
           return {
             collectorProfile: {
               ...data.collector_profile,
-              // forward the partnerId to the collectorProfile to be used by data loaders
+              // inject data that can be optionally used by
+              // collectorProfile fields to resolve
               partnerId: to_id,
+              artworkID,
             },
             isCollectorFollowingPartner: data.follows_profile,
             userId: from_id,

--- a/src/schema/v2/me/__tests__/collector_profile.test.js
+++ b/src/schema/v2/me/__tests__/collector_profile.test.js
@@ -138,13 +138,13 @@ describe("Me", () => {
       })
     })
 
-    describe("summarySentence", () => {
-      it("returns a summary sentence", () => {
+    describe("summaryParagraph", () => {
+      it("returns a summary paragraph", () => {
         const query = `
           {
             me {
               collectorProfile {
-                summarySentence(partnerID: "foo-partner")
+                summaryParagraph(artworkID: "blah")
               }
             }
           }
@@ -156,11 +156,13 @@ describe("Me", () => {
 
         const context = {
           meCollectorProfileLoader: () => Promise.resolve(collectorProfile),
+          collectorProfileSummaryLoader: () =>
+            Promise.resolve({ paragraph: "This collector exists." }),
         }
 
         return runAuthenticatedQuery(query, context).then(
           ({ me: { collectorProfile } }) => {
-            expect(collectorProfile.summarySentence).toBe(
+            expect(collectorProfile.summaryParagraph).toBe(
               "This collector exists."
             )
           }


### PR DESCRIPTION
This adds `summaryParagraph` as a field under `CollectorProfile` - so it can be queried for - pretty vanilla just hooking it up to the API endpoint.

Since the summary is _also_ based on an artwork (someday we can generalize the concept maybe to still produce a summary w/o an artwork - for use in a different context in CMS perhaps) - that can be an arg passed in - _however_ for easier use in CMS conversations, that artwork identifier will be injected in from the parent so you can more simply query the field from a client in a fragment w/o specifying any arguments.