### PR TITLE
chore: add artworkImportsConnection for a Partner

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2930,6 +2930,26 @@ type ArtworkImport implements Node {
   unmatchedArtistNames: [String!]!
 }
 
+# A connection to a list of items.
+type ArtworkImportConnection {
+  # A list of edges.
+  edges: [ArtworkImportEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type ArtworkImportEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: ArtworkImport
+}
+
 type ArtworkImportRow {
   artists: [Artist!]
   artwork: Artwork
@@ -15256,6 +15276,14 @@ type Partner implements Node {
     size: Int
     sort: ArtistAlertsSort
   ): ArtistsWithAlertCountsConnection
+
+  # A connection of artwork imports from a Partner.
+  artworkImportsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkImportConnection
 
   # A connection of artworks from a Partner.
   artworksConnection(

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -47,6 +47,11 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    artworkImportsLoader: gravityLoader(
+      "artwork_imports",
+      {},
+      { headers: true }
+    ),
     artworkImportUnmatchedArtistNamesLoader: gravityLoader(
       (id) => `artwork_import/${id}/unmatched_artist_names`
     ),

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -130,3 +130,7 @@ export const ArtworkImport: GraphQLFieldConfig<any, ResolverContext> = {
     return artworkImportLoader(id)
   },
 }
+
+export const ArtworkImportsConnectionType = connectionWithCursorInfo({
+  nodeType: ArtworkImportType,
+}).connectionType

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -211,6 +211,10 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       nodeType: AlertType,
     }).connectionType
 
+    const {
+      ArtworkImportsConnectionType,
+    } = require("schema/v2/ArtworkImport/artworkImport")
+
     return {
       ...SlugAndInternalIDFields,
       cached,
@@ -700,6 +704,35 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
               args,
             })
           }
+
+          return paginationResolver({
+            totalCount,
+            offset,
+            page,
+            size,
+            body,
+            args,
+          })
+        },
+      },
+      artworkImportsConnection: {
+        description: "A connection of artwork imports from a Partner.",
+        type: ArtworkImportsConnectionType,
+        args: pageable(),
+        resolve: async ({ id }, args, { artworkImportsLoader }) => {
+          if (!artworkImportsLoader) return null
+          const { page, size, offset } = convertConnectionArgsToGravityArgs(
+            args
+          )
+
+          const { body, headers } = await artworkImportsLoader({
+            page,
+            size,
+            total_count: true,
+            partner_id: id,
+          })
+
+          const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 
           return paginationResolver({
             totalCount,


### PR DESCRIPTION
Allows us to populate the imports listings page (show a partner their history of imports).