### PR TITLE
feat: return preferred network as card brand when available

### DIFF
--- a/src/schema/v2/__tests__/credit_card.test.ts
+++ b/src/schema/v2/__tests__/credit_card.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable promise/always-return */
 import { runQuery } from "schema/v2/test/utils"
 
-describe.skip("CreditCard type", () => {
+describe("CreditCard type", () => {
   let creditCard: any
   let context: any
 
@@ -10,6 +10,7 @@ describe.skip("CreditCard type", () => {
       id: "card123",
       brand: "Visa",
       last_digits: "4242",
+      preferred_network: null,
     }
 
     context = {
@@ -17,7 +18,7 @@ describe.skip("CreditCard type", () => {
     }
   })
 
-  it("fetches a credit card ID", () => {
+  it("fetches a credit card ID", async () => {
     const query = `
       {
         creditCard(id: "card123") {
@@ -28,10 +29,46 @@ describe.skip("CreditCard type", () => {
       }
     `
 
-    return runQuery(query, context).then((data) => {
-      expect(data!.creditCard.internalID).toBe("card123")
-      expect(data!.creditCard.brand).toBe("Visa")
-      expect(data!.creditCard.lastDigits).toBe("4242")
-    })
+    const data = await runQuery(query, context)
+    expect(data!.creditCard.internalID).toBe("card123")
+    expect(data!.creditCard.brand).toBe("Visa")
+    expect(data!.creditCard.lastDigits).toBe("4242")
+  })
+
+  it("returns card brand directly when preferred network unavailable", async () => {
+    const query = `
+      {
+        creditCard(id: "card123") {
+          brand
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+    expect(data!.creditCard.brand).toBe("Visa")
+  })
+
+  it("returns preferred network as card brand when available", async () => {
+    creditCard = {
+      id: "card123",
+      brand: "Visa",
+      last_digits: "4242",
+      preferred_network: "Cartes Bancaires",
+    }
+
+    context = {
+      creditCardLoader: () => Promise.resolve(creditCard),
+    }
+
+    const query = `
+      {
+        creditCard(id: "card123") {
+          brand
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+    expect(data!.creditCard.brand).toBe("Cartes Bancaires")
   })
 })

--- a/src/schema/v2/credit_card.ts
+++ b/src/schema/v2/credit_card.ts
@@ -65,6 +65,7 @@ export const CreditCardType = new GraphQLObjectType<any, ResolverContext>({
     brand: {
       type: new GraphQLNonNull(GraphQLString),
       description: "Brand of credit card",
+      resolve: ({ brand, preferred_network }) => preferred_network || brand,
     },
     name: {
       type: GraphQLString,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/EMI-2063

We use the credit card brand when displaying card icons, and in the co-branded card compliance project, we'll want to display the preferred card network (that users select) in the icon so that users understand which network will be used to process a card transaction.