### PR TITLE
feat(isProfileComplete): remove other_relevant_positions from isProfileComplete

### DIFF
--- a/src/schema/v2/CollectorProfile/collectorProfile.ts
+++ b/src/schema/v2/CollectorProfile/collectorProfile.ts
@@ -212,12 +212,8 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
   },
   isProfileComplete: {
     type: GraphQLBoolean,
-    resolve: ({ icon, name, location, profession, other_relevant_positions }) =>
-      !!icon &&
-      !!name &&
-      !!location?.display &&
-      !!profession &&
-      !!other_relevant_positions,
+    resolve: ({ icon, name, location, profession }) =>
+      !!icon && !!name && !!location?.display && !!profession,
   },
   summarySentence: {
     type: new GraphQLNonNull(GraphQLString),

--- a/src/schema/v2/me/__tests__/collector_profile.test.js
+++ b/src/schema/v2/me/__tests__/collector_profile.test.js
@@ -89,7 +89,6 @@ describe("Me", () => {
             display: "Berlin",
           },
           profession: "coder",
-          other_relevant_positions: "other typer",
         }
 
         const context = {
@@ -122,8 +121,6 @@ describe("Me", () => {
             display: "Berlin",
           },
           profession: "",
-          other_relevant_positions: "no one knows",
-          bio: "¯\\_(ツ)_//¯",
         }
 
         const context = {


### PR DESCRIPTION
Related to [DIA-565]

Removes the field `other_relevant_positions` from `isProfileComplete`. We no longer require this field as a necessary one for the completeness of the profile.