### PR TITLE
chore(analytics): add ownerType value to home view viewAll signals

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10912,7 +10912,7 @@ type HomeViewComponent {
   description: String
 
   # A screen to navigate to when this component is clicked
-  href: String
+  href: String @deprecated(reason: "Use `behaviors.viewAll.href` instead")
 
   # A display title for this section
   title: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10937,6 +10937,9 @@ type HomeViewComponentBehaviorsViewAll {
 
   # href of the view all button
   href: String
+
+  # [Analytics] `owner type` analytics value, as defined in our schema (artsy/cohesion), for the requested destination
+  ownerType: String
 }
 
 # A user activity section in the home view

--- a/src/schema/v2/homeView/HomeViewComponent.ts
+++ b/src/schema/v2/homeView/HomeViewComponent.ts
@@ -137,6 +137,7 @@ export const HomeViewComponent = new GraphQLObjectType({
           return description
         }
       },
+      deprecationReason: "Use `behaviors.viewAll.href` instead",
     },
     behaviors: {
       type: HomeViewComponentBehaviors,

--- a/src/schema/v2/homeView/HomeViewComponent.ts
+++ b/src/schema/v2/homeView/HomeViewComponent.ts
@@ -1,3 +1,4 @@
+import { OwnerType } from "@artsy/cohesion"
 import { GraphQLEnumType, GraphQLObjectType, GraphQLString } from "graphql"
 import { ResolverContext } from "types/graphql"
 
@@ -5,6 +6,7 @@ export type HomeViewComponentBehaviors = {
   viewAll?: {
     href?: string | null
     buttonText?: string
+    ownerType?: OwnerType
   }
 }
 const HomeViewComponentBehaviors = new GraphQLObjectType<
@@ -17,13 +19,18 @@ const HomeViewComponentBehaviors = new GraphQLObjectType<
       type: new GraphQLObjectType({
         name: "HomeViewComponentBehaviorsViewAll",
         fields: {
+          buttonText: {
+            type: GraphQLString,
+            description: "Text for the CTA of the view all button",
+          },
           href: {
             type: GraphQLString,
             description: "href of the view all button",
           },
-          buttonText: {
+          ownerType: {
             type: GraphQLString,
-            description: "Text for the CTA of the view all button",
+            description:
+              "[Analytics] `owner type` analytics value, as defined in our schema (artsy/cohesion), for the requested destination",
           },
         },
       }),

--- a/src/schema/v2/homeView/__tests__/HomeView.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeView.test.ts
@@ -146,7 +146,7 @@ describe("homeView", () => {
                 "node": Object {
                   "__typename": "HomeViewSectionArtworks",
                   "component": Object {
-                    "title": "New works for you",
+                    "title": "New works for You",
                   },
                 },
               },
@@ -168,7 +168,7 @@ describe("homeView", () => {
                 "node": Object {
                   "__typename": "HomeViewSectionArtworks",
                   "component": Object {
-                    "title": "Auction lots for you",
+                    "title": "Auction lots for You",
                   },
                 },
               },
@@ -338,7 +338,7 @@ describe("homeView", () => {
                       Object {
                         "__typename": "HomeViewSectionArtworks",
                         "component": Object {
-                          "title": "Auction lots for you",
+                          "title": "Auction lots for You",
                         },
                       }
                   `)

--- a/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
@@ -129,7 +129,7 @@ describe("HomeViewSection", () => {
                 "href": null,
               },
             },
-            "title": "New works for you",
+            "title": "New works for You",
           },
         }
       `)
@@ -173,7 +173,7 @@ describe("HomeViewSection", () => {
                 "href": "/auctions/lots-for-you-ending-soon",
               },
             },
-            "title": "Auction lots for you",
+            "title": "Auction lots for You",
           },
         }
       `)
@@ -959,7 +959,6 @@ describe("HomeViewSection", () => {
               ... on HomeViewSectionAuctionResults {
                 component {
                   title
-                  href
                   behaviors {
                     viewAll {
                       href
@@ -1048,10 +1047,9 @@ describe("HomeViewSection", () => {
               "component": Object {
                 "behaviors": Object {
                   "viewAll": Object {
-                    "href": "/auction-results-for-artists-you-follow",
+                    "href": null,
                   },
                 },
-                "href": "/auction-results-for-artists-you-follow",
                 "title": "Latest Auction Results",
               },
             },
@@ -1351,7 +1349,6 @@ describe("HomeViewSection", () => {
                   title
                   backgroundImageURL
                   description
-                  href
                   behaviors {
                     viewAll {
                       href
@@ -1377,11 +1374,10 @@ describe("HomeViewSection", () => {
                     "behaviors": Object {
                       "viewAll": Object {
                         "buttonText": "Explore",
-                        "href": "/galleries-for-you",
+                        "href": null,
                       },
                     },
                     "description": "Follow these local galleries for updates on artists you love.",
-                    "href": "/galleries-for-you",
                     "title": "Galleries Near You",
                   },
                 }

--- a/src/schema/v2/homeView/sections/index.ts
+++ b/src/schema/v2/homeView/sections/index.ts
@@ -27,7 +27,7 @@ import { HomeViewComponentBehaviors } from "../HomeViewComponent"
 import { SalesResolver } from "../resolvers/salesResolvers"
 import { withHomeViewTimeout } from "../helpers/withHomeViewTimeout"
 import { HomeViewSectionTypeNames } from "../HomeViewSection"
-import { ContextModule } from "@artsy/cohesion"
+import { ContextModule, OwnerType } from "@artsy/cohesion"
 
 type MaybeResolved<T> =
   | T
@@ -102,6 +102,7 @@ export const CuratorsPicksEmerging: HomeViewSection = {
       viewAll: {
         href: "/collection/curators-picks-emerging",
         buttonText: "Browse All Artworks",
+        ownerType: OwnerType.collection,
       },
     },
     href: "/collection/curators-picks-emerging",
@@ -136,6 +137,7 @@ export const AuctionLotsForYou: HomeViewSection = {
       viewAll: {
         href: "/auctions/lots-for-you-ending-soon",
         buttonText: "Browse All Artworks",
+        ownerType: OwnerType.lotsForYou,
       },
     },
   },
@@ -294,6 +296,7 @@ export const ViewingRooms: HomeViewSection = {
     behaviors: {
       viewAll: {
         href: "/viewing-rooms",
+        ownerType: OwnerType.viewingRooms,
       },
     },
   },
@@ -312,8 +315,9 @@ export const LatestActivity: HomeViewSection = {
     title: "Latest Activity",
     behaviors: {
       viewAll: {
-        href: "/notifications",
         buttonText: "See All",
+        href: "/notifications",
+        ownerType: OwnerType.activities,
       },
     },
   },
@@ -356,8 +360,9 @@ export const News: HomeViewSection = {
     type: "ArticlesCard",
     behaviors: {
       viewAll: {
-        href: "/news",
         buttonText: "More in News",
+        href: "/news",
+        ownerType: "marketNews" as OwnerType,
       },
     },
   },
@@ -374,6 +379,7 @@ export const LatestArticles: HomeViewSection = {
     behaviors: {
       viewAll: {
         href: "/articles",
+        ownerType: OwnerType.articles,
       },
     },
   },
@@ -393,8 +399,9 @@ export const Auctions: HomeViewSection = {
     title: "Auctions",
     behaviors: {
       viewAll: {
-        href: "/auctions",
         buttonText: "Browse All Auctions",
+        href: "/auctions",
+        ownerType: OwnerType.auctions,
       },
     },
   },

--- a/src/schema/v2/homeView/sections/index.ts
+++ b/src/schema/v2/homeView/sections/index.ts
@@ -42,7 +42,6 @@ export type HomeViewSection = {
     type?: string
     description?: MaybeResolved<string>
     backgroundImageURL?: MaybeResolved<string>
-    href?: MaybeResolved<string>
     behaviors?: HomeViewComponentBehaviors
   }
   requiresAuthentication: boolean
@@ -105,7 +104,6 @@ export const CuratorsPicksEmerging: HomeViewSection = {
         ownerType: OwnerType.collection,
       },
     },
-    href: "/collection/curators-picks-emerging",
   },
   requiresAuthentication: false,
   resolver: withHomeViewTimeout(CuratorsPicksEmergingArtworksResolver),
@@ -356,7 +354,6 @@ export const News: HomeViewSection = {
   contextModule: ContextModule.articleRail,
   component: {
     title: "News",
-    href: "/news",
     type: "ArticlesCard",
     behaviors: {
       viewAll: {

--- a/src/schema/v2/homeView/sections/index.ts
+++ b/src/schema/v2/homeView/sections/index.ts
@@ -60,7 +60,6 @@ export const SimilarToRecentlyViewedArtworks: HomeViewSection = {
     title: "Similar to Works You’ve Viewed",
     behaviors: {
       viewAll: {
-        href: null,
         buttonText: "Browse All Artworks",
       },
     },
@@ -119,7 +118,6 @@ export const RecentlyViewedArtworks: HomeViewSection = {
     title: "Recently Viewed",
     behaviors: {
       viewAll: {
-        href: null,
         buttonText: "Browse All Artworks",
       },
     },
@@ -133,7 +131,7 @@ export const AuctionLotsForYou: HomeViewSection = {
   type: HomeViewSectionTypeNames.HomeViewSectionArtworks,
   contextModule: ContextModule.lotsForYouRail,
   component: {
-    title: "Auction lots for you",
+    title: "Auction lots for You",
     behaviors: {
       viewAll: {
         href: "/auctions/lots-for-you-ending-soon",
@@ -150,10 +148,9 @@ export const NewWorksForYou: HomeViewSection = {
   type: HomeViewSectionTypeNames.HomeViewSectionArtworks,
   contextModule: ContextModule.newWorksForYouRail,
   component: {
-    title: "New works for you",
+    title: "New works for You",
     behaviors: {
       viewAll: {
-        href: null,
         buttonText: "Browse All Artworks",
       },
     },
@@ -170,7 +167,6 @@ export const NewWorksFromGalleriesYouFollow: HomeViewSection = {
     title: "New Works from Galleries You Follow",
     behaviors: {
       viewAll: {
-        href: null,
         buttonText: "Browse All Artworks",
       },
     },
@@ -187,7 +183,6 @@ export const RecommendedArtworks: HomeViewSection = {
     title: "Artwork Recommendations",
     behaviors: {
       viewAll: {
-        href: null,
         buttonText: "Browse All Artworks",
       },
     },
@@ -336,10 +331,8 @@ export const LatestAuctionResults: HomeViewSection = {
   contextModule: ContextModule.auctionResultsRail,
   component: {
     title: "Latest Auction Results",
-    href: "/auction-results-for-artists-you-follow",
     behaviors: {
       viewAll: {
-        href: "/auction-results-for-artists-you-follow",
         buttonText: "Browse All Results",
       },
     },
@@ -422,10 +415,8 @@ export const GalleriesNearYou: HomeViewSection = {
     description:
       "Follow these local galleries for updates on artists you love.",
     backgroundImageURL: "https://files.artsy.net/images/galleries_for_you.webp",
-    href: "/galleries-for-you",
     behaviors: {
       viewAll: {
-        href: "/galleries-for-you",
         buttonText: "Explore",
       },
     },


### PR DESCRIPTION
Add `ownerType` to viewAll behaviors with an explicit `href` provided so we can reliably pass this value through to analytics event payloads.