### PR TITLE
chore: add artwork framed dimensions and weight.

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2439,7 +2439,9 @@ type Artwork implements Node & Searchable & Sellable {
 
   # The depth as expressed by the original input metric
   depth: String
+  depthCm: Float
   description(format: Format): String
+  diameterCm: Float
   dimensions: dimensions
   displayArtistBio: Boolean
   displayLabel: String
@@ -2474,7 +2476,10 @@ type Artwork implements Node & Searchable & Sellable {
   framed: ArtworkInfoRow
     @deprecated(reason: "Consider using isFramed field (boolean) instead")
   framedDepth: String
+  framedDiameter: Float
   framedHeight: String
+
+  # The unit of measurement for the framed dimensions
   framedMetric: String
   framedWidth: String
 
@@ -2697,6 +2702,10 @@ type Artwork implements Node & Searchable & Sellable {
 
   # Minimal location information describing from where artwork will be shipped.
   shippingOrigin: String
+  shippingWeight: Float
+
+  # The unit of measurement for the shipping weight
+  shippingWeightMetric: String
 
   # Is this work available for shipping only within the Continental US?
   shipsToContinentalUSOnly: Boolean

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -5502,4 +5502,92 @@ describe("Artwork type", () => {
       })
     })
   })
+
+  describe("shippingWeight and shippingWeightMetric", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          shippingWeight
+          shippingWeightMetric
+        }
+      }
+    `
+    it("returns the artwork shipping weight and metric", async () => {
+      artwork.shipping_weight = 10
+      artwork.shipping_weight_metric = "kg"
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          shippingWeight: 10,
+          shippingWeightMetric: "kg",
+        },
+      })
+    })
+  })
+
+  describe("framed height/width/depth/diameter/metric", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          framedHeight
+          framedWidth
+          framedDepth
+          framedDiameter
+          framedMetric
+        }
+      }
+    `
+    it("returns the artwork framed dimensions", async () => {
+      artwork.framed_height = 10
+      artwork.framed_width = 20
+      artwork.framed_depth = 30
+      artwork.framed_diameter = 40
+      artwork.framed_metric = "cm"
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          framedHeight: "10",
+          framedWidth: "20",
+          framedDepth: "30",
+          framedDiameter: 40,
+          framedMetric: "cm",
+        },
+      })
+    })
+  })
+
+  describe("unframed height/width/depth/diameter in cm", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          heightCm
+          widthCm
+          depthCm
+          diameterCm
+        }
+      }
+    `
+
+    it("returns the artwork dimensions in cm", async () => {
+      artwork.height_cm = 10
+      artwork.width_cm = 20
+      artwork.depth_cm = 30
+      artwork.diameter_cm = 40
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          heightCm: 10,
+          widthCm: 20,
+          depthCm: 30,
+          diameterCm: 40,
+        },
+      })
+    })
+  })
 })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -545,7 +545,15 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         description: "The depth as expressed by the original input metric",
         type: GraphQLString,
       },
+      depthCm: {
+        type: GraphQLFloat,
+        resolve: ({ depth_cm }) => depth_cm,
+      },
       description: markdown(({ blurb }) => blurb),
+      diameterCm: {
+        type: GraphQLFloat,
+        resolve: ({ diameter_cm }) => diameter_cm,
+      },
       dimensions: Dimensions,
       dominantColors: {
         type: new GraphQLNonNull(
@@ -1322,6 +1330,15 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ artsy_shipping_international }) =>
           artsy_shipping_international,
       },
+      shippingWeight: {
+        type: GraphQLFloat,
+        resolve: ({ shipping_weight }) => shipping_weight,
+      },
+      shippingWeightMetric: {
+        type: GraphQLString,
+        description: "The unit of measurement for the shipping weight",
+        resolve: ({ shipping_weight_metric }) => shipping_weight_metric,
+      },
       processWithArtsyShippingDomestic: {
         type: GraphQLBoolean,
         description:
@@ -1816,11 +1833,16 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       },
       framedMetric: {
         type: GraphQLString,
+        description: "The unit of measurement for the framed dimensions",
         resolve: ({ framed_metric }) => framed_metric,
       },
       framedWidth: {
         type: GraphQLString,
         resolve: ({ framed_width }) => framed_width,
+      },
+      framedDiameter: {
+        type: GraphQLFloat,
+        resolve: ({ framed_diameter }) => framed_diameter,
       },
       signatureInfo: {
         type: ArtworkInfoRowType,
@@ -1877,6 +1899,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           }
         },
       },
+
       hasCertificateOfAuthenticity: {
         type: GraphQLBoolean,
         description:


### PR DESCRIPTION
The type of this pr is **chore**
Part of [EMI-2278]

This PR adds the following properties to our artwork type for use in our client-side shipping estimates widget:
`depthCm, diameterCm, shippingWeight, shippingWeightMetric, framedDiameter`

It depends on artsy/gravity#18560 for some of the fields.

Some related adjacent fields (like `framedHeight` and `framedWidth` are typed as GraphQL strings instead of floats. I'd argue we should convert these, which would be a breaking schema change, or re-implement these fields to follow the `_Cm` naming convention of our non-framed dimensions fields.

[EMI-2278]: https://artsyproduct.atlassian.net/browse/EMI-2278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ