### PR TITLE
feat: Expose external submission ID in ArtworkConsignmentSubmission

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2790,6 +2790,7 @@ type ArtworkConsignmentSubmission {
   # Button label visible to the user.
   buttonLabel: String
   displayText: String @deprecated(reason: "Prefer `stateLabel` field.")
+  externalID: String
   inProgress: Boolean
   internalID: String
   isSold: Boolean

--- a/src/schema/v2/artwork/__tests__/artworkConsignmentSubmissionType.test.ts
+++ b/src/schema/v2/artwork/__tests__/artworkConsignmentSubmissionType.test.ts
@@ -7,6 +7,7 @@ describe("ArtworkConsignmentSubmissionType", () => {
     consignmentSubmission: {
       state: "draft",
       id: "someID",
+      externalId: "someExternalID",
     },
   }
 
@@ -28,13 +29,17 @@ describe("ArtworkConsignmentSubmissionType", () => {
           slug
           consignmentSubmission {
             internalID
+            externalID
           }
         }
       }
     `
-    it("returns internalID if present", async () => {
+    it("returns IDs if present", async () => {
       const data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.internalID).toEqual("someID")
+      expect(data.artwork.consignmentSubmission.externalID).toEqual(
+        "someExternalID"
+      )
     })
   })
 

--- a/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
+++ b/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
@@ -33,6 +33,10 @@ const ArtworkConsignmentSubmissionType = new GraphQLObjectType<
         type: GraphQLString,
         resolve: ({ id }) => id,
       },
+      externalID: {
+        type: GraphQLString,
+        resolve: ({ externalId }) => externalId,
+      },
       displayText: {
         type: GraphQLString,
         deprecationReason: "Prefer `stateLabel` field.",

--- a/src/schema/v2/me/loadSubmissions.ts
+++ b/src/schema/v2/me/loadSubmissions.ts
@@ -13,6 +13,7 @@ export const loadSubmissions = async (
             edges {
               node {
                 id
+                externalId
                 state
                 saleState
                 rejectionReason


### PR DESCRIPTION
## Description

Expose external submission ID in ArtworkConsignmentSubmission to be able to link to the correct step in the Sell flow (https://github.com/artsy/force/pull/14297).