### PR TITLE
chore: guard against a null/undefined `body` when resolving partner locations

### DIFF
--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -762,8 +762,9 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           { size },
           { unauthenticatedLoaders: { partnerLocationsConnectionLoader } }
         ) => {
-          const locations = await partnerLocationsConnectionLoader(id, { size })
-          const cities = locations.body.map((location) => location.city)
+          const { body } = await partnerLocationsConnectionLoader(id, { size })
+
+          const cities = (body ?? []).map((location) => location.city)
 
           // Filter for dupes and blanks
           return Array.from(new Set(cities)).filter(Boolean)


### PR DESCRIPTION
Seeing traces that imply this is undefined (and can't call `map` on that). I can't actually reproduce this, but for now - coalesce it to `[]`