### PR TITLE
fix: error handling for `bulkUpdateArtworksMetadataMutation` and `ArtsyShippingOptInMutation`

### DIFF
--- a/src/schema/v2/partner/ArtsyShippingOptIn/__tests__/artsyShippingOptInMutation.test.ts
+++ b/src/schema/v2/partner/ArtsyShippingOptIn/__tests__/artsyShippingOptInMutation.test.ts
@@ -1,0 +1,106 @@
+import gql from "lib/gql"
+import { HTTPError } from "lib/HTTPError"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("ArtsyShippingOptInMutation", () => {
+  const mutation = gql`
+    mutation {
+      artsyShippingOptIn(
+        input: {
+          id: "partner123"
+          artsyShippingDomestic: true
+          artsyShippingInternational: false
+        }
+      ) {
+        ArtsyShippingOptInOrError {
+          __typename
+          ... on ArtsyShippingOptInMutationSuccess {
+            updatedPartnerArtworks {
+              count
+              ids
+            }
+            skippedPartnerArtworks {
+              count
+              ids
+            }
+          }
+          ... on ArtsyShippingOptInMutationFailure {
+            mutationError {
+              error
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("successfully updates partner artworks shipping options", async () => {
+    const context = {
+      artsyShippingOptInLoader: jest.fn().mockResolvedValue({
+        success: 10,
+        errors: {
+          count: 2,
+          ids: ["artwork1", "artwork2"],
+        },
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(context.artsyShippingOptInLoader).toHaveBeenCalledWith(
+      "partner123",
+      {
+        artsy_shipping_domestic: true,
+        artsy_shipping_international: false,
+      }
+    )
+
+    expect(result).toEqual({
+      artsyShippingOptIn: {
+        ArtsyShippingOptInOrError: {
+          __typename: "ArtsyShippingOptInMutationSuccess",
+          updatedPartnerArtworks: {
+            count: 10,
+            ids: [],
+          },
+          skippedPartnerArtworks: {
+            count: 2,
+            ids: ["artwork1", "artwork2"],
+          },
+        },
+      },
+    })
+  })
+
+  it("throws error when user is not authenticated", async () => {
+    const context = {
+      artsyShippingOptInLoader: undefined,
+    }
+
+    await expect(runAuthenticatedQuery(mutation, context)).rejects.toThrow(
+      "You need to be signed in to perform this action"
+    )
+  })
+
+  it("handles gravity API errors gracefully", async () => {
+    const context = {
+      artsyShippingOptInLoader: () =>
+        Promise.reject(new HTTPError(`Forbidden`, 403, "Gravity Error")),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      artsyShippingOptIn: {
+        ArtsyShippingOptInOrError: {
+          __typename: "ArtsyShippingOptInMutationFailure",
+          mutationError: {
+            error: null,
+            message: "Gravity Error",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/partner/ArtsyShippingOptIn/artsyShippingOptInMutation.ts
+++ b/src/schema/v2/partner/ArtsyShippingOptIn/artsyShippingOptInMutation.ts
@@ -3,16 +3,16 @@ import {
   GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
+  GraphQLObjectType,
   GraphQLString,
+  GraphQLUnionType,
 } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
-import { ResolverContext } from "types/graphql"
 import {
   GravityMutationErrorType,
   formatGravityError,
 } from "lib/gravityErrorHandler"
-import { GraphQLObjectType } from "graphql"
-import { GraphQLUnionType } from "graphql"
+import { ResolverContext } from "types/graphql"
 
 interface Input {
   id: string
@@ -65,7 +65,7 @@ const ArtsyShippingOptInMutationType = new GraphQLUnionType({
     ArtsyShippingOptInMutationFailureType,
   ],
   resolveType: (object) => {
-    if (object.mutationError) {
+    if (object.mutationError || object._type === "GravityMutationError") {
       return ArtsyShippingOptInMutationFailureType
     }
     return ArtsyShippingOptInMutationSuccessType
@@ -97,6 +97,9 @@ export const artsyShippingOptInMutation = mutationWithClientMutationId<
     ArtsyShippingOptInOrError: {
       type: ArtsyShippingOptInMutationType,
       resolve: (result) => {
+        if (result._type === "GravityMutationError") {
+          return result
+        }
         // In the future it could be helpful to have a list of successfully opted in ids, can add this to gravity at a later date
         return {
           updatedPartnerArtworks: { count: result.success, ids: [] },

--- a/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
+++ b/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
@@ -1,4 +1,5 @@
 import gql from "lib/gql"
+import { HTTPError } from "lib/HTTPError"
 import { runAuthenticatedQuery } from "schema/v2/test/utils"
 
 describe("BulkUpdateArtworksMetadataMutation", () => {
@@ -142,5 +143,26 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
         },
       }
     )
+  })
+
+  it("handles gravity API errors gracefully", async () => {
+    const context = {
+      updatePartnerArtworksMetadataLoader: () =>
+        Promise.reject(new HTTPError(`Forbidden`, 403, "Gravity Error")),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      bulkUpdateArtworksMetadata: {
+        bulkUpdateArtworksMetadataOrError: {
+          __typename: "BulkUpdateArtworksMetadataMutationFailure",
+          mutationError: {
+            error: null,
+            message: "Gravity Error",
+          },
+        },
+      },
+    })
   })
 })

--- a/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
@@ -1,21 +1,21 @@
 import {
   GraphQLBoolean,
+  GraphQLFloat,
   GraphQLInputObjectType,
   GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
+  GraphQLObjectType,
   GraphQLString,
-  GraphQLFloat,
+  GraphQLUnionType,
 } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
-import { ResolverContext } from "types/graphql"
 import {
   GravityMutationErrorType,
   formatGravityError,
 } from "lib/gravityErrorHandler"
-import { GraphQLObjectType } from "graphql"
-import { GraphQLUnionType } from "graphql"
 import { Availability } from "schema/v2/types/availability"
+import { ResolverContext } from "types/graphql"
 
 interface Input {
   id: string
@@ -157,7 +157,7 @@ const BulkUpdateArtworksMetadataMutationType = new GraphQLUnionType({
     BulkUpdateArtworksMetadataMutationFailureType,
   ],
   resolveType: (object) => {
-    if (object.mutationError) {
+    if (object.mutationError || object._type === "GravityMutationError") {
       return BulkUpdateArtworksMetadataMutationFailureType
     }
     return BulkUpdateArtworksMetadataMutationSuccessType


### PR DESCRIPTION
Resolges [AMBER-NOTION](https://www.notion.so/artsy/Let-bulkUpdateArtworksMetadata-mutation-fail-when-unauthorized-1ffcab0764a08062abf6f245841706d5?pvs=4)

## Description

This fixes error handling for `bulkUpdateArtworksMetadataMutation` and `ArtsyShippingOptInMutation`. 

### bulkUpdateArtworksMetadataMutation:

**Before:**

<img width="1598" alt="Bildschirmfoto 2025-05-27 um 10 59 42" src="https://github.com/user-attachments/assets/333b7fe7-1084-44fb-9fba-671c16daec80" />

**After:**

<img width="1598" alt="Bildschirmfoto 2025-05-27 um 10 59 06" src="https://github.com/user-attachments/assets/d13b3b01-c1d0-41ca-b64a-3d8077a294cc" />

### ArtsyShippingOptInMutation:

**Before:**

<img width="1596" alt="Bildschirmfoto 2025-05-27 um 11 01 12" src="https://github.com/user-attachments/assets/d73b409e-6010-41c1-b6f0-aee63a99710d" />


**After:**

<img width="1566" alt="Bildschirmfoto 2025-05-27 um 11 01 38" src="https://github.com/user-attachments/assets/cb8f5da7-5815-4d21-bdbe-ebc295de9775" />