### PR TITLE
feat: add isFixedShippingFeeOnly property to artwork

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2556,6 +2556,9 @@ type Artwork implements Node & Searchable & Sellable {
   # Artwork meets minimum metadata criteria to have an alert created from it
   isEligibleToCreateAlert: Boolean!
   isEmbeddableVideo: Boolean
+
+  # Is this work has shipping fee set to fixed amount?
+  isFixedShippingFeeOnly: Boolean
   isForSale: Boolean
   isFramed: Boolean
   isHangable: Boolean

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -3213,6 +3213,237 @@ describe("Artwork type", () => {
     })
   })
 
+  describe("#isFixedShippingFeeOnly", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          isFixedShippingFeeOnly
+        }
+      }
+    `
+    describe("when artsy domestic shipping enabled", () => {
+      beforeEach(() => {
+        artwork.process_with_artsy_shipping_domestic = true
+      })
+
+      describe("when domestic_shipping_fee_cents and international_shipping_fee is null", () => {
+        beforeEach(() => {
+          artwork.domestic_shipping_fee_cents = null
+          artwork.international_shipping_fee_cents = null
+        })
+
+        it("returns false", () => {
+          return runQuery(query, context).then((data) => {
+            expect(data).toEqual({
+              artwork: {
+                isFixedShippingFeeOnly: false,
+              },
+            })
+          })
+        })
+      })
+
+      describe("when domestic_shipping_fee_cents is present", () => {
+        beforeEach(() => {
+          artwork.domestic_shipping_fee_cents = 100
+          artwork.international_shipping_fee_cents = null
+        })
+
+        it("returns false", () => {
+          return runQuery(query, context).then((data) => {
+            expect(data).toEqual({
+              artwork: {
+                isFixedShippingFeeOnly: false,
+              },
+            })
+          })
+        })
+      })
+
+      describe("when only international_shipping_fee_cents is present", () => {
+        beforeEach(() => {
+          artwork.domestic_shipping_fee_cents = null
+          artwork.international_shipping_fee_cents = 100
+        })
+
+        it("returns false", () => {
+          return runQuery(query, context).then((data) => {
+            expect(data).toEqual({
+              artwork: {
+                isFixedShippingFeeOnly: false,
+              },
+            })
+          })
+        })
+
+        describe("when only artsy international shipping is present", () => {
+          beforeEach(() => {
+            artwork.domestic_shipping_fee_cents = null
+            artwork.international_shipping_fee_cents = null
+            artwork.artsy_shipping_international = true
+          })
+
+          it("returns false", () => {
+            return runQuery(query, context).then((data) => {
+              expect(data).toEqual({
+                artwork: {
+                  isFixedShippingFeeOnly: false,
+                },
+              })
+            })
+          })
+        })
+
+        describe("when both domesting and international fee set to free", () => {
+          beforeEach(() => {
+            artwork.domestic_shipping_fee_cents = 0
+            artwork.international_shipping_fee_cents = 0
+          })
+
+          it("returns false", () => {
+            return runQuery(query, context).then((data) => {
+              expect(data).toEqual({
+                artwork: {
+                  isFixedShippingFeeOnly: false,
+                },
+              })
+            })
+          })
+        })
+      })
+    })
+
+    describe("when artsy domestic shipping disabled", () => {
+      beforeEach(() => {
+        artwork.process_with_artsy_shipping_domestic = false
+        artwork.artsy_shipping_international = false
+      })
+
+      describe("when domestic_shipping_fee_cents and international_shipping_fee is null", () => {
+        beforeEach(() => {
+          artwork.domestic_shipping_fee_cents = null
+          artwork.international_shipping_fee_cents = null
+        })
+
+        it("returns false", () => {
+          return runQuery(query, context).then((data) => {
+            expect(data).toEqual({
+              artwork: {
+                isFixedShippingFeeOnly: false,
+              },
+            })
+          })
+        })
+      })
+
+      describe("when domestic_shipping_fee_cents is present and international shipping is not arta", () => {
+        beforeEach(() => {
+          artwork.domestic_shipping_fee_cents = 100
+          artwork.artsy_shipping_international = false
+          artwork.international_shipping_fee_cents = null
+        })
+
+        it("returns true", () => {
+          return runQuery(query, context).then((data) => {
+            expect(data).toEqual({
+              artwork: {
+                isFixedShippingFeeOnly: true,
+              },
+            })
+          })
+        })
+      })
+
+      describe("when domestic_shipping_fee_cents is present but international shipping is set to arta", () => {
+        beforeEach(() => {
+          artwork.domestic_shipping_fee_cents = 100
+          artwork.artsy_shipping_international = true
+          artwork.international_shipping_fee_cents = null
+        })
+
+        it("returns false", () => {
+          return runQuery(query, context).then((data) => {
+            expect(data).toEqual({
+              artwork: {
+                isFixedShippingFeeOnly: false,
+              },
+            })
+          })
+        })
+      })
+
+      describe("when only international_shipping_fee_cents is present", () => {
+        beforeEach(() => {
+          artwork.domestic_shipping_fee_cents = null
+          artwork.international_shipping_fee_cents = 100
+        })
+
+        it("returns false", () => {
+          return runQuery(query, context).then((data) => {
+            expect(data).toEqual({
+              artwork: {
+                isFixedShippingFeeOnly: false,
+              },
+            })
+          })
+        })
+
+        describe("when only artsy international shipping is present", () => {
+          beforeEach(() => {
+            artwork.domestic_shipping_fee_cents = null
+            artwork.international_shipping_fee_cents = null
+            artwork.artsy_shipping_international = true
+          })
+
+          it("returns false", () => {
+            return runQuery(query, context).then((data) => {
+              expect(data).toEqual({
+                artwork: {
+                  isFixedShippingFeeOnly: false,
+                },
+              })
+            })
+          })
+        })
+
+        describe("when free shipping worldwide", () => {
+          beforeEach(() => {
+            artwork.artsy_shipping_international = false
+            artwork.domestic_shipping_fee_cents = 0
+            artwork.international_shipping_fee_cents = 0
+          })
+
+          it("returns true", () => {
+            return runQuery(query, context).then((data) => {
+              expect(data).toEqual({
+                artwork: {
+                  isFixedShippingFeeOnly: true,
+                },
+              })
+            })
+          })
+        })
+
+        describe("when free domestic shipping and international not configured", () => {
+          beforeEach(() => {
+            artwork.domestic_shipping_fee_cents = 0
+            artwork.international_shipping_fee_cents = null
+          })
+
+          it("returns true", () => {
+            return runQuery(query, context).then((data) => {
+              expect(data).toEqual({
+                artwork: {
+                  isFixedShippingFeeOnly: true,
+                },
+              })
+            })
+          })
+        })
+      })
+    })
+  })
+
   describe("#shippingOrigin", () => {
     const query = `
       {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1377,6 +1377,19 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           )
         },
       },
+      isFixedShippingFeeOnly: {
+        type: GraphQLBoolean,
+        description: "Is this work has shipping fee set to fixed amount?",
+        resolve: (artwork) => {
+          const domesticShippingFixed =
+            !artwork.process_with_artsy_shipping_domestic &&
+            artwork.domestic_shipping_fee_cents != null
+
+          return Boolean(
+            domesticShippingFixed && !artwork.artsy_shipping_international
+          )
+        },
+      },
       domesticShippingFee: {
         type: Money,
         description: "Domestic shipping fee.",


### PR DESCRIPTION
In preparation to check in Force (EMI-2357) for fixed shipping fee for the order adding this property here. 

Was debating if just request a raw data and do this check in Force but figured it might be helpful in other contexts and also did not want a lot of logic on the client for this one.
