### PR TITLE
feat(EMI-2208): Rich phone number field for `Order.fulfillmentDetails` type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11975,7 +11975,9 @@ type FulfillmentDetails {
 
   # Country code of the buyer's phone number
   phoneNumberCountryCode: String
-    @deprecated(reason: "Use `order.fulfillmentDetails.phoneNumber.regionCode`")
+    @deprecated(
+      reason: "Use `phoneNumber.regionCode` for the alpha-2 country code or phoneNumber.countryCode for the numeric country code"
+    )
 
   # Shipping address postal code
   postalCode: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11971,10 +11971,13 @@ type FulfillmentDetails {
   name: String
 
   # Phone number of the buyer
-  phoneNumber: String
+  phoneNumber: PhoneNumberType
 
   # Country code of the buyer's phone number
   phoneNumberCountryCode: String
+    @deprecated(
+      reason: "Use `order.fulfillmentDetails.phoneNumber.countryCode`"
+    )
 
   # Shipping address postal code
   postalCode: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17951,6 +17951,7 @@ enum PhoneNumberFormats {
 }
 
 type PhoneNumberType {
+  # Numeric phone number country code
   countryCode: String
 
   # A formatted phone number if the number could be parsed
@@ -17958,6 +17959,8 @@ type PhoneNumberType {
   error: PhoneNumberErrors
   isValid: Boolean
   originalNumber: String
+
+  # Two-letter region code (ISO 3166-1 alpha-2)
   regionCode: String
 }
 
@@ -19473,7 +19476,13 @@ type Query {
   ): PartnerConnection
 
   # Phone number information
-  phoneNumber(phoneNumber: String!, regionCode: String): PhoneNumberType
+  phoneNumber(
+    # Phone number to parse
+    phoneNumber: String!
+
+    # Two-letter region code (ISO 3166-1 alpha-2)
+    regionCode: String
+  ): PhoneNumberType
 
   # A previewed saved search
   previewSavedSearch(
@@ -25126,7 +25135,13 @@ type Viewer {
   ): PartnerConnection
 
   # Phone number information
-  phoneNumber(phoneNumber: String!, regionCode: String): PhoneNumberType
+  phoneNumber(
+    # Phone number to parse
+    phoneNumber: String!
+
+    # Two-letter region code (ISO 3166-1 alpha-2)
+    regionCode: String
+  ): PhoneNumberType
 
   # A previewed saved search
   previewSavedSearch(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17954,6 +17954,8 @@ enum PhoneNumberFormats {
 
 type PhoneNumberType {
   countryCode: String
+
+  # A formatted phone number. Null if isValid is false
   display(format: PhoneNumberFormats): String
   error: PhoneNumberErrors
   isValid: Boolean

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11975,9 +11975,7 @@ type FulfillmentDetails {
 
   # Country code of the buyer's phone number
   phoneNumberCountryCode: String
-    @deprecated(
-      reason: "Use `order.fulfillmentDetails.phoneNumber.countryCode`"
-    )
+    @deprecated(reason: "Use `order.fulfillmentDetails.phoneNumber.regionCode`")
 
   # Shipping address postal code
   postalCode: String
@@ -17955,7 +17953,7 @@ enum PhoneNumberFormats {
 type PhoneNumberType {
   countryCode: String
 
-  # A formatted phone number. Null if isValid is false
+  # A formatted phone number if the number could be parsed
   display(format: PhoneNumberFormats): String
   error: PhoneNumberErrors
   isValid: Boolean

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -418,7 +418,7 @@ describe("Me", () => {
 
       it("returns only countryCode, originalNumber and a null display field if validation fails", async () => {
         orderJson.buyer_phone_number_country_code = "us"
-        orderJson.buyer_phone_number = "7738asdf675309"
+        orderJson.buyer_phone_number = "773867530Z"
         context = {
           meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
           meOrderLoader: jest.fn().mockResolvedValue(orderJson),
@@ -447,10 +447,10 @@ describe("Me", () => {
         const result = await runAuthenticatedQuery(query, context)
         expect(result.me.order.fulfillmentDetails.phoneNumber).toEqual({
           countryCode: "1",
-          regionCode: null,
-          originalNumber: "7738asdf675309",
+          regionCode: "us",
+          originalNumber: "773867530Z",
           isValid: false,
-          display: null,
+          display: "+1773867530",
         })
       })
 

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -56,23 +56,29 @@ describe("Me", () => {
               displayTexts {
                 titleText
               }
-              fulfillmentDetails {
-                addressLine1
-                addressLine2
-                city
-                country
-                name
-                phoneNumber
-                phoneNumberCountryCode
-                postalCode
-                region
-              }
+
               fulfillmentOptions {
+                type
                 amount {
                   currencyCode
                   display
                 }
                 selected
+              }
+              fulfillmentDetails {
+                phoneNumber {
+                  originalNumber
+                }
+                phoneNumberCountryCode
+                name
+                addressLine1
+                addressLine2
+                city
+                region
+                country
+                postalCode
+              }
+              selectedFulfillmentOption {
                 type
               }
               internalID
@@ -170,7 +176,9 @@ describe("Me", () => {
           city: "New York",
           country: "US",
           name: "John Doe",
-          phoneNumber: "123-456-7890",
+          phoneNumber: {
+            originalNumber: "123-456-7890",
+          },
           phoneNumberCountryCode: "US",
           postalCode: "10001",
           region: "NY",
@@ -352,6 +360,177 @@ describe("Me", () => {
         const result = await runAuthenticatedQuery(query, context)
 
         expect(result.me.order.taxTotal).toEqual(null)
+      })
+    })
+
+    describe("fulfillmentDetails", () => {
+      let consoleErrorSpy: jest.SpyInstance
+      beforeEach(() => {
+        const realConsoleError = console.error
+        consoleErrorSpy = jest.spyOn(console, "error").mockImplementation()
+        console.error = (...args) => {
+          if (args[0] !== "Parse phone number error: ") {
+            realConsoleError(...args)
+          }
+        }
+      })
+      afterEach(() => {
+        consoleErrorSpy.mockRestore()
+      })
+
+      it("returns phoneNumber if there is a blank country code", async () => {
+        orderJson.buyer_phone_number_country_code = ""
+        orderJson.buyer_phone_number = "7738675309"
+        context = {
+          meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+          meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+          artworkLoader: jest.fn().mockResolvedValue(artwork),
+          authenticatedArtworkVersionLoader: jest
+            .fn()
+            .mockResolvedValue(artworkVersion),
+        }
+        const query = gql`
+          query {
+            me {
+              order(id: "order-id") {
+                fulfillmentDetails {
+                  phoneNumber {
+                    countryCode
+                    regionCode
+                    originalNumber
+                    isValid
+                    display
+                  }
+                }
+              }
+            }
+          }
+        `
+        const result = await runAuthenticatedQuery(query, context)
+        expect(result.me.order.fulfillmentDetails.phoneNumber).toEqual({
+          countryCode: null,
+          regionCode: null,
+          originalNumber: "7738675309",
+          isValid: false,
+          display: null,
+        })
+      })
+
+      it("returns only countryCode, originalNumber and a possibly strange display field if validation fails", async () => {
+        orderJson.buyer_phone_number_country_code = "us"
+        orderJson.buyer_phone_number = "7738asdf675309"
+        context = {
+          meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+          meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+          artworkLoader: jest.fn().mockResolvedValue(artwork),
+          authenticatedArtworkVersionLoader: jest
+            .fn()
+            .mockResolvedValue(artworkVersion),
+        }
+        const query = gql`
+          query {
+            me {
+              order(id: "order-id") {
+                fulfillmentDetails {
+                  phoneNumber {
+                    countryCode
+                    regionCode
+                    originalNumber
+                    isValid
+                    display(format: E164)
+                  }
+                }
+              }
+            }
+          }
+        `
+        const result = await runAuthenticatedQuery(query, context)
+        expect(result.me.order.fulfillmentDetails.phoneNumber).toEqual({
+          countryCode: "1",
+          regionCode: null,
+          originalNumber: "7738asdf675309",
+          isValid: false,
+          display: "+177382733675309",
+        })
+      })
+
+      it("returns phoneNumber with rich values with a valid region code", async () => {
+        orderJson.buyer_phone_number_country_code = "us"
+        orderJson.buyer_phone_number = "7738675309"
+        context = {
+          meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+          meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+          artworkLoader: jest.fn().mockResolvedValue(artwork),
+          authenticatedArtworkVersionLoader: jest
+            .fn()
+            .mockResolvedValue(artworkVersion),
+        }
+        const query = gql`
+          query {
+            me {
+              order(id: "order-id") {
+                fulfillmentDetails {
+                  phoneNumber {
+                    countryCode
+                    regionCode
+                    originalNumber
+                    isValid
+                    display
+                  }
+                }
+              }
+            }
+          }
+        `
+        const result = await runAuthenticatedQuery(query, context)
+        expect(result.me.order.fulfillmentDetails.phoneNumber).toEqual({
+          countryCode: "1",
+          display: "773-867-5309",
+          isValid: true,
+          originalNumber: "7738675309",
+          regionCode: "us",
+        })
+      })
+
+      it("returns shipping address fields", async () => {
+        const query = gql`
+          query {
+            me {
+              order(id: "order-id") {
+                fulfillmentDetails {
+                  name
+                  addressLine1
+                  addressLine2
+                  city
+                  region
+                  country
+                  postalCode
+                }
+              }
+            }
+          }
+        `
+
+        context = {
+          meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+          meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+          artworkLoader: jest.fn().mockResolvedValue(artwork),
+          authenticatedArtworkVersionLoader: jest
+            .fn()
+            .mockResolvedValue(artworkVersion),
+        }
+
+        const result = await runAuthenticatedQuery(query, context)
+
+        expect(result.me.order.fulfillmentDetails).toEqual({
+          name: "John Doe",
+          addressLine1: "123 Main St",
+          addressLine2: "Apt 4B",
+          city: "New York",
+          region: "NY",
+          country: "US",
+          postalCode: "10001",
+        })
       })
     })
   })

--- a/src/schema/v2/order/__tests__/updateOrderMutation.test.ts
+++ b/src/schema/v2/order/__tests__/updateOrderMutation.test.ts
@@ -26,7 +26,9 @@ const mockMutation = `
           order {
             internalID
             fulfillmentDetails {
-              phoneNumber
+              phoneNumber {
+                originalNumber
+              }
               phoneNumberCountryCode
               name
               addressLine1
@@ -58,7 +60,7 @@ describe("updateOrderMutation", () => {
         items_total_cents: 500000,
         shipping_total_cents: 2000,
         buyer_phone_number: "123-456-7890",
-        buyer_phone_number_country_code: "+1",
+        buyer_phone_number_country_code: "us",
         shipping_name: "John Doe",
         shipping_country: "US",
         shipping_postal_code: "10001",
@@ -83,8 +85,10 @@ describe("updateOrderMutation", () => {
           order: {
             internalID: "order-id",
             fulfillmentDetails: {
-              phoneNumber: "123-456-7890",
-              phoneNumberCountryCode: "+1",
+              phoneNumber: {
+                originalNumber: "123-456-7890",
+              },
+              phoneNumberCountryCode: "us",
               name: "John Doe",
               addressLine1: "123 Main St",
               addressLine2: "Apt 4B",

--- a/src/schema/v2/order/__tests__/updateOrderShippingAddressMutation.test.ts
+++ b/src/schema/v2/order/__tests__/updateOrderShippingAddressMutation.test.ts
@@ -26,7 +26,11 @@ const mockMutation = `
           order {
             internalID
             fulfillmentDetails {
-              phoneNumber
+              phoneNumber {
+                display(format: E164)
+                countryCode
+                regionCode
+              }
               phoneNumberCountryCode
               name
               addressLine1
@@ -58,7 +62,7 @@ describe("updateOrderShippingAddressMutation", () => {
         items_total_cents: 500000,
         shipping_total_cents: 2000,
         buyer_phone_number: "123-456-7890",
-        buyer_phone_number_country_code: "+1",
+        buyer_phone_number_country_code: "US",
         shipping_name: "John Doe",
         shipping_country: "US",
         shipping_postal_code: "10001",
@@ -83,8 +87,12 @@ describe("updateOrderShippingAddressMutation", () => {
           order: {
             internalID: "order-id",
             fulfillmentDetails: {
-              phoneNumber: "123-456-7890",
-              phoneNumberCountryCode: "+1",
+              phoneNumber: {
+                display: "+11234567890",
+                countryCode: "1",
+                regionCode: "us",
+              },
+              phoneNumberCountryCode: "US",
               name: "John Doe",
               addressLine1: "123 Main St",
               addressLine2: "Apt 4B",

--- a/src/schema/v2/order/sharedOrderTypes.ts
+++ b/src/schema/v2/order/sharedOrderTypes.ts
@@ -14,6 +14,7 @@ import { Money, resolveMinorAndCurrencyFieldsToMoney } from "../fields/money"
 import { ArtworkVersionType } from "../artwork_version"
 import { ArtworkType } from "../artwork"
 import { PartnerType } from "schema/v2/partner/partner"
+import { PhoneNumberType, resolvePhoneNumber } from "../phoneNumber"
 
 /**
  * The order json as received from the exchange REST API.
@@ -172,11 +173,19 @@ const FulfillmentDetailsType = new GraphQLObjectType<any, ResolverContext>({
   description: "Buyer fulfillment details for order",
   fields: {
     phoneNumber: {
-      type: GraphQLString,
+      type: PhoneNumberType,
       description: "Phone number of the buyer",
+      resolve: ({ phoneNumber, phoneNumberCountryCode }) => {
+        return resolvePhoneNumber({
+          phoneNumber,
+          regionCode: phoneNumberCountryCode,
+        })
+      },
     },
     phoneNumberCountryCode: {
       type: GraphQLString,
+      deprecationReason:
+        "Use `order.fulfillmentDetails.phoneNumber.countryCode`",
       description: "Country code of the buyer's phone number",
     },
     name: {

--- a/src/schema/v2/order/sharedOrderTypes.ts
+++ b/src/schema/v2/order/sharedOrderTypes.ts
@@ -185,7 +185,7 @@ const FulfillmentDetailsType = new GraphQLObjectType<any, ResolverContext>({
     phoneNumberCountryCode: {
       type: GraphQLString,
       deprecationReason:
-        "Use `order.fulfillmentDetails.phoneNumber.countryCode`",
+        "Use `order.fulfillmentDetails.phoneNumber.regionCode`",
       description: "Country code of the buyer's phone number",
     },
     name: {

--- a/src/schema/v2/order/sharedOrderTypes.ts
+++ b/src/schema/v2/order/sharedOrderTypes.ts
@@ -185,7 +185,7 @@ const FulfillmentDetailsType = new GraphQLObjectType<any, ResolverContext>({
     phoneNumberCountryCode: {
       type: GraphQLString,
       deprecationReason:
-        "Use `order.fulfillmentDetails.phoneNumber.regionCode`",
+        "Use `phoneNumber.regionCode` for the alpha-2 country code or phoneNumber.countryCode for the numeric country code",
       description: "Country code of the buyer's phone number",
     },
     name: {

--- a/src/schema/v2/phoneNumber.ts
+++ b/src/schema/v2/phoneNumber.ts
@@ -57,7 +57,7 @@ export const PhoneNumberErrors = new GraphQLEnumType({
   },
 })
 
-const PhoneNumberType: GraphQLObjectType<
+export const PhoneNumberType: GraphQLObjectType<
   PhoneNumberTypeSource,
   ResolverContext
 > = new GraphQLObjectType<PhoneNumberTypeSource, ResolverContext>({
@@ -114,6 +114,23 @@ const PhoneNumberType: GraphQLObjectType<
   },
 })
 
+export const resolvePhoneNumber = ({ phoneNumber, regionCode }) => {
+  const phoneUtil = PhoneNumberUtil.getInstance()
+  let parsedPhone: GooglePhoneNumber | undefined
+
+  try {
+    parsedPhone = phoneUtil.parse(phoneNumber, regionCode || "")
+  } catch (e) {
+    console.error("Parse phone number error: ", e)
+  }
+
+  return {
+    phoneNumber,
+    parsedPhone,
+    phoneUtil,
+  }
+}
+
 export const PhoneNumber: GraphQLFieldConfig<any, ResolverContext> = {
   type: PhoneNumberType,
   description: "Phone number information",
@@ -126,19 +143,6 @@ export const PhoneNumber: GraphQLFieldConfig<any, ResolverContext> = {
     },
   },
   resolve: (_, { phoneNumber, regionCode }) => {
-    const phoneUtil = PhoneNumberUtil.getInstance()
-    let parsedPhone: GooglePhoneNumber | undefined
-
-    try {
-      parsedPhone = phoneUtil.parse(phoneNumber, regionCode || "")
-    } catch (e) {
-      console.error("Parse phone number error: ", e)
-    }
-
-    return {
-      phoneNumber,
-      parsedPhone,
-      phoneUtil,
-    }
+    return resolvePhoneNumber({ phoneNumber, regionCode })
   },
 }

--- a/src/schema/v2/phoneNumber.ts
+++ b/src/schema/v2/phoneNumber.ts
@@ -108,8 +108,11 @@ export const PhoneNumberType: GraphQLObjectType<
       args: {
         format: PhoneNumberFormats,
       },
+      description: "A formatted phone number. Null if isValid is false",
       resolve: ({ parsedPhone, phoneUtil }, { format }) =>
-        parsedPhone && phoneUtil.format(parsedPhone, format),
+        parsedPhone && phoneUtil.isValidNumber(parsedPhone)
+          ? phoneUtil.format(parsedPhone, format)
+          : null,
     },
   },
 })
@@ -117,6 +120,10 @@ export const PhoneNumberType: GraphQLObjectType<
 export const resolvePhoneNumber = ({ phoneNumber, regionCode }) => {
   const phoneUtil = PhoneNumberUtil.getInstance()
   let parsedPhone: GooglePhoneNumber | undefined
+
+  if (!phoneNumber) {
+    return null
+  }
 
   try {
     parsedPhone = phoneUtil.parse(phoneNumber, regionCode || "")

--- a/src/schema/v2/phoneNumber.ts
+++ b/src/schema/v2/phoneNumber.ts
@@ -99,20 +99,22 @@ export const PhoneNumberType: GraphQLObjectType<
     },
     regionCode: {
       type: GraphQLString,
-      resolve: ({ parsedPhone, phoneUtil }) =>
-        parsedPhone &&
-        phoneUtil.getRegionCodeForNumber(parsedPhone)?.toLowerCase(),
+      resolve: ({ parsedPhone, phoneUtil }) => {
+        const countryCode = parsedPhone?.getCountryCode()
+        return (
+          countryCode &&
+          phoneUtil.getRegionCodeForCountryCode(countryCode)?.toLowerCase()
+        )
+      },
     },
     display: {
       type: GraphQLString,
       args: {
         format: PhoneNumberFormats,
       },
-      description: "A formatted phone number. Null if isValid is false",
+      description: "A formatted phone number if the number could be parsed",
       resolve: ({ parsedPhone, phoneUtil }, { format }) =>
-        parsedPhone && phoneUtil.isValidNumber(parsedPhone)
-          ? phoneUtil.format(parsedPhone, format)
-          : null,
+        parsedPhone && phoneUtil.format(parsedPhone, format),
     },
   },
 })

--- a/src/schema/v2/phoneNumber.ts
+++ b/src/schema/v2/phoneNumber.ts
@@ -94,10 +94,12 @@ export const PhoneNumberType: GraphQLObjectType<
       resolve: ({ phoneNumber }) => phoneNumber,
     },
     countryCode: {
+      description: "Numeric phone number country code",
       type: GraphQLString,
       resolve: ({ parsedPhone }) => parsedPhone?.getCountryCode(),
     },
     regionCode: {
+      description: "Two-letter region code (ISO 3166-1 alpha-2)",
       type: GraphQLString,
       resolve: ({ parsedPhone, phoneUtil }) => {
         const countryCode = parsedPhone?.getCountryCode()
@@ -145,9 +147,11 @@ export const PhoneNumber: GraphQLFieldConfig<any, ResolverContext> = {
   description: "Phone number information",
   args: {
     phoneNumber: {
+      description: "Phone number to parse",
       type: new GraphQLNonNull(GraphQLString),
     },
     regionCode: {
+      description: "Two-letter region code (ISO 3166-1 alpha-2)",
       type: GraphQLString,
     },
   },


### PR DESCRIPTION
type: **Feat**
relates to [EMI-2208] and artsy/force#15460

This PR adds the phone number type to an order's saved `fulfillmentDetails` object. I made minimal modifications to the existing type but it might deserve a larger conversation to make sure this wouldn't break something.

This assumes we would store country codes as the alpha2 code (technically case doesn't matter to the phone validation layer), not the `+{number}` code. This matches the behavior of the settings/shipping address modal which uses downcased alpha2.

This also includes a breaking schema change to the existing field it is replacing but I don't think we use it yet.

[EMI-2208]: https://artsyproduct.atlassian.net/browse/EMI-2208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ