### PR TITLE
feat: expose current user's auction segmentation from Vortex

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3954,6 +3954,21 @@ enum AuctionResultsState {
   UPCOMING
 }
 
+# Classification of users based on auction activity
+enum AuctionSegmentationType {
+  # Users with recent auction-related activity
+  ADJACENT
+
+  # Users who have not engaged with auctions recently
+  DISENGAGED
+
+  # Users with a recent auction registration
+  ENGAGED
+
+  # Users with recently created accounts
+  NEW
+}
+
 enum AuctionState {
   CLOSED
   OPEN
@@ -14277,6 +14292,9 @@ type Me implements Node {
     # State of the returned auction results (can be past, upcoming, or all)
     state: AuctionResultsState = ALL
   ): AuctionResultConnection
+
+  # Classification of the user based on their auction-related activity
+  auctionSegmentation: AuctionSegmentationType
   auctionsLotStandingConnection(
     after: String
     before: String

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -14,6 +14,7 @@ const FEATURE_FLAGS_LIST = [
   "emerald_clientside-collector-signals",
   "onyx_enable-home-view-mixer",
   "onyx_enable-quick-links-v2",
+  "onyx_enable-home-view-auction-segmentation",
 ] as const
 
 export type FeatureFlag = typeof FEATURE_FLAGS_LIST[number]

--- a/src/lib/loaders/loaders_with_authentication/vortex.ts
+++ b/src/lib/loaders/loaders_with_authentication/vortex.ts
@@ -98,6 +98,7 @@ export default (accessToken, opts) => {
     auctionLotRecommendationsLoader: vortexLoader(
       "auction_lot_recommendations"
     ),
+    auctionUserSegmentationLoader: vortexLoader("auction_user_segmentation"),
   }
 }
 

--- a/src/schema/v2/homeView/mixer/__tests__/rules/AuctionEngagementRule.test.ts
+++ b/src/schema/v2/homeView/mixer/__tests__/rules/AuctionEngagementRule.test.ts
@@ -5,8 +5,16 @@ import { NewWorksForYou } from "../../../sections/NewWorksForYou"
 import { AuctionLotsForYou } from "../../../sections/AuctionLotsForYou"
 import { Auctions } from "../../../sections/Auctions"
 import { LatestAuctionResults } from "../../../sections/LatestAuctionResults"
+import { isFeatureFlagEnabled } from "lib/featureFlags"
+
+const mockIsFeatureFlagEnabled = isFeatureFlagEnabled as jest.Mock
 
 describe("AuctionEngagementRule", () => {
+  beforeEach(() => {
+    mockIsFeatureFlagEnabled.mockImplementation((flag: string) => {
+      if (flag === "onyx_enable-home-view-auction-segmentation") return true
+    })
+  })
   it("moves auction sections after NewWorksForYou for engaged users", async () => {
     const mockContext: Partial<ResolverContext> = {
       userID: "123",

--- a/src/schema/v2/homeView/mixer/__tests__/rules/AuctionEngagementRule.test.ts
+++ b/src/schema/v2/homeView/mixer/__tests__/rules/AuctionEngagementRule.test.ts
@@ -1,0 +1,237 @@
+import { HomeViewSection } from "schema/v2/homeView/sections"
+import { AuctionEngagementRule } from "../../rules/AuctionEngagementRule"
+import { ResolverContext } from "types/graphql"
+import { NewWorksForYou } from "../../../sections/NewWorksForYou"
+import { AuctionLotsForYou } from "../../../sections/AuctionLotsForYou"
+import { Auctions } from "../../../sections/Auctions"
+import { LatestAuctionResults } from "../../../sections/LatestAuctionResults"
+
+describe("AuctionEngagementRule", () => {
+  it("moves auction sections after NewWorksForYou for engaged users", async () => {
+    const mockContext: Partial<ResolverContext> = {
+      userID: "123",
+      auctionUserSegmentationLoader: jest.fn().mockResolvedValue({
+        data: [
+          {
+            user_id: "123",
+            auction_segmentation: "engaged",
+          },
+        ],
+      }),
+    }
+
+    const inputSections: Partial<HomeViewSection>[] = [
+      { id: "quick-links-section" },
+      { id: "tasks-section" },
+      NewWorksForYou,
+      { id: "some-section" },
+      Auctions,
+      { id: "another-section" },
+      AuctionLotsForYou,
+      { id: "yet-another-section" },
+      LatestAuctionResults,
+    ]
+
+    const auctionEngagementRule = new AuctionEngagementRule()
+
+    const outputSections = await auctionEngagementRule.apply(
+      inputSections as HomeViewSection[],
+      mockContext as ResolverContext
+    )
+
+    // Expect auction-related sections to be moved right after NewWorksForYou
+    expect(outputSections).toEqual([
+      { id: "quick-links-section" },
+      { id: "tasks-section" },
+      NewWorksForYou,
+      Auctions,
+      AuctionLotsForYou,
+      LatestAuctionResults,
+      { id: "some-section" },
+      { id: "another-section" },
+      { id: "yet-another-section" },
+    ])
+    expect(outputSections.length).toEqual(inputSections.length)
+  })
+
+  it("moves auction sections after NewWorksForYou for adjacent users", async () => {
+    const mockContext: Partial<ResolverContext> = {
+      userID: "123",
+      auctionUserSegmentationLoader: jest.fn().mockResolvedValue({
+        data: [
+          {
+            user_id: "123",
+            auction_segmentation: "adjacent",
+          },
+        ],
+      }),
+    }
+
+    const inputSections: Partial<HomeViewSection>[] = [
+      { id: "quick-links-section" },
+      { id: "tasks-section" },
+      NewWorksForYou,
+      { id: "some-section" },
+      Auctions,
+      { id: "another-section" },
+      AuctionLotsForYou,
+      { id: "yet-another-section" },
+      LatestAuctionResults,
+    ]
+
+    const auctionEngagementRule = new AuctionEngagementRule()
+
+    const outputSections = await auctionEngagementRule.apply(
+      inputSections as HomeViewSection[],
+      mockContext as ResolverContext
+    )
+
+    // Expect auction-related sections to be moved right after NewWorksForYou
+    expect(outputSections).toEqual([
+      { id: "quick-links-section" },
+      { id: "tasks-section" },
+      NewWorksForYou,
+      Auctions,
+      AuctionLotsForYou,
+      LatestAuctionResults,
+      { id: "some-section" },
+      { id: "another-section" },
+      { id: "yet-another-section" },
+    ])
+    expect(outputSections.length).toEqual(inputSections.length)
+  })
+
+  it("leaves sections unchanged for disengaged users", async () => {
+    const mockContext: Partial<ResolverContext> = {
+      userID: "123",
+      auctionUserSegmentationLoader: jest.fn().mockResolvedValue({
+        data: [
+          {
+            user_id: "123",
+            auction_segmentation: "disengaged",
+          },
+        ],
+      }),
+    }
+
+    const inputSections: Partial<HomeViewSection>[] = [
+      { id: "quick-links-section" },
+      { id: "tasks-section" },
+      NewWorksForYou,
+      { id: "some-section" },
+      Auctions,
+      { id: "another-section" },
+      AuctionLotsForYou,
+      { id: "yet-another-section" },
+      LatestAuctionResults,
+    ]
+
+    const auctionEngagementRule = new AuctionEngagementRule()
+
+    const outputSections = await auctionEngagementRule.apply(
+      inputSections as HomeViewSection[],
+      mockContext as ResolverContext
+    )
+
+    // Expect sections to remain in original order
+    expect(outputSections).toEqual(inputSections)
+  })
+
+  it("leaves sections unchanged for new users", async () => {
+    const mockContext: Partial<ResolverContext> = {
+      userID: "123",
+      auctionUserSegmentationLoader: jest.fn().mockResolvedValue({
+        data: [
+          {
+            user_id: "123",
+            auction_segmentation: "new",
+          },
+        ],
+      }),
+    }
+
+    const inputSections: Partial<HomeViewSection>[] = [
+      { id: "quick-links-section" },
+      { id: "tasks-section" },
+      NewWorksForYou,
+      { id: "some-section" },
+      Auctions,
+      { id: "another-section" },
+      AuctionLotsForYou,
+      { id: "yet-another-section" },
+      LatestAuctionResults,
+    ]
+
+    const auctionEngagementRule = new AuctionEngagementRule()
+
+    const outputSections = await auctionEngagementRule.apply(
+      inputSections as HomeViewSection[],
+      mockContext as ResolverContext
+    )
+
+    // Expect sections to remain in original order
+    expect(outputSections).toEqual(inputSections)
+  })
+
+  it("leaves sections unchanged when segmentation data is missing", async () => {
+    const mockContext: Partial<ResolverContext> = {
+      userID: "123",
+      auctionUserSegmentationLoader: jest.fn().mockResolvedValue({
+        data: [], // Empty data
+      }),
+    }
+
+    const inputSections: Partial<HomeViewSection>[] = [
+      { id: "quick-links-section" },
+      { id: "tasks-section" },
+      NewWorksForYou,
+      { id: "some-section" },
+      Auctions,
+      { id: "another-section" },
+      AuctionLotsForYou,
+      { id: "yet-another-section" },
+      LatestAuctionResults,
+    ]
+
+    const auctionEngagementRule = new AuctionEngagementRule()
+
+    const outputSections = await auctionEngagementRule.apply(
+      inputSections as HomeViewSection[],
+      mockContext as ResolverContext
+    )
+
+    // Expect sections to remain in original order
+    expect(outputSections).toEqual(inputSections)
+  })
+
+  it("handles errors gracefully", async () => {
+    const mockContext: Partial<ResolverContext> = {
+      userID: "123",
+      auctionUserSegmentationLoader: jest
+        .fn()
+        .mockRejectedValue(new Error("Test error")),
+    }
+
+    const inputSections: Partial<HomeViewSection>[] = [
+      { id: "quick-links-section" },
+      { id: "tasks-section" },
+      NewWorksForYou,
+      { id: "some-section" },
+      Auctions,
+      { id: "another-section" },
+      AuctionLotsForYou,
+      { id: "yet-another-section" },
+      LatestAuctionResults,
+    ]
+
+    const auctionEngagementRule = new AuctionEngagementRule()
+
+    const outputSections = await auctionEngagementRule.apply(
+      inputSections as HomeViewSection[],
+      mockContext as ResolverContext
+    )
+
+    // Expect sections to remain in original order
+    expect(outputSections).toEqual(inputSections)
+  })
+})

--- a/src/schema/v2/homeView/mixer/rules/AuctionEngagementRule.ts
+++ b/src/schema/v2/homeView/mixer/rules/AuctionEngagementRule.ts
@@ -1,0 +1,55 @@
+import { HomeViewSection } from "schema/v2/homeView/sections"
+import { ResolverContext } from "types/graphql"
+import { HomeViewMixerRule } from "../HomeViewMixerRule"
+import { NewWorksForYou } from "../../sections/NewWorksForYou"
+import { AuctionLotsForYou } from "../../sections/AuctionLotsForYou"
+import { Auctions } from "../../sections/Auctions"
+import { LatestAuctionResults } from "../../sections/LatestAuctionResults"
+import { compact } from "lodash"
+
+/**
+ * Rule that moves auction-related sections near the top for eligible users
+ * based on their auction segmentation.
+ *
+ * See: https://www.notion.so/artsy/19fcab0764a080229129edbd6efa7dce
+ */
+export class AuctionEngagementRule extends HomeViewMixerRule {
+  async apply(
+    sections: HomeViewSection[],
+    context: ResolverContext
+  ): Promise<HomeViewSection[]> {
+    const segment = await getUserAuctionSegmentation(context)
+
+    // for eligible user segments
+    if (segment === "adjacent" || segment === "engaged") {
+      // find the auction-related sections
+      const auctionRelatedSections = [
+        Auctions,
+        AuctionLotsForYou,
+        LatestAuctionResults,
+      ]
+      // and remove them
+      const sectionsToMove = auctionRelatedSections.map((section) => {
+        const index = sections.findIndex((s) => s.id === section.id)
+        if (index !== -1) {
+          const [removed] = sections.splice(index, 1)
+          return removed
+        }
+      })
+      // then re-insert them right after NewWorksForYou
+      const newWorksForYouIndex = sections.findIndex(
+        (section) => section.id === NewWorksForYou.id
+      )
+      sections.splice(newWorksForYouIndex + 1, 0, ...compact(sectionsToMove))
+    }
+
+    return sections
+  }
+}
+
+function getUserAuctionSegmentation(context: ResolverContext) {
+  return context
+    .auctionUserSegmentationLoader?.()
+    .then((response) => response?.data?.[0]?.auction_segmentation)
+    .catch(() => null)
+}

--- a/src/schema/v2/homeView/zones/__tests__/default.test.ts
+++ b/src/schema/v2/homeView/zones/__tests__/default.test.ts
@@ -112,4 +112,163 @@ describe("getSections", () => {
       })
     })
   })
+
+  describe("Auction segmentation", () => {
+    describe("when the feature flag is enabled", () => {
+      beforeEach(() => {
+        mockIsFeatureFlagEnabled.mockImplementation((flag: string) => {
+          if (flag === "onyx_enable-home-view-mixer") return true
+          if (flag === "onyx_enable-home-view-auction-segmentation") return true
+          return false
+        })
+      })
+
+      describe("for eligible user segments", () => {
+        let context: Partial<ResolverContext>
+
+        beforeEach(() => {
+          context = {
+            accessToken: "some-token",
+            auctionUserSegmentationLoader: jest.fn().mockResolvedValue({
+              data: [{ auction_segmentation: "engaged" }],
+            }),
+          }
+        })
+        it("reorders the sections", async () => {
+          const sections = await getSections(context as ResolverContext)
+          const sectionIds = sections.map((section) => section.id)
+
+          expect(sectionIds).toMatchInlineSnapshot(`
+                      [
+                        "home-view-section-quick-links",
+                        "home-view-section-tasks",
+                        "home-view-section-latest-activity",
+                        "home-view-section-new-works-for-you",
+                        "home-view-section-auctions",
+                        "home-view-section-auction-lots-for-you",
+                        "home-view-section-latest-auction-results",
+                        "home-view-section-recently-viewed-artworks",
+                        "home-view-section-infinite-discovery",
+                        "home-view-section-discover-something-new",
+                        "home-view-section-recommended-artworks",
+                        "home-view-section-curators-picks-emerging",
+                        "home-view-section-explore-by-category",
+                        "home-view-section-hero-units",
+                        "home-view-section-galleries-near-you",
+                        "home-view-section-latest-articles",
+                        "home-view-section-news",
+                        "home-view-section-new-works-from-galleries-you-follow",
+                        "home-view-section-recommended-artists",
+                        "home-view-section-trending-artists",
+                        "home-view-section-similar-to-recently-viewed-artworks",
+                        "home-view-section-viewing-rooms",
+                        "home-view-section-shows-for-you",
+                      ]
+                  `)
+        })
+      })
+
+      describe("for ineligible user segments", () => {
+        let context: Partial<ResolverContext>
+
+        beforeEach(() => {
+          context = {
+            accessToken: "some-token",
+            auctionUserSegmentationLoader: jest.fn().mockResolvedValue({
+              data: [{ auction_segmentation: "disengaged" }],
+            }),
+          }
+        })
+        it("does not reorder the sections", async () => {
+          const sections = await getSections(context as ResolverContext)
+          const sectionIds = sections.map((section) => section.id)
+
+          expect(sectionIds).toMatchInlineSnapshot(`
+            [
+              "home-view-section-quick-links",
+              "home-view-section-tasks",
+              "home-view-section-latest-activity",
+              "home-view-section-new-works-for-you",
+              "home-view-section-recently-viewed-artworks",
+              "home-view-section-infinite-discovery",
+              "home-view-section-discover-something-new",
+              "home-view-section-recommended-artworks",
+              "home-view-section-curators-picks-emerging",
+              "home-view-section-explore-by-category",
+              "home-view-section-hero-units",
+              "home-view-section-auction-lots-for-you",
+              "home-view-section-auctions",
+              "home-view-section-latest-auction-results",
+              "home-view-section-galleries-near-you",
+              "home-view-section-latest-articles",
+              "home-view-section-news",
+              "home-view-section-new-works-from-galleries-you-follow",
+              "home-view-section-recommended-artists",
+              "home-view-section-trending-artists",
+              "home-view-section-similar-to-recently-viewed-artworks",
+              "home-view-section-viewing-rooms",
+              "home-view-section-shows-for-you",
+            ]
+          `)
+        })
+      })
+    })
+
+    describe("when the feature flag is not enabled", () => {
+      beforeEach(() => {
+        mockIsFeatureFlagEnabled.mockImplementation((flag: string) => {
+          if (flag === "onyx_enable-home-view-mixer") return true
+          if (flag === "onyx_enable-home-view-auction-segmentation")
+            return false
+          return false
+        })
+      })
+
+      describe("for eligible user segments", () => {
+        let context: Partial<ResolverContext>
+
+        beforeEach(() => {
+          context = {
+            accessToken: "some-token",
+            auctionUserSegmentationLoader: jest.fn().mockResolvedValue({
+              data: [{ auction_segmentation: "engaged" }],
+            }),
+          }
+        })
+
+        it("does not reorder the sections", async () => {
+          const sections = await getSections(context as ResolverContext)
+          const sectionIds = sections.map((section) => section.id)
+
+          expect(sectionIds).toMatchInlineSnapshot(`
+            [
+              "home-view-section-quick-links",
+              "home-view-section-tasks",
+              "home-view-section-latest-activity",
+              "home-view-section-new-works-for-you",
+              "home-view-section-recently-viewed-artworks",
+              "home-view-section-infinite-discovery",
+              "home-view-section-discover-something-new",
+              "home-view-section-recommended-artworks",
+              "home-view-section-curators-picks-emerging",
+              "home-view-section-explore-by-category",
+              "home-view-section-hero-units",
+              "home-view-section-auction-lots-for-you",
+              "home-view-section-auctions",
+              "home-view-section-latest-auction-results",
+              "home-view-section-galleries-near-you",
+              "home-view-section-latest-articles",
+              "home-view-section-news",
+              "home-view-section-new-works-from-galleries-you-follow",
+              "home-view-section-recommended-artists",
+              "home-view-section-trending-artists",
+              "home-view-section-similar-to-recently-viewed-artworks",
+              "home-view-section-viewing-rooms",
+              "home-view-section-shows-for-you",
+            ]
+          `)
+        })
+      })
+    })
+  })
 })

--- a/src/schema/v2/homeView/zones/default.ts
+++ b/src/schema/v2/homeView/zones/default.ts
@@ -29,6 +29,7 @@ import { QuickLinks } from "../sections/QuickLinks"
 import { BoostHeroUnitsForNewUsersRule } from "../mixer/rules/BoostHeroUnitsForNewUsersRule"
 import { isSectionDisplayable } from "../helpers/isSectionDisplayable"
 import { isFeatureFlagEnabled } from "lib/featureFlags"
+import { AuctionEngagementRule } from "../mixer/rules/AuctionEngagementRule"
 
 const SECTIONS: HomeViewSection[] = [
   QuickLinks,
@@ -74,6 +75,7 @@ async function getSectionsViaMixer(context: ResolverContext) {
   const mixer = new HomeViewMixer([
     new DisplayableRule(),
     new BoostHeroUnitsForNewUsersRule(),
+    new AuctionEngagementRule(),
   ])
 
   return await mixer.mix(SECTIONS, context)

--- a/src/schema/v2/me/__tests__/auctionSegmentation.test.ts
+++ b/src/schema/v2/me/__tests__/auctionSegmentation.test.ts
@@ -1,0 +1,67 @@
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("me.auctionSegmentation", () => {
+  describe("when the data is present in Vortex", () => {
+    it("returns the user's auction segmentation from Vortex", async () => {
+      const query = gql`
+        {
+          me {
+            auctionSegmentation
+          }
+        }
+      `
+
+      const auctionUserSegmentationLoader = jest.fn().mockResolvedValue({
+        data: [
+          {
+            user_id: "abc123",
+            auction_segmentation: "adjacent",
+          },
+        ],
+      })
+
+      const context = {
+        meLoader: jest.fn().mockResolvedValue({}),
+        auctionUserSegmentationLoader,
+      }
+
+      const response = await runAuthenticatedQuery(query, context)
+
+      expect(response).toEqual({
+        me: {
+          auctionSegmentation: "ADJACENT",
+        },
+      })
+    })
+  })
+
+  describe("when the data is not present in Vortex", () => {
+    it("returns null", async () => {
+      const query = gql`
+        {
+          me {
+            auctionSegmentation
+          }
+        }
+      `
+
+      const auctionUserSegmentationLoader = jest.fn().mockResolvedValue({
+        data: [],
+      })
+
+      const context = {
+        meLoader: jest.fn().mockResolvedValue({}),
+        auctionUserSegmentationLoader,
+      }
+
+      const response = await runAuthenticatedQuery(query, context)
+
+      expect(response).toEqual({
+        me: {
+          auctionSegmentation: null,
+        },
+      })
+    })
+  })
+})

--- a/src/schema/v2/me/auctionSegmentation.ts
+++ b/src/schema/v2/me/auctionSegmentation.ts
@@ -1,0 +1,36 @@
+import { GraphQLFieldConfig, GraphQLEnumType } from "graphql"
+import { ResolverContext } from "types/graphql"
+
+export const AuctionSegmentationType = new GraphQLEnumType({
+  name: "AuctionSegmentationType",
+  description: "Classification of users based on auction activity",
+  values: {
+    NEW: {
+      value: "new",
+      description: "Users with recently created accounts",
+    },
+    ADJACENT: {
+      value: "adjacent",
+      description: "Users with recent auction-related activity",
+    },
+    ENGAGED: {
+      value: "engaged",
+      description: "Users with a recent auction registration",
+    },
+    DISENGAGED: {
+      value: "disengaged",
+      description: "Users who have not engaged with auctions recently",
+    },
+  },
+})
+
+export const AuctionSegmentation: GraphQLFieldConfig<void, ResolverContext> = {
+  type: AuctionSegmentationType,
+  description:
+    "Classification of the user based on their auction-related activity",
+  resolve: async (_parent, _args, context, _info) => {
+    const { auctionUserSegmentationLoader } = context
+    const vortexResponse = await auctionUserSegmentationLoader?.()
+    return vortexResponse?.data?.[0]?.auction_segmentation
+  },
+}

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -98,6 +98,7 @@ import {
 } from "./secondFactors/secondFactors"
 import { MeOrder } from "../order"
 import { ConfirmationToken } from "../order/confirmationToken"
+import { AuctionSegmentation } from "./auctionSegmentation"
 
 /**
  * @deprecated: Please use the CollectorProfile type instead of adding fields to me directly.
@@ -208,6 +209,7 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
     artworkRecommendations: ArtworkRecommendations,
     artworkInquiriesConnection: ArtworkInquiries,
     auctionResultsByFollowedArtists: AuctionResultsByFollowedArtists,
+    auctionSegmentation: AuctionSegmentation,
     authentications: authentications,
     bankAccounts: BankAccounts,
     bidders: Bidders,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-1719

> [!NOTE]
> Now also contains the stacked changes from #6732 

Takes the user auction segmentation that newly resides in Vortex, and exposes it in MP on the `me` object.

The value is an enum, based on the [upstream classification](https://github.com/artsy/fulcrum/blob/main/dbt/models/analytics/content_personalization_models/auction_user_segmentation.sql#L2)

(This is mostly done as a convenience, on the way to using this segmentation in the home view mixer, in a separate PR).

### Request

```graphql
{
  me {
    email
    auctionSegmentation
  }
}
```

### Response

```json
{
  "data": {
    "me": {
      "email": "somebody@example.com",
      "auctionSegmentation": "ENGAGED"
    }
  }
}
```