### PR TITLE
feat: add artworks batch count configurable 

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16922,6 +16922,9 @@ type Query {
     before: String
     certainty: Float
 
+    # The number of curated artworks to return. This is a temporary field to support the transition to OpenSearch
+    curatedPicksSize: Int = 2
+
     # (Only for when useOpenSearch is true) Exclude these artworks from the response
     excludeArtworkIds: [String]
     first: Int
@@ -21575,6 +21578,9 @@ type Viewer {
     after: String
     before: String
     certainty: Float
+
+    # The number of curated artworks to return. This is a temporary field to support the transition to OpenSearch
+    curatedPicksSize: Int = 2
 
     # (Only for when useOpenSearch is true) Exclude these artworks from the response
     excludeArtworkIds: [String]

--- a/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
+++ b/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
@@ -133,7 +133,7 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
 
         // backfill with random curated picks if we don't have enough similar artworks
         const randomArtworks = await getInitialArtworksSample(
-          2,
+          limit - result.length,
           excludeArtworkIds,
           artworksLoader
         )

--- a/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
+++ b/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
@@ -134,12 +134,13 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
         }
 
         result = await findSimilarArtworks(options, artworksLoader)
-
         result = result.slice(0, limit - curatedPicksSize)
 
         // backfill with random curated picks if we don't have enough similar artworks
         const randomArtworks = await getInitialArtworksSample(
-          curatedPicksSize,
+          limit - result.length === curatedPicksSize
+            ? curatedPicksSize
+            : limit - result.length,
           excludeArtworkIds,
           artworksLoader
         )

--- a/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
+++ b/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
@@ -74,6 +74,12 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
         "(Only for when useOpenSearch is true) Weights for the OpenSearch query",
       defaultValue: [0.6, 0.4],
     },
+    curatedPicksSize: {
+      type: GraphQLInt,
+      description:
+        "The number of curated artworks to return. This is a temporary field to support the transition to OpenSearch",
+      defaultValue: 2,
+    },
   }),
   resolve: async (
     _root,
@@ -97,6 +103,7 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
       useOpenSearch,
       mltFields,
       osWeights,
+      curatedPicksSize,
     } = args
 
     if (useOpenSearch) {
@@ -128,12 +135,11 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
 
         result = await findSimilarArtworks(options, artworksLoader)
 
-        // use first 8 artworks
-        result = result.slice(0, 8)
+        result = result.slice(0, limit - curatedPicksSize)
 
         // backfill with random curated picks if we don't have enough similar artworks
         const randomArtworks = await getInitialArtworksSample(
-          limit - result.length,
+          curatedPicksSize,
           excludeArtworkIds,
           artworksLoader
         )


### PR DESCRIPTION
<img width="1603" alt="image" src="https://github.com/user-attachments/assets/e7eac582-99bd-4ef9-8496-4efe888cda9c" />

Adds configuration option for changing the count of the artworks batch. 