### PR TITLE
feat(show): Add admin show details to mutations

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9426,6 +9426,26 @@ type CreatePartnerShowFailure {
   mutationError: GravityMutationError
 }
 
+input CreatePartnerShowFairLocationInput {
+  # The booth of the show in the fair.
+  booth: String
+
+  # The floor of the show in the fair.
+  floor: String
+
+  # The hall of the show in the fair.
+  hall: String
+
+  # The pier of the show in the fair.
+  pier: String
+
+  # The room of the show in the fair.
+  room: String
+
+  # The section of the show in the fair.
+  section: String
+}
+
 input CreatePartnerShowMutationInput {
   clientMutationId: String
 
@@ -9435,11 +9455,9 @@ input CreatePartnerShowMutationInput {
   # The end date of the show.
   endAt: String!
 
-  # The booth of the fair to create the show for.
-  fairBooth: String
-
   # The id of the fair to create the show for.
   fairId: String
+  fairLocation: CreatePartnerShowFairLocationInput
 
   # Is the show featured?
   featured: Boolean
@@ -13760,6 +13778,7 @@ type Location {
 
   # Buisness, temporary, or private address
   addressType: String
+  booth: String
   cached: Int
   city: String
   coordinates: LatLng
@@ -13772,6 +13791,8 @@ type Location {
   displayCountry: String
   email: String
   euShippingLocation: Boolean
+  floor: String
+  hall: String
 
   # A globally unique ID.
   id: ID!
@@ -13782,10 +13803,13 @@ type Location {
   # Union returning opening hours in formatted structure or a string
   openingHours: OpeningHoursUnion
   phone: String
+  pier: String
   postalCode: String
 
   # Boolean flag that denotes whether a location is publicly viewable on Partner's Artsy Profile
   publiclyViewable: Boolean
+  room: String
+  section: String
   state: String
   summary: String
 }
@@ -23518,6 +23542,26 @@ type UpdatePartnerShowFailure {
   mutationError: GravityMutationError
 }
 
+input UpdatePartnerShowFairLocationInput {
+  # The booth of the show in the fair.
+  booth: String
+
+  # The floor of the show in the fair
+  floor: String
+
+  # The hall of the show in the fair
+  hall: String
+
+  # The pier of the show in the fair
+  pier: String
+
+  # The room of the show in the fair
+  room: String
+
+  # The section of the show in the fair
+  section: String
+}
+
 input UpdatePartnerShowMutationInput {
   clientMutationId: String
 
@@ -23530,11 +23574,9 @@ input UpdatePartnerShowMutationInput {
   # The end date of the show.
   endAt: String
 
-  # The booth of the fair to update the show for.
-  fairBooth: String
-
   # The id of the fair to update the show for.
   fairId: String
+  fairLocation: UpdatePartnerShowFairLocationInput
 
   # Is the show featured?
   featured: Boolean

--- a/src/schema/v2/Show/createPartnerShowMutation.ts
+++ b/src/schema/v2/Show/createPartnerShowMutation.ts
@@ -5,6 +5,7 @@ import {
   GraphQLUnionType,
   GraphQLBoolean,
   GraphQLList,
+  GraphQLInputObjectType,
 } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 import {
@@ -16,14 +17,22 @@ import Show from "../show"
 import moment from "moment"
 
 interface CreatePartnerShowMutationInputProps {
-  partnerId: string
-  name: string
   description?: string
-  startAt?: string
   endAt?: string
-  locationId?: string
   featured?: boolean
+  locationId?: string
+  name: string
+  partnerId: string
   pressRelease?: string
+  startAt?: string
+  fairLocation?: {
+    booth?: string
+    floor?: string
+    hall?: string
+    pier?: string
+    room?: string
+    section?: string
+  }
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
@@ -89,9 +98,36 @@ export const createPartnerShowMutation = mutationWithClientMutationId<
       type: GraphQLString,
       description: "The id of the fair to create the show for.",
     },
-    fairBooth: {
-      type: GraphQLString,
-      description: "The booth of the fair to create the show for.",
+    fairLocation: {
+      type: new GraphQLInputObjectType({
+        name: "CreatePartnerShowFairLocationInput",
+        fields: {
+          booth: {
+            type: GraphQLString,
+            description: "The booth of the show in the fair.",
+          },
+          floor: {
+            type: GraphQLString,
+            description: "The floor of the show in the fair.",
+          },
+          hall: {
+            type: GraphQLString,
+            description: "The hall of the show in the fair.",
+          },
+          pier: {
+            type: GraphQLString,
+            description: "The pier of the show in the fair.",
+          },
+          room: {
+            type: GraphQLString,
+            description: "The room of the show in the fair.",
+          },
+          section: {
+            type: GraphQLString,
+            description: "The section of the show in the fair.",
+          },
+        },
+      }),
     },
     pressRelease: {
       type: GraphQLString,
@@ -131,6 +167,15 @@ export const createPartnerShowMutation = mutationWithClientMutationId<
       start_at?: number
       end_at?: number
       fair?: string
+      fair_location?: {
+        booth?: string
+        floor?: string
+        hall?: string
+        pier?: string
+        room?: string
+        section?: string
+      }
+      viewing_room_ids?: string[]
     } = {
       name: args.name,
       featured: args.featured,
@@ -140,7 +185,7 @@ export const createPartnerShowMutation = mutationWithClientMutationId<
       end_at: moment(args.endAt).unix(),
       partner_location: args.locationId,
       fair: args.fairId,
-      ...(args.fairBooth && { fair_location: { booth: args.fairBooth } }),
+      fair_location: args.fairLocation,
       viewing_room_ids: args.viewingRoomIds,
     }
 

--- a/src/schema/v2/Show/updatePartnerShowMutation.ts
+++ b/src/schema/v2/Show/updatePartnerShowMutation.ts
@@ -5,6 +5,7 @@ import {
   GraphQLUnionType,
   GraphQLBoolean,
   GraphQLList,
+  GraphQLInputObjectType,
 } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 import {
@@ -110,9 +111,36 @@ export const updatePartnerShowMutation = mutationWithClientMutationId<
       type: GraphQLString,
       description: "The id of the fair to update the show for.",
     },
-    fairBooth: {
-      type: GraphQLString,
-      description: "The booth of the fair to update the show for.",
+    fairLocation: {
+      type: new GraphQLInputObjectType({
+        name: "UpdatePartnerShowFairLocationInput",
+        fields: {
+          booth: {
+            type: GraphQLString,
+            description: "The booth of the show in the fair.",
+          },
+          floor: {
+            type: GraphQLString,
+            description: "The floor of the show in the fair",
+          },
+          hall: {
+            type: GraphQLString,
+            description: "The hall of the show in the fair",
+          },
+          pier: {
+            type: GraphQLString,
+            description: "The pier of the show in the fair",
+          },
+          room: {
+            type: GraphQLString,
+            description: "The room of the show in the fair",
+          },
+          section: {
+            type: GraphQLString,
+            description: "The section of the show in the fair",
+          },
+        },
+      }),
     },
     viewingRoomIds: {
       type: new GraphQLList(GraphQLString),
@@ -156,10 +184,7 @@ export const updatePartnerShowMutation = mutationWithClientMutationId<
         args.endAt !== undefined ? moment(args.endAt).unix() : undefined
       ),
       ...addField("fair", args.fairId),
-      ...addField(
-        "fair_location",
-        args.fairBooth !== undefined ? { booth: args.fairBooth } : undefined
-      ),
+      ...addField("fair_location", args.fairLocation),
       ...addField("viewing_room_ids", args.viewingRoomIds),
     }
 

--- a/src/schema/v2/location.ts
+++ b/src/schema/v2/location.ts
@@ -71,6 +71,30 @@ export const LocationType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
       resolve: ({ address_2 }) => address_2,
     },
+    booth: {
+      type: GraphQLString,
+      resolve: ({ booth }) => booth,
+    },
+    floor: {
+      type: GraphQLString,
+      resolve: ({ floor }) => floor,
+    },
+    hall: {
+      type: GraphQLString,
+      resolve: ({ hall }) => hall,
+    },
+    pier: {
+      type: GraphQLString,
+      resolve: ({ pier }) => pier,
+    },
+    room: {
+      type: GraphQLString,
+      resolve: ({ room }) => room,
+    },
+    section: {
+      type: GraphQLString,
+      resolve: ({ section }) => section,
+    },
     city: {
       type: GraphQLString,
       resolve: ({ city }) => existyValue(city),

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -844,6 +844,7 @@ const Show: GraphQLFieldConfig<void, ResolverContext> = {
       ) {
         return new HTTPError("Show Not Found", 404)
       }
+
       return show
     })
   },


### PR DESCRIPTION
This updates the show create/update mutations with some admin-only inputs, and update the location type to return them. 

cc @artsy/amber-devs 