### PR TITLE
feat: add user seen artworks mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8887,6 +8887,30 @@ type CreateUserSaleProfileSuccess {
   userSaleProfile: UserSaleProfile
 }
 
+type CreateUserSeenArtworkFailure {
+  mutationError: GravityMutationError
+}
+
+input CreateUserSeenArtworkInput {
+  artworkId: String!
+  clientMutationId: String
+}
+
+type CreateUserSeenArtworkPayload {
+  clientMutationId: String
+
+  # On success: the created User Seen Artwork.
+  userSeenArtworkOrError: CreateUserSeenArtworkSuccessResponseOrError
+}
+
+type CreateUserSeenArtworkSuccess {
+  artworkId: String
+}
+
+union CreateUserSeenArtworkSuccessResponseOrError =
+    CreateUserSeenArtworkFailure
+  | CreateUserSeenArtworkSuccess
+
 type CreateVerifiedRepresentativeFailure {
   mutationError: GravityMutationError
 }
@@ -14265,6 +14289,11 @@ type Mutation {
     input: CreateUserSaleProfileMutationInput!
   ): CreateUserSaleProfileMutationPayload
 
+  # Creates User Seen Artwork.
+  createUserSeenArtwork(
+    input: CreateUserSeenArtworkInput!
+  ): CreateUserSeenArtworkPayload
+
   # Creates Verified Representative.
   createVerifiedRepresentative(
     input: CreateVerifiedRepresentativeInput!
@@ -17308,6 +17337,9 @@ type Query {
 
     # Weights for the KNN and MLT query
     osWeights: [Float] = [0.6, 0.4]
+
+    # Internal Redis tracking for the user seen artworks
+    useInternalTracking: Boolean = false
   ): ArtworkConnection
 
   # A namespace external partners (provided by Galaxy)
@@ -22063,6 +22095,9 @@ type Viewer {
 
     # Weights for the KNN and MLT query
     osWeights: [Float] = [0.6, 0.4]
+
+    # Internal Redis tracking for the user seen artworks
+    useInternalTracking: Boolean = false
   ): ArtworkConnection
 
   # A namespace external partners (provided by Galaxy)

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14289,7 +14289,7 @@ type Mutation {
     input: CreateUserSaleProfileMutationInput!
   ): CreateUserSaleProfileMutationPayload
 
-  # Creates User Seen Artwork.
+  # Marks an artwork as seen when a user swipes through Infinite Discovery.
   createUserSeenArtwork(
     input: CreateUserSeenArtworkInput!
   ): CreateUserSeenArtworkPayload

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -132,6 +132,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    createUserSeenArtworkLoader: gravityLoader(
+      "artworks_discovery/artworks/seen",
+      {},
+      { method: "POST" }
+    ),
     deliverSecondFactor: gravityLoader(
       (id) => `me/second_factors/${id}/deliver`,
       {},

--- a/src/schema/v2/infiniteDiscovery/__tests__/discoverArtworks.test.ts
+++ b/src/schema/v2/infiniteDiscovery/__tests__/discoverArtworks.test.ts
@@ -32,6 +32,7 @@ describe("discoverArtworks", () => {
         os_weights: [0.6, 0.4],
         curated_picks_size: 2,
         user_id: "user-id",
+        use_internal_tracking: false,
       })
 
       expect(result).toMatchInlineSnapshot(`
@@ -91,6 +92,7 @@ describe("discoverArtworks", () => {
         os_weights: [0.5, 0.5],
         curated_picks_size: 3,
         user_id: "user-id",
+        use_internal_tracking: false,
       })
 
       expect(result).toMatchInlineSnapshot(`

--- a/src/schema/v2/infiniteDiscovery/createUserSeenArtworkMutation.ts
+++ b/src/schema/v2/infiniteDiscovery/createUserSeenArtworkMutation.ts
@@ -57,7 +57,8 @@ export const createUserSeenArtworkMutation = mutationWithClientMutationId<
   ResolverContext
 >({
   name: "CreateUserSeenArtwork",
-  description: "Creates User Seen Artwork.",
+  description:
+    "Marks an artwork as seen when a user swipes through Infinite Discovery.",
   inputFields,
   outputFields: {
     userSeenArtworkOrError: {

--- a/src/schema/v2/infiniteDiscovery/createUserSeenArtworkMutation.ts
+++ b/src/schema/v2/infiniteDiscovery/createUserSeenArtworkMutation.ts
@@ -1,0 +1,97 @@
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { snakeCase } from "lodash"
+
+interface Input {
+  artworkId: string
+}
+
+const inputFields = {
+  artworkId: { type: new GraphQLNonNull(GraphQLString) },
+}
+
+interface GravityInput {
+  artwork_id: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreateUserSeenArtworkSuccess",
+  isTypeOf: (data) => data.artwork_id,
+  fields: {
+    artworkId: {
+      type: GraphQLString,
+      resolve: ({ artwork_id }) => artwork_id,
+    },
+  },
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreateUserSeenArtworkFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "CreateUserSeenArtworkSuccessResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const createUserSeenArtworkMutation = mutationWithClientMutationId<
+  Input,
+  any,
+  ResolverContext
+>({
+  name: "CreateUserSeenArtwork",
+  description: "Creates User Seen Artwork.",
+  inputFields,
+  outputFields: {
+    userSeenArtworkOrError: {
+      type: ResponseOrErrorType,
+      description: "On success: the created User Seen Artwork.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (args, { createUserSeenArtworkLoader }) => {
+    if (!createUserSeenArtworkLoader) {
+      throw new Error(
+        "You need to pass a X-Access-Token header to perform this action"
+      )
+    }
+
+    const createUserSeenArtworkLoaderPayload = Object.keys(args)
+      .filter((key) => key !== "id")
+      .reduce(
+        (acc, key) => ({ ...acc, [snakeCase(key)]: args[key] }),
+        {} as GravityInput
+      )
+
+    try {
+      return await createUserSeenArtworkLoader(
+        createUserSeenArtworkLoaderPayload
+      )
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
+++ b/src/schema/v2/infiniteDiscovery/discoverArtworks.ts
@@ -4,6 +4,7 @@ import {
   GraphQLInt,
   GraphQLFloat,
   GraphQLList,
+  GraphQLBoolean,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { artworkConnection } from "../artwork"
@@ -17,6 +18,11 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
     excludeArtworkIds: {
       type: new GraphQLList(GraphQLString),
       description: "Exclude these artworks from the response",
+    },
+    useInternalTracking: {
+      type: GraphQLBoolean,
+      description: "Internal Redis tracking for the user seen artworks",
+      defaultValue: false,
     },
     mltFields: {
       type: new GraphQLList(GraphQLString),
@@ -52,6 +58,7 @@ export const DiscoverArtworks: GraphQLFieldConfig<void, ResolverContext> = {
       os_weights: args.osWeights,
       curated_picks_size: args.curatedPicksSize,
       user_id: userID,
+      use_internal_tracking: args.useInternalTracking,
     }
 
     const gravityResponse = await artworksDiscoveryLoader(gravityArgs)

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -259,6 +259,7 @@ import { deliverSecondFactorMutation } from "./me/secondFactors/mutations/delive
 import { enableSecondFactorMutation } from "./me/secondFactors/mutations/enableSecondFactor"
 import { createAndSendBackupSecondFactorMutation } from "./users/createAndSendBackupSecondFactorMutation"
 import { createViewingRoomMutation } from "./viewingRooms/mutations/createViewingRoomMutation"
+import { createUserSeenArtworkMutation } from "./infiniteDiscovery/createUserSeenArtworkMutation"
 import { updateViewingRoomMutation } from "./viewingRooms/mutations/updateViewingRoomMutation"
 import { deleteViewingRoomMutation } from "./viewingRooms/mutations/deleteViewingRoomMutation"
 import { publishViewingRoomMutation } from "./viewingRooms/mutations/publishViewingRoomMutation"
@@ -477,6 +478,7 @@ export default new GraphQLSchema({
       createPage: CreatePageMutation,
       createPartnerOffer: createPartnerOfferMutation,
       createUserAdminNote: createUserAdminNoteMutation,
+      createUserSeenArtwork: createUserSeenArtworkMutation,
       createUserInterest: createUserInterestMutation,
       createUserInterestForUser: createUserInterestForUser,
       createUserInterests: createUserInterestsMutation,


### PR DESCRIPTION
This PR introduces a new mutation, createUserSeenArtwork, which will be used to track seen artworks for Infinite Discovery. [Gravity PR](https://github.com/artsy/gravity/pull/18598) that introduced the endpoint for tracking seen artworks.

Ticket [DIA-1155](https://artsyproduct.atlassian.net/browse/DIA-1155)

<img width="1194" alt="Screenshot 2025-02-19 at 2 17 08 PM" src="https://github.com/user-attachments/assets/1ac5e054-3c8c-4572-b4ff-2e069ad1e893" />



[DIA-1155]: https://artsyproduct.atlassian.net/browse/DIA-1155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ