### PR TITLE
feat: propagate a 429 status code if email-provider rate limiting occurs

### DIFF
--- a/src/extensions/email_provider_rate_limit_extension.ts
+++ b/src/extensions/email_provider_rate_limit_extension.ts
@@ -1,0 +1,22 @@
+import { flattenErrors, statusCodeForError } from "lib/graphqlErrorHandler"
+
+// Log in `extensions` if this request was by an email provider and resulted
+// in a 429 rate limit error from a downstream request made using `fetch`.
+export const emailProviderRateLimitExtension = (_documentAST, result) => {
+  const extensions = {}
+
+  if (result.errors && result.errors.length) {
+    result.errors.some((err) => {
+      flattenErrors(err).some((e) => {
+        const httpStatusCode = statusCodeForError(e)
+        if (httpStatusCode === 429) {
+          extensions["emailProviderLimited"] = true
+          return true
+        }
+        return false
+      })
+    })
+  }
+
+  return extensions
+}

--- a/src/integration/__tests__/email_provider_rate_limit.test.ts
+++ b/src/integration/__tests__/email_provider_rate_limit.test.ts
@@ -1,0 +1,38 @@
+jest.mock("lib/apis/fetch", () => jest.fn())
+import { HTTPError } from "lib/HTTPError"
+import fetch from "lib/apis/fetch"
+const mockFetch = fetch as jest.Mock
+
+describe("rate limiting custom status code and response", () => {
+  const request = require("supertest")
+  const app = require("../../index").default
+  const gql = require("lib/gql").default
+
+  beforeEach(() => {
+    mockFetch.mockClear()
+    mockFetch.mockReset()
+  })
+
+  it("propagates a 429 for email provider rate limiting", async () => {
+    mockFetch.mockRejectedValueOnce(
+      new HTTPError("Braze rate limit reached", 429)
+    )
+
+    const response = await request(app)
+      .post("/v2")
+      .set("Accept", "application/json")
+      .set("User-Agent", "Braze")
+      .send({
+        query: gql`
+          {
+            artist(id: "banksy") {
+              name
+            }
+          }
+        `,
+      })
+
+    expect(response.statusCode).toBe(429)
+    expect(response.body.error).toBe("rate limit reached, try again later")
+  })
+})


### PR DESCRIPTION
This is an alternate implementation of https://github.com/artsy/metaphysics/pull/5798 , different approach altogether.

This is a two-pronged thing:

First - if there are any 429's from an upstream service experienced by an email provider app making a request to MP - we log this via `extensions`, as `emailProviderLimited: true`. This is sort-of a place where we temporarily store the fact that this situation has occurred during this request, and some middleware elsewhere in the stack will introspect. The GraphQL spec allows for arbitrary data to live here, and while our middleware will actually introspect _and_ intercept requests with this extension so it never makes it to an end user as-is, I think using `extensions` for this is reasonable.

Second - we have a middleware on our GraphQL route that is mounted _before_ our regular GraphQL server. This allows it to register a custom `res.end` function to be able to intercept the response and introspect - if there is `extensions` and `emailProviderLimited: true` exists, we can send our custom 429/error response.

This overall still feels wonky to me as there's a bit of hackiness around `res.end` re-defining, I'm not sure if this is truly better or not than the patch in https://github.com/artsy/metaphysics/pull/5798 - but it is an alternative!