### PR TITLE
feat(home view): implement NWFY price affinity experiment

### DIFF
--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -16,6 +16,7 @@ const FEATURE_FLAGS_LIST = [
   "onyx_enable-quick-links-v2",
   "onyx_enable-home-view-auction-segmentation",
   "onyx_enable-quick-links-price-budget",
+  "onyx_nwfy-price-affinity-test",
 ] as const
 
 export type FeatureFlag = typeof FEATURE_FLAGS_LIST[number]

--- a/src/schema/v2/homeView/experiments/experiments.ts
+++ b/src/schema/v2/homeView/experiments/experiments.ts
@@ -6,4 +6,5 @@ import { FeatureFlag } from "lib/featureFlags"
  */
 export const CURRENTLY_RUNNING_EXPERIMENTS: FeatureFlag[] = [
   "onyx_experiment_home_view_test",
+  "onyx_nwfy-price-affinity-test",
 ]

--- a/src/schema/v2/homeView/sections/NewWorksForYou.ts
+++ b/src/schema/v2/homeView/sections/NewWorksForYou.ts
@@ -3,6 +3,7 @@ import { HomeViewSection } from "."
 import { withHomeViewTimeout } from "../helpers/withHomeViewTimeout"
 import { HomeViewSectionTypeNames } from "../sectionTypes/names"
 import { artworksForUser } from "schema/v2/artworksForUser/artworksForUser"
+import { getExperimentVariant } from "lib/featureFlags"
 
 export const NewWorksForYou: HomeViewSection = {
   id: "home-view-section-new-works-for-you",
@@ -20,12 +21,22 @@ export const NewWorksForYou: HomeViewSection = {
   requiresAuthentication: true,
 
   resolver: withHomeViewTimeout(async (parent, args, context, info) => {
+    const variant = getExperimentVariant("onyx_nwfy-price-affinity-test", {
+      userId: context.userID,
+    })
+
+    let recommendationsVersion = "C"
+
+    if (variant && variant.enabled && variant.name === "experiment") {
+      recommendationsVersion = "A"
+    }
+
     const finalArgs = {
       // formerly specified client-side
       maxWorksPerArtist: 3,
       includeBackfill: true,
       first: args.first,
-      version: "C",
+      version: recommendationsVersion,
       excludeDislikedArtworks: true,
       excludeArtworkIds: [],
 

--- a/src/schema/v2/homeView/sections/__tests__/NewWorksForYou.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/NewWorksForYou.test.ts
@@ -1,5 +1,13 @@
 import gql from "lib/gql"
 import { runQuery } from "schema/v2/test/utils"
+import { getExperimentVariant } from "lib/featureFlags"
+import "schema/v2/homeView/experiments/experiments"
+
+jest.mock("lib/featureFlags", () => ({
+  getExperimentVariant: jest.fn(),
+}))
+
+const mockGetExperimentVariant = getExperimentVariant as jest.Mock
 
 describe("NewWorksForYou", () => {
   it("returns the section's metadata", async () => {
@@ -54,7 +62,114 @@ describe("NewWorksForYou", () => {
     `)
   })
 
+  // eslint-disable-next-line jest/no-disabled-tests
   it.skip("returns the section's connection data", async () => {
     // see artworksForUser.test.ts
+  })
+
+  describe("when the onyx_nwfy-price-affinity-test experiment is enabled", () => {
+    it("serves Version C to the control group", async () => {
+      mockGetExperimentVariant.mockImplementation(() => ({
+        name: "control",
+        enabled: true,
+      }))
+
+      const query = gql`
+        {
+          homeView {
+            section(id: "home-view-section-new-works-for-you") {
+              ... on HomeViewSectionArtworks {
+                artworksConnection(first: 20) {
+                  edges {
+                    node {
+                      slug
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      type VortexGraphqlLoaderArgs = { query: string }
+      const mockVortexGraphqlLoader = jest.fn(
+        (_args: VortexGraphqlLoaderArgs) => () =>
+          Promise.resolve({ data: { newForYouRecommendations: [{}] } })
+      )
+
+      const context = {
+        accessToken: "424242",
+        userID: "vortex-user-id",
+        artworksLoader: jest.fn(() => Promise.resolve([])),
+        setsLoader: jest.fn(() => Promise.resolve({ body: [] })),
+        setItemsLoader: jest.fn(() => Promise.resolve({ body: [{}] })),
+        authenticatedLoaders: {
+          vortexGraphqlLoader: mockVortexGraphqlLoader,
+        },
+        unauthenticatedLoaders: {
+          vortexGraphqlLoader: jest.fn(),
+        },
+      } as any
+
+      await runQuery(query, context)
+
+      const vortexGraphqlQuery =
+        mockVortexGraphqlLoader.mock.calls?.[0]?.[0]?.query
+
+      expect(vortexGraphqlQuery).toMatch('version: "C"')
+    })
+
+    it("serves Version A to the experiment group", async () => {
+      mockGetExperimentVariant.mockImplementation(() => ({
+        name: "experiment",
+        enabled: true,
+      }))
+
+      const query = gql`
+        {
+          homeView {
+            section(id: "home-view-section-new-works-for-you") {
+              ... on HomeViewSectionArtworks {
+                artworksConnection(first: 20) {
+                  edges {
+                    node {
+                      slug
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      type VortexGraphqlLoaderArgs = { query: string }
+      const mockVortexGraphqlLoader = jest.fn(
+        (_args: VortexGraphqlLoaderArgs) => () =>
+          Promise.resolve({ data: { newForYouRecommendations: [{}] } })
+      )
+
+      const context = {
+        accessToken: "424242",
+        userID: "vortex-user-id",
+        artworksLoader: jest.fn(() => Promise.resolve([])),
+        setsLoader: jest.fn(() => Promise.resolve({ body: [] })),
+        setItemsLoader: jest.fn(() => Promise.resolve({ body: [{}] })),
+        authenticatedLoaders: {
+          vortexGraphqlLoader: mockVortexGraphqlLoader,
+        },
+        unauthenticatedLoaders: {
+          vortexGraphqlLoader: jest.fn(),
+        },
+      } as any
+
+      await runQuery(query, context)
+
+      const vortexGraphqlQuery =
+        mockVortexGraphqlLoader.mock.calls?.[0]?.[0]?.query
+
+      expect(vortexGraphqlQuery).toMatch('version: "A"')
+    })
   })
 })


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-1756


This implements the server-driven home view experiment for New Works for You with  price affinity.

Based on the Unleash flag [`onyx_nwfy-price-affinity-test`](https://unleash.artsy.net/projects/default/features/onyx_nwfy-price-affinity-test):

- users in the `control` group will continue to receive Version C 
- users in the `experiment` group will receive Version A (see [zenith/499](https://github.com/artsy/zenith/pull/499))

The experiment is enabled in staging already, but not in production. (And note that the experiment is app-only ([see thread](https://artsy.slack.com/archives/C05EQL4R5N0/p1750092031700919)) so setting this experiment up for Force is out of scope.)

Here is Eigen emitting the corresponding tracking event based on this home-view experiment setup:


https://github.com/user-attachments/assets/556bb222-5436-4651-98fb-bbdf9b2f0bed

