### PR TITLE
feat(perf): avoid API requests that are usually unnecessary for Artwork.partner

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2597,7 +2597,7 @@ type Artwork implements Node & Searchable & Sellable {
   onlyShipsDomestically: Boolean
   partner(
     # Use whatever is in the original response instead of making a request
-    shallow: Boolean
+    shallow: Boolean = true
   ): Partner
   partnerOffersConnection(
     after: String

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1185,6 +1185,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             type: GraphQLBoolean,
             description:
               "Use whatever is in the original response instead of making a request",
+            defaultValue: true, // avoids API request that's usually unnecessary
           },
         },
         resolve: ({ partner }, { shallow }, { partnerLoader }) => {


### PR DESCRIPTION
As described in https://github.com/artsy/force/pull/14885#issuecomment-2494625571, our 2 major clients never need partners' "extended" properties when querying `Artwork.partner`. As a result, I hope it's safe to simply change that property's `shallow` argument to default to `true`. This avoids potentially many unnecessary API requests, and immediately benefits deployed clients.

(Of course, there _is_ some potential for developer confusion when documented properties come back as `null` in the `Artwork` context.)

As a precaution, I've dumped this updated schema locally (`yarn dump:local`) and confirmed that Force and Eigen both relay-compile successfully. For good measure I spot-checked Energy as well and didn't find any references to extended properties.