### PR TITLE
chore: set timestamp of collector profile update prompt

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4286,6 +4286,14 @@ type CollectorProfileType implements Node {
   isEmailConfirmed: Boolean
   isIdentityVerified: Boolean
   isProfileComplete: Boolean
+  lastUpdatePromptAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See
+    # http://www.iana.org/time-zones,
+    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
   location: MyLocation
   loyaltyApplicantAt(
     format: String
@@ -11529,6 +11537,14 @@ type InquirerCollectorProfile {
   isEmailConfirmed: Boolean
   isIdentityVerified: Boolean
   isProfileComplete: Boolean
+  lastUpdatePromptAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See
+    # http://www.iana.org/time-zones,
+    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
   location: MyLocation
   loyaltyApplicantAt(
     format: String
@@ -19372,6 +19388,9 @@ input UpdateCollectorProfileInput {
   loyaltyApplicant: Boolean
   professionalBuyer: Boolean
 
+  # Since we don't want to ask a collector to update their profile too often, set this to record they've been prompted
+  promptedForUpdate: Boolean
+
   # Free-form text of purchases the collector has indicated.
   selfReportedPurchases: String
 }
@@ -19432,6 +19451,14 @@ type UpdateCollectorProfilePayload {
   isEmailConfirmed: Boolean
   isIdentityVerified: Boolean
   isProfileComplete: Boolean
+  lastUpdatePromptAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See
+    # http://www.iana.org/time-zones,
+    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
   location: MyLocation
   loyaltyApplicantAt(
     format: String

--- a/src/schema/v2/CollectorProfile/collectorProfile.ts
+++ b/src/schema/v2/CollectorProfile/collectorProfile.ts
@@ -219,6 +219,9 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
       !!profession &&
       !!other_relevant_positions,
   },
+  lastUpdatePromptAt: dateFormatter(
+    ({ last_update_prompt_at }) => last_update_prompt_at
+  ),
   summaryParagraph: {
     type: GraphQLString,
     description: "An artwork-specific paragraph describing the collector.",

--- a/src/schema/v2/me/__tests__/update_collector_profile.test.js
+++ b/src/schema/v2/me/__tests__/update_collector_profile.test.js
@@ -5,7 +5,7 @@ describe("UpdateCollectorProfile", () => {
   it("calls the expected loader with correctly formatted params", async () => {
     const mutation = `
       mutation {
-        updateCollectorProfile(input: { professionalBuyer: true, loyaltyApplicant: true, selfReportedPurchases: "trust me i buy art", intents: [BUY_ART_AND_DESIGN], institutionalAffiliations: "example", companyName: "Cool Art Stuff", companyWebsite: "https://artsy.net" }) {
+        updateCollectorProfile(input: { professionalBuyer: true, loyaltyApplicant: true, selfReportedPurchases: "trust me i buy art", intents: [BUY_ART_AND_DESIGN], institutionalAffiliations: "example", companyName: "Cool Art Stuff", companyWebsite: "https://artsy.net", promptedForUpdate: true }) {
           internalID
           name
           email
@@ -14,6 +14,7 @@ describe("UpdateCollectorProfile", () => {
           companyName
           companyWebsite
           professionalBuyerAt
+          lastUpdatePromptAt
         }
       }
     `
@@ -28,6 +29,7 @@ describe("UpdateCollectorProfile", () => {
         email: "percy@cat.com",
         self_reported_purchases: "treats",
         intents: ["buy art & design"],
+        last_update_prompt_at: "2022-08-15T11:14:55+00:00",
       })
     )
 
@@ -44,6 +46,7 @@ describe("UpdateCollectorProfile", () => {
       email: "percy@cat.com",
       selfReportedPurchases: "treats",
       intents: ["buy art & design"],
+      lastUpdatePromptAt: "2022-08-15T11:14:55+00:00",
     }
 
     expect.assertions(2)
@@ -63,6 +66,7 @@ describe("UpdateCollectorProfile", () => {
       institutional_affiliations: "example",
       company_name: "Cool Art Stuff",
       company_website: "https://artsy.net",
+      prompted_for_update: true,
     })
   })
 

--- a/src/schema/v2/me/update_collector_profile.ts
+++ b/src/schema/v2/me/update_collector_profile.ts
@@ -27,6 +27,11 @@ export default mutationWithClientMutationId<any, any, ResolverContext>({
     intents: { type: new GraphQLList(IntentsType) },
     loyaltyApplicant: { type: GraphQLBoolean },
     professionalBuyer: { type: GraphQLBoolean },
+    promptedForUpdate: {
+      type: GraphQLBoolean,
+      description:
+        "Since we don't want to ask a collector to update their profile too often, set this to record they've been prompted",
+    },
     selfReportedPurchases: {
       description: "Free-form text of purchases the collector has indicated.",
       type: GraphQLString,


### PR DESCRIPTION
Companion to https://github.com/artsy/gravity/pull/17839 , allows timestamp to be set via mutation and also adds it to schema.