### PR TITLE
chore(perf): clean up unused systemTimeLoader

### DIFF
--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -314,7 +314,6 @@ export default (opts) => {
       { method: "PUT" }
     ),
     staticContentLoader: gravityLoader((id) => `page/${id}`),
-    systemTimeLoader: gravityUncachedLoader("system/time", null),
     tagLoader: gravityLoader((id) => `tag/${id}`),
     trendingArtistsLoader: gravityLoader("artists/trending"),
     userByEmailLoader: gravityLoader("user", {}, { method: "GET" }),


### PR DESCRIPTION
Looking back at https://github.com/artsy/metaphysics/pull/6247 reminded me that the `systemTimeLoader` is now unused, and can be cleaned up.