### PR TITLE
feat(settingsv2): Exposes mutation to update partner profile type images

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -23077,11 +23077,11 @@ union UpdatePartnerProfileImageOrError =
 
 type UpdatePartnerProfileImagePayload {
   clientMutationId: String
-  profileOrError: UpdatePartnerProfileImageOrError
+  imageOrError: UpdatePartnerProfileImageOrError
 }
 
 type UpdatePartnerProfileImageSuccess {
-  profile: Profile
+  image: Image
 }
 
 union UpdatePartnerResponseOrError = UpdatePartnerFailure | UpdatePartnerSuccess

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -23058,8 +23058,8 @@ type UpdatePartnerProfileImageFailure {
 input UpdatePartnerProfileImageInput {
   clientMutationId: String
 
-  # ID of the partner's profile
-  profileId: String!
+  # ID of the partner
+  partnerId: String!
 
   # S3 bucket containing the image to be uploaded
   remoteImageS3Bucket: String!
@@ -23077,11 +23077,11 @@ union UpdatePartnerProfileImageOrError =
 
 type UpdatePartnerProfileImagePayload {
   clientMutationId: String
-  imageOrError: UpdatePartnerProfileImageOrError
+  partnerOrError: UpdatePartnerProfileImageOrError
 }
 
 type UpdatePartnerProfileImageSuccess {
-  image: Image
+  partner: Partner
 }
 
 union UpdatePartnerResponseOrError = UpdatePartnerFailure | UpdatePartnerSuccess

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15959,10 +15959,10 @@ type Mutation {
     input: UpdatePartnerLocationInput!
   ): UpdatePartnerLocationPayload
 
-  # Updates the image icon for a partner
-  updatePartnerProfileIcon(
-    input: UpdatePartnerProfileIconInput!
-  ): UpdatePartnerProfileIconPayload
+  # Updates the icon or cover image for a partner's profile page
+  updatePartnerProfileImage(
+    input: UpdatePartnerProfileImageInput!
+  ): UpdatePartnerProfileImagePayload
 
   # Updates a partner show.
   updatePartnerShow(
@@ -23051,33 +23051,36 @@ type UpdatePartnerMutationPayload {
   partnerOrError: UpdatePartnerResponseOrError
 }
 
-type UpdatePartnerProfileIconFailure {
+type UpdatePartnerProfileImageFailure {
   mutationError: GravityMutationError
 }
 
-input UpdatePartnerProfileIconInput {
+input UpdatePartnerProfileImageInput {
   clientMutationId: String
-
-  # Gemini Token
-  geminiToken: String
 
   # ID of the partner's profile
   profileId: String!
 
-  # Profile icon image
-  remoteImageUrl: String
+  # S3 bucket containing the image to be uploaded
+  remoteImageS3Bucket: String!
+
+  # S3 key of the image to be uploaded
+  remoteImageS3Key: String!
+
+  # Can be of type Cover or Icon
+  type: String!
 }
 
-union UpdatePartnerProfileIconOrError =
-    UpdatePartnerProfileIconFailure
-  | UpdatePartnerProfileIconSuccess
+union UpdatePartnerProfileImageOrError =
+    UpdatePartnerProfileImageFailure
+  | UpdatePartnerProfileImageSuccess
 
-type UpdatePartnerProfileIconPayload {
+type UpdatePartnerProfileImagePayload {
   clientMutationId: String
-  profileOrError: UpdatePartnerProfileIconOrError
+  profileOrError: UpdatePartnerProfileImageOrError
 }
 
-type UpdatePartnerProfileIconSuccess {
+type UpdatePartnerProfileImageSuccess {
   profile: Profile
 }
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15926,6 +15926,11 @@ type Mutation {
     input: UpdatePartnerLocationInput!
   ): UpdatePartnerLocationPayload
 
+  # Updates the image icon for a partner
+  updatePartnerProfileIcon(
+    input: UpdatePartnerProfileIconInput!
+  ): UpdatePartnerProfileIconPayload
+
   # Updates a partner show.
   updatePartnerShow(
     input: UpdatePartnerShowMutationInput!
@@ -22993,6 +22998,36 @@ type UpdatePartnerMutationPayload {
 
   # On success: the updated partner. On error: the error that occurred.
   partnerOrError: UpdatePartnerResponseOrError
+}
+
+type UpdatePartnerProfileIconFailure {
+  mutationError: GravityMutationError
+}
+
+input UpdatePartnerProfileIconInput {
+  clientMutationId: String
+
+  # Gemini Token
+  geminiToken: String
+
+  # ID of the partner's profile
+  profileId: String!
+
+  # Profile icon image
+  remoteImageUrl: String
+}
+
+union UpdatePartnerProfileIconOrError =
+    UpdatePartnerProfileIconFailure
+  | UpdatePartnerProfileIconSuccess
+
+type UpdatePartnerProfileIconPayload {
+  clientMutationId: String
+  profileOrError: UpdatePartnerProfileIconOrError
+}
+
+type UpdatePartnerProfileIconSuccess {
+  profile: Profile
 }
 
 union UpdatePartnerResponseOrError = UpdatePartnerFailure | UpdatePartnerSuccess

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1243,10 +1243,8 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" }
     ),
-    // PUT /api/v1/profile/:id/cover_image
-    // POST /api/v1/profile/:id/icon
-    updatePartnerProfileIconLoader: gravityLoader(
-      (id) => `profile/${id}/icon`,
+    updatePartnerProfileImageLoader: gravityLoader(
+      (id) => `profile/${id}/images`,
       {},
       { method: "POST" } // intentional POST
     ),

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1243,6 +1243,13 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" }
     ),
+    // PUT /api/v1/profile/:id/cover_image
+    // POST /api/v1/profile/:id/icon
+    updatePartnerProfileIconLoader: gravityLoader(
+      (id) => `profile/${id}/icon`,
+      {},
+      { method: "POST" } // intentional POST
+    ),
     deletePartnerArtistLoader: gravityLoader<
       any,
       { partnerId: string; artistId: string }

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1244,7 +1244,7 @@ export default (accessToken, userID, opts) => {
       { method: "PUT" }
     ),
     updatePartnerProfileImageLoader: gravityLoader(
-      (id) => `profile/${id}/images`,
+      (id) => `partner/${id}/profile_images`,
       {},
       { method: "POST" } // intentional POST
     ),

--- a/src/schema/v2/partner/Settings/__tests__/updatePartnerProfileImageMutation.test.js
+++ b/src/schema/v2/partner/Settings/__tests__/updatePartnerProfileImageMutation.test.js
@@ -6,16 +6,16 @@ describe("UpdatePartnerProfileImageMutation", () => {
     mutation {
       updatePartnerProfileImage(
         input: {
-          profileId: "foo"
+          partnerId: "foo"
           type: "icon"
           remoteImageS3Key: "s3-key-here"
           remoteImageS3Bucket: "s3-bucket-here"
         }
       ) {
-        imageOrError {
+        partnerOrError {
           __typename
           ... on UpdatePartnerProfileImageSuccess {
-            image {
+            partner {
               internalID
             }
           }
@@ -33,7 +33,10 @@ describe("UpdatePartnerProfileImageMutation", () => {
     const context = {
       updatePartnerProfileImageLoader: () =>
         Promise.resolve({
-          id: "newly-created-image-id",
+          id: "profile-id",
+          owner: {
+            _id: "foo",
+          },
         }),
     }
 
@@ -41,10 +44,10 @@ describe("UpdatePartnerProfileImageMutation", () => {
 
     expect(updatedProfile).toEqual({
       updatePartnerProfileImage: {
-        imageOrError: {
+        partnerOrError: {
           __typename: "UpdatePartnerProfileImageSuccess",
-          image: {
-            internalID: "newly-created-image-id",
+          partner: {
+            internalID: "foo",
           },
         },
       },
@@ -66,7 +69,7 @@ describe("UpdatePartnerProfileImageMutation", () => {
 
       expect(updatedPartner).toEqual({
         updatePartnerProfileImage: {
-          imageOrError: {
+          partnerOrError: {
             __typename: "UpdatePartnerProfileImageFailure",
             mutationError: {
               message: "Profile not found",

--- a/src/schema/v2/partner/Settings/__tests__/updatePartnerProfileImageMutation.test.js
+++ b/src/schema/v2/partner/Settings/__tests__/updatePartnerProfileImageMutation.test.js
@@ -1,0 +1,86 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("UpdatePartnerProfileImageMutation", () => {
+  const mutation = gql`
+    mutation {
+      updatePartnerProfileImage(
+        input: {
+          profileId: "foo"
+          type: "icon"
+          remoteImageS3Key: "s3-key-here"
+          remoteImageS3Bucket: "s3-bucket-here"
+        }
+      ) {
+        profileOrError {
+          __typename
+          ... on UpdatePartnerProfileImageSuccess {
+            profile {
+              internalID
+              icon {
+                url
+              }
+            }
+          }
+          ... on UpdatePartnerProfileImageFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("updates the partner's given profile image", async () => {
+    const context = {
+      updatePartnerProfileImageLoader: () =>
+        Promise.resolve({
+          _id: "foo",
+          icon: { url: "https://image.url.com/" },
+        }),
+    }
+
+    const updatedProfile = await runAuthenticatedQuery(mutation, context)
+
+    expect(updatedProfile).toEqual({
+      updatePartnerProfileImage: {
+        profileOrError: {
+          __typename: "UpdatePartnerProfileImageSuccess",
+          profile: {
+            internalID: "foo",
+            icon: {
+              url: "https://image.url.com/",
+            },
+          },
+        },
+      },
+    })
+  })
+
+  describe("when profile is not found", () => {
+    it("returns an error", async () => {
+      const context = {
+        updatePartnerProfileImageLoader: () =>
+          Promise.reject(
+            new Error(
+              `https://stagingapi.artsy.net/api/v1/partners/foo/images/bar - {"type":"error","message":"Profile not found"}`
+            )
+          ),
+      }
+
+      const updatedPartner = await runAuthenticatedQuery(mutation, context)
+
+      expect(updatedPartner).toEqual({
+        updatePartnerProfileImage: {
+          profileOrError: {
+            __typename: "UpdatePartnerProfileImageFailure",
+            mutationError: {
+              message: "Profile not found",
+            },
+          },
+        },
+      })
+    })
+  })
+})

--- a/src/schema/v2/partner/Settings/__tests__/updatePartnerProfileImageMutation.test.js
+++ b/src/schema/v2/partner/Settings/__tests__/updatePartnerProfileImageMutation.test.js
@@ -12,14 +12,11 @@ describe("UpdatePartnerProfileImageMutation", () => {
           remoteImageS3Bucket: "s3-bucket-here"
         }
       ) {
-        profileOrError {
+        imageOrError {
           __typename
           ... on UpdatePartnerProfileImageSuccess {
-            profile {
+            image {
               internalID
-              icon {
-                url
-              }
             }
           }
           ... on UpdatePartnerProfileImageFailure {
@@ -36,8 +33,7 @@ describe("UpdatePartnerProfileImageMutation", () => {
     const context = {
       updatePartnerProfileImageLoader: () =>
         Promise.resolve({
-          _id: "foo",
-          icon: { url: "https://image.url.com/" },
+          id: "newly-created-image-id",
         }),
     }
 
@@ -45,13 +41,10 @@ describe("UpdatePartnerProfileImageMutation", () => {
 
     expect(updatedProfile).toEqual({
       updatePartnerProfileImage: {
-        profileOrError: {
+        imageOrError: {
           __typename: "UpdatePartnerProfileImageSuccess",
-          profile: {
-            internalID: "foo",
-            icon: {
-              url: "https://image.url.com/",
-            },
+          image: {
+            internalID: "newly-created-image-id",
           },
         },
       },
@@ -73,7 +66,7 @@ describe("UpdatePartnerProfileImageMutation", () => {
 
       expect(updatedPartner).toEqual({
         updatePartnerProfileImage: {
-          profileOrError: {
+          imageOrError: {
             __typename: "UpdatePartnerProfileImageFailure",
             mutationError: {
               message: "Profile not found",

--- a/src/schema/v2/partner/Settings/updatePartnerProfileIconMutation.ts
+++ b/src/schema/v2/partner/Settings/updatePartnerProfileIconMutation.ts
@@ -1,0 +1,100 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { ProfileType } from "schema/v2/profile"
+
+interface UpdatePartnerProfileIconInputProps {
+  profileId: string
+  geminiToken?: string
+  remoteImageUrl?: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdatePartnerProfileIconSuccess",
+  isTypeOf: (data) => !!data.id,
+  fields: () => ({
+    profile: {
+      type: ProfileType,
+      resolve: (result) => result,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdatePartnerProfileIconFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdatePartnerProfileIconOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const UpdatePartnerProfileIconMutation = mutationWithClientMutationId<
+  UpdatePartnerProfileIconInputProps,
+  any,
+  ResolverContext
+>({
+  name: "UpdatePartnerProfileIcon",
+  description: "Updates the image icon for a partner",
+  inputFields: {
+    profileId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "ID of the partner's profile",
+    },
+    geminiToken: {
+      type: GraphQLString,
+      description: "Gemini Token",
+    },
+    remoteImageUrl: {
+      type: GraphQLString,
+      description: "Profile icon image",
+    },
+  },
+  outputFields: {
+    profileOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { profileId, geminiToken, remoteImageUrl },
+    { updatePartnerProfileIconLoader }
+  ) => {
+    if (!updatePartnerProfileIconLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const response = await updatePartnerProfileIconLoader(profileId, {
+        gemini_token: geminiToken,
+        remove_image_url: remoteImageUrl,
+      })
+
+      console.log("response", response)
+      return response
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/Settings/updatePartnerProfileImageMutation.ts
+++ b/src/schema/v2/partner/Settings/updatePartnerProfileImageMutation.ts
@@ -10,7 +10,7 @@ import {
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
-import { ProfileType } from "schema/v2/profile"
+import { ImageType } from "schema/v2/image"
 
 interface UpdatePartnerProfileImageInputProps {
   profileId: string
@@ -21,10 +21,10 @@ interface UpdatePartnerProfileImageInputProps {
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
   name: "UpdatePartnerProfileImageSuccess",
-  isTypeOf: (data) => !!data._id,
+  isTypeOf: (data) => !!data.id,
   fields: () => ({
-    profile: {
-      type: ProfileType,
+    image: {
+      type: ImageType,
       resolve: (result) => result,
     },
   }),
@@ -72,7 +72,7 @@ export const UpdatePartnerProfileImageMutation = mutationWithClientMutationId<
     },
   },
   outputFields: {
-    profileOrError: {
+    imageOrError: {
       type: ResponseOrErrorType,
       resolve: (result) => result,
     },

--- a/src/schema/v2/partner/Settings/updatePartnerProfileImageMutation.ts
+++ b/src/schema/v2/partner/Settings/updatePartnerProfileImageMutation.ts
@@ -10,10 +10,10 @@ import {
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
-import { ImageType } from "schema/v2/image"
+import { PartnerType } from "../partner"
 
 interface UpdatePartnerProfileImageInputProps {
-  profileId: string
+  partnerId: string
   type: string
   remoteImageS3Key: string
   remoteImageS3Bucket: string
@@ -23,9 +23,9 @@ const SuccessType = new GraphQLObjectType<any, ResolverContext>({
   name: "UpdatePartnerProfileImageSuccess",
   isTypeOf: (data) => !!data.id,
   fields: () => ({
-    image: {
-      type: ImageType,
-      resolve: (result) => result,
+    partner: {
+      type: PartnerType,
+      resolve: (result) => result.owner,
     },
   }),
 })
@@ -54,9 +54,9 @@ export const UpdatePartnerProfileImageMutation = mutationWithClientMutationId<
   name: "UpdatePartnerProfileImage",
   description: "Updates the icon or cover image for a partner's profile page",
   inputFields: {
-    profileId: {
+    partnerId: {
       type: new GraphQLNonNull(GraphQLString),
-      description: "ID of the partner's profile",
+      description: "ID of the partner",
     },
     type: {
       type: new GraphQLNonNull(GraphQLString),
@@ -72,13 +72,13 @@ export const UpdatePartnerProfileImageMutation = mutationWithClientMutationId<
     },
   },
   outputFields: {
-    imageOrError: {
+    partnerOrError: {
       type: ResponseOrErrorType,
       resolve: (result) => result,
     },
   },
   mutateAndGetPayload: async (
-    { profileId, type, remoteImageS3Bucket, remoteImageS3Key },
+    { partnerId, type, remoteImageS3Bucket, remoteImageS3Key },
     { updatePartnerProfileImageLoader }
   ) => {
     if (!updatePartnerProfileImageLoader) {
@@ -86,7 +86,7 @@ export const UpdatePartnerProfileImageMutation = mutationWithClientMutationId<
     }
 
     try {
-      const response = await updatePartnerProfileImageLoader(profileId, {
+      const response = await updatePartnerProfileImageLoader(partnerId, {
         type,
         remote_image_s3_key: remoteImageS3Key,
         remote_image_s3_bucket: remoteImageS3Bucket,

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -318,7 +318,7 @@ import { DeletePartnerLocationMutation } from "./partner/Settings/deletePartnerL
 import { repositionPartnerLocationsMutation } from "./partner/Settings/repositionPartnerLocations"
 import { PartnerMatch } from "./match/partner"
 import { CreatePartnerLocationDaySchedulesMutation } from "./partner/Settings/createPartnerLocationDaySchedulesMutation"
-import { UpdatePartnerProfileIconMutation } from "./partner/Settings/updatePartnerProfileIconMutation"
+import { UpdatePartnerProfileImageMutation } from "./partner/Settings/updatePartnerProfileImageMutation"
 
 const rootFields = {
   // artworkVersion: ArtworkVersionResolver,
@@ -622,8 +622,7 @@ export default new GraphQLSchema({
       updatePage: UpdatePageMutation,
       updatePartnerContact: UpdatePartnerContactMutation,
       updatePartnerLocation: UpdatePartnerLocationMutation,
-      // generalize and consolidate!!!!!!!!!!!
-      updatePartnerProfileIcon: UpdatePartnerProfileIconMutation,
+      updatePartnerProfileImage: UpdatePartnerProfileImageMutation,
       updatePartnerShow: updatePartnerShowMutation,
       updateQuiz: updateQuizMutation,
       updateSaleAgreement: UpdateSaleAgreementMutation,

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -318,6 +318,7 @@ import { DeletePartnerLocationMutation } from "./partner/Settings/deletePartnerL
 import { repositionPartnerLocationsMutation } from "./partner/Settings/repositionPartnerLocations"
 import { PartnerMatch } from "./match/partner"
 import { CreatePartnerLocationDaySchedulesMutation } from "./partner/Settings/createPartnerLocationDaySchedulesMutation"
+import { UpdatePartnerProfileIconMutation } from "./partner/Settings/updatePartnerProfileIconMutation"
 
 const rootFields = {
   // artworkVersion: ArtworkVersionResolver,
@@ -621,6 +622,8 @@ export default new GraphQLSchema({
       updatePage: UpdatePageMutation,
       updatePartnerContact: UpdatePartnerContactMutation,
       updatePartnerLocation: UpdatePartnerLocationMutation,
+      // generalize and consolidate!!!!!!!!!!!
+      updatePartnerProfileIcon: UpdatePartnerProfileIconMutation,
       updatePartnerShow: updatePartnerShowMutation,
       updateQuiz: updateQuizMutation,
       updateSaleAgreement: UpdateSaleAgreementMutation,


### PR DESCRIPTION
 Exposes mutation to update partner profile type images
 
 Wires in Gravity's new endpoint ~[here](https://github.com/artsy/gravity/pull/18850/files)~ [here](https://github.com/artsy/gravity/pull/18852)
 
 Now using `partnerId` on the input type and returning the full partner object (`owner`) from the resolver
 
 Ex:
 
<img width="1684" alt="Screenshot 2025-04-22 at 9 17 24 AM" src="https://github.com/user-attachments/assets/9177fbb3-51fc-4045-b6b9-e69434fdb0c0" />
