### PR TITLE
feat(onyx-1191): add 'curator's picks: emerging' home view section

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9809,6 +9809,25 @@ enum FeatureSorts {
   NAME_DESC
 }
 
+# A featured collection section in the home view
+type FeaturedCollectionHomeViewSection implements GenericHomeViewSection & Node {
+  artworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection!
+
+  # The component that is prescribed for this section
+  component: HomeViewComponent
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+}
+
 # An illustrated link chosen to highlight a Gene from a given GeneFamily
 type FeaturedGeneLink {
   href: String!
@@ -10913,6 +10932,12 @@ type HomeView {
 
 # A component specification
 type HomeViewComponent {
+  # A background color for this section
+  backgroundColor: String
+
+  # A display subtitle for this section
+  subtitle: String
+
   # A display title for this section
   title: String
 }
@@ -10920,6 +10945,7 @@ type HomeViewComponent {
 union HomeViewSection =
     ArtistsRailHomeViewSection
   | ArtworksRailHomeViewSection
+  | FeaturedCollectionHomeViewSection
   | HeroUnitsHomeViewSection
 
 # A connection to a list of items.

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -91,6 +91,7 @@ export default (opts) => {
     geneFamiliesLoader: gravityLoader("gene_families"),
     geneLoader: gravityLoader((id) => `gene/${id}`),
     genesLoader: gravityLoader("genes"),
+    siteHeroUnitLoader: gravityLoader((id) => `site_hero_unit/${id}`),
     siteHeroUnitsLoader: gravityLoader("site_hero_units"),
     heroUnitsLoader: gravityLoader("hero_units", {}, { headers: true }),
     heroUnitLoader: gravityLoader(

--- a/src/schema/v2/homeView/HomeViewComponent.ts
+++ b/src/schema/v2/homeView/HomeViewComponent.ts
@@ -8,5 +8,13 @@ export const HomeViewComponent = new GraphQLObjectType({
       type: GraphQLString,
       description: "A display title for this section",
     },
+    subtitle: {
+      type: GraphQLString,
+      description: "A display subtitle for this section",
+    },
+    backgroundColor: {
+      type: GraphQLString,
+      description: "A background color for this section",
+    },
   },
 })

--- a/src/schema/v2/homeView/HomeViewSection.ts
+++ b/src/schema/v2/homeView/HomeViewSection.ts
@@ -88,6 +88,25 @@ const HeroUnitsHomeViewSectionType = new GraphQLObjectType<
   },
 })
 
+const FeaturedCollectionHomeViewSectionType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "FeaturedCollectionHomeViewSection",
+  description: "A featured collection section in the home view",
+  interfaces: [GenericHomeViewSectionInterface, NodeInterface],
+  fields: {
+    ...standardSectionFields,
+
+    artworksConnection: {
+      type: new GraphQLNonNull(artworkConnection.connectionType),
+      args: pageable({}),
+      resolve: (parent, ...rest) =>
+        parent.resolver ? parent.resolver(parent, ...rest) : [],
+    },
+  },
+})
+
 // the Section union type of all concrete sections
 
 export const HomeViewSectionType = new GraphQLUnionType({
@@ -96,6 +115,7 @@ export const HomeViewSectionType = new GraphQLUnionType({
     ArtworksRailHomeViewSectionType,
     ArtistsRailHomeViewSectionType,
     HeroUnitsHomeViewSectionType,
+    FeaturedCollectionHomeViewSectionType,
   ],
   resolveType: (value) => {
     return value.type

--- a/src/schema/v2/homeView/featuredCollectionArtworksResolver.ts
+++ b/src/schema/v2/homeView/featuredCollectionArtworksResolver.ts
@@ -1,0 +1,19 @@
+import { filterArtworksConnectionWithParams } from "../filterArtworksConnection"
+
+export const featuredCollectionArtworksResolver = (collectionId: string) => {
+  return async (parent, args, context, info) => {
+    const loader = filterArtworksConnectionWithParams((_args) => {
+      return {
+        marketing_collection_id: collectionId,
+      }
+    })
+
+    if (!loader?.resolve) {
+      return
+    }
+
+    const result = await loader.resolve(parent, args, context, info)
+
+    return result
+  }
+}

--- a/src/schema/v2/homeView/getSectionsForUser.ts
+++ b/src/schema/v2/homeView/getSectionsForUser.ts
@@ -1,8 +1,9 @@
 import { ResolverContext } from "types/graphql"
 import {
   AuctionLotsForYou,
+  featuredCollection,
   HeroUnits,
-  HomeViewSection,
+  HomeViewSectionOrResolver,
   NewWorksForYou,
   NewWorksFromGalleriesYouFollow,
   RecentlyViewedArtworks,
@@ -13,7 +14,7 @@ import {
 
 export async function getSectionsForUser(
   context: ResolverContext
-): Promise<HomeViewSection[]> {
+): Promise<HomeViewSectionOrResolver[]> {
   /*
    * FAKE temporary placeholder logic for determining the sections that a user will see
    */
@@ -23,10 +24,14 @@ export async function getSectionsForUser(
 
   const me = await meLoader()
 
-  let sections: HomeViewSection[] = []
+  let sections: HomeViewSectionOrResolver[] = []
 
   if (me.type === "Admin") {
     sections = [
+      featuredCollection(
+        "curators-picks-emerging-app",
+        "curators-picks-emerging"
+      ),
       RecentlyViewedArtworks,
       TrendingArtists,
       SimilarToRecentlyViewedArtworks,
@@ -38,6 +43,10 @@ export async function getSectionsForUser(
     ]
   } else {
     sections = [
+      featuredCollection(
+        "curators-picks-emerging-app",
+        "curators-picks-emerging"
+      ),
       SimilarToRecentlyViewedArtworks,
       NewWorksForYou,
       HeroUnits,


### PR DESCRIPTION
I am trying to migrate "Curator's picks: emerging" rail to the new schema (which is [MarketingCollectionRail in Eigen](https://github.com/artsy/eigen/blob/main/src/app/Scenes/Home/Components/MarketingCollectionRail.tsx)). There is something different about this rail - it is not "hardcoded", i.e. component info, such as as title, subtitle, background image, etc. is stored in Gravity (accessible via `homePage.heroUnits(platform: MOBILE)` MP query). Current `homeView` implementation does't allow fetching component-level details from backend, this is what I am trying to achieve in this PR.

The implementation feels a bit weird to me and I would like to hear your feedback about it. The biggest change is that sections are now can be not only `HomeViewSection`s, but also callable functions (see `featuredCollection("curators-picks-emerging-app", "curators-picks-emerging")` in `getSectionsForUser` function). I don't know how else to achieve this "dynamic" behaviour.