### PR TITLE
fix: dont create new Error for cache miss

### DIFF
--- a/src/lib/__tests__/cache.test.ts
+++ b/src/lib/__tests__/cache.test.ts
@@ -46,9 +46,17 @@ describe("Cache with compression enabled", () => {
 
         await cache.delete("get_foo")
 
-        await expect(cache.get("get_foo")).rejects.toThrow(
-          "[Cache#get] Cache miss"
-        )
+        let data
+
+        try {
+          data = await cache.get("get_foo")
+
+          throw new Error("unexpected error")
+        } catch {
+          // no-op
+        }
+
+        expect(data).toBeUndefined()
       })
     })
 
@@ -113,11 +121,21 @@ describe("Cache with compression disabled", () => {
       beforeEach(async () => await cache.set("get_foo", { bar: "baz" }))
 
       it("deletes the data", async () => {
-        cache.delete("get_foo")
+        expect.assertions(1)
 
-        await expect(cache.get("get_foo")).rejects.toThrow(
-          "[Cache#get] Cache miss"
-        )
+        await cache.delete("get_foo")
+
+        let data
+
+        try {
+          data = await cache.get("get_foo")
+
+          throw new Error("unexpected error")
+        } catch {
+          // no-op
+        }
+
+        expect(data).toBeUndefined()
       })
     })
 

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -127,7 +127,7 @@ function _get<T>(key) {
           })
         }
       } else {
-        reject(new Error("[Cache#get] Cache miss"))
+        reject()
       }
     })
   })


### PR DESCRIPTION
This comment - https://github.com/artsy/metaphysics/pull/6067/files#r1779150198 - made me 🦆 myself into thinking -

Datadog seems to automatically pick up `new Error("cache miss")`. Since we're `catch`'ing these and not actually doing anything with them (even when there are other `reject`'s from the cache - even real errors) besides falling thru to the API - this might be a simple fix that helps clean up Datadog.

Basically - cache misses are not errors, so we shouldn't have `new Error` for them.

Simpler version of https://github.com/artsy/metaphysics/pull/6067