### PR TITLE
feat(EMI-2013): add curatorsPick field to artwork signals

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4513,6 +4513,9 @@ type CollectorSignals {
   # Bid count on lots open for bidding
   bidCount: Int @deprecated(reason: "Use nested field in `auction` instead")
 
+  # Artwork is part of either the Curators' Pick Emerging or Blue Chip collections
+  curatorsPick: Boolean
+
   # Increased interest in the artwork
   increasedInterest: Boolean!
 

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -1,14 +1,8 @@
-import {
-  GraphQLBoolean,
-  GraphQLFieldConfig,
-  GraphQLString,
-  GraphQLList,
-} from "graphql"
+import { GraphQLBoolean, GraphQLFieldConfig, GraphQLString } from "graphql"
 import { GraphQLInt, GraphQLObjectType } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { PartnerOfferToCollectorType } from "../partnerOfferToCollector"
 import { isFeatureFlagEnabled } from "lib/featureFlags"
-import { fetchMarketingCollections } from "../marketingCollections"
 import { date } from "../fields/date"
 import { GraphQLNonNull } from "graphql"
 


### PR DESCRIPTION
Paired with @erikdstock on this.

Adds a `curatorsPick` field that is `true` if the artwork is either in the `curators-picks-blue-chip-artists` or `curators-picks-emerging-artists` marketing collections and false otherwise.

I did a smoke test in staging adding one artwork to one of the collections via https://stagingapi.artsy.net/admin/curated_marketing_collection/08b45eb4-b975-49c7-8ccb-b16d2304a308 (it took me some time to find where we edit those collections, so posting here for future reference; **you need the `METADATA_ADMIN` role to see the page**) and it looks good locally.

```
query {
artwork(id: "molly-magai-fladson-test") {
          collectorSignals {
            increasedInterest
            curatorsPick
            auction {
              bidCount
              lotWatcherCount
              registrationEndsAt
              lotClosesAt
              liveBiddingStarted
              liveStartAt
              onlineBiddingExtended
            }
            partnerOffer {
              endAt
            }
          }
        }
}
```

**_Response_**
```
{
  "data": {
    "artwork": {
      "collectorSignals": {
        "increasedInterest": false,
        "curatorsPick": true,
        "auction": null,
        "partnerOffer": null
      }
    }
  },
  "extensions": {
    "requests": {
      "gravity": {
        "requests": {
          "artwork/molly-magai-fladson-test": {
            "time": "0s 404.437ms",
            "cache": false,
            "length": "N/A"
          },
          "marketing_collections/curators-picks-emerging-artists": {
            "time": "1s 62.764ms",
            "cache": false,
            "length": "N/A"
          },
          "marketing_collections/curators-picks-blue-chip-artists": {
            "time": "1s 95.374ms",
            "cache": false,
            "length": "N/A"
          }
        }
      }
    },
    "requestID": "737dba20-6560-11ef-b75c-8332f479afe9",
    "userAgent": "graphiql-app"
  }
}
```

@artsy/emerald-devs 