### PR TITLE
fix: random collections populating fairs pages

### DIFF
--- a/src/schema/v2/fair.ts
+++ b/src/schema/v2/fair.ts
@@ -227,8 +227,16 @@ export const FairType = new GraphQLObjectType<any, ResolverContext>({
             args,
             { marketingCollectionsLoader }
           ) => {
-            args.slugs = kaws_collection_slugs
-            return fetchMarketingCollections(args, marketingCollectionsLoader)
+            const slugs = kaws_collection_slugs || []
+
+            if (slugs.length === 0) {
+              return []
+            }
+
+            return fetchMarketingCollections(
+              { ...args, slugs },
+              marketingCollectionsLoader
+            )
           },
         },
       }),


### PR DESCRIPTION
This PR fixes the issue of random collections populating as curated highlights on the fair page when the admin field is blank.

[Ticket](https://artsyproduct.atlassian.net/browse/DIA-786)