### PR TITLE
chore: revert disco debugging logs

### DIFF
--- a/src/lib/semanticVersioning.ts
+++ b/src/lib/semanticVersioning.ts
@@ -7,29 +7,16 @@ export type SemanticVersionNumber = {
 export function getEigenVersionNumber(
   userAgent: string
 ): SemanticVersionNumber | null {
-  console.log(
-    "[INFINITE_DISCO] getEigenVersionNumber",
-    JSON.stringify({ userAgent })
-  )
-
   if (!userAgent) return null
   if (!userAgent.includes("Artsy-Mobile")) return null
 
   const parts = userAgent.split("/")
   const version = parts.at(-1)
-  console.log(
-    "[INFINITE_DISCO] getEigenVersionNumber",
-    JSON.stringify({ version })
-  )
 
   if (!version) return null
 
   const [major, minor, patch] = version.split(".").map(Number)
 
-  console.log(
-    "[INFINITE_DISCO] getEigenVersionNumber",
-    JSON.stringify({ major, minor, patch })
-  )
   return { major, minor, patch }
 }
 
@@ -37,14 +24,6 @@ export function isAtLeastVersion(
   version: SemanticVersionNumber,
   atLeast: SemanticVersionNumber
 ): boolean {
-  console.log(
-    "[INFINITE_DISCO] isAtLeastVersion",
-    JSON.stringify({
-      version,
-      atLeast,
-    })
-  )
-
   const { major, minor, patch } = atLeast
 
   if (version.major > major) return true

--- a/src/schema/v2/homeView/helpers/isSectionDisplayable.ts
+++ b/src/schema/v2/homeView/helpers/isSectionDisplayable.ts
@@ -21,17 +21,6 @@ export function isSectionDisplayable(
 
   let isDisplayable = isPublicSection || isValidPersonalizedSection
 
-  section.id === "home-view-section-infinite-discovery" &&
-    console.log(
-      "[INFINITE_DISCO] even before check",
-      JSON.stringify({
-        isPublicSection,
-        isAuthenticatedUser,
-        requiresAuthentication: section.requiresAuthentication,
-        isDisplayable,
-      })
-    )
-
   // feature flags
   if (isDisplayable && section.featureFlag) {
     isDisplayable = isFeatureFlagEnabled(section.featureFlag, {
@@ -39,68 +28,23 @@ export function isSectionDisplayable(
     })
   }
 
-  section.id === "home-view-section-infinite-discovery" &&
-    console.log(
-      "[INFINITE_DISCO] before check",
-      JSON.stringify({
-        id: section.id,
-        isDisplayable,
-        sectionMinimumEigenVersion: section.minimumEigenVersion,
-        userId: context.userID,
-      })
-    )
   // minimum Eigen version
   if (isDisplayable && section.minimumEigenVersion) {
     const actualEigenVersion = getEigenVersionNumber(
       context.userAgent as string
     )
-    section.id === "home-view-section-infinite-discovery" &&
-      console.log(
-        "[INFINITE_DISCO] checking",
-        JSON.stringify({
-          actualEigenVersion,
-          contextUserAgent: context.userAgent,
-          userId: context.userID,
-        })
-      )
-
     if (actualEigenVersion) {
-      section.id === "home-view-section-infinite-discovery" &&
-        console.log(
-          "[INFINITE_DISCO] isAtLeast?",
-          isAtLeastVersion(actualEigenVersion, section.minimumEigenVersion)
-        )
       isDisplayable = isAtLeastVersion(
         actualEigenVersion,
         section.minimumEigenVersion
       )
     }
   }
-  section.id === "home-view-section-infinite-discovery" &&
-    console.log(
-      "[INFINITE_DISCO] after check",
-      JSON.stringify({
-        id: section.id,
-        isDisplayable,
-        sectionMinimumEigenVersion: section.minimumEigenVersion,
-        userId: context.userID,
-      })
-    )
 
   // section's display pre-check
   if (typeof section.shouldBeDisplayed === "function") {
     isDisplayable = isDisplayable && section?.shouldBeDisplayed(context)
   }
-
-  section.id === "home-view-section-infinite-discovery" &&
-    console.log(
-      "[INFINITE_DISCO] finally",
-      JSON.stringify({
-        id: section.id,
-        isDisplayable,
-        userId: context.userID,
-      })
-    )
 
   return isDisplayable
 }


### PR DESCRIPTION
Removes the debug output from #6309, #6310, #6311 — after this hits staging we can remove the current deploy block.