### PR TITLE
chore(partnerShows): Add loader to `loaders_with_authentication`

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -643,6 +643,11 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    partnerShowsLoader: gravityLoader(
+      (partner_id) => `partner/${partner_id}/shows`,
+      {},
+      { headers: true }
+    ),
     partnerShowArtworksLoader: gravityLoader<
       any,
       { partner_id: string; show_id: string }


### PR DESCRIPTION
Fixes some weird caching behavior that was observed when marking shows as featured and discussed in slack [here](https://artsy.slack.com/archives/C05F8TNKGAV/p1718033011169169). 

TLDR, as we "metaphysics-ize" more of volt via mutations this will likely come up again, where realtime results need to be returned as uncached. If something seems off, check to see if the loader has been added to `src/lib/loaders/loaders_with_authentication/gravity.ts`, and not just `loaders_without_authentication`. If so, you'll likely run into unexpected behavior due to MP-level redis caching. 

cc @artsy/amber-devs 