### PR TITLE
refactor(onyx-1410): add publish and unpublish viewing room mutations (unstitching)

### DIFF
--- a/src/lib/stitching/gravity/schema.ts
+++ b/src/lib/stitching/gravity/schema.ts
@@ -64,6 +64,10 @@ export const executableGravitySchema = () => {
     duplicatedTypes.push("ViewingRoomAttributes")
     duplicatedTypes.push("UpdateViewingRoomPayload")
     duplicatedTypes.push("UpdateViewingRoomArtworksInput")
+    duplicatedTypes.push("PublishViewingRoomInput")
+    duplicatedTypes.push("PublishViewingRoomPayload")
+    duplicatedTypes.push("UnpublishViewingRoomInput")
+    duplicatedTypes.push("UnpublishViewingRoomPayload")
   }
 
   const excludedMutations: string[] = []
@@ -71,6 +75,8 @@ export const executableGravitySchema = () => {
     excludedMutations.push("createViewingRoom")
     excludedMutations.push("deleteViewingRoom")
     excludedMutations.push("updateViewingRoom")
+    excludedMutations.push("publishViewingRoom")
+    excludedMutations.push("unpublishViewingRoom")
   }
 
   // Types which come from Gravity that are not (yet) needed in MP.

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -263,6 +263,8 @@ import { createAndSendBackupSecondFactorMutation } from "./users/createAndSendBa
 import { createViewingRoomMutation } from "./viewingRooms/mutations/createViewingRoomMutation"
 import { updateViewingRoomMutation } from "./viewingRooms/mutations/updateViewingRoomMutation"
 import { deleteViewingRoomMutation } from "./viewingRooms/mutations/deleteViewingRoomMutation"
+import { publishViewingRoomMutation } from "./viewingRooms/mutations/publishViewingRoomMutation"
+import { unpublishViewingRoomMutation } from "./viewingRooms/mutations/unpublishViewingRoomMutation"
 
 const viewingRoomUnstitchedRootField = config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA
   ? {
@@ -276,6 +278,8 @@ const viewingRoomsMutations = config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA
       createViewingRoom: createViewingRoomMutation,
       deleteViewingRoom: deleteViewingRoomMutation,
       updateViewingRoom: updateViewingRoomMutation,
+      publishViewingRoom: publishViewingRoomMutation,
+      unpublishViewingRoom: unpublishViewingRoomMutation,
     }
   : ({} as any)
 

--- a/src/schema/v2/viewingRooms/mutations/__tests__/publishViewingRoomMutation.test.ts
+++ b/src/schema/v2/viewingRooms/mutations/__tests__/publishViewingRoomMutation.test.ts
@@ -1,0 +1,52 @@
+import config from "config"
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("publishViewingRoomMutation", () => {
+  const mockUpdateViewingRoomLoader = jest.fn()
+
+  const context = {
+    updateViewingRoomLoader: mockUpdateViewingRoomLoader,
+  }
+
+  const viewingRoomData = {
+    id: "viewing-room-id",
+  }
+
+  beforeAll(() => {
+    config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA = true
+  })
+
+  afterAll(() => {
+    config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA = false
+  })
+
+  beforeEach(() => {
+    mockUpdateViewingRoomLoader.mockResolvedValue(
+      Promise.resolve(viewingRoomData)
+    )
+  })
+
+  afterEach(() => {
+    mockUpdateViewingRoomLoader.mockReset()
+  })
+
+  const mutation = gql`
+    mutation {
+      publishViewingRoom(input: { viewingRoomID: "viewing-room-id" }) {
+        __typename
+      }
+    }
+  `
+
+  it("correctly calls the updateViewingRoomLoader", async () => {
+    await runAuthenticatedQuery(mutation, context)
+
+    expect(mockUpdateViewingRoomLoader).toHaveBeenCalledWith(
+      "viewing-room-id",
+      {
+        published: true,
+      }
+    )
+  })
+})

--- a/src/schema/v2/viewingRooms/mutations/__tests__/unpublishViewingRoomMutation.test.ts
+++ b/src/schema/v2/viewingRooms/mutations/__tests__/unpublishViewingRoomMutation.test.ts
@@ -1,0 +1,52 @@
+import config from "config"
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("unpublishViewingRoomMutation", () => {
+  const mockUpdateViewingRoomLoader = jest.fn()
+
+  const context = {
+    updateViewingRoomLoader: mockUpdateViewingRoomLoader,
+  }
+
+  const viewingRoomData = {
+    id: "viewing-room-id",
+  }
+
+  beforeAll(() => {
+    config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA = true
+  })
+
+  afterAll(() => {
+    config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA = false
+  })
+
+  beforeEach(() => {
+    mockUpdateViewingRoomLoader.mockResolvedValue(
+      Promise.resolve(viewingRoomData)
+    )
+  })
+
+  afterEach(() => {
+    mockUpdateViewingRoomLoader.mockReset()
+  })
+
+  const mutation = gql`
+    mutation {
+      unpublishViewingRoom(input: { viewingRoomID: "viewing-room-id" }) {
+        __typename
+      }
+    }
+  `
+
+  it("correctly calls the updateViewingRoomLoader", async () => {
+    await runAuthenticatedQuery(mutation, context)
+
+    expect(mockUpdateViewingRoomLoader).toHaveBeenCalledWith(
+      "viewing-room-id",
+      {
+        published: false,
+      }
+    )
+  })
+})

--- a/src/schema/v2/viewingRooms/mutations/publishViewingRoomMutation.ts
+++ b/src/schema/v2/viewingRooms/mutations/publishViewingRoomMutation.ts
@@ -1,0 +1,27 @@
+import { GraphQLNonNull, GraphQLString } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+
+export const publishViewingRoomMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "publishViewingRoom",
+  inputFields: {
+    viewingRoomID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+  },
+  mutateAndGetPayload: async (args, { updateViewingRoomLoader }) => {
+    if (!updateViewingRoomLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    const response = await updateViewingRoomLoader(args.viewingRoomID, {
+      published: true,
+    })
+
+    return response
+  },
+})

--- a/src/schema/v2/viewingRooms/mutations/unpublishViewingRoomMutation.ts
+++ b/src/schema/v2/viewingRooms/mutations/unpublishViewingRoomMutation.ts
@@ -1,0 +1,27 @@
+import { GraphQLNonNull, GraphQLString } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+
+export const unpublishViewingRoomMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "unpublishViewingRoom",
+  inputFields: {
+    viewingRoomID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+  },
+  mutateAndGetPayload: async (args, { updateViewingRoomLoader }) => {
+    if (!updateViewingRoomLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    const response = await updateViewingRoomLoader(args.viewingRoomID, {
+      published: false,
+    })
+
+    return response
+  },
+})


### PR DESCRIPTION
> [!NOTE]
> The code in this PR is branched from nickskalkin/onyx-1408, as it depends on some of refactoring made there.

This PR adds an unstitched versions of `publishViewingRoom` and `unpublishViewingRoom` mutations. The changes are hidden behind a feature flag.

```graphql
mutation {
  (un)publishViewingRoom(
    input: { viewingRoomID: "room-id" }
  ) {
    __typename
  }
}
```