### PR TITLE
feat: return list of user submissions

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2804,6 +2804,26 @@ type ArtworkConsignmentSubmission {
   stateLabel: String
 }
 
+# A connection to a list of items.
+type ArtworkConsignmentSubmissionConnection {
+  # A list of edges.
+  edges: [ArtworkConsignmentSubmissionEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type ArtworkConsignmentSubmissionEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: ArtworkConsignmentSubmission
+}
+
 enum ArtworkConsignmentSubmissionState {
   APPROVED
   CLOSED
@@ -12796,6 +12816,21 @@ type Me implements Node {
     first: Int
     last: Int
   ): ArtworkConnection
+
+  # A list of the current user’s submissions
+  submissionsConnection(
+    after: String
+    before: String
+
+    #
+    # If true, only return submissions that are complete (approved, rejected, or closed).
+    # if false, only return submissions that are not complete (draft).
+    # If not provided/undefined, return all submissions.
+    #
+    complete: Boolean
+    first: Int
+    last: Int
+  ): ArtworkConsignmentSubmissionConnection
   type: String
 
   # The count of conversations with unread messages.

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12823,7 +12823,7 @@ type Me implements Node {
     before: String
     first: Int
     last: Int
-    state: [ArtworkConsignmentSubmissionState]
+    states: [ArtworkConsignmentSubmissionState]
   ): ArtworkConsignmentSubmissionConnection
   type: String
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12823,7 +12823,7 @@ type Me implements Node {
     before: String
     first: Int
     last: Int
-    state: ArtworkConsignmentSubmissionState
+    state: [ArtworkConsignmentSubmissionState]
   ): ArtworkConsignmentSubmissionConnection
   type: String
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12821,15 +12821,9 @@ type Me implements Node {
   submissionsConnection(
     after: String
     before: String
-
-    #
-    # If true, only return submissions that are complete (approved, rejected, or closed).
-    # if false, only return submissions that are not complete (draft).
-    # If not provided/undefined, return all submissions.
-    #
-    complete: Boolean
     first: Int
     last: Int
+    state: ArtworkConsignmentSubmissionState
   ): ArtworkConsignmentSubmissionConnection
   type: String
 

--- a/src/lib/loaders/loaders_with_authentication/convection.ts
+++ b/src/lib/loaders/loaders_with_authentication/convection.ts
@@ -88,7 +88,7 @@ export default (accessToken, opts) => {
       {},
       { method: "POST" }
     ),
-    submissionsLoader: convectionLoader(`submissions`),
+    submissionsLoader: convectionLoader(`submissions`, {}, { headers: true }),
     submissionUpdateLoader: convectionLoader(
       (id) => `submissions/${id}`,
       {},

--- a/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
+++ b/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
@@ -8,7 +8,7 @@ import {
 import { ResolverContext } from "types/graphql"
 
 // Based directly on Convection Submission#state: https://github.com/artsy/convection/blob/main/app/models/submission.rb
-const ArtworkConsignmentSubmissionStateType = new GraphQLEnumType({
+export const ArtworkConsignmentSubmissionStateType = new GraphQLEnumType({
   name: "ArtworkConsignmentSubmissionState",
   values: {
     DRAFT: { value: "draft" },

--- a/src/schema/v2/me/__tests__/submissionsConnection.test.ts
+++ b/src/schema/v2/me/__tests__/submissionsConnection.test.ts
@@ -59,7 +59,7 @@ describe("submissionsConnection", () => {
     const query = gql`
       {
         me {
-          submissionsConnection(first: 10, state: DRAFT) {
+          submissionsConnection(first: 10, state: [DRAFT]) {
             totalCount
             edges {
               node {
@@ -90,7 +90,7 @@ describe("submissionsConnection", () => {
     expect(submissionsLoader).toHaveBeenCalledWith({
       offset: 0,
       size: 10,
-      state: "draft",
+      state: ["draft"],
       total_count: true,
     })
     expect(submissionsConnection).toEqual({

--- a/src/schema/v2/me/__tests__/submissionsConnection.test.ts
+++ b/src/schema/v2/me/__tests__/submissionsConnection.test.ts
@@ -59,7 +59,7 @@ describe("submissionsConnection", () => {
     const query = gql`
       {
         me {
-          submissionsConnection(first: 10, state: [DRAFT]) {
+          submissionsConnection(first: 10, states: [DRAFT]) {
             totalCount
             edges {
               node {

--- a/src/schema/v2/me/__tests__/submissionsConnection.test.ts
+++ b/src/schema/v2/me/__tests__/submissionsConnection.test.ts
@@ -1,0 +1,333 @@
+/* eslint-disable promise/always-return */
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("submissionsConnection", () => {
+  it("returns list of submissions", async () => {
+    const query = gql`
+      {
+        me {
+          submissionsConnection(first: 10) {
+            totalCount
+            edges {
+              node {
+                state
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const submissionsLoader = jest.fn(async () => {
+      return {
+        headers: { "x-total-count": "3" },
+        body: [
+          mockDraftSubmission,
+          mockRejectedSubmission,
+          mockApprovedSubmission,
+        ],
+      }
+    })
+
+    const context: any = {
+      meLoader: () => Promise.resolve({}),
+      submissionsLoader: submissionsLoader,
+    }
+
+    const {
+      me: { submissionsConnection },
+    } = await runAuthenticatedQuery(query, context)
+
+    expect(submissionsLoader).toHaveBeenCalledWith({
+      offset: 0,
+      size: 10,
+      state: undefined,
+      total_count: true,
+    })
+    expect(submissionsConnection).toEqual({
+      edges: [
+        { node: { state: "DRAFT" } },
+        { node: { state: "REJECTED" } },
+        { node: { state: "APPROVED" } },
+      ],
+      totalCount: 3,
+    })
+  })
+
+  it("filters submissions by state", async () => {
+    const query = gql`
+      {
+        me {
+          submissionsConnection(first: 10, state: DRAFT) {
+            totalCount
+            edges {
+              node {
+                state
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const submissionsLoader = jest.fn(async () => {
+      return {
+        headers: { "x-total-count": "1" },
+        body: [mockDraftSubmission],
+      }
+    })
+
+    const context: any = {
+      meLoader: () => Promise.resolve({}),
+      submissionsLoader: submissionsLoader,
+    }
+
+    const {
+      me: { submissionsConnection },
+    } = await runAuthenticatedQuery(query, context)
+
+    expect(submissionsLoader).toHaveBeenCalledWith({
+      offset: 0,
+      size: 10,
+      state: "draft",
+      total_count: true,
+    })
+    expect(submissionsConnection).toEqual({
+      edges: [{ node: { state: "DRAFT" } }],
+      totalCount: 1,
+    })
+  })
+})
+
+const mockDraftSubmission = {
+  id: 225966,
+  ext_user_id: null,
+  qualified: null,
+  artist_id: "",
+  title: "",
+  medium: "",
+  year: "",
+  category: null,
+  height: "",
+  width: "",
+  depth: "",
+  dimensions_metric: "in",
+  signature: null,
+  authenticity_certificate: null,
+  provenance: "",
+  location_city: "",
+  location_state: "",
+  location_country: "",
+  deadline_to_sell: null,
+  additional_info: null,
+  created_at: "2024-03-01T11:28:04.815Z",
+  updated_at: "2024-03-01T11:48:00.968Z",
+  edition: null,
+  state: "draft",
+  receipt_sent_at: null,
+  edition_number: "",
+  edition_size: "",
+  reminders_sent_count: 0,
+  admin_receipt_sent_at: null,
+  approved_by: null,
+  approved_at: null,
+  rejected_by: null,
+  rejected_at: null,
+  primary_image_id: null,
+  consigned_partner_submission_id: null,
+  user_email: "email@gmail.com",
+  offers_count: 0,
+  user_id: 46583,
+  minimum_price_cents: null,
+  currency: "USD",
+  user_agent: "Artsy-Mobile ios Artsy-Mobile/8.34.0 Eigen/2022.05.11.13/8.34.0",
+  deleted_at: null,
+  artist_score: 0,
+  auction_score: 0,
+  assigned_to: null,
+  published_at: null,
+  source_artwork_id: null,
+  utm_source: "",
+  utm_medium: "",
+  utm_term: "",
+  attribution_class: null,
+  publisher: null,
+  artist_proofs: null,
+  literature: null,
+  exhibition: null,
+  condition_report: null,
+  signature_detail: null,
+  coa_by_authenticating_body: null,
+  coa_by_gallery: null,
+  rejection_reason: null,
+  cataloguer: null,
+  user_name: "John Does ",
+  user_phone: "",
+  session_id: null,
+  my_collection_artwork_id: null,
+  admin_id: null,
+  uuid: "safe-049d-4e0c-8a98-7475ea9ca7ee",
+  source: "app_inbound",
+  location_postal_code: null,
+  location_country_code: "",
+  listed_artwork_ids: [],
+  minimum_price_dollars: null,
+  sale_state: null,
+  consignment_state: null,
+}
+
+const mockRejectedSubmission = {
+  id: 157125,
+  ext_user_id: null,
+  qualified: null,
+  artist_id: "5c341559fc5469445dbd236b",
+  title: "sorry, internal test",
+  medium: "Oil on canvas",
+  year: "2021",
+  category: "Painting",
+  height: "10",
+  width: "10",
+  depth: "2",
+  dimensions_metric: "in",
+  signature: null,
+  authenticity_certificate: null,
+  provenance: "sorry, internal test",
+  location_city: "Berlin",
+  location_state: "Berlin",
+  location_country: "Germany",
+  deadline_to_sell: null,
+  additional_info: null,
+  created_at: "2023-07-07T16:54:31.059Z",
+  updated_at: "2023-07-07T17:20:08.255Z",
+  edition: null,
+  state: "rejected",
+  receipt_sent_at: "2023-07-07T16:55:17.858Z",
+  edition_number: "",
+  edition_size: "",
+  reminders_sent_count: 0,
+  admin_receipt_sent_at: "2023-07-07T16:55:17.842Z",
+  approved_by: null,
+  approved_at: null,
+  rejected_by: "5ed0fd7e2fbdfe0012e695c2",
+  rejected_at: "2023-07-07T17:20:08.255Z",
+  primary_image_id: null,
+  consigned_partner_submission_id: null,
+  user_email: "email@gmail.com",
+  offers_count: 0,
+  user_id: 46583,
+  minimum_price_cents: null,
+  currency: "USD",
+  user_agent:
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36 Artsy-Web Force",
+  deleted_at: null,
+  artist_score: 0.1533636414,
+  auction_score: 0,
+  assigned_to: null,
+  published_at: null,
+  source_artwork_id: null,
+  utm_source: null,
+  utm_medium: null,
+  utm_term: null,
+  attribution_class: "unique",
+  publisher: null,
+  artist_proofs: null,
+  literature: null,
+  exhibition: null,
+  condition_report: null,
+  signature_detail: null,
+  coa_by_authenticating_body: null,
+  coa_by_gallery: null,
+  rejection_reason: "Other",
+  cataloguer: null,
+  user_name: "John Does",
+  user_phone: "+49 176724582355",
+  session_id: null,
+  my_collection_artwork_id: "64a8432a117d26000d355045",
+  admin_id: null,
+  uuid: "safe-9d6f-40a3-a47b-a93d027eef2b",
+  source: "my_collection",
+  location_postal_code: null,
+  location_country_code: "DE",
+  listed_artwork_ids: [],
+  minimum_price_dollars: null,
+  sale_state: null,
+  consignment_state: null,
+}
+
+const mockApprovedSubmission = {
+  id: 96106,
+  ext_user_id: null,
+  qualified: null,
+  artist_id: "4d8b92b34eb68a1b2c0003f4",
+  title: "Internal test",
+  medium: "Materials",
+  year: "2000",
+  category: null,
+  height: "2",
+  width: "10",
+  depth: "110",
+  dimensions_metric: "in",
+  signature: null,
+  authenticity_certificate: null,
+  provenance: "From a friend",
+  location_city: "Berlin",
+  location_state: "Berlin",
+  location_country: "Germany",
+  deadline_to_sell: null,
+  additional_info: null,
+  created_at: "2022-10-06T12:33:58.638Z",
+  updated_at: "2022-10-06T12:37:57.435Z",
+  edition: null,
+  state: "approved",
+  receipt_sent_at: "2022-10-06T12:34:18.886Z",
+  edition_number: "",
+  edition_size: "",
+  reminders_sent_count: 0,
+  admin_receipt_sent_at: "2022-10-06T12:34:18.874Z",
+  approved_by: null,
+  approved_at: null,
+  rejected_by: "5ed0fd7e2fbdfe0012e695c2",
+  rejected_at: "2022-10-06T12:37:57.434Z",
+  primary_image_id: null,
+  consigned_partner_submission_id: null,
+  user_email: "email@gmail.com",
+  offers_count: 0,
+  user_id: 46583,
+  minimum_price_cents: null,
+  currency: "USD",
+  user_agent: "unknown Artsy-Mobile/8.1.3 Eigen/2022.10.05.06/8.1.3",
+  deleted_at: null,
+  artist_score: 0.3963036854,
+  auction_score: 0.30094543625,
+  assigned_to: null,
+  published_at: null,
+  source_artwork_id: null,
+  utm_source: "",
+  utm_medium: "",
+  utm_term: "",
+  attribution_class: "unique",
+  publisher: null,
+  artist_proofs: null,
+  literature: null,
+  exhibition: null,
+  condition_report: null,
+  signature_detail: null,
+  coa_by_authenticating_body: null,
+  coa_by_gallery: null,
+  rejection_reason: "Fake",
+  cataloguer: null,
+  user_name: "John Does ",
+  user_phone: "+49 17 6724582355",
+  session_id: null,
+  my_collection_artwork_id: "633ecb4a693f7e000b701ea1",
+  admin_id: null,
+  uuid: "safe-be97-48a9-9d55-87c4d40dac42",
+  source: "app_inbound",
+  location_postal_code: "10233",
+  location_country_code: "DE",
+  listed_artwork_ids: [],
+  minimum_price_dollars: null,
+  sale_state: null,
+  consignment_state: null,
+}

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -92,6 +92,7 @@ import {
   PartnerOfferToCollectorSortsType,
 } from "../partnerOfferToCollector"
 import { PreviewSavedSearchAttributesType } from "../previewSavedSearch"
+import { submissionsConnection } from "./submissionsConnection"
 
 /**
  * @deprecated: Please use the CollectorProfile type instead of adding fields to me directly.
@@ -634,6 +635,7 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
         return !!share_follows
       },
     },
+    submissionsConnection: submissionsConnection,
     // genomic recommendation
     recommendedArtworks: {
       type: artworkConnection.connectionType,

--- a/src/schema/v2/me/submissionsConnection.ts
+++ b/src/schema/v2/me/submissionsConnection.ts
@@ -1,0 +1,67 @@
+import { GraphQLBoolean, GraphQLFieldConfig } from "graphql"
+import { getPagingParameters, pageable } from "relay-cursor-paging"
+import { ResolverContext } from "types/graphql"
+import ArtworkConsignmentSubmissionType from "../artwork/artworkConsignmentSubmissionType"
+import { connectionWithCursorInfo } from "../fields/pagination"
+import { connectionFromArraySlice } from "graphql-relay"
+
+export const submissionsConnectionType = connectionWithCursorInfo({
+  nodeType: ArtworkConsignmentSubmissionType,
+}).connectionType
+
+export const submissionsConnection: GraphQLFieldConfig<
+  {
+    id: string
+  },
+  ResolverContext
+> = {
+  type: submissionsConnectionType,
+  args: pageable({
+    complete: {
+      description: `
+If true, only return submissions that are complete (approved, rejected, or closed).
+if false, only return submissions that are not complete (draft).
+If not provided/undefined, return all submissions.
+      `,
+      type: GraphQLBoolean,
+      defaultValue: undefined,
+    },
+  }),
+  description: "A list of the current user’s submissions",
+  resolve: async ({ id: userID }, options, { submissionsLoader }) => {
+    if (!userID || !submissionsLoader) {
+      throw new Error("You need to be signed in to query for submission")
+    }
+
+    const { limit: size, offset } = getPagingParameters(options)
+
+    const convectionArgs = {
+      size,
+      offset,
+      total_count: true,
+      completed: options.complete,
+    }
+
+    try {
+      const { body: submissions, headers } = await submissionsLoader(
+        convectionArgs
+      )
+
+      const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+      return {
+        totalCount,
+        ...connectionFromArraySlice(submissions, options, {
+          arrayLength: totalCount,
+          sliceStart: offset,
+        }),
+      }
+      // return submissions
+    } catch (error) {
+      console.error(
+        `[metaphysics @ submissionsConnection] ${JSON.stringify(error)}`
+      )
+      return null
+    }
+  },
+}

--- a/src/schema/v2/me/submissionsConnection.ts
+++ b/src/schema/v2/me/submissionsConnection.ts
@@ -19,7 +19,7 @@ export const submissionsConnection: GraphQLFieldConfig<
 > = {
   type: submissionsConnectionType,
   args: pageable({
-    state: {
+    states: {
       type: new GraphQLList(ArtworkConsignmentSubmissionStateType),
     },
   }),
@@ -35,7 +35,7 @@ export const submissionsConnection: GraphQLFieldConfig<
       size,
       offset,
       total_count: true,
-      state: options.state,
+      state: options.states,
     }
 
     try {

--- a/src/schema/v2/me/submissionsConnection.ts
+++ b/src/schema/v2/me/submissionsConnection.ts
@@ -24,8 +24,8 @@ export const submissionsConnection: GraphQLFieldConfig<
     },
   }),
   description: "A list of the current user’s submissions",
-  resolve: async ({ id: userID }, options, { submissionsLoader }) => {
-    if (!userID || !submissionsLoader) {
+  resolve: async (_, options, { submissionsLoader }) => {
+    if (!submissionsLoader) {
       throw new Error("You need to be signed in to query for submission")
     }
 

--- a/src/schema/v2/me/submissionsConnection.ts
+++ b/src/schema/v2/me/submissionsConnection.ts
@@ -1,4 +1,4 @@
-import { GraphQLFieldConfig } from "graphql"
+import { GraphQLFieldConfig, GraphQLList } from "graphql"
 import { connectionFromArraySlice } from "graphql-relay"
 import { getPagingParameters, pageable } from "relay-cursor-paging"
 import { ResolverContext } from "types/graphql"
@@ -20,7 +20,7 @@ export const submissionsConnection: GraphQLFieldConfig<
   type: submissionsConnectionType,
   args: pageable({
     state: {
-      type: ArtworkConsignmentSubmissionStateType,
+      type: new GraphQLList(ArtworkConsignmentSubmissionStateType),
     },
   }),
   description: "A list of the current user’s submissions",

--- a/src/schema/v2/me/submissionsConnection.ts
+++ b/src/schema/v2/me/submissionsConnection.ts
@@ -1,9 +1,11 @@
-import { GraphQLBoolean, GraphQLFieldConfig } from "graphql"
+import { GraphQLFieldConfig } from "graphql"
+import { connectionFromArraySlice } from "graphql-relay"
 import { getPagingParameters, pageable } from "relay-cursor-paging"
 import { ResolverContext } from "types/graphql"
-import ArtworkConsignmentSubmissionType from "../artwork/artworkConsignmentSubmissionType"
+import ArtworkConsignmentSubmissionType, {
+  ArtworkConsignmentSubmissionStateType,
+} from "../artwork/artworkConsignmentSubmissionType"
 import { connectionWithCursorInfo } from "../fields/pagination"
-import { connectionFromArraySlice } from "graphql-relay"
 
 export const submissionsConnectionType = connectionWithCursorInfo({
   nodeType: ArtworkConsignmentSubmissionType,
@@ -17,14 +19,8 @@ export const submissionsConnection: GraphQLFieldConfig<
 > = {
   type: submissionsConnectionType,
   args: pageable({
-    complete: {
-      description: `
-If true, only return submissions that are complete (approved, rejected, or closed).
-if false, only return submissions that are not complete (draft).
-If not provided/undefined, return all submissions.
-      `,
-      type: GraphQLBoolean,
-      defaultValue: undefined,
+    state: {
+      type: ArtworkConsignmentSubmissionStateType,
     },
   }),
   description: "A list of the current user’s submissions",
@@ -39,7 +35,7 @@ If not provided/undefined, return all submissions.
       size,
       offset,
       total_count: true,
-      completed: options.complete,
+      state: options.state,
     }
 
     try {


### PR DESCRIPTION
[SPIKE]

This PR adds a new connection to the `Me` interface that returns a list of submitted artworks by a certain user. I added only one argument currently to filter through the state of the submissions.


https://github.com/artsy/metaphysics/assets/11945712/3340c2fd-f8ef-4738-907a-59696487303e

