### PR TITLE
chore(EMI-2306): Add tests for Order.taxTotal

### DIFF
--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -186,5 +186,69 @@ describe("Me", () => {
         ],
       })
     })
+
+    describe("taxTotal", () => {
+      const query = gql`
+        query {
+          me {
+            order(id: "order-id") {
+              taxTotal {
+                minor
+              }
+            }
+          }
+        }
+      `
+      it("returns taxTotal when present", async () => {
+        orderJson.tax_total_cents = 4299
+        context = {
+          meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+          meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+          artworkLoader: jest.fn().mockResolvedValue(artwork),
+          authenticatedArtworkVersionLoader: jest
+            .fn()
+            .mockResolvedValue(artworkVersion),
+        }
+
+        const result = await runAuthenticatedQuery(query, context)
+
+        expect(result.me.order.taxTotal).toEqual({
+          minor: 4299,
+        })
+      })
+
+      it("returns 0 when taxTotal is 0", async () => {
+        orderJson.tax_total_cents = 0
+        context = {
+          meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+          meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+          artworkLoader: jest.fn().mockResolvedValue(artwork),
+          authenticatedArtworkVersionLoader: jest
+            .fn()
+            .mockResolvedValue(artworkVersion),
+        }
+        const result = await runAuthenticatedQuery(query, context)
+
+        expect(result.me.order.taxTotal).toEqual({
+          minor: 0,
+        })
+      })
+
+      it("returns null when taxTotal is not present", async () => {
+        orderJson.tax_total_cents = null
+        context = {
+          meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+          meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+          artworkLoader: jest.fn().mockResolvedValue(artwork),
+          authenticatedArtworkVersionLoader: jest
+            .fn()
+            .mockResolvedValue(artworkVersion),
+        }
+
+        const result = await runAuthenticatedQuery(query, context)
+
+        expect(result.me.order.taxTotal).toEqual(null)
+      })
+    })
   })
 })


### PR DESCRIPTION
Type: **chore**
#minor

Related to [EMI-2306]
This PR adds tests to validate the nullability of the taxTotal money type.

[EMI-2306]: https://artsyproduct.atlassian.net/browse/EMI-2306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ