### PR TITLE
feat: add schema for ArtworkImport and a createArtworkImport mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2907,6 +2907,51 @@ union ArtworkFilterFacet = Gene | Tag
 
 union ArtworkHighlight = Article | Show
 
+type ArtworkImport {
+  fileName: String!
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+  rowsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkImportRowConnection
+}
+
+type ArtworkImportRow {
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+  rawData: JSON!
+}
+
+# A connection to a list of items.
+type ArtworkImportRowConnection {
+  # A list of edges.
+  edges: [ArtworkImportRowEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type ArtworkImportRowEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: ArtworkImportRow
+}
+
 enum ArtworkImportSource {
   CONVECTION
   MY_COLLECTION
@@ -8099,6 +8144,29 @@ type CreateArtistSuccess {
 }
 
 union CreateArtistSuccessOrErrorType = CreateArtistFailure | CreateArtistSuccess
+
+type CreateArtworkImportFailure {
+  mutationError: GravityMutationError
+}
+
+input CreateArtworkImportInput {
+  clientMutationId: String
+  filePath: String!
+  partnerID: String!
+}
+
+type CreateArtworkImportPayload {
+  artworkImportOrError: CreateArtworkImportResponseOrError
+  clientMutationId: String
+}
+
+union CreateArtworkImportResponseOrError =
+    CreateArtworkImportFailure
+  | CreateArtworkImportSuccess
+
+type CreateArtworkImportSuccess {
+  artworkImport: ArtworkImport
+}
 
 input CreateBackupSecondFactorsInput {
   clientMutationId: String
@@ -13848,6 +13916,9 @@ type Mutation {
 
   # Create an artist
   createArtist(input: CreateArtistMutationInput!): CreateArtistMutationPayload
+  createArtworkImport(
+    input: CreateArtworkImportInput!
+  ): CreateArtworkImportPayload
   createBackupSecondFactors(
     input: CreateBackupSecondFactorsInput!
   ): CreateBackupSecondFactorsPayload
@@ -16628,6 +16699,7 @@ type Query {
 
   # List of all artwork attribution classes
   artworkAttributionClasses: [AttributionClass]
+  artworkImport(id: String!): ArtworkImport
 
   # List of all artwork mediums
   artworkMediums: [ArtworkMedium]
@@ -21438,6 +21510,7 @@ type Viewer {
 
   # List of all artwork attribution classes
   artworkAttributionClasses: [AttributionClass]
+  artworkImport(id: String!): ArtworkImport
 
   # List of all artwork mediums
   artworkMediums: [ArtworkMedium]

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -26,6 +26,12 @@ export default (accessToken, userID, opts) => {
       { headers: true }
     ),
     artworkLoader: gravityLoader((id) => `artwork/${id}`),
+    artworkImportLoader: gravityLoader((id) => `artwork_import/${id}`),
+    artworkImportRowsLoader: gravityLoader(
+      (id) => `artwork_import/${id}/rows`,
+      {},
+      { headers: true }
+    ),
     artworksCollectionsBatchUpdateLoader: gravityLoader(
       "artworks/collections/batch",
       {},
@@ -70,6 +76,11 @@ export default (accessToken, userID, opts) => {
     createArtistLoader: gravityLoader("artist", {}, { method: "POST" }),
     createArtistCareerHighlightLoader: gravityLoader(
       "artist_career_highlight",
+      {},
+      { method: "POST" }
+    ),
+    createArtworkImportLoader: gravityLoader(
+      "artwork_import",
       {},
       { method: "POST" }
     ),

--- a/src/schema/v2/ArtworkImport/__tests__/artworkImport.test.ts
+++ b/src/schema/v2/ArtworkImport/__tests__/artworkImport.test.ts
@@ -1,0 +1,87 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("ArtworkImport", () => {
+  it("fetches an artwork import by id", async () => {
+    const artworkImportLoader = jest.fn().mockReturnValue({
+      id: "artwork-import-1",
+      file_name: "import.csv",
+    })
+
+    const query = gql`
+      query {
+        artworkImport(id: "artwork-import-1") {
+          internalID
+          fileName
+        }
+      }
+    `
+
+    const context = { artworkImportLoader }
+    const result = await runAuthenticatedQuery(query, context)
+
+    expect(artworkImportLoader).toHaveBeenCalledWith("artwork-import-1")
+    expect(result).toEqual({
+      artworkImport: {
+        internalID: "artwork-import-1",
+        fileName: "import.csv",
+      },
+    })
+  })
+
+  it("fetches rowsConnection with pagination", async () => {
+    const artworkImportLoader = jest.fn().mockReturnValue({
+      id: "artwork-import-1",
+      file_name: "import.csv",
+    })
+
+    const artworkImportRowsLoader = jest.fn().mockResolvedValue({
+      body: [
+        { id: "row1", raw_data: { foo: "bar" } },
+        { id: "row2", raw_data: { foo: "baz" } },
+      ],
+      headers: { "x-total-count": "2" },
+    })
+
+    const query = gql`
+      query {
+        artworkImport(id: "artwork-import-1") {
+          internalID
+          fileName
+          rowsConnection(first: 10) {
+            totalCount
+            edges {
+              node {
+                internalID
+                rawData
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const context = { artworkImportLoader, artworkImportRowsLoader }
+    const result = await runAuthenticatedQuery(query, context)
+
+    expect(artworkImportRowsLoader).toHaveBeenCalledWith(
+      "artwork-import-1",
+      expect.objectContaining({
+        size: 10,
+        offset: 0,
+        total_count: true,
+      })
+    )
+
+    expect(result.artworkImport.rowsConnection.totalCount).toBe(2)
+    expect(result.artworkImport.rowsConnection.edges).toHaveLength(2)
+    expect(result.artworkImport.rowsConnection.edges[0].node).toEqual({
+      internalID: "row1",
+      rawData: { foo: "bar" },
+    })
+    expect(result.artworkImport.rowsConnection.edges[1].node).toEqual({
+      internalID: "row2",
+      rawData: { foo: "baz" },
+    })
+  })
+})

--- a/src/schema/v2/ArtworkImport/__tests__/creatArtworkImportMutation.test.ts
+++ b/src/schema/v2/ArtworkImport/__tests__/creatArtworkImportMutation.test.ts
@@ -1,0 +1,47 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("CreateArtworkImportMutation", () => {
+  it("creates an artwork import successfully", async () => {
+    const createArtworkImportLoader = jest.fn().mockResolvedValue({
+      id: "artwork-import-1",
+      file_name: "import.csv",
+    })
+
+    const mutation = gql`
+      mutation {
+        createArtworkImport(
+          input: { partnerID: "partner-1", filePath: "/some/path/file.csv" }
+        ) {
+          artworkImportOrError {
+            ... on CreateArtworkImportSuccess {
+              artworkImport {
+                internalID
+                fileName
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const context = { createArtworkImportLoader }
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(createArtworkImportLoader).toHaveBeenCalledWith({
+      partner_id: "partner-1",
+      file_path: "/some/path/file.csv",
+    })
+
+    expect(result).toEqual({
+      createArtworkImport: {
+        artworkImportOrError: {
+          artworkImport: {
+            internalID: "artwork-import-1",
+            fileName: "import.csv",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -1,0 +1,78 @@
+import {
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLFieldConfig,
+} from "graphql"
+import { InternalIDFields } from "../object_identification"
+import { ResolverContext } from "types/graphql"
+import {
+  connectionWithCursorInfo,
+  paginationResolver,
+} from "../fields/pagination"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { pageable } from "relay-cursor-paging"
+import GraphQLJSON from "graphql-type-json"
+
+const ArtworkImportRowType = new GraphQLObjectType({
+  name: "ArtworkImportRow",
+  fields: {
+    ...InternalIDFields,
+    rawData: {
+      type: new GraphQLNonNull(GraphQLJSON),
+      resolve: ({ raw_data }) => raw_data,
+    },
+  },
+})
+
+const ArtworkImportRowConnectionType = connectionWithCursorInfo({
+  nodeType: ArtworkImportRowType,
+}).connectionType
+
+export const ArtworkImportType = new GraphQLObjectType({
+  name: "ArtworkImport",
+  fields: {
+    ...InternalIDFields,
+    fileName: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ file_name }) => file_name,
+    },
+    rowsConnection: {
+      type: ArtworkImportRowConnectionType,
+      args: pageable(),
+      resolve: async ({ id }, args, { artworkImportRowsLoader }) => {
+        const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+        const { body, headers } = await artworkImportRowsLoader(id, {
+          size,
+          offset,
+          total_count: true,
+        })
+
+        const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+        return paginationResolver({
+          totalCount,
+          offset,
+          page,
+          size,
+          body,
+          args,
+        })
+      },
+    },
+  },
+})
+
+export const ArtworkImport: GraphQLFieldConfig<any, ResolverContext> = {
+  type: ArtworkImportType,
+  args: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+  },
+  resolve: (_parent, { id }, { artworkImportLoader }) => {
+    if (!artworkImportLoader) return null
+
+    return artworkImportLoader(id)
+  },
+}

--- a/src/schema/v2/ArtworkImport/createArtworkImportMutation.ts
+++ b/src/schema/v2/ArtworkImport/createArtworkImportMutation.ts
@@ -1,0 +1,84 @@
+import {
+  GraphQLString,
+  GraphQLObjectType,
+  GraphQLUnionType,
+  GraphQLNonNull,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ArtworkImportType } from "./artworkImport"
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreateArtworkImportSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    artworkImport: {
+      type: ArtworkImportType,
+      resolve: (result) => result,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreateArtworkImportFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "CreateArtworkImportResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const CreateArtworkImportMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "CreateArtworkImport",
+  inputFields: {
+    partnerID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    filePath: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+  },
+  outputFields: {
+    artworkImportOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (args, { createArtworkImportLoader }) => {
+    if (!createArtworkImportLoader) {
+      throw new Error("This operation requires an `X-Access-Token` header.")
+    }
+
+    const gravityArgs = {
+      partner_id: args.partnerID,
+      file_path: args.filePath,
+    }
+
+    try {
+      const result = await createArtworkImportLoader(gravityArgs)
+      return result
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -267,6 +267,8 @@ import { updateViewingRoomSubsectionsMutation } from "./viewingRooms/mutations/u
 import { ViewingRoomConnection } from "./viewingRooms"
 import { seoExperimentArtists } from "schema/v2/seoExperimentArtists"
 import { Collection } from "./collection"
+import { CreateArtworkImportMutation } from "./ArtworkImport/createArtworkImportMutation"
+import { ArtworkImport } from "./ArtworkImport/artworkImport"
 
 const viewingRoomUnstitchedRootField = config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA
   ? {
@@ -318,6 +320,7 @@ const rootFields = {
   artwork: Artwork,
   artworkAttributionClasses: ArtworkAttributionClasses,
   artworkMediums: ArtworkMediums,
+  artworkImport: ArtworkImport,
   artworkResult: ArtworkResult,
   artworks: Artworks,
   artworksConnection: filterArtworksConnection(),
@@ -441,6 +444,7 @@ export default new GraphQLSchema({
       commerceOptInReport: commerceOptInReportMutation,
       createAccountRequest: createAccountRequestMutation,
       createAlert: createAlertMutation,
+      createArtworkImport: CreateArtworkImportMutation,
       createInvoicePayment: createInvoicePaymentMutation,
       createVerifiedRepresentative: createVerifiedRepresentativeMutation,
       deleteVerifiedRepresentative: deleteVerifiedRepresentativeMutation,


### PR DESCRIPTION
Adds a pretty light/boilerplate-ish schema for an artwork import - as well as creating an artwork import after a CSV upload.

Looks like-

![Screenshot 2025-02-06 at 3 45 12 PM](https://github.com/user-attachments/assets/f9fc5646-f381-449b-a897-0f268a6fdad3)
