### PR TITLE
fix(artwork): Make signatureMeta subfields non-null

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3341,22 +3341,22 @@ type ArtworkSavedSearch {
 
 type ArtworkSignatureMeta {
   # Whether the artwork has a signature
-  hasSignature: Boolean
+  hasSignature: Boolean!
 
   # Whether the artwork has a sticker label
-  hasStickerLabel: Boolean
+  hasStickerLabel: Boolean!
 
   # Whether the artwork is signed by the artist
-  isSignedByArtist: Boolean
+  isSignedByArtist: Boolean!
 
   # Whether the artwork is signed in plate
-  isSignedInPlate: Boolean
+  isSignedInPlate: Boolean!
 
   # Whether the artwork is signed by someone else
-  isSignedOther: Boolean
+  isSignedOther: Boolean!
 
   # Whether the artwork is stamped by the artist's estate
-  isStampedByArtistEstate: Boolean
+  isStampedByArtistEstate: Boolean!
 }
 
 enum ArtworkSignatureTypeEnum {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1767,7 +1767,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           name: "ArtworkSignatureMeta",
           fields: {
             hasSignature: {
-              type: GraphQLBoolean,
+              type: new GraphQLNonNull(GraphQLBoolean),
               description: "Whether the artwork has a signature",
               resolve: (artwork) => {
                 return !!(
@@ -1780,29 +1780,29 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
               },
             },
             hasStickerLabel: {
-              type: GraphQLBoolean,
+              type: new GraphQLNonNull(GraphQLBoolean),
               description: "Whether the artwork has a sticker label",
               resolve: ({ sticker_label }) => !!sticker_label,
             },
             isSignedByArtist: {
-              type: GraphQLBoolean,
+              type: new GraphQLNonNull(GraphQLBoolean),
               description: "Whether the artwork is signed by the artist",
               resolve: ({ signed_by_artist }) => !!signed_by_artist,
             },
             isSignedOther: {
-              type: GraphQLBoolean,
+              type: new GraphQLNonNull(GraphQLBoolean),
               description: "Whether the artwork is signed by someone else",
               resolve: ({ signed_other }) => !!signed_other,
             },
             isStampedByArtistEstate: {
-              type: GraphQLBoolean,
+              type: new GraphQLNonNull(GraphQLBoolean),
               description:
                 "Whether the artwork is stamped by the artist's estate",
               resolve: ({ stamped_by_artist_estate }) =>
                 !!stamped_by_artist_estate,
             },
             isSignedInPlate: {
-              type: GraphQLBoolean,
+              type: new GraphQLNonNull(GraphQLBoolean),
               description: "Whether the artwork is signed in plate",
               resolve: ({ signed_in_plate }) => !!signed_in_plate,
             },


### PR DESCRIPTION
Follow up to https://github.com/artsy/metaphysics/pull/6605#discussion_r2032126895

Makes some new field sub-selections non-nullable. 

cc @artsy/amber-devs 