### PR TITLE
chore: include metric for edition set

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10726,6 +10726,9 @@ type EditionSet implements Sellable {
 
   # In CMS, has the artwork been marked as BNMO?
   listingOptions: ArtworkListingOptions
+
+  # The unit of length of the edition set, expressed in `in` or `cm`
+  metric: String
   price: String
   priceDisplay: String
   priceListed: Money

--- a/src/schema/v2/edition_set.ts
+++ b/src/schema/v2/edition_set.ts
@@ -177,6 +177,11 @@ export const EditionSetType = new GraphQLObjectType<any, ResolverContext>({
     },
     listingOptions,
     listPrice,
+    metric: {
+      description:
+        "The unit of length of the edition set, expressed in `in` or `cm`",
+      type: GraphQLString,
+    },
     price: {
       type: GraphQLString,
     },


### PR DESCRIPTION
We aren't properly figuring out the `metric` for an edition set currently - let's include that (which we have in the edition set gravity JSON) in the schema.