### PR TITLE
feat: use href for deep linking to explore by component

### DIFF
--- a/src/schema/v2/homeView/sections/ExploreByCategory.ts
+++ b/src/schema/v2/homeView/sections/ExploreByCategory.ts
@@ -3,44 +3,58 @@ import { HomeViewSection } from "."
 import { HomeViewSectionTypeNames } from "../sectionTypes/names"
 import { connectionFromArray } from "graphql-relay"
 
-const marketingColletionCategories = {
+const HOMEVIEW_SECTION_ID = "home-view-section-explore-by-category"
+
+const marketingCollectionCategories = {
   Medium: {
     id: "Medium",
     title: "Medium",
     imageUrl:
       "https://files.artsy.net/images/collections-mediums-category.jpeg",
+    href:
+      '/collections-by-category/home-view-section-explore-by-category?slugs=["painting","sculpture","photography","prints-and-multiples","work-on-paper","design","drawing","installation","film-and-video","jewelry","performance-art","ceramics","textile-art","mixed-media"]',
   },
   Movement: {
     id: "Movement",
     title: "Movement",
     imageUrl:
       "https://files.artsy.net/images/collections-movement-category.jpeg",
+    href:
+      '/collections-by-category/home-view-section-explore-by-category?slugs=["contemporary-art","abstract-art","impressionist-and-modern","emerging-art","minimalist-art","street-art","pop-art","post-war","20th-century-art","pre-columbian-art"]',
   },
   "Collect by Size": {
     id: "Collect by Size",
     title: "Size",
     imageUrl: "https://files.artsy.net/images/collections-size-category.jpeg",
+    href:
+      '/collections-by-category/home-view-section-explore-by-category?slugs=["art-for-small-spaces","art-for-large-spaces","tabletop-sculpture"]',
   },
   "Collect by Color": {
     id: "Collect by Color",
     title: "Color",
     imageUrl: "https://files.artsy.net/images/collections-color-category.png",
+    href:
+      '/collections-by-category/home-view-section-explore-by-category?slugs=["black-and-white-artworks","warm-toned-artworks","cool-toned-artworks","blue-artworks","red-artworks","neutral-artworks","green-artworks","yellow-artworks","orange-artworks"]',
   },
   "Collect by Price": {
     id: "Collect by Price",
     title: "Price",
     imageUrl: "https://files.artsy.net/images/collections-price-category.jpeg",
+    href:
+      '/collections-by-category/home-view-section-explore-by-category?slugs=["art-under-500-dollars","art-under-1000-dollars","art-under-2500-dollars","art-under-5000-dollars","art-under-10000-dollars","art-under-25000-dollars","art-under-50000-dollars"]',
   },
   Gallery: {
     id: "Gallery",
     title: "Gallery",
     imageUrl:
       "https://files.artsy.net/images/collections-gallery-category.jpeg",
+    href:
+      '/collections-by-category/home-view-section-explore-by-category?slugs=["new-from-tastemaking-galleries","new-from-nonprofits-acaf27cc-2d39-4ed3-93dd-d7099e183691","new-from-small-galleries","new-from-leading-galleries","new-to-artsy"]',
   },
 }
 
 export const ExploreByCategory: HomeViewSection = {
-  id: "home-view-section-explore-by-category",
+  id: HOMEVIEW_SECTION_ID,
   featureFlag: "diamond_home-view-marketing-collection-categories",
   contextModule: ContextModule.exploreBy,
   type: HomeViewSectionTypeNames.HomeViewSectionCards,
@@ -49,7 +63,7 @@ export const ExploreByCategory: HomeViewSection = {
   },
   requiresAuthentication: false,
   resolver: (_parent, args, _context, _info) => {
-    const cards = Object.values(marketingColletionCategories).map(
+    const cards = Object.values(marketingCollectionCategories).map(
       (category) => {
         return {
           ...category,

--- a/src/schema/v2/homeView/sections/__tests__/ExploreByCategory.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/ExploreByCategory.test.ts
@@ -69,6 +69,7 @@ describe("ExploreByCategory", () => {
                   edges {
                     node {
                       entityID
+                      href
                     }
                   }
                 }
@@ -89,31 +90,37 @@ describe("ExploreByCategory", () => {
               {
                 "node": {
                   "entityID": "Medium",
+                  "href": "/collections-by-category/home-view-section-explore-by-category?slugs=["painting","sculpture","photography","prints-and-multiples","work-on-paper","design","drawing","installation","film-and-video","jewelry","performance-art","ceramics","textile-art","mixed-media"]",
                 },
               },
               {
                 "node": {
                   "entityID": "Movement",
+                  "href": "/collections-by-category/home-view-section-explore-by-category?slugs=["contemporary-art","abstract-art","impressionist-and-modern","emerging-art","minimalist-art","street-art","pop-art","post-war","20th-century-art","pre-columbian-art"]",
                 },
               },
               {
                 "node": {
                   "entityID": "Collect by Size",
+                  "href": "/collections-by-category/home-view-section-explore-by-category?slugs=["art-for-small-spaces","art-for-large-spaces","tabletop-sculpture"]",
                 },
               },
               {
                 "node": {
                   "entityID": "Collect by Color",
+                  "href": "/collections-by-category/home-view-section-explore-by-category?slugs=["black-and-white-artworks","warm-toned-artworks","cool-toned-artworks","blue-artworks","red-artworks","neutral-artworks","green-artworks","yellow-artworks","orange-artworks"]",
                 },
               },
               {
                 "node": {
                   "entityID": "Collect by Price",
+                  "href": "/collections-by-category/home-view-section-explore-by-category?slugs=["art-under-500-dollars","art-under-1000-dollars","art-under-2500-dollars","art-under-5000-dollars","art-under-10000-dollars","art-under-25000-dollars","art-under-50000-dollars"]",
                 },
               },
               {
                 "node": {
                   "entityID": "Gallery",
+                  "href": "/collections-by-category/home-view-section-explore-by-category?slugs=["new-from-tastemaking-galleries","new-from-nonprofits-acaf27cc-2d39-4ed3-93dd-d7099e183691","new-from-small-galleries","new-from-leading-galleries","new-to-artsy"]",
                 },
               },
             ],


### PR DESCRIPTION
This PR adds `href` deep link to to the `ExploreByCategories` section of the home view. The goal is to enable curated sorting, which currently requires hardcoding the list here and resolving it in Eigen (TBD PR from @araujobarret)

Open to any suggestions! 😊

[Slack discussion](https://artsy.slack.com/archives/C05EEBNEF71/p1730199412491929)