### PR TITLE
feat: add weaviate integration

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -84,6 +84,7 @@ const {
   VORTEX_API_BASE,
   VORTEX_APP_ID,
   VORTEX_TOKEN,
+  WEAVIATE_API_BASE,
 } = process.env
 
 const mustHave = {
@@ -219,4 +220,5 @@ export default {
   VORTEX_API_BASE,
   VORTEX_APP_ID,
   VORTEX_TOKEN,
+  WEAVIATE_API_BASE,
 }

--- a/src/lib/apis/weaviate.ts
+++ b/src/lib/apis/weaviate.ts
@@ -1,0 +1,15 @@
+import urljoin from "url-join"
+import { assign } from "lodash"
+import fetch from "./fetch"
+import config from "config"
+
+const { WEAVIATE_API_BASE } = config
+
+export const weaviate = (path, _accessToken, fetchOptions: any = {}) => {
+  const headers = { Accept: "application/json" }
+
+  return fetch(
+    urljoin(WEAVIATE_API_BASE, path),
+    assign({}, fetchOptions, { headers })
+  )
+}

--- a/src/lib/loaders/api/index.ts
+++ b/src/lib/loaders/api/index.ts
@@ -12,6 +12,7 @@ import { vortex } from "lib/apis/vortex"
 import { greenhouse } from "lib/apis/greenhouse"
 import { ipbase } from "lib/apis/ipbase"
 import { unleash } from "lib/apis/unleash"
+import { weaviate } from "lib/apis/weaviate"
 
 import { apiLoaderWithAuthenticationFactory } from "lib/loaders/api/loader_with_authentication_factory"
 import { apiLoaderWithoutAuthenticationFactory } from "lib/loaders/api/loader_without_authentication_factory"
@@ -256,6 +257,14 @@ export default (opts) => ({
   vortexLoaderWithoutAuthenticationFactory: apiLoaderWithoutAuthenticationFactory(
     vortex,
     "vortex",
+    opts
+  ),
+
+  // Loaders created by this factory are used for Weaviate requests.
+  // There is no authentication required for these requests **for now**.
+  weaviateLoaderWithoutAuthenticationFactory: apiLoaderWithoutAuthenticationFactory(
+    weaviate,
+    "weaviate",
     opts
   ),
 })

--- a/src/lib/loaders/loaders_without_authentication/index.ts
+++ b/src/lib/loaders/loaders_without_authentication/index.ts
@@ -9,6 +9,7 @@ import positronLoaders from "./positron"
 import greenhouseLoaders from "./greenhouse"
 import ipbaseLoaders from "./ipbase"
 import vortexLoaders from "./vortex"
+import weaviateLoaders from "./weaviate"
 
 export const createLoadersWithoutAuthentication = (opts) => ({
   ...convectionLoaders(opts),
@@ -22,6 +23,7 @@ export const createLoadersWithoutAuthentication = (opts) => ({
   ...greenhouseLoaders(opts),
   ...ipbaseLoaders(opts),
   ...vortexLoaders(opts),
+  ...weaviateLoaders(opts),
 })
 
 export type LoadersWithoutAuthentication = ReturnType<

--- a/src/lib/loaders/loaders_without_authentication/weaviate.ts
+++ b/src/lib/loaders/loaders_without_authentication/weaviate.ts
@@ -1,0 +1,24 @@
+import factories from "../api"
+
+interface GraphQLArgs {
+  query: string
+  variables?: any
+}
+
+export default (opts) => {
+  const {
+    weaviateLoaderWithoutAuthenticationFactory: weaviateLoader,
+  } = factories(opts)
+
+  return {
+    weaviateGraphqlLoader: ({ query, variables }: GraphQLArgs) => {
+      return weaviateLoader(
+        "/graphql",
+        { query, variables: JSON.stringify(variables) },
+        {
+          method: "POST",
+        }
+      )
+    },
+  }
+}


### PR DESCRIPTION
This PR adds Weaviate integration to Metaphysics.  
It sets up unauthenticated loaders, currently accessible only through the staging VPN. I will follow up on resolver types once [this PR](https://github.com/artsy/quantum/pull/36/files) is merged.