### PR TITLE
feat(artworksConnection): Thread `artworkIDs` prop through to ES

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -341,6 +341,9 @@ type Alert {
     artistNationalities: [String]
     artistSeriesID: String
     artistSeriesIDs: [String]
+
+    # When provided, will only return artworks with these IDs.
+    artworkIDs: [String]
     atAuction: Boolean
     attributionClass: [String]
     availability: String
@@ -1744,6 +1747,9 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     artistNationalities: [String]
     artistSeriesID: String
     artistSeriesIDs: [String]
+
+    # When provided, will only return artworks with these IDs.
+    artworkIDs: [String]
     atAuction: Boolean
     attributionClass: [String]
     availability: String
@@ -2185,6 +2191,9 @@ type ArtistPartnerEdge {
     artistNationalities: [String]
     artistSeriesID: String
     artistSeriesIDs: [String]
+
+    # When provided, will only return artworks with these IDs.
+    artworkIDs: [String]
     atAuction: Boolean
     attributionClass: [String]
     availability: String
@@ -2335,6 +2344,9 @@ type ArtistSeries implements Node {
     artistNationalities: [String]
     artistSeriesID: String
     artistSeriesIDs: [String]
+
+    # When provided, will only return artworks with these IDs.
+    artworkIDs: [String]
     atAuction: Boolean
     attributionClass: [String]
     availability: String
@@ -10681,6 +10693,9 @@ interface EntityWithFilterArtworksConnectionInterface {
     artistNationalities: [String]
     artistSeriesID: String
     artistSeriesIDs: [String]
+
+    # When provided, will only return artworks with these IDs.
+    artworkIDs: [String]
     atAuction: Boolean
     attributionClass: [String]
     availability: String
@@ -10943,6 +10958,9 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
     artistNationalities: [String]
     artistSeriesID: String
     artistSeriesIDs: [String]
+
+    # When provided, will only return artworks with these IDs.
+    artworkIDs: [String]
     atAuction: Boolean
     attributionClass: [String]
     availability: String
@@ -11468,6 +11486,9 @@ input FilterArtworksInput {
   artistNationalities: [String]
   artistSeriesID: String
   artistSeriesIDs: [String]
+
+  # When provided, will only return artworks with these IDs.
+  artworkIDs: [String]
   atAuction: Boolean
   attributionClass: [String]
   availability: String
@@ -11990,6 +12011,9 @@ type Gene implements Node & Searchable {
     artistNationalities: [String]
     artistSeriesID: String
     artistSeriesIDs: [String]
+
+    # When provided, will only return artworks with these IDs.
+    artworkIDs: [String]
     atAuction: Boolean
     attributionClass: [String]
     availability: String
@@ -13940,6 +13964,9 @@ type MarketingCollection implements Node {
     artistNationalities: [String]
     artistSeriesID: String
     artistSeriesIDs: [String]
+
+    # When provided, will only return artworks with these IDs.
+    artworkIDs: [String]
     atAuction: Boolean
     attributionClass: [String]
     availability: String
@@ -16862,6 +16889,9 @@ type Partner implements Node {
     artistNationalities: [String]
     artistSeriesID: String
     artistSeriesIDs: [String]
+
+    # When provided, will only return artworks with these IDs.
+    artworkIDs: [String]
     atAuction: Boolean
     attributionClass: [String]
     availability: String
@@ -17180,6 +17210,9 @@ type PartnerArtist {
     artistNationalities: [String]
     artistSeriesID: String
     artistSeriesIDs: [String]
+
+    # When provided, will only return artworks with these IDs.
+    artworkIDs: [String]
     atAuction: Boolean
     attributionClass: [String]
     availability: String
@@ -17371,6 +17404,9 @@ type PartnerArtistEdge {
     artistNationalities: [String]
     artistSeriesID: String
     artistSeriesIDs: [String]
+
+    # When provided, will only return artworks with these IDs.
+    artworkIDs: [String]
     atAuction: Boolean
     attributionClass: [String]
     availability: String
@@ -18583,6 +18619,9 @@ type Query {
     artistNationalities: [String]
     artistSeriesID: String
     artistSeriesIDs: [String]
+
+    # When provided, will only return artworks with these IDs.
+    artworkIDs: [String]
     atAuction: Boolean
     attributionClass: [String]
     availability: String
@@ -21179,6 +21218,9 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
     artistNationalities: [String]
     artistSeriesID: String
     artistSeriesIDs: [String]
+
+    # When provided, will only return artworks with these IDs.
+    artworkIDs: [String]
     atAuction: Boolean
     attributionClass: [String]
     availability: String
@@ -21724,6 +21766,9 @@ type Tag implements Node {
     artistNationalities: [String]
     artistSeriesID: String
     artistSeriesIDs: [String]
+
+    # When provided, will only return artworks with these IDs.
+    artworkIDs: [String]
     atAuction: Boolean
     attributionClass: [String]
     availability: String
@@ -24220,6 +24265,9 @@ type Viewer {
     artistNationalities: [String]
     artistSeriesID: String
     artistSeriesIDs: [String]
+
+    # When provided, will only return artworks with these IDs.
+    artworkIDs: [String]
     atAuction: Boolean
     attributionClass: [String]
     availability: String

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -122,6 +122,10 @@ export const filterArtworksArgs: GraphQLFieldConfigArgumentMap = {
   artistSeriesIDs: {
     type: new GraphQLList(GraphQLString),
   },
+  artworkIDs: {
+    type: new GraphQLList(GraphQLString),
+    description: "When provided, will only return artworks with these IDs.",
+  },
   atAuction: {
     type: GraphQLBoolean,
   },
@@ -443,6 +447,7 @@ const convertFilterArgs = ({
   artistNationalities,
   artistSeriesID,
   artistSeriesIDs,
+  artworkIDs,
   atAuction,
   attributionClass,
   dimensionRange,
@@ -487,6 +492,7 @@ const convertFilterArgs = ({
     for_sale: forSale,
     gene_id: geneID,
     gene_ids: geneIDs,
+    ids: artworkIDs,
     include_all_json: includeAllJSON,
     include_artworks_by_followed_artists: includeArtworksByFollowedArtists,
     include_medium_filter_in_aggregation: includeMediumFilterInAggregation,


### PR DESCRIPTION
Threads this through so that we can filter based upon specific artwork IDs:

```graphql
query SpecificArtworks {
  artworksConnection(first:10, input:{ artworkIDs:[
    "67feb54f06661d00100a2e7f", 
    "67feb54fe12c8d0014a9da05", 
    "67d31fbbdec7ae0013cdba16"
  ] }) {
    edges {
      node {
        title
        artist {
          name
        }
      }
    }
  }
}
```

cc @artsy/amber-devs 