### PR TITLE
fix: improvements for discoverArtworks

### DIFF
--- a/src/lib/infiniteDiscovery/findSimilarArtworks.ts
+++ b/src/lib/infiniteDiscovery/findSimilarArtworks.ts
@@ -19,6 +19,9 @@ export const findSimilarArtworks = async (
   const knnQuery = {
     size: size,
     _source: ["_id"],
+    collapse: {
+      field: "artistName",
+    },
     query: {
       bool: {
         must_not: {

--- a/src/lib/infiniteDiscovery/getInitialArtworksSample.ts
+++ b/src/lib/infiniteDiscovery/getInitialArtworksSample.ts
@@ -1,21 +1,37 @@
 import { opensearch } from "lib/apis/opensearch"
 
-export const getInitialArtworksSample = async (limit, artworksLoader) => {
+export const getInitialArtworksSample = async (
+  limit,
+  excludeArtworkIds,
+  artworksLoader
+) => {
   // initial artworks sample comes from indexed curators picks, but
   // in future we plan to come up with a more sophisticated approach
+  const RANDOM_SEED = Math.floor(Math.random() * 1000)
+
   const curatorsPicks = await opensearch(`/curators_picks/_search`, undefined, {
     method: "POST",
     body: JSON.stringify({
       size: limit,
       query: {
         function_score: {
+          query: {
+            bool: {
+              must_not: {
+                terms: {
+                  _id: excludeArtworkIds,
+                },
+              },
+            },
+          },
           functions: [
             {
               random_score: {
-                seed: Math.floor(Math.random() * 1000),
+                seed: RANDOM_SEED,
               },
             },
           ],
+          boost_mode: "replace",
         },
       },
     }),

--- a/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
+++ b/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
@@ -91,7 +91,11 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
       let result = []
 
       if (likedArtworkIds.length < 3) {
-        result = await getInitialArtworksSample(limit, artworksLoader)
+        result = await getInitialArtworksSample(
+          limit,
+          excludeArtworkIds,
+          artworksLoader
+        )
       } else {
         const tasteProfileVector = await calculateMeanArtworksVector(
           likedArtworkIds


### PR DESCRIPTION
- prevent artworks appearing twice in initial taste builder
- add collapse to query to allow only unique artworks/artists