### PR TITLE
fix: update help article link for taxes

### DIFF
--- a/src/schema/v2/artwork/taxInfo.ts
+++ b/src/schema/v2/artwork/taxInfo.ts
@@ -2,7 +2,7 @@ import { GraphQLNonNull, GraphQLObjectType, GraphQLString } from "graphql"
 import { isEligibleForOnPlatformTransaction } from "./utilities"
 
 export const CHECKOUT_TAXES_DOC_URL =
-  "https://support.artsy.net/s/article/How-are-taxes-customs-VAT-and-import-fees-handled-on-works-listed-with-secure-checkout"
+  "https://support.artsy.net/s/article/How-are-taxes-and-customs-fees-calculated"
 
 const TaxMoreInfoType = new GraphQLObjectType({
   name: "TaxMoreInfo",


### PR DESCRIPTION
See [Slack](https://artsy.slack.com/archives/C03N12SR0RK/p1726063808864249?thread_ts=1725961290.888429&cid=C03N12SR0RK) for context. The "learn more" link in the shipping and taxes section of the artwork page is broken. The team has merged some articles and this updates the link accordingly.

![Screenshot 2024-09-11 at 10 08 17 AM](https://github.com/user-attachments/assets/577ff076-8e96-4807-95c8-500bccda5a5a)
