### PR TITLE
chore: adding match endpoint for partners

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -19025,6 +19025,12 @@ type Query {
     size: Int = 10
     term: String!
   ): MatchConnection
+
+  # A Search for Artists
+  matchPartner(
+    # Your search term
+    query: String!
+  ): [Partner]
   me: Me
 
   # Fetches an object given its globally unique ID.
@@ -24332,6 +24338,12 @@ type Viewer {
     size: Int = 10
     term: String!
   ): MatchConnection
+
+  # A Search for Artists
+  matchPartner(
+    # Your search term
+    query: String!
+  ): [Partner]
   me: Me
 
   # Fetches an object given its globally unique ID.

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -717,6 +717,9 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    matchPartnerLoader: gravityLoader<any, { term: string }>(
+      ({ term }) => `/match/partners?term=${term}&size=10`
+    ),
     matchProfilesLoader: gravityLoader("match/profiles", {}, { headers: true }),
     matchSalesLoader: gravityLoader("match/sales", {}, { headers: true }),
     matchSetsLoader: gravityLoader("match/sets", {}, { headers: true }),

--- a/src/schema/v2/match/__tests__/partner.test.js
+++ b/src/schema/v2/match/__tests__/partner.test.js
@@ -1,0 +1,25 @@
+/* eslint-disable promise/always-return */
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("matchPartner", () => {
+  it("queries match/partner for the term 'Gallery'", async () => {
+    const query = gql`
+      {
+        matchPartner(query: "Gallery") {
+          name
+        }
+      }
+    `
+
+    const partner = { name: "John Gallery" }
+    const context = {
+      matchPartnerLoader: jest.fn().mockResolvedValue([partner]),
+    }
+
+    const data = await runAuthenticatedQuery(query, context)
+    expect(data).toEqual({
+      matchPartner: [{ name: "John Gallery" }],
+    })
+  })
+})

--- a/src/schema/v2/match/partner.ts
+++ b/src/schema/v2/match/partner.ts
@@ -1,0 +1,28 @@
+import {
+  GraphQLFieldConfig,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLString,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import Partner from "../partner/partner"
+
+export const PartnerMatch: GraphQLFieldConfig<void, ResolverContext> = {
+  type: new GraphQLList(Partner.type),
+  description: "A Search for Artists",
+  args: {
+    query: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "Your search term",
+    },
+  },
+  resolve: async (_root, { query }, { matchPartnerLoader }) => {
+    if (!matchPartnerLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    const partners = await matchPartnerLoader({ term: query })
+
+    return partners
+  },
+}

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -309,6 +309,7 @@ import { unsetOrderFulfillmentOptionMutation } from "./order/unsetOrderFulfillme
 import { UpdatePartnerLocationMutation } from "./partner/Settings/updatePartnerLocationMutation"
 import { DeletePartnerLocationMutation } from "./partner/Settings/deletePartnerLocationMutation"
 import { repositionPartnerLocationsMutation } from "./partner/Settings/repositionPartnerLocations"
+import { PartnerMatch } from "./match/partner"
 
 const rootFields = {
   // artworkVersion: ArtworkVersionResolver,
@@ -387,6 +388,7 @@ const rootFields = {
   saleAgreementsConnection: SaleAgreementsConnection,
   markdown: MarkdownContent,
   matchArtist: MatchArtist,
+  matchPartner: PartnerMatch,
   matchConnection: MatchConnection,
   marketingCollection: MarketingCollection,
   marketingCollections: MarketingCollections,


### PR DESCRIPTION
This adds a new endpoint mapping to the [partner match endpoint](https://github.com/artsy/gravity/blob/40dab2533b4628f9cc7a48d42bf354c356326e56/app/api/v1/match_endpoint.rb#L40-L70) in gravity. This will be used to recreate the [partner selections page](https://cms-staging.artsy.net/partner_selections) in Volt

### Example Request

```
{
  matchPartner(query:"Gallery"){
    name
    id
    ... on Partner{
      meta {
        image
      }
    }
  }
}
```

### Example Response

```
{
  "data": {
    "matchPartner": [
      {
        "name": "&Gallery",
        "id": "UGFydG5lcjo1YTk1NmVlZTljMThkYjUzMDljMDc0ZjI=",
        "meta": {
          "image": "https://d32dm0rphc51dk.cloudfront.net/7Vcr5HFjhEGAul-skkNi3Q/square140.png"
        }
      },
      {
        "name": "CHROMA GALLERY",
        "id": "UGFydG5lcjo1OTU2ZDBiMzljMThkYjNjODcyOWIzYjY=",
        "meta": {
          "image": "https://d32dm0rphc51dk.cloudfront.net/CIveNUM3si1Zfq4bNZOWjA/square140.png"
        }
      },
      {
        "name": "AD Gallery",
        "id": "UGFydG5lcjo2MDkyYWMxYTJmM2RiMjAwMGZmNjZkNGY=",
        "meta": {
          "image": null
        }
      },
      {
        "name": "FREMIN GALLERY",
        "id": "UGFydG5lcjo1MjQyZWQ3MmI1MDRmNTBhZmMwMDAwNTE=",
        "meta": {
          "image": "https://d32dm0rphc51dk.cloudfront.net/m4maKXjhHlJ8OnsCrsf0Jw/square140.png"
        }
      },
      {
        "name": "Locks Gallery",
        "id": "UGFydG5lcjo1MzYyYjkxODI3NWIyNDA3YmYwMDAxZTU=",
        "meta": {
          "image": "https://d32dm0rphc51dk.cloudfront.net/HoQOh-07TlqOrwJcgoeDXQ/square140.png"
        }
      },
      {
        "name": "Gallery 38",
        "id": "UGFydG5lcjo1N2UzODRlZmM5ZGMyNDJjZDcwMDE5NzE=",
        "meta": {
          "image": "https://d32dm0rphc51dk.cloudfront.net/U481S7S7PpmGUIzjIZvBtg/square140.png"
        }
      },
      {
        "name": "T Gallery",
        "id": "UGFydG5lcjo2NjJiYjFmM2NjNGZiNjAwMGY5ODllY2Y=",
        "meta": {
          "image": "https://d32dm0rphc51dk.cloudfront.net/sSPo2Fd3Tz5K7DR89UVRNA/square140.png"
        }
      },
      {
        "name": "Casemore Gallery",
        "id": "UGFydG5lcjo1NTM3ZWI2ZTc3NmY3MjcyYzczZTAwMDA=",
        "meta": {
          "image": "https://d32dm0rphc51dk.cloudfront.net/OBUE4FnZ29h6xNrvwRkwlA/square140.png"
        }
      },
      {
        "name": "Havet Gallery.",
        "id": "UGFydG5lcjo1Zjk2YWY3NjMxODdiMDAwMTEyZmJmYTg=",
        "meta": {
          "image": "https://d32dm0rphc51dk.cloudfront.net/Eu3GVNx8M5lP0S94ic_lPA/square140.png"
        }
      },
      {
        "name": "22Muse Gallery",
        "id": "UGFydG5lcjo2N2VhNGZjYzVhOWMxYjU1NTI3Nzk1YmE=",
        "meta": {
          "image": null
        }
      }
    ]
  }
}
```