### PR TITLE
feat(partner): Add updatePartnerShow mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13706,6 +13706,11 @@ type Mutation {
   # Updates a page.
   updatePage(input: UpdatePageMutationInput!): UpdatePageMutationPayload
 
+  # Updates a partner artist.
+  updatePartnerShow(
+    input: UpdatePartnerShowMutationInput!
+  ): UpdatePartnerShowMutationPayload
+
   # Update a quiz artwork interacted_with flag
   updateQuiz(input: updateQuizMutationInput!): updateQuizMutationPayload
 
@@ -19905,6 +19910,38 @@ union UpdatePageResponseOrError = UpdatePageFailure | UpdatePageSuccess
 
 type UpdatePageSuccess {
   page: Page
+}
+
+type UpdatePartnerShowFailure {
+  mutationError: GravityMutationError
+}
+
+input UpdatePartnerShowMutationInput {
+  clientMutationId: String
+
+  # Is
+  featured: Boolean
+
+  # The id of the partner to update.
+  partnerId: String!
+
+  # The id of the artist to update.
+  showId: String!
+}
+
+type UpdatePartnerShowMutationPayload {
+  clientMutationId: String
+
+  # On success: the updated partner. On error: the error that occurred.
+  showOrError: UpdatePartnerShowResponseOrError
+}
+
+union UpdatePartnerShowResponseOrError =
+    UpdatePartnerShowFailure
+  | UpdatePartnerShowSuccess
+
+type UpdatePartnerShowSuccess {
+  show: Show
 }
 
 input updateQuizMutationInput {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -824,6 +824,14 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" }
     ),
+    updatePartnerShowLoader: gravityLoader<
+      any,
+      { partnerId: string; showId: string }
+    >(
+      ({ partnerId, showId }) => `partner/${partnerId}/show/${showId}`,
+      {},
+      { method: "PUT" }
+    ),
     updatePartnerFlagsLoader: gravityLoader(
       (id) => `partner/${id}/partner_flags`,
       {},

--- a/src/schema/v2/partner/__tests__/updatePartnerShowMutation.test.ts
+++ b/src/schema/v2/partner/__tests__/updatePartnerShowMutation.test.ts
@@ -1,0 +1,74 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("UpdatePartnerShowMutation", () => {
+  const mutation = gql`
+    mutation {
+      updatePartnerShow(
+        input: { partnerId: "foo", showId: "bar", featured: true }
+      ) {
+        showOrError {
+          __typename
+          ... on UpdatePartnerShowSuccess {
+            show {
+              internalID
+            }
+          }
+          ... on UpdatePartnerShowFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("updates the partner show featured field", async () => {
+    const context = {
+      updatePartnerShowLoader: () =>
+        Promise.resolve({
+          _id: "foo",
+        }),
+    }
+
+    const updatedPartner = await runAuthenticatedQuery(mutation, context)
+
+    expect(updatedPartner).toEqual({
+      updatePartnerShow: {
+        showOrError: {
+          __typename: "UpdatePartnerShowSuccess",
+          show: {
+            internalID: "foo",
+          },
+        },
+      },
+    })
+  })
+
+  describe("when failure", () => {
+    it("returns an error", async () => {
+      const context = {
+        updatePartnerShowLoader: () =>
+          Promise.reject(
+            new Error(
+              `https://stagingapi.artsy.net/api/v1/partners/foo/show/bar - {"type":"error","message":"Error from API"}`
+            )
+          ),
+      }
+
+      const updatedPartner = await runAuthenticatedQuery(mutation, context)
+
+      expect(updatedPartner).toEqual({
+        updatePartnerShow: {
+          showOrError: {
+            __typename: "UpdatePartnerShowFailure",
+            mutationError: {
+              message: "Error from API",
+            },
+          },
+        },
+      })
+    })
+  })
+})

--- a/src/schema/v2/partner/updatePartnerShowMutation.ts
+++ b/src/schema/v2/partner/updatePartnerShowMutation.ts
@@ -1,0 +1,104 @@
+import {
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLUnionType,
+  GraphQLBoolean,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import Show from "../show"
+
+interface UpdatePartnerShowMutationInputProps {
+  partnerId: string
+  showId: string
+  featured: boolean
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdatePartnerShowSuccess",
+  isTypeOf: (data) => data._id,
+  fields: () => ({
+    show: {
+      type: Show.type,
+      resolve: (show) => show,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdatePartnerShowFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdatePartnerShowResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const updatePartnerShowMutation = mutationWithClientMutationId<
+  UpdatePartnerShowMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "UpdatePartnerShowMutation",
+  description: "Updates a partner artist.",
+  inputFields: {
+    partnerId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The id of the partner to update.",
+    },
+    showId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The id of the artist to update.",
+    },
+    featured: {
+      type: GraphQLBoolean,
+      description: "Is",
+    },
+  },
+  outputFields: {
+    showOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the updated partner. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { partnerId, showId, featured },
+    { updatePartnerShowLoader }
+  ) => {
+    if (!updatePartnerShowLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const response = await updatePartnerShowLoader(
+        { partnerId, showId },
+        {
+          featured,
+        }
+      )
+
+      return response
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -223,6 +223,7 @@ import { SaleAgreement } from "./SaleAgreements/SaleAgreement"
 import { createCareerHighlightMutation } from "./careerHighlight/createCareerHighlightMutation"
 import { deleteCareerHighlightMutation } from "./careerHighlight/deleteCareerHighlightMutation"
 import { updateCareerHighlightMutation } from "./careerHighlight/updateCareerHighlightMutation"
+import { updatePartnerShowMutation } from "./partner/updatePartnerShowMutation"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -461,6 +462,7 @@ export default new GraphQLSchema({
       updateNotificationPreferences: updateNotificationPreferencesMutation,
       updateOrderedSet: updateOrderedSetMutation,
       updatePage: UpdatePageMutation,
+      updatePartnerShow: updatePartnerShowMutation,
       updateQuiz: updateQuizMutation,
       updateUser: updateUserMutation,
       updateUserInterest: updateUserInterestMutation,


### PR DESCRIPTION
Quick PR that adds the paperwork for calling a mutation for updating a partner show:

Query:

```graphql
mutation updatePartnerShowMutation($input:UpdatePartnerShowMutationInput!) {
  updatePartnerShow(input:$input) {
    showOrError {
      ... on UpdatePartnerShowSuccess {
        show {
          internalID
          isFeatured
          partner {
            ... on Partner {
              showsConnection(first:10) {
                edges {
                  node {
                    isFeatured
                    slug
                  }
                }
              }
            }
          }
        }
      }
      ... on UpdatePartnerShowFailure {
        mutationError {
          error
          message
        }
      }
    }
  }
}
```

Response: 

<img width="579" alt="Screenshot 2024-06-09 at 8 42 03 PM" src="https://github.com/artsy/metaphysics/assets/236943/df86cfd9-423d-4020-a41c-25921a73ff1c">

cc @artsy/amber-devs 

