### PR TITLE
feat(EMI-2399): create updateOrderShippingAddressMutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15933,6 +15933,11 @@ type Mutation {
   # Update an order
   updateOrder(input: updateOrderInput!): updateOrderPayload
 
+  # Update an order's shipping address
+  updateOrderShippingAddress(
+    input: updateOrderShippingAddressInput!
+  ): updateOrderShippingAddressPayload
+
   # updates an ordered set.
   updateOrderedSet(
     input: UpdateOrderedSetMutationInput!
@@ -26240,6 +26245,44 @@ input updateOrderInput {
 }
 
 type updateOrderPayload {
+  clientMutationId: String
+  orderOrError: SetOrderFulfillmentOptionResponse
+}
+
+input updateOrderShippingAddressInput {
+  # Buyer's phone number
+  buyerPhoneNumber: String
+
+  # Buyer's phone number country code
+  buyerPhoneNumberCountryCode: String
+  clientMutationId: String
+
+  # Order id.
+  id: ID!
+
+  # Shipping address line 1
+  shippingAddressLine1: String
+
+  # Shipping address line 2
+  shippingAddressLine2: String
+
+  # Shipping address city
+  shippingCity: String
+
+  # Shipping address country
+  shippingCountry: String
+
+  # Shipping address name
+  shippingName: String
+
+  # Shipping address postal code
+  shippingPostalCode: String
+
+  # Shipping address state/province/region
+  shippingRegion: String
+}
+
+type updateOrderShippingAddressPayload {
   clientMutationId: String
   orderOrError: SetOrderFulfillmentOptionResponse
 }

--- a/src/lib/loaders/loaders_with_authentication/exchange.ts
+++ b/src/lib/loaders/loaders_with_authentication/exchange.ts
@@ -47,6 +47,14 @@ export const exchangeLoaders = (accessToken, opts) => {
     }
   )
 
+  const meOrderUpdateShippingAddressLoader = exchangeLoader(
+    (id) => `me/orders/${id}/shipping_address`,
+    {},
+    {
+      method: "PUT",
+    }
+  )
+
   const meOrderSetFulfillmentOptionLoader = exchangeLoader(
     (id) => `me/orders/${id}/fulfillment_option`,
     {},
@@ -122,6 +130,7 @@ export const exchangeLoaders = (accessToken, opts) => {
     exchangeGraphQLLoader,
     meOrderLoader,
     meOrderUpdateLoader,
+    meOrderUpdateShippingAddressLoader,
     meOrderSetFulfillmentOptionLoader,
     meOrderSubmitLoader,
     meOrderUnsetFulfillmentOptionLoader,

--- a/src/schema/v2/order/__tests__/updateOrderShippingAddressMutation.test.ts
+++ b/src/schema/v2/order/__tests__/updateOrderShippingAddressMutation.test.ts
@@ -1,0 +1,198 @@
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import { baseArtwork, baseOrderJson } from "./support"
+
+const mockMutation = `
+  mutation {
+    updateOrderShippingAddress(input: {
+      id: "order-id",
+      buyerPhoneNumber: "123-456-7890",
+      buyerPhoneNumberCountryCode: "+1",
+      shippingName: "John Doe",
+      shippingAddressLine1: "123 Main St",
+      shippingAddressLine2: "Apt 4B",
+      shippingCity: "New York",
+      shippingRegion: "NY",
+      shippingCountry: "US",
+      shippingPostalCode: "10001"
+    }) {
+      orderOrError {
+        ...on OrderMutationError {
+          mutationError {
+            message
+            code
+          }
+        }
+        ...on OrderMutationSuccess {
+          order {
+            internalID
+            fulfillmentDetails {
+              phoneNumber
+              phoneNumberCountryCode
+              name
+              addressLine1
+              addressLine2
+              city
+              region
+              country
+              postalCode
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
+let context
+describe("updateOrderShippingAddressMutation", () => {
+  beforeEach(() => {
+    context = {
+      meOrderUpdateShippingAddressLoader: jest.fn().mockResolvedValue({
+        ...baseOrderJson,
+        id: "order-id",
+        source: "artwork_page",
+        code: "order-code",
+        mode: "buy",
+        currency_code: "USD",
+        buyer_total_cents: null,
+        items_total_cents: 500000,
+        shipping_total_cents: 2000,
+        buyer_phone_number: "123-456-7890",
+        buyer_phone_number_country_code: "+1",
+        shipping_name: "John Doe",
+        shipping_country: "US",
+        shipping_postal_code: "10001",
+        shipping_region: "NY",
+        shipping_city: "New York",
+        shipping_address_line1: "123 Main St",
+        shipping_address_line2: "Apt 4B",
+      }),
+      artworkLoader: jest.fn().mockResolvedValue({ ...baseArtwork }),
+      artworkVersionLoader: jest
+        .fn()
+        .mockResolvedValue({ ...baseArtwork, id: "artwork-version-id" }),
+    }
+  })
+  it("should update an order with all fields", async () => {
+    const result = await runAuthenticatedQuery(mockMutation, context)
+
+    expect(result.errors).toBeUndefined()
+    expect(result).toEqual({
+      updateOrderShippingAddress: {
+        orderOrError: {
+          order: {
+            internalID: "order-id",
+            fulfillmentDetails: {
+              phoneNumber: "123-456-7890",
+              phoneNumberCountryCode: "+1",
+              name: "John Doe",
+              addressLine1: "123 Main St",
+              addressLine2: "Apt 4B",
+              city: "New York",
+              region: "NY",
+              country: "US",
+              postalCode: "10001",
+            },
+          },
+        },
+      },
+    })
+
+    expect(context.meOrderUpdateShippingAddressLoader).toHaveBeenCalledWith(
+      "order-id",
+      {
+        buyer_phone_number: "123-456-7890",
+        buyer_phone_number_country_code: "+1",
+        shipping_address_line1: "123 Main St",
+        shipping_address_line2: "Apt 4B",
+        shipping_city: "New York",
+        shipping_country: "US",
+        shipping_name: "John Doe",
+        shipping_postal_code: "10001",
+        shipping_region: "NY",
+      }
+    )
+  })
+
+  it("only sends the fields that are provided (including Null", async () => {
+    const result = await runAuthenticatedQuery(
+      `
+      mutation {
+        updateOrderShippingAddress(input: {
+          id: "order-id",
+          buyerPhoneNumber: null
+        }) {
+          orderOrError {
+            ...on OrderMutationSuccess {
+              order {
+                internalID
+              }
+            }
+          }
+        }
+      }
+    `,
+      context
+    )
+
+    expect(result.updateOrderShippingAddress.orderOrError.order).toBeDefined()
+    expect(result).toEqual({
+      updateOrderShippingAddress: {
+        orderOrError: {
+          order: {
+            internalID: "order-id",
+          },
+        },
+      },
+    })
+
+    expect(context.meOrderUpdateShippingAddressLoader).toHaveBeenCalledWith(
+      "order-id",
+      {
+        buyer_phone_number: null,
+      }
+    )
+  })
+
+  it("propagates an error", async () => {
+    context.meOrderUpdateShippingAddressLoader = jest
+      .fn()
+      .mockRejectedValue(new Error("Oops - Error updating order"))
+    const result = await runAuthenticatedQuery(mockMutation, context)
+
+    expect(result.errors).toBeUndefined()
+    expect(result).toEqual({
+      updateOrderShippingAddress: {
+        orderOrError: {
+          mutationError: {
+            message: "An error occurred",
+            code: "internal_error",
+          },
+        },
+      },
+    })
+  })
+
+  it("propagates a 422 error from exchange", async () => {
+    context.meOrderUpdateShippingAddressLoader = jest.fn().mockRejectedValue({
+      statusCode: 422,
+      body: {
+        message: "order_not_pending: submitted",
+        code: "order_not_pending",
+      },
+    })
+    const result = await runAuthenticatedQuery(mockMutation, context)
+
+    expect(result.errors).toBeUndefined()
+    expect(result).toEqual({
+      updateOrderShippingAddress: {
+        orderOrError: {
+          mutationError: {
+            message: "order_not_pending: submitted",
+            code: "order_not_pending",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/order/updateOrderShippingAddressMutation.ts
+++ b/src/schema/v2/order/updateOrderShippingAddressMutation.ts
@@ -1,0 +1,108 @@
+import { GraphQLString, GraphQLNonNull, GraphQLID } from "graphql"
+import {
+  ORDER_MUTATION_FLAGS,
+  OrderMutationResponseType,
+} from "./sharedOrderTypes"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import { handleExchangeError } from "./exchangeErrorHandling"
+
+interface Input {
+  id: string
+  buyerPhoneNumber?: string
+  buyerPhoneNumberCountryCode?: string
+  shippingName?: string
+  shippingAddressLine1?: string
+  shippingAddressLine2?: string
+  shippingCity?: string
+  shippingRegion?: string
+  shippingCountry?: string
+  shippingPostalCode?: string
+}
+
+export const updateOrderShippingAddressMutation = mutationWithClientMutationId<
+  Input,
+  any,
+  ResolverContext
+>({
+  name: "updateOrderShippingAddress",
+  description: "Update an order's shipping address",
+  inputFields: {
+    id: { type: new GraphQLNonNull(GraphQLID), description: "Order id." },
+    buyerPhoneNumber: {
+      type: GraphQLString,
+      description: "Buyer's phone number",
+    },
+    buyerPhoneNumberCountryCode: {
+      type: GraphQLString,
+      description: "Buyer's phone number country code",
+    },
+    shippingName: {
+      type: GraphQLString,
+      description: "Shipping address name",
+    },
+    shippingAddressLine1: {
+      type: GraphQLString,
+      description: "Shipping address line 1",
+    },
+    shippingAddressLine2: {
+      type: GraphQLString,
+      description: "Shipping address line 2",
+    },
+    shippingCity: {
+      type: GraphQLString,
+      description: "Shipping address city",
+    },
+    shippingRegion: {
+      type: GraphQLString,
+      description: "Shipping address state/province/region",
+    },
+    shippingCountry: {
+      type: GraphQLString,
+      description: "Shipping address country",
+    },
+    shippingPostalCode: {
+      type: GraphQLString,
+      description: "Shipping address postal code",
+    },
+  },
+  outputFields: {
+    orderOrError: {
+      type: OrderMutationResponseType,
+      resolve: (response) => response,
+    },
+  },
+  mutateAndGetPayload: async (input, context) => {
+    const { meOrderUpdateShippingAddressLoader } = context
+    if (!meOrderUpdateShippingAddressLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+    try {
+      const exchangeInputFields = {
+        buyer_phone_number: input.buyerPhoneNumber,
+        buyer_phone_number_country_code: input.buyerPhoneNumberCountryCode,
+        shipping_name: input.shippingName,
+        shipping_address_line1: input.shippingAddressLine1,
+        shipping_address_line2: input.shippingAddressLine2,
+        shipping_city: input.shippingCity,
+        shipping_region: input.shippingRegion,
+        shipping_country: input.shippingCountry,
+        shipping_postal_code: input.shippingPostalCode,
+      }
+      // filter out `undefined` values from the input fields
+      const payload = Object.fromEntries(
+        Object.entries(exchangeInputFields).filter(
+          ([_, value]) => value !== undefined
+        )
+      )
+      const updatedOrder = await meOrderUpdateShippingAddressLoader(
+        input.id,
+        payload
+      )
+      updatedOrder._type = ORDER_MUTATION_FLAGS.SUCCESS // Set the type for the response
+      return updatedOrder
+    } catch (error) {
+      return handleExchangeError(error)
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -322,6 +322,7 @@ import { CreatePartnerLocationDaySchedulesMutation } from "./partner/Settings/cr
 import { UpdatePartnerProfileImageMutation } from "./partner/Settings/updatePartnerProfileImageMutation"
 import { PurchasesConnection } from "./purchases"
 import { Purchase } from "./purchase"
+import { updateOrderShippingAddressMutation } from "./order/updateOrderShippingAddressMutation"
 
 const rootFields = {
   // artworkVersion: ArtworkVersionResolver,
@@ -623,6 +624,7 @@ export default new GraphQLSchema({
       updateMyUserProfile: UpdateMyUserProfileMutation,
       updateNotificationPreferences: updateNotificationPreferencesMutation,
       updateOrder: updateOrderMutation,
+      updateOrderShippingAddress: updateOrderShippingAddressMutation,
       updateOrderedSet: updateOrderedSetMutation,
       updatePage: UpdatePageMutation,
       updatePartnerContact: UpdatePartnerContactMutation,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/EMI-2399

Followup from https://github.com/artsy/exchange/pull/2535

Porting the new `PUT /api/me/orders/:id/shipping` REST endpoint from exchange in order to deprecate the update of shipping address related fields using `updateOrderMutation`.

The next step is to update Force to use this new mutation and remove shipping related fields from the `updateOrderMutation`.

@artsy/emerald-devs 