### PR TITLE
chore: add hasTitle to Artwork type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2736,6 +2736,7 @@ type Artwork implements Node & Searchable & Sellable {
 
   # Whether a request for price estimate has been submitted for this artwork
   hasPriceEstimateRequest: Boolean
+  hasTitle: Boolean!
 
   # The height as expressed by the original input metric
   height: String

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1887,6 +1887,12 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLString,
         resolve: ({ title }) => (_.isEmpty(title) ? "Untitled" : title),
       },
+      hasTitle: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        resolve: ({ title }) => {
+          return Boolean(title && title.trim().length > 0)
+        },
+      },
       published: {
         type: new GraphQLNonNull(GraphQLBoolean),
         description: "Whether this artwork is published or not",


### PR DESCRIPTION
Modern Volt (backed by MP schema) needs to know if an artwork has a title or not. But, artworks can be explicitly titled as 'Untitled' - and MP uses that as a placeholder if an artwork lacks a title.

So, currently - we can't tell if an artwork that comes back as "Untitled" is _actually_ titled that, or is truly lacking a title.