### PR TITLE
chore: Allow artworks to be updated in bulk (Batch Edits)

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4149,6 +4149,11 @@ type BidderPositionSuggestedNextBid {
 # exceed the size of a 32-bit integer, it's encoded as a string.
 scalar BigInt
 
+input BulkUpdatePartnerArtworksMetadataInput {
+  # The partner location ID to assign
+  locationId: String
+}
+
 type BulkUpdatePartnerArtworksMutationFailure {
   mutationError: GravityMutationError
 }
@@ -4164,8 +4169,8 @@ input BulkUpdatePartnerArtworksMutationInput {
   # ID of the partner
   id: String!
 
-  # The partner location ID to assign
-  location: String
+  # Metadata to be updated
+  metadata: BulkUpdatePartnerArtworksMetadataInput
 }
 
 type BulkUpdatePartnerArtworksMutationPayload {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4149,9 +4149,42 @@ type BidderPositionSuggestedNextBid {
 # exceed the size of a 32-bit integer, it's encoded as a string.
 scalar BigInt
 
-input BulkUpdatePartnerArtworksMetadataInput {
+input BulkUpdateArtworksMetadataInput {
   # The partner location ID to assign
   location_id: String
+}
+
+type BulkUpdateArtworksMetadataMutationFailure {
+  mutationError: GravityMutationError
+}
+
+input BulkUpdateArtworksMetadataMutationInput {
+  clientMutationId: String
+
+  # ID of the partner
+  id: String!
+
+  # Metadata to be updated
+  metadata: BulkUpdateArtworksMetadataInput
+}
+
+type BulkUpdateArtworksMetadataMutationPayload {
+  bulkUpdateArtworksMetadataOrError: BulkUpdateArtworksMetadataMutationType
+  clientMutationId: String
+}
+
+type BulkUpdateArtworksMetadataMutationSuccess {
+  skippedPartnerArtworks: BulkUpdateArtworksMetadataResponse
+  updatedPartnerArtworks: BulkUpdateArtworksMetadataResponse
+}
+
+union BulkUpdateArtworksMetadataMutationType =
+    BulkUpdateArtworksMetadataMutationFailure
+  | BulkUpdateArtworksMetadataMutationSuccess
+
+type BulkUpdateArtworksMetadataResponse {
+  count: Int
+  ids: [String]
 }
 
 type BulkUpdatePartnerArtworksMutationFailure {
@@ -4168,9 +4201,6 @@ input BulkUpdatePartnerArtworksMutationInput {
 
   # ID of the partner
   id: String!
-
-  # Metadata to be updated
-  metadata: BulkUpdatePartnerArtworksMetadataInput
 }
 
 type BulkUpdatePartnerArtworksMutationPayload {
@@ -13873,6 +13903,11 @@ type Mutation {
   assignArtworkImportArtist(
     input: AssignArtworkImportArtistInput!
   ): AssignArtworkImportArtistPayload
+
+  # Update all artworks that belong to the partner
+  bulkUpdateArtworksMetadata(
+    input: BulkUpdateArtworksMetadataMutationInput!
+  ): BulkUpdateArtworksMetadataMutationPayload
 
   # Update all artworks that belong to the partner
   bulkUpdatePartnerArtworks(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4151,7 +4151,7 @@ scalar BigInt
 
 input BulkUpdatePartnerArtworksMetadataInput {
   # The partner location ID to assign
-  locationId: String
+  location_id: String
 }
 
 type BulkUpdatePartnerArtworksMutationFailure {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -990,6 +990,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" }
     ),
+    updatePartnerArtworksMetadataLoader: gravityLoader(
+      (id) => `partner/${id}/bulk_operations/update_metadata`,
+      {},
+      { method: "PUT" }
+    ),
     updatePartnerShowLoader: gravityLoader<
       any,
       { partnerId: string; showId: string }

--- a/src/schema/v2/bulkUpdatePartnerArtworksMutation.ts
+++ b/src/schema/v2/bulkUpdatePartnerArtworksMutation.ts
@@ -1,5 +1,6 @@
 import {
   GraphQLBoolean,
+  GraphQLInputObjectType,
   GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
@@ -16,10 +17,22 @@ import { GraphQLUnionType } from "graphql"
 
 interface Input {
   id: string
+  // these to be migrated out soon by Jackie
   artsyShippingDomestic: boolean | null
   artsyShippingInternational: boolean | null
-  locationId: string | null
+  // ---------------------
+  metadata: { locationId: string | null } | null
 }
+
+const BulkUpdatePartnerArtworksMetadataInput = new GraphQLInputObjectType({
+  name: "BulkUpdatePartnerArtworksMetadataInput",
+  fields: {
+    locationId: {
+      type: GraphQLString,
+      description: "The partner location ID to assign",
+    },
+  },
+})
 
 const BulkUpdatePartnerArtworksResponseType = new GraphQLObjectType<
   any,
@@ -93,9 +106,9 @@ export const bulkUpdatePartnerArtworksMutation = mutationWithClientMutationId<
       type: GraphQLBoolean,
       description: "Whether Artsy international shipping should be enabled",
     },
-    locationId: {
-      type: GraphQLString,
-      description: "The partner location ID to assign",
+    metadata: {
+      type: BulkUpdatePartnerArtworksMetadataInput,
+      description: "Metadata to be updated",
     },
   },
   outputFields: {
@@ -114,13 +127,13 @@ export const bulkUpdatePartnerArtworksMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    { id, artsyShippingDomestic, artsyShippingInternational, locationId },
+    { id, artsyShippingDomestic, artsyShippingInternational, metadata },
     { updatePartnerArtworksLoader }
   ) => {
     const gravityOptions = {
       artsy_shipping_domestic: artsyShippingDomestic,
       artsy_shipping_international: artsyShippingInternational,
-      location_id: locationId,
+      metadata: metadata,
     }
 
     if (!updatePartnerArtworksLoader) {

--- a/src/schema/v2/bulkUpdatePartnerArtworksMutation.ts
+++ b/src/schema/v2/bulkUpdatePartnerArtworksMutation.ts
@@ -21,13 +21,13 @@ interface Input {
   artsyShippingDomestic: boolean | null
   artsyShippingInternational: boolean | null
   // ---------------------
-  metadata: { locationId: string | null } | null
+  metadata: { location_id: string | null } | null
 }
 
 const BulkUpdatePartnerArtworksMetadataInput = new GraphQLInputObjectType({
   name: "BulkUpdatePartnerArtworksMetadataInput",
   fields: {
-    locationId: {
+    location_id: {
       type: GraphQLString,
       description: "The partner location ID to assign",
     },

--- a/src/schema/v2/bulkUpdatePartnerArtworksMutation.ts
+++ b/src/schema/v2/bulkUpdatePartnerArtworksMutation.ts
@@ -18,7 +18,7 @@ interface Input {
   id: string
   artsyShippingDomestic: boolean | null
   artsyShippingInternational: boolean | null
-  location: string | null
+  locationId: string | null
 }
 
 const BulkUpdatePartnerArtworksResponseType = new GraphQLObjectType<
@@ -93,7 +93,7 @@ export const bulkUpdatePartnerArtworksMutation = mutationWithClientMutationId<
       type: GraphQLBoolean,
       description: "Whether Artsy international shipping should be enabled",
     },
-    location: {
+    locationId: {
       type: GraphQLString,
       description: "The partner location ID to assign",
     },
@@ -114,13 +114,13 @@ export const bulkUpdatePartnerArtworksMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    { id, artsyShippingDomestic, artsyShippingInternational, location },
+    { id, artsyShippingDomestic, artsyShippingInternational, locationId },
     { updatePartnerArtworksLoader }
   ) => {
     const gravityOptions = {
       artsy_shipping_domestic: artsyShippingDomestic,
       artsy_shipping_international: artsyShippingInternational,
-      location,
+      location_id: locationId,
     }
 
     if (!updatePartnerArtworksLoader) {

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -144,6 +144,7 @@ import { updateArtworkMutation } from "./artwork/updateArtworkMutation"
 import { artworksForUser } from "./artworksForUser"
 import { authenticationStatus } from "./authenticationStatus"
 import { BankAccount } from "./bank_account"
+import { bulkUpdateArtworksMetadataMutation } from "./partner/BulkOperation/bulkUpdateArtworksMetadataMutation"
 import { bulkUpdatePartnerArtworksMutation } from "./bulkUpdatePartnerArtworksMutation"
 import { CollectorProfileForUser } from "./CollectorProfile/collectorProfile"
 import { CollectorProfilesConnection } from "./CollectorProfile/collectorProfiles"
@@ -445,6 +446,7 @@ export default new GraphQLSchema({
       adminUpdateFeatureFlag: updateFeatureFlagMutation,
       artworksCollectionsBatchUpdate: artworksCollectionsBatchUpdateMutation,
       assignArtworkImportArtist: AssignArtworkImportArtistMutation,
+      bulkUpdateArtworksMetadata: bulkUpdateArtworksMetadataMutation,
       bulkUpdatePartnerArtworks: bulkUpdatePartnerArtworksMutation,
       commerceOptIn: commerceOptInMutation,
       commerceOptInReport: commerceOptInReportMutation,


### PR DESCRIPTION
[AMBER-1272]

Pairing with @jpotts244

Kick-off the MP mutation for triggering Bulk Update operations (Batch Edits)

Example:
```graphql
mutation bulkUpdateArtworksMetadata(
  $id: String!
  $metadata: BulkUpdateArtworksMetadataInput!
) {
  bulkUpdateArtworksMetadata(
    input: {
      id: $id
      metadata: $metadata
    }
  ) {
    __typename
    bulkUpdateArtworksMetadataOrError {
    __typename
    ... on BulkUpdateArtworksMetadataMutationSuccess {
	updatedPartnerArtworks {
          ids
       }
     }
      ... on BulkUpdateArtworksMetadataMutationFailure {
        mutationError {
          message
        }
      }
    }
  }
}
```

Variables used on local tests:
```json
{
  "id": "almine-rech",
  "metadata": {
    "location_id": "67acd02ac4a53e0007b51cc0",
    "category": "foobar"
  }
}
```

_Intentionally using a random value for category given we have no validations for this field_

[AMBER-1272]: https://artsyproduct.atlassian.net/browse/AMBER-1272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ