### PR TITLE
chore: drop type/schema enforcement for home view section contextModule

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11006,7 +11006,7 @@ type HomeViewSectionActivity implements HomeViewSectionGeneric & Node {
   component: HomeViewComponent
 
   # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
-  contextModule: String!
+  contextModule: String
 
   # A globally unique ID.
   id: ID!
@@ -11037,7 +11037,7 @@ type HomeViewSectionArticles implements HomeViewSectionGeneric & Node {
   component: HomeViewComponent
 
   # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
-  contextModule: String!
+  contextModule: String
 
   # A globally unique ID.
   id: ID!
@@ -11062,7 +11062,7 @@ type HomeViewSectionArtists implements HomeViewSectionGeneric & Node {
   component: HomeViewComponent
 
   # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
-  contextModule: String!
+  contextModule: String
 
   # A globally unique ID.
   id: ID!
@@ -11087,7 +11087,7 @@ type HomeViewSectionArtworks implements HomeViewSectionGeneric & Node {
   component: HomeViewComponent
 
   # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
-  contextModule: String!
+  contextModule: String
 
   # A globally unique ID.
   id: ID!
@@ -11112,7 +11112,7 @@ type HomeViewSectionAuctionResults implements HomeViewSectionGeneric & Node {
   component: HomeViewComponent
 
   # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
-  contextModule: String!
+  contextModule: String
 
   # A globally unique ID.
   id: ID!
@@ -11130,7 +11130,7 @@ type HomeViewSectionFairs implements HomeViewSectionGeneric & Node {
   component: HomeViewComponent
 
   # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
-  contextModule: String!
+  contextModule: String
   fairsConnection(
     after: String
     before: String
@@ -11154,7 +11154,7 @@ type HomeViewSectionGalleries implements HomeViewSectionGeneric & Node {
   component: HomeViewComponent
 
   # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
-  contextModule: String!
+  contextModule: String
 
   # A globally unique ID.
   id: ID!
@@ -11172,7 +11172,7 @@ interface HomeViewSectionGeneric {
   component: HomeViewComponent
 
   # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
-  contextModule: String!
+  contextModule: String
 
   # A globally unique ID.
   id: ID!
@@ -11210,7 +11210,7 @@ type HomeViewSectionHeroUnits implements HomeViewSectionGeneric & Node {
   component: HomeViewComponent
 
   # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
-  contextModule: String!
+  contextModule: String
   heroUnitsConnection(
     after: String
     before: String
@@ -11234,7 +11234,7 @@ type HomeViewSectionMarketingCollections implements HomeViewSectionGeneric & Nod
   component: HomeViewComponent
 
   # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
-  contextModule: String!
+  contextModule: String
 
   # A globally unique ID.
   id: ID!
@@ -11258,7 +11258,7 @@ type HomeViewSectionSales implements HomeViewSectionGeneric & Node {
   component: HomeViewComponent
 
   # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
-  contextModule: String!
+  contextModule: String
 
   # A globally unique ID.
   id: ID!
@@ -11282,7 +11282,7 @@ type HomeViewSectionShows implements HomeViewSectionGeneric & Node {
   component: HomeViewComponent
 
   # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
-  contextModule: String!
+  contextModule: String
 
   # A globally unique ID.
   id: ID!
@@ -11300,7 +11300,7 @@ type HomeViewSectionViewingRooms implements HomeViewSectionGeneric & Node {
   component: HomeViewComponent
 
   # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
-  contextModule: String!
+  contextModule: String
 
   # A globally unique ID.
   id: ID!

--- a/src/schema/v2/homeView/HomeViewSection.ts
+++ b/src/schema/v2/homeView/HomeViewSection.ts
@@ -34,7 +34,7 @@ const standardSectionFields: GraphQLFieldConfigMap<any, ResolverContext> = {
     },
   },
   contextModule: {
-    type: new GraphQLNonNull(GraphQLString),
+    type: GraphQLString,
     description:
       "[Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)",
   },

--- a/src/schema/v2/homeView/sections/index.ts
+++ b/src/schema/v2/homeView/sections/index.ts
@@ -32,7 +32,7 @@ type MaybeResolved<T> =
 
 export type HomeViewSection = {
   id: string
-  contextModule: ContextModule
+  contextModule?: ContextModule
   featureFlag?: FeatureFlag
   component?: {
     title?: MaybeResolved<string>


### PR DESCRIPTION
This will allow devs to optionally omit contextModule (as well as other ownerType value current nullable) from the concrete section defintion while development is ongoing.

Sections shipped to production users should have these values specified and that usually requires some alignment with data to determine values and adding those values in our analytics schema package: [artsy/cohesion][].

[artsy/cohesion]: https://github.com/artsy/cohesion

cc/ @joeyAghion 