### PR TITLE
feat: add includeOnlyTargetSupply param to MyCollectionConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12561,6 +12561,9 @@ type Me implements Node {
     # Exclude artworks that have been purchased on Artsy and automatically added to the collection.
     excludePurchasedArtworks: Boolean = false
     first: Int
+
+    # Show only artworks from target supply artists
+    includeOnlyTargetSupply: Boolean = false
     last: Int
     page: Int
     size: Int

--- a/src/schema/v2/me/myCollection.ts
+++ b/src/schema/v2/me/myCollection.ts
@@ -42,6 +42,11 @@ export const MyCollection: GraphQLFieldConfig<any, ResolverContext> = {
   args: pageable({
     page: { type: GraphQLInt },
     size: { type: GraphQLInt },
+    includeOnlyTargetSupply: {
+      type: GraphQLBoolean,
+      defaultValue: false,
+      description: "Show only artworks from target supply artists",
+    },
     sort: {
       type: new GraphQLEnumType({
         name: "MyCollectionArtworkSorts",


### PR DESCRIPTION
Jira ticket [ONYX-1067]

This PR adds `includeOnlyTargetSupply` to `MyCollectionConnection`. This is required in order to show a valid list of eligible artworks in users' collection.

<img src="https://github.com/artsy/metaphysics/assets/11945712/30bf86f8-5b21-4d42-915c-550693f63e2a" width="300" />




[ONYX-1067]: https://artsyproduct.atlassian.net/browse/ONYX-1067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ