### PR TITLE
fix: trailing comma in inquiries with questions

### DIFF
--- a/src/schema/v2/conversation/__tests__/__snapshots__/conversation.test.js.snap
+++ b/src/schema/v2/conversation/__tests__/__snapshots__/conversation.test.js.snap
@@ -67,7 +67,7 @@ Object {
 `;
 
 exports[`Me Conversation inquiry request returns the formatted first message, questions, and shipping location when present 3`] = `
-"Hello world!,
+"Hello world!
 
 I would like to request the following information about this artwork:
 • Shipping Quote to New York City, US

--- a/src/schema/v2/partner/partnerInquiryRequest.ts
+++ b/src/schema/v2/partner/partnerInquiryRequest.ts
@@ -40,7 +40,7 @@ export const InquiryRequestType = new GraphQLObjectType<any, ResolverContext>({
               : `• ${question?.question}`
           )
         })
-        if (message) lines.unshift([message, "\n"].join())
+        if (message) lines.unshift(`${message}\n`)
         return lines.join("\n")
       },
     },


### PR DESCRIPTION
This PR prevents a trailing comma from appearing in conversation messages in CMS when questions are attached to an inquiry.

<img width="482" alt="Screenshot 2024-06-20 at 9 15 45 AM" src="https://github.com/artsy/metaphysics/assets/44589599/08df3e52-2d19-4b79-a9d8-ca3b2105de51">