### PR TITLE
feat(EMI-2391): create unsetPaymentMethod mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15530,6 +15530,11 @@ type Mutation {
     input: unsetOrderFulfillmentOptionInput!
   ): unsetOrderFulfillmentOptionPayload
 
+  # Unset payment method and credit card wallet type on an order
+  unsetOrderPaymentMethod(
+    input: unsetOrderPaymentMethodInput!
+  ): unsetOrderPaymentMethodPayload
+
   # Create an alert
   updateAlert(input: updateAlertInput!): updateAlertPayload
   updateAppSecondFactor(
@@ -25173,6 +25178,18 @@ input unsetOrderFulfillmentOptionInput {
 }
 
 type unsetOrderFulfillmentOptionPayload {
+  clientMutationId: String
+  orderOrError: SetOrderFulfillmentOptionResponse
+}
+
+input unsetOrderPaymentMethodInput {
+  clientMutationId: String
+
+  # Order id.
+  id: ID!
+}
+
+type unsetOrderPaymentMethodPayload {
   clientMutationId: String
   orderOrError: SetOrderFulfillmentOptionResponse
 }

--- a/src/lib/loaders/loaders_with_authentication/exchange.ts
+++ b/src/lib/loaders/loaders_with_authentication/exchange.ts
@@ -63,6 +63,14 @@ export const exchangeLoaders = (accessToken, opts) => {
     }
   )
 
+  const meOrderUnsetPaymentMethodLoader = exchangeLoader(
+    (id) => `me/orders/${id}/unset_payment_method`,
+    {},
+    {
+      method: "PUT",
+    }
+  )
+
   const meOrderSubmitLoader = exchangeLoader(
     (id) => `me/orders/${id}/submit`,
     {},
@@ -113,5 +121,6 @@ export const exchangeLoaders = (accessToken, opts) => {
     meOrderSetFulfillmentOptionLoader,
     meOrderSubmitLoader,
     meOrderUnsetFulfillmentOptionLoader,
+    meOrderUnsetPaymentMethodLoader,
   }
 }

--- a/src/schema/v2/order/__tests__/unsetOrderPaymentMethodMutation.test.ts
+++ b/src/schema/v2/order/__tests__/unsetOrderPaymentMethodMutation.test.ts
@@ -1,0 +1,100 @@
+import { baseArtwork, baseOrderJson } from "./support"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+const mockMutation = `
+  mutation {
+    unsetOrderPaymentMethod(input: { id: "order-id" }) {
+      orderOrError {
+        ... on OrderMutationSuccess {
+          order {
+            internalID
+          }
+        }
+        ... on OrderMutationError {
+          mutationError {
+            message
+            code
+          }
+        }
+      }
+    }
+  }
+`
+
+describe("unsetOrderPaymentMethod", () => {
+  const context = {
+    meOrderUnsetPaymentMethodLoader: jest.fn().mockResolvedValue({
+      ...baseOrderJson,
+      id: "order-id",
+    }),
+    artworkLoader: jest
+      .fn()
+      .mockResolvedValue({ ...baseArtwork, id: "artwork-id" }),
+    artworkVersionLoader: jest
+      .fn()
+      .mockResolvedValue({ ...baseArtwork, id: "artwork-version-id" }),
+  }
+
+  it("should unset the payment method", async () => {
+    const result = await runAuthenticatedQuery(mockMutation, context)
+
+    expect(context.meOrderUnsetPaymentMethodLoader).toHaveBeenCalledWith(
+      "order-id"
+    )
+    expect(result.errors).toBeUndefined()
+    expect(result).toEqual({
+      unsetOrderPaymentMethod: {
+        orderOrError: {
+          order: {
+            internalID: "order-id",
+          },
+        },
+      },
+    })
+  })
+
+  it("should handle 422 error from exchange", async () => {
+    context.meOrderUnsetPaymentMethodLoader = jest.fn().mockRejectedValue({
+      statusCode: 422,
+      body: {
+        message: "order_not_pending - submitted",
+        code: "order_not_pending",
+      },
+    })
+
+    const result = await runAuthenticatedQuery(mockMutation, context)
+
+    expect(result.errors).toBeUndefined()
+    expect(result).toEqual({
+      unsetOrderPaymentMethod: {
+        orderOrError: {
+          mutationError: {
+            message: "order_not_pending - submitted",
+            code: "order_not_pending",
+          },
+        },
+      },
+    })
+  })
+
+  it("should handle errors", async () => {
+    context.meOrderUnsetPaymentMethodLoader = jest.fn().mockRejectedValue({
+      message: "An error occurred",
+      statusCode: 500,
+    })
+
+    const result = await runAuthenticatedQuery(mockMutation, context)
+
+    expect(result.errors).toBeUndefined()
+    expect(result).toEqual({
+      unsetOrderPaymentMethod: {
+        orderOrError: {
+          mutationError: {
+            message: "An error occurred",
+            code: "internal_error",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/order/unsetOrderPaymentMethodMutation.ts
+++ b/src/schema/v2/order/unsetOrderPaymentMethodMutation.ts
@@ -1,0 +1,46 @@
+import { GraphQLID, GraphQLNonNull } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import {
+  ORDER_MUTATION_FLAGS,
+  OrderMutationResponseType,
+} from "./sharedOrderTypes"
+import { handleExchangeError } from "./exchangeErrorHandling"
+
+interface Input {
+  id: string
+}
+
+export const unsetOrderPaymentMethodMutation = mutationWithClientMutationId<
+  Input,
+  any,
+  ResolverContext
+>({
+  name: "unsetOrderPaymentMethod",
+  description: "Unset payment method and credit card wallet type on an order",
+  inputFields: {
+    id: { type: new GraphQLNonNull(GraphQLID), description: "Order id." },
+  },
+  outputFields: {
+    orderOrError: {
+      type: OrderMutationResponseType,
+      resolve: (response) => response,
+    },
+  },
+
+  mutateAndGetPayload: async (input, context) => {
+    const { meOrderUnsetPaymentMethodLoader } = context
+    if (!meOrderUnsetPaymentMethodLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+    try {
+      const updatedOrder = await meOrderUnsetPaymentMethodLoader(input.id)
+
+      updatedOrder._type = ORDER_MUTATION_FLAGS.SUCCESS
+
+      return updatedOrder
+    } catch (error) {
+      return handleExchangeError(error)
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -303,6 +303,7 @@ import { CreatePartnerLocationMutation } from "./partner/Settings/createPartnerL
 import { UpdatePartnerContactMutation } from "./partner/Settings/updatePartnerContactMutation"
 import { DeletePartnerContactMutation } from "./partner/Settings/deletePartnerContactMutation"
 import { unsetOrderFulfillmentOptionMutation } from "./order/unsetOrderFulfillmentOptionMutation"
+import { unsetOrderPaymentMethodMutation } from "./order/unsetOrderPaymentMethodMutation"
 import { UpdatePartnerLocationMutation } from "./partner/Settings/updatePartnerLocationMutation"
 import { DeletePartnerLocationMutation } from "./partner/Settings/deletePartnerLocationMutation"
 
@@ -575,6 +576,7 @@ export default new GraphQLSchema({
       unlinkAuthentication: unlinkAuthenticationMutation,
       unpublishViewingRoom: unpublishViewingRoomMutation,
       unsetOrderFulfillmentOption: unsetOrderFulfillmentOptionMutation,
+      unsetOrderPaymentMethod: unsetOrderPaymentMethodMutation,
       updateAlert: updateAlertMutation,
       updateAppSecondFactor: updateAppSecondFactorMutation,
       updateArtist: updateArtistMutation,


### PR DESCRIPTION
This PR resolves part of [EMI-2391]

### Description
This PR is a follow-up on artsy/exchange#2515 🔒
This PR exposes the newly created endpoint to unset the payment method on an order

[EMI-2391]: https://artsyproduct.atlassian.net/browse/EMI-2391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ