### PR TITLE
chore: allow statuses to be passed as an arg to show viewingRoomsConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -20571,7 +20571,13 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
   # Is it a fair booth or a show?
   type: String
   viewingRoomIDs: [String!]!
-  viewingRoomsConnection: ViewingRoomsConnection
+  viewingRoomsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    statuses: [ViewingRoomStatusEnum!]
+  ): ViewingRoomsConnection
 }
 
 type ShowArtworkGrid implements ArtworkContextGrid {

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -56,7 +56,10 @@ import { LOCAL_DISCOVERY_RADIUS_KM } from "./city/constants"
 import { ResolverContext } from "types/graphql"
 import followArtistsResolver from "lib/shared_resolvers/followedArtistsResolver"
 import { ExhibitionPeriodFormatEnum } from "./types/exhibitonPeriod"
-import { ViewingRoomsConnection } from "./viewingRoomConnection"
+import {
+  ViewingRoomsConnection,
+  ViewingRoomStatusEnum,
+} from "./viewingRoomConnection"
 import { PartnerDocumentsConnection } from "./partner/partnerDocumentsConnection"
 
 const FollowArtistType = new GraphQLObjectType<any, ResolverContext>({
@@ -711,9 +714,14 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
       },
       viewingRoomsConnection: {
         type: ViewingRoomsConnection.type,
+        args: pageable({
+          statuses: {
+            type: new GraphQLList(new GraphQLNonNull(ViewingRoomStatusEnum)),
+          },
+        }),
         resolve: async (
           { viewing_room_ids },
-          _args,
+          { statuses },
           { viewingRoomsLoader }
         ) => {
           if (!viewing_room_ids || viewing_room_ids.length === 0) {
@@ -731,6 +739,7 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
             page,
             size,
             total_count: true,
+            statuses,
           }
 
           const { body, headers } = await viewingRoomsLoader(gravityArgs)


### PR DESCRIPTION
In CMS, we want to display a linked viewing room to a show, even if it's not publicly viewable. So - we can specify the `statuses:[closed, draft, live, scheduled]` - and for an authorized user they'd see any linked VR, even if it's not public (which we want in CMS).