### PR TITLE
fix: add the constant values for args

### DIFF
--- a/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
+++ b/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
@@ -86,7 +86,7 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
     } = args
 
     if (useOpenSearch) {
-      const { excludeArtworkIds, likedArtworkIds } = args
+      const { excludeArtworkIds = [], likedArtworkIds = [] } = args
 
       let result = []
 


### PR DESCRIPTION
This PR adds constant values for args to avoid issues when there are no expected args.

![Screenshot 2024-12-16 at 9 49 29 AM](https://github.com/user-attachments/assets/9e86bd91-fc47-447f-bae6-7eaba37e7d58)

✅ Added the `OPENSEARCH_API_BASE` and `OPENSEARCH_ARTWORKS_INFINITE_DISCOVERY_INDEX` env variablwes to staging.
