### PR TITLE
feat(updateArtwork): Add published input argument

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -21717,6 +21717,7 @@ input UpdateArtworkEditionSetInput {
   priceListed: String
   priceMax: Int
   priceMin: Int
+  published: Boolean
   shippingWeight: Float
   shippingWeightMetric: String
 }
@@ -21786,6 +21787,7 @@ input UpdateArtworkMutationInput {
   priceListed: String
   priceMax: Int
   priceMin: Int
+  published: Boolean
   shippingWeight: Float
   shippingWeightMetric: String
 }

--- a/src/schema/v2/artwork/updateArtworkMutation.ts
+++ b/src/schema/v2/artwork/updateArtworkMutation.ts
@@ -60,6 +60,7 @@ interface UpdateArtworkMutationInputProps {
   framedWidth?: string
   id?: string
   offer?: boolean
+  published?: boolean
   priceCurrency?: string
   priceHidden?: boolean
   priceIncludesTax?: boolean
@@ -124,6 +125,9 @@ const inputFields = {
     type: GraphQLString,
   },
   framed: {
+    type: GraphQLBoolean,
+  },
+  published: {
     type: GraphQLBoolean,
   },
   priceCurrency: {
@@ -196,6 +200,7 @@ export const updateArtworkMutation = mutationWithClientMutationId<
         framed: inputArgs.framed,
         id: inputArgs.id,
         offer: inputArgs.offer,
+        published: inputArgs.published,
         price_currency: inputArgs.priceCurrency,
         price_hidden: inputArgs.priceHidden,
         price_includes_tax: inputArgs.priceIncludesTax,


### PR DESCRIPTION
Quick one -- expose `published: boolean` argument on `updateArtwork` mutation for publishing an artwork. 

cc @artsy/amber-devs 