### PR TITLE
feat: ensure home view section titles are title cased

### DIFF
--- a/src/schema/v2/homeView/__tests__/HomeView.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeView.test.ts
@@ -79,7 +79,7 @@ describe("homeView", () => {
                 "node": Object {
                   "__typename": "HomeViewSectionCard",
                   "component": Object {
-                    "title": "Galleries Near You",
+                    "title": "Galleries near You",
                   },
                 },
               },
@@ -171,7 +171,7 @@ describe("homeView", () => {
                 "node": Object {
                   "__typename": "HomeViewSectionArtworks",
                   "component": Object {
-                    "title": "New works for You",
+                    "title": "New Works for You",
                   },
                 },
               },
@@ -209,7 +209,7 @@ describe("homeView", () => {
                 "node": Object {
                   "__typename": "HomeViewSectionArtworks",
                   "component": Object {
-                    "title": "Auction lots for You",
+                    "title": "Auction Lots for You",
                   },
                 },
               },
@@ -233,7 +233,7 @@ describe("homeView", () => {
                 "node": Object {
                   "__typename": "HomeViewSectionCard",
                   "component": Object {
-                    "title": "Galleries Near You",
+                    "title": "Galleries near You",
                   },
                 },
               },
@@ -387,7 +387,7 @@ describe("homeView", () => {
                       Object {
                         "__typename": "HomeViewSectionArtworks",
                         "component": Object {
-                          "title": "Auction lots for You",
+                          "title": "Auction Lots for You",
                         },
                       }
                   `)

--- a/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeViewSection.test.ts
@@ -147,7 +147,7 @@ describe("HomeViewSection", () => {
                 "ownerType": null,
               },
             },
-            "title": "New works for You",
+            "title": "New Works for You",
           },
           "ownerType": "newWorksForYou",
         }
@@ -195,7 +195,7 @@ describe("HomeViewSection", () => {
                 "ownerType": null,
               },
             },
-            "title": "Auction lots for You",
+            "title": "Auction Lots for You",
           },
           "ownerType": "lotsByArtistsYouFollow",
         }
@@ -1621,7 +1621,7 @@ describe("HomeViewSection", () => {
               "imageURL": "https://files.artsy.net/images/galleries_for_you.webp",
             },
             "subtitle": "Follow these local galleries for updates on artists you love.",
-            "title": "Galleries Near You",
+            "title": "Galleries near You",
           },
           "ownerType": "galleriesForYou",
         }

--- a/src/schema/v2/homeView/sections/AuctionLotsForYou.ts
+++ b/src/schema/v2/homeView/sections/AuctionLotsForYou.ts
@@ -9,7 +9,7 @@ export const AuctionLotsForYou: HomeViewSection = {
   type: HomeViewSectionTypeNames.HomeViewSectionArtworks,
   contextModule: ContextModule.lotsForYouRail,
   component: {
-    title: "Auction lots for You",
+    title: "Auction Lots for You",
     behaviors: {
       viewAll: {
         buttonText: "Browse All Artworks",

--- a/src/schema/v2/homeView/sections/GalleriesNearYou.ts
+++ b/src/schema/v2/homeView/sections/GalleriesNearYou.ts
@@ -9,7 +9,7 @@ export const GalleriesNearYou: HomeViewSection = {
   type: HomeViewSectionTypeNames.HomeViewSectionCard,
   contextModule: ContextModule.galleriesForYouBanner,
   component: {
-    title: "Galleries Near You",
+    title: "Galleries near You",
     description:
       "Follow these local galleries for updates on artists you love.",
   },

--- a/src/schema/v2/homeView/sections/NewWorksForYou.ts
+++ b/src/schema/v2/homeView/sections/NewWorksForYou.ts
@@ -9,7 +9,7 @@ export const NewWorksForYou: HomeViewSection = {
   type: HomeViewSectionTypeNames.HomeViewSectionArtworks,
   contextModule: ContextModule.newWorksForYouRail,
   component: {
-    title: "New works for You",
+    title: "New Works for You",
     behaviors: {
       viewAll: {
         buttonText: "Browse All Artworks",

--- a/src/schema/v2/homeView/sections/__tests__/GalleriesNearYou.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/GalleriesNearYou.test.ts
@@ -28,7 +28,7 @@ describe("GalleriesNearYou", () => {
       Object {
         "__typename": "HomeViewSectionCard",
         "component": Object {
-          "title": "Galleries Near You",
+          "title": "Galleries near You",
         },
         "contextModule": "galleriesForYouBanner",
         "internalID": "home-view-section-galleries-near-you",
@@ -72,7 +72,7 @@ describe("GalleriesNearYou", () => {
             "imageURL": "https://files.artsy.net/images/galleries_for_you.webp",
           },
           "subtitle": "Follow these local galleries for updates on artists you love.",
-          "title": "Galleries Near You",
+          "title": "Galleries near You",
         },
       }
     `)


### PR DESCRIPTION
According to our [house style / artsy copy style guide][guide], we should be using Chicago-style title case for "Main header components", "Collection titles", and "Navigation".

Based on our current usage of the section title, I think this rule applies.

Whenever in doubt, I used the [tool][] mentioned in our guide, selecting "Chicago" style.

[guide]: https://docs.google.com/document/d/1NoBSYM-EBA4b6rdux-8CQJWneXcglISHzZNvSkKFDh0/edit?usp=sharing
[tool]: https://titlecaseconverter.com