### PR TITLE
feat: add ES recommendations for infinite discovery

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16890,6 +16890,7 @@ type Query {
     limit: Int
     offset: Int
     sort: DiscoverArtworksSort
+    useRelatedArtworks: Boolean = false
     userId: String!
   ): ArtworkConnection
 
@@ -21567,6 +21568,7 @@ type Viewer {
     limit: Int
     offset: Int
     sort: DiscoverArtworksSort
+    useRelatedArtworks: Boolean = false
     userId: String!
   ): ArtworkConnection
 

--- a/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
+++ b/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
@@ -13,7 +13,7 @@ import { connectionFromArray } from "graphql-relay"
 import { pageable } from "relay-cursor-paging"
 import gql from "lib/gql"
 import uuid from "uuid/v5"
-import { sampleSize } from "lodash"
+import { sampleSize, shuffle } from "lodash"
 
 export const generateUuid = (userId: string) => {
   if (!userId) return ""
@@ -114,9 +114,12 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
         size: 8,
       })
 
-      // inject two random curated artworks
-      const finalArtworks = [...relatedArtworks, ...randomCuratedArtworks]
-      return connectionFromArray(finalArtworks, args)
+      // inject two random curated artworks and shuffle the list
+      const shuffledArtworks = shuffle([
+        ...relatedArtworks,
+        ...randomCuratedArtworks,
+      ])
+      return connectionFromArray(shuffledArtworks, args)
     }
 
     const userUUID = generateUuid(userId)


### PR DESCRIPTION
This PR adds the recommendation based on [Elastic Search Artwork Similarity Index](https://github.com/artsy/gravity/blob/8b6d8cbfbeb3d55e2d39b365fb3ddce9e075d3b3/app/models/search/indexes/artwork_similarity_index.rb#L1). 

**Recommendation Logic:**
- New Users (No Saved Artworks): Recommendations are generated using the "curators-picks" collection.
- Users with At Least One Saved Artwork: Recommendations are generated using 2 random artworks from the "curators-picks" (we could take more artworks) collection along with artworks from the user’s saved list.
- Users with Multiple Saved Artworks: Recommendations are generated using 2 random artworks from the "curators-picks" collection plus all artworks from the user’s saved collection.
- Maximum Artwork Limit: Recommendations are capped at 30 artworks total (28 from the saved collection + 2 from "curators-picks").