### PR TITLE
fix: always return a list for Partner.locations

### DIFF
--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -948,8 +948,11 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             defaultValue: 25,
           },
         },
-        resolve: ({ id }, options, { partnerLocationsLoader }) =>
-          partnerLocationsLoader(id, options),
+        resolve: async ({ id }, options, { partnerLocationsLoader }) => {
+          const locations = await partnerLocationsLoader(id, options)
+
+          return locations ?? []
+        },
       },
       locationsConnection: {
         description: "A connection of locations from a Partner.",


### PR DESCRIPTION
We see a large volume of: `GraphQLError: Expected Iterable, but did not find one for field Partner.locations`

It's not actually clear to me why this is happening / a repro! Clearly we're...not returning a list where we should be? But stubbing loader responses of `null`, `[]`, `[null]`, `[[]]` doesn't trigger it.

So I'm a bit surprised, but this feels like a sensible default/update that we can try and see if that clears up the errors (would still love to see a repro though). No test cause no repro  