### PR TITLE
feat(settingsV2): Fetch single, update, and delete support for partner locations

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9026,7 +9026,7 @@ input CreatePartnerLocationInput {
   email: String
 
   # ID of the partner
-  partnerID: String!
+  partnerId: String!
 
   # Primary phone of given location
   phone: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13383,6 +13383,7 @@ type Location {
   daySchedules: [DaySchedule]
   display: String
   displayCountry: String
+  email: String
   euShippingLocation: Boolean
 
   # A globally unique ID.
@@ -16577,6 +16578,12 @@ type Partner implements Node {
 
   # Indicates the partner is a trusted seller on Artsy
   isVerifiedSeller: Boolean
+
+  # A Singular Location belonging to the Partner
+  location(
+    # The slug or ID of the Contact
+    locationId: String!
+  ): Location
 
   # This field is deprecated and is being used in Eigen release predating the 6.0 release
   locations(size: Int = 25): [Location]

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15513,6 +15513,11 @@ type Mutation {
     input: UpdatePartnerContactInput!
   ): UpdatePartnerContactPayload
 
+  # Updates a new location for a partner
+  updatePartnerLocation(
+    input: UpdatePartnerLocationInput!
+  ): UpdatePartnerLocationPayload
+
   # Updates a partner show.
   updatePartnerShow(
     input: UpdatePartnerShowMutationInput!
@@ -22061,6 +22066,49 @@ type UpdatePartnerContactSuccess {
   partnerContact: Contact
 }
 
+type UpdatePartnerLocationFailure {
+  mutationError: GravityMutationError
+}
+
+input UpdatePartnerLocationInput {
+  address: String
+  address2: String
+  addressType: partnerLocationType
+  city: String
+  clientMutationId: String
+  country: String
+
+  # Primary email of given location
+  email: String
+
+  # ID of the location to update
+  locationId: String!
+
+  # ID of the partner
+  partnerId: String!
+
+  # Primary phone of given location
+  phone: String
+  postalCode: String
+
+  # Boolean flag that denotes whether a location is publicly viewable on Partner's Artsy Profile
+  publiclyViewable: Boolean
+  state: String
+}
+
+union UpdatePartnerLocationOrError =
+    UpdatePartnerLocationFailure
+  | UpdatePartnerLocationSuccess
+
+type UpdatePartnerLocationPayload {
+  clientMutationId: String
+  partnerLocationOrError: UpdatePartnerLocationOrError
+}
+
+type UpdatePartnerLocationSuccess {
+  location: Location
+}
+
 type UpdatePartnerShowDocumentFailure {
   mutationError: GravityMutationError
 }
@@ -24751,6 +24799,12 @@ enum locationType {
 
 type partnerBiographyBlurb {
   text: String
+}
+
+enum partnerLocationType {
+  BUSINESS
+  OTHER
+  TEMPORARY
 }
 
 type purchases {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9859,6 +9859,33 @@ type DeletePartnerContactSuccess {
   partnerContact: Contact
 }
 
+type DeletePartnerLocationFailure {
+  mutationError: GravityMutationError
+}
+
+input DeletePartnerLocationMutationInput {
+  clientMutationId: String
+
+  # ID of the Location to delete
+  locationId: String!
+
+  # ID of the partner
+  partnerId: String!
+}
+
+type DeletePartnerLocationMutationPayload {
+  clientMutationId: String
+  partnerLocationOrError: DeletePartnerLocationOrError
+}
+
+union DeletePartnerLocationOrError =
+    DeletePartnerLocationFailure
+  | DeletePartnerLocationSuccess
+
+type DeletePartnerLocationSuccess {
+  location: Location
+}
+
 type DeletePartnerShowDocumentFailure {
   mutationError: GravityMutationError
 }
@@ -15168,6 +15195,11 @@ type Mutation {
   deletePartnerContact(
     input: DeletePartnerContactMutationInput!
   ): DeletePartnerContactMutationPayload
+
+  # Deletes a location for a partner
+  deletePartnerLocation(
+    input: DeletePartnerLocationMutationInput!
+  ): DeletePartnerLocationMutationPayload
 
   # Deletes a partner show.
   deletePartnerShow(

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -927,6 +927,13 @@ export default (accessToken, userID, opts) => {
       ({ partnerId, inquiryId }) =>
         `partner/${partnerId}/inquiry_request/${inquiryId}`
     ),
+    partnerLocationLoader: gravityLoader<
+      any,
+      { partnerId: string; locationId: string }
+    >(
+      ({ partnerId, locationId }) =>
+        `partner/${partnerId}/locationId/${locationId}`
+    ),
     partnerLocationsConnectionLoader: gravityLoader(
       (id) => `partner/${id}/locations`,
       {},

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -403,6 +403,15 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "DELETE" }
     ),
+    deletePartnerLocationLoader: gravityLoader<
+      any,
+      { partnerId: string; locationId: string }
+    >(
+      ({ partnerId, locationId }) =>
+        `partner/${partnerId}/location/${locationId}`,
+      {},
+      { method: "DELETE" }
+    ),
     deletePartnerShowLoader: gravityLoader<
       any,
       { partnerID: string; showID: string }

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1166,6 +1166,15 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" }
     ),
+    updatePartnerLocationLoader: gravityLoader<
+      any,
+      { partnerId: string; locationId: string }
+    >(
+      ({ partnerId, locationId }) =>
+        `partner/${partnerId}/location/${locationId}`,
+      {},
+      { method: "PUT" }
+    ),
     updatePartnerShowLoader: gravityLoader<
       any,
       { partnerId: string; showId: string }

--- a/src/schema/v2/location.ts
+++ b/src/schema/v2/location.ts
@@ -99,6 +99,10 @@ export const LocationType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
       resolve: ({ day_schedule_text }) => day_schedule_text,
     },
+    email: {
+      type: GraphQLString,
+      resolve: ({ email }) => email,
+    },
     addressType: {
       description: "Buisness, temporary, or private address",
       type: GraphQLString,

--- a/src/schema/v2/partner/Settings/__tests__/createPartnerLocationMutation.test.js
+++ b/src/schema/v2/partner/Settings/__tests__/createPartnerLocationMutation.test.js
@@ -5,7 +5,7 @@ const mutation = gql`
   mutation {
     createPartnerLocation(
       input: {
-        partnerID: "partner_123"
+        partnerId: "partner_123"
         address: "123 Happy Lane"
         address2: "Apt 2b"
         city: "New York"

--- a/src/schema/v2/partner/Settings/__tests__/deletePartnerLocationMutation.test.ts
+++ b/src/schema/v2/partner/Settings/__tests__/deletePartnerLocationMutation.test.ts
@@ -1,0 +1,72 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("DeletePartnerLocationMutation", () => {
+  const mutation = gql`
+    mutation {
+      deletePartnerLocation(input: { partnerId: "foo", locationId: "bar" }) {
+        partnerLocationOrError {
+          __typename
+          ... on DeletePartnerLocationSuccess {
+            location {
+              internalID
+            }
+          }
+          ... on DeletePartnerLocationFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("deletes the partner location", async () => {
+    const context = {
+      deletePartnerLocationLoader: () =>
+        Promise.resolve({
+          id: "bar",
+        }),
+    }
+
+    const deletedPartner = await runAuthenticatedQuery(mutation, context)
+
+    expect(deletedPartner).toEqual({
+      deletePartnerLocation: {
+        partnerLocationOrError: {
+          __typename: "DeletePartnerLocationSuccess",
+          location: {
+            internalID: "bar",
+          },
+        },
+      },
+    })
+  })
+
+  describe("when failure", () => {
+    it("returns an error", async () => {
+      const context = {
+        deletePartnerLocationLoader: () =>
+          Promise.reject(
+            new Error(
+              `https://stagingapi.artsy.net/api/v1/partners/foo/location/bar - {"type":"error","message":"Location not found"}`
+            )
+          ),
+      }
+
+      const deletedPartner = await runAuthenticatedQuery(mutation, context)
+
+      expect(deletedPartner).toEqual({
+        deletePartnerLocation: {
+          partnerLocationOrError: {
+            __typename: "DeletePartnerLocationFailure",
+            mutationError: {
+              message: "Location not found",
+            },
+          },
+        },
+      })
+    })
+  })
+})

--- a/src/schema/v2/partner/Settings/__tests__/updatePartnerLocationMutation.test.js
+++ b/src/schema/v2/partner/Settings/__tests__/updatePartnerLocationMutation.test.js
@@ -1,0 +1,77 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("UpdatePartnerLocationMutation", () => {
+  const mutation = gql`
+    mutation {
+      updatePartnerLocation(
+        input: { partnerId: "foo", locationId: "bar", address: "456 New Drive" }
+      ) {
+        partnerLocationOrError {
+          __typename
+          ... on UpdatePartnerLocationSuccess {
+            location {
+              internalID
+              address
+            }
+          }
+          ... on UpdatePartnerLocationFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("updates the partner location", async () => {
+    const context = {
+      updatePartnerLocationLoader: () =>
+        Promise.resolve({
+          id: "bar",
+          address: "456 New Drive",
+        }),
+    }
+
+    const updatedPartner = await runAuthenticatedQuery(mutation, context)
+
+    expect(updatedPartner).toEqual({
+      updatePartnerLocation: {
+        partnerLocationOrError: {
+          __typename: "UpdatePartnerLocationSuccess",
+          location: {
+            internalID: "bar",
+            address: "456 New Drive",
+          },
+        },
+      },
+    })
+  })
+
+  describe("when failure", () => {
+    it("returns an error", async () => {
+      const context = {
+        updatePartnerLocationLoader: () =>
+          Promise.reject(
+            new Error(
+              `https://stagingapi.artsy.net/api/v1/partners/foo/location/bar - {"type":"error","message":"Location not found"}`
+            )
+          ),
+      }
+
+      const updatedPartner = await runAuthenticatedQuery(mutation, context)
+
+      expect(updatedPartner).toEqual({
+        updatePartnerLocation: {
+          partnerLocationOrError: {
+            __typename: "UpdatePartnerLocationFailure",
+            mutationError: {
+              message: "Location not found",
+            },
+          },
+        },
+      })
+    })
+  })
+})

--- a/src/schema/v2/partner/Settings/createPartnerLocationMutation.ts
+++ b/src/schema/v2/partner/Settings/createPartnerLocationMutation.ts
@@ -15,7 +15,7 @@ import { ResolverContext } from "types/graphql"
 import { LocationType } from "../../location"
 
 interface Input {
-  partnerID: string
+  partnerId: string
   addressType: string
   country: string
   address: string
@@ -63,7 +63,7 @@ export const CreatePartnerLocationMutation = mutationWithClientMutationId<
   name: "CreatePartnerLocation",
   description: "Creates a new location for a partner",
   inputFields: {
-    partnerID: {
+    partnerId: {
       type: new GraphQLNonNull(GraphQLString),
       description: "ID of the partner",
     },
@@ -127,7 +127,7 @@ export const CreatePartnerLocationMutation = mutationWithClientMutationId<
       email,
       phone,
       publiclyViewable,
-      partnerID,
+      partnerId,
     },
     { createPartnerLocationLoader }
   ) => {
@@ -136,7 +136,7 @@ export const CreatePartnerLocationMutation = mutationWithClientMutationId<
     }
 
     try {
-      const response = await createPartnerLocationLoader(partnerID, {
+      const response = await createPartnerLocationLoader(partnerId, {
         address,
         address_2: address2,
         address_type: addressType,

--- a/src/schema/v2/partner/Settings/deletePartnerLocationMutation.ts
+++ b/src/schema/v2/partner/Settings/deletePartnerLocationMutation.ts
@@ -1,0 +1,94 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { LocationType } from "schema/v2/location"
+import { ResolverContext } from "types/graphql"
+
+interface DeletePartnerLocationInputProps {
+  LocationId: string
+  partnerId: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DeletePartnerLocationSuccess",
+  isTypeOf: (data) => !!data.id,
+  fields: () => ({
+    location: {
+      type: LocationType,
+      resolve: (result) => result,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DeletePartnerLocationFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "DeletePartnerLocationOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const DeletePartnerLocationMutation = mutationWithClientMutationId<
+  DeletePartnerLocationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "DeletePartnerLocationMutation",
+  description: "Deletes a location for a partner",
+  inputFields: {
+    partnerId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "ID of the partner",
+    },
+    locationId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "ID of the Location to delete",
+    },
+  },
+  outputFields: {
+    partnerLocationOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { partnerId, LocationId },
+    { deletePartnerLocationLoader }
+  ) => {
+    if (!deletePartnerLocationLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const response = await deletePartnerLocationLoader({
+        partnerId,
+        LocationId,
+      })
+
+      return response
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/Settings/updatePartnerLocationMutation.ts
+++ b/src/schema/v2/partner/Settings/updatePartnerLocationMutation.ts
@@ -1,0 +1,171 @@
+import {
+  GraphQLBoolean,
+  GraphQLEnumType,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { LocationType } from "../../location"
+
+interface UpdatePartnerLocationInputProps {
+  locationId: string
+  partnerId: string
+  addressType?: string
+  country?: string
+  address?: string
+  address2?: string
+  city?: string
+  state?: string
+  postalCode?: string
+  email?: string
+  phone?: string
+  publiclyViewable?: boolean
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdatePartnerLocationSuccess",
+  isTypeOf: (data) => !!data.id,
+  fields: () => ({
+    location: {
+      type: LocationType,
+      resolve: (result) => result,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdatePartnerLocationFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdatePartnerLocationOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const UpdatePartnerLocationMutation = mutationWithClientMutationId<
+  UpdatePartnerLocationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "UpdatePartnerLocation",
+  description: "Updates a new location for a partner",
+  inputFields: {
+    partnerId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "ID of the partner",
+    },
+    locationId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "ID of the location to update",
+    },
+    addressType: {
+      type: new GraphQLEnumType({
+        name: "partnerLocationType",
+        values: {
+          BUSINESS: { value: "Business" },
+          TEMPORARY: { value: "Temporary" },
+          OTHER: { value: "Other" },
+        },
+      }),
+    },
+    country: {
+      type: GraphQLString,
+    },
+    address: {
+      type: GraphQLString,
+    },
+    address2: {
+      type: GraphQLString,
+    },
+    city: {
+      type: GraphQLString,
+    },
+    state: {
+      type: GraphQLString,
+    },
+    postalCode: {
+      type: GraphQLString,
+    },
+    email: {
+      type: GraphQLString,
+      description: "Primary email of given location",
+    },
+    phone: {
+      type: GraphQLString,
+      description: "Primary phone of given location",
+    },
+    publiclyViewable: {
+      type: GraphQLBoolean,
+      description:
+        "Boolean flag that denotes whether a location is publicly viewable on Partner's Artsy Profile",
+    },
+  },
+  outputFields: {
+    partnerLocationOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    {
+      addressType,
+      address,
+      address2,
+      city,
+      state,
+      country,
+      postalCode,
+      email,
+      phone,
+      publiclyViewable,
+      partnerId,
+      locationId,
+    },
+    { updatePartnerLocationLoader }
+  ) => {
+    if (!updatePartnerLocationLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const response = await updatePartnerLocationLoader(
+        { partnerId, locationId },
+        {
+          address,
+          address_2: address2,
+          address_type: addressType,
+          city,
+          country,
+          email,
+          phone,
+          postal_code: postalCode,
+          publicly_viewable: publiclyViewable,
+          state,
+        }
+      )
+
+      return response
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/__tests__/partner.test.js
+++ b/src/schema/v2/partner/__tests__/partner.test.js
@@ -652,6 +652,58 @@ describe("Partner type", () => {
     })
   })
 
+  describe("#location", () => {
+    let singleLocationResponse
+
+    const partnerLocationLoader = jest.fn(() => {
+      return Promise.resolve(singleLocationResponse)
+    })
+
+    const partnerLoader = jest.fn(() => {
+      return Promise.resolve(partnerData)
+    })
+
+    beforeEach(() => {
+      singleLocationResponse = {
+        id: "location-1",
+        email: "md@artsy.net",
+        address: "123 Happy St",
+        state: "NY",
+      }
+    })
+
+    it("returns a given partner location", async () => {
+      context = {
+        partnerLocationLoader,
+        partnerLoader,
+      }
+
+      const query = `
+        {
+          partner(id:"bau-xi-gallery") {
+            location(locationId: "location-1") {
+              email
+              address
+              state
+            }
+          }
+        }
+      `
+
+      const data = await runAuthenticatedQuery(query, context)
+
+      expect(data).toEqual({
+        partner: {
+          location: {
+            email: "md@artsy.net",
+            address: "123 Happy St",
+            state: "NY",
+          },
+        },
+      })
+    })
+  })
+
   describe("#locationsConnection", () => {
     let locationsResponse
 

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -1126,6 +1126,28 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           })
         },
       },
+      location: {
+        type: LocationType,
+        description: "A Singular Location belonging to the Partner",
+        args: {
+          locationId: {
+            type: new GraphQLNonNull(GraphQLString),
+            description: "The slug or ID of the Contact",
+          },
+        },
+        resolve: async ({ id }, args, { partnerLocationLoader }) => {
+          const { locationId } = args
+
+          if (!partnerLocationLoader) return null
+
+          const location = await partnerLocationLoader({
+            partnerId: id,
+            locationId: locationId,
+          })
+
+          return location
+        },
+      },
       name: {
         type: GraphQLString,
         resolve: ({ name }) => name.trim(),

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -304,6 +304,7 @@ import { UpdatePartnerContactMutation } from "./partner/Settings/updatePartnerCo
 import { DeletePartnerContactMutation } from "./partner/Settings/deletePartnerContactMutation"
 import { unsetOrderFulfillmentOptionMutation } from "./order/unsetOrderFulfillmentOptionMutation"
 import { UpdatePartnerLocationMutation } from "./partner/Settings/updatePartnerLocationMutation"
+import { DeletePartnerLocationMutation } from "./partner/Settings/deletePartnerLocationMutation"
 
 const rootFields = {
   // artworkVersion: ArtworkVersionResolver,
@@ -517,6 +518,7 @@ export default new GraphQLSchema({
       deleteFeaturedLink: DeleteFeaturedLinkMutation,
       deleteHeroUnit: deleteHeroUnitMutation,
       deletePartnerContact: DeletePartnerContactMutation,
+      deletePartnerLocation: DeletePartnerLocationMutation,
       deletePartnerShow: deletePartnerShowMutation,
       deletePartnerShowDocument: deletePartnerShowDocumentMutation,
       deletePartnerShowEvent: deletePartnerShowEventMutation,

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -303,6 +303,7 @@ import { CreatePartnerLocationMutation } from "./partner/Settings/createPartnerL
 import { UpdatePartnerContactMutation } from "./partner/Settings/updatePartnerContactMutation"
 import { DeletePartnerContactMutation } from "./partner/Settings/deletePartnerContactMutation"
 import { unsetOrderFulfillmentOptionMutation } from "./order/unsetOrderFulfillmentOptionMutation"
+import { UpdatePartnerLocationMutation } from "./partner/Settings/updatePartnerLocationMutation"
 
 const rootFields = {
   // artworkVersion: ArtworkVersionResolver,
@@ -595,6 +596,7 @@ export default new GraphQLSchema({
       updateOrderedSet: updateOrderedSetMutation,
       updatePage: UpdatePageMutation,
       updatePartnerContact: UpdatePartnerContactMutation,
+      updatePartnerLocation: UpdatePartnerLocationMutation,
       updatePartnerShow: updatePartnerShowMutation,
       updateQuiz: updateQuizMutation,
       updateSaleAgreement: UpdateSaleAgreementMutation,


### PR DESCRIPTION
feat(settingsV2): Fetch single, update, and delete support for partner locations

Adds 2 new mutations and the ability to query for a single location under partner

1. `updatePartnerLocation`
2. `deletePartnerLocation`
3. fetch a single partner location via id
4. Expose `email` on Location type
5. better synthesize `partnerID` vs `partnerId`