### PR TITLE
fix: correct analytics context module for infinite discovery

### DIFF
--- a/src/schema/v2/homeView/sections/InfiniteDiscovery.ts
+++ b/src/schema/v2/homeView/sections/InfiniteDiscovery.ts
@@ -5,7 +5,7 @@ import { HomeViewCard } from "../sectionTypes/Card"
 import { HomeViewSectionTypeNames } from "../sectionTypes/names"
 
 export const InfiniteDiscovery: HomeViewSection = {
-  contextModule: ContextModule.infiniteDiscoveryBanner,
+  contextModule: ContextModule.infiniteDiscovery,
   featureFlag: "diamond_home-view-infinite-discovery",
   id: "home-view-section-infinite-discovery",
   requiresAuthentication: false,

--- a/src/schema/v2/homeView/sections/__tests__/InfiniteDiscovery.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/InfiniteDiscovery.test.ts
@@ -52,7 +52,7 @@ describe("InfiniteDiscovery", () => {
         {
           "__typename": "HomeViewSectionCard",
           "component": null,
-          "contextModule": "infiniteDiscoveryBanner",
+          "contextModule": "infiniteDiscovery",
           "internalID": "home-view-section-infinite-discovery",
           "ownerType": "infiniteDiscovery",
         }


### PR DESCRIPTION
[This doc](https://docs.google.com/spreadsheets/d/1cLefOz5i9uvC3JAeXFqG6_5U-4hdgY7CBElZ4nDjGSU/edit?gid=827314299#gid=827314299) that Louis put together mentions `infiniteDiscovery` context module (not `infiniteDiscoveryBanner`). Fixing it