### PR TITLE
feat(EMI-1924): return isActive for partner offers

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14876,6 +14876,7 @@ type PartnerOffer implements Node {
 
   # A type-specific ID.
   internalID: ID!
+  isActive: Boolean
   isAvailable: Boolean
   note: String
   partnerId: String
@@ -14970,6 +14971,7 @@ type PartnerOfferToCollector implements Node {
 
   # A type-specific ID.
   internalID: ID!
+  isActive: Boolean
   isAvailable: Boolean
   note: String
   partnerId: String

--- a/src/schema/v2/me/__tests__/index.test.ts
+++ b/src/schema/v2/me/__tests__/index.test.ts
@@ -704,6 +704,7 @@ describe("me/index", () => {
                 node {
                   internalID
                   artworkId
+                  isActive
                   isAvailable
                   note
                   partnerId
@@ -743,6 +744,7 @@ describe("me/index", () => {
                   createdAt: "2024-02-27T19:01:51.461Z",
                   endAt: "2024-03-01T19:01:51.457Z",
                   internalID: "866f16a0-92bf-4fb6-8911-e1ab1a5fb508",
+                  isActive: true,
                   isAvailable: true,
                   note: "This is a note!",
                   partnerId: "5f80bfefe8d808000ea212c1",

--- a/src/schema/v2/partnerOffer.ts
+++ b/src/schema/v2/partnerOffer.ts
@@ -30,6 +30,10 @@ export const PartnerOfferType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
       resolve: ({ artwork_id }) => artwork_id,
     },
+    isActive: {
+      type: GraphQLBoolean,
+      resolve: ({ active }) => active,
+    },
     isAvailable: {
       type: GraphQLBoolean,
       resolve: ({ available }) => available,

--- a/src/schema/v2/partnerOfferToCollector.ts
+++ b/src/schema/v2/partnerOfferToCollector.ts
@@ -25,6 +25,10 @@ export const PartnerOfferToCollectorType = new GraphQLObjectType<
     },
     createdAt: date(),
     endAt: date(),
+    isActive: {
+      type: GraphQLBoolean,
+      resolve: ({ active }) => active,
+    },
     isAvailable: {
       type: GraphQLBoolean,
       resolve: ({ available }) => available,


### PR DESCRIPTION
Part of https://artsyproduct.atlassian.net/browse/EMI-1924

Return isActive so clients can easily know if an offer is active or not and can render banners or messaging accordingly.
Basically reverting this revert https://github.com/artsy/metaphysics/pull/5586/commits/7aff9df4157c4ed48d1351261fce67f17c654748