### PR TITLE
fix(WIP): Do not allow setting MyC artwork condition to Null in mutations

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13937,7 +13937,7 @@ input MyCollectionCreateArtworkInput {
 
   # The given location of the user as structured data
   collectorLocation: EditableLocation
-  condition: ArtworkConditionEnumType
+  condition: ArtworkConditionEnumType!
   conditionDescription: String
   confidentialNotes: String
   costCurrencyCode: String
@@ -14039,7 +14039,7 @@ input MyCollectionUpdateArtworkInput {
 
   # The given location of the user as structured data
   collectorLocation: EditableLocation
-  condition: ArtworkConditionEnumType
+  condition: ArtworkConditionEnumType!
   conditionDescription: String
   confidentialNotes: String
   costCurrencyCode: String

--- a/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionCreateArtworkMutation.ts
@@ -14,13 +14,13 @@ import { snakeCaseKeys } from "lib/helpers"
 import { StaticPathLoader } from "lib/loaders/api/loader_interface"
 import { ResolverContext } from "types/graphql"
 import { ArtworkImportSourceEnum } from "../artwork"
-import { MyCollectionArtworkMutationType } from "./myCollection"
-import { EditableLocationFields } from "./update_me_mutation"
+import { ArtworkConditionEnum } from "../artwork/artworkCondition"
 import {
   ArtworkSignatureTypeEnum,
   transformSignatureFieldsToGravityFields,
 } from "../artwork/artworkSignatureTypes"
-import { ArtworkConditionEnum } from "../artwork/artworkCondition"
+import { MyCollectionArtworkMutationType } from "./myCollection"
+import { EditableLocationFields } from "./update_me_mutation"
 
 export const externalUrlRegex = /https:\/\/(?<sourceBucket>.*).s3.amazonaws.com\/(?<sourceKey>.*)/
 
@@ -79,7 +79,7 @@ export const myCollectionCreateArtworkMutation = mutationWithClientMutationId<
       type: GraphQLBoolean,
     },
     condition: {
-      type: ArtworkConditionEnum,
+      type: GraphQLNonNull(ArtworkConditionEnum),
     },
     confidentialNotes: {
       type: GraphQLString,

--- a/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
+++ b/src/schema/v2/me/myCollectionUpdateArtworkMutation.ts
@@ -9,6 +9,11 @@ import { mutationWithClientMutationId } from "graphql-relay"
 import { GraphQLLong } from "lib/customTypes/GraphQLLong"
 import { formatGravityError } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
+import { ArtworkConditionEnum } from "../artwork/artworkCondition"
+import {
+  ArtworkSignatureTypeEnum,
+  transformSignatureFieldsToGravityFields,
+} from "../artwork/artworkSignatureTypes"
 import { MyCollectionArtworkMutationType } from "./myCollection"
 import {
   ArtworkAttributionClassEnum,
@@ -16,11 +21,6 @@ import {
   transformToPricePaidCents,
 } from "./myCollectionCreateArtworkMutation"
 import { EditableLocationFields } from "./update_me_mutation"
-import {
-  ArtworkSignatureTypeEnum,
-  transformSignatureFieldsToGravityFields,
-} from "../artwork/artworkSignatureTypes"
-import { ArtworkConditionEnum } from "../artwork/artworkCondition"
 
 interface MyCollectionArtworkUpdateMutationInput {
   additionalInformation?: string
@@ -87,7 +87,7 @@ export const myCollectionUpdateArtworkMutation = mutationWithClientMutationId<
       type: GraphQLBoolean,
     },
     condition: {
-      type: ArtworkConditionEnum,
+      type: GraphQLNonNull(ArtworkConditionEnum),
     },
     conditionDescription: {
       type: GraphQLString,


### PR DESCRIPTION
Related to https://github.com/artsy/eigen/pull/10785

## Description

With this, we don't allow setting MyC artwork's `condition` to `null` in mutations because it's [not allowed in Gravity](https://github.com/artsy/gravity/blob/2049ddd10a5ab8d964e1bec5644b8bc5737d463b/app/models/concerns/my_collection_artwork.rb#L4) and we're getting an error message that `null` is not allowed when we try to. 

This is fix is related to https://github.com/artsy/eigen/pull/10785.