### PR TITLE
feat(onyx-1224): add reduced schema for Shows for You rail

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11043,6 +11043,7 @@ union HomeViewSection =
   | FairsRailHomeViewSection
   | HeroUnitsHomeViewSection
   | MarketingCollectionsRailHomeViewSection
+  | ShowsRailHomeViewSection
 
 # A connection to a list of items.
 type HomeViewSectionConnection {
@@ -18762,6 +18763,18 @@ enum ShowSorts {
   START_AT_DESC
   UPDATED_AT_ASC
   UPDATED_AT_DESC
+}
+
+# A shows rail section in the home view
+type ShowsRailHomeViewSection implements GenericHomeViewSection & Node {
+  # The component that is prescribed for this section
+  component: HomeViewComponent
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
 }
 
 # SMS Two-Factor Authentication factor

--- a/src/schema/v2/homeView/HomeViewSection.ts
+++ b/src/schema/v2/homeView/HomeViewSection.ts
@@ -150,6 +150,18 @@ const MarketingCollectionsRailHomeViewSectionType = new GraphQLObjectType<
   },
 })
 
+const ShowsRailHomeViewSectionType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "ShowsRailHomeViewSection",
+  description: "A shows rail section in the home view",
+  interfaces: [GenericHomeViewSectionInterface, NodeInterface],
+  fields: {
+    ...standardSectionFields,
+  },
+})
+
 // the Section union type of all concrete sections
 
 export const HomeViewSectionType = new GraphQLUnionType({
@@ -161,6 +173,7 @@ export const HomeViewSectionType = new GraphQLUnionType({
     FairsRailHomeViewSectionType,
     HeroUnitsHomeViewSectionType,
     MarketingCollectionsRailHomeViewSectionType,
+    ShowsRailHomeViewSectionType,
   ],
   resolveType: (value) => {
     return value.type

--- a/src/schema/v2/homeView/__tests__/HomeView.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeView.test.ts
@@ -55,6 +55,14 @@ describe("homeView", () => {
             },
             Object {
               "node": Object {
+                "__typename": "ShowsRailHomeViewSection",
+                "component": Object {
+                  "title": "Shows for You",
+                },
+              },
+            },
+            Object {
+              "node": Object {
                 "__typename": "MarketingCollectionsRailHomeViewSection",
                 "component": Object {
                   "title": "Collections",

--- a/src/schema/v2/homeView/getSectionsForUser.ts
+++ b/src/schema/v2/homeView/getSectionsForUser.ts
@@ -11,6 +11,7 @@ import {
   NewWorksFromGalleriesYouFollow,
   RecentlyViewedArtworks,
   RecommendedArtists,
+  ShowsForYou,
   SimilarToRecentlyViewedArtworks,
   TrendingArtists,
 } from "./sections"
@@ -33,6 +34,7 @@ export async function getSectionsForUser(
     sections = [
       LatestArticles,
       RecentlyViewedArtworks,
+      ShowsForYou,
       MarketingCollections,
       TrendingArtists,
       FeaturedFairs,
@@ -48,6 +50,7 @@ export async function getSectionsForUser(
     sections = [
       CuratorsPicksEmerging,
       SimilarToRecentlyViewedArtworks,
+      ShowsForYou,
       MarketingCollections,
       FeaturedFairs,
       NewWorksForYou,

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -167,6 +167,14 @@ export const MarketingCollections: HomeViewSection = {
   resolver: MarketingCollectionsResolver,
 }
 
+export const ShowsForYou: HomeViewSection = {
+  id: "home-view-section-shows-for-you",
+  type: "ShowsRailHomeViewSection",
+  component: {
+    title: "Shows for You",
+  },
+}
+
 const sections: HomeViewSection[] = [
   AuctionLotsForYou,
   CuratorsPicksEmerging,
@@ -180,6 +188,7 @@ const sections: HomeViewSection[] = [
   SimilarToRecentlyViewedArtworks,
   TrendingArtists,
   MarketingCollections,
+  ShowsForYou,
 ]
 
 export const registry = sections.reduce(


### PR DESCRIPTION
Example request:

```graphql
query {
  homeView {
    sectionsConnection(first: 4) {
      edges {
        node {
          ... on ShowsRailHomeViewSection {
            component {
              title
            }
          }
        }
      }
    }
    
    section(id: "home-view-section-shows-for-you") {
      ... on ShowsRailHomeViewSection {
        __typename
        component {
          title
        }
      }
    }
  }
}
```

Response:

```json
{
  "data": {
    "homeView": {
      "sectionsConnection": {
        "edges": [
          {
            "node": {}
          },
          {
            "node": {}
          },
          {
            "node": {
              "component": {
                "title": "Shows for You"
              }
            }
          },
          {
            "node": {}
          }
        ]
      },
      "section": {
        "__typename": "ShowsRailHomeViewSection",
        "component": {
          "title": "Shows for You"
        }
      }
    }
  }
}
```