### PR TITLE
chore(EMI-2341): update curators pick signal to only look at emerging collection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4781,7 +4781,7 @@ type CollectorSignals {
   # Bid count on lots open for bidding
   bidCount: Int @deprecated(reason: "Use nested field in `auction` instead")
 
-  # Artwork is part of either the Curators' Pick Emerging or Blue Chip collections
+  # Artwork is part of Curators' Pick Emerging collection
   curatorsPick: Boolean
 
   # Increased interest in the artwork

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -118,8 +118,7 @@ export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
       },
       curatorsPick: {
         type: GraphQLBoolean,
-        description:
-          "Artwork is part of either the Curators' Pick Emerging or Blue Chip collections",
+        description: "Artwork is part of Curators' Pick Emerging collection",
         resolve: (artwork, {}, ctx) => getIsCuratorsPick(artwork, ctx),
       },
       lotWatcherCount: {
@@ -274,10 +273,7 @@ const getActivePartnerOffer = async (artwork, ctx) => {
 }
 
 const getIsCuratorsPick = async (artwork, ctx) => {
-  const CURATED_COLLECTION_SLUGS = [
-    "curators-picks-blue-chip-artists",
-    "curators-picks-emerging-artists",
-  ]
+  const CURATED_COLLECTION_SLUGS = ["curators-picks-emerging-artists"]
 
   const checks = await Promise.all(
     CURATED_COLLECTION_SLUGS.map(async (slug) => {


### PR DESCRIPTION
The collection url on artsy is https://www.artsy.net/collection/curators-picks and the other ones(the one that we removed) was https://www.artsy.net/collection/icons

In our selection we are using alternative slug for the collection which creates a bit of stumble in understanding. Was thinking of updating the slug as well but figured maybe we intentionally want to be a bit ambiguous here. 