### PR TITLE
Revert "feat: add Access-Control-Expose-Header: Cf-Cache-Status to CDN worker"

### DIFF
--- a/workers/caching/metaphysics-cdn.ts
+++ b/workers/caching/metaphysics-cdn.ts
@@ -118,7 +118,6 @@ export default {
           response.headers.set("Cache-Control", `max-age=${maxAge}`)
           ctx.waitUntil(cache.put(cacheKey, response.clone()))
         }
-        response.headers.set("Access-Control-Expose-Headers", "Cf-Cache-Status")
         return response
       }
 


### PR DESCRIPTION
Reverts artsy/metaphysics#6307

This doesn't harm anything, but we don't need it (no longer have need of tracking this on the front-end after prefetching) and no code > any code.