### PR TITLE
chore: add singular artwork to batch collection update mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3122,6 +3122,7 @@ union ArtworksCollectionsBatchUpdateResponseOrError =
 
 type ArtworksCollectionsBatchUpdateSuccess {
   addedToCollections: [Collection]
+  artwork: Artwork
   counts: ArtworksCollectionsBatchUpdateCounts
   removedFromCollections: [Collection]
 }

--- a/src/schema/v2/me/artworksCollectionsBatchUpdateMutation.ts
+++ b/src/schema/v2/me/artworksCollectionsBatchUpdateMutation.ts
@@ -13,11 +13,17 @@ import {
 } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
 import { CollectionType } from "./collection"
+import { ArtworkType } from "../artwork"
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
   name: "ArtworksCollectionsBatchUpdateSuccess",
   isTypeOf: (data) => data.counts,
   fields: () => ({
+    artwork: {
+      type: ArtworkType,
+      resolve: ({ artworkID }, _, { artworkLoader }) =>
+        artworkLoader(artworkID),
+    },
     counts: {
       type: new GraphQLObjectType<any, ResolverContext>({
         name: "ArtworksCollectionsBatchUpdateCounts",
@@ -130,7 +136,12 @@ export const artworksCollectionsBatchUpdateMutation = mutationWithClientMutation
         remove_from: args.removeFromCollectionIDs,
       })
 
-      return response
+      const artworkID = args.artworkIDs[0]
+
+      return {
+        ...response,
+        artworkID,
+      }
     } catch (error) {
       const formattedErr = formatGravityError(error)
 


### PR DESCRIPTION
The one weird part here is that this mutation technically can operate on a list of artworks, however I don't see any use-cases in Force of that (and that sounds like an interesting 'powerful' UI that I'm not sure where that might be offered - batch updating list memberships _for_ a batch of artworks?).

So, let's just return the artwork.

This lets us add `isSavedToAnyList` and skip Relay store updating in https://github.com/artsy/force/blob/63b000f40aa8dcf3a6a99edad7098874a80bea7f/src/Apps/CollectorProfile/Routes/Saves/Components/SelectArtworkListsModal/useSelectArtworkLists.ts#L53