### PR TITLE
fix: fix broken pagination for recently viewed artworks query

### DIFF
--- a/src/schema/v2/me/__tests__/recentlyViewedArtworks.test.ts
+++ b/src/schema/v2/me/__tests__/recentlyViewedArtworks.test.ts
@@ -70,6 +70,42 @@ describe("RecentlyViewedArtworks", () => {
     `)
   })
 
+  it("returns a second page of artworks", async () => {
+    // "YXJyYXljb25uZWN0aW9uOjE" is for "Matt the Person"
+    const query = gql`
+      {
+        me {
+          recentlyViewedArtworksConnection(
+            first: 1
+            after: "YXJyYXljb25uZWN0aW9uOjE"
+          ) {
+            edges {
+              node {
+                slug
+                title
+              }
+            }
+          }
+        }
+      }
+    `
+    const data = await runAuthenticatedQuery(query, context)
+    const recentlyViewedArtworks = data!.me.recentlyViewedArtworksConnection
+
+    expect(recentlyViewedArtworks).toMatchInlineSnapshot(`
+      Object {
+        "edges": Array [
+          Object {
+            "node": Object {
+              "slug": "paul",
+              "title": "Paul the snail",
+            },
+          },
+        ],
+      }
+    `)
+  })
+
   it("works for a request using impersonation", async () => {
     context.meLoader = () => Promise.reject("This should not be called")
     context.xImpersonateUserID = "some-user-id"

--- a/src/schema/v2/me/__tests__/recentlyViewedArtworks.test.ts
+++ b/src/schema/v2/me/__tests__/recentlyViewedArtworks.test.ts
@@ -71,7 +71,8 @@ describe("RecentlyViewedArtworks", () => {
   })
 
   it("returns a second page of artworks", async () => {
-    // "YXJyYXljb25uZWN0aW9uOjE" is for "Matt the Person"
+    // In this test I want to get an artwork which comes right after "Matt the Person" artwork.
+    // It's cursor is "YXJyYXljb25uZWN0aW9uOjE" - I specify it a few lines bellow.
     const query = gql`
       {
         me {

--- a/src/schema/v2/me/recentlyViewedArtworks.ts
+++ b/src/schema/v2/me/recentlyViewedArtworks.ts
@@ -1,5 +1,5 @@
 import { GraphQLFieldConfig } from "graphql"
-import { connectionFromArraySlice } from "graphql-relay"
+import { connectionFromArray } from "graphql-relay"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { formatGravityError } from "lib/gravityErrorHandler"
 import { pageable } from "relay-cursor-paging"
@@ -26,7 +26,7 @@ export const RecentlyViewedArtworks: GraphQLFieldConfig<
   ) => {
     if (!userID && !xImpersonateUserID) return null
 
-    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+    const { page, size } = convertConnectionArgsToGravityArgs(args)
 
     try {
       let artworkIDs
@@ -47,10 +47,7 @@ export const RecentlyViewedArtworks: GraphQLFieldConfig<
 
       const totalCount = artworks.length
 
-      const connection = connectionFromArraySlice(artworks, args, {
-        arrayLength: totalCount,
-        sliceStart: offset,
-      })
+      const connection = connectionFromArray(artworks, args)
 
       const totalPages = Math.ceil(totalCount / size)
 


### PR DESCRIPTION
This PR should fix a pagination issue for `recentlyViewedArtworksConnection` query (actually any query which uses `RecentlyViewedArtworks` GraphQL field config). Currently `recentlyViewedArtworksConnection` always returns first N recently viewed artworks regardless of cursor (offset, page) provided. 

# Before

Here I'm requesting first 2 artworks:

```graphql
query {
  me {
    recentlyViewedArtworksConnection(first: 2) {
      pageInfo {
        endCursor
      }
      
      edges {
        node {
          title
        }
      }
    }
  }
}
```

Pay attention to returned artworks - Golf Sale and Swimmers with Towel.

```json
{
  "data": {
    "me": {
      "recentlyViewedArtworksConnection": {
        "pageInfo": {
          "endCursor": "YXJyYXljb25uZWN0aW9uOjE="
        },
        "edges": [
          {
            "node": {
              "title": "Golf Sale"
            }
          },
          {
            "node": {
              "title": "Swimmers with Towel"
            }
          }
        ]
      }
    }
  }
}
```

Requesting next to artworks by providing after cursor:

```graphql
query {
  me {
    recentlyViewedArtworksConnection(first: 2, after: "YXJyYXljb25uZWN0aW9uOjE=") {
      pageInfo {
        endCursor
      }
      
      edges {
        node {
          title
        }
      }
    }
  }
}
```

Same artworks in response:

```json
{
  "data": {
    "me": {
      "recentlyViewedArtworksConnection": {
        "pageInfo": {
          "endCursor": "YXJyYXljb25uZWN0aW9uOjM="
        },
        "edges": [
          {
            "node": {
              "title": "Golf Sale"
            }
          },
          {
            "node": {
              "title": "Swimmers with Towel"
            }
          }
        ]
      }
    }
  }
}
```

# After

Now request returns correct artworks list:

```json
{
  "data": {
    "me": {
      "recentlyViewedArtworksConnection": {
        "pageInfo": {
          "endCursor": "YXJyYXljb25uZWN0aW9uOjM="
        },
        "edges": [
          {
            "node": {
              "title": "Vancouver Circa 1995-6"
            }
          },
          {
            "node": {
              "title": "Hollywood Silhouette"
            }
          }
        ]
      }
    }
  }
}
```