### PR TITLE
fix(artworkImport): dont always resolve currency

### DIFF
--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -111,6 +111,10 @@ const ArtworkImportRowType = new GraphQLObjectType({
         context,
         info
       ) => {
+        if (!minor || !currencyCode) {
+          return null
+        }
+
         return resolveMinorAndCurrencyFieldsToMoney(
           {
             minor,


### PR DESCRIPTION
Fixes small regression  from https://github.com/artsy/metaphysics/pull/6543

We need to be aware of missing or invalid price information, vs always resolving (which returns values like $US 0 for invalid things). 
