### PR TITLE
feat(EMI-2399): deprecate shipping params from updateOrderMutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -26188,11 +26188,6 @@ type updateNotificationPreferencesMutationPayload {
 }
 
 input updateOrderInput {
-  # Buyer's phone number
-  buyerPhoneNumber: String
-
-  # Buyer's phone number country code
-  buyerPhoneNumberCountryCode: String
   clientMutationId: String
 
   # Credit card wallet type
@@ -26203,27 +26198,6 @@ input updateOrderInput {
 
   # Payment method.
   paymentMethod: OrderPaymentMethodEnum
-
-  # Shipping address line 1
-  shippingAddressLine1: String
-
-  # Shipping address line 2
-  shippingAddressLine2: String
-
-  # Shipping address city
-  shippingCity: String
-
-  # Shipping address country
-  shippingCountry: String
-
-  # Shipping address name
-  shippingName: String
-
-  # Shipping address postal code
-  shippingPostalCode: String
-
-  # Shipping address state/province/region
-  shippingRegion: String
 }
 
 type updateOrderPayload {

--- a/src/schema/v2/order/__tests__/updateOrderMutation.test.ts
+++ b/src/schema/v2/order/__tests__/updateOrderMutation.test.ts
@@ -5,15 +5,8 @@ const mockMutation = `
   mutation {
     updateOrder(input: {
       id: "order-id",
-      buyerPhoneNumber: "123-456-7890",
-      buyerPhoneNumberCountryCode: "+1",
-      shippingName: "John Doe",
-      shippingAddressLine1: "123 Main St",
-      shippingAddressLine2: "Apt 4B",
-      shippingCity: "New York",
-      shippingRegion: "NY",
-      shippingCountry: "US",
-      shippingPostalCode: "10001"
+      paymentMethod: CREDIT_CARD,
+      creditCardWalletType: APPLE_PAY
     }) {
       orderOrError {
         ...on OrderMutationError {
@@ -25,20 +18,7 @@ const mockMutation = `
         ...on OrderMutationSuccess {
           order {
             internalID
-            fulfillmentDetails {
-              phoneNumber {
-                originalNumber
-              }
-              phoneNumberCountryCode
-              name
-              addressLine1
-              addressLine2
-              city
-              region
-              country
-              postalCode
-            }
-          }     
+          }
         }
       }
     }
@@ -56,18 +36,8 @@ describe("updateOrderMutation", () => {
         code: "order-code",
         mode: "buy",
         currency_code: "USD",
-        buyer_total_cents: null,
-        items_total_cents: 500000,
-        shipping_total_cents: 2000,
-        buyer_phone_number: "123-456-7890",
-        buyer_phone_number_country_code: "us",
-        shipping_name: "John Doe",
-        shipping_country: "US",
-        shipping_postal_code: "10001",
-        shipping_region: "NY",
-        shipping_city: "New York",
-        shipping_address_line1: "123 Main St",
-        shipping_address_line2: "Apt 4B",
+        payment_method: "credit card",
+        credit_card_wallet_type: "apple_pay",
       }),
       artworkLoader: jest.fn().mockResolvedValue({ ...baseArtwork }),
       artworkVersionLoader: jest
@@ -84,34 +54,14 @@ describe("updateOrderMutation", () => {
         orderOrError: {
           order: {
             internalID: "order-id",
-            fulfillmentDetails: {
-              phoneNumber: {
-                originalNumber: "123-456-7890",
-              },
-              phoneNumberCountryCode: "us",
-              name: "John Doe",
-              addressLine1: "123 Main St",
-              addressLine2: "Apt 4B",
-              city: "New York",
-              region: "NY",
-              country: "US",
-              postalCode: "10001",
-            },
           },
         },
       },
     })
 
     expect(context.meOrderUpdateLoader).toHaveBeenCalledWith("order-id", {
-      buyer_phone_number: "123-456-7890",
-      buyer_phone_number_country_code: "+1",
-      shipping_address_line1: "123 Main St",
-      shipping_address_line2: "Apt 4B",
-      shipping_city: "New York",
-      shipping_country: "US",
-      shipping_name: "John Doe",
-      shipping_postal_code: "10001",
-      shipping_region: "NY",
+      payment_method: "credit card",
+      credit_card_wallet_type: "apple_pay",
     })
   })
 
@@ -121,7 +71,7 @@ describe("updateOrderMutation", () => {
       mutation {
         updateOrder(input: {
           id: "order-id",
-          buyerPhoneNumber: null
+          paymentMethod: null
         }) {
           orderOrError {
             ...on OrderMutationSuccess {
@@ -148,7 +98,7 @@ describe("updateOrderMutation", () => {
     })
 
     expect(context.meOrderUpdateLoader).toHaveBeenCalledWith("order-id", {
-      buyer_phone_number: null,
+      payment_method: null,
     })
   })
 

--- a/src/schema/v2/order/updateOrderMutation.ts
+++ b/src/schema/v2/order/updateOrderMutation.ts
@@ -13,15 +13,6 @@ interface Input {
   id: string
   paymentMethod?: string
   creditCardWalletType?: string
-  buyerPhoneNumber?: string
-  buyerPhoneNumberCountryCode?: string
-  shippingName?: string
-  shippingAddressLine1?: string
-  shippingAddressLine2?: string
-  shippingCity?: string
-  shippingRegion?: string
-  shippingCountry?: string
-  shippingPostalCode?: string
 }
 
 export const updateOrderMutation = mutationWithClientMutationId<
@@ -41,42 +32,6 @@ export const updateOrderMutation = mutationWithClientMutationId<
       type: OrderCreditCardWalletTypeEnum,
       description: "Credit card wallet type",
     },
-    buyerPhoneNumber: {
-      type: GraphQLString,
-      description: "Buyer's phone number",
-    },
-    buyerPhoneNumberCountryCode: {
-      type: GraphQLString,
-      description: "Buyer's phone number country code",
-    },
-    shippingName: {
-      type: GraphQLString,
-      description: "Shipping address name",
-    },
-    shippingAddressLine1: {
-      type: GraphQLString,
-      description: "Shipping address line 1",
-    },
-    shippingAddressLine2: {
-      type: GraphQLString,
-      description: "Shipping address line 2",
-    },
-    shippingCity: {
-      type: GraphQLString,
-      description: "Shipping address city",
-    },
-    shippingRegion: {
-      type: GraphQLString,
-      description: "Shipping address state/province/region",
-    },
-    shippingCountry: {
-      type: GraphQLString,
-      description: "Shipping address country",
-    },
-    shippingPostalCode: {
-      type: GraphQLString,
-      description: "Shipping address postal code",
-    },
   },
   outputFields: {
     orderOrError: {
@@ -93,15 +48,6 @@ export const updateOrderMutation = mutationWithClientMutationId<
       const exchangeInputFields = {
         payment_method: input.paymentMethod,
         credit_card_wallet_type: input.creditCardWalletType,
-        buyer_phone_number: input.buyerPhoneNumber,
-        buyer_phone_number_country_code: input.buyerPhoneNumberCountryCode,
-        shipping_name: input.shippingName,
-        shipping_address_line1: input.shippingAddressLine1,
-        shipping_address_line2: input.shippingAddressLine2,
-        shipping_city: input.shippingCity,
-        shipping_region: input.shippingRegion,
-        shipping_country: input.shippingCountry,
-        shipping_postal_code: input.shippingPostalCode,
       }
       // filter out `undefined` values from the input fields
       const payload = Object.fromEntries(

--- a/src/schema/v2/order/updateOrderMutation.ts
+++ b/src/schema/v2/order/updateOrderMutation.ts
@@ -1,4 +1,4 @@
-import { GraphQLString, GraphQLNonNull, GraphQLID } from "graphql"
+import { GraphQLNonNull, GraphQLID } from "graphql"
 import {
   ORDER_MUTATION_FLAGS,
   OrderMutationResponseType,


### PR DESCRIPTION
This is a followup from https://github.com/artsy/exchange/pull/2550

https://artsyproduct.atlassian.net/browse/EMI-2399
@artsy/emerald-devs 