### PR TITLE
chore: Retire custom AlertsEdgeFields

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -363,11 +363,8 @@ type AlertConnection {
 
 # An edge in a connection.
 type AlertEdge {
-  counts: AlertsCounts
-
   # A cursor for use in pagination
   cursor: String!
-  isRecentlyEnabled: Boolean
 
   # The item at the end of the edge
   node: Alert
@@ -421,10 +418,6 @@ enum AlertSourceType {
 enum AlertsConnectionSortEnum {
   ENABLED_AT_DESC
   NAME_ASC
-}
-
-type AlertsCounts {
-  totalUserSearchCriteriaCount: Int
 }
 
 type Algolia {

--- a/src/schema/v2/Alerts/index.ts
+++ b/src/schema/v2/Alerts/index.ts
@@ -392,25 +392,6 @@ export const AlertType = new GraphQLObjectType<
   },
 })
 
-const AlertsEdgeFields = {
-  counts: {
-    type: new GraphQLObjectType({
-      name: "AlertsCounts",
-      fields: {
-        totalUserSearchCriteriaCount: {
-          type: GraphQLInt,
-          resolve: ({ count_30d }) => count_30d,
-        },
-      },
-    }),
-    resolve: (x) => x,
-  },
-  isRecentlyEnabled: {
-    type: GraphQLBoolean,
-    resolve: ({ count_7d }) => count_7d > 0,
-  },
-}
-
 export const AlertsConnectionSortEnum = new GraphQLEnumType({
   name: "AlertsConnectionSortEnum",
   values: {
@@ -437,7 +418,6 @@ export const resolveAlertFromJSON = (alert) => {
 export const AlertsConnectionType = connectionWithCursorInfo({
   name: "Alert",
   nodeType: AlertType,
-  edgeFields: AlertsEdgeFields,
 }).connectionType
 
 export const PartnerAlertsEdgeFields = {


### PR DESCRIPTION
Retire custom `AlertsEdgeFields` as they are no longer in use

The usage has been retired in Volt and continued to be retired in gravity

Retired gravity code:
- https://github.com/artsy/gravity/pull/18180
- https://github.com/artsy/gravity/pull/18177
- https://github.com/artsy/gravity/pull/18176