### PR TITLE
feat: switch some relatedShowsLoader usage to showsLoader

### DIFF
--- a/src/lib/stitching/__tests__/mergeSchemas.test.js
+++ b/src/lib/stitching/__tests__/mergeSchemas.test.js
@@ -36,7 +36,7 @@ describe("stitched schema regressions", () => {
         artworkLoader: async () => artworkResponse,
         salesLoader: async () => salesResponse,
         relatedFairsLoader: async () => ({}),
-        relatedShowsLoader: async () => ({}),
+        showsLoader: async () => ({}),
       }
     )
     expect(result).toEqual({

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -1821,7 +1821,7 @@ describe("Artwork type", () => {
       })
       context.salesLoader = sinon.stub().returns(Promise.resolve([relatedSale]))
       context.relatedFairsLoader = sinon.stub().returns(Promise.resolve([]))
-      context.relatedShowsLoader = sinon.stub().returns(Promise.resolve([]))
+      context.showsLoader = sinon.stub().returns(Promise.resolve([]))
       const query = `
         {
           artwork(id: "richard-prince-untitled-portrait") {
@@ -4670,7 +4670,7 @@ describe("Artwork type", () => {
         salesLoader: jest.fn(),
         saleArtworkLoader: jest.fn(),
         marketingCollectionLoader: jest.fn(),
-        relatedShowsLoader: jest.fn(),
+        showsLoader: jest.fn(),
       }
       context = {
         userID: "testUser",
@@ -4681,7 +4681,7 @@ describe("Artwork type", () => {
       context.mePartnerOffersLoader.mockResolvedValue({ body: [] })
       context.salesLoader.mockResolvedValue([])
       context.marketingCollectionLoader.mockResolvedValue({ artwork_ids: [] })
-      context.relatedShowsLoader.mockResolvedValue({ body: [] })
+      context.showsLoader.mockResolvedValue([])
     })
 
     describe("feature flags enabled", () => {
@@ -5129,15 +5129,13 @@ describe("Artwork type", () => {
       describe("runningShow", () => {
         it("returns the show or fair if the artwork id is in a running show or fair", async () => {
           artwork.purchasable = true
-          context.relatedShowsLoader.mockResolvedValue({
-            body: [
-              {
-                name: "Test Show",
-                start_at: "2023-01-01T00:00:00Z",
-                end_at: "2023-01-02T00:00:00Z",
-              },
-            ],
-          })
+          context.showsLoader.mockResolvedValue([
+            {
+              name: "Test Show",
+              start_at: "2023-01-01T00:00:00Z",
+              end_at: "2023-01-02T00:00:00Z",
+            },
+          ])
 
           const data = await runQuery(query, context)
           expect(data.artwork.collectorSignals.runningShow).toEqual({
@@ -5149,7 +5147,7 @@ describe("Artwork type", () => {
 
         it("returns null if the artwork id is not in a running show or fair", async () => {
           artwork.purchasable = true
-          context.relatedShowsLoader.mockResolvedValue({ body: [] })
+          context.showsLoader.mockResolvedValue([])
 
           const data = await runQuery(query, context)
           expect(data.artwork.collectorSignals.runningShow).toBeNull()

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -186,14 +186,14 @@ export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
         description:
           "Most recent running Show or Fair booth the artwork is currently in, sorted by relevance",
         resolve: async (artwork, {}, ctx) => {
-          const showOrFair = await await ctx.relatedShowsLoader({
-            artwork: [artwork._id],
+          const showOrFair = await await ctx.showsLoader({
+            artwork: artwork._id,
             size: 1,
             status: "running",
-            hasLocation: true,
+            has_location: true,
             sort: "-relevance,-start_at",
           })
-          return showOrFair.body[0]
+          return showOrFair[0]
         },
       },
     },

--- a/src/schema/v2/artwork/context.ts
+++ b/src/schema/v2/artwork/context.ts
@@ -36,7 +36,7 @@ const Context: GraphQLFieldConfig<any, ResolverContext> = {
   resolve: (
     { id, sale_ids },
     _options,
-    { salesLoader, relatedFairsLoader, relatedShowsLoader }
+    { salesLoader, relatedFairsLoader, showsLoader }
   ) => {
     let sale_promise
     if (sale_ids && sale_ids.length > 0) {
@@ -58,13 +58,11 @@ const Context: GraphQLFieldConfig<any, ResolverContext> = {
         return assign({ context_type: "Fair" }, fair)
       })
 
-    const show_promise = relatedShowsLoader({
-      artwork: [id],
+    const show_promise = showsLoader({
+      artwork: id,
       size: 1,
-      active: false,
       at_a_fair: false,
     })
-      .then(({ body }) => body)
       .then(first)
       .then((show) => {
         if (!show) return null


### PR DESCRIPTION
This updates two places that we were using the ES-backed `/related/shows` endpoint to fulfill queries that can be fulfilled by the regular database-backed `/shows` endpoint.

Should only be merged after https://github.com/artsy/gravity/pull/18382 is in production.