### PR TITLE
chore: add deletePartnerArtist mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10034,6 +10034,34 @@ type DeletePartnerArtistDocumentSuccess {
   partner: Partner
 }
 
+type DeletePartnerArtistFailure {
+  mutationError: GravityMutationError
+}
+
+input DeletePartnerArtistMutationInput {
+  # The ID of the artist to delete.
+  artistId: String!
+  clientMutationId: String
+
+  # The ID of the partner.
+  partnerId: String!
+}
+
+type DeletePartnerArtistMutationPayload {
+  clientMutationId: String
+
+  # On success: confirmation of deletion. On error: the error that occurred.
+  partnerArtistOrError: DeletePartnerArtistResponseOrError
+}
+
+union DeletePartnerArtistResponseOrError =
+    DeletePartnerArtistFailure
+  | DeletePartnerArtistSuccess
+
+type DeletePartnerArtistSuccess {
+  partner: Partner
+}
+
 type DeletePartnerContactFailure {
   mutationError: GravityMutationError
 }
@@ -15421,6 +15449,11 @@ type Mutation {
 
   # Deletes a page.
   deletePage(input: DeletePageMutationInput!): DeletePageMutationPayload
+
+  # Deletes a partner artist.
+  deletePartnerArtist(
+    input: DeletePartnerArtistMutationInput!
+  ): DeletePartnerArtistMutationPayload
 
   # Deletes a partner artist document.
   deletePartnerArtistDocument(

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1234,6 +1234,15 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" }
     ),
+    deletePartnerArtistLoader: gravityLoader<
+      any,
+      { partnerId: string; artistId: string }
+    >(
+      ({ partnerId, artistId }) =>
+        `partner/${partnerId}/artist/${artistId}?delete_artworks=true`,
+      {},
+      { method: "DELETE" }
+    ),
     updatePartnerArtistLoader: gravityLoader(
       (id) => `partner_artist/${id}`,
       {},

--- a/src/schema/v2/partner/Mutations/PartnerArtist/__tests__/deletePartnerArtistMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/PartnerArtist/__tests__/deletePartnerArtistMutation.test.ts
@@ -1,0 +1,44 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("DeletePartnerArtistMutation", () => {
+  const mutation = gql`
+    mutation {
+      deletePartnerArtist(
+        input: { partnerId: "partner123", artistId: "artist123" }
+      ) {
+        partnerArtistOrError {
+          __typename
+          ... on DeletePartnerArtistSuccess {
+            partner {
+              name
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("deletes a partner artist", async () => {
+    const context = {
+      deletePartnerArtistLoader: () =>
+        Promise.resolve({
+          id: "partner-artist-123",
+        }),
+      partnerLoader: () => Promise.resolve({ name: "Test Partner" }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      deletePartnerArtist: {
+        partnerArtistOrError: {
+          __typename: "DeletePartnerArtistSuccess",
+          partner: {
+            name: "Test Partner",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/partner/Mutations/PartnerArtist/deletePartnerArtistMutation.ts
+++ b/src/schema/v2/partner/Mutations/PartnerArtist/deletePartnerArtistMutation.ts
@@ -1,0 +1,99 @@
+import {
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import Partner from "../../partner"
+
+interface DeletePartnerArtistMutationInputProps {
+  partnerId: string
+  artistId: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DeletePartnerArtistSuccess",
+  isTypeOf: (data) => data.partnerId,
+  fields: () => ({
+    partner: {
+      type: Partner.type,
+      resolve: ({ partnerId }, _args, { partnerLoader }) => {
+        return partnerLoader(partnerId)
+      },
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DeletePartnerArtistFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "DeletePartnerArtistResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const deletePartnerArtistMutation = mutationWithClientMutationId<
+  DeletePartnerArtistMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "DeletePartnerArtistMutation",
+  description: "Deletes a partner artist.",
+  inputFields: {
+    partnerId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the partner.",
+    },
+    artistId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the artist to delete.",
+    },
+  },
+  outputFields: {
+    partnerArtistOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: confirmation of deletion. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { partnerId, artistId },
+    { deletePartnerArtistLoader }
+  ) => {
+    if (!deletePartnerArtistLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    const identifiers = {
+      partnerId,
+      artistId,
+    }
+
+    try {
+      await deletePartnerArtistLoader(identifiers)
+      return { partnerId }
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -247,6 +247,7 @@ import { updatePartnerShowEventMutation } from "./Show/updatePartnerShowEventMut
 import { updatePartnerShowDocumentMutation } from "./Show/updatePartnerShowDocumentMutation"
 import { createPartnerArtistDocumentMutation } from "./partner/Mutations/PartnerArtist/createPartnerArtistDocumentMutation"
 import { deletePartnerArtistDocumentMutation } from "./partner/Mutations/PartnerArtist/deletePartnerArtistDocumentMutation"
+import { deletePartnerArtistMutation } from "./partner/Mutations/PartnerArtist/deletePartnerArtistMutation"
 import { repositionPartnerArtistArtworksMutation } from "./partner/Mutations/PartnerArtist/repositionPartnerArtistArtworksMutation"
 import { updatePartnerArtistDocumentMutation } from "./partner/Mutations/PartnerArtist/updatePartnerArtistDocumentMutation"
 import { updatePartnerArtistMutation } from "./partner/Mutations/PartnerArtist/updatePartnerArtistMutation"
@@ -528,6 +529,7 @@ export default new GraphQLSchema({
       deleteFeature: DeleteFeatureMutation,
       deleteFeaturedLink: DeleteFeaturedLinkMutation,
       deleteHeroUnit: deleteHeroUnitMutation,
+      deletePartnerArtist: deletePartnerArtistMutation,
       deletePartnerContact: DeletePartnerContactMutation,
       deletePartnerArtistDocument: deletePartnerArtistDocumentMutation,
       deletePartnerLocation: DeletePartnerLocationMutation,


### PR DESCRIPTION
Pretty boilerplate-y - adds a mutation to let a partner clean up a partner artist (which also soft-deletes all their artworks).