### PR TITLE
chore: AMBER-1682 - adding blocking attribute per row error

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3292,7 +3292,7 @@ type ArtworkImportRowEdge {
 }
 
 type ArtworkImportRowError {
-  blocking: Boolean
+  blocking: Boolean!
   errorType: ArtworkImportError
 
   # A globally unique ID.

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3292,6 +3292,7 @@ type ArtworkImportRowEdge {
 }
 
 type ArtworkImportRowError {
+  blocking: Boolean
   errorType: ArtworkImportError
 
   # A globally unique ID.

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -83,7 +83,7 @@ const ArtworkImportRowErrorType = new GraphQLObjectType({
       type: GraphQLJSON,
     },
     blocking: {
-      type: GraphQLBoolean,
+      type: new GraphQLNonNull(GraphQLBoolean),
     },
   },
 })

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -82,6 +82,9 @@ const ArtworkImportRowErrorType = new GraphQLObjectType({
     metadata: {
       type: GraphQLJSON,
     },
+    blocking: {
+      type: GraphQLBoolean,
+    },
   },
 })
 


### PR DESCRIPTION
Solves [AMBER-1682]

This maps the newly added attribute for ArtworkImportRowError in this Gravity PR: https://github.com/artsy/gravity/pull/19039

cc: @artsy/amber-devs 

[AMBER-1682]: https://artsyproduct.atlassian.net/browse/AMBER-1682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ