### PR TITLE
feat(onyx-1191): add "Curators' Picks: Emerging" home view section

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10913,6 +10913,9 @@ type HomeView {
 
 # A component specification
 type HomeViewComponent {
+  # A background color for this section
+  backgroundColor: String
+
   # A description for this section
   description: String
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10913,14 +10913,27 @@ type HomeView {
 
 # A component specification
 type HomeViewComponent {
-  # A background color for this section
-  backgroundColor: String
+  # A background image for this section
+  backgroundImageURL(
+    version: HomeViewComponentBackgroundImageURLVersion
+  ): String
 
   # A description for this section
   description: String
 
+  # A screen to navigate to when this component is clicked
+  href: String
+
   # A display title for this section
   title: String
+
+  # How this component should be rendered
+  type: String
+}
+
+enum HomeViewComponentBackgroundImageURLVersion {
+  NARROW
+  WIDE
 }
 
 union HomeViewSection =

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10913,6 +10913,9 @@ type HomeView {
 
 # A component specification
 type HomeViewComponent {
+  # A description for this section
+  description: String
+
   # A display title for this section
   title: String
 }

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -91,6 +91,7 @@ export default (opts) => {
     geneFamiliesLoader: gravityLoader("gene_families"),
     geneLoader: gravityLoader((id) => `gene/${id}`),
     genesLoader: gravityLoader("genes"),
+    siteHeroUnitLoader: gravityLoader((id) => `site_hero_unit/${id}`),
     siteHeroUnitsLoader: gravityLoader("site_hero_units"),
     heroUnitsLoader: gravityLoader("hero_units", {}, { headers: true }),
     heroUnitLoader: gravityLoader(

--- a/src/schema/v2/homeView/HomeViewComponent.ts
+++ b/src/schema/v2/homeView/HomeViewComponent.ts
@@ -20,5 +20,21 @@ export const HomeViewComponent = new GraphQLObjectType({
         }
       },
     },
+    description: {
+      type: GraphQLString,
+      description: "A description for this section",
+      resolve: async (parent, _args, context, _info) => {
+        const { description: _description } = parent
+
+        if (typeof _description === "string") {
+          return _description
+        }
+
+        if (typeof _description === "function") {
+          const description = await _description(context)
+          return description
+        }
+      },
+    },
   },
 })

--- a/src/schema/v2/homeView/HomeViewComponent.ts
+++ b/src/schema/v2/homeView/HomeViewComponent.ts
@@ -36,5 +36,21 @@ export const HomeViewComponent = new GraphQLObjectType({
         }
       },
     },
+    backgroundColor: {
+      type: GraphQLString,
+      description: "A background color for this section",
+      resolve: async (parent, _args, context, _info) => {
+        const { backgroundColor } = parent
+
+        if (typeof backgroundColor === "string") {
+          return backgroundColor
+        }
+
+        if (typeof backgroundColor === "function") {
+          const color = await backgroundColor(context)
+          return color
+        }
+      },
+    },
   },
 })

--- a/src/schema/v2/homeView/HomeViewComponent.ts
+++ b/src/schema/v2/homeView/HomeViewComponent.ts
@@ -7,6 +7,18 @@ export const HomeViewComponent = new GraphQLObjectType({
     title: {
       type: GraphQLString,
       description: "A display title for this section",
+      resolve: async (parent, _args, context, _info) => {
+        const { title: _title } = parent
+
+        if (typeof _title === "string") {
+          return _title
+        }
+
+        if (typeof _title === "function") {
+          const title = await _title(context)
+          return title
+        }
+      },
     },
   },
 })

--- a/src/schema/v2/homeView/HomeViewComponent.ts
+++ b/src/schema/v2/homeView/HomeViewComponent.ts
@@ -1,9 +1,25 @@
-import { GraphQLObjectType, GraphQLString } from "graphql"
+import { GraphQLEnumType, GraphQLObjectType, GraphQLString } from "graphql"
 
 export const HomeViewComponent = new GraphQLObjectType({
   name: "HomeViewComponent",
   description: "A component specification",
   fields: {
+    type: {
+      type: GraphQLString,
+      description: "How this component should be rendered",
+      resolve: async (parent, _args, context, _info) => {
+        const { type: _type } = parent
+
+        if (typeof _type === "string") {
+          return _type
+        }
+
+        if (typeof _type === "function") {
+          const type = await _type(context)
+          return type
+        }
+      },
+    },
     title: {
       type: GraphQLString,
       description: "A display title for this section",
@@ -36,19 +52,50 @@ export const HomeViewComponent = new GraphQLObjectType({
         }
       },
     },
-    backgroundColor: {
+    backgroundImageURL: {
       type: GraphQLString,
-      description: "A background color for this section",
-      resolve: async (parent, _args, context, _info) => {
-        const { backgroundColor } = parent
+      args: {
+        version: {
+          type: new GraphQLEnumType({
+            name: "HomeViewComponentBackgroundImageURLVersion",
+            values: {
+              WIDE: {
+                value: "wide",
+              },
+              NARROW: {
+                value: "narrow",
+              },
+            },
+          }),
+        },
+      },
+      description: "A background image for this section",
+      resolve: async (parent, args, context, _info) => {
+        const { backgroundImageURL } = parent
 
-        if (typeof backgroundColor === "string") {
-          return backgroundColor
+        if (typeof backgroundImageURL === "string") {
+          return backgroundImageURL
         }
 
-        if (typeof backgroundColor === "function") {
-          const color = await backgroundColor(context)
+        if (typeof backgroundImageURL === "function") {
+          const color = await backgroundImageURL(context, args)
           return color
+        }
+      },
+    },
+    href: {
+      type: GraphQLString,
+      description: "A screen to navigate to when this component is clicked",
+      resolve: async (parent, _args, context, _info) => {
+        const { href: _href } = parent
+
+        if (typeof _href === "string") {
+          return _href
+        }
+
+        if (typeof _href === "function") {
+          const description = await _href(context)
+          return description
         }
       },
     },

--- a/src/schema/v2/homeView/__tests__/HomeView.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeView.test.ts
@@ -26,12 +26,15 @@ describe("homeView", () => {
       authenticatedLoaders: {
         meLoader: jest.fn().mockReturnValue({ type: "User" }),
       },
+      siteHeroUnitLoader: jest.fn().mockReturnValue({
+        app_title: "Curators' Picks Emerging",
+      }),
     }
 
     it("returns a connection of home view sections", async () => {
       const { homeView } = await runQuery(query, context)
 
-      expect(homeView.sectionsConnection.edges).toHaveLength(8)
+      expect(homeView.sectionsConnection.edges).toHaveLength(9)
     })
 
     it("returns requested data for each section", async () => {
@@ -40,6 +43,14 @@ describe("homeView", () => {
       expect(homeView.sectionsConnection).toMatchInlineSnapshot(`
         Object {
           "edges": Array [
+            Object {
+              "node": Object {
+                "__typename": "ArtworksRailHomeViewSection",
+                "component": Object {
+                  "title": "Curators' Picks Emerging",
+                },
+              },
+            },
             Object {
               "node": Object {
                 "__typename": "ArtworksRailHomeViewSection",

--- a/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
@@ -238,4 +238,96 @@ describe("HomeViewSection", () => {
       `)
     })
   })
+
+  describe("CuratorsPicksEmerging", () => {
+    it("returns correct data", async () => {
+      const query = gql`
+        {
+          homeView {
+            section(id: "home-view-section-curators-picks-emerging") {
+              __typename
+
+              ... on ArtworksRailHomeViewSection {
+                component {
+                  title
+                  description
+                  href
+                  backgroundImageURL
+                }
+
+                artworksConnection(first: 2) {
+                  edges {
+                    node {
+                      id
+                      title
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const artworks = [
+        { _id: "percy", title: "Percy the Cat" },
+        { _id: "matt", title: "Matt the Person" },
+      ]
+
+      const context = {
+        authenticatedLoaders: {
+          meLoader: jest.fn().mockReturnValue({ type: "User" }),
+        },
+        unauthenticatedLoaders: {
+          filterArtworksLoader: jest.fn().mockReturnValue(
+            Promise.resolve({
+              hits: artworks,
+              aggregations: {
+                total: {
+                  value: 2,
+                },
+              },
+            })
+          ),
+        },
+        siteHeroUnitLoader: jest.fn().mockReturnValue({
+          app_title: "Curators' Picks Emerging",
+          app_description:
+            "The best works by rising talents on Artsy, available now.",
+          background_image_app_phone_url: "image.jpg",
+          background_image_app_tablet_url: "image.jpg",
+        }),
+      }
+
+      const { homeView } = await runQuery(query, context)
+
+      expect(homeView.section).toMatchInlineSnapshot(`
+        Object {
+          "__typename": "ArtworksRailHomeViewSection",
+          "artworksConnection": Object {
+            "edges": Array [
+              Object {
+                "node": Object {
+                  "id": "QXJ0d29yazpwZXJjeQ==",
+                  "title": "Percy the Cat",
+                },
+              },
+              Object {
+                "node": Object {
+                  "id": "QXJ0d29yazptYXR0",
+                  "title": "Matt the Person",
+                },
+              },
+            ],
+          },
+          "component": Object {
+            "backgroundImageURL": "image.jpg",
+            "description": "The best works by rising talents on Artsy, available now.",
+            "href": "/collection/curators-picks-emerging",
+            "title": "Curators' Picks Emerging",
+          },
+        }
+      `)
+    })
+  })
 })

--- a/src/schema/v2/homeView/artworkResolvers.ts
+++ b/src/schema/v2/homeView/artworkResolvers.ts
@@ -4,6 +4,7 @@ import { artworksForUser } from "../artworksForUser"
 import { newWorksFromGalleriesYouFollow } from "../me/newWorksFromGalleriesYouFollow"
 import { RecentlyViewedArtworks } from "../me/recentlyViewedArtworks"
 import { SimilarToRecentlyViewed } from "../me/similarToRecentlyViewed"
+import { filterArtworksConnectionWithParams } from "../filterArtworksConnection"
 
 /*
  * Resolvers for home view artwork sections
@@ -28,6 +29,26 @@ export const SimilarToRecentlyViewedArtworksResolver: GraphQLFieldResolver<
     context,
     info
   )
+}
+
+export const CuratorsPicksEmergingArtworksResolver: GraphQLFieldResolver<
+  any,
+  ResolverContext
+> = async (parent, args, context, info) => {
+  const loader = filterArtworksConnectionWithParams((_args) => {
+    return {
+      marketing_collection_id: "curators-picks-emerging",
+      sort: "-decayed_merch",
+    }
+  })
+
+  if (!loader?.resolve) {
+    return
+  }
+
+  const result = await loader.resolve(parent, args, context, info)
+
+  return result
 }
 
 export const NewWorksForYouResolver: GraphQLFieldResolver<

--- a/src/schema/v2/homeView/getSectionsForUser.ts
+++ b/src/schema/v2/homeView/getSectionsForUser.ts
@@ -1,6 +1,7 @@
 import { ResolverContext } from "types/graphql"
 import {
   AuctionLotsForYou,
+  CuratorsPicksEmerging,
   HeroUnits,
   HomeViewSection,
   NewWorksForYou,
@@ -35,9 +36,11 @@ export async function getSectionsForUser(
       HeroUnits,
       NewWorksFromGalleriesYouFollow,
       RecommendedArtists,
+      CuratorsPicksEmerging,
     ]
   } else {
     sections = [
+      CuratorsPicksEmerging,
       SimilarToRecentlyViewedArtworks,
       NewWorksForYou,
       HeroUnits,

--- a/src/schema/v2/homeView/getSectionsForUser.ts
+++ b/src/schema/v2/homeView/getSectionsForUser.ts
@@ -30,13 +30,13 @@ export async function getSectionsForUser(
     sections = [
       RecentlyViewedArtworks,
       TrendingArtists,
+      CuratorsPicksEmerging,
       SimilarToRecentlyViewedArtworks,
       AuctionLotsForYou,
       NewWorksForYou,
       HeroUnits,
       NewWorksFromGalleriesYouFollow,
       RecommendedArtists,
-      CuratorsPicksEmerging,
     ]
   } else {
     sections = [

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -14,15 +14,19 @@ import {
 } from "./artistResolvers"
 import { HeroUnitsResolver } from "./heroUnitsResolver"
 
-type MaybeResolved<T> = T | ((context: ResolverContext) => Promise<T>)
+type MaybeResolved<T> =
+  | T
+  | ((context: ResolverContext, args: any) => Promise<T>)
 
 export type HomeViewSection = {
   id: string
   type: string
   component?: {
     title?: MaybeResolved<string>
+    type?: MaybeResolved<string>
     description?: MaybeResolved<string>
-    backgroundColor?: MaybeResolved<string>
+    backgroundImageURL?: MaybeResolved<string>
+    href?: MaybeResolved<string>
   }
   resolver?: GraphQLFieldResolver<any, ResolverContext>
 }
@@ -40,6 +44,7 @@ export const CuratorsPicksEmerging: HomeViewSection = {
   id: "home-view-section-curators-picks-emerging",
   type: "ArtworksRailHomeViewSection",
   component: {
+    type: "FeaturedCollection",
     title: async (context: ResolverContext) => {
       const { app_title } = await context.siteHeroUnitLoader(
         "curators-picks-emerging-app"
@@ -52,7 +57,19 @@ export const CuratorsPicksEmerging: HomeViewSection = {
       )
       return app_description
     },
-    backgroundColor: "black100",
+    backgroundImageURL: async (context: ResolverContext, args) => {
+      const {
+        background_image_app_phone_url,
+        background_image_app_tablet_url,
+      } = await context.siteHeroUnitLoader("curators-picks-emerging-app")
+
+      if (args.version === "wide") {
+        return background_image_app_tablet_url
+      }
+
+      return background_image_app_phone_url
+    },
+    href: "/collection/curators-picks-emerging",
   },
   resolver: CuratorsPicksEmergingArtworksResolver,
 }

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -30,6 +30,7 @@ export const SimilarToRecentlyViewedArtworks: HomeViewSection = {
   },
   resolver: SimilarToRecentlyViewedArtworksResolver,
 }
+
 export const RecentlyViewedArtworks: HomeViewSection = {
   id: "home-view-section-recently-viewed-artworks",
   type: "ArtworksRailHomeViewSection",

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -22,6 +22,7 @@ export type HomeViewSection = {
   component?: {
     title?: MaybeResolved<string>
     description?: MaybeResolved<string>
+    backgroundColor?: MaybeResolved<string>
   }
   resolver?: GraphQLFieldResolver<any, ResolverContext>
 }
@@ -51,6 +52,7 @@ export const CuratorsPicksEmerging: HomeViewSection = {
       )
       return app_description
     },
+    backgroundColor: "black100",
   },
   resolver: CuratorsPicksEmergingArtworksResolver,
 }

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -12,6 +12,7 @@ import {
   SuggestedArtistsResolver,
 } from "./artistResolvers"
 import { HeroUnitsResolver } from "./heroUnitsResolver"
+import { connectionFromArray } from "graphql-relay"
 
 export type HomeViewSection = {
   id: string
@@ -29,6 +30,22 @@ export const SimilarToRecentlyViewedArtworks: HomeViewSection = {
     title: "Similar to Works You’ve Viewed",
   },
   resolver: SimilarToRecentlyViewedArtworksResolver,
+}
+
+export const CuratorsPicksEmerging: HomeViewSection = {
+  id: "home-view-section-curators-picks-emerging",
+  type: "ArtworksRailHomeViewSection",
+  component: {
+    title: async (context: ResolverContext) => {
+      const { app_title } = await context.siteHeroUnitLoader(
+        "curators-picks-emerging-app"
+      )
+      return app_title
+    },
+  },
+  resolver: async (_parent, args) => {
+    return connectionFromArray([{ id: "TODO" }], args)
+  },
 }
 
 export const RecentlyViewedArtworks: HomeViewSection = {
@@ -95,6 +112,7 @@ export const HeroUnits: HomeViewSection = {
 
 const sections: HomeViewSection[] = [
   AuctionLotsForYou,
+  CuratorsPicksEmerging,
   HeroUnits,
   NewWorksForYou,
   NewWorksFromGalleriesYouFollow,

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -2,6 +2,7 @@ import { GraphQLFieldResolver } from "graphql"
 import { ResolverContext } from "types/graphql"
 import {
   AuctionLotsForYouResolver,
+  CuratorsPicksEmergingArtworksResolver,
   NewWorksForYouResolver,
   NewWorksFromGalleriesYouFollowResolver,
   RecentlyViewedArtworksResolver,
@@ -12,7 +13,6 @@ import {
   SuggestedArtistsResolver,
 } from "./artistResolvers"
 import { HeroUnitsResolver } from "./heroUnitsResolver"
-import { connectionFromArray } from "graphql-relay"
 
 export type HomeViewSection = {
   id: string
@@ -43,9 +43,7 @@ export const CuratorsPicksEmerging: HomeViewSection = {
       return app_title
     },
   },
-  resolver: async (_parent, args) => {
-    return connectionFromArray([{ id: "TODO" }], args)
-  },
+  resolver: CuratorsPicksEmergingArtworksResolver,
 }
 
 export const RecentlyViewedArtworks: HomeViewSection = {

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -17,7 +17,7 @@ export type HomeViewSection = {
   id: string
   type: string
   component?: {
-    title?: string | null
+    title?: string | ((context: ResolverContext) => Promise<string>)
   } | null
   resolver?: GraphQLFieldResolver<any, ResolverContext>
 }

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -21,6 +21,7 @@ export type HomeViewSection = {
   type: string
   component?: {
     title?: MaybeResolved<string>
+    description?: MaybeResolved<string>
   }
   resolver?: GraphQLFieldResolver<any, ResolverContext>
 }
@@ -43,6 +44,12 @@ export const CuratorsPicksEmerging: HomeViewSection = {
         "curators-picks-emerging-app"
       )
       return app_title
+    },
+    description: async (context: ResolverContext) => {
+      const { app_description } = await context.siteHeroUnitLoader(
+        "curators-picks-emerging-app"
+      )
+      return app_description
     },
   },
   resolver: CuratorsPicksEmergingArtworksResolver,

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -14,12 +14,14 @@ import {
 } from "./artistResolvers"
 import { HeroUnitsResolver } from "./heroUnitsResolver"
 
+type MaybeResolved<T> = T | ((context: ResolverContext) => Promise<T>)
+
 export type HomeViewSection = {
   id: string
   type: string
   component?: {
-    title?: string | ((context: ResolverContext) => Promise<string>)
-  } | null
+    title?: MaybeResolved<string>
+  }
   resolver?: GraphQLFieldResolver<any, ResolverContext>
 }
 


### PR DESCRIPTION
Related: https://github.com/artsy/metaphysics/pull/5912

Adds "Curators' Picks: Emerging" section to our new schema. See a discussion why we came up with some of implementation decisions [in Slack](https://artsy.slack.com/archives/C05EQL4R5N0/p1723746300946949).

Example request:

```graphql
query {
  homeView {
    section(id: "home-view-section-curators-picks-emerging") {
      ... on ArtworksRailHomeViewSection {
        component {
          title
          description
          backgroundImageURL
          href
        }

        artworksConnection(first: 1) {
          edges {
            node {
              title
            }
          }
        }
      }
    }
  }
}

```

And response:

```json
{
  "data": {
    "homeView": {
      "section": {
        "component": {
          "title": "Curators’ Picks: Emerging",
          "description": "The best works by rising talents on Artsy, available now.",
          "backgroundImageURL": "https://d32dm0rphc51dk.cloudfront.net/8hMW7lYWoZZXO3Kv2u8EaA/untouched-jpg.jpg",
          "href": "/collection/curators-picks-emerging"
        },
        "artworksConnection": {
          "edges": [
            {
              "node": {
                "title": "Landscapes (series VIII) #5"
              }
            }
          ]
        }
      }
    }
  }
}
```