### PR TITLE
chore: let partner-artist be created when an artist is created by a partner

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8291,6 +8291,9 @@ input CreateArtistMutationInput {
   lastName: String
   middleName: String
   nationality: String
+
+  # When present, will create the partner-artist record as well
+  partnerID: String
 }
 
 type CreateArtistMutationPayload {
@@ -8402,6 +8405,9 @@ input CreateCanonicalArtistMutationInput {
   lastName: String
   middleName: String
   nationality: String
+
+  # When present, will create the partner-artist record as well
+  partnerID: String
 }
 
 type CreateCanonicalArtistMutationPayload {
@@ -14221,7 +14227,7 @@ type Mutation {
     input: CreateAppSecondFactorInput!
   ): CreateAppSecondFactorPayload
 
-  # Create an artist
+  # Create an artist, used for MyCollection. use CreateCanonicalArtistMutation for all other cases
   createArtist(input: CreateArtistMutationInput!): CreateArtistMutationPayload
   createArtworkImport(
     input: CreateArtworkImportInput!

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -211,6 +211,14 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    createPartnerArtistLoader: gravityLoader<
+      any,
+      { partnerID: string; artistID: string }
+    >(
+      ({ partnerID, artistID }) => `partner/${partnerID}/artist/${artistID}`,
+      {},
+      { method: "PUT" } // Intentional PUT even though this is a create operation
+    ),
     createPartnerOfferLoader: gravityLoader(
       "partner_offer",
       {},

--- a/src/schema/v2/artist/__tests__/createArtistMutation.test.ts
+++ b/src/schema/v2/artist/__tests__/createArtistMutation.test.ts
@@ -53,6 +53,77 @@ describe("createArtistMutation", () => {
     })
   })
 
+  it("creates the partner artist record when partnerID is provided", async () => {
+    const mockCreateArtistLoader = jest.fn(() =>
+      Promise.resolve({
+        id: "artistID",
+        display_name: "Andy Manner",
+      })
+    )
+    const mockCreatePartnerArtistLoader = jest.fn(() =>
+      Promise.resolve({
+        id: "partnerArtistID",
+        artist_id: "artistID",
+      })
+    )
+
+    const context = {
+      createArtistLoader: mockCreateArtistLoader,
+      createPartnerArtistLoader: mockCreatePartnerArtistLoader,
+    }
+
+    const mutationWithPartner = gql`
+      mutation {
+        createArtist(
+          input: {
+            displayName: "Andy Manner"
+            isPersonalArtist: true
+            partnerID: "partnerID"
+          }
+        ) {
+          artistOrError {
+            __typename
+            ... on CreateArtistSuccess {
+              artist {
+                displayName
+              }
+            }
+            ... on CreateArtistFailure {
+              mutationError {
+                message
+              }
+            }
+          }
+        }
+      }
+    `
+    const result = await runAuthenticatedQuery(mutationWithPartner, context)
+
+    expect(mockCreateArtistLoader).toBeCalledWith({
+      display_name: "Andy Manner",
+      is_personal_artist: true,
+    })
+
+    expect(mockCreatePartnerArtistLoader).toBeCalledWith(
+      {
+        artistID: "artistID",
+        partnerID: "partnerID",
+      },
+      { represented_by: false }
+    )
+
+    expect(result).toEqual({
+      createArtist: {
+        artistOrError: {
+          __typename: "CreateArtistSuccess",
+          artist: {
+            displayName: "Andy Manner",
+          },
+        },
+      },
+    })
+  })
+
   it("throws error when data loader is missing", async () => {
     const errorResponse = "You need to be logged in to perform this action"
 


### PR DESCRIPTION
For a newly built 'Create Artist' flow in Volt (not Kinetic based) - we need to support not just creating the artist but also associating the partner artist.

This replicates the logic that Volt server side was currently doing [here](https://github.com/artsy/volt/blob/88070a1a394356d51e8ea5b3949ae51a60785c83/app/controllers/artists_controller.rb#L33).