### PR TITLE
chore(EMI-2306): Add Order.taxTotal money field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15435,6 +15435,9 @@ type Order {
 
   # Source of the order
   source: OrderSourceEnum!
+
+  # The total amount for tax
+  taxTotal: Money
 }
 
 enum OrderModeEnum {

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -26,6 +26,7 @@ describe("Me", () => {
       shipping_city: "New York",
       shipping_address_line1: "123 Main St",
       shipping_address_line2: "Apt 4B",
+      tax_total_cents: 4299,
     }
     artwork = artwork || {
       ...baseArtwork,
@@ -57,7 +58,10 @@ describe("Me", () => {
                 currencyCode
               }
               shippingTotal {
-                display
+                minor
+              }
+              taxTotal {
+                minor
               }
               fulfillmentOptions {
                 type
@@ -127,7 +131,10 @@ describe("Me", () => {
           minor: 500000,
         },
         shippingTotal: {
-          display: "US$20",
+          minor: 2000,
+        },
+        taxTotal: {
+          minor: 4299,
         },
         fulfillmentOptions: [
           {

--- a/src/schema/v2/order/sharedOrderTypes.ts
+++ b/src/schema/v2/order/sharedOrderTypes.ts
@@ -37,6 +37,7 @@ interface OrderJSON {
   shipping_postal_code?: string
   shipping_region?: string
   shipping_country?: string
+  tax_total_cents?: number
   fulfillment_options: Array<{
     type: string
     amount_minor: number
@@ -50,6 +51,7 @@ interface OrderJSON {
     list_price_cents: number
     quantity: number
     shipping_total_cents?: number
+    tax_cents?: number
     currency_code: string
   }>
 }
@@ -306,6 +308,26 @@ export const OrderType = new GraphQLObjectType<OrderJSON, ResolverContext>({
       description: "The total amount for shipping",
       resolve: (
         { shipping_total_cents: minor, currency_code: currencyCode },
+        _args,
+        ctx,
+        _info
+      ) => {
+        if (minor == null || currencyCode == null) {
+          return null
+        }
+        return resolveMinorAndCurrencyFieldsToMoney(
+          { minor, currencyCode },
+          _args,
+          ctx,
+          _info
+        )
+      },
+    },
+    taxTotal: {
+      type: Money,
+      description: "The total amount for tax",
+      resolve: (
+        { tax_total_cents: minor, currency_code: currencyCode },
         _args,
         ctx,
         _info


### PR DESCRIPTION
Type: Chore

Relates to [EMI-2306]

This PR adds the new exchange `tax_total_cents` field to the Order type. Minor change overall- I updated the queried Money field in our tests to `minor` because I realized that display is rounding the numbers (eg `4299` becomes `"US$43"`). Since we don't need these display fields yet I changed the specs, but we'll probably need to reconfigure that soon.

[EMI-2306]: https://artsyproduct.atlassian.net/browse/EMI-2306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ