### PR TITLE
chore: support install shots/covers for a show

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -21395,6 +21395,9 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
     after: String
     before: String
     first: Int
+
+    # When false, will exclude the cover image from the results
+    isDefault: Boolean
     last: Int
   ): ImageConnection
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -157,11 +157,17 @@ input AddInstallShotToPartnerShowMutationInput {
   caption: String
   clientMutationId: String
 
+  # Optional URL of the image to add as an installation shot. If provided, this will be used instead of the S3 bucket and key.
+  imageUrl: String
+
+  # Optional flag to indicate if this installation shot should be set as the default (cover) image for the show.
+  isDefault: Boolean
+
   # The S3 bucket where the image is stored.
-  s3Bucket: String!
+  s3Bucket: String
 
   # The S3 key for the image to add as an installation shot.
-  s3Key: String!
+  s3Key: String
 
   # The ID of the show.
   showId: String!

--- a/src/schema/v2/Show/addInstallShotToPartnerShowMutation.ts
+++ b/src/schema/v2/Show/addInstallShotToPartnerShowMutation.ts
@@ -3,6 +3,7 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLUnionType,
+  GraphQLBoolean,
 } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 import {
@@ -14,9 +15,11 @@ import { ShowType } from "../show"
 
 interface AddInstallShotToPartnerShowMutationInputProps {
   showId: string
-  s3Bucket: string
-  s3Key: string
+  s3Bucket?: string
+  s3Key?: string
   caption?: string
+  isDefault?: boolean
+  imageUrl?: string
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
@@ -59,12 +62,22 @@ export const addInstallShotToPartnerShowMutation = mutationWithClientMutationId<
       description: "The ID of the show.",
     },
     s3Bucket: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: GraphQLString,
       description: "The S3 bucket where the image is stored.",
     },
     s3Key: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: GraphQLString,
       description: "The S3 key for the image to add as an installation shot.",
+    },
+    imageUrl: {
+      type: GraphQLString,
+      description:
+        "Optional URL of the image to add as an installation shot. If provided, this will be used instead of the S3 bucket and key.",
+    },
+    isDefault: {
+      type: GraphQLBoolean,
+      description:
+        "Optional flag to indicate if this installation shot should be set as the default (cover) image for the show.",
     },
     caption: {
       type: GraphQLString,
@@ -80,7 +93,14 @@ export const addInstallShotToPartnerShowMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    { showId, s3Bucket, s3Key, caption },
+    {
+      showId,
+      s3Bucket,
+      s3Key,
+      caption,
+      isDefault,
+      imageUrl,
+    }: AddInstallShotToPartnerShowMutationInputProps,
     { addInstallShotToPartnerShowLoader }
   ) => {
     if (!addInstallShotToPartnerShowLoader) {
@@ -94,6 +114,8 @@ export const addInstallShotToPartnerShowMutation = mutationWithClientMutationId<
     const data = {
       remote_image_s3_bucket: s3Bucket,
       remote_image_s3_key: s3Key,
+      remote_image_url: imageUrl,
+      default: isDefault,
       ...(caption && { caption }),
     }
 

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -438,8 +438,18 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
       },
       imagesConnection: {
         type: ImageConnectionType,
-        args: pageable({}),
-        resolve: async ({ id }, options, { partnerShowImagesLoader }) => {
+        args: pageable({
+          isDefault: {
+            type: GraphQLBoolean,
+            description:
+              "When false, will exclude the cover image from the results",
+          },
+        }),
+        resolve: async (
+          { id },
+          { isDefault, ...options },
+          { partnerShowImagesLoader }
+        ) => {
           const { page, size, offset } = convertConnectionArgsToGravityArgs(
             options
           )
@@ -447,6 +457,7 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
             size,
             offset,
             total_count: true,
+            default: isDefault,
           }
 
           const { body, headers } = await partnerShowImagesLoader(


### PR DESCRIPTION
cc @damassi 

This supports our current backend for the 'cover' of a show. The cover of a show can be selected by a user and is implemented as an install shot set as 'default'.

So we need to update the mutation to create an install shot to support creating one from URL as well as marking a created install shot as default. And then reading the data, on `imagesConnection` you need a way to specify to _exclude_ the cover image - which mimics what Force and Eigen do when presenting install shots (and excluding the cover).