### PR TITLE
feat(sellable): Add listingOptions CMS pass-through

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2762,9 +2762,6 @@ type Artwork implements Node & Searchable & Sellable {
   isComparableWithAuctionResults: Boolean
   isDisliked: Boolean!
   isDownloadable: Boolean
-
-  # Whether this artwork is eligible for an ecommerce transaction
-  isEcommerce: Boolean
   isEdition: Boolean
 
   # Artwork is eligible for the Artsy Guarantee
@@ -2847,6 +2844,9 @@ type Artwork implements Node & Searchable & Sellable {
     first: Int
     last: Int
   ): ArtworkConnection!
+
+  # In CMS, has the artwork been marked as BNMO?
+  listingOptions: ArtworkListingOptions
   literature(format: Format): String
 
   # Represents partner's location
@@ -3354,6 +3354,11 @@ type ArtworkLayer {
   internalID: ID!
   name: String
   type: String
+}
+
+type ArtworkListingOptions {
+  isBuyNow: Boolean
+  isMakeOffer: Boolean
 }
 
 # Collection of fields that describe medium type, such as _Painting_. (This field is also commonly referred to as just "medium", but should not be confused with the artwork attribute called `medium`.)
@@ -10479,7 +10484,6 @@ type EditionSet implements Sellable {
   internalID: ID!
   inventory: EditionSetInventory
   isAcquireable: Boolean
-  isEcommerce: Boolean
   isForSale: Boolean
 
   # Is the edition set parent-artwork part of an auction?
@@ -10492,6 +10496,9 @@ type EditionSet implements Sellable {
   isPriceHidden: Boolean
   isSold: Boolean
   listPrice: ListPrice
+
+  # In CMS, has the artwork been marked as BNMO?
+  listingOptions: ArtworkListingOptions
   price: String
   priceDisplay: String
   priceListed: Money
@@ -20752,7 +20759,6 @@ interface Sellable {
 
   # Whether a piece can be purchased through e-commerce
   isAcquireable: Boolean
-  isEcommerce: Boolean
   isForSale: Boolean
   isInAuction: Boolean
   isInquireable: Boolean
@@ -20765,6 +20771,9 @@ interface Sellable {
   isPriceHidden: Boolean
   isSold: Boolean
   listPrice: ListPrice
+
+  # In CMS, has the artwork been marked as BNMO?
+  listingOptions: ArtworkListingOptions
   priceListed: Money
   published: Boolean
   saleMessage: String

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -99,6 +99,7 @@ import { ArtworkVisibility } from "./artworkVisibility"
 import { ArtworkConditionType } from "./artworkCondition"
 import { CollectorSignals } from "./collectorSignals"
 import { ArtistSeriesConnectionType } from "../artistSeries"
+import { listingOptions } from "./listingOptions"
 
 const has_price_range = (price) => {
   return new RegExp(/-/).test(price)
@@ -923,12 +924,6 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           return comparables_count > 0 && category !== "Architecture"
         },
       },
-      isEcommerce: {
-        type: GraphQLBoolean,
-        description:
-          "Whether this artwork is eligible for an ecommerce transaction",
-        resolve: ({ ecommerce }) => ecommerce,
-      },
       isDownloadable: {
         type: GraphQLBoolean,
         resolve: ({ images }) => !!(_.first(images) && images[0].downloadable),
@@ -1182,6 +1177,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       literature: markdown(({ literature }) =>
         literature.replace(/^literature:\s+/i, "")
       ),
+      listingOptions,
       location: {
         type: LocationType,
         resolve: ({ location }) => location,

--- a/src/schema/v2/artwork/listingOptions.ts
+++ b/src/schema/v2/artwork/listingOptions.ts
@@ -1,0 +1,20 @@
+import { GraphQLBoolean, GraphQLObjectType } from "graphql"
+import { ResolverContext } from "types/graphql"
+
+export const listingOptions = {
+  description: "In CMS, has the artwork been marked as BNMO?",
+  type: new GraphQLObjectType<any, ResolverContext>({
+    name: "ArtworkListingOptions",
+    fields: {
+      isBuyNow: {
+        type: GraphQLBoolean,
+        resolve: ({ ecommerce }) => !!ecommerce,
+      },
+      isMakeOffer: {
+        type: GraphQLBoolean,
+        resolve: ({ offer }) => !!offer,
+      },
+    },
+  }),
+  resolve: (artwork) => artwork,
+}

--- a/src/schema/v2/edition_set.ts
+++ b/src/schema/v2/edition_set.ts
@@ -16,6 +16,7 @@ import { ResolverContext } from "types/graphql"
 import { listPrice } from "./fields/listPrice"
 import { Money } from "./fields/money"
 import currencyCodes from "lib/currency_codes.json"
+import { listingOptions } from "./artwork/listingOptions"
 
 export const EditionSetSorts = {
   type: new GraphQLEnumType({
@@ -133,10 +134,6 @@ export const EditionSetType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLBoolean,
       resolve: ({ acquireable }) => acquireable,
     },
-    isEcommerce: {
-      type: GraphQLBoolean,
-      resolve: ({ ecommerce }) => ecommerce,
-    },
     isForSale: {
       type: GraphQLBoolean,
       resolve: ({ forsale }) => forsale,
@@ -178,6 +175,7 @@ export const EditionSetType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLBoolean,
       resolve: ({ sold }) => sold,
     },
+    listingOptions,
     listPrice,
     price: {
       type: GraphQLString,

--- a/src/schema/v2/sellable.ts
+++ b/src/schema/v2/sellable.ts
@@ -4,6 +4,7 @@ import Dimensions from "./dimensions"
 import { InternalIDFields } from "./object_identification"
 import { Money } from "./fields/money"
 import { listPrice } from "./fields/listPrice"
+import { listingOptions } from "./artwork/listingOptions"
 
 export const Sellable = new GraphQLInterfaceType({
   name: "Sellable",
@@ -63,9 +64,6 @@ export const sharedSellableFields = {
   internalDisplayPrice: {
     type: GraphQLString,
   },
-  isEcommerce: {
-    type: GraphQLBoolean,
-  },
   isInAuction: {
     type: GraphQLBoolean,
   },
@@ -82,6 +80,7 @@ export const sharedSellableFields = {
     type: Money,
   },
   listPrice,
+  listingOptions,
   published: {
     type: GraphQLBoolean,
   },


### PR DESCRIPTION
With the `isEcommerce` option being better understood, this should more accurately be reflected via the `listingOptions` props on the artwork model, which directly point to:

- ecommerce -> isBuyNow
- offer -> isMakeOffer

So this updates things and passes it through:

```
query Artwork {
  artwork(id: "hi") {
    listingOptions {
      isBuyNow
      isMakeOffer
    }
  }
}
```
cc @artsy/amber-devs 