### PR TITLE
chore: make component non nullable

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2286,7 +2286,7 @@ enum ArtistTargetSupplyType {
 # An artists rail section in the home view
 type ArtistsRailHomeViewSection implements GenericHomeViewSection & Node {
   # The component that is prescribed for this section
-  component: HomeViewComponent
+  component: HomeViewComponent!
 
   # A globally unique ID.
   id: ID!
@@ -3133,7 +3133,7 @@ type ArtworksRailHomeViewSection implements GenericHomeViewSection & Node {
   ): ArtworkConnection
 
   # The component that is prescribed for this section
-  component: HomeViewComponent
+  component: HomeViewComponent!
 
   # A globally unique ID.
   id: ID!
@@ -10490,7 +10490,7 @@ type GeneMeta {
 # Abstract interface shared by every kind of home view section
 interface GenericHomeViewSection {
   # The component that is prescribed for this section
-  component: HomeViewComponent
+  component: HomeViewComponent!
 
   # A globally unique ID.
   id: ID!

--- a/src/schema/v2/homeView/HomeViewSection.ts
+++ b/src/schema/v2/homeView/HomeViewSection.ts
@@ -1,6 +1,7 @@
 import {
   GraphQLFieldConfigMap,
   GraphQLInterfaceType,
+  GraphQLNonNull,
   GraphQLObjectType,
   GraphQLUnionType,
 } from "graphql"
@@ -15,7 +16,7 @@ import { artworkConnection } from "../artwork"
 const standardSectionFields: GraphQLFieldConfigMap<any, ResolverContext> = {
   ...InternalIDFields,
   component: {
-    type: HomeViewComponent,
+    type: new GraphQLNonNull(HomeViewComponent),
     description: "The component that is prescribed for this section",
   },
 }


### PR DESCRIPTION
**Description**
This PR improves the `Section.Component` to be a non nullable. This will help us avoid the hassle of testing over and over if `section.component` is available while it's always there.