### PR TITLE
chore: support timezones for show events

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9069,6 +9069,9 @@ input CreatePartnerShowEventMutationInput {
 
   # The start time of the event.
   startAt: String!
+
+  # The time zone of the event.
+  timeZone: String
 }
 
 type CreatePartnerShowEventMutationPayload {
@@ -20663,6 +20666,9 @@ type ShowEventType {
     format: ExhibitionPeriodFormat = LONG
   ): String
 
+  # A formatted description of the time zone
+  formattedTimeZone: String
+
   # A globally unique ID.
   id: ID!
 
@@ -20674,6 +20680,7 @@ type ShowEventType {
     # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String
+  timeZone: String
   title: String
 }
 
@@ -21984,6 +21991,9 @@ input UpdatePartnerShowEventMutationInput {
 
   # The start time of the event.
   startAt: String
+
+  # The time zone of the event.
+  timeZone: String
 }
 
 type UpdatePartnerShowEventMutationPayload {

--- a/src/schema/v2/Show/__tests__/createPartnerShowEventMutation.test.ts
+++ b/src/schema/v2/Show/__tests__/createPartnerShowEventMutation.test.ts
@@ -12,6 +12,7 @@ describe("CreatePartnerShowEventMutation", () => {
           endAt: "2025-01-01T18:00:00+00:00"
           eventType: "Opening Reception"
           description: "Join us for the opening reception"
+          timeZone: "(GMT-04:00) New York"
         }
       ) {
         showEventOrError {
@@ -21,6 +22,8 @@ describe("CreatePartnerShowEventMutation", () => {
               eventType
               description
               startAt
+              timeZone
+              formattedTimeZone
               endAt
             }
           }
@@ -31,14 +34,18 @@ describe("CreatePartnerShowEventMutation", () => {
 
   it("creates a partner show event", async () => {
     const context = {
-      createPartnerShowEventLoader: () =>
-        Promise.resolve({
+      createPartnerShowEventLoader: (_, args) => {
+        expect(args.time_zone).toEqual("America/New_York")
+
+        return Promise.resolve({
           _id: "event123",
           event_type: "Opening Reception",
           description: "Join us for the opening reception",
           start_at: "2025-01-01T12:00:00.000Z",
           end_at: "2025-01-01T18:00:00.000Z",
-        }),
+          time_zone: "America/New_York",
+        })
+      },
     }
 
     const createdEvent = await runAuthenticatedQuery(mutation, context)
@@ -52,6 +59,8 @@ describe("CreatePartnerShowEventMutation", () => {
             description: "Join us for the opening reception",
             startAt: "2025-01-01T12:00:00.000Z",
             endAt: "2025-01-01T18:00:00.000Z",
+            formattedTimeZone: "(GMT-04:00) New York",
+            timeZone: "America/New_York",
           },
         },
       },

--- a/src/schema/v2/Show/__tests__/updatePartnerShowEventMutation.test.ts
+++ b/src/schema/v2/Show/__tests__/updatePartnerShowEventMutation.test.ts
@@ -11,6 +11,7 @@ describe("UpdatePartnerShowEventMutation", () => {
           eventId: "event123"
           eventType: "Closing Reception"
           description: "Join us for the closing reception"
+          timeZone: "(GMT-04:00) New York"
         }
       ) {
         showEventOrError {
@@ -21,6 +22,8 @@ describe("UpdatePartnerShowEventMutation", () => {
               description
               startAt
               endAt
+              timeZone
+              formattedTimeZone
             }
           }
         }
@@ -30,14 +33,17 @@ describe("UpdatePartnerShowEventMutation", () => {
 
   it("updates a partner show event", async () => {
     const context = {
-      updatePartnerShowEventLoader: () =>
-        Promise.resolve({
+      updatePartnerShowEventLoader: (_, args) => {
+        expect(args.time_zone).toEqual("America/New_York")
+        return Promise.resolve({
           _id: "event123",
           event_type: "Closing Reception",
           description: "Join us for the closing reception",
           start_at: "2025-01-01T12:00:00.000Z",
           end_at: "2025-01-01T18:00:00.000Z",
-        }),
+          time_zone: "America/New_York",
+        })
+      },
     }
 
     const updatedEvent = await runAuthenticatedQuery(mutation, context)
@@ -51,6 +57,8 @@ describe("UpdatePartnerShowEventMutation", () => {
             description: "Join us for the closing reception",
             startAt: "2025-01-01T12:00:00.000Z",
             endAt: "2025-01-01T18:00:00.000Z",
+            formattedTimeZone: "(GMT-04:00) New York",
+            timeZone: "America/New_York",
           },
         },
       },

--- a/src/schema/v2/Show/createPartnerShowEventMutation.ts
+++ b/src/schema/v2/Show/createPartnerShowEventMutation.ts
@@ -10,8 +10,9 @@ import {
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
-import ShowEventType from "../show_event"
+import ShowEventType, { formatTimeZone } from "../show_event"
 import moment from "moment"
+import momentTz from "moment-timezone"
 import { ShowType } from "../show"
 
 interface CreatePartnerShowEventMutationInputProps {
@@ -86,6 +87,10 @@ export const createPartnerShowEventMutation = mutationWithClientMutationId<
       type: GraphQLString,
       description: "A description of the event.",
     },
+    timeZone: {
+      type: GraphQLString,
+      description: "The time zone of the event.",
+    },
   },
   outputFields: {
     showEventOrError: {
@@ -110,6 +115,7 @@ export const createPartnerShowEventMutation = mutationWithClientMutationId<
       end_at: number
       event_type: string
       description?: string
+      time_zone?: string
     } = {
       start_at: moment(args.startAt).unix(),
       end_at: moment(args.endAt).unix(),
@@ -118,6 +124,12 @@ export const createPartnerShowEventMutation = mutationWithClientMutationId<
 
     if (args.description) {
       gravityArgs.description = args.description
+    }
+
+    if (args.timeZone) {
+      gravityArgs.time_zone = momentTz.tz
+        .names()
+        .find((timeZone) => formatTimeZone(timeZone) === args.timeZone)
     }
 
     try {

--- a/src/schema/v2/Show/updatePartnerShowEventMutation.ts
+++ b/src/schema/v2/Show/updatePartnerShowEventMutation.ts
@@ -12,6 +12,8 @@ import {
 import { ResolverContext } from "types/graphql"
 import ShowEventType from "../show_event"
 import moment from "moment"
+import momentTz from "moment-timezone"
+import { formatTimeZone } from "../show_event"
 import { ShowType } from "../show"
 
 interface UpdatePartnerShowEventMutationInputProps {
@@ -91,6 +93,10 @@ export const updatePartnerShowEventMutation = mutationWithClientMutationId<
       type: GraphQLString,
       description: "A description of the event.",
     },
+    timeZone: {
+      type: GraphQLString,
+      description: "The time zone of the event.",
+    },
   },
   outputFields: {
     showEventOrError: {
@@ -115,6 +121,7 @@ export const updatePartnerShowEventMutation = mutationWithClientMutationId<
       end_at?: number
       event_type?: string
       description?: string
+      time_zone?: string
     } = {}
 
     if (args.startAt) {
@@ -131,6 +138,12 @@ export const updatePartnerShowEventMutation = mutationWithClientMutationId<
 
     if (args.description !== undefined) {
       gravityArgs.description = args.description
+    }
+
+    if (args.timeZone) {
+      gravityArgs.time_zone = momentTz.tz
+        .names()
+        .find((timeZone) => formatTimeZone(timeZone) === args.timeZone)
     }
 
     try {

--- a/src/schema/v2/show_event.ts
+++ b/src/schema/v2/show_event.ts
@@ -5,6 +5,15 @@ import { dateRange, dateTimeRange } from "lib/date"
 import { ExhibitionPeriodFormatEnum } from "./types/exhibitonPeriod"
 import { connectionWithCursorInfo } from "./fields/pagination"
 import { GravityIDFields } from "./object_identification"
+import moment from "moment-timezone"
+
+export const formatTimeZone = (timeZone: string) => {
+  // Get current offset in hours for the given timezone
+  const offset = moment.tz(timeZone).format("Z")
+  // Extract a user-friendly name
+  const displayName = timeZone.split("/")[1].replace("_", " ")
+  return `(GMT${offset}) ${displayName}`
+}
 
 const ShowEventType = new GraphQLObjectType<any, ResolverContext>({
   name: "ShowEventType",
@@ -46,6 +55,19 @@ const ShowEventType = new GraphQLObjectType<any, ResolverContext>({
         const { format } = args
         return dateRange(start_at, end_at, "UTC", format)
       },
+    },
+    formattedTimeZone: {
+      type: GraphQLString,
+      description: "A formatted description of the time zone",
+      resolve: ({ time_zone }) => {
+        if (!time_zone) return null
+
+        return formatTimeZone(time_zone)
+      },
+    },
+    timeZone: {
+      type: GraphQLString,
+      resolve: ({ time_zone }) => time_zone,
     },
   },
 })


### PR DESCRIPTION
This supports displaying the timezone of a show event in a way suitable for a select picker, as well as lets the mutations to create/edit a show event specify a timezone.

The quirk here is that the backend expects one format which is a bit specific to Rails - and we want to be able to translate for a nicer UI to show the partner.

This code supports properly managing data like (note the time zone specific stuff):

<img width="608" alt="Screenshot 2025-04-02 at 9 14 50 PM" src="https://github.com/user-attachments/assets/21a8ee15-8175-4cc6-ba39-1c2df2f79d03" />

