### PR TITLE
feat: add remaining unstitched marketing collection types

### DIFF
--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -736,8 +736,8 @@ describe("gravity/stitching", () => {
 
       it("passes artist internalID to marketingCollections' artistID arg when querying `... on Artist`", async () => {
         const { resolvers } = await getGravityStitchedSchema()
-        const marketingCollectionsResolver =
-          resolvers.Artist.marketingCollections.resolve
+        const marketingCollectionsResolver = resolvers.Artist
+          .marketingCollections!.resolve
         const mergeInfo = { delegateToSchema: jest.fn() }
 
         await marketingCollectionsResolver(

--- a/src/lib/stitching/gravity/schema.ts
+++ b/src/lib/stitching/gravity/schema.ts
@@ -58,6 +58,7 @@ export const executableGravitySchema = () => {
 
   if (config.USE_UNSTITCHED_MARKETING_COLLECTION_SCHEMA) {
     duplicatedTypes.push("MarketingCollection")
+    duplicatedTypes.push("MarketingCollectionGroup")
   }
   // Types which come from Gravity that are not (yet) needed in MP.
   // In the future, these can be removed from this list as they are needed.

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -63,7 +63,13 @@ import { parsePriceRangeValues } from "lib/moneyHelper"
 import { ArtistGroupIndicatorEnum } from "schema/v2/artist/groupIndicator"
 import { AlertsConnectionType } from "../Alerts"
 import CareerHighlights from "./careerHighlights"
+import {
+  MarketingCollections,
+  fetchMarketingCollections,
+} from "../marketingCollections"
+import config from "config"
 
+const useUnstitchedMarketingCollections = !!config.USE_UNSTITCHED_MARKETING_COLLECTION_SCHEMA
 // Manually curated list of artist id's who has verified auction lots that can be
 // returned, when queried for via `recordsTrusted: true`.
 const auctionRecordsTrusted = require("lib/auction_records_trusted.json")
@@ -827,6 +833,19 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
       displayLabel: { type: GraphQLString, resolve: ({ name }) => name },
       location: { type: GraphQLString },
       meta: Meta,
+      ...(useUnstitchedMarketingCollections && {
+        marketingCollections: {
+          type: MarketingCollections.type,
+          args: pageable({}),
+          resolve: (artist, _args, { marketingCollectionsLoader }) => {
+            const args = {
+              artist_id: artist._id,
+              ..._args,
+            }
+            return fetchMarketingCollections(args, marketingCollectionsLoader)
+          },
+        },
+      }),
       nationality: { type: GraphQLString },
       name: { type: GraphQLString },
       first: { type: GraphQLString },

--- a/src/schema/v2/marketingCollections.ts
+++ b/src/schema/v2/marketingCollections.ts
@@ -335,7 +335,7 @@ export const MarketingCollections: GraphQLFieldConfig<void, ResolverContext> = {
 
 export const fetchMarketingCollections = async (args, loader) => {
   const { size } = convertConnectionArgsToGravityArgs(args)
-  const gravityArgs: { size?: number; slugs?: string[] } = {
+  const gravityArgs: { size?: number; slugs?: string[]; artist_id?: string } = {
     size,
     ...args,
   }

--- a/src/schema/v2/marketingCollections.ts
+++ b/src/schema/v2/marketingCollections.ts
@@ -197,6 +197,7 @@ const MarketingCollectionGroupTypeEnum = new GraphQLEnumType({
     },
   },
 })
+
 const MarketingCollectionGroupType = new GraphQLObjectType<
   any,
   ResolverContext


### PR DESCRIPTION
This PR adds remaining unstitched types to Artist model and flippin' flag to gravity/stitching. 

<img width="1196" alt="image" src="https://github.com/user-attachments/assets/058f2503-8679-4a6d-8d74-fb2257a257a1">
