### PR TITLE
chore: allow multiple images to be added to a created artwork

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8709,10 +8709,16 @@ input CreateArtworkMutationInput {
   clientMutationId: String
 
   # The S3 bucket where the artwork image is stored.
-  imageS3Bucket: String!
+  imageS3Bucket: String @deprecated(reason: "Use imageS3Buckets instead.")
+
+  # The S3 buckets where the artwork images are stored. This is a list of bucket names.
+  imageS3Buckets: [String!]
 
   # The S3 key for the artwork image.
-  imageS3Key: String!
+  imageS3Key: String @deprecated(reason: "Use imageS3Keys instead.")
+
+  # The S3 keys for the artwork images. This is a list of object keys.
+  imageS3Keys: [String!]
 
   # The ID of the partner under which the artwork is created.
   partnerId: String!

--- a/src/schema/v2/artwork/__tests__/createArtworkMutation.test.ts
+++ b/src/schema/v2/artwork/__tests__/createArtworkMutation.test.ts
@@ -57,10 +57,35 @@ describe("CreateArtworkMutation", () => {
     }
   `
 
-  it("creates an artwork with an image", async () => {
-    const mockArtwork = {
-      _id: "artwork123",
+  const mutationWithMultipleImages = gql`
+    mutation {
+      createArtwork(
+        input: {
+          partnerId: "partner123"
+          artistIds: ["artist123", "artist456"]
+          imageS3Buckets: ["bucket1", "bucket2"]
+          imageS3Keys: ["key1", "key2"]
+        }
+      ) {
+        artworkOrError {
+          __typename
+          ... on CreateArtworkSuccess {
+            artwork {
+              internalID
+            }
+          }
+          ... on CreateArtworkFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
     }
+  `
+
+  it("creates an artwork with an image", async () => {
+    const mockArtwork = { _id: "artwork123" }
 
     const context = {
       artworkLoader: () => Promise.resolve(mockArtwork),
@@ -69,7 +94,6 @@ describe("CreateArtworkMutation", () => {
           artists: ["artist123", "artist456"],
           partner: "partner123",
         })
-
         return Promise.resolve(mockArtwork)
       },
       addImageToArtworkLoader: (artworkId, data) => {
@@ -78,7 +102,6 @@ describe("CreateArtworkMutation", () => {
           source_bucket: "artwork-images",
           source_key: "artworks/new_artwork.jpg",
         })
-
         return Promise.resolve({})
       },
       addArtworkToPartnerShowLoader: jest.fn(),
@@ -97,15 +120,11 @@ describe("CreateArtworkMutation", () => {
       },
     })
 
-    // Should not be called when partnerShowId is not provided
     expect(context.addArtworkToPartnerShowLoader).not.toHaveBeenCalled()
   })
 
   it("creates an artwork with an image and adds it to a partner show", async () => {
-    const mockArtwork = {
-      _id: "artwork123",
-    }
-
+    const mockArtwork = { _id: "artwork123" }
     const addArtworkToPartnerShowLoaderMock = jest.fn().mockResolvedValue({})
 
     const context = {
@@ -115,7 +134,6 @@ describe("CreateArtworkMutation", () => {
           artists: ["artist123", "artist456"],
           partner: "partner123",
         })
-
         return Promise.resolve(mockArtwork)
       },
       addImageToArtworkLoader: (artworkId, data) => {
@@ -124,7 +142,6 @@ describe("CreateArtworkMutation", () => {
           source_bucket: "artwork-images",
           source_key: "artworks/new_artwork.jpg",
         })
-
         return Promise.resolve({})
       },
       addArtworkToPartnerShowLoader: addArtworkToPartnerShowLoaderMock,
@@ -143,11 +160,60 @@ describe("CreateArtworkMutation", () => {
       },
     })
 
-    // Should be called with the right parameters
     expect(addArtworkToPartnerShowLoaderMock).toHaveBeenCalledWith({
       showId: "show123",
       artworkId: "artwork123",
       partnerId: "partner123",
     })
+  })
+
+  it("creates an artwork with multiple images", async () => {
+    const mockArtwork = { _id: "artwork123" }
+    const createArtworkLoaderMock = jest.fn().mockImplementation((data) => {
+      expect(data).toEqual({
+        artists: ["artist123", "artist456"],
+        partner: "partner123",
+      })
+      return Promise.resolve(mockArtwork)
+    })
+    const addImageToArtworkLoaderMock = jest.fn().mockResolvedValue({})
+    const context = {
+      artworkLoader: () => Promise.resolve(mockArtwork),
+      createArtworkLoader: createArtworkLoaderMock,
+      addImageToArtworkLoader: addImageToArtworkLoaderMock,
+      addArtworkToPartnerShowLoader: jest.fn(),
+    }
+
+    const result = await runAuthenticatedQuery(
+      mutationWithMultipleImages,
+      context
+    )
+
+    expect(result).toEqual({
+      createArtwork: {
+        artworkOrError: {
+          __typename: "CreateArtworkSuccess",
+          artwork: {
+            internalID: "artwork123",
+          },
+        },
+      },
+    })
+
+    // Should call once per bucket/key pair
+    expect(addImageToArtworkLoaderMock).toHaveBeenCalledTimes(2)
+    expect(addImageToArtworkLoaderMock).toHaveBeenNthCalledWith(
+      1,
+      "artwork123",
+      { source_bucket: "bucket1", source_key: "key1" }
+    )
+    expect(addImageToArtworkLoaderMock).toHaveBeenNthCalledWith(
+      2,
+      "artwork123",
+      { source_bucket: "bucket2", source_key: "key2" }
+    )
+
+    // Should not add to a show
+    expect(context.addArtworkToPartnerShowLoader).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
This updates our mutation to create an artwork (with an uploaded image via s3 bucket/key) to also support an array of s3 buckets/keys. There is some basic validation on those, and the mutation is backwards compatible - you can use _either_ the singular or plural form (although I've deprecated the singular form as the plural form can handle both).