### PR TITLE
chore: add remainingMinor to Invoice

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11999,6 +11999,7 @@ type Invoice {
     symbol: String
     thousand: String = ","
   ): String
+  remainingMinor: Int!
   state: InvoiceState!
 }
 

--- a/src/schema/v2/Invoice/invoice.ts
+++ b/src/schema/v2/Invoice/invoice.ts
@@ -93,6 +93,10 @@ const InvoiceType = new GraphQLObjectType<any, ResolverContext>({
       resolve: ({ payments }) => payments,
     },
     remaining: amount(({ remaining_cents }) => remaining_cents),
+    remainingMinor: {
+      type: new GraphQLNonNull(GraphQLInt),
+      resolve: ({ remaining_cents }) => remaining_cents,
+    },
     externalNote: {
       type: GraphQLString,
       resolve: ({ external_note }) => external_note,


### PR DESCRIPTION
Minor - need this field so we can allow a payment to be made in this numeric amount.