### PR TITLE
chore: drop rowID argument from matching an image to an import by filename

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13007,7 +13007,6 @@ input MatchArtworkImportRowImageInput {
   artworkImportID: String!
   clientMutationId: String
   fileName: String!
-  rowID: String!
   s3Bucket: String!
   s3Key: String!
 }

--- a/src/schema/v2/ArtworkImport/__tests__/matchArtworkImportRowImageMutation.test.ts
+++ b/src/schema/v2/ArtworkImport/__tests__/matchArtworkImportRowImageMutation.test.ts
@@ -12,7 +12,6 @@ describe("MatchArtworkImportRowImageMutation", () => {
         matchArtworkImportRowImage(
           input: {
             artworkImportID: "artwork-import-1"
-            rowID: "row-1"
             fileName: "cat.jpg"
             s3Key: "/some/path/cat.jpg"
             s3Bucket: "someBucket"
@@ -35,7 +34,6 @@ describe("MatchArtworkImportRowImageMutation", () => {
     expect(artworkImportRowMatchImageLoader).toHaveBeenCalledWith(
       "artwork-import-1",
       {
-        row_id: "row-1",
         file_name: "cat.jpg",
         s3_key: "/some/path/cat.jpg",
         s3_bucket: "someBucket",

--- a/src/schema/v2/ArtworkImport/matchArtworkImportRowImageMutation.ts
+++ b/src/schema/v2/ArtworkImport/matchArtworkImportRowImageMutation.ts
@@ -49,9 +49,6 @@ export const MatchArtworkImportRowImageMutation = mutationWithClientMutationId<
     artworkImportID: {
       type: new GraphQLNonNull(GraphQLString),
     },
-    rowID: {
-      type: new GraphQLNonNull(GraphQLString),
-    },
     fileName: {
       type: new GraphQLNonNull(GraphQLString),
     },
@@ -69,7 +66,7 @@ export const MatchArtworkImportRowImageMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: (
-    { artworkImportID, rowID, fileName, s3Key, s3Bucket },
+    { artworkImportID, fileName, s3Key, s3Bucket },
     { artworkImportRowMatchImageLoader }
   ) => {
     if (!artworkImportRowMatchImageLoader) {
@@ -77,7 +74,6 @@ export const MatchArtworkImportRowImageMutation = mutationWithClientMutationId<
     }
 
     const gravityArgs = {
-      row_id: rowID,
       file_name: fileName,
       s3_key: s3Key,
       s3_bucket: s3Bucket,


### PR DESCRIPTION
When working on the prototype - I realized when we're uploading all the images - we don't have the row id's - we just have the import and all the filenames from the upload, so this just drops the argument.

https://github.com/artsy/gravity/pull/18594 is the actual backend behavior update that makes it work without the row id.