### PR TITLE
chore: Enable address type filter on partner locations query

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -108,6 +108,12 @@ type addOrderedSetItemSuccess {
   setItem: OrderedSetItem
 }
 
+enum addressType {
+  BUSINESS
+  OTHER
+  TEMPORARY
+}
+
 type addUserRoleFailure {
   mutationError: GravityMutationError
 }
@@ -14902,6 +14908,7 @@ type Partner implements Node {
 
   # A connection of locations from a Partner.
   locationsConnection(
+    addressType: addressType
     after: String
     before: String
     first: Int

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -1,5 +1,6 @@
 import { CursorPageable, pageable } from "relay-cursor-paging"
 import {
+  GraphQLEnumType,
   GraphQLString,
   GraphQLObjectType,
   GraphQLNonNull,
@@ -832,6 +833,16 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             type: GraphQLBoolean,
             description: "Return all partner-authenticated locations.",
           },
+          addressType: {
+            type: new GraphQLEnumType({
+              name: "addressType",
+              values: {
+                BUSINESS: { value: "Business" },
+                TEMPORARY: { value: "Temporary" },
+                OTHER: { value: "Other" },
+              },
+            }),
+          },
         }),
         resolve: async (
           { id },
@@ -854,6 +865,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
 
           const { body, headers } = await partnerLocationsConnectionLoader(id, {
             private: args.private,
+            address_type: args.addressType,
             total_count: true,
             offset,
             size,


### PR DESCRIPTION
I just realised I forgot to add this when writing [AMBER-828], but we need to be able to filter partner locations by address type so we can use this query in Volt (the one currently consumed by orders filters only partner locations with a `Business` address type)

```graphql
{
  partner(id: "commerce-test-partner") {
    id
    locationsConnection(first: 5, private: true, addressType: BUSINESS) {
      edges {
        node {
          address
          city
        }
      }
    }
  }
}
```

Ref for the same filter in Volt [here](https://github.com/artsy/volt/blob/cefe12e3145bd76dc6f094b1dc92d84cb5bf2459/app/models/partner.rb#L234)

@artsy/amber-devs 

[AMBER-828]: https://artsyproduct.atlassian.net/browse/AMBER-828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ