### PR TITLE
fix: remove redundant CI dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,6 @@ workflows:
           <<: *only_main
           context: hokusai
           requires:
-            - push-staging-image
             - deploy-staging
 
       - node/run:
@@ -126,7 +125,6 @@ workflows:
           pkg-manager: yarn
           yarn-run: deploy-cloudflare-workers:staging
           requires:
-            - push-staging-image
             - deploy-staging
 
       # release


### PR DESCRIPTION
This removes a redundant dependency in the CI graph, but doesn't have any practical effect.

<img width="1427" alt="Screenshot 2024-09-19 at 12 18 07 PM" src="https://github.com/user-attachments/assets/3dcdf319-a5e2-44f2-bd82-9106732c4efd">
