### PR TITLE
chore: allow requesting totalListPrice for meOrder

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16530,6 +16530,9 @@ type Order {
 
   # The total amount for tax
   taxTotal: Money
+
+  # The total list price of items (accounting for limited partner offer if applicable)
+  totalListPrice: Money
 }
 
 enum OrderCreditCardWalletTypeEnum {

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -25,6 +25,7 @@ describe("Me", () => {
       seller_type: "gallery",
       buyer_total_cents: null,
       items_total_cents: 500000,
+      total_list_price_cents: 700000,
       shipping_total_cents: 2000,
       buyer_phone_number: "123-456-7890",
       buyer_phone_number_country_code: "US",
@@ -96,6 +97,11 @@ describe("Me", () => {
                 display
                 minor
               }
+              totalListPrice {
+                currencyCode
+                display
+                minor
+              }
               lineItems {
                 artwork {
                   title
@@ -157,6 +163,11 @@ describe("Me", () => {
           currencyCode: "USD",
           display: "US$5,000",
           minor: 500000,
+        },
+        totalListPrice: {
+          currencyCode: "USD",
+          display: "US$7,000",
+          minor: 700000,
         },
         shippingTotal: {
           minor: 2000,

--- a/src/schema/v2/order/types/exchangeJson.ts
+++ b/src/schema/v2/order/types/exchangeJson.ts
@@ -31,6 +31,7 @@ export interface OrderJSON {
   buyer_total_cents?: number
   shipping_total_cents?: number
   items_total_cents?: number
+  total_list_price_cents?: number
   shipping_name?: string
   shipping_address_line1?: string
   shipping_address_line2?: string

--- a/src/schema/v2/order/types/sharedOrderTypes.ts
+++ b/src/schema/v2/order/types/sharedOrderTypes.ts
@@ -418,6 +418,27 @@ export const OrderType = new GraphQLObjectType<OrderJSON, ResolverContext>({
         )
       },
     },
+    totalListPrice: {
+      type: Money,
+      description:
+        "The total list price of items (accounting for limited partner offer if applicable)",
+      resolve: (
+        { total_list_price_cents: minor, currency_code: currencyCode },
+        _args,
+        ctx,
+        _info
+      ) => {
+        if (minor == null || currencyCode == null) {
+          return null
+        }
+        return resolveMinorAndCurrencyFieldsToMoney(
+          { minor, currencyCode },
+          _args,
+          ctx,
+          _info
+        )
+      },
+    },
   },
 })
 


### PR DESCRIPTION
Allow queuing for  totalListPrice on the order. Will be used to display ListPrice for this pr: https://github.com/artsy/force/pull/15612

This value I believe gives us what we want here without looking at underlying artowk/edition_set/list items except for the case where `limited_partner_offer` is present on original artwork. This list price I believe will reflect this original 'partner offer'. Though I think it's valid to display this value as Artwork price in this case?