### PR TITLE
feat: let a logged out user view public collection data

### DIFF
--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -70,6 +70,12 @@ export default (opts) => {
     artworksLoader: gravityLoader("artworks"),
     authenticationStatusLoader: gravityLoader("me", {}, { headers: true }),
     bidderLoader: gravityLoader((id) => `bidder/${id}`),
+    collectionArtworksLoader: gravityLoader(
+      (id) => `collection/${id}/artworks`,
+      {},
+      { headers: true }
+    ),
+    collectionLoader: gravityLoader((id) => `collection/${id}`),
     createInvoicePaymentLoader: gravityLoader(
       (id) => `invoice/${id}/payment`,
       {},

--- a/src/schema/v2/me/myCollectionInfo.ts
+++ b/src/schema/v2/me/myCollectionInfo.ts
@@ -243,7 +243,7 @@ export const MyCollectionInfo: GraphQLFieldConfig<any, ResolverContext> = {
   type: MyCollectionInfoType,
   description: "Info about the current user's my-collection",
   resolve: async (_parent, _options, { userID, collectionLoader }) => {
-    if (!(collectionLoader && userID)) {
+    if (!userID) {
       return null
     }
 


### PR DESCRIPTION
The backend already properly enforces authorization. If a collection is not public, only the owner can read it. If a collection is public, anyone can read it.

So, we can relax that here in MP by defining the loaders we need in the _without_ authentication factory. Now, if you're logged in and make any of these collection requests that use the loaders, it all works as before.

But, if you're logged out and make any of these requests, as long as the collection is public - it will succeed.