### PR TITLE
feat(updateCollectorProfile): expose CollectorProfileType field 

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13440,7 +13440,7 @@ type Mutation {
   # Update a collection
   updateCollection(input: updateCollectionInput!): updateCollectionPayload
 
-  # Updating a collector profile (loyalty applicant status).
+  # Update a collector profile.
   updateCollectorProfile(
     input: UpdateCollectorProfileInput!
   ): UpdateCollectorProfilePayload
@@ -19112,6 +19112,10 @@ type UpdateCollectionSuccess {
   collection: Collection
 }
 
+type UpdateCollectorProfileFailure {
+  mutationError: GravityMutationError
+}
+
 input UpdateCollectorProfileInput {
   # List of affiliated auction house ids, referencing Galaxy.
   affiliatedAuctionHouseIds: [String]
@@ -19137,110 +19141,14 @@ input UpdateCollectorProfileInput {
 }
 
 type UpdateCollectorProfilePayload {
-  artsyUserSince(
-    format: String
-
-    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-    timezone: String
-  ): String
-  bio: String
   clientMutationId: String
-  collectedArtworksCount: Int!
-  collectorLevel: Int
+
+  # On success: the updated collector profile.
+  collectorProfileOrError: updateCollectorProfileResponseOrError
+}
+
+type UpdateCollectorProfileSuccess {
   collectorProfile: CollectorProfileType
-  companyName: String
-  companyWebsite: String
-  confirmedBuyerAt(
-    format: String
-
-    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-    timezone: String
-  ): String
-  email: String
-  emailConfirmed: Boolean
-    @deprecated(
-      reason: "emailConfirmed is going to be removed, use isEmailConfirmed instead"
-    )
-  firstNameLastInitial: String
-  followedArtistsCount: Int!
-  icon: Image
-
-  # A globally unique ID.
-  id: ID!
-  identityVerified: Boolean
-    @deprecated(
-      reason: "identityVerified is going to be removed, use isIdentityVerified instead"
-    )
-  initials(length: Int = 3): String
-  inquiryRequestsCount: Int!
-  institutionalAffiliations: String
-  intents: [String]
-  interestsConnection(
-    after: String
-    before: String
-    first: Int
-    last: Int
-  ): UserInterestConnection
-
-  # A type-specific ID likely used as a database ID.
-  internalID: ID!
-  isActiveBidder: Boolean
-  isActiveInquirer: Boolean
-  isEmailConfirmed: Boolean
-  isIdentityVerified: Boolean
-  isProfileComplete: Boolean
-  lastUpdatePromptAt(
-    format: String
-
-    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-    timezone: String
-  ): String
-  location: MyLocation
-  loyaltyApplicantAt(
-    format: String
-
-    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-    timezone: String
-  ): String
-  name: String
-
-  # Collector's position with relevant institutions
-  otherRelevantPositions: String
-  owner: User!
-
-  # User ID of the collector profile's owner
-  ownerID: ID!
-
-  # Holds information about the engagement a collector profile has with a given partner
-  partnerEngagement(
-    # The ID of the partner to check for engagement
-    partnerID: ID!
-  ): PartnerEngagement
-  privacy: String
-  profession: String
-  professionalBuyerAppliedAt(
-    format: String
-
-    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-    timezone: String
-  ): String
-  professionalBuyerAt(
-    format: String
-
-    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-    timezone: String
-  ): String
-  savedArtworksCount: Int!
-  selfReportedPurchases: String
-
-  # An artwork-specific paragraph describing the collector.
-  summaryParagraph(
-    # This can be specified, and is injected in a conversation context for convenience.
-    artworkID: String
-  ): String
-  totalBidsCount: Int!
-  userInterests: [UserInterest]!
-    @deprecated(reason: "Use \"owner#interestsConnection\" field instead.")
 }
 
 type UpdateCollectorProfileWithIDFailure {
@@ -22242,6 +22150,10 @@ type updateCollectionPayload {
   clientMutationId: String
   responseOrError: UpdateCollectionResponseOrError
 }
+
+union updateCollectorProfileResponseOrError =
+    UpdateCollectorProfileFailure
+  | UpdateCollectorProfileSuccess
 
 type updateHeroUnitFailure {
   mutationError: GravityMutationError

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -19147,6 +19147,7 @@ type UpdateCollectorProfilePayload {
   clientMutationId: String
   collectedArtworksCount: Int!
   collectorLevel: Int
+  collectorProfile: CollectorProfileType
   companyName: String
   companyWebsite: String
   confirmedBuyerAt(

--- a/src/schema/v2/CollectorProfile/__tests__/updateCollectorProfileWithID.test.ts
+++ b/src/schema/v2/CollectorProfile/__tests__/updateCollectorProfileWithID.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable promise/always-return */
 import gql from "lib/gql"
-import { runAuthenticatedQuery, runQuery } from "schema/v2/test/utils"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
 
 describe("UpdateCollectorProfileWithID", () => {
   it("calls the expected loader with correctly formatted params", async () => {
@@ -83,30 +83,29 @@ describe("UpdateCollectorProfileWithID", () => {
   })
 
   it("throws error when data loader is missing", async () => {
-    const mutation = `
+    const mutation = gql`
       mutation {
-        updateCollectorProfile(input: { professionalBuyer: true, loyaltyApplicant: true, selfReportedPurchases: "trust me i buy art" }) {
-          internalID
-          name
-          email
-          selfReportedPurchases
-          intents
+        updateCollectorProfileWithID(
+          input: {
+            professionalBuyer: true
+            loyaltyApplicant: true
+            selfReportedPurchases: "trust me i buy art"
+          }
+        ) {
+          collectorProfileOrError {
+            __typename
+          }
         }
       }
     `
 
-    const errorResponse =
-      "Missing Update Collector Profile Loader. Check your access token."
+    const context = { updateCollectorProfileLoader: undefined }
 
-    expect.assertions(1)
-
-    try {
-      await runQuery(mutation)
-      throw new Error("An error was not thrown but was expected.")
-    } catch (error) {
-      // eslint-disable-next-line jest/no-conditional-expect, jest/no-try-expect
-      expect(error.message).toEqual(errorResponse)
-    }
+    await expect(
+      runAuthenticatedQuery(mutation, context)
+    ).rejects.toMatchInlineSnapshot(
+      "[Error: Missing Update Collector Profile Loader. Check your access token.]"
+    )
   })
 
   it("returns a GravityMutationError when invalid param is used", async () => {

--- a/src/schema/v2/me/__tests__/update_collector_profile.test.js
+++ b/src/schema/v2/me/__tests__/update_collector_profile.test.js
@@ -15,6 +15,10 @@ describe("UpdateCollectorProfile", () => {
           companyWebsite
           professionalBuyerAt
           lastUpdatePromptAt
+          collectorProfile {
+            email
+            internalID
+          }
         }
       }
     `
@@ -47,6 +51,10 @@ describe("UpdateCollectorProfile", () => {
       selfReportedPurchases: "treats",
       intents: ["buy art & design"],
       lastUpdatePromptAt: "2022-08-15T11:14:55+00:00",
+      collectorProfile: {
+        internalID: "3",
+        email: "percy@cat.com",
+      },
     }
 
     expect.assertions(2)

--- a/src/schema/v2/me/__tests__/update_collector_profile.test.js
+++ b/src/schema/v2/me/__tests__/update_collector_profile.test.js
@@ -1,23 +1,34 @@
 /* eslint-disable promise/always-return */
-import { runAuthenticatedQuery, runQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
 
 describe("UpdateCollectorProfile", () => {
   it("calls the expected loader with correctly formatted params", async () => {
-    const mutation = `
+    const mutation = gql`
       mutation {
-        updateCollectorProfile(input: { professionalBuyer: true, loyaltyApplicant: true, selfReportedPurchases: "trust me i buy art", intents: [BUY_ART_AND_DESIGN], institutionalAffiliations: "example", companyName: "Cool Art Stuff", companyWebsite: "https://artsy.net", promptedForUpdate: true }) {
-          internalID
-          name
-          email
-          selfReportedPurchases
-          intents
-          companyName
-          companyWebsite
-          professionalBuyerAt
-          lastUpdatePromptAt
-          collectorProfile {
-            email
-            internalID
+        updateCollectorProfile(
+          input: {
+            professionalBuyer: true
+            loyaltyApplicant: true
+            selfReportedPurchases: "trust me i buy art"
+            intents: [BUY_ART_AND_DESIGN]
+            institutionalAffiliations: "example"
+            companyName: "Cool Art Stuff"
+            companyWebsite: "https://artsy.net"
+            promptedForUpdate: true
+          }
+        ) {
+          collectorProfileOrError {
+            __typename
+            ... on UpdateCollectorProfileSuccess {
+              collectorProfile {
+                internalID
+                name
+                email
+                intents
+                lastUpdatePromptAt
+              }
+            }
           }
         }
       }
@@ -42,22 +53,17 @@ describe("UpdateCollectorProfile", () => {
     }
 
     const expectedProfileData = {
-      companyName: "Cool Art Stuff",
-      companyWebsite: "https://artsy.net",
-      professionalBuyerAt: "2022-08-15T11:14:55+00:00",
-      internalID: "3",
-      name: "Percy",
-      email: "percy@cat.com",
-      selfReportedPurchases: "treats",
-      intents: ["buy art & design"],
-      lastUpdatePromptAt: "2022-08-15T11:14:55+00:00",
-      collectorProfile: {
-        internalID: "3",
-        email: "percy@cat.com",
+      collectorProfileOrError: {
+        __typename: "UpdateCollectorProfileSuccess",
+        collectorProfile: {
+          internalID: "3",
+          name: "Percy",
+          email: "percy@cat.com",
+          intents: ["buy art & design"],
+          lastUpdatePromptAt: "2022-08-15T11:14:55+00:00",
+        },
       },
     }
-
-    expect.assertions(2)
 
     const { updateCollectorProfile } = await runAuthenticatedQuery(
       mutation,
@@ -78,30 +84,46 @@ describe("UpdateCollectorProfile", () => {
     })
   })
 
-  it("throws error when data loader is missing", async () => {
-    const mutation = `
+  it("returns updateClientId", async () => {
+    const mutation = gql`
       mutation {
-        updateCollectorProfile(input: { professionalBuyer: true, loyaltyApplicant: true, selfReportedPurchases: "trust me i buy art" }) {
-          internalID
-          name
-          email
-          selfReportedPurchases
-          intents
+        updateCollectorProfile(
+          input: { professionalBuyer: true, clientMutationId: "mutation-id" }
+        ) {
+          clientMutationId
         }
       }
     `
 
-    const errorResponse =
-      "Missing Update Collector Profile Loader. Check your access token."
-
-    expect.assertions(1)
-
-    try {
-      await runQuery(mutation)
-      throw new Error("An error was not thrown but was expected.")
-    } catch (error) {
-      // eslint-disable-next-line jest/no-conditional-expect, jest/no-try-expect
-      expect(error.message).toEqual(errorResponse)
+    const context = {
+      meUpdateCollectorProfileLoader: jest.fn().mockReturnValue({}),
     }
+
+    const { updateCollectorProfile } = await runAuthenticatedQuery(
+      mutation,
+      context
+    )
+
+    expect(updateCollectorProfile).toEqual({ clientMutationId: "mutation-id" })
+  })
+
+  it("throws an error given a missing data loader", async () => {
+    const mutation = gql`
+      mutation {
+        updateCollectorProfile(input: { professionalBuyer: true }) {
+          collectorProfileOrError {
+            __typename
+          }
+        }
+      }
+    `
+
+    const context = { meUpdateCollectorProfileLoader: undefined }
+
+    await expect(
+      runAuthenticatedQuery(mutation, context)
+    ).rejects.toMatchInlineSnapshot(
+      "[Error: Missing Update Collector Profile Loader. Check your access token.]"
+    )
   })
 })

--- a/src/schema/v2/me/update_collector_profile.ts
+++ b/src/schema/v2/me/update_collector_profile.ts
@@ -2,7 +2,10 @@ import { GraphQLBoolean, GraphQLString, GraphQLList } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 import { ResolverContext } from "types/graphql"
 import { snakeCase } from "lodash"
-import { CollectorProfileFields } from "../CollectorProfile/collectorProfile"
+import {
+  CollectorProfileFields,
+  CollectorProfileType,
+} from "../CollectorProfile/collectorProfile"
 import { IntentsType } from "../CollectorProfile/types/IntentsType"
 
 export default mutationWithClientMutationId<any, any, ResolverContext>({
@@ -37,7 +40,13 @@ export default mutationWithClientMutationId<any, any, ResolverContext>({
       type: GraphQLString,
     },
   },
-  outputFields: CollectorProfileFields,
+  outputFields: {
+    ...CollectorProfileFields,
+    collectorProfile: {
+      type: CollectorProfileType,
+      resolve: (collectorProfile) => collectorProfile,
+    },
+  },
   mutateAndGetPayload: (args, { meUpdateCollectorProfileLoader }) => {
     // snake_case keys for Gravity (keys are the same otherwise)
     const options = Object.keys(args).reduce(


### PR DESCRIPTION
This old mutation returns a default `UpdateCollectorProfilePayload` which doesn't fit anywhere using it with relay. 
The changes here expose `collectorProfile` with the type supported by our schema when it comes to spreading fragments. Nothing new here, we have this pattern in other mutations such as `updateMyUserProfile`, and could extend it to something like `collectorProfileOrError` but it seemed too much for this small exposition, open to feedback 😄 
