### PR TITLE
fix: Fix to use the correct endpoint url structure

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -932,7 +932,7 @@ export default (accessToken, userID, opts) => {
       { partnerId: string; locationId: string }
     >(
       ({ partnerId, locationId }) =>
-        `partner/${partnerId}/locationId/${locationId}`
+        `partner/${partnerId}/location/${locationId}`
     ),
     partnerLocationsConnectionLoader: gravityLoader(
       (id) => `partner/${id}/locations`,


### PR DESCRIPTION
Fix: uses the correct URL structure to hitting the GET `api/v1/parnter/partner_id/location/id` endpoint

Ooops! You'll always get a 404 as this `locationId` path doesnt exist:


<img width="1116" alt="Screenshot 2025-04-09 at 12 29 02 PM" src="https://github.com/user-attachments/assets/e179cfbd-701e-494d-88bf-8a2efe6eb823" />
