### PR TITLE
chore: change button label for approved status

### DIFF
--- a/src/schema/v2/artwork/__tests__/artworkConsignmentSubmissionType.test.ts
+++ b/src/schema/v2/artwork/__tests__/artworkConsignmentSubmissionType.test.ts
@@ -493,7 +493,7 @@ describe("ArtworkConsignmentSubmissionType", () => {
       artwork.consignmentSubmission.state = "APPROVED"
       data = await runQuery(query, context)
       expect(data.artwork.consignmentSubmission.buttonLabel).toEqual(
-        "Add Additional Information"
+        "Complete Listing"
       )
 
       artwork.consignmentSubmission.state = "PUBLISHED"

--- a/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
+++ b/src/schema/v2/artwork/artworkConsignmentSubmissionType.ts
@@ -136,7 +136,7 @@ const ArtworkConsignmentSubmissionType = new GraphQLObjectType<
             case "draft":
               return "Complete Submission"
             case "approved":
-              return "Add Additional Information"
+              return "Complete Listing"
             case "submitted":
             case "published":
             case "resubmitted":


### PR DESCRIPTION
Change button label for APPROVED status
Addressed [Notion card](https://www.notion.so/artsy/CTA-should-say-Complete-Listing-41570cab607f4ff2b3abd4cf6a303bb4?pvs=4) 