### PR TITLE
fix: ended_at sales are closed

### DIFF
--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -51,11 +51,13 @@ const AuctionCollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
     const lotClosesAt =
       !activeLotData.sale.live_start_at &&
       (activeLotData.saleArtwork.extended_bidding_end_at ||
-        activeLotData.saleArtwork.end_at ||
-        activeLotData.sale.ended_at)
+        activeLotData.saleArtwork.end_at)
 
     // If the lot is closed for bidding, return null
-    if (lotClosesAt && new Date(lotClosesAt) <= new Date()) {
+    if (
+      !!activeLotData.sale.ended_at ||
+      (lotClosesAt && new Date(lotClosesAt) <= new Date())
+    ) {
       return null
     }
 


### PR DESCRIPTION
#minor 

At first I thought this might be a bigger issue but on looking I think this change is pretty immaterial - basically if the sale is ended, we don't need to check if it is in the past since that value's existence implies that it is in the past. In addition, the query we use right above these lines is for only active sales - so this code should actually never apply at all.