### PR TITLE
feat(job): exposes department name field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12187,6 +12187,7 @@ scalar JSON
 type Job {
   # HTML of job listing
   content: String!
+  departmentName: String!
 
   # The url of the job listing on Greenhouse
   externalURL: String!

--- a/src/schema/v2/jobs.ts
+++ b/src/schema/v2/jobs.ts
@@ -20,6 +20,7 @@ interface Job {
   updated_at: string
   requisition_id: null | string
   title: string
+  departments: { name: string }[]
 }
 
 export const jobType = new GraphQLObjectType<Job, ResolverContext>({
@@ -54,6 +55,15 @@ export const jobType = new GraphQLObjectType<Job, ResolverContext>({
     },
     title: {
       type: new GraphQLNonNull(GraphQLString),
+    },
+    departmentName: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ departments }) => {
+        return departments
+          .map((department) => department.name)
+          .join(", ")
+          .replace(/\s\d.+/, "")
+      },
     },
   },
 })


### PR DESCRIPTION
This change supports transitioning to the Ashby API for our job service. While Ashby doesn't provide direct department-based job querying, we do receive department names with each job record. Instead of introducing breaking changes by creating new job types and fields, I'm opting to handle the department grouping on the frontend rather than in Metaphysics. This approach lets us push the API integration and deprecate the jobs field on department type without introducing breaking changes to the schema.

I'll follow this up with a Force PR to switch over the grouping and then another Metaphysics PR which then replaces the API out from under it.