### PR TITLE
feat: support certificate of authenticity fields for MyC artworks

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2380,6 +2380,7 @@ type Artwork implements Node & Searchable & Sellable {
 
   # Returns the display label and detail when artwork has a certificate of authenticity
   certificateOfAuthenticity: ArtworkInfoRow
+  certificateOfAuthenticityDetails: CertificateOfAuthenticityDetails
   collectingInstitution: String
   collectionsConnection(
     after: String
@@ -4056,6 +4057,11 @@ type CausalityLotState {
   sellingPrice: Money
   sellingPriceCents: Int
   soldStatus: String
+}
+
+type CertificateOfAuthenticityDetails {
+  coaByAuthenticatingBody: Boolean
+  coaByGallery: Boolean
 }
 
 type Channel {
@@ -13812,6 +13818,8 @@ input MyCollectionCreateArtworkInput {
   attributionClass: ArtworkAttributionClassType
   category: String
   clientMutationId: String
+  coaByAuthenticatingBody: Boolean
+  coaByGallery: Boolean
 
   # The given location of the user as structured data
   collectorLocation: EditableLocation
@@ -13828,6 +13836,7 @@ input MyCollectionCreateArtworkInput {
   framedHeight: String
   framedMetric: String
   framedWidth: String
+  hasCertificateOfAuthenticity: Boolean
   height: String
   importSource: ArtworkImportSource
   isEdition: Boolean
@@ -13908,6 +13917,8 @@ input MyCollectionUpdateArtworkInput {
   attributionClass: ArtworkAttributionClassType
   category: String
   clientMutationId: String
+  coaByAuthenticatingBody: Boolean
+  coaByGallery: Boolean
 
   # The given location of the user as structured data
   collectorLocation: EditableLocation
@@ -13924,6 +13935,7 @@ input MyCollectionUpdateArtworkInput {
   framedHeight: String
   framedMetric: String
   framedWidth: String
+  hasCertificateOfAuthenticity: Boolean
   height: String
   isEdition: Boolean
   isFramed: Boolean

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1862,6 +1862,23 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           }
         },
       },
+      certificateOfAuthenticityDetails: {
+        type: new GraphQLObjectType<any, ResolverContext>({
+          name: "CertificateOfAuthenticityDetails",
+          fields: {
+            coaByAuthenticatingBody: {
+              type: GraphQLBoolean,
+              resolve: ({ coa_by_authenticating_body }) =>
+                coa_by_authenticating_body,
+            },
+            coaByGallery: {
+              type: GraphQLBoolean,
+              resolve: ({ coa_by_gallery }) => coa_by_gallery,
+            },
+          },
+        }),
+        resolve: (artwork) => artwork,
+      },
       visibilityLevel: {
         description: "The visibility level of the artwork",
         type: ArtworkVisibility,

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -9,6 +9,9 @@ const newArtwork = { id: "some-artwork-id" }
 const newArtist = { id: "some-artist-id" }
 const artworkDetails = {
   id: "some-artwork-id",
+  certificate_of_authenticity: true,
+  coa_by_authenticating_body: false,
+  coa_by_gallery: true,
   medium: "Painting",
   price_paid_cents: 10000,
   price_paid_currency: "USD",
@@ -60,10 +63,13 @@ const computeMutationInput = ({
               : null
           }],
           category: "some strange category"
+          coaByAuthenticatingBody: false
+          coaByGallery: true
           costCurrencyCode: "USD"
           costMinor: 200
           date: "1990"
           depth: "20"
+          hasCertificateOfAuthenticity: true
           isEdition: ${JSON.stringify(isEdition)}
           isFramed: true,
           editionNumber: ${JSON.stringify(editionNumber)}
@@ -93,6 +99,10 @@ const computeMutationInput = ({
             artwork {
               medium
               artworkLocation
+              certificateOfAuthenticityDetails {
+                coaByAuthenticatingBody
+                coaByGallery
+              }
               collectorLocation {
                 city
                 country
@@ -100,6 +110,7 @@ const computeMutationInput = ({
               pricePaid {
                 display
               }
+              hasCertificateOfAuthenticity
               images(includeAll: true) {
                 imageURL
               }
@@ -184,6 +195,10 @@ describe("myCollectionCreateArtworkMutation", () => {
         Object {
           "artwork": Object {
             "artworkLocation": "Berlin, Germany",
+            "certificateOfAuthenticityDetails": Object {
+              "coaByAuthenticatingBody": false,
+              "coaByGallery": true,
+            },
             "collectorLocation": Object {
               "city": "Berlin",
               "country": "Germany",
@@ -192,6 +207,7 @@ describe("myCollectionCreateArtworkMutation", () => {
             "framedHeight": "21",
             "framedMetric": "in",
             "framedWidth": "21",
+            "hasCertificateOfAuthenticity": true,
             "images": Array [
               Object {
                 "imageURL": null,
@@ -255,6 +271,9 @@ describe("myCollectionCreateArtworkMutation", () => {
         artwork_location: "Berlin, Germany",
         attribution_class: undefined,
         category: "some strange category",
+        certificate_of_authenticity: true,
+        coa_by_authenticating_body: false,
+        coa_by_gallery: true,
         collection_id: "my-collection",
         collector_location: { city: "Berlin", country: "Germany" },
         confidential_notes: undefined,
@@ -303,6 +322,10 @@ describe("myCollectionCreateArtworkMutation", () => {
         Object {
           "artwork": Object {
             "artworkLocation": "Berlin, Germany",
+            "certificateOfAuthenticityDetails": Object {
+              "coaByAuthenticatingBody": false,
+              "coaByGallery": true,
+            },
             "collectorLocation": Object {
               "city": "Berlin",
               "country": "Germany",
@@ -311,6 +334,7 @@ describe("myCollectionCreateArtworkMutation", () => {
             "framedHeight": "21",
             "framedMetric": "in",
             "framedWidth": "21",
+            "hasCertificateOfAuthenticity": true,
             "images": Array [
               Object {
                 "imageURL": null,

--- a/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
@@ -19,6 +19,9 @@ const defaultArtworkDetails = ({
   artistIds: ["4d8b92b34eb68a1b2c0003f4"],
   artworkId: "some-artwork-id",
   category: "some strange category",
+  certificate_of_authenticity: true,
+  coa_by_authenticating_body: false,
+  coa_by_gallery: true,
   images: [
     {
       imageUrl: "an-image-url",
@@ -78,8 +81,11 @@ const computeMutationInput = ({
           artistIds: ["4d8b92b34eb68a1b2c0003f4"]
           artworkId: "some-artwork-id"
           category: "some strange category"
+          coaByAuthenticatingBody: false
+          coaByGallery: true
           date: "1990"
           depth: "20"
+          hasCertificateOfAuthenticity: true
           isEdition: ${JSON.stringify(isEdition)}
           isFramed: true
           framedDepth: "1"
@@ -108,8 +114,13 @@ const computeMutationInput = ({
           ... on MyCollectionArtworkMutationSuccess {
             artwork {
               category
+              certificateOfAuthenticityDetails {
+                coaByAuthenticatingBody
+                coaByGallery
+              }
               date
               depth
+              hasCertificateOfAuthenticity
               isEdition
               editionNumber
               editionSize
@@ -219,6 +230,10 @@ describe("myCollectionUpdateArtworkMutation", () => {
               "name": "Open edition",
             },
             "category": "some strange category",
+            "certificateOfAuthenticityDetails": Object {
+              "coaByAuthenticatingBody": false,
+              "coaByGallery": true,
+            },
             "collectorLocation": Object {
               "city": "Berlin",
               "country": "Germany",
@@ -231,6 +246,7 @@ describe("myCollectionUpdateArtworkMutation", () => {
             "framedHeight": "21",
             "framedMetric": "in",
             "framedWidth": "21",
+            "hasCertificateOfAuthenticity": true,
             "height": "20",
             "images": Array [
               Object {
@@ -281,6 +297,10 @@ describe("myCollectionUpdateArtworkMutation", () => {
               "name": "Open edition",
             },
             "category": "some strange category",
+            "certificateOfAuthenticityDetails": Object {
+              "coaByAuthenticatingBody": false,
+              "coaByGallery": true,
+            },
             "collectorLocation": Object {
               "city": "Berlin",
               "country": "Germany",
@@ -293,6 +313,7 @@ describe("myCollectionUpdateArtworkMutation", () => {
             "framedHeight": "21",
             "framedMetric": "in",
             "framedWidth": "21",
+            "hasCertificateOfAuthenticity": true,
             "height": "20",
             "images": Array [
               Object {

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -68,12 +68,20 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
     title: {
       type: new GraphQLNonNull(GraphQLString),
     },
-    // Optional
+    coaByAuthenticatingBody: {
+      type: GraphQLBoolean,
+    },
+    coaByGallery: {
+      type: GraphQLBoolean,
+    },
     confidentialNotes: {
       type: GraphQLString,
     },
     importSource: {
       type: ArtworkImportSourceEnum,
+    },
+    hasCertificateOfAuthenticity: {
+      type: GraphQLBoolean,
     },
     isFramed: {
       type: GraphQLBoolean,
@@ -175,6 +183,8 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
       artists,
       artworkLocation,
       attributionClass,
+      coaByAuthenticatingBody,
+      coaByGallery,
       collectorLocation,
       confidentialNotes,
       costCurrencyCode,
@@ -183,6 +193,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
       editionNumber,
       editionSize,
       externalImageUrls = [],
+      hasCertificateOfAuthenticity,
       importSource,
       isEdition,
       isFramed,
@@ -236,6 +247,9 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
       const response = await createArtworkLoader({
         artists: artistIds,
         submission_id: submissionId,
+        certificate_of_authenticity: hasCertificateOfAuthenticity,
+        coa_by_authenticating_body: coaByAuthenticatingBody,
+        coa_by_gallery: coaByGallery,
         collection_id: "my-collection",
         confidential_notes: confidentialNotes,
         cost_currency_code: costCurrencyCode,

--- a/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
@@ -26,12 +26,15 @@ interface MyCollectionArtworkUpdateMutationInput {
   artistIds?: [string]
   attributionClass?: string
   category?: string
+  coaByAuthenticatingBody?: boolean
+  coaByGallery?: boolean
   confidentialNotes?: string
   costCurrencyCode?: string
   costMajor?: number
   costMinor?: number
   date?: string
   depth?: string
+  hasCertificateOfAuthenticity?: boolean
   isEdition?: boolean
   isFramed?: boolean
   framedDepth?: string
@@ -70,6 +73,12 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
     category: {
       type: GraphQLString,
     },
+    coaByAuthenticatingBody: {
+      type: GraphQLBoolean,
+    },
+    coaByGallery: {
+      type: GraphQLBoolean,
+    },
     confidentialNotes: {
       type: GraphQLString,
     },
@@ -87,6 +96,9 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
     },
     depth: {
       type: GraphQLString,
+    },
+    hasCertificateOfAuthenticity: {
+      type: GraphQLBoolean,
     },
     isEdition: {
       type: GraphQLBoolean,
@@ -168,6 +180,8 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
       artworkId,
       artworkLocation,
       attributionClass,
+      coaByAuthenticatingBody,
+      coaByGallery,
       collectorLocation,
       confidentialNotes,
       costCurrencyCode,
@@ -176,6 +190,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
       editionNumber,
       editionSize,
       externalImageUrls = [],
+      hasCertificateOfAuthenticity,
       isEdition,
       isFramed,
       framedDepth,
@@ -218,10 +233,13 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
     try {
       const response = await updateArtworkLoader(artworkId, {
         artists: artistIds,
+        coa_by_authenticating_body: coaByAuthenticatingBody,
+        coa_by_gallery: coaByGallery,
         confidential_notes: confidentialNotes,
         cost_currency_code: costCurrencyCode,
         cost_minor: costMinor,
         artwork_location: artworkLocation,
+        certificate_of_authenticity: hasCertificateOfAuthenticity,
         collector_location: collectorLocation,
         framed: isFramed,
         framed_depth: framedDepth,


### PR DESCRIPTION
Adds certificate of authenticity fields to MyC artwork mutations (also adds structured certificate of authenticity response to artwork field).

Example request:

```graphql
mutation {
  myCollectionCreateArtwork(input: { title: "test nikita", artistIds: ["banksy"], hasCertificateOfAuthenticity: true, coaByAuthenticatingBody: true, coaByGallery: true }) {
    artworkOrError {
      ... on MyCollectionArtworkMutationSuccess {
        artwork {
          title
           hasCertificateOfAuthenticity
           certificateOfAuthenticityDetails {
             coaByAuthenticatingBody
             coaByGallery
           }
        }
      }
    }
  }
}
```

Response:

```json
{
  "data": {
    "myCollectionCreateArtwork": {
      "artworkOrError": {
        "artwork": {
          "title": "test nikita",
          "hasCertificateOfAuthenticity": true,
          "certificateOfAuthenticityDetails": {
            "coaByAuthenticatingBody": true,
            "coaByGallery": true
          }
        }
      }
    }
  }
}
```