### PR TITLE
chore: use uncached data loader to fetch an artworks artists

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2288,6 +2288,8 @@ type Artwork implements Node & Searchable & Sellable {
     last: Int
   ): ArtistSeriesConnection
   artists(
+    private: Boolean = true
+
     # Use whatever is in the original response instead of making a request
     shallow: Boolean
   ): [Artist]

--- a/src/lib/stitching/vortex/__tests__/pricingContext.test.ts
+++ b/src/lib/stitching/vortex/__tests__/pricingContext.test.ts
@@ -54,11 +54,17 @@ describe("PricingContext type", () => {
       },
     ])
   )
-  const context: Partial<ResolverContext> = {
+  const context: Partial<
+    Omit<ResolverContext, "authenticatedLoaders" | "unauthenticatedLoaders"> & {
+      authenticatedLoaders: Partial<ResolverContext["authenticatedLoaders"]>
+      unauthenticatedLoaders: Partial<ResolverContext["unauthenticatedLoaders"]>
+    }
+  > = {
     meLoader,
     artworkLoader,
     artistLoader,
     salesLoader,
+    unauthenticatedLoaders: { artistLoader },
   }
   const query = gql`
     query {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -303,9 +303,27 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             description:
               "Use whatever is in the original response instead of making a request",
           },
+          private: {
+            type: GraphQLBoolean,
+            defaultValue: true,
+          },
         },
-        resolve: ({ artists }, { shallow }, { artistLoader }) => {
-          if (shallow) return artists
+        resolve: (
+          { artists },
+          args,
+          {
+            unauthenticatedLoaders: {
+              artistLoader: unauthenticatedArtistLoader,
+            },
+            authenticatedLoaders,
+          }
+        ) => {
+          if (args.shallow) return artists
+
+          const artistLoader =
+            args.private && authenticatedLoaders?.artistLoader
+              ? authenticatedLoaders?.artistLoader
+              : unauthenticatedArtistLoader
 
           return Promise.all(
             artists.map((artist) => artistLoader(artist.id))

--- a/src/schema/v2/artworkResult/__tests__/index.test.ts
+++ b/src/schema/v2/artworkResult/__tests__/index.test.ts
@@ -129,7 +129,9 @@ describe("Artwork type", () => {
 
     const context = {
       artworkLoader: () => Promise.resolve(artwork),
-      artistLoader: () => Promise.resolve({ name: "Catty Artist" }),
+      unauthenticatedLoaders: {
+        artistLoader: () => Promise.resolve({ name: "Catty Artist" }),
+      },
     }
     const query = `
       {

--- a/src/schema/v2/conversation/__tests__/submit_inquiry_request_mutation.test.ts
+++ b/src/schema/v2/conversation/__tests__/submit_inquiry_request_mutation.test.ts
@@ -82,7 +82,8 @@ describe("SubmitInquiryRequestMutation", () => {
       const context = {
         submitArtworkInquiryRequestLoader,
         userByIDLoader,
-        artistLoader,
+        unauthenticatedLoaders: { artistLoader },
+        authenticatedLoaders: { artistLoader },
       }
 
       expect.assertions(4)
@@ -156,7 +157,8 @@ describe("SubmitInquiryRequestMutation", () => {
       const context = {
         submitArtworkInquiryRequestLoader,
         userByIDLoader,
-        artistLoader,
+        unauthenticatedLoaders: { artistLoader },
+        authenticatedLoaders: { artistLoader },
       }
 
       expect.assertions(4)

--- a/src/schema/v2/test/utils.ts
+++ b/src/schema/v2/test/utils.ts
@@ -96,7 +96,12 @@ const unpackGraphQLError = (error: GraphQLError) => error.originalError || error
  */
 export const runAuthenticatedQuery = (
   query,
-  context: Partial<ResolverContext> = {}
+  context: Partial<
+    Omit<ResolverContext, "authenticatedLoaders" | "unauthenticatedLoaders"> & {
+      authenticatedLoaders: Partial<ResolverContext["authenticatedLoaders"]>
+      unauthenticatedLoaders: Partial<ResolverContext["unauthenticatedLoaders"]>
+    }
+  >
 ) => {
   const accessToken = "secret"
   const userID = "user-42"


### PR DESCRIPTION
Sort of minor, but we were never using a cached data loader to fetch artists for an artwork/artwork page. There _might_ be some use-cases where we do want to fetch a private artist, so I left this as opt-in, and on the artwork page we can include `private: false`.