### PR TITLE
feat(DIA-1363): add maximum eigen version to home view sections

### DIFF
--- a/src/lib/semanticVersioning.ts
+++ b/src/lib/semanticVersioning.ts
@@ -34,3 +34,18 @@ export function isAtLeastVersion(
 
   return version.patch >= patch
 }
+
+export function isAtMostVersion(
+  version: SemanticVersionNumber,
+  atMost: SemanticVersionNumber
+): boolean {
+  const { major, minor, patch } = atMost
+
+  if (version.major < major) return true
+  if (version.major > major) return false
+
+  if (version.minor < minor) return true
+  if (version.minor > minor) return false
+
+  return version.patch <= patch
+}

--- a/src/schema/v2/homeView/helpers/__tests__/isSectionDisplayable.test.ts
+++ b/src/schema/v2/homeView/helpers/__tests__/isSectionDisplayable.test.ts
@@ -198,4 +198,143 @@ describe("isSectionDisplayable", () => {
       ).toBe(true)
     })
   })
+
+  describe("with a section that requires a maximum Eigen version", () => {
+    it("returns false if the user's Eigen version is above the maximum", () => {
+      const section: Partial<HomeViewSection> = {
+        requiresAuthentication: false,
+        maximumEigenVersion: { major: 8, minor: 0, patch: 0 },
+      }
+
+      const context: Partial<ResolverContext> = {
+        userAgent:
+          "unknown iOS/18.1.1 Artsy-Mobile/8.59.0 Eigen/2024.12.10.06/8.59.0",
+      }
+
+      expect(
+        isSectionDisplayable(
+          section as HomeViewSection,
+          context as ResolverContext
+        )
+      ).toBe(false)
+    })
+
+    it("returns true if the user's Eigen version is equal to the maximum", () => {
+      const section: Partial<HomeViewSection> = {
+        requiresAuthentication: false,
+        maximumEigenVersion: { major: 8, minor: 59, patch: 0 },
+      }
+
+      const context: Partial<ResolverContext> = {
+        userAgent:
+          "unknown iOS/18.1.1 Artsy-Mobile/8.59.0 Eigen/2024.12.10.06/8.59.0",
+      }
+
+      expect(
+        isSectionDisplayable(
+          section as HomeViewSection,
+          context as ResolverContext
+        )
+      ).toBe(true)
+    })
+
+    it("returns true if the user's Eigen version is below the maximum", () => {
+      const section: Partial<HomeViewSection> = {
+        requiresAuthentication: false,
+        maximumEigenVersion: { major: 9, minor: 0, patch: 0 },
+      }
+
+      const context: Partial<ResolverContext> = {
+        userAgent:
+          "unknown iOS/18.1.1 Artsy-Mobile/8.59.0 Eigen/2024.12.10.06/8.59.0",
+      }
+
+      expect(
+        isSectionDisplayable(
+          section as HomeViewSection,
+          context as ResolverContext
+        )
+      ).toBe(true)
+    })
+
+    it("returns true if an Eigen version is not recognized", () => {
+      const section: Partial<HomeViewSection> = {
+        requiresAuthentication: false,
+        maximumEigenVersion: { major: 8, minor: 0, patch: 0 },
+      }
+
+      const context: Partial<ResolverContext> = {
+        userAgent: "Hi it's me, Moo Deng, again",
+      }
+
+      expect(
+        isSectionDisplayable(
+          section as HomeViewSection,
+          context as ResolverContext
+        )
+      ).toBe(true)
+    })
+  })
+
+  describe("with a section that has both minimum and maximum Eigen versions", () => {
+    it("returns true if the user's Eigen version is within the range", () => {
+      const section: Partial<HomeViewSection> = {
+        requiresAuthentication: false,
+        minimumEigenVersion: { major: 8, minor: 0, patch: 0 },
+        maximumEigenVersion: { major: 9, minor: 0, patch: 0 },
+      }
+
+      const context: Partial<ResolverContext> = {
+        userAgent:
+          "unknown iOS/18.1.1 Artsy-Mobile/8.59.0 Eigen/2024.12.10.06/8.59.0",
+      }
+
+      expect(
+        isSectionDisplayable(
+          section as HomeViewSection,
+          context as ResolverContext
+        )
+      ).toBe(true)
+    })
+
+    it("returns false if the user's Eigen version is below the minimum", () => {
+      const section: Partial<HomeViewSection> = {
+        requiresAuthentication: false,
+        minimumEigenVersion: { major: 9, minor: 0, patch: 0 },
+        maximumEigenVersion: { major: 10, minor: 0, patch: 0 },
+      }
+
+      const context: Partial<ResolverContext> = {
+        userAgent:
+          "unknown iOS/18.1.1 Artsy-Mobile/8.59.0 Eigen/2024.12.10.06/8.59.0",
+      }
+
+      expect(
+        isSectionDisplayable(
+          section as HomeViewSection,
+          context as ResolverContext
+        )
+      ).toBe(false)
+    })
+
+    it("returns false if the user's Eigen version is above the maximum", () => {
+      const section: Partial<HomeViewSection> = {
+        requiresAuthentication: false,
+        minimumEigenVersion: { major: 7, minor: 0, patch: 0 },
+        maximumEigenVersion: { major: 8, minor: 0, patch: 0 },
+      }
+
+      const context: Partial<ResolverContext> = {
+        userAgent:
+          "unknown iOS/18.1.1 Artsy-Mobile/8.59.0 Eigen/2024.12.10.06/8.59.0",
+      }
+
+      expect(
+        isSectionDisplayable(
+          section as HomeViewSection,
+          context as ResolverContext
+        )
+      ).toBe(false)
+    })
+  })
 })

--- a/src/schema/v2/homeView/helpers/isSectionDisplayable.ts
+++ b/src/schema/v2/homeView/helpers/isSectionDisplayable.ts
@@ -1,7 +1,11 @@
 import { ResolverContext } from "types/graphql"
 import { HomeViewSection } from "../sections"
 import { isFeatureFlagEnabled } from "lib/featureFlags"
-import { getEigenVersionNumber, isAtLeastVersion } from "lib/semanticVersioning"
+import {
+  getEigenVersionNumber,
+  isAtLeastVersion,
+  isAtMostVersion,
+} from "lib/semanticVersioning"
 
 /**
  * Determine if an individual section can be displayed, considering the current
@@ -28,17 +32,22 @@ export function isSectionDisplayable(
     })
   }
 
+  const actualEigenVersion = getEigenVersionNumber(context.userAgent as string)
+
   // minimum Eigen version
-  if (isDisplayable && section.minimumEigenVersion) {
-    const actualEigenVersion = getEigenVersionNumber(
-      context.userAgent as string
+  if (isDisplayable && section.minimumEigenVersion && actualEigenVersion) {
+    isDisplayable = isAtLeastVersion(
+      actualEigenVersion,
+      section.minimumEigenVersion
     )
-    if (actualEigenVersion) {
-      isDisplayable = isAtLeastVersion(
-        actualEigenVersion,
-        section.minimumEigenVersion
-      )
-    }
+  }
+
+  // maximum Eigen version
+  if (isDisplayable && section.maximumEigenVersion && actualEigenVersion) {
+    isDisplayable = isAtMostVersion(
+      actualEigenVersion,
+      section.maximumEigenVersion
+    )
   }
 
   // section's display pre-check

--- a/src/schema/v2/homeView/sections/index.ts
+++ b/src/schema/v2/homeView/sections/index.ts
@@ -48,6 +48,7 @@ export type HomeViewSection = {
   ownerType?: OwnerType
   requiresAuthentication: boolean
   minimumEigenVersion?: SemanticVersionNumber
+  maximumEigenVersion?: SemanticVersionNumber
   shouldBeDisplayed?: (context: ResolverContext) => boolean
   resolver?: GraphQLFieldResolver<any, ResolverContext>
   type: keyof typeof HomeViewSectionTypeNames


### PR DESCRIPTION
This PR adds a `maximumEigenVersion` to the existing logic that checks whether a Home View section is displayable or not.

This is needed because we will be moving Discover Something New and Explore by Category from the Home tab to the Search tab in an upcoming release, but we still need to guarantee that old versions of the app continue showing them on the Home tab.

For context, we added `minimumEigenVersion` to prevent the Discover Daily entry point from displaying on older versions of the app (that did not know about Discover Daily).

cc: @artsy/diamond-devs 