### PR TITLE
fix: resolve node(id: ...) for new home view sections

### DIFF
--- a/src/schema/v2/homeView/index.ts
+++ b/src/schema/v2/homeView/index.ts
@@ -40,7 +40,7 @@ const SectionConnection: GraphQLFieldConfig<any, ResolverContext> = {
   },
 }
 
-const Section: GraphQLFieldConfig<void, ResolverContext> = {
+export const Section: GraphQLFieldConfig<void, ResolverContext> = {
   type: HomeViewSectionType,
   description: "A home view section",
   args: {


### PR DESCRIPTION
When I do 

```graphql
query {
  homeView {
    section(id: "home-view-section-new-works-for-you") {
      ... on ArtworksRailHomeViewSection {
        id
      }
    }
  }
}
```

it returns global id for the section:

```json
{
  "data": {
    "homeView": {
      "section": {
        "id": "QXJ0d29ya3NSYWlsSG9tZVZpZXdTZWN0aW9uOmhvbWUtdmlldy1zZWN0aW9uLW5ldy13b3Jrcy1mb3IteW91"
      }
    }
  }
}
```

Before this fix such query would return null:

```graphql
query {
  section: node(id: "QXJ0d29ya3NSYWlsSG9tZVZpZXdTZWN0aW9uOmhvbWUtdmlldy1zZWN0aW9uLW5ldy13b3Jrcy1mb3IteW91") {
    id
    __typename
  }
}
```

Without it Relay doesn't function properly. It was discovered when Onyx team tried to implement artworks pagination for the New for You section.