### PR TITLE
feat: discoverArtworks sends user_id to Gravity for user authentication

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -31,6 +31,7 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    artworksDiscoveryLoader: gravityLoader("artworks_discovery"),
     artistLoader: gravityLoader((id) => `artist/${id}`),
     authenticatedArtworkVersionLoader: gravityLoader(
       (id) => `artwork_version/${id}`

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -68,7 +68,6 @@ export default (opts) => {
     >(({ artwork_id, image_id }) => `artwork/${artwork_id}/image/${image_id}`),
     artworkLoader: gravityLoader((id) => `artwork/${id}`),
     artworksLoader: gravityLoader("artworks"),
-    artworksDiscoveryLoader: gravityLoader("artworks_discovery"),
     authenticationStatusLoader: gravityLoader("me", {}, { headers: true }),
     bidderLoader: gravityLoader((id) => `bidder/${id}`),
     collectionArtworksLoader: gravityLoader(

--- a/src/schema/v2/infiniteDiscovery/__tests__/discoverArtworks.test.ts
+++ b/src/schema/v2/infiniteDiscovery/__tests__/discoverArtworks.test.ts
@@ -7,8 +7,9 @@ describe("discoverArtworks", () => {
       const artworksDiscoveryLoader = jest
         .fn()
         .mockResolvedValue([{ id: "artwork-1" }, { id: "artwork-2" }])
+      const meLoader = jest.fn().mockResolvedValue({ id: "user-id" })
 
-      const context = { artworksDiscoveryLoader }
+      const context = { artworksDiscoveryLoader, meLoader }
 
       const query = gql`
         {
@@ -31,6 +32,7 @@ describe("discoverArtworks", () => {
         liked_artwork_ids: undefined,
         os_weights: [0.6, 0.4],
         curated_picks_size: 2,
+        user_id: "user-id",
       })
 
       expect(result).toMatchInlineSnapshot(`
@@ -59,8 +61,9 @@ describe("discoverArtworks", () => {
       const artworksDiscoveryLoader = jest
         .fn()
         .mockResolvedValue([{ id: "artwork-1" }, { id: "artwork-2" }])
+      const meLoader = jest.fn().mockResolvedValue({ id: "user-id" })
 
-      const context = { artworksDiscoveryLoader }
+      const context = { artworksDiscoveryLoader, meLoader }
 
       const query = gql`
         {
@@ -89,6 +92,7 @@ describe("discoverArtworks", () => {
         mlt_fields: ["materials", "tags", "medium"],
         os_weights: [0.5, 0.5],
         curated_picks_size: 3,
+        user_id: "user-id",
       })
 
       expect(result).toMatchInlineSnapshot(`

--- a/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
+++ b/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
@@ -39,7 +39,13 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
       defaultValue: 2,
     },
   }),
-  resolve: async (_root, args, { artworksDiscoveryLoader }) => {
+  resolve: async (_root, args, { artworksDiscoveryLoader, meLoader }) => {
+    if (!meLoader || !artworksDiscoveryLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    const me = await meLoader()
+
     const gravityArgs = {
       limit: args.limit,
       exclude_artwork_ids: args.excludeArtworkIds,
@@ -47,6 +53,7 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
       liked_artwork_ids: args.likedArtworkIds,
       os_weights: args.osWeights,
       curated_picks_size: args.curatedPicksSize,
+      user_id: me.id,
     }
 
     const gravityResponse = await artworksDiscoveryLoader(gravityArgs)


### PR DESCRIPTION
follow-up https://github.com/artsy/gravity/pull/18531

Only authenticated users can access infinite discovery endpoint