### PR TITLE
feat(EMI-2052): avoid returning lotWatcherCount for closed lots

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3229,7 +3229,7 @@ type AuctionCollectorSignals {
   ): String
 
   # Lot watcher count, null if lot is closed for bidding
-  lotWatcherCount: Int
+  lotWatcherCount: Int!
 
   # Lot bidding period extended due to last-minute bids
   onlineBiddingExtended: Boolean!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3228,7 +3228,7 @@ type AuctionCollectorSignals {
     timezone: String
   ): String
 
-  # Lot watcher count, null if lot is closed for bidding
+  # Lot watcher count
   lotWatcherCount: Int!
 
   # Lot bidding period extended due to last-minute bids

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3228,8 +3228,8 @@ type AuctionCollectorSignals {
     timezone: String
   ): String
 
-  # Lot watcher count
-  lotWatcherCount: Int!
+  # Lot watcher count, null if lot is closed for bidding
+  lotWatcherCount: Int
 
   # Lot bidding period extended due to last-minute bids
   onlineBiddingExtended: Boolean!

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -4975,9 +4975,8 @@ describe("Artwork type", () => {
           expect(data.artwork.collectorSignals.auction).toBeNull()
         })
 
-        it("does not return lotWatcherCount if the bidding is closed", async () => {
+        it("does not return auction data if bidding is closed", async () => {
           artwork.purchasable = true
-          artwork.recent_saves_count = 123
           context.salesLoader.mockResolvedValue([
             { id: "sale-id-auction", ended_at: pastTime },
           ])
@@ -4987,9 +4986,8 @@ describe("Artwork type", () => {
           })
 
           const data = await runQuery(query, context)
-          console.log(data.artwork.collectorSignals.auction)
 
-          expect(data.artwork.collectorSignals.auction.lotWatcherCount).toBeNull()
+          expect(data.artwork.collectorSignals.auction).toBeNull()
         })
       })
 

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -4974,6 +4974,23 @@ describe("Artwork type", () => {
 
           expect(data.artwork.collectorSignals.auction).toBeNull()
         })
+
+        it("does not return lotWatcherCount if the bidding is closed", async () => {
+          artwork.purchasable = true
+          artwork.recent_saves_count = 123
+          context.salesLoader.mockResolvedValue([
+            { id: "sale-id-auction", ended_at: pastTime },
+          ])
+          context.saleArtworkLoader.mockResolvedValue({
+            end_at: pastTime,
+            extended_bidding_end_at: pastTime,
+          })
+
+          const data = await runQuery(query, context)
+          console.log(data.artwork.collectorSignals.auction)
+
+          expect(data.artwork.collectorSignals.auction.lotWatcherCount).toBeNull()
+        })
       })
 
       describe("curatorsPick", () => {

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -52,7 +52,11 @@ const AuctionCollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
       (activeLotData.saleArtwork.extended_bidding_end_at ||
         activeLotData.saleArtwork.end_at ||
         activeLotData.sale.ended_at)
-    const isBiddingClosed = lotClosesAt && new Date(lotClosesAt) <= new Date()
+
+    // If the lot is closed for bidding, return null
+    if (lotClosesAt && new Date(lotClosesAt) <= new Date()) {
+      return null
+    }
 
     // Resolve all associated auctions data in one object
     return {
@@ -60,7 +64,6 @@ const AuctionCollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
       saleArtwork: activeLotData.saleArtwork,
       sale: activeLotData.sale,
       lotClosesAt,
-      isBiddingClosed,
     }
   },
 
@@ -74,10 +77,9 @@ const AuctionCollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
         resolve: ({ saleArtwork }) => saleArtwork.bidder_positions_count ?? 0,
       },
       lotWatcherCount: {
-        type: GraphQLInt,
+        type: new GraphQLNonNull(GraphQLInt),
         description: "Lot watcher count, null if lot is closed for bidding",
-        resolve: ({ artwork, isBiddingClosed }) =>
-          isBiddingClosed ? null : artwork.recent_saves_count,
+        resolve: ({ artwork }) => artwork.recent_saves_count ?? 0,
       },
       liveBiddingStarted: {
         type: new GraphQLNonNull(GraphQLBoolean),

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -48,10 +48,10 @@ const AuctionCollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
     }
 
     const lotClosesAt =
-      (!activeLotData.sale.live_start_at &&
-        activeLotData.saleArtwork.extended_bidding_end_at) ||
-      activeLotData.saleArtwork.end_at ||
-      activeLotData.sale.ended_at
+      !activeLotData.sale.live_start_at &&
+      (activeLotData.saleArtwork.extended_bidding_end_at ||
+        activeLotData.saleArtwork.end_at ||
+        activeLotData.sale.ended_at)
     const isBiddingClosed = lotClosesAt && new Date(lotClosesAt) <= new Date()
 
     // Resolve all associated auctions data in one object

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -78,7 +78,7 @@ const AuctionCollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
       },
       lotWatcherCount: {
         type: new GraphQLNonNull(GraphQLInt),
-        description: "Lot watcher count, null if lot is closed for bidding",
+        description: "Lot watcher count",
         resolve: ({ artwork }) => artwork.recent_saves_count ?? 0,
       },
       liveBiddingStarted: {


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/EMI-2052

~Return `null` instead of `0` for the `artwork.collectorSignals.auction.lotWatcherCount` if the lot is closed for bidding.
I got the lot closed logic from the current `lotClosesAt` field, so any feedback is welcome on that.~

Return no auction data if the lot is closed for bidding.

@artsy/emerald-devs 