### PR TITLE
fix: add totalCount to trending artists section

### DIFF
--- a/src/schema/v2/homeView/sections/TrendingArtists.ts
+++ b/src/schema/v2/homeView/sections/TrendingArtists.ts
@@ -16,6 +16,9 @@ export const TrendingArtists: HomeViewSection = {
 
   resolver: withHomeViewTimeout(async (_parent, args, context, _info) => {
     const artistRecords = await getCuratedArtists(context)
-    return connectionFromArray(artistRecords, args)
+    return {
+      totalCount: artistRecords.length,
+      ...connectionFromArray(artistRecords, args),
+    }
   }),
 }


### PR DESCRIPTION
Add missing `totalCount` to `home-view-section-trending-artists` section. Because it is missing - this section is not displayed at all (because of this [condition](https://github.com/artsy/eigen/blob/main/src/app/Scenes/HomeView/Sections/HomeViewSectionArtists.tsx#L72) in Eigen).

```graphql
query {
  homeView {
    section(id: "home-view-section-trending-artists") {
      ... on HomeViewSectionArtists {
        artistsConnection(first: 0) {
          totalCount
        }
      }
    }
  }
}
```

```json
{
  "data": {
    "homeView": {
      "section": {
        "artistsConnection": {
          "totalCount": 12
        }
      }
    }
  }
}
```

There are other sections that do not return totalCount. Although they do not result to a component not being displayed - I think it's worth fixing all of them. I will create a ticket.