### PR TITLE
feat(onyx-1071): allow syncing my collection artwork data when creating submission

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13244,6 +13244,10 @@ type Mutation {
     input: CommerceUpdateImpulseConversationIdInput!
   ): CommerceUpdateImpulseConversationIdPayload
   confirmPassword(input: ConfirmPasswordInput!): ConfirmPasswordPayload
+  convectionCreateConsignmentSubmission(
+    # Parameters for CreateSubmissionMutation
+    input: CreateSubmissionMutationInput!
+  ): CreateSubmissionMutationPayload
 
   # Create an account request
   createAccountRequest(

--- a/src/lib/__tests__/artworkToSubmissionMapping.test.ts
+++ b/src/lib/__tests__/artworkToSubmissionMapping.test.ts
@@ -15,7 +15,7 @@ describe("artworkToSubmissionMapping", () => {
     const artwork = {
       artist: { id: "artist-id" },
       title: "Artwork Title",
-      dates: ["2020"],
+      date: "2020",
       medium: "Medium",
       category: "Photography",
       attribution_class: "Attribution Class",
@@ -32,30 +32,36 @@ describe("artworkToSubmissionMapping", () => {
         countryCode: "US",
         postalCode: "10001",
       },
+      signature: "back",
     }
 
     const submission = artworkToSubmissionMapping(artwork)
 
-    expect(submission).toEqual({
-      artistID: "artist-id",
-      title: "Artwork Title",
-      year: "2020",
-      medium: "Medium",
-      category: "PHOTOGRAPHY",
-      attributionClass: "ATTRIBUTION_CLASS",
-      editionNumber: 1,
-      editionSize: 2,
-      height: "10",
-      width: "10",
-      depth: "10",
-      dimensionsMetric: "in",
-      provenance: "Provenance",
-      locationCity: "City",
-      locationCountry: "Country",
-      locationState: "State",
-      locationCountryCode: "US",
-      locationPostalCode: "10001",
-    })
+    expect(submission).toMatchInlineSnapshot(
+      `
+      Object {
+        "artistID": "artist-id",
+        "attributionClass": "ATTRIBUTION_CLASS",
+        "category": "PHOTOGRAPHY",
+        "depth": "10",
+        "dimensionsMetric": "in",
+        "editionNumber": 1,
+        "editionSize": 2,
+        "height": "10",
+        "locationCity": "City",
+        "locationCountry": "Country",
+        "locationCountryCode": "US",
+        "locationPostalCode": "10001",
+        "locationState": "State",
+        "medium": "Medium",
+        "provenance": "Provenance",
+        "signature": true,
+        "title": "Artwork Title",
+        "width": "10",
+        "year": "2020",
+      }
+    `
+    )
   })
 })
 

--- a/src/lib/__tests__/artworkToSubmissionMapping.test.ts
+++ b/src/lib/__tests__/artworkToSubmissionMapping.test.ts
@@ -1,0 +1,90 @@
+import {
+  artworkToSubmissionCategory,
+  artworkToSubmissionMapping,
+} from "lib/artworkToSubmissionMapping"
+
+describe("artworkToSubmissionMapping", () => {
+  it("doesn't fail with empty artwork", () => {
+    const artwork = {}
+    const submission = artworkToSubmissionMapping(artwork)
+
+    expect(submission).toEqual({})
+  })
+
+  it("correctly maps artwork to submission", () => {
+    const artwork = {
+      artist: { id: "artist-id" },
+      title: "Artwork Title",
+      dates: ["2020"],
+      medium: "Medium",
+      category: "Photography",
+      attribution_class: "Attribution Class",
+      edition_sets: [{ available_editions: [1], edition_size: "2" }],
+      height: "10",
+      width: "10",
+      depth: "10",
+      metric: "in",
+      provenance: "Provenance",
+      collector_location: {
+        city: "City",
+        country: "Country",
+        state: "State",
+        countryCode: "US",
+        postalCode: "10001",
+      },
+    }
+
+    const submission = artworkToSubmissionMapping(artwork)
+
+    expect(submission).toEqual({
+      artistID: "artist-id",
+      title: "Artwork Title",
+      year: "2020",
+      medium: "Medium",
+      category: "PHOTOGRAPHY",
+      attributionClass: "ATTRIBUTION_CLASS",
+      editionNumber: 1,
+      editionSize: 2,
+      height: "10",
+      width: "10",
+      depth: "10",
+      dimensionsMetric: "in",
+      provenance: "Provenance",
+      locationCity: "City",
+      locationCountry: "Country",
+      locationState: "State",
+      locationCountryCode: "US",
+      locationPostalCode: "10001",
+    })
+  })
+})
+
+describe("artworkToSubmissionCategory", () => {
+  it("correctly maps artwork category to submission category", () => {
+    expect(artworkToSubmissionCategory("Architecture")).toEqual("ARCHITECTURE")
+    expect(artworkToSubmissionCategory("Design/Decorative Art")).toEqual(
+      "DESIGN_DECORATIVE_ART"
+    )
+    expect(
+      artworkToSubmissionCategory("Drawing, Collage or other Work on Paper")
+    ).toEqual("DRAWING_COLLAGE_OR_OTHER_WORK_ON_PAPER")
+    expect(
+      artworkToSubmissionCategory("Fashion Design and Wearable Art")
+    ).toEqual("FASHION_DESIGN_AND_WEARABLE_ART")
+    expect(artworkToSubmissionCategory("Installation")).toEqual("INSTALLATION")
+    expect(artworkToSubmissionCategory("Jewelry")).toEqual("JEWELRY")
+    expect(artworkToSubmissionCategory("Mixed Media")).toEqual("MIXED_MEDIA")
+    expect(artworkToSubmissionCategory("Painting")).toEqual("PAINTING")
+    expect(artworkToSubmissionCategory("Performance Art")).toEqual(
+      "PERFORMANCE_ART"
+    )
+    expect(artworkToSubmissionCategory("Photography")).toEqual("PHOTOGRAPHY")
+    expect(artworkToSubmissionCategory("Print")).toEqual("PRINT")
+    expect(artworkToSubmissionCategory("Sculpture")).toEqual("SCULPTURE")
+    expect(artworkToSubmissionCategory("Textile Arts")).toEqual("TEXTILE_ARTS")
+    expect(artworkToSubmissionCategory("Video/Film/Animation")).toEqual(
+      "VIDEO_FILM_ANIMATION"
+    )
+    expect(artworkToSubmissionCategory("Posters")).toEqual("OTHER")
+  })
+})

--- a/src/lib/artworkToSubmissionMapping.ts
+++ b/src/lib/artworkToSubmissionMapping.ts
@@ -1,3 +1,5 @@
+import { isUndefined, omitBy } from "lodash"
+
 const ValidSubmissionCategories = [
   "ARCHITECTURE",
   "DESIGN_DECORATIVE_ART",
@@ -20,9 +22,7 @@ export const artworkToSubmissionCategory = (category: string) => {
 
   // replace all spaces, commas, and slashes with underscores, remove double underscores, and uppercase
   const normalizedArtworkCategory = category
-    .replace(/ /g, "_")
-    .replace(/,/g, "_")
-    .replace(/\//g, "_")
+    .replace(/\W/g, "_")
     .replace(/\_\_/g, "_")
     .toUpperCase()
 
@@ -35,36 +35,31 @@ export const artworkToSubmissionCategory = (category: string) => {
 
 // artwork is an object taken from the Gravity API (artworkLoader)
 export const artworkToSubmissionMapping = (artwork) => {
-  return (
-    Object.entries({
-      artistID: artwork.artist?.id,
-      title: artwork.title,
-      year: (artwork.dates || [])[0]?.toString(),
-      medium: artwork.medium,
-      category: artworkToSubmissionCategory(artwork.category),
-      attributionClass: artwork.attribution_class
-        ?.replace(" ", "_")
-        ?.toUpperCase(),
-      editionNumber: artwork.edition_sets?.[0]?.available_editions?.[0],
-      editionSize: artwork.edition_sets?.[0]?.edition_size
-        ? +artwork.edition_sets?.[0]?.edition_size
-        : undefined,
-      height: artwork.height,
-      width: artwork.width,
-      depth: artwork.depth,
-      dimensionsMetric: artwork.metric,
-      provenance: artwork.provenance,
-      locationCity: artwork.collector_location?.city,
-      locationCountry: artwork.collector_location?.country,
-      locationState: artwork.collector_location?.state,
-      locationCountryCode: artwork.collector_location?.countryCode,
-      locationPostalCode: artwork.collector_location?.postalCode,
-    })
-      // Remove undefined values
-      .filter(([_key, value]) => value !== undefined)
-      .reduce((obj, [key, value]) => {
-        obj[key] = value
-        return obj
-      }, {})
-  )
+  const values = {
+    artistID: artwork.artist?.id,
+    title: artwork.title,
+    year: artwork.date,
+    medium: artwork.medium,
+    category: artworkToSubmissionCategory(artwork.category),
+    attributionClass: artwork.attribution_class
+      ?.replace(" ", "_")
+      ?.toUpperCase(),
+    editionNumber: artwork.edition_sets?.[0]?.available_editions?.[0],
+    editionSize: artwork.edition_sets?.[0]?.edition_size
+      ? +artwork.edition_sets?.[0]?.edition_size
+      : undefined,
+    height: artwork.height,
+    width: artwork.width,
+    depth: artwork.depth,
+    dimensionsMetric: artwork.metric,
+    provenance: artwork.provenance,
+    locationCity: artwork.collector_location?.city,
+    locationCountry: artwork.collector_location?.country,
+    locationState: artwork.collector_location?.state,
+    locationCountryCode: artwork.collector_location?.countryCode,
+    locationPostalCode: artwork.collector_location?.postalCode,
+    signature: artwork.signature ? true : undefined,
+  }
+
+  return omitBy(values, isUndefined)
 }

--- a/src/lib/artworkToSubmissionMapping.ts
+++ b/src/lib/artworkToSubmissionMapping.ts
@@ -1,0 +1,70 @@
+const ValidSubmissionCategories = [
+  "ARCHITECTURE",
+  "DESIGN_DECORATIVE_ART",
+  "DRAWING_COLLAGE_OR_OTHER_WORK_ON_PAPER",
+  "FASHION_DESIGN_AND_WEARABLE_ART",
+  "INSTALLATION",
+  "JEWELRY",
+  "MIXED_MEDIA",
+  "PAINTING",
+  "PERFORMANCE_ART",
+  "PHOTOGRAPHY",
+  "PRINT",
+  "SCULPTURE",
+  "TEXTILE_ARTS",
+  "VIDEO_FILM_ANIMATION",
+]
+
+export const artworkToSubmissionCategory = (category: string) => {
+  if (!category) return
+
+  // replace all spaces, commas, and slashes with underscores, remove double underscores, and uppercase
+  const normalizedArtworkCategory = category
+    .replace(/ /g, "_")
+    .replace(/,/g, "_")
+    .replace(/\//g, "_")
+    .replace(/\_\_/g, "_")
+    .toUpperCase()
+
+  if (ValidSubmissionCategories.includes(normalizedArtworkCategory)) {
+    return normalizedArtworkCategory
+  }
+
+  return "OTHER"
+}
+
+// artwork is an object taken from the Gravity API (artworkLoader)
+export const artworkToSubmissionMapping = (artwork) => {
+  return (
+    Object.entries({
+      artistID: artwork.artist?.id,
+      title: artwork.title,
+      year: (artwork.dates || [])[0]?.toString(),
+      medium: artwork.medium,
+      category: artworkToSubmissionCategory(artwork.category),
+      attributionClass: artwork.attribution_class
+        ?.replace(" ", "_")
+        ?.toUpperCase(),
+      editionNumber: artwork.edition_sets?.[0]?.available_editions?.[0],
+      editionSize: artwork.edition_sets?.[0]?.edition_size
+        ? +artwork.edition_sets?.[0]?.edition_size
+        : undefined,
+      height: artwork.height,
+      width: artwork.width,
+      depth: artwork.depth,
+      dimensionsMetric: artwork.metric,
+      provenance: artwork.provenance,
+      locationCity: artwork.collector_location?.city,
+      locationCountry: artwork.collector_location?.country,
+      locationState: artwork.collector_location?.state,
+      locationCountryCode: artwork.collector_location?.countryCode,
+      locationPostalCode: artwork.collector_location?.postalCode,
+    })
+      // Remove undefined values
+      .filter(([_key, value]) => value !== undefined)
+      .reduce((obj, [key, value]) => {
+        obj[key] = value
+        return obj
+      }, {})
+  )
+}

--- a/src/lib/stitching/convection/__tests__/stitching.test.ts
+++ b/src/lib/stitching/convection/__tests__/stitching.test.ts
@@ -158,7 +158,7 @@ describe("createConsignmentSubmission mutation", () => {
     }
 
     context.artworkLoader.mockResolvedValue({
-      dates: [2003],
+      date: "2003",
       category: "Drawing, Collage or other Work on Paper",
       edition_sets: [{ available_editions: ["1"], edition_size: "2" }],
     })
@@ -186,6 +186,7 @@ describe("createConsignmentSubmission mutation", () => {
             category: "DRAWING_COLLAGE_OR_OTHER_WORK_ON_PAPER",
             editionNumber: "1",
             editionSize: 2,
+            source: "MY_COLLECTION",
           },
         },
         operation: "mutation",

--- a/src/lib/stitching/convection/__tests__/stitching.test.ts
+++ b/src/lib/stitching/convection/__tests__/stitching.test.ts
@@ -126,3 +126,60 @@ it("resolves the myCollectionArtwork field on Consignment Submission", async () 
     })
   )
 })
+
+describe("createConsignmentSubmission mutation", () => {
+  it("delegates to convectionCreateConsignmentSubmission mutation", async () => {
+    const { resolvers } = await getConvectionStitchedSchema()
+    const { createConsignmentSubmission } = resolvers.Mutation
+    const info = { mergeInfo: { delegateToSchema: jest.fn() } }
+
+    createConsignmentSubmission.resolve(
+      {},
+      { input: { artistID: "banksy" } },
+      {},
+      info
+    )
+
+    expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: { input: { artistID: "banksy" } },
+        operation: "mutation",
+        fieldName: "convectionCreateConsignmentSubmission",
+      })
+    )
+  })
+
+  it("uses artwork data to fill in submission when myCollectionArtworkID is specified", async () => {
+    const { resolvers } = await getConvectionStitchedSchema()
+    const { createConsignmentSubmission } = resolvers.Mutation
+    const info = { mergeInfo: { delegateToSchema: jest.fn() } }
+    const context = {
+      artworkLoader: jest.fn(),
+    }
+
+    context.artworkLoader.mockResolvedValue({
+      dates: [2003],
+    })
+
+    createConsignmentSubmission.resolve(
+      {},
+      { input: { artistID: "banksy", myCollectionArtworkID: "artwork-id" } },
+      context,
+      info
+    )
+
+    expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: {
+          input: {
+            artistID: "banksy",
+            myCollectionArtworkID: "artwork-id",
+            year: "2003",
+          },
+        },
+        operation: "mutation",
+        fieldName: "convectionCreateConsignmentSubmission",
+      })
+    )
+  })
+})

--- a/src/lib/stitching/convection/__tests__/stitching.test.ts
+++ b/src/lib/stitching/convection/__tests__/stitching.test.ts
@@ -151,7 +151,7 @@ describe("createConsignmentSubmission mutation", () => {
 
   it("uses artwork data to fill in submission when myCollectionArtworkID is specified", async () => {
     const { resolvers } = await getConvectionStitchedSchema()
-    const { createConsignmentSubmission } = resolvers.Mutation
+    const resolver = resolvers.Mutation.createConsignmentSubmission.resolve
     const info = { mergeInfo: { delegateToSchema: jest.fn() } }
     const context = {
       artworkLoader: jest.fn(),
@@ -159,11 +159,19 @@ describe("createConsignmentSubmission mutation", () => {
 
     context.artworkLoader.mockResolvedValue({
       dates: [2003],
+      category: "Drawing, Collage or other Work on Paper",
+      edition_sets: [{ available_editions: ["1"], edition_size: "2" }],
     })
 
-    createConsignmentSubmission.resolve(
+    await resolver(
       {},
-      { input: { artistID: "banksy", myCollectionArtworkID: "artwork-id" } },
+      {
+        input: {
+          artistID: "banksy",
+          myCollectionArtworkID: "artwork-id",
+          year: "2004",
+        },
+      },
       context,
       info
     )
@@ -174,7 +182,10 @@ describe("createConsignmentSubmission mutation", () => {
           input: {
             artistID: "banksy",
             myCollectionArtworkID: "artwork-id",
-            year: "2003",
+            year: "2004",
+            category: "DRAWING_COLLAGE_OR_OTHER_WORK_ON_PAPER",
+            editionNumber: "1",
+            editionSize: 2,
           },
         },
         operation: "mutation",

--- a/src/lib/stitching/convection/schema.ts
+++ b/src/lib/stitching/convection/schema.ts
@@ -3,6 +3,7 @@ import {
   makeRemoteExecutableSchema,
   transformSchema,
   RenameTypes,
+  RenameRootFields,
 } from "graphql-tools"
 import { readFileSync } from "fs"
 
@@ -40,6 +41,15 @@ export const executableConvectionSchema = () => {
     new RenameTypes((name) => {
       const newName = remap[name] || name
       return newName
+    }),
+    new RenameRootFields((_operation, name) => {
+      // We re-define createConsignmentSubmission mutation in Metaphysics, but we want to
+      // use the Convection version of the mutation there, that's why we rename it here.
+      if (name === "createConsignmentSubmission") {
+        return "convectionCreateConsignmentSubmission"
+      }
+
+      return name
     }),
   ])
 }

--- a/src/lib/stitching/convection/v2/stitching.ts
+++ b/src/lib/stitching/convection/v2/stitching.ts
@@ -123,6 +123,7 @@ export const consignmentStitchingEnvironment = (
                 input: {
                   ...artworkSubmissionData,
                   ...createSubmissionArgs.input,
+                  source: "MY_COLLECTION",
                 },
               }
             }


### PR DESCRIPTION
This PR allows to sync artwork data when specifying it's ID as `myCollectionArtworkID` argument to `createConsignmentSubmission` mutation.

Previously, `createConsignmentSubmission` was simply stitched from Convection. This PR adds a resolver for this mutation (keeping the same name). This mutation does two things:

- If  `myCollectionArtworkID` is specified - fetches artwork data using `artworkLoader` and prepares it to be passed to Convection.
- Calls `convectionCreateConsignmentSubmission` mutation (which was renamed from `createConsignmentSubmission`) with artwork data + mutation input arguments (mutation input arguments override artwork data if specified)

Example request (uses this [artwork](https://staging.artsy.net/collector-profile/my-collection/artwork/6654590c43bd0200125ea0b1)):

```graphql
mutation {
  createConsignmentSubmission(input: { artistID: "banksy", myCollectionArtworkID: "6654590c43bd0200125ea0b1" }) {
    consignmentSubmission {
      artistId
      myCollectionArtworkID
      title
      
      medium
      category
      year
      
      attributionClass
      
      editionNumber
      editionSize
      
      height
      width
      depth
      
      dimensionsMetric
      provenance
      
      locationCity
      locationCountry
      locationState
      locationCountryCode
      locationPostalCode
    }
  }
}
```

Response:

```json
{
  "data": {
    "createConsignmentSubmission": {
      "consignmentSubmission": {
        "artistId": "banksy",
        "myCollectionArtworkID": "6654590c43bd0200125ea0b1",
        "title": "Happy Choppers",
        "medium": "Screen print in colours on wove paper",
        "category": "Drawing, Collage or other Work on Paper",
        "year": "2003",
        "attributionClass": "LIMITED_EDITION",
        "editionNumber": "1",
        "editionSize": "2",
        "height": "10",
        "width": "20",
        "depth": "",
        "dimensionsMetric": "in",
        "provenance": "Stolen",
        "locationCity": "Berlin",
        "locationCountry": "Germany",
        "locationState": "Berlin",
        "locationCountryCode": null,
        "locationPostalCode": null
      }
    }
  }
}
```
