### PR TITLE
refactor(onyx-1406): add partner artwork to viewing room type

### DIFF
--- a/src/schema/v2/__tests__/viewingRoom.test.js
+++ b/src/schema/v2/__tests__/viewingRoom.test.js
@@ -43,14 +43,14 @@ describe("ViewingRoom", () => {
           partner {
             name
           }
-          # partnerArtworksConnection(first: 1) {
-          #   totalCount
-          #   edges {
-          #     node {
-          #       title
-          #     }
-          #   }
-          # }
+          partnerArtworksConnection(first: 1) {
+            totalCount
+            edges {
+              node {
+                title
+              }
+            }
+          }
           partnerID
           published
           pullQuote
@@ -135,12 +135,12 @@ describe("ViewingRoom", () => {
 
       expect(partnerLoader).toHaveBeenCalledWith("partner-id")
 
-      // expect(partnerArtworksLoader).toHaveBeenCalledWith("partner-id", {
-      //   page: 1,
-      //   size: 1,
-      //   total_count: true,
-      //   viewing_room_id: "viewing-room-id",
-      // })
+      expect(partnerArtworksLoader).toHaveBeenCalledWith("partner-id", {
+        page: 1,
+        size: 1,
+        total_count: true,
+        viewing_room_id: "viewing-room-id",
+      })
 
       expect(result).toMatchInlineSnapshot(`
         {
@@ -176,6 +176,16 @@ describe("ViewingRoom", () => {
             "introStatement": "intro statement",
             "partner": {
               "name": "Partner Name",
+            },
+            "partnerArtworksConnection": {
+              "edges": [
+                {
+                  "node": {
+                    "title": "Partner Artwork 1",
+                  },
+                },
+              ],
+              "totalCount": 2,
             },
             "partnerID": "partner-id",
             "published": true,

--- a/src/schema/v2/partner/partnerArtworks.ts
+++ b/src/schema/v2/partner/partnerArtworks.ts
@@ -8,7 +8,7 @@ import { GraphQLBoolean } from "graphql"
 import { merge } from "lodash"
 import { createPageCursors } from "schema/v2/fields/pagination"
 
-const PartnerArtworks: GraphQLFieldConfig<void, ResolverContext> = {
+export const PartnerArtworks: GraphQLFieldConfig<void, ResolverContext> = {
   type: artworkConnection.connectionType,
   description: "A list of Artworks for a partner",
   deprecationReason:

--- a/src/schema/v2/viewingRoom.ts
+++ b/src/schema/v2/viewingRoom.ts
@@ -12,7 +12,7 @@ import {
   convertConnectionArgsToGravityArgs,
   defineCustomLocale,
 } from "lib/helpers"
-import { createPageCursors } from "./fields/pagination"
+import { createPageCursors, emptyConnection } from "./fields/pagination"
 import { connectionFromArray } from "graphql-relay"
 import { artworkConnection } from "./artwork"
 import { pageable } from "relay-cursor-paging"
@@ -21,7 +21,6 @@ import { PartnerType } from "./partner/partner"
 import { dateRange } from "lib/date"
 import { GravityARImageType } from "./GravityARImageType"
 import { ViewingRoomSubsectionType } from "./viewingRoomSubsection"
-// import PartnerArtworks from "./partner/partnerArtworks"
 import { ViewingRoomArtworkType } from "./viewingRoomArtwork"
 
 const LocaleEnViewingRoomRelativeShort = "en-viewing-room-relative-short"
@@ -66,6 +65,8 @@ defineCustomLocale(LocaleEnViewingRoomRelativeLong, {
 export const ViewingRoomType = new GraphQLObjectType<any, ResolverContext>({
   name: "ViewingRoom",
   fields: () => {
+    const { PartnerArtworks } = require("schema/v2/partner/partnerArtworks")
+
     return {
       internalID: {
         description: "A type-specific ID likely used as a database ID.",
@@ -225,27 +226,26 @@ export const ViewingRoomType = new GraphQLObjectType<any, ResolverContext>({
           return partnerLoader(partner_id)
         },
       },
-      // TODO: it causes yarn dump:local to fail with typeError: Cannot read properties of undefined (reading 'connectionType') in partnerArtworks.ts
-      // partnerArtworksConnection: {
-      //   type: artworkConnection.connectionType,
-      //   args: pageable({}),
-      //   resolve: ({ partner_id, id }, args, context, info) => {
-      //     if (!PartnerArtworks?.resolve) {
-      //       return emptyConnection
-      //     }
+      partnerArtworksConnection: {
+        type: artworkConnection.connectionType,
+        args: pageable({}),
+        resolve: ({ partner_id, id }, args, context, info) => {
+          if (!PartnerArtworks?.resolve) {
+            return emptyConnection
+          }
 
-      //     return PartnerArtworks.resolve(
-      //       undefined,
-      //       {
-      //         partnerID: partner_id,
-      //         viewingRoomID: id,
-      //         ...args,
-      //       },
-      //       context,
-      //       info
-      //     )
-      //   },
-      // },
+          return PartnerArtworks.resolve(
+            undefined,
+            {
+              partnerID: partner_id,
+              viewingRoomID: id,
+              ...args,
+            },
+            context,
+            info
+          )
+        },
+      },
       partnerID: {
         type: new GraphQLNonNull(GraphQLString),
         description: "ID of the partner associated with this viewing room",


### PR DESCRIPTION
Thanks again @mzikherman for suggesting to try `require` thingy, couldn't figure out where the error was coming from!

Follow-up: https://github.com/artsy/metaphysics/pull/6065#discussion_r1846229641

This PR adds partner artworks connection to viewing rooms:

```graphql
{
  viewingRoom(id: "leslie-feely-alice-baber") {
    partnerArtworksConnection(first: 1) {
      totalCount
      edges {
        node {
          title
        }
      }
    }
  }
}
```