### PR TITLE
feat(DIA-990): Switching out marketing collections in Discover Something New

### DIFF
--- a/src/schema/v2/homeView/sections/DiscoverSomethingNew.ts
+++ b/src/schema/v2/homeView/sections/DiscoverSomethingNew.ts
@@ -6,7 +6,7 @@ import { connectionFromArray } from "graphql-relay"
 const marketingCollectionSlugs = [
   "most-loved",
   "understated",
-  "curators-picks",
+  "art-gifts-under-1000-dollars",
   "transcendent",
   "best-bids",
   "statement-pieces",


### PR DESCRIPTION
Addresses [DIA-990] 

This PR removes the Curator's Pick collection which is now redundant, replacing it with "Art Under $1,000".

![Screenshot 2025-02-14 at 4 34 08 PM](https://github.com/user-attachments/assets/cacb72d7-1033-440a-bef1-0ae499aaeaab)

I also changed the collection category to "Price" instead of "The Artsy Gift Guide" to match the naming patterns in Discover Something New. 

[DIA-990]: https://artsyproduct.atlassian.net/browse/DIA-990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ