### PR TITLE
refactor: always use Vortex's app token

### DIFF
--- a/src/lib/apis/vortex.ts
+++ b/src/lib/apis/vortex.ts
@@ -7,7 +7,8 @@ const { VORTEX_API_BASE, VORTEX_TOKEN } = config
 
 export const vortex = (path, accessToken, fetchOptions: any = {}) => {
   const headers = { Accept: "application/json" }
-  const token = accessToken || fetchOptions.appToken || VORTEX_TOKEN
+  // NOTE: we use the Vortex token instead of fetchOptions.appToken
+  const token = accessToken || VORTEX_TOKEN
 
   assign(headers, { Authorization: `Bearer ${token}` })
 


### PR DESCRIPTION
This PR follows https://github.com/artsy/force/pull/15609 and ensures that we always use the `VORTEX_TOKEN`. 