### PR TITLE
feat: load real data for new home view sections

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2285,6 +2285,13 @@ enum ArtistTargetSupplyType {
 
 # An artists rail section in the home view
 type ArtistsRailHomeViewSection implements GenericHomeViewSection & Node {
+  artistsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtistConnection
+
   # The component that is prescribed for this section
   component: HomeViewComponent
 

--- a/src/schema/v2/homeView/HomeViewSection.ts
+++ b/src/schema/v2/homeView/HomeViewSection.ts
@@ -9,6 +9,7 @@ import { ResolverContext } from "types/graphql"
 import { InternalIDFields, NodeInterface } from "../object_identification"
 import { HomeViewComponent } from "./HomeViewComponent"
 import { artworkConnection } from "../artwork"
+import { artistsConnection } from "../artists"
 
 // section interface
 
@@ -56,6 +57,13 @@ const ArtistsRailHomeViewSectionType = new GraphQLObjectType<
   interfaces: [GenericHomeViewSectionInterface, NodeInterface],
   fields: {
     ...standardSectionFields,
+
+    artistsConnection: {
+      type: artistsConnection.type,
+      args: pageable({}),
+      resolve: (parent, ...rest) =>
+        parent.resolver ? parent.resolver(parent, ...rest) : [],
+    },
   },
 })
 

--- a/src/schema/v2/homeView/artworkResolvers.ts
+++ b/src/schema/v2/homeView/artworkResolvers.ts
@@ -2,6 +2,8 @@ import type { GraphQLFieldResolver } from "graphql"
 import type { ResolverContext } from "types/graphql"
 import { artworksForUser } from "../artworksForUser"
 import { RecentlyViewedArtworks } from "../me/recentlyViewedArtworks"
+import { getCuratedArtists } from "../artists/curatedTrending"
+import { connectionFromArray } from "graphql-relay"
 
 /*
  * Resolvers for home view artwork sections
@@ -68,4 +70,12 @@ export const AuctionLotsForYouResolver: GraphQLFieldResolver<
   )
 
   return result
+}
+
+export const SuggestedArtistsResolver: GraphQLFieldResolver<
+  any,
+  ResolverContext
+> = async (_parent, args, context, _info) => {
+  const artistRecords = await getCuratedArtists(context)
+  return connectionFromArray(artistRecords, args)
 }

--- a/src/schema/v2/homeView/artworkResolvers.ts
+++ b/src/schema/v2/homeView/artworkResolvers.ts
@@ -3,6 +3,7 @@ import type { ResolverContext } from "types/graphql"
 import { artworksForUser } from "../artworksForUser"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { paginationResolver } from "../fields/pagination"
+import { RecentlyViewedArtworks } from "../me/recentlyViewedArtworks"
 
 /*
  * Resolvers for home view artwork sections
@@ -39,22 +40,13 @@ export const NewWorksForYouResolver: GraphQLFieldResolver<
 export const RecentlyViewedArtworksResolver: GraphQLFieldResolver<
   any,
   ResolverContext
-> = (_parent, args, _context, _info) => {
-  // TODO: use actual loader
+> = async (_parent, args, context, info) => {
+  if (!context.meLoader)
+    throw new Error("You need to be signed in to perform this action")
 
-  const stubData = [{ id: "TODO-recently_viewed_artworks" }]
-  const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
-  const data = stubData.slice(offset, offset + size)
-  const totalCount = stubData.length
+  const me = await context.meLoader()
 
-  return paginationResolver({
-    totalCount,
-    offset,
-    page,
-    size,
-    body: data,
-    args,
-  })
+  return RecentlyViewedArtworks.resolve!(me, args, context, info)
 }
 
 export const AuctionLotsForYouResolver: GraphQLFieldResolver<

--- a/src/schema/v2/homeView/artworkResolvers.ts
+++ b/src/schema/v2/homeView/artworkResolvers.ts
@@ -1,15 +1,11 @@
 import type { GraphQLFieldResolver } from "graphql"
 import type { ResolverContext } from "types/graphql"
 import { artworksForUser } from "../artworksForUser"
-import { convertConnectionArgsToGravityArgs } from "lib/helpers"
-import { paginationResolver } from "../fields/pagination"
 import { RecentlyViewedArtworks } from "../me/recentlyViewedArtworks"
 
 /*
  * Resolvers for home view artwork sections
  */
-
-// the resolvers
 
 export const NewWorksForYouResolver: GraphQLFieldResolver<
   any,
@@ -52,20 +48,24 @@ export const RecentlyViewedArtworksResolver: GraphQLFieldResolver<
 export const AuctionLotsForYouResolver: GraphQLFieldResolver<
   any,
   ResolverContext
-> = async (_parent, args, _context, _info) => {
-  // TODO: use actual loader
+> = async (parent, args, context, info) => {
+  const finalArgs = {
+    // formerly specified client-side
+    includeBackfill: true,
+    onlyAtAuction: true,
+    first: args.first,
+    excludeDislikedArtworks: true,
+    excludeArtworkIds: [],
 
-  const stubData = [{ id: "TODO-auction_lots_for_you" }]
-  const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
-  const data = stubData.slice(offset, offset + size)
-  const totalCount = stubData.length
+    ...args,
+  }
 
-  return paginationResolver({
-    totalCount,
-    offset,
-    page,
-    size,
-    body: data,
-    args,
-  })
+  const result = await artworksForUser.resolve!(
+    parent,
+    finalArgs,
+    context,
+    info
+  )
+
+  return result
 }

--- a/src/schema/v2/homeView/getSectionsForUser.ts
+++ b/src/schema/v2/homeView/getSectionsForUser.ts
@@ -4,7 +4,7 @@ import {
   HomeViewSection,
   NewWorksForYou,
   RecentlyViewedArtworks,
-  SuggestedArtists,
+  TrendingArtists,
 } from "./sections"
 
 export async function getSectionsForUser(
@@ -24,7 +24,7 @@ export async function getSectionsForUser(
   if (me.type === "Admin") {
     sections = [
       RecentlyViewedArtworks,
-      SuggestedArtists,
+      TrendingArtists,
       AuctionLotsForYou,
       NewWorksForYou,
     ]
@@ -32,7 +32,7 @@ export async function getSectionsForUser(
     sections = [
       NewWorksForYou,
       AuctionLotsForYou,
-      SuggestedArtists,
+      TrendingArtists,
       RecentlyViewedArtworks,
     ]
   }

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -3,6 +3,7 @@ import {
   AuctionLotsForYouResolver,
   NewWorksForYouResolver,
   RecentlyViewedArtworksResolver,
+  SuggestedArtistsResolver,
 } from "./artworkResolvers"
 import { ResolverContext } from "types/graphql"
 
@@ -42,19 +43,20 @@ export const NewWorksForYou: HomeViewSection = {
   resolver: NewWorksForYouResolver,
 }
 
-export const SuggestedArtists: HomeViewSection = {
-  id: "home-view-section-suggested-artists",
+export const TrendingArtists: HomeViewSection = {
+  id: "home-view-section-trending-artists",
   type: "ArtistsRailHomeViewSection",
   component: {
-    title: "Suggested artists for you",
+    title: "Trending Artists on Artsy",
   },
+  resolver: SuggestedArtistsResolver,
 }
 
 const sections: HomeViewSection[] = [
   RecentlyViewedArtworks,
   AuctionLotsForYou,
   NewWorksForYou,
-  SuggestedArtists,
+  TrendingArtists,
 ]
 
 export const registry = sections.reduce(


### PR DESCRIPTION
Swap out stub data for real data via existing resolvers / data loaders.

- [feat: load real data for homeView > Recently Viewed Artworks](https://github.com/artsy/metaphysics/commit/debf842eb021a87dc120ec5e745cfac7babf0231)
- [feat: load real data for homeView > Auction Lots For You](https://github.com/artsy/metaphysics/commit/82b1c36d9bbe65685dab4fd7fc8f4163974bcd7e)
- [feat: load real data for homeView > Trending Artists](https://github.com/artsy/metaphysics/commit/8e641e9d9026160650d1f96e4bd64e87ef822299)