### PR TITLE
feat: add isSavedToAnyList to Artwork

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2531,6 +2531,9 @@ type Artwork implements Node & Searchable & Sellable {
   isPurchasable: Boolean
   isSaved: Boolean
 
+  # Checks if artwork is saved to any of the user's 'saves' lists
+  isSavedToAnyList: Boolean!
+
   # Checks if artwork is saved to user's lists
   isSavedToList(default: Boolean = false, saves: Boolean = true): Boolean!
 

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1017,6 +1017,30 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           return savedArtworkLoader(_id).then(({ is_saved }) => is_saved)
         },
       },
+      isSavedToAnyList: {
+        description:
+          "Checks if artwork is saved to any of the user's 'saves' lists",
+        type: new GraphQLNonNull(GraphQLBoolean),
+        resolve: async ({ _id }, {}, { collectionsLoader, userID }) => {
+          if (!userID || !collectionsLoader) return false
+          try {
+            const { headers } = await collectionsLoader({
+              artwork_id: _id,
+              user_id: userID,
+              private: true,
+              size: 0,
+              total_count: true,
+              saves: true,
+            })
+            const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+            return totalCount > 0
+          } catch (e) {
+            error(e)
+            return false
+          }
+        },
+      },
       isSavedToList: {
         description: "Checks if artwork is saved to user's lists",
         args: {


### PR DESCRIPTION
It's helpful to have a field that can be used to render a save button in the correct state - saved to any 'saves' list (default or not). Then, we can defer checking non-default list inclusion only when someone unsaves a saved artwork (to see if it was saved in any non-default lists, which prompts a modal interaction).