### PR TITLE
feat: adds "Art Under $X" quick pill for users with price preferences

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14631,6 +14631,9 @@ type Me implements Node {
   pendingIdentityVerification: IdentityVerification
   phone: String
   phoneNumber: PhoneNumberType
+
+  # User's price preference, in USD.
+  pricePreference: Float
   priceRange: String
   priceRangeMax: Float
   priceRangeMin: Float

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -15,6 +15,7 @@ const FEATURE_FLAGS_LIST = [
   "onyx_enable-home-view-mixer",
   "onyx_enable-quick-links-v2",
   "onyx_enable-home-view-auction-segmentation",
+  "onyx_enable-quick-links-price-budget",
 ] as const
 
 export type FeatureFlag = typeof FEATURE_FLAGS_LIST[number]

--- a/src/lib/loaders/loaders_with_authentication/vortex.ts
+++ b/src/lib/loaders/loaders_with_authentication/vortex.ts
@@ -99,6 +99,7 @@ export default (accessToken, opts) => {
       "auction_lot_recommendations"
     ),
     auctionUserSegmentationLoader: vortexLoader("auction_user_segmentation"),
+    userPricePreferenceLoader: vortexLoader("user_price_preference"),
   }
 }
 

--- a/src/schema/v2/homeView/helpers/__tests__/priceBucketBasedOnPricePreference.test.ts
+++ b/src/schema/v2/homeView/helpers/__tests__/priceBucketBasedOnPricePreference.test.ts
@@ -1,0 +1,183 @@
+import { priceBucketBasedOnPricePreference } from "../priceBucketBasedOnPricePreference"
+
+describe("priceBucketBasedOnPricePreference", () => {
+  it("returns the 0-500 bucket for minimum value (0)", () => {
+    expect(priceBucketBasedOnPricePreference(0)).toEqual({
+      priceRange: "0-500",
+      min: 0,
+      max: 500,
+      text: "Art Under $500",
+    })
+  })
+
+  it("returns the 0-500 bucket for a value within the range", () => {
+    expect(priceBucketBasedOnPricePreference(250)).toEqual({
+      priceRange: "0-500",
+      min: 0,
+      max: 500,
+      text: "Art Under $500",
+    })
+  })
+
+  it("returns the 0-500 bucket for the maximum value of the range (500)", () => {
+    expect(priceBucketBasedOnPricePreference(500)).toEqual({
+      priceRange: "0-500",
+      min: 0,
+      max: 500,
+      text: "Art Under $500",
+    })
+  })
+
+  it("returns the 501-1000 bucket for the minimum value of the range (501)", () => {
+    expect(priceBucketBasedOnPricePreference(501)).toEqual({
+      priceRange: "501-1000",
+      min: 501,
+      max: 1000,
+      text: "Art Under $1000",
+    })
+  })
+
+  it("returns the 501-1000 bucket for a value within the range", () => {
+    expect(priceBucketBasedOnPricePreference(750)).toEqual({
+      priceRange: "501-1000",
+      min: 501,
+      max: 1000,
+      text: "Art Under $1000",
+    })
+  })
+
+  it("returns the 501-1000 bucket for the maximum value of the range (1000)", () => {
+    expect(priceBucketBasedOnPricePreference(1000)).toEqual({
+      priceRange: "501-1000",
+      min: 501,
+      max: 1000,
+      text: "Art Under $1000",
+    })
+  })
+
+  it("returns the 1001-2500 bucket for the minimum value of the range (1001)", () => {
+    expect(priceBucketBasedOnPricePreference(1001)).toEqual({
+      priceRange: "1001-2500",
+      min: 1001,
+      max: 2500,
+      text: "Art Under $2500",
+    })
+  })
+
+  it("returns the 1001-2500 bucket for a value within the range", () => {
+    expect(priceBucketBasedOnPricePreference(2000)).toEqual({
+      priceRange: "1001-2500",
+      min: 1001,
+      max: 2500,
+      text: "Art Under $2500",
+    })
+  })
+
+  it("returns the 1001-2500 bucket for the maximum value of the range (2500)", () => {
+    expect(priceBucketBasedOnPricePreference(2500)).toEqual({
+      priceRange: "1001-2500",
+      min: 1001,
+      max: 2500,
+      text: "Art Under $2500",
+    })
+  })
+
+  it("returns the 2501-5000 bucket for the minimum value of the range (2501)", () => {
+    expect(priceBucketBasedOnPricePreference(2501)).toEqual({
+      priceRange: "2501-5000",
+      min: 2501,
+      max: 5000,
+      text: "Art Under $5000",
+    })
+  })
+
+  it("returns the 2501-5000 bucket for a value within the range", () => {
+    expect(priceBucketBasedOnPricePreference(3750)).toEqual({
+      priceRange: "2501-5000",
+      min: 2501,
+      max: 5000,
+      text: "Art Under $5000",
+    })
+  })
+
+  it("returns the 2501-5000 bucket for the maximum value of the range (5000)", () => {
+    expect(priceBucketBasedOnPricePreference(5000)).toEqual({
+      priceRange: "2501-5000",
+      min: 2501,
+      max: 5000,
+      text: "Art Under $5000",
+    })
+  })
+
+  it("returns the 5001-10000 bucket for the minimum value of the range (5001)", () => {
+    expect(priceBucketBasedOnPricePreference(5001)).toEqual({
+      priceRange: "5001-10000",
+      min: 5001,
+      max: 10000,
+      text: "Art Under $10000",
+    })
+  })
+
+  it("returns the 5001-10000 bucket for a value within the range", () => {
+    expect(priceBucketBasedOnPricePreference(7500)).toEqual({
+      priceRange: "5001-10000",
+      min: 5001,
+      max: 10000,
+      text: "Art Under $10000",
+    })
+  })
+
+  it("returns the 5001-10000 bucket for the maximum value of the range (10000)", () => {
+    expect(priceBucketBasedOnPricePreference(10000)).toEqual({
+      priceRange: "5001-10000",
+      min: 5001,
+      max: 10000,
+      text: "Art Under $10000",
+    })
+  })
+
+  it("returns the 10001-25000 bucket for the minimum value of the range (10001)", () => {
+    expect(priceBucketBasedOnPricePreference(10001)).toEqual({
+      priceRange: "10001-25000",
+      min: 10001,
+      max: 25000,
+      text: "Art Under $25000",
+    })
+  })
+
+  it("returns the 10001-25000 bucket for a value within the range", () => {
+    expect(priceBucketBasedOnPricePreference(15000)).toEqual({
+      priceRange: "10001-25000",
+      min: 10001,
+      max: 25000,
+      text: "Art Under $25000",
+    })
+  })
+
+  it("returns the 10001-25000 bucket for the maximum value of the range (25000)", () => {
+    expect(priceBucketBasedOnPricePreference(25000)).toEqual({
+      priceRange: "10001-25000",
+      min: 10001,
+      max: 25000,
+      text: "Art Under $25000",
+    })
+  })
+
+  it("returns the 25000-* bucket for a value above the minimum value of the range", () => {
+    expect(priceBucketBasedOnPricePreference(25001)).toEqual({
+      priceRange: "25001-*",
+      min: 25001,
+      max: Number.POSITIVE_INFINITY,
+      text: "Art Above $25000",
+    })
+  })
+
+  it("returns the 25000-* bucket for a very large value", () => {
+    expect(priceBucketBasedOnPricePreference(1000000)).toEqual({
+      priceRange: "25001-*",
+      min: 25001,
+      max: Number.POSITIVE_INFINITY,
+      text: "Art Above $25000",
+    })
+  })
+})

--- a/src/schema/v2/homeView/helpers/__tests__/priceBucketBasedOnPricePreference.test.ts
+++ b/src/schema/v2/homeView/helpers/__tests__/priceBucketBasedOnPricePreference.test.ts
@@ -28,154 +28,109 @@ describe("priceBucketBasedOnPricePreference", () => {
     })
   })
 
-  it("returns the 501-1000 bucket for the minimum value of the range (501)", () => {
+  it("returns the 500-1000 bucket for 500.9", () => {
+    expect(priceBucketBasedOnPricePreference(500.1)).toEqual({
+      priceRange: "500-1000",
+      min: 500,
+      max: 1000,
+      text: "Art Under $1000",
+    })
+  })
+
+  it("returns the 500-1000 bucket for a value within the range", () => {
     expect(priceBucketBasedOnPricePreference(501)).toEqual({
-      priceRange: "501-1000",
-      min: 501,
+      priceRange: "500-1000",
+      min: 500,
       max: 1000,
       text: "Art Under $1000",
     })
   })
 
-  it("returns the 501-1000 bucket for a value within the range", () => {
-    expect(priceBucketBasedOnPricePreference(750)).toEqual({
-      priceRange: "501-1000",
-      min: 501,
-      max: 1000,
-      text: "Art Under $1000",
-    })
-  })
-
-  it("returns the 501-1000 bucket for the maximum value of the range (1000)", () => {
+  it("returns the 500-1000 bucket for the maximum value of the range (1000)", () => {
     expect(priceBucketBasedOnPricePreference(1000)).toEqual({
-      priceRange: "501-1000",
-      min: 501,
+      priceRange: "500-1000",
+      min: 500,
       max: 1000,
       text: "Art Under $1000",
     })
   })
 
-  it("returns the 1001-2500 bucket for the minimum value of the range (1001)", () => {
-    expect(priceBucketBasedOnPricePreference(1001)).toEqual({
-      priceRange: "1001-2500",
-      min: 1001,
+  it("returns the 1000-2500 bucket for a value within the range", () => {
+    expect(priceBucketBasedOnPricePreference(1000.01)).toEqual({
+      priceRange: "1000-2500",
+      min: 1000,
       max: 2500,
       text: "Art Under $2500",
     })
   })
 
-  it("returns the 1001-2500 bucket for a value within the range", () => {
-    expect(priceBucketBasedOnPricePreference(2000)).toEqual({
-      priceRange: "1001-2500",
-      min: 1001,
-      max: 2500,
-      text: "Art Under $2500",
-    })
-  })
-
-  it("returns the 1001-2500 bucket for the maximum value of the range (2500)", () => {
+  it("returns the 1000-2500 bucket for the maximum value of the range (2500)", () => {
     expect(priceBucketBasedOnPricePreference(2500)).toEqual({
-      priceRange: "1001-2500",
-      min: 1001,
+      priceRange: "1000-2500",
+      min: 1000,
       max: 2500,
       text: "Art Under $2500",
     })
   })
 
-  it("returns the 2501-5000 bucket for the minimum value of the range (2501)", () => {
-    expect(priceBucketBasedOnPricePreference(2501)).toEqual({
-      priceRange: "2501-5000",
-      min: 2501,
-      max: 5000,
-      text: "Art Under $5000",
-    })
-  })
-
-  it("returns the 2501-5000 bucket for a value within the range", () => {
+  it("returns the 2500-5000 bucket for a value within the range", () => {
     expect(priceBucketBasedOnPricePreference(3750)).toEqual({
-      priceRange: "2501-5000",
-      min: 2501,
+      priceRange: "2500-5000",
+      min: 2500,
       max: 5000,
       text: "Art Under $5000",
     })
   })
 
-  it("returns the 2501-5000 bucket for the maximum value of the range (5000)", () => {
+  it("returns the 2500-5000 bucket for the maximum value of the range (5000)", () => {
     expect(priceBucketBasedOnPricePreference(5000)).toEqual({
-      priceRange: "2501-5000",
-      min: 2501,
+      priceRange: "2500-5000",
+      min: 2500,
       max: 5000,
       text: "Art Under $5000",
     })
   })
 
-  it("returns the 5001-10000 bucket for the minimum value of the range (5001)", () => {
-    expect(priceBucketBasedOnPricePreference(5001)).toEqual({
-      priceRange: "5001-10000",
-      min: 5001,
-      max: 10000,
-      text: "Art Under $10000",
-    })
-  })
-
-  it("returns the 5001-10000 bucket for a value within the range", () => {
+  it("returns the 5000-10000 bucket for a value within the range", () => {
     expect(priceBucketBasedOnPricePreference(7500)).toEqual({
-      priceRange: "5001-10000",
-      min: 5001,
+      priceRange: "5000-10000",
+      min: 5000,
       max: 10000,
       text: "Art Under $10000",
     })
   })
 
-  it("returns the 5001-10000 bucket for the maximum value of the range (10000)", () => {
+  it("returns the 5000-10000 bucket for the maximum value of the range (10000)", () => {
     expect(priceBucketBasedOnPricePreference(10000)).toEqual({
-      priceRange: "5001-10000",
-      min: 5001,
+      priceRange: "5000-10000",
+      min: 5000,
       max: 10000,
       text: "Art Under $10000",
     })
   })
 
-  it("returns the 10001-25000 bucket for the minimum value of the range (10001)", () => {
-    expect(priceBucketBasedOnPricePreference(10001)).toEqual({
-      priceRange: "10001-25000",
-      min: 10001,
-      max: 25000,
-      text: "Art Under $25000",
-    })
-  })
-
-  it("returns the 10001-25000 bucket for a value within the range", () => {
+  it("returns the 10000-25000 bucket for a value within the range", () => {
     expect(priceBucketBasedOnPricePreference(15000)).toEqual({
-      priceRange: "10001-25000",
-      min: 10001,
+      priceRange: "10000-25000",
+      min: 10000,
       max: 25000,
       text: "Art Under $25000",
     })
   })
 
-  it("returns the 10001-25000 bucket for the maximum value of the range (25000)", () => {
+  it("returns the 10000-25000 bucket for the maximum value of the range (25000)", () => {
     expect(priceBucketBasedOnPricePreference(25000)).toEqual({
-      priceRange: "10001-25000",
-      min: 10001,
+      priceRange: "10000-25000",
+      min: 10000,
       max: 25000,
       text: "Art Under $25000",
-    })
-  })
-
-  it("returns the 25000-* bucket for a value above the minimum value of the range", () => {
-    expect(priceBucketBasedOnPricePreference(25001)).toEqual({
-      priceRange: "25001-*",
-      min: 25001,
-      max: Number.POSITIVE_INFINITY,
-      text: "Art Above $25000",
     })
   })
 
   it("returns the 25000-* bucket for a very large value", () => {
     expect(priceBucketBasedOnPricePreference(1000000)).toEqual({
-      priceRange: "25001-*",
-      min: 25001,
+      priceRange: "25000-*",
+      min: 25000,
       max: Number.POSITIVE_INFINITY,
       text: "Art Above $25000",
     })

--- a/src/schema/v2/homeView/helpers/priceBucketBasedOnPricePreference.ts
+++ b/src/schema/v2/homeView/helpers/priceBucketBasedOnPricePreference.ts
@@ -2,33 +2,34 @@ export const priceBucketBasedOnPricePreference = (pricePreference: number) => {
   // Price buckets are aligned with the dropdown options on the website's top menu's dropdown
   const priceBuckets = [
     { priceRange: "0-500", min: 0, max: 500, text: "Art Under $500" },
-    { priceRange: "501-1000", min: 501, max: 1000, text: "Art Under $1000" },
-    { priceRange: "1001-2500", min: 1001, max: 2500, text: "Art Under $2500" },
-    { priceRange: "2501-5000", min: 2501, max: 5000, text: "Art Under $5000" },
+    { priceRange: "500-1000", min: 500, max: 1000, text: "Art Under $1000" },
+    { priceRange: "1000-2500", min: 1000, max: 2500, text: "Art Under $2500" },
+    { priceRange: "2500-5000", min: 2500, max: 5000, text: "Art Under $5000" },
     {
-      priceRange: "5001-10000",
-      min: 5001,
+      priceRange: "5000-10000",
+      min: 5000,
       max: 10000,
       text: "Art Under $10000",
     },
     {
-      priceRange: "10001-25000",
-      min: 10001,
+      priceRange: "10000-25000",
+      min: 10000,
       max: 25000,
       text: "Art Under $25000",
     },
     {
-      priceRange: "25001-*",
-      min: 25001,
+      priceRange: "25000-*",
+      min: 25000,
       max: Number.POSITIVE_INFINITY,
       text: "Art Above $25000",
     },
   ]
 
   if (pricePreference > 25000) return priceBuckets[priceBuckets.length - 1]
+  if (pricePreference === 0) return priceBuckets[0]
 
   const priceBucket = priceBuckets.find(({ min, max }) => {
-    return pricePreference >= min && pricePreference <= max
+    return pricePreference > min && pricePreference <= max
   })
 
   return priceBucket

--- a/src/schema/v2/homeView/helpers/priceBucketBasedOnPricePreference.ts
+++ b/src/schema/v2/homeView/helpers/priceBucketBasedOnPricePreference.ts
@@ -1,0 +1,35 @@
+export const priceBucketBasedOnPricePreference = (pricePreference: number) => {
+  // Price buckets are aligned with the dropdown options on the website's top menu's dropdown
+  const priceBuckets = [
+    { priceRange: "0-500", min: 0, max: 500, text: "Art Under $500" },
+    { priceRange: "501-1000", min: 501, max: 1000, text: "Art Under $1000" },
+    { priceRange: "1001-2500", min: 1001, max: 2500, text: "Art Under $2500" },
+    { priceRange: "2501-5000", min: 2501, max: 5000, text: "Art Under $5000" },
+    {
+      priceRange: "5001-10000",
+      min: 5001,
+      max: 10000,
+      text: "Art Under $10000",
+    },
+    {
+      priceRange: "10001-25000",
+      min: 10001,
+      max: 25000,
+      text: "Art Under $25000",
+    },
+    {
+      priceRange: "25001-*",
+      min: 25001,
+      max: Number.POSITIVE_INFINITY,
+      text: "Art Above $25000",
+    },
+  ]
+
+  if (pricePreference > 25000) return priceBuckets[priceBuckets.length - 1]
+
+  const priceBucket = priceBuckets.find(({ min, max }) => {
+    return pricePreference >= min && pricePreference <= max
+  })
+
+  return priceBucket
+}

--- a/src/schema/v2/homeView/sections/QuickLinks.ts
+++ b/src/schema/v2/homeView/sections/QuickLinks.ts
@@ -15,8 +15,8 @@ export const QuickLinks: HomeViewSection = {
   requiresAuthentication: true,
   resolver: async (_parent, _args, context, _info) => {
     let links = getDisplayableQuickLinks(context)
-    links = await maybeInsertYourBidsLink(links, context)
     links = await maybeInsertArtworksWithinPriceBudgetLink(links, context)
+    links = await maybeInsertYourBidsLink(links, context)
 
     return links
   },
@@ -185,7 +185,7 @@ async function maybeInsertYourBidsLink(
 
 /**
  * If the use has a price preference set in Vortex, we insert
- * the **Art Under $X** link immediately after the **New This Week** link.
+ * the **Art Under $X** link immediately after the **Auctions** link.
  * We return the (maybe) updated full list of quick links.
  */
 async function maybeInsertArtworksWithinPriceBudgetLink(
@@ -209,18 +209,17 @@ async function maybeInsertArtworksWithinPriceBudgetLink(
         return links
       }
 
-      const newThisWeekIndex = links.findIndex(
-        (link) => link.href === "/collection/new-this-week"
-      )
+      const auctionsIndex = links.findIndex((link) => link.href === "/auctions")
 
       const priceBudgetPill: NavigationPill = {
         title: priceBucket.text,
         href: `/collect?price_range=${priceBucket.priceRange}`,
         ownerType: OwnerType.collect,
         icon: undefined,
+        minimumEigenVersion: { major: 8, minor: 74, patch: 0 }, // when /collect screen was added to the app
       }
 
-      links.splice(newThisWeekIndex + 1, 0, priceBudgetPill)
+      links.splice(auctionsIndex + 1, 0, priceBudgetPill)
     }
   }
 

--- a/src/schema/v2/homeView/sections/QuickLinks.ts
+++ b/src/schema/v2/homeView/sections/QuickLinks.ts
@@ -5,6 +5,7 @@ import type { NavigationPill } from "../sectionTypes/NavigationPills"
 import { ResolverContext } from "types/graphql"
 import { getEigenVersionNumber, isAtLeastVersion } from "lib/semanticVersioning"
 import { isFeatureFlagEnabled } from "lib/featureFlags"
+import { priceBucketBasedOnPricePreference } from "../helpers/priceBucketBasedOnPricePreference"
 
 export const QuickLinks: HomeViewSection = {
   id: "home-view-section-quick-links",
@@ -15,6 +16,8 @@ export const QuickLinks: HomeViewSection = {
   resolver: async (_parent, _args, context, _info) => {
     let links = getDisplayableQuickLinks(context)
     links = await maybeInsertYourBidsLink(links, context)
+    links = await maybeInsertArtworksWithinPriceBudgetLink(links, context)
+
     return links
   },
 }
@@ -177,5 +180,49 @@ async function maybeInsertYourBidsLink(
       links.splice(auctionsIndex + 1, 0, yourBids)
     }
   }
+  return links
+}
+
+/**
+ * If the use has a price preference set in Vortex, we insert
+ * the **Art Under $X** link immediately after the **New This Week** link.
+ * We return the (maybe) updated full list of quick links.
+ */
+async function maybeInsertArtworksWithinPriceBudgetLink(
+  links: NavigationPill[],
+  context: ResolverContext
+): Promise<NavigationPill[]> {
+  if (isFeatureFlagEnabled("onyx_enable-quick-links-price-budget")) {
+    const { UserPricePreference } = require("schema/v2/me/userPricePreference")
+
+    const pricePreference = await UserPricePreference.resolve?.(
+      {},
+      {},
+      context,
+      {} as any
+    )
+
+    if (pricePreference) {
+      const priceBucket = priceBucketBasedOnPricePreference(pricePreference)
+
+      if (!priceBucket) {
+        return links
+      }
+
+      const newThisWeekIndex = links.findIndex(
+        (link) => link.href === "/collection/new-this-week"
+      )
+
+      const priceBudgetPill: NavigationPill = {
+        title: priceBucket.text,
+        href: `/collect?price_range=${priceBucket.priceRange}`,
+        ownerType: OwnerType.collect,
+        icon: undefined,
+      }
+
+      links.splice(newThisWeekIndex + 1, 0, priceBudgetPill)
+    }
+  }
+
   return links
 }

--- a/src/schema/v2/homeView/sections/__tests__/QuickLinks.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/QuickLinks.test.ts
@@ -34,7 +34,12 @@ describe("QuickLinks", () => {
 
   describe("when v2 is enabled", () => {
     beforeEach(() => {
-      mockIsFeatureFlagEnabled.mockReturnValue(true)
+      mockIsFeatureFlagEnabled.mockImplementation((flag) => {
+        if (flag === "onyx_enable-quick-links-v2") {
+          return true
+        }
+        return false
+      })
     })
 
     it("returns the section's data", async () => {
@@ -239,6 +244,140 @@ describe("QuickLinks", () => {
     })
   })
 
+  describe("when onyx_enable-quick-links-price-budget is enabled", () => {
+    beforeEach(() => {
+      mockIsFeatureFlagEnabled.mockImplementation((flag) => {
+        if (
+          flag === "onyx_enable-quick-links-price-budget" ||
+          flag === "onyx_enable-quick-links-v2"
+        ) {
+          return true
+        }
+        return false
+      })
+    })
+
+    describe("when user has price preferences", () => {
+      beforeEach(() => {
+        jest.mock("schema/v2/me/userPricePreference", () => {
+          const originalModule = jest.requireActual(
+            "schema/v2/me/userPricePreference"
+          )
+
+          return {
+            UserPricePreference: {
+              ...originalModule.UserPricePreference,
+              resolve: jest.fn().mockReturnValueOnce(2500.0),
+            },
+          }
+        })
+      })
+      afterEach(() => {
+        jest.clearAllMocks()
+      })
+
+      it("returns the Art Under $X quick link", async () => {
+        const { homeView } = await runQuery(query, context)
+
+        expect(homeView.section.navigationPills).toContainEqual(
+          expect.objectContaining({
+            title: "Art Under $2500",
+            href: "/collect?price_range=1001-2500",
+          })
+        )
+      })
+    })
+
+    describe("when user has no price preferences", () => {
+      beforeEach(() => {
+        jest.mock("schema/v2/me/userPricePreference", () => {
+          const originalModule = jest.requireActual(
+            "schema/v2/me/userPricePreference"
+          )
+
+          return {
+            UserPricePreference: {
+              ...originalModule.UserPricePreference,
+              resolve: jest.fn().mockReturnValueOnce(null),
+            },
+          }
+        })
+      })
+      afterEach(() => {
+        jest.clearAllMocks()
+      })
+
+      it("does NOT return the Art Under $X quick link", async () => {
+        const { homeView } = await runQuery(query, context)
+
+        expect(homeView.section).toMatchInlineSnapshot(`
+          {
+            "__typename": "HomeViewSectionNavigationPills",
+            "contextModule": "quickLinks",
+            "internalID": "home-view-section-quick-links",
+            "navigationPills": [
+              {
+                "href": "/infinite-discovery",
+                "icon": "ImageSetIcon",
+                "ownerType": "infiniteDiscovery",
+                "title": "Discover Daily",
+              },
+              {
+                "href": "/auctions",
+                "icon": "GavelIcon",
+                "ownerType": "auctions",
+                "title": "Auctions",
+              },
+              {
+                "href": "/collection/new-this-week",
+                "icon": null,
+                "ownerType": "collection",
+                "title": "New This Week",
+              },
+              {
+                "href": "/articles",
+                "icon": "PublicationIcon",
+                "ownerType": "articles",
+                "title": "Articles",
+              },
+              {
+                "href": "/collection/statement-pieces",
+                "icon": null,
+                "ownerType": "collection",
+                "title": "Statement Pieces",
+              },
+              {
+                "href": "/collection/paintings",
+                "icon": "ArtworkIcon",
+                "ownerType": "collection",
+                "title": "Paintings",
+              },
+              {
+                "href": "galleries-for-you",
+                "icon": "InstitutionIcon",
+                "ownerType": "galleriesForYou",
+                "title": "Galleries for You",
+              },
+              {
+                "href": "/shows-for-you",
+                "icon": null,
+                "ownerType": "shows",
+                "title": "Shows for You",
+              },
+              {
+                "href": "/featured-fairs",
+                "icon": "FairIcon",
+                "ownerType": "featuredFairs",
+                "title": "Featured Fairs",
+              },
+            ],
+            "ownerType": "quickLinks",
+          }
+        `)
+      })
+    })
+  })
+
   describe("When a quick link specifies a minimum Eigen version", () => {
     const versionedQuickLink = {
       title: "A futuristic feature",
@@ -249,6 +388,10 @@ describe("QuickLinks", () => {
 
     beforeAll(() => QUICK_LINKS.push(versionedQuickLink))
     afterAll(() => QUICK_LINKS.pop())
+
+    beforeEach(() => {
+      mockIsFeatureFlagEnabled.mockReturnValue(false)
+    })
 
     describe("When Eigen < minimum version", () => {
       it("does not return the quick link", async () => {

--- a/src/schema/v2/homeView/sections/__tests__/QuickLinks.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/QuickLinks.test.ts
@@ -282,7 +282,7 @@ describe("QuickLinks", () => {
         expect(homeView.section.navigationPills).toContainEqual(
           expect.objectContaining({
             title: "Art Under $2500",
-            href: "/collect?price_range=1001-2500",
+            href: "/collect?price_range=1000-2500",
           })
         )
       })

--- a/src/schema/v2/me/__tests__/userPricePreference.test.ts
+++ b/src/schema/v2/me/__tests__/userPricePreference.test.ts
@@ -1,0 +1,67 @@
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("me.pricePreference", () => {
+  describe("when the data is present in Vortex", () => {
+    it("returns the user's price preference from Vortex", async () => {
+      const query = gql`
+        {
+          me {
+            pricePreference
+          }
+        }
+      `
+
+      const userPricePreferenceLoader = jest.fn().mockResolvedValue({
+        data: [
+          {
+            user_id: "abc123",
+            price_preference: 2500.0,
+          },
+        ],
+      })
+
+      const context = {
+        meLoader: jest.fn().mockResolvedValue({}),
+        userPricePreferenceLoader,
+      }
+
+      const response = await runAuthenticatedQuery(query, context)
+
+      expect(response).toEqual({
+        me: {
+          pricePreference: 2500.0,
+        },
+      })
+    })
+  })
+
+  describe("when the data is not present in Vortex", () => {
+    it("returns null", async () => {
+      const query = gql`
+        {
+          me {
+            pricePreference
+          }
+        }
+      `
+
+      const userPricePreferenceLoader = jest.fn().mockResolvedValue({
+        data: [],
+      })
+
+      const context = {
+        meLoader: jest.fn().mockResolvedValue({}),
+        userPricePreferenceLoader,
+      }
+
+      const response = await runAuthenticatedQuery(query, context)
+
+      expect(response).toEqual({
+        me: {
+          pricePreference: null,
+        },
+      })
+    })
+  })
+})

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -99,6 +99,7 @@ import {
 import { MeOrder } from "../order"
 import { ConfirmationToken } from "../order/confirmationToken"
 import { AuctionSegmentation } from "./auctionSegmentation"
+import { UserPricePreference } from "./UserPricePreference"
 
 /**
  * @deprecated: Please use the CollectorProfile type instead of adding fields to me directly.
@@ -534,6 +535,7 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
       resolve: ({ phone }, _, context, info) =>
         PhoneNumber.resolve?.(null, { phoneNumber: phone }, context, info),
     },
+    pricePreference: UserPricePreference,
     priceRange: {
       type: GraphQLString,
       resolve: ({ price_range }) => price_range,

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -99,7 +99,7 @@ import {
 import { MeOrder } from "../order"
 import { ConfirmationToken } from "../order/confirmationToken"
 import { AuctionSegmentation } from "./auctionSegmentation"
-import { UserPricePreference } from "./UserPricePreference"
+import { UserPricePreference } from "./userPricePreference"
 
 /**
  * @deprecated: Please use the CollectorProfile type instead of adding fields to me directly.

--- a/src/schema/v2/me/userPricePreference.ts
+++ b/src/schema/v2/me/userPricePreference.ts
@@ -1,0 +1,18 @@
+import { GraphQLFloat } from "graphql"
+import type { GraphQLFieldConfig } from "graphql"
+import type { ResolverContext } from "types/graphql"
+
+export const UserPricePreference: GraphQLFieldConfig<void, ResolverContext> = {
+  type: GraphQLFloat,
+  description: "User's price preference, in USD.",
+  resolve: async (_parent, _args, context, _info) => {
+    const { userPricePreferenceLoader } = context
+
+    if (!userPricePreferenceLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    const vortexResponse = await userPricePreferenceLoader?.()
+    return vortexResponse?.data?.[0]?.price_preference
+  },
+}


### PR DESCRIPTION
This implements the conditional "Art Under $X" link that is shown only to users with [computed price preferences](https://github.com/artsy/vortex/pull/709). For this feature I've added a new field under `me`, which is called `pricePreference`.

Price buckets are the same as on the website under the "What's new" dropdown:

<img src="https://github.com/user-attachments/assets/ad7a32b1-8db2-405c-89cd-5171b835b150" width="400px" />


Request:

```graphql
{
  me {
    pricePreference
  }
  
  homeView {
    sectionsConnection(first: 1) {
      edges {
        node {
          ... on HomeViewSectionNavigationPills {
            navigationPills {
              title
              href
            }
          }
        }
      }
    }
  }
}
```

Response:

```json
{
  "data": {
    "me": {
      "email": "nikita.skalkin@artsymail.com",
      "pricePreference": 250
    },
    "homeView": {
      "sectionsConnection": {
        "edges": [
          {
            "node": {
              "navigationPills": [
                {
                  "title": "Discover Daily",
                  "href": "/infinite-discovery"
                },
                {
                  "title": "Auctions",
                  "href": "/auctions"
                },
                {
                  "title": "New This Week",
                  "href": "/collection/new-this-week"
                },
                {
                  "title": "Art Under $500",
                  "href": "/collect?price_range=0-500"
                },
                ...
              ]
            }
          }
        ]
      }
    }
  }
}
```