### PR TITLE
chore: add columns and transformedData to ArtworkImport

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2912,6 +2912,8 @@ union ArtworkFilterFacet = Gene | Tag
 union ArtworkHighlight = Article | Show
 
 type ArtworkImport implements Node {
+  # Columns to display for an import, will exist in a row's `transformedData`
+  columns: [String!]!
   fileName: String!
 
   # A globally unique ID.
@@ -2962,6 +2964,7 @@ type ArtworkImportRow {
   # A type-specific ID likely used as a database ID.
   internalID: ID!
   rawData: JSON!
+  transformedData: JSON!
 }
 
 # A connection to a list of items.

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -65,6 +65,10 @@ const ArtworkImportRowType = new GraphQLObjectType({
       type: new GraphQLNonNull(GraphQLJSON),
       resolve: ({ raw_data }) => raw_data,
     },
+    transformedData: {
+      type: new GraphQLNonNull(GraphQLJSON),
+      resolve: ({ transformed_data }) => transformed_data,
+    },
     errors: {
       type: new GraphQLNonNull(
         GraphQLList(new GraphQLNonNull(ArtworkImportRowErrorType))
@@ -89,6 +93,11 @@ export const ArtworkImportType = new GraphQLObjectType({
   interfaces: [NodeInterface],
   fields: {
     ...InternalIDFields,
+    columns: {
+      type: new GraphQLNonNull(GraphQLList(new GraphQLNonNull(GraphQLString))),
+      description:
+        "Columns to display for an import, will exist in a row's `transformedData`",
+    },
     fileName: {
       type: new GraphQLNonNull(GraphQLString),
       resolve: ({ file_name }) => file_name,


### PR DESCRIPTION
I think this will allow Volt's table view of an import to be a bit generic, just showing the user the columns they initially included (and transformed/normalized data values).

Now, Volt still needs to 'know' for example that titles can have inline editing enabled and maybe should render differently than another column type, but I feel like _that_ could be a little config within Volt: column names -> Component kinda thing. We can see if that makes sense to move somewhere upstream - into MP _kinda_ like homeview. But, since Volt is likely to be the _only_ client for this whole imports schema, we can probably keep that stuff in Volt.

Ultimately, we want the specifics of the CSV in question to 'inform' the Volt table rendering of the import. This is b/c different partners may start to include different columns, we have optional columns, etc.

We can even drive Volt's experience for images this way _without_ a feature flag! If an import _included_ image filenames as a column - it can present those and ask for the image upload step, as we currently do. But if an import didn't include that column...it won't render in the table and the UI can skip that step.