### PR TITLE
fix: ArtworksForUser pagination logic

### DIFF
--- a/src/schema/v2/artworksForUser/__tests__/artworksForUser.test.ts
+++ b/src/schema/v2/artworksForUser/__tests__/artworksForUser.test.ts
@@ -1,6 +1,6 @@
-import { runAuthenticatedQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
 import { extractNodes } from "lib/helpers"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
 
 const buildQuery = (args: any = {}) => {
   const first = args.first || 10
@@ -11,6 +11,10 @@ const buildQuery = (args: any = {}) => {
   const query = gql`
       {
         artworksForUser(first: ${first}, includeBackfill: ${includeBackfill}, userId: "${userId}", excludeDislikedArtworks: ${excludeDislikedArtworks}) {
+          pageInfo {
+            hasPreviousPage
+            hasNextPage
+          }
           edges {
             node {
               title
@@ -65,6 +69,13 @@ describe("artworksForUser", () => {
 
       const artworks = extractNodes(response.artworksForUser)
       expect(artworks.length).toEqual(0)
+
+      expect(response.artworksForUser.pageInfo).toMatchInlineSnapshot(`
+        Object {
+          "hasNextPage": false,
+          "hasPreviousPage": false,
+        }
+      `)
     })
   })
 
@@ -81,6 +92,13 @@ describe("artworksForUser", () => {
       const { artworksForUser } = await runAuthenticatedQuery(query, context)
       const artworks = extractNodes(artworksForUser)
       expect(artworks.length).toEqual(0)
+
+      expect(artworksForUser.pageInfo).toMatchInlineSnapshot(`
+        Object {
+          "hasNextPage": false,
+          "hasPreviousPage": false,
+        }
+      `)
     })
   })
 
@@ -99,6 +117,13 @@ describe("artworksForUser", () => {
       const { artworksForUser } = await runAuthenticatedQuery(query, context)
       const artworks = extractNodes(artworksForUser)
       expect(artworks.length).toEqual(1)
+
+      expect(artworksForUser.pageInfo).toMatchInlineSnapshot(`
+        Object {
+          "hasNextPage": false,
+          "hasPreviousPage": false,
+        }
+      `)
     })
   })
 
@@ -117,6 +142,13 @@ describe("artworksForUser", () => {
       const { artworksForUser } = await runAuthenticatedQuery(query, context)
       const artworks = extractNodes(artworksForUser)
       expect(artworks.length).toEqual(1)
+
+      expect(artworksForUser.pageInfo).toMatchInlineSnapshot(`
+        Object {
+          "hasNextPage": false,
+          "hasPreviousPage": false,
+        }
+      `)
     })
   })
 
@@ -139,6 +171,13 @@ describe("artworksForUser", () => {
       const { artworksForUser } = await runAuthenticatedQuery(query, context)
       const artworks = extractNodes(artworksForUser)
       expect(artworks.length).toEqual(1)
+
+      expect(artworksForUser.pageInfo).toMatchInlineSnapshot(`
+        Object {
+          "hasNextPage": true,
+          "hasPreviousPage": false,
+        }
+      `)
     })
   })
 
@@ -161,6 +200,13 @@ describe("artworksForUser", () => {
       const { artworksForUser } = await runAuthenticatedQuery(query, context)
       const artworks = extractNodes(artworksForUser)
       expect(artworks.length).toEqual(2)
+
+      expect(artworksForUser.pageInfo).toMatchInlineSnapshot(`
+        Object {
+          "hasNextPage": false,
+          "hasPreviousPage": false,
+        }
+      `)
     })
   })
 
@@ -179,6 +225,13 @@ describe("artworksForUser", () => {
       const { artworksForUser } = await runAuthenticatedQuery(query, context)
       const artworks = extractNodes(artworksForUser)
       expect(artworks.length).toEqual(1)
+
+      expect(artworksForUser.pageInfo).toMatchInlineSnapshot(`
+        Object {
+          "hasNextPage": false,
+          "hasPreviousPage": false,
+        }
+      `)
     })
   })
 

--- a/src/schema/v2/artworksForUser/artworksForUser.ts
+++ b/src/schema/v2/artworksForUser/artworksForUser.ts
@@ -19,8 +19,6 @@ import {
   getNewForYouArtworks,
 } from "./helpers"
 
-const MAX_ARTWORKS = 100
-
 export const artworksForUser: GraphQLFieldConfig<void, ResolverContext> = {
   description: "A connection of artworks for a user.",
   type: artworkConnection.connectionType,

--- a/src/schema/v2/artworksForUser/artworksForUser.ts
+++ b/src/schema/v2/artworksForUser/artworksForUser.ts
@@ -47,7 +47,7 @@ export const artworksForUser: GraphQLFieldConfig<void, ResolverContext> = {
     const { page, size, offset } = gravityArgs
 
     const newForYouArtworkIds = await getNewForYouArtworkIDs(
-      { ...args, ...gravityArgs },
+      gravityArgs,
       context
     )
 

--- a/src/schema/v2/artworksForUser/helpers.ts
+++ b/src/schema/v2/artworksForUser/helpers.ts
@@ -1,7 +1,10 @@
-import { ResolverContext } from "types/graphql"
-import { CursorPageable } from "relay-cursor-paging"
-import { convertConnectionArgsToGravityArgs, extractNodes } from "lib/helpers"
 import gql from "lib/gql"
+import { convertConnectionArgsToGravityArgs, extractNodes } from "lib/helpers"
+import { CursorPageable } from "relay-cursor-paging"
+import { ResolverContext } from "types/graphql"
+
+// Because we're currently not able to use pagination with the Vortex API GraphQL endpoint.
+const MAX_ARTWORKS = 50
 
 export const getNewForYouArtworkIDs = async (
   args: CursorPageable,
@@ -53,13 +56,11 @@ export const getNewForYouArtworkIDs = async (
     ? `maxWorksPerArtist: ${args.maxWorksPerArtist}`
     : ""
 
-  const first = args.first + args.excludeArtworkIds.length
-
   const query = {
     query: gql`
         query newForYouRecommendationsQuery {
           newForYouRecommendations(
-            first: ${first}
+            first: ${MAX_ARTWORKS}
             ${userIdArgument}
             ${versionArgument}
             ${maxWorksPerArtistArgument}


### PR DESCRIPTION
Addresses [ONYX-1174](https://artsyproduct.atlassian.net/browse/ONYX-1174)

- [Slack thread with context](https://artsy.slack.com/archives/C05EQL4R5N0/p1722948565984559)

## Description

This fixes the pagination logic for `ArtworksForUser` by overfetching recommended artwork IDs and slicing these IDs after adding backfill and excluding disliked artworks.

[ONYX-1174]: https://artsyproduct.atlassian.net/browse/ONYX-1174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ