### PR TITLE
feat(homeView): allow QuickLinks to enforce minimum Eigen version requirements

### DIFF
--- a/src/schema/v2/homeView/sectionTypes/NavigationPills.ts
+++ b/src/schema/v2/homeView/sectionTypes/NavigationPills.ts
@@ -10,12 +10,14 @@ import { HomeViewGenericSectionInterface } from "./GenericSectionInterface"
 import { HomeViewSectionTypeNames } from "./names"
 import { standardSectionFields } from "./GenericSectionInterface"
 import { OwnerType } from "@artsy/cohesion"
+import { SemanticVersionNumber } from "lib/semanticVersioning"
 
 export interface NavigationPill {
   title: string
   href: string
   ownerType: OwnerType
   icon?: string
+  minimumEigenVersion?: SemanticVersionNumber
 }
 
 const NavigationPillType = new GraphQLObjectType<

--- a/src/schema/v2/homeView/sectionTypes/NavigationPills.ts
+++ b/src/schema/v2/homeView/sectionTypes/NavigationPills.ts
@@ -17,6 +17,11 @@ export interface NavigationPill {
   href: string
   ownerType: OwnerType
   icon?: string
+
+  /**
+   * The implementing section must enforce this check.
+   * See QuickLinks for an example
+   */
   minimumEigenVersion?: SemanticVersionNumber
 }
 

--- a/src/schema/v2/homeView/sections/__tests__/QuickLinks.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/QuickLinks.test.ts
@@ -1,33 +1,35 @@
 import gql from "lib/gql"
 import { runQuery } from "schema/v2/test/utils"
+import { QUICK_LINKS } from "../QuickLinks"
+import { OwnerType } from "@artsy/cohesion"
 
 describe("QuickLinks", () => {
-  it("returns the section's data", async () => {
-    const query = gql`
-      {
-        homeView {
-          section(id: "home-view-section-quick-links") {
-            __typename
-            internalID
-            contextModule
-            ownerType
-            ... on HomeViewSectionNavigationPills {
-              navigationPills {
-                title
-                icon
-                href
-                ownerType
-              }
+  const query = gql`
+    {
+      homeView {
+        section(id: "home-view-section-quick-links") {
+          __typename
+          internalID
+          contextModule
+          ownerType
+          ... on HomeViewSectionNavigationPills {
+            navigationPills {
+              title
+              icon
+              href
+              ownerType
             }
           }
         }
       }
-    `
-
-    const context = {
-      accessToken: "424242",
     }
+  `
 
+  const context = {
+    accessToken: "424242",
+  }
+
+  it("returns the section's data", async () => {
     const { homeView } = await runQuery(query, context)
 
     expect(homeView.section).toMatchInlineSnapshot(`
@@ -76,5 +78,79 @@ describe("QuickLinks", () => {
         "ownerType": "quickLinks",
       }
     `)
+  })
+
+  describe("When a quick link specifies a minimum Eigen version", () => {
+    const versionedQuickLink = {
+      title: "A futuristic feature",
+      href: "/futuristic/feature",
+      ownerType: "test" as OwnerType,
+      minimumEigenVersion: { major: 42, minor: 0, patch: 0 },
+    }
+
+    beforeAll(() => QUICK_LINKS.push(versionedQuickLink))
+    afterAll(() => QUICK_LINKS.pop())
+
+    describe("When Eigen < minimum version", () => {
+      it("does not return the quick link", async () => {
+        const { homeView } = await runQuery(query, {
+          ...context,
+          userAgent:
+            "unknown iOS/18.1.1 Artsy-Mobile/9.0.0 Eigen/2024.12.10.06/9.0.0",
+        })
+
+        expect(homeView.section.navigationPills).toHaveLength(
+          QUICK_LINKS.length - 1
+        )
+
+        expect(homeView.section.navigationPills).not.toContainEqual(
+          expect.objectContaining({
+            title: "A futuristic feature",
+            href: "/futuristic/feature",
+          })
+        )
+      })
+    })
+
+    describe("When Eigen >= minimum version", () => {
+      it("does return the quick link", async () => {
+        const { homeView } = await runQuery(query, {
+          ...context,
+          userAgent:
+            "unknown iOS/18.1.1 Artsy-Mobile/42.0.0 Eigen/2024.12.10.06/42.0.0",
+        })
+
+        expect(homeView.section.navigationPills).toHaveLength(
+          QUICK_LINKS.length
+        )
+
+        expect(homeView.section.navigationPills).toContainEqual(
+          expect.objectContaining({
+            title: "A futuristic feature",
+            href: "/futuristic/feature",
+          })
+        )
+      })
+    })
+
+    describe("When the request is not from Eigen", () => {
+      it("does return the quick link", async () => {
+        const { homeView } = await runQuery(query, {
+          ...context,
+          userAgent: "anything else",
+        })
+
+        expect(homeView.section.navigationPills).toHaveLength(
+          QUICK_LINKS.length
+        )
+
+        expect(homeView.section.navigationPills).toContainEqual(
+          expect.objectContaining({
+            title: "A futuristic feature",
+            href: "/futuristic/feature",
+          })
+        )
+      })
+    })
   })
 })


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-1558

The approach here is quite similar to https://github.com/artsy/metaphysics/pull/6297 and makes use of the versioning helpers already introduced in that PR.

QuickLinks now can individually set a minimum required Eigen version:

```diff
{
  title: "Featured Fairs",
  href: "/featured-fairs",
  ownerType: OwnerType.fairs,
  icon: "FairIcon",
+ minimumEigenVersion: { major: 42, minor: 0, patch: 0 },
},
```

That one-line change should be sufficient to **release** a quick link to supported versions of Eigen.

Note that this does not solve the question of how to return a WIP quick link for **dev or testing** purposes. For that we might have to rely on other techniques like feature flags; or limiting to staging by checking `config.SYSTEM_ENVIRONMENT`. And once we are satisfied that a quick link is releasable, only then would we set a `minimumEigenVersion` to release it. 

That two-step sequence doesn't seem _so_ bad to me, but I'm open to ideas for streamlining.

