### PR TITLE
feat: expose foundations insights

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1771,6 +1771,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
 
   # A string of the form "Nationality, Birthday (or Birthday-Deathday)"
   formattedNationalityAndBirthday: String
+  foundations: String
   gender: String
 
   # A list of genes associated with an artist
@@ -1805,6 +1806,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
       REVIEWED
       AWARDS
       RESIDENCIES
+      FOUNDATIONS
     ]
   ): [ArtistInsight!]!
 
@@ -2046,6 +2048,7 @@ enum ArtistInsightKind {
   COLLECTED
   CRITICALLY_ACCLAIMED
   CURATORS_PICK_EMERGING
+  FOUNDATIONS
   GAINING_FOLLOWERS
   GROUP_SHOW
   HIGH_AUCTION_RECORD

--- a/src/schema/v2/artist/__tests__/helpers.test.ts
+++ b/src/schema/v2/artist/__tests__/helpers.test.ts
@@ -228,4 +228,41 @@ describe("getArtistInsights", () => {
       expect(recentShow).toEqual(null)
     })
   })
+
+  describe("foundations", () => {
+    it("returns foundations insights", () => {
+      const field = {
+        kind: "FOUNDATIONS",
+        artist: {
+          foundations: "Summer 2023|Winter 2024",
+        },
+        value: "Summer 2023 and Winter 2024",
+      }
+
+      const artist = field.artist
+
+      const insights = getArtistInsights(artist)
+      const insight = insights.find((insight) => insight.kind === field.kind)!
+      expect(insight.label).toEqual("Foundations Summer 2023 and Winter 2024")
+      expect(insight.description).toEqual(
+        "Featured in [Foundations](/fair/foundations-winter-2024), the online fair for emerging art, curated by Artsy."
+      )
+    })
+
+    it("with empty foundations", () => {
+      const field = {
+        kind: "FOUNDATIONS",
+        artist: {
+          foundations: null,
+        },
+        value: null,
+      }
+
+      const artist = field.artist
+
+      const insights = getArtistInsights(artist)
+      const insight = insights.find((insight) => insight.kind === field.kind)!
+      expect(insight).toBeUndefined()
+    })
+  })
 })

--- a/src/schema/v2/artist/helpers.ts
+++ b/src/schema/v2/artist/helpers.ts
@@ -24,6 +24,7 @@ export const ARTIST_INSIGHT_KINDS = [
   "REVIEWED",
   "AWARDS", // Not ranked
   "RESIDENCIES", // Not ranked
+  "FOUNDATIONS",
 ] as const
 
 type ArtistInsightKind = typeof ARTIST_INSIGHT_KINDS[number]
@@ -162,6 +163,12 @@ export const ARTIST_INSIGHT_MAPPING: Record<
       `Winner of ${
         count === 1 ? "a top industry award" : `${count} top industry awards`
       }`,
+  },
+  FOUNDATIONS: {
+    getDescription: (artist) =>
+      formatFoundationsDescription(artist.foundations),
+    getEntities: (artist) => splitEntities(artist.foundations) && [],
+    getLabel: (artist) => formatFoundationsLabel(artist.foundations),
   },
 }
 
@@ -309,4 +316,36 @@ export const getRecentShow = (artist): string | null => {
   const title = `${year} ${show}`
 
   return title
+}
+
+const formatFoundationsLabel = (foundationsArr) => {
+  const foundations = splitEntities(foundationsArr)
+
+  if (!foundations || foundations.length === 0) {
+    return "Foundations"
+  }
+
+  const allButLast = foundations.slice(0, -1).join(", ")
+  const lastItem = foundations[foundations.length - 1]
+
+  return `Foundations ${
+    allButLast ? `${allButLast} and ${lastItem}` : lastItem
+  }`
+}
+
+const formatFoundationsDescription = (foundationsArr) => {
+  if (!foundationsArr || !foundationsArr.length) return null
+
+  const foundations = splitEntities(foundationsArr) || []
+
+  const foundationsUrls = {
+    "Summer 2023": "/fair/foundations",
+    "Winter 2024": "/fair/foundations-winter-2024",
+    "Summer 2024": "/fair/foundations-summer-2024",
+  }
+
+  const lastFoundation = foundations[foundations.length - 1]
+  const lastFoundationUrl = foundationsUrls[lastFoundation]
+
+  return `Featured in [Foundations](${lastFoundationUrl}), the online fair for emerging art, curated by Artsy.`
 }

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -850,6 +850,10 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
       nationality: { type: GraphQLString },
       name: { type: GraphQLString },
       first: { type: GraphQLString },
+      foundations: {
+        type: GraphQLString,
+        resolve: ({ foundations }) => foundations,
+      },
       last: { type: GraphQLString },
       displayName: {
         type: GraphQLString,


### PR DESCRIPTION
This PR exposes the foundations insight. 

PR for the ground work are done in Gravity: 
- https://github.com/artsy/gravity/pull/18069
- https://github.com/artsy/gravity/pull/18035 

Successful import:

```
[2024-08-22, 07:13:45 UTC] {batch.py:116} INFO - I, [2024-08-22T07:13:16.617801 #6]  INFO -- : importing data...
[2024-08-22, 07:13:45 UTC] {batch.py:116} INFO - D, [2024-08-22T07:13:17.339910 #6] DEBUG -- : Dalli::Server#connect gravity-prod-memcached-2022.uvuuuk.cfg.use1.cache.amazonaws.com:11211
[2024-08-22, 07:13:45 UTC] {batch.py:116} INFO - I, [2024-08-22T07:13:33.264296 #6]  INFO -- : processed 1000 rows
[2024-08-22, 07:13:45 UTC] {batch.py:116} INFO - I, [2024-08-22T07:13:38.186215 #6]  INFO -- : updated 1304 artists
```