### PR TITLE
feat: add add auction results home view section

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3503,6 +3503,25 @@ type AuctionResultsByArtistsEdge {
   node: AuctionResultsByArtists
 }
 
+# An auction results rail section in the home view
+type AuctionResultsRailHomeViewSection implements GenericHomeViewSection & Node {
+  auctionResultsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): AuctionResultConnection
+
+  # The component that is prescribed for this section
+  component: HomeViewComponent
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+}
+
 enum AuctionResultsState {
   ALL
   PAST
@@ -11059,6 +11078,7 @@ union HomeViewSection =
   | ArticlesRailHomeViewSection
   | ArtistsRailHomeViewSection
   | ArtworksRailHomeViewSection
+  | AuctionResultsRailHomeViewSection
   | FairsRailHomeViewSection
   | HeroUnitsHomeViewSection
   | MarketingCollectionsRailHomeViewSection

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11055,6 +11055,9 @@ type HomeViewComponent {
     version: HomeViewComponentBackgroundImageURLVersion
   ): String
 
+  # Behaviors for the view
+  behaviors: HomeViewComponentBehaviors
+
   # A description for this section
   description: String
 
@@ -11071,6 +11074,19 @@ type HomeViewComponent {
 enum HomeViewComponentBackgroundImageURLVersion {
   NARROW
   WIDE
+}
+
+type HomeViewComponentBehaviors {
+  # Represents the behavior of the view all button
+  viewAll: HomeViewComponentBehaviorsViewAll
+}
+
+type HomeViewComponentBehaviorsViewAll {
+  # Text for the CTA of the view all button
+  buttonText: String!
+
+  # href of the view all button
+  href: String!
 }
 
 union HomeViewSection =

--- a/src/schema/v2/auction_result.ts
+++ b/src/schema/v2/auction_result.ts
@@ -34,27 +34,29 @@ import { InternalIDFields, NodeInterface } from "./object_identification"
 import { YearRange } from "./types/yearRange"
 import { GraphQLError } from "graphql"
 
-export const AuctionResultSorts = {
-  type: new GraphQLEnumType({
-    name: "AuctionResultSorts",
-    values: {
-      DATE_DESC: {
-        value: "-sale_date",
-      },
-      DATE_ASC: {
-        value: "sale_date",
-      },
-      PRICE_AND_DATE_DESC: {
-        value: "-price_realized_cents_usd,-sale_date",
-      },
-      ESTIMATE_AND_DATE_DESC: {
-        value: "-high_estimate_cents_usd,-sale_date",
-      },
+export const AuctionResultSortEnum = new GraphQLEnumType({
+  name: "AuctionResultSorts",
+  values: {
+    DATE_DESC: {
+      value: "-sale_date",
     },
-  }),
+    DATE_ASC: {
+      value: "sale_date",
+    },
+    PRICE_AND_DATE_DESC: {
+      value: "-price_realized_cents_usd,-sale_date",
+    },
+    ESTIMATE_AND_DATE_DESC: {
+      value: "-high_estimate_cents_usd,-sale_date",
+    },
+  },
+})
+
+export const AuctionResultSorts = {
+  type: AuctionResultSortEnum,
 }
 
-const AuctionResultsStateEnums = new GraphQLEnumType({
+export const AuctionResultsStateEnums = new GraphQLEnumType({
   name: "AuctionResultsState",
   values: {
     ALL: {

--- a/src/schema/v2/homeView/HomeViewComponent.ts
+++ b/src/schema/v2/homeView/HomeViewComponent.ts
@@ -1,4 +1,41 @@
-import { GraphQLEnumType, GraphQLObjectType, GraphQLString } from "graphql"
+import {
+  GraphQLEnumType,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+
+export type HomeViewComponentBehaviors = {
+  viewAll?: {
+    href: string
+    buttonText: string
+  }
+}
+const HomeViewComponentBehaviors = new GraphQLObjectType<
+  HomeViewComponentBehaviors,
+  ResolverContext
+>({
+  name: "HomeViewComponentBehaviors",
+  fields: {
+    viewAll: {
+      type: new GraphQLObjectType({
+        name: "HomeViewComponentBehaviorsViewAll",
+        fields: {
+          href: {
+            type: new GraphQLNonNull(GraphQLString),
+            description: "href of the view all button",
+          },
+          buttonText: {
+            type: new GraphQLNonNull(GraphQLString),
+            description: "Text for the CTA of the view all button",
+          },
+        },
+      }),
+      description: "Represents the behavior of the view all button",
+    },
+  },
+})
 
 export const HomeViewComponent = new GraphQLObjectType({
   name: "HomeViewComponent",
@@ -98,6 +135,10 @@ export const HomeViewComponent = new GraphQLObjectType({
           return description
         }
       },
+    },
+    behaviors: {
+      type: HomeViewComponentBehaviors,
+      description: "Behaviors for the view",
     },
   },
 })

--- a/src/schema/v2/homeView/HomeViewSection.ts
+++ b/src/schema/v2/homeView/HomeViewSection.ts
@@ -16,6 +16,7 @@ import { MarketingCollectionType } from "../marketingCollections"
 import { NotificationsConnection } from "../notifications"
 import { InternalIDFields, NodeInterface } from "../object_identification"
 import { HomeViewComponent } from "./HomeViewComponent"
+import { auctionResultConnection } from "../auction_result"
 
 // section interface
 
@@ -196,20 +197,41 @@ const ActivityRailHomeViewSectionType = new GraphQLObjectType<
   },
 })
 
+export const AuctionResultsRailHomeViewSectionType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "AuctionResultsRailHomeViewSection",
+  description: "An auction results rail section in the home view",
+  interfaces: [GenericHomeViewSectionInterface, NodeInterface],
+  fields: {
+    ...standardSectionFields,
+
+    auctionResultsConnection: {
+      type: auctionResultConnection.connectionType,
+      args: pageable({}),
+      resolve: (parent, ...rest) => {
+        return parent.resolver ? parent.resolver(parent, ...rest) : []
+      },
+    },
+  },
+})
+
 // the Section union type of all concrete sections
 
 export const HomeViewSectionType = new GraphQLUnionType({
   name: "HomeViewSection",
   types: [
+    ActivityRailHomeViewSectionType,
     ArticlesRailHomeViewSectionType,
     ArtistsRailHomeViewSectionType,
     ArtworksRailHomeViewSectionType,
+    AuctionResultsRailHomeViewSectionType,
     FairsRailHomeViewSectionType,
     HeroUnitsHomeViewSectionType,
     MarketingCollectionsRailHomeViewSectionType,
     ShowsRailHomeViewSectionType,
     ViewingRoomsRailHomeViewSectionType,
-    ActivityRailHomeViewSectionType,
   ],
   resolveType: (value) => {
     return value.type

--- a/src/schema/v2/homeView/__tests__/HomeView.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeView.test.ts
@@ -149,6 +149,14 @@ describe("homeView", () => {
             },
             Object {
               "node": Object {
+                "__typename": "AuctionResultsRailHomeViewSection",
+                "component": Object {
+                  "title": "Latest Auction Results",
+                },
+              },
+            },
+            Object {
+              "node": Object {
                 "__typename": "ViewingRoomsRailHomeViewSection",
                 "component": Object {
                   "title": "Viewing Rooms",

--- a/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
@@ -627,6 +627,13 @@ describe("HomeViewSection", () => {
               ... on AuctionResultsRailHomeViewSection {
                 component {
                   title
+                  href
+                  behaviors {
+                    viewAll {
+                      href
+                      buttonText
+                    }
+                  }
                 }
                 auctionResultsConnection(first: 2) {
                   edges {
@@ -710,6 +717,13 @@ describe("HomeViewSection", () => {
                 ],
               },
               "component": Object {
+                "behaviors": Object {
+                  "viewAll": Object {
+                    "buttonText": "Browse All Results",
+                    "href": "/auction-results-for-artists-you-follow",
+                  },
+                },
+                "href": "/auction-results-for-artists-you-follow",
                 "title": "Latest Auction Results",
               },
             },

--- a/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
@@ -616,4 +616,106 @@ describe("HomeViewSection", () => {
       `)
     })
   })
+
+  describe("AuctionResultsRailHomeViewSection", () => {
+    it("returns the latest activity", async () => {
+      const query = `
+        {
+          homeView {
+            section(id: "home-view-section-latest-auction-results") {
+              __typename
+              ... on AuctionResultsRailHomeViewSection {
+                component {
+                  title
+                }
+                auctionResultsConnection(first: 2) {
+                  edges {
+                    node {
+                      title
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const auctionLotsLoader = jest.fn(async () => ({
+        total_count: 2,
+        _embedded: {
+          items: [
+            {
+              title: "Auction Result 1",
+              artist_id: "artist-1",
+            },
+            {
+              title: "Auction Result 2",
+              artist_id: "artist-2",
+            },
+            {
+              title: "Auction Result Without Artist ID",
+            },
+          ],
+        },
+      }))
+
+      const followedArtistsLoader = jest.fn(async () => ({
+        headers: { "x-total-count": 2 },
+        body: [
+          {
+            id: "followartist-1",
+            artist: {
+              _id: "artist-1",
+              name: "Artist 1",
+            },
+          },
+          {
+            id: "followartist-2",
+            artist: {
+              _id: "artist-2",
+              name: "Artist 2",
+            },
+          },
+        ],
+      }))
+
+      const context = {
+        authenticatedLoaders: {
+          meLoader: jest.fn().mockReturnValue({ type: "User" }),
+        },
+        followedArtistsLoader,
+        auctionLotsLoader,
+      }
+
+      const data = await runQuery(query, context)
+
+      expect(data).toMatchInlineSnapshot(`
+        Object {
+          "homeView": Object {
+            "section": Object {
+              "__typename": "AuctionResultsRailHomeViewSection",
+              "auctionResultsConnection": Object {
+                "edges": Array [
+                  Object {
+                    "node": Object {
+                      "title": "Auction Result 1",
+                    },
+                  },
+                  Object {
+                    "node": Object {
+                      "title": "Auction Result 2",
+                    },
+                  },
+                ],
+              },
+              "component": Object {
+                "title": "Latest Auction Results",
+              },
+            },
+          },
+        }
+      `)
+    })
+  })
 })

--- a/src/schema/v2/homeView/auctionResultsResolvers.ts
+++ b/src/schema/v2/homeView/auctionResultsResolvers.ts
@@ -1,0 +1,25 @@
+import { GraphQLFieldResolver } from "graphql"
+import { ResolverContext } from "types/graphql"
+import {
+  AuctionResultSortEnum,
+  AuctionResultsStateEnums,
+} from "../auction_result"
+import AuctionResultsByFollowedArtists from "../me/auctionResultsByFollowedArtists"
+
+export const LatestAuctionResultsResolver: GraphQLFieldResolver<
+  any,
+  ResolverContext
+> = async (parent, args, context, info) => {
+  const finalArgs = {
+    state: AuctionResultsStateEnums.getValue("PAST")?.value,
+    sort: AuctionResultSortEnum.getValue("DATE_DESC")?.value,
+    ...args,
+  }
+
+  return await AuctionResultsByFollowedArtists.resolve!(
+    parent,
+    finalArgs,
+    context,
+    info
+  )
+}

--- a/src/schema/v2/homeView/getSectionsForUser.ts
+++ b/src/schema/v2/homeView/getSectionsForUser.ts
@@ -16,6 +16,7 @@ import {
   SimilarToRecentlyViewedArtworks,
   TrendingArtists,
   ViewingRooms,
+  LatestAuctionResults,
 } from "./sections"
 
 export async function getSectionsForUser(
@@ -35,6 +36,7 @@ export async function getSectionsForUser(
   if (me.type === "Admin") {
     sections = [
       LatestActivity,
+      LatestAuctionResults,
       LatestArticles,
       RecentlyViewedArtworks,
       ShowsForYou,
@@ -66,6 +68,7 @@ export async function getSectionsForUser(
       TrendingArtists,
       NewWorksFromGalleriesYouFollow,
       RecentlyViewedArtworks,
+      LatestAuctionResults,
       ViewingRooms,
     ]
   }

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -22,6 +22,7 @@ import { LatestArticlesResolvers } from "./articlesResolvers"
 import { MarketingCollectionsResolver } from "./marketingCollectionsResolver"
 import { LatestActivityResolver } from "./activityResolvers"
 import { LatestAuctionResultsResolver } from "./auctionResultsResolvers"
+import { HomeViewComponentBehaviors } from "./HomeViewComponent"
 
 export type HomeViewSection = {
   id: string
@@ -32,6 +33,7 @@ export type HomeViewSection = {
     description?: MaybeResolved<string>
     backgroundImageURL?: MaybeResolved<string>
     href?: MaybeResolved<string>
+    behaviors?: HomeViewComponentBehaviors
   }
   resolver?: GraphQLFieldResolver<any, ResolverContext>
 }
@@ -200,6 +202,12 @@ export const LatestAuctionResults: HomeViewSection = {
   component: {
     title: "Latest Auction Results",
     href: "/auction-results-for-artists-you-follow",
+    behaviors: {
+      viewAll: {
+        href: "/auction-results-for-artists-you-follow",
+        buttonText: "Browse All Results",
+      },
+    },
   },
   resolver: LatestAuctionResultsResolver,
 }

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -199,6 +199,7 @@ export const LatestAuctionResults: HomeViewSection = {
   type: "AuctionResultsRailHomeViewSection",
   component: {
     title: "Latest Auction Results",
+    href: "/auction-results-for-artists-you-follow",
   },
   resolver: LatestAuctionResultsResolver,
 }

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -21,6 +21,7 @@ type MaybeResolved<T> =
 import { LatestArticlesResolvers } from "./articlesResolvers"
 import { MarketingCollectionsResolver } from "./marketingCollectionsResolver"
 import { LatestActivityResolver } from "./activityResolvers"
+import { LatestAuctionResultsResolver } from "./auctionResultsResolvers"
 
 export type HomeViewSection = {
   id: string
@@ -193,6 +194,15 @@ export const LatestActivity: HomeViewSection = {
   resolver: LatestActivityResolver,
 }
 
+export const LatestAuctionResults: HomeViewSection = {
+  id: "home-view-section-latest-auction-results",
+  type: "AuctionResultsRailHomeViewSection",
+  component: {
+    title: "Latest Auction Results",
+  },
+  resolver: LatestAuctionResultsResolver,
+}
+
 const sections: HomeViewSection[] = [
   AuctionLotsForYou,
   CuratorsPicksEmerging,
@@ -200,15 +210,16 @@ const sections: HomeViewSection[] = [
   HeroUnits,
   LatestActivity,
   LatestArticles,
+  LatestAuctionResults,
+  MarketingCollections,
   MarketingCollections,
   NewWorksForYou,
   NewWorksFromGalleriesYouFollow,
   RecentlyViewedArtworks,
   RecommendedArtists,
+  ShowsForYou,
   SimilarToRecentlyViewedArtworks,
   TrendingArtists,
-  MarketingCollections,
-  ShowsForYou,
   ViewingRooms,
 ]
 


### PR DESCRIPTION
This PR resolves [ONYX-1234]

This PR adds a new home view section for auction results. It also exposes the latest auction results to client apps.


**Query on Insomnia**

<img width="1147" alt="Screenshot 2024-08-26 at 16 16 01" src="https://github.com/user-attachments/assets/f6cbe965-518f-454d-805b-f32577de560f">

___

**New section on Eigen**
<img width="400" src="https://github.com/user-attachments/assets/56adb471-911d-48f1-9ed8-cf921461b3c6" />



[ONYX-1234]: https://artsyproduct.atlassian.net/browse/ONYX-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ