### PR TITLE
feat(homeView): define an optional displayability check per section

### DIFF
--- a/src/schema/v2/homeView/helpers/__tests__/isSectionDisplayable.test.ts
+++ b/src/schema/v2/homeView/helpers/__tests__/isSectionDisplayable.test.ts
@@ -74,4 +74,51 @@ describe("isSectionDisplayable", () => {
       ).toBe(false)
     })
   })
+
+  describe("with a section's own displayability check", () => {
+    it("returns true if the section does NOT define a displayability check", () => {
+      const section: Partial<HomeViewSection> = {
+        requiresAuthentication: false,
+        shouldBeDisplayed: undefined,
+      }
+      const context: Partial<ResolverContext> = { userID: "42" }
+
+      expect(
+        isSectionDisplayable(
+          section as HomeViewSection,
+          context as ResolverContext
+        )
+      ).toBe(true)
+    })
+
+    it("returns true if the section's displayability check passes", () => {
+      const section: Partial<HomeViewSection> = {
+        requiresAuthentication: false,
+        shouldBeDisplayed: () => true,
+      }
+      const context: Partial<ResolverContext> = { userID: "42" }
+
+      expect(
+        isSectionDisplayable(
+          section as HomeViewSection,
+          context as ResolverContext
+        )
+      ).toBe(true)
+    })
+
+    it("returns false if the section's displayability check fails", () => {
+      const section: Partial<HomeViewSection> = {
+        requiresAuthentication: false,
+        shouldBeDisplayed: () => false,
+      }
+      const context: Partial<ResolverContext> = { userID: "42" }
+
+      expect(
+        isSectionDisplayable(
+          section as HomeViewSection,
+          context as ResolverContext
+        )
+      ).toBe(false)
+    })
+  })
 })

--- a/src/schema/v2/homeView/helpers/__tests__/isSectionDisplayable.test.ts
+++ b/src/schema/v2/homeView/helpers/__tests__/isSectionDisplayable.test.ts
@@ -1,0 +1,77 @@
+import { ResolverContext } from "types/graphql"
+import { HomeViewSection } from "../../sections"
+import { isSectionDisplayable } from "../isSectionDisplayable"
+import { isFeatureFlagEnabled, FeatureFlag } from "lib/featureFlags"
+
+jest.mock("lib/featureFlags", () => ({
+  isFeatureFlagEnabled: jest.fn(() => true),
+}))
+
+const mockIsFeatureFlagEnabled = isFeatureFlagEnabled as jest.Mock
+
+describe("isSectionDisplayable", () => {
+  describe("with a section that requires authentication", () => {
+    it("returns true if the user is authenticated", () => {
+      const section: Partial<HomeViewSection> = { requiresAuthentication: true }
+      const context: Partial<ResolverContext> = { accessToken: "42" }
+
+      expect(
+        isSectionDisplayable(
+          section as HomeViewSection,
+          context as ResolverContext
+        )
+      ).toBe(true)
+    })
+
+    it("returns false if the user is not authenticated", () => {
+      const section: Partial<HomeViewSection> = { requiresAuthentication: true }
+      const context: Partial<ResolverContext> = { accessToken: undefined }
+
+      expect(
+        isSectionDisplayable(
+          section as HomeViewSection,
+          context as ResolverContext
+        )
+      ).toBe(false)
+    })
+  })
+
+  describe("with a section that depends on a feature flag", () => {
+    it("returns true if the feature flag is enabled", () => {
+      const section: Partial<HomeViewSection> = {
+        requiresAuthentication: false,
+        featureFlag: "enable-home-view-section-foo" as FeatureFlag,
+      }
+      const context: Partial<ResolverContext> = { userID: "42" }
+
+      mockIsFeatureFlagEnabled.mockImplementation((flag: string) => {
+        if (flag === "enable-home-view-section-foo") return true
+      })
+
+      expect(
+        isSectionDisplayable(
+          section as HomeViewSection,
+          context as ResolverContext
+        )
+      ).toBe(true)
+    })
+
+    it("returns false if the feature flag is disabled", () => {
+      const section: Partial<HomeViewSection> = {
+        requiresAuthentication: false,
+        featureFlag: "enable-home-view-section-foo" as FeatureFlag,
+      }
+      const context: Partial<ResolverContext> = { userID: "42" }
+
+      mockIsFeatureFlagEnabled.mockImplementation((flag: string) => {
+        if (flag === "enable-home-view-section-foo") return false
+      })
+      expect(
+        isSectionDisplayable(
+          section as HomeViewSection,
+          context as ResolverContext
+        )
+      ).toBe(false)
+    })
+  })
+})

--- a/src/schema/v2/homeView/helpers/isSectionDisplayable.ts
+++ b/src/schema/v2/homeView/helpers/isSectionDisplayable.ts
@@ -27,5 +27,10 @@ export function isSectionDisplayable(
     })
   }
 
+  // section's display pre-check
+  if (typeof section.shouldBeDisplayed === "function") {
+    isDisplayable = isDisplayable && section?.shouldBeDisplayed(context)
+  }
+
   return isDisplayable
 }

--- a/src/schema/v2/homeView/sections/index.ts
+++ b/src/schema/v2/homeView/sections/index.ts
@@ -43,6 +43,7 @@ export type HomeViewSection = {
   }
   ownerType?: OwnerType
   requiresAuthentication: boolean
+  shouldBeDisplayed?: (context: ResolverContext) => boolean
   resolver?: GraphQLFieldResolver<any, ResolverContext>
   type: keyof typeof HomeViewSectionTypeNames
 }


### PR DESCRIPTION
Here we add the ability for a section to define its own displayability check that can govern whether the section should be displayed, considering any arbitrary data or condition _beyond_ the standard ones (auth, feature flags) that we've already defined

(See https://github.com/artsy/metaphysics/commit/d9562a59558fd710653ceb7cfce446dfe3cb9a38  for a less noisy view)