### PR TITLE
fix(featured fairs): add missing criteria

### DIFF
--- a/src/schema/v2/FeaturedFairs/__tests__/featuredFairs.test.ts
+++ b/src/schema/v2/FeaturedFairs/__tests__/featuredFairs.test.ts
@@ -25,6 +25,16 @@ describe("featuredFairs", () => {
 
       expect(fairsLoader).toHaveBeenCalledTimes(1)
 
+      expect(fairsLoader).toHaveBeenCalledWith(
+        expect.objectContaining({
+          size: requestedSize,
+          sort: "-start_at",
+          status: "running",
+          has_full_feature: true,
+          has_listing: true,
+        })
+      )
+
       expect(featuredFairs).toMatchInlineSnapshot(`
         [
           {

--- a/src/schema/v2/FeaturedFairs/featuredFairs.ts
+++ b/src/schema/v2/FeaturedFairs/featuredFairs.ts
@@ -18,6 +18,7 @@ export const FeaturedFairs: GraphQLFieldConfig<void, ResolverContext> = {
   resolve: async (_root, args, { fairsLoader }) => {
     const sharedOptions = {
       has_full_feature: true,
+      has_listing: true,
       sort: "-start_at",
     }
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-1658

A colleague [reported](https://artsy.slack.com/archives/C03N12SR0RK/p1743691566357749) that the app was displaying **Featured Fairs** that were not visible on web.

This brings the `featuredFairs` field's filtering criteria closer inline with the [existing query](https://github.com/artsy/force/blob/f651e59f4c09ca1e5909802dd745d4a2b93fe168/src/Apps/Fairs/Routes/FairsIndex.tsx#L335) that Force uses to generate the fairs listing on the /fairs landing page.