### PR TITLE
feat: add signed as a param to filterArtworksConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -320,6 +320,9 @@ type Alert {
     periods: [String]
     priceRange: String
     saleID: ID
+
+    # When true, will only return signed artworks.
+    signed: Boolean
     size: Int
 
     # Filter results by Artwork sizes
@@ -1706,6 +1709,9 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     periods: [String]
     priceRange: String
     saleID: ID
+
+    # When true, will only return signed artworks.
+    signed: Boolean
     size: Int
 
     # Filter results by Artwork sizes
@@ -2185,6 +2191,9 @@ type ArtistSeries implements Node {
     periods: [String]
     priceRange: String
     saleID: ID
+
+    # When true, will only return signed artworks.
+    signed: Boolean
     size: Int
 
     # Filter results by Artwork sizes
@@ -9475,6 +9484,9 @@ interface EntityWithFilterArtworksConnectionInterface {
     periods: [String]
     priceRange: String
     saleID: ID
+
+    # When true, will only return signed artworks.
+    signed: Boolean
     size: Int
 
     # Filter results by Artwork sizes
@@ -9719,6 +9731,9 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
     periods: [String]
     priceRange: String
     saleID: ID
+
+    # When true, will only return signed artworks.
+    signed: Boolean
     size: Int
 
     # Filter results by Artwork sizes
@@ -10227,6 +10242,9 @@ input FilterArtworksInput {
   periods: [String]
   priceRange: String
   saleID: ID
+
+  # When true, will only return signed artworks.
+  signed: Boolean
   size: Int
 
   # Filter results by Artwork sizes
@@ -10683,6 +10701,9 @@ type Gene implements Node & Searchable {
     periods: [String]
     priceRange: String
     saleID: ID
+
+    # When true, will only return signed artworks.
+    signed: Boolean
     size: Int
 
     # Filter results by Artwork sizes
@@ -12558,6 +12579,9 @@ type MarketingCollection implements Node {
     periods: [String]
     priceRange: String
     saleID: ID
+
+    # When true, will only return signed artworks.
+    signed: Boolean
     size: Int
 
     # Filter results by Artwork sizes
@@ -15078,6 +15102,9 @@ type Partner implements Node {
     periods: [String]
     priceRange: String
     saleID: ID
+
+    # When true, will only return signed artworks.
+    signed: Boolean
     size: Int
 
     # Filter results by Artwork sizes
@@ -16578,6 +16605,9 @@ type Query {
     periods: [String]
     priceRange: String
     saleID: ID
+
+    # When true, will only return signed artworks.
+    signed: Boolean
     size: Int
 
     # Filter results by Artwork sizes
@@ -18929,6 +18959,9 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
     periods: [String]
     priceRange: String
     saleID: ID
+
+    # When true, will only return signed artworks.
+    signed: Boolean
     size: Int
 
     # Filter results by Artwork sizes
@@ -19418,6 +19451,9 @@ type Tag implements Node {
     periods: [String]
     priceRange: String
     saleID: ID
+
+    # When true, will only return signed artworks.
+    signed: Boolean
     size: Int
 
     # Filter results by Artwork sizes
@@ -21361,6 +21397,9 @@ type Viewer {
     periods: [String]
     priceRange: String
     saleID: ID
+
+    # When true, will only return signed artworks.
+    signed: Boolean
     size: Int
 
     # Filter results by Artwork sizes

--- a/src/schema/v2/__tests__/filterArtworksConnection.test.ts
+++ b/src/schema/v2/__tests__/filterArtworksConnection.test.ts
@@ -892,4 +892,54 @@ describe("artworksConnection", () => {
       ])
     })
   })
+
+  describe("filter by signed", () => {
+    const mockFilterArtworksLoader = jest.fn(() => {
+      return Promise.resolve({
+        hits: [
+          {
+            id: "kaws-toys",
+          },
+        ],
+        aggregations: {
+          total: {
+            value: 1,
+          },
+        },
+      })
+    })
+
+    it("returns correct artwork", async () => {
+      const context = {
+        authenticatedLoaders: {},
+        unauthenticatedLoaders: {
+          filterArtworksLoader: mockFilterArtworksLoader,
+        },
+      }
+
+      const query = gql`
+        {
+          artworksConnection(input: { signed: true, first: 10 }) {
+            edges {
+              node {
+                slug
+              }
+            }
+          }
+        }
+      `
+
+      const { artworksConnection } = await runQuery(query, context)
+
+      expect(mockFilterArtworksLoader).toHaveBeenCalledWith(
+        expect.objectContaining({
+          signed: true,
+        })
+      )
+
+      expect(artworksConnection.edges).toEqual([
+        { node: { slug: "kaws-toys" } },
+      ])
+    })
+  })
 })

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -215,6 +215,10 @@ export const filterArtworksArgs: GraphQLFieldConfigArgumentMap = {
   size: {
     type: GraphQLInt,
   },
+  signed: {
+    type: GraphQLBoolean,
+    description: "When true, will only return signed artworks.",
+  },
   sort: {
     type: GraphQLString,
   },


### PR DESCRIPTION
This PR adds signed as a param to `filterArtworksConnection`. 

This is blocked by https://github.com/artsy/gravity/pull/18512