### PR TITLE
feat: only propagate vortex token if no subject application

### DIFF
--- a/src/lib/apis/vortex.ts
+++ b/src/lib/apis/vortex.ts
@@ -2,12 +2,14 @@ import urljoin from "url-join"
 import { assign } from "lodash"
 import fetch from "./fetch"
 import config from "config"
+import { decodeUnverifiedJWT } from "lib/decodeUnverifiedJWT"
 
 const { VORTEX_API_BASE, VORTEX_TOKEN } = config
 
 export const vortex = (path, accessToken, fetchOptions: any = {}) => {
   const headers = { Accept: "application/json" }
-  const token = accessToken || fetchOptions.appToken || VORTEX_TOKEN
+  const token =
+    accessToken || tokenIfPropagatable(fetchOptions.appToken) || VORTEX_TOKEN
 
   assign(headers, { Authorization: `Bearer ${token}` })
 
@@ -15,4 +17,13 @@ export const vortex = (path, accessToken, fetchOptions: any = {}) => {
     urljoin(VORTEX_API_BASE, path),
     assign({}, fetchOptions, { headers })
   )
+}
+
+export const tokenIfPropagatable = (token) => {
+  const decoded = decodeUnverifiedJWT(token)
+  if (!decoded?.subject_application) {
+    return null
+  }
+
+  return token
 }

--- a/src/lib/apis/vortex.ts
+++ b/src/lib/apis/vortex.ts
@@ -7,8 +7,7 @@ const { VORTEX_API_BASE, VORTEX_TOKEN } = config
 
 export const vortex = (path, accessToken, fetchOptions: any = {}) => {
   const headers = { Accept: "application/json" }
-  // NOTE: we use the Vortex token instead of fetchOptions.appToken
-  const token = accessToken || VORTEX_TOKEN
+  const token = accessToken || fetchOptions.appToken || VORTEX_TOKEN
 
   assign(headers, { Authorization: `Bearer ${token}` })
 

--- a/src/lib/stitching/vortex/link.ts
+++ b/src/lib/stitching/vortex/link.ts
@@ -9,6 +9,7 @@ import { responseLoggerLink } from "../logLinkMiddleware"
 import { setContext } from "apollo-link-context"
 import { headers as requestIDHeaders } from "lib/requestIDs"
 import { ResolverContext } from "types/graphql"
+import { tokenIfPropagatable } from "lib/apis/vortex"
 
 const { VORTEX_API_BASE, VORTEX_TOKEN } = config
 
@@ -25,7 +26,7 @@ export const createVortexLink = () => {
         ...(graphqlContext && requestIDHeaders(graphqlContext.requestIDs)),
       }
 
-      if (tokenLoader && !graphqlContext.appToken) {
+      if (tokenLoader && !tokenIfPropagatable(graphqlContext.appToken)) {
         return tokenLoader().then(({ token }) => {
           return {
             headers: Object.assign(headers, {
@@ -35,7 +36,7 @@ export const createVortexLink = () => {
         })
       }
 
-      const token = graphqlContext.appToken || VORTEX_TOKEN
+      const token = tokenIfPropagatable(graphqlContext.appToken) || VORTEX_TOKEN
       const bearer = `Bearer ${token}`
 
       return {


### PR DESCRIPTION
This PR does two things:

1. Reverts #6769
2. adds a check for `vortex` to only propagate the given application token if it includes subject application. Otherwise, it will use the fallback `VORTEX_TOKEN`. 

This allows us to support both the `force` use case and braze use case. 

co-authored w/ @mzikherman 