### PR TITLE
feat(settingsV2): Adds mutation to allow for creating of partner locations

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8963,6 +8963,33 @@ type CreatePartnerContactSuccess {
   partnerContact: Contact
 }
 
+type CreatePartnerLocationFailure {
+  mutationError: GravityMutationError
+}
+
+input CreatePartnerLocationInput {
+  clientMutationId: String
+
+  # Location name
+  name: String
+
+  # ID of the partner
+  partnerID: String!
+}
+
+union CreatePartnerLocationOrError =
+    CreatePartnerLocationFailure
+  | CreatePartnerLocationSuccess
+
+type CreatePartnerLocationPayload {
+  clientMutationId: String
+  partnerLocationOrError: CreatePartnerLocationOrError
+}
+
+type CreatePartnerLocationSuccess {
+  location: Location
+}
+
 type CreatePartnerShowDocumentFailure {
   mutationError: GravityMutationError
 }
@@ -14867,6 +14894,11 @@ type Mutation {
   createPartnerContact(
     input: CreatePartnerContactInput!
   ): CreatePartnerContactPayload
+
+  # Creates a new location for a partner
+  createPartnerLocation(
+    input: CreatePartnerLocationInput!
+  ): CreatePartnerLocationPayload
 
   # Create a partner offer for the users
   createPartnerOffer(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8968,13 +8968,26 @@ type CreatePartnerLocationFailure {
 }
 
 input CreatePartnerLocationInput {
+  addressLine: String
+  addressLine2: String
+  addressType: locationType
+  city: String
   clientMutationId: String
+  country: String
 
-  # Location name
-  name: String
+  # Primary email of given location
+  email: String
 
   # ID of the partner
   partnerID: String!
+
+  # Primary phone of given location
+  phone: String
+  postalCode: String
+
+  # Boolean flag that denotes whether a location is publicly viewable on Partner's Artsy Profile
+  publiclyViewable: Boolean
+  state: String
 }
 
 union CreatePartnerLocationOrError =
@@ -24465,6 +24478,12 @@ type deleteUserRoleSuccess {
 type dimensions {
   cm: String
   in: String
+}
+
+enum locationType {
+  BUSINESS
+  OTHER
+  TEMPORARY
 }
 
 type partnerBiographyBlurb {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8968,8 +8968,8 @@ type CreatePartnerLocationFailure {
 }
 
 input CreatePartnerLocationInput {
-  addressLine: String
-  addressLine2: String
+  address: String
+  address2: String
   addressType: locationType
   city: String
   clientMutationId: String

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -290,6 +290,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    createPartnerLocationLoader: gravityLoader(
+      (id) => `partner/${id}/location`,
+      {},
+      { method: "POST" }
+    ),
     createPartnerOfferLoader: gravityLoader(
       "partner_offer",
       {},
@@ -899,7 +904,7 @@ export default (accessToken, userID, opts) => {
       ({ partnerId, inquiryId }) =>
         `partner/${partnerId}/inquiry_request/${inquiryId}`
     ),
-    partnerLocationsConnectionLoader: gravityLoader(
+    partnerLocationsLoader: gravityLoader(
       (id) => `partner/${id}/locations`,
       {},
       { headers: true }

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -904,7 +904,7 @@ export default (accessToken, userID, opts) => {
       ({ partnerId, inquiryId }) =>
         `partner/${partnerId}/inquiry_request/${inquiryId}`
     ),
-    partnerLocationsLoader: gravityLoader(
+    partnerLocationsConnectionLoader: gravityLoader(
       (id) => `partner/${id}/locations`,
       {},
       { headers: true }

--- a/src/schema/v2/partner/__tests__/createPartnerLocationMutation.test.js
+++ b/src/schema/v2/partner/__tests__/createPartnerLocationMutation.test.js
@@ -1,0 +1,97 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+const mutation = gql`
+  mutation {
+    createPartnerLocation(
+      input: {
+        partnerID: "partner_123"
+        address: "123 Happy Lane"
+        address2: "Apt 2b"
+        city: "New York"
+        state: "NY"
+        postalCode: "10013"
+        publiclyViewable: true
+        email: "jane@example.com"
+        phone: "123-456-7890"
+      }
+    ) {
+      partnerLocationOrError {
+        __typename
+        ... on CreatePartnerLocationSuccess {
+          location {
+            internalID
+            display
+            publiclyViewable
+          }
+        }
+        ... on CreatePartnerLocationFailure {
+          mutationError {
+            message
+          }
+        }
+      }
+    }
+  }
+`
+
+describe("CreatePartnerLocationMutation", () => {
+  describe("when successful", () => {
+    const partnerLocation = {
+      id: "location_123",
+      address: "123 Happy Lane",
+      address_2: "Apt 2b",
+      city: "New York",
+      state: "NY",
+      postal_code: "10013",
+      phone: "123-456-7890",
+      publicly_viewable: true,
+    }
+
+    const context = {
+      createPartnerLocationLoader: () => Promise.resolve(partnerLocation),
+    }
+
+    it("creates a partner location", async () => {
+      const data = await runAuthenticatedQuery(mutation, context)
+      expect(data).toEqual({
+        createPartnerLocation: {
+          partnerLocationOrError: {
+            __typename: "CreatePartnerLocationSuccess",
+            location: {
+              internalID: "location_123",
+              display: "123 Happy Lane, Apt 2b, New York, NY, 10013",
+              publiclyViewable: true,
+            },
+          },
+        },
+      })
+    })
+  })
+
+  describe("when failure", () => {
+    it("returns an error", async () => {
+      const context = {
+        createPartnerLocationLoader: () =>
+          Promise.reject(
+            new Error(
+              `https://stagingapi.artsy.net/api/v1/partner/:id/location - {"type":"error","message":"Partner not found"}`
+            )
+          ),
+      }
+
+      const response = await runAuthenticatedQuery(mutation, context)
+
+      expect(response).toEqual({
+        createPartnerLocation: {
+          partnerLocationOrError: {
+            __typename: "CreatePartnerLocationFailure",
+            mutationError: {
+              message: "Partner not found",
+            },
+          },
+        },
+      })
+    })
+  })
+})

--- a/src/schema/v2/partner/createPartnerLocationMutation.ts
+++ b/src/schema/v2/partner/createPartnerLocationMutation.ts
@@ -18,8 +18,8 @@ interface Input {
   partnerID: string
   addressType: string
   country: string
-  addressLine: string
-  addressLine2?: string
+  address: string
+  address2?: string
   city: string
   state?: string
   postalCode: string
@@ -50,16 +50,9 @@ const FailureType = new GraphQLObjectType<any, ResolverContext>({
   }),
 })
 
-// Check why this custom stuff is needed
 const ResponseOrErrorType = new GraphQLUnionType({
   name: "CreatePartnerLocationOrError",
   types: [SuccessType, FailureType],
-  resolveType: (value) => {
-    if (value?._type === "GravityMutationError") {
-      return "CreatePartnerLocationFailure"
-    }
-    return "CreatePartnerLocationSuccess"
-  },
 })
 
 export const CreatePartnerLocationMutation = mutationWithClientMutationId<
@@ -87,10 +80,10 @@ export const CreatePartnerLocationMutation = mutationWithClientMutationId<
     country: {
       type: GraphQLString,
     },
-    addressLine: {
+    address: {
       type: GraphQLString,
     },
-    addressLine2: {
+    address2: {
       type: GraphQLString,
     },
     city: {
@@ -125,8 +118,8 @@ export const CreatePartnerLocationMutation = mutationWithClientMutationId<
   mutateAndGetPayload: async (
     {
       addressType,
-      addressLine,
-      addressLine2,
+      address,
+      address2,
       city,
       state,
       country,
@@ -144,11 +137,10 @@ export const CreatePartnerLocationMutation = mutationWithClientMutationId<
 
     try {
       const response = await createPartnerLocationLoader(partnerID, {
-        name: "OMG IM REQUIRED",
         address_type: addressType,
         country,
-        address: addressLine,
-        address_2: addressLine2,
+        address,
+        address_2: address2,
         city,
         state,
         postal_code: postalCode,

--- a/src/schema/v2/partner/createPartnerLocationMutation.ts
+++ b/src/schema/v2/partner/createPartnerLocationMutation.ts
@@ -1,4 +1,6 @@
 import {
+  GraphQLBoolean,
+  GraphQLEnumType,
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
@@ -72,9 +74,46 @@ export const CreatePartnerLocationMutation = mutationWithClientMutationId<
       type: new GraphQLNonNull(GraphQLString),
       description: "ID of the partner",
     },
-    name: {
+    addressType: {
+      type: new GraphQLEnumType({
+        name: "locationType",
+        values: {
+          BUSINESS: { value: "Business" },
+          TEMPORARY: { value: "Temporary" },
+          OTHER: { value: "Other" },
+        },
+      }),
+    },
+    country: {
       type: GraphQLString,
-      description: "Location name",
+    },
+    addressLine: {
+      type: GraphQLString,
+    },
+    addressLine2: {
+      type: GraphQLString,
+    },
+    city: {
+      type: GraphQLString,
+    },
+    state: {
+      type: GraphQLString,
+    },
+    postalCode: {
+      type: GraphQLString,
+    },
+    email: {
+      type: GraphQLString,
+      description: "Primary email of given location",
+    },
+    phone: {
+      type: GraphQLString,
+      description: "Primary phone of given location",
+    },
+    publiclyViewable: {
+      type: GraphQLBoolean,
+      description:
+        "Boolean flag that denotes whether a location is publicly viewable on Partner's Artsy Profile",
     },
   },
   outputFields: {
@@ -84,7 +123,19 @@ export const CreatePartnerLocationMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    { partnerID },
+    {
+      addressType,
+      addressLine,
+      addressLine2,
+      city,
+      state,
+      country,
+      postalCode,
+      email,
+      phone,
+      publiclyViewable,
+      partnerID,
+    },
     { createPartnerLocationLoader }
   ) => {
     if (!createPartnerLocationLoader) {
@@ -93,7 +144,17 @@ export const CreatePartnerLocationMutation = mutationWithClientMutationId<
 
     try {
       const response = await createPartnerLocationLoader(partnerID, {
-        name: "Happy Gallery",
+        name: "OMG IM REQUIRED",
+        address_type: addressType,
+        country,
+        address: addressLine,
+        address_2: addressLine2,
+        city,
+        state,
+        postal_code: postalCode,
+        email,
+        phone,
+        publicly_viewable: publiclyViewable,
       })
 
       return response

--- a/src/schema/v2/partner/createPartnerLocationMutation.ts
+++ b/src/schema/v2/partner/createPartnerLocationMutation.ts
@@ -1,0 +1,105 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { LocationType } from "../location"
+
+interface Input {
+  partnerID: string
+  name?: string
+  // position?: string
+  // canContact?: boolean
+  // email?: string
+  // phone?: string
+  // locationID?: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreatePartnerLocationSuccess",
+  isTypeOf: (data) => !!data.id,
+  fields: () => ({
+    location: {
+      type: LocationType,
+      resolve: (result) => result,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreatePartnerLocationFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+// Check why this custom stuff is needed
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "CreatePartnerLocationOrError",
+  types: [SuccessType, FailureType],
+  resolveType: (value) => {
+    if (value?._type === "GravityMutationError") {
+      return "CreatePartnerLocationFailure"
+    }
+    return "CreatePartnerLocationSuccess"
+  },
+})
+
+export const CreatePartnerLocationMutation = mutationWithClientMutationId<
+  Input,
+  any,
+  ResolverContext
+>({
+  name: "CreatePartnerLocation",
+  description: "Creates a new location for a partner",
+  inputFields: {
+    partnerID: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "ID of the partner",
+    },
+    name: {
+      type: GraphQLString,
+      description: "Location name",
+    },
+  },
+  outputFields: {
+    partnerLocationOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { partnerID },
+    { createPartnerLocationLoader }
+  ) => {
+    if (!createPartnerLocationLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const response = await createPartnerLocationLoader(partnerID, {
+        name: "Happy Gallery",
+      })
+
+      return response
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/createPartnerLocationMutation.ts
+++ b/src/schema/v2/partner/createPartnerLocationMutation.ts
@@ -137,22 +137,24 @@ export const CreatePartnerLocationMutation = mutationWithClientMutationId<
 
     try {
       const response = await createPartnerLocationLoader(partnerID, {
-        address_type: addressType,
-        country,
         address,
         address_2: address2,
+        address_type: addressType,
         city,
-        state,
-        postal_code: postalCode,
+        country,
         email,
         phone,
+        postal_code: postalCode,
         publicly_viewable: publiclyViewable,
+        state,
       })
 
       return response
     } catch (error) {
       const formattedErr = formatGravityError(error)
+      console.log(formattedErr)
       if (formattedErr) {
+        console.log("hello?")
         return { ...formattedErr, _type: "GravityMutationError" }
       } else {
         throw new Error(error)

--- a/src/schema/v2/partner/createPartnerLocationMutation.ts
+++ b/src/schema/v2/partner/createPartnerLocationMutation.ts
@@ -14,12 +14,16 @@ import { LocationType } from "../location"
 
 interface Input {
   partnerID: string
-  name?: string
-  // position?: string
-  // canContact?: boolean
-  // email?: string
-  // phone?: string
-  // locationID?: string
+  addressType: string
+  country: string
+  addressLine: string
+  addressLine2?: string
+  city: string
+  state?: string
+  postalCode: string
+  email?: string
+  phone?: string
+  publiclyViewable?: boolean
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({

--- a/src/schema/v2/partner/createPartnerLocationMutation.ts
+++ b/src/schema/v2/partner/createPartnerLocationMutation.ts
@@ -152,9 +152,7 @@ export const CreatePartnerLocationMutation = mutationWithClientMutationId<
       return response
     } catch (error) {
       const formattedErr = formatGravityError(error)
-      console.log(formattedErr)
       if (formattedErr) {
-        console.log("hello?")
         return { ...formattedErr, _type: "GravityMutationError" }
       } else {
         throw new Error(error)

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -299,6 +299,7 @@ import {
   submitOrderMutation,
 } from "./order"
 import { CreatePartnerContactMutation } from "./partner/createPartnerContactMutation"
+import { CreatePartnerLocationMutation } from "./partner/createPartnerLocationMutation"
 
 const rootFields = {
   // artworkVersion: ArtworkVersionResolver,
@@ -484,6 +485,7 @@ export default new GraphQLSchema({
       createInvoicePayment: createInvoicePaymentMutation,
       createOrderedSet: createOrderedSetMutation,
       createPartnerContact: CreatePartnerContactMutation,
+      createPartnerLocation: CreatePartnerLocationMutation,
       createPartnerShow: createPartnerShowMutation,
       createPartnerShowDocument: createPartnerShowDocumentMutation,
       createPartnerShowEvent: createPartnerShowEventMutation,


### PR DESCRIPTION
Adds mutation to allow for creating of partner locations

⚠️ [This Gravity change](https://github.com/artsy/gravity/pull/18777) is blocking this PR

Mutation Structure
```graphql

mutation {
  createPartnerLocation(input: { 
  partnerID: "5f80bfefe8d808000ea212c1"
  address: "12345 Happy St"
  address2: "Apt 23"
  city: "Orchard Park"
  state: "NY"
  postalCode: "14127"
  publiclyViewable: true
  }) {
    partnerLocationOrError {
      ... on CreatePartnerLocationSuccess {
        location {
          internalID
          display
        }
      }
      ... on CreatePartnerLocationFailure {
        mutationError {
          message
        }
      }
    }
  }
}

```


Response Structure
```json
{
  "data": {
    "createPartnerLocation": {
      "partnerLocationOrError": {
        "location": {
          "internalID": "67e6e8f7185671000fd3b536",
          "display": "12345 Happy St, Apt 23, Orchard Park, NY, 14127"
        }
      }
    }
  },
  "extensions": {
    "requests": {
      "gravity": {
        "requests": {
          "partner/5f80bfefe8d808000ea212c1/location?address=12345%20Happy%20St&address_2=Apt%2023&address_type=Business&city=Orchard%20Park&name=OMG%20IM%20REQUIRED&postal_code=14127&publicly_viewable=true&state=NY": {
            "time": "0s 504.715ms",
            "cache": false,
            "length": "0 B"
          }
        }
      }
    },
    "requestID": "a67dd390-0c01-11f0-ad7e-4dd4ee341aa4",
    "userAgent": "graphiql-app"
  }
}
```
---

Ex
<img width="1574" alt="Screenshot 2025-03-28 at 3 34 00 PM" src="https://github.com/user-attachments/assets/7eb0fc62-82f5-47ee-82ab-cddde917f49b" />

---

## TODOs:
- [x] Partner location name is required on the backend and secretly passed in as a SecureRandom hex from Volt Controller level. Figure out what to do [here](https://artsy.slack.com/archives/CP9P4KR35/p1743185391768839), I'm leaning on removing the validation for its presence
- [x] Specs