### PR TITLE
chore: add flagArtworkImportCell mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -11730,6 +11730,32 @@ type FilterSaleArtworksCounts {
   ): FormattedNumber
 }
 
+type FlagArtworkImportCellFailure {
+  mutationError: GravityMutationError
+}
+
+input FlagArtworkImportCellInput {
+  artworkImportID: String!
+  clientMutationId: String
+  columnName: String!
+  flaggedValue: String
+  rowID: String!
+  userNote: String!
+}
+
+type FlagArtworkImportCellPayload {
+  clientMutationId: String
+  flagArtworkImportCellOrError: FlagArtworkImportCellResponseOrError
+}
+
+union FlagArtworkImportCellResponseOrError =
+    FlagArtworkImportCellFailure
+  | FlagArtworkImportCellSuccess
+
+type FlagArtworkImportCellSuccess {
+  artworkImport: ArtworkImport
+}
+
 type FollowArtist {
   artist: Artist
   auto: Boolean
@@ -15730,6 +15756,9 @@ type Mutation {
 
   # Mark sale as ended.
   endSale(input: EndSaleInput!): EndSalePayload
+  flagArtworkImportCell(
+    input: FlagArtworkImportCellInput!
+  ): FlagArtworkImportCellPayload
 
   # Follow (or unfollow) an artist
   followArtist(input: FollowArtistInput!): FollowArtistPayload

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -101,6 +101,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    artworkImportFlagCellLoader: gravityLoader(
+      (id) => `artwork_import/${id}/flag_cell`,
+      {},
+      { method: "POST" }
+    ),
     artworkImportLoader: gravityLoader((id) => `artwork_import/${id}`),
     artworkImportMatchArtistsLoader: gravityLoader(
       (id) => `artwork_import/${id}/match_artists`,

--- a/src/schema/v2/ArtworkImport/__tests__/flagArtworkImportCellMutation.test.ts
+++ b/src/schema/v2/ArtworkImport/__tests__/flagArtworkImportCellMutation.test.ts
@@ -1,0 +1,62 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("FlagArtworkImportCellMutation", () => {
+  it("flags a cell", async () => {
+    const artworkImportFlagCellLoader = jest.fn().mockResolvedValue({
+      artworkImportID: "artwork-import-id",
+    })
+
+    const mutation = gql`
+      mutation {
+        flagArtworkImportCell(
+          input: {
+            artworkImportID: "artwork-import-1"
+            rowID: "row-1"
+            columnName: "title"
+            userNote: "This title needs review"
+            flaggedValue: "Hallucinated title"
+          }
+        ) {
+          flagArtworkImportCellOrError {
+            ... on FlagArtworkImportCellSuccess {
+              artworkImport {
+                internalID
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const artworkImportLoader = jest.fn().mockResolvedValue({
+      id: "artwork-import-id",
+    })
+
+    const context = {
+      artworkImportFlagCellLoader,
+      artworkImportLoader,
+    }
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(artworkImportFlagCellLoader).toHaveBeenCalledWith(
+      "artwork-import-1",
+      {
+        row_id: "row-1",
+        column_name: "title",
+        user_note: "This title needs review",
+        flagged_value: "Hallucinated title",
+      }
+    )
+
+    expect(result).toEqual({
+      flagArtworkImportCell: {
+        flagArtworkImportCellOrError: {
+          artworkImport: {
+            internalID: "artwork-import-id",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/ArtworkImport/flagArtworkImportCellMutation.ts
+++ b/src/schema/v2/ArtworkImport/flagArtworkImportCellMutation.ts
@@ -1,0 +1,100 @@
+import {
+  GraphQLString,
+  GraphQLObjectType,
+  GraphQLUnionType,
+  GraphQLNonNull,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ArtworkImportType } from "./artworkImport"
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "FlagArtworkImportCellSuccess",
+  isTypeOf: (data) => !!data.artworkImportID,
+  fields: () => ({
+    artworkImport: {
+      type: ArtworkImportType,
+      resolve: ({ artworkImportID }, _args, { artworkImportLoader }) => {
+        if (!artworkImportLoader) return null
+        return artworkImportLoader(artworkImportID)
+      },
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "FlagArtworkImportCellFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "FlagArtworkImportCellResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const FlagArtworkImportCellMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "FlagArtworkImportCell",
+  inputFields: {
+    artworkImportID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    rowID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    columnName: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    userNote: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    flaggedValue: {
+      type: GraphQLString,
+    },
+  },
+  outputFields: {
+    flagArtworkImportCellOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { artworkImportID, rowID, columnName, userNote, flaggedValue },
+    { artworkImportFlagCellLoader }
+  ) => {
+    if (!artworkImportFlagCellLoader) {
+      throw new Error("This operation requires an `X-Access-Token` header.")
+    }
+
+    try {
+      await artworkImportFlagCellLoader(artworkImportID, {
+        row_id: rowID,
+        column_name: columnName,
+        user_note: userNote,
+        flagged_value: flaggedValue,
+      })
+
+      return { artworkImportID }
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -300,6 +300,7 @@ import { MatchArtworkImportArtistsMutation } from "./ArtworkImport/matchArtworkI
 import { CreateArtworkImportArtworksMutation } from "./ArtworkImport/createArtworkImportArtworksMutation"
 import { AssignArtworkImportArtistMutation } from "./ArtworkImport/assignArtworkImportArtistMutation"
 import { UpdateArtworkImportRowMutation } from "./ArtworkImport/updateArtworkImportRowMutation"
+import { FlagArtworkImportCellMutation } from "./ArtworkImport/flagArtworkImportCellMutation"
 import { MatchArtworkImportRowImageMutation } from "./ArtworkImport/matchArtworkImportRowImageMutation"
 import { FeaturedFairs } from "./FeaturedFairs/featuredFairs"
 import { CancelArtworkImportMutation } from "./ArtworkImport/cancelArtworkImportMutation"
@@ -610,6 +611,7 @@ export default new GraphQLSchema({
       updateArtwork: updateArtworkMutation,
       updateArtworkImportRow: UpdateArtworkImportRowMutation,
       updateCareerHighlight: updateCareerHighlightMutation,
+      flagArtworkImportCell: FlagArtworkImportCellMutation,
       updateCMSLastAccessTimestamp: updateCMSLastAccessTimestampMutation,
       updateCollection: updateCollectionMutation,
       updateCollectorProfile: UpdateCollectorProfile,


### PR DESCRIPTION
Adds a mutation that lets you flag a cell of an artwork import - pretty analogous to the other mutations around imports - this is just a new one! Based on https://github.com/artsy/gravity/pull/19030