### PR TITLE
fix(DIA-1236): Update Discover Daily homefeed image to new asset

### DIFF
--- a/src/schema/v2/homeView/sections/InfiniteDiscovery.ts
+++ b/src/schema/v2/homeView/sections/InfiniteDiscovery.ts
@@ -20,7 +20,7 @@ export const InfiniteDiscovery: HomeViewSection = {
       subtitle:
         "Effortless discovery, expert curation — find art you love, one swipe at a time.",
       buttonText: "Try It",
-      image_url: "https://files.artsy.net/images/DD_Asset.png",
+      image_url: "https://files.artsy.net/images/discover_daily_cover.webp",
       entityType: "Page",
       entityID: parent.ownerType,
       badgeText: "New",

--- a/src/schema/v2/homeView/sections/InfiniteDiscovery.ts
+++ b/src/schema/v2/homeView/sections/InfiniteDiscovery.ts
@@ -20,7 +20,7 @@ export const InfiniteDiscovery: HomeViewSection = {
       subtitle:
         "Effortless discovery, expert curation — find art you love, one swipe at a time.",
       buttonText: "Try It",
-      image_url: "https://files.artsy.net/images/infinite_disco_large.webp",
+      image_url: "https://files.artsy.net/images/DD_Asset.png",
       entityType: "Page",
       entityID: parent.ownerType,
       badgeText: "New",

--- a/src/schema/v2/homeView/sections/__tests__/InfiniteDiscovery.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/InfiniteDiscovery.test.ts
@@ -96,7 +96,7 @@ describe("InfiniteDiscovery", () => {
             "entityType": "Page",
             "href": null,
             "image": {
-              "imageURL": "https://files.artsy.net/images/DD_Asset.png",
+              "imageURL": "https://files.artsy.net/images/discover_daily_cover.webp",
             },
             "subtitle": "Effortless discovery, expert curation — find art you love, one swipe at a time.",
             "title": "Discover Daily",

--- a/src/schema/v2/homeView/sections/__tests__/InfiniteDiscovery.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/InfiniteDiscovery.test.ts
@@ -96,7 +96,7 @@ describe("InfiniteDiscovery", () => {
             "entityType": "Page",
             "href": null,
             "image": {
-              "imageURL": "https://files.artsy.net/images/infinite_disco_large.webp",
+              "imageURL": "https://files.artsy.net/images/DD_Asset.png",
             },
             "subtitle": "Effortless discovery, expert curation — find art you love, one swipe at a time.",
             "title": "Discover Daily",


### PR DESCRIPTION
This addresses [DIA-1236], updating the homeview image.

[DIA-1236]: https://artsyproduct.atlassian.net/browse/DIA-1236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ