### PR TITLE
feat: add infinite discovery type and mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8036,6 +8036,26 @@ union CreateConsignmentInquiryMutationType =
     ConsignmentInquiryMutationFailure
   | ConsignmentInquiryMutationSuccess
 
+input CreateDiscoveryLikedArtworkMutationInput {
+  # The artwork's ID
+  artworkId: String!
+  clientMutationId: String
+
+  # The user's ID
+  userId: String!
+}
+
+type CreateDiscoveryLikedArtworkMutationPayload {
+  clientMutationId: String
+
+  # On success: return boolean. On failure: MutationError.
+  createDiscoveryLikedArtworkResponseOrError: CreateDiscoveryLikedArtworkResponseOrError
+}
+
+union CreateDiscoveryLikedArtworkResponseOrError =
+    DiscoveryLikedArtworkMutationFailure
+  | DiscoveryLikedArtworkMutationSuccess
+
 type CreateFeatureFailure {
   mutationError: GravityMutationError
 }
@@ -9125,6 +9145,14 @@ type DisableSecondFactorPayload {
   # A unique identifier for the client performing the mutation.
   clientMutationId: String
   secondFactorOrErrors: SecondFactorOrErrorsUnion!
+}
+
+type DiscoveryLikedArtworkMutationFailure {
+  mutationError: GravityMutationError
+}
+
+type DiscoveryLikedArtworkMutationSuccess {
+  success: Boolean
 }
 
 input DislikeArtworkInput {
@@ -13543,6 +13571,11 @@ type Mutation {
 
   # Create a credit card
   createCreditCard(input: CreditCardInput!): CreditCardPayload
+
+  # Create a liked artwork cross reference for the user in weaviate
+  createDiscoveryLikedArtworkMutation(
+    input: CreateDiscoveryLikedArtworkMutationInput!
+  ): CreateDiscoveryLikedArtworkMutationPayload
 
   # Creates a feature.
   createFeature(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8045,7 +8045,7 @@ input CreateDiscoveryArtworkReferenceMutationInput {
   reference: ReferenceTypes!
 
   # The user's ID
-  userId: String!
+  userId: String
 }
 
 type CreateDiscoveryArtworkReferenceMutationPayload {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16617,6 +16617,14 @@ type Query {
     last: Int
   ): ArtistConnection
   departments: [Department!]!
+  discoverArtworks(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    limit: Int
+    userId: String
+  ): ArtworkConnection
 
   # A namespace external partners (provided by Galaxy)
   external: External!
@@ -21256,6 +21264,14 @@ type Viewer {
     last: Int
   ): ArtistConnection
   departments: [Department!]!
+  discoverArtworks(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    limit: Int
+    userId: String
+  ): ArtworkConnection
 
   # A namespace external partners (provided by Galaxy)
   external: External!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8036,25 +8036,28 @@ union CreateConsignmentInquiryMutationType =
     ConsignmentInquiryMutationFailure
   | ConsignmentInquiryMutationSuccess
 
-input CreateDiscoveryLikedArtworkMutationInput {
+input CreateDiscoveryArtworkReferenceMutationInput {
   # The artwork's ID
   artworkId: String!
   clientMutationId: String
+
+  # The reference type
+  reference: ReferenceTypes!
 
   # The user's ID
   userId: String!
 }
 
-type CreateDiscoveryLikedArtworkMutationPayload {
+type CreateDiscoveryArtworkReferenceMutationPayload {
   clientMutationId: String
 
   # On success: return boolean. On failure: MutationError.
-  createDiscoveryLikedArtworkResponseOrError: CreateDiscoveryLikedArtworkResponseOrError
+  createDiscoveryArtworkReferenceResponseOrError: CreateDiscoveryArtworkReferenceResponseOrError
 }
 
-union CreateDiscoveryLikedArtworkResponseOrError =
-    DiscoveryLikedArtworkMutationFailure
-  | DiscoveryLikedArtworkMutationSuccess
+union CreateDiscoveryArtworkReferenceResponseOrError =
+    DiscoveryArtworkReferenceMutationFailure
+  | DiscoveryArtworkReferenceMutationSuccess
 
 type CreateFeatureFailure {
   mutationError: GravityMutationError
@@ -9147,11 +9150,11 @@ type DisableSecondFactorPayload {
   secondFactorOrErrors: SecondFactorOrErrorsUnion!
 }
 
-type DiscoveryLikedArtworkMutationFailure {
+type DiscoveryArtworkReferenceMutationFailure {
   mutationError: GravityMutationError
 }
 
-type DiscoveryLikedArtworkMutationSuccess {
+type DiscoveryArtworkReferenceMutationSuccess {
   success: Boolean
 }
 
@@ -13572,10 +13575,10 @@ type Mutation {
   # Create a credit card
   createCreditCard(input: CreditCardInput!): CreditCardPayload
 
-  # Create a liked artwork cross reference for the user in weaviate
-  createDiscoveryLikedArtworkMutation(
-    input: CreateDiscoveryLikedArtworkMutationInput!
-  ): CreateDiscoveryLikedArtworkMutationPayload
+  # Creates a cross reference for artwork and user in weaviate
+  createDiscoveryArtworkReference(
+    input: CreateDiscoveryArtworkReferenceMutationInput!
+  ): CreateDiscoveryArtworkReferenceMutationPayload
 
   # Creates a feature.
   createFeature(
@@ -17545,6 +17548,11 @@ type RecordArtworkViewPayload {
 
   # A unique identifier for the client performing the mutation.
   clientMutationId: String
+}
+
+enum ReferenceTypes {
+  DISLIKED_ARTWORKS
+  LIKED_ARTWORKS
 }
 
 enum RelatedArtistsKind {

--- a/src/lib/loaders/loaders_without_authentication/weaviate.ts
+++ b/src/lib/loaders/loaders_without_authentication/weaviate.ts
@@ -20,5 +20,11 @@ export default (opts) => {
         }
       )
     },
+    weaviateCreateCrossReferenceLoader: weaviateLoader(
+      (userId) =>
+        `objects/InfiniteDiscoveryUsers/${userId}/references/likedArtworks`,
+      {},
+      { method: "POST" }
+    ),
   }
 }

--- a/src/lib/loaders/loaders_without_authentication/weaviate.ts
+++ b/src/lib/loaders/loaders_without_authentication/weaviate.ts
@@ -21,8 +21,7 @@ export default (opts) => {
       )
     },
     weaviateCreateCrossReferenceLoader: weaviateLoader(
-      (userId) =>
-        `objects/InfiniteDiscoveryUsers/${userId}/references/likedArtworks`,
+      (path) => `objects/InfiniteDiscoveryUsers/${path}`,
       {},
       { method: "POST" }
     ),

--- a/src/schema/v2/__tests__/discoverArtworks.test.js
+++ b/src/schema/v2/__tests__/discoverArtworks.test.js
@@ -1,0 +1,76 @@
+import { runQuery } from "schema/v2/test/utils"
+import config from "config"
+
+beforeAll(() => {
+  config.WEAVIATE_API_BASE = "https://api.artsy.net/v1"
+})
+
+describe("DiscoverArtworks", () => {
+  let context
+
+  const artworkIds = [
+    {
+      internalID: "percy-cat",
+    },
+    {
+      internalID: "fiby-cat",
+    },
+  ]
+
+  const artworks = [
+    {
+      internalID: "percy-cat",
+      title: "Percy Cat",
+    },
+    {
+      internalID: "fiby-cat",
+      title: "Fiby Cat",
+    },
+  ]
+
+  beforeEach(() => {
+    context = {
+      weaviateGraphqlLoader: () => () => {
+        return Promise.resolve({
+          data: {
+            Get: {
+              InfiniteDiscoveryArtworks: artworkIds,
+            },
+          },
+        })
+      },
+      artworksLoader: () => Promise.resolve(artworks),
+    }
+  })
+
+  it("returns artworks connection", async () => {
+    const query = `
+        {
+          discoverArtworks(userId: "user-xyz") {
+            edges {
+              node {
+                title
+              }
+            }
+          }
+        }
+      `
+
+    const { discoverArtworks } = await runQuery(query, context)
+
+    expect(discoverArtworks.edges).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "node": Object {
+            "title": "Percy Cat",
+          },
+        },
+        Object {
+          "node": Object {
+            "title": "Fiby Cat",
+          },
+        },
+      ]
+    `)
+  })
+})

--- a/src/schema/v2/createDiscoveryArtworkReferenceMutation.ts
+++ b/src/schema/v2/createDiscoveryArtworkReferenceMutation.ts
@@ -65,7 +65,7 @@ export const CreateDiscoveryLikedArtworkMutation = mutationWithClientMutationId<
   inputFields: {
     userId: {
       description: "The user's ID",
-      type: new GraphQLNonNull(GraphQLString),
+      type: GraphQLString,
     },
     artworkId: {
       description: "The artwork's ID",

--- a/src/schema/v2/createDiscoveryLikedArtworkMutation.ts
+++ b/src/schema/v2/createDiscoveryLikedArtworkMutation.ts
@@ -1,0 +1,102 @@
+import {
+  GraphQLBoolean,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { mutationWithClientMutationId } from "graphql-relay"
+import uuid from "uuid/v5"
+
+export const generateUuid = (userId: string) => {
+  if (!userId) return ""
+  return uuid(userId, uuid.DNS).toString()
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DiscoveryLikedArtworkMutationSuccess",
+  isTypeOf: (data) => data.success,
+  fields: () => ({
+    success: {
+      type: GraphQLBoolean,
+      resolve: (result) => result.success,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DiscoveryLikedArtworkMutationFailure",
+  isTypeOf: (data) => {
+    return data._type === "GravityMutationError"
+  },
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "CreateDiscoveryLikedArtworkResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const createDiscoveryLikedArtworkMutation = mutationWithClientMutationId<
+  { userId: string; artworkId: string },
+  any,
+  ResolverContext
+>({
+  name: "CreateDiscoveryLikedArtworkMutation",
+  description:
+    "Create a liked artwork cross reference for the user in weaviate",
+  inputFields: {
+    userId: {
+      description: "The user's ID",
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    artworkId: {
+      description: "The artwork's ID",
+      type: new GraphQLNonNull(GraphQLString),
+    },
+  },
+  outputFields: {
+    createDiscoveryLikedArtworkResponseOrError: {
+      type: ResponseOrErrorType,
+      description: "On success: return boolean. On failure: MutationError.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { userId, artworkId },
+    { weaviateCreateCrossReferenceLoader }
+  ) => {
+    if (!weaviateCreateCrossReferenceLoader) {
+      new Error("Weaviate loader not available")
+    }
+
+    const artworkUUID = generateUuid(artworkId)
+
+    // TODO: Understand why localhost works here and weaviate://weaviate.stg.artsy.net doesn't
+    const artworkBeacon = `weaviate://localhost/InfiniteDiscoveryArtworks/${artworkUUID}`
+    const userUUID = generateUuid(userId)
+    try {
+      await weaviateCreateCrossReferenceLoader(userUUID, {
+        beacon: artworkBeacon,
+      })
+      return { success: true }
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/createDiscoveryLikedArtworkMutation.ts
+++ b/src/schema/v2/createDiscoveryLikedArtworkMutation.ts
@@ -11,12 +11,7 @@ import {
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
 import { mutationWithClientMutationId } from "graphql-relay"
-import uuid from "uuid/v5"
-
-export const generateUuid = (userId: string) => {
-  if (!userId) return ""
-  return uuid(userId, uuid.DNS).toString()
-}
+import { generateUuid, generateBeacon } from "./discoverArtworks"
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
   name: "DiscoveryLikedArtworkMutationSuccess",
@@ -81,10 +76,13 @@ export const createDiscoveryLikedArtworkMutation = mutationWithClientMutationId<
     }
 
     const artworkUUID = generateUuid(artworkId)
+    const artworkBeacon = generateBeacon(
+      "InfiniteDiscoveryArtworks",
+      artworkUUID
+    )
 
-    // TODO: Understand why localhost works here and weaviate://weaviate.stg.artsy.net doesn't
-    const artworkBeacon = `weaviate://localhost/InfiniteDiscoveryArtworks/${artworkUUID}`
     const userUUID = generateUuid(userId)
+
     try {
       await weaviateCreateCrossReferenceLoader(userUUID, {
         beacon: artworkBeacon,

--- a/src/schema/v2/discoverArtworks.ts
+++ b/src/schema/v2/discoverArtworks.ts
@@ -1,0 +1,62 @@
+import { GraphQLString, GraphQLFieldConfig, GraphQLInt } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { artworkConnection } from "./artwork"
+import { connectionFromArray } from "graphql-relay"
+import { pageable } from "relay-cursor-paging"
+import gql from "lib/gql"
+import config from "config"
+import { URL } from "url"
+import uuid from "uuid/v5"
+
+export const generateUuid = (userId: string) => {
+  if (!userId) return ""
+  return uuid(userId, uuid.DNS).toString()
+}
+
+export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
+  type: artworkConnection.connectionType,
+  args: pageable({
+    userId: { type: GraphQLString },
+    limit: { type: GraphQLInt },
+  }),
+  resolve: async (_root, args, { weaviateGraphqlLoader, artworksLoader }) => {
+    if (!weaviateGraphqlLoader) return
+
+    const { userId, limit = 5 } = args
+    const { WEAVIATE_API_BASE } = config
+
+    const userUUID = generateUuid(userId)
+
+    const hostName = new URL(WEAVIATE_API_BASE as string).hostname
+    const beacon = `weaviate://${hostName}/InfiniteDiscoveryUsers/${userUUID}`
+
+    const query = gql`
+      {
+        Get {
+          InfiniteDiscoveryArtworks(nearObject: {beacon: "${beacon}"}, limit: ${limit}) {
+            internalID
+            _additional {
+              id
+            }
+          }
+        }
+      }
+    `
+
+    const body = await weaviateGraphqlLoader({
+      query,
+    })()
+
+    if (!body.data.Get.InfiniteDiscoveryArtworks)
+      return connectionFromArray([], args)
+
+    const artworkIds = body.data.Get.InfiniteDiscoveryArtworks.map(
+      (node) => node.internalID
+    )
+
+    const artworks =
+      artworkIds?.length > 0 ? await artworksLoader({ ids: artworkIds }) : []
+
+    return connectionFromArray(artworks, args)
+  },
+}

--- a/src/schema/v2/discoverArtworks.ts
+++ b/src/schema/v2/discoverArtworks.ts
@@ -4,8 +4,6 @@ import { artworkConnection } from "./artwork"
 import { connectionFromArray } from "graphql-relay"
 import { pageable } from "relay-cursor-paging"
 import gql from "lib/gql"
-import config from "config"
-import { URL } from "url"
 import uuid from "uuid/v5"
 
 export const generateUuid = (userId: string) => {
@@ -23,12 +21,11 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
     if (!weaviateGraphqlLoader) return
 
     const { userId, limit = 5 } = args
-    const { WEAVIATE_API_BASE } = config
 
     const userUUID = generateUuid(userId)
 
-    const hostName = new URL(WEAVIATE_API_BASE as string).hostname
-    const beacon = `weaviate://${hostName}/InfiniteDiscoveryUsers/${userUUID}`
+    // TODO: Understand why localhost works here and weaviate://weaviate.stg.artsy.net doesn't
+    const beacon = `weaviate://localhost/InfiniteDiscoveryUsers/${userUUID}`
 
     const query = gql`
       {

--- a/src/schema/v2/discoverArtworks.ts
+++ b/src/schema/v2/discoverArtworks.ts
@@ -11,6 +11,11 @@ export const generateUuid = (userId: string) => {
   return uuid(userId, uuid.DNS).toString()
 }
 
+export const generateBeacon = (namespace: string, identifier: string) => {
+  // TODO: Understand why localhost works here and weaviate://weaviate.stg.artsy.net doesn't
+  return `weaviate://localhost/${namespace}/${identifier}`
+}
+
 export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
   type: artworkConnection.connectionType,
   args: pageable({
@@ -23,9 +28,7 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
     const { userId, limit = 5 } = args
 
     const userUUID = generateUuid(userId)
-
-    // TODO: Understand why localhost works here and weaviate://weaviate.stg.artsy.net doesn't
-    const beacon = `weaviate://localhost/InfiniteDiscoveryUsers/${userUUID}`
+    const beacon = generateBeacon("InfiniteDiscoveryUsers", userUUID)
 
     const query = gql`
       {

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -235,7 +235,7 @@ import { PrincipalFieldDirective } from "directives/principalField/principalFiel
 import { commerceOptInMutation } from "./partner/CommerceOptIn/commerceOptInMutation"
 import { commerceOptInReportMutation } from "./partner/CommerceOptIn/commerceOptInReportMutation"
 import { DiscoverArtworks } from "./discoverArtworks"
-import { createDiscoveryLikedArtworkMutation } from "./createDiscoveryLikedArtworkMutation"
+import { CreateDiscoveryLikedArtworkMutation } from "./createDiscoveryArtworkReferenceMutation"
 
 const rootFields = {
   // artworkVersion: ArtworkVersionResolver,
@@ -396,7 +396,7 @@ export default new GraphQLSchema({
       createCollection: createCollectionMutation,
       createConsignmentInquiry: createConsignmentInquiryMutation,
       createCreditCard: createCreditCardMutation,
-      createDiscoveryLikedArtworkMutation: createDiscoveryLikedArtworkMutation,
+      createDiscoveryArtworkReference: CreateDiscoveryLikedArtworkMutation,
       createFeature: CreateFeatureMutation,
       createFeaturedLink: CreateFeaturedLinkMutation,
       createGeminiEntryForAsset: CreateGeminiEntryForAsset,

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -235,6 +235,7 @@ import { PrincipalFieldDirective } from "directives/principalField/principalFiel
 import { commerceOptInMutation } from "./partner/CommerceOptIn/commerceOptInMutation"
 import { commerceOptInReportMutation } from "./partner/CommerceOptIn/commerceOptInReportMutation"
 import { DiscoverArtworks } from "./discoverArtworks"
+import { createDiscoveryLikedArtworkMutation } from "./createDiscoveryLikedArtworkMutation"
 
 const rootFields = {
   // artworkVersion: ArtworkVersionResolver,
@@ -395,6 +396,7 @@ export default new GraphQLSchema({
       createCollection: createCollectionMutation,
       createConsignmentInquiry: createConsignmentInquiryMutation,
       createCreditCard: createCreditCardMutation,
+      createDiscoveryLikedArtworkMutation: createDiscoveryLikedArtworkMutation,
       createFeature: CreateFeatureMutation,
       createFeaturedLink: CreateFeaturedLinkMutation,
       createGeminiEntryForAsset: CreateGeminiEntryForAsset,

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -234,6 +234,7 @@ import { OptionalFieldDirective } from "directives/optionalField/optionalFieldsD
 import { PrincipalFieldDirective } from "directives/principalField/principalFieldDirectiveExtension"
 import { commerceOptInMutation } from "./partner/CommerceOptIn/commerceOptInMutation"
 import { commerceOptInReportMutation } from "./partner/CommerceOptIn/commerceOptInReportMutation"
+import { DiscoverArtworks } from "./discoverArtworks"
 
 const rootFields = {
   // artworkVersion: ArtworkVersionResolver,
@@ -281,6 +282,7 @@ const rootFields = {
   conversationsConnection: Conversations,
   creditCard: CreditCard,
   curatedTrendingArtists: CuratedTrendingArtists,
+  discoverArtworks: DiscoverArtworks,
   departments,
   external: externalField,
   fair: Fair,


### PR DESCRIPTION
This PR introduces the `discoverArtworks` query type and the `createDiscoveryArtworkReference` mutation used for Infinite Discovery:

```graphql
discoverArtworks(
  after: String
  before: String
  first: Int
  last: Int
  userId: String
): ArtworkConnection
```

```graphql
createDiscoveryArtworkReference(
  input: CreateDiscoveryArtworkReferenceMutationInput!
): CreateDiscoveryArtworkReferenceMutationPayload
```