### PR TITLE
feat: add legacy zone logic

### DIFF
--- a/src/schema/v2/homeView/__tests__/HomeView.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeView.test.ts
@@ -1,5 +1,6 @@
 import gql from "lib/gql"
 import { runQuery } from "schema/v2/test/utils"
+import { ResolverContext } from "types/graphql"
 
 describe("homeView", () => {
   describe("sectionsConnection", () => {
@@ -22,182 +23,255 @@ describe("homeView", () => {
       }
     `
 
-    const context = {
-      authenticatedLoaders: {
-        meLoader: jest.fn().mockReturnValue({ type: "User" }),
-      },
-      siteHeroUnitLoader: jest.fn().mockReturnValue({
-        app_title: "Curators' Picks Emerging",
-      }),
-    }
+    describe("with an unauthenticated user", () => {
+      const context: Partial<ResolverContext> = {
+        siteHeroUnitLoader: jest.fn().mockReturnValue({
+          app_title: "Curators' Picks Emerging",
+        }),
+      }
 
-    it("returns every section", async () => {
-      const { homeView } = await runQuery(query, context)
+      it("returns the correct sections", async () => {
+        const { homeView } = await runQuery(query, context)
 
-      expect(homeView.sectionsConnection).toMatchInlineSnapshot(`
-        Object {
-          "edges": Array [
-            Object {
-              "node": Object {
-                "__typename": "ArticlesRailHomeViewSection",
-                "component": Object {
-                  "title": "News",
+        expect(homeView.sectionsConnection).toMatchInlineSnapshot(`
+          Object {
+            "edges": Array [
+              Object {
+                "node": Object {
+                  "__typename": "HeroUnitsHomeViewSection",
+                  "component": null,
                 },
               },
-            },
-            Object {
-              "node": Object {
-                "__typename": "ActivityRailHomeViewSection",
-                "component": Object {
-                  "title": "Latest Activity",
+              Object {
+                "node": Object {
+                  "__typename": "SalesRailHomeViewSection",
+                  "component": Object {
+                    "title": "Auctions",
+                  },
                 },
               },
-            },
-            Object {
-              "node": Object {
-                "__typename": "ArtworksRailHomeViewSection",
-                "component": Object {
-                  "title": "Your Active Bids",
+              Object {
+                "node": Object {
+                  "__typename": "ArticlesRailHomeViewSection",
+                  "component": Object {
+                    "title": "Artsy Editorial",
+                  },
                 },
               },
-            },
-            Object {
-              "node": Object {
-                "__typename": "SalesRailHomeViewSection",
-                "component": Object {
-                  "title": "Auctions",
+              Object {
+                "node": Object {
+                  "__typename": "ArticlesRailHomeViewSection",
+                  "component": Object {
+                    "title": "News",
+                  },
                 },
               },
-            },
-            Object {
-              "node": Object {
-                "__typename": "ArtworksRailHomeViewSection",
-                "component": Object {
-                  "title": "Curators' Picks Emerging",
+              Object {
+                "node": Object {
+                  "__typename": "ArtworksRailHomeViewSection",
+                  "component": Object {
+                    "title": "Curators' Picks Emerging",
+                  },
                 },
               },
-            },
-            Object {
-              "node": Object {
-                "__typename": "ArtworksRailHomeViewSection",
-                "component": Object {
-                  "title": "Similar to Works You’ve Viewed",
+              Object {
+                "node": Object {
+                  "__typename": "MarketingCollectionsRailHomeViewSection",
+                  "component": Object {
+                    "title": "Collections",
+                  },
                 },
               },
-            },
-            Object {
-              "node": Object {
-                "__typename": "ShowsRailHomeViewSection",
-                "component": Object {
-                  "title": "Shows for You",
+              Object {
+                "node": Object {
+                  "__typename": "ArtistsRailHomeViewSection",
+                  "component": Object {
+                    "title": "Trending Artists on Artsy",
+                  },
                 },
               },
-            },
-            Object {
-              "node": Object {
-                "__typename": "MarketingCollectionsRailHomeViewSection",
-                "component": Object {
-                  "title": "Collections",
+              Object {
+                "node": Object {
+                  "__typename": "ViewingRoomsRailHomeViewSection",
+                  "component": Object {
+                    "title": "Viewing Rooms",
+                  },
                 },
               },
-            },
-            Object {
-              "node": Object {
-                "__typename": "FairsRailHomeViewSection",
-                "component": Object {
-                  "title": "Featured Fairs",
+              Object {
+                "node": Object {
+                  "__typename": "FairsRailHomeViewSection",
+                  "component": Object {
+                    "title": "Featured Fairs",
+                  },
                 },
               },
-            },
-            Object {
-              "node": Object {
-                "__typename": "ArtworksRailHomeViewSection",
-                "component": Object {
-                  "title": "New works for you",
+            ],
+          }
+        `)
+      })
+    })
+
+    describe("with an authenticated user", () => {
+      const context: Partial<ResolverContext> = {
+        accessToken: "424242",
+        siteHeroUnitLoader: jest.fn().mockReturnValue({
+          app_title: "Curators' Picks Emerging",
+        }),
+      }
+
+      it("returns the correct sections", async () => {
+        const { homeView } = await runQuery(query, context)
+
+        expect(homeView.sectionsConnection).toMatchInlineSnapshot(`
+          Object {
+            "edges": Array [
+              Object {
+                "node": Object {
+                  "__typename": "ActivityRailHomeViewSection",
+                  "component": Object {
+                    "title": "Latest Activity",
+                  },
                 },
               },
-            },
-            Object {
-              "node": Object {
-                "__typename": "HeroUnitsHomeViewSection",
-                "component": null,
-              },
-            },
-            Object {
-              "node": Object {
-                "__typename": "ArtworksRailHomeViewSection",
-                "component": Object {
-                  "title": "Auction lots for you",
+              Object {
+                "node": Object {
+                  "__typename": "ArtworksRailHomeViewSection",
+                  "component": Object {
+                    "title": "New works for you",
+                  },
                 },
               },
-            },
-            Object {
-              "node": Object {
-                "__typename": "ArticlesRailHomeViewSection",
-                "component": Object {
-                  "title": "Artsy Editorial",
+              Object {
+                "node": Object {
+                  "__typename": "HeroUnitsHomeViewSection",
+                  "component": null,
                 },
               },
-            },
-            Object {
-              "node": Object {
-                "__typename": "ArtistsRailHomeViewSection",
-                "component": Object {
-                  "title": "Recommended Artists",
+              Object {
+                "node": Object {
+                  "__typename": "ArtworksRailHomeViewSection",
+                  "component": Object {
+                    "title": "Auction lots for you",
+                  },
                 },
               },
-            },
-            Object {
-              "node": Object {
-                "__typename": "ArtistsRailHomeViewSection",
-                "component": Object {
-                  "title": "Trending Artists on Artsy",
+              Object {
+                "node": Object {
+                  "__typename": "SalesRailHomeViewSection",
+                  "component": Object {
+                    "title": "Auctions",
+                  },
                 },
               },
-            },
-            Object {
-              "node": Object {
-                "__typename": "ArtworksRailHomeViewSection",
-                "component": Object {
-                  "title": "New Works from Galleries You Follow",
+              Object {
+                "node": Object {
+                  "__typename": "AuctionResultsRailHomeViewSection",
+                  "component": Object {
+                    "title": "Latest Auction Results",
+                  },
                 },
               },
-            },
-            Object {
-              "node": Object {
-                "__typename": "ArtworksRailHomeViewSection",
-                "component": Object {
-                  "title": "Artwork Recommendations",
+              Object {
+                "node": Object {
+                  "__typename": "ArticlesRailHomeViewSection",
+                  "component": Object {
+                    "title": "Artsy Editorial",
+                  },
                 },
               },
-            },
-            Object {
-              "node": Object {
-                "__typename": "ArtworksRailHomeViewSection",
-                "component": Object {
-                  "title": "Recently viewed works",
+              Object {
+                "node": Object {
+                  "__typename": "ArticlesRailHomeViewSection",
+                  "component": Object {
+                    "title": "News",
+                  },
                 },
               },
-            },
-            Object {
-              "node": Object {
-                "__typename": "AuctionResultsRailHomeViewSection",
-                "component": Object {
-                  "title": "Latest Auction Results",
+              Object {
+                "node": Object {
+                  "__typename": "ArtworksRailHomeViewSection",
+                  "component": Object {
+                    "title": "Curators' Picks Emerging",
+                  },
                 },
               },
-            },
-            Object {
-              "node": Object {
-                "__typename": "ViewingRoomsRailHomeViewSection",
-                "component": Object {
-                  "title": "Viewing Rooms",
+              Object {
+                "node": Object {
+                  "__typename": "MarketingCollectionsRailHomeViewSection",
+                  "component": Object {
+                    "title": "Collections",
+                  },
                 },
               },
-            },
-          ],
-        }
-      `)
+              Object {
+                "node": Object {
+                  "__typename": "ArtworksRailHomeViewSection",
+                  "component": Object {
+                    "title": "New Works from Galleries You Follow",
+                  },
+                },
+              },
+              Object {
+                "node": Object {
+                  "__typename": "ArtistsRailHomeViewSection",
+                  "component": Object {
+                    "title": "Recommended Artists",
+                  },
+                },
+              },
+              Object {
+                "node": Object {
+                  "__typename": "ArtistsRailHomeViewSection",
+                  "component": Object {
+                    "title": "Trending Artists on Artsy",
+                  },
+                },
+              },
+              Object {
+                "node": Object {
+                  "__typename": "ArtworksRailHomeViewSection",
+                  "component": Object {
+                    "title": "Recently viewed works",
+                  },
+                },
+              },
+              Object {
+                "node": Object {
+                  "__typename": "ArtworksRailHomeViewSection",
+                  "component": Object {
+                    "title": "Similar to Works You’ve Viewed",
+                  },
+                },
+              },
+              Object {
+                "node": Object {
+                  "__typename": "ViewingRoomsRailHomeViewSection",
+                  "component": Object {
+                    "title": "Viewing Rooms",
+                  },
+                },
+              },
+              Object {
+                "node": Object {
+                  "__typename": "ShowsRailHomeViewSection",
+                  "component": Object {
+                    "title": "Shows for You",
+                  },
+                },
+              },
+              Object {
+                "node": Object {
+                  "__typename": "FairsRailHomeViewSection",
+                  "component": Object {
+                    "title": "Featured Fairs",
+                  },
+                },
+              },
+            ],
+          }
+        `)
+      })
     })
   })
 

--- a/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
@@ -81,11 +81,11 @@ describe("HomeViewSection", () => {
       const artworksLoader = jest.fn(async () => artworksResponse)
 
       const context: any = {
+        accessToken: "424242",
         artworksLoader,
         userID: "vortex-user-id",
         authenticatedLoaders: {
           vortexGraphqlLoader: vortexGraphQLAuthenticatedLoader,
-          meLoader: () => Promise.resolve({}),
         },
         unauthenticatedLoaders: {
           vortexGraphqlLoader: null,
@@ -155,9 +155,7 @@ describe("HomeViewSection", () => {
       ]
 
       const context = {
-        authenticatedLoaders: {
-          meLoader: jest.fn().mockReturnValue({ type: "User" }),
-        },
+        accessToken: "424242",
         followedProfilesArtworksLoader: jest
           .fn()
           .mockReturnValue({ body: artworks, headers: { "x-total-count": 2 } }),
@@ -253,8 +251,8 @@ describe("HomeViewSection", () => {
       }
 
       const context = {
+        accessToken: "424242",
         authenticatedLoaders: {
-          meLoader: jest.fn().mockReturnValue({ type: "User" }),
           vortexGraphqlLoader: jest.fn(() => async () => mockVortexResponse),
         },
         unauthenticatedLoaders: {
@@ -327,9 +325,6 @@ describe("HomeViewSection", () => {
       }
 
       const context = {
-        authenticatedLoaders: {
-          meLoader: jest.fn().mockReturnValue({ type: "User" }),
-        },
         heroUnitsLoader: jest.fn().mockReturnValue(mockHeroUnitsResponse),
       }
 
@@ -393,9 +388,7 @@ describe("HomeViewSection", () => {
       ]
 
       const context = {
-        authenticatedLoaders: {
-          meLoader: jest.fn().mockReturnValue({ type: "User" }),
-        },
+        authenticatedLoaders: {},
         unauthenticatedLoaders: {
           filterArtworksLoader: jest.fn().mockReturnValue(
             Promise.resolve({
@@ -493,9 +486,6 @@ describe("HomeViewSection", () => {
       }
 
       const context = {
-        authenticatedLoaders: {
-          meLoader: jest.fn().mockReturnValue({ type: "User" }),
-        },
         fairsLoader: jest.fn().mockResolvedValue(fairs),
       }
 
@@ -564,9 +554,6 @@ describe("HomeViewSection", () => {
       }
 
       const context = {
-        authenticatedLoaders: {
-          meLoader: jest.fn().mockReturnValue({ type: "User" }),
-        },
         marketingCollectionsLoader: jest.fn().mockResolvedValue(collections),
       }
 
@@ -615,11 +602,7 @@ describe("HomeViewSection", () => {
         }
       `
 
-      const context = {
-        authenticatedLoaders: {
-          meLoader: jest.fn().mockReturnValue({ type: "User" }),
-        },
-      }
+      const context = {}
 
       const data = await runQuery(query, context)
 
@@ -696,9 +679,7 @@ describe("HomeViewSection", () => {
       )
 
       const context = {
-        authenticatedLoaders: {
-          meLoader: jest.fn().mockReturnValue({ type: "User" }),
-        },
+        accessToken: "424242",
         notificationsFeedLoader,
       }
 
@@ -806,9 +787,7 @@ describe("HomeViewSection", () => {
       }))
 
       const context = {
-        authenticatedLoaders: {
-          meLoader: jest.fn().mockReturnValue({ type: "User" }),
-        },
+        accessToken: "424242",
         followedArtistsLoader,
         auctionLotsLoader,
       }
@@ -896,9 +875,6 @@ describe("HomeViewSection", () => {
           count: articles.length,
           results: articles,
         }),
-        authenticatedLoaders: {
-          meLoader: jest.fn().mockReturnValue({ type: "User" }),
-        },
       }
 
       const { homeView } = await runQuery(query, context)
@@ -974,9 +950,6 @@ describe("HomeViewSection", () => {
       ]
 
       const context = {
-        authenticatedLoaders: {
-          meLoader: jest.fn().mockReturnValue({ type: "User" }),
-        },
         salesLoader: jest.fn().mockResolvedValue(sales),
       }
 
@@ -1057,9 +1030,7 @@ describe("HomeViewSection", () => {
       ]
 
       const context = {
-        authenticatedLoaders: {
-          meLoader: jest.fn().mockReturnValue({ type: "User" }),
-        },
+        accessToken: "424242",
         lotStandingLoader: jest.fn().mockResolvedValue(lots),
       }
 

--- a/src/schema/v2/homeView/getSectionsForUser.ts
+++ b/src/schema/v2/homeView/getSectionsForUser.ts
@@ -1,89 +1,14 @@
 import { ResolverContext } from "types/graphql"
-import {
-  LatestActivity,
-  AuctionLotsForYou,
-  CuratorsPicksEmerging,
-  FeaturedFairs,
-  HeroUnits,
-  HomeViewSection,
-  LatestArticles,
-  MarketingCollections,
-  NewWorksForYou,
-  NewWorksFromGalleriesYouFollow,
-  RecentlyViewedArtworks,
-  RecommendedArtists,
-  ShowsForYou,
-  SimilarToRecentlyViewedArtworks,
-  TrendingArtists,
-  ViewingRooms,
-  LatestAuctionResults,
-  News,
-  Auctions,
-  ActiveBids,
-  RecommendedArtworks,
-} from "./sections"
+import { HomeViewSection } from "./sections"
+import { getLegacyZoneSections } from "./zones/legacy"
 
 export async function getSectionsForUser(
   context: ResolverContext
 ): Promise<HomeViewSection[]> {
-  /*
-   * FAKE temporary placeholder logic for determining the sections that a user will see
-   */
-  const { meLoader } = context.authenticatedLoaders
+  const legacyZoneSections = await getLegacyZoneSections(context)
 
-  if (!meLoader) throw new Error("You must be signed in to see this content.")
-
-  const me = await meLoader()
-
-  let sections: HomeViewSection[] = []
-
-  if (me.type === "Admin") {
-    sections = [
-      LatestActivity,
-      LatestAuctionResults,
-      ActiveBids,
-      Auctions,
-      LatestArticles,
-      RecentlyViewedArtworks,
-      ShowsForYou,
-      MarketingCollections,
-      TrendingArtists,
-      FeaturedFairs,
-      CuratorsPicksEmerging,
-      SimilarToRecentlyViewedArtworks,
-      AuctionLotsForYou,
-      NewWorksForYou,
-      HeroUnits,
-      NewWorksFromGalleriesYouFollow,
-      RecommendedArtists,
-      ViewingRooms,
-      News,
-      RecommendedArtworks,
-    ]
-  } else {
-    sections = [
-      News,
-      LatestActivity,
-      ActiveBids,
-      Auctions,
-      CuratorsPicksEmerging,
-      SimilarToRecentlyViewedArtworks,
-      ShowsForYou,
-      MarketingCollections,
-      FeaturedFairs,
-      NewWorksForYou,
-      HeroUnits,
-      AuctionLotsForYou,
-      LatestArticles,
-      RecommendedArtists,
-      TrendingArtists,
-      NewWorksFromGalleriesYouFollow,
-      RecommendedArtworks,
-      RecentlyViewedArtworks,
-      LatestAuctionResults,
-      ViewingRooms,
-    ]
-  }
-
-  return sections
+  return [
+    ...legacyZoneSections,
+    // other zones’ sections TK
+  ]
 }

--- a/src/schema/v2/homeView/index.ts
+++ b/src/schema/v2/homeView/index.ts
@@ -49,15 +49,20 @@ const Section: GraphQLFieldConfig<void, ResolverContext> = {
       type: new GraphQLNonNull(GraphQLString),
     },
   },
-  resolve: (_root, { id }, context) => {
-    const { meLoader } = context.authenticatedLoaders
+  resolve: (_parent, args, context, _info) => {
+    const { id } = args
+    const section = registry[id]
+    const userIsAuthenticated = !!context.accessToken
 
-    if (!meLoader) throw new Error("You must be signed in to see this content.")
-
-    if (id.length === 0) {
-      return null
+    if (!section) {
+      throw new Error(`Section not found: ${id}`)
     }
-    return registry[id]
+
+    if (section.requiresAuthentication && !userIsAuthenticated) {
+      throw new Error(`Section requires authenticated user: ${id}`)
+    }
+
+    return section
   },
 }
 

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -38,6 +38,7 @@ export type HomeViewSection = {
     href?: MaybeResolved<string>
     behaviors?: HomeViewComponentBehaviors
   }
+  requiresAuthentication: boolean
   resolver?: GraphQLFieldResolver<any, ResolverContext>
 }
 
@@ -47,6 +48,7 @@ export const SimilarToRecentlyViewedArtworks: HomeViewSection = {
   component: {
     title: "Similar to Works You’ve Viewed",
   },
+  requiresAuthentication: true,
   resolver: SimilarToRecentlyViewedArtworksResolver,
 }
 
@@ -81,6 +83,7 @@ export const CuratorsPicksEmerging: HomeViewSection = {
     },
     href: "/collection/curators-picks-emerging",
   },
+  requiresAuthentication: false,
   resolver: CuratorsPicksEmergingArtworksResolver,
 }
 
@@ -90,6 +93,7 @@ export const RecentlyViewedArtworks: HomeViewSection = {
   component: {
     title: "Recently viewed works",
   },
+  requiresAuthentication: true,
   resolver: RecentlyViewedArtworksResolver,
 }
 
@@ -99,6 +103,7 @@ export const AuctionLotsForYou: HomeViewSection = {
   component: {
     title: "Auction lots for you",
   },
+  requiresAuthentication: true,
   resolver: AuctionLotsForYouResolver,
 }
 
@@ -108,6 +113,7 @@ export const NewWorksForYou: HomeViewSection = {
   component: {
     title: "New works for you",
   },
+  requiresAuthentication: true,
   resolver: NewWorksForYouResolver,
 }
 
@@ -117,6 +123,7 @@ export const NewWorksFromGalleriesYouFollow: HomeViewSection = {
   component: {
     title: "New Works from Galleries You Follow",
   },
+  requiresAuthentication: true,
   resolver: NewWorksFromGalleriesYouFollowResolver,
 }
 
@@ -126,6 +133,7 @@ export const RecommendedArtworks: HomeViewSection = {
   component: {
     title: "Artwork Recommendations",
   },
+  requiresAuthentication: true,
   resolver: RecommendedArtworksResolver,
 }
 
@@ -137,6 +145,7 @@ export const TrendingArtists: HomeViewSection = {
   component: {
     title: "Trending Artists on Artsy",
   },
+  requiresAuthentication: false,
   resolver: SuggestedArtistsResolver,
 }
 
@@ -146,12 +155,14 @@ export const RecommendedArtists: HomeViewSection = {
   component: {
     title: "Recommended Artists",
   },
+  requiresAuthentication: true,
   resolver: RecommendedArtistsResolver,
 }
 
 export const HeroUnits: HomeViewSection = {
   id: "home-view-section-hero-units",
   type: "HeroUnitsHomeViewSection",
+  requiresAuthentication: false,
   resolver: HeroUnitsResolver,
 }
 
@@ -162,6 +173,7 @@ export const FeaturedFairs: HomeViewSection = {
     title: "Featured Fairs",
     description: "See Works in Top Art Fairs",
   },
+  requiresAuthentication: false,
   resolver: FeaturedFairsResolver,
 }
 
@@ -171,6 +183,7 @@ export const LatestArticles: HomeViewSection = {
   component: {
     title: "Artsy Editorial",
   },
+  requiresAuthentication: false,
   resolver: LatestArticlesResolvers,
 }
 
@@ -180,6 +193,7 @@ export const MarketingCollections: HomeViewSection = {
   component: {
     title: "Collections",
   },
+  requiresAuthentication: false,
   resolver: MarketingCollectionsResolver,
 }
 
@@ -189,6 +203,7 @@ export const ShowsForYou: HomeViewSection = {
   component: {
     title: "Shows for You",
   },
+  requiresAuthentication: true,
 }
 
 export const ViewingRooms: HomeViewSection = {
@@ -197,6 +212,7 @@ export const ViewingRooms: HomeViewSection = {
   component: {
     title: "Viewing Rooms",
   },
+  requiresAuthentication: false,
 }
 
 export const LatestActivity: HomeViewSection = {
@@ -205,6 +221,7 @@ export const LatestActivity: HomeViewSection = {
   component: {
     title: "Latest Activity",
   },
+  requiresAuthentication: true,
   resolver: LatestActivityResolver,
 }
 
@@ -221,6 +238,7 @@ export const LatestAuctionResults: HomeViewSection = {
       },
     },
   },
+  requiresAuthentication: true,
   resolver: LatestAuctionResultsResolver,
 }
 
@@ -232,6 +250,7 @@ export const News: HomeViewSection = {
     href: "/news",
     type: "ArticlesCard",
   },
+  requiresAuthentication: false,
   resolver: NewsResolver,
 }
 
@@ -247,6 +266,7 @@ export const Auctions: HomeViewSection = {
       },
     },
   },
+  requiresAuthentication: false,
   resolver: SalesResolver,
 }
 
@@ -256,6 +276,7 @@ export const ActiveBids: HomeViewSection = {
   component: {
     title: "Your Active Bids",
   },
+  requiresAuthentication: true,
   resolver: ActiveBidsResolver,
 }
 

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -16,16 +16,16 @@ import {
 } from "./artistResolvers"
 import { HeroUnitsResolver } from "./heroUnitsResolver"
 import { FeaturedFairsResolver } from "./featuredFairsResolver"
-
-type MaybeResolved<T> =
-  | T
-  | ((context: ResolverContext, args: any) => Promise<T>)
 import { LatestArticlesResolvers, NewsResolver } from "./articlesResolvers"
 import { MarketingCollectionsResolver } from "./marketingCollectionsResolver"
 import { LatestActivityResolver } from "./activityResolvers"
 import { LatestAuctionResultsResolver } from "./auctionResultsResolvers"
 import { HomeViewComponentBehaviors } from "./HomeViewComponent"
 import { SalesResolver } from "./salesResolver"
+
+type MaybeResolved<T> =
+  | T
+  | ((context: ResolverContext, args: any) => Promise<T>)
 
 export type HomeViewSection = {
   id: string

--- a/src/schema/v2/homeView/zones/__tests__/legacy.test.ts
+++ b/src/schema/v2/homeView/zones/__tests__/legacy.test.ts
@@ -1,0 +1,63 @@
+import { ResolverContext } from "types/graphql"
+import { getLegacyZoneSections } from "../legacy"
+
+describe("getLegacyZoneSections", () => {
+  describe("with an authenticated user", () => {
+    it("returns the correct sections", async () => {
+      const context: Partial<ResolverContext> = {
+        accessToken: "some-token",
+      }
+
+      const sections = await getLegacyZoneSections(context as ResolverContext)
+      const sectionIds = sections.map((section) => section.id)
+
+      expect(sectionIds).toMatchInlineSnapshot(`
+        Array [
+          "home-view-section-latest-activity",
+          "home-view-section-new-works-for-you",
+          "home-view-section-hero-units",
+          "home-view-section-auction-lots-for-you",
+          "home-view-section-auctions",
+          "home-view-section-latest-auction-results",
+          "home-view-section-latest-articles",
+          "home-view-section-news",
+          "home-view-section-curators-picks-emerging",
+          "home-view-section-marketing-collections",
+          "home-view-section-new-works-from-galleries-you-follow",
+          "home-view-section-recommended-artists",
+          "home-view-section-trending-artists",
+          "home-view-section-recently-viewed-artworks",
+          "home-view-section-similar-to-recently-viewed-artworks",
+          "home-view-section-viewing-rooms",
+          "home-view-section-shows-for-you",
+          "home-view-section-featured-fairs",
+        ]
+      `)
+    })
+  })
+
+  describe("without an authenticated user", () => {
+    it("returns the correct sections", async () => {
+      const context: Partial<ResolverContext> = {
+        accessToken: undefined,
+      }
+
+      const sections = await getLegacyZoneSections(context as ResolverContext)
+      const sectionIds = sections.map((section) => section.id)
+
+      expect(sectionIds).toMatchInlineSnapshot(`
+        Array [
+          "home-view-section-hero-units",
+          "home-view-section-auctions",
+          "home-view-section-latest-articles",
+          "home-view-section-news",
+          "home-view-section-curators-picks-emerging",
+          "home-view-section-marketing-collections",
+          "home-view-section-trending-artists",
+          "home-view-section-viewing-rooms",
+          "home-view-section-featured-fairs",
+        ]
+      `)
+    })
+  })
+})

--- a/src/schema/v2/homeView/zones/legacy.ts
+++ b/src/schema/v2/homeView/zones/legacy.ts
@@ -1,0 +1,64 @@
+import { ResolverContext } from "types/graphql"
+import {
+  Auctions,
+  AuctionLotsForYou,
+  CuratorsPicksEmerging,
+  FeaturedFairs,
+  HeroUnits,
+  HomeViewSection,
+  LatestActivity,
+  LatestArticles,
+  LatestAuctionResults,
+  MarketingCollections,
+  NewWorksForYou,
+  NewWorksFromGalleriesYouFollow,
+  News,
+  RecentlyViewedArtworks,
+  RecommendedArtists,
+  ShowsForYou,
+  SimilarToRecentlyViewedArtworks,
+  TrendingArtists,
+  ViewingRooms,
+} from "schema/v2/homeView/sections"
+
+const LEGACY_ZONE_SECTIONS: HomeViewSection[] = [
+  LatestActivity,
+  NewWorksForYou,
+  HeroUnits,
+  // TK: active bids
+  AuctionLotsForYou,
+  Auctions,
+  LatestAuctionResults,
+  // TK: galleries near you
+  LatestArticles,
+  News,
+  CuratorsPicksEmerging,
+  MarketingCollections,
+  // TK: artwork recs
+  NewWorksFromGalleriesYouFollow,
+  RecommendedArtists,
+  TrendingArtists,
+  RecentlyViewedArtworks,
+  SimilarToRecentlyViewedArtworks,
+  ViewingRooms,
+  ShowsForYou,
+  FeaturedFairs,
+]
+
+export async function getLegacyZoneSections(context: ResolverContext) {
+  const isAuthenticatedUser = !!context.accessToken
+
+  const displayableSections = LEGACY_ZONE_SECTIONS.reduce(
+    (sections, section) => {
+      const isDisplayable =
+        section.requiresAuthentication === false || // public content, or
+        (section.requiresAuthentication && isAuthenticatedUser) // user-specific content
+
+      if (isDisplayable) sections.push(section)
+      return sections
+    },
+    [] as HomeViewSection[]
+  )
+
+  return displayableSections
+}


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-1161

This started out as:

- introduce a legacy zone concept to the home view

And then I feature-creeped it with:

- relax the requirement for an _authenticated_ user for requesting the `homeView` fields

So now this can be requested by either an authenticated or an un-authenticated user:

👉🏽  Most of the interesting stuff is in https://github.com/artsy/metaphysics/pull/5948/commits/004450f7f0ddad31556a8848e0fae8a03e0af39c

### Request

```graphql
{
  homeView {
    sectionsConnection(first: 30) {
      edges {
        node {
          ... on GenericHomeViewSection {
            internalID
          }
        }
      }
    }
  }
}
```

### Response (authenticated user)

This represents the "legacy zone", which is an internal but not (as of yet) a client-facing concept. This zone consists of the same sections, in the same order, as the current Eigen home feed.

```json
{
  "data": {
    "homeView": {
      "sectionsConnection": {
        "edges": [
          { "node": { "internalID": "home-view-section-latest-activity" }},
          { "node": { "internalID": "home-view-section-new-works-for-you" }},
          { "node": { "internalID": "home-view-section-hero-units" }},
          { "node": { "internalID": "home-view-section-auction-lots-for-you" }},
          { "node": { "internalID": "home-view-section-auctions" }},
          { "node": { "internalID": "home-view-section-latest-auction-results" }},
          { "node": { "internalID": "home-view-section-latest-articles" }},
          { "node": { "internalID": "home-view-section-news" }},
          { "node": { "internalID": "home-view-section-curators-picks-emerging" }},
          { "node": { "internalID": "home-view-section-marketing-collections" }},
          { "node": { "internalID": "home-view-section-new-works-from-galleries-you-follow" }},
          { "node": { "internalID": "home-view-section-recommended-artists" }},
          { "node": { "internalID": "home-view-section-trending-artists" }},
          { "node": { "internalID": "home-view-section-recently-viewed-artworks" }},
          { "node": { "internalID": "home-view-section-similar-to-recently-viewed-artworks" }},
          { "node": { "internalID": "home-view-section-viewing-rooms" }},
          { "node": { "internalID": "home-view-section-shows-for-you" }},
          { "node": { "internalID": "home-view-section-featured-fairs" }
          }
        ]
      }
    }
  }
}
```

### Response (un-authenticated user)

This returns all sections that do not contain personalized content. (I assume this list will need tweaking, but it's a start). Should also help unblock [ONYX-1165](https://artsyproduct.atlassian.net/browse/ONYX-1165)

```json
{
  "data": {
    "homeView": {
      "sectionsConnection": {
        "edges": [
          { "node": { "internalID": "home-view-section-hero-units" }},
          { "node": { "internalID": "home-view-section-auctions" }},
          { "node": { "internalID": "home-view-section-latest-articles" }},
          { "node": { "internalID": "home-view-section-news" }},
          { "node": { "internalID": "home-view-section-curators-picks-emerging" }},
          { "node": { "internalID": "home-view-section-marketing-collections" }},
          { "node": { "internalID": "home-view-section-trending-artists" }},
          { "node": { "internalID": "home-view-section-viewing-rooms" }},
          { "node": { "internalID": "home-view-section-featured-fairs" }}
        ]
      }
    }
  }
}
```




[ONYX-1165]: https://artsyproduct.atlassian.net/browse/ONYX-1165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ