### PR TITLE
fix: correctly handle known errors from exchange

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10278,6 +10278,7 @@ enum EventStatus {
 }
 
 type ExchangeError {
+  code: String!
   message: String!
 }
 

--- a/src/schema/v2/order/exchangeErrorHandling.ts
+++ b/src/schema/v2/order/exchangeErrorHandling.ts
@@ -1,0 +1,28 @@
+import { ORDER_MUTATION_FLAGS } from "./sharedOrderTypes"
+
+type ExchangeError = Error & {
+  statusCode: number
+  body?: {
+    message: string
+    code: string
+  }
+}
+export const handleExchangeError = (error: ExchangeError) => {
+  let errorProperties: { message: string; code: string }
+
+  if (error.statusCode === 422 && typeof error.body === "object") {
+    errorProperties = {
+      message: error.body.message,
+      code: error.body.code,
+    }
+  } else {
+    errorProperties = {
+      message: "An error occurred",
+      code: "internal_error",
+    }
+  }
+  return {
+    ...errorProperties,
+    _type: ORDER_MUTATION_FLAGS.ERROR,
+  }
+}

--- a/src/schema/v2/order/setOrderFulfillmentOptionMutation.ts
+++ b/src/schema/v2/order/setOrderFulfillmentOptionMutation.ts
@@ -10,6 +10,7 @@ import {
   OrderMutationResponseType,
   ORDER_MUTATION_FLAGS,
 } from "./sharedOrderTypes"
+import { handleExchangeError } from "./exchangeErrorHandling"
 
 interface Input {
   id: string
@@ -79,10 +80,7 @@ export const setOrderFulfillmentOptionMutation = mutationWithClientMutationId<
 
       return updatedOrder
     } catch (error) {
-      return {
-        message: error.message,
-        _type: ORDER_MUTATION_FLAGS.ERROR,
-      }
+      return handleExchangeError(error)
     }
   },
 })

--- a/src/schema/v2/order/sharedOrderTypes.ts
+++ b/src/schema/v2/order/sharedOrderTypes.ts
@@ -404,6 +404,7 @@ const ExchangeErrorType = new GraphQLObjectType<any, ResolverContext>({
   name: "ExchangeError",
   fields: {
     message: { type: new GraphQLNonNull(GraphQLString) },
+    code: { type: new GraphQLNonNull(GraphQLString) },
   },
 })
 

--- a/src/schema/v2/order/updateOrderMutation.ts
+++ b/src/schema/v2/order/updateOrderMutation.ts
@@ -5,6 +5,7 @@ import {
 } from "./sharedOrderTypes"
 import { mutationWithClientMutationId } from "graphql-relay"
 import { ResolverContext } from "types/graphql"
+import { handleExchangeError } from "./exchangeErrorHandling"
 
 interface Input {
   id: string
@@ -98,7 +99,7 @@ export const updateOrderMutation = mutationWithClientMutationId<
       updatedOrder._type = ORDER_MUTATION_FLAGS.SUCCESS // Set the type for the response
       return updatedOrder
     } catch (error) {
-      return { message: error.message, _type: ORDER_MUTATION_FLAGS.ERROR }
+      return handleExchangeError(error)
     }
   },
 })


### PR DESCRIPTION
type: **fix**
resolves [EMI-2358]

This PR adds a lightweight error handling pattern so we can forward known error types from exchange. Currently it is only concerned with validation errors: these have a `message` and a `code` which are by default the same (unless the error gets a [details](https://github.com/artsy/exchange/blob/main/spec/api/me/orders_endpoint_spec.rb#L246-L249) as well).

We could get more clever about this:
- we could also send the error `type`, ie `validation`
- we could make the various error types a union type
- we could make the various error codes an enum type

Curious on others thoughts but this works for today.

cc @artsy/emerald-devs 


https://github.com/artsy/exchange/blob/main/app/api/concerns/grape_error_handlers.rb#L50-L52



[EMI-2358]: https://artsyproduct.atlassian.net/browse/EMI-2358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ