### PR TITLE
fix: throw exception for case with no curated artworks

### DIFF
--- a/src/lib/infiniteDiscovery/getInitialArtworksSample.ts
+++ b/src/lib/infiniteDiscovery/getInitialArtworksSample.ts
@@ -40,6 +40,10 @@ export const getInitialArtworksSample = async (
     }),
   })
 
+  if (curatorsPicks.hits?.hits?.length === 0) {
+    throw Error("Failed to fetch curated artworks")
+  }
+
   const artworkIds = curatorsPicks.hits?.hits?.map((hit) => hit._id) || []
   const artworks = await artworksLoader({ ids: artworkIds })
 


### PR DESCRIPTION
This PR introduces an error handler for cases where no curated artworks are available.  In the future, we'll refine the error message, and it will comply with `ErrorType` once it becomes available from Gravity.