### PR TITLE
feat(artwork): adds context match field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2467,6 +2467,15 @@ type Artwork implements Node & Searchable & Sellable {
     includeRelatedArtworks: Boolean! = true
   ): [ArtworkContextGrid]
 
+  # Returns a specific Fair/Sale/Show context if it exists
+  contextMatch(
+    # The ID of the context to return
+    id: String!
+
+    # The type of context to return
+    type: ArtworkContextEnum!
+  ): ArtworkContext
+
   # The currency code used to pay for the artwork
   costCurrencyCode: String
 
@@ -2906,6 +2915,12 @@ enum ArtworkConsignmentSubmissionState {
 }
 
 union ArtworkContext = Fair | Sale | Show
+
+enum ArtworkContextEnum {
+  FAIR
+  SALE
+  SHOW
+}
 
 # A specific grid.
 interface ArtworkContextGrid {

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -232,9 +232,7 @@ export default (opts) => {
       {},
       { headers: true }
     ),
-    relatedFairsLoader: gravityLoader<{ has_full_feature: boolean }[]>(
-      "related/fairs"
-    ),
+    relatedFairsLoader: gravityLoader<any[]>("related/fairs"),
     relatedGenesLoader: gravityLoader("related/genes"),
     relatedLayerArtworksLoader: gravityLoader<
       any,

--- a/src/schema/v2/artwork/contextMatch.ts
+++ b/src/schema/v2/artwork/contextMatch.ts
@@ -1,0 +1,87 @@
+import { assign } from "lodash"
+import {
+  GraphQLFieldConfig,
+  GraphQLEnumType,
+  GraphQLString,
+  GraphQLNonNull,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import { ArtworkContextType } from "./context"
+
+export const ArtworkContextEnum = new GraphQLEnumType({
+  name: "ArtworkContextEnum",
+  values: {
+    FAIR: { value: "Fair" },
+    SHOW: { value: "Show" },
+    SALE: { value: "Sale" },
+  },
+})
+
+export const ContextMatch: GraphQLFieldConfig<any, ResolverContext> = {
+  type: ArtworkContextType,
+  description: "Returns a specific Fair/Sale/Show context if it exists",
+  args: {
+    type: {
+      type: new GraphQLNonNull(ArtworkContextEnum),
+      description: "The type of context to return",
+    },
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the context to return",
+    },
+  },
+  resolve: async (
+    { id: artworkId, sale_ids, show_ids },
+    { type, id },
+    { salesLoader, relatedFairsLoader, showsLoader }
+  ) => {
+    switch (type) {
+      case "Sale": {
+        if (!sale_ids) return null
+
+        const sales = await salesLoader({ id: sale_ids })
+        const sale = sales.find((s) => s.id === id)
+
+        if (!sale) return null
+
+        return assign({ context_type: "Sale" }, sale)
+      }
+
+      case "Fair": {
+        const fairs = await relatedFairsLoader({
+          artwork: [artworkId],
+          size: 10,
+        })
+
+        if (!fairs) return null
+
+        const fair = fairs.find((f) => f.id === id)
+
+        if (!fair) return null
+
+        return assign({ context_type: "Fair" }, fair)
+      }
+
+      case "Show": {
+        if (!show_ids) return null
+
+        const shows = await showsLoader({
+          id: show_ids,
+          size: 1,
+        })
+
+        if (!shows) return null
+
+        const show = shows.find((s) => s.id === id)
+
+        if (!show) return null
+
+        return assign({ context_type: "Show" }, show)
+      }
+
+      default: {
+        return null
+      }
+    }
+  },
+}

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -99,6 +99,7 @@ import { ArtworkVisibility } from "./artworkVisibility"
 import { ArtworkConditionType } from "./artworkCondition"
 import { CollectorSignals } from "./collectorSignals"
 import { ArtistSeriesConnectionType } from "../artistSeries"
+import { ContextMatch } from "schema/v2/artwork/contextMatch"
 
 const has_price_range = (price) => {
   return new RegExp(/-/).test(price)
@@ -525,6 +526,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       context: Context,
+      contextMatch: ContextMatch,
       contextGrids: ArtworkContextGrids,
       costCurrencyCode: {
         description: "The currency code used to pay for the artwork",


### PR DESCRIPTION
Marking this as draft while frontend implementation is in progress. The core concept is that artworks can exist in multiple contexts (e.g., a fair and a show). Rather than fetching all contexts (artwork#fair, artwork#show, etc) or defaulting to the first available one (artwork#context), we request and return only the specific context that's relevant to the current query.