### PR TITLE
feat(home view): add a showsConnection to HomeViewSectionShows

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11414,6 +11414,12 @@ type HomeViewSectionShows implements HomeViewSectionGeneric & Node {
 
   # [Analytics] `owner type` analytics value for this scetion when displayed in a standalone UI, as defined in our schema (artsy/cohesion)
   ownerType: String
+  showsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ShowConnection
 }
 
 # A viewing rooms section in the home view

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11419,6 +11419,9 @@ type HomeViewSectionShows implements HomeViewSectionGeneric & Node {
     before: String
     first: Int
     last: Int
+
+    # Include shows within a radius of the provided location
+    near: Near
   ): ShowConnection
 }
 

--- a/src/schema/v2/homeView/sectionTypes/Shows.ts
+++ b/src/schema/v2/homeView/sectionTypes/Shows.ts
@@ -7,6 +7,7 @@ import { standardSectionFields } from "./GenericSectionInterface"
 import { ShowsConnection } from "schema/v2/show"
 import { pageable } from "relay-cursor-paging"
 import { emptyConnection } from "schema/v2/fields/pagination"
+import Near from "schema/v2/input_fields/near"
 
 export const HomeViewShowsSectionType = new GraphQLObjectType<
   any,
@@ -20,7 +21,12 @@ export const HomeViewShowsSectionType = new GraphQLObjectType<
 
     showsConnection: {
       type: ShowsConnection.connectionType,
-      args: pageable({}),
+      args: pageable({
+        near: {
+          type: Near,
+          description: "Include shows within a radius of the provided location",
+        },
+      }),
       resolve: (parent, ...rest) =>
         parent.resolver ? parent.resolver(parent, ...rest) : emptyConnection,
     },

--- a/src/schema/v2/homeView/sectionTypes/Shows.ts
+++ b/src/schema/v2/homeView/sectionTypes/Shows.ts
@@ -4,6 +4,9 @@ import { NodeInterface } from "../../object_identification"
 import { HomeViewGenericSectionInterface } from "./GenericSectionInterface"
 import { HomeViewSectionTypeNames } from "./names"
 import { standardSectionFields } from "./GenericSectionInterface"
+import { ShowsConnection } from "schema/v2/show"
+import { pageable } from "relay-cursor-paging"
+import { emptyConnection } from "schema/v2/fields/pagination"
 
 export const HomeViewShowsSectionType = new GraphQLObjectType<
   any,
@@ -14,5 +17,12 @@ export const HomeViewShowsSectionType = new GraphQLObjectType<
   interfaces: [HomeViewGenericSectionInterface, NodeInterface],
   fields: {
     ...standardSectionFields,
+
+    showsConnection: {
+      type: ShowsConnection.connectionType,
+      args: pageable({}),
+      resolve: (parent, ...rest) =>
+        parent.resolver ? parent.resolver(parent, ...rest) : emptyConnection,
+    },
   },
 })

--- a/src/schema/v2/homeView/sections/ShowsForYou.ts
+++ b/src/schema/v2/homeView/sections/ShowsForYou.ts
@@ -1,6 +1,13 @@
 import { ContextModule } from "@artsy/cohesion"
 import { HomeViewSection } from "."
 import { HomeViewSectionTypeNames } from "../sectionTypes/names"
+import { withHomeViewTimeout } from "../helpers/withHomeViewTimeout"
+import { ResolverContext } from "types/graphql"
+import { ShowsConnection } from "schema/v2/me/showsConnection"
+import { emptyConnection } from "schema/v2/fields/pagination"
+import { EventStatusEnums } from "schema/v2/input_fields/event_status"
+
+const SHOWS_TIMEOUT_MS = 6000
 
 export const ShowsForYou: HomeViewSection = {
   id: "home-view-section-shows-for-you",
@@ -10,4 +17,24 @@ export const ShowsForYou: HomeViewSection = {
     title: "Shows for You",
   },
   requiresAuthentication: true,
+
+  shouldBeDisplayed: (_context: ResolverContext) => true,
+
+  resolver: withHomeViewTimeout(async (parent, args, context, info) => {
+    if (!ShowsConnection.resolve) return emptyConnection
+
+    const finalArgs = {
+      ...args,
+      status: EventStatusEnums.getValue("RUNNING_AND_UPCOMING")?.value,
+    }
+
+    const result = await ShowsConnection.resolve(
+      parent,
+      finalArgs,
+      context,
+      info
+    )
+
+    return result
+  }, SHOWS_TIMEOUT_MS),
 }

--- a/src/schema/v2/homeView/sections/__tests__/ShowsForYou.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/ShowsForYou.test.ts
@@ -1,0 +1,174 @@
+import gql from "lib/gql"
+import { runQuery } from "schema/v2/test/utils"
+
+describe("ShowsForYou", () => {
+  it("returns the section's metadata", async () => {
+    const query = gql`
+      {
+        homeView {
+          section(id: "home-view-section-shows-for-you") {
+            __typename
+            internalID
+            contextModule
+            component {
+              title
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      accessToken: "424242",
+    }
+
+    const { homeView } = await runQuery(query, context)
+
+    expect(homeView.section).toMatchInlineSnapshot(`
+      Object {
+        "__typename": "HomeViewSectionShows",
+        "component": Object {
+          "title": "Shows for You",
+        },
+        "contextModule": "showsRail",
+        "internalID": "home-view-section-shows-for-you",
+      }
+    `)
+  })
+
+  it("returns the section's connection data", async () => {
+    const query = gql`
+      {
+        homeView {
+          section(id: "home-view-section-shows-for-you") {
+            ... on HomeViewSectionShows {
+              showsConnection(first: 3) {
+                edges {
+                  node {
+                    slug
+                    name
+                    location {
+                      city
+                      coordinates {
+                        lat
+                        lng
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const showsResponse = {
+      headers: {
+        "x-total-count": 2,
+      },
+      body: [
+        {
+          id: "gallery-one-a-nice-show",
+          name: "A nice show",
+          location: {
+            city: "New York",
+            coordinates: { lng: -74.0027, lat: 40.2854 },
+          },
+        },
+        {
+          id: "gallery-two-another-nice-show",
+          name: "Another nice show",
+          location: {
+            city: "New York",
+            coordinates: { lng: -73.4105, lat: 40.2535 },
+          },
+        },
+      ],
+    }
+
+    const meShowsLoader = jest.fn(async () => showsResponse)
+
+    const context: any = {
+      accessToken: "424242",
+      meShowsLoader,
+    }
+
+    const { homeView } = await runQuery(query, context)
+
+    expect(homeView.section).toMatchInlineSnapshot(`
+      Object {
+        "showsConnection": Object {
+          "edges": Array [
+            Object {
+              "node": Object {
+                "location": Object {
+                  "city": "New York",
+                  "coordinates": Object {
+                    "lat": 40.2854,
+                    "lng": -74.0027,
+                  },
+                },
+                "name": "A nice show",
+                "slug": "gallery-one-a-nice-show",
+              },
+            },
+            Object {
+              "node": Object {
+                "location": Object {
+                  "city": "New York",
+                  "coordinates": Object {
+                    "lat": 40.2535,
+                    "lng": -73.4105,
+                  },
+                },
+                "name": "Another nice show",
+                "slug": "gallery-two-another-nice-show",
+              },
+            },
+          ],
+        },
+      }
+    `)
+  })
+
+  it("handles a `near` argument", async () => {
+    const query = gql`
+      {
+        homeView {
+          section(id: "home-view-section-shows-for-you") {
+            ... on HomeViewSectionShows {
+              showsConnection(first: 3, near: { lat: 40.7, lng: -74 }) {
+                edges {
+                  node {
+                    slug
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const showsResponse = {
+      headers: {
+        "x-total-count": 0,
+      },
+      body: [],
+    }
+
+    const meShowsLoader = jest.fn(async () => showsResponse)
+
+    const context: any = {
+      accessToken: "424242",
+      meShowsLoader,
+    }
+
+    await runQuery(query, context)
+
+    expect(meShowsLoader).toHaveBeenCalledWith(
+      expect.objectContaining({ near: "40.7,-74" })
+    )
+  })
+})


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-1340

`HomeViewSectionShows` is one of the three section types that wasn't yet using new-style data resolution. 

This PR addresses that.

First we modify the `HomeViewSectionShows` _section **type**_ by :

- giving it a `showsConnection`
- allowing that `showsConnection` to take a `near` argument

Then we modify the `ShowsForYou` _section **instance**_ by:

- wiring up the existing `meShowsLoader` (via `ShowsConnection.resolve`) which can make use of the `near` argument passed in from the client