### PR TITLE
feat(homeView): introduce HomeViewMixer and use it for for boosting content to new users

### DIFF
--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -12,6 +12,7 @@ const FEATURE_FLAGS_LIST = [
   "onyx_enable-home-view-section-featured-fairs",
   "onyx_experiment_home_view_test",
   "emerald_clientside-collector-signals",
+  "onyx_enable-home-view-mixer",
 ] as const
 
 export type FeatureFlag = typeof FEATURE_FLAGS_LIST[number]

--- a/src/schema/v2/homeView/mixer/HomeViewMixer.ts
+++ b/src/schema/v2/homeView/mixer/HomeViewMixer.ts
@@ -1,18 +1,18 @@
 import { HomeViewSection } from "schema/v2/homeView/sections"
 import { ResolverContext } from "types/graphql"
-import { SectionRule } from "./SectionRule"
+import { HomeViewMixerRule } from "./HomeViewMixerRule"
 
 /**
  * Orchestrates the application of multiple rules to a list of sections.
  */
 export class HomeViewMixer {
-  private rules: SectionRule[]
+  private rules: HomeViewMixerRule[]
 
   /**
    * Create a new HomeViewMixer with the specified rules.
    * @param rules Array of section rules to apply in sequence
    */
-  constructor(rules: SectionRule[]) {
+  constructor(rules: HomeViewMixerRule[]) {
     this.rules = rules
   }
 

--- a/src/schema/v2/homeView/mixer/HomeViewMixer.ts
+++ b/src/schema/v2/homeView/mixer/HomeViewMixer.ts
@@ -1,0 +1,37 @@
+import { HomeViewSection } from "schema/v2/homeView/sections"
+import { ResolverContext } from "types/graphql"
+import { SectionRule } from "./SectionRule"
+
+/**
+ * Orchestrates the application of multiple rules to a list of sections.
+ */
+export class HomeViewMixer {
+  private rules: SectionRule[]
+
+  /**
+   * Create a new HomeViewMixer with the specified rules.
+   * @param rules Array of section rules to apply in sequence
+   */
+  constructor(rules: SectionRule[]) {
+    this.rules = rules
+  }
+
+  /**
+   * Apply all rules sequentially to the provided sections.
+   * @param initialSections Initial list of sections to process
+   * @param context GraphQL resolver context
+   * @returns Final list of sections after all rules have been applied
+   */
+  async mix(
+    initialSections: HomeViewSection[],
+    context: ResolverContext
+  ): Promise<HomeViewSection[]> {
+    let sections = [...initialSections]
+
+    for (const rule of this.rules) {
+      sections = await rule.apply(sections, context)
+    }
+
+    return sections
+  }
+}

--- a/src/schema/v2/homeView/mixer/HomeViewMixerRule.ts
+++ b/src/schema/v2/homeView/mixer/HomeViewMixerRule.ts
@@ -2,12 +2,14 @@ import { HomeViewSection } from "schema/v2/homeView/sections"
 import { ResolverContext } from "types/graphql"
 
 /**
- * Abstract base class for section rules.
- * Each rule may transform the list of sections.
+ * Abstract base class for mixer rules.
+ *
+ * Each rule may transform the list of sections, based on its own logic
+ * and the provided GraphQL request context.
  */
-export abstract class SectionRule {
+export abstract class HomeViewMixerRule {
   /**
-   * Method that transforms sections based on specific logic
+   * Transforms a list of incoming sections
    * @param sections List of sections to transform
    * @param context GraphQL resolver context
    * @returns Transformed list of sections

--- a/src/schema/v2/homeView/mixer/SectionRule.ts
+++ b/src/schema/v2/homeView/mixer/SectionRule.ts
@@ -1,0 +1,19 @@
+import { HomeViewSection } from "schema/v2/homeView/sections"
+import { ResolverContext } from "types/graphql"
+
+/**
+ * Abstract base class for section rules.
+ * Each rule may transform the list of sections.
+ */
+export abstract class SectionRule {
+  /**
+   * Method that transforms sections based on specific logic
+   * @param sections List of sections to transform
+   * @param context GraphQL resolver context
+   * @returns Transformed list of sections
+   */
+  abstract apply(
+    sections: HomeViewSection[],
+    context: ResolverContext
+  ): Promise<HomeViewSection[]>
+}

--- a/src/schema/v2/homeView/mixer/__tests__/HomeViewMixer.test.ts
+++ b/src/schema/v2/homeView/mixer/__tests__/HomeViewMixer.test.ts
@@ -1,7 +1,7 @@
 import { ResolverContext } from "types/graphql"
 import { HomeViewSection } from "../../sections"
 import { HomeViewMixer } from "../HomeViewMixer"
-import { SectionRule } from "../SectionRule"
+import { HomeViewMixerRule } from "../HomeViewMixerRule"
 
 describe("HomeViewMixer", () => {
   it("should apply all rules to produce the final section list", async () => {
@@ -30,7 +30,7 @@ describe("HomeViewMixer", () => {
 
 // Mock rules
 
-class RemoveBadArtworksRule extends SectionRule {
+class RemoveBadArtworksRule extends HomeViewMixerRule {
   async apply(
     sections: HomeViewSection[],
     _context: ResolverContext
@@ -39,7 +39,7 @@ class RemoveBadArtworksRule extends SectionRule {
   }
 }
 
-class BoostGreatArtworksRule extends SectionRule {
+class BoostGreatArtworksRule extends HomeViewMixerRule {
   async apply(
     sections: HomeViewSection[],
     _context: ResolverContext

--- a/src/schema/v2/homeView/mixer/__tests__/HomeViewMixer.test.ts
+++ b/src/schema/v2/homeView/mixer/__tests__/HomeViewMixer.test.ts
@@ -1,0 +1,80 @@
+import { ResolverContext } from "types/graphql"
+import { HomeViewSection } from "../../sections"
+import { HomeViewMixer } from "../HomeViewMixer"
+import { SectionRule } from "../SectionRule"
+
+describe("HomeViewMixer", () => {
+  it("should apply all rules to produce the final section list", async () => {
+    const context = {} as ResolverContext
+
+    const INITIAL_SECTIONS = [
+      BadArtworks, // should be removed
+      OkayArtworks,
+      GreatArtworks, // should be boosted to the top
+    ]
+
+    const mixer = new HomeViewMixer([
+      new RemoveBadArtworksRule(),
+      new BoostGreatArtworksRule(),
+    ])
+
+    const finalSections = await mixer.mix(INITIAL_SECTIONS, context)
+
+    expect(finalSections).toEqual([
+      GreatArtworks,
+      OkayArtworks,
+      // and BadArtworks has been removed
+    ])
+  })
+})
+
+// Mock rules
+
+class RemoveBadArtworksRule extends SectionRule {
+  async apply(
+    sections: HomeViewSection[],
+    _context: ResolverContext
+  ): Promise<HomeViewSection[]> {
+    return sections.filter((section) => section.id !== BadArtworks.id)
+  }
+}
+
+class BoostGreatArtworksRule extends SectionRule {
+  async apply(
+    sections: HomeViewSection[],
+    _context: ResolverContext
+  ): Promise<HomeViewSection[]> {
+    const greatArtworksSectionIndex = sections.findIndex(
+      (section) => section.id === GreatArtworks.id
+    )
+
+    // move it to the top
+    if (greatArtworksSectionIndex !== -1) {
+      const greatArtworksSection = sections[greatArtworksSectionIndex]
+      sections.splice(greatArtworksSectionIndex, 1)
+      sections.unshift(greatArtworksSection)
+    }
+
+    return sections
+  }
+}
+
+// Mock sections
+
+const BadArtworks: HomeViewSection = {
+  id: "home-view-section-bad",
+  requiresAuthentication: false,
+  type: "HomeViewSectionArtworks",
+}
+
+const OkayArtworks: HomeViewSection = {
+  id: "home-view-section-okay",
+  requiresAuthentication: false,
+  type: "HomeViewSectionArtworks",
+}
+
+const GreatArtworks: HomeViewSection = {
+  id: "home-view-section-great",
+  requiresAuthentication: false,
+  type: "HomeViewSectionArtworks",
+}

--- a/src/schema/v2/homeView/mixer/__tests__/rules/BoostHeroUnitsForNewUsersRule.test.ts
+++ b/src/schema/v2/homeView/mixer/__tests__/rules/BoostHeroUnitsForNewUsersRule.test.ts
@@ -1,0 +1,77 @@
+import { HomeViewSection } from "schema/v2/homeView/sections"
+import { BoostHeroUnitsForNewUsersRule } from "../../rules/BoostHeroUnitsForNewUsersRule"
+import moment from "moment"
+import { HeroUnits } from "schema/v2/homeView/sections/HeroUnits"
+import { ResolverContext } from "types/graphql"
+
+describe("BoostHeroUnitsForNewUsersRule", () => {
+  it("moves HeroUnits near the top if user is new", async () => {
+    const mockContext: Partial<ResolverContext> = {
+      userID: "123",
+      userByIDLoader: jest.fn().mockResolvedValue(NEW_USER),
+    }
+
+    const inputSections: Partial<HomeViewSection>[] = [
+      { id: "quick-links-section" },
+      { id: "tasks-section" },
+      { id: "some-section" },
+      { id: "another-section" },
+      HeroUnits,
+    ]
+
+    const boostHeroUnits = new BoostHeroUnitsForNewUsersRule()
+
+    const outputSections = await boostHeroUnits.apply(
+      inputSections as HomeViewSection[],
+      mockContext as ResolverContext
+    )
+
+    expect(outputSections).toEqual([
+      { id: "quick-links-section" },
+      { id: "tasks-section" },
+      HeroUnits,
+      { id: "some-section" },
+      { id: "another-section" },
+    ])
+  })
+
+  it("leaves HeroUnits alone if user is not new", async () => {
+    const mockContext: Partial<ResolverContext> = {
+      userID: "123",
+      userByIDLoader: jest.fn().mockResolvedValue(OLD_USER),
+    }
+
+    const inputSections: Partial<HomeViewSection>[] = [
+      { id: "quick-links-section" },
+      { id: "tasks-section" },
+      { id: "some-section" },
+      { id: "another-section" },
+      HeroUnits,
+    ]
+
+    const boostHeroUnits = new BoostHeroUnitsForNewUsersRule()
+
+    const outputSections = await boostHeroUnits.apply(
+      inputSections as HomeViewSection[],
+      mockContext as ResolverContext
+    )
+
+    expect(outputSections).toEqual([
+      { id: "quick-links-section" },
+      { id: "tasks-section" },
+      { id: "some-section" },
+      { id: "another-section" },
+      HeroUnits,
+    ])
+  })
+})
+
+const NEW_USER = {
+  email: "new.user@example.com",
+  created_at: moment().subtract(1, "day").toISOString(),
+}
+
+const OLD_USER = {
+  email: "old.user@example.com",
+  created_at: moment().subtract(1, "year").toISOString(),
+}

--- a/src/schema/v2/homeView/mixer/rules/BoostHeroUnitsForNewUsersRule.ts
+++ b/src/schema/v2/homeView/mixer/rules/BoostHeroUnitsForNewUsersRule.ts
@@ -1,6 +1,6 @@
 import { HomeViewSection } from "schema/v2/homeView/sections"
 import { ResolverContext } from "types/graphql"
-import { SectionRule } from "../SectionRule"
+import { HomeViewMixerRule } from "../HomeViewMixerRule"
 import { HeroUnits } from "../../sections/HeroUnits"
 
 const THRESHOLD_IN_HOURS = 2 * 7 * 24 // equals two weeks
@@ -8,7 +8,7 @@ const THRESHOLD_IN_HOURS = 2 * 7 * 24 // equals two weeks
 /**
  * Rule that moves the HeroUnits section to the top of the list if the user is new.
  */
-export class BoostHeroUnitsForNewUsersRule extends SectionRule {
+export class BoostHeroUnitsForNewUsersRule extends HomeViewMixerRule {
   async apply(
     sections: HomeViewSection[],
     context: ResolverContext

--- a/src/schema/v2/homeView/mixer/rules/BoostHeroUnitsForNewUsersRule.ts
+++ b/src/schema/v2/homeView/mixer/rules/BoostHeroUnitsForNewUsersRule.ts
@@ -1,0 +1,47 @@
+import { HomeViewSection } from "schema/v2/homeView/sections"
+import { ResolverContext } from "types/graphql"
+import { SectionRule } from "../SectionRule"
+import { HeroUnits } from "../../sections/HeroUnits"
+
+const THRESHOLD_IN_HOURS = 2 * 7 * 24 // equals two weeks
+
+/**
+ * Rule that moves the HeroUnits section to the top of the list if the user is new.
+ */
+export class BoostHeroUnitsForNewUsersRule extends SectionRule {
+  async apply(
+    sections: HomeViewSection[],
+    context: ResolverContext
+  ): Promise<HomeViewSection[]> {
+    const { userID, userByIDLoader } = context
+
+    if (userID && userByIDLoader) {
+      const user = await userByIDLoader(userID)
+      const age = getAccountAgeInHours(user)
+
+      if (age < THRESHOLD_IN_HOURS) {
+        // find the HeroUnits section
+        const heroUnitsIndex = sections.findIndex(
+          (section) => section.id === HeroUnits.id
+        )
+
+        // move it to the top (after Quick Links and Tasks, i.e. index 2)
+        if (heroUnitsIndex !== -1) {
+          const heroUnitsSection = sections[heroUnitsIndex]
+          sections.splice(heroUnitsIndex, 1)
+          sections.splice(2, 0, heroUnitsSection)
+        }
+      }
+    }
+
+    return sections
+  }
+}
+
+function getAccountAgeInHours(user) {
+  const createdAt = user.created_at
+  const accountAgeMillis = new Date().getTime() - new Date(createdAt).getTime()
+  const accountAgeHours = accountAgeMillis / (1000 * 60 * 60)
+
+  return accountAgeHours
+}

--- a/src/schema/v2/homeView/mixer/rules/DisplayableRule.ts
+++ b/src/schema/v2/homeView/mixer/rules/DisplayableRule.ts
@@ -1,12 +1,12 @@
 import { HomeViewSection } from "schema/v2/homeView/sections"
 import { ResolverContext } from "types/graphql"
 import { isSectionDisplayable } from "../../helpers/isSectionDisplayable"
-import { SectionRule } from "../SectionRule"
+import { HomeViewMixerRule } from "../HomeViewMixerRule"
 
 /**
  * Rule that removes sections based on the isSectionDisplayable helper.
  */
-export class DisplayableRule extends SectionRule {
+export class DisplayableRule extends HomeViewMixerRule {
   async apply(
     sections: HomeViewSection[],
     context: ResolverContext

--- a/src/schema/v2/homeView/mixer/rules/DisplayableRule.ts
+++ b/src/schema/v2/homeView/mixer/rules/DisplayableRule.ts
@@ -1,0 +1,16 @@
+import { HomeViewSection } from "schema/v2/homeView/sections"
+import { ResolverContext } from "types/graphql"
+import { isSectionDisplayable } from "../../helpers/isSectionDisplayable"
+import { SectionRule } from "../SectionRule"
+
+/**
+ * Rule that removes sections based on the isSectionDisplayable helper.
+ */
+export class DisplayableRule extends SectionRule {
+  async apply(
+    sections: HomeViewSection[],
+    context: ResolverContext
+  ): Promise<HomeViewSection[]> {
+    return sections.filter((section) => isSectionDisplayable(section, context))
+  }
+}

--- a/src/schema/v2/homeView/zones/default.ts
+++ b/src/schema/v2/homeView/zones/default.ts
@@ -26,6 +26,7 @@ import { TrendingArtists } from "../sections/TrendingArtists"
 import { ViewingRooms } from "../sections/ViewingRooms"
 import { InfiniteDiscovery } from "../sections/InfiniteDiscovery"
 import { QuickLinks } from "../sections/QuickLinks"
+import { BoostHeroUnitsForNewUsersRule } from "../mixer/rules/BoostHeroUnitsForNewUsersRule"
 
 const SECTIONS: HomeViewSection[] = [
   QuickLinks,
@@ -60,7 +61,7 @@ const SECTIONS: HomeViewSection[] = [
 export async function getSections(context: ResolverContext) {
   const mixer = new HomeViewMixer([
     new DisplayableRule(),
-    // other rules tk
+    new BoostHeroUnitsForNewUsersRule(),
   ])
 
   return await mixer.mix(SECTIONS, context)

--- a/src/schema/v2/homeView/zones/default.ts
+++ b/src/schema/v2/homeView/zones/default.ts
@@ -1,6 +1,7 @@
 import { HomeViewSection } from "schema/v2/homeView/sections"
 import { ResolverContext } from "types/graphql"
-import { isSectionDisplayable } from "../helpers/isSectionDisplayable"
+import { DisplayableRule } from "../mixer/rules/DisplayableRule"
+import { HomeViewMixer } from "../mixer/HomeViewMixer"
 import { AuctionLotsForYou } from "../sections/AuctionLotsForYou"
 import { Auctions } from "../sections/Auctions"
 import { CuratorsPicksEmerging } from "../sections/CuratorsPicksEmerging"
@@ -57,13 +58,10 @@ const SECTIONS: HomeViewSection[] = [
  * Assemble the list of sections that can be displayed
  */
 export async function getSections(context: ResolverContext) {
-  const displayableSections: HomeViewSection[] = []
+  const mixer = new HomeViewMixer([
+    new DisplayableRule(),
+    // other rules tk
+  ])
 
-  SECTIONS.forEach((section) => {
-    if (isSectionDisplayable(section, context)) {
-      displayableSections.push(section)
-    }
-  })
-
-  return displayableSections
+  return await mixer.mix(SECTIONS, context)
 }


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-1674

This implements the proposal sketched out here — [slides](https://docs.google.com/presentation/d/1UdeoZ5XSZSdylohK9xwlyvp0Ak-1bq8Y61KRfvxtDrg/edit?usp=sharing) and [discussion](https://artsy.slack.com/archives/C05EQL4R5N0/p1745488800435159) — and presented to Onyx today.

The big idea here is the `HomeViewMixer`, explained in [this slide](https://docs.google.com/presentation/d/1UdeoZ5XSZSdylohK9xwlyvp0Ak-1bq8Y61KRfvxtDrg/edit#slide=id.g34fb28ebba3_0_82):

<img src="https://github.com/user-attachments/assets/f87a9bc6-b825-4949-97df-a1fbc4f99461" width="50%" />

This PR:

- introduces `HomeViewMixer` 
- adds a `BoostHeroUnitsForNewUsersFilter` — which (unsurprisingly) boosts the `HeroUnit` section for newly created accounts
- puts this new logic behind a `onyx_enable-home-view-mixer` [Unleash flag](https://unleash.artsy.net/projects/default/features/onyx_enable-home-view-mixer) (currently enabled in dev only)

We discussed many possible refinements, but the version here satisfies the requirements for the NY Art Week marketing campaign, which is the first production use of this pattern.