### PR TITLE
chore(EMI-2076): add arg to suppress primary labels in collector signals

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4453,7 +4453,10 @@ type CollectorSignals {
   partnerOffer: PartnerOfferToCollector
 
   # Primary label signal available to collector
-  primaryLabel: LabelSignalEnum
+  primaryLabel(
+    # Signals to ignore
+    ignore: [LabelSignalEnum]
+  ): LabelSignalEnum
 
   # Pending auction registration end time
   registrationEndsAt: String

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -4874,6 +4874,25 @@ describe("Artwork type", () => {
             ).toBeNull()
           })
 
+          it("does not allow illegal values for `ignorePrimaryLabels` arg", async () => {
+            const queryWithTooManyLabels = `
+            {
+              artwork(id: "richard-prince-untitled-portrait") {
+                collectorSignals {
+                  primaryLabel(ignore: [PARTNER_OFFER, CURATORS_PICK, INCREASED_INTEREST, PARTNER_OFFER])
+                }
+              }
+            }
+          `
+            await expect(
+              runQuery(queryWithTooManyLabels, context)
+            ).rejects.toThrow(
+              new Error(
+                `Ignore list length limited to number of available signals - max 3`
+              )
+            )
+          })
+
           it("returns null if there is no active partner offer increased interest, or curators pick collection", async () => {
             context.mePartnerOffersLoader.mockResolvedValue({
               body: [],

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -175,10 +175,13 @@ export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
           },
         },
         resolve: (artwork, args, ctx) => {
-          if (args.ignore?.length > 0) {
-            const uniqueIgnoredLabels = new Set(args.ignore)
-            if (uniqueIgnoredLabels.size !== args.ignore.length) {
-              throw new Error("Duplicate values found in ignore argument")
+          const { ignore } = args
+          if (ignore?.length > 0) {
+            const availableLabelCount = LabelSignalEnumType.getValues().length
+            if (ignore.length > availableLabelCount) {
+              throw new Error(
+                `Ignore list length limited to number of available signals - max ${availableLabelCount}`
+              )
             }
           }
           return getPrimaryLabel(artwork, args, ctx)

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -111,6 +111,7 @@ const LabelSignalEnumType = new GraphQLEnumType({
     CURATORS_PICK: { value: "CURATORS_PICK" },
   },
 })
+const AVAILABLE_LABEL_COUNT = LabelSignalEnumType.getValues().length
 
 export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
   description: "Collector signals on artwork",
@@ -177,10 +178,9 @@ export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
         resolve: (artwork, args, ctx) => {
           const { ignore } = args
           if (ignore?.length > 0) {
-            const availableLabelCount = LabelSignalEnumType.getValues().length
-            if (ignore.length > availableLabelCount) {
+            if (ignore.length > AVAILABLE_LABEL_COUNT) {
               throw new Error(
-                `Ignore list length limited to number of available signals - max ${availableLabelCount}`
+                `Ignore list length limited to number of available signals - max ${AVAILABLE_LABEL_COUNT}`
               )
             }
           }

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -2,6 +2,7 @@ import {
   GraphQLBoolean,
   GraphQLEnumType,
   GraphQLFieldConfig,
+  GraphQLList,
   GraphQLString,
 } from "graphql"
 import { GraphQLInt, GraphQLObjectType } from "graphql"
@@ -112,6 +113,12 @@ const LabelSignalEnumType = new GraphQLEnumType({
 })
 
 export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
+  description: "Collector signals on artwork",
+  resolve: (artwork) => {
+    const canSendSignals = artwork.purchasable || artwork.sale_ids?.length > 0
+    return canSendSignals ? artwork : null
+  },
+
   type: new GraphQLObjectType({
     description: "Collector signals available to the artwork",
     name: "CollectorSignals",
@@ -162,7 +169,21 @@ export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
       primaryLabel: {
         type: LabelSignalEnumType,
         description: "Primary label signal available to collector",
-        resolve: (artwork, {}, ctx) => getPrimaryLabel(artwork, ctx),
+        args: {
+          ignore: {
+            type: GraphQLList(LabelSignalEnumType),
+            description: "Signals to ignore",
+          },
+        },
+        resolve: (artwork, args, ctx) => {
+          if (args.ignore?.length > 0) {
+            const uniqueIgnoredLabels = new Set(args.ignore)
+            if (uniqueIgnoredLabels.size !== args.ignore.length) {
+              throw new Error("Duplicate values found in ignore argument")
+            }
+          }
+          return getPrimaryLabel(artwork, args, ctx)
+        },
       },
       partnerOffer: {
         type: PartnerOfferToCollectorType,
@@ -191,38 +212,38 @@ export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
       },
     },
   }),
-  description: "Collector signals on artwork",
-  resolve: (artwork) => {
-    const canSendSignals = artwork.purchasable || artwork.sale_ids?.length > 0
-    return canSendSignals ? artwork : null
-  },
 }
 
-type PrimaryLabel =
-  | "PARTNER_OFFER"
-  | "INCREASED_INTEREST"
-  | "CURATORS_PICK"
-  | null
+type PrimaryLabel = "PARTNER_OFFER" | "INCREASED_INTEREST" | "CURATORS_PICK"
 
 // Single function to resolve mutually-exclusive label signals
-const getPrimaryLabel = async (artwork, ctx): Promise<PrimaryLabel> => {
+const getPrimaryLabel = async (
+  artwork,
+  args,
+  ctx
+): Promise<PrimaryLabel | null> => {
   const partnerOfferPromise = getActivePartnerOffer(artwork, ctx)
   const curatorsPickPromise = getIsCuratorsPick(artwork, ctx)
+
+  const ignoreLabels = (args.ignore ?? []) as PrimaryLabel[]
 
   const [activePartnerOffer, curatorsPick] = await Promise.all([
     partnerOfferPromise,
     curatorsPickPromise,
   ])
 
-  if (activePartnerOffer) {
+  if (activePartnerOffer && !ignoreLabels.includes("PARTNER_OFFER")) {
     return "PARTNER_OFFER"
   }
 
-  if (curatorsPick) {
+  if (!ignoreLabels.includes("CURATORS_PICK") && curatorsPick) {
     return "CURATORS_PICK"
   }
 
-  if (artwork.increased_interest_signal) {
+  if (
+    !ignoreLabels.includes("INCREASED_INTEREST") &&
+    artwork.increased_interest_signal
+  ) {
     return "INCREASED_INTEREST"
   }
 

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -118,7 +118,6 @@ export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
     const canSendSignals = artwork.purchasable || artwork.sale_ids?.length > 0
     return canSendSignals ? artwork : null
   },
-
   type: new GraphQLObjectType({
     description: "Collector signals available to the artwork",
     name: "CollectorSignals",
@@ -225,23 +224,23 @@ const getPrimaryLabel = async (
   const partnerOfferPromise = getActivePartnerOffer(artwork, ctx)
   const curatorsPickPromise = getIsCuratorsPick(artwork, ctx)
 
-  const ignoreLabels = (args.ignore ?? []) as PrimaryLabel[]
+  const ignoreLabels = args.ignore
 
   const [activePartnerOffer, curatorsPick] = await Promise.all([
     partnerOfferPromise,
     curatorsPickPromise,
   ])
 
-  if (activePartnerOffer && !ignoreLabels.includes("PARTNER_OFFER")) {
+  if (!ignoreLabels?.includes("PARTNER_OFFER") && activePartnerOffer) {
     return "PARTNER_OFFER"
   }
 
-  if (!ignoreLabels.includes("CURATORS_PICK") && curatorsPick) {
+  if (!ignoreLabels?.includes("CURATORS_PICK") && curatorsPick) {
     return "CURATORS_PICK"
   }
 
   if (
-    !ignoreLabels.includes("INCREASED_INTEREST") &&
+    !ignoreLabels?.includes("INCREASED_INTEREST") &&
     artwork.increased_interest_signal
   ) {
     return "INCREASED_INTEREST"

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -177,12 +177,10 @@ export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
         },
         resolve: (artwork, args, ctx) => {
           const { ignore } = args
-          if (ignore?.length > 0) {
-            if (ignore.length > AVAILABLE_LABEL_COUNT) {
-              throw new Error(
-                `Ignore list length limited to number of available signals - max ${AVAILABLE_LABEL_COUNT}`
-              )
-            }
+          if (ignore && ignore.length > AVAILABLE_LABEL_COUNT) {
+            throw new Error(
+              `Ignore list length limited to number of available signals - max ${AVAILABLE_LABEL_COUNT}`
+            )
           }
           return getPrimaryLabel(artwork, args, ctx)
         },


### PR DESCRIPTION
Thie PR adds an optional argument to the `collectorSignals.primaryLabel` field to ignore specific labels on the `primaryLabel` field. See tests for usage.

Resolves [EMI-2076].

[EMI-2076]: https://artsyproduct.atlassian.net/browse/EMI-2076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ