### PR TITLE
feat(DIA-1014): infinite discovery home view section

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "string-width": "4.2.3"
   },
   "dependencies": {
-    "@artsy/cohesion": "^4.213.0",
+    "@artsy/cohesion": "^4.219.0",
     "@artsy/img": "1.0.3",
     "@artsy/morgan": "^1.0.2",
     "@artsy/multienv": "^1.2.0",

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -11,6 +11,7 @@ const { UNLEASH_API, UNLEASH_APP_NAME, UNLEASH_SERVER_KEY } = config
 const FEATURE_FLAGS_LIST = [
   "diamond_blurhash-enabled-globally",
   "onyx_enable-home-view-section-featured-fairs",
+  "diamond_home-view-infinite-discovery",
   "diamond_home-view-marketing-collection-categories",
   "onyx_experiment_home_view_test",
 ] as const

--- a/src/schema/v2/homeView/sections/InfiniteDiscovery.ts
+++ b/src/schema/v2/homeView/sections/InfiniteDiscovery.ts
@@ -1,9 +1,27 @@
+import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { HomeViewSection } from "."
+import { withHomeViewTimeout } from "../helpers/withHomeViewTimeout"
+import { HomeViewCard } from "../sectionTypes/Card"
 import { HomeViewSectionTypeNames } from "../sectionTypes/names"
 
 export const InfiniteDiscovery: HomeViewSection = {
-  id: "home-view-section-infinite-discovery",
+  contextModule: ContextModule.infiniteDiscoveryBanner,
   featureFlag: "diamond_home-view-infinite-discovery",
-  type: HomeViewSectionTypeNames.HomeViewSectionCard,
+  id: "home-view-section-infinite-discovery",
   requiresAuthentication: true,
+  ownerType: OwnerType.infiniteDiscovery,
+  type: HomeViewSectionTypeNames.HomeViewSectionCard,
+
+  resolver: withHomeViewTimeout(async (parent, _args, _context, _info) => {
+    const card: HomeViewCard = {
+      title: "Discover art, tailored to you",
+      subtitle:
+        "Our new feature learns your unique tastes as you explore, delivering personalized recommendations effortlessly.",
+      buttonText: "Explore Art",
+      image_url: "https://files.artsy.net/images/infinite_discovery.png",
+      entityType: "Page",
+      entityID: parent.ownerType,
+    }
+    return card
+  }),
 }

--- a/src/schema/v2/homeView/sections/InfiniteDiscovery.ts
+++ b/src/schema/v2/homeView/sections/InfiniteDiscovery.ts
@@ -1,0 +1,9 @@
+import { HomeViewSection } from "."
+import { HomeViewSectionTypeNames } from "../sectionTypes/names"
+
+export const InfiniteDiscovery: HomeViewSection = {
+  id: "home-view-section-infinite-discovery",
+  featureFlag: "diamond_home-view-infinite-discovery",
+  type: HomeViewSectionTypeNames.HomeViewSectionCard,
+  requiresAuthentication: true,
+}

--- a/src/schema/v2/homeView/sections/__tests__/InfiniteDiscovery.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/InfiniteDiscovery.test.ts
@@ -1,0 +1,93 @@
+import { isFeatureFlagEnabled } from "lib/featureFlags"
+import gql from "lib/gql"
+import { runQuery } from "schema/v2/test/utils"
+
+jest.mock("lib/featureFlags", () => ({
+  isFeatureFlagEnabled: jest.fn(() => true),
+}))
+
+const mockIsFeatureFlagEnabled = isFeatureFlagEnabled as jest.Mock
+
+describe("InfiniteDiscovery", () => {
+  describe("when the feature flag is enabled", () => {
+    beforeEach(() => {
+      mockIsFeatureFlagEnabled.mockImplementation((flag: string) => {
+        if (flag === "diamond_home-view-infinite-discovery") {
+          return true
+        }
+      })
+    })
+
+    it("returns the section's metadata", async () => {
+      const query = gql`
+        {
+          homeView {
+            section(id: "home-view-section-infinite-discovery") {
+              __typename
+              internalID
+              contextModule
+              ownerType
+              component {
+                title
+                behaviors {
+                  viewAll {
+                    buttonText
+                    href
+                    ownerType
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const context = {
+        accessToken: "424242",
+      }
+
+      const { homeView } = await runQuery(query, context)
+
+      expect(homeView.section).toMatchInlineSnapshot(`
+        {
+          "__typename": "HomeViewSectionCard",
+          "component": null,
+          "contextModule": null,
+          "internalID": "home-view-section-infinite-discovery",
+          "ownerType": null,
+        }
+      `)
+    })
+  })
+
+  describe("when the feature flag is disabled", () => {
+    beforeEach(() => {
+      mockIsFeatureFlagEnabled.mockImplementation((flag: string) => {
+        if (flag === "diamond_home-view-infinite-discovery") {
+          return false
+        }
+      })
+    })
+
+    it("throws an error when accessed by id", async () => {
+      const query = gql`
+        {
+          homeView {
+            section(id: "home-view-section-infinite-discovery") {
+              __typename
+              internalID
+            }
+          }
+        }
+      `
+
+      const context = {
+        accessToken: "424242",
+      }
+
+      await expect(runQuery(query, context)).rejects.toThrow(
+        "Section is not displayable"
+      )
+    })
+  })
+})

--- a/src/schema/v2/homeView/sections/__tests__/InfiniteDiscovery.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/InfiniteDiscovery.test.ts
@@ -52,9 +52,53 @@ describe("InfiniteDiscovery", () => {
         {
           "__typename": "HomeViewSectionCard",
           "component": null,
-          "contextModule": null,
+          "contextModule": "infiniteDiscoveryBanner",
           "internalID": "home-view-section-infinite-discovery",
-          "ownerType": null,
+          "ownerType": "infiniteDiscovery",
+        }
+      `)
+    })
+
+    it("returns the section's card data", async () => {
+      const query = gql`
+        {
+          homeView {
+            section(id: "home-view-section-infinite-discovery") {
+              ... on HomeViewSectionCard {
+                card {
+                  title
+                  subtitle
+                  href
+                  image {
+                    imageURL
+                  }
+                  entityType
+                  entityID
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const context = {
+        accessToken: "424242",
+      }
+
+      const { homeView } = await runQuery(query, context)
+
+      expect(homeView.section).toMatchInlineSnapshot(`
+        {
+          "card": {
+            "entityID": "infiniteDiscovery",
+            "entityType": "Page",
+            "href": null,
+            "image": {
+              "imageURL": "https://files.artsy.net/images/infinite_discovery.png",
+            },
+            "subtitle": "Our new feature learns your unique tastes as you explore, delivering personalized recommendations effortlessly.",
+            "title": "Discover art, tailored to you",
+          },
         }
       `)
     })

--- a/src/schema/v2/homeView/sections/index.ts
+++ b/src/schema/v2/homeView/sections/index.ts
@@ -27,6 +27,7 @@ import { SimilarToRecentlyViewedArtworks } from "./SimilarToRecentlyViewedArtwor
 import { Tasks } from "./Tasks"
 import { TrendingArtists } from "./TrendingArtists"
 import { ViewingRooms } from "./ViewingRooms"
+import { InfiniteDiscovery } from "./InfiniteDiscovery"
 
 type MaybeResolved<T> =
   | T
@@ -60,6 +61,7 @@ const sections: HomeViewSection[] = [
   FeaturedFairs,
   GalleriesNearYou,
   HeroUnits,
+  InfiniteDiscovery,
   LatestActivity,
   LatestArticles,
   LatestAuctionResults,

--- a/src/schema/v2/homeView/zones/__tests__/default.test.ts
+++ b/src/schema/v2/homeView/zones/__tests__/default.test.ts
@@ -27,6 +27,7 @@ describe("getSections", () => {
           "home-view-section-discover-something-new",
           "home-view-section-recommended-artworks",
           "home-view-section-curators-picks-emerging",
+          "home-view-section-infinite-discovery",
           "home-view-section-explore-by-category",
           "home-view-section-hero-units",
           "home-view-section-active-bids",

--- a/src/schema/v2/homeView/zones/default.ts
+++ b/src/schema/v2/homeView/zones/default.ts
@@ -24,6 +24,7 @@ import { SimilarToRecentlyViewedArtworks } from "../sections/SimilarToRecentlyVi
 import { Tasks } from "../sections/Tasks"
 import { TrendingArtists } from "../sections/TrendingArtists"
 import { ViewingRooms } from "../sections/ViewingRooms"
+import { InfiniteDiscovery } from "../sections/InfiniteDiscovery"
 
 const SECTIONS: HomeViewSection[] = [
   Tasks,
@@ -33,6 +34,7 @@ const SECTIONS: HomeViewSection[] = [
   DiscoverSomethingNew,
   RecommendedArtworks,
   CuratorsPicksEmerging,
+  InfiniteDiscovery,
   ExploreByCategory,
   HeroUnits,
   ActiveBids,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,10 +10,10 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@artsy/cohesion@^4.213.0":
-  version "4.213.0"
-  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-4.213.0.tgz#c935e8f51e852937ae08984df5abb2fd3d741480"
-  integrity sha512-Q+JOcGVUrprwukUdTYNlJ2Am/Dj4iiq8vy6R7GDUj9jUZbj4OFFiVzBGeBXR8+dT7dn4DIwd9NUW6drnGnnmJA==
+"@artsy/cohesion@^4.219.0":
+  version "4.219.0"
+  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-4.219.0.tgz#331cdd7ea0b0f76754cac65c17ac8c0a145d1392"
+  integrity sha512-KzDpewJfnuZ+WoGqlVlFcE307yALyWtzdtw58QjCW1JAZZOGUi4inEf4zpVsqcmeARJCzVHvqySej+ZBkbtkjg==
   dependencies:
     core-js "3"
 


### PR DESCRIPTION
This PR adds a new home view section for [Infinite Discovery](https://www.figma.com/design/BzXubI34mJlLU9CmmYip0p/Infinite-Discovery?node-id=917-27991&t=BJwsDAs7piAAOw6G-4) so that Diamond can start building it.

![card](https://github.com/user-attachments/assets/1c11b6f4-9d8f-4a7f-999b-145bfad6545e)
