### PR TITLE
fix: avoid serialization / deserialization of request body to query string and back

### DIFF
--- a/src/schema/v2/viewingRooms/mutations/updateViewingRoomArtworks.ts
+++ b/src/schema/v2/viewingRooms/mutations/updateViewingRoomArtworks.ts
@@ -8,7 +8,6 @@ import {
   GraphQLString,
 } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
-import { identity, pickBy } from "lodash"
 import { ResolverContext } from "types/graphql"
 
 const ViewingRoomArtworkInput = new GraphQLInputObjectType({
@@ -58,21 +57,24 @@ export const updateViewingRoomArtworksMutation = mutationWithClientMutationId<
       throw new Error("You need to be signed in to perform this action")
     }
 
-    const artworks = args.artworks.map((artwork, index) => {
-      return pickBy(
-        {
-          [index]: {
-            artwork_id: artwork.artworkID,
-            delete: artwork.delete,
-          },
-        },
-        identity
-      )
+    const artworks = args.artworks.map((artwork, _index) => {
+      return {
+        artwork_id: artwork.artworkID,
+        delete: artwork.delete,
+      }
     })
 
-    const response = await updateViewingRoomArtworksLoader(args.viewingRoomID, {
-      artworks: artworks,
-    })
+    // Can we keep the argument input the same and trigger use of
+    // the request body (instead of query params) further down the stack?
+    const response = await updateViewingRoomArtworksLoader(
+      args.viewingRoomID,
+      {},
+      {
+        body: {
+          artworks: artworks,
+        },
+      }
+    )
 
     return response
   },

--- a/src/schema/v2/viewingRooms/mutations/updateViewingRoomSubsections.ts
+++ b/src/schema/v2/viewingRooms/mutations/updateViewingRoomSubsections.ts
@@ -75,21 +75,16 @@ export const updateViewingRoomSubsectionsMutation = mutationWithClientMutationId
       throw new Error("You need to be signed in to perform this action")
     }
 
-    const subsections = args.subsections.map((subsection, index) => {
+    const subsections = args.subsections.map((subsection, _index) => {
       return {
-        [index]: pickBy(
+        id: subsection.internalID,
+        delete: subsection.delete,
+        ar_image_id: subsection.image?.internalID,
+        attributes: pickBy(
           {
-            id: subsection.internalID,
-            delete: subsection.delete,
-            ar_image_id: subsection.image?.internalID,
-            attributes: pickBy(
-              {
-                body: subsection.attributes?.body,
-                caption: subsection.attributes?.caption,
-                title: subsection.attributes?.title,
-              },
-              identity
-            ),
+            body: subsection.attributes?.body,
+            caption: subsection.attributes?.caption,
+            title: subsection.attributes?.title,
           },
           identity
         ),
@@ -98,6 +93,7 @@ export const updateViewingRoomSubsectionsMutation = mutationWithClientMutationId
 
     const response = await updateViewingRoomSubsectionsLoader(
       args.viewingRoomID,
+      {},
       {
         subsections: subsections,
       }


### PR DESCRIPTION
paired with @dblandin on this one. This is not a final PR, just a proposal / conversation starter:

When working on https://github.com/artsy/metaphysics/pull/6331 we've noticed that when we send POST / PUT / DELETE requests with some data in them, the data is being converted ([here](https://github.com/artsy/metaphysics/blob/main/src/lib/loaders/api/loader_interface.ts#L72), but it's not very obvious to understand) to query string params, and then back ([here](https://github.com/artsy/metaphysics/blob/main/src/lib/apis/fetch.ts#L22)) before sending this data to the next service. Basically when we do `gravityLoader('/something', { some: 'data' })`, the data will be temporarily converted to `/something?some=data`. In most cases, this is not a problem.

But apparently it can be a problem sometimes, like, for example, with [this issue](https://github.com/artsy/metaphysics/pull/6331) mentioned above. @dblandin and I are wondering - should PPST / PUT / DELETE requests completely skip this weird intermediate step?