### PR TITLE
refactor: don't repeat InternalIDField definition

### DIFF
--- a/src/schema/v2/object_identification.ts
+++ b/src/schema/v2/object_identification.ts
@@ -245,6 +245,14 @@ export const InternalIDFields: GraphQLFieldConfigMap<any, ResolverContext> = {
   },
 }
 
+export const InternalIDField: GraphQLFieldConfigMap<any, ResolverContext> = {
+  internalID: {
+    description: "A type-specific ID likely used as a database ID.",
+    type: new GraphQLNonNull(GraphQLID),
+    resolve: ({ id }) => id,
+  },
+}
+
 export default {
   GlobalIDField,
   GravityIDFields,

--- a/src/schema/v2/viewingRoom.ts
+++ b/src/schema/v2/viewingRoom.ts
@@ -22,6 +22,7 @@ import { dateRange } from "lib/date"
 import { GravityARImageType } from "./GravityARImageType"
 import { ViewingRoomSubsectionType } from "./viewingRoomSubsection"
 import { ViewingRoomArtworkType } from "./viewingRoomArtwork"
+import { InternalIDField } from "./object_identification"
 
 const LocaleEnViewingRoomRelativeShort = "en-viewing-room-relative-short"
 defineCustomLocale(LocaleEnViewingRoomRelativeShort, {
@@ -68,11 +69,7 @@ export const ViewingRoomType = new GraphQLObjectType<any, ResolverContext>({
     const { PartnerArtworks } = require("schema/v2/partner/partnerArtworks")
 
     return {
-      internalID: {
-        description: "A type-specific ID likely used as a database ID.",
-        type: new GraphQLNonNull(GraphQLID),
-        resolve: ({ id }) => id,
-      },
+      ...InternalIDField,
       artworkIDs: {
         type: new GraphQLNonNull(new GraphQLList(GraphQLString)),
         resolve: ({ artwork_ids }) => artwork_ids,

--- a/src/schema/v2/viewingRoomArtwork.ts
+++ b/src/schema/v2/viewingRoomArtwork.ts
@@ -5,6 +5,7 @@ import {
   GraphQLObjectType,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { InternalIDField } from "./object_identification"
 
 export const ViewingRoomArtworkType = new GraphQLObjectType<
   any,
@@ -13,11 +14,7 @@ export const ViewingRoomArtworkType = new GraphQLObjectType<
   name: "ViewingRoomArtwork",
   fields: () => {
     return {
-      internalID: {
-        description: "A type-specific ID likely used as a database ID.",
-        type: new GraphQLNonNull(GraphQLID),
-        resolve: ({ id }) => id,
-      },
+      ...InternalIDField,
       artworkID: {
         type: new GraphQLNonNull(GraphQLID),
         resolve: ({ artwork_id }) => artwork_id,

--- a/src/schema/v2/viewingRoomSubsection.ts
+++ b/src/schema/v2/viewingRoomSubsection.ts
@@ -1,11 +1,7 @@
-import {
-  GraphQLID,
-  GraphQLNonNull,
-  GraphQLObjectType,
-  GraphQLString,
-} from "graphql"
+import { GraphQLObjectType, GraphQLString } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { GravityARImageType } from "./GravityARImageType"
+import { InternalIDField } from "./object_identification"
 
 export const ViewingRoomSubsectionType = new GraphQLObjectType<
   any,
@@ -14,11 +10,7 @@ export const ViewingRoomSubsectionType = new GraphQLObjectType<
   name: "ViewingRoomSubsection",
   fields: () => {
     return {
-      internalID: {
-        description: "A type-specific ID likely used as a database ID.",
-        type: new GraphQLNonNull(GraphQLID),
-        resolve: ({ id }) => id,
-      },
+      ...InternalIDField,
       body: {
         type: GraphQLString,
       },


### PR DESCRIPTION
Follow-up of this code review comment: https://github.com/artsy/metaphysics/pull/6249#discussion_r1850676046

Before I was repeating definition of `InternalID` field in multiple places, now I simply spread the definition from a single place. 