### PR TITLE
feat(EMI-2374): create unsetOrderFulfillmentOption mutation + tests

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15302,7 +15302,7 @@ type Mutation {
     input: SendIdentityVerificationEmailMutationInput!
   ): SendIdentityVerificationEmailMutationPayload
 
-  # Update an order
+  # Set fulfillment option on an order
   setOrderFulfillmentOption(
     input: setOrderFulfillmentOptionInput!
   ): setOrderFulfillmentOptionPayload
@@ -15339,6 +15339,11 @@ type Mutation {
   unpublishViewingRoom(
     input: UnpublishViewingRoomInput!
   ): UnpublishViewingRoomPayload
+
+  # Unset fulfillment option on an order
+  unsetOrderFulfillmentOption(
+    input: unsetOrderFulfillmentOptionInput!
+  ): unsetOrderFulfillmentOptionPayload
 
   # Create an alert
   updateAlert(input: updateAlertInput!): updateAlertPayload
@@ -24733,6 +24738,18 @@ input submitOrderInput {
 }
 
 type submitOrderPayload {
+  clientMutationId: String
+  orderOrError: SetOrderFulfillmentOptionResponse
+}
+
+input unsetOrderFulfillmentOptionInput {
+  clientMutationId: String
+
+  # Order id.
+  id: ID!
+}
+
+type unsetOrderFulfillmentOptionPayload {
   clientMutationId: String
   orderOrError: SetOrderFulfillmentOptionResponse
 }

--- a/src/lib/loaders/loaders_with_authentication/exchange.ts
+++ b/src/lib/loaders/loaders_with_authentication/exchange.ts
@@ -55,6 +55,14 @@ export const exchangeLoaders = (accessToken, opts) => {
     }
   )
 
+  const meOrderUnsetFulfillmentOptionLoader = exchangeLoader(
+    (id) => `me/orders/${id}/unset_fulfillment_option`,
+    {},
+    {
+      method: "PUT",
+    }
+  )
+
   const meOrderSubmitLoader = exchangeLoader(
     (id) => `me/orders/${id}/submit`,
     {},
@@ -104,5 +112,6 @@ export const exchangeLoaders = (accessToken, opts) => {
     meOrderUpdateLoader,
     meOrderSetFulfillmentOptionLoader,
     meOrderSubmitLoader,
+    meOrderUnsetFulfillmentOptionLoader,
   }
 }

--- a/src/schema/v2/order/__tests__/unsetOrderFulfillmentOptionMutation.test.ts
+++ b/src/schema/v2/order/__tests__/unsetOrderFulfillmentOptionMutation.test.ts
@@ -1,0 +1,139 @@
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import { baseArtwork, baseOrderJson } from "./support"
+
+const mockMutation = `
+  mutation {
+    unsetOrderFulfillmentOption(input: {
+      id: "order-id",
+    }) {
+      orderOrError {
+        ... on OrderMutationSuccess {
+          order {
+            internalID
+            fulfillmentOptions {
+              type
+              amount {
+                minor
+                currencyCode
+              }
+              selected
+            }
+          }
+        }
+        ... on OrderMutationError {
+          mutationError {
+            message
+            code
+          }
+        }
+      }
+    }
+  }
+`
+
+let context
+describe("unsetOrderFulfillmentOption", () => {
+  beforeEach(() => {
+    context = {
+      meOrderUnsetFulfillmentOptionLoader: jest.fn().mockResolvedValue({
+        ...baseOrderJson,
+        id: "order-id", // Ensure the id field is present
+        fulfillment_options: [
+          {
+            type: "domestic_flat",
+            amount_minor: 2000,
+            currency_code: "USD",
+          },
+          {
+            type: "pickup",
+            amount_minor: null,
+            currency_code: "USD",
+          },
+        ],
+      }),
+      artworkLoader: jest
+        .fn()
+        .mockResolvedValue({ ...baseArtwork, id: "artwork-id" }),
+      artworkVersionLoader: jest
+        .fn()
+        .mockResolvedValue({ ...baseArtwork, id: "artwork-version-id" }),
+    }
+  })
+
+  it("should update fulfillment option", async () => {
+    const result = await runAuthenticatedQuery(mockMutation, context)
+
+    expect(result.errors).toBeUndefined()
+    expect(result).toEqual({
+      unsetOrderFulfillmentOption: {
+        orderOrError: {
+          order: {
+            internalID: "order-id",
+            fulfillmentOptions: [
+              {
+                type: "DOMESTIC_FLAT",
+                selected: null,
+                amount: {
+                  minor: 2000,
+                  currencyCode: "USD",
+                },
+              },
+              {
+                type: "PICKUP",
+                amount: null,
+                selected: null,
+              },
+            ],
+          },
+        },
+      },
+    })
+
+    expect(context.meOrderUnsetFulfillmentOptionLoader).toHaveBeenCalledWith(
+      "order-id"
+    )
+  })
+
+  it("propagates an unknown error", async () => {
+    context.meOrderUnsetFulfillmentOptionLoader = jest.fn().mockRejectedValue({
+      message: "An error occurred",
+      statusCode: 500,
+    })
+    const result = await runAuthenticatedQuery(mockMutation, context)
+
+    expect(result.errors).toBeUndefined()
+    expect(result).toEqual({
+      unsetOrderFulfillmentOption: {
+        orderOrError: {
+          mutationError: {
+            message: "An error occurred",
+            code: "internal_error",
+          },
+        },
+      },
+    })
+  })
+
+  it("propagates a 422 error from exchange", async () => {
+    context.meOrderUnsetFulfillmentOptionLoader = jest.fn().mockRejectedValue({
+      statusCode: 422,
+      body: {
+        message: "order_not_pending - submitted",
+        code: "order_not_pending",
+      },
+    })
+    const result = await runAuthenticatedQuery(mockMutation, context)
+
+    expect(result.errors).toBeUndefined()
+    expect(result).toEqual({
+      unsetOrderFulfillmentOption: {
+        orderOrError: {
+          mutationError: {
+            message: "order_not_pending - submitted",
+            code: "order_not_pending",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/order/setOrderFulfillmentOptionMutation.ts
+++ b/src/schema/v2/order/setOrderFulfillmentOptionMutation.ts
@@ -43,7 +43,7 @@ export const setOrderFulfillmentOptionMutation = mutationWithClientMutationId<
   ResolverContext
 >({
   name: "setOrderFulfillmentOption",
-  description: "Update an order",
+  description: "Set fulfillment option on an order",
   inputFields: {
     id: { type: new GraphQLNonNull(GraphQLID), description: "Order id." },
     fulfillmentOption: {

--- a/src/schema/v2/order/unsetOrderFulfillmentOptionMutation.ts
+++ b/src/schema/v2/order/unsetOrderFulfillmentOptionMutation.ts
@@ -1,0 +1,46 @@
+import { GraphQLNonNull, GraphQLID } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import {
+  OrderMutationResponseType,
+  ORDER_MUTATION_FLAGS,
+} from "./sharedOrderTypes"
+import { handleExchangeError } from "./exchangeErrorHandling"
+
+interface Input {
+  id: string
+}
+
+export const unsetOrderFulfillmentOptionMutation = mutationWithClientMutationId<
+  Input,
+  any,
+  ResolverContext
+>({
+  name: "unsetOrderFulfillmentOption",
+  description: "Unset fulfillment option on an order",
+  inputFields: {
+    id: { type: new GraphQLNonNull(GraphQLID), description: "Order id." },
+  },
+  outputFields: {
+    orderOrError: {
+      type: OrderMutationResponseType,
+      resolve: (response) => response,
+    },
+  },
+
+  mutateAndGetPayload: async (input, context) => {
+    const { meOrderUnsetFulfillmentOptionLoader } = context
+    if (!meOrderUnsetFulfillmentOptionLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+    try {
+      const updatedOrder = await meOrderUnsetFulfillmentOptionLoader(input.id)
+
+      updatedOrder._type = ORDER_MUTATION_FLAGS.SUCCESS
+
+      return updatedOrder
+    } catch (error) {
+      return handleExchangeError(error)
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -302,6 +302,7 @@ import { CreatePartnerContactMutation } from "./partner/Settings/createPartnerCo
 import { CreatePartnerLocationMutation } from "./partner/Settings/createPartnerLocationMutation"
 import { UpdatePartnerContactMutation } from "./partner/Settings/updatePartnerContactMutation"
 import { DeletePartnerContactMutation } from "./partner/Settings/deletePartnerContactMutation"
+import { unsetOrderFulfillmentOptionMutation } from "./order/unsetOrderFulfillmentOptionMutation"
 
 const rootFields = {
   // artworkVersion: ArtworkVersionResolver,
@@ -570,6 +571,7 @@ export default new GraphQLSchema({
       triggerCampaign: triggerCampaignMutation,
       unlinkAuthentication: unlinkAuthenticationMutation,
       unpublishViewingRoom: unpublishViewingRoomMutation,
+      unsetOrderFulfillmentOption: unsetOrderFulfillmentOptionMutation,
       updateAlert: updateAlertMutation,
       updateAppSecondFactor: updateAppSecondFactorMutation,
       updateArtist: updateArtistMutation,


### PR DESCRIPTION
type: **feat**

Related to [EMI-2374]
depends on artsy/exchange#2477

This PR creates a new mutation to unset the fulfillment option on an order. It is mostly a copy-paste of the setFulfillmentOption mutation.



[EMI-2374]: https://artsyproduct.atlassian.net/browse/EMI-2374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ