### PR TITLE
feat: adding digital art to artworkMediums for artwork grid filtering 

### DIFF
--- a/src/lib/artworkMediums.ts
+++ b/src/lib/artworkMediums.ts
@@ -25,6 +25,16 @@ const artworkCategories = {
     mediumFilterGeneSlug: "design",
     internalID: "4ddbbd3c4027ac0001001962",
   },
+  "Digital Art": {
+    id: "Digital Art",
+    long_description: [
+      "A general category for works created using digital technology.",
+      "whether in the form of tangible hardware, such as computer monitors or electronics, or software, such as graphics editors, websites, and programming languages.",
+    ].join(" "),
+    name: "Digital Art",
+    mediumFilterGeneSlug: "digital-art",
+    internalID: "5577512c7261690a6500046f",
+  },
   "Drawing, Collage or other Work on Paper": {
     id: "Drawing, Collage or other Work on Paper",
     long_description: [

--- a/src/schema/v2/__tests__/artworkMediums.test.ts
+++ b/src/schema/v2/__tests__/artworkMediums.test.ts
@@ -46,7 +46,7 @@ describe("ArtworkMediums type", () => {
 
     const result = await runQuery(query, context)
 
-    expect(context.geneLoader).toHaveBeenCalledTimes(19)
+    expect(context.geneLoader).toHaveBeenCalledTimes(20)
 
     expect(result.artworkMediums[0].filterGene).toEqual({
       slug: "architecture-1",


### PR DESCRIPTION
This PR is associated with [AMBER-1121] 

This change includes 'digital art' to artworkMediums, allowing it (and therefore its corresponding gene) to be filtered in artwork grids and alert setting functionality. 




[AMBER-1121]: https://artsyproduct.atlassian.net/browse/AMBER-1121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ