### PR TITLE
feat: Adds mutation to support partner location reordering

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15451,6 +15451,11 @@ type Mutation {
   repositionInstallShotsInPartnerShow(
     input: RepositionInstallShotsInPartnerShowMutationInput!
   ): RepositionInstallShotsInPartnerShowMutationPayload
+
+  # Reposition partners locations in various CMS surfaces, settings, Artwork Form, etc.
+  repositionPartnerLocations(
+    input: RepositionPartnerLocationsMutationInput!
+  ): RepositionPartnerLocationsMutationPayload
   requestConditionReport(
     # Parameters for RequestConditionReport
     input: RequestConditionReportInput!
@@ -19659,6 +19664,33 @@ union RepositionInstallShotsInPartnerShowResponseOrError =
 type RepositionInstallShotsInPartnerShowSuccess {
   show: Show
 }
+
+type RepositionPartnerLocationsFailure {
+  mutationError: GravityMutationError
+}
+
+input RepositionPartnerLocationsMutationInput {
+  clientMutationId: String
+
+  # An ordered array of location IDs representing the new display order.
+  locationIds: [String!]!
+
+  # The ID partner.
+  partnerId: String!
+}
+
+type RepositionPartnerLocationsMutationPayload {
+  clientMutationId: String
+  partnerOrError: RepositionPartnerLocationsSuccessOrError
+}
+
+type RepositionPartnerLocationsSuccess {
+  partner: Partner
+}
+
+union RepositionPartnerLocationsSuccessOrError =
+    RepositionPartnerLocationsFailure
+  | RepositionPartnerLocationsSuccess
 
 type Request {
   # IP Address of the current request, useful for debugging

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -939,6 +939,11 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    repositionPartnerLocationsLoader: gravityLoader(
+      (id) => `partner/${id}/locations/reposition`,
+      {},
+      { method: "POST" }
+    ),
     partnerOffersLoader: gravityLoader("partner_offers", {}, { headers: true }),
     partnerSearchArtistsLoader: gravityLoader(
       (id) => `/match/partner/${id}/artists`,

--- a/src/schema/v2/partner/Settings/__tests__/repositionPartnerLocationsMutations.test.ts
+++ b/src/schema/v2/partner/Settings/__tests__/repositionPartnerLocationsMutations.test.ts
@@ -1,0 +1,55 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("RepositionPartnerLocationMutation", () => {
+  const mutation = gql`
+    mutation {
+      repositionPartnerLocations(
+        input: {
+          partnerId: "partner456"
+          locationIds: ["nyc-location-1", "astoria-location-2"]
+        }
+      ) {
+        partnerOrError {
+          __typename
+          ... on RepositionPartnerLocationsSuccess {
+            partner {
+              internalID
+              name
+            }
+          }
+          ... on RepositionPartnerLocationsFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("reorders list of partner locations", async () => {
+    const context = {
+      repositionPartnerLocationsLoader: () => {
+        return Promise.resolve({
+          _id: "partner456",
+          name: "Partner 456",
+        })
+      },
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      repositionPartnerLocations: {
+        partnerOrError: {
+          __typename: "RepositionPartnerLocationsSuccess",
+          partner: {
+            internalID: "partner456",
+            name: "Partner 456",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/partner/Settings/repositionPartnerLocations.ts
+++ b/src/schema/v2/partner/Settings/repositionPartnerLocations.ts
@@ -1,0 +1,98 @@
+import {
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLUnionType,
+  GraphQLList,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { PartnerType } from "../partner"
+
+interface RepositionPartnerLocationsProps {
+  partnerId: string
+  locationIds: string[]
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "RepositionPartnerLocationsSuccess",
+  isTypeOf: (data) => !!data._id,
+  fields: () => ({
+    partner: {
+      type: PartnerType,
+      resolve: (result) => result,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "RepositionPartnerLocationsFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "RepositionPartnerLocationsSuccessOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const repositionPartnerLocationsMutation = mutationWithClientMutationId<
+  RepositionPartnerLocationsProps,
+  any,
+  ResolverContext
+>({
+  name: "RepositionPartnerLocationsMutation",
+  description:
+    "Reposition partners locations in various CMS surfaces, settings, Artwork Form, etc.",
+  inputFields: {
+    partnerId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID partner.",
+    },
+    locationIds: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(GraphQLString))
+      ),
+      description:
+        "An ordered array of location IDs representing the new display order.",
+    },
+  },
+  outputFields: {
+    partnerOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { partnerId, locationIds },
+    { repositionPartnerLocationsLoader }
+  ) => {
+    if (!repositionPartnerLocationsLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const response = await repositionPartnerLocationsLoader(partnerId, {
+        location_ids: locationIds,
+      })
+
+      return response
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -305,6 +305,7 @@ import { DeletePartnerContactMutation } from "./partner/Settings/deletePartnerCo
 import { unsetOrderFulfillmentOptionMutation } from "./order/unsetOrderFulfillmentOptionMutation"
 import { UpdatePartnerLocationMutation } from "./partner/Settings/updatePartnerLocationMutation"
 import { DeletePartnerLocationMutation } from "./partner/Settings/deletePartnerLocationMutation"
+import { repositionPartnerLocationsMutation } from "./partner/Settings/repositionPartnerLocations"
 
 const rootFields = {
   // artworkVersion: ArtworkVersionResolver,
@@ -560,6 +561,7 @@ export default new GraphQLSchema({
       removeInstallShotFromPartnerShow: removeInstallShotFromPartnerShowMutation,
       repositionArtworksInPartnerShow: repositionArtworksInPartnerShowMutation,
       repositionInstallShotsInPartnerShow: repositionInstallShotsInPartnerShowMutation,
+      repositionPartnerLocations: repositionPartnerLocationsMutation,
       requestCredentialsForAssetUpload: CreateAssetRequestLoader,
       requestPriceEstimate: requestPriceEstimateMutation,
       saveArtwork: saveArtworkMutation,


### PR DESCRIPTION
Adds a new MP loader to hit `POST api/v1/partner/:id/locations/reposition` gravity endpoint ([ref](https://github.com/artsy/gravity/blob/main/app/api/v1/partners_locations_endpoint.rb#L97))


Ex structure:
```graphql
mutation {
  repositionPartnerLocations(input: {
    partnerId: "5f80bfefe8d808000ea212c1", 
    locationIds: ["5f8123abec5de8000ea9b785", "60dcc8f849a149000f9ece3a"], 
  }) {
    partnerOrError {
      ... on RepositionPartnerLocationsSuccess {
        partner {
          internalID
        }
      }
      ... on RepositionPartnerLocationsFailure {
        mutationError {
          message
        }
      }
    }
  }
}
```

<img width="1391" alt="Screenshot 2025-04-10 at 5 37 11 PM" src="https://github.com/user-attachments/assets/b286c985-81a4-48e8-beec-a25566886c90" />



## Background
Here's an example of the Kinetic <> Gravity backed experience, we want to carry this over in settings V2, discussed in this [thread](https://artsy.slack.com/archives/C05F8TNKGAV/p1742413671128289?thread_ts=1742412854.670859&cid=C05F8TNKGAV)


https://github.com/user-attachments/assets/3d6821ee-61ef-49b1-b97c-5d01e49b7921


