### PR TITLE
chore: add showID to filterArtworksConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -398,6 +398,7 @@ type Alert {
     # When false, will only return unpublished artworks for authorized users.
     published: Boolean
     saleID: ID
+    showID: String
 
     # When true, will only return signed artworks.
     signed: Boolean
@@ -1805,6 +1806,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     # When false, will only return unpublished artworks for authorized users.
     published: Boolean
     saleID: ID
+    showID: String
 
     # When true, will only return signed artworks.
     signed: Boolean
@@ -2250,6 +2252,7 @@ type ArtistPartnerEdge {
     # When false, will only return unpublished artworks for authorized users.
     published: Boolean
     saleID: ID
+    showID: String
 
     # When true, will only return signed artworks.
     signed: Boolean
@@ -2404,6 +2407,7 @@ type ArtistSeries implements Node {
     # When false, will only return unpublished artworks for authorized users.
     published: Boolean
     saleID: ID
+    showID: String
 
     # When true, will only return signed artworks.
     signed: Boolean
@@ -10746,6 +10750,7 @@ interface EntityWithFilterArtworksConnectionInterface {
     # When false, will only return unpublished artworks for authorized users.
     published: Boolean
     saleID: ID
+    showID: String
 
     # When true, will only return signed artworks.
     signed: Boolean
@@ -11013,6 +11018,7 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
     # When false, will only return unpublished artworks for authorized users.
     published: Boolean
     saleID: ID
+    showID: String
 
     # When true, will only return signed artworks.
     signed: Boolean
@@ -11541,6 +11547,7 @@ input FilterArtworksInput {
   # When false, will only return unpublished artworks for authorized users.
   published: Boolean
   saleID: ID
+  showID: String
 
   # When true, will only return signed artworks.
   signed: Boolean
@@ -12068,6 +12075,7 @@ type Gene implements Node & Searchable {
     # When false, will only return unpublished artworks for authorized users.
     published: Boolean
     saleID: ID
+    showID: String
 
     # When true, will only return signed artworks.
     signed: Boolean
@@ -13939,6 +13947,7 @@ type MarketingCollection implements Node {
     # When false, will only return unpublished artworks for authorized users.
     published: Boolean
     saleID: ID
+    showID: String
 
     # When true, will only return signed artworks.
     signed: Boolean
@@ -16873,6 +16882,7 @@ type Partner implements Node {
     # When false, will only return unpublished artworks for authorized users.
     published: Boolean
     saleID: ID
+    showID: String
 
     # When true, will only return signed artworks.
     signed: Boolean
@@ -17199,6 +17209,7 @@ type PartnerArtist {
     # When false, will only return unpublished artworks for authorized users.
     published: Boolean
     saleID: ID
+    showID: String
 
     # When true, will only return signed artworks.
     signed: Boolean
@@ -17394,6 +17405,7 @@ type PartnerArtistEdge {
     # When false, will only return unpublished artworks for authorized users.
     published: Boolean
     saleID: ID
+    showID: String
 
     # When true, will only return signed artworks.
     signed: Boolean
@@ -18667,6 +18679,7 @@ type Query {
     # When false, will only return unpublished artworks for authorized users.
     published: Boolean
     saleID: ID
+    showID: String
 
     # When true, will only return signed artworks.
     signed: Boolean
@@ -21293,6 +21306,7 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
     # When false, will only return unpublished artworks for authorized users.
     published: Boolean
     saleID: ID
+    showID: String
 
     # When true, will only return signed artworks.
     signed: Boolean
@@ -21842,6 +21856,7 @@ type Tag implements Node {
     # When false, will only return unpublished artworks for authorized users.
     published: Boolean
     saleID: ID
+    showID: String
 
     # When true, will only return signed artworks.
     signed: Boolean
@@ -24476,6 +24491,7 @@ type Viewer {
     # When false, will only return unpublished artworks for authorized users.
     published: Boolean
     saleID: ID
+    showID: String
 
     # When true, will only return signed artworks.
     signed: Boolean

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -250,6 +250,9 @@ export const filterArtworksArgs: GraphQLFieldConfigArgumentMap = {
   saleID: {
     type: GraphQLID,
   },
+  showID: {
+    type: GraphQLString,
+  },
   sold: {
     type: GraphQLBoolean,
   },
@@ -474,6 +477,7 @@ const convertFilterArgs = ({
   partnerIDs,
   priceRange,
   saleID,
+  showID,
   sizes,
   tagID,
   visibilityLevel,
@@ -509,6 +513,7 @@ const convertFilterArgs = ({
     partner_cities: partnerCities,
     partner_id: partnerID,
     partner_ids: partnerIDs,
+    partner_show_id: showID,
     price_range: priceRange,
     sale_id: saleID,
     sizes: sizes,


### PR DESCRIPTION
Makes for easier querying, rather than needing to go through the `show: Show`.