### PR TITLE
feat: Allow clients to pass in contact type arg to contacts connection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15731,6 +15731,7 @@ type Partner implements Node {
   contactsConnection(
     after: String
     before: String
+    contactType: contactType
     first: Int
     last: Int
   ): ContactConnection
@@ -23333,6 +23334,11 @@ enum addressType {
   BUSINESS
   OTHER
   TEMPORARY
+}
+
+enum contactType {
+  ADMIN
+  PARTNER
 }
 
 input createAlertInput {

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -756,7 +756,17 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       contactsConnection: {
         description: "A connection of contacts from a Partner.",
         type: contactsConnection.connectionType,
-        args: pageable(),
+        args: pageable({
+          contactType: {
+            type: new GraphQLEnumType({
+              name: "contactType",
+              values: {
+                PARTNER: { value: "partner" },
+                ADMIN: { value: "admin" },
+              },
+            }),
+          },
+        }),
         resolve: async ({ id }, args, { partnerContactsLoader }) => {
           if (!partnerContactsLoader) return null
 
@@ -768,6 +778,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             page,
             size,
             total_count: true,
+            contact_type: args.contactType,
           })
 
           const totalCount = parseInt(headers["x-total-count"] || "0", 10)


### PR DESCRIPTION
feat: Allow clients to pass in contact type arg to contacts connection

The PartnerContact model supports two contact types:
 - `admin` 
 - `partner`
 
What is the difference between these two? I dont know! More digging for tomorrow

but TL;DR Gravity's PartnerContact endpoint will return any type of partner type if not specified and Volt only wants records where `contact_type='partner'`



Historically on Volt's side we only display PartnerContact records where the `contact_type='partner'`. See here: https://github.com/artsy/volt/blob/85e135ec5854e1c272f5430bcedd7c1d5172ea46/app/controllers/contacts_controller.rb#L7-L18


Anyway, allow the new `contactsConnection` to accept a type argument so clients can filter


