### PR TITLE
feat(homeView): add a feature-flagging pattern for home view sections

### DIFF
--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -12,6 +12,7 @@ const FEATURE_FLAGS_LIST = [
   "diamond_blurhash-enabled-globally",
   "emerald_signals-partner-offers",
   "emerald_signals-auction-improvements",
+  "onyx_enable-home-view-section-featured-fairs",
 ] as const
 
 type FeatureFlag = typeof FEATURE_FLAGS_LIST[number]

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -15,7 +15,7 @@ const FEATURE_FLAGS_LIST = [
   "onyx_enable-home-view-section-featured-fairs",
 ] as const
 
-type FeatureFlag = typeof FEATURE_FLAGS_LIST[number]
+export type FeatureFlag = typeof FEATURE_FLAGS_LIST[number]
 
 let unleashClient: Unleash
 

--- a/src/schema/v2/homeView/__tests__/HomeView.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeView.test.ts
@@ -2,6 +2,12 @@ import gql from "lib/gql"
 import { runQuery } from "schema/v2/test/utils"
 import { ResolverContext } from "types/graphql"
 
+jest.mock("lib/featureFlags", () => ({
+  isFeatureFlagEnabled: jest.fn((flag: string) => {
+    return !!flag.match("enable-home-view-section")
+  }),
+}))
+
 describe("homeView", () => {
   describe("sectionsConnection", () => {
     const query = gql`

--- a/src/schema/v2/homeView/__tests__/HomeView.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeView.test.ts
@@ -327,7 +327,7 @@ describe("homeView", () => {
 
         it("throws an error", async () => {
           await expect(runQuery(query, context)).rejects.toThrow(
-            "Section requires authenticated user"
+            "Section requires authorized user"
           )
         })
       })

--- a/src/schema/v2/homeView/helpers/isSectionDisplayable.ts
+++ b/src/schema/v2/homeView/helpers/isSectionDisplayable.ts
@@ -1,0 +1,31 @@
+import { ResolverContext } from "types/graphql"
+import { HomeViewSection } from "../sections"
+import { isFeatureFlagEnabled } from "lib/featureFlags"
+
+/**
+ * Determine if an individual section can be displayed, considering the current
+ * context, session, feature flags, etc.
+ */
+export function isSectionDisplayable(
+  section: HomeViewSection,
+  context: ResolverContext
+): boolean {
+  // public content
+  const isPublicSection = section.requiresAuthentication === false
+
+  // personalized content
+  const isAuthenticatedUser = !!context.accessToken
+  const isValidPersonalizedSection =
+    section.requiresAuthentication && isAuthenticatedUser
+
+  let isDisplayable = isPublicSection || isValidPersonalizedSection
+
+  // feature flags
+  if (isDisplayable && section.featureFlag) {
+    isDisplayable = isFeatureFlagEnabled(section.featureFlag, {
+      userId: context.userID,
+    })
+  }
+
+  return isDisplayable
+}

--- a/src/schema/v2/homeView/index.ts
+++ b/src/schema/v2/homeView/index.ts
@@ -14,6 +14,7 @@ import {
 import { HomeViewGenericSectionInterface } from "./HomeViewSection"
 import { getSectionsForUser } from "./helpers/getSectionsForUser"
 import { registry } from "./sections"
+import { isSectionDisplayable } from "./helpers/isSectionDisplayable"
 
 const SectionsConnectionType = connectionWithCursorInfo({
   nodeType: HomeViewGenericSectionInterface,
@@ -53,14 +54,13 @@ export const Section: GraphQLFieldConfig<void, ResolverContext> = {
   resolve: (_parent, args, context, _info) => {
     const { id } = args
     const section = registry[id]
-    const userIsAuthenticated = !!context.accessToken
 
     if (!section) {
       throw new Error(`Section not found: ${id}`)
     }
 
-    if (section.requiresAuthentication && !userIsAuthenticated) {
-      throw new Error(`Section requires authenticated user: ${id}`)
+    if (!isSectionDisplayable(section, context)) {
+      throw new Error(`Section requires authorized user: ${id}`)
     }
 
     return section

--- a/src/schema/v2/homeView/sections/FeaturedFairs.ts
+++ b/src/schema/v2/homeView/sections/FeaturedFairs.ts
@@ -13,6 +13,7 @@ export const FeaturedFairs: HomeViewSection = {
     title: "Featured Fairs",
     description: "See Works in Top Art Fairs",
   },
+  featureFlag: "onyx_enable-home-view-section-featured-fairs",
   requiresAuthentication: false,
 
   resolver: withHomeViewTimeout(async (parent, args, context, info) => {

--- a/src/schema/v2/homeView/sections/index.ts
+++ b/src/schema/v2/homeView/sections/index.ts
@@ -24,6 +24,7 @@ import { News } from "./News"
 import { LatestArticles } from "./LatestArticles"
 import { Auctions } from "./Auctions"
 import { GalleriesNearYou } from "./GalleriesNearYou"
+import { FeatureFlag } from "lib/featureFlags"
 
 type MaybeResolved<T> =
   | T
@@ -32,7 +33,7 @@ type MaybeResolved<T> =
 export type HomeViewSection = {
   id: string
   contextModule: ContextModule
-  type: keyof typeof HomeViewSectionTypeNames
+  featureFlag?: FeatureFlag
   component?: {
     title?: MaybeResolved<string>
     type?: string
@@ -43,6 +44,7 @@ export type HomeViewSection = {
   ownerType?: OwnerType
   requiresAuthentication: boolean
   resolver?: GraphQLFieldResolver<any, ResolverContext>
+  type: keyof typeof HomeViewSectionTypeNames
 }
 
 const sections: HomeViewSection[] = [

--- a/src/schema/v2/homeView/zones/legacy.ts
+++ b/src/schema/v2/homeView/zones/legacy.ts
@@ -21,6 +21,7 @@ import { AuctionLotsForYou } from "../sections/AuctionLotsForYou"
 import { RecentlyViewedArtworks } from "../sections/RecentlyViewedArtworks"
 import { CuratorsPicksEmerging } from "../sections/CuratorsPicksEmerging"
 import { SimilarToRecentlyViewedArtworks } from "../sections/SimilarToRecentlyViewedArtworks"
+import { isFeatureFlagEnabled } from "lib/featureFlags"
 
 const LEGACY_ZONE_SECTIONS: HomeViewSection[] = [
   LatestActivity,
@@ -75,7 +76,12 @@ function isDisplayable(section: HomeViewSection, context: ResolverContext) {
     section.requiresAuthentication && isAuthenticatedUser
 
   // feature flagged sections
-  // TKTK
+  if (section.id === "home-view-section-featured-fairs") {
+    return isFeatureFlagEnabled(
+      "onyx_enable-home-view-section-featured-fairs",
+      { userId: context.userID }
+    )
+  }
 
   return isPublicSection || isValidPersonalizedSection
 }

--- a/src/schema/v2/homeView/zones/legacy.ts
+++ b/src/schema/v2/homeView/zones/legacy.ts
@@ -63,7 +63,7 @@ export async function getLegacyZoneSections(context: ResolverContext) {
 }
 
 /**
- * Determine if an individual section can displayed, consdering the current
+ * Determine if an individual section can be displayed, considering the current
  * context, session, feature flags, etc.
  */
 function isDisplayable(section: HomeViewSection, context: ResolverContext) {

--- a/src/schema/v2/homeView/zones/legacy.ts
+++ b/src/schema/v2/homeView/zones/legacy.ts
@@ -46,20 +46,36 @@ const LEGACY_ZONE_SECTIONS: HomeViewSection[] = [
   FeaturedFairs,
 ]
 
+/**
+ * Assemble the list of sections that can be displayed
+ */
 export async function getLegacyZoneSections(context: ResolverContext) {
-  const isAuthenticatedUser = !!context.accessToken
+  const displayableSections: HomeViewSection[] = []
 
-  const displayableSections = LEGACY_ZONE_SECTIONS.reduce(
-    (sections, section) => {
-      const isDisplayable =
-        section.requiresAuthentication === false || // public content, or
-        (section.requiresAuthentication && isAuthenticatedUser) // user-specific content
-
-      if (isDisplayable) sections.push(section)
-      return sections
-    },
-    [] as HomeViewSection[]
-  )
+  LEGACY_ZONE_SECTIONS.forEach((section) => {
+    if (isDisplayable(section, context)) {
+      displayableSections.push(section)
+    }
+  })
 
   return displayableSections
+}
+
+/**
+ * Determine if an individual section can displayed, consdering the current
+ * context, session, feature flags, etc.
+ */
+function isDisplayable(section: HomeViewSection, context: ResolverContext) {
+  // public content
+  const isPublicSection = section.requiresAuthentication === false
+
+  // personalized content
+  const isAuthenticatedUser = !!context.accessToken
+  const isValidPersonalizedSection =
+    section.requiresAuthentication && isAuthenticatedUser
+
+  // feature flagged sections
+  // TKTK
+
+  return isPublicSection || isValidPersonalizedSection
 }

--- a/src/schema/v2/homeView/zones/legacy.ts
+++ b/src/schema/v2/homeView/zones/legacy.ts
@@ -21,7 +21,7 @@ import { AuctionLotsForYou } from "../sections/AuctionLotsForYou"
 import { RecentlyViewedArtworks } from "../sections/RecentlyViewedArtworks"
 import { CuratorsPicksEmerging } from "../sections/CuratorsPicksEmerging"
 import { SimilarToRecentlyViewedArtworks } from "../sections/SimilarToRecentlyViewedArtworks"
-import { isFeatureFlagEnabled } from "lib/featureFlags"
+import { isSectionDisplayable } from "../helpers/isSectionDisplayable"
 
 const LEGACY_ZONE_SECTIONS: HomeViewSection[] = [
   LatestActivity,
@@ -54,35 +54,10 @@ export async function getLegacyZoneSections(context: ResolverContext) {
   const displayableSections: HomeViewSection[] = []
 
   LEGACY_ZONE_SECTIONS.forEach((section) => {
-    if (isDisplayable(section, context)) {
+    if (isSectionDisplayable(section, context)) {
       displayableSections.push(section)
     }
   })
 
   return displayableSections
-}
-
-/**
- * Determine if an individual section can be displayed, considering the current
- * context, session, feature flags, etc.
- */
-function isDisplayable(section: HomeViewSection, context: ResolverContext) {
-  // public content
-  const isPublicSection = section.requiresAuthentication === false
-
-  // personalized content
-  const isAuthenticatedUser = !!context.accessToken
-  const isValidPersonalizedSection =
-    section.requiresAuthentication && isAuthenticatedUser
-
-  let isDisplayable = isPublicSection || isValidPersonalizedSection
-
-  // feature flags
-  if (isDisplayable && section.featureFlag) {
-    isDisplayable = isFeatureFlagEnabled(section.featureFlag, {
-      userId: context.userID,
-    })
-  }
-
-  return isDisplayable
 }

--- a/src/schema/v2/homeView/zones/legacy.ts
+++ b/src/schema/v2/homeView/zones/legacy.ts
@@ -75,13 +75,14 @@ function isDisplayable(section: HomeViewSection, context: ResolverContext) {
   const isValidPersonalizedSection =
     section.requiresAuthentication && isAuthenticatedUser
 
-  // feature flagged sections
-  if (section.id === "home-view-section-featured-fairs") {
-    return isFeatureFlagEnabled(
-      "onyx_enable-home-view-section-featured-fairs",
-      { userId: context.userID }
-    )
+  let isDisplayable = isPublicSection || isValidPersonalizedSection
+
+  // feature flags
+  if (isDisplayable && section.featureFlag) {
+    isDisplayable = isFeatureFlagEnabled(section.featureFlag, {
+      userId: context.userID,
+    })
   }
 
-  return isPublicSection || isValidPersonalizedSection
+  return isDisplayable
 }


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-1311

This PR adds a pattern for selectively enabling home view sections via Unleash flags. Those flags can take advantage of the usual Unleash capabilities, such as constraining to set of specific user IDs.

I have created a [`onyx_enable-home-view-section-featured-fairs`](https://unleash.artsy.net/projects/default/features/onyx_enable-home-view-section-featured-fairs) flag which controls the actual `FeaturedFairs` home view section in this PR. 

That one was [cited](https://www.figma.com/board/kgm28u8rZLh3EfznOuOYSe/Homefeed-Versions?node-id=310-704&node-type=table&t=QtUKndCidPTPMG47-0) as a section whose fate is TBD, so seemed like a good enough guinea pig for this pattern. And may give us some early insight into any latency concerns re: checking the flag on every `homeView.sectionsConnection` request.

(We can also replace that with the first "real" feature-flagged section that emerges from one of the product teams.)

