### PR TITLE
chore: correct argument for saving location of a partner show

### DIFF
--- a/src/schema/v2/Show/createPartnerShowMutation.ts
+++ b/src/schema/v2/Show/createPartnerShowMutation.ts
@@ -114,7 +114,7 @@ export const createPartnerShowMutation = mutationWithClientMutationId<
       featured?: boolean
       description?: string
       press_release?: string
-      location_id?: string
+      partner_location?: string
       start_at?: number
       end_at?: number
     } = {
@@ -122,7 +122,7 @@ export const createPartnerShowMutation = mutationWithClientMutationId<
       featured: args.featured,
       description: args.description,
       press_release: args.pressRelease,
-      location_id: args.locationId,
+      partner_location: args.locationId,
     }
 
     // Convert the date strings to Unix-style timestamps.

--- a/src/schema/v2/Show/updatePartnerShowMutation.ts
+++ b/src/schema/v2/Show/updatePartnerShowMutation.ts
@@ -111,19 +111,19 @@ export const updatePartnerShowMutation = mutationWithClientMutationId<
     const showIdentifiers = { partnerId, showId }
 
     const gravityArgs: {
-      featured: any
-      description: any
-      press_release: any
-      name: any
-      location_id: any
-      start_at?: any
-      end_at?: any
+      name: string
+      featured: boolean
+      description: string
+      press_release: string
+      partner_location: string
+      start_at?: number
+      end_at?: number
     } = {
       featured: args.featured,
       description: args.description,
       press_release: args.pressRelease,
       name: args.name,
-      location_id: args.locationId,
+      partner_location: args.locationId,
     }
 
     // Convert the date strings to Unix-style timestamps.


### PR DESCRIPTION
Whoops! Noticed I didn't have the right argument to line up with the API - which expects the identifier to be called `partner_location`.