### PR TITLE
chore(dia-1224): removes blurhash feature flag and related field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12785,7 +12785,6 @@ type Image {
 
   # Blurhash code for the image
   blurhash: String
-  blurhashDataURL(width: Int = 64): String
   caption: String
   cropped(
     height: Int!

--- a/package.json
+++ b/package.json
@@ -53,9 +53,7 @@
     "apollo-link": "1.2.14",
     "apollo-link-context": "^1.0.20",
     "apollo-link-http": "^1.5.17",
-    "base64-arraybuffer": "^1.0.2",
     "basic-auth": "1.1.0",
-    "blurhash": "^2.0.5",
     "body-parser": "1.20.3",
     "chalk": "^4.1.2",
     "compression": "1.7.2",
@@ -103,7 +101,6 @@
     "request": "2.88.2",
     "runtypes": "4.2.0",
     "unleash-client": "^5.5.2",
-    "upng-js": "^2.1.0",
     "url-join": "4.0.0",
     "uuid": "3.1.0"
   },

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -9,7 +9,6 @@ const { UNLEASH_API, UNLEASH_APP_NAME, UNLEASH_SERVER_KEY } = config
  * @see https://tools.artsy.net/feature-flags
  */
 const FEATURE_FLAGS_LIST = [
-  "diamond_blurhash-enabled-globally",
   "onyx_enable-home-view-section-featured-fairs",
   "diamond_home-view-infinite-discovery",
   "onyx_experiment_home_view_test",

--- a/src/schema/v2/image/__tests__/index.test.js
+++ b/src/schema/v2/image/__tests__/index.test.js
@@ -1,5 +1,4 @@
 /* eslint-disable promise/always-return */
-import { isFeatureFlagEnabled } from "lib/featureFlags"
 import { assign } from "lodash"
 import { getDefault } from "schema/v2/image"
 
@@ -63,102 +62,6 @@ describe("Image type", () => {
         .withArgs(artwork.id)
         .returns(Promise.resolve(artwork)),
     }
-  })
-
-  describe("blurhashDataURL", () => {
-    describe("when the feature flag is enabled", () => {
-      const mockIsFeatureFlagEnabled = isFeatureFlagEnabled
-
-      it("returns a data URL when client is not Eigen", () => {
-        mockIsFeatureFlagEnabled.mockReturnValue(true)
-
-        const query = `{
-          artwork(id: "richard-prince-untitled-portrait") {
-            image {
-              blurhashDataURL
-            }
-          }
-        }`
-        assign(image, { blurhash: "LGHLe$4oIU-;_3%MbHRj~pIo%MM{" })
-        return runQuery(query, context).then((data) => {
-          expect(data.artwork.image.blurhashDataURL).toStartWith(
-            "data:image/png;base64,"
-          )
-        })
-      })
-
-      it("returns a data URL when client is Eigen", () => {
-        mockIsFeatureFlagEnabled.mockReturnValue(true)
-
-        const query = `{
-          artwork(id: "richard-prince-untitled-portrait") {
-            image {
-              blurhashDataURL
-            }
-          }
-        }`
-        assign(image, { blurhash: "LGHLe$4oIU-;_3%MbHRj~pIo%MM{" })
-
-        const context = {
-          artworkLoader: sinon
-            .stub()
-            .withArgs(artwork.id)
-            .returns(Promise.resolve(artwork)),
-          userAgent: "Artsy-Mobile/version-Eigen/build-number/app-version",
-        }
-        return runQuery(query, context).then((data) => {
-          expect(data.artwork.image.blurhashDataURL).toStartWith(
-            "data:image/png;base64,"
-          )
-        })
-      })
-    })
-
-    describe("when the feature flag is disabled", () => {
-      const mockIsFeatureFlagEnabled = isFeatureFlagEnabled
-
-      it("returns data URL as null when client is not Eigen", () => {
-        mockIsFeatureFlagEnabled.mockReturnValue(false)
-
-        const query = `{
-          artwork(id: "richard-prince-untitled-portrait") {
-            image {
-              blurhashDataURL
-            }
-          }
-        }`
-        assign(image, { blurhash: "LGHLe$4oIU-;_3%MbHRj~pIo%MM{" })
-        return runQuery(query, context).then((data) => {
-          expect(data.artwork.image.blurhashDataURL).toBeNull()
-        })
-      })
-
-      it("returns a data URL when client is Eigen", () => {
-        mockIsFeatureFlagEnabled.mockReturnValue(false)
-
-        const query = `{
-          artwork(id: "richard-prince-untitled-portrait") {
-            image {
-              blurhashDataURL
-            }
-          }
-        }`
-        assign(image, { blurhash: "LGHLe$4oIU-;_3%MbHRj~pIo%MM{" })
-
-        const context = {
-          artworkLoader: sinon
-            .stub()
-            .withArgs(artwork.id)
-            .returns(Promise.resolve(artwork)),
-          userAgent: "Artsy-Mobile/version-Eigen/build-number/app-version",
-        }
-        return runQuery(query, context).then((data) => {
-          expect(data.artwork.image.blurhashDataURL).toStartWith(
-            "data:image/png;base64,"
-          )
-        })
-      })
-    })
   })
 
   describe("#aspect_ratio", () => {

--- a/src/schema/v2/image/index.ts
+++ b/src/schema/v2/image/index.ts
@@ -16,9 +16,6 @@ import DeepZoom, { isZoomable } from "./deep_zoom"
 import { ImageData, normalize } from "./normalize"
 import ResizedUrl from "./resized"
 import VersionedUrl from "./versioned"
-import { decode as decodeBlurHash } from "blurhash"
-import UPNG from "upng-js"
-import { encode } from "base64-arraybuffer"
 import { connectionWithCursorInfo } from "../fields/pagination"
 
 export type OriginalImage = {
@@ -61,30 +58,6 @@ export const ImageType = new GraphQLObjectType<any, ResolverContext>({
     blurhash: {
       type: GraphQLString,
       description: "Blurhash code for the image",
-    },
-    blurhashDataURL: {
-      type: GraphQLString,
-      args: {
-        width: {
-          type: GraphQLInt,
-          defaultValue: 64,
-        },
-      },
-      resolve: ({ blurhash, aspect_ratio }, { width }) => {
-        if (!blurhash) return null
-
-        try {
-          const aspectRatio = aspect_ratio || 1
-          const height = Math.round(width / aspectRatio)
-          const pixels = decodeBlurHash(blurhash, width, height)
-          const png = UPNG.encode([pixels], width, height, 256)
-
-          return `data:image/png;base64,${encode(png)}`
-        } catch (error) {
-          console.error("[schema/v2/image/blurhashDataURI] Error:", error)
-          return null
-        }
-      },
     },
     caption: {
       type: GraphQLString,

--- a/src/schema/v2/image/index.ts
+++ b/src/schema/v2/image/index.ts
@@ -19,7 +19,6 @@ import VersionedUrl from "./versioned"
 import { decode as decodeBlurHash } from "blurhash"
 import UPNG from "upng-js"
 import { encode } from "base64-arraybuffer"
-import { isFeatureFlagEnabled } from "lib/featureFlags"
 import { connectionWithCursorInfo } from "../fields/pagination"
 
 export type OriginalImage = {
@@ -71,13 +70,7 @@ export const ImageType = new GraphQLObjectType<any, ResolverContext>({
           defaultValue: 64,
         },
       },
-      resolve: ({ blurhash, aspect_ratio }, { width }, { userAgent }) => {
-        const isEigen = userAgent?.match("Artsy-Mobile") != null
-
-        const isBlurhashEnabled =
-          isEigen || isFeatureFlagEnabled("diamond_blurhash-enabled-globally")
-
-        if (!isBlurhashEnabled) return null
+      resolve: ({ blurhash, aspect_ratio }, { width }) => {
         if (!blurhash) return null
 
         try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3025,11 +3025,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-arraybuffer@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#1c37589a7c4b0746e34bd1feb951da2df01c1bdc"
-  integrity sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==
-
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -3076,11 +3071,6 @@ blake3-wasm@^2.1.5:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/blake3-wasm/-/blake3-wasm-2.1.5.tgz#b22dbb84bc9419ed0159caa76af4b1b132e6ba52"
   integrity sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==
-
-blurhash@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/blurhash/-/blurhash-2.0.5.tgz#efde729fc14a2f03571a6aa91b49cba80d1abe4b"
-  integrity sha512-cRygWd7kGBQO3VEhPiTgq4Wc43ctsM+o46urrmPOiuAe+07fzlSB9OJVdpgDL0jPqXUVQ9ht7aq7kxOeJHRK+w==
 
 body-parser@1.20.3:
   version "1.20.3"
@@ -7915,11 +7905,6 @@ package-json-from-dist@^1.0.0:
   resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
   integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
 
-pako@^1.0.5:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
-  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
-
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -9313,16 +9298,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@4.2.3, string-width@^1.0.1, string-width@^2.1.1, string-width@^3.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@4.2.3, string-width@^1.0.1, string-width@^2.1.1, string-width@^3.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9375,7 +9351,7 @@ stringify-object@^3.2.2:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9402,13 +9378,6 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -9935,13 +9904,6 @@ update-browserslist-db@^1.1.1:
     escalade "^3.2.0"
     picocolors "^1.1.0"
 
-upng-js@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/upng-js/-/upng-js-2.1.0.tgz#7176e73973db361ca95d0fa14f958385db6b9dd2"
-  integrity sha512-d3xzZzpMP64YkjP5pr8gNyvBt7dLk/uGI67EctzDuVp4lCZyVMo0aJO6l/VDlgbInJYDY6cnClLoBp29eKWI6g==
-  dependencies:
-    pako "^1.0.5"
-
 uri-js@^4.2.2:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
@@ -10159,7 +10121,7 @@ wrangler@^3.78.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -10175,15 +10137,6 @@ wrap-ansi@^3.0.1:
   dependencies:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
 
 wrap-ansi@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
In the effort to reduce the number of future flags that 💎  has.

This field is being removed entirely as it's not used by either Eigen or Force and because it appears to be at an attack vector. Usage of it in Force with larger arguments appears to have caused [inc-219](https://artsy.app.opsgenie.com/reports/post-mortem/154274cc-497e-4b30-92a6-6dcc85f45bf1/detail)