### PR TITLE
feat: implement QuickLinks v2

### DIFF
--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -13,6 +13,7 @@ const FEATURE_FLAGS_LIST = [
   "onyx_experiment_home_view_test",
   "emerald_clientside-collector-signals",
   "onyx_enable-home-view-mixer",
+  "onyx_enable-quick-links-v2",
 ] as const
 
 export type FeatureFlag = typeof FEATURE_FLAGS_LIST[number]

--- a/src/schema/v2/homeView/sections/QuickLinks.ts
+++ b/src/schema/v2/homeView/sections/QuickLinks.ts
@@ -4,6 +4,7 @@ import { HomeViewSectionTypeNames } from "../sectionTypes/names"
 import type { NavigationPill } from "../sectionTypes/NavigationPills"
 import { ResolverContext } from "types/graphql"
 import { getEigenVersionNumber, isAtLeastVersion } from "lib/semanticVersioning"
+import { isFeatureFlagEnabled } from "lib/featureFlags"
 
 export const QuickLinks: HomeViewSection = {
   id: "home-view-section-quick-links",
@@ -17,7 +18,11 @@ export const QuickLinks: HomeViewSection = {
 }
 
 function getDisplayableQuickLinks(context: ResolverContext) {
-  return QUICK_LINKS.filter((quickLink) => {
+  const quickLinks = isFeatureFlagEnabled("onyx_enable-quick-links-v2")
+    ? QUICK_LINKS_V2
+    : QUICK_LINKS
+
+  return quickLinks.filter((quickLink) => {
     let isDisplayable = true
     const actualEigenVersion = getEigenVersionNumber(
       context.userAgent as string
@@ -31,6 +36,64 @@ function getDisplayableQuickLinks(context: ResolverContext) {
     return isDisplayable
   })
 }
+
+export const QUICK_LINKS_V2: Array<NavigationPill> = [
+  {
+    title: "Discover Daily",
+    href: "/infinite-discovery",
+    ownerType: OwnerType.infiniteDiscovery,
+    icon: "ImageSetIcon",
+    minimumEigenVersion: { major: 8, minor: 67, patch: 0 }, // same constraint as InfiniteDiscovery section
+  },
+  {
+    title: "Auctions",
+    href: "/auctions",
+    ownerType: OwnerType.auctions,
+    icon: "GavelIcon",
+  },
+  {
+    title: "New This Week",
+    href: "/collection/new-this-week",
+    ownerType: OwnerType.collection,
+    icon: undefined,
+  },
+  {
+    title: "Articles",
+    href: "/articles",
+    ownerType: OwnerType.articles,
+    icon: "PublicationIcon",
+  },
+  {
+    title: "Statement Pieces",
+    href: "/collection/statement-pieces",
+    ownerType: OwnerType.collection,
+    icon: undefined,
+  },
+  {
+    title: "Paintings",
+    href: "/collection/paintings",
+    ownerType: OwnerType.collection,
+    icon: "ArtworkIcon",
+  },
+  {
+    title: "Galleries for You",
+    href: "galleries-for-you",
+    ownerType: OwnerType.galleriesForYou,
+    icon: "InstitutionIcon",
+  },
+  {
+    title: "Shows for You",
+    href: "/shows-for-you",
+    ownerType: OwnerType.shows,
+    icon: undefined,
+  },
+  {
+    title: "Featured Fairs",
+    href: "/featured-fairs",
+    ownerType: OwnerType.featuredFairs,
+    icon: "FairIcon",
+  },
+]
 
 export const QUICK_LINKS: Array<NavigationPill> = [
   {

--- a/src/schema/v2/homeView/sections/__tests__/QuickLinks.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/QuickLinks.test.ts
@@ -2,6 +2,9 @@ import gql from "lib/gql"
 import { runQuery } from "schema/v2/test/utils"
 import { QUICK_LINKS } from "../QuickLinks"
 import { OwnerType } from "@artsy/cohesion"
+import { isFeatureFlagEnabled } from "lib/featureFlags"
+
+const mockIsFeatureFlagEnabled = isFeatureFlagEnabled as jest.Mock
 
 describe("QuickLinks", () => {
   const query = gql`
@@ -29,67 +32,148 @@ describe("QuickLinks", () => {
     accessToken: "424242",
   }
 
-  it("returns the section's data", async () => {
-    const { homeView } = await runQuery(query, context)
+  describe("when v2 is enabled", () => {
+    beforeEach(() => {
+      mockIsFeatureFlagEnabled.mockReturnValue(true)
+    })
 
-    expect(homeView.section).toMatchInlineSnapshot(`
-      {
-        "__typename": "HomeViewSectionNavigationPills",
-        "contextModule": "quickLinks",
-        "internalID": "home-view-section-quick-links",
-        "navigationPills": [
-          {
-            "href": "/favorites/saves",
-            "icon": "HeartStrokeIcon",
-            "ownerType": "saves",
-            "title": "Saves",
-          },
-          {
-            "href": "/auctions",
-            "icon": "GavelIcon",
-            "ownerType": "auctions",
-            "title": "Auctions",
-          },
-          {
-            "href": "/collection/new-this-week",
-            "icon": null,
-            "ownerType": "collection",
-            "title": "New This Week",
-          },
-          {
-            "href": "/articles",
-            "icon": "PublicationIcon",
-            "ownerType": "articles",
-            "title": "Editorial",
-          },
-          {
-            "href": "/collection/statement-pieces",
-            "icon": null,
-            "ownerType": "collection",
-            "title": "Statement Pieces",
-          },
-          {
-            "href": "/collections-by-category/Medium?homeViewSectionId=home-view-section-explore-by-category&entityID=Medium",
-            "icon": "ArtworkIcon",
-            "ownerType": "collectionsCategory",
-            "title": "Medium",
-          },
-          {
-            "href": "/shows-for-you",
-            "icon": null,
-            "ownerType": "shows",
-            "title": "Shows for You",
-          },
-          {
-            "href": "/featured-fairs",
-            "icon": "FairIcon",
-            "ownerType": "featuredFairs",
-            "title": "Featured Fairs",
-          },
-        ],
-        "ownerType": "quickLinks",
-      }
-    `)
+    it("returns the section's data", async () => {
+      const { homeView } = await runQuery(query, context)
+
+      expect(homeView.section).toMatchInlineSnapshot(`
+        {
+          "__typename": "HomeViewSectionNavigationPills",
+          "contextModule": "quickLinks",
+          "internalID": "home-view-section-quick-links",
+          "navigationPills": [
+            {
+              "href": "/infinite-discovery",
+              "icon": "ImageSetIcon",
+              "ownerType": "infiniteDiscovery",
+              "title": "Discover Daily",
+            },
+            {
+              "href": "/auctions",
+              "icon": "GavelIcon",
+              "ownerType": "auctions",
+              "title": "Auctions",
+            },
+            {
+              "href": "/collection/new-this-week",
+              "icon": null,
+              "ownerType": "collection",
+              "title": "New This Week",
+            },
+            {
+              "href": "/articles",
+              "icon": "PublicationIcon",
+              "ownerType": "articles",
+              "title": "Articles",
+            },
+            {
+              "href": "/collection/statement-pieces",
+              "icon": null,
+              "ownerType": "collection",
+              "title": "Statement Pieces",
+            },
+            {
+              "href": "/collection/paintings",
+              "icon": "ArtworkIcon",
+              "ownerType": "collection",
+              "title": "Paintings",
+            },
+            {
+              "href": "galleries-for-you",
+              "icon": "InstitutionIcon",
+              "ownerType": "galleriesForYou",
+              "title": "Galleries for You",
+            },
+            {
+              "href": "/shows-for-you",
+              "icon": null,
+              "ownerType": "shows",
+              "title": "Shows for You",
+            },
+            {
+              "href": "/featured-fairs",
+              "icon": "FairIcon",
+              "ownerType": "featuredFairs",
+              "title": "Featured Fairs",
+            },
+          ],
+          "ownerType": "quickLinks",
+        }
+      `)
+    })
+  })
+
+  describe("when v2 is not enabled", () => {
+    beforeEach(() => {
+      mockIsFeatureFlagEnabled.mockReturnValue(false)
+    })
+
+    it("returns the section's data", async () => {
+      const { homeView } = await runQuery(query, context)
+
+      expect(homeView.section).toMatchInlineSnapshot(`
+        {
+          "__typename": "HomeViewSectionNavigationPills",
+          "contextModule": "quickLinks",
+          "internalID": "home-view-section-quick-links",
+          "navigationPills": [
+            {
+              "href": "/favorites/saves",
+              "icon": "HeartStrokeIcon",
+              "ownerType": "saves",
+              "title": "Saves",
+            },
+            {
+              "href": "/auctions",
+              "icon": "GavelIcon",
+              "ownerType": "auctions",
+              "title": "Auctions",
+            },
+            {
+              "href": "/collection/new-this-week",
+              "icon": null,
+              "ownerType": "collection",
+              "title": "New This Week",
+            },
+            {
+              "href": "/articles",
+              "icon": "PublicationIcon",
+              "ownerType": "articles",
+              "title": "Editorial",
+            },
+            {
+              "href": "/collection/statement-pieces",
+              "icon": null,
+              "ownerType": "collection",
+              "title": "Statement Pieces",
+            },
+            {
+              "href": "/collections-by-category/Medium?homeViewSectionId=home-view-section-explore-by-category&entityID=Medium",
+              "icon": "ArtworkIcon",
+              "ownerType": "collectionsCategory",
+              "title": "Medium",
+            },
+            {
+              "href": "/shows-for-you",
+              "icon": null,
+              "ownerType": "shows",
+              "title": "Shows for You",
+            },
+            {
+              "href": "/featured-fairs",
+              "icon": "FairIcon",
+              "ownerType": "featuredFairs",
+              "title": "Featured Fairs",
+            },
+          ],
+          "ownerType": "quickLinks",
+        }
+      `)
+    })
   })
 
   describe("When a quick link specifies a minimum Eigen version", () => {


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-1689

- Implements the new selection of Quick Links names and destinations for the v2 iteration.
- Places this behind the [onyx_enable-quick-links-v2](https://unleash.artsy.net/projects/default/features/onyx_enable-quick-links-v2) Unleash flag (enabled in staging)

When Eigen receives the updated response (and [supports the newest icons](https://github.com/artsy/eigen/pull/12003) ) it will look like this:

![pills](https://github.com/user-attachments/assets/b12946ac-0bc3-4ed7-b0a5-7da1424f3b84)
