### PR TITLE
chore: configure alternate ingress host for metaphysics staging (DIA-818)

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -146,3 +146,13 @@ spec:
             name: metaphysics-web-internal
             port:
               name: mp-http
+  - host: metaphysics-staging-alt.artsy.net
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: metaphysics-web-internal
+            port:
+              name: mp-http


### PR DESCRIPTION
This adds an alternate hostname for the same metaphysics-staging (only) deployment. It aims to simplify caching experiments ([DIA-818](https://artsyproduct.atlassian.net/browse/DIA-818)), which would probably be applied at the "edge" before passing requests through to the actual origin. During these experiments I'd rather not touch the live configuration for `metaphysics-[staging|production].artsy.net`, so this alternate name gives us freedom to experiment while iterating on realistic configuration.

[DIA-818]: https://artsyproduct.atlassian.net/browse/DIA-818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ