### PR TITLE
refactor(onyx-1405): add viewing room artworks to viewing room type

### DIFF
--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -333,6 +333,9 @@ export default (opts) => {
     viewingRoomSubsectionsLoader: gravityLoader(
       (id) => `viewing_room/${id}/subsections`
     ),
+    viewingRoomArtworksLoader: gravityLoader(
+      (id) => `viewing_room/${id}/viewing_room_artworks`
+    ),
     viewingRoomsLoader: gravityLoader("viewing_rooms", {}, { headers: true }),
   }
 }

--- a/src/schema/v2/__tests__/viewingRoom.test.js
+++ b/src/schema/v2/__tests__/viewingRoom.test.js
@@ -59,7 +59,6 @@ describe("ViewingRoom", () => {
           status
           timeZone
           title
-          # viewingRoomArtworks
         }
       }
     `

--- a/src/schema/v2/__tests__/viewingRoomArtwork.test.ts
+++ b/src/schema/v2/__tests__/viewingRoomArtwork.test.ts
@@ -1,0 +1,71 @@
+import { runQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+import config from "config"
+
+describe("ViewingRoomArtwork", () => {
+  beforeAll(() => {
+    config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA = true
+  })
+
+  afterAll(() => {
+    config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA = false
+  })
+
+  const query = gql`
+    {
+      viewingRoom(id: "example-viewing-room") {
+        viewingRoomArtworks {
+          __typename
+          artworkID
+          internalID
+          published
+        }
+      }
+    }
+  `
+
+  it("fetches viewing room artworks", async () => {
+    const viewingRoomArtworksData = [
+      {
+        id: "example-viewing-room-artwork",
+        artwork_id: "example-artwork",
+        published: true,
+      },
+      {
+        id: "example-viewing-room-artwork-2",
+        artwork_id: "example-artwork-2",
+        published: false,
+      },
+    ]
+
+    const context = {
+      viewingRoomLoader: jest.fn().mockResolvedValue({ id: "viewing-room-id" }),
+      viewingRoomArtworksLoader: jest
+        .fn()
+        .mockResolvedValue(viewingRoomArtworksData),
+    }
+
+    const result = await runQuery(query, context)
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "viewingRoom": {
+          "viewingRoomArtworks": [
+            {
+              "__typename": "ViewingRoomArtwork",
+              "artworkID": "example-artwork",
+              "internalID": "example-viewing-room-artwork",
+              "published": true,
+            },
+            {
+              "__typename": "ViewingRoomArtwork",
+              "artworkID": "example-artwork-2",
+              "internalID": "example-viewing-room-artwork-2",
+              "published": false,
+            },
+          ],
+        },
+      }
+    `)
+  })
+})

--- a/src/schema/v2/viewingRoom.ts
+++ b/src/schema/v2/viewingRoom.ts
@@ -22,7 +22,7 @@ import { dateRange } from "lib/date"
 import { GravityARImageType } from "./GravityARImageType"
 import { ViewingRoomSubsectionType } from "./viewingRoomSubsection"
 // import PartnerArtworks from "./partner/partnerArtworks"
-// import { ViewingRoomArtworkType } from "./viewingRoomArtwork"
+import { ViewingRoomArtworkType } from "./viewingRoomArtwork"
 
 const LocaleEnViewingRoomRelativeShort = "en-viewing-room-relative-short"
 defineCustomLocale(LocaleEnViewingRoomRelativeShort, {
@@ -285,11 +285,12 @@ export const ViewingRoomType = new GraphQLObjectType<any, ResolverContext>({
         type: new GraphQLNonNull(GraphQLString),
         description: "Viewing room name",
       },
-      // TODO: In separate PR
-      // viewingRoomArtworks: {
-      //   type: new GraphQLNonNull(new GraphQLList(ViewingRoomArtworkType)),
-      //   resolve: ({ viewing_room_artworks }) => viewing_room_artworks,
-      // },
+      viewingRoomArtworks: {
+        type: new GraphQLNonNull(new GraphQLList(ViewingRoomArtworkType)),
+        resolve: async ({ id }, _args, { viewingRoomArtworksLoader }) => {
+          return viewingRoomArtworksLoader(id)
+        },
+      },
     }
   },
 })

--- a/src/schema/v2/viewingRoomArtwork.ts
+++ b/src/schema/v2/viewingRoomArtwork.ts
@@ -1,0 +1,30 @@
+import {
+  GraphQLBoolean,
+  GraphQLID,
+  GraphQLNonNull,
+  GraphQLObjectType,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+
+export const ViewingRoomArtworkType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "ViewingRoomArtwork",
+  fields: () => {
+    return {
+      internalID: {
+        description: "A type-specific ID likely used as a database ID.",
+        type: new GraphQLNonNull(GraphQLID),
+        resolve: ({ id }) => id,
+      },
+      artworkID: {
+        type: new GraphQLNonNull(GraphQLID),
+        resolve: ({ artwork_id }) => artwork_id,
+      },
+      published: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+      },
+    }
+  },
+})


### PR DESCRIPTION
Continuation of https://github.com/artsy/metaphysics/pull/6065 (unstitching viewing rooms)

Adds `viewingRoomArtworks` field:

```graphql
{
  viewingRoom(id: "leslie-feely-alice-baber") {
    viewingRoomArtworks {
      __typename
      artworkID
      internalID
      published
    }
  }
}
```