### PR TITLE
feat(CI): split schema push job into shards

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
           name: Set up environment variables
           command: |
             # Run the Node.js script, passing total_nodes and node_index as arguments
-            node path-to-your-script.js $CIRCLE_NODE_TOTAL $CIRCLE_NODE_INDEX
+            node scripts/push-schema-changes.js $CIRCLE_NODE_TOTAL $CIRCLE_NODE_INDEX
 
 workflows:
   default:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,10 +124,10 @@ workflows:
             - test
 
       - push-schema-changes:
-          # <<: *only_main
+          <<: *only_main
           context: hokusai
-          # requires:
-          # - deploy-staging
+          requires:
+            - deploy-staging
 
       - node/run:
           <<: *only_main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,10 +82,26 @@ jobs:
     executor:
       name: node/default
       tag: "18.15"
+    parallelism: 7
     steps:
       - checkout
       - setup_hokusai
       - yarn_install
+      - run: |
+          REPOS=("eigen" "energy" "prediction" "force" "forque" "pulse" "volt")
+          TOTAL_NODES=${CIRCLE_NODE_TOTAL:-1}
+          NODE_INDEX=${CIRCLE_NODE_INDEX:-0}
+
+          # Calculate the subset of repos for this node
+          CHUNK_SIZE=$(( (${#REPOS[@]} + TOTAL_NODES - 1) / TOTAL_NODES ))
+          START_INDEX=$(( NODE_INDEX * CHUNK_SIZE ))
+          END_INDEX=$(( START_INDEX + CHUNK_SIZE ))
+
+          # Convert subset to JSON for easy parsing in Node.js
+          REPO_SUBSET=$(printf "%s\n" "${REPOS[@]:$START_INDEX:$CHUNK_SIZE}" | jq -cR '[inputs | {"repo": .}]')
+
+          echo "Repos for this node: $REPO_SUBSET"
+          echo "export REPOS_TO_UPDATE='$REPO_SUBSET'" >> $BASH_ENV
       - run:
           name: push schema changes
           command: node scripts/push-schema-changes.js
@@ -121,10 +137,10 @@ workflows:
             - test
 
       - push-schema-changes:
-          <<: *only_main
+          # <<: *only_main
           context: hokusai
-          requires:
-            - deploy-staging
+          # requires:
+          # - deploy-staging
 
       - node/run:
           <<: *only_main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,27 +87,11 @@ jobs:
       - checkout
       - setup_hokusai
       - yarn_install
-      - run: |
-          REPOS=("eigen" "energy" "prediction" "force" "forque" "pulse" "volt")
-          TOTAL_NODES=${CIRCLE_NODE_TOTAL:-1}
-          NODE_INDEX=${CIRCLE_NODE_INDEX:-0}
-
-          # Calculate the subset of repos for this node
-          CHUNK_SIZE=$(( (${#REPOS[@]} + TOTAL_NODES - 1) / TOTAL_NODES ))
-          START_INDEX=$(( NODE_INDEX * CHUNK_SIZE ))
-          END_INDEX=$(( START_INDEX + CHUNK_SIZE ))
-
-          # Get the subset of repos for this node
-          REPO_SUBSET=("${REPOS[@]:START_INDEX:CHUNK_SIZE}")
-
-          # Convert REPO_SUBSET array to JSON for Node.js
-          REPO_JSON=$(printf '%s\n' "${REPO_SUBSET[@]}" | jq -Rc '[inputs | {"repo": .}]')
-
-          echo "Repos for this node: $REPO_SUBSET"
-          echo "export REPOS_TO_UPDATE='$REPO_JSON'" >> $BASH_ENV
       - run:
-          name: push schema changes
-          command: node scripts/push-schema-changes.js
+          name: Set up environment variables
+          command: |
+            # Run the Node.js script, passing total_nodes and node_index as arguments
+            node path-to-your-script.js $CIRCLE_NODE_TOTAL $CIRCLE_NODE_INDEX
 
 workflows:
   default:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
     executor:
       name: node/default
       tag: "18.15"
-    parallelism: 7
+    parallelism: 4
     steps:
       - checkout
       - setup_hokusai
@@ -103,11 +103,6 @@ jobs:
           # Convert REPO_SUBSET array to JSON for Node.js
           REPO_JSON=$(printf '%s\n' "${REPO_SUBSET[@]}" | jq -Rc '[inputs | {"repo": .}]')
 
-          echo "Total nodes: $TOTAL_NODES"
-          echo "Node index: $NODE_INDEX"
-          echo "Chunk size: $CHUNK_SIZE"
-          echo "Start index: $START_INDEX"
-          echo "End index: $END_INDEX"
           echo "Repos for this node: $REPO_SUBSET"
           echo "export REPOS_TO_UPDATE='$REPO_JSON'" >> $BASH_ENV
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
     executor:
       name: node/default
       tag: "18.15"
-    parallelism: 4
+    parallelism: 7
     steps:
       - checkout
       - setup_hokusai

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,8 +97,11 @@ jobs:
           START_INDEX=$(( NODE_INDEX * CHUNK_SIZE ))
           END_INDEX=$(( START_INDEX + CHUNK_SIZE ))
 
-          # Convert subset to JSON for easy parsing in Node.js
-          REPO_SUBSET=$(printf "%s\n" "${REPOS[@]:$START_INDEX:$CHUNK_SIZE}" | jq -cR '[inputs | {"repo": .}]')
+          # Get the subset of repos for this node
+          REPO_SUBSET=("${REPOS[@]:START_INDEX:CHUNK_SIZE}")
+
+          # Convert REPO_SUBSET array to JSON for Node.js
+          REPO_JSON=$(printf '%s\n' "${REPO_SUBSET[@]}" | jq -Rc '[inputs | {"repo": .}]')
 
           echo "Total nodes: $TOTAL_NODES"
           echo "Node index: $NODE_INDEX"
@@ -106,7 +109,7 @@ jobs:
           echo "Start index: $START_INDEX"
           echo "End index: $END_INDEX"
           echo "Repos for this node: $REPO_SUBSET"
-          echo "export REPOS_TO_UPDATE='$REPO_SUBSET'" >> $BASH_ENV
+          echo "export REPOS_TO_UPDATE='$REPO_JSON'" >> $BASH_ENV
       - run:
           name: push schema changes
           command: node scripts/push-schema-changes.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,11 @@ jobs:
           # Convert subset to JSON for easy parsing in Node.js
           REPO_SUBSET=$(printf "%s\n" "${REPOS[@]:$START_INDEX:$CHUNK_SIZE}" | jq -cR '[inputs | {"repo": .}]')
 
+          echo "Total nodes: $TOTAL_NODES"
+          echo "Node index: $NODE_INDEX"
+          echo "Chunk size: $CHUNK_SIZE"
+          echo "Start index: $START_INDEX"
+          echo "End index: $END_INDEX"
           echo "Repos for this node: $REPO_SUBSET"
           echo "export REPOS_TO_UPDATE='$REPO_SUBSET'" >> $BASH_ENV
       - run:

--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -25,7 +25,10 @@ async function updateSchemaFile({
   body = defaultBody,
 }) {
   return new Promise((resolve) => {
-    setTimeout(resolve, 1000)
+    setTimeout(() => {
+      console.log(`∙ Updating schema for ${repo}`)
+      resolve(true)
+    }, 1000)
   })
   await updateRepo({
     repo: {

--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -115,7 +115,7 @@ async function main() {
 
     if (totalNodes > 1 && totalNodes !== repos.length) {
       throw new Error(
-        `Number of nodes should bethe number of supported repos or 1, received: ${totalNodes}`
+        `Number of nodes should be the number of supported repos or 1, received: ${totalNodes}`
       )
     }
 

--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -5,6 +5,7 @@ const { execSync } = require("child_process")
 const path = require("path")
 const { buildSchema, getIntrospectionQuery, graphqlSync } = require("graphql")
 const { readFileSync, writeFileSync } = require("fs")
+const e = require("express")
 
 const introspectionQuery = getIntrospectionQuery()
 
@@ -23,6 +24,9 @@ async function updateSchemaFile({
   destinations = ["data/schema.graphql"],
   body = defaultBody,
 }) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 1000)
+  })
   await updateRepo({
     repo: {
       owner: "artsy",
@@ -68,30 +72,29 @@ async function updateSchemaFile({
   })
 }
 
+const supportedRepos = {
+  eigen: { body: `${defaultBody} #nochangelog` },
+  energy: {},
+  prediction: {},
+  force: {},
+  forque: {},
+  pulse: { destinations: ["vendor/graphql/schema/metaphysics.json"] },
+  volt: {
+    destinations: [
+      "vendor/graphql/schema/schema.graphql",
+      "vendor/graphql/schema/metaphysics.json",
+    ],
+  },
+}
+
 async function main() {
   try {
     console.log("∙ Dumping staging schema")
 
     execSync("yarn dump:staging")
 
-    const reposToUpdate = [
-      { repo: "eigen", body: `${defaultBody} #nochangelog` },
-      { repo: "energy" },
-      { repo: "prediction" },
-      { repo: "force" },
-      { repo: "forque" },
-      {
-        repo: "pulse",
-        destinations: ["vendor/graphql/schema/metaphysics.json"],
-      },
-      {
-        repo: "volt",
-        destinations: [
-          "vendor/graphql/schema/schema.graphql",
-          "vendor/graphql/schema/metaphysics.json",
-        ],
-      },
-    ]
+    // Get repos from environment variables on the CI
+    const reposToUpdate = JSON.parse(process.env.REPOS_TO_PUSH_SCHEMA || "[]")
 
     const updatePromises = reposToUpdate.map((repo) => updateSchemaFile(repo))
 

--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -24,12 +24,6 @@ async function updateSchemaFile({
   destinations = ["data/schema.graphql"],
   body = defaultBody,
 }) {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      console.log(`∙ Updating schema for ${repo}`)
-      resolve(true)
-    }, 1000)
-  })
   await updateRepo({
     repo: {
       owner: "artsy",
@@ -99,9 +93,13 @@ async function main() {
     // Get repos from environment variables on the CI
     const reposToUpdate = JSON.parse(process.env.REPOS_TO_PUSH_SCHEMA || "[]")
 
-    const updatePromises = reposToUpdate.map((repo) =>
-      updateSchemaFile({ repo: repo, ...supportedRepos[repo] })
-    )
+    const updatePromises = reposToUpdate.map((repo) => {
+      if (supportedRepos[repo]) {
+        updateSchemaFile({ repo: repo, ...supportedRepos[repo] })
+      } else {
+        console.error(`Repo ${repo} is not supported`)
+      }
+    })
 
     await Promise.all(updatePromises)
   } catch (error) {

--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -18,7 +18,7 @@ const defaultBody =
  * @param {string} [input.body] - body: The PR body description
  * @param {Array<string>} [input.destinations] - destinations: Paths to schema files in target repo
  */
-export async function updateSchemaFile({
+async function updateSchemaFile({
   repo,
   destinations = ["data/schema.graphql"],
   body = defaultBody,
@@ -94,7 +94,7 @@ const supportedRepos = {
  * @param {number} nodeIndex
  * @returns {Array<string>} subset of repos assigned to the current node
  */
-export function getRepoSubset(repos, totalNodes, nodeIndex) {
+function getRepoSubset(repos, totalNodes, nodeIndex) {
   if (totalNodes !== 1) {
     return repos.slice(nodeIndex, nodeIndex + 1)
   }
@@ -102,7 +102,7 @@ export function getRepoSubset(repos, totalNodes, nodeIndex) {
   return repos
 }
 
-export async function main() {
+async function main() {
   try {
     execSync("yarn dump:staging")
 
@@ -139,3 +139,9 @@ export async function main() {
 }
 
 main()
+
+module.exports = {
+  updateSchemaFile,
+  supportedRepos,
+  getRepoSubset,
+}

--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -99,7 +99,9 @@ async function main() {
     // Get repos from environment variables on the CI
     const reposToUpdate = JSON.parse(process.env.REPOS_TO_PUSH_SCHEMA || "[]")
 
-    const updatePromises = reposToUpdate.map((repo) => updateSchemaFile(repo))
+    const updatePromises = reposToUpdate.map((repo) =>
+      updateSchemaFile({ repo: repo, ...supportedRepos[repo] })
+    )
 
     await Promise.all(updatePromises)
   } catch (error) {

--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -23,10 +23,7 @@ async function updateSchemaFile({
   destinations = ["data/schema.graphql"],
   body = defaultBody,
 }) {
-  console.log(`∙ Updating schema for ${repo}`)
-  return new Promise((resolve) => {
-    setTimeout(resolve, 1000)
-  })
+  console.log(`Updating schema for ${repo}`)
   await updateRepo({
     repo: {
       owner: "artsy",
@@ -121,7 +118,7 @@ async function main() {
 
     const reposToUpdate = getRepoSubset(repos, totalNodes, nodeIndex)
 
-    console.log(`∙ Dumping staging schema for the repos ${reposToUpdate}`)
+    console.log(`Dumping staging schema for the repos ${reposToUpdate}`)
 
     const updatePromises = reposToUpdate.map((repo) => {
       if (supportedRepos[repo]) {
@@ -139,9 +136,3 @@ async function main() {
 }
 
 main()
-
-module.exports = {
-  updateSchemaFile,
-  supportedRepos,
-  getRepoSubset,
-}


### PR DESCRIPTION
This PR splits the push schema job into 7 shards in order to optimize this expensive step on `main` branch(around 11 minutes).

There's a dummy execution [here](https://app.circleci.com/pipelines/github/artsy/metaphysics/24197/workflows/e85dd38d-c367-4b9c-8c06-c524edca5ee0/jobs/49897) with log outputs for each repo attempt.