### PR TITLE
fix(home view): nullability and empty responses

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2295,7 +2295,7 @@ type ArtistsRailHomeViewSection implements GenericHomeViewSection & Node {
     before: String
     first: Int
     last: Int
-  ): ArtistConnection!
+  ): ArtistConnection
 
   # The component that is prescribed for this section
   component: HomeViewComponent
@@ -3165,7 +3165,7 @@ type ArtworksRailHomeViewSection implements GenericHomeViewSection & Node {
     before: String
     first: Int
     last: Int
-  ): ArtworkConnection!
+  ): ArtworkConnection
 
   # The component that is prescribed for this section
   component: HomeViewComponent
@@ -10644,7 +10644,7 @@ type HeroUnitsHomeViewSection implements GenericHomeViewSection & Node {
     before: String
     first: Int
     last: Int
-  ): HeroUnitConnection!
+  ): HeroUnitConnection
 
   # A globally unique ID.
   id: ID!

--- a/src/schema/v2/homeView/HomeViewSection.ts
+++ b/src/schema/v2/homeView/HomeViewSection.ts
@@ -1,7 +1,6 @@
 import {
   GraphQLFieldConfigMap,
   GraphQLInterfaceType,
-  GraphQLNonNull,
   GraphQLObjectType,
   GraphQLUnionType,
 } from "graphql"
@@ -42,7 +41,7 @@ const ArtworksRailHomeViewSectionType = new GraphQLObjectType<
     ...standardSectionFields,
 
     artworksConnection: {
-      type: new GraphQLNonNull(artworkConnection.connectionType),
+      type: artworkConnection.connectionType,
       args: pageable({}),
       resolve: (parent, ...rest) =>
         parent.resolver ? parent.resolver(parent, ...rest) : [],
@@ -61,7 +60,7 @@ const ArtistsRailHomeViewSectionType = new GraphQLObjectType<
     ...standardSectionFields,
 
     artistsConnection: {
-      type: new GraphQLNonNull(artistsConnection.type),
+      type: artistsConnection.type,
       args: pageable({}),
       resolve: (parent, ...rest) =>
         parent.resolver ? parent.resolver(parent, ...rest) : [],
@@ -80,7 +79,7 @@ const HeroUnitsHomeViewSectionType = new GraphQLObjectType<
     ...standardSectionFields,
 
     heroUnitsConnection: {
-      type: new GraphQLNonNull(heroUnitsConnection.type),
+      type: heroUnitsConnection.type,
       args: pageable({}),
       resolve: (parent, ...rest) =>
         parent.resolver ? parent.resolver(parent, ...rest) : [],

--- a/src/schema/v2/homeView/HomeViewSection.ts
+++ b/src/schema/v2/homeView/HomeViewSection.ts
@@ -7,6 +7,7 @@ import {
 import { pageable } from "relay-cursor-paging"
 import { ResolverContext } from "types/graphql"
 import { InternalIDFields, NodeInterface } from "../object_identification"
+import { emptyConnection } from "../fields/pagination"
 import { HomeViewComponent } from "./HomeViewComponent"
 import { artworkConnection } from "../artwork"
 import { artistsConnection } from "../artists"
@@ -44,7 +45,7 @@ const ArtworksRailHomeViewSectionType = new GraphQLObjectType<
       type: artworkConnection.connectionType,
       args: pageable({}),
       resolve: (parent, ...rest) =>
-        parent.resolver ? parent.resolver(parent, ...rest) : [],
+        parent.resolver ? parent.resolver(parent, ...rest) : emptyConnection,
     },
   },
 })
@@ -63,7 +64,7 @@ const ArtistsRailHomeViewSectionType = new GraphQLObjectType<
       type: artistsConnection.type,
       args: pageable({}),
       resolve: (parent, ...rest) =>
-        parent.resolver ? parent.resolver(parent, ...rest) : [],
+        parent.resolver ? parent.resolver(parent, ...rest) : emptyConnection,
     },
   },
 })
@@ -82,7 +83,7 @@ const HeroUnitsHomeViewSectionType = new GraphQLObjectType<
       type: heroUnitsConnection.type,
       args: pageable({}),
       resolve: (parent, ...rest) =>
-        parent.resolver ? parent.resolver(parent, ...rest) : [],
+        parent.resolver ? parent.resolver(parent, ...rest) : emptyConnection,
     },
   },
 })


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-1201

Addresses two issues in the design of the new `homeView` schema (h/t @mzikherman):

- The schema currently is over-aggressive about declaring non-nullability. It makes that promise even when it can't guarantee it, e.g. when making an async upstream call to fetch the data to fulfill an `artworksConnection` or `artistsConnection`. Not only is this not realistic, it also results in [cryptic error messages that have already derailed developers.](https://artsy.slack.com/archives/C05EQL4R5N0/p1724096191940129?thread_ts=1724081856.316439&cid=C05EQL4R5N0)

- There is a [better way](https://artsy.slack.com/archives/C05EQL4R5N0/p1724099057516639?thread_ts=1724081856.316439&cid=C05EQL4R5N0) to return an empty connection with the correct shape than the `[]` we are doing currently

This also sets us up to wire up the incoming `withTimeout` helper (#5920), which will produce sensible error messages after this change 🎉 