### PR TITLE
feat(EMI-2578): Update subtotal display text

### DIFF
--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -672,7 +672,7 @@ describe("Me", () => {
         expect(result.me.order.pricingBreakdownLines).toEqual([
           {
             __typename: "SubtotalLine",
-            displayName: "Subtotal",
+            displayName: "Price",
             amount: {
               display: "US$5,000",
               currencySymbol: "$",
@@ -729,7 +729,7 @@ describe("Me", () => {
         expect(result.me.order.pricingBreakdownLines).toEqual([
           {
             __typename: "SubtotalLine",
-            displayName: "Subtotal",
+            displayName: "Price",
             amount: {
               display: "US$5,000",
               currencySymbol: "$",
@@ -755,6 +755,121 @@ describe("Me", () => {
             amount: null,
           },
         ])
+      })
+
+      describe("Price line display names", () => {
+        const query = gql`
+          query {
+            me {
+              order(id: "order-id") {
+                pricingBreakdownLines {
+                  __typename
+                  ... on SubtotalLine {
+                    displayName
+                    amount {
+                      amount
+                    }
+                  }
+                }
+              }
+            }
+          }
+        `
+
+        it("returns 'Price' display name for buy now orders", async () => {
+          orderJson.mode = "buy"
+          context = {
+            meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+            meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+            artworkLoader: jest.fn().mockResolvedValue(artwork),
+            authenticatedArtworkVersionLoader: jest
+              .fn()
+              .mockResolvedValue(artworkVersion),
+          }
+          const result = await runAuthenticatedQuery(query, context)
+          expect(result.me.order.pricingBreakdownLines).toEqual([
+            {
+              __typename: "SubtotalLine",
+              displayName: "Price",
+              amount: { amount: "5,000" },
+            },
+            { __typename: "ShippingLine" },
+            { __typename: "TaxLine" },
+            { __typename: "TotalLine" },
+          ])
+        })
+
+        it("returns 'Gallery offer' display name for partner offer orders", async () => {
+          orderJson.mode = "buy"
+          orderJson.source = "partner_offer"
+          context = {
+            meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+            meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+            artworkLoader: jest.fn().mockResolvedValue(artwork),
+            authenticatedArtworkVersionLoader: jest
+              .fn()
+              .mockResolvedValue(artworkVersion),
+          }
+          const result = await runAuthenticatedQuery(query, context)
+          expect(result.me.order.pricingBreakdownLines).toEqual([
+            {
+              __typename: "SubtotalLine",
+              displayName: "Gallery offer",
+              amount: { amount: "5,000" },
+            },
+            { __typename: "ShippingLine" },
+            { __typename: "TaxLine" },
+            { __typename: "TotalLine" },
+          ])
+        })
+
+        it("returns 'Seller's offer' display name for counter offers from seller", async () => {
+          orderJson.mode = "offer"
+          orderJson.awaiting_response_from = "buyer"
+          orderJson.items_total_cents = 500000
+          context = {
+            meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+            meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+            artworkLoader: jest.fn().mockResolvedValue(artwork),
+            authenticatedArtworkVersionLoader: jest
+              .fn()
+              .mockResolvedValue(artworkVersion),
+          }
+          const result = await runAuthenticatedQuery(query, context)
+          expect(result.me.order.pricingBreakdownLines).toEqual([
+            {
+              __typename: "SubtotalLine",
+              displayName: "Seller's offer",
+              amount: { amount: "5,000" },
+            },
+            { __typename: "ShippingLine" },
+            { __typename: "TaxLine" },
+            { __typename: "TotalLine" },
+          ])
+        })
+
+        it("returns 'Your offer' display name for make offer orders", async () => {
+          orderJson.mode = "offer"
+          context = {
+            meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+            meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+            artworkLoader: jest.fn().mockResolvedValue(artwork),
+            authenticatedArtworkVersionLoader: jest
+              .fn()
+              .mockResolvedValue(artworkVersion),
+          }
+          const result = await runAuthenticatedQuery(query, context)
+          expect(result.me.order.pricingBreakdownLines).toEqual([
+            {
+              __typename: "SubtotalLine",
+              displayName: "Your offer",
+              amount: { amount: "5,000" },
+            },
+            { __typename: "ShippingLine" },
+            { __typename: "TaxLine" },
+            { __typename: "TotalLine" },
+          ])
+        })
       })
 
       describe("Shipping line display names", () => {

--- a/src/schema/v2/order/types/PricingBreakdownLines.ts
+++ b/src/schema/v2/order/types/PricingBreakdownLines.ts
@@ -14,7 +14,14 @@ import type { ResolverContext } from "types/graphql"
 import { OrderJSON, FulfillmentOptionJson } from "./exchangeJson"
 
 const COPY = {
-  subtotal: { displayName: "Subtotal" },
+  subtotal: {
+    displayName: {
+      buyNow: "Price",
+      counterOffer: "Seller's offer",
+      makeOffer: "Your offer",
+      partnerOffer: "Gallery offer",
+    },
+  },
   shipping: {
     displayName: {
       pickup: "Pickup",
@@ -75,6 +82,9 @@ export const PricingBreakdownLines: GraphQLFieldConfig<
       tax_total_cents: taxTotalCents,
       items_total_cents: itemsTotalCents,
       buyer_total_cents: buyerTotalCents,
+      awaiting_response_from: awaitingResponseFrom,
+      mode,
+      source,
     } = order
 
     const resolveMoney = (amount: number) => {
@@ -91,9 +101,24 @@ export const PricingBreakdownLines: GraphQLFieldConfig<
       )
     }
 
+    let subtotalDisplayName: string
+    switch (true) {
+      case mode === "buy" && source === "partner_offer":
+        subtotalDisplayName = COPY.subtotal.displayName.partnerOffer
+        break
+      case mode === "offer" && awaitingResponseFrom === "buyer":
+        subtotalDisplayName = COPY.subtotal.displayName.counterOffer
+        break
+      case mode === "offer":
+        subtotalDisplayName = COPY.subtotal.displayName.makeOffer
+        break
+      default:
+        subtotalDisplayName = COPY.subtotal.displayName.buyNow
+    }
+
     const subtotalLine = {
       __typename: "SubtotalLine",
-      displayName: COPY.subtotal.displayName,
+      displayName: subtotalDisplayName,
       amount: itemsTotalCents && resolveMoney(itemsTotalCents),
     }
 

--- a/src/schema/v2/order/types/exchangeJson.ts
+++ b/src/schema/v2/order/types/exchangeJson.ts
@@ -17,6 +17,7 @@ export interface FulfillmentOptionJson {
 }
 export interface OrderJSON {
   available_shipping_countries: string[]
+  awaiting_response_from: "buyer" | "seller" | null
   bank_account_id?: string
   buyer_id: string
   buyer_phone_number?: string


### PR DESCRIPTION
This PR resolves [EMI-2578]

>[!NOTE]
> This PR requires artsy/exchange#2614 to be merged

### Description
This PR updates the Subtotal line to match the design, where it displays
- `Price` for buy now orders
- `Gallery offer` for partner offers
- `Your offer` on all make offer orders
- `Seller's offer` on a counteroffer from the partner 
