### PR TITLE
feat(dia-1038): infinite discovery - make initial arworks batch index configurable

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16812,6 +16812,9 @@ type Query {
     # (Only for when useOpenSearch is true) Exclude these artworks from the response
     excludeArtworkIds: [String]
     first: Int
+
+    # (Only for when useOpenSearch is true) Which index to use to display initial batch of artworks
+    initialArtworksIndexName: String = "infinite_discovery_initial_artworks"
     last: Int
 
     # (Only for when useOpenSearch is true) These artworks are used to calculate the taste profile vector. Such artworks are excluded from the response
@@ -21448,6 +21451,9 @@ type Viewer {
     # (Only for when useOpenSearch is true) Exclude these artworks from the response
     excludeArtworkIds: [String]
     first: Int
+
+    # (Only for when useOpenSearch is true) Which index to use to display initial batch of artworks
+    initialArtworksIndexName: String = "infinite_discovery_initial_artworks"
     last: Int
 
     # (Only for when useOpenSearch is true) These artworks are used to calculate the taste profile vector. Such artworks are excluded from the response

--- a/src/lib/infiniteDiscovery/getInitialArtworksSample.ts
+++ b/src/lib/infiniteDiscovery/getInitialArtworksSample.ts
@@ -3,13 +3,14 @@ import { opensearch } from "lib/apis/opensearch"
 export const getInitialArtworksSample = async (
   limit,
   excludeArtworkIds,
-  artworksLoader
+  artworksLoader,
+  indexName
 ) => {
   // initial artworks sample comes from indexed curators picks, but
   // in future we plan to come up with a more sophisticated approach
   const RANDOM_SEED = Math.floor(Math.random() * 1000)
 
-  const curatorsPicks = await opensearch(`/curators_picks/_search`, undefined, {
+  const curatorsPicks = await opensearch(`/${indexName}/_search`, undefined, {
     method: "POST",
     body: JSON.stringify({
       size: limit,

--- a/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
+++ b/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
@@ -45,13 +45,25 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
         "The number of curated artworks to return. This is a temporary field to support the transition to OpenSearch",
       defaultValue: 2,
     },
+    initialArtworksIndexName: {
+      type: GraphQLString,
+      description:
+        "(Only for when useOpenSearch is true) Which index to use to display initial batch of artworks",
+      defaultValue: "infinite_discovery_initial_artworks",
+    },
   }),
   resolve: async (_root, args, { artworksLoader }) => {
     if (!artworksLoader) {
       new Error("A loader is not available")
     }
 
-    const { limit = 10, mltFields, osWeights, curatedPicksSize } = args
+    const {
+      limit = 10,
+      mltFields,
+      osWeights,
+      curatedPicksSize,
+      initialArtworksIndexName,
+    } = args
 
     const { excludeArtworkIds = [], likedArtworkIds = [] } = args
 
@@ -61,7 +73,8 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
       result = await getInitialArtworksSample(
         limit,
         excludeArtworkIds,
-        artworksLoader
+        artworksLoader,
+        initialArtworksIndexName
       )
     } else {
       const tasteProfileVector = await calculateMeanArtworksVector(
@@ -88,7 +101,8 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
           ? curatedPicksSize
           : limit - result.length,
         excludeArtworkIds,
-        artworksLoader
+        artworksLoader,
+        initialArtworksIndexName
       )
       result.push(...randomArtworks)
     }


### PR DESCRIPTION
@egdbear let me know what you think. I suppose we may want to experiment with different initial artwork datasets in future, and I think it will be easy if `discoverArtworks` query field has an option to specify which artworks collection to use. For now, I've indexed Most Loved, Street Art, and New this Week marketing collections to the `infinite_discovery_initial_artworks` index (zenith PR to come).