### PR TITLE
fix: make fetch serialize arrays with more than 21 elements correctly

### DIFF
--- a/src/lib/apis/fetch.ts
+++ b/src/lib/apis/fetch.ts
@@ -19,7 +19,8 @@ export const constructUrlAndParams = (method, url): URLAndRequestBodyParams => {
 
   if (method === "PUT" || method === "POST" || method === "DELETE") {
     const [path, queryParams] = url.split("?")
-    const parsedParams = parse(queryParams)
+    const parsedParams = parse(queryParams, { arrayLimit: 1000 })
+
     let body
 
     if (isExisty(parsedParams)) {


### PR DESCRIPTION
Initially, this was reported by a gallery partner.  ([slack](https://artsy.slack.com/archives/C07PRTJSD6G/p1734645878738339)). They tried to add more than 21 artworks to a viewing room, but the backend was allowing only 21. I’ve noticed that the fetch doesn’t work correctly - for long arrays, it produces weird results like this one:

```json
{
  artworks: [
    {   // <- for some reason it reduces a bunch of artworks to a single nested object
      '21': [Object],
      '22': [Object],
      '23': [Object],
      '24': [Object],
      '25': [Object],
      '26': [Object],
      '27': [Object],
      '28': [Object],
      '29': [Object],
      artwork_id: '...',
      delete: 'false'
    },
    { artwork_id: '...', delete: 'false' }, // <- this looks normal
    { artwork_id: '...', delete: 'false' },
    { artwork_id: '...', delete: 'false' },
    ...
  ]
}
```

I discovered that qs (which we use to parse query parameters) has an array limit set to 20 by default. I’ve increased it to 1000, but I’m open to other suggestions.