### PR TITLE
feat: update fields on displayTexts for the order

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10575,10 +10575,10 @@ type DismissTaskSuccess {
 # Display texts for the order based on its state and order shipping/payment states
 type DisplayTexts {
   # First paragraph of the message text for the order
-  messageText(format: Format = MARKDOWN): String
+  message(format: Format = MARKDOWN): String
 
   # Title text to display for the order
-  titleText: String!
+  title: String!
 }
 
 type DoNotUseThisPartner {

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -58,8 +58,8 @@ describe("Me", () => {
               }
               code
               displayTexts {
-                titleText
-                messageText
+                title
+                message
               }
 
               fulfillmentOptions {
@@ -137,9 +137,9 @@ describe("Me", () => {
       expect(result.me.order).toEqual({
         internalID: "order-id",
         displayTexts: {
-          titleText: "Great choice!",
-          messageText:
-            "Thank you! Your order is being processed.<br/>You will receive an email shortly with all the details.",
+          title: "Great choice!",
+          message:
+            "Thank you! Your order is being processed.<br/>You will receive an email shortly with all the details.<br/><br/>You can <a href='#' data-link='contact-gallery'>contact the gallery</a> with any questions about your order.",
         },
         mode: "BUY",
         source: "ARTWORK_PAGE",

--- a/src/schema/v2/order/types/DisplayTexts.ts
+++ b/src/schema/v2/order/types/DisplayTexts.ts
@@ -8,17 +8,18 @@ import type { ResolverContext } from "types/graphql"
 import { OrderJSON } from "./exchangeJson"
 import { formatMarkdownValue } from "../../fields/markdown"
 import { FormatEnums } from "../../input_fields/format"
+import moment from "moment-timezone"
 
 const DisplayTextsType = new GraphQLObjectType<any, ResolverContext>({
   name: "DisplayTexts",
   description:
     "Display texts for the order based on its state and order shipping/payment states",
   fields: {
-    titleText: {
+    title: {
       type: new GraphQLNonNull(GraphQLString),
       description: "Title text to display for the order",
     },
-    messageText: {
+    message: {
       type: GraphQLString,
       description: "First paragraph of the message text for the order",
       args: {
@@ -27,9 +28,9 @@ const DisplayTextsType = new GraphQLObjectType<any, ResolverContext>({
           defaultValue: "markdown",
         },
       },
-      resolve: ({ messageText }, { format }) => {
-        if (!messageText) return null
-        return formatMarkdownValue(messageText, format)
+      resolve: ({ message }, { format }) => {
+        if (!message) return null
+        return formatMarkdownValue(message, format)
       },
     },
   },
@@ -42,29 +43,50 @@ export const DisplayTexts: GraphQLFieldConfig<OrderJSON, ResolverContext> = {
   resolve: (order) => resolveDisplayTexts(order),
 }
 
-const formatMessage = (parts: string[]) => parts.join("<br/><br/>")
+const formatMessage = (parts: string[], joinWith = "<br/><br/>") =>
+  parts.join(joinWith)
+
 const resolveDisplayTexts = (order: OrderJSON) => {
   const isPickup = order.fulfillment_type == "pickup"
+  const stateExpireTime =
+    order.buyer_state_expires_at && moment.tz(order.buyer_state_expires_at)
+  const formattedStateExpireTime =
+    stateExpireTime &&
+    `${stateExpireTime.format("MMM D")}, ${stateExpireTime.format("h:mma z")}`
 
   switch (order.buyer_state) {
-    case "submitted":
+    case "submitted": {
+      const messageParts = [
+        "Thank you! Your order is being processed.<br/>You will receive an email shortly with all the details.",
+      ]
+
+      const secondBlockParts: string[] = []
+      formattedStateExpireTime &&
+        secondBlockParts.push(
+          `The gallery will confirm by ${formattedStateExpireTime}.`
+        )
+      secondBlockParts.push(
+        "You can <a href='#' data-link='contact-gallery'>contact the gallery</a> with any questions about your order."
+      )
+
+      messageParts.push(formatMessage(secondBlockParts, "<br/>"))
+
       return {
-        titleText: "Great choice!",
-        messageText: formatMessage([
-          "Thank you! Your order is being processed.<br/>You will receive an email shortly with all the details.",
-        ]),
+        title: "Great choice!",
+        message: formatMessage(messageParts),
       }
+    }
     case "payment_failed":
       return {
-        titleText: "Payment failed",
-        messageText: formatMessage([
-          "To complete your purchase, please update your payment details or provide an alternative payment method.",
+        title: "Payment failed",
+        message: formatMessage([
+          `To complete your purchase, please <a href='#' data-link='update-payment'>update your payment details</a> or provide an alternative payment method by ${formattedStateExpireTime}`,
         ]),
       }
     case "processing_payment":
       return {
-        titleText: "Your payment is processing",
-        messageText: formatMessage([
+        title: "Your payment is processing",
+        message: formatMessage([
           `Thank you for your purchase. You will be notified when the work ${
             isPickup ? "is available for pickup" : "has shipped"
           }.`,
@@ -72,41 +94,72 @@ const resolveDisplayTexts = (order: OrderJSON) => {
       }
     case "processing_offline_payment":
       return {
-        titleText: "Congratulations!",
-        messageText: formatMessage([
+        title: "Congratulations!",
+        message: formatMessage([
           "Your order has been confirmed. Thank you for your purchase.",
+          "<b>Please proceed with the wire transfer within 7 days to complete your purchase</b><br/><ol><li>Find the total amount due and Artsy's banking details below.</li><li>Please inform your bank that you are responsible for all wire transfer fees.</li><li>Please make the transfer in the currency displayed on the order breakdown and then email proof of payment to orders@artsy.net.</li></ul>",
         ]),
       }
-    case "approved":
+    case "approved": {
+      const messageParts = [
+        isPickup
+          ? "Thank you for your purchase. A specialist will contact you within 2 business days to coordinate pickup. You can <a href='#' data-link='contact-gallery'>contact the gallery</a> with any questions about your order."
+          : "Your order has been confirmed. Thank you for your purchase.",
+      ]
+
+      if (order.selected_fulfillment_option == "artsy_express")
+        messageParts.push(
+          "Your order will be processed and packaged, and you will be notified once it ships.<br/>Once shipped, your order will be delivered in 2 business days."
+        )
+      else if (order.selected_fulfillment_option == "artsy_standard")
+        messageParts.push(
+          "Your order will be processed and packaged, and you will be notified once it ships.<br/>Once shipped, your order will be delivered in 3-5 business days."
+        )
+      else if (order.selected_fulfillment_option == "artsy_white_glove")
+        messageParts.push(
+          "Once shipped, you will receive a notification and further details.<br/>You can contact <a href='#' data-link='contact-orders'>orders@artsy.net</a> with any questions."
+        )
+      else
+        messageParts.push(
+          "You will be notified when the work has shipped, typically within 5-7 business days.<br/>You can <a href='#' data-link='contact-gallery'>contact the gallery</a> with any questions about your order."
+        )
+
       return {
-        titleText: "Congratulations!",
-        messageText: formatMessage([
-          isPickup
-            ? "Thank you for your purchase. A specialist will contact you within 2 business days to coordinate pickup. You can <a href='#' data-link='contact-gallery'>contact the gallery</a> with any questions about your order."
-            : "Your order has been confirmed. Thank you for your purchase.",
-        ]),
+        title: "Congratulations!",
+        message: formatMessage(messageParts),
       }
-    case "shipped":
+    }
+    case "shipped": {
+      const messageParts = ["Your work is on its way."]
+      // TODO: add shipping info when present
+      messageParts.push(
+        "This artwork will be added to your Collection on Artsy. You can view and manage all your artworks on the Artsy app, available in the <a href='#' data-link='apple-store'>Apple App Store</a> and <a href='#' data-link='google-store'>Google Play Store.</a>"
+      )
+
       return {
-        titleText: "Good news, your order has shipped!",
-        messageText: formatMessage(["Your work is on its way."]),
+        title: "Good news, your order has shipped!",
+        message: formatMessage(messageParts),
       }
+    }
     case "completed":
       return {
-        titleText: isPickup
+        title: isPickup
           ? "Your order has been picked up"
           : "Your order has been delivered",
-        messageText: formatMessage([
-          "We hope you love your purchase! Your feedback is valuable—share any thoughts with us at orders@artsy.net.",
+        message: formatMessage([
+          "We hope you love your purchase! Your feedback is valuable—share any thoughts with us at <a href='#' data-link='contact-orders'>orders@artsy.net.</a>",
+          "This artwork will be added to your Collection on Artsy. You can view and manage all your artworks on the Artsy app, available in the <a href='#' data-link='apple-store'>Apple App Store</a> and <a href='#' data-link='google-store'>Google Play Store.</a>",
         ]),
       }
     case "canceled_and_refunded":
       return {
-        titleText: "Your order was canceled",
+        title: "Your order was canceled",
+        message:
+          "You can contact <a href='#' data-link='contact-orders'>orders@artsy.net</a> with any questions.",
       }
     default:
       return {
-        titleText: "Your order",
+        titlet: "Your order",
       }
   }
 }

--- a/src/schema/v2/order/types/exchangeJson.ts
+++ b/src/schema/v2/order/types/exchangeJson.ts
@@ -27,6 +27,7 @@ export interface OrderJSON {
   shipping_country?: string
   tax_total_cents?: number
   buyer_state?: string
+  buyer_state_expires_at?: string
   fulfillment_type?: string
   fulfillment_options: Array<{
     type:
@@ -40,6 +41,14 @@ export interface OrderJSON {
     amount_minor: number
     selected?: boolean
   }>
+  selected_fulfillment_option?:
+    | "domestic_flat"
+    | "international_flat"
+    | "pickup"
+    | "artsy_standard"
+    | "artsy_express"
+    | "artsy_white_glove"
+    | "shipping_tbd"
   line_items: Array<{
     id: string
     artwork_id: string


### PR DESCRIPTION
This will be used for display for https://artsyproduct.atlassian.net/browse/EMI-2436

Currently only has one happy pass test here. We need to figure out more comprehensive strategy for testing here. Created placeholder story for testing part: https://artsyproduct.atlassian.net/jira/software/c/projects/EMI/boards/114

@starsirius - also changed the field names to drop the `test` part per your suggestion. It's a breaking change for Force page but as it's behind feature flag - don't think is a big issue. Will update force as soon as this is merged.