### PR TITLE
feat(onyx-1084): add artwork condition

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2407,6 +2407,7 @@ type Artwork implements Node & Searchable & Sellable {
     first: Int
     last: Int
   ): AuctionResultConnection
+  condition: ArtworkCondition
   conditionDescription: ArtworkInfoRow
 
   # Notes by a partner or MyCollection user on the artwork, can only be accessed by partner or the user that owns the artwork
@@ -2769,6 +2770,19 @@ enum ArtworkAttributionClassType {
   OPEN_EDITION
   UNIQUE
   UNKNOWN_EDITION
+}
+
+type ArtworkCondition {
+  description: String
+  displayText: String
+  value: String
+}
+
+enum ArtworkConditionEnumType {
+  EXCELLENT
+  FAIR
+  GOOD
+  VERY_GOOD
 }
 
 # A connection to a list of items.
@@ -13907,6 +13921,7 @@ input MyCollectionCreateArtworkInput {
 
   # The given location of the user as structured data
   collectorLocation: EditableLocation
+  condition: ArtworkConditionEnumType
   conditionDescription: String
   confidentialNotes: String
   costCurrencyCode: String
@@ -14008,6 +14023,7 @@ input MyCollectionUpdateArtworkInput {
 
   # The given location of the user as structured data
   collectorLocation: EditableLocation
+  condition: ArtworkConditionEnumType
   conditionDescription: String
   confidentialNotes: String
   costCurrencyCode: String

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -123,7 +123,7 @@ describe("Artwork type", () => {
       expect(data).toEqual({
         artwork: {
           condition: {
-            value: "very_good",
+            value: "VERY_GOOD",
             displayText: "Very good",
             description: "No visible damage",
           },

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -94,6 +94,44 @@ describe("Artwork type", () => {
     }
   })
 
+  describe("#condition", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          condition {
+            value
+            displayText
+            description
+          }
+        }
+      }
+    `
+
+    it("returns the artwork's condition", async () => {
+      artwork = {
+        ...artwork,
+        condition: "very_good",
+        condition_description: "no visible damage",
+      }
+
+      context = {
+        artworkLoader: () => Promise.resolve(artwork),
+      }
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          condition: {
+            value: "very_good",
+            displayText: "Very good",
+            description: "No visible damage",
+          },
+        },
+      })
+    })
+  })
+
   describe("#importSource", () => {
     const query = `
       {

--- a/src/schema/v2/artwork/artworkCondition.ts
+++ b/src/schema/v2/artwork/artworkCondition.ts
@@ -1,0 +1,56 @@
+import { GraphQLEnumType, GraphQLObjectType, GraphQLString } from "graphql"
+import { upperFirst } from "lodash"
+import { ResolverContext } from "types/graphql"
+
+export const ArtworkConditionType = new GraphQLObjectType<any, ResolverContext>(
+  {
+    name: "ArtworkCondition",
+    fields: () => {
+      return {
+        value: {
+          type: GraphQLString,
+          resolve: ({ condition }) => {
+            if (!condition) return
+
+            return condition.toUpperCase()
+          },
+        },
+        displayText: {
+          type: GraphQLString,
+          resolve: ({ condition }) => {
+            if (!condition) return
+
+            return upperFirst(condition.split("_").join(" "))
+          },
+        },
+        description: {
+          type: GraphQLString,
+          resolve: (artwork) => {
+            const { condition_description } = artwork
+            if (!condition_description) return
+
+            return upperFirst(condition_description)
+          },
+        },
+      }
+    },
+  }
+)
+
+export const ArtworkConditionEnum = new GraphQLEnumType({
+  name: "ArtworkConditionEnumType",
+  values: {
+    EXCELLENT: {
+      value: "excellent",
+    },
+    VERY_GOOD: {
+      value: "very_good",
+    },
+    GOOD: {
+      value: "good",
+    },
+    FAIR: {
+      value: "fair",
+    },
+  },
+})

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -96,6 +96,7 @@ import { PartnerOfferType } from "../partnerOffer"
 import currencyCodes from "lib/currency_codes.json"
 import { date } from "../fields/date"
 import { ArtworkVisibility } from "./artworkVisibility"
+import { ArtworkConditionType } from "./artworkCondition"
 
 const has_price_range = (price) => {
   return new RegExp(/-/).test(price)
@@ -1787,6 +1788,10 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             details: capitalizeFirstCharacter(detailsParts.join(", ")),
           }
         },
+      },
+      condition: {
+        type: ArtworkConditionType,
+        resolve: (artwork) => artwork,
       },
       conditionDescription: {
         type: ArtworkInfoRowType,

--- a/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionCreateArtworkMutation.test.ts
@@ -18,6 +18,7 @@ const artworkDetails = {
   price_paid_currency: "USD",
   artwork_location: "Berlin, Germany",
   collector_location: { country: "Germany", city: "Berlin" },
+  condition: "very_good",
   condition_description: "like a new!",
   attribution_class: "open edition",
   images: [
@@ -68,6 +69,7 @@ const computeMutationInput = ({
           category: "some strange category"
           coaByAuthenticatingBody: false
           coaByGallery: true
+          condition: VERY_GOOD
           conditionDescription: "like a new!"
           costCurrencyCode: "USD"
           costMinor: 200
@@ -111,6 +113,11 @@ const computeMutationInput = ({
               collectorLocation {
                 city
                 country
+              }
+              condition {
+                value
+                displayText
+                description
               }
               conditionDescription {
                 label
@@ -213,6 +220,11 @@ describe("myCollectionCreateArtworkMutation", () => {
               "city": "Berlin",
               "country": "Germany",
             },
+            "condition": Object {
+              "description": "Like a new!",
+              "displayText": "Very good",
+              "value": "VERY_GOOD",
+            },
             "conditionDescription": Object {
               "details": "Like a new!",
               "label": "Condition details",
@@ -291,6 +303,7 @@ describe("myCollectionCreateArtworkMutation", () => {
         coa_by_gallery: true,
         collection_id: "my-collection",
         collector_location: { city: "Berlin", country: "Germany" },
+        condition: "very_good",
         condition_description: "like a new!",
         confidential_notes: undefined,
         cost_currency_code: "USD",
@@ -346,6 +359,11 @@ describe("myCollectionCreateArtworkMutation", () => {
             "collectorLocation": Object {
               "city": "Berlin",
               "country": "Germany",
+            },
+            "condition": Object {
+              "description": "Like a new!",
+              "displayText": "Very good",
+              "value": "VERY_GOOD",
             },
             "conditionDescription": Object {
               "details": "Like a new!",

--- a/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
+++ b/src/schema/v2/me/__tests__/myCollectionUpdateArtworkMutation.test.ts
@@ -46,6 +46,7 @@ const defaultArtworkDetails = ({
   price_paid_currency: "USD",
   artwork_location: "Berlin, Germany",
   collector_location: { city: "Berlin", country: "Germany" },
+  condition: "very_good",
   condition_description: "like a new!",
   provenance: "Pat Hearn Gallery",
   title: "hey now",
@@ -103,6 +104,7 @@ const computeMutationInput = ({
           metric: "in"
           artworkLocation: "Berlin, Germany"
           collectorLocation: {country: "Germany", city: "Berlin"}
+          condition: VERY_GOOD
           conditionDescription: "like a new!"
           pricePaidCents: 10000
           pricePaidCurrency: "USD"
@@ -135,6 +137,11 @@ const computeMutationInput = ({
               collectorLocation {
                 city
                 country
+              }
+              condition {
+                value
+                displayText
+                description
               }
               conditionDescription {
                 label
@@ -248,6 +255,11 @@ describe("myCollectionUpdateArtworkMutation", () => {
               "city": "Berlin",
               "country": "Germany",
             },
+            "condition": Object {
+              "description": "Like a new!",
+              "displayText": "Very good",
+              "value": "VERY_GOOD",
+            },
             "conditionDescription": Object {
               "details": "Like a new!",
               "label": "Condition details",
@@ -319,6 +331,11 @@ describe("myCollectionUpdateArtworkMutation", () => {
             "collectorLocation": Object {
               "city": "Berlin",
               "country": "Germany",
+            },
+            "condition": Object {
+              "description": "Like a new!",
+              "displayText": "Very good",
+              "value": "VERY_GOOD",
             },
             "conditionDescription": Object {
               "details": "Like a new!",

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -20,6 +20,7 @@ import {
   ArtworkSignatureTypeEnum,
   transformSignatureFieldsToGravityFields,
 } from "../artwork/artworkSignatureTypes"
+import { ArtworkConditionEnum } from "../artwork/artworkCondition"
 
 export const externalUrlRegex = /https:\/\/(?<sourceBucket>.*).s3.amazonaws.com\/(?<sourceKey>.*)/
 
@@ -76,6 +77,9 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
     },
     coaByGallery: {
       type: GraphQLBoolean,
+    },
+    condition: {
+      type: ArtworkConditionEnum,
     },
     confidentialNotes: {
       type: GraphQLString,
@@ -193,6 +197,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
       coaByAuthenticatingBody,
       coaByGallery,
       collectorLocation,
+      condition,
       conditionDescription,
       confidentialNotes,
       costCurrencyCode,
@@ -260,6 +265,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
         coa_by_authenticating_body: coaByAuthenticatingBody,
         coa_by_gallery: coaByGallery,
         collection_id: "my-collection",
+        condition: condition,
         condition_description: conditionDescription,
         confidential_notes: confidentialNotes,
         cost_currency_code: costCurrencyCode,

--- a/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
@@ -20,6 +20,7 @@ import {
   ArtworkSignatureTypeEnum,
   transformSignatureFieldsToGravityFields,
 } from "../artwork/artworkSignatureTypes"
+import { ArtworkConditionEnum } from "../artwork/artworkCondition"
 
 interface MyCollectionArtworkUpdateMutationInput {
   additionalInformation?: string
@@ -29,6 +30,7 @@ interface MyCollectionArtworkUpdateMutationInput {
   category?: string
   coaByAuthenticatingBody?: boolean
   coaByGallery?: boolean
+  condition?: string
   conditionDescription?: string
   confidentialNotes?: string
   costCurrencyCode?: string
@@ -83,6 +85,9 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
     },
     coaByGallery: {
       type: GraphQLBoolean,
+    },
+    condition: {
+      type: ArtworkConditionEnum,
     },
     conditionDescription: {
       type: GraphQLString,
@@ -192,6 +197,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
       coaByAuthenticatingBody,
       coaByGallery,
       collectorLocation,
+      condition,
       conditionDescription,
       confidentialNotes,
       costCurrencyCode,
@@ -246,6 +252,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
         artists: artistIds,
         coa_by_authenticating_body: coaByAuthenticatingBody,
         coa_by_gallery: coaByGallery,
+        condition: condition,
         condition_description: conditionDescription,
         confidential_notes: confidentialNotes,
         cost_currency_code: costCurrencyCode,


### PR DESCRIPTION
Depends on https://github.com/artsy/gravity/pull/17872

We want to allow users to pick an artwork condition when submitting an artwork for purchase.

## Create MyC artwork

```graphql
mutation {
  myCollectionCreateArtwork(input: { artistIds: ["bea-nettles"], title: "Hello", condition: VERY_GOOD, conditionDescription: "no scratches!" }) {
    artworkOrError {
      ... on MyCollectionArtworkMutationSuccess {
        artwork {
          title
          
          condition {
            value
            displayText
            description
          }
        }
      }
    }
  }
}
```

Response:

```json
{
  "data": {
    "myCollectionCreateArtwork": {
      "artworkOrError": {
        "artwork": {
          "title": "Hello",
          "condition": {
            "value": "VERY_GOOD",
            "displayText": "Very good",
            "description": "No scratches!"
          }
        }
      }
    }
  }
}
```

## Update MyC artwork

```graphql
mutation {
  myCollectionUpdateArtwork(input: { artworkId: "668406f9b3e438648d4c4e82", condition: FAIR, conditionDescription: "a few scratches" }) {
    artworkOrError {
      ... on MyCollectionArtworkMutationSuccess {
        artwork {
          title
          internalID
          
          condition {
            value
            displayText
            description
          }
        }
      }
    }
  }
}
```

Response:

```json
{
  "data": {
    "myCollectionUpdateArtwork": {
      "artworkOrError": {
        "artwork": {
          "title": "Hello",
          "internalID": "668406f9b3e438648d4c4e82",
          "condition": {
            "value": "FAIR",
            "displayText": "Fair",
            "description": "A few scratches"
          }
        }
      }
    }
  },
```