### PR TITLE
feat: Add `importSources` arg to `filterArtworksConnection`

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -371,6 +371,7 @@ type Alert {
     geneID: String
     geneIDs: [String]
     height: String
+    importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
@@ -1779,6 +1780,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     geneID: String
     geneIDs: [String]
     height: String
+    importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
@@ -2225,6 +2227,7 @@ type ArtistPartnerEdge {
     geneID: String
     geneIDs: [String]
     height: String
+    importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
@@ -2380,6 +2383,7 @@ type ArtistSeries implements Node {
     geneID: String
     geneIDs: [String]
     height: String
+    importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
@@ -10742,6 +10746,7 @@ interface EntityWithFilterArtworksConnectionInterface {
     geneID: String
     geneIDs: [String]
     height: String
+    importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
@@ -11009,6 +11014,7 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
     geneID: String
     geneIDs: [String]
     height: String
+    importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
@@ -11539,6 +11545,7 @@ input FilterArtworksInput {
   geneID: String
   geneIDs: [String]
   height: String
+  importSources: [String]
   includeAllJSON: Boolean
   includeArtworksByFollowedArtists: Boolean
   includeMediumFilterInAggregation: Boolean
@@ -12069,6 +12076,7 @@ type Gene implements Node & Searchable {
     geneID: String
     geneIDs: [String]
     height: String
+    importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
@@ -13944,6 +13952,7 @@ type MarketingCollection implements Node {
     geneID: String
     geneIDs: [String]
     height: String
+    importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
@@ -16882,6 +16891,7 @@ type Partner implements Node {
     geneID: String
     geneIDs: [String]
     height: String
+    importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
@@ -17209,6 +17219,7 @@ type PartnerArtist {
     geneID: String
     geneIDs: [String]
     height: String
+    importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
@@ -17405,6 +17416,7 @@ type PartnerArtistEdge {
     geneID: String
     geneIDs: [String]
     height: String
+    importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
@@ -18684,6 +18696,7 @@ type Query {
     geneID: String
     geneIDs: [String]
     height: String
+    importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
@@ -21317,6 +21330,7 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
     geneID: String
     geneIDs: [String]
     height: String
+    importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
@@ -21870,6 +21884,7 @@ type Tag implements Node {
     geneID: String
     geneIDs: [String]
     height: String
+    importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean
@@ -24505,6 +24520,7 @@ type Viewer {
     geneID: String
     geneIDs: [String]
     height: String
+    importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
     includeMediumFilterInAggregation: Boolean

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -1,57 +1,57 @@
-import { pageable } from "relay-cursor-paging"
 import {
-  convertConnectionArgsToGravityArgs,
-  removeNulls,
-  removeEmptyValues,
-  isExisty,
-} from "lib/helpers"
+  GraphQLBoolean,
+  GraphQLFieldConfig,
+  GraphQLFieldConfigArgumentMap,
+  GraphQLID,
+  GraphQLInputObjectType,
+  GraphQLInt,
+  GraphQLInterfaceType,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
 import {
-  connectionFromArraySlice,
   connectionDefinitions,
+  connectionFromArraySlice,
   toGlobalId,
 } from "graphql-relay"
 import {
-  GraphQLFieldConfig,
-  GraphQLNonNull,
-  GraphQLID,
-  GraphQLFieldConfigArgumentMap,
-  GraphQLBoolean,
-  GraphQLList,
-  GraphQLString,
-  GraphQLInt,
-  GraphQLUnionType,
-  GraphQLObjectType,
-  GraphQLInterfaceType,
-  GraphQLInputObjectType,
-} from "graphql"
+  convertConnectionArgsToGravityArgs,
+  isExisty,
+  removeEmptyValues,
+  removeNulls,
+} from "lib/helpers"
+import { pageable } from "relay-cursor-paging"
 
-import { ResolverContext } from "types/graphql"
 import { includesFieldsOtherThanSelectionSet } from "lib/hasFieldSelection"
 import {
   computeTotalPages,
   createPageCursors,
-  pageToCursor,
   PageCursorsType,
+  pageToCursor,
 } from "schema/v2/fields/pagination"
+import { ResolverContext } from "types/graphql"
 
-import Artwork, {
-  artworkConnection,
-  ArtworkConnectionInterface,
-  ArtworkEdgeInterface,
-} from "./artwork"
-import { NodeInterface, GlobalIDField } from "./object_identification"
+import { deprecate } from "lib/deprecation"
+import { keys, map, omit } from "lodash"
 import {
   ArtworksAggregation,
   ArtworksAggregationResultsType,
 } from "./aggregations/filter_artworks_aggregation"
-import { omit, keys, map } from "lodash"
 import Artist from "./artist"
-import { TagType } from "./tag"
-import { GeneType } from "./gene"
-import numeral from "./fields/numeral"
-import { ArtworkType } from "./artwork"
-import { deprecate } from "lib/deprecation"
+import Artwork, {
+  artworkConnection,
+  ArtworkConnectionInterface,
+  ArtworkEdgeInterface,
+  ArtworkType,
+} from "./artwork"
 import ArtworkSizes from "./artwork/artworkSizes"
+import numeral from "./fields/numeral"
+import { GeneType } from "./gene"
+import { GlobalIDField, NodeInterface } from "./object_identification"
+import { TagType } from "./tag"
 
 interface ContextSource {
   context_type: GraphQLObjectType<any, ResolverContext>
@@ -173,6 +173,9 @@ export const filterArtworksArgs: GraphQLFieldConfigArgumentMap = {
   },
   height: {
     type: GraphQLString,
+  },
+  importSources: {
+    type: GraphQLList(GraphQLString),
   },
   includeAllJSON: {
     type: GraphQLBoolean,
@@ -462,6 +465,7 @@ const convertFilterArgs = ({
   forSale,
   geneID,
   geneIDs,
+  importSources,
   includeAllJSON,
   includeArtworksByFollowedArtists,
   includeMediumFilterInAggregation,
@@ -500,6 +504,7 @@ const convertFilterArgs = ({
     gene_id: geneID,
     gene_ids: geneIDs,
     ids: artworkIDs,
+    import_sources: importSources,
     include_all_json: includeAllJSON,
     include_artworks_by_followed_artists: includeArtworksByFollowedArtists,
     include_medium_filter_in_aggregation: includeMediumFilterInAggregation,


### PR DESCRIPTION
Resolves https://www.notion.so/artsy/Allow-artworks-to-be-filtered-by-Import-Source-1decab0764a080f4be48cb86e0410668?pvs=4

* https://github.com/artsy/gravity/pull/18899

### Description

This adds an `importSources` arg to `filterArtworksConnectione` to allow filtering artworks by import source in Volt.