### PR TITLE
fix: replace the watercolor slug from medium categories

### DIFF
--- a/src/lib/marketingCollectionCategories.ts
+++ b/src/lib/marketingCollectionCategories.ts
@@ -14,7 +14,7 @@ export const marketingCollectionCategories = {
       "ceramics",
       "mixed-media",
       "design",
-      "watercolor",
+      "photography",
     ],
   },
   Movement: {


### PR DESCRIPTION
This PR replaces the "watercolor" with "photography" in marketing collection categories.