### PR TITLE
fix: dont make `name` required when updating a collection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -22877,7 +22877,7 @@ input updateCollectionInput {
 
   # The internal ID of the collection
   id: String!
-  name: String!
+  name: String
   private: Boolean
   shareableWithPartners: Boolean
 }

--- a/src/schema/v2/me/updateCollectionMutation.ts
+++ b/src/schema/v2/me/updateCollectionMutation.ts
@@ -63,7 +63,7 @@ export const updateCollectionMutation = mutationWithClientMutationId<
       description: "The internal ID of the collection",
       type: new GraphQLNonNull(GraphQLString),
     },
-    name: { type: new GraphQLNonNull(GraphQLString) },
+    name: { type: GraphQLString },
     shareableWithPartners: { type: GraphQLBoolean },
     private: { type: GraphQLBoolean },
   },


### PR DESCRIPTION
This mutation gets used for updating other attributes besides the name, so it shouldn't be required.