### PR TITLE
chore: add updateArtworkImportRow mutation (inline editing)

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14421,6 +14421,9 @@ type Mutation {
   updateArtwork(
     input: UpdateArtworkMutationInput!
   ): UpdateArtworkMutationPayload
+  updateArtworkImportRow(
+    input: UpdateArtworkImportRowInput!
+  ): UpdateArtworkImportRowPayload
 
   # Updates the flags on a partner.
   updateCMSLastAccessTimestamp(
@@ -20020,6 +20023,31 @@ union UpdateArtistResponseOrError = UpdateArtistFailure | UpdateArtistSuccess
 
 type UpdateArtistSuccess {
   artist: Artist
+}
+
+type UpdateArtworkImportRowFailure {
+  mutationError: GravityMutationError
+}
+
+input UpdateArtworkImportRowInput {
+  artworkImportID: String!
+  artworkImportRowID: String!
+  clientMutationId: String
+  fieldName: String!
+  fieldValue: String!
+}
+
+type UpdateArtworkImportRowPayload {
+  clientMutationId: String
+  updateArtworkImportRowOrError: UpdateArtworkImportRowResponseOrError
+}
+
+union UpdateArtworkImportRowResponseOrError =
+    UpdateArtworkImportRowFailure
+  | UpdateArtworkImportRowSuccess
+
+type UpdateArtworkImportRowSuccess {
+  success: Boolean!
 }
 
 input UpdateArtworkMutationInput {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -50,6 +50,11 @@ export default (accessToken, userID, opts) => {
     artworkImportUnmatchedArtistNamesLoader: gravityLoader(
       (id) => `artwork_import/${id}/unmatched_artist_names`
     ),
+    artworkImportUpdateRowLoader: gravityLoader(
+      (id) => `artwork_import/${id}/update_row`,
+      {},
+      { method: "PUT" }
+    ),
     artworksCollectionsBatchUpdateLoader: gravityLoader(
       "artworks/collections/batch",
       {},

--- a/src/schema/v2/ArtworkImport/__tests__/updateArtworkImportRowMutation.test.ts
+++ b/src/schema/v2/ArtworkImport/__tests__/updateArtworkImportRowMutation.test.ts
@@ -1,0 +1,51 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("UpdateArtworkImportRowMutation", () => {
+  it("updates a row", async () => {
+    const artworkImportUpdateRowLoader = jest.fn().mockResolvedValue({
+      id: "artwork-import-id",
+    })
+
+    const mutation = gql`
+      mutation {
+        updateArtworkImportRow(
+          input: {
+            artworkImportID: "artwork-import-1"
+            artworkImportRowID: "row-1"
+            fieldName: "ArtistNames"
+            fieldValue: "Andy Warhol"
+          }
+        ) {
+          updateArtworkImportRowOrError {
+            ... on UpdateArtworkImportRowSuccess {
+              success
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      artworkImportUpdateRowLoader,
+    }
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(artworkImportUpdateRowLoader).toHaveBeenCalledWith(
+      "artwork-import-1",
+      {
+        row_id: "row-1",
+        field_name: "ArtistNames",
+        field_value: "Andy Warhol",
+      }
+    )
+
+    expect(result).toEqual({
+      updateArtworkImportRow: {
+        updateArtworkImportRowOrError: {
+          success: true,
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/ArtworkImport/updateArtworkImportRowMutation.ts
+++ b/src/schema/v2/ArtworkImport/updateArtworkImportRowMutation.ts
@@ -1,0 +1,91 @@
+import {
+  GraphQLString,
+  GraphQLObjectType,
+  GraphQLUnionType,
+  GraphQLNonNull,
+  GraphQLBoolean,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateArtworkImportRowSuccess",
+  isTypeOf: (data) => !!data.id,
+  fields: () => ({
+    success: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      resolve: () => true,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateArtworkImportRowFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdateArtworkImportRowResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const UpdateArtworkImportRowMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "UpdateArtworkImportRow",
+  inputFields: {
+    artworkImportID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    artworkImportRowID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    fieldName: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    fieldValue: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+  },
+  outputFields: {
+    updateArtworkImportRowOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { artworkImportID, fieldName, fieldValue, artworkImportRowID },
+    { artworkImportUpdateRowLoader }
+  ) => {
+    if (!artworkImportUpdateRowLoader) {
+      throw new Error("This operation requires an `X-Access-Token` header.")
+    }
+
+    try {
+      return artworkImportUpdateRowLoader(artworkImportID, {
+        field_name: fieldName,
+        field_value: fieldValue,
+        row_id: artworkImportRowID,
+      })
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -272,6 +272,7 @@ import { ArtworkImport } from "./ArtworkImport/artworkImport"
 import { MatchArtworkImportArtistsMutation } from "./ArtworkImport/matchArtworkImportArtistsMutation"
 import { CreateArtworkImportArtworksMutation } from "./ArtworkImport/createArtworkImportArtworksMutation"
 import { AssignArtworkImportArtistMutation } from "./ArtworkImport/assignArtworkImportArtistMutation"
+import { UpdateArtworkImportRowMutation } from "./ArtworkImport/updateArtworkImportRowMutation"
 
 const viewingRoomUnstitchedRootField = config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA
   ? {
@@ -528,6 +529,7 @@ export default new GraphQLSchema({
       updateAlert: updateAlertMutation,
       updateArtist: updateArtistMutation,
       updateArtwork: updateArtworkMutation,
+      updateArtworkImportRow: UpdateArtworkImportRowMutation,
       updateCMSLastAccessTimestamp: updateCMSLastAccessTimestampMutation,
       updateCollection: updateCollectionMutation,
       updateMeCollectionsMutation: updateMeCollectionsMutation,


### PR DESCRIPTION
Adds a mutation that lets a field/value pair be updated for an artwork import row (inline editing).