### PR TITLE
feat: add likedDiscoveryArtworks

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16307,6 +16307,15 @@ type PublishViewingRoomPayload {
 }
 
 type Query {
+  LikedDiscoveryArtworks(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    limit: Int
+    userId: String!
+  ): ArtworkConnection
+
   # Do not use (only used internally for stitching)
   _do_not_use_conversation(
     # The ID of the Conversation
@@ -21224,6 +21233,15 @@ type Video {
 
 # A wildcard used to support complex root queries in Relay
 type Viewer {
+  LikedDiscoveryArtworks(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    limit: Int
+    userId: String!
+  ): ArtworkConnection
+
   # Do not use (only used internally for stitching)
   _do_not_use_conversation(
     # The ID of the Conversation

--- a/src/schema/v2/infiniteDiscovery/likedDiscoveryArtworks.ts
+++ b/src/schema/v2/infiniteDiscovery/likedDiscoveryArtworks.ts
@@ -1,0 +1,60 @@
+import {
+  GraphQLString,
+  GraphQLFieldConfig,
+  GraphQLNonNull,
+  GraphQLInt,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import { artworkConnection } from "../artwork"
+import { connectionFromArray } from "graphql-relay"
+import { pageable } from "relay-cursor-paging"
+import gql from "lib/gql"
+
+export const LikedDiscoveryArtworks: GraphQLFieldConfig<
+  void,
+  ResolverContext
+> = {
+  type: artworkConnection.connectionType,
+  args: pageable({
+    userId: { type: GraphQLNonNull(GraphQLString) },
+    limit: { type: GraphQLInt },
+  }),
+  resolve: async (_root, args, { weaviateGraphqlLoader, artworksLoader }) => {
+    if (!weaviateGraphqlLoader || !artworksLoader) {
+      new Error("A loader is not available")
+    }
+    const { userId, limit } = args
+
+    const userQuery = gql`
+      {
+        Get {
+          InfiniteDiscoveryUsers(
+            where: { path: ["internalID"], operator: Equal, valueString: "${userId}" },
+            limit: ${limit}
+          ) {
+            likedArtworks {
+              ... on InfiniteDiscoveryArtworks {
+                internalID
+              }
+            }
+          }
+        }
+      }
+    `
+    const userQueryResponse = await weaviateGraphqlLoader({
+      query: userQuery,
+    })()
+
+    const user = userQueryResponse?.data?.Get?.InfiniteDiscoveryUsers?.[0]
+
+    const likedArtworkIds =
+      user?.likedArtworks?.map((node) => node.internalID) || []
+
+    const artworks =
+      likedArtworkIds?.length > 0
+        ? await artworksLoader({ ids: likedArtworkIds })
+        : []
+
+    return connectionFromArray(artworks, args)
+  },
+}

--- a/src/schema/v2/infiniteDiscovery/likedDiscoveryArtworks.ts
+++ b/src/schema/v2/infiniteDiscovery/likedDiscoveryArtworks.ts
@@ -23,7 +23,7 @@ export const LikedDiscoveryArtworks: GraphQLFieldConfig<
     if (!weaviateGraphqlLoader || !artworksLoader) {
       new Error("A loader is not available")
     }
-    const { userId, limit } = args
+    const { userId, limit = 10 } = args
 
     const userQuery = gql`
       {

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -241,6 +241,7 @@ import { DiscoverArtworks } from "./infiniteDiscovery/discoverArtworks"
 import { CreateDiscoveryLikedArtworkMutation } from "./infiniteDiscovery/createDiscoveryArtworkReferenceMutation"
 import { CreateDiscoveryUserMutation } from "./infiniteDiscovery/createDiscoveryUserMutation"
 import { DeleteDiscoveryUserReferencesMutation } from "./infiniteDiscovery/resetDiscoveryArtworkReferencesMutation"
+import { LikedDiscoveryArtworks } from "./infiniteDiscovery/likedDiscoveryArtworks"
 
 const rootFields = {
   // artworkVersion: ArtworkVersionResolver,
@@ -312,6 +313,7 @@ const rootFields = {
   invoice: Invoice,
   job,
   jobs,
+  LikedDiscoveryArtworks,
   saleAgreement: SaleAgreement,
   saleAgreementsConnection: SaleAgreementsConnection,
   markdown: MarkdownContent,


### PR DESCRIPTION
This PR adds a `likedDiscoveryArtworks` so that we can easily get the artworks a user has liked from weaviate (not just the recommended artworks). Primary motivation for this is to be able to display a list of artworks they have "liked" in the testing prototype.