### PR TITLE
chore: add state to ArtworkImport

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2966,6 +2966,7 @@ type ArtworkImport implements Node {
     hasErrors: Boolean
     last: Int
   ): ArtworkImportRowConnection
+  state: String!
   unmatchedArtistNames: [String!]!
 }
 

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -125,6 +125,9 @@ export const ArtworkImportType = new GraphQLObjectType({
       type: new GraphQLNonNull(GraphQLString),
       resolve: ({ file_name }) => file_name,
     },
+    state: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
     unmatchedArtistNames: {
       type: new GraphQLNonNull(GraphQLList(new GraphQLNonNull(GraphQLString))),
       resolve: async (


### PR DESCRIPTION
We now will have a `state` property coming back with the artwork import JSON.