### PR TITLE
chore: Add `vatInformation` calculated field to Partner

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17075,7 +17075,11 @@ type Partner implements Node {
   # A slug ID.
   slug: ID!
   type: String
+
+  # Returns VAT number or a fallback message based on the partner's VAT status.
+  vatInformation: String
   vatNumber: String
+  vatStatus: String
   viewingRoomsConnection(
     after: String
     before: String

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -937,6 +937,28 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLString,
         resolve: ({ vat_number }) => vat_number,
       },
+      vatStatus: {
+        type: GraphQLString,
+        resolve: ({ vat_status }) => vat_status,
+      },
+      vatInformation: {
+        type: GraphQLString,
+        description:
+          "Returns VAT number or a fallback message based on the partner's VAT status.",
+        resolve: ({ vat_status, vat_number }) => {
+          switch (vat_status) {
+            case "registered":
+            case "registered_and_exempt":
+              return vat_number
+            case "ineligible":
+              return "Not required"
+            case "exempt":
+              return "Exempt"
+            default:
+              return "None provided"
+          }
+        },
+      },
       hasFairPartnership: {
         type: GraphQLBoolean,
         resolve: ({ has_fair_partnership }) => has_fair_partnership,


### PR DESCRIPTION
In an attempt to reduce some ruby code in Volt, moving this informational VAT string calculation into Metaphysics
This data is rendered within the settings overview UI in CMS.

Where `vatInformation` will be the equivalent to this Volt ruby code ([ref](https://github.com/artsy/volt/blob/main/app/models/partner.rb#L299C1-L308C6))
```ruby
def self.vat_information(partner)
    case partner.vat_status
    when "registered", "registered_and_exempt"
      partner.vat_number
    when "ineligible", "exempt"
      I18n.t("settings.index.gallery_info.vat_id_number_#{partner.vat_status}")
    else
      I18n.t("settings.index.gallery_info.vat_id_number_fallback")
    end
  end
```

Which displays in CMS as so:
<img width="1562" alt="Screenshot 2025-04-21 at 11 47 18 AM" src="https://github.com/user-attachments/assets/2c119690-d1d0-4e13-84fe-9bcac6bab16a" />


---

## Example of MP query shape
```
query {
  partner(id: "commerce-test-partner"){
    vatNumber
    vatStatus
    vatInformation
  }
}
```
## Example of different strings:
<img width="500" alt="Screenshot 2025-04-21 at 12 44 20 PM" src="https://github.com/user-attachments/assets/bd83de44-23da-40a4-81bc-7555181edb92" />


<img width="500" alt="Screenshot 2025-04-21 at 1 00 53 PM" src="https://github.com/user-attachments/assets/96efdec1-a81d-4f73-b236-7db04e3ffb28" />

Needs some access level changes in the JSON API response to complete this calculation
- https://github.com/artsy/gravity/pull/18851/files