### PR TITLE
feat: Allow artworks to be published/unpublished in batch

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4480,6 +4480,9 @@ input BulkUpdateArtworksMetadataInput {
 
   # The price for the artworks
   priceListed: Float
+
+  # Publish or unpublish artworks
+  published: Boolean
 }
 
 type BulkUpdateArtworksMetadataMutationFailure {

--- a/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
+++ b/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
@@ -11,6 +11,7 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
             locationId: "location456"
             category: "Painting"
             priceListed: 1000
+            published: true
           }
           filters: {
             artworkIds: ["artwork1", "artwork2"]
@@ -62,6 +63,7 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
           location_id: "location456",
           category: "Painting",
           price_listed: 1000,
+          published: true,
         },
         filters: {
           artwork_ids: ["artwork1", "artwork2"],

--- a/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
@@ -1,4 +1,5 @@
 import {
+  GraphQLBoolean,
   GraphQLInputObjectType,
   GraphQLInt,
   GraphQLList,
@@ -17,16 +18,17 @@ import { GraphQLUnionType } from "graphql"
 
 interface Input {
   id: string
-  metadata: {
-    locationId: string | null
-    category: string | null
-    priceListed: number | null
-  } | null
-  filters: {
-    artworkIds: string[] | null
-    locationId: string | null
-    partnerArtistId: string | null
-  } | null
+  metadata?: {
+    locationId?: string
+    category?: string
+    priceListed?: number
+    published?: boolean
+  }
+  filters?: {
+    artworkIds?: string[]
+    locationId?: string
+    partnerArtistId?: string
+  }
 }
 
 const BulkUpdateArtworksMetadataInput = new GraphQLInputObjectType({
@@ -43,6 +45,10 @@ const BulkUpdateArtworksMetadataInput = new GraphQLInputObjectType({
     priceListed: {
       type: GraphQLFloat,
       description: "The price for the artworks",
+    },
+    published: {
+      type: GraphQLBoolean,
+      description: "Publish or unpublish artworks",
     },
   },
 })
@@ -171,6 +177,7 @@ export const bulkUpdateArtworksMetadataMutation = mutationWithClientMutationId<
         location_id: metadata.locationId,
         category: metadata.category,
         price_listed: metadata.priceListed,
+        published: metadata.published,
       }
     }
 


### PR DESCRIPTION
Depends on https://github.com/artsy/gravity/pull/18838

Allow `published` to be passed within the metadata to the batch edits mutation.
It can publish or unpublish the artworks depending on its boolean value

cc @artsy/amber-devs 