### PR TITLE
chore: AMBER-1709 - updating error code to be more readable for partners

### DIFF
--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -43,7 +43,7 @@ export const ArtworkImportErrorType = new GraphQLEnumType({
     ARTWORK_CREATION_FAILED: { value: "artwork_creation_failed" },
     UNMATCHED_ARTIST: { value: "unmatched_artist" },
     INVALID_CERTIFICATE_OF_AUTHENTICITY: {
-      value: "invalid_coa",
+      value: "invalid_certificate_of_authenticity",
     },
     INVALID_SIGNATURE: { value: "invalid_signature" },
     INVALID_CLASSIFICATION: { value: "invalid_classification" },


### PR DESCRIPTION
Relates to the changes recently made in Gravity: https://github.com/artsy/gravity/pull/19057

As the error value has been updated for the certificate of authenticity, we need to ensure that the mapping works as expected. There should be no changes required in the consumer of this, Volt.

cc: @artsy/amber-devs 