### PR TITLE
chore: Enable filters for bulk update artworks metadata

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4455,6 +4455,17 @@ type BidderPositionSuggestedNextBid {
 # exceed the size of a 32-bit integer, it's encoded as a string.
 scalar BigInt
 
+input BulkUpdateArtworksFilterInput {
+  # Filter artworks with matching ids
+  artwork_ids: [String]
+
+  # Filter artworks by location
+  location_id: String
+
+  # Filter artworks by partner artist id
+  partner_artist_id: String
+}
+
 input BulkUpdateArtworksMetadataInput {
   # The category (medium type) to be assigned
   category: String
@@ -4472,6 +4483,9 @@ type BulkUpdateArtworksMetadataMutationFailure {
 
 input BulkUpdateArtworksMetadataMutationInput {
   clientMutationId: String
+
+  # Filter options to apply
+  filters: BulkUpdateArtworksFilterInput
 
   # ID of the partner
   id: String!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4457,13 +4457,13 @@ scalar BigInt
 
 input BulkUpdateArtworksFilterInput {
   # Filter artworks with matching ids
-  artwork_ids: [String]
+  artworkIds: [String]
 
   # Filter artworks by location
-  location_id: String
+  locationId: String
 
   # Filter artworks by partner artist id
-  partner_artist_id: String
+  partnerArtistId: String
 }
 
 input BulkUpdateArtworksMetadataInput {
@@ -4471,10 +4471,10 @@ input BulkUpdateArtworksMetadataInput {
   category: String
 
   # The partner location ID to assign
-  location_id: String
+  locationId: String
 
   # The price for the artworks
-  price_listed: Float
+  priceListed: Float
 }
 
 type BulkUpdateArtworksMetadataMutationFailure {

--- a/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
+++ b/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
@@ -1,0 +1,132 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("BulkUpdateArtworksMetadataMutation", () => {
+  const mutation = gql`
+    mutation {
+      bulkUpdateArtworksMetadata(
+        input: {
+          id: "partner123"
+          metadata: {
+            location_id: "location456"
+            category: "Painting"
+            price_listed: 1000
+          }
+          filters: {
+            artwork_ids: ["artwork1", "artwork2"]
+            location_id: "oldLocation"
+            partner_artist_id: "artist789"
+          }
+        }
+      ) {
+        bulkUpdateArtworksMetadataOrError {
+          __typename
+          ... on BulkUpdateArtworksMetadataMutationSuccess {
+            updatedPartnerArtworks {
+              count
+              ids
+            }
+            skippedPartnerArtworks {
+              count
+              ids
+            }
+          }
+          ... on BulkUpdateArtworksMetadataMutationFailure {
+            mutationError {
+              error
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("updates multiple artworks metadata", async () => {
+    const context = {
+      updatePartnerArtworksMetadataLoader: jest.fn().mockResolvedValue({
+        success: 2,
+        errors: {
+          count: 1,
+          ids: ["artwork3"],
+        },
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(context.updatePartnerArtworksMetadataLoader).toHaveBeenCalledWith(
+      "partner123",
+      {
+        metadata: {
+          location_id: "location456",
+          category: "Painting",
+          price_listed: 1000,
+        },
+        filters: {
+          artwork_ids: ["artwork1", "artwork2"],
+          location_id: "oldLocation",
+          partner_artist_id: "artist789",
+        },
+      }
+    )
+
+    expect(result).toEqual({
+      bulkUpdateArtworksMetadata: {
+        bulkUpdateArtworksMetadataOrError: {
+          __typename: "BulkUpdateArtworksMetadataMutationSuccess",
+          updatedPartnerArtworks: {
+            count: 2,
+            ids: [],
+          },
+          skippedPartnerArtworks: {
+            count: 1,
+            ids: ["artwork3"],
+          },
+        },
+      },
+    })
+  })
+
+  it("respects the filter parameters", async () => {
+    const mutationWithFilterOnly = gql`
+      mutation {
+        bulkUpdateArtworksMetadata(
+          input: {
+            id: "partner123"
+            metadata: { category: "Sculpture" }
+            filters: { partner_artist_id: "artist789" }
+          }
+        ) {
+          bulkUpdateArtworksMetadataOrError {
+            __typename
+          }
+        }
+      }
+    `
+
+    const context = {
+      updatePartnerArtworksMetadataLoader: jest.fn().mockResolvedValue({
+        success: 5,
+        errors: {
+          count: 0,
+          ids: [],
+        },
+      }),
+    }
+
+    await runAuthenticatedQuery(mutationWithFilterOnly, context)
+
+    expect(context.updatePartnerArtworksMetadataLoader).toHaveBeenCalledWith(
+      "partner123",
+      {
+        metadata: {
+          category: "Sculpture",
+        },
+        filters: {
+          partner_artist_id: "artist789",
+        },
+      }
+    )
+  })
+})

--- a/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
+++ b/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
@@ -8,14 +8,14 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
         input: {
           id: "partner123"
           metadata: {
-            location_id: "location456"
+            locationId: "location456"
             category: "Painting"
-            price_listed: 1000
+            priceListed: 1000
           }
           filters: {
-            artwork_ids: ["artwork1", "artwork2"]
-            location_id: "oldLocation"
-            partner_artist_id: "artist789"
+            artworkIds: ["artwork1", "artwork2"]
+            locationId: "oldLocation"
+            partnerArtistId: "artist789"
           }
         }
       ) {
@@ -95,7 +95,7 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
           input: {
             id: "partner123"
             metadata: { category: "Sculpture" }
-            filters: { partner_artist_id: "artist789" }
+            filters: { partnerArtistId: "artist789" }
           }
         ) {
           bulkUpdateArtworksMetadataOrError {

--- a/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
@@ -18,21 +18,21 @@ import { GraphQLUnionType } from "graphql"
 interface Input {
   id: string
   metadata: {
-    location_id: string | null
+    locationId: string | null
     category: string | null
-    price_listed: number | null
+    priceListed: number | null
   } | null
   filters: {
-    artwork_ids: string[] | null
-    location_id: string | null
-    partner_artist_id: string | null
+    artworkIds: string[] | null
+    locationId: string | null
+    partnerArtistId: string | null
   } | null
 }
 
 const BulkUpdateArtworksMetadataInput = new GraphQLInputObjectType({
   name: "BulkUpdateArtworksMetadataInput",
   fields: {
-    location_id: {
+    locationId: {
       type: GraphQLString,
       description: "The partner location ID to assign",
     },
@@ -40,7 +40,7 @@ const BulkUpdateArtworksMetadataInput = new GraphQLInputObjectType({
       type: GraphQLString,
       description: "The category (medium type) to be assigned",
     },
-    price_listed: {
+    priceListed: {
       type: GraphQLFloat,
       description: "The price for the artworks",
     },
@@ -50,15 +50,15 @@ const BulkUpdateArtworksMetadataInput = new GraphQLInputObjectType({
 const BulkUpdateArtworksFilterInput = new GraphQLInputObjectType({
   name: "BulkUpdateArtworksFilterInput",
   fields: {
-    artwork_ids: {
+    artworkIds: {
       type: new GraphQLList(GraphQLString),
       description: "Filter artworks with matching ids",
     },
-    location_id: {
+    locationId: {
       type: GraphQLString,
       description: "Filter artworks by location",
     },
-    partner_artist_id: {
+    partnerArtistId: {
       type: GraphQLString,
       description: "Filter artworks by partner artist id",
     },
@@ -164,9 +164,22 @@ export const bulkUpdateArtworksMetadataMutation = mutationWithClientMutationId<
     { id, metadata, filters },
     { updatePartnerArtworksMetadataLoader }
   ) => {
-    const gravityOptions = {
-      metadata: metadata,
-      filters: filters,
+    const gravityOptions: any = {}
+
+    if (metadata) {
+      gravityOptions.metadata = {
+        location_id: metadata.locationId,
+        category: metadata.category,
+        price_listed: metadata.priceListed,
+      }
+    }
+
+    if (filters) {
+      gravityOptions.filters = {
+        artwork_ids: filters.artworkIds,
+        location_id: filters.locationId,
+        partner_artist_id: filters.partnerArtistId,
+      }
     }
 
     if (!updatePartnerArtworksMetadataLoader) {


### PR DESCRIPTION
These filters (artwork ids, partner artist and location) are already available on the Gravity endpoint. Changes here allow them on the mutation as well.

cc @artsy/amber-devs 