### PR TITLE
chore(AMBER-1084): Commerce Opt in and Opt in Report allow for locationID param 

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5546,7 +5546,7 @@ input CommerceOptInMutationInput {
   id: String!
 
   # The partner location ID to assign
-  location: String
+  locationId: String
 
   # whether or not pick up it is pick up available
   pickupAvailable: Boolean
@@ -5585,6 +5585,9 @@ input CommerceOptInReportMutationInput {
 
   # ID of the partner
   id: String!
+
+  # The partner location ID to assign
+  locationId: String
 
   # whether or not pick up should be available
   pickupAvailable: Boolean

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5545,6 +5545,9 @@ input CommerceOptInMutationInput {
   # ID of the partner
   id: String!
 
+  # The partner location ID to assign
+  location: String
+
   # whether or not pick up it is pick up available
   pickupAvailable: Boolean
 }

--- a/src/schema/v2/partner/CommerceOptIn/commerceOptInMutation.ts
+++ b/src/schema/v2/partner/CommerceOptIn/commerceOptInMutation.ts
@@ -33,6 +33,7 @@ interface Input {
   certificateOfAuthenticity?: boolean
   coaByGallery?: boolean
   coaByAuthenticatingBody?: boolean
+  location?: string
 }
 
 const CommerceOptInSuccesssType = new GraphQLObjectType<any, ResolverContext>({
@@ -106,6 +107,10 @@ export const commerceOptInMutation = mutationWithClientMutationId<
       type: GraphQLBoolean,
       description: "whether or not the CoA is by an authenticating body",
     },
+    location: {
+      type: GraphQLString,
+      description: "The partner location ID to assign",
+    },
   },
   outputFields: {
     commerceOptInMutationOrError: {
@@ -122,6 +127,7 @@ export const commerceOptInMutation = mutationWithClientMutationId<
       certificateOfAuthenticity,
       coaByGallery,
       coaByAuthenticatingBody,
+      locationId,
     },
     { optInArtworksIntoCommerceLoader }
   ) => {
@@ -132,6 +138,7 @@ export const commerceOptInMutation = mutationWithClientMutationId<
       certificate_of_authenticity: certificateOfAuthenticity,
       coa_by_gallery: coaByGallery,
       coa_by_authenticating_body: coaByAuthenticatingBody,
+      location_id: locationId,
     }
 
     if (!optInArtworksIntoCommerceLoader) {

--- a/src/schema/v2/partner/CommerceOptIn/commerceOptInMutation.ts
+++ b/src/schema/v2/partner/CommerceOptIn/commerceOptInMutation.ts
@@ -33,7 +33,7 @@ interface Input {
   certificateOfAuthenticity?: boolean
   coaByGallery?: boolean
   coaByAuthenticatingBody?: boolean
-  location?: string
+  locationId?: string
 }
 
 const CommerceOptInSuccesssType = new GraphQLObjectType<any, ResolverContext>({
@@ -107,7 +107,7 @@ export const commerceOptInMutation = mutationWithClientMutationId<
       type: GraphQLBoolean,
       description: "whether or not the CoA is by an authenticating body",
     },
-    location: {
+    locationId: {
       type: GraphQLString,
       description: "The partner location ID to assign",
     },

--- a/src/schema/v2/partner/CommerceOptIn/commerceOptInReportMutation.ts
+++ b/src/schema/v2/partner/CommerceOptIn/commerceOptInReportMutation.ts
@@ -31,6 +31,7 @@ interface Input {
   coaByGallery?: boolean
   coaByAuthenticatingBody?: boolean
   eligible?: boolean
+  locationId?: string
 }
 
 const CommerceOptInReportSuccesssType = new GraphQLObjectType<
@@ -116,6 +117,10 @@ export const commerceOptInReportMutation = mutationWithClientMutationId<
       description:
         "whether the report will contain data for eligible or non-eligible artworks.",
     },
+    locationId: {
+      type: GraphQLString,
+      description: "The partner location ID to assign",
+    },
   },
   outputFields: {
     commerceOptInReportMutationOrError: {
@@ -133,6 +138,7 @@ export const commerceOptInReportMutation = mutationWithClientMutationId<
       coaByGallery,
       coaByAuthenticatingBody,
       eligible,
+      locationId,
     },
     { createCommerceOptInEligibleArtworksReportLoader }
   ) => {
@@ -144,6 +150,7 @@ export const commerceOptInReportMutation = mutationWithClientMutationId<
       coa_by_gallery: coaByGallery,
       coa_by_authenticating_body: coaByAuthenticatingBody,
       eligible: eligible,
+      location_id: locationId,
     }
 
     if (!createCommerceOptInEligibleArtworksReportLoader) {


### PR DESCRIPTION
This PR addresses [AMBER-1084]

We're adding `locationID` as a potential attribute for CommerceOptIn and CommerceOptInReport. Will follow up with artsy_shipping in separate PR.

[AMBER-1084]: https://artsyproduct.atlassian.net/browse/AMBER-1084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ