### PR TITLE
feat: allow filtering home view sections by zone ID

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10899,6 +10899,9 @@ type HomeView {
     before: String
     first: Int
     last: Int
+
+    # The ID of the zone to fetch sections for
+    zoneID: String
   ): HomeViewSectionGenericConnection!
 }
 

--- a/src/schema/v2/homeView/__tests__/HomeView.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeView.test.ts
@@ -4,17 +4,17 @@ import { ResolverContext } from "types/graphql"
 
 describe("homeView", () => {
   describe("sectionsConnection", () => {
-    const query = gql`
+    const getQuery = (zoneID?: string) => gql`
       {
         homeView {
-          sectionsConnection(first: 20) {
+          sectionsConnection(first: 20${
+            zoneID ? `, zoneID: "${zoneID}"` : ""
+          }) {
             edges {
               node {
                 __typename
-                ... on HomeViewSectionGeneric {
-                  component {
-                    title
-                  }
+                component {
+                  title
                 }
               }
             }
@@ -31,7 +31,7 @@ describe("homeView", () => {
       }
 
       it("returns the correct sections", async () => {
-        const { homeView } = await runQuery(query, context)
+        const { homeView } = await runQuery(getQuery(), context)
 
         expect(homeView.sectionsConnection).toMatchInlineSnapshot(`
           Object {
@@ -129,7 +129,7 @@ describe("homeView", () => {
       }
 
       it("returns the correct sections", async () => {
-        const { homeView } = await runQuery(query, context)
+        const { homeView } = await runQuery(getQuery(), context)
 
         expect(homeView.sectionsConnection).toMatchInlineSnapshot(`
           Object {
@@ -281,6 +281,111 @@ describe("homeView", () => {
                   "__typename": "HomeViewSectionViewingRooms",
                   "component": Object {
                     "title": "Viewing Rooms",
+                  },
+                },
+              },
+              Object {
+                "node": Object {
+                  "__typename": "HomeViewSectionShows",
+                  "component": Object {
+                    "title": "Shows for You",
+                  },
+                },
+              },
+            ],
+          }
+        `)
+      })
+    })
+
+    describe("specifying zone ID", () => {
+      const context: Partial<ResolverContext> = {
+        accessToken: "424242",
+      }
+
+      it("returns the correct sections", async () => {
+        const { homeView } = await runQuery(getQuery("next"), context)
+
+        expect(homeView.sectionsConnection).toMatchInlineSnapshot(`
+          Object {
+            "edges": Array [
+              Object {
+                "node": Object {
+                  "__typename": "HomeViewSectionActivity",
+                  "component": Object {
+                    "title": "Latest Activity",
+                  },
+                },
+              },
+              Object {
+                "node": Object {
+                  "__typename": "HomeViewSectionArtworks",
+                  "component": Object {
+                    "title": "New works for You",
+                  },
+                },
+              },
+              Object {
+                "node": Object {
+                  "__typename": "HomeViewSectionArtworks",
+                  "component": Object {
+                    "title": "Your Active Bids",
+                  },
+                },
+              },
+              Object {
+                "node": Object {
+                  "__typename": "HomeViewSectionArtworks",
+                  "component": Object {
+                    "title": "Auction lots for You",
+                  },
+                },
+              },
+              Object {
+                "node": Object {
+                  "__typename": "HomeViewSectionAuctionResults",
+                  "component": Object {
+                    "title": "Latest Auction Results",
+                  },
+                },
+              },
+              Object {
+                "node": Object {
+                  "__typename": "HomeViewSectionArtworks",
+                  "component": Object {
+                    "title": "Artwork Recommendations",
+                  },
+                },
+              },
+              Object {
+                "node": Object {
+                  "__typename": "HomeViewSectionArtworks",
+                  "component": Object {
+                    "title": "New Works from Galleries You Follow",
+                  },
+                },
+              },
+              Object {
+                "node": Object {
+                  "__typename": "HomeViewSectionArtists",
+                  "component": Object {
+                    "title": "Recommended Artists",
+                  },
+                },
+              },
+              Object {
+                "node": Object {
+                  "__typename": "HomeViewSectionArtworks",
+                  "component": Object {
+                    "title": "Recently Viewed",
+                  },
+                },
+              },
+              Object {
+                "node": Object {
+                  "__typename": "HomeViewSectionArtworks",
+                  "component": Object {
+                    "title": "Similar to Works You’ve Viewed",
                   },
                 },
               },

--- a/src/schema/v2/homeView/helpers/getSectionsForUser.ts
+++ b/src/schema/v2/homeView/helpers/getSectionsForUser.ts
@@ -1,14 +1,26 @@
 import { ResolverContext } from "types/graphql"
-import { getLegacyZoneSections } from "../zones/legacy"
+import { getSections as getDiscoverySections } from "../zones/discovery"
+import { getSections as getNextSections } from "../zones/next"
+import { getSections as getLegacySections } from "../zones/legacy"
 import { HomeViewSection } from "../sections/"
 
-export async function getSectionsForUser(
-  context: ResolverContext
-): Promise<HomeViewSection[]> {
-  const legacyZoneSections = await getLegacyZoneSections(context)
+const zones = {
+  legacy: getLegacySections,
+  next: getNextSections,
+  discovery: getDiscoverySections,
+}
 
-  return [
-    ...legacyZoneSections,
-    // other zones’ sections TK
-  ]
+export async function getSectionsForUser(
+  context: ResolverContext,
+  zoneID = "legacy"
+): Promise<HomeViewSection[]> {
+  const getSections = zones[zoneID]
+
+  if (!getSections) {
+    throw new Error(`Unknown zone ID: ${zoneID}`)
+  }
+
+  const sections = await getSections(context)
+
+  return sections
 }

--- a/src/schema/v2/homeView/index.ts
+++ b/src/schema/v2/homeView/index.ts
@@ -22,11 +22,16 @@ const SectionsConnectionType = connectionWithCursorInfo({
 const SectionConnection: GraphQLFieldConfig<any, ResolverContext> = {
   type: new GraphQLNonNull(SectionsConnectionType),
   description: "A paginated list of home view sections",
-  args: pageable({}),
+  args: pageable({
+    zoneID: {
+      type: GraphQLString,
+      description: "The ID of the zone to fetch sections for",
+    },
+  }),
   resolve: async (_parent, args, context, _info) => {
     const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
 
-    const sections = await getSectionsForUser(context)
+    const sections = await getSectionsForUser(context, args.zoneID)
     const totalCount = sections.length
     const data = sections.slice(offset, offset + size)
 

--- a/src/schema/v2/homeView/zones/__tests__/discovery.test.ts
+++ b/src/schema/v2/homeView/zones/__tests__/discovery.test.ts
@@ -1,5 +1,5 @@
 import { ResolverContext } from "types/graphql"
-import { getSections } from "../legacy"
+import { getSections } from "../discovery"
 
 describe("getSections", () => {
   describe("with an authenticated user", () => {
@@ -13,24 +13,14 @@ describe("getSections", () => {
 
       expect(sectionIds).toMatchInlineSnapshot(`
         Array [
-          "home-view-section-latest-activity",
-          "home-view-section-new-works-for-you",
           "home-view-section-hero-units",
-          "home-view-section-active-bids",
-          "home-view-section-auction-lots-for-you",
           "home-view-section-auctions",
-          "home-view-section-latest-auction-results",
           "home-view-section-galleries-near-you",
           "home-view-section-latest-articles",
           "home-view-section-news",
           "home-view-section-curators-picks-emerging",
           "home-view-section-marketing-collections",
-          "home-view-section-recommended-artworks",
-          "home-view-section-new-works-from-galleries-you-follow",
-          "home-view-section-recommended-artists",
           "home-view-section-trending-artists",
-          "home-view-section-recently-viewed-artworks",
-          "home-view-section-similar-to-recently-viewed-artworks",
           "home-view-section-viewing-rooms",
           "home-view-section-shows-for-you",
           "home-view-section-featured-fairs",

--- a/src/schema/v2/homeView/zones/__tests__/next.test.ts
+++ b/src/schema/v2/homeView/zones/__tests__/next.test.ts
@@ -1,0 +1,31 @@
+import { ResolverContext } from "types/graphql"
+import { getSections } from "../next"
+
+describe("getSections", () => {
+  describe("with an authenticated user", () => {
+    it("returns the correct sections", async () => {
+      const context: Partial<ResolverContext> = {
+        accessToken: "some-token",
+      }
+
+      const sections = await getSections(context as ResolverContext)
+      const sectionIds = sections.map((section) => section.id)
+
+      expect(sectionIds).toMatchInlineSnapshot(`
+        Array [
+          "home-view-section-latest-activity",
+          "home-view-section-new-works-for-you",
+          "home-view-section-active-bids",
+          "home-view-section-auction-lots-for-you",
+          "home-view-section-latest-auction-results",
+          "home-view-section-recommended-artworks",
+          "home-view-section-new-works-from-galleries-you-follow",
+          "home-view-section-recommended-artists",
+          "home-view-section-recently-viewed-artworks",
+          "home-view-section-similar-to-recently-viewed-artworks",
+          "home-view-section-shows-for-you",
+        ]
+      `)
+    })
+  })
+})

--- a/src/schema/v2/homeView/zones/discovery.ts
+++ b/src/schema/v2/homeView/zones/discovery.ts
@@ -1,0 +1,42 @@
+import { ResolverContext } from "types/graphql"
+import { HomeViewSection } from "schema/v2/homeView/sections"
+import { GalleriesNearYou } from "../sections/GalleriesNearYou"
+import { Auctions } from "../sections/Auctions"
+import { LatestArticles } from "../sections/LatestArticles"
+import { News } from "../sections/News"
+import { ViewingRooms } from "../sections/ViewingRooms"
+import { ShowsForYou } from "../sections/ShowsForYou"
+import { MarketingCollections } from "../sections/MarketingCollections"
+import { FeaturedFairs } from "../sections/FeaturedFairs"
+import { HeroUnits } from "../sections/HeroUnits"
+import { TrendingArtists } from "../sections/TrendingArtists"
+import { CuratorsPicksEmerging } from "../sections/CuratorsPicksEmerging"
+
+const SECTIONS: HomeViewSection[] = [
+  HeroUnits,
+  Auctions,
+  GalleriesNearYou,
+  LatestArticles,
+  News,
+  CuratorsPicksEmerging,
+  MarketingCollections,
+  TrendingArtists,
+  ViewingRooms,
+  ShowsForYou,
+  FeaturedFairs,
+]
+
+export async function getSections(context: ResolverContext) {
+  const isAuthenticatedUser = !!context.accessToken
+
+  const displayableSections = SECTIONS.reduce((sections, section) => {
+    const isDisplayable =
+      section.requiresAuthentication === false || // public content, or
+      (section.requiresAuthentication && isAuthenticatedUser) // user-specific content
+
+    if (isDisplayable) sections.push(section)
+    return sections
+  }, [] as HomeViewSection[])
+
+  return displayableSections
+}

--- a/src/schema/v2/homeView/zones/legacy.ts
+++ b/src/schema/v2/homeView/zones/legacy.ts
@@ -46,7 +46,7 @@ const LEGACY_ZONE_SECTIONS: HomeViewSection[] = [
   FeaturedFairs,
 ]
 
-export async function getLegacyZoneSections(context: ResolverContext) {
+export async function getSections(context: ResolverContext) {
   const isAuthenticatedUser = !!context.accessToken
 
   const displayableSections = LEGACY_ZONE_SECTIONS.reduce(

--- a/src/schema/v2/homeView/zones/next.ts
+++ b/src/schema/v2/homeView/zones/next.ts
@@ -1,0 +1,42 @@
+import { ActiveBids } from "../sections/ActiveBids"
+import { AuctionLotsForYou } from "../sections/AuctionLotsForYou"
+import { HomeViewSection } from "schema/v2/homeView/sections"
+import { LatestActivity } from "../sections/LatestActivity"
+import { LatestAuctionResults } from "../sections/LatestAuctionResults"
+import { NewWorksForYou } from "../sections/NewWorksForYou"
+import { NewWorksFromGalleriesYouFollow } from "../sections/NewWorksFromGalleriesYouFollow"
+import { RecentlyViewedArtworks } from "../sections/RecentlyViewedArtworks"
+import { RecommendedArtists } from "../sections/RecommendedArtists"
+import { RecommendedArtworks } from "../sections/RecommendedArtworks"
+import { ResolverContext } from "types/graphql"
+import { SimilarToRecentlyViewedArtworks } from "../sections/SimilarToRecentlyViewedArtworks"
+import { ShowsForYou } from "../sections/ShowsForYou"
+
+const SECTIONS: HomeViewSection[] = [
+  LatestActivity,
+  NewWorksForYou,
+  ActiveBids,
+  AuctionLotsForYou,
+  LatestAuctionResults,
+  RecommendedArtworks,
+  NewWorksFromGalleriesYouFollow,
+  RecommendedArtists,
+  RecentlyViewedArtworks,
+  SimilarToRecentlyViewedArtworks,
+  ShowsForYou,
+]
+
+export async function getSections(context: ResolverContext) {
+  const isAuthenticatedUser = !!context.accessToken
+
+  const displayableSections = SECTIONS.reduce((sections, section) => {
+    const isDisplayable =
+      section.requiresAuthentication === false || // public content, or
+      (section.requiresAuthentication && isAuthenticatedUser) // user-specific content
+
+    if (isDisplayable) sections.push(section)
+    return sections
+  }, [] as HomeViewSection[])
+
+  return displayableSections
+}


### PR DESCRIPTION
feat: allow filtering home view sections by zone ID



```graphql
{
  homeView {
    sectionsConnection(first: 10, zoneID: "next") {
       ... snip ...
    }
  }
}
```