### PR TITLE
feat: add unstitched marketing categories

### DIFF
--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -111,6 +111,9 @@ export default (opts) => {
       {},
       { headers: true }
     ),
+    marketingCategoriesLoader: gravityLoader(
+      "marketing_collections_categories"
+    ),
     matchArtistsLoader: gravityLoader("match/artists", {}, { headers: true }),
     matchGenesLoader: gravityLoader("match/genes"),
     anonNotificationPreferencesLoader: gravityLoader(

--- a/src/lib/stitching/gravity/schema.ts
+++ b/src/lib/stitching/gravity/schema.ts
@@ -13,7 +13,6 @@ const rootFieldsAllowList = [
   "agreement",
   "artistSeries",
   "artistSeriesConnection",
-  "marketingCategories",
   "viewingRoom",
   "viewingRooms",
 ].concat(
@@ -23,6 +22,7 @@ const rootFieldsAllowList = [
         "marketingCollection",
         "marketingCollections",
         "curatedMarketingCollections",
+        "marketingCategories",
       ]
 )
 

--- a/src/lib/stitching/gravity/schema.ts
+++ b/src/lib/stitching/gravity/schema.ts
@@ -59,6 +59,7 @@ export const executableGravitySchema = () => {
   if (config.USE_UNSTITCHED_MARKETING_COLLECTION_SCHEMA) {
     duplicatedTypes.push("MarketingCollection")
     duplicatedTypes.push("MarketingCollectionGroup")
+    duplicatedTypes.push("MarketingCollectionCategory")
   }
   // Types which come from Gravity that are not (yet) needed in MP.
   // In the future, these can be removed from this list as they are needed.

--- a/src/schema/v2/__tests__/marketingCategories.test.ts
+++ b/src/schema/v2/__tests__/marketingCategories.test.ts
@@ -1,0 +1,88 @@
+import gql from "lib/gql"
+import { runQuery } from "../test/utils"
+import config from "config"
+
+const marketingCategoriesData = [
+  {
+    name: "Contemporary",
+    collections: [
+      {
+        id: "percys-z-collection-1",
+        slug: "percys-z-collection-1",
+        title: "Percy Z Collection",
+      },
+      {
+        id: "fiby-z-collection-2",
+        slug: "fiby-z-collection-2",
+        title: "Fiby Z Collection 2",
+      },
+    ],
+  },
+  {
+    name: "Impressionism",
+    collections: [
+      {
+        id: "fiby-z-collection-2",
+        slug: "fiby-z-collection-2",
+        title: "Fiby Z Collection 2",
+      },
+    ],
+  },
+]
+
+beforeAll(() => {
+  config.USE_UNSTITCHED_MARKETING_COLLECTION_SCHEMA = true
+})
+
+afterAll(() => {
+  config.USE_UNSTITCHED_MARKETING_COLLECTION_SCHEMA = false
+})
+
+describe("MarketingCategories", () => {
+  it("returns a list of marketing categories", async () => {
+    const query = gql`
+      {
+        marketingCategories {
+          name
+          collections {
+            slug
+            title
+          }
+        }
+      }
+    `
+    const context = {
+      marketingCategoriesLoader: () =>
+        Promise.resolve({ body: marketingCategoriesData }),
+    } as any
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      marketingCategories: [
+        {
+          name: "Contemporary",
+          collections: [
+            {
+              slug: "percys-z-collection-1",
+              title: "Percy Z Collection",
+            },
+            {
+              slug: "fiby-z-collection-2",
+              title: "Fiby Z Collection 2",
+            },
+          ],
+        },
+        {
+          name: "Impressionism",
+          collections: [
+            {
+              slug: "fiby-z-collection-2",
+              title: "Fiby Z Collection 2",
+            },
+          ],
+        },
+      ],
+    })
+  })
+})

--- a/src/schema/v2/__tests__/marketingCategories.test.ts
+++ b/src/schema/v2/__tests__/marketingCategories.test.ts
@@ -52,8 +52,7 @@ describe("MarketingCategories", () => {
       }
     `
     const context = {
-      marketingCategoriesLoader: () =>
-        Promise.resolve({ body: marketingCategoriesData }),
+      marketingCategoriesLoader: () => Promise.resolve(marketingCategoriesData),
     } as any
 
     const data = await runQuery(query, context)

--- a/src/schema/v2/marketingCategories.ts
+++ b/src/schema/v2/marketingCategories.ts
@@ -30,7 +30,7 @@ export const MarketingCategories: GraphQLFieldConfig<any, ResolverContext> = {
   ),
   description: "Marketing Categories",
   resolve: async (_root, _args, { marketingCategoriesLoader }) => {
-    const { body } = await marketingCategoriesLoader()
+    const body = await marketingCategoriesLoader()
     return body
   },
 }

--- a/src/schema/v2/marketingCategories.ts
+++ b/src/schema/v2/marketingCategories.ts
@@ -1,0 +1,36 @@
+import {
+  GraphQLList,
+  GraphQLString,
+  GraphQLObjectType,
+  GraphQLFieldConfig,
+  GraphQLNonNull,
+} from "graphql"
+import { MarketingCollectionType } from "./marketingCollections"
+import { ResolverContext } from "types/graphql"
+
+const MarketingCollectionCategory = new GraphQLObjectType<any, ResolverContext>(
+  {
+    name: "MarketingCollectionCategory",
+    fields: {
+      collections: {
+        type: new GraphQLList(MarketingCollectionType),
+        resolve: ({ collections }) => collections,
+      },
+      name: {
+        type: GraphQLString,
+        resolve: ({ name }) => name,
+      },
+    },
+  }
+)
+
+export const MarketingCategories: GraphQLFieldConfig<any, ResolverContext> = {
+  type: GraphQLNonNull(
+    GraphQLList(GraphQLNonNull(MarketingCollectionCategory))
+  ),
+  description: "Marketing Categories",
+  resolve: async (_root, _args, { marketingCategoriesLoader }) => {
+    const { body } = await marketingCategoriesLoader()
+    return body
+  },
+}

--- a/src/schema/v2/marketingCollections.ts
+++ b/src/schema/v2/marketingCollections.ts
@@ -132,7 +132,7 @@ export const MarketingCollectionFields: GraphQLFieldConfigMap<
   },
   headerImage: {
     type: GraphQLString,
-    resolve: ({ header_image_id }) => header_image_id,
+    resolve: ({ header_image }) => header_image,
   },
   thumbnail: {
     type: GraphQLString,

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -226,6 +226,7 @@ import {
   MarketingCollections,
   CuratedMarketingCollections,
 } from "./marketingCollections"
+import { MarketingCategories } from "./marketingCategories"
 import { createCareerHighlightMutation } from "./careerHighlight/createCareerHighlightMutation"
 import { deleteCareerHighlightMutation } from "./careerHighlight/deleteCareerHighlightMutation"
 import { updateCareerHighlightMutation } from "./careerHighlight/updateCareerHighlightMutation"
@@ -247,6 +248,7 @@ const marketingCollectionUnstitchedRootField = config.USE_UNSTITCHED_MARKETING_C
       marketingCollection: MarketingCollection,
       marketingCollections: MarketingCollections,
       curatedMarketingCollections: CuratedMarketingCollections,
+      marketingCategories: MarketingCategories,
     }
   : ({} as any)
 


### PR DESCRIPTION
This PR is a follow-up to the new [Gravity endpoint](https://github.com/artsy/gravity/pull/17996), and continuation of the unstitching the marketing collections.