### PR TITLE
chore: return a static `id` for `coverArtwork` for an Artist

### DIFF
--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -651,9 +651,15 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
           _options,
           { artistArtworksLoader, unauthenticatedLoaders: { artworkLoader } }
         ) => {
+          const staticArtworkID = `${id}-coverArtwork`
+
           if (cover_artwork_id) {
             try {
-              return await artworkLoader(cover_artwork_id)
+              const artwork = await artworkLoader(cover_artwork_id)
+              return {
+                ...artwork,
+                _id: staticArtworkID,
+              }
             } catch {
               // Intentionally ignore errors from unpublished/deleted artworks
               // that are set as cover artworks.
@@ -667,7 +673,10 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
             published: true,
           })
 
-          return fallbackArtwork
+          return {
+            ...fallbackArtwork,
+            _id: staticArtworkID,
+          }
         },
       },
       createdAt: date(),


### PR DESCRIPTION
So, this field can be cached for up to 24 hours - above the fold artist query.

But, as you prefetch artworks in the artist page grid, that query may be live and uncached - and if an admin has recently changed the cover artwork, you'd get back a totally different one in the prefetch - different `id` and everything.

This has the effect of messing up the Relay store normalization (or rather, it's working as designed), and that component which initially rendered gets lost.

So, let's treat this field with a synthetic id that's static (still scoped to the artist) - and see if that helps this behavior.