### PR TITLE
feat(EMI-2017): Expose increased interest collector signal

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4491,6 +4491,9 @@ type CollectorSignals {
   # Bid count on lots open for bidding
   bidCount: Int @deprecated(reason: "Use nested field in `auction` instead")
 
+  # Increased interest in the artwork
+  increasedInterest: Boolean!
+
   # Live bidding has started on this lot's auction
   liveBiddingStarted: Boolean
     @deprecated(reason: "Use nested field in `auction` instead")

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -166,7 +166,7 @@ export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
       increasedInterest: {
         type: new GraphQLNonNull(GraphQLBoolean),
         description: "Increased interest in the artwork",
-        resolve: (artwork, {}) => {
+        resolve: (artwork) => {
           return !!artwork.increased_interest_signal
         },
       },

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -166,11 +166,8 @@ export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
       increasedInterest: {
         type: new GraphQLNonNull(GraphQLBoolean),
         description: "Increased interest in the artwork",
-        resolve: (artwork, {}, ctx) => {
-          return !!(
-            checkFeatureFlag("emerald_signals-increased-interest", ctx) &&
-            artwork.increased_interest_signal
-          )
+        resolve: (artwork, {}) => {
+          return !!artwork.increased_interest_signal
         },
       },
     },

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -163,10 +163,23 @@ export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
           return activePartnerOffers?.[0]
         },
       },
+      increasedInterest: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        description: "Increased interest in the artwork",
+        resolve: (artwork, {}, ctx) => {
+          return !!(
+            checkFeatureFlag("emerald_signals-increased-interest", ctx) &&
+            artwork.increased_interest_signal
+          )
+        },
+      },
     },
   }),
   description: "Collector signals on artwork",
-  resolve: (artwork) => artwork,
+  resolve: (artwork) => {
+    const canSendSignals = artwork.purchasable || artwork.sale_ids?.length > 0
+    return canSendSignals ? artwork : null
+  },
 }
 
 const checkFeatureFlag = (flag: any, context: any) => {


### PR DESCRIPTION
Completes [EMI-2017]

This PR exposes the new `artwork.increased_interest_signal` field through the metaphysics `artwork.collectorSignals` field. In addition it makes the `artwork.collectorSignals` field explicitly null if the artwork is not subject to collector signals.

[EMI-2017]: https://artsyproduct.atlassian.net/browse/EMI-2017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ