### PR TITLE
feat(onyx-1663): purchasesConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -18387,6 +18387,8 @@ type Purchase implements Node {
     # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String
+
+  # Person who found the sale
   discoverAdmin: User
   email: String
   fair: Fair
@@ -18399,6 +18401,8 @@ type Purchase implements Node {
   note: String
   ownerType: String
   sale: Sale
+
+  # Person who facilitated the sale
   saleAdmin: User
   saleDate(
     format: String
@@ -19579,9 +19583,11 @@ type Query {
     before: String
     first: Int
     last: Int
+    page: Int
 
     # The ID of the sale to filter purchases by.
     saleId: String
+    size: Int
 
     # The ID of the user to filter purchases by.
     userId: String
@@ -25103,9 +25109,11 @@ type Viewer {
     before: String
     first: Int
     last: Int
+    page: Int
 
     # The ID of the sale to filter purchases by.
     saleId: String
+    size: Int
 
     # The ID of the user to filter purchases by.
     userId: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -18378,6 +18378,59 @@ type PublishViewingRoomPayload {
   viewingRoom: ViewingRoom!
 }
 
+type Purchase implements Node {
+  artsyCommission: Float
+  artwork: Artwork
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+  discoverAdmin: User
+  email: String
+  fair: Fair
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID.
+  internalID: ID!
+  note: String
+  ownerType: String
+  sale: Sale
+  saleAdmin: User
+  saleDate(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+  salePrice: Float
+  source: String
+  user: User
+}
+
+# A connection to a list of items.
+type PurchasesConnection {
+  # A list of edges.
+  edges: [PurchasesEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type PurchasesEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: Purchase
+}
+
 type Query {
   # Do not use (only used internally for stitching)
   _do_not_use_conversation(
@@ -19513,6 +19566,26 @@ type Query {
     # If present, will search by term
     term: String
   ): ProfileConnection
+
+  # A list of purchases made by users.
+  purchasesConnection(
+    after: String
+
+    # The ID or slug of the artist to filter purchases by.
+    artistId: String
+
+    # The ID or slug of the artwork to filter purchases by.
+    artworkId: String
+    before: String
+    first: Int
+    last: Int
+
+    # The ID of the sale to filter purchases by.
+    saleId: String
+
+    # The ID of the user to filter purchases by.
+    userId: String
+  ): PurchasesConnection
 
   # Static set of recently sold artworks for the SWA landing page
   recentlySoldArtworks(
@@ -25017,6 +25090,26 @@ type Viewer {
     # If present, will search by term
     term: String
   ): ProfileConnection
+
+  # A list of purchases made by users.
+  purchasesConnection(
+    after: String
+
+    # The ID or slug of the artist to filter purchases by.
+    artistId: String
+
+    # The ID or slug of the artwork to filter purchases by.
+    artworkId: String
+    before: String
+    first: Int
+    last: Int
+
+    # The ID of the sale to filter purchases by.
+    saleId: String
+
+    # The ID of the user to filter purchases by.
+    userId: String
+  ): PurchasesConnection
 
   # Static set of recently sold artworks for the SWA landing page
   recentlySoldArtworks(

--- a/src/schema/v2/__tests__/purchases.test.ts
+++ b/src/schema/v2/__tests__/purchases.test.ts
@@ -1,0 +1,218 @@
+import { runQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+import sinon from "sinon"
+
+describe("purchases", () => {
+  describe("purchasesConnection", () => {
+    const purchasesMockData = [
+      {
+        id: "purchase-id",
+        artsy_commission: 25.5,
+        artwork: { _id: "artwork-id" },
+        created_at: "2025-04-14T00:00:00Z",
+        discover_admin: { id: "discover-user-id" },
+        email: "email@example.com",
+        fair: { _id: "fair-id" },
+        note: "Test purchase",
+        owner_type: "bid",
+        sale: { _id: "sale-id" },
+        sale_admin: { id: "sale-user-id" },
+        sale_price: 1984,
+        sale_date: "2025-04-14T00:00:00Z",
+        source: "auction",
+        user: { id: "user-id" },
+      },
+    ]
+
+    it("resolves a connection with all query arguments", async () => {
+      const context = {
+        purchasesLoader: sinon
+          .stub()
+          .withArgs({
+            artwork_id: "artwork-id",
+            artist_id: "artist-id",
+            sale_id: "sale-id",
+            user_id: "user-id",
+            page: 1,
+            size: 5,
+            total_count: true,
+          })
+          .returns(
+            Promise.resolve({
+              headers: { "x-total-count": 1 },
+              body: purchasesMockData,
+            })
+          ),
+      }
+
+      const query = gql`
+        {
+          purchasesConnection(
+            first: 5
+            artworkId: "artwork-id"
+            artistId: "artist-id"
+            saleId: "sale-id"
+            userId: "user-id"
+          ) {
+            totalCount
+            edges {
+              node {
+                internalID
+                artsyCommission
+                artwork {
+                  internalID
+                }
+                createdAt
+                discoverAdmin {
+                  internalID
+                }
+                email
+                fair {
+                  internalID
+                }
+                note
+                ownerType
+                sale {
+                  internalID
+                }
+                saleAdmin {
+                  internalID
+                }
+                salePrice
+                saleDate
+                source
+                user {
+                  internalID
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const { purchasesConnection } = await runQuery(query, context)
+
+      expect(purchasesConnection).toMatchInlineSnapshot(`
+        {
+          "edges": [
+            {
+              "node": {
+                "artsyCommission": 25.5,
+                "artwork": {
+                  "internalID": "artwork-id",
+                },
+                "createdAt": "2025-04-14T00:00:00Z",
+                "discoverAdmin": {
+                  "internalID": "discover-user-id",
+                },
+                "email": "email@example.com",
+                "fair": {
+                  "internalID": "fair-id",
+                },
+                "internalID": "purchase-id",
+                "note": "Test purchase",
+                "ownerType": "bid",
+                "sale": {
+                  "internalID": "sale-id",
+                },
+                "saleAdmin": {
+                  "internalID": "sale-user-id",
+                },
+                "saleDate": "2025-04-14T00:00:00Z",
+                "salePrice": 1984,
+                "source": "auction",
+                "user": {
+                  "internalID": "user-id",
+                },
+              },
+            },
+          ],
+          "totalCount": 1,
+        }
+      `)
+
+      expect(context.purchasesLoader.callCount).toEqual(1)
+      expect(context.purchasesLoader.args[0][0]).toEqual({
+        artwork_id: "artwork-id",
+        artist_id: "artist-id",
+        sale_id: "sale-id",
+        user_id: "user-id",
+        page: 1,
+        size: 5,
+        total_count: true,
+      })
+    })
+
+    it("only passes non-empty arguments to the loader", async () => {
+      const context = {
+        purchasesLoader: sinon
+          .stub()
+          .withArgs({
+            artwork_id: "artwork-id",
+            page: 1,
+            size: 5,
+            total_count: true,
+          })
+          .returns(
+            Promise.resolve({
+              headers: { "x-total-count": 1 },
+              body: purchasesMockData,
+            })
+          ),
+      }
+
+      const query = gql`
+        {
+          purchasesConnection(first: 5, artworkId: "artwork-id") {
+            totalCount
+            edges {
+              node {
+                internalID
+              }
+            }
+          }
+        }
+      `
+
+      const { purchasesConnection } = await runQuery(query, context)
+
+      expect(purchasesConnection.totalCount).toEqual(1)
+      expect(purchasesConnection.edges[0].node).toEqual({
+        internalID: "purchase-id",
+      })
+
+      // Verify that empty args like artist_id were not passed to gravity
+      expect(context.purchasesLoader.callCount).toEqual(1)
+      expect(context.purchasesLoader.args[0][0]).toEqual({
+        artwork_id: "artwork-id",
+        page: 1,
+        size: 5,
+        total_count: true,
+      })
+      expect(context.purchasesLoader.args[0][0].artist_id).toBeUndefined()
+      expect(context.purchasesLoader.args[0][0].sale_id).toBeUndefined()
+      expect(context.purchasesLoader.args[0][0].user_id).toBeUndefined()
+    })
+
+    it("throws an error if purchasesLoader is not available", async () => {
+      const context = {}
+
+      const query = gql`
+        {
+          purchasesConnection(first: 5, artworkId: "artwork-id") {
+            totalCount
+            edges {
+              node {
+                internalID
+              }
+            }
+          }
+        }
+      `
+
+      await expect(runQuery(query, context)).rejects.toThrow(
+        "A X-Access-Token header is required to perform this action."
+      )
+    })
+  })
+})

--- a/src/schema/v2/purchases.ts
+++ b/src/schema/v2/purchases.ts
@@ -1,0 +1,127 @@
+import type { ResolverContext } from "types/graphql"
+import { GraphQLString, GraphQLFloat, GraphQLObjectType } from "graphql"
+import type { GraphQLFieldConfig } from "graphql"
+import { IDFields, NodeInterface } from "./object_identification"
+import { ArtworkType } from "./artwork"
+import {
+  connectionWithCursorInfo,
+  createPageCursors,
+} from "schema/v2/fields/pagination"
+import { date } from "./fields/date"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { connectionFromArraySlice } from "graphql-relay"
+import { pageable } from "relay-cursor-paging"
+import { UserType } from "./user"
+import { FairType } from "./fair"
+import { SaleType } from "./sale"
+import { identity, pickBy } from "lodash"
+
+const PurchaseType = new GraphQLObjectType<any, ResolverContext>({
+  name: "Purchase",
+  interfaces: [NodeInterface],
+  fields: {
+    ...IDFields,
+    artsyCommission: {
+      type: GraphQLFloat,
+      resolve: ({ artsy_commission }) => artsy_commission,
+    },
+    artwork: {
+      type: ArtworkType,
+    },
+    createdAt: date(({ created_at }) => created_at),
+    discoverAdmin: {
+      type: UserType,
+      resolve: ({ discover_admin }) => discover_admin,
+    },
+    email: {
+      type: GraphQLString,
+    },
+    fair: {
+      type: FairType,
+    },
+    note: {
+      type: GraphQLString,
+    },
+    ownerType: {
+      type: GraphQLString,
+      resolve: ({ owner_type }) => owner_type,
+    },
+    sale: {
+      type: SaleType,
+    },
+    saleAdmin: {
+      type: UserType,
+      resolve: ({ sale_admin }) => sale_admin,
+    },
+    salePrice: {
+      type: GraphQLFloat,
+      resolve: ({ sale_price }) => sale_price,
+    },
+    saleDate: date(({ sale_date }) => sale_date),
+    source: { type: GraphQLString },
+    user: {
+      type: UserType,
+    },
+  },
+})
+
+export const PurchasesConnection: GraphQLFieldConfig<void, ResolverContext> = {
+  type: connectionWithCursorInfo({
+    name: "Purchases",
+    nodeType: PurchaseType,
+  }).connectionType,
+  description: "A list of purchases made by users.",
+  args: pageable({
+    artistId: {
+      type: GraphQLString,
+      description: "The ID or slug of the artist to filter purchases by.",
+    },
+    artworkId: {
+      type: GraphQLString,
+      description: "The ID or slug of the artwork to filter purchases by.",
+    },
+    saleId: {
+      type: GraphQLString,
+      description: "The ID of the sale to filter purchases by.",
+    },
+    userId: {
+      type: GraphQLString,
+      description: "The ID of the user to filter purchases by.",
+    },
+  }),
+  resolve: async (_, args, { purchasesLoader }) => {
+    if (!purchasesLoader) {
+      throw new Error(
+        "A X-Access-Token header is required to perform this action."
+      )
+    }
+
+    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+
+    // Removes falsey values from arguments
+    const gravityArgs = pickBy(
+      {
+        artwork_id: args.artworkId,
+        artist_id: args.artistId,
+        sale_id: args.saleId,
+        user_id: args.userId,
+        page,
+        size,
+        total_count: true,
+      },
+      identity
+    )
+
+    const { body, headers } = await purchasesLoader(gravityArgs)
+    const totalCount = Number.parseInt(headers["x-total-count"] || "0", 10)
+
+    return {
+      totalCount,
+      pageCursors: createPageCursors({ page, size }, totalCount),
+      ...connectionFromArraySlice(body, args, {
+        arrayLength: totalCount,
+        sliceStart: offset,
+      }),
+    }
+  },
+}

--- a/src/schema/v2/purchases.ts
+++ b/src/schema/v2/purchases.ts
@@ -35,8 +35,8 @@ const PurchaseType = new GraphQLObjectType<any, ResolverContext>({
     createdAt: date(({ created_at }) => created_at),
     discoverAdmin: {
       type: UserType,
-      resolve: ({ discover_admin }) => discover_admin,
       description: "Person who found the sale",
+      resolve: ({ discover_admin }) => discover_admin,
     },
     email: {
       type: GraphQLString,
@@ -57,6 +57,7 @@ const PurchaseType = new GraphQLObjectType<any, ResolverContext>({
     saleAdmin: {
       type: UserType,
       description: "Person who facilitated the sale",
+      resolve: ({ sale_admin }) => sale_admin,
     },
     salePrice: {
       type: GraphQLFloat,

--- a/src/schema/v2/purchases.ts
+++ b/src/schema/v2/purchases.ts
@@ -1,15 +1,19 @@
 import type { ResolverContext } from "types/graphql"
-import { GraphQLString, GraphQLFloat, GraphQLObjectType } from "graphql"
+import {
+  GraphQLString,
+  GraphQLFloat,
+  GraphQLObjectType,
+  GraphQLInt,
+} from "graphql"
 import type { GraphQLFieldConfig } from "graphql"
 import { IDFields, NodeInterface } from "./object_identification"
 import { ArtworkType } from "./artwork"
 import {
   connectionWithCursorInfo,
-  createPageCursors,
+  paginationResolver,
 } from "schema/v2/fields/pagination"
 import { date } from "./fields/date"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
-import { connectionFromArraySlice } from "graphql-relay"
 import { pageable } from "relay-cursor-paging"
 import { UserType } from "./user"
 import { FairType } from "./fair"
@@ -32,6 +36,7 @@ const PurchaseType = new GraphQLObjectType<any, ResolverContext>({
     discoverAdmin: {
       type: UserType,
       resolve: ({ discover_admin }) => discover_admin,
+      description: "Person who found the sale",
     },
     email: {
       type: GraphQLString,
@@ -51,7 +56,7 @@ const PurchaseType = new GraphQLObjectType<any, ResolverContext>({
     },
     saleAdmin: {
       type: UserType,
-      resolve: ({ sale_admin }) => sale_admin,
+      description: "Person who facilitated the sale",
     },
     salePrice: {
       type: GraphQLFloat,
@@ -84,6 +89,8 @@ export const PurchasesConnection: GraphQLFieldConfig<void, ResolverContext> = {
       type: GraphQLString,
       description: "The ID of the sale to filter purchases by.",
     },
+    size: { type: GraphQLInt },
+    page: { type: GraphQLInt },
     userId: {
       type: GraphQLString,
       description: "The ID of the user to filter purchases by.",
@@ -115,13 +122,13 @@ export const PurchasesConnection: GraphQLFieldConfig<void, ResolverContext> = {
     const { body, headers } = await purchasesLoader(gravityArgs)
     const totalCount = Number.parseInt(headers["x-total-count"] || "0", 10)
 
-    return {
+    return paginationResolver({
+      args,
+      body,
+      offset,
+      page,
+      size,
       totalCount,
-      pageCursors: createPageCursors({ page, size }, totalCount),
-      ...connectionFromArraySlice(body, args, {
-        arrayLength: totalCount,
-        sliceStart: offset,
-      }),
-    }
+    })
   },
 }

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -319,6 +319,7 @@ import { repositionPartnerLocationsMutation } from "./partner/Settings/repositio
 import { PartnerMatch } from "./match/partner"
 import { CreatePartnerLocationDaySchedulesMutation } from "./partner/Settings/createPartnerLocationDaySchedulesMutation"
 import { UpdatePartnerProfileImageMutation } from "./partner/Settings/updatePartnerProfileImageMutation"
+import { PurchasesConnection } from "./purchases"
 
 const rootFields = {
   // artworkVersion: ArtworkVersionResolver,
@@ -423,6 +424,7 @@ const rootFields = {
   previewSavedSearch: PreviewSavedSearchField,
   profile: Profile,
   profilesConnection: Profiles,
+  purchasesConnection: PurchasesConnection,
   recentlySoldArtworks: RecentlySoldArtworks,
   requestLocation: RequestLocationField,
   sale: Sale,


### PR DESCRIPTION
As part of our effort to finalize the Torque deprecation, we are migrating the Purchases section to Forque. To display the table, we need a new field called `purchasesConnection`:

```graphql
{
  purchasesConnection(first: 10) {
    edges {
      node {
        internalID
        user {
          internalID 
        }
        artwork {
          internalID
        }
        saleDate
        salePrice
      }
    }
  }
}
```