### PR TITLE
chore(AMBER-1085): update Commerce Opt in and Opt in Report allow for artsyDomesticShipping param

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5528,6 +5528,9 @@ type CommerceOptInFailure {
 }
 
 input CommerceOptInMutationInput {
+  # Opt artwork into Artsy Shipping Domestic
+  artsyShippingDomestic: Boolean
+
   # whether or not there is a CoA
   certificateOfAuthenticity: Boolean
   clientMutationId: String
@@ -5566,6 +5569,9 @@ type CommerceOptInReportFailure {
 }
 
 input CommerceOptInReportMutationInput {
+  # Opt artwork into Artsy Shipping Domestic
+  artsyShippingDomestic: Boolean
+
   # whether it should be updated to CoA
   certificateOfAuthenticity: Boolean
   clientMutationId: String

--- a/src/schema/v2/partner/CommerceOptIn/commerceOptInMutation.ts
+++ b/src/schema/v2/partner/CommerceOptIn/commerceOptInMutation.ts
@@ -34,6 +34,7 @@ interface Input {
   coaByGallery?: boolean
   coaByAuthenticatingBody?: boolean
   locationId?: string
+  artsyShippingDomestic?: boolean
 }
 
 const CommerceOptInSuccesssType = new GraphQLObjectType<any, ResolverContext>({
@@ -111,6 +112,10 @@ export const commerceOptInMutation = mutationWithClientMutationId<
       type: GraphQLString,
       description: "The partner location ID to assign",
     },
+    artsyShippingDomestic: {
+      type: GraphQLBoolean,
+      description: "Opt artwork into Artsy Shipping Domestic",
+    },
   },
   outputFields: {
     commerceOptInMutationOrError: {
@@ -128,6 +133,7 @@ export const commerceOptInMutation = mutationWithClientMutationId<
       coaByGallery,
       coaByAuthenticatingBody,
       locationId,
+      artsyShippingDomestic,
     },
     { optInArtworksIntoCommerceLoader }
   ) => {
@@ -139,6 +145,7 @@ export const commerceOptInMutation = mutationWithClientMutationId<
       coa_by_gallery: coaByGallery,
       coa_by_authenticating_body: coaByAuthenticatingBody,
       location_id: locationId,
+      artsy_shipping_domestic: artsyShippingDomestic,
     }
 
     if (!optInArtworksIntoCommerceLoader) {

--- a/src/schema/v2/partner/CommerceOptIn/commerceOptInReportMutation.ts
+++ b/src/schema/v2/partner/CommerceOptIn/commerceOptInReportMutation.ts
@@ -32,6 +32,7 @@ interface Input {
   coaByAuthenticatingBody?: boolean
   eligible?: boolean
   locationId?: string
+  artsyShippingDomestic?: boolean
 }
 
 const CommerceOptInReportSuccesssType = new GraphQLObjectType<
@@ -121,6 +122,10 @@ export const commerceOptInReportMutation = mutationWithClientMutationId<
       type: GraphQLString,
       description: "The partner location ID to assign",
     },
+    artsyShippingDomestic: {
+      type: GraphQLBoolean,
+      description: "Opt artwork into Artsy Shipping Domestic",
+    },
   },
   outputFields: {
     commerceOptInReportMutationOrError: {
@@ -139,6 +144,7 @@ export const commerceOptInReportMutation = mutationWithClientMutationId<
       coaByAuthenticatingBody,
       eligible,
       locationId,
+      artsyShippingDomestic,
     },
     { createCommerceOptInEligibleArtworksReportLoader }
   ) => {
@@ -151,6 +157,7 @@ export const commerceOptInReportMutation = mutationWithClientMutationId<
       coa_by_authenticating_body: coaByAuthenticatingBody,
       eligible: eligible,
       location_id: locationId,
+      artsy_shipping_domestic: artsyShippingDomestic,
     }
 
     if (!createCommerceOptInEligibleArtworksReportLoader) {


### PR DESCRIPTION
This PR addresses [AMBER-1085](https://artsyproduct.atlassian.net/browse/AMBER-1084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

We're adding artsyDomesticShipping as a potential attribute for CommerceOptIn and CommerceOptInReport. 

[AMBER-1085]: https://artsyproduct.atlassian.net/browse/AMBER-1085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ