### PR TITLE
feat(WIP): add more properties to order.DisplayTexts

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16421,7 +16421,7 @@ type Order {
   # Order code
   code: String!
 
-  # Display texts for the order based on its buyer_state
+  # Display texts for the order based on its buyer_state and order shipping/payment states
   displayTexts: DisplayTexts!
 
   # Buyer fulfillment details for order

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10558,6 +10558,15 @@ type DismissTaskSuccess {
 
 # Display texts for the order based on its state
 type DisplayTexts {
+  # First paragraph of the message text for the order
+  messageText1(format: Format = MARKDOWN): String
+
+  # Second paragraph of the message text for the order
+  messageText2(format: Format = MARKDOWN): String
+
+  # Third paragraph of the message text for the order
+  messageText3(format: Format = MARKDOWN): String
+
   # Title text to display for the order
   titleText: String!
 }

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10559,13 +10559,7 @@ type DismissTaskSuccess {
 # Display texts for the order based on its state
 type DisplayTexts {
   # First paragraph of the message text for the order
-  messageText1(format: Format = MARKDOWN): String
-
-  # Second paragraph of the message text for the order
-  messageText2(format: Format = MARKDOWN): String
-
-  # Third paragraph of the message text for the order
-  messageText3(format: Format = MARKDOWN): String
+  messageText(format: Format = MARKDOWN): String
 
   # Title text to display for the order
   titleText: String!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10556,7 +10556,7 @@ type DismissTaskSuccess {
   task: Task!
 }
 
-# Display texts for the order based on its state
+# Display texts for the order based on its state and order shipping/payment states
 type DisplayTexts {
   # First paragraph of the message text for the order
   messageText(format: Format = MARKDOWN): String

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -18,6 +18,7 @@ describe("Me", () => {
       mode: "buy",
       currency_code: "USD",
       buyer_id: "buyer-id-1",
+      buyer_state: "submitted",
       buyer_type: "user",
       seller_id: "seller-id-1",
       seller_type: "gallery",
@@ -58,6 +59,7 @@ describe("Me", () => {
               code
               displayTexts {
                 titleText
+                messageText1
               }
 
               fulfillmentOptions {
@@ -135,7 +137,9 @@ describe("Me", () => {
       expect(result.me.order).toEqual({
         internalID: "order-id",
         displayTexts: {
-          titleText: "Your order",
+          titleText: "Great choice!",
+          messageText1:
+            "Thank you! Your order is being processed.<br/>You will receive an email shortly with all the details.",
         },
         mode: "BUY",
         source: "ARTWORK_PAGE",

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -59,7 +59,7 @@ describe("Me", () => {
               code
               displayTexts {
                 titleText
-                messageText1
+                messageText
               }
 
               fulfillmentOptions {
@@ -138,7 +138,7 @@ describe("Me", () => {
         internalID: "order-id",
         displayTexts: {
           titleText: "Great choice!",
-          messageText1:
+          messageText:
             "Thank you! Your order is being processed.<br/>You will receive an email shortly with all the details.",
         },
         mode: "BUY",

--- a/src/schema/v2/order/types/DisplayTexts.ts
+++ b/src/schema/v2/order/types/DisplayTexts.ts
@@ -1,0 +1,112 @@
+import {
+  GraphQLFieldConfig,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import type { ResolverContext } from "types/graphql"
+import { OrderJSON } from "./exchangeJson"
+import { formatMarkdownValue } from "../../fields/markdown"
+import { FormatEnums } from "../../input_fields/format"
+
+const DisplayTextsType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DisplayTexts",
+  description:
+    "Display texts for the order based on its state and order shipping/payment states",
+  fields: {
+    titleText: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "Title text to display for the order",
+    },
+    messageText: {
+      type: GraphQLString,
+      description: "First paragraph of the message text for the order",
+      args: {
+        format: {
+          type: FormatEnums,
+          defaultValue: "markdown",
+        },
+      },
+      resolve: ({ messageText }, { format }) => {
+        if (!messageText) return null
+        return formatMarkdownValue(messageText, format)
+      },
+    },
+  },
+})
+
+export const DisplayTexts: GraphQLFieldConfig<OrderJSON, ResolverContext> = {
+  description:
+    "Display texts for the order based on its buyer_state and order shipping/payment states",
+  type: new GraphQLNonNull(DisplayTextsType),
+  resolve: (order) => resolveDisplayTexts(order),
+}
+
+const formatMessage = (parts: string[]) => parts.join("<br/><br/>")
+const resolveDisplayTexts = (order: OrderJSON) => {
+  const isPickup = order.fulfillment_type == "pickup"
+
+  switch (order.buyer_state) {
+    case "submitted":
+      return {
+        titleText: "Great choice!",
+        messageText: formatMessage([
+          "Thank you! Your order is being processed.<br/>You will receive an email shortly with all the details.",
+        ]),
+      }
+    case "payment_failed":
+      return {
+        titleText: "Payment failed",
+        messageText: formatMessage([
+          "To complete your purchase, please update your payment details or provide an alternative payment method.",
+        ]),
+      }
+    case "processing_payment":
+      return {
+        titleText: "Your payment is processing",
+        messageText: formatMessage([
+          `Thank you for your purchase. You will be notified when the work ${
+            isPickup ? "is available for pickup" : "has shipped"
+          }.`,
+        ]),
+      }
+    case "processing_offline_payment":
+      return {
+        titleText: "Congratulations!",
+        messageText: formatMessage([
+          "Your order has been confirmed. Thank you for your purchase.",
+        ]),
+      }
+    case "approved":
+      return {
+        titleText: "Congratulations!",
+        messageText: formatMessage([
+          isPickup
+            ? "Thank you for your purchase. A specialist will contact you within 2 business days to coordinate pickup. You can <a href='#' data-link='contact-gallery'>contact the gallery</a> with any questions about your order."
+            : "Your order has been confirmed. Thank you for your purchase.",
+        ]),
+      }
+    case "shipped":
+      return {
+        titleText: "Good news, your order has shipped!",
+        messageText: formatMessage(["Your work is on its way."]),
+      }
+    case "completed":
+      return {
+        titleText: isPickup
+          ? "Your order has been picked up"
+          : "Your order has been delivered",
+        messageText: formatMessage([
+          "We hope you love your purchase! Your feedback is valuable—share any thoughts with us at orders@artsy.net.",
+        ]),
+      }
+    case "canceled_and_refunded":
+      return {
+        titleText: "Your order was canceled",
+      }
+    default:
+      return {
+        titleText: "Your order",
+      }
+  }
+}

--- a/src/schema/v2/order/types/sharedOrderTypes.ts
+++ b/src/schema/v2/order/types/sharedOrderTypes.ts
@@ -13,12 +13,11 @@ import { InternalIDFields } from "../../object_identification"
 import { Money, resolveMinorAndCurrencyFieldsToMoney } from "../../fields/money"
 import { ArtworkVersionType } from "../../artwork_version"
 import { ArtworkType } from "../../artwork"
+import { DisplayTexts } from "./DisplayTexts"
 import { PartnerType } from "schema/v2/partner/partner"
 import { PhoneNumberType, resolvePhoneNumber } from "../../phoneNumber"
 import { PricingBreakdownLines } from "./PricingBreakdownLines"
 import { OrderJSON } from "./exchangeJson"
-import { formatMarkdownValue } from "../../fields/markdown"
-import { FormatEnums } from "../../input_fields/format"
 
 const OrderModeEnum = new GraphQLEnumType({
   name: "OrderModeEnum",
@@ -236,101 +235,6 @@ const SellerType = new GraphQLUnionType({
   },
 })
 
-const DisplayTextsType = new GraphQLObjectType<any, ResolverContext>({
-  name: "DisplayTexts",
-  description:
-    "Display texts for the order based on its state and order shipping/payment states",
-  fields: {
-    titleText: {
-      type: new GraphQLNonNull(GraphQLString),
-      description: "Title text to display for the order",
-    },
-    messageText: {
-      type: GraphQLString,
-      description: "First paragraph of the message text for the order",
-      args: {
-        format: {
-          type: FormatEnums,
-          defaultValue: "markdown",
-        },
-      },
-      resolve: ({ messageText }, { format }) => {
-        if (!messageText) return null
-        return formatMarkdownValue(messageText, format)
-      },
-    },
-  },
-})
-
-const formatMessage = (parts: string[]) => parts.join("<br/><br/>")
-const resolveDisplayTexts = (order: OrderJSON) => {
-  const isPickup = order.fulfillment_type == "pickup"
-
-  switch (order.buyer_state) {
-    case "submitted":
-      return {
-        titleText: "Great choice!",
-        messageText: formatMessage([
-          "Thank you! Your order is being processed.<br/>You will receive an email shortly with all the details.",
-        ]),
-      }
-    case "payment_failed":
-      return {
-        titleText: "Payment failed",
-        messageText: formatMessage([
-          "To complete your purchase, please update your payment details or provide an alternative payment method.",
-        ]),
-      }
-    case "processing_payment":
-      return {
-        titleText: "Your payment is processing",
-        messageText: formatMessage([
-          `Thank you for your purchase. You will be notified when the work ${
-            isPickup ? "is available for pickup" : "has shipped"
-          }.`,
-        ]),
-      }
-    case "processing_offline_payment":
-      return {
-        titleText: "Congratulations!",
-        messageText: formatMessage([
-          "Your order has been confirmed. Thank you for your purchase.",
-        ]),
-      }
-    case "approved":
-      return {
-        titleText: "Congratulations!",
-        messageText: formatMessage([
-          isPickup
-            ? "Thank you for your purchase. A specialist will contact you within 2 business days to coordinate pickup. You can <a href='#' data-link='contact-gallery'>contact the gallery</a> with any questions about your order."
-            : "Your order has been confirmed. Thank you for your purchase.",
-        ]),
-      }
-    case "shipped":
-      return {
-        titleText: "Good news, your order has shipped!",
-        messageText: formatMessage(["Your work is on its way."]),
-      }
-    case "completed":
-      return {
-        titleText: isPickup
-          ? "Your order has been picked up"
-          : "Your order has been delivered",
-        messageText: formatMessage([
-          "We hope you love your purchase! Your feedback is valuable—share any thoughts with us at orders@artsy.net.",
-        ]),
-      }
-    case "canceled_and_refunded":
-      return {
-        titleText: "Your order was canceled",
-      }
-    default:
-      return {
-        titleText: "Your order",
-      }
-  }
-}
-
 export const OrderType = new GraphQLObjectType<OrderJSON, ResolverContext>({
   name: "Order",
   description: "Buyer's representation of an order",
@@ -376,12 +280,7 @@ export const OrderType = new GraphQLObjectType<OrderJSON, ResolverContext>({
       description: "Order code",
       resolve: ({ code }) => code,
     },
-    displayTexts: {
-      type: new GraphQLNonNull(DisplayTextsType),
-      description:
-        "Display texts for the order based on its buyer_state and order shipping/payment states",
-      resolve: (order) => resolveDisplayTexts(order),
-    },
+    displayTexts: DisplayTexts,
     fulfillmentDetails: {
       type: FulfillmentDetailsType,
       description: "Buyer fulfillment details for order",

--- a/src/schema/v2/order/types/sharedOrderTypes.ts
+++ b/src/schema/v2/order/types/sharedOrderTypes.ts
@@ -17,6 +17,8 @@ import { PartnerType } from "schema/v2/partner/partner"
 import { PhoneNumberType, resolvePhoneNumber } from "../../phoneNumber"
 import { PricingBreakdownLines } from "./PricingBreakdownLines"
 import { OrderJSON } from "./exchangeJson"
+import { formatMarkdownValue } from "../../fields/markdown"
+import { FormatEnums } from "../../input_fields/format"
 
 const OrderModeEnum = new GraphQLEnumType({
   name: "OrderModeEnum",
@@ -236,44 +238,87 @@ const SellerType = new GraphQLUnionType({
 
 const DisplayTextsType = new GraphQLObjectType<any, ResolverContext>({
   name: "DisplayTexts",
-  description: "Display texts for the order based on its state",
+  description:
+    "Display texts for the order based on its state and order shipping/payment states",
   fields: {
     titleText: {
       type: new GraphQLNonNull(GraphQLString),
       description: "Title text to display for the order",
     },
+    messageText: {
+      type: GraphQLString,
+      description: "First paragraph of the message text for the order",
+      args: {
+        format: {
+          type: FormatEnums,
+          defaultValue: "markdown",
+        },
+      },
+      resolve: ({ messageText }, { format }) => {
+        if (!messageText) return null
+        return formatMarkdownValue(messageText, format)
+      },
+    },
   },
 })
 
+const formatMessage = (parts: string[]) => parts.join("<br/><br/>")
 const resolveDisplayTexts = (order: OrderJSON) => {
+  const isPickup = order.fulfillment_type == "pickup"
+
   switch (order.buyer_state) {
     case "submitted":
       return {
         titleText: "Great choice!",
+        messageText: formatMessage([
+          "Thank you! Your order is being processed.<br/>You will receive an email shortly with all the details.",
+        ]),
       }
     case "payment_failed":
       return {
         titleText: "Payment failed",
+        messageText: formatMessage([
+          "To complete your purchase, please update your payment details or provide an alternative payment method.",
+        ]),
       }
     case "processing_payment":
       return {
         titleText: "Your payment is processing",
+        messageText: formatMessage([
+          `Thank you for your purchase. You will be notified when the work ${
+            isPickup ? "is available for pickup" : "has shipped"
+          }.`,
+        ]),
       }
     case "processing_offline_payment":
+      return {
+        titleText: "Congratulations!",
+        messageText: formatMessage([
+          "Your order has been confirmed. Thank you for your purchase.",
+        ]),
+      }
     case "approved":
       return {
         titleText: "Congratulations!",
+        messageText: formatMessage([
+          isPickup
+            ? "Thank you for your purchase. A specialist will contact you within 2 business days to coordinate pickup. You can <a href='#' data-link='contact-gallery'>contact the gallery</a> with any questions about your order."
+            : "Your order has been confirmed. Thank you for your purchase.",
+        ]),
       }
     case "shipped":
       return {
         titleText: "Good news, your order has shipped!",
+        messageText: formatMessage(["Your work is on its way."]),
       }
     case "completed":
       return {
-        titleText:
-          order.fulfillment_type === "pickup"
-            ? "Your order has been picked up"
-            : "Your order has been delivered",
+        titleText: isPickup
+          ? "Your order has been picked up"
+          : "Your order has been delivered",
+        messageText: formatMessage([
+          "We hope you love your purchase! Your feedback is valuable—share any thoughts with us at orders@artsy.net.",
+        ]),
       }
     case "canceled_and_refunded":
       return {
@@ -333,7 +378,8 @@ export const OrderType = new GraphQLObjectType<OrderJSON, ResolverContext>({
     },
     displayTexts: {
       type: new GraphQLNonNull(DisplayTextsType),
-      description: "Display texts for the order based on its buyer_state",
+      description:
+        "Display texts for the order based on its buyer_state and order shipping/payment states",
       resolve: (order) => resolveDisplayTexts(order),
     },
     fulfillmentDetails: {

--- a/src/schema/v2/order/types/sharedOrderTypes.ts
+++ b/src/schema/v2/order/types/sharedOrderTypes.ts
@@ -322,10 +322,6 @@ const resolveDisplayTexts = (order: OrderJSON) => {
       }
     case "canceled_and_refunded":
       return {
-        titleText: "Your order was canceled",
-      }
-    default:
-      return {
         titleText: "Your order",
       }
   }

--- a/src/schema/v2/order/types/sharedOrderTypes.ts
+++ b/src/schema/v2/order/types/sharedOrderTypes.ts
@@ -322,6 +322,10 @@ const resolveDisplayTexts = (order: OrderJSON) => {
       }
     case "canceled_and_refunded":
       return {
+        titleText: "Your order was canceled",
+      }
+    default:
+      return {
         titleText: "Your order",
       }
   }


### PR DESCRIPTION
I was trying to think how to add this additional texts that will be displayed in message for each state and make it shareable between Force and Eigen. Basically we need to cover all states in this table: https://www.figma.com/board/3y8s4tNuSvq69cs4DCb0Mm/Status-Page-Copy-Audit?node-id=64-158&t=MNHfmSmdNhHOcDSZ-4. (there might be some more updates there based on our discussions about arta state). 

Here is my initial proposal.
I tried to go through all the cases and assign them to the appropriate `buyer_state` that we have created previously. And seems like there is some additional sharing between state if we break the whole message into paragraphs. Added those strings into this table: https://docs.google.com/spreadsheets/d/1GOd7UHdyeLOSJTJRppR30ZW2vXq4JwGq_wKE5FFAzAY/edit?gid=346921686#gid=346921686 (G,H,I column).

In this pr I'm adding simple implementation for `messageText1`. The value can be displayed as is I believe with one caveat that the links should be properly implemented. My intention here is that clients can look up links by appropriate `data-link` id and do the transform on the client. Not sure it's the best approach - happy to figure out alternatives. 

For the messageText2 (2nd paragraph) we'll need to get into more details about specific shipping. This will need to wait till https://github.com/artsy/exchange/pull/2558 is resolved. I'll also add a separate issue to define all the rules for available Arta shipping options.

This is def WIP - will need to cover more specs. But wonder if the approach seems reasonable to all: @MrSltun @erikdstock @starsirius @fladson @leamotta ?