### PR TITLE
refactor: add create viewing room mutation (unstitching)

### DIFF
--- a/src/lib/gravityErrorHandler.ts
+++ b/src/lib/gravityErrorHandler.ts
@@ -9,6 +9,39 @@ import { isArray, isObject, omit, pickBy } from "lodash"
 import { ResolverContext } from "types/graphql"
 import { HTTPError } from "./HTTPError"
 
+// Gravity-defined error types: https://github.com/artsy/gravity/blob/main/app/graphql/types/errors_type.rb
+
+const ErrorType = new GraphQLObjectType<any, ResolverContext>({
+  name: "Error",
+  fields: () => ({
+    code: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "Error code",
+    },
+    data: {
+      type: GraphQLString, // Defined as JSON in Gravity
+      description: "Extra data about error.",
+    },
+    message: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "A description of the error",
+    },
+    path: {
+      type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
+      description: "Which input value this error came from",
+    },
+  }),
+})
+
+export const ErrorsType = new GraphQLObjectType<any, ResolverContext>({
+  name: "Errors",
+  fields: {
+    errors: {
+      type: new GraphQLList(ErrorType),
+    },
+  },
+})
+
 export const GravityMutationErrorType = new GraphQLObjectType<
   any,
   ResolverContext

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -123,6 +123,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    createViewingRoomLoader: gravityLoader(
+      "viewing_room",
+      {},
+      { method: "POST" }
+    ),
     deleteVerifiedRepresetativeLoader: gravityLoader(
       (id) => `verified_representatives/${id}`,
       {},

--- a/src/lib/stitching/gravity/schema.ts
+++ b/src/lib/stitching/gravity/schema.ts
@@ -5,6 +5,7 @@ import {
   FilterTypes,
   RenameTypes,
   RenameRootFields,
+  FilterRootFields,
 } from "graphql-tools"
 import { readFileSync } from "fs"
 import config from "config"
@@ -53,6 +54,17 @@ export const executableGravitySchema = () => {
     duplicatedTypes.push("ViewingRoom")
     duplicatedTypes.push("ViewingRoomsConnection")
     duplicatedTypes.push("ViewingRoomsEdge")
+    duplicatedTypes.push("ViewingRoomsEdge")
+
+    duplicatedTypes.push("CreateViewingRoomPayload")
+    duplicatedTypes.push("CreateViewingRoomInput")
+    duplicatedTypes.push("ViewingRoomOrErrorsUnion")
+    duplicatedTypes.push("ViewingRoomAttributes")
+  }
+
+  const excludedMutations: string[] = []
+  if (config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA) {
+    excludedMutations.push("createViewingRoom")
   }
 
   // Types which come from Gravity that are not (yet) needed in MP.
@@ -94,6 +106,15 @@ export const executableGravitySchema = () => {
       } else {
         return name
       }
+    }),
+    new FilterRootFields((operation, name) => {
+      if (!name) return true
+
+      if (operation === "Mutation") {
+        return !excludedMutations.includes(name)
+      }
+
+      return true
     }),
   ])
 }

--- a/src/schema/v2/me/secondFactors/secondFactors.ts
+++ b/src/schema/v2/me/secondFactors/secondFactors.ts
@@ -12,6 +12,7 @@ import {
 } from "graphql"
 import { date } from "../../fields/date"
 import { ResolverContext } from "types/graphql"
+import { ErrorsType } from "lib/gravityErrorHandler"
 
 export const SecondFactorKind = new GraphQLEnumType({
   name: "SecondFactorKind",
@@ -155,27 +156,6 @@ export const AppSecondFactorAttributes = new GraphQLInputObjectType({
   fields: {
     name: {
       type: GraphQLString,
-    },
-  },
-})
-
-const ErrorType = new GraphQLObjectType<any, ResolverContext>({
-  name: "Error",
-  fields: () => ({
-    code: {
-      type: new GraphQLNonNull(GraphQLString),
-    },
-    message: {
-      type: new GraphQLNonNull(GraphQLString),
-    },
-  }),
-})
-
-const ErrorsType = new GraphQLObjectType<any, ResolverContext>({
-  name: "Errors",
-  fields: {
-    errors: {
-      type: new GraphQLList(ErrorType),
     },
   },
 })

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -260,11 +260,18 @@ import { disableSecondFactorMutation } from "./me/secondFactors/mutations/disabl
 import { deliverSecondFactorMutation } from "./me/secondFactors/mutations/deliverSecondFactor"
 import { enableSecondFactorMutation } from "./me/secondFactors/mutations/enableSecondFactor"
 import { createAndSendBackupSecondFactorMutation } from "./users/createAndSendBackupSecondFactorMutation"
+import { createViewingRoomMutation } from "./viewingRooms/mutations/createViewingRoomMutation"
 
 const viewingRoomUnstitchedRootField = config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA
   ? {
       viewingRoom: ViewingRoom,
       viewingRoomsConnection: ViewingRoomsConnection,
+    }
+  : ({} as any)
+
+const viewingRoomsMutations = config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA
+  ? {
+      createViewingRoom: createViewingRoomMutation,
     }
   : ({} as any)
 
@@ -530,6 +537,7 @@ export default new GraphQLSchema({
       deliverSecondFactor: deliverSecondFactorMutation,
       enableSecondFactor: enableSecondFactorMutation,
       createAndSendBackupSecondFactor: createAndSendBackupSecondFactorMutation,
+      ...viewingRoomsMutations,
     },
   }),
   query: new GraphQLObjectType<any, ResolverContext>({

--- a/src/schema/v2/viewingRooms/mutations/__tests__/createViewingRoomMutation.test.ts
+++ b/src/schema/v2/viewingRooms/mutations/__tests__/createViewingRoomMutation.test.ts
@@ -83,15 +83,15 @@ describe("createViewingRoomMutation", () => {
         })
 
         expect(result).toMatchInlineSnapshot(`
-                  {
-                    "createViewingRoom": {
-                      "viewingRoomOrErrors": {
-                        "__typename": "ViewingRoom",
-                        "internalID": "viewing-room-id",
-                      },
-                    },
-                  }
-              `)
+          {
+            "createViewingRoom": {
+              "viewingRoomOrErrors": {
+                "__typename": "ViewingRoom",
+                "internalID": "viewing-room-id",
+              },
+            },
+          }
+        `)
       })
     })
 
@@ -148,15 +148,15 @@ describe("createViewingRoomMutation", () => {
         })
 
         expect(result).toMatchInlineSnapshot(`
-                  {
-                    "createViewingRoom": {
-                      "viewingRoomOrErrors": {
-                        "__typename": "ViewingRoom",
-                        "internalID": "viewing-room-id",
-                      },
-                    },
-                  }
-              `)
+          {
+            "createViewingRoom": {
+              "viewingRoomOrErrors": {
+                "__typename": "ViewingRoom",
+                "internalID": "viewing-room-id",
+              },
+            },
+          }
+        `)
       })
     })
 
@@ -209,15 +209,15 @@ describe("createViewingRoomMutation", () => {
         })
 
         expect(result).toMatchInlineSnapshot(`
-                  {
-                    "createViewingRoom": {
-                      "viewingRoomOrErrors": {
-                        "__typename": "ViewingRoom",
-                        "internalID": "viewing-room-id",
-                      },
-                    },
-                  }
-              `)
+          {
+            "createViewingRoom": {
+              "viewingRoomOrErrors": {
+                "__typename": "ViewingRoom",
+                "internalID": "viewing-room-id",
+              },
+            },
+          }
+        `)
       })
     })
   })

--- a/src/schema/v2/viewingRooms/mutations/__tests__/createViewingRoomMutation.test.ts
+++ b/src/schema/v2/viewingRooms/mutations/__tests__/createViewingRoomMutation.test.ts
@@ -1,0 +1,297 @@
+import config from "config"
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("createViewingRoomMutation", () => {
+  const mockCreateViewingRoomLoader = jest.fn()
+
+  beforeAll(() => {
+    config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA = true
+  })
+
+  afterAll(() => {
+    config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA = false
+  })
+
+  describe("success", () => {
+    const context = {
+      createViewingRoomLoader: mockCreateViewingRoomLoader,
+    }
+
+    const viewingRoomData = {
+      id: "viewing-room-id",
+    }
+
+    beforeEach(() => {
+      mockCreateViewingRoomLoader.mockResolvedValue(
+        Promise.resolve(viewingRoomData)
+      )
+    })
+
+    afterEach(() => {
+      mockCreateViewingRoomLoader.mockReset()
+    })
+
+    describe("when passing top-level attributes", () => {
+      const mutation = gql`
+        mutation {
+          createViewingRoom(
+            input: {
+              body: "test body"
+              endAt: "2092-05-23T00:00:00.000Z"
+              image: { internalID: "image-id" }
+              introStatement: "intro statement"
+              partnerID: "partner-id"
+              pullQuote: "pull quote"
+              startAt: "1992-05-23T00:00:00.000Z"
+              timeZone: "Etc/UTC"
+              title: "test title"
+            }
+          ) {
+            viewingRoomOrErrors {
+              __typename
+
+              ... on ViewingRoom {
+                __typename
+
+                internalID
+              }
+
+              ... on Errors {
+                errors {
+                  message
+                }
+              }
+            }
+          }
+        }
+      `
+
+      it("correctly calls the createViewingRoomLoader", async () => {
+        const result = await runAuthenticatedQuery(mutation, context)
+
+        expect(mockCreateViewingRoomLoader).toHaveBeenCalledWith({
+          body: "test body",
+          end_at: "2092-05-23T00:00:00.000Z",
+          image: { internalID: "image-id" },
+          intro_statement: "intro statement",
+          partner_id: "partner-id",
+          pull_quote: "pull quote",
+          start_at: "1992-05-23T00:00:00.000Z",
+          time_zone: "Etc/UTC",
+          title: "test title",
+        })
+
+        expect(result).toMatchInlineSnapshot(`
+                  {
+                    "createViewingRoom": {
+                      "viewingRoomOrErrors": {
+                        "__typename": "ViewingRoom",
+                        "internalID": "viewing-room-id",
+                      },
+                    },
+                  }
+              `)
+      })
+    })
+
+    describe("when passing nested attributes", () => {
+      const mutation = gql`
+        mutation {
+          createViewingRoom(
+            input: {
+              image: { internalID: "image-id" }
+              partnerID: "partner-id"
+              attributes: {
+                body: "test body"
+                endAt: "2092-05-23T00:00:00.000Z"
+                introStatement: "intro statement"
+                pullQuote: "pull quote"
+                startAt: "1992-05-23T00:00:00.000Z"
+                timeZone: "Etc/UTC"
+                title: "test title"
+              }
+            }
+          ) {
+            viewingRoomOrErrors {
+              __typename
+
+              ... on ViewingRoom {
+                __typename
+
+                internalID
+              }
+
+              ... on Errors {
+                errors {
+                  message
+                }
+              }
+            }
+          }
+        }
+      `
+
+      it("correctly calls the createViewingRoomLoader", async () => {
+        const result = await runAuthenticatedQuery(mutation, context)
+
+        expect(mockCreateViewingRoomLoader).toHaveBeenCalledWith({
+          body: "test body",
+          end_at: "2092-05-23T00:00:00.000Z",
+          image: { internalID: "image-id" },
+          intro_statement: "intro statement",
+          partner_id: "partner-id",
+          pull_quote: "pull quote",
+          start_at: "1992-05-23T00:00:00.000Z",
+          time_zone: "Etc/UTC",
+          title: "test title",
+        })
+
+        expect(result).toMatchInlineSnapshot(`
+                  {
+                    "createViewingRoom": {
+                      "viewingRoomOrErrors": {
+                        "__typename": "ViewingRoom",
+                        "internalID": "viewing-room-id",
+                      },
+                    },
+                  }
+              `)
+      })
+    })
+
+    describe("when some attributes are ommited", () => {
+      const mutation = gql`
+        mutation {
+          createViewingRoom(
+            input: {
+              image: { internalID: "image-id" }
+              partnerID: "partner-id"
+              attributes: {
+                body: "test body"
+                endAt: "2092-05-23T00:00:00.000Z"
+                startAt: "1992-05-23T00:00:00.000Z"
+                timeZone: "Etc/UTC"
+                title: "test title"
+              }
+            }
+          ) {
+            viewingRoomOrErrors {
+              __typename
+
+              ... on ViewingRoom {
+                __typename
+
+                internalID
+              }
+
+              ... on Errors {
+                errors {
+                  message
+                }
+              }
+            }
+          }
+        }
+      `
+
+      it("correctly calls the createViewingRoomLoader (doesn't send undefined attributes)", async () => {
+        const result = await runAuthenticatedQuery(mutation, context)
+
+        expect(mockCreateViewingRoomLoader).toHaveBeenCalledWith({
+          body: "test body",
+          end_at: "2092-05-23T00:00:00.000Z",
+          image: { internalID: "image-id" },
+          partner_id: "partner-id",
+          start_at: "1992-05-23T00:00:00.000Z",
+          time_zone: "Etc/UTC",
+          title: "test title",
+        })
+
+        expect(result).toMatchInlineSnapshot(`
+                  {
+                    "createViewingRoom": {
+                      "viewingRoomOrErrors": {
+                        "__typename": "ViewingRoom",
+                        "internalID": "viewing-room-id",
+                      },
+                    },
+                  }
+              `)
+      })
+    })
+  })
+
+  describe("when gravity returns an error", () => {
+    const context = {
+      createViewingRoomLoader: mockCreateViewingRoomLoader,
+    }
+
+    beforeEach(() => {
+      mockCreateViewingRoomLoader.mockRejectedValue({
+        body: {
+          message: "An error occurred",
+        },
+      })
+    })
+
+    afterEach(() => {
+      mockCreateViewingRoomLoader.mockReset()
+    })
+
+    const mutation = gql`
+      mutation {
+        createViewingRoom(
+          input: {
+            image: { internalID: "image-id" }
+            partnerID: "partner-id"
+            attributes: {
+              body: "test body"
+              endAt: "2092-05-23T00:00:00.000Z"
+              introStatement: "intro statement"
+              pullQuote: "pull quote"
+              startAt: "1992-05-23T00:00:00.000Z"
+              timeZone: "Etc/UTC"
+              title: "test title"
+            }
+          }
+        ) {
+          viewingRoomOrErrors {
+            __typename
+
+            ... on ViewingRoom {
+              __typename
+
+              internalID
+            }
+
+            ... on Errors {
+              errors {
+                message
+              }
+            }
+          }
+        }
+      }
+    `
+
+    it("returns an error", async () => {
+      const result = await runAuthenticatedQuery(mutation, context)
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "createViewingRoom": {
+            "viewingRoomOrErrors": {
+              "__typename": "Errors",
+              "errors": [
+                {
+                  "message": "An error occurred",
+                },
+              ],
+            },
+          },
+        }
+      `)
+    })
+  })
+})

--- a/src/schema/v2/viewingRooms/mutations/__tests__/createViewingRoomMutation.test.ts
+++ b/src/schema/v2/viewingRooms/mutations/__tests__/createViewingRoomMutation.test.ts
@@ -71,9 +71,9 @@ describe("createViewingRoomMutation", () => {
         const result = await runAuthenticatedQuery(mutation, context)
 
         expect(mockCreateViewingRoomLoader).toHaveBeenCalledWith({
+          ar_image_id: "image-id",
           body: "test body",
           end_at: "2092-05-23T00:00:00.000Z",
-          image: { internalID: "image-id" },
           intro_statement: "intro statement",
           partner_id: "partner-id",
           pull_quote: "pull quote",
@@ -136,9 +136,9 @@ describe("createViewingRoomMutation", () => {
         const result = await runAuthenticatedQuery(mutation, context)
 
         expect(mockCreateViewingRoomLoader).toHaveBeenCalledWith({
+          ar_image_id: "image-id",
           body: "test body",
           end_at: "2092-05-23T00:00:00.000Z",
-          image: { internalID: "image-id" },
           intro_statement: "intro statement",
           partner_id: "partner-id",
           pull_quote: "pull quote",
@@ -199,9 +199,9 @@ describe("createViewingRoomMutation", () => {
         const result = await runAuthenticatedQuery(mutation, context)
 
         expect(mockCreateViewingRoomLoader).toHaveBeenCalledWith({
+          ar_image_id: "image-id",
           body: "test body",
           end_at: "2092-05-23T00:00:00.000Z",
-          image: { internalID: "image-id" },
           partner_id: "partner-id",
           start_at: "1992-05-23T00:00:00.000Z",
           time_zone: "Etc/UTC",

--- a/src/schema/v2/viewingRooms/mutations/createViewingRoomMutation.ts
+++ b/src/schema/v2/viewingRooms/mutations/createViewingRoomMutation.ts
@@ -1,0 +1,154 @@
+import {
+  GraphQLID,
+  GraphQLInputObjectType,
+  GraphQLNonNull,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ErrorsType } from "lib/gravityErrorHandler"
+import { ViewingRoomType } from "schema/v2/viewingRoom"
+import { ResolverContext } from "types/graphql"
+
+const ResponseOrErrorType = new GraphQLNonNull(
+  new GraphQLUnionType({
+    name: "ViewingRoomOrErrorsUnion",
+    types: [ViewingRoomType, ErrorsType],
+    resolveType: (data) => {
+      if (data.id) {
+        return ViewingRoomType
+      }
+
+      return ErrorsType
+    },
+  })
+)
+
+export const createViewingRoomMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "createViewingRoom",
+  inputFields: {
+    // TODO: explain duplication
+    attributes: {
+      type: new GraphQLInputObjectType({
+        name: "ViewingRoomAttributes",
+        fields: {
+          body: {
+            type: GraphQLString,
+          },
+          endAt: {
+            type: GraphQLString,
+            description: "Datetime (in UTC) when Viewing Room closes",
+          },
+          introStatement: {
+            type: GraphQLString,
+          },
+          pullQuote: {
+            type: GraphQLString,
+          },
+          startAt: {
+            type: GraphQLString,
+            description: "Datetime (in UTC) when Viewing Room opens",
+          },
+          timeZone: {
+            type: GraphQLString,
+            description:
+              "Time zone (tz database format, e.g. America/New_York) in which start_at/end_at attributes were input",
+          },
+          title: {
+            type: GraphQLString,
+            description: "Title",
+          },
+        },
+      }),
+    },
+    body: {
+      type: GraphQLString,
+      description: "Main text",
+    },
+    endAt: {
+      type: GraphQLString,
+      description: "End datetime",
+    },
+    image: {
+      type: new GraphQLInputObjectType({
+        name: "ARImageInput",
+        fields: {
+          internalID: {
+            type: new GraphQLNonNull(GraphQLID),
+          },
+        },
+      }),
+    },
+    introStatement: {
+      type: GraphQLString,
+      description: "Introduction",
+    },
+    partnerId: {
+      type: GraphQLString,
+      description: "Partner Id",
+    },
+    partnerID: {
+      type: GraphQLString,
+    },
+    pullQuote: {
+      type: GraphQLString,
+      description: "Pullquote",
+    },
+    startAt: {
+      type: GraphQLString,
+      description: "Start datetime",
+    },
+    timeZone: {
+      type: GraphQLString,
+      description: "Timezone",
+    },
+    title: {
+      type: GraphQLString,
+      description: "Title",
+    },
+  },
+  outputFields: {
+    viewingRoomOrErrors: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (args, { createViewingRoomLoader }) => {
+    if (!createViewingRoomLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const gravityArgs = {
+        body: args.body || args.attributes?.body,
+        end_at: args.endAt || args.attributes?.endAt,
+        image: args.image,
+        intro_statement: args.introStatement || args.attributes?.introStatement,
+        partner_id: args.partnerId || args.partnerID,
+        pull_quote: args.pullQuote || args.attributes?.pullQuote,
+        start_at: args.startAt || args.attributes?.startAt,
+        time_zone: args.timeZone || args.attributes?.timeZone,
+        title: args.title || args.attributes?.title,
+      }
+
+      const response = await createViewingRoomLoader(gravityArgs)
+
+      return response
+    } catch (error) {
+      const { body } = error
+
+      return {
+        errors: [
+          {
+            message: body.message ?? body.error,
+            code: "invalid",
+          },
+        ],
+      }
+    }
+  },
+})

--- a/src/schema/v2/viewingRooms/mutations/createViewingRoomMutation.ts
+++ b/src/schema/v2/viewingRooms/mutations/createViewingRoomMutation.ts
@@ -31,7 +31,9 @@ export const createViewingRoomMutation = mutationWithClientMutationId<
 >({
   name: "createViewingRoom",
   inputFields: {
-    // TODO: explain duplication
+    // If you scroll futher down, you'll notice that some attributes from attributes are duplicated in the inputFields
+    // This is because Gravity has such duplication https://github.com/artsy/gravity/blob/main/app/graphql/mutations/create_viewing_room.rb#L12
+    // We can get rid of it once we finish with the migration. For now I want to keep such changes to a minimum
     attributes: {
       type: new GraphQLInputObjectType({
         name: "ViewingRoomAttributes",

--- a/src/schema/v2/viewingRooms/mutations/createViewingRoomMutation.ts
+++ b/src/schema/v2/viewingRooms/mutations/createViewingRoomMutation.ts
@@ -7,6 +7,7 @@ import {
 } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 import { ErrorsType } from "lib/gravityErrorHandler"
+import { identity, pickBy } from "lodash"
 import { ViewingRoomType } from "schema/v2/viewingRoom"
 import { ResolverContext } from "types/graphql"
 
@@ -125,17 +126,21 @@ export const createViewingRoomMutation = mutationWithClientMutationId<
     }
 
     try {
-      const gravityArgs = {
-        body: args.body || args.attributes?.body,
-        end_at: args.endAt || args.attributes?.endAt,
-        image: args.image,
-        intro_statement: args.introStatement || args.attributes?.introStatement,
-        partner_id: args.partnerId || args.partnerID,
-        pull_quote: args.pullQuote || args.attributes?.pullQuote,
-        start_at: args.startAt || args.attributes?.startAt,
-        time_zone: args.timeZone || args.attributes?.timeZone,
-        title: args.title || args.attributes?.title,
-      }
+      const gravityArgs = pickBy(
+        {
+          body: args.body || args.attributes?.body,
+          end_at: args.endAt || args.attributes?.endAt,
+          ar_image_id: args.image?.internalID,
+          intro_statement:
+            args.introStatement || args.attributes?.introStatement,
+          partner_id: args.partnerId || args.partnerID,
+          pull_quote: args.pullQuote || args.attributes?.pullQuote,
+          start_at: args.startAt || args.attributes?.startAt,
+          time_zone: args.timeZone || args.attributes?.timeZone,
+          title: args.title || args.attributes?.title,
+        },
+        identity
+      )
 
       const response = await createViewingRoomLoader(gravityArgs)
 


### PR DESCRIPTION
(This is one of many PRs for viewing rooms unstitching)

This PR adds `createViewingRoom` mutation. I've compared the responses between stitched and unstitched implementations and they mostly look the same, except errors (structure is the same, but error messages are different sometimes). I will either re-iterate, or will talk to Volt people to see if new errors are fine.

