### PR TITLE
fix: Fix `locationId` argument casing

### DIFF
--- a/src/schema/v2/partner/Settings/deletePartnerLocationMutation.ts
+++ b/src/schema/v2/partner/Settings/deletePartnerLocationMutation.ts
@@ -68,7 +68,7 @@ export const DeletePartnerLocationMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    { partnerId, LocationId },
+    { partnerId, locationId },
     { deletePartnerLocationLoader }
   ) => {
     if (!deletePartnerLocationLoader) {
@@ -78,7 +78,7 @@ export const DeletePartnerLocationMutation = mutationWithClientMutationId<
     try {
       const response = await deletePartnerLocationLoader({
         partnerId,
-        LocationId,
+        locationId,
       })
 
       return response


### PR DESCRIPTION
Oops!  Fix argument for `locationId`

Otherwise we are always passing in undefined to Gravity

<img width="1208" alt="Screenshot 2025-04-10 at 3 57 00 PM" src="https://github.com/user-attachments/assets/6873337a-5ec7-46ff-ba7e-31053d5268e6" />
