### PR TITLE
feat(onyx-1157): add href and button texts to all home view sections that require it

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11099,7 +11099,7 @@ type HomeViewComponentBehaviorsViewAll {
   buttonText: String
 
   # href of the view all button
-  href: String!
+  href: String
 }
 
 union HomeViewSection =

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11096,7 +11096,7 @@ type HomeViewComponentBehaviors {
 
 type HomeViewComponentBehaviorsViewAll {
   # Text for the CTA of the view all button
-  buttonText: String!
+  buttonText: String
 
   # href of the view all button
   href: String!

--- a/src/schema/v2/homeView/HomeViewComponent.ts
+++ b/src/schema/v2/homeView/HomeViewComponent.ts
@@ -9,7 +9,7 @@ import { ResolverContext } from "types/graphql"
 export type HomeViewComponentBehaviors = {
   viewAll?: {
     href: string
-    buttonText: string
+    buttonText?: string
   }
 }
 const HomeViewComponentBehaviors = new GraphQLObjectType<
@@ -27,7 +27,7 @@ const HomeViewComponentBehaviors = new GraphQLObjectType<
             description: "href of the view all button",
           },
           buttonText: {
-            type: new GraphQLNonNull(GraphQLString),
+            type: GraphQLString,
             description: "Text for the CTA of the view all button",
           },
         },

--- a/src/schema/v2/homeView/HomeViewComponent.ts
+++ b/src/schema/v2/homeView/HomeViewComponent.ts
@@ -1,14 +1,9 @@
-import {
-  GraphQLEnumType,
-  GraphQLNonNull,
-  GraphQLObjectType,
-  GraphQLString,
-} from "graphql"
+import { GraphQLEnumType, GraphQLObjectType, GraphQLString } from "graphql"
 import { ResolverContext } from "types/graphql"
 
 export type HomeViewComponentBehaviors = {
   viewAll?: {
-    href: string
+    href?: string
     buttonText?: string
   }
 }
@@ -23,7 +18,7 @@ const HomeViewComponentBehaviors = new GraphQLObjectType<
         name: "HomeViewComponentBehaviorsViewAll",
         fields: {
           href: {
-            type: new GraphQLNonNull(GraphQLString),
+            type: GraphQLString,
             description: "href of the view all button",
           },
           buttonText: {

--- a/src/schema/v2/homeView/__tests__/HomeView.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeView.test.ts
@@ -86,7 +86,7 @@ describe("homeView", () => {
                 "node": Object {
                   "__typename": "ArtistsRailHomeViewSection",
                   "component": Object {
-                    "title": "Trending Artists on Artsy",
+                    "title": "Trending Artists",
                   },
                 },
               },
@@ -224,7 +224,7 @@ describe("homeView", () => {
                 "node": Object {
                   "__typename": "ArtistsRailHomeViewSection",
                   "component": Object {
-                    "title": "Trending Artists on Artsy",
+                    "title": "Trending Artists",
                   },
                 },
               },

--- a/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
@@ -17,7 +17,6 @@ describe("HomeViewSection", () => {
                   behaviors {
                     viewAll {
                       href
-                      buttonText
                     }
                   }
                 }
@@ -39,7 +38,6 @@ describe("HomeViewSection", () => {
           "component": Object {
             "behaviors": Object {
               "viewAll": Object {
-                "buttonText": "Browse All Artworks",
                 "href": "/similar-to-recently-viewed",
               },
             },
@@ -63,7 +61,6 @@ describe("HomeViewSection", () => {
                   behaviors {
                     viewAll {
                       href
-                      buttonText
                     }
                   }
                 }
@@ -85,7 +82,6 @@ describe("HomeViewSection", () => {
           "component": Object {
             "behaviors": Object {
               "viewAll": Object {
-                "buttonText": "Browse All Artworks",
                 "href": "/recently-viewed",
               },
             },
@@ -109,7 +105,6 @@ describe("HomeViewSection", () => {
                   behaviors {
                     viewAll {
                       href
-                      buttonText
                     }
                   }
                 }
@@ -131,7 +126,6 @@ describe("HomeViewSection", () => {
           "component": Object {
             "behaviors": Object {
               "viewAll": Object {
-                "buttonText": "Browse All Artworks",
                 "href": "/new-for-you",
               },
             },
@@ -155,7 +149,6 @@ describe("HomeViewSection", () => {
                   behaviors {
                     viewAll {
                       href
-                      buttonText
                     }
                   }
                 }
@@ -177,7 +170,6 @@ describe("HomeViewSection", () => {
           "component": Object {
             "behaviors": Object {
               "viewAll": Object {
-                "buttonText": "Browse All Artworks",
                 "href": "/auctions/lots-for-you-ending-soon",
               },
             },
@@ -201,7 +193,6 @@ describe("HomeViewSection", () => {
                   behaviors {
                     viewAll {
                       href
-                      buttonText
                     }
                   }
                 }
@@ -313,7 +304,6 @@ describe("HomeViewSection", () => {
             "component": Object {
               "behaviors": Object {
                 "viewAll": Object {
-                  "buttonText": "Browse All Artworks",
                   "href": "/artwork-recommendations",
                 },
               },
@@ -340,7 +330,6 @@ describe("HomeViewSection", () => {
                   behaviors {
                     viewAll {
                       href
-                      buttonText
                     }
                   }
                 }
@@ -396,7 +385,6 @@ describe("HomeViewSection", () => {
           "component": Object {
             "behaviors": Object {
               "viewAll": Object {
-                "buttonText": "Browse All Artworks",
                 "href": "/new-works-from-galleries-you-follow",
               },
             },
@@ -585,7 +573,6 @@ describe("HomeViewSection", () => {
                   behaviors {
                     viewAll {
                       href
-                      buttonText
                     }
                   }
                 }
@@ -657,7 +644,6 @@ describe("HomeViewSection", () => {
             "backgroundImageURL": "image.jpg",
             "behaviors": Object {
               "viewAll": Object {
-                "buttonText": "Browse All Artworks",
                 "href": "/collection/curators-picks-emerging",
               },
             },
@@ -867,7 +853,6 @@ describe("HomeViewSection", () => {
                   behaviors {
                     viewAll {
                       href
-                      buttonText
                     }
                   }
                 }
@@ -936,7 +921,6 @@ describe("HomeViewSection", () => {
               "component": Object {
                 "behaviors": Object {
                   "viewAll": Object {
-                    "buttonText": "See All",
                     "href": "/notifications",
                   },
                 },
@@ -979,7 +963,6 @@ describe("HomeViewSection", () => {
                   behaviors {
                     viewAll {
                       href
-                      buttonText
                     }
                   }
                 }
@@ -1065,7 +1048,6 @@ describe("HomeViewSection", () => {
               "component": Object {
                 "behaviors": Object {
                   "viewAll": Object {
-                    "buttonText": "Browse All Results",
                     "href": "/auction-results-for-artists-you-follow",
                   },
                 },
@@ -1134,7 +1116,6 @@ describe("HomeViewSection", () => {
                   behaviors {
                     viewAll {
                       href
-                      buttonText
                     }
                   }
                 }
@@ -1195,7 +1176,6 @@ describe("HomeViewSection", () => {
           "component": Object {
             "behaviors": Object {
               "viewAll": Object {
-                "buttonText": "More in News",
                 "href": "/news",
               },
             },
@@ -1221,7 +1201,6 @@ describe("HomeViewSection", () => {
                   behaviors {
                     viewAll {
                       href
-                      buttonText
                     }
                   }
                 }
@@ -1260,7 +1239,6 @@ describe("HomeViewSection", () => {
           "component": Object {
             "behaviors": Object {
               "viewAll": Object {
-                "buttonText": "Browse All Auctions",
                 "href": "/auctions",
               },
             },

--- a/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
@@ -2,6 +2,192 @@ import gql from "lib/gql"
 import { runQuery } from "schema/v2/test/utils"
 
 describe("HomeViewSection", () => {
+  describe("SimilarToRecentlyViewedArtworks", () => {
+    it("returns correct data", async () => {
+      const query = gql`
+        {
+          homeView {
+            section(
+              id: "home-view-section-similar-to-recently-viewed-artworks"
+            ) {
+              __typename
+              ... on ArtworksRailHomeViewSection {
+                component {
+                  title
+                  behaviors {
+                    viewAll {
+                      href
+                      buttonText
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const context = {
+        accessToken: "424242",
+      }
+
+      const { homeView } = await runQuery(query, context)
+
+      expect(homeView.section).toMatchInlineSnapshot(`
+        Object {
+          "__typename": "ArtworksRailHomeViewSection",
+          "component": Object {
+            "behaviors": Object {
+              "viewAll": Object {
+                "buttonText": "Browse All Artworks",
+                "href": "/similar-to-recently-viewed",
+              },
+            },
+            "title": "Similar to Works You’ve Viewed",
+          },
+        }
+      `)
+    })
+  })
+
+  describe("RecentlyViewedArtworks", () => {
+    it("returns correct data", async () => {
+      const query = gql`
+        {
+          homeView {
+            section(id: "home-view-section-recently-viewed-artworks") {
+              __typename
+              ... on ArtworksRailHomeViewSection {
+                component {
+                  title
+                  behaviors {
+                    viewAll {
+                      href
+                      buttonText
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const context = {
+        accessToken: "424242",
+      }
+
+      const { homeView } = await runQuery(query, context)
+
+      expect(homeView.section).toMatchInlineSnapshot(`
+        Object {
+          "__typename": "ArtworksRailHomeViewSection",
+          "component": Object {
+            "behaviors": Object {
+              "viewAll": Object {
+                "buttonText": "Browse All Artworks",
+                "href": "/recently-viewed",
+              },
+            },
+            "title": "Recently viewed works",
+          },
+        }
+      `)
+    })
+  })
+
+  describe("NewWorksForYou", () => {
+    it("returns correct data", async () => {
+      const query = gql`
+        {
+          homeView {
+            section(id: "home-view-section-new-works-for-you") {
+              __typename
+              ... on ArtworksRailHomeViewSection {
+                component {
+                  title
+                  behaviors {
+                    viewAll {
+                      href
+                      buttonText
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const context = {
+        accessToken: "424242",
+      }
+
+      const { homeView } = await runQuery(query, context)
+
+      expect(homeView.section).toMatchInlineSnapshot(`
+        Object {
+          "__typename": "ArtworksRailHomeViewSection",
+          "component": Object {
+            "behaviors": Object {
+              "viewAll": Object {
+                "buttonText": "Browse All Artworks",
+                "href": "/new-for-you",
+              },
+            },
+            "title": "New works for you",
+          },
+        }
+      `)
+    })
+  })
+
+  describe("AuctionLotsForYou", () => {
+    it("returns correct data", async () => {
+      const query = gql`
+        {
+          homeView {
+            section(id: "home-view-section-auction-lots-for-you") {
+              __typename
+              ... on ArtworksRailHomeViewSection {
+                component {
+                  title
+                  behaviors {
+                    viewAll {
+                      href
+                      buttonText
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const context = {
+        accessToken: "424242",
+      }
+
+      const { homeView } = await runQuery(query, context)
+
+      expect(homeView.section).toMatchInlineSnapshot(`
+        Object {
+          "__typename": "ArtworksRailHomeViewSection",
+          "component": Object {
+            "behaviors": Object {
+              "viewAll": Object {
+                "buttonText": "Browse All Artworks",
+                "href": "/auctions/lots-for-you-ending-soon",
+              },
+            },
+            "title": "Auction lots for you",
+          },
+        }
+      `)
+    })
+  })
+
   describe("RecommendedArtworks", () => {
     it("returns lists of artworksConnection", async () => {
       const query = gql`
@@ -12,6 +198,12 @@ describe("HomeViewSection", () => {
               ... on ArtworksRailHomeViewSection {
                 component {
                   title
+                  behaviors {
+                    viewAll {
+                      href
+                      buttonText
+                    }
+                  }
                 }
                 artworksConnection(first: 2) {
                   edges {
@@ -98,25 +290,38 @@ describe("HomeViewSection", () => {
         ids: ["608a7417bdfbd1a789ba092a", "308a7416bdfbd1a789ba0911"],
       })
 
-      expect(response.homeView.section.artworksConnection)
-        .toMatchInlineSnapshot(`
-      Object {
-        "edges": Array [
-          Object {
-            "node": Object {
-              "id": "QXJ0d29yazo2MDhhNzQxN2JkZmJkMWE3ODliYTA5MmE=",
-              "title": "Untitled",
+      expect(response.homeView).toMatchInlineSnapshot(`
+        Object {
+          "section": Object {
+            "__typename": "ArtworksRailHomeViewSection",
+            "artworksConnection": Object {
+              "edges": Array [
+                Object {
+                  "node": Object {
+                    "id": "QXJ0d29yazo2MDhhNzQxN2JkZmJkMWE3ODliYTA5MmE=",
+                    "title": "Untitled",
+                  },
+                },
+                Object {
+                  "node": Object {
+                    "id": "QXJ0d29yazozMDhhNzQxNmJkZmJkMWE3ODliYTA5MTE=",
+                    "title": "Untitled",
+                  },
+                },
+              ],
+            },
+            "component": Object {
+              "behaviors": Object {
+                "viewAll": Object {
+                  "buttonText": "Browse All Artworks",
+                  "href": "/artwork-recommendations",
+                },
+              },
+              "title": "Artwork Recommendations",
             },
           },
-          Object {
-            "node": Object {
-              "id": "QXJ0d29yazozMDhhNzQxNmJkZmJkMWE3ODliYTA5MTE=",
-              "title": "Untitled",
-            },
-          },
-        ],
-      }
-    `)
+        }
+      `)
     })
   })
 
@@ -132,6 +337,12 @@ describe("HomeViewSection", () => {
               ... on ArtworksRailHomeViewSection {
                 component {
                   title
+                  behaviors {
+                    viewAll {
+                      href
+                      buttonText
+                    }
+                  }
                 }
                 artworksConnection(first: 2) {
                   edges {
@@ -183,6 +394,12 @@ describe("HomeViewSection", () => {
             ],
           },
           "component": Object {
+            "behaviors": Object {
+              "viewAll": Object {
+                "buttonText": "Browse All Artworks",
+                "href": "/new-works-from-galleries-you-follow",
+              },
+            },
             "title": "New Works from Galleries You Follow",
           },
         }
@@ -364,8 +581,13 @@ describe("HomeViewSection", () => {
                 component {
                   title
                   description
-                  href
                   backgroundImageURL
+                  behaviors {
+                    viewAll {
+                      href
+                      buttonText
+                    }
+                  }
                 }
 
                 artworksConnection(first: 2) {
@@ -433,8 +655,13 @@ describe("HomeViewSection", () => {
           },
           "component": Object {
             "backgroundImageURL": "image.jpg",
+            "behaviors": Object {
+              "viewAll": Object {
+                "buttonText": "Browse All Artworks",
+                "href": "/collection/curators-picks-emerging",
+              },
+            },
             "description": "The best works by rising talents on Artsy, available now.",
-            "href": "/collection/curators-picks-emerging",
             "title": "Curators' Picks Emerging",
           },
         }
@@ -595,6 +822,11 @@ describe("HomeViewSection", () => {
               ... on ViewingRoomsRailHomeViewSection {
                 component {
                   title
+                  behaviors {
+                    viewAll {
+                      href
+                    }
+                  }
                 }
               }
             }
@@ -610,6 +842,11 @@ describe("HomeViewSection", () => {
                 Object {
                   "__typename": "ViewingRoomsRailHomeViewSection",
                   "component": Object {
+                    "behaviors": Object {
+                      "viewAll": Object {
+                        "href": "/viewing-rooms",
+                      },
+                    },
                     "title": "Viewing Rooms",
                   },
                 }
@@ -627,6 +864,12 @@ describe("HomeViewSection", () => {
               ... on ActivityRailHomeViewSection {
                 component {
                   title
+                  behaviors {
+                    viewAll {
+                      href
+                      buttonText
+                    }
+                  }
                 }
                 notificationsConnection(first: 1) {
                   edges {
@@ -691,6 +934,12 @@ describe("HomeViewSection", () => {
             "section": Object {
               "__typename": "ActivityRailHomeViewSection",
               "component": Object {
+                "behaviors": Object {
+                  "viewAll": Object {
+                    "buttonText": "See All",
+                    "href": "/notifications",
+                  },
+                },
                 "title": "Latest Activity",
               },
               "notificationsConnection": Object {
@@ -830,6 +1079,46 @@ describe("HomeViewSection", () => {
     })
   })
 
+  describe("LatestArticles", () => {
+    it("returns correct data", async () => {
+      const query = gql`
+        {
+          homeView {
+            section(id: "home-view-section-latest-articles") {
+              __typename
+              ... on ArticlesRailHomeViewSection {
+                component {
+                  title
+                  behaviors {
+                    viewAll {
+                      href
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const { homeView } = await runQuery(query, {})
+
+      expect(homeView.section).toMatchInlineSnapshot(`
+        Object {
+          "__typename": "ArticlesRailHomeViewSection",
+          "component": Object {
+            "behaviors": Object {
+              "viewAll": Object {
+                "href": "/articles",
+              },
+            },
+            "title": "Artsy Editorial",
+          },
+        }
+      `)
+    })
+  })
+
   describe("News", () => {
     it("returns correct data", async () => {
       const query = gql`
@@ -841,8 +1130,13 @@ describe("HomeViewSection", () => {
               ... on ArticlesRailHomeViewSection {
                 component {
                   title
-                  href
                   type
+                  behaviors {
+                    viewAll {
+                      href
+                      buttonText
+                    }
+                  }
                 }
 
                 articlesConnection(first: 3) {
@@ -899,7 +1193,12 @@ describe("HomeViewSection", () => {
             ],
           },
           "component": Object {
-            "href": "/news",
+            "behaviors": Object {
+              "viewAll": Object {
+                "buttonText": "More in News",
+                "href": "/news",
+              },
+            },
             "title": "News",
             "type": "ArticlesCard",
           },

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -47,6 +47,12 @@ export const SimilarToRecentlyViewedArtworks: HomeViewSection = {
   type: "ArtworksRailHomeViewSection",
   component: {
     title: "Similar to Works You’ve Viewed",
+    behaviors: {
+      viewAll: {
+        href: "/similar-to-recently-viewed",
+        buttonText: "Browse All Artworks",
+      },
+    },
   },
   requiresAuthentication: true,
   resolver: SimilarToRecentlyViewedArtworksResolver,
@@ -81,6 +87,12 @@ export const CuratorsPicksEmerging: HomeViewSection = {
 
       return background_image_app_phone_url
     },
+    behaviors: {
+      viewAll: {
+        href: "/collection/curators-picks-emerging",
+        buttonText: "Browse All Artworks",
+      },
+    },
     href: "/collection/curators-picks-emerging",
   },
   requiresAuthentication: false,
@@ -92,6 +104,12 @@ export const RecentlyViewedArtworks: HomeViewSection = {
   type: "ArtworksRailHomeViewSection",
   component: {
     title: "Recently viewed works",
+    behaviors: {
+      viewAll: {
+        href: "/recently-viewed",
+        buttonText: "Browse All Artworks",
+      },
+    },
   },
   requiresAuthentication: true,
   resolver: RecentlyViewedArtworksResolver,
@@ -102,6 +120,12 @@ export const AuctionLotsForYou: HomeViewSection = {
   type: "ArtworksRailHomeViewSection",
   component: {
     title: "Auction lots for you",
+    behaviors: {
+      viewAll: {
+        href: "/auctions/lots-for-you-ending-soon",
+        buttonText: "Browse All Artworks",
+      },
+    },
   },
   requiresAuthentication: true,
   resolver: AuctionLotsForYouResolver,
@@ -112,6 +136,12 @@ export const NewWorksForYou: HomeViewSection = {
   type: "ArtworksRailHomeViewSection",
   component: {
     title: "New works for you",
+    behaviors: {
+      viewAll: {
+        href: "/new-for-you",
+        buttonText: "Browse All Artworks",
+      },
+    },
   },
   requiresAuthentication: true,
   resolver: NewWorksForYouResolver,
@@ -122,6 +152,12 @@ export const NewWorksFromGalleriesYouFollow: HomeViewSection = {
   type: "ArtworksRailHomeViewSection",
   component: {
     title: "New Works from Galleries You Follow",
+    behaviors: {
+      viewAll: {
+        href: "/new-works-from-galleries-you-follow",
+        buttonText: "Browse All Artworks",
+      },
+    },
   },
   requiresAuthentication: true,
   resolver: NewWorksFromGalleriesYouFollowResolver,
@@ -132,6 +168,12 @@ export const RecommendedArtworks: HomeViewSection = {
   type: "ArtworksRailHomeViewSection",
   component: {
     title: "Artwork Recommendations",
+    behaviors: {
+      viewAll: {
+        href: "/artwork-recommendations",
+        buttonText: "Browse All Artworks",
+      },
+    },
   },
   requiresAuthentication: true,
   resolver: RecommendedArtworksResolver,
@@ -143,7 +185,7 @@ export const TrendingArtists: HomeViewSection = {
   id: "home-view-section-trending-artists",
   type: "ArtistsRailHomeViewSection",
   component: {
-    title: "Trending Artists on Artsy",
+    title: "Trending Artists",
   },
   requiresAuthentication: false,
   resolver: SuggestedArtistsResolver,
@@ -182,6 +224,11 @@ export const LatestArticles: HomeViewSection = {
   type: "ArticlesRailHomeViewSection",
   component: {
     title: "Artsy Editorial",
+    behaviors: {
+      viewAll: {
+        href: "/articles",
+      },
+    },
   },
   requiresAuthentication: false,
   resolver: LatestArticlesResolvers,
@@ -211,6 +258,11 @@ export const ViewingRooms: HomeViewSection = {
   type: "ViewingRoomsRailHomeViewSection",
   component: {
     title: "Viewing Rooms",
+    behaviors: {
+      viewAll: {
+        href: "/viewing-rooms",
+      },
+    },
   },
   requiresAuthentication: false,
 }
@@ -220,6 +272,12 @@ export const LatestActivity: HomeViewSection = {
   type: "ActivityRailHomeViewSection",
   component: {
     title: "Latest Activity",
+    behaviors: {
+      viewAll: {
+        href: "/notifications",
+        buttonText: "See All",
+      },
+    },
   },
   requiresAuthentication: true,
   resolver: LatestActivityResolver,
@@ -249,6 +307,12 @@ export const News: HomeViewSection = {
     title: "News",
     href: "/news",
     type: "ArticlesCard",
+    behaviors: {
+      viewAll: {
+        href: "/news",
+        buttonText: "More in News",
+      },
+    },
   },
   requiresAuthentication: false,
   resolver: NewsResolver,


### PR DESCRIPTION
I've added hrefs and button texts to all sections following @MounirDhahri 's approach from this PR: https://github.com/artsy/metaphysics/pull/5944

Let's debate if we want to implement the interface somehow else. @anandaroop you've left a few comments here: https://github.com/artsy/metaphysics/pull/5944#discussion_r1731598695

> Is this meant to handle both of the current (or future) kinds of placements for the view-all UI? Or would we distinguish between them in the response?

Currently both title section and buttons lead to the same page. I am not sure if it will be different in future, but if there will be a need to distinguish them, will it be possible to do it by expanding current schema and not changing it a lot? Something like this maybe:

```graphql
behaviors {
  sectionTitle {
    href
  }

  viewAll {
    href
    buttonText
  }
}
```

> This clearly sets out the behavior where we want to go to a predefined route. But what about the other case: where we don't have a route but instead just expand to a full-screen view of the data. Would that be indicated by the absence of href? Or should it be signaled by the presence of some other attribute, with some more explicit gql modeling?

Let's fantasize. Do you have a suggestion how to depict it? I've also noticed that some horizontal rails (Recommended Artists) have infinite pagination (not infinite technically, limited by 20 artists). Should this behavior also be a part of `behaviors`? 

Regarding naming of the field. When I was thinking about it, this is what I had in mind. Rail components are mostly react native flat lists, which have a ListFooterComponent property. We use it to configure "Browse All" buttons (see [ArtworksRail example](https://github.com/artsy/eigen/blob/main/src/app/Components/ArtworkRail/ArtworkRail.tsx#L50)). Lists can be horizontal or vertical, when horizontal - Browse All button moves to the right, when vertical (we don't have them on home page currently, but I saw something similar in draft designs of a new home feed) - to the bottom. I was thinking that maybe component definition should be more down to earth, something like this:

```graphql
component {
  title
  vertical # false by default

  footer { # optional
    button { # optional
      href
      text
    }

    pagination # optional, configure whether component has pagination and maybe how to paginate (max number of entities, etc.)
  }
}
```