### PR TITLE
feat(DIA-1363): add discoveryMarketingCollections query

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -19290,6 +19290,15 @@ type Query {
     osWeights: [Float] = [0.6, 0.4]
   ): ArtworkConnection
 
+  # Discovery Marketing Collections for personalized recommendations
+  discoveryMarketingCollections(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    size: Int = 12
+  ): [MarketingCollection]
+
   # A namespace external partners (provided by Galaxy)
   external: External!
 
@@ -25078,6 +25087,15 @@ type Viewer {
     # Weights for the KNN and MLT query
     osWeights: [Float] = [0.6, 0.4]
   ): ArtworkConnection
+
+  # Discovery Marketing Collections for personalized recommendations
+  discoveryMarketingCollections(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    size: Int = 12
+  ): [MarketingCollection]
 
   # A namespace external partners (provided by Galaxy)
   external: External!

--- a/src/schema/v2/__tests__/marketingCollections.test.ts
+++ b/src/schema/v2/__tests__/marketingCollections.test.ts
@@ -240,4 +240,41 @@ describe("MarketingCollections", () => {
       "Category is required for CURATED sort."
     )
   })
+
+  it("returns discovery marketing collections", async () => {
+    const discoveryCollectionsData = [
+      {
+        slug: "most-loved",
+        title: "Most Loved",
+      },
+      {
+        slug: "understated",
+        title: "Understated",
+      },
+    ]
+
+    const query = gql`
+      {
+        discoveryMarketingCollections(size: 2) {
+          slug
+          title
+        }
+      }
+    `
+
+    const context = {
+      marketingCollectionsLoader: ({ slugs }) =>
+        Promise.resolve({
+          body: discoveryCollectionsData.filter((collection) =>
+            slugs.includes(collection.slug)
+          ),
+        }),
+    } as any
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      discoveryMarketingCollections: discoveryCollectionsData,
+    })
+  })
 })

--- a/src/schema/v2/marketingCollections.ts
+++ b/src/schema/v2/marketingCollections.ts
@@ -408,3 +408,39 @@ export const CuratedMarketingCollections: GraphQLFieldConfig<
     )
   },
 }
+
+export const DiscoveryMarketingCollections: GraphQLFieldConfig<
+  void,
+  ResolverContext
+> = {
+  type: new GraphQLList(MarketingCollectionType),
+  description:
+    "Discovery Marketing Collections for personalized recommendations",
+  args: pageable({
+    size: {
+      type: GraphQLInt,
+      defaultValue: 12,
+    },
+  }),
+  resolve: async (_root, args, { marketingCollectionsLoader }) => {
+    const marketingCollectionSlugs = [
+      "most-loved",
+      "understated",
+      "art-gifts-under-1000-dollars",
+      "transcendent",
+      "best-bids",
+      "statement-pieces",
+      "little-gems",
+      "feast-for-the-eyes",
+      "street-art-edit",
+      "icons",
+      "bleeding-edge",
+      "flora-and-fauna",
+    ]
+
+    return fetchMarketingCollections(
+      { ...args, slugs: marketingCollectionSlugs },
+      marketingCollectionsLoader
+    )
+  },
+}

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -227,6 +227,7 @@ import {
   MarketingCollection,
   MarketingCollections,
   CuratedMarketingCollections,
+  DiscoveryMarketingCollections,
 } from "./marketingCollections"
 import { MarketingCategories } from "./marketingCategories"
 import { createCareerHighlightMutation } from "./careerHighlight/createCareerHighlightMutation"
@@ -411,6 +412,7 @@ const rootFields = {
   marketingCollection: MarketingCollection,
   marketingCollections: MarketingCollections,
   curatedMarketingCollections: CuratedMarketingCollections,
+  discoveryMarketingCollections: DiscoveryMarketingCollections,
   marketingCategories: MarketingCategories,
   me: Me,
   node: ObjectIdentification.NodeField,


### PR DESCRIPTION
This PR adds a `discoveryMarketingCollections` query to the Metaphysics schema. This will allow Eigen to query a subset of our marketing collections for the _Discover Something New_ widget, while allowing us to update its contents without an app deployment.

```graphql
{
  discoveryMarketingCollections {
    slug
    title
    category
    thumbnail
  }
}
```

cc: @artsy/diamond-devs 