### PR TITLE
fix: guard agaunst unpublished sales in formattedEndDateTime

### DIFF
--- a/src/schema/v2/sale_artwork.ts
+++ b/src/schema/v2/sale_artwork.ts
@@ -173,17 +173,19 @@ export const SaleArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLString,
         description: "A formatted description of the lot end date and time",
         resolve: (saleArtwork, _options, { defaultTimezone, saleLoader }) =>
-          saleLoader(saleArtwork.sale_id).then((sale) => {
-            if (
-              !sale.cascading_end_time_interval_minutes ||
-              saleArtwork.ended_at ||
-              !saleArtwork.end_at
-            ) {
-              return null
-            } else {
-              return formattedEndDateTime(saleArtwork.end_at, defaultTimezone)
-            }
-          }),
+          saleLoader(saleArtwork.sale_id)
+            .then((sale) => {
+              if (
+                !sale.cascading_end_time_interval_minutes ||
+                saleArtwork.ended_at ||
+                !saleArtwork.end_at
+              ) {
+                return null
+              } else {
+                return formattedEndDateTime(saleArtwork.end_at, defaultTimezone)
+              }
+            })
+            .catch(() => null),
       },
       highEstimate: money({
         name: "SaleArtworkHighEstimate",


### PR DESCRIPTION
Looks like when sales are unpublished, this field (which is being requested as part of auction artworks in our standard artwork component in Force)- causes an exception which bubbles up in `errors`.

The front-end is defensive enough for this component-wise, _but_ it looks like prefetching doesn't 'commit' to the store if there's an error.

I think there might have been a bunch of old sales unpublished recently (?) - so we're noticing prefetch not working in some contexts.

Let's see if this helps out.