### PR TITLE
feat: add submission copy to GraphQL schema

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2826,6 +2826,11 @@ interface ArtworkConnectionInterface {
 }
 
 type ArtworkConsignmentSubmission {
+  # Action label asks the user to poseed with the submission.
+  actionLabel: String
+
+  # Button label visible to the user.
+  buttonLabel: String
   displayText: String @deprecated(reason: "Prefer `stateLabel` field.")
   inProgress: Boolean
   internalID: String
@@ -2839,6 +2844,7 @@ type ArtworkConsignmentSubmission {
 
   # Submission state label visible to the user.
   stateLabel: String
+  stateLabelColor: String
 }
 
 # A connection to a list of items.

--- a/src/schema/v2/artwork/__tests__/artworkConsignmentSubmissionType.test.ts
+++ b/src/schema/v2/artwork/__tests__/artworkConsignmentSubmissionType.test.ts
@@ -305,9 +305,20 @@ describe("ArtworkConsignmentSubmissionType", () => {
     it("returns correct state label", async () => {
       artwork.consignmentSubmission.state = "DRAFT"
       let data = await runQuery(query, context)
-      expect(data.artwork.consignmentSubmission.stateLabel).toEqual(
-        "In Progress"
-      )
+      expect(data.artwork.consignmentSubmission.stateLabel).toEqual(null)
+
+      artwork.consignmentSubmission.state = "HOLD"
+      data = await runQuery(query, context)
+
+      expect(data.artwork.consignmentSubmission.stateLabel).toEqual(null)
+      artwork.consignmentSubmission.state = "CLOSED"
+
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateLabel).toEqual(null)
+
+      artwork.consignmentSubmission.state = "APPROVED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateLabel).toEqual("Approved")
 
       artwork.consignmentSubmission.state = "SUBMITTED"
       data = await runQuery(query, context)
@@ -315,35 +326,19 @@ describe("ArtworkConsignmentSubmissionType", () => {
         "In Progress"
       )
 
-      artwork.consignmentSubmission.state = "APPROVED"
+      artwork.consignmentSubmission.state = "REJECTED"
       data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.stateLabel).toEqual(
-        "Evaluation Complete"
+        "Submission Unsuccessful"
       )
 
       artwork.consignmentSubmission.state = "PUBLISHED"
       data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.stateLabel).toEqual(
-        "Evaluation Complete"
-      )
-
-      artwork.consignmentSubmission.state = "REJECTED"
-      data = await runQuery(query, context)
-      expect(data.artwork.consignmentSubmission.stateLabel).toEqual(
-        "Evaluation Complete"
-      )
-
-      artwork.consignmentSubmission.state = "HOLD"
-      data = await runQuery(query, context)
-      expect(data.artwork.consignmentSubmission.stateLabel).toEqual(
         "In Progress"
       )
 
-      artwork.consignmentSubmission.state = "CLOSED"
-      data = await runQuery(query, context)
-      expect(data.artwork.consignmentSubmission.stateLabel).toEqual(
-        "Evaluation Complete"
-      )
+      // RESUBMITTED same as PUBLISHED
     })
   })
 
@@ -358,53 +353,205 @@ describe("ArtworkConsignmentSubmissionType", () => {
       }
     `
 
-    const IN_PROGRESS_MESSAGE =
-      "The artwork is being reviewed or is in the sale process."
-    const SUBMISSION_EVALUATED_MESSAGE =
-      "Our specialists have reviewed this submission and determined that we do not currently have a market for it."
-
     it("returns correct help message", async () => {
       artwork.consignmentSubmission.state = "DRAFT"
       let data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.stateHelpMessage).toEqual(
-        IN_PROGRESS_MESSAGE
+        "You’ve started a submission to sell with Artsy but have not yet completed it."
       )
 
       artwork.consignmentSubmission.state = "SUBMITTED"
       data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.stateHelpMessage).toEqual(
-        IN_PROGRESS_MESSAGE
+        "Your submission is currently being reviewed by our team. You will receive a response within 3 to 5 days."
       )
 
       artwork.consignmentSubmission.state = "APPROVED"
       data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.stateHelpMessage).toEqual(
-        SUBMISSION_EVALUATED_MESSAGE
+        "Congratulations, your submission has been approved. Please provide additional information so we can list your work and match it with the best selling opportunity."
       )
 
       artwork.consignmentSubmission.state = "PUBLISHED"
       data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.stateHelpMessage).toEqual(
-        SUBMISSION_EVALUATED_MESSAGE
+        "Thank you for the information. Your submission is being assessed for sales opportunities. Our specialists will contact you via email or phone to coordinate the next steps."
       )
+
+      // RESUBMITTED same as PUBLISHED
 
       artwork.consignmentSubmission.state = "REJECTED"
       data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.stateHelpMessage).toEqual(
-        SUBMISSION_EVALUATED_MESSAGE
+        "Our specialists have reviewed this submission and determined that we do not currently have a market for it."
       )
 
       artwork.consignmentSubmission.state = "HOLD"
       data = await runQuery(query, context)
-      expect(data.artwork.consignmentSubmission.stateHelpMessage).toEqual(
-        IN_PROGRESS_MESSAGE
-      )
+      expect(data.artwork.consignmentSubmission.stateHelpMessage).toEqual(null)
 
       artwork.consignmentSubmission.state = "CLOSED"
       data = await runQuery(query, context)
-      expect(data.artwork.consignmentSubmission.stateHelpMessage).toEqual(
-        SUBMISSION_EVALUATED_MESSAGE
+      expect(data.artwork.consignmentSubmission.stateHelpMessage).toEqual(null)
+    })
+  })
+
+  describe("#actionLabel", () => {
+    const query = `
+    {
+      artwork(id: "richard-prince-untitled-portrait") {
+        consignmentSubmission {
+          actionLabel
+        }
+      }
+    }
+  `
+
+    it("returns correct button lable", async () => {
+      artwork.consignmentSubmission.state = "DRAFT"
+      let data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.actionLabel).toEqual(
+        "Complete Submission"
       )
+
+      artwork.consignmentSubmission.state = "SUBMITTED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.actionLabel).toEqual(null)
+
+      artwork.consignmentSubmission.state = "APPROVED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.actionLabel).toEqual(
+        "Complete Listing"
+      )
+
+      artwork.consignmentSubmission.state = "PUBLISHED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.actionLabel).toEqual(null)
+
+      // RESUBMITTED same as PUBLISHED
+
+      artwork.consignmentSubmission.state = "REJECTED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.actionLabel).toEqual(null)
+
+      artwork.consignmentSubmission.state = "HOLD"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.actionLabel).toEqual(null)
+
+      artwork.consignmentSubmission.state = "CLOSED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.actionLabel).toEqual(null)
+    })
+  })
+
+  describe("#buttonLable", () => {
+    const query = `
+    {
+      artwork(id: "richard-prince-untitled-portrait") {
+        consignmentSubmission {
+          buttonLable
+        }
+      }
+    }
+  `
+
+    it("returns correct button lable", async () => {
+      artwork.consignmentSubmission.state = "DRAFT"
+      let data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.buttonLable).toEqual(
+        "Complete Submission"
+      )
+
+      artwork.consignmentSubmission.state = "SUBMITTED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.buttonLable).toEqual(
+        "Edit Submission"
+      )
+
+      artwork.consignmentSubmission.state = "APPROVED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.buttonLable).toEqual(
+        "Add Additional Information"
+      )
+
+      artwork.consignmentSubmission.state = "PUBLISHED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.buttonLable).toEqual(
+        "Edit Submission"
+      )
+
+      // RESUBMITTED same as PUBLISHED
+
+      artwork.consignmentSubmission.state = "REJECTED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.buttonLable).toEqual(null)
+
+      artwork.consignmentSubmission.state = "HOLD"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.buttonLable).toEqual(null)
+
+      artwork.consignmentSubmission.state = "CLOSED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.buttonLable).toEqual(null)
+    })
+  })
+
+  describe("#stateLabelColor", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          consignmentSubmission {
+            stateLabelColor
+          }
+        }
+      }
+    `
+
+    it("returns correct state label", async () => {
+      artwork.consignmentSubmission.state = "DRAFT"
+      let data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateLabelColor).toEqual(
+        "black100"
+      )
+
+      artwork.consignmentSubmission.state = "HOLD"
+      data = await runQuery(query, context)
+
+      expect(data.artwork.consignmentSubmission.stateLabelColor).toEqual(
+        "black100"
+      )
+      artwork.consignmentSubmission.state = "CLOSED"
+
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateLabelColor).toEqual(
+        "black100"
+      )
+
+      artwork.consignmentSubmission.state = "APPROVED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateLabelColor).toEqual(
+        "black100"
+      )
+
+      artwork.consignmentSubmission.state = "SUBMITTED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateLabelColor).toEqual(
+        "black100"
+      )
+
+      artwork.consignmentSubmission.state = "REJECTED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateLabelColor).toEqual(
+        "black60"
+      )
+
+      artwork.consignmentSubmission.state = "PUBLISHED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateLabelColor).toEqual(
+        "black100"
+      )
+
+      // RESUBMITTED same as PUBLISHED
     })
   })
 })

--- a/src/schema/v2/artwork/__tests__/artworkConsignmentSubmissionType.test.ts
+++ b/src/schema/v2/artwork/__tests__/artworkConsignmentSubmissionType.test.ts
@@ -326,19 +326,27 @@ describe("ArtworkConsignmentSubmissionType", () => {
         "In Progress"
       )
 
-      artwork.consignmentSubmission.state = "REJECTED"
-      data = await runQuery(query, context)
-      expect(data.artwork.consignmentSubmission.stateLabel).toEqual(
-        "Submission Unsuccessful"
-      )
-
       artwork.consignmentSubmission.state = "PUBLISHED"
       data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.stateLabel).toEqual(
         "In Progress"
       )
 
-      // RESUBMITTED same as PUBLISHED
+      artwork.consignmentSubmission.state = "RESUBMITTED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateLabel).toEqual(
+        "In Progress"
+      )
+
+      artwork.consignmentSubmission.state = "LISTED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateLabel).toEqual("Listed")
+
+      artwork.consignmentSubmission.state = "REJECTED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateLabel).toEqual(
+        "Submission Unsuccessful"
+      )
     })
   })
 
@@ -378,7 +386,17 @@ describe("ArtworkConsignmentSubmissionType", () => {
         "Thank you for the information. Your submission is being assessed for sales opportunities. Our specialists will contact you via email or phone to coordinate the next steps."
       )
 
-      // RESUBMITTED same as PUBLISHED
+      artwork.consignmentSubmission.state = "RESUBMITTED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateHelpMessage).toEqual(
+        "Thank you for the information. Your submission is being assessed for sales opportunities. Our specialists will contact you via email or phone to coordinate the next steps."
+      )
+
+      artwork.consignmentSubmission.state = "LISTED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateHelpMessage).toEqual(
+        "Your artwork has been successfully listed on Artsy."
+      )
 
       artwork.consignmentSubmission.state = "REJECTED"
       data = await runQuery(query, context)
@@ -428,7 +446,9 @@ describe("ArtworkConsignmentSubmissionType", () => {
       data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.actionLabel).toEqual(null)
 
-      // RESUBMITTED same as PUBLISHED
+      artwork.consignmentSubmission.state = "RESUBMITTED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.actionLabel).toEqual(null)
 
       artwork.consignmentSubmission.state = "REJECTED"
       data = await runQuery(query, context)
@@ -480,7 +500,17 @@ describe("ArtworkConsignmentSubmissionType", () => {
         "Edit Submission"
       )
 
-      // RESUBMITTED same as PUBLISHED
+      artwork.consignmentSubmission.state = "RESUBMITTED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.buttonLabel).toEqual(
+        "Edit Submission"
+      )
+
+      artwork.consignmentSubmission.state = "LISTED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.buttonLabel).toEqual(
+        "View Listing"
+      )
 
       artwork.consignmentSubmission.state = "REJECTED"
       data = await runQuery(query, context)
@@ -539,19 +569,23 @@ describe("ArtworkConsignmentSubmissionType", () => {
         "black100"
       )
 
-      artwork.consignmentSubmission.state = "REJECTED"
-      data = await runQuery(query, context)
-      expect(data.artwork.consignmentSubmission.stateLabelColor).toEqual(
-        "black60"
-      )
-
       artwork.consignmentSubmission.state = "PUBLISHED"
       data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.stateLabelColor).toEqual(
         "black100"
       )
 
-      // RESUBMITTED same as PUBLISHED
+      artwork.consignmentSubmission.state = "RESUBMITTED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateLabelColor).toEqual(
+        "black100"
+      )
+
+      artwork.consignmentSubmission.state = "REJECTED"
+      data = await runQuery(query, context)
+      expect(data.artwork.consignmentSubmission.stateLabelColor).toEqual(
+        "black60"
+      )
     })
   })
 })

--- a/src/schema/v2/artwork/__tests__/artworkConsignmentSubmissionType.test.ts
+++ b/src/schema/v2/artwork/__tests__/artworkConsignmentSubmissionType.test.ts
@@ -444,12 +444,12 @@ describe("ArtworkConsignmentSubmissionType", () => {
     })
   })
 
-  describe("#buttonLable", () => {
+  describe("#buttonLabel", () => {
     const query = `
     {
       artwork(id: "richard-prince-untitled-portrait") {
         consignmentSubmission {
-          buttonLable
+          buttonLabel
         }
       }
     }
@@ -458,25 +458,25 @@ describe("ArtworkConsignmentSubmissionType", () => {
     it("returns correct button lable", async () => {
       artwork.consignmentSubmission.state = "DRAFT"
       let data = await runQuery(query, context)
-      expect(data.artwork.consignmentSubmission.buttonLable).toEqual(
+      expect(data.artwork.consignmentSubmission.buttonLabel).toEqual(
         "Complete Submission"
       )
 
       artwork.consignmentSubmission.state = "SUBMITTED"
       data = await runQuery(query, context)
-      expect(data.artwork.consignmentSubmission.buttonLable).toEqual(
+      expect(data.artwork.consignmentSubmission.buttonLabel).toEqual(
         "Edit Submission"
       )
 
       artwork.consignmentSubmission.state = "APPROVED"
       data = await runQuery(query, context)
-      expect(data.artwork.consignmentSubmission.buttonLable).toEqual(
+      expect(data.artwork.consignmentSubmission.buttonLabel).toEqual(
         "Add Additional Information"
       )
 
       artwork.consignmentSubmission.state = "PUBLISHED"
       data = await runQuery(query, context)
-      expect(data.artwork.consignmentSubmission.buttonLable).toEqual(
+      expect(data.artwork.consignmentSubmission.buttonLabel).toEqual(
         "Edit Submission"
       )
 
@@ -484,15 +484,15 @@ describe("ArtworkConsignmentSubmissionType", () => {
 
       artwork.consignmentSubmission.state = "REJECTED"
       data = await runQuery(query, context)
-      expect(data.artwork.consignmentSubmission.buttonLable).toEqual(null)
+      expect(data.artwork.consignmentSubmission.buttonLabel).toEqual(null)
 
       artwork.consignmentSubmission.state = "HOLD"
       data = await runQuery(query, context)
-      expect(data.artwork.consignmentSubmission.buttonLable).toEqual(null)
+      expect(data.artwork.consignmentSubmission.buttonLabel).toEqual(null)
 
       artwork.consignmentSubmission.state = "CLOSED"
       data = await runQuery(query, context)
-      expect(data.artwork.consignmentSubmission.buttonLable).toEqual(null)
+      expect(data.artwork.consignmentSubmission.buttonLabel).toEqual(null)
     })
   })
 

--- a/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
+++ b/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
@@ -86,13 +86,60 @@ const ArtworkConsignmentSubmissionType = new GraphQLObjectType<
         description: "Submission state label visible to the user.",
         resolve: ({ state }) => {
           switch (state.toLowerCase()) {
-            case "approved":
-            case "rejected":
+            case "draft":
+            case "hold":
             case "closed":
-            case "published":
-              return "Evaluation Complete"
+              return null
+            case "approved":
+              return "Approved"
+            case "rejected":
+              return "Submission Unsuccessful"
             default:
               return "In Progress"
+          }
+        },
+      },
+      stateLabelColor: {
+        type: GraphQLString,
+        resolve: ({ state }) => {
+          switch (state.toLowerCase()) {
+            case "rejected":
+              return "black60"
+            default:
+              return "black100"
+          }
+        },
+      },
+      actionLabel: {
+        type: GraphQLString,
+        description:
+          "Action label asks the user to poseed with the submission.",
+        resolve: ({ state }) => {
+          switch (state.toLowerCase()) {
+            case "draft":
+              return "Complete Submission"
+            case "approved":
+              return "Complete Listing"
+            default:
+              return null
+          }
+        },
+      },
+      buttonLable: {
+        type: GraphQLString,
+        description: "Button label visible to the user.",
+        resolve: ({ state }) => {
+          switch (state.toLowerCase()) {
+            case "draft":
+              return "Complete Submission"
+            case "approved":
+              return "Add Additional Information"
+            case "submitted":
+            case "published":
+              /* case "RESUBMITTED": */
+              return "Edit Submission"
+            default:
+              return null
           }
         },
       },
@@ -101,13 +148,22 @@ const ArtworkConsignmentSubmissionType = new GraphQLObjectType<
         description: "More information about the submission state.",
         resolve: ({ state }) => {
           switch (state.toLowerCase()) {
+            case "draft":
+              return "You’ve started a submission to sell with Artsy but have not yet completed it."
+            case "submitted":
+              return "Your submission is currently being reviewed by our team. You will receive a response within 3 to 5 days."
             case "approved":
-            case "rejected":
-            case "closed":
+              return "Congratulations, your submission has been approved. Please provide additional information so we can list your work and match it with the best selling opportunity."
             case "published":
+              /* case "RESUBMITTED": */
+              return "Thank you for the information. Your submission is being assessed for sales opportunities. Our specialists will contact you via email or phone to coordinate the next steps."
+            case "rejected":
               return "Our specialists have reviewed this submission and determined that we do not currently have a market for it."
+            case "hold":
+            case "closed":
+              return null
             default:
-              return "The artwork is being reviewed or is in the sale process."
+              return "The artwork is currently being reviewed by our team."
           }
         },
       },

--- a/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
+++ b/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
@@ -92,6 +92,8 @@ const ArtworkConsignmentSubmissionType = new GraphQLObjectType<
               return null
             case "approved":
               return "Approved"
+            case "listed":
+              return "Listed"
             case "rejected":
               return "Submission Unsuccessful"
             default:
@@ -136,8 +138,10 @@ const ArtworkConsignmentSubmissionType = new GraphQLObjectType<
               return "Add Additional Information"
             case "submitted":
             case "published":
-              /* case "RESUBMITTED": */
+            case "resubmitted":
               return "Edit Submission"
+            case "listed":
+              return "View Listing"
             default:
               return null
           }
@@ -155,8 +159,10 @@ const ArtworkConsignmentSubmissionType = new GraphQLObjectType<
             case "approved":
               return "Congratulations, your submission has been approved. Please provide additional information so we can list your work and match it with the best selling opportunity."
             case "published":
-              /* case "RESUBMITTED": */
+            case "resubmitted":
               return "Thank you for the information. Your submission is being assessed for sales opportunities. Our specialists will contact you via email or phone to coordinate the next steps."
+            case "listed":
+              return "Your artwork has been successfully listed on Artsy."
             case "rejected":
               return "Our specialists have reviewed this submission and determined that we do not currently have a market for it."
             case "hold":

--- a/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
+++ b/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
@@ -125,7 +125,7 @@ const ArtworkConsignmentSubmissionType = new GraphQLObjectType<
           }
         },
       },
-      buttonLable: {
+      buttonLabel: {
         type: GraphQLString,
         description: "Button label visible to the user.",
         resolve: ({ state }) => {


### PR DESCRIPTION
As discussed in [this thread](https://artsy.slack.com/archives/D032AFMTJES/p1721828639408619), adding submission copies to MP
Addressed [ONYX-1135](https://artsyproduct.atlassian.net/browse/ONYX-1135) 

[ONYX-1135]: https://artsyproduct.atlassian.net/browse/ONYX-1135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ