### PR TITLE
fix: allow inquiry questions on inquireable artworks

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -2029,7 +2029,7 @@ describe("Artwork type", () => {
     it("returns available inquiry questions if an artwork is not inquirable", () => {
       const context = {
         artworkLoader: () => {
-          return Promise.resolve({ id: "blah", sale_ids: ["sale_id"] })
+          return Promise.resolve({ id: "blah", inquireable: false })
         },
         inquiryRequestQuestionsLoader: () => {
           return Promise.reject()
@@ -2044,7 +2044,7 @@ describe("Artwork type", () => {
     it("returns inquiry questions if an artwork is inquirable", () => {
       const context = {
         artworkLoader: () => {
-          return Promise.resolve({ id: "blah", sale_ids: [] })
+          return Promise.resolve({ id: "blah", inquireable: true })
         },
         inquiryRequestQuestionsLoader: () => {
           return Promise.resolve([

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -728,12 +728,11 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         description:
           "Structured questions a collector can inquire on about this work",
         resolve: (
-          { sale_ids, id },
+          { id, inquireable },
           _params,
           { inquiryRequestQuestionsLoader }
         ) => {
-          // Sale artworks are not inquirable
-          if (!sale_ids.length) {
+          if (inquireable) {
             return inquiryRequestQuestionsLoader({
               inquireable_id: id,
               inquireable_type: "Artwork",


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PBRW-72

There seems to be a regression after https://github.com/artsy/eigen/pull/10833 that causes the send inquiry button disabled on Eigen when there is no inquiry questions selected. The inquiry artworks associated with the Kamala sale ([example](https://www.artsy.net/artwork/hugh-hayden-potus)) do not return inquiry questions because of [existing condition check](https://github.com/artsy/metaphysics/blob/82f73dd0fcfdd033783cfeeebaadcbab27609c62/src/schema/v2/artwork/index.ts#L735-L736). I propose we decouple inquireability from auctions here, and rely on the main `artwork.inquireable` to determine the inquireability. I think after this change, app users should be able to see the questions and at least able to send an inquiry from the app.

We'll need to revisit the app issue separately.