### PR TITLE
chore: add createArtworkMutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8455,6 +8455,10 @@ type CreateArtistSuccess {
 
 union CreateArtistSuccessOrErrorType = CreateArtistFailure | CreateArtistSuccess
 
+type CreateArtworkFailure {
+  mutationError: GravityMutationError
+}
+
 type CreateArtworkImportArtworksFailure {
   mutationError: GravityMutationError
 }
@@ -8503,6 +8507,33 @@ union CreateArtworkImportResponseOrError =
 
 type CreateArtworkImportSuccess {
   artworkImport: ArtworkImport
+}
+
+input CreateArtworkMutationInput {
+  # The IDs of the artists associated with the artwork.
+  artistIds: [String!]!
+  clientMutationId: String
+
+  # The S3 bucket where the artwork image is stored.
+  imageS3Bucket: String!
+
+  # The S3 key for the artwork image.
+  imageS3Key: String!
+
+  # The ID of the partner under which the artwork is created.
+  partnerId: String!
+}
+
+type CreateArtworkMutationPayload {
+  # On success: the created artwork. On error: the error that occurred.
+  artworkOrError: CreateArtworkResponseOrError
+  clientMutationId: String
+}
+
+union CreateArtworkResponseOrError = CreateArtworkFailure | CreateArtworkSuccess
+
+type CreateArtworkSuccess {
+  artwork: Artwork
 }
 
 input CreateBackupSecondFactorsInput {
@@ -14725,6 +14756,11 @@ type Mutation {
 
   # Create an artist, used for MyCollection. use CreateCanonicalArtistMutation for all other cases
   createArtist(input: CreateArtistMutationInput!): CreateArtistMutationPayload
+
+  # Creates a new artwork with an associated image.
+  createArtwork(
+    input: CreateArtworkMutationInput!
+  ): CreateArtworkMutationPayload
   createArtworkImport(
     input: CreateArtworkImportInput!
   ): CreateArtworkImportPayload

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -178,6 +178,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    addImageToArtworkLoader: gravityLoader(
+      (id) => `artwork/${id}/image`,
+      {},
+      { method: "POST" }
+    ),
     createCommerceOptInEligibleArtworksReportLoader: gravityLoader(
       (id) => `partner/${id}/commerce_opt_in_eligible_artworks_report`,
       {},

--- a/src/schema/v2/artwork/__tests__/createArtworkMutation.test.ts
+++ b/src/schema/v2/artwork/__tests__/createArtworkMutation.test.ts
@@ -1,0 +1,71 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("CreateArtworkMutation", () => {
+  const mutation = gql`
+    mutation {
+      createArtwork(
+        input: {
+          partnerId: "partner123"
+          artistIds: ["artist123", "artist456"]
+          imageS3Bucket: "artwork-images"
+          imageS3Key: "artworks/new_artwork.jpg"
+        }
+      ) {
+        artworkOrError {
+          __typename
+          ... on CreateArtworkSuccess {
+            artwork {
+              internalID
+            }
+          }
+          ... on CreateArtworkFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("creates an artwork with an image", async () => {
+    const mockArtwork = {
+      _id: "artwork123",
+    }
+
+    const context = {
+      artworkLoader: () => Promise.resolve(mockArtwork),
+      createArtworkLoader: (data) => {
+        expect(data).toEqual({
+          artists: ["artist123", "artist456"],
+          partner: "partner123",
+        })
+
+        return Promise.resolve(mockArtwork)
+      },
+      addImageToArtworkLoader: (artworkId, data) => {
+        expect(artworkId).toEqual("artwork123")
+        expect(data).toEqual({
+          source_bucket: "artwork-images",
+          source_key: "artworks/new_artwork.jpg",
+        })
+
+        return Promise.resolve({})
+      },
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      createArtwork: {
+        artworkOrError: {
+          __typename: "CreateArtworkSuccess",
+          artwork: {
+            internalID: "artwork123",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/artwork/createArtworkMutation.ts
+++ b/src/schema/v2/artwork/createArtworkMutation.ts
@@ -1,0 +1,131 @@
+import {
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLUnionType,
+  GraphQLList,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { ArtworkType } from "../artwork"
+
+interface CreateArtworkMutationInputProps {
+  artistIds: string[]
+  partnerId: string
+  imageS3Bucket: string
+  imageS3Key: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreateArtworkSuccess",
+  isTypeOf: ({ artworkId }) => !!artworkId,
+  fields: () => ({
+    artwork: {
+      type: ArtworkType,
+      resolve: ({ artworkId }, _args, { artworkLoader }) =>
+        artworkLoader(artworkId),
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreateArtworkFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "CreateArtworkResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const createArtworkMutation = mutationWithClientMutationId<
+  CreateArtworkMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "CreateArtworkMutation",
+  description: "Creates a new artwork with an associated image.",
+  inputFields: {
+    artistIds: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(GraphQLString))
+      ),
+      description: "The IDs of the artists associated with the artwork.",
+    },
+    partnerId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the partner under which the artwork is created.",
+    },
+    imageS3Bucket: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The S3 bucket where the artwork image is stored.",
+    },
+    imageS3Key: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The S3 key for the artwork image.",
+    },
+  },
+  outputFields: {
+    artworkOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the created artwork. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { artistIds, imageS3Bucket, imageS3Key, partnerId },
+    { createArtworkLoader, addImageToArtworkLoader }
+  ) => {
+    if (!createArtworkLoader || !addImageToArtworkLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    // Step 1: Create the artwork with artist IDs
+    const createArtworkData = {
+      artists: artistIds,
+      partner: partnerId,
+    }
+
+    try {
+      const artwork = await createArtworkLoader(createArtworkData)
+
+      const imageData = {
+        source_bucket: imageS3Bucket,
+        source_key: imageS3Key,
+      }
+
+      try {
+        await addImageToArtworkLoader(artwork._id, imageData)
+
+        return { artworkId: artwork._id }
+      } catch (imageError) {
+        // Handle image upload error
+        const formattedImageErr = formatGravityError(imageError)
+        if (formattedImageErr) {
+          return { ...formattedImageErr, _type: "GravityMutationError" }
+        } else {
+          throw new Error(imageError)
+        }
+      }
+    } catch (artworkError) {
+      // Handle artwork creation error
+      const formattedArtworkErr = formatGravityError(artworkError)
+      if (formattedArtworkErr) {
+        return { ...formattedArtworkErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(artworkError)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -140,6 +140,7 @@ import { channel } from "./article/channel"
 import { createArtistMutation } from "./artist/createArtistMutation"
 import { createCanonicalArtistMutation } from "./artist/createCanonicalArtistMutation"
 import { deleteArtistMutation } from "./artist/deleteArtistMutation"
+import { createArtworkMutation } from "./artwork/createArtworkMutation"
 import { updateArtworkMutation } from "./artwork/updateArtworkMutation"
 import { artworksForUser } from "./artworksForUser"
 import { authenticationStatus } from "./authenticationStatus"
@@ -461,6 +462,7 @@ export default new GraphQLSchema({
       commerceOptInReport: commerceOptInReportMutation,
       createAccountRequest: createAccountRequestMutation,
       createAlert: createAlertMutation,
+      createArtwork: createArtworkMutation,
       createAndSendBackupSecondFactor: createAndSendBackupSecondFactorMutation,
       createAppSecondFactor: createAppSecondFactorMutation,
       createArtist: createArtistMutation,


### PR DESCRIPTION
This adds a minimal mutation that can be used for the **single** artwork upload flow.

Namely - for a given artist(s) (and partner, naturally) - as well as an uploaded image - we can now create an artwork and associate that image. This mimics the current two step flow in https://cms-staging.artsy.net/uploads where you select an artist, and upload images - and one artwork (per image) is created.

There was no Gravity updates needed to get artwork processing working for the image association when specifying the S3 info of an upload in this format! This mutation allowed me to create an artwork and have the image immediately associate and show up on /artworks.