### PR TITLE
chore: add imagesConnection to Show

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12366,6 +12366,26 @@ type Image {
   width: Int
 }
 
+# A connection to a list of items.
+type ImageConnection {
+  # A list of edges.
+  edges: [ImageEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type ImageEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: Image
+}
+
 type ImageURLs {
   normalized: String
 }
@@ -19755,6 +19775,12 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
     # Number of images to return
     size: Int
   ): [Image]
+  imagesConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ImageConnection
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -840,7 +840,11 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
-    partnerShowImagesLoader: gravityLoader((id) => `partner_show/${id}/images`),
+    partnerShowImagesLoader: gravityLoader(
+      (id) => `partner_show/${id}/images`,
+      {},
+      { headers: true }
+    ),
     partnerShowDocumentsLoader: gravityLoader<
       any,
       { partnerID: string; showID: string }

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -204,7 +204,11 @@ export default (opts) => {
       {},
       { headers: true }
     ),
-    partnerShowImagesLoader: gravityLoader((id) => `partner_show/${id}/images`),
+    partnerShowImagesLoader: gravityLoader(
+      (id) => `partner_show/${id}/images`,
+      {},
+      { headers: true }
+    ),
     partnerShowArtistsLoader: gravityLoader<
       any,
       { partner_id: string; show_id: string }

--- a/src/schema/v2/artist/carousel.ts
+++ b/src/schema/v2/artist/carousel.ts
@@ -39,7 +39,9 @@ const ArtistCarousel: GraphQLFieldConfig<{ id: string }, ResolverContext> = {
         const elligibleShows = shows.filter((show) => show.images_count > 0)
         return Promise.all(
           elligibleShows.map((show) =>
-            partnerShowImagesLoader(show.id, { size: 1 })
+            partnerShowImagesLoader(show.id, { size: 1 }).then(
+              ({ body }) => body
+            )
           )
         )
           .then((showImages) => {

--- a/src/schema/v2/image/index.ts
+++ b/src/schema/v2/image/index.ts
@@ -20,6 +20,7 @@ import { decode as decodeBlurHash } from "blurhash"
 import UPNG from "upng-js"
 import { encode } from "base64-arraybuffer"
 import { isFeatureFlagEnabled } from "lib/featureFlags"
+import { connectionWithCursorInfo } from "../fields/pagination"
 
 export type OriginalImage = {
   original_width?: number
@@ -195,5 +196,10 @@ const Image: GraphQLFieldConfig<ImageData, ResolverContext> = {
     return normalize(resolvedData)
   },
 }
+
+export const ImageConnectionType = connectionWithCursorInfo({
+  name: "Image",
+  nodeType: ImageType,
+}).connectionType
 
 export default Image


### PR DESCRIPTION
To display install shots at a show using our standard list pagination - need a connection here.