### PR TITLE
feat(DIA-857): ExploreBy adjust wrong field and href route

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9367,9 +9367,9 @@ enum ExhibitionPeriodFormat {
 
 # A marketing collection category to explore by
 type ExploreByMarketingCollectionCategory {
+  href: String!
   image: Image
   name: String!
-  slug: String!
 }
 
 type External {

--- a/src/schema/v2/homeView/HomeViewSection.ts
+++ b/src/schema/v2/homeView/HomeViewSection.ts
@@ -178,7 +178,7 @@ const ExploreByMarketingCollectionCategory = new GraphQLObjectType<
   name: "ExploreByMarketingCollectionCategory",
   description: "A marketing collection category to explore by",
   fields: () => ({
-    slug: {
+    href: {
       type: GraphQLNonNull(GraphQLString),
     },
     name: {

--- a/src/schema/v2/homeView/sections/ExploreByMarketingCollectionCategories.ts
+++ b/src/schema/v2/homeView/sections/ExploreByMarketingCollectionCategories.ts
@@ -21,7 +21,7 @@ const categories = [
     image: {
       image_url: "https://files.artsy.net/images/capivara_chimarrao.jpg",
     },
-    href: "/marketing-collections/Medium",
+    href: "/collections-by-category/Medium",
   },
   {
     name: "Movement",
@@ -29,28 +29,28 @@ const categories = [
       image_url: "https://files.artsy.net/images/capivara_chimarrao.jpg",
     },
     // TODO: once the Movement MarketingCollectionCategory is available, we can use it here
-    href: "/marketing-collections/Medium",
+    href: "/collections-by-category/Medium",
   },
   {
     name: "Color",
     image: {
       image_url: "https://files.artsy.net/images/capivara_boia.jpg",
     },
-    href: "/marketing-collections/Collect by Color",
+    href: "/collections-by-category/Collect by Color",
   },
   {
     name: "Size",
     image: {
       image_url: "https://files.artsy.net/images/capivara_nadando.jpg",
     },
-    href: "/marketing-collections/Collect by Size",
+    href: "/collections-by-category/Collect by Size",
   },
   {
     name: "Price",
     image: {
       image_url: "https://files.artsy.net/images/capivara_filhotes.jpg",
     },
-    href: "/marketing-collections/Collect by Price",
+    href: "/collections-by-category/Collect by Price",
   },
   {
     name: "Gallery",
@@ -58,6 +58,6 @@ const categories = [
       image_url: "https://files.artsy.net/images/capivara_filhotes.jpg",
     },
     // TODO: once the Gallery MarketingCollectionCategory is available, we can use it here
-    href: "/marketing-collections/Medium",
+    href: "/collections-by-category/Medium",
   },
 ]


### PR DESCRIPTION
Follow-up on #6058 

Change the route name to `/collections-by-category/foo` on the Explore By Categories element.