### PR TITLE
chore: Add mutation to update partner flags

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -22668,13 +22668,21 @@ type UpdatePartnerFlagsFailure {
 }
 
 input UpdatePartnerFlagsMutationInput {
-  clientMutationId: String
+  # The default currency to use for artworks. If null, the flag will be unset.
+  artworksDefaultCurrency: String
 
-  # An object containing flag keys and values to update. If a value is empty, the flag will be unset.
-  flags: JSON!
+  # The default metric system to use for artworks. If null, the flag will be unset.
+  artworksDefaultMetric: String
+
+  # The default partner location ID to use for artworks. If null, the flag will be unset.
+  artworksDefaultPartnerLocationId: String
+  clientMutationId: String
 
   # The id of the partner to update.
   id: String!
+
+  # Controls whether the partner has enabled the inquire availability price display. If null, the flag will be unset.
+  inquireAvailabilityPriceDisplayEnabledByPartner: Boolean
 }
 
 type UpdatePartnerFlagsMutationPayload {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15787,6 +15787,11 @@ type Mutation {
     input: UpdatePartnerContactInput!
   ): UpdatePartnerContactPayload
 
+  # Updates multiple flags on a partner simultaneously.
+  updatePartnerFlags(
+    input: UpdatePartnerFlagsMutationInput!
+  ): UpdatePartnerFlagsMutationPayload
+
   # Updates a new location for a partner
   updatePartnerLocation(
     input: UpdatePartnerLocationInput!
@@ -22656,6 +22661,35 @@ type UpdatePartnerContactPayload {
 
 type UpdatePartnerContactSuccess {
   partnerContact: Contact
+}
+
+type UpdatePartnerFlagsFailure {
+  mutationError: GravityMutationError
+}
+
+input UpdatePartnerFlagsMutationInput {
+  clientMutationId: String
+
+  # An object containing flag keys and values to update. If a value is empty, the flag will be unset.
+  flags: JSON!
+
+  # The id of the partner to update.
+  id: String!
+}
+
+type UpdatePartnerFlagsMutationPayload {
+  clientMutationId: String
+
+  # On success: the updated partner. On error: the error that occurred.
+  partnerOrError: UpdatePartnerFlagsResponseOrError
+}
+
+union UpdatePartnerFlagsResponseOrError =
+    UpdatePartnerFlagsFailure
+  | UpdatePartnerFlagsSuccess
+
+type UpdatePartnerFlagsSuccess {
+  partner: Partner
 }
 
 type UpdatePartnerLocationFailure {

--- a/src/schema/v2/partner/__tests__/updatePartnerFlagsMutation.test.ts
+++ b/src/schema/v2/partner/__tests__/updatePartnerFlagsMutation.test.ts
@@ -1,0 +1,76 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("UpdatePartnerFlagsMutation", () => {
+  const mutation = gql`
+    mutation {
+      updatePartnerFlags(input: { id: "partner-id", flags: { feature_1: "enabled", feature_2: "" } }) {
+        partnerOrError {
+          __typename
+          ... on UpdatePartnerFlagsSuccess {
+            partner {
+              internalID
+            }
+          }
+          ... on UpdatePartnerFlagsFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("updates multiple partner flags", async () => {
+    const context = {
+      updatePartnerFlagsLoader: jest.fn((id, { flags }) => {
+        expect(id).toEqual("partner-id")
+        expect(flags).toEqual({ feature_1: "enabled", feature_2: "" })
+        return Promise.resolve({
+          _id: "partner-id",
+        })
+      }),
+    }
+
+    const updatedPartner = await runAuthenticatedQuery(mutation, context)
+
+    expect(updatedPartner).toEqual({
+      updatePartnerFlags: {
+        partnerOrError: {
+          __typename: "UpdatePartnerFlagsSuccess",
+          partner: {
+            internalID: "partner-id",
+          },
+        },
+      },
+    })
+  })
+
+  describe("when failure", () => {
+    it("returns an error", async () => {
+      const context = {
+        updatePartnerFlagsLoader: jest.fn((_id, _params) =>
+          Promise.reject(
+            new Error(
+              `https://stagingapi.artsy.net/api/v1/partner/partner-id/partner_flags - {"type":"error","message":"Error updating partner flags"}`
+            )
+          )
+        ),
+      }
+
+      const updatedPartner = await runAuthenticatedQuery(mutation, context)
+
+      expect(updatedPartner).toEqual({
+        updatePartnerFlags: {
+          partnerOrError: {
+            __typename: "UpdatePartnerFlagsFailure",
+            mutationError: {
+              message: "Error updating partner flags",
+            },
+          },
+        },
+      })
+    })
+  })
+})

--- a/src/schema/v2/partner/__tests__/updatePartnerFlagsMutation.test.ts
+++ b/src/schema/v2/partner/__tests__/updatePartnerFlagsMutation.test.ts
@@ -1,53 +1,227 @@
 import gql from "lib/gql"
-import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import { runAuthenticatedQuery, runQuery } from "schema/v2/test/utils"
 
 describe("UpdatePartnerFlagsMutation", () => {
-  const mutation = gql`
-    mutation {
-      updatePartnerFlags(input: { id: "partner-id", flags: { feature_1: "enabled", feature_2: "" } }) {
-        partnerOrError {
-          __typename
-          ... on UpdatePartnerFlagsSuccess {
-            partner {
-              internalID
-            }
+  describe("with all flag types", () => {
+    const mutationWithAllFlags = gql`
+      mutation {
+        updatePartnerFlags(
+          input: { 
+            id: "partner-id", 
+            inquireAvailabilityPriceDisplayEnabledByPartner: true,
+            artworksDefaultMetric: "cm",
+            artworksDefaultCurrency: "USD",
+            artworksDefaultPartnerLocationId: "location-1"
           }
-          ... on UpdatePartnerFlagsFailure {
-            mutationError {
-              message
+        ) {
+          partnerOrError {
+            __typename
+            ... on UpdatePartnerFlagsSuccess {
+              partner {
+                internalID
+              }
+            }
+            ... on UpdatePartnerFlagsFailure {
+              mutationError {
+                message
+              }
             }
           }
         }
       }
-    }
-  `
+    `
 
-  it("updates multiple partner flags", async () => {
-    const context = {
-      updatePartnerFlagsLoader: jest.fn((id, { flags }) => {
-        expect(id).toEqual("partner-id")
-        expect(flags).toEqual({ feature_1: "enabled", feature_2: "" })
-        return Promise.resolve({
-          _id: "partner-id",
-        })
-      }),
-    }
+    it("updates all partner flags", async () => {
+      const context = {
+        updatePartnerFlagsLoader: jest.fn((id, { flags }) => {
+          expect(id).toEqual("partner-id")
+          expect(flags).toEqual({
+            inquire_availability_price_display_enabled_by_partner: true,
+            artworks_default_metric: "cm",
+            artworks_default_currency: "USD",
+            artworks_default_partner_location_id: "location-1"
+          })
+          return Promise.resolve({
+            _id: "partner-id",
+          })
+        }),
+      }
 
-    const updatedPartner = await runAuthenticatedQuery(mutation, context)
+      const updatedPartner = await runAuthenticatedQuery(mutationWithAllFlags, context)
 
-    expect(updatedPartner).toEqual({
-      updatePartnerFlags: {
-        partnerOrError: {
-          __typename: "UpdatePartnerFlagsSuccess",
-          partner: {
-            internalID: "partner-id",
+      expect(updatedPartner).toEqual({
+        updatePartnerFlags: {
+          partnerOrError: {
+            __typename: "UpdatePartnerFlagsSuccess",
+            partner: {
+              internalID: "partner-id",
+            },
           },
         },
-      },
+      })
     })
   })
 
-  describe("when failure", () => {
+  describe("with subset of flags", () => {
+    const mutationWithSubsetOfFlags = gql`
+      mutation {
+        updatePartnerFlags(
+          input: { 
+            id: "partner-id", 
+            inquireAvailabilityPriceDisplayEnabledByPartner: true,
+            artworksDefaultCurrency: "EUR"
+          }
+        ) {
+          partnerOrError {
+            __typename
+            ... on UpdatePartnerFlagsSuccess {
+              partner {
+                internalID
+              }
+            }
+          }
+        }
+      }
+    `
+
+    it("updates only specified partner flags", async () => {
+      const context = {
+        updatePartnerFlagsLoader: jest.fn((id, { flags }) => {
+          expect(id).toEqual("partner-id")
+          expect(flags).toEqual({
+            inquire_availability_price_display_enabled_by_partner: true,
+            artworks_default_currency: "EUR"
+          })
+          // Make sure other flags are not included
+          expect(flags).not.toHaveProperty("artworks_default_metric")
+          expect(flags).not.toHaveProperty("artworks_default_partner_location_id")
+          return Promise.resolve({
+            _id: "partner-id",
+          })
+        }),
+      }
+
+      const updatedPartner = await runAuthenticatedQuery(mutationWithSubsetOfFlags, context)
+
+      expect(updatedPartner).toEqual({
+        updatePartnerFlags: {
+          partnerOrError: {
+            __typename: "UpdatePartnerFlagsSuccess",
+            partner: {
+              internalID: "partner-id",
+            },
+          },
+        },
+      })
+    })
+  })
+
+  describe("with null flag values", () => {
+    const mutationWithNullFlags = gql`
+      mutation {
+        updatePartnerFlags(
+          input: { 
+            id: "partner-id", 
+            inquireAvailabilityPriceDisplayEnabledByPartner: null,
+            artworksDefaultMetric: null
+          }
+        ) {
+          partnerOrError {
+            __typename
+            ... on UpdatePartnerFlagsSuccess {
+              partner {
+                internalID
+              }
+            }
+          }
+        }
+      }
+    `
+
+    it("unsets flags when explicitly set to null", async () => {
+      const context = {
+        updatePartnerFlagsLoader: jest.fn((id, { flags }) => {
+          expect(id).toEqual("partner-id")
+          expect(flags).toEqual({
+            inquire_availability_price_display_enabled_by_partner: null,
+            artworks_default_metric: null
+          })
+          return Promise.resolve({
+            _id: "partner-id",
+          })
+        }),
+      }
+
+      const updatedPartner = await runAuthenticatedQuery(mutationWithNullFlags, context)
+
+      expect(updatedPartner).toEqual({
+        updatePartnerFlags: {
+          partnerOrError: {
+            __typename: "UpdatePartnerFlagsSuccess",
+            partner: {
+              internalID: "partner-id",
+            },
+          },
+        },
+      })
+    })
+  })
+
+  describe("with no authorization", () => {
+    const mutation = gql`
+      mutation {
+        updatePartnerFlags(
+          input: { 
+            id: "partner-id", 
+            inquireAvailabilityPriceDisplayEnabledByPartner: true
+          }
+        ) {
+          partnerOrError {
+            __typename
+            ... on UpdatePartnerFlagsFailure {
+              mutationError {
+                message
+              }
+            }
+          }
+        }
+      }
+    `
+
+    it("returns an authorization error when no loader is available", async () => {
+      // Use runQuery without any loaders to simulate unauthenticated request
+      try {
+        await runQuery(mutation, {})
+        // If we get here, the test should fail
+        throw new Error("An error was not thrown but was expected")
+      } catch (error) {
+        // Verify the error is related to authentication
+        expect(error.message).toContain("signed in")
+      }
+    })
+  })
+
+  describe("when API failure occurs", () => {
+    const mutation = gql`
+      mutation {
+        updatePartnerFlags(
+          input: { 
+            id: "partner-id", 
+            inquireAvailabilityPriceDisplayEnabledByPartner: true
+          }
+        ) {
+          partnerOrError {
+            __typename
+            ... on UpdatePartnerFlagsFailure {
+              mutationError {
+                message
+              }
+            }
+          }
+        }
+      }
+    `
+
     it("returns an error", async () => {
       const context = {
         updatePartnerFlagsLoader: jest.fn((_id, _params) =>

--- a/src/schema/v2/partner/updatePartnerFlagsMutation.ts
+++ b/src/schema/v2/partner/updatePartnerFlagsMutation.ts
@@ -3,6 +3,7 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLUnionType,
+  GraphQLBoolean,
 } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 import {
@@ -11,11 +12,13 @@ import {
 } from "lib/gravityErrorHandler"
 import Partner from "./partner"
 import { ResolverContext } from "types/graphql"
-import GraphQLJSON from "graphql-type-json"
 
 interface UpdatePartnerFlagsMutationInputProps {
   id: string
-  flags: Record<string, string>
+  inquireAvailabilityPriceDisplayEnabledByPartner?: boolean | null
+  artworksDefaultMetric?: string | null
+  artworksDefaultCurrency?: string | null
+  artworksDefaultPartnerLocationId?: string | null
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
@@ -57,9 +60,21 @@ export const updatePartnerFlagsMutation = mutationWithClientMutationId<
       type: new GraphQLNonNull(GraphQLString),
       description: "The id of the partner to update.",
     },
-    flags: {
-      type: new GraphQLNonNull(GraphQLJSON),
-      description: "An object containing flag keys and values to update. If a value is empty, the flag will be unset.",
+    inquireAvailabilityPriceDisplayEnabledByPartner: {
+      type: GraphQLBoolean,
+      description: "Controls whether the partner has enabled the inquire availability price display. If null, the flag will be unset.",
+    },
+    artworksDefaultMetric: {
+      type: GraphQLString,
+      description: "The default metric system to use for artworks. If null, the flag will be unset.",
+    },
+    artworksDefaultCurrency: {
+      type: GraphQLString,
+      description: "The default currency to use for artworks. If null, the flag will be unset.",
+    },
+    artworksDefaultPartnerLocationId: {
+      type: GraphQLString,
+      description: "The default partner location ID to use for artworks. If null, the flag will be unset.",
     },
   },
   outputFields: {
@@ -70,12 +85,38 @@ export const updatePartnerFlagsMutation = mutationWithClientMutationId<
       resolve: (result) => result,
     },
   },
-  mutateAndGetPayload: async ({ id, flags }, { updatePartnerFlagsLoader }) => {
+  mutateAndGetPayload: async ({ 
+    id, 
+    inquireAvailabilityPriceDisplayEnabledByPartner, 
+    artworksDefaultMetric,
+    artworksDefaultCurrency,
+    artworksDefaultPartnerLocationId
+  }, { updatePartnerFlagsLoader }) => {
     if (!updatePartnerFlagsLoader) {
       return new Error("You need to be signed in to perform this action")
     }
 
     try {
+      // Convert camelCase inputs to snake_case flags
+      const flags = {}
+      
+      // Only include the flags if they're being set or explicitly unset
+      if (inquireAvailabilityPriceDisplayEnabledByPartner !== undefined) {
+        flags["inquire_availability_price_display_enabled_by_partner"] = inquireAvailabilityPriceDisplayEnabledByPartner
+      }
+      
+      if (artworksDefaultMetric !== undefined) {
+        flags["artworks_default_metric"] = artworksDefaultMetric
+      }
+      
+      if (artworksDefaultCurrency !== undefined) {
+        flags["artworks_default_currency"] = artworksDefaultCurrency
+      }
+      
+      if (artworksDefaultPartnerLocationId !== undefined) {
+        flags["artworks_default_partner_location_id"] = artworksDefaultPartnerLocationId
+      }
+
       const response = await updatePartnerFlagsLoader(id, { flags })
       return response
     } catch (error) {

--- a/src/schema/v2/partner/updatePartnerFlagsMutation.ts
+++ b/src/schema/v2/partner/updatePartnerFlagsMutation.ts
@@ -1,0 +1,90 @@
+import {
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import Partner from "./partner"
+import { ResolverContext } from "types/graphql"
+import GraphQLJSON from "graphql-type-json"
+
+interface UpdatePartnerFlagsMutationInputProps {
+  id: string
+  flags: Record<string, string>
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdatePartnerFlagsSuccess",
+  isTypeOf: (data) => data._id,
+  fields: () => ({
+    partner: {
+      type: Partner.type,
+      resolve: (partner) => partner,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdatePartnerFlagsFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdatePartnerFlagsResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const updatePartnerFlagsMutation = mutationWithClientMutationId<
+  UpdatePartnerFlagsMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "UpdatePartnerFlagsMutation",
+  description: "Updates multiple flags on a partner simultaneously.",
+  inputFields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The id of the partner to update.",
+    },
+    flags: {
+      type: new GraphQLNonNull(GraphQLJSON),
+      description: "An object containing flag keys and values to update. If a value is empty, the flag will be unset.",
+    },
+  },
+  outputFields: {
+    partnerOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the updated partner. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async ({ id, flags }, { updatePartnerFlagsLoader }) => {
+    if (!updatePartnerFlagsLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const response = await updatePartnerFlagsLoader(id, { flags })
+      return response
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -194,6 +194,7 @@ import { UpdatePageMutation } from "./Page/UpdatePageMutation"
 import { PartnerArtistDocumentsConnection } from "./partner/partnerArtistDocumentsConnection"
 import { PartnerShowDocumentsConnection } from "./partner/partnerShowDocumentsConnection"
 import { updateCMSLastAccessTimestampMutation } from "./partner/updateCMSLastAccessTimestampMutation"
+import { updatePartnerFlagsMutation } from "./partner/updatePartnerFlagsMutation"
 import { PaymentMethodUnion, WireTransferType } from "./payment_method_union"
 import { PhoneNumber } from "./phoneNumber"
 import { PreviewSavedSearchField } from "./previewSavedSearch"
@@ -620,6 +621,7 @@ export default new GraphQLSchema({
       updatePartnerArtistDocument: updatePartnerArtistDocumentMutation,
       updatePartnerShowDocument: updatePartnerShowDocumentMutation,
       updatePartnerShowEvent: updatePartnerShowEventMutation,
+      updatePartnerFlags: updatePartnerFlagsMutation,
       updateUser: updateUserMutation,
       updateUserInterest: updateUserInterestMutation,
       updateUserInterests: updateUserInterestsMutation,


### PR DESCRIPTION
This PR takes the work done over on this one: https://github.com/artsy/gravity/pull/18820 and uses it to create a general purpose mutation that can update multiple partner flags. I'll use this mutation in the work I'm doing to migrate the CMS preferences page.

I worked with Claude to do this so I'm not 100% sure if it's following patterns/best practices so def open to feedback!!

/cc @artsy/amber-devs