### PR TITLE
chore: simplify show href construction to only consider displayable

### DIFF
--- a/src/schema/v2/__tests__/show.test.js
+++ b/src/schema/v2/__tests__/show.test.js
@@ -507,8 +507,7 @@ describe("Show type", () => {
   })
 
   describe("href", () => {
-    it("returns the href for a regular show", async () => {
-      showData.is_reference = false
+    it("when displayable, returns the show page path", async () => {
       const query = gql`
         {
           show(id: "new-museum-1-2015-triennial-surround-audience") {
@@ -524,7 +523,8 @@ describe("Show type", () => {
       })
     })
 
-    it("returns null for a reference show", async () => {
+    it("when not displayable, returns null", async () => {
+      showData.displayable = false
       const query = gql`
         {
           show(id: "new-museum-1-2015-triennial-surround-audience") {

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -365,9 +365,8 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
       href: {
         description: "A path to the show on Artsy",
         type: GraphQLString,
-        resolve: ({ id, is_reference, displayable }) => {
-          if (is_reference || !displayable) return null
-          return `/show/${id}`
+        resolve: ({ id, displayable }) => {
+          if (displayable) return `/show/${id}`
         },
       },
       images: {


### PR DESCRIPTION
We definitely have some bad modeling on the data side, but I think this fix is correct.

Basically - we have 'reference' shows which should not have a page on Artsy.

But - we also have 'displayable' shows which do - where displayable can include shows with no published artworks if they have > 2 install shots.

The 'reference' show definition doesn't take that into account - while it requires no published artworks it doesn't check install shots - so we have shows that are set to both 'displayable' _and_ 'reference'. Those concepts seem orthogonal to me since by definition a reference show _isn't_ displayable. Specifically this applies to shows with > 2 install shots, but all unpublished artworks.

I don't think it's worth tangling/un-tangling any of that logic on `PartnerShow` - so decided to switch the criteria here.

This has the effect of making displayable shows (which _should_ always be linkable) in fact linkable, despite being flagged as reference shows. That makes sense to me?