### PR TITLE
chore: use graphql parser when formatting schema during push-schema-changes task

### DIFF
--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -59,7 +59,7 @@ async function updateSchemaFile({
         }
 
         execSync(
-          `[ ! -f ./node_modules/.bin/prettier ] || ./node_modules/.bin/prettier --write ${dest}`,
+          `[ ! -f ./node_modules/.bin/prettier ] || ./node_modules/.bin/prettier --parser=graphql --write ${dest}`,
           {
             cwd: repoDir,
           }


### PR DESCRIPTION
Addresses the following error when running prettier in repositories where `parser` is configured via `.pretterrc`:

```
$ cd ~/code/artsy/force
$ cp ../metaphysics/_schemaV2.graphql data/schema.graphql 
$ ./node_modules/.bin/prettier --write data/schema.graphql
data/schema.graphql
[error] data/schema.graphql: SyntaxError: Unexpected keyword or identifier. (1:1)
[error] > 1 | directive @cacheable on QUERY
[error]     | ^
[error]   2 |
[error]   3 | directive @optionalField on FIELD
[error]   4 |
```

Surfaced [here in Slack](https://artsy.slack.com/archives/CP9P4KR35/p1736250971875779) and in [a Circle CI build](https://app.circleci.com/pipelines/github/artsy/metaphysics/25022/workflows/5b9c98ba-3d10-4b33-9f1f-0bfd2cd49515/jobs/51495).