### PR TITLE
chore(EMI-2049): expose primaryLabel field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11707,6 +11707,7 @@ type Job {
 }
 
 enum LabelSignalEnum {
+  CURATORS_PICK
   INCREASED_INTEREST
   PARTNER_OFFER
 }

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4546,6 +4546,9 @@ type CollectorSignals {
   # Partner offer available to collector
   partnerOffer: PartnerOfferToCollector
 
+  # Primary label signal available to collector
+  primaryLabel: LabelSignalEnum
+
   # Pending auction registration end time
   registrationEndsAt: String
     @deprecated(reason: "Use nested field in `auction` instead")
@@ -11701,6 +11704,11 @@ type Job {
     # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String
+}
+
+enum LabelSignalEnum {
+  INCREASED_INTEREST
+  PARTNER_OFFER
 }
 
 type LatLng {

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -4745,6 +4745,51 @@ describe("Artwork type", () => {
             },
           })
         })
+        describe("primaryLabel signal", () => {
+          const query = `
+            {
+              artwork(id: "richard-prince-untitled-portrait") {
+                collectorSignals {
+                  primaryLabel
+                  increasedInterest
+                  partnerOffer {
+                    endAt
+                  }
+                }
+              }
+            }
+          `
+          it("prefers 'PARTNER_OFFER' if there is an active partner offer", async () => {
+            context.mePartnerOffersLoader.mockResolvedValue({
+              body: [{ endAt: "2023-01-01", active: true }],
+            })
+            artwork.increased_interest_signal = true
+            const data = await runQuery(query, context)
+            expect(data.artwork.collectorSignals.primaryLabel).toEqual(
+              "PARTNER_OFFER"
+            )
+          })
+
+          it("shows 'INCREASED_INTEREST' if there is no active partner offer but increased interest", async () => {
+            context.mePartnerOffersLoader.mockResolvedValue({
+              body: [],
+            })
+            artwork.increased_interest_signal = true
+            const data = await runQuery(query, context)
+            expect(data.artwork.collectorSignals.primaryLabel).toEqual(
+              "INCREASED_INTEREST"
+            )
+          })
+
+          it("returns null if there is no active partner offer and no increased interest", async () => {
+            context.mePartnerOffersLoader.mockResolvedValue({
+              body: [],
+            })
+            artwork.increased_interest_signal = false
+            const data = await runQuery(query, context)
+            expect(data.artwork.collectorSignals.primaryLabel).toBeNull()
+          })
+        })
       })
 
       describe("auction artwork", () => {

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -4789,6 +4789,19 @@ describe("Artwork type", () => {
             const data = await runQuery(query, context)
             expect(data.artwork.collectorSignals.primaryLabel).toBeNull()
           })
+          it("shows 'CURATORS_PICK' if there is no active partner offer, no increased interest, but the artwork is in a curators pick collection", async () => {
+            context.mePartnerOffersLoader.mockResolvedValue({
+              body: [],
+            })
+            artwork.increased_interest_signal = false
+            context.marketingCollectionLoader.mockResolvedValue({
+              artwork_ids: [artwork._id],
+            })
+            const data = await runQuery(query, context)
+            expect(data.artwork.collectorSignals.primaryLabel).toEqual(
+              "CURATORS_PICK"
+            )
+          })
         })
       })
 

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -172,15 +172,12 @@ export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
       partnerOffer: {
         type: PartnerOfferToCollectorType,
         description: "Partner offer available to collector",
-        resolve: async (artwork, {}, ctx) => {
-          const fields = await getLabelSignalFields(artwork, ctx)
-          return fields.partnerOffer
-        },
+        resolve: (artwork, {}, ctx) => getActivePartnerOffer(artwork, ctx),
       },
       increasedInterest: {
         type: new GraphQLNonNull(GraphQLBoolean),
         description: "Increased interest in the artwork",
-        resolve: (artwork, {}, ctx) => getActivePartnerOffer(artwork, ctx),
+        resolve: (artwork) => !!artwork.increased_interest_signal,
       },
     },
   }),
@@ -237,8 +234,6 @@ const getLabelSignalFields = async (
     signals.primaryLabel = "INCREASED_INTEREST"
   } else if (signals.curatorsPick) {
     signals.primaryLabel = "CURATORS_PICK"
-  } else {
-    signals.primaryLabel = null
   }
 
   return signals


### PR DESCRIPTION
Completes [EMI-2049] 🦄 

This PR adds a `primaryLabel` field to collector signals which is an enum of the possible signal labels. PARTNER_OFFER implies existence of the partnerOffer field as well, while others come from a boolean. However this PR does not change the schema to guarantee a partner offer if the label is PARTNER_OFFER.

relates to #5954 and should probably go in after rebasing on that change.

[EMI-2049]: https://artsyproduct.atlassian.net/browse/EMI-2049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ