### PR TITLE
chore: rename legacy zone to default

### DIFF
--- a/src/schema/v2/homeView/helpers/getSectionsForUser.ts
+++ b/src/schema/v2/homeView/helpers/getSectionsForUser.ts
@@ -1,14 +1,14 @@
 import { ResolverContext } from "types/graphql"
-import { getLegacyZoneSections } from "../zones/legacy"
+import { getSections } from "../zones/default"
 import { HomeViewSection } from "../sections/"
 
 export async function getSectionsForUser(
   context: ResolverContext
 ): Promise<HomeViewSection[]> {
-  const legacyZoneSections = await getLegacyZoneSections(context)
+  const sections = await getSections(context)
 
   return [
-    ...legacyZoneSections,
+    ...sections,
     // other zones’ sections TK
   ]
 }

--- a/src/schema/v2/homeView/zones/__tests__/default.test.ts
+++ b/src/schema/v2/homeView/zones/__tests__/default.test.ts
@@ -1,5 +1,5 @@
 import { ResolverContext } from "types/graphql"
-import { getLegacyZoneSections } from "../legacy"
+import { getSections } from "../default"
 import { isFeatureFlagEnabled } from "lib/featureFlags"
 
 jest.mock("lib/featureFlags", () => ({
@@ -8,14 +8,14 @@ jest.mock("lib/featureFlags", () => ({
 
 const mockIsFeatureFlagEnabled = isFeatureFlagEnabled as jest.Mock
 
-describe("getLegacyZoneSections", () => {
+describe("getSections", () => {
   describe("with an authenticated user", () => {
     it("returns the correct sections", async () => {
       const context: Partial<ResolverContext> = {
         accessToken: "some-token",
       }
 
-      const sections = await getLegacyZoneSections(context as ResolverContext)
+      const sections = await getSections(context as ResolverContext)
       const sectionIds = sections.map((section) => section.id)
 
       expect(sectionIds).toMatchInlineSnapshot(`
@@ -52,7 +52,7 @@ describe("getLegacyZoneSections", () => {
         accessToken: undefined,
       }
 
-      const sections = await getLegacyZoneSections(context as ResolverContext)
+      const sections = await getSections(context as ResolverContext)
       const sectionIds = sections.map((section) => section.id)
 
       expect(sectionIds).toMatchInlineSnapshot(`
@@ -83,7 +83,7 @@ describe("getLegacyZoneSections", () => {
 
       it("returns the section", async () => {
         const context: Partial<ResolverContext> = {}
-        const sections = await getLegacyZoneSections(context as ResolverContext)
+        const sections = await getSections(context as ResolverContext)
         const sectionIds = sections.map((section) => section.id)
 
         expect(sectionIds).toInclude("home-view-section-featured-fairs")
@@ -100,7 +100,7 @@ describe("getLegacyZoneSections", () => {
 
       it("does not return the section", async () => {
         const context: Partial<ResolverContext> = {}
-        const sections = await getLegacyZoneSections(context as ResolverContext)
+        const sections = await getSections(context as ResolverContext)
         const sectionIds = sections.map((section) => section.id)
 
         expect(sectionIds).not.toInclude("home-view-section-featured-fairs")

--- a/src/schema/v2/homeView/zones/default.ts
+++ b/src/schema/v2/homeView/zones/default.ts
@@ -23,7 +23,7 @@ import { CuratorsPicksEmerging } from "../sections/CuratorsPicksEmerging"
 import { SimilarToRecentlyViewedArtworks } from "../sections/SimilarToRecentlyViewedArtworks"
 import { isSectionDisplayable } from "../helpers/isSectionDisplayable"
 
-const LEGACY_ZONE_SECTIONS: HomeViewSection[] = [
+const SECTIONS: HomeViewSection[] = [
   LatestActivity,
   NewWorksForYou,
   HeroUnits,
@@ -50,10 +50,10 @@ const LEGACY_ZONE_SECTIONS: HomeViewSection[] = [
 /**
  * Assemble the list of sections that can be displayed
  */
-export async function getLegacyZoneSections(context: ResolverContext) {
+export async function getSections(context: ResolverContext) {
   const displayableSections: HomeViewSection[] = []
 
-  LEGACY_ZONE_SECTIONS.forEach((section) => {
+  SECTIONS.forEach((section) => {
     if (isSectionDisplayable(section, context)) {
       displayableSections.push(section)
     }


### PR DESCRIPTION
We initially created support for the "zone" concept thinking that we would switch from a "legacy" set of sections to a completely different set of sections, possibly backed by multiple zones.

That need seems less clear and we're now planning more incremental changes, often backed by feature flags or A/B testing setup, to a default set of sections.

This commit removes the label "legacy" from this set of sections in favor of a more neutral "default" name.