### PR TITLE
feat(onyx-1218): add Collections section to new home view schema

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1509,7 +1509,7 @@ type ArticlesRailHomeViewSection implements GenericHomeViewSection & Node {
     before: String
     first: Int
     last: Int
-  ): ArticleConnection!
+  ): ArticleConnection
 
   # The component that is prescribed for this section
   component: HomeViewComponent
@@ -9759,7 +9759,7 @@ type FairsRailHomeViewSection implements GenericHomeViewSection & Node {
     before: String
     first: Int
     last: Int
-  ): FairConnection!
+  ): FairConnection
 
   # A globally unique ID.
   id: ID!
@@ -11042,6 +11042,7 @@ union HomeViewSection =
   | ArtworksRailHomeViewSection
   | FairsRailHomeViewSection
   | HeroUnitsHomeViewSection
+  | MarketingCollectionsRailHomeViewSection
 
 # A connection to a list of items.
 type HomeViewSectionConnection {
@@ -12004,6 +12005,26 @@ type MarketingCollectionCategory {
   name: String!
 }
 
+# A connection to a list of items.
+type MarketingCollectionConnection {
+  # A list of edges.
+  edges: [MarketingCollectionEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type MarketingCollectionEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: MarketingCollection
+}
+
 type MarketingCollectionGroup {
   groupType: MarketingCollectionGroupTypeEnum!
   internalID: ID!
@@ -12029,6 +12050,24 @@ type MarketingCollectionQuery {
   internalID: ID
   keyword: String
   tagID: String
+}
+
+# A marketing collections rail section in the home view
+type MarketingCollectionsRailHomeViewSection implements GenericHomeViewSection & Node {
+  # The component that is prescribed for this section
+  component: HomeViewComponent
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+  marketingCollectionsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): MarketingCollectionConnection
 }
 
 union Match =

--- a/src/schema/v2/homeView/__tests__/HomeView.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeView.test.ts
@@ -55,6 +55,14 @@ describe("homeView", () => {
             },
             Object {
               "node": Object {
+                "__typename": "MarketingCollectionsRailHomeViewSection",
+                "component": Object {
+                  "title": "Collections",
+                },
+              },
+            },
+            Object {
+              "node": Object {
                 "__typename": "FairsRailHomeViewSection",
                 "component": Object {
                   "title": "Featured Fairs",

--- a/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
@@ -407,4 +407,75 @@ describe("HomeViewSection", () => {
       `)
     })
   })
+
+  describe("MarketingCollectionsRailHomeViewSection", () => {
+    it("returns correct data", async () => {
+      const query = gql`
+        {
+          homeView {
+            section(id: "home-view-section-marketing-collections") {
+              __typename
+
+              ... on MarketingCollectionsRailHomeViewSection {
+                component {
+                  title
+                }
+
+                marketingCollectionsConnection(first: 2) {
+                  edges {
+                    node {
+                      title
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const collections = {
+        body: [
+          {
+            title: "Trending Now",
+          },
+          {
+            title: "Top Auction Works",
+          },
+        ],
+      }
+
+      const context = {
+        authenticatedLoaders: {
+          meLoader: jest.fn().mockReturnValue({ type: "User" }),
+        },
+        marketingCollectionsLoader: jest.fn().mockResolvedValue(collections),
+      }
+
+      const { homeView } = await runQuery(query, context)
+
+      expect(homeView.section).toMatchInlineSnapshot(`
+        Object {
+          "__typename": "MarketingCollectionsRailHomeViewSection",
+          "component": Object {
+            "title": "Collections",
+          },
+          "marketingCollectionsConnection": Object {
+            "edges": Array [
+              Object {
+                "node": Object {
+                  "title": "Trending Now",
+                },
+              },
+              Object {
+                "node": Object {
+                  "title": "Top Auction Works",
+                },
+              },
+            ],
+          },
+        }
+      `)
+    })
+  })
 })

--- a/src/schema/v2/homeView/featuredFairsResolver.ts
+++ b/src/schema/v2/homeView/featuredFairsResolver.ts
@@ -7,7 +7,7 @@ export const FeaturedFairsResolver: GraphQLFieldResolver<
   any,
   ResolverContext
 > = async (parent, args, context, info) => {
-  const resolver = HomePageFairsModuleType.getFields().results
+  const { results: resolver } = HomePageFairsModuleType.getFields()
 
   if (!resolver?.resolve) {
     return []

--- a/src/schema/v2/homeView/getSectionsForUser.ts
+++ b/src/schema/v2/homeView/getSectionsForUser.ts
@@ -6,6 +6,7 @@ import {
   HeroUnits,
   HomeViewSection,
   LatestArticles,
+  MarketingCollections,
   NewWorksForYou,
   NewWorksFromGalleriesYouFollow,
   RecentlyViewedArtworks,
@@ -32,6 +33,7 @@ export async function getSectionsForUser(
     sections = [
       LatestArticles,
       RecentlyViewedArtworks,
+      MarketingCollections,
       TrendingArtists,
       FeaturedFairs,
       CuratorsPicksEmerging,
@@ -46,6 +48,7 @@ export async function getSectionsForUser(
     sections = [
       CuratorsPicksEmerging,
       SimilarToRecentlyViewedArtworks,
+      MarketingCollections,
       FeaturedFairs,
       NewWorksForYou,
       HeroUnits,

--- a/src/schema/v2/homeView/marketingCollectionsResolver.ts
+++ b/src/schema/v2/homeView/marketingCollectionsResolver.ts
@@ -1,0 +1,19 @@
+import { GraphQLFieldResolver } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { connectionFromArray } from "graphql-relay"
+import { HomePageMarketingCollectionsModuleType } from "../home/home_page_marketing_collections_module"
+
+export const MarketingCollectionsResolver: GraphQLFieldResolver<
+  any,
+  ResolverContext
+> = async (parent, args, context, info) => {
+  const resolver = HomePageMarketingCollectionsModuleType.getFields().results
+
+  if (!resolver?.resolve) {
+    return []
+  }
+
+  const result = await resolver.resolve(parent, args, context, info)
+
+  return connectionFromArray(result, args)
+}

--- a/src/schema/v2/homeView/marketingCollectionsResolver.ts
+++ b/src/schema/v2/homeView/marketingCollectionsResolver.ts
@@ -7,7 +7,9 @@ export const MarketingCollectionsResolver: GraphQLFieldResolver<
   any,
   ResolverContext
 > = async (parent, args, context, info) => {
-  const resolver = HomePageMarketingCollectionsModuleType.getFields().results
+  const {
+    results: resolver,
+  } = HomePageMarketingCollectionsModuleType.getFields()
 
   if (!resolver?.resolve) {
     return []

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -19,6 +19,7 @@ type MaybeResolved<T> =
   | T
   | ((context: ResolverContext, args: any) => Promise<T>)
 import { LatestArticlesResolvers } from "./articlesResolvers"
+import { MarketingCollectionsResolver } from "./marketingCollectionsResolver"
 
 export type HomeViewSection = {
   id: string
@@ -157,6 +158,15 @@ export const LatestArticles: HomeViewSection = {
   resolver: LatestArticlesResolvers,
 }
 
+export const MarketingCollections: HomeViewSection = {
+  id: "home-view-section-marketing-collections",
+  type: "MarketingCollectionsRailHomeViewSection",
+  component: {
+    title: "Collections",
+  },
+  resolver: MarketingCollectionsResolver,
+}
+
 const sections: HomeViewSection[] = [
   AuctionLotsForYou,
   CuratorsPicksEmerging,
@@ -169,6 +179,7 @@ const sections: HomeViewSection[] = [
   RecommendedArtists,
   SimilarToRecentlyViewedArtworks,
   TrendingArtists,
+  MarketingCollections,
 ]
 
 export const registry = sections.reduce(


### PR DESCRIPTION
Example request:

```graphql
query {
  homeView {
    sectionsConnection(first: 4) {
      edges {
        node {
          ... on MarketingCollectionsRailHomeViewSection {
            component {
              title
            }
            
            marketingCollectionsConnection(first: 1) {
              edges {
                node {
                  title
                }
              }
            }
          }
        }
      }
    }
    
    section(id: "home-view-section-marketing-collections") {
      ... on MarketingCollectionsRailHomeViewSection {
        component {
          title
        }
      }
    }
  }
}
```

Response:

```json
{
  "data": {
    "homeView": {
      "sectionsConnection": {
        "edges": [
          {
            "node": {}
          },
          {
            "node": {}
          },
          {
            "node": {
              "component": {
                "title": "Collections"
              },
              "marketingCollectionsConnection": {
                "edges": [
                  {
                    "node": {
                      "title": "Trending Now"
                    }
                  }
                ]
              }
            }
          },
          {
            "node": {}
          }
        ]
      },
      "section": {
        "component": {
          "title": "Collections"
        }
      }
    }
  }
}
```