### PR TITLE
chore: update schema for Exchange

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4583,6 +4583,7 @@ type CommerceBuyOrder implements CommerceOrder {
   orderUpdateState: String
   paymentMethod: CommercePaymentMethodEnum
   paymentMethodDetails: PaymentMethodUnion
+  paymentSet: Boolean!
   requestedFulfillment: CommerceRequestedFulfillmentUnion
 
   # Whether the buyer needs to complete identity verification to make this purchase.
@@ -4972,7 +4973,7 @@ type CommerceCreatePartnerOfferOrderPayload {
 scalar CommerceDate
 
 # An ISO 8601 datetime
-scalar CommerceDateTime
+scalar CommerceDateTime @specifiedBy(url: "https://tools.ietf.org/html/rfc3339")
 
 enum CommerceEeiFormStatusEnum {
   # approved
@@ -5430,6 +5431,7 @@ type CommerceOfferOrder implements CommerceOrder {
   orderUpdateState: String
   paymentMethod: CommercePaymentMethodEnum
   paymentMethodDetails: PaymentMethodUnion
+  paymentSet: Boolean!
   requestedFulfillment: CommerceRequestedFulfillmentUnion
 
   # Whether the buyer needs to complete identity verification to make this purchase.
@@ -5717,6 +5719,7 @@ interface CommerceOrder {
   orderUpdateState: String
   paymentMethod: CommercePaymentMethodEnum
   paymentMethodDetails: PaymentMethodUnion
+  paymentSet: Boolean!
   requestedFulfillment: CommerceRequestedFulfillmentUnion
 
   # Whether the buyer needs to complete identity verification to make this purchase.
@@ -5801,6 +5804,11 @@ interface CommerceOrder {
 # Order Action data
 type CommerceOrderActionData {
   clientSecret: String!
+}
+
+enum CommerceOrderConnectionFilterEnum {
+  # payment failure preventing order from processing further
+  PAYMENT_FAILED
 }
 
 # Fields to sort by
@@ -16553,6 +16561,7 @@ type Query {
 
     # Returns the elements in the list that come before the specified cursor.
     before: String
+    filters: [CommerceOrderConnectionFilterEnum!] = []
 
     # Returns the first _n_ elements from the list.
     first: Int

--- a/src/data/exchange.graphql
+++ b/src/data/exchange.graphql
@@ -147,6 +147,7 @@ type BuyOrder implements Order {
   orderHistory: [OrderEventUnion!]!
   orderUpdateState: String
   paymentMethod: PaymentMethodEnum
+  paymentSet: Boolean!
   requestedFulfillment: RequestedFulfillmentUnion
 
   """
@@ -669,7 +670,7 @@ scalar Date
 """
 An ISO 8601 datetime
 """
-scalar DateTime
+scalar DateTime @specifiedBy(url: "https://tools.ietf.org/html/rfc3339")
 
 enum EeiFormStatusEnum {
   """
@@ -1360,6 +1361,7 @@ type OfferOrder implements Order {
   orderHistory: [OrderEventUnion!]!
   orderUpdateState: String
   paymentMethod: PaymentMethodEnum
+  paymentSet: Boolean!
   requestedFulfillment: RequestedFulfillmentUnion
 
   """
@@ -1450,6 +1452,7 @@ interface Order {
   orderHistory: [OrderEventUnion!]!
   orderUpdateState: String
   paymentMethod: PaymentMethodEnum
+  paymentSet: Boolean!
   requestedFulfillment: RequestedFulfillmentUnion
 
   """
@@ -1477,6 +1480,13 @@ Order Action data
 """
 type OrderActionData {
   clientSecret: String!
+}
+
+enum OrderConnectionFilterEnum {
+  """
+  payment failure preventing order from processing further
+  """
+  PAYMENT_FAILED
 }
 
 """
@@ -1964,6 +1974,7 @@ type Query {
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    filters: [OrderConnectionFilterEnum!] = []
 
     """
     Returns the first _n_ elements from the list.


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/EMI-2085

Following https://github.com/artsy/exchange/pull/2270, this updates MP schema to exposed the new `paymentSet` field on an order.

This picks up the update in https://github.com/artsy/metaphysics/pull/6113. Let's see which one gets merged first! 😬 