### PR TITLE
feat: expose arg in paginated endpoint

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14593,6 +14593,10 @@ type Partner implements Node {
     includeAllFields: Boolean
     last: Int
     representedBy: Boolean
+
+    # Include artists that are represented or have published artworks, should not
+    # be used in conjunction with hasPublishedArtworks or representedBy.
+    representedByOrHasPublishedArtworks: Boolean
     sort: ArtistSorts
   ): ArtistPartnerConnection
   artistsSearchConnection(

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -423,6 +423,11 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           hasPublishedArtworks: {
             type: GraphQLBoolean,
           },
+          representedByOrHasPublishedArtworks: {
+            type: GraphQLBoolean,
+            description:
+              "Include artists that are represented or have published artworks, should not be used in conjunction with hasPublishedArtworks or representedBy.",
+          },
           artistIDs: {
             type: new GraphQLList(GraphQLString),
           },
@@ -449,6 +454,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             display_on_partner_profile: boolean
             artist_ids: [string]
             has_published_artworks: boolean
+            represented_by_or_has_published_artworks: boolean
           }
 
           const gravityArgs: GravityArgs = {
@@ -460,6 +466,8 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             display_on_partner_profile: args.displayOnPartnerProfile,
             artist_ids: args.artistIDs,
             has_published_artworks: args.hasPublishedArtworks,
+            represented_by_or_has_published_artworks:
+              args.representedByOrHasPublishedArtworks,
           }
 
           const partnerArtistsLoader = (() => {


### PR DESCRIPTION
Resolves: https://artsyproduct.atlassian.net/browse/PHIRE-1053

Exposes representedByOrHasPublishedArtworks arg added here so we can use the paginated endpoint on partner pages. 

https://github.com/artsy/gravity/pull/17934

Hold on merging until gravity changes are deployed. 


Potential follow-up: 
- Should we deprecate the arg here that does the same thing in non-paginated endpoint?: https://github.com/artsy/metaphysics/blob/0425a51714086a25f182e5026ddaf14abc23d922/src/schema/v2/partner/partner.ts#L394