### PR TITLE
feat: add fallback for discovery users without liked artworks

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16852,6 +16852,7 @@ type Query {
     first: Int
     last: Int
     limit: Int
+    offset: Int
     sort: DiscoverArtworksSort
     userId: String
   ): ArtworkConnection
@@ -21528,6 +21529,7 @@ type Viewer {
     first: Int
     last: Int
     limit: Int
+    offset: Int
     sort: DiscoverArtworksSort
     userId: String
   ): ArtworkConnection

--- a/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
+++ b/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
@@ -103,6 +103,7 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
                 certainty: ${certainty}
               },
               limit: ${limit},
+              offset: ${offset},
           ) {
             internalID
             _additional {


### PR DESCRIPTION
This PR adds a fallback for infinite discovery users who don't have any existing "likes", so that we can still produce some artworks for them to react to and start getting personalized recommendations. The fallback query, just gets the first `x` amount (set by `limit`) of artworks from `weaviate`. Additionally, I've added an `offset` argument so that we can get variation in our starting point. 