### PR TITLE
chore: add blockersOnly to rowsConnection on ArtworkImport

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2960,6 +2960,7 @@ type ArtworkImport implements Node {
   rowsConnection(
     after: String
     before: String
+    blockersOnly: Boolean
     errorTypes: [String!]
     first: Int
     hasErrors: Boolean

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -150,6 +150,9 @@ export const ArtworkImportType = new GraphQLObjectType({
         errorTypes: {
           type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
         },
+        blockersOnly: {
+          type: GraphQLBoolean,
+        },
       }),
       resolve: async ({ id, currency }, args, { artworkImportRowsLoader }) => {
         const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
@@ -158,6 +161,7 @@ export const ArtworkImportType = new GraphQLObjectType({
           offset,
           has_errors: args.hasErrors,
           error_types: args.errorTypes,
+          blockers_only: args.blockers_only,
           total_count: true,
         })
 


### PR DESCRIPTION
Can be used to retrieve the rows/count of rows that aren't eligible to have artworks created.