### PR TITLE
chore: Expose addressType and publiclyViewable filed on Location

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12719,6 +12719,9 @@ enum LiveAuctionRole {
 type Location {
   address: String
   address2: String
+
+  # Buisness, temporary, or private address
+  addressType: String
   cached: Int
   city: String
   coordinates: LatLng
@@ -12741,6 +12744,9 @@ type Location {
   openingHours: OpeningHoursUnion
   phone: String
   postalCode: String
+
+  # Boolean flag that denotes whether a location is publicly viewable on Partner's Artsy Profile
+  publiclyViewable: Boolean
   state: String
   summary: String
 }

--- a/src/schema/v2/location.ts
+++ b/src/schema/v2/location.ts
@@ -99,7 +99,17 @@ export const LocationType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
       resolve: ({ day_schedule_text }) => day_schedule_text,
     },
-
+    addressType: {
+      description: "Buisness, temporary, or private address",
+      type: GraphQLString,
+      resolve: ({ address_type }) => address_type,
+    },
+    publiclyViewable: {
+      description:
+        "Boolean flag that denotes whether a location is publicly viewable on Partner's Artsy Profile",
+      type: GraphQLBoolean,
+      resolve: ({ publicly_viewable }) => publicly_viewable,
+    },
     openingHours: {
       type: OpeningHoursUnion,
       resolve: ({ day_schedules, day_schedule_text }) =>

--- a/src/schema/v2/partner/__tests__/partner.test.js
+++ b/src/schema/v2/partner/__tests__/partner.test.js
@@ -521,6 +521,8 @@ describe("Partner type", () => {
           address_2: "",
           postal_code: "10013",
           state: "NY",
+          publicly_viewable: true,
+          address_type: "Buisness",
         },
         {
           city: "Detroit",
@@ -655,6 +657,44 @@ describe("Partner type", () => {
               {
                 node: {
                   city: "Tokyo",
+                },
+              },
+            ],
+          },
+        },
+      })
+    })
+
+    it("returns additional location metadata", async () => {
+      const query = `
+      {
+        partner(id:"bau-xi-gallery") {
+          locationsConnection(first:1) {
+            totalCount
+            edges {
+              node {
+                publiclyViewable
+                addressType
+                display
+              }
+            }
+          }
+        }
+      }
+    `
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        partner: {
+          locationsConnection: {
+            totalCount: 3,
+            edges: [
+              {
+                node: {
+                  addressType: "Buisness",
+                  publiclyViewable: true,
+                  display: "401 Broadway 26th floor, New York, NY, 10013, US",
                 },
               },
             ],


### PR DESCRIPTION
Exposes already accessible from Gravity's partner/locations endpoint the `addressType` and `publiclyViewable` filed on Location

It is available in Gravity's endpoint JSON
- https://github.com/artsy/gravity/blob/main/app/models/domain/partner_location.rb#L91
- https://github.com/artsy/gravity/blob/main/app/models/domain/partner_location.rb#L99

It is needed to populate some details in Volt's settings V2 [here](https://github.com/artsy/volt/pull/8541)


Ex:
```graphql
{
  partner(id: "commerce-test-partner") {
    locationsConnection(first: 15) {
      edges {
        node {
          display
          publiclyViewable
          addressType
        }
      }
    }
  }
}

```
```
{
  "data": {
    "partner": {
      "locationsConnection": {
        "edges": [
          {
            "node": {
              "display": "401 Broadway 26th floor, New York, NY, 10013, US",
              "publiclyViewable": true,
              "addressType": "Business"
            }
          },
          {
            "node": {
              "display": "96 Greene Street, 3rd Fl, New York, NY, 10013, US",
              "publiclyViewable": true,
              "addressType": "Business"
            }
          },
          {
            "node": {
              "display": "Gala Place, 56 Dundas Street Mong Kok, Kowloon, Hong Kong, -, HK",
              "publiclyViewable": true,
              "addressType": "Business"
            }
          },
```

<img width="1268" alt="Screenshot 2025-03-18 at 5 58 33 PM" src="https://github.com/user-attachments/assets/11465310-1cb4-46e5-9c07-21706c40ef0b" />

