### PR TITLE
feat: add improvements for discoverArtworks query

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16860,8 +16860,14 @@ type Query {
     # (Only for when useOpenSearch is true) These artworks are used to calculate the taste profile vector. Such artworks are excluded from the response
     likedArtworkIds: [String]
     limit: Int
+
+    # (Only for when useOpenSearch is true) These fields are used to calculate the More Like This query
+    mltFields: [String] = ["material", "categories", "tags", "medium"]
     offset: Int
     sort: DiscoverArtworksSort
+
+    # (Only for when useOpenSearch is true) Use the More Like This query with the kNN query
+    useMltQuery: Boolean = false
     useOpenSearch: Boolean = false
     userId: String
   ): ArtworkConnection
@@ -21508,8 +21514,14 @@ type Viewer {
     # (Only for when useOpenSearch is true) These artworks are used to calculate the taste profile vector. Such artworks are excluded from the response
     likedArtworkIds: [String]
     limit: Int
+
+    # (Only for when useOpenSearch is true) These fields are used to calculate the More Like This query
+    mltFields: [String] = ["material", "categories", "tags", "medium"]
     offset: Int
     sort: DiscoverArtworksSort
+
+    # (Only for when useOpenSearch is true) Use the More Like This query with the kNN query
+    useMltQuery: Boolean = false
     useOpenSearch: Boolean = false
     userId: String
   ): ArtworkConnection

--- a/src/lib/infiniteDiscovery/findSimilarArtworks.ts
+++ b/src/lib/infiniteDiscovery/findSimilarArtworks.ts
@@ -1,58 +1,79 @@
 import config from "config"
 import { opensearch } from "lib/apis/opensearch"
 
+interface FindSimilarArtworksOptions {
+  vectorEmbedding: number[]
+  size?: number
+  likedArtworkIds?: string[]
+  excludeArtworkIds?: string[]
+  fields?: string[]
+  useMltQuery?: boolean
+}
+
 /**
- * Perform kNN operation to find artworks similiar to vectorEmbedding
- * and then return the artworks loaded by artworksLoader
+ * Perform kNN operation to find artworks similar to a vector embedding
+ * and optionally use a More Like This (MLT) query.
  *
- * @param vectorEmbedding - vector embedding of the artwork
- * @param size - number of similar artworks to return
- * @param excludeArtworkIds - list of artwork ids to exclude from the response
- * @param artworksLoader - artworks loader
+ * @param options - Configuration options for the query
+ * @param artworksLoader - Function to load artworks
  */
 export const findSimilarArtworks = async (
-  vectorEmbedding: number[],
-  size = 10,
-  excludeArtworkIds: string[] = [],
-  artworksLoader
+  options: FindSimilarArtworksOptions,
+  artworksLoader: (params: { ids: string[] }) => Promise<any>
 ) => {
-  const knnQuery = {
-    size: size,
-    _source: ["_id"],
-    collapse: {
-      field: "artistName",
+  const {
+    vectorEmbedding,
+    size,
+    likedArtworkIds = [],
+    excludeArtworkIds = [],
+    fields = [],
+    useMltQuery,
+  } = options
+
+  const mltQuery = {
+    more_like_this: {
+      fields,
+      like: likedArtworkIds.map((id) => ({ _id: id })),
+      min_term_freq: 1,
+      min_doc_freq: 1,
     },
-    query: {
-      bool: {
-        must_not: {
-          terms: {
-            _id: excludeArtworkIds,
-          },
-        },
-        should: [
-          {
-            knn: {
-              vector_embedding: {
-                vector: vectorEmbedding,
-                k: size,
-              },
-            },
-          },
-        ],
+  }
+
+  const knnQuery = {
+    knn: {
+      vector_embedding: {
+        vector: vectorEmbedding,
+        k: size,
       },
     },
   }
 
-  const knnResponse = await opensearch(
+  // Combine MLT and k-NN queries into a `should` clause
+  const shouldQueries = useMltQuery ? [mltQuery, knnQuery] : [knnQuery]
+
+  const query = {
+    size,
+    _source: ["_id"],
+    collapse: { field: "artistName" },
+    query: {
+      bool: {
+        must_not: { terms: { _id: excludeArtworkIds } },
+        should: shouldQueries,
+      },
+    },
+  }
+
+  // Execute the query
+  const response = await opensearch(
     `/${config.OPENSEARCH_ARTWORKS_INFINITE_DISCOVERY_INDEX}/_search`,
     undefined,
     {
       method: "POST",
-      body: JSON.stringify(knnQuery),
+      body: JSON.stringify(query),
     }
   )
 
-  const artworkIds = knnResponse.hits?.hits?.map((hit) => hit._id) || []
-
-  return await artworksLoader({ ids: artworkIds })
+  // Extract and return artwork IDs
+  const artworkIds = response.hits?.hits?.map((hit) => hit._id) || []
+  return artworksLoader({ ids: artworkIds })
 }


### PR DESCRIPTION
This PR introduces two new parameters for discoverArtworks:

- **`useMltQuery`**  
  - When set to `true`, combines k-NN search (visual similarity) with the "More Like This" (MLT) content similarity search.  

- **`mltFields`**  
  - An array of fields that the MLT query will use to calculate similarity.  

**Visuals:**  

Example:

![image](https://github.com/user-attachments/assets/b2ede0f2-9b2e-41c2-96cf-4b5c4d6be43d)


**Before** - knn only search 

![Screenshot 2024-12-18 at 10 43 35 AM](https://github.com/user-attachments/assets/f26e7ee6-5508-467f-82e0-70ce256c8ff3)

**After** - mlt + knn search

![Screenshot 2024-12-18 at 10 36 19 AM](https://github.com/user-attachments/assets/aee155dd-92b1-4ad9-94ab-7b59575e087e)

