### PR TITLE
chore: resolve each collectorSignal field in its own resolver

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3259,7 +3259,7 @@ type AuctionCollectorSignals {
   ): String
 
   # Lot watcher count
-  lotWatcherCount: Int
+  lotWatcherCount: Int!
 
   # Lot bidding period extended due to last-minute bids
   onlineBiddingExtended: Boolean!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3237,10 +3237,10 @@ type AuctionArtworkGrid implements ArtworkContextGrid {
 # Collector signals on a biddable auction lot
 type AuctionCollectorSignals {
   # Bid count
-  bidCount: Int
+  bidCount: Int!
 
   # Live bidding has started on this lot's auction
-  liveBiddingStarted: Boolean
+  liveBiddingStarted: Boolean!
 
   # Auction live bidding start time
   liveStartAt(
@@ -3262,7 +3262,7 @@ type AuctionCollectorSignals {
   lotWatcherCount: Int
 
   # Lot bidding period extended due to last-minute bids
-  onlineBiddingExtended: Boolean
+  onlineBiddingExtended: Boolean!
 
   # Pending auction registration end time
   registrationEndsAt(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4409,29 +4409,37 @@ type CollectorResume {
 
 # Collector signals available to the artwork
 type CollectorSignals {
+  auction: auctionCollectorSignals
+
   # Bid count on lots open for bidding
-  bidCount: Int
+  bidCount: Int @deprecated(reason: "Use nested field in `auction` instead")
 
   # Live bidding has started on this lot's auction
   liveBiddingStarted: Boolean
+    @deprecated(reason: "Use nested field in `auction` instead")
 
   # Auction live bidding start time
   liveStartAt: String
+    @deprecated(reason: "Use nested field in `auction` instead")
 
   # Pending auction lot end time for bidding
   lotClosesAt: String
+    @deprecated(reason: "Use nested field in `auction` instead")
 
   # Lot watcher count on lots open for bidding
   lotWatcherCount: Int
+    @deprecated(reason: "Use nested field in `auction` instead")
 
   # Auction lot bidding period extended due to last-minute bids
   onlineBiddingExtended: Boolean
+    @deprecated(reason: "Use nested field in `auction` instead")
 
   # Partner offer available to collector
   partnerOffer: PartnerOfferToCollector
 
   # Pending auction registration end time
   registrationEndsAt: String
+    @deprecated(reason: "Use nested field in `auction` instead")
 }
 
 # Represents either an action or a potential failure
@@ -21792,6 +21800,45 @@ enum addressType {
   BUSINESS
   OTHER
   TEMPORARY
+}
+
+# Collector signals on a biddable auction lot
+type auctionCollectorSignals {
+  # Bid count
+  bidCount: Int
+
+  # Live bidding has started on this lot's auction
+  liveBiddingStarted: Boolean
+
+  # Auction live bidding start time
+  liveStartAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+
+  # Pending auction lot end time for bidding
+  lotClosesAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+
+  # Lot watcher count
+  lotWatcherCount: Int
+
+  # Lot bidding period extended due to last-minute bids
+  onlineBiddingExtended: Boolean
+
+  # Pending auction registration end time
+  registrationEndsAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
 }
 
 input createAlertInput {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3234,6 +3234,45 @@ type AuctionArtworkGrid implements ArtworkContextGrid {
   title: String
 }
 
+# Collector signals on a biddable auction lot
+type AuctionCollectorSignals {
+  # Bid count
+  bidCount: Int
+
+  # Live bidding has started on this lot's auction
+  liveBiddingStarted: Boolean
+
+  # Auction live bidding start time
+  liveStartAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+
+  # Pending auction lot end time for bidding
+  lotClosesAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+
+  # Lot watcher count
+  lotWatcherCount: Int
+
+  # Lot bidding period extended due to last-minute bids
+  onlineBiddingExtended: Boolean
+
+  # Pending auction registration end time
+  registrationEndsAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+}
+
 # In centimeters.
 type AuctionLotDimensions {
   depth: Float
@@ -4409,7 +4448,7 @@ type CollectorResume {
 
 # Collector signals available to the artwork
 type CollectorSignals {
-  auction: auctionCollectorSignals
+  auction: AuctionCollectorSignals
 
   # Bid count on lots open for bidding
   bidCount: Int @deprecated(reason: "Use nested field in `auction` instead")
@@ -21800,45 +21839,6 @@ enum addressType {
   BUSINESS
   OTHER
   TEMPORARY
-}
-
-# Collector signals on a biddable auction lot
-type auctionCollectorSignals {
-  # Bid count
-  bidCount: Int
-
-  # Live bidding has started on this lot's auction
-  liveBiddingStarted: Boolean
-
-  # Auction live bidding start time
-  liveStartAt(
-    format: String
-
-    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-    timezone: String
-  ): String
-
-  # Pending auction lot end time for bidding
-  lotClosesAt(
-    format: String
-
-    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-    timezone: String
-  ): String
-
-  # Lot watcher count
-  lotWatcherCount: Int
-
-  # Lot bidding period extended due to last-minute bids
-  onlineBiddingExtended: Boolean
-
-  # Pending auction registration end time
-  registrationEndsAt(
-    format: String
-
-    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-    timezone: String
-  ): String
 }
 
 input createAlertInput {

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -56,12 +56,12 @@ const AuctionCollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
       bidCount: {
         type: new GraphQLNonNull(GraphQLInt),
         description: "Bid count",
-        resolve: ({ saleArtwork }) => saleArtwork.bidder_positions_count,
+        resolve: ({ saleArtwork }) => saleArtwork.bidder_positions_count ?? 0,
       },
       lotWatcherCount: {
         type: new GraphQLNonNull(GraphQLInt),
         description: "Lot watcher count",
-        resolve: ({ artwork }) => artwork.recent_saves_count,
+        resolve: ({ artwork }) => artwork.recent_saves_count ?? 0,
       },
       liveBiddingStarted: {
         type: new GraphQLNonNull(GraphQLBoolean),

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -76,8 +76,11 @@ const AuctionCollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
       },
       lotClosesAt: {
         ...date(
-          ({ saleArtwork }) =>
-            saleArtwork.extended_bidding_end_at || saleArtwork.end_at
+          ({ saleArtwork, sale }) =>
+            !sale.live_start_at &&
+            (saleArtwork.extended_bidding_end_at ||
+              saleArtwork.end_at ||
+              sale.end_at)
         ),
         description: "Pending auction lot end time for bidding",
       },

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -49,7 +49,7 @@ const AuctionCollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
   },
 
   type: new GraphQLObjectType({
-    name: "auctionCollectorSignals",
+    name: "AuctionCollectorSignals",
     description: "Collector signals on a biddable auction lot",
     fields: {
       bidCount: {

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -59,7 +59,7 @@ const AuctionCollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
         resolve: ({ saleArtwork }) => saleArtwork.bidder_positions_count,
       },
       lotWatcherCount: {
-        type: GraphQLInt,
+        type: new GraphQLNonNull(GraphQLInt),
         description: "Lot watcher count",
         resolve: ({ artwork }) => artwork.recent_saves_count,
       },

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -4,6 +4,7 @@ import { ResolverContext } from "types/graphql"
 import { PartnerOfferToCollectorType } from "../partnerOfferToCollector"
 import { isFeatureFlagEnabled } from "lib/featureFlags"
 import { date } from "../fields/date"
+import { GraphQLNonNull } from "graphql"
 
 interface ActiveLotData {
   saleArtwork: {
@@ -53,7 +54,7 @@ const AuctionCollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
     description: "Collector signals on a biddable auction lot",
     fields: {
       bidCount: {
-        type: GraphQLInt,
+        type: new GraphQLNonNull(GraphQLInt),
         description: "Bid count",
         resolve: ({ saleArtwork }) => saleArtwork.bidder_positions_count,
       },
@@ -63,13 +64,13 @@ const AuctionCollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
         resolve: ({ artwork }) => artwork.recent_saves_count,
       },
       liveBiddingStarted: {
-        type: GraphQLBoolean,
+        type: new GraphQLNonNull(GraphQLBoolean),
         description: "Live bidding has started on this lot's auction",
         resolve: ({ sale }) =>
           !!sale.live_start_at && new Date(sale.live_start_at) <= new Date(),
       },
       onlineBiddingExtended: {
-        type: GraphQLBoolean,
+        type: new GraphQLNonNull(GraphQLBoolean),
         description: "Lot bidding period extended due to last-minute bids",
         resolve: ({ saleArtwork }) => !!saleArtwork.extended_bidding_end_at,
       },


### PR DESCRIPTION
This is a quick followup to @mzikherman's comment in https://github.com/artsy/metaphysics/pull/5889#pullrequestreview-2238572145.

This PR changes how we resolve collector signals to get each field from its own `resolve` function, rather than one single resolver that constructs the entire `collectorSignals` object.

**PROs** for this approach
- It is more in line with our patterns in metaphysics, possibly easier to trace where things come from
- Less need to worry about checks like `isFieldRequested` when thinking about cascading requests
- `DataLoader` used in our loaders will avoid duplicative requests

**Cons:** The collector signals object could be thought of as a unit. If we think of them that way then they are more intuitively structured as a single resolver:
- There has been some discussion with folks responsible for FE implementations over which service will own final prioritization of competing signals, preferring that Metaphysics make these judgements - for this a single resolver feels natural
- Some properties are interdependent and this isn't clear when looking at it as separate resolvers.
- Duplicative code could open the door to other bugs in the future (for example: [closing time can come from multiple places](https://github.com/artsy/metaphysics/compare/erik.collectorSignals-per-field-resolvers?expand=1#diff-dc52d603a602c819aef005d759243d63b275674ea6954b70a204fec0f49d29b5L176-L189))