### PR TITLE
feat: update open search artworks index

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16896,7 +16896,7 @@ type Query {
     limit: Int
 
     # (Only for when useOpenSearch is true) These fields are used to calculate the More Like This query
-    mltFields: [String] = ["material", "categories", "tags", "medium"]
+    mltFields: [String] = ["genes", "materials", "tags", "medium"]
     offset: Int
 
     # (Only for when useOpenSearch is true) Weights for the OpenSearch query
@@ -21550,7 +21550,7 @@ type Viewer {
     limit: Int
 
     # (Only for when useOpenSearch is true) These fields are used to calculate the More Like This query
-    mltFields: [String] = ["material", "categories", "tags", "medium"]
+    mltFields: [String] = ["genes", "materials", "tags", "medium"]
     offset: Int
 
     # (Only for when useOpenSearch is true) Weights for the OpenSearch query

--- a/src/lib/infiniteDiscovery/findSimilarArtworks.ts
+++ b/src/lib/infiniteDiscovery/findSimilarArtworks.ts
@@ -86,7 +86,7 @@ export const findSimilarArtworks = async (
       response_processors: [
         {
           collapse: {
-            field: "artistName",
+            field: "artist_id",
           },
         },
       ],

--- a/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
+++ b/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
@@ -61,7 +61,7 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
       type: new GraphQLList(GraphQLString),
       description:
         "(Only for when useOpenSearch is true) These fields are used to calculate the More Like This query",
-      defaultValue: ["material", "categories", "tags", "medium"],
+      defaultValue: ["genes", "materials", "tags", "medium"],
     },
     likedArtworkIds: {
       type: new GraphQLList(GraphQLString),
@@ -133,7 +133,7 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
 
         // backfill with random curated picks if we don't have enough similar artworks
         const randomArtworks = await getInitialArtworksSample(
-          limit - result.length,
+          2,
           excludeArtworkIds,
           artworksLoader
         )


### PR DESCRIPTION
This PR updates the latest index built using [the OpenSearch pipeline](https://github.com/artsy/zenith/tree/main/projects/infinite_discovery/src).