### PR TITLE
feat: add latest articles section

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1501,6 +1501,25 @@ type ArticleUnpublishedArtworkPartner {
   slug: String
 }
 
+# An articles rail section in the home view
+type ArticlesRailHomeViewSection implements GenericHomeViewSection & Node {
+  articlesConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArticleConnection!
+
+  # The component that is prescribed for this section
+  component: HomeViewComponent
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+}
+
 type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Searchable {
   alertsConnection(
     after: String
@@ -11017,7 +11036,8 @@ enum HomeViewComponentBackgroundImageURLVersion {
 }
 
 union HomeViewSection =
-    ArtistsRailHomeViewSection
+    ArticlesRailHomeViewSection
+  | ArtistsRailHomeViewSection
   | ArtworksRailHomeViewSection
   | FairsRailHomeViewSection
   | HeroUnitsHomeViewSection

--- a/src/schema/v2/homeView/HomeViewSection.ts
+++ b/src/schema/v2/homeView/HomeViewSection.ts
@@ -14,6 +14,7 @@ import { artworkConnection } from "../artwork"
 import { artistsConnection } from "../artists"
 import { heroUnitsConnection } from "../HeroUnit/heroUnitsConnection"
 import { fairsConnection } from "../fairs"
+import ArticlesConnection from "../articlesConnection"
 
 // section interface
 
@@ -109,15 +110,34 @@ const FairsRailHomeViewSectionType = new GraphQLObjectType<
   },
 })
 
+const ArticlesRailHomeViewSectionType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "ArticlesRailHomeViewSection",
+  description: "An articles rail section in the home view",
+  interfaces: [GenericHomeViewSectionInterface, NodeInterface],
+  fields: {
+    ...standardSectionFields,
+
+    articlesConnection: {
+      type: new GraphQLNonNull(ArticlesConnection.type),
+      args: pageable({}),
+      resolve: (parent, ...rest) =>
+        parent.resolver ? parent.resolver(parent, ...rest) : [],
+    },
+  },
+})
 // the Section union type of all concrete sections
 
 export const HomeViewSectionType = new GraphQLUnionType({
   name: "HomeViewSection",
   types: [
-    ArtworksRailHomeViewSectionType,
+    ArticlesRailHomeViewSectionType,
     ArtistsRailHomeViewSectionType,
-    HeroUnitsHomeViewSectionType,
+    ArtworksRailHomeViewSectionType,
     FairsRailHomeViewSectionType,
+    HeroUnitsHomeViewSectionType,
   ],
   resolveType: (value) => {
     return value.type

--- a/src/schema/v2/homeView/__tests__/HomeView.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeView.test.ts
@@ -85,6 +85,14 @@ describe("homeView", () => {
             },
             Object {
               "node": Object {
+                "__typename": "ArticlesRailHomeViewSection",
+                "component": Object {
+                  "title": "Artsy Editorial",
+                },
+              },
+            },
+            Object {
+              "node": Object {
                 "__typename": "ArtistsRailHomeViewSection",
                 "component": Object {
                   "title": "Recommended Artists",

--- a/src/schema/v2/homeView/articlesResolvers.ts
+++ b/src/schema/v2/homeView/articlesResolvers.ts
@@ -1,0 +1,12 @@
+import type { GraphQLFieldResolver } from "graphql"
+import type { ResolverContext } from "types/graphql"
+import ArticlesConnection from "../articlesConnection"
+
+/*
+ * Resolvers for home view articels sections
+ */
+
+export const LatestArticlesResolvers: GraphQLFieldResolver<
+  any,
+  ResolverContext
+> = ArticlesConnection.resolve!

--- a/src/schema/v2/homeView/getSectionsForUser.ts
+++ b/src/schema/v2/homeView/getSectionsForUser.ts
@@ -5,6 +5,7 @@ import {
   FeaturedFairs,
   HeroUnits,
   HomeViewSection,
+  LatestArticles,
   NewWorksForYou,
   NewWorksFromGalleriesYouFollow,
   RecentlyViewedArtworks,
@@ -29,6 +30,7 @@ export async function getSectionsForUser(
 
   if (me.type === "Admin") {
     sections = [
+      LatestArticles,
       RecentlyViewedArtworks,
       TrendingArtists,
       FeaturedFairs,
@@ -48,6 +50,7 @@ export async function getSectionsForUser(
       NewWorksForYou,
       HeroUnits,
       AuctionLotsForYou,
+      LatestArticles,
       RecommendedArtists,
       TrendingArtists,
       NewWorksFromGalleriesYouFollow,

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -18,6 +18,7 @@ import { FeaturedFairsResolver } from "./featuredFairsResolver"
 type MaybeResolved<T> =
   | T
   | ((context: ResolverContext, args: any) => Promise<T>)
+import { LatestArticlesResolvers } from "./articlesResolvers"
 
 export type HomeViewSection = {
   id: string
@@ -147,11 +148,21 @@ export const FeaturedFairs: HomeViewSection = {
   resolver: FeaturedFairsResolver,
 }
 
+export const LatestArticles: HomeViewSection = {
+  id: "home-view-section-latest-articles",
+  type: "ArticlesRailHomeViewSection",
+  component: {
+    title: "Artsy Editorial",
+  },
+  resolver: LatestArticlesResolvers,
+}
+
 const sections: HomeViewSection[] = [
   AuctionLotsForYou,
   CuratorsPicksEmerging,
   FeaturedFairs,
   HeroUnits,
+  LatestArticles,
   NewWorksForYou,
   NewWorksFromGalleriesYouFollow,
   RecentlyViewedArtworks,


### PR DESCRIPTION
This PR adds a new articles rail home view section. It also exposes "Artsy Editorial" as a new section.


<img width="1160" alt="Screenshot 2024-08-09 at 15 23 08" src="https://github.com/user-attachments/assets/b74f4530-c1e5-4b82-9374-26ef9b39f2b1">

Remaining: Add tests to `HomeViewSection` 