### PR TITLE
feat(onyx-1229): add Auctions home view section

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11104,6 +11104,7 @@ union HomeViewSection =
   | FairsRailHomeViewSection
   | HeroUnitsHomeViewSection
   | MarketingCollectionsRailHomeViewSection
+  | SalesRailHomeViewSection
   | ShowsRailHomeViewSection
   | ViewingRoomsRailHomeViewSection
 
@@ -17998,6 +17999,24 @@ enum SaleSorts {
   TIMELY_AT_NAME_DESC
   _ID_ASC
   _ID_DESC
+}
+
+# A sales rail section in the home view
+type SalesRailHomeViewSection implements GenericHomeViewSection & Node {
+  # The component that is prescribed for this section
+  component: HomeViewComponent
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+  salesConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): SaleConnection
 }
 
 input SaveArtworkInput {

--- a/src/schema/v2/homeView/HomeViewSection.ts
+++ b/src/schema/v2/homeView/HomeViewSection.ts
@@ -17,6 +17,7 @@ import { NotificationsConnection } from "../notifications"
 import { InternalIDFields, NodeInterface } from "../object_identification"
 import { HomeViewComponent } from "./HomeViewComponent"
 import { auctionResultConnection } from "../auction_result"
+import { SalesConnectionField } from "../sales"
 
 // section interface
 
@@ -217,6 +218,25 @@ export const AuctionResultsRailHomeViewSectionType = new GraphQLObjectType<
   },
 })
 
+const SalesRailHomeViewSectionType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "SalesRailHomeViewSection",
+  description: "A sales rail section in the home view",
+  interfaces: [GenericHomeViewSectionInterface, NodeInterface],
+  fields: {
+    ...standardSectionFields,
+
+    salesConnection: {
+      type: SalesConnectionField.type,
+      args: pageable({}),
+      resolve: (parent, ...rest) =>
+        parent.resolver ? parent.resolver(parent, ...rest) : [],
+    },
+  },
+})
+
 // the Section union type of all concrete sections
 
 export const HomeViewSectionType = new GraphQLUnionType({
@@ -232,6 +252,7 @@ export const HomeViewSectionType = new GraphQLUnionType({
     MarketingCollectionsRailHomeViewSectionType,
     ShowsRailHomeViewSectionType,
     ViewingRoomsRailHomeViewSectionType,
+    SalesRailHomeViewSectionType,
   ],
   resolveType: (value) => {
     return value.type

--- a/src/schema/v2/homeView/__tests__/HomeView.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeView.test.ts
@@ -55,6 +55,14 @@ describe("homeView", () => {
             },
             Object {
               "node": Object {
+                "__typename": "SalesRailHomeViewSection",
+                "component": Object {
+                  "title": "Auctions",
+                },
+              },
+            },
+            Object {
+              "node": Object {
                 "__typename": "ArtworksRailHomeViewSection",
                 "component": Object {
                   "title": "Curators' Picks Emerging",

--- a/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
@@ -825,6 +825,12 @@ describe("HomeViewSection", () => {
               ... on SalesRailHomeViewSection {
                 component {
                   title
+                  behaviors {
+                    viewAll {
+                      href
+                      buttonText
+                    }
+                  }
                 }
 
                 salesConnection(first: 2) {
@@ -862,6 +868,12 @@ describe("HomeViewSection", () => {
         Object {
           "__typename": "SalesRailHomeViewSection",
           "component": Object {
+            "behaviors": Object {
+              "viewAll": Object {
+                "buttonText": "Browse All Auctions",
+                "href": "/auctions",
+              },
+            },
             "title": "Auctions",
           },
           "salesConnection": Object {

--- a/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
@@ -813,4 +813,73 @@ describe("HomeViewSection", () => {
       `)
     })
   })
+
+  describe("SalesRailHomeViewSection", () => {
+    it("returns correct data", async () => {
+      const query = gql`
+        {
+          homeView {
+            section(id: "home-view-section-auctions") {
+              __typename
+
+              ... on SalesRailHomeViewSection {
+                component {
+                  title
+                }
+
+                salesConnection(first: 2) {
+                  edges {
+                    node {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const sales = [
+        {
+          name: "Auction 1",
+        },
+        {
+          name: "Auction 2",
+        },
+      ]
+
+      const context = {
+        authenticatedLoaders: {
+          meLoader: jest.fn().mockReturnValue({ type: "User" }),
+        },
+        salesLoader: jest.fn().mockResolvedValue(sales),
+      }
+
+      const { homeView } = await runQuery(query, context)
+
+      expect(homeView.section).toMatchInlineSnapshot(`
+        Object {
+          "__typename": "SalesRailHomeViewSection",
+          "component": Object {
+            "title": "Auctions",
+          },
+          "salesConnection": Object {
+            "edges": Array [
+              Object {
+                "node": Object {
+                  "name": "Auction 1",
+                },
+              },
+              Object {
+                "node": Object {
+                  "name": "Auction 2",
+                },
+              },
+            ],
+          },
+        }
+      `)
+    })
+  })
 })

--- a/src/schema/v2/homeView/getSectionsForUser.ts
+++ b/src/schema/v2/homeView/getSectionsForUser.ts
@@ -18,6 +18,7 @@ import {
   ViewingRooms,
   LatestAuctionResults,
   News,
+  Auctions,
 } from "./sections"
 
 export async function getSectionsForUser(
@@ -38,6 +39,7 @@ export async function getSectionsForUser(
     sections = [
       LatestActivity,
       LatestAuctionResults,
+      Auctions,
       LatestArticles,
       RecentlyViewedArtworks,
       ShowsForYou,
@@ -58,6 +60,7 @@ export async function getSectionsForUser(
     sections = [
       News,
       LatestActivity,
+      Auctions,
       CuratorsPicksEmerging,
       SimilarToRecentlyViewedArtworks,
       ShowsForYou,

--- a/src/schema/v2/homeView/salesResolver.ts
+++ b/src/schema/v2/homeView/salesResolver.ts
@@ -1,0 +1,21 @@
+import { GraphQLFieldResolver } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { HomePageSalesModuleType } from "../home/home_page_sales_module"
+import { connectionFromArray } from "graphql-relay"
+
+export const SalesResolver: GraphQLFieldResolver<any, ResolverContext> = async (
+  parent,
+  args,
+  context,
+  info
+) => {
+  const { results: resolver } = HomePageSalesModuleType.getFields()
+
+  if (!resolver?.resolve) {
+    return []
+  }
+
+  const result = await resolver.resolve(parent, args, context, info)
+
+  return connectionFromArray(result, args)
+}

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -23,6 +23,7 @@ import { MarketingCollectionsResolver } from "./marketingCollectionsResolver"
 import { LatestActivityResolver } from "./activityResolvers"
 import { LatestAuctionResultsResolver } from "./auctionResultsResolvers"
 import { HomeViewComponentBehaviors } from "./HomeViewComponent"
+import { SalesResolver } from "./salesResolver"
 
 export type HomeViewSection = {
   id: string
@@ -221,7 +222,17 @@ export const News: HomeViewSection = {
   resolver: NewsResolver,
 }
 
+export const Auctions: HomeViewSection = {
+  id: "home-view-section-auctions",
+  type: "SalesRailHomeViewSection",
+  component: {
+    title: "Auctions",
+  },
+  resolver: SalesResolver,
+}
+
 const sections: HomeViewSection[] = [
+  Auctions,
   AuctionLotsForYou,
   CuratorsPicksEmerging,
   FeaturedFairs,

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -227,6 +227,12 @@ export const Auctions: HomeViewSection = {
   type: "SalesRailHomeViewSection",
   component: {
     title: "Auctions",
+    behaviors: {
+      viewAll: {
+        href: "/auctions",
+        buttonText: "Browse All Auctions",
+      },
+    },
   },
   resolver: SalesResolver,
 }


### PR DESCRIPTION
# Request

```graphql
query {
  homeView {
    section(id: "home-view-section-auctions") {
      ... on SalesRailHomeViewSection {
        component {
          title
        }

        salesConnection(first: 2) {
          edges {
            node {
              name
            }
          }
        }
      }
    }
  }
}
```

# Response

```json
{
  "data": {
    "homeView": {
      "section": {
        "component": {
          "title": "Auctions"
        },
        "salesConnection": {
          "edges": [
            {
              "node": {
                "name": "Artsy Auction: 100 x 100 (Part I) "
              }
            },
            {
              "node": {
                "name": "Collector signals live now"
              }
            }
          ]
        }
      }
    }
  }
}
```