### PR TITLE
refactor(onyx-1409): add deleteViewingRoom mutation (unstitching)

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -294,6 +294,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "DELETE" }
     ),
+    deleteViewingRoomLoader: gravityLoader(
+      (id) => `viewing_room/${id}`,
+      {},
+      { method: "DELETE" }
+    ),
     dislikeArtworkLoader: gravityLoader(
       (id) => `collection/disliked-artwork/artwork/${id}`,
       {},

--- a/src/lib/stitching/gravity/schema.ts
+++ b/src/lib/stitching/gravity/schema.ts
@@ -58,6 +58,8 @@ export const executableGravitySchema = () => {
 
     duplicatedTypes.push("CreateViewingRoomPayload")
     duplicatedTypes.push("CreateViewingRoomInput")
+    duplicatedTypes.push("DeleteViewingRoomInput")
+    duplicatedTypes.push("DeleteViewingRoomPayload")
     duplicatedTypes.push("ViewingRoomOrErrorsUnion")
     duplicatedTypes.push("ViewingRoomAttributes")
     duplicatedTypes.push("UpdateViewingRoomPayload")
@@ -67,6 +69,7 @@ export const executableGravitySchema = () => {
   const excludedMutations: string[] = []
   if (config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA) {
     excludedMutations.push("createViewingRoom")
+    excludedMutations.push("deleteViewingRoom")
     excludedMutations.push("updateViewingRoom")
   }
 

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -262,6 +262,7 @@ import { enableSecondFactorMutation } from "./me/secondFactors/mutations/enableS
 import { createAndSendBackupSecondFactorMutation } from "./users/createAndSendBackupSecondFactorMutation"
 import { createViewingRoomMutation } from "./viewingRooms/mutations/createViewingRoomMutation"
 import { updateViewingRoomMutation } from "./viewingRooms/mutations/updateViewingRoomMutation"
+import { deleteViewingRoomMutation } from "./viewingRooms/mutations/deleteViewingRoomMutation"
 
 const viewingRoomUnstitchedRootField = config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA
   ? {
@@ -273,6 +274,7 @@ const viewingRoomUnstitchedRootField = config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA
 const viewingRoomsMutations = config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA
   ? {
       createViewingRoom: createViewingRoomMutation,
+      deleteViewingRoom: deleteViewingRoomMutation,
       updateViewingRoom: updateViewingRoomMutation,
     }
   : ({} as any)

--- a/src/schema/v2/viewingRooms/mutations/__tests__/deleteViewingRoomMutation.test.ts
+++ b/src/schema/v2/viewingRooms/mutations/__tests__/deleteViewingRoomMutation.test.ts
@@ -1,0 +1,47 @@
+import config from "config"
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("deleteViewingRoomMutation", () => {
+  const mockDeleteViewingRoomLoader = jest.fn()
+
+  const context = {
+    deleteViewingRoomLoader: mockDeleteViewingRoomLoader,
+  }
+
+  const viewingRoomData = {
+    id: "viewing-room-id",
+  }
+
+  beforeAll(() => {
+    config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA = true
+  })
+
+  afterAll(() => {
+    config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA = false
+  })
+
+  beforeEach(() => {
+    mockDeleteViewingRoomLoader.mockResolvedValue(
+      Promise.resolve(viewingRoomData)
+    )
+  })
+
+  afterEach(() => {
+    mockDeleteViewingRoomLoader.mockReset()
+  })
+
+  const mutation = gql`
+    mutation {
+      deleteViewingRoom(input: { viewingRoomID: "viewing-room-id" }) {
+        __typename
+      }
+    }
+  `
+
+  it("correctly calls the deleteViewingRoomLoader", async () => {
+    await runAuthenticatedQuery(mutation, context)
+
+    expect(mockDeleteViewingRoomLoader).toHaveBeenCalledWith("viewing-room-id")
+  })
+})

--- a/src/schema/v2/viewingRooms/mutations/deleteViewingRoomMutation.ts
+++ b/src/schema/v2/viewingRooms/mutations/deleteViewingRoomMutation.ts
@@ -1,0 +1,25 @@
+import { GraphQLNonNull, GraphQLString } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+
+export const deleteViewingRoomMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "deleteViewingRoom",
+  inputFields: {
+    viewingRoomID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+  },
+  mutateAndGetPayload: async (args, { deleteViewingRoomLoader }) => {
+    if (!deleteViewingRoomLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    const response = await deleteViewingRoomLoader(args.viewingRoomID)
+
+    return response
+  },
+})


### PR DESCRIPTION
> [!NOTE]
> The code in this PR is branched from nickskalkin/onyx-1408, as it depends on some of refactoring made there.

This PR adds an unstitched version of `deleteViewingRoom` mutation. The changes are hidden behind a feature flag.

```graphql
mutation {
  deleteViewingRoom(
    input: { viewingRoomID: "room-id" }
  ) {
    __typename
  }
}
```