### PR TITLE
fix: bring back unstitched viewingRooms query

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17609,17 +17609,10 @@ type Query {
 
   # (Deprecate) use viewingRoomsConnection
   viewingRooms(
-    # Returns the elements in the list that come after the specified cursor.
     after: String
-
-    # Returns the elements in the list that come before the specified cursor.
     before: String
     featured: Boolean
-
-    # Returns the first _n_ elements from the list.
     first: Int
-
-    # Returns the last _n_ elements from the list.
     last: Int
     partnerID: ID
 
@@ -22172,6 +22165,22 @@ type Viewer {
 
   # Find a viewing room by ID
   viewingRoom(id: ID!): ViewingRoom
+
+  # (Deprecate) use viewingRoomsConnection
+  viewingRooms(
+    after: String
+    before: String
+    featured: Boolean
+    first: Int
+    last: Int
+    partnerID: ID
+
+    # (Deprecated) Use statuses
+    published: Boolean
+
+    # Returns only viewing rooms with these statuses
+    statuses: [ViewingRoomStatusEnum!] = [live]
+  ): ViewingRoomConnection @deprecated(reason: "Use viewingRoomsConnection")
   viewingRoomsConnection(
     after: String
     before: String
@@ -22273,22 +22282,24 @@ input ViewingRoomAttributes {
   title: String
 }
 
-# The connection type for ViewingRoom.
+# A connection to a list of items.
 type ViewingRoomConnection {
   # A list of edges.
   edges: [ViewingRoomEdge]
+  pageCursors: PageCursors!
 
   # Information to aid in pagination.
   pageInfo: PageInfo!
-
-  # Total count of matching nodes, before pagination
-  totalCount: Int!
+  totalCount: Int
 }
 
 # An edge in a connection.
 type ViewingRoomEdge {
-  # A cursor for use in pagination.
+  # A cursor for use in pagination
   cursor: String!
+
+  # The item at the end of the edge
+  node: ViewingRoom
 }
 
 union ViewingRoomOrErrorsUnion = Errors | ViewingRoom

--- a/src/lib/stitching/gravity/schema.ts
+++ b/src/lib/stitching/gravity/schema.ts
@@ -12,7 +12,7 @@ import config from "config"
 
 const rootFieldsAllowList = ["agreement"].concat(
   config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA
-    ? ["viewingRooms"]
+    ? []
     : ["viewingRoom", "viewingRooms", "viewingRoomsConnection"]
 )
 
@@ -53,8 +53,11 @@ export const executableGravitySchema = () => {
   if (config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA) {
     duplicatedTypes.push("ViewingRoom")
     duplicatedTypes.push("ViewingRoomsConnection")
+    duplicatedTypes.push("ViewingRoomConnection")
     duplicatedTypes.push("ViewingRoomsEdge")
     duplicatedTypes.push("ViewingRoomsEdge")
+    duplicatedTypes.push("ViewingRoomEdge")
+    duplicatedTypes.push("ViewingRoomEdge")
 
     duplicatedTypes.push("CreateViewingRoomPayload")
     duplicatedTypes.push("CreateViewingRoomInput")

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -267,11 +267,13 @@ import { publishViewingRoomMutation } from "./viewingRooms/mutations/publishView
 import { unpublishViewingRoomMutation } from "./viewingRooms/mutations/unpublishViewingRoomMutation"
 import { updateViewingRoomArtworksMutation } from "./viewingRooms/mutations/updateViewingRoomArtworks"
 import { updateViewingRoomSubsectionsMutation } from "./viewingRooms/mutations/updateViewingRoomSubsections"
+import { ViewingRoomConnection } from "./viewingRooms"
 
 const viewingRoomUnstitchedRootField = config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA
   ? {
       viewingRoom: ViewingRoom,
       viewingRoomsConnection: ViewingRoomsConnection,
+      viewingRooms: ViewingRoomConnection,
     }
   : ({} as any)
 

--- a/src/schema/v2/viewingRooms.ts
+++ b/src/schema/v2/viewingRooms.ts
@@ -1,0 +1,78 @@
+import {
+  GraphQLBoolean,
+  GraphQLFieldConfig,
+  GraphQLID,
+  GraphQLList,
+  GraphQLNonNull,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import {
+  connectionWithCursorInfo,
+  paginationResolver,
+} from "./fields/pagination"
+import { ViewingRoomType } from "./viewingRoom"
+import { pageable } from "relay-cursor-paging"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { ViewingRoomStatusEnum } from "./viewingRoomConnection"
+
+const ViewingRoomConnectionType = connectionWithCursorInfo({
+  name: "ViewingRoom",
+  nodeType: ViewingRoomType,
+})
+
+export const ViewingRoomConnection: GraphQLFieldConfig<
+  void,
+  ResolverContext
+> = {
+  type: ViewingRoomConnectionType.connectionType,
+  description: "(Deprecate) use viewingRoomsConnection",
+  deprecationReason: "Use viewingRoomsConnection",
+  args: pageable({
+    featured: {
+      type: GraphQLBoolean,
+    },
+    partnerID: {
+      type: GraphQLID,
+    },
+    published: {
+      type: GraphQLBoolean,
+      description: "(Deprecated) Use statuses",
+    },
+    statuses: {
+      type: new GraphQLList(new GraphQLNonNull(ViewingRoomStatusEnum)),
+      defaultValue: ["live"],
+      description: "Returns only viewing rooms with these statuses",
+    },
+  }),
+  resolve: async (_root, args, { viewingRoomsLoader }) => {
+    // TODO: Currently clients do not specify `first` and expect 20 viewing rooms in response.
+    //       This should be removed once clients are updated.
+    if (!args.first) {
+      args.first = 20
+    }
+
+    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+
+    const gravityArgs = {
+      partner_id: args.partnerID,
+      featured: args.featured,
+      statuses: args.statuses,
+      page,
+      size,
+      total_count: true,
+    }
+
+    const { body, headers } = await viewingRoomsLoader(gravityArgs)
+
+    const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+    return paginationResolver({
+      args,
+      body,
+      offset,
+      page,
+      size,
+      totalCount,
+    })
+  },
+}


### PR DESCRIPTION
When I've started viewing rooms unstitching, one weird thing I've noticed is that there are "duplicates" of connection definitions coming from Gravity: [ViewingRoomConnection](https://github.com/artsy/metaphysics/blob/9271468efc011386216fc146580306a3148f82d2/_schemaV2.graphql#L21822) and [ViewingRoomEdge](https://github.com/artsy/metaphysics/blob/9271468efc011386216fc146580306a3148f82d2/_schemaV2.graphql#L21837) vs [ViewingRoomsConnection](https://github.com/artsy/metaphysics/blob/9271468efc011386216fc146580306a3148f82d2/_schemaV2.graphql#L21905) and [ViewingRoomsEdge](https://github.com/artsy/metaphysics/blob/9271468efc011386216fc146580306a3148f82d2/_schemaV2.graphql#L21920) (last two are plural). First two come from [here](https://github.com/artsy/gravity/blob/7e77d2096fcf96167728eef950f3d846f4f69c95/app/graphql/types/query_type.rb#L93) and they are deprecated.

I wanted to simplify my life and instead of re-defining deprecated types on Metaphysics side - switch clients to use viewingRoomsConnection and kill old viewingRooms query. I did it [in Eigen](https://github.com/artsy/eigen/pull/10822) and [in Force](https://github.com/artsy/force/pull/14522). 

A few months have passed since then and I was hoping that old Eigen clients are dead already and nothing is using `viewingRooms` query, but apparently I was wrong. @MounirDhahri [reported](https://artsy.slack.com/archives/C02BAQ5K7/p1733500042065269?thread_ts=1733499946.584029&cid=C02BAQ5K7) that there are a bunch of errors caused by the missing field. 

That's why I am adding this field, which is marked as deprecated and shouldn't be used by any client, and should be removed as soon as nothing uses it.

Once this PR is on prod we should re-enable unstitching 