### PR TITLE
chore: pass sync_to_es: true when creating an artwork

### DIFF
--- a/src/schema/v2/artwork/__tests__/createArtworkMutation.test.ts
+++ b/src/schema/v2/artwork/__tests__/createArtworkMutation.test.ts
@@ -93,6 +93,7 @@ describe("CreateArtworkMutation", () => {
         expect(data).toEqual({
           artists: ["artist123", "artist456"],
           partner: "partner123",
+          sync_to_es: true,
         })
         return Promise.resolve(mockArtwork)
       },
@@ -133,6 +134,7 @@ describe("CreateArtworkMutation", () => {
         expect(data).toEqual({
           artists: ["artist123", "artist456"],
           partner: "partner123",
+          sync_to_es: true,
         })
         return Promise.resolve(mockArtwork)
       },
@@ -173,6 +175,7 @@ describe("CreateArtworkMutation", () => {
       expect(data).toEqual({
         artists: ["artist123", "artist456"],
         partner: "partner123",
+        sync_to_es: true,
       })
       return Promise.resolve(mockArtwork)
     })

--- a/src/schema/v2/artwork/createArtworkMutation.ts
+++ b/src/schema/v2/artwork/createArtworkMutation.ts
@@ -163,6 +163,7 @@ export const createArtworkMutation = mutationWithClientMutationId<
       const artwork = await createArtworkLoader({
         artists: artistIds,
         partner: partnerId,
+        sync_to_es: true,
       })
 
       // Attach all images


### PR DESCRIPTION
Passes the new param to sync to ES inline that's been added in https://github.com/artsy/gravity/pull/18881