### PR TITLE
chore: Improve mutation to update partner records

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -23089,6 +23089,9 @@ type UpdatePartnerLocationSuccess {
 }
 
 input UpdatePartnerMutationInput {
+  # Admin assigned for this partner.
+  adminId: String
+
   # Alternate names or synonyms for this partner.
   alternateNames: [String]
 
@@ -23096,11 +23099,17 @@ input UpdatePartnerMutationInput {
   artsyCollectsSalesTax: Boolean
   clientMutationId: String
 
+  # Partner could opt their works to buy now / make offer and accept payments using their merchant account.
+  commerceEnabled: Boolean
+
   # Commission paid by non-subscriber/fair partner.
   commissionRate: Float
 
   # Contract type.
   contractType: String
+
+  # Include in Criteo artwork report.
+  criteoEligible: Boolean
 
   # Whether the partner is directly contactable.
   directlyContactable: Boolean
@@ -23120,14 +23129,41 @@ input UpdatePartnerMutationInput {
   # The email of the partner.
   email: String
 
+  # Whether the partner should have access to ACH payment method on subscriptions.
+  enableAchPaymentMethod: Boolean
+
+  # Triggers partner on platform transaction notifications.
+  enforceOnPlatformTransactions: Boolean
+
+  # Suggested filters for associated artworks.
+  featuredKeywords: [String]
+
   # The given name of the partner.
   givenName: String
 
   # Profile completeness.
   hasFullProfile: Boolean
 
+  # Whether this partner has limited Folio access.
+  hasLimitedFolioAccess: Boolean
+
   # The id of the partner to update.
   id: String!
+
+  # Partner can have artworks implictly enrolled as 'Make Offer' on the artwork page.
+  implicitOfferEnabled: Boolean
+
+  # Partner could list artworks for purchasing from inquiry conversations.
+  inquiryOrderEnabled: Boolean
+
+  # Whether the partner is managed by ERP for subscriptions.
+  managedByErp: Boolean
+
+  # Admin that signed up this partner.
+  outreachAdminId: String
+
+  # Array of partner slugs to assign to this partner.
+  partnerCategories: [String]
 
   # Whether the partner requires pre-qualification.
   preQualify: Boolean
@@ -23138,8 +23174,17 @@ input UpdatePartnerMutationInput {
   # Banner display on the profile overview page.
   profileBannerDisplay: String
 
+  # Admin that referred this partner and gets the commission.
+  referralContactId: String
+
   # The region of the partner.
   region: String
+
+  # Size of the partner.
+  relativeSize: Int
+
+  # Partner is required to configure a merchant account.
+  requiresMerchantAccount: Boolean
 
   # The short name of the partner.
   shortName: String
@@ -23150,8 +23195,23 @@ input UpdatePartnerMutationInput {
   # Type of the partner.
   type: String
 
+  # Whether the partner's VAT exempt status is approved by Artsy.
+  vatExemptApproved: Boolean
+
+  # The VAT identification number belonging to this partner.
+  vatNumber: String
+
+  # Whether the partner is registered, registered_and_exempt, exempt, or ineligible for a VAT identification number.
+  vatStatus: String
+
+  # Indicates the partner is a trusted seller on Artsy.
+  verifiedSeller: Boolean
+
   # The website of the partner.
   website: String
+
+  # Indicates the partner is eligible for manual wire transfers.
+  wireTransferEnabled: Boolean
 }
 
 type UpdatePartnerMutationPayload {

--- a/src/schema/v2/partner/updatePartnerMutation.ts
+++ b/src/schema/v2/partner/updatePartnerMutation.ts
@@ -6,6 +6,7 @@ import {
   GraphQLBoolean,
   GraphQLFloat,
   GraphQLList,
+  GraphQLInt,
 } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 import {
@@ -17,9 +18,12 @@ import { ResolverContext } from "types/graphql"
 
 interface UpdatePartnerMutationInputProps {
   id: string
+  adminId?: string | null
   alternateNames?: string[] | null
   artsyCollectsSalesTax?: boolean | null
   commissionRate?: number | null
+  commerceEnabled?: boolean | null
+  criteoEligible?: boolean | null
   contractType?: string | null
   directlyContactable?: boolean | null
   displayArtistsSection?: boolean | null
@@ -27,16 +31,33 @@ interface UpdatePartnerMutationInputProps {
   displayWorksSection?: boolean | null
   distinguishRepresentedArtists?: boolean | null
   email?: string | null
+  enableAchPaymentMethod?: boolean | null
+  enforceOnPlatformTransactions?: boolean | null
+  featuredKeywords?: string[] | null
   givenName?: string | null
   hasFullProfile?: boolean | null
+  hasLimitedFolioAccess?: boolean | null
+  implicitOfferEnabled?: boolean | null
+  inquiryOrderEnabled?: boolean | null
+  managedByErp?: boolean | null
+  outreachAdminId?: string | null
+  partnerCategories?: string[] | null
   preQualify?: boolean | null
   profileArtistsLayout?: string | null
   profileBannerDisplay?: string | null
+  referralContactId?: string | null
   region?: string | null
+  relativeSize?: number | null
+  requiresMerchantAccount?: boolean | null
   shortName?: string | null
   sortableName?: string | null
   type?: string | null
+  vatNumber?: string | null
+  vatStatus?: string | null
+  vatExemptApproved?: boolean | null
+  verifiedSeller?: boolean | null
   website?: string | null
+  wireTransferEnabled?: boolean | null
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
@@ -74,6 +95,10 @@ export const updatePartnerMutation = mutationWithClientMutationId<
   name: "UpdatePartnerMutation",
   description: "Updates general information on a partner.",
   inputFields: {
+    adminId: {
+      type: GraphQLString,
+      description: "Admin assigned for this partner.",
+    },
     alternateNames: {
       type: new GraphQLList(GraphQLString),
       description: "Alternate names or synonyms for this partner.",
@@ -85,6 +110,14 @@ export const updatePartnerMutation = mutationWithClientMutationId<
     commissionRate: {
       type: GraphQLFloat,
       description: "Commission paid by non-subscriber/fair partner.",
+    },
+    commerceEnabled: {
+      type: GraphQLBoolean,
+      description: "Partner could opt their works to buy now / make offer and accept payments using their merchant account.",
+    },
+    criteoEligible: {
+      type: GraphQLBoolean,
+      description: "Include in Criteo artwork report.",
     },
     contractType: {
       type: GraphQLString,
@@ -116,6 +149,18 @@ export const updatePartnerMutation = mutationWithClientMutationId<
       type: GraphQLString,
       description: "The email of the partner.",
     },
+    enableAchPaymentMethod: {
+      type: GraphQLBoolean,
+      description: "Whether the partner should have access to ACH payment method on subscriptions.",
+    },
+    enforceOnPlatformTransactions: {
+      type: GraphQLBoolean,
+      description: "Triggers partner on platform transaction notifications.",
+    },
+    featuredKeywords: {
+      type: new GraphQLList(GraphQLString),
+      description: "Suggested filters for associated artworks.",
+    },
     givenName: {
       type: GraphQLString,
       description: "The given name of the partner.",
@@ -124,9 +169,33 @@ export const updatePartnerMutation = mutationWithClientMutationId<
       type: GraphQLBoolean,
       description: "Profile completeness.",
     },
+    hasLimitedFolioAccess: {
+      type: GraphQLBoolean,
+      description: "Whether this partner has limited Folio access.",
+    },
     id: {
       type: new GraphQLNonNull(GraphQLString),
       description: "The id of the partner to update.",
+    },
+    implicitOfferEnabled: {
+      type: GraphQLBoolean,
+      description: "Partner can have artworks implictly enrolled as 'Make Offer' on the artwork page.",
+    },
+    inquiryOrderEnabled: {
+      type: GraphQLBoolean,
+      description: "Partner could list artworks for purchasing from inquiry conversations.",
+    },
+    managedByErp: {
+      type: GraphQLBoolean,
+      description: "Whether the partner is managed by ERP for subscriptions.",
+    },
+    outreachAdminId: {
+      type: GraphQLString,
+      description: "Admin that signed up this partner.",
+    },
+    partnerCategories: {
+      type: new GraphQLList(GraphQLString),
+      description: "Array of partner slugs to assign to this partner.",
     },
     preQualify: {
       type: GraphQLBoolean,
@@ -140,9 +209,21 @@ export const updatePartnerMutation = mutationWithClientMutationId<
       type: GraphQLString,
       description: "Banner display on the profile overview page.",
     },
+    referralContactId: {
+      type: GraphQLString,
+      description: "Admin that referred this partner and gets the commission.",
+    },
     region: {
       type: GraphQLString,
       description: "The region of the partner.",
+    },
+    relativeSize: {
+      type: GraphQLInt,
+      description: "Size of the partner.",
+    },
+    requiresMerchantAccount: {
+      type: GraphQLBoolean,
+      description: "Partner is required to configure a merchant account.",
     },
     shortName: {
       type: GraphQLString,
@@ -156,9 +237,29 @@ export const updatePartnerMutation = mutationWithClientMutationId<
       type: GraphQLString,
       description: "Type of the partner.",
     },
+    vatNumber: {
+      type: GraphQLString,
+      description: "The VAT identification number belonging to this partner.",
+    },
+    vatStatus: {
+      type: GraphQLString,
+      description: "Whether the partner is registered, registered_and_exempt, exempt, or ineligible for a VAT identification number.",
+    },
+    vatExemptApproved: {
+      type: GraphQLBoolean,
+      description: "Whether the partner's VAT exempt status is approved by Artsy.",
+    },
+    verifiedSeller: {
+      type: GraphQLBoolean,
+      description: "Indicates the partner is a trusted seller on Artsy.",
+    },
     website: {
       type: GraphQLString,
       description: "The website of the partner.",
+    },
+    wireTransferEnabled: {
+      type: GraphQLBoolean,
+      description: "Indicates the partner is eligible for manual wire transfers.",
     },
   },
   outputFields: {
@@ -172,9 +273,12 @@ export const updatePartnerMutation = mutationWithClientMutationId<
   mutateAndGetPayload: async (
     {
       id,
+      adminId,
       alternateNames,
       artsyCollectsSalesTax,
       commissionRate,
+      commerceEnabled,
+      criteoEligible,
       contractType,
       directlyContactable,
       displayArtistsSection,
@@ -182,16 +286,33 @@ export const updatePartnerMutation = mutationWithClientMutationId<
       displayWorksSection,
       distinguishRepresentedArtists,
       email,
+      enableAchPaymentMethod,
+      enforceOnPlatformTransactions,
+      featuredKeywords,
       givenName,
       hasFullProfile,
+      hasLimitedFolioAccess,
+      implicitOfferEnabled,
+      inquiryOrderEnabled,
+      managedByErp,
+      outreachAdminId,
+      partnerCategories,
       preQualify,
       profileArtistsLayout,
       profileBannerDisplay,
+      referralContactId,
       region,
+      relativeSize,
+      requiresMerchantAccount,
       shortName,
       sortableName,
       type,
+      vatNumber,
+      vatStatus,
+      vatExemptApproved,
+      verifiedSeller,
       website,
+      wireTransferEnabled,
     },
     { updatePartnerLoader }
   ) => {
@@ -201,9 +322,12 @@ export const updatePartnerMutation = mutationWithClientMutationId<
 
     try {
       const partnerData = {
+        admin_id: adminId,
         alternate_names: alternateNames,
         artsy_collects_sales_tax: artsyCollectsSalesTax,
         commission_rate: commissionRate,
+        commerce_enabled: commerceEnabled,
+        criteo_eligible: criteoEligible,
         contract_type: contractType,
         directly_contactable: directlyContactable,
         display_artists_section: displayArtistsSection,
@@ -211,16 +335,33 @@ export const updatePartnerMutation = mutationWithClientMutationId<
         display_works_section: displayWorksSection,
         distinguish_represented_artists: distinguishRepresentedArtists,
         email: email,
+        enable_ach_payment_method: enableAchPaymentMethod,
+        enforce_on_platform_transactions: enforceOnPlatformTransactions,
+        featured_keywords: featuredKeywords,
         given_name: givenName,
         has_full_profile: hasFullProfile,
+        has_limited_folio_access: hasLimitedFolioAccess,
+        implicit_offer_enabled: implicitOfferEnabled,
+        inquiry_order_enabled: inquiryOrderEnabled,
+        managed_by_erp: managedByErp,
+        outreach_admin_id: outreachAdminId,
+        partner_categories: partnerCategories,
         pre_qualify: preQualify,
         profile_artists_layout: profileArtistsLayout,
         profile_banner_display: profileBannerDisplay,
+        referral_contact_id: referralContactId, 
         region: region,
+        relative_size: relativeSize,
+        requires_merchant_account: requiresMerchantAccount,
         short_name: shortName,
         sortable_name: sortableName,
         type: type,
+        vat_number: vatNumber,
+        vat_status: vatStatus,
+        vat_exempt_approved: vatExemptApproved,
+        verified_seller: verifiedSeller,
         website: website,
+        wire_transfer_enabled: wireTransferEnabled,
       }
 
       const response = await updatePartnerLoader(id, partnerData)


### PR DESCRIPTION
This PR is a follow up to https://github.com/artsy/metaphysics/pull/6638 where I added a mutation to update partner records. I'm not sure how exactly but Claude failed to add a bunch of fields to that initial PR and I def missed it! This time it seems to have correctly taken the API doc and added all the possible fields. The ones I actually needed are the vat ones but this seemed worth doing.

/cc @artsy/amber-devs