### PR TITLE
feat(partner.artistsConnection): Add support for returning authenticated fields

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14400,6 +14400,9 @@ type Partner implements Node {
     displayOnPartnerProfile: Boolean
     first: Int
     hasPublishedArtworks: Boolean
+
+    # Include additional fields on artists, requires authentication
+    includeAllFields: Boolean
     last: Int
     representedBy: Boolean
     sort: ArtistSorts
@@ -14724,6 +14727,11 @@ type PartnerArtistCounts {
     label: String
   ): FormattedNumber
   managedArtworks(
+    # Returns a `String` when format is specified. e.g.`'0,0.0000''`
+    format: String
+    label: String
+  ): FormattedNumber
+  unlistedArtworks(
     # Returns a `String` when format is specified. e.g.`'0,0.0000''`
     format: String
     label: String

--- a/src/schema/v2/partner/partner_artist.ts
+++ b/src/schema/v2/partner/partner_artist.ts
@@ -53,6 +53,10 @@ const counts: GraphQLFieldConfig<PartnerArtistDetails, ResolverContext> = {
         ({ published_for_sale_artworks_count }) =>
           published_for_sale_artworks_count
       ),
+      unlistedArtworks: numeral(
+        ({ published_unlisted_artworks_count }) =>
+          published_unlisted_artworks_count
+      ),
     },
   }),
   resolve: (partner_artist) => partner_artist,


### PR DESCRIPTION
Previously, we supported the use of `allArtistsConnection` for returning authenticated partner.artist counts data. However, that's clunky and returns everything at once, and doesn't support pagination. 

This updates the (bettter) `partner.artistConnection` to support authentication, and also fixes an issue where relay-based cursor pagination support was broken. 

In addition to adding better connection support to CMS, this will allow us to sanely page through lengthy artist lists in folio, vs rendering everything which has terrible network performance. 

<img width="933" alt="Screenshot 2024-06-09 at 1 40 33 PM" src="https://github.com/artsy/metaphysics/assets/236943/995377f5-a603-4a99-af1a-00cc8b1cdd71">

<img width="1047" alt="Screenshot 2024-06-09 at 1 51 59 PM" src="https://github.com/artsy/metaphysics/assets/236943/6601d018-4fcf-4214-9c93-135528714c8f">

cc @artsy/amber-devs 
