### PR TITLE
chore(homeView): switch from union to interface

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10889,13 +10889,13 @@ type HomeView {
   section(
     # The ID of the section
     id: String!
-  ): HomeViewSection
+  ): HomeViewSectionGeneric
   sectionsConnection(
     after: String
     before: String
     first: Int
     last: Int
-  ): HomeViewSectionConnection!
+  ): HomeViewSectionGenericConnection!
 }
 
 # A component specification
@@ -10938,20 +10938,6 @@ type HomeViewComponentBehaviorsViewAll {
   # href of the view all button
   href: String
 }
-
-union HomeViewSection =
-    HomeViewSectionActivity
-  | HomeViewSectionArticles
-  | HomeViewSectionArtists
-  | HomeViewSectionArtworks
-  | HomeViewSectionAuctionResults
-  | HomeViewSectionFairs
-  | HomeViewSectionGalleries
-  | HomeViewSectionHeroUnits
-  | HomeViewSectionMarketingCollections
-  | HomeViewSectionSales
-  | HomeViewSectionShows
-  | HomeViewSectionViewingRooms
 
 # A user activity section in the home view
 type HomeViewSectionActivity implements HomeViewSectionGeneric & Node {
@@ -11062,26 +11048,6 @@ type HomeViewSectionAuctionResults implements HomeViewSectionGeneric & Node {
   internalID: ID!
 }
 
-# A connection to a list of items.
-type HomeViewSectionConnection {
-  # A list of edges.
-  edges: [HomeViewSectionEdge]
-  pageCursors: PageCursors!
-
-  # Information to aid in pagination.
-  pageInfo: PageInfo!
-  totalCount: Int
-}
-
-# An edge in a connection.
-type HomeViewSectionEdge {
-  # A cursor for use in pagination
-  cursor: String!
-
-  # The item at the end of the edge
-  node: HomeViewSection
-}
-
 # A fairs section in the home view
 type HomeViewSectionFairs implements HomeViewSectionGeneric & Node {
   # The component that is prescribed for this section
@@ -11131,6 +11097,26 @@ interface HomeViewSectionGeneric {
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
+}
+
+# A connection to a list of items.
+type HomeViewSectionGenericConnection {
+  # A list of edges.
+  edges: [HomeViewSectionGenericEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type HomeViewSectionGenericEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: HomeViewSectionGeneric
 }
 
 # A hero units section in the home view

--- a/src/schema/v2/homeView/HomeViewSection.ts
+++ b/src/schema/v2/homeView/HomeViewSection.ts
@@ -5,7 +5,6 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
-  GraphQLUnionType,
 } from "graphql"
 import { pageable } from "relay-cursor-paging"
 import { ResolverContext } from "types/graphql"
@@ -60,10 +59,13 @@ export const HomeViewSectionTypeNames = {
   HomeViewSectionViewingRooms: "HomeViewSectionViewingRooms",
 } as const
 
-const HomeViewGenericSectionInterface = new GraphQLInterfaceType({
+export const HomeViewGenericSectionInterface = new GraphQLInterfaceType({
   name: HomeViewSectionTypeNames.HomeViewSectionGeneric,
   description: "Abstract interface shared by every kind of home view section",
   fields: standardSectionFields,
+  resolveType: (value) => {
+    return value.type
+  },
 })
 
 // concrete sections
@@ -265,24 +267,17 @@ export const HomeViewGalleriesSectionType = new GraphQLObjectType<
   },
 })
 
-// the Section union type of all concrete sections
-export const HomeViewSectionType = new GraphQLUnionType({
-  name: "HomeViewSection",
-  types: [
-    HomeViewActivitySectionType,
-    HomeViewArticlesSectionType,
-    HomeViewArtistsSectionType,
-    HomeViewArtworksSectionType,
-    HomeViewAuctionResultsSectionType,
-    HomeViewFairsSectionType,
-    HomeViewGalleriesSectionType,
-    HomeViewHeroUnitsSectionType,
-    HomeViewMarketingCollectionsSectionType,
-    HomeViewSalesSectionType,
-    HomeViewShowsSectionType,
-    HomeViewViewingRoomsSectionType,
-  ],
-  resolveType: (value) => {
-    return value.type
-  },
-})
+export const homeViewSectionTypes: GraphQLObjectType<any, ResolverContext>[] = [
+  HomeViewActivitySectionType,
+  HomeViewArticlesSectionType,
+  HomeViewArtistsSectionType,
+  HomeViewArtworksSectionType,
+  HomeViewAuctionResultsSectionType,
+  HomeViewFairsSectionType,
+  HomeViewGalleriesSectionType,
+  HomeViewHeroUnitsSectionType,
+  HomeViewMarketingCollectionsSectionType,
+  HomeViewSalesSectionType,
+  HomeViewShowsSectionType,
+  HomeViewViewingRoomsSectionType,
+]

--- a/src/schema/v2/homeView/index.ts
+++ b/src/schema/v2/homeView/index.ts
@@ -11,12 +11,12 @@ import {
   connectionWithCursorInfo,
   paginationResolver,
 } from "../fields/pagination"
-import { HomeViewSectionType } from "./HomeViewSection"
+import { HomeViewGenericSectionInterface } from "./HomeViewSection"
 import { getSectionsForUser } from "./getSectionsForUser"
 import { registry } from "./sections"
 
 const SectionsConnectionType = connectionWithCursorInfo({
-  nodeType: HomeViewSectionType,
+  nodeType: HomeViewGenericSectionInterface,
 }).connectionType
 
 const SectionConnection: GraphQLFieldConfig<any, ResolverContext> = {
@@ -41,7 +41,7 @@ const SectionConnection: GraphQLFieldConfig<any, ResolverContext> = {
 }
 
 export const Section: GraphQLFieldConfig<void, ResolverContext> = {
-  type: HomeViewSectionType,
+  type: HomeViewGenericSectionInterface,
   description: "A home view section",
   args: {
     id: {

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -234,6 +234,7 @@ import { updatePartnerShowMutation } from "./partner/updatePartnerShowMutation"
 import { VerifyUser } from "./verifyUser"
 import { ArtistSeries, ArtistSeriesConnection } from "./artistSeries"
 import config from "config"
+import { homeViewSectionTypes } from "./homeView/HomeViewSection"
 
 const PrincipalFieldDirective = new GraphQLDirective({
   name: "principalField",
@@ -516,6 +517,7 @@ export default new GraphQLSchema({
     ShowArtworkGridType,
     ArtworkOrEditionSetType,
     SearchCriteriaLabel,
+    ...homeViewSectionTypes,
   ],
   directives: specifiedDirectives.concat([
     PrincipalFieldDirective,


### PR DESCRIPTION
This allows us to query for generally support attributes across all sections without needed a named fragment like `... on HomeViewSectionGeneric`. This does switch the connection from exposing a Union to an Interface, but all else seems to work exactly the same.

I don't see much of a downside here. There was some [recent discussion in Slack](https://artsy.slack.com/archives/C05EQL4R5N0/p1726078732679849?thread_ts=1726069270.194679) regarding the `matchConnection` field using a union type instead of an interface implemented for `searchConnection` but I think the real problems with the `searchConnection` field stems more from [the query introspection and this error](https://github.com/artsy/metaphysics/blob/7bd5e7a988f761185a2310b3132eca9533750ca0/src/schema/v2/search/SearchResolver.ts#L64-L68) rather than the implementation of an interface-backed connection.

## Example

```graphql
{
  homeView {
    sectionsConnection(first: 5) {
      __typename
      internalID
      component {
        title
      }
      contextModule
    }
  }
}
```