### PR TITLE
chore: add deliveryInfo to order json

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10536,6 +10536,24 @@ type Delivery {
   ): String
 }
 
+# Shipment details for an order
+type DeliveryInfo {
+  # Eesimated delivery date as saved on the order
+  estimatedDelivery: String
+
+  # Eesimated delivery window as saved on the order
+  estimatedDeliveryWindow: String
+
+  # The carrier handling the shipment as saved on the order (e.g., UPS, FedEx, DHL, USPS)
+  shipperName: String
+
+  # The tracking number for the shipment
+  trackingNumber: String
+
+  # The URL to track the shipment
+  trackingURL: String
+}
+
 type Department {
   id: ID!
   jobs: [Job!]! @deprecated
@@ -16506,6 +16524,9 @@ type Order {
 
   # Currency code
   currencyCode: String!
+
+  # Details about the shipment of an order
+  deliveryInfo: DeliveryInfo
 
   # Display texts for the order based on its buyer_state and order shipping/payment states
   displayTexts: DisplayTexts!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10538,10 +10538,10 @@ type Delivery {
 
 # Shipment details for an order
 type DeliveryInfo {
-  # Eesimated delivery date as saved on the order
+  # Estimated delivery date saved on the order as date stringr
   estimatedDelivery: String
 
-  # Eesimated delivery window as saved on the order
+  # Estimated delivery window saved on the otder as display text
   estimatedDeliveryWindow: String
 
   # The carrier handling the shipment as saved on the order (e.g., UPS, FedEx, DHL, USPS)

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -15,6 +15,13 @@ describe("Me", () => {
       id: "order-id",
       source: "artwork_page",
       code: "order-code",
+      delivery_info: {
+        shipper_name: "DHL",
+        tracking_id: "12345",
+        tracking_url: "track_me.com",
+        type: "artsy_shipping",
+        estimated_delivery_window: "will arrive at some point",
+      },
       mode: "buy",
       currency_code: "USD",
       buyer_id: "buyer-id-1",
@@ -63,6 +70,13 @@ describe("Me", () => {
               buyerStateExpiresAt
               code
               currencyCode
+              deliveryInfo {
+                shipperName
+                trackingNumber
+                trackingURL
+                estimatedDelivery
+                estimatedDeliveryWindow
+              }
               displayTexts {
                 title
                 messageType
@@ -150,6 +164,13 @@ describe("Me", () => {
         buyerStateExpiresAt: "January 1, 2035 19:00 EST",
         code: "order-code",
         currencyCode: "USD",
+        deliveryInfo: {
+          shipperName: "DHL",
+          trackingNumber: "12345",
+          trackingURL: "track_me.com",
+          estimatedDelivery: null,
+          estimatedDeliveryWindow: "will arrive at some point",
+        },
         displayTexts: {
           title: "Congratulations!",
           messageType: "APPROVED_SHIP",

--- a/src/schema/v2/order/types/DeliveryInfo.ts
+++ b/src/schema/v2/order/types/DeliveryInfo.ts
@@ -22,12 +22,13 @@ const DeliveryInfoType = new GraphQLObjectType({
 
     estimatedDelivery: {
       type: GraphQLString,
-      description: "Eesimated delivery date as saved on the order",
+      description: "Estimated delivery date saved on the order as date stringr",
     },
 
     estimatedDeliveryWindow: {
       type: GraphQLString,
-      description: "Eesimated delivery window as saved on the order",
+      description:
+        "Estimated delivery window saved on the otder as display text",
     },
   }),
 })

--- a/src/schema/v2/order/types/DeliveryInfo.ts
+++ b/src/schema/v2/order/types/DeliveryInfo.ts
@@ -1,0 +1,63 @@
+import { GraphQLFieldConfig, GraphQLObjectType, GraphQLString } from "graphql"
+import { OrderJSON } from "./exchangeJson"
+import { ResolverContext } from "types/graphql"
+
+const DeliveryInfoType = new GraphQLObjectType({
+  name: "DeliveryInfo",
+  description: "Shipment details for an order",
+  fields: () => ({
+    shipperName: {
+      type: GraphQLString,
+      description:
+        "The carrier handling the shipment as saved on the order (e.g., UPS, FedEx, DHL, USPS)",
+    },
+    trackingNumber: {
+      type: GraphQLString,
+      description: "The tracking number for the shipment",
+    },
+    trackingURL: {
+      type: GraphQLString,
+      description: "The URL to track the shipment",
+    },
+
+    estimatedDelivery: {
+      type: GraphQLString,
+      description: "Eesimated delivery date as saved on the order",
+    },
+
+    estimatedDeliveryWindow: {
+      type: GraphQLString,
+      description: "Eesimated delivery window as saved on the order",
+    },
+  }),
+})
+
+export const DeliveryInfo: GraphQLFieldConfig<OrderJSON, ResolverContext> = {
+  type: DeliveryInfoType,
+  description: "Details about the shipment of an order",
+  resolve: (order: OrderJSON) => {
+    return resolveDeliveryInfo(order)
+  },
+}
+
+const resolveDeliveryInfo = (order: OrderJSON) => {
+  if (!order.delivery_info) {
+    return null
+  }
+
+  const {
+    shipper_name,
+    tracking_url,
+    tracking_id,
+    estimated_delivery,
+    estimated_delivery_window,
+  } = order.delivery_info
+
+  return {
+    shipperName: shipper_name,
+    trackingNumber: tracking_id,
+    trackingURL: tracking_url,
+    estimatedDelivery: estimated_delivery,
+    estimatedDeliveryWindow: estimated_delivery_window,
+  }
+}

--- a/src/schema/v2/order/types/exchangeJson.ts
+++ b/src/schema/v2/order/types/exchangeJson.ts
@@ -16,53 +16,61 @@ export interface FulfillmentOptionJson {
   shipping_quote_id?: string
 }
 export interface OrderJSON {
-  id: string
-  code: string
-  source: "artwork_page" | "inquiry" | "private_sale" | "partner_offer"
-  mode: "buy" | "offer"
-  currency_code: string
   available_shipping_countries: string[]
+  bank_account_id?: string
   buyer_id: string
-  buyer_type: string
-  seller_id: string
-  seller_type: string
   buyer_phone_number?: string
   buyer_phone_number_country_code?: string
-  buyer_total_cents?: number
-  shipping_total_cents?: number
-  items_total_cents?: number
-  total_list_price_cents?: number
-  shipping_origin?: string
-  shipping_name?: string
-  shipping_address_line1?: string
-  shipping_address_line2?: string
-  shipping_city?: string
-  shipping_postal_code?: string
-  shipping_region?: string
-  shipping_country?: string
-  tax_total_cents?: number
   buyer_state?: string
   buyer_state_expires_at?: string
-  fulfillment_type?: string
+  buyer_total_cents?: number
+  buyer_type: string
+  code: string
+  credit_card_id?: string
+  credit_card_wallet_type?: "apple_pay" | "google_pay"
+  currency_code: string
+  delivery_info?: {
+    shipper_name?: string
+    tracking_id?: string
+    tracking_url?: string
+    type: "artsy_shipping" | "partner_shipping"
+    estimated_delivery?: string
+    estimated_delivery_window?: string
+  }
   fulfillment_options: Array<FulfillmentOptionJson>
-  selected_fulfillment_option?: FulfillmentOptionJson
+  fulfillment_type?: string
+  id: string
+  items_total_cents?: number
   line_items: Array<{
-    id: string
     artwork_id: string
     artwork_version_id: string
+    currency_code: string
     edition_set_id?: string
+    id: string
     list_price_cents: number
     quantity: number
     shipping_total_cents?: number
     tax_cents?: number
-    currency_code: string
   }>
-  credit_card_wallet_type?: "apple_pay" | "google_pay"
+  mode: "buy" | "offer"
   payment_method?:
     | "credit card"
     | "wire_transfer"
     | "us_bank_account"
     | "sepa_debit"
-  bank_account_id?: string
-  credit_card_id?: string
+  selected_fulfillment_option?: FulfillmentOptionJson
+  seller_id: string
+  seller_type: string
+  shipping_address_line1?: string
+  shipping_address_line2?: string
+  shipping_city?: string
+  shipping_country?: string
+  shipping_name?: string
+  shipping_origin?: string
+  shipping_postal_code?: string
+  shipping_region?: string
+  shipping_total_cents?: number
+  source: "artwork_page" | "inquiry" | "private_sale" | "partner_offer"
+  tax_total_cents?: number
+  total_list_price_cents?: number
 }

--- a/src/schema/v2/order/types/sharedOrderTypes.ts
+++ b/src/schema/v2/order/types/sharedOrderTypes.ts
@@ -19,6 +19,7 @@ import { PhoneNumberType, resolvePhoneNumber } from "../../phoneNumber"
 import { PricingBreakdownLines } from "./PricingBreakdownLines"
 import { OrderJSON } from "./exchangeJson"
 import { PaymentMethodUnion } from "schema/v2/payment_method_union"
+import { DeliveryInfo } from "./DeliveryInfo"
 
 const OrderModeEnum = new GraphQLEnumType({
   name: "OrderModeEnum",
@@ -305,6 +306,7 @@ export const OrderType = new GraphQLObjectType<OrderJSON, ResolverContext>({
       description: "Currency code",
       resolve: ({ currency_code }) => currency_code,
     },
+    deliveryInfo: DeliveryInfo,
     displayTexts: DisplayTexts,
     fulfillmentDetails: {
       type: FulfillmentDetailsType,


### PR DESCRIPTION
Just cherryPicking parts of what you added in https://github.com/artsy/metaphysics/pull/6789 minus this fancy shipperCode/url generation.

Debated if we want to consolidate `estimatedDelivery` and `estimatedDeliveryWindow'` into something like `estimatedDeliveryDisplay` but for now decided against it as clients might want to only display one. Also one is more of a string and the other one is a data format but not necessarily with timezone so might need to tweak it on the client.

Thanks @erikdstock for pushing the Exchange addition. And we can follow up with fancier url generation