### PR TITLE
chore: add excludeErrorTypes arg to rowsConnection on ArtworkImport

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2971,6 +2971,7 @@ type ArtworkImport implements Node {
     blockersOnly: Boolean
     createdOnly: Boolean
     errorTypes: [String!]
+    excludeErrorTypes: [String!]
     first: Int
     hasErrors: Boolean
     last: Int

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -217,6 +217,9 @@ export const ArtworkImportType = new GraphQLObjectType<any, ResolverContext>({
         errorTypes: {
           type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
         },
+        excludeErrorTypes: {
+          type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
+        },
         blockersOnly: {
           type: GraphQLBoolean,
         },
@@ -237,6 +240,7 @@ export const ArtworkImportType = new GraphQLObjectType<any, ResolverContext>({
           offset,
           has_errors: args.hasErrors,
           error_types: args.errorTypes,
+          exclude_error_types: args.excludeErrorTypes,
           blockers_only: args.blockersOnly,
           created_only: args.createdOnly,
           total_count: true,


### PR DESCRIPTION
Threads through the argument from https://github.com/artsy/gravity/pull/18683

Can be used to exclude unmatched artist errors from the current imports client