### PR TITLE
chore: make sure pageCursors available on artworksConnection: Show

### DIFF
--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -172,6 +172,7 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
 
           return {
             totalCount,
+            pageCursors: createPageCursors({ page, size }, totalCount),
             ...connectionFromArraySlice(body, options, {
               arrayLength: totalCount,
               sliceStart: offset,


### PR DESCRIPTION
This is probably just for a placeholder since we'll use the ES-backed connection (sharing from new artworks listing). But for now - let's use this, but annoyingly - it didn't offer our standard cursor setup for list pagination!