### PR TITLE
chore: tweak timezone handling for mutation input

### DIFF
--- a/src/schema/v2/Show/__tests__/createPartnerShowEventMutation.test.ts
+++ b/src/schema/v2/Show/__tests__/createPartnerShowEventMutation.test.ts
@@ -12,7 +12,7 @@ describe("CreatePartnerShowEventMutation", () => {
           endAt: "2025-01-01T18:00:00+00:00"
           eventType: "Opening Reception"
           description: "Join us for the opening reception"
-          timeZone: "(GMT-04:00) New York"
+          timeZone: "America/New_York"
         }
       ) {
         showEventOrError {

--- a/src/schema/v2/Show/__tests__/updatePartnerShowEventMutation.test.ts
+++ b/src/schema/v2/Show/__tests__/updatePartnerShowEventMutation.test.ts
@@ -11,7 +11,7 @@ describe("UpdatePartnerShowEventMutation", () => {
           eventId: "event123"
           eventType: "Closing Reception"
           description: "Join us for the closing reception"
-          timeZone: "(GMT-04:00) New York"
+          timeZone: "America/New_York"
         }
       ) {
         showEventOrError {

--- a/src/schema/v2/Show/createPartnerShowEventMutation.ts
+++ b/src/schema/v2/Show/createPartnerShowEventMutation.ts
@@ -10,9 +10,8 @@ import {
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
-import ShowEventType, { formatTimeZone } from "../show_event"
+import ShowEventType from "../show_event"
 import moment from "moment"
-import momentTz from "moment-timezone"
 import { ShowType } from "../show"
 
 interface CreatePartnerShowEventMutationInputProps {
@@ -120,16 +119,11 @@ export const createPartnerShowEventMutation = mutationWithClientMutationId<
       start_at: moment(args.startAt).unix(),
       end_at: moment(args.endAt).unix(),
       event_type: args.eventType,
+      time_zone: args.timeZone,
     }
 
     if (args.description) {
       gravityArgs.description = args.description
-    }
-
-    if (args.timeZone) {
-      gravityArgs.time_zone = momentTz.tz
-        .names()
-        .find((timeZone) => formatTimeZone(timeZone) === args.timeZone)
     }
 
     try {

--- a/src/schema/v2/Show/updatePartnerShowEventMutation.ts
+++ b/src/schema/v2/Show/updatePartnerShowEventMutation.ts
@@ -12,8 +12,6 @@ import {
 import { ResolverContext } from "types/graphql"
 import ShowEventType from "../show_event"
 import moment from "moment"
-import momentTz from "moment-timezone"
-import { formatTimeZone } from "../show_event"
 import { ShowType } from "../show"
 
 interface UpdatePartnerShowEventMutationInputProps {
@@ -141,9 +139,7 @@ export const updatePartnerShowEventMutation = mutationWithClientMutationId<
     }
 
     if (args.timeZone) {
-      gravityArgs.time_zone = momentTz.tz
-        .names()
-        .find((timeZone) => formatTimeZone(timeZone) === args.timeZone)
+      gravityArgs.time_zone = args.timeZone
     }
 
     try {


### PR DESCRIPTION
Ok, this feels much more correct! Take in the properly formatted timezone as mutation inputs that Gravity will understand. I have a corresponding Volt PR coming that makes use of this field and makes it clear.