### PR TITLE
chore: add mutations for managing partner artist documents

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9061,6 +9061,41 @@ type CreatePageSuccess {
   page: Page
 }
 
+type CreatePartnerArtistDocumentFailure {
+  mutationError: GravityMutationError
+}
+
+input CreatePartnerArtistDocumentMutationInput {
+  # The ID of the artist.
+  artistId: String!
+  clientMutationId: String
+
+  # The ID of the partner.
+  partnerId: String!
+
+  # The URL of the document to upload.
+  remoteDocumentUrl: String!
+
+  # The title of the document.
+  title: String!
+}
+
+type CreatePartnerArtistDocumentMutationPayload {
+  clientMutationId: String
+
+  # On success: the created document. On error: the error that occurred.
+  documentOrError: CreatePartnerArtistDocumentResponseOrError
+}
+
+union CreatePartnerArtistDocumentResponseOrError =
+    CreatePartnerArtistDocumentFailure
+  | CreatePartnerArtistDocumentSuccess
+
+type CreatePartnerArtistDocumentSuccess {
+  document: PartnerDocument
+  partner: Partner
+}
+
 type CreatePartnerContactFailure {
   mutationError: GravityMutationError
 }
@@ -9922,6 +9957,38 @@ union DeletePageResponseOrError = DeletePageFailure | DeletePageSuccess
 
 type DeletePageSuccess {
   page: Page
+}
+
+type DeletePartnerArtistDocumentFailure {
+  mutationError: GravityMutationError
+}
+
+input DeletePartnerArtistDocumentMutationInput {
+  # The ID of the artist.
+  artistId: String!
+  clientMutationId: String
+
+  # The ID of the document to delete.
+  documentId: String!
+
+  # The ID of the partner.
+  partnerId: String!
+}
+
+type DeletePartnerArtistDocumentMutationPayload {
+  clientMutationId: String
+
+  # On success: the deleted document. On error: the error that occurred.
+  documentOrError: DeletePartnerArtistDocumentResponseOrError
+}
+
+union DeletePartnerArtistDocumentResponseOrError =
+    DeletePartnerArtistDocumentFailure
+  | DeletePartnerArtistDocumentSuccess
+
+type DeletePartnerArtistDocumentSuccess {
+  document: PartnerDocument
+  partner: Partner
 }
 
 type DeletePartnerContactFailure {
@@ -15144,6 +15211,11 @@ type Mutation {
   # Creates a static Markdown-backed page.
   createPage(input: CreatePageMutationInput!): CreatePageMutationPayload
 
+  # Creates a partner artist document.
+  createPartnerArtistDocument(
+    input: CreatePartnerArtistDocumentMutationInput!
+  ): CreatePartnerArtistDocumentMutationPayload
+
   # Creates a new contact for a partner
   createPartnerContact(
     input: CreatePartnerContactInput!
@@ -15283,6 +15355,11 @@ type Mutation {
 
   # Deletes a page.
   deletePage(input: DeletePageMutationInput!): DeletePageMutationPayload
+
+  # Deletes a partner artist document.
+  deletePartnerArtistDocument(
+    input: DeletePartnerArtistDocumentMutationInput!
+  ): DeletePartnerArtistDocumentMutationPayload
 
   # Deletes a contact for a partner
   deletePartnerContact(
@@ -15632,6 +15709,11 @@ type Mutation {
 
   # Updates a page.
   updatePage(input: UpdatePageMutationInput!): UpdatePageMutationPayload
+
+  # Updates a partner artist document.
+  updatePartnerArtistDocument(
+    input: UpdatePartnerArtistDocumentMutationInput!
+  ): UpdatePartnerArtistDocumentMutationPayload
 
   # Updates an existing contact for a partner
   updatePartnerContact(
@@ -22337,6 +22419,44 @@ union UpdatePageResponseOrError = UpdatePageFailure | UpdatePageSuccess
 
 type UpdatePageSuccess {
   page: Page
+}
+
+type UpdatePartnerArtistDocumentFailure {
+  mutationError: GravityMutationError
+}
+
+input UpdatePartnerArtistDocumentMutationInput {
+  # The ID of the artist.
+  artistId: String!
+  clientMutationId: String
+
+  # The ID of the document to update.
+  documentId: String!
+
+  # The ID of the partner.
+  partnerId: String!
+
+  # The URL of the document to upload.
+  remoteDocumentUrl: String
+
+  # The updated title of the document.
+  title: String
+}
+
+type UpdatePartnerArtistDocumentMutationPayload {
+  clientMutationId: String
+
+  # On success: the updated document. On error: the error that occurred.
+  documentOrError: UpdatePartnerArtistDocumentResponseOrError
+}
+
+union UpdatePartnerArtistDocumentResponseOrError =
+    UpdatePartnerArtistDocumentFailure
+  | UpdatePartnerArtistDocumentSuccess
+
+type UpdatePartnerArtistDocumentSuccess {
+  document: PartnerDocument
+  partner: Partner
 }
 
 type UpdatePartnerContactFailure {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -305,6 +305,15 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    createPartnerArtistDocumentLoader: gravityLoader<
+      any,
+      { partnerID: string; artistID: string }
+    >(
+      ({ partnerID, artistID }) =>
+        `partner/${partnerID}/artist/${artistID}/document`,
+      {},
+      { method: "POST" }
+    ),
     createPartnerShowDocumentLoader: gravityLoader<
       any,
       { partnerID: string; showID: string }
@@ -417,6 +426,15 @@ export default (accessToken, userID, opts) => {
       { partnerID: string; showID: string }
     >(
       ({ partnerID, showID }) => `partner/${partnerID}/show/${showID}`,
+      {},
+      { method: "DELETE" }
+    ),
+    deletePartnerArtistDocumentLoader: gravityLoader<
+      any,
+      { partnerID: string; artistID: string; documentId: string }
+    >(
+      ({ partnerID, artistID, documentId }) =>
+        `partner/${partnerID}/artist/${artistID}/document/${documentId}`,
       {},
       { method: "DELETE" }
     ),
@@ -1196,6 +1214,15 @@ export default (accessToken, userID, opts) => {
       { partnerId: string; showId: string }
     >(
       ({ partnerId, showId }) => `partner/${partnerId}/show/${showId}`,
+      {},
+      { method: "PUT" }
+    ),
+    updatePartnerArtistDocumentLoader: gravityLoader<
+      any,
+      { partnerId: string; artistId: string; documentId: string }
+    >(
+      ({ partnerId, artistId, documentId }) =>
+        `partner/${partnerId}/artist/${artistId}/document/${documentId}`,
       {},
       { method: "PUT" }
     ),

--- a/src/schema/v2/partner/Mutations/PartnerArtist/__tests__/createPartnerArtistDocumentMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/PartnerArtist/__tests__/createPartnerArtistDocumentMutation.test.ts
@@ -1,0 +1,60 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("CreatePartnerArtistDocumentMutation", () => {
+  const mutation = gql`
+    mutation {
+      createPartnerArtistDocument(
+        input: {
+          partnerId: "partner123"
+          artistId: "artist123"
+          remoteDocumentUrl: "https://example.com/document.pdf"
+          title: "Press Release"
+        }
+      ) {
+        documentOrError {
+          __typename
+          ... on CreatePartnerArtistDocumentSuccess {
+            document {
+              title
+              publicURL
+            }
+            partner {
+              name
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("creates a partner artist document", async () => {
+    const context = {
+      createPartnerArtistDocumentLoader: () =>
+        Promise.resolve({
+          _id: "document123",
+          title: "Press Release",
+          uri: "documents/partner/artist/document123/press-release.pdf",
+        }),
+      partnerLoader: () => Promise.resolve({ name: "Test Partner" }),
+    }
+
+    const createdDocument = await runAuthenticatedQuery(mutation, context)
+
+    expect(createdDocument).toEqual({
+      createPartnerArtistDocument: {
+        documentOrError: {
+          __typename: "CreatePartnerArtistDocumentSuccess",
+          document: {
+            title: "Press Release",
+            publicURL:
+              "https://api.artsy.test/api/v1/documents/partner/artist/document123/press-release.pdf",
+          },
+          partner: {
+            name: "Test Partner",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/partner/Mutations/PartnerArtist/__tests__/deletePartnerArtistDocumentMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/PartnerArtist/__tests__/deletePartnerArtistDocumentMutation.test.ts
@@ -1,0 +1,59 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("DeletePartnerArtistDocumentMutation", () => {
+  const mutation = gql`
+    mutation {
+      deletePartnerArtistDocument(
+        input: {
+          partnerId: "partner123"
+          artistId: "artist123"
+          documentId: "document123"
+        }
+      ) {
+        documentOrError {
+          __typename
+          ... on DeletePartnerArtistDocumentSuccess {
+            document {
+              title
+              publicURL
+            }
+            partner {
+              name
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("deletes a partner artist document", async () => {
+    const context = {
+      deletePartnerArtistDocumentLoader: () =>
+        Promise.resolve({
+          _id: "document123",
+          title: "Press Release",
+          uri: "documents/partner/artist/document123/press-release.pdf",
+        }),
+      partnerLoader: () => Promise.resolve({ name: "Test Partner" }),
+    }
+
+    const deletedDocument = await runAuthenticatedQuery(mutation, context)
+
+    expect(deletedDocument).toEqual({
+      deletePartnerArtistDocument: {
+        documentOrError: {
+          __typename: "DeletePartnerArtistDocumentSuccess",
+          document: {
+            title: "Press Release",
+            publicURL:
+              "https://api.artsy.test/api/v1/documents/partner/artist/document123/press-release.pdf",
+          },
+          partner: {
+            name: "Test Partner",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/partner/Mutations/PartnerArtist/__tests__/updatePartnerArtistDocumentMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/PartnerArtist/__tests__/updatePartnerArtistDocumentMutation.test.ts
@@ -1,0 +1,60 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("UpdatePartnerArtistDocumentMutation", () => {
+  const mutation = gql`
+    mutation {
+      updatePartnerArtistDocument(
+        input: {
+          partnerId: "partner123"
+          artistId: "artist123"
+          documentId: "document123"
+          title: "Updated Press Release"
+        }
+      ) {
+        documentOrError {
+          __typename
+          ... on UpdatePartnerArtistDocumentSuccess {
+            document {
+              title
+              publicURL
+            }
+            partner {
+              name
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("updates a partner artist document", async () => {
+    const context = {
+      updatePartnerArtistDocumentLoader: () =>
+        Promise.resolve({
+          _id: "document123",
+          title: "Updated Press Release",
+          uri: "documents/partner/artist/document123/updated-press-release.pdf",
+        }),
+      partnerLoader: () => Promise.resolve({ name: "Test Partner" }),
+    }
+
+    const updatedDocument = await runAuthenticatedQuery(mutation, context)
+
+    expect(updatedDocument).toEqual({
+      updatePartnerArtistDocument: {
+        documentOrError: {
+          __typename: "UpdatePartnerArtistDocumentSuccess",
+          document: {
+            title: "Updated Press Release",
+            publicURL:
+              "https://api.artsy.test/api/v1/documents/partner/artist/document123/updated-press-release.pdf",
+          },
+          partner: {
+            name: "Test Partner",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/partner/Mutations/PartnerArtist/createPartnerArtistDocumentMutation.ts
+++ b/src/schema/v2/partner/Mutations/PartnerArtist/createPartnerArtistDocumentMutation.ts
@@ -1,0 +1,120 @@
+import {
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { PartnerDocumentType } from "../../partnerDocumentsConnection"
+import Partner from "../../partner"
+
+interface CreatePartnerArtistDocumentMutationInputProps {
+  partnerId: string
+  artistId: string
+  remoteDocumentUrl: string
+  title: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreatePartnerArtistDocumentSuccess",
+  isTypeOf: (data) => data._id,
+  fields: () => ({
+    document: {
+      type: PartnerDocumentType,
+      resolve: (document) => document,
+    },
+    partner: {
+      type: Partner.type,
+      resolve: ({ partnerId }, _args, { partnerLoader }) => {
+        return partnerLoader(partnerId)
+      },
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreatePartnerArtistDocumentFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "CreatePartnerArtistDocumentResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const createPartnerArtistDocumentMutation = mutationWithClientMutationId<
+  CreatePartnerArtistDocumentMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "CreatePartnerArtistDocumentMutation",
+  description: "Creates a partner artist document.",
+  inputFields: {
+    partnerId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the partner.",
+    },
+    artistId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the artist.",
+    },
+    remoteDocumentUrl: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The URL of the document to upload.",
+    },
+    title: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The title of the document.",
+    },
+  },
+  outputFields: {
+    documentOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the created document. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { partnerId, artistId, remoteDocumentUrl, title },
+    { createPartnerArtistDocumentLoader }
+  ) => {
+    if (!createPartnerArtistDocumentLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    const artistIdentifiers = { partnerID: partnerId, artistID: artistId }
+
+    const gravityArgs = {
+      remote_document_url: remoteDocumentUrl,
+      title,
+    }
+
+    try {
+      const response = await createPartnerArtistDocumentLoader(
+        artistIdentifiers,
+        gravityArgs
+      )
+
+      return { ...response, partnerId }
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/Mutations/PartnerArtist/deletePartnerArtistDocumentMutation.ts
+++ b/src/schema/v2/partner/Mutations/PartnerArtist/deletePartnerArtistDocumentMutation.ts
@@ -1,0 +1,107 @@
+import {
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { PartnerDocumentType } from "../../partnerDocumentsConnection"
+import Partner from "../../partner"
+
+interface DeletePartnerArtistDocumentMutationInputProps {
+  partnerId: string
+  artistId: string
+  documentId: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DeletePartnerArtistDocumentSuccess",
+  isTypeOf: (data) => data._id,
+  fields: () => ({
+    document: {
+      type: PartnerDocumentType,
+      resolve: (document) => document,
+    },
+    partner: {
+      type: Partner.type,
+      resolve: ({ partnerId }, _args, { partnerLoader }) => {
+        return partnerLoader(partnerId)
+      },
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DeletePartnerArtistDocumentFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "DeletePartnerArtistDocumentResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const deletePartnerArtistDocumentMutation = mutationWithClientMutationId<
+  DeletePartnerArtistDocumentMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "DeletePartnerArtistDocumentMutation",
+  description: "Deletes a partner artist document.",
+  inputFields: {
+    partnerId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the partner.",
+    },
+    artistId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the artist.",
+    },
+    documentId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the document to delete.",
+    },
+  },
+  outputFields: {
+    documentOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the deleted document. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { partnerId, artistId, documentId },
+    { deletePartnerArtistDocumentLoader }
+  ) => {
+    if (!deletePartnerArtistDocumentLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    const identifiers = { partnerID: partnerId, artistID: artistId, documentId }
+
+    try {
+      const response = await deletePartnerArtistDocumentLoader(identifiers)
+
+      return { ...response, partnerId }
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/Mutations/PartnerArtist/updatePartnerArtistDocumentMutation.ts
+++ b/src/schema/v2/partner/Mutations/PartnerArtist/updatePartnerArtistDocumentMutation.ts
@@ -1,0 +1,137 @@
+import {
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { PartnerDocumentType } from "../../partnerDocumentsConnection"
+import Partner from "../../partner"
+
+interface UpdatePartnerArtistDocumentMutationInputProps {
+  partnerId: string
+  artistId: string
+  documentId: string
+  title?: string
+  remoteDocumentUrl?: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdatePartnerArtistDocumentSuccess",
+  isTypeOf: (data) => data._id,
+  fields: () => ({
+    document: {
+      type: PartnerDocumentType,
+      resolve: (document) => document,
+    },
+    partner: {
+      type: Partner.type,
+      resolve: ({ partnerId }, _args, { partnerLoader }) => {
+        return partnerLoader(partnerId)
+      },
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdatePartnerArtistDocumentFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdatePartnerArtistDocumentResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const updatePartnerArtistDocumentMutation = mutationWithClientMutationId<
+  UpdatePartnerArtistDocumentMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "UpdatePartnerArtistDocumentMutation",
+  description: "Updates a partner artist document.",
+  inputFields: {
+    partnerId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the partner.",
+    },
+    artistId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the artist.",
+    },
+    documentId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the document to update.",
+    },
+    title: {
+      type: GraphQLString,
+      description: "The updated title of the document.",
+    },
+    remoteDocumentUrl: {
+      type: GraphQLString,
+      description: "The URL of the document to upload.",
+    },
+  },
+  outputFields: {
+    documentOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the updated document. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { partnerId, artistId, documentId, ...args },
+    { updatePartnerArtistDocumentLoader }
+  ) => {
+    if (!updatePartnerArtistDocumentLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    const identifiers = {
+      partnerId: partnerId,
+      artistId: artistId,
+      documentId: documentId,
+    }
+
+    const gravityArgs: {
+      title?: string
+      remoteDocumentUrl?: string
+    } = {}
+
+    if (args.title !== undefined) {
+      gravityArgs.title = args.title
+    }
+
+    if (args.remoteDocumentUrl !== undefined) {
+      gravityArgs.remoteDocumentUrl = args.remoteDocumentUrl
+    }
+
+    try {
+      const response = await updatePartnerArtistDocumentLoader(
+        identifiers,
+        gravityArgs
+      )
+
+      return { ...response, partnerId }
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -244,6 +244,9 @@ import { updateInstallShotForPartnerShowMutation } from "./Show/updateInstallSho
 import { updatePartnerShowMutation } from "./Show/updatePartnerShowMutation"
 import { updatePartnerShowEventMutation } from "./Show/updatePartnerShowEventMutation"
 import { updatePartnerShowDocumentMutation } from "./Show/updatePartnerShowDocumentMutation"
+import { createPartnerArtistDocumentMutation } from "./partner/Mutations/PartnerArtist/createPartnerArtistDocumentMutation"
+import { deletePartnerArtistDocumentMutation } from "./partner/Mutations/PartnerArtist/deletePartnerArtistDocumentMutation"
+import { updatePartnerArtistDocumentMutation } from "./partner/Mutations/PartnerArtist/updatePartnerArtistDocumentMutation"
 import { VerifyUser } from "./verifyUser"
 import { ArtistSeries, ArtistSeriesConnection } from "./artistSeries"
 import { homeViewSectionTypes } from "./homeView/sectionTypes"
@@ -491,6 +494,7 @@ export default new GraphQLSchema({
       createOrderedSet: createOrderedSetMutation,
       createPartnerContact: CreatePartnerContactMutation,
       createPartnerLocation: CreatePartnerLocationMutation,
+      createPartnerArtistDocument: createPartnerArtistDocumentMutation,
       createPartnerShow: createPartnerShowMutation,
       createPartnerShowDocument: createPartnerShowDocumentMutation,
       createPartnerShowEvent: createPartnerShowEventMutation,
@@ -518,6 +522,7 @@ export default new GraphQLSchema({
       deleteFeaturedLink: DeleteFeaturedLinkMutation,
       deleteHeroUnit: deleteHeroUnitMutation,
       deletePartnerContact: DeletePartnerContactMutation,
+      deletePartnerArtistDocument: deletePartnerArtistDocumentMutation,
       deletePartnerLocation: DeletePartnerLocationMutation,
       deletePartnerShow: deletePartnerShowMutation,
       deletePartnerShowDocument: deletePartnerShowDocumentMutation,
@@ -604,6 +609,7 @@ export default new GraphQLSchema({
       updateSaleAgreement: UpdateSaleAgreementMutation,
       updateSmsSecondFactor: updateSmsSecondFactorMutation,
       updateInstallShotForPartnerShow: updateInstallShotForPartnerShowMutation,
+      updatePartnerArtistDocument: updatePartnerArtistDocumentMutation,
       updatePartnerShowDocument: updatePartnerShowDocumentMutation,
       updatePartnerShowEvent: updatePartnerShowEventMutation,
       updateUser: updateUserMutation,


### PR DESCRIPTION
Boilerplate / following from the show documents mutations. Three new ones for managing (CRUD)