### PR TITLE
feat: add featuredFairs query field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17413,6 +17413,9 @@ type Query {
     # The slug or ID of the Feature
     id: ID
   ): Feature
+
+  # A list of currently running featured fairs, backfilled with past fairs. Fairs are sorted by start date in descending order.
+  featuredFairs(includeBackfill: Boolean = true, size: Int): [Fair]
   featuredLinksConnection(
     after: String
     before: String
@@ -22169,6 +22172,9 @@ type Viewer {
     # The slug or ID of the Feature
     id: ID
   ): Feature
+
+  # A list of currently running featured fairs, backfilled with past fairs. Fairs are sorted by start date in descending order.
+  featuredFairs(includeBackfill: Boolean = true, size: Int): [Fair]
   featuredLinksConnection(
     after: String
     before: String

--- a/src/schema/v2/FeaturedFairs/__tests__/featuredFairs.test.ts
+++ b/src/schema/v2/FeaturedFairs/__tests__/featuredFairs.test.ts
@@ -1,0 +1,149 @@
+import gql from "lib/gql"
+import { range } from "lodash"
+import { runQuery } from "schema/v2/test/utils"
+
+describe("featuredFairs", () => {
+  const requestedSize = 3
+  const query = gql`
+    {
+      featuredFairs(size: ${requestedSize}, includeBackfill: true) {
+        name
+      }
+    }
+  `
+
+  describe("with enough current fairs", () => {
+    const fairsLoader = jest.fn().mockImplementationOnce(() =>
+      Promise.resolve({
+        body: range(requestedSize).map((i) => mockRunningFair(i)),
+        headers: {},
+      })
+    )
+
+    it("returns current fairs", async () => {
+      const { featuredFairs } = await runQuery(query, { fairsLoader })
+
+      expect(fairsLoader).toHaveBeenCalledTimes(1)
+
+      expect(featuredFairs).toMatchInlineSnapshot(`
+        [
+          {
+            "name": "A running fair 0",
+          },
+          {
+            "name": "A running fair 1",
+          },
+          {
+            "name": "A running fair 2",
+          },
+        ]
+      `)
+    })
+  })
+
+  describe("with not enough current fairs", () => {
+    const fairsLoader = jest.fn()
+
+    fairsLoader
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          body: range(requestedSize - 1).map((i) => mockRunningFair(i)),
+          headers: {},
+        })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          body: range(1).map((i) => mockPastFair(i)),
+          headers: {},
+        })
+      )
+
+    describe("with backfill", () => {
+      it("returns current and past fairs", async () => {
+        const { featuredFairs } = await runQuery(query, {
+          fairsLoader,
+        })
+
+        expect(fairsLoader).toHaveBeenCalledTimes(2)
+
+        expect(featuredFairs).toMatchInlineSnapshot(`
+          [
+            {
+              "name": "A running fair 0",
+            },
+            {
+              "name": "A running fair 1",
+            },
+            {
+              "name": "A past fair 0",
+            },
+          ]
+        `)
+      })
+    })
+
+    describe("without backfill", () => {
+      const fairsLoader = jest.fn(() =>
+        Promise.resolve({
+          body: range(requestedSize - 1).map((i) => mockRunningFair(i)),
+          headers: {},
+        })
+      )
+
+      it("returns only current fairs", async () => {
+        const query = gql`
+          {
+            featuredFairs(size: ${requestedSize}, includeBackfill: false) {
+              name
+            }
+          }
+        `
+
+        const { featuredFairs } = await runQuery(query, {
+          fairsLoader,
+        })
+
+        expect(fairsLoader).toHaveBeenCalledTimes(1)
+
+        expect(featuredFairs).toMatchInlineSnapshot(`
+          [
+            {
+              "name": "A running fair 0",
+            },
+            {
+              "name": "A running fair 1",
+            },
+          ]
+        `)
+      })
+    })
+  })
+})
+
+const mockRunningFair = (id) => {
+  return {
+    id: `running-fair-${id}`,
+    default_profile_id: `running-fair-${id}`,
+    name: `A running fair ${id}`,
+    published: true,
+    subtype: null,
+    summary: "",
+    layout: null,
+    display_vip: false,
+    has_full_feature: true,
+  }
+}
+
+const mockPastFair = (id) => {
+  return {
+    id: `past-fair-${id}`,
+    default_profile_id: `past-fair-${id}`,
+    name: `A past fair ${id}`,
+    published: true,
+    subtype: null,
+    summary: "",
+    layout: null,
+    display_vip: false,
+    has_full_feature: true,
+  }
+}

--- a/src/schema/v2/FeaturedFairs/featuredFairs.ts
+++ b/src/schema/v2/FeaturedFairs/featuredFairs.ts
@@ -1,0 +1,44 @@
+import {
+  GraphQLBoolean,
+  GraphQLFieldConfig,
+  GraphQLInt,
+  GraphQLList,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import Fair from "../fair"
+
+export const FeaturedFairs: GraphQLFieldConfig<void, ResolverContext> = {
+  description:
+    "A list of currently running featured fairs, backfilled with past fairs. Fairs are sorted by start date in descending order.",
+  type: GraphQLList(Fair.type),
+  args: {
+    includeBackfill: { type: GraphQLBoolean, defaultValue: true },
+    size: { type: GraphQLInt },
+  },
+  resolve: async (_root, args, { fairsLoader }) => {
+    const sharedOptions = {
+      has_full_feature: true,
+      sort: "-start_at",
+    }
+
+    const runningFairs = await fairsLoader({
+      ...sharedOptions,
+      status: "running",
+      size: args.size,
+    })
+
+    let fairs = runningFairs.body
+
+    if (args.includeBackfill && fairs.length < args.size) {
+      const backfillFairs = await fairsLoader({
+        ...sharedOptions,
+        status: "closed",
+        size: Math.min(args.size - fairs.length, 5),
+      })
+
+      fairs = fairs.concat(backfillFairs.body)
+    }
+
+    return fairs
+  },
+}

--- a/src/schema/v2/homeView/sections/FeaturedFairs.ts
+++ b/src/schema/v2/homeView/sections/FeaturedFairs.ts
@@ -1,10 +1,10 @@
 import { ContextModule } from "@artsy/cohesion"
+import { FeaturedFairs as FeaturedFairsType } from "schema/v2/FeaturedFairs/featuredFairs"
 import { HomeViewSection } from "."
 import { withHomeViewTimeout } from "../helpers/withHomeViewTimeout"
 import { HomeViewSectionTypeNames } from "../sectionTypes/names"
-import { HomePageFairsModuleType } from "schema/v2/home/home_page_fairs_module"
 import { connectionFromArray } from "graphql-relay"
-import { emptyConnection } from "schema/v2/fields/pagination"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 
 export const FeaturedFairs: HomeViewSection = {
   id: "home-view-section-featured-fairs",
@@ -18,14 +18,15 @@ export const FeaturedFairs: HomeViewSection = {
   requiresAuthentication: false,
 
   resolver: withHomeViewTimeout(async (parent, args, context, info) => {
-    const { results: resolver } = HomePageFairsModuleType.getFields()
+    const { size } = convertConnectionArgsToGravityArgs(args)
 
-    if (!resolver?.resolve) {
-      return emptyConnection
-    }
+    const featuredFairs = await FeaturedFairsType.resolve!(
+      parent,
+      { size, includeBackfill: true },
+      context,
+      info
+    )
 
-    const result = await resolver.resolve(parent, args, context, info)
-
-    return connectionFromArray(result, args)
+    return connectionFromArray(featuredFairs, args)
   }),
 }

--- a/src/schema/v2/homeView/sections/__tests__/FeaturedFairs.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/FeaturedFairs.test.ts
@@ -79,25 +79,26 @@ describe("FeaturedFairs", () => {
         }
       `
 
-      const fairs = {
-        body: [
-          {
-            id: "fair-1",
-            name: "Fair 1",
-            start_at: "2024-05-23T11:00:00+00:00",
-            end_at: "2024-06-23T11:00:00+00:00",
-          },
-          {
-            id: "fair-2",
-            name: "Fair 2",
-            start_at: "2024-05-23T11:00:00+00:00",
-            end_at: "2024-06-23T11:00:00+00:00",
-          },
-        ],
-      }
+      const fairs = [
+        {
+          id: "fair-1",
+          name: "Fair 1",
+          start_at: "2024-05-23T11:00:00+00:00",
+          end_at: "2024-06-23T11:00:00+00:00",
+        },
+        {
+          id: "fair-2",
+          name: "Fair 2",
+          start_at: "2024-05-23T11:00:00+00:00",
+          end_at: "2024-06-23T11:00:00+00:00",
+        },
+      ]
 
       const context = {
-        fairsLoader: jest.fn().mockResolvedValue(fairs),
+        fairsLoader: jest.fn().mockResolvedValue({
+          body: fairs,
+          headers: {},
+        }),
       }
 
       const { homeView } = await runQuery(query, context)

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -275,6 +275,7 @@ import { CreateArtworkImportArtworksMutation } from "./ArtworkImport/createArtwo
 import { AssignArtworkImportArtistMutation } from "./ArtworkImport/assignArtworkImportArtistMutation"
 import { UpdateArtworkImportRowMutation } from "./ArtworkImport/updateArtworkImportRowMutation"
 import { MatchArtworkImportRowImageMutation } from "./ArtworkImport/matchArtworkImportRowImageMutation"
+import { FeaturedFairs } from "./FeaturedFairs/featuredFairs"
 
 const rootFields = {
   // artworkVersion: ArtworkVersionResolver,
@@ -332,6 +333,7 @@ const rootFields = {
   fairs: Fairs,
   fairsConnection,
   feature: Feature,
+  featuredFairs: FeaturedFairs,
   featuredLinksConnection: FeaturedLinksConnection,
   featuresConnection: FeaturesConnection,
   filterPartners: FilterPartners,


### PR DESCRIPTION
_Note: this departs from the approach in #6421, preferring a GraphQLList return type. If we want to fully model a GraphQL Connection, I think it would be far easier to first model this backfill-enabled + featured concept in Gravity so we can execute against a single API call. It became too complicated to stitch multiple API request responses together to fulfill both a GraphQL Connection response and backfill logic._

---

Returns a simple GraphQLList of fairs. When we don't have enough running fairs to satisfy the requested size, we backfill from recently closed fairs (up to 5).

```graphql
{
  featuredFairs(size: 5, includeBackfill: true) {
    internalID
    name
    href
    exhibitionPeriod
  }
}
```

```json
{
   "data":{
      "featuredFairs":[
         {
            "internalID":"672cf102ed11650011a5f70b",
            "name":"LA Art Show 2025",
            "href":"/fair/la-art-show-2025",
            "exhibitionPeriod": "February 12 – March 12, 2025"
         },
         {
            "internalID":"677eb330d06730000f81a520",
            "name":"Black-Owned Galleries Now",
            "href":"/fair/black-owned-galleries-now",
            "exhibitionPeriod": "February 1 – 28, 2025"
         },
         {
            "internalID":"66f19b7e03ceb3001230f514",
            "name":"The Artsy Edition Shop",
            "href":"/fair/the-artsy-edition-shop",
            "exhibitionPeriod": "November 1, 2024 – January 1, 2026"
         },
         {
            "internalID":"673705410bf04f4e423b8d99",
            "name":"NOMAD St. Moritz 2025",
            "href":"/fair/nomad-st-moritz-2025",
            "exhibitionPeriod": "February 20 – 23, 2025"
         },
         {
            "internalID":"678e6887816a9b000eced92f",
            "name":"Investec Cape Town Art Fair 2025",
            "href":"/fair/investec-cape-town-art-fair-2025",
            "exhibitionPeriod": "February 20 – 23, 2025"
         }
      ]
   }
}
```