### PR TITLE
chore: add eventsConnection to Show

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -19664,6 +19664,14 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
   # Events from the partner that runs this show
   events: [ShowEventType]
 
+  # Connection of events attached to the show
+  eventsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ShowEventConnection
+
   # A formatted description of the start to end dates
   exhibitionPeriod(
     # Formatting option to apply to exhibition period
@@ -19915,6 +19923,26 @@ type ShowEdge {
 
   # The item at the end of the edge
   node: Show
+}
+
+# A connection to a list of items.
+type ShowEventConnection {
+  # A list of edges.
+  edges: [ShowEventEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type ShowEventEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: ShowEventType
 }
 
 type ShowEventType {

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -28,7 +28,7 @@ import Image, {
   ImageConnectionType,
   normalizeImageData,
 } from "./image"
-import ShowEventType from "./show_event"
+import ShowEventType, { ShowEventConnectionType } from "./show_event"
 import {
   connectionWithCursorInfo,
   createPageCursors,
@@ -362,6 +362,20 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
             partner_id: partner.id,
             show_id: id,
           }).then(({ events }) => events),
+      },
+      eventsConnection: {
+        description: "Connection of events attached to the show",
+        type: ShowEventConnectionType,
+        args: pageable({}),
+        resolve: ({ events }, args) => {
+          const { page, size } = convertConnectionArgsToGravityArgs(args)
+          const totalCount = events.length
+          return {
+            totalCount,
+            pageCursors: createPageCursors({ page, size }, totalCount),
+            ...connectionFromArray(events, args),
+          }
+        },
       },
       exhibitionPeriod: {
         type: GraphQLString,

--- a/src/schema/v2/show_event.ts
+++ b/src/schema/v2/show_event.ts
@@ -3,6 +3,7 @@ import { GraphQLString, GraphQLObjectType } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { dateRange, dateTimeRange } from "lib/date"
 import { ExhibitionPeriodFormatEnum } from "./types/exhibitonPeriod"
+import { connectionWithCursorInfo } from "./fields/pagination"
 
 const ShowEventType = new GraphQLObjectType<any, ResolverContext>({
   name: "ShowEventType",
@@ -46,5 +47,10 @@ const ShowEventType = new GraphQLObjectType<any, ResolverContext>({
     },
   },
 })
+
+export const ShowEventConnectionType = connectionWithCursorInfo({
+  name: "ShowEvent",
+  nodeType: ShowEventType,
+}).connectionType
 
 export default ShowEventType


### PR DESCRIPTION
Similar to `artists` - we have the full list of `events` included in show JSON - but let's include a connection that lets you slice through that data to work nicer with our FE (specifically list/pagination).