### PR TITLE
chore: remaining install shot mutations

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15243,6 +15243,11 @@ type Mutation {
     input: UpdateHeroUnitMutationInput!
   ): UpdateHeroUnitMutationPayload
 
+  # Updates an installation shot for a partner show.
+  updateInstallShotForPartnerShow(
+    input: UpdateInstallShotForPartnerShowMutationInput!
+  ): UpdateInstallShotForPartnerShowMutationPayload
+
   # Updates the user's collections in batch.
   updateMeCollectionsMutation(
     input: updateMeCollectionsMutationInput!
@@ -21360,6 +21365,37 @@ type UpdateHeroUnitMutationPayload {
 
   # On success: the hero unit updated.
   heroUnitOrError: updateHeroUnitResponseOrError
+}
+
+type UpdateInstallShotForPartnerShowFailure {
+  mutationError: GravityMutationError
+}
+
+input UpdateInstallShotForPartnerShowMutationInput {
+  # The updated caption for the installation shot.
+  caption: String!
+  clientMutationId: String
+
+  # The ID of the installation shot image to update.
+  imageId: String!
+
+  # The ID of the show.
+  showId: String!
+}
+
+type UpdateInstallShotForPartnerShowMutationPayload {
+  clientMutationId: String
+
+  # On success: the show that contains the updated installation shot. On error: the error that occurred.
+  showOrError: UpdateInstallShotForPartnerShowResponseOrError
+}
+
+union UpdateInstallShotForPartnerShowResponseOrError =
+    UpdateInstallShotForPartnerShowFailure
+  | UpdateInstallShotForPartnerShowSuccess
+
+type UpdateInstallShotForPartnerShowSuccess {
+  show: Show
 }
 
 input UpdateMeCollectionInput {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15103,6 +15103,11 @@ type Mutation {
     # Parameters for RemoveAssetFromConsignmentSubmission
     input: RemoveAssetFromConsignmentSubmissionInput!
   ): RemoveAssetFromConsignmentSubmissionPayload
+
+  # Removes an installation shot from a partner show.
+  removeInstallShotFromPartnerShow(
+    input: RemoveInstallShotFromPartnerShowMutationInput!
+  ): RemoveInstallShotFromPartnerShowMutationPayload
   requestConditionReport(
     # Parameters for RequestConditionReport
     input: RequestConditionReportInput!
@@ -18991,6 +18996,35 @@ type RemoveAssetFromConsignmentSubmissionPayload {
 
   # A unique identifier for the client performing the mutation.
   clientMutationId: String
+}
+
+type RemoveInstallShotFromPartnerShowFailure {
+  mutationError: GravityMutationError
+}
+
+input RemoveInstallShotFromPartnerShowMutationInput {
+  clientMutationId: String
+
+  # The ID of the installation shot image to remove.
+  imageId: String!
+
+  # The ID of the show.
+  showId: String!
+}
+
+type RemoveInstallShotFromPartnerShowMutationPayload {
+  clientMutationId: String
+
+  # On success: the show that the installation shot was removed from. On error: the error that occurred.
+  showOrError: RemoveInstallShotFromPartnerShowResponseOrError
+}
+
+union RemoveInstallShotFromPartnerShowResponseOrError =
+    RemoveInstallShotFromPartnerShowFailure
+  | RemoveInstallShotFromPartnerShowSuccess
+
+type RemoveInstallShotFromPartnerShowSuccess {
+  show: Show
 }
 
 type Request {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -41,6 +41,14 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "DELETE" }
     ),
+    updateInstallShotLoader: gravityLoader<
+      any,
+      { showId: string; imageId: string }
+    >(
+      ({ showId, imageId }) => `partner_show/${showId}/image/${imageId}`,
+      {},
+      { method: "PUT" }
+    ),
     addUserRoleLoader: gravityLoader<any, { id: string; role_type: string }>(
       ({ id, role_type }) => `user/${id}/roles/${role_type}`,
       {},

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -33,6 +33,14 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    removeInstallShotFromPartnerShowLoader: gravityLoader<
+      any,
+      { showId: string; imageId: string }
+    >(
+      ({ showId, imageId }) => `partner_show/${showId}/image/${imageId}`,
+      {},
+      { method: "DELETE" }
+    ),
     addUserRoleLoader: gravityLoader<any, { id: string; role_type: string }>(
       ({ id, role_type }) => `user/${id}/roles/${role_type}`,
       {},

--- a/src/schema/v2/Show/__tests__/removeInstallShotFromPartnerShowMutation.test.ts
+++ b/src/schema/v2/Show/__tests__/removeInstallShotFromPartnerShowMutation.test.ts
@@ -1,0 +1,63 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("RemoveInstallShotFromPartnerShowMutation", () => {
+  const mutation = gql`
+    mutation {
+      removeInstallShotFromPartnerShow(
+        input: { showId: "show123", imageId: "image123" }
+      ) {
+        showOrError {
+          __typename
+          ... on RemoveInstallShotFromPartnerShowSuccess {
+            show {
+              internalID
+              name
+              status
+            }
+          }
+          ... on RemoveInstallShotFromPartnerShowFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("removes an installation shot from a partner show", async () => {
+    const context = {
+      removeInstallShotFromPartnerShowLoader: (identifiers) => {
+        // Test that we're sending the right data
+        expect(identifiers).toEqual({
+          showId: "show123",
+          imageId: "image123",
+        })
+
+        return Promise.resolve({})
+      },
+      showLoader: () =>
+        Promise.resolve({
+          _id: "show123",
+          name: "Sample Show",
+          status: "running",
+        }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      removeInstallShotFromPartnerShow: {
+        showOrError: {
+          __typename: "RemoveInstallShotFromPartnerShowSuccess",
+          show: {
+            internalID: "show123",
+            name: "Sample Show",
+            status: "running",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/Show/__tests__/updateInstallShotForPartnerShowMutation.test.ts
+++ b/src/schema/v2/Show/__tests__/updateInstallShotForPartnerShowMutation.test.ts
@@ -1,0 +1,70 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("UpdateInstallShotForPartnerShowMutation", () => {
+  const mutation = gql`
+    mutation {
+      updateInstallShotForPartnerShow(
+        input: {
+          showId: "show123"
+          imageId: "image123"
+          caption: "Updated caption for opening night"
+        }
+      ) {
+        showOrError {
+          __typename
+          ... on UpdateInstallShotForPartnerShowSuccess {
+            show {
+              internalID
+              name
+              status
+            }
+          }
+          ... on UpdateInstallShotForPartnerShowFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("updates an installation shot caption for a partner show", async () => {
+    const context = {
+      updateInstallShotLoader: (identifiers, data) => {
+        // Test that we're sending the right data
+        expect(identifiers).toEqual({
+          showId: "show123",
+          imageId: "image123",
+        })
+        expect(data).toEqual({
+          caption: "Updated caption for opening night",
+        })
+
+        return Promise.resolve({})
+      },
+      showLoader: () =>
+        Promise.resolve({
+          _id: "show123",
+          name: "Sample Show",
+          status: "running",
+        }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      updateInstallShotForPartnerShow: {
+        showOrError: {
+          __typename: "UpdateInstallShotForPartnerShowSuccess",
+          show: {
+            internalID: "show123",
+            name: "Sample Show",
+            status: "running",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/Show/removeInstallShotFromPartnerShowMutation.ts
+++ b/src/schema/v2/Show/removeInstallShotFromPartnerShowMutation.ts
@@ -1,0 +1,101 @@
+import {
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { ShowType } from "../show"
+
+interface RemoveInstallShotFromPartnerShowMutationInputProps {
+  showId: string
+  imageId: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "RemoveInstallShotFromPartnerShowSuccess",
+  isTypeOf: ({ showId }) => !!showId,
+  fields: () => ({
+    show: {
+      type: ShowType,
+      resolve: ({ showId }, _args, { showLoader }) => showLoader(showId),
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "RemoveInstallShotFromPartnerShowFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "RemoveInstallShotFromPartnerShowResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const removeInstallShotFromPartnerShowMutation = mutationWithClientMutationId<
+  RemoveInstallShotFromPartnerShowMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "RemoveInstallShotFromPartnerShowMutation",
+  description: "Removes an installation shot from a partner show.",
+  inputFields: {
+    showId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the show.",
+    },
+    imageId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the installation shot image to remove.",
+    },
+  },
+  outputFields: {
+    showOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the show that the installation shot was removed from. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { showId, imageId },
+    { removeInstallShotFromPartnerShowLoader }
+  ) => {
+    if (!removeInstallShotFromPartnerShowLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    const identifiers = {
+      showId,
+      imageId,
+    }
+
+    try {
+      const response = await removeInstallShotFromPartnerShowLoader(identifiers)
+
+      return {
+        ...response,
+        showId,
+      }
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/Show/updateInstallShotForPartnerShowMutation.ts
+++ b/src/schema/v2/Show/updateInstallShotForPartnerShowMutation.ts
@@ -1,0 +1,110 @@
+import {
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { ShowType } from "../show"
+
+interface UpdateInstallShotForPartnerShowMutationInputProps {
+  showId: string
+  imageId: string
+  caption: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateInstallShotForPartnerShowSuccess",
+  isTypeOf: ({ showId }) => !!showId,
+  fields: () => ({
+    show: {
+      type: ShowType,
+      resolve: ({ showId }, _args, { showLoader }) => showLoader(showId),
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateInstallShotForPartnerShowFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdateInstallShotForPartnerShowResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const updateInstallShotForPartnerShowMutation = mutationWithClientMutationId<
+  UpdateInstallShotForPartnerShowMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "UpdateInstallShotForPartnerShowMutation",
+  description: "Updates an installation shot for a partner show.",
+  inputFields: {
+    showId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the show.",
+    },
+    imageId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the installation shot image to update.",
+    },
+    caption: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The updated caption for the installation shot.",
+    },
+  },
+  outputFields: {
+    showOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the show that contains the updated installation shot. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { showId, imageId, caption },
+    { updateInstallShotLoader }
+  ) => {
+    if (!updateInstallShotLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    const identifiers = {
+      showId,
+      imageId,
+    }
+
+    const data = {
+      caption,
+    }
+
+    try {
+      const response = await updateInstallShotLoader(identifiers, data)
+
+      return {
+        ...response,
+        showId,
+      }
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -237,6 +237,7 @@ import { deletePartnerShowEventMutation } from "./Show/deletePartnerShowEventMut
 import { deletePartnerShowDocumentMutation } from "./Show/deletePartnerShowDocumentMutation"
 import { removeArtworkFromPartnerShowMutation } from "./Show/removeArtworkFromPartnerShowMutation"
 import { removeInstallShotFromPartnerShowMutation } from "./Show/removeInstallShotFromPartnerShowMutation"
+import { updateInstallShotForPartnerShowMutation } from "./Show/updateInstallShotForPartnerShowMutation"
 import { updatePartnerShowMutation } from "./Show/updatePartnerShowMutation"
 import { updatePartnerShowEventMutation } from "./Show/updatePartnerShowEventMutation"
 import { updatePartnerShowDocumentMutation } from "./Show/updatePartnerShowDocumentMutation"
@@ -579,6 +580,7 @@ export default new GraphQLSchema({
       updateQuiz: updateQuizMutation,
       updateSaleAgreement: UpdateSaleAgreementMutation,
       updateSmsSecondFactor: updateSmsSecondFactorMutation,
+      updateInstallShotForPartnerShow: updateInstallShotForPartnerShowMutation,
       updatePartnerShowDocument: updatePartnerShowDocumentMutation,
       updatePartnerShowEvent: updatePartnerShowEventMutation,
       updateUser: updateUserMutation,

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -236,6 +236,7 @@ import { deletePartnerShowMutation } from "./Show/deletePartnerShowMutation"
 import { deletePartnerShowEventMutation } from "./Show/deletePartnerShowEventMutation"
 import { deletePartnerShowDocumentMutation } from "./Show/deletePartnerShowDocumentMutation"
 import { removeArtworkFromPartnerShowMutation } from "./Show/removeArtworkFromPartnerShowMutation"
+import { removeInstallShotFromPartnerShowMutation } from "./Show/removeInstallShotFromPartnerShowMutation"
 import { updatePartnerShowMutation } from "./Show/updatePartnerShowMutation"
 import { updatePartnerShowEventMutation } from "./Show/updatePartnerShowEventMutation"
 import { updatePartnerShowDocumentMutation } from "./Show/updatePartnerShowDocumentMutation"
@@ -538,6 +539,7 @@ export default new GraphQLSchema({
       myCollectionUpdateArtwork: myCollectionUpdateArtworkMutation,
       publishViewingRoom: publishViewingRoomMutation,
       removeArtworkFromPartnerShow: removeArtworkFromPartnerShowMutation,
+      removeInstallShotFromPartnerShow: removeInstallShotFromPartnerShowMutation,
       requestCredentialsForAssetUpload: CreateAssetRequestLoader,
       requestPriceEstimate: requestPriceEstimateMutation,
       saveArtwork: saveArtworkMutation,


### PR DESCRIPTION
Now that we can add an install shot, we should be able to remove it, and also update it (currently the only thing we support updating is the caption).