### PR TITLE
chore: always use sale's database id when querying saleArtworkLoader

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -4936,6 +4936,7 @@ describe("Artwork type", () => {
           context.salesLoader.mockResolvedValue([
             {
               id: "sale-id-auction",
+              _id: "sale-database-id",
             },
           ])
 
@@ -4953,7 +4954,7 @@ describe("Artwork type", () => {
 
           expect(context.saleArtworkLoader).toHaveBeenCalledWith({
             saleArtworkId: "richard-prince-untitled-portrait",
-            saleId: "sale-id-auction",
+            saleId: "sale-database-id",
           })
 
           expect(data.artwork.collectorSignals.auction.bidCount).toEqual(5)
@@ -5006,7 +5007,7 @@ describe("Artwork type", () => {
                 name: "Test Show",
                 start_at: "2023-01-01T00:00:00Z",
                 end_at: "2023-01-02T00:00:00Z",
-              }
+              },
             ],
           })
 

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -287,7 +287,7 @@ const getActiveAuctionValues = async (
 
   const saleArtwork =
     (await ctx.saleArtworkLoader({
-      saleId: activeAuction.id,
+      saleId: activeAuction._id,
       saleArtworkId: artworkId,
     })) ?? null
 

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -558,8 +558,8 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
       saleArtwork: {
         type: SaleArtworkType,
         args: { id: { type: new GraphQLNonNull(GraphQLString) } },
-        resolve: (sale, { id }, { saleArtworkLoader }) => {
-          return saleArtworkLoader({ saleId: sale.id, saleArtworkId: id })
+        resolve: ({ _id }, { id }, { saleArtworkLoader }) => {
+          return saleArtworkLoader({ saleId: _id, saleArtworkId: id })
         },
       },
       symbol: { type: GraphQLString },


### PR DESCRIPTION
This may not improve performance from end-user perspectives since backend requests from MP are parallelized. Removing unnecessary ones I think always makes sense since you keep all the equivalent data that's being queried, but less requests.

In this case, I went through uses of this loader, and made sure we were consistent in the arguments being used. This prevents a query from being issued which results in two separate requests which actually are identical (but can't be combined by data loader due to different arguments).
