### PR TITLE
feat(DIA-1363): guarantee non-null discoveryMarketingCollections results

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -19297,7 +19297,7 @@ type Query {
     first: Int
     last: Int
     size: Int = 12
-  ): [MarketingCollection]
+  ): [MarketingCollection!]
 
   # A namespace external partners (provided by Galaxy)
   external: External!
@@ -25095,7 +25095,7 @@ type Viewer {
     first: Int
     last: Int
     size: Int = 12
-  ): [MarketingCollection]
+  ): [MarketingCollection!]
 
   # A namespace external partners (provided by Galaxy)
   external: External!

--- a/src/schema/v2/__tests__/marketingCollections.test.ts
+++ b/src/schema/v2/__tests__/marketingCollections.test.ts
@@ -277,4 +277,59 @@ describe("MarketingCollections", () => {
       discoveryMarketingCollections: discoveryCollectionsData,
     })
   })
+
+  it("filters out null and undefined collections from discovery marketing collections", async () => {
+    const discoveryCollectionsDataWithNulls = [
+      {
+        slug: "most-loved",
+        title: "Most Loved",
+      },
+      null,
+      {
+        slug: "understated",
+        title: "Understated",
+      },
+      undefined,
+      {
+        slug: "best-bids",
+        title: "Best Bids",
+      },
+    ]
+
+    const query = gql`
+      {
+        discoveryMarketingCollections {
+          slug
+          title
+        }
+      }
+    `
+
+    const context = {
+      marketingCollectionsLoader: () =>
+        Promise.resolve({
+          body: discoveryCollectionsDataWithNulls,
+        }),
+    } as any
+
+    const data = await runQuery(query, context)
+
+    // Should only return the valid collections, filtering out null/undefined
+    expect(data).toEqual({
+      discoveryMarketingCollections: [
+        {
+          slug: "most-loved",
+          title: "Most Loved",
+        },
+        {
+          slug: "understated",
+          title: "Understated",
+        },
+        {
+          slug: "best-bids",
+          title: "Best Bids",
+        },
+      ],
+    })
+  })
 })

--- a/src/schema/v2/marketingCollections.ts
+++ b/src/schema/v2/marketingCollections.ts
@@ -413,7 +413,7 @@ export const DiscoveryMarketingCollections: GraphQLFieldConfig<
   void,
   ResolverContext
 > = {
-  type: new GraphQLList(MarketingCollectionType),
+  type: new GraphQLList(new GraphQLNonNull(MarketingCollectionType)),
   description:
     "Discovery Marketing Collections for personalized recommendations",
   args: pageable({
@@ -438,9 +438,12 @@ export const DiscoveryMarketingCollections: GraphQLFieldConfig<
       "flora-and-fauna",
     ]
 
-    return fetchMarketingCollections(
+    const collections = await fetchMarketingCollections(
       { ...args, slugs: marketingCollectionSlugs },
       marketingCollectionsLoader
     )
+
+    // Filter out any null collections to match the non-null schema
+    return collections.filter(Boolean)
   },
 }


### PR DESCRIPTION
This PR makes the `discoveryMarketingCollections` query guarantee non-null results so that clients don't need to filter them out if the discovery collections are changed.