### PR TITLE
fix(editionSets): Fix type for artistProofs

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10567,7 +10567,7 @@ input EditableLocation {
 }
 
 type EditionSet implements Sellable {
-  artistProofs: Boolean
+  artistProofs: String
   availability: String
   availableEditions: [String]
   depth: String

--- a/src/schema/v2/edition_set.ts
+++ b/src/schema/v2/edition_set.ts
@@ -41,7 +41,7 @@ export const EditionSetType = new GraphQLObjectType<any, ResolverContext>({
       resolve: ({ availability }) => availability,
     },
     artistProofs: {
-      type: GraphQLBoolean,
+      type: GraphQLString,
       resolve: ({ artist_proofs }) => artist_proofs,
     },
     availableEditions: {


### PR DESCRIPTION
The type was wrong here and surfaced in the /artworks2 validation in volt. 