### PR TITLE
feat: use hybrid search for open search query

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16864,10 +16864,10 @@ type Query {
     # (Only for when useOpenSearch is true) These fields are used to calculate the More Like This query
     mltFields: [String] = ["material", "categories", "tags", "medium"]
     offset: Int
-    sort: DiscoverArtworksSort
 
-    # (Only for when useOpenSearch is true) Use the More Like This query with the kNN query
-    useMltQuery: Boolean = false
+    # (Only for when useOpenSearch is true) Weights for the OpenSearch query
+    osWeights: [Float] = [0.6, 0.4]
+    sort: DiscoverArtworksSort
     useOpenSearch: Boolean = false
     userId: String
   ): ArtworkConnection
@@ -21518,10 +21518,10 @@ type Viewer {
     # (Only for when useOpenSearch is true) These fields are used to calculate the More Like This query
     mltFields: [String] = ["material", "categories", "tags", "medium"]
     offset: Int
-    sort: DiscoverArtworksSort
 
-    # (Only for when useOpenSearch is true) Use the More Like This query with the kNN query
-    useMltQuery: Boolean = false
+    # (Only for when useOpenSearch is true) Weights for the OpenSearch query
+    osWeights: [Float] = [0.6, 0.4]
+    sort: DiscoverArtworksSort
     useOpenSearch: Boolean = false
     userId: String
   ): ArtworkConnection

--- a/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
+++ b/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
@@ -57,12 +57,6 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
       description:
         "(Only for when useOpenSearch is true) Exclude these artworks from the response",
     },
-    useMltQuery: {
-      type: GraphQLBoolean,
-      description:
-        "(Only for when useOpenSearch is true) Use the More Like This query with the kNN query",
-      defaultValue: false,
-    },
     mltFields: {
       type: new GraphQLList(GraphQLString),
       description:
@@ -73,6 +67,12 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
       type: new GraphQLList(GraphQLString),
       description:
         "(Only for when useOpenSearch is true) These artworks are used to calculate the taste profile vector. Such artworks are excluded from the response",
+    },
+    osWeights: {
+      type: new GraphQLList(GraphQLFloat),
+      description:
+        "(Only for when useOpenSearch is true) Weights for the OpenSearch query",
+      defaultValue: [0.6, 0.4],
     },
   }),
   resolve: async (
@@ -95,8 +95,8 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
       certainty = 0.5,
       sort,
       useOpenSearch,
-      useMltQuery,
       mltFields,
+      osWeights,
     } = args
 
     if (useOpenSearch) {
@@ -123,7 +123,7 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
           likedArtworkIds,
           excludeArtworkIds,
           fields: mltFields,
-          useMltQuery,
+          weights: osWeights,
         }
 
         result = await findSimilarArtworks(options, artworksLoader)


### PR DESCRIPTION
This PR enhances the OpenSearch query to include a hybrid search pipeline combining `more_like_this` and `knn` queries. Added normalization and combination processors for result scoring and a collapse response processor to filter out duplicated results by artistName.

