### PR TITLE
fix: infinite disco use splice instead of toSpliced

### DIFF
--- a/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
+++ b/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
@@ -233,7 +233,7 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
       ).forEach((challengeArtwork) => {
         const length = response.length
         const randomIndex = random(length)
-        response = response.toSpliced(randomIndex, 0, challengeArtwork)
+        response.splice(randomIndex, 0, challengeArtwork)
       })
     } else {
       response = await weaviateGraphqlLoader({


### PR DESCRIPTION
Quick patch to #6229. Didn't catch `toSpliced` [isn't compatible with node until](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSpliced#browser_compatibility) `v20`. Temp revert to using `splice` until after today's testing.