### PR TITLE
chore: remove stale coverage settings

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,5 @@
 module.exports = {
   cacheDirectory: ".cache/jest",
-  coverageDirectory: "coverage",
-  collectCoverage: true,
-  coverageReporters: ["lcov", "text-summary"],
   moduleFileExtensions: ["js", "jsx", "json", "ts", "tsx"],
   setupFilesAfterEnv: ["jest-extended", "<rootDir>/src/test/helper.js"],
   testRegex: "(.test)\\.(js|ts)$",


### PR DESCRIPTION
This PR makes it possible to once again run Jest's code coverage tool on demand in MP.

Brief history:
- Automated coverage reporting was added in https://github.com/artsy/metaphysics/pull/2098
- And the orb that enables it was removed in https://github.com/artsy/metaphysics/pull/3822

However the configuration was left in place, which makes it difficult to run code coverage commands locally. (All the output gets shunted to `./coverage` rather than the convenient terminal output you see e.g. [here in Eigen](https://github.com/artsy/eigen/pull/11068))

There was [some talk](https://artsy.slack.com/archives/C2TQ4PT8R/p1730942547171529) of enabling this again in CI. If we do so let's treat that as a separate effort and try to configure it such that it does not interfere with local usage of the coverage tools.