### PR TITLE
fix: infinite disco cold start curated limit

### DIFF
--- a/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
+++ b/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
@@ -257,7 +257,7 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
           }
         `,
       })().then((res) => {
-        return shuffle(res.data.Get.InfiniteDiscoveryArtworks).slice(0, limit)
+        return sampleSize(res.data.Get.InfiniteDiscoveryArtworks, limit)
       })
     }
 

--- a/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
+++ b/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
@@ -246,7 +246,7 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
                   operator: Equal
                   valueBoolean: true
                 }
-                limit: ${limit}
+                limit: 200
               ) {
                 internalID
                 _additional {
@@ -257,7 +257,7 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
           }
         `,
       })().then((res) => {
-        return shuffle(res.data.Get.InfiniteDiscoveryArtworks)
+        return shuffle(res.data.Get.InfiniteDiscoveryArtworks).slice(0, limit)
       })
     }
 


### PR DESCRIPTION
Another quick fix to ensure that cold start users get a random sampling from all curated artworks. With the previous implementation, it was just shuffling this first `x`, where `x` is the `limit` argument, which defaults to `15` client side.