### PR TITLE
chore(AMBER-776): Omit sale mentions in case of VIP listing

### DIFF
--- a/src/schema/v2/artwork/__tests__/meta.test.ts
+++ b/src/schema/v2/artwork/__tests__/meta.test.ts
@@ -10,6 +10,7 @@ describe("Meta", () => {
     title: "P. 25-1975-H-8",
     date: "1975",
     forsale: true,
+    sale_message: "Price on request",
     dimensions: {
       in: "22 4/5 × 30 7/10 in",
       cm: "58 × 78 cm",
@@ -25,25 +26,44 @@ describe("Meta", () => {
     artworkLoader: () => Promise.resolve(artworkData),
   }
 
-  describe("#description", () => {
-    it("returns properly formatted string", async () => {
-      const query = `
-        {
-          artwork(id:"hans-hartung-p-25-1975-h-8") {
-            meta {
-              description
-            }
+  describe("title and description", () => {
+    const query = `
+      {
+        artwork(id:"hans-hartung-p-25-1975-h-8") {
+          meta {
+            title
+            description
           }
         }
-      `
+      }
+    `
+
+    it("includes mention to sale if availability and sale message allow it", async () => {
+      const data = await runQuery(query, context as any)
+
+      expect(data).toEqual({
+        artwork: {
+          meta: {
+            title:
+              "Hans Hartung | P. 25-1975-H-8 (1975) | Available for Sale | Artsy",
+            description:
+              "Available for sale from Galerie Michel Descours, Hans Hartung, P. 25-1975-H-8 (1975), Acrylic on baryte card, 58 × 78 cm",
+          },
+        },
+      })
+    })
+
+    it("does not include mentions to sale in case of 'Inquire about availability'", async () => {
+      artworkData.sale_message = "Inquire about availability"
 
       const data = await runQuery(query, context as any)
 
       expect(data).toEqual({
         artwork: {
           meta: {
+            title: "Hans Hartung | P. 25-1975-H-8 (1975) | Artsy",
             description:
-              "Available for sale from Galerie Michel Descours, Hans Hartung, P. 25-1975-H-8 (1975), Acrylic on baryte card, 58 × 78 cm",
+              "From Galerie Michel Descours, Hans Hartung, P. 25-1975-H-8 (1975), Acrylic on baryte card, 58 × 78 cm",
           },
         },
       })

--- a/src/schema/v2/artwork/meta.ts
+++ b/src/schema/v2/artwork/meta.ts
@@ -10,6 +10,9 @@ import {
 } from "graphql"
 import { ResolverContext } from "types/graphql"
 
+const isInquireAboutAvailability = (saleMessage) =>
+  saleMessage == "Inquire about availability"
+
 const titleWithDate = ({ title, date }) =>
   join(" ", [title, date ? `(${date})` : undefined])
 
@@ -17,14 +20,20 @@ export const artistNames = (artwork) =>
   artwork.cultural_maker || map(artwork.artists, "name").join(", ")
 
 const forSaleIndication = (artwork) =>
-  artwork.forsale ? "Available for Sale" : undefined
+  artwork.forsale && !isInquireAboutAvailability(artwork.sale_message)
+    ? "Available for Sale"
+    : undefined
 
 const dimensions = (artwork) => artwork.dimensions[artwork.metric]
 
-const partnerDescription = ({ partner, forsale }, expanded = true) => {
+const partnerDescription = (
+  { partner, forsale, sale_message },
+  expanded = true
+) => {
   const name = partner && partner.name
   if (isEmpty(name)) return undefined
-  return forsale && expanded
+
+  return forsale && expanded && !isInquireAboutAvailability(sale_message)
     ? `Available for sale from ${name}`
     : `From ${name}`
 }


### PR DESCRIPTION
[AMBER-776]

If an an artwork is listed as "Inquire about availability, it means the partner is choosing the new setting instead of the default one ("Price on request") for artworks with hidden price. In that case, we want the language to feel less commercial, therefore, the metadata shouldn't indicate any mentions to sales

cc @artsy/amber-devs 

[AMBER-776]: https://artsyproduct.atlassian.net/browse/AMBER-776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ