### PR TITLE
fix: static content returns hardcoded ID and slug

### DIFF
--- a/src/schema/v2/static_content.ts
+++ b/src/schema/v2/static_content.ts
@@ -26,7 +26,11 @@ const StaticContent: GraphQLFieldConfig<void, ResolverContext> = {
     },
   },
   resolve: (_root, { id }, { staticContentLoader }) => {
-    if (!id) return {}
+    if (!id)
+      return {
+        id: "static-content",
+        slug: "static-content",
+      }
 
     return staticContentLoader(id)
   },


### PR DESCRIPTION
Awhile ago I've added `specialistBios` section under `staticContent`: https://github.com/artsy/metaphysics/pull/5653. Before, `staticContent` was used to fetch `pages` from Gravity. User can specify ID or slug of a page to fetch it:

```graphql
query X {
  staticContent(id: "swa-listing-terms") {
    id
    slug
    name
    content
  }
}
```

ID field was required (otherwise how would it be possible to fetch a Page). In this PR ⬆️ I've made this field optional, because now we want to put all sorts of static (really static) content under `staticContent` scope. For specialist bios it looks like this:

```graphql
query X {
  staticContent {
    specialistBios {
      name
      firstName
      jobTitle
    }
  }
}
```

This query doesn't fail, but it fails when querying other top-level `staticContent` fields, such as `id` or `slug`:

```graphql
query X {
  staticContent {
    id
    slug

    specialistBios {
      name
    }
  }
}
```

Why would we query `id`? It seems like Relay clients add `id` to the query even when it's not specified. That's why we add hardcoded ID (and slug just in case).