### PR TITLE
feat: add a News home view section

### DIFF
--- a/src/schema/v2/homeView/__tests__/HomeView.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeView.test.ts
@@ -31,12 +31,20 @@ describe("homeView", () => {
       }),
     }
 
-    it("returns requested data for each section", async () => {
+    it("returns every section", async () => {
       const { homeView } = await runQuery(query, context)
 
       expect(homeView.sectionsConnection).toMatchInlineSnapshot(`
         Object {
           "edges": Array [
+            Object {
+              "node": Object {
+                "__typename": "ArticlesRailHomeViewSection",
+                "component": Object {
+                  "title": "News",
+                },
+              },
+            },
             Object {
               "node": Object {
                 "__typename": "ActivityRailHomeViewSection",

--- a/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
@@ -505,13 +505,13 @@ describe("HomeViewSection", () => {
         const data = await runQuery(query, context)
 
         expect(data.homeView.section).toMatchInlineSnapshot(`
-        Object {
-          "__typename": "ViewingRoomsRailHomeViewSection",
-          "component": Object {
-            "title": "Viewing Rooms",
-          },
-        }
-      `)
+                  Object {
+                    "__typename": "ViewingRoomsRailHomeViewSection",
+                    "component": Object {
+                      "title": "Viewing Rooms",
+                    },
+                  }
+              `)
       })
     })
   })
@@ -727,6 +727,87 @@ describe("HomeViewSection", () => {
                 "title": "Latest Auction Results",
               },
             },
+          },
+        }
+      `)
+    })
+  })
+
+  describe("News", () => {
+    it("returns correct data", async () => {
+      const query = gql`
+        {
+          homeView {
+            section(id: "home-view-section-news") {
+              __typename
+
+              ... on ArticlesRailHomeViewSection {
+                component {
+                  title
+                  href
+                  type
+                }
+
+                articlesConnection(first: 3) {
+                  edges {
+                    node {
+                      title
+                      href
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const articles = [
+        {
+          title: "Bored apes stolen",
+          slug: "stolen-apes",
+        },
+        {
+          title: "More apes stolen",
+          slug: "more-apes",
+        },
+      ]
+
+      const context = {
+        articlesLoader: jest.fn().mockReturnValue({
+          count: articles.length,
+          results: articles,
+        }),
+        authenticatedLoaders: {
+          meLoader: jest.fn().mockReturnValue({ type: "User" }),
+        },
+      }
+
+      const { homeView } = await runQuery(query, context)
+
+      expect(homeView.section).toMatchInlineSnapshot(`
+        Object {
+          "__typename": "ArticlesRailHomeViewSection",
+          "articlesConnection": Object {
+            "edges": Array [
+              Object {
+                "node": Object {
+                  "href": "/article/stolen-apes",
+                  "title": "Bored apes stolen",
+                },
+              },
+              Object {
+                "node": Object {
+                  "href": "/article/more-apes",
+                  "title": "More apes stolen",
+                },
+              },
+            ],
+          },
+          "component": Object {
+            "href": "/news",
+            "title": "News",
+            "type": "ArticlesCard",
           },
         }
       `)

--- a/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
@@ -477,42 +477,42 @@ describe("HomeViewSection", () => {
         }
       `)
     })
+  })
 
-    describe("ViewingRoomsRailHomeViewSection", () => {
-      it("returns correct data", async () => {
-        const query = gql`
-          {
-            homeView {
-              section(id: "home-view-section-viewing-rooms") {
-                __typename
+  describe("ViewingRoomsRailHomeViewSection", () => {
+    it("returns correct data", async () => {
+      const query = gql`
+        {
+          homeView {
+            section(id: "home-view-section-viewing-rooms") {
+              __typename
 
-                ... on ViewingRoomsRailHomeViewSection {
-                  component {
-                    title
-                  }
+              ... on ViewingRoomsRailHomeViewSection {
+                component {
+                  title
                 }
               }
             }
           }
-        `
-
-        const context = {
-          authenticatedLoaders: {
-            meLoader: jest.fn().mockReturnValue({ type: "User" }),
-          },
         }
+      `
 
-        const data = await runQuery(query, context)
+      const context = {
+        authenticatedLoaders: {
+          meLoader: jest.fn().mockReturnValue({ type: "User" }),
+        },
+      }
 
-        expect(data.homeView.section).toMatchInlineSnapshot(`
-                  Object {
-                    "__typename": "ViewingRoomsRailHomeViewSection",
-                    "component": Object {
-                      "title": "Viewing Rooms",
-                    },
-                  }
-              `)
-      })
+      const data = await runQuery(query, context)
+
+      expect(data.homeView.section).toMatchInlineSnapshot(`
+                Object {
+                  "__typename": "ViewingRoomsRailHomeViewSection",
+                  "component": Object {
+                    "title": "Viewing Rooms",
+                  },
+                }
+            `)
     })
   })
 

--- a/src/schema/v2/homeView/articlesResolvers.ts
+++ b/src/schema/v2/homeView/articlesResolvers.ts
@@ -1,6 +1,8 @@
 import type { GraphQLFieldResolver } from "graphql"
 import type { ResolverContext } from "types/graphql"
 import ArticlesConnection from "../articlesConnection"
+import ArticleSorts from "../sorts/article_sorts"
+import { ArticleLayoutEnum } from "../article/models"
 
 /*
  * Resolvers for home view articels sections
@@ -10,3 +12,28 @@ export const LatestArticlesResolvers: GraphQLFieldResolver<
   any,
   ResolverContext
 > = ArticlesConnection.resolve!
+
+export const NewsResolver: GraphQLFieldResolver<any, ResolverContext> = async (
+  parent,
+  args,
+  context,
+  info
+) => {
+  const finalArgs = {
+    // formerly specified client-side
+    published: true,
+    sort: ArticleSorts.type.getValue("PUBLISHED_AT_DESC")?.value,
+    layout: ArticleLayoutEnum.getValue("NEWS")?.value,
+
+    ...args,
+  }
+
+  const result = await ArticlesConnection.resolve!(
+    parent,
+    finalArgs,
+    context,
+    info
+  )
+
+  return result
+}

--- a/src/schema/v2/homeView/getSectionsForUser.ts
+++ b/src/schema/v2/homeView/getSectionsForUser.ts
@@ -17,6 +17,7 @@ import {
   TrendingArtists,
   ViewingRooms,
   LatestAuctionResults,
+  News,
 } from "./sections"
 
 export async function getSectionsForUser(
@@ -51,9 +52,11 @@ export async function getSectionsForUser(
       NewWorksFromGalleriesYouFollow,
       RecommendedArtists,
       ViewingRooms,
+      News,
     ]
   } else {
     sections = [
+      News,
       LatestActivity,
       CuratorsPicksEmerging,
       SimilarToRecentlyViewedArtworks,

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -117,8 +117,6 @@ export const NewWorksFromGalleriesYouFollow: HomeViewSection = {
   resolver: NewWorksFromGalleriesYouFollowResolver,
 }
 
-// Artists Rails
-
 export const TrendingArtists: HomeViewSection = {
   id: "home-view-section-trending-artists",
   type: "ArtistsRailHomeViewSection",
@@ -220,6 +218,7 @@ const sections: HomeViewSection[] = [
   LatestActivity,
   LatestArticles,
   LatestAuctionResults,
+  MarketingCollections,
   MarketingCollections,
   MarketingCollections,
   NewWorksForYou,

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -18,7 +18,7 @@ import { FeaturedFairsResolver } from "./featuredFairsResolver"
 type MaybeResolved<T> =
   | T
   | ((context: ResolverContext, args: any) => Promise<T>)
-import { LatestArticlesResolvers } from "./articlesResolvers"
+import { LatestArticlesResolvers, NewsResolver } from "./articlesResolvers"
 import { MarketingCollectionsResolver } from "./marketingCollectionsResolver"
 import { LatestActivityResolver } from "./activityResolvers"
 import { LatestAuctionResultsResolver } from "./auctionResultsResolvers"
@@ -210,6 +210,17 @@ export const LatestAuctionResults: HomeViewSection = {
   resolver: LatestAuctionResultsResolver,
 }
 
+export const News: HomeViewSection = {
+  id: "home-view-section-news",
+  type: "ArticlesRailHomeViewSection",
+  component: {
+    title: "News",
+    href: "/news",
+    type: "ArticlesCard",
+  },
+  resolver: NewsResolver,
+}
+
 const sections: HomeViewSection[] = [
   AuctionLotsForYou,
   CuratorsPicksEmerging,
@@ -223,6 +234,7 @@ const sections: HomeViewSection[] = [
   MarketingCollections,
   NewWorksForYou,
   NewWorksFromGalleriesYouFollow,
+  News,
   RecentlyViewedArtworks,
   RecommendedArtists,
   ShowsForYou,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-1237

Adds the section data and resolver for the News section of the home view

### Request

```graphql
{
  homeView {
    section(id: "home-view-section-news") {
      ... on GenericHomeViewSection {
        internalID
        component {
          title
          type
        }
      }
      ... on ArticlesRailHomeViewSection {
        articlesConnection(first: 3) {
          edges {
            node {
              title
              href
            }
          }
        }
      }
    }
  }
}
```

### Response

```json
{
  "data": {
    "homeView": {
      "section": {
        "internalID": "home-view-section-news",
        "component": {
          "title": "News",
          "type": "ArticlesCard"
        },
        "articlesConnection": {
          "edges": [
            {
              "node": {
                "title": "Lauren Halsey to receive first U.K. solo show at Serpentine.",
                "href": "/article/artsy-editorial-lauren-halsey-receive-first-uk-solo-serpentine"
              }
            },
            {
              "node": {
                "title": "$35 million Monet painting to headline inaugural sale at Christie’s Hong Kong headquarters.",
                "href": "/article/artsy-editorial-35-million-monet-painting-headline-inaugural-sale-christies-hong-kong-headquarters"
              }
            },
            {
              "node": {
                "title": "Influential Japanese Pop artist Keiichi Tanaami dies at 88.",
                "href": "/article/artsy-editorial-influential-japanese-pop-artist-keiichi-tanaami-dies-88"
              }
            }
          ]
        }
      }
    }
  },
}
```