### PR TITLE
feat(onyx-1042): Expose the associated My Collection artwork underneath a Submission

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6939,6 +6939,7 @@ type ConsignmentSubmission {
   additionalInfo: String
   artist: Artist
   artistId: String!
+  artwork: Artwork
   assets: [ConsignmentSubmissionCategoryAsset]
   attributionClass: ConsignmentAttributionClass
   authenticityCertificate: Boolean
@@ -6965,6 +6966,7 @@ type ConsignmentSubmission {
   locationState: String
   medium: String
   minimumPriceDollars: Int
+  myCollectionArtworkID: String
   offers(gravityPartnerId: ID!): [ConsignmentOffer!]!
   primaryImage: ConsignmentSubmissionCategoryAsset
   provenance: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6939,7 +6939,6 @@ type ConsignmentSubmission {
   additionalInfo: String
   artist: Artist
   artistId: String!
-  artwork: Artwork
   assets: [ConsignmentSubmissionCategoryAsset]
   attributionClass: ConsignmentAttributionClass
   authenticityCertificate: Boolean
@@ -6966,6 +6965,7 @@ type ConsignmentSubmission {
   locationState: String
   medium: String
   minimumPriceDollars: Int
+  myCollectionArtwork: Artwork
   myCollectionArtworkID: String
   offers(gravityPartnerId: ID!): [ConsignmentOffer!]!
   primaryImage: ConsignmentSubmissionCategoryAsset

--- a/src/data/convection.graphql
+++ b/src/data/convection.graphql
@@ -1367,6 +1367,7 @@ type Submission {
   locationState: String
   medium: String
   minimumPriceDollars: Int
+  myCollectionArtworkID: String
   offers(gravityPartnerId: ID!): [Offer!]!
   primaryImage: Asset
   provenance: String

--- a/src/lib/stitching/convection/__tests__/stitching.test.ts
+++ b/src/lib/stitching/convection/__tests__/stitching.test.ts
@@ -1,7 +1,10 @@
 import { incrementalMergeSchemas } from "lib/stitching/mergeSchemas"
 import { graphql } from "graphql"
 import { addMockFunctionsToSchema } from "graphql-tools"
-import { useConvectionStitching } from "./testingUtils"
+import {
+  getConvectionStitchedSchema,
+  useConvectionStitching,
+} from "./testingUtils"
 import gql from "lib/gql"
 import schema from "schema/v2/schema"
 
@@ -101,4 +104,20 @@ it("resolves an Artist on a Consignment Submission", async () => {
   expect(result).toEqual({
     data: { submission: { artist: { name: "Hello World" }, artistId: "321" } },
   })
+})
+
+it("resolves the artwork field on Consignment Submission", async () => {
+  const { resolvers } = await getConvectionStitchedSchema()
+  const { artwork } = resolvers.ConsignmentSubmission
+  const info = { mergeInfo: { delegateToSchema: jest.fn() } }
+
+  artwork.resolve({ myCollectionArtworkID: "artwork-id" }, {}, {}, info)
+
+  expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith(
+    expect.objectContaining({
+      args: { id: "artwork-id" },
+      operation: "query",
+      fieldName: "artwork",
+    })
+  )
 })

--- a/src/lib/stitching/convection/__tests__/stitching.test.ts
+++ b/src/lib/stitching/convection/__tests__/stitching.test.ts
@@ -106,12 +106,17 @@ it("resolves an Artist on a Consignment Submission", async () => {
   })
 })
 
-it("resolves the artwork field on Consignment Submission", async () => {
+it("resolves the myCollectionArtwork field on Consignment Submission", async () => {
   const { resolvers } = await getConvectionStitchedSchema()
-  const { artwork } = resolvers.ConsignmentSubmission
+  const { myCollectionArtwork } = resolvers.ConsignmentSubmission
   const info = { mergeInfo: { delegateToSchema: jest.fn() } }
 
-  artwork.resolve({ myCollectionArtworkID: "artwork-id" }, {}, {}, info)
+  myCollectionArtwork.resolve(
+    { myCollectionArtworkID: "artwork-id" },
+    {},
+    {},
+    info
+  )
 
   expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith(
     expect.objectContaining({

--- a/src/lib/stitching/convection/__tests__/testingUtils.ts
+++ b/src/lib/stitching/convection/__tests__/testingUtils.ts
@@ -55,7 +55,7 @@ const getConvectionTransformedSchema = async () => {
  * Gets a cached copy of the stitched schema, independent of being merged into
  * the local schema
  */
-const getConvectionStitchedSchema = async () => {
+export const getConvectionStitchedSchema = async () => {
   if (!stitchedSchema) {
     const cachedSchema = await getConvectionTransformedSchema()
     stitchedSchema = consignmentStitchingEnvironment(localSchema, cachedSchema)

--- a/src/lib/stitching/convection/v2/stitching.ts
+++ b/src/lib/stitching/convection/v2/stitching.ts
@@ -10,6 +10,7 @@ export const consignmentStitchingEnvironment = (
   extensionSchema: `
     extend type ConsignmentSubmission {
       artist: Artist
+      artwork: Artwork
     }
 
     extend type ConsignmentOffer {
@@ -29,6 +30,23 @@ export const consignmentStitchingEnvironment = (
             schema: localSchema,
             operation: "query",
             fieldName: "artist",
+            args: {
+              id,
+            },
+            context,
+            info,
+            transforms: convectionSchema.transforms,
+          })
+        },
+      },
+      artwork: {
+        fragment: `fragment SubmissionArtwork on ConsignmentSubmission { myCollectionArtworkID }`,
+        resolve: (parent, _args, context, info) => {
+          const id = parent.myCollectionArtworkID
+          return info.mergeInfo.delegateToSchema({
+            schema: localSchema,
+            operation: "query",
+            fieldName: "artwork",
             args: {
               id,
             },

--- a/src/lib/stitching/convection/v2/stitching.ts
+++ b/src/lib/stitching/convection/v2/stitching.ts
@@ -10,7 +10,7 @@ export const consignmentStitchingEnvironment = (
   extensionSchema: `
     extend type ConsignmentSubmission {
       artist: Artist
-      artwork: Artwork
+      myCollectionArtwork: Artwork
     }
 
     extend type ConsignmentOffer {
@@ -39,7 +39,7 @@ export const consignmentStitchingEnvironment = (
           })
         },
       },
-      artwork: {
+      myCollectionArtwork: {
         fragment: `fragment SubmissionArtwork on ConsignmentSubmission { myCollectionArtworkID }`,
         resolve: (parent, _args, context, info) => {
           const id = parent.myCollectionArtworkID


### PR DESCRIPTION
[Jira ticket](https://artsyproduct.atlassian.net/browse/ONYX-1042)

To more easily query for artwork metadata stored in My Collection via an associated Submission (in Convection), expose an artwork field under Submission within the GraphQL schema.

Example request:

```graphql
query X {
  submission(id: "250396") {
    myCollectionArtworkID
    
    artwork {
      internalID
      title
    }
  }
}
```

Response:

```json
{
  "data": {
    "submission": {
      "myCollectionArtworkID": "665f27035e8fac000efde37c",
      "artwork": {
        "internalID": "665f27035e8fac000efde37c",
        "title": "No Ball Games (Green) Test - MyC changes"
      }
    }
  }
}
```