### PR TITLE
feat(updateArtwork): Update mutation with new fields

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2659,6 +2659,7 @@ type Artwork implements Node & Searchable & Sellable {
   pickupAvailable: Boolean
   price: String
   priceCurrency: String
+  priceDisplay: String
   priceIncludesTax: Boolean
   priceIncludesTaxDisplay: String
   priceListed: Money
@@ -9533,6 +9534,7 @@ input EditableLocation {
 }
 
 type EditionSet implements Sellable {
+  availability: String
   dimensions: dimensions
   displayPriceRange: Boolean
   editionOf: String
@@ -9555,6 +9557,7 @@ type EditionSet implements Sellable {
   isSold: Boolean
   listPrice: ListPrice
   price: String
+  priceDisplay: String
   priceListed: Money
   saleMessage: String
 
@@ -20025,6 +20028,29 @@ type UpdateArtistSuccess {
   artist: Artist
 }
 
+input UpdateArtworkEditionSetInput {
+  # The availability of the artwork
+  availability: String
+
+  # Show/Hide the price range of an artwork
+  displayPriceRange: Boolean
+
+  # True for `Buy Now` artworks
+  ecommerce: Boolean
+
+  # The id of the artwork to update.
+  id: String!
+
+  # True for `Make Offer` artworks
+  offer: Boolean
+
+  # Show/Hide the price of an artwork
+  priceHidden: Boolean
+
+  # The price of the artwork
+  priceListed: String
+}
+
 type UpdateArtworkImportRowFailure {
   mutationError: GravityMutationError
 }
@@ -20055,8 +20081,26 @@ input UpdateArtworkMutationInput {
   availability: String
   clientMutationId: String
 
+  # Show/Hide the price range of an artwork
+  displayPriceRange: Boolean
+
+  # True for `Buy Now` artworks
+  ecommerce: Boolean
+
+  # A list of edition sets for the artwork
+  editionSets: [UpdateArtworkEditionSetInput]
+
   # The id of the artwork to update.
   id: String!
+
+  # True for `Make Offer` artworks
+  offer: Boolean
+
+  # Show/Hide the price of an artwork
+  priceHidden: Boolean
+
+  # The price of the artwork
+  priceListed: String
 }
 
 type UpdateArtworkMutationPayload {

--- a/src/schema/v2/artwork/__tests__/updateArtworkMutation.test.ts
+++ b/src/schema/v2/artwork/__tests__/updateArtworkMutation.test.ts
@@ -4,12 +4,27 @@ import { runAuthenticatedQuery } from "schema/v2/test/utils"
 describe("UpdateArtworkMutation", () => {
   const mutation = gql`
     mutation {
-      updateArtwork(input: { id: "25", availability: "sold" }) {
+      updateArtwork(
+        input: {
+          id: "25"
+          availability: "sold"
+          ecommerce: true
+          offer: true
+          priceListed: "1000"
+          priceHidden: false
+          displayPriceRange: false
+        }
+      ) {
         artworkOrError {
           __typename
           ... on updateArtworkSuccess {
             artwork {
               availability
+              isAcquireable
+              isOfferable
+              price
+              priceDisplay
+              displayPriceRange
             }
           }
           ... on updateArtworkFailure {
@@ -26,8 +41,13 @@ describe("UpdateArtworkMutation", () => {
     const context = {
       updateArtworkLoader: () =>
         Promise.resolve({
-          id: "foo",
+          id: "25",
           availability: "sold",
+          acquireable: true,
+          offerable: true,
+          price: "$1000",
+          price_display: "exact",
+          display_price_range: false,
         }),
     }
 
@@ -37,7 +57,14 @@ describe("UpdateArtworkMutation", () => {
       updateArtwork: {
         artworkOrError: {
           __typename: "updateArtworkSuccess",
-          artwork: { availability: "sold" },
+          artwork: {
+            availability: "sold",
+            isAcquireable: true,
+            isOfferable: true,
+            price: "$1000",
+            priceDisplay: "exact",
+            displayPriceRange: false,
+          },
         },
       },
     })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -865,6 +865,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLBoolean,
         resolve: ({ display_artist_bio }) => display_artist_bio,
       },
+
       displayPriceRange: {
         type: GraphQLBoolean,
         resolve: ({ display_price_range }) => display_price_range,
@@ -1292,6 +1293,10 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       priceCurrency: {
         type: GraphQLString,
         resolve: ({ price_currency }) => price_currency,
+      },
+      priceDisplay: {
+        type: GraphQLString,
+        resolve: ({ price_display }) => price_display,
       },
       priceIncludesTax: {
         type: GraphQLBoolean,

--- a/src/schema/v2/edition_set.ts
+++ b/src/schema/v2/edition_set.ts
@@ -31,6 +31,9 @@ export const EditionSetType = new GraphQLObjectType<any, ResolverContext>({
   interfaces: [Sellable],
   fields: {
     ...InternalIDFields,
+    availability: {
+      type: GraphQLString,
+    },
     dimensions: Dimensions,
     displayPriceRange: {
       type: GraphQLBoolean,
@@ -69,6 +72,10 @@ export const EditionSetType = new GraphQLObjectType<any, ResolverContext>({
     },
     price: {
       type: GraphQLString,
+    },
+    priceDisplay: {
+      type: GraphQLString,
+      resolve: ({ price_display }) => price_display,
     },
     priceListed: {
       type: Money,


### PR DESCRIPTION
This updates the `updateArtworkMutation` and exposes some additional gravity fields for the quick edit form:
- ecommerce: boolean
- displayPriceRange: boolean
- offer: boolean
- priceHidden: boolean
- priceListed: string

### Input
```json
{
  "input": {
    "id": "67af5d652ff989000fe339d3",
    "availability": "for sale",
    "ecommerce": false,
    "priceListed": "4100",
    "priceHidden": true,
    "displayPriceRange": false 
  }
}
```

### Query
```graphql
mutation foo($input: UpdateArtworkMutationInput!) {
  updateArtwork(input: $input) {
    artworkOrError {
      ... on updateArtworkSuccess {
        artwork {
          isAcquireable
          isOfferable
          availability
          price 
          priceDisplay 
          displayPriceRange
        }
      }
      ... on updateArtworkFailure {
        mutationError {
          error
        }
      }
    }
  }
}
```

(Might be some quick follow-up PRs after this related to edition sets but this should be good)