### PR TITLE
feat: Allow flat fee update and published filter in bulk

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4539,6 +4539,9 @@ input BulkUpdateArtworksFilterInput {
 
   # Filter artworks by partner artist id
   partnerArtistId: String
+
+  # Filter artworks by published status
+  published: Boolean
 }
 
 input BulkUpdateArtworksMetadataInput {
@@ -4547,6 +4550,9 @@ input BulkUpdateArtworksMetadataInput {
 
   # The category (medium type) to be assigned
   category: String
+
+  # Flat fee for domestic shipping. It must be entered in cents.
+  domestic_shipping_fee_cents: Int
 
   # Whether the artworks must be listed as Purchase
   ecommerce: Boolean

--- a/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
+++ b/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
@@ -9,6 +9,7 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
           id: "partner123"
           metadata: {
             availability: SOLD
+            domestic_shipping_fee_cents: 20000
             locationId: "location456"
             category: "Painting"
             ecommerce: true
@@ -21,6 +22,7 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
             availability: FOR_SALE
             locationId: "oldLocation"
             partnerArtistId: "artist789"
+            published: true
           }
         }
       ) {
@@ -65,6 +67,7 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
       {
         metadata: {
           availability: "sold",
+          domestic_shipping_fee_cents: 20000,
           location_id: "location456",
           category: "Painting",
           ecommerce: true,
@@ -77,6 +80,7 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
           availability: "for sale",
           location_id: "oldLocation",
           partner_artist_id: "artist789",
+          published: true,
         },
       }
     )

--- a/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
@@ -21,6 +21,7 @@ interface Input {
   id: string
   metadata?: {
     availability?: string
+    domestic_shipping_fee_cents?: number
     ecommerce: boolean
     locationId?: string
     category?: string
@@ -34,6 +35,7 @@ interface Input {
     artworkIds?: string[]
     locationId?: string
     partnerArtistId?: string
+    published?: boolean
   }
 }
 
@@ -43,6 +45,11 @@ const BulkUpdateArtworksMetadataInput = new GraphQLInputObjectType({
     availability: {
       type: Availability,
       description: "The availaiblity to be assigned",
+    },
+    domestic_shipping_fee_cents: {
+      type: GraphQLInt,
+      description:
+        "Flat fee for domestic shipping. It must be entered in cents.",
     },
     locationId: {
       type: GraphQLString,
@@ -93,6 +100,10 @@ const BulkUpdateArtworksFilterInput = new GraphQLInputObjectType({
     partnerArtistId: {
       type: GraphQLString,
       description: "Filter artworks by partner artist id",
+    },
+    published: {
+      type: GraphQLBoolean,
+      description: "Filter artworks by published status",
     },
   },
 })
@@ -201,6 +212,7 @@ export const bulkUpdateArtworksMetadataMutation = mutationWithClientMutationId<
     if (metadata) {
       gravityOptions.metadata = {
         availability: metadata.availability,
+        domestic_shipping_fee_cents: metadata.domestic_shipping_fee_cents,
         location_id: metadata.locationId,
         category: metadata.category,
         price_listed: metadata.priceListed,
@@ -217,6 +229,7 @@ export const bulkUpdateArtworksMetadataMutation = mutationWithClientMutationId<
         artwork_ids: filters.artworkIds,
         location_id: filters.locationId,
         partner_artist_id: filters.partnerArtistId,
+        published: filters.published,
       }
     }
 


### PR DESCRIPTION
Relies on the changes added during:
https://github.com/artsy/gravity/pull/18926

Allow bulk operations to filter artworks by published status and allow domestic shipping fee to be updated in batch.

cc @artsy/amber-devs 