### PR TITLE
feat: Add query to fetch single partner contact

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16321,9 +16321,9 @@ type Partner implements Node {
   claimed: Boolean
   collectingInstitution: String
 
-  # A Contact belonging to a Partner
+  # A Singular Contact belonging to the Partner
   contact(
-    # The slug or ID of the Show
+    # The slug or ID of the Contact
     contactId: String!
   ): Contact
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16321,6 +16321,12 @@ type Partner implements Node {
   claimed: Boolean
   collectingInstitution: String
 
+  # A Contact belonging to a Partner
+  contact(
+    # The slug or ID of the Show
+    contactId: String!
+  ): Contact
+
   # A connection of contacts from a Partner.
   contactsConnection(
     after: String

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -900,6 +900,14 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    partnerContactLoader: gravityLoader<
+      any,
+      { partnerId: string; contactId: string }
+    >(
+      ({ partnerId, contactId }) => `partner/${partnerId}/contact/${contactId}`,
+      {},
+      { headers: true }
+    ),
     partnerContactsLoader: gravityLoader(
       (id) => `partner/${id}/contacts`,
       {},

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -904,9 +904,7 @@ export default (accessToken, userID, opts) => {
       any,
       { partnerId: string; contactId: string }
     >(
-      ({ partnerId, contactId }) => `partner/${partnerId}/contact/${contactId}`,
-      {},
-      { headers: true }
+      ({ partnerId, contactId }) => `partner/${partnerId}/contact/${contactId}`
     ),
     partnerContactsLoader: gravityLoader(
       (id) => `partner/${id}/contacts`,

--- a/src/schema/v2/partner/__tests__/partner.test.js
+++ b/src/schema/v2/partner/__tests__/partner.test.js
@@ -513,12 +513,7 @@ describe("Partner type", () => {
     let singleContactResponse
 
     const partnerContactLoader = jest.fn(() => {
-      return Promise.resolve({
-        body: singleContactResponse,
-        headers: {
-          "x-total-count": 1,
-        },
-      })
+      return Promise.resolve(singleContactResponse)
     })
 
     const partnerLoader = jest.fn(() => {

--- a/src/schema/v2/partner/__tests__/partner.test.js
+++ b/src/schema/v2/partner/__tests__/partner.test.js
@@ -509,6 +509,67 @@ describe("Partner type", () => {
     })
   })
 
+  describe("#contact", () => {
+    let singleContactResponse
+
+    const partnerContactLoader = jest.fn(() => {
+      return Promise.resolve({
+        body: singleContactResponse,
+        headers: {
+          "x-total-count": 1,
+        },
+      })
+    })
+
+    const partnerLoader = jest.fn(() => {
+      return Promise.resolve(partnerData)
+    })
+
+    beforeEach(() => {
+      singleContactResponse = {
+        id: "contact-1",
+        name: "Molly D",
+        email: "md@artsy.net",
+        partner_location: { display: "123 Happy St, NY NY" },
+      }
+    })
+
+    it("returns a given partner contact", async () => {
+      context = {
+        partnerContactLoader,
+        partnerLoader,
+      }
+
+      const query = `
+        {
+          partner(id:"bau-xi-gallery") {
+            contact(contactId: "contact-1") {
+              name
+              email
+              location {
+                display
+              }
+            }
+          }
+        }
+      `
+
+      const data = await runAuthenticatedQuery(query, context)
+
+      expect(data).toEqual({
+        partner: {
+          contact: {
+            name: "Molly D",
+            email: "md@artsy.net",
+            location: {
+              display: "123 Happy St, NY NY",
+            },
+          },
+        },
+      })
+    })
+  })
+
   describe("#contactsConnection", () => {
     let contactsResponse
 

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -60,7 +60,7 @@ import {
   ViewingRoomsConnection,
   ViewingRoomStatusEnum,
 } from "../viewingRoomConnection"
-import { contactsConnection } from "schema/v2/Contacts"
+import { contactsConnection, ContactType } from "schema/v2/Contacts"
 
 const isFairOrganizer = (type) => type === "FairOrganizer"
 const isGallery = (type) => type === "PartnerGallery"
@@ -851,6 +851,29 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
 
           // Filter for dupes and blanks
           return Array.from(new Set(cities)).filter(Boolean)
+        },
+      },
+      contact: {
+        type: ContactType,
+        description: "A Contact belonging to a Partner",
+        args: {
+          contactId: {
+            type: new GraphQLNonNull(GraphQLString),
+            description: "The slug or ID of the Show",
+          },
+        },
+        resolve: async ({ id }, args, { partnerContactLoader }) => {
+          const { contactId } = args
+          console.log("hello???", id, contactId)
+
+          if (!partnerContactLoader) return null
+
+          const { body } = await partnerContactLoader({
+            partnerId: id,
+            contactId: contactId,
+          })
+
+          return body ?? null
         },
       },
       defaultProfileID: {

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -855,11 +855,11 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       },
       contact: {
         type: ContactType,
-        description: "A Contact belonging to a Partner",
+        description: "A Singular Contact belonging to the Partner",
         args: {
           contactId: {
             type: new GraphQLNonNull(GraphQLString),
-            description: "The slug or ID of the Show",
+            description: "The slug or ID of the Contact",
           },
         },
         resolve: async ({ id }, args, { partnerContactLoader }) => {

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -864,7 +864,6 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         },
         resolve: async ({ id }, args, { partnerContactLoader }) => {
           const { contactId } = args
-          console.log("hello???", id, contactId)
 
           if (!partnerContactLoader) return null
 

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -867,12 +867,12 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
 
           if (!partnerContactLoader) return null
 
-          const { body } = await partnerContactLoader({
+          const contact = await partnerContactLoader({
             partnerId: id,
             contactId: contactId,
           })
 
-          return body ?? null
+          return contact
         },
       },
       defaultProfileID: {


### PR DESCRIPTION
Welp I didnt get too far sketching out the [edit functionality in volt](https://github.com/artsy/volt/compare/jpotts244-contact-delete-edit?expand=1)

Adding the ability to fetch a singular partner contact ✅  
Will need this to rehydrate the contact records on the front end after a user edits a record + we dont have to use the larger `contactsConnection` query only in Volt 📈 

--- 


```graphql
{
  partner(id: "commerce-test-partner") {
    internalID
    contact(contactId: "4820b8cb-983f-4cf8-a35b-90e0f7954d1a") {
      internalID
      name
      email
      phone
      position
      canContact
      location {
        internalID
        display
      }
    }
  }
}

```


<img width="1481" alt="Screenshot 2025-04-02 at 8 21 25 PM" src="https://github.com/user-attachments/assets/2c7590aa-8780-4a74-b347-69523a56a408" />

