### PR TITLE
chore: Add argument to exclude certain works from artwork recs DIA-652

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16020,6 +16020,7 @@ type Query {
   artworksForUser(
     after: String
     before: String
+    excludeArtworkIds: [String] = []
     excludeDislikedArtworks: Boolean = false
     first: Int
     includeBackfill: Boolean!
@@ -21044,6 +21045,7 @@ type Viewer {
   artworksForUser(
     after: String
     before: String
+    excludeArtworkIds: [String] = []
     excludeDislikedArtworks: Boolean = false
     first: Int
     includeBackfill: Boolean!

--- a/src/schema/v2/artworksForUser/__tests__/helpers.test.ts
+++ b/src/schema/v2/artworksForUser/__tests__/helpers.test.ts
@@ -15,7 +15,7 @@ const mockLoaderFactory = (affinities) => {
   return loader
 }
 
-describe("getNewForYouRecs", () => {
+describe("getNewForYouArtworkIDs", () => {
   const userLoader = mockLoaderFactory([{ artworkId: "banksy" }])
   const appLoader = mockLoaderFactory([{ artworkId: "warhol" }])
 
@@ -29,7 +29,10 @@ describe("getNewForYouRecs", () => {
       },
     } as any
 
-    const artworkIds = await getNewForYouArtworkIDs({}, context)
+    const artworkIds = await getNewForYouArtworkIDs(
+      { excludeArtworkIds: [] },
+      context
+    )
 
     expect(artworkIds).toEqual(["banksy"])
   })

--- a/src/schema/v2/artworksForUser/artworksForUser.ts
+++ b/src/schema/v2/artworksForUser/artworksForUser.ts
@@ -2,6 +2,7 @@ import {
   GraphQLBoolean,
   GraphQLFieldConfig,
   GraphQLInt,
+  GraphQLList,
   GraphQLNonNull,
   GraphQLString,
 } from "graphql"
@@ -38,16 +39,23 @@ export const artworksForUser: GraphQLFieldConfig<void, ResolverContext> = {
       type: GraphQLBoolean,
       defaultValue: false,
     },
+    excludeArtworkIds: {
+      type: new GraphQLList(GraphQLString),
+      defaultValue: [],
+    },
   }),
   resolve: async (_root, args: CursorPageable, context) => {
     const newForYouArtworkIds = await getNewForYouArtworkIDs(args, context)
+    const filteredArtworkIds = newForYouArtworkIds.filter(
+      (artworkId) => !args.excludeArtworkIds.includes(artworkId)
+    )
 
     const gravityArgs = convertConnectionArgsToGravityArgs(args)
     const { page, size, offset } = gravityArgs
 
     const newForYouArtworks = await getNewForYouArtworks(
       {
-        ids: newForYouArtworkIds,
+        ids: filteredArtworkIds,
         marketable: args.marketable,
         excludeDislikedArtworks: args.excludeDislikedArtworks,
       },

--- a/src/schema/v2/artworksForUser/helpers.ts
+++ b/src/schema/v2/artworksForUser/helpers.ts
@@ -25,7 +25,8 @@ export const getNewForYouArtworkIDs = async (
 
     const userID = args.userId || xImpersonateUserID
     const gravityArgs = convertConnectionArgsToGravityArgs(args)
-    const { page, size } = gravityArgs
+    const { page } = gravityArgs
+    const size = gravityArgs.size + args.excludeArtworkIds.length
 
     // When a `userID` is specified, this is an app request and we should use the
     // unauthenticated loader. The authenticated loader is for logged-in users.
@@ -52,11 +53,13 @@ export const getNewForYouArtworkIDs = async (
     ? `maxWorksPerArtist: ${args.maxWorksPerArtist}`
     : ""
 
+  const first = args.first + args.excludeArtworkIds.length
+
   const query = {
     query: gql`
         query newForYouRecommendationsQuery {
           newForYouRecommendations(
-            first: ${args.first}
+            first: ${first}
             ${userIdArgument}
             ${versionArgument}
             ${maxWorksPerArtistArgument}


### PR DESCRIPTION
This PR adds a new argument to the `artworksForUser` query called `excludeArtworkIds` and when it is provided then matching recommendations from vortex are excluded.

<details><summary> Here's some visual proof </summary>
<p>

![Screenshot 2024-06-04 at 4 07 37 PM](https://github.com/artsy/metaphysics/assets/79799/4b5d9f1c-5bac-430c-9665-7b330e144133)
![Screenshot 2024-06-04 at 4 08 02 PM](https://github.com/artsy/metaphysics/assets/79799/b4876a74-0d56-422e-9e77-79b43e235083)


</p>
</details> 

When I make a query for the recs without the new argument then I get a particular artwork. When I use the new argument and provide that artwork's id then it is skipped. 😎 

https://artsyproduct.atlassian.net/browse/DIA-652

/cc @artsy/amber-devs @isakelaris 