### PR TITLE
feat(onyx-1664): createPurchase mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9497,6 +9497,18 @@ type CreatePartnerShowSuccess {
   show: Show
 }
 
+type CreatePurchaseFailure {
+  mutationError: GravityMutationError
+}
+
+union CreatePurchaseResponseOrError =
+    CreatePurchaseFailure
+  | CreatePurchaseSuccess
+
+type CreatePurchaseSuccess {
+  purchase: Purchase
+}
+
 type CreateSaleAgreementFailure {
   mutationError: GravityMutationError
 }
@@ -15552,6 +15564,9 @@ type Mutation {
   createPartnerShowEvent(
     input: CreatePartnerShowEventMutationInput!
   ): CreatePartnerShowEventMutationPayload
+
+  # Create a purchase
+  createPurchase(input: createPurchaseInput!): createPurchasePayload
 
   # Creates a static Markdown-backed sale agreement.
   createSaleAgreement(
@@ -26097,6 +26112,31 @@ union createPartnerOfferResponseOrError =
 type createPartnerOfferSuccess {
   partner: Partner
   partnerOffer: PartnerOffer
+}
+
+input createPurchaseInput {
+  artsyCommission: Float
+  artworkID: String
+  clientMutationId: String
+  discoverAdminID: String
+  email: String
+  fairID: String
+  note: String
+  ownerID: String
+  ownerType: String
+  saleAdminID: String
+  saleDate: String
+  saleID: String
+
+  # Sale price in USD.
+  salePrice: Float
+  source: String
+  userID: String
+}
+
+type createPurchasePayload {
+  clientMutationId: String
+  responseOrError: CreatePurchaseResponseOrError
 }
 
 type createUserAdminNoteFailure {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -855,6 +855,7 @@ export default (accessToken, userID, opts) => {
     pageLoader: gravityLoader((id) => `page/${id}`),
     pagesLoader: gravityLoader("pages", {}, { headers: true }),
     createPageLoader: gravityLoader("page", {}, { method: "POST" }),
+    createPurchaseLoader: gravityLoader("purchase", {}, { method: "POST" }),
     deletePageLoader: gravityLoader(
       (id) => `page/${id}`,
       {},

--- a/src/schema/v2/Purchases/__tests__/createPurchaseMutation.test.ts
+++ b/src/schema/v2/Purchases/__tests__/createPurchaseMutation.test.ts
@@ -1,0 +1,169 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("createPurchaseMutation", () => {
+  const mutation = gql`
+    mutation {
+      createPurchase(
+        input: {
+          artsyCommission: 10.5
+          artworkID: "some-artwork-id"
+          discoverAdminID: "nikita-admin-id"
+          email: "nikita@artsy.net"
+          fairID: "some-fair-id"
+          note: "My note"
+          ownerID: "sale-artwork-id"
+          ownerType: "SaleArtwork"
+          saleDate: "2025-06-13"
+          saleAdminID: "nikita-sale-admin-id"
+          saleID: "some-sale-id"
+          salePrice: 999.99
+          source: "auction"
+          userID: "some-user-id"
+        }
+      ) {
+        responseOrError {
+          __typename
+          ... on CreatePurchaseSuccess {
+            purchase {
+              internalID
+              artsyCommission
+              artwork {
+                internalID
+              }
+              discoverAdmin {
+                internalID
+              }
+              email
+              fair {
+                internalID
+              }
+              note
+              ownerID
+              ownerType
+              saleDate
+              saleAdmin {
+                internalID
+              }
+              sale {
+                internalID
+              }
+              salePrice
+              source
+              user {
+                internalID
+              }
+            }
+          }
+        }
+      }
+    }
+  `
+
+  const purchase = {
+    id: "purchase-id",
+    artsy_commission: 10.5,
+    artwork: {
+      _id: "some-artwork-id",
+    },
+    discover_admin: {
+      id: "nikita-admin-id",
+    },
+    email: "nikita@artsy.net",
+    fair: {
+      _id: "some-fair-id",
+    },
+    note: "My note",
+    owner_id: "sale-artwork-id",
+    owner_type: "SaleArtwork",
+    sale_date: "2025-06-13",
+    sale_admin: {
+      id: "nikita-sale-admin-id",
+    },
+    sale: {
+      _id: "some-sale-id",
+    },
+    sale_price: 999.99,
+    source: "auction",
+    user: {
+      id: "some-user-id",
+    },
+  }
+
+  const mockCreatePurchaseLoader = jest.fn()
+
+  const context = {
+    createPurchaseLoader: mockCreatePurchaseLoader,
+  }
+
+  beforeEach(() => {
+    mockCreatePurchaseLoader.mockResolvedValue(Promise.resolve(purchase))
+  })
+
+  afterEach(() => {
+    mockCreatePurchaseLoader.mockReset()
+  })
+
+  it("asserts that the loader is called with the correct arguments and returns the purchase", async () => {
+    const res = await runAuthenticatedQuery(mutation, context)
+
+    const loaderArgs = mockCreatePurchaseLoader.mock.calls[0]
+    const params = loaderArgs[0]
+
+    expect(params).toMatchObject({
+      artsy_commission: 10.5,
+      artwork_id: "some-artwork-id",
+      discover_admin_id: "nikita-admin-id",
+      email: "nikita@artsy.net",
+      fair_id: "some-fair-id",
+      note: "My note",
+      owner_id: "sale-artwork-id",
+      owner_type: "SaleArtwork",
+      sale_date: 1749772800,
+      sale_admin_id: "nikita-sale-admin-id",
+      sale_id: "some-sale-id",
+      sale_price: 999.99,
+      source: "auction",
+      user_id: "some-user-id",
+    })
+
+    expect(res).toMatchInlineSnapshot(`
+      {
+        "createPurchase": {
+          "responseOrError": {
+            "__typename": "CreatePurchaseSuccess",
+            "purchase": {
+              "artsyCommission": 10.5,
+              "artwork": {
+                "internalID": "some-artwork-id",
+              },
+              "discoverAdmin": {
+                "internalID": "nikita-admin-id",
+              },
+              "email": "nikita@artsy.net",
+              "fair": {
+                "internalID": "some-fair-id",
+              },
+              "internalID": "purchase-id",
+              "note": "My note",
+              "ownerID": "sale-artwork-id",
+              "ownerType": "SaleArtwork",
+              "sale": {
+                "internalID": "some-sale-id",
+              },
+              "saleAdmin": {
+                "internalID": "nikita-sale-admin-id",
+              },
+              "saleDate": "2025-06-13",
+              "salePrice": 999.99,
+              "source": "auction",
+              "user": {
+                "internalID": "some-user-id",
+              },
+            },
+          },
+        },
+      }
+    `)
+  })
+})

--- a/src/schema/v2/Purchases/createPurchaseMutation.ts
+++ b/src/schema/v2/Purchases/createPurchaseMutation.ts
@@ -1,0 +1,77 @@
+import { GraphQLObjectType, GraphQLUnionType } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  GravityMutationErrorType,
+  formatGravityError,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { PurchaseType } from "../purchase"
+import { PurchaseInputFields } from "./types"
+import { convertToGravityArgs } from "./helpers"
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreatePurchaseSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    purchase: {
+      type: PurchaseType,
+      resolve: (data) => data,
+    },
+  }),
+})
+
+const ErrorType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreatePurchaseFailure",
+  isTypeOf: (data) => {
+    return data._type === "GravityMutationError"
+  },
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "CreatePurchaseResponseOrError",
+  types: [SuccessType, ErrorType],
+})
+
+export const createPurchaseMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "createPurchase",
+  description: "Create a purchase",
+  inputFields: {
+    ...PurchaseInputFields,
+  },
+  outputFields: {
+    responseOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async ({ ...args }, { createPurchaseLoader }) => {
+    if (!createPurchaseLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const gravityArgs = convertToGravityArgs(args)
+      const response = await createPurchaseLoader(gravityArgs)
+
+      return response
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -325,6 +325,7 @@ import { PurchasesConnection } from "./purchases"
 import { Purchase } from "./purchase"
 import { updateOrderShippingAddressMutation } from "./order/updateOrderShippingAddressMutation"
 import { updatePurchaseMutation } from "./Purchases/updatePurchaseMutation"
+import { createPurchaseMutation } from "./Purchases/createPurchaseMutation"
 
 const rootFields = {
   // artworkVersion: ArtworkVersionResolver,
@@ -521,6 +522,7 @@ export default new GraphQLSchema({
       createPartnerShowEvent: createPartnerShowEventMutation,
       createPage: CreatePageMutation,
       createPartnerOffer: createPartnerOfferMutation,
+      createPurchase: createPurchaseMutation,
       createSaleAgreement: CreateSaleAgreementMutation,
       createSmsSecondFactor: createSmsSecondFactorMutation,
       createUserAdminNote: createUserAdminNoteMutation,


### PR DESCRIPTION
This is part of the Torque deprecation effort. The new admin panel, Forque, does not include a Purchases section yet. Since Forque communicates with the backend via Metaphysics (unlike Torque, which talks to Gravity directly), we are adding support for creating, updating, and deleting purchases to Metaphysics.

This PR introduces the `createPurchase` mutation:

```graphql
mutation {
  createPurchase(
    input: { ... }
  ) {
    responseOrError {
      ... on CreatePurchaseSuccess {
        purchase {
          internalID
        }
      }
      ... on CreatePurchaseFailure {
        mutationError {
          error
          message
        }
      }
    }
  }
}
```
