### PR TITLE
feat: add withTimeout wrapper for DataLoader

### DIFF
--- a/src/lib/loaders/__tests__/helpers.test.ts
+++ b/src/lib/loaders/__tests__/helpers.test.ts
@@ -1,0 +1,51 @@
+import { withTimeout } from "../helpers"
+
+jest.useFakeTimers()
+
+describe("withTimeout", () => {
+  it("rejects after the timeout", async () => {
+    const loader = new Promise((resolve) => {
+      setTimeout(() => {
+        resolve("done")
+      }, 1000)
+    })
+
+    const timeoutMs = 500
+    const result = withTimeout(loader, timeoutMs)
+
+    jest.advanceTimersByTime(1000)
+
+    await expect(result).rejects.toThrow("Timeout of 500ms")
+  })
+
+  it("resolves before the timeout", async () => {
+    const loader = new Promise((resolve) => {
+      setTimeout(() => {
+        resolve("done")
+      }, 500)
+    })
+
+    const timeoutMs = 1000
+    const result = withTimeout(loader, timeoutMs)
+
+    jest.advanceTimersByTime(500)
+
+    await expect(result).resolves.toBe("done")
+  })
+
+  it("works with a loader that errors", async () => {
+    // eslint-disable-next-line promise/param-names
+    const loader = new Promise((_resolve, reject) => {
+      setTimeout(() => {
+        reject(new Error("failed"))
+      }, 500)
+    })
+
+    const timeoutMs = 1000
+    const result = withTimeout(loader, timeoutMs)
+
+    jest.advanceTimersByTime(500)
+
+    await expect(result).rejects.toThrow("failed")
+  })
+})

--- a/src/lib/loaders/helpers.ts
+++ b/src/lib/loaders/helpers.ts
@@ -5,6 +5,55 @@ const MAX_FOLLOWED_ARTISTS_PER_STEP = 100
 const MAX_STEPS = 1
 
 /**
+ * This is a wrapper for invoking a data loader with a configurable timeout.
+ */
+export const withTimeout = async (loader: Promise<any>, timeoutMs: number) => {
+  try {
+    let data: unknown
+
+    await new Promise<void>((resolve, reject) => {
+      // Will reject promise after configured timeout if the loader command has
+      // not completed yet.
+      let timeoutId: NodeJS.Timeout | null = setTimeout(() => {
+        timeoutId = null
+
+        const error = new Error(`Timeout of ${timeoutMs}ms`)
+
+        reject(error)
+      }, timeoutMs)
+
+      const onComplete = (response) => {
+        if (!timeoutId) {
+          return // Already timed out.
+        }
+
+        clearTimeout(timeoutId)
+        data = response
+        resolve()
+      }
+
+      const onError = (error) => {
+        if (!timeoutId) {
+          return // Already timed out.
+        }
+
+        clearTimeout(timeoutId)
+        reject(error)
+      }
+
+      loader.then(onComplete).catch(onError)
+    })
+
+    return data
+  } catch (e) {
+    console.error(`[withTimeout]: ${e.message}`)
+
+    // Re-throw to bubble up the error.
+    throw e
+  }
+}
+
+/**
  * This is a helper function that loads all followed artists for a user.
  * Since we cannot query more than 100 artists at a time, we have to do this in several steps.
  */


### PR DESCRIPTION
This adds a `withTimeout` wrapper that you can use when invoking a data loader, passing in a timeout (in milliseconds).

If the loader takes longer than the specified timeout, the method throws - when configuring it as a test via `withTimeout(artworkLoader(id), 50)` (an intentionally short timeout) - looks like:

<img width="1008" alt="Screenshot 2024-08-19 at 1 13 21 PM" src="https://github.com/user-attachments/assets/ab69a717-01c6-4ed6-9e0e-3e440e3cbb8f">

Based on the Slack discussion about wanting more finer-grained control over homepage data resolution. I can envision homeview-scoped data loader invocations wanting to use this in order to ensure quick (altho potentially incomplete) responses. Pretty simple approach to start - I decided against over-engineering anything w.r.t to factories and the like (like a 'homeview' data loader factory that always includes this functionality kind of thing).

Do y'all think this might be a useful approach/tool to have?