### PR TITLE
fix: Add single profileLoader to loaders with authentication

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -23287,9 +23287,6 @@ input UpdateProfileMutationInput {
   # Location.
   location: String
 
-  # Menu color class.
-  menuColorClass: String
-
   # Website.
   website: String
 }

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -978,6 +978,7 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    profileLoader: gravityLoader((id) => `profile/${id}`),
     repositionPartnerLocationsLoader: gravityLoader(
       (id) => `partner/${id}/locations/reposition`,
       {},


### PR DESCRIPTION
Add a singular `profileLoader` to loaders with authentication

Noticed I was getting `403` accessing partner profile information in MP + Volt even though I was associated with the profile

## Before Example
<img width="1413" alt="Screenshot 2025-04-23 at 5 00 56 PM" src="https://github.com/user-attachments/assets/3eeb84cd-4483-4689-8f61-9d69368c88b9" />


## After Example
<img width="1512" alt="Screenshot 2025-04-23 at 5 02 07 PM" src="https://github.com/user-attachments/assets/dff100ff-78fb-4fa4-8b16-27d094cd065f" />

