### PR TITLE
feat(home view): add icons to navigation pills

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14704,6 +14704,9 @@ type NavigationPill {
   # Link URL
   href: String!
 
+  # Icon file name
+  icon: String
+
   # The context module for analytics
   ownerType: String!
 

--- a/src/schema/v2/homeView/sectionTypes/NavigationPills.ts
+++ b/src/schema/v2/homeView/sectionTypes/NavigationPills.ts
@@ -15,6 +15,7 @@ export interface NavigationPill {
   title: string
   href: string
   ownerType: OwnerType
+  icon?: string
 }
 
 const NavigationPillType = new GraphQLObjectType<
@@ -34,6 +35,10 @@ const NavigationPillType = new GraphQLObjectType<
     ownerType: {
       type: new GraphQLNonNull(GraphQLString),
       description: "The context module for analytics",
+    },
+    icon: {
+      type: GraphQLString,
+      description: "Icon file name",
     },
   }),
 })

--- a/src/schema/v2/homeView/sections/QuickLinks.ts
+++ b/src/schema/v2/homeView/sections/QuickLinks.ts
@@ -15,9 +15,24 @@ export const QuickLinks: HomeViewSection = {
 }
 
 const QUICK_LINKS: Array<NavigationPill> = [
-  { title: "Follows", href: "/favorites", ownerType: OwnerType.follows },
-  { title: "Auctions", href: "/auctions", ownerType: OwnerType.auctions },
-  { title: "Saves", href: "/favorites/saves", ownerType: OwnerType.saves },
+  {
+    title: "Follows",
+    href: "/favorites",
+    ownerType: OwnerType.follows,
+    icon: "FollowArtistIcon",
+  },
+  {
+    title: "Auctions",
+    href: "/auctions",
+    ownerType: OwnerType.auctions,
+    icon: "AuctionIcon",
+  },
+  {
+    title: "Saves",
+    href: "/favorites/saves",
+    ownerType: OwnerType.saves,
+    icon: "HeartIcon",
+  },
   {
     title: "Art under $1000",
     href: "/collect?price_range=%2A-1000",
@@ -28,5 +43,9 @@ const QUICK_LINKS: Array<NavigationPill> = [
     href: "/price-database",
     ownerType: OwnerType.priceDatabase,
   },
-  { title: "Editorial", href: "/news", ownerType: OwnerType.articles },
+  {
+    title: "Editorial",
+    href: "/news",
+    ownerType: OwnerType.articles,
+  },
 ]

--- a/src/schema/v2/homeView/sections/__tests__/QuickLinks.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/QuickLinks.test.ts
@@ -14,6 +14,7 @@ describe("QuickLinks", () => {
             ... on HomeViewSectionNavigationPills {
               navigationPills {
                 title
+                icon
                 href
                 ownerType
               }
@@ -37,31 +38,37 @@ describe("QuickLinks", () => {
         "navigationPills": [
           {
             "href": "/favorites",
+            "icon": "FollowArtistIcon",
             "ownerType": "follows",
             "title": "Follows",
           },
           {
             "href": "/auctions",
+            "icon": "AuctionIcon",
             "ownerType": "auctions",
             "title": "Auctions",
           },
           {
             "href": "/favorites/saves",
+            "icon": "HeartIcon",
             "ownerType": "saves",
             "title": "Saves",
           },
           {
             "href": "/collect?price_range=%2A-1000",
+            "icon": null,
             "ownerType": "collect",
             "title": "Art under $1000",
           },
           {
             "href": "/price-database",
+            "icon": null,
             "ownerType": "priceDatabase",
             "title": "Price Database",
           },
           {
             "href": "/news",
+            "icon": null,
             "ownerType": "articles",
             "title": "Editorial",
           },


### PR DESCRIPTION
> [!note]
> Required by https://github.com/artsy/eigen/pull/11528

https://artsyproduct.atlassian.net/browse/ONYX-1484

Adds an optional `icon` to the `NavigationPill` section type, which is used by the new `QuickLinks` section:

```graphql
{
  homeView {
    section(id: "home-view-section-quick-links") {
      internalID
      __typename
      
      ... on HomeViewSectionNavigationPills {
        navigationPills {
          href
          ownerType
          title
          icon            # 👈🏽 👈🏽 new
        }
      }
    }
  }
}
```

```json
{
  "data": {
    "homeView": {
      "section": {
        "internalID": "home-view-section-quick-links",
        "__typename": "HomeViewSectionNavigationPills",
        "navigationPills": [
          {
            "href": "/favorites",
            "ownerType": "follows",
            "title": "Follows",
            "icon": "FollowArtistIcon" // 👈🏽 👈🏽 icon name included in response, if it is defined
          },
          {
            "href": "/auctions",
            "ownerType": "auctions",
            "title": "Auctions",
            "icon": "AuctionIcon"
          },
          {
            "href": "/favorites/saves",
            "ownerType": "saves",
            "title": "Saves",
            "icon": "HeartIcon"
          },
          {
            "href": "/collect?price_range=%2A-1000",
            "ownerType": "collect",
            "title": "Art under $1000",
            "icon": null               // 👈🏽 👈🏽 else it is null
          },
          {
            "href": "/price-database",
            "ownerType": "priceDatabase",
            "title": "Price Database",
            "icon": null
          },
          {
            "href": "/news",
            "ownerType": "articles",
            "title": "Editorial",
            "icon": null
          }
        ]
      }
    }
  }
```