### PR TITLE
chore: add artistsConnection to Show

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -19578,6 +19578,14 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
   # The Artists presenting in this show
   artists: [Artist]
 
+  # Connection of Artists included in the show
+  artistsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtistConnection
+
   # Artists in the show grouped by last name
   artistsGroupedByName: [ArtistGroup]
 

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -27,9 +27,11 @@ import Image, { getDefault, normalizeImageData } from "./image"
 import ShowEventType from "./show_event"
 import {
   connectionWithCursorInfo,
+  createPageCursors,
   paginationResolver,
 } from "schema/v2/fields/pagination"
 import { NodeInterface, SlugAndInternalIDFields } from "./object_identification"
+import { artistConnection } from "./artist"
 import {
   GraphQLObjectType,
   GraphQLString,
@@ -116,6 +118,20 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
         type: new GraphQLList(Artist.type),
         resolve: ({ artists }) => {
           return artists
+        },
+      },
+      artistsConnection: {
+        description: "Connection of Artists included in the show",
+        type: artistConnection.connectionType,
+        args: pageable({}),
+        resolve: ({ artists }, args) => {
+          const { page, size } = convertConnectionArgsToGravityArgs(args)
+          const totalCount = artists.length
+          return {
+            totalCount,
+            pageCursors: createPageCursors({ page, size }, totalCount),
+            ...connectionFromArray(artists, args),
+          }
         },
       },
       artworksConnection: {


### PR DESCRIPTION
We have `artists` available, an un-paginated list, as the entire un-paginated set of artists available on a show are included with the show JSON!

But, for convenience and reuse of front-end components that expect a connection (like our `List`) - let's add and front that list w/ a connection.