### PR TITLE
chore: AMBER-1530 - adding medium to match its addition in Gravity

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3309,6 +3309,7 @@ type ArtworkImportTransformedData {
   diameter: String
   height: String
   imageFileNames: String
+  medium: String
   price: String
   width: String
 }

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -171,6 +171,10 @@ const ArtworkImportRowType = new GraphQLObjectType({
               type: GraphQLString,
               resolve: ({ Width }) => Width,
             },
+            medium: {
+              type: GraphQLString,
+              resolve: ({ Medium }) => Medium,
+            },
           },
         })
       ),


### PR DESCRIPTION
Partially solves [AMBER-1530]

Maps the new `medium` value added in https://github.com/artsy/gravity/pull/18854

[AMBER-1530]: https://artsyproduct.atlassian.net/browse/AMBER-1530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ