### PR TITLE
fix(markdown): ensures internal hardcoded http links are https for seo purposes

### DIFF
--- a/src/schema/v2/fields/__tests__/markdown.test.ts
+++ b/src/schema/v2/fields/__tests__/markdown.test.ts
@@ -1,4 +1,8 @@
-import { formatMarkdownValue, markdown } from "../markdown"
+import {
+  enforceInternalHTTPS,
+  formatMarkdownValue,
+  markdown,
+} from "../markdown"
 
 describe("formatMarkdownValue", () => {
   it("formats markdown as html", () => {
@@ -50,5 +54,52 @@ describe("markdown", () => {
         { fieldName: "description" } as any
       )
     ).toMatchInlineSnapshot(`"Here's a description with some emphasis !"`)
+  })
+})
+
+describe("enforceInternalHTTPS", () => {
+  it("converts http://artsy.net links to https://www.artsy.net", () => {
+    const input =
+      "Check out this artwork on http://artsy.net/artwork/andy-warhol-flowers"
+    expect(enforceInternalHTTPS(input)).toBe(
+      "Check out this artwork on https://www.artsy.net/artwork/andy-warhol-flowers"
+    )
+  })
+
+  it("converts http://www.artsy.net links to https://www.artsy.net", () => {
+    const input =
+      "Visit our blog at http://www.artsy.net/blog and our magazine at http://www.artsy.net/magazine"
+    expect(enforceInternalHTTPS(input)).toBe(
+      "Visit our blog at https://www.artsy.net/blog and our magazine at https://www.artsy.net/magazine"
+    )
+  })
+
+  it("handles complex art-focused markdown with mixed internal and external links", () => {
+    const input = `
+Artsy's curatorial highlights include [Liu Ye](http://artsy.net/artist/liu-ye-liu-ye)'s Mondrian-inspired paintings and [Luo Yang](http://www.artsy.net/artwork/5e0a14386a2fb5001127943d)'s photographs. Browse works from [Art Basel](http://artsy.net/art-basel-hong-kong-2020) and [Art Central](http://www.artsy.net/art-central-2020).
+
+For more information visit [our partners](https://www.artpartners.com) or [contact us](http://artsy.net/contact).
+    `.trim()
+
+    const expected = `
+Artsy's curatorial highlights include [Liu Ye](https://www.artsy.net/artist/liu-ye-liu-ye)'s Mondrian-inspired paintings and [Luo Yang](https://www.artsy.net/artwork/5e0a14386a2fb5001127943d)'s photographs. Browse works from [Art Basel](https://www.artsy.net/art-basel-hong-kong-2020) and [Art Central](https://www.artsy.net/art-central-2020).
+
+For more information visit [our partners](https://www.artpartners.com) or [contact us](https://www.artsy.net/contact).
+    `.trim()
+
+    expect(enforceInternalHTTPS(input)).toBe(expected)
+  })
+
+  it("leaves other URLs unchanged", () => {
+    const input =
+      "Check these sites: http://example.com, https://google.com, http://artsy.net/about, https://www.artsy.net/contact"
+    expect(enforceInternalHTTPS(input)).toBe(
+      "Check these sites: http://example.com, https://google.com, https://www.artsy.net/about, https://www.artsy.net/contact"
+    )
+  })
+
+  it("handles text without any URLs", () => {
+    const input = "This is just a regular text with no URLs in it."
+    expect(enforceInternalHTTPS(input)).toBe(input)
   })
 })

--- a/src/schema/v2/fields/markdown.ts
+++ b/src/schema/v2/fields/markdown.ts
@@ -24,10 +24,10 @@ export const formatMarkdownValue = (
         tables: true,
       })
 
-      return marked(value)
+      return marked(enforceInternalHTTPS(value))
     }
     case "markdown":
-      return value
+      return enforceInternalHTTPS(value)
     case "plain":
       return markdownToPlainText(value)
     default:
@@ -51,4 +51,12 @@ export const markdown = <T>(
       return formatMarkdownValue(value, format)
     },
   }
+}
+
+// Replace any http://www.artsy.net or http://artsy.net links with https://www.artsy.net
+export const enforceInternalHTTPS = (input: string) => {
+  return input.replace(
+    /(http:\/\/www\.artsy\.net|http:\/\/artsy\.net)/g,
+    "https://www.artsy.net"
+  )
 }


### PR DESCRIPTION
While we currently redirect HTTP to HTTPS in production, our SEO reports flagged hard-coded HTTP links as an issue. This change automatically updates HTTP links found in markdown inputs to HTTPS, addressing all likely instances where these might appear.