### PR TITLE
ci(circle): Improve CI times more

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,7 @@ workflows:
     jobs:
       - test:
           <<: *not_staging_or_release
+
       - node/run:
           <<: *not_staging_or_release
           name: type-check
@@ -109,8 +110,6 @@ workflows:
       - hokusai/push:
           name: push-staging-image
           <<: *only_main
-          requires:
-            - test
 
       - hokusai/deploy-staging:
           name: deploy-staging
@@ -118,6 +117,8 @@ workflows:
           project-name: metaphysics
           requires:
             - push-staging-image
+            - type-check
+            - test
 
       - push-schema-changes:
           <<: *only_main


### PR DESCRIPTION
Noticed that we're waiting to push the staging image until after we've run the tests, but this can be parallelized since the deploy step doesn't go out until other checks pass. So optimize this via less staggering, like we do in force. 

cc @artsy/diamond-devs 