### PR TITLE
feat: expose Gravity's viewingRoomsConnection to replace deprecated viewingRooms query

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15963,27 +15963,6 @@ type Query {
     last: Int
     userId: ID!
   ): UserAddressConnection
-
-  # List viewing rooms
-  _unused_gravity_viewingRoomsConnection(
-    # Returns the elements in the list that come after the specified cursor.
-    after: String
-
-    # Returns the elements in the list that come before the specified cursor.
-    before: String
-    featured: Boolean
-
-    # Returns the first _n_ elements from the list.
-    first: Int
-    ids: [ID!]
-
-    # Returns the last _n_ elements from the list.
-    last: Int
-    partnerID: ID
-
-    # Returns only viewing rooms with these statuses
-    statuses: [ViewingRoomStatusEnum!] = [live]
-  ): ViewingRoomsConnection
   admin: Admin
 
   # Find an agreement by ID
@@ -17257,6 +17236,27 @@ type Query {
     # Returns only viewing rooms with these statuses
     statuses: [ViewingRoomStatusEnum!] = [live]
   ): ViewingRoomConnection @deprecated(reason: "Use viewingRoomsConnection")
+
+  # List viewing rooms
+  viewingRoomsConnection(
+    # Returns the elements in the list that come after the specified cursor.
+    after: String
+
+    # Returns the elements in the list that come before the specified cursor.
+    before: String
+    featured: Boolean
+
+    # Returns the first _n_ elements from the list.
+    first: Int
+    ids: [ID!]
+
+    # Returns the last _n_ elements from the list.
+    last: Int
+    partnerID: ID
+
+    # Returns only viewing rooms with these statuses
+    statuses: [ViewingRoomStatusEnum!] = [live]
+  ): ViewingRoomsConnection
 }
 
 type Quiz {

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -466,7 +466,7 @@ describe("gravity/stitching", () => {
       expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
         args: { partnerID: "partner-id", first: 2 },
         operation: "query",
-        fieldName: "_unused_gravity_viewingRoomsConnection",
+        fieldName: "viewingRoomsConnection",
         schema: expect.anything(),
         context: expect.anything(),
         info: expect.anything(),
@@ -497,7 +497,7 @@ describe("gravity/stitching", () => {
       expect(info.mergeInfo.delegateToSchema).toHaveBeenCalledWith({
         args: { ids: ["view-lots-of-cats-id"] },
         operation: "query",
-        fieldName: "_unused_gravity_viewingRoomsConnection",
+        fieldName: "viewingRoomsConnection",
         schema: expect.anything(),
         context: expect.anything(),
         info: expect.anything(),

--- a/src/lib/stitching/gravity/schema.ts
+++ b/src/lib/stitching/gravity/schema.ts
@@ -8,7 +8,12 @@ import {
 } from "graphql-tools"
 import { readFileSync } from "fs"
 
-const rootFieldsAllowList = ["agreement", "viewingRoom", "viewingRooms"]
+const rootFieldsAllowList = [
+  "agreement",
+  "viewingRoom",
+  "viewingRooms",
+  "viewingRoomsConnection",
+]
 
 export const executableGravitySchema = () => {
   const gravityTypeDefs = readFileSync("src/data/gravity.graphql", "utf8")

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -179,7 +179,7 @@ export const gravityStitchingEnvironment = (
             return info.mergeInfo.delegateToSchema({
               schema: gravitySchema,
               operation: "query",
-              fieldName: "_unused_gravity_viewingRoomsConnection",
+              fieldName: "viewingRoomsConnection",
               args: {
                 partnerID,
                 ...args,
@@ -203,7 +203,7 @@ export const gravityStitchingEnvironment = (
             return info.mergeInfo.delegateToSchema({
               schema: gravitySchema,
               operation: "query",
-              fieldName: "_unused_gravity_viewingRoomsConnection",
+              fieldName: "viewingRoomsConnection",
               args: {
                 ids,
               },
@@ -428,7 +428,7 @@ export const gravityStitchingEnvironment = (
             return info.mergeInfo.delegateToSchema({
               schema: gravitySchema,
               operation: "query",
-              fieldName: "_unused_gravity_viewingRoomsConnection",
+              fieldName: "viewingRoomsConnection",
               args: {
                 ...args,
                 ids,
@@ -449,7 +449,7 @@ export const gravityStitchingEnvironment = (
             return info.mergeInfo.delegateToSchema({
               schema: gravitySchema,
               operation: "query",
-              fieldName: "_unused_gravity_viewingRoomsConnection",
+              fieldName: "viewingRoomsConnection",
               args,
               context,
               info,


### PR DESCRIPTION
I've finally started working on viewing rooms un-stitching! One weird thing I've noticed is that there are "duplicates" of connection definitions coming from Gravity: [ViewingRoomConnection](https://github.com/artsy/metaphysics/blob/9271468efc011386216fc146580306a3148f82d2/_schemaV2.graphql#L21822) and [ViewingRoomEdge](https://github.com/artsy/metaphysics/blob/9271468efc011386216fc146580306a3148f82d2/_schemaV2.graphql#L21837) vs [ViewingRoomsConnection](https://github.com/artsy/metaphysics/blob/9271468efc011386216fc146580306a3148f82d2/_schemaV2.graphql#L21905) and [ViewingRoomsEdge](https://github.com/artsy/metaphysics/blob/9271468efc011386216fc146580306a3148f82d2/_schemaV2.graphql#L21920) (last two are plural). First two come from [here](https://github.com/artsy/gravity/blob/7e77d2096fcf96167728eef950f3d846f4f69c95/app/graphql/types/query_type.rb#L88) and they are deprecated.

I want to simplify my life and instead of re-defining deprecated types on Metaphysics side - switch clients to use `viewingRoomsConnection` and kill old `viewingRooms` query. This PR exposes `viewingRoomsConnection` which was missing in Metaphysics before. 

P.S. implementations of `viewingRooms` and `viewingRoomsConnection` seem almost identical, I've made a small change to sync them here: https://github.com/artsy/gravity/pull/18162