### PR TITLE
fix: remove discover tab from home view running experiments

### DIFF
--- a/src/schema/v2/homeView/experiments/experiments.ts
+++ b/src/schema/v2/homeView/experiments/experiments.ts
@@ -6,5 +6,4 @@ import { FeatureFlag } from "lib/featureFlags"
  */
 export const CURRENTLY_RUNNING_EXPERIMENTS: FeatureFlag[] = [
   "onyx_experiment_home_view_test",
-  "diamond_discover-tab",
 ]


### PR DESCRIPTION
I'm removing "diamond_discover-tab" from the list of currently running experiments on the Home View because:

1. It is not an experiment that is exclusive to the home view
2. This causes a tracking event to be fired when users visit the home view in the app