### PR TITLE
refactor(onyx-1408): add updateViewingRoom mutation (unstitching)

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -256,6 +256,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" }
     ),
+    updateViewingRoomLoader: gravityLoader(
+      (id) => `viewing_room/${id}`,
+      {},
+      { method: "PUT" }
+    ),
     deleteHeroUnitLoader: gravityLoader(
       (id) => `hero_units/${id}`,
       {},

--- a/src/lib/stitching/gravity/schema.ts
+++ b/src/lib/stitching/gravity/schema.ts
@@ -60,11 +60,14 @@ export const executableGravitySchema = () => {
     duplicatedTypes.push("CreateViewingRoomInput")
     duplicatedTypes.push("ViewingRoomOrErrorsUnion")
     duplicatedTypes.push("ViewingRoomAttributes")
+    duplicatedTypes.push("UpdateViewingRoomPayload")
+    duplicatedTypes.push("UpdateViewingRoomArtworksInput")
   }
 
   const excludedMutations: string[] = []
   if (config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA) {
     excludedMutations.push("createViewingRoom")
+    excludedMutations.push("updateViewingRoom")
   }
 
   // Types which come from Gravity that are not (yet) needed in MP.

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -261,6 +261,7 @@ import { deliverSecondFactorMutation } from "./me/secondFactors/mutations/delive
 import { enableSecondFactorMutation } from "./me/secondFactors/mutations/enableSecondFactor"
 import { createAndSendBackupSecondFactorMutation } from "./users/createAndSendBackupSecondFactorMutation"
 import { createViewingRoomMutation } from "./viewingRooms/mutations/createViewingRoomMutation"
+import { updateViewingRoomMutation } from "./viewingRooms/mutations/updateViewingRoomMutation"
 
 const viewingRoomUnstitchedRootField = config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA
   ? {
@@ -272,6 +273,7 @@ const viewingRoomUnstitchedRootField = config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA
 const viewingRoomsMutations = config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA
   ? {
       createViewingRoom: createViewingRoomMutation,
+      updateViewingRoom: updateViewingRoomMutation,
     }
   : ({} as any)
 

--- a/src/schema/v2/viewingRooms/mutations/ARImageInput.ts
+++ b/src/schema/v2/viewingRooms/mutations/ARImageInput.ts
@@ -1,0 +1,10 @@
+import { GraphQLID, GraphQLInputObjectType, GraphQLNonNull } from "graphql"
+
+export const ARImageInputType = new GraphQLInputObjectType({
+  name: "ARImageInput",
+  fields: {
+    internalID: {
+      type: new GraphQLNonNull(GraphQLID),
+    },
+  },
+})

--- a/src/schema/v2/viewingRooms/mutations/__tests__/updateViewingRoomMutation.test.ts
+++ b/src/schema/v2/viewingRooms/mutations/__tests__/updateViewingRoomMutation.test.ts
@@ -1,0 +1,238 @@
+import config from "config"
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("updateViewingRoomMutation", () => {
+  const mockUpdateViewingRoomLoader = jest.fn()
+
+  beforeAll(() => {
+    config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA = true
+  })
+
+  afterAll(() => {
+    config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA = false
+  })
+
+  describe("success", () => {
+    const context = {
+      updateViewingRoomLoader: mockUpdateViewingRoomLoader,
+    }
+
+    const viewingRoomData = {
+      id: "viewing-room-id",
+    }
+
+    beforeEach(() => {
+      mockUpdateViewingRoomLoader.mockResolvedValue(
+        Promise.resolve(viewingRoomData)
+      )
+    })
+
+    afterEach(() => {
+      mockUpdateViewingRoomLoader.mockReset()
+    })
+
+    describe("when passing all possible attributes", () => {
+      const mutation = gql`
+        mutation {
+          updateViewingRoom(
+            input: {
+              viewingRoomID: "viewing-room-id"
+              image: { internalID: "image-id" }
+              attributes: {
+                body: "test body"
+                endAt: "2092-05-23T00:00:00.000Z"
+                introStatement: "intro statement"
+                pullQuote: "pull quote"
+                startAt: "1992-05-23T00:00:00.000Z"
+                timeZone: "Etc/UTC"
+                title: "test title"
+              }
+            }
+          ) {
+            viewingRoomOrErrors {
+              __typename
+
+              ... on ViewingRoom {
+                __typename
+
+                internalID
+              }
+
+              ... on Errors {
+                errors {
+                  message
+                }
+              }
+            }
+          }
+        }
+      `
+
+      it("correctly calls the updateViewingRoomLoader", async () => {
+        const result = await runAuthenticatedQuery(mutation, context)
+
+        expect(mockUpdateViewingRoomLoader).toHaveBeenCalledWith(
+          "viewing-room-id",
+          {
+            ar_image_id: "image-id",
+            body: "test body",
+            end_at: "2092-05-23T00:00:00.000Z",
+            intro_statement: "intro statement",
+            pull_quote: "pull quote",
+            start_at: "1992-05-23T00:00:00.000Z",
+            time_zone: "Etc/UTC",
+            title: "test title",
+          }
+        )
+
+        expect(result).toMatchInlineSnapshot(`
+          {
+            "updateViewingRoom": {
+              "viewingRoomOrErrors": {
+                "__typename": "ViewingRoom",
+                "internalID": "viewing-room-id",
+              },
+            },
+          }
+        `)
+      })
+    })
+
+    describe("when some attributes are ommited", () => {
+      const mutation = gql`
+        mutation {
+          updateViewingRoom(
+            input: {
+              viewingRoomID: "viewing-room-id"
+              image: { internalID: "image-id" }
+              attributes: {
+                body: "test body"
+                endAt: "2092-05-23T00:00:00.000Z"
+                startAt: "1992-05-23T00:00:00.000Z"
+                timeZone: "Etc/UTC"
+                title: "test title"
+              }
+            }
+          ) {
+            viewingRoomOrErrors {
+              __typename
+
+              ... on ViewingRoom {
+                __typename
+
+                internalID
+              }
+
+              ... on Errors {
+                errors {
+                  message
+                }
+              }
+            }
+          }
+        }
+      `
+
+      it("correctly calls the updateViewingRoomLoader (doesn't send undefined attributes)", async () => {
+        const result = await runAuthenticatedQuery(mutation, context)
+
+        expect(mockUpdateViewingRoomLoader).toHaveBeenCalledWith(
+          "viewing-room-id",
+          {
+            ar_image_id: "image-id",
+            body: "test body",
+            end_at: "2092-05-23T00:00:00.000Z",
+            start_at: "1992-05-23T00:00:00.000Z",
+            time_zone: "Etc/UTC",
+            title: "test title",
+          }
+        )
+
+        expect(result).toMatchInlineSnapshot(`
+          {
+            "updateViewingRoom": {
+              "viewingRoomOrErrors": {
+                "__typename": "ViewingRoom",
+                "internalID": "viewing-room-id",
+              },
+            },
+          }
+        `)
+      })
+    })
+  })
+
+  describe("when gravity returns an error", () => {
+    const context = {
+      updateViewingRoomLoader: mockUpdateViewingRoomLoader,
+    }
+
+    beforeEach(() => {
+      mockUpdateViewingRoomLoader.mockRejectedValue({
+        body: {
+          message: "An error occurred",
+        },
+      })
+    })
+
+    afterEach(() => {
+      mockUpdateViewingRoomLoader.mockReset()
+    })
+
+    const mutation = gql`
+      mutation {
+        updateViewingRoom(
+          input: {
+            viewingRoomID: "viewing-room-id"
+            image: { internalID: "image-id" }
+            attributes: {
+              body: "test body"
+              endAt: "2092-05-23T00:00:00.000Z"
+              introStatement: "intro statement"
+              pullQuote: "pull quote"
+              startAt: "1992-05-23T00:00:00.000Z"
+              timeZone: "Etc/UTC"
+              title: "test title"
+            }
+          }
+        ) {
+          viewingRoomOrErrors {
+            __typename
+
+            ... on ViewingRoom {
+              __typename
+
+              internalID
+            }
+
+            ... on Errors {
+              errors {
+                message
+              }
+            }
+          }
+        }
+      }
+    `
+
+    it("returns an error", async () => {
+      const result = await runAuthenticatedQuery(mutation, context)
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "updateViewingRoom": {
+            "viewingRoomOrErrors": {
+              "__typename": "Errors",
+              "errors": [
+                {
+                  "message": "An error occurred",
+                },
+              ],
+            },
+          },
+        }
+      `)
+    })
+  })
+})

--- a/src/schema/v2/viewingRooms/mutations/__tests__/updateViewingRoomMutation.test.ts
+++ b/src/schema/v2/viewingRooms/mutations/__tests__/updateViewingRoomMutation.test.ts
@@ -99,7 +99,7 @@ describe("updateViewingRoomMutation", () => {
       })
     })
 
-    describe("when some attributes are ommited", () => {
+    describe("with null and ommited values", () => {
       const mutation = gql`
         mutation {
           updateViewingRoom(
@@ -107,7 +107,8 @@ describe("updateViewingRoomMutation", () => {
               viewingRoomID: "viewing-room-id"
               image: { internalID: "image-id" }
               attributes: {
-                body: "test body"
+                body: null
+                pullQuote: null
                 endAt: "2092-05-23T00:00:00.000Z"
                 startAt: "1992-05-23T00:00:00.000Z"
                 timeZone: "Etc/UTC"
@@ -134,14 +135,15 @@ describe("updateViewingRoomMutation", () => {
         }
       `
 
-      it("correctly calls the updateViewingRoomLoader (doesn't send undefined attributes)", async () => {
+      it("correctly calls the updateViewingRoomLoader", async () => {
         const result = await runAuthenticatedQuery(mutation, context)
 
         expect(mockUpdateViewingRoomLoader).toHaveBeenCalledWith(
           "viewing-room-id",
           {
             ar_image_id: "image-id",
-            body: "test body",
+            body: null,
+            pull_quote: null,
             end_at: "2092-05-23T00:00:00.000Z",
             start_at: "1992-05-23T00:00:00.000Z",
             time_zone: "Etc/UTC",

--- a/src/schema/v2/viewingRooms/mutations/createViewingRoomMutation.ts
+++ b/src/schema/v2/viewingRooms/mutations/createViewingRoomMutation.ts
@@ -1,29 +1,10 @@
-import {
-  GraphQLID,
-  GraphQLInputObjectType,
-  GraphQLNonNull,
-  GraphQLString,
-  GraphQLUnionType,
-} from "graphql"
+import { GraphQLString } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
-import { ErrorsType } from "lib/gravityErrorHandler"
 import { identity, pickBy } from "lodash"
-import { ViewingRoomType } from "schema/v2/viewingRoom"
 import { ResolverContext } from "types/graphql"
-
-const ResponseOrErrorType = new GraphQLNonNull(
-  new GraphQLUnionType({
-    name: "ViewingRoomOrErrorsUnion",
-    types: [ViewingRoomType, ErrorsType],
-    resolveType: (data) => {
-      if (data.id) {
-        return ViewingRoomType
-      }
-
-      return ErrorsType
-    },
-  })
-)
+import { ViewingRoomInputAttributesType } from "./viewingRoomInputAttributes"
+import { ViewingRoomOrErrorType } from "./viewingRoomOrError"
+import { ARImageInputType } from "./ARImageInput"
 
 export const createViewingRoomMutation = mutationWithClientMutationId<
   any,
@@ -36,37 +17,7 @@ export const createViewingRoomMutation = mutationWithClientMutationId<
     // This is because Gravity has such duplication https://github.com/artsy/gravity/blob/main/app/graphql/mutations/create_viewing_room.rb#L12
     // We can get rid of it once we finish with the migration. For now I want to keep such changes to a minimum
     attributes: {
-      type: new GraphQLInputObjectType({
-        name: "ViewingRoomAttributes",
-        fields: {
-          body: {
-            type: GraphQLString,
-          },
-          endAt: {
-            type: GraphQLString,
-            description: "Datetime (in UTC) when Viewing Room closes",
-          },
-          introStatement: {
-            type: GraphQLString,
-          },
-          pullQuote: {
-            type: GraphQLString,
-          },
-          startAt: {
-            type: GraphQLString,
-            description: "Datetime (in UTC) when Viewing Room opens",
-          },
-          timeZone: {
-            type: GraphQLString,
-            description:
-              "Time zone (tz database format, e.g. America/New_York) in which start_at/end_at attributes were input",
-          },
-          title: {
-            type: GraphQLString,
-            description: "Title",
-          },
-        },
-      }),
+      type: ViewingRoomInputAttributesType,
     },
     body: {
       type: GraphQLString,
@@ -77,14 +28,7 @@ export const createViewingRoomMutation = mutationWithClientMutationId<
       description: "End datetime",
     },
     image: {
-      type: new GraphQLInputObjectType({
-        name: "ARImageInput",
-        fields: {
-          internalID: {
-            type: new GraphQLNonNull(GraphQLID),
-          },
-        },
-      }),
+      type: ARImageInputType,
     },
     introStatement: {
       type: GraphQLString,
@@ -116,7 +60,7 @@ export const createViewingRoomMutation = mutationWithClientMutationId<
   },
   outputFields: {
     viewingRoomOrErrors: {
-      type: ResponseOrErrorType,
+      type: ViewingRoomOrErrorType,
       resolve: (result) => result,
     },
   },

--- a/src/schema/v2/viewingRooms/mutations/updateViewingRoomMutation.ts
+++ b/src/schema/v2/viewingRooms/mutations/updateViewingRoomMutation.ts
@@ -4,7 +4,6 @@ import { ResolverContext } from "types/graphql"
 import { ViewingRoomInputAttributesType } from "./viewingRoomInputAttributes"
 import { ViewingRoomOrErrorType } from "./viewingRoomOrError"
 import { ARImageInputType } from "./ARImageInput"
-import { identity, pickBy } from "lodash"
 
 export const updateViewingRoomMutation = mutationWithClientMutationId<
   any,
@@ -35,20 +34,16 @@ export const updateViewingRoomMutation = mutationWithClientMutationId<
     }
 
     try {
-      // remove undefined or null values from attributes
-      const gravityArgs = pickBy(
-        {
-          ar_image_id: args.image?.internalID,
-          body: args.attributes?.body,
-          end_at: args.attributes?.endAt,
-          intro_statement: args.attributes?.introStatement,
-          pull_quote: args.attributes?.pullQuote,
-          start_at: args.attributes?.startAt,
-          time_zone: args.attributes?.timeZone,
-          title: args.attributes?.title,
-        },
-        identity
-      )
+      const gravityArgs = {
+        ar_image_id: args.image?.internalID,
+        body: args.attributes?.body,
+        end_at: args.attributes?.endAt,
+        intro_statement: args.attributes?.introStatement,
+        pull_quote: args.attributes?.pullQuote,
+        start_at: args.attributes?.startAt,
+        time_zone: args.attributes?.timeZone,
+        title: args.attributes?.title,
+      }
 
       const response = await updateViewingRoomLoader(
         args.viewingRoomID,

--- a/src/schema/v2/viewingRooms/mutations/updateViewingRoomMutation.ts
+++ b/src/schema/v2/viewingRooms/mutations/updateViewingRoomMutation.ts
@@ -1,0 +1,72 @@
+import { GraphQLNonNull, GraphQLString } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import { ViewingRoomInputAttributesType } from "./viewingRoomInputAttributes"
+import { ViewingRoomOrErrorType } from "./viewingRoomOrError"
+import { ARImageInputType } from "./ARImageInput"
+import { identity, pickBy } from "lodash"
+
+export const updateViewingRoomMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "updateViewingRoom",
+  inputFields: {
+    attributes: {
+      type: ViewingRoomInputAttributesType,
+    },
+    image: {
+      type: ARImageInputType,
+    },
+    viewingRoomID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+  },
+  outputFields: {
+    viewingRoomOrErrors: {
+      type: ViewingRoomOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (args, { updateViewingRoomLoader }) => {
+    if (!updateViewingRoomLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      // remove undefined or null values from attributes
+      const gravityArgs = pickBy(
+        {
+          ar_image_id: args.image?.internalID,
+          body: args.attributes?.body,
+          end_at: args.attributes?.endAt,
+          intro_statement: args.attributes?.introStatement,
+          pull_quote: args.attributes?.pullQuote,
+          start_at: args.attributes?.startAt,
+          time_zone: args.attributes?.timeZone,
+          title: args.attributes?.title,
+        },
+        identity
+      )
+
+      const response = await updateViewingRoomLoader(
+        args.viewingRoomID,
+        gravityArgs
+      )
+
+      return response
+    } catch (error) {
+      const { body } = error
+
+      return {
+        errors: [
+          {
+            message: body.message ?? body.error,
+            code: "invalid",
+          },
+        ],
+      }
+    }
+  },
+})

--- a/src/schema/v2/viewingRooms/mutations/viewingRoomInputAttributes.ts
+++ b/src/schema/v2/viewingRooms/mutations/viewingRoomInputAttributes.ts
@@ -1,0 +1,33 @@
+import { GraphQLInputObjectType, GraphQLString } from "graphql"
+
+export const ViewingRoomInputAttributesType = new GraphQLInputObjectType({
+  name: "ViewingRoomAttributes",
+  fields: {
+    body: {
+      type: GraphQLString,
+    },
+    endAt: {
+      type: GraphQLString,
+      description: "Datetime (in UTC) when Viewing Room closes",
+    },
+    introStatement: {
+      type: GraphQLString,
+    },
+    pullQuote: {
+      type: GraphQLString,
+    },
+    startAt: {
+      type: GraphQLString,
+      description: "Datetime (in UTC) when Viewing Room opens",
+    },
+    timeZone: {
+      type: GraphQLString,
+      description:
+        "Time zone (tz database format, e.g. America/New_York) in which start_at/end_at attributes were input",
+    },
+    title: {
+      type: GraphQLString,
+      description: "Title",
+    },
+  },
+})

--- a/src/schema/v2/viewingRooms/mutations/viewingRoomOrError.ts
+++ b/src/schema/v2/viewingRooms/mutations/viewingRoomOrError.ts
@@ -1,0 +1,17 @@
+import { GraphQLNonNull, GraphQLUnionType } from "graphql"
+import { ErrorsType } from "lib/gravityErrorHandler"
+import { ViewingRoomType } from "schema/v2/viewingRoom"
+
+export const ViewingRoomOrErrorType = new GraphQLNonNull(
+  new GraphQLUnionType({
+    name: "ViewingRoomOrErrorsUnion",
+    types: [ViewingRoomType, ErrorsType],
+    resolveType: (data) => {
+      if (data.id) {
+        return ViewingRoomType
+      }
+
+      return ErrorsType
+    },
+  })
+)


### PR DESCRIPTION
This PR adds an unstitched version of `updateViewingRoom` mutation. The changes are hidden behind a feature flag.

To test:

```graphql
mutation {
  updateViewingRoom(
    input: {
      viewingRoomID: "room-id"
      image: { internalID: "image-id" }
      attributes: {
        body: "new body2"
        endAt: "2024-11-24T00:00:00.000Z"
        introStatement: "new intro"
        pullQuote: "new quote 2"
        startAt: "2024-11-21T00:00:00.000Z"
        timeZone: "Europe/Rome"
        title: "new title 2"
      }
    }
  ) {
    viewingRoomOrErrors {
      ... on ViewingRoom {
        title
      }

      ... on Errors {
        errors {
          message
        }
      }
    }
  }
}
```