### PR TITLE
chore: allow specifying an artwork import to be parsed with AI

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8747,6 +8747,7 @@ type CreateArtworkImportFailure {
 input CreateArtworkImportInput {
   clientMutationId: String
   fileName: String
+  parseWithAI: Boolean
   partnerID: String!
   s3Bucket: String!
   s3Key: String!

--- a/src/schema/v2/ArtworkImport/createArtworkImportMutation.ts
+++ b/src/schema/v2/ArtworkImport/createArtworkImportMutation.ts
@@ -3,6 +3,7 @@ import {
   GraphQLObjectType,
   GraphQLUnionType,
   GraphQLNonNull,
+  GraphQLBoolean,
 } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 import { ResolverContext } from "types/graphql"
@@ -58,6 +59,9 @@ export const CreateArtworkImportMutation = mutationWithClientMutationId<
     fileName: {
       type: GraphQLString,
     },
+    parseWithAI: {
+      type: GraphQLBoolean,
+    },
   },
   outputFields: {
     artworkImportOrError: {
@@ -75,6 +79,7 @@ export const CreateArtworkImportMutation = mutationWithClientMutationId<
       s3_bucket: args.s3Bucket,
       s3_key: args.s3Key,
       file_name: args.fileName,
+      parse_with_ai: args.parseWithAI,
     }
 
     try {


### PR DESCRIPTION
For an uploaded file, if you pass this argument in - the resulting created import and rows will be the AI-parsed output of the file.

So, this supports a UI where a user can choose whether to upload a 'standard' file or upload a file with 'Let us parse it for you' style CTA.