### PR TITLE
feat: Support EXPLORE_BY sort for marketing collections

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12667,6 +12667,7 @@ type MarketingCollectionQuery {
 enum MarketingCollectionsSorts {
   CREATED_AT_ASC
   CREATED_AT_DESC
+  EXPLORE_BY
   UPDATED_AT_ASC
   UPDATED_AT_DESC
 }

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12667,7 +12667,7 @@ type MarketingCollectionQuery {
 enum MarketingCollectionsSorts {
   CREATED_AT_ASC
   CREATED_AT_DESC
-  EXPLORE_BY
+  CURATED
   UPDATED_AT_ASC
   UPDATED_AT_DESC
 }

--- a/src/lib/marketingCollectionCategories.ts
+++ b/src/lib/marketingCollectionCategories.ts
@@ -1,0 +1,93 @@
+const marketingCollectionCategories = {
+  Medium: {
+    id: "Medium",
+    title: "Medium",
+    imageUrl:
+      "https://files.artsy.net/images/collections-mediums-category.jpeg",
+    orderedCollectionSlugs: [
+      "painting",
+      "sculpture",
+      "works-on-paper",
+      "prints",
+      "drawing",
+      "textile-art",
+      "ceramics",
+      "mixed-media",
+      "design",
+      "watercolor",
+    ],
+  },
+  Movement: {
+    id: "Movement",
+    title: "Movement",
+    imageUrl:
+      "https://files.artsy.net/images/collections-movement-category.jpeg",
+    orderedCollectionSlugs: [
+      "contemporary-art",
+      "abstract-art",
+      "impressionist-and-modern",
+      "emerging-art",
+      "minimalist-art",
+      "street-art",
+      "pop-art",
+      "post-war",
+      "20th-century-art",
+      "pre-columbian-art",
+    ],
+  },
+  "Collect by Size": {
+    id: "Collect by Size",
+    title: "Size",
+    imageUrl: "https://files.artsy.net/images/collections-size-category.jpeg",
+    orderedCollectionSlugs: [
+      "art-for-small-spaces",
+      "art-for-large-spaces",
+      "tabletop-sculpture",
+    ],
+  },
+  "Collect by Color": {
+    id: "Collect by Color",
+    title: "Color",
+    imageUrl: "https://files.artsy.net/images/collections-color-category.png",
+    orderedCollectionSlugs: [
+      "black-and-white-artworks",
+      "warm-toned-artworks",
+      "cool-toned-artworks",
+      "blue-artworks",
+      "red-artworks",
+      "neutral-artworks",
+      "green-artworks",
+      "yellow-artworks",
+      "orange-artworks",
+    ],
+  },
+  "Collect by Price": {
+    id: "Collect by Price",
+    title: "Price",
+    imageUrl: "https://files.artsy.net/images/collections-price-category.jpeg",
+    orderedCollectionSlugs: [
+      "art-under-500-dollars",
+      "art-under-1000-dollars",
+      "art-under-2500-dollars",
+      "art-under-5000-dollars",
+      "art-under-10000-dollars",
+      "art-under-25000-dollars",
+      "art-under-50000-dollars",
+    ],
+  },
+  Gallery: {
+    id: "Gallery",
+    title: "Gallery",
+    imageUrl:
+      "https://files.artsy.net/images/collections-gallery-category.jpeg",
+    orderedCollectionSlugs: [
+      "new-from-tastemaking-galleries",
+      "new-from-nonprofits-acaf27cc-2d39-4ed3-93dd-d7099e183691",
+      "new-from-small-galleries",
+      "new-from-leading-galleries",
+      "new-to-artsy",
+    ],
+  },
+}
+
+export default marketingCollectionCategories

--- a/src/schema/v2/__tests__/marketingCollections.test.ts
+++ b/src/schema/v2/__tests__/marketingCollections.test.ts
@@ -142,6 +142,44 @@ describe("MarketingCollections", () => {
       }
     `)
   })
+  it("requests an ordered set of collections by slug when using curated sort", async () => {
+    const marketingCollectionsLoaderMock = jest
+      .fn()
+      .mockResolvedValue({ body: marketingCollectionsData })
+
+    const query = gql`
+      {
+        marketingCollections(category: "Collect by Price", sort: CURATED) {
+          slug
+          title
+        }
+      }
+    `
+
+    const context: any = {
+      marketingCollectionsLoader: marketingCollectionsLoaderMock,
+    }
+
+    await runQuery(query, context)
+
+    expect(marketingCollectionsLoaderMock.mock.calls[0][0]).not.toContainKeys([
+      "category",
+      "sort",
+    ])
+    expect(marketingCollectionsLoaderMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        slugs: [
+          "art-under-500-dollars",
+          "art-under-1000-dollars",
+          "art-under-2500-dollars",
+          "art-under-5000-dollars",
+          "art-under-10000-dollars",
+          "art-under-25000-dollars",
+          "art-under-50000-dollars",
+        ],
+      })
+    )
+  })
 
   it("returns curated marketing collections", async () => {
     const query = gql`

--- a/src/schema/v2/homeView/sections/ExploreByCategory.ts
+++ b/src/schema/v2/homeView/sections/ExploreByCategory.ts
@@ -2,42 +2,7 @@ import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { HomeViewSection } from "."
 import { HomeViewSectionTypeNames } from "../sectionTypes/names"
 import { connectionFromArray } from "graphql-relay"
-
-const marketingColletionCategories = {
-  Medium: {
-    id: "Medium",
-    title: "Medium",
-    imageUrl:
-      "https://files.artsy.net/images/collections-mediums-category.jpeg",
-  },
-  Movement: {
-    id: "Movement",
-    title: "Movement",
-    imageUrl:
-      "https://files.artsy.net/images/collections-movement-category.jpeg",
-  },
-  "Collect by Size": {
-    id: "Collect by Size",
-    title: "Size",
-    imageUrl: "https://files.artsy.net/images/collections-size-category.jpeg",
-  },
-  "Collect by Color": {
-    id: "Collect by Color",
-    title: "Color",
-    imageUrl: "https://files.artsy.net/images/collections-color-category.png",
-  },
-  "Collect by Price": {
-    id: "Collect by Price",
-    title: "Price",
-    imageUrl: "https://files.artsy.net/images/collections-price-category.jpeg",
-  },
-  Gallery: {
-    id: "Gallery",
-    title: "Gallery",
-    imageUrl:
-      "https://files.artsy.net/images/collections-gallery-category.jpeg",
-  },
-}
+import marketingColletionCategories from "lib/marketingCollectionCategories"
 
 export const ExploreByCategory: HomeViewSection = {
   id: "home-view-section-explore-by-category",

--- a/src/schema/v2/sorts/marketingCollectionsSort.ts
+++ b/src/schema/v2/sorts/marketingCollectionsSort.ts
@@ -7,8 +7,8 @@ export const MARKETING_COLLECTIONS_SORTS = {
   CREATED_AT_DESC: {
     value: "-created_at",
   },
-  EXPLORE_BY: {
-    value: "explore_by",
+  CURATED: {
+    value: "curated",
   },
   UPDATED_AT_ASC: {
     value: "updated_at",

--- a/src/schema/v2/sorts/marketingCollectionsSort.ts
+++ b/src/schema/v2/sorts/marketingCollectionsSort.ts
@@ -1,11 +1,14 @@
 import { GraphQLEnumType } from "graphql"
 
-const MARKETING_COLLECTIONS_SORTS = {
+export const MARKETING_COLLECTIONS_SORTS = {
   CREATED_AT_ASC: {
     value: "created_at",
   },
   CREATED_AT_DESC: {
     value: "-created_at",
+  },
+  EXPLORE_BY: {
+    value: "explore_by",
   },
   UPDATED_AT_ASC: {
     value: "updated_at",


### PR DESCRIPTION
POC PR to demonstrate an alternate approach to https://github.com/artsy/metaphysics/pull/6185, to implement custom ordering of marketing collections filtered by a known category.

---

To support the new Explore By feature in the app, this allows the client to request an `EXPLORE_BY` sort on Marketing Collections, when also specifying a category, which switches the query to use a hard-coded and ordered list of Marketing Collection slugs.

cc/ @egdbear @araujobarret @anandaroop 