### PR TITLE
fix: Use locationId over locationID in partner contact space

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9181,7 +9181,7 @@ input CreatePartnerContactInput {
   email: String
 
   # ID of the contact's partner location
-  locationID: String
+  locationId: String
 
   # Contact's name
   name: String

--- a/src/schema/v2/partner/Settings/__tests__/createPartnerContactMutation.test.js
+++ b/src/schema/v2/partner/Settings/__tests__/createPartnerContactMutation.test.js
@@ -11,7 +11,7 @@ const mutation = gql`
         canContact: true
         email: "jane@example.com"
         phone: "123-456-7890"
-        locationID: "location_567"
+        locationId: "location_567"
       }
     ) {
       partnerContactOrError {

--- a/src/schema/v2/partner/Settings/createPartnerContactMutation.ts
+++ b/src/schema/v2/partner/Settings/createPartnerContactMutation.ts
@@ -20,7 +20,7 @@ interface Input {
   canContact?: boolean
   email?: string
   phone?: string
-  locationID?: string
+  locationId?: string
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
@@ -83,7 +83,7 @@ export const CreatePartnerContactMutation = mutationWithClientMutationId<
       type: GraphQLString,
       description: "Phone number of the contact",
     },
-    locationID: {
+    locationId: {
       type: GraphQLString,
       description: "ID of the contact's partner location",
     },
@@ -95,7 +95,7 @@ export const CreatePartnerContactMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    { partnerID, name, position, canContact, email, phone, locationID },
+    { partnerID, name, position, canContact, email, phone, locationId },
     { createPartnerContactLoader }
   ) => {
     if (!createPartnerContactLoader) {
@@ -109,7 +109,7 @@ export const CreatePartnerContactMutation = mutationWithClientMutationId<
         can_contact: canContact,
         email,
         phone,
-        partner_location_id: locationID,
+        partner_location_id: locationId,
       })
 
       return response


### PR DESCRIPTION
Consolidates the usage of `locationId` in the partner contacts mutation space

You'll notice the create mutation uses one spelling while the update uses another
- https://github.com/artsy/metaphysics/blob/main/src/schema/v2/partner/Settings/updatePartnerContactMutation.ts#L24
- https://github.com/artsy/metaphysics/blob/main/src/schema/v2/partner/Settings/createPartnerContactMutation.ts#L23


It is messing with Volt's side of things!