### PR TITLE
feat(edition-sets): Share fields with sellable

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10212,6 +10212,8 @@ input EditableLocation {
 type EditionSet implements Sellable {
   availability: String
   dimensions: dimensions
+
+  # The edition set parent-artwork display label (title)
   displayLabel: String
   displayPriceRange: Boolean
   editionOf: String
@@ -10230,7 +10232,10 @@ type EditionSet implements Sellable {
   isAcquireable: Boolean
   isForSale: Boolean
 
-  # Do we want to encourage inquiries on this work?
+  # Is the edition set parent-artwork part of an auction?
+  isInAuction: Boolean
+
+  # Is the edition set parent-artwork inquireable?
   isInquireable: Boolean
   isOfferable: Boolean
   isOfferableFromInquiry: Boolean
@@ -10241,7 +10246,7 @@ type EditionSet implements Sellable {
   priceDisplay: String
   priceListed: Money
 
-  # Whether this artwork is published or not
+  # Is the edition set parent-artwork published?
   published: Boolean
   saleMessage: String
 
@@ -20149,19 +20154,33 @@ union SecondFactorOrErrorsUnion = AppSecondFactor | Errors | SmsSecondFactor
 
 # A piece that can be sold
 interface Sellable {
+  availability: String
   dimensions: dimensions
+  displayLabel: String
+  displayPriceRange: Boolean
   editionOf: String
+
+  # A globally unique ID.
+  id: ID!
+  internalDisplayPrice: String
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
 
   # Whether a piece can be purchased through e-commerce
   isAcquireable: Boolean
   isForSale: Boolean
+  isInAuction: Boolean
+  isInquireable: Boolean
 
   # Whether a user can make an offer on the work
   isOfferable: Boolean
 
   # Whether a user can make an offer on the work through inquiry
   isOfferableFromInquiry: Boolean
+  isPriceHidden: Boolean
   isSold: Boolean
+  published: Boolean
   saleMessage: String
 }
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10212,6 +10212,7 @@ input EditableLocation {
 type EditionSet implements Sellable {
   availability: String
   dimensions: dimensions
+  displayLabel: String
   displayPriceRange: Boolean
   editionOf: String
 
@@ -10228,13 +10229,23 @@ type EditionSet implements Sellable {
   internalID: ID!
   isAcquireable: Boolean
   isForSale: Boolean
+
+  # Is this artwork part of an auction?
+  isInAuction: Boolean
+
+  # Do we want to encourage inquiries on this work?
+  isInquireable: Boolean
   isOfferable: Boolean
   isOfferableFromInquiry: Boolean
+  isPriceHidden: Boolean
   isSold: Boolean
   listPrice: ListPrice
   price: String
   priceDisplay: String
   priceListed: Money
+
+  # Whether this artwork is published or not
+  published: Boolean
   saleMessage: String
 
   # size bucket assigned to an artwork based on its dimensions
@@ -20141,19 +20152,41 @@ union SecondFactorOrErrorsUnion = AppSecondFactor | Errors | SmsSecondFactor
 
 # A piece that can be sold
 interface Sellable {
+  availability: String
   dimensions: dimensions
+  displayLabel: String
+  displayPriceRange: Boolean
   editionOf: String
+
+  # A globally unique ID.
+  id: ID!
+
+  # Price for internal partner display, requires partner access
+  internalDisplayPrice: String
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
 
   # Whether a piece can be purchased through e-commerce
   isAcquireable: Boolean
   isForSale: Boolean
+
+  # Is this artwork part of an auction?
+  isInAuction: Boolean
+
+  # Do we want to encourage inquiries on this work?
+  isInquireable: Boolean
 
   # Whether a user can make an offer on the work
   isOfferable: Boolean
 
   # Whether a user can make an offer on the work through inquiry
   isOfferableFromInquiry: Boolean
+  isPriceHidden: Boolean
   isSold: Boolean
+
+  # Whether this artwork is published or not
+  published: Boolean
   saleMessage: String
 }
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2579,7 +2579,7 @@ type Artwork implements Node & Searchable & Sellable {
   framed: ArtworkInfoRow
     @deprecated(reason: "Consider using isFramed field (boolean) instead")
   framedDepth: String
-  framedDiameter: Float
+  framedDiameter: String
   framedHeight: String
 
   # The unit of measurement for the framed dimensions
@@ -10229,9 +10229,6 @@ type EditionSet implements Sellable {
   internalID: ID!
   isAcquireable: Boolean
   isForSale: Boolean
-
-  # Is this artwork part of an auction?
-  isInAuction: Boolean
 
   # Do we want to encourage inquiries on this work?
   isInquireable: Boolean
@@ -20152,41 +20149,19 @@ union SecondFactorOrErrorsUnion = AppSecondFactor | Errors | SmsSecondFactor
 
 # A piece that can be sold
 interface Sellable {
-  availability: String
   dimensions: dimensions
-  displayLabel: String
-  displayPriceRange: Boolean
   editionOf: String
-
-  # A globally unique ID.
-  id: ID!
-
-  # Price for internal partner display, requires partner access
-  internalDisplayPrice: String
-
-  # A type-specific ID likely used as a database ID.
-  internalID: ID!
 
   # Whether a piece can be purchased through e-commerce
   isAcquireable: Boolean
   isForSale: Boolean
-
-  # Is this artwork part of an auction?
-  isInAuction: Boolean
-
-  # Do we want to encourage inquiries on this work?
-  isInquireable: Boolean
 
   # Whether a user can make an offer on the work
   isOfferable: Boolean
 
   # Whether a user can make an offer on the work through inquiry
   isOfferableFromInquiry: Boolean
-  isPriceHidden: Boolean
   isSold: Boolean
-
-  # Whether this artwork is published or not
-  published: Boolean
   saleMessage: String
 }
 
@@ -21300,26 +21275,42 @@ type UpdateArtistSuccess {
 }
 
 input UpdateArtworkEditionSetInput {
+  artistProofs: String
+
   # The availability of the artwork
   availability: String
+  delete: Boolean
 
   # Show/Hide the price range of an artwork
   displayPriceRange: Boolean
 
-  # True for `Buy Now` artworks
+  # True for `Buy Now` edition sets
   ecommerce: Boolean
+  editionSize: String
+  framed: Boolean
+  framedDepth: String
+  framedDiameter: String
+  framedHeight: String
+  framedMetric: String
+  framedWidth: String
 
   # The id of the artwork to update.
   id: String!
 
   # True for `Make Offer` artworks
   offer: Boolean
+  priceCurrency: String
 
   # Show/Hide the price of an artwork
   priceHidden: Boolean
+  priceIncludesTax: Boolean
 
   # The price of the artwork
   priceListed: String
+  priceMax: Int
+  priceMin: Int
+  shippingWeight: Float
+  shippingWeightMetric: String
 }
 
 type UpdateArtworkImportRowFailure {
@@ -21349,30 +21340,46 @@ type UpdateArtworkImportRowSuccess {
 }
 
 input UpdateArtworkMutationInput {
+  artistProofs: String
+
   # The availability of the artwork
   availability: String
   clientMutationId: String
+  delete: Boolean
 
   # Show/Hide the price range of an artwork
   displayPriceRange: Boolean
 
-  # True for `Buy Now` artworks
+  # True for `Buy Now` edition sets
   ecommerce: Boolean
 
   # A list of edition sets for the artwork
   editionSets: [UpdateArtworkEditionSetInput]
+  editionSize: String
+  framed: Boolean
+  framedDepth: String
+  framedDiameter: String
+  framedHeight: String
+  framedMetric: String
+  framedWidth: String
 
   # The id of the artwork to update.
   id: String!
 
   # True for `Make Offer` artworks
   offer: Boolean
+  priceCurrency: String
 
   # Show/Hide the price of an artwork
   priceHidden: Boolean
+  priceIncludesTax: Boolean
 
   # The price of the artwork
   priceListed: String
+  priceMax: Int
+  priceMin: Int
+  shippingWeight: Float
+  shippingWeightMetric: String
 }
 
 type UpdateArtworkMutationPayload {

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -5784,7 +5784,7 @@ describe("Artwork type", () => {
           framedHeight: "10",
           framedWidth: "20",
           framedDepth: "30",
-          framedDiameter: 40,
+          framedDiameter: "40",
           framedMetric: "cm",
         },
       })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1858,7 +1858,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ framed_width }) => framed_width,
       },
       framedDiameter: {
-        type: GraphQLFloat,
+        type: GraphQLString,
         resolve: ({ framed_diameter }) => framed_diameter,
       },
       signatureInfo: {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -611,10 +611,18 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       editionSets: {
         type: new GraphQLList(EditionSet.type),
         args: { sort: EditionSetSorts },
-        resolve: ({ edition_sets }, { sort }) => {
+        resolve: ({ edition_sets, ...artwork }, { sort }) => {
+          // Inject a copy of the artwork into each edition set
+          const editionSets = edition_sets.map((editionSet) => {
+            return {
+              artwork,
+              ...editionSet,
+            }
+          })
+
           if (sort) {
             // Only ascending price sort supported currently.
-            return edition_sets.sort(
+            return editionSets.sort(
               ({ price_cents: aPrice }, { price_cents: bPrice }) => {
                 if (!aPrice || aPrice.length === 0) {
                   return 1
@@ -626,7 +634,8 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
               }
             )
           }
-          return edition_sets
+
+          return editionSets
         },
       },
       exhibitionHistory: markdown(

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -865,7 +865,6 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLBoolean,
         resolve: ({ display_artist_bio }) => display_artist_bio,
       },
-
       displayPriceRange: {
         type: GraphQLBoolean,
         resolve: ({ display_price_range }) => display_price_range,
@@ -1807,7 +1806,6 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         }),
         resolve: (artwork) => artwork,
       },
-
       title: {
         type: GraphQLString,
         resolve: ({ title }) => (_.isEmpty(title) ? "Untitled" : title),

--- a/src/schema/v2/artwork/updateArtworkMutation.ts
+++ b/src/schema/v2/artwork/updateArtworkMutation.ts
@@ -6,6 +6,8 @@ import {
   GraphQLList,
   GraphQLInputObjectType,
   GraphQLBoolean,
+  GraphQLFloat,
+  GraphQLInt,
 } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 import { ResolverContext } from "types/graphql"
@@ -43,14 +45,29 @@ const ResponseOrErrorType = new GraphQLUnionType({
 })
 
 interface UpdateArtworkMutationInputProps {
-  id?: string
-  availability?: boolean
-  ecommerce?: boolean
+  artistProofs?: string
+  availability?: string
+  delete?: boolean
   displayPriceRange?: boolean
-  offer?: boolean
-  priceHidden?: boolean
-  priceListed?: string
+  ecommerce?: boolean
   editionSets?: Omit<UpdateArtworkMutationInputProps, "editionSets">[]
+  editionSize?: string
+  framed?: boolean
+  framedDepth?: string
+  framedDiameter?: string
+  framedHeight?: string
+  framedMetric?: string
+  framedWidth?: string
+  id?: string
+  offer?: boolean
+  priceCurrency?: string
+  priceHidden?: boolean
+  priceIncludesTax?: boolean
+  priceListed?: string
+  priceMax?: number
+  priceMin?: number
+  shippingWeight?: number
+  shippingWeightMetric?: string
 }
 
 const inputFields = {
@@ -61,10 +78,6 @@ const inputFields = {
   availability: {
     type: GraphQLString,
     description: "The availability of the artwork",
-  },
-  ecommerce: {
-    type: GraphQLBoolean,
-    description: "True for `Buy Now` artworks",
   },
   displayPriceRange: {
     type: GraphQLBoolean,
@@ -81,6 +94,55 @@ const inputFields = {
   priceListed: {
     type: GraphQLString,
     description: "The price of the artwork",
+  },
+  artistProofs: {
+    type: GraphQLString,
+  },
+  delete: {
+    type: GraphQLBoolean,
+  },
+  ecommerce: {
+    description: "True for `Buy Now` edition sets",
+    type: GraphQLBoolean,
+  },
+  editionSize: {
+    type: GraphQLString,
+  },
+  framedDepth: {
+    type: GraphQLString,
+  },
+  framedDiameter: {
+    type: GraphQLString,
+  },
+  framedHeight: {
+    type: GraphQLString,
+  },
+  framedMetric: {
+    type: GraphQLString,
+  },
+  framedWidth: {
+    type: GraphQLString,
+  },
+  framed: {
+    type: GraphQLBoolean,
+  },
+  priceCurrency: {
+    type: GraphQLString,
+  },
+  priceIncludesTax: {
+    type: GraphQLBoolean,
+  },
+  priceMax: {
+    type: GraphQLInt,
+  },
+  priceMin: {
+    type: GraphQLInt,
+  },
+  shippingWeightMetric: {
+    type: GraphQLString,
+  },
+  shippingWeight: {
+    type: GraphQLFloat,
   },
 }
 
@@ -120,13 +182,28 @@ export const updateArtworkMutation = mutationWithClientMutationId<
 
     const getGravityArgs = (inputArgs: UpdateArtworkMutationInputProps) => {
       return {
-        id: inputArgs.id,
+        artist_proofs: inputArgs.artistProofs,
         availability: inputArgs.availability,
-        ecommerce: inputArgs.ecommerce,
+        delete: inputArgs.delete,
         display_price_range: inputArgs.displayPriceRange,
+        ecommerce: inputArgs.ecommerce,
+        edition_size: inputArgs.editionSize,
+        framed_depth: inputArgs.framedDepth,
+        framed_diameter: inputArgs.framedDiameter,
+        framed_height: inputArgs.framedHeight,
+        framed_metric: inputArgs.framedMetric,
+        framed_width: inputArgs.framedWidth,
+        framed: inputArgs.framed,
+        id: inputArgs.id,
         offer: inputArgs.offer,
+        price_currency: inputArgs.priceCurrency,
         price_hidden: inputArgs.priceHidden,
+        price_includes_tax: inputArgs.priceIncludesTax,
         price_listed: inputArgs.priceListed,
+        price_max: inputArgs.priceMax,
+        price_min: inputArgs.priceMin,
+        shipping_weight_metric: inputArgs.shippingWeightMetric,
+        shipping_weight: inputArgs.shippingWeight,
       }
     }
 
@@ -134,13 +211,15 @@ export const updateArtworkMutation = mutationWithClientMutationId<
       if (editionSets?.length) {
         await Promise.all(
           editionSets.map((editionSet) => {
-            const input = {
-              ...getGravityArgs(editionSet),
-              artworkId: id,
-              editionSetId: editionSet.id,
-            }
+            const input = getGravityArgs(editionSet)
 
-            return updateArtworkEditionSetLoader(input)
+            return updateArtworkEditionSetLoader(
+              {
+                artworkId: id,
+                editionSetId: editionSet.id,
+              },
+              input
+            )
           })
         )
       }

--- a/src/schema/v2/artwork/updateArtworkMutation.ts
+++ b/src/schema/v2/artwork/updateArtworkMutation.ts
@@ -54,6 +54,10 @@ interface UpdateArtworkMutationInputProps {
 }
 
 const inputFields = {
+  id: {
+    type: new GraphQLNonNull(GraphQLString),
+    description: "The id of the artwork to update.",
+  },
   availability: {
     type: GraphQLString,
     description: "The availability of the artwork",
@@ -77,10 +81,6 @@ const inputFields = {
   priceListed: {
     type: GraphQLString,
     description: "The price of the artwork",
-  },
-  id: {
-    type: new GraphQLNonNull(GraphQLString),
-    description: "The id of the artwork to update.",
   },
 }
 
@@ -134,11 +134,13 @@ export const updateArtworkMutation = mutationWithClientMutationId<
       if (editionSets?.length) {
         await Promise.all(
           editionSets.map((editionSet) => {
-            return updateArtworkEditionSetLoader({
+            const input = {
               ...getGravityArgs(editionSet),
               artworkId: id,
               editionSetId: editionSet.id,
-            })
+            }
+
+            return updateArtworkEditionSetLoader(input)
           })
         )
       }

--- a/src/schema/v2/artwork/updateArtworkMutation.ts
+++ b/src/schema/v2/artwork/updateArtworkMutation.ts
@@ -208,7 +208,7 @@ export const updateArtworkMutation = mutationWithClientMutationId<
     }
 
     try {
-      if (editionSets?.length) {
+      if (editionSets?.length > 0) {
         await Promise.all(
           editionSets.map((editionSet) => {
             const input = getGravityArgs(editionSet)

--- a/src/schema/v2/edition_set.ts
+++ b/src/schema/v2/edition_set.ts
@@ -9,7 +9,7 @@ import {
   GraphQLFieldConfig,
   GraphQLFloat,
 } from "graphql"
-import { Sellable } from "./sellable"
+import { Sellable, sharedSellableFields } from "./sellable"
 import { ResolverContext } from "types/graphql"
 import { listPrice } from "./fields/listPrice"
 import { Money } from "./fields/money"
@@ -29,8 +29,9 @@ export const EditionSetSorts = {
 export const EditionSetType = new GraphQLObjectType<any, ResolverContext>({
   name: "EditionSet",
   interfaces: [Sellable],
-  fields: {
+  fields: () => ({
     ...InternalIDFields,
+    ...sharedSellableFields,
     availability: {
       type: GraphQLString,
     },
@@ -119,7 +120,7 @@ export const EditionSetType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLFloat,
       resolve: ({ height_cm }) => height_cm,
     },
-  },
+  }),
 })
 
 const EditionSet: GraphQLFieldConfig<void, ResolverContext> = {

--- a/src/schema/v2/edition_set.ts
+++ b/src/schema/v2/edition_set.ts
@@ -9,7 +9,7 @@ import {
   GraphQLFieldConfig,
   GraphQLFloat,
 } from "graphql"
-import { Sellable, sharedSellableFields } from "./sellable"
+import { Sellable } from "./sellable"
 import { ResolverContext } from "types/graphql"
 import { listPrice } from "./fields/listPrice"
 import { Money } from "./fields/money"
@@ -31,11 +31,14 @@ export const EditionSetType = new GraphQLObjectType<any, ResolverContext>({
   interfaces: [Sellable],
   fields: () => ({
     ...InternalIDFields,
-    ...sharedSellableFields,
     availability: {
       type: GraphQLString,
     },
     dimensions: Dimensions,
+    displayLabel: {
+      type: GraphQLString,
+      resolve: ({ title }) => title,
+    },
     displayPriceRange: {
       type: GraphQLBoolean,
       resolve: ({ display_price_range }) => display_price_range,
@@ -44,9 +47,30 @@ export const EditionSetType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
       resolve: ({ editions }) => editions,
     },
+    heightCm: {
+      description:
+        "If you need to render artwork dimensions as a string, prefer the `Artwork#dimensions` field",
+      type: GraphQLFloat,
+      resolve: ({ height_cm }) => height_cm,
+    },
+    internalDisplayPrice: {
+      type: GraphQLString,
+      resolve: ({ internal_display_price }) => internal_display_price,
+      description:
+        "Price for internal partner display, requires partner access",
+    },
     isAcquireable: {
       type: GraphQLBoolean,
       resolve: ({ acquireable }) => acquireable,
+    },
+    isForSale: {
+      type: GraphQLBoolean,
+      resolve: ({ forsale }) => forsale,
+    },
+    isInquireable: {
+      type: GraphQLBoolean,
+      description: "Do we want to encourage inquiries on this work?",
+      resolve: ({ inquireable }) => inquireable,
     },
     isOfferable: {
       type: GraphQLBoolean,
@@ -56,21 +80,15 @@ export const EditionSetType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLBoolean,
       resolve: ({ offerable_from_inquiry }) => offerable_from_inquiry,
     },
-    isForSale: {
+    isPriceHidden: {
       type: GraphQLBoolean,
-      resolve: ({ forsale }) => forsale,
+      resolve: ({ price_hidden }) => price_hidden,
     },
     isSold: {
       type: GraphQLBoolean,
       resolve: ({ sold }) => sold,
     },
     listPrice,
-    internalDisplayPrice: {
-      type: GraphQLString,
-      resolve: ({ internal_display_price }) => internal_display_price,
-      description:
-        "Price for internal partner display, requires partner access",
-    },
     price: {
       type: GraphQLString,
     },
@@ -86,6 +104,10 @@ export const EditionSetType = new GraphQLObjectType<any, ResolverContext>({
         const cents = price_listed * factor
         return { cents, currency }
       },
+    },
+    published: {
+      type: GraphQLBoolean,
+      description: "Whether this artwork is published or not",
     },
     sizeScore: {
       description: "score assigned to an artwork based on its dimensions",
@@ -113,12 +135,6 @@ export const EditionSetType = new GraphQLObjectType<any, ResolverContext>({
         "If you need to render artwork dimensions as a string, prefer the `Artwork#dimensions` field",
       type: GraphQLFloat,
       resolve: ({ width_cm }) => width_cm,
-    },
-    heightCm: {
-      description:
-        "If you need to render artwork dimensions as a string, prefer the `Artwork#dimensions` field",
-      type: GraphQLFloat,
-      resolve: ({ height_cm }) => height_cm,
     },
   }),
 })

--- a/src/schema/v2/sellable.ts
+++ b/src/schema/v2/sellable.ts
@@ -1,11 +1,13 @@
 import { GraphQLBoolean, GraphQLInterfaceType, GraphQLString } from "graphql"
 
 import Dimensions from "./dimensions"
+import { InternalIDFields } from "./object_identification"
 
 export const Sellable = new GraphQLInterfaceType({
   name: "Sellable",
   description: "A piece that can be sold",
   fields: () => ({
+    ...sharedSellableFields,
     dimensions: Dimensions,
     editionOf: {
       type: GraphQLString,
@@ -41,3 +43,34 @@ export const Sellable = new GraphQLInterfaceType({
     },
   }),
 })
+
+export const sharedSellableFields = {
+  // Note: while EditionSets require this field to perform mutation updates,
+  // since they're technically embedded documents on the artwork, they're not
+  // queryable in isolation, by ID. They exist only in the context of the artwork.
+  ...InternalIDFields,
+  availability: {
+    type: GraphQLString,
+  },
+  displayLabel: {
+    type: GraphQLString,
+  },
+  displayPriceRange: {
+    type: GraphQLBoolean,
+  },
+  internalDisplayPrice: {
+    type: GraphQLString,
+  },
+  isInAuction: {
+    type: GraphQLBoolean,
+  },
+  isInquireable: {
+    type: GraphQLBoolean,
+  },
+  isPriceHidden: {
+    type: GraphQLBoolean,
+  },
+  published: {
+    type: GraphQLBoolean,
+  },
+}

--- a/src/schema/v2/sellable.ts
+++ b/src/schema/v2/sellable.ts
@@ -1,11 +1,13 @@
 import { GraphQLBoolean, GraphQLInterfaceType, GraphQLString } from "graphql"
 
 import Dimensions from "./dimensions"
+import { InternalIDFields } from "./object_identification"
 
 export const Sellable = new GraphQLInterfaceType({
   name: "Sellable",
   description: "A piece that can be sold",
-  fields: {
+  fields: () => ({
+    ...sharedSellableFields,
     dimensions: Dimensions,
     editionOf: {
       type: GraphQLString,
@@ -39,5 +41,57 @@ export const Sellable = new GraphQLInterfaceType({
       type: GraphQLString,
       resolve: ({ sale_message }) => sale_message,
     },
-  },
+  }),
 })
+
+export const sharedSellableFields = {
+  // Note: while EditionSets require this field to perform mutation updates,
+  // since they're technically embedded documents on the artwork, they're not
+  // queryable in isolation, by ID. They exist only in the context of the artwork.
+  ...InternalIDFields,
+  availability: {
+    type: GraphQLString,
+  },
+  displayLabel: {
+    type: GraphQLString,
+    resolve: ({ title }) => title,
+  },
+  displayPriceRange: {
+    type: GraphQLBoolean,
+    resolve: ({ display_price_range }) => display_price_range,
+  },
+  internalDisplayPrice: {
+    type: GraphQLString,
+    resolve: ({ internal_display_price }) => internal_display_price,
+    description: "Price for internal partner display, requires partner access",
+  },
+  isInAuction: {
+    type: GraphQLBoolean,
+    description: "Is this artwork part of an auction?",
+    resolve: async ({ sale_ids }, _options, { salesLoader }) => {
+      if (sale_ids && sale_ids.length > 0) {
+        const sales = await salesLoader({
+          id: sale_ids,
+          is_auction: true,
+        })
+
+        return sales.length > 0
+      }
+
+      return false
+    },
+  },
+  isInquireable: {
+    type: GraphQLBoolean,
+    description: "Do we want to encourage inquiries on this work?",
+    resolve: ({ inquireable }) => inquireable,
+  },
+  isPriceHidden: {
+    type: GraphQLBoolean,
+    resolve: ({ price_hidden }) => price_hidden,
+  },
+  published: {
+    type: GraphQLBoolean,
+    description: "Whether this artwork is published or not",
+  },
+}

--- a/src/schema/v2/sellable.ts
+++ b/src/schema/v2/sellable.ts
@@ -1,13 +1,11 @@
 import { GraphQLBoolean, GraphQLInterfaceType, GraphQLString } from "graphql"
 
 import Dimensions from "./dimensions"
-import { InternalIDFields } from "./object_identification"
 
 export const Sellable = new GraphQLInterfaceType({
   name: "Sellable",
   description: "A piece that can be sold",
   fields: () => ({
-    ...sharedSellableFields,
     dimensions: Dimensions,
     editionOf: {
       type: GraphQLString,
@@ -43,55 +41,3 @@ export const Sellable = new GraphQLInterfaceType({
     },
   }),
 })
-
-export const sharedSellableFields = {
-  // Note: while EditionSets require this field to perform mutation updates,
-  // since they're technically embedded documents on the artwork, they're not
-  // queryable in isolation, by ID. They exist only in the context of the artwork.
-  ...InternalIDFields,
-  availability: {
-    type: GraphQLString,
-  },
-  displayLabel: {
-    type: GraphQLString,
-    resolve: ({ title }) => title,
-  },
-  displayPriceRange: {
-    type: GraphQLBoolean,
-    resolve: ({ display_price_range }) => display_price_range,
-  },
-  internalDisplayPrice: {
-    type: GraphQLString,
-    resolve: ({ internal_display_price }) => internal_display_price,
-    description: "Price for internal partner display, requires partner access",
-  },
-  isInAuction: {
-    type: GraphQLBoolean,
-    description: "Is this artwork part of an auction?",
-    resolve: async ({ sale_ids }, _options, { salesLoader }) => {
-      if (sale_ids && sale_ids.length > 0) {
-        const sales = await salesLoader({
-          id: sale_ids,
-          is_auction: true,
-        })
-
-        return sales.length > 0
-      }
-
-      return false
-    },
-  },
-  isInquireable: {
-    type: GraphQLBoolean,
-    description: "Do we want to encourage inquiries on this work?",
-    resolve: ({ inquireable }) => inquireable,
-  },
-  isPriceHidden: {
-    type: GraphQLBoolean,
-    resolve: ({ price_hidden }) => price_hidden,
-  },
-  published: {
-    type: GraphQLBoolean,
-    description: "Whether this artwork is published or not",
-  },
-}


### PR DESCRIPTION
Ran into an issue where EditionSets are _not_ Artworks, but `Artwork` implements the `Sellable` interface. So expand the `Sellable` interface with some additional `Artwork` types, and implement them via a shared object in `EditionSets` 😵‍💫 

Something feels sloppy here, and i'm not quite sure about naming, but it does smooth things out nicely on the GraphQL consumer side and makes things feel more "artwork like". 

Thoughts?

cc @artsy/amber-devs 