### PR TITLE
feat(partnerArtist): Add partner artist image support

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2121,6 +2121,8 @@ type ArtistPartnerEdge {
 
   # A globally unique ID.
   id: ID!
+  image: Image
+  imageUrl: String
 
   # A type-specific ID.
   internalID: ID!
@@ -14692,6 +14694,8 @@ type PartnerArtist {
 
   # A globally unique ID.
   id: ID!
+  image: Image
+  imageUrl: String
 
   # A type-specific ID.
   internalID: ID!
@@ -14784,6 +14788,8 @@ type PartnerArtistEdge {
 
   # A globally unique ID.
   id: ID!
+  image: Image
+  imageUrl: String
 
   # A type-specific ID.
   internalID: ID!

--- a/src/schema/v2/partner/__tests__/partner_artist.test.js
+++ b/src/schema/v2/partner/__tests__/partner_artist.test.js
@@ -188,6 +188,48 @@ describe("partnerArtist", () => {
     })
   })
 
+  it("returns a partner image", async () => {
+    partnerArtistData = [
+      {
+        image_url: "foo.jpg",
+        images_urls: ["foo.jpg", "bar.jpg"],
+        image_versions: ["wide"],
+      },
+    ]
+
+    const query = gql`
+      {
+        partner(id: "levy-gorvy") {
+          artistsConnection(first: 3) {
+            edges {
+              imageUrl
+              image {
+                url
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      partner: {
+        artistsConnection: {
+          edges: [
+            {
+              image: {
+                url: "foo.jpg",
+              },
+              imageUrl: "foo.jpg",
+            },
+          ],
+        },
+      },
+    })
+  })
+
   it("isHiddenInPresentationMode", async () => {
     partnerArtistData = [
       {

--- a/src/schema/v2/partner/partner_artist.ts
+++ b/src/schema/v2/partner/partner_artist.ts
@@ -20,6 +20,8 @@ import { BodyAndHeaders } from "lib/loaders"
 import { formatMarkdownValue, markdown } from "schema/v2/fields/markdown"
 import { artworkConnection } from "schema/v2/artwork"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import Image, { getDefault } from "../image"
+import { setVersion } from "../image/normalize"
 
 // TODO: This should move to the gravity loader
 interface PartnerArtistDetails {
@@ -30,6 +32,9 @@ interface PartnerArtistDetails {
   biography: string
   display_on_partner_profile: boolean
   hide_in_presentation_mode: boolean
+  image_versions: string[]
+  image_url: string
+  image_urls: string[]
   partner: {
     id: string
     name: string
@@ -168,6 +173,20 @@ export const fields: Thunk<GraphQLFieldConfigMap<
           }),
         }
       })
+    },
+  },
+  image: Image,
+  imageUrl: {
+    type: GraphQLString,
+    resolve: ({ image_versions, image_url, image_urls }) => {
+      return setVersion(
+        getDefault({
+          image_url,
+          images_urls: image_urls,
+          image_versions,
+        }),
+        ["square"]
+      )
     },
   },
   isDisplayOnPartnerProfile: {


### PR DESCRIPTION
This updates our partnerArtist edge to return the associated partner artist image:

```graphql
{
  partner(id: "foo") {
    artistsConnection(includeAllFields: true, first: 10) {
      edges {
        artist {
          name
        }
        imageUrl
        image {
          url
        }
      }
    }
  }
}
```

<img width="384" alt="Screenshot 2024-06-11 at 10 06 16 AM" src="https://github.com/artsy/metaphysics/assets/236943/f49f8ed5-bf9b-484f-8b7a-4986509fb3d0">



cc @artsy/amber-devs 