### PR TITLE
chore: Add mutation to update partners

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15824,6 +15824,11 @@ type Mutation {
   # Updates a page.
   updatePage(input: UpdatePageMutationInput!): UpdatePageMutationPayload
 
+  # Updates general information on a partner.
+  updatePartner(
+    input: UpdatePartnerMutationInput!
+  ): UpdatePartnerMutationPayload
+
   # Updates a partner artist.
   updatePartnerArtist(
     input: UpdatePartnerArtistMutationInput!
@@ -22752,6 +22757,10 @@ type UpdatePartnerContactSuccess {
   partnerContact: Contact
 }
 
+type UpdatePartnerFailure {
+  mutationError: GravityMutationError
+}
+
 type UpdatePartnerFlagsFailure {
   mutationError: GravityMutationError
 }
@@ -22831,6 +22840,81 @@ type UpdatePartnerLocationPayload {
 type UpdatePartnerLocationSuccess {
   location: Location
 }
+
+input UpdatePartnerMutationInput {
+  # Alternate names or synonyms for this partner.
+  alternateNames: [String]
+
+  # Whether to charge sales tax on ecommerce orders.
+  artsyCollectsSalesTax: Boolean
+  clientMutationId: String
+
+  # Commission paid by non-subscriber/fair partner.
+  commissionRate: Float
+
+  # Contract type.
+  contractType: String
+
+  # Whether the partner is directly contactable.
+  directlyContactable: Boolean
+
+  # Controls artists tab presence on gpp. Artists tab is hidden for Institutional partners and present for the rest of partners.
+  displayArtistsSection: Boolean
+
+  # The display name of the partner.
+  displayName: String
+
+  # Controls whether the works section is displayed.
+  displayWorksSection: Boolean
+
+  # Distinguish artists the partner represents on their profile page.
+  distinguishRepresentedArtists: Boolean
+
+  # The email of the partner.
+  email: String
+
+  # The given name of the partner.
+  givenName: String
+
+  # Profile completeness.
+  hasFullProfile: Boolean
+
+  # The id of the partner to update.
+  id: String!
+
+  # Whether the partner requires pre-qualification.
+  preQualify: Boolean
+
+  # Artists layout on the profile overview page.
+  profileArtistsLayout: String
+
+  # Banner display on the profile overview page.
+  profileBannerDisplay: String
+
+  # The region of the partner.
+  region: String
+
+  # The short name of the partner.
+  shortName: String
+
+  # The sortable name of the partner.
+  sortableName: String
+
+  # Type of the partner.
+  type: String
+
+  # The website of the partner.
+  website: String
+}
+
+type UpdatePartnerMutationPayload {
+  clientMutationId: String
+
+  # On success: the updated partner. On error: the error that occurred.
+  partnerOrError: UpdatePartnerResponseOrError
+}
+
+union UpdatePartnerResponseOrError = UpdatePartnerFailure | UpdatePartnerSuccess
 
 type UpdatePartnerShowDocumentFailure {
   mutationError: GravityMutationError
@@ -22976,6 +23060,10 @@ union UpdatePartnerShowResponseOrError =
 
 type UpdatePartnerShowSuccess {
   show: Show
+}
+
+type UpdatePartnerSuccess {
+  partner: Partner
 }
 
 type UpdateSaleAgreementFailure {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1280,6 +1280,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" }
     ),
+    updatePartnerLoader: gravityLoader(
+      (id) => `partner/${id}`,
+      {},
+      { method: "PUT" }
+    ),
     updateSaleAgreementLoader: gravityLoader(
       (id) => `sale_agreements/${id}`,
       {},

--- a/src/schema/v2/partner/__tests__/updatePartnerMutation.test.ts
+++ b/src/schema/v2/partner/__tests__/updatePartnerMutation.test.ts
@@ -1,0 +1,193 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery, runQuery } from "schema/v2/test/utils"
+
+describe("UpdatePartnerMutation", () => {
+  describe("with multiple fields", () => {
+    const mutationWithMultipleFields = gql`
+      mutation {
+        updatePartner(
+          input: {
+            id: "partner-id"
+            displayName: "Updated Gallery Name"
+            email: "contact@gallery.com"
+            website: "https://gallery.com"
+            hasFullProfile: true
+          }
+        ) {
+          partnerOrError {
+            __typename
+            ... on UpdatePartnerSuccess {
+              partner {
+                internalID
+                name
+              }
+            }
+            ... on UpdatePartnerFailure {
+              mutationError {
+                message
+              }
+            }
+          }
+        }
+      }
+    `
+
+    it("updates multiple partner fields", async () => {
+      const context = {
+        updatePartnerLoader: jest.fn((id, partnerData) => {
+          expect(id).toEqual("partner-id")
+          expect(partnerData).toEqual({
+            display_name: "Updated Gallery Name",
+            email: "contact@gallery.com",
+            website: "https://gallery.com",
+            has_full_profile: true,
+          })
+          return Promise.resolve({
+            _id: "partner-id",
+            name: "Updated Gallery Name",
+          })
+        }),
+      }
+
+      const updatedPartner = await runAuthenticatedQuery(
+        mutationWithMultipleFields,
+        context
+      )
+
+      expect(updatedPartner).toEqual({
+        updatePartner: {
+          partnerOrError: {
+            __typename: "UpdatePartnerSuccess",
+            partner: {
+              internalID: "partner-id",
+              name: "Updated Gallery Name",
+            },
+          },
+        },
+      })
+    })
+  })
+
+  describe("with null field values", () => {
+    const mutationWithNullFields = gql`
+      mutation {
+        updatePartner(input: { id: "partner-id", email: null, website: null }) {
+          partnerOrError {
+            __typename
+            ... on UpdatePartnerSuccess {
+              partner {
+                internalID
+              }
+            }
+          }
+        }
+      }
+    `
+
+    it("unsets fields when explicitly set to null", async () => {
+      const context = {
+        updatePartnerLoader: jest.fn((id, partnerData) => {
+          expect(id).toEqual("partner-id")
+          expect(partnerData).toEqual({
+            email: null,
+            website: null,
+          })
+          return Promise.resolve({
+            _id: "partner-id",
+          })
+        }),
+      }
+
+      const updatedPartner = await runAuthenticatedQuery(
+        mutationWithNullFields,
+        context
+      )
+
+      expect(updatedPartner).toEqual({
+        updatePartner: {
+          partnerOrError: {
+            __typename: "UpdatePartnerSuccess",
+            partner: {
+              internalID: "partner-id",
+            },
+          },
+        },
+      })
+    })
+  })
+
+  describe("with no authorization", () => {
+    const mutation = gql`
+      mutation {
+        updatePartner(
+          input: { id: "partner-id", displayName: "Updated Gallery Name" }
+        ) {
+          partnerOrError {
+            __typename
+            ... on UpdatePartnerFailure {
+              mutationError {
+                message
+              }
+            }
+          }
+        }
+      }
+    `
+
+    it("returns an authorization error when no loader is available", async () => {
+      // Use runQuery without any loaders to simulate unauthenticated request
+      try {
+        await runQuery(mutation, {})
+        // If we get here, the test should fail
+        throw new Error("An error was not thrown but was expected")
+      } catch (error) {
+        // Verify the error is related to authentication
+        expect(error.message).toContain("signed in")
+      }
+    })
+  })
+
+  describe("when API failure occurs", () => {
+    const mutation = gql`
+      mutation {
+        updatePartner(
+          input: { id: "partner-id", displayName: "Updated Gallery Name" }
+        ) {
+          partnerOrError {
+            __typename
+            ... on UpdatePartnerFailure {
+              mutationError {
+                message
+              }
+            }
+          }
+        }
+      }
+    `
+
+    it("returns an error", async () => {
+      const context = {
+        updatePartnerLoader: jest.fn((_id, _partnerData) =>
+          Promise.reject(
+            new Error(
+              `https://stagingapi.artsy.net/api/v1/partner/partner-id - {"type":"error","message":"Error updating partner"}`
+            )
+          )
+        ),
+      }
+
+      const updatedPartner = await runAuthenticatedQuery(mutation, context)
+
+      expect(updatedPartner).toEqual({
+        updatePartner: {
+          partnerOrError: {
+            __typename: "UpdatePartnerFailure",
+            mutationError: {
+              message: "Error updating partner",
+            },
+          },
+        },
+      })
+    })
+  })
+})

--- a/src/schema/v2/partner/updatePartnerMutation.ts
+++ b/src/schema/v2/partner/updatePartnerMutation.ts
@@ -1,0 +1,237 @@
+import {
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLUnionType,
+  GraphQLBoolean,
+  GraphQLFloat,
+  GraphQLList,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import Partner from "./partner"
+import { ResolverContext } from "types/graphql"
+
+interface UpdatePartnerMutationInputProps {
+  id: string
+  alternateNames?: string[] | null
+  artsyCollectsSalesTax?: boolean | null
+  commissionRate?: number | null
+  contractType?: string | null
+  directlyContactable?: boolean | null
+  displayArtistsSection?: boolean | null
+  displayName?: string | null
+  displayWorksSection?: boolean | null
+  distinguishRepresentedArtists?: boolean | null
+  email?: string | null
+  givenName?: string | null
+  hasFullProfile?: boolean | null
+  preQualify?: boolean | null
+  profileArtistsLayout?: string | null
+  profileBannerDisplay?: string | null
+  region?: string | null
+  shortName?: string | null
+  sortableName?: string | null
+  type?: string | null
+  website?: string | null
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdatePartnerSuccess",
+  isTypeOf: (data) => data._id,
+  fields: () => ({
+    partner: {
+      type: Partner.type,
+      resolve: (partner) => partner,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdatePartnerFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdatePartnerResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const updatePartnerMutation = mutationWithClientMutationId<
+  UpdatePartnerMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "UpdatePartnerMutation",
+  description: "Updates general information on a partner.",
+  inputFields: {
+    alternateNames: {
+      type: new GraphQLList(GraphQLString),
+      description: "Alternate names or synonyms for this partner.",
+    },
+    artsyCollectsSalesTax: {
+      type: GraphQLBoolean,
+      description: "Whether to charge sales tax on ecommerce orders.",
+    },
+    commissionRate: {
+      type: GraphQLFloat,
+      description: "Commission paid by non-subscriber/fair partner.",
+    },
+    contractType: {
+      type: GraphQLString,
+      description: "Contract type.",
+    },
+    directlyContactable: {
+      type: GraphQLBoolean,
+      description: "Whether the partner is directly contactable.",
+    },
+    displayArtistsSection: {
+      type: GraphQLBoolean,
+      description:
+        "Controls artists tab presence on gpp. Artists tab is hidden for Institutional partners and present for the rest of partners.",
+    },
+    displayName: {
+      type: GraphQLString,
+      description: "The display name of the partner.",
+    },
+    displayWorksSection: {
+      type: GraphQLBoolean,
+      description: "Controls whether the works section is displayed.",
+    },
+    distinguishRepresentedArtists: {
+      type: GraphQLBoolean,
+      description:
+        "Distinguish artists the partner represents on their profile page.",
+    },
+    email: {
+      type: GraphQLString,
+      description: "The email of the partner.",
+    },
+    givenName: {
+      type: GraphQLString,
+      description: "The given name of the partner.",
+    },
+    hasFullProfile: {
+      type: GraphQLBoolean,
+      description: "Profile completeness.",
+    },
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The id of the partner to update.",
+    },
+    preQualify: {
+      type: GraphQLBoolean,
+      description: "Whether the partner requires pre-qualification.",
+    },
+    profileArtistsLayout: {
+      type: GraphQLString,
+      description: "Artists layout on the profile overview page.",
+    },
+    profileBannerDisplay: {
+      type: GraphQLString,
+      description: "Banner display on the profile overview page.",
+    },
+    region: {
+      type: GraphQLString,
+      description: "The region of the partner.",
+    },
+    shortName: {
+      type: GraphQLString,
+      description: "The short name of the partner.",
+    },
+    sortableName: {
+      type: GraphQLString,
+      description: "The sortable name of the partner.",
+    },
+    type: {
+      type: GraphQLString,
+      description: "Type of the partner.",
+    },
+    website: {
+      type: GraphQLString,
+      description: "The website of the partner.",
+    },
+  },
+  outputFields: {
+    partnerOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the updated partner. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    {
+      id,
+      alternateNames,
+      artsyCollectsSalesTax,
+      commissionRate,
+      contractType,
+      directlyContactable,
+      displayArtistsSection,
+      displayName,
+      displayWorksSection,
+      distinguishRepresentedArtists,
+      email,
+      givenName,
+      hasFullProfile,
+      preQualify,
+      profileArtistsLayout,
+      profileBannerDisplay,
+      region,
+      shortName,
+      sortableName,
+      type,
+      website,
+    },
+    { updatePartnerLoader }
+  ) => {
+    if (!updatePartnerLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const partnerData = {
+        alternate_names: alternateNames,
+        artsy_collects_sales_tax: artsyCollectsSalesTax,
+        commission_rate: commissionRate,
+        contract_type: contractType,
+        directly_contactable: directlyContactable,
+        display_artists_section: displayArtistsSection,
+        display_name: displayName,
+        display_works_section: displayWorksSection,
+        distinguish_represented_artists: distinguishRepresentedArtists,
+        email: email,
+        given_name: givenName,
+        has_full_profile: hasFullProfile,
+        pre_qualify: preQualify,
+        profile_artists_layout: profileArtistsLayout,
+        profile_banner_display: profileBannerDisplay,
+        region: region,
+        short_name: shortName,
+        sortable_name: sortableName,
+        type: type,
+        website: website,
+      }
+
+      const response = await updatePartnerLoader(id, partnerData)
+      return response
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -195,6 +195,7 @@ import { PartnerArtistDocumentsConnection } from "./partner/partnerArtistDocumen
 import { PartnerShowDocumentsConnection } from "./partner/partnerShowDocumentsConnection"
 import { updateCMSLastAccessTimestampMutation } from "./partner/updateCMSLastAccessTimestampMutation"
 import { updatePartnerFlagsMutation } from "./partner/updatePartnerFlagsMutation"
+import { updatePartnerMutation } from "./partner/updatePartnerMutation"
 import { PaymentMethodUnion, WireTransferType } from "./payment_method_union"
 import { PhoneNumber } from "./phoneNumber"
 import { PreviewSavedSearchField } from "./previewSavedSearch"
@@ -625,6 +626,7 @@ export default new GraphQLSchema({
       updatePartnerArtistDocument: updatePartnerArtistDocumentMutation,
       updatePartnerShowDocument: updatePartnerShowDocumentMutation,
       updatePartnerShowEvent: updatePartnerShowEventMutation,
+      updatePartner: updatePartnerMutation,
       updatePartnerFlags: updatePartnerFlagsMutation,
       updateUser: updateUserMutation,
       updateUserInterest: updateUserInterestMutation,


### PR DESCRIPTION
This PR adds a new mutation for updating a partner record in the API. I exported the documentation for that REST endpoint and used that as a starting point for this mutation. I asked Claude to follow our typical mutation patterns and I think what emerged looks pretty good but lmk if there's anything that seems off!

/cc @artsy/amber-devs