### PR TITLE
feat: short-circuit shows call for an artwork if no show_ids

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -5129,6 +5129,7 @@ describe("Artwork type", () => {
       describe("runningShow", () => {
         it("returns the show or fair if the artwork id is in a running show or fair", async () => {
           artwork.purchasable = true
+          artwork.show_ids = ["show-id"]
           context.showsLoader.mockResolvedValue([
             {
               name: "Test Show",

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -185,12 +185,12 @@ export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
         type: Show.type,
         description:
           "Most recent running Show or Fair booth the artwork is currently in, sorted by relevance",
-        resolve: async ({ show_ids, _id }, {}, ctx) => {
+        resolve: async ({ show_ids }, {}, ctx) => {
           if (!show_ids || show_ids.length === 0) {
             return null
           }
           const showOrFair = await await ctx.showsLoader({
-            artwork: _id,
+            id: show_ids,
             size: 1,
             status: "running",
             has_location: true,

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -185,9 +185,12 @@ export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
         type: Show.type,
         description:
           "Most recent running Show or Fair booth the artwork is currently in, sorted by relevance",
-        resolve: async (artwork, {}, ctx) => {
+        resolve: async ({ show_ids, _id }, {}, ctx) => {
+          if (!show_ids || show_ids.length === 0) {
+            return null
+          }
           const showOrFair = await await ctx.showsLoader({
-            artwork: artwork._id,
+            artwork: _id,
             size: 1,
             status: "running",
             has_location: true,

--- a/src/schema/v2/artwork/context.ts
+++ b/src/schema/v2/artwork/context.ts
@@ -61,7 +61,7 @@ const Context: GraphQLFieldConfig<any, ResolverContext> = {
     let showPromise
     if (show_ids && show_ids.length > 0) {
       showPromise = showsLoader({
-        artwork: id,
+        id: show_ids,
         size: 1,
         at_a_fair: false,
       })

--- a/src/schema/v2/artwork/context.ts
+++ b/src/schema/v2/artwork/context.ts
@@ -34,7 +34,7 @@ const Context: GraphQLFieldConfig<any, ResolverContext> = {
   type: ArtworkContextType,
   description: "Returns the associated Fair/Sale/Show",
   resolve: (
-    { id, sale_ids },
+    { id, sale_ids, show_ids },
     _options,
     { salesLoader, relatedFairsLoader, showsLoader }
   ) => {
@@ -58,21 +58,24 @@ const Context: GraphQLFieldConfig<any, ResolverContext> = {
         return assign({ context_type: "Fair" }, fair)
       })
 
-    const show_promise = showsLoader({
-      artwork: id,
-      size: 1,
-      at_a_fair: false,
-    })
-      .then(first)
-      .then((show) => {
-        if (!show) return null
-        return assign({ context_type: "Show" }, show)
+    let showPromise
+    if (show_ids && show_ids.length > 0) {
+      showPromise = showsLoader({
+        artwork: id,
+        size: 1,
+        at_a_fair: false,
       })
+        .then(first)
+        .then((show) => {
+          if (!show) return null
+          return assign({ context_type: "Show" }, show)
+        })
+    }
 
     return Promise.all([
       sale_promise || Promise.resolve(null),
       fair_promise,
-      show_promise,
+      showPromise || Promise.resolve(null),
     ]).then(choose)
   },
 }


### PR DESCRIPTION
Not for merging yet.

This shows the two invocations of `showsLoader` on the artwork page being able to short-circuit if the artwork doesn't contain any denormalized `show_ids` in the first place.

Should only be merged after https://github.com/artsy/gravity/pull/18384 is fully deployed.