### PR TITLE
chore: Adjust address type to just be a string field for now

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9017,7 +9017,7 @@ type CreatePartnerLocationFailure {
 input CreatePartnerLocationInput {
   address: String
   address2: String
-  addressType: locationType
+  addressType: String
   city: String
   clientMutationId: String
   country: String
@@ -22112,7 +22112,7 @@ type UpdatePartnerLocationFailure {
 input UpdatePartnerLocationInput {
   address: String
   address2: String
-  addressType: partnerLocationType
+  addressType: String
   city: String
   clientMutationId: String
   country: String
@@ -24830,20 +24830,8 @@ type dimensions {
   in: String
 }
 
-enum locationType {
-  BUSINESS
-  OTHER
-  TEMPORARY
-}
-
 type partnerBiographyBlurb {
   text: String
-}
-
-enum partnerLocationType {
-  BUSINESS
-  OTHER
-  TEMPORARY
 }
 
 type purchases {

--- a/src/schema/v2/partner/Settings/createPartnerLocationMutation.ts
+++ b/src/schema/v2/partner/Settings/createPartnerLocationMutation.ts
@@ -1,6 +1,5 @@
 import {
   GraphQLBoolean,
-  GraphQLEnumType,
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
@@ -68,14 +67,7 @@ export const CreatePartnerLocationMutation = mutationWithClientMutationId<
       description: "ID of the partner",
     },
     addressType: {
-      type: new GraphQLEnumType({
-        name: "locationType",
-        values: {
-          BUSINESS: { value: "Business" },
-          TEMPORARY: { value: "Temporary" },
-          OTHER: { value: "Other" },
-        },
-      }),
+      type: GraphQLString,
     },
     country: {
       type: GraphQLString,

--- a/src/schema/v2/partner/Settings/updatePartnerLocationMutation.ts
+++ b/src/schema/v2/partner/Settings/updatePartnerLocationMutation.ts
@@ -1,6 +1,5 @@
 import {
   GraphQLBoolean,
-  GraphQLEnumType,
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
@@ -73,14 +72,7 @@ export const UpdatePartnerLocationMutation = mutationWithClientMutationId<
       description: "ID of the location to update",
     },
     addressType: {
-      type: new GraphQLEnumType({
-        name: "partnerLocationType",
-        values: {
-          BUSINESS: { value: "Business" },
-          TEMPORARY: { value: "Temporary" },
-          OTHER: { value: "Other" },
-        },
-      }),
+      type: GraphQLString,
     },
     country: {
       type: GraphQLString,


### PR DESCRIPTION
Losening up the `addressType` when creating or updating partner locations

I'll let Gravity [hold the main validation for now](https://github.com/artsy/gravity/blob/main/app/models/domain/partner_location.rb#L56)


I want Volt to be less "aware" of casing logic like [this](https://github.com/artsy/volt/pull/8707/files#diff-4cbcf0d9fa148c5b2ac47eb243a4f8b17b23cf2bdc614219e4f748f6c9e175b0R16-R17) for now!