### PR TITLE
feat: Expose artistSeriesNames field from Search criteria

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -230,6 +230,7 @@ type Alert {
   additionalGeneNames: [String]
   artistIDs: [String]
   artistSeriesIDs: [String]
+  artistSeriesNames: [String]
   artists: [Artist!]!
   artistsConnection(
     after: String

--- a/src/schema/v2/Alerts/index.ts
+++ b/src/schema/v2/Alerts/index.ts
@@ -168,6 +168,7 @@ type GravitySearchCriteriaJSON = {
   count_7d?: number // only present when data is returned from ElasticSearch
   artist_ids: string[]
   artist_series_ids: string[]
+  artist_series_names: string[]
   partner_ids: string[]
   location_cities: string[]
   major_periods: string[]
@@ -267,6 +268,10 @@ export const AlertType = new GraphQLObjectType<
       artistSeriesIDs: {
         type: new GraphQLList(GraphQLString),
         resolve: ({ artist_series_ids }) => artist_series_ids,
+      },
+      artistSeriesNames: {
+        type: new GraphQLList(GraphQLString),
+        resolve: ({ artist_series_names }) => artist_series_names,
       },
       atAuction: {
         type: GraphQLBoolean,


### PR DESCRIPTION
feat: Expose `artistSeriesNames` field from Search criteria


Exposes the new field from Gravity of human readable Artist series names
https://github.com/artsy/gravity/pull/18060

```graphql
{
  partner(id: "commerce-test-partner") {
    slug
    name
    alertsConnection(first: 10) {
      totalCount
      edges {
        node {
          internalID
          attributionClass
          artistSeriesIDs
          artistSeriesNames
        }
      }
    }
  }
}



```


<img width="1565" alt="Screenshot 2024-08-21 at 12 03 50 PM" src="https://github.com/user-attachments/assets/5e0948c4-542d-49eb-9932-962fdb7ec51f">
