### PR TITLE
chore(AMBER-769): Remove sale message condition checks

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -887,23 +887,11 @@ describe("Artwork type", () => {
     it("returns the proper saleMessage for edition sets", () => {
       artwork.edition_sets = [
         {
-          availability: "on hold",
+          forsale: false,
           price: "$1,000",
+          sale_message: "Permanent collection",
         },
-        {
-          availability: "on loan",
-        },
-        {
-          availability: "permanent collection",
-        },
-        {
-          availabilitiy: "for sale",
-          price: "$1,000",
-        },
-        {
-          availabilitiy: "not for sale",
-        },
-        { forsale: true, sale_message: "Contact for price" },
+        { forsale: true, price: "$1,000" },
         { forsale: true, sale_message: "Inquire about availability" },
       ]
 
@@ -912,22 +900,10 @@ describe("Artwork type", () => {
           artwork: {
             editionSets: [
               {
-                saleMessage: "On hold",
-              },
-              {
-                saleMessage: "On loan",
-              },
-              {
                 saleMessage: "Permanent collection",
               },
               {
                 saleMessage: "$1,000",
-              },
-              {
-                saleMessage: "No longer available",
-              },
-              {
-                saleMessage: "Contact for price",
               },
               {
                 saleMessage: "Inquire about availability",
@@ -1089,92 +1065,6 @@ describe("Artwork type", () => {
         }
       }
     `
-
-    it("returns 'On hold' if work is on hold with no price", () => {
-      artwork.sale_message = "Not for sale"
-      artwork.price = null
-      artwork.availability = "on hold"
-
-      return runQuery(query, context).then((data) => {
-        expect(data).toEqual({
-          artwork: {
-            slug: "richard-prince-untitled-portrait",
-            saleMessage: "On hold",
-          },
-        })
-      })
-    })
-
-    it("returns '[Price], on hold' if work is on hold with a price", () => {
-      artwork.sale_message = "Not for sale"
-      artwork.price = "$420,000"
-      artwork.price_cents = [42000000]
-      artwork.price_currency = "USD"
-      artwork.availability = "on hold"
-
-      return runQuery(query, context).then((data) => {
-        expect(data).toEqual({
-          artwork: {
-            slug: "richard-prince-untitled-portrait",
-            saleMessage: "US$420,000, on hold",
-          },
-        })
-      })
-    })
-
-    it("returns 'Sold' if work is sold", () => {
-      artwork.sale_message = "$420,000 - Sold"
-
-      return runQuery(query, context).then((data) => {
-        expect(data).toEqual({
-          artwork: {
-            slug: "richard-prince-untitled-portrait",
-            saleMessage: "Sold",
-          },
-        })
-      })
-    })
-
-    it("returns null if work is not for sale", () => {
-      artwork.availability = "not for sale"
-
-      return runQuery(query, context).then((data) => {
-        expect(data).toEqual({
-          artwork: {
-            slug: "richard-prince-untitled-portrait",
-            saleMessage: null,
-          },
-        })
-      })
-    })
-
-    it("returns 'On loan' if work is on loan", () => {
-      artwork.sale_message = "Not for sale"
-      artwork.availability = "on loan"
-
-      return runQuery(query, context).then((data) => {
-        expect(data).toEqual({
-          artwork: {
-            slug: "richard-prince-untitled-portrait",
-            saleMessage: "On loan",
-          },
-        })
-      })
-    })
-
-    it("returns Permanent Collection if work is part of permanent collection", () => {
-      artwork.sale_message = "for sale"
-      artwork.availability = "permanent collection"
-
-      return runQuery(query, context).then((data) => {
-        expect(data).toEqual({
-          artwork: {
-            slug: "richard-prince-untitled-portrait",
-            saleMessage: "Permanent collection",
-          },
-        })
-      })
-    })
 
     it("returns the gravity sale_message if for sale but there is no price", () => {
       artwork.availability = "for sale"

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1528,47 +1528,21 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           price_cents,
           price_currency,
         }) => {
-          // Don't display anything if artwork is not for sale.
-          if (availability === "not for sale") {
-            return null
+          if (availability !== "for sale" || !price_cents) {
+            return sale_message
           }
 
-          // If permanent collection, on loan or sold, just return those, do not include price.
-          if (availability === "permanent collection") {
-            return "Permanent collection"
-          }
-          if (availability === "on loan") {
-            return "On loan"
-          }
-          if (sale_message && sale_message.indexOf("Sold") > -1) {
-            return "Sold"
-          }
+          const formattedSaleMessage =
+            price_cents.length === 1
+              ? priceDisplayText(price_cents[0], price_currency, "")
+              : priceRangeDisplayText(
+                  price_cents[0],
+                  price_cents[1],
+                  price_currency,
+                  ""
+                )
 
-          let formatted
-
-          if (price_cents) {
-            formatted =
-              price_cents.length === 1
-                ? priceDisplayText(price_cents[0], price_currency, "")
-                : priceRangeDisplayText(
-                    price_cents[0],
-                    price_cents[1],
-                    price_currency,
-                    ""
-                  )
-          } else {
-            formatted = sale_message
-          }
-
-          // If on hold, prepend the price (if there is one).
-          if (availability === "on hold") {
-            if (price_cents) {
-              return `${formatted}, on hold`
-            }
-            return "On hold"
-          }
-
-          return formatted
+          return formattedSaleMessage
         },
       },
       priceListedDisplay: {

--- a/src/schema/v2/edition_set.ts
+++ b/src/schema/v2/edition_set.ts
@@ -1,4 +1,4 @@
-import { isEmpty, includes } from "lodash"
+import { isEmpty } from "lodash"
 import { InternalIDFields } from "./object_identification"
 import Dimensions from "./dimensions"
 import {
@@ -9,7 +9,6 @@ import {
   GraphQLFieldConfig,
   GraphQLFloat,
 } from "graphql"
-import { capitalizeFirstCharacter } from "lib/helpers"
 import { Sellable } from "./sellable"
 import { ResolverContext } from "types/graphql"
 import { listPrice } from "./fields/listPrice"
@@ -26,13 +25,6 @@ export const EditionSetSorts = {
     },
   }),
 }
-
-const EditionSetAvailabilities = [
-  "sold",
-  "on hold",
-  "on loan",
-  "permanent collection",
-]
 
 export const EditionSetType = new GraphQLObjectType<any, ResolverContext>({
   name: "EditionSet",
@@ -99,22 +91,13 @@ export const EditionSetType = new GraphQLObjectType<any, ResolverContext>({
     },
     saleMessage: {
       type: GraphQLString,
-      resolve: ({ availability, price, forsale, sale_message }) => {
-        // If it's a supported availability, just return it (capitalized).
-        if (includes(EditionSetAvailabilities, availability)) {
-          return capitalizeFirstCharacter(availability)
-        }
-
-        // If there's a price string, just return it.
-        if (!isEmpty(price)) {
-          return price
-        }
-
-        if (forsale) {
+      resolve: ({ price, forsale, sale_message }) => {
+        if (!forsale || isEmpty(price)) {
           return sale_message
         }
 
-        return "No longer available"
+        // If there's a price string, just return it.
+        return price
       },
     },
     widthCm: {


### PR DESCRIPTION
[AMBER-769]

During the work done in https://github.com/artsy/gravity/pull/17851, we ensured sale message will return the correct value according to the artwork availability. Therefore, we no longer need to perform these checks in Metaphysics (we do not want to have different versions of the sale message depending on the spot it's used).

The only sale message logic that was not yet removed from MP is the one we use to build the price display text.
The reasoning is that there are many more inconsistencies on those and it should be a separate refactor.

----

## For more context on price display:
Even within Metaphysics, we have different formats used.
See, for example, the way we display prices depending on whether we're querying from artwork or edition sets:


### Querying from artwork:
- `US` prefix before the dollar sign
- No spaces around the hyphen
- Currency present on both values
<img width="628" alt="edition_set_1_edition_price_range" src="https://github.com/artsy/metaphysics/assets/8002618/1b785a78-1011-4fda-90ec-97bc816f7de7">


### Querying from edition sets:
- No `US` prefix before the dollar sign (which is confusing, if it's US dollars or AU dollars, the user can't tell the difference)
- Spaces around the hyphen
- Currency displayed only once (only on the lowest value of the range)
<img width="615" alt="edition_set_2_editions_price_range" src="https://github.com/artsy/metaphysics/assets/8002618/1d166b5a-9f98-47ed-a8c8-ca2e2883234a">

I rather move this discussion to [a separate ticket though](https://artsyproduct.atlassian.net/browse/AMBER-778) (there are probably more decisions to be made and more spots to be affected than the examples above).

@artsy/amber-devs 

[AMBER-769]: https://artsyproduct.atlassian.net/browse/AMBER-769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ