### PR TITLE
chore: support NodeInterface/refetching on ArtworkImport

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2907,7 +2907,7 @@ union ArtworkFilterFacet = Gene | Tag
 
 union ArtworkHighlight = Article | Show
 
-type ArtworkImport {
+type ArtworkImport implements Node {
   fileName: String!
 
   # A globally unique ID.

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -6,7 +6,7 @@ import {
   GraphQLBoolean,
   GraphQLList,
 } from "graphql"
-import { InternalIDFields } from "../object_identification"
+import { InternalIDFields, NodeInterface } from "../object_identification"
 import { ResolverContext } from "types/graphql"
 import {
   connectionWithCursorInfo,
@@ -59,6 +59,7 @@ const ArtworkImportRowConnectionType = connectionWithCursorInfo({
 
 export const ArtworkImportType = new GraphQLObjectType({
   name: "ArtworkImport",
+  interfaces: [NodeInterface],
   fields: {
     ...InternalIDFields,
     fileName: {

--- a/src/schema/v2/object_identification.ts
+++ b/src/schema/v2/object_identification.ts
@@ -58,6 +58,7 @@ const SupportedTypes: any = {
     "./sale_artwork",
     "./user",
     "./homeView/index",
+    "./ArtworkImport/artworkImport",
   ],
 }
 
@@ -69,6 +70,7 @@ const typeNames = {
 const exportNames = {
   filterArtworksConnection: "filterArtworksConnection",
   HomeViewSection: "Section",
+  ArtworkImport: "ArtworkImport",
 }
 
 SupportedTypes.typeMap = SupportedTypes.files.reduce((typeMap, file) => {


### PR DESCRIPTION
In order to 'refetch' on an import (for presenting + paginating thru the rows of an import) - have to do this little dance.