### PR TITLE
Chore: Keeps gravity.graphql up to latest schema

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12059,6 +12059,8 @@ type MarketingCollection {
   category: String!
   createdAt: ISO8601DateTime!
   credit: String
+
+  # HTML description, derived from the markdown description
   description: String
   descriptionMarkdown: String
   featuredArtistExclusionIds: [String!]!
@@ -13085,6 +13087,7 @@ union MoneyOrErrorUnion = Error
 
 type Mutation {
   acceptPartnerAgreement(
+    # Parameters for AcceptPartnerAgreement
     input: AcceptPartnerAgreementInput!
   ): AcceptPartnerAgreementPayload
   addAssetsToConsignmentSubmission(
@@ -13137,7 +13140,10 @@ type Mutation {
   bulkUpdatePartnerArtworks(
     input: BulkUpdatePartnerArtworksMutationInput!
   ): BulkUpdatePartnerArtworksMutationPayload
-  captureHold(input: CaptureHoldInput!): CaptureHoldPayload
+  captureHold(
+    # Parameters for CaptureHold
+    input: CaptureHoldInput!
+  ): CaptureHoldPayload
 
   # Creates a pending offer on an pending order.
   commerceAddInitialOfferToOrder(
@@ -13308,7 +13314,10 @@ type Mutation {
     # Parameters for UpdateImpulseConversationId
     input: CommerceUpdateImpulseConversationIdInput!
   ): CommerceUpdateImpulseConversationIdPayload
-  confirmPassword(input: ConfirmPasswordInput!): ConfirmPasswordPayload
+  confirmPassword(
+    # Parameters for ConfirmPassword
+    input: ConfirmPasswordInput!
+  ): ConfirmPasswordPayload
   convectionCreateConsignmentSubmission(
     # Parameters for CreateSubmissionMutation
     input: CreateSubmissionMutationInput!
@@ -13322,18 +13331,22 @@ type Mutation {
   # Create an alert
   createAlert(input: createAlertInput!): createAlertPayload
   createAndSendBackupSecondFactor(
+    # Parameters for CreateAndSendBackupSecondFactor
     input: CreateAndSendBackupSecondFactorInput!
   ): CreateAndSendBackupSecondFactorPayload
   createAppSecondFactor(
+    # Parameters for CreateAppSecondFactor
     input: CreateAppSecondFactorInput!
   ): CreateAppSecondFactorPayload
 
   # Create an artist
   createArtist(input: CreateArtistMutationInput!): CreateArtistMutationPayload
   createBackupSecondFactors(
+    # Parameters for CreateBackupSecondFactors
     input: CreateBackupSecondFactorsInput!
   ): CreateBackupSecondFactorsPayload
   createBankDebitSetup(
+    # Parameters for CreateBankDebitSetup
     input: CreateBankDebitSetupInput!
   ): CreateBankDebitSetupPayload
 
@@ -13395,7 +13408,10 @@ type Mutation {
   createIdentityVerificationOverride(
     input: CreateIdentityVerificationOverrideMutationInput!
   ): CreateIdentityVerificationOverrideMutationPayload
-  createImage(input: CreateImageInput!): CreateImagePayload
+  createImage(
+    # Parameters for CreateImage
+    input: CreateImageInput!
+  ): CreateImagePayload
   createInquiryOfferOrder(
     input: CommerceCreateInquiryOfferOrderWithArtworkInput!
   ): CommerceCreateInquiryOfferOrderWithArtworkPayload
@@ -13422,11 +13438,18 @@ type Mutation {
   createSaleAgreement(
     input: CreateSaleAgreementMutationInput!
   ): CreateSaleAgreementMutationPayload
-  createSavedSearch(input: CreateSavedSearchInput!): CreateSavedSearchPayload
+  createSavedSearch(
+    # Parameters for CreateSavedSearch
+    input: CreateSavedSearchInput!
+  ): CreateSavedSearchPayload
   createSmsSecondFactor(
+    # Parameters for CreateSmsSecondFactor
     input: CreateSmsSecondFactorInput!
   ): CreateSmsSecondFactorPayload
-  createUserAddress(input: CreateUserAddressInput!): CreateUserAddressPayload
+  createUserAddress(
+    # Parameters for CreateUserAddress
+    input: CreateUserAddressInput!
+  ): CreateUserAddressPayload
 
   # Create a admin note for the user
   createUserAdminNote(
@@ -13457,7 +13480,10 @@ type Mutation {
   createVerifiedRepresentative(
     input: CreateVerifiedRepresentativeInput!
   ): CreateVerifiedRepresentativePayload
-  createViewingRoom(input: CreateViewingRoomInput!): CreateViewingRoomPayload
+  createViewingRoom(
+    # Parameters for CreateViewingRoom
+    input: CreateViewingRoomInput!
+  ): CreateViewingRoomPayload
 
   # Deletes an alert
   deleteAlert(input: deleteAlertInput!): deleteAlertPayload
@@ -13523,7 +13549,10 @@ type Mutation {
 
   # Delete a User
   deleteUser(input: DeleteUserInput!): DeleteUserPayload
-  deleteUserAddress(input: DeleteUserAddressInput!): DeleteUserAddressPayload
+  deleteUserAddress(
+    # Parameters for DeleteUserAddress
+    input: DeleteUserAddressInput!
+  ): DeleteUserAddressPayload
 
   # delete an admin note for the user
   deleteUserAdminNote(
@@ -13554,18 +13583,29 @@ type Mutation {
   deleteVerifiedRepresentative(
     input: DeleteVerifiedRepresentativeMutationInput!
   ): DeleteVerifiedRepresentativeMutationPayload
-  deleteViewingRoom(input: DeleteViewingRoomInput!): DeleteViewingRoomPayload
+  deleteViewingRoom(
+    # Parameters for DeleteViewingRoom
+    input: DeleteViewingRoomInput!
+  ): DeleteViewingRoomPayload
   deliverSecondFactor(
+    # Parameters for DeliverSecondFactor
     input: DeliverSecondFactorInput!
   ): DeliverSecondFactorPayload
-  disableSavedSearch(input: DisableSavedSearchInput!): DisableSavedSearchPayload
+  disableSavedSearch(
+    # Parameters for DisableSavedSearch
+    input: DisableSavedSearchInput!
+  ): DisableSavedSearchPayload
   disableSecondFactor(
+    # Parameters for DisableSecondFactor
     input: DisableSecondFactorInput!
   ): DisableSecondFactorPayload
 
   # Add (or remove) an artwork to (from) a users dislikes.
   dislikeArtwork(input: DislikeArtworkInput!): DislikeArtworkPayload
-  enableSecondFactor(input: EnableSecondFactorInput!): EnableSecondFactorPayload
+  enableSecondFactor(
+    # Parameters for EnableSecondFactor
+    input: EnableSecondFactorInput!
+  ): EnableSecondFactorPayload
 
   # Mark sale as ended.
   endSale(input: EndSaleInput!): EndSalePayload
@@ -13581,7 +13621,10 @@ type Mutation {
 
   # Follow (or unfollow) a show
   followShow(input: FollowShowInput!): FollowShowPayload
-  holdInventory(input: HoldInventoryInput!): HoldInventoryPayload
+  holdInventory(
+    # Parameters for HoldInventory
+    input: HoldInventoryInput!
+  ): HoldInventoryPayload
 
   # Links a 3rd party account
   linkAuthentication(
@@ -13620,13 +13663,20 @@ type Mutation {
   myCollectionUpdateArtwork(
     input: MyCollectionUpdateArtworkInput!
   ): MyCollectionUpdateArtworkPayload
-  publishViewingRoom(input: PublishViewingRoomInput!): PublishViewingRoomPayload
-  recordArtworkView(input: RecordArtworkViewInput!): RecordArtworkViewPayload
+  publishViewingRoom(
+    # Parameters for PublishViewingRoom
+    input: PublishViewingRoomInput!
+  ): PublishViewingRoomPayload
+  recordArtworkView(
+    # Parameters for RecordArtworkView
+    input: RecordArtworkViewInput!
+  ): RecordArtworkViewPayload
   removeAssetFromConsignmentSubmission(
     # Parameters for RemoveAssetFromConsignmentSubmission
     input: RemoveAssetFromConsignmentSubmissionInput!
   ): RemoveAssetFromConsignmentSubmissionPayload
   requestConditionReport(
+    # Parameters for RequestConditionReport
     input: RequestConditionReportInput!
   ): RequestConditionReportPayload
 
@@ -13676,6 +13726,7 @@ type Mutation {
     input: CommerceSubmitOrderWithOfferInput!
   ): CommerceSubmitOrderWithOfferPayload
   transferMyCollection(
+    # Parameters for TransferMyCollection
     input: TransferMyCollectionInput!
   ): TransferMyCollectionPayload
 
@@ -13687,12 +13738,14 @@ type Mutation {
     input: UnlinkAuthenticationMutationInput!
   ): UnlinkAuthenticationMutationPayload
   unpublishViewingRoom(
+    # Parameters for UnpublishViewingRoom
     input: UnpublishViewingRoomInput!
   ): UnpublishViewingRoomPayload
 
   # Create an alert
   updateAlert(input: updateAlertInput!): updateAlertPayload
   updateAppSecondFactor(
+    # Parameters for UpdateAppSecondFactor
     input: UpdateAppSecondFactorInput!
   ): UpdateAppSecondFactorPayload
 
@@ -13794,15 +13847,23 @@ type Mutation {
   updateSaleAgreement(
     input: UpdateSaleAgreementMutationInput!
   ): UpdateSaleAgreementMutationPayload
-  updateSavedSearch(input: UpdateSavedSearchInput!): UpdateSavedSearchPayload
+  updateSavedSearch(
+    # Parameters for UpdateSavedSearch
+    input: UpdateSavedSearchInput!
+  ): UpdateSavedSearchPayload
   updateSmsSecondFactor(
+    # Parameters for UpdateSmsSecondFactor
     input: UpdateSmsSecondFactorInput!
   ): UpdateSmsSecondFactorPayload
 
   # Update the user
   updateUser(input: UpdateUserMutationInput!): UpdateUserMutationPayload
-  updateUserAddress(input: UpdateUserAddressInput!): UpdateUserAddressPayload
+  updateUserAddress(
+    # Parameters for UpdateUserAddress
+    input: UpdateUserAddressInput!
+  ): UpdateUserAddressPayload
   updateUserDefaultAddress(
+    # Parameters for UpdateUserDefaultAddress
     input: UpdateUserDefaultAddressInput!
   ): UpdateUserDefaultAddressPayload
 
@@ -13820,11 +13881,16 @@ type Mutation {
   updateUserSaleProfile(
     input: UpdateUserSaleProfileMutationInput!
   ): UpdateUserSaleProfileMutationPayload
-  updateViewingRoom(input: UpdateViewingRoomInput!): UpdateViewingRoomPayload
+  updateViewingRoom(
+    # Parameters for UpdateViewingRoom
+    input: UpdateViewingRoomInput!
+  ): UpdateViewingRoomPayload
   updateViewingRoomArtworks(
+    # Parameters for UpdateViewingRoomArtworks
     input: UpdateViewingRoomArtworksInput!
   ): UpdateViewingRoomArtworksPayload
   updateViewingRoomSubsections(
+    # Parameters for UpdateViewingRoomSubsections
     input: UpdateViewingRoomSubsectionsInput!
   ): UpdateViewingRoomSubsectionsPayload
 }
@@ -15112,17 +15178,6 @@ type PartnerInquiryRequest {
   internalID: ID!
   questions: [InquiryQuestion]
   shippingLocation: Location
-}
-
-# A location
-type PartnerLocation {
-  address: String
-  address2: String
-  city: String
-  country: String
-  id: ID!
-  postalCode: String
-  state: String
 }
 
 type PartnerMeta {

--- a/src/data/gravity.graphql
+++ b/src/data/gravity.graphql
@@ -247,11 +247,6 @@ type Artwork {
   id: ID!
 
   """
-  Artwork location
-  """
-  location: PartnerLocation
-
-  """
   Description of the work's medium
   """
   medium: String
@@ -1111,6 +1106,10 @@ type MarketingCollection {
   category: String!
   createdAt: ISO8601DateTime!
   credit: String
+
+  """
+  HTML description, derived from the markdown description
+  """
   description: String
   descriptionMarkdown: String
   featuredArtistExclusionIds: [String!]!
@@ -1235,81 +1234,215 @@ union MoneyOrErrorUnion = Error | Money
 
 type Mutation {
   acceptPartnerAgreement(
+    """
+    Parameters for AcceptPartnerAgreement
+    """
     input: AcceptPartnerAgreementInput!
   ): AcceptPartnerAgreementPayload
-  captureHold(input: CaptureHoldInput!): CaptureHoldPayload
-  confirmPassword(input: ConfirmPasswordInput!): ConfirmPasswordPayload
+  captureHold(
+    """
+    Parameters for CaptureHold
+    """
+    input: CaptureHoldInput!
+  ): CaptureHoldPayload
+  confirmPassword(
+    """
+    Parameters for ConfirmPassword
+    """
+    input: ConfirmPasswordInput!
+  ): ConfirmPasswordPayload
   createAndSendBackupSecondFactor(
+    """
+    Parameters for CreateAndSendBackupSecondFactor
+    """
     input: CreateAndSendBackupSecondFactorInput!
   ): CreateAndSendBackupSecondFactorPayload
   createAppSecondFactor(
+    """
+    Parameters for CreateAppSecondFactor
+    """
     input: CreateAppSecondFactorInput!
   ): CreateAppSecondFactorPayload
   createBackupSecondFactors(
+    """
+    Parameters for CreateBackupSecondFactors
+    """
     input: CreateBackupSecondFactorsInput!
   ): CreateBackupSecondFactorsPayload
   createBankDebitSetup(
+    """
+    Parameters for CreateBankDebitSetup
+    """
     input: CreateBankDebitSetupInput!
   ): CreateBankDebitSetupPayload
-  createImage(input: CreateImageInput!): CreateImagePayload
-  createSavedSearch(input: CreateSavedSearchInput!): CreateSavedSearchPayload
+  createImage(
+    """
+    Parameters for CreateImage
+    """
+    input: CreateImageInput!
+  ): CreateImagePayload
+  createSavedSearch(
+    """
+    Parameters for CreateSavedSearch
+    """
+    input: CreateSavedSearchInput!
+  ): CreateSavedSearchPayload
   createSmsSecondFactor(
+    """
+    Parameters for CreateSmsSecondFactor
+    """
     input: CreateSmsSecondFactorInput!
   ): CreateSmsSecondFactorPayload
-  createUserAddress(input: CreateUserAddressInput!): CreateUserAddressPayload
-  createViewingRoom(input: CreateViewingRoomInput!): CreateViewingRoomPayload
+  createUserAddress(
+    """
+    Parameters for CreateUserAddress
+    """
+    input: CreateUserAddressInput!
+  ): CreateUserAddressPayload
+  createViewingRoom(
+    """
+    Parameters for CreateViewingRoom
+    """
+    input: CreateViewingRoomInput!
+  ): CreateViewingRoomPayload
 
   """
   Deduct from the partner's exemption balance, against which they can make sales and not pay commission
   """
   debitCommissionExemption(
+    """
+    Parameters for DebitCommissionExemption
+    """
     input: DebitCommissionExemptionInput!
   ): DebitCommissionExemptionPayload
-  deleteUserAddress(input: DeleteUserAddressInput!): DeleteUserAddressPayload
-  deleteViewingRoom(input: DeleteViewingRoomInput!): DeleteViewingRoomPayload
+  deleteUserAddress(
+    """
+    Parameters for DeleteUserAddress
+    """
+    input: DeleteUserAddressInput!
+  ): DeleteUserAddressPayload
+  deleteViewingRoom(
+    """
+    Parameters for DeleteViewingRoom
+    """
+    input: DeleteViewingRoomInput!
+  ): DeleteViewingRoomPayload
   deliverSecondFactor(
+    """
+    Parameters for DeliverSecondFactor
+    """
     input: DeliverSecondFactorInput!
   ): DeliverSecondFactorPayload
-  disableSavedSearch(input: DisableSavedSearchInput!): DisableSavedSearchPayload
+  disableSavedSearch(
+    """
+    Parameters for DisableSavedSearch
+    """
+    input: DisableSavedSearchInput!
+  ): DisableSavedSearchPayload
   disableSecondFactor(
+    """
+    Parameters for DisableSecondFactor
+    """
     input: DisableSecondFactorInput!
   ): DisableSecondFactorPayload
-  enableSecondFactor(input: EnableSecondFactorInput!): EnableSecondFactorPayload
-  holdInventory(input: HoldInventoryInput!): HoldInventoryPayload
-  publishViewingRoom(input: PublishViewingRoomInput!): PublishViewingRoomPayload
-  recordArtworkView(input: RecordArtworkViewInput!): RecordArtworkViewPayload
+  enableSecondFactor(
+    """
+    Parameters for EnableSecondFactor
+    """
+    input: EnableSecondFactorInput!
+  ): EnableSecondFactorPayload
+  holdInventory(
+    """
+    Parameters for HoldInventory
+    """
+    input: HoldInventoryInput!
+  ): HoldInventoryPayload
+  publishViewingRoom(
+    """
+    Parameters for PublishViewingRoom
+    """
+    input: PublishViewingRoomInput!
+  ): PublishViewingRoomPayload
+  recordArtworkView(
+    """
+    Parameters for RecordArtworkView
+    """
+    input: RecordArtworkViewInput!
+  ): RecordArtworkViewPayload
 
   """
   Refund commission exemption for a previous transaction
   """
   refundCommissionExemption(
+    """
+    Parameters for RefundCommissionExemption
+    """
     input: RefundCommissionExemptionInput!
   ): RefundCommissionExemptionPayload
   requestConditionReport(
+    """
+    Parameters for RequestConditionReport
+    """
     input: RequestConditionReportInput!
   ): RequestConditionReportPayload
   transferMyCollection(
+    """
+    Parameters for TransferMyCollection
+    """
     input: TransferMyCollectionInput!
   ): TransferMyCollectionPayload
   unpublishViewingRoom(
+    """
+    Parameters for UnpublishViewingRoom
+    """
     input: UnpublishViewingRoomInput!
   ): UnpublishViewingRoomPayload
   updateAppSecondFactor(
+    """
+    Parameters for UpdateAppSecondFactor
+    """
     input: UpdateAppSecondFactorInput!
   ): UpdateAppSecondFactorPayload
-  updateSavedSearch(input: UpdateSavedSearchInput!): UpdateSavedSearchPayload
+  updateSavedSearch(
+    """
+    Parameters for UpdateSavedSearch
+    """
+    input: UpdateSavedSearchInput!
+  ): UpdateSavedSearchPayload
   updateSmsSecondFactor(
+    """
+    Parameters for UpdateSmsSecondFactor
+    """
     input: UpdateSmsSecondFactorInput!
   ): UpdateSmsSecondFactorPayload
-  updateUserAddress(input: UpdateUserAddressInput!): UpdateUserAddressPayload
+  updateUserAddress(
+    """
+    Parameters for UpdateUserAddress
+    """
+    input: UpdateUserAddressInput!
+  ): UpdateUserAddressPayload
   updateUserDefaultAddress(
+    """
+    Parameters for UpdateUserDefaultAddress
+    """
     input: UpdateUserDefaultAddressInput!
   ): UpdateUserDefaultAddressPayload
-  updateViewingRoom(input: UpdateViewingRoomInput!): UpdateViewingRoomPayload
+  updateViewingRoom(
+    """
+    Parameters for UpdateViewingRoom
+    """
+    input: UpdateViewingRoomInput!
+  ): UpdateViewingRoomPayload
   updateViewingRoomArtworks(
+    """
+    Parameters for UpdateViewingRoomArtworks
+    """
     input: UpdateViewingRoomArtworksInput!
   ): UpdateViewingRoomArtworksPayload
   updateViewingRoomSubsections(
+    """
+    Parameters for UpdateViewingRoomSubsections
+    """
     input: UpdateViewingRoomSubsectionsInput!
   ): UpdateViewingRoomSubsectionsPayload
 }
@@ -1460,19 +1593,6 @@ type PartnerAgreement {
 A partner agreement or errors object
 """
 union PartnerAgreementOrErrorsUnion = Errors | PartnerAgreement
-
-"""
-A location
-"""
-type PartnerLocation {
-  address: String
-  address2: String
-  city: String
-  country: String
-  id: ID!
-  postalCode: String
-  state: String
-}
 
 """
 Autogenerated input type of PublishViewingRoom


### PR DESCRIPTION
Chore: Keeps gravity.graphql up to latest schema to remove Location from being queried on Artwork type

Building off of @mzikherman's work here: https://github.com/artsy/gravity/pull/17883 