### PR TITLE
chore: remove action message

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -19458,7 +19458,6 @@ type TargetSupplyMicrofunnelMetadata {
 
 type Task implements Node {
   actionLink: String!
-  actionMessage: String!
   createdAt(
     format: String
 

--- a/src/schema/v2/me/task.ts
+++ b/src/schema/v2/me/task.ts
@@ -8,7 +8,6 @@ export interface Task {
   title: string
   created_at: string
   message: string
-  action_message: string
   action_link: string
   resolved_at: string
   dismissed_at: string
@@ -29,10 +28,6 @@ export const TaskType = new GraphQLObjectType<any, ResolverContext>({
     },
     title: { type: new GraphQLNonNull(GraphQLString) },
     message: { type: new GraphQLNonNull(GraphQLString) },
-    actionMessage: {
-      type: new GraphQLNonNull(GraphQLString),
-      resolve: ({ action_message }) => action_message,
-    },
     actionLink: {
       type: new GraphQLNonNull(GraphQLString),
       resolve: ({ action_link }) => action_link,


### PR DESCRIPTION
Follow up for https://github.com/artsy/gravity/pull/18261
We can remove instead of deprecating as no one is using it yet