### PR TITLE
docs(homeView): touch up the inline schema documentation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10887,11 +10887,13 @@ type HomePageSalesModule {
 
 # Schema for server-driven home view content
 type HomeView {
-  # A home view section
+  # A single home view section, addressed by internal id
   section(
     # The ID of the section
     id: String!
   ): HomeViewSectionGeneric
+
+  # A paginated list of home view sections
   sectionsConnection(
     after: String
     before: String
@@ -10900,17 +10902,17 @@ type HomeView {
   ): HomeViewSectionGenericConnection!
 }
 
-# A component specification
+# A component specification, to allow for customization of presentation and behavior
 type HomeViewComponent {
   # A background image for this section
   backgroundImageURL(
     version: HomeViewComponentBackgroundImageURLVersion
   ): String
 
-  # Behaviors for the view
+  # Behaviors for this component
   behaviors: HomeViewComponentBehaviors
 
-  # A description for this section
+  # A description or blurb for this section
   description: String
 
   # A screen to navigate to when this component is clicked
@@ -10919,7 +10921,7 @@ type HomeViewComponent {
   # A display title for this section
   title: String
 
-  # How this component should be rendered
+  # The name of the client-side component which should be preferred (when the default component for a given section type is not sufficient)
   type: String
 }
 
@@ -10928,28 +10930,30 @@ enum HomeViewComponentBackgroundImageURLVersion {
   WIDE
 }
 
+# Behaviors for this component
 type HomeViewComponentBehaviors {
-  # Represents the behavior of the view all button
+  # Represents the behavior of the View All button
   viewAll: HomeViewComponentBehaviorsViewAll
 }
 
+# A specification for this section’s View All behavior
 type HomeViewComponentBehaviorsViewAll {
-  # Text for the CTA of the view all button
+  # Text for the CTA of the View All button
   buttonText: String
 
-  # href of the view all button
+  # `href` of the View All button. When present, will result in a navigation to the specified route. When `null`, will result in the client-side component’s default view-all behavior, e.g. a full-screen modal overlay
   href: String
 
-  # [Analytics] `owner type` analytics value, as defined in our schema (artsy/cohesion), for the requested destination
+  # [Analytics] `owner type` analytics value for the requested destination, as defined in our schema (artsy/cohesion)
   ownerType: String
 }
 
 # A user activity section in the home view
 type HomeViewSectionActivity implements HomeViewSectionGeneric & Node {
-  # The component that is prescribed for this section
+  # Component prescription for this section, for overriding or customizing presentation and behavior
   component: HomeViewComponent
 
-  # An analytics context label for this section
+  # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
   contextModule: String!
 
   # A globally unique ID.
@@ -10974,10 +10978,10 @@ type HomeViewSectionArticles implements HomeViewSectionGeneric & Node {
     last: Int
   ): ArticleConnection
 
-  # The component that is prescribed for this section
+  # Component prescription for this section, for overriding or customizing presentation and behavior
   component: HomeViewComponent
 
-  # An analytics context label for this section
+  # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
   contextModule: String!
 
   # A globally unique ID.
@@ -10996,10 +11000,10 @@ type HomeViewSectionArtists implements HomeViewSectionGeneric & Node {
     last: Int
   ): ArtistConnection
 
-  # The component that is prescribed for this section
+  # Component prescription for this section, for overriding or customizing presentation and behavior
   component: HomeViewComponent
 
-  # An analytics context label for this section
+  # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
   contextModule: String!
 
   # A globally unique ID.
@@ -11018,10 +11022,10 @@ type HomeViewSectionArtworks implements HomeViewSectionGeneric & Node {
     last: Int
   ): ArtworkConnection
 
-  # The component that is prescribed for this section
+  # Component prescription for this section, for overriding or customizing presentation and behavior
   component: HomeViewComponent
 
-  # An analytics context label for this section
+  # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
   contextModule: String!
 
   # A globally unique ID.
@@ -11040,10 +11044,10 @@ type HomeViewSectionAuctionResults implements HomeViewSectionGeneric & Node {
     last: Int
   ): AuctionResultConnection
 
-  # The component that is prescribed for this section
+  # Component prescription for this section, for overriding or customizing presentation and behavior
   component: HomeViewComponent
 
-  # An analytics context label for this section
+  # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
   contextModule: String!
 
   # A globally unique ID.
@@ -11055,10 +11059,10 @@ type HomeViewSectionAuctionResults implements HomeViewSectionGeneric & Node {
 
 # A fairs section in the home view
 type HomeViewSectionFairs implements HomeViewSectionGeneric & Node {
-  # The component that is prescribed for this section
+  # Component prescription for this section, for overriding or customizing presentation and behavior
   component: HomeViewComponent
 
-  # An analytics context label for this section
+  # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
   contextModule: String!
   fairsConnection(
     after: String
@@ -11076,10 +11080,10 @@ type HomeViewSectionFairs implements HomeViewSectionGeneric & Node {
 
 # A section containing a list of galleries
 type HomeViewSectionGalleries implements HomeViewSectionGeneric & Node {
-  # The component that is prescribed for this section
+  # Component prescription for this section, for overriding or customizing presentation and behavior
   component: HomeViewComponent
 
-  # An analytics context label for this section
+  # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
   contextModule: String!
 
   # A globally unique ID.
@@ -11091,10 +11095,10 @@ type HomeViewSectionGalleries implements HomeViewSectionGeneric & Node {
 
 # Abstract interface shared by every kind of home view section
 interface HomeViewSectionGeneric {
-  # The component that is prescribed for this section
+  # Component prescription for this section, for overriding or customizing presentation and behavior
   component: HomeViewComponent
 
-  # An analytics context label for this section
+  # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
   contextModule: String!
 
   # A globally unique ID.
@@ -11126,10 +11130,10 @@ type HomeViewSectionGenericEdge {
 
 # A hero units section in the home view
 type HomeViewSectionHeroUnits implements HomeViewSectionGeneric & Node {
-  # The component that is prescribed for this section
+  # Component prescription for this section, for overriding or customizing presentation and behavior
   component: HomeViewComponent
 
-  # An analytics context label for this section
+  # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
   contextModule: String!
   heroUnitsConnection(
     after: String
@@ -11147,10 +11151,10 @@ type HomeViewSectionHeroUnits implements HomeViewSectionGeneric & Node {
 
 # A marketing collections section in the home view
 type HomeViewSectionMarketingCollections implements HomeViewSectionGeneric & Node {
-  # The component that is prescribed for this section
+  # Component prescription for this section, for overriding or customizing presentation and behavior
   component: HomeViewComponent
 
-  # An analytics context label for this section
+  # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
   contextModule: String!
 
   # A globally unique ID.
@@ -11168,10 +11172,10 @@ type HomeViewSectionMarketingCollections implements HomeViewSectionGeneric & Nod
 
 # A sales (auctions) section in the home view
 type HomeViewSectionSales implements HomeViewSectionGeneric & Node {
-  # The component that is prescribed for this section
+  # Component prescription for this section, for overriding or customizing presentation and behavior
   component: HomeViewComponent
 
-  # An analytics context label for this section
+  # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
   contextModule: String!
 
   # A globally unique ID.
@@ -11189,10 +11193,10 @@ type HomeViewSectionSales implements HomeViewSectionGeneric & Node {
 
 # A shows section in the home view
 type HomeViewSectionShows implements HomeViewSectionGeneric & Node {
-  # The component that is prescribed for this section
+  # Component prescription for this section, for overriding or customizing presentation and behavior
   component: HomeViewComponent
 
-  # An analytics context label for this section
+  # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
   contextModule: String!
 
   # A globally unique ID.
@@ -11204,10 +11208,10 @@ type HomeViewSectionShows implements HomeViewSectionGeneric & Node {
 
 # A viewing rooms section in the home view
 type HomeViewSectionViewingRooms implements HomeViewSectionGeneric & Node {
-  # The component that is prescribed for this section
+  # Component prescription for this section, for overriding or customizing presentation and behavior
   component: HomeViewComponent
 
-  # An analytics context label for this section
+  # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
   contextModule: String!
 
   # A globally unique ID.

--- a/src/schema/v2/homeView/HomeViewComponent.ts
+++ b/src/schema/v2/homeView/HomeViewComponent.ts
@@ -14,38 +14,43 @@ const HomeViewComponentBehaviors = new GraphQLObjectType<
   ResolverContext
 >({
   name: "HomeViewComponentBehaviors",
+  description: "Behaviors for this component",
   fields: {
     viewAll: {
       type: new GraphQLObjectType({
         name: "HomeViewComponentBehaviorsViewAll",
+        description: "A specification for this section’s View All behavior",
         fields: {
           buttonText: {
             type: GraphQLString,
-            description: "Text for the CTA of the view all button",
+            description: "Text for the CTA of the View All button",
           },
           href: {
             type: GraphQLString,
-            description: "href of the view all button",
+            description:
+              "`href` of the View All button. When present, will result in a navigation to the specified route. When `null`, will result in the client-side component’s default view-all behavior, e.g. a full-screen modal overlay",
           },
           ownerType: {
             type: GraphQLString,
             description:
-              "[Analytics] `owner type` analytics value, as defined in our schema (artsy/cohesion), for the requested destination",
+              "[Analytics] `owner type` analytics value for the requested destination, as defined in our schema (artsy/cohesion)",
           },
         },
       }),
-      description: "Represents the behavior of the view all button",
+      description: "Represents the behavior of the View All button",
     },
   },
 })
 
 export const HomeViewComponent = new GraphQLObjectType({
   name: "HomeViewComponent",
-  description: "A component specification",
+  description:
+    "A component specification, to allow for customization of presentation and behavior",
   fields: {
     type: {
       type: GraphQLString,
-      description: "How this component should be rendered",
+      description:
+        "The name of the client-side component which should be preferred (when the default component for a given section type is not sufficient)",
       resolve: async (parent, _args, context, _info) => {
         const { type: _type } = parent
 
@@ -77,7 +82,7 @@ export const HomeViewComponent = new GraphQLObjectType({
     },
     description: {
       type: GraphQLString,
-      description: "A description for this section",
+      description: "A description or blurb for this section",
       resolve: async (parent, _args, context, _info) => {
         const { description: _description } = parent
 
@@ -141,7 +146,7 @@ export const HomeViewComponent = new GraphQLObjectType({
     },
     behaviors: {
       type: HomeViewComponentBehaviors,
-      description: "Behaviors for the view",
+      description: "Behaviors for this component",
     },
   },
 })

--- a/src/schema/v2/homeView/HomeViewSection.ts
+++ b/src/schema/v2/homeView/HomeViewSection.ts
@@ -35,11 +35,13 @@ const standardSectionFields: GraphQLFieldConfigMap<any, ResolverContext> = {
   },
   contextModule: {
     type: new GraphQLNonNull(GraphQLString),
-    description: "An analytics context label for this section",
+    description:
+      "[Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)",
   },
   component: {
     type: HomeViewComponent,
-    description: "The component that is prescribed for this section",
+    description:
+      "Component prescription for this section, for overriding or customizing presentation and behavior",
   },
 }
 

--- a/src/schema/v2/homeView/index.ts
+++ b/src/schema/v2/homeView/index.ts
@@ -21,6 +21,7 @@ const SectionsConnectionType = connectionWithCursorInfo({
 
 const SectionConnection: GraphQLFieldConfig<any, ResolverContext> = {
   type: new GraphQLNonNull(SectionsConnectionType),
+  description: "A paginated list of home view sections",
   args: pageable({}),
   resolve: async (_parent, args, context, _info) => {
     const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
@@ -42,7 +43,7 @@ const SectionConnection: GraphQLFieldConfig<any, ResolverContext> = {
 
 export const Section: GraphQLFieldConfig<void, ResolverContext> = {
   type: HomeViewGenericSectionInterface,
-  description: "A home view section",
+  description: "A single home view section, addressed by internal id",
   args: {
     id: {
       description: "The ID of the section",


### PR DESCRIPTION
With an eye towards onboarding the rest of the team soon, I wanted to tighten up some of the inline documentation.

The schema diff here is purely changes to various `description` fields:

<table>
<tr>
  <th>root homeview type</th>
  <th>section types</th>
  <th colspan=3>component types</th>
</tr>
<tr>
  <td><img src="https://github.com/user-attachments/assets/a94c5201-78fb-4cf4-b3ba-d49f0c037a5a" alt="HomeView"/></td>
  <td><img src="https://github.com/user-attachments/assets/0ce0ffdb-0106-4bee-ad2e-2fbafa789b83" alt="HomeViewSectionGeneric"/></td>
  <td><img src="https://github.com/user-attachments/assets/66cf978a-c977-45f0-bf0b-2989892841cd" alt="HomeViewComponent"/></td>
  <td><img src="https://github.com/user-attachments/assets/f8c54bc7-3967-438b-b879-f08538f4609e" alt="HomeViewComponentBehaviors"/></td>
  <td><img src="https://github.com/user-attachments/assets/886777e5-64a9-44d8-b5fe-3694eb1e7df0" alt="HomeViewComponentBehaviorsViewAll"/></td>
</tr>
</table>
