### PR TITLE
feat: add messageType as an alternative to displayMessage

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10589,11 +10589,33 @@ type DismissTaskSuccess {
 
 # Display texts for the order based on its state and order shipping/payment states
 type DisplayTexts {
-  # First paragraph of the message text for the order
+  # Fomatted full message text for the order
   message(format: Format = MARKDOWN): String
 
-  # Title text to display for the order
+  # Granular order states specific type that should be directly interpreted by clients
+  messageType: DisplayTextsMessageTypeEnum!
+
+  # Text to display as a first message on the page (header)
   title: String!
+}
+
+enum DisplayTextsMessageTypeEnum {
+  APPROVED_PICKUP
+  APPROVED_SHIP
+  APPROVED_SHIP_EXPRESS
+  APPROVED_SHIP_STANDARD
+  APPROVED_SHIP_WHITE_GLOVE
+  CANCELLED_ORDER
+  COMPLETED_PICKUP
+  COMPLETED_SHIP
+  PAYMENT_FAILED
+  PROCESSING_PAYMENT_PICKUP
+  PROCESSING_PAYMENT_SHIP
+  PROCESSING_WIRE
+  SHIPPED
+  SUBMITTED_OFFER
+  SUBMITTED_ORDER
+  UNKNOWN
 }
 
 type DoNotUseThisPartner {
@@ -16445,6 +16467,9 @@ type Order {
   # Phone number of the buyer
   buyerPhoneNumber: String
     @deprecated(reason: "Use `order.fulfillmentDetails.phoneNumber`")
+
+  # Expiration for the current state of the order
+  buyerStateExpiresAt: String
 
   # The total amount the buyer is expected to pay
   buyerTotal: Money

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -18,7 +18,8 @@ describe("Me", () => {
       mode: "buy",
       currency_code: "USD",
       buyer_id: "buyer-id-1",
-      buyer_state: "submitted",
+      buyer_state: "approved",
+      buyer_state_expires_at: "January 1, 2035 19:00 EST",
       buyer_type: "user",
       seller_id: "seller-id-1",
       seller_type: "gallery",
@@ -27,6 +28,7 @@ describe("Me", () => {
       shipping_total_cents: 2000,
       buyer_phone_number: "123-456-7890",
       buyer_phone_number_country_code: "US",
+      fulfillment_type: "ship",
       shipping_name: "John Doe",
       shipping_country: "US",
       shipping_postal_code: "10001",
@@ -56,10 +58,12 @@ describe("Me", () => {
               buyerTotal {
                 display
               }
+              buyerStateExpiresAt
               code
               displayTexts {
                 title
                 message
+                messageType
               }
 
               fulfillmentOptions {
@@ -136,10 +140,12 @@ describe("Me", () => {
 
       expect(result.me.order).toEqual({
         internalID: "order-id",
+        buyerStateExpiresAt: "January 1, 2035 19:00 EST",
         displayTexts: {
-          title: "Great choice!",
+          title: "Congratulations!",
           message:
-            "Thank you! Your order is being processed.<br/>You will receive an email shortly with all the details.<br/><br/>You can <a href='#' data-link='contact-gallery'>contact the gallery</a> with any questions about your order.",
+            "Your order has been confirmed. Thank you for your purchase.<br/><br/>You will be notified when the work has shipped, typically within 5-7 business days.<br/>You can <a href='#' data-link='contact-gallery'>contact the gallery</a> with any questions about your order.",
+          messageType: "APPROVED_SHIP",
         },
         mode: "BUY",
         source: "ARTWORK_PAGE",

--- a/src/schema/v2/order/types/sharedOrderTypes.ts
+++ b/src/schema/v2/order/types/sharedOrderTypes.ts
@@ -275,6 +275,11 @@ export const OrderType = new GraphQLObjectType<OrderJSON, ResolverContext>({
         )
       },
     },
+    buyerStateExpiresAt: {
+      type: GraphQLString,
+      description: "Expiration for the current state of the order",
+      resolve: ({ buyer_state_expires_at }) => buyer_state_expires_at,
+    },
     code: {
       type: new GraphQLNonNull(GraphQLString),
       description: "Order code",


### PR DESCRIPTION
Discussed with @MrSltun that it might be really hard (next to impossible) to share html between Force and Eigen. So we might need to repeat texts for the message part as html elements integrated there. 

However we still want to keep the logic of what message is applicable based on all the 'mode', 'payment', 'shipment' etc combinations and create a very specific type just for this messageDisplay.
