### PR TITLE
feat(DIA-1286): set up discover tab a/b test

### DIFF
--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -14,6 +14,7 @@ const FEATURE_FLAGS_LIST = [
   "emerald_clientside-collector-signals",
   "onyx_enable-home-view-mixer",
   "onyx_enable-quick-links-v2",
+  "diamond_discover-tab",
 ] as const
 
 export type FeatureFlag = typeof FEATURE_FLAGS_LIST[number]

--- a/src/schema/v2/homeView/experiments/experiments.ts
+++ b/src/schema/v2/homeView/experiments/experiments.ts
@@ -6,4 +6,5 @@ import { FeatureFlag } from "lib/featureFlags"
  */
 export const CURRENTLY_RUNNING_EXPERIMENTS: FeatureFlag[] = [
   "onyx_experiment_home_view_test",
+  "diamond_discover-tab",
 ]

--- a/src/schema/v2/homeView/sections/DiscoverSomethingNew.ts
+++ b/src/schema/v2/homeView/sections/DiscoverSomethingNew.ts
@@ -1,7 +1,8 @@
 import { ContextModule } from "@artsy/cohesion"
+import { connectionFromArray } from "graphql-relay"
+import { getExperimentVariant } from "lib/featureFlags"
 import { HomeViewSection } from "."
 import { HomeViewSectionTypeNames } from "../sectionTypes/names"
-import { connectionFromArray } from "graphql-relay"
 
 const marketingCollectionSlugs = [
   "most-loved",
@@ -27,6 +28,16 @@ export const DiscoverSomethingNew: HomeViewSection = {
     type: "Chips",
   },
   requiresAuthentication: false,
+  shouldBeDisplayed: (context) => {
+    const variant = getExperimentVariant("diamond_discover-tab", {
+      userId: context.userID,
+    })
+
+    const isDiscoverVariant =
+      variant && variant.name === "variant-a" && variant.enabled
+
+    return !isDiscoverVariant
+  },
   resolver: async (_parent, args, context, _info) => {
     const { body } = await context.marketingCollectionsLoader({
       slugs: marketingCollectionSlugs,

--- a/src/schema/v2/homeView/sections/ExploreByCategory.ts
+++ b/src/schema/v2/homeView/sections/ExploreByCategory.ts
@@ -3,6 +3,7 @@ import { HomeViewSection } from "."
 import { HomeViewSectionTypeNames } from "../sectionTypes/names"
 import { connectionFromArray } from "graphql-relay"
 import { marketingCollectionCategories } from "lib/marketingCollectionCategories"
+import { getExperimentVariant } from "lib/featureFlags"
 
 const orderedCategoryKeys = [
   "Medium",
@@ -21,6 +22,16 @@ export const ExploreByCategory: HomeViewSection = {
     title: "Explore by Category",
   },
   requiresAuthentication: false,
+  shouldBeDisplayed: (context) => {
+    const variant = getExperimentVariant("diamond_discover-tab", {
+      userId: context.userID,
+    })
+
+    const isDiscoverVariant =
+      variant && variant.name === "variant-a" && variant.enabled
+
+    return !isDiscoverVariant
+  },
   resolver: (_parent, args, _context, _info) => {
     const cards = orderedCategoryKeys.map((key) => {
       const category = marketingCollectionCategories[key]

--- a/src/schema/v2/homeView/sections/__tests__/DiscoverSomethingNew.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/DiscoverSomethingNew.test.ts
@@ -1,7 +1,18 @@
 import gql from "lib/gql"
 import { runQuery } from "schema/v2/test/utils"
+import * as featureFlags from "lib/featureFlags"
+
+jest.mock("lib/featureFlags", () => ({
+  getExperimentVariant: jest.fn(),
+}))
 
 describe("DiscoverSomethingNew", () => {
+  const mockGetExperimentVariant = featureFlags.getExperimentVariant as jest.Mock
+
+  beforeEach(() => {
+    mockGetExperimentVariant.mockClear().mockReturnValue(false)
+  })
+
   it("returns the section's metadata", async () => {
     const query = gql`
       {
@@ -116,5 +127,34 @@ describe("DiscoverSomethingNew", () => {
           },
         }
       `)
+  })
+
+  it("is not displayable when user is in variant A of diamond_discover-tab experiment", async () => {
+    mockGetExperimentVariant.mockReturnValue({
+      name: "variant-a",
+      enabled: true,
+    })
+
+    const query = gql`
+      {
+        homeView {
+          section(id: "home-view-section-discover-something-new") {
+            __typename
+          }
+        }
+      }
+    `
+
+    const context = {
+      userID: "test-user-id",
+    }
+
+    await expect(runQuery(query, context)).rejects.toThrow(
+      "Section is not displayable"
+    )
+
+    expect(
+      mockGetExperimentVariant
+    ).toHaveBeenCalledWith("diamond_discover-tab", { userId: "test-user-id" })
   })
 })

--- a/src/schema/v2/homeView/zones/__tests__/default.test.ts
+++ b/src/schema/v2/homeView/zones/__tests__/default.test.ts
@@ -1,12 +1,14 @@
-import { isFeatureFlagEnabled } from "lib/featureFlags"
+import { isFeatureFlagEnabled, getExperimentVariant } from "lib/featureFlags"
 import { ResolverContext } from "types/graphql"
 import { getSections } from "../default"
 
 jest.mock("lib/featureFlags", () => ({
   isFeatureFlagEnabled: jest.fn(() => true),
+  getExperimentVariant: jest.fn(() => false),
 }))
 
 const mockIsFeatureFlagEnabled = isFeatureFlagEnabled as jest.Mock
+const mockGetExperimentVariant = getExperimentVariant as jest.Mock
 
 describe("getSections", () => {
   describe("with an authenticated user", () => {
@@ -109,6 +111,58 @@ describe("getSections", () => {
         const sectionIds = sections.map((section) => section.id)
 
         expect(sectionIds).not.toInclude("home-view-section-featured-fairs")
+      })
+    })
+  })
+
+  describe("diamond_discover-tab experiment", () => {
+    describe("when user is in variant-a", () => {
+      beforeEach(() => {
+        mockGetExperimentVariant.mockImplementation((flag: string) => {
+          if (flag === "diamond_discover-tab") {
+            return {
+              name: "variant-a",
+              enabled: true,
+            }
+          }
+          return false
+        })
+      })
+
+      it("does not include DiscoverSomethingNew and ExploreByCategory sections", async () => {
+        const context: Partial<ResolverContext> = {
+          userID: "test-user-id",
+        }
+
+        const sections = await getSections(context as ResolverContext)
+        const sectionIds = sections.map((section) => section.id)
+
+        expect(sectionIds).not.toInclude(
+          "home-view-section-discover-something-new"
+        )
+        expect(sectionIds).not.toInclude(
+          "home-view-section-explore-by-category"
+        )
+      })
+    })
+
+    describe("when user is not in variant-a", () => {
+      beforeEach(() => {
+        mockGetExperimentVariant.mockImplementation(() => {
+          return false
+        })
+      })
+
+      it("includes DiscoverSomethingNew and ExploreByCategory sections", async () => {
+        const context: Partial<ResolverContext> = {
+          userID: "test-user-id",
+        }
+
+        const sections = await getSections(context as ResolverContext)
+        const sectionIds = sections.map((section) => section.id)
+
+        expect(sectionIds).toInclude("home-view-section-discover-something-new")
+        expect(sectionIds).toInclude("home-view-section-explore-by-category")
       })
     })
   })


### PR DESCRIPTION
This PR sets up part of an A/B test for the `discover_diamond-tab` experiment. This portion is responsible for hiding the _Discover Something New_ and _Explore by Category_ home view sections for users assigned to variant A. (Those users will be able to find those sections in the new discover tab, which is set up in [Eigen](https://github.com/artsy/eigen/pull/11974).)