### PR TITLE
feat(home view): allow per-env timeout for shows resolver

### DIFF
--- a/src/schema/v2/homeView/helpers/__tests__/withHomeViewTimeout.test.ts
+++ b/src/schema/v2/homeView/helpers/__tests__/withHomeViewTimeout.test.ts
@@ -1,0 +1,61 @@
+import { withTimeout } from "lib/loaders/helpers"
+import { withHomeViewTimeout } from "../withHomeViewTimeout"
+import { ResolverContext } from "types/graphql"
+import { GraphQLResolveInfo } from "graphql"
+import config from "config"
+
+jest.mock("lib/loaders/helpers", () => ({
+  withTimeout: jest.fn(() => Promise.resolve()),
+}))
+
+const mockWithTimeout = withTimeout as jest.Mock
+
+const fakeResolverArgs: [any, any, ResolverContext, GraphQLResolveInfo] = [
+  {},
+  {},
+  {} as ResolverContext,
+  {} as GraphQLResolveInfo,
+]
+
+describe("withHomeViewTimeout", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("when no timeout is provided", () => {
+    it("defaults to an env var value from the config", async () => {
+      const aSlowResolver = jest.fn()
+      const aResolverWithTimeout = withHomeViewTimeout(aSlowResolver)
+
+      await aResolverWithTimeout(...fakeResolverArgs)
+
+      expect(mockWithTimeout.mock.calls[0][1]).toBe(
+        config.HOME_VIEW_RESOLVER_TIMEOUT_MS
+      )
+    })
+  })
+
+  describe("when timeout is provided", () => {
+    it("defaults to the provided value", async () => {
+      const aSlowResolver = jest.fn()
+      const aResolverWithTimeout = withHomeViewTimeout(aSlowResolver, 4242)
+
+      await aResolverWithTimeout(...fakeResolverArgs)
+
+      expect(mockWithTimeout.mock.calls[0][1]).toBe(4242)
+    })
+  })
+
+  describe("when timeout is `undefined`", () => {
+    it("defaults to an env var value from the config", async () => {
+      const aSlowResolver = jest.fn()
+      const aResolverWithTimeout = withHomeViewTimeout(aSlowResolver, undefined)
+
+      await aResolverWithTimeout(...fakeResolverArgs)
+
+      expect(mockWithTimeout.mock.calls[0][1]).toBe(
+        config.HOME_VIEW_RESOLVER_TIMEOUT_MS
+      )
+    })
+  })
+})

--- a/src/schema/v2/homeView/sections/ShowsForYou.ts
+++ b/src/schema/v2/homeView/sections/ShowsForYou.ts
@@ -6,8 +6,11 @@ import { ResolverContext } from "types/graphql"
 import { ShowsConnection } from "schema/v2/me/showsConnection"
 import { emptyConnection } from "schema/v2/fields/pagination"
 import { EventStatusEnums } from "schema/v2/input_fields/event_status"
+import config from "config"
 
-const SHOWS_TIMEOUT_MS = 6000
+// custom timeout for development/staging
+const SHOWS_TIMEOUT_MS =
+  config.SYSTEM_ENVIRONMENT === "production" ? undefined : 10000
 
 export const ShowsForYou: HomeViewSection = {
   id: "home-view-section-shows-for-you",


### PR DESCRIPTION
Follow-up to [this discussion](https://github.com/artsy/metaphysics/pull/6107/files#r1792716561) 

This tweaks the `ShowsForYou` resolver — known to be slow — to allow a more generous timeout in dev/staging, while still honoring the `HOME_VIEW_RESOLVER_TIMEOUT_MS` env var in production.

