### PR TITLE
fix: Put a cap on amount of collector profile returned from the connection…

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14497,7 +14497,8 @@ type PartnerAlertsEdge {
     before: String
     first: Int
     last: Int
-    totalCount: Boolean
+    page: Int
+    size: Int
   ): PartnerCollectorProfilesConnection
 
   # A cursor for use in pagination

--- a/src/schema/v2/Alerts/index.ts
+++ b/src/schema/v2/Alerts/index.ts
@@ -518,8 +518,11 @@ export const PartnerAlertsEdgeFields = {
   collectorProfilesConnection: {
     type: PartnerCollectorProfilesConnectionType,
     args: pageable({
-      totalCount: {
-        type: GraphQLBoolean,
+      page: {
+        type: GraphQLInt,
+      },
+      size: {
+        type: GraphQLInt,
       },
     }),
     resolve: async (parent, args, { partnerCollectorProfilesLoader }) => {
@@ -533,6 +536,9 @@ export const PartnerAlertsEdgeFields = {
           "partnerId or userIds is undefined in the parent object"
         )
       }
+
+      // Make API call to fetch the first X collector profile records
+      const slicedUserIds = parent.user_ids.slice(0, 20)
 
       type GravityArgs = {
         page: number
@@ -549,18 +555,17 @@ export const PartnerAlertsEdgeFields = {
         offset,
         total_count: true,
         partner_id: parent.partner_id,
-        user_ids: parent.user_ids,
+        user_ids: slicedUserIds,
       }
 
-      const { body, headers } = await partnerCollectorProfilesLoader(
-        gravityArgs
-      )
+      const { body } = await partnerCollectorProfilesLoader(gravityArgs)
 
       const collectorProfiles = body.flatMap((item) =>
         item.collector_profile ? [item.collector_profile].flat() : []
       )
 
-      const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+      const totalCount = parent.user_ids.length
+
       return paginationResolver({
         totalCount,
         offset,

--- a/src/schema/v2/Alerts/index.ts
+++ b/src/schema/v2/Alerts/index.ts
@@ -181,6 +181,8 @@ type GravitySearchCriteriaJSON = {
   search_criteria_id: string
 }
 
+const DEFAULT_COLLECTOR_PROFILES_BATCH_SIZE = 20
+
 export const AlertType = new GraphQLObjectType<
   GravitySearchCriteriaJSON,
   ResolverContext
@@ -538,7 +540,8 @@ export const PartnerAlertsEdgeFields = {
       }
 
       // Make API call to fetch the first X collector profile records
-      const slicedUserIds = parent.user_ids.slice(0, 20)
+      const first = args.first ?? DEFAULT_COLLECTOR_PROFILES_BATCH_SIZE
+      const slicedUserIds = parent.user_ids.slice(0, first)
 
       type GravityArgs = {
         page: number


### PR DESCRIPTION
…, allow for pagination args to be passed in from client

Reworks `collectorProfilesConnection` under `Partner` type to limit the about of collector profiles we return to the client 

We were facing some performance issues on really large datasets
<img width="1250" alt="Screenshot 2024-08-07 at 9 41 00 AM" src="https://github.com/user-attachments/assets/06d59d67-7c88-4b2f-bc45-cffa91dd34af">

---

Downstream Gravity would return this exception
<img width="1166" alt="Screenshot 2024-08-07 at 10 51 19 AM" src="https://github.com/user-attachments/assets/fa83edc1-d383-4653-b73c-c1d430e9fcb5">

---

Limits to 20 and exposes paginations params so they can be passed downstream
and adjusts `totalCount` to be a count of the full data set


<img width="1237" alt="Screenshot 2024-08-07 at 10 42 11 AM" src="https://github.com/user-attachments/assets/307ae6f1-e56a-4bd3-968c-a52fff5355f3">

