### PR TITLE
fix: New Works for You total count

### DIFF
--- a/src/schema/v2/artworksForUser/__tests__/artworksForUser.test.ts
+++ b/src/schema/v2/artworksForUser/__tests__/artworksForUser.test.ts
@@ -11,6 +11,7 @@ const buildQuery = (args: any = {}) => {
   const query = gql`
       {
         artworksForUser(first: ${first}, includeBackfill: ${includeBackfill}, userId: "${userId}", excludeDislikedArtworks: ${excludeDislikedArtworks}) {
+          totalCount
           pageInfo {
             hasPreviousPage
             hasNextPage
@@ -70,6 +71,7 @@ describe("artworksForUser", () => {
       const artworks = extractNodes(response.artworksForUser)
       expect(artworks.length).toEqual(0)
 
+      expect(response.artworksForUser.totalCount).toBe(0)
       expect(response.artworksForUser.pageInfo).toMatchInlineSnapshot(`
         Object {
           "hasNextPage": false,
@@ -93,6 +95,7 @@ describe("artworksForUser", () => {
       const artworks = extractNodes(artworksForUser)
       expect(artworks.length).toEqual(0)
 
+      expect(artworksForUser.totalCount).toBe(0)
       expect(artworksForUser.pageInfo).toMatchInlineSnapshot(`
         Object {
           "hasNextPage": false,
@@ -118,6 +121,7 @@ describe("artworksForUser", () => {
       const artworks = extractNodes(artworksForUser)
       expect(artworks.length).toEqual(1)
 
+      expect(artworksForUser.totalCount).toBe(1)
       expect(artworksForUser.pageInfo).toMatchInlineSnapshot(`
         Object {
           "hasNextPage": false,
@@ -143,6 +147,7 @@ describe("artworksForUser", () => {
       const artworks = extractNodes(artworksForUser)
       expect(artworks.length).toEqual(1)
 
+      expect(artworksForUser.totalCount).toBe(1)
       expect(artworksForUser.pageInfo).toMatchInlineSnapshot(`
         Object {
           "hasNextPage": false,
@@ -172,6 +177,7 @@ describe("artworksForUser", () => {
       const artworks = extractNodes(artworksForUser)
       expect(artworks.length).toEqual(1)
 
+      expect(artworksForUser.totalCount).toBe(2)
       expect(artworksForUser.pageInfo).toMatchInlineSnapshot(`
         Object {
           "hasNextPage": true,
@@ -201,6 +207,7 @@ describe("artworksForUser", () => {
       const artworks = extractNodes(artworksForUser)
       expect(artworks.length).toEqual(2)
 
+      expect(artworksForUser.totalCount).toBe(2)
       expect(artworksForUser.pageInfo).toMatchInlineSnapshot(`
         Object {
           "hasNextPage": false,
@@ -226,6 +233,7 @@ describe("artworksForUser", () => {
       const artworks = extractNodes(artworksForUser)
       expect(artworks.length).toEqual(1)
 
+      expect(artworksForUser.totalCount).toBe(1)
       expect(artworksForUser.pageInfo).toMatchInlineSnapshot(`
         Object {
           "hasNextPage": false,
@@ -255,7 +263,7 @@ describe("artworksForUser", () => {
         setItems,
       })
 
-      await runAuthenticatedQuery(query, context)
+      const response = await runAuthenticatedQuery(query, context)
 
       expect(context.artworksLoader).toBeCalledWith(
         expect.objectContaining({
@@ -266,6 +274,8 @@ describe("artworksForUser", () => {
       expect(context.setItemsLoader).toBeCalledWith("valid-id", {
         exclude_disliked_artworks: true,
       })
+
+      expect(response.artworksForUser.totalCount).toBe(2)
     })
   })
 })

--- a/src/schema/v2/artworksForUser/__tests__/helpers.test.ts
+++ b/src/schema/v2/artworksForUser/__tests__/helpers.test.ts
@@ -1,7 +1,7 @@
 import {
   getBackfillArtworks,
-  getNewForYouArtworks,
   getNewForYouArtworkIDs,
+  getNewForYouArtworks,
 } from "../helpers"
 
 const mockLoaderFactory = (affinities) => {
@@ -100,13 +100,14 @@ describe("getBackfillArtworks", () => {
     const includeBackfill = false
     const context = {} as any
 
-    const backfillArtworks = await getBackfillArtworks(
+    const { artworks, totalCount } = await getBackfillArtworks(
       size,
       includeBackfill,
       context
     )
 
-    expect(backfillArtworks).toEqual([])
+    expect(artworks).toEqual([])
+    expect(totalCount).toEqual(0)
   })
 
   it("returns an empty array with zero remaining size", async () => {
@@ -114,13 +115,14 @@ describe("getBackfillArtworks", () => {
     const includeBackfill = true
     const context = {} as any
 
-    const backfillArtworks = await getBackfillArtworks(
+    const { artworks, totalCount } = await getBackfillArtworks(
       size,
       includeBackfill,
       context
     )
 
-    expect(backfillArtworks).toEqual([])
+    expect(artworks).toEqual([])
+    expect(totalCount).toEqual(0)
   })
 
   it("returns an empty array with no backfill id", async () => {
@@ -131,13 +133,14 @@ describe("getBackfillArtworks", () => {
       setsLoader: mockSetsLoader,
     } as any
 
-    const backfillArtworks = await getBackfillArtworks(
+    const { artworks, totalCount } = await getBackfillArtworks(
       size,
       includeBackfill,
       context
     )
 
-    expect(backfillArtworks).toEqual([])
+    expect(artworks).toEqual([])
+    expect(totalCount).toEqual(0)
   })
 
   it("returns backfill with a remaining size", async () => {
@@ -152,7 +155,7 @@ describe("getBackfillArtworks", () => {
       unauthenticatedLoaders: {},
     } as any
 
-    const backfillArtworks = await getBackfillArtworks(
+    const { artworks, totalCount } = await getBackfillArtworks(
       size,
       includeBackfill,
       context
@@ -161,7 +164,8 @@ describe("getBackfillArtworks", () => {
     expect(mockSetItemsLoader).toBeCalledWith("valid_id", {
       exclude_disliked_artworks: false,
     })
-    expect(backfillArtworks.length).toEqual(1)
+    expect(artworks.length).toEqual(1)
+    expect(totalCount).toEqual(1)
   })
 
   it("passes exclude_disliked_artworks parameter to Gravity setItemsLoader", async () => {
@@ -204,7 +208,7 @@ describe("getBackfillArtworks", () => {
       },
     } as any
 
-    const backfillArtworks = await getBackfillArtworks(
+    const { artworks, totalCount } = await getBackfillArtworks(
       size,
       includeBackfill,
       context,
@@ -217,9 +221,10 @@ describe("getBackfillArtworks", () => {
       sort: "-decayed_merch",
       marketing_collection_id: "top-auction-lots",
     })
-    expect(backfillArtworks.map((artwork) => artwork.id)).toEqual([
+    expect(artworks.map((artwork) => artwork.id)).toEqual([
       "backfill-artwork-id",
     ])
+    expect(totalCount).toEqual(1)
   })
 
   it("passes exclude_disliked_artworks to Gravity filterArtworksLoader", async () => {
@@ -237,7 +242,7 @@ describe("getBackfillArtworks", () => {
       },
     } as any
 
-    const backfillArtworks = await getBackfillArtworks(
+    const { artworks, totalCount } = await getBackfillArtworks(
       remainingSize,
       includeBackfill,
       context,
@@ -251,9 +256,10 @@ describe("getBackfillArtworks", () => {
       sort: "-decayed_merch",
       marketing_collection_id: "top-auction-lots",
     })
-    expect(backfillArtworks.map((artwork) => artwork.id)).toEqual([
+    expect(artworks.map((artwork) => artwork.id)).toEqual([
       "backfill-artwork-id",
     ])
+    expect(totalCount).toEqual(1)
   })
 
   it("returns no more backfill than the remaining size asks for", async () => {
@@ -268,12 +274,13 @@ describe("getBackfillArtworks", () => {
       unauthenticatedLoaders: {},
     } as any
 
-    const backfillArtworks = await getBackfillArtworks(
+    const { artworks, totalCount } = await getBackfillArtworks(
       size,
       includeBackfill,
       context
     )
 
-    expect(backfillArtworks.length).toEqual(1)
+    expect(artworks.length).toEqual(1)
+    expect(totalCount).toEqual(2)
   })
 })

--- a/src/schema/v2/artworksForUser/artworksForUser.ts
+++ b/src/schema/v2/artworksForUser/artworksForUser.ts
@@ -67,7 +67,10 @@ export const artworksForUser: GraphQLFieldConfig<void, ResolverContext> = {
       context
     )
 
-    const backfillArtworks = await getBackfillArtworks(
+    const {
+      artworks: backfillArtworks,
+      totalCount: backfillArtworksTotalCount,
+    } = await getBackfillArtworks(
       size || 0,
       args.includeBackfill,
       context,
@@ -80,7 +83,8 @@ export const artworksForUser: GraphQLFieldConfig<void, ResolverContext> = {
       "id"
     ).slice(0, size)
 
-    const totalCount = filteredArtworkIds.length + backfillArtworks.length
+    const totalCount =
+      filteredArtworkIds.length + (backfillArtworksTotalCount ?? 0)
 
     return {
       totalCount,

--- a/src/schema/v2/artworksForUser/helpers.ts
+++ b/src/schema/v2/artworksForUser/helpers.ts
@@ -124,8 +124,8 @@ export const getBackfillArtworks = async (
   context: ResolverContext,
   onlyAtAuction = false,
   excludeDislikedArtworks = false
-): Promise<any[]> => {
-  if (!includeBackfill || size < 1) return []
+): Promise<{ artworks: any[]; totalCount: number | null }> => {
+  if (!includeBackfill || size < 1) return { artworks: [], totalCount: 0 }
 
   const {
     setItemsLoader,
@@ -151,20 +151,25 @@ export const getBackfillArtworks = async (
       marketing_collection_id: "top-auction-lots",
     })
 
-    return hits
+    return { artworks: hits, totalCount: hits.length }
   }
 
-  const { body: setsBody } = await setsLoader({
+  const data = await setsLoader({
     key: "artwork-backfill",
     sort: "internal_name",
   })
+
+  const { body: setsBody } = data
   const backfillSetId = setsBody?.map((set) => set.id)[0]
 
-  if (!backfillSetId) return []
+  if (!backfillSetId) return { artworks: [], totalCount: 0 }
 
   const { body: itemsBody } = await setItemsLoader(backfillSetId, {
     exclude_disliked_artworks: excludeDislikedArtworks,
   })
 
-  return (itemsBody || []).slice(0, size)
+  return {
+    artworks: (itemsBody || []).slice(0, size),
+    totalCount: itemsBody?.length,
+  }
 }

--- a/src/schema/v2/artworksForUser/helpers.ts
+++ b/src/schema/v2/artworksForUser/helpers.ts
@@ -154,12 +154,11 @@ export const getBackfillArtworks = async (
     return { artworks: hits, totalCount: hits.length }
   }
 
-  const data = await setsLoader({
+  const { body: setsBody } = await setsLoader({
     key: "artwork-backfill",
     sort: "internal_name",
   })
 
-  const { body: setsBody } = data
   const backfillSetId = setsBody?.map((set) => set.id)[0]
 
   if (!backfillSetId) return { artworks: [], totalCount: 0 }


### PR DESCRIPTION
This PR resolves [ONYX-1174](https://artsyproduct.atlassian.net/browse/ONYX-1174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

- Related Eigen PR: https://github.com/artsy/eigen/pull/10647

## Description

This fixes `artworkForUser`'s total count.

[ONYX-1174]: https://artsyproduct.atlassian.net/browse/ONYX-1174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ