### PR TITLE
WIP: Adds support to batch create schedule for a partners location

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9180,6 +9180,36 @@ type CreatePartnerContactSuccess {
   partnerContact: Contact
 }
 
+type CreatePartnerLocationDayScheduleFailure {
+  mutationError: GravityMutationError
+}
+
+input CreatePartnerLocationDayScheduleInput {
+  clientMutationId: String
+
+  # List of day schedules for the full week
+  daySchedules: [DayScheduleInput!]!
+
+  # ID of the location
+  locationId: String!
+
+  # ID of the partner
+  partnerId: String!
+}
+
+union CreatePartnerLocationDayScheduleOrError =
+    CreatePartnerLocationDayScheduleFailure
+  | CreatePartnerLocationDayScheduleSuccess
+
+type CreatePartnerLocationDaySchedulePayload {
+  clientMutationId: String
+  partnerLocationOrError: CreatePartnerLocationDayScheduleOrError
+}
+
+type CreatePartnerLocationDayScheduleSuccess {
+  location: Location
+}
+
 type CreatePartnerLocationFailure {
   mutationError: GravityMutationError
 }
@@ -9777,6 +9807,12 @@ type DaySchedule {
   dayOfWeek: String
   endTime: Int
   startTime: Int
+}
+
+input DayScheduleInput {
+  day: Int!
+  endTime: Int!
+  startTime: Int!
 }
 
 type DeepZoom {
@@ -15291,6 +15327,11 @@ type Mutation {
   createPartnerLocation(
     input: CreatePartnerLocationInput!
   ): CreatePartnerLocationPayload
+
+  # Creates a new weekly schedule for a partner location
+  createPartnerLocationDaySchedule(
+    input: CreatePartnerLocationDayScheduleInput!
+  ): CreatePartnerLocationDaySchedulePayload
 
   # Create a partner offer for the users
   createPartnerOffer(

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -304,6 +304,15 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    createPartnerLocationDayScheduleLoader: gravityLoader<
+      any,
+      { partnerId: string; locationId: string }
+    >(
+      ({ partnerId, locationId }) =>
+        `partner/${partnerId}/location/${locationId}/day_schedules`,
+      {},
+      { method: "POST" }
+    ),
     createPartnerOfferLoader: gravityLoader(
       "partner_offer",
       {},

--- a/src/schema/v2/partner/Settings/createPartnerLocationDaySchedule.ts
+++ b/src/schema/v2/partner/Settings/createPartnerLocationDaySchedule.ts
@@ -1,0 +1,128 @@
+import {
+  GraphQLInputObjectType,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { LocationType } from "schema/v2/location"
+import { ResolverContext } from "types/graphql"
+
+type DayScheduleInput = {
+  day: number
+  startTime: number
+  endTime: number
+}
+
+interface Input {
+  partnerId: string
+  locationId: string
+  daySchedules: DayScheduleInput[]
+}
+
+const DayScheduleInputType = new GraphQLInputObjectType({
+  name: "DayScheduleInput",
+  fields: {
+    day: { type: new GraphQLNonNull(GraphQLInt) },
+    startTime: { type: new GraphQLNonNull(GraphQLInt) },
+    endTime: { type: new GraphQLNonNull(GraphQLInt) },
+  },
+})
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreatePartnerLocationDayScheduleSuccess",
+  isTypeOf: (data) => !!data._id,
+  fields: () => ({
+    location: {
+      type: LocationType,
+      resolve: (result) => result,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreatePartnerLocationDayScheduleFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "CreatePartnerLocationDayScheduleOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const CreatePartnerLocationDayScheduleMutation = mutationWithClientMutationId<
+  Input,
+  any,
+  ResolverContext
+>({
+  name: "CreatePartnerLocationDaySchedule",
+  description: "Creates a new weekly schedule for a partner location",
+  inputFields: {
+    partnerId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "ID of the partner",
+    },
+    locationId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "ID of the location",
+    },
+    daySchedules: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(DayScheduleInputType))
+      ),
+      description: "List of day schedules for the full week",
+    },
+  },
+  outputFields: {
+    partnerLocationOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { partnerId, locationId, daySchedules },
+    { createPartnerLocationDayScheduleLoader }
+  ) => {
+    if (!createPartnerLocationDayScheduleLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const snakeCasedDaySchedules = daySchedules.map(
+        ({ day, startTime, endTime }) => ({
+          day,
+          start_time: startTime,
+          end_time: endTime,
+        })
+      )
+
+      const response = await createPartnerLocationDayScheduleLoader({
+        partnerId,
+        locationId,
+        day_schedules: snakeCasedDaySchedules,
+      })
+
+      return response
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -313,6 +313,7 @@ import { UpdatePartnerLocationMutation } from "./partner/Settings/updatePartnerL
 import { DeletePartnerLocationMutation } from "./partner/Settings/deletePartnerLocationMutation"
 import { repositionPartnerLocationsMutation } from "./partner/Settings/repositionPartnerLocations"
 import { PartnerMatch } from "./match/partner"
+import { CreatePartnerLocationDayScheduleMutation } from "./partner/Settings/createPartnerLocationDaySchedule"
 
 const rootFields = {
   // artworkVersion: ArtworkVersionResolver,
@@ -500,6 +501,7 @@ export default new GraphQLSchema({
       createOrderedSet: createOrderedSetMutation,
       createPartnerContact: CreatePartnerContactMutation,
       createPartnerLocation: CreatePartnerLocationMutation,
+      createPartnerLocationDaySchedule: CreatePartnerLocationDayScheduleMutation,
       createPartnerArtistDocument: createPartnerArtistDocumentMutation,
       createPartnerShow: createPartnerShowMutation,
       createPartnerShowDocument: createPartnerShowDocumentMutation,


### PR DESCRIPTION
```graphql
mutation {
  createPartnerLocationDaySchedule(input: {
    partnerId: "5f80bfefe8d808000ea212c1", 
    locationId:"64fa15a89846f3000aef6c84",
    daySchedules: [
      {day: 1, startTime: 1200, endTime: 8000}, 
      {day:6, startTime: 123, endTime: 1234}
    ]
  }) {
   partnerLocationOrError {
      ... on CreatePartnerLocationDayScheduleSuccess {
        location {
          internalID
          display
          phone
          daySchedules {
            dayOfWeek
            startTime
            endTime
          }
        }
      }
      ... on CreatePartnerLocationDayScheduleFailure {
        mutationError {
          message
        }
      }
    }
  }
}
```