### PR TITLE
feat: add verifyUser for new authentication flow

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17067,6 +17067,15 @@ type Query {
   # Verify a given address.
   verifyAddress(input: VerifyAddressInput!): VerifyAddressPayload
 
+  # Verify a given user.
+  verifyUser(
+    # Email address to verify.
+    email: String!
+
+    # Recaptcha token.
+    recaptchaToken: String!
+  ): VerifyUser
+
   # A wildcard used to support complex root queries in Relay
   viewer: Viewer
 
@@ -20726,6 +20735,10 @@ type VerifyAddressType {
   verificationStatus: VerificationStatuses!
 }
 
+type VerifyUser {
+  exists: Boolean!
+}
+
 # An object containing video metadata
 type Video {
   # The height of the video
@@ -21686,6 +21699,15 @@ type Viewer {
 
   # Verify a given address.
   verifyAddress(input: VerifyAddressInput!): VerifyAddressPayload
+
+  # Verify a given user.
+  verifyUser(
+    # Email address to verify.
+    email: String!
+
+    # Recaptcha token.
+    recaptchaToken: String!
+  ): VerifyUser
   viewingRoomsConnection(
     after: String
     first: Int

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -302,6 +302,11 @@ export default (opts) => {
     trendingArtistsLoader: gravityLoader("artists/trending"),
     userByEmailLoader: gravityLoader("user", {}, { method: "GET" }),
     userByIDLoader: gravityLoader((id) => `user/${id}`, {}, { method: "GET" }),
+    userIdentificationLoader: gravityLoader(
+      "user/identify",
+      {},
+      { method: "POST" } // Un-cached
+    ),
     verifiedRepresentativesLoader: gravityLoader<any, { artist_id: string }>(
       ({ artist_id }) => `verified_representatives?artist_id=${artist_id}`,
       {},

--- a/src/schema/v2/__tests__/verifyUser.test.ts
+++ b/src/schema/v2/__tests__/verifyUser.test.ts
@@ -1,0 +1,23 @@
+import { runQuery } from "../test/utils"
+
+describe("veryifyUser", () => {
+  it("resolves with `exists`", async () => {
+    const query = `
+    {
+      verifyUser(email: "percy@cat.com", recaptchaToken: "token") {
+        exists
+      }
+    }
+  `
+
+    const context = {
+      userIdentificationLoader: () => {
+        return Promise.resolve({ exists: true })
+      },
+    }
+
+    const { verifyUser: result } = await runQuery(query, context)
+
+    expect(result.exists).toBeTrue()
+  })
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -232,6 +232,7 @@ import { deleteCareerHighlightMutation } from "./careerHighlight/deleteCareerHig
 import { updateCareerHighlightMutation } from "./careerHighlight/updateCareerHighlightMutation"
 import { updatePartnerShowMutation } from "./partner/updatePartnerShowMutation"
 import config from "config"
+import { VerifyUser } from "./verifyUser"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -362,6 +363,7 @@ const rootFields = {
   usersConnection: Users,
   vanityURLEntity: VanityURLEntity,
   verifyAddress: VerifyAddress,
+  verifyUser: VerifyUser,
 }
 
 // FIXME: Remove type once Reaction MPv2 migration is complete

--- a/src/schema/v2/verifyUser.ts
+++ b/src/schema/v2/verifyUser.ts
@@ -1,0 +1,35 @@
+import {
+  GraphQLBoolean,
+  GraphQLFieldConfig,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+
+const VerifyUserType = new GraphQLObjectType({
+  name: "VerifyUser",
+  fields: {
+    exists: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+    },
+  },
+})
+
+export const VerifyUser: GraphQLFieldConfig<void, ResolverContext> = {
+  type: VerifyUserType,
+  description: "Verify a given user.",
+  args: {
+    email: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "Email address to verify.",
+    },
+    recaptchaToken: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "Recaptcha token.",
+    },
+  },
+  resolve: (_root, { email, recaptchaToken }, { userIdentificationLoader }) => {
+    return userIdentificationLoader({ email, recaptcha_token: recaptchaToken })
+  },
+}


### PR DESCRIPTION
Based on https://github.com/artsy/gravity/pull/18058 , this adds support for deciding if a user exists - and so is used in the new authentication flow. Of course, Gravity enforces a very strict rate limit as well as requiring a valid reCAPTCHA, so the Metaphysics implementation can remain vanilla.

I decided to go with `verifyUser` -> return an object so it's future-proof if we wanted to add any related data, and also we have a `verifyAddress` field as well, so went with that pattern - but of course there are a lot of different names for this potentially, `userStatus`, etc.