### PR TITLE
chore(EMI-2075): update precedence of collectorSignal.primaryLabel

### DIFF
--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -217,11 +217,13 @@ const getPrimaryLabel = async (artwork, ctx): Promise<PrimaryLabel> => {
   if (activePartnerOffer) {
     return "PARTNER_OFFER"
   }
-  if (artwork.increased_interest_signal) {
-    return "INCREASED_INTEREST"
-  }
+
   if (curatorsPick) {
     return "CURATORS_PICK"
+  }
+
+  if (artwork.increased_interest_signal) {
+    return "INCREASED_INTEREST"
   }
 
   return null


### PR DESCRIPTION
This PR flips the precedence of INCREASED_INTEREST and CURATORS_PICK for the `primaryLabel` value in `artwork.collectorSignals`.

Resolves [EMI-2075]

[EMI-2075]: https://artsyproduct.atlassian.net/browse/EMI-2075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ