### PR TITLE
feat: stop counting cache misses as errors

### DIFF
--- a/src/lib/__tests__/cache.test.ts
+++ b/src/lib/__tests__/cache.test.ts
@@ -46,9 +46,15 @@ describe("Cache with compression enabled", () => {
 
         await cache.delete("get_foo")
 
-        await expect(cache.get("get_foo")).rejects.toThrow(
-          "[Cache#get] Cache miss"
-        )
+        let data
+
+        try {
+          data = await cache.get("get_foo")
+
+          expect(data).toBeUndefined()
+        } catch {
+          throw new Error("unexpected error")
+        }
       })
     })
 
@@ -113,11 +119,19 @@ describe("Cache with compression disabled", () => {
       beforeEach(async () => await cache.set("get_foo", { bar: "baz" }))
 
       it("deletes the data", async () => {
-        cache.delete("get_foo")
+        expect.assertions(1)
 
-        await expect(cache.get("get_foo")).rejects.toThrow(
-          "[Cache#get] Cache miss"
-        )
+        await cache.delete("get_foo")
+
+        let data
+
+        try {
+          data = await cache.get("get_foo")
+
+          expect(data).toBeUndefined()
+        } catch {
+          throw new Error("unexpected error")
+        }
       })
     })
 

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -87,7 +87,7 @@ const cacheTracer: ReturnType<typeof createCacheTracer> = isTest
 const statsClient = isTest ? null : createStatsClient()
 
 function _get<T>(key) {
-  return new Promise<T>((resolve, reject) => {
+  return new Promise<T | undefined>((resolve, reject) => {
     let timeoutId: NodeJS.Timer | null = setTimeout(() => {
       timeoutId = null
       const err = new Error(`[Cache#get] Timeout for key ${cacheKey(key)}`)
@@ -127,7 +127,12 @@ function _get<T>(key) {
           })
         }
       } else {
-        reject(new Error("[Cache#get] Cache miss"))
+        // Cache miss.
+        //
+        // It's fine to `reject` in the conditions above as those are errors.
+        // A cache miss is not an error, and these show up in DataDog, so instead
+        // we resolve with an `undefined` value.
+        resolve(undefined)
       }
     })
   })


### PR DESCRIPTION
This seems to work properly locally, but deserves careful review.

Basically - our custom cache client/API winds up treating a cache miss as an error - which shows up noisily in Datadog.

![Screenshot 2024-09-27 at 4 44 30 PM](https://github.com/user-attachments/assets/372b411f-68f7-4fa2-91cb-14cdc8f93b34)

It makes checking out the error rate for certain queries not usable, as cache misses count!

This attempts a refactor to basically stop trying to throw an error or reject any promise when there's a cache miss, and instead resolve with an undefined. This led to a little refactor of the caller of this client as the signature of things (what constitutes a cache hit/miss) has changed.