### PR TITLE
chore: add includeAllJSON argument to filterArtworks

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -293,6 +293,7 @@ type Alert {
     geneID: String
     geneIDs: [String]
     height: String
+    includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
     includeUnpublished: Boolean
@@ -1689,6 +1690,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     geneID: String
     geneIDs: [String]
     height: String
+    includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
     includeUnpublished: Boolean
@@ -2178,6 +2180,7 @@ type ArtistSeries implements Node {
     geneID: String
     geneIDs: [String]
     height: String
+    includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
     includeUnpublished: Boolean
@@ -9627,6 +9630,7 @@ interface EntityWithFilterArtworksConnectionInterface {
     geneID: String
     geneIDs: [String]
     height: String
+    includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
     includeUnpublished: Boolean
@@ -9880,6 +9884,7 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
     geneID: String
     geneIDs: [String]
     height: String
+    includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
     includeUnpublished: Boolean
@@ -10399,6 +10404,7 @@ input FilterArtworksInput {
   geneID: String
   geneIDs: [String]
   height: String
+  includeAllJSON: Boolean
   includeArtworksByFollowedArtists: Boolean
   includeMediumFilterInAggregation: Boolean
   includeUnpublished: Boolean
@@ -10864,6 +10870,7 @@ type Gene implements Node & Searchable {
     geneID: String
     geneIDs: [String]
     height: String
+    includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
     includeUnpublished: Boolean
@@ -12769,6 +12776,7 @@ type MarketingCollection implements Node {
     geneID: String
     geneIDs: [String]
     height: String
+    includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
     includeUnpublished: Boolean
@@ -15352,6 +15360,7 @@ type Partner implements Node {
     geneID: String
     geneIDs: [String]
     height: String
+    includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
     includeUnpublished: Boolean
@@ -16863,6 +16872,7 @@ type Query {
     geneID: String
     geneIDs: [String]
     height: String
+    includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
     includeUnpublished: Boolean
@@ -19221,6 +19231,7 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
     geneID: String
     geneIDs: [String]
     height: String
+    includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
     includeUnpublished: Boolean
@@ -19720,6 +19731,7 @@ type Tag implements Node {
     geneID: String
     geneIDs: [String]
     height: String
+    includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
     includeUnpublished: Boolean
@@ -21740,6 +21752,7 @@ type Viewer {
     geneID: String
     geneIDs: [String]
     height: String
+    includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
     includeUnpublished: Boolean

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -162,6 +162,9 @@ export const filterArtworksArgs: GraphQLFieldConfigArgumentMap = {
   height: {
     type: GraphQLString,
   },
+  includeAllJSON: {
+    type: GraphQLBoolean,
+  },
   includeArtworksByFollowedArtists: {
     type: GraphQLBoolean,
   },
@@ -443,6 +446,7 @@ const convertFilterArgs = ({
   forSale,
   geneID,
   geneIDs,
+  includeAllJSON,
   includeArtworksByFollowedArtists,
   includeMediumFilterInAggregation,
   includeUnpublished,
@@ -478,6 +482,7 @@ const convertFilterArgs = ({
     for_sale: forSale,
     gene_id: geneID,
     gene_ids: geneIDs,
+    include_all_json: includeAllJSON,
     include_artworks_by_followed_artists: includeArtworksByFollowedArtists,
     include_medium_filter_in_aggregation: includeMediumFilterInAggregation,
     include_unpublished: includeUnpublished,
@@ -532,6 +537,7 @@ const filterArtworksConnectionTypeFactory = (
       before,
       size,
       include_artworks_by_followed_artists,
+      include_all_json,
       visibility_level,
       aggregations: aggregationOptions = [],
     } = options
@@ -563,7 +569,8 @@ const filterArtworksConnectionTypeFactory = (
     const requestedAuthorizedFilters = !!(
       gravityOptions.include_unpublished ||
       include_artworks_by_followed_artists ||
-      visibility_level
+      visibility_level ||
+      include_all_json
     )
 
     // Support queries that show all mediums using the medium param.
@@ -586,6 +593,7 @@ const filterArtworksConnectionTypeFactory = (
         delete gravityOptions.include_artworks_by_followed_artists
         delete gravityOptions.include_unpublished
         delete gravityOptions.visibility_level
+        delete gravityOptions.include_json
         gravityOptions.aggregations = gravityOptions.aggregations.filter(
           (item) => item !== "followed_artists"
         )


### PR DESCRIPTION
Based on https://github.com/artsy/gravity/pull/18589 - this adds support for that argument as an input to the connection - as well as making sure the uncached data loader is used if this argument is specified.