### PR TITLE
refactor(onyx-1404): add subsections to viewing room type

### DIFF
--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -330,6 +330,9 @@ export default (opts) => {
       { method: "GET" }
     ),
     viewingRoomLoader: gravityLoader((id) => `viewing_room/${id}`),
+    viewingRoomSubsectionsLoader: gravityLoader(
+      (id) => `viewing_room/${id}/subsections`
+    ),
     viewingRoomsLoader: gravityLoader("viewing_rooms", {}, { headers: true }),
   }
 }

--- a/src/schema/v2/GravityARImageType.ts
+++ b/src/schema/v2/GravityARImageType.ts
@@ -10,7 +10,7 @@ const GravityImageURLsType = new GraphQLObjectType<any, ResolverContext>({
   name: "GravityImageURLs",
   fields: {
     normalized: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: GraphQLString,
     },
   },
 })

--- a/src/schema/v2/__tests__/viewingRoom.test.js
+++ b/src/schema/v2/__tests__/viewingRoom.test.js
@@ -57,7 +57,6 @@ describe("ViewingRoom", () => {
           slug
           startAt
           status
-          # subsections
           timeZone
           title
           # viewingRoomArtworks

--- a/src/schema/v2/__tests__/viewingRoomSubsection.test.ts
+++ b/src/schema/v2/__tests__/viewingRoomSubsection.test.ts
@@ -1,0 +1,122 @@
+import { runQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+import config from "config"
+
+describe("ViewingRoomSubsection", () => {
+  beforeAll(() => {
+    config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA = true
+  })
+
+  afterAll(() => {
+    config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA = false
+  })
+
+  const query = gql`
+    {
+      viewingRoom(id: "example-viewing-room") {
+        subsections {
+          __typename
+          body
+          caption
+          image {
+            __typename
+            internalID
+            height
+            width
+            imageURLs {
+              __typename
+              normalized
+            }
+          }
+          internalID
+          title
+        }
+      }
+    }
+  `
+
+  it("fetches viewing room subsections", async () => {
+    const viewingRoomSubsectionsData = [
+      {
+        body: "subsection body",
+        caption: "subsection caption",
+        image: {
+          id: "example-image",
+          original_height: 100,
+          original_width: 100,
+          image_urls: {
+            normalized: "https://example.com/image.jpg",
+          },
+        },
+        id: "example-subsection",
+        title: "subsection title",
+      },
+      {
+        body: "another subsection body",
+        caption: "another subsection caption",
+        image: {
+          id: "another-example-image",
+          original_height: 200,
+          original_width: 200,
+          image_urls: {
+            normalized: "https://example.com/another-image.jpg",
+          },
+        },
+        id: "another-example-subsection",
+        title: "another subsection title",
+      },
+    ]
+
+    const context = {
+      viewingRoomLoader: jest.fn().mockResolvedValue({ id: "viewing-room-id" }),
+      viewingRoomSubsectionsLoader: jest
+        .fn()
+        .mockResolvedValue(viewingRoomSubsectionsData),
+    }
+
+    const result = await runQuery(query, context)
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "viewingRoom": {
+          "subsections": [
+            {
+              "__typename": "ViewingRoomSubsection",
+              "body": "subsection body",
+              "caption": "subsection caption",
+              "image": {
+                "__typename": "ARImage",
+                "height": 100,
+                "imageURLs": {
+                  "__typename": "ImageURLs",
+                  "normalized": "https://example.com/image.jpg",
+                },
+                "internalID": "example-image",
+                "width": 100,
+              },
+              "internalID": "example-subsection",
+              "title": "subsection title",
+            },
+            {
+              "__typename": "ViewingRoomSubsection",
+              "body": "another subsection body",
+              "caption": "another subsection caption",
+              "image": {
+                "__typename": "ARImage",
+                "height": 200,
+                "imageURLs": {
+                  "__typename": "ImageURLs",
+                  "normalized": "https://example.com/another-image.jpg",
+                },
+                "internalID": "another-example-image",
+                "width": 200,
+              },
+              "internalID": "another-example-subsection",
+              "title": "another subsection title",
+            },
+          ],
+        },
+      }
+    `)
+  })
+})

--- a/src/schema/v2/viewingRoom.ts
+++ b/src/schema/v2/viewingRoom.ts
@@ -20,8 +20,8 @@ import moment from "moment"
 import { PartnerType } from "./partner/partner"
 import { dateRange } from "lib/date"
 import { GravityARImageType } from "./GravityARImageType"
+import { ViewingRoomSubsectionType } from "./viewingRoomSubsection"
 // import PartnerArtworks from "./partner/partnerArtworks"
-// import { ViewingRoomSubsectionType } from "./viewingRoomSubsection"
 // import { ViewingRoomArtworkType } from "./viewingRoomArtwork"
 
 const LocaleEnViewingRoomRelativeShort = "en-viewing-room-relative-short"
@@ -213,9 +213,6 @@ export const ViewingRoomType = new GraphQLObjectType<any, ResolverContext>({
       },
       image: {
         type: GravityARImageType,
-        resolve: ({ image }) => {
-          return image
-        },
       },
       introStatement: {
         type: GraphQLString,
@@ -274,10 +271,12 @@ export const ViewingRoomType = new GraphQLObjectType<any, ResolverContext>({
         description:
           "Calculated field to reflect visibility and state of this viewing room",
       },
-      // TODO: In separate PR
-      // subsections: {
-      //   type: new GraphQLNonNull(new GraphQLList(ViewingRoomSubsectionType)),
-      // },
+      subsections: {
+        type: new GraphQLNonNull(new GraphQLList(ViewingRoomSubsectionType)),
+        resolve: async ({ id }, _args, { viewingRoomSubsectionsLoader }) => {
+          return viewingRoomSubsectionsLoader(id)
+        },
+      },
       timeZone: {
         type: GraphQLString,
         resolve: ({ time_zone }) => time_zone,

--- a/src/schema/v2/viewingRoomSubsection.ts
+++ b/src/schema/v2/viewingRoomSubsection.ts
@@ -1,0 +1,38 @@
+import {
+  GraphQLID,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import { InternalIDFields } from "./object_identification"
+import { GravityARImageType } from "./GravityARImageType"
+
+export const ViewingRoomSubsectionType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "ViewingRoomSubsection",
+  fields: () => {
+    return {
+      ...InternalIDFields,
+      internalID: {
+        description: "A type-specific ID likely used as a database ID.",
+        type: new GraphQLNonNull(GraphQLID),
+        resolve: ({ id }) => id,
+      },
+      body: {
+        type: GraphQLString,
+      },
+      caption: {
+        type: GraphQLString,
+      },
+      image: {
+        type: GravityARImageType,
+      },
+      title: {
+        type: GraphQLString,
+      },
+    }
+  },
+})

--- a/src/schema/v2/viewingRoomSubsection.ts
+++ b/src/schema/v2/viewingRoomSubsection.ts
@@ -5,7 +5,6 @@ import {
   GraphQLString,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
-import { InternalIDFields } from "./object_identification"
 import { GravityARImageType } from "./GravityARImageType"
 
 export const ViewingRoomSubsectionType = new GraphQLObjectType<
@@ -15,7 +14,6 @@ export const ViewingRoomSubsectionType = new GraphQLObjectType<
   name: "ViewingRoomSubsection",
   fields: () => {
     return {
-      ...InternalIDFields,
       internalID: {
         description: "A type-specific ID likely used as a database ID.",
         type: new GraphQLNonNull(GraphQLID),


### PR DESCRIPTION
Continuation of https://github.com/artsy/metaphysics/pull/6065 (viewing rooms unstitching)

This PR adds `viewingRoom.subsections` field:

```graphql
{
  viewingRoom(id: "leslie-feely-alice-baber") {
    subsections {
      __typename
      body
      caption
      image {
        __typename
        internalID
        height
        width
        imageURLs {
          __typename
          normalized
        }
      }
      internalID
      title
    }
  }
}
```

Response:

```json
{
  "data": {
    "viewingRoom": {
      "subsections": [
        {
          "__typename": "ViewingRoomSubsection",
          "body": "",
          "caption": "Alice Baber, 1972, photo by Richard Galef, Alice Baber Papers, AAA",
          "image": {
            "__typename": "ARImage",
            "internalID": "e2185542-6cad-4916-b39c-4e5458f6066b",
            "height": 1007,
            "width": 1024,
            "imageURLs": {
              "__typename": "ImageURLs",
              "normalized": "https://d32dm0rphc51dk.cloudfront.net/w6qTHWN4EWvAZh7Dxnto5A/normalized.jpg"
            }
          },
          "internalID": "fbfadaed-caba-4006-a19f-f131811b2f07",
          "title": "Baber, in Her Studio"
        }
      ]
    }
  }
}
```