### PR TITLE
feat: add excludeArtistFromDiscoveryLoader

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10989,6 +10989,30 @@ type ExchangeError {
   message: String!
 }
 
+type ExcludeArtistFromDiscoveryFailure {
+  mutationError: GravityMutationError
+}
+
+input ExcludeArtistFromDiscoveryInput {
+  artistId: String!
+  clientMutationId: String
+}
+
+type ExcludeArtistFromDiscoveryPayload {
+  clientMutationId: String
+
+  # On success: the excluded artist information.
+  excludeArtistFromDiscoveryOrError: ExcludeArtistFromDiscoveryResponseOrError
+}
+
+union ExcludeArtistFromDiscoveryResponseOrError =
+    ExcludeArtistFromDiscoveryFailure
+  | ExcludeArtistFromDiscoverySuccess
+
+type ExcludeArtistFromDiscoverySuccess {
+  artistId: String
+}
+
 enum ExhibitionPeriodFormat {
   # Long formatted period e.g. February 25 – May 24, 2015
   LONG
@@ -15787,6 +15811,11 @@ type Mutation {
 
   # Mark sale as ended.
   endSale(input: EndSaleInput!): EndSalePayload
+
+  # Excludes an artist from appearing in Infinite Discovery recommendations.
+  excludeArtistFromDiscovery(
+    input: ExcludeArtistFromDiscoveryInput!
+  ): ExcludeArtistFromDiscoveryPayload
   flagArtworkImportCell(
     input: FlagArtworkImportCellInput!
   ): FlagArtworkImportCellPayload

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -217,6 +217,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    createUserExcludeArtistLoader: gravityLoader(
+      "artworks_discovery/artist/exclude",
+      {},
+      { method: "POST" }
+    ),
     deliverSecondFactor: gravityLoader(
       (id) => `me/second_factors/${id}/deliver`,
       {},

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -217,8 +217,8 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
-    createUserExcludeArtistLoader: gravityLoader(
-      "artworks_discovery/artist/exclude",
+    excludeArtistFromDiscoveryLoader: gravityLoader(
+      "artworks_discovery/artists/exclude",
       {},
       { method: "POST" }
     ),

--- a/src/schema/v2/infiniteDiscovery/excludeArtistFromDiscoveryMutation.ts
+++ b/src/schema/v2/infiniteDiscovery/excludeArtistFromDiscoveryMutation.ts
@@ -1,0 +1,94 @@
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+
+interface Input {
+  artistId: string
+}
+
+const inputFields = {
+  artistId: { type: new GraphQLNonNull(GraphQLString) },
+}
+
+interface GravityInput {
+  artist_id: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "ExcludeArtistFromDiscoverySuccess",
+  isTypeOf: (data) => data.artist_id,
+  fields: {
+    artistId: {
+      type: GraphQLString,
+      resolve: ({ artist_id }) => artist_id,
+    },
+  },
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "ExcludeArtistFromDiscoveryFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "ExcludeArtistFromDiscoveryResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const excludeArtistFromDiscoveryMutation = mutationWithClientMutationId<
+  Input,
+  any,
+  ResolverContext
+>({
+  name: "ExcludeArtistFromDiscovery",
+  description:
+    "Excludes an artist from appearing in Infinite Discovery recommendations.",
+  inputFields,
+  outputFields: {
+    excludeArtistFromDiscoveryOrError: {
+      type: ResponseOrErrorType,
+      description: "On success: the excluded artist information.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (args, { createUserExcludeArtistLoader }) => {
+    if (!createUserExcludeArtistLoader) {
+      throw new Error(
+        "You need to pass a X-Access-Token header to perform this action"
+      )
+    }
+
+    const createUserExcludeArtistLoaderPayload: GravityInput = {
+      artist_id: args.artistId,
+    }
+
+    try {
+      return await createUserExcludeArtistLoader(
+        createUserExcludeArtistLoaderPayload
+      )
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/infiniteDiscovery/excludeArtistFromDiscoveryMutation.ts
+++ b/src/schema/v2/infiniteDiscovery/excludeArtistFromDiscoveryMutation.ts
@@ -66,20 +66,20 @@ export const excludeArtistFromDiscoveryMutation = mutationWithClientMutationId<
       resolve: (result) => result,
     },
   },
-  mutateAndGetPayload: async (args, { createUserExcludeArtistLoader }) => {
-    if (!createUserExcludeArtistLoader) {
+  mutateAndGetPayload: async (args, { excludeArtistFromDiscoveryLoader }) => {
+    if (!excludeArtistFromDiscoveryLoader) {
       throw new Error(
         "You need to pass a X-Access-Token header to perform this action"
       )
     }
 
-    const createUserExcludeArtistLoaderPayload: GravityInput = {
+    const excludeArtistFromDiscoveryPayload: GravityInput = {
       artist_id: args.artistId,
     }
 
     try {
-      return await createUserExcludeArtistLoader(
-        createUserExcludeArtistLoaderPayload
+      return await excludeArtistFromDiscoveryLoader(
+        excludeArtistFromDiscoveryPayload
       )
     } catch (error) {
       const formattedErr = formatGravityError(error)

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -285,6 +285,7 @@ import { enableSecondFactorMutation } from "./me/secondFactors/mutations/enableS
 import { createAndSendBackupSecondFactorMutation } from "./users/createAndSendBackupSecondFactorMutation"
 import { createViewingRoomMutation } from "./viewingRooms/mutations/createViewingRoomMutation"
 import { createUserSeenArtworkMutation } from "./infiniteDiscovery/createUserSeenArtworkMutation"
+import { excludeArtistFromDiscoveryMutation } from "./infiniteDiscovery/excludeArtistFromDiscoveryMutation"
 import { updateViewingRoomMutation } from "./viewingRooms/mutations/updateViewingRoomMutation"
 import { deleteViewingRoomMutation } from "./viewingRooms/mutations/deleteViewingRoomMutation"
 import { publishViewingRoomMutation } from "./viewingRooms/mutations/publishViewingRoomMutation"
@@ -532,6 +533,7 @@ export default new GraphQLSchema({
       createUserInterests: createUserInterestsMutation,
       createUserSaleProfile: createUserSaleProfileMutation,
       createUserSeenArtwork: createUserSeenArtworkMutation,
+      excludeArtistFromDiscovery: excludeArtistFromDiscoveryMutation,
       createVerifiedRepresentative: createVerifiedRepresentativeMutation,
       createViewingRoom: createViewingRoomMutation,
       deleteAlert: deleteAlertMutation,


### PR DESCRIPTION
This PR adds a new GraphQL mutation that allows users to exclude artists when dismissing them in Discover Daily.

<img width="1192" alt="image" src="https://github.com/user-attachments/assets/821ba877-f429-47b9-805e-b4f0afb02fb0" />


Changes:
- Created excludeArtistFromDiscovery mutation
- Added excludeArtistFromDiscoveryLoader gravity loader with endpoint artworks_discovery/artist/exclude

This mutation follows the same pattern as createUserSeenArtwork but is used when users want to exclude/dismiss artists from Discover Daily.

- [x] - Merge [Gravity PR](https://github.com/artsy/gravity/pull/19025) first

/cc @artsy/diamond-devs 