### PR TITLE
chore(EMI-2019): filter active partner offers for collector signals

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -4657,7 +4657,7 @@ describe("Artwork type", () => {
 
       context.userID = "user-id"
       context.mePartnerOffersLoader.mockResolvedValue({
-        body: [{ endAt: "2023-01-01T00:00:00Z" }],
+        body: [{ endAt: "2023-01-01T00:00:00Z", active: true }],
       })
 
       const data = await runQuery(query, context)
@@ -4676,6 +4676,29 @@ describe("Artwork type", () => {
             partnerOffer: {
               endAt: "2023-01-01T00:00:00Z",
             },
+          },
+        },
+      })
+    })
+    it("only returns active partner offer signal", async () => {
+      mockIsFeatureFlagEnabled.mockReturnValue(true)
+
+      artwork.purchasable = true
+      artwork.sale_ids = []
+
+      context.userID = "user-id"
+      context.mePartnerOffersLoader.mockResolvedValue({
+        body: [{ endAt: "2023-01-01T00:00:00Z", active: false }],
+      })
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          collectorSignals: {
+            bidCount: null,
+            lotWatcherCount: null,
+            partnerOffer: null,
           },
         },
       })

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -88,7 +88,9 @@ const collectorSignalsLoader = async (
         size: 1,
       })
 
-      partnerOffer = partnerOffers.body[0]
+      const activePartnerOffers = partnerOffers.body?.filter((po) => po.active)
+
+      partnerOffer = activePartnerOffers?.[0]
     }
   }
 


### PR DESCRIPTION
Minor chore related to [EMI-2019] - Following https://github.com/artsy/gravity/pull/18042 we will want to filter only active partner offers when finding collector signals for partner offers.

[EMI-2019]: https://artsyproduct.atlassian.net/browse/EMI-2019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ