### PR TITLE
feat: update query args for homeview > latest articles

### DIFF
--- a/src/schema/v2/homeView/sections/LatestArticles.ts
+++ b/src/schema/v2/homeView/sections/LatestArticles.ts
@@ -3,6 +3,7 @@ import { HomeViewSection } from "."
 import { withHomeViewTimeout } from "../helpers/withHomeViewTimeout"
 import { HomeViewSectionTypeNames } from "../sectionTypes/names"
 import ArticlesConnection from "schema/v2/articlesConnection"
+import ArticleSorts from "schema/v2/sorts/article_sorts"
 
 export const LatestArticles: HomeViewSection = {
   id: "home-view-section-latest-articles",
@@ -19,5 +20,22 @@ export const LatestArticles: HomeViewSection = {
   },
   requiresAuthentication: false,
 
-  resolver: withHomeViewTimeout(ArticlesConnection.resolve!),
+  resolver: withHomeViewTimeout(async (parent, args, context, info) => {
+    const finalArgs = {
+      // formerly specified client-side
+      published: true,
+      sort: ArticleSorts.type.getValue("PUBLISHED_AT_DESC")?.value,
+      featured: true,
+      ...args,
+    }
+
+    const result = await ArticlesConnection.resolve!(
+      parent,
+      finalArgs,
+      context,
+      info
+    )
+
+    return result
+  }),
 }


### PR DESCRIPTION
This PR fixes an issue with the new home view latest articles rail. We were missing the default sorting props and that resulted in returning different articles in the rail compared to the screen.

**Screenshot after changes**

![Group 26](https://github.com/user-attachments/assets/801c8917-4cb1-4c33-b1d7-b70341a517d5)
