### PR TITLE
chore: add artworkImport to mutation payload for all import-related mutations

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3354,6 +3354,7 @@ union AssignArtworkImportArtistResponseOrError =
   | AssignArtworkImportArtistSuccess
 
 type AssignArtworkImportArtistSuccess {
+  artworkImport: ArtworkImport
   artworkImportID: String!
   updatedRowsCount: Int!
 }
@@ -8284,6 +8285,7 @@ union CreateArtworkImportArtworksResponseOrError =
   | CreateArtworkImportArtworksSuccess
 
 type CreateArtworkImportArtworksSuccess {
+  artworkImport: ArtworkImport
   artworkImportID: String!
   created: Int!
   errors: Int!
@@ -13058,6 +13060,7 @@ union MatchArtworkImportArtistsResponseOrError =
   | MatchArtworkImportArtistsSuccess
 
 type MatchArtworkImportArtistsSuccess {
+  artworkImport: ArtworkImport
   artworkImportID: String!
   matched: Int!
   unmatched: Int!
@@ -13085,6 +13088,7 @@ union MatchArtworkImportRowImageResponseOrError =
   | MatchArtworkImportRowImageSuccess
 
 type MatchArtworkImportRowImageSuccess {
+  artworkImport: ArtworkImport
   success: Boolean!
 }
 
@@ -20232,6 +20236,7 @@ union UpdateArtworkImportRowResponseOrError =
   | UpdateArtworkImportRowSuccess
 
 type UpdateArtworkImportRowSuccess {
+  artworkImport: ArtworkImport
   success: Boolean!
 }
 

--- a/src/schema/v2/ArtworkImport/assignArtworkImportArtistMutation.ts
+++ b/src/schema/v2/ArtworkImport/assignArtworkImportArtistMutation.ts
@@ -11,6 +11,7 @@ import {
   formatGravityError,
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
+import { ArtworkImportType } from "./artworkImport"
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
   name: "AssignArtworkImportArtistSuccess",
@@ -21,6 +22,13 @@ const SuccessType = new GraphQLObjectType<any, ResolverContext>({
     },
     updatedRowsCount: {
       type: new GraphQLNonNull(GraphQLInt),
+    },
+    artworkImport: {
+      type: ArtworkImportType,
+      resolve: ({ artworkImportID }, _args, { artworkImportLoader }) => {
+        if (!artworkImportLoader) return null
+        return artworkImportLoader(artworkImportID)
+      },
     },
   }),
 })

--- a/src/schema/v2/ArtworkImport/createArtworkImportArtworksMutation.ts
+++ b/src/schema/v2/ArtworkImport/createArtworkImportArtworksMutation.ts
@@ -11,6 +11,7 @@ import {
   formatGravityError,
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
+import { ArtworkImportType } from "./artworkImport"
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
   name: "CreateArtworkImportArtworksSuccess",
@@ -24,6 +25,13 @@ const SuccessType = new GraphQLObjectType<any, ResolverContext>({
     },
     errors: {
       type: new GraphQLNonNull(GraphQLInt),
+    },
+    artworkImport: {
+      type: ArtworkImportType,
+      resolve: ({ artworkImportID }, _args, { artworkImportLoader }) => {
+        if (!artworkImportLoader) return null
+        return artworkImportLoader(artworkImportID)
+      },
     },
   }),
 })

--- a/src/schema/v2/ArtworkImport/matchArtworkImportArtistsMutation.ts
+++ b/src/schema/v2/ArtworkImport/matchArtworkImportArtistsMutation.ts
@@ -11,6 +11,7 @@ import {
   formatGravityError,
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
+import { ArtworkImportType } from "./artworkImport"
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
   name: "MatchArtworkImportArtistsSuccess",
@@ -24,6 +25,13 @@ const SuccessType = new GraphQLObjectType<any, ResolverContext>({
     },
     unmatched: {
       type: new GraphQLNonNull(GraphQLInt),
+    },
+    artworkImport: {
+      type: ArtworkImportType,
+      resolve: ({ artworkImportID }, _args, { artworkImportLoader }) => {
+        if (!artworkImportLoader) return null
+        return artworkImportLoader(artworkImportID)
+      },
     },
   }),
 })

--- a/src/schema/v2/ArtworkImport/updateArtworkImportRowMutation.ts
+++ b/src/schema/v2/ArtworkImport/updateArtworkImportRowMutation.ts
@@ -11,6 +11,7 @@ import {
   formatGravityError,
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
+import { ArtworkImportType } from "./artworkImport"
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
   name: "UpdateArtworkImportRowSuccess",
@@ -19,6 +20,13 @@ const SuccessType = new GraphQLObjectType<any, ResolverContext>({
     success: {
       type: new GraphQLNonNull(GraphQLBoolean),
       resolve: () => true,
+    },
+    artworkImport: {
+      type: ArtworkImportType,
+      resolve: ({ artworkImportID }, _args, { artworkImportLoader }) => {
+        if (!artworkImportLoader) return null
+        return artworkImportLoader(artworkImportID)
+      },
     },
   }),
 })
@@ -74,11 +82,14 @@ export const UpdateArtworkImportRowMutation = mutationWithClientMutationId<
     }
 
     try {
-      return artworkImportUpdateRowLoader(artworkImportID, {
-        field_name: fieldName,
-        field_value: fieldValue,
-        row_id: artworkImportRowID,
-      })
+      return {
+        ...(await artworkImportUpdateRowLoader(artworkImportID, {
+          field_name: fieldName,
+          field_value: fieldValue,
+          row_id: artworkImportRowID,
+        })),
+        artworkImportID,
+      }
     } catch (error) {
       const formattedErr = formatGravityError(error)
       if (formattedErr) {


### PR DESCRIPTION
Pretty straightforward - we require `artworkImportID` as an argument for all these mutations, so it's easy to add `artworkImport: ArtworkImport` to the mutation payloads for all of them.

This should enable the behavior of triggering a mutation and requesting the `fragment on ArtworkImport` for the next screen in the result.