### PR TITLE
refactor(batch-import): Migrate away from JSON type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3021,7 +3021,7 @@ type ArtworkImportRow {
   internalID: ID!
   priceListed: Money
   rawData: JSON!
-  transformedData: JSON!
+  transformedData: ArtworkImportTransformedData!
 }
 
 # A connection to a list of items.
@@ -3070,6 +3070,18 @@ type ArtworkImportRowImage {
 enum ArtworkImportSource {
   CONVECTION
   MY_COLLECTION
+}
+
+type ArtworkImportTransformedData {
+  artistNames: String
+  artworkTitle: String
+  date: String
+  depth: String
+  diameter: String
+  height: String
+  imageFileNames: String
+  price: String
+  width: String
 }
 
 type ArtworkInfoRow {

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -99,7 +99,49 @@ const ArtworkImportRowType = new GraphQLObjectType({
       resolve: ({ raw_data }) => raw_data,
     },
     transformedData: {
-      type: new GraphQLNonNull(GraphQLJSON),
+      type: new GraphQLNonNull(
+        new GraphQLObjectType<any, ResolverContext>({
+          name: "ArtworkImportTransformedData",
+          fields: {
+            artistNames: {
+              type: GraphQLString,
+              resolve: ({ ArtistNames }) => ArtistNames,
+            },
+            artworkTitle: {
+              type: GraphQLString,
+              resolve: ({ ArtworkTitle }) => ArtworkTitle,
+            },
+            date: {
+              type: GraphQLString,
+              resolve: ({ Date }) => Date,
+            },
+            depth: {
+              type: GraphQLString,
+              resolve: ({ Depth }) => Depth,
+            },
+            diameter: {
+              type: GraphQLString,
+              resolve: ({ Diameter }) => Diameter,
+            },
+            height: {
+              type: GraphQLString,
+              resolve: ({ Height }) => Height,
+            },
+            imageFileNames: {
+              type: GraphQLString,
+              resolve: ({ ImageFileNames }) => ImageFileNames,
+            },
+            price: {
+              type: GraphQLString,
+              resolve: ({ Price }) => Price,
+            },
+            width: {
+              type: GraphQLString,
+              resolve: ({ Width }) => Width,
+            },
+          },
+        })
+      ),
       resolve: ({ transformed_data }) => transformed_data,
     },
     errors: {


### PR DESCRIPTION
This starts the process of migrating away from the JSON scalar type, which is nice to prototype with but comes at the cost of some type safety in the system (and self-docs). So far we've only updated `transformedData` but might as well update `rawData` as well, just not too sure of the shape of that data ATM. (And we're not using it anywhere in the codebase - is it needed?)

Breaking change, but going to push up a quick volt PR with the optimistic update now that this is in. 