### PR TITLE
chore: add repositionPartnerArtistArtworks mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15556,6 +15556,11 @@ type Mutation {
     input: RepositionInstallShotsInPartnerShowMutationInput!
   ): RepositionInstallShotsInPartnerShowMutationPayload
 
+  # Reposition artworks for a partner artist, determining their display order.
+  repositionPartnerArtistArtworks(
+    input: RepositionPartnerArtistArtworksMutationInput!
+  ): RepositionPartnerArtistArtworksMutationPayload
+
   # Reposition partners locations in various CMS surfaces, settings, Artwork Form, etc.
   repositionPartnerLocations(
     input: RepositionPartnerLocationsMutationInput!
@@ -19784,6 +19789,35 @@ union RepositionInstallShotsInPartnerShowResponseOrError =
 
 type RepositionInstallShotsInPartnerShowSuccess {
   show: Show
+}
+
+type RepositionPartnerArtistArtworksFailure {
+  mutationError: GravityMutationError
+}
+
+input RepositionPartnerArtistArtworksMutationInput {
+  # The ID of the artist.
+  artistId: String!
+
+  # An ordered array of artwork IDs representing the new display order.
+  artworkIds: [String!]!
+  clientMutationId: String
+
+  # The ID of the partner.
+  partnerId: String!
+}
+
+type RepositionPartnerArtistArtworksMutationPayload {
+  clientMutationId: String
+  partnerOrError: RepositionPartnerArtistArtworksResponseOrError
+}
+
+union RepositionPartnerArtistArtworksResponseOrError =
+    RepositionPartnerArtistArtworksFailure
+  | RepositionPartnerArtistArtworksSuccess
+
+type RepositionPartnerArtistArtworksSuccess {
+  partner: Partner
 }
 
 type RepositionPartnerLocationsFailure {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -45,6 +45,15 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    repositionPartnerArtistArtworksLoader: gravityLoader<
+      any,
+      { artistId: string; partnerId: string }
+    >(
+      ({ artistId, partnerId }) =>
+        `partner/${partnerId}/artist/${artistId}/partner_artist_artworks/reposition`,
+      {},
+      { method: "POST" }
+    ),
     addInstallShotToPartnerShowLoader: gravityLoader<any, { showId: string }>(
       ({ showId }) => `partner_show/${showId}/image`,
       {},

--- a/src/schema/v2/partner/Mutations/PartnerArtist/__tests__/repositionPartnerArtistArtworksMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/PartnerArtist/__tests__/repositionPartnerArtistArtworksMutation.test.ts
@@ -1,0 +1,48 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("RepositionPartnerArtistArtworksMutation", () => {
+  const mutation = gql`
+    mutation {
+      repositionPartnerArtistArtworks(
+        input: {
+          partnerId: "partner123"
+          artistId: "artist123"
+          artworkIds: ["artwork1", "artwork2", "artwork3"]
+        }
+      ) {
+        partnerOrError {
+          __typename
+          ... on RepositionPartnerArtistArtworksSuccess {
+            partner {
+              name
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("repositions artworks for a partner artist", async () => {
+    const context = {
+      repositionPartnerArtistArtworksLoader: () =>
+        Promise.resolve({
+          id: "123",
+        }),
+      partnerLoader: () => Promise.resolve({ name: "Test Partner" }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      repositionPartnerArtistArtworks: {
+        partnerOrError: {
+          __typename: "RepositionPartnerArtistArtworksSuccess",
+          partner: {
+            name: "Test Partner",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/partner/Mutations/PartnerArtist/repositionPartnerArtistArtworksMutation.ts
+++ b/src/schema/v2/partner/Mutations/PartnerArtist/repositionPartnerArtistArtworksMutation.ts
@@ -1,0 +1,115 @@
+import {
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLUnionType,
+  GraphQLList,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import Partner from "../../partner"
+
+interface RepositionPartnerArtistArtworksMutationInputProps {
+  artistId: string
+  partnerId: string
+  artworkIds: string[]
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "RepositionPartnerArtistArtworksSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    partner: {
+      type: Partner.type,
+      resolve: ({ partnerId }, _args, { partnerLoader }) => {
+        return partnerLoader(partnerId)
+      },
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "RepositionPartnerArtistArtworksFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "RepositionPartnerArtistArtworksResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const repositionPartnerArtistArtworksMutation = mutationWithClientMutationId<
+  RepositionPartnerArtistArtworksMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "RepositionPartnerArtistArtworksMutation",
+  description:
+    "Reposition artworks for a partner artist, determining their display order.",
+  inputFields: {
+    artistId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the artist.",
+    },
+    partnerId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the partner.",
+    },
+    artworkIds: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(GraphQLString))
+      ),
+      description:
+        "An ordered array of artwork IDs representing the new display order.",
+    },
+  },
+  outputFields: {
+    partnerOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { artistId, partnerId, artworkIds },
+    { repositionPartnerArtistArtworksLoader }
+  ) => {
+    if (!repositionPartnerArtistArtworksLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    const identifiers = {
+      artistId,
+      partnerId,
+    }
+
+    const data = {
+      artwork_ids: artworkIds,
+    }
+
+    try {
+      const response = await repositionPartnerArtistArtworksLoader(
+        identifiers,
+        data
+      )
+
+      return { ...response, partnerId }
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -246,6 +246,7 @@ import { updatePartnerShowEventMutation } from "./Show/updatePartnerShowEventMut
 import { updatePartnerShowDocumentMutation } from "./Show/updatePartnerShowDocumentMutation"
 import { createPartnerArtistDocumentMutation } from "./partner/Mutations/PartnerArtist/createPartnerArtistDocumentMutation"
 import { deletePartnerArtistDocumentMutation } from "./partner/Mutations/PartnerArtist/deletePartnerArtistDocumentMutation"
+import { repositionPartnerArtistArtworksMutation } from "./partner/Mutations/PartnerArtist/repositionPartnerArtistArtworksMutation"
 import { updatePartnerArtistDocumentMutation } from "./partner/Mutations/PartnerArtist/updatePartnerArtistDocumentMutation"
 import { VerifyUser } from "./verifyUser"
 import { ArtistSeries, ArtistSeriesConnection } from "./artistSeries"
@@ -566,6 +567,7 @@ export default new GraphQLSchema({
       removeInstallShotFromPartnerShow: removeInstallShotFromPartnerShowMutation,
       repositionArtworksInPartnerShow: repositionArtworksInPartnerShowMutation,
       repositionInstallShotsInPartnerShow: repositionInstallShotsInPartnerShowMutation,
+      repositionPartnerArtistArtworks: repositionPartnerArtistArtworksMutation,
       repositionPartnerLocations: repositionPartnerLocationsMutation,
       requestCredentialsForAssetUpload: CreateAssetRequestLoader,
       requestPriceEstimate: requestPriceEstimateMutation,


### PR DESCRIPTION
Easy breezy boilerplate.

Depends on https://github.com/artsy/gravity/pull/18819 to accept `artwork_ids` .