### PR TITLE
chore: use a non-ES loader for a simple request to filterArtworksConnection from CMS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,7 @@ const graphqlServer = graphqlHTTP((req, res, params) => {
   const xImpersonateUserID = req.headers["x-impersonate-user-id"] as
     | string
     | undefined
-
+  const isCMSRequest = !!(req.headers["x-cms-request"] == "true")
   const ipAddress = requestIPAddress(req)
 
   const { requestIDs } = res.locals
@@ -194,6 +194,7 @@ const graphqlServer = graphqlHTTP((req, res, params) => {
     appToken,
     ipAddress,
     xImpersonateUserID,
+    isCMSRequest,
   }
 
   const validationRules = [

--- a/src/types/graphql.d.ts
+++ b/src/types/graphql.d.ts
@@ -30,6 +30,7 @@ export interface ResolverContextValues {
 
   ipAddress: string
   xImpersonateUserID?: string
+  isCMSRequest: boolean
 }
 
 export type ResolverContext = ResolverContextValues &


### PR DESCRIPTION
Going off of some discussions in Slack around ElasticSearch stability, and noticing that some filters/combinations can be served by our non-ES endpoint - would that work better?

The resolver here is a good place to encapsulate that complexity - 'picking' which loader to use.

I decided to focus just on the initial screen partners see at /artworks (as well as paging through that) - when adjusting a sort, filter, search, etc. - we would fall back to the ES endpoint as usual.

One observation is that this endpoint feels like it could be a bit slower - but that might just be my local Metaphysics.

Another observation is that the code is kind of brittle/complex - but _maybe_ this pattern is ok and we can keep iterating?