### PR TITLE
chore: add the type for fulfillment_option and refactor a bit how it's used

### DIFF
--- a/src/schema/v2/order/__tests__/DisplayTexts.test.ts
+++ b/src/schema/v2/order/__tests__/DisplayTexts.test.ts
@@ -151,7 +151,10 @@ describe("DisplayTexts", () => {
     it("returns correct display texts for standard shipping", async () => {
       orderJson.buyer_state = "approved"
       orderJson.fulfillment_type = "ship"
-      orderJson.selected_fulfillment_option = "artsy_standard"
+      orderJson.selected_fulfillment_option = {
+        type: "artsy_standard",
+        amount_minor: 2344,
+      }
       context = {
         meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
         meOrderLoader: jest.fn().mockResolvedValue(orderJson),
@@ -168,7 +171,10 @@ describe("DisplayTexts", () => {
     it("returns correct display texts for express shipping", async () => {
       orderJson.buyer_state = "approved"
       orderJson.fulfillment_type = "ship"
-      orderJson.selected_fulfillment_option = "artsy_express"
+      orderJson.selected_fulfillment_option = {
+        type: "artsy_express",
+        amount_minor: 123,
+      }
       context = {
         meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
         meOrderLoader: jest.fn().mockResolvedValue(orderJson),
@@ -185,7 +191,10 @@ describe("DisplayTexts", () => {
     it("returns correct display texts for white glove shipping", async () => {
       orderJson.buyer_state = "approved"
       orderJson.fulfillment_type = "ship"
-      orderJson.selected_fulfillment_option = "artsy_white_glove"
+      orderJson.selected_fulfillment_option = {
+        type: "artsy_white_glove",
+        amount_minor: 456,
+      }
       context = {
         meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
         meOrderLoader: jest.fn().mockResolvedValue(orderJson),
@@ -202,7 +211,7 @@ describe("DisplayTexts", () => {
     it("returns correct display texts for default shipping", async () => {
       orderJson.buyer_state = "approved"
       orderJson.fulfillment_type = "ship"
-      orderJson.selected_fulfillment_option = "other"
+      orderJson.selected_fulfillment_option = { type: "other", amount_minor: 0 }
       context = {
         meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
         meOrderLoader: jest.fn().mockResolvedValue(orderJson),

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -749,7 +749,10 @@ describe("Me", () => {
         it("returns a shipping line for type pickup", async () => {
           orderJson.items_total_cents = 500000
           orderJson.shipping_total_cents = 0
-          orderJson.fulfillment_options = [{ type: "pickup", selected: true }]
+          orderJson.selected_fulfillment_option = {
+            type: "pickup",
+            selected: true,
+          }
           context = {
             meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
             meOrderLoader: jest.fn().mockResolvedValue(orderJson),
@@ -784,9 +787,10 @@ describe("Me", () => {
         it("returns the correct display name for shipping line with free international shipping", async () => {
           orderJson.items_total_cents = 500000
           orderJson.shipping_total_cents = 0
-          orderJson.fulfillment_options = [
-            { type: "international_flat", selected: true },
-          ]
+          orderJson.selected_fulfillment_option = {
+            type: "international_flat",
+            selected: true,
+          }
           context = {
             meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
             meOrderLoader: jest.fn().mockResolvedValue(orderJson),
@@ -820,9 +824,10 @@ describe("Me", () => {
         it("returns the correct display name for free domestic shipping", async () => {
           orderJson.items_total_cents = 500000
           orderJson.shipping_total_cents = 0
-          orderJson.fulfillment_options = [
-            { type: "domestic_flat", selected: true },
-          ]
+          orderJson.selected_fulfillment_option = {
+            type: "domestic_flat",
+            selected: true,
+          }
           context = {
             meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
             meOrderLoader: jest.fn().mockResolvedValue(orderJson),
@@ -856,9 +861,10 @@ describe("Me", () => {
         it("returns the correct display name for flat fee domestic shipping", async () => {
           orderJson.items_total_cents = 500000
           orderJson.shipping_total_cents = 420
-          orderJson.fulfillment_options = [
-            { type: "domestic_flat", selected: true },
-          ]
+          orderJson.selected_fulfillment_option = {
+            type: "domestic_flat",
+            selected: true,
+          }
           context = {
             meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
             meOrderLoader: jest.fn().mockResolvedValue(orderJson),
@@ -892,9 +898,11 @@ describe("Me", () => {
         it("returns the correct display name for flat fee international shipping", async () => {
           orderJson.items_total_cents = 500000
           orderJson.shipping_total_cents = 420
-          orderJson.fulfillment_options = [
-            { type: "international_flat", selected: true },
-          ]
+          orderJson.selected_fulfillment_option = {
+            type: "international_flat",
+            selected: true,
+          }
+
           context = {
             meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
             meOrderLoader: jest.fn().mockResolvedValue(orderJson),

--- a/src/schema/v2/order/__tests__/support.ts
+++ b/src/schema/v2/order/__tests__/support.ts
@@ -34,6 +34,11 @@ export const baseOrderJson = {
     { type: "pickup", amount_minor: 0 },
     { type: "domestic_flat", amount_minor: 10000, selected: true },
   ],
+  selected_fulfillment_option: {
+    type: "domestic_flat",
+    amount_minor: 10000,
+    selected: true,
+  },
 }
 
 export const baseArtwork = {

--- a/src/schema/v2/order/types/DisplayTexts.ts
+++ b/src/schema/v2/order/types/DisplayTexts.ts
@@ -120,11 +120,15 @@ const resolveDisplayTexts = (order: OrderJSON) => {
       if (isPickup) {
         messageType = "APPROVED_PICKUP"
       } else {
-        if (order.selected_fulfillment_option == "artsy_express") {
+        if (order.selected_fulfillment_option?.type == "artsy_express") {
           messageType = "APPROVED_SHIP_EXPRESS"
-        } else if (order.selected_fulfillment_option == "artsy_standard") {
+        } else if (
+          order.selected_fulfillment_option?.type == "artsy_standard"
+        ) {
           messageType = "APPROVED_SHIP_STANDARD"
-        } else if (order.selected_fulfillment_option == "artsy_white_glove") {
+        } else if (
+          order.selected_fulfillment_option?.type == "artsy_white_glove"
+        ) {
           messageType = "APPROVED_SHIP_WHITE_GLOVE"
         } else {
           messageType = "APPROVED_SHIP"

--- a/src/schema/v2/order/types/PricingBreakdownLines.ts
+++ b/src/schema/v2/order/types/PricingBreakdownLines.ts
@@ -11,7 +11,7 @@ import {
   resolveMinorAndCurrencyFieldsToMoney,
 } from "schema/v2/fields/money"
 import type { ResolverContext } from "types/graphql"
-import { OrderJSON } from "./exchangeJson"
+import { OrderJSON, FulfillmentOptionJson } from "./exchangeJson"
 
 const COPY = {
   subtotal: { displayName: "Subtotal" },
@@ -97,9 +97,9 @@ export const PricingBreakdownLines: GraphQLFieldConfig<
       amount: itemsTotalCents && resolveMoney(itemsTotalCents),
     }
 
-    const selectedFulfillment = order.fulfillment_options.find(
-      (option) => option.selected
-    )
+    const selectedFulfillment: FulfillmentOptionJson = order.selected_fulfillment_option || {
+      type: "shipping_tbd",
+    }
 
     let shippingLine: ResolvedPriceLineData | null = null
     const hasShippingTotal = shippingTotalCents != null

--- a/src/schema/v2/order/types/exchangeJson.ts
+++ b/src/schema/v2/order/types/exchangeJson.ts
@@ -2,6 +2,19 @@
  * The order json as received from the exchange REST API.
  * Used to nudge our our OrderType resolvers
  */
+export interface FulfillmentOptionJson {
+  type:
+    | "domestic_flat"
+    | "international_flat"
+    | "pickup"
+    | "artsy_standard"
+    | "artsy_express"
+    | "artsy_white_glove"
+    | "shipping_tbd"
+  amount_minor?: number
+  selected?: boolean
+  shipping_quote_id?: string
+}
 export interface OrderJSON {
   id: string
   code: string
@@ -29,26 +42,8 @@ export interface OrderJSON {
   buyer_state?: string
   buyer_state_expires_at?: string
   fulfillment_type?: string
-  fulfillment_options: Array<{
-    type:
-      | "domestic_flat"
-      | "international_flat"
-      | "pickup"
-      | "artsy_standard"
-      | "artsy_express"
-      | "artsy_white_glove"
-      | "shipping_tbd"
-    amount_minor: number
-    selected?: boolean
-  }>
-  selected_fulfillment_option?:
-    | "domestic_flat"
-    | "international_flat"
-    | "pickup"
-    | "artsy_standard"
-    | "artsy_express"
-    | "artsy_white_glove"
-    | "shipping_tbd"
+  fulfillment_options: Array<FulfillmentOptionJson>
+  selected_fulfillment_option?: FulfillmentOptionJson
   line_items: Array<{
     id: string
     artwork_id: string


### PR DESCRIPTION
Discovered a small bug in displayTexts that was from improper expectation for `selected_fulfillment_option` type. So updating here.