### PR TITLE
feat(alerts): Add partnerAlertHitsConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14526,6 +14526,16 @@ type Partner implements Node {
   ): LocationConnection
   meta: PartnerMeta
   name: String
+
+  # A connection of search criteria hits from a Partner.
+  partnerAlertHitsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    page: Int
+    size: Int
+  ): PartnerAlertHitsConnection
   partnerPageEligible: Boolean
   partnerType: String
   profile: Profile
@@ -14598,6 +14608,36 @@ type PartnerAgreement {
 
 # A partner agreement or errors object
 union PartnerAgreementOrErrorsUnion = Errors | PartnerAgreement
+
+# A connection to a list of items.
+type PartnerAlertHitsConnection {
+  # A list of edges.
+  edges: [PartnerAlertHitsEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type PartnerAlertHitsEdge {
+  artwork: Artwork
+  createdAt: String
+
+  # A cursor for use in pagination
+  cursor: String!
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID.
+  internalID: ID!
+
+  # The item at the end of the edge
+  node: Alert
+  userIDs: [String]
+}
 
 # A connection to a list of items.
 type PartnerAlertsConnection {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -559,6 +559,7 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+
     partnerAllLoader: gravityLoader((id) => `partner/${id}/all`),
     partnerArtistDocumentsLoader: gravityLoader<
       any,
@@ -660,6 +661,11 @@ export default (accessToken, userID, opts) => {
     ),
     partnerSearchCriteriaLoader: gravityLoader(
       (id) => `/partner/${id}/partner_search_criterias`,
+      {},
+      { headers: true }
+    ),
+    partnerSearchCriteriaHitsLoader: gravityLoader(
+      (id) => `partner/${id}/partner_search_criteria_hits`,
       {},
       { headers: true }
     ),

--- a/src/schema/v2/partner/__tests__/partner.test.js
+++ b/src/schema/v2/partner/__tests__/partner.test.js
@@ -14,7 +14,6 @@ describe("Partner type", () => {
       type: "Gallery",
       has_full_profile: true,
       inquireable: false,
-      profile_banner_display: true,
       distinguish_represented_artists: true,
       profile_banner_display: "Artworks",
       claimed: true,
@@ -1497,24 +1496,24 @@ describe("Partner type", () => {
             {
               artist: {
                 name: "Molly D",
-                id: "5f80bfefe8d808000ea212c2"
+                id: "5f80bfefe8d808000ea212c2",
               },
-              total_alert_count: 1
+              total_alert_count: 1,
             },
             {
-              artist: { 
+              artist: {
                 name: "Percy Z",
-                id: "5f80bfefe8d808000ea212c1"
+                id: "5f80bfefe8d808000ea212c1",
               },
-              total_alert_count: 12
-            }
-          ]  
+              total_alert_count: 12,
+            },
+          ],
         },
         headers: {
           "x-total-count": 2,
         },
       }
-      
+
       const query = gql`
         {
           partner(id: "catty-partner") {
@@ -1530,7 +1529,8 @@ describe("Partner type", () => {
           }
         }
       `
-      const partnerArtistsWithAlertCountsLoader = () => Promise.resolve(response)
+      const partnerArtistsWithAlertCountsLoader = () =>
+        Promise.resolve(response)
 
       const data = await runAuthenticatedQuery(query, {
         ...context,
@@ -1540,7 +1540,7 @@ describe("Partner type", () => {
         partner: {
           artistsWithAlertCountsConnection: {
             totalCount: 2,
-              edges: [
+            edges: [
               {
                 totalAlertCount: 1,
                 node: {
@@ -1551,6 +1551,79 @@ describe("Partner type", () => {
                 totalAlertCount: 12,
                 node: {
                   name: "Percy Z",
+                },
+              },
+            ],
+          },
+        },
+      })
+    })
+  })
+
+  describe("#partnerAlertHitsConnection", () => {
+    it("returns connection of matching partner_alert_hits", async () => {
+      const response = {
+        body: [
+          {
+            id: "some-id",
+            artwork: {
+              title: "Some Artwork",
+              _id: "5f80bfefe8d808000ea212c2",
+            },
+            created_at: "foo",
+            user_ids: ["foo", "bar"],
+            search_criteria: {
+              id: "3f980bbe-7b9b-4fa9-beb1-69d13e94fb0c",
+            },
+          },
+        ],
+        headers: {
+          "x-total-count": 1,
+        },
+      }
+
+      const query = gql`
+        {
+          partner(id: "cypress-test-partner-for-automated-testing-purposes") {
+            partnerAlertHitsConnection(first: 10) {
+              totalCount
+              edges {
+                internalID
+                artwork {
+                  internalID
+                  title
+                }
+                userIDs
+                createdAt
+                node {
+                  internalID
+                }
+              }
+            }
+          }
+        }
+      `
+      const partnerSearchCriteriaHitsLoader = () => Promise.resolve(response)
+
+      const data = await runAuthenticatedQuery(query, {
+        ...context,
+        partnerSearchCriteriaHitsLoader,
+      })
+      expect(data).toEqual({
+        partner: {
+          partnerAlertHitsConnection: {
+            totalCount: 1,
+            edges: [
+              {
+                internalID: "some-id",
+                userIDs: ["foo", "bar"],
+                createdAt: "foo",
+                artwork: {
+                  internalID: "5f80bfefe8d808000ea212c2",
+                  title: "Some Artwork",
+                },
+                node: {
+                  internalID: "3f980bbe-7b9b-4fa9-beb1-69d13e94fb0c",
                 },
               },
             ],

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -21,10 +21,11 @@ import EventStatus, {
   EventStatusEnums,
 } from "schema/v2/input_fields/event_status"
 import {
+  IDFields,
   NodeInterface,
   SlugAndInternalIDFields,
 } from "schema/v2/object_identification"
-import { artworkConnection } from "schema/v2/artwork"
+import Artwork, { artworkConnection } from "schema/v2/artwork"
 import numeral from "schema/v2/fields/numeral"
 import { ShowsConnection, ShowType } from "schema/v2/show"
 import { ArtistType } from "schema/v2/artist"
@@ -175,22 +176,40 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       nodeType: ArtistType,
     }).connectionType
 
-    const PartnerArtistsSummaryEdgeFields = {
-      totalAlertCount: {
-        type: GraphQLInt,
-        resolve: ({ total_alert_count }) => total_alert_count,
-      },
-    }
-
-    const artistsWithAlertCountsConnectionType = connectionWithCursorInfo({
+    const ArtistsWithAlertCountsConnectionType = connectionWithCursorInfo({
       name: "ArtistsWithAlertCounts",
-      edgeFields: PartnerArtistsSummaryEdgeFields,
+      edgeFields: {
+        totalAlertCount: {
+          type: GraphQLInt,
+          resolve: ({ total_alert_count }) => total_alert_count,
+        },
+      },
       nodeType: ArtistType,
     }).connectionType
 
     const PartnerAlertsConnectionType = connectionWithCursorInfo({
       name: "PartnerAlerts",
       edgeFields: PartnerAlertsEdgeFields,
+      nodeType: AlertType,
+    }).connectionType
+
+    const PartnerAlertHitsConnection = connectionWithCursorInfo({
+      name: "PartnerAlertHits",
+      edgeFields: {
+        ...IDFields,
+        artwork: {
+          type: Artwork.type,
+          resolve: ({ artwork }) => artwork,
+        },
+        createdAt: {
+          type: GraphQLString,
+          resolve: ({ created_at }) => created_at,
+        },
+        userIDs: {
+          type: new GraphQLList(GraphQLString),
+          resolve: ({ user_ids }) => user_ids,
+        },
+      },
       nodeType: AlertType,
     }).connectionType
 
@@ -263,7 +282,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       artistsWithAlertCountsConnection: {
-        type: artistsWithAlertCountsConnectionType,
+        type: ArtistsWithAlertCountsConnectionType,
         args: pageable({
           page: {
             type: GraphQLInt,
@@ -362,6 +381,53 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             page,
             size,
             body: body.hits,
+            args,
+            resolveNode: ({ search_criteria }) => search_criteria,
+          })
+        },
+      },
+      partnerAlertHitsConnection: {
+        description: "A connection of search criteria hits from a Partner.",
+        type: PartnerAlertHitsConnection,
+        args: pageable({
+          page: {
+            type: GraphQLInt,
+          },
+          size: {
+            type: GraphQLInt,
+          },
+        }),
+        resolve: async ({ _id }, args, { partnerSearchCriteriaHitsLoader }) => {
+          if (!partnerSearchCriteriaHitsLoader) return null
+          const { page, size, offset } = convertConnectionArgsToGravityArgs(
+            args
+          )
+
+          type GravityArgs = {
+            page: number
+            size: number
+            total_count: boolean
+          }
+
+          const gravityArgs: GravityArgs = {
+            page,
+            size,
+            total_count: true,
+          }
+
+          const { body, headers } = await partnerSearchCriteriaHitsLoader?.(
+            _id,
+            gravityArgs
+          )
+
+          const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+          return paginationResolver({
+            totalCount,
+            offset,
+            page,
+            size,
+            body,
             args,
             resolveNode: ({ search_criteria }) => search_criteria,
           })


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/AMBER-914

Adds a new connection to the partners alerts eco system:

```graphql
{
  partner(id: "cypress-test-partner-for-automated-testing-purposes") {
    partnerAlertHitsConnection(first: 10) {
      totalCount
      edges {
        
        internalID
        artwork {
          internalID
          title
        }
        userIDs
        createdAt
        node {
          additionalGeneIDs
        }
      }
    }
  }
}
```

cc @artsy/amber-devs 