### PR TITLE
feat(EMI-2013): get curated collection and active show collector signals

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4386,8 +4386,14 @@ type CollectorResume {
 
 # Collector signals available to the artwork
 type CollectorSignals {
+  # Show the artwork is currently in
+  activeShow: Show
+
   # Lot bid count
   bidCount: Int
+
+  # Curated collections the artwork is a member of
+  curatedCollectionSlugs: [String]
 
   # Lot watcher count
   lotWatcherCount: Int

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4393,7 +4393,7 @@ type CollectorSignals {
   bidCount: Int
 
   # Curated collections the artwork is a member of
-  curatedCollectionSlugs: [String]
+  curatedCollections: [MarketingCollection]
 
   # Lot watcher count
   lotWatcherCount: Int

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -1,4 +1,4 @@
-import { GraphQLFieldConfig, GraphQLList, GraphQLString } from "graphql"
+import { GraphQLFieldConfig, GraphQLList } from "graphql"
 import { GraphQLInt, GraphQLObjectType } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { PartnerOfferToCollectorType } from "../partnerOfferToCollector"

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -111,7 +111,7 @@ const collectorSignalsLoader = async (
   // Temporary
   const experimentalCollectorSignalsEnabled = auctionsCollectorSignalsEnabled
   if (experimentalCollectorSignalsEnabled) {
-    curatedCollections = await getcuratedCollections({ artworkId }, ctx)
+    curatedCollections = await getCuratedCollections({ artworkId }, ctx)
     activeShow = await getActiveShow({ artworkId }, ctx)
   }
 
@@ -166,7 +166,7 @@ const CURATED_COLLECTION_SLUGS = [
   "curators-picks-emerging-artists",
   "trending-now",
 ]
-const getcuratedCollections = async (
+const getCuratedCollections = async (
   { artworkId },
   ctx
 ): Promise<string[] | null> => {
@@ -182,7 +182,8 @@ const getcuratedCollections = async (
     slug: string
     artwork_ids: string[]
   }>).reduce<any[]>((acc, marketingCollection) => {
-    if (marketingCollection.artwork_ids.includes(artworkId)) {
+    console.log(marketingCollection)
+    if (marketingCollection?.artwork_ids?.includes(artworkId)) {
       acc.push(marketingCollection)
     }
     return acc
@@ -195,6 +196,7 @@ const getActiveShow = async ({ artworkId }, ctx): Promise<string[] | null> => {
   const shows = await await ctx.relatedShowsLoader({
     artwork: [artworkId],
     size: 1,
+    // status: "running_and_upcoming", // requires api/v1/related/shows update
     status: "running", // could also include "upcoming" but i think that is another query
     // active: true, // need to investigate what active means here - part of FilteredSearch
     // maybe it is the same as status: "running" + 'upcoming


### PR DESCRIPTION
🚧 WIP 🚧 

This PR adds basic fetching for more artwork collector signals:
- active shows [[Figma]](https://www.figma.com/design/22RFPSkUu97g0ska3azFL2/Social-proof-%26-urgency-signals?node-id=2315-28859&t=6PXsPCsu5z4xnidJ-0)
  - I'm returning a single ShowType here
  - depends on artsy/gravity#18007 or resolving the questions I asked in it
- Curated collections [[Figma]](https://www.figma.com/design/22RFPSkUu97g0ska3azFL2/Social-proof-%26-urgency-signals?node-id=2262-27864&t=6PXsPCsu5z4xnidJ-0)
  - I'm returning an array of collections here

The difference between these types seems totally arbitrary to me - either could be single/plural but collections seem more likely to be plural. We might want metaphysics to be more opinionated about these - prioritizing one curated collection label ('trending' takes priority over 'curators pick') rather than making clients deal with lists, and 'showing now' vs 'showing soon' could be explicit values on the object.

This is a first pass to see the data flowing. It seems to work:
<details><summary>Screenshots</summary>

<img width="609" alt="image" src="https://github.com/user-attachments/assets/81de972f-b9e8-43d9-b27b-f85a83e84274">


</details> 