### PR TITLE
feat(edition-sets): Expose listPrice for price ranges

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -20719,6 +20719,7 @@ interface Sellable {
   isOfferableFromInquiry: Boolean
   isPriceHidden: Boolean
   isSold: Boolean
+  listPrice: ListPrice
   priceListed: Money
   published: Boolean
   saleMessage: String

--- a/src/lib/stitching/vortex/__tests__/pricingContext.test.ts
+++ b/src/lib/stitching/vortex/__tests__/pricingContext.test.ts
@@ -157,14 +157,17 @@ describe("PricingContext type", () => {
         {
           size_score: 600,
           price_cents: [124, 235],
+          price_currency: "USD",
         },
         {
           size_score: 3000,
           price_cents: [154, 185],
+          price_currency: "USD",
         },
         {
           size_score: 10300,
           price_cents: [12443], // THIS ONE SHOULD BE CHOSEN
+          price_currency: "USD",
         },
       ],
     })
@@ -185,14 +188,17 @@ describe("PricingContext type", () => {
         {
           size_score: 600,
           price_cents: [124, 235],
+          price_currency: "USD",
         },
         {
           size_score: 3000,
           price_cents: [154, 18555], // THIS ONE SHOULD BE CHOSEN
+          price_currency: "USD",
         },
         {
           size_score: 10300,
           price_cents: [12443],
+          price_currency: "USD",
         },
       ],
     })

--- a/src/schema/v2/fields/listPrice.ts
+++ b/src/schema/v2/fields/listPrice.ts
@@ -15,7 +15,7 @@ const PriceRange = new GraphQLObjectType({
     minPrice: {
       type: Money,
       resolve: ({ minPriceCents, price_currency }) => {
-        if (!minPriceCents) return null
+        if (!minPriceCents || !price_currency) return null
         return {
           cents: minPriceCents,
           currency: price_currency,
@@ -25,7 +25,7 @@ const PriceRange = new GraphQLObjectType({
     maxPrice: {
       type: Money,
       resolve: ({ maxPriceCents, price_currency }) => {
-        if (!maxPriceCents) return null
+        if (!maxPriceCents || !price_currency) return null
         return {
           cents: maxPriceCents,
           currency: price_currency,

--- a/src/schema/v2/sellable.ts
+++ b/src/schema/v2/sellable.ts
@@ -3,6 +3,7 @@ import { GraphQLBoolean, GraphQLInterfaceType, GraphQLString } from "graphql"
 import Dimensions from "./dimensions"
 import { InternalIDFields } from "./object_identification"
 import { Money } from "./fields/money"
+import { listPrice } from "./fields/listPrice"
 
 export const Sellable = new GraphQLInterfaceType({
   name: "Sellable",
@@ -80,6 +81,7 @@ export const sharedSellableFields = {
   priceListed: {
     type: Money,
   },
+  listPrice,
   published: {
     type: GraphQLBoolean,
   },


### PR DESCRIPTION
Noticed this wasn't exposed, and also fixes a bug in `listPrice` where if there's no `price_currency` set, don't resolve. ListPrice (and further down, Money) has a hard requirement that it is there. 

cc @artsy/amber-devs 