### PR TITLE
feat: stitch userPhoneNumber to ConsignmentSubmission

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7029,6 +7029,7 @@ type ConsignmentSubmission {
   userId: String!
   userName: String
   userPhone: String
+  userPhoneNumber: PhoneNumberType
   utmMedium: String
   utmSource: String
   utmTerm: String

--- a/src/lib/stitching/convection/__tests__/stitching.test.ts
+++ b/src/lib/stitching/convection/__tests__/stitching.test.ts
@@ -127,6 +127,22 @@ it("resolves the myCollectionArtwork field on Consignment Submission", async () 
   )
 })
 
+it("resolves userPhoneNumber field on Consignment Submission", async () => {
+  const { resolvers } = await getConvectionStitchedSchema()
+  const { userPhoneNumber } = resolvers.ConsignmentSubmission
+  const info = { mergeInfo: { delegateToSchema: jest.fn() } }
+
+  userPhoneNumber.resolve({ userPhone: "1234567890" }, {}, {}, info)
+
+  expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith(
+    expect.objectContaining({
+      args: { phoneNumber: "1234567890" },
+      operation: "query",
+      fieldName: "phoneNumber",
+    })
+  )
+})
+
 it("resolves null for the myCollectionArtwork field on Consignment Submission if myCollectionArtworkID is null", async () => {
   const { resolvers } = await getConvectionStitchedSchema()
   const { myCollectionArtwork } = resolvers.ConsignmentSubmission

--- a/src/lib/stitching/convection/v2/stitching.ts
+++ b/src/lib/stitching/convection/v2/stitching.ts
@@ -12,6 +12,7 @@ export const consignmentStitchingEnvironment = (
     extend type ConsignmentSubmission {
       artist: Artist
       myCollectionArtwork: Artwork
+      userPhoneNumber: PhoneNumberType
     }
 
     extend type ConsignmentOffer {
@@ -62,6 +63,27 @@ export const consignmentStitchingEnvironment = (
             fieldName: "artwork",
             args: {
               id,
+            },
+            context,
+            info,
+            transforms: convectionSchema.transforms,
+          })
+        },
+      },
+      userPhoneNumber: {
+        fragment: gql`
+          fragment ConsignmentSubmissionUserPhoneNumber on ConsignmentSubmission {
+            userPhone
+          }
+        `,
+        resolve: (parent, _args, context, info) => {
+          const phoneNumber = parent.userPhone
+          return info.mergeInfo.delegateToSchema({
+            schema: localSchema,
+            operation: "query",
+            fieldName: "phoneNumber",
+            args: {
+              phoneNumber: phoneNumber || "",
             },
             context,
             info,


### PR DESCRIPTION
This PR adds a new field to `ConsignmentSubmission`  called `userPhoneNumber` that returns a `PhoneNumberType` instead of a `string` to make using it easier in the frontend and avoid destructuring it in client apps.

<img width="1004" alt="343737844-349fb538-f22a-4c12-a806-49240617ec03" src="https://github.com/artsy/metaphysics/assets/11945712/ace3b0d2-e813-402b-a779-46d41efc7351">
