### PR TITLE
chore: skip lotStandings fetch when the artwork isnt in an auction

### DIFF
--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1148,8 +1148,9 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       myLotStanding: {
         type: new GraphQLList(new GraphQLNonNull(LotStandingType)),
         args: { live: { type: GraphQLBoolean, defaultValue: null } },
-        resolve: ({ id }, { live }, { lotStandingLoader }) => {
+        resolve: ({ id, sale_ids }, { live }, { lotStandingLoader }) => {
           if (!lotStandingLoader) return null
+          if (!sale_ids || sale_ids.length === 0) return null
           return lotStandingLoader({ artwork_id: id, live })
         },
       },


### PR DESCRIPTION
We have `sale_ids` denormalized onto artworks exactly for this reason! You can tell if an artwork is in a sale or not just by fetching the artwork itself. Of course you may need to fetch the sale (or lot standings) to see if the sale is 'live', or fulfill other things, but you can always short-circuit if it's _not_ in a sale.