### PR TITLE
feat: set Cache-control: no-cache when the query contains any errors

### DIFF
--- a/patches/express-graphql+0.12.0.patch
+++ b/patches/express-graphql+0.12.0.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/express-graphql/index.js b/node_modules/express-graphql/index.js
+index 3bc78dc..477be08 100644
+--- a/node_modules/express-graphql/index.js
++++ b/node_modules/express-graphql/index.js
+@@ -153,6 +153,10 @@ function graphqlHTTP(options) {
+                     result = { ...result, extensions };
+                 }
+             }
++            // If errors in execution, set the `Cache-Control: no-cache` header.
++            if (result.errors != null) {
++                response.setHeader('Cache-Control', 'no-cache');
++            }
+         }
+         catch (rawError) {
+             // If an error was caught, report the httpError status, or 500.

--- a/src/integration/__tests__/customHeaderOnError.test.ts
+++ b/src/integration/__tests__/customHeaderOnError.test.ts
@@ -1,0 +1,66 @@
+jest.mock("lib/apis/fetch", () => jest.fn())
+import { HTTPError } from "lib/HTTPError"
+import fetch from "lib/apis/fetch"
+const mockFetch = fetch as jest.Mock
+
+describe("setting custom headers", () => {
+  const request = require("supertest")
+  const app = require("../../index").default
+  const gql = require("lib/gql").default
+
+  beforeEach(() => {
+    mockFetch.mockClear()
+    mockFetch.mockReset()
+  })
+
+  describe("when there is an upstream eror", () => {
+    it("sets `Cache-Control: no-cache`", async () => {
+      mockFetch.mockRejectedValueOnce(
+        new HTTPError("Upstream hiccup, cats in the server room", 500)
+      )
+
+      const response = await request(app)
+        .post("/v2")
+        .set("Accept", "application/json")
+        .send({
+          query: gql`
+            {
+              artist(id: "banksy") {
+                name
+              }
+            }
+          `,
+        })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.body.errors).not.toBeUndefined()
+      expect(response.headers["cache-control"]).toBe("no-cache")
+    })
+  })
+
+  describe("when there's no upstream error", () => {
+    it("does not set `Cache-Control: no-cache`", async () => {
+      mockFetch.mockResolvedValueOnce(
+        Promise.resolve({ body: { name: "Banksy" } })
+      )
+
+      const response = await request(app)
+        .post("/v2")
+        .set("Accept", "application/json")
+        .send({
+          query: gql`
+            {
+              artist(id: "banksy") {
+                name
+              }
+            }
+          `,
+        })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.body).toEqual({ data: { artist: { name: "Banksy" } } })
+      expect(response.body.errors).toBeUndefined()
+      expect(response.headers["cache-control"]).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
## What this does

For more sane usage of our CDN - we've decided that we don't want to cache any GraphQL queries that contained errors. Our clients should likely be more resilient as they'll encounter such responses with errors, _but_ if we cache those we'd likely be 'down' for longer than needed when there was some upstream hiccup.

Ideally, we'd be able to implement something that accomplishes this _without_ needing to re-parse any response into JSON to look for `errors`, or anything like that.

To that end - I'm proposing a **patch** to `express-graphql` where we'll have access to the JSON.

## Why a patch? 

While we don't typically reach for patches, in this case:
  - there is a corresponding spec
  - we're not anticipating upgrading this lib anymore (after the last upgrades from @MounirDhahri ) - eventually we need to move off of it anyway, and thus likely re-implement any patch or non-patch code
  - while there are other solutions that don't involve a patch (putting this logic in the Cloudflare worker, custom MP middleware to intercept the response) - those _do_ involve needing to parse the JSON for every MP request, which is kind of a steep performance penalty all to avoid a couple lines of a patch, especially when most requests won't even have an error.