### PR TITLE
feat(DIA-1303): enable unauth access to the profile loader

### DIFF
--- a/src/schema/v2/partner/__tests__/hasVisibleFollowsCount.test.ts
+++ b/src/schema/v2/partner/__tests__/hasVisibleFollowsCount.test.ts
@@ -132,34 +132,5 @@ describe("Partner", () => {
       expect(profileLoader).toHaveBeenCalledWith("example-profile")
       expect(partner.hasVisibleFollowsCount).toBe(false)
     })
-
-    it("returns false when user is not authenticated", async () => {
-      const query = gql`
-        {
-          partner(id: "example-partner") {
-            hasVisibleFollowsCount
-          }
-        }
-      `
-
-      const partnerLoader = jest.fn().mockReturnValue(
-        Promise.resolve({
-          id: "example-partner",
-          default_profile_id: "example-profile",
-        })
-      )
-
-      const profileLoader = jest.fn()
-
-      const { partner } = await runAuthenticatedQuery(query, {
-        partnerLoader,
-        profileLoader,
-        userID: undefined,
-        accessToken: undefined,
-      })
-
-      expect(partner.hasVisibleFollowsCount).toBe(false)
-      expect(profileLoader).not.toHaveBeenCalledWith("example-profile")
-    })
   })
 })

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -966,14 +966,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       hasVisibleFollowsCount: {
         type: GraphQLNonNull(GraphQLBoolean),
         description: "If the partner has more than 500 follows",
-        resolve: async (
-          { default_profile_id },
-          _,
-          { profileLoader, userID, accessToken }
-        ) => {
-          if (!userID || !accessToken) {
-            return false
-          }
+        resolve: async ({ default_profile_id }, _, { profileLoader }) => {
           try {
             const res = await profileLoader(default_profile_id)
             return res?.follows_count > 500


### PR DESCRIPTION
Remove auth necessity from `hasVisibleFollowsCount`.