### PR TITLE
refactor: filter discovery artworks and use seenArtworks

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17746,8 +17746,10 @@ type RecordArtworkViewPayload {
 }
 
 enum ReferenceTypes {
-  DISLIKED_ARTWORKS
   LIKED_ARTWORKS
+
+  # Artworks that the user has seen and not "liked". Should not be considered a negative signal.
+  SEEN_ARTWORKS
 }
 
 enum RelatedArtistsKind {

--- a/src/schema/v2/infiniteDiscovery/createDiscoveryArtworkReferenceMutation.ts
+++ b/src/schema/v2/infiniteDiscovery/createDiscoveryArtworkReferenceMutation.ts
@@ -20,8 +20,10 @@ export const ReferenceTypesEnum = new GraphQLEnumType({
     LIKED_ARTWORKS: {
       value: "likedArtworks",
     },
-    DISLIKED_ARTWORKS: {
-      value: "dislikedArtworks",
+    SEEN_ARTWORKS: {
+      value: "seenArtworks",
+      description:
+        'Artworks that the user has seen and not "liked". Should not be considered a negative signal.',
     },
   },
 })

--- a/src/schema/v2/infiniteDiscovery/deleteDiscoveryArtworkReferencesMutation.ts
+++ b/src/schema/v2/infiniteDiscovery/deleteDiscoveryArtworkReferencesMutation.ts
@@ -89,7 +89,7 @@ export const DeleteDiscoveryUserReferencesMutation = mutationWithClientMutationI
                 }
               }
             }
-            dislikedArtworks {
+            seenArtworks {
               ... on InfiniteDiscoveryArtworks {
                 _additional {
                   id
@@ -111,7 +111,7 @@ export const DeleteDiscoveryUserReferencesMutation = mutationWithClientMutationI
       const {
         _additional: { id: uuid },
         likedArtworks,
-        dislikedArtworks,
+        seenArtworks,
       } = users[0]
 
       const references = [
@@ -121,8 +121,8 @@ export const DeleteDiscoveryUserReferencesMutation = mutationWithClientMutationI
           uuid,
         }),
         ...getArtworkReferences({
-          data: dislikedArtworks ?? [],
-          reference: "dislikedArtworks",
+          data: seenArtworks ?? [],
+          reference: "seenArtworks",
           uuid,
         }),
       ]


### PR DESCRIPTION
This PR follow https://github.com/artsy/quantum/pull/38 and does two things:

1. It changes the concept of `disliked` to `seen` for the reasons outlined in the above PR. 
2. It filters out `seenArtworks` AND `likedArtworks` from the final artwork results. 

### Considerations
- Regarding the filtering, this does mean that we can (and likely will) get less results than any limit we set. Maybe this is fine, but just want to call it out. Also this may not be a final filtering strategy. Just the naive approach to keep things moving. 