### PR TITLE
feat: add Node support for new homeview sections / support union

### DIFF
--- a/src/schema/v2/homeView/HomeViewSection.ts
+++ b/src/schema/v2/homeView/HomeViewSection.ts
@@ -1,6 +1,8 @@
 import {
   GraphQLFieldConfigMap,
+  GraphQLID,
   GraphQLInterfaceType,
+  GraphQLNonNull,
   GraphQLObjectType,
   GraphQLUnionType,
 } from "graphql"
@@ -18,11 +20,19 @@ import { NotificationsConnection } from "../notifications"
 import { InternalIDFields, NodeInterface } from "../object_identification"
 import { SalesConnectionField } from "../sales"
 import { HomeViewComponent } from "./HomeViewComponent"
+import { toGlobalId } from "graphql-relay"
 
 // section interface
 
 const standardSectionFields: GraphQLFieldConfigMap<any, ResolverContext> = {
   ...InternalIDFields,
+  id: {
+    type: new GraphQLNonNull(GraphQLID),
+    description: "A globally unique ID.",
+    resolve: ({ id }) => {
+      return toGlobalId("HomeViewSection", id)
+    },
+  },
   component: {
     type: HomeViewComponent,
     description: "The component that is prescribed for this section",

--- a/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
@@ -1111,4 +1111,60 @@ describe("HomeViewSection", () => {
             `)
     })
   })
+
+  describe("implements the NodeInterface", () => {
+    it("returns the correct id", async () => {
+      const query = gql`
+        {
+          homeView {
+            section(id: "home-view-section-news") {
+              __typename
+              ... on ArticlesRailHomeViewSection {
+                id
+              }
+            }
+          }
+        }
+      `
+
+      const context = {}
+
+      const data = await runQuery(query, context)
+
+      expect(data.homeView.section).toMatchInlineSnapshot(`
+        Object {
+          "__typename": "ArticlesRailHomeViewSection",
+          "id": "SG9tZVZpZXdTZWN0aW9uOmhvbWUtdmlldy1zZWN0aW9uLW5ld3M=",
+        }
+      `)
+    })
+
+    it("can query via the node interface", async () => {
+      const query = gql`
+        {
+          node(id: "SG9tZVZpZXdTZWN0aW9uOmhvbWUtdmlldy1zZWN0aW9uLW5ld3M=") {
+            __typename
+            ... on ArticlesRailHomeViewSection {
+              component {
+                title
+              }
+            }
+          }
+        }
+      `
+
+      const context = {}
+
+      const data = await runQuery(query, context)
+
+      expect(data.node).toMatchInlineSnapshot(`
+        Object {
+          "__typename": "ArticlesRailHomeViewSection",
+          "component": Object {
+            "title": "News",
+          },
+        }
+      `)
+    })
+  })
 })

--- a/src/schema/v2/homeView/index.ts
+++ b/src/schema/v2/homeView/index.ts
@@ -40,7 +40,7 @@ const SectionConnection: GraphQLFieldConfig<any, ResolverContext> = {
   },
 }
 
-const Section: GraphQLFieldConfig<void, ResolverContext> = {
+export const Section: GraphQLFieldConfig<void, ResolverContext> = {
   type: HomeViewSectionType,
   description: "A home view section",
   args: {

--- a/src/schema/v2/object_identification.ts
+++ b/src/schema/v2/object_identification.ts
@@ -58,15 +58,18 @@ const SupportedTypes: any = {
     "./sale",
     "./sale_artwork",
     "./user",
+    "./homeView/index",
   ],
 }
 
 const typeNames = {
   "./filterArtworksConnection": "filterArtworksConnection",
+  "./homeView/index": "HomeViewSection",
 }
 
 const exportNames = {
   filterArtworksConnection: "filterArtworksConnection",
+  HomeViewSection: "Section",
 }
 
 SupportedTypes.typeMap = SupportedTypes.files.reduce((typeMap, file) => {
@@ -156,9 +159,14 @@ const NodeField: GraphQLFieldConfig<any, ResolverContext> = {
           rootValueForChild(rootValue)
         )
       ).then((data) => {
+        // Further narrow down the type if it is a union or interface.
+        const specificType = type?.resolveType
+          ? type.resolveType(data)
+          : type?._types?.find((t) => t.isTypeOf(data))
+
         // Add the already known type so `NodeInterface` can pluck that out in
         // its `resolveType` implementation.
-        return { __type: type, ...data }
+        return { __type: specificType ?? type, ...data }
       })
     }
   },


### PR DESCRIPTION
This is an alternate version of https://github.com/artsy/metaphysics/pull/5968.

It winds up adding in some generic support union types here, and so this might be good to go and a bit easier to use w.r.t to less boilerplate needed.

Looks like-

<img width="1009" alt="Screenshot 2024-08-30 at 4 30 49 PM" src="https://github.com/user-attachments/assets/7474ed92-28c4-4b43-a959-e7bbeeb42cd5">
