### PR TITLE
chore: remove href from generic artwork rails

### DIFF
--- a/src/schema/v2/homeView/HomeViewComponent.ts
+++ b/src/schema/v2/homeView/HomeViewComponent.ts
@@ -3,7 +3,7 @@ import { ResolverContext } from "types/graphql"
 
 export type HomeViewComponentBehaviors = {
   viewAll?: {
-    href?: string
+    href?: string | null
     buttonText?: string
   }
 }

--- a/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
@@ -38,7 +38,7 @@ describe("HomeViewSection", () => {
           "component": Object {
             "behaviors": Object {
               "viewAll": Object {
-                "href": "/similar-to-recently-viewed",
+                "href": null,
               },
             },
             "title": "Similar to Works You’ve Viewed",
@@ -82,7 +82,7 @@ describe("HomeViewSection", () => {
           "component": Object {
             "behaviors": Object {
               "viewAll": Object {
-                "href": "/recently-viewed",
+                "href": null,
               },
             },
             "title": "Recently Viewed",
@@ -126,7 +126,7 @@ describe("HomeViewSection", () => {
           "component": Object {
             "behaviors": Object {
               "viewAll": Object {
-                "href": "/new-for-you",
+                "href": null,
               },
             },
             "title": "New works for you",
@@ -304,7 +304,7 @@ describe("HomeViewSection", () => {
             "component": Object {
               "behaviors": Object {
                 "viewAll": Object {
-                  "href": "/artwork-recommendations",
+                  "href": null,
                 },
               },
               "title": "Artwork Recommendations",
@@ -385,7 +385,7 @@ describe("HomeViewSection", () => {
           "component": Object {
             "behaviors": Object {
               "viewAll": Object {
-                "href": "/new-works-from-galleries-you-follow",
+                "href": null,
               },
             },
             "title": "New Works from Galleries You Follow",

--- a/src/schema/v2/homeView/sections.ts
+++ b/src/schema/v2/homeView/sections.ts
@@ -50,7 +50,7 @@ export const SimilarToRecentlyViewedArtworks: HomeViewSection = {
     title: "Similar to Works You’ve Viewed",
     behaviors: {
       viewAll: {
-        href: "/similar-to-recently-viewed",
+        href: null,
         buttonText: "Browse All Artworks",
       },
     },
@@ -107,7 +107,7 @@ export const RecentlyViewedArtworks: HomeViewSection = {
     title: "Recently Viewed",
     behaviors: {
       viewAll: {
-        href: "/recently-viewed",
+        href: null,
         buttonText: "Browse All Artworks",
       },
     },
@@ -139,7 +139,7 @@ export const NewWorksForYou: HomeViewSection = {
     title: "New works for you",
     behaviors: {
       viewAll: {
-        href: "/new-for-you",
+        href: null,
         buttonText: "Browse All Artworks",
       },
     },
@@ -155,7 +155,7 @@ export const NewWorksFromGalleriesYouFollow: HomeViewSection = {
     title: "New Works from Galleries You Follow",
     behaviors: {
       viewAll: {
-        href: "/new-works-from-galleries-you-follow",
+        href: null,
         buttonText: "Browse All Artworks",
       },
     },
@@ -171,7 +171,7 @@ export const RecommendedArtworks: HomeViewSection = {
     title: "Artwork Recommendations",
     behaviors: {
       viewAll: {
-        href: "/artwork-recommendations",
+        href: null,
         buttonText: "Browse All Artworks",
       },
     },


### PR DESCRIPTION
This PR comes as a follow-up on https://github.com/artsy/metaphysics/pull/5963#issuecomment-2326108590

Some artwork sections, define their own URL, however some others will be using the generic `home-view/sections/sectionID` route. In this PR, I am setting the `href` to null in the sections where we want the default behaviour to be used.

