### PR TITLE
fix(DIA-1286): allow visibility of home view sections to be overridden

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12535,6 +12535,9 @@ type HomeView {
   section(
     # The ID of the section
     id: String!
+
+    # Overrides shouldBeDisplayed to show sections that would otherwise be hidden
+    overrideShouldBeDisplayed: Boolean = false
   ): HomeViewSectionGeneric
 
   # A paginated list of home view sections

--- a/src/schema/v2/homeView/__tests__/HomeView.test.ts
+++ b/src/schema/v2/homeView/__tests__/HomeView.test.ts
@@ -520,6 +520,73 @@ describe("homeView", () => {
         })
       })
     })
+
+    describe("with overrideShouldBeDisplayed parameter", () => {
+      describe("accessing a section that would be hidden by overrideShouldBeDisplayed", () => {
+        const context: Partial<ResolverContext> = {
+          userID: "test-user-id",
+        }
+
+        beforeEach(() => {
+          mockGetExperimentVariant.mockImplementation((flag: string) => {
+            if (flag === "diamond_discover-tab") {
+              return {
+                name: "variant-a",
+                enabled: true,
+              }
+            }
+            return false
+          })
+        })
+
+        it("throws an error when overrideShouldBeDisplayed is false", async () => {
+          const query = gql`
+            {
+              homeView {
+                section(id: "home-view-section-discover-something-new") {
+                  __typename
+                }
+              }
+            }
+          `
+
+          await expect(runQuery(query, context)).rejects.toThrow(
+            "Section is not displayable"
+          )
+        })
+
+        it("returns the hidden section when overrideShouldBeDisplayed is true", async () => {
+          const query = gql`
+            {
+              homeView {
+                section(
+                  id: "home-view-section-discover-something-new"
+                  overrideShouldBeDisplayed: true
+                ) {
+                  __typename
+                  ... on HomeViewSectionGeneric {
+                    component {
+                      title
+                    }
+                  }
+                }
+              }
+            }
+          `
+
+          const { homeView } = await runQuery(query, context)
+
+          expect(homeView.section).toMatchInlineSnapshot(`
+            {
+              "__typename": "HomeViewSectionCards",
+              "component": {
+                "title": "Discover Something New",
+              },
+            }
+          `)
+        })
+      })
+    })
   })
 
   describe("experiments", () => {

--- a/src/schema/v2/homeView/helpers/isSectionDisplayable.ts
+++ b/src/schema/v2/homeView/helpers/isSectionDisplayable.ts
@@ -9,7 +9,8 @@ import { getEigenVersionNumber, isAtLeastVersion } from "lib/semanticVersioning"
  */
 export function isSectionDisplayable(
   section: HomeViewSection,
-  context: ResolverContext
+  context: ResolverContext,
+  options?: { overrideShouldBeDisplayed?: boolean }
 ): boolean {
   // public content
   const isPublicSection = section.requiresAuthentication === false
@@ -41,9 +42,14 @@ export function isSectionDisplayable(
     }
   }
 
+  // override section's display pre-check if present
+  if (options?.overrideShouldBeDisplayed) {
+    return isDisplayable
+  }
+
   // section's display pre-check
   if (typeof section.shouldBeDisplayed === "function") {
-    isDisplayable = isDisplayable && section?.shouldBeDisplayed(context)
+    isDisplayable = isDisplayable && section.shouldBeDisplayed(context)
   }
 
   return isDisplayable

--- a/src/schema/v2/homeView/index.ts
+++ b/src/schema/v2/homeView/index.ts
@@ -1,4 +1,5 @@
 import {
+  GraphQLBoolean,
   GraphQLFieldConfig,
   GraphQLNonNull,
   GraphQLObjectType,
@@ -51,16 +52,24 @@ export const Section: GraphQLFieldConfig<void, ResolverContext> = {
       description: "The ID of the section",
       type: new GraphQLNonNull(GraphQLString),
     },
+    overrideShouldBeDisplayed: {
+      description:
+        "Overrides shouldBeDisplayed to show sections that would otherwise be hidden",
+      type: GraphQLBoolean,
+      defaultValue: false,
+    },
   },
   resolve: (_parent, args, context, _info) => {
-    const { id } = args
+    const { id, overrideShouldBeDisplayed } = args
     const section = registry[id]
 
     if (!section) {
       throw new Error(`Section not found: ${id}`)
     }
 
-    if (!isSectionDisplayable(section, context)) {
+    if (
+      !isSectionDisplayable(section, context, { overrideShouldBeDisplayed })
+    ) {
       throw new Error(`Section is not displayable: ${id}`)
     }
 


### PR DESCRIPTION
This PR allows clients that query Home View sections to override the `shouldBeDisplayed` property. This was done so that the Diamond team could conduct an A/B test to display some sections on the Search tab instead of the Home tab of the app. We were able to hide these sections from the Home tab with the `shouldBeDisplayed` property, but that also prevented us from querying those sections individually for the Search tab.

After this change, feature flags and minimum eigen versions will still be respected.