### PR TITLE
feat: exposes me under notification

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4390,6 +4390,7 @@ type CollectorProfileTypeEdge {
 
 type CollectorProfileUpdatePromptNotificationItem {
   collectorProfile: CollectorProfileType!
+  me: Me!
 }
 
 type CollectorResume {

--- a/src/schema/v2/notifications/Item/CollectorProfileUpdatePromptNotificationItem.ts
+++ b/src/schema/v2/notifications/Item/CollectorProfileUpdatePromptNotificationItem.ts
@@ -1,5 +1,6 @@
 import { GraphQLNonNull, GraphQLObjectType } from "graphql"
 import { CollectorProfileType } from "schema/v2/CollectorProfile/collectorProfile"
+import { meType } from "schema/v2/me"
 import { ResolverContext } from "types/graphql"
 
 export const CollectorProfileUpdatePromptNotificationItemType = new GraphQLObjectType<
@@ -7,10 +8,16 @@ export const CollectorProfileUpdatePromptNotificationItemType = new GraphQLObjec
   ResolverContext
 >({
   name: "CollectorProfileUpdatePromptNotificationItem",
-  fields: {
+  fields: () => ({
     collectorProfile: {
-      type: GraphQLNonNull(CollectorProfileType),
+      type: new GraphQLNonNull(CollectorProfileType),
       resolve: ({ object }) => object,
     },
-  },
+    me: {
+      type: new GraphQLNonNull(meType),
+      resolve: (_source, _args, { meLoader }) => {
+        return meLoader?.()
+      },
+    },
+  }),
 })


### PR DESCRIPTION
Needs `me` in order to access the user interests to determine the state of the CTA