### PR TITLE
refactor(homeView): naming within new quick link navigation pills

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11529,7 +11529,7 @@ type HomeViewSectionMarketingCollections implements HomeViewSectionGeneric & Nod
   ownerType: String
 }
 
-# A selection of quick links in the home view
+# A selection of navigation links in the home view
 type HomeViewSectionNavigationPills implements HomeViewSectionGeneric & Node {
   # Component prescription for this section, for overriding or customizing presentation and behavior
   component: HomeViewComponent
@@ -11542,10 +11542,10 @@ type HomeViewSectionNavigationPills implements HomeViewSectionGeneric & Node {
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
+  navigationPills: [NavigationPill]!
 
   # [Analytics] `owner type` analytics value for this scetion when displayed in a standalone UI, as defined in our schema (artsy/cohesion)
   ownerType: String
-  quickLinks: [NavigationPill]!
 }
 
 # A sales (auctions) section in the home view
@@ -14565,13 +14565,13 @@ type MyLocation {
 }
 
 type NavigationPill {
-  # Quick link URL
+  # Link URL
   href: String!
 
   # The context module for analytics
   ownerType: String!
 
-  # Quick link title
+  # Link title
   title: String!
 }
 

--- a/src/schema/v2/homeView/sectionTypes/NavigationPills.ts
+++ b/src/schema/v2/homeView/sectionTypes/NavigationPills.ts
@@ -25,11 +25,11 @@ const NavigationPillType = new GraphQLObjectType<
   fields: () => ({
     title: {
       type: new GraphQLNonNull(GraphQLString),
-      description: "Quick link title",
+      description: "Link title",
     },
     href: {
       type: new GraphQLNonNull(GraphQLString),
-      description: "Quick link URL",
+      description: "Link URL",
     },
     ownerType: {
       type: new GraphQLNonNull(GraphQLString),
@@ -43,11 +43,11 @@ export const HomeViewNavigationPillsSectionType = new GraphQLObjectType<
   ResolverContext
 >({
   name: HomeViewSectionTypeNames.HomeViewSectionNavigationPills,
-  description: "A selection of quick links in the home view",
+  description: "A selection of navigation links in the home view",
   interfaces: [HomeViewGenericSectionInterface, NodeInterface],
   fields: {
     ...standardSectionFields,
-    quickLinks: {
+    navigationPills: {
       type: new GraphQLNonNull(new GraphQLList(NavigationPillType)),
       resolve: (parent, ...rest) =>
         parent.resolver ? parent.resolver(parent, ...rest) : [],

--- a/src/schema/v2/homeView/sectionTypes/NavigationPills.ts
+++ b/src/schema/v2/homeView/sectionTypes/NavigationPills.ts
@@ -9,7 +9,13 @@ import { NodeInterface } from "../../object_identification"
 import { HomeViewGenericSectionInterface } from "./GenericSectionInterface"
 import { HomeViewSectionTypeNames } from "./names"
 import { standardSectionFields } from "./GenericSectionInterface"
-import { NavigationPill } from "../sections/QuickLinks"
+import { OwnerType } from "@artsy/cohesion"
+
+export interface NavigationPill {
+  title: string
+  href: string
+  ownerType: OwnerType
+}
 
 const NavigationPillType = new GraphQLObjectType<
   NavigationPill,

--- a/src/schema/v2/homeView/sectionTypes/NavigationPills.ts
+++ b/src/schema/v2/homeView/sectionTypes/NavigationPills.ts
@@ -9,9 +9,12 @@ import { NodeInterface } from "../../object_identification"
 import { HomeViewGenericSectionInterface } from "./GenericSectionInterface"
 import { HomeViewSectionTypeNames } from "./names"
 import { standardSectionFields } from "./GenericSectionInterface"
-import { QuickLink } from "../sections/QuickLinks"
+import { NavigationPill } from "../sections/QuickLinks"
 
-const NavigationPillType = new GraphQLObjectType<QuickLink, ResolverContext>({
+const NavigationPillType = new GraphQLObjectType<
+  NavigationPill,
+  ResolverContext
+>({
   name: "NavigationPill",
   fields: () => ({
     title: {

--- a/src/schema/v2/homeView/sections/QuickLinks.ts
+++ b/src/schema/v2/homeView/sections/QuickLinks.ts
@@ -13,13 +13,13 @@ export const QuickLinks: HomeViewSection = {
   },
 }
 
-export interface QuickLink {
+export interface NavigationPill {
   title: string
   href: string
   ownerType: OwnerType
 }
 
-const QUICK_LINKS: Array<QuickLink> = [
+const QUICK_LINKS: Array<NavigationPill> = [
   { title: "Follows", href: "/favorites", ownerType: OwnerType.follows },
   { title: "Auctions", href: "/auctions", ownerType: OwnerType.auctions },
   { title: "Saves", href: "/favorites/saves", ownerType: OwnerType.saves },

--- a/src/schema/v2/homeView/sections/QuickLinks.ts
+++ b/src/schema/v2/homeView/sections/QuickLinks.ts
@@ -1,6 +1,7 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { HomeViewSection } from "."
 import { HomeViewSectionTypeNames } from "../sectionTypes/names"
+import type { NavigationPill } from "../sectionTypes/NavigationPills"
 
 export const QuickLinks: HomeViewSection = {
   id: "home-view-section-quick-links",
@@ -11,12 +12,6 @@ export const QuickLinks: HomeViewSection = {
   resolver: () => {
     return QUICK_LINKS
   },
-}
-
-export interface NavigationPill {
-  title: string
-  href: string
-  ownerType: OwnerType
 }
 
 const QUICK_LINKS: Array<NavigationPill> = [

--- a/src/schema/v2/homeView/sections/__tests__/QuickLinks.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/QuickLinks.test.ts
@@ -12,7 +12,7 @@ describe("QuickLinks", () => {
             contextModule
             ownerType
             ... on HomeViewSectionNavigationPills {
-              quickLinks {
+              navigationPills {
                 title
                 href
                 ownerType
@@ -34,8 +34,7 @@ describe("QuickLinks", () => {
         "__typename": "HomeViewSectionNavigationPills",
         "contextModule": "quickLinks",
         "internalID": "home-view-section-quick-links",
-        "ownerType": "quickLinks",
-        "quickLinks": [
+        "navigationPills": [
           {
             "href": "/favorites",
             "ownerType": "follows",
@@ -67,6 +66,7 @@ describe("QuickLinks", () => {
             "title": "Editorial",
           },
         ],
+        "ownerType": "quickLinks",
       }
     `)
   })


### PR DESCRIPTION
To elaborate on my comments in https://github.com/artsy/metaphysics/pull/6354 I'm showing what I mean by separating the concepts of section instance and section type.

Just as…
- the `Artists` section type exposes a list of `artists`
-  the `Cards` section type exposes a list of `cards`

I propose that…
- `NavigationPills` section type exposes a list of `navigationPills`

This decouples the `NavigationPills` naming from the specific instance that makes use of this section type (`QuickLinks`). 

Just like the `Cards` naming is decoupled from the specific instances of `DiscoverSomethingNew` and `ExploreByCategory`.

(This may end up being a lot of fuss for nothing if `NavigationPills` never enjoys any re-use, but I still think this is the right default mindset for naming in the home view)