### PR TITLE
feat(onyx-1665): updatePurchaseMutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16072,6 +16072,9 @@ type Mutation {
     input: UpdateProfileMutationInput!
   ): UpdateProfileMutationPayload
 
+  # Update a purchase
+  updatePurchase(input: updatePurchaseInput!): updatePurchasePayload
+
   # Update a quiz artwork interacted_with flag
   updateQuiz(input: updateQuizMutationInput!): updateQuizMutationPayload
 
@@ -18538,6 +18541,7 @@ type Purchase implements Node {
   # A type-specific ID.
   internalID: ID!
   note: String
+  ownerID: String
   ownerType: String
   sale: Sale
 
@@ -23667,6 +23671,18 @@ type UpdateProfileSuccess {
   profile: Profile
 }
 
+type UpdatePurchaseFailure {
+  mutationError: GravityMutationError
+}
+
+union UpdatePurchaseResponseOrError =
+    UpdatePurchaseFailure
+  | UpdatePurchaseSuccess
+
+type UpdatePurchaseSuccess {
+  purchase: Purchase
+}
+
 type UpdateSaleAgreementFailure {
   mutationError: GravityMutationError
 }
@@ -26485,6 +26501,32 @@ input updateOrderShippingAddressInput {
 type updateOrderShippingAddressPayload {
   clientMutationId: String
   orderOrError: SetOrderFulfillmentOptionResponse
+}
+
+input updatePurchaseInput {
+  artsyCommission: Float
+  artworkID: String
+  clientMutationId: String
+  discoverAdminID: String
+  email: String
+  fairID: String
+  id: String!
+  note: String
+  ownerID: String
+  ownerType: String
+  saleAdminID: String
+  saleDate: String
+  saleID: String
+
+  # Sale price in USD.
+  salePrice: Float
+  source: String
+  userID: String
+}
+
+type updatePurchasePayload {
+  clientMutationId: String
+  responseOrError: UpdatePurchaseResponseOrError
 }
 
 input updateQuizMutationInput {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -860,6 +860,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" }
     ),
+    updatePurchaseLoader: gravityLoader(
+      (id) => `purchase/${id}`,
+      {},
+      { method: "PUT" }
+    ),
     matchPagesLoader: gravityLoader("match/pages", {}, { headers: true }),
     optInArtworksIntoCommerceLoader: gravityLoader(
       (id) => `partner/${id}/bulk_operations/commerce_opt_in`,

--- a/src/schema/v2/Purchases/__tests__/updatePurchaseMutation.test.ts
+++ b/src/schema/v2/Purchases/__tests__/updatePurchaseMutation.test.ts
@@ -1,0 +1,172 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("updatePurchaseMutation", () => {
+  const mutation = gql`
+    mutation {
+      updatePurchase(
+        input: {
+          id: "purchase-id"
+          artsyCommission: 10.5
+          artworkID: "some-artwork-id"
+          discoverAdminID: "nikita-admin-id"
+          email: "nikita@artsy.net"
+          fairID: "some-fair-id"
+          note: "My note"
+          ownerID: "sale-artwork-id"
+          ownerType: "SaleArtwork"
+          saleDate: "2025-06-13"
+          saleAdminID: "nikita-sale-admin-id"
+          saleID: "some-sale-id"
+          salePrice: 999.99
+          source: "auction"
+          userID: "some-user-id"
+        }
+      ) {
+        responseOrError {
+          __typename
+          ... on UpdatePurchaseSuccess {
+            purchase {
+              internalID
+              artsyCommission
+              artwork {
+                internalID
+              }
+              discoverAdmin {
+                internalID
+              }
+              email
+              fair {
+                internalID
+              }
+              note
+              ownerID
+              ownerType
+              saleDate
+              saleAdmin {
+                internalID
+              }
+              sale {
+                internalID
+              }
+              salePrice
+              source
+              user {
+                internalID
+              }
+            }
+          }
+        }
+      }
+    }
+  `
+
+  const purchase = {
+    id: "purchase-id",
+    artsy_commission: 10.5,
+    artwork: {
+      _id: "some-artwork-id",
+    },
+    discover_admin: {
+      id: "nikita-admin-id",
+    },
+    email: "nikita@artsy.net",
+    fair: {
+      _id: "some-fair-id",
+    },
+    note: "My note",
+    owner_id: "sale-artwork-id",
+    owner_type: "SaleArtwork",
+    sale_date: "2025-06-13",
+    sale_admin: {
+      id: "nikita-sale-admin-id",
+    },
+    sale: {
+      _id: "some-sale-id",
+    },
+    sale_price: 999.99,
+    source: "auction",
+    user: {
+      id: "some-user-id",
+    },
+  }
+
+  const mockUpdatePurchaseLoader = jest.fn()
+
+  const context = {
+    updatePurchaseLoader: mockUpdatePurchaseLoader,
+  }
+
+  beforeEach(() => {
+    mockUpdatePurchaseLoader.mockResolvedValue(Promise.resolve(purchase))
+  })
+
+  afterEach(() => {
+    mockUpdatePurchaseLoader.mockReset()
+  })
+
+  it("asserts that the loader is called with the correct arguments and returns the purchase", async () => {
+    const res = await runAuthenticatedQuery(mutation, context)
+
+    const loaderArgs = mockUpdatePurchaseLoader.mock.calls[0]
+    const id = loaderArgs[0]
+    const params = loaderArgs[1]
+
+    expect(id).toEqual("purchase-id")
+    expect(params).toMatchObject({
+      artsy_commission: 10.5,
+      artwork_id: "some-artwork-id",
+      discover_admin_id: "nikita-admin-id",
+      email: "nikita@artsy.net",
+      fair_id: "some-fair-id",
+      note: "My note",
+      owner_id: "sale-artwork-id",
+      owner_type: "SaleArtwork",
+      sale_date: 1749772800,
+      sale_admin_id: "nikita-sale-admin-id",
+      sale_id: "some-sale-id",
+      sale_price: 999.99,
+      source: "auction",
+      user_id: "some-user-id",
+    })
+
+    expect(res).toMatchInlineSnapshot(`
+      {
+        "updatePurchase": {
+          "responseOrError": {
+            "__typename": "UpdatePurchaseSuccess",
+            "purchase": {
+              "artsyCommission": 10.5,
+              "artwork": {
+                "internalID": "some-artwork-id",
+              },
+              "discoverAdmin": {
+                "internalID": "nikita-admin-id",
+              },
+              "email": "nikita@artsy.net",
+              "fair": {
+                "internalID": "some-fair-id",
+              },
+              "internalID": "purchase-id",
+              "note": "My note",
+              "ownerID": "sale-artwork-id",
+              "ownerType": "SaleArtwork",
+              "sale": {
+                "internalID": "some-sale-id",
+              },
+              "saleAdmin": {
+                "internalID": "nikita-sale-admin-id",
+              },
+              "saleDate": "2025-06-13",
+              "salePrice": 999.99,
+              "source": "auction",
+              "user": {
+                "internalID": "some-user-id",
+              },
+            },
+          },
+        },
+      }
+    `)
+  })
+})

--- a/src/schema/v2/Purchases/helpers.ts
+++ b/src/schema/v2/Purchases/helpers.ts
@@ -1,0 +1,40 @@
+import { identity, pickBy } from "lodash"
+
+export const convertToGravityArgs = (args: any) => {
+  const gravityArgs = pickBy(
+    {
+      artist_id: args.artistID,
+      artsy_commission: args.artsyCommission,
+      artwork_id: args.artworkID,
+      discover_admin_id: args.discoverAdminID,
+      email: args.email,
+      fair_id: args.fairID,
+      note: args.note,
+      owner_id: args.ownerID,
+      owner_type: args.ownerType,
+      partner_id: args.partnerID,
+      sale_date: convertStringDateToInteger(args.saleDate),
+      sale_admin_id: args.saleAdminID,
+      sale_id: args.saleID,
+      sale_price: args.salePrice,
+      source: args.source,
+      user_id: args.userID,
+    },
+    identity
+  )
+
+  return gravityArgs
+}
+
+// Gravity expects sale_date to be an integer, but the input is a string
+// so we need to convert the string to an integer first.
+const convertStringDateToInteger = (date: string | null) => {
+  if (!date) {
+    return null
+  }
+
+  const dateObj = new Date(date)
+  // getTime() returns the number of milliseconds, but ruby's Time.at()
+  // expects the number of seconds since the epoch. That's why we divide by 1000.
+  return Math.floor(dateObj.getTime() / 1000)
+}

--- a/src/schema/v2/Purchases/types.ts
+++ b/src/schema/v2/Purchases/types.ts
@@ -1,0 +1,48 @@
+import { GraphQLFloat, GraphQLString } from "graphql"
+
+// Fields the `createPurchase` and `updatePurchase` mutations have in common.
+export const PurchaseInputFields = {
+  artsyCommission: {
+    type: GraphQLFloat,
+  },
+  artworkID: {
+    type: GraphQLString,
+  },
+  discoverAdminID: {
+    type: GraphQLString,
+  },
+  email: {
+    type: GraphQLString,
+  },
+  fairID: {
+    type: GraphQLString,
+  },
+  note: {
+    type: GraphQLString,
+  },
+  ownerID: {
+    type: GraphQLString,
+  },
+  ownerType: {
+    type: GraphQLString,
+  },
+  saleDate: {
+    type: GraphQLString,
+  },
+  saleAdminID: {
+    type: GraphQLString,
+  },
+  saleID: {
+    type: GraphQLString,
+  },
+  salePrice: {
+    type: GraphQLFloat,
+    description: "Sale price in USD.",
+  },
+  source: {
+    type: GraphQLString,
+  },
+  userID: {
+    type: GraphQLString,
+  },
+}

--- a/src/schema/v2/Purchases/updatePurchaseMutation.ts
+++ b/src/schema/v2/Purchases/updatePurchaseMutation.ts
@@ -1,0 +1,85 @@
+import {
+  GraphQLObjectType,
+  GraphQLUnionType,
+  GraphQLNonNull,
+  GraphQLString,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  GravityMutationErrorType,
+  formatGravityError,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { PurchaseType } from "../purchase"
+import { PurchaseInputFields } from "./types"
+import { convertToGravityArgs } from "./helpers"
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdatePurchaseSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    purchase: {
+      type: PurchaseType,
+      resolve: (data) => data,
+    },
+  }),
+})
+
+const ErrorType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdatePurchaseFailure",
+  isTypeOf: (data) => {
+    return data._type === "GravityMutationError"
+  },
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdatePurchaseResponseOrError",
+  types: [SuccessType, ErrorType],
+})
+
+export const updatePurchaseMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "updatePurchase",
+  description: "Update a purchase",
+  inputFields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    ...PurchaseInputFields,
+  },
+  outputFields: {
+    responseOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async ({ id, ...args }, { updatePurchaseLoader }) => {
+    if (!updatePurchaseLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const gravityArgs = convertToGravityArgs(args)
+      const response = await updatePurchaseLoader(id, gravityArgs)
+
+      return response
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/purchase.ts
+++ b/src/schema/v2/purchase.ts
@@ -40,6 +40,10 @@ export const PurchaseType = new GraphQLObjectType<any, ResolverContext>({
     note: {
       type: GraphQLString,
     },
+    ownerID: {
+      type: GraphQLString,
+      resolve: ({ owner_id }) => owner_id,
+    },
     ownerType: {
       type: GraphQLString,
       resolve: ({ owner_type }) => owner_type,

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -323,6 +323,7 @@ import { UpdatePartnerProfileImageMutation } from "./partner/Settings/updatePart
 import { PurchasesConnection } from "./purchases"
 import { Purchase } from "./purchase"
 import { updateOrderShippingAddressMutation } from "./order/updateOrderShippingAddressMutation"
+import { updatePurchaseMutation } from "./Purchases/updatePurchaseMutation"
 
 const rootFields = {
   // artworkVersion: ArtworkVersionResolver,
@@ -627,6 +628,7 @@ export default new GraphQLSchema({
       updateOrderShippingAddress: updateOrderShippingAddressMutation,
       updateOrderedSet: updateOrderedSetMutation,
       updatePage: UpdatePageMutation,
+      updatePurchase: updatePurchaseMutation,
       updatePartnerContact: UpdatePartnerContactMutation,
       updatePartnerLocation: UpdatePartnerLocationMutation,
       updatePartnerProfileImage: UpdatePartnerProfileImageMutation,


### PR DESCRIPTION
This is part of the Torque deprecation effort. The new admin panel, Forque, does not include a Purchases section yet. Since Forque communicates with the backend via Metaphysics (unlike Torque, which talks to Gravity directly), we are adding support for creating, updating, and deleting purchases to Metaphysics.

This PR introduces the `updatePurchase` mutation:

```graphql
mutation {
  updatePurchase(
    input: {id: "purchase-id", ...}
  ) {
    responseOrError {
      ... on UpdatePurchaseSuccess {
        purchase {
          internalID
        }
      }
      ... on UpdatePurchaseFailure {
        mutationError {
          error
          message
        }
      }
    }
  }
}
```