### PR TITLE
fix(EMI-2442): Update Me Order argument type to ID

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14601,7 +14601,7 @@ type Me implements Node {
     # The ID of the Notification
     id: String!
   ): Notification
-  order(id: String!): Order
+  order(id: ID!): Order
   orders(
     after: String
     before: String

--- a/src/schema/v2/order/MeOrder.ts
+++ b/src/schema/v2/order/MeOrder.ts
@@ -1,11 +1,11 @@
-import { GraphQLFieldConfig, GraphQLNonNull, GraphQLString } from "graphql"
+import { GraphQLFieldConfig, GraphQLNonNull, GraphQLID } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { OrderType } from "schema/v2/order/types/sharedOrderTypes"
 
 export const MeOrder: GraphQLFieldConfig<void, ResolverContext> = {
   args: {
     id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNull(GraphQLID),
     },
   },
   type: OrderType,


### PR DESCRIPTION
This PR resolves [EMI-2442]

> [!Warning]
> This change is breaking, and we need to coordinate its release with Force (PR artsy/force#15574)

### Description
This PR updates the type of `me.order` argument from `String!` to `ID!`





[EMI-2442]: https://artsyproduct.atlassian.net/browse/EMI-2442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ