### PR TITLE
feat: support images for an artwork import row

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2953,10 +2953,11 @@ type ArtworkImportEdge {
 type ArtworkImportRow {
   artists: [Artist!]
   artwork: Artwork
-  errors: [ArtworkImportRowError!]
+  errors: [ArtworkImportRowError!]!
 
   # A globally unique ID.
   id: ID!
+  images: [ArtworkImportRowImage!]!
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
@@ -2992,6 +2993,18 @@ type ArtworkImportRowError {
   # A type-specific ID likely used as a database ID.
   internalID: ID!
   metadata: JSON
+}
+
+type ArtworkImportRowImage {
+  fileName: String!
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+  s3Bucket: String
+  s3Key: String
 }
 
 enum ArtworkImportSource {
@@ -12986,6 +12999,32 @@ type MatchArtworkImportArtistsSuccess {
   unmatched: Int!
 }
 
+type MatchArtworkImportRowImageFailure {
+  mutationError: GravityMutationError
+}
+
+input MatchArtworkImportRowImageInput {
+  artworkImportID: String!
+  clientMutationId: String
+  fileName: String!
+  rowID: String!
+  s3Bucket: String!
+  s3Key: String!
+}
+
+type MatchArtworkImportRowImagePayload {
+  clientMutationId: String
+  matchArtworkImportRowImageOrError: MatchArtworkImportRowImageResponseOrError
+}
+
+union MatchArtworkImportRowImageResponseOrError =
+    MatchArtworkImportRowImageFailure
+  | MatchArtworkImportRowImageSuccess
+
+type MatchArtworkImportRowImageSuccess {
+  success: Boolean!
+}
+
 # A connection to a list of items.
 type MatchConnection {
   # A list of edges.
@@ -14347,6 +14386,9 @@ type Mutation {
   matchArtworkImportArtists(
     input: MatchArtworkImportArtistsInput!
   ): MatchArtworkImportArtistsPayload
+  matchArtworkImportRowImage(
+    input: MatchArtworkImportRowImageInput!
+  ): MatchArtworkImportRowImagePayload
 
   # Merge multiple artist records in order to deduplicate artists
   mergeArtists(input: MergeArtistsMutationInput!): MergeArtistsMutationPayload

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -42,6 +42,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" }
     ),
+    artworkImportRowMatchImageLoader: gravityLoader(
+      (id) => `artwork_import/${id}/match_image`,
+      {},
+      { method: "PUT" }
+    ),
     artworkImportRowsLoader: gravityLoader(
       (id) => `artwork_import/${id}/rows`,
       {},

--- a/src/schema/v2/ArtworkImport/__tests__/matchArtworkImportRowImageMutation.test.ts
+++ b/src/schema/v2/ArtworkImport/__tests__/matchArtworkImportRowImageMutation.test.ts
@@ -1,0 +1,53 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("MatchArtworkImportRowImageMutation", () => {
+  it("updates a row's image based on filename", async () => {
+    const artworkImportRowMatchImageLoader = jest.fn().mockResolvedValue({
+      id: "artwork-import-id",
+    })
+
+    const mutation = gql`
+      mutation {
+        matchArtworkImportRowImage(
+          input: {
+            artworkImportID: "artwork-import-1"
+            rowID: "row-1"
+            fileName: "cat.jpg"
+            s3Key: "/some/path/cat.jpg"
+            s3Bucket: "someBucket"
+          }
+        ) {
+          matchArtworkImportRowImageOrError {
+            ... on MatchArtworkImportRowImageSuccess {
+              success
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      artworkImportRowMatchImageLoader,
+    }
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(artworkImportRowMatchImageLoader).toHaveBeenCalledWith(
+      "artwork-import-1",
+      {
+        row_id: "row-1",
+        file_name: "cat.jpg",
+        s3_key: "/some/path/cat.jpg",
+        s3_bucket: "someBucket",
+      }
+    )
+
+    expect(result).toEqual({
+      matchArtworkImportRowImage: {
+        matchArtworkImportRowImageOrError: {
+          success: true,
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -32,6 +32,25 @@ const ArtworkImportRowErrorType = new GraphQLObjectType({
   },
 })
 
+const ArtworkImportRowImageType = new GraphQLObjectType({
+  name: "ArtworkImportRowImage",
+  fields: {
+    ...InternalIDFields,
+    fileName: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ file_name }) => file_name,
+    },
+    s3Key: {
+      type: GraphQLString,
+      resolve: ({ s3_key }) => s3_key,
+    },
+    s3Bucket: {
+      type: GraphQLString,
+      resolve: ({ s3_bucket }) => s3_bucket,
+    },
+  },
+})
+
 const ArtworkImportRowType = new GraphQLObjectType({
   name: "ArtworkImportRow",
   fields: {
@@ -47,8 +66,16 @@ const ArtworkImportRowType = new GraphQLObjectType({
       resolve: ({ raw_data }) => raw_data,
     },
     errors: {
-      type: new GraphQLList(new GraphQLNonNull(ArtworkImportRowErrorType)),
+      type: new GraphQLNonNull(
+        GraphQLList(new GraphQLNonNull(ArtworkImportRowErrorType))
+      ),
       resolve: ({ artwork_import_row_errors }) => artwork_import_row_errors,
+    },
+    images: {
+      type: new GraphQLNonNull(
+        GraphQLList(new GraphQLNonNull(ArtworkImportRowImageType))
+      ),
+      resolve: ({ artwork_import_row_images }) => artwork_import_row_images,
     },
   },
 })

--- a/src/schema/v2/ArtworkImport/matchArtworkImportRowImageMutation.ts
+++ b/src/schema/v2/ArtworkImport/matchArtworkImportRowImageMutation.ts
@@ -1,0 +1,97 @@
+import {
+  GraphQLString,
+  GraphQLObjectType,
+  GraphQLUnionType,
+  GraphQLNonNull,
+  GraphQLBoolean,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "MatchArtworkImportRowImageSuccess",
+  isTypeOf: (data) => !!data.id,
+  fields: () => ({
+    success: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      resolve: () => true,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "MatchArtworkImportRowImageFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "MatchArtworkImportRowImageResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const MatchArtworkImportRowImageMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "MatchArtworkImportRowImage",
+  inputFields: {
+    artworkImportID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    rowID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    fileName: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    s3Key: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    s3Bucket: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+  },
+  outputFields: {
+    matchArtworkImportRowImageOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: (
+    { artworkImportID, rowID, fileName, s3Key, s3Bucket },
+    { artworkImportRowMatchImageLoader }
+  ) => {
+    if (!artworkImportRowMatchImageLoader) {
+      throw new Error("This operation requires an `X-Access-Token` header.")
+    }
+
+    const gravityArgs = {
+      row_id: rowID,
+      file_name: fileName,
+      s3_key: s3Key,
+      s3_bucket: s3Bucket,
+    }
+
+    try {
+      return artworkImportRowMatchImageLoader(artworkImportID, gravityArgs)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -273,6 +273,7 @@ import { MatchArtworkImportArtistsMutation } from "./ArtworkImport/matchArtworkI
 import { CreateArtworkImportArtworksMutation } from "./ArtworkImport/createArtworkImportArtworksMutation"
 import { AssignArtworkImportArtistMutation } from "./ArtworkImport/assignArtworkImportArtistMutation"
 import { UpdateArtworkImportRowMutation } from "./ArtworkImport/updateArtworkImportRowMutation"
+import { MatchArtworkImportRowImageMutation } from "./ArtworkImport/matchArtworkImportRowImageMutation"
 
 const viewingRoomUnstitchedRootField = config.USE_UNSTITCHED_VIEWING_ROOM_SCHEMA
   ? {
@@ -511,6 +512,7 @@ export default new GraphQLSchema({
       markNotificationAsRead: markNotificationAsReadMutation,
       markNotificationsAsSeen: markNotificationsAsSeenMutation,
       matchArtworkImportArtists: MatchArtworkImportArtistsMutation,
+      matchArtworkImportRowImage: MatchArtworkImportRowImageMutation,
       mergeArtists: mergeArtistsMutation,
       myCollectionCreateArtwork: myCollectionCreateArtworkMutation,
       myCollectionDeleteArtwork: myCollectionDeleteArtworkMutation,


### PR DESCRIPTION
This adds support for image manipulation for artwork imports.

It returns the image data (so in the client, we can show the filenames they specified, as well as a warning if we weren't able to match an uploaded image to the specified filename on a row).

Additionally, there's a mutation that lets a particular row/filename tuple to be updated with the uploaded file location.