### PR TITLE
fix: remove leading and trailing whitespace characters from the search query

### DIFF
--- a/src/schema/v2/__tests__/search.test.ts
+++ b/src/schema/v2/__tests__/search.test.ts
@@ -356,4 +356,24 @@ describe("Search", () => {
       expect(geneNode.name).toBe("Minimalism")
     })
   })
+
+  it("Removes leading and trailing whitespace characters from the query", async () => {
+    const query = `
+      {
+        searchConnection(query: "  David Bowie  ", first: 10) {
+          edges {
+            node {
+              __typename
+            }
+          }
+        }
+      }
+    `
+    context.searchLoader = jest.fn().mockImplementation(() => searchResponse)
+
+    await runQuery(query, context)
+
+    // confirm that searchLoader was called with the trimmed query
+    expect(context.searchLoader.mock.calls[0][0].query).toBe("David Bowie")
+  })
 })

--- a/src/schema/v2/search/SearchResolver.ts
+++ b/src/schema/v2/search/SearchResolver.ts
@@ -1,6 +1,7 @@
 import { GraphQLResolveInfo, visit } from "graphql"
 import { connectionFromArraySlice } from "graphql-relay"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { trim } from "lodash"
 import compact from "lodash/compact"
 import { SearchableItem } from "schema/v2/SearchableItem"
 import { createPageCursors, pageToCursor } from "schema/v2/fields/pagination"
@@ -110,6 +111,7 @@ export class SearchResolver {
     const { page, size, offset, ...rest } = pageOptions
     const gravityArgs = {
       ...rest,
+      query: trim(this.args.query),
       page,
       size,
       entities: this.args.entities,


### PR DESCRIPTION
When I type "Claudia" and "Claudia " (with a trailing space) into the search input, I get completely different results:

| "Claudia" | "Claudia " |
|---|---|
| <img src="https://github.com/user-attachments/assets/0818919a-7484-4d3f-a122-46e29ac9dd78" > | <img src="https://github.com/user-attachments/assets/4c89234a-0ec0-4109-a3a0-5b2e5d91a0e1" /> |

We believe this is worth fixing.

## Tech notes

The issue occurs because we apply a strong boost to the `name_exact` field, which is a `keyword` field. Keyword fields in Elasticsearch don’t apply any normalization — for example, they don’t trim surrounding whitespace. You can see the difference by comparing the analyzer results between the `name_exact` (keyword) and `name` (text) fields:

### name_exact

```
POST /artists_production/_analyze
{
  "field": "name_exact",
  "text": "   Claudia   "
}
```

Returns:

```json
{
  "tokens": [
    {
      "token": "   Claudia   "
     }
  ]
}
```

### name

```
POST /artists_production/_analyze
{
  "field": "name",
  "text": "   Claudia   "
}
```

Returns:

```json
{
  "tokens": [
    {
      "token": "claudia"
     }
  ]
}
```

One potential solution would be to apply normalization logic (like trimming) at index or query time in Elasticsearch. However, I think the simplest fix would be to trim leading/trailing spaces in Metaphysics before sending the query.