### PR TITLE
fix(EMI-2015): Typo in userID property

### DIFF
--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -171,7 +171,7 @@ export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
 
 const checkFeatureFlag = (flag: any, context: any) => {
   const unleashContext = {
-    userId: context.userId,
+    userId: context.userID,
   }
   return isFeatureFlagEnabled(flag, unleashContext)
 }


### PR DESCRIPTION
#minor 
This PR fixes a small typo in a property we were accessing on the context to build an unleash context's user id.