### PR TITLE
chore: mark the genomic recs gravity loader as deprecated

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13166,6 +13166,9 @@ type Me implements Node {
     last: Int
     page: Int
   ): ArtworkConnection
+    @deprecated(
+      reason: "These genomic recs are deprecated. Use artworkRecommendations instead."
+    )
   saleRegistrationsConnection(
     after: String
     auctionState: AuctionState

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -393,6 +393,7 @@ export default (accessToken, userID, opts) => {
     followedShowsLoader: gravityLoader("follow_shows", {}, { headers: true }),
     gravityGraphQLLoader: gravityGraphQL(accessToken),
     homepageModulesLoader: gravityLoader("me/modules"),
+    // DEPRECATED: This endpoint is no longer in use.
     homepageSuggestedArtworksLoader: gravityLoader(
       "me/suggested/artworks/homepage"
     ),

--- a/src/schema/v2/home/results.ts
+++ b/src/schema/v2/home/results.ts
@@ -102,6 +102,8 @@ const moduleResults: HomePageArtworkModuleResolvers<any> = {
       }).then(({ hits }) => hits)
     })
   },
+  // DEPRECATED: This endpoint is no longer in use.
+  // Use the artworkRecommendations connection to vortex instead.
   recommended_works: ({ homepageSuggestedArtworksLoader }) => {
     if (!homepageSuggestedArtworksLoader) return null
     return homepageSuggestedArtworksLoader({

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -630,7 +630,8 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
       },
     },
     submissionsConnection: submissionsConnection,
-    // genomic recommendation
+    // DEPRECATED: This genomic recs loader is no longer in use.
+    // Use the artworkRecommendations connection to Vortex instead.
     recommendedArtworks: {
       type: artworkConnection.connectionType,
       args: pageable({

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -631,7 +631,7 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
     },
     submissionsConnection: submissionsConnection,
     recommendedArtworks: {
-       deprecationReason: "This genomic recs loader is no longer in use. Use the artworkRecommendations instead.",
+      deprecationReason: "These genomic recs are deprecated. Use artworkRecommendations instead.",
       type: artworkConnection.connectionType,
       args: pageable({
         page: { type: GraphQLInt },

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -630,9 +630,8 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
       },
     },
     submissionsConnection: submissionsConnection,
-    // DEPRECATED: This genomic recs loader is no longer in use.
-    // Use the artworkRecommendations connection to Vortex instead.
     recommendedArtworks: {
+       deprecationReason: "This genomic recs loader is no longer in use. Use the artworkRecommendations instead.",
       type: artworkConnection.connectionType,
       args: pageable({
         page: { type: GraphQLInt },


### PR DESCRIPTION
Trying to mark the old genomic recs graphql loader/endpoint as deprecated, since it was decided in https://github.com/artsy/gravity/pull/18204 to not remove it entirely due to some old mobile clients.