### PR TITLE
feat: expose featuredKeywords on sales

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17179,6 +17179,9 @@ type Sale implements Node {
   # Duration before lot closes that a late bid would extend the end time.
   extendedBiddingPeriodMinutes: Int
 
+  # Suggested filters for associated artworks
+  featuredKeywords: [String!]!
+
   # A formatted description of when the auction starts or ends or if it has ended
   formattedStartDateTime: String
   href: String

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -256,6 +256,13 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ extended_bidding_period_minutes }) =>
           extended_bidding_period_minutes,
       },
+      featuredKeywords: {
+        type: new GraphQLNonNull(
+          GraphQLList(new GraphQLNonNull(GraphQLString))
+        ),
+        description: "Suggested filters for associated artworks",
+        resolve: ({ featured_keywords }) => featured_keywords ?? [],
+      },
       formattedStartDateTime: {
         type: GraphQLString,
         description:


### PR DESCRIPTION
Like https://github.com/artsy/metaphysics/pull/5878 and https://github.com/artsy/metaphysics/pull/5888, but for sales. Depends on https://github.com/artsy/gravity/pull/18025 but can safely be deployed whenever.