### PR TITLE
feat(onyx-1199): add 'Featured Fairs' home view section

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9683,6 +9683,24 @@ type FairSponsoredContent {
   pressReleaseUrl: String
 }
 
+# Fairs rail section
+type FairsRailHomeViewSection implements GenericHomeViewSection & Node {
+  # The component that is prescribed for this section
+  component: HomeViewComponent
+  fairsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): FairConnection!
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+}
+
 # A Feature
 type Feature {
   callout(format: Format): String
@@ -10954,6 +10972,7 @@ enum HomeViewComponentBackgroundImageURLVersion {
 union HomeViewSection =
     ArtistsRailHomeViewSection
   | ArtworksRailHomeViewSection
+  | FairsRailHomeViewSection
   | HeroUnitsHomeViewSection
 
 # A connection to a list of items.

--- a/src/schema/v2/homeView/HomeViewSection.ts
+++ b/src/schema/v2/homeView/HomeViewSection.ts
@@ -12,6 +12,7 @@ import { HomeViewComponent } from "./HomeViewComponent"
 import { artworkConnection } from "../artwork"
 import { artistsConnection } from "../artists"
 import { heroUnitsConnection } from "../HeroUnit/heroUnitsConnection"
+import { fairsConnection } from "../fairs"
 
 // section interface
 
@@ -88,6 +89,25 @@ const HeroUnitsHomeViewSectionType = new GraphQLObjectType<
   },
 })
 
+const FairsRailHomeViewSectionType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "FairsRailHomeViewSection",
+  description: "Fairs rail section",
+  interfaces: [GenericHomeViewSectionInterface, NodeInterface],
+  fields: {
+    ...standardSectionFields,
+
+    fairsConnection: {
+      type: new GraphQLNonNull(fairsConnection.type),
+      args: pageable({}),
+      resolve: (parent, ...rest) =>
+        parent.resolver ? parent.resolver(parent, ...rest) : [],
+    },
+  },
+})
+
 // the Section union type of all concrete sections
 
 export const HomeViewSectionType = new GraphQLUnionType({
@@ -96,6 +116,7 @@ export const HomeViewSectionType = new GraphQLUnionType({
     ArtworksRailHomeViewSectionType,
     ArtistsRailHomeViewSectionType,
     HeroUnitsHomeViewSectionType,
+    FairsRailHomeViewSectionType,
   ],
   resolveType: (value) => {
     return value.type

--- a/src/schema/v2/homeView/__tests__/HomeView.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeView.test.ts
@@ -6,7 +6,7 @@ describe("homeView", () => {
     const query = gql`
       {
         homeView {
-          sectionsConnection(first: 10) {
+          sectionsConnection(first: 20) {
             edges {
               node {
                 __typename
@@ -31,12 +31,6 @@ describe("homeView", () => {
       }),
     }
 
-    it("returns a connection of home view sections", async () => {
-      const { homeView } = await runQuery(query, context)
-
-      expect(homeView.sectionsConnection.edges).toHaveLength(9)
-    })
-
     it("returns requested data for each section", async () => {
       const { homeView } = await runQuery(query, context)
 
@@ -56,6 +50,14 @@ describe("homeView", () => {
                 "__typename": "ArtworksRailHomeViewSection",
                 "component": Object {
                   "title": "Similar to Works You’ve Viewed",
+                },
+              },
+            },
+            Object {
+              "node": Object {
+                "__typename": "FairsRailHomeViewSection",
+                "component": Object {
+                  "title": "Featured Fairs",
                 },
               },
             },

--- a/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
@@ -330,4 +330,81 @@ describe("HomeViewSection", () => {
       `)
     })
   })
+
+  describe("FairsRailHomeViewSection", () => {
+    it("returns correct data", async () => {
+      const query = gql`
+        {
+          homeView {
+            section(id: "home-view-section-featured-fairs") {
+              __typename
+
+              ... on FairsRailHomeViewSection {
+                component {
+                  title
+                }
+
+                fairsConnection(first: 2) {
+                  edges {
+                    node {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const fairs = {
+        body: [
+          {
+            id: "fair-1",
+            name: "Fair 1",
+            start_at: "2024-05-23T11:00:00+00:00",
+            end_at: "2024-06-23T11:00:00+00:00",
+          },
+          {
+            id: "fair-2",
+            name: "Fair 2",
+            start_at: "2024-05-23T11:00:00+00:00",
+            end_at: "2024-06-23T11:00:00+00:00",
+          },
+        ],
+      }
+
+      const context = {
+        authenticatedLoaders: {
+          meLoader: jest.fn().mockReturnValue({ type: "User" }),
+        },
+        fairsLoader: jest.fn().mockResolvedValue(fairs),
+      }
+
+      const { homeView } = await runQuery(query, context)
+
+      expect(homeView.section).toMatchInlineSnapshot(`
+        Object {
+          "__typename": "FairsRailHomeViewSection",
+          "component": Object {
+            "title": "Featured Fairs",
+          },
+          "fairsConnection": Object {
+            "edges": Array [
+              Object {
+                "node": Object {
+                  "name": "Fair 1",
+                },
+              },
+              Object {
+                "node": Object {
+                  "name": "Fair 2",
+                },
+              },
+            ],
+          },
+        }
+      `)
+    })
+  })
 })

--- a/src/schema/v2/homeView/featuredFairsResolver.ts
+++ b/src/schema/v2/homeView/featuredFairsResolver.ts
@@ -1,0 +1,19 @@
+import { GraphQLFieldResolver } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { HomePageFairsModuleType } from "../home/home_page_fairs_module"
+import { connectionFromArray } from "graphql-relay"
+
+export const FeaturedFairsResolver: GraphQLFieldResolver<
+  any,
+  ResolverContext
+> = async (parent, args, context, info) => {
+  const resolver = HomePageFairsModuleType.getFields().results
+
+  if (!resolver?.resolve) {
+    return []
+  }
+
+  const result = await resolver.resolve(parent, args, context, info)
+
+  return connectionFromArray(result, args)
+}

--- a/src/schema/v2/homeView/getSectionsForUser.ts
+++ b/src/schema/v2/homeView/getSectionsForUser.ts
@@ -2,6 +2,7 @@ import { ResolverContext } from "types/graphql"
 import {
   AuctionLotsForYou,
   CuratorsPicksEmerging,
+  FeaturedFairs,
   HeroUnits,
   HomeViewSection,
   NewWorksForYou,
@@ -30,6 +31,7 @@ export async function getSectionsForUser(
     sections = [
       RecentlyViewedArtworks,
       TrendingArtists,
+      FeaturedFairs,
       CuratorsPicksEmerging,
       SimilarToRecentlyViewedArtworks,
       AuctionLotsForYou,
@@ -42,6 +44,7 @@ export async function getSectionsForUser(
     sections = [
       CuratorsPicksEmerging,
       SimilarToRecentlyViewedArtworks,
+      FeaturedFairs,
       NewWorksForYou,
       HeroUnits,
       AuctionLotsForYou,

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -13,6 +13,7 @@ import {
   SuggestedArtistsResolver,
 } from "./artistResolvers"
 import { HeroUnitsResolver } from "./heroUnitsResolver"
+import { FeaturedFairsResolver } from "./featuredFairsResolver"
 
 type MaybeResolved<T> =
   | T
@@ -23,7 +24,7 @@ export type HomeViewSection = {
   type: string
   component?: {
     title?: MaybeResolved<string>
-    type?: MaybeResolved<string>
+    type?: string
     description?: MaybeResolved<string>
     backgroundImageURL?: MaybeResolved<string>
     href?: MaybeResolved<string>
@@ -136,9 +137,20 @@ export const HeroUnits: HomeViewSection = {
   resolver: HeroUnitsResolver,
 }
 
+export const FeaturedFairs: HomeViewSection = {
+  id: "home-view-section-featured-fairs",
+  type: "FairsRailHomeViewSection",
+  component: {
+    title: "Featured Fairs",
+    description: "See Works in Top Art Fairs",
+  },
+  resolver: FeaturedFairsResolver,
+}
+
 const sections: HomeViewSection[] = [
   AuctionLotsForYou,
   CuratorsPicksEmerging,
+  FeaturedFairs,
   HeroUnits,
   NewWorksForYou,
   NewWorksFromGalleriesYouFollow,


### PR DESCRIPTION
Example request:

```graphql
query X {
  homeView {
    section(id: "home-view-section-featured-fairs") {
      ... on FairsRailHomeViewSection {
        __typename
        component {
          title
        }

        fairsConnection(first: 10) {
          edges {
            node {
              __typename
              name
            }
          }
        }
      }
    }
  }
}
```

Response:

```
{
  "data": {
    "homeView": {
      "section": {
        "__typename": "FairsRailHomeViewSection",
        "component": {
          "title": "Featured Fairs"
        },
        "fairsConnection": {
          "edges": [
            {
              "node": {
                "__typename": "Fair",
                "name": "Intersect Aspen 2024"
              }
            },
            {
              "node": {
                "__typename": "Fair",
                "name": "The Aspen Art Fair 2024"
              }
            },
           ...
        }
      }
    }
  }
}
```
```