### PR TITLE
feat: Add mutation to create canonical artist AMBER-1200

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8044,6 +8044,35 @@ type CreateBidderPayload {
   clientMutationId: String
 }
 
+type CreateCanonicalArtistFailure {
+  mutationError: GravityMutationError
+}
+
+input CreateCanonicalArtistMutationInput {
+  birthday: String
+  clientMutationId: String
+  deathday: String
+  displayName: String
+  firstName: String
+  lastName: String
+  middleName: String
+  nationality: String
+}
+
+type CreateCanonicalArtistMutationPayload {
+  # Success or Error, where on success Artist is returned
+  artistOrError: CreateCanonicalArtistSuccessOrErrorType
+  clientMutationId: String
+}
+
+type CreateCanonicalArtistSuccess {
+  artist: Artist
+}
+
+union CreateCanonicalArtistSuccessOrErrorType =
+    CreateCanonicalArtistFailure
+  | CreateCanonicalArtistSuccess
+
 type CreateCareerHighlightFailure {
   mutationError: GravityMutationError
 }
@@ -13747,6 +13776,11 @@ type Mutation {
 
   # Creates a bidder position
   createBidderPosition(input: BidderPositionInput!): BidderPositionPayload
+
+  # Create a canonical artist
+  createCanonicalArtist(
+    input: CreateCanonicalArtistMutationInput!
+  ): CreateCanonicalArtistMutationPayload
 
   # Creates Artist Career Highlight.
   createCareerHighlight(

--- a/src/schema/v2/artist/createCanonicalArtistMutation.ts
+++ b/src/schema/v2/artist/createCanonicalArtistMutation.ts
@@ -1,0 +1,118 @@
+import { GraphQLString, GraphQLUnionType } from "graphql"
+import { GraphQLObjectType } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { snakeCase } from "lodash"
+import { ResolverContext } from "types/graphql"
+import { ArtistType } from "./index"
+
+interface CreateCanonicalArtistMutationInput {
+  birthday: string
+  deathday: string
+  displayName: string
+  firstName: string
+  lastName: string
+  middleName: string
+  nationality: string
+}
+
+const CreateCanonicalArtistSuccessType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "CreateCanonicalArtistSuccess",
+  isTypeOf: (data) => {
+    return data.id
+  },
+  fields: () => ({
+    artist: {
+      type: ArtistType,
+      resolve: (artist) => artist,
+    },
+  }),
+})
+
+const CreateCanonicalArtistFailureType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "CreateCanonicalArtistFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const SuccessOrErrorType = new GraphQLUnionType({
+  name: "CreateCanonicalArtistSuccessOrErrorType",
+  types: [CreateCanonicalArtistSuccessType, CreateCanonicalArtistFailureType],
+})
+
+export const createCanonicalArtistMutation = mutationWithClientMutationId<
+  CreateCanonicalArtistMutationInput,
+  any | null,
+  ResolverContext
+>({
+  name: "CreateCanonicalArtistMutation",
+  description: "Create a canonical artist",
+  inputFields: {
+    birthday: { type: GraphQLString },
+    deathday: { type: GraphQLString },
+    displayName: { type: GraphQLString },
+    firstName: { type: GraphQLString },
+    lastName: { type: GraphQLString },
+    middleName: { type: GraphQLString },
+    nationality: { type: GraphQLString },
+  },
+  outputFields: {
+    artistOrError: {
+      type: SuccessOrErrorType,
+      description: "Success or Error, where on success Artist is returned",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (args, { createArtistLoader }) => {
+    if (!createArtistLoader) {
+      throw new Error("You need to be logged in to perform this action")
+    }
+
+    const { firstName, middleName, lastName, ...otherArgs } = args
+
+    const names = {
+      first: firstName,
+      middle: middleName,
+      last: lastName,
+    }
+
+    const transformedOtherPayload = Object.keys(otherArgs).reduce(
+      (acc, key) => ({ ...acc, [snakeCase(key)]: otherArgs[key] }),
+      {} as Omit<
+        CreateCanonicalArtistMutationInput,
+        "firstName" | "middleName" | "lastName"
+      >
+    )
+
+    const gravityPayload = {
+      ...names,
+      ...transformedOtherPayload,
+    }
+
+    try {
+      return await createArtistLoader(gravityPayload)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -138,6 +138,7 @@ import { toggleFeatureFlagMutation } from "./featureFlags/admin/mutations/toggle
 import { updateFeatureFlagMutation } from "./featureFlags/admin/mutations/updateFeatureFlagMutation"
 import { channel } from "./article/channel"
 import { createArtistMutation } from "./artist/createArtistMutation"
+import { createCanonicalArtistMutation } from "./artist/createCanonicalArtistMutation"
 import { deleteArtistMutation } from "./artist/deleteArtistMutation"
 import { updateArtworkMutation } from "./artwork/updateArtworkMutation"
 import { artworksForUser } from "./artworksForUser"
@@ -448,6 +449,7 @@ export default new GraphQLSchema({
       updateCareerHighlight: updateCareerHighlightMutation,
       deleteCareerHighlight: deleteCareerHighlightMutation,
       createArtist: createArtistMutation,
+      createCanonicalArtist: createCanonicalArtistMutation,
       createBidder: createBidderMutation,
       createBidderPosition: BidderPositionMutation,
       createCollection: createCollectionMutation,


### PR DESCRIPTION
This PR adds a new mutation to create an `Artist` record in gravity. I'm using the term "canonical" here to differentiate this mutation from the existing one called `CreateArtistMutation`. That one is being used to create artists for My Collection purposes and includes an unfortunate requirement that the mutation include a display name.

This assumption does not fit with how our admin users create artists over in Forque. In that context a display name should be optional.

So yeah, all I did here was copy/paste the existing mutation and update its name. Then I updated the type of the display name to optional. Once this lands then I can turn my attention over to Forque and use this mutation instead and allow admin's to skip display name when it's not applicable.

https://artsyproduct.atlassian.net/browse/AMBER-1200

/cc @artsy/amber-devs