### PR TITLE
fix(EMI-2093): remove ineligible signals from auction artworks

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -4657,6 +4657,7 @@ describe("Artwork type", () => {
             partnerOffer {
               endAt
             }
+            primaryLabel
           }
         }
       }

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -5087,7 +5087,7 @@ describe("Artwork type", () => {
       })
 
       describe("curatorsPick", () => {
-        it("returns false if the artwork id is in a curated collection but has sale_ids", async () => {
+        it("returns true if the artwork id is in a curated collection but has sale_ids", async () => {
           artwork.purchasable = true
           artwork.sale_ids = ["sale-id-auction"]
           context.marketingCollectionLoader.mockResolvedValue({
@@ -5095,7 +5095,7 @@ describe("Artwork type", () => {
           })
 
           const data = await runQuery(query, context)
-          expect(data.artwork.collectorSignals.curatorsPick).toBe(false)
+          expect(data.artwork.collectorSignals.curatorsPick).toBe(true)
         })
 
         it("returns true if the artwork id is in a curated collection with no sale ids", async () => {

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -4915,6 +4915,12 @@ describe("Artwork type", () => {
         const futureTime = moment().add(1, "day").toISOString()
         const pastTime = moment().subtract(1, "day").toISOString()
 
+        it("returns null for primaryLabel even if a signal is available", async () => {
+          artwork.increased_interest_signal = true
+          const data = await runQuery(query, context)
+          expect(data.artwork.collectorSignals.primaryLabel).toBeNull()
+        })
+
         it("returns false for increasedInterest", async () => {
           artwork.increased_interest_signal = true
 

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -4915,16 +4915,10 @@ describe("Artwork type", () => {
         const futureTime = moment().add(1, "day").toISOString()
         const pastTime = moment().subtract(1, "day").toISOString()
 
-        it("returns the increasedInterest signal", async () => {
+        it("returns false for increasedInterest", async () => {
           artwork.increased_interest_signal = true
 
-          let data = await runQuery(query, context)
-
-          expect(data.artwork.collectorSignals.increasedInterest).toEqual(true)
-
-          artwork.increased_interest_signal = false
-
-          data = await runQuery(query, context)
+          const data = await runQuery(query, context)
 
           expect(data.artwork.collectorSignals.increasedInterest).toEqual(false)
         })
@@ -5086,8 +5080,20 @@ describe("Artwork type", () => {
       })
 
       describe("curatorsPick", () => {
-        it("returns true if the artwork id is in a curated collection", async () => {
+        it("returns false if the artwork id is in a curated collection but has sale_ids", async () => {
           artwork.purchasable = true
+          artwork.sale_ids = ["sale-id-auction"]
+          context.marketingCollectionLoader.mockResolvedValue({
+            artwork_ids: [artwork._id],
+          })
+
+          const data = await runQuery(query, context)
+          expect(data.artwork.collectorSignals.curatorsPick).toBe(false)
+        })
+
+        it("returns true if the artwork id is in a curated collection with no sale ids", async () => {
+          artwork.purchasable = true
+          artwork.sale_ids = []
           context.marketingCollectionLoader.mockResolvedValue({
             artwork_ids: [artwork._id],
           })

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -218,6 +218,10 @@ const getPrimaryLabel = async (
   args,
   ctx
 ): Promise<PrimaryLabel | null> => {
+  if (isAuctionArtwork(artwork)) {
+    return null
+  }
+
   const ignoreLabels = args.ignore
   const partnerOfferPromise =
     !ignoreLabels?.includes("PARTNER_OFFER") &&

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -281,10 +281,6 @@ const getActivePartnerOffer = async (artwork, ctx) => {
 }
 
 const getIsCuratorsPick = async (artwork, ctx) => {
-  if (isAuctionArtwork(artwork)) {
-    return false
-  }
-
   const CURATED_COLLECTION_SLUGS = [
     "curators-picks-blue-chip-artists",
     "curators-picks-emerging-artists",

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -112,7 +112,7 @@ const AVAILABLE_LABEL_COUNT = LabelSignalEnumType.getValues().length
 export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
   description: "Collector signals on artwork",
   resolve: (artwork) => {
-    const canSendSignals = artwork.purchasable || artwork.sale_ids?.length > 0
+    const canSendSignals = artwork.purchasable || isAuctionArtwork(artwork)
     return canSendSignals ? artwork : null
   },
   type: new GraphQLObjectType({
@@ -260,7 +260,7 @@ const checkFeatureFlag = (flag: any, context: any) => {
 }
 
 const getIncreasedInterest = (artwork) => {
-  return !(artwork.sale_ids?.length > 0) && !!artwork.increased_interest_signal
+  return !isAuctionArtwork(artwork) && !!artwork.increased_interest_signal
 }
 
 const getActivePartnerOffer = async (artwork, ctx) => {


### PR DESCRIPTION
The type of this PR is **fix**

This PR skips checks for curators' pick and increased interest signals on auction artworks.

This PR resolves [EMI-2093].


[EMI-2093]: https://artsyproduct.atlassian.net/browse/EMI-2093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ