### PR TITLE
chore: artwork import price listed currency

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14125,8 +14125,14 @@ type MetaphysicsService {
 }
 
 type Money {
+  # A pre-formatted price.
+  amount: String
+
   # The ISO-4217 alphabetic currency code, as per https://en.wikipedia.org/wiki/ISO_4217
   currencyCode: String!
+
+  # The symbol used for the currency
+  currencyPrefix: String
 
   # A pre-formatted price.
   display: String

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -18,6 +18,7 @@ import { pageable } from "relay-cursor-paging"
 import GraphQLJSON from "graphql-type-json"
 import { ArtistType } from "../artist"
 import { ArtworkType } from "../artwork"
+import { Money } from "../fields/money"
 import { date } from "schema/v2/fields/date"
 
 export const ArtworkImportErrorType = new GraphQLEnumType({

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -18,7 +18,6 @@ import { pageable } from "relay-cursor-paging"
 import GraphQLJSON from "graphql-type-json"
 import { ArtistType } from "../artist"
 import { ArtworkType } from "../artwork"
-import { Money, resolveMinorAndCurrencyFieldsToMoney } from "../fields/money"
 import { date } from "schema/v2/fields/date"
 
 export const ArtworkImportErrorType = new GraphQLEnumType({

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -105,22 +105,9 @@ const ArtworkImportRowType = new GraphQLObjectType({
     },
     priceListed: {
       type: Money,
-      resolve: (
-        { price_minor: minor, currency: currencyCode },
-        args,
-        context,
-        info
-      ) => {
+      resolve: ({ price_minor: minor, currency: currencyCode }) => {
         if (!minor || !currencyCode) return null
-        return resolveMinorAndCurrencyFieldsToMoney(
-          {
-            minor,
-            currencyCode,
-          },
-          args,
-          context,
-          info
-        )
+        return { minor, currencyCode }
       },
     },
     rawData: {

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -18,7 +18,7 @@ import { pageable } from "relay-cursor-paging"
 import GraphQLJSON from "graphql-type-json"
 import { ArtistType } from "../artist"
 import { ArtworkType } from "../artwork"
-import { Money } from "../fields/money"
+import { Money, resolveMinorAndCurrencyFieldsToMoney } from "../fields/money"
 import { date } from "schema/v2/fields/date"
 
 export const ArtworkImportErrorType = new GraphQLEnumType({
@@ -105,9 +105,21 @@ const ArtworkImportRowType = new GraphQLObjectType({
     },
     priceListed: {
       type: Money,
-      resolve: ({ price_minor: minor, currency: currencyCode }) => {
-        if (!minor || !currencyCode) return null
-        return { minor, currencyCode }
+      resolve: (
+        { price_minor: minor, currency: currencyCode },
+        args,
+        context,
+        info
+      ) => {
+        return resolveMinorAndCurrencyFieldsToMoney(
+          {
+            minor,
+            currencyCode,
+          },
+          args,
+          context,
+          info
+        )
       },
     },
     rawData: {

--- a/src/schema/v2/fields/money.ts
+++ b/src/schema/v2/fields/money.ts
@@ -14,7 +14,7 @@ import { ResolverContext } from "types/graphql"
 // Taken from https://github.com/RubyMoney/money/blob/master/config/currency_iso.json
 import currencyCodes from "lib/currency_codes.json"
 import { GraphQLLong } from "lib/customTypes/GraphQLLong"
-import { priceDisplayText } from "lib/moneyHelpers"
+import { priceDisplayText, currencyPrefix, priceAmount } from "lib/moneyHelpers"
 
 export const amountSDL = (name) => `
   ${name}(
@@ -187,6 +187,11 @@ export const Money = new GraphQLObjectType<any, ResolverContext>({
       },
       resolve: moneyMajorResolver,
     },
+    currencyPrefix: {
+      type: GraphQLString,
+      description: "The symbol used for the currency",
+    },
+    amount: { type: GraphQLString, description: "A pre-formatted price." },
   },
 })
 
@@ -227,6 +232,8 @@ export const resolveMinorAndCurrencyFieldsToMoney = async (
       cents: minor,
       currency: currencyCode,
       display: priceDisplayText(minor, currencyCode, ""),
+      amount: priceAmount(minor, currencyCode, ""),
+      currencyPrefix: currencyPrefix(currencyCode),
     }
   } catch (error) {
     console.error(


### PR DESCRIPTION
This will enable us to be able to highlight the `currencyPrefix` when showing price without having to do additional work on the front end. An example us of this can be found in [this figma file](https://www.figma.com/design/y31Q2l6ggPJEtUfWWtvBuE/Listing-experience?node-id=2654-12379&t=FxVBrxKUGtoid3sy-4).

An example response with these changes is as follows

```
"priceListed": {
  "major": 5000,
  "minor": 500000,
  "currencyCode": "USD",
  "display": "US$5,000",
  "currencyPrefix": "US$",
  "amount": "5,000"
}
```