### PR TITLE
chore: configure alternate ingress host for metaphysics production (DIA-818)

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -159,3 +159,13 @@ spec:
             name: metaphysics-web-internal
             port:
               name: mp-http
+  - host: metaphysics-production-alt.artsy.net
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: metaphysics-web-internal
+            port:
+              name: mp-http


### PR DESCRIPTION
Like https://github.com/artsy/metaphysics/pull/5953, but for production. Enables validating any new CDN configuration with live traffic, by targeting the `...-alt` hostname.