### PR TITLE
feat(EMI-2486): Order shipment properties with generated tracking URLs

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8616,21 +8616,6 @@ enum ConversationsInputMode {
   USER
 }
 
-# Enum for different courier codes
-enum CourierCode {
-  # DHL Express
-  DHL
-
-  # Federal Express
-  FEDEX
-
-  # United Parcel Service
-  UPS
-
-  # United States Postal Service
-  USPS
-}
-
 type CreateAccountRequestMutationFailure {
   mutationError: GravityMutationError
 }
@@ -10549,6 +10534,21 @@ type Delivery {
     # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String
+}
+
+# Shipment details for an order
+type DeliveryInfo {
+  # The code representing a known courier
+  shipperCode: ShipperCode
+
+  # The carrier handling the shipment as saved on the order (e.g., UPS, FedEx, DHL, USPS)
+  shipperName: String
+
+  # The tracking number for the shipment
+  trackingNumber: String
+
+  # The URL to track the shipment
+  trackingURL: String
 }
 
 type Department {
@@ -16522,6 +16522,9 @@ type Order {
   # Currency code
   currencyCode: String!
 
+  # Details about the shipment of an order
+  deliveryInfo: DeliveryInfo
+
   # Display texts for the order based on its buyer_state and order shipping/payment states
   displayTexts: DisplayTexts!
 
@@ -16554,9 +16557,6 @@ type Order {
 
   # The seller of the order
   seller: SellerType
-
-  # Details about the shipment of an order
-  shipment: Shipment
 
   # Display short version of order's artwork location
   shippingOrigin: String
@@ -21335,19 +21335,19 @@ union SetOrderFulfillmentOptionResponse =
     OrderMutationError
   | OrderMutationSuccess
 
-# Shipment details for an order
-type Shipment {
-  # The carrier handling the shipment as saved on the order (e.g., UPS, FedEx, DHL, USPS)
-  courier: String
+# Enum for different courier codes
+enum ShipperCode {
+  # DHL Express
+  DHL
 
-  # The code representing a known courier
-  courierCode: CourierCode
+  # Federal Express
+  FEDEX
 
-  # The tracking number for the shipment
-  trackingNumber: String
+  # United Parcel Service
+  UPS
 
-  # The URL to track the shipment
-  trackingURL: String
+  # United States Postal Service
+  USPS
 }
 
 # Shipping line

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -8616,6 +8616,21 @@ enum ConversationsInputMode {
   USER
 }
 
+# Enum for different courier codes
+enum CourierCode {
+  # DHL Express
+  DHL
+
+  # Federal Express
+  FEDEX
+
+  # United Parcel Service
+  UPS
+
+  # United States Postal Service
+  USPS
+}
+
 type CreateAccountRequestMutationFailure {
   mutationError: GravityMutationError
 }
@@ -21322,8 +21337,11 @@ union SetOrderFulfillmentOptionResponse =
 
 # Shipment details for an order
 type Shipment {
-  # The carrier handling the shipment (e.g., UPS, FedEx, DHL, USPS)
+  # The carrier handling the shipment as saved on the order (e.g., UPS, FedEx, DHL, USPS)
   courier: String
+
+  # The code representing a known courier
+  courierCode: CourierCode
 
   # The tracking number for the shipment
   trackingNumber: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16540,6 +16540,9 @@ type Order {
   # The seller of the order
   seller: SellerType
 
+  # Details about the shipment of an order
+  shipment: Shipment
+
   # Display short version of order's artwork location
   shippingOrigin: String
 
@@ -21316,6 +21319,18 @@ type Services {
 union SetOrderFulfillmentOptionResponse =
     OrderMutationError
   | OrderMutationSuccess
+
+# Shipment details for an order
+type Shipment {
+  # The carrier handling the shipment (e.g., UPS, FedEx, DHL, USPS)
+  courier: String
+
+  # The tracking number for the shipment
+  trackingNumber: String
+
+  # The URL to track the shipment
+  trackingURL: String
+}
 
 # Shipping line
 type ShippingLine {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -21343,6 +21343,9 @@ enum ShipperCode {
   # Federal Express
   FEDEX
 
+  # Other courier not listed - see shipperName
+  OTHER
+
   # United Parcel Service
   UPS
 

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "relay-runtime": "10.0.1",
     "request": "2.88.2",
     "runtypes": "4.2.0",
+    "ts-tracking-number": "^1.0.17",
     "unleash-client": "^5.5.2",
     "url-join": "4.0.0",
     "uuid": "3.1.0"

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -227,6 +227,41 @@ describe("Me", () => {
       })
     })
 
+    describe("shipment", () => {
+      const query = gql`
+        {
+          me {
+            order(id: "order-id") {
+              shipment {
+                trackingNumber
+                trackingURL
+                courier
+              }
+            }
+          }
+        }
+      `
+
+      it("returns shipment details with partner shipping shape", async () => {
+        orderJson.shipment = {
+          type: "partner_shipping",
+          courier: "USPs",
+          tracking_id: "9405550206217013523037",
+        }
+        context = {
+          meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+          meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+        }
+        const result = await runAuthenticatedQuery(query, context)
+        expect(result.me.order.shipment).toEqual({
+          trackingNumber: "9405550206217013523037",
+          trackingURL:
+            "https://tools.usps.com/go/TrackConfirmAction?tLabels=9405550206217013523037",
+          courier: "USPs",
+        })
+      })
+    })
+
     describe("seller", () => {
       const query = gql`
         query {

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -264,6 +264,48 @@ describe("Me", () => {
           shipperCode: "USPS",
         })
       })
+
+      it("returns a value for an unusual tracking number without erroring", async () => {
+        orderJson.delivery_info = {
+          type: "partner_shipping",
+          shipper_name: "Amazon Logistics",
+          tracking_id: "TBA123456789000",
+        }
+        context = {
+          meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+          meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+        }
+
+        const result = await runAuthenticatedQuery(query, context)
+
+        expect(result.me.order.deliveryInfo).toEqual({
+          trackingNumber: "TBA123456789000",
+          trackingURL: null,
+          shipperName: "Amazon",
+          shipperCode: "OTHER",
+        })
+      })
+
+      it("returns something for an invalid tracking number without erroring", async () => {
+        orderJson.delivery_info = {
+          type: "partner_shipping",
+          shipper_name: "Art handler interns bargain shipping",
+          tracking_id: "I am not a valid tracking number",
+        }
+        context = {
+          meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+          meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+        }
+
+        const result = await runAuthenticatedQuery(query, context)
+
+        expect(result.me.order.deliveryInfo).toEqual({
+          shipperName: "Art handler interns bargain shipping",
+          trackingNumber: "I am not a valid tracking number",
+          trackingURL: null,
+          shipperCode: null,
+        })
+      })
     })
 
     describe("seller", () => {

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -236,6 +236,7 @@ describe("Me", () => {
                 trackingNumber
                 trackingURL
                 courier
+                courierCode
               }
             }
           }
@@ -252,12 +253,15 @@ describe("Me", () => {
           meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
           meOrderLoader: jest.fn().mockResolvedValue(orderJson),
         }
+
         const result = await runAuthenticatedQuery(query, context)
+
         expect(result.me.order.shipment).toEqual({
           trackingNumber: "9405550206217013523037",
           trackingURL:
             "https://tools.usps.com/go/TrackConfirmAction?tLabels=9405550206217013523037",
-          courier: "USPs",
+          courier: "United States Postal Service",
+          courierCode: "USPS",
         })
       })
     })

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -232,11 +232,11 @@ describe("Me", () => {
         {
           me {
             order(id: "order-id") {
-              shipment {
+              deliveryInfo {
                 trackingNumber
                 trackingURL
-                courier
-                courierCode
+                shipperName
+                shipperCode
               }
             }
           }
@@ -244,9 +244,9 @@ describe("Me", () => {
       `
 
       it("returns shipment details with partner shipping shape", async () => {
-        orderJson.shipment = {
+        orderJson.delivery_info = {
           type: "partner_shipping",
-          courier: "USPs",
+          shipper_name: "USPs",
           tracking_id: "9405550206217013523037",
         }
         context = {
@@ -256,12 +256,12 @@ describe("Me", () => {
 
         const result = await runAuthenticatedQuery(query, context)
 
-        expect(result.me.order.shipment).toEqual({
+        expect(result.me.order.deliveryInfo).toEqual({
           trackingNumber: "9405550206217013523037",
           trackingURL:
             "https://tools.usps.com/go/TrackConfirmAction?tLabels=9405550206217013523037",
-          courier: "United States Postal Service",
-          courierCode: "USPS",
+          shipperName: "United States Postal Service",
+          shipperCode: "USPS",
         })
       })
     })

--- a/src/schema/v2/order/types/Shipment.ts
+++ b/src/schema/v2/order/types/Shipment.ts
@@ -1,0 +1,98 @@
+import { GraphQLFieldConfig, GraphQLObjectType, GraphQLString } from "graphql"
+import {
+  getTracking,
+  TrackingNumber,
+  ups,
+  fedex,
+  dhl,
+  usps,
+} from "ts-tracking-number"
+import { OrderJSON } from "./exchangeJson"
+import { ResolverContext } from "types/graphql"
+
+const ShipmentType = new GraphQLObjectType({
+  name: "Shipment",
+  description: "Shipment details for an order",
+  fields: () => ({
+    trackingNumber: {
+      type: GraphQLString,
+      description: "The tracking number for the shipment",
+    },
+    trackingURL: {
+      type: GraphQLString,
+      description: "The URL to track the shipment",
+    },
+    courier: {
+      type: GraphQLString,
+      description:
+        "The carrier handling the shipment (e.g., UPS, FedEx, DHL, USPS)",
+    },
+  }),
+})
+
+export const Shipment: GraphQLFieldConfig<OrderJSON, ResolverContext> = {
+  type: ShipmentType,
+  description: "Details about the shipment of an order",
+  resolve: (order: OrderJSON) => {
+    return resolveShipment(order)
+  },
+}
+
+const resolveShipment = (order: OrderJSON) => {
+  if (!order.shipment) {
+    return null
+  }
+
+  const { tracking_id: trackingNumber, courier } = order.shipment
+  let trackingURL: string | null
+
+  const tracking = guessTracking(courier, trackingNumber)
+  const urlTemplate = tracking?.trackingUrl
+
+  if (urlTemplate && tracking.trackingNumber) {
+    // If urlTemplate is present it is in the format https://tools.usps.com/go/TrackConfirmAction?tLabels=%s
+    // so we just need to format that into place using
+    trackingURL = urlTemplate.replace(
+      "%s",
+      encodeURIComponent(tracking.trackingNumber)
+    )
+  } else {
+    trackingURL = order.shipment.tracking_url ?? null
+  }
+
+  return {
+    courier,
+    trackingNumber,
+    trackingURL,
+  }
+}
+
+const guessTracking = (
+  courierRaw?: string,
+  trackingNumber?: string
+): TrackingNumber | null => {
+  if (!trackingNumber) {
+    return null
+  }
+
+  let tracking: TrackingNumber | undefined
+  const normalizedCourier = courierRaw?.toLowerCase()
+
+  if (normalizedCourier?.startsWith("ups")) {
+    tracking = getTracking(trackingNumber, [ups])
+  } else if (normalizedCourier?.startsWith("fedex")) {
+    tracking = getTracking(trackingNumber, [fedex])
+  } else if (normalizedCourier?.startsWith("dhl")) {
+    tracking = getTracking(trackingNumber, [dhl])
+  } else if (normalizedCourier?.startsWith("usps")) {
+    tracking = getTracking(trackingNumber, [usps])
+  } else {
+    tracking = getTracking(trackingNumber)
+  }
+
+  if (!tracking) {
+    return null
+  }
+
+  return tracking
+}

--- a/src/schema/v2/order/types/exchangeJson.ts
+++ b/src/schema/v2/order/types/exchangeJson.ts
@@ -65,10 +65,10 @@ export interface OrderJSON {
     | "sepa_debit"
   bank_account_id?: string
   credit_card_id?: string
-  shipment?: {
+  delivery_info?: {
     type: "artsy_shipping" | "partner_shipping"
     tracking_id?: string
     tracking_url?: string
-    courier?: string
+    shipper_name?: string
   }
 }

--- a/src/schema/v2/order/types/exchangeJson.ts
+++ b/src/schema/v2/order/types/exchangeJson.ts
@@ -65,4 +65,10 @@ export interface OrderJSON {
     | "sepa_debit"
   bank_account_id?: string
   credit_card_id?: string
+  shipment?: {
+    type: "artsy_shipping" | "partner_shipping"
+    tracking_id?: string
+    tracking_url?: string
+    courier?: string
+  }
 }

--- a/src/schema/v2/order/types/sharedOrderTypes.ts
+++ b/src/schema/v2/order/types/sharedOrderTypes.ts
@@ -19,7 +19,7 @@ import { PhoneNumberType, resolvePhoneNumber } from "../../phoneNumber"
 import { PricingBreakdownLines } from "./PricingBreakdownLines"
 import { OrderJSON } from "./exchangeJson"
 import { PaymentMethodUnion } from "schema/v2/payment_method_union"
-import { DeliveryInfo, Shipment } from "./DeliveryInfo"
+import { DeliveryInfo } from "./DeliveryInfo"
 
 const OrderModeEnum = new GraphQLEnumType({
   name: "OrderModeEnum",

--- a/src/schema/v2/order/types/sharedOrderTypes.ts
+++ b/src/schema/v2/order/types/sharedOrderTypes.ts
@@ -19,7 +19,7 @@ import { PhoneNumberType, resolvePhoneNumber } from "../../phoneNumber"
 import { PricingBreakdownLines } from "./PricingBreakdownLines"
 import { OrderJSON } from "./exchangeJson"
 import { PaymentMethodUnion } from "schema/v2/payment_method_union"
-import { Shipment } from "./Shipment"
+import { DeliveryInfo, Shipment } from "./DeliveryInfo"
 
 const OrderModeEnum = new GraphQLEnumType({
   name: "OrderModeEnum",
@@ -399,7 +399,7 @@ export const OrderType = new GraphQLObjectType<OrderJSON, ResolverContext>({
         return partnerLoader(seller_id).catch(() => null)
       },
     },
-    shipment: Shipment,
+    deliveryInfo: DeliveryInfo,
     shippingOrigin: {
       type: GraphQLString,
       description: "Display short version of order's artwork location",

--- a/src/schema/v2/order/types/sharedOrderTypes.ts
+++ b/src/schema/v2/order/types/sharedOrderTypes.ts
@@ -19,6 +19,7 @@ import { PhoneNumberType, resolvePhoneNumber } from "../../phoneNumber"
 import { PricingBreakdownLines } from "./PricingBreakdownLines"
 import { OrderJSON } from "./exchangeJson"
 import { PaymentMethodUnion } from "schema/v2/payment_method_union"
+import { Shipment } from "./Shipment"
 
 const OrderModeEnum = new GraphQLEnumType({
   name: "OrderModeEnum",
@@ -398,6 +399,7 @@ export const OrderType = new GraphQLObjectType<OrderJSON, ResolverContext>({
         return partnerLoader(seller_id).catch(() => null)
       },
     },
+    shipment: Shipment,
     shippingOrigin: {
       type: GraphQLString,
       description: "Display short version of order's artwork location",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8366,6 +8366,11 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
+ramda@^0.27.0:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.2.tgz#84463226f7f36dc33592f6f4ed6374c48306c3f1"
+  integrity sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==
+
 range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
@@ -9298,7 +9303,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@4.2.3, string-width@^1.0.1, string-width@^2.1.1, string-width@^3.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@4.2.3, string-width@^1.0.1, string-width@^2.1.1, string-width@^3.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9351,7 +9365,7 @@ stringify-object@^3.2.2:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9378,6 +9392,13 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -9629,6 +9650,13 @@ ts-invariant@^0.4.0:
   integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
   dependencies:
     tslib "^1.9.3"
+
+ts-tracking-number@^1.0.17:
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/ts-tracking-number/-/ts-tracking-number-1.0.17.tgz#42a363f20efa615c50d9e01845778ebbf0cc20be"
+  integrity sha512-zq8Lgjn0+zvtOzKualtYF2WrxlQ0UQ5nOvOa5e6xSSJSwuMuwbMs+lZybUReG0gLYXZomhW00ErgBgP0BapDYQ==
+  dependencies:
+    ramda "^0.27.0"
 
 tsconfig-paths@^3.9.0:
   version "3.15.0"
@@ -10121,7 +10149,7 @@ wrangler@^3.78.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -10137,6 +10165,15 @@ wrap-ansi@^3.0.1:
   dependencies:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
 
 wrap-ansi@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
Type: FEAT

Related to [EMI-2486]
Requires https://github.com/artsy/exchange/pull/2594 to work good

This PR adds a shipment type that includes tracking numbers and the url to visit that number for the most common carriers. It relies on the [ts-tracking-number](https://github.com/rjbrooksjr/ts-tracking-number) package, which is recommended by the tracking number reference package linked... from that repo. Overall pretty straightforward.

I tried to be conservative in how much i re-interpret what comes from exchange. Artsy shipping orders should often already have tracking numbers so I leave those alone, and I only match against carriers that match some text (like DHL or DHL Global).

[EMI-2486]: https://artsyproduct.atlassian.net/browse/EMI-2486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ