### PR TITLE
feat(EMI-2015): Auction deadline collector signals

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4409,14 +4409,29 @@ type CollectorResume {
 
 # Collector signals available to the artwork
 type CollectorSignals {
-  # Lot bid count
+  # Bid count on lots open for bidding
   bidCount: Int
 
-  # Lot watcher count
+  # Live bidding has started on this lot's auction
+  liveBiddingStarted: Boolean
+
+  # Auction live bidding start time
+  liveStartAt: String
+
+  # Pending auction lot end time for bidding
+  lotClosesAt: String
+
+  # Lot watcher count on lots open for bidding
   lotWatcherCount: Int
+
+  # Auction lot bidding period extended due to last-minute bids
+  onlineBiddingExtended: Boolean
 
   # Partner offer available to collector
   partnerOffer: PartnerOfferToCollector
+
+  # Pending auction registration end time
+  registrationEndsAt: String
 }
 
 # Represents either an action or a potential failure

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -4630,6 +4630,11 @@ describe("Artwork type", () => {
           collectorSignals {
             bidCount
             lotWatcherCount
+            registrationEndsAt
+            lotClosesAt
+            liveBiddingStarted
+            liveStartAt
+            onlineBiddingExtended
             partnerOffer {
               endAt
             }
@@ -4637,129 +4642,318 @@ describe("Artwork type", () => {
         }
       }
     `
+    let supportingLoaders = {}
 
     beforeEach(() => {
-      context = {
-        userID: "testUser",
+      supportingLoaders = {
         mePartnerOffersLoader: jest.fn(),
         salesLoader: jest.fn(),
         saleArtworkLoader: jest.fn(),
+      }
+      context = {
+        userID: "testUser",
         artworkLoader: jest.fn(),
+        ...supportingLoaders,
       }
       context.artworkLoader.mockResolvedValue(artwork)
     })
 
-    it("fetches & returns the user-specific collector signals for a purchasable artwork if requested by a logged-in user", async () => {
-      mockIsFeatureFlagEnabled.mockReturnValue(true)
-
-      artwork.purchasable = true
-      artwork.sale_ids = []
-
-      context.userID = "user-id"
-      context.mePartnerOffersLoader.mockResolvedValue({
-        body: [{ endAt: "2023-01-01T00:00:00Z", active: true }],
+    describe("feature flags enabled", () => {
+      beforeEach(() => {
+        mockIsFeatureFlagEnabled.mockReturnValue(true)
       })
 
-      const data = await runQuery(query, context)
+      describe("purchasable artwork", () => {
+        beforeEach(() => {
+          artwork.purchasable = true
+          artwork.sale_ids = []
+        })
+        it("fetches & returns the user-specific collector signals for a purchasable artwork if requested by a logged-in user", async () => {
+          context.userID = "user-id"
+          context.mePartnerOffersLoader.mockResolvedValue({
+            body: [{ endAt: "2023-01-01T00:00:00Z", active: true }],
+          })
 
-      expect(context.mePartnerOffersLoader).toHaveBeenCalledWith({
-        artwork_id: "richard-prince-untitled-portrait",
-        size: 1,
-        sort: "-created_at",
+          const data = await runQuery(query, context)
+
+          expect(context.mePartnerOffersLoader).toHaveBeenCalledWith({
+            artwork_id: "richard-prince-untitled-portrait",
+            size: 1,
+            sort: "-created_at",
+          })
+
+          expect(data.artwork.collectorSignals.partnerOffer).toEqual({
+            endAt: "2023-01-01T00:00:00Z",
+          })
+        })
+
+        it("only returns active partner offer signal", async () => {
+          mockIsFeatureFlagEnabled.mockReturnValue(true)
+
+          artwork.purchasable = true
+          artwork.sale_ids = []
+
+          context.userID = "user-id"
+          context.mePartnerOffersLoader.mockResolvedValue({
+            body: [{ endAt: "2023-01-01T00:00:00Z", active: false }],
+          })
+
+          const data = await runQuery(query, context)
+
+          expect(data.artwork.collectorSignals.partnerOffer).toBeNull()
+        })
+
+        it("does not query partner offer signal loaders if the user is not logged in", async () => {
+          context.mePartnerOffersLoader = null
+
+          const data = await runQuery(query, context)
+
+          expect(data).toEqual({
+            artwork: {
+              collectorSignals: expect.objectContaining({
+                partnerOffer: null,
+              }),
+            },
+          })
+        })
       })
 
-      expect(data).toEqual({
-        artwork: {
-          collectorSignals: {
-            bidCount: null,
-            lotWatcherCount: null,
-            partnerOffer: {
-              endAt: "2023-01-01T00:00:00Z",
+      describe("auction artwork", () => {
+        beforeEach(() => {
+          artwork.purchasable = false
+          artwork.sale_ids = ["sale-id-not-auction", "sale-id-auction"]
+        })
+
+        const futureTime = moment().add(1, "day").toISOString()
+        const pastTime = moment().subtract(1, "day").toISOString()
+
+        it("returns the registration end time if it is in the future, `null` if in the past", async () => {
+          context.salesLoader.mockResolvedValue([
+            { id: "sale-id-auction", registration_ends_at: futureTime },
+          ])
+
+          context.saleArtworkLoader.mockResolvedValue({})
+
+          let data = await runQuery(query, context)
+
+          expect(data.artwork.collectorSignals.registrationEndsAt).toEqual(
+            futureTime
+          )
+
+          context.salesLoader.mockResolvedValue([
+            { id: "sale-id-auction", registration_ends_at: pastTime },
+          ])
+          context.saleArtworkLoader.mockResolvedValue({})
+
+          data = await runQuery(query, context)
+
+          expect(data.artwork.collectorSignals.registrationEndsAt).toEqual(null)
+        })
+
+        it("returns correct values for a lot with an end time and no extended bidding", async () => {
+          context.salesLoader.mockResolvedValue([{ id: "sale-id-auction" }])
+
+          context.saleArtworkLoader.mockResolvedValue({
+            end_at: futureTime,
+            extended_bidding_end_at: null,
+          })
+
+          const data = await runQuery(query, context)
+
+          expect(data.artwork.collectorSignals.lotClosesAt).toEqual(futureTime)
+          expect(data.artwork.collectorSignals.onlineBiddingExtended).toEqual(
+            false
+          )
+        })
+        it("returns correct values for a lot with an end time and extended bidding", async () => {
+          context.salesLoader.mockResolvedValue([{ id: "sale-id-auction" }])
+
+          context.saleArtworkLoader.mockResolvedValue({
+            end_at: pastTime,
+            extended_bidding_end_at: futureTime,
+          })
+
+          const data = await runQuery(query, context)
+
+          expect(data.artwork.collectorSignals.lotClosesAt).toEqual(futureTime)
+          expect(data.artwork.collectorSignals.onlineBiddingExtended).toEqual(
+            true
+          )
+        })
+        it("returns correct values for a lot with a future live start time", async () => {
+          context.salesLoader.mockResolvedValue([
+            { id: "sale-id-auction", live_start_at: futureTime },
+          ])
+
+          // live start at not set on sale artwork
+          context.saleArtworkLoader.mockResolvedValue({})
+          const data = await runQuery(query, context)
+
+          expect(data.artwork.collectorSignals.liveBiddingStarted).toEqual(
+            false
+          )
+          expect(data.artwork.collectorSignals.lotClosesAt).toEqual(null)
+          expect(data.artwork.collectorSignals.liveStartAt).toEqual(futureTime)
+        })
+        it("returns correct values for an auction that has started live bidding", async () => {
+          context.salesLoader.mockResolvedValue([
+            { id: "sale-id-auction", live_start_at: pastTime },
+          ])
+
+          // live start at not set on sale artwork
+          context.saleArtworkLoader.mockResolvedValue({})
+          const data = await runQuery(query, context)
+
+          expect(data.artwork.collectorSignals.liveBiddingStarted).toEqual(true)
+          expect(data.artwork.collectorSignals.lotClosesAt).toEqual(null)
+          expect(data.artwork.collectorSignals.liveStartAt).toEqual(null)
+        })
+        it("returns correct values for an auction which has ended", async () => {
+          context.salesLoader.mockResolvedValue([
+            { id: "sale-id-auction", ended_at: pastTime },
+          ])
+
+          context.saleArtworkLoader.mockResolvedValue({})
+
+          const data = await runQuery(query, context)
+
+          expect(data.artwork.collectorSignals.lotClosesAt).toEqual(null)
+        })
+
+        it("fetches & returns the lot watcher and bid count signals for an auction lot artwork if requested", async () => {
+          artwork.recent_saves_count = 123
+          context.salesLoader.mockResolvedValue([
+            {
+              id: "sale-id-auction",
+            },
+          ])
+
+          context.saleArtworkLoader.mockResolvedValue({
+            bidder_positions_count: 5,
+          })
+
+          const data = await runQuery(query, context)
+
+          expect(context.salesLoader).toHaveBeenCalledWith({
+            id: ["sale-id-not-auction", "sale-id-auction"],
+            is_auction: true,
+            live: true,
+          })
+
+          expect(context.saleArtworkLoader).toHaveBeenCalledWith({
+            saleArtworkId: "richard-prince-untitled-portrait",
+            saleId: "sale-id-auction",
+          })
+
+          expect(data.artwork.collectorSignals.bidCount).toEqual(5)
+          expect(data.artwork.collectorSignals.lotWatcherCount).toEqual(123)
+        })
+
+        it("does not query auction signal loaders if the artwork has no sale_ids", async () => {
+          artwork.sale_ids = []
+
+          const data = await runQuery(query, context)
+
+          expect(context.salesLoader).not.toHaveBeenCalled()
+          expect(context.saleArtworkLoader).not.toHaveBeenCalled()
+
+          expect(data).toEqual({
+            artwork: {
+              collectorSignals: expect.objectContaining({
+                bidCount: null,
+                lotWatcherCount: null,
+                partnerOffer: null,
+              }),
+            },
+          })
+        })
+      })
+
+      it("does not query partner offer signal loaders if the artwork is not purchasable", async () => {
+        artwork.purchasable = false
+        context.salesLoader.mockResolvedValue([])
+
+        const data = await runQuery(query, context)
+
+        expect(context.mePartnerOffersLoader).not.toHaveBeenCalled()
+
+        expect(data).toEqual({
+          artwork: {
+            collectorSignals: expect.objectContaining({
+              partnerOffer: null,
+            }),
+          },
+        })
+      })
+
+      it("does not query partner offer signal loaders if the partnerOffer field is not requested", async () => {
+        context.salesLoader.mockResolvedValue([])
+
+        const noPartnerOfferQuery = `
+          
+          {
+            artwork(id: "richard-prince-untitled-portrait") {
+              collectorSignals {
+                bidCount
+              }
+            }
+          }`
+
+        const data = await runQuery(noPartnerOfferQuery, context)
+
+        expect(context.mePartnerOffersLoader).not.toHaveBeenCalled()
+
+        expect(data).toEqual({
+          artwork: {
+            collectorSignals: {
+              bidCount: null,
             },
           },
-        },
-      })
-    })
-    it("only returns active partner offer signal", async () => {
-      mockIsFeatureFlagEnabled.mockReturnValue(true)
-
-      artwork.purchasable = true
-      artwork.sale_ids = []
-
-      context.userID = "user-id"
-      context.mePartnerOffersLoader.mockResolvedValue({
-        body: [{ endAt: "2023-01-01T00:00:00Z", active: false }],
+        })
       })
 
-      const data = await runQuery(query, context)
-
-      expect(data).toEqual({
-        artwork: {
-          collectorSignals: {
-            bidCount: null,
-            lotWatcherCount: null,
-            partnerOffer: null,
-          },
-        },
-      })
-    })
-
-    it("fetches & returns the auction collector signals for an artwork if requested", async () => {
-      mockIsFeatureFlagEnabled.mockReturnValue(true)
-
-      artwork.recent_saves_count = 123
-      context.salesLoader.mockResolvedValue([
+      it("does not query auction loaders if the partnerOffer field is not requested", async () => {
+        const noAuctionFieldsQuery = `
+        
         {
-          id: "sale1",
-        },
-      ])
+          artwork(id: "richard-prince-untitled-portrait") {
+            collectorSignals {
+              partnerOffer { endAt }
+            }
+          }
+        }`
 
-      context.saleArtworkLoader.mockResolvedValue({
-        bidder_positions_count: 5,
-      })
+        const data = await runQuery(noAuctionFieldsQuery, context)
 
-      const data = await runQuery(query, context)
+        expect(context.salesLoader).not.toHaveBeenCalled()
 
-      expect(context.salesLoader).toHaveBeenCalledWith({
-        id: ["sale-id-not-auction", "sale-id-auction"],
-        is_auction: true,
-        live: true,
-      })
-
-      expect(context.saleArtworkLoader).toHaveBeenCalledWith({
-        saleArtworkId: "richard-prince-untitled-portrait",
-        saleId: "sale1",
-      })
-
-      expect(data).toEqual({
-        artwork: {
-          collectorSignals: {
-            bidCount: 5,
-            lotWatcherCount: 123,
-            partnerOffer: null,
+        expect(data).toEqual({
+          artwork: {
+            collectorSignals: {
+              partnerOffer: null,
+            },
           },
-        },
+        })
       })
-    })
-    it("does not query signal loaders if the artwork has no sale_ids", async () => {
-      mockIsFeatureFlagEnabled.mockReturnValue(true)
+      it("does not use any loaders if feature flag is disabled", async () => {
+        mockIsFeatureFlagEnabled.mockReturnValue(false)
 
-      artwork.sale_ids = []
-      artwork.purchasable = false
+        const data = await runQuery(query, context)
 
-      const data = await runQuery(query, context)
+        Object.values(supportingLoaders).forEach((loader) =>
+          expect(loader).not.toHaveBeenCalled()
+        )
 
-      expect(context.salesLoader).not.toHaveBeenCalled()
-      expect(context.mePartnerOffersLoader).not.toHaveBeenCalled()
-
-      expect(data).toEqual({
-        artwork: {
-          collectorSignals: {
-            bidCount: null,
-            lotWatcherCount: null,
-            partnerOffer: null,
-          },
-        },
+        expect(data.artwork.collectorSignals).toEqual({
+          bidCount: null,
+          lotWatcherCount: null,
+          registrationEndsAt: null,
+          lotClosesAt: null,
+          liveStartAt: null,
+          liveBiddingStarted: null,
+          onlineBiddingExtended: null,
+          partnerOffer: null,
+        })
       })
     })
   })

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -1,8 +1,25 @@
-import { GraphQLFieldConfig } from "graphql"
+import { GraphQLBoolean, GraphQLFieldConfig, GraphQLString } from "graphql"
 import { GraphQLInt, GraphQLObjectType } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { PartnerOfferToCollectorType } from "../partnerOfferToCollector"
 import { isFeatureFlagEnabled } from "lib/featureFlags"
+import { some } from "lodash"
+import { isFieldRequested } from "lib/isFieldRequested"
+
+const NOW = new Date()
+
+interface ActiveLotData {
+  saleArtwork: {
+    bidder_positions_count: number
+    extended_bidding_end_at?: string
+    end_at?: string
+  }
+  sale: {
+    registration_ends_at: string
+    live_start_at: string
+    ended_at?: string
+  }
+}
 
 export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
   type: new GraphQLObjectType({
@@ -11,11 +28,32 @@ export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
     fields: {
       bidCount: {
         type: GraphQLInt,
-        description: "Lot bid count",
+        description: "Bid count on lots open for bidding",
       },
       lotWatcherCount: {
         type: GraphQLInt,
-        description: "Lot watcher count",
+        description: "Lot watcher count on lots open for bidding",
+      },
+      registrationEndsAt: {
+        type: GraphQLString,
+        description: "Pending auction registration end time",
+      },
+      lotClosesAt: {
+        type: GraphQLString,
+        description: "Pending auction lot end time for bidding",
+      },
+      onlineBiddingExtended: {
+        type: GraphQLBoolean,
+        description:
+          "Auction lot bidding period extended due to last-minute bids",
+      },
+      liveStartAt: {
+        type: GraphQLString,
+        description: "Auction live bidding start time",
+      },
+      liveBiddingStarted: {
+        type: GraphQLBoolean,
+        description: "Live bidding has started on this lot's auction",
       },
       partnerOffer: {
         type: PartnerOfferToCollectorType,
@@ -25,8 +63,12 @@ export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
   }),
   description: "Collector signals on artwork",
 
-  resolve: async (artwork, {}, ctx) => {
-    const collectorSignals = await collectorSignalsLoader(artwork, ctx)
+  resolve: async (artwork, {}, ctx, resolveInfo) => {
+    const collectorSignals = await collectorSignalsLoader(
+      artwork,
+      ctx,
+      resolveInfo
+    )
     return collectorSignals
   },
 }
@@ -35,13 +77,36 @@ interface CollectorSignals {
   bidCount?: number
   lotWatcherCount?: number
   partnerOffer?: { endAt: string }
+  registrationEndsAt?: string
+  liveStartAt?: string
+  liveBiddingStarted?: boolean
+  onlineBiddingExtended?: boolean
+  lotClosesAt?: string
 }
+
+const AUCTION_FIELDS = [
+  "bidCount",
+  "lotWatcherCount",
+  "registrationEndsAt",
+  "liveStartAt",
+  "liveBiddingStarted",
+  "lotClosesAt",
+  "onlineBiddingExtended",
+]
 
 const collectorSignalsLoader = async (
   artwork,
-  ctx
+  ctx,
+  resolveInfo
 ): Promise<CollectorSignals> => {
-  let bidCount, lotWatcherCount, partnerOffer
+  let bidCount,
+    lotWatcherCount,
+    partnerOffer,
+    registrationEndsAt,
+    liveStartAt,
+    liveBiddingStarted,
+    lotClosesAt,
+    onlineBiddingExtended
 
   const artworkId = artwork.id
 
@@ -59,9 +124,18 @@ const collectorSignalsLoader = async (
     unleashContext
   )
 
+  const auctionSignalsRequested =
+    auctionsCollectorSignalsEnabled &&
+    isInSale &&
+    some(AUCTION_FIELDS, (key) => isFieldRequested(key, resolveInfo))
+
+  const partnerOfferSignalsRequested =
+    partnerOfferCollectorSignalsEnabled &&
+    isFieldRequested("partnerOffer", resolveInfo)
+
   // Handle signals for auction artworks
-  if (isInSale && auctionsCollectorSignalsEnabled) {
-    const activeSaleArtwork = await getActiveSaleArtwork(
+  if (auctionSignalsRequested) {
+    const activeLotData = await getActiveSaleArtwork(
       {
         artworkId,
         saleIds: artwork.sale_ids,
@@ -69,18 +143,55 @@ const collectorSignalsLoader = async (
       ctx
     )
 
-    if (activeSaleArtwork) {
+    const activeAuctionLot = activeLotData && !activeLotData.sale.ended_at
+    if (activeAuctionLot) {
+      const { saleArtwork, sale } = activeLotData
+
       if (artwork.recent_saves_count) {
         lotWatcherCount = artwork.recent_saves_count
       }
-      if (activeSaleArtwork.bidder_positions_count) {
-        bidCount = activeSaleArtwork.bidder_positions_count
+
+      if (saleArtwork.bidder_positions_count) {
+        bidCount = saleArtwork.bidder_positions_count
+      }
+
+      const registrationEndAtDate =
+        sale.registration_ends_at && new Date(sale.registration_ends_at)
+
+      if (registrationEndAtDate && registrationEndAtDate > NOW) {
+        registrationEndsAt = registrationEndAtDate.toISOString()
+      }
+
+      const saleLiveStartAtDate =
+        sale.live_start_at && new Date(sale.live_start_at)
+      if (saleLiveStartAtDate) {
+        if (saleLiveStartAtDate > NOW) {
+          liveBiddingStarted = false
+          liveStartAt = saleLiveStartAtDate.toISOString()
+        } else {
+          liveBiddingStarted = true
+        }
+      }
+
+      const extendedBiddingEndAtDate =
+        saleArtwork.extended_bidding_end_at &&
+        new Date(saleArtwork.extended_bidding_end_at)
+
+      if (extendedBiddingEndAtDate && extendedBiddingEndAtDate > NOW) {
+        onlineBiddingExtended = true
+        lotClosesAt = extendedBiddingEndAtDate.toISOString()
+      } else {
+        onlineBiddingExtended = false
+
+        const lotClosesAtDate =
+          saleArtwork.end_at && new Date(saleArtwork.end_at)
+        lotClosesAt = lotClosesAtDate && lotClosesAtDate.toISOString()
       }
     }
   }
 
   // Handle signals for non-auction artworks
-  if (artwork.purchasable && partnerOfferCollectorSignalsEnabled) {
+  if (artwork.purchasable && partnerOfferSignalsRequested) {
     if (ctx.mePartnerOffersLoader) {
       const partnerOffers = await ctx.mePartnerOffersLoader({
         artwork_id: artworkId,
@@ -95,20 +206,23 @@ const collectorSignalsLoader = async (
   }
 
   return {
+    // auction signals
     bidCount,
+    liveBiddingStarted,
+    liveStartAt,
+    lotClosesAt,
     lotWatcherCount,
+    onlineBiddingExtended,
+    registrationEndsAt,
+    // purchasable signals
     partnerOffer,
   }
-}
-
-interface SaleArtwork {
-  bidder_positions_count: number
 }
 
 const getActiveSaleArtwork = async (
   { artworkId, saleIds },
   ctx
-): Promise<SaleArtwork | null> => {
+): Promise<ActiveLotData | null> => {
   if (!saleIds?.length) {
     return null
   }
@@ -118,7 +232,7 @@ const getActiveSaleArtwork = async (
     is_auction: true,
     live: true,
   })
-  const activeAuction = sales[0]
+  const activeAuction = sales?.[0]
 
   if (!activeAuction) {
     return null
@@ -130,5 +244,5 @@ const getActiveSaleArtwork = async (
       saleArtworkId: artworkId,
     })) ?? null
 
-  return saleArtwork
+  return { saleArtwork, sale: activeAuction }
 }


### PR DESCRIPTION
This PR completes [EMI-2015] by adding auction deadline values to the CollectorSignals type.

Only future dates are included for the date values. I have an alternative idea for the interface, but this essentially collects data that we normally check from multiple different sources - it's mostly up to clients to choose which to prioritize based on presence.

- [x] Needs tests

[EMI-2015]: https://artsyproduct.atlassian.net/browse/EMI-2015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ