### PR TITLE
chore: Add partner search criteria id to hits edge AMBER-1090

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15095,6 +15095,7 @@ type PartnerAlertHitsEdge {
 
   # The item at the end of the edge
   node: Alert
+  partnerSearchCriteriaID: String
   userIDs: [String]
 }
 

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -193,6 +193,11 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           resolve: ({ artwork }) => artwork,
         },
         createdAt: date(),
+        partnerSearchCriteriaID: {
+          type: GraphQLString,
+          resolve: ({ partner_search_criteria_id }) =>
+            partner_search_criteria_id,
+        },
         userIDs: {
           type: new GraphQLList(GraphQLString),
           resolve: ({ user_ids }) => user_ids,


### PR DESCRIPTION
Building on top of https://github.com/artsy/gravity/pull/18243, this PR updates the edge of the hits connection to include this `PartnerSearchCriteria` id so that we can properly track from the "Matched Alerts" tab in CMS.

https://artsyproduct.atlassian.net/browse/AMBER-1090

/cc @artsy/amber-devs