### PR TITLE
chore: Add mutation to update profiles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+- Build: `yarn build`
+- Dev server: `yarn dev` or `yarn verbose-dev` for more logs
+- Lint: `yarn lint` (fix with `yarn lint:fix`)
+- Type check: `yarn type-check`
+- Test all: `yarn test`
+- Test single file: `yarn jest path/to/file.test.ts`
+- Watch tests: `yarn jest --watch`
+- Format code: `yarn prettier-project`
+
+## Code Style
+- TypeScript with strict typing
+- Prettier formatting: no semicolons, double quotes, trailing commas
+- Use camelCase for variables, PascalCase for types/interfaces
+- Avoid any when possible, but allowed when necessary
+- Unused variables should be prefixed with `_`
+- Jest for testing with descriptive test names
+- GraphQL queries use the `gql` tag from lib/gql
+- Organize imports logically (internal vs external)
+- Follow React best practices for component structure

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15990,6 +15990,11 @@ type Mutation {
     input: UpdatePartnerShowEventMutationInput!
   ): UpdatePartnerShowEventMutationPayload
 
+  # Updates a profile.
+  updateProfile(
+    input: UpdateProfileMutationInput!
+  ): UpdateProfileMutationPayload
+
   # Update a quiz artwork interacted_with flag
   updateQuiz(input: updateQuizMutationInput!): updateQuizMutationPayload
 
@@ -23256,6 +23261,50 @@ type UpdatePartnerShowSuccess {
 
 type UpdatePartnerSuccess {
   partner: Partner
+}
+
+type UpdateProfileFailure {
+  mutationError: GravityMutationError
+}
+
+input UpdateProfileMutationInput {
+  # Short bio (275 character max).
+  bio: String
+  clientMutationId: String
+
+  # Full bio (800 character max).
+  fullBio: String
+
+  # Unique handle.
+  handle: String
+
+  # The id of the profile to update.
+  id: String!
+
+  # Private profiles hide certain features for non admins.
+  isPrivate: Boolean
+
+  # Location.
+  location: String
+
+  # Menu color class.
+  menuColorClass: String
+
+  # Website.
+  website: String
+}
+
+type UpdateProfileMutationPayload {
+  clientMutationId: String
+
+  # On success: the updated profile. On error: the error that occurred.
+  profileOrError: UpdateProfileResponseOrError
+}
+
+union UpdateProfileResponseOrError = UpdateProfileFailure | UpdateProfileSuccess
+
+type UpdateProfileSuccess {
+  profile: Profile
 }
 
 type UpdateSaleAgreementFailure {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1299,6 +1299,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" }
     ),
+    updateProfileLoader: gravityLoader(
+      (id) => `profile/${id}`,
+      {},
+      { method: "PUT" }
+    ),
     updateSaleAgreementLoader: gravityLoader(
       (id) => `sale_agreements/${id}`,
       {},

--- a/src/schema/v2/profile/__tests__/updateProfileMutation.test.ts
+++ b/src/schema/v2/profile/__tests__/updateProfileMutation.test.ts
@@ -1,0 +1,104 @@
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("updateProfileMutation", () => {
+  it("updates a profile", async () => {
+    const context = {
+      updateProfileLoader: jest.fn().mockResolvedValue({
+        _id: "profile123",
+        id: "profile123",
+        bio: "New bio",
+        full_bio: "Full biography text here",
+      }),
+    }
+
+    const mutation = gql`
+      mutation {
+        updateProfile(
+          input: {
+            id: "profile123"
+            handle: "new-handle"
+            bio: "New bio"
+            fullBio: "Full biography text here"
+            website: "http://example.com"
+            location: "New York"
+            isPrivate: true
+          }
+        ) {
+          profileOrError {
+            ... on UpdateProfileSuccess {
+              profile {
+                id
+                bio
+                fullBio
+              }
+            }
+            ... on UpdateProfileFailure {
+              mutationError {
+                message
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runAuthenticatedQuery(mutation, context)
+    expect(context.updateProfileLoader).toHaveBeenCalledWith("profile123", {
+      handle: "new-handle",
+      bio: "New bio",
+      full_bio: "Full biography text here",
+      website: "http://example.com",
+      location: "New York",
+      private: true,
+    })
+
+    // ID is returned as a base64-encoded value
+    expect(typeof data.updateProfile.profileOrError.profile.id).toBe("string")
+    expect(data.updateProfile.profileOrError.profile.bio).toBe("New bio")
+    expect(data.updateProfile.profileOrError.profile.fullBio).toBe("Full biography text here")
+  })
+
+  it("returns an error if the mutation fails", async () => {
+    const context = {
+      updateProfileLoader: jest.fn().mockRejectedValue({
+        statusCode: 400,
+        body: {
+          type: "param_error",
+          message: "Handle already taken",
+          detail: "The handle is already in use by another profile",
+        },
+        error: "Bad Request",
+      }),
+    }
+
+    const mutation = gql`
+      mutation {
+        updateProfile(
+          input: {
+            id: "profile123"
+            handle: "existing-handle"
+          }
+        ) {
+          profileOrError {
+            ... on UpdateProfileSuccess {
+              profile {
+                id
+              }
+            }
+            ... on UpdateProfileFailure {
+              mutationError {
+                message
+                type
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runAuthenticatedQuery(mutation, context)
+    expect(data.updateProfile.profileOrError.mutationError.type).toBe("param_error")
+    expect(data.updateProfile.profileOrError.mutationError.message).toBe("Handle already taken")
+  })
+})

--- a/src/schema/v2/profile/updateProfileMutation.ts
+++ b/src/schema/v2/profile/updateProfileMutation.ts
@@ -1,0 +1,135 @@
+import {
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLUnionType,
+  GraphQLBoolean,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ProfileType } from "../profile"
+import { ResolverContext } from "types/graphql"
+
+interface UpdateProfileMutationInputProps {
+  id: string
+  handle?: string | null
+  bio?: string | null
+  fullBio?: string | null
+  website?: string | null
+  location?: string | null
+  isPrivate?: boolean | null
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateProfileSuccess",
+  isTypeOf: (data) => data._id,
+  fields: () => ({
+    profile: {
+      type: ProfileType,
+      resolve: (profile) => profile,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateProfileFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdateProfileResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const updateProfileMutation = mutationWithClientMutationId<
+  UpdateProfileMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "UpdateProfileMutation",
+  description: "Updates a profile.",
+  inputFields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The id of the profile to update.",
+    },
+    handle: {
+      type: GraphQLString,
+      description: "Unique handle.",
+    },
+    bio: {
+      type: GraphQLString,
+      description: "Short bio (275 character max).",
+    },
+    fullBio: {
+      type: GraphQLString,
+      description: "Full bio (800 character max).",
+    },
+    website: {
+      type: GraphQLString,
+      description: "Website.",
+    },
+    location: {
+      type: GraphQLString,
+      description: "Location.",
+    },
+    isPrivate: {
+      type: GraphQLBoolean,
+      description: "Private profiles hide certain features for non admins.",
+    },
+  },
+  outputFields: {
+    profileOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the updated profile. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    {
+      id,
+      handle,
+      bio,
+      fullBio,
+      website,
+      location,
+      isPrivate,
+    },
+    { updateProfileLoader }
+  ) => {
+    if (!updateProfileLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const profileData = {
+        handle,
+        bio,
+        full_bio: fullBio,
+        website,
+        location,
+        private: isPrivate,
+      }
+
+      const response = await updateProfileLoader(id, profileData)
+      return response
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -197,6 +197,7 @@ import { PartnerShowDocumentsConnection } from "./partner/partnerShowDocumentsCo
 import { updateCMSLastAccessTimestampMutation } from "./partner/updateCMSLastAccessTimestampMutation"
 import { updatePartnerFlagsMutation } from "./partner/updatePartnerFlagsMutation"
 import { updatePartnerMutation } from "./partner/updatePartnerMutation"
+import { updateProfileMutation } from "./profile/updateProfileMutation"
 import { PaymentMethodUnion, WireTransferType } from "./payment_method_union"
 import { PhoneNumber } from "./phoneNumber"
 import { PreviewSavedSearchField } from "./previewSavedSearch"
@@ -634,6 +635,7 @@ export default new GraphQLSchema({
       updatePartnerShowEvent: updatePartnerShowEventMutation,
       updatePartner: updatePartnerMutation,
       updatePartnerFlags: updatePartnerFlagsMutation,
+      updateProfile: updateProfileMutation,
       updateUser: updateUserMutation,
       updateUserInterest: updateUserInterestMutation,
       updateUserInterests: updateUserInterestsMutation,


### PR DESCRIPTION
This PR adds a basic mutation to update a `Profile` record over in Gravity. I used Claude to come up with a plan to add this mutation as it did over on https://github.com/artsy/metaphysics/pull/6632 and https://github.com/artsy/metaphysics/pull/6638 but something seems to have gone a little sideways. Will fix what's wrong and get this back on track!

/cc @artsy/amber-devs 