### PR TITLE
feat: support collector profile update activity type in Item schema

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4360,6 +4360,10 @@ type CollectorProfileTypeEdge {
   node: CollectorProfileType
 }
 
+type CollectorProfileUpdatePromptNotificationItem {
+  collectorProfile: CollectorProfileType!
+}
+
 type CollectorResume {
   buyerActivity: CommerceBuyerActivity
   collectorProfile: CollectorProfileType!
@@ -14102,6 +14106,7 @@ union NotificationItem =
     AlertNotificationItem
   | ArticleFeaturedArtistNotificationItem
   | ArtworkPublishedNotificationItem
+  | CollectorProfileUpdatePromptNotificationItem
   | PartnerOfferCreatedNotificationItem
   | ShowOpenedNotificationItem
   | ViewingRoomPublishedNotificationItem

--- a/src/schema/v2/notifications/Item/CollectorProfileUpdatePromptNotificationItem.ts
+++ b/src/schema/v2/notifications/Item/CollectorProfileUpdatePromptNotificationItem.ts
@@ -1,0 +1,16 @@
+import { GraphQLNonNull, GraphQLObjectType } from "graphql"
+import { CollectorProfileType } from "schema/v2/CollectorProfile/collectorProfile"
+import { ResolverContext } from "types/graphql"
+
+export const CollectorProfileUpdatePromptNotificationItemType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "CollectorProfileUpdatePromptNotificationItem",
+  fields: {
+    collectorProfile: {
+      type: GraphQLNonNull(CollectorProfileType),
+      resolve: ({ object }) => object,
+    },
+  },
+})

--- a/src/schema/v2/notifications/Item/index.ts
+++ b/src/schema/v2/notifications/Item/index.ts
@@ -5,6 +5,7 @@ import { ArtworkPublishedNotificationItemType } from "./ArtworkPublishedNotifica
 import { ShowOpenedNotificationItemType } from "./ShowOpenedNotificationItem"
 import { ViewingRoomPublishedNotificationItemType } from "./ViewingRoomPublishedNotificationItem"
 import { PartnerOfferCreatedNotificationItemType } from "./PartnerOfferCreatedNotificationItem"
+import { CollectorProfileUpdatePromptNotificationItemType } from "./CollectorProfileUpdatePromptNotificationItem"
 
 export const NotificationItemType = new GraphQLUnionType({
   name: "NotificationItem",
@@ -15,6 +16,7 @@ export const NotificationItemType = new GraphQLUnionType({
     ShowOpenedNotificationItemType,
     ViewingRoomPublishedNotificationItemType,
     PartnerOfferCreatedNotificationItemType,
+    CollectorProfileUpdatePromptNotificationItemType,
   ],
   resolveType: ({ activity_type }) => {
     switch (activity_type) {
@@ -30,6 +32,8 @@ export const NotificationItemType = new GraphQLUnionType({
         return ViewingRoomPublishedNotificationItemType
       case "PartnerOfferCreatedActivity":
         return PartnerOfferCreatedNotificationItemType
+      case "CollectorProfileUpdatePromptActivity":
+        return CollectorProfileUpdatePromptNotificationItemType
       default:
         throw new Error("Unknown notification content type")
     }


### PR DESCRIPTION
### What this does

This should allow the /notifications page and bell dropdown (on web) to render -> right now the queries error out if your feed includes an item of this type b/c the richer `Item` schema is being queried for (for some activity types), and even though we likely don't need it for this type, as it is a union type we need to include something minimally - it simply throws an exception otherwise.

With this addition the query will succeed, however the rendering of the notification will be basically empty, as we're not returning any 'real' data from MP for this activity type -> it's really more of a placeholder.

My thinking is while some of the copy used is shared between Force/Eigen and so _can_ go to MP (possibly using the existing `headline` and `message` fields, _or_ as part of the richer `Item` schema here -> of course clients need to have an implementation for this specific activity item anyway as there's some custom modal behavior when being clicked or tapped.

So, I _think_ maybe let's hold off on implementing anything _more_ in MP for this, since that would be a little bit of bike-shedding and over-engineering..

### To sum up (as this is the last backend PR for the prompt activity for now):

Right now, we have an activity item in a user's feed that's created at most once every 30 days, which is a placeholder for a 'collector profile prompt' -> triggered by a user taking a commercial action (either BNMO order or making an offer). Queries against our notification schema in MP can resolve + succeed for activity feeds that include an item of this type, although there's no meaningful 'data' coming through in that schema - so of course the rendering on the client is wonky.

This feels more-or-less like a reasonable attempt at implementing the intent of this feature on the backend. I think that it's enough to unblock the front-end, and Force could even start by hard-coding the copy (for now) - and only once the front-end is farther along we can have a sense for what, if anything, makes sense to escalate upstream to MP (or even Gravity).

@dzucconi @iskounen let me know what you think of where we ended up on this overall backend support for this or what else you might need!