### PR TITLE
chore: misc batched loader updates

### DIFF
--- a/src/lib/loaders/batchSaleArtworkLoader.ts
+++ b/src/lib/loaders/batchSaleArtworkLoader.ts
@@ -10,7 +10,10 @@ const groupByParams = (
     if (!acc[saleId]) {
       acc[saleId] = []
     }
-    acc[saleId].push(artworkId)
+
+    if (!acc[saleId].includes(artworkId)) {
+      acc[saleId].push(artworkId)
+    }
     return acc
   }, {})
 


### PR DESCRIPTION
In staging, was seeing that we were sometimes batching in sizes _less_ than 20, _and_ also when we were over-fetching.

Both of these had the same underlying cause: the loader was being invoked multiple times for the same arguments - need to dedupe those in order to guarantee we're batching at 20 (and not over-fetching).