### PR TITLE
feat(updatePartnerShow): add displayOnPartnerProfile toggle

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -21577,6 +21577,9 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
   # Is this something we can display to the front-end?
   isDisplayable: Boolean
 
+  # Should this show be displayed on the partner profile page?
+  isDisplayableOnPartnerProfile: Boolean
+
   # Does the show exist as a fair booth?
   isFairBooth: Boolean
   isFeatured: Boolean
@@ -23519,6 +23522,9 @@ input UpdatePartnerShowMutationInput {
 
   # The description of the show.
   description: String
+
+  # Should the show be displayed on the partner profile page?
+  displayOnPartnerProfile: Boolean
 
   # The end date of the show.
   endAt: String

--- a/src/schema/v2/Show/updatePartnerShowMutation.ts
+++ b/src/schema/v2/Show/updatePartnerShowMutation.ts
@@ -16,17 +16,18 @@ import Show from "../show"
 import moment from "moment"
 
 interface UpdatePartnerShowMutationInputProps {
-  partnerId: string
-  showId: string
-  featured?: boolean
   description?: string
+  displayOnPartnerProfile?: boolean
   endAt?: string
+  fairBooth?: string
+  fairId?: string
+  featured?: boolean
   locationId?: string
   name?: string
+  partnerId: string
   pressRelease?: string
+  showId: string
   startAt?: string
-  fairId?: string
-  fairBooth?: string
   viewingRoomIds?: string[]
 }
 
@@ -68,6 +69,10 @@ export const updatePartnerShowMutation = mutationWithClientMutationId<
     description: {
       type: GraphQLString,
       description: "The description of the show.",
+    },
+    displayOnPartnerProfile: {
+      type: GraphQLBoolean,
+      description: "Should the show be displayed on the partner profile page?",
     },
     endAt: {
       type: GraphQLString,
@@ -139,6 +144,7 @@ export const updatePartnerShowMutation = mutationWithClientMutationId<
       ...addField("name", args.name),
       ...addField("featured", args.featured),
       ...addField("description", args.description),
+      ...addField("display_on_partner_profile", args.displayOnPartnerProfile),
       ...addField("press_release", args.pressRelease),
       ...addField("partner_location", args.locationId),
       ...addField(

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -501,6 +501,13 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLBoolean,
         resolve: ({ displayable }) => displayable,
       },
+      isDisplayableOnPartnerProfile: {
+        description:
+          "Should this show be displayed on the partner profile page?",
+        type: GraphQLBoolean,
+        resolve: ({ display_on_partner_profile }) =>
+          !!display_on_partner_profile,
+      },
       isFairBooth: {
         description: "Does the show exist as a fair booth?",
         type: GraphQLBoolean,


### PR DESCRIPTION
Quick one to expose `displayOnPartnerProfile` in the mutation, so we can toggle show visibility / invisibility. 