### PR TITLE
fix: permit collection.slug nullability

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4559,7 +4559,7 @@ type Collection {
   # True if this collection represents artworks explicitly saved by the user, false otherwise.
   saves: Boolean!
   shareableWithPartners: Boolean!
-  slug: String!
+  slug: String
 }
 
 enum CollectionArtworkSorts {

--- a/src/schema/v2/me/collection.ts
+++ b/src/schema/v2/me/collection.ts
@@ -155,7 +155,7 @@ export const CollectionType = new GraphQLObjectType<any, ResolverContext>({
       type: new GraphQLNonNull(GraphQLBoolean),
     },
     slug: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: GraphQLString,
     },
   }),
 })


### PR DESCRIPTION
This `slug` field was added for collection sharing last Hackathon.

This changes it from non-nullable to nullable, to make it consistent with Gravity, which is [expected to return](https://github.com/artsy/gravity/blob/f0cc2252702133add0d0b62f7f84f13faa6fd5e7/app/models/domain/collection.rb#L273) `slug: null` for any collection which has not yet been made public:

(I'm making some updates to the sharing UI and, without this change, we get the dreaded `Cannot return null for non-nullable field` on the `collection`.)

Since the hackathon feature is the only use of this new `slug` field, and it is [_not_ assumed](https://github.com/artsy/force/blob/dca9d97cce0b24100251d21dd62bba960684566a/src/Apps/CollectorProfile/Routes/Saves/Components/SavesArtworksHeader.tsx#L98) to be non-null, I believe this breaking change should still be safe.