### PR TITLE
chore(debugging home view): chatty logs for home view sections

### DIFF
--- a/src/lib/semanticVersioning.ts
+++ b/src/lib/semanticVersioning.ts
@@ -7,16 +7,29 @@ export type SemanticVersionNumber = {
 export function getEigenVersionNumber(
   userAgent: string
 ): SemanticVersionNumber | null {
+  console.log(
+    "[INFINITE_DISCO] getEigenVersionNumber",
+    JSON.stringify({ userAgent })
+  )
+
   if (!userAgent) return null
   if (!userAgent.includes("Artsy-Mobile")) return null
 
   const parts = userAgent.split("/")
   const version = parts.at(-1)
+  console.log(
+    "[INFINITE_DISCO] getEigenVersionNumber",
+    JSON.stringify({ version })
+  )
 
   if (!version) return null
 
   const [major, minor, patch] = version.split(".").map(Number)
 
+  console.log(
+    "[INFINITE_DISCO] getEigenVersionNumber",
+    JSON.stringify({ major, minor, patch })
+  )
   return { major, minor, patch }
 }
 
@@ -24,6 +37,14 @@ export function isAtLeastVersion(
   version: SemanticVersionNumber,
   atLeast: SemanticVersionNumber
 ): boolean {
+  console.log(
+    "[INFINITE_DISCO] isAtLeastVersion",
+    JSON.stringify({
+      version,
+      atLeast,
+    })
+  )
+
   const { major, minor, patch } = atLeast
 
   if (version.major > major) return true

--- a/src/schema/v2/homeView/helpers/isSectionDisplayable.ts
+++ b/src/schema/v2/homeView/helpers/isSectionDisplayable.ts
@@ -28,23 +28,59 @@ export function isSectionDisplayable(
     })
   }
 
+  console.log(
+    "[INFINITE_DISCO] before check",
+    JSON.stringify({
+      id: section.id,
+      isDisplayable,
+      sectionMinimumEigenVersion: section.minimumEigenVersion,
+    })
+  )
   // minimum Eigen version
   if (isDisplayable && section.minimumEigenVersion) {
     const actualEigenVersion = getEigenVersionNumber(
       context.userAgent as string
     )
+    console.log(
+      "[INFINITE_DISCO] checking",
+      JSON.stringify({
+        actualEigenVersion,
+        contextUserAgent: context.userAgent,
+      })
+    )
+
     if (actualEigenVersion) {
+      console.log(
+        "[INFINITE_DISCO] isAtLeast?",
+        isAtLeastVersion(actualEigenVersion, section.minimumEigenVersion)
+      )
       isDisplayable = isAtLeastVersion(
         actualEigenVersion,
         section.minimumEigenVersion
       )
     }
   }
+  console.log(
+    "[INFINITE_DISCO] after check",
+    JSON.stringify({
+      id: section.id,
+      isDisplayable,
+      sectionMinimumEigenVersion: section.minimumEigenVersion,
+    })
+  )
 
   // section's display pre-check
   if (typeof section.shouldBeDisplayed === "function") {
     isDisplayable = isDisplayable && section?.shouldBeDisplayed(context)
   }
+
+  console.log(
+    "[INFINITE_DISCO] finally",
+    JSON.stringify({
+      id: section.id,
+      isDisplayable,
+    })
+  )
 
   return isDisplayable
 }


### PR DESCRIPTION
Temporarily adding some verbose logging (along with a deploy block) to debug user agent issues with infinite disco 