### PR TITLE
feat: add root-level collection: Collection to let a user access another user's public collection by slug

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16615,6 +16615,11 @@ type Query {
     # A slug for the city, conforming to Gravity's city slug naming conventions
     slug: String
   ): City
+  collection(
+    # The ID or slug of the Collection
+    id: String!
+    userID: String!
+  ): Collection
 
   # A collector profile.
   collectorProfile(userID: String): CollectorProfileType
@@ -21368,6 +21373,11 @@ type Viewer {
     # A slug for the city, conforming to Gravity's city slug naming conventions
     slug: String
   ): City
+  collection(
+    # The ID or slug of the Collection
+    id: String!
+    userID: String!
+  ): Collection
 
   # A collector profile.
   collectorProfile(userID: String): CollectorProfileType

--- a/src/schema/v2/__tests__/collection.test.ts
+++ b/src/schema/v2/__tests__/collection.test.ts
@@ -1,0 +1,87 @@
+import { runAuthenticatedQuery } from "../test/utils"
+
+describe("collection", () => {
+  const collection = {
+    id: "collection-id",
+    name: "Dining room",
+    private: false,
+    shareable_with_partners: true,
+    slug: "dining-room",
+  }
+
+  const context = {
+    collectionLoader: jest.fn().mockResolvedValue(collection),
+    collectionArtworksLoader: jest.fn().mockResolvedValue({
+      headers: { "x-total-count": "1" },
+      body: [{ id: "artwork-id" }],
+    }),
+  }
+
+  it("fetches a collection by id", async () => {
+    const query = `
+      {
+        collection(id: "collection-id", userID: "user-42") {
+          name
+          private
+          shareableWithPartners
+          slug
+        }
+      }
+    `
+
+    await runAuthenticatedQuery(query, context)
+
+    expect(context.collectionLoader).toHaveBeenCalledWith("collection-id", {
+      user_id: "user-42",
+    })
+  })
+
+  it("returns a collection", async () => {
+    const query = `
+      {
+        collection(id: "collection-id", userID: "user-42") {
+          name
+          private
+          shareableWithPartners
+          slug
+        }
+      }
+    `
+
+    const data = await runAuthenticatedQuery(query, context)
+
+    expect(data).toEqual({
+      collection: {
+        name: "Dining room",
+        private: false,
+        shareableWithPartners: true,
+        slug: "dining-room",
+      },
+    })
+  })
+
+  it("uses the injected userID when fetching artworks", async () => {
+    const query = `
+      {
+        collection(id: "collection-id", userID: "user-42") {
+          artworksConnection(first: 1) {
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+      }
+    `
+
+    await runAuthenticatedQuery(query, context)
+
+    expect(context.collectionArtworksLoader).toHaveBeenCalledWith(
+      "collection-id",
+      expect.objectContaining({
+        user_id: "user-42",
+      })
+    )
+  })
+})

--- a/src/schema/v2/collection.ts
+++ b/src/schema/v2/collection.ts
@@ -1,0 +1,30 @@
+import { GraphQLFieldConfig, GraphQLNonNull, GraphQLString } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { CollectionType } from "./me/collection"
+
+export const Collection: GraphQLFieldConfig<any, ResolverContext> = {
+  type: CollectionType,
+  args: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID or slug of the Collection",
+    },
+    userID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+  },
+  resolve: async (_parent, args, { collectionLoader }, _info) => {
+    const { id, userID } = args
+
+    if (!collectionLoader) return null
+
+    const response = await collectionLoader(id, {
+      user_id: userID,
+    })
+
+    return {
+      ...response,
+      userID, // Inject the userID into the response
+    }
+  },
+}

--- a/src/schema/v2/me/collection.ts
+++ b/src/schema/v2/me/collection.ts
@@ -41,14 +41,14 @@ export const CollectionType = new GraphQLObjectType<any, ResolverContext>({
         const { collectionArtworksLoader } = context
         if (!collectionArtworksLoader) return null
 
-        const { id } = parent
-        const { userID } = context
+        const { id, userID: injectedUserID } = parent
+        const { userID: currentUserID } = context
         const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
 
         const gravityOptions = {
           page,
           size,
-          user_id: userID,
+          user_id: injectedUserID ?? currentUserID, // Prefer injected user ID if provided (e.g. in the case of a public collection)
           private: true,
           sort: args.sort,
           total_count: true,

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -266,6 +266,7 @@ import { updateViewingRoomArtworksMutation } from "./viewingRooms/mutations/upda
 import { updateViewingRoomSubsectionsMutation } from "./viewingRooms/mutations/updateViewingRoomSubsections"
 import { ViewingRoomConnection } from "./viewingRooms"
 import { seoExperimentArtists } from "schema/v2/seoExperimentArtists"
+import { Collection } from "./collection"
 
 const viewingRoomUnstitchedRootField = config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA
   ? {
@@ -327,6 +328,7 @@ const rootFields = {
   channel,
   cities,
   city: City,
+  collection: Collection,
   collectorProfile: CollectorProfileForUser,
   collectorProfilesConnection: CollectorProfilesConnection,
   conversation: Conversation,


### PR DESCRIPTION
I think this should be sufficient to get a public list/My Collection page up. Tested locally w/ two user's, and I'm able to access the expected info for a list that was made public, including My Collection (and via slug).

(screenshot is when logged in as a new user, accessing collections my personal user account set to public)

![Screenshot 2025-01-21 at 6 31 14 PM](https://github.com/user-attachments/assets/f42e4424-847c-4126-ba4e-2334c702a15c)
