### PR TITLE
chore: set partnerLocationId when updating an artwork

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -22295,6 +22295,7 @@ input UpdateArtworkEditionSetInput {
 
   # True for `Make Offer` artworks
   offer: Boolean
+  partnerLocationId: String
   priceCurrency: String
 
   # Show/Hide the price of an artwork
@@ -22365,6 +22366,7 @@ input UpdateArtworkMutationInput {
 
   # True for `Make Offer` artworks
   offer: Boolean
+  partnerLocationId: String
   priceCurrency: String
 
   # Show/Hide the price of an artwork

--- a/src/schema/v2/artwork/updateArtworkMutation.ts
+++ b/src/schema/v2/artwork/updateArtworkMutation.ts
@@ -60,6 +60,7 @@ interface UpdateArtworkMutationInputProps {
   framedWidth?: string
   id?: string
   offer?: boolean
+  partnerLocationId?: string
   published?: boolean
   priceCurrency?: string
   priceHidden?: boolean
@@ -126,6 +127,9 @@ const inputFields = {
   },
   framed: {
     type: GraphQLBoolean,
+  },
+  partnerLocationId: {
+    type: GraphQLString,
   },
   published: {
     type: GraphQLBoolean,
@@ -200,6 +204,7 @@ export const updateArtworkMutation = mutationWithClientMutationId<
         framed: inputArgs.framed,
         id: inputArgs.id,
         offer: inputArgs.offer,
+        partner_location_id: inputArgs.partnerLocationId,
         published: inputArgs.published,
         price_currency: inputArgs.priceCurrency,
         price_hidden: inputArgs.priceHidden,


### PR DESCRIPTION
As part of Artemis -> Relay orders, missed that we sometimes need to update the artwork with a location (when a partner accepts an offer on an artwork w/ incomplete info and sets the location in the same 'step').