### PR TITLE
fix(marketingcollection): exposes arguments for formatting markdown

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12282,7 +12282,9 @@ type MarketingCollection implements Node {
   ): String
   credit: String
   description: String
+    @deprecated(reason: "Use `markdownDescription` field instead")
   descriptionMarkdown: String
+    @deprecated(reason: "Use `markdownDescription` field instead")
   featuredArtistExclusionIds: [String!]!
   geneIds: [String]
   headerImage: String
@@ -12298,6 +12300,7 @@ type MarketingCollection implements Node {
 
   # Linked Collections
   linkedCollections: [MarketingCollectionGroup!]!
+  markdownDescription(format: Format): String
   priceGuidance: Float
   query: MarketingCollectionQuery!
 

--- a/src/schema/v2/marketingCollections.ts
+++ b/src/schema/v2/marketingCollections.ts
@@ -18,6 +18,7 @@ import { MarketingCollectionsSorts } from "./sorts/marketingCollectionsSort"
 import { NodeInterface, InternalIDFields } from "./object_identification"
 import Image, { normalizeImageData, getDefault } from "schema/v2/image"
 import { date } from "schema/v2/fields/date"
+import { markdown } from "schema/v2/fields/markdown"
 
 const MarketingCollectionQuery = new GraphQLObjectType<any, ResolverContext>({
   name: "MarketingCollectionQuery",
@@ -79,12 +80,17 @@ export const MarketingCollectionFields: GraphQLFieldConfigMap<
   },
   description: {
     type: GraphQLString,
+    deprecationReason: "Use `markdownDescription` field instead",
     resolve: ({ description }) => description,
   },
   descriptionMarkdown: {
     type: GraphQLString,
+    deprecationReason: "Use `markdownDescription` field instead",
     resolve: ({ description_markdown }) => description_markdown,
   },
+  markdownDescription: markdown(
+    ({ description_markdown }) => description_markdown
+  ),
   credit: {
     type: GraphQLString,
     resolve: ({ credit }) => credit,


### PR DESCRIPTION
Exposes `format` arg so that we can strip the link syntax for meta tags.

Edit: I had to expose a new field because the default arg would make this a breaking change. I can correct this once I switch Force over though.