### PR TITLE
feat: add backfill for search results

### DIFF
--- a/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
+++ b/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
@@ -88,7 +88,7 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
     if (useOpenSearch) {
       const { excludeArtworkIds = [], likedArtworkIds = [] } = args
 
-      let result = []
+      let result: any = []
 
       if (likedArtworkIds.length < 3) {
         result = await getInitialArtworksSample(
@@ -105,10 +105,18 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
 
         result = await findSimilarArtworks(
           tasteProfileVector,
-          limit,
+          8,
           excludeArtworkIds,
           artworksLoader
         )
+
+        // backfill with random curated picks if we don't have enough similar artworks
+        const randomArtworks = await getInitialArtworksSample(
+          limit - result.length,
+          excludeArtworkIds,
+          artworksLoader
+        )
+        result.push(...randomArtworks)
       }
 
       return connectionFromArray(result, args)


### PR DESCRIPTION
This PR adds backfill functionality for cases when there are fewer than 8 artworks. The requirement is always to have: - 8 artworks, plus 2 random picks (currently limited to curated collection).