### PR TITLE
fix: get default image for previewImages

### DIFF
--- a/src/schema/v2/notifications/index.ts
+++ b/src/schema/v2/notifications/index.ts
@@ -24,7 +24,7 @@ import { IDFields, NodeInterface } from "../object_identification"
 import moment from "moment-timezone"
 import { DEFAULT_TZ } from "lib/date"
 import { NotificationItemType } from "./Item"
-import Image, { normalizeImageData } from "../image"
+import Image, { getDefault, normalizeImageData } from "../image"
 import { NormalizedImageData } from "../image/normalize"
 
 const NotificationTypesEnum = new GraphQLEnumType({
@@ -162,8 +162,9 @@ export const NotificationType = new GraphQLObjectType<any, ResolverContext>({
             const artworks = await artworksLoader({
               ids: slicedObjectIds,
             })
-
-            images = artworks.map((artwork) => artwork.images?.[0])
+            images = artworks.map((artwork) =>
+              normalizeImageData(getDefault(artwork.images))
+            )
           }
         }
 


### PR DESCRIPTION
Fixes case where a Partner Offer notification activity uses the first image of the images array instead of the default one of the artwork.

### Before:
<img width="1510" alt="Screenshot 2025-02-27 at 14 26 51" src="https://github.com/user-attachments/assets/c64beb33-2eff-46e4-95c1-5e0922f052fb" />

### After:
<img width="1510" alt="Screenshot 2025-02-27 at 14 26 58" src="https://github.com/user-attachments/assets/a3f69efc-0517-43f5-9012-12e062e866f8" />
