### PR TITLE
chore: dont render empty prices

### DIFF
--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -70,6 +70,7 @@ const ArtworkImportRowType = new GraphQLObjectType({
         context,
         info
       ) => {
+        if (!minor || !currencyCode) return null
         return resolveMinorAndCurrencyFieldsToMoney(
           {
             minor,


### PR DESCRIPTION
Playing around with the prototype and realized - at least if price isn't required and we have rows without a price - then there's no `priceListed` (the money resolver will resolve to `$0` otherwise).