### PR TITLE
feat(AMBER-1304): Expose category and price fields for Batch Edits

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4192,8 +4192,14 @@ type BidderPositionSuggestedNextBid {
 scalar BigInt
 
 input BulkUpdateArtworksMetadataInput {
+  # The category (medium type) to be assigned
+  category: String
+
   # The partner location ID to assign
   location_id: String
+
+  # The price for the artworks
+  price_listed: Float
 }
 
 type BulkUpdateArtworksMetadataMutationFailure {

--- a/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
@@ -4,6 +4,7 @@ import {
   GraphQLList,
   GraphQLNonNull,
   GraphQLString,
+  GraphQLFloat,
 } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 import { ResolverContext } from "types/graphql"
@@ -16,7 +17,11 @@ import { GraphQLUnionType } from "graphql"
 
 interface Input {
   id: string
-  metadata: { location_id: string | null } | null
+  metadata: {
+    location_id: string | null
+    category: string | null
+    price_listed: number | null
+  } | null
 }
 
 const BulkUpdateArtworksMetadataInput = new GraphQLInputObjectType({
@@ -25,6 +30,14 @@ const BulkUpdateArtworksMetadataInput = new GraphQLInputObjectType({
     location_id: {
       type: GraphQLString,
       description: "The partner location ID to assign",
+    },
+    category: {
+      type: GraphQLString,
+      description: "The category (medium type) to be assigned",
+    },
+    price_listed: {
+      type: GraphQLFloat,
+      description: "The price for the artworks",
     },
   },
 })


### PR DESCRIPTION
[AMBER-1304]

Expose `category` and `price_listed` as metadata possibilities on the Batch Edits mutation

(`category` was supposed to have been added during 6433, but I forgot to push it 🙏  )

cc @artsy/amber-devs 

[AMBER-1304]: https://artsyproduct.atlassian.net/browse/AMBER-1304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ