### PR TITLE
chore(EMI-2226): Add homeViewTasksSection to success response when clearing a task.

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -67,6 +67,7 @@ type AckTaskMutationPayload {
 union AckTaskResponseOrError = AckTaskFailure | AckTaskSuccess
 
 type AckTaskSuccess {
+  homeViewTasksSection: HomeViewSectionTasks
   task: Task!
 }
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -59,6 +59,7 @@ input AckTaskMutationInput {
 
 type AckTaskMutationPayload {
   clientMutationId: String
+  homeViewTasksSection: HomeViewSectionTasks
 
   # On success: the new state of the Task
   taskOrError: AckTaskResponseOrError!
@@ -67,7 +68,6 @@ type AckTaskMutationPayload {
 union AckTaskResponseOrError = AckTaskFailure | AckTaskSuccess
 
 type AckTaskSuccess {
-  homeViewTasksSection: HomeViewSectionTasks
   task: Task!
 }
 
@@ -9289,6 +9289,7 @@ input DismissTaskMutationInput {
 
 type DismissTaskMutationPayload {
   clientMutationId: String
+  homeViewTasksSection: HomeViewSectionTasks
 
   # On success: the new state of the Task
   taskOrError: DismissTaskResponseOrError!
@@ -9297,7 +9298,6 @@ type DismissTaskMutationPayload {
 union DismissTaskResponseOrError = DismissTaskFailure | DismissTaskSuccess
 
 type DismissTaskSuccess {
-  homeViewTasksSection: HomeViewSectionTasks
   task: Task!
 }
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9296,6 +9296,7 @@ type DismissTaskMutationPayload {
 union DismissTaskResponseOrError = DismissTaskFailure | DismissTaskSuccess
 
 type DismissTaskSuccess {
+  homeViewTasksSection: HomeViewSectionTasks
   task: Task!
 }
 

--- a/src/schema/v2/homeView/sectionTypes/Tasks.ts
+++ b/src/schema/v2/homeView/sectionTypes/Tasks.ts
@@ -1,10 +1,7 @@
 import { GraphQLObjectType } from "graphql"
 import { pageable } from "relay-cursor-paging"
-import {
-  connectionWithCursorInfo,
-  emptyConnection,
-} from "schema/v2/fields/pagination"
-import { TaskType } from "schema/v2/me/task"
+import { emptyConnection } from "schema/v2/fields/pagination"
+import { TaskConnectionType } from "schema/v2/me/task"
 import { NodeInterface } from "schema/v2/object_identification"
 import { ResolverContext } from "types/graphql"
 import {
@@ -24,9 +21,7 @@ export const HomeViewTasksSectionType = new GraphQLObjectType<
     ...standardSectionFields,
 
     tasksConnection: {
-      type: connectionWithCursorInfo({
-        nodeType: TaskType,
-      }).connectionType,
+      type: TaskConnectionType,
       args: pageable({}),
       resolve: (parent, ...rest) =>
         parent.resolver ? parent.resolver(parent, ...rest) : emptyConnection,

--- a/src/schema/v2/homeView/sections/Tasks.ts
+++ b/src/schema/v2/homeView/sections/Tasks.ts
@@ -15,7 +15,6 @@ export const Tasks: HomeViewSection = {
   },
   requiresAuthentication: true,
   resolver: withHomeViewTimeout(async (_parent, args, { meTasksLoader }) => {
-    console.log("resolving tasks")
     if (!meTasksLoader) return null
 
     const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
@@ -28,7 +27,6 @@ export const Tasks: HomeViewSection = {
 
     const count = parseInt(headers["x-total-count"] || "0", 10)
 
-    console.log("resolved tasks", { count })
     return {
       totalCount: count,
       pageCursors: createPageCursors({ ...args, page, size }, count),

--- a/src/schema/v2/homeView/sections/Tasks.ts
+++ b/src/schema/v2/homeView/sections/Tasks.ts
@@ -15,6 +15,7 @@ export const Tasks: HomeViewSection = {
   },
   requiresAuthentication: true,
   resolver: withHomeViewTimeout(async (_parent, args, { meTasksLoader }) => {
+    console.log("resolving tasks")
     if (!meTasksLoader) return null
 
     const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
@@ -27,6 +28,7 @@ export const Tasks: HomeViewSection = {
 
     const count = parseInt(headers["x-total-count"] || "0", 10)
 
+    console.log("resolved tasks", { count })
     return {
       totalCount: count,
       pageCursors: createPageCursors({ ...args, page, size }, count),

--- a/src/schema/v2/me/__tests__/ack_task_mutation.test.js
+++ b/src/schema/v2/me/__tests__/ack_task_mutation.test.js
@@ -6,21 +6,21 @@ describe("AckTaskMutation", () => {
     const mutation = gql`
       mutation {
         ackTask(input: { id: "task-id" }) {
+          homeViewTasksSection {
+            tasksConnection(first: 10) {
+              edges {
+                node {
+                  internalID
+                  title
+                }
+              }
+            }
+          }
           taskOrError {
             ... on AckTaskSuccess {
               task {
                 internalID
                 title
-              }
-              homeViewTasksSection {
-                tasksConnection(first: 10) {
-                  edges {
-                    node {
-                      internalID
-                      title
-                    }
-                  }
-                }
               }
             }
             ... on AckTaskFailure {
@@ -35,17 +35,17 @@ describe("AckTaskMutation", () => {
 
     const mutationResponse = {
       ackTask: {
+        homeViewTasksSection: {
+          tasksConnection: {
+            edges: [
+              { node: { internalID: "asdf1234", title: "Remaining Task" } },
+            ],
+          },
+        },
         taskOrError: {
           task: {
             internalID: "task-id",
             title: "Test Task",
-          },
-          homeViewTasksSection: {
-            tasksConnection: {
-              edges: [
-                { node: { internalID: "asdf1234", title: "Remaining Task" } },
-              ],
-            },
           },
         },
       },

--- a/src/schema/v2/me/__tests__/ack_task_mutation.test.js
+++ b/src/schema/v2/me/__tests__/ack_task_mutation.test.js
@@ -12,6 +12,16 @@ describe("AckTaskMutation", () => {
                 internalID
                 title
               }
+              homeViewTasksSection {
+                tasksConnection(first: 10) {
+                  edges {
+                    node {
+                      internalID
+                      title
+                    }
+                  }
+                }
+              }
             }
             ... on AckTaskFailure {
               mutationError {
@@ -30,6 +40,13 @@ describe("AckTaskMutation", () => {
             internalID: "task-id",
             title: "Test Task",
           },
+          homeViewTasksSection: {
+            tasksConnection: {
+              edges: [
+                { node: { internalID: "asdf1234", title: "Remaining Task" } },
+              ],
+            },
+          },
         },
       },
     }
@@ -38,6 +55,10 @@ describe("AckTaskMutation", () => {
       meAckTaskLoader: jest.fn().mockResolvedValue({
         id: "task-id",
         title: "Test Task",
+      }),
+      meTasksLoader: jest.fn().mockResolvedValue({
+        body: [{ id: "asdf1234", title: "Remaining Task" }],
+        headers: { "x-total-count": 1 },
       }),
     }
 

--- a/src/schema/v2/me/__tests__/dismiss_task_mutation.test.js
+++ b/src/schema/v2/me/__tests__/dismiss_task_mutation.test.js
@@ -6,21 +6,21 @@ describe("DismissTaskMutation", () => {
     const mutation = gql`
       mutation {
         dismissTask(input: { id: "task-id" }) {
+          homeViewTasksSection {
+            tasksConnection(first: 10) {
+              edges {
+                node {
+                  internalID
+                  title
+                }
+              }
+            }
+          }
           taskOrError {
             ... on DismissTaskSuccess {
               task {
                 internalID
                 title
-              }
-              homeViewTasksSection {
-                tasksConnection(first: 10) {
-                  edges {
-                    node {
-                      internalID
-                      title
-                    }
-                  }
-                }
               }
             }
             ... on DismissTaskFailure {
@@ -40,12 +40,12 @@ describe("DismissTaskMutation", () => {
             internalID: "task-id",
             title: "Test Task",
           },
-          homeViewTasksSection: {
-            tasksConnection: {
-              edges: [
-                { node: { internalID: "asdf1234", title: "Remaining Task" } },
-              ],
-            },
+        },
+        homeViewTasksSection: {
+          tasksConnection: {
+            edges: [
+              { node: { internalID: "asdf1234", title: "Remaining Task" } },
+            ],
           },
         },
       },

--- a/src/schema/v2/me/__tests__/dismiss_task_mutation.test.js
+++ b/src/schema/v2/me/__tests__/dismiss_task_mutation.test.js
@@ -12,6 +12,16 @@ describe("DismissTaskMutation", () => {
                 internalID
                 title
               }
+              homeViewTasksSection {
+                tasksConnection(first: 10) {
+                  edges {
+                    node {
+                      internalID
+                      title
+                    }
+                  }
+                }
+              }
             }
             ... on DismissTaskFailure {
               mutationError {
@@ -30,6 +40,13 @@ describe("DismissTaskMutation", () => {
             internalID: "task-id",
             title: "Test Task",
           },
+          homeViewTasksSection: {
+            tasksConnection: {
+              edges: [
+                { node: { internalID: "asdf1234", title: "Remaining Task" } },
+              ],
+            },
+          },
         },
       },
     }
@@ -38,6 +55,10 @@ describe("DismissTaskMutation", () => {
       meDismissTaskLoader: jest.fn().mockResolvedValue({
         id: "task-id",
         title: "Test Task",
+      }),
+      meTasksLoader: jest.fn().mockResolvedValue({
+        body: [{ id: "asdf1234", title: "Remaining Task" }],
+        headers: { "x-total-count": 1 },
       }),
     }
 

--- a/src/schema/v2/me/ack_task_mutation.ts
+++ b/src/schema/v2/me/ack_task_mutation.ts
@@ -28,10 +28,6 @@ const SuccessType = new GraphQLObjectType<any, ResolverContext>({
         return response
       },
     },
-    homeViewTasksSection: {
-      type: HomeViewTasksSectionType,
-      resolve: () => Tasks,
-    },
   }),
 })
 
@@ -70,6 +66,10 @@ export const ackTaskMutation = mutationWithClientMutationId<
       type: new GraphQLNonNull(ResponseOrErrorType),
       description: "On success: the new state of the Task",
       resolve: (result) => result,
+    },
+    homeViewTasksSection: {
+      type: HomeViewTasksSectionType,
+      resolve: () => Tasks,
     },
   },
   mutateAndGetPayload: async ({ id }, { meAckTaskLoader }) => {

--- a/src/schema/v2/me/ack_task_mutation.ts
+++ b/src/schema/v2/me/ack_task_mutation.ts
@@ -11,6 +11,8 @@ import {
 } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
 import { Task, TaskType } from "./task"
+import { HomeViewTasksSectionType } from "../homeView/sectionTypes/Tasks"
+import { Tasks } from "../homeView/sections/Tasks"
 
 interface Input {
   id: string
@@ -25,6 +27,10 @@ const SuccessType = new GraphQLObjectType<any, ResolverContext>({
       resolve: (response) => {
         return response
       },
+    },
+    homeViewTasksSection: {
+      type: HomeViewTasksSectionType,
+      resolve: () => Tasks,
     },
   }),
 })

--- a/src/schema/v2/me/dismiss_task_mutation.ts
+++ b/src/schema/v2/me/dismiss_task_mutation.ts
@@ -28,10 +28,6 @@ const SuccessType = new GraphQLObjectType<any, ResolverContext>({
         return response
       },
     },
-    homeViewTasksSection: {
-      type: HomeViewTasksSectionType,
-      resolve: () => Tasks,
-    },
   }),
 })
 
@@ -70,6 +66,10 @@ export const dismissTaskMutation = mutationWithClientMutationId<
       type: new GraphQLNonNull(ResponseOrErrorType),
       description: "On success: the new state of the Task",
       resolve: (result) => result,
+    },
+    homeViewTasksSection: {
+      type: HomeViewTasksSectionType,
+      resolve: () => Tasks,
     },
   },
   mutateAndGetPayload: async ({ id }, { meDismissTaskLoader }) => {

--- a/src/schema/v2/me/dismiss_task_mutation.ts
+++ b/src/schema/v2/me/dismiss_task_mutation.ts
@@ -11,6 +11,8 @@ import {
 } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
 import { Task, TaskType } from "./task"
+import { HomeViewTasksSectionType } from "../homeView/sectionTypes/Tasks"
+import { Tasks } from "../homeView/sections/Tasks"
 
 interface Input {
   id: string
@@ -26,6 +28,39 @@ const SuccessType = new GraphQLObjectType<any, ResolverContext>({
         return response
       },
     },
+    homeViewTasksSection: {
+      type: HomeViewTasksSectionType,
+      resolve: () => Tasks.resolver,
+    },
+    // tasksConnection: {
+    //   type: TaskConnectionType,
+    //   args: pageable({}),
+    //   resolve: async (_parent, args, { meTasksLoader }) => {
+    //     if (!meTasksLoader)
+    //       throw new Error(
+    //         "There must have been a user, but no task loader... :/"
+    //       )
+
+    //     const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+
+    //     const { body: results, headers } = await meTasksLoader({
+    //       page,
+    //       size,
+    //       total_count: true,
+    //     })
+
+    //     const count = parseInt(headers["x-total-count"] || "0", 10)
+
+    //     return {
+    //       totalCount: count,
+    //       pageCursors: createPageCursors({ ...args, page, size }, count),
+    //       ...connectionFromArraySlice(results, args, {
+    //         arrayLength: count,
+    //         sliceStart: offset,
+    //       }),
+    //     }
+    //   },
+    // },
   }),
 })
 

--- a/src/schema/v2/me/dismiss_task_mutation.ts
+++ b/src/schema/v2/me/dismiss_task_mutation.ts
@@ -30,37 +30,8 @@ const SuccessType = new GraphQLObjectType<any, ResolverContext>({
     },
     homeViewTasksSection: {
       type: HomeViewTasksSectionType,
-      resolve: () => Tasks.resolver,
+      resolve: () => Tasks,
     },
-    // tasksConnection: {
-    //   type: TaskConnectionType,
-    //   args: pageable({}),
-    //   resolve: async (_parent, args, { meTasksLoader }) => {
-    //     if (!meTasksLoader)
-    //       throw new Error(
-    //         "There must have been a user, but no task loader... :/"
-    //       )
-
-    //     const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
-
-    //     const { body: results, headers } = await meTasksLoader({
-    //       page,
-    //       size,
-    //       total_count: true,
-    //     })
-
-    //     const count = parseInt(headers["x-total-count"] || "0", 10)
-
-    //     return {
-    //       totalCount: count,
-    //       pageCursors: createPageCursors({ ...args, page, size }, count),
-    //       ...connectionFromArraySlice(results, args, {
-    //         arrayLength: count,
-    //         sliceStart: offset,
-    //       }),
-    //     }
-    //   },
-    // },
   }),
 })
 
@@ -109,7 +80,7 @@ export const dismissTaskMutation = mutationWithClientMutationId<
     try {
       const task: Task = await meDismissTaskLoader?.(id)
 
-      return { ...task, __typename: "SuccessType" }
+      return { ...task, _type: "SuccessType" }
     } catch (error) {
       const formattedErr = formatGravityError(error)
 

--- a/src/schema/v2/me/task.ts
+++ b/src/schema/v2/me/task.ts
@@ -2,6 +2,7 @@ import { GraphQLNonNull, GraphQLObjectType, GraphQLString } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { IDFields, NodeInterface } from "../object_identification"
 import { date } from "./../fields/date"
+import { connectionWithCursorInfo } from "../fields/pagination"
 
 export interface Task {
   image_url: string
@@ -47,3 +48,7 @@ export const TaskType = new GraphQLObjectType<any, ResolverContext>({
     createdAt: date(),
   }),
 })
+
+export const TaskConnectionType = connectionWithCursorInfo({
+  nodeType: TaskType,
+}).connectionType


### PR DESCRIPTION
Part of [EMI-2226].

This PR adds the `homeViewTasksSection` field to our success response type so that we can refresh the home view with an updated task list when dismissing or acknowledging a task. Eigen PR to consume this new field and optimistically update forthcoming.

Somewhat confusingly I realized that I added this field to the `taskOrError` field. It is adjacent to the task on the non-error type but the field name implies that it is one thing - a task. Not sure if there is a better way here.

cc @artsy/emerald-devs
paired with @MrSltun on some of it.


[EMI-2026]: https://artsyproduct.atlassian.net/browse/EMI-2226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[EMI-2226]: https://artsyproduct.atlassian.net/browse/EMI-2226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ