### PR TITLE
fix: handle formatted markdown properly for stitched ArtistSeries type

### DIFF
--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -869,7 +869,7 @@ describe("gravity/stitching", () => {
       const { descriptionFormatted } = resolvers.ArtistSeries
       const formattedDescription = await descriptionFormatted.resolve(
         { description: "**Bold Type**" },
-        { format: "HTML" }
+        { format: "html" }
       )
       expect(formattedDescription).toEqual(
         "<p><strong>Bold Type</strong></p>\n"

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -5,7 +5,6 @@ import { defineCustomLocale, isExisty } from "lib/helpers"
 import { pageableFilterArtworksArgsWithInput } from "schema/v2/filterArtworksConnection"
 import { normalizeImageData, getDefault } from "schema/v2/image"
 import { formatMarkdownValue } from "schema/v2/fields/markdown"
-import Format from "schema/v2/input_fields/format"
 import { toGlobalId } from "graphql-relay"
 import { printType } from "lib/stitching/lib/printType"
 import { dateRange } from "lib/date"
@@ -401,12 +400,7 @@ export const gravityStitchingEnvironment = (
             if (!isExisty(description) || typeof description !== "string")
               return null
 
-            const { type: formatType } = Format
-            const desiredFormat = formatType
-              ?.getValues()
-              ?.find((e) => e.name === format)?.value
-
-            return formatMarkdownValue(description, desiredFormat)
+            return formatMarkdownValue(description, format)
           },
         },
         artworksCountMessage: {


### PR DESCRIPTION
I'm not totally sure what's going on here but something in the recent dependency PR changed how the formatted text args worked and I think the stitched resolvers might have been overlooked. 

This fixes the broken markdown formatted for the stitched ArtistSeries type, as reported [here in Slack](https://artsy.slack.com/archives/C03N12SR0RK/p1722611523473189) 🔒.