### PR TITLE
fix(onyx-1110): fixes artwork.consignmentSubmission.internalID is always null

### DIFF
--- a/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
+++ b/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
@@ -30,7 +30,7 @@ const ArtworkConsignmentSubmissionType = new GraphQLObjectType<
     return {
       internalID: {
         type: GraphQLString,
-        resolver: ({ id }) => id,
+        resolve: ({ id }) => id,
       },
       displayText: {
         type: GraphQLString,


### PR DESCRIPTION
ArtworkConsignmentSubmission’s internalID was always `null` but now returns the submission's `id`.