### PR TITLE
feat: add prototype schema for new home view sections

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2288,7 +2288,7 @@ enum ArtistSorts {
 }
 
 # An artists rail section in the home view
-type ArtistsRailSection implements GenericHomeViewSection & Node {
+type ArtistsRailHomeViewSection implements GenericHomeViewSection & Node {
   # The component that is prescribed for this section
   component: HomeViewComponent
 
@@ -3151,7 +3151,7 @@ enum ArtworkSorts {
 }
 
 # An artwork rail section in the home view
-type ArtworksRailSection implements GenericHomeViewSection & Node {
+type ArtworksRailHomeViewSection implements GenericHomeViewSection & Node {
   # The component that is prescribed for this section
   component: HomeViewComponent
 
@@ -11358,7 +11358,7 @@ enum HomeViewComponentType {
   ARTWORKS_RAIL
 }
 
-union HomeViewSection = ArtistsRailSection | ArtworksRailSection
+union HomeViewSection = ArtistsRailHomeViewSection | ArtworksRailHomeViewSection
 
 # A connection to a list of items.
 type HomeViewSectionConnection {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2288,9 +2288,15 @@ enum ArtistSorts {
 }
 
 # An artists rail section in the home view
-type ArtistsRailSection implements GenericSection {
+type ArtistsRailSection implements GenericSection & Node {
   # The component that is prescribed for this section
   component: Component
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
 
   # A stable identifier for this section
   key: String!
@@ -3145,9 +3151,15 @@ enum ArtworkSorts {
 }
 
 # An artwork rail section in the home view
-type ArtworksRailSection implements GenericSection {
+type ArtworksRailSection implements GenericSection & Node {
   # The component that is prescribed for this section
   component: Component
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
 
   # A stable identifier for this section
   key: String!
@@ -10974,6 +10986,12 @@ interface GenericSection {
   # The component that is prescribed for this section
   component: Component
 
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+
   # A stable identifier for this section
   key: String!
 
@@ -11334,6 +11352,12 @@ type HomePageSalesModule {
 type HomeView {
   # A list of sections on the home view
   sections: [Section!]!
+  sectionsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): SectionConnection
 }
 
 type IdentityVerification {
@@ -18509,6 +18533,26 @@ enum SecondFactorKind {
 union SecondFactorOrErrorsUnion = AppSecondFactor | Errors | SmsSecondFactor
 
 union Section = ArtistsRailSection | ArtworksRailSection
+
+# A connection to a list of items.
+type SectionConnection {
+  # A list of edges.
+  edges: [SectionEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type SectionEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: Section
+}
 
 # A piece that can be sold
 interface Sellable {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11283,6 +11283,9 @@ type HomePageSalesModule {
 type HomeView {
   # Hello, world
   hello: String
+
+  # A list of sections on the home view
+  sections: [Section]
 }
 
 type IdentityVerification {
@@ -18456,6 +18459,12 @@ enum SecondFactorKind {
 
 # A second factor or errors
 union SecondFactorOrErrorsUnion = AppSecondFactor | Errors | SmsSecondFactor
+
+# A generic section in the home view
+type Section {
+  # The title of the section
+  title: String
+}
 
 # A piece that can be sold
 interface Sellable {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2288,9 +2288,9 @@ enum ArtistSorts {
 }
 
 # An artists rail section in the home view
-type ArtistsRailSection implements GenericSection & Node {
+type ArtistsRailSection implements GenericHomeViewSection & Node {
   # The component that is prescribed for this section
-  component: Component
+  component: HomeViewComponent
 
   # A globally unique ID.
   id: ID!
@@ -3151,9 +3151,9 @@ enum ArtworkSorts {
 }
 
 # An artwork rail section in the home view
-type ArtworksRailSection implements GenericSection & Node {
+type ArtworksRailSection implements GenericHomeViewSection & Node {
   # The component that is prescribed for this section
-  component: Component
+  component: HomeViewComponent
 
   # A globally unique ID.
   id: ID!
@@ -6471,21 +6471,6 @@ type CommerceUpdateImpulseConversationIdPayload {
 
 type CommerceUser {
   id: String!
-}
-
-# A component specification
-type Component {
-  # Which component type to render
-  type: ComponentType
-}
-
-# Known component types for use in home view
-enum ComponentType {
-  # A standard rail of artists
-  ARTISTS_RAIL
-
-  # A standard rail of artworks
-  ARTWORKS_RAIL
 }
 
 type ConditionReportRequest {
@@ -10982,9 +10967,9 @@ type GeneMeta {
 }
 
 # Abstract interface shared by every kind of home view section
-interface GenericSection {
+interface GenericHomeViewSection {
   # The component that is prescribed for this section
-  component: Component
+  component: HomeViewComponent
 
   # A globally unique ID.
   id: ID!
@@ -11355,7 +11340,44 @@ type HomeView {
     before: String
     first: Int
     last: Int
-  ): SectionConnection
+  ): HomeViewSectionConnection
+}
+
+# A component specification
+type HomeViewComponent {
+  # Which component type to render
+  type: HomeViewComponentType
+}
+
+# Known component types for use in home view
+enum HomeViewComponentType {
+  # A standard rail of artists
+  ARTISTS_RAIL
+
+  # A standard rail of artworks
+  ARTWORKS_RAIL
+}
+
+union HomeViewSection = ArtistsRailSection | ArtworksRailSection
+
+# A connection to a list of items.
+type HomeViewSectionConnection {
+  # A list of edges.
+  edges: [HomeViewSectionEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type HomeViewSectionEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: HomeViewSection
 }
 
 type IdentityVerification {
@@ -18529,28 +18551,6 @@ enum SecondFactorKind {
 
 # A second factor or errors
 union SecondFactorOrErrorsUnion = AppSecondFactor | Errors | SmsSecondFactor
-
-union Section = ArtistsRailSection | ArtworksRailSection
-
-# A connection to a list of items.
-type SectionConnection {
-  # A list of edges.
-  edges: [SectionEdge]
-  pageCursors: PageCursors!
-
-  # Information to aid in pagination.
-  pageInfo: PageInfo!
-  totalCount: Int
-}
-
-# An edge in a connection.
-type SectionEdge {
-  # A cursor for use in pagination
-  cursor: String!
-
-  # The item at the end of the edge
-  node: Section
-}
 
 # A piece that can be sold
 interface Sellable {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11281,9 +11281,6 @@ type HomePageSalesModule {
 
 # Experimental schema for new home view
 type HomeView {
-  # Hello, world
-  hello: String!
-
   # A list of sections on the home view
   sections: [Section!]!
 }

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11350,8 +11350,6 @@ type HomePageSalesModule {
 
 # Experimental schema for new home view
 type HomeView {
-  # A list of sections on the home view
-  sections: [Section!]!
   sectionsConnection(
     after: String
     before: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11282,10 +11282,10 @@ type HomePageSalesModule {
 # Experimental schema for new home view
 type HomeView {
   # Hello, world
-  hello: String
+  hello: String!
 
   # A list of sections on the home view
-  sections: [Section]
+  sections: [Section!]!
 }
 
 type IdentityVerification {
@@ -16707,7 +16707,7 @@ type Query {
   homePage: HomePage
 
   # Home view content
-  homeView: HomeView
+  homeView: HomeView!
 
   # An identity verification that the user has access to
   identityVerification(
@@ -18463,7 +18463,7 @@ union SecondFactorOrErrorsUnion = AppSecondFactor | Errors | SmsSecondFactor
 # A generic section in the home view
 type Section {
   # The title of the section
-  title: String
+  title: String!
 }
 
 # A piece that can be sold
@@ -21695,7 +21695,7 @@ type Viewer {
   homePage: HomePage
 
   # Home view content
-  homeView: HomeView
+  homeView: HomeView!
 
   # An identity verification that the user has access to
   identityVerification(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11279,6 +11279,12 @@ type HomePageSalesModule {
   results: [Sale]!
 }
 
+# Experimental schema for new home view
+type HomeView {
+  # Hello, world
+  hello: String
+}
+
 type IdentityVerification {
   createdAt(
     format: String
@@ -16697,6 +16703,9 @@ type Query {
   # Home screen content
   homePage: HomePage
 
+  # Home view content
+  homeView: HomeView
+
   # An identity verification that the user has access to
   identityVerification(
     # ID of the IdentityVerification
@@ -21675,6 +21684,9 @@ type Viewer {
 
   # Home screen content
   homePage: HomePage
+
+  # Home view content
+  homeView: HomeView
 
   # An identity verification that the user has access to
   identityVerification(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2287,6 +2287,18 @@ enum ArtistSorts {
   TRENDING_DESC
 }
 
+# An artists rail section in the home view
+type ArtistsRailSection implements GenericSection {
+  # The component that is prescribed for this section
+  component: Component
+
+  # A stable identifier for this section
+  key: String!
+
+  # A display title for this section
+  title: String!
+}
+
 type ArtistStatuses {
   articles: Boolean
   artists: Boolean
@@ -3130,6 +3142,18 @@ enum ArtworkSorts {
   RECENT_SAVES_COUNT_DESC
   TITLE_ASC
   TITLE_DESC
+}
+
+# An artwork rail section in the home view
+type ArtworksRailSection implements GenericSection {
+  # The component that is prescribed for this section
+  component: Component
+
+  # A stable identifier for this section
+  key: String!
+
+  # A display title for this section
+  title: String!
 }
 
 type ArtworkVersion implements Node {
@@ -6435,6 +6459,21 @@ type CommerceUpdateImpulseConversationIdPayload {
 
 type CommerceUser {
   id: String!
+}
+
+# A component specification
+type Component {
+  # Which component type to render
+  type: ComponentType
+}
+
+# Known component types for use in home view
+enum ComponentType {
+  # A standard rail of artists
+  ARTISTS_RAIL
+
+  # A standard rail of artworks
+  ARTWORKS_RAIL
 }
 
 type ConditionReportRequest {
@@ -10928,6 +10967,18 @@ type GeneFamilyEdge {
 # Meta tags for Gene pages
 type GeneMeta {
   description: String!
+}
+
+# Abstract interface shared by every kind of home view section
+interface GenericSection {
+  # The component that is prescribed for this section
+  component: Component
+
+  # A stable identifier for this section
+  key: String!
+
+  # A display title for this section
+  title: String!
 }
 
 type GravityMutationError {
@@ -18457,11 +18508,7 @@ enum SecondFactorKind {
 # A second factor or errors
 union SecondFactorOrErrorsUnion = AppSecondFactor | Errors | SmsSecondFactor
 
-# A generic section in the home view
-type Section {
-  # The title of the section
-  title: String!
-}
+union Section = ArtistsRailSection | ArtworksRailSection
 
 # A piece that can be sold
 interface Sellable {

--- a/src/schema/v2/homeView/HomeViewComponent.ts
+++ b/src/schema/v2/homeView/HomeViewComponent.ts
@@ -1,0 +1,31 @@
+import { GraphQLEnumType, GraphQLObjectType } from "graphql"
+
+// known standard component types
+
+const HomeViewComponentTypeType = new GraphQLEnumType({
+  name: "HomeViewComponentType",
+  description: "Known component types for use in home view",
+  values: {
+    ARTWORKS_RAIL: {
+      value: "artworks_rail",
+      description: "A standard rail of artworks",
+    },
+    ARTISTS_RAIL: {
+      value: "artists_rail",
+      description: "A standard rail of artists",
+    },
+  },
+})
+
+// a component spec, to be prescribed by each section
+
+export const HomeViewComponent = new GraphQLObjectType({
+  name: "HomeViewComponent",
+  description: "A component specification",
+  fields: {
+    type: {
+      type: HomeViewComponentTypeType,
+      description: "Which component type to render",
+    },
+  },
+})

--- a/src/schema/v2/homeView/HomeViewComponent.ts
+++ b/src/schema/v2/homeView/HomeViewComponent.ts
@@ -7,11 +7,11 @@ const HomeViewComponentTypeType = new GraphQLEnumType({
   description: "Known component types for use in home view",
   values: {
     ARTWORKS_RAIL: {
-      value: "artworks_rail",
+      value: "ArtworksRail",
       description: "A standard rail of artworks",
     },
     ARTISTS_RAIL: {
-      value: "artists_rail",
+      value: "ArtistsRail",
       description: "A standard rail of artists",
     },
   },

--- a/src/schema/v2/homeView/HomeViewSection.ts
+++ b/src/schema/v2/homeView/HomeViewSection.ts
@@ -56,7 +56,7 @@ const ArtworksRailHomeViewSectionType = new GraphQLObjectType<
     },
   },
   isTypeOf: (value) => {
-    return value.component.type === "artworks_rail"
+    return value.component.type === "ArtworksRail"
   },
 })
 
@@ -83,7 +83,7 @@ const ArtistsRailHomeViewSectionType = new GraphQLObjectType<
     },
   },
   isTypeOf: (value) => {
-    return value.component.type === "artists_rail"
+    return value.component.type === "ArtistsRail"
   },
 })
 

--- a/src/schema/v2/homeView/HomeViewSection.ts
+++ b/src/schema/v2/homeView/HomeViewSection.ts
@@ -1,0 +1,89 @@
+import {
+  GraphQLInterfaceType,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { InternalIDFields, NodeInterface } from "../object_identification"
+import { HomeViewComponent } from "./HomeViewComponent"
+
+// section interface
+
+import { ResolverContext } from "types/graphql"
+const GenericHomeViewSectionInterface = new GraphQLInterfaceType({
+  name: "GenericHomeViewSection",
+  description: "Abstract interface shared by every kind of home view section",
+  fields: {
+    ...InternalIDFields,
+    key: {
+      type: GraphQLNonNull(GraphQLString),
+      description: "A stable identifier for this section",
+    },
+    title: {
+      type: GraphQLNonNull(GraphQLString),
+      description: "A display title for this section",
+    },
+    component: {
+      type: HomeViewComponent,
+      description: "The component that is prescribed for this section",
+    },
+  },
+})
+
+// concrete sections
+
+const ArtworksRailSectionType = new GraphQLObjectType<any, ResolverContext>({
+  name: "ArtworksRailSection",
+  description: "An artwork rail section in the home view",
+  interfaces: [GenericHomeViewSectionInterface, NodeInterface],
+  fields: {
+    ...InternalIDFields,
+    key: {
+      type: GraphQLNonNull(GraphQLString),
+      description: "A stable identifier for this section",
+    },
+    title: {
+      type: GraphQLNonNull(GraphQLString),
+      description: "A display title for this section",
+    },
+    component: {
+      type: HomeViewComponent,
+      description: "The component that is prescribed for this section",
+    },
+  },
+  isTypeOf: (value) => {
+    return value.component.type === "artworks_rail"
+  },
+})
+
+const ArtistsRailSectionType = new GraphQLObjectType<any, ResolverContext>({
+  name: "ArtistsRailSection",
+  description: "An artists rail section in the home view",
+  interfaces: [GenericHomeViewSectionInterface, NodeInterface],
+  fields: {
+    ...InternalIDFields,
+    key: {
+      type: GraphQLNonNull(GraphQLString),
+      description: "A stable identifier for this section",
+    },
+    title: {
+      type: GraphQLNonNull(GraphQLString),
+      description: "A display title for this section",
+    },
+    component: {
+      type: HomeViewComponent,
+      description: "The component that is prescribed for this section",
+    },
+  },
+  isTypeOf: (value) => {
+    return value.component.type === "artists_rail"
+  },
+})
+
+// the Section union type of all concrete sections
+
+export const HomeViewSectionType = new GraphQLUnionType({
+  name: "HomeViewSection",
+  types: [ArtworksRailSectionType, ArtistsRailSectionType],
+})

--- a/src/schema/v2/homeView/HomeViewSection.ts
+++ b/src/schema/v2/homeView/HomeViewSection.ts
@@ -33,8 +33,11 @@ const GenericHomeViewSectionInterface = new GraphQLInterfaceType({
 
 // concrete sections
 
-const ArtworksRailSectionType = new GraphQLObjectType<any, ResolverContext>({
-  name: "ArtworksRailSection",
+const ArtworksRailHomeViewSectionType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "ArtworksRailHomeViewSection",
   description: "An artwork rail section in the home view",
   interfaces: [GenericHomeViewSectionInterface, NodeInterface],
   fields: {
@@ -57,8 +60,11 @@ const ArtworksRailSectionType = new GraphQLObjectType<any, ResolverContext>({
   },
 })
 
-const ArtistsRailSectionType = new GraphQLObjectType<any, ResolverContext>({
-  name: "ArtistsRailSection",
+const ArtistsRailHomeViewSectionType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "ArtistsRailHomeViewSection",
   description: "An artists rail section in the home view",
   interfaces: [GenericHomeViewSectionInterface, NodeInterface],
   fields: {
@@ -85,5 +91,5 @@ const ArtistsRailSectionType = new GraphQLObjectType<any, ResolverContext>({
 
 export const HomeViewSectionType = new GraphQLUnionType({
   name: "HomeViewSection",
-  types: [ArtworksRailSectionType, ArtistsRailSectionType],
+  types: [ArtworksRailHomeViewSectionType, ArtistsRailHomeViewSectionType],
 })

--- a/src/schema/v2/homeView/HomeViewSection.ts
+++ b/src/schema/v2/homeView/HomeViewSection.ts
@@ -1,34 +1,37 @@
 import {
+  GraphQLFieldConfigMap,
   GraphQLInterfaceType,
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
   GraphQLUnionType,
 } from "graphql"
+import { ResolverContext } from "types/graphql"
 import { InternalIDFields, NodeInterface } from "../object_identification"
 import { HomeViewComponent } from "./HomeViewComponent"
 
 // section interface
 
-import { ResolverContext } from "types/graphql"
+const standardSectionFields: GraphQLFieldConfigMap<any, ResolverContext> = {
+  ...InternalIDFields,
+  key: {
+    type: GraphQLNonNull(GraphQLString),
+    description: "A stable identifier for this section",
+  },
+  title: {
+    type: GraphQLNonNull(GraphQLString),
+    description: "A display title for this section",
+  },
+  component: {
+    type: HomeViewComponent,
+    description: "The component that is prescribed for this section",
+  },
+}
+
 const GenericHomeViewSectionInterface = new GraphQLInterfaceType({
   name: "GenericHomeViewSection",
   description: "Abstract interface shared by every kind of home view section",
-  fields: {
-    ...InternalIDFields,
-    key: {
-      type: GraphQLNonNull(GraphQLString),
-      description: "A stable identifier for this section",
-    },
-    title: {
-      type: GraphQLNonNull(GraphQLString),
-      description: "A display title for this section",
-    },
-    component: {
-      type: HomeViewComponent,
-      description: "The component that is prescribed for this section",
-    },
-  },
+  fields: standardSectionFields,
 })
 
 // concrete sections
@@ -41,19 +44,7 @@ const ArtworksRailHomeViewSectionType = new GraphQLObjectType<
   description: "An artwork rail section in the home view",
   interfaces: [GenericHomeViewSectionInterface, NodeInterface],
   fields: {
-    ...InternalIDFields,
-    key: {
-      type: GraphQLNonNull(GraphQLString),
-      description: "A stable identifier for this section",
-    },
-    title: {
-      type: GraphQLNonNull(GraphQLString),
-      description: "A display title for this section",
-    },
-    component: {
-      type: HomeViewComponent,
-      description: "The component that is prescribed for this section",
-    },
+    ...standardSectionFields,
   },
   isTypeOf: (value) => {
     return value.component.type === "ArtworksRail"
@@ -68,19 +59,7 @@ const ArtistsRailHomeViewSectionType = new GraphQLObjectType<
   description: "An artists rail section in the home view",
   interfaces: [GenericHomeViewSectionInterface, NodeInterface],
   fields: {
-    ...InternalIDFields,
-    key: {
-      type: GraphQLNonNull(GraphQLString),
-      description: "A stable identifier for this section",
-    },
-    title: {
-      type: GraphQLNonNull(GraphQLString),
-      description: "A display title for this section",
-    },
-    component: {
-      type: HomeViewComponent,
-      description: "The component that is prescribed for this section",
-    },
+    ...standardSectionFields,
   },
   isTypeOf: (value) => {
     return value.component.type === "ArtistsRail"

--- a/src/schema/v2/homeView/__tests__/HomeView.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeView.test.ts
@@ -1,0 +1,59 @@
+import gql from "lib/gql"
+import { runQuery } from "schema/v2/test/utils"
+
+describe("homeView", () => {
+  const query = gql`
+    {
+      homeView {
+        sectionsConnection(first: 2) {
+          edges {
+            node {
+              ... on GenericHomeViewSection {
+                key
+                title
+                component {
+                  type
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("returns a connection of home view sections", async () => {
+    const { homeView } = await runQuery(query)
+
+    expect(homeView.sectionsConnection.edges).toHaveLength(2)
+  })
+
+  it("returns requested data for each section", async () => {
+    const { homeView } = await runQuery(query)
+
+    expect(homeView.sectionsConnection).toMatchInlineSnapshot(`
+      Object {
+        "edges": Array [
+          Object {
+            "node": Object {
+              "component": Object {
+                "type": "ARTWORKS_RAIL",
+              },
+              "key": "RECENTLY_VIEWED_ARTWORKS",
+              "title": "Recently viewed works",
+            },
+          },
+          Object {
+            "node": Object {
+              "component": Object {
+                "type": "ARTISTS_RAIL",
+              },
+              "key": "SUGGESTED_ARTISTS",
+              "title": "Suggested artists for you",
+            },
+          },
+        ],
+      }
+    `)
+  })
+})

--- a/src/schema/v2/homeView/index.ts
+++ b/src/schema/v2/homeView/index.ts
@@ -1,4 +1,9 @@
-import { GraphQLObjectType, GraphQLFieldConfig, GraphQLString } from "graphql"
+import {
+  GraphQLObjectType,
+  GraphQLFieldConfig,
+  GraphQLString,
+  GraphQLList,
+} from "graphql"
 import { ResolverContext } from "types/graphql"
 
 // homeView.hello -- hello world
@@ -9,6 +14,31 @@ const Hello: GraphQLFieldConfig<void, ResolverContext> = {
   resolve: () => "world",
 }
 
+// homeView.sections -- a list of blank-slate sections
+
+const SectionType = new GraphQLObjectType<any, ResolverContext>({
+  name: "Section",
+  description: "A generic section in the home view",
+  fields: {
+    title: {
+      type: GraphQLString,
+      description: "The title of the section",
+    },
+  },
+})
+
+const Sections: GraphQLFieldConfig<void, ResolverContext> = {
+  type: new GraphQLList(SectionType),
+  description: "A list of sections on the home view",
+  resolve: () => {
+    return Array.from({ length: 10 }).map((_, i) => {
+      return {
+        title: `Section ${i}`,
+      }
+    })
+  },
+}
+
 // root homeView field
 
 const HomeViewType = new GraphQLObjectType<any, ResolverContext>({
@@ -16,6 +46,7 @@ const HomeViewType = new GraphQLObjectType<any, ResolverContext>({
   description: "Experimental schema for new home view",
   fields: {
     hello: Hello,
+    sections: Sections,
   },
 })
 

--- a/src/schema/v2/homeView/index.ts
+++ b/src/schema/v2/homeView/index.ts
@@ -8,14 +8,6 @@ import {
 import { ResolverContext } from "types/graphql"
 import { stubDataResolver } from "./stubDataResolver"
 
-// homeView.hello -- hello world
-
-const Hello: GraphQLFieldConfig<void, ResolverContext> = {
-  type: GraphQLNonNull(GraphQLString),
-  description: "Hello, world",
-  resolve: () => "world",
-}
-
 // homeView.sections -- a list of blank-slate sections
 
 const SectionType = new GraphQLObjectType<any, ResolverContext>({
@@ -41,7 +33,6 @@ const HomeViewType = new GraphQLObjectType<any, ResolverContext>({
   name: "HomeView",
   description: "Experimental schema for new home view",
   fields: {
-    hello: Hello,
     sections: Sections,
   },
 })

--- a/src/schema/v2/homeView/index.ts
+++ b/src/schema/v2/homeView/index.ts
@@ -1,12 +1,4 @@
-import {
-  GraphQLObjectType,
-  GraphQLFieldConfig,
-  GraphQLString,
-  GraphQLNonNull,
-  GraphQLInterfaceType,
-  GraphQLUnionType,
-  GraphQLEnumType,
-} from "graphql"
+import { GraphQLObjectType, GraphQLFieldConfig, GraphQLNonNull } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { STUB_SECTIONS } from "./stubData"
 import {
@@ -14,117 +6,8 @@ import {
   paginationResolver,
 } from "../fields/pagination"
 import { pageable } from "relay-cursor-paging"
-import { InternalIDFields, NodeInterface } from "../object_identification"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
-
-// known standard component types
-
-const HomeViewComponentTypeType = new GraphQLEnumType({
-  name: "HomeViewComponentType",
-  description: "Known component types for use in home view",
-  values: {
-    ARTWORKS_RAIL: {
-      value: "artworks_rail",
-      description: "A standard rail of artworks",
-    },
-    ARTISTS_RAIL: {
-      value: "artists_rail",
-      description: "A standard rail of artists",
-    },
-  },
-})
-
-// a component spec, to be prescribed by each section
-
-const HomeViewComponent = new GraphQLObjectType({
-  name: "HomeViewComponent",
-  description: "A component specification",
-  fields: {
-    type: {
-      type: HomeViewComponentTypeType,
-      description: "Which component type to render",
-    },
-  },
-})
-
-// section interface
-
-const GenericHomeViewSectionInterface = new GraphQLInterfaceType({
-  name: "GenericHomeViewSection",
-  description: "Abstract interface shared by every kind of home view section",
-  fields: {
-    ...InternalIDFields,
-    key: {
-      type: GraphQLNonNull(GraphQLString),
-      description: "A stable identifier for this section",
-    },
-    title: {
-      type: GraphQLNonNull(GraphQLString),
-      description: "A display title for this section",
-    },
-    component: {
-      type: HomeViewComponent,
-      description: "The component that is prescribed for this section",
-    },
-  },
-})
-
-// concrete sections
-
-const ArtworksRailSectionType = new GraphQLObjectType<any, ResolverContext>({
-  name: "ArtworksRailSection",
-  description: "An artwork rail section in the home view",
-  interfaces: [GenericHomeViewSectionInterface, NodeInterface],
-  fields: {
-    ...InternalIDFields,
-    key: {
-      type: GraphQLNonNull(GraphQLString),
-      description: "A stable identifier for this section",
-    },
-    title: {
-      type: GraphQLNonNull(GraphQLString),
-      description: "A display title for this section",
-    },
-    component: {
-      type: HomeViewComponent,
-      description: "The component that is prescribed for this section",
-    },
-  },
-  isTypeOf: (value) => {
-    return value.component.type === "artworks_rail"
-  },
-})
-
-const ArtistsRailSectionType = new GraphQLObjectType<any, ResolverContext>({
-  name: "ArtistsRailSection",
-  description: "An artists rail section in the home view",
-  interfaces: [GenericHomeViewSectionInterface, NodeInterface],
-  fields: {
-    ...InternalIDFields,
-    key: {
-      type: GraphQLNonNull(GraphQLString),
-      description: "A stable identifier for this section",
-    },
-    title: {
-      type: GraphQLNonNull(GraphQLString),
-      description: "A display title for this section",
-    },
-    component: {
-      type: HomeViewComponent,
-      description: "The component that is prescribed for this section",
-    },
-  },
-  isTypeOf: (value) => {
-    return value.component.type === "artists_rail"
-  },
-})
-
-// the Section union type of all concrete sections
-
-const HomeViewSectionType = new GraphQLUnionType({
-  name: "HomeViewSection",
-  types: [ArtworksRailSectionType, ArtistsRailSectionType],
-})
+import { HomeViewSectionType } from "./HomeViewSection"
 
 const SectionsConnectionType = connectionWithCursorInfo({
   nodeType: HomeViewSectionType,

--- a/src/schema/v2/homeView/index.ts
+++ b/src/schema/v2/homeView/index.ts
@@ -2,14 +2,13 @@ import {
   GraphQLObjectType,
   GraphQLFieldConfig,
   GraphQLString,
-  GraphQLList,
   GraphQLNonNull,
   GraphQLInterfaceType,
   GraphQLUnionType,
   GraphQLEnumType,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
-import { STUB_SECTIONS, stubDataResolver } from "./stubDataResolver"
+import { STUB_SECTIONS } from "./stubData"
 import {
   connectionWithCursorInfo,
   paginationResolver,
@@ -127,12 +126,6 @@ const SectionType = new GraphQLUnionType({
   types: [ArtworksRailSectionType, ArtistsRailSectionType],
 })
 
-const Sections: GraphQLFieldConfig<void, ResolverContext> = {
-  type: GraphQLNonNull(GraphQLList(GraphQLNonNull(SectionType))),
-  description: "A list of sections on the home view",
-  resolve: stubDataResolver,
-}
-
 const SectionsConnectionType = connectionWithCursorInfo({
   nodeType: SectionType,
 }).connectionType
@@ -163,7 +156,6 @@ const HomeViewType = new GraphQLObjectType<any, ResolverContext>({
   name: "HomeView",
   description: "Experimental schema for new home view",
   fields: {
-    sections: Sections,
     sectionsConnection: SectionConnection,
   },
 })

--- a/src/schema/v2/homeView/index.ts
+++ b/src/schema/v2/homeView/index.ts
@@ -4,22 +4,120 @@ import {
   GraphQLString,
   GraphQLList,
   GraphQLNonNull,
+  GraphQLInterfaceType,
+  GraphQLUnionType,
+  GraphQLEnumType,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { stubDataResolver } from "./stubDataResolver"
 
-// homeView.sections -- a list of blank-slate sections
+// known standard component types
 
-const SectionType = new GraphQLObjectType<any, ResolverContext>({
-  name: "Section",
-  description: "A generic section in the home view",
-  fields: {
-    title: {
-      type: GraphQLNonNull(GraphQLString),
-      description: "The title of the section",
+const ComponentTypeType = new GraphQLEnumType({
+  name: "ComponentType",
+  description: "Known component types for use in home view",
+  values: {
+    ARTWORKS_RAIL: {
+      value: "artworks_rail",
+      description: "A standard rail of artworks",
+    },
+    ARTISTS_RAIL: {
+      value: "artists_rail",
+      description: "A standard rail of artists",
     },
   },
 })
+
+// a component spec, to be prescribed by each section
+
+const Component = new GraphQLObjectType({
+  name: "Component",
+  description: "A component specification",
+  fields: {
+    type: {
+      type: ComponentTypeType,
+      description: "Which component type to render",
+    },
+  },
+})
+
+// section interface
+
+const GenericSectionInterface = new GraphQLInterfaceType({
+  name: "GenericSection",
+  description: "Abstract interface shared by every kind of home view section",
+  fields: {
+    key: {
+      type: GraphQLNonNull(GraphQLString),
+      description: "A stable identifier for this section",
+    },
+    title: {
+      type: GraphQLNonNull(GraphQLString),
+      description: "A display title for this section",
+    },
+    component: {
+      type: Component,
+      description: "The component that is prescribed for this section",
+    },
+  },
+})
+
+// concrete sections
+
+const ArtworksRailSectionType = new GraphQLObjectType<any, ResolverContext>({
+  name: "ArtworksRailSection",
+  description: "An artwork rail section in the home view",
+  interfaces: [GenericSectionInterface],
+  fields: {
+    key: {
+      type: GraphQLNonNull(GraphQLString),
+      description: "A stable identifier for this section",
+    },
+    title: {
+      type: GraphQLNonNull(GraphQLString),
+      description: "A display title for this section",
+    },
+    component: {
+      type: Component,
+      description: "The component that is prescribed for this section",
+    },
+  },
+  isTypeOf: (value) => {
+    return value.component.type === "artworks_rail"
+  },
+})
+
+const ArtistsRailSectionType = new GraphQLObjectType<any, ResolverContext>({
+  name: "ArtistsRailSection",
+  description: "An artists rail section in the home view",
+  interfaces: [GenericSectionInterface],
+  fields: {
+    key: {
+      type: GraphQLNonNull(GraphQLString),
+      description: "A stable identifier for this section",
+    },
+    title: {
+      type: GraphQLNonNull(GraphQLString),
+      description: "A display title for this section",
+    },
+    component: {
+      type: Component,
+      description: "The component that is prescribed for this section",
+    },
+  },
+  isTypeOf: (value) => {
+    return value.component.type === "artists_rail"
+  },
+})
+
+// the Section union type of all concrete sections
+
+const SectionType = new GraphQLUnionType({
+  name: "Section",
+  types: [ArtworksRailSectionType, ArtistsRailSectionType],
+})
+
+// a list (TODO: connection) of sections
 
 const Sections: GraphQLFieldConfig<void, ResolverContext> = {
   type: GraphQLNonNull(GraphQLList(GraphQLNonNull(SectionType))),

--- a/src/schema/v2/homeView/index.ts
+++ b/src/schema/v2/homeView/index.ts
@@ -3,13 +3,14 @@ import {
   GraphQLFieldConfig,
   GraphQLString,
   GraphQLList,
+  GraphQLNonNull,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
 
 // homeView.hello -- hello world
 
 const Hello: GraphQLFieldConfig<void, ResolverContext> = {
-  type: GraphQLString,
+  type: GraphQLNonNull(GraphQLString),
   description: "Hello, world",
   resolve: () => "world",
 }
@@ -21,14 +22,14 @@ const SectionType = new GraphQLObjectType<any, ResolverContext>({
   description: "A generic section in the home view",
   fields: {
     title: {
-      type: GraphQLString,
+      type: GraphQLNonNull(GraphQLString),
       description: "The title of the section",
     },
   },
 })
 
 const Sections: GraphQLFieldConfig<void, ResolverContext> = {
-  type: new GraphQLList(SectionType),
+  type: GraphQLNonNull(GraphQLList(GraphQLNonNull(SectionType))),
   description: "A list of sections on the home view",
   resolve: () => {
     return Array.from({ length: 10 }).map((_, i) => {
@@ -51,7 +52,7 @@ const HomeViewType = new GraphQLObjectType<any, ResolverContext>({
 })
 
 export const HomeView: GraphQLFieldConfig<void, ResolverContext> = {
-  type: HomeViewType,
+  type: GraphQLNonNull(HomeViewType),
   description: "Home view content",
   resolve: () => {
     // dummy response object, otherwise the nested fields won’t work

--- a/src/schema/v2/homeView/index.ts
+++ b/src/schema/v2/homeView/index.ts
@@ -19,8 +19,8 @@ import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 
 // known standard component types
 
-const ComponentTypeType = new GraphQLEnumType({
-  name: "ComponentType",
+const HomeViewComponentTypeType = new GraphQLEnumType({
+  name: "HomeViewComponentType",
   description: "Known component types for use in home view",
   values: {
     ARTWORKS_RAIL: {
@@ -36,12 +36,12 @@ const ComponentTypeType = new GraphQLEnumType({
 
 // a component spec, to be prescribed by each section
 
-const Component = new GraphQLObjectType({
-  name: "Component",
+const HomeViewComponent = new GraphQLObjectType({
+  name: "HomeViewComponent",
   description: "A component specification",
   fields: {
     type: {
-      type: ComponentTypeType,
+      type: HomeViewComponentTypeType,
       description: "Which component type to render",
     },
   },
@@ -49,8 +49,8 @@ const Component = new GraphQLObjectType({
 
 // section interface
 
-const GenericSectionInterface = new GraphQLInterfaceType({
-  name: "GenericSection",
+const GenericHomeViewSectionInterface = new GraphQLInterfaceType({
+  name: "GenericHomeViewSection",
   description: "Abstract interface shared by every kind of home view section",
   fields: {
     ...InternalIDFields,
@@ -63,7 +63,7 @@ const GenericSectionInterface = new GraphQLInterfaceType({
       description: "A display title for this section",
     },
     component: {
-      type: Component,
+      type: HomeViewComponent,
       description: "The component that is prescribed for this section",
     },
   },
@@ -74,7 +74,7 @@ const GenericSectionInterface = new GraphQLInterfaceType({
 const ArtworksRailSectionType = new GraphQLObjectType<any, ResolverContext>({
   name: "ArtworksRailSection",
   description: "An artwork rail section in the home view",
-  interfaces: [GenericSectionInterface, NodeInterface],
+  interfaces: [GenericHomeViewSectionInterface, NodeInterface],
   fields: {
     ...InternalIDFields,
     key: {
@@ -86,7 +86,7 @@ const ArtworksRailSectionType = new GraphQLObjectType<any, ResolverContext>({
       description: "A display title for this section",
     },
     component: {
-      type: Component,
+      type: HomeViewComponent,
       description: "The component that is prescribed for this section",
     },
   },
@@ -98,7 +98,7 @@ const ArtworksRailSectionType = new GraphQLObjectType<any, ResolverContext>({
 const ArtistsRailSectionType = new GraphQLObjectType<any, ResolverContext>({
   name: "ArtistsRailSection",
   description: "An artists rail section in the home view",
-  interfaces: [GenericSectionInterface, NodeInterface],
+  interfaces: [GenericHomeViewSectionInterface, NodeInterface],
   fields: {
     ...InternalIDFields,
     key: {
@@ -110,7 +110,7 @@ const ArtistsRailSectionType = new GraphQLObjectType<any, ResolverContext>({
       description: "A display title for this section",
     },
     component: {
-      type: Component,
+      type: HomeViewComponent,
       description: "The component that is prescribed for this section",
     },
   },
@@ -121,13 +121,13 @@ const ArtistsRailSectionType = new GraphQLObjectType<any, ResolverContext>({
 
 // the Section union type of all concrete sections
 
-const SectionType = new GraphQLUnionType({
-  name: "Section",
+const HomeViewSectionType = new GraphQLUnionType({
+  name: "HomeViewSection",
   types: [ArtworksRailSectionType, ArtistsRailSectionType],
 })
 
 const SectionsConnectionType = connectionWithCursorInfo({
-  nodeType: SectionType,
+  nodeType: HomeViewSectionType,
 }).connectionType
 
 const SectionConnection: GraphQLFieldConfig<any, ResolverContext> = {

--- a/src/schema/v2/homeView/index.ts
+++ b/src/schema/v2/homeView/index.ts
@@ -1,0 +1,29 @@
+import { GraphQLObjectType, GraphQLFieldConfig, GraphQLString } from "graphql"
+import { ResolverContext } from "types/graphql"
+
+// homeView.hello -- hello world
+
+const Hello: GraphQLFieldConfig<void, ResolverContext> = {
+  type: GraphQLString,
+  description: "Hello, world",
+  resolve: () => "world",
+}
+
+// root homeView field
+
+const HomeViewType = new GraphQLObjectType<any, ResolverContext>({
+  name: "HomeView",
+  description: "Experimental schema for new home view",
+  fields: {
+    hello: Hello,
+  },
+})
+
+export const HomeView: GraphQLFieldConfig<void, ResolverContext> = {
+  type: HomeViewType,
+  description: "Home view content",
+  resolve: () => {
+    // dummy response object, otherwise the nested fields won’t work
+    return {}
+  },
+}

--- a/src/schema/v2/homeView/index.ts
+++ b/src/schema/v2/homeView/index.ts
@@ -6,6 +6,7 @@ import {
   GraphQLNonNull,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { stubDataResolver } from "./stubDataResolver"
 
 // homeView.hello -- hello world
 
@@ -31,13 +32,7 @@ const SectionType = new GraphQLObjectType<any, ResolverContext>({
 const Sections: GraphQLFieldConfig<void, ResolverContext> = {
   type: GraphQLNonNull(GraphQLList(GraphQLNonNull(SectionType))),
   description: "A list of sections on the home view",
-  resolve: () => {
-    return Array.from({ length: 10 }).map((_, i) => {
-      return {
-        title: `Section ${i}`,
-      }
-    })
-  },
+  resolve: stubDataResolver,
 }
 
 // root homeView field

--- a/src/schema/v2/homeView/stubData.ts
+++ b/src/schema/v2/homeView/stubData.ts
@@ -4,7 +4,7 @@ export const STUB_SECTIONS = [
     key: "RECENTLY_VIEWED_ARTWORKS",
     title: "Recently viewed works",
     component: {
-      type: "artworks_rail",
+      type: "ArtworksRail",
     },
   },
   {
@@ -12,7 +12,7 @@ export const STUB_SECTIONS = [
     key: "SUGGESTED_ARTISTS",
     title: "Suggested artists for you",
     component: {
-      type: "artists_rail",
+      type: "ArtistsRail",
     },
   },
   {
@@ -20,7 +20,7 @@ export const STUB_SECTIONS = [
     key: "AUCTION_LOTS_FOR_YOU",
     title: "Auction lots for you",
     component: {
-      type: "artworks_rail",
+      type: "ArtworksRail",
     },
   },
 ]

--- a/src/schema/v2/homeView/stubData.ts
+++ b/src/schema/v2/homeView/stubData.ts
@@ -1,6 +1,3 @@
-import { GraphQLFieldResolver } from "graphql"
-import { ResolverContext } from "types/graphql"
-
 export const STUB_SECTIONS = [
   {
     id: 1,
@@ -27,10 +24,3 @@ export const STUB_SECTIONS = [
     },
   },
 ]
-
-export const stubDataResolver: GraphQLFieldResolver<
-  void,
-  ResolverContext
-> = () => {
-  return STUB_SECTIONS
-}

--- a/src/schema/v2/homeView/stubDataResolver.ts
+++ b/src/schema/v2/homeView/stubDataResolver.ts
@@ -1,0 +1,25 @@
+import { GraphQLFieldResolver } from "graphql"
+import { ResolverContext } from "types/graphql"
+
+const STUB_SECTIONS = [
+  {
+    key: "RECENTLY_VIEWED_ARTWORKS",
+    title: "Recently viewed works",
+    component: {
+      type: "artworks_rail",
+    },
+  },
+  {
+    key: "SUGGESTED_ARTISTS",
+    title: "Suggested artists for you",
+    component: {
+      type: "artists_rail",
+    },
+  },
+]
+export const stubDataResolver: GraphQLFieldResolver<
+  void,
+  ResolverContext
+> = () => {
+  return STUB_SECTIONS
+}

--- a/src/schema/v2/homeView/stubDataResolver.ts
+++ b/src/schema/v2/homeView/stubDataResolver.ts
@@ -1,8 +1,9 @@
 import { GraphQLFieldResolver } from "graphql"
 import { ResolverContext } from "types/graphql"
 
-const STUB_SECTIONS = [
+export const STUB_SECTIONS = [
   {
+    id: 1,
     key: "RECENTLY_VIEWED_ARTWORKS",
     title: "Recently viewed works",
     component: {
@@ -10,13 +11,23 @@ const STUB_SECTIONS = [
     },
   },
   {
+    id: 2,
     key: "SUGGESTED_ARTISTS",
     title: "Suggested artists for you",
     component: {
       type: "artists_rail",
     },
   },
+  {
+    id: 3,
+    key: "AUCTION_LOTS_FOR_YOU",
+    title: "Auction lots for you",
+    component: {
+      type: "artworks_rail",
+    },
+  },
 ]
+
 export const stubDataResolver: GraphQLFieldResolver<
   void,
   ResolverContext

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -61,6 +61,7 @@ import GeneFamilies from "./gene_families"
 import Genes from "./genes"
 import { HighlightsField } from "./Highlights"
 import HomePage from "./home"
+import { HomeView } from "./homeView"
 import Image from "./image"
 import Me from "./me"
 import { BidderPositionMutation } from "./me/bidder_position_mutation"
@@ -304,6 +305,7 @@ const rootFields = {
   heroUnit,
   highlights: HighlightsField,
   homePage: HomePage,
+  homeView: HomeView,
   identityVerification: IdentityVerification,
   identityVerificationsConnection,
   job,


### PR DESCRIPTION
A first increment towards the goal of a dynamic Art Advisor home view. 

Onyx has been leading a brainstorm and PoC schema for a flexible Home View, which can provide a list of content sections and their recommended components. 

See: [tech plan](https://www.notion.so/artsy/Art-Advisor-Dynamic-Home-View-3615106ef393433a9f16dcf13b2414f2) and [early share-out](https://artsy.slack.com/archives/C07ANEV7RNV/p1721410245056939)

This PR reflects this early, provisional thinking. (We expect this to evolve, perhaps drastically, as the requirements become clearer.)

The high-level goals are:

- the server controls the selection and ordering of such sections (based on personalization/curation/etc)
- the client knows enough to be able to passively render them using standardized components

The section content is provide via a new root field called `homeView`, which serves as a sandbox for us to iterate on the new schema without affecting / being affected by any existing home screen functionality.

A skeletal version of this, with schema from this PR being consumed by Eigen:

![skel](https://github.com/user-attachments/assets/42713260-5fd3-4448-8baa-50fd7e5de5f6)

Co-authored-by: @nickskalkin