### PR TITLE
chore: change type for swa specialist fields

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -18836,12 +18836,12 @@ enum sort {
 }
 
 type SpecialistBio {
-  bio: String
-  email: String
-  firstName: String
-  image: Image
-  jobTitle: String
-  name: String
+  bio: String!
+  email: String!
+  firstName: String!
+  image: Image!
+  jobTitle: String!
+  name: String!
 }
 
 type StartIdentityVerificationFailure {
@@ -18886,7 +18886,7 @@ type StaticContent {
   slug: ID!
 
   # A list of specialists
-  specialistBios: [SpecialistBio]
+  specialistBios: [SpecialistBio!]
 }
 
 enum SubGroupInputStatus {

--- a/src/schema/v2/specialistBios.ts
+++ b/src/schema/v2/specialistBios.ts
@@ -1,6 +1,7 @@
 import {
   GraphQLFieldConfig,
   GraphQLList,
+  GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
 } from "graphql"
@@ -21,13 +22,13 @@ const SpecialistBioType = new GraphQLObjectType<specialistBio, ResolverContext>(
   {
     name: "SpecialistBio",
     fields: {
-      bio: { type: GraphQLString },
-      email: { type: GraphQLString },
+      bio: { type: new GraphQLNonNull(GraphQLString) },
+      email: { type: new GraphQLNonNull(GraphQLString) },
       firstName: {
-        type: GraphQLString,
+        type: new GraphQLNonNull(GraphQLString),
       },
       image: {
-        type: ImageType,
+        type: new GraphQLNonNull(ImageType),
         resolve: ({ imageUrl }) => {
           if (!imageUrl) return null
 
@@ -36,14 +37,14 @@ const SpecialistBioType = new GraphQLObjectType<specialistBio, ResolverContext>(
           }
         },
       },
-      jobTitle: { type: GraphQLString },
-      name: { type: GraphQLString },
+      jobTitle: { type: new GraphQLNonNull(GraphQLString) },
+      name: { type: new GraphQLNonNull(GraphQLString) },
     },
   }
 )
 
 export const SpecialistBios: GraphQLFieldConfig<void, ResolverContext> = {
   description: "A list of specialists",
-  type: new GraphQLList(SpecialistBioType),
+  type: new GraphQLList(new GraphQLNonNull(SpecialistBioType)),
   resolve: () => specialistBiosData,
 }


### PR DESCRIPTION
Changing the types of fields from `TYPE` to `new GraphQLNonNull(TYPE)` to simplify implementation on the frontend.