### PR TITLE
chore(perf): switch to data-saving me/ping endpoint for authentication status

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -517,6 +517,7 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    mePingLoader: gravityLoader("me/ping"),
     meTasksLoader: gravityLoader("me/tasks", {}, { headers: true }),
     meDismissTaskLoader: gravityLoader(
       (id) => `me/task/${id}/dismiss`,

--- a/src/schema/v2/__tests__/authenticationStatus.test.ts
+++ b/src/schema/v2/__tests__/authenticationStatus.test.ts
@@ -1,0 +1,31 @@
+/* eslint-disable promise/always-return */
+import { runQuery } from "schema/v2/test/utils"
+import { HTTPError } from "lib/HTTPError"
+
+describe("authenticationStatus", () => {
+  const query = `{ authenticationStatus }`
+
+  it("requests successful authentication status", async () => {
+    const context = {
+      mePingLoader: () => Promise.resolve({}),
+    }
+
+    const data = await runQuery(query, context)
+    expect(data!.authenticationStatus).toBe("LOGGED_IN")
+  })
+
+  it("requests invalid authentication status", async () => {
+    const context = {
+      mePingLoader: () =>
+        Promise.reject(new HTTPError(`Unauthorized`, 401, "Gravity Error")),
+    }
+    const data = await runQuery(query, context)
+    expect(data!.authenticationStatus).toBe("INVALID")
+  })
+
+  it("requests logged-out authentication status", async () => {
+    const context = {}
+    const data = await runQuery(query, context)
+    expect(data!.authenticationStatus).toBe("LOGGED_OUT")
+  })
+})

--- a/src/schema/v2/authenticationStatus.ts
+++ b/src/schema/v2/authenticationStatus.ts
@@ -14,11 +14,11 @@ export const authenticationStatus: GraphQLFieldConfig<any, ResolverContext> = {
   type: new GraphQLNonNull(AuthenticationStatus),
   description:
     "If user is logged out; status is `LOGGED_OUT`. If user is logged in; status is `LOGGED_IN`. If user is logged in with invalid authentication (401); 'Promise' resolves to 'Status.Invalid'. All other status codes will resolve to `LOGGED_IN` because we don't know whether or not the authentication is valid (error could be something else).",
-  resolve: async (_root, _args, { meLoader }) => {
-    if (!meLoader) return "LOGGED_OUT"
+  resolve: async (_root, _args, { mePingLoader }) => {
+    if (!mePingLoader) return "LOGGED_OUT"
 
     try {
-      await meLoader()
+      await mePingLoader()
     } catch (err) {
       if (err.statusCode === 401 || err.statusCode === 403) {
         return "INVALID"


### PR DESCRIPTION
This is the complement of https://github.com/artsy/gravity/pull/18332, which introduces a lightweight endpoint for the very frequent `authenticationStatus` queries. **Don't merge** until that's been released.

As discussed there, this is just an experiment and should be rolled back if the `me/ping` endpoint performs similarly to the `me` endpoint. (Although we can probably keep the new tests.)