### PR TITLE
feat: Set app version for Art Under $X quick link to 8.75

### DIFF
--- a/src/schema/v2/homeView/sections/QuickLinks.ts
+++ b/src/schema/v2/homeView/sections/QuickLinks.ts
@@ -216,7 +216,7 @@ async function maybeInsertArtworksWithinPriceBudgetLink(
         href: `/collect?price_range=${priceBucket.priceRange}`,
         ownerType: OwnerType.collect,
         icon: undefined,
-        minimumEigenVersion: { major: 8, minor: 74, patch: 0 }, // when /collect screen was added to the app
+        minimumEigenVersion: { major: 8, minor: 75, patch: 0 }, // when /collect screen was added to the app
       }
 
       links.splice(auctionsIndex + 1, 0, priceBudgetPill)


### PR DESCRIPTION
Sets min app version to 8.75 for the Art Under $X quick link (introduced earlier here: https://github.com/artsy/metaphysics/pull/6751)