### PR TITLE
feat: add enable field to UserType and updateUserMutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -23601,6 +23601,7 @@ input UpdateUserMutationInput {
   clientMutationId: String
   dataTransferOptOut: Boolean
   email: String
+  enabled: Boolean
   id: String!
   name: String
   phone: String
@@ -23709,6 +23710,9 @@ type User implements Node {
     # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String
+
+  # If the user is enabled
+  enabled: Boolean!
   follows: UserFollows
 
   # A globally unique ID.

--- a/src/schema/v2/user.ts
+++ b/src/schema/v2/user.ts
@@ -226,6 +226,11 @@ export const UserType = new GraphQLObjectType<any, ResolverContext>({
       emailConfirmationSentAt: date(
         ({ confirmation_sent_at }) => confirmation_sent_at
       ),
+      enabled: {
+        description: "If the user is enabled",
+        type: new GraphQLNonNull(GraphQLBoolean),
+        resolve: ({ is_enabled }) => is_enabled,
+      },
       secondFactorEnabled: {
         description:
           "If the user has enabled two-factor authentication on their account",

--- a/src/schema/v2/users/updateUserMutation.ts
+++ b/src/schema/v2/users/updateUserMutation.ts
@@ -38,6 +38,7 @@ export const updateUserMutation = mutationWithClientMutationId<
     email: { type: GraphQLString },
     name: { type: GraphQLString },
     phone: { type: GraphQLString },
+    enabled: { type: GraphQLBoolean },
   },
   outputFields: {},
   mutateAndGetPayload: async (args, { updateUserLoader }) => {


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PHIRE-1759

Related to https://github.com/artsy/gravity/pull/18901

Introduces `enabled` field to `UserType` and `updateUserMutation` to allow toggling of this field on a given user.

