### PR TITLE
feat: resolve time queries immediately instead of from main API

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -19382,7 +19382,7 @@ type System {
   # The schema for difference micro-service settings
   services: Services
 
-  # Core system time, necessary for synchronizing device clocks.
+  # Core system time, helpful for reliable times on clients.
   time: SystemTime
 
   # List of all available product privileges
@@ -19391,17 +19391,14 @@ type System {
 
 type SystemTime {
   day: Int
-  dst: Boolean
   hour: Int
   iso8601: String
   min: Int
   month: Int
   sec: Int
   unix: Int
-  utcOffset: Int
   wday: Int
   year: Int
-  zone: String
 }
 
 type Tag implements Node {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -19382,7 +19382,7 @@ type System {
   # The schema for difference micro-service settings
   services: Services
 
-  # Gravity system time, necessary for synchronizing device clocks.
+  # Core system time, necessary for synchronizing device clocks.
   time: SystemTime
 
   # List of all available product privileges

--- a/src/schema/v2/system/__tests__/time.test.js
+++ b/src/schema/v2/system/__tests__/time.test.js
@@ -1,28 +1,6 @@
 import { runQuery } from "schema/v2/test/utils"
 
-jest.mock("lib/apis/fetch", () => jest.fn())
-
 describe.skip("SystemTime type", () => {
-  const systemTimeData = {
-    time: "2018-07-02 20:58:58 UTC",
-    day: 2,
-    wday: 1,
-    month: 7,
-    year: 2018,
-    hour: 20,
-    min: 58,
-    sec: 58,
-    dst: false,
-    unix: 1530565138,
-    utcOffset: 0,
-    zone: "UTC",
-    iso8601: "2018-07-02T20:58:58Z",
-  }
-
-  const context = {
-    systemTimeLoader: sinon.stub().returns(Promise.resolve(systemTimeData)),
-  }
-
   it("fetches gravity's system time", async () => {
     const query = `
       {
@@ -45,7 +23,7 @@ describe.skip("SystemTime type", () => {
       }
     `
 
-    const { system } = await runQuery(query, context)
+    const { system } = await runQuery(query, {})
     expect(system.time.day).toEqual(2)
     expect(system.time.iso8601).toEqual("2018-07-02T20:58:58Z")
   })

--- a/src/schema/v2/system/time.ts
+++ b/src/schema/v2/system/time.ts
@@ -32,10 +32,26 @@ const SystemTimeType = new GraphQLObjectType<any, ResolverContext>({
 
 const SystemTime: GraphQLFieldConfig<any, ResolverContext> = {
   type: SystemTimeType,
-  description:
-    "Gravity system time, necessary for synchronizing device clocks.",
-  resolve: (_root, _options, { systemTimeLoader }) => {
-    return systemTimeLoader()
+  description: "Core system time, necessary for synchronizing device clocks.",
+  resolve: () => {
+    const now = new Date()
+    return {
+      day: now.getDate(),
+      wday: now.getDay(),
+      month: now.getMonth() + 1, // convert from 0-indexed to 1-indexed
+      year: now.getFullYear(),
+      hour: now.getHours(),
+      min: now.getMinutes(),
+      sec: now.getSeconds(),
+      dst: false, // TODO
+      unix: Math.floor(now.getTime() / 1000),
+      utcOffset: now.getTimezoneOffset() * -60,
+      zone: now
+        .toLocaleString("en", { timeZoneName: "short" })
+        .split(" ")
+        .pop(),
+      iso8601: now.toISOString(),
+    }
   },
 }
 

--- a/src/schema/v2/system/time.ts
+++ b/src/schema/v2/system/time.ts
@@ -1,6 +1,5 @@
 import {
   GraphQLString,
-  GraphQLBoolean,
   GraphQLInt,
   GraphQLObjectType,
   GraphQLFieldConfig,
@@ -18,13 +17,7 @@ const SystemTimeType = new GraphQLObjectType<any, ResolverContext>({
       hour: { type: GraphQLInt },
       min: { type: GraphQLInt },
       sec: { type: GraphQLInt },
-      dst: { type: GraphQLBoolean },
       unix: { type: GraphQLInt },
-      utcOffset: {
-        type: GraphQLInt,
-        resolve: ({ utc_offset }) => utc_offset,
-      },
-      zone: { type: GraphQLString },
       iso8601: { type: GraphQLString },
     }
   },
@@ -32,7 +25,7 @@ const SystemTimeType = new GraphQLObjectType<any, ResolverContext>({
 
 const SystemTime: GraphQLFieldConfig<any, ResolverContext> = {
   type: SystemTimeType,
-  description: "Core system time, necessary for synchronizing device clocks.",
+  description: "Core system time, helpful for reliable times on clients.",
   resolve: () => {
     const now = new Date()
     return {
@@ -43,13 +36,7 @@ const SystemTime: GraphQLFieldConfig<any, ResolverContext> = {
       hour: now.getHours(),
       min: now.getMinutes(),
       sec: now.getSeconds(),
-      dst: false, // TODO
       unix: Math.floor(now.getTime() / 1000),
-      utcOffset: now.getTimezoneOffset() * -60,
-      zone: now
-        .toLocaleString("en", { timeZoneName: "short" })
-        .split(" ")
-        .pop(),
       iso8601: now.toISOString(),
     }
   },


### PR DESCRIPTION
Another tiny overhead-savings: resolve time queries immediately instead of making another request to Gravity. The 2 services share hosts and network-time configurations, so Metaphysics' system time should be _fine_ for client calculation purposes.

Will leave a few questions/comments inline...