### PR TITLE
chore(analytics): small fix for RecommendedArtworks contextModule value

### DIFF
--- a/src/schema/v2/homeView/sections/RecommendedArtworks.ts
+++ b/src/schema/v2/homeView/sections/RecommendedArtworks.ts
@@ -7,7 +7,7 @@ import { ArtworkRecommendations } from "schema/v2/me/artworkRecommendations"
 export const RecommendedArtworks: HomeViewSection = {
   id: "home-view-section-recommended-artworks",
   type: HomeViewSectionTypeNames.HomeViewSectionArtworks,
-  contextModule: ContextModule.recommendedArtistsRail,
+  contextModule: ContextModule.artworkRecommendationsRail,
   component: {
     title: "Artwork Recommendations",
     behaviors: {


### PR DESCRIPTION
This was mistakenly set to `recommendedArtistsRail`.