### PR TITLE
feat: add biennials and review sources to artist type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1670,6 +1670,9 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
 
   # In applicable contexts, this is what the artist (as a suggestion) is based on.
   basedOn: Artist
+
+  # The biennials the artist has participated in
+  biennials: String
   bio: String
 
   # The Artist biography article written by Artsy
@@ -1898,6 +1901,9 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   # The most recent show for an artist
   recentShow: String
   related: ArtistRelatedData
+
+  # publications that have reviewed the artist
+  reviewSources: String
   sales(
     isAuction: Boolean
     live: Boolean
@@ -21258,6 +21264,7 @@ type UpdateArtistFailure {
 input UpdateArtistMutationInput {
   alternateNames: [String!]
   awards: String
+  biennials: String
   birthday: String
   blurb: String
   clientMutationId: String
@@ -21276,6 +21283,7 @@ input UpdateArtistMutationInput {
   nationality: String
   public: Boolean
   recentShow: String
+  reviewSources: String
   targetSupplyPriority: ArtistTargetSupplyPriority
   targetSupplyType: ArtistTargetSupplyType
   vanguardYear: String

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -508,6 +508,11 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       birthday: { type: GraphQLString },
+      biennials: {
+        type: GraphQLString,
+        description: "The biennials the artist has participated in",
+        resolve: ({ biennials }) => biennials,
+      },
       blurb: {
         args: markdown().args,
         type: GraphQLString,
@@ -956,6 +961,11 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLString,
         description: "The most recent show for an artist",
         resolve: ({ recent_show }) => recent_show,
+      },
+      reviewSources: {
+        type: GraphQLString,
+        description: "publications that have reviewed the artist",
+        resolve: ({ review_sources }) => review_sources,
       },
       sales: {
         type: new GraphQLList(Sale.type),

--- a/src/schema/v2/artist/updateArtistMutation.ts
+++ b/src/schema/v2/artist/updateArtistMutation.ts
@@ -28,6 +28,7 @@ import {
 interface Input {
   alternateNames: string[]
   awards?: string
+  biennials?: string
   birthday?: string
   blurb?: string
   criticallyAcclaimed?: boolean
@@ -45,6 +46,7 @@ interface Input {
   nationality?: string
   public?: boolean
   recentShow?: string
+  reviewSources?: string
   targetSupplyPriority?: ArtistTargetSupplyPriority
   targetSupplyType?: ArtistTargetSupplyType
   vanguardYear?: string
@@ -54,6 +56,7 @@ const inputFields = {
   alternateNames: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) },
   awards: { type: GraphQLString },
   birthday: { type: GraphQLString },
+  biennials: { type: GraphQLString },
   blurb: { type: GraphQLString },
   criticallyAcclaimed: { type: GraphQLBoolean },
   coverArtworkId: { type: GraphQLString },
@@ -70,6 +73,7 @@ const inputFields = {
   nationality: { type: GraphQLString },
   public: { type: GraphQLBoolean },
   recentShow: { type: GraphQLString },
+  reviewSources: { type: GraphQLString },
   targetSupplyPriority: { type: ArtistTargetSupplyPriorityEnum },
   targetSupplyType: { type: ArtistTargetSupplyTypeEnum },
   vanguardYear: { type: GraphQLString },
@@ -79,6 +83,7 @@ interface GravityInput {
   alternate_names: string[]
   awards?: string
   birthday?: string
+  biennials?: string
   blurb?: string
   cover_artwork_id?: string
   critically_acclaimed?: boolean
@@ -95,6 +100,7 @@ interface GravityInput {
   nationality?: string
   public?: boolean
   recent_show?: string
+  review_sources?: string
   target_supply_priority?: string
   target_supply_type?: string
   vanguard_year?: string


### PR DESCRIPTION
This PR adds two new data points to Artist type used for publications and biennials.

[Gravity PR](https://github.com/artsy/gravity/pull/18809)
[Forque PR](https://github.com/artsy/forque/pull/1411)