### PR TITLE
feat: partners support featured keywords for curated browsing

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14287,6 +14287,9 @@ type Partner implements Node {
     last: Int
     showID: String
   ): PartnerDocumentConnection
+
+  # Suggested filters for associated artworks
+  featuredKeywords: [String!]!
   featuredShow: Show
 
   # Artworks Elastic Search results

--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -165,7 +165,7 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
           GraphQLList(new GraphQLNonNull(GraphQLString))
         ),
         description: "Suggested filters for associated artworks",
-        resolve: ({ featured_keywords }) => featured_keywords,
+        resolve: ({ featured_keywords }) => featured_keywords ?? [],
       },
       formattedOpeningHours: {
         type: GraphQLString,

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -766,6 +766,13 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ default_profile_id }) => default_profile_id,
       },
       documentsConnection: PartnerDocumentsConnection,
+      featuredKeywords: {
+        type: new GraphQLNonNull(
+          GraphQLList(new GraphQLNonNull(GraphQLString))
+        ),
+        description: "Suggested filters for associated artworks",
+        resolve: ({ featured_keywords }) => featured_keywords ?? [],
+      },
       featuredShow: {
         type: ShowType,
         resolve: async ({ id }, _args, { partnerShowsLoader }) => {


### PR DESCRIPTION
Like, https://github.com/artsy/metaphysics/pull/5878, but for partners. Depends on https://github.com/artsy/gravity/pull/18014 (but can be merged whenever).
