### PR TITLE
feat: let a user toggle their Collection to public via updateCollectionMutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4257,10 +4257,12 @@ type Collection {
 
   # Name of the collection. Has a predictable value for 'standard' collections such as Saved Artwork, My Collection, etc. Can be provided by user otherwise.
   name: String!
+  private: Boolean!
 
   # True if this collection represents artworks explicitly saved by the user, false otherwise.
   saves: Boolean!
   shareableWithPartners: Boolean!
+  slug: String!
 }
 
 enum CollectionArtworkSorts {
@@ -22786,6 +22788,7 @@ input updateCollectionInput {
   # The internal ID of the collection
   id: String!
   name: String!
+  private: Boolean
   shareableWithPartners: Boolean
 }
 

--- a/src/schema/v2/me/__tests__/updateCollectionMutation.test.ts
+++ b/src/schema/v2/me/__tests__/updateCollectionMutation.test.ts
@@ -4,11 +4,13 @@ import { HTTPError } from "lib/HTTPError"
 
 const mutation = `
   mutation {
-    updateCollection(input: { id: "collection-id", name: "Dining room", shareableWithPartners: true }) {
+    updateCollection(input: { id: "collection-id", name: "Dining room", shareableWithPartners: true, private: false }) {
       responseOrError {
         ... on UpdateCollectionSuccess {
           collection {
             name
+            private
+            slug
             shareableWithPartners
           }
         }
@@ -32,6 +34,8 @@ describe("updateCollection", () => {
       id: "collection-id",
       name: "Dining room",
       shareable_with_partners: true,
+      private: false,
+      slug: "dining-room",
     }
 
     let context: Partial<ResolverContext>
@@ -53,6 +57,7 @@ describe("updateCollection", () => {
           user_id: "user-42",
           name: "Dining room",
           shareable_with_partners: true,
+          private: false,
         }
       )
     })
@@ -66,7 +71,9 @@ describe("updateCollection", () => {
             "responseOrError": {
               "collection": {
                 "name": "Dining room",
+                "private": false,
                 "shareableWithPartners": true,
+                "slug": "dining-room",
               },
             },
           },

--- a/src/schema/v2/me/collection.ts
+++ b/src/schema/v2/me/collection.ts
@@ -151,6 +151,12 @@ export const CollectionType = new GraphQLObjectType<any, ResolverContext>({
         return collection.shareable_with_partners
       },
     },
+    private: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+    },
+    slug: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
   }),
 })
 

--- a/src/schema/v2/me/updateCollectionMutation.ts
+++ b/src/schema/v2/me/updateCollectionMutation.ts
@@ -48,6 +48,7 @@ interface InputProps {
   id: string
   name: string
   shareableWithPartners: boolean
+  private: boolean
 }
 
 export const updateCollectionMutation = mutationWithClientMutationId<
@@ -64,6 +65,7 @@ export const updateCollectionMutation = mutationWithClientMutationId<
     },
     name: { type: new GraphQLNonNull(GraphQLString) },
     shareableWithPartners: { type: GraphQLBoolean },
+    private: { type: GraphQLBoolean },
   },
   outputFields: {
     responseOrError: {
@@ -81,6 +83,7 @@ export const updateCollectionMutation = mutationWithClientMutationId<
         name: args.name,
         user_id: context.userID,
         shareable_with_partners: args.shareableWithPartners,
+        private: args.private,
       })
 
       return response


### PR DESCRIPTION
This one's easy, just thread this argument through in the mutation. Also added `slug` and `private` to the `Collection` type since we'll need that to expose the toggle control / public URL to a user who wants to share.

Up next, once https://github.com/artsy/gravity/pull/18492 is merged, an updated schema that lets you retrieve another user's public collection/artworks (right now all that is only under `me`).