### PR TITLE
fix(home view): shape of empty connections

### DIFF
--- a/src/schema/v2/homeView/sectionTypes/Activity.ts
+++ b/src/schema/v2/homeView/sectionTypes/Activity.ts
@@ -6,6 +6,7 @@ import { NodeInterface } from "../../object_identification"
 import { HomeViewGenericSectionInterface } from "./GenericSectionInterface"
 import { HomeViewSectionTypeNames } from "./names"
 import { standardSectionFields } from "./GenericSectionInterface"
+import { emptyConnection } from "schema/v2/fields/pagination"
 
 export const HomeViewActivitySectionType = new GraphQLObjectType<
   any,
@@ -22,7 +23,9 @@ export const HomeViewActivitySectionType = new GraphQLObjectType<
 
       args: pageable({}),
       resolve: (parent, ...rest) => {
-        return parent.resolver ? parent.resolver(parent, ...rest) : []
+        return parent.resolver
+          ? parent.resolver(parent, ...rest)
+          : emptyConnection
       },
     },
   },

--- a/src/schema/v2/homeView/sectionTypes/Articles.ts
+++ b/src/schema/v2/homeView/sectionTypes/Articles.ts
@@ -6,6 +6,7 @@ import { NodeInterface } from "../../object_identification"
 import { HomeViewSectionTypeNames } from "./names"
 import { standardSectionFields } from "./GenericSectionInterface"
 import { HomeViewGenericSectionInterface } from "./GenericSectionInterface"
+import { emptyConnection } from "schema/v2/fields/pagination"
 
 export const HomeViewArticlesSectionType = new GraphQLObjectType<
   any,
@@ -21,7 +22,7 @@ export const HomeViewArticlesSectionType = new GraphQLObjectType<
       type: ArticlesConnection.type,
       args: pageable({}),
       resolve: (parent, ...rest) =>
-        parent.resolver ? parent.resolver(parent, ...rest) : [],
+        parent.resolver ? parent.resolver(parent, ...rest) : emptyConnection,
     },
   },
 })

--- a/src/schema/v2/homeView/sectionTypes/AuctionResults.ts
+++ b/src/schema/v2/homeView/sectionTypes/AuctionResults.ts
@@ -6,6 +6,7 @@ import { NodeInterface } from "../../object_identification"
 import { HomeViewGenericSectionInterface } from "./GenericSectionInterface"
 import { HomeViewSectionTypeNames } from "./names"
 import { standardSectionFields } from "./GenericSectionInterface"
+import { emptyConnection } from "schema/v2/fields/pagination"
 
 export const HomeViewAuctionResultsSectionType = new GraphQLObjectType<
   any,
@@ -21,7 +22,9 @@ export const HomeViewAuctionResultsSectionType = new GraphQLObjectType<
       type: auctionResultConnection.connectionType,
       args: pageable({}),
       resolve: (parent, ...rest) => {
-        return parent.resolver ? parent.resolver(parent, ...rest) : []
+        return parent.resolver
+          ? parent.resolver(parent, ...rest)
+          : emptyConnection
       },
     },
   },

--- a/src/schema/v2/homeView/sectionTypes/Fairs.ts
+++ b/src/schema/v2/homeView/sectionTypes/Fairs.ts
@@ -6,6 +6,7 @@ import { NodeInterface } from "../../object_identification"
 import { HomeViewGenericSectionInterface } from "./GenericSectionInterface"
 import { HomeViewSectionTypeNames } from "./names"
 import { standardSectionFields } from "./GenericSectionInterface"
+import { emptyConnection } from "schema/v2/fields/pagination"
 
 export const HomeViewFairsSectionType = new GraphQLObjectType<
   any,
@@ -21,7 +22,7 @@ export const HomeViewFairsSectionType = new GraphQLObjectType<
       type: fairsConnection.type,
       args: pageable({}),
       resolve: (parent, ...rest) =>
-        parent.resolver ? parent.resolver(parent, ...rest) : [],
+        parent.resolver ? parent.resolver(parent, ...rest) : emptyConnection,
     },
   },
 })

--- a/src/schema/v2/homeView/sectionTypes/MarketingCollections.ts
+++ b/src/schema/v2/homeView/sectionTypes/MarketingCollections.ts
@@ -1,7 +1,10 @@
 import { GraphQLObjectType } from "graphql"
 import { pageable } from "relay-cursor-paging"
 import { ResolverContext } from "types/graphql"
-import { connectionWithCursorInfo } from "../../fields/pagination"
+import {
+  connectionWithCursorInfo,
+  emptyConnection,
+} from "../../fields/pagination"
 import { MarketingCollectionType } from "../../marketingCollections"
 import { NodeInterface } from "../../object_identification"
 import { HomeViewGenericSectionInterface } from "./GenericSectionInterface"
@@ -24,7 +27,7 @@ export const HomeViewMarketingCollectionsSectionType = new GraphQLObjectType<
       }).connectionType,
       args: pageable({}),
       resolve: (parent, ...rest) =>
-        parent.resolver ? parent.resolver(parent, ...rest) : [],
+        parent.resolver ? parent.resolver(parent, ...rest) : emptyConnection,
     },
   },
 })

--- a/src/schema/v2/homeView/sectionTypes/Sales.ts
+++ b/src/schema/v2/homeView/sectionTypes/Sales.ts
@@ -6,6 +6,7 @@ import { SalesConnectionField } from "../../sales"
 import { HomeViewGenericSectionInterface } from "./GenericSectionInterface"
 import { HomeViewSectionTypeNames } from "./names"
 import { standardSectionFields } from "./GenericSectionInterface"
+import { emptyConnection } from "schema/v2/fields/pagination"
 
 export const HomeViewSalesSectionType = new GraphQLObjectType<
   any,
@@ -21,7 +22,7 @@ export const HomeViewSalesSectionType = new GraphQLObjectType<
       type: SalesConnectionField.type,
       args: pageable({}),
       resolve: (parent, ...rest) =>
-        parent.resolver ? parent.resolver(parent, ...rest) : [],
+        parent.resolver ? parent.resolver(parent, ...rest) : emptyConnection,
     },
   },
 })

--- a/src/schema/v2/homeView/sections/ActiveBids.ts
+++ b/src/schema/v2/homeView/sections/ActiveBids.ts
@@ -3,6 +3,7 @@ import { HomeViewSection } from "."
 import { withHomeViewTimeout } from "../helpers/withHomeViewTimeout"
 import { HomeViewSectionTypeNames } from "../sectionTypes/names"
 import { connectionFromArray } from "graphql-relay"
+import { emptyConnection } from "schema/v2/fields/pagination"
 
 export const ActiveBids: HomeViewSection = {
   id: "home-view-section-active-bids",
@@ -16,7 +17,7 @@ export const ActiveBids: HomeViewSection = {
   resolver: withHomeViewTimeout(async (_parent, args, context, _info) => {
     const { lotStandingLoader } = context
 
-    if (!lotStandingLoader) return []
+    if (!lotStandingLoader) return emptyConnection
 
     let result = await lotStandingLoader({
       live: true,

--- a/src/schema/v2/homeView/sections/Auctions.ts
+++ b/src/schema/v2/homeView/sections/Auctions.ts
@@ -4,6 +4,7 @@ import { withHomeViewTimeout } from "../helpers/withHomeViewTimeout"
 import { HomeViewSectionTypeNames } from "../sectionTypes/names"
 import { HomePageSalesModuleType } from "schema/v2/home/home_page_sales_module"
 import { connectionFromArray } from "graphql-relay"
+import { emptyConnection } from "schema/v2/fields/pagination"
 
 export const Auctions: HomeViewSection = {
   id: "home-view-section-auctions",
@@ -25,7 +26,7 @@ export const Auctions: HomeViewSection = {
     const { results: resolver } = HomePageSalesModuleType.getFields()
 
     if (!resolver?.resolve) {
-      return []
+      return emptyConnection
     }
 
     const result = await resolver.resolve(parent, args, context, info)

--- a/src/schema/v2/homeView/sections/FeaturedFairs.ts
+++ b/src/schema/v2/homeView/sections/FeaturedFairs.ts
@@ -4,6 +4,7 @@ import { withHomeViewTimeout } from "../helpers/withHomeViewTimeout"
 import { HomeViewSectionTypeNames } from "../sectionTypes/names"
 import { HomePageFairsModuleType } from "schema/v2/home/home_page_fairs_module"
 import { connectionFromArray } from "graphql-relay"
+import { emptyConnection } from "schema/v2/fields/pagination"
 
 export const FeaturedFairs: HomeViewSection = {
   id: "home-view-section-featured-fairs",
@@ -20,7 +21,7 @@ export const FeaturedFairs: HomeViewSection = {
     const { results: resolver } = HomePageFairsModuleType.getFields()
 
     if (!resolver?.resolve) {
-      return []
+      return emptyConnection
     }
 
     const result = await resolver.resolve(parent, args, context, info)

--- a/src/schema/v2/homeView/sections/MarketingCollections.ts
+++ b/src/schema/v2/homeView/sections/MarketingCollections.ts
@@ -4,6 +4,7 @@ import { withHomeViewTimeout } from "../helpers/withHomeViewTimeout"
 import { HomeViewSectionTypeNames } from "../sectionTypes/names"
 import { HomePageMarketingCollectionsModuleType } from "schema/v2/home/home_page_marketing_collections_module"
 import { connectionFromArray } from "graphql-relay"
+import { emptyConnection } from "schema/v2/fields/pagination"
 
 export const MarketingCollections: HomeViewSection = {
   id: "home-view-section-marketing-collections",
@@ -20,7 +21,7 @@ export const MarketingCollections: HomeViewSection = {
     } = HomePageMarketingCollectionsModuleType.getFields()
 
     if (!resolver?.resolve) {
-      return []
+      return emptyConnection
     }
 
     const result = await resolver.resolve(parent, args, context, info)

--- a/src/schema/v2/homeView/sections/SimilarToRecentlyViewedArtworks.ts
+++ b/src/schema/v2/homeView/sections/SimilarToRecentlyViewedArtworks.ts
@@ -3,6 +3,7 @@ import { HomeViewSection } from "."
 import { withHomeViewTimeout } from "../helpers/withHomeViewTimeout"
 import { HomeViewSectionTypeNames } from "../sectionTypes/names"
 import { SimilarToRecentlyViewed } from "schema/v2/me/similarToRecentlyViewed"
+import { emptyConnection } from "schema/v2/fields/pagination"
 
 export const SimilarToRecentlyViewedArtworks: HomeViewSection = {
   id: "home-view-section-similar-to-recently-viewed-artworks",
@@ -20,12 +21,12 @@ export const SimilarToRecentlyViewedArtworks: HomeViewSection = {
   requiresAuthentication: true,
 
   resolver: withHomeViewTimeout(async (parent, args, context, info) => {
-    if (!context.meLoader) return []
+    if (!context.meLoader) return emptyConnection
 
     const { recently_viewed_artwork_ids } = await context.meLoader()
 
     if (recently_viewed_artwork_ids.length === 0) {
-      return []
+      return emptyConnection
     }
     const recentlyViewedIds = recently_viewed_artwork_ids.slice(0, 7)
 


### PR DESCRIPTION
As [pointed out a while back](https://artsy.slack.com/archives/C05EQL4R5N0/p1724099057516639?thread_ts=1724081856.316439&cid=C05EQL4R5N0) by @mzikherman, it's technically incorrect to return `[]` for an empty connection.

Instead we have an `emptyConnection` helper that returns the correct shape — 

https://github.com/artsy/metaphysics/blob/0f2e865fbe86b705cace2df46018daf1c7dedaec/src/schema/v2/fields/pagination.ts#L235-L238

We applied this a little bit after that comment, but not everywhere.

This PR fixes that. Confirmed that all sections still look good in simulator 👍🏽 