### PR TITLE
fix: dont crash if requesting followedArtists count w/o followed artist agg specified

### DIFF
--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -87,7 +87,7 @@ export const FilterArtworksCounts = {
     fields: {
       total: numeral(({ aggregations }) => aggregations.total.value),
       followedArtists: numeral(
-        ({ aggregations }) => aggregations.followed_artists.value
+        ({ aggregations }) => aggregations.followed_artists?.value
       ),
     },
   }),


### PR DESCRIPTION
Noticing this lil one, it crashes when the value isn't available.