### PR TITLE
feat: add seller field to order

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15896,6 +15896,9 @@ type Order {
   # The selected fulfillment option for the order
   selectedFulfillmentOption: FulfillmentOption
 
+  # The seller of the order
+  seller: SellerType
+
   # The total amount for shipping
   shippingTotal: Money
 
@@ -20102,6 +20105,8 @@ interface Sellable {
   isSold: Boolean
   saleMessage: String
 }
+
+union SellerType = Partner
 
 type SendConfirmationEmailMutationFailure {
   mutationError: GravityMutationError


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/EMI-2362

Following https://github.com/artsy/exchange/pull/2486, this adds a `seller` field on the order type in which we'll be able fetch the stripe account id. It's basically to replace the current [stitched version](https://github.com/artsy/metaphysics/blob/c83d5b17aa3cb4cceb9b18978a243b6d36f6e87b/src/lib/stitching/exchange/v2/stitching.ts#L607).

cc @artsy/emerald-devs 