### PR TITLE
chore: allow nil locations to be set for a partner show

### DIFF
--- a/src/lib/apis/fetch.ts
+++ b/src/lib/apis/fetch.ts
@@ -37,7 +37,11 @@ export const constructUrlAndParams = (method, url): URLAndRequestBodyParams => {
         )
         body = arrayParams
       } else {
-        body = parsedParams
+        // We need to allow `key: null` to be sent in a way that unsets (`null`), and not as an empty string
+        body = Object.keys(parsedParams).reduce((acc, key) => {
+          acc[key] = parsedParams[key] === "" ? null : parsedParams[key]
+          return acc
+        }, {})
       }
 
       opts.body = body

--- a/src/schema/v2/Show/createPartnerShowMutation.ts
+++ b/src/schema/v2/Show/createPartnerShowMutation.ts
@@ -122,7 +122,6 @@ export const createPartnerShowMutation = mutationWithClientMutationId<
       featured: args.featured,
       description: args.description,
       press_release: args.pressRelease,
-      partner_location: args.locationId,
     }
 
     // Convert the date strings to Unix-style timestamps.
@@ -131,6 +130,10 @@ export const createPartnerShowMutation = mutationWithClientMutationId<
     }
     if (args.endAt) {
       gravityArgs.end_at = moment(args.endAt).unix()
+    }
+
+    if (args.locationId) {
+      gravityArgs.partner_location = args.locationId
     }
 
     try {


### PR DESCRIPTION
At first - when creating a show, we can just not send a blank location value.

But - what about when updating a show with a location, and _unsetting_? We likely _never_ have done that before with mutation ('unsetting'), as the way our `fetch` is all hooked up - those variables to a data loader, `key: null`, always make it to the API as `key: ""` - which is _not_ unsetting!

This might be sketchy in that, what if you want to set a string field, like a description, to a blank string? Would just rewriting to `null` be ok? I think it would, and since this allows us to unset fields, I think we need to make this change - but overall something is sketchy in how we're sending mutation payloads upstream - for POSTs we're not even really using a request body but query params!