### PR TITLE
chore: send right unix timestamp back with consideration of timezone

### DIFF
--- a/src/schema/v2/Show/createPartnerShowEventMutation.ts
+++ b/src/schema/v2/Show/createPartnerShowEventMutation.ts
@@ -11,7 +11,7 @@ import {
 } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
 import ShowEventType from "../show_event"
-import moment from "moment"
+import momentTimezone from "moment-timezone"
 import { ShowType } from "../show"
 
 interface CreatePartnerShowEventMutationInputProps {
@@ -116,8 +116,8 @@ export const createPartnerShowEventMutation = mutationWithClientMutationId<
       description?: string
       time_zone?: string
     } = {
-      start_at: moment(args.startAt).unix(),
-      end_at: moment(args.endAt).unix(),
+      start_at: momentTimezone.tz(args.startAt, args.timeZone).unix(),
+      end_at: momentTimezone.tz(args.endAt, args.timeZone).unix(),
       event_type: args.eventType,
       time_zone: args.timeZone,
     }

--- a/src/schema/v2/Show/updatePartnerShowEventMutation.ts
+++ b/src/schema/v2/Show/updatePartnerShowEventMutation.ts
@@ -11,7 +11,7 @@ import {
 } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
 import ShowEventType from "../show_event"
-import moment from "moment"
+import momentTimezone from "moment-timezone"
 import { ShowType } from "../show"
 
 interface UpdatePartnerShowEventMutationInputProps {
@@ -123,11 +123,13 @@ export const updatePartnerShowEventMutation = mutationWithClientMutationId<
     } = {}
 
     if (args.startAt) {
-      gravityArgs.start_at = moment(args.startAt).unix()
+      gravityArgs.start_at = momentTimezone
+        .tz(args.startAt, args.timeZone)
+        .unix()
     }
 
     if (args.endAt) {
-      gravityArgs.end_at = moment(args.endAt).unix()
+      gravityArgs.end_at = momentTimezone.tz(args.endAt, args.timeZone).unix()
     }
 
     if (args.eventType) {


### PR DESCRIPTION
Noticing that an input like 5:00 and America/New_York was being returned back from Gravity as "1:00pm EDT" -> realized we need to convert that initial timestamp to Unix-style _in the provided timezone_.