### PR TITLE
feat: add Your Bids quick link for users with active bids

### DIFF
--- a/src/schema/v2/homeView/sections/QuickLinks.ts
+++ b/src/schema/v2/homeView/sections/QuickLinks.ts
@@ -152,10 +152,15 @@ export const QUICK_LINKS: Array<NavigationPill> = [
   },
 ]
 
+/**
+ * If the user has currently active bids then we insert
+ * the **Your Bids** link immediately after the **Auctions** link.
+ * We return the (maybe) updated full list of quick links.
+ */
 async function maybeInsertYourBidsLink(
   links: NavigationPill[],
   context: ResolverContext
-) {
+): Promise<NavigationPill[]> {
   if (isFeatureFlagEnabled("onyx_enable-quick-links-v2")) {
     const { MyBids } = require("schema/v2/me/myBids")
     const bids = await MyBids.resolve?.({}, {}, context, {} as any)

--- a/src/schema/v2/homeView/sections/__tests__/QuickLinks.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/QuickLinks.test.ts
@@ -105,6 +105,69 @@ describe("QuickLinks", () => {
         }
       `)
     })
+
+    describe("when user has active bids", () => {
+      beforeEach(() => {
+        jest.mock("schema/v2/me/myBids", () => {
+          const originalModule = jest.requireActual("schema/v2/me/myBids")
+
+          return {
+            MyBidType: originalModule.MyBidType,
+            MyBids: {
+              ...originalModule.MyBids,
+              resolve: jest.fn().mockReturnValueOnce({
+                active: [
+                  {
+                    // some bid
+                  },
+                ],
+              }),
+            },
+          }
+        })
+      })
+      afterEach(() => {
+        jest.clearAllMocks()
+      })
+
+      it("returns the Your Bids quick link", async () => {
+        const { homeView } = await runQuery(query, context)
+
+        expect(homeView.section.navigationPills).toContainEqual(
+          expect.objectContaining({
+            title: "Your Bids",
+          })
+        )
+      })
+    })
+
+    describe("when user has no active bids", () => {
+      beforeEach(() => {
+        jest.mock("schema/v2/me/myBids", () => {
+          const originalModule = jest.requireActual("schema/v2/me/myBids")
+
+          return {
+            MyBidType: originalModule.MyBidType,
+            MyBids: {
+              ...originalModule.MyBids,
+              resolve: jest.fn().mockReturnValueOnce({}),
+            },
+          }
+        })
+      })
+      afterEach(() => {
+        jest.clearAllMocks()
+      })
+
+      it("does NOT return the Your Bids quick link", async () => {
+        const { homeView } = await runQuery(query, context)
+        expect(homeView.section.navigationPills).not.toContainEqual(
+          expect.objectContaining({
+            title: "Your Bids",
+          })
+        )
+      })
+    })
   })
 
   describe("when v2 is not enabled", () => {


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-1691

For Quick Links v2, this Implements the conditional **Your Bids** link that is shown only to users with active bids:

```js
{
  title: "Your Bids",
  href: "/inbox",
  ownerType: OwnerType.inbox,
  icon: undefined,
}
```

Tapping on the pill takes you to `/inbox`, which in turn defaults to the **Bids** view if there are active bids.


| Pill | Destination |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/429e6a63-a23b-4473-8ded-ba765a90295a" height=400 /> | <img src="https://github.com/user-attachments/assets/fcf37d0f-babd-4fd3-b989-4d68962bfb6d" height=400 /> | 


