### PR TITLE
chore(AMBER-1116): Enable signature fields to be selected

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5620,8 +5620,26 @@ input CommerceOptInMutationInput {
   # The partner location ID to assign
   locationId: String
 
-  # whether or not pick up it is pick up available
+  # whether or not it is pick up available
   pickupAvailable: Boolean
+
+  # whether or not it is signed
+  signedByArtist: Boolean
+
+  # whether or not it is stamped by the artist estate
+  stampedByArtistEstate: Boolean
+
+  # whether or not it has a sticker label
+  stickerLabel: Boolean
+
+  # whether or not it is signed in plate
+  signedInPlate: Boolean
+
+  # whether or not other is selected for signature
+  signedOther: Boolean
+
+  # whether or not it is not signed
+  notSigned: Boolean
 }
 
 type CommerceOptInMutationPayload {
@@ -5666,6 +5684,24 @@ input CommerceOptInReportMutationInput {
 
   # whether or not pick up should be available
   pickupAvailable: Boolean
+
+  # whether or not it is signed
+  signedByArtist: Boolean
+
+  # whether or not it is stamped by the artist estate
+  stampedByArtistEstate: Boolean
+
+  # whether or not it has a sticker label
+  stickerLabel: Boolean
+
+  # whether or not it is signed in plate
+  signedInPlate: Boolean
+
+  # whether or not other is selected for signature
+  signedOther: Boolean
+
+  # whether or not it is not signed
+  notSigned: Boolean
 }
 
 type CommerceOptInReportMutationPayload {

--- a/src/schema/v2/partner/CommerceOptIn/commerceOptInMutation.ts
+++ b/src/schema/v2/partner/CommerceOptIn/commerceOptInMutation.ts
@@ -35,6 +35,12 @@ interface Input {
   coaByAuthenticatingBody?: boolean
   locationId?: string
   artsyShippingDomestic?: boolean
+  signedByArtist?: boolean
+  stampedByArtistEstate?: boolean
+  stickerLabel?: boolean
+  signedInPlate?: boolean
+  signedOther?: boolean
+  notSigned?: boolean
 }
 
 const CommerceOptInSuccesssType = new GraphQLObjectType<any, ResolverContext>({
@@ -116,6 +122,30 @@ export const commerceOptInMutation = mutationWithClientMutationId<
       type: GraphQLBoolean,
       description: "Opt artwork into Artsy Shipping Domestic",
     },
+    signedByArtist: {
+      type: GraphQLBoolean,
+      description: "whether or not it is signed",
+    },
+    stampedByArtistEstate: {
+      type: GraphQLBoolean,
+      description: "whether or not it is stamped by the artist estate",
+    },
+    stickerLabel: {
+      type: GraphQLBoolean,
+      description: "whether or not it has a sticker label",
+    },
+    signedInPlate: {
+      type: GraphQLBoolean,
+      description: "whether or not it is signed in plate",
+    },
+    signedOther: {
+      type: GraphQLBoolean,
+      description: "whether or not other is selected for signature",
+    },
+    notSigned: {
+      type: GraphQLBoolean,
+      description: "whether or not it is not signed",
+    },
   },
   outputFields: {
     commerceOptInMutationOrError: {
@@ -134,6 +164,12 @@ export const commerceOptInMutation = mutationWithClientMutationId<
       coaByAuthenticatingBody,
       locationId,
       artsyShippingDomestic,
+      signedByArtist,
+      stampedByArtistEstate,
+      stickerLabel,
+      signedInPlate,
+      signedOther,
+      notSigned,
     },
     { optInArtworksIntoCommerceLoader }
   ) => {
@@ -146,6 +182,12 @@ export const commerceOptInMutation = mutationWithClientMutationId<
       coa_by_authenticating_body: coaByAuthenticatingBody,
       location_id: locationId,
       artsy_shipping_domestic: artsyShippingDomestic,
+      signed_by_artist: signedByArtist,
+      stamped_by_artist_estate: stampedByArtistEstate,
+      sticker_label: stickerLabel,
+      signed_in_plate: signedInPlate,
+      signed_other: signedOther,
+      not_signed: notSigned,
     }
 
     if (!optInArtworksIntoCommerceLoader) {

--- a/src/schema/v2/partner/CommerceOptIn/commerceOptInReportMutation.ts
+++ b/src/schema/v2/partner/CommerceOptIn/commerceOptInReportMutation.ts
@@ -33,6 +33,12 @@ interface Input {
   eligible?: boolean
   locationId?: string
   artsyShippingDomestic?: boolean
+  signedByArtist?: boolean
+  stampedByArtistEstate?: boolean
+  stickerLabel?: boolean
+  signedInPlate?: boolean
+  signedOther?: boolean
+  notSigned?: boolean
 }
 
 const CommerceOptInReportSuccesssType = new GraphQLObjectType<
@@ -126,6 +132,30 @@ export const commerceOptInReportMutation = mutationWithClientMutationId<
       type: GraphQLBoolean,
       description: "Opt artwork into Artsy Shipping Domestic",
     },
+    signedByArtist: {
+      type: GraphQLBoolean,
+      description: "whether or not it is signed",
+    },
+    stampedByArtistEstate: {
+      type: GraphQLBoolean,
+      description: "whether or not it is stamped by the artist estate",
+    },
+    stickerLabel: {
+      type: GraphQLBoolean,
+      description: "whether or not it has a sticker label",
+    },
+    signedInPlate: {
+      type: GraphQLBoolean,
+      description: "whether or not it is signed in plate",
+    },
+    signedOther: {
+      type: GraphQLBoolean,
+      description: "whether or not other is selected for signature",
+    },
+    notSigned: {
+      type: GraphQLBoolean,
+      description: "whether or not it is not signed",
+    },
   },
   outputFields: {
     commerceOptInReportMutationOrError: {
@@ -145,6 +175,12 @@ export const commerceOptInReportMutation = mutationWithClientMutationId<
       eligible,
       locationId,
       artsyShippingDomestic,
+      signedByArtist,
+      stampedByArtistEstate,
+      stickerLabel,
+      signedInPlate,
+      signedOther,
+      notSigned,
     },
     { createCommerceOptInEligibleArtworksReportLoader }
   ) => {
@@ -158,6 +194,12 @@ export const commerceOptInReportMutation = mutationWithClientMutationId<
       eligible: eligible,
       location_id: locationId,
       artsy_shipping_domestic: artsyShippingDomestic,
+      signed_by_artist: signedByArtist,
+      stamped_by_artist_estate: stampedByArtistEstate,
+      sticker_label: stickerLabel,
+      signed_in_plate: signedInPlate,
+      signed_other: signedOther,
+      not_signed: notSigned,
     }
 
     if (!createCommerceOptInEligibleArtworksReportLoader) {


### PR DESCRIPTION
This PR resolves [AMBER-1116]

This work allows us to add selects to the BNMO opt in page for all of the signature fields.

[AMBER-1116]: https://artsyproduct.atlassian.net/browse/AMBER-1116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ