### PR TITLE
fix(EMI-2124): no auction signals if no sale artwork, avoid local time comparisons

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -5029,27 +5029,6 @@ describe("Artwork type", () => {
             pastTime
           )
         })
-        it("may say live bidding has not started even though the start time has passed", async () => {
-          context.salesLoader.mockResolvedValue([
-            {
-              id: "sale-id-auction",
-              live_start_at: pastTime,
-              live_integration_started: false,
-            },
-          ])
-
-          // live start at not set on sale artwork
-          context.saleArtworkLoader.mockResolvedValue({})
-          const data = await runQuery(query, context)
-
-          expect(
-            data.artwork.collectorSignals.auction.liveBiddingStarted
-          ).toEqual(false)
-
-          expect(data.artwork.collectorSignals.auction.liveStartAt).toEqual(
-            pastTime
-          )
-        })
 
         it("fetches & returns the nested lot watcher and bid count signals for an auction lot artwork if requested", async () => {
           artwork.recent_saves_count = 123

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -5010,7 +5010,11 @@ describe("Artwork type", () => {
         })
         it("returns correct nested values for an auction that has started live bidding", async () => {
           context.salesLoader.mockResolvedValue([
-            { id: "sale-id-auction", live_start_at: pastTime },
+            {
+              id: "sale-id-auction",
+              live_start_at: pastTime,
+              live_integration_started: true,
+            },
           ])
 
           // live start at not set on sale artwork
@@ -5020,6 +5024,27 @@ describe("Artwork type", () => {
           expect(
             data.artwork.collectorSignals.auction.liveBiddingStarted
           ).toEqual(true)
+
+          expect(data.artwork.collectorSignals.auction.liveStartAt).toEqual(
+            pastTime
+          )
+        })
+        it("may say live bidding has not started even though the start time has passed", async () => {
+          context.salesLoader.mockResolvedValue([
+            {
+              id: "sale-id-auction",
+              live_start_at: pastTime,
+              live_integration_started: false,
+            },
+          ])
+
+          // live start at not set on sale artwork
+          context.saleArtworkLoader.mockResolvedValue({})
+          const data = await runQuery(query, context)
+
+          expect(
+            data.artwork.collectorSignals.auction.liveBiddingStarted
+          ).toEqual(false)
 
           expect(data.artwork.collectorSignals.auction.liveStartAt).toEqual(
             pastTime
@@ -5070,10 +5095,10 @@ describe("Artwork type", () => {
           expect(data.artwork.collectorSignals.auction).toBeNull()
         })
 
-        it("does not return auction data if bidding is closed", async () => {
+        it("may return auction data after end time if the sale closes late", async () => {
           artwork.purchasable = true
           context.salesLoader.mockResolvedValue([
-            { id: "sale-id-auction", ended_at: pastTime },
+            { id: "sale-id-auction", end_at: pastTime, ended_at: null },
           ])
           context.saleArtworkLoader.mockResolvedValue({
             end_at: pastTime,
@@ -5082,7 +5107,9 @@ describe("Artwork type", () => {
 
           const data = await runQuery(query, context)
 
-          expect(data.artwork.collectorSignals.auction).toBeNull()
+          expect(data.artwork.collectorSignals.auction.lotClosesAt).toEqual(
+            pastTime
+          )
         })
       })
 

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -70,8 +70,16 @@ const AuctionCollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
       liveBiddingStarted: {
         type: new GraphQLNonNull(GraphQLBoolean),
         description: "Live bidding has started on this lot's auction",
-        resolve: ({ sale }) =>
-          !!sale.live_start_at && new Date(sale.live_start_at) <= new Date(),
+        resolve: async ({ sale }, {}, { systemTimeLoader }) => {
+          if (!sale.live_start_at) {
+            return false
+          }
+          const systemTime = await systemTimeLoader()
+          if (!systemTime) {
+            return false
+          }
+          return new Date(sale.live_start_at) < new Date(systemTime)
+        },
       },
       onlineBiddingExtended: {
         type: new GraphQLNonNull(GraphQLBoolean),

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -70,7 +70,8 @@ const AuctionCollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
       liveBiddingStarted: {
         type: new GraphQLNonNull(GraphQLBoolean),
         description: "Live bidding has started on this lot's auction",
-        resolve: async ({ sale }) => !!sale.live_integration_started,
+        resolve: ({ sale }) =>
+          !!sale.live_start_at && new Date(sale.live_start_at) <= new Date(),
       },
       onlineBiddingExtended: {
         type: new GraphQLNonNull(GraphQLBoolean),


### PR DESCRIPTION
Resolves [EMI-2124]
Depends on https://github.com/artsy/gravity/pull/18199

This PR:
- Improves handling of a query for a sale artwork that may come back null.
- Changes our 'is this lot open for bidding? if not, then there are no auction signals' logic to rely on gravity rather than a time comparison on metaphysics.
- Changes our 'has live integration started' logic to rely on a newly-exposed gravity `live_integration_started` property.

- [x] Adding tests

cc @artsy/emerald-devs 

[EMI-2124]: https://artsyproduct.atlassian.net/browse/EMI-2124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ