### PR TITLE
chore: remove message from displayTexts as we are using  instead

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10600,6 +10600,9 @@ type DisplayTexts {
 
   # Text to display as a first message on the page (header)
   title: String!
+
+  # Wire specific type that specifies which wire details to use
+  wireType: DisplayTextsWireTypeEnum
 }
 
 enum DisplayTextsMessageTypeEnum {
@@ -10619,6 +10622,12 @@ enum DisplayTextsMessageTypeEnum {
   SUBMITTED_OFFER
   SUBMITTED_ORDER
   UNKNOWN
+}
+
+enum DisplayTextsWireTypeEnum {
+  WIRE_EUR
+  WIRE_GBP
+  WIRE_USD
 }
 
 type DoNotUseThisPartner {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10600,9 +10600,6 @@ type DisplayTexts {
 
   # Text to display as a first message on the page (header)
   title: String!
-
-  # Wire specific type that specifies which wire details to use
-  wireType: DisplayTextsWireTypeEnum
 }
 
 enum DisplayTextsMessageTypeEnum {
@@ -10622,12 +10619,6 @@ enum DisplayTextsMessageTypeEnum {
   SUBMITTED_OFFER
   SUBMITTED_ORDER
   UNKNOWN
-}
-
-enum DisplayTextsWireTypeEnum {
-  WIRE_EUR
-  WIRE_GBP
-  WIRE_USD
 }
 
 type DoNotUseThisPartner {
@@ -16488,6 +16479,9 @@ type Order {
 
   # Order code
   code: String!
+
+  # Currency code
+  currencyCode: String!
 
   # Display texts for the order based on its buyer_state and order shipping/payment states
   displayTexts: DisplayTexts!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10595,9 +10595,6 @@ type DismissTaskSuccess {
 
 # Display texts for the order based on its state and order shipping/payment states
 type DisplayTexts {
-  # Fomatted full message text for the order
-  message(format: Format = MARKDOWN): String
-
   # Granular order states specific type that should be directly interpreted by clients
   messageType: DisplayTextsMessageTypeEnum!
 

--- a/src/schema/v2/order/__tests__/DisplayTexts.test.ts
+++ b/src/schema/v2/order/__tests__/DisplayTexts.test.ts
@@ -24,7 +24,6 @@ describe("DisplayTexts", () => {
           displayTexts {
             title
             messageType
-            wireType
           }
         }
       }
@@ -44,7 +43,6 @@ describe("DisplayTexts", () => {
       expect(result.me.order.displayTexts).toEqual({
         title: "Great choice!",
         messageType: "SUBMITTED_ORDER",
-        wireType: null,
       })
     })
 
@@ -60,7 +58,6 @@ describe("DisplayTexts", () => {
       expect(result.me.order.displayTexts).toEqual({
         title: "Great choice!",
         messageType: "SUBMITTED_OFFER",
-        wireType: null,
       })
     })
   })
@@ -78,7 +75,6 @@ describe("DisplayTexts", () => {
       expect(result.me.order.displayTexts).toEqual({
         title: "Payment failed",
         messageType: "PAYMENT_FAILED",
-        wireType: null,
       })
     })
   })
@@ -97,7 +93,6 @@ describe("DisplayTexts", () => {
       expect(result.me.order.displayTexts).toEqual({
         title: "Your payment is processing",
         messageType: "PROCESSING_PAYMENT_PICKUP",
-        wireType: null,
       })
     })
 
@@ -114,7 +109,6 @@ describe("DisplayTexts", () => {
       expect(result.me.order.displayTexts).toEqual({
         title: "Your payment is processing",
         messageType: "PROCESSING_PAYMENT_SHIP",
-        wireType: null,
       })
     })
   })
@@ -133,41 +127,6 @@ describe("DisplayTexts", () => {
       expect(result.me.order.displayTexts).toEqual({
         title: "Congratulations!",
         messageType: "PROCESSING_WIRE",
-        wireType: "WIRE_USD",
-      })
-    })
-
-    it("returns correct display texts for GBP", async () => {
-      orderJson.buyer_state = "processing_offline_payment"
-      orderJson.currency_code = "GBP"
-      context = {
-        meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
-        meOrderLoader: jest.fn().mockResolvedValue(orderJson),
-      }
-
-      const result = await runAuthenticatedQuery(query, context)
-
-      expect(result.me.order.displayTexts).toEqual({
-        title: "Congratulations!",
-        messageType: "PROCESSING_WIRE",
-        wireType: "WIRE_GBP",
-      })
-    })
-
-    it("returns correct display texts for EUR", async () => {
-      orderJson.buyer_state = "processing_offline_payment"
-      orderJson.currency_code = "EUR"
-      context = {
-        meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
-        meOrderLoader: jest.fn().mockResolvedValue(orderJson),
-      }
-
-      const result = await runAuthenticatedQuery(query, context)
-
-      expect(result.me.order.displayTexts).toEqual({
-        title: "Congratulations!",
-        messageType: "PROCESSING_WIRE",
-        wireType: "WIRE_EUR",
       })
     })
   })
@@ -186,7 +145,6 @@ describe("DisplayTexts", () => {
       expect(result.me.order.displayTexts).toEqual({
         title: "Congratulations!",
         messageType: "APPROVED_PICKUP",
-        wireType: null,
       })
     })
 
@@ -204,7 +162,6 @@ describe("DisplayTexts", () => {
       expect(result.me.order.displayTexts).toEqual({
         title: "Congratulations!",
         messageType: "APPROVED_SHIP_STANDARD",
-        wireType: null,
       })
     })
 
@@ -222,7 +179,6 @@ describe("DisplayTexts", () => {
       expect(result.me.order.displayTexts).toEqual({
         title: "Congratulations!",
         messageType: "APPROVED_SHIP_EXPRESS",
-        wireType: null,
       })
     })
 
@@ -240,7 +196,6 @@ describe("DisplayTexts", () => {
       expect(result.me.order.displayTexts).toEqual({
         title: "Congratulations!",
         messageType: "APPROVED_SHIP_WHITE_GLOVE",
-        wireType: null,
       })
     })
 
@@ -258,7 +213,6 @@ describe("DisplayTexts", () => {
       expect(result.me.order.displayTexts).toEqual({
         title: "Congratulations!",
         messageType: "APPROVED_SHIP",
-        wireType: null,
       })
     })
   })
@@ -276,7 +230,6 @@ describe("DisplayTexts", () => {
       expect(result.me.order.displayTexts).toEqual({
         title: "Good news, your order has shipped!",
         messageType: "SHIPPED",
-        wireType: null,
       })
     })
   })
@@ -295,7 +248,6 @@ describe("DisplayTexts", () => {
       expect(result.me.order.displayTexts).toEqual({
         title: "Your order has been picked up",
         messageType: "COMPLETED_PICKUP",
-        wireType: null,
       })
     })
 
@@ -312,7 +264,6 @@ describe("DisplayTexts", () => {
       expect(result.me.order.displayTexts).toEqual({
         title: "Your order has been delivered",
         messageType: "COMPLETED_SHIP",
-        wireType: null,
       })
     })
   })
@@ -330,7 +281,6 @@ describe("DisplayTexts", () => {
       expect(result.me.order.displayTexts).toEqual({
         title: "Your order was canceled",
         messageType: "CANCELLED_ORDER",
-        wireType: null,
       })
     })
   })
@@ -348,7 +298,6 @@ describe("DisplayTexts", () => {
       expect(result.me.order.displayTexts).toEqual({
         title: "Your order",
         messageType: "UNKNOWN",
-        wireType: null,
       })
     })
   })

--- a/src/schema/v2/order/__tests__/DisplayTexts.test.ts
+++ b/src/schema/v2/order/__tests__/DisplayTexts.test.ts
@@ -1,0 +1,355 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import { baseOrderJson } from "./support"
+
+let context
+let orderJson
+
+describe("DisplayTexts", () => {
+  beforeEach(() => {
+    orderJson = {
+      ...baseOrderJson,
+      id: "order-id",
+      mode: "buy",
+      currency_code: "USD",
+      buyer_state: "submitted",
+      fulfillment_type: "ship",
+    }
+  })
+
+  const query = gql`
+    query {
+      me {
+        order(id: "order-id") {
+          displayTexts {
+            title
+            messageType
+            wireType
+          }
+        }
+      }
+    }
+  `
+
+  describe("buyer_state: submitted", () => {
+    it("returns correct display texts for buy order", async () => {
+      orderJson.mode = "buy"
+      context = {
+        meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+        meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+      }
+
+      const result = await runAuthenticatedQuery(query, context)
+
+      expect(result.me.order.displayTexts).toEqual({
+        title: "Great choice!",
+        messageType: "SUBMITTED_ORDER",
+        wireType: null,
+      })
+    })
+
+    it("returns correct display texts for offer order", async () => {
+      orderJson.mode = "offer"
+      context = {
+        meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+        meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+      }
+
+      const result = await runAuthenticatedQuery(query, context)
+
+      expect(result.me.order.displayTexts).toEqual({
+        title: "Great choice!",
+        messageType: "SUBMITTED_OFFER",
+        wireType: null,
+      })
+    })
+  })
+
+  describe("buyer_state: payment_failed", () => {
+    it("returns correct display texts", async () => {
+      orderJson.buyer_state = "payment_failed"
+      context = {
+        meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+        meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+      }
+
+      const result = await runAuthenticatedQuery(query, context)
+
+      expect(result.me.order.displayTexts).toEqual({
+        title: "Payment failed",
+        messageType: "PAYMENT_FAILED",
+        wireType: null,
+      })
+    })
+  })
+
+  describe("buyer_state: processing_payment", () => {
+    it("returns correct display texts for pickup", async () => {
+      orderJson.buyer_state = "processing_payment"
+      orderJson.fulfillment_type = "pickup"
+      context = {
+        meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+        meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+      }
+
+      const result = await runAuthenticatedQuery(query, context)
+
+      expect(result.me.order.displayTexts).toEqual({
+        title: "Your payment is processing",
+        messageType: "PROCESSING_PAYMENT_PICKUP",
+        wireType: null,
+      })
+    })
+
+    it("returns correct display texts for shipping", async () => {
+      orderJson.buyer_state = "processing_payment"
+      orderJson.fulfillment_type = "ship"
+      context = {
+        meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+        meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+      }
+
+      const result = await runAuthenticatedQuery(query, context)
+
+      expect(result.me.order.displayTexts).toEqual({
+        title: "Your payment is processing",
+        messageType: "PROCESSING_PAYMENT_SHIP",
+        wireType: null,
+      })
+    })
+  })
+
+  describe("buyer_state: processing_offline_payment", () => {
+    it("returns correct display texts for USD", async () => {
+      orderJson.buyer_state = "processing_offline_payment"
+      orderJson.currency_code = "USD"
+      context = {
+        meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+        meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+      }
+
+      const result = await runAuthenticatedQuery(query, context)
+
+      expect(result.me.order.displayTexts).toEqual({
+        title: "Congratulations!",
+        messageType: "PROCESSING_WIRE",
+        wireType: "WIRE_USD",
+      })
+    })
+
+    it("returns correct display texts for GBP", async () => {
+      orderJson.buyer_state = "processing_offline_payment"
+      orderJson.currency_code = "GBP"
+      context = {
+        meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+        meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+      }
+
+      const result = await runAuthenticatedQuery(query, context)
+
+      expect(result.me.order.displayTexts).toEqual({
+        title: "Congratulations!",
+        messageType: "PROCESSING_WIRE",
+        wireType: "WIRE_GBP",
+      })
+    })
+
+    it("returns correct display texts for EUR", async () => {
+      orderJson.buyer_state = "processing_offline_payment"
+      orderJson.currency_code = "EUR"
+      context = {
+        meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+        meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+      }
+
+      const result = await runAuthenticatedQuery(query, context)
+
+      expect(result.me.order.displayTexts).toEqual({
+        title: "Congratulations!",
+        messageType: "PROCESSING_WIRE",
+        wireType: "WIRE_EUR",
+      })
+    })
+  })
+
+  describe("buyer_state: approved", () => {
+    it("returns correct display texts for pickup", async () => {
+      orderJson.buyer_state = "approved"
+      orderJson.fulfillment_type = "pickup"
+      context = {
+        meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+        meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+      }
+
+      const result = await runAuthenticatedQuery(query, context)
+
+      expect(result.me.order.displayTexts).toEqual({
+        title: "Congratulations!",
+        messageType: "APPROVED_PICKUP",
+        wireType: null,
+      })
+    })
+
+    it("returns correct display texts for standard shipping", async () => {
+      orderJson.buyer_state = "approved"
+      orderJson.fulfillment_type = "ship"
+      orderJson.selected_fulfillment_option = "artsy_standard"
+      context = {
+        meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+        meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+      }
+
+      const result = await runAuthenticatedQuery(query, context)
+
+      expect(result.me.order.displayTexts).toEqual({
+        title: "Congratulations!",
+        messageType: "APPROVED_SHIP_STANDARD",
+        wireType: null,
+      })
+    })
+
+    it("returns correct display texts for express shipping", async () => {
+      orderJson.buyer_state = "approved"
+      orderJson.fulfillment_type = "ship"
+      orderJson.selected_fulfillment_option = "artsy_express"
+      context = {
+        meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+        meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+      }
+
+      const result = await runAuthenticatedQuery(query, context)
+
+      expect(result.me.order.displayTexts).toEqual({
+        title: "Congratulations!",
+        messageType: "APPROVED_SHIP_EXPRESS",
+        wireType: null,
+      })
+    })
+
+    it("returns correct display texts for white glove shipping", async () => {
+      orderJson.buyer_state = "approved"
+      orderJson.fulfillment_type = "ship"
+      orderJson.selected_fulfillment_option = "artsy_white_glove"
+      context = {
+        meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+        meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+      }
+
+      const result = await runAuthenticatedQuery(query, context)
+
+      expect(result.me.order.displayTexts).toEqual({
+        title: "Congratulations!",
+        messageType: "APPROVED_SHIP_WHITE_GLOVE",
+        wireType: null,
+      })
+    })
+
+    it("returns correct display texts for default shipping", async () => {
+      orderJson.buyer_state = "approved"
+      orderJson.fulfillment_type = "ship"
+      orderJson.selected_fulfillment_option = "other"
+      context = {
+        meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+        meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+      }
+
+      const result = await runAuthenticatedQuery(query, context)
+
+      expect(result.me.order.displayTexts).toEqual({
+        title: "Congratulations!",
+        messageType: "APPROVED_SHIP",
+        wireType: null,
+      })
+    })
+  })
+
+  describe("buyer_state: shipped", () => {
+    it("returns correct display texts", async () => {
+      orderJson.buyer_state = "shipped"
+      context = {
+        meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+        meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+      }
+
+      const result = await runAuthenticatedQuery(query, context)
+
+      expect(result.me.order.displayTexts).toEqual({
+        title: "Good news, your order has shipped!",
+        messageType: "SHIPPED",
+        wireType: null,
+      })
+    })
+  })
+
+  describe("buyer_state: completed", () => {
+    it("returns correct display texts for pickup", async () => {
+      orderJson.buyer_state = "completed"
+      orderJson.fulfillment_type = "pickup"
+      context = {
+        meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+        meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+      }
+
+      const result = await runAuthenticatedQuery(query, context)
+
+      expect(result.me.order.displayTexts).toEqual({
+        title: "Your order has been picked up",
+        messageType: "COMPLETED_PICKUP",
+        wireType: null,
+      })
+    })
+
+    it("returns correct display texts for shipping", async () => {
+      orderJson.buyer_state = "completed"
+      orderJson.fulfillment_type = "ship"
+      context = {
+        meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+        meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+      }
+
+      const result = await runAuthenticatedQuery(query, context)
+
+      expect(result.me.order.displayTexts).toEqual({
+        title: "Your order has been delivered",
+        messageType: "COMPLETED_SHIP",
+        wireType: null,
+      })
+    })
+  })
+
+  describe("buyer_state: canceled_and_refunded", () => {
+    it("returns correct display texts", async () => {
+      orderJson.buyer_state = "canceled_and_refunded"
+      context = {
+        meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+        meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+      }
+
+      const result = await runAuthenticatedQuery(query, context)
+
+      expect(result.me.order.displayTexts).toEqual({
+        title: "Your order was canceled",
+        messageType: "CANCELLED_ORDER",
+        wireType: null,
+      })
+    })
+  })
+
+  describe("unknown buyer_state", () => {
+    it("returns default display texts", async () => {
+      orderJson.buyer_state = "unknown_state"
+      context = {
+        meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+        meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+      }
+
+      const result = await runAuthenticatedQuery(query, context)
+
+      expect(result.me.order.displayTexts).toEqual({
+        title: "Your order",
+        messageType: "UNKNOWN",
+        wireType: null,
+      })
+    })
+  })
+})

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -62,7 +62,6 @@ describe("Me", () => {
               code
               displayTexts {
                 title
-                message
                 messageType
               }
 
@@ -143,8 +142,6 @@ describe("Me", () => {
         buyerStateExpiresAt: "January 1, 2035 19:00 EST",
         displayTexts: {
           title: "Congratulations!",
-          message:
-            "Your order has been confirmed. Thank you for your purchase.<br/><br/>You will be notified when the work has shipped, typically within 5-7 business days.<br/>You can <a href='#' data-link='contact-gallery'>contact the gallery</a> with any questions about your order.",
           messageType: "APPROVED_SHIP",
         },
         mode: "BUY",

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -63,6 +63,7 @@ describe("Me", () => {
               displayTexts {
                 title
                 messageType
+                wireType
               }
 
               fulfillmentOptions {
@@ -143,6 +144,7 @@ describe("Me", () => {
         displayTexts: {
           title: "Congratulations!",
           messageType: "APPROVED_SHIP",
+          wireType: null,
         },
         mode: "BUY",
         source: "ARTWORK_PAGE",

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -60,10 +60,10 @@ describe("Me", () => {
               }
               buyerStateExpiresAt
               code
+              currencyCode
               displayTexts {
                 title
                 messageType
-                wireType
               }
 
               fulfillmentOptions {
@@ -144,11 +144,11 @@ describe("Me", () => {
         displayTexts: {
           title: "Congratulations!",
           messageType: "APPROVED_SHIP",
-          wireType: null,
         },
         mode: "BUY",
         source: "ARTWORK_PAGE",
         code: "order-code",
+        currencyCode: "USD",
         availableShippingCountries: ["US", "JP"],
         buyerTotal: {
           display: "US$5,000",

--- a/src/schema/v2/order/types/DisplayTexts.ts
+++ b/src/schema/v2/order/types/DisplayTexts.ts
@@ -7,9 +7,6 @@ import {
 } from "graphql"
 import type { ResolverContext } from "types/graphql"
 import { OrderJSON } from "./exchangeJson"
-import { formatMarkdownValue } from "../../fields/markdown"
-import { FormatEnums } from "../../input_fields/format"
-import moment from "moment-timezone"
 
 const DisplayTextsMessageTypeEnum = new GraphQLEnumType({
   name: "DisplayTextsMessageTypeEnum",
@@ -74,20 +71,6 @@ const DisplayTextsType = new GraphQLObjectType<any, ResolverContext>({
       type: new GraphQLNonNull(GraphQLString),
       description: "Text to display as a first message on the page (header)",
     },
-    message: {
-      type: GraphQLString,
-      description: "Fomatted full message text for the order",
-      args: {
-        format: {
-          type: FormatEnums,
-          defaultValue: "markdown",
-        },
-      },
-      resolve: ({ message }, { format }) => {
-        if (!message) return null
-        return formatMarkdownValue(message, format)
-      },
-    },
     messageType: {
       type: new GraphQLNonNull(DisplayTextsMessageTypeEnum),
       description:
@@ -103,57 +86,25 @@ export const DisplayTexts: GraphQLFieldConfig<OrderJSON, ResolverContext> = {
   resolve: (order) => resolveDisplayTexts(order),
 }
 
-const formatMessage = (parts: string[], joinWith = "<br/><br/>") =>
-  parts.join(joinWith)
-
 const resolveDisplayTexts = (order: OrderJSON) => {
   const isBuyOrder = order.mode === "buy" ? true : false
   const isPickup = order.fulfillment_type == "pickup"
-  const stateExpireTime =
-    order.buyer_state_expires_at && moment.tz(order.buyer_state_expires_at)
-  const formattedStateExpireTime =
-    stateExpireTime &&
-    `${stateExpireTime.format("MMM D")}, ${stateExpireTime.format("h:mma z")}`
 
   switch (order.buyer_state) {
     case "submitted": {
-      const messageParts = [
-        "Thank you! Your order is being processed.<br/>You will receive an email shortly with all the details.",
-      ]
-
-      const secondBlockParts: string[] = []
-      formattedStateExpireTime &&
-        secondBlockParts.push(
-          `The gallery will confirm by ${formattedStateExpireTime}.`
-        )
-      secondBlockParts.push(
-        "You can <a href='#' data-link='contact-gallery'>contact the gallery</a> with any questions about your order."
-      )
-
-      messageParts.push(formatMessage(secondBlockParts, "<br/>"))
-
       return {
         title: "Great choice!",
-        message: formatMessage(messageParts),
         messageType: isBuyOrder ? "SUBMITTED_ORDER" : "SUBMITTED_OFFER",
       }
     }
     case "payment_failed":
       return {
         title: "Payment failed",
-        message: formatMessage([
-          `To complete your purchase, please <a href='#' data-link='update-payment'>update your payment details</a> or provide an alternative payment method by ${formattedStateExpireTime}`,
-        ]),
         messageType: "PAYMENT_FAILED",
       }
     case "processing_payment":
       return {
         title: "Your payment is processing",
-        message: formatMessage([
-          `Thank you for your purchase. You will be notified when the work ${
-            isPickup ? "is available for pickup" : "has shipped"
-          }.`,
-        ]),
         messageType: isPickup
           ? "PROCESSING_PAYMENT_PICKUP"
           : "PROCESSING_PAYMENT_SHIP",
@@ -161,65 +112,33 @@ const resolveDisplayTexts = (order: OrderJSON) => {
     case "processing_offline_payment":
       return {
         title: "Congratulations!",
-        message: formatMessage([
-          "Your order has been confirmed. Thank you for your purchase.",
-          "<b>Please proceed with the wire transfer within 7 days to complete your purchase</b><br/><ol><li>Find the total amount due and Artsy's banking details below.</li><li>Please inform your bank that you are responsible for all wire transfer fees.</li><li>Please make the transfer in the currency displayed on the order breakdown and then email proof of payment to orders@artsy.net.</li></ul>",
-        ]),
         messageType: "PROCESSING_WIRE",
       }
     case "approved": {
       let messageType = "UNKNOWN"
-      const messageParts: string[] = []
 
       if (isPickup) {
-        messageParts.push(
-          "Thank you for your purchase. A specialist will contact you within 2 business days to coordinate pickup.<br/>You can <a href='#' data-link='contact-gallery'>contact the gallery</a> with any questions about your order."
-        )
         messageType = "APPROVED_PICKUP"
       } else {
-        messageParts.push(
-          "Your order has been confirmed. Thank you for your purchase."
-        )
-
         if (order.selected_fulfillment_option == "artsy_express") {
-          messageParts.push(
-            "Your order will be processed and packaged, and you will be notified once it ships.<br/>Once shipped, your order will be delivered in 2 business days."
-          )
           messageType = "APPROVED_SHIP_EXPRESS"
         } else if (order.selected_fulfillment_option == "artsy_standard") {
-          messageParts.push(
-            "Your order will be processed and packaged, and you will be notified once it ships.<br/>Once shipped, your order will be delivered in 3-5 business days."
-          )
           messageType = "APPROVED_SHIP_STANDARD"
         } else if (order.selected_fulfillment_option == "artsy_white_glove") {
-          messageParts.push(
-            "Once shipped, you will receive a notification and further details.<br/>You can contact <a href='#' data-link='contact-orders'>orders@artsy.net</a> with any questions."
-          )
           messageType = "APPROVED_SHIP_WHITE_GLOVE"
         } else {
-          messageParts.push(
-            "You will be notified when the work has shipped, typically within 5-7 business days.<br/>You can <a href='#' data-link='contact-gallery'>contact the gallery</a> with any questions about your order."
-          )
           messageType = "APPROVED_SHIP"
         }
       }
 
       return {
         title: "Congratulations!",
-        message: formatMessage(messageParts),
         messageType: messageType,
       }
     }
     case "shipped": {
-      const messageParts = ["Your work is on its way."]
-      // TODO: add shipping info when present
-      messageParts.push(
-        "This artwork will be added to your Collection on Artsy. You can view and manage all your artworks on the Artsy app, available in the <a href='#' data-link='apple-store'>Apple App Store</a> and <a href='#' data-link='google-store'>Google Play Store.</a>"
-      )
-
       return {
         title: "Good news, your order has shipped!",
-        message: formatMessage(messageParts),
         messageType: "SHIPPED",
       }
     }
@@ -228,17 +147,11 @@ const resolveDisplayTexts = (order: OrderJSON) => {
         title: isPickup
           ? "Your order has been picked up"
           : "Your order has been delivered",
-        message: formatMessage([
-          "We hope you love your purchase! Your feedback is valuable—share any thoughts with us at <a href='#' data-link='contact-orders'>orders@artsy.net.</a>",
-          "This artwork will be added to your Collection on Artsy. You can view and manage all your artworks on the Artsy app, available in the <a href='#' data-link='apple-store'>Apple App Store</a> and <a href='#' data-link='google-store'>Google Play Store.</a>",
-        ]),
         messageType: isPickup ? "COMPLETED_PICKUP" : "COMPLETED_SHIP",
       }
     case "canceled_and_refunded":
       return {
         title: "Your order was canceled",
-        message:
-          "You can contact <a href='#' data-link='contact-orders'>orders@artsy.net</a> with any questions.",
         messageType: "CANCELLED_ORDER",
       }
     default:

--- a/src/schema/v2/order/types/DisplayTexts.ts
+++ b/src/schema/v2/order/types/DisplayTexts.ts
@@ -62,21 +62,6 @@ const DisplayTextsMessageTypeEnum = new GraphQLEnumType({
   },
 })
 
-const DisplayTextsWireTypeEnum = new GraphQLEnumType({
-  name: "DisplayTextsWireTypeEnum",
-  values: {
-    WIRE_GBP: {
-      value: "WIRE_GBP",
-    },
-    WIRE_EUR: {
-      value: "WIRE_EUR",
-    },
-    WIRE_USD: {
-      value: "WIRE_USD",
-    },
-  },
-})
-
 const DisplayTextsType = new GraphQLObjectType<any, ResolverContext>({
   name: "DisplayTexts",
   description:
@@ -91,11 +76,6 @@ const DisplayTextsType = new GraphQLObjectType<any, ResolverContext>({
       description:
         "Granular order states specific type that should be directly interpreted by clients",
     },
-    wireType: {
-      type: DisplayTextsWireTypeEnum,
-      description:
-        "Wire specific type that specifies which wire details to use",
-    },
   },
 })
 
@@ -109,7 +89,6 @@ export const DisplayTexts: GraphQLFieldConfig<OrderJSON, ResolverContext> = {
 const resolveDisplayTexts = (order: OrderJSON) => {
   const isBuyOrder = order.mode === "buy" ? true : false
   const isPickup = order.fulfillment_type == "pickup"
-  const currencyCode = order.currency_code
 
   switch (order.buyer_state) {
     case "submitted": {
@@ -130,19 +109,11 @@ const resolveDisplayTexts = (order: OrderJSON) => {
           ? "PROCESSING_PAYMENT_PICKUP"
           : "PROCESSING_PAYMENT_SHIP",
       }
-    case "processing_offline_payment": {
-      let wireType = "WIRE_USD"
-      if (currencyCode === "GBP") {
-        wireType = "WIRE_GBP"
-      } else if (currencyCode == "EUR") {
-        wireType = "WIRE_EUR"
-      }
+    case "processing_offline_payment":
       return {
         title: "Congratulations!",
         messageType: "PROCESSING_WIRE",
-        wireType: wireType,
       }
-    }
     case "approved": {
       let messageType = "UNKNOWN"
 

--- a/src/schema/v2/order/types/DisplayTexts.ts
+++ b/src/schema/v2/order/types/DisplayTexts.ts
@@ -62,6 +62,21 @@ const DisplayTextsMessageTypeEnum = new GraphQLEnumType({
   },
 })
 
+const DisplayTextsWireTypeEnum = new GraphQLEnumType({
+  name: "DisplayTextsWireTypeEnum",
+  values: {
+    WIRE_GBP: {
+      value: "WIRE_GBP",
+    },
+    WIRE_EUR: {
+      value: "WIRE_EUR",
+    },
+    WIRE_USD: {
+      value: "WIRE_USD",
+    },
+  },
+})
+
 const DisplayTextsType = new GraphQLObjectType<any, ResolverContext>({
   name: "DisplayTexts",
   description:
@@ -76,6 +91,11 @@ const DisplayTextsType = new GraphQLObjectType<any, ResolverContext>({
       description:
         "Granular order states specific type that should be directly interpreted by clients",
     },
+    wireType: {
+      type: DisplayTextsWireTypeEnum,
+      description:
+        "Wire specific type that specifies which wire details to use",
+    },
   },
 })
 
@@ -89,6 +109,7 @@ export const DisplayTexts: GraphQLFieldConfig<OrderJSON, ResolverContext> = {
 const resolveDisplayTexts = (order: OrderJSON) => {
   const isBuyOrder = order.mode === "buy" ? true : false
   const isPickup = order.fulfillment_type == "pickup"
+  const currencyCode = order.currency_code
 
   switch (order.buyer_state) {
     case "submitted": {
@@ -109,11 +130,19 @@ const resolveDisplayTexts = (order: OrderJSON) => {
           ? "PROCESSING_PAYMENT_PICKUP"
           : "PROCESSING_PAYMENT_SHIP",
       }
-    case "processing_offline_payment":
+    case "processing_offline_payment": {
+      let wireType = "WIRE_USD"
+      if (currencyCode === "GBP") {
+        wireType = "WIRE_GBP"
+      } else if (currencyCode == "EUR") {
+        wireType = "WIRE_EUR"
+      }
       return {
         title: "Congratulations!",
         messageType: "PROCESSING_WIRE",
+        wireType: wireType,
       }
+    }
     case "approved": {
       let messageType = "UNKNOWN"
 
@@ -156,7 +185,7 @@ const resolveDisplayTexts = (order: OrderJSON) => {
       }
     default:
       return {
-        titlet: "Your order",
+        title: "Your order",
         messageType: "UNKNOWN",
       }
   }

--- a/src/schema/v2/order/types/sharedOrderTypes.ts
+++ b/src/schema/v2/order/types/sharedOrderTypes.ts
@@ -285,6 +285,11 @@ export const OrderType = new GraphQLObjectType<OrderJSON, ResolverContext>({
       description: "Order code",
       resolve: ({ code }) => code,
     },
+    currencyCode: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "Currency code",
+      resolve: ({ currency_code }) => currency_code,
+    },
     displayTexts: DisplayTexts,
     fulfillmentDetails: {
       type: FulfillmentDetailsType,


### PR DESCRIPTION
Unfortunately looks like sharing html straight out of MP for both Force and Eigen proved difficult. Would still require significant client code to format and interpret it properly and might make tracking and proper formatting more complicated.

So ended up creating the very 'custom' `messageType` here that will be mapped 1x1 to the view variations on client. And refactored it for Force.

Nothing else uses this `message` field so cleaning it up here to keep things simpler.