### PR TITLE
feat(settingsV2): Adds mutation to create partner contacts

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8822,14 +8822,45 @@ type CreatePageSuccess {
   page: Page
 }
 
-type CreatePartnerContactResponse {
+type CreatePartnerContactFailure {
+  mutationError: GravityMutationError
+}
+
+input CreatePartnerContactInput {
+  # If true, send all user inquiries and order notifications to this contact.
   canContact: Boolean
+  clientMutationId: String
+
+  # Email address of the contact
   email: String
-  id: String!
+
+  # ID of the contact's partner location
   locationID: String
+
+  # Contact's name
   name: String
+
+  # ID of the partner
+  partnerID: String!
+
+  # Phone number of the contact
   phone: String
+
+  # Contact's position at the partner
   position: String
+}
+
+union CreatePartnerContactOrError =
+    CreatePartnerContactFailure
+  | CreatePartnerContactSuccess
+
+type CreatePartnerContactPayload {
+  clientMutationId: String
+  partnerContactOrError: CreatePartnerContactOrError
+}
+
+type CreatePartnerContactSuccess {
+  contact: Contact
 }
 
 type CreateSaleAgreementFailure {
@@ -14491,8 +14522,8 @@ type Mutation {
 
   # Creates a new contact for a partner
   createPartnerContact(
-    input: createPartnerContactInput!
-  ): createPartnerContactPayload
+    input: CreatePartnerContactInput!
+  ): CreatePartnerContactPayload
 
   # Create a partner offer for the users
   createPartnerOffer(
@@ -23490,35 +23521,6 @@ union createOrderedSetResponseOrError =
 
 type createOrderedSetSuccess {
   set: OrderedSet
-}
-
-input createPartnerContactInput {
-  # If true, send all user inquiries and order notifications to this contact.
-  canContact: Boolean
-  clientMutationId: String
-
-  # Email address of the contact
-  email: String
-
-  # ID of the contact's partner location
-  locationID: String
-
-  # Contact's name
-  name: String
-
-  # ID of the partner
-  partnerID: String!
-
-  # Phone number of the contact
-  phone: String
-
-  # Contact's position at the partner
-  position: String
-}
-
-type createPartnerContactPayload {
-  clientMutationId: String
-  partnerContact: CreatePartnerContactResponse
 }
 
 type createPartnerOfferFailure {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -23500,9 +23500,6 @@ input createPartnerContactInput {
   # Email address of the contact
   email: String
 
-  # Confirmation of the email address
-  emailConfirmation: String
-
   # ID of the contact's partner location
   locationID: String
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8860,7 +8860,7 @@ type CreatePartnerContactPayload {
 }
 
 type CreatePartnerContactSuccess {
-  contact: Contact
+  partnerContact: Contact
 }
 
 type CreateSaleAgreementFailure {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8822,6 +8822,16 @@ type CreatePageSuccess {
   page: Page
 }
 
+type CreatePartnerContactResponse {
+  canContact: Boolean
+  email: String
+  id: String!
+  locationID: String
+  name: String
+  phone: String
+  position: String
+}
+
 type CreateSaleAgreementFailure {
   mutationError: GravityMutationError
 }
@@ -14478,6 +14488,11 @@ type Mutation {
 
   # Creates a static Markdown-backed page.
   createPage(input: CreatePageMutationInput!): CreatePageMutationPayload
+
+  # Creates a new contact for a partner
+  createPartnerContact(
+    input: createPartnerContactInput!
+  ): createPartnerContactPayload
 
   # Create a partner offer for the users
   createPartnerOffer(
@@ -23475,6 +23490,38 @@ union createOrderedSetResponseOrError =
 
 type createOrderedSetSuccess {
   set: OrderedSet
+}
+
+input createPartnerContactInput {
+  # If true, send all user inquiries and order notifications to this contact.
+  canContact: Boolean
+  clientMutationId: String
+
+  # Email address of the contact
+  email: String
+
+  # Confirmation of the email address
+  emailConfirmation: String
+
+  # ID of the contact's partner location
+  locationID: String
+
+  # Contact's name
+  name: String
+
+  # ID of the partner
+  partnerID: String!
+
+  # Phone number of the contact
+  phone: String
+
+  # Contact's position at the partner
+  position: String
+}
+
+type createPartnerContactPayload {
+  clientMutationId: String
+  partnerContact: CreatePartnerContactResponse
 }
 
 type createPartnerOfferFailure {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -224,6 +224,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" } // Intentional PUT even though this is a create operation
     ),
+    createPartnerContactLoader: gravityLoader(
+      (id) => `partner/${id}/contact`,
+      {},
+      { method: "POST" }
+    ),
     createPartnerOfferLoader: gravityLoader(
       "partner_offer",
       {},

--- a/src/schema/v2/partner/__tests__/createPartnerContactMutation.test.js
+++ b/src/schema/v2/partner/__tests__/createPartnerContactMutation.test.js
@@ -1,0 +1,100 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+const mutation = gql`
+  mutation {
+    createPartnerContact(
+      input: {
+        partnerID: "partner_123"
+        name: "Jane Doe"
+        position: "Manager"
+        canContact: true
+        email: "jane@example.com"
+        phone: "123-456-7890"
+        locationID: "location_567"
+      }
+    ) {
+      partnerContactOrError {
+        __typename
+        ... on CreatePartnerContactSuccess {
+          partnerContact {
+            internalID
+            name
+            canContact
+            position
+            email
+            phone
+          }
+        }
+        ... on CreatePartnerContactFailure {
+          mutationError {
+            message
+          }
+        }
+      }
+    }
+  }
+`
+
+describe("CreatePartnerContactMutation", () => {
+  describe("when successful", () => {
+    const partnerContact = {
+      id: "contact_123",
+      name: "Jane Doe",
+      position: "Manager",
+      can_contact: true,
+      email: "jane@example.com",
+      phone: "123-456-7890",
+      location_id: "location_567",
+    }
+
+    const context = {
+      createPartnerContactLoader: () => Promise.resolve(partnerContact),
+    }
+
+    it("creates a partner contact", async () => {
+      const data = await runAuthenticatedQuery(mutation, context)
+      expect(data).toEqual({
+        createPartnerContact: {
+          partnerContactOrError: {
+            __typename: "CreatePartnerContactSuccess",
+            partnerContact: {
+              internalID: "contact_123",
+              name: "Jane Doe",
+              position: "Manager",
+              canContact: true,
+              email: "jane@example.com",
+              phone: "123-456-7890",
+            },
+          },
+        },
+      })
+    })
+  })
+
+  describe("when failure", () => {
+    it("returns an error", async () => {
+      const context = {
+        createPartnerContactLoader: () =>
+          Promise.reject(
+            new Error(
+              `https://stagingapi.artsy.net/api/v1/partner_contact - {"type":"error","message":"Partner not found"}`
+            )
+          ),
+      }
+
+      const response = await runAuthenticatedQuery(mutation, context)
+
+      expect(response).toEqual({
+        createPartnerContact: {
+          partnerContactOrError: {
+            __typename: "CreatePartnerContactFailure",
+            mutationError: {
+              message: "Partner not found",
+            },
+          },
+        },
+      })
+    })
+  })
+})

--- a/src/schema/v2/partner/createPartnerContactMutation.ts
+++ b/src/schema/v2/partner/createPartnerContactMutation.ts
@@ -7,14 +7,12 @@ import {
 import { mutationWithClientMutationId } from "graphql-relay"
 import { ResolverContext } from "types/graphql"
 
-// Check whats required and whats optional
 interface Input {
   partnerID: string
   name?: string
   position?: string
   canContact?: boolean
   email?: string
-  emailConfirmation?: string
   phone?: string
   locationID?: string
 }
@@ -64,11 +62,6 @@ export const createPartnerContactMutation = mutationWithClientMutationId<
       type: GraphQLString,
       description: "Email address of the contact",
     },
-    // Do we need this? is it persisted in the database? What does volt use to read it
-    emailConfirmation: {
-      type: GraphQLString,
-      description: "Confirmation of the email address",
-    },
     phone: {
       type: GraphQLString,
       description: "Phone number of the contact",
@@ -85,16 +78,7 @@ export const createPartnerContactMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    {
-      partnerID,
-      name,
-      position,
-      canContact,
-      email,
-      emailConfirmation,
-      phone,
-      locationID,
-    },
+    { partnerID, name, position, canContact, email, phone, locationID },
     { createPartnerContactLoader }
   ) => {
     if (!createPartnerContactLoader) {
@@ -107,7 +91,6 @@ export const createPartnerContactMutation = mutationWithClientMutationId<
         position,
         can_contact: canContact,
         email,
-        email_confirmation: emailConfirmation,
         phone,
         partner_location_id: locationID,
       })

--- a/src/schema/v2/partner/createPartnerContactMutation.ts
+++ b/src/schema/v2/partner/createPartnerContactMutation.ts
@@ -1,0 +1,120 @@
+import {
+  GraphQLBoolean,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+
+// Check whats required and whats optional
+interface Input {
+  partnerID: string
+  name?: string
+  position?: string
+  canContact?: boolean
+  email?: string
+  emailConfirmation?: string
+  phone?: string
+  locationID?: string
+}
+
+const CreatePartnerContactMutationResponseType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "CreatePartnerContactResponse",
+  fields: () => ({
+    id: { type: new GraphQLNonNull(GraphQLString) },
+    name: { type: GraphQLString },
+    position: { type: GraphQLString },
+    canContact: { type: GraphQLBoolean },
+    email: { type: GraphQLString },
+    phone: { type: GraphQLString },
+    locationID: { type: GraphQLString },
+  }),
+})
+
+export const createPartnerContactMutation = mutationWithClientMutationId<
+  Input,
+  any,
+  ResolverContext
+>({
+  name: "createPartnerContact",
+  description: "Creates a new contact for a partner",
+  inputFields: {
+    partnerID: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "ID of the partner",
+    },
+    name: {
+      type: GraphQLString,
+      description: "Contact's name",
+    },
+    position: {
+      type: GraphQLString,
+      description: "Contact's position at the partner",
+    },
+    canContact: {
+      type: GraphQLBoolean,
+      description:
+        "If true, send all user inquiries and order notifications to this contact.",
+    },
+    email: {
+      type: GraphQLString,
+      description: "Email address of the contact",
+    },
+    // Do we need this? is it persisted in the database? What does volt use to read it
+    emailConfirmation: {
+      type: GraphQLString,
+      description: "Confirmation of the email address",
+    },
+    phone: {
+      type: GraphQLString,
+      description: "Phone number of the contact",
+    },
+    locationID: {
+      type: GraphQLString,
+      description: "ID of the contact's partner location",
+    },
+  },
+  outputFields: {
+    partnerContact: {
+      type: CreatePartnerContactMutationResponseType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    {
+      partnerID,
+      name,
+      position,
+      canContact,
+      email,
+      emailConfirmation,
+      phone,
+      locationID,
+    },
+    { createPartnerContactLoader }
+  ) => {
+    if (!createPartnerContactLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const response = await createPartnerContactLoader(partnerID, {
+        name,
+        position,
+        can_contact: canContact,
+        email,
+        email_confirmation: emailConfirmation,
+        phone,
+        partner_location_id: locationID,
+      })
+
+      return response
+    } catch (error) {
+      throw new Error(`Failed to create partner contact: ${error.message}`)
+    }
+  },
+})

--- a/src/schema/v2/partner/createPartnerContactMutation.ts
+++ b/src/schema/v2/partner/createPartnerContactMutation.ts
@@ -6,7 +6,10 @@ import {
   GraphQLUnionType,
 } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
-import { GravityMutationErrorType } from "lib/gravityErrorHandler"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
 import { ContactType } from "../Contacts"
 
@@ -24,7 +27,7 @@ const SuccessType = new GraphQLObjectType<any, ResolverContext>({
   name: "CreatePartnerContactSuccess",
   isTypeOf: (data) => data.id,
   fields: () => ({
-    contact: {
+    partnerContact: {
       type: ContactType,
       resolve: (result) => result,
     },
@@ -111,7 +114,12 @@ export const CreatePartnerContactMutation = mutationWithClientMutationId<
 
       return response
     } catch (error) {
-      throw new Error(`Failed to create partner contact: ${error.message}`)
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
     }
   },
 })

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -278,6 +278,7 @@ import { MatchArtworkImportRowImageMutation } from "./ArtworkImport/matchArtwork
 import { FeaturedFairs } from "./FeaturedFairs/featuredFairs"
 import { CancelArtworkImportMutation } from "./ArtworkImport/cancelArtworkImportMutation"
 import { updateOrderMutation, setOrderFulfillmentOptionMutation } from "./order"
+import { createPartnerContactMutation } from "./partner/createPartnerContactMutation"
 
 const rootFields = {
   // artworkVersion: ArtworkVersionResolver,
@@ -459,6 +460,7 @@ export default new GraphQLSchema({
       createIdentityVerificationOverride: createIdentityVerificationOverrideMutation,
       createInvoicePayment: createInvoicePaymentMutation,
       createOrderedSet: createOrderedSetMutation,
+      createPartnerContact: createPartnerContactMutation,
       createPage: CreatePageMutation,
       createPartnerOffer: createPartnerOfferMutation,
       createSaleAgreement: CreateSaleAgreementMutation,

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -278,7 +278,7 @@ import { MatchArtworkImportRowImageMutation } from "./ArtworkImport/matchArtwork
 import { FeaturedFairs } from "./FeaturedFairs/featuredFairs"
 import { CancelArtworkImportMutation } from "./ArtworkImport/cancelArtworkImportMutation"
 import { updateOrderMutation, setOrderFulfillmentOptionMutation } from "./order"
-import { createPartnerContactMutation } from "./partner/createPartnerContactMutation"
+import { CreatePartnerContactMutation } from "./partner/createPartnerContactMutation"
 
 const rootFields = {
   // artworkVersion: ArtworkVersionResolver,
@@ -460,7 +460,7 @@ export default new GraphQLSchema({
       createIdentityVerificationOverride: createIdentityVerificationOverrideMutation,
       createInvoicePayment: createInvoicePaymentMutation,
       createOrderedSet: createOrderedSetMutation,
-      createPartnerContact: createPartnerContactMutation,
+      createPartnerContact: CreatePartnerContactMutation,
       createPage: CreatePageMutation,
       createPartnerOffer: createPartnerOfferMutation,
       createSaleAgreement: CreateSaleAgreementMutation,


### PR DESCRIPTION
Creates a new mutation that processes the creation of new partner contact records


## Example mutation shape
```graphql

mutation {
  createPartnerContact(input: { 
  partnerID: "5f80bfefe8d808000ea212c1"
    name: "Molly D"
    position: "Account Manager"
    canContact: true
    email: "md@2example.com"
    phone: "123-456-7890"
    locationID: "location-567"
  }) {
    partnerContactOrError {
      ... on CreatePartnerContactSuccess {
        contact {
          internalID
          name
          position
          canContact
          email
          phone
          location {
            display
          }
        }
      }
      ... on CreatePartnerContactFailure {
        mutationError {
          message
        }
      }
    }
  }
}

```


which will return the created contact or an error:
```json
{
  "data": {
    "createPartnerContact": {
      "partnerContactOrError": {
        "contact": {
          "internalID": "molly-d-8cd3152d-0684-4735-b2d8-1e962f68dc5d",
          "name": "Molly D",
          "position": "Account Manager",
          "canContact": true,
          "email": "md@2example.com",
          "phone": "123-456-7890",
          "location": null
        }
      }
    }
  },
  "extensions": {
    "requests": {
      "gravity": {
        "requests": {
          "partner/5f80bfefe8d808000ea212c1/contact?can_contact=true&email=md%402example.com&name=Molly%20D&partner_location_id=location-567&phone=123-456-7890&position=Account%20Manager": {
            "time": "0s 362.82ms",
            "cache": false,
            "length": "0 B"
          }
        }
      }
    },
    "requestID": "f1083c20-05df-11f0-87ff-1748375545e7",
    "userAgent": "graphiql-app"
  }
}
```

---

<img width="1105" alt="Screenshot 2025-03-20 at 7 07 56 PM" src="https://github.com/user-attachments/assets/539e8076-bc50-44f1-8e70-6c7ed22cbac5" />

---


## Additional Background
Heres the endpoint params in the [Gravity side of things](https://github.com/artsy/gravity/blob/main/app/api/v1/partners_contacts_endpoint.rb#L141-L148)

All optional fields

<img width="300" alt="Screenshot 2025-03-20 at 4 48 10 PM" src="https://github.com/user-attachments/assets/e195dd7b-8c27-4bb3-8db5-f2cfb4a72c43" />


And here's legacy volt form in the UI:

<img width="1301" alt="Screenshot 2025-03-20 at 4 48 56 PM" src="https://github.com/user-attachments/assets/eba9dfce-194d-4f7c-ac26-fe3b1b43e076" />

