### PR TITLE
fix: lower target CPU utilization, allowing greater scale

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -118,7 +118,7 @@ spec:
     name: metaphysics-web
   minReplicas: 10
   maxReplicas: 35
-  targetCPUUtilizationPercentage: 60
+  targetCPUUtilizationPercentage: 50
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
We experimented with a lower target CPU utilization [recently](https://artsy.slack.com/archives/CA8SANW3W/p1727625446428559?thread_ts=1727453010.022849&cid=CA8SANW3W), and found that it somewhat mitigated spikes in latency. Otherwise, Metaphysics would operate at low scale but expend increasing amounts of time waiting for HTTP requests, eventually timing out. We still don't have a diagnosis of the root cause, and those requests don't appear to be timing out upstream, but this configuration change allows the deployment to scale up more often and more liberally, spreading the load and decreasing the worst spikes.