### PR TITLE
feat: support certainty config for discoverArtworks

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9254,6 +9254,14 @@ type DisableSecondFactorPayload {
   secondFactorOrErrors: SecondFactorOrErrorsUnion!
 }
 
+enum DiscoverArtworksSort {
+  # Sort by certainty ascending. High certainty means the artwork is more likely to be recommended.
+  CERTAINTY_ASC
+
+  # Sort by certainty descending. High certainty means the artwork is more likely to be recommended.
+  CERTAINTY_DESC
+}
+
 type DiscoveryArtworkReferenceMutationFailure {
   mutationError: GravityMutationError
 }
@@ -16840,9 +16848,11 @@ type Query {
   discoverArtworks(
     after: String
     before: String
+    certainty: Int
     first: Int
     last: Int
     limit: Int
+    sort: DiscoverArtworksSort
     userId: String
   ): ArtworkConnection
 
@@ -21513,9 +21523,11 @@ type Viewer {
   discoverArtworks(
     after: String
     before: String
+    certainty: Int
     first: Int
     last: Int
     limit: Int
+    sort: DiscoverArtworksSort
     userId: String
   ): ArtworkConnection
 


### PR DESCRIPTION
This PR does two things:

1. Adds the ability to pass in a `certainty` argument that gets passed along to `weaviate`. In effect, `certainty` is a[ similarity rating between 0 and 1](https://weaviate.io/developers/weaviate/api/graphql/search-operators#variables-1), where 1 is almost identical and 0 is an opposite. `certainty` and `distance` get at the same thing, so I am not including `distance`, for now, despite it being the newer approach recommended by `weaviate`.
2. Adds the ability to `sort` by `certainty` level. Defaults to returning more similar artworks first (i.e. artworks with higher `certainty` scores).

Together this gives us greater ability to configure the results coming back from `weaviate`. I'm particularly interested if we get better recommendation by moving slightly away from the most similar results. This could be part of a strategy to address the potential issue of `weaviate` recommending artworks that are too similar to each other. 