### PR TITLE
chore: make some homeView field types non-nullable

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2290,10 +2290,10 @@ type ArtistsRailHomeViewSection implements GenericHomeViewSection & Node {
     before: String
     first: Int
     last: Int
-  ): ArtistConnection
+  ): ArtistConnection!
 
   # The component that is prescribed for this section
-  component: HomeViewComponent
+  component: HomeViewComponent!
 
   # A globally unique ID.
   id: ID!
@@ -3138,10 +3138,10 @@ type ArtworksRailHomeViewSection implements GenericHomeViewSection & Node {
     before: String
     first: Int
     last: Int
-  ): ArtworkConnection
+  ): ArtworkConnection!
 
   # The component that is prescribed for this section
-  component: HomeViewComponent
+  component: HomeViewComponent!
 
   # A globally unique ID.
   id: ID!
@@ -10498,7 +10498,7 @@ type GeneMeta {
 # Abstract interface shared by every kind of home view section
 interface GenericHomeViewSection {
   # The component that is prescribed for this section
-  component: HomeViewComponent
+  component: HomeViewComponent!
 
   # A globally unique ID.
   id: ID!
@@ -10860,7 +10860,7 @@ type HomeView {
     before: String
     first: Int
     last: Int
-  ): HomeViewSectionConnection
+  ): HomeViewSectionConnection!
 }
 
 # A component specification

--- a/src/schema/v2/homeView/HomeViewSection.ts
+++ b/src/schema/v2/homeView/HomeViewSection.ts
@@ -1,6 +1,7 @@
 import {
   GraphQLFieldConfigMap,
   GraphQLInterfaceType,
+  GraphQLNonNull,
   GraphQLObjectType,
   GraphQLUnionType,
 } from "graphql"
@@ -16,7 +17,7 @@ import { artistsConnection } from "../artists"
 const standardSectionFields: GraphQLFieldConfigMap<any, ResolverContext> = {
   ...InternalIDFields,
   component: {
-    type: HomeViewComponent,
+    type: new GraphQLNonNull(HomeViewComponent),
     description: "The component that is prescribed for this section",
   },
 }
@@ -40,7 +41,7 @@ const ArtworksRailHomeViewSectionType = new GraphQLObjectType<
     ...standardSectionFields,
 
     artworksConnection: {
-      type: artworkConnection.connectionType,
+      type: new GraphQLNonNull(artworkConnection.connectionType),
       args: pageable({}),
       resolve: (parent, ...rest) =>
         parent.resolver ? parent.resolver(parent, ...rest) : [],
@@ -59,7 +60,7 @@ const ArtistsRailHomeViewSectionType = new GraphQLObjectType<
     ...standardSectionFields,
 
     artistsConnection: {
-      type: artistsConnection.type,
+      type: new GraphQLNonNull(artistsConnection.type),
       args: pageable({}),
       resolve: (parent, ...rest) =>
         parent.resolver ? parent.resolver(parent, ...rest) : [],

--- a/src/schema/v2/homeView/index.ts
+++ b/src/schema/v2/homeView/index.ts
@@ -20,7 +20,7 @@ const SectionsConnectionType = connectionWithCursorInfo({
 }).connectionType
 
 const SectionConnection: GraphQLFieldConfig<any, ResolverContext> = {
-  type: SectionsConnectionType,
+  type: new GraphQLNonNull(SectionsConnectionType),
   args: pageable({}),
   resolve: async (_parent, args, context, _info) => {
     const { page, size, offset } = convertConnectionArgsToGravityArgs(args)


### PR DESCRIPTION
Reduces the amount of null-checking needed by the client and we expect all of these types to consistently present data.