### PR TITLE
chore: add documentsConnection under Show

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -19618,6 +19618,14 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
 
   # A description of the show
   description: String
+
+  # Retrieve all documents for this show
+  documentsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): PartnerDocumentConnection
   endAt(
     format: String
 


### PR DESCRIPTION
Adds `documentsConnection` under the `Show` type (necessary for rebuild of partner show show/edit functionality in Volt).

Technically this existed under `Partner` where you needed to provide a `showID` argument - but I think this is a worthy addition to the `Show` type to make it more inline with other data that lives on this type.