### PR TITLE
feat: allow for contacts to be accessible on Partner type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8015,6 +8015,41 @@ enum ConsignmentSubmissionStateAggregation {
   SUBMITTED
 }
 
+type Contact {
+  canContact: Boolean
+  email: String
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID.
+  internalID: ID!
+  location: Location
+  name: String
+  phone: String
+  position: String
+}
+
+# A connection to a list of items.
+type ContactConnection {
+  # A list of edges.
+  edges: [ContactEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type ContactEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: Contact
+}
+
 type ConvectionService {
   geminiTemplateKey: String!
 }
@@ -15621,6 +15656,16 @@ type Partner implements Node {
   cities(size: Int = 25): [String]
   claimed: Boolean
   collectingInstitution: String
+
+  # A connection of contacts from a Partner.
+  contactsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    page: Int
+    size: Int
+  ): ContactConnection
   counts: PartnerCounts
   defaultProfileID: String
   displayArtistsSection: Boolean

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15663,8 +15663,6 @@ type Partner implements Node {
     before: String
     first: Int
     last: Int
-    page: Int
-    size: Int
   ): ContactConnection
   counts: PartnerCounts
   defaultProfileID: String

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -774,6 +774,11 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    partnerContactsLoader: gravityLoader(
+      (id) => `partner/${id}/contacts`,
+      {},
+      { headers: true }
+    ),
     partnerInquiryRequestLoader: gravityLoader<
       any,
       { partnerId: string; inquiryId: string }

--- a/src/schema/Contacts/index.ts
+++ b/src/schema/Contacts/index.ts
@@ -1,0 +1,42 @@
+import { GraphQLBoolean, GraphQLObjectType, GraphQLString } from "graphql"
+import { connectionWithCursorInfo } from "schema/v2/fields/pagination"
+import { LocationType } from "schema/v2/location"
+import { IDFields } from "schema/v2/object_identification"
+import { ResolverContext } from "types/graphql"
+
+export const ContactType = new GraphQLObjectType<any, ResolverContext>({
+  name: "Contact",
+  fields: () => {
+    return {
+      ...IDFields,
+      name: {
+        type: GraphQLString,
+        resolve: ({ name }) => name,
+      },
+      email: {
+        type: GraphQLString,
+        resolve: ({ email }) => email,
+      },
+      phone: {
+        type: GraphQLString,
+        resolve: ({ phone }) => phone,
+      },
+      position: {
+        type: GraphQLString,
+        resolve: ({ position }) => position,
+      },
+      location: {
+        type: LocationType,
+        resolve: ({ partner_location }) => partner_location,
+      },
+      canContact: {
+        type: GraphQLBoolean,
+        resolve: ({ can_contact }) => can_contact,
+      },
+    }
+  },
+})
+
+export const contactsConnection = connectionWithCursorInfo({
+  nodeType: ContactType,
+})

--- a/src/schema/v2/partner/__tests__/partner.test.js
+++ b/src/schema/v2/partner/__tests__/partner.test.js
@@ -509,6 +509,93 @@ describe("Partner type", () => {
     })
   })
 
+  describe("#contactsConnection", () => {
+    let contactsResponse
+
+    const partnerContactsLoader = jest.fn(() => {
+      return Promise.resolve({
+        body: contactsResponse,
+        headers: {
+          "x-total-count": contactsResponse.length,
+        },
+      })
+    })
+
+    const partnerLoader = jest.fn(() => {
+      return Promise.resolve(partnerData)
+    })
+
+    beforeEach(() => {
+      contactsResponse = [
+        {
+          id: "contact-1",
+          name: "Molly D",
+          email: "md@artsy.net",
+          partner_location: { display: "123 Happy St, NY NY" },
+        },
+        {
+          id: "contact-2",
+          name: "Percy Z",
+          email: "pz@gmail.com",
+        },
+      ]
+    })
+
+    it("returns partner contacts", async () => {
+      context = {
+        partnerContactsLoader,
+        partnerLoader,
+      }
+
+      const query = `
+        {
+          partner(id:"bau-xi-gallery") {
+            contactsConnection(first:3) {
+              totalCount
+              edges {
+                node {
+                  name
+                  email
+                  location {
+                    display
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const data = await runAuthenticatedQuery(query, context)
+
+      expect(data).toEqual({
+        partner: {
+          contactsConnection: {
+            totalCount: 2,
+            edges: [
+              {
+                node: {
+                  name: "Molly D",
+                  email: "md@artsy.net",
+                  location: {
+                    display: "123 Happy St, NY NY",
+                  },
+                },
+              },
+              {
+                node: {
+                  name: "Percy Z",
+                  email: "pz@gmail.com",
+                  location: null,
+                },
+              },
+            ],
+          },
+        },
+      })
+    })
+  })
+
   describe("#locationsConnection", () => {
     let locationsResponse
 

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -756,14 +756,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       contactsConnection: {
         description: "A connection of contacts from a Partner.",
         type: contactsConnection.connectionType,
-        args: pageable({
-          page: {
-            type: GraphQLInt,
-          },
-          size: {
-            type: GraphQLInt,
-          },
-        }),
+        args: pageable(),
         resolve: async ({ id }, args, { partnerContactsLoader }) => {
           if (!partnerContactsLoader) return null
 
@@ -771,12 +764,13 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             args
           )
 
-          const { body } = await partnerContactsLoader(id, {
+          const { body, headers } = await partnerContactsLoader(id, {
             page,
             size,
+            total_count: true,
           })
 
-          const totalCount = body.length
+          const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 
           return paginationResolver({
             totalCount,


### PR DESCRIPTION
Adds a `contactsConnection` on the `Partner` type for the Settings V2 re-write

Historically this data was fetched via Volt -> Kinetic -> Grav Rest
Adding this to the MP layer

Here's the data needed for the existing screen:
<img width="500" alt="Screenshot 2025-03-19 at 1 20 52 PM" src="https://github.com/user-attachments/assets/f529bbe8-e475-43df-b7c9-4dbb6d5bc86c" />




The new MP query will look like this
```graphql
{
  partner(id: "commerce-test-partner") {
    contactsConnection(first: 10) {
      edges {
        node {
          name
          location {
            display
          }
        }
      }
    }
  }
}

```
<img width="1089" alt="Screenshot 2025-03-19 at 1 18 49 PM" src="https://github.com/user-attachments/assets/9538cd17-0ac4-46b3-8340-1907b52c1127" />


---

## TODOs:
- [ ] Need to thread through `partner_communications` from the API, that seems to be an array of objects. That concept needs to be properly typed here in MP and I'll do it after getting just some general approach feedback
- [x] Tests


