### PR TITLE
feat(onyx-1669): add purchase root field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -19578,6 +19578,10 @@ type Query {
     # If present, will search by term
     term: String
   ): ProfileConnection
+  purchase(
+    # The ID of the purchase
+    id: String!
+  ): Purchase
 
   # A list of purchases made by users.
   purchasesConnection(
@@ -25145,6 +25149,10 @@ type Viewer {
     # If present, will search by term
     term: String
   ): ProfileConnection
+  purchase(
+    # The ID of the purchase
+    id: String!
+  ): Purchase
 
   # A list of purchases made by users.
   purchasesConnection(

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1050,6 +1050,7 @@ export default (accessToken, userID, opts) => {
     partnersLoader: gravityLoader("partners", {}, { headers: true }),
     popularArtistsLoader: gravityLoader("artists/popular"),
     profilesLoader: gravityLoader("profiles", {}, { headers: true }),
+    purchaseLoader: gravityLoader((id) => `purchase/${id}`),
     purchasesLoader: gravityLoader("purchases", {}, { headers: true }),
     recordArtworkViewLoader: gravityLoader(
       "me/Recently_viewed_artworks",

--- a/src/schema/v2/__tests__/purchase.test.ts
+++ b/src/schema/v2/__tests__/purchase.test.ts
@@ -1,0 +1,121 @@
+import { runQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+import sinon from "sinon"
+
+describe("purchase", () => {
+  const purchaseMockData = {
+    id: "purchase-id",
+    artsy_commission: 25.5,
+    artwork: { _id: "artwork-id" },
+    created_at: "2025-04-14T00:00:00Z",
+    discover_admin: { id: "discover-user-id" },
+    email: "email@example.com",
+    fair: { _id: "fair-id" },
+    note: "Test purchase",
+    owner_type: "bid",
+    sale: { _id: "sale-id" },
+    sale_admin: { id: "sale-user-id" },
+    sale_price: 1984,
+    sale_date: "2025-04-14T00:00:00Z",
+    source: "auction",
+    user: { id: "user-id" },
+  }
+
+  it("resolves a purchase", async () => {
+    const context = {
+      purchaseLoader: sinon
+        .stub()
+        .withArgs({
+          id: "purchase-id",
+        })
+        .returns(Promise.resolve(purchaseMockData)),
+    }
+
+    const query = gql`
+      {
+        purchase(id: "purchase-id") {
+          internalID
+          artsyCommission
+          artwork {
+            internalID
+          }
+          createdAt
+          discoverAdmin {
+            internalID
+          }
+          email
+          fair {
+            internalID
+          }
+          note
+          ownerType
+          sale {
+            internalID
+          }
+          saleAdmin {
+            internalID
+          }
+          salePrice
+          saleDate
+          source
+          user {
+            internalID
+          }
+        }
+      }
+    `
+
+    const { purchase } = await runQuery(query, context)
+
+    expect(purchase).toMatchInlineSnapshot(`
+      {
+        "artsyCommission": 25.5,
+        "artwork": {
+          "internalID": "artwork-id",
+        },
+        "createdAt": "2025-04-14T00:00:00Z",
+        "discoverAdmin": {
+          "internalID": "discover-user-id",
+        },
+        "email": "email@example.com",
+        "fair": {
+          "internalID": "fair-id",
+        },
+        "internalID": "purchase-id",
+        "note": "Test purchase",
+        "ownerType": "bid",
+        "sale": {
+          "internalID": "sale-id",
+        },
+        "saleAdmin": {
+          "internalID": "sale-user-id",
+        },
+        "saleDate": "2025-04-14T00:00:00Z",
+        "salePrice": 1984,
+        "source": "auction",
+        "user": {
+          "internalID": "user-id",
+        },
+      }
+    `)
+
+    expect(context.purchaseLoader.callCount).toEqual(1)
+    expect(context.purchaseLoader.args[0][0]).toEqual("purchase-id")
+  })
+
+  it("throws an error if purchaseLoader is not available", async () => {
+    const context = {}
+
+    const query = gql`
+      {
+        purchase(id: "purchase-id") {
+          internalID
+        }
+      }
+    `
+
+    await expect(runQuery(query, context)).rejects.toThrow(
+      "A X-Access-Token header is required to perform this action."
+    )
+  })
+})

--- a/src/schema/v2/__tests__/purchase.test.ts
+++ b/src/schema/v2/__tests__/purchase.test.ts
@@ -1,6 +1,5 @@
 import { runQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
-import sinon from "sinon"
 
 describe("purchase", () => {
   const purchaseMockData = {
@@ -22,13 +21,10 @@ describe("purchase", () => {
   }
 
   it("resolves a purchase", async () => {
+    const purchaseLoader = jest.fn().mockResolvedValue(purchaseMockData)
+
     const context = {
-      purchaseLoader: sinon
-        .stub()
-        .withArgs({
-          id: "purchase-id",
-        })
-        .returns(Promise.resolve(purchaseMockData)),
+      purchaseLoader,
     }
 
     const query = gql`
@@ -99,8 +95,8 @@ describe("purchase", () => {
       }
     `)
 
-    expect(context.purchaseLoader.callCount).toEqual(1)
-    expect(context.purchaseLoader.args[0][0]).toEqual("purchase-id")
+    expect(purchaseLoader).toHaveBeenCalledTimes(1)
+    expect(purchaseLoader).toHaveBeenCalledWith("purchase-id")
   })
 
   it("throws an error if purchaseLoader is not available", async () => {

--- a/src/schema/v2/__tests__/purchases.test.ts
+++ b/src/schema/v2/__tests__/purchases.test.ts
@@ -1,6 +1,5 @@
 import { runQuery } from "schema/v2/test/utils"
 import gql from "lib/gql"
-import sinon from "sinon"
 
 describe("purchases", () => {
   describe("purchasesConnection", () => {
@@ -25,24 +24,12 @@ describe("purchases", () => {
     ]
 
     it("resolves a connection with all query arguments", async () => {
+      const purchasesLoader = jest.fn().mockResolvedValue({
+        headers: { "x-total-count": 1 },
+        body: purchasesMockData,
+      })
       const context = {
-        purchasesLoader: sinon
-          .stub()
-          .withArgs({
-            artwork_id: "artwork-id",
-            artist_id: "artist-id",
-            sale_id: "sale-id",
-            user_id: "user-id",
-            page: 1,
-            size: 5,
-            total_count: true,
-          })
-          .returns(
-            Promise.resolve({
-              headers: { "x-total-count": 1 },
-              body: purchasesMockData,
-            })
-          ),
+        purchasesLoader,
       }
 
       const query = gql`
@@ -131,8 +118,8 @@ describe("purchases", () => {
         }
       `)
 
-      expect(context.purchasesLoader.callCount).toEqual(1)
-      expect(context.purchasesLoader.args[0][0]).toEqual({
+      expect(purchasesLoader).toHaveBeenCalledTimes(1)
+      expect(purchasesLoader).toHaveBeenCalledWith({
         artwork_id: "artwork-id",
         artist_id: "artist-id",
         sale_id: "sale-id",
@@ -144,21 +131,12 @@ describe("purchases", () => {
     })
 
     it("only passes non-empty arguments to the loader", async () => {
+      const purchasesLoader = jest.fn().mockResolvedValue({
+        headers: { "x-total-count": 1 },
+        body: purchasesMockData,
+      })
       const context = {
-        purchasesLoader: sinon
-          .stub()
-          .withArgs({
-            artwork_id: "artwork-id",
-            page: 1,
-            size: 5,
-            total_count: true,
-          })
-          .returns(
-            Promise.resolve({
-              headers: { "x-total-count": 1 },
-              body: purchasesMockData,
-            })
-          ),
+        purchasesLoader,
       }
 
       const query = gql`
@@ -181,17 +159,13 @@ describe("purchases", () => {
         internalID: "purchase-id",
       })
 
-      // Verify that empty args like artist_id were not passed to gravity
-      expect(context.purchasesLoader.callCount).toEqual(1)
-      expect(context.purchasesLoader.args[0][0]).toEqual({
+      expect(purchasesLoader).toHaveBeenCalledTimes(1)
+      expect(purchasesLoader).toHaveBeenCalledWith({
         artwork_id: "artwork-id",
         page: 1,
         size: 5,
         total_count: true,
       })
-      expect(context.purchasesLoader.args[0][0].artist_id).toBeUndefined()
-      expect(context.purchasesLoader.args[0][0].sale_id).toBeUndefined()
-      expect(context.purchasesLoader.args[0][0].user_id).toBeUndefined()
     })
 
     it("throws an error if purchasesLoader is not available", async () => {

--- a/src/schema/v2/purchase.ts
+++ b/src/schema/v2/purchase.ts
@@ -1,0 +1,84 @@
+import {
+  GraphQLFloat,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import type { GraphQLFieldConfig } from "graphql"
+import type { ResolverContext } from "types/graphql"
+import { IDFields, NodeInterface } from "./object_identification"
+import { ArtworkType } from "./artwork"
+import { date } from "./fields/date"
+import { UserType } from "./user"
+import { FairType } from "./fair"
+import { SaleType } from "./sale"
+
+export const PurchaseType = new GraphQLObjectType<any, ResolverContext>({
+  name: "Purchase",
+  interfaces: [NodeInterface],
+  fields: {
+    ...IDFields,
+    artsyCommission: {
+      type: GraphQLFloat,
+      resolve: ({ artsy_commission }) => artsy_commission,
+    },
+    artwork: {
+      type: ArtworkType,
+    },
+    createdAt: date(({ created_at }) => created_at),
+    discoverAdmin: {
+      type: UserType,
+      description: "Person who found the sale",
+      resolve: ({ discover_admin }) => discover_admin,
+    },
+    email: {
+      type: GraphQLString,
+    },
+    fair: {
+      type: FairType,
+    },
+    note: {
+      type: GraphQLString,
+    },
+    ownerType: {
+      type: GraphQLString,
+      resolve: ({ owner_type }) => owner_type,
+    },
+    sale: {
+      type: SaleType,
+    },
+    saleAdmin: {
+      type: UserType,
+      description: "Person who facilitated the sale",
+      resolve: ({ sale_admin }) => sale_admin,
+    },
+    salePrice: {
+      type: GraphQLFloat,
+      resolve: ({ sale_price }) => sale_price,
+    },
+    saleDate: date(({ sale_date }) => sale_date),
+    source: { type: GraphQLString },
+    user: {
+      type: UserType,
+    },
+  },
+})
+
+export const Purchase: GraphQLFieldConfig<void, ResolverContext> = {
+  type: PurchaseType,
+  args: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the purchase",
+    },
+  },
+  resolve: async (_root, { id }, { purchaseLoader }) => {
+    if (!purchaseLoader) {
+      throw new Error(
+        "A X-Access-Token header is required to perform this action."
+      )
+    }
+
+    return purchaseLoader(id)
+  },
+}

--- a/src/schema/v2/purchases.ts
+++ b/src/schema/v2/purchases.ts
@@ -1,75 +1,14 @@
 import type { ResolverContext } from "types/graphql"
-import {
-  GraphQLString,
-  GraphQLFloat,
-  GraphQLObjectType,
-  GraphQLInt,
-} from "graphql"
+import { GraphQLString, GraphQLInt } from "graphql"
 import type { GraphQLFieldConfig } from "graphql"
-import { IDFields, NodeInterface } from "./object_identification"
-import { ArtworkType } from "./artwork"
 import {
   connectionWithCursorInfo,
   paginationResolver,
 } from "schema/v2/fields/pagination"
-import { date } from "./fields/date"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { pageable } from "relay-cursor-paging"
-import { UserType } from "./user"
-import { FairType } from "./fair"
-import { SaleType } from "./sale"
 import { identity, pickBy } from "lodash"
-
-const PurchaseType = new GraphQLObjectType<any, ResolverContext>({
-  name: "Purchase",
-  interfaces: [NodeInterface],
-  fields: {
-    ...IDFields,
-    artsyCommission: {
-      type: GraphQLFloat,
-      resolve: ({ artsy_commission }) => artsy_commission,
-    },
-    artwork: {
-      type: ArtworkType,
-    },
-    createdAt: date(({ created_at }) => created_at),
-    discoverAdmin: {
-      type: UserType,
-      description: "Person who found the sale",
-      resolve: ({ discover_admin }) => discover_admin,
-    },
-    email: {
-      type: GraphQLString,
-    },
-    fair: {
-      type: FairType,
-    },
-    note: {
-      type: GraphQLString,
-    },
-    ownerType: {
-      type: GraphQLString,
-      resolve: ({ owner_type }) => owner_type,
-    },
-    sale: {
-      type: SaleType,
-    },
-    saleAdmin: {
-      type: UserType,
-      description: "Person who facilitated the sale",
-      resolve: ({ sale_admin }) => sale_admin,
-    },
-    salePrice: {
-      type: GraphQLFloat,
-      resolve: ({ sale_price }) => sale_price,
-    },
-    saleDate: date(({ sale_date }) => sale_date),
-    source: { type: GraphQLString },
-    user: {
-      type: UserType,
-    },
-  },
-})
+import { PurchaseType } from "./purchase"
 
 export const PurchasesConnection: GraphQLFieldConfig<void, ResolverContext> = {
   type: connectionWithCursorInfo({

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -321,6 +321,7 @@ import { PartnerMatch } from "./match/partner"
 import { CreatePartnerLocationDaySchedulesMutation } from "./partner/Settings/createPartnerLocationDaySchedulesMutation"
 import { UpdatePartnerProfileImageMutation } from "./partner/Settings/updatePartnerProfileImageMutation"
 import { PurchasesConnection } from "./purchases"
+import { Purchase } from "./purchase"
 
 const rootFields = {
   // artworkVersion: ArtworkVersionResolver,
@@ -425,6 +426,7 @@ const rootFields = {
   previewSavedSearch: PreviewSavedSearchField,
   profile: Profile,
   profilesConnection: Profiles,
+  purchase: Purchase,
   purchasesConnection: PurchasesConnection,
   recentlySoldArtworks: RecentlySoldArtworks,
   requestLocation: RequestLocationField,


### PR DESCRIPTION
As part of our effort to finalize the Torque deprecation, we are migrating the Purchases section to Forque. This PR adds `purchase(id: ...)` root field so that we could render /purchase/:id page there

```graphql
{
  purchase(id: "purchase-id") {
    internalID
}
```