### PR TITLE
feat: Adds authenticated partnerLoader

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -871,7 +871,7 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
-
+    partnerLoader: gravityLoader((id) => `partner/${id}`),
     partnerAllLoader: gravityLoader((id) => `partner/${id}/all`),
     partnerArtistDocumentsLoader: gravityLoader<
       any,


### PR DESCRIPTION
feat: Adds authenticated partnerLoader


Volt's new settingsV2 experience is now _updating_ partner data through metaphysics. Before now there was only an unauthenticated `partnerLoader`, we are implementing an authenticated `partnerLoader` here to make the experience better for partners and bypass the cache of the unauth'ed loader

Tested this locally:

### How the partner query looks without being authenticated
Note the `cache: true`
<img width="840" alt="Screenshot 2025-05-19 at 2 58 28 PM" src="https://github.com/user-attachments/assets/422cb9bd-4b9a-48de-b057-1b4aa6a65eca" />


### How the partner query looks being authenticated
Note the nice fresh `cache: false` - you cannot tell from the screenshot but the cache was still false after making 10s of requests

<img width="900" alt="Screenshot 2025-05-19 at 2 45 17 PM" src="https://github.com/user-attachments/assets/ea4ba197-938d-4969-8b53-50b9c1dc9020" />


This will address staleness reports from or recent QA
- https://www.notion.so/artsy/Settings-V2-1e3cab0764a08081931ed34703c5ead8

cc @artsy/amber-devs 


