### PR TITLE
feat: add discover marketing collections to homeview

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11124,6 +11124,30 @@ type HomeViewSectionAuctionResults implements HomeViewSectionGeneric & Node {
   ownerType: String
 }
 
+# A section containing a list of curated marketing collections
+type HomeViewSectionDiscoverMarketingCollections implements HomeViewSectionGeneric & Node {
+  # Component prescription for this section, for overriding or customizing presentation and behavior
+  component: HomeViewComponent
+
+  # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
+  contextModule: String
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+  linksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): FeaturedLinkConnection
+
+  # [Analytics] `owner type` analytics value for this scetion when displayed in a standalone UI, as defined in our schema (artsy/cohesion)
+  ownerType: String
+}
+
 # A fairs section in the home view
 type HomeViewSectionFairs implements HomeViewSectionGeneric & Node {
   # Component prescription for this section, for overriding or customizing presentation and behavior

--- a/src/schema/v2/homeView/HomeViewSection.ts
+++ b/src/schema/v2/homeView/HomeViewSection.ts
@@ -21,6 +21,7 @@ import { InternalIDFields, NodeInterface } from "../object_identification"
 import { SalesConnectionField } from "../sales"
 import { HomeViewComponent } from "./HomeViewComponent"
 import { toGlobalId } from "graphql-relay"
+import { FeaturedLinkConnectionType } from "../FeaturedLink/featuredLink"
 
 // section interface
 
@@ -56,6 +57,8 @@ export const HomeViewSectionTypeNames = {
   HomeViewSectionArtists: "HomeViewSectionArtists",
   HomeViewSectionArtworks: "HomeViewSectionArtworks",
   HomeViewSectionAuctionResults: "HomeViewSectionAuctionResults",
+  HomeViewSectionDiscoverMarketingCollections:
+    "HomeViewSectionDiscoverMarketingCollections",
   HomeViewSectionFairs: "HomeViewSectionFairs",
   HomeViewSectionGalleries: "HomeViewSectionGalleries",
   HomeViewSectionGeneric: "HomeViewSectionGeneric",
@@ -274,6 +277,24 @@ export const HomeViewGalleriesSectionType = new GraphQLObjectType<
   },
 })
 
+export const HomeViewDiscoverMarketingCollectionType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: HomeViewSectionTypeNames.HomeViewSectionDiscoverMarketingCollections,
+  description: "A section containing a list of curated marketing collections",
+  interfaces: [HomeViewGenericSectionInterface, NodeInterface],
+  fields: {
+    ...standardSectionFields,
+    linksConnection: {
+      type: FeaturedLinkConnectionType,
+      args: pageable({}),
+      resolve: (parent, ...rest) =>
+        parent.resolver ? parent.resolver(parent, ...rest) : emptyConnection,
+    },
+  },
+})
+
 export const homeViewSectionTypes: GraphQLObjectType<any, ResolverContext>[] = [
   HomeViewActivitySectionType,
   HomeViewArticlesSectionType,
@@ -287,4 +308,5 @@ export const homeViewSectionTypes: GraphQLObjectType<any, ResolverContext>[] = [
   HomeViewSalesSectionType,
   HomeViewShowsSectionType,
   HomeViewViewingRoomsSectionType,
+  HomeViewDiscoverMarketingCollectionType,
 ]

--- a/src/schema/v2/homeView/__tests__/HomeView.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeView.test.ts
@@ -13,7 +13,7 @@ describe("homeView", () => {
     const query = gql`
       {
         homeView {
-          sectionsConnection(first: 20) {
+          sectionsConnection(first: 21) {
             edges {
               node {
                 __typename
@@ -53,6 +53,14 @@ describe("homeView", () => {
                   "__typename": "HomeViewSectionSales",
                   "component": Object {
                     "title": "Auctions",
+                  },
+                },
+              },
+              Object {
+                "node": Object {
+                  "__typename": "HomeViewSectionDiscoverMarketingCollections",
+                  "component": Object {
+                    "title": "Discover Something New",
                   },
                 },
               },
@@ -183,6 +191,14 @@ describe("homeView", () => {
                   "__typename": "HomeViewSectionSales",
                   "component": Object {
                     "title": "Auctions",
+                  },
+                },
+              },
+              Object {
+                "node": Object {
+                  "__typename": "HomeViewSectionDiscoverMarketingCollections",
+                  "component": Object {
+                    "title": "Discover Something New",
                   },
                 },
               },

--- a/src/schema/v2/homeView/sections/DiscoverMarketingCollections.ts
+++ b/src/schema/v2/homeView/sections/DiscoverMarketingCollections.ts
@@ -1,0 +1,82 @@
+import { ContextModule, OwnerType } from "@artsy/cohesion"
+import { HomeViewSection } from "."
+import { withHomeViewTimeout } from "../helpers/withHomeViewTimeout"
+import { HomeViewSectionTypeNames } from "../HomeViewSection"
+import { connectionFromArray } from "graphql-relay"
+
+export const DiscoverMarketingCollections: HomeViewSection = {
+  id: "home-view-section-discover-marketing-collections",
+
+  contextModule: "ContextModule.discover-marketing-collections" as ContextModule,
+  ownerType: "OwnerType.discover-marketing-collections" as OwnerType,
+
+  type: HomeViewSectionTypeNames.HomeViewSectionDiscoverMarketingCollections,
+
+  component: {
+    title: "Discover Something New",
+  },
+
+  requiresAuthentication: false,
+
+  resolver: withHomeViewTimeout(async (_parent, args, _context, _info) => {
+    const links = [
+      {
+        id: "figurative-art",
+        title: "Figurative Art",
+        subtitle: "Movement",
+        href: "/collection/figurative-art",
+      },
+      {
+        id: "new-from-leading-galleries",
+        title: "New From Leading Galleries",
+        subtitle: "Gallery",
+        href: "/collection/new-from-leading-galleries",
+      },
+      {
+        id: "paintings",
+        title: "Paintings",
+        subtitle: "Medium",
+        href: "/collection/paintings",
+      },
+      {
+        id: "prints",
+        title: "Prints",
+        subtitle: "Medium",
+        href: "/collection/prints",
+      },
+      {
+        id: "street-art",
+        title: "Street Art",
+        subtitle: "Movement",
+        href: "/collection/street-art",
+      },
+      {
+        id: "black-and-white",
+        title: "Black and White",
+        subtitle: "Color",
+        href: "collection/black-and-white-artworks",
+      },
+
+      {
+        id: "art-under-1000",
+        title: "Art Under $1,000",
+        subtitle: "Price",
+        href: "/collection/art-under-1000-dollars",
+      },
+      {
+        id: "art-for-small-spaces",
+        title: "Art for small spaces",
+        subtitle: "Size",
+        href: "/collection/art-for-small-spaces",
+      },
+      {
+        id: "cool-toned-artworks",
+        title: "Cool Toned Artworks",
+        subtitle: "Color",
+        href: "/collection/cool-toned-artworks",
+      },
+    ]
+
+    return connectionFromArray(links, args)
+  }),
+}

--- a/src/schema/v2/homeView/sections/index.ts
+++ b/src/schema/v2/homeView/sections/index.ts
@@ -25,6 +25,7 @@ import { LatestArticles } from "./LatestArticles"
 import { Auctions } from "./Auctions"
 import { GalleriesNearYou } from "./GalleriesNearYou"
 import { FeatureFlag } from "lib/featureFlags"
+import { DiscoverMarketingCollections } from "./DiscoverMarketingCollections"
 
 type MaybeResolved<T> =
   | T
@@ -53,6 +54,7 @@ const sections: HomeViewSection[] = [
   AuctionLotsForYou,
   Auctions,
   CuratorsPicksEmerging,
+  DiscoverMarketingCollections,
   FeaturedFairs,
   GalleriesNearYou,
   HeroUnits,

--- a/src/schema/v2/homeView/zones/__tests__/default.test.ts
+++ b/src/schema/v2/homeView/zones/__tests__/default.test.ts
@@ -26,6 +26,7 @@ describe("getSections", () => {
           "home-view-section-active-bids",
           "home-view-section-auction-lots-for-you",
           "home-view-section-auctions",
+          "home-view-section-discover-marketing-collections",
           "home-view-section-latest-auction-results",
           "home-view-section-galleries-near-you",
           "home-view-section-latest-articles",
@@ -59,6 +60,7 @@ describe("getSections", () => {
         Array [
           "home-view-section-hero-units",
           "home-view-section-auctions",
+          "home-view-section-discover-marketing-collections",
           "home-view-section-galleries-near-you",
           "home-view-section-latest-articles",
           "home-view-section-news",

--- a/src/schema/v2/homeView/zones/default.ts
+++ b/src/schema/v2/homeView/zones/default.ts
@@ -22,6 +22,7 @@ import { RecentlyViewedArtworks } from "../sections/RecentlyViewedArtworks"
 import { CuratorsPicksEmerging } from "../sections/CuratorsPicksEmerging"
 import { SimilarToRecentlyViewedArtworks } from "../sections/SimilarToRecentlyViewedArtworks"
 import { isSectionDisplayable } from "../helpers/isSectionDisplayable"
+import { DiscoverMarketingCollections } from "../sections/DiscoverMarketingCollections"
 
 const SECTIONS: HomeViewSection[] = [
   LatestActivity,
@@ -30,6 +31,7 @@ const SECTIONS: HomeViewSection[] = [
   ActiveBids,
   AuctionLotsForYou,
   Auctions,
+  DiscoverMarketingCollections,
   LatestAuctionResults,
   GalleriesNearYou,
   LatestArticles,


### PR DESCRIPTION
Discover Marketing Collection Component

This PR introduces the new **Discover Marketing Collection** component to the homeView:

[Ticket (figma url in the ticket)](https://artsyproduct.atlassian.net/browse/DIA-861)

Component Preview

![image](https://github.com/user-attachments/assets/68cda8d3-3679-4971-8611-1a773860b888)

Query

![Query Screenshot](https://github.com/user-attachments/assets/f552ba02-4b72-43ff-8a20-78662fb7732a)

Response

![image](https://github.com/user-attachments/assets/1fafebd0-8a3c-4c88-8642-dbc85294e5c9)

The placement, content collections, component style, and wording are still being refined and may change as we continue to complete the feature.