### PR TITLE
chore: add new filter arguments to artworks in a collection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4156,8 +4156,15 @@ type Collection {
     after: String
     before: String
     first: Int
+    forSale: Boolean
     last: Int
     page: Int
+
+    # In USD Dollars
+    priceMax: Int
+
+    # In USD Dollars
+    priceMin: Int
     sort: CollectionArtworkSorts
   ): ArtworkConnection
 

--- a/src/schema/v2/me/collection.ts
+++ b/src/schema/v2/me/collection.ts
@@ -32,6 +32,9 @@ export const CollectionType = new GraphQLObjectType<any, ResolverContext>({
               .value,
           },
           page: { type: GraphQLInt },
+          forSale: { type: GraphQLBoolean },
+          priceMin: { type: GraphQLInt, description: "In USD Dollars" },
+          priceMax: { type: GraphQLInt, description: "In USD Dollars" },
         }),
       },
       resolve: async (parent, args, context, _info) => {
@@ -49,6 +52,9 @@ export const CollectionType = new GraphQLObjectType<any, ResolverContext>({
           private: true,
           sort: args.sort,
           total_count: true,
+          for_sale: args.forSale,
+          price_min_major_usd: args.priceMin,
+          price_max_major_usd: args.priceMax,
         }
 
         try {


### PR DESCRIPTION
This still needs to be deployed + backfilled in Gravity, but this would be the API (just new arguments to the connection/endpoint) - hopefully that works for getting hooked up to a FE price slider + availability checkbox filter.