### PR TITLE
fix: dont error when personalized arguments are used without a user in filtering

### DIFF
--- a/src/schema/v2/__tests__/filterArtworksConnection.test.ts
+++ b/src/schema/v2/__tests__/filterArtworksConnection.test.ts
@@ -418,6 +418,50 @@ describe("artworksConnection", () => {
         { node: { slug: "oseberg-norway-queens-ship-0" } },
       ])
     })
+
+    it("returns results using the non personalized loader if there is no user", async () => {
+      context = {
+        unauthenticatedLoaders: {
+          filterArtworksLoader: () =>
+            Promise.resolve({
+              hits: [
+                {
+                  id: "oseberg-norway-queens-ship-0",
+                },
+              ],
+              aggregations: {
+                total: {
+                  value: 303,
+                },
+              },
+            }),
+        },
+        authenticatedLoaders: {},
+      }
+
+      const query = gql`
+        {
+          artworksConnection(
+            first: 1
+            after: ""
+            aggregations: [TOTAL, FOLLOWED_ARTISTS]
+            includeArtworksByFollowedArtists: true
+          ) {
+            edges {
+              node {
+                slug
+              }
+            }
+          }
+        }
+      `
+
+      const { artworksConnection } = await runQuery(query, context)
+
+      expect(artworksConnection.edges).toEqual([
+        { node: { slug: "oseberg-norway-queens-ship-0" } },
+      ])
+    })
   })
 
   describe(`When filtering on a sale and filtering/sorting by price`, () => {

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -544,9 +544,20 @@ const filterArtworksConnectionTypeFactory = (
       requestedPersonalizedAggregation
     ) {
       if (!filterArtworksAuthenticatedLoader) {
-        throw new Error("You must be logged in to request these params.")
+        // TODO: Instead of throwing an error, let's use the unauthenticated loader
+        // without the personalized options if they are specified while unauthenticated.
+        //
+        // throw new Error("You must be logged in to request these params.")
+
+        delete gravityOptions.include_artworks_by_followed_artists
+        gravityOptions.aggregations = gravityOptions.aggregations.filter(
+          (item) => item !== "followed_artists"
+        )
+
+        loader = filterArtworksUnauthenticatedLoader
+      } else {
+        loader = filterArtworksAuthenticatedLoader
       }
-      loader = filterArtworksAuthenticatedLoader
     } else {
       // If filtering by sale and filtering/sorting by price,
       // use the uncached loader to avoid stale data.


### PR DESCRIPTION
Rather than loudly error, MP can more gracefully fallback to not erroring _or_ including any personalized arguments, if they were provided without a user context. Currently there is an ongoing issue where that's occurring, so at least for now we can relax it.

It's debatable whether a loud error, logging but not an error, or silently ignoring these arguments is the 'right' thing to do, generally!