### PR TITLE
feat: propagate a 429 status code if Braze rate limiting occurs

### DIFF
--- a/patches/express-graphql+0.9.0.patch
+++ b/patches/express-graphql+0.9.0.patch
@@ -1,0 +1,17 @@
+diff --git a/node_modules/express-graphql/index.js b/node_modules/express-graphql/index.js
+index 609aba7..572a7d1 100644
+--- a/node_modules/express-graphql/index.js
++++ b/node_modules/express-graphql/index.js
+@@ -167,6 +167,12 @@ function graphqlHTTP(options) {
+         };
+       }
+     }).then(result => {
++      const { errors } = result
++      if (errors) {
++        if (errors.find(error => error.message === "Braze rate limit reached")) {
++          response.statusCode = 429;
++        }
++      }
+       // Collect and apply any metadata extensions if a function was provided.
+       // https://graphql.github.io/graphql-spec/#sec-Response-Format
+       if (result && extensionsFn) {

--- a/src/integration/__tests__/braze_rate_limiting_patch.test.ts
+++ b/src/integration/__tests__/braze_rate_limiting_patch.test.ts
@@ -1,0 +1,36 @@
+jest.mock("lib/apis/fetch", () => jest.fn())
+import { HTTPError } from "lib/HTTPError"
+import fetch from "lib/apis/fetch"
+const mockFetch = fetch as jest.Mock
+
+describe("rate limiting patch", () => {
+  const request = require("supertest")
+  const app = require("../../index").default
+  const gql = require("lib/gql").default
+
+  beforeEach(() => {
+    mockFetch.mockClear()
+    mockFetch.mockReset()
+  })
+
+  it("propagates a 429 for Braze rate limiting", async () => {
+    mockFetch.mockRejectedValueOnce(
+      new HTTPError("Braze rate limit reached", 429)
+    )
+
+    const response = await request(app)
+      .post("/v2")
+      .set("Accept", "application/json")
+      .send({
+        query: gql`
+          {
+            artist(id: "banksy") {
+              name
+            }
+          }
+        `,
+      })
+
+    expect(response.statusCode).toBe(429)
+  })
+})


### PR DESCRIPTION
Here's my attempt at propagating a 429 status code for the entire request if there's a rate-limiting error when fetching from an upstream backend, _and_ it's a Braze user agent.

I am not crazy about this implementation b/c it uses a patch on `express-graphql`. I found the patch necessary in this attempt bc wanting to adjust the status code of the response is a pretty low-level (and a bit of an anti-pattern as well) thing which I just couldn't figure out how to do otherwise.

Worth noting that `express-graphql` is one of our old and outdated dependencies - the entire [repo](https://github.com/graphql/express-graphql) and package is archived and read-only, which I think is actually a point in _favor_ of the patch, as we're unlikely to ever deal with an upgrade of this package (+ there's a spec). Being hard to upgrade (and re-implement or re-apply the patch) is usually the main annoyance of a patch, and doubly-so w/o an integration test in your app that exercises the functionality.

This implementation is also a bit brittle because the exact contents of the error message is used in the lib to propagate a 429, but at least there is a spec for this.