### PR TITLE
fix: handle Sale#totalRaised null case

### DIFF
--- a/src/schema/v2/me/__tests__/create_bidder_mutation.test.js
+++ b/src/schema/v2/me/__tests__/create_bidder_mutation.test.js
@@ -20,6 +20,7 @@ describe("Bidder mutation", () => {
     registration_ends_at: null,
     require_bidder_approval: false,
     increment_strategy: "default",
+    total_raised_minor: null,
   }
 
   const bidder = {
@@ -40,6 +41,9 @@ describe("Bidder mutation", () => {
         sale {
           slug
           status
+          totalRaised{
+            minor
+          }
         }
       }
     }
@@ -60,6 +64,7 @@ describe("Bidder mutation", () => {
             sale: {
               slug: "shared-live-mocktion",
               status: "open",
+              totalRaised: null,
             },
           },
         },

--- a/src/schema/v2/sale/__tests__/index.test.ts
+++ b/src/schema/v2/sale/__tests__/index.test.ts
@@ -1296,5 +1296,16 @@ describe("Sale type", () => {
         },
       })
     })
+
+    it("returns null if total_raised_minor is not present", async () => {
+      sale.hide_total = true
+      sale.total_raised_minor = null
+      expect(await execute(query)).toEqual({
+        sale: {
+          hideTotal: true,
+          totalRaised: null,
+        },
+      })
+    })
   })
 })

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -584,6 +584,7 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
           context,
           info
         ) => {
+          if (!minor) return null
           return resolveMinorAndCurrencyFieldsToMoney(
             {
               minor,


### PR DESCRIPTION
Followup from https://github.com/artsy/gravity/pull/18527

We have [another case](https://github.com/artsy/metaphysics/blob/main/src/schema/v2/artwork/index.ts#L1541) where Gravity can return `nil` for a Money type and we are returning `null`, so I am following the same pattern.

After this, we can rollback https://github.com/artsy/gravity/pull/18527