### PR TITLE
feat(AMBER-1036): Create mutation to generate artworks eligibility report

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5561,6 +5561,54 @@ type CommerceOptInMutationPayload {
 
 union CommerceOptInMutationType = CommerceOptInFailure | CommerceOptInSuccess
 
+type CommerceOptInReportFailure {
+  mutationError: GravityMutationError
+}
+
+input CommerceOptInReportMutationInput {
+  # whether it should be updated to CoA
+  certificateOfAuthenticity: Boolean
+  clientMutationId: String
+
+  # whether or not the CoA is by an authenticating body
+  coaByAuthenticatingBody: Boolean
+
+  # whether or not the CoA is by the gallery
+  coaByGallery: Boolean
+
+  # whether the report will contain data for eligible or non-eligible artworks.
+  eligible: Boolean
+
+  # whether or not the artworks should be set to exact price
+  exactPrice: Boolean
+
+  # whether or not it should be set to framed
+  framed: Boolean
+
+  # ID of the partner
+  id: String!
+
+  # whether or not pick up should be available
+  pickupAvailable: Boolean
+}
+
+type CommerceOptInReportMutationPayload {
+  clientMutationId: String
+  commerceOptInReportMutationOrError: CommerceOptInReportMutationType
+}
+
+union CommerceOptInReportMutationType =
+    CommerceOptInReportFailure
+  | CommerceOptInReportSuccess
+
+type CommerceOptInReportResponse {
+  message: String
+}
+
+type CommerceOptInReportSuccess {
+  createdCommerceOptInReport: CommerceOptInReportResponse
+}
+
 type CommerceOptInResponse {
   count: Int
   ids: [String]
@@ -13251,6 +13299,11 @@ type Mutation {
   commerceOptIn(
     input: CommerceOptInMutationInput!
   ): CommerceOptInMutationPayload
+
+  # Generate CommerceOptIn report about artworks eligibility for a given partner
+  commerceOptInReport(
+    input: CommerceOptInReportMutationInput!
+  ): CommerceOptInReportMutationPayload
 
   # Selects an ARTA shipping option for an order, updating the LineItem#selected_shipping_quote_id.
   commerceSelectShippingOption(

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -61,11 +61,6 @@ export default (accessToken, userID, opts) => {
       { headers: true }
     ),
     collectorProfileSummaryLoader: gravityLoader("collector_profile_summary"),
-    optInArtworksIntoCommerceLoader: gravityLoader(
-      (id) => `partner/${id}/opt_in_artworks_into_commerce`,
-      {},
-      { method: "PUT" }
-    ),
     createAccountRequestLoader: gravityLoader(
       "account_requests",
       {},
@@ -74,6 +69,11 @@ export default (accessToken, userID, opts) => {
     createArtistLoader: gravityLoader("artist", {}, { method: "POST" }),
     createArtistCareerHighlightLoader: gravityLoader(
       "artist_career_highlight",
+      {},
+      { method: "POST" }
+    ),
+    createCommerceOptInEligibleArtworksReportLoader: gravityLoader(
+      (id) => `partner/${id}/commerce_opt_in_eligible_artworks_report`,
       {},
       { method: "POST" }
     ),
@@ -555,6 +555,11 @@ export default (accessToken, userID, opts) => {
       { method: "PUT" }
     ),
     matchPagesLoader: gravityLoader("match/pages", {}, { headers: true }),
+    optInArtworksIntoCommerceLoader: gravityLoader(
+      (id) => `partner/${id}/opt_in_artworks_into_commerce`,
+      {},
+      { method: "PUT" }
+    ),
     partnerArtistsWithAlertCountsLoader: gravityLoader(
       (id) => `partner/${id}/artists_with_alert_counts`,
       {},

--- a/src/schema/v2/partner/CommerceOptIn/__tests__/commerceOptInReportMutation.test.ts
+++ b/src/schema/v2/partner/CommerceOptIn/__tests__/commerceOptInReportMutation.test.ts
@@ -1,0 +1,91 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("CommerceOptInReportMutation", () => {
+  const mutation = gql`
+    mutation {
+      commerceOptInReport(input: { id: "commerce-test-partner" }) {
+        __typename
+        commerceOptInReportMutationOrError {
+          __typename
+          ... on CommerceOptInReportSuccess {
+            createdCommerceOptInReport {
+              message
+            }
+          }
+          ... on CommerceOptInReportFailure {
+            mutationError {
+              error
+            }
+          }
+        }
+      }
+    }
+  `
+
+  describe("Create a report containing data about commerce opt in eligibility for a given partner", () => {
+    describe("when successful", () => {
+      const successfulResponse = {
+        message: "success",
+      }
+
+      const context = {
+        createCommerceOptInEligibleArtworksReportLoader: () =>
+          Promise.resolve(successfulResponse),
+      }
+
+      it("sends the report to the user", async () => {
+        const createdCommerceOptInReport = await runAuthenticatedQuery(
+          mutation,
+          context
+        )
+
+        expect(createdCommerceOptInReport).toEqual({
+          commerceOptInReport: {
+            __typename: "CommerceOptInReportMutationPayload",
+            commerceOptInReportMutationOrError: {
+              __typename: "CommerceOptInReportSuccess",
+              createdCommerceOptInReport: {
+                message: "success",
+              },
+            },
+          },
+        })
+      })
+    })
+
+    describe("when failure", () => {
+      const failureResponse = {
+        type: "param_error",
+        message: "Invalid parameters.",
+        detail: {
+          exact_price: ["does not have a valid value"],
+        },
+      }
+
+      const context = {
+        createCommerceOptInEligibleArtworksReportLoader: () =>
+          Promise.resolve(failureResponse),
+      }
+
+      it("returns an error", async () => {
+        const createdCommerceOptInReport = await runAuthenticatedQuery(
+          mutation,
+          context
+        )
+
+        expect(createdCommerceOptInReport).toEqual({
+          commerceOptInReport: {
+            __typename: "CommerceOptInReportMutationPayload",
+            commerceOptInReportMutationOrError: {
+              __typename: "CommerceOptInReportSuccess",
+              createdCommerceOptInReport: {
+                message: "Invalid parameters.",
+              },
+            },
+          },
+        })
+      })
+    })
+  })
+})

--- a/src/schema/v2/partner/CommerceOptIn/commerceOptInReportMutation.ts
+++ b/src/schema/v2/partner/CommerceOptIn/commerceOptInReportMutation.ts
@@ -1,0 +1,167 @@
+import { GraphQLNonNull } from "graphql"
+import {
+  GraphQLBoolean,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+
+export const CommerceOptInReportResponseType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "CommerceOptInReportResponse",
+  fields: () => ({
+    message: { type: GraphQLString },
+  }),
+})
+
+interface Input {
+  id: string
+  exactPrice?: boolean
+  pickupAvailable?: boolean
+  framed?: boolean
+  certificateOfAuthenticity?: boolean
+  coaByGallery?: boolean
+  coaByAuthenticatingBody?: boolean
+  eligible?: boolean
+}
+
+const CommerceOptInReportSuccesssType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "CommerceOptInReportSuccess",
+  fields: () => ({
+    createdCommerceOptInReport: {
+      type: CommerceOptInReportResponseType,
+      resolve: (result) => {
+        return { message: result.message }
+      },
+    },
+  }),
+})
+
+const CommerceOptInReportFailureType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "CommerceOptInReportFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const CommerceOptInReportMutationType = new GraphQLUnionType({
+  name: "CommerceOptInReportMutationType",
+  types: [CommerceOptInReportSuccesssType, CommerceOptInReportFailureType],
+  resolveType: (object) => {
+    if (object._type == "GravityMutationError") {
+      return CommerceOptInReportFailureType
+    }
+
+    return CommerceOptInReportSuccesssType
+  },
+})
+
+export const commerceOptInReportMutation = mutationWithClientMutationId<
+  Input,
+  any,
+  ResolverContext
+>({
+  name: "CommerceOptInReportMutation",
+  description:
+    "Generate CommerceOptIn report about artworks eligibility for a given partner",
+  inputFields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "ID of the partner",
+    },
+    exactPrice: {
+      type: GraphQLBoolean,
+      description: "whether or not the artworks should be set to exact price",
+    },
+    pickupAvailable: {
+      type: GraphQLBoolean,
+      description: "whether or not pick up should be available",
+    },
+    framed: {
+      type: GraphQLBoolean,
+      description: "whether or not it should be set to framed",
+    },
+    certificateOfAuthenticity: {
+      type: GraphQLBoolean,
+      description: "whether it should be updated to CoA",
+    },
+    coaByGallery: {
+      type: GraphQLBoolean,
+      description: "whether or not the CoA is by the gallery",
+    },
+    coaByAuthenticatingBody: {
+      type: GraphQLBoolean,
+      description: "whether or not the CoA is by an authenticating body",
+    },
+    eligible: {
+      type: GraphQLBoolean,
+      description:
+        "whether the report will contain data for eligible or non-eligible artworks.",
+    },
+  },
+  outputFields: {
+    commerceOptInReportMutationOrError: {
+      type: CommerceOptInReportMutationType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    {
+      id,
+      exactPrice,
+      pickupAvailable,
+      framed,
+      certificateOfAuthenticity,
+      coaByGallery,
+      coaByAuthenticatingBody,
+      eligible,
+    },
+    { createCommerceOptInEligibleArtworksReportLoader }
+  ) => {
+    const gravityOptions = {
+      exact_price: exactPrice,
+      pickup_available: pickupAvailable,
+      framed,
+      certificate_of_authenticity: certificateOfAuthenticity,
+      coa_by_gallery: coaByGallery,
+      coa_by_authenticating_body: coaByAuthenticatingBody,
+      eligible: eligible,
+    }
+
+    if (!createCommerceOptInEligibleArtworksReportLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      return await createCommerceOptInEligibleArtworksReportLoader(
+        id,
+        gravityOptions
+      )
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -232,6 +232,7 @@ import { CacheableDirective } from "directives/cacheableDirective"
 import { OptionalFieldDirective } from "directives/optionalField/optionalFieldsDirectiveExtension"
 import { PrincipalFieldDirective } from "directives/principalField/principalFieldDirectiveExtension"
 import { commerceOptInMutation } from "./partner/CommerceOptIn/commerceOptInMutation"
+import { commerceOptInReportMutation } from "./partner/CommerceOptIn/commerceOptInReportMutation"
 
 const rootFields = {
   // artworkVersion: ArtworkVersionResolver,
@@ -377,6 +378,7 @@ export default new GraphQLSchema({
       artworksCollectionsBatchUpdate: artworksCollectionsBatchUpdateMutation,
       bulkUpdatePartnerArtworks: bulkUpdatePartnerArtworksMutation,
       commerceOptIn: commerceOptInMutation,
+      commerceOptInReport: commerceOptInReportMutation,
       createAccountRequest: createAccountRequestMutation,
       createAlert: createAlertMutation,
       createVerifiedRepresentative: createVerifiedRepresentativeMutation,


### PR DESCRIPTION
[AMBER-1036]

Add a mutation that when hit, it generates the report containing eligibility data for Commerce Opt In for a given partner and send it to the current user's email address.

Example:

```graphql
mutation
  { 
    commerceOptInReport(input: { id: "<partner-id>", exactPrice: true, certificateOfAuthenticity: false, framed: false, pickupAvailable: true}) {
      __typename
      commerceOptInReportMutationOrError {
        __typename
        ... on CommerceOptInReportSuccess {
          createdCommerceOptInReport {
            message
          }
        }
        ... on CommerceOptInReportFailure {
          mutationError {
            message
          }
        }
      }
    }
}
```

cc @artsy/amber-devs 

[AMBER-1036]: https://artsyproduct.atlassian.net/browse/AMBER-1036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ