### PR TITLE
feat: add auction engagment rule to home view mixer

### DIFF
--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -14,6 +14,7 @@ const FEATURE_FLAGS_LIST = [
   "emerald_clientside-collector-signals",
   "onyx_enable-home-view-mixer",
   "onyx_enable-quick-links-v2",
+  "onyx_enable-home-view-auction-segmentation",
 ] as const
 
 export type FeatureFlag = typeof FEATURE_FLAGS_LIST[number]

--- a/src/schema/v2/homeView/mixer/__tests__/rules/AuctionEngagementRule.test.ts
+++ b/src/schema/v2/homeView/mixer/__tests__/rules/AuctionEngagementRule.test.ts
@@ -5,8 +5,16 @@ import { NewWorksForYou } from "../../../sections/NewWorksForYou"
 import { AuctionLotsForYou } from "../../../sections/AuctionLotsForYou"
 import { Auctions } from "../../../sections/Auctions"
 import { LatestAuctionResults } from "../../../sections/LatestAuctionResults"
+import { isFeatureFlagEnabled } from "lib/featureFlags"
+
+const mockIsFeatureFlagEnabled = isFeatureFlagEnabled as jest.Mock
 
 describe("AuctionEngagementRule", () => {
+  beforeEach(() => {
+    mockIsFeatureFlagEnabled.mockImplementation((flag: string) => {
+      if (flag === "onyx_enable-home-view-auction-segmentation") return true
+    })
+  })
   it("moves auction sections after NewWorksForYou for engaged users", async () => {
     const mockContext: Partial<ResolverContext> = {
       userID: "123",

--- a/src/schema/v2/homeView/mixer/__tests__/rules/AuctionEngagementRule.test.ts
+++ b/src/schema/v2/homeView/mixer/__tests__/rules/AuctionEngagementRule.test.ts
@@ -1,0 +1,237 @@
+import { HomeViewSection } from "schema/v2/homeView/sections"
+import { AuctionEngagementRule } from "../../rules/AuctionEngagementRule"
+import { ResolverContext } from "types/graphql"
+import { NewWorksForYou } from "../../../sections/NewWorksForYou"
+import { AuctionLotsForYou } from "../../../sections/AuctionLotsForYou"
+import { Auctions } from "../../../sections/Auctions"
+import { LatestAuctionResults } from "../../../sections/LatestAuctionResults"
+
+describe("AuctionEngagementRule", () => {
+  it("moves auction sections after NewWorksForYou for engaged users", async () => {
+    const mockContext: Partial<ResolverContext> = {
+      userID: "123",
+      auctionUserSegmentationLoader: jest.fn().mockResolvedValue({
+        data: [
+          {
+            user_id: "123",
+            auction_segmentation: "engaged",
+          },
+        ],
+      }),
+    }
+
+    const inputSections: Partial<HomeViewSection>[] = [
+      { id: "quick-links-section" },
+      { id: "tasks-section" },
+      NewWorksForYou,
+      { id: "some-section" },
+      Auctions,
+      { id: "another-section" },
+      AuctionLotsForYou,
+      { id: "yet-another-section" },
+      LatestAuctionResults,
+    ]
+
+    const auctionEngagementRule = new AuctionEngagementRule()
+
+    const outputSections = await auctionEngagementRule.apply(
+      inputSections as HomeViewSection[],
+      mockContext as ResolverContext
+    )
+
+    // Expect auction-related sections to be moved right after NewWorksForYou
+    expect(outputSections).toEqual([
+      { id: "quick-links-section" },
+      { id: "tasks-section" },
+      NewWorksForYou,
+      Auctions,
+      AuctionLotsForYou,
+      LatestAuctionResults,
+      { id: "some-section" },
+      { id: "another-section" },
+      { id: "yet-another-section" },
+    ])
+    expect(outputSections.length).toEqual(inputSections.length)
+  })
+
+  it("moves auction sections after NewWorksForYou for adjacent users", async () => {
+    const mockContext: Partial<ResolverContext> = {
+      userID: "123",
+      auctionUserSegmentationLoader: jest.fn().mockResolvedValue({
+        data: [
+          {
+            user_id: "123",
+            auction_segmentation: "adjacent",
+          },
+        ],
+      }),
+    }
+
+    const inputSections: Partial<HomeViewSection>[] = [
+      { id: "quick-links-section" },
+      { id: "tasks-section" },
+      NewWorksForYou,
+      { id: "some-section" },
+      Auctions,
+      { id: "another-section" },
+      AuctionLotsForYou,
+      { id: "yet-another-section" },
+      LatestAuctionResults,
+    ]
+
+    const auctionEngagementRule = new AuctionEngagementRule()
+
+    const outputSections = await auctionEngagementRule.apply(
+      inputSections as HomeViewSection[],
+      mockContext as ResolverContext
+    )
+
+    // Expect auction-related sections to be moved right after NewWorksForYou
+    expect(outputSections).toEqual([
+      { id: "quick-links-section" },
+      { id: "tasks-section" },
+      NewWorksForYou,
+      Auctions,
+      AuctionLotsForYou,
+      LatestAuctionResults,
+      { id: "some-section" },
+      { id: "another-section" },
+      { id: "yet-another-section" },
+    ])
+    expect(outputSections.length).toEqual(inputSections.length)
+  })
+
+  it("leaves sections unchanged for disengaged users", async () => {
+    const mockContext: Partial<ResolverContext> = {
+      userID: "123",
+      auctionUserSegmentationLoader: jest.fn().mockResolvedValue({
+        data: [
+          {
+            user_id: "123",
+            auction_segmentation: "disengaged",
+          },
+        ],
+      }),
+    }
+
+    const inputSections: Partial<HomeViewSection>[] = [
+      { id: "quick-links-section" },
+      { id: "tasks-section" },
+      NewWorksForYou,
+      { id: "some-section" },
+      Auctions,
+      { id: "another-section" },
+      AuctionLotsForYou,
+      { id: "yet-another-section" },
+      LatestAuctionResults,
+    ]
+
+    const auctionEngagementRule = new AuctionEngagementRule()
+
+    const outputSections = await auctionEngagementRule.apply(
+      inputSections as HomeViewSection[],
+      mockContext as ResolverContext
+    )
+
+    // Expect sections to remain in original order
+    expect(outputSections).toEqual(inputSections)
+  })
+
+  it("leaves sections unchanged for new users", async () => {
+    const mockContext: Partial<ResolverContext> = {
+      userID: "123",
+      auctionUserSegmentationLoader: jest.fn().mockResolvedValue({
+        data: [
+          {
+            user_id: "123",
+            auction_segmentation: "new",
+          },
+        ],
+      }),
+    }
+
+    const inputSections: Partial<HomeViewSection>[] = [
+      { id: "quick-links-section" },
+      { id: "tasks-section" },
+      NewWorksForYou,
+      { id: "some-section" },
+      Auctions,
+      { id: "another-section" },
+      AuctionLotsForYou,
+      { id: "yet-another-section" },
+      LatestAuctionResults,
+    ]
+
+    const auctionEngagementRule = new AuctionEngagementRule()
+
+    const outputSections = await auctionEngagementRule.apply(
+      inputSections as HomeViewSection[],
+      mockContext as ResolverContext
+    )
+
+    // Expect sections to remain in original order
+    expect(outputSections).toEqual(inputSections)
+  })
+
+  it("leaves sections unchanged when segmentation data is missing", async () => {
+    const mockContext: Partial<ResolverContext> = {
+      userID: "123",
+      auctionUserSegmentationLoader: jest.fn().mockResolvedValue({
+        data: [], // Empty data
+      }),
+    }
+
+    const inputSections: Partial<HomeViewSection>[] = [
+      { id: "quick-links-section" },
+      { id: "tasks-section" },
+      NewWorksForYou,
+      { id: "some-section" },
+      Auctions,
+      { id: "another-section" },
+      AuctionLotsForYou,
+      { id: "yet-another-section" },
+      LatestAuctionResults,
+    ]
+
+    const auctionEngagementRule = new AuctionEngagementRule()
+
+    const outputSections = await auctionEngagementRule.apply(
+      inputSections as HomeViewSection[],
+      mockContext as ResolverContext
+    )
+
+    // Expect sections to remain in original order
+    expect(outputSections).toEqual(inputSections)
+  })
+
+  it("handles errors gracefully", async () => {
+    const mockContext: Partial<ResolverContext> = {
+      userID: "123",
+      auctionUserSegmentationLoader: jest
+        .fn()
+        .mockRejectedValue(new Error("Test error")),
+    }
+
+    const inputSections: Partial<HomeViewSection>[] = [
+      { id: "quick-links-section" },
+      { id: "tasks-section" },
+      NewWorksForYou,
+      { id: "some-section" },
+      Auctions,
+      { id: "another-section" },
+      AuctionLotsForYou,
+      { id: "yet-another-section" },
+      LatestAuctionResults,
+    ]
+
+    const auctionEngagementRule = new AuctionEngagementRule()
+
+    const outputSections = await auctionEngagementRule.apply(
+      inputSections as HomeViewSection[],
+      mockContext as ResolverContext
+    )
+
+    // Expect sections to remain in original order
+    expect(outputSections).toEqual(inputSections)
+  })
+})

--- a/src/schema/v2/homeView/mixer/rules/AuctionEngagementRule.ts
+++ b/src/schema/v2/homeView/mixer/rules/AuctionEngagementRule.ts
@@ -1,0 +1,55 @@
+import { HomeViewSection } from "schema/v2/homeView/sections"
+import { ResolverContext } from "types/graphql"
+import { HomeViewMixerRule } from "../HomeViewMixerRule"
+import { NewWorksForYou } from "../../sections/NewWorksForYou"
+import { AuctionLotsForYou } from "../../sections/AuctionLotsForYou"
+import { Auctions } from "../../sections/Auctions"
+import { LatestAuctionResults } from "../../sections/LatestAuctionResults"
+import { compact } from "lodash"
+
+/**
+ * Rule that moves auction-related sections near the top for eligible users
+ * based on their auction segmentation.
+ *
+ * See: https://www.notion.so/artsy/19fcab0764a080229129edbd6efa7dce
+ */
+export class AuctionEngagementRule extends HomeViewMixerRule {
+  async apply(
+    sections: HomeViewSection[],
+    context: ResolverContext
+  ): Promise<HomeViewSection[]> {
+    const segment = await getUserAuctionSegmentation(context)
+
+    // for eligible user segments
+    if (segment === "adjacent" || segment === "engaged") {
+      // find the auction-related sections
+      const auctionRelatedSections = [
+        Auctions,
+        AuctionLotsForYou,
+        LatestAuctionResults,
+      ]
+      // and remove them
+      const sectionsToMove = auctionRelatedSections.map((section) => {
+        const index = sections.findIndex((s) => s.id === section.id)
+        if (index !== -1) {
+          const [removed] = sections.splice(index, 1)
+          return removed
+        }
+      })
+      // then re-insert them right after NewWorksForYou
+      const newWorksForYouIndex = sections.findIndex(
+        (section) => section.id === NewWorksForYou.id
+      )
+      sections.splice(newWorksForYouIndex + 1, 0, ...compact(sectionsToMove))
+    }
+
+    return sections
+  }
+}
+
+function getUserAuctionSegmentation(context: ResolverContext) {
+  return context
+    .auctionUserSegmentationLoader?.()
+    .then((response) => response?.data?.[0]?.auction_segmentation)
+    .catch(() => null)
+}

--- a/src/schema/v2/homeView/zones/__tests__/default.test.ts
+++ b/src/schema/v2/homeView/zones/__tests__/default.test.ts
@@ -112,4 +112,163 @@ describe("getSections", () => {
       })
     })
   })
+
+  describe("Auction segmentation", () => {
+    describe("when the feature flag is enabled", () => {
+      beforeEach(() => {
+        mockIsFeatureFlagEnabled.mockImplementation((flag: string) => {
+          if (flag === "onyx_enable-home-view-mixer") return true
+          if (flag === "onyx_enable-home-view-auction-segmentation") return true
+          return false
+        })
+      })
+
+      describe("for eligible user segments", () => {
+        let context: Partial<ResolverContext>
+
+        beforeEach(() => {
+          context = {
+            accessToken: "some-token",
+            auctionUserSegmentationLoader: jest.fn().mockResolvedValue({
+              data: [{ auction_segmentation: "engaged" }],
+            }),
+          }
+        })
+        it("reorders the sections", async () => {
+          const sections = await getSections(context as ResolverContext)
+          const sectionIds = sections.map((section) => section.id)
+
+          expect(sectionIds).toMatchInlineSnapshot(`
+                      [
+                        "home-view-section-quick-links",
+                        "home-view-section-tasks",
+                        "home-view-section-latest-activity",
+                        "home-view-section-new-works-for-you",
+                        "home-view-section-auctions",
+                        "home-view-section-auction-lots-for-you",
+                        "home-view-section-latest-auction-results",
+                        "home-view-section-recently-viewed-artworks",
+                        "home-view-section-infinite-discovery",
+                        "home-view-section-discover-something-new",
+                        "home-view-section-recommended-artworks",
+                        "home-view-section-curators-picks-emerging",
+                        "home-view-section-explore-by-category",
+                        "home-view-section-hero-units",
+                        "home-view-section-galleries-near-you",
+                        "home-view-section-latest-articles",
+                        "home-view-section-news",
+                        "home-view-section-new-works-from-galleries-you-follow",
+                        "home-view-section-recommended-artists",
+                        "home-view-section-trending-artists",
+                        "home-view-section-similar-to-recently-viewed-artworks",
+                        "home-view-section-viewing-rooms",
+                        "home-view-section-shows-for-you",
+                      ]
+                  `)
+        })
+      })
+
+      describe("for ineligible user segments", () => {
+        let context: Partial<ResolverContext>
+
+        beforeEach(() => {
+          context = {
+            accessToken: "some-token",
+            auctionUserSegmentationLoader: jest.fn().mockResolvedValue({
+              data: [{ auction_segmentation: "disengaged" }],
+            }),
+          }
+        })
+        it("does not reorder the sections", async () => {
+          const sections = await getSections(context as ResolverContext)
+          const sectionIds = sections.map((section) => section.id)
+
+          expect(sectionIds).toMatchInlineSnapshot(`
+            [
+              "home-view-section-quick-links",
+              "home-view-section-tasks",
+              "home-view-section-latest-activity",
+              "home-view-section-new-works-for-you",
+              "home-view-section-recently-viewed-artworks",
+              "home-view-section-infinite-discovery",
+              "home-view-section-discover-something-new",
+              "home-view-section-recommended-artworks",
+              "home-view-section-curators-picks-emerging",
+              "home-view-section-explore-by-category",
+              "home-view-section-hero-units",
+              "home-view-section-auction-lots-for-you",
+              "home-view-section-auctions",
+              "home-view-section-latest-auction-results",
+              "home-view-section-galleries-near-you",
+              "home-view-section-latest-articles",
+              "home-view-section-news",
+              "home-view-section-new-works-from-galleries-you-follow",
+              "home-view-section-recommended-artists",
+              "home-view-section-trending-artists",
+              "home-view-section-similar-to-recently-viewed-artworks",
+              "home-view-section-viewing-rooms",
+              "home-view-section-shows-for-you",
+            ]
+          `)
+        })
+      })
+    })
+
+    describe("when the feature flag is not enabled", () => {
+      beforeEach(() => {
+        mockIsFeatureFlagEnabled.mockImplementation((flag: string) => {
+          if (flag === "onyx_enable-home-view-mixer") return true
+          if (flag === "onyx_enable-home-view-auction-segmentation")
+            return false
+          return false
+        })
+      })
+
+      describe("for eligible user segments", () => {
+        let context: Partial<ResolverContext>
+
+        beforeEach(() => {
+          context = {
+            accessToken: "some-token",
+            auctionUserSegmentationLoader: jest.fn().mockResolvedValue({
+              data: [{ auction_segmentation: "engaged" }],
+            }),
+          }
+        })
+
+        it("does not reorder the sections", async () => {
+          const sections = await getSections(context as ResolverContext)
+          const sectionIds = sections.map((section) => section.id)
+
+          expect(sectionIds).toMatchInlineSnapshot(`
+            [
+              "home-view-section-quick-links",
+              "home-view-section-tasks",
+              "home-view-section-latest-activity",
+              "home-view-section-new-works-for-you",
+              "home-view-section-recently-viewed-artworks",
+              "home-view-section-infinite-discovery",
+              "home-view-section-discover-something-new",
+              "home-view-section-recommended-artworks",
+              "home-view-section-curators-picks-emerging",
+              "home-view-section-explore-by-category",
+              "home-view-section-hero-units",
+              "home-view-section-auction-lots-for-you",
+              "home-view-section-auctions",
+              "home-view-section-latest-auction-results",
+              "home-view-section-galleries-near-you",
+              "home-view-section-latest-articles",
+              "home-view-section-news",
+              "home-view-section-new-works-from-galleries-you-follow",
+              "home-view-section-recommended-artists",
+              "home-view-section-trending-artists",
+              "home-view-section-similar-to-recently-viewed-artworks",
+              "home-view-section-viewing-rooms",
+              "home-view-section-shows-for-you",
+            ]
+          `)
+        })
+      })
+    })
+  })
 })

--- a/src/schema/v2/homeView/zones/default.ts
+++ b/src/schema/v2/homeView/zones/default.ts
@@ -29,6 +29,7 @@ import { QuickLinks } from "../sections/QuickLinks"
 import { BoostHeroUnitsForNewUsersRule } from "../mixer/rules/BoostHeroUnitsForNewUsersRule"
 import { isSectionDisplayable } from "../helpers/isSectionDisplayable"
 import { isFeatureFlagEnabled } from "lib/featureFlags"
+import { AuctionEngagementRule } from "../mixer/rules/AuctionEngagementRule"
 
 const SECTIONS: HomeViewSection[] = [
   QuickLinks,
@@ -74,6 +75,7 @@ async function getSectionsViaMixer(context: ResolverContext) {
   const mixer = new HomeViewMixer([
     new DisplayableRule(),
     new BoostHeroUnitsForNewUsersRule(),
+    new AuctionEngagementRule(),
   ])
 
   return await mixer.mix(SECTIONS, context)


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-1702 (and stacked on #6731)

This incorporates the new user auction segmentation into the [personalization logic](https://www.figma.com/design/3LYkzfvfTPcYAIgzkaOM1C/Personalization?node-id=39-8054&m=dev) for ordering the home view.

It does so by adding a new `AuctionEngagementRule` to the [recently introduced](https://github.com/artsy/metaphysics/pull/6677) `HomeViewMixer` 

This has the effect of taking three auction-related sections — Auctions; Auction Lots for You; Latest Auction Results — and hoisting them up near the top for eligible user segments: auction-`engaged` or auction-`adjacent` users. 

For all others this rule leaves the sections untouched.

### Request 

```graphql
{
  homeView {
    sectionsConnection(first: 30) {
      edges {
        node {
          internalID
        }
      }
    }
  }
}
```

### Response

`engaged` and `adjacent` users will see the following difference…

```json
{
  "data": {
    "homeView": {
      "sectionsConnection": {
        "edges": [
          { "node": { "internalID": "home-view-section-quick-links" }},
          { "node": { "internalID": "home-view-section-tasks" }},
          { "node": { "internalID": "home-view-section-latest-activity" }},
          { "node": { "internalID": "home-view-section-new-works-for-you" }},
       ⏫ { "node": { "internalID": "home-view-section-auctions" }},
       ⏫ { "node": { "internalID": "home-view-section-auction-lots-for-you" }},
       ⏫ { "node": { "internalID": "home-view-section-latest-auction-results" }},
          { "node": { "internalID": "home-view-section-recently-viewed-artworks" }},
          { "node": { "internalID": "home-view-section-infinite-discovery" }},
          { "node": { "internalID": "home-view-section-discover-something-new" }},
          { "node": { "internalID": "home-view-section-recommended-artworks" }},
          { "node": { "internalID": "home-view-section-curators-picks-emerging" }},
          { "node": { "internalID": "home-view-section-explore-by-category" }},
          { "node": { "internalID": "home-view-section-hero-units" }},
          { "node": { "internalID": "home-view-section-galleries-near-you" }},
          { "node": { "internalID": "home-view-section-latest-articles" }},
          { "node": { "internalID": "home-view-section-news" }},
          { "node": { "internalID": "home-view-section-new-works-from-galleries-you-follow" }},
          { "node": { "internalID": "home-view-section-recommended-artists" }},
          { "node": { "internalID": "home-view-section-trending-artists" }},
          { "node": { "internalID": "home-view-section-similar-to-recently-viewed-artworks" }},
          { "node": { "internalID": "home-view-section-viewing-rooms" }},
          { "node": { "internalID": "home-view-section-shows-for-you" }},
          { "node": { "internalID": "home-view-section-featured-fairs" }
           }
        ]
      }
    }
  }
}
```

> [!IMPORTANT]
> See [update](https://github.com/artsy/metaphysics/pull/6732#issuecomment-2877191025)
 ~I haven't put this behind a feature flag, so merging this will put the new logic into effect. I may hold off on that until some client-side visual changes are merged into Eigen first. Or I can put this behind a flag if we prefer.~ 
