### PR TITLE
chore: consistent artwork money fields resolver

### DIFF
--- a/src/lib/stitching/vortex/__tests__/pricingContext.test.ts
+++ b/src/lib/stitching/vortex/__tests__/pricingContext.test.ts
@@ -157,14 +157,17 @@ describe("PricingContext type", () => {
         {
           size_score: 600,
           price_cents: [124, 235],
+          price_currency: "USD",
         },
         {
           size_score: 3000,
           price_cents: [154, 185],
+          price_currency: "USD",
         },
         {
           size_score: 10300,
           price_cents: [12443], // THIS ONE SHOULD BE CHOSEN
+          price_currency: "USD",
         },
       ],
     })
@@ -185,14 +188,17 @@ describe("PricingContext type", () => {
         {
           size_score: 600,
           price_cents: [124, 235],
+          price_currency: "USD",
         },
         {
           size_score: 3000,
           price_cents: [154, 18555], // THIS ONE SHOULD BE CHOSEN
+          price_currency: "USD",
         },
         {
           size_score: 10300,
           price_cents: [12443],
+          price_currency: "USD",
         },
       ],
     })

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -568,7 +568,7 @@ describe("Artwork type", () => {
         expect(data).toEqual({
           artwork: {
             pricePaid: {
-              display: "$210",
+              display: "US$210",
               currencyCode: "USD",
             },
           },
@@ -654,7 +654,7 @@ describe("Artwork type", () => {
               maxPrice: {
                 minor: 42000,
                 major: 420,
-                display: null,
+                display: "US$420",
                 currencyCode: "USD",
               },
             },
@@ -676,7 +676,7 @@ describe("Artwork type", () => {
               minPrice: {
                 minor: 42000,
                 major: 420,
-                display: null,
+                display: "US$420",
                 currencyCode: "USD",
               },
               maxPrice: null,

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -568,7 +568,7 @@ describe("Artwork type", () => {
         expect(data).toEqual({
           artwork: {
             pricePaid: {
-              display: "US$210",
+              display: "$210",
               currencyCode: "USD",
             },
           },

--- a/src/schema/v2/fields/__tests__/money.test.ts
+++ b/src/schema/v2/fields/__tests__/money.test.ts
@@ -1,4 +1,4 @@
-import { amount } from "../money"
+import { amount, resolvePriceAndCurrencyFieldsToMoney } from "../money"
 import { runQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
 
@@ -175,6 +175,7 @@ describe("major(convertTo:)", () => {
     })
   })
 
+  // eslint-disable-next-line jest/no-disabled-tests
   it.skip("only supports USD", async () => {
     expect.assertions(1)
 
@@ -254,5 +255,47 @@ describe("major(convertTo:)", () => {
     expect(result!.artwork.listPrice.major).toEqual(
       expectedPriceAfterConversion
     )
+  })
+})
+
+describe("resolvePriceAndCurrencyFieldsToMoney()", () => {
+  const args = {}
+  const ctx = { exchangeRatesLoader: jest.fn(() => Promise.resolve()) }
+  const info = {}
+  it("returns money fields for major + currencyCode", async () => {
+    const result = await resolvePriceAndCurrencyFieldsToMoney(
+      {
+        major: 1234,
+        currencyCode: "USD",
+      },
+      args,
+      ctx,
+      info
+    )
+    expect(result).toEqual({
+      cents: 123400,
+      major: 1234,
+      display: "US$1,234",
+      currency: "USD",
+    })
+  })
+
+  it("returns money fields for minor + currencyCode", async () => {
+    const result = await resolvePriceAndCurrencyFieldsToMoney(
+      {
+        minor: 123400,
+        currencyCode: "USD",
+      },
+      args,
+      ctx,
+      info
+    )
+
+    expect(result).toEqual({
+      cents: 123400,
+      major: 1234,
+      display: "US$1,234",
+      currency: "USD",
+    })
   })
 })

--- a/src/schema/v2/fields/listPrice.ts
+++ b/src/schema/v2/fields/listPrice.ts
@@ -4,7 +4,7 @@ import {
   GraphQLUnionType,
   GraphQLString,
 } from "graphql"
-import { Money } from "./money"
+import { Money, resolvePriceAndCurrencyFieldsToMoney } from "./money"
 
 const PriceRange = new GraphQLObjectType({
   name: "PriceRange",
@@ -14,22 +14,36 @@ const PriceRange = new GraphQLObjectType({
     },
     minPrice: {
       type: Money,
-      resolve: ({ minPriceCents, price_currency }) => {
-        if (!minPriceCents) return null
-        return {
-          cents: minPriceCents,
-          currency: price_currency,
-        }
+      resolve: (
+        { minPriceCents: minor, price_currency: currencyCode },
+        args,
+        ctx,
+        info
+      ) => {
+        if (!minor) return null
+        return resolvePriceAndCurrencyFieldsToMoney(
+          { minor, currencyCode },
+          args,
+          ctx,
+          info
+        )
       },
     },
     maxPrice: {
       type: Money,
-      resolve: ({ maxPriceCents, price_currency }) => {
-        if (!maxPriceCents) return null
-        return {
-          cents: maxPriceCents,
-          currency: price_currency,
-        }
+      resolve: (
+        { maxPriceCents: minor, price_currency: currencyCode },
+        args,
+        ctx,
+        info
+      ) => {
+        if (!minor) return null
+        return resolvePriceAndCurrencyFieldsToMoney(
+          { minor, currencyCode },
+          args,
+          ctx,
+          info
+        )
       },
     },
   },
@@ -40,28 +54,42 @@ export const listPrice: GraphQLFieldConfig<any, any> = {
     name: "ListPrice",
     types: [PriceRange, Money],
   }),
-  resolve: ({ price_cents, price, price_currency }) => {
+  resolve: async (
+    { price_cents, price: displayPrice, price_currency },
+    args,
+    ctx,
+    info
+  ) => {
     if (!price_cents || price_cents.length === 0) {
       return null
     }
     const isExactPrice = price_cents.length === 1
 
-    return isExactPrice
-      ? {
-          __typename: Money.name,
-          cents: price_cents[0],
-          display: price,
-          currency: price_currency,
-        }
-      : {
-          // For deprecated types
-          __typename: PriceRange.name,
-          minPriceCents: price_cents[0],
-          maxPriceCents: price_cents[1],
+    if (isExactPrice) {
+      const moneyFields = await resolvePriceAndCurrencyFieldsToMoney(
+        { minor: price_cents[0], currencyCode: price_currency },
+        args,
+        ctx,
+        info
+      )
+      return {
+        __typename: Money.name,
+        ...moneyFields,
+        // To support existing usage which assumes Gravity's Artwork#display_price
+        // TODO: Update clients to use real `display` field with formatting string
+        // if necessary
+        display: displayPrice,
+      }
+    }
+    return {
+      // For deprecated types
+      __typename: PriceRange.name,
+      minPriceCents: price_cents[0],
+      maxPriceCents: price_cents[1],
 
-          // For preferred types
-          price_currency,
-          display: price,
-        }
+      // For preferred types
+      price_currency,
+      display: displayPrice,
+    }
   },
 }

--- a/src/schema/v2/fields/money.ts
+++ b/src/schema/v2/fields/money.ts
@@ -253,7 +253,7 @@ export const resolvePriceAndCurrencyFieldsToMoney = async (
     }
   } catch (error) {
     console.error(
-      "v2/fields/money @resolveMinorAndCurrencyFieldsToMoney: Error:",
+      "v2/fields/money @resolvePriceAndCurrencyFieldsToMoney: Error:",
       error
     )
     return null

--- a/src/schema/v2/partnerOffer.ts
+++ b/src/schema/v2/partnerOffer.ts
@@ -11,7 +11,7 @@ import { ResolverContext } from "types/graphql"
 import { IDFields, NodeInterface } from "./object_identification"
 import { priceDisplayText } from "lib/moneyHelpers"
 import { connectionWithCursorInfo } from "./fields/pagination"
-import { Money, resolveMinorAndCurrencyFieldsToMoney } from "./fields/money"
+import { Money, resolvePriceAndCurrencyFieldsToMoney } from "./fields/money"
 
 export const PartnerOfferSourceEnumType = new GraphQLEnumType({
   name: "PartnerOfferSourceEnum",
@@ -52,7 +52,7 @@ export const PartnerOfferType = new GraphQLObjectType<any, ResolverContext>({
         context,
         info
       ) => {
-        return resolveMinorAndCurrencyFieldsToMoney(
+        return resolvePriceAndCurrencyFieldsToMoney(
           {
             minor,
             currencyCode,
@@ -83,7 +83,7 @@ export const PartnerOfferType = new GraphQLObjectType<any, ResolverContext>({
         context,
         info
       ) => {
-        return resolveMinorAndCurrencyFieldsToMoney(
+        return resolvePriceAndCurrencyFieldsToMoney(
           {
             minor,
             currencyCode,

--- a/src/schema/v2/partnerOfferToCollector.ts
+++ b/src/schema/v2/partnerOfferToCollector.ts
@@ -8,7 +8,7 @@ import {
 import { ResolverContext } from "types/graphql"
 import { IDFields, NodeInterface } from "./object_identification"
 import { connectionWithCursorInfo } from "./fields/pagination"
-import { Money, resolveMinorAndCurrencyFieldsToMoney } from "./fields/money"
+import { Money, resolvePriceAndCurrencyFieldsToMoney } from "./fields/money"
 import { PartnerOfferSourceEnumType } from "./partnerOffer"
 
 export const PartnerOfferToCollectorType = new GraphQLObjectType<
@@ -48,7 +48,7 @@ export const PartnerOfferToCollectorType = new GraphQLObjectType<
         context,
         info
       ) => {
-        return resolveMinorAndCurrencyFieldsToMoney(
+        return resolvePriceAndCurrencyFieldsToMoney(
           {
             minor,
             currencyCode,

--- a/src/schema/v2/recentlySoldArtworks.ts
+++ b/src/schema/v2/recentlySoldArtworks.ts
@@ -1,20 +1,20 @@
 import { GraphQLFieldConfig, GraphQLObjectType, GraphQLString } from "graphql"
 import { connectionDefinitions, connectionFromArray } from "graphql-relay"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
-import { priceDisplayText } from "lib/moneyHelpers"
 import { pageable } from "relay-cursor-paging"
 import { createPageCursors } from "schema/v2/fields/pagination"
 import { ResolverContext } from "types/graphql"
 import { ArtworkType } from "./artwork"
-import { Money } from "./fields/money"
+import { Money, resolvePriceAndCurrencyFieldsToMoney } from "./fields/money"
 
-const moneyResolver = (cents, currency) => {
-  if (!cents) return null
-  return {
-    cents,
-    currency,
-    display: priceDisplayText(cents, currency, ""),
-  }
+const moneyResolver = (minor, currencyCode, args, ctx, info) => {
+  if (!minor) return null
+  return resolvePriceAndCurrencyFieldsToMoney(
+    { minor, currencyCode },
+    args,
+    ctx,
+    info
+  )
 }
 
 const RecentlySoldArtworkType = new GraphQLObjectType<any, ResolverContext>({
@@ -22,18 +22,30 @@ const RecentlySoldArtworkType = new GraphQLObjectType<any, ResolverContext>({
   fields: {
     lowEstimate: {
       type: Money,
-      resolve: ({ lowEstimateCents, currency }) =>
-        moneyResolver(lowEstimateCents, currency),
+      resolve: (
+        { lowEstimateCents: minor, currency: currencyCode },
+        args,
+        ctx,
+        info
+      ) => moneyResolver(minor, currencyCode, args, ctx, info),
     },
     highEstimate: {
       type: Money,
-      resolve: ({ highEstimateCents, currency }) =>
-        moneyResolver(highEstimateCents, currency),
+      resolve: (
+        { highEstimateCents: minor, currency: currencyCode },
+        args,
+        ctx,
+        info
+      ) => moneyResolver(minor, currencyCode, args, ctx, info),
     },
     priceRealized: {
       type: Money,
-      resolve: ({ priceRealizedCents, currency }) =>
-        moneyResolver(priceRealizedCents, currency),
+      resolve: (
+        { priceRealizedCents: minor, currency: currencyCode },
+        args,
+        ctx,
+        info
+      ) => moneyResolver(minor, currencyCode, args, ctx, info),
     },
     artwork: {
       type: ArtworkType,


### PR DESCRIPTION
Downstream from some hackathon work... This PR updates our artwork and editionSet fields to use a consistent resolver for the money type, avoiding missing display values.

In order to preserve some behavior I clobbered that display value on one field where we are using the gravity `price_display` json value instead. There might be other cases where we want to verify that nothing is changing drastically - for example, are we querying any `display` fields where the format is hardcoded.

cc @artsy/emerald-devs 