### PR TITLE
chore: update home view tests after removing discover daily feature flag

### DIFF
--- a/src/schema/v2/homeView/__tests__/HomeView.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeView.test.ts
@@ -45,6 +45,11 @@ describe("homeView", () => {
                     title
                   }
                 }
+                ... on HomeViewSectionCard {
+                  card {
+                    title
+                  }
+                }
               }
             }
           }
@@ -68,6 +73,9 @@ describe("homeView", () => {
               {
                 "node": {
                   "__typename": "HomeViewSectionCard",
+                  "card": {
+                    "title": "Discover Daily",
+                  },
                   "component": null,
                 },
               },
@@ -112,6 +120,9 @@ describe("homeView", () => {
               {
                 "node": {
                   "__typename": "HomeViewSectionCard",
+                  "card": {
+                    "title": "Galleries for You",
+                  },
                   "component": {
                     "title": "Galleries for You",
                   },
@@ -218,6 +229,9 @@ describe("homeView", () => {
               {
                 "node": {
                   "__typename": "HomeViewSectionCard",
+                  "card": {
+                    "title": "Discover Daily",
+                  },
                   "component": null,
                 },
               },
@@ -286,6 +300,9 @@ describe("homeView", () => {
               {
                 "node": {
                   "__typename": "HomeViewSectionCard",
+                  "card": {
+                    "title": "Galleries for You",
+                  },
                   "component": {
                     "title": "Galleries for You",
                   },


### PR DESCRIPTION
These tests started failing when we deprecated the Discover Daily feature flag because that section was hidden by default. This PR updates these tests to look at the `card` title instead of the `component` title when a section is a HomeViewSectionCard type. (This also impacted the assertion for "Galleries Near You".)