### PR TITLE
fix: 'Request header field User-Agent is not allowed by Access-Control-Allow-Headers

### DIFF
--- a/workers/caching/metaphysics-cdn.ts
+++ b/workers/caching/metaphysics-cdn.ts
@@ -71,7 +71,7 @@ export default {
           status: 204,
           headers: {
             "Access-Control-Allow-Headers":
-              "cache-control,content-type,x-access-token,x-original-session-id,x-timezone,x-user-id",
+              "cache-control,content-type,user-agent,x-access-token,x-original-session-id,x-timezone,x-user-id",
             "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
             "Access-Control-Allow-Origin": "*",
             "Access-Control-Max-Age": "600",


### PR DESCRIPTION
Noticed some Sentry errors resulting from the new preflight handling (https://github.com/artsy/metaphysics/pull/6048). This is the 2nd time an inconsequential header causes production issues, so I think we should probably respond dynamically instead of this allow-list.
