### PR TITLE
feat: add similar to works you viewed resolver

### DIFF
--- a/src/schema/v2/homeView/__tests__/HomeView.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeView.test.ts
@@ -6,7 +6,7 @@ describe("homeView", () => {
     const query = gql`
       {
         homeView {
-          sectionsConnection(first: 2) {
+          sectionsConnection(first: 3) {
             edges {
               node {
                 __typename
@@ -31,7 +31,7 @@ describe("homeView", () => {
     it("returns a connection of home view sections", async () => {
       const { homeView } = await runQuery(query, context)
 
-      expect(homeView.sectionsConnection.edges).toHaveLength(2)
+      expect(homeView.sectionsConnection.edges).toHaveLength(3)
     })
 
     it("returns requested data for each section", async () => {
@@ -40,6 +40,14 @@ describe("homeView", () => {
       expect(homeView.sectionsConnection).toMatchInlineSnapshot(`
         Object {
           "edges": Array [
+            Object {
+              "node": Object {
+                "__typename": "ArtworksRailHomeViewSection",
+                "component": Object {
+                  "title": "Similar to Works You’ve Viewed",
+                },
+              },
+            },
             Object {
               "node": Object {
                 "__typename": "ArtworksRailHomeViewSection",

--- a/src/schema/v2/homeView/artworkResolvers.ts
+++ b/src/schema/v2/homeView/artworkResolvers.ts
@@ -4,10 +4,40 @@ import { artworksForUser } from "../artworksForUser"
 import { RecentlyViewedArtworks } from "../me/recentlyViewedArtworks"
 import { getCuratedArtists } from "../artists/curatedTrending"
 import { connectionFromArray } from "graphql-relay"
+import { SimilarToRecentlyViewed } from "../me/similarToRecentlyViewed"
 
 /*
  * Resolvers for home view artwork sections
  */
+
+export const SimilarToRecentlyViewedArtworksResolver: GraphQLFieldResolver<
+  any,
+  ResolverContext
+> = async (parent, args, context, info) => {
+  if (!context.meLoader) return []
+
+  const { recently_viewed_artwork_ids, id } = await context.meLoader()
+
+  if (recently_viewed_artwork_ids.length === 0) {
+    return []
+  }
+  const recentlyViewedIds = recently_viewed_artwork_ids.slice(0, 7)
+
+  const result = await SimilarToRecentlyViewed.resolve!(
+    {
+      ...parent,
+      recently_viewed_artwork_ids: recentlyViewedIds,
+    },
+    args,
+    {
+      ...context,
+      userID: id,
+    },
+    info
+  )
+
+  return result
+}
 
 export const NewWorksForYouResolver: GraphQLFieldResolver<
   any,

--- a/src/schema/v2/homeView/artworkResolvers.ts
+++ b/src/schema/v2/homeView/artworkResolvers.ts
@@ -1,9 +1,9 @@
 import type { GraphQLFieldResolver } from "graphql"
+import { connectionFromArray } from "graphql-relay"
 import type { ResolverContext } from "types/graphql"
+import { getCuratedArtists } from "../artists/curatedTrending"
 import { artworksForUser } from "../artworksForUser"
 import { RecentlyViewedArtworks } from "../me/recentlyViewedArtworks"
-import { getCuratedArtists } from "../artists/curatedTrending"
-import { connectionFromArray } from "graphql-relay"
 import { SimilarToRecentlyViewed } from "../me/similarToRecentlyViewed"
 
 /*
@@ -16,27 +16,19 @@ export const SimilarToRecentlyViewedArtworksResolver: GraphQLFieldResolver<
 > = async (parent, args, context, info) => {
   if (!context.meLoader) return []
 
-  const { recently_viewed_artwork_ids, id } = await context.meLoader()
+  const { recently_viewed_artwork_ids } = await context.meLoader()
 
   if (recently_viewed_artwork_ids.length === 0) {
     return []
   }
   const recentlyViewedIds = recently_viewed_artwork_ids.slice(0, 7)
 
-  const result = await SimilarToRecentlyViewed.resolve!(
-    {
-      ...parent,
-      recently_viewed_artwork_ids: recentlyViewedIds,
-    },
+  return SimilarToRecentlyViewed.resolve!(
+    { ...parent, recently_viewed_artwork_ids: recentlyViewedIds },
     args,
-    {
-      ...context,
-      userID: id,
-    },
+    context,
     info
   )
-
-  return result
 }
 
 export const NewWorksForYouResolver: GraphQLFieldResolver<

--- a/src/schema/v2/homeView/getSectionsForUser.ts
+++ b/src/schema/v2/homeView/getSectionsForUser.ts
@@ -4,6 +4,7 @@ import {
   HomeViewSection,
   NewWorksForYou,
   RecentlyViewedArtworks,
+  SimilarToRecentlyViewedArtworks,
   TrendingArtists,
 } from "./sections"
 
@@ -25,11 +26,13 @@ export async function getSectionsForUser(
     sections = [
       RecentlyViewedArtworks,
       TrendingArtists,
+      SimilarToRecentlyViewedArtworks,
       AuctionLotsForYou,
       NewWorksForYou,
     ]
   } else {
     sections = [
+      SimilarToRecentlyViewedArtworks,
       NewWorksForYou,
       AuctionLotsForYou,
       TrendingArtists,

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -1,11 +1,12 @@
 import { GraphQLFieldResolver } from "graphql"
+import { ResolverContext } from "types/graphql"
 import {
   AuctionLotsForYouResolver,
   NewWorksForYouResolver,
   RecentlyViewedArtworksResolver,
+  SimilarToRecentlyViewedArtworksResolver,
   SuggestedArtistsResolver,
 } from "./artworkResolvers"
-import { ResolverContext } from "types/graphql"
 
 export type HomeViewSection = {
   id: string
@@ -16,6 +17,14 @@ export type HomeViewSection = {
   resolver?: GraphQLFieldResolver<any, ResolverContext>
 }
 
+export const SimilarToRecentlyViewedArtworks: HomeViewSection = {
+  id: "home-view-section-similar-to-recently-viewed-artworks",
+  type: "ArtworksRailHomeViewSection",
+  component: {
+    title: "Similar to Works You’ve Viewed",
+  },
+  resolver: SimilarToRecentlyViewedArtworksResolver,
+}
 export const RecentlyViewedArtworks: HomeViewSection = {
   id: "home-view-section-recently-viewed-artworks",
   type: "ArtworksRailHomeViewSection",
@@ -57,6 +66,7 @@ const sections: HomeViewSection[] = [
   AuctionLotsForYou,
   NewWorksForYou,
   TrendingArtists,
+  SimilarToRecentlyViewedArtworks,
 ]
 
 export const registry = sections.reduce(


### PR DESCRIPTION
This PR resolves [ONYX-1173]


This PR adds a new artwork home section (**Similar to Works You Viewed**) to the list of `Sections` and exposes it to client app.

<img width="1447" alt="Screenshot 2024-08-07 at 10 35 34" src="https://github.com/user-attachments/assets/97cf7de6-6159-4402-952b-5b4c4ce98c60">

The process to add this was the following:
- [x] Add section to `sections.ts`
- [x] Expose the section to users and define its position in `getSectionsForUser.ts`
- [x] Define resolver in `ArtworkResolvers.ts`



[ONYX-1173]: https://artsyproduct.atlassian.net/browse/ONYX-1173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ