### PR TITLE
fix: include headers: true info in cache key

### DIFF
--- a/src/lib/loaders/api/loader_without_authentication_factory.ts
+++ b/src/lib/loaders/api/loader_without_authentication_factory.ts
@@ -101,8 +101,12 @@ export const apiLoaderWithoutAuthenticationFactory = <T = any>(
             const reduceData = ({ body, headers }) =>
               apiOptions.headers ? { body, headers } : body
 
+            // Include `headers` in the cache key if `headers: true` was specified.
+            // This is because the shape of the cached data will be different.
+            const cacheKey = apiOptions.headers ? `${key}::headers` : key
+
             const cacheData = (data, options: CacheOptions) => {
-              cache.set(key, data, options).catch((err) => warn(key, err))
+              cache.set(cacheKey, data, options).catch((err) => warn(key, err))
               return data
             }
 
@@ -126,7 +130,7 @@ export const apiLoaderWithoutAuthenticationFactory = <T = any>(
               // No need to run reduceData on a cache fetch.
               return (
                 cache
-                  .get(key)
+                  .get(cacheKey)
                   // Cache hit
                   .then(
                     finish({


### PR DESCRIPTION
Great spot from @joeyAghion .

Consider the scenario:
  - a request using a loader with `headers: true` comes in - and caches the data and headers
  - a request using a loader without `headers: true` comes in....but with the same resulting arguments/cache key as that first request - it gets served the cached data that's in the wrong form it was expecting

Partner locations seem to be a big offender of it b/c we have two loaders pointing to the same endpoint (easily called w/ identical arguments) - but one specifies `headers: true` and one doesn't.

It's ok to not modify their keys w.r.t to DataLoader - if all of their arguments are identical, we can just make one request to fulfill both data loader requests.

But - they must then be cached differently.

So the fix is - include that `headers` information in the resulting cache key.