### PR TITLE
chore: allow a missing _or_ unpublished cover artwork to fallback on Artist

### DIFF
--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -696,22 +696,23 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
           _options,
           { artistArtworksLoader, artworkLoader }
         ) => {
-          try {
-            if (cover_artwork_id) {
-              return artworkLoader(cover_artwork_id)
+          if (cover_artwork_id) {
+            try {
+              return await artworkLoader(cover_artwork_id)
+            } catch {
+              // Intentionally ignore errors from unpublished/deleted artworks
+              // that are set as cover artworks.
             }
-
-            const [fallbackArtwork] = await artistArtworksLoader(id, {
-              offset: 0,
-              size: 1,
-              sort: "-iconicity",
-              published: true,
-            })
-
-            return fallbackArtwork
-          } catch (error) {
-            return null
           }
+
+          const [fallbackArtwork] = await artistArtworksLoader(id, {
+            offset: 0,
+            size: 1,
+            sort: "-iconicity",
+            published: true,
+          })
+
+          return fallbackArtwork
         },
       },
       createdAt: date(),


### PR DESCRIPTION
Tweaks the resolver a bit so that if the cover artwork is set _but unpublished/deleted_ (true for ~20% of artists where the cover is set) - we still fallback.