### PR TITLE
fix(artist): uses correct attribute for slug

### DIFF
--- a/src/schema/v2/artist/meta.ts
+++ b/src/schema/v2/artist/meta.ts
@@ -64,7 +64,7 @@ const ArtistMetaType = new GraphQLObjectType<any, ResolverContext>({
               artist
             )} - Biography, Shows, Articles & More | Artsy`
           case "ARTWORKS": {
-            if (EXPERIMENT_GROUP.includes(artist.slug)) {
+            if (EXPERIMENT_GROUP.includes(artist.id)) {
               return metaName(artist)
             }
 


### PR DESCRIPTION
I've made this mistake so many times: slugs are ids and we don't have types to tell one otherwise.