### PR TITLE
feat: Allow alertsConnection to accept alert id filter

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14320,6 +14320,7 @@ type Partner implements Node {
     artistID: String
     before: String
     first: Int
+    id: String
     last: Int
     page: Int
     size: Int

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -659,12 +659,12 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
-    partnerSearchCriteriaLoader: gravityLoader(
+    partnerSearchCriteriasLoader: gravityLoader(
       (id) => `/partner/${id}/partner_search_criterias`,
       {},
       { headers: true }
     ),
-    partnerSearchCriteriaSingleLoader: gravityLoader<
+    partnerSearchCriteriaLoader: gravityLoader<
       any,
       { partner_id: string; id: string }
     >(

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -669,7 +669,7 @@ export default (accessToken, userID, opts) => {
       { partner_id: string; id: string }
     >(
       ({ partner_id, id }) =>
-        `/partner/${partner_id}/partner_search_criterias/${id}`,
+        `/partner/${partner_id}/partner_search_criteria/${id}`,
       {},
       { headers: true }
     ),

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -664,18 +664,17 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
-    partnerSearchCriteriaHitsLoader: gravityLoader(
-      (id) => `partner/${id}/partner_search_criteria_hits`,
-      {},
-      { headers: true }
-    ),
-    // TODO: rename
-    singlePartnerSearchCriteriaLoader: gravityLoader<
+    partnerSearchCriteriaSingleLoader: gravityLoader<
       any,
       { partner_id: string; id: string }
     >(
       ({ partner_id, id }) =>
         `/partner/${partner_id}/partner_search_criterias/${id}`,
+      {},
+      { headers: true }
+    ),
+    partnerSearchCriteriaHitsLoader: gravityLoader(
+      (id) => `partner/${id}/partner_search_criteria_hits`,
       {},
       { headers: true }
     ),

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -669,6 +669,16 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    // TODO: rename
+    singlePartnerSearchCriteriaLoader: gravityLoader<
+      any,
+      { partner_id: string; id: string }
+    >(
+      ({ partner_id, id }) =>
+        `/partner/${partner_id}/partner_search_criterias/${id}`,
+      {},
+      { headers: true }
+    ),
     partnerShowsLoader: gravityLoader(
       (partner_id) => `partner/${partner_id}/shows`,
       {},

--- a/src/schema/v2/partner/__tests__/partner.test.js
+++ b/src/schema/v2/partner/__tests__/partner.test.js
@@ -1634,6 +1634,57 @@ describe("Partner type", () => {
   })
 
   describe("#alertsConnection", () => {
+    it("returns a single partner alert", async () => {
+      const response = {
+        body: {
+          id: "8754ff90-b020-425b-8dae-894ce5ad9d1f",
+          search_criteria_id: "3f980bbe-7b9b-4fa9-beb1-69d13e94fb0c",
+          partner_id: "5f80bfefe8d808000ea212c1",
+          search_criteria: {
+            id: "3f980bbe-7b9b-4fa9-beb1-69d13e94fb0c",
+            price_range: "1-2",
+          },
+        },
+      }
+
+      const query = gql`
+        {
+          partner(id: "catty-partner") {
+            alertsConnection(
+              first: 1
+              id: "8754ff90-b020-425b-8dae-894ce5ad9d1f"
+            ) {
+              edges {
+                node {
+                  priceRange
+                }
+              }
+            }
+          }
+        }
+      `
+      const partnerSearchCriteriaSingleLoader = () => Promise.resolve(response)
+
+      const data = await runAuthenticatedQuery(query, {
+        ...context,
+        partnerSearchCriteriaSingleLoader,
+      })
+
+      expect(data).toEqual({
+        partner: {
+          alertsConnection: {
+            edges: [
+              {
+                node: {
+                  priceRange: "1-2",
+                },
+              },
+            ],
+          },
+        },
+      })
+    })
+
     it("returns partner search criteria details and associated search criteria details", async () => {
       const response = {
         body: {

--- a/src/schema/v2/partner/__tests__/partner.test.js
+++ b/src/schema/v2/partner/__tests__/partner.test.js
@@ -1650,10 +1650,7 @@ describe("Partner type", () => {
       const query = gql`
         {
           partner(id: "catty-partner") {
-            alertsConnection(
-              first: 1
-              id: "8754ff90-b020-425b-8dae-894ce5ad9d1f"
-            ) {
+            alertsConnection(id: "8754ff90-b020-425b-8dae-894ce5ad9d1f") {
               edges {
                 node {
                   priceRange

--- a/src/schema/v2/partner/__tests__/partner.test.js
+++ b/src/schema/v2/partner/__tests__/partner.test.js
@@ -1660,11 +1660,11 @@ describe("Partner type", () => {
           }
         }
       `
-      const partnerSearchCriteriaSingleLoader = () => Promise.resolve(response)
+      const partnerSearchCriteriaLoader = () => Promise.resolve(response)
 
       const data = await runAuthenticatedQuery(query, {
         ...context,
-        partnerSearchCriteriaSingleLoader,
+        partnerSearchCriteriaLoader,
       })
 
       expect(data).toEqual({
@@ -1724,11 +1724,11 @@ describe("Partner type", () => {
           }
         }
       `
-      const partnerSearchCriteriaLoader = () => Promise.resolve(response)
+      const partnerSearchCriteriasLoader = () => Promise.resolve(response)
 
       const data = await runAuthenticatedQuery(query, {
         ...context,
-        partnerSearchCriteriaLoader,
+        partnerSearchCriteriasLoader,
       })
       expect(data).toEqual({
         partner: {

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -352,12 +352,9 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         resolve: async (
           { _id },
           args,
-          { partnerSearchCriteriaSingleLoader, partnerSearchCriteriaLoader }
+          { partnerSearchCriteriaLoader, partnerSearchCriteriasLoader }
         ) => {
-          if (
-            !partnerSearchCriteriaLoader ||
-            !partnerSearchCriteriaSingleLoader
-          )
+          if (!partnerSearchCriteriasLoader || !partnerSearchCriteriaLoader)
             return null
 
           if (args.id && !args.first) {
@@ -387,7 +384,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           let body, totalCount
 
           if (args.id) {
-            const singleResult = await partnerSearchCriteriaSingleLoader({
+            const singleResult = await partnerSearchCriteriaLoader({
               partner_id: _id,
               id: args.id,
             })
@@ -395,8 +392,11 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             body = singleResult ? [singleResult.body] : []
             totalCount = body.length
           } else {
-            // Otherwise, use the partnerSearchCriteriaLoader list endpoint
-            const response = await partnerSearchCriteriaLoader(_id, gravityArgs)
+            // Otherwise, use the partnerSearchCriteriasLoader list endpoint
+            const response = await partnerSearchCriteriasLoader(
+              _id,
+              gravityArgs
+            )
             body = response.body.hits
             totalCount = parseInt(response.headers["x-total-count"] || "0", 10)
           }

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -349,16 +349,14 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             type: GraphQLString,
           },
         }),
-        // TODO: clean up naming
-        // TODO: make gravity endpoint
         resolve: async (
           { _id },
           args,
-          { singlePartnerSearchCriteriaLoader, partnerSearchCriteriaLoader }
+          { partnerSearchCriteriaSingleLoader, partnerSearchCriteriaLoader }
         ) => {
           if (
             !partnerSearchCriteriaLoader ||
-            !singlePartnerSearchCriteriaLoader
+            !partnerSearchCriteriaSingleLoader
           )
             return null
 
@@ -366,7 +364,6 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             args
           )
 
-          console.log("made it past")
           type GravityArgs = {
             page: number
             size: number
@@ -387,20 +384,19 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
 
           if (args.id) {
             // If id is present, call the singlePartnerSearchCriteriaLoader
-            const singleResult = await singlePartnerSearchCriteriaLoader({
+            const singleResult = await partnerSearchCriteriaSingleLoader({
               partner_id: _id,
               id: args.id,
             })
             body = singleResult ? [singleResult] : []
             totalCount = body.length
           } else {
-            // Otherwise, use the partnerSearchCriteriaLoader
+            // Otherwise, use the partnerSearchCriteriaLoader list endpoint
             const response = await partnerSearchCriteriaLoader(_id, gravityArgs)
             body = response.body.hits
             totalCount = parseInt(response.headers["x-total-count"] || "0", 10)
           }
 
-          console.log("hello?")
           return paginationResolver({
             totalCount,
             offset,

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -337,7 +337,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         type: PartnerAlertsConnectionType,
         args: pageable({
           id: {
-            type: GraphQLString, // errr, or ID type?
+            type: GraphQLString,
           },
           page: {
             type: GraphQLInt,
@@ -359,6 +359,10 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             !partnerSearchCriteriaSingleLoader
           )
             return null
+
+          if (args.id && !args.first) {
+            args.first = 1
+          }
 
           const { page, size, offset } = convertConnectionArgsToGravityArgs(
             args

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -383,12 +383,12 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           let body, totalCount
 
           if (args.id) {
-            // If id is present, call the singlePartnerSearchCriteriaLoader
             const singleResult = await partnerSearchCriteriaSingleLoader({
               partner_id: _id,
               id: args.id,
             })
-            body = singleResult ? [singleResult] : []
+
+            body = singleResult ? [singleResult.body] : []
             totalCount = body.length
           } else {
             // Otherwise, use the partnerSearchCriteriaLoader list endpoint


### PR DESCRIPTION
Adds support for single alert with partner facing metadata so we can support a show single alert page in CMS

[Wires in new Gravity endpoint](https://github.com/artsy/gravity/pull/18073)

This connection should support:
```
{
  partner(id: "commerce-test-partner") {
    slug
    name
    alertsConnection(first: 10) {
      totalCount
      edges {
        id
        collectorProfilesConnection(first: 10) {
          totalCount
          edges {
            node {
              name
              internalID
            }
          }
        }
        node {
          internalID
          attributionClass
        }
      }
    }
  }
}
```

but also a

```
{
  partner(id: "commerce-test-partner") {
    slug
    name
    alertsConnection(id: "im-a-regular-old-single-record") {
      totalCount
      edges {
        id
        collectorProfilesConnection(first: 10) {
          totalCount
          edges {
            node {
              name
              internalID
            }
          }
        }
        node {
          internalID
          attributionClass
        }
      }
    }
  }
}
```