### PR TITLE
fix: avoid schema error when Submission#myCollectionArtworkID is null

### DIFF
--- a/src/lib/stitching/convection/__tests__/stitching.test.ts
+++ b/src/lib/stitching/convection/__tests__/stitching.test.ts
@@ -126,3 +126,18 @@ it("resolves the myCollectionArtwork field on Consignment Submission", async () 
     })
   )
 })
+
+it("resolves null for the myCollectionArtwork field on Consignment Submission if myCollectionArtworkID is null", async () => {
+  const { resolvers } = await getConvectionStitchedSchema()
+  const { myCollectionArtwork } = resolvers.ConsignmentSubmission
+  const info = { mergeInfo: { delegateToSchema: jest.fn() } }
+
+  const response = myCollectionArtwork.resolve(
+    { myCollectionArtworkID: null },
+    {},
+    {},
+    info
+  )
+
+  expect(response).toEqual(null)
+})

--- a/src/lib/stitching/convection/v2/stitching.ts
+++ b/src/lib/stitching/convection/v2/stitching.ts
@@ -43,6 +43,9 @@ export const consignmentStitchingEnvironment = (
         fragment: `fragment SubmissionArtwork on ConsignmentSubmission { myCollectionArtworkID }`,
         resolve: (parent, _args, context, info) => {
           const id = parent.myCollectionArtworkID
+
+          if (!id) return null
+
           return info.mergeInfo.delegateToSchema({
             schema: localSchema,
             operation: "query",


### PR DESCRIPTION
## Desired

**Request**

```graphql
{
  submission(id: "d641cd14-98b4-41c3-9332-f7b2904c4dc8") {
    myCollectionArtwork {
      internalID
    }
  }
}
```

**Response**

```json
{
  "data": {
    "submission": {
      "myCollectionArtwork": null
    }
  }
}
```

## Actual

```
"message": "Variable \"$_v0_id\" of non-null type \"String!\" must not be null.",
```