### PR TITLE
feat(partner): Add authenticated partnerLocationsConnection loader

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14901,6 +14901,9 @@ type Partner implements Node {
     first: Int
     last: Int
     page: Int
+
+    # Return all partner-authenticated locations.
+    private: Boolean
     size: Int
   ): LocationConnection
   meta: PartnerMeta

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -632,6 +632,11 @@ export default (accessToken, userID, opts) => {
       ({ partnerId, inquiryId }) =>
         `partner/${partnerId}/inquiry_request/${inquiryId}`
     ),
+    partnerLocationsConnectionLoader: gravityLoader(
+      (id) => `partner/${id}/locations`,
+      {},
+      { headers: true }
+    ),
     partnerOffersLoader: gravityLoader("partner_offers", {}, { headers: true }),
     partnerSearchArtistsLoader: gravityLoader(
       (id) => `/match/partner/${id}/artists`,


### PR DESCRIPTION
This adds support for returning partner-authenticated location data from Gravity via a new `private: true` argument:

```graphql
{
  partner(id: "some-partner") { 
    locationsConnection(first: 100, private: true){
      edges {
        node {
          address
        }
      }
    } 
  }
}
```

cc @artsy/amber-devs 