### PR TITLE
chore: update artwork rails href

### DIFF
--- a/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
@@ -38,7 +38,7 @@ describe("HomeViewSection", () => {
           "component": Object {
             "behaviors": Object {
               "viewAll": Object {
-                "href": "/similar-to-recently-viewed",
+                "href": "/home-view/section/artworks/home-view-section-similar-to-recently-viewed-artworks",
               },
             },
             "title": "Similar to Works You’ve Viewed",
@@ -82,7 +82,7 @@ describe("HomeViewSection", () => {
           "component": Object {
             "behaviors": Object {
               "viewAll": Object {
-                "href": "/recently-viewed",
+                "href": "home-view/section/artworks/home-view-section-recently-viewed-artworks",
               },
             },
             "title": "Recently Viewed",
@@ -126,7 +126,7 @@ describe("HomeViewSection", () => {
           "component": Object {
             "behaviors": Object {
               "viewAll": Object {
-                "href": "/new-for-you",
+                "href": "home-view/section/artworks/home-view-section-new-works-for-you",
               },
             },
             "title": "New works for you",
@@ -304,7 +304,7 @@ describe("HomeViewSection", () => {
             "component": Object {
               "behaviors": Object {
                 "viewAll": Object {
-                  "href": "/artwork-recommendations",
+                  "href": "home-view/section/artworks/home-view-section-recommended-artworks",
                 },
               },
               "title": "Artwork Recommendations",
@@ -385,7 +385,7 @@ describe("HomeViewSection", () => {
           "component": Object {
             "behaviors": Object {
               "viewAll": Object {
-                "href": "/new-works-from-galleries-you-follow",
+                "href": "home-view/section/artworks/home-view-section-new-works-from-galleries-you-follow",
               },
             },
             "title": "New Works from Galleries You Follow",

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -50,7 +50,8 @@ export const SimilarToRecentlyViewedArtworks: HomeViewSection = {
     title: "Similar to Works You’ve Viewed",
     behaviors: {
       viewAll: {
-        href: "/similar-to-recently-viewed",
+        href:
+          "/home-view/section/artworks/home-view-section-similar-to-recently-viewed-artworks",
         buttonText: "Browse All Artworks",
       },
     },
@@ -100,6 +101,16 @@ export const CuratorsPicksEmerging: HomeViewSection = {
   resolver: withHomeViewTimeout(CuratorsPicksEmergingArtworksResolver),
 }
 
+export const ActiveBids: HomeViewSection = {
+  id: "home-view-section-active-bids",
+  type: "ArtworksRailHomeViewSection",
+  component: {
+    title: "Your Active Bids",
+  },
+  requiresAuthentication: true,
+  resolver: withHomeViewTimeout(ActiveBidsResolver),
+}
+
 export const RecentlyViewedArtworks: HomeViewSection = {
   id: "home-view-section-recently-viewed-artworks",
   type: "ArtworksRailHomeViewSection",
@@ -107,7 +118,8 @@ export const RecentlyViewedArtworks: HomeViewSection = {
     title: "Recently Viewed",
     behaviors: {
       viewAll: {
-        href: "/recently-viewed",
+        href:
+          "home-view/section/artworks/home-view-section-recently-viewed-artworks",
         buttonText: "Browse All Artworks",
       },
     },
@@ -139,7 +151,7 @@ export const NewWorksForYou: HomeViewSection = {
     title: "New works for you",
     behaviors: {
       viewAll: {
-        href: "/new-for-you",
+        href: "home-view/section/artworks/home-view-section-new-works-for-you",
         buttonText: "Browse All Artworks",
       },
     },
@@ -155,7 +167,8 @@ export const NewWorksFromGalleriesYouFollow: HomeViewSection = {
     title: "New Works from Galleries You Follow",
     behaviors: {
       viewAll: {
-        href: "/new-works-from-galleries-you-follow",
+        href:
+          "home-view/section/artworks/home-view-section-new-works-from-galleries-you-follow",
         buttonText: "Browse All Artworks",
       },
     },
@@ -171,7 +184,8 @@ export const RecommendedArtworks: HomeViewSection = {
     title: "Artwork Recommendations",
     behaviors: {
       viewAll: {
-        href: "/artwork-recommendations",
+        href:
+          "home-view/section/artworks/home-view-section-recommended-artworks",
         buttonText: "Browse All Artworks",
       },
     },
@@ -333,16 +347,6 @@ export const Auctions: HomeViewSection = {
   },
   requiresAuthentication: false,
   resolver: withHomeViewTimeout(SalesResolver),
-}
-
-export const ActiveBids: HomeViewSection = {
-  id: "home-view-section-active-bids",
-  type: "ArtworksRailHomeViewSection",
-  component: {
-    title: "Your Active Bids",
-  },
-  requiresAuthentication: true,
-  resolver: withHomeViewTimeout(ActiveBidsResolver),
 }
 
 /*


### PR DESCRIPTION
This PR updates the home artwork section with a new href that will be valid for the new generic Artwork screens.

The route is open for debate.
Initially, I named the route `home-view/section/sectionID` in Eigen. However that led to more complication around telling which type of section it: Artists? artworks? auctions. For each of those section we have a different placeholder. So there was a need to make 2 requests, one to tell what type of section it is. and one to query for the data. This can be avoided by being explicit about the route URL. I am interested to hear what you think about it?  


https://github.com/user-attachments/assets/1670b06a-2f6b-4568-94ab-c2950d11ed23

Related Eigen PR: https://github.com/artsy/eigen/pull/10546