### PR TITLE
chore: add a schema/structure to rawData of an artwork import row

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3258,8 +3258,8 @@ type ArtworkImportRow {
   # A type-specific ID likely used as a database ID.
   internalID: ID!
   priceListed: Money
-  rawData: JSON!
-  transformedData: ArtworkImportTransformedData!
+  rawData: ArtworkImportRowData!
+  transformedData: ArtworkImportRowData!
 }
 
 # A connection to a list of items.
@@ -3271,6 +3271,22 @@ type ArtworkImportRowConnection {
   # Information to aid in pagination.
   pageInfo: PageInfo!
   totalCount: Int
+}
+
+type ArtworkImportRowData {
+  artistNames: String
+  artworkTitle: String
+  certificateOfAuthenticity: String
+  date: String
+  depth: String
+  diameter: String
+  height: String
+  imageFileNames: String
+  inventoryId: String
+  materials: String
+  medium: String
+  price: String
+  width: String
 }
 
 # An edge in a connection.
@@ -3315,22 +3331,6 @@ enum ArtworkImportState {
   ARTWORKS_CREATION_COMPLETE
   CANCELED
   PENDING
-}
-
-type ArtworkImportTransformedData {
-  artistNames: String
-  artworkTitle: String
-  certificateOfAuthenticity: String
-  date: String
-  depth: String
-  diameter: String
-  height: String
-  imageFileNames: String
-  inventoryId: String
-  materials: String
-  medium: String
-  price: String
-  width: String
 }
 
 type ArtworkInfoRow {

--- a/src/schema/v2/ArtworkImport/__tests__/artworkImport.test.ts
+++ b/src/schema/v2/ArtworkImport/__tests__/artworkImport.test.ts
@@ -33,12 +33,13 @@ describe("ArtworkImport", () => {
     const artworkImportLoader = jest.fn().mockReturnValue({
       id: "artwork-import-1",
       file_name: "import.csv",
+      raw_data_mapping: { ArtistNames: "artist" },
     })
 
     const artworkImportRowsLoader = jest.fn().mockResolvedValue({
       body: [
-        { id: "row1", raw_data: { foo: "bar" } },
-        { id: "row2", raw_data: { foo: "baz" } },
+        { id: "row1", raw_data: { artist: "bar" } },
+        { id: "row2", raw_data: { artist: "baz" } },
       ],
       headers: { "x-total-count": "2" },
     })
@@ -53,7 +54,9 @@ describe("ArtworkImport", () => {
             edges {
               node {
                 internalID
-                rawData
+                rawData {
+                  artistNames
+                }
               }
             }
           }
@@ -77,11 +80,11 @@ describe("ArtworkImport", () => {
     expect(result.artworkImport.rowsConnection.edges).toHaveLength(2)
     expect(result.artworkImport.rowsConnection.edges[0].node).toEqual({
       internalID: "row1",
-      rawData: { foo: "bar" },
+      rawData: { artistNames: "bar" },
     })
     expect(result.artworkImport.rowsConnection.edges[1].node).toEqual({
       internalID: "row2",
-      rawData: { foo: "baz" },
+      rawData: { artistNames: "baz" },
     })
   })
 

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -97,6 +97,51 @@ const ArtworkImportRowImageType = new GraphQLObjectType({
   },
 })
 
+const ArtworkImportRowDataType = new GraphQLObjectType({
+  name: "ArtworkImportRowData",
+  fields: {
+    artistNames: {
+      type: GraphQLString,
+    },
+    artworkTitle: {
+      type: GraphQLString,
+    },
+    date: {
+      type: GraphQLString,
+    },
+    depth: {
+      type: GraphQLString,
+    },
+    diameter: {
+      type: GraphQLString,
+    },
+    height: {
+      type: GraphQLString,
+    },
+    imageFileNames: {
+      type: GraphQLString,
+    },
+    inventoryId: {
+      type: GraphQLString,
+    },
+    materials: {
+      type: GraphQLString,
+    },
+    price: {
+      type: GraphQLString,
+    },
+    width: {
+      type: GraphQLString,
+    },
+    medium: {
+      type: GraphQLString,
+    },
+    certificateOfAuthenticity: {
+      type: GraphQLString,
+    },
+  },
+})
+
 const ArtworkImportRowType = new GraphQLObjectType({
   name: "ArtworkImportRow",
   fields: {
@@ -131,71 +176,45 @@ const ArtworkImportRowType = new GraphQLObjectType({
       },
     },
     rawData: {
-      type: new GraphQLNonNull(GraphQLJSON),
-      resolve: ({ raw_data }) => raw_data,
+      type: new GraphQLNonNull(ArtworkImportRowDataType),
+      resolve: ({ raw_data, rawDataMapping }) => {
+        return {
+          artistNames: raw_data[rawDataMapping["ArtistNames"]],
+          artworkTitle: raw_data[rawDataMapping["ArtworkTitle"]],
+          date: raw_data[rawDataMapping["Date"]],
+          depth: raw_data[rawDataMapping["Depth"]],
+          diameter: raw_data[rawDataMapping["Diameter"]],
+          height: raw_data[rawDataMapping["Height"]],
+          imageFileNames: raw_data[rawDataMapping["ImageFileNames"]],
+          inventoryId: raw_data[rawDataMapping["Inventory ID"]],
+          materials: raw_data[rawDataMapping["Materials"]],
+          price: raw_data[rawDataMapping["Price"]],
+          width: raw_data[rawDataMapping["Width"]],
+          medium: raw_data[rawDataMapping["Medium"]],
+          certificateOfAuthenticity:
+            raw_data[rawDataMapping["CertificateOfAuthenticity"]],
+        }
+      },
     },
     transformedData: {
-      type: new GraphQLNonNull(
-        new GraphQLObjectType<any, ResolverContext>({
-          name: "ArtworkImportTransformedData",
-          fields: {
-            artistNames: {
-              type: GraphQLString,
-              resolve: ({ ArtistNames }) => ArtistNames,
-            },
-            artworkTitle: {
-              type: GraphQLString,
-              resolve: ({ ArtworkTitle }) => ArtworkTitle,
-            },
-            date: {
-              type: GraphQLString,
-              resolve: ({ Date }) => Date,
-            },
-            depth: {
-              type: GraphQLString,
-              resolve: ({ Depth }) => Depth,
-            },
-            diameter: {
-              type: GraphQLString,
-              resolve: ({ Diameter }) => Diameter,
-            },
-            height: {
-              type: GraphQLString,
-              resolve: ({ Height }) => Height,
-            },
-            imageFileNames: {
-              type: GraphQLString,
-              resolve: ({ ImageFileNames }) => ImageFileNames,
-            },
-            inventoryId: {
-              type: GraphQLString,
-              resolve: (data) => data["Inventory ID"],
-            },
-            materials: {
-              type: GraphQLString,
-              resolve: ({ Materials }) => Materials,
-            },
-            price: {
-              type: GraphQLString,
-              resolve: ({ Price }) => Price,
-            },
-            width: {
-              type: GraphQLString,
-              resolve: ({ Width }) => Width,
-            },
-            medium: {
-              type: GraphQLString,
-              resolve: ({ Medium }) => Medium,
-            },
-            certificateOfAuthenticity: {
-              type: GraphQLString,
-              resolve: ({ CertificateOfAuthenticity }) =>
-                CertificateOfAuthenticity,
-            },
-          },
-        })
-      ),
-      resolve: ({ transformed_data }) => transformed_data,
+      type: new GraphQLNonNull(ArtworkImportRowDataType),
+      resolve: ({ transformed_data }) => {
+        return {
+          artistNames: transformed_data.ArtistNames,
+          artworkTitle: transformed_data.ArtworkTitle,
+          date: transformed_data.Date,
+          depth: transformed_data.Depth,
+          diameter: transformed_data.Diameter,
+          height: transformed_data.Height,
+          imageFileNames: transformed_data.ImageFileNames,
+          inventoryId: transformed_data["Inventory ID"],
+          materials: transformed_data.Materials,
+          price: transformed_data.Price,
+          width: transformed_data.Width,
+          medium: transformed_data.Medium,
+          certificateOfAuthenticity: transformed_data.CertificateOfAuthenticity,
+        }
+      },
     },
     errors: {
       type: new GraphQLNonNull(
@@ -280,7 +299,11 @@ export const ArtworkImportType = new GraphQLObjectType<any, ResolverContext>({
           type: GraphQLBoolean,
         },
       }),
-      resolve: async ({ id, currency }, args, { artworkImportRowsLoader }) => {
+      resolve: async (
+        { id, currency, raw_data_mapping },
+        args,
+        { artworkImportRowsLoader }
+      ) => {
         if (!artworkImportRowsLoader) {
           throw new Error(
             "A X-Access-Token header is required to perform this action."
@@ -309,6 +332,7 @@ export const ArtworkImportType = new GraphQLObjectType<any, ResolverContext>({
           body: body.map((row) => ({
             ...row,
             currency,
+            rawDataMapping: raw_data_mapping,
           })),
           args,
         })


### PR DESCRIPTION
This adds the same schema/structure to `rawData` as we had for `transformedData`.

It seems as though there might be a need/divergence of wanting to store certain normalized data differently than the way we'd want to display it in the UI (where we might want to display the user's original value).