### PR TITLE
feat(job): exposes team name

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12172,6 +12172,7 @@ type Job {
   externalURL: String!
   id: ID!
   location: String!
+  teamName: String!
   title: String!
   updatedAt(
     format: String
@@ -16819,7 +16820,7 @@ type Query {
     first: Int
 
     # Which index to use to display initial batch of artworks
-    initialArtworksIndexName: String
+    initialArtworksIndexName: String = "infinite_discovery_initial_artworks"
     last: Int
 
     # These artworks are used to calculate the taste profile vector. Such artworks are excluded from the response
@@ -21461,7 +21462,7 @@ type Viewer {
     first: Int
 
     # Which index to use to display initial batch of artworks
-    initialArtworksIndexName: String
+    initialArtworksIndexName: String = "infinite_discovery_initial_artworks"
     last: Int
 
     # These artworks are used to calculate the taste profile vector. Such artworks are excluded from the response

--- a/src/schema/v2/jobs.ts
+++ b/src/schema/v2/jobs.ts
@@ -109,6 +109,10 @@ export const jobType = new GraphQLObjectType<
       type: new GraphQLNonNull(GraphQLString),
       resolve: ({ departmentName }) => cleanDepartmentName(departmentName),
     },
+    teamName: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ teamName }) => teamName,
+    },
   },
 })
 


### PR DESCRIPTION
We want to change to grouping based on team instead of dept on the jobs pages.