### PR TITLE
refactor: fallback to vortex token based on role

### DIFF
--- a/src/lib/apis/vortex.ts
+++ b/src/lib/apis/vortex.ts
@@ -21,9 +21,16 @@ export const vortex = (path, accessToken, fetchOptions: any = {}) => {
 
 export const tokenIfPropagatable = (token) => {
   const decoded = decodeUnverifiedJWT(token)
-  if (!decoded?.subject_application) {
+
+  const roles = decoded?.roles.split(",")
+  const isEmailProvider = roles?.includes("email_provider")
+
+  // If the token doesn't have the email provider role,
+  // we want to fallback to the Vortex token.
+  if (!isEmailProvider) {
     return null
   }
 
+  // Return the token with the email provider role
   return token
 }


### PR DESCRIPTION
This PR patches #6772 . 

Looks like we inspected an incorrect token testing and `force`'s  does include a subject application so we need to fallback on another criteria. In this case, we will use the `email_provider` role. 