### PR TITLE
feat(partner-artist): Add #isPartnerArtistHiddenInPresentationMode

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2125,6 +2125,7 @@ type ArtistPartnerEdge {
   # A type-specific ID.
   internalID: ID!
   isDisplayOnPartnerProfile: Boolean
+  isHiddenInPresentationMode: Boolean
   isUseDefaultBiography: Boolean
 
   # The item at the end of the edge
@@ -14663,6 +14664,7 @@ type PartnerArtist {
   # A type-specific ID.
   internalID: ID!
   isDisplayOnPartnerProfile: Boolean
+  isHiddenInPresentationMode: Boolean
   isUseDefaultBiography: Boolean
   partner: Partner
   representedBy: Boolean
@@ -14749,6 +14751,7 @@ type PartnerArtistEdge {
   # A type-specific ID.
   internalID: ID!
   isDisplayOnPartnerProfile: Boolean
+  isHiddenInPresentationMode: Boolean
   isUseDefaultBiography: Boolean
 
   # The item at the end of the edge

--- a/src/schema/v2/artist/__tests__/index.test.js
+++ b/src/schema/v2/artist/__tests__/index.test.js
@@ -576,7 +576,7 @@ describe("Artist type", () => {
       {
         artist(id: "foo-bar") {
           partnerBiographyBlurb {
-            text   
+            text
           }
         }
       }
@@ -585,7 +585,7 @@ describe("Artist type", () => {
       const partnerArtists = Promise.resolve([
         {
           biography: "Oh hello, I am a bio",
-        }
+        },
       ])
       context.partnerArtistsForArtistLoader = sinon
         .stub()
@@ -607,7 +607,7 @@ describe("Artist type", () => {
       const partnerArtists = Promise.resolve([
         {
           biography: null,
-        }
+        },
       ])
       context.partnerArtistsForArtistLoader = sinon
         .stub()

--- a/src/schema/v2/partner/__tests__/partner_artist.test.js
+++ b/src/schema/v2/partner/__tests__/partner_artist.test.js
@@ -7,6 +7,19 @@ describe("partnerArtist", () => {
   let context = null
 
   beforeEach(() => {
+    partnerArtistData = [
+      {
+        use_default_biography: true,
+        biography: "Partner provided biography",
+        artist: {
+          blurb: "Artsy provided biography",
+        },
+        partner: {
+          name: "Catty Gallery",
+        },
+      },
+    ]
+
     partnerData = {
       id: "catty-partner",
       slug: "catty-partner",
@@ -172,6 +185,40 @@ describe("partnerArtist", () => {
           },
         },
       })
+    })
+  })
+
+  it("isHiddenInPresentationMode", async () => {
+    partnerArtistData = [
+      {
+        hide_in_presentation_mode: true,
+      },
+    ]
+
+    const query = gql`
+      {
+        partner(id: "levy-gorvy") {
+          artistsConnection(first: 3) {
+            edges {
+              isHiddenInPresentationMode
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      partner: {
+        artistsConnection: {
+          edges: [
+            {
+              isHiddenInPresentationMode: true,
+            },
+          ],
+        },
+      },
     })
   })
 

--- a/src/schema/v2/partner/partner_artist.ts
+++ b/src/schema/v2/partner/partner_artist.ts
@@ -23,21 +23,22 @@ import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 
 // TODO: This should move to the gravity loader
 interface PartnerArtistDetails {
-  sortable_id: string
-  use_default_biography: boolean
-  published_artworks_count: number
-  published_for_sale_artworks_count: number
-  display_on_partner_profile: boolean
-  represented_by: boolean
-  biography: string
   artist: {
     id: string
     blurb: string
   }
+  biography: string
+  display_on_partner_profile: boolean
+  hide_in_presentation_mode: boolean
   partner: {
     id: string
     name: string
   }
+  published_artworks_count: number
+  published_for_sale_artworks_count: number
+  represented_by: boolean
+  sortable_id: string
+  use_default_biography: boolean
 }
 
 const counts: GraphQLFieldConfig<PartnerArtistDetails, ResolverContext> = {
@@ -125,6 +126,10 @@ export const fields: Thunk<GraphQLFieldConfigMap<
   },
   biographyBlurb,
   counts,
+  isHiddenInPresentationMode: {
+    type: GraphQLBoolean,
+    resolve: ({ hide_in_presentation_mode }) => !!hide_in_presentation_mode,
+  },
   artworksConnection: {
     type: artworkConnection.connectionType,
     args: pageable({


### PR DESCRIPTION
This is to support a feature request in folio, for partners to be able to toggle off particular artists wholesale from CMS from display in the folio list view if presentation mode is on. 

This updates the partner artist fields with a new `isPartnerArtistHiddenInPresentationMode`, which we can now toggle on and off in volt. 

```graphql
{
  partner(id: "foo") {
    allArtistsConnection(includeAllFields: true) {
      edges {
        node {
          isPartnerArtistHiddenInPresentationMode
          name
        }
      }
    }
  }
}
```