### PR TITLE
chore(DIA-738): change vanguard insight url to evergreen url

### DIFF
--- a/src/schema/v2/artist/__tests__/insights.test.ts
+++ b/src/schema/v2/artist/__tests__/insights.test.ts
@@ -233,7 +233,7 @@ describe("ArtistInsights type", () => {
         },
         {
           description:
-            '<p>Featured in Artsy’s <a href="/collection/the-artsy-vanguard">annual list</a> of the most promising artists working today</p>',
+            '<p>Featured in Artsy’s <a href="/collection/artsy-vanguard-artists">annual list</a> of the most promising artists working today</p>',
         },
         {
           description:

--- a/src/schema/v2/artist/helpers.ts
+++ b/src/schema/v2/artist/helpers.ts
@@ -103,7 +103,7 @@ export const ARTIST_INSIGHT_MAPPING: Record<
   },
   ARTSY_VANGUARD_YEAR: {
     getDescription: () =>
-      `Featured in Artsy’s [annual list](/collection/the-artsy-vanguard) of the most promising artists working today`,
+      `Featured in Artsy’s [annual list](/collection/artsy-vanguard-artists) of the most promising artists working today`,
     getEntities: (artist) => artist.vanguard_year && [],
     getLabel: (artist) => `The Artsy Vanguard ${artist.vanguard_year}`,
   },


### PR DESCRIPTION
We need to update the link on the Artsy Vanguard artist insight on artist pages to be to the evergreen collection, i.e. "/collection/artsy-vanguard-artists"