### PR TITLE
feat(EMI-2016): add runningShowOrFair field to Artwork collector signals

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4550,7 +4550,7 @@ type CollectorSignals {
   registrationEndsAt: String
     @deprecated(reason: "Use nested field in `auction` instead")
 
-  # Most recent running Show or Fair the artwork is currently in, sorted by relevance
+  # Most recent running Show or Fair booth the artwork is currently in, sorted by relevance
   runningShow: Show
 }
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4549,6 +4549,9 @@ type CollectorSignals {
   # Pending auction registration end time
   registrationEndsAt: String
     @deprecated(reason: "Use nested field in `auction` instead")
+
+  # Most recent running Show or Fair the artwork is currently in, sorted by relevance
+  runningShowOrFair: Show
 }
 
 # Represents either an action or a potential failure

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4551,7 +4551,7 @@ type CollectorSignals {
     @deprecated(reason: "Use nested field in `auction` instead")
 
   # Most recent running Show or Fair the artwork is currently in, sorted by relevance
-  runningShowOrFair: Show
+  runningShow: Show
 }
 
 # Represents either an action or a potential failure

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -4636,7 +4636,7 @@ describe("Artwork type", () => {
       {
         artwork(id: "richard-prince-untitled-portrait") {
           collectorSignals {
-            runningShowOrFair {
+            runningShow {
               name
               startAt
               endAt
@@ -4939,7 +4939,7 @@ describe("Artwork type", () => {
         })
       })
 
-      describe("runningShowOrFair", () => {
+      describe("runningShow", () => {
         it("returns the show or fair if the artwork id is in a running show or fair", async () => {
           artwork.purchasable = true
           context.relatedShowsLoader.mockResolvedValue({
@@ -4953,7 +4953,7 @@ describe("Artwork type", () => {
           })
 
           const data = await runQuery(query, context)
-          expect(data.artwork.collectorSignals.runningShowOrFair).toEqual({
+          expect(data.artwork.collectorSignals.runningShow).toEqual({
             name: "Test Show",
             startAt: "2023-01-01T00:00:00Z",
             endAt: "2023-01-02T00:00:00Z",
@@ -4965,7 +4965,7 @@ describe("Artwork type", () => {
           context.relatedShowsLoader.mockResolvedValue({ body: [] })
 
           const data = await runQuery(query, context)
-          expect(data.artwork.collectorSignals.runningShowOrFair).toBeNull
+          expect(data.artwork.collectorSignals.runningShow).toBeNull
         })
       })
 

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -4636,6 +4636,11 @@ describe("Artwork type", () => {
       {
         artwork(id: "richard-prince-untitled-portrait") {
           collectorSignals {
+            runningShowOrFair {
+              name
+              startAt
+              endAt
+            }
             increasedInterest
             curatorsPick
             auction {
@@ -4662,6 +4667,7 @@ describe("Artwork type", () => {
         salesLoader: jest.fn(),
         saleArtworkLoader: jest.fn(),
         marketingCollectionLoader: jest.fn(),
+        relatedShowsLoader: jest.fn(),
       }
       context = {
         userID: "testUser",
@@ -4672,6 +4678,7 @@ describe("Artwork type", () => {
       context.mePartnerOffersLoader.mockResolvedValue({ body: [] })
       context.salesLoader.mockResolvedValue([])
       context.marketingCollectionLoader.mockResolvedValue({ artwork_ids: [] })
+      context.relatedShowsLoader.mockResolvedValue({ body: [] })
     })
 
     describe("feature flags enabled", () => {
@@ -4929,6 +4936,36 @@ describe("Artwork type", () => {
 
           const data = await runQuery(query, context)
           expect(data.artwork.collectorSignals.curatorsPick).toBe(false)
+        })
+      })
+
+      describe("runningShowOrFair", () => {
+        it("returns the show or fair if the artwork id is in a running show or fair", async () => {
+          artwork.purchasable = true
+          context.relatedShowsLoader.mockResolvedValue({
+            body: [
+              {
+                name: "Test Show",
+                start_at: "2023-01-01T00:00:00Z",
+                end_at: "2023-01-02T00:00:00Z",
+              }
+            ],
+          })
+
+          const data = await runQuery(query, context)
+          expect(data.artwork.collectorSignals.runningShowOrFair).toEqual({
+            name: "Test Show",
+            startAt: "2023-01-01T00:00:00Z",
+            endAt: "2023-01-02T00:00:00Z",
+          })
+        })
+
+        it("returns null if the artwork id is not in a running show or fair", async () => {
+          artwork.purchasable = true
+          context.relatedShowsLoader.mockResolvedValue({ body: [] })
+
+          const data = await runQuery(query, context)
+          expect(data.artwork.collectorSignals.runningShowOrFair).toBeNull
         })
       })
 

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -3,6 +3,7 @@ import { GraphQLInt, GraphQLObjectType } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { PartnerOfferToCollectorType } from "../partnerOfferToCollector"
 import { isFeatureFlagEnabled } from "lib/featureFlags"
+import Show from "../show"
 import { date } from "../fields/date"
 import { GraphQLNonNull } from "graphql"
 
@@ -187,6 +188,21 @@ export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
         description: "Increased interest in the artwork",
         resolve: (artwork) => {
           return !!artwork.increased_interest_signal
+        },
+      },
+      runningShowOrFair: {
+        type: Show.type,
+        description:
+          "Most recent running Show or Fair the artwork is currently in, sorted by relevance",
+        resolve: async (artwork, {}, ctx) => {
+          const showOrFair = await await ctx.relatedShowsLoader({
+            artwork: [artwork._id],
+            first: 1,
+            status: "running",
+            hasLocation: true,
+            sort: "-relevance,-start_at",
+          })
+          return showOrFair.body[0]
         },
       },
     },

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -190,7 +190,7 @@ export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
           return !!artwork.increased_interest_signal
         },
       },
-      runningShowOrFair: {
+      runningShow: {
         type: Show.type,
         description:
           "Most recent running Show or Fair the artwork is currently in, sorted by relevance",

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -193,7 +193,7 @@ export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
       runningShow: {
         type: Show.type,
         description:
-          "Most recent running Show or Fair the artwork is currently in, sorted by relevance",
+          "Most recent running Show or Fair booth the artwork is currently in, sorted by relevance",
         resolve: async (artwork, {}, ctx) => {
           const showOrFair = await await ctx.relatedShowsLoader({
             artwork: [artwork._id],

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -197,7 +197,7 @@ export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
         resolve: async (artwork, {}, ctx) => {
           const showOrFair = await await ctx.relatedShowsLoader({
             artwork: [artwork._id],
-            first: 1,
+            size: 1,
             status: "running",
             hasLocation: true,
             sort: "-relevance,-start_at",


### PR DESCRIPTION
Adds a `runningShowOrFair` field that will return the latest running show or fair that the artwork is currently in, sorted by relevance.
My reasoning behind returning the Show or the Fair in one field is that the signal only needs one show/fair to display the name and date, so with this approach we avoid more logic in Force to select which object to show. Also, the `relatedFairs` query was not returning the expected results (see screenshot below), and the `relatedShows` is returning both shows and fairs, so I think it's fine to have it like this. Let me know if anyone has a strong opinion on this.

![SCR-20240904-hbd](https://github.com/user-attachments/assets/45e4412f-2d25-4b32-8546-e5ff433a003b)

Staging test

![Screenshot 2024-09-04 at 12 58 10](https://github.com/user-attachments/assets/5e1b9048-65d4-4add-b8d9-26e65cd21578)


![Screenshot 2024-09-04 at 12 57 08](https://github.com/user-attachments/assets/0fc674de-1ff7-4714-b01a-50f6e5878113)

`relatedShows` response for this artwork
```
[
  {
    "fair": null,
    "location": {
      "day_schedules": [],
      "id": "5f8123abec5de8000ea9b785",
      "name": "00b942590fd74a14d9a9ecb68e935f53",
      "address": "401 Broadway 26th floor",
      "address_2": null,
      "city": "New York",
      "country": "US",
      "state": "NY",
      "postal_code": "10013",
      "timezone": "America/New_York",
      "address_type": "Business",
      "day_schedule_text": "",
      "phone": "",
      "coordinates": {
        "lng": -74.0025579,
        "lat": 40.7188725
      },
      "eu_shipping_location": false,
      "position": 1,
      "email": null,
      "fax": null,
      "publicly_viewable": true,
      "skip_geocoding": false
    },
    "fair_location": null,
    "partner": {
      "partner_categories": [],
      "_id": "5f80bfefe8d808000ea212c1",
      "id": "commerce-test-partner",
      "default_profile_id": "commerce-test-partner",
      "default_profile_public": false,
      "sortable_id": "commerce-test-partner",
      "type": "Gallery",
      "name": "Commerce Test Partner",
      "short_name": "",
      "pre_qualify": false,
      "website": "https://www.artsy.net",
      "has_full_profile": false,
      "has_fair_partnership": false,
      "profile_layout": "gallery_five",
      "display_works_section": true,
      "profile_banner_display": "Shows",
      "profile_artists_layout": "List",
      "display_artists_section": true
    },
    "events": [],
    "_id": "66d830bd84144c000fd1068a",
    "id": "commerce-test-partner-running-show",
    "name": "Running show",
    "in_upcoming_fair": false,
    "original_width": 1559,
    "original_height": 1800,
    "image_url": "https://d2v80f5yrouhh2.cloudfront.net/NDJ0ireBjCFs1SBDzeYuFw/:version.jpg",
    "image_versions": [
      "square",
      "normalized",
      "larger",
      "medium",
      "small",
      "large",
      "tall",
      "medium_rectangle",
      "large_rectangle"
    ],
    "image_urls": {
      "square": "https://d2v80f5yrouhh2.cloudfront.net/NDJ0ireBjCFs1SBDzeYuFw/square.jpg",
      "normalized": "https://d2v80f5yrouhh2.cloudfront.net/NDJ0ireBjCFs1SBDzeYuFw/normalized.jpg",
      "larger": "https://d2v80f5yrouhh2.cloudfront.net/NDJ0ireBjCFs1SBDzeYuFw/larger.jpg",
      "medium": "https://d2v80f5yrouhh2.cloudfront.net/NDJ0ireBjCFs1SBDzeYuFw/medium.jpg",
      "small": "https://d2v80f5yrouhh2.cloudfront.net/NDJ0ireBjCFs1SBDzeYuFw/small.jpg",
      "large": "https://d2v80f5yrouhh2.cloudfront.net/NDJ0ireBjCFs1SBDzeYuFw/large.jpg",
      "tall": "https://d2v80f5yrouhh2.cloudfront.net/NDJ0ireBjCFs1SBDzeYuFw/tall.jpg",
      "medium_rectangle": "https://d2v80f5yrouhh2.cloudfront.net/NDJ0ireBjCFs1SBDzeYuFw/medium_rectangle.jpg",
      "large_rectangle": "https://d2v80f5yrouhh2.cloudfront.net/NDJ0ireBjCFs1SBDzeYuFw/large_rectangle.jpg"
    },
    "gemini_token_updated_at": "2024-09-04T09:50:29+00:00",
    "artists": [
      {
        "_id": "4f5f64c13b555230ac000368",
        "artworks_count": 376,
        "birthday": "1954",
        "blurb": "The subjects of Karen Knorr’s work are as geographically diverse as the artist’s own biography: Knorr was born in Germany and raised in Puerto Rico, before she ventured to Paris and settled in London. While she works in video and installation, she is perhaps best known for her photographs and digital collages. Principal themes in her work include the stratification of class, the distribution of privilege and wealth, value systems, the symbolic role of animal representations, and issues of power at the foundation of cultural heritage. Knorr prefers to look at the privileged rather than the disenfranchised; her subjects have included wealthy English classes and their patriarchal systems and frequented clubs. More recently, Knorr has produced a series of digitally modified interiors set in India, based on fables and injustices. ",
        "consignable": false,
        "created_at": "2012-03-13T15:22:20+00:00",
        "critically_acclaimed": false,
        "deathday": "",
        "forsale_artworks_count": 157,
        "group_indicator": "individual",
        "id": "karen-knorr",
        "image_url": "https://d32dm0rphc51dk.cloudfront.net/ia5hSauv4IESKA0uyh1F_Q/:version.jpg",
        "image_urls": {
          "four_thirds": "https://d32dm0rphc51dk.cloudfront.net/ia5hSauv4IESKA0uyh1F_Q/four_thirds.jpg",
          "large": "https://d32dm0rphc51dk.cloudfront.net/ia5hSauv4IESKA0uyh1F_Q/large.jpg",
          "square": "https://d32dm0rphc51dk.cloudfront.net/ia5hSauv4IESKA0uyh1F_Q/square.jpg",
          "tall": "https://d32dm0rphc51dk.cloudfront.net/ia5hSauv4IESKA0uyh1F_Q/tall.jpg"
        },
        "image_versions": [
          "four_thirds",
          "large",
          "square",
          "tall"
        ],
        "is_personal_artist": false,
        "medium_known_for": "",
        "name": "Karen Knorr",
        "nationality": "British-American",
        "original_height": null,
        "original_width": null,
        "public": true,
        "published_artworks_count": 195,
        "sortable_id": "knorr-karen",
        "target_supply": false,
        "target_supply_priority": 0,
        "target_supply_type": null,
        "vanguard_year": null,
        "years": "born 1954"
      }
    ],
    "description": "Test",
    "press_release": "",
    "press_release_url": null,
    "created_at": "2024-09-04T10:04:45+00:00",
    "featured": false,
    "start_at": "2024-09-01T12:00:00+00:00",
    "batch_publish": true,
    "end_at": "2024-09-28T12:00:00+00:00",
    "artworks_count": 1,
    "eligible_artworks_count": 1,
    "displayable": true,
    "images_count": 0,
    "status": "running",
    "updated_at": "2024-09-04T10:06:03+00:00",
    "coordinates": {
      "lng": -74.0025579,
      "lat": 40.7188725
    },
    "display_on_partner_profile": true,
    "is_reference": false,
    "is_local_discovery": false,
    "galaxy_partner_id": null,
    "partner_city": null,
    "group": false,
    "artists_without_artworks": [],
    "opening_reception_text": "",
    "partner_type": "Gallery",
    "discovery_blocked_reason": null,
    "discovery_blocked_at": null,
    "duplicate_of_id": null,
    "viewing_room_ids": []
  },
  {
    "fair": {
      "organizer": null,
      "mobile_image": null,
      "_id": "66a7c439528643000ef54f01",
      "id": "frieze-seoul-2024",
      "default_profile_id": "frieze-seoul-2024",
      "start_at": "2024-08-29T01:00:00+00:00",
      "end_at": "2024-09-07T17:00:00+00:00",
      "name": "Frieze Seoul 2024",
      "published": true,
      "subtype": null,
      "summary": "",
      "artworks_count": 402,
      "partners_count": 30,
      "artists_count": 191,
      "partner_shows_count": 30,
      "layout": null,
      "display_vip": false,
      "has_full_feature": true,
      "image_url": "https://d32dm0rphc51dk.cloudfront.net/26sHTfGOIWFAE7NoG86wNA/:version.jpg",
      "image_versions": [
        "large_rectangle",
        "wide",
        "square"
      ],
      "image_urls": {
        "large_rectangle": "https://d32dm0rphc51dk.cloudfront.net/26sHTfGOIWFAE7NoG86wNA/large_rectangle.jpg",
        "wide": "https://d32dm0rphc51dk.cloudfront.net/26sHTfGOIWFAE7NoG86wNA/wide.jpg",
        "square": "https://d32dm0rphc51dk.cloudfront.net/26sHTfGOIWFAE7NoG86wNA/square.jpg"
      },
      "original_width": 3189,
      "original_height": 2545,
      "created_at": "2024-07-29T16:32:57+00:00",
      "autopublish_artworks_at": "2024-08-28T05:00:00+00:00",
      "banner_image_urls": null,
      "banner_size": "x-large"
    },
    "location": null,
    "fair_location": {
      "map_points": [],
      "id": "66d8322bfe56ba0014e86bce",
      "display": ""
    },
    "partner": {
      "partner_categories": [],
      "_id": "5f80bfefe8d808000ea212c1",
      "id": "commerce-test-partner",
      "default_profile_id": "commerce-test-partner",
      "default_profile_public": false,
      "sortable_id": "commerce-test-partner",
      "type": "Gallery",
      "name": "Commerce Test Partner",
      "short_name": "",
      "pre_qualify": false,
      "website": "https://www.artsy.net",
      "has_full_profile": false,
      "has_fair_partnership": false,
      "profile_layout": "gallery_five",
      "display_works_section": true,
      "profile_banner_display": "Shows",
      "profile_artists_layout": "List",
      "display_artists_section": true
    },
    "events": [
      {
        "_id": "66d83289fe56ba0010539756",
        "id": "66d83289fe56ba0010539756",
        "title": "",
        "start_at": "2024-09-03T00:12:00+00:00",
        "end_at": "2024-09-07T00:12:00+00:00",
        "time_zone": "Etc/GMT+12",
        "description": "",
        "event_type": "Opening Reception"
      }
    ],
    "_id": "66d8322bfe56ba0014e86bcd",
    "id": "commerce-test-partner-commerce-test-partner-at-frieze-seoul-2024",
    "name": "Commerce Test Partner at Frieze Seoul 2024",
    "in_upcoming_fair": false,
    "original_width": 1559,
    "original_height": 1800,
    "image_url": "https://d2v80f5yrouhh2.cloudfront.net/NDJ0ireBjCFs1SBDzeYuFw/:version.jpg",
    "image_versions": [
      "square",
      "normalized",
      "larger",
      "medium",
      "small",
      "large",
      "tall",
      "medium_rectangle",
      "large_rectangle"
    ],
    "image_urls": {
      "square": "https://d2v80f5yrouhh2.cloudfront.net/NDJ0ireBjCFs1SBDzeYuFw/square.jpg",
      "normalized": "https://d2v80f5yrouhh2.cloudfront.net/NDJ0ireBjCFs1SBDzeYuFw/normalized.jpg",
      "larger": "https://d2v80f5yrouhh2.cloudfront.net/NDJ0ireBjCFs1SBDzeYuFw/larger.jpg",
      "medium": "https://d2v80f5yrouhh2.cloudfront.net/NDJ0ireBjCFs1SBDzeYuFw/medium.jpg",
      "small": "https://d2v80f5yrouhh2.cloudfront.net/NDJ0ireBjCFs1SBDzeYuFw/small.jpg",
      "large": "https://d2v80f5yrouhh2.cloudfront.net/NDJ0ireBjCFs1SBDzeYuFw/large.jpg",
      "tall": "https://d2v80f5yrouhh2.cloudfront.net/NDJ0ireBjCFs1SBDzeYuFw/tall.jpg",
      "medium_rectangle": "https://d2v80f5yrouhh2.cloudfront.net/NDJ0ireBjCFs1SBDzeYuFw/medium_rectangle.jpg",
      "large_rectangle": "https://d2v80f5yrouhh2.cloudfront.net/NDJ0ireBjCFs1SBDzeYuFw/large_rectangle.jpg"
    },
    "gemini_token_updated_at": "2024-09-04T09:50:29+00:00",
    "artists": [
      {
        "_id": "4f5f64c13b555230ac000368",
        "artworks_count": 376,
        "birthday": "1954",
        "blurb": "The subjects of Karen Knorr’s work are as geographically diverse as the artist’s own biography: Knorr was born in Germany and raised in Puerto Rico, before she ventured to Paris and settled in London. While she works in video and installation, she is perhaps best known for her photographs and digital collages. Principal themes in her work include the stratification of class, the distribution of privilege and wealth, value systems, the symbolic role of animal representations, and issues of power at the foundation of cultural heritage. Knorr prefers to look at the privileged rather than the disenfranchised; her subjects have included wealthy English classes and their patriarchal systems and frequented clubs. More recently, Knorr has produced a series of digitally modified interiors set in India, based on fables and injustices. ",
        "consignable": false,
        "created_at": "2012-03-13T15:22:20+00:00",
        "critically_acclaimed": false,
        "deathday": "",
        "forsale_artworks_count": 157,
        "group_indicator": "individual",
        "id": "karen-knorr",
        "image_url": "https://d32dm0rphc51dk.cloudfront.net/ia5hSauv4IESKA0uyh1F_Q/:version.jpg",
        "image_urls": {
          "four_thirds": "https://d32dm0rphc51dk.cloudfront.net/ia5hSauv4IESKA0uyh1F_Q/four_thirds.jpg",
          "large": "https://d32dm0rphc51dk.cloudfront.net/ia5hSauv4IESKA0uyh1F_Q/large.jpg",
          "square": "https://d32dm0rphc51dk.cloudfront.net/ia5hSauv4IESKA0uyh1F_Q/square.jpg",
          "tall": "https://d32dm0rphc51dk.cloudfront.net/ia5hSauv4IESKA0uyh1F_Q/tall.jpg"
        },
        "image_versions": [
          "four_thirds",
          "large",
          "square",
          "tall"
        ],
        "is_personal_artist": false,
        "medium_known_for": "",
        "name": "Karen Knorr",
        "nationality": "British-American",
        "original_height": null,
        "original_width": null,
        "public": true,
        "published_artworks_count": 195,
        "sortable_id": "knorr-karen",
        "target_supply": false,
        "target_supply_priority": 0,
        "target_supply_type": null,
        "vanguard_year": null,
        "years": "born 1954"
      }
    ],
    "description": "description",
    "press_release": "",
    "press_release_url": null,
    "created_at": "2024-09-04T10:10:51+00:00",
    "featured": false,
    "start_at": "2024-08-29T01:00:00+00:00",
    "batch_publish": true,
    "end_at": "2024-09-07T17:00:00+00:00",
    "artworks_count": 1,
    "eligible_artworks_count": 1,
    "displayable": true,
    "images_count": 0,
    "status": "running",
    "updated_at": "2024-09-04T10:14:35+00:00",
    "coordinates": null,
    "display_on_partner_profile": true,
    "is_reference": false,
    "is_local_discovery": false,
    "galaxy_partner_id": null,
    "partner_city": null,
    "group": false,
    "artists_without_artworks": [],
    "opening_reception_text": "",
    "partner_type": "Gallery",
    "discovery_blocked_reason": null,
    "discovery_blocked_at": null,
    "duplicate_of_id": null,
    "viewing_room_ids": []
  }
]
```

@artsy/emerald-devs 