### PR TITLE
chore: remove marketing-collection-categories feature flag from homeView

### DIFF
--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -12,7 +12,6 @@ const FEATURE_FLAGS_LIST = [
   "diamond_blurhash-enabled-globally",
   "onyx_enable-home-view-section-featured-fairs",
   "diamond_home-view-infinite-discovery",
-  "diamond_home-view-marketing-collection-categories",
   "onyx_experiment_home_view_test",
   "emerald_clientside-collector-signals",
 ] as const

--- a/src/schema/v2/homeView/__tests__/HomeView.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeView.test.ts
@@ -29,10 +29,7 @@ describe("homeView", () => {
   describe("sectionsConnection", () => {
     beforeEach(() => {
       mockIsFeatureFlagEnabled.mockImplementation((flag: string) => {
-        return [
-          "onyx_enable-home-view-section-featured-fairs",
-          "diamond_home-view-marketing-collection-categories",
-        ].includes(flag)
+        return ["onyx_enable-home-view-section-featured-fairs"].includes(flag)
       })
     })
 

--- a/src/schema/v2/homeView/sections/DiscoverSomethingNew.ts
+++ b/src/schema/v2/homeView/sections/DiscoverSomethingNew.ts
@@ -20,7 +20,6 @@ const marketingCollectionSlugs = [
 
 export const DiscoverSomethingNew: HomeViewSection = {
   id: "home-view-section-discover-something-new",
-  featureFlag: "diamond_home-view-marketing-collection-categories",
   contextModule: ContextModule.discoverSomethingNewRail,
   type: HomeViewSectionTypeNames.HomeViewSectionCards,
   component: {

--- a/src/schema/v2/homeView/sections/ExploreByCategory.ts
+++ b/src/schema/v2/homeView/sections/ExploreByCategory.ts
@@ -15,7 +15,6 @@ const orderedCategoryKeys = [
 
 export const ExploreByCategory: HomeViewSection = {
   id: "home-view-section-explore-by-category",
-  featureFlag: "diamond_home-view-marketing-collection-categories",
   contextModule: ContextModule.exploreBy,
   type: HomeViewSectionTypeNames.HomeViewSectionCards,
   component: {

--- a/src/schema/v2/homeView/sections/__tests__/DiscoverSomethingNew.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/DiscoverSomethingNew.test.ts
@@ -1,51 +1,36 @@
-import { isFeatureFlagEnabled } from "lib/featureFlags"
 import gql from "lib/gql"
 import { runQuery } from "schema/v2/test/utils"
 
-jest.mock("lib/featureFlags", () => ({
-  isFeatureFlagEnabled: jest.fn(() => true),
-}))
-
-const mockIsFeatureFlagEnabled = isFeatureFlagEnabled as jest.Mock
-
 describe("DiscoverSomethingNew", () => {
-  describe("when the feature flag is enabled", () => {
-    beforeEach(() => {
-      mockIsFeatureFlagEnabled.mockImplementation((flag: string) => {
-        if (flag === "diamond_home-view-marketing-collection-categories")
-          return true
-      })
-    })
-
-    it("returns the section's metadata", async () => {
-      const query = gql`
-        {
-          homeView {
-            section(id: "home-view-section-discover-something-new") {
-              __typename
-              internalID
-              contextModule
-              ownerType
-              component {
-                title
-                behaviors {
-                  viewAll {
-                    buttonText
-                    href
-                    ownerType
-                  }
+  it("returns the section's metadata", async () => {
+    const query = gql`
+      {
+        homeView {
+          section(id: "home-view-section-discover-something-new") {
+            __typename
+            internalID
+            contextModule
+            ownerType
+            component {
+              title
+              behaviors {
+                viewAll {
+                  buttonText
+                  href
+                  ownerType
                 }
               }
             }
           }
         }
-      `
+      }
+    `
 
-      const context = {}
+    const context = {}
 
-      const { homeView } = await runQuery(query, context)
+    const { homeView } = await runQuery(query, context)
 
-      expect(homeView.section).toMatchInlineSnapshot(`
+    expect(homeView.section).toMatchInlineSnapshot(`
         {
           "__typename": "HomeViewSectionCards",
           "component": {
@@ -57,22 +42,21 @@ describe("DiscoverSomethingNew", () => {
           "ownerType": null,
         }
       `)
-    })
+  })
 
-    it("returns the section's connection data", async () => {
-      const query = gql`
-        {
-          homeView {
-            section(id: "home-view-section-discover-something-new") {
-              ... on HomeViewSectionCards {
-                cardsConnection(first: 6) {
-                  edges {
-                    node {
-                      entityID
-                      title
-                      image {
-                        url
-                      }
+  it("returns the section's connection data", async () => {
+    const query = gql`
+      {
+        homeView {
+          section(id: "home-view-section-discover-something-new") {
+            ... on HomeViewSectionCards {
+              cardsConnection(first: 6) {
+                edges {
+                  node {
+                    entityID
+                    title
+                    image {
+                      url
                     }
                   }
                 }
@@ -80,32 +64,33 @@ describe("DiscoverSomethingNew", () => {
             }
           }
         }
-      `
-
-      const context = {
-        marketingCollectionsLoader: jest.fn().mockResolvedValue({
-          body: [
-            {
-              slug: "figurative-art",
-              id: "figurative-art",
-              title: "Figurative Art",
-              subtitle: "Our Picks",
-              thumbnail: "figurative-art.jpg",
-            },
-            {
-              slug: "new-from-leading-galleries",
-              id: "new-from-leading-galleries",
-              title: "New from Leading Galleries",
-              subtitle: "Our Picks",
-              thumbnail: "new-from-leading-galleries.jpg",
-            },
-          ],
-        }),
       }
+    `
 
-      const { homeView } = await runQuery(query, context)
+    const context = {
+      marketingCollectionsLoader: jest.fn().mockResolvedValue({
+        body: [
+          {
+            slug: "figurative-art",
+            id: "figurative-art",
+            title: "Figurative Art",
+            subtitle: "Our Picks",
+            thumbnail: "figurative-art.jpg",
+          },
+          {
+            slug: "new-from-leading-galleries",
+            id: "new-from-leading-galleries",
+            title: "New from Leading Galleries",
+            subtitle: "Our Picks",
+            thumbnail: "new-from-leading-galleries.jpg",
+          },
+        ],
+      }),
+    }
 
-      expect(homeView.section).toMatchInlineSnapshot(`
+    const { homeView } = await runQuery(query, context)
+
+    expect(homeView.section).toMatchInlineSnapshot(`
         {
           "cardsConnection": {
             "edges": [
@@ -131,34 +116,5 @@ describe("DiscoverSomethingNew", () => {
           },
         }
       `)
-    })
-  })
-
-  describe("when the feature flag is disabled", () => {
-    beforeEach(() => {
-      mockIsFeatureFlagEnabled.mockImplementation((flag: string) => {
-        if (flag === "diamond_home-view-marketing-collection-categories")
-          return false
-      })
-    })
-
-    it("throws an error when accessed by id", async () => {
-      const query = gql`
-        {
-          homeView {
-            section(id: "home-view-section-discover-something-new") {
-              __typename
-              internalID
-            }
-          }
-        }
-      `
-
-      const context = {}
-
-      await expect(runQuery(query, context)).rejects.toThrow(
-        "Section is not displayable"
-      )
-    })
   })
 })

--- a/src/schema/v2/homeView/sections/__tests__/ExploreByCategory.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/ExploreByCategory.test.ts
@@ -1,51 +1,36 @@
-import { isFeatureFlagEnabled } from "lib/featureFlags"
 import gql from "lib/gql"
 import { runQuery } from "schema/v2/test/utils"
 
-jest.mock("lib/featureFlags", () => ({
-  isFeatureFlagEnabled: jest.fn(() => true),
-}))
-
-const mockIsFeatureFlagEnabled = isFeatureFlagEnabled as jest.Mock
-
 describe("ExploreByCategory", () => {
-  describe("when the feature flag is enabled", () => {
-    beforeEach(() => {
-      mockIsFeatureFlagEnabled.mockImplementation((flag: string) => {
-        if (flag === "diamond_home-view-marketing-collection-categories")
-          return true
-      })
-    })
-
-    it("returns the section's metadata", async () => {
-      const query = gql`
-        {
-          homeView {
-            section(id: "home-view-section-explore-by-category") {
-              __typename
-              internalID
-              contextModule
-              ownerType
-              component {
-                title
-                behaviors {
-                  viewAll {
-                    buttonText
-                    href
-                    ownerType
-                  }
+  it("returns the section's metadata", async () => {
+    const query = gql`
+      {
+        homeView {
+          section(id: "home-view-section-explore-by-category") {
+            __typename
+            internalID
+            contextModule
+            ownerType
+            component {
+              title
+              behaviors {
+                viewAll {
+                  buttonText
+                  href
+                  ownerType
                 }
               }
             }
           }
         }
-      `
+      }
+    `
 
-      const context = {}
+    const context = {}
 
-      const { homeView } = await runQuery(query, context)
+    const { homeView } = await runQuery(query, context)
 
-      expect(homeView.section).toMatchInlineSnapshot(`
+    expect(homeView.section).toMatchInlineSnapshot(`
         {
           "__typename": "HomeViewSectionCards",
           "component": {
@@ -57,32 +42,32 @@ describe("ExploreByCategory", () => {
           "ownerType": null,
         }
       `)
-    })
+  })
 
-    it("returns the section's connection data", async () => {
-      const query = gql`
-        {
-          homeView {
-            section(id: "home-view-section-explore-by-category") {
-              ... on HomeViewSectionCards {
-                cardsConnection(first: 6) {
-                  edges {
-                    node {
-                      entityID
-                    }
+  it("returns the section's connection data", async () => {
+    const query = gql`
+      {
+        homeView {
+          section(id: "home-view-section-explore-by-category") {
+            ... on HomeViewSectionCards {
+              cardsConnection(first: 6) {
+                edges {
+                  node {
+                    entityID
                   }
                 }
               }
             }
           }
         }
-      `
+      }
+    `
 
-      const context = {}
+    const context = {}
 
-      const { homeView } = await runQuery(query, context)
+    const { homeView } = await runQuery(query, context)
 
-      expect(homeView.section).toMatchInlineSnapshot(`
+    expect(homeView.section).toMatchInlineSnapshot(`
         {
           "cardsConnection": {
             "edges": [
@@ -120,34 +105,5 @@ describe("ExploreByCategory", () => {
           },
         }
       `)
-    })
-  })
-
-  describe("when the feature flag is disabled", () => {
-    beforeEach(() => {
-      mockIsFeatureFlagEnabled.mockImplementation((flag: string) => {
-        if (flag === "diamond_home-view-marketing-collection-categories")
-          return false
-      })
-    })
-
-    it("throws an error when accessed by id", async () => {
-      const query = gql`
-        {
-          homeView {
-            section(id: "home-view-section-explore-by-category") {
-              __typename
-              internalID
-            }
-          }
-        }
-      `
-
-      const context = {}
-
-      await expect(runQuery(query, context)).rejects.toThrow(
-        "Section is not displayable"
-      )
-    })
   })
 })


### PR DESCRIPTION
This PR cleans up the obsolete feature flag.

Eigen PR: https://github.com/artsy/eigen/pull/11769
Echo PR: https://github.com/artsy/echo/pull/789
