### PR TITLE
fix: fix broken analytics.rankedStats query for unstitched viewing rooms

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:lib": "babel src --copy-files --extensions '.ts,.js' --ignore src/test,src/integration,src/**/__tests__ -s inline -d build/src",
     "build:remote-schemas": "cp src/data/*.graphql build/src/data/",
     "build": "yarn build:lib && yarn build:index && yarn build:fixtures && yarn build:remote-schemas",
-    "ci": "yarn test",
+    "ci": "USE_UNSTITCHED_VIEWING_ROOM_SCHEMA=true yarn test",
     "deploy-cloudflare-workers:staging": "yarn wrangler deploy --keep-vars --config=workers/caching/metaphysics-cdn.toml --env staging",
     "deploy-cloudflare-workers": "yarn wrangler deploy --keep-vars --config=workers/caching/metaphysics-cdn.toml --env production",
     "dev": "DEBUG=info,warn,error babel-node --extensions '.ts,.js' --inspect index.js",

--- a/src/lib/stitching/vortex/v2/stitching.ts
+++ b/src/lib/stitching/vortex/v2/stitching.ts
@@ -3,6 +3,7 @@ import { amount } from "schema/v2/fields/money"
 import { GraphQLSchema } from "graphql/type/schema"
 import gql from "lib/gql"
 import { sortBy } from "lodash"
+import config from "config"
 
 const vortexSchema = executableVortexSchema({ removeRootFields: false })
 
@@ -337,8 +338,12 @@ export const vortexStitchingEnvironment = (
             typenameWithoutPrefix.charAt(0).toLowerCase() +
             typenameWithoutPrefix.slice(1)
           const id = parent.rankedEntity.entityId
-          const schema =
-            fieldName == "viewingRoom" ? gravitySchema : localSchema
+          let schema = localSchema
+
+          // don't fallback to gravitySchema when USE_UNSTITCHED_VIEWING_ROOM_SCHEMA is true
+          if (!config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA) {
+            schema = fieldName == "viewingRoom" ? gravitySchema : localSchema
+          }
 
           return info.mergeInfo
             .delegateToSchema({


### PR DESCRIPTION
Fixes [this exception](https://app.datadoghq.com/error-tracking/issue/df966ba4-b190-11ef-8b7e-da7ad0900002?query=env%3Aproduction%20service%3Ametaphysics.graphql&fromUser=false&refresh_mode=sliding&from_ts=1733241390337&to_ts=1733327789945&live=true) (happens only when viewing room unstitching flag is enabled).

The reason is that vortex stitching code fallbacks to gravity schema for such requests:

```graphql
{
  partner(id: "xxx") {
    analytics {
      rankedStats(objectType: VIEWING_ROOM, period: FOUR_WEEKS, first: 15) {
        edges {
          node {
            value

            entity {
              ... on ViewingRoom {
                title
              }
            }
          }
        }
      }
    }
  }
}
```

Now there is no need for such fallback - `viewingRoom` type is supported natively in metaphysics