### PR TITLE
feat: Add Artwork#isListed field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2582,6 +2582,7 @@ type Artwork implements Node & Searchable & Sellable {
 
   # Is this artwork part of a current show
   isInShow: Boolean
+  isListed: Boolean!
   isNotForSale: String
 
   # Whether a user can make an offer on a work

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -4522,6 +4522,67 @@ describe("Artwork type", () => {
     })
   })
 
+  describe("#isListed", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          isListed
+        }
+      }
+    `
+
+    it("true if listed_artworks_ids length is > 0", async () => {
+      const context = {
+        artworkLoader: () =>
+          Promise.resolve({
+            listed_artwork_ids: ["foo-bar", "bar-foo"],
+          }),
+      }
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          isListed: true,
+        },
+      })
+    })
+
+    it("false if listed_artworks_ids is empty", async () => {
+      const context = {
+        artworkLoader: () =>
+          Promise.resolve({
+            listed_artwork_ids: [],
+          }),
+      }
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          isListed: false,
+        },
+      })
+    })
+
+    it("false if listed_artworks_ids is null", async () => {
+      const context = {
+        artworkLoader: () =>
+          Promise.resolve({
+            listed_artwork_ids: null,
+          }),
+      }
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          isListed: false,
+        },
+      })
+    })
+  })
+
   describe("#priceListed", () => {
     const query = `
       {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1062,6 +1062,14 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           return connectionFromArray(artworks, args)
         },
       },
+      isListed: {
+        type: GraphQLNonNull(GraphQLBoolean),
+        resolve: ({ listed_artwork_ids }) => {
+          return (
+            Array.isArray(listed_artwork_ids) && listed_artwork_ids.length > 0
+          )
+        },
+      },
       literature: markdown(({ literature }) =>
         literature.replace(/^literature:\s+/i, "")
       ),


### PR DESCRIPTION
Returns true if `Artwork#listed_artworks_ids` is present and non-empty. For use within My Collection surfaces to determine whether we render a component/links representing an artwork's commercial listings or query against any active submission status.

```graphql
{
  artwork(id: "ID") {
    isListed
  }
}
```

| MyC Artwork | Image |
|--------|--------|
| isListed=true | ![Screenshot 2024-07-25 at 17 04 38](https://github.com/user-attachments/assets/87276a6b-9405-4590-bd1d-105e1835217c) |
| isListed=false + active submission | ![Screenshot 2024-07-25 at 17 04 50](https://github.com/user-attachments/assets/b304fafe-ac34-40c7-b4b2-16acd64402db) | 





Source: [Figma](https://www.figma.com/design/E6rVm1tiSI4PW3EzibKKZw/Submission-%26-Pre-Consignment-Management?node-id=2894-17256&t=45sKhcM4NWwKPTmf-0)