### PR TITLE
feat: slightly more verbose errors for home view resolvers

### DIFF
--- a/src/schema/v2/homeView/withHomeViewTimeout.ts
+++ b/src/schema/v2/homeView/withHomeViewTimeout.ts
@@ -8,6 +8,14 @@ export const withHomeViewTimeout = (
   timeout: number = config.HOME_VIEW_RESOLVER_TIMEOUT_MS
 ): GraphQLFieldResolver<any, ResolverContext> => {
   return async (parent, args, context, info) => {
-    return await withTimeout(resolver(parent, args, context, info), timeout)
+    return await withTimeout(
+      resolver(parent, args, context, info),
+      timeout
+    ).catch((err) => {
+      const errorMessage = `[homeViewSection #${parent.id}]: ${err.message}`
+      const error = new Error(errorMessage)
+
+      throw error
+    })
   }
 }

--- a/src/schema/v2/homeView/withHomeViewTimeout.ts
+++ b/src/schema/v2/homeView/withHomeViewTimeout.ts
@@ -12,7 +12,7 @@ export const withHomeViewTimeout = (
       resolver(parent, args, context, info),
       timeout
     ).catch((err) => {
-      const errorMessage = `[homeViewSection #${parent.id}]: ${err.message}`
+      const errorMessage = `${err.message} (${parent.id}): `
       const error = new Error(errorMessage)
 
       throw error


### PR DESCRIPTION
Not sure if we want this change, but without it is not very clear for me which section timed out:

```graphql
{
  "errors": [
    {
      "message": "Timeout of 2000ms",
      "locations": [
        {
          "line": 39,
          "column": 13
        }
      ],
      "path": [
        "homeView",
        "sectionsConnection",
        "edges",
        1,
        "node",
        "artworksConnection"
      ],
      "stack": [...]
    }
  ]
}
```

With this change developer can notice which section failed right away:

```graphql
{
  "errors": [
    {
      "message": "[homeView section #home-view-section-new-works-for-you]: Timeout of 2000ms",
      "locations": [
        {
          "line": 39,
          "column": 13
        }
      ],
      "path": [
        "homeView",
        "sectionsConnection",
        "edges",
        1,
        "node",
        "artworksConnection"
      ],
      "stack": [...]
    }, 
    {
      "message": "[homeView section #home-view-section-marketing-collections]: Timeout of 2000ms",
      "locations": [
        {
          "line": 79,
          "column": 13
        }
      ],
      "path": [
        "homeView",
        "sectionsConnection",
        "edges",
        11,
        "node",
        "marketingCollectionsConnection"
      ],
      "stack": [...]
    }
  ],
}
```