### PR TITLE
fix: removes @specifiedBy directive from exchange schema

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4973,7 +4973,7 @@ type CommerceCreatePartnerOfferOrderPayload {
 scalar CommerceDate
 
 # An ISO 8601 datetime
-scalar CommerceDateTime @specifiedBy(url: "https://tools.ietf.org/html/rfc3339")
+scalar CommerceDateTime
 
 enum CommerceEeiFormStatusEnum {
   # approved

--- a/src/data/exchange.graphql
+++ b/src/data/exchange.graphql
@@ -670,7 +670,7 @@ scalar Date
 """
 An ISO 8601 datetime
 """
-scalar DateTime @specifiedBy(url: "https://tools.ietf.org/html/rfc3339")
+scalar DateTime
 
 enum EeiFormStatusEnum {
   """


### PR DESCRIPTION
The Force/Relay setup there doesn't seem to like this directive, so for now just remove it manually (but we should follow-up to ensure it doesn't come back in Exchange).