### PR TITLE
fix: use float type instead of int type for certainty

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16848,7 +16848,7 @@ type Query {
   discoverArtworks(
     after: String
     before: String
-    certainty: Int
+    certainty: Float
     first: Int
     last: Int
     limit: Int
@@ -21522,7 +21522,7 @@ type Viewer {
   discoverArtworks(
     after: String
     before: String
-    certainty: Int
+    certainty: Float
     first: Int
     last: Int
     limit: Int

--- a/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
+++ b/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
@@ -3,6 +3,7 @@ import {
   GraphQLFieldConfig,
   GraphQLInt,
   GraphQLEnumType,
+  GraphQLFloat,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { artworkConnection } from "../artwork"
@@ -26,7 +27,7 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
   args: pageable({
     userId: { type: GraphQLString },
     limit: { type: GraphQLInt },
-    certainty: { type: GraphQLInt },
+    certainty: { type: GraphQLFloat },
     sort: {
       type: new GraphQLEnumType({
         name: "DiscoverArtworksSort",


### PR DESCRIPTION
Patches #6152 to use the correct type for `certainty` argument. Should be a float, not integer.