### PR TITLE
fix: use unauthenticated artworkLoader for coverArtwork on Artist

### DIFF
--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -649,7 +649,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
         resolve: async (
           { id, cover_artwork_id },
           _options,
-          { artistArtworksLoader, artworkLoader }
+          { artistArtworksLoader, unauthenticatedLoaders: { artworkLoader } }
         ) => {
           if (cover_artwork_id) {
             try {


### PR DESCRIPTION
We see a mismatch when the cover artwork is unpublished. Some queries that propagate an admin's access token will continue to resolve the unpublished artwork. Other queries that are `@cacheable` won't - this mismatch (combined with more prefetching) - leads to images flashing/changing/disappearing.

The fix is to not return unpublished artworks from here by explicitly using a loader that won't.