### PR TITLE
refactor: delete infinite disco user on reference reset

### DIFF
--- a/src/schema/v2/infiniteDiscovery/resetDiscoveryArtworkReferencesMutation.ts
+++ b/src/schema/v2/infiniteDiscovery/resetDiscoveryArtworkReferencesMutation.ts
@@ -69,26 +69,18 @@ export const DeleteDiscoveryUserReferencesMutation = mutationWithClientMutationI
     },
   },
   mutateAndGetPayload: async ({ userId }, {}) => {
-    const weaviteUserId = generateUuid(userId)
+    const weaviateUserId = generateUuid(userId)
 
-    // TODO: Temporary implementation to delete likedArtworks and seenArtworks
-    // during spike/testing phase. Don't let this code go to production.
+    // TODO: Temporary implementation to reset likedArtworks and seenArtworks.
+    // This works right now because we always create a new user object in weaviate
+    // if it doesn't exist.
+    // Just for spike/testing phase. Don't let this code go to production.
     // https://github.com/artsy/metaphysics/pull/6211#discussion_r1832675631
     try {
       await fetch(
-        `${WEAVIATE_API_BASE}/objects/InfiniteDiscoveryUsers/${weaviteUserId}`,
+        `${WEAVIATE_API_BASE}/objects/InfiniteDiscoveryUsers/${weaviateUserId}`,
         {
-          method: "PATCH",
-          headers: {
-            "Content-Type": "application/json",
-            Accept: "application/json",
-          },
-          body: JSON.stringify({
-            properties: {
-              likedArtworks: null,
-              seenArtworks: null,
-            },
-          }),
+          method: "DELETE",
         }
       )
       return { success: true }


### PR DESCRIPTION
In some more testing of the prototype, I realized `PATCH`ing the `likedArtworks` and `seenArtworks` fields doesn't update the vector. So the user would still effectively have their previous `likedArtworks` persisted. 

This changes the implementation to delete the user instead. This works because we [always check for a user when requesting artworks and create one if it doesn't exist](https://github.com/artsy/metaphysics/blob/aa9c9f57bbc284984c562122fa2c196bb5218011/src/schema/v2/infiniteDiscovery/discoverArtworks.ts#L156-L170).

Will follow up with better naming. 