### PR TITLE
chore: update exchange schema

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4592,6 +4592,7 @@ type CommerceBuyOrder implements CommerceOrder {
     timezone: String
   ): String
   lastTransactionFailed: Boolean
+  lastTransactionFailureCode: String
   lineItems(
     # Returns the elements in the list that come after the specified cursor.
     after: String
@@ -5364,6 +5365,7 @@ type CommerceOfferOrder implements CommerceOrder {
     timezone: String
   ): String
   lastTransactionFailed: Boolean
+  lastTransactionFailureCode: String
   lineItems(
     # Returns the elements in the list that come after the specified cursor.
     after: String
@@ -5597,6 +5599,7 @@ interface CommerceOrder {
     timezone: String
   ): String
   lastTransactionFailed: Boolean
+  lastTransactionFailureCode: String
   lineItems(
     # Returns the elements in the list that come after the specified cursor.
     after: String
@@ -16093,6 +16096,27 @@ type Query {
     # Term used for searching collector profiles
     term: String
   ): CollectorProfileTypeConnection
+
+  # Find list of abandoned orders
+  commerceAbandonedOrders(
+    # Returns the elements in the list that come after the specified cursor.
+    after: String
+    artworkId: ID!
+
+    # Returns the elements in the list that come before the specified cursor.
+    before: String
+
+    # Ignored for the time being, future iterations will support this.
+    excludeFailedPayments: Boolean
+
+    # Returns the first _n_ elements from the list.
+    first: Int
+    from: CommerceDateTime!
+
+    # Returns the last _n_ elements from the list.
+    last: Int
+    sellerId: String!
+  ): CommerceOrderConnectionWithTotalCount
 
   # Find balance of an account associated with a setup intent
   commerceBankAccountBalance(

--- a/src/data/exchange.graphql
+++ b/src/data/exchange.graphql
@@ -121,6 +121,7 @@ type BuyOrder implements Order {
   lastApprovedAt: DateTime
   lastSubmittedAt: DateTime
   lastTransactionFailed: Boolean
+  lastTransactionFailureCode: String
   lineItems(
     """
     Returns the elements in the list that come after the specified cursor.
@@ -1309,6 +1310,7 @@ type OfferOrder implements Order {
   lastOffer: Offer
   lastSubmittedAt: DateTime
   lastTransactionFailed: Boolean
+  lastTransactionFailureCode: String
   lineItems(
     """
     Returns the elements in the list that come after the specified cursor.
@@ -1422,6 +1424,7 @@ interface Order {
   lastApprovedAt: DateTime
   lastSubmittedAt: DateTime
   lastTransactionFailed: Boolean
+  lastTransactionFailureCode: String
   lineItems(
     """
     Returns the elements in the list that come after the specified cursor.
@@ -1850,6 +1853,39 @@ type Pickup {
 }
 
 type Query {
+  """
+  Find list of abandoned orders
+  """
+  abandonedOrders(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+    artworkId: ID!
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Ignored for the time being, future iterations will support this.
+    """
+    excludeFailedPayments: Boolean
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+    from: DateTime!
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+    sellerId: String!
+  ): OrderConnectionWithTotalCount
+
   """
   Find balance of an account associated with a setup intent
   """


### PR DESCRIPTION
Generated the latest exchange schema.

@leamotta @starsirius @fladson - a bit surprised that the `abandonedOrders` schema is included here. But maybe we have not used it yet?