### PR TITLE
fix(homeView): casing in FeaturedFairs section

### DIFF
--- a/src/schema/v2/homeView/sections/FeaturedFairs.ts
+++ b/src/schema/v2/homeView/sections/FeaturedFairs.ts
@@ -11,7 +11,7 @@ export const FeaturedFairs: HomeViewSection = {
   contextModule: ContextModule.fairRail,
   component: {
     title: "Featured Fairs",
-    description: "See Works in Top Art Fairs",
+    description: "See works in top art fairs",
   },
   featureFlag: "onyx_enable-home-view-section-featured-fairs",
   requiresAuthentication: false,


### PR DESCRIPTION
Addresses https://www.notion.so/artsy/Subtitle-under-Featured-Fairs-should-it-be-in-sentence-case-11acab0764a0805cb0ead821f47be498

Small QA fix, now follows our [house guidelines](https://docs.google.com/document/d/1NoBSYM-EBA4b6rdux-8CQJWneXcglISHzZNvSkKFDh0/edit#bookmark=id.ki32zyvvxu5h) for subheadings.
