### PR TITLE
fix(home view): relax auth requirement for infinite discovery card

### DIFF
--- a/src/schema/v2/homeView/helpers/isSectionDisplayable.ts
+++ b/src/schema/v2/homeView/helpers/isSectionDisplayable.ts
@@ -21,6 +21,17 @@ export function isSectionDisplayable(
 
   let isDisplayable = isPublicSection || isValidPersonalizedSection
 
+  section.id === "home-view-section-infinite-discovery" &&
+    console.log(
+      "[INFINITE_DISCO] even before check",
+      JSON.stringify({
+        isPublicSection,
+        isAuthenticatedUser,
+        requiresAuthentication: section.requiresAuthentication,
+        isDisplayable,
+      })
+    )
+
   // feature flags
   if (isDisplayable && section.featureFlag) {
     isDisplayable = isFeatureFlagEnabled(section.featureFlag, {

--- a/src/schema/v2/homeView/sections/InfiniteDiscovery.ts
+++ b/src/schema/v2/homeView/sections/InfiniteDiscovery.ts
@@ -8,7 +8,7 @@ export const InfiniteDiscovery: HomeViewSection = {
   contextModule: ContextModule.infiniteDiscoveryBanner,
   featureFlag: "diamond_home-view-infinite-discovery",
   id: "home-view-section-infinite-discovery",
-  requiresAuthentication: true,
+  requiresAuthentication: false,
   // TODO: update this to match the first release that can support Infinite Discovery
   minimumEigenVersion: { major: 8, minor: 59, patch: 0 },
   ownerType: OwnerType.infiniteDiscovery,

--- a/src/schema/v2/homeView/zones/__tests__/default.test.ts
+++ b/src/schema/v2/homeView/zones/__tests__/default.test.ts
@@ -62,6 +62,7 @@ describe("getSections", () => {
         [
           "home-view-section-discover-something-new",
           "home-view-section-curators-picks-emerging",
+          "home-view-section-infinite-discovery",
           "home-view-section-explore-by-category",
           "home-view-section-hero-units",
           "home-view-section-auctions",


### PR DESCRIPTION
Testing a theory whereby `@cacheable` directive inteferes with a section that specifies `requiresAuthentication: true`