### PR TITLE
fix: alias stitched artist query to avoid conflicts on shallow arg

### DIFF
--- a/src/lib/stitching/vortex/v2/stitching.ts
+++ b/src/lib/stitching/vortex/v2/stitching.ts
@@ -154,7 +154,7 @@ export const vortexStitchingEnvironment = (
             isPriceHidden
             isInAuction
             priceCurrency
-            artists {
+            pricingContextArtists: artists(shallow: true) {
               internalID
             }
             artistNames
@@ -163,7 +163,7 @@ export const vortexStitchingEnvironment = (
         resolve: async (source, _, context, info) => {
           const {
             artist,
-            artists,
+            pricingContextArtists,
             artistNames,
             category,
             editionSets,
@@ -196,7 +196,7 @@ export const vortexStitchingEnvironment = (
             isPriceHidden ||
             isInAuction ||
             priceCurrency !== "USD" ||
-            (artists && artists.length > 1) ||
+            (pricingContextArtists && pricingContextArtists.length > 1) ||
             !isForSale ||
             !price ||
             !artist ||


### PR DESCRIPTION
We observed a large number of `PricingContextQuery` failures after the optimization in https://github.com/artsy/force/pull/14858. Unfortunately, this sort of conflict between the client's and stitched-in query isn't automatically surfaced during Relay compilation.